### PR TITLE
static-quality-gates: surface PR buffer consumption

### DIFF
--- a/tasks/static_quality_gates/gates_reporter.py
+++ b/tasks/static_quality_gates/gates_reporter.py
@@ -6,6 +6,10 @@ Provides clear, customer-friendly reporting and output formatting for external u
 from tasks.libs.common.color import color_message
 from tasks.static_quality_gates.decisions import GateVerdict
 
+# Visual width of the summary table dividers. Update together with the column widths
+# in the header below if columns are added or resized.
+SUMMARY_TABLE_WIDTH = 160
+
 
 class QualityGateOutputFormatter:
     """
@@ -82,9 +86,9 @@ class QualityGateOutputFormatter:
             gate_verdicts: List of GateVerdicts with decisions on gates
             metric_handler: Optional GateMetricHandler for getting measurement data
         """
-        print(color_message("\n" + "=" * 160, "magenta"))
+        print(color_message("\n" + "=" * SUMMARY_TABLE_WIDTH, "magenta"))
         print(color_message("🛡️  STATIC QUALITY GATES SUMMARY", "magenta"))
-        print(color_message("=" * 160, "magenta"))
+        print(color_message("=" * SUMMARY_TABLE_WIDTH, "magenta"))
 
         # Create a lookup for gate states
         verdict_lookup = {verdict.name: verdict for verdict in gate_verdicts}
@@ -96,7 +100,7 @@ class QualityGateOutputFormatter:
             f"{'Comp Remain':<12} {'Uncomp Remain':<14} {'Comp PR Buf%':<13} {'Uncomp PR Buf%':<14}"
         )
         print(color_message(header, "cyan"))
-        print(color_message("-" * 160, "cyan"))
+        print(color_message("-" * SUMMARY_TABLE_WIDTH, "cyan"))
 
         passed_count = 0
         failed_count = 0
@@ -198,7 +202,7 @@ class QualityGateOutputFormatter:
             )
 
         # Summary footer
-        print(color_message("-" * 160, "cyan"))
+        print(color_message("-" * SUMMARY_TABLE_WIDTH, "cyan"))
 
         # Overall statistics
         total_gates = len(gate_list)
@@ -213,4 +217,4 @@ class QualityGateOutputFormatter:
         print(
             color_message("📊 Dashboard: https://app.datadoghq.com/dashboard/5np-man-vak/static-quality-gates", "cyan")
         )
-        print(color_message("=" * 160, "magenta"))
+        print(color_message("=" * SUMMARY_TABLE_WIDTH, "magenta"))

--- a/tasks/static_quality_gates/gates_reporter.py
+++ b/tasks/static_quality_gates/gates_reporter.py
@@ -82,17 +82,21 @@ class QualityGateOutputFormatter:
             gate_verdicts: List of GateVerdicts with decisions on gates
             metric_handler: Optional GateMetricHandler for getting measurement data
         """
-        print(color_message("\n" + "=" * 132, "magenta"))
+        print(color_message("\n" + "=" * 160, "magenta"))
         print(color_message("🛡️  STATIC QUALITY GATES SUMMARY", "magenta"))
-        print(color_message("=" * 132, "magenta"))
+        print(color_message("=" * 160, "magenta"))
 
         # Create a lookup for gate states
         verdict_lookup = {verdict.name: verdict for verdict in gate_verdicts}
 
         # Table header
-        header = f"{'Gate Name':<40} {'Status':<8} {'Compressed':<20} {'Uncompressed':<20} {'Comp Remain':<12} {'Uncomp Remain':<14}"
+        # "PR Buffer %" = share of headroom (max - baseline) consumed by this PR (relative / buffer * 100)
+        header = (
+            f"{'Gate Name':<40} {'Status':<8} {'Compressed':<20} {'Uncompressed':<20} "
+            f"{'Comp Remain':<12} {'Uncomp Remain':<14} {'Comp PR Buf%':<13} {'Uncomp PR Buf%':<14}"
+        )
         print(color_message(header, "cyan"))
-        print(color_message("-" * 132, "cyan"))
+        print(color_message("-" * 160, "cyan"))
 
         passed_count = 0
         failed_count = 0
@@ -116,11 +120,15 @@ class QualityGateOutputFormatter:
             # Get measurement data from metric handler if available
             wire_current_bytes = 0
             disk_current_bytes = 0
+            wire_relative_bytes = None
+            disk_relative_bytes = None
 
             if metric_handler and gate.config.gate_name in metric_handler.metrics:
                 gate_metrics = metric_handler.metrics[gate.config.gate_name]
                 wire_current_bytes = gate_metrics.get('current_on_wire_size', 0)
                 disk_current_bytes = gate_metrics.get('current_on_disk_size', 0)
+                wire_relative_bytes = gate_metrics.get('relative_on_wire_size')
+                disk_relative_bytes = gate_metrics.get('relative_on_disk_size')
 
             # Convert to MB for display
             wire_current = wire_current_bytes / (1024 * 1024)
@@ -163,12 +171,34 @@ class QualityGateOutputFormatter:
             comp_remain_padding = 12 - len(compressed_remaining_text)
             uncomp_remain_padding = 14 - len(uncompressed_remaining_text)
 
+            # Change in buffer from this PR, expressed from the buffer's POV:
+            # a size increase shrinks the buffer (negative), a reduction grows it (positive).
+            # Formula: -relative / (max - baseline) * 100, with baseline = current - relative.
+            def format_buffer_pct(relative_bytes, current_bytes, max_bytes):
+                if relative_bytes is None:
+                    return "—"
+                baseline = current_bytes - relative_bytes
+                buffer_bytes = max_bytes - baseline
+                if buffer_bytes <= 0:
+                    return "n/a"
+                return f"{-(relative_bytes / buffer_bytes) * 100:+6.2f}%"
+
+            comp_buffer_pct_text = format_buffer_pct(
+                wire_relative_bytes, wire_current_bytes, gate.config.max_on_wire_size
+            )
+            uncomp_buffer_pct_text = format_buffer_pct(
+                disk_relative_bytes, disk_current_bytes, gate.config.max_on_disk_size
+            )
+
             print(
-                f"{display_name:<40} {status:<8} {compressed_info:<20} {uncompressed_info:<20} {compressed_remaining_info}{' ' * comp_remain_padding} {uncompressed_remaining_info}{' ' * uncomp_remain_padding}"
+                f"{display_name:<40} {status:<8} {compressed_info:<20} {uncompressed_info:<20} "
+                f"{compressed_remaining_info}{' ' * comp_remain_padding} "
+                f"{uncompressed_remaining_info}{' ' * uncomp_remain_padding} "
+                f"{comp_buffer_pct_text:<13} {uncomp_buffer_pct_text:<14}"
             )
 
         # Summary footer
-        print(color_message("-" * 132, "cyan"))
+        print(color_message("-" * 160, "cyan"))
 
         # Overall statistics
         total_gates = len(gate_list)
@@ -183,4 +213,4 @@ class QualityGateOutputFormatter:
         print(
             color_message("📊 Dashboard: https://app.datadoghq.com/dashboard/5np-man-vak/static-quality-gates", "cyan")
         )
-        print(color_message("=" * 132, "magenta"))
+        print(color_message("=" * 160, "magenta"))

--- a/tasks/static_quality_gates/pr_comment.py
+++ b/tasks/static_quality_gates/pr_comment.py
@@ -51,7 +51,10 @@ def get_change_metrics(
 
     Returns:
         Tuple of (change_str, limit_bounds_str, is_neutral) for display in PR comment.
-        - change_str: e.g., "neutral", "-58.7 KiB (0.29% reduction)", "+98.3 KiB (1.35% increase)"
+        - change_str: e.g., "neutral", "-58.7 KiB (0.29% reduction, +2.10% of buffer)",
+          "+98.3 KiB (1.35% increase, -12.40% of buffer)"
+          Buffer % is reported from the buffer's POV: a size increase shrinks the buffer (negative),
+          a size reduction grows it (positive).
         - limit_bounds_str: e.g., "**707.163** MiB" for neutral, "707.000 → **707.163** → 707.240" for changes
         - is_neutral: True if the change is below the threshold (< 2 KiB)
     """
@@ -94,6 +97,15 @@ def get_change_metrics(
     else:
         limit_bounds_str = f"N/A → **{current_mib:.3f}** → {max_mib:.3f}"
 
+    # Buffer = headroom between baseline and max. Change reported from buffer's POV:
+    # size increase shrinks buffer (negative), size reduction grows buffer (positive).
+    buffer_size = max_size - baseline_size if baseline_size is not None else None
+    if buffer_size is not None and buffer_size > 0 and relative_size is not None:
+        buffer_pct = -(relative_size / buffer_size) * 100
+        buffer_str = f"{buffer_pct:+.2f}% of buffer"
+    else:
+        buffer_str = None
+
     # Build change string with delta and percentage
     if baseline_size is None or relative_size is None:
         change_str = "N/A"
@@ -117,6 +129,9 @@ def get_change_metrics(
                 change_str = f"+{delta_str} (new)"
             else:
                 change_str = f"{delta_str} (reduction)"
+
+        if buffer_str is not None:
+            change_str = f"{change_str[:-1]}, {buffer_str})"
 
     return change_str, limit_bounds_str, is_neutral
 


### PR DESCRIPTION
## Summary

Display how much of the available headroom (buffer or `max - baseline`) a PR consumes:

- **PR comment "Change" column** now includes the per-PR buffer change alongside the existing delta and percentage, e.g. `+98.3 KiB (1.35% increase, -12.40% of buffer)`.
- **CI summary table** (`gates_reporter`) gains two new columns: `Comp PR Buf%` and `Uncomp PR Buf%`.

The percentage is reported from the buffer's perspective: a size increase shrinks the buffer (negative), a size reduction grows it (positive). This makes it easier to gauge whether a PR is eating meaningfully into the remaining quota even when the absolute delta looks small.

### Example

For a gate with `1 MiB` of buffer where a PR adds `+500 KiB` to an artifact currently at `200 MiB`:

- PR comment: `+500.0 KiB (0.24% increase, -48.83% of buffer)`
- CI summary buffer column: `-48.83%`

### Implementation notes

- `get_change_metrics` computes `buffer_size = max - baseline` and appends `±X.XX% of buffer` to the existing change string when a meaningful baseline + relative size is available. Neutral / N/A rows are unchanged.
- `print_summary_table` reuses `relative_on_wire_size` / `relative_on_disk_size` from the metric handler (already populated before the table is printed) and falls back to `—` (no relative metrics) or `n/a` (non-positive buffer).
- Divider widths in the CI summary bumped from 132 to 160 chars to fit the two new columns without wrapping.

## Test plan

- [x] `python -m unittest tasks.unit_tests.static_quality_gates.pr_comment_tests tasks.unit_tests.static_quality_gates.gates_reporter_tests` — 39/39 pass locally
- [ ] Static quality gates CI job on this PR shows the new buffer column in the summary table
- [ ] Generated PR comment on this draft shows the `% of buffer` suffix in the Change column

🤖 Generated with [Claude Code](https://claude.com/claude-code)