### PR TITLE
fix(aggregator): set Title on agent lifecycle events

### DIFF
--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -343,6 +343,7 @@ func (d *AgentDemultiplexer) agentLifecycleEvent(agentVersion string, eventType 
 	}
 
 	return event.Event{
+		Title:          eventType,
 		Text:           "Version " + agentVersion,
 		SourceTypeName: "System",
 		Host:           d.aggregator.hostname,

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -161,6 +161,7 @@ func TestAddAgentStartupTelemetrySendsShutdownEventOnFinalStop(t *testing.T) {
 	case <-time.After(time.Second):
 		require.FailNow(t, "timed out waiting for Agent Shutdown event")
 	}
+	require.Equal(t, "Agent Shutdown", shutdownEvent.Title)
 	require.Equal(t, "Version 7.0.0", shutdownEvent.Text)
 	require.Equal(t, "System", shutdownEvent.SourceTypeName)
 	require.Equal(t, "hostname", shutdownEvent.Host)

--- a/releasenotes/notes/fix-agent-lifecycle-event-title-3f8ceeb3f3d57914.yaml
+++ b/releasenotes/notes/fix-agent-lifecycle-event-title-3f8ceeb3f3d57914.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Set the ``Title`` (``msg_title``) field on ``Agent Startup`` and ``Agent Shutdown``
+    lifecycle events. Previously these events were submitted with an empty title,
+    which caused them to appear without a title in Event Explorer.


### PR DESCRIPTION
### What does this PR do?

Sets the `Title` field on the `event.Event` constructed by `agentLifecycleEvent` in `pkg/aggregator/demultiplexer_agent.go`. The title is set to the same value as `EventType` ("Agent Startup" / "Agent Shutdown").

### Motivation

`agentLifecycleEvent` constructs `Agent Startup` and `Agent Shutdown` events without a `Title`. Because `Title` is serialized to the `msg_title` JSON field on the intake payload, every lifecycle event reached the backend with an empty `msg_title` and surfaced in Event Explorer with no title.

Repro in Event Explorer: `!@title:* @evt.type:"Agent Shutdown"` — all hits.

Fix: populate `Title` with the same value as `EventType`, matching the convention used by other agent-emitted events.

JIRA: [ECT-5537](https://datadoghq.atlassian.net/browse/ECT-5537)

### Describe how you validated your changes

- Extended `TestAddAgentStartupTelemetrySendsShutdownEventOnFinalStop` to assert `shutdownEvent.Title == "Agent Shutdown"`.
- Added a reno release note under `releasenotes/notes/`.

### Additional Notes

One-line behavior change; no API or config surface modified.

[ECT-5537]: https://datadoghq.atlassian.net/browse/ECT-5537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ