### PR TITLE
revert socket__dns_filter to pre-43756 port-53 check

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/dns.c
+++ b/pkg/network/ebpf/c/prebuilt/dns.c
@@ -25,19 +25,11 @@ int socket__dns_filter(struct __sk_buff* skb) {
     if (!read_conn_tuple_skb(skb, &skb_info, &tup)) {
         return 0;
     }
-
-    __u16 sport = tup.sport;
-    __u16 dport = tup.dport;
-
-    if (bpf_map_lookup_elem(&dns_ports, &sport) != NULL) {
-        return -1;
+    if (tup.sport != 53 && (!dns_stats_enabled() || tup.dport != 53)) {
+        return 0;
     }
 
-    if (dns_stats_enabled() && bpf_map_lookup_elem(&dns_ports, &dport) != NULL) {
-        return -1;
-    }
-
-    return 0;
+    return -1;
 }
 
 char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
Prototype to A/B the old hardcoded port-53 comparison against the current dns_ports map lookup. The dns_ports map declaration is kept so the Go side that populates it still compiles; it's just no longer consulted by the BPF program.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
