### PR TITLE
Add kube_pod_uid as a high cardinality tag for Kubernetes pods

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -416,6 +416,7 @@ func (c *WorkloadMetaCollector) labelsToTags(labels map[string]string, tags *tag
 
 func (c *WorkloadMetaCollector) extractTagsFromPodEntity(pod *workloadmeta.KubernetesPod, tagList *taglist.TagList, isComplete bool) *types.TagInfo {
 	tagList.AddOrchestrator(tags.KubePod, pod.Name)
+	tagList.AddHigh(tags.KubePodUID, pod.EntityID.ID)
 	tagList.AddLow(tags.KubeNamespace, pod.Namespace)
 	tagList.AddLow(tags.PodPhase, strings.ToLower(pod.Phase))
 	tagList.AddLow(tags.KubePriorityClass, pod.PriorityClass)

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -237,6 +237,7 @@ func TestHandleKubePod(t *testing.T) {
 					EntityID: podTaggerEntityID,
 					HighCardTags: []string{
 						"gitcommit:foobar",
+						"kube_pod_uid:" + podEntityID.ID,
 					},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
@@ -300,7 +301,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},
@@ -355,7 +356,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},
@@ -406,7 +407,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},
@@ -461,7 +462,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},
@@ -506,7 +507,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 						"oshift_deployment:gitlab-ce-1",
@@ -536,7 +537,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},
@@ -568,7 +569,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 						"kube_ownerref_name:owner_name",
@@ -601,7 +602,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 						"kube_ownerref_name:owner_name",
@@ -637,7 +638,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 						"kube_ownerref_name:owner_name",
@@ -671,7 +672,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 						"kube_ownerref_name:owner_name",
@@ -708,7 +709,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 						"kube_ownerref_name:some_cronjob-123",
@@ -742,7 +743,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 						"kube_ownerref_name:owner_name",
@@ -784,7 +785,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 						"kube_ownerref_name:some_deployment-bcd2",
@@ -816,7 +817,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},
@@ -844,7 +845,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},
@@ -874,7 +875,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},
@@ -906,7 +907,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},
@@ -962,6 +963,7 @@ func TestHandleKubePod(t *testing.T) {
 					Source:   podSource,
 					EntityID: podTaggerEntityID,
 					HighCardTags: []string{
+						"kube_pod_uid:" + podEntityID.ID,
 						"pod_uid:" + podEntityID.ID,
 					},
 					OrchestratorCardTags: []string{
@@ -1005,7 +1007,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},
@@ -1060,7 +1062,7 @@ func TestHandleKubePod(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},
@@ -1173,7 +1175,7 @@ func TestHandleKubePodWithoutPvcAsTags(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},
@@ -1322,7 +1324,7 @@ func TestHandleKubePodNoContainerName(t *testing.T) {
 				{
 					Source:       podSource,
 					EntityID:     podTaggerEntityID,
-					HighCardTags: []string{},
+					HighCardTags: []string{"kube_pod_uid:" + podEntityID.ID},
 					OrchestratorCardTags: []string{
 						"pod_name:" + podName,
 					},

--- a/comp/core/tagger/tags/tags.go
+++ b/comp/core/tagger/tags/tags.go
@@ -240,6 +240,8 @@ const (
 	ContainerName = "container_name"
 	// ContainerID is the tag for the container ID
 	ContainerID = "container_id"
+	// KubePodUID is the tag for the Kubernetes pod UID
+	KubePodUID = "kube_pod_uid"
 	// RancherContainer is the tag for the Rancher container name
 	RancherContainer = "rancher_container"
 )

--- a/releasenotes/notes/add-kube-pod-uid-high-cardinality-tag-a1b2c3d4e5f6g7h8.yaml
+++ b/releasenotes/notes/add-kube-pod-uid-high-cardinality-tag-a1b2c3d4e5f6g7h8.yaml
@@ -1,0 +1,6 @@
+features:
+  - |
+    Added ``kube_pod_uid`` as a high cardinality tag for Kubernetes pods. This tag contains
+    the pod's UID (``metadata.uid``) and is emitted when tag cardinality is set to ``high``.
+    This enables unique identification of pods across restarts and correlation with external
+    systems like DCGM that use pod UID as an identifier.


### PR DESCRIPTION
### What does this PR do?

Adds `kube_pod_uid` as a high cardinality tag for Kubernetes pods. The pod UID (`metadata.uid`) is already available in the workloadmeta store (`pod.EntityID.ID`) but was not exposed as a tag. This adds it alongside `container_id`, which has similar cardinality characteristics.

### Motivation

This is a follow-up to #41798 and the discussion around #45579.

The template variable support added in 7.77 (`%%kube_pod_uid%%` in `ad.datadoghq.com/tags`) requires the annotation to be present on every pod. For users who need `pod_uid` across all pods in a cluster, this still requires an external policy engine (Kyverno, OPA, etc.) to inject the annotation — the same fundamental problem as the `DD_CONTAINER_ENV_AS_TAGS` workaround.

The agent already has every pod's UID in the workloadmeta store. This PR simply exposes it as an opt-in high cardinality tag, the same way `container_id` is exposed. Users who set `checksCardinality: high` (or `DD_CHECKS_TAG_CARDINALITY=high`) get `kube_pod_uid` automatically on all pod metrics — no per-pod annotations, no admission webhooks, no external tooling.

**Use cases:**
- Joining Datadog k8s/container metrics with NVIDIA DCGM GPU metrics (DCGM exports `pod_uid` but not `container_id`)
- Uniquely identifying pods across restarts when pod names are reused
- Aggregating metrics per pod for multi-container pods (where `container_id` is per-container, not per-pod)

### Describe how you validated your changes

- Updated all pod entity test assertions in `TestHandleKubePod` to include the new `kube_pod_uid` high cardinality tag
- The change is a single `AddHigh` call following the exact same pattern as `container_id`

### Additional Notes

The cardinality impact is minimal since `checksCardinality: high` already includes `container_id`, which has equal or greater cardinality (multiple containers per pod). Adding `kube_pod_uid` does not meaningfully increase the tag volume for users already at high cardinality.