### PR TITLE
test(e2e/windows): ignore TiWorker.exe crash dumps

### DIFF
--- a/test/new-e2e/tests/windows/common/crashdump.go
+++ b/test/new-e2e/tests/windows/common/crashdump.go
@@ -153,6 +153,7 @@ var DefaultIgnoredCrashDumpImages = []string{
 	"svchost.exe",
 	"WmiPrvSE.exe",
 	"powershell.exe",
+	"TiWorker.exe",
 }
 
 // IsIgnoredCrashDump reports whether the dump's image name appears in ignore


### PR DESCRIPTION
### What does this PR do?

Adds `TiWorker.exe` to `DefaultIgnoredCrashDumpImages` so Windows Modules Installer Worker crashes are still collected as artifacts but do not fail Windows E2E tests.

### Motivation

Ref: [WINA-2712](https://datadoghq.atlassian.net/browse/WINA-2712). TiWorker crashes were failing `TestAgentMSIInstallsDotnetLibrary`. Analysis of the dump from job [1698945354](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1698945354) with cdb:

- Faulting instruction: `MPCLIENT!tlgEnableCallback` in an already-unloaded `MPCLIENT.DLL` (Microsoft Defender).
- Stack is entirely `ntdll!Etwp*` notification thread frames.
- `!analyze -v` root cause: *"An ETW client DLL was unloaded but failed to unregister the ETW provider GUID prior to unload. This is a problem with the provider."*

This is a Microsoft Defender ETW unload race, unrelated to the Datadog agent.


[WINA-2712]: https://datadoghq.atlassian.net/browse/WINA-2712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ