### PR TITLE
test(e2e/windows): enable log_level: debug in service-test fixtures

### DIFF
--- a/test/new-e2e/tests/windows/service-test/fixtures/datadog-di-disabled.yaml
+++ b/test/new-e2e/tests/windows/service-test/fixtures/datadog-di-disabled.yaml
@@ -1,3 +1,5 @@
+log_level: debug
+
 # enable logs agent
 logs_enabled: true
 

--- a/test/new-e2e/tests/windows/service-test/fixtures/datadog-pa-disabled.yaml
+++ b/test/new-e2e/tests/windows/service-test/fixtures/datadog-pa-disabled.yaml
@@ -1,3 +1,5 @@
+log_level: debug
+
 # disable logs agent
 logs_enabled: false
 

--- a/test/new-e2e/tests/windows/service-test/fixtures/datadog-rc-enabled.yaml
+++ b/test/new-e2e/tests/windows/service-test/fixtures/datadog-rc-enabled.yaml
@@ -1,3 +1,5 @@
+log_level: debug
+
 # enable logs agent
 logs_enabled: true
 

--- a/test/new-e2e/tests/windows/service-test/fixtures/datadog-ta-disabled.yaml
+++ b/test/new-e2e/tests/windows/service-test/fixtures/datadog-ta-disabled.yaml
@@ -1,3 +1,5 @@
+log_level: debug
+
 # enable logs agent
 logs_enabled: true
 

--- a/test/new-e2e/tests/windows/service-test/fixtures/datadog.yaml
+++ b/test/new-e2e/tests/windows/service-test/fixtures/datadog.yaml
@@ -1,3 +1,5 @@
+log_level: debug
+
 # enable logs agent
 logs_enabled: true
 

--- a/test/new-e2e/tests/windows/service-test/fixtures/security-agent-disabled.yaml
+++ b/test/new-e2e/tests/windows/service-test/fixtures/security-agent-disabled.yaml
@@ -1,3 +1,5 @@
+log_level: debug
+
 # enable security agent
 runtime_security_config:
   enabled: false

--- a/test/new-e2e/tests/windows/service-test/fixtures/security-agent.yaml
+++ b/test/new-e2e/tests/windows/service-test/fixtures/security-agent.yaml
@@ -1,3 +1,5 @@
+log_level: debug
+
 # enable security agent
 runtime_security_config:
   enabled: true

--- a/test/new-e2e/tests/windows/service-test/fixtures/system-probe-disabled.yaml
+++ b/test/new-e2e/tests/windows/service-test/fixtures/system-probe-disabled.yaml
@@ -1,3 +1,5 @@
+log_level: debug
+
 # disable NPM
 network_config:
   enabled: false

--- a/test/new-e2e/tests/windows/service-test/fixtures/system-probe-nofim.yaml
+++ b/test/new-e2e/tests/windows/service-test/fixtures/system-probe-nofim.yaml
@@ -1,3 +1,5 @@
+log_level: debug
+
 # enable NPM
 network_config:
   enabled: true

--- a/test/new-e2e/tests/windows/service-test/fixtures/system-probe.yaml
+++ b/test/new-e2e/tests/windows/service-test/fixtures/system-probe.yaml
@@ -1,3 +1,5 @@
+log_level: debug
+
 # enable NPM
 network_config:
   enabled: true


### PR DESCRIPTION
### What does this PR do?

Adds `log_level: debug` to every fixture used by `test/new-e2e/tests/windows/service-test/` — core agent (`datadog*.yaml`), system-probe (`system-probe*.yaml`), and security-agent (`security-agent*.yaml`).

### Motivation

When these tests fail (especially the driver-verifier variants), the captured agent logs only contain INFO and above. Several startup paths log at DEBUG only (e.g. the workloadmeta-readiness retry in `comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go:174`), which makes it hard to tell, from artifacts alone, whether a long gap in the log is one slow call or many fast retries spaced apart. Enabling debug-level logging in the fixtures means future failures land with the information needed to diagnose timing issues without a re-run.

### Describe how you validated your changes

Test-fixture-only change. No new tests added.