### PR TITLE
omnibus: drop redundant rpath patching on rtloader libs

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -84,11 +84,6 @@ build do
     command "dda inv -- -e systray.build", env: env, :live_stream => Omnibus.logger.live_stream(:info)
   else
     command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install --destdir='#{install_dir}'"
-    sh_ext = if linux_target? then "so" else "dylib" end
-    command_on_repo_root "bazelisk run #{bazel_flags} -- //bazel/rules:replace_prefix" \
-      " --prefix '#{install_dir}/embedded'" \
-      " #{install_dir}/embedded/lib/libdatadog-agent-rtloader.#{sh_ext}" \
-      " #{install_dir}/embedded/lib/libdatadog-agent-three.#{sh_ext}"
     command "dda inv -- -e agent.build --exclude-rtloader --no-development --install-path=#{install_dir} --embedded-path=#{install_dir}/embedded --flavor #{flavor_arg}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
   end
 


### PR DESCRIPTION
### What does this PR do?

Drops the `bazelisk run //bazel/rules:replace_prefix` call in `datadog-agent.rb` that edit rpath on `libdatadog-agent-rtloader.{so,dylib}` and `libdatadog-agent-three.{so,dylib}`.

### Motivation

Both libraries already flow through `dd_cc_packaged` (`rtloader_pkg`, `three_pkg`), which calls `rewrite_rpath` at Bazel install time. Verified locally: `readelf -d` on the installed `.so`s shows `RPATH: /opt/datadog-agent/embedded/lib` directly out of `//rtloader:install`, before the omnibus replace_prefix step ever runs.

### Describe how you validated your changes

- `bazelisk run --//:install_dir=/opt/datadog-agent //rtloader:install -- --destdir=/tmp/x`
- `readelf -d /tmp/x/embedded/lib/libdatadog-agent-{rtloader,three}.so | grep RPATH` returns the expected `/opt/datadog-agent/embedded/lib` on both.
- CI agent build.

### Additional Notes