### PR TITLE
Use container-scoped `outputBase` for Windows GitLab jobs

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -402,7 +402,7 @@
         "recordedInputs": [
           "FILE:@@//.bazelversion 077ee5b3a3a7fc2622ceff6466fea0c28f3fb08b24653dcc7f4baab29b9aef36",
           "FILE:@@//tools/bazel 8cd8e05bc6563f0ec312c10447f63c0d984f3bee34418ee07490e007f3ebfc3f",
-          "FILE:@@//tools/bazel.bat 24c80eecf763cf0f70ef5919413247b8e3dbc9eecd41dd63bc21f7c461b8a010",
+          "FILE:@@//tools/bazel.bat f13ecb6de386829a4d6fea1e81c6f1cdac0d38e28b52c969eb7da833934a37da",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
         ],
         "generatedRepoSpecs": {}

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -9,12 +9,12 @@ exit /b 2
 :bazelisk_ok
 
 :: Ensure `XDG_CACHE_HOME` denotes a directory
+if not defined DOTNET_RUNNING_IN_CONTAINER >nul 2>&1 sc query CExecSvc && set DOTNET_RUNNING_IN_CONTAINER=1
 if not exist "%XDG_CACHE_HOME%" (
   if defined CI (
     >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote a directory in CI!
     exit /b 2
   )
-  if not defined DOTNET_RUNNING_IN_CONTAINER >nul 2>&1 sc query CExecSvc && set DOTNET_RUNNING_IN_CONTAINER=1
   if defined DOTNET_RUNNING_IN_CONTAINER (
     >&2 echo 💡 To persist caches across restarts, please set XDG_CACHE_HOME pointing to a mounted directory, e.g.:
     >&2 echo     docker.exe run --env=XDG_CACHE_HOME=C:\cache --volume="$HOME\.cache:C:\cache" ...
@@ -34,7 +34,9 @@ if defined XDG_CACHE_HOME (
   set "PIP_CACHE_DIR=!XDG_CACHE_HOME!\pip"
   :: https://github.com/bazelbuild/bazel/issues/27808
   set "bazel_home=!XDG_CACHE_HOME!\bazel"
-  set bazel_home_startup_option="--output_user_root=!bazel_home!"
+  set startup_options="--output_user_root=!bazel_home!"
+  :: Use container-scoped `outputBase` to prevent races on `outputUserRoot\<same workspace hash>\server\jvm.out`
+  if defined DOTNET_RUNNING_IN_CONTAINER set startup_options=!startup_options! "--output_base=%SYSTEMDRIVE%\bob"
   set extra_args="--disk_cache=!bazel_home!\disk-cache"
   :: https://github.com/bazelbuild/bazel/issues/26384
   for %%i in ("%~dp0..\.cache") do if "!XDG_CACHE_HOME!" == "%%~fi" set "extra_args=!extra_args! --repo_contents_cache="
@@ -64,7 +66,7 @@ if not exist "!more_than_260_chars!" (
 
 set "args=%*"
 if defined args if defined extra_args call :insert_extra_args
-"%BAZEL_REAL%" !bazel_home_startup_option! !args!
+"%BAZEL_REAL%" !startup_options! !args!
 exit /b !errorlevel!
 
 :: "--startup cmd ..." -> "--startup cmd --config=ci ..."


### PR DESCRIPTION
### What does this PR do?
`tools/bazel.bat` now also passes `--output_base=%SYSTEMDRIVE%\bob` whenever it detects we're running inside a Windows container, so each container's per-workspace Bazel state (`server\`, `lock`, `action_cache\`, `execroot\`, `external\`, `bazel-out\`) lives on its own writable `outputBase` rather than any shared `outputUserRoot` (under a bind mount).

`install_base`, `disk_cache` and `repository_cache` continue to live under the shared `outputUserRoot`.

### Motivation
GitLab Windows runners might bind-mount the same host `c:\bzl` into several concurrent containers, or more likely a filesystem handle to a file under that directory may leak when a job is interrupted.
Inside each container, Bazel indeed resolves the same `outputUserRoot` and hashes the same in-container workspace path to the same `outputBase` directory:
```
outputUserRoot\<same workspace hash>\server\jvm.out
               ^^^^^^^^^^^^^^^^^^^^^ outputBase
```
... so concurrent bazel server (JVM) spawns race:
```
FATAL: ExecuteDaemon(c:\bzl\bazel\install\5ea2e927a67192a1c29b93353d8199e3\embedded_tools\jdk\bin\java.exe): CreateJvmOutputFile(c:\bzl\bazel\bv4fleb2\server\jvm.out) failed: (error: 32): The process cannot access the file because it is being used by another process.
```