### PR TITLE
deps: cpython: rpath-patch lib-dynload via dd_cc_packaged

### DIFF
--- a/bazel/rules/rewrite_rpath/macos.sh
+++ b/bazel/rules/rewrite_rpath/macos.sh
@@ -9,6 +9,9 @@ OUTPUT=$4
 
 # PREFIX is the full rpath (e.g. {install_dir}/embedded/lib); use as-is, do not append /lib
 cp "$INPUT" "$OUTPUT"
+# Restore owner-write so install_name_tool can modify dylibs installed as
+# read-only by their build system (e.g. Python lib-dynload modules).
+chmod u+w "$OUTPUT"
 install_name_tool -add_rpath "$PREFIX" "$OUTPUT" 2>/dev/null || true
 dylib_name=$(basename "$OUTPUT")
 new_id="$PREFIX/$dylib_name"

--- a/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
+++ b/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
@@ -65,8 +65,11 @@ def patchelf_dir_action(ctx, input_dir, output_dir, rpath):
     ctx.actions.run_shell(
         inputs = [input_dir],
         outputs = [output_dir],
+        # chmod restores owner-write so patchelf can rewrite read-only files
+        # (e.g. Python lib-dynload modules installed as mode 0555).
         command = (
             "cp -rL '{input}' '{output}' && " +
+            "chmod -R u+w '{output}' && " +
             "find '{output}' -type f \\( -name '*.so' -o -name '*.so.*' \\) " +
             "-exec '{patchelf}' --set-rpath '{rpath}' --force-rpath {{}} \\;"
         ).format(

--- a/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
+++ b/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
@@ -65,10 +65,11 @@ def patchelf_dir_action(ctx, input_dir, output_dir, rpath):
     ctx.actions.run_shell(
         inputs = [input_dir],
         outputs = [output_dir],
-        # chmod restores owner-write so patchelf can rewrite read-only files
-        # (e.g. Python lib-dynload modules installed as mode 0555).
+        # /. copies the contents of input rather than nesting it under output
+        # (Bazel pre-creates output via declare_directory). chmod restores
+        # owner-write so patchelf can rewrite files installed as 0555.
         command = (
-            "cp -rL '{input}' '{output}' && " +
+            "cp -rL '{input}/.' '{output}' && " +
             "chmod -R u+w '{output}' && " +
             "find '{output}' -type f \\( -name '*.so' -o -name '*.so.*' \\) " +
             "-exec '{patchelf}' --set-rpath '{rpath}' --force-rpath {{}} \\;"

--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -449,19 +449,6 @@ pkg_files(
     srcs = [":headers_unix"],
 )
 
-# Stdlib dir + stable API lib only — the versioned shared lib is handled by python_pkg/dd_cc_packaged.
-pkg_files(
-    name = "install_stdlib_unix",
-    srcs = [
-        ":python_lib_dir_unix",
-    ] + select({
-        "@platforms//os:linux": [":python_stable_lib_linux"],
-        "//conditions:default": [],
-    }),
-    attributes = pkg_attributes("0755"),
-    prefix = "lib",
-)
-
 pkg_files(
     name = "install_pip_unix",
     srcs = [":patch_pip_interpreter"],
@@ -474,7 +461,6 @@ pkg_files(
 pkg_filegroup(
     name = "_python_pkg_common_files",
     srcs = [
-        ":install_stdlib_unix",
         ":install_headers_unix",
         ":install_pip_unix",
     ] + [":python_bin_symlink_" + name for name in BIN_SYMLINKS.values()] + select({
@@ -487,7 +473,13 @@ dd_cc_packaged(
     name = "python_pkg",
     input = ":python_unix_shared",
     installed_files = [":_python_pkg_common_files"],
-    installed_executables = {":python3_bin": "bin"},
+    installed_executables = {
+        ":python3_bin": "bin",
+        ":python_lib_dir_unix": "lib/python{}".format(VERSION_STR),
+    } | select({
+        "@platforms//os:linux": {":python_stable_lib_linux": "lib"},
+        "//conditions:default": {},
+    }),
     visibility = ["//visibility:public"],
 )
 
@@ -499,7 +491,6 @@ pkg_filegroup(
             ":_openssl_deps_win",
         ],
         "//conditions:default": [
-            ":install_stdlib_unix",
             ":install_headers_unix",
             ":install_pip_unix",
         ] + [":python_bin_symlink_" + name for name in BIN_SYMLINKS.values()],

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -14,11 +14,9 @@ build do
   if !windows_target?
     env = with_standard_compiler_flags(with_embedded_path)
     command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @cpython//:install --destdir='#{install_dir}'"
-    sh_ext = if linux_target? then "so" else "dylib" end
+    # Libraries and binaries are rpath-patched by dd_cc_packaged in cpython.BUILD.bazel;
+    # this call is now only for the ##PREFIX## text substitution in _sysconfigdata.
     command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-      " #{install_dir}/embedded/lib/libpython3.*#{sh_ext}" \
-      " #{install_dir}/embedded/lib/python3.*/lib-dynload/*.so" \
-      " #{install_dir}/embedded/bin/python3*" \
       " #{install_dir}/embedded/lib/python3.*/_sysconfigdata__*.py"
     python = "#{install_dir}/embedded/bin/python3"
   else


### PR DESCRIPTION
### What does this PR do?
Moves rpath patching of `libpython3.so` and `lib-dynload/*.so` from the omnibus `replace_prefix` step into Bazel via `dd_cc_packaged.installed_executables`.

Along the way, two latent bugs in `patchelf_dir_action` / `macos.sh` are fixed (each in its own commit):

1. **chmod**: `cp` preserved the source mode (Python's lib-dynload modules ship `0555`), so patchelf/install_name_tool silently failed on the read-only copies. `chmod -R u+w` after the cp restores owner-write; `PackageFilesInfo.attributes = {"mode": "0755"}` overrides the installed mode so the chmod doesn't leak.
2. **flatten**: `cp -rL src dst` placed src *as a child of* dst, producing double-nested paths like `lib/engines-3/engines-3/*.so` on Linux. macOS's `otool_dir_action` (which uses `find | while` + per-file cp) was already flat. Switching to `cp -rL src/. dst` makes Linux match.

The second fix also unbreaks the OpenSSL FIPS engines/modules install layout: `lib/ossl-modules/legacy.so` and `lib/engines-3/*.so` are now at the canonical paths the callsites expect (was `lib/ossl-modules/ossl-modules/legacy.so` etc.). This was silent because our `openssl.cnf` only activates `fips` + `base` providers — `legacy` and engine .so files were never requested.

### Motivation
Continued migration of rpath patching from omnibus to Bazel.

### Describe how you validated your changes
- All 71 lib-dynload `.so` files ship with `RPATH: /opt/datadog-agent/embedded/lib` (zero sandbox-path leaks).
- `lib/ossl-modules/{fips,legacy}.so` and `lib/engines-3/*.so` land at the correct paths (no more double-nest).
- Installed mode is `755`.
- CI agent build.

### Additional Notes