### PR TITLE
Use registry.datadoghq.com for external image defaults

### DIFF
--- a/Dockerfiles/agent-ddot/Dockerfile
+++ b/Dockerfiles/agent-ddot/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE_DD_VERSION=latest
-FROM gcr.io/datadoghq/agent:$BASE_IMAGE_DD_VERSION AS baseimage
+FROM registry.datadoghq.com/agent:$BASE_IMAGE_DD_VERSION AS baseimage
 
 FROM baseimage
 

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -1,5 +1,5 @@
 # check=skip=SecretsUsedInArgOrEnv
-ARG AGENT_DOCKER_REPO=datadog/agent
+ARG AGENT_DOCKER_REPO=registry.datadoghq.com/agent
 ARG AGENT_VERSION=7.72.2
 ARG UBUNTU_VERSION=24.04
 ARG AGENT_DOCKER_TAG=${AGENT_VERSION}-full

--- a/Dockerfiles/manifests/agent-kubelet-only.yaml
+++ b/Dockerfiles/manifests/agent-kubelet-only.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: datadog-agent
       containers:
-      - image: datadog/agent:7
+      - image: registry.datadoghq.com/agent:7
         imagePullPolicy: Always
         name: datadog-agent
         env:

--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       serviceAccountName: datadog-agent
       containers:
-      - image: datadog/agent:7
+      - image: registry.datadoghq.com/agent:7
         imagePullPolicy: Always
         name: datadog-agent
         ports:

--- a/Dockerfiles/manifests/all-containers/cluster-agent-deployment.yaml
+++ b/Dockerfiles/manifests/all-containers/cluster-agent-deployment.yaml
@@ -36,7 +36,7 @@ spec:
       automountServiceAccountToken: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/cluster-agent:7.76.1"
+          image: "registry.datadoghq.com/cluster-agent:7.76.1"
           imagePullPolicy: IfNotPresent
           command:
             - cp
@@ -49,7 +49,7 @@ spec:
               mountPath: /opt/datadog-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:7.76.1"
+          image: "registry.datadoghq.com/cluster-agent:7.76.1"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -116,7 +116,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: "gcr.io/datadoghq"
+              value: "registry.datadoghq.com"
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED

--- a/Dockerfiles/manifests/all-containers/daemonset.yaml
+++ b/Dockerfiles/manifests/all-containers/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.76.1"
+          image: "registry.datadoghq.com/agent:7.76.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           securityContext:
@@ -248,7 +248,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.76.1"
+          image: "registry.datadoghq.com/agent:7.76.1"
           imagePullPolicy: IfNotPresent
           command: ["trace-loader", "/etc/datadog-agent/datadog.yaml", "trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           securityContext:
@@ -356,7 +356,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.76.1"
+          image: "registry.datadoghq.com/agent:7.76.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
           securityContext:
@@ -459,7 +459,7 @@ spec:
               subPath: system-probe.yaml
               readOnly: true
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.76.1"
+          image: "registry.datadoghq.com/agent:7.76.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -570,7 +570,7 @@ spec:
               mountPropagation: None
               readOnly: true
         - name: security-agent
-          image: "gcr.io/datadoghq/agent:7.76.1"
+          image: "registry.datadoghq.com/agent:7.76.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -684,7 +684,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.76.1"
+          image: "registry.datadoghq.com/agent:7.76.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -695,7 +695,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.76.1"
+          image: "registry.datadoghq.com/agent:7.76.1"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -749,7 +749,7 @@ spec:
               value: "false"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.76.1"
+          image: "registry.datadoghq.com/agent:7.76.1"
           imagePullPolicy: IfNotPresent
           command:
             - cp

--- a/cmd/host-profiler/docker-compose.yml
+++ b/cmd/host-profiler/docker-compose.yml
@@ -2,7 +2,7 @@ name: "host-profiler-with-agent"
 
 services:
   datadog-agent:
-    image: gcr.io/datadoghq/agent:7
+    image: registry.datadoghq.com/agent:7
     privileged: true
     environment:
       DD_SITE: ${DD_SITE:-datadoghq.com}

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -469,7 +469,7 @@ def hacky_dev_image_build(
 
         # Try to guess what is the latest release of the agent
         latest_release = semver.VersionInfo(0)
-        tags = requests.get("https://gcr.io/v2/datadoghq/agent/tags/list", timeout=10)
+        tags = requests.get("https://registry.datadoghq.com/v2/agent/tags/list", timeout=10)
         for tag in tags.json()['tags']:
             if not semver.VersionInfo.isvalid(tag):
                 continue
@@ -478,7 +478,7 @@ def hacky_dev_image_build(
                 continue
             if ver > latest_release:
                 latest_release = ver
-        base_image = f"gcr.io/datadoghq/agent:{latest_release}"
+        base_image = f"registry.datadoghq.com/agent:{latest_release}"
 
     # Extract the python library of the docker image
     with tempfile.TemporaryDirectory() as extracted_python_dir:

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -203,7 +203,7 @@ def hacky_dev_image_build(
 
         # Try to guess what is the latest release of the cluster-agent
         latest_release = semver.VersionInfo(0)
-        tags = requests.get("https://gcr.io/v2/datadoghq/cluster-agent/tags/list")
+        tags = requests.get("https://registry.datadoghq.com/v2/cluster-agent/tags/list")
         for tag in tags.json()['tags']:
             if not semver.VersionInfo.isvalid(tag):
                 continue
@@ -212,7 +212,7 @@ def hacky_dev_image_build(
                 continue
             if ver > latest_release:
                 latest_release = ver
-        base_image = f"gcr.io/datadoghq/cluster-agent:{latest_release}"
+        base_image = f"registry.datadoghq.com/cluster-agent:{latest_release}"
 
     with tempfile.NamedTemporaryFile(mode='w') as dockerfile:
         dockerfile.write(

--- a/test/e2e-framework/components/datadog/agent/docker_image.go
+++ b/test/e2e-framework/components/datadog/agent/docker_image.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	defaultAgentImageRepo            = "gcr.io/datadoghq/agent"
-	defaultClusterAgentImageRepo     = "gcr.io/datadoghq/cluster-agent"
-	defaultOTelAgentGatewayImageRepo = "gcr.io/datadoghq/ddot-collector"
+	defaultAgentImageRepo            = "registry.datadoghq.com/agent"
+	defaultClusterAgentImageRepo     = "registry.datadoghq.com/cluster-agent"
+	defaultOTelAgentGatewayImageRepo = "registry.datadoghq.com/ddot-collector"
 	defaultAgentImageTag             = "latest"
 	defaultAgent6ImageTag            = "6"
 	defaultDevAgentImageRepo         = "datadog/agent-dev" // Used as default repository for images that are not stable and released yet, should not be used in the CI

--- a/test/e2e-framework/components/datadog/csi-driver/driver.go
+++ b/test/e2e-framework/components/datadog/csi-driver/driver.go
@@ -31,7 +31,7 @@ func NewDatadogCSIDriver(e config.Env, kubeProvider *kubernetes.Provider, csiDri
 	}
 	opts = append(opts, utils.PulumiDependsOn(ns))
 
-	csiRepo := "docker.io/datadog/csi-driver"
+	csiRepo := "registry.datadoghq.com/csi-driver"
 	registrarRepo := "registry.k8s.io/sig-storage/csi-node-driver-registrar"
 
 	var imgPullSecret *corev1.Secret

--- a/test/e2e-framework/components/datadog/dogstatsd-standalone/docker_image.go
+++ b/test/e2e-framework/components/datadog/dogstatsd-standalone/docker_image.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultDogstatsdImageRepo = "gcr.io/datadoghq/dogstatsd"
+	defaultDogstatsdImageRepo = "registry.datadoghq.com/dogstatsd"
 	defaultDogstatsdImageTag  = "latest"
 )
 

--- a/test/e2e-framework/components/datadog/dogstatsd-standalone/k8s.go
+++ b/test/e2e-framework/components/datadog/dogstatsd-standalone/k8s.go
@@ -257,7 +257,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("dogstatsd-standalone"),
-							Image: pulumi.String(dockerDogstatsdFullImagePath(e, "gcr.io/datadoghq/dogstatsd")),
+							Image: pulumi.String(dockerDogstatsdFullImagePath(e, "registry.datadoghq.com/dogstatsd")),
 							Ports: corev1.ContainerPortArray{
 								&corev1.ContainerPortArgs{
 									ContainerPort: pulumi.Int(8125),

--- a/test/e2e-framework/components/datadog/operator/docker_image.go
+++ b/test/e2e-framework/components/datadog/operator/docker_image.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultOperatorImageRepo = "gcr.io/datadoghq/operator"
+	defaultOperatorImageRepo = "registry.datadoghq.com/operator"
 	defaultOperatorImageTag  = "latest"
 )
 

--- a/test/e2e-framework/scenarios/gcp/fakeintake/params.go
+++ b/test/e2e-framework/scenarios/gcp/fakeintake/params.go
@@ -20,7 +20,7 @@ type Option = func(*Params) error
 // NewParams returns a new instance of Fakeintake Params
 func NewParams(options ...Option) (*Params, error) {
 	params := &Params{
-		ImageURL:        "gcr.io/datadoghq/fakeintake:latest",
+		ImageURL:        "registry.datadoghq.com/fakeintake:latest",
 		DDDevForwarding: true,
 		Memory:          1024,
 		LoadBalancer:    false,

--- a/test/new-e2e/tests/ssi/ssi_test.go
+++ b/test/new-e2e/tests/ssi/ssi_test.go
@@ -170,7 +170,7 @@ func (v *ssiSuite) TestLocalSDKInjection() {
 					Apps: []singlestep.App{
 						{
 							Name:    "local-sdk-injection-app",
-							Image:   "registry.datadoghq.com/injector-dev/python",
+							Image:   "gcr.io/datadoghq/injector-dev/python",
 							Version: "d425e7df",
 							Port:    8080,
 							PodLabels: map[string]string{
@@ -183,7 +183,7 @@ func (v *ssiSuite) TestLocalSDKInjection() {
 						},
 						{
 							Name:    "local-sdk-expect-no-injection",
-							Image:   "registry.datadoghq.com/injector-dev/python",
+							Image:   "gcr.io/datadoghq/injector-dev/python",
 							Version: "d425e7df",
 							Port:    8080,
 						},
@@ -237,7 +237,7 @@ func (v *ssiSuite) TestNamespaceSelection() {
 					Apps: []singlestep.App{
 						{
 							Name:    "namespace-selection-inject",
-							Image:   "registry.datadoghq.com/injector-dev/python",
+							Image:   "gcr.io/datadoghq/injector-dev/python",
 							Version: "d425e7df",
 							Port:    8080,
 						},
@@ -248,7 +248,7 @@ func (v *ssiSuite) TestNamespaceSelection() {
 					Apps: []singlestep.App{
 						{
 							Name:    "namespace-selection-no-inject",
-							Image:   "registry.datadoghq.com/injector-dev/python",
+							Image:   "gcr.io/datadoghq/injector-dev/python",
 							Version: "d425e7df",
 							Port:    8080,
 						},
@@ -306,7 +306,7 @@ func (v *ssiSuite) TestWorkloadSelection() {
 					Apps: []singlestep.App{
 						{
 							Name:    "workload-selection-inject",
-							Image:   "registry.datadoghq.com/injector-dev/python",
+							Image:   "gcr.io/datadoghq/injector-dev/python",
 							Version: "d425e7df",
 							Port:    8080,
 							PodLabels: map[string]string{
@@ -315,7 +315,7 @@ func (v *ssiSuite) TestWorkloadSelection() {
 						},
 						{
 							Name:    "workload-selection-expect-no-injection",
-							Image:   "registry.datadoghq.com/injector-dev/python",
+							Image:   "gcr.io/datadoghq/injector-dev/python",
 							Version: "d425e7df",
 							Port:    8080,
 						},
@@ -358,9 +358,9 @@ func (v *ssiSuite) TestWorkloadSelection() {
 }
 
 func (v *ssiSuite) TestRegistryAllowList() {
-	// All three apps run in the same cluster with allow list = registry.datadoghq.com.
-	// The default container registry for injector and library images is registry.datadoghq.com.
-	// - "allowed": default injector and library, both from registry.datadoghq.com — injection proceeds.
+	// All three apps run in the same cluster with allow list = gcr.io/datadoghq.
+	// The default container registry for injector and library images is gcr.io/datadoghq.
+	// - "allowed": default injector and library, both from gcr.io/datadoghq — injection proceeds.
 	// - "injector-blocked": injector image overridden to fake.registry.invalid — injection blocked.
 	// - "library-blocked": injector is allowed, but python-lib.custom-image points to
 	//   fake.registry.invalid — injection blocked by library registry check.

--- a/test/new-e2e/tests/ssi/ssi_test.go
+++ b/test/new-e2e/tests/ssi/ssi_test.go
@@ -170,7 +170,7 @@ func (v *ssiSuite) TestLocalSDKInjection() {
 					Apps: []singlestep.App{
 						{
 							Name:    "local-sdk-injection-app",
-							Image:   "gcr.io/datadoghq/injector-dev/python",
+							Image:   "registry.datadoghq.com/injector-dev/python",
 							Version: "d425e7df",
 							Port:    8080,
 							PodLabels: map[string]string{
@@ -183,7 +183,7 @@ func (v *ssiSuite) TestLocalSDKInjection() {
 						},
 						{
 							Name:    "local-sdk-expect-no-injection",
-							Image:   "gcr.io/datadoghq/injector-dev/python",
+							Image:   "registry.datadoghq.com/injector-dev/python",
 							Version: "d425e7df",
 							Port:    8080,
 						},
@@ -237,7 +237,7 @@ func (v *ssiSuite) TestNamespaceSelection() {
 					Apps: []singlestep.App{
 						{
 							Name:    "namespace-selection-inject",
-							Image:   "gcr.io/datadoghq/injector-dev/python",
+							Image:   "registry.datadoghq.com/injector-dev/python",
 							Version: "d425e7df",
 							Port:    8080,
 						},
@@ -248,7 +248,7 @@ func (v *ssiSuite) TestNamespaceSelection() {
 					Apps: []singlestep.App{
 						{
 							Name:    "namespace-selection-no-inject",
-							Image:   "gcr.io/datadoghq/injector-dev/python",
+							Image:   "registry.datadoghq.com/injector-dev/python",
 							Version: "d425e7df",
 							Port:    8080,
 						},
@@ -306,7 +306,7 @@ func (v *ssiSuite) TestWorkloadSelection() {
 					Apps: []singlestep.App{
 						{
 							Name:    "workload-selection-inject",
-							Image:   "gcr.io/datadoghq/injector-dev/python",
+							Image:   "registry.datadoghq.com/injector-dev/python",
 							Version: "d425e7df",
 							Port:    8080,
 							PodLabels: map[string]string{
@@ -315,7 +315,7 @@ func (v *ssiSuite) TestWorkloadSelection() {
 						},
 						{
 							Name:    "workload-selection-expect-no-injection",
-							Image:   "gcr.io/datadoghq/injector-dev/python",
+							Image:   "registry.datadoghq.com/injector-dev/python",
 							Version: "d425e7df",
 							Port:    8080,
 						},
@@ -358,9 +358,9 @@ func (v *ssiSuite) TestWorkloadSelection() {
 }
 
 func (v *ssiSuite) TestRegistryAllowList() {
-	// All three apps run in the same cluster with allow list = gcr.io/datadoghq.
-	// The default container registry for injector and library images is gcr.io/datadoghq.
-	// - "allowed": default injector and library, both from gcr.io/datadoghq — injection proceeds.
+	// All three apps run in the same cluster with allow list = registry.datadoghq.com.
+	// The default container registry for injector and library images is registry.datadoghq.com.
+	// - "allowed": default injector and library, both from registry.datadoghq.com — injection proceeds.
 	// - "injector-blocked": injector image overridden to fake.registry.invalid — injection blocked.
 	// - "library-blocked": injector is allowed, but python-lib.custom-image points to
 	//   fake.registry.invalid — injection blocked by library registry check.

--- a/test/new-e2e/tests/ssi/testdata/base.yaml
+++ b/test/new-e2e/tests/ssi/testdata/base.yaml
@@ -6,7 +6,7 @@ clusterAgent:
 # Temporary until the Datadog CSI driver is released
 datadog-csi-driver:
   image:
-    repository: "gcr.io/datadoghq/csi-driver"
+    repository: "registry.datadoghq.com/csi-driver"
     tag: "1.2.0"
 
 datadog:

--- a/test/new-e2e/tests/ssi/testdata/injection_mode.yaml
+++ b/test/new-e2e/tests/ssi/testdata/injection_mode.yaml
@@ -6,7 +6,7 @@ clusterAgent:
 # Temporary until the Datadog CSI driver is released
 datadog-csi-driver:
   image:
-    repository: "gcr.io/datadoghq/csi-driver"
+    repository: "registry.datadoghq.com/csi-driver"
     tag: "1.2.0"
 
 datadog:

--- a/test/new-e2e/tests/ssi/testdata/registry_allow_list.yaml
+++ b/test/new-e2e/tests/ssi/testdata/registry_allow_list.yaml
@@ -4,9 +4,9 @@ clusterAgent:
     configMode: "hostip"
   env:
     - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY_ALLOW_LIST
-      value: "registry.datadoghq.com"
+      value: "gcr.io/datadoghq"
     # Disable gradual rollout so the injector resolves deterministically to
-    # registry.datadoghq.com (the NoOpResolver). Without this, the rollout
+    # gcr.io/datadoghq (the NoOpResolver). Without this, the rollout
     # resolver may return an image from a different registry, causing the
     # allow list check to block the "allowed" pod unexpectedly.
     - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_GRADUAL_ROLLOUT_ENABLED

--- a/test/new-e2e/tests/ssi/testdata/registry_allow_list.yaml
+++ b/test/new-e2e/tests/ssi/testdata/registry_allow_list.yaml
@@ -4,9 +4,9 @@ clusterAgent:
     configMode: "hostip"
   env:
     - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY_ALLOW_LIST
-      value: "gcr.io/datadoghq"
+      value: "registry.datadoghq.com"
     # Disable gradual rollout so the injector resolves deterministically to
-    # gcr.io/datadoghq (the NoOpResolver). Without this, the rollout
+    # registry.datadoghq.com (the NoOpResolver). Without this, the rollout
     # resolver may return an image from a different registry, causing the
     # allow list check to block the "allowed" pod unexpectedly.
     - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_GRADUAL_ROLLOUT_ENABLED
@@ -15,7 +15,7 @@ clusterAgent:
 # Temporary until the Datadog CSI driver is released
 datadog-csi-driver:
   image:
-    repository: "gcr.io/datadoghq/csi-driver"
+    repository: "registry.datadoghq.com/csi-driver"
     tag: "1.2.0"
 
 datadog:


### PR DESCRIPTION
## What

Update selected external image pull paths from `gcr.io/datadoghq` and Docker Hub `datadog/*` references to `registry.datadoghq.com`.

This covers Dockerfiles, example manifests, host-profiler compose, invoke base-image lookups, E2E framework default image repositories, fakeintake defaults, and selected E2E Helm/image values.

## Why

These paths can cause builds, examples, or E2E tests to pull Datadog images from legacy public registry locations. Moving the selected references to `registry.datadoghq.com` keeps the external pull surface aligned with the current registry.

## Scope

This intentionally does not change Agent runtime/admission-controller internals, Fleet installer registry fallback behavior, historical release notes, broad fixture expectations, local `agent-dev` defaults whose replacement tags were not consistently available, or SSI injection test defaults that still depend on the Agent's current `gcr.io/datadoghq` admission-controller registry.

## Tracking

- Jira: https://datadoghq.atlassian.net/browse/BARX-1848

## Validation

- Verified introduced `registry.datadoghq.com` image manifests with `crane manifest`.
- Verified tag listing works for dynamic Agent and Cluster Agent base-image lookup repositories with `crane ls`.
- Ran `git diff --check`.
- Ran `dda inv test --module=test/new-e2e --targets=./tests/ssi --test-run-name=^$ --timeout=120 --verbose`.
- Pre-push hooks passed: `go-mod-tidy`, `go-mod-replace`, `go-test`, `go-linter`, and related repository hooks.
