### PR TITLE
[Backport 7.79.x] fix(npm/windows): suppress lingering flow re-reports that cause >100% TCP failure rate

### DIFF
--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -40,6 +40,7 @@ var stateTelemetry = struct {
 	postgresStatsDropped   *telemetry.StatCounterWrapper
 	redisStatsDropped      *telemetry.StatCounterWrapper
 	dnsPidCollisions       *telemetry.StatCounterWrapper
+	windowsLingeringFlows  *telemetry.StatCounterWrapper
 	incomingDirectionFixes telemetry.Counter
 	outgoingDirectionFixes telemetry.Counter
 }{
@@ -55,6 +56,7 @@ var stateTelemetry = struct {
 	telemetry.NewStatCounterWrapper(stateModuleName, "postgres_stats_dropped", []string{}, "Counter measuring the number of postgres stats dropped"),
 	telemetry.NewStatCounterWrapper(stateModuleName, "redis_stats_dropped", []string{}, "Counter measuring the number of redis stats dropped"),
 	telemetry.NewStatCounterWrapper(stateModuleName, "dns_pid_collisions", []string{}, "Counter measuring the number of DNS PID collisions"),
+	telemetry.NewStatCounterWrapper(stateModuleName, "windows_lingering_flows", []string{}, "Counter measuring flows that were already reported closed but are still being re-reported with failures by the Windows NPM driver (lingering openFlows bug)"),
 	telemetry.NewCounter(stateModuleName, "incoming_direction_fixes", []string{}, "Counter measuring the number of udp direction fixes for incoming connections"),
 	telemetry.NewCounter(stateModuleName, "outgoing_direction_fixes", []string{}, "Counter measuring the number of udp/tcp direction fixes for outgoing connections"),
 }
@@ -134,6 +136,7 @@ type lastStateTelemetry struct {
 	postgresStatsDropped  int64
 	redisStatsDropped     int64
 	dnsPidCollisions      int64
+	windowsLingeringFlows int64
 }
 
 const minClosedCapacity = 1024
@@ -446,6 +449,7 @@ func (ns *networkState) logTelemetry() {
 	postgresStatsDroppedDelta := stateTelemetry.postgresStatsDropped.Load() - ns.lastTelemetry.postgresStatsDropped
 	redisStatsDroppedDelta := stateTelemetry.redisStatsDropped.Load() - ns.lastTelemetry.redisStatsDropped
 	dnsPidCollisionsDelta := stateTelemetry.dnsPidCollisions.Load() - ns.lastTelemetry.dnsPidCollisions
+	windowsLingeringFlowsDelta := stateTelemetry.windowsLingeringFlows.Load() - ns.lastTelemetry.windowsLingeringFlows
 
 	// Flush log line if any metric is non-zero
 	if connDroppedDelta > 0 || closedConnDroppedDelta > 0 || dnsStatsDroppedDelta > 0 || httpStatsDroppedDelta > 0 ||
@@ -473,17 +477,20 @@ func (ns *networkState) logTelemetry() {
 
 	// debug metrics that aren't useful for customers to see
 	if statsCookieCollisionsDelta > 0 || statsUnderflowsDelta > 0 ||
-		timeSyncCollisionsDelta > 0 || dnsPidCollisionsDelta > 0 {
+		timeSyncCollisionsDelta > 0 || dnsPidCollisionsDelta > 0 ||
+		windowsLingeringFlowsDelta > 0 {
 		s := "State telemetry debug: "
 		s += " [%d stats cookie collisions]"
 		s += " [%d stats underflows]"
 		s += " [%d time sync collisions]"
 		s += " [%d DNS pid collisions]"
+		s += " [%d Windows lingering flows suppressed]"
 		log.Debugf(s,
 			statsCookieCollisionsDelta,
 			statsUnderflowsDelta,
 			timeSyncCollisionsDelta,
 			dnsPidCollisionsDelta,
+			windowsLingeringFlowsDelta,
 		)
 	}
 
@@ -499,6 +506,7 @@ func (ns *networkState) logTelemetry() {
 	ns.lastTelemetry.postgresStatsDropped = stateTelemetry.postgresStatsDropped.Load()
 	ns.lastTelemetry.redisStatsDropped = stateTelemetry.redisStatsDropped.Load()
 	ns.lastTelemetry.dnsPidCollisions = stateTelemetry.dnsPidCollisions.Load()
+	ns.lastTelemetry.windowsLingeringFlows = stateTelemetry.windowsLingeringFlows.Load()
 }
 
 // RegisterClient registers a client before it first gets stream of data.
@@ -741,6 +749,8 @@ func (ns *networkState) updateConnWithStats(client *client, cookie StatCookie, c
 			c.Monotonic = c.Monotonic.Max(sts)
 			last, _ = c.Monotonic.Sub(sts)
 		}
+
+		dropStaleFlowFailures(c, sts, last)
 
 		c.Last = c.Last.Add(last)
 		client.stats[cookie] = c.Monotonic

--- a/pkg/network/state_notwindows.go
+++ b/pkg/network/state_notwindows.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package network
+
+// dropStaleFlowFailures is a no-op on non-Windows platforms. The stale-failure
+// condition it guards against is caused by a race in the ddnpm Windows kernel
+// driver that leaves terminated flows in its openFlows table indefinitely;
+// that driver bug does not exist on Linux or macOS.
+// See state_windows.go for the full implementation and root-cause explanation.
+func dropStaleFlowFailures(_ *ConnectionStats, _, _ StatCounters) {}

--- a/pkg/network/state_tcp_failure_replay_windows_test.go
+++ b/pkg/network/state_tcp_failure_replay_windows_test.go
@@ -1,0 +1,141 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package network
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+func replayNewDefaultState() *networkState {
+	return NewState(nil, 2*time.Minute, 50000, 75000, 75000, 7500, 7500, 7500, 7500, false, false, []int{53}).(*networkState)
+}
+
+// lingeringFlowFixture returns a ConnectionStats that models what FlowToConnStat
+// produces for a Windows flow stuck in the driver's openFlows table.
+// pollIdx drives monotonically increasing byte counts so the delta is non-zero
+// and the connection is not filtered before updateConnWithStats runs.
+func lingeringFlowFixture(pollIdx int) ConnectionStats {
+	// 104 matches what event_windows.go:146 emits for ConnectionStatusRecvRst.
+	const eConnReset = uint16(104)
+	return ConnectionStats{
+		ConnectionTuple: ConnectionTuple{
+			Pid:    1234,
+			Type:   TCP,
+			Family: AFINET,
+			Source: util.AddressFromString("10.0.0.1"),
+			Dest:   util.AddressFromString("10.0.0.2"),
+			SPort:  45678,
+			DPort:  443,
+		},
+		Monotonic: StatCounters{
+			SentBytes:      uint64(1500 * pollIdx),
+			RecvBytes:      uint64(200 * pollIdx),
+			TCPEstablished: 1,
+			TCPClosed:      1, // PR #47005: set because TCPFailures is non-empty
+		},
+		TCPFailures: map[uint16]uint32{eConnReset: 1},
+		Cookie:      0xCAFEBABE,
+	}
+}
+
+// TestWindowsTCPFailureReplay verifies the agent-side fix for the >100% TCP
+// failure rate caused by flows stuck in the Windows ddnpm driver's openFlows
+// table (lingering-flow bug, WINA-2711).
+//
+// The fix lives in state_windows.go: when a connection was already reported as
+// closed (sts.TCPClosed > 0) and the current delta has no new close
+// (last.TCPClosed == 0), zero out TCPFailures so no additional failures ship.
+func TestWindowsTCPFailureReplay(t *testing.T) {
+	var epoch uint64
+	nextEpoch := func() uint64 { epoch++; return epoch }
+
+	const clientID = "test-client"
+	state := replayNewDefaultState()
+	state.RegisterClient(clientID)
+
+	lingeringBefore := stateTelemetry.windowsLingeringFlows.Load()
+
+	const numPolls = 3
+	var totalFailures, totalClosed uint32
+
+	for poll := 1; poll <= numPolls; poll++ {
+		poll := poll
+		t.Run(fmt.Sprintf("poll=%d", poll), func(t *testing.T) {
+			conn := lingeringFlowFixture(poll)
+			delta := state.GetDelta(clientID, nextEpoch(), []ConnectionStats{conn}, nil, nil)
+			require.Len(t, delta.Conns, 1, "poll %d should report 1 connection", poll)
+
+			shipped := delta.Conns[0]
+			lastClosed := uint32(shipped.Last.TCPClosed)
+			var failuresThisPoll uint32
+			for _, v := range shipped.TCPFailures {
+				failuresThisPoll += v
+			}
+			t.Logf("Last.TCPClosed=%d TCPFailures=%v", lastClosed, shipped.TCPFailures)
+
+			totalClosed += lastClosed
+			totalFailures += failuresThisPoll
+
+			switch poll {
+			case 1:
+				require.Equal(t, uint32(1), lastClosed, "poll 1 must ship TCPClosed=1")
+				require.Equal(t, uint32(1), failuresThisPoll, "poll 1 must ship 1 failure")
+			default:
+				require.Equal(t, uint32(0), lastClosed,
+					"poll %d: TCPClosed delta is 0 (already counted on poll 1)", poll)
+				require.Equal(t, uint32(0), failuresThisPoll,
+					"poll %d: failures suppressed by lingering-flow fix", poll)
+			}
+		})
+	}
+
+	require.Equal(t, uint32(1), totalFailures, "only poll 1 ships a failure; re-reports are suppressed")
+	require.Equal(t, uint32(1), totalClosed, "TCPClosed only shipped on first poll")
+
+	require.NotZero(t, totalClosed, "GetDelta never shipped a TCPClosed event across all polls")
+	backendRatePct := float64(totalFailures) * 100.0 / float64(totalClosed)
+	require.Equal(t, 100.0, backendRatePct, "fix keeps backend rate at exactly 100%%")
+
+	lingeringAfter := stateTelemetry.windowsLingeringFlows.Load()
+	require.Equal(t, int64(numPolls-1), lingeringAfter-lingeringBefore,
+		"windowsLingeringFlows counter should increment once per suppressed re-report")
+}
+
+// TestWindowsTCPFailureReplay_NoFailuresNoOp verifies that the suppression path
+// is a no-op for flows with empty TCPFailures.
+func TestWindowsTCPFailureReplay_NoFailuresNoOp(t *testing.T) {
+	var epoch uint64
+	nextEpoch := func() uint64 { epoch++; return epoch }
+
+	const clientID = "test-nofailures"
+	state := replayNewDefaultState()
+	state.RegisterClient(clientID)
+
+	lingeringBefore := stateTelemetry.windowsLingeringFlows.Load()
+
+	for poll := 1; poll <= 2; poll++ {
+		conn := ConnectionStats{
+			ConnectionTuple: ConnectionTuple{Pid: 1, Type: TCP, Family: AFINET,
+				Source: util.AddressFromString("10.0.0.3"), Dest: util.AddressFromString("10.0.0.4"),
+				SPort: 2222, DPort: 80},
+			Monotonic: StatCounters{SentBytes: uint64(1000 * poll), TCPClosed: 1},
+			Cookie:    0xBEEFCAFE,
+		}
+		delta := state.GetDelta(clientID, nextEpoch(), []ConnectionStats{conn}, nil, nil)
+		require.Len(t, delta.Conns, 1, "poll %d", poll)
+	}
+
+	require.Equal(t, lingeringBefore, stateTelemetry.windowsLingeringFlows.Load(),
+		"counter must not increment for flows with no TCPFailures")
+}

--- a/pkg/network/state_windows.go
+++ b/pkg/network/state_windows.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package network
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// dropStaleFlowFailures suppresses duplicate TCPFailures from flows that are
+// still in the driver's open state and being re-reported across multiple polls
+// while waiting to fully close. Once a connection has already been reported as
+// closed (sts.TCPClosed > 0), any re-report with no new close event
+// (last.TCPClosed == 0) is a duplicate — zero out its TCPFailures so no
+// additional failures ship for that poll.
+func dropStaleFlowFailures(c *ConnectionStats, sts, last StatCounters) {
+	if sts.TCPClosed > 0 && last.TCPClosed == 0 && len(c.TCPFailures) > 0 {
+		stateTelemetry.windowsLingeringFlows.Inc()
+		// Log before zeroing so the closure sees the non-nil map.
+		log.DebugFunc(func() string {
+			return fmt.Sprintf("NPM windows: suppressing lingering flow cookie:%d already-closed re-report (failures: %v)", c.Cookie, c.TCPFailures)
+		})
+		c.TCPFailures = nil
+	}
+}

--- a/releasenotes/notes/npm-windows-tcp-failure-rate-19186450c26c3544.yaml
+++ b/releasenotes/notes/npm-windows-tcp-failure-rate-19186450c26c3544.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug on Windows where the NPM TCP failure rate could exceed 100% and
+    climb indefinitely.


### PR DESCRIPTION
Backport 4d8c72b372a7153f004d4236876637859f660211 from #50823.

 ___

### What does this PR do?

On Windows, the ddnpm kernel driver can leave a terminated flow stuck in `openFlows` when a WFP transport callout holds a refcount > 2 at the moment the closure callback fires. Each agent poll re-reports the flow with a fresh `TCPFailures={104:1}`. Since `TCPFailures` is not tracked in `StatCounters`, it has no delta baseline and ships as a new failure every poll while `Last.TCPClosed` stays at 0 after the first poll — causing the backend rate to climb past 100% unboundedly.

Fix: in `updateConnWithStats`, when a connection was already reported as closed (`sts.TCPClosed > 0`) and the current delta has no new close event (`last.TCPClosed == 0`), zero out `TCPFailures` so the re-report is empty and filtered from the payload entirely.

Adds a `windows_lingering_flows` telemetry counter and warn-level log line in `system-probe.log` so affected hosts are observable.

### Motivation

https://datadoghq.atlassian.net/browse/WINA-2711

### Describe how you validated your changes

Unit test in `pkg/network/state_tcp_failure_replay_test.go` reproduces the state-machine asymmetry across 3 polls and verifies the fix holds the backend rate at exactly 100%, with the `windowsLingeringFlows` counter incrementing once per suppressed re-report.

Reproduced end-to-end on EC2 (Windows Server 2025, real ENI) with ~10,000 TLS+HTTP RST connections at 256 workers. Before the fix: NPM rate > 100% and climbing. After deploying the patched `system-probe.exe`: `system-probe.log` showed `[74 Windows lingering flows suppressed]` and the NPM rate held at 100%.

### Additional Notes

The permanent fix belongs in the ddnpm driver (`flowdata.c` — the `InterlockedCompareExchange` in `DecrementRefCountAndMoveFromOpenToClosedTable` should retry or use a different sync primitive). This is an agent-side workaround to prevent the symptom from reaching customers while the driver fix is developed.

Note: loopback traffic is synchronous in the Windows kernel and cannot trigger the race. Real NIC traffic is required to reproduce.