### PR TITLE
macos: fix system-probe.yaml being overwritten on upgrade

### DIFF
--- a/omnibus/package-scripts/agent-dmg/postinst
+++ b/omnibus/package-scripts/agent-dmg/postinst
@@ -88,6 +88,7 @@ mkdir -vp $CONF_DIR/checks.d
 
 if [ -d "$SAVED_CONF_DIR" ]; then
     cp -vf "$SAVED_CONF_DIR/datadog.yaml" $CONF_DIR/ 2>/dev/null || true
+    cp -vf "$SAVED_CONF_DIR/system-probe.yaml" $CONF_DIR/ 2>/dev/null || true
     cp -vfR "$SAVED_CONF_DIR/conf.d/"* $CONF_DIR/conf.d 2>/dev/null || true
     cp -vn "$SAVED_CONF_DIR/checks.d/"* $CONF_DIR/checks.d 2>/dev/null || true
 fi

--- a/omnibus/package-scripts/agent-dmg/preinst
+++ b/omnibus/package-scripts/agent-dmg/preinst
@@ -203,6 +203,7 @@ if [ -e "$CONF_DIR/datadog.yaml" ]; then
     mkdir -vp "$SAVED_CONF_DIR/checks.d"
     chmod 700 "$INSTALL_STAGING_DIR"
     cp -vf $CONF_DIR/datadog.yaml "$SAVED_CONF_DIR/"
+    cp -vf $CONF_DIR/system-probe.yaml "$SAVED_CONF_DIR/" 2>/dev/null || true
     cp -vfR $CONF_DIR/conf.d/* "$SAVED_CONF_DIR/conf.d" 2>/dev/null || true
     find "$SAVED_CONF_DIR/conf.d" '(' -name '*.yaml.example' -o -name '*.yaml.default' ')' -delete
     cp -vfR $CONF_DIR/checks.d/* "$SAVED_CONF_DIR/checks.d" 2>/dev/null || true

--- a/releasenotes/notes/macos-preserve-system-probe-yaml-fb19dd3338a82b3b.yaml
+++ b/releasenotes/notes/macos-preserve-system-probe-yaml-fb19dd3338a82b3b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    On macOS, preserve user customizations to ``system-probe.yaml`` across Agent upgrades.


### PR DESCRIPTION
### What does this PR do?

Saves and restores `system-probe.yaml` across DMG upgrades, mirroring the existing `datadog.yaml` save/restore in the pre/postinst scripts.

### Motivation

The Bazel `//cmd/agent/dist:config_files` rule ships a bare `system-probe.yaml` (generated from `system-probe_template.yaml`) in the pkg payload — verified by running `bazel run //packages/agent/product:post_build_install`, which writes both `etc/system-probe.yaml` and `etc/datadog.yaml` to the destdir. The pkg installer overwrites those exact paths during extraction. `datadog.yaml` survives upgrade because preinst saves it and postinst restores it after extraction; `system-probe.yaml` had no such save/restore, so any user customization (NPM, USM, CWS settings, etc.) was lost on every agent upgrade.

### Describe how you validated your changes

Ran `bazel run //packages/agent/product:post_build_install -- --destdir=/tmp/check` and confirmed `etc/system-probe.yaml` is present as a bare file in the payload. Verified the new `cp` lines follow the existing pattern (`cp -vf … 2>/dev/null || true`), so a missing source file (the common case where the user never touched `system-probe.yaml`) doesn't fail the install. Full macOS install/upgrade E2E coverage runs on merge to `main`, not on PR branches.

### Additional Notes

`security-agent.yaml` is shipped only as `*.yaml.example` (via the omnibus `move` from `pkg/config/example/security-agent.yaml.example`) and therefore survives upgrade without explicit save/restore — out of scope here. Same for `ai_usage_native_host.yaml`, which postinst seeds from `.example` when missing.