### PR TITLE
chore(aggregator): set title on Agent lifecycle event

### DIFF
--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -343,6 +343,7 @@ func (d *AgentDemultiplexer) agentLifecycleEvent(agentVersion string, eventType 
 	}
 
 	return event.Event{
+		Title:          eventType,
 		Text:           "Version " + agentVersion,
 		SourceTypeName: "System",
 		Host:           d.aggregator.hostname,

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -161,6 +161,7 @@ func TestAddAgentStartupTelemetrySendsShutdownEventOnFinalStop(t *testing.T) {
 	case <-time.After(time.Second):
 		require.FailNow(t, "timed out waiting for Agent Shutdown event")
 	}
+	require.Equal(t, "Agent Shutdown", shutdownEvent.Title)
 	require.Equal(t, "Version 7.0.0", shutdownEvent.Text)
 	require.Equal(t, "System", shutdownEvent.SourceTypeName)
 	require.Equal(t, "hostname", shutdownEvent.Host)


### PR DESCRIPTION
### What does this PR do?
Populates `title` for the agent's lifecycle events (startup and shutdown)

### Motivation
ECT-5537
### Describe how you validated your changes
1. Run the agent and shutdown gracefully.
2. Observe that the events in Datadog have titles.

### Additional Notes
