### PR TITLE
[Backport 7.80.x] Bump pip to 26.1.1 in embedded Python distribution

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -26,8 +26,9 @@ build do
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
   end
 
-  # Upgrade pip to 26.0.1 to address CVE-2026-1703 (path traversal in pip < 26.0
-  # when installing malicious wheel archives). Python 3.13 ships with pip 25.3 via
+  # Upgrade pip to 26.1.1 to address CVE-2026-6357 (self-update import-after-install
+  # timing in pip < 26.1) and CVE-2026-1703 (path traversal in pip < 26.0 when
+  # installing malicious wheel archives). Python 3.13 ships with pip 25.3 via
   # ensurepip, which is vulnerable.
-  command "#{python} -m pip install pip==26.0.1"
+  command "#{python} -m pip install pip==26.1.1"
 end

--- a/releasenotes/notes/pip-26.1-cve-2026-6357-4d941bde7e76ef3f.yaml
+++ b/releasenotes/notes/pip-26.1-cve-2026-6357-4d941bde7e76ef3f.yaml
@@ -1,0 +1,4 @@
+---
+security:
+  - |
+    Bumped pip to 26.1.1 in the embedded Python distribution to address CVE-2026-6357.

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,51 +1,51 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 750.8 MiB
-  max_on_wire_size: 179.34 MiB
+  max_on_disk_size: 750.96 MiB
+  max_on_wire_size: 179.37 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 704.3 MiB
-  max_on_wire_size: 174.61 MiB
+  max_on_disk_size: 703.35 MiB
+  max_on_wire_size: 174.77 MiB
 static_quality_gate_agent_heroku_amd64:
-  max_on_disk_size: 314.26 MiB
-  max_on_wire_size: 80.38 MiB
+  max_on_disk_size: 315.1 MiB
+  max_on_wire_size: 80.57 MiB
 static_quality_gate_agent_msi:
-  max_on_disk_size: 624.04 MiB
-  max_on_wire_size: 148.83 MiB
+  max_on_disk_size: 624.07 MiB
+  max_on_wire_size: 148.69 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 750.77 MiB
-  max_on_wire_size: 182.23 MiB
+  max_on_disk_size: 750.93 MiB
+  max_on_wire_size: 182.33 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 704.3 MiB
-  max_on_wire_size: 174.08 MiB
+  max_on_disk_size: 703.33 MiB
+  max_on_wire_size: 174.12 MiB
 static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 724.5 MiB
-  max_on_wire_size: 163.78 MiB
+  max_on_disk_size: 724.69 MiB
+  max_on_wire_size: 163.95 MiB
 static_quality_gate_agent_rpm_arm64_fips:
-  max_on_disk_size: 684.87 MiB
-  max_on_wire_size: 156.99 MiB
+  max_on_disk_size: 685.09 MiB
+  max_on_wire_size: 157.15 MiB
 static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 750.77 MiB
-  max_on_wire_size: 182.23 MiB
+  max_on_disk_size: 750.93 MiB
+  max_on_wire_size: 182.33 MiB
 static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 704.3 MiB
-  max_on_wire_size: 174.08 MiB
+  max_on_disk_size: 703.33 MiB
+  max_on_wire_size: 174.12 MiB
 static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 724.5 MiB
-  max_on_wire_size: 163.78 MiB
+  max_on_disk_size: 724.69 MiB
+  max_on_wire_size: 163.95 MiB
 static_quality_gate_agent_suse_arm64_fips:
-  max_on_disk_size: 684.87 MiB
-  max_on_wire_size: 156.99 MiB
+  max_on_disk_size: 685.09 MiB
+  max_on_wire_size: 157.15 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 806.34 MiB
-  max_on_wire_size: 273.18 MiB
+  max_on_disk_size: 806.5 MiB
+  max_on_wire_size: 273.45 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 810.12 MiB
-  max_on_wire_size: 261.65 MiB
+  max_on_disk_size: 810.31 MiB
+  max_on_wire_size: 261.91 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 997.6 MiB
-  max_on_wire_size: 341.81 MiB
+  max_on_disk_size: 997.22 MiB
+  max_on_wire_size: 342.07 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 989.8 MiB
-  max_on_wire_size: 326.22 MiB
+  max_on_disk_size: 989.99 MiB
+  max_on_wire_size: 326.47 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 207.71 MiB
   max_on_wire_size: 73.5 MiB

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -2,7 +2,7 @@ static_quality_gate_agent_deb_amd64:
   max_on_disk_size: 750.8 MiB
   max_on_wire_size: 179.34 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 703.15 MiB
+  max_on_disk_size: 704.3 MiB
   max_on_wire_size: 174.61 MiB
 static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 314.26 MiB
@@ -14,7 +14,7 @@ static_quality_gate_agent_rpm_amd64:
   max_on_disk_size: 750.77 MiB
   max_on_wire_size: 182.23 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 703.13 MiB
+  max_on_disk_size: 704.3 MiB
   max_on_wire_size: 174.08 MiB
 static_quality_gate_agent_rpm_arm64:
   max_on_disk_size: 724.5 MiB
@@ -26,7 +26,7 @@ static_quality_gate_agent_suse_amd64:
   max_on_disk_size: 750.77 MiB
   max_on_wire_size: 182.23 MiB
 static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 703.13 MiB
+  max_on_disk_size: 704.3 MiB
   max_on_wire_size: 174.08 MiB
 static_quality_gate_agent_suse_arm64:
   max_on_disk_size: 724.5 MiB
@@ -41,7 +41,7 @@ static_quality_gate_docker_agent_arm64:
   max_on_disk_size: 810.12 MiB
   max_on_wire_size: 261.65 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 997.06 MiB
+  max_on_disk_size: 997.6 MiB
   max_on_wire_size: 341.81 MiB
 static_quality_gate_docker_agent_jmx_arm64:
   max_on_disk_size: 989.8 MiB


### PR DESCRIPTION
Manual backport of #51087 to 7.80.x (DDCI backport bot was unavailable).

### What does this PR do?

Bumps pip from 26.0.1 to 26.1.1 in the omnibus-built embedded Python distribution.

### Motivation

Addresses CVE-2026-6357 (self-update import-after-install timing in pip < 26.1).

Fixes: [VULN-81523](https://datadoghq.atlassian.net/browse/VULN-81523)

### Additional Notes

26.1.1 is the latest patch release; it includes the CVE-2026-6357 fix from 26.1 plus subsequent bug fixes.

[VULN-81523]: https://datadoghq.atlassian.net/browse/VULN-81523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ