### PR TITLE
comp/core/agenttelemetry: use preserve_tags for dogstatsd metrics

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -217,10 +217,10 @@ var defaultProfiles = `
         zero_metric: true
       metrics:
         - name: dogstatsd.udp_packets_bytes
-          aggregate_tags:
+          preserve_tags:
             - remote_agent
         - name: dogstatsd.uds_packets_bytes
-          aggregate_tags:
+          preserve_tags:
             - remote_agent
         - name: logs.bytes_missed
         - name: logs.bytes_sent


### PR DESCRIPTION
## Summary

Updates the two dogstatsd metrics in the COAT default profile (`dogstatsd.udp_packets_bytes` and `dogstatsd.uds_packets_bytes`) to use the `preserve_tags` key instead of the deprecated `aggregate_tags` alias. These entries were added by #50386 after #50647 (the `aggregate_tags` → `preserve_tags` rename) had already merged, so they landed on main with the old key.

## Test plan
- [x] `dda inv test --targets=./comp/core/agenttelemetry/impl/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)