### PR TITLE
chore(AD): Simple Interface Cleanup

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -132,13 +132,13 @@ func Module() fxutil.Module {
 }
 
 func newProvides(deps dependencies) provides {
-	c := newAutoConfig(deps)
+	ac := newAutoConfig(deps)
 	return provides{
-		Comp:           c,
-		StatusProvider: status.NewInformationProvider(autodiscoveryStatus.GetProvider(c, deps.FilterStore)),
+		Comp:           ac,
+		StatusProvider: status.NewInformationProvider(autodiscoveryStatus.GetProvider(ac, deps.FilterStore)),
 
-		Endpoint:      api.NewAgentEndpointProvider(c.(*AutoConfig).writeConfigCheck, "/config-check", "GET"),
-		FlareProvider: flaretypes.NewProvider(c.(*AutoConfig).fillFlare),
+		Endpoint:      api.NewAgentEndpointProvider(ac.writeConfigCheck, "/config-check", "GET"),
+		FlareProvider: flaretypes.NewProvider(ac.fillFlare),
 	}
 }
 
@@ -154,7 +154,7 @@ func (l *listenerCandidate) try() (listeners.ServiceListener, error) {
 }
 
 // newAutoConfig creates an AutoConfig instance and starts it.
-func newAutoConfig(deps dependencies) autodiscovery.Component {
+func newAutoConfig(deps dependencies) *AutoConfig {
 	schController := scheduler.NewController()
 	// Non-blocking start of the scheduler controller
 	go func() {

--- a/comp/core/autodiscovery/component.go
+++ b/comp/core/autodiscovery/component.go
@@ -23,7 +23,6 @@ import (
 type Component interface {
 	AddConfigProvider(provider types.ConfigProvider, shouldPoll bool, pollInterval time.Duration)
 	LoadAndRun(ctx context.Context)
-	GetAllConfigs() []integration.Config
 	GetUnresolvedConfigs() []integration.Config
 	AddListeners(listenerConfigs []pkgconfigsetup.Listeners)
 	AddScheduler(name string, s scheduler.Scheduler, replayConfigs bool)

--- a/comp/core/autodiscovery/noopimpl/autoconfig.go
+++ b/comp/core/autodiscovery/noopimpl/autoconfig.go
@@ -37,10 +37,6 @@ func (n *noopAutoConfig) AddConfigProvider(types.ConfigProvider, bool, time.Dura
 
 func (n *noopAutoConfig) LoadAndRun(context.Context) {}
 
-func (n *noopAutoConfig) GetAllConfigs() []integration.Config {
-	return []integration.Config{}
-}
-
 func (n *noopAutoConfig) GetUnresolvedConfigs() []integration.Config {
 	return []integration.Config{}
 }


### PR DESCRIPTION
### What does this PR do?

Simply Autodiscovery cleanup uncovering while analyzing the component recently.

Future work: take a look into how we can initialize Autodiscovery within Autodiscovery. There's a handful of methods that are called externally just once to setup collectors and providers.
