### PR TITLE
ignore sigpipe in mac gui app

### DIFF
--- a/comp/core/gui/impl/systray/Sources/main.swift
+++ b/comp/core/gui/impl/systray/Sources/main.swift
@@ -1,5 +1,9 @@
 import Cocoa
 
+// Avoid process termination when writing to a client socket that already closed.
+// write() will return -1 with errno=EPIPE, which WiFiIPCServer handles.
+signal(SIGPIPE, SIG_IGN)
+
 // Parse command-line arguments
 let args = CommandLine.arguments
 let useFileLogging = args.contains("--use-file-logging")

--- a/releasenotes/notes/mac_gui_app_ignore_sigpipe-bae4a60020eedb45.yaml
+++ b/releasenotes/notes/mac_gui_app_ignore_sigpipe-bae4a60020eedb45.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    MacOS agent GUI app needs to ignore SIGPIPE to avoid process termination.


### PR DESCRIPTION
### What does this PR do?
This PR makes the MacOS gui app ignore SIGPIPE to avoid process termination.

### Motivation
[WINA-2731](https://datadoghq.atlassian.net/browse/WINA-2731)

### Describe how you validated your changes
Conduct stress test on both old and new solution to ensure SIGPIPE is handled correctly and the GUI app process is not terminated by closed IPC socket.

### Additional Notes


[WINA-2731]: https://datadoghq.atlassian.net/browse/WINA-2731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ