### PR TITLE
Remove tag_devel invoke task

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -279,13 +279,6 @@ def tag_version(
 
 
 @task
-def tag_devel(ctx, release_branch, commit="HEAD", push=True, force=False):
-    with agent_context(ctx, get_default_branch(major=get_version_major(release_branch))):
-        tag_version(ctx, release_branch, commit, push, force, devel=True, skip_agent_context=True)
-        tag_modules(ctx, release_branch, commit, push, force, devel=True, trust=True, skip_agent_context=True)
-
-
-@task
 def finish(ctx, release_branch, upstream="origin", release_date=None):
     """Updates the release.json file for the new version.
 


### PR DESCRIPTION
### What does this PR do?

Removes the `tag_devel` invoke task from `tasks/release.py`.

### Motivation

This task has been superseded by the [Temporal-based Release Coordinator Automation](https://datadoghq.atlassian.net/wiki/spaces/BARX/pages/6425117374/Release+Coordinator+Automation+Guide) workflow, which now handles the release process. The two functions it called (`tag_version` and `tag_modules`) are still used by the `rc` task and are left in place.

### Describe how you validated your changes

N/A — pure deletion of dead code.

### Additional Notes

None.