### PR TITLE
ci(actions): add concurrency groups to label-triggered workflows

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -12,6 +12,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   do-not-merge:
     if: ${{ contains(github.event.*.labels.*.name, 'do-not-merge/hold') || contains(github.event.*.labels.*.name, 'do-not-merge/WIP') }}

--- a/.github/workflows/go-update-commenter.yml
+++ b/.github/workflows/go-update-commenter.yml
@@ -9,6 +9,10 @@ permissions:
   # write permissions are needed to create the comment
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   old-versions-match:
     # Only run if the PR is labeled with 'go-update'

--- a/.github/workflows/go-update-commenter.yml
+++ b/.github/workflows/go-update-commenter.yml
@@ -9,10 +9,6 @@ permissions:
   # write permissions are needed to create the comment
   pull-requests: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   old-versions-match:
     # Only run if the PR is labeled with 'go-update'

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -8,6 +8,10 @@ on:
       - main
       - "[0-9]+.[0-9]+.x"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### What does this PR do?

Adds `concurrency` blocks with `cancel-in-progress: true` to three GitHub Actions workflows that fire on every `labeled` event:

- `.github/workflows/label-analysis.yml`
- `.github/workflows/do-not-merge.yml`
- `.github/workflows/go-update-commenter.yml`

### Motivation

Renovate (and Dependabot before it) applies several labels to a PR at once. Each label fires a separate `labeled` event, causing these workflows to run 6–9 times per PR for work that only needs to happen once with the final label state. On a typical Renovate PR (e.g. #51203), this generated ~26 redundant runs across these 3 workflows alone.

Adding per-PR concurrency groups collapses each burst to a single surviving run, saving ~18 runs per Renovate PR (~⅓ of total GitHub Actions runs triggered).

`ask-review` and `backport-pr` are intentionally excluded: each `labeled` event for those workflows targets a distinct team or backport branch. Cancelling a previous run there would silently drop work (a team never notified, or a backport never created).

### Describe how you validated your changes

Reviewed the trigger logic of all 6 `labeled`-triggered workflows to confirm which ones are idempotent (safe to cancel) vs. which process unique per-label data. Applied concurrency only to the safe subset.

### Additional Notes

`do-not-merge.yml` uses `github.event.pull_request.number || github.ref` as the group key because that workflow also fires on `push` to `mq-working-branch-*` branches (where there is no PR number).