### PR TITLE
Add rule to make foreign_cc targets runnable and apply it to Python

### DIFF
--- a/bazel/rules/foreign_cc_runnable/BUILD.bazel
+++ b/bazel/rules/foreign_cc_runnable/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["patch_rpaths.sh"])

--- a/bazel/rules/foreign_cc_runnable/foreign_cc_runnable.bzl
+++ b/bazel/rules/foreign_cc_runnable/foreign_cc_runnable.bzl
@@ -1,0 +1,161 @@
+"""Make a rules_foreign_cc tree runnable from Bazel actions.
+
+`configure_make` outputs don't come out with rpaths pointing at where their dependencies
+would be found under Bazel's output tree.
+This rule produces a copy of the tree with rpaths rewritten so that:
+
+  - Intra-tree shared libs (e.g. libpython in the tree's own `lib/`) are found
+    via `$ORIGIN`-relative paths from each binary/shared lib.
+  - Cross-tree shared libs (from the input's dynamic deps) are found at their
+    canonical bazel-out paths, which Bazel stages in any consumer action that
+    receives this rule's output.
+
+Most of the necessary information to decide which files to patch and what rpath entries
+to add are based on CcInfo and DefaultInfo entries produced by `rules_foreign_cc` rules.
+
+Linux only for now (uses patchelf). macOS support to be added.
+"""
+
+load("@bazel_lib//lib:paths.bzl", "relative_file")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+
+def _relative_folder(to_dir, from_path):
+    """Relative path between folders."""
+
+    # bazel_lib's relative_file assumes files, to make it work for folders
+    # we need to go up one more level.
+    return paths.normalize("../" + relative_file(to_dir, from_path))
+
+def _collect_cc_libs(cc_info, input_label):
+    """Collect libs from CcInfo's linker inputs."""
+    own_libs = []
+    dep_libs = []
+    for linker_input in cc_info.linking_context.linker_inputs.to_list():
+        for lib in linker_input.libraries:
+            f = lib.resolved_symlink_dynamic_library or lib.dynamic_library
+            if f == None:
+                continue
+            if linker_input.owner == input_label:
+                own_libs.append(f)
+            else:
+                dep_libs.append(f)
+    return own_libs, dep_libs
+
+def _foreign_cc_runnable_impl(ctx):
+    # rules_foreign_cc exposes the full install root via the `gen_dir` output
+    # group; the default files list is a heterogeneous mix of binaries,
+    # shared libs and data dirs.
+    gen_dir_files = ctx.attr.input[OutputGroupInfo].gen_dir.to_list()
+    if len(gen_dir_files) != 1:
+        fail("Expected a single `gen_dir` tree artifact on {}, got {}".format(
+            ctx.attr.input.label,
+            len(gen_dir_files),
+        ))
+    input_tree = gen_dir_files[0]
+    output_tree = ctx.actions.declare_directory(ctx.label.name)
+
+    # Canonical path to the root of the install tree for individual file outputs.
+    install_root = paths.join(
+        input_tree.root.path,
+        ctx.attr.input.label.workspace_root,
+        ctx.attr.input.label.package,
+        ctx.attr.input.label.name,
+    )
+
+    # Collect own and dependency libraries
+    own_libs, dep_libs = _collect_cc_libs(ctx.attr.input[CcInfo], ctx.attr.input.label)
+
+    # Tree-relative directories that should be in every patched file's rpath,
+    # based on the libraries coming from the input itself as well as those in dependencies.
+    own_dirs = set([paths.dirname(paths.relativize(f.path, install_root)) for f in own_libs])
+    dep_dirs = set([f.dirname for f in dep_libs])
+    rpath_dirs = sorted(own_dirs) + sorted([_relative_folder(d, output_tree.path) for d in dep_dirs])
+
+    # Build manifest instructions. Each line:
+    #   FILE<TAB>tree-relative-path
+    #   GLOB<TAB>tree-relative-pattern
+    instructions = []
+
+    # Always patch the rule's executable binary.
+    instructions.append("FILE\t" + ctx.attr.binary_path)
+
+    # Auto-discovered own shared libs.
+    for lib in own_libs:
+        instructions.append("FILE\t" + paths.relativize(lib.path, install_root))
+
+    # Globs for contents of opaque TreeArtifacts that need to be patched.
+    for glob in ctx.attr.patch_globs:
+        instructions.append("GLOB\t" + glob)
+
+    manifest = ctx.actions.declare_file(ctx.label.name + "_patch_manifest.txt")
+    ctx.actions.write(manifest, "\n".join(instructions) + "\n")
+
+    toolchain = ctx.toolchains["@@//bazel/toolchains/patchelf:patchelf_toolchain_type"].patchelf
+
+    args = ctx.actions.args()
+    args.add(toolchain.path)
+    args.add(input_tree.path)
+    args.add(output_tree.path)
+    args.add(manifest.path)
+    args.add_all(rpath_dirs)
+
+    ctx.actions.run(
+        executable = ctx.file._script,
+        arguments = [args],
+        inputs = [input_tree, manifest],
+        outputs = [output_tree],
+        mnemonic = "ForeignCcRunnable",
+        progress_message = "Rewriting rpaths for %{label}",
+    )
+
+    # Expose the chosen binary inside the tree as a separately-declared executable output,
+    # so callers can use it as an `executable` without digging into the TreeArtifact.
+    executable = ctx.actions.declare_symlink(ctx.label.name + "_bin")
+    ctx.actions.symlink(
+        output = executable,
+        target_path = "{tree}/{path}".format(
+            tree = ctx.label.name,
+            path = ctx.attr.binary_path,
+        ),
+    )
+
+    return DefaultInfo(
+        files = depset([output_tree, executable] + dep_libs),
+        executable = executable,
+    )
+
+foreign_cc_runnable = rule(
+    implementation = _foreign_cc_runnable_impl,
+    executable = True,
+    doc = """Rewrite rpaths in a rules_foreign_cc tree so it can be used as a
+    tool in Bazel actions. Cross-tree dependencies are derived from the
+    input's CcInfo and bundled via DefaultInfo so consumers automatically
+    stage them.""",
+    attrs = {
+        "input": attr.label(
+            mandatory = True,
+            providers = [OutputGroupInfo, CcInfo],
+            doc = "A rules_foreign_cc target (configure_make/cmake) whose output tree should be made runnable.",
+        ),
+        "binary_path": attr.string(
+            mandatory = True,
+            doc = """Tree-relative path of the binary to expose as the rule's executable.
+            A symlink at the rule's output level points into the patched tree at this path;
+            the file itself is always patched.""",
+        ),
+        "patch_globs": attr.string_list(
+            doc = """Tree-relative glob patterns matching additional files to patch.
+            Use for files produced by the build which are not declared as libraries.""",
+        ),
+        "_script": attr.label(
+            default = "//bazel/rules/foreign_cc_runnable:patch_rpaths.sh",
+            allow_single_file = True,
+            cfg = "exec",
+            executable = True,
+        ),
+    },
+    toolchains = [
+        "@@//bazel/toolchains/patchelf:patchelf_toolchain_type",
+    ],
+)

--- a/bazel/rules/foreign_cc_runnable/foreign_cc_runnable.bzl
+++ b/bazel/rules/foreign_cc_runnable/foreign_cc_runnable.bzl
@@ -12,8 +12,6 @@ This rule produces a copy of the tree with rpaths rewritten so that:
 
 Most of the necessary information to decide which files to patch and what rpath entries
 to add are based on CcInfo and DefaultInfo entries produced by `rules_foreign_cc` rules.
-
-Linux only for now (uses patchelf). macOS support to be added.
 """
 
 load("@bazel_lib//lib:paths.bzl", "relative_file")
@@ -26,6 +24,9 @@ def _relative_folder(to_dir, from_path):
     # bazel_lib's relative_file assumes files, to make it work for folders
     # we need to go up one more level.
     return paths.normalize("../" + relative_file(to_dir, from_path))
+
+def _is_os(ctx, constraint):
+    return ctx.target_platform_has_constraint(constraint[platform_common.ConstraintValueInfo])
 
 def _collect_cc_libs(cc_info, input_label):
     """Collect libs from CcInfo's linker inputs."""
@@ -91,10 +92,16 @@ def _foreign_cc_runnable_impl(ctx):
     manifest = ctx.actions.declare_file(ctx.label.name + "_patch_manifest.txt")
     ctx.actions.write(manifest, "\n".join(instructions) + "\n")
 
-    toolchain = ctx.toolchains["@@//bazel/toolchains/patchelf:patchelf_toolchain_type"].patchelf
+    is_linux = _is_os(ctx, ctx.attr._linux_constraint)
+    is_macos = _is_os(ctx, ctx.attr._macos_constraint)
+    if not is_linux and not is_macos:
+        fail("{}: unsupported platform (Linux and macOS only)".format(ctx.label))
+
+    patchelf = ctx.toolchains["@@//bazel/toolchains/patchelf:patchelf_toolchain_type"].patchelf
 
     args = ctx.actions.args()
-    args.add(toolchain.path)
+    args.add("linux" if is_linux else "darwin")
+    args.add(patchelf.path)
     args.add(input_tree.path)
     args.add(output_tree.path)
     args.add(manifest.path)
@@ -153,6 +160,12 @@ foreign_cc_runnable = rule(
             allow_single_file = True,
             cfg = "exec",
             executable = True,
+        ),
+        "_linux_constraint": attr.label(
+            default = "@platforms//os:linux",
+        ),
+        "_macos_constraint": attr.label(
+            default = "@platforms//os:macos",
         ),
     },
     toolchains = [

--- a/bazel/rules/foreign_cc_runnable/patch_rpaths.sh
+++ b/bazel/rules/foreign_cc_runnable/patch_rpaths.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Materialize a runnable copy of $INPUT in $OUTPUT, rewriting rpaths on the
+# files listed in $MANIFEST.
+
+# The rpath each file gets is derived from its position in the output tree
+# and the directories in $RPATH_DIRS
+#
+# Manifest format (tab-separated, one instruction per line):
+#   FILE\t<tree-relative path>
+#   GLOB\t<tree-relative pattern>
+#
+# A FILE must exist; a GLOB must match at least one file.
+set -euo pipefail
+
+PATCHELF="$1"
+INPUT="$2"
+OUTPUT="$3"
+MANIFEST="$4"
+shift 4
+RPATH_DIRS=("$@")
+
+# `cp -rL` materializes a real copy and dereferences any symlinks that
+# rules_foreign_cc may have left in the install tree. The `/.` on $INPUT
+# copies its contents rather than the directory itself.
+cp -rL "$INPUT/." "$OUTPUT/"
+
+patch_file() {
+    local f="$1"
+    local rel="${f#"$OUTPUT"/}"
+    # Number of parent directories between $f and $OUTPUT (= number of slashes)
+    local slashes="${rel//[^\/]/}"
+    local depth=${#slashes}
+
+    local ups=""
+    for ((i = 0; i < depth; i++)); do
+        ups="${ups}../"
+    done
+
+    local rpath=""
+    for dir in "${RPATH_DIRS[@]}"; do
+        rpath+="${rpath:+:}\$ORIGIN/${ups}${dir}"
+    done
+
+    "$PATCHELF" --set-rpath "$rpath" --force-rpath "$f"
+}
+
+while IFS=$'\t' read -r kind path; do
+    case "$kind" in
+        FILE)
+            target="$OUTPUT/$path"
+            if [[ ! -e "$target" ]]; then
+                echo "patch_rpaths: FILE '$path' not found in tree" >&2
+                exit 1
+            fi
+            patch_file "$target"
+            ;;
+        GLOB)
+            count=0
+            while IFS= read -r -d '' f; do
+                patch_file "$f"
+                count=$((count + 1))
+            done < <(find "$OUTPUT" -path "$OUTPUT/$path" -type f -print0)
+            if [[ $count -eq 0 ]]; then
+                echo "patch_rpaths: GLOB '$path' matched no files" >&2
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Unknown manifest instruction kind: $kind" >&2
+            exit 1
+            ;;
+    esac
+done < "$MANIFEST"

--- a/bazel/rules/foreign_cc_runnable/patch_rpaths.sh
+++ b/bazel/rules/foreign_cc_runnable/patch_rpaths.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # Materialize a runnable copy of $INPUT in $OUTPUT, rewriting rpaths on the
-# files listed in $MANIFEST.
-
-# The rpath each file gets is derived from its position in the output tree
-# and the directories in $RPATH_DIRS
+# files listed in $MANIFEST. On Linux each rpath entry is prefixed with
+# `$ORIGIN/<ups>`; on macOS with `@loader_path/<ups>`.
 #
 # Manifest format (tab-separated, one instruction per line):
 #   FILE\t<tree-relative path>
@@ -12,11 +10,12 @@
 # A FILE must exist; a GLOB must match at least one file.
 set -euo pipefail
 
-PATCHELF="$1"
-INPUT="$2"
-OUTPUT="$3"
-MANIFEST="$4"
-shift 4
+PLATFORM="$1"
+PATCHELF="$2"
+INPUT="$3"
+OUTPUT="$4"
+MANIFEST="$5"
+shift 5
 RPATH_DIRS=("$@")
 
 # `cp -rL` materializes a real copy and dereferences any symlinks that
@@ -36,12 +35,19 @@ patch_file() {
         ups="${ups}../"
     done
 
-    local rpath=""
-    for dir in "${RPATH_DIRS[@]}"; do
-        rpath+="${rpath:+:}\$ORIGIN/${ups}${dir}"
-    done
-
-    "$PATCHELF" --set-rpath "$rpath" --force-rpath "$f"
+    if [[ "$PLATFORM" == "darwin" ]]; then
+        for dir in "${RPATH_DIRS[@]}"; do
+            install_name_tool -add_rpath "@loader_path/${ups}${dir}" "$f" 2>/dev/null || true
+        done
+        # Re-sign with an ad-hoc signature; install_name_tool invalidates any existing code signature.
+        codesign --sign - --force "$f" 2>/dev/null
+    else
+        local rpath=""
+        for dir in "${RPATH_DIRS[@]}"; do
+            rpath+="${rpath:+:}\$ORIGIN/${ups}${dir}"
+        done
+        "$PATCHELF" --set-rpath "$rpath" --force-rpath "$f"
+    fi
 }
 
 while IFS=$'\t' read -r kind path; do

--- a/bazel/rules/foreign_cc_runnable/patch_rpaths.sh
+++ b/bazel/rules/foreign_cc_runnable/patch_rpaths.sh
@@ -37,7 +37,7 @@ patch_file() {
 
     if [[ "$PLATFORM" == "darwin" ]]; then
         for dir in "${RPATH_DIRS[@]}"; do
-            install_name_tool -add_rpath "@loader_path/${ups}${dir}" "$f" 2>/dev/null || true
+            install_name_tool -add_rpath "@loader_path/${ups}${dir}" "$f"
         done
         # Re-sign with an ad-hoc signature; install_name_tool invalidates any existing code signature.
         codesign --sign - --force "$f" 2>/dev/null

--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -2,6 +2,7 @@ load("@@//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
 load("@//bazel/rules:foreign_cc_shared_wrapper.bzl", "foreign_cc_shared_wrapper")
 load("@@//bazel/rules/dd_packaging:dd_cc_packaged.bzl", "dd_cc_packaged")
 load("@@//bazel/rules/dd_packaging:dd_collect_dependencies.bzl", "dd_collect_dependencies")
+load("@@//bazel/rules/foreign_cc_runnable:foreign_cc_runnable.bzl", "foreign_cc_runnable")
 load("@//deps/openssl:version.bzl", "OPENSSL_VERSION")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@bazel_lib//lib:run_binary.bzl", "run_binary")
@@ -306,6 +307,23 @@ configure_make(
 foreign_cc_shared_wrapper(
     name = "python_unix_shared",
     input = ":python_unix",
+    visibility = ["//visibility:public"],
+)
+
+# A copy of python_unix with rpaths rewritten so the interpreter and its
+# lib-dynload modules can find libpython and the dynamic deps at runtime.
+# Use this (not :python_unix) when invoking python from a Bazel action.
+foreign_cc_runnable(
+    name = "python_unix_runnable",
+    input = ":python_unix",
+    binary_path = "bin/python{}".format(VERSION_STR),
+    patch_globs = [
+        "lib/python{}/lib-dynload/*.so".format(VERSION_STR),
+    ],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -49,8 +49,8 @@ WIN_LIBCRYPTO = "libcrypto-3-x64.dll"
 LINUX_LIBSSL = "libssl.so.3"
 LINUX_LIBCRYPTO = "libcrypto.so.3"
 
-MACOS_LIBSSL = "libssl.dylib"
-MACOS_LIBCRYPTO = "libcrypto.dylib"
+MACOS_LIBSSL = "libssl.3.dylib"
+MACOS_LIBCRYPTO = "libcrypto.3.dylib"
 
 configure_make(
     name = "openssl",

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -44,8 +44,10 @@ DEFAULT_CONFIG = [
 WIN_LIBSSL = "libssl-3-x64.dll"
 WIN_LIBCRYPTO = "libcrypto-3-x64.dll"
 
-LINUX_LIBSSL = "libssl.so"
-LINUX_LIBCRYPTO = "libcrypto.so"
+# We want the filenames matching the library SONAMEs here such that we can run targets from the bazel tree
+# Hence the inclusion of the major version
+LINUX_LIBSSL = "libssl.so.3"
+LINUX_LIBCRYPTO = "libcrypto.so.3"
 
 MACOS_LIBSSL = "libssl.dylib"
 MACOS_LIBCRYPTO = "libcrypto.dylib"


### PR DESCRIPTION
### What does this PR do?

It creates a rule able to make rules_foreign_cc usable within build actions and with `bazel run`, and implements a "runnable Python" for Linux and macos based on it.

The new rule creates a copy of the original target, where files are rpath-patched as needed to find internal and external libraries.

### Motivation

[ABLD-260](https://datadoghq.atlassian.net/browse/ABLD-260)

To be used to, for example, install dependencies like in this WIP branch:
https://github.com/DataDog/datadog-agent/blob/e4d577d9de8d3f5a6424668a8a1fd724067d2310/deps/agent_integrations/defs.bzl#L15-L33

The main problem to solve is that rules_foreign_cc built artifacts don't set their rpaths to the solib farms that would let them find the libraries they need at runtime like rules_cc rules can do.

### Describe how you validated your changes

1. Locally, I can `bazel run` this Python without installing it, and I get correct runtime dynamic linking.

```
❯ bazel run @cpython//:python_unix_runnable -- -c "import ssl; print(ssl.OPENSSL_VERSION)"
INFO: Invocation ID: 4603600b-fec4-4a32-a22a-5eca981a04dc
INFO: Analyzed target @@+http_archive+cpython//:python_unix_runnable (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target @@+http_archive+cpython//:python_unix_runnable up-to-date:
  bazel-bin/external/+http_archive+cpython/python_unix_runnable
  bazel-bin/external/+http_archive+cpython/python_unix_runnable_bin
  bazel-bin/external/+http_archive+openssl/openssl/lib/libssl.3.dylib
  bazel-bin/external/+http_archive+openssl/openssl/lib/libcrypto.3.dylib
  bazel-bin/external/+http_archive+bzip2/libbz2.dylib
  bazel-bin/external/+http_archive+sqlite3/libsqlite3.dylib
  bazel-bin/external/+http_archive+xz/liblzma.dylib
  bazel-bin/external/+http_archive+zlib/libz.dylib
INFO: Elapsed time: 17.736s, Critical Path: 16.65s
INFO: 2 processes: 1 internal, 1 darwin-sandbox.
INFO: Build completed successfully, 2 total actions
INFO: Running command line: bazel-bin/external/+http_archive+cpython/python_unix_runnable_bin <args omitted>
OpenSSL 3.5.6 7 Apr 2026
```

2. The above example from the WIP branch works as intended – pip install runs correctly.

### Additional Notes

- Copying the entire output tree of the rules_foreign_cc target is the only practical way to achieve this as a wrapping rule. There might be ways to populate the rpath's within the rules_foreign_cc rules to avoid this, though probably not in a generic way.
- There's a chance that the initial use case that motivated this – running `pip install --no-deps` on prebuilt wheels or pure source – doesn't hold enough weight and might be solvable by pure unzipping in the example of wheels. I still think this is a worthwhile addition because:
  - It removes guesswork as we translate what we have on omnibus to Bazel by using as similar as possible commands to get there.
  - There might be other places where this could prove useful, like tests and `bazel run`-ning the Agent, and perhaps others.

[ABLD-260]: https://datadoghq.atlassian.net/browse/ABLD-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ