### PR TITLE
fix(cws): include last approver event type in stats reset loop

### DIFF
--- a/pkg/security/probe/monitors/approver/approver_monitor.go
+++ b/pkg/security/probe/monitors/approver/approver_monitor.go
@@ -126,7 +126,7 @@ func (d *Monitor) SendStats() error {
 			_ = d.statsdClient.Count(metrics.MetricEventApproved, int64(stats.EventApprovedByInUpperLayer), tagsForInUpperLayerApprovedEvents, 1.0)
 		}
 	}
-	for i := uint32(0); i != uint32(model.LastApproverEventType); i++ {
+	for i := uint32(0); i <= uint32(model.LastApproverEventType); i++ {
 		_ = buffer.Put(i, d.statsZero)
 	}
 


### PR DESCRIPTION
The approver monitor stats reset loop used `i != LastApproverEventType`,
which excluded the last key from being reset. Stats for that event type
accumulated across flushes instead of being interval-based, skewing
observability whenever a new event type was added at the end of the
approver event list.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
