### PR TITLE
Remove get_unreleased_release_branches invoke task (migrated to Temporal workflow)

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -6,7 +6,6 @@ Notes about Agent6:
     the task will be run in the agent6 branch.
 """
 
-import json
 import os
 import sys
 import tempfile

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -776,15 +776,6 @@ def get_active_release_branch(ctx, release_branch):
             print(get_default_branch())
 
 
-@task
-def get_unreleased_release_branches(_):
-    """
-    Determine what are the current active release branches for the Agent.
-    """
-    gh = GithubAPI()
-    print(json.dumps([branch.name for branch in gh.latest_unreleased_release_branches()]))
-
-
 def get_next_version(gh, latest_release=None):
     latest_release = latest_release or gh.latest_release()
     current_version = _create_version_from_match(VERSION_RE.search(latest_release))


### PR DESCRIPTION
### What does this PR do?

Removes the `get_unreleased_release_branches` invoke task from `tasks/release.py`.

### Motivation

This functionality has been migrated to the [Release Coordinator Temporal workflow](https://datadoghq.atlassian.net/wiki/spaces/BARX/pages/6425117374/Release+Coordinator+Automation+Guide). The Python invoke task is no longer needed.

### Describe how you validated your changes

Dead code removal — the function is never called, imported, or referenced anywhere in the `tasks/` tree.

### Additional Notes

