### PR TITLE
Fix agent crash when kubeactions enabled, rc disabled

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -583,18 +583,21 @@ func start(log log.Component,
 		}
 	}
 
-	// Kubernetes Actions
+	// Kubernetes Actions. Failures here must never be fatal — kubeactions is an
+	// optional feature and the cluster-agent must keep serving its other
+	// responsibilities even if remote-config is unavailable or setup fails.
 	var kubeactionsRetriever *kubeactions.ConfigRetriever
 	if config.GetBool("kubeactions.enabled") {
 		if rcClient == nil {
-			return errors.New("remote config is disabled or failed to initialize, remote config is a required dependency for kubeactions")
+			log.Errorf("[KubeActions] kubeactions.enabled is true but remote config is disabled or failed to initialize; kubeactions will not run")
+		} else {
+			log.Infof("[KubeActions] Starting with cluster_id=%s, cluster_name=%s", clusterID, clusterName)
+			if kubeactionsRetriever, err = kubeactions.Setup(mainCtx, apiCl.Cl, clusterName, clusterID, le.IsLeader, rcClient, epForwarder); err != nil {
+				log.Errorf("[KubeActions] Error while starting kubernetes actions, feature will be disabled: %v", err)
+			} else {
+				log.Info("Kubernetes actions subsystem started successfully")
+			}
 		}
-		log.Infof("[KubeActions] Starting with cluster_id=%s, cluster_name=%s", clusterID, clusterName)
-
-		if kubeactionsRetriever, err = kubeactions.Setup(mainCtx, apiCl.Cl, clusterName, clusterID, le.IsLeader, rcClient, epForwarder); err != nil {
-			return fmt.Errorf("Error while starting kubernetes actions: %v", err)
-		}
-		log.Info("Kubernetes actions subsystem started successfully")
 	}
 
 	// Compliance

--- a/releasenotes/notes/fix-kubernetes-actions-rc-disabled-3223fd8c8b9efd5c.yaml
+++ b/releasenotes/notes/fix-kubernetes-actions-rc-disabled-3223fd8c8b9efd5c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes codepath where kubernetes-actions is enabled, but remote-config is disabled - causing the cluster agent to crash.


### PR DESCRIPTION
### What does this PR do?
Fixes bug where agent would crash if the kubernetes-actions feature was enabled, but remote-config was disabled.

### Motivation
Agent crashing on staging fed cluster 

### Describe how you validated your changes

### Additional Notes
