### PR TITLE
Make openssl strings check more robust

### DIFF
--- a/deps/openssl/BUILD.bazel
+++ b/deps/openssl/BUILD.bazel
@@ -3,6 +3,10 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 sh_test(
     name = "check_no_sandbox_paths",
     srcs = ["check_no_sandbox_paths.sh"],
+    args = [
+        "$(rlocationpath @openssl//:libcrypto_shared_file)",
+        "$(rlocationpath @openssl//:libssl_shared_file)",
+    ],
     data = [
         "@openssl//:libcrypto_shared_file",
         "@openssl//:libssl_shared_file",

--- a/deps/openssl/check_no_sandbox_paths.sh
+++ b/deps/openssl/check_no_sandbox_paths.sh
@@ -7,19 +7,27 @@ set -euo pipefail
 
 FAILED=0
 
-while IFS= read -r lib; do
+libs=("$1" "$2")
+
+for lib_relpath in "${libs[@]}"; do
+    lib="$TEST_SRCDIR/$lib_relpath"
     echo "Checking $(basename "$lib")..."
+    if [[ ! -f "$lib" ]]; then
+        echo "FAIL: library not found: $lib" >&2
+        FAILED=1
+        continue
+    fi
     # Only flag strings that combine a Bazel sandbox indicator with an OpenSSL
     # runtime path suffix. This avoids false positives from the compiler
     # command line that OpenSSL embeds in the binary for `openssl version -a`.
-    if strings "$lib" | grep -qE "(bazel-out|execroot|build_tmpdir).*/?(ssl|lib/ossl-modules|lib/engines-[0-9]+)"; then
+    bad_paths=$(strings "$lib" | grep -E "(bazel-out|execroot|build_tmpdir).*/?(ssl|lib/ossl-modules|lib/engines-[0-9]+)" || true)
+    if [[ -n "$bad_paths" ]]; then
         echo "FAIL: Bazel sandbox path found in $lib:"
-        strings "$lib" | grep -E "(bazel-out|execroot|build_tmpdir).*/?(ssl|lib/ossl-modules|lib/engines-[0-9]+)"
+        echo "$bad_paths"
         FAILED=1
     else
         echo "OK: no sandbox paths in $(basename "$lib")"
     fi
-done < <(find "$TEST_SRCDIR" \( -name "libcrypto.so" -o -name "libssl.so" \
-                               -o -name "libcrypto.dylib" -o -name "libssl.dylib" \) 2>/dev/null)
+done
 
 exit $FAILED

--- a/deps/openssl/check_no_sandbox_paths.sh
+++ b/deps/openssl/check_no_sandbox_paths.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 FAILED=0
 
-libs=("$1" "$2")
+libs=("$@")
 
 for lib_relpath in "${libs[@]}"; do
     lib="$TEST_SRCDIR/$lib_relpath"


### PR DESCRIPTION
### What does this PR do?

It makes openssl string check more robust by passing the locations of the libraries to check directly instead of relying on hardcoded file names.

It also prevents duplicated checks (as extra symlinks were present on the TEST_SRCDIR).

### Motivation

Addresses this: https://github.com/DataDog/datadog-agent/pull/51221#discussion_r3288228793.

The existing test would fail silently without actually checking any files.

### Describe how you validated your changes

- Ensured the tests still fail when the sandbox strings are present (making local changes based around reverting https://github.com/DataDog/datadog-agent/pull/51166).
- Ensured the tests fail when if we mess up and the paths we pass to the test script are wrong.
- Tests pass when expected.

### Additional Notes
