### PR TITLE
TEST

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -71,7 +71,7 @@ common:windows --extra_toolchains=@rust_toolchains//:rw-2070622084
 # datadog-agent virtually isolates caching instance from its parent (which is remote-caching).
 # If entry isn't found in datadog-agent, it will be searched in remote-caching.
 common:cache --remote_cache=grpcs://buildbarn-frontend-datadog-agent.us1.ddbuild.io:443
-common:cache --remote_instance_name=ci/datadog-agent
+common:cache --remote_instance_name=ci/dd-source
 common:cache --remote_local_fallback # best-effort on transient connection errors (no such host)
 common:cache --incompatible_remote_local_fallback_for_remote_cache # works only if --remote_local_fallback is also set
 common:cache --remote_retries=1


### PR DESCRIPTION
## Summary

- Updates `.bazelrc` remote cache instance name from `ci/datadog-agent` to `ci/dd-source`

## Test plan

- [ ] Verify Bazel remote cache hits correctly with the new instance name

🤖 Generated with [Claude Code](https://claude.com/claude-code)