### PR TITLE
[anomalydetection] Fix events

### DIFF
--- a/comp/anomalydetection/reporter/impl/BUILD.bazel
+++ b/comp/anomalydetection/reporter/impl/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//comp/anomalydetection/observer/def",
         "//comp/anomalydetection/reporter/def",
         "//comp/core/config",
+        "//comp/core/hostname/hostnameinterface",
         "//comp/core/log/def",
         "//comp/forwarder/eventplatform",
         "//pkg/logs/message",

--- a/comp/anomalydetection/reporter/impl/notify.go
+++ b/comp/anomalydetection/reporter/impl/notify.go
@@ -49,14 +49,10 @@ const (
 	// changedResourceNameMaxLen caps the changed_resource.name length.
 	changedResourceNameMaxLen = 128
 
-	// changeEventIntegrationID identifies the publishing integration. The
-	// `edge-intelligence` integration is registered upstream in
-	// integrations-internal-core#3240 (source_type_id 78252213) and the
-	// event-management intake derives source_type from this value. We also
-	// emit changeEventSourceTypeID explicitly so the intake can validate the
-	// pairing without a registry lookup.
+	// changeEventIntegrationID identifies the publishing integration.
+	// source_type_id is intentionally omitted: the intake rejects it as a
+	// custom property and derives source_type from integration_id instead.
 	changeEventIntegrationID = "edge-intelligence"
-	changeEventSourceTypeID  = 78252213
 
 	// changedResourceType is the resource classification carried in
 	// data.attributes.attributes.changed_resource.type.
@@ -180,7 +176,6 @@ func buildChangeEventPayload(c observerdef.ActiveCorrelation, msg, ts, aggKey, h
 		"message":         msg,
 		"category":        "change",
 		"integration_id":  changeEventIntegrationID,
-		"source_type_id":  changeEventSourceTypeID,
 		"tags":            BuildEventTags(c),
 		"timestamp":       ts,
 		"aggregation_key": aggKey,

--- a/comp/anomalydetection/reporter/impl/notify.go
+++ b/comp/anomalydetection/reporter/impl/notify.go
@@ -52,7 +52,9 @@ const (
 	// changeEventIntegrationID identifies the publishing integration. The
 	// `edge-intelligence` integration is registered upstream in
 	// integrations-internal-core#3240 (source_type_id 78252213) and the
-	// event-management intake derives source_type from this value.
+	// event-management intake derives source_type from this value. We also
+	// emit changeEventSourceTypeID explicitly so the intake can validate the
+	// pairing without a registry lookup.
 	changeEventIntegrationID = "edge-intelligence"
 	changeEventSourceTypeID  = 78252213
 

--- a/comp/anomalydetection/reporter/impl/notify.go
+++ b/comp/anomalydetection/reporter/impl/notify.go
@@ -6,6 +6,7 @@
 package reporterimpl
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	hostname "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -79,12 +81,13 @@ type eventSender struct {
 	forwarder eventplatform.Forwarder
 	logger    log.Component
 	storage   observerdef.StorageReader
+	hostname  hostname.Component
 }
 
 // newEventSender creates an eventSender backed by the given forwarder.
 // storage is used to compute windowed log rates for display in event messages;
 // it may be nil and will be set later via EventReporter.SetStorage.
-func newEventSender(forwarder eventplatform.Forwarder, logger log.Component, storage observerdef.StorageReader) (*eventSender, error) {
+func newEventSender(forwarder eventplatform.Forwarder, logger log.Component, storage observerdef.StorageReader, hn hostname.Component) (*eventSender, error) {
 	if forwarder == nil {
 		return nil, errors.New("event-platform forwarder is not available")
 	}
@@ -92,6 +95,7 @@ func newEventSender(forwarder eventplatform.Forwarder, logger log.Component, sto
 		forwarder: forwarder,
 		logger:    logger,
 		storage:   storage,
+		hostname:  hn,
 	}, nil
 }
 
@@ -147,9 +151,14 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 	ts := time.Unix(c.FirstSeen, 0).UTC().Format(time.RFC3339)
 	aggKey := "observer:" + c.Pattern
 
+	var host string
+	if s.hostname != nil {
+		host = s.hostname.GetSafe(context.TODO())
+	}
+
 	s.logger.Infof("[observer] sending change event: pattern=%s title=%q aggKey=%s timestamp=%s\n%s\n", c.Pattern, c.Title, aggKey, ts, msg)
 
-	payload := buildChangeEventPayload(c, msg, ts, aggKey)
+	payload := buildChangeEventPayload(c, msg, ts, aggKey, host)
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal change-event payload: %w", err)
@@ -165,21 +174,25 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 // category, integration_id, source_type_id, tags, timestamp, aggregation_key,
 // attributes}). integration_id pins the publisher to the `edge-intelligence`
 // integration so the event-management intake can route and authorize the event.
-func buildChangeEventPayload(c observerdef.ActiveCorrelation, msg, ts, aggKey string) map[string]any {
+func buildChangeEventPayload(c observerdef.ActiveCorrelation, msg, ts, aggKey, host string) map[string]any {
+	attrs := map[string]any{
+		"title":           c.Title,
+		"message":         msg,
+		"category":        "change",
+		"integration_id":  changeEventIntegrationID,
+		"source_type_id":  changeEventSourceTypeID,
+		"tags":            BuildEventTags(c),
+		"timestamp":       ts,
+		"aggregation_key": aggKey,
+		"attributes":      buildChangeAttributes(c),
+	}
+	if host != "" {
+		attrs["host"] = host
+	}
 	return map[string]any{
 		"data": map[string]any{
-			"type": "event",
-			"attributes": map[string]any{
-				"title":           c.Title,
-				"message":         msg,
-				"category":        "change",
-				"integration_id":  changeEventIntegrationID,
-				"source_type_id":  changeEventSourceTypeID,
-				"tags":            BuildEventTags(c),
-				"timestamp":       ts,
-				"aggregation_key": aggKey,
-				"attributes":      buildChangeAttributes(c),
-			},
+			"type":       "event",
+			"attributes": attrs,
 		},
 	}
 }

--- a/comp/anomalydetection/reporter/impl/notify.go
+++ b/comp/anomalydetection/reporter/impl/notify.go
@@ -49,10 +49,12 @@ const (
 	// changedResourceNameMaxLen caps the changed_resource.name length.
 	changedResourceNameMaxLen = 128
 
-	// changeEventIntegrationID identifies the publishing integration.
-	// source_type_id is intentionally omitted: the intake rejects it as a
-	// custom property and derives source_type from integration_id instead.
+	// changeEventIntegrationID identifies the publishing integration. The
+	// `edge-intelligence` integration is registered upstream in
+	// integrations-internal-core#3240 (source_type_id 78252213) and the
+	// event-management intake derives source_type from this value.
 	changeEventIntegrationID = "edge-intelligence"
+	changeEventSourceTypeID  = 78252213
 
 	// changedResourceType is the resource classification carried in
 	// data.attributes.attributes.changed_resource.type.
@@ -176,6 +178,7 @@ func buildChangeEventPayload(c observerdef.ActiveCorrelation, msg, ts, aggKey, h
 		"message":         msg,
 		"category":        "change",
 		"integration_id":  changeEventIntegrationID,
+		"source_type_id":  changeEventSourceTypeID,
 		"tags":            BuildEventTags(c),
 		"timestamp":       ts,
 		"aggregation_key": aggKey,

--- a/comp/anomalydetection/reporter/impl/payload_test.go
+++ b/comp/anomalydetection/reporter/impl/payload_test.go
@@ -63,10 +63,8 @@ func TestBuildChangeEventPayload_WireShape(t *testing.T) {
 	// host is required by the event-management intake (mirrors notableevents and logonduration).
 	assert.Equal(t, "my-test-host", attrs["host"])
 
-	// edge-intelligence routing: must be present and locked to the registered
-	// values from integrations-internal-core#3240.
 	assert.Equal(t, "edge-intelligence", attrs["integration_id"])
-	assert.EqualValues(t, 78252213, attrs["source_type_id"])
+	assert.NotContains(t, attrs, "source_type_id", "source_type_id is rejected by the intake")
 
 	tags, ok := attrs["tags"].([]any)
 	assert.True(t, ok, "tags must be a JSON array")

--- a/comp/anomalydetection/reporter/impl/payload_test.go
+++ b/comp/anomalydetection/reporter/impl/payload_test.go
@@ -39,7 +39,7 @@ func TestBuildChangeEventPayload_WireShape(t *testing.T) {
 		},
 	}
 
-	payload := buildChangeEventPayload(c, "hello", "2024-01-01T00:00:00Z", "observer:kernel_bottleneck")
+	payload := buildChangeEventPayload(c, "hello", "2024-01-01T00:00:00Z", "observer:kernel_bottleneck", "my-test-host")
 
 	// Round-trip through JSON so we exercise the same marshalling path as send().
 	blob, err := json.Marshal(payload)
@@ -59,6 +59,9 @@ func TestBuildChangeEventPayload_WireShape(t *testing.T) {
 	assert.Equal(t, "change", attrs["category"])
 	assert.Equal(t, "2024-01-01T00:00:00Z", attrs["timestamp"])
 	assert.Equal(t, "observer:kernel_bottleneck", attrs["aggregation_key"])
+
+	// host is required by the event-management intake (mirrors notableevents and logonduration).
+	assert.Equal(t, "my-test-host", attrs["host"])
 
 	// edge-intelligence routing: must be present and locked to the registered
 	// values from integrations-internal-core#3240.
@@ -110,13 +113,13 @@ func TestBuildChangeEventPayload_TruncatesChangedResourceName(t *testing.T) {
 	}
 	c := observerdef.ActiveCorrelation{Pattern: string(long), Title: "t"}
 
-	payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k")
+	payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k", "")
 
 	inner := payload["data"].(map[string]any)["attributes"].(map[string]any)["attributes"].(map[string]any)
 	changed := inner["changed_resource"].(map[string]any)
 	name := changed["name"].(string)
 	assert.Equal(t, changedResourceNameMaxLen, utf8.RuneCountInString(name), "truncated name should be exactly maxChars runes long")
-	assert.True(t, strings.HasSuffix(name, "\u2026"), "truncated name should end with an ellipsis")
+	assert.True(t, strings.HasSuffix(name, "…"), "truncated name should end with an ellipsis")
 }
 
 // TestBuildChangeEventPayload_TruncatesAtRuneBoundary checks that a pattern
@@ -131,13 +134,13 @@ func TestBuildChangeEventPayload_TruncatesAtRuneBoundary(t *testing.T) {
 	}
 	c := observerdef.ActiveCorrelation{Pattern: b.String(), Title: "t"}
 
-	payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k")
+	payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k", "")
 
 	inner := payload["data"].(map[string]any)["attributes"].(map[string]any)["attributes"].(map[string]any)
 	name := inner["changed_resource"].(map[string]any)["name"].(string)
 	assert.True(t, utf8.ValidString(name), "truncated name must remain valid UTF-8")
 	assert.Equal(t, changedResourceNameMaxLen, utf8.RuneCountInString(name), "truncated name should be exactly maxChars runes long")
-	assert.True(t, strings.HasSuffix(name, "\u2026"), "truncated name should end with an ellipsis")
+	assert.True(t, strings.HasSuffix(name, "…"), "truncated name should end with an ellipsis")
 }
 
 // TestBuildChangeEventPayload_AnomalyInventoryAlwaysPresent asserts that both
@@ -167,7 +170,7 @@ func TestBuildChangeEventPayload_AnomalyInventoryAlwaysPresent(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k")
+			payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k", "")
 			inner := payload["data"].(map[string]any)["attributes"].(map[string]any)["attributes"].(map[string]any)
 			meta := inner["change_metadata"].(map[string]any)
 			assert.Contains(t, meta, "metric_anomalies", "metric_anomalies must be present")
@@ -191,11 +194,24 @@ func TestBuildChangeEventPayload_AnomalyInventoryAlwaysPresent(t *testing.T) {
 func TestBuildChangeEventPayload_NoImpactedResourcesWhenEmpty(t *testing.T) {
 	c := observerdef.ActiveCorrelation{Pattern: "p", Title: "t"}
 
-	payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k")
+	payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k", "")
 
 	inner := payload["data"].(map[string]any)["attributes"].(map[string]any)["attributes"].(map[string]any)
 	_, present := inner["impacted_resources"]
 	assert.False(t, present, "impacted_resources should be omitted when no services are impacted")
+}
+
+// TestBuildChangeEventPayload_HostOmittedWhenEmpty verifies that when no host
+// is available (empty string), the field is not present in the payload so the
+// intake does not receive a blank host value.
+func TestBuildChangeEventPayload_HostOmittedWhenEmpty(t *testing.T) {
+	c := observerdef.ActiveCorrelation{Pattern: "p", Title: "t"}
+
+	payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k", "")
+
+	attrs := payload["data"].(map[string]any)["attributes"].(map[string]any)
+	_, present := attrs["host"]
+	assert.False(t, present, "host should be omitted when empty")
 }
 
 // --- classifyCorrelationSubCategory ---

--- a/comp/anomalydetection/reporter/impl/payload_test.go
+++ b/comp/anomalydetection/reporter/impl/payload_test.go
@@ -63,8 +63,10 @@ func TestBuildChangeEventPayload_WireShape(t *testing.T) {
 	// host is required by the event-management intake (mirrors notableevents and logonduration).
 	assert.Equal(t, "my-test-host", attrs["host"])
 
+	// edge-intelligence routing: must be present and locked to the registered
+	// values from integrations-internal-core#3240.
 	assert.Equal(t, "edge-intelligence", attrs["integration_id"])
-	assert.NotContains(t, attrs, "source_type_id", "source_type_id is rejected by the intake")
+	assert.EqualValues(t, 78252213, attrs["source_type_id"])
 
 	tags, ok := attrs["tags"].([]any)
 	assert.True(t, ok, "tags must be a JSON array")

--- a/comp/anomalydetection/reporter/impl/reporter.go
+++ b/comp/anomalydetection/reporter/impl/reporter.go
@@ -15,6 +15,7 @@ import (
 
 	reporterdef "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
 	config "github.com/DataDog/datadog-agent/comp/core/config"
+	hostname "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 )
@@ -24,6 +25,7 @@ type Requires struct {
 	Config        config.Component
 	Log           log.Component
 	EventPlatform eventplatform.Component
+	Hostname      hostname.Component
 }
 
 // Provides defines the output of the live reporter component.
@@ -45,7 +47,7 @@ func NewComponent(req Requires) (Provides, error) {
 		if !ok {
 			req.Log.Warnf("[reporter] event_reporter disabled: event-platform forwarder is not running")
 		} else {
-			sender, err := newEventSender(forwarder, req.Log, nil)
+			sender, err := newEventSender(forwarder, req.Log, nil, req.Hostname)
 			if err != nil {
 				req.Log.Warnf("[reporter] event_reporter disabled: %v", err)
 			} else {


### PR DESCRIPTION
### What does this PR do?

Fixes issues that prevent us from sending events.

Missing `host` field in `data.attributes` — required by the intake, present in all other senders (`notableevents`, `logonduration`). Threads `hostnameinterface.Component` through `Requires → newEventSender → buildChangeEventPayload`, mirroring those senders.

### Motivation

### Describe how you validated your changes

### Additional Notes