### PR TITLE
packaging/aix: keep embedded/include for C extension installs

### DIFF
--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -10,6 +10,8 @@
 
 <!-- Add entries here for changes not yet in a release. -->
 
+- Keep Python headers (`embedded/include/`) in the package so users can build C extension packages (e.g. `ibm_db` for the DB2 check) against the embedded Python, matching Linux/macOS omnibus behaviour
+
 - Include missing Go check configurations in the package: `cisco_sdwan`, `snmp`, `cloud_hostinfo`, `discovery`, `telemetry`, `versa` — these checks are compiled into the agent binary but their config files were missing from `AIX_CORECHECKS`
 - Fix SQLite build: link with `-lm` when `SQLITE_ENABLE_MATH_FUNCTIONS` is enabled
 - Include `final_constraints-py3.txt` in the BFF package at `/opt/datadog-agent/final_constraints-py3.txt`

--- a/packaging/aix/stages/09-strip-bytecode.sh
+++ b/packaging/aix/stages/09-strip-bytecode.sh
@@ -44,14 +44,18 @@ log "Strip pass complete"
 
 # ─── Step 2: Remove build artefacts not needed at runtime ─────────────────────
 #
-# Headers, pkg-config metadata, and man pages are only needed during compilation.
+# pkg-config metadata and man pages are only needed during compilation.
 # Source files (.c/.h) inside the Python stdlib tree are not needed at runtime.
+# Note: embedded/include (Python.h etc.) is intentionally kept so users can
+# build C extension packages (e.g. ibm_db) against the embedded Python.
 # __pycache__ directories may contain stale .pyc files from an earlier compileall
 # run or a pip install; delete them before the fresh compileall in Step 4 so
 # there are no stale bytecode files with incorrect magic numbers.
 
-log "Removing build-time artefacts (headers, pkgconfig, man pages, .c/.h files)"
-rm -rf "$EMBEDDED_DESTDIR/include"
+log "Removing build-time artefacts (pkgconfig, man pages, .c/.h files)"
+# Keep embedded/include (Python headers) — users need Python.h to build C
+# extensions such as ibm_db. Linux/macOS omnibus packages also ship these
+# headers; we match that behaviour here.
 rm -rf "$EMBEDDED_DESTDIR/lib/pkgconfig"
 rm -rf "$EMBEDDED_DESTDIR/share/man"
 find "$EMBEDDED_DESTDIR/lib/python${PYTHON_MAJ_MIN}" -name "*.c" -exec rm -f {} \;


### PR DESCRIPTION
### What does this PR do?
Removes `rm -rf "$EMBEDDED_DESTDIR/include"` from stage 09, keeping Python headers (`Python.h` etc.) in the package.

### Motivation
Stage 09 was stripping the entire `embedded/include` directory, preventing users from building C extension packages like `ibm_db` (required by the IBM DB2 integration) against the embedded Python. Linux/macOS omnibus packages keep `embedded/include` and only remove specific subdirectories (e.g. `dbus-1.0`). This matches that behaviour.

Confirmed by testing `pip install ibm_db` on AIX 7.3: pip works correctly after the shebang fix, `ibm_db` correctly auto-downloads the AIX64 ODBC driver, but fails with "No Python.h header file detected" — fixed by this PR.

### Describe how you validated your changes
Code inspection against omnibus finalize step (`datadog-agent-finalize.rb`), which only removes `embedded/include/dbus-1.0`, not `embedded/include` wholesale.

### Additional Notes
N/A