### PR TITLE
fix(logs): carry last aggregated line's timestamp through auto-multiline (AGENT-16207)

### DIFF
--- a/pkg/logs/internal/decoder/line_handler_test.go
+++ b/pkg/logs/internal/decoder/line_handler_test.go
@@ -36,6 +36,12 @@ func getDummyMessageWithLF(content string) *message.Message {
 	return m
 }
 
+func getDummyMessageWithTimestamp(content, timestamp string) *message.Message {
+	m := getDummyMessageWithLF(content)
+	m.ParsingExtra.Timestamp = timestamp
+	return m
+}
+
 func lineHandlerChans() (func(*message.Message), chan *message.Message) {
 	ch := make(chan *message.Message, 20)
 	return func(m *message.Message) { ch <- m }, ch
@@ -186,6 +192,43 @@ func TestMultiLineHandler(t *testing.T) {
 	output = <-outputChan
 	assert.Equal(t, "6. next line", string(output.GetContent()))
 	assert.Equal(t, len(shortLineTracingSpaces)+1, output.RawDataLen)
+}
+
+// TestMultiLineHandlerCarriesLastLineTimestamp confirms that the regex-driven
+// MultiLineHandler emits combined messages stamped with the LAST aggregated
+// line's ParsingExtra.Timestamp. This is the existing (correct) behavior and
+// is asserted here as a counterpart to TestAggregateCarriesLastLineTimestamp
+// in the auto-multiline aggregator — both paths must agree, otherwise the
+// Docker socket tailer's lastSince offset gets stuck on the first line of a
+// group and replays the rest on every reader restart. See AGENT-16207.
+func TestMultiLineHandlerCarriesLastLineTimestamp(t *testing.T) {
+	const (
+		ts1 = "2026-05-11T10:00:00.000000001Z"
+		ts2 = "2026-05-11T10:00:00.000000002Z"
+		ts3 = "2026-05-11T10:00:00.000000003Z"
+		ts4 = "2026-05-11T10:00:00.000000004Z"
+	)
+
+	re := regexp.MustCompile(`^[0-9]+\.`)
+	outputFn, outputChan := lineHandlerChans()
+	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false, status.NewInfoRegistry(), "")
+
+	h.process(getDummyMessageWithTimestamp("1. first", ts1))
+	h.process(getDummyMessageWithTimestamp("continuation", ts2))
+	h.process(getDummyMessageWithTimestamp("more", ts3))
+	// A new start-of-group flushes the buffered group [L1, L2, L3].
+	h.process(getDummyMessageWithTimestamp("2. second", ts4))
+
+	output := <-outputChan
+	assert.Equal(t, "1. first\\ncontinuation\\nmore", string(output.GetContent()))
+	assert.Equal(t, ts3, output.ParsingExtra.Timestamp,
+		"regex multiline must emit the LAST aggregated line's timestamp so the tailer offset advances past every combined line")
+
+	// Flush the buffered "2. second" — single-line groups keep their own timestamp.
+	h.flush()
+	output = <-outputChan
+	assert.Equal(t, "2. second", string(output.GetContent()))
+	assert.Equal(t, ts4, output.ParsingExtra.Timestamp)
 }
 
 func TestTrimMultiLine(t *testing.T) {

--- a/pkg/logs/internal/decoder/line_handler_test.go
+++ b/pkg/logs/internal/decoder/line_handler_test.go
@@ -200,7 +200,7 @@ func TestMultiLineHandler(t *testing.T) {
 // is asserted here as a counterpart to TestAggregateCarriesLastLineTimestamp
 // in the auto-multiline aggregator — both paths must agree, otherwise the
 // Docker socket tailer's lastSince offset gets stuck on the first line of a
-// group and replays the rest on every reader restart. See AGENT-16207.
+// group and replays the rest on every reader restart.
 func TestMultiLineHandlerCarriesLastLineTimestamp(t *testing.T) {
 	const (
 		ts1 = "2026-05-11T10:00:00.000000001Z"

--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -25,6 +25,12 @@ func newMessage(content string) *message.Message {
 	return m
 }
 
+func newMessageWithTimestamp(content, timestamp string) *message.Message {
+	m := newMessage(content)
+	m.ParsingExtra.Timestamp = timestamp
+	return m
+}
+
 func assertMessageContent(t *testing.T, m *message.Message, content string) {
 	t.Helper()
 	isMultiLine := len(strings.Split(content, "\\n")) > 1
@@ -122,6 +128,52 @@ func TestAggregateDoesntStartGroup(t *testing.T) {
 	msgs = processMsg(ag, newMessage("3"), aggregate)
 	require.Len(t, msgs, 1)
 	assertMessageContent(t, msgs[0], "3")
+}
+
+// TestAggregateCarriesLastLineTimestamp guards against AGENT-16207: when the
+// auto-multiline aggregator emits a combined message, its
+// ParsingExtra.Timestamp must equal the LAST aggregated line's timestamp.
+// The Docker socket tailer uses this field as the lastSince offset; if it
+// holds the first line's timestamp instead, any reader restart causes
+// Docker to replay lines 2..N as duplicates.
+func TestAggregateCarriesLastLineTimestamp(t *testing.T) {
+	const (
+		ts1 = "2026-05-11T10:00:00.000000001Z"
+		ts2 = "2026-05-11T10:00:00.000000002Z"
+		ts3 = "2026-05-11T10:00:00.000000003Z"
+		ts4 = "2026-05-11T10:00:00.000000004Z"
+	)
+
+	ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
+
+	require.Empty(t, processMsg(ag, newMessageWithTimestamp("1", ts1), startGroup))
+	require.Empty(t, processMsg(ag, newMessageWithTimestamp("2", ts2), aggregate))
+	require.Empty(t, processMsg(ag, newMessageWithTimestamp("3", ts3), aggregate))
+
+	// A new startGroup flushes the previous bucket [L1, L2, L3].
+	msgs := processMsg(ag, newMessageWithTimestamp("4", ts4), startGroup)
+	require.Len(t, msgs, 1)
+	assertMessageContent(t, msgs[0], "1\\n2\\n3")
+	assert.Equal(t, ts3, msgs[0].ParsingExtra.Timestamp,
+		"aggregated message must carry the LAST line's parser timestamp so the tailer offset advances past every combined line")
+
+	// The pending single-line "4" carries its own timestamp.
+	msgs = flushMsgs(ag)
+	require.Len(t, msgs, 1)
+	assertMessageContent(t, msgs[0], "4")
+	assert.Equal(t, ts4, msgs[0].ParsingExtra.Timestamp)
+}
+
+// TestSingleLineKeepsOwnTimestamp confirms the fix is a no-op for single-line
+// flushes (the carry-forward only runs when len(b.lines) > 1).
+func TestSingleLineKeepsOwnTimestamp(t *testing.T) {
+	const ts1 = "2026-05-11T10:00:00.000000001Z"
+
+	ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
+
+	msgs := processMsg(ag, newMessageWithTimestamp("solo", ts1), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, ts1, msgs[0].ParsingExtra.Timestamp)
 }
 
 func TestForceFlush(t *testing.T) {

--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -130,12 +130,11 @@ func TestAggregateDoesntStartGroup(t *testing.T) {
 	assertMessageContent(t, msgs[0], "3")
 }
 
-// TestAggregateCarriesLastLineTimestamp guards against AGENT-16207: when the
-// auto-multiline aggregator emits a combined message, its
-// ParsingExtra.Timestamp must equal the LAST aggregated line's timestamp.
-// The Docker socket tailer uses this field as the lastSince offset; if it
-// holds the first line's timestamp instead, any reader restart causes
-// Docker to replay lines 2..N as duplicates.
+// TestAggregateCarriesLastLineTimestamp asserts that when the auto-multiline
+// aggregator emits a combined message, its ParsingExtra.Timestamp equals the
+// LAST aggregated line's timestamp. The Docker socket tailer uses this field
+// as the lastSince offset; if it held the first line's timestamp instead,
+// any reader restart would cause Docker to replay lines 2..N as duplicates.
 func TestAggregateCarriesLastLineTimestamp(t *testing.T) {
 	const (
 		ts1 = "2026-05-11T10:00:00.000000001Z"

--- a/pkg/logs/internal/decoder/preprocessor/combining_aggregator.go
+++ b/pkg/logs/internal/decoder/preprocessor/combining_aggregator.go
@@ -95,6 +95,12 @@ func (b *bucket) flush() AggregatedMessageWithTokens {
 	truncatedReason := "single_line"
 	if lineCount > 1 {
 		truncatedReason = "auto_multiline"
+		// Carry the LAST line's parser timestamp so downstream offset trackers
+		// (the Docker socket tailer's lastSince, in particular) advance past every
+		// line that was combined. Without this, a reader restart resumes from the
+		// first line's timestamp and Docker replays lines 2..N of the group as
+		// duplicates. See AGENT-16207.
+		msg.ParsingExtra.Timestamp = b.lines[lineCount-1].Msg.ParsingExtra.Timestamp
 	}
 
 	// Process flushes multiline buckets before an additional aggregate line can push the

--- a/pkg/logs/internal/decoder/preprocessor/combining_aggregator.go
+++ b/pkg/logs/internal/decoder/preprocessor/combining_aggregator.go
@@ -99,7 +99,7 @@ func (b *bucket) flush() AggregatedMessageWithTokens {
 		// (the Docker socket tailer's lastSince, in particular) advance past every
 		// line that was combined. Without this, a reader restart resumes from the
 		// first line's timestamp and Docker replays lines 2..N of the group as
-		// duplicates. See AGENT-16207.
+		// duplicates.
 		msg.ParsingExtra.Timestamp = b.lines[lineCount-1].Msg.ParsingExtra.Timestamp
 	}
 

--- a/pkg/logs/tailers/container/tailer_test.go
+++ b/pkg/logs/tailers/container/tailer_test.go
@@ -115,13 +115,13 @@ func TestGetLastSince(t *testing.T) {
 	assert.Equal(t, _time.Add(time.Nanosecond), tailer.getLastSince())
 }
 
-// TestBuildMessageAdvancesLastSince guards the auditor-side half of the
-// AGENT-16207 fix: the docker tailer commits whatever ParsingExtra.Timestamp
-// sits on the emitted message. Combined with the aggregator change that
-// carries the LAST aggregated line's timestamp on combined messages, this
-// guarantees the lastSince offset advances past every line of a multi-line
-// group, so a reader restart resumes after the group instead of replaying
-// lines 2..N as duplicates.
+// TestBuildMessageAdvancesLastSince covers the auditor-side half of
+// multi-line offset tracking: the docker tailer commits whatever
+// ParsingExtra.Timestamp sits on the emitted message. Combined with the
+// aggregator carrying the LAST aggregated line's timestamp on combined
+// messages, this guarantees the lastSince offset advances past every line
+// of a multi-line group, so a reader restart resumes after the group
+// instead of replaying lines 2..N as duplicates.
 func TestBuildMessageAdvancesLastSince(t *testing.T) {
 	const aggregatedTimestamp = "2026-05-11T10:00:00.000000003Z"
 

--- a/pkg/logs/tailers/container/tailer_test.go
+++ b/pkg/logs/tailers/container/tailer_test.go
@@ -115,6 +115,43 @@ func TestGetLastSince(t *testing.T) {
 	assert.Equal(t, _time.Add(time.Nanosecond), tailer.getLastSince())
 }
 
+// TestBuildMessageAdvancesLastSince guards the auditor-side half of the
+// AGENT-16207 fix: the docker tailer commits whatever ParsingExtra.Timestamp
+// sits on the emitted message. Combined with the aggregator change that
+// carries the LAST aggregated line's timestamp on combined messages, this
+// guarantees the lastSince offset advances past every line of a multi-line
+// group, so a reader restart resumes after the group instead of replaying
+// lines 2..N as duplicates.
+func TestBuildMessageAdvancesLastSince(t *testing.T) {
+	const aggregatedTimestamp = "2026-05-11T10:00:00.000000003Z"
+
+	source := sources.NewLogSource("foo", nil)
+	tailer := &Tailer{
+		ContainerID: "test",
+		Source:      source,
+		tagProvider: tag.NewLocalProvider(nil),
+	}
+
+	output := message.NewMessageWithParsingExtra(
+		[]byte("line1\\nline2\\nline3"),
+		message.NewOrigin(source),
+		message.StatusInfo,
+		0,
+		message.ParsingExtra{Timestamp: aggregatedTimestamp},
+	)
+
+	built := buildMessage(tailer, output)
+
+	assert.Equal(t, aggregatedTimestamp, tailer.lastSince,
+		"buildMessage must commit the emitted message's ParsingExtra.Timestamp to lastSince so the next reader restart resumes past the multi-line group")
+	assert.Equal(t, aggregatedTimestamp, built.Origin.Offset)
+
+	// Verify the +1ns resume offset is anchored on the LAST line's timestamp.
+	expected, err := time.Parse(config.DateFormat, aggregatedTimestamp)
+	assert.NoError(t, err)
+	assert.Equal(t, expected.Add(time.Nanosecond), tailer.getLastSince())
+}
+
 func TestRead(t *testing.T) {
 	tailer := NewTestTailer(&mockReaderNoSleep{}, nil, func() {})
 	inBuf := make([]byte, 4096)

--- a/releasenotes/notes/fix-auto-multiline-docker-duplicate-logs-16bf166a67adc698.yaml
+++ b/releasenotes/notes/fix-auto-multiline-docker-duplicate-logs-16bf166a67adc698.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Logs: Fix duplicate logs from containers tailed via the Docker socket
+    when ``logs_config.auto_multi_line_detection`` is enabled. The
+    auto-multiline aggregator emitted combined messages stamped with the
+    first aggregated line's timestamp, which the Docker tailer committed
+    as its resume offset; any reader restart then replayed lines 2..N of
+    the group as duplicate, un-aggregated entries. The aggregator now
+    carries the last aggregated line's timestamp through to the emitted
+    message so the offset advances past the full group. Container logs
+    tailed via files and the regex-driven ``log_processing_rules``
+    multi-line path were unaffected.


### PR DESCRIPTION
## Summary

The auto-multiline aggregator (`combiningAggregator.bucket.flush`) built combined messages on top of `b.lines[0].Msg`, so the emitted message kept the **first** aggregated line's `ParsingExtra.Timestamp`. The Docker socket tailer commits that field as `lastSince` ([container/tailer.go:393](https://github.com/DataDog/datadog-agent/blob/main/pkg/logs/tailers/container/tailer.go#L393)) and resumes Docker log streaming from `lastSince + 1ns` on any reader restart (EOF, read timeout, container restart, daemon reload — routine for idle or bursty containers).

The effect: lines 2..N of every aggregated group are replayed on each reconnect, arriving as duplicate, un-aggregated entries. Matches the customer's report exactly: *"correctly aggregated multiline log will come in, followed by a duplicate, incorrectly parsed log, split over multiple logs"*.

The regex `MultiLineHandler` was already correct — it overwrites `h.msg` on every continuation line, so `sendBuffer` emits the last one's message. Reflecting the customer's observation that *"this works fine with regular multiline rules"*.

## Fix

In `bucket.flush()`, when `lineCount > 1`, set the emitted message's `ParsingExtra.Timestamp` to the last aggregated line's value.

## Tests

- `preprocessor.TestAggregateCarriesLastLineTimestamp` — regression for the fix.
- `preprocessor.TestSingleLineKeepsOwnTimestamp` — no-op single-line path.
- `decoder.TestMultiLineHandlerCarriesLastLineTimestamp` — pins regex multi-line's already-correct behavior so the two codepaths stay in lockstep.
- `container.TestBuildMessageAdvancesLastSince` — auditor side: `lastSince` is set from the emitted message's `ParsingExtra.Timestamp`.

## Reported

[AGENT-16207](https://datadoghq.atlassian.net/browse/AGENT-16207) — Jenkins container, host agent 7.77.1, `container_collect_all: true`, `auto_multi_line_detection: true`, Docker file tailer unavailable so falling back to socket.

## Test plan

- [ ] CI passes on the touched packages.
- [ ] Manual repro on a Docker container with `auto_multi_line_detection: true` and socket tailing (e.g. revoke read on `/var/lib/docker/containers/*-json.log`); confirm duplicates stop on reader restart.

[AGENT-16207]: https://datadoghq.atlassian.net/browse/AGENT-16207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ