### PR TITLE
feat(gpum): add memory utilization metric

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -355,9 +355,15 @@ func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 				if err != nil {
 					return nil, 0, err
 				}
+				// Prevent division by zero if the total is zero.
+				memoryUtilization := 0.0
+				if memInfo.Total > 0 {
+					memoryUtilization = float64(memInfo.Used) / float64(memInfo.Total)
+				}
 				return []Metric{
 					{Name: "memory.free", Value: float64(memInfo.Free), Priority: Medium, Type: metrics.GaugeType},
 					{Name: "memory.reserved", Value: float64(memInfo.Reserved), Type: metrics.GaugeType},
+					{Name: "memory.utilization", Value: memoryUtilization, Type: metrics.GaugeType},
 				}, 0, nil
 			},
 		},

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -227,7 +227,8 @@ metrics:
   clock.throttle_reasons.sync_boost:
     metadata:
       metric_type: gauge
-      description: GPU clocks that are throttled to match clock speed of another GPU
+      description:
+        GPU clocks that are throttled to match clock speed of another GPU
         in the current sync boost group
       aggregation: sensor_data
     tagsets:
@@ -490,7 +491,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the time that the 16-bit floating point calculation
+      description:
+        Percentage of the time that the 16-bit floating point calculation
         engine was active. Only for Hopper and newer GPUs
       aggregation: relative_activity
     tagsets:
@@ -513,7 +515,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the time that the 32-bit floating point calculation
+      description:
+        Percentage of the time that the 32-bit floating point calculation
         engine was active. Only for Hopper and newer GPUs
       aggregation: relative_activity
     tagsets:
@@ -536,7 +539,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the time that the 64-bit floating point calculation
+      description:
+        Percentage of the time that the 64-bit floating point calculation
         engine was active. Only for Hopper and newer GPUs
       aggregation: relative_activity
     tagsets:
@@ -575,7 +579,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the time that the integer calculation engine was
+      description:
+        Percentage of the time that the integer calculation engine was
         active. Only for Hopper and newer GPUs
       aggregation: relative_activity
     tagsets:
@@ -694,6 +699,23 @@ metrics:
         mig: true
         physical: true
         vgpu: true
+  memory.utilization:
+    metadata:
+      metric_type: gauge
+      unit: fraction
+      description: Ratio of used memory compared to total memory
+    tagsets:
+      - device
+    validator:
+      range:
+        min: 0
+        max: 1
+    support:
+      unsupported_architectures: []
+      device_modes:
+        mig: false
+        physical: true
+        vgpu: false
   memory.temperature:
     metadata:
       metric_type: gauge
@@ -1865,7 +1887,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: byte
-      description: The memory used by this process at the point the metric was given.
+      description:
+        The memory used by this process at the point the metric was given.
         Only emitted when processes are active.
       used_in_dd_ui: true
       aggregation: absolute_usage
@@ -1888,7 +1911,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of time the streaming multiprocessor was active for a
+      description:
+        Percentage of time the streaming multiprocessor was active for a
         specific process
       aggregation: relative_activity
     workload_only: true
@@ -2040,7 +2064,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the Streaming Multiprocessors that were active in the
+      description:
+        Percentage of the Streaming Multiprocessors that were active in the
         interval
       used_in_dd_ui: true
       aggregation: relative_activity
@@ -2064,7 +2089,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the Streaming Multiprocessors that were in use in the
+      description:
+        Percentage of the Streaming Multiprocessors that were in use in the
         interval
       aggregation: relative_activity
     tagsets:

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -711,11 +711,14 @@ metrics:
         min: 0
         max: 1
     support:
-      unsupported_architectures: []
+      unsupported_architectures:
+        - fermi
+        - kepler
+        - maxwell
       device_modes:
-        mig: false
+        mig: true
         physical: true
-        vgpu: false
+        vgpu: true
   memory.temperature:
     metadata:
       metric_type: gauge

--- a/releasenotes/notes/add-additional-memory-metrics-5c79d6d80130e909.yaml
+++ b/releasenotes/notes/add-additional-memory-metrics-5c79d6d80130e909.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    New metrics for GPU memory have been added to the GPU Monitoring product:
+    * ``gpu.memory.utilization``: Ratio of used memory compared to total memory.


### PR DESCRIPTION
### What does this PR do?
Add a memory utilization metric (`gpu.memory.utilization`) to represent the ratio of used memory compared to total memory.

### Motivation
We want to make aggregations more streamlined for the GPU Monitoring product

### Describe how you validated your changes
I ran my agent:
```
dda inv agent.build --build-exclude=systemd    
sudo ./bin/agent/agent run -c /home/bits/scenarios/agent/datadog.yaml
```

I ran [GPU burner](https://github.com/DataDog/gpu-burner) with the following parameter:
```
uv run gpu-burner auto --target_sm 60 --target_mem 50
```

<img width="889" height="287" alt="Screenshot 2026-05-22 at 12 46 21 PM" src="https://github.com/user-attachments/assets/6e8c61e5-a204-409b-8cb8-dc61092e9413" />

### Additional Notes
The formatting changes feel like we should leave, but I can revert them if we decide I shouldn't