### PR TITLE
packaging/aix: remove redundant Go check config copy from stage 08

### DIFF
--- a/packaging/aix/stages/08-integrations.sh
+++ b/packaging/aix/stages/08-integrations.sh
@@ -49,26 +49,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# ─── Step 1: Copy built-in Go check example configs ───────────────────────────
-#
-# Built-in Go checks (cpu, memory, disk, load, network) are implemented in the
-# agent binary itself and do not require pip install. We bundle their example
-# configuration files so the operator can see the available options.
-
-log "Copying built-in Go check default configs"
-# Built-in check config files are named conf.yaml.default (not conf.yaml.example).
-# The network check is intentionally excluded: datadog_checks.network is a Python
-# check that is not bundled in the AIX package; including its config causes the
-# agent to attempt loading the Python check and log an ImportError at startup.
-for check in cpu memory disk load; do
-    mkdir -p "$STAGING/etc/datadog-agent/conf.d/${check}.d"
-    cp "/opt/datadog-agent/cmd/agent/dist/conf.d/${check}.d/conf.yaml.default" \
-       "$STAGING/etc/datadog-agent/conf.d/${check}.d/" 2>/dev/null || \
-        log "WARNING: no conf.yaml.default for built-in check: $check"
-done
-log "Built-in check configs copied"
-
-# ─── Step 2: Install Python checks from integrations-core ─────────────────────
+# ─── Step 1: Install Python checks from integrations-core ─────────────────────
 #
 # Install each check from the pinned integrations-core checkout.
 # --constraint pins all transitive deps to the exact versions frozen by Stage 07,


### PR DESCRIPTION
### What does this PR do?
Removes the hardcoded loop in stage 08 that copied `conf.yaml.default` for `cpu`, `memory`, `disk`, and `load`.

### Motivation
Stage 10 already copies all Go check configs from `bin/agent/dist/conf.d/` (populated by `inv agent.build` via `AIX_CORECHECKS`) to the final staging conf.d. The loop in stage 08 was redundant: it covered only 4 of the checks in `AIX_CORECHECKS`, was never updated as new checks were added, and was completely overwritten by stage 10 anyway.

### Describe how you validated your changes
Code inspection — stage 10's `cp -r "$DIST_CONFD/." "$STAGING_CONFD/"` covers everything in `AIX_CORECHECKS`.

### Additional Notes
N/A