### PR TITLE
feat(gpum): add distribution activity metrics

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -453,6 +453,8 @@ func (c *Check) emitSingleMetric(metric *nvidia.Metric, snd sender.Sender, curre
 		err = snd.CountWithTimestamp(metricName, metric.Value, "", allTags, metricTimestamp)
 	case ddmetrics.GaugeType:
 		err = snd.GaugeWithTimestamp(metricName, metric.Value, "", allTags, metricTimestamp)
+	case ddmetrics.DistributionType:
+		snd.Distribution(metricName, metric.Value, "", allTags)
 	default:
 		err = fmt.Errorf("unsupported metric type %s", metric.Type)
 	}

--- a/pkg/collector/corechecks/gpu/nvidia/sampling.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling.go
@@ -173,6 +173,7 @@ func processUtilizationSample(device ddnvml.Device, lastTimestamp uint64) ([]Met
 				Metric{Name: "process.dram_active", Value: float64(sample.MemUtil), Type: ddmetrics.GaugeType, AssociatedWorkloads: workloads},
 				Metric{Name: "process.encoder_active", Value: float64(sample.EncUtil), Type: ddmetrics.GaugeType, AssociatedWorkloads: workloads},
 				Metric{Name: "process.decoder_active", Value: float64(sample.DecUtil), Type: ddmetrics.GaugeType, AssociatedWorkloads: workloads},
+				Metric{Name: "sm_active.dist", Value: float64(sample.SmUtil), Type: ddmetrics.DistributionType, Priority: Medium},
 			)
 
 			if sample.SmUtil > maxSmUtil {

--- a/pkg/collector/corechecks/gpu/nvidia/sampling.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling.go
@@ -20,6 +20,56 @@ import (
 	ddmetrics "github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
+// processSampleDist emits each NVML sample as an individual distribution point,
+// preserving the per-sample values so the backend can compute percentiles
+// instead of collapsing them to a single time-weighted average like processSample.
+func processSampleDist(device ddnvml.Device, metricName string, samplingType nvml.SamplingType, lastTimestamp uint64, priority MetricPriority) ([]Metric, uint64, error) {
+	valueType, samples, err := device.GetSamples(samplingType, lastTimestamp)
+	if err != nil {
+		var nvmlErr *ddnvml.NvmlAPIError
+		if errors.As(err, &nvmlErr) && errors.Is(nvmlErr.NvmlErrorCode, nvml.ERROR_NOT_FOUND) {
+			return nil, lastTimestamp, nil
+		}
+
+		return nil, 0, fmt.Errorf("failed to get samples for %s: %w", metricName, err)
+	}
+
+	if len(samples) == 0 {
+		return nil, lastTimestamp, nil
+	}
+
+	currentTimestamp := lastTimestamp
+	var metrics []Metric
+	var multiErr []error
+
+	for _, s := range samples {
+		if s.TimeStamp <= lastTimestamp {
+			// Mirror processSample: zero timestamps are invalid placeholders,
+			// and samples at or before lastTimestamp were already accounted for.
+			continue
+		}
+
+		value, err := fieldValueToNumber[float64](valueType, s.SampleValue)
+		if err != nil {
+			multiErr = append(multiErr, fmt.Errorf("failed to convert sample value %s from %v with type %v: %w", metricName, s.SampleValue, valueType, err))
+			continue
+		}
+
+		metrics = append(metrics, Metric{
+			Name:     metricName,
+			Value:    value,
+			Type:     ddmetrics.DistributionType,
+			Priority: priority,
+		})
+
+		if s.TimeStamp > currentTimestamp {
+			currentTimestamp = s.TimeStamp
+		}
+	}
+
+	return metrics, currentTimestamp, errors.Join(multiErr...)
+}
+
 // processSample handles the complex time-weighted averaging logic for NVML sample types
 func processSample(device ddnvml.Device, metricName string, samplingType nvml.SamplingType, lastTimestamp uint64, priority MetricPriority) ([]Metric, uint64, error) {
 	// GetSamples returns a list of samples (timestamp + value) for the
@@ -161,6 +211,12 @@ func createSampleAPIs() []apiCallInfo {
 			Name: "gr_engine_samples",
 			Handler: func(device ddnvml.Device, lastTimestamp uint64) ([]Metric, uint64, error) {
 				return processSample(device, "gr_engine_active", nvml.GPU_UTILIZATION_SAMPLES, lastTimestamp, Medium)
+			},
+		},
+		{
+			Name: "gr_engine_dist",
+			Handler: func(device ddnvml.Device, lastTimestamp uint64) ([]Metric, uint64, error) {
+				return processSampleDist(device, "gr_engine_active.dist", nvml.GPU_UTILIZATION_SAMPLES, lastTimestamp, Medium)
 			},
 		},
 		{

--- a/pkg/collector/corechecks/gpu/nvidia/sampling.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling.go
@@ -173,7 +173,6 @@ func processUtilizationSample(device ddnvml.Device, lastTimestamp uint64) ([]Met
 				Metric{Name: "process.dram_active", Value: float64(sample.MemUtil), Type: ddmetrics.GaugeType, AssociatedWorkloads: workloads},
 				Metric{Name: "process.encoder_active", Value: float64(sample.EncUtil), Type: ddmetrics.GaugeType, AssociatedWorkloads: workloads},
 				Metric{Name: "process.decoder_active", Value: float64(sample.DecUtil), Type: ddmetrics.GaugeType, AssociatedWorkloads: workloads},
-				Metric{Name: "sm_active.dist", Value: float64(sample.SmUtil), Type: ddmetrics.DistributionType, Priority: Medium},
 			)
 
 			if sample.SmUtil > maxSmUtil {
@@ -191,6 +190,7 @@ func processUtilizationSample(device ddnvml.Device, lastTimestamp uint64) ([]Met
 
 	allMetrics = append(allMetrics,
 		Metric{Name: "sm_active", Value: deviceSmActive, Type: ddmetrics.GaugeType, Priority: Medium}, // There's an ebpf based fallback for this metric which should have lower priority
+		Metric{Name: "sm_active.dist", Value: deviceSmActive, Type: ddmetrics.DistributionType, Priority: Medium},
 		Metric{Name: "core.limit", Value: float64(device.GetDeviceInfo().CoreCount), Type: ddmetrics.GaugeType, AssociatedWorkloads: allWorkloadIDs},
 	)
 

--- a/pkg/collector/corechecks/gpu/nvidia/sampling_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling_test.go
@@ -31,7 +31,7 @@ func TestNewSampleCollector(t *testing.T) {
 			name:                  "Supported",
 			customSetup:           nil, // Use default setup with all functions enabled
 			expectError:           false,
-			expectedSupportedAPIs: 5,
+			expectedSupportedAPIs: 6,
 		},
 		{
 			name: "Unsupported",

--- a/pkg/collector/corechecks/gpu/nvidia/sampling_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling_test.go
@@ -80,14 +80,14 @@ func TestCollectProcessUtilization(t *testing.T) {
 		{
 			name:          "NoUtilizationProcesses",
 			samples:       []nvml.ProcessUtilizationSample{},
-			expectedCount: 2, // sm_active + core.limit
+			expectedCount: 3, // sm_active + sm_active.dist + core.limit
 		},
 		{
 			name: "SingleUtilizationProcess",
 			samples: []nvml.ProcessUtilizationSample{
 				{Pid: 1234, TimeStamp: 1000, SmUtil: 75, MemUtil: 60, EncUtil: 30, DecUtil: 15},
 			},
-			expectedCount: 7, // 4 per-process + sm_active.dist + sm_active + core.limit
+			expectedCount: 7, // 4 per-process + sm_active + sm_active.dist + core.limit
 		},
 		{
 			name: "MultipleUtilizationProcesses",
@@ -95,14 +95,14 @@ func TestCollectProcessUtilization(t *testing.T) {
 				{Pid: 1001, TimeStamp: 1100, SmUtil: 50, MemUtil: 40, EncUtil: 20, DecUtil: 10},
 				{Pid: 1003, TimeStamp: 1200, SmUtil: 80, MemUtil: 70, EncUtil: 35, DecUtil: 25},
 			},
-			expectedCount: 12, // 2×(4 per-process + sm_active.dist) + sm_active + core.limit
+			expectedCount: 11, // 2×4 per-process + sm_active + sm_active.dist + core.limit
 		},
 		{
 			name: "ZeroUtilizationValues",
 			samples: []nvml.ProcessUtilizationSample{
 				{Pid: 13001, TimeStamp: 4000, SmUtil: 0, MemUtil: 0, EncUtil: 0, DecUtil: 0},
 			},
-			expectedCount: 7, // 4 per-process + sm_active.dist + sm_active + core.limit
+			expectedCount: 7, // 4 per-process + sm_active + sm_active.dist + core.limit
 		},
 	}
 
@@ -151,13 +151,13 @@ func TestCollectProcessUtilization_Error(t *testing.T) {
 		{
 			name:          "ProcessUtilizationAPIError_NOT_FOUND",
 			apiError:      &safenvml.NvmlAPIError{APIName: "GetProcessUtilization", NvmlErrorCode: nvml.ERROR_NOT_FOUND},
-			expectedCount: 2, // sm_active + core.limit (gracefully handled)
+			expectedCount: 3, // sm_active + sm_active.dist + core.limit (gracefully handled)
 			expectError:   false,
 		},
 		{
 			name:          "ProcessUtilizationAPIError_Other",
 			apiError:      &safenvml.NvmlAPIError{APIName: "GetProcessUtilization", NvmlErrorCode: nvml.ERROR_UNKNOWN},
-			expectedCount: 2, // sm_active + core.limit (still emitted on error)
+			expectedCount: 3, // sm_active + sm_active.dist + core.limit (still emitted on error)
 			expectError:   true,
 		},
 	}

--- a/pkg/collector/corechecks/gpu/nvidia/sampling_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling_test.go
@@ -87,7 +87,7 @@ func TestCollectProcessUtilization(t *testing.T) {
 			samples: []nvml.ProcessUtilizationSample{
 				{Pid: 1234, TimeStamp: 1000, SmUtil: 75, MemUtil: 60, EncUtil: 30, DecUtil: 15},
 			},
-			expectedCount: 6, // 4 per-process + sm_active + core.limit
+			expectedCount: 7, // 4 per-process + sm_active.dist + sm_active + core.limit
 		},
 		{
 			name: "MultipleUtilizationProcesses",
@@ -95,14 +95,14 @@ func TestCollectProcessUtilization(t *testing.T) {
 				{Pid: 1001, TimeStamp: 1100, SmUtil: 50, MemUtil: 40, EncUtil: 20, DecUtil: 10},
 				{Pid: 1003, TimeStamp: 1200, SmUtil: 80, MemUtil: 70, EncUtil: 35, DecUtil: 25},
 			},
-			expectedCount: 10, // 2×4 per-process + sm_active + core.limit
+			expectedCount: 12, // 2×(4 per-process + sm_active.dist) + sm_active + core.limit
 		},
 		{
 			name: "ZeroUtilizationValues",
 			samples: []nvml.ProcessUtilizationSample{
 				{Pid: 13001, TimeStamp: 4000, SmUtil: 0, MemUtil: 0, EncUtil: 0, DecUtil: 0},
 			},
-			expectedCount: 6, // 4 per-process + sm_active + core.limit
+			expectedCount: 7, // 4 per-process + sm_active.dist + sm_active + core.limit
 		},
 	}
 

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -2053,6 +2053,22 @@ metrics:
         mig: true
         physical: true
         vgpu: true
+  sm_active.dist:
+    metadata:
+      metric_type: distribution
+      unit: percent
+      description: Distribution of per-process streaming multiprocessor activity,
+        emitted as individual process utilization samples so the backend can compute
+        percentiles instead of a single device-wide aggregate.
+      aggregation: relative_activity
+    tagsets:
+      - device
+    support:
+      unsupported_architectures: []
+      device_modes:
+        mig: true
+        physical: true
+        vgpu: true
   sm_occupancy:
     metadata:
       metric_type: gauge

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -575,9 +575,7 @@ metrics:
     metadata:
       metric_type: distribution
       unit: percent
-      description: Distribution of per-sample graphics engine activity, emitted as
-        individual NVML samples so the backend can compute percentiles instead of a
-        time-weighted average.
+      description: Percent of time that the graphics engine was active, as a distribution
       aggregation: relative_activity
     tagsets:
       - device
@@ -2057,9 +2055,7 @@ metrics:
     metadata:
       metric_type: distribution
       unit: percent
-      description: Distribution of per-process streaming multiprocessor activity,
-        emitted as individual process utilization samples so the backend can compute
-        percentiles instead of a single device-wide aggregate.
+      description: Percentage of time the streaming multiprocessor was active, as a distribution
       aggregation: relative_activity
     tagsets:
       - device

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -571,6 +571,23 @@ metrics:
         mig: true
         physical: true
         vgpu: true
+  gr_engine_active.dist:
+    metadata:
+      metric_type: distribution
+      unit: percent
+      description: Distribution of per-sample graphics engine activity, emitted as
+        individual NVML samples so the backend can compute percentiles instead of a
+        time-weighted average.
+      aggregation: relative_activity
+    tagsets:
+      - device
+    support:
+      unsupported_architectures:
+        - fermi
+      device_modes:
+        mig: true
+        physical: true
+        vgpu: true
   integer_active:
     metadata:
       metric_type: gauge

--- a/pkg/collector/corechecks/gpu/spec/spec.go
+++ b/pkg/collector/corechecks/gpu/spec/spec.go
@@ -123,11 +123,11 @@ func (m *MetricMetadataSpec) UnmarshalYAML(unmarshal func(interface{}) error) er
 	}
 
 	switch decoded.MetricType {
-	case "", "gauge", "counter", "histogram":
+	case "", "gauge", "counter", "histogram", "distribution":
 		*m = MetricMetadataSpec(decoded)
 		return nil
 	default:
-		return fmt.Errorf("invalid metric_type %q: must be one of [gauge, counter, histogram]", decoded.MetricType)
+		return fmt.Errorf("invalid metric_type %q: must be one of [gauge, counter, histogram, distribution]", decoded.MetricType)
 	}
 }
 

--- a/pkg/collector/corechecks/gpu/spec/spec_test.go
+++ b/pkg/collector/corechecks/gpu/spec/spec_test.go
@@ -218,7 +218,7 @@ support:
 `), &spec)
 
 	require.Error(t, err)
-	require.ErrorContains(t, err, `invalid metric_type "this-will-never-be-a-valid-metric-type": must be one of [gauge, counter, histogram]`)
+	require.ErrorContains(t, err, `invalid metric_type "this-will-never-be-a-valid-metric-type": must be one of [gauge, counter, histogram, distribution]`)
 }
 
 func TestLoadedMetricsIncludeMetadata(t *testing.T) {

--- a/releasenotes/notes/add-distribution-metrics-5cf2b95fae36c059.yaml
+++ b/releasenotes/notes/add-distribution-metrics-5cf2b95fae36c059.yaml
@@ -1,0 +1,40 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    List upgrade notes here, or remove this section.
+    Upgrade notes should be rare: only list known/potential breaking changes,
+    or major behaviorial changes that require user action before the upgrade.
+    Notes here must include steps that users can follow to 1. know if they're
+    affected and 2. handle the change gracefully on their end.
+features:
+  - |
+    List new features here, or remove this section.
+enhancements:
+  - |
+    List enhancements (new behavior that is too small to be
+    considered a new feature), or remove this section.
+issues:
+  - |
+    List known issues here, or remove this section.
+deprecations:
+  - |
+    List deprecations notes here, or remove this section.
+security:
+  - |
+    Include security notes here, or remove this section if none. Specific CVEs are handled automatically and should not be mentioned directly in the changelog.
+    For instance, if you bumped a lib to fix a CVE, just mention the bump.
+fixes:
+  - |
+    Add normal bug fixes here, or remove this section.
+other:
+  - |
+    Add here every other information you want in the CHANGELOG that
+    don't fit in any other section. This section should rarely be
+    used.

--- a/releasenotes/notes/add-distribution-metrics-5cf2b95fae36c059.yaml
+++ b/releasenotes/notes/add-distribution-metrics-5cf2b95fae36c059.yaml
@@ -3,4 +3,4 @@ features:
   - |
     Two new distribution metrics have been added for the GPU Monitoring product:
     * ``gpu.sm_active.dist``: Percentage of time the streaming multiprocessor was active, as a distribution
-    * ``gr_engine_active.dist``: Percent of time that the graphics engine was active, as a distribution
+    * ``gpu.gr_engine_active.dist``: Percent of time that the graphics engine was active, as a distribution

--- a/releasenotes/notes/add-distribution-metrics-5cf2b95fae36c059.yaml
+++ b/releasenotes/notes/add-distribution-metrics-5cf2b95fae36c059.yaml
@@ -1,40 +1,6 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
 ---
-upgrade:
-  - |
-    List upgrade notes here, or remove this section.
-    Upgrade notes should be rare: only list known/potential breaking changes,
-    or major behaviorial changes that require user action before the upgrade.
-    Notes here must include steps that users can follow to 1. know if they're
-    affected and 2. handle the change gracefully on their end.
 features:
   - |
-    List new features here, or remove this section.
-enhancements:
-  - |
-    List enhancements (new behavior that is too small to be
-    considered a new feature), or remove this section.
-issues:
-  - |
-    List known issues here, or remove this section.
-deprecations:
-  - |
-    List deprecations notes here, or remove this section.
-security:
-  - |
-    Include security notes here, or remove this section if none. Specific CVEs are handled automatically and should not be mentioned directly in the changelog.
-    For instance, if you bumped a lib to fix a CVE, just mention the bump.
-fixes:
-  - |
-    Add normal bug fixes here, or remove this section.
-other:
-  - |
-    Add here every other information you want in the CHANGELOG that
-    don't fit in any other section. This section should rarely be
-    used.
+    Two new distribution metrics have been added for the GPU Monitoring product:
+    * ``gpu.sm_active.dist``: Percentage of time the streaming multiprocessor was active, as a distribution
+    * ``gr_engine_active.dist``: Percent of time that the graphics engine was active, as a distribution


### PR DESCRIPTION
### What does this PR do?
This change adds two new distribution metrics have been added for the GPU Monitoring product:
    * `gpu.sm_active.dist`: Percentage of time the streaming multiprocessor was active, as a distribution
    * `gpu.gr_engine_active.dist`: Percent of time that the graphics engine was active, as a distribution

### Motivation
We want to more accurately calculate activity metrics. We also want to be able to show a heatmap.

### Describe how you validated your changes
I ran my agent:
```
dda inv agent.build --build-exclude=systemd    
sudo ./bin/agent/agent run -c /home/bits/scenarios/agent/datadog.yaml
```

I ran [GPU burner](https://github.com/DataDog/gpu-burner) with the following parameter:
```
uv run gpu-burner --run_time 600 auto --target_sm 85 --target_mem 20
```

I compared all 4 activity based metrics:
<img width="1911" height="942" alt="Screenshot 2026-05-22 at 4 24 01 PM" src="https://github.com/user-attachments/assets/65faa02d-6b39-4be3-b674-0e1efa8d4673" />


### Additional Notes
I need follow up changes to add the metric types to ebpf/gpm.