### PR TITLE
test(e2e): DDOT extension under procmgr (install-script)

### DIFF
--- a/pkg/fleet/installer/packages/BUILD.bazel
+++ b/pkg/fleet/installer/packages/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "datadog_agent_ddot_windows.go",
         "datadog_agent_extensions.go",
         "datadog_agent_linux.go",
+        "datadog_agent_version.go",
         "datadog_agent_windows.go",
         "otel_config_common.go",
         "packages.go",

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
@@ -6,6 +6,7 @@
 package packages
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -250,7 +251,7 @@ func postInstallDDOTExtension(ctx HookContext) (err error) {
 
 	installDir := ddotExtensionInstallDir(ctx)
 	if installDir == "" {
-		return fmt.Errorf("ddot extension not found under agent install roots")
+		return errors.New("ddot extension not found under agent install roots")
 	}
 	extensionPath := filepath.Join(installDir, "ext", "ddot")
 
@@ -279,9 +280,11 @@ func postInstallDDOTExtension(ctx HookContext) (err error) {
 }
 
 const (
-	ddotProcmgrYAMLName  = "datadog-agent-ddot.yaml"
-	procmgrUnitStable    = "datadog-agent-procmgr.service"
-	fleetAgentStablePath = "/opt/datadog-packages/datadog-agent/stable"
+	ddotProcmgrYAMLName      = "datadog-agent-ddot.yaml"
+	procmgrUnitStable        = "datadog-agent-procmgr.service"
+	procmgrUnitExperiment    = "datadog-agent-procmgr-exp.service"
+	fleetAgentStablePath     = "/opt/datadog-packages/datadog-agent/stable"
+	fleetAgentExperimentPath = "/opt/datadog-packages/datadog-agent/experiment"
 )
 
 func ddotExtensionInstallDir(ctx HookContext) string {
@@ -299,18 +302,27 @@ func ddotExtensionInstallDir(ctx HookContext) string {
 	return ""
 }
 
-func procmgrAgentInstallRoot() string {
-	if _, err := os.Stat(filepath.Join(fleetAgentStablePath, "embedded/bin/dd-procmgrd")); err == nil {
-		return fleetAgentStablePath
+func procmgrAgentInstallRoot(ctx HookContext) string {
+	candidates := []string{}
+	if ctx.PackagePath != "" {
+		candidates = append(candidates, ctx.PackagePath)
 	}
-	if _, err := os.Stat(filepath.Join("/opt/datadog-agent", "embedded/bin/dd-procmgrd")); err == nil {
-		return "/opt/datadog-agent"
+	if ctx.IsExperiment {
+		candidates = append(candidates, fleetAgentExperimentPath)
+	} else {
+		candidates = append(candidates, fleetAgentStablePath)
+	}
+	candidates = append(candidates, "/opt/datadog-agent")
+	for _, root := range candidates {
+		if _, err := os.Stat(filepath.Join(root, "embedded/bin/dd-procmgrd")); err == nil {
+			return root
+		}
 	}
 	return ""
 }
 
 func writeDDOTProcmgrConfig(ctx HookContext, installDir string) error {
-	procmgrRoot := procmgrAgentInstallRoot()
+	procmgrRoot := procmgrAgentInstallRoot(ctx)
 	if procmgrRoot == "" {
 		return nil
 	}
@@ -323,13 +335,18 @@ func writeDDOTProcmgrConfig(ctx HookContext, installDir string) error {
 	if ctx.PackageType == PackageTypeOCI || strings.HasPrefix(procmgrRoot, paths.PackagesPath) {
 		unitType = embedded.SystemdUnitTypeOCI
 	}
-	raw, err := embedded.GetDDOTProcessConfig(unitType, true, ambientCapabilitiesSupported)
+	stable := !ctx.IsExperiment
+	raw, err := embedded.GetDDOTProcessConfig(unitType, stable, ambientCapabilitiesSupported)
 	if err != nil {
 		return fmt.Errorf("ddot procmgr yaml: %w", err)
 	}
+	fleetTemplateRoot := fleetAgentStablePath
+	if !stable {
+		fleetTemplateRoot = fleetAgentExperimentPath
+	}
 	yaml := string(raw)
-	if installDir != fleetAgentStablePath {
-		yaml = strings.ReplaceAll(yaml, fleetAgentStablePath, installDir)
+	if installDir != fleetTemplateRoot {
+		yaml = strings.ReplaceAll(yaml, fleetTemplateRoot, installDir)
 	}
 	processesDir := filepath.Join(procmgrRoot, "processes.d")
 	if err := os.MkdirAll(processesDir, 0755); err != nil {
@@ -338,7 +355,11 @@ func writeDDOTProcmgrConfig(ctx HookContext, installDir string) error {
 	if err := os.WriteFile(filepath.Join(processesDir, ddotProcmgrYAMLName), []byte(yaml), 0644); err != nil {
 		return err
 	}
-	return systemd.RestartUnit(ctx, procmgrUnitStable)
+	procmgrUnit := procmgrUnitStable
+	if ctx.IsExperiment {
+		procmgrUnit = procmgrUnitExperiment
+	}
+	return systemd.RestartUnit(ctx, procmgrUnit)
 }
 
 // preRemoveDDOTExtension stops and disables the DDOT service before extension removal

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
@@ -11,10 +11,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/embedded"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/file"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/packagemanager"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/systemd"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/user"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -246,8 +248,11 @@ func postInstallDDOTExtension(ctx HookContext) (err error) {
 		span.Finish(err)
 	}()
 
-	// extensionPath is the path to the DDOT extension. It is already scoped to stable / experiment per the Agent package.
-	extensionPath := filepath.Join(ctx.PackagePath, "ext", "ddot")
+	installDir := ddotExtensionInstallDir(ctx)
+	if installDir == "" {
+		return fmt.Errorf("ddot extension not found under agent install roots")
+	}
+	extensionPath := filepath.Join(installDir, "ext", "ddot")
 
 	// Copy the example file to the configuration directory
 	// XXX: Maybe we should always embed the example file in the Agent package?
@@ -270,7 +275,70 @@ func postInstallDDOTExtension(ctx HookContext) (err error) {
 		return fmt.Errorf("failed to set DDOT config ownerships: %v", err)
 	}
 
-	return nil
+	return writeDDOTProcmgrConfig(ctx, installDir)
+}
+
+const (
+	ddotProcmgrYAMLName  = "datadog-agent-ddot.yaml"
+	procmgrUnitStable    = "datadog-agent-procmgr.service"
+	fleetAgentStablePath = "/opt/datadog-packages/datadog-agent/stable"
+)
+
+func ddotExtensionInstallDir(ctx HookContext) string {
+	roots := []string{ctx.PackagePath, "/opt/datadog-agent", fleetAgentStablePath}
+	roots = append(roots, filepath.Join(paths.PackagesPath, "datadog-agent", agentVersionForExtensions()))
+	for _, root := range roots {
+		installRoot := root
+		if resolved, err := filepath.EvalSymlinks(root); err == nil {
+			installRoot = resolved
+		}
+		if _, err := os.Stat(filepath.Join(installRoot, "ext", "ddot")); err == nil {
+			return installRoot
+		}
+	}
+	return ""
+}
+
+func procmgrAgentInstallRoot() string {
+	if _, err := os.Stat(filepath.Join(fleetAgentStablePath, "embedded/bin/dd-procmgrd")); err == nil {
+		return fleetAgentStablePath
+	}
+	if _, err := os.Stat(filepath.Join("/opt/datadog-agent", "embedded/bin/dd-procmgrd")); err == nil {
+		return "/opt/datadog-agent"
+	}
+	return ""
+}
+
+func writeDDOTProcmgrConfig(ctx HookContext, installDir string) error {
+	procmgrRoot := procmgrAgentInstallRoot()
+	if procmgrRoot == "" {
+		return nil
+	}
+	ambientCapabilitiesSupported, err := isAmbiantCapabilitiesSupported()
+	if err != nil {
+		log.Warnf("failed to check ambient capabilities support: %v", err)
+		ambientCapabilitiesSupported = false
+	}
+	unitType := embedded.SystemdUnitTypeDebRpm
+	if ctx.PackageType == PackageTypeOCI || strings.HasPrefix(procmgrRoot, paths.PackagesPath) {
+		unitType = embedded.SystemdUnitTypeOCI
+	}
+	raw, err := embedded.GetDDOTProcessConfig(unitType, true, ambientCapabilitiesSupported)
+	if err != nil {
+		return fmt.Errorf("ddot procmgr yaml: %w", err)
+	}
+	yaml := string(raw)
+	if installDir != fleetAgentStablePath {
+		yaml = strings.ReplaceAll(yaml, fleetAgentStablePath, installDir)
+	}
+	processesDir := filepath.Join(procmgrRoot, "processes.d")
+	if err := os.MkdirAll(processesDir, 0755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(processesDir, ddotProcmgrYAMLName), []byte(yaml), 0644); err != nil {
+		return err
+	}
+	return systemd.RestartUnit(ctx, procmgrUnitStable)
 }
 
 // preRemoveDDOTExtension stops and disables the DDOT service before extension removal

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
@@ -287,6 +287,14 @@ const (
 	fleetAgentExperimentPath = "/opt/datadog-packages/datadog-agent/experiment"
 )
 
+// isFleetAgentSlotPath reports whether root is the fleet stable/experiment slot symlink.
+// These paths must not be canonicalized: procmgr process YAML should reference the slot
+// so promote/upgrade can retarget the symlink without rewriting processes.d.
+func isFleetAgentSlotPath(root string) bool {
+	clean := filepath.Clean(root)
+	return clean == fleetAgentStablePath || clean == fleetAgentExperimentPath
+}
+
 func ddotAgentInstallRoot(ctx HookContext) (string, error) {
 	roots := []string{}
 	if ctx.PackagePath != "" {
@@ -301,8 +309,10 @@ func ddotAgentInstallRoot(ctx HookContext) (string, error) {
 	roots = append(roots, filepath.Join(paths.PackagesPath, "datadog-agent", agentVersionForExtensions()))
 	for _, root := range roots {
 		installRoot := root
-		if resolved, err := filepath.EvalSymlinks(root); err == nil {
-			installRoot = resolved
+		if !isFleetAgentSlotPath(root) {
+			if resolved, err := filepath.EvalSymlinks(root); err == nil {
+				installRoot = resolved
+			}
 		}
 		if _, err := os.Stat(filepath.Join(installRoot, "ext", "ddot")); err == nil {
 			return installRoot, nil

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
@@ -385,6 +385,27 @@ func writeDDOTProcmgrConfig(ctx HookContext, agentInstallRoot string) error {
 	return systemd.RestartUnit(ctx, procmgrUnit)
 }
 
+func removeDDOTProcmgrConfig(ctx HookContext) error {
+	procmgrRoot := procmgrAgentInstallRoot(ctx)
+	if procmgrRoot == "" {
+		return nil
+	}
+
+	yamlPath := filepath.Join(procmgrRoot, "processes.d", ddotProcmgrYAMLName)
+	if err := os.Remove(yamlPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	procmgrUnit := procmgrUnitStable
+	if ctx.IsExperiment {
+		procmgrUnit = procmgrUnitExperiment
+	}
+	if err := systemd.RestartUnit(ctx, procmgrUnit); err != nil {
+		log.Warnf("failed to restart %s after DDOT removal: %v", procmgrUnit, err)
+	}
+	return nil
+}
+
 // preRemoveDDOTExtension stops and disables the DDOT service before extension removal
 func preRemoveDDOTExtension(ctx HookContext) error {
 	span, _ := ctx.StartSpan("pre_remove_extension_ddot")
@@ -394,6 +415,10 @@ func preRemoveDDOTExtension(ctx HookContext) error {
 	// During an upgrade, this will be re-enabled by the post-install hook. This gives us flexibility to change the config during upgrade.
 	if err := disableOtelCollectorConfigCommon(datadogYamlPath); err != nil {
 		log.Warnf("failed to disable otelcollector config: %s", err)
+	}
+
+	if err := removeDDOTProcmgrConfig(ctx); err != nil {
+		log.Warnf("failed to remove ddot procmgr process definition: %v", err)
 	}
 
 	return nil

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
@@ -249,11 +249,11 @@ func postInstallDDOTExtension(ctx HookContext) (err error) {
 		span.Finish(err)
 	}()
 
-	installDir := ddotExtensionInstallDir(ctx)
-	if installDir == "" {
-		return errors.New("ddot extension not found under agent install roots")
+	agentRoot, err := ddotAgentInstallRoot(ctx)
+	if err != nil {
+		return err
 	}
-	extensionPath := filepath.Join(installDir, "ext", "ddot")
+	extensionPath := ddotExtensionPathFromRoot(agentRoot)
 
 	// Copy the example file to the configuration directory
 	// XXX: Maybe we should always embed the example file in the Agent package?
@@ -276,7 +276,7 @@ func postInstallDDOTExtension(ctx HookContext) (err error) {
 		return fmt.Errorf("failed to set DDOT config ownerships: %v", err)
 	}
 
-	return writeDDOTProcmgrConfig(ctx, installDir)
+	return writeDDOTProcmgrConfig(ctx, agentRoot)
 }
 
 const (
@@ -287,8 +287,17 @@ const (
 	fleetAgentExperimentPath = "/opt/datadog-packages/datadog-agent/experiment"
 )
 
-func ddotExtensionInstallDir(ctx HookContext) string {
-	roots := []string{ctx.PackagePath, "/opt/datadog-agent", fleetAgentStablePath}
+func ddotAgentInstallRoot(ctx HookContext) (string, error) {
+	roots := []string{}
+	if ctx.PackagePath != "" {
+		roots = append(roots, ctx.PackagePath)
+	}
+	if ctx.IsExperiment {
+		roots = append(roots, fleetAgentExperimentPath)
+	} else {
+		roots = append(roots, fleetAgentStablePath)
+	}
+	roots = append(roots, "/opt/datadog-agent")
 	roots = append(roots, filepath.Join(paths.PackagesPath, "datadog-agent", agentVersionForExtensions()))
 	for _, root := range roots {
 		installRoot := root
@@ -296,10 +305,14 @@ func ddotExtensionInstallDir(ctx HookContext) string {
 			installRoot = resolved
 		}
 		if _, err := os.Stat(filepath.Join(installRoot, "ext", "ddot")); err == nil {
-			return installRoot
+			return installRoot, nil
 		}
 	}
-	return ""
+	return "", errors.New("ddot extension not found under agent install roots")
+}
+
+func ddotExtensionPathFromRoot(agentRoot string) string {
+	return filepath.Join(agentRoot, "ext", "ddot")
 }
 
 func procmgrAgentInstallRoot(ctx HookContext) string {
@@ -321,7 +334,7 @@ func procmgrAgentInstallRoot(ctx HookContext) string {
 	return ""
 }
 
-func writeDDOTProcmgrConfig(ctx HookContext, installDir string) error {
+func writeDDOTProcmgrConfig(ctx HookContext, agentInstallRoot string) error {
 	procmgrRoot := procmgrAgentInstallRoot(ctx)
 	if procmgrRoot == "" {
 		return nil
@@ -345,8 +358,8 @@ func writeDDOTProcmgrConfig(ctx HookContext, installDir string) error {
 		fleetTemplateRoot = fleetAgentExperimentPath
 	}
 	yaml := string(raw)
-	if installDir != fleetTemplateRoot {
-		yaml = strings.ReplaceAll(yaml, fleetTemplateRoot, installDir)
+	if agentInstallRoot != fleetTemplateRoot {
+		yaml = strings.ReplaceAll(yaml, fleetTemplateRoot, agentInstallRoot)
 	}
 	processesDir := filepath.Join(procmgrRoot, "processes.d")
 	if err := os.MkdirAll(processesDir, 0755); err != nil {

--- a/pkg/fleet/installer/packages/datadog_agent_extensions.go
+++ b/pkg/fleet/installer/packages/datadog_agent_extensions.go
@@ -36,6 +36,15 @@ func getCurrentAgentVersion() string {
 	return v + "-1"
 }
 
+//nolint:unused // Used in platform-specific files
+func agentVersionForExtensions() string {
+	ver := getCurrentAgentVersion()
+	if override := env.FromEnv().DefaultPackagesVersionOverride[agentPackage]; override != "" {
+		return override
+	}
+	return ver
+}
+
 // Config structs for reading installer registry configuration from datadog.yaml
 
 //nolint:unused // Used in platform-specific files

--- a/pkg/fleet/installer/packages/datadog_agent_extensions.go
+++ b/pkg/fleet/installer/packages/datadog_agent_extensions.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -19,31 +18,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
-//nolint:unused // Used in platform-specific files
 const agentPackage = "datadog-agent"
-
-// getCurrentAgentVersion returns the current agent version in URL-safe format with -1 suffix
-//
-//nolint:unused // Used in platform-specific files
-func getCurrentAgentVersion() string {
-	v := version.AgentVersionURLSafe
-	if strings.HasSuffix(v, "-1") {
-		return v
-	}
-	return v + "-1"
-}
-
-//nolint:unused // Used in platform-specific files
-func agentVersionForExtensions() string {
-	ver := getCurrentAgentVersion()
-	if override := env.FromEnv().DefaultPackagesVersionOverride[agentPackage]; override != "" {
-		return override
-	}
-	return ver
-}
 
 // Config structs for reading installer registry configuration from datadog.yaml
 

--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/installinfo"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/embedded"
 	extensionsPkg "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/extensions"
@@ -31,6 +32,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+func agentVersionForExtensions() string {
+	ver := getCurrentAgentVersion()
+	if override := env.FromEnv().DefaultPackagesVersionOverride[agentPackage]; override != "" {
+		return override
+	}
+	return ver
+}
 
 var datadogAgentPackage = hooks{
 	preInstall:  preInstallDatadogAgent,

--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -125,8 +125,8 @@ var (
 	agentService = datadogAgentService{
 		SystemdMainUnitStable: "datadog-agent.service",
 		SystemdMainUnitExp:    "datadog-agent-exp.service",
-		SystemdUnitsStable:    []string{"datadog-agent.service", "datadog-agent-installer.service", "datadog-agent-trace.service", "datadog-agent-process.service", "datadog-agent-sysprobe.service", "datadog-agent-security.service", "datadog-agent-data-plane.service", "datadog-agent-action.service", "datadog-agent-ddot.service", "datadog-agent-procmgrd.service"},
-		SystemdUnitsExp:       []string{"datadog-agent-exp.service", "datadog-agent-installer-exp.service", "datadog-agent-trace-exp.service", "datadog-agent-process-exp.service", "datadog-agent-sysprobe-exp.service", "datadog-agent-security-exp.service", "datadog-agent-data-plane-exp.service", "datadog-agent-action-exp.service", "datadog-agent-ddot-exp.service", "datadog-agent-procmgrd-exp.service"},
+		SystemdUnitsStable:    []string{"datadog-agent.service", "datadog-agent-installer.service", "datadog-agent-trace.service", "datadog-agent-process.service", "datadog-agent-sysprobe.service", "datadog-agent-security.service", "datadog-agent-data-plane.service", "datadog-agent-action.service", "datadog-agent-ddot.service", "datadog-agent-procmgr.service"},
+		SystemdUnitsExp:       []string{"datadog-agent-exp.service", "datadog-agent-installer-exp.service", "datadog-agent-trace-exp.service", "datadog-agent-process-exp.service", "datadog-agent-sysprobe-exp.service", "datadog-agent-security-exp.service", "datadog-agent-data-plane-exp.service", "datadog-agent-action-exp.service", "datadog-agent-ddot-exp.service", "datadog-agent-procmgr-exp.service"},
 
 		UpstartMainService: "datadog-agent",
 		UpstartServices:    []string{"datadog-agent", "datadog-agent-trace", "datadog-agent-process", "datadog-agent-sysprobe", "datadog-agent-security", "datadog-agent-data-plane", "datadog-agent-action"},
@@ -139,6 +139,16 @@ var (
 	oldInstallerUnitPaths = file.Paths{
 		"datadog-installer-exp.service",
 		"datadog-installer.service",
+	}
+
+	legacyProcmgrUnitNames = []string{
+		"datadog-agent-procmgrd.service",
+		"datadog-agent-procmgrd-exp.service",
+	}
+
+	legacyProcmgrUnitPaths = file.Paths{
+		"datadog-agent-procmgrd.service",
+		"datadog-agent-procmgrd-exp.service",
 	}
 )
 
@@ -195,7 +205,37 @@ func installFilesystem(ctx HookContext) (err error) {
 	if err = oldInstallerUnitPaths.EnsureAbsent(ctx, "/etc/systemd/system"); err != nil {
 		return fmt.Errorf("failed to remove old installer units: %v", err)
 	}
+
+	// 7. Retire legacy datadog-agent-procmgrd* units in favor of datadog-agent-procmgr*.
+	if err = retireLegacyProcmgrUnits(ctx); err != nil {
+		return fmt.Errorf("failed to retire legacy procmgr units: %w", err)
+	}
 	return nil
+}
+
+// retireLegacyProcmgrUnits removes datadog-agent-procmgrd*.service units.
+func retireLegacyProcmgrUnits(ctx HookContext) error {
+	if !service.IsSystemdHost() {
+		return nil
+	}
+	running, err := systemd.IsRunning()
+	if err != nil {
+		return err
+	}
+	if running {
+		if err := systemd.StopUnits(ctx, legacyProcmgrUnitNames...); err != nil {
+			return err
+		}
+		if err := systemd.DisableUnits(ctx, legacyProcmgrUnitNames...); err != nil {
+			return err
+		}
+	}
+	for _, unitsPath := range systemdUnitInstallPaths {
+		if err := legacyProcmgrUnitPaths.EnsureAbsent(ctx, unitsPath); err != nil {
+			return err
+		}
+	}
+	return systemd.Reload(ctx)
 }
 
 // uninstallFilesystem cleans the filesystem by removing various temporary files, symlinks and installation metadata
@@ -266,7 +306,7 @@ func postInstallDatadogAgent(ctx HookContext) (err error) {
 	if err := restoreODBCConfig(ctx.PackagePath); err != nil {
 		log.Warnf("failed to restore ODBC config: %s", err)
 	}
-	agentVersion := getCurrentAgentVersion()
+	agentVersion := agentVersionForExtensions()
 	if err := extensionsPkg.SetPackage(ctx, agentPackage, agentVersion, false); err != nil {
 		return fmt.Errorf("failed to set package version in extensions db: %w", err)
 	}
@@ -750,6 +790,8 @@ const (
 	debUnitsPath = "/lib/systemd/system"
 	rpmUnitsPath = "/usr/lib/systemd/system"
 )
+
+var systemdUnitInstallPaths = []string{ociUnitsPath, debUnitsPath, rpmUnitsPath}
 
 func removeUnits(ctx HookContext, units ...string) error {
 	var unitsPath string

--- a/pkg/fleet/installer/packages/datadog_agent_version.go
+++ b/pkg/fleet/installer/packages/datadog_agent_version.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package packages
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// getCurrentAgentVersion returns the current agent version in URL-safe format with -1 suffix.
+func getCurrentAgentVersion() string {
+	v := version.AgentVersionURLSafe
+	if strings.HasSuffix(v, "-1") {
+		return v
+	}
+	return v + "-1"
+}

--- a/pkg/fleet/installer/packages/datadog_agent_version.go
+++ b/pkg/fleet/installer/packages/datadog_agent_version.go
@@ -12,6 +12,8 @@ import (
 )
 
 // getCurrentAgentVersion returns the current agent version in URL-safe format with -1 suffix.
+//
+//nolint:unused // Used in platform-specific files
 func getCurrentAgentVersion() string {
 	v := version.AgentVersionURLSafe
 	if strings.HasSuffix(v, "-1") {

--- a/pkg/fleet/installer/packages/embedded/BUILD.bazel
+++ b/pkg/fleet/installer/packages/embedded/BUILD.bazel
@@ -22,8 +22,8 @@ service_srcs = [
     "tmpl/gen/debrpm/datadog-agent-installer.service",
     "tmpl/gen/debrpm/datadog-agent-process-exp.service",
     "tmpl/gen/debrpm/datadog-agent-process.service",
-    "tmpl/gen/debrpm/datadog-agent-procmgrd-exp.service",
-    "tmpl/gen/debrpm/datadog-agent-procmgrd.service",
+    "tmpl/gen/debrpm/datadog-agent-procmgr-exp.service",
+    "tmpl/gen/debrpm/datadog-agent-procmgr.service",
     "tmpl/gen/debrpm/datadog-agent-security-exp.service",
     "tmpl/gen/debrpm/datadog-agent-security.service",
     "tmpl/gen/debrpm/datadog-agent-sysprobe-exp.service",
@@ -44,8 +44,8 @@ service_srcs = [
     "tmpl/gen/oci/datadog-agent-installer.service",
     "tmpl/gen/oci/datadog-agent-process-exp.service",
     "tmpl/gen/oci/datadog-agent-process.service",
-    "tmpl/gen/oci/datadog-agent-procmgrd-exp.service",
-    "tmpl/gen/oci/datadog-agent-procmgrd.service",
+    "tmpl/gen/oci/datadog-agent-procmgr-exp.service",
+    "tmpl/gen/oci/datadog-agent-procmgr.service",
     "tmpl/gen/oci/datadog-agent-security-exp.service",
     "tmpl/gen/oci/datadog-agent-security.service",
     "tmpl/gen/oci/datadog-agent-sysprobe-exp.service",
@@ -55,6 +55,16 @@ service_srcs = [
     "tmpl/gen/oci/datadog-agent.service",
 ]
 
+# Only :embedded embeds these; keep them out of service_srcs so tmpl_test's
+# service_srcs + glob(nocap/**) does not list duplicate embedsrc labels.
+# keep
+ddot_nocap_yaml_embedsrcs = [
+    "tmpl/gen/debrpm-nocap/datadog-agent-ddot-exp.yaml",
+    "tmpl/gen/debrpm-nocap/datadog-agent-ddot.yaml",
+    "tmpl/gen/oci-nocap/datadog-agent-ddot-exp.yaml",
+    "tmpl/gen/oci-nocap/datadog-agent-ddot.yaml",
+]
+
 go_library(
     name = "embedded",
     srcs = ["embed.go"],
@@ -62,7 +72,7 @@ go_library(
         "scripts/dd-cleanup",
         "scripts/dd-container-install",
         "scripts/dd-host-install",
-    ] + service_srcs,  # keep
+    ] + service_srcs + ddot_nocap_yaml_embedsrcs,  # keep
     importpath = "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/embedded",
     visibility = ["//visibility:public"],
 )
@@ -78,7 +88,7 @@ go_library(
         "tmpl/datadog-agent-ddot.yaml.tmpl",
         "tmpl/datadog-agent-installer.service.tmpl",
         "tmpl/datadog-agent-process.service.tmpl",
-        "tmpl/datadog-agent-procmgrd.service.tmpl",
+        "tmpl/datadog-agent-procmgr.service.tmpl",
         "tmpl/datadog-agent-security.service.tmpl",
         "tmpl/datadog-agent-sysprobe.service.tmpl",
         "tmpl/datadog-agent-trace.service.tmpl",

--- a/pkg/fleet/installer/packages/embedded/embed.go
+++ b/pkg/fleet/installer/packages/embedded/embed.go
@@ -35,6 +35,30 @@ var systemdUnits embed.FS
 //go:embed tmpl/gen/debrpm/datadog-agent-ddot.yaml
 var DDOTProcessConfig string
 
+//go:embed tmpl/gen/debrpm/datadog-agent-ddot.yaml
+//go:embed tmpl/gen/debrpm/datadog-agent-ddot-exp.yaml
+//go:embed tmpl/gen/debrpm-nocap/datadog-agent-ddot.yaml
+//go:embed tmpl/gen/debrpm-nocap/datadog-agent-ddot-exp.yaml
+//go:embed tmpl/gen/oci/datadog-agent-ddot.yaml
+//go:embed tmpl/gen/oci/datadog-agent-ddot-exp.yaml
+//go:embed tmpl/gen/oci-nocap/datadog-agent-ddot.yaml
+//go:embed tmpl/gen/oci-nocap/datadog-agent-ddot-exp.yaml
+var ddotProcessYAML embed.FS
+
+// GetDDOTProcessConfig returns embedded DDOT extension process YAML (OCI or deb/rpm layout).
+func GetDDOTProcessConfig(unitType SystemdUnitType, stable bool, ambiantCapabilitiesSupported bool) ([]byte, error) {
+	dir := string(unitType)
+	if !ambiantCapabilitiesSupported {
+		dir += "-nocap"
+	}
+	exp := ""
+	if !stable {
+		exp = "-exp"
+	}
+	name := "datadog-agent-ddot" + exp + ".yaml"
+	return ddotProcessYAML.ReadFile(filepath.Join("tmpl/gen", dir, name))
+}
+
 // SystemdUnitType is the type of systemd unit.
 type SystemdUnitType string
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-procmgr.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-procmgr.service.tmpl
@@ -3,12 +3,12 @@
 Description=Datadog Process Manager Daemon
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
-Conflicts=datadog-agent-exp.service datadog-agent-procmgrd-exp.service
+Conflicts=datadog-agent-exp.service datadog-agent-procmgr-exp.service
 {{- else}}
 Description=Datadog Process Manager Daemon Experiment
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
-Conflicts=datadog-agent.service datadog-agent-procmgrd.service
+Conflicts=datadog-agent.service datadog-agent-procmgr.service
 {{- end}}
 ConditionPathExists={{.InstallDir}}/embedded/bin/dd-procmgrd
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent.service.tmpl
@@ -3,12 +3,12 @@
 Description=Datadog Agent
 After=network.target
 Conflicts=datadog-agent-exp.service
-Wants=datadog-agent-installer.service datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service datadog-agent-data-plane.service datadog-agent-ddot.service datadog-agent-action.service datadog-agent-procmgrd.service
+Wants=datadog-agent-installer.service datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service datadog-agent-data-plane.service datadog-agent-ddot.service datadog-agent-action.service datadog-agent-procmgr.service
 {{- else}}
 Description=Datadog Agent Experiment
 After=network.target
 Conflicts=datadog-agent.service
-Wants=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service datadog-agent-data-plane-exp.service datadog-agent-ddot-exp.service datadog-agent-action-exp.service datadog-agent-procmgrd-exp.service
+Wants=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service datadog-agent-data-plane-exp.service datadog-agent-ddot-exp.service datadog-agent-action-exp.service datadog-agent-procmgr-exp.service
 OnFailure=datadog-agent.service
 Before=datadog-agent.service
 {{- end}}

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-exp.service
@@ -2,7 +2,7 @@
 Description=Datadog Agent Experiment
 After=network.target
 Conflicts=datadog-agent.service
-Wants=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service datadog-agent-data-plane-exp.service datadog-agent-ddot-exp.service datadog-agent-action-exp.service datadog-agent-procmgrd-exp.service
+Wants=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service datadog-agent-data-plane-exp.service datadog-agent-ddot-exp.service datadog-agent-action-exp.service datadog-agent-procmgr-exp.service
 OnFailure=datadog-agent.service
 Before=datadog-agent.service
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-procmgr-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-procmgr-exp.service
@@ -2,17 +2,17 @@
 Description=Datadog Process Manager Daemon Experiment
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
-Conflicts=datadog-agent.service datadog-agent-procmgrd.service
-ConditionPathExists=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/dd-procmgrd
+Conflicts=datadog-agent.service datadog-agent-procmgr.service
+ConditionPathExists=/opt/datadog-agent/embedded/bin/dd-procmgrd
 
 [Service]
 Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_PM_CONFIG_DIR=/opt/datadog-packages/datadog-agent/experiment/processes.d"
+Environment="DD_PM_CONFIG_DIR=/opt/datadog-agent/processes.d"
 RuntimeDirectory=datadog-procmgrd
-ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/dd-procmgrd
+ExecStart=/opt/datadog-agent/embedded/bin/dd-procmgrd
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-procmgr.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-procmgr.service
@@ -2,7 +2,7 @@
 Description=Datadog Process Manager Daemon
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
-Conflicts=datadog-agent-exp.service datadog-agent-procmgrd-exp.service
+Conflicts=datadog-agent-exp.service datadog-agent-procmgr-exp.service
 ConditionPathExists=/opt/datadog-agent/embedded/bin/dd-procmgrd
 
 [Service]

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent.service
@@ -2,7 +2,7 @@
 Description=Datadog Agent
 After=network.target
 Conflicts=datadog-agent-exp.service
-Wants=datadog-agent-installer.service datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service datadog-agent-data-plane.service datadog-agent-ddot.service datadog-agent-action.service datadog-agent-procmgrd.service
+Wants=datadog-agent-installer.service datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service datadog-agent-data-plane.service datadog-agent-ddot.service datadog-agent-action.service datadog-agent-procmgr.service
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-exp.service
@@ -2,7 +2,7 @@
 Description=Datadog Agent Experiment
 After=network.target
 Conflicts=datadog-agent.service
-Wants=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service datadog-agent-data-plane-exp.service datadog-agent-ddot-exp.service datadog-agent-action-exp.service datadog-agent-procmgrd-exp.service
+Wants=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service datadog-agent-data-plane-exp.service datadog-agent-ddot-exp.service datadog-agent-action-exp.service datadog-agent-procmgr-exp.service
 OnFailure=datadog-agent.service
 Before=datadog-agent.service
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-procmgr-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-procmgr-exp.service
@@ -2,17 +2,17 @@
 Description=Datadog Process Manager Daemon Experiment
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
-Conflicts=datadog-agent.service datadog-agent-procmgrd.service
-ConditionPathExists=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/dd-procmgrd
+Conflicts=datadog-agent.service datadog-agent-procmgr.service
+ConditionPathExists=/opt/datadog-agent/embedded/bin/dd-procmgrd
 
 [Service]
 Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_PM_CONFIG_DIR=/opt/datadog-packages/datadog-agent/experiment/processes.d"
+Environment="DD_PM_CONFIG_DIR=/opt/datadog-agent/processes.d"
 RuntimeDirectory=datadog-procmgrd
-ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/dd-procmgrd
+ExecStart=/opt/datadog-agent/embedded/bin/dd-procmgrd
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-procmgr.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-procmgr.service
@@ -2,7 +2,7 @@
 Description=Datadog Process Manager Daemon
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
-Conflicts=datadog-agent-exp.service datadog-agent-procmgrd-exp.service
+Conflicts=datadog-agent-exp.service datadog-agent-procmgr-exp.service
 ConditionPathExists=/opt/datadog-agent/embedded/bin/dd-procmgrd
 
 [Service]

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent.service
@@ -2,7 +2,7 @@
 Description=Datadog Agent
 After=network.target
 Conflicts=datadog-agent-exp.service
-Wants=datadog-agent-installer.service datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service datadog-agent-data-plane.service datadog-agent-ddot.service datadog-agent-action.service datadog-agent-procmgrd.service
+Wants=datadog-agent-installer.service datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service datadog-agent-data-plane.service datadog-agent-ddot.service datadog-agent-action.service datadog-agent-procmgr.service
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-exp.service
@@ -2,7 +2,7 @@
 Description=Datadog Agent Experiment
 After=network.target
 Conflicts=datadog-agent.service
-Wants=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service datadog-agent-data-plane-exp.service datadog-agent-ddot-exp.service datadog-agent-action-exp.service datadog-agent-procmgrd-exp.service
+Wants=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service datadog-agent-data-plane-exp.service datadog-agent-ddot-exp.service datadog-agent-action-exp.service datadog-agent-procmgr-exp.service
 OnFailure=datadog-agent.service
 Before=datadog-agent.service
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-procmgr-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-procmgr-exp.service
@@ -2,17 +2,17 @@
 Description=Datadog Process Manager Daemon Experiment
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
-Conflicts=datadog-agent.service datadog-agent-procmgrd.service
-ConditionPathExists=/opt/datadog-agent/embedded/bin/dd-procmgrd
+Conflicts=datadog-agent.service datadog-agent-procmgr.service
+ConditionPathExists=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/dd-procmgrd
 
 [Service]
 Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_PM_CONFIG_DIR=/opt/datadog-agent/processes.d"
+Environment="DD_PM_CONFIG_DIR=/opt/datadog-packages/datadog-agent/experiment/processes.d"
 RuntimeDirectory=datadog-procmgrd
-ExecStart=/opt/datadog-agent/embedded/bin/dd-procmgrd
+ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/dd-procmgrd
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-procmgr.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-procmgr.service
@@ -2,7 +2,7 @@
 Description=Datadog Process Manager Daemon
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
-Conflicts=datadog-agent-exp.service datadog-agent-procmgrd-exp.service
+Conflicts=datadog-agent-exp.service datadog-agent-procmgr-exp.service
 ConditionPathExists=/opt/datadog-packages/datadog-agent/stable/embedded/bin/dd-procmgrd
 
 [Service]

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent.service
@@ -2,7 +2,7 @@
 Description=Datadog Agent
 After=network.target
 Conflicts=datadog-agent-exp.service
-Wants=datadog-agent-installer.service datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service datadog-agent-data-plane.service datadog-agent-ddot.service datadog-agent-action.service datadog-agent-procmgrd.service
+Wants=datadog-agent-installer.service datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service datadog-agent-data-plane.service datadog-agent-ddot.service datadog-agent-action.service datadog-agent-procmgr.service
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-exp.service
@@ -2,7 +2,7 @@
 Description=Datadog Agent Experiment
 After=network.target
 Conflicts=datadog-agent.service
-Wants=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service datadog-agent-data-plane-exp.service datadog-agent-ddot-exp.service datadog-agent-action-exp.service datadog-agent-procmgrd-exp.service
+Wants=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service datadog-agent-data-plane-exp.service datadog-agent-ddot-exp.service datadog-agent-action-exp.service datadog-agent-procmgr-exp.service
 OnFailure=datadog-agent.service
 Before=datadog-agent.service
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-procmgr-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-procmgr-exp.service
@@ -2,17 +2,17 @@
 Description=Datadog Process Manager Daemon Experiment
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
-Conflicts=datadog-agent.service datadog-agent-procmgrd.service
-ConditionPathExists=/opt/datadog-agent/embedded/bin/dd-procmgrd
+Conflicts=datadog-agent.service datadog-agent-procmgr.service
+ConditionPathExists=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/dd-procmgrd
 
 [Service]
 Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_PM_CONFIG_DIR=/opt/datadog-agent/processes.d"
+Environment="DD_PM_CONFIG_DIR=/opt/datadog-packages/datadog-agent/experiment/processes.d"
 RuntimeDirectory=datadog-procmgrd
-ExecStart=/opt/datadog-agent/embedded/bin/dd-procmgrd
+ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/dd-procmgrd
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-procmgr.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-procmgr.service
@@ -2,7 +2,7 @@
 Description=Datadog Process Manager Daemon
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
-Conflicts=datadog-agent-exp.service datadog-agent-procmgrd-exp.service
+Conflicts=datadog-agent-exp.service datadog-agent-procmgr-exp.service
 ConditionPathExists=/opt/datadog-packages/datadog-agent/stable/embedded/bin/dd-procmgrd
 
 [Service]

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent.service
@@ -2,7 +2,7 @@
 Description=Datadog Agent
 After=network.target
 Conflicts=datadog-agent-exp.service
-Wants=datadog-agent-installer.service datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service datadog-agent-data-plane.service datadog-agent-ddot.service datadog-agent-action.service datadog-agent-procmgrd.service
+Wants=datadog-agent-installer.service datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service datadog-agent-data-plane.service datadog-agent-ddot.service datadog-agent-action.service datadog-agent-procmgr.service
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/main.go
+++ b/pkg/fleet/installer/packages/embedded/tmpl/main.go
@@ -121,7 +121,7 @@ func mustRenderYAMLConfig(name string, data systemdTemplateData) []byte {
 	return mustRenderTemplate(name+".tmpl", data, false)
 }
 
-func systemdUnits(stableData, expData systemdTemplateData, ambiantCapabilitiesSupported bool) map[string][]byte {
+func systemdUnits(stableData, expData systemdTemplateData, ambiantCapabilitiesSupported, withDDOTProcessYAML bool) map[string][]byte {
 	units := map[string][]byte{
 		"datadog-agent.service":                mustReadSystemdUnit("datadog-agent.service", stableData, ambiantCapabilitiesSupported),
 		"datadog-agent-exp.service":            mustReadSystemdUnit("datadog-agent.service", expData, ambiantCapabilitiesSupported),
@@ -141,12 +141,12 @@ func systemdUnits(stableData, expData systemdTemplateData, ambiantCapabilitiesSu
 		"datadog-agent-ddot-exp.service":       mustReadSystemdUnit("datadog-agent-ddot.service", expData, ambiantCapabilitiesSupported),
 		"datadog-agent-action.service":         mustReadSystemdUnit("datadog-agent-action.service", stableData, ambiantCapabilitiesSupported),
 		"datadog-agent-action-exp.service":     mustReadSystemdUnit("datadog-agent-action.service", expData, ambiantCapabilitiesSupported),
-		"datadog-agent-procmgrd.service":       mustReadSystemdUnit("datadog-agent-procmgrd.service", stableData, ambiantCapabilitiesSupported),
-		"datadog-agent-procmgrd-exp.service":   mustReadSystemdUnit("datadog-agent-procmgrd.service", expData, ambiantCapabilitiesSupported),
-
-		// dd-procmgrd process configs
-		"datadog-agent-ddot.yaml":     mustRenderYAMLConfig("datadog-agent-ddot.yaml", stableData),
-		"datadog-agent-ddot-exp.yaml": mustRenderYAMLConfig("datadog-agent-ddot.yaml", expData),
+		"datadog-agent-procmgr.service":        mustReadSystemdUnit("datadog-agent-procmgr.service", stableData, ambiantCapabilitiesSupported),
+		"datadog-agent-procmgr-exp.service":    mustReadSystemdUnit("datadog-agent-procmgr.service", expData, ambiantCapabilitiesSupported),
+	}
+	if withDDOTProcessYAML {
+		units["datadog-agent-ddot.yaml"] = mustRenderYAMLConfig("datadog-agent-ddot.yaml", stableData)
+		units["datadog-agent-ddot-exp.yaml"] = mustRenderYAMLConfig("datadog-agent-ddot.yaml", expData)
 	}
 	return units
 }
@@ -182,9 +182,9 @@ var (
 		Stable:           false,
 	}
 
-	systemdUnitsOCI    = systemdUnits(stableDataOCI, expDataOCI, true)
-	systemdUnitsDebRpm = systemdUnits(stableDataDebRpm, expDataDebRpm, true)
+	systemdUnitsOCI    = systemdUnits(stableDataOCI, expDataOCI, true, true)
+	systemdUnitsDebRpm = systemdUnits(stableDataDebRpm, expDataDebRpm, true, true)
 
-	systemdUnitsOCILegacyKernel    = systemdUnits(stableDataOCI, expDataOCI, false)
-	systemdUnitsDebRpmLegacyKernel = systemdUnits(stableDataDebRpm, expDataDebRpm, false)
+	systemdUnitsOCILegacyKernel    = systemdUnits(stableDataOCI, expDataOCI, false, true)
+	systemdUnitsDebRpmLegacyKernel = systemdUnits(stableDataDebRpm, expDataDebRpm, false, true)
 )

--- a/pkg/fleet/installer/packages/packages.go
+++ b/pkg/fleet/installer/packages/packages.go
@@ -180,6 +180,7 @@ type HookContext struct {
 	Upgrade         bool        `json:"upgrade"`
 	WindowsArgs     []string    `json:"windows_args"`
 	Extension       string      `json:"extension"`
+	IsExperiment    bool        `json:"is_experiment"`
 }
 
 // StartSpan starts a new span with the given operation name.
@@ -256,14 +257,15 @@ func (h *hooksCLI) callHook(ctx context.Context, experiment bool, pkg string, na
 		}
 	}
 	hookCtx := HookContext{
-		Context:     ctx,
-		Hook:        name,
-		Package:     pkg,
-		PackagePath: pkgPath,
-		PackageType: packageType,
-		Upgrade:     upgrade,
-		WindowsArgs: windowsArgs,
-		Extension:   extension,
+		Context:      ctx,
+		Hook:         name,
+		Package:      pkg,
+		PackagePath:  pkgPath,
+		PackageType:  packageType,
+		Upgrade:      upgrade,
+		WindowsArgs:  windowsArgs,
+		Extension:    extension,
+		IsExperiment: experiment,
 	}
 	serializedHookCtx, err := json.Marshal(hookCtx)
 	if err != nil {

--- a/pkg/fleet/installer/packages/service/service.go
+++ b/pkg/fleet/installer/packages/service/service.go
@@ -36,6 +36,12 @@ func GetServiceManagerType() Type {
 	return serviceManagerType
 }
 
+// IsSystemdHost reports whether systemctl is available on the host.
+func IsSystemdHost() bool {
+	_, err := exec.LookPath("systemctl")
+	return err == nil
+}
+
 func getServiceManagerType() Type {
 	_, err := exec.LookPath("systemctl")
 	if err == nil {

--- a/test/new-e2e/internal/procmgrtest/BUILD.bazel
+++ b/test/new-e2e/internal/procmgrtest/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "procmgrtest",
+    srcs = ["process.go"],
+    importpath = "github.com/DataDog/datadog-agent/test/new-e2e/internal/procmgrtest",
+    visibility = ["//test/new-e2e:__subpackages__"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/test/new-e2e/internal/procmgrtest/process.go
+++ b/test/new-e2e/internal/procmgrtest/process.go
@@ -1,0 +1,263 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package procmgrtest provides new-e2e helpers for asserting processes managed by
+// dd-procmgr (describe output, /proc/<pid>/exe, optional expected binary paths).
+package procmgrtest
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	DDOTProcessName = "datadog-agent-ddot"
+
+	ddotProcmgrYAMLFileName = "datadog-agent-ddot.yaml"
+	// StableDDOTProcmgrYAMLDeb is the stable processes.d DDOT file on classic deb/rpm installs.
+	StableDDOTProcmgrYAMLDeb = "/opt/datadog-agent/processes.d/" + ddotProcmgrYAMLFileName
+	// StableDDOTProcmgrYAMLOCI is the stable processes.d DDOT file on fleet OCI agent installs.
+	StableDDOTProcmgrYAMLOCI = "/opt/datadog-packages/datadog-agent/stable/processes.d/" + ddotProcmgrYAMLFileName
+
+	DDOTOtelAgentExtensionBinary            = "/opt/datadog-agent/ext/ddot/embedded/bin/otel-agent"
+	DDOTOtelAgentFleetStableExtensionBinary = "/opt/datadog-packages/datadog-agent/stable/ext/ddot/embedded/bin/otel-agent"
+	DDOTOtelAgentFleetPackageBinary         = "/opt/datadog-packages/datadog-agent-ddot/stable/embedded/bin/otel-agent"
+
+	CLIBinDefault     = "/opt/datadog-agent/embedded/bin/dd-procmgr"
+	CLIBinFleetStable = "/opt/datadog-packages/datadog-agent/stable/embedded/bin/dd-procmgr"
+
+	ProcessStateRunning               = "Running"
+	ProcessStateStopped               = "Stopped"
+	waitForProcessTimeout             = 90 * time.Second
+	waitForProcessPollInterval        = 2 * time.Second
+	waitForProcessRunningStableWindow = 5 * time.Second
+	waitForProcessRunningStablePoll   = 500 * time.Millisecond
+)
+
+// CLIBinForLinuxHost returns CLIBinFleetStable when that binary is executable on the host,
+// otherwise CLIBinDefault (classic deb/rpm layout). Staging install-script suites often use
+// /opt/datadog-agent only until an OCI experiment is promoted.
+func CLIBinForLinuxHost(t *testing.T, executor CommandExecutor) string {
+	t.Helper()
+	cmd := fmt.Sprintf(`if sudo test -x %q; then echo %q; elif sudo test -x %q; then echo %q; else echo ""; fi`,
+		CLIBinFleetStable, CLIBinFleetStable, CLIBinDefault, CLIBinDefault)
+	out, err := executor.ExecuteCommand(cmd)
+	require.NoError(t, err)
+	path := strings.TrimSpace(out)
+	require.NotEmpty(t, path, "dd-procmgr CLI not found (checked %s and %s)", CLIBinFleetStable, CLIBinDefault)
+	return path
+}
+
+// StableDDOTProcmgrYAMLPath returns the on-disk path to stable DDOT procmgr YAML, preferring
+// the fleet OCI layout when present, otherwise the classic deb/rpm path.
+func StableDDOTProcmgrYAMLPath(t *testing.T, executor CommandExecutor) string {
+	t.Helper()
+	cmd := fmt.Sprintf(`if sudo test -f %q; then echo %q; elif sudo test -f %q; then echo %q; else echo ""; fi`,
+		StableDDOTProcmgrYAMLOCI, StableDDOTProcmgrYAMLOCI, StableDDOTProcmgrYAMLDeb, StableDDOTProcmgrYAMLDeb)
+	out, err := executor.ExecuteCommand(cmd)
+	require.NoError(t, err)
+	path := strings.TrimSpace(out)
+	require.NotEmpty(t, path, "datadog-agent-ddot.yaml not found (checked %s and %s)", StableDDOTProcmgrYAMLOCI, StableDDOTProcmgrYAMLDeb)
+	return path
+}
+
+// CommandExecutor executes a command on the remote host.
+type CommandExecutor interface {
+	ExecuteCommand(command string) (string, error)
+}
+
+type WaitForProcessArgs struct {
+	ProcmgrCLIBin  string
+	ProcessName    string
+	ExpectedBinary string
+	DesiredState   string
+}
+
+type WaitForProcessResult struct {
+	PID      string
+	Restarts int
+}
+
+// WaitForProcess polls dd-procmgr describe until State matches DesiredState and returns
+// a snapshot result. Restarts is always populated; PID is only populated for
+// ProcessStateRunning. For ProcessStateRunning, when ExpectedBinary is set, describe
+// Command must equal it. The describe Command path is canonicalized with readlink -f and
+// must match readlink -f /proc/<pid>/exe (PID from describe).
+// For Running, success additionally requires State and PID to stay unchanged for
+// waitForProcessRunningStableWindow inside one Eventually callback (otherwise the callback
+// returns false and Eventually retries—e.g. a brief Running before a crash does not pass).
+func WaitForProcess(t *testing.T, executor CommandExecutor, args WaitForProcessArgs) WaitForProcessResult {
+	t.Helper()
+	require.NotEmpty(t, args.ProcmgrCLIBin, "WaitForProcessArgs.ProcmgrCLIBin must be set")
+	require.NotEmpty(t, args.DesiredState, "WaitForProcessArgs.DesiredState must be set")
+
+	describeCmd := fmt.Sprintf(`sudo -u dd-agent -- %q describe %q`, args.ProcmgrCLIBin, args.ProcessName)
+	desiredState := args.DesiredState
+
+	var result WaitForProcessResult
+	require.Eventually(t, func() bool {
+		out, err := executor.ExecuteCommand(describeCmd)
+		if err != nil {
+			t.Logf("WaitForProcess: dd-procmgr describe cmd=%q err=%v\noutput:\n%s", describeCmd, err, out)
+			return false
+		}
+		if st := fieldValue(out, "State"); st != desiredState {
+			t.Logf("WaitForProcess: dd-procmgr describe cmd=%q State=%q (want %s)\noutput:\n%s", describeCmd, st, desiredState, out)
+			return false
+		}
+		descCmd := fieldValue(out, "Command")
+		if args.ExpectedBinary != "" {
+			if descCmd != args.ExpectedBinary {
+				t.Logf("WaitForProcess: dd-procmgr describe cmd=%q unexpected Command field got=%q want=%q\noutput:\n%s", describeCmd, descCmd, args.ExpectedBinary, out)
+				return false
+			}
+		}
+		if desiredState != ProcessStateRunning {
+			result = WaitForProcessResult{
+				Restarts: restartsFromDescribe(out),
+			}
+			return true
+		}
+
+		r, ok := resolveRunningPIDFromDescribe(t, executor, describeCmd, out)
+		if !ok {
+			return false
+		}
+		if !confirmStableRunningPID(t, executor, describeCmd, desiredState, r.PID) {
+			return false
+		}
+		result = r
+		return true
+	}, waitForProcessTimeout, waitForProcessPollInterval, fmt.Sprintf("process %q should be %s via dd-procmgr describe", args.ProcessName, desiredState))
+	return result
+}
+
+// WaitForDDOTRunning polls until process datadog-agent-ddot is Running, using CLIBinForLinuxHost
+// and validating describe Command against expectedBinary (e.g. DDOTOtelAgentExtensionBinary vs
+// DDOTOtelAgentFleetPackageBinary for extension vs standalone ddot-package installs).
+func WaitForDDOTRunning(t *testing.T, executor CommandExecutor, expectedBinary string) WaitForProcessResult {
+	t.Helper()
+	cli := CLIBinForLinuxHost(t, executor)
+	require.NotEmpty(t, expectedBinary,
+		"expectedBinary must be set (use DDOTOtelAgentExtensionBinary, DDOTOtelAgentFleetStableExtensionBinary, DDOTOtelAgentFleetPackageBinary)")
+	return WaitForProcess(t, executor, WaitForProcessArgs{
+		ProcmgrCLIBin:  cli,
+		ProcessName:    DDOTProcessName,
+		ExpectedBinary: expectedBinary,
+		DesiredState:   ProcessStateRunning,
+	})
+}
+
+// confirmStableRunningPID returns true iff describe shows wantState and wantPID on every
+// poll for waitForProcessRunningStableWindow. Any drift returns false so the caller can
+// retry (e.g. DDOT may briefly report Running before a failed restart settles on a stable PID).
+func confirmStableRunningPID(t *testing.T, executor CommandExecutor, describeCmd, wantState, wantPID string) bool {
+	t.Helper()
+	start := time.Now()
+	for time.Since(start) < waitForProcessRunningStableWindow {
+		out, err := executor.ExecuteCommand(describeCmd)
+		if err != nil {
+			t.Logf("confirmStableRunningPID: describe err=%v\n%s", err, out)
+			return false
+		}
+		if st := fieldValue(out, "State"); st != wantState {
+			t.Logf("confirmStableRunningPID: State=%q want %q", st, wantState)
+			return false
+		}
+		if pid := fieldValue(out, "PID"); pid != wantPID {
+			t.Logf("confirmStableRunningPID: PID=%q want %q", pid, wantPID)
+			return false
+		}
+		time.Sleep(waitForProcessRunningStablePoll)
+	}
+	return true
+}
+
+func resolveRunningPIDFromDescribe(
+	t *testing.T,
+	executor CommandExecutor,
+	describeCmd, describeOut string,
+) (WaitForProcessResult, bool) {
+	t.Helper()
+	cmd, cmdExe, ok := resolveCommandExeFromDescribe(t, executor, describeCmd, describeOut)
+	if !ok {
+		return WaitForProcessResult{}, false
+	}
+	pid, ok := resolveRunningPIDFromProc(t, executor, describeCmd, describeOut, cmd, cmdExe)
+	if !ok {
+		return WaitForProcessResult{}, false
+	}
+	return WaitForProcessResult{
+		PID:      pid,
+		Restarts: restartsFromDescribe(describeOut),
+	}, true
+}
+
+func resolveCommandExeFromDescribe(
+	t *testing.T,
+	executor CommandExecutor,
+	describeCmd, describeOut string,
+) (string, string, bool) {
+	t.Helper()
+	cmd := fieldValue(describeOut, "Command")
+	cmdExe, err := executor.ExecuteCommand(fmt.Sprintf("sudo readlink -f %q", cmd))
+	if err != nil {
+		t.Logf("resolveCommandExeFromDescribe: describe cmd=%q readlink -f %q (Command from describe) err=%v\n%s", describeCmd, cmd, err, cmdExe)
+		return "", "", false
+	}
+	cmdExe = strings.TrimSpace(cmdExe)
+	if cmdExe == "" {
+		t.Logf("resolveCommandExeFromDescribe: describe cmd=%q readlink -f %q returned empty path (Command from describe)", describeCmd, cmd)
+		return "", "", false
+	}
+	return cmd, cmdExe, true
+}
+
+func resolveRunningPIDFromProc(
+	t *testing.T,
+	executor CommandExecutor,
+	describeCmd, describeOut, cmd, cmdExe string,
+) (string, bool) {
+	t.Helper()
+	pid := fieldValue(describeOut, "PID")
+	if pid == "" || pid == "-" {
+		t.Logf("resolveRunningPIDFromProc: dd-procmgr describe cmd=%q missing PID (got %q)\noutput:\n%s", describeCmd, pid, describeOut)
+		return "", false
+	}
+	exeOut, err := executor.ExecuteCommand("sudo readlink -f /proc/" + pid + "/exe")
+	if err != nil {
+		t.Logf("resolveRunningPIDFromProc: readlink -f /proc/%s/exe err=%v\n%s", pid, err, exeOut)
+		return "", false
+	}
+	if strings.TrimSpace(exeOut) != cmdExe {
+		t.Logf("resolveRunningPIDFromProc: readlink -f /proc/%s/exe got=%q want=%q (canonical Command %q from dd-procmgr describe)\ndd-procmgr describe output:\n%s", pid, strings.TrimSpace(exeOut), cmdExe, cmd, describeOut)
+		return "", false
+	}
+	return pid, true
+}
+
+func restartsFromDescribe(describeOut string) int {
+	n, err := strconv.Atoi(fieldValue(describeOut, "Restarts"))
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func fieldValue(output, label string) string {
+	needle := label + ":"
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, needle) {
+			return strings.TrimSpace(trimmed[len(needle):])
+		}
+	}
+	return ""
+}

--- a/test/new-e2e/internal/procmgrtest/process.go
+++ b/test/new-e2e/internal/procmgrtest/process.go
@@ -55,6 +55,20 @@ func CLIBinForLinuxHost(t *testing.T, executor CommandExecutor) string {
 	return path
 }
 
+// DDOTOtelAgentExtensionBinaryForHost returns the extension otel-agent path for fleet stable or deb layout.
+func DDOTOtelAgentExtensionBinaryForHost(t *testing.T, executor CommandExecutor) string {
+	t.Helper()
+	cmd := fmt.Sprintf(`if sudo test -x %q; then echo %q; elif sudo test -x %q; then echo %q; else echo ""; fi`,
+		DDOTOtelAgentFleetStableExtensionBinary, DDOTOtelAgentFleetStableExtensionBinary,
+		DDOTOtelAgentExtensionBinary, DDOTOtelAgentExtensionBinary)
+	out, err := executor.ExecuteCommand(cmd)
+	require.NoError(t, err)
+	path := strings.TrimSpace(out)
+	require.NotEmpty(t, path, "otel-agent extension binary not found (checked %s and %s)",
+		DDOTOtelAgentFleetStableExtensionBinary, DDOTOtelAgentExtensionBinary)
+	return path
+}
+
 // StableDDOTProcmgrYAMLPath returns the on-disk path to stable DDOT procmgr YAML, preferring
 // the fleet OCI layout when present, otherwise the classic deb/rpm path.
 func StableDDOTProcmgrYAMLPath(t *testing.T, executor CommandExecutor) string {

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
@@ -24,10 +24,11 @@ import (
 )
 
 const (
-	linuxDaemonBin = "/opt/datadog-agent/embedded/bin/dd-procmgrd"
-	linuxCLIBin    = "/opt/datadog-agent/embedded/bin/dd-procmgr"
-	linuxSocket    = "/var/run/datadog-procmgrd/dd-procmgrd.sock"
-	linuxConfigDir = "/opt/datadog-agent/processes.d"
+	linuxDaemonBin   = "/opt/datadog-agent/embedded/bin/dd-procmgrd"
+	linuxCLIBin      = "/opt/datadog-agent/embedded/bin/dd-procmgr"
+	linuxSocket      = "/var/run/datadog-procmgrd/dd-procmgrd.sock"
+	linuxConfigDir   = "/opt/datadog-agent/processes.d"
+	linuxProcmgrUnit = "datadog-agent-procmgr.service"
 
 	ddotPkgBinaryPath = "/opt/datadog-agent/embedded/bin/otel-agent"
 	ddotExtBinaryPath = "/opt/datadog-agent/ext/ddot/embedded/bin/otel-agent"
@@ -56,7 +57,7 @@ var linuxPlatform = platformConfig{
 	testProcessYAML:   linuxTestProcessConfig,
 	missingBinaryYAML: linuxMissingBinaryConfig,
 	checkBinCmd:       func(path string) string { return "test -f " + path },
-	checkSvcRunning:   "systemctl is-active datadog-agent-procmgrd",
+	checkSvcRunning:   "systemctl is-active datadog-agent-procmgr",
 	svcRunningOutput:  "active",
 	cliCmd:            func(args string) string { return linuxCLIBin + " " + args },
 }
@@ -138,7 +139,7 @@ func (s *procmgrLinuxSuite) installRealDDOT() bool {
 	s.Env().RemoteHost.MustExecute("sudo chown dd-agent:dd-agent /etc/datadog-agent/otel-config.yaml && sudo chmod 640 /etc/datadog-agent/otel-config.yaml")
 
 	s.Env().RemoteHost.MustExecute("sudo systemctl restart datadog-agent.service")
-	s.Env().RemoteHost.MustExecute("sudo systemctl restart datadog-agent-procmgrd")
+	s.Env().RemoteHost.MustExecute("sudo systemctl restart " + linuxProcmgrUnit)
 
 	return true
 }
@@ -150,11 +151,11 @@ func (s *procmgrLinuxSuite) TestDDOTProcessRunning() {
 
 	pidFileContent := strings.TrimSpace(
 		s.Env().RemoteHost.MustExecute("cat /opt/datadog-agent/run/otel-agent.pid"))
-	assert.Equal(s.T(), pid, pidFileContent, "PID file should match procmgrd-reported PID")
+	assert.Equal(s.T(), pid, pidFileContent, "PID file should match procmgr-reported PID")
 
 	unitState := strings.TrimSpace(
 		s.Env().RemoteHost.MustExecute("systemctl is-active datadog-agent-ddot.service || true"))
-	assert.NotEqual(s.T(), "active", unitState, "systemd unit should not be active; procmgrd manages DDOT")
+	assert.NotEqual(s.T(), "active", unitState, "systemd unit should not be active; procmgr manages DDOT")
 }
 
 func (s *procmgrLinuxSuite) TestDDOTRestartAfterKill() {

--- a/test/new-e2e/tests/installer/unix/package_agent_test.go
+++ b/test/new-e2e/tests/installer/unix/package_agent_test.go
@@ -36,6 +36,7 @@ const (
 	dataPlaneUnit   = "datadog-agent-data-plane.service"
 	dataPlaneUnitXP = "datadog-agent-data-plane-exp.service"
 	installerUnit   = "datadog-agent-installer.service"
+	procmgrUnit     = "datadog-agent-procmgr.service"
 )
 
 type packageAgentSuite struct {

--- a/test/new-e2e/tests/installer/unix/package_ddot_test.go
+++ b/test/new-e2e/tests/installer/unix/package_ddot_test.go
@@ -19,11 +19,16 @@ import (
 
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/internal/procmgrtest"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
 )
 
 type packageDDOTSuite struct {
 	packageBaseSuite
+}
+
+func (s *packageDDOTSuite) ExecuteCommand(command string) (string, error) {
+	return s.Env().RemoteHost.Execute(command)
 }
 
 func testDDOT(os e2eos.Descriptor, arch e2eos.Architecture, method InstallMethodOption) packageSuite {
@@ -66,25 +71,23 @@ func (s *packageDDOTSuite) RunInstallScript(params ...string) {
 }
 
 func (s *packageDDOTSuite) TestInstallDDOTInstallScript() {
-	// Install agent and DDOT together via environment variable
 	s.RunInstallScript("DD_REMOTE_UPDATES=true", "DD_OTELCOLLECTOR_ENABLED=true", envForceInstall("datadog-agent"))
 	defer s.Purge()
 
-	// Verify agent is installed
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
 
-	// Wait for services to be active
-	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit, ddotUnit)
+	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit, procmgrUnit)
+	procmgrtest.WaitForDDOTRunning(s.T(), s, procmgrtest.DDOTOtelAgentFleetStableExtensionBinary)
 
 	state := s.host.State()
 	s.assertCoreUnits(state, false)
-	s.assertDDOTUnits(state, false)
+	state.AssertUnitsLoaded(procmgrUnit)
+	state.AssertUnitsRunning(procmgrUnit)
+	state.AssertUnitsLoaded(ddotUnit)
+	state.AssertUnitsDead(ddotUnit)
 
-	// Verify configuration files exist
 	state.AssertFileExists("/etc/datadog-agent/datadog.yaml", 0640, "dd-agent", "dd-agent")
 	state.AssertFileExists("/etc/datadog-agent/otel-config.yaml", 0640, "dd-agent", "dd-agent")
-
-	// Verify otelcollector configuration is present in datadog.yaml
 	s.host.Run("sudo grep -q 'otelcollector:' /etc/datadog-agent/datadog.yaml")
 }
 

--- a/test/new-e2e/tests/installer/unix/package_ddot_test.go
+++ b/test/new-e2e/tests/installer/unix/package_ddot_test.go
@@ -77,7 +77,7 @@ func (s *packageDDOTSuite) TestInstallDDOTInstallScript() {
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
 
 	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit, procmgrUnit)
-	procmgrtest.WaitForDDOTRunning(s.T(), s, procmgrtest.DDOTOtelAgentExtensionBinaryForHost(s))
+	procmgrtest.WaitForDDOTRunning(s.T(), s, procmgrtest.DDOTOtelAgentExtensionBinaryForHost(s.T(), s))
 
 	state := s.host.State()
 	s.assertCoreUnits(state, false)

--- a/test/new-e2e/tests/installer/unix/package_ddot_test.go
+++ b/test/new-e2e/tests/installer/unix/package_ddot_test.go
@@ -77,7 +77,7 @@ func (s *packageDDOTSuite) TestInstallDDOTInstallScript() {
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
 
 	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit, procmgrUnit)
-	procmgrtest.WaitForDDOTRunning(s.T(), s, procmgrtest.DDOTOtelAgentFleetStableExtensionBinary)
+	procmgrtest.WaitForDDOTRunning(s.T(), s, procmgrtest.DDOTOtelAgentExtensionBinaryForHost(s))
 
 	state := s.host.State()
 	s.assertCoreUnits(state, false)


### PR DESCRIPTION
### What does this PR do?

- Migrates **`TestInstallDDOTInstallScript`** to expect DDOT as an **agent extension** under **dd-procmgr** (procmgr unit active, legacy `datadog-agent-ddot` unit inactive, `otel-agent` running via `dd-procmgr describe`).
- Adds **`procmgrtest`** helpers and `procmgrUnit`.

Installer changes to satisfy this test will land in **follow-up commits** on this branch.

### Motivation

E2E-first: define the install-script contract before/minimal installer work.

### Describe how you validated your changes

- `go test -c ./test/new-e2e/tests/installer/unix/...`

### Additional Notes

Follow-up commits: `processes.d` YAML + procmgr restart after extension install.