### PR TITLE
[AGENTCFG-806] bump non-core agent readiness timeout in configrefresh tests

### DIFF
--- a/test/new-e2e/tests/agent-configuration/configrefresh_nix_test.go
+++ b/test/new-e2e/tests/agent-configuration/configrefresh_nix_test.go
@@ -74,6 +74,9 @@ func (v *configRefreshLinuxSuite) TestConfigRefresh() {
 			agentclientparams.WithTraceAgentOnPort(apmReceiverPort),
 			agentclientparams.WithProcessAgentOnPort(processCmdPort),
 			agentclientparams.WithSecurityAgentOnPort(securityCmdPort),
+			// Default 1m readiness wait has timed out repeatedly here when
+			// trace/process-agent are slow to bind after an UpdateEnv re-provision.
+			agentclientparams.WithWaitForDuration(3*time.Minute),
 		)),
 	))
 
@@ -143,6 +146,9 @@ func (v *configRefreshLinuxSuite) TestConfigRefreshOverSocket() {
 			agentclientparams.WithTraceAgentOnPort(apmReceiverPort),
 			agentclientparams.WithProcessAgentOnPort(processCmdPort),
 			agentclientparams.WithSecurityAgentOnPort(securityCmdPort),
+			// Default 1m readiness wait has timed out repeatedly here when
+			// trace/process-agent are slow to bind after an UpdateEnv re-provision.
+			agentclientparams.WithWaitForDuration(3*time.Minute),
 		)),
 	))
 

--- a/test/new-e2e/tests/agent-configuration/configrefresh_nix_test.go
+++ b/test/new-e2e/tests/agent-configuration/configrefresh_nix_test.go
@@ -74,8 +74,6 @@ func (v *configRefreshLinuxSuite) TestConfigRefresh() {
 			agentclientparams.WithTraceAgentOnPort(apmReceiverPort),
 			agentclientparams.WithProcessAgentOnPort(processCmdPort),
 			agentclientparams.WithSecurityAgentOnPort(securityCmdPort),
-			// Default 1m readiness wait has timed out repeatedly here when
-			// trace/process-agent are slow to bind after an UpdateEnv re-provision.
 			agentclientparams.WithWaitForDuration(3*time.Minute),
 		)),
 	))
@@ -146,8 +144,6 @@ func (v *configRefreshLinuxSuite) TestConfigRefreshOverSocket() {
 			agentclientparams.WithTraceAgentOnPort(apmReceiverPort),
 			agentclientparams.WithProcessAgentOnPort(processCmdPort),
 			agentclientparams.WithSecurityAgentOnPort(securityCmdPort),
-			// Default 1m readiness wait has timed out repeatedly here when
-			// trace/process-agent are slow to bind after an UpdateEnv re-provision.
 			agentclientparams.WithWaitForDuration(3*time.Minute),
 		)),
 	))

--- a/test/new-e2e/tests/agent-configuration/configrefresh_win_test.go
+++ b/test/new-e2e/tests/agent-configuration/configrefresh_win_test.go
@@ -75,8 +75,6 @@ func (v *configRefreshWindowsSuite) TestConfigRefresh() {
 				agentclientparams.WithAuthTokenPath(authTokenFilePath),
 				agentclientparams.WithTraceAgentOnPort(apmReceiverPort),
 				agentclientparams.WithProcessAgentOnPort(processCmdPort),
-				// Default 1m readiness wait has timed out repeatedly here when
-				// trace/process-agent are slow to bind after an UpdateEnv re-provision.
 				agentclientparams.WithWaitForDuration(3*time.Minute),
 			)),
 	))

--- a/test/new-e2e/tests/agent-configuration/configrefresh_win_test.go
+++ b/test/new-e2e/tests/agent-configuration/configrefresh_win_test.go
@@ -75,6 +75,9 @@ func (v *configRefreshWindowsSuite) TestConfigRefresh() {
 				agentclientparams.WithAuthTokenPath(authTokenFilePath),
 				agentclientparams.WithTraceAgentOnPort(apmReceiverPort),
 				agentclientparams.WithProcessAgentOnPort(processCmdPort),
+				// Default 1m readiness wait has timed out repeatedly here when
+				// trace/process-agent are slow to bind after an UpdateEnv re-provision.
+				agentclientparams.WithWaitForDuration(3*time.Minute),
 			)),
 	))
 


### PR DESCRIPTION
## Summary

Bumps `agentclientparams.WithWaitForDuration` from the default 1m to 3m in the three `TestConfigRefresh*` methods (Linux+Windows). The default has hit its ceiling in this test family 9 times in the past 60 days at `waitForAgentsReady` (`e2e-framework/testing/utils/e2e/client/agent_client.go:142`), stalling on either trace-agent (`http://localhost:8126/info`) or process-agent (`https://localhost:6162/agent/status`) after an `UpdateEnv` re-provisioning. Sometimes the re-provision retries through a transient AWS S3 503, which leaves the non-core agents short of the 1m wait window.

## Linked Jira

[AGENTCFG-806](https://datadoghq.atlassian.net/browse/AGENTCFG-806) — original failure: pipeline 114795829, job 1707525806, 2026-05-22, `TestConfigRefreshLinuxSuite/TestConfigRefreshOverSocket`.

## Why scoped (not a framework default change)

Framework default applies to every E2E suite. No other suite has shown this symptom in the same window, so a global bump would slow failure detection elsewhere without evidence.

## Test plan

- [x] `dda inv linter.go --targets=./test/new-e2e/tests/agent-configuration` passes
- [x] CI E2E run of `new-e2e-agent-configuration` on this branch
- [x] No regression in pass duration on green runs (timeout is a ceiling, agents normally bind in seconds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AGENTCFG-806]: https://datadoghq.atlassian.net/browse/AGENTCFG-806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ