### PR TITLE
CONTP[1693] feat(autodiscovery): Enforce instrumentation check config provider priority

### DIFF
--- a/comp/core/autodiscovery/listeners/service.go
+++ b/comp/core/autodiscovery/listeners/service.go
@@ -148,8 +148,11 @@ func (s *WorkloadService) FilterTemplates(configs map[string]integration.Config)
 	// comp/core/autodiscovery/configresolver/configresolver.go
 	s.filterTemplatesEmptyOverrides(configs)
 	s.filterTemplatesOverriddenChecks(configs)
-	s.filterTemplatesInstrumentationOverFile(configs)
 	filterTemplatesMatched(s, configs)
+
+	// Runs after matching so only instrumentation configs that are actually
+	// bound to this service override file-based configs.
+	s.filterTemplatesInstrumentationOverFile(configs)
 
 	// Drop discovery templates when another config source already covers
 	// the same integration for this service. Runs after AD-identifier and
@@ -203,7 +206,7 @@ func (s *WorkloadService) filterTemplatesOverriddenChecks(configs map[string]int
 		}
 		for _, checkName := range s.checkNames {
 			if config.Name == checkName {
-				// Ignore config from file when the same check is activated on
+				// Ignore config from file or CRD when the same check is activated on
 				// the same service via other config providers (k8s annotations
 				// or container labels)
 				log.Debugf("Ignoring config from %s: the service %s overrides check %s",

--- a/comp/core/autodiscovery/listeners/service.go
+++ b/comp/core/autodiscovery/listeners/service.go
@@ -148,6 +148,7 @@ func (s *WorkloadService) FilterTemplates(configs map[string]integration.Config)
 	// comp/core/autodiscovery/configresolver/configresolver.go
 	s.filterTemplatesEmptyOverrides(configs)
 	s.filterTemplatesOverriddenChecks(configs)
+	s.filterTemplatesInstrumentationOverFile(configs)
 	filterTemplatesMatched(s, configs)
 
 	// Drop discovery templates when another config source already covers
@@ -197,8 +198,8 @@ func (s *WorkloadService) filterTemplatesEmptyOverrides(configs map[string]integ
 // labels/annotations specify a check of the same name.
 func (s *WorkloadService) filterTemplatesOverriddenChecks(configs map[string]integration.Config) {
 	for digest, config := range configs {
-		if config.Provider != names.File {
-			continue // only override file configs
+		if config.Provider != names.File && config.Provider != names.InstrumentationChecks {
+			continue // only override file & instrumentation configs
 		}
 		for _, checkName := range s.checkNames {
 			if config.Name == checkName {
@@ -209,6 +210,28 @@ func (s *WorkloadService) filterTemplatesOverriddenChecks(configs map[string]int
 					config.Source, s.GetServiceID(), config.Name)
 				delete(configs, digest)
 			}
+		}
+	}
+}
+
+// filterTemplatesInstrumentationOverFile drops file-based templates when an
+// instrumentation check of the same name exists, giving instrumentation checks
+// priority over file-based ones.
+func (s *WorkloadService) filterTemplatesInstrumentationOverFile(configs map[string]integration.Config) {
+	instrumentationCheckNames := make(map[string]bool)
+	for _, config := range configs {
+		if config.Provider == names.InstrumentationChecks {
+			instrumentationCheckNames[config.Name] = true
+		}
+	}
+	for digest, config := range configs {
+		if config.Provider != names.File {
+			continue
+		}
+		if instrumentationCheckNames[config.Name] {
+			log.Debugf("Ignoring config from %s: instrumentation check overrides file check %s",
+				config.Source, config.Name)
+			delete(configs, digest)
 		}
 	}
 }

--- a/comp/core/autodiscovery/listeners/service_test.go
+++ b/comp/core/autodiscovery/listeners/service_test.go
@@ -82,6 +82,7 @@ func TestServiceFilterTemplatesOverriddenChecks(t *testing.T) {
 	entity := &workloadmeta.Container{EntityID: workloadmeta.EntityID{Kind: "container", ID: "testy"}}
 	fooTpl := integration.Config{Name: "foo", Provider: names.File, LogsConfig: []byte(`{"source":"foo"}`)}
 	barTpl := integration.Config{Name: "bar", Provider: names.File, LogsConfig: []byte(`{"source":"bar"}`)}
+	fooInstrTpl := integration.Config{Name: "foo", Provider: names.InstrumentationChecks, LogsConfig: []byte(`{"source":"foo-instr"}`)}
 	fooNonFileTpl := integration.Config{Name: "foo", Provider: "xxx", LogsConfig: []byte(`{"source":"foo-nf"}`)}
 	barNonFileTpl := integration.Config{Name: "bar", Provider: "xxx", LogsConfig: []byte(`{"source":"bar-nf"}`)}
 	nothingDropped := []integration.Config{}
@@ -104,6 +105,54 @@ func TestServiceFilterTemplatesOverriddenChecks(t *testing.T) {
 	t.Run("some checkNames, partial match", func(t *testing.T) {
 		assert.Equal(t, []integration.Config{barTpl},
 			filterDrops(&WorkloadService{entity: entity, checkNames: []string{"bing", "bar"}}, fooTpl, barTpl, fooNonFileTpl, barNonFileTpl))
+	})
+
+	t.Run("annotation overrides instrumentation check", func(t *testing.T) {
+		assert.Equal(t, []integration.Config{fooInstrTpl},
+			filterDrops(&WorkloadService{entity: entity, checkNames: []string{"foo"}}, fooInstrTpl, barTpl))
+	})
+
+	t.Run("annotation overrides both file and instrumentation check", func(t *testing.T) {
+		assert.Equal(t, []integration.Config{fooTpl, fooInstrTpl},
+			filterDrops(&WorkloadService{entity: entity, checkNames: []string{"foo"}}, fooTpl, fooInstrTpl, barTpl))
+	})
+}
+
+func TestServiceFilterTemplatesInstrumentationOverFile(t *testing.T) {
+	filterDrops := func(svc *WorkloadService, configs ...integration.Config) (dropped []integration.Config) {
+		return filterConfigsDropped(svc.filterTemplatesInstrumentationOverFile, configs...)
+	}
+
+	entity := &workloadmeta.Container{EntityID: workloadmeta.EntityID{Kind: "container", ID: "testy"}}
+	fooFileTpl := integration.Config{Name: "foo", Provider: names.File, LogsConfig: []byte(`{"source":"foo-file"}`)}
+	fooInstrTpl := integration.Config{Name: "foo", Provider: names.InstrumentationChecks, LogsConfig: []byte(`{"source":"foo-instr"}`)}
+	barFileTpl := integration.Config{Name: "bar", Provider: names.File, LogsConfig: []byte(`{"source":"bar-file"}`)}
+	nothingDropped := []integration.Config{}
+
+	t.Run("file dropped when instrumentation check has same name", func(t *testing.T) {
+		assert.Equal(t, []integration.Config{fooFileTpl},
+			filterDrops(&WorkloadService{entity: entity}, fooFileTpl, fooInstrTpl))
+	})
+
+	t.Run("instrumentation check is kept", func(t *testing.T) {
+		assert.NotContains(t,
+			filterDrops(&WorkloadService{entity: entity}, fooFileTpl, fooInstrTpl),
+			fooInstrTpl)
+	})
+
+	t.Run("file kept when no instrumentation check exists", func(t *testing.T) {
+		assert.Equal(t, nothingDropped,
+			filterDrops(&WorkloadService{entity: entity}, fooFileTpl, barFileTpl))
+	})
+
+	t.Run("file kept when instrumentation check has different name", func(t *testing.T) {
+		assert.Equal(t, nothingDropped,
+			filterDrops(&WorkloadService{entity: entity}, barFileTpl, fooInstrTpl))
+	})
+
+	t.Run("multiple files, only matching one dropped", func(t *testing.T) {
+		assert.Equal(t, []integration.Config{fooFileTpl},
+			filterDrops(&WorkloadService{entity: entity}, fooFileTpl, barFileTpl, fooInstrTpl))
 	})
 }
 

--- a/comp/core/autodiscovery/listeners/service_test.go
+++ b/comp/core/autodiscovery/listeners/service_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
@@ -36,6 +37,15 @@ func filterConfigsDropped(filter func(map[string]integration.Config), configs ..
 		}
 	}
 	return
+}
+
+// neverMatchProgram is a MatchingProgram that always returns false, used in
+// tests to simulate a config that does not match the current service's entity.
+type neverMatchProgram struct{}
+
+func (neverMatchProgram) IsMatched(workloadfilter.Filterable) bool { return false }
+func (neverMatchProgram) GetTargetType() workloadfilter.ResourceType {
+	return workloadfilter.ContainerType
 }
 
 func TestServiceFilterTemplatesEmptyOverrides(t *testing.T) {
@@ -256,6 +266,53 @@ func TestServiceFilterTemplatesDiscovery(t *testing.T) {
 			"discovery template should be kept when the sibling is logs-only")
 		assert.Contains(t, configs, logsOnlySibling.Digest(),
 			"logs-only sibling should be kept")
+	})
+
+	t.Run("instrumentation check overrides matched file check", func(t *testing.T) {
+		fileTpl := integration.Config{
+			Name:      "redis",
+			Provider:  names.File,
+			Instances: []integration.Data{[]byte("port: 6379")},
+			Source:    "file:redis/conf.yaml",
+		}
+		instrTpl := integration.Config{
+			Name:      "redis",
+			Provider:  names.InstrumentationChecks,
+			Instances: []integration.Data{[]byte("{}")},
+			Source:    "instrumentation:redis",
+		}
+		configs := map[string]integration.Config{
+			fileTpl.Digest():  fileTpl,
+			instrTpl.Digest(): instrTpl,
+		}
+		mkSvc(NewStaticConfigIndex()).FilterTemplates(configs)
+		assert.NotContains(t, configs, fileTpl.Digest(), "file template should be dropped in favour of the instrumentation check")
+		assert.Contains(t, configs, instrTpl.Digest(), "instrumentation template should be kept")
+	})
+
+	t.Run("file kept when instrumentation check does not match service", func(t *testing.T) {
+		fileTpl := integration.Config{
+			Name:      "redis",
+			Provider:  names.File,
+			Instances: []integration.Data{[]byte("port: 6379")},
+			Source:    "file:redis/conf.yaml",
+		}
+		instrTpl := integration.Config{
+			Name:      "redis",
+			Provider:  names.InstrumentationChecks,
+			Instances: []integration.Data{[]byte("{}")},
+			Source:    "instrumentation:redis",
+		}
+		instrTpl.SetMatchingPrograms(map[workloadfilter.ResourceType]integration.MatchingProgram{
+			workloadfilter.ContainerType: neverMatchProgram{},
+		})
+		configs := map[string]integration.Config{
+			fileTpl.Digest():  fileTpl,
+			instrTpl.Digest(): instrTpl,
+		}
+		mkSvc(NewStaticConfigIndex()).FilterTemplates(configs)
+		assert.Contains(t, configs, fileTpl.Digest(), "file template should be kept when instrumentation check does not match the service")
+		assert.NotContains(t, configs, instrTpl.Digest(), "non-matching instrumentation template should be dropped")
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

Enforces a priority order for check config providers in autodiscovery: annotations/labels > instrumentation checks > file-based checks.

- Labels/annotations now override both instrumentation and file configs of the same check name (previously only overrode file configs)
- Instrumentation checks now override file-based configs of the same check name

### Motivation

Without this ordering, a file-based auto-conf template could remain active alongside an instrumentation-injected check for the same integration, resulting in duplicate or conflicting check scheduling.

### Describe how you validated your changes

- Added unit tests covering annotation override of instrumentation checks ✅ 

#### Manually QA'd

1. Deploy agent with instrumentation controller enabled & file provider targeting a test service.
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  features:
    logCollection:
      enabled: true
      containerCollectAll: false
  global:
    clusterName: "<CLUSTER_NAME>"
    checksTagCardinality: "high"
    logLevel: "info"
    kubelet:
      tlsVerify: false
    secretBackend:
      command: "/readsecret_multiple_providers.sh"
  override:
    clusterAgent:
      env:
        - name: DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED
          value: "true"
    nodeAgent:
      extraConfd:
        configDataMap:
          redisdb.yaml: |
            ad_identifiers:
              - redis
            init_config: {}
            instances:
              - host: "%%host%%"
                port: "%%port%%"
                password: "ENC[k8s_secret@cache/redis-secret/password]"
      env:
        - name: DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED
          value: "true"
        - name: DD_IGNORE_AUTOCONF
          value: "redisdb"
```
2. Deploy tmp service that matches file workload.
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: redis
spec:
  replicas: 1
  selector:
    matchLabels:
      app: redis
  template:
    metadata:
      labels:
        app: redis
    spec:
      containers:
      - name: redis
        image: redis:latest
        ports:
        - containerPort: 6379
        env:
          - name: REDIS_PASS
            valueFrom:
              secretKeyRef:
                name: redis-secret
                key: password
        command: ["sh", "-c", "redis-server --requirepass \"$REDIS_PASS\" --loglevel debug"]
---
apiVersion: v1
kind: Service
metadata:
  name: redis
spec:
  selector:
    app: redis
  ports:
    - port: 6379
      targetPort: 6379
```
3. Verify file-provider check is running.
<img width="511" height="91" alt="image" src="https://github.com/user-attachments/assets/97095757-7245-47fa-a999-b37ee9b2d10d" />

<details><summary>Instrumentation CR > File Provider</summary>
<p>

- Deploy DatadogInstrumentation (DDI) CR targeting the same deployment.
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogInstrumentation
metadata:
  name: redis-instrumentation
  namespace: cache
spec:
  targetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: redis
  config:
    checks:
      - integration: redisdb
        containerImage:
          - redis
        initConfig: {}
        instances:
          - host: "%%host%%"
            port: "%%port%%"
            password: "ENC[k8s_secret@%%kube_namespace%%/redis-secret/password]"
            tags:
              - service:redis
        logs:
          - source: "redis"
            service: "redis"
```

- Verify **one** check schedule from `instrumentation-check` provider
<img width="538" height="129" alt="image" src="https://github.com/user-attachments/assets/37aaea9c-df46-43a2-a802-784fb5cb9363" />

</p>
</details> 

<details><summary>Pod Annotation > Instrumentation CR </summary>
<p>

- Add pod annotation to the same deployment
```yaml
...
  annotations:
    ad.datadoghq.com/redis.checks: |
      {
        "redisdb": {
          "init_config": {},
          "instances": [
            {
              "host": "%%host%%",
              "port": "%%port%%",
              "password": "ENC[k8s_secret@%%kube_namespace%%/redis-secret/password]"
            }
          ]
        }
      }
```

- Verify **one** check scheduled from kubernetes provider.
<img width="742" height="109" alt="image" src="https://github.com/user-attachments/assets/59a7a840-cf1d-4c4f-8581-153d54bf606c" />

</p>
</details> 
