### PR TITLE
Add Claude OTEL resource attributes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,8 @@
 {
   "enabledPlugins": {
-    "datadog-agent-gopls@datadog-agent-local": true
+    "datadog-agent-gopls@datadog-agent-local": true,
+    "marketplace-auto-update@datadog-claude-plugins": true,
+    "dd@datadog-claude-plugins": true
   },
   "extraKnownMarketplaces": {
     "datadog-agent-local": {
@@ -8,6 +10,16 @@
         "source": "directory",
         "path": ".claude-plugins"
       }
+    },
+    "datadog-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "DataDog/claude-marketplace"
+      },
+      "autoUpdate": true
     }
+  },
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "repo.owner=DataDog,repo.name=datadog-agent"
   }
 }


### PR DESCRIPTION
## Problem

Claude sessions in this repository do not declare repo-level OpenTelemetry resource attributes, so telemetry cannot reliably attribute activity to `DataDog/datadog-agent`.

## Changes

- Add `OTEL_RESOURCE_ATTRIBUTES=repo.owner=DataDog,repo.name=datadog-agent` to `.claude/settings.json`.
- Preserve the existing local datadog-agent Claude plugin configuration.
- Register the Datadog Claude plugin marketplace and enable the Datadog plugin plus marketplace auto-update.

## Validation

- Verified the settings payload is valid JSON.
- No runtime tests were run; this is a Claude settings-only change.