### PR TITLE
remoteconfig/state: register APM_SEMANTIC_CORE_DD product

### DIFF
--- a/pkg/remoteconfig/state/products.go
+++ b/pkg/remoteconfig/state/products.go
@@ -16,6 +16,7 @@ var validProducts = map[string]struct{}{
 	ProductAgentTask:                    {},
 	ProductAgentIntegrations:            {},
 	ProductAPMSampling:                  {},
+	ProductAPMSemanticCoreDD:            {},
 	ProductCWSDD:                        {},
 	ProductCWSCustom:                    {},
 	ProductCWSRemediation:               {},
@@ -70,6 +71,11 @@ const (
 	ProductAgentTask = "AGENT_TASK"
 	// ProductAPMSampling is the apm sampling product
 	ProductAPMSampling = "APM_SAMPLING"
+	// ProductAPMSemanticCoreDD is the employee-signed product that pushes
+	// semantic-core mapping updates (span tag equivalences, peer tag mappings)
+	// to the trace-agent. A future API-signed per-org variant will be
+	// ProductAPMSemanticCore (without the _DD suffix).
+	ProductAPMSemanticCoreDD = "APM_SEMANTIC_CORE_DD"
 	// ProductCWSDD is the cloud workload security product managed by datadog employees
 	ProductCWSDD = "CWS_DD"
 	// ProductCWSCustom is the cloud workload security product managed by datadog customers


### PR DESCRIPTION
### What does this PR do?

Adds the `ProductAPMSemanticCoreDD = "APM_SEMANTIC_CORE_DD"` constant and the corresponding `validProducts` entry for the new employee-signed Remote Config product used to push semantic-core span tag mapping updates to the trace-agent.

No consumer wiring in this PR — the trace-agent subscription and peer-tags cache land in two follow-up stacked PRs.

### Motivation

Part of [DSEM-706](https://datadoghq.atlassian.net/browse/DSEM-706). Pairs with the producer-side work in [DataDog/semantic-core#703](https://github.com/DataDog/semantic-core/pull/703).

### Describe how you validated your changes

`pkg/remoteconfig/state` unit tests pass.

### Additional Notes

Future API-signed per-org variant will be `ProductAPMSemanticCore` (without the `_DD` suffix); deferred to a later RFC.

[DSEM-706]: https://datadoghq.atlassian.net/browse/DSEM-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ