### PR TITLE
[clusteragent/clusterchecks/checks_distribution] Fix preferred runner tiebreaker

### DIFF
--- a/pkg/clusteragent/clusterchecks/checks_distribution.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution.go
@@ -75,10 +75,10 @@ func (distribution *checksDistribution) leastBusyRunner(preferredRunner string, 
 		runnerUtilization := runnerStatus.utilization()
 		runnerNumChecks := runnerStatus.NumChecks
 
-		selectRunner := leastBusyRunner == "" ||
-			runnerUtilization < minUtilization ||
-			runnerUtilization == minUtilization && runnerName == preferredRunner ||
-			runnerUtilization == minUtilization && runnerNumChecks < numChecksLeastBusyRunner
+		selectRunner := (leastBusyRunner == "") ||
+			(runnerUtilization < minUtilization) ||
+			(runnerUtilization == minUtilization && runnerName == preferredRunner) ||
+			(runnerUtilization == minUtilization && leastBusyRunner != preferredRunner && runnerNumChecks < numChecksLeastBusyRunner)
 
 		if selectRunner {
 			leastBusyRunner = runnerName

--- a/pkg/clusteragent/clusterchecks/checks_distribution_test.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution_test.go
@@ -110,6 +110,22 @@ func TestAddToLeastBusy(t *testing.T) {
 			expectedPlacement: "runner2",
 		},
 		{
+			name: "2 least busy runners. Preferred wins over fewer checks",
+			existingRunners: map[string]int{
+				"runner1": 4,
+				"runner2": 4,
+				"runner3": 4,
+			},
+			existingChecks: map[string]CheckStatus{
+				"check1": {WorkersNeeded: 3, Runner: "runner1"}, // runner1: util 0.75, 1 check
+				"check2": {WorkersNeeded: 1, Runner: "runner2"}, // runner2: util 0.5,  2 checks
+				"check3": {WorkersNeeded: 1, Runner: "runner2"},
+				"check4": {WorkersNeeded: 2, Runner: "runner3"}, // runner3: util 0.5,  1 check
+			},
+			preferredRunner:   "runner2",
+			expectedPlacement: "runner2",
+		},
+		{
 			name: "only one runner",
 			existingRunners: map[string]int{
 				"runner1": 4,

--- a/releasenotes-dca/notes/fix-cluster-checks-rebalance-90900a2f68c6d651.yaml
+++ b/releasenotes-dca/notes/fix-cluster-checks-rebalance-90900a2f68c6d651.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an issue in the algorithm used to rebalance cluster checks
+    that could cause unnecessary check moves between runners.


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue in the algorithm used to rebalance cluster checks.

The description of the `leastBusyRunner` function says that the preferred runner should take precedence when there's a tie in utilization, but that wasn't always the case. The bug could cause unnecessary check moves between runners. This PR fixes it.


### Describe how you validated your changes

I added a regression test.