### PR TITLE
test(agenttelemetry): add E2E coverage for error-log tracking

### DIFF
--- a/test/e2e-framework/components/datadog/agentparams/params.go
+++ b/test/e2e-framework/components/datadog/agentparams/params.go
@@ -306,6 +306,9 @@ data_streams.forwarder.logs_dd_url: %[1]s:%[2]d
 data_streams.forwarder.logs_no_ssl: true
 event_management.forwarder.logs_dd_url: %[1]s:%[2]d
 event_management.forwarder.logs_no_ssl: true
+agent_telemetry.logs_dd_url: %[1]s:%[2]d
+agent_telemetry.logs_no_ssl: true
+agent_telemetry.use_compression: false
 `, hostname, port, scheme)
 		p.ExtraAgentConfig = append(p.ExtraAgentConfig, extraConfig)
 		return nil

--- a/test/fakeintake/aggregator/apmTelemetryAggregator.go
+++ b/test/fakeintake/aggregator/apmTelemetryAggregator.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package aggregator
+
+import (
+	"bytes"
+	"encoding/json"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
+)
+
+// AgentTelemetryLog represents a single log record from the agent's internal
+// telemetry pipeline. It mirrors comp/core/agenttelemetry/impl/logs_payload.go::Log
+// and is populated only for payloads whose request_type is "agent-logs".
+type AgentTelemetryLog struct {
+	Level      string `json:"level"`
+	StackTrace string `json:"stack_trace"`
+	TracerTime int64  `json:"tracer_time"`
+	Count      int    `json:"count"`
+	IsCrash    bool   `json:"is_crash"`
+	Message    string `json:"message"`
+	collectedTime time.Time
+}
+
+// name returns the grouping key used by the aggregator. All agent-logs records
+// share one key; per-hostname grouping is not needed for single-agent test VMs.
+func (l *AgentTelemetryLog) name() string { return "agent-errortracking" }
+
+// GetTags returns no tags — agent telemetry logs carry none on the wire.
+func (l *AgentTelemetryLog) GetTags() []string { return []string{} }
+
+// GetCollectedTime returns when the fakeintake server received this payload.
+func (l *AgentTelemetryLog) GetCollectedTime() time.Time { return l.collectedTime }
+
+// apmTelemetryEnvelope is the outer POST body sent to /api/v2/apmtelemetry.
+// The same endpoint receives metrics, heartbeats, and other request types;
+// request_type discriminates agent-logs records from the rest.
+type apmTelemetryEnvelope struct {
+	RequestType string `json:"request_type"`
+	Payload     struct {
+		Logs []*AgentTelemetryLog `json:"logs"`
+	} `json:"payload"`
+}
+
+// ParseAgentTelemetryLogs parses one api.Payload into zero-or-more
+// AgentTelemetryLog items. Payloads whose request_type is not "agent-logs"
+// are silently skipped — the /api/v2/apmtelemetry endpoint is shared with
+// agent metrics, heartbeats, and other telemetry types.
+func ParseAgentTelemetryLogs(payload api.Payload) ([]*AgentTelemetryLog, error) {
+	if bytes.Equal(payload.Data, []byte("{}")) {
+		return []*AgentTelemetryLog{}, nil
+	}
+
+	inflated, err := inflate(payload.Data, payload.Encoding)
+	if err != nil {
+		return nil, err
+	}
+
+	var env apmTelemetryEnvelope
+	if err := json.Unmarshal(inflated, &env); err != nil {
+		return nil, err
+	}
+
+	if env.RequestType != "agent-logs" {
+		return []*AgentTelemetryLog{}, nil
+	}
+
+	for _, l := range env.Payload.Logs {
+		l.collectedTime = payload.Timestamp
+	}
+	return env.Payload.Logs, nil
+}
+
+// AgentTelemetryLogAggregator aggregates AgentTelemetryLog payloads received
+// on the /api/v2/apmtelemetry endpoint.
+type AgentTelemetryLogAggregator struct {
+	Aggregator[*AgentTelemetryLog]
+}
+
+// NewAgentTelemetryLogAggregator returns a new AgentTelemetryLogAggregator.
+func NewAgentTelemetryLogAggregator() AgentTelemetryLogAggregator {
+	return AgentTelemetryLogAggregator{
+		Aggregator: newAggregator(ParseAgentTelemetryLogs),
+	}
+}

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -152,6 +152,7 @@ type Client struct {
 	ncmAggregator                  aggregator.NCMAggregator
 	hostAggregator                 aggregator.HostTagsAggregator
 	agentHealthAggregator          aggregator.AgentHealthAggregator
+	agentTelemetryLogAggregator    aggregator.AgentTelemetryLogAggregator
 }
 
 // NewClient creates a new fake intake client
@@ -186,6 +187,7 @@ func NewClient(fakeIntakeURL string, opts ...Option) *Client {
 		ncmAggregator:                  aggregator.NewNCMAggregator(),
 		hostAggregator:                 aggregator.NewHostTagsAggregator(),
 		agentHealthAggregator:          aggregator.NewAgentHealthAggregator(),
+		agentTelemetryLogAggregator:    aggregator.NewAgentTelemetryLogAggregator(),
 	}
 	for _, opt := range opts {
 		opt(client)
@@ -375,6 +377,14 @@ func (c *Client) getAgentHealth() error {
 		return err
 	}
 	return c.agentHealthAggregator.UnmarshallPayloads(payloads)
+}
+
+func (c *Client) getAgentTelemetryLogs() error {
+	payloads, err := c.getFakePayloads(apmTelemetryEndpoint)
+	if err != nil {
+		return err
+	}
+	return c.agentTelemetryLogAggregator.UnmarshallPayloads(payloads)
 }
 
 // FilterMetrics fetches fakeintake on `/api/v2/series` endpoint and returns
@@ -714,6 +724,7 @@ func (c *Client) FlushServerAndResetAggregators() error {
 	c.logAggregator.Reset()
 	c.apmStatsAggregator.Reset()
 	c.traceAggregator.Reset()
+	c.agentTelemetryLogAggregator.Reset()
 	return nil
 }
 
@@ -1157,6 +1168,21 @@ func (c *Client) GetHosts() ([]string, error) {
 	}
 
 	return c.hostAggregator.GetNames(), nil
+}
+
+// GetAgentTelemetryLogs fetches fakeintake on `/api/v2/apmtelemetry` and returns
+// all agent-logs telemetry records received since the last flush. Each call
+// fetches the server's full accumulated state (UnmarshallPayloads replaces, not
+// appends). Payloads whose request_type is not "agent-logs" are silently skipped.
+func (c *Client) GetAgentTelemetryLogs() ([]*aggregator.AgentTelemetryLog, error) {
+	if err := c.getAgentTelemetryLogs(); err != nil {
+		return nil, err
+	}
+	var logs []*aggregator.AgentTelemetryLog
+	for _, name := range c.agentTelemetryLogAggregator.GetNames() {
+		logs = append(logs, c.agentTelemetryLogAggregator.GetPayloadsByName(name)...)
+	}
+	return logs, nil
 }
 
 // GetAgentHealth fetches fakeintake on `/api/v2/agenthealth` endpoint and returns all received agent health payloads

--- a/test/new-e2e/tests/agent-telemetry/errortracking_test.go
+++ b/test/new-e2e/tests/agent-telemetry/errortracking_test.go
@@ -1,0 +1,142 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package agenttelemetry contains E2E tests for the agent's internal telemetry
+// error-tracking pipeline: pkg/util/log/errortracking → comp/core/agenttelemetry →
+// /api/v2/apmtelemetry (request_type: agent-logs).
+package agenttelemetry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	ec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+)
+
+const (
+	waitFor = 2 * time.Minute
+	tick    = 10 * time.Second
+)
+
+// errorTrackingEnabledConfig enables the error-tracking feature with a short
+// flush interval and zero jitter/bouncer window for deterministic test behaviour.
+const errorTrackingEnabledConfig = `
+agent_telemetry:
+  enabled: true
+  errortracking:
+    enabled: true
+    flush_interval_seconds: 10
+    bouncer_window_seconds: 0
+    startup_jitter_seconds: 0
+`
+
+// errorTrackingDisabledConfig omits the errortracking stanza entirely,
+// verifying that the feature is off by default.
+const errorTrackingDisabledConfig = `
+agent_telemetry:
+  enabled: true
+`
+
+// failingCheckConfig points http_check at a guaranteed-closed local port.
+// The Go check runner logs at Error via pkg/util/log when the TCP connection
+// is refused, which flows through the slog errortracking handler into errLogsCh.
+const failingCheckConfig = `
+init_config:
+instances:
+  - name: test-unreachable
+    url: http://127.0.0.1:19998/
+    timeout: 1
+`
+
+type errorTrackingSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+// TestAgentTelemetryErrorTrackingSuite is the entry point for the suite.
+func TestAgentTelemetryErrorTrackingSuite(t *testing.T) {
+	e2e.Run(t, &errorTrackingSuite{},
+		e2e.WithProvisioner(
+			awshost.Provisioner(
+				awshost.WithRunOptions(
+					ec2.WithAgentOptions(
+						agentparams.WithAgentConfig(errorTrackingEnabledConfig),
+						agentparams.WithIntegration("http_check.d", failingCheckConfig),
+					),
+				),
+			),
+		),
+		e2e.WithStackName("agent-telemetry-errortracking"),
+	)
+}
+
+// BeforeTest flushes both the server and all client aggregators before each
+// test case so payload state from a previous test cannot bleed in.
+func (s *errorTrackingSuite) BeforeTest(suiteName, testName string) {
+	s.BaseSuite.BeforeTest(suiteName, testName)
+	require.NoError(s.T(), s.Env().FakeIntake.Client().FlushServerAndResetAggregators())
+}
+
+// TearDownSuite flushes on teardown (best-effort) before calling the base
+// implementation.
+func (s *errorTrackingSuite) TearDownSuite() {
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators() //nolint:errcheck
+	s.BaseSuite.TearDownSuite()
+}
+
+// TestPayloadShape verifies the happy path: with errortracking enabled and a
+// failing check in place, FakeIntake must receive at least one agent-logs record
+// with the expected wire shape.
+func (s *errorTrackingSuite) TestPayloadShape() {
+	// Phase 1: poll until at least one record arrives.
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		logs, err := s.Env().FakeIntake.Client().GetAgentTelemetryLogs()
+		assert.NoError(c, err)
+		assert.NotEmpty(c, logs, "no agent-logs telemetry received yet")
+	}, waitFor, tick, "timed out waiting for agent-logs telemetry to reach fakeintake")
+
+	// Phase 2: assert wire shape outside the polling loop.
+	logs, err := s.Env().FakeIntake.Client().GetAgentTelemetryLogs()
+	require.NoError(s.T(), err)
+	require.NotEmpty(s.T(), logs)
+
+	l := logs[0]
+	assert.Equal(s.T(), "ERROR", l.Level)
+	assert.NotEmpty(s.T(), l.StackTrace, "stack_trace must be non-empty")
+	assert.False(s.T(), l.IsCrash, "agent error logs are not crash reports")
+	assert.GreaterOrEqual(s.T(), l.Count, 1)
+	// Message is intentionally empty — user-controlled data is never shipped.
+	assert.Empty(s.T(), l.Message, "message must not be on the wire")
+}
+
+// TestDisabledByDefault verifies that when the errortracking stanza is absent,
+// no agent-logs records reach FakeIntake even when errors occur.
+func (s *errorTrackingSuite) TestDisabledByDefault() {
+	s.Run("reconfigure without errortracking", func() {
+		s.UpdateEnv(awshost.Provisioner(
+			awshost.WithRunOptions(
+				ec2.WithAgentOptions(
+					agentparams.WithAgentConfig(errorTrackingDisabledConfig),
+					agentparams.WithIntegration("http_check.d", failingCheckConfig),
+				),
+			),
+		))
+		require.NoError(s.T(), s.Env().FakeIntake.Client().FlushServerAndResetAggregators())
+
+		// Wait longer than two flush intervals to give a misconfigured agent
+		// time to send if the gate were broken.
+		time.Sleep(30 * time.Second)
+
+		logs, err := s.Env().FakeIntake.Client().GetAgentTelemetryLogs()
+		require.NoError(s.T(), err)
+		assert.Empty(s.T(), logs, "no agent-logs must arrive when errortracking is disabled")
+	})
+}


### PR DESCRIPTION
### What does this PR do?

Follow-up to #50607. Adds an E2E test suite that validates the agent error-tracking telemetry pipeline end-to-end on a real AWS EC2 VM via FakeIntake.

Three shared framework additions:
- `test/fakeintake/aggregator/apmTelemetryAggregator.go` — new aggregator for `/api/v2/apmtelemetry` payloads; filters to `request_type: "agent-logs"` so unrelated agent telemetry (metrics, heartbeats) sharing the same endpoint is silently skipped.
- `test/fakeintake/client/client.go` — `GetAgentTelemetryLogs()` method, private `getAgentTelemetryLogs()` fetch, and `agentTelemetryLogAggregator.Reset()` inside `FlushServerAndResetAggregators()`.
- `test/e2e-framework/components/datadog/agentparams/params.go` — adds `agent_telemetry.logs_dd_url`, `logs_no_ssl`, and `use_compression` to `withIntakeHostname()` so `WithFakeintake()` automatically redirects agent telemetry traffic to FakeIntake.

One new test suite (`test/new-e2e/tests/agent-telemetry/errortracking_test.go`):
- `TestPayloadShape` — with errortracking enabled and a failing `http_check` in place, asserts FakeIntake receives ≥1 record with `level: "ERROR"`, non-empty `stack_trace`, `is_crash: false`, and empty `message` (user-controlled data is never shipped).
- `TestDisabledByDefault` — reconfigures the agent without the errortracking stanza via `UpdateEnv` and asserts zero records arrive.

Error trigger: `http_check` pointing at `127.0.0.1:19998` (guaranteed closed). The Go check runner calls `log.Errorf` via `pkg/util/log` on connection refused, which flows through the slog errortracking handler into `errLogsCh`.

### Motivation

#50607 ships the error-tracking feature with unit tests only. This PR adds the E2E layer: a real agent binary running on a provisioned VM, emitting real HTTP payloads to FakeIntake, with assertions on the wire shape. It also replaces the local hand-rolled HTTP receiver (`/tmp/coat-receiver/main.go`) and manual test config used during development with a reproducible, CI-runnable test.

### Describe how you validated your changes

**Compilation:**
- `go build ./test/fakeintake/...` — aggregator and client changes compile clean.
- `go build ./test/e2e-framework/...` — agentparams change compiles clean.

**E2E suite** (requires Pulumi/AWS setup per [Getting started with E2E](https://datadoghq.atlassian.net/wiki/spaces/ADX/pages/3492282517)):
```bash
aws-vault exec sso-agent-sandbox-account-admin -- \
  go test -v -timeout 30m \
  -run TestAgentTelemetryErrorTrackingSuite \
  ./test/new-e2e/tests/agent-telemetry/...
```

### Additional Notes

- This PR is based on `coat-errortracking` and targets that branch as its base. It should be rebased onto `main` once #50607 merges, at which point the base can be updated to `main`.
- `use_compression: false` is set in the agent config for tests so FakeIntake receives plain JSON without requiring zstd decompression; the aggregator's `inflate()` handles zstd if compression is ever re-enabled.
- `BeforeTest` calls `FlushServerAndResetAggregators()` (with `require.NoError`) before each test case to prevent cross-test payload contamination. `TearDownSuite` does the same as best-effort cleanup.