### PR TITLE
[backport] rshell v0.0.14-1 to fix ps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -969,7 +969,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.79.0
 	github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace v0.79.0
 	github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5
-	github.com/DataDog/rshell v0.0.14
+	github.com/DataDog/rshell v0.0.14-1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8
 	github.com/aymerick/raymond v2.0.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2598,8 +2598,8 @@ github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816 h1:8diKw2aLYE6LsjWfYxD
 github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816/go.mod h1:7cPuErOAt7k/oVWAVJnxqAC6mwArrAazkvk0RXiih2A=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260317195537-817b91eb7dd4 h1:9+K8vjF7sQSLjVJporNyv6nw46cMg/Q8ogxbBZmrf+A=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260317195537-817b91eb7dd4/go.mod h1:KEBv+q78RzBcDPNFm1WB0V0za14gY95E/Atp3dJZ/8M=
-github.com/DataDog/rshell v0.0.14 h1:1BJxm8FQ0uZ6amxItyKmlG4e2y2CPTNvjxtY/Nx1Pg0=
-github.com/DataDog/rshell v0.0.14/go.mod h1:r2pK0NQpE1SL+ESYjlfhigWDEELPY5LacwLbisR9nxI=
+github.com/DataDog/rshell v0.0.14-1 h1:D1AiG/m5Vw8iIDttLaLJXBx8D7nCyB1bZVkfMoL4NbA=
+github.com/DataDog/rshell v0.0.14-1/go.mod h1:r2pK0NQpE1SL+ESYjlfhigWDEELPY5LacwLbisR9nxI=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=
 github.com/DataDog/sketches-go v1.4.8/go.mod h1:a/wjRUqzqtGS8qRHRPDCs4EAQfmvPDZGDlMIF5mxXOE=
 github.com/DataDog/trivy v0.0.0-20260407220859-6cf8ddc1826c h1:oiwmRrkRVblZBI3SFVEnrwxkQ28W7nmwwI/VHgex0ZU=


### PR DESCRIPTION
### What does this PR do?

[backport] rshell v0.0.14-1 to fix ps

Rshell release link: https://github.com/DataDog/rshell/releases/tag/v0.0.14-1

### Motivation

Backport needed for this fix: https://github.com/DataDog/rshell/pull/269

### Describe how you validated your changes

### Additional Notes
