### PR TITLE
[CWS] snapshot inherited variables on process reparenting

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2698,6 +2698,13 @@ func (p *EBPFProbe) OnNewRuleSetLoaded(rs *rules.RuleSet) {
 	p.variableStore = rs.GetVariableStore()
 	p.variableStoreMu.Unlock()
 
+	// Snapshot inherited SECL variables onto an entry before its parent link
+	// is changed, so the values resolved through inheritance survive the
+	// reparenting.
+	p.Resolvers.ProcessResolver.SetPreReparentCb(func(entry *model.ProcessCacheEntry) {
+		rs.CopyInheritedVariables(entry)
+	})
+
 	p.HandleRemediationStatus(rs)
 }
 

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -115,6 +115,21 @@ type EBPFResolver struct {
 	procFallbackLimiter *utils.Limiter[uint32]
 
 	exitedQueue []uint32
+
+	// preReparentCb, if non-nil, is invoked just before an entry's parent
+	// link is updated (e.g. subreaper or procfs reparenting). It is called
+	// with the resolver lock held; the implementation must not call back into
+	// the resolver. Used to snapshot inherited SECL variables so they keep
+	// their pre-reparent value after the parent chain changes.
+	preReparentCb func(*model.ProcessCacheEntry)
+}
+
+// SetPreReparentCb registers a callback invoked just before the parent
+// link of a process cache entry is updated.
+func (p *EBPFResolver) SetPreReparentCb(cb func(*model.ProcessCacheEntry)) {
+	p.Lock()
+	defer p.Unlock()
+	p.preReparentCb = cb
 }
 
 // reparentTo looks up newPPid in the cache (falling back to procfs) and
@@ -131,6 +146,9 @@ func (p *EBPFResolver) reparentTo(entry *model.ProcessCacheEntry, newPPid uint32
 		}
 	}
 	if newParent != nil {
+		if p.preReparentCb != nil {
+			p.preReparentCb(entry)
+		}
 		entry.Reparent(newParent)
 		p.reparentSuccessStats[callpathTag].Inc()
 	} else {
@@ -165,6 +183,9 @@ func (p *EBPFResolver) resolveParentFromProcfs(entry *model.ProcessCacheEntry, c
 	entry.PPid = newPPidU32
 
 	if newParent := p.entryCache[newPPidU32]; newParent != nil {
+		if p.preReparentCb != nil {
+			p.preReparentCb(entry)
+		}
 		entry.Reparent(newParent)
 		p.reparentSuccessStats[callpathTag].Inc()
 	} else {

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -1062,6 +1062,10 @@ func (v *Variables) GetScopedVariables(_ string) map[ScopeHashKey]Variable {
 	return nil
 }
 
+// CopyInheritedVariables is a no-op for global variables, which have no
+// parent scope chain.
+func (v *Variables) CopyInheritedVariables(_ VariableScope) {}
+
 // MutableSECLVariable describes the interface implemented by mutable SECL variable
 type MutableSECLVariable interface {
 	Variable
@@ -1228,6 +1232,69 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 		}, setVariable, VariableOpts{}), nil
 	default:
 		return nil, fmt.Errorf("unsupported variable type %s for '%s'", reflect.TypeOf(value), name)
+	}
+}
+
+// CopyInheritedVariables snapshots all inherited variables visible to scope
+// through its parent chain into the scope's own variable storage. After this
+// call, the closest inherited value for each name is materialised directly
+// under scope, so subsequent changes to the parent chain (e.g. process
+// reparenting) no longer affect the values resolved against scope. Variables
+// already defined directly on scope are left untouched.
+func (v *ScopedVariables) CopyInheritedVariables(scope VariableScope) {
+	if scope == nil {
+		return
+	}
+	currentHash := scope.Hash()
+
+	v.varsLock.Lock()
+	defer v.varsLock.Unlock()
+
+	currentVars := v.vars[currentHash]
+
+	parent := scope
+	for {
+		var exists bool
+		if parent, exists = parent.ParentScope(); !exists {
+			break
+		}
+		parentVars := v.vars[parent.Hash()]
+		for name, variable := range parentVars {
+			if !variable.GetVariableOpts().Inherited {
+				continue
+			}
+			if _, exists := currentVars[name]; exists {
+				continue
+			}
+
+			if currentVars == nil {
+				scope.AppendReleaseCallback(func() {
+					v.ReleaseVariable(currentHash)
+				})
+				v.vars[currentHash] = make(map[string]MutableSECLVariable)
+				currentVars = v.vars[currentHash]
+			}
+
+			value, exists := variable.GetValue()
+			if !exists {
+				continue
+			}
+			opts := variable.GetVariableOpts()
+			newVar, err := newSECLVariable(value, opts)
+			if err != nil {
+				continue
+			}
+			if err := newVar.Set(nil, value); err != nil {
+				continue
+			}
+			currentVars[name] = newVar
+
+			if expirable, ok := newVar.(expirableVariable); ok && opts.TTL > 0 {
+				v.expirablesLock.Lock()
+				v.expirables[currentHash] = append(v.expirables[currentHash], expirable)
+				v.expirablesLock.Unlock()
+			}
+		}
 	}
 }
 

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -18,6 +18,7 @@ type VariableProvider interface {
 	NewSECLVariable(name string, value interface{}, scope string, opts eval.VariableOpts) (eval.SECLVariable, error)
 	CleanupExpiredVariables()
 	GetScopedVariables(name string) map[eval.ScopeHashKey]eval.Variable
+	CopyInheritedVariables(scope eval.VariableScope)
 }
 
 // VariableProviderFactory describes a function called to instantiate a variable provider

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -1392,6 +1392,16 @@ func (rs *RuleSet) CleanupExpiredVariables() {
 	}
 }
 
+// CopyInheritedVariables snapshots the inherited variables visible to scope
+// across every scoped variable provider in the ruleset. Used when the scope's
+// parent chain is about to change (e.g. process reparenting) and the values
+// resolved through inheritance should be preserved at their pre-change state.
+func (rs *RuleSet) CopyInheritedVariables(scope eval.VariableScope) {
+	for _, variableProvider := range rs.scopedVariables {
+		variableProvider.CopyInheritedVariables(scope)
+	}
+}
+
 // NewRuleSet returns a new ruleset for the specified data model
 func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts, evalOpts *eval.Opts) *RuleSet {
 	logger := log.OrNullLogger(opts.Logger)

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -2074,6 +2074,72 @@ int test_subreaper(int argc, char **argv) {
     return EXIT_SUCCESS;
 }
 
+// subreaper-with-var: sets the current process as a subreaper, forks an
+// intermediate child which opens <trigger_file> (to fire a rule that sets an
+// inherited process-scoped SECL variable), then forks a grandchild and exits.
+// The grandchild waits for the kernel to complete reparenting onto the
+// subreaper, then opens <check_file>. The intermediate is now gone from the
+// grandchild's parent chain, so a rule reading the inherited variable on the
+// <check_file> event must rely on a pre-reparent snapshot to still see the
+// value set on the intermediate.
+// Usage: syscall_tester subreaper-with-var <trigger_file> <check_file>
+int test_subreaper_with_var(int argc, char **argv) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: subreaper-with-var <trigger_file> <check_file>\n");
+        return EXIT_FAILURE;
+    }
+    char *trigger_file = argv[1];
+    char *check_file = argv[2];
+
+    if (prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0) {
+        perror("prctl PR_SET_CHILD_SUBREAPER");
+        return EXIT_FAILURE;
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        perror("fork (child)");
+        return EXIT_FAILURE;
+    }
+
+    if (child == 0) {
+        // intermediate: open trigger_file so the set-variable rule fires on
+        // this process scope, then fork a grandchild and exit.
+        int fd = open(trigger_file, O_RDONLY | O_CREAT, 0400);
+        if (fd > 0)
+            close(fd);
+
+        // give the agent a moment to process the trigger event before we exit
+        sleep(1);
+
+        pid_t grandchild = fork();
+        if (grandchild < 0) {
+            perror("fork (grandchild)");
+            _exit(EXIT_FAILURE);
+        }
+        if (grandchild == 0) {
+            // grandchild: wait for the kernel reparenting to settle, then open
+            // check_file so the inheritance-check rule evaluates against the
+            // post-reparent process context.
+            sleep(2);
+
+            int gfd = open(check_file, O_RDONLY | O_CREAT, 0400);
+            if (gfd > 0)
+                close(gfd);
+
+            _exit(EXIT_SUCCESS);
+        }
+        // intermediate exits; the kernel reparents grandchild onto the subreaper
+        _exit(EXIT_SUCCESS);
+    }
+
+    // subreaper: wait for the intermediate, then reap the reparented grandchild
+    waitpid(child, NULL, 0);
+    while (waitpid(-1, NULL, 0) > 0) {}
+
+    return EXIT_SUCCESS;
+}
+
 /* clone3 is not wrapped by glibc, call it directly. */
 static pid_t sys_clone3(struct clone_args *args, size_t size) {
     return (pid_t)syscall(__NR_clone3, args, size);
@@ -2260,6 +2326,8 @@ int main(int argc, char **argv) {
             exit_code = test_dnsloop(sub_argc, sub_argv);
         } else if (strcmp(cmd, "subreaper") == 0) {
             exit_code = test_subreaper(sub_argc, sub_argv);
+        } else if (strcmp(cmd, "subreaper-with-var") == 0) {
+            exit_code = test_subreaper_with_var(sub_argc, sub_argv);
         } else if (strcmp(cmd, "process-clone-into-cgroup") == 0) {
             exit_code = test_clone_into_cgroup(sub_argc, sub_argv);
         } else {

--- a/pkg/security/tests/variables_test.go
+++ b/pkg/security/tests/variables_test.go
@@ -185,9 +185,7 @@ func TestVariableInheritanceReparenting(t *testing.T) {
 		cmd := exec.CommandContext(context.Background(), syscallTester,
 			"subreaper-with-var", triggerFile, checkFile)
 		return cmd.Run()
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(_ *model.Event, rule *rules.Rule) {
 		assertTriggeredRule(t, rule, "check_subreaper_var")
-		assertFieldEqual(t, event, "process.parent.file.name", "syscall_tester",
-			"after subreaper reparenting, parent should be syscall_tester")
 	}, "check_subreaper_var")
 }

--- a/pkg/security/tests/variables_test.go
+++ b/pkg/security/tests/variables_test.go
@@ -9,8 +9,10 @@
 package tests
 
 import (
+	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/avast/retry-go/v4"
@@ -110,4 +112,82 @@ func TestVariablePrivateField(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+// TestVariableInheritanceReparenting verifies that an inherited process-scoped
+// variable set on an intermediate process is still visible to its grandchild
+// after the intermediate exits and the grandchild is reparented onto a
+// subreaper - i.e. that the inherited value is snapshotted onto the grandchild
+// before its parent link changes.
+func TestVariableInheritanceReparenting(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	if ebpfLessEnabled {
+		t.Skip("subreaper reparenting not supported in ebpfless mode")
+	}
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "set_subreaper_var",
+			Expression: `open.file.path == "{{.Root}}/subreaper-var-trigger" && process.file.name == "syscall_tester"`,
+			Actions: []*rules.ActionDefinition{
+				{
+					Set: &rules.SetDefinition{
+						Scope:     "process",
+						Name:      "subreaper_var",
+						Value:     "intermediate-value",
+						Inherited: true,
+					},
+				},
+			},
+		},
+		{
+			ID: "check_subreaper_var",
+			Expression: `open.file.path == "{{.Root}}/subreaper-var-check" ` +
+				`&& process.parent.file.name == "syscall_tester" ` +
+				`&& ${process.subreaper_var} == "intermediate-value"`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	triggerFile, _, err := test.Path("subreaper-var-trigger")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(triggerFile)
+
+	checkFile, _, err := test.Path("subreaper-var-check")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(checkFile)
+
+	// syscall_tester "subreaper-with-var" forks an intermediate that opens
+	// triggerFile (firing set_subreaper_var on the intermediate's scope), then
+	// forks a grandchild and exits. After the kernel reparents the grandchild
+	// onto the subreaper, the grandchild opens checkFile. The check_subreaper_var
+	// rule then asserts that:
+	//   - the grandchild's parent is now syscall_tester (the subreaper), and
+	//   - ${process.subreaper_var} is still "intermediate-value" - which is
+	//     only possible if the value was snapshotted onto the grandchild before
+	//     its parent link was redirected away from the (now-gone) intermediate.
+	test.WaitSignalFromRule(t, func() error {
+		cmd := exec.CommandContext(context.Background(), syscallTester,
+			"subreaper-with-var", triggerFile, checkFile)
+		return cmd.Run()
+	}, func(event *model.Event, rule *rules.Rule) {
+		assertTriggeredRule(t, rule, "check_subreaper_var")
+		assertFieldEqual(t, event, "process.parent.file.name", "syscall_tester",
+			"after subreaper reparenting, parent should be syscall_tester")
+	}, "check_subreaper_var")
 }


### PR DESCRIPTION
Add ScopedVariables.CopyInheritedVariables, which materialises the closest visible inherited value for each name directly under the scope just before its parent link changes. Fan it out from RuleSet to every scoped provider and expose a SetPreReparentCb hook on the process resolver fired in both reparenting paths (reparentTo and resolveParentFromProcfs). The probe wires the hook to the current ruleset on every OnNewRuleSetLoaded.

Cover the behaviour with a functional test that uses a new syscall_tester "subreaper-with-var" helper: an intermediate process fires a set-variable rule, exits, the grandchild is reparented onto the subreaper, and a check rule asserts the inherited value still resolves against the grandchild.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
