### PR TITLE
[AGTMETRICS] telemetry check: log Gather errors to aid debugging

### DIFF
--- a/pkg/collector/corechecks/telemetry/check.go
+++ b/pkg/collector/corechecks/telemetry/check.go
@@ -35,6 +35,7 @@ type checkImpl struct {
 func (c *checkImpl) Run() error {
 	mfs, err := c.telemetry.Gather(true)
 	if err != nil {
+		log.Warnf("agent_telemetry check: failed to gather default telemetry metrics: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
## What does this PR do?

Adds a `Warnf` log line when `Gather(true)` fails in the `agent_telemetry` check's `Run()` method. Previously the error was silently returned with no log output, making it impossible to diagnose failures from log data alone.

```go
// Before
if err != nil {
    return err
}

// After
if err != nil {
    log.Warnf("agent_telemetry check: failed to gather default telemetry metrics: %v", err)
    return err
}
```

## Motivation

Investigation of a 25% `agent_telemetry` check failure rate on ddstaging clusters (notebook: https://ddstaging.datadoghq.com/notebook/14614870). The failure rate jumped from <0.02% to 25% on lagaffe (nightly builds) starting with `main-0a5bcc53` (May 21 2026) and has persisted in every subsequent nightly.

Current state: `datadog.agent.checks.runs{state:fail, check_name:agent_telemetry}` shows ~25% failure across all agent profiles (compute-nodeless-200m-v2, default, gpu-nodes) on lagaffe, yet there are **no error log entries** corresponding to these failures. Without this log line, it is impossible to confirm from logs what `Gather(true)` returns when it fails.

### Known suspects from investigation

Two parallel threads of inquiry remain open:

1. **Python `agent_telemetry` check (primary suspect for the 25% rate)**: Error logs on lagaffe show a Python check named `agent_telemetry` failing with HTTP connection errors to `localhost:7650-7654/telemetry` ("Connection refused", ~5000 occurrences/24h). This Python check is distinct from this Go check. The port it targets may have changed with `main-0a5bcc53`.

2. **Race condition in `defaultRegistry.Gather()`**: Analysis of the two AGTHEAL V2 migrations merged 8 seconds apart on May 21 (PR #50904 demultiplexer V2, PR #49779 settings V2) found that `Gather(defaultGather=true)` accesses `t.defaultRegistry` **without holding any lock**, while `mustRegister()` for `DefaultMetric: true` metrics also runs without the telemetry mutex. Under concurrent load this could cause Prometheus registry errors. The V2 migrations may have altered component initialization order, exposing this pre-existing race.

## How to validate

This PR adds observability only. After merging to a nightly build on lagaffe:
- Check for `agent_telemetry check: failed to gather default telemetry metrics: <error>` in agent logs
- The error message will identify the actual root cause (registry error, missing metric, etc.)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: pducolin <pducolin@users.noreply.github.com>