### PR TITLE
Remove release env vars from internal image builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -583,19 +583,13 @@ workflow:
 .on_deploy_internal_or_internal_image_change_or_manual:
   - !reference [.except_mergequeue]
   - <<: *if_deploy
-    variables:
-      RELEASE_PROD: "true"
   - changes:
       paths:
         - .gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
         - Dockerfiles/**/*
       compare_to: $COMPARE_TO_BRANCH
-    variables:
-      RELEASE_PROD: "false"
   - when: manual
     allow_failure: true
-    variables:
-      RELEASE_PROD: "false"
 
 .on_deploy_nightly_repo_branch:
   - <<: *if_not_nightly_or_dev_repo_branch

--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -17,7 +17,6 @@
         RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
   script:
     # Constant variables
-    - export RELEASE_STAGING=""
     - export DYNAMIC_BUILD_RENDER_RULES="agent-build-only"
     - export IMAGES_GIT_REF="master"
     # Job specific variables
@@ -37,14 +36,7 @@
         TMPL_SRC_REPO="${TMPL_SRC_REPO}-nightly"
       fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${BASE_RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}${RELEASE_TAG_SUFFIX}${RELEASE_TAG_COMPRESSION_SUFFIX}"; fi
-    - |
-      # TODO: Remove this workaround once JIT replication is reliable for these
-      # images.
-      if [ -z "$CI_COMMIT_TAG" ]; then
-        export RELEASE_STAGING="true"
-        export RELEASE_PROD=""
-      fi
-    - "dda inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref ${IMAGES_GIT_REF} --timeout 3600 --variable IMAGE_VERSION --variable IMAGE_NAME --variable RELEASE_TAG --variable TMPL_SRC_IMAGE --variable TMPL_SRC_REPO --variable TMPL_ADP_VERSION --variable RELEASE_STAGING --variable RELEASE_PROD --variable DYNAMIC_BUILD_RENDER_RULES --variable APPS --variable BAZEL_TARGET --variable DDR --variable DDR_WORKFLOW_ID --variable TARGET_ENV --variable DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+    - "dda inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref ${IMAGES_GIT_REF} --timeout 3600 --variable IMAGE_VERSION --variable IMAGE_NAME --variable RELEASE_TAG --variable TMPL_SRC_IMAGE --variable TMPL_SRC_REPO --variable TMPL_ADP_VERSION --variable DYNAMIC_BUILD_RENDER_RULES --variable APPS --variable BAZEL_TARGET --variable DDR --variable DDR_WORKFLOW_ID --variable TARGET_ENV --variable DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
   retry: 2
 
 # -- binary specific variables --
@@ -57,7 +49,6 @@
   IMAGE_VERSION: tmpl-v12
   IMAGE_NAME: datadog-cluster-agent
   TMPL_SRC_REPO: ci/datadog-agent/cluster-agent
-  RELEASE_PROD: "true"
 
 .ot_standalone_variables: &ot_standalone_variables
   IMAGE_VERSION: tmpl-v7


### PR DESCRIPTION
## Summary

This PR removes the release-target controls from internal image build child pipelines:

- removes `RELEASE_PROD` from the internal image deploy CI rules
- removes the `RELEASE_STAGING` initialization and non-tag override from the internal image deploy script
- stops forwarding both `RELEASE_PROD` and `RELEASE_STAGING` into the `DataDog/images` child pipeline
- removes the DCA-specific `RELEASE_PROD` override

## Problem

Internal image builds could still forward release-like flags into the images pipeline through a mix of rule-level variables, script exports, and job-specific variables. Removing these variables lets the images pipeline use its own defaults instead of receiving release-target hints from datadog-agent CI.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "parsed #{path}" }' .gitlab-ci.yml .gitlab/deploy/internal_image_deploy/internal_image_deploy.yml`
- `rg -n "RELEASE_STAGING|RELEASE_PROD" .gitlab-ci.yml .gitlab/deploy/internal_image_deploy/internal_image_deploy.yml` returns no matches
- commit hooks: `protected-branches`, `shell-check-no-set-x`, `update-go`
- pre-push hooks: `fix end of files`, `protected-branches`, `go-mod-tidy`, `go-mod-replace`, `go-test`, `go-linter`, `gitlab-configuration`
