### PR TITLE
Bump rshell to v0.0.20 (#51247)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -960,7 +960,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/hostport v0.80.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace v0.80.0-rc.3
 	github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5
-	github.com/DataDog/rshell v0.0.18
+	github.com/DataDog/rshell v0.0.20
 	github.com/aptly-dev/aptly v1.6.3-0.20260504093056-0d31298f3709
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.6
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.5

--- a/go.sum
+++ b/go.sum
@@ -2591,8 +2591,8 @@ github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816 h1:8diKw2aLYE6LsjWfYxD
 github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816/go.mod h1:7cPuErOAt7k/oVWAVJnxqAC6mwArrAazkvk0RXiih2A=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260416144717-96f8924d6e18 h1:VbUS1B3mpSjponiKDWHXtofoNBp99Nckf5uZaBeQyPo=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260416144717-96f8924d6e18/go.mod h1:34LtYk9Gh/SCItzi7v8ok9E5lk88AA5I+5aKoVKQClI=
-github.com/DataDog/rshell v0.0.18 h1:gQB6Y1p5fHyg+QA5FjA/3JFmhiVuAly/WoSM9H2Yh2o=
-github.com/DataDog/rshell v0.0.18/go.mod h1:jZm0YIxCKYEyHJeSSH5rxqmlI1oUi+mXQF6Zf102q+k=
+github.com/DataDog/rshell v0.0.20 h1:WO/GUY/SPplBBRU2wPVMLE8SCP4lZpFhVXu/h6KBzb0=
+github.com/DataDog/rshell v0.0.20/go.mod h1:jZm0YIxCKYEyHJeSSH5rxqmlI1oUi+mXQF6Zf102q+k=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=
 github.com/DataDog/sketches-go v1.4.8/go.mod h1:a/wjRUqzqtGS8qRHRPDCs4EAQfmvPDZGDlMIF5mxXOE=
 github.com/DataDog/trivy v0.0.0-20260513170708-3c7f1f6b38e8 h1:SGspm+q7GP1LWZvvhx2NbkRjYWRowvTXvI/QXAbkrrg=

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -6,9 +6,11 @@
 package com_datadoghq_remoteaction_rshell
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
@@ -18,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
+	"github.com/DataDog/rshell/interp"
 )
 
 func makeTask(command string, allowedCommands []string) *types.Task {
@@ -534,6 +537,49 @@ func TestRunCommandSandboxWarningsNilWhenCleanConfig(t *testing.T) {
 	assert.Equal(t, 0, result.ExitCode)
 	assert.Nil(t, result.SandboxWarnings,
 		"a clean sandbox configuration must produce no warnings")
+}
+
+func TestRunCommandOutputLimitsReturnActionErrors(t *testing.T) {
+	// RunCommandOutputs has no truncation marker. Treat output caps as
+	// action errors instead of returning partial stdout/stderr as normal
+	// command results.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "payload.txt"),
+		bytes.Repeat([]byte("x"), 10*1024*1024+1),
+		0600,
+	))
+
+	cases := []struct {
+		name    string
+		command string
+		wantErr error
+	}{
+		{
+			name:    "stdout limit",
+			command: "cat payload.txt",
+			wantErr: interp.ErrOutputLimitExceeded,
+		},
+		{
+			name:    "stderr limit",
+			command: "cat payload.txt >&2",
+			wantErr: interp.ErrStderrLimitExceeded,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := NewRunCommandHandler([]string{setup.RShellPathAllowAll}, []string{"rshell:cat"})
+			task := makeTaskWithPaths(tc.command,
+				[]string{"rshell:cat"},
+				map[string][]string{setup.RShellPathAllowMapDefaultKey: {dir}})
+
+			out, err := handler.Run(context.Background(), task, nil)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tc.wantErr)
+			assert.Nil(t, out)
+		})
+	}
 }
 
 func mockStatFn(existing map[string]bool) func(string) (os.FileInfo, error) {


### PR DESCRIPTION
Backport of https://github.com/DataDog/datadog-agent/pull/51247

---

Bumps `github.com/DataDog/rshell` from `v0.0.18` to `v0.0.20` and updates the corresponding `go.sum` entries.

Adds focused `runCommand` coverage that pins stdout and stderr output-limit sentinels as action-level errors instead of normal `RunCommandOutputs`, since the output schema has no truncation marker.

Pick up the latest `rshell` release in the Agent dependency set.

Mainly for this security fix: https://github.com/DataDog/rshell/pull/268

- `dda inv test --targets=./pkg/privateactionrunner/bundles/remoteaction/rshell --extra-args="-run ^TestRunCommandOutputLimitsReturnActionErrors$ -count=1 -timeout=30s"`
- `git diff --check`

The output-limit test documents the intentional integration contract: partial stdout/stderr from rshell output caps is not returned as a normal command result without an explicit truncation field.


(cherry picked from commit 9101702b630538ecd6db0b949e7d8750d4953ef5)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
