### PR TITLE
serverless-init: enable Remote Config support

### DIFF
--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -50,6 +50,7 @@ import (
 	serverlessInitTag "github.com/DataDog/datadog-agent/cmd/serverless-init/tag"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
@@ -59,6 +60,7 @@ import (
 	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 const datadogConfigPath = "datadog.yaml"
@@ -171,8 +173,10 @@ func setup(secretComp secrets.Component, delegatedAuthComp delegatedauth.Compone
 		return cloudService, agentLogConfig, tracingCtx, metricAgent, logsAgent, nil, false
 	}
 
+	rcService := setupRemoteConfig(hostname)
+
 	traceTags := serverlessInitTag.MakeTraceAgentTags(tagConfig.Tags)
-	traceAgent := setupTraceAgent(traceTags, tagConfig.ConfiguredTags, tagger, origin)
+	traceAgent := setupTraceAgent(traceTags, tagConfig.ConfiguredTags, tagger, origin, rcService)
 
 	tracingCtx := &cloudservice.TracingContext{
 		TraceAgent: traceAgent,
@@ -261,7 +265,7 @@ var serverlessProfileTags = []string{
 	"_dd.origin",
 }
 
-func setupTraceAgent(tags map[string]string, configuredTags []string, tagger tagger.Component, origin string) trace.ServerlessTraceAgent {
+func setupTraceAgent(tags map[string]string, configuredTags []string, tagger tagger.Component, origin string, rcService *remoteconfig.CoreAgentService) trace.ServerlessTraceAgent {
 	profileTags := make(map[string]string)
 	for _, serverlessProfileTag := range serverlessProfileTags {
 		if value, ok := tags[serverlessProfileTag]; ok {
@@ -292,6 +296,7 @@ func setupTraceAgent(tags map[string]string, configuredTags []string, tagger tag
 		LoadConfig:            &trace.LoadConfig{Path: datadogConfigPath, Tagger: tagger},
 		AdditionalProfileTags: profileTags,
 		FunctionTags:          functionTags,
+		RCService:             rcService,
 	})
 	traceAgent.SetTags(tags)
 	go func() {
@@ -300,6 +305,107 @@ func setupTraceAgent(tags map[string]string, configuredTags []string, tagger tag
 		}
 	}()
 	return traceAgent
+}
+
+// noopRcTelemetryReporter satisfies the RcTelemetryReporter interface that
+// remoteconfig.NewService requires, without emitting any metrics.
+//
+// The full Datadog Agent passes DdRcTelemetryReporter from
+// comp/remote-config/rctelemetryreporter/impl, which is backed by
+// comp/core/telemetry (Prometheus). That component is explicitly disabled on
+// serverless builds (comp/core/telemetry/fx/fx.go has //go:build !serverless),
+// and serverless-init already wires in comp/core/telemetry/fx-noop above. So
+// pulling the real reporter is not just heavy — it isn't compiled at all in
+// our build configuration.
+//
+// What we lose: six metrics about RC's own internals (none functional). Every
+// callsite in pkg/config/remote/service/service.go treats the reporter as
+// fire-and-forget, so RC delivers configs identically with the no-op. The
+// metrics and their callsites:
+//
+//   IncRateLimit                            datadog.remoteconfig.cache_bypass_ratelimiter_skip
+//                                           Tracer cache-bypass request was throttled by the
+//                                           rate limiter. service.go:725, 750.
+//   IncTimeout                              datadog.remoteconfig.cache_bypass_timeout
+//                                           Tracer's blocking refresh request timed out before
+//                                           configs arrived from the RC backend. service.go:997.
+//   IncConfigSubscriptionsConnectedCounter  datadog.remoteconfig.config_subscriptions_connected_counter
+//                                           New (client, product) subscription created.
+//   IncConfigSubscriptionsDisconnectedCounter
+//                                           datadog.remoteconfig.config_subscriptions_disconnected_counter
+//                                           Subscription torn down.
+//   SetConfigSubscriptionsActive            datadog.remoteconfig.config_subscriptions_active
+//                                           Current live subscription count.
+//   SetConfigSubscriptionClientsTracked     datadog.remoteconfig.config_subscription_clients_tracked
+//                                           Distinct tracer clients across all subscriptions.
+//
+// These observe RC's own health (throughput, churn, throttling) and are
+// primarily useful to whoever runs the RC backend, not to a customer using
+// serverless-init for tracing. If they become desirable later, the cheap path
+// is to back this type with the ServerlessMetricAgent (pkg/serverless/metrics)
+// that we already start in setupMetricAgent — six calls to AddEnhancedMetric,
+// no new fx wiring, no new dependency. Trying to use comp/core/telemetry
+// directly is a multi-week refactor (would require dropping the `serverless`
+// build tag).
+type noopRcTelemetryReporter struct{}
+
+func (noopRcTelemetryReporter) IncTimeout()                                {}
+func (noopRcTelemetryReporter) IncRateLimit()                              {}
+func (noopRcTelemetryReporter) IncConfigSubscriptionsConnectedCounter()    {}
+func (noopRcTelemetryReporter) IncConfigSubscriptionsDisconnectedCounter() {}
+func (noopRcTelemetryReporter) SetConfigSubscriptionsActive(int)           {}
+func (noopRcTelemetryReporter) SetConfigSubscriptionClientsTracked(int)    {}
+
+// setupRemoteConfig instantiates and starts the embedded RemoteConfig
+// service. The trace-agent's /v0.7/config proxy endpoint depends on this
+// service to forward configurations to in-process tracers (e.g. dd-trace
+// in the customer's process running under serverless-init).
+//
+// Returns nil if RC is disabled or initialization fails — the trace agent's
+// proxy endpoint is gated on a non-nil service.
+func setupRemoteConfig(hostname hostnameinterface.Component) *remoteconfig.CoreAgentService {
+	cfg := pkgconfigsetup.Datadog()
+	if !configUtils.IsRemoteConfigEnabled(cfg) {
+		log.Debug("Remote Config is disabled, skipping RC service setup")
+		return nil
+	}
+
+	apiKey := configUtils.SanitizeAPIKey(cfg.GetString("api_key"))
+	if cfg.IsSet("remote_configuration.api_key") {
+		apiKey = configUtils.SanitizeAPIKey(cfg.GetString("remote_configuration.api_key"))
+	}
+	if apiKey == "" {
+		log.Warn("Remote Config requires DD_API_KEY; service not started")
+		return nil
+	}
+
+	baseRawURL := configUtils.GetMainEndpoint(cfg, "https://config.", "remote_configuration.rc_dd_url")
+
+	opts := []remoteconfig.Option{
+		remoteconfig.WithAPIKey(apiKey),
+		remoteconfig.WithConfigRootOverride(cfg.GetString("site"), cfg.GetString("remote_configuration.config_root")),
+		remoteconfig.WithDirectorRootOverride(cfg.GetString("site"), cfg.GetString("remote_configuration.director_root")),
+		remoteconfig.WithRcKey(cfg.GetString("remote_configuration.key")),
+	}
+
+	svc, err := remoteconfig.NewService(
+		cfg,
+		"Remote Config",
+		baseRawURL,
+		hostname.GetSafe(context.Background()),
+		func() []string { return nil },
+		noopRcTelemetryReporter{},
+		version.AgentVersion,
+		opts...,
+	)
+	if err != nil {
+		log.Warnf("Failed to start Remote Config service: %v", err)
+		return nil
+	}
+
+	svc.Start()
+	log.Info("Remote Config service started")
+	return svc
 }
 
 func setupMetricAgent(tags map[string]string, enhancedMetricTags map[string]string, enhancedUsageMetricTags map[string]string, tagger tagger.Component, shouldForceFlushAllOnForceFlushToSerializer bool) *metrics.ServerlessMetricAgent {

--- a/cmd/serverless-init/mode/mode.go
+++ b/cmd/serverless-init/mode/mode.go
@@ -33,11 +33,9 @@ const (
 func DetectMode() Conf {
 
 	envToSet := map[string]string{
-		"DD_INSTRUMENTATION_TELEMETRY_ENABLED": "false",
-		"DD_REMOTE_CONFIGURATION_ENABLED":      "false",
-		"DD_HOSTNAME":                          "none",
-		"DD_APM_ENABLED":                       "true",
-		"DD_TRACE_ENABLED":                     "true",
+		"DD_HOSTNAME":      "none",
+		"DD_APM_ENABLED":   "true",
+		"DD_TRACE_ENABLED": "true",
 	}
 
 	if len(os.Args) == 1 {


### PR DESCRIPTION
### What does this PR do?

Enables Remote Config in `cmd/serverless-init/`:

- Drops the hard-coded `DD_REMOTE_CONFIGURATION_ENABLED=false` and
  `DD_INSTRUMENTATION_TELEMETRY_ENABLED=false` env defaults in
  `mode/mode.go`.
- Adds a `setupRemoteConfig` in `main.go` that instantiates a
  `pkg/config/remote/service.CoreAgentService` and threads it into the
  trace agent via `trace.StartServerlessTraceAgentArgs.RCService`. This
  is what makes the trace agent's `/v0.7/config` endpoint a real proxy
  to the in-process tracer (e.g. dd-trace running under serverless-init
  in init mode).
- Includes a `noopRcTelemetryReporter` since `comp/core/telemetry/fx`
  isn't compiled on serverless builds (its `fx.go` has
  `//go:build !serverless`, and serverless-init already wires
  `comp/core/telemetry/fx-noop`). The new comment block in `main.go`
  documents the six RC metrics this forfeits and the upgrade path
  (back the type with the existing `ServerlessMetricAgent`) if those
  metrics become desirable.

### Motivation

Customers using serverless-init for tracing on Cloud Run / Azure
Container Apps / Azure App Service (and increasingly Lambda Managed
Instances) currently can't use Remote Config or Live Debugger because
the binary hard-disables both RC and tracer instrumentation telemetry
at startup, and the trace agent's `/v0.7/config` proxy isn't wired to
a backing RC service.

The instrumentation-telemetry default is the subtler half: Live
Debugger's backend matches probes against the `live-service-instances`
list, which is populated from tracer telemetry. With telemetry off,
every probe sits in `NO_AGENTS — No instances match the probe instance
selection`, even when RC is otherwise working.

### Describe how you validated your changes

Built `cmd/serverless-init/` (linux/arm64, tags `serverless otlp`,
ldflags injecting `AgentVersion`) and ran it in a local Docker
container wrapping a `dd-trace-py 4.8.7` sample app pointed at
`config.datadoghq.com`.

Confirmed in container logs:
- `Detected cloud service: local`
- `Remote Config service started`
- Tracer registers RC products `APM_TRACING`, `AGENT_CONFIG`,
  `AGENT_TASK`, `ASM_FEATURES`, `LIVE_DEBUGGING`,
  `LIVE_DEBUGGING_SYMBOL_DB` against the local agent.
- Trace agent `/info` advertises `/v0.7/config`, `/debugger/v1/input`,
  `/debugger/v1/diagnostics`, `/debugger/v2/input`, `/symdb/v1/input`,
  `/telemetry/proxy/`.

Confirmed in the Datadog UI (Live Debugger sessions for service
`local-serverless-init` env `dev`):
- The service shows as recognized (language Python).
- Log probes set on `app.py:32` and `app.py:36` flip from
  `NO_AGENTS` → `ACTIVE — 1/1 instances instrumented successfully`.
- Snapshots stream into the session's events panel in real time
  (~700 events captured over the verification window).

### Additional Notes

**No new module dependencies.** Both `pkg/config/remote/service` and
`pkg/version` are already in the monorepo and transitively reachable
from `pkg/serverless/trace` (which already exposes `RCService` in its
public API). Measured binary size delta on linux/arm64 builds (CGO,
tags `serverless otlp`, ldflags injecting `AgentVersion`):

| build | bytes | size |
| --- | --- | --- |
| no RC wiring (stock main) | 68,097,328 | 64.943 MB |
| with RC wiring (this PR) | 68,117,808 | 64.963 MB |
| delta | +20,480 B | +20.0 KB (~0.03%) |

**Two operational caveats I'd like reviewers' input on:**

1. `cmd/serverless-init/` ships with `pkg/version.AgentVersion` at its
   default `"6.0.0"` unless built with `-ldflags '-X .../AgentVersion=...'`.
   Datadog Live Debugger requires `min_agent_version: 7.49.0` for the
   enablement capabilities (`manual_enablement`, `one_click_enablement`,
   `default_on_enablement`), so customers running stock serverless-init
   release builds will see the UI treat their service as unsupported.
   Worth confirming the release build path injects the real version.

2. In init mode (i.e. when serverless-init wraps a customer process,
   not sidecar mode), `DD_LOGS_ENABLED` defaults to `false`. The trace
   agent's `/debugger/v2/input` proxy gates on `logs_enabled` and
   silently drops every snapshot otherwise, with only a DEBUG-level log
   line. This is the worst footgun a Live Debugger customer can hit
   — probes show installed, no errors, no snapshots. Not addressed in
   this PR, but worth either flipping the default in init mode or
   surfacing prominently in the docs.

Marking draft; happy to add tests once we agree on shape. Sibling task
running serverless-init on Lambda Managed Instances has validated the
same RC wiring against the Lambda runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)