### PR TITLE
enhance(instrumentation): Add instrumentation status endpoint to skip config collection when up to date.

### DIFF
--- a/cmd/cluster-agent/api/v1/instrumentationchecks.go
+++ b/cmd/cluster-agent/api/v1/instrumentationchecks.go
@@ -29,8 +29,8 @@ func getInstrumentationConfigs(confLister clusteragent.ConfigLister) func(w http
 	}
 
 	return func(w http.ResponseWriter, _ *http.Request) {
-		response := cctypes.ConfigResponse{
-			LastChange: confLister.LastChange(),
+		response := cctypes.InstrumentationConfigResponse{
+			ConfigHash: confLister.ConfigHash(),
 			Configs:    confLister.ListConfigs(),
 		}
 		slcB, err := json.Marshal(response)
@@ -52,7 +52,7 @@ func getInstrumentationStatus(confLister clusteragent.ConfigLister) func(w http.
 
 	return func(w http.ResponseWriter, _ *http.Request) {
 		response := cctypes.InstrumentationStatusResponse{
-			LastChange: confLister.LastChange(),
+			ConfigHash: confLister.ConfigHash(),
 		}
 		slcB, err := json.Marshal(response)
 		if err != nil {

--- a/cmd/cluster-agent/api/v1/instrumentationchecks.go
+++ b/cmd/cluster-agent/api/v1/instrumentationchecks.go
@@ -29,9 +29,10 @@ func getInstrumentationConfigs(confLister clusteragent.ConfigLister) func(w http
 	}
 
 	return func(w http.ResponseWriter, _ *http.Request) {
+		configs, hash := confLister.ListConfigs()
 		response := cctypes.InstrumentationConfigResponse{
-			ConfigHash: confLister.ConfigHash(),
-			Configs:    confLister.ListConfigs(),
+			ConfigHash: hash,
+			Configs:    configs,
 		}
 		slcB, err := json.Marshal(response)
 		if err != nil {
@@ -52,7 +53,7 @@ func getInstrumentationStatus(confLister clusteragent.ConfigLister) func(w http.
 
 	return func(w http.ResponseWriter, _ *http.Request) {
 		response := cctypes.InstrumentationStatusResponse{
-			ConfigHash: confLister.ConfigHash(),
+			ConfigHash: confLister.Hash(),
 		}
 		slcB, err := json.Marshal(response)
 		if err != nil {

--- a/cmd/cluster-agent/api/v1/instrumentationchecks.go
+++ b/cmd/cluster-agent/api/v1/instrumentationchecks.go
@@ -18,6 +18,7 @@ import (
 
 func installInstrumentationCheckEndpoints(r *http.ServeMux, confLister clusteragent.ConfigLister) {
 	r.HandleFunc("GET /instrumentation/configs", api.WithTelemetryWrapper("getInstrumentationConfigs", getInstrumentationConfigs(confLister)))
+	r.HandleFunc("GET /instrumentation/status", api.WithTelemetryWrapper("getInstrumentationStatus", getInstrumentationStatus(confLister)))
 }
 
 func getInstrumentationConfigs(confLister clusteragent.ConfigLister) func(w http.ResponseWriter, r *http.Request) {
@@ -29,7 +30,29 @@ func getInstrumentationConfigs(confLister clusteragent.ConfigLister) func(w http
 
 	return func(w http.ResponseWriter, _ *http.Request) {
 		response := cctypes.ConfigResponse{
-			Configs: confLister.ListConfigs(),
+			LastChange: confLister.LastChange(),
+			Configs:    confLister.ListConfigs(),
+		}
+		slcB, err := json.Marshal(response)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(slcB) //nolint:errcheck
+	}
+}
+
+func getInstrumentationStatus(confLister clusteragent.ConfigLister) func(w http.ResponseWriter, r *http.Request) {
+	if confLister == nil {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "instrumentation config provider not available", http.StatusServiceUnavailable)
+		}
+	}
+
+	return func(w http.ResponseWriter, _ *http.Request) {
+		response := cctypes.InstrumentationStatusResponse{
+			LastChange: confLister.LastChange(),
 		}
 		slcB, err := json.Marshal(response)
 		if err != nil {

--- a/comp/core/autodiscovery/listeners/service.go
+++ b/comp/core/autodiscovery/listeners/service.go
@@ -148,7 +148,6 @@ func (s *WorkloadService) FilterTemplates(configs map[string]integration.Config)
 	// comp/core/autodiscovery/configresolver/configresolver.go
 	s.filterTemplatesEmptyOverrides(configs)
 	s.filterTemplatesOverriddenChecks(configs)
-	s.filterTemplatesInstrumentationOverFile(configs)
 	filterTemplatesMatched(s, configs)
 
 	// Runs after matching so only instrumentation configs that are actually

--- a/comp/core/autodiscovery/listeners/service.go
+++ b/comp/core/autodiscovery/listeners/service.go
@@ -148,6 +148,7 @@ func (s *WorkloadService) FilterTemplates(configs map[string]integration.Config)
 	// comp/core/autodiscovery/configresolver/configresolver.go
 	s.filterTemplatesEmptyOverrides(configs)
 	s.filterTemplatesOverriddenChecks(configs)
+	s.filterTemplatesInstrumentationOverFile(configs)
 	filterTemplatesMatched(s, configs)
 
 	// Runs after matching so only instrumentation configs that are actually

--- a/comp/core/autodiscovery/providers/instrumentationchecks.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks.go
@@ -29,6 +29,7 @@ type InstrumentationChecksConfigProvider struct {
 	degradedDuration time.Duration
 	heartbeat        time.Time
 	flushedConfigs   bool
+	lastChange       int64
 }
 
 // NewInstrumentationChecksConfigProvider returns a new ConfigProvider collecting
@@ -53,9 +54,18 @@ func (c *InstrumentationChecksConfigProvider) String() string {
 	return names.InstrumentationChecks
 }
 
-// IsUpToDate always returns false so that Collect is called on every poll cycle.
-func (c *InstrumentationChecksConfigProvider) IsUpToDate(_ context.Context) (bool, error) {
-	return false, nil
+// IsUpToDate polls the cluster agent's /instrumentation/status endpoint and
+// compares the returned timestamp against the provider's last known change.
+func (c *InstrumentationChecksConfigProvider) IsUpToDate(ctx context.Context) (bool, error) {
+	if c.dcaClient == nil {
+		return false, nil
+	}
+	status, err := c.dcaClient.GetInstrumentationStatus(ctx)
+	if err != nil {
+		// On error, fall through to Collect so the provider can handle degraded mode.
+		return false, nil
+	}
+	return status.LastChange == c.lastChange, nil
 }
 
 func (c *InstrumentationChecksConfigProvider) withinDegradedModePeriod() bool {
@@ -95,6 +105,7 @@ func (c *InstrumentationChecksConfigProvider) Collect(ctx context.Context) ([]in
 	// restarts from this successful response.
 	c.flushedConfigs = false
 	c.heartbeat = time.Now()
+	c.lastChange = reply.LastChange
 
 	return reply.Configs, nil
 }

--- a/comp/core/autodiscovery/providers/instrumentationchecks.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks.go
@@ -60,6 +60,14 @@ func (c *InstrumentationChecksConfigProvider) IsUpToDate(ctx context.Context) (b
 	if c.dcaClient == nil {
 		return false, nil
 	}
+
+	// If configs were flushed due to a transient error, force a Collect so checks
+	// get rescheduled once the cluster agent recovers — even if LastChange hasn't
+	// advanced (no config mutations occurred during the outage).
+	if c.flushedConfigs {
+		return false, nil
+	}
+
 	status, err := c.dcaClient.GetInstrumentationStatus(ctx)
 	if err != nil {
 		// On error, fall through to Collect so the provider can handle degraded mode.

--- a/comp/core/autodiscovery/providers/instrumentationchecks.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks.go
@@ -29,7 +29,7 @@ type InstrumentationChecksConfigProvider struct {
 	degradedDuration time.Duration
 	heartbeat        time.Time
 	flushedConfigs   bool
-	lastChange       int64
+	configHash       int64
 }
 
 // NewInstrumentationChecksConfigProvider returns a new ConfigProvider collecting
@@ -55,15 +55,16 @@ func (c *InstrumentationChecksConfigProvider) String() string {
 }
 
 // IsUpToDate polls the cluster agent's /instrumentation/status endpoint and
-// compares the returned timestamp against the provider's last known change.
+// compares the returned config hash against the provider's last known hash.
+// Returns true (skip Collect) only when the cluster agent confirms no new changes.
 func (c *InstrumentationChecksConfigProvider) IsUpToDate(ctx context.Context) (bool, error) {
 	if c.dcaClient == nil {
 		return false, nil
 	}
 
 	// If configs were flushed due to a transient error, force a Collect so checks
-	// get rescheduled once the cluster agent recovers — even if LastChange hasn't
-	// advanced (no config mutations occurred during the outage).
+	// get rescheduled once the cluster agent recovers — even if the config hash
+	// hasn't changed (no config mutations occurred during the outage).
 	if c.flushedConfigs {
 		return false, nil
 	}
@@ -73,7 +74,7 @@ func (c *InstrumentationChecksConfigProvider) IsUpToDate(ctx context.Context) (b
 		// On error, fall through to Collect so the provider can handle degraded mode.
 		return false, nil
 	}
-	return status.LastChange == c.lastChange, nil
+	return status.ConfigHash == c.configHash, nil
 }
 
 func (c *InstrumentationChecksConfigProvider) withinDegradedModePeriod() bool {
@@ -113,7 +114,7 @@ func (c *InstrumentationChecksConfigProvider) Collect(ctx context.Context) ([]in
 	// restarts from this successful response.
 	c.flushedConfigs = false
 	c.heartbeat = time.Now()
-	c.lastChange = reply.LastChange
+	c.configHash = reply.ConfigHash
 
 	return reply.Configs, nil
 }

--- a/comp/core/autodiscovery/providers/instrumentationchecks.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks.go
@@ -29,7 +29,7 @@ type InstrumentationChecksConfigProvider struct {
 	degradedDuration time.Duration
 	heartbeat        time.Time
 	flushedConfigs   bool
-	configHash       int64
+	configHash       uint64
 }
 
 // NewInstrumentationChecksConfigProvider returns a new ConfigProvider collecting

--- a/comp/core/autodiscovery/providers/instrumentationchecks_test.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks_test.go
@@ -54,8 +54,8 @@ func TestInstrumentationChecksCollect(t *testing.T) {
 		wantErr          bool
 		wantErrVal       error
 		wantFlushed      bool
-		wantHeartbeat    bool  // whether heartbeat should be non-zero after Collect
-		wantConfigHash   int64 // expected configHash saved after Collect
+		wantHeartbeat    bool
+		wantConfigHash   uint64
 	}{
 		{
 			name: "success with configs",

--- a/comp/core/autodiscovery/providers/instrumentationchecks_test.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks_test.go
@@ -25,13 +25,13 @@ import (
 
 // mockInstrumentationClient implements InstrumentationCheckClient.
 type mockInstrumentationClient struct {
-	configs   types.ConfigResponse
+	configs   types.InstrumentationConfigResponse
 	err       error
 	status    types.InstrumentationStatusResponse
 	statusErr error
 }
 
-func (m *mockInstrumentationClient) GetInstrumentationConfigs(_ context.Context) (types.ConfigResponse, error) {
+func (m *mockInstrumentationClient) GetInstrumentationConfigs(_ context.Context) (types.InstrumentationConfigResponse, error) {
 	return m.configs, m.err
 }
 
@@ -55,13 +55,13 @@ func TestInstrumentationChecksCollect(t *testing.T) {
 		wantErrVal       error
 		wantFlushed      bool
 		wantHeartbeat    bool  // whether heartbeat should be non-zero after Collect
-		wantLastChange   int64 // expected lastChange saved after Collect
+		wantConfigHash   int64 // expected configHash saved after Collect
 	}{
 		{
 			name: "success with configs",
 			client: &mockInstrumentationClient{
-				configs: types.ConfigResponse{
-					LastChange: 12345,
+				configs: types.InstrumentationConfigResponse{
+					ConfigHash: 12345,
 					Configs: []integration.Config{
 						{Name: "check1"},
 						{Name: "check2"},
@@ -71,28 +71,28 @@ func TestInstrumentationChecksCollect(t *testing.T) {
 			wantConfigs:      []integration.Config{{Name: "check1"}, {Name: "check2"}},
 			wantFlushed:      false,
 			wantHeartbeat:    true,
-			wantLastChange:   12345,
+			wantConfigHash:   12345,
 		},
 		{
 			name: "success resets flushedConfigs and updates heartbeat",
 			client: &mockInstrumentationClient{
-				configs: types.ConfigResponse{LastChange: 99999, Configs: []integration.Config{{Name: "check1"}}},
+				configs: types.InstrumentationConfigResponse{ConfigHash: 99999, Configs: []integration.Config{{Name: "check1"}}},
 			},
 			degradedDuration: defaultDegradedDeadline,
 			flushedConfigs:   true,
 			wantConfigs:      []integration.Config{{Name: "check1"}},
 			wantFlushed:      false,
 			wantHeartbeat:    true,
-			wantLastChange:   99999,
+			wantConfigHash:   99999,
 		},
 		{
 			name:             "empty response still updates heartbeat",
-			client:           &mockInstrumentationClient{configs: types.ConfigResponse{LastChange: 1, Configs: []integration.Config{}}},
+			client:           &mockInstrumentationClient{configs: types.InstrumentationConfigResponse{ConfigHash: 1, Configs: []integration.Config{}}},
 			degradedDuration: defaultDegradedDeadline,
 			wantConfigs:      []integration.Config{},
 			wantFlushed:      false,
 			wantHeartbeat:    true,
-			wantLastChange:   1,
+			wantConfigHash:   1,
 		},
 		{
 			name:             "remote error within infinite degraded mode returns error",
@@ -171,7 +171,7 @@ func TestInstrumentationChecksCollect(t *testing.T) {
 				assert.Equal(t, names.InstrumentationChecks, cfg.Provider)
 			}
 			assert.Equal(t, tt.wantFlushed, provider.flushedConfigs)
-			assert.Equal(t, tt.wantLastChange, provider.lastChange)
+			assert.Equal(t, tt.wantConfigHash, provider.configHash)
 			if tt.wantHeartbeat {
 				assert.False(t, provider.heartbeat.IsZero())
 			}
@@ -194,45 +194,45 @@ func TestInstrumentationChecksIsUpToDate(t *testing.T) {
 	tests := []struct {
 		name           string
 		client         clusteragent.InstrumentationCheckClient
-		lastChange     int64
+		configHash     int64
 		flushedConfigs bool
 		wantResult     bool
 	}{
 		{
 			name:       "timestamps match — up to date",
-			client:     &mockInstrumentationClient{status: types.InstrumentationStatusResponse{LastChange: 100}},
-			lastChange: 100,
+			client:     &mockInstrumentationClient{status: types.InstrumentationStatusResponse{ConfigHash: 100}},
+			configHash: 100,
 			wantResult: true,
 		},
 		{
 			name:       "server timestamp is newer — not up to date",
-			client:     &mockInstrumentationClient{status: types.InstrumentationStatusResponse{LastChange: 200}},
-			lastChange: 100,
+			client:     &mockInstrumentationClient{status: types.InstrumentationStatusResponse{ConfigHash: 200}},
+			configHash: 100,
 			wantResult: false,
 		},
 		{
 			name:       "no changes yet — both zero",
-			client:     &mockInstrumentationClient{status: types.InstrumentationStatusResponse{LastChange: 0}},
-			lastChange: 0,
+			client:     &mockInstrumentationClient{status: types.InstrumentationStatusResponse{ConfigHash: 0}},
+			configHash: 0,
 			wantResult: true,
 		},
 		{
 			name:           "flushed configs — force Collect even if timestamps match",
-			client:         &mockInstrumentationClient{status: types.InstrumentationStatusResponse{LastChange: 100}},
-			lastChange:     100,
+			client:         &mockInstrumentationClient{status: types.InstrumentationStatusResponse{ConfigHash: 100}},
+			configHash:     100,
 			flushedConfigs: true,
 			wantResult:     false,
 		},
 		{
 			name:       "status endpoint error — fall through to Collect",
 			client:     &mockInstrumentationClient{statusErr: errors.New("connection refused")},
-			lastChange: 100,
+			configHash: 100,
 			wantResult: false,
 		},
 		{
 			name:       "nil client — fall through to Collect",
 			client:     nil,
-			lastChange: 0,
+			configHash: 0,
 			wantResult: false,
 		},
 	}
@@ -241,7 +241,7 @@ func TestInstrumentationChecksIsUpToDate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &InstrumentationChecksConfigProvider{
 				dcaClient:      tt.client,
-				lastChange:     tt.lastChange,
+				configHash:     tt.configHash,
 				flushedConfigs: tt.flushedConfigs,
 			}
 			upToDate, err := provider.IsUpToDate(context.Background())

--- a/comp/core/autodiscovery/providers/instrumentationchecks_test.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks_test.go
@@ -20,16 +20,23 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 )
 
 // mockInstrumentationClient implements InstrumentationCheckClient.
 type mockInstrumentationClient struct {
-	configs types.ConfigResponse
-	err     error
+	configs   types.ConfigResponse
+	err       error
+	status    types.InstrumentationStatusResponse
+	statusErr error
 }
 
 func (m *mockInstrumentationClient) GetInstrumentationConfigs(_ context.Context) (types.ConfigResponse, error) {
 	return m.configs, m.err
+}
+
+func (m *mockInstrumentationClient) GetInstrumentationStatus(_ context.Context) (types.InstrumentationStatusResponse, error) {
+	return m.status, m.statusErr
 }
 
 func TestInstrumentationChecksCollect(t *testing.T) {
@@ -47,39 +54,45 @@ func TestInstrumentationChecksCollect(t *testing.T) {
 		wantErr          bool
 		wantErrVal       error
 		wantFlushed      bool
-		wantHeartbeat    bool // whether heartbeat should be non-zero after Collect
+		wantHeartbeat    bool  // whether heartbeat should be non-zero after Collect
+		wantLastChange   int64 // expected lastChange saved after Collect
 	}{
 		{
 			name: "success with configs",
 			client: &mockInstrumentationClient{
-				configs: types.ConfigResponse{Configs: []integration.Config{
-					{Name: "check1"},
-					{Name: "check2"},
-				}},
+				configs: types.ConfigResponse{
+					LastChange: 12345,
+					Configs: []integration.Config{
+						{Name: "check1"},
+						{Name: "check2"},
+					}},
 			},
 			degradedDuration: defaultDegradedDeadline,
 			wantConfigs:      []integration.Config{{Name: "check1"}, {Name: "check2"}},
 			wantFlushed:      false,
 			wantHeartbeat:    true,
+			wantLastChange:   12345,
 		},
 		{
 			name: "success resets flushedConfigs and updates heartbeat",
 			client: &mockInstrumentationClient{
-				configs: types.ConfigResponse{Configs: []integration.Config{{Name: "check1"}}},
+				configs: types.ConfigResponse{LastChange: 99999, Configs: []integration.Config{{Name: "check1"}}},
 			},
 			degradedDuration: defaultDegradedDeadline,
 			flushedConfigs:   true,
 			wantConfigs:      []integration.Config{{Name: "check1"}},
 			wantFlushed:      false,
 			wantHeartbeat:    true,
+			wantLastChange:   99999,
 		},
 		{
 			name:             "empty response still updates heartbeat",
-			client:           &mockInstrumentationClient{configs: types.ConfigResponse{Configs: []integration.Config{}}},
+			client:           &mockInstrumentationClient{configs: types.ConfigResponse{LastChange: 1, Configs: []integration.Config{}}},
 			degradedDuration: defaultDegradedDeadline,
 			wantConfigs:      []integration.Config{},
 			wantFlushed:      false,
 			wantHeartbeat:    true,
+			wantLastChange:   1,
 		},
 		{
 			name:             "remote error within infinite degraded mode returns error",
@@ -158,6 +171,7 @@ func TestInstrumentationChecksCollect(t *testing.T) {
 				assert.Equal(t, names.InstrumentationChecks, cfg.Provider)
 			}
 			assert.Equal(t, tt.wantFlushed, provider.flushedConfigs)
+			assert.Equal(t, tt.wantLastChange, provider.lastChange)
 			if tt.wantHeartbeat {
 				assert.False(t, provider.heartbeat.IsZero())
 			}
@@ -174,4 +188,65 @@ func TestInstrumentationChecksCollectNilClientInitFails(t *testing.T) {
 	configs, err := provider.Collect(context.Background())
 	assert.Nil(t, configs)
 	assert.Error(t, err)
+}
+
+func TestInstrumentationChecksIsUpToDate(t *testing.T) {
+	tests := []struct {
+		name           string
+		client         clusteragent.InstrumentationCheckClient
+		lastChange     int64
+		flushedConfigs bool
+		wantResult     bool
+	}{
+		{
+			name:       "timestamps match — up to date",
+			client:     &mockInstrumentationClient{status: types.InstrumentationStatusResponse{LastChange: 100}},
+			lastChange: 100,
+			wantResult: true,
+		},
+		{
+			name:       "server timestamp is newer — not up to date",
+			client:     &mockInstrumentationClient{status: types.InstrumentationStatusResponse{LastChange: 200}},
+			lastChange: 100,
+			wantResult: false,
+		},
+		{
+			name:       "no changes yet — both zero",
+			client:     &mockInstrumentationClient{status: types.InstrumentationStatusResponse{LastChange: 0}},
+			lastChange: 0,
+			wantResult: true,
+		},
+		{
+			name:           "flushed configs — force Collect even if timestamps match",
+			client:         &mockInstrumentationClient{status: types.InstrumentationStatusResponse{LastChange: 100}},
+			lastChange:     100,
+			flushedConfigs: true,
+			wantResult:     false,
+		},
+		{
+			name:       "status endpoint error — fall through to Collect",
+			client:     &mockInstrumentationClient{statusErr: errors.New("connection refused")},
+			lastChange: 100,
+			wantResult: false,
+		},
+		{
+			name:       "nil client — fall through to Collect",
+			client:     nil,
+			lastChange: 0,
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &InstrumentationChecksConfigProvider{
+				dcaClient:      tt.client,
+				lastChange:     tt.lastChange,
+				flushedConfigs: tt.flushedConfigs,
+			}
+			upToDate, err := provider.IsUpToDate(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantResult, upToDate)
+		})
+	}
 }

--- a/comp/core/autodiscovery/providers/instrumentationchecks_test.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks_test.go
@@ -194,7 +194,7 @@ func TestInstrumentationChecksIsUpToDate(t *testing.T) {
 	tests := []struct {
 		name           string
 		client         clusteragent.InstrumentationCheckClient
-		configHash     int64
+		configHash     uint64
 		flushedConfigs bool
 		wantResult     bool
 	}{

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -69,7 +69,7 @@ type ConfigResponse struct {
 
 // InstrumentationConfigResponse holds the DCA response for an instrumentation config query.
 type InstrumentationConfigResponse struct {
-	ConfigHash int64                `json:"config_hash"`
+	ConfigHash uint64               `json:"config_hash"`
 	Configs    []integration.Config `json:"configs"`
 }
 
@@ -77,7 +77,7 @@ type InstrumentationConfigResponse struct {
 // It carries only the config hash, allowing node agents to decide whether to fetch the
 // full config payload.
 type InstrumentationStatusResponse struct {
-	ConfigHash int64 `json:"config_hash"`
+	ConfigHash uint64 `json:"config_hash"`
 }
 
 // StateResponse holds the DCA response for a dispatching state query

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -67,6 +67,13 @@ type ConfigResponse struct {
 	Configs    []integration.Config `json:"configs"`
 }
 
+// InstrumentationStatusResponse holds the DCA response for an instrumentation status query.
+// It carries only the timestamp of the most recent config change, allowing node agents
+// to decide whether to fetch the full config payload.
+type InstrumentationStatusResponse struct {
+	LastChange int64 `json:"last_change"`
+}
+
 // StateResponse holds the DCA response for a dispatching state query
 type StateResponse struct {
 	NotRunning string               `json:"not_running"` // Reason why not running, empty if leading

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -67,11 +67,17 @@ type ConfigResponse struct {
 	Configs    []integration.Config `json:"configs"`
 }
 
+// InstrumentationConfigResponse holds the DCA response for an instrumentation config query.
+type InstrumentationConfigResponse struct {
+	ConfigHash int64                `json:"config_hash"`
+	Configs    []integration.Config `json:"configs"`
+}
+
 // InstrumentationStatusResponse holds the DCA response for an instrumentation status query.
-// It carries only the timestamp of the most recent config change, allowing node agents
-// to decide whether to fetch the full config payload.
+// It carries only the config hash, allowing node agents to decide whether to fetch the
+// full config payload.
 type InstrumentationStatusResponse struct {
-	LastChange int64 `json:"last_change"`
+	ConfigHash int64 `json:"config_hash"`
 }
 
 // StateResponse holds the DCA response for a dispatching state query

--- a/pkg/clusteragent/instrumentation/handlers/BUILD.bazel
+++ b/pkg/clusteragent/instrumentation/handlers/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "test",
     ],
     deps = [
+        "//comp/core/autodiscovery/integration",
         "//pkg/clusteragent/instrumentation",
         "@com_github_datadog_datadog_operator_api//datadoghq/v1alpha1",
         "@com_github_stretchr_testify//assert",
@@ -35,5 +36,6 @@ go_test(
         "@io_k8s_api//autoscaling/v2:autoscaling",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_apimachinery//pkg/types",
     ],
 )

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -173,19 +173,19 @@ func (h *AutodiscoveryHandler) Handle(_ context.Context, event instrumentation.E
 	}, nil
 }
 
-func (c *CheckStore) ListConfigs() []integration.Config {
+func (c *CheckStore) ListConfigs() ([]integration.Config, uint64) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	out := make([]integration.Config, 0)
 	for _, cfgs := range c.configs {
 		out = append(out, cfgs...)
 	}
-	return out
+	return out, c.configHash
 }
 
 // ConfigHash returns a deterministic hash of the current set of (key, generation) pairs,
 // consistent across all cluster agent replicas for the same CR state.
-func (c *CheckStore) ConfigHash() uint64 {
+func (c *CheckStore) Hash() uint64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.configHash

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -33,8 +34,9 @@ const (
 )
 
 type CheckStore struct {
-	mu      sync.RWMutex
-	configs map[string][]integration.Config
+	mu         sync.RWMutex
+	configs    map[string][]integration.Config
+	lastChange int64
 }
 
 func NewCheckStore() *CheckStore {
@@ -164,12 +166,6 @@ func (h *AutodiscoveryHandler) Handle(_ context.Context, event instrumentation.E
 	}, nil
 }
 
-// ListConfigs returns a snapshot of all stored integration.Config entries
-// across all DatadogInstrumentation CRs handled by this instance.
-func (h *AutodiscoveryHandler) ListConfigs() []integration.Config {
-	return h.checkStore.ListConfigs()
-}
-
 func (c *CheckStore) ListConfigs() []integration.Config {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -180,20 +176,29 @@ func (c *CheckStore) ListConfigs() []integration.Config {
 	return out
 }
 
+// LastChange returns the Unix nanosecond timestamp of the most recent mutation.
+func (c *CheckStore) LastChange() int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.lastChange
+}
+
 func (c *CheckStore) setConfigs(key string, configs []integration.Config) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(configs) == 0 {
 		delete(c.configs, key)
-		return
+	} else {
+		c.configs[key] = configs
 	}
-	c.configs[key] = configs
+	c.lastChange = time.Now().UnixNano()
 }
 
 func (c *CheckStore) deleteConfigs(key string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.configs, key)
+	c.lastChange = time.Now().UnixNano()
 }
 
 func translateCheck(cr *datadoghq.DatadogInstrumentation, check datadoghq.DatadogInstrumentationCheckConfig) (integration.Config, error) {

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -11,9 +11,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
+	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -34,14 +35,16 @@ const (
 )
 
 type CheckStore struct {
-	mu         sync.RWMutex
-	configs    map[string][]integration.Config
-	lastChange int64
+	mu          sync.RWMutex
+	configs     map[string][]integration.Config
+	generations map[string]int64
+	configHash  int64
 }
 
 func NewCheckStore() *CheckStore {
 	return &CheckStore{
-		configs: make(map[string][]integration.Config),
+		configs:     make(map[string][]integration.Config),
+		generations: make(map[string]int64),
 	}
 }
 
@@ -156,7 +159,7 @@ func (h *AutodiscoveryHandler) Handle(_ context.Context, event instrumentation.E
 		configs = append(configs, cfg)
 	}
 
-	h.checkStore.setConfigs(key, configs)
+	h.checkStore.setConfigs(key, configs, cr.Generation)
 
 	return instrumentation.HandlerStatus{
 		Type:    checksReadyConditionType,
@@ -176,29 +179,48 @@ func (c *CheckStore) ListConfigs() []integration.Config {
 	return out
 }
 
-// LastChange returns the Unix nanosecond timestamp of the most recent mutation.
-func (c *CheckStore) LastChange() int64 {
+// ConfigHash returns a deterministic hash of the current set of (key, generation) pairs,
+// consistent across all cluster agent replicas for the same CR state.
+func (c *CheckStore) ConfigHash() int64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.lastChange
+	return c.configHash
 }
 
-func (c *CheckStore) setConfigs(key string, configs []integration.Config) {
+func (c *CheckStore) setConfigs(key string, configs []integration.Config, generation int64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(configs) == 0 {
 		delete(c.configs, key)
+		delete(c.generations, key)
 	} else {
 		c.configs[key] = configs
+		c.generations[key] = generation
 	}
-	c.lastChange = time.Now().UnixNano()
+	c.configHash = c.hashGenerations()
 }
 
 func (c *CheckStore) deleteConfigs(key string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.configs, key)
-	c.lastChange = time.Now().UnixNano()
+	delete(c.generations, key)
+	c.configHash = c.hashGenerations()
+}
+
+// hashGenerations computes a deterministic int64 from the sorted (key, generation)
+// pairs currently in the store. Must be called under the write lock.
+func (c *CheckStore) hashGenerations() int64 {
+	keys := make([]string, 0, len(c.generations))
+	for k := range c.generations {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	h := fnv.New64a()
+	for _, k := range keys {
+		fmt.Fprintf(h, "%s:%d\n", k, c.generations[k]) //nolint:errcheck
+	}
+	return int64(h.Sum64())
 }
 
 func translateCheck(cr *datadoghq.DatadogInstrumentation, check datadoghq.DatadogInstrumentationCheckConfig) (integration.Config, error) {

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -35,16 +35,20 @@ const (
 )
 
 type CheckStore struct {
-	mu          sync.RWMutex
-	configs     map[string][]integration.Config
-	generations map[string]int64
-	configHash  int64
+	mu      sync.RWMutex
+	configs map[string][]integration.Config
+	// states maps namespace/name → "uid:generation". Including the UID ensures that a
+	// delete+recreate of a CR with the same name is detected even when the new CR
+	// starts at generation 1.
+	states     map[string]string
+	configHash uint64
 }
 
 func NewCheckStore() *CheckStore {
 	return &CheckStore{
-		configs:     make(map[string][]integration.Config),
-		generations: make(map[string]int64),
+		configs:    make(map[string][]integration.Config),
+		states:     make(map[string]string),
+		configHash: fnv.New64a().Sum64(),
 	}
 }
 
@@ -159,7 +163,7 @@ func (h *AutodiscoveryHandler) Handle(_ context.Context, event instrumentation.E
 		configs = append(configs, cfg)
 	}
 
-	h.checkStore.setConfigs(key, configs, cr.Generation)
+	h.checkStore.setConfigs(key, configs, cr.Generation, string(cr.UID))
 
 	return instrumentation.HandlerStatus{
 		Type:    checksReadyConditionType,
@@ -181,46 +185,48 @@ func (c *CheckStore) ListConfigs() []integration.Config {
 
 // ConfigHash returns a deterministic hash of the current set of (key, generation) pairs,
 // consistent across all cluster agent replicas for the same CR state.
-func (c *CheckStore) ConfigHash() int64 {
+func (c *CheckStore) ConfigHash() uint64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.configHash
 }
 
-func (c *CheckStore) setConfigs(key string, configs []integration.Config, generation int64) {
+func (c *CheckStore) setConfigs(key string, configs []integration.Config, generation int64, uid string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(configs) == 0 {
 		delete(c.configs, key)
-		delete(c.generations, key)
+		delete(c.states, key)
 	} else {
 		c.configs[key] = configs
-		c.generations[key] = generation
+		c.states[key] = fmt.Sprintf("%s:%d", uid, generation)
 	}
-	c.configHash = c.hashGenerations()
+	c.configHash = c.hashStates()
 }
 
 func (c *CheckStore) deleteConfigs(key string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.configs, key)
-	delete(c.generations, key)
-	c.configHash = c.hashGenerations()
+	delete(c.states, key)
+	c.configHash = c.hashStates()
 }
 
-// hashGenerations computes a deterministic int64 from the sorted (key, generation)
-// pairs currently in the store. Must be called under the write lock.
-func (c *CheckStore) hashGenerations() int64 {
-	keys := make([]string, 0, len(c.generations))
-	for k := range c.generations {
+// hashStates computes a deterministic hash from the sorted set of
+// "key:uid:generation" entries in the store. Including the UID ensures that a
+// recreation of a CR with the same namespace/name is detected even when
+// the new CR starts at generation 1.
+func (c *CheckStore) hashStates() uint64 {
+	keys := make([]string, 0, len(c.states))
+	for k := range c.states {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	h := fnv.New64a()
 	for _, k := range keys {
-		fmt.Fprintf(h, "%s:%d\n", k, c.generations[k]) //nolint:errcheck
+		fmt.Fprintf(h, "%s:%s\n", k, c.states[k]) //nolint:errcheck
 	}
-	return int64(h.Sum64())
+	return h.Sum64()
 }
 
 func translateCheck(cr *datadoghq.DatadogInstrumentation, check datadoghq.DatadogInstrumentationCheckConfig) (integration.Config, error) {

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -18,6 +18,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
@@ -39,6 +40,7 @@ func newCRWithGeneration(name, namespace string, targetKind, targetName string, 
 			Name:       name,
 			Namespace:  namespace,
 			Generation: generation,
+			UID:        k8stypes.UID(namespace + "/" + name),
 		},
 		Spec: datadoghq.DatadogInstrumentationSpec{
 			TargetRef: autoscalingv2.CrossVersionObjectReference{
@@ -437,33 +439,45 @@ func TestConfigHash(t *testing.T) {
 
 	baseline := store.ConfigHash()
 
-	// Adding a key changes the hash.
-	store.setConfigs("ns/cr1", cfg, 1)
+	t.Run("create changes hash", func(t *testing.T) {
+		store.setConfigs("ns/cr1", cfg, 1, "uid-a")
+		assert.NotEqual(t, baseline, store.ConfigHash())
+	})
 	after1 := store.ConfigHash()
-	assert.NotEqual(t, baseline, after1)
 
-	// Generation bump changes the hash.
-	store.setConfigs("ns/cr1", cfg, 2)
+	t.Run("generation bump changes hash", func(t *testing.T) {
+		store.setConfigs("ns/cr1", cfg, 2, "uid-a")
+		assert.NotEqual(t, after1, store.ConfigHash())
+	})
 	after2 := store.ConfigHash()
-	assert.NotEqual(t, after1, after2)
 
-	// Same generation is idempotent — hash is stable.
-	store.setConfigs("ns/cr1", cfg, 2)
-	assert.Equal(t, after2, store.ConfigHash())
+	t.Run("same generation and UID is idempotent", func(t *testing.T) {
+		store.setConfigs("ns/cr1", cfg, 2, "uid-a")
+		assert.Equal(t, after2, store.ConfigHash())
+	})
 
-	// Second key changes the hash.
-	store.setConfigs("ns/cr2", cfg, 1)
+	t.Run("recreate with same generation but new UID changes hash", func(t *testing.T) {
+		store.deleteConfigs("ns/cr1")
+		store.setConfigs("ns/cr1", cfg, 1, "uid-b")
+		assert.NotEqual(t, after1, store.ConfigHash())
+	})
+	afterRecreate := store.ConfigHash()
+
+	t.Run("adding a second key changes hash", func(t *testing.T) {
+		store.setConfigs("ns/cr2", cfg, 1, "uid-c")
+		assert.NotEqual(t, afterRecreate, store.ConfigHash())
+	})
 	after3 := store.ConfigHash()
-	assert.NotEqual(t, after2, after3)
 
-	// Delete changes the hash.
-	store.deleteConfigs("ns/cr1")
-	after4 := store.ConfigHash()
-	assert.NotEqual(t, after3, after4)
+	t.Run("delete changes hash", func(t *testing.T) {
+		store.deleteConfigs("ns/cr1")
+		assert.NotEqual(t, after3, store.ConfigHash())
+	})
 
-	// Back to empty — hash matches baseline.`
-	store.deleteConfigs("ns/cr2")
-	assert.Equal(t, baseline, store.ConfigHash())
+	t.Run("empty store returns to baseline", func(t *testing.T) {
+		store.deleteConfigs("ns/cr2")
+		assert.Equal(t, baseline, store.ConfigHash())
+	})
 }
 
 func TestBuildCELSelector(t *testing.T) {

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
 )
 
@@ -29,10 +30,15 @@ func newHandler() *AutodiscoveryHandler {
 }
 
 func newCR(name, namespace string, targetKind, targetName string, checks []datadoghq.DatadogInstrumentationCheckConfig) *datadoghq.DatadogInstrumentation {
+	return newCRWithGeneration(name, namespace, targetKind, targetName, checks, 1)
+}
+
+func newCRWithGeneration(name, namespace string, targetKind, targetName string, checks []datadoghq.DatadogInstrumentationCheckConfig, generation int64) *datadoghq.DatadogInstrumentation {
 	return &datadoghq.DatadogInstrumentation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:       name,
+			Namespace:  namespace,
+			Generation: generation,
 		},
 		Spec: datadoghq.DatadogInstrumentationSpec{
 			TargetRef: autoscalingv2.CrossVersionObjectReference{
@@ -423,6 +429,41 @@ func TestTranslateCheck(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigHash(t *testing.T) {
+	store := NewCheckStore()
+	cfg := []integration.Config{{Name: "check1"}}
+
+	baseline := store.ConfigHash()
+
+	// Adding a key changes the hash.
+	store.setConfigs("ns/cr1", cfg, 1)
+	after1 := store.ConfigHash()
+	assert.NotEqual(t, baseline, after1)
+
+	// Generation bump changes the hash.
+	store.setConfigs("ns/cr1", cfg, 2)
+	after2 := store.ConfigHash()
+	assert.NotEqual(t, after1, after2)
+
+	// Same generation is idempotent — hash is stable.
+	store.setConfigs("ns/cr1", cfg, 2)
+	assert.Equal(t, after2, store.ConfigHash())
+
+	// Second key changes the hash.
+	store.setConfigs("ns/cr2", cfg, 1)
+	after3 := store.ConfigHash()
+	assert.NotEqual(t, after2, after3)
+
+	// Delete changes the hash.
+	store.deleteConfigs("ns/cr1")
+	after4 := store.ConfigHash()
+	assert.NotEqual(t, after3, after4)
+
+	// Back to empty — hash matches baseline.`
+	store.deleteConfigs("ns/cr2")
+	assert.Equal(t, baseline, store.ConfigHash())
 }
 
 func TestBuildCELSelector(t *testing.T) {

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -256,14 +256,14 @@ func TestHandle_Delete(t *testing.T) {
 	// First create checkStore
 	_, err := h.Handle(context.Background(), instrumentation.EventCreate, cr)
 	require.NoError(t, err)
-	assert.Len(t, h.ListConfigs(), 1)
+	assert.Len(t, h.checkStore.ListConfigs(), 1)
 
 	// Then delete
 	status, err := h.Handle(context.Background(), instrumentation.EventDelete, cr)
 	require.NoError(t, err)
 	assert.Equal(t, metav1.ConditionTrue, status.Status)
 	assert.Equal(t, "Deleted", status.Reason)
-	assert.Empty(t, h.ListConfigs())
+	assert.Empty(t, h.checkStore.ListConfigs())
 }
 
 func TestHandle_CreateAndUpdate(t *testing.T) {
@@ -282,7 +282,7 @@ func TestHandle_CreateAndUpdate(t *testing.T) {
 	assert.Equal(t, "Configured", status.Reason)
 	assert.Contains(t, status.Message, "1 check(s) configured")
 
-	configs := h.ListConfigs()
+	configs := h.checkStore.ListConfigs()
 	require.Len(t, configs, 1)
 	assert.Equal(t, "redisdb", configs[0].Name)
 	assert.Equal(t, "datadoginstrumentation:default/test", configs[0].Source)
@@ -296,7 +296,7 @@ func TestHandle_CreateAndUpdate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, metav1.ConditionTrue, status.Status)
 	assert.Contains(t, status.Message, "2 check(s) configured")
-	assert.Len(t, h.ListConfigs(), 2)
+	assert.Len(t, h.checkStore.ListConfigs(), 2)
 }
 
 func TestHandle_MultipleCRs(t *testing.T) {
@@ -312,12 +312,12 @@ func TestHandle_MultipleCRs(t *testing.T) {
 	require.NoError(t, err)
 	_, err = h.Handle(context.Background(), instrumentation.EventCreate, cr2)
 	require.NoError(t, err)
-	assert.Len(t, h.ListConfigs(), 2)
+	assert.Len(t, h.checkStore.ListConfigs(), 2)
 
 	// Delete first CR; second should remain
 	_, err = h.Handle(context.Background(), instrumentation.EventDelete, cr1)
 	require.NoError(t, err)
-	configs := h.ListConfigs()
+	configs := h.checkStore.ListConfigs()
 	require.Len(t, configs, 1)
 	assert.Equal(t, "nginx", configs[0].Name)
 }
@@ -404,7 +404,7 @@ func TestTranslateCheck(t *testing.T) {
 			_, err := h.Handle(context.Background(), instrumentation.EventCreate, cr)
 			require.NoError(t, err)
 
-			configs := h.ListConfigs()
+			configs := h.checkStore.ListConfigs()
 			require.Len(t, configs, 1)
 			assert.Equal(t, tt.expectedInit, string(configs[0].InitConfig))
 			require.Len(t, configs[0].Instances, tt.expectedInstLen)

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -264,14 +264,16 @@ func TestHandle_Delete(t *testing.T) {
 	// First create checkStore
 	_, err := h.Handle(context.Background(), instrumentation.EventCreate, cr)
 	require.NoError(t, err)
-	assert.Len(t, h.checkStore.ListConfigs(), 1)
+	configs, _ := h.checkStore.ListConfigs()
+	assert.Len(t, configs, 1)
 
 	// Then delete
 	status, err := h.Handle(context.Background(), instrumentation.EventDelete, cr)
 	require.NoError(t, err)
 	assert.Equal(t, metav1.ConditionTrue, status.Status)
 	assert.Equal(t, "Deleted", status.Reason)
-	assert.Empty(t, h.checkStore.ListConfigs())
+	configs, _ = h.checkStore.ListConfigs()
+	assert.Empty(t, configs)
 }
 
 func TestHandle_CreateAndUpdate(t *testing.T) {
@@ -290,7 +292,7 @@ func TestHandle_CreateAndUpdate(t *testing.T) {
 	assert.Equal(t, "Configured", status.Reason)
 	assert.Contains(t, status.Message, "1 check(s) configured")
 
-	configs := h.checkStore.ListConfigs()
+	configs, _ := h.checkStore.ListConfigs()
 	require.Len(t, configs, 1)
 	assert.Equal(t, "redisdb", configs[0].Name)
 	assert.Equal(t, "datadoginstrumentation:default/test", configs[0].Source)
@@ -304,7 +306,8 @@ func TestHandle_CreateAndUpdate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, metav1.ConditionTrue, status.Status)
 	assert.Contains(t, status.Message, "2 check(s) configured")
-	assert.Len(t, h.checkStore.ListConfigs(), 2)
+	configs, _ = h.checkStore.ListConfigs()
+	assert.Len(t, configs, 2)
 }
 
 func TestHandle_MultipleCRs(t *testing.T) {
@@ -320,12 +323,13 @@ func TestHandle_MultipleCRs(t *testing.T) {
 	require.NoError(t, err)
 	_, err = h.Handle(context.Background(), instrumentation.EventCreate, cr2)
 	require.NoError(t, err)
-	assert.Len(t, h.checkStore.ListConfigs(), 2)
+	configs, _ := h.checkStore.ListConfigs()
+	assert.Len(t, configs, 2)
 
 	// Delete first CR; second should remain
 	_, err = h.Handle(context.Background(), instrumentation.EventDelete, cr1)
 	require.NoError(t, err)
-	configs := h.checkStore.ListConfigs()
+	configs, _ = h.checkStore.ListConfigs()
 	require.Len(t, configs, 1)
 	assert.Equal(t, "nginx", configs[0].Name)
 }
@@ -412,7 +416,7 @@ func TestTranslateCheck(t *testing.T) {
 			_, err := h.Handle(context.Background(), instrumentation.EventCreate, cr)
 			require.NoError(t, err)
 
-			configs := h.checkStore.ListConfigs()
+			configs, _ := h.checkStore.ListConfigs()
 			require.Len(t, configs, 1)
 			assert.Equal(t, tt.expectedInit, string(configs[0].InitConfig))
 			require.Len(t, configs[0].Instances, tt.expectedInstLen)
@@ -437,46 +441,46 @@ func TestConfigHash(t *testing.T) {
 	store := NewCheckStore()
 	cfg := []integration.Config{{Name: "check1"}}
 
-	baseline := store.ConfigHash()
+	baseline := store.Hash()
 
 	t.Run("create changes hash", func(t *testing.T) {
 		store.setConfigs("ns/cr1", cfg, 1, "uid-a")
-		assert.NotEqual(t, baseline, store.ConfigHash())
+		assert.NotEqual(t, baseline, store.Hash())
 	})
-	after1 := store.ConfigHash()
+	after1 := store.Hash()
 
 	t.Run("generation bump changes hash", func(t *testing.T) {
 		store.setConfigs("ns/cr1", cfg, 2, "uid-a")
-		assert.NotEqual(t, after1, store.ConfigHash())
+		assert.NotEqual(t, after1, store.Hash())
 	})
-	after2 := store.ConfigHash()
+	after2 := store.Hash()
 
 	t.Run("same generation and UID is idempotent", func(t *testing.T) {
 		store.setConfigs("ns/cr1", cfg, 2, "uid-a")
-		assert.Equal(t, after2, store.ConfigHash())
+		assert.Equal(t, after2, store.Hash())
 	})
 
 	t.Run("recreate with same generation but new UID changes hash", func(t *testing.T) {
 		store.deleteConfigs("ns/cr1")
 		store.setConfigs("ns/cr1", cfg, 1, "uid-b")
-		assert.NotEqual(t, after1, store.ConfigHash())
+		assert.NotEqual(t, after1, store.Hash())
 	})
-	afterRecreate := store.ConfigHash()
+	afterRecreate := store.Hash()
 
 	t.Run("adding a second key changes hash", func(t *testing.T) {
 		store.setConfigs("ns/cr2", cfg, 1, "uid-c")
-		assert.NotEqual(t, afterRecreate, store.ConfigHash())
+		assert.NotEqual(t, afterRecreate, store.Hash())
 	})
-	after3 := store.ConfigHash()
+	after3 := store.Hash()
 
 	t.Run("delete changes hash", func(t *testing.T) {
 		store.deleteConfigs("ns/cr1")
-		assert.NotEqual(t, after3, store.ConfigHash())
+		assert.NotEqual(t, after3, store.Hash())
 	})
 
 	t.Run("empty store returns to baseline", func(t *testing.T) {
 		store.deleteConfigs("ns/cr2")
-		assert.Equal(t, baseline, store.ConfigHash())
+		assert.Equal(t, baseline, store.Hash())
 	})
 }
 

--- a/pkg/clusteragent/servercontext.go
+++ b/pkg/clusteragent/servercontext.go
@@ -11,10 +11,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
 )
 
-// ConfigLister exposes integration.Configs derived from DatadogInstrumentation CRs.
+// ConfigLister exposes check configs derived from DatadogInstrumentation CRs.
 type ConfigLister interface {
 	ListConfigs() []integration.Config
-	LastChange() int64
+	// ConfigHash returns a deterministic hash of the current instrumentation config state.
+	ConfigHash() int64
 }
 
 // ServerContext holds business logic classes required to setup API endpoints

--- a/pkg/clusteragent/servercontext.go
+++ b/pkg/clusteragent/servercontext.go
@@ -13,9 +13,10 @@ import (
 
 // ConfigLister exposes check configs derived from DatadogInstrumentation CRs.
 type ConfigLister interface {
-	ListConfigs() []integration.Config
-	// ConfigHash returns a deterministic hash of the current instrumentation config state.
-	ConfigHash() uint64
+	// ListConfigs returns all check configs and the state hash.
+	ListConfigs() ([]integration.Config, uint64)
+	// Hash returns a deterministic hash of the current instrumentation config state.
+	Hash() uint64
 }
 
 // ServerContext holds business logic classes required to setup API endpoints

--- a/pkg/clusteragent/servercontext.go
+++ b/pkg/clusteragent/servercontext.go
@@ -14,6 +14,7 @@ import (
 // ConfigLister exposes integration.Configs derived from DatadogInstrumentation CRs.
 type ConfigLister interface {
 	ListConfigs() []integration.Config
+	LastChange() int64
 }
 
 // ServerContext holds business logic classes required to setup API endpoints

--- a/pkg/clusteragent/servercontext.go
+++ b/pkg/clusteragent/servercontext.go
@@ -15,7 +15,7 @@ import (
 type ConfigLister interface {
 	ListConfigs() []integration.Config
 	// ConfigHash returns a deterministic hash of the current instrumentation config state.
-	ConfigHash() int64
+	ConfigHash() uint64
 }
 
 // ServerContext holds business logic classes required to setup API endpoints

--- a/pkg/util/clusteragent/instrumentationchecks.go
+++ b/pkg/util/clusteragent/instrumentationchecks.go
@@ -13,12 +13,14 @@ import (
 
 const (
 	dcaInstrumentationConfigsPath = "api/v1/instrumentation/configs"
+	dcaInstrumentationStatusPath  = "api/v1/instrumentation/status"
 )
 
 // InstrumentationCheckClient is the interface used by the instrumentation
 // checks config provider to retrieve AD configurations from the cluster agent.
 type InstrumentationCheckClient interface {
 	GetInstrumentationConfigs(ctx context.Context) (types.ConfigResponse, error)
+	GetInstrumentationStatus(ctx context.Context) (types.InstrumentationStatusResponse, error)
 }
 
 // GetInstrumentationConfigs is called by the instrumentation checks config provider
@@ -27,4 +29,13 @@ func (c *DCAClient) GetInstrumentationConfigs(ctx context.Context) (types.Config
 	var configs types.ConfigResponse
 	err := c.doJSONQuery(ctx, dcaInstrumentationConfigsPath, "GET", nil, &configs, false)
 	return configs, err
+}
+
+// GetInstrumentationStatus returns the timestamp of the most recent instrumentation
+// config change. Node agents use this to avoid fetching the full config payload
+// when nothing has changed.
+func (c *DCAClient) GetInstrumentationStatus(ctx context.Context) (types.InstrumentationStatusResponse, error) {
+	var status types.InstrumentationStatusResponse
+	err := c.doJSONQuery(ctx, dcaInstrumentationStatusPath, "GET", nil, &status, false)
+	return status, err
 }

--- a/pkg/util/clusteragent/instrumentationchecks.go
+++ b/pkg/util/clusteragent/instrumentationchecks.go
@@ -19,14 +19,14 @@ const (
 // InstrumentationCheckClient is the interface used by the instrumentation
 // checks config provider to retrieve AD configurations from the cluster agent.
 type InstrumentationCheckClient interface {
-	GetInstrumentationConfigs(ctx context.Context) (types.ConfigResponse, error)
+	GetInstrumentationConfigs(ctx context.Context) (types.InstrumentationConfigResponse, error)
 	GetInstrumentationStatus(ctx context.Context) (types.InstrumentationStatusResponse, error)
 }
 
 // GetInstrumentationConfigs is called by the instrumentation checks config provider
 // to retrieve AD configurations derived from DatadogInstrumentation CRs.
-func (c *DCAClient) GetInstrumentationConfigs(ctx context.Context) (types.ConfigResponse, error) {
-	var configs types.ConfigResponse
+func (c *DCAClient) GetInstrumentationConfigs(ctx context.Context) (types.InstrumentationConfigResponse, error) {
+	var configs types.InstrumentationConfigResponse
 	err := c.doJSONQuery(ctx, dcaInstrumentationConfigsPath, "GET", nil, &configs, false)
 	return configs, err
 }

--- a/pkg/util/clusteragent/instrumentationchecks.go
+++ b/pkg/util/clusteragent/instrumentationchecks.go
@@ -31,8 +31,8 @@ func (c *DCAClient) GetInstrumentationConfigs(ctx context.Context) (types.Instru
 	return configs, err
 }
 
-// GetInstrumentationStatus returns the timestamp of the most recent instrumentation
-// config change. Node agents use this to avoid fetching the full config payload
+// GetInstrumentationStatus returns the hash of the latest instrumentation
+// config state. Node agents use this to avoid fetching the full config payload
 // when nothing has changed.
 func (c *DCAClient) GetInstrumentationStatus(ctx context.Context) (types.InstrumentationStatusResponse, error) {
 	var status types.InstrumentationStatusResponse


### PR DESCRIPTION
### What does this PR do?

Adds a lightweight `GET /instrumentation/status` endpoint to the cluster agent that returns the timestamp of the most recent instrumentation config change. Node agents poll this endpoint before fetching the full `/instrumentation/configs` payload, skipping it entirely when nothing has changed.

### Motivation

With many instrumentation configs and many node agents, every poll cycle fetched the full config payload regardless of whether anything changed. This is wasteful given that configs will change infrequently. The status endpoint makes the common case (no change) a small, cheap request.

### Describe how you validated your changes

- Updated unit tests for `InstrumentationChecksConfigProvider` to cover `IsUpToDate` — including timestamp matching, status endpoint errors, nil client, and the post-outage recovery (flushed configs) case.
- Updated `TestInstrumentationChecksCollect` to assert `lastChange` is saved from the response after a successful collect.