### PR TITLE
SSH helpers

### DIFF
--- a/pkg/networkconfigmanagement/profile/BUILD.bazel
+++ b/pkg/networkconfigmanagement/profile/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "profile",
     srcs = [
+        "command.go",
         "profile.go",
         "profile_cache.go",
         "profile_processing.go",

--- a/pkg/networkconfigmanagement/profile/command.go
+++ b/pkg/networkconfigmanagement/profile/command.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package profile defines models, logic, functions to load/parse/manage network device profiles
+package profile
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Validator contains rules for validating the output of a command - requiring
+// specific regexes to be present or absent in stdout and/or stderr.
+type Validator struct {
+	Require []*regexp.Regexp `json:"require,omitempty"`
+	Reject  []*regexp.Regexp `json:"reject,omitempty"`
+}
+
+func (v *Validator) Validate(text string) error {
+	for _, rule := range v.Require {
+		if !rule.MatchString(text) {
+			return fmt.Errorf("does not match required regex %q", rule)
+		}
+	}
+	for _, rule := range v.Reject {
+		if rule.MatchString(text) {
+			return fmt.Errorf("matches failure regex %q", rule)
+		}
+	}
+	return nil
+}
+
+// Command represents a single command plus zero or more regexes to run against
+// the combined stdout/stderr of that command.
+type Command struct {
+	Command   string    `json:"command"`
+	Validator Validator `json:"validator"`
+}
+
+// SCPCommand represents a command that expects to receive valid scp input via
+// stdin. The actual command run over SSH will be `<RemoteCommand> -t <FilePath>`
+type SCPCommand struct {
+	RemoteCommand string `json:"remote_command"`
+	Filepath      string `json:"filepath"`
+	// usually this should be empty - scp does not print output on most systems.
+	Validator Validator `json:"validator"`
+}

--- a/pkg/networkconfigmanagement/remote/BUILD.bazel
+++ b/pkg/networkconfigmanagement/remote/BUILD.bazel
@@ -3,7 +3,11 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "remote",
     srcs = [
+        "cmd.go",
+        "fake_server.go",
         "interfaces.go",
+        "retry.go",
+        "scp.go",
         "ssh.go",
         "test_utils.go",
     ],
@@ -20,11 +24,16 @@ go_library(
 
 go_test(
     name = "remote_test",
-    srcs = ["ssh_test.go"],
+    srcs = [
+        "cmd_test.go",
+        "retry_test.go",
+        "ssh_test.go",
+    ],
     embed = [":remote"],
     gotags = ["test"],
     deps = [
         "//pkg/networkconfigmanagement/config",
+        "//pkg/networkconfigmanagement/profile",
         "//pkg/util/log",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/networkconfigmanagement/remote/cmd.go
+++ b/pkg/networkconfigmanagement/remote/cmd.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package remote
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile"
+)
+
+type result struct {
+	message string
+	err     error
+}
+
+// sshClient is a common interface between ssh.Client and RetryingSSHClient
+type sshClient interface {
+	NewSession() (*ssh.Session, error)
+}
+
+// Execute runs a command and validates the output with its validation rules.
+// The validation runs on the combined stdout and stderr of the command.
+func ExecuteCommand(ctx context.Context, client sshClient, cmd *profile.Command) (string, error) {
+	session, err := client.NewSession()
+	if err != nil {
+		return "", err
+	}
+	defer session.Close()
+	ch := make(chan result, 1)
+	go func() {
+		output, err := session.CombinedOutput(cmd.Command)
+		ch <- result{string(output), err}
+	}()
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			return "", r.err
+		}
+		return r.message, cmd.Validator.Validate(r.message)
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// ExecuteSCP executes an SCP command, sending the given data over SSH.
+func ExecuteSCP(ctx context.Context, client sshClient, cmd *profile.SCPCommand, data string) (string, error) {
+	session, err := client.NewSession()
+	if err != nil {
+		return "", err
+	}
+	defer session.Close()
+
+	cmdStr := fmt.Sprintf("%s -t '%s'", cmd.RemoteCommand, strings.ReplaceAll(cmd.Filepath, "'", "'\"'\"'"))
+	ch := make(chan result)
+	go func() {
+		response, err := executeSCP(session, cmdStr, filepath.Base(cmd.Filepath), data)
+		ch <- result{response, err}
+	}()
+	var response string
+	select {
+	case result := <-ch:
+		response = result.message
+		err = result.err
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
+	if err != nil {
+		return "", fmt.Errorf("scp command %q failed: %w", cmdStr, err)
+	}
+	if err := cmd.Validator.Validate(response); err != nil {
+		return response, fmt.Errorf("scp command %q bad output: %w", cmdStr, err)
+	}
+	return response, nil
+}

--- a/pkg/networkconfigmanagement/remote/cmd_test.go
+++ b/pkg/networkconfigmanagement/remote/cmd_test.go
@@ -1,0 +1,191 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package remote
+
+import (
+	"context"
+	"io"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile"
+)
+
+func TestCommand(t *testing.T) {
+	srv := StartFakeSSHServer(t, map[string]FakeResponse{
+		"show version": Ok("Fakesco fOS\n"),
+		"show venison": Fail("bad command", 1),
+	})
+	client := MustConnect(t, srv)
+
+	for _, tc := range []struct {
+		name      string
+		cmd       *profile.Command
+		expected  string
+		expectErr bool
+	}{{
+		name: "unchecked_command",
+		cmd: &profile.Command{
+			Command: "show version",
+		},
+		expected: "Fakesco fOS\n",
+	}, {
+		name: "valid_command",
+		cmd: &profile.Command{
+			Command: "show version",
+			Validator: profile.Validator{
+				Require: []*regexp.Regexp{regexp.MustCompile("Fakesco")},
+				Reject:  []*regexp.Regexp{regexp.MustCompile("Realco")},
+			},
+		},
+		expected: "Fakesco fOS\n",
+	}, {
+		name: "missing_req",
+		cmd: &profile.Command{
+			Command: "show version",
+			Validator: profile.Validator{
+				Require: []*regexp.Regexp{regexp.MustCompile("Realco")},
+			},
+		},
+		expectErr: true,
+	}, {
+		name: "has_rejection",
+		cmd: &profile.Command{
+			Command: "show version",
+			Validator: profile.Validator{
+				Reject: []*regexp.Regexp{regexp.MustCompile("Fakesco")},
+			},
+		},
+		expectErr: true,
+	}, {
+		name: "command_fails",
+		cmd: &profile.Command{
+			Command: "show venison",
+			Validator: profile.Validator{
+				Require: []*regexp.Regexp{regexp.MustCompile("Fakesco")},
+				Reject:  []*regexp.Regexp{regexp.MustCompile("Realco")},
+			},
+		},
+		expectErr: true,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ExecuteCommand(context.Background(), client, tc.cmd)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, string(result))
+			}
+		})
+	}
+}
+
+func TestSCPCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		op        ShellFunc
+		validator profile.Validator
+		expected  string
+		expectErr string
+	}{{
+		name: "unchecked_command",
+		op: func(shell *ShellContext) uint32 {
+			shell.stdout.Write([]byte{0, 0})
+			// wait for the other end to write some data so we don't close stdin early
+			shell.stdin.ReadByte()
+			return 0
+		},
+		expected: "",
+	}, {
+		name: "failing_from_stdout",
+		op: func(shell *ShellContext) uint32 {
+			io.WriteString(shell.stdout, "\x01permission denied")
+			shell.stdin.ReadByte()
+			return 1
+		},
+		expectErr: "permission denied",
+	}, {
+		name: "failing_from_stderr",
+		op: func(shell *ShellContext) uint32 {
+			io.WriteString(shell.stderr, "Unknown command: scp")
+			return 0
+		},
+		expectErr: "Unknown command: scp",
+	}, {
+		name: "failing_without_feedback",
+		op: func(_ *ShellContext) uint32 {
+			return 0
+		},
+		expectErr: "unexpected EOF",
+	}, {
+		name: "validate_response",
+		op: func(shell *ShellContext) uint32 {
+			io.WriteString(shell.stdout, "\x00\x00returning feedback")
+			// wait for the other end to write some data so we don't close shell.stdin early
+			shell.stdin.ReadByte()
+			return 0
+		},
+		validator: profile.Validator{
+			Require: []*regexp.Regexp{
+				regexp.MustCompile("feedback"),
+			},
+		},
+		expected: "returning feedback",
+	}, {
+		name: "invalid_response",
+		op: func(shell *ShellContext) uint32 {
+			io.WriteString(shell.stdout, "\x00\x00incorrect response")
+			// wait for the other end to write some data so we don't close shell.stdin early
+			shell.stdin.Read(make([]byte, 100))
+			return 0
+		},
+		validator: profile.Validator{
+			Require: []*regexp.Regexp{
+				regexp.MustCompile("feedback"),
+			},
+		},
+		expectErr: "does not match required regex",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := StartFakeSSHServerWithFunc(t, tc.op)
+			client := MustConnect(t, srv)
+			cmd := &profile.SCPCommand{
+				RemoteCommand: "scp",
+				Filepath:      "/mnt/flash/backup.txt",
+				Validator:     tc.validator,
+			}
+			response, err := ExecuteSCP(context.Background(), client, cmd, "this is the data")
+			if tc.expectErr != "" {
+				assert.ErrorContains(t, err, tc.expectErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, response)
+			}
+		})
+	}
+}
+
+func TestSCPCommand_Timeout(t *testing.T) {
+	srv := StartFakeSSHServerWithFunc(t, func(sc *ShellContext) uint32 {
+		io.WriteString(sc.stdout, "\x01some random data but it never closes")
+		time.Sleep(time.Second * 10)
+		return 0
+	})
+	client := MustConnect(t, srv)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Microsecond)
+	defer cancel()
+	_, err := ExecuteSCP(ctx, client, &profile.SCPCommand{
+		RemoteCommand: "scp",
+		Filepath:      "/ignored.txt",
+	}, "this is the data")
+	assert.ErrorContains(t, err, "context deadline exceeded")
+}

--- a/pkg/networkconfigmanagement/remote/fake_server.go
+++ b/pkg/networkconfigmanagement/remote/fake_server.go
@@ -1,0 +1,368 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package remote
+
+import (
+	"bufio"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// FakeResponse is the canned reply for one command on the fake SSH server.
+// Stdout is written to the channel; Stderr to the channel's stderr stream;
+// ExitStatus is reported to the client (0 = success).
+type FakeResponse struct {
+	Stdout     string
+	Stderr     string
+	ExitStatus uint32
+}
+
+// Ok returns a successful (exit 0) response with the given stdout.
+func Ok(stdout string) FakeResponse { return FakeResponse{Stdout: stdout} }
+
+// Fail returns a failure response with stderr and the given non-zero exit
+// status.
+func Fail(stderr string, exit uint32) FakeResponse {
+	return FakeResponse{Stderr: stderr, ExitStatus: exit}
+}
+
+func FakeData(data map[string]FakeResponse) ShellFunc {
+	return func(shell *ShellContext) uint32 {
+		resp, ok := data[shell.command]
+		if !ok {
+			resp = FakeResponse{
+				Stderr:     fmt.Sprintf("unknown command: %s\n", shell.command),
+				ExitStatus: 127,
+			}
+		}
+		if resp.Stdout != "" {
+			_, _ = io.WriteString(shell.stdout, resp.Stdout)
+		}
+		if resp.Stderr != "" {
+			_, _ = io.WriteString(shell.stderr, resp.Stderr)
+		}
+		return resp.ExitStatus
+	}
+}
+
+type ShellContext struct {
+	command        string
+	stdin          *bufio.Reader
+	stdout, stderr io.Writer
+}
+
+func NewShellContext(command string, ch ssh.Channel) *ShellContext {
+	return &ShellContext{
+		command: command,
+		stdin:   bufio.NewReader(ch),
+		stdout:  ch,
+		stderr:  ch.Stderr(),
+	}
+}
+
+type ShellFunc func(*ShellContext) (returnCode uint32)
+
+// FakeSSHServer is an in-process SSH server backed by a map of canned
+// command -> response replies. It is intended for tests that exercise the
+// real SSHClient against a server without depending on system sshd or Docker.
+//
+// The harness deliberately uses ed25519 host keys (fast key generation) and
+// tracks every accepted connection so that Stop() can tear them down
+// deterministically — this matters when a test wants to assert that NewSession
+// fails after the server goes away.
+type FakeSSHServer struct {
+	listener  net.Listener
+	hostKey   ssh.Signer
+	getOutput ShellFunc
+
+	expectedUser     string
+	expectedPassword string
+
+	mu       sync.Mutex
+	received []string
+	conns    []net.Conn
+	stopped  bool
+}
+
+// FakeServerOption configures a fakeSSHServer at startup.
+type FakeServerOption func(*FakeSSHServer)
+
+// WithCredentials sets the username/password the server expects. Defaults to
+// "test" / "hunter2".
+func WithCredentials(user, password string) FakeServerOption {
+	return func(s *FakeSSHServer) {
+		s.expectedUser = user
+		s.expectedPassword = password
+	}
+}
+
+// StartFakeSSHServer launches an in-process SSH server on 127.0.0.1 with a
+// random port. The server is shut down via t.Cleanup, which closes the
+// listener and every accepted connection.
+func StartFakeSSHServer(t *testing.T, outputs map[string]FakeResponse, opts ...FakeServerOption) *FakeSSHServer {
+	return StartFakeSSHServerWithFunc(t, FakeData(outputs), opts...)
+}
+
+// StartFakeSSHServerWithFunc starts an in-process SSH server using the given
+// function to reply to requests.
+func StartFakeSSHServerWithFunc(t *testing.T, getOutput ShellFunc, opts ...FakeServerOption) *FakeSSHServer {
+	t.Helper()
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate host key: %v", err)
+	}
+	hostKey, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+
+	srv := &FakeSSHServer{
+		hostKey:          hostKey,
+		getOutput:        getOutput,
+		expectedUser:     "test",
+		expectedPassword: "hunter2",
+	}
+	for _, opt := range opts {
+		opt(srv)
+	}
+
+	cfg := &ssh.ServerConfig{
+		PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
+			if c.User() == srv.expectedUser && string(pass) == srv.expectedPassword {
+				return nil, nil
+			}
+			return nil, errors.New("invalid credentials")
+		},
+	}
+	cfg.AddHostKey(hostKey)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv.listener = lis
+
+	go srv.acceptLoop(cfg)
+	t.Cleanup(srv.Stop)
+
+	return srv
+}
+
+func (s *FakeSSHServer) acceptLoop(cfg *ssh.ServerConfig) {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		s.mu.Lock()
+		stopped := s.stopped
+		if !stopped {
+			s.conns = append(s.conns, conn)
+		}
+		s.mu.Unlock()
+		if stopped {
+			_ = conn.Close()
+			return
+		}
+		go s.serveConn(conn, cfg)
+	}
+}
+
+func (s *FakeSSHServer) serveConn(conn net.Conn, cfg *ssh.ServerConfig) {
+	defer conn.Close()
+
+	sconn, chans, reqs, err := ssh.NewServerConn(conn, cfg)
+	if err != nil {
+		return
+	}
+	defer sconn.Close()
+
+	go ssh.DiscardRequests(reqs)
+
+	for newCh := range chans {
+		if newCh.ChannelType() != "session" {
+			_ = newCh.Reject(ssh.UnknownChannelType, "only session channels are supported")
+			continue
+		}
+		ch, chReqs, err := newCh.Accept()
+		if err != nil {
+			continue
+		}
+		go s.handleSession(ch, chReqs)
+	}
+}
+
+func (s *FakeSSHServer) handleSession(ch ssh.Channel, reqs <-chan *ssh.Request) {
+	defer ch.Close()
+	for req := range reqs {
+		switch req.Type {
+		case "exec":
+			// Per RFC 4254 §6.5: payload is "string", which is uint32 length
+			// + bytes. ssh.Unmarshal handles this for us.
+			var payload struct{ Command string }
+			if err := ssh.Unmarshal(req.Payload, &payload); err != nil {
+				_ = req.Reply(false, nil)
+				return
+			}
+
+			s.mu.Lock()
+			s.received = append(s.received, payload.Command)
+			s.mu.Unlock()
+
+			_ = req.Reply(true, nil)
+			shell := NewShellContext(payload.Command, ch)
+			exitStatus := s.getOutput(shell)
+
+			_, _ = ch.SendRequest("exit-status", false, ssh.Marshal(struct{ Status uint32 }{Status: exitStatus}))
+			return
+
+		default:
+			if req.WantReply {
+				_ = req.Reply(false, nil)
+			}
+		}
+	}
+}
+
+// Stop closes the listener and every connection accepted so far. Idempotent.
+// Tests that want to drive a "server went away" scenario call this explicitly;
+// otherwise it runs once via t.Cleanup.
+func (s *FakeSSHServer) Stop() {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	s.stopped = true
+	conns := s.conns
+	s.conns = nil
+	s.mu.Unlock()
+
+	_ = s.listener.Close()
+	for _, c := range conns {
+		_ = c.Close()
+	}
+}
+
+// Addr returns the host:port the server is bound to.
+func (s *FakeSSHServer) Addr() string {
+	return s.listener.Addr().String()
+}
+
+// Host returns just the host portion of the bound address ("127.0.0.1").
+func (s *FakeSSHServer) Host() string {
+	host, _, _ := net.SplitHostPort(s.Addr())
+	return host
+}
+
+// Port returns the bound port as a string (matches DeviceInstance.Auth.Port).
+func (s *FakeSSHServer) Port() string {
+	_, port, _ := net.SplitHostPort(s.Addr())
+	return port
+}
+
+// User returns the username this server expects.
+func (s *FakeSSHServer) User() string {
+	return s.expectedUser
+}
+
+// Password returns the password this server expects.
+func (s *FakeSSHServer) Password() string {
+	return s.expectedPassword
+}
+
+// Received returns a snapshot of the commands the server has been asked to
+// execute, in arrival order.
+func (s *FakeSSHServer) Received() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.received))
+	copy(out, s.received)
+	return out
+}
+
+// WriteKnownHostsFile writes a known_hosts file containing this server's host
+// key, formatted for the bound host:port. Returns the file path.
+func (s *FakeSSHServer) WriteKnownHostsFile(path string) error {
+	pub := s.hostKey.PublicKey()
+	// OpenSSH non-default-port form: "[host]:port keytype base64(key)\n"
+	entry := fmt.Sprintf("[%s]:%s %s %s\n",
+		s.Host(), s.Port(),
+		pub.Type(),
+		base64.StdEncoding.EncodeToString(pub.Marshal()),
+	)
+	if err := os.WriteFile(path, []byte(entry), 0600); err != nil {
+		return fmt.Errorf("write known_hosts: %w", err)
+	}
+	return nil
+}
+
+func (s *FakeSSHServer) MakeConfig(knownHostsPath string) (*ssh.ClientConfig, error) {
+	hostKey := ssh.InsecureIgnoreHostKey()
+	if knownHostsPath != "" {
+		var err error
+		hostKey, err = knownhosts.New(knownHostsPath)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing known_hosts file from path: %w", err)
+		}
+	}
+	return &ssh.ClientConfig{
+		User:            s.User(),
+		Auth:            []ssh.AuthMethod{ssh.Password(s.Password())},
+		HostKeyCallback: hostKey,
+		Timeout:         0,
+	}, nil
+}
+
+func (s *FakeSSHServer) Dial(knownHostsPath string) (*ssh.Client, error) {
+	sshConfig, err := s.MakeConfig(knownHostsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to %s: %w", s.Addr(), err)
+	}
+	client, err := ssh.Dial("tcp", s.Addr(), sshConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to %s: %w", s.Addr(), err)
+	}
+	return client, nil
+}
+
+func MakeKnownHostsFile(t testing.TB, s *FakeSSHServer) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "known_hosts")
+	if err := s.WriteKnownHostsFile(path); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func MustConnect(t *testing.T, srv *FakeSSHServer) *ssh.Client {
+	t.Helper()
+	client, err := srv.Dial(MakeKnownHostsFile(t, srv))
+	if err != nil {
+		t.Fatalf("Unable to connect to fake server: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+	})
+
+	return client
+}

--- a/pkg/networkconfigmanagement/remote/retry.go
+++ b/pkg/networkconfigmanagement/remote/retry.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package remote
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// isTransientSSH checks if the error is transient and can be retried (devices that may only accept a limited number of connections)
+func isTransientSSH(err error) bool {
+	if err == io.EOF {
+		return true
+	}
+	s := err.Error()
+	// TODO where does this list of strings come from?
+	return strings.Contains(s, "unexpected packet in response to channel open") ||
+		strings.Contains(s, "channel open") ||
+		strings.Contains(s, "connection reset by peer")
+}
+
+// RetryingSSHClient wraps an ssh.Client, and on NewSession will reconnect if
+// the connection appears to have failed. In general this shouldn't happen
+// often, but we see it sometimes with devices that take a very long time to
+// report their config (especially true when testing against public sandboxes).
+// We will only attempt to reconnect once per NewSession call, on the grounds
+// that if the other end closes the connection immediately after making it then
+// retrying probably won't help.
+type RetryingSSHClient struct {
+	*ssh.Client
+	Reconnect func() (*ssh.Client, error)
+}
+
+// NewRetryingSSHClient creates a RetryingSSHClient from a connection function.
+// The function will be called immediately, and will be called again if
+// NewSession ever returns EOF.
+func NewRetryingSSHClient(reconnect func() (*ssh.Client, error)) (*RetryingSSHClient, error) {
+	client, err := reconnect()
+	if err != nil {
+		return nil, err
+	}
+	return &RetryingSSHClient{
+		Client:    client,
+		Reconnect: reconnect,
+	}, nil
+}
+
+// NewSession opens a new Session for this client. (A session is a remote
+// execution of a program). If the first attempt to open a session fails because
+// the other end has closed the connection, this will attempt to reconnect and
+// then will retry.
+func (r *RetryingSSHClient) NewSession() (*ssh.Session, error) {
+	sess, sessErr := r.Client.NewSession()
+	if sessErr != nil {
+		if !isTransientSSH(sessErr) {
+			return nil, sessErr
+		}
+		// Try to reconnect
+		newClient, clientErr := r.Reconnect()
+		if clientErr != nil {
+			return nil, fmt.Errorf("new session failed with [%w] and reconnection failed with [%w]", sessErr, clientErr)
+		}
+		// new connection succeeded, so clean up the old one and try the new one
+		_ = r.Client.Close()
+		r.Client = newClient
+		sess, sessErr = r.Client.NewSession()
+		if sessErr != nil {
+			// if we have an error immediately after reconnecting then this is
+			// probably not a transient thing.
+			return nil, sessErr
+		}
+	}
+	return sess, nil
+}

--- a/pkg/networkconfigmanagement/remote/retry_test.go
+++ b/pkg/networkconfigmanagement/remote/retry_test.go
@@ -1,0 +1,123 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package remote
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestRetryingSSHClient_InitialDialFails(t *testing.T) {
+	errBoom := errors.New("dial boom")
+	_, err := NewRetryingSSHClient(func() (*ssh.Client, error) {
+		return nil, errBoom
+	})
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestRetryingSSHClient_NewSession_Success(t *testing.T) {
+	srv := StartFakeSSHServer(t, map[string]FakeResponse{
+		"show version": Ok("Cisco IOS\n"),
+	})
+	hostfile := MakeKnownHostsFile(t, srv)
+
+	var dials int
+	reconnect := func() (*ssh.Client, error) {
+		dials++
+		return srv.Dial(hostfile)
+	}
+
+	r, err := NewRetryingSSHClient(reconnect)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.Equal(t, 1, dials, "constructor should dial once")
+
+	sess, err := r.NewSession()
+	require.NoError(t, err)
+	defer sess.Close()
+
+	out, err := sess.CombinedOutput("show version")
+	require.NoError(t, err)
+	assert.Equal(t, "Cisco IOS\n", string(out))
+	assert.Equal(t, 1, dials, "no reconnect when first session works")
+}
+
+func TestRetryingSSHClient_NewSession_ReconnectsOnTransientError(t *testing.T) {
+	srv := StartFakeSSHServer(t, map[string]FakeResponse{
+		"show version": Ok("from-srv1\n"),
+	})
+	hostfile := MakeKnownHostsFile(t, srv)
+	config, err := srv.MakeConfig(hostfile)
+	require.NoError(t, err)
+	var dials int
+	reconnect := func() (*ssh.Client, error) {
+		dials++
+		return ssh.Dial("tcp", srv.Addr(), config)
+	}
+
+	r, err := NewRetryingSSHClient(reconnect)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	// Stop the original server and wait until the client observes the
+	// disconnect. Once Wait returns, the inner mux is closed and the next
+	// NewSession returns io.EOF, which isTransientSSH recognises.
+	srv.Stop()
+	_ = r.Client.Wait()
+	r.Client.Wait()
+
+	// Stand up a fresh server and re-point the device at it so the reconnect
+	// has somewhere to land rather than racing the now-dead address.
+	srv = StartFakeSSHServer(t, map[string]FakeResponse{
+		"show version": Ok("from-srv2\n"),
+	})
+	config, err = srv.MakeConfig(MakeKnownHostsFile(t, srv))
+	require.NoError(t, err)
+
+	sess, err := r.NewSession()
+	require.NoError(t, err)
+	defer sess.Close()
+
+	out, err := sess.CombinedOutput("show version")
+	require.NoError(t, err)
+	assert.Equal(t, "from-srv2\n", string(out), "session should be served by the reconnect target")
+	assert.Equal(t, 2, dials, "expected one reconnect after transient error")
+}
+
+func TestRetryingSSHClient_NewSession_ReconnectFails(t *testing.T) {
+	srv := StartFakeSSHServer(t, map[string]FakeResponse{})
+	hostfile := MakeKnownHostsFile(t, srv)
+
+	errReconnect := errors.New("dial again boom")
+	var dials int
+	reconnect := func() (*ssh.Client, error) {
+		dials++
+		if dials == 1 {
+			return srv.Dial(hostfile)
+		}
+		return nil, errReconnect
+	}
+
+	r, err := NewRetryingSSHClient(reconnect)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	// stop the server so that NewSession will get an EOF and retry
+	srv.Stop()
+	_ = r.Client.Wait()
+
+	_, err = r.NewSession()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errReconnect)
+	assert.Contains(t, err.Error(), "reconnection failed")
+	assert.Equal(t, 2, dials)
+}

--- a/pkg/networkconfigmanagement/remote/scp.go
+++ b/pkg/networkconfigmanagement/remote/scp.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package remote
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// readSCPResponse reads an SCP response from the reader. If the first byte is
+// 0, the command succeeded and nothing more is read. Otherwise, the remaining
+// bytes are read and returned as the error message.
+func readSCPResponse(reader *bufio.Reader) error {
+	b, err := reader.ReadByte()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return io.ErrUnexpectedEOF
+		}
+		return err
+	}
+	if b > 0 {
+		msg, err := reader.ReadBytes('\n')
+		if errors.Is(err, io.EOF) {
+			if len(msg) > 0 {
+				err = nil
+			} else {
+				err = io.ErrUnexpectedEOF
+			}
+		}
+		if err != nil {
+			return err
+		}
+		return errors.New(string(msg))
+	}
+	return nil
+}
+
+func executeSCP(session *ssh.Session, cmdStr string, filename string, data string) (output string, err error) {
+	// Get I/O handles
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		return "", err
+	}
+	rawStdout, err := session.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+	stdout := bufio.NewReader(rawStdout)
+	stderr, err := session.StderrPipe()
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			// If we stopped because the other side closed, instead of because
+			// we got an error message, check if they wrote anything to stderr
+			// and return that if so.
+			errBytes, _ := io.ReadAll(stderr)
+			if len(errBytes) > 0 {
+				err = errors.New(string(errBytes))
+			}
+		}
+	}()
+	// Start the SCP command
+	if err := session.Start(cmdStr); err != nil {
+		return "", err
+	}
+	// Write the scp control line
+	if _, err := fmt.Fprintln(stdin, "C0600", len(data), filename); err != nil {
+		if errors.Is(err, io.EOF) {
+			err = io.ErrUnexpectedEOF
+		}
+		return "", err
+	}
+	if err := readSCPResponse(stdout); err != nil {
+		return "", err
+	}
+	// Write the data
+	if _, err = fmt.Fprint(stdin, data+"\x00"); err != nil {
+		if errors.Is(err, io.EOF) {
+			err = io.ErrUnexpectedEOF
+		}
+		return "", err
+	}
+	if err := readSCPResponse(stdout); err != nil {
+		return "", err
+	}
+	stdin.Close()
+	if err := session.Wait(); err != nil {
+		return "", err
+	}
+	// Read any additional output that the command provides
+	result, err := io.ReadAll(stdout)
+	return string(result), err
+}

--- a/pkg/networkconfigmanagement/remote/ssh.go
+++ b/pkg/networkconfigmanagement/remote/ssh.go
@@ -9,10 +9,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"slices"
-	"strings"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -40,7 +38,7 @@ func init() {
 
 // SSHClient implements Client using SSH
 type SSHClient struct {
-	client *ssh.Client
+	client *RetryingSSHClient
 	device *ncmconfig.DeviceInstance // Device configuration for authentication
 	prof   *profile.NCMProfile
 }
@@ -53,7 +51,7 @@ type SSHSession struct {
 // NewSSHClient creates a new SSH client for the given device configuration
 func NewSSHClient(device *ncmconfig.DeviceInstance) (*SSHClient, error) {
 	if device.Auth.SSH != nil {
-		if err := validateClientConfig(device.Auth.SSH); err != nil {
+		if err := ValidateSSHConfig(device.Auth.SSH); err != nil {
 			return nil, fmt.Errorf("error validating ssh client config: %w", err)
 		}
 	}
@@ -110,7 +108,7 @@ func buildAuthMethods(auth ncmconfig.AuthCredentials) ([]ssh.AuthMethod, error) 
 	return methods, nil
 }
 
-func validateClientConfig(config *ncmconfig.SSHConfig) error {
+func ValidateSSHConfig(config *ncmconfig.SSHConfig) error {
 	var validCiphers, validKeyExchanges, validHostKeys []string
 	if config.AllowLegacyAlgorithms {
 		// Log a warning about the insecure nature of algorithms, still check that it's a "valid" algorithm vs. only a safe/supported algo
@@ -146,22 +144,11 @@ func (c *SSHClient) SetProfile(profile *profile.NCMProfile) {
 	c.prof = profile
 }
 
-// redial attempts to re-establish the SSH connection to the device
-func (c *SSHClient) redial() error {
-	if c.client != nil {
-		_ = c.client.Close()
-	}
-	newClient, err := connectToHost(c.device.IPAddress, c.device.Auth, c.device.Auth.SSH)
-	if err != nil {
-		return err
-	}
-	c.client = newClient
-	return nil
-}
-
 // Connect establishes a new SSH connection to the specified IP address using the provided authentication credentials
 func (c *SSHClient) Connect() error {
-	client, err := connectToHost(c.device.IPAddress, c.device.Auth, c.device.Auth.SSH)
+	client, err := NewRetryingSSHClient(func() (*ssh.Client, error) {
+		return connectToDevice(c.device)
+	})
 	if err != nil {
 		return err
 	}
@@ -172,26 +159,10 @@ func (c *SSHClient) Connect() error {
 // NewSession creates a new SSH session for the client (needed for every command execution)
 func (c *SSHClient) NewSession() (Session, error) {
 	sess, err := c.client.NewSession()
-	if err != nil && isTransientSSH(err) {
-		if rerr := c.redial(); rerr == nil {
-			sess, err = c.client.NewSession()
-		}
-	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SSH session: %w", err)
 	}
 	return &SSHSession{session: sess}, nil
-}
-
-// isTransientSSH checks if the error is transient and can be retried (devices that may only accept a limited number of connections)
-func isTransientSSH(err error) bool {
-	if err == io.EOF {
-		return true
-	}
-	s := err.Error()
-	return strings.Contains(s, "unexpected packet in response to channel open") ||
-		strings.Contains(s, "channel open") ||
-		strings.Contains(s, "connection reset by peer")
 }
 
 // CombinedOutput runs a command using the SSH session and returns its output
@@ -276,6 +247,11 @@ func (c *SSHClient) Close() error {
 // Close closes the SSH session
 func (s *SSHSession) Close() error {
 	return s.session.Close()
+}
+
+// connectToDevice is a shorthand for connectToHost with parameters from the device
+func connectToDevice(device *ncmconfig.DeviceInstance) (*ssh.Client, error) {
+	return connectToHost(device.IPAddress, device.Auth, device.Auth.SSH)
 }
 
 // connectToHost establishes an SSH connection to the specified IP address using the provided authentication credentials

--- a/pkg/networkconfigmanagement/remote/ssh_test.go
+++ b/pkg/networkconfigmanagement/remote/ssh_test.go
@@ -20,11 +20,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	ncmconfig "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+
+	ncmconfig "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func TestSSHClient_RetrieveRunningConfig_Success(t *testing.T) {
@@ -266,7 +267,7 @@ func TestValidateClientConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateClientConfig(tt.config)
+			err := ValidateSSHConfig(tt.config)
 
 			if tt.errContains != "" {
 				assert.Error(t, err)


### PR DESCRIPTION
### What does this PR do?

This PR adds:
 * The fake SSH server from #50033, refactored slightly to be more powerful (I needed a version that actually reads and writes stdin/stdout in order to test SCP commands)
 * A `RetryingSSHClient`, which wraps a normal `ssh.Client` except that it will attempt to reconnect if calling `NewSession` results in an EOF because the other end closed the connection early.
 * `Command` and `SCPCommand` types that represent a simple SSH command and a more complex SCP command that could be executed against a device
 * Methods for executing both command types over an SSH connection

Additionally, I refactored the `SSHClient` type to use `RetryingSSHClient` instead of containing the retry logic itself.

I split this PR out of #51257 because 51257 was too large.

### Motivation

This is part of supporting config pushes - we need a way to get config files to devices, and SCP seems like the most straightforward approach.

### Describe how you validated your changes

The behavior of the agent shouldn't change; tests pass and the agent runs normally locally.

