### PR TITLE
[CONTINT-5329] Emitting pod level resources and updated the appropiate unit test

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet_test.go
@@ -88,7 +88,7 @@ func TestPodParser(t *testing.T) {
 					{
 						Name:  "nginx-container",
 						Image: "nginx:1.25.2",
-						Resources: &kubelet.ContainerResourcesSpec{
+						Resources: &kubelet.ResourcesSpec{
 							Requests: kubelet.ResourceList{
 								"nvidia.com/gpu":              resource.MustParse("1"),
 								"cpu":                         resource.MustParse("100m"),

--- a/comp/core/workloadmeta/collectors/util/kubelet.go
+++ b/comp/core/workloadmeta/collectors/util/kubelet.go
@@ -133,6 +133,7 @@ func ParseKubeletPods(pods []*kubelet.Pod, collectEphemeralContainers bool, stor
 			InitContainers:             podInitContainers,
 			Containers:                 podContainers,
 			EphemeralContainers:        podEphemeralContainers,
+			Resources:                  extractPodResources(pod.Spec.Resources),
 			Ready:                      kubelet.IsPodReady(pod),
 			Phase:                      pod.Status.Phase,
 			IP:                         pod.Status.PodIP,
@@ -436,6 +437,38 @@ func extractEnvFromSpec(envSpec []kubelet.EnvVar) map[string]string {
 	}
 
 	return env
+}
+
+func extractPodResources(resourcesSpec *kubelet.ContainerResourcesSpec) workloadmeta.ContainerResources {
+	resources := workloadmeta.ContainerResources{}
+
+	if resourcesSpec == nil {
+		return resources
+	}
+
+	if cpuReq, found := resourcesSpec.Requests[kubelet.ResourceCPU]; found {
+		resources.CPURequest = kubernetes.FormatCPURequests(cpuReq)
+	}
+	if memoryReq, found := resourcesSpec.Requests[kubelet.ResourceMemory]; found {
+		resources.MemoryRequest = kubernetes.FormatMemoryRequests(memoryReq)
+	}
+	if cpuLimit, found := resourcesSpec.Limits[kubelet.ResourceCPU]; found {
+		resources.CPULimit = kubernetes.FormatCPURequests(cpuLimit)
+	}
+	if memoryLimit, found := resourcesSpec.Limits[kubelet.ResourceMemory]; found {
+		resources.MemoryLimit = kubernetes.FormatMemoryRequests(memoryLimit)
+	}
+
+	resources.RawRequests = make(map[string]string, len(resourcesSpec.Requests))
+	for resourceName, quantity := range resourcesSpec.Requests {
+		resources.RawRequests[string(resourceName)] = quantity.String()
+	}
+	resources.RawLimits = make(map[string]string, len(resourcesSpec.Limits))
+	for resourceName, quantity := range resourcesSpec.Limits {
+		resources.RawLimits[string(resourceName)] = quantity.String()
+	}
+
+	return resources
 }
 
 func extractResources(spec *kubelet.ContainerSpec, status *kubelet.ContainerStatus) workloadmeta.ContainerResources {

--- a/comp/core/workloadmeta/collectors/util/kubelet.go
+++ b/comp/core/workloadmeta/collectors/util/kubelet.go
@@ -439,7 +439,7 @@ func extractEnvFromSpec(envSpec []kubelet.EnvVar) map[string]string {
 	return env
 }
 
-func extractPodResources(resourcesSpec *kubelet.ContainerResourcesSpec) workloadmeta.ContainerResources {
+func extractPodResources(resourcesSpec *kubelet.ResourcesSpec) workloadmeta.ContainerResources {
 	resources := workloadmeta.ContainerResources{}
 
 	if resourcesSpec == nil {

--- a/comp/core/workloadmeta/collectors/util/kubelet_test.go
+++ b/comp/core/workloadmeta/collectors/util/kubelet_test.go
@@ -194,7 +194,7 @@ func TestExtractResources_InPlaceResize(t *testing.T) {
 			name: "status.resources overrides spec (resized down)",
 			spec: &kubelet.ContainerSpec{
 				Name: "c",
-				Resources: &kubelet.ContainerResourcesSpec{
+				Resources: &kubelet.ResourcesSpec{
 					Requests: kubelet.ResourceList{
 						kubelet.ResourceCPU:              resource.MustParse("500m"),
 						kubelet.ResourceMemory:           resource.MustParse("1Gi"),
@@ -208,7 +208,7 @@ func TestExtractResources_InPlaceResize(t *testing.T) {
 			},
 			status: &kubelet.ContainerStatus{
 				Name: "c",
-				Resources: &kubelet.ContainerResourcesSpec{
+				Resources: &kubelet.ResourcesSpec{
 					Requests: kubelet.ResourceList{
 						kubelet.ResourceCPU:    resource.MustParse("200m"),
 						kubelet.ResourceMemory: resource.MustParse("512Mi"),
@@ -237,7 +237,7 @@ func TestExtractResources_InPlaceResize(t *testing.T) {
 			name: "legacy cluster (no status resources) falls back to spec",
 			spec: &kubelet.ContainerSpec{
 				Name: "c",
-				Resources: &kubelet.ContainerResourcesSpec{
+				Resources: &kubelet.ResourcesSpec{
 					Requests: kubelet.ResourceList{
 						kubelet.ResourceCPU:    resource.MustParse("100m"),
 						kubelet.ResourceMemory: resource.MustParse("256Mi"),
@@ -266,7 +266,7 @@ func TestExtractResources_InPlaceResize(t *testing.T) {
 			name: "status.resources with partial keys falls through to spec for missing keys",
 			spec: &kubelet.ContainerSpec{
 				Name: "c",
-				Resources: &kubelet.ContainerResourcesSpec{
+				Resources: &kubelet.ResourcesSpec{
 					Requests: kubelet.ResourceList{
 						kubelet.ResourceCPU:              resource.MustParse("500m"),
 						kubelet.ResourceMemory:           resource.MustParse("1Gi"),
@@ -280,7 +280,7 @@ func TestExtractResources_InPlaceResize(t *testing.T) {
 			},
 			status: &kubelet.ContainerStatus{
 				Name: "c",
-				Resources: &kubelet.ContainerResourcesSpec{
+				Resources: &kubelet.ResourcesSpec{
 					Requests: kubelet.ResourceList{
 						kubelet.ResourceCPU: resource.MustParse("300m"),
 					},

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -829,6 +829,7 @@ type KubernetesPod struct {
 	NamespaceAnnotations       map[string]string   `proto:"ignore"`
 	FinishedAt                 time.Time           `proto:"ignore"`
 	SecurityContext            *PodSecurityContext `proto:"ignore"`
+	Resources                  ContainerResources `proto:"ignore"`
 
 	// The following fields are only needed for the kubelet check or KSM check
 	// when configured to emit pod metrics from the node agent. That means only

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -829,7 +829,7 @@ type KubernetesPod struct {
 	NamespaceAnnotations       map[string]string   `proto:"ignore"`
 	FinishedAt                 time.Time           `proto:"ignore"`
 	SecurityContext            *PodSecurityContext `proto:"ignore"`
-	Resources                  ContainerResources `proto:"ignore"`
+	Resources                  ContainerResources  `proto:"ignore"`
 
 	// The following fields are only needed for the kubelet check or KSM check
 	// when configured to emit pod metrics from the node agent. That means only

--- a/pkg/collector/corechecks/containers/kubelet/common/testing/utils.go
+++ b/pkg/collector/corechecks/containers/kubelet/common/testing/utils.go
@@ -122,6 +122,10 @@ var (
 			"kube_namespace:default",
 		},
 		"kubernetes_pod_uid://resized-pod-uid-0001": {"pod_name:resized-pod"},
+		"kubernetes_pod_uid://dc24642d-e142-11e9-b8b8-42010af002dd": {
+			"pod_name:cassandra-0",
+			"kube_namespace:default",
+		},
 	}
 
 	// InstanceTags are default tags that should be applied to all metrics at the instance level

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
@@ -142,8 +142,56 @@ func (p *Provider) processWorkloadmetaPod(pod *workloadmeta.KubernetesPod, sende
 	p.generatePodTerminationMetric(sender, pod)
 	p.generatePodResizeMetric(sender, pod)
 	p.generatePodStartupMetrics(sender, pod)
+	p.generatePodSpecMetrics(sender, pod)
 
 	runningAggregator.recordPod(p, pod)
+}
+
+func (p *Provider) generatePodSpecMetrics(sender sender.Sender, pod *workloadmeta.KubernetesPod) {
+	if pod.Phase != "Running" && pod.Phase != "Pending" {
+		return
+	}
+
+	podID := pod.ID
+	if podID == "" {
+		log.Debug("skipping pod with no uid for pod resource metrics")
+		return
+	}
+
+	entityID := types.NewEntityID(types.KubernetesPodUID, podID)
+	tagList, _ := p.tagger.Tag(entityID, types.HighCardinality)
+	if len(tagList) == 0 {
+		return
+	}
+	tagList = utils.ConcatenateTags(tagList, p.config.Tags)
+
+	for r, value := range pod.Resources.RawRequests {
+		if r != "cpu" && r != "memory" {
+			continue
+		}
+
+		quantity, err := resource.ParseQuantity(value)
+		if err != nil {
+			log.Warnf("Failed to parse pod resource quantity %s: %s", value, err)
+			continue
+		}
+
+		sender.Gauge(common.KubeletMetricsPrefix+"pod."+r+".request", quantity.AsApproximateFloat64(), "", tagList)
+	}
+
+	for r, value := range pod.Resources.RawLimits {
+		if r != "cpu" && r != "memory" {
+			continue
+		}
+
+		quantity, err := resource.ParseQuantity(value)
+		if err != nil {
+			log.Warnf("Failed to parse pod resource quantity %s: %s", value, err)
+			continue
+		}
+
+		sender.Gauge(common.KubeletMetricsPrefix+"pod."+r+".limit", quantity.AsApproximateFloat64(), "", tagList)
+	}
 }
 
 func (p *Provider) generateContainerSpecMetrics(sender sender.Sender, pod *workloadmeta.KubernetesPod, cStatus *workloadmeta.KubernetesContainerStatus, containerID types.EntityID) {

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
@@ -239,6 +239,12 @@ func (suite *ProviderTestSuite) TestTransformPodsRequestsLimits() {
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"cpu.limits", 0.5, "", append(config.Tags, "pod_name:cassandra-0"))
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.limits", 1073741824.0, "", append(config.Tags, "pod_name:cassandra-0"))
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"ephemeral-storage.limits", 2147483648.0, "", append(config.Tags, "pod_name:cassandra-0"))
+
+	// pod resource metrics
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.cpu.request", 0.75, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.memory.request", 1610612736.0, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.cpu.limit", 1.0, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.memory.limit", 2147483648.0, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
 }
 
 // TestTransformPodsInPlaceResize verifies that request/limit metrics

--- a/pkg/collector/corechecks/containers/kubelet/testdata/pods_requests_limits.json
+++ b/pkg/collector/corechecks/containers/kubelet/testdata/pods_requests_limits.json
@@ -35,6 +35,16 @@
         ]
       },
       "spec":{
+        "resources": {
+          "limits": {
+            "cpu": "1",
+            "memory": "2Gi"
+          },
+          "requests": {
+            "cpu": "750m",
+            "memory": "1536Mi"
+          }
+        },
         "volumes":[
           {
             "name":"cassandra-data",

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -55,6 +55,7 @@ type Spec struct {
 	Containers          []ContainerSpec         `json:"containers,omitempty"`
 	EphemeralContainers []ContainerSpec         `json:"ephemeralContainers,omitempty"`
 	Volumes             []VolumeSpec            `json:"volumes,omitempty"`
+	Resources           *ContainerResourcesSpec `json:"resources,omitempty"`
 	PriorityClassName   string                  `json:"priorityClassName,omitempty"`
 	SecurityContext     *PodSecurityContextSpec `json:"securityContext,omitempty"`
 	RuntimeClassName    *string                 `json:"runtimeClassName,omitempty"`

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -55,7 +55,7 @@ type Spec struct {
 	Containers          []ContainerSpec         `json:"containers,omitempty"`
 	EphemeralContainers []ContainerSpec         `json:"ephemeralContainers,omitempty"`
 	Volumes             []VolumeSpec            `json:"volumes,omitempty"`
-	Resources           *ContainerResourcesSpec `json:"resources,omitempty"`
+	Resources           *ResourcesSpec          `json:"resources,omitempty"`
 	PriorityClassName   string                  `json:"priorityClassName,omitempty"`
 	SecurityContext     *PodSecurityContextSpec `json:"securityContext,omitempty"`
 	RuntimeClassName    *string                 `json:"runtimeClassName,omitempty"`
@@ -77,7 +77,7 @@ type ContainerSpec struct {
 	ReadinessProbe  *ContainerProbe               `json:"readinessProbe,omitempty"`
 	Env             []EnvVar                      `json:"env,omitempty"`
 	SecurityContext *ContainerSecurityContextSpec `json:"securityContext,omitempty"`
-	Resources       *ContainerResourcesSpec       `json:"resources,omitempty"`
+	Resources       *ResourcesSpec                `json:"resources,omitempty"`
 	ResizePolicy    []ContainerResizePolicySpec   `json:"resizePolicy,omitempty"`
 }
 
@@ -125,8 +125,8 @@ func GetGPUResourceNames() []ResourceName {
 // ResourceList is the type of fields in Pod.Spec.Containers.Resources
 type ResourceList map[ResourceName]resource.Quantity
 
-// ContainerResourcesSpec contains fields for unmarshalling a Pod.Spec.Containers.Resources
-type ContainerResourcesSpec struct {
+// ResourcesSpec contains fields for unmarshalling a Pod.Spec.Resources and Pod.Spec.Containers.Resources
+type ResourcesSpec struct {
 	Requests ResourceList `json:"requests,omitempty"`
 	Limits   ResourceList `json:"limits,omitempty"`
 }
@@ -256,7 +256,7 @@ type ContainerStatus struct {
 	ResolvedAllocatedResources []ContainerAllocatedResource `json:"resolvedAllocatedResources,omitempty"`
 
 	// Resources may not be the same as spec due to in-place vertical sizing
-	Resources *ContainerResourcesSpec `json:"resources,omitempty"`
+	Resources *ResourcesSpec `json:"resources,omitempty"`
 }
 
 // ContainerAllocatedResource contains the fields for an assigned resource to a container

--- a/releasenotes/notes/pod-level-resources-79ac0a28bdbcd7c8.yaml
+++ b/releasenotes/notes/pod-level-resources-79ac0a28bdbcd7c8.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Parses and collects ``kubernetes.pod.cpu.request``, ``kubernetes.pod.memory.request``,
+    ``kubernetes.pod.cpu.limit``, and ``kubernetes.pod.memory.limit``.


### PR DESCRIPTION
### What does this PR do?

Parse the pod level resource block, if present, and emit the metrics:
- kubernetes.pod.cpu.request
- kubernetes.pod.cpu.limit
- kubernetes.pod.memory.request
- kubernetes.pod.memory.limit

### Motivation

Emit pod level resources 

### Describe how you validated your changes

I started a local minikube cluster, where the PodLevelResources feature gate is enabled by default.

On my test cluster, I deployed a pod with pod-level spec.resources set
```
  apiVersion: v1
  kind: Pod
  metadata:
    name: pod-level-resources-test
  spec:
    resources:
      requests:
        cpu: 200m
        memory: 256Mi
      limits:
        cpu: 500m
        memory: 512Mi
    containers:
    - name: app
      image: nginx:alpine
```

On my test cluster I deployed a custom Datadog Agent build of my branch and observed the emitted metrics in the Datadog Metric Explorer UI:
<img width="1730" height="314" alt="image" src="https://github.com/user-attachments/assets/2b1011c7-7bb4-45c7-8f03-88d6149017aa" />

<img width="1732" height="308" alt="image" src="https://github.com/user-attachments/assets/74ea7a3a-bf96-471f-bca5-5f03ba1df01a" />

<img width="1737" height="326" alt="image" src="https://github.com/user-attachments/assets/68b5b724-6d89-4920-b609-38d4d44dda88" />

<img width="1737" height="327" alt="image" src="https://github.com/user-attachments/assets/73d2e0af-0121-43ab-98ef-6584cdd4b58e" />


### Additional Notes
