### PR TITLE
Add systemd-timesyncd default location to NTP check

### DIFF
--- a/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_nowindows.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_nowindows.go
@@ -27,9 +27,28 @@ func getNTPServersFromFiles(files []string) ([]string, error) {
 
 			for line := range lines {
 				line = strings.TrimSpace(line)
+				if idx := strings.Index(line, "#"); idx >= 0 {
+					line = strings.TrimSpace(line[:idx])
+				}
+				if line == "" {
+					continue
+				}
+
+				// chrony / ntp.conf: "server|pool|peer <host>"
 				fields := strings.Fields(line)
 				if len(fields) >= 2 && (fields[0] == "server" || fields[0] == "pool" || fields[0] == "peer") {
 					serversMap[fields[1]] = true
+					continue
+				}
+
+				// systemd-timesyncd: "NTP=host1 host2" or "FallbackNTP=host1 host2"
+				if key, value, ok := strings.Cut(line, "="); ok {
+					key = strings.TrimSpace(key)
+					if key == "NTP" || key == "FallbackNTP" {
+						for _, host := range strings.Fields(value) {
+							serversMap[host] = true
+						}
+					}
 				}
 			}
 		}

--- a/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_nowindows.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_nowindows.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getLocalDefinedNTPServers() ([]string, error) {
-	return getNTPServersFromFiles([]string{"/etc/ntp.conf", "/etc/xntp.conf", "/etc/chrony.conf", "/etc/chrony/chrony.conf", "/etc/ntpd.conf", "/etc/openntpd/ntpd.conf"})
+	return getNTPServersFromFiles([]string{"/etc/ntp.conf", "/etc/xntp.conf", "/etc/chrony.conf", "/etc/chrony/chrony.conf", "/etc/ntpd.conf", "/etc/openntpd/ntpd.conf", "/etc/systemd/timesyncd.conf"})
 }
 
 func getNTPServersFromFiles(files []string) ([]string, error) {

--- a/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_nowindows_test.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_nowindows_test.go
@@ -164,24 +164,10 @@ FallbackNTP=
 	})
 }
 
-func TestGetNTPServersFromTimesyncdConfigOnlyFallback(t *testing.T) {
-	config := `[Time]
-FallbackNTP=0.pool.ntp.org
-`
-	createTempFile(t, config, func(f1 string) {
-		servers, err := getNTPServersFromFiles([]string{f1})
-		assert.NoError(t, err)
-		assert.Equal(t, []string{"0.pool.ntp.org"}, servers)
-	})
-}
-
-func TestGetNTPServersFromTimesyncdAllCommented(t *testing.T) {
-	config := `[Time]
-#NTP=time1.example.com
-#FallbackNTP=0.pool.ntp.org
-`
-	createTempFile(t, config, func(f1 string) {
-		_, err := getNTPServersFromFiles([]string{f1})
-		assert.Error(t, err)
-	})
+func TestGetLocalDefinedNTPServersIncludesTimesyncdPath(t *testing.T) {
+	_, err := getLocalDefinedNTPServers()
+	if err == nil {
+		t.Skip("a real ntp/chrony/timesyncd config exists on this host")
+	}
+	assert.Contains(t, err.Error(), "/etc/systemd/timesyncd.conf")
 }

--- a/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_nowindows_test.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_nowindows_test.go
@@ -148,3 +148,40 @@ FallbackNTP=0.pool.ntp.org 1.pool.ntp.org
 		assert.Equal(t, []string{"0.pool.ntp.org", "1.pool.ntp.org", "time1.example.com", "time2.example.com"}, servers)
 	})
 }
+
+func TestGetNTPServersFromTimesyncdConfigEdgeCases(t *testing.T) {
+	config := `# vendor defaults
+[Time]
+#NTP=
+NTP=time1.example.com  time2.example.com   # trailing comment
+FallbackNTP=
+`
+	createTempFile(t, config, func(f1 string) {
+		servers, err := getNTPServersFromFiles([]string{f1})
+		assert.NoError(t, err)
+		sort.Strings(servers)
+		assert.Equal(t, []string{"time1.example.com", "time2.example.com"}, servers)
+	})
+}
+
+func TestGetNTPServersFromTimesyncdConfigOnlyFallback(t *testing.T) {
+	config := `[Time]
+FallbackNTP=0.pool.ntp.org
+`
+	createTempFile(t, config, func(f1 string) {
+		servers, err := getNTPServersFromFiles([]string{f1})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"0.pool.ntp.org"}, servers)
+	})
+}
+
+func TestGetNTPServersFromTimesyncdAllCommented(t *testing.T) {
+	config := `[Time]
+#NTP=time1.example.com
+#FallbackNTP=0.pool.ntp.org
+`
+	createTempFile(t, config, func(f1 string) {
+		_, err := getNTPServersFromFiles([]string{f1})
+		assert.Error(t, err)
+	})
+}

--- a/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_nowindows_test.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_nowindows_test.go
@@ -135,3 +135,16 @@ func TestGetNTPServersFromFileNoServer(t *testing.T) {
 		assert.Equal(t, []string(nil), servers)
 	})
 }
+
+func TestGetNTPServersFromTimesyncdConfig(t *testing.T) {
+	config := `[Time]
+NTP=time1.example.com time2.example.com
+FallbackNTP=0.pool.ntp.org 1.pool.ntp.org
+`
+	createTempFile(t, config, func(f1 string) {
+		servers, err := getNTPServersFromFiles([]string{f1})
+		assert.NoError(t, err)
+		sort.Strings(servers)
+		assert.Equal(t, []string{"0.pool.ntp.org", "1.pool.ntp.org", "time1.example.com", "time2.example.com"}, servers)
+	})
+}

--- a/releasenotes/notes/add-systemd-timesyncd-default-location-f2792c2933e3881f.yaml
+++ b/releasenotes/notes/add-systemd-timesyncd-default-location-f2792c2933e3881f.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Updated the ntp check to support the default location of
+    ``systemd-timesyncd`` (``/etc/systemd/timesyncd.conf``). The
+    check now parses ``NTP=`` and ``FallbackNTP=`` keys in addition
+    to the existing chrony/ntp.conf ``server``/``pool``/``peer``
+    directives.


### PR DESCRIPTION
### What does this PR do?
Adds `/etc/systemd/timesyncd.conf` to the list of files discovered by the NTP check's `use_local_defined_servers` mode, and extends the parser to recognize `NTP=` / `FallbackNTP=` keys (multiple servers per line, equals-delimited) in addition to chrony/ntp.conf's `server`/`pool`/`peer` directives.

### Motivation
On Ubuntu, Debian, and Fedora Workstation defaults, time sync is handled by `systemd-timesyncd` rather than chrony or ntpd. Before this change, hosts using timesyncd fall through every existing path and the NTP check fails to load with `Cannot find NTP server in ...`.

FR: [FRAGENT-3591](https://datadoghq.atlassian.net/browse/FRAGENT-3591) · [AGENT-16263](https://datadoghq.atlassian.net/browse/AGENT-16263) · [TEEP-6785](https://datadoghq.atlassian.net/browse/TEEP-6785)

### Verification
* `go test ./pkg/collector/corechecks/net/ntp/...` — new and existing tests pass.
* Ran a standalone fork of the parser (post-PR logic + the new file list) in vanilla `ubuntu:24.04` arm64 containers with realistic, edge-case, all-commented, and chrony-style fixtures bind-mounted. All four cases produced the expected output. Full method + results in the [FRAGENT-3591 comment](https://datadoghq.atlassian.net/browse/FRAGENT-3591?focusedCommentId=3287048).

### Out of scope
* Drop-in directories (`/etc/systemd/timesyncd.conf.d/*.conf`, etc.) — no glob precedent in prior NTP-config PRs; can follow up if requested.
* Querying `timedatectl` over D-Bus.

[FRAGENT-3591]: https://datadoghq.atlassian.net/browse/FRAGENT-3591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AGENT-16263]: https://datadoghq.atlassian.net/browse/AGENT-16263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TEEP-6785]: https://datadoghq.atlassian.net/browse/TEEP-6785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ