### PR TITLE
[snmpscan] add --use-getbulk flag for opt-in GetBulk walk with backend reporting

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -48,6 +48,14 @@ const (
 // argsType is an alias so we can inject the args via fx.
 type argsType []string
 
+// scanFlags carries flags specific to the `agent snmp scan` subcommand.
+// Wrapped in a struct so fx can inject it without colliding with the int args
+// the rest of the bundle already supplies.
+type scanFlags struct {
+	useGetBulk bool
+	bulkMaxRep int
+}
+
 // configErr wraps any error caused by invalid configuration.
 // If the main script returns a configErr it will print the usage string along
 // with the error message.
@@ -144,7 +152,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 	logLevelDefaultOff := command.LogLevelDefaultOff{}
 
-	// This command does nothing until the backend supports it, so it isn't visible yet.
+	var (
+		useGetBulk bool
+		bulkMaxRep int
+	)
+
+	// Scan results are reported to the NDM backend via the EventPlatformForwarder
+	// and surface in the Profile Manager "All Metrics" table.
 	snmpScanCmd := &cobra.Command{
 		Hidden: true,
 		Use:    "scan <ipaddress>[:port]",
@@ -154,7 +168,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			err := fxutil.OneShot(scanDevice,
-				fx.Supply(connParams, globalParams, cmd),
+				fx.Supply(connParams, globalParams, cmd, scanFlags{useGetBulk: useGetBulk, bulkMaxRep: bulkMaxRep}),
 				fx.Provide(func() argsType { return args }),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
@@ -206,7 +220,11 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	snmpScanCmd.Flags().IntVarP(&connParams.Retries, "retries", "r", defaultRetries, "Set the number of retries")
 	snmpScanCmd.Flags().IntVarP(&connParams.Timeout, "timeout", "t", defaultTimeout, "Set the request timeout (in seconds)")
 
-	// This command does nothing until the backend supports it, so it isn't enabled yet.
+	// GetBulk-based walk (experimental). Required for devices that previously caused
+	// infinite loops or crashes with the default SkipOIDRowsNaive-based walk.
+	snmpScanCmd.Flags().BoolVar(&useGetBulk, "use-getbulk", false, "Use the GetBulk-based scan walk (experimental). Required to scan devices that previously caused infinite loops or crashes.")
+	snmpScanCmd.Flags().IntVar(&bulkMaxRep, "bulk-max-rep", 0, "Starting max-repetitions for GetBulk during scan (0 = default 10, matching snmpbulkwalk -Cr). Halves on timeout, recovers on success. Only used when --use-getbulk is set.")
+
 	snmpCmd.AddCommand(snmpScanCmd)
 
 	return []*cobra.Command{snmpCmd}
@@ -264,7 +282,7 @@ func setDefaultsFromAgent(connParams *snmpparse.SNMPConfig, agentParams *snmppar
 	}
 }
 
-func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snmpscan.Component, conf config.Component, client ipc.HTTPClient) error {
+func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, flags scanFlags, snmpScanner snmpscan.Component, conf config.Component, client ipc.HTTPClient) error {
 	// Parse args
 	if len(args) == 0 {
 		return confErrf("missing argument: IP address")
@@ -288,7 +306,9 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 	fmt.Printf("Launching scan for device: %s\n", deviceID)
 	err := snmpScanner.ScanDeviceAndSendData(context.Background(), connParams, namespace,
 		snmpscan.ScanParams{
-			ScanType: metadata.ManualScan,
+			ScanType:           metadata.ManualScan,
+			UseGetBulk:         flags.useGetBulk,
+			BulkMaxRepetitions: flags.bulkMaxRep,
 		})
 	if err != nil {
 		fmt.Printf("Unable to perform device scan for device %s: %v\n", deviceID, err)

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -35,4 +35,17 @@ type ScanParams struct {
 	// MaxCallCount limits the total number of SNMP calls in a scan.
 	// A value of 0 means there is no limit.
 	MaxCallCount int
+
+	// UseGetBulk selects the GetBulk-based walk introduced in PR #49734.
+	// When false (default), the scan uses the existing SkipOIDRowsNaive-based
+	// gatherPDUs path. When true, the scan uses gatherPDUsWithBulk, which never
+	// fabricates OIDs and is required to scan devices that previously caused
+	// infinite loops or crashes.
+	UseGetBulk bool
+
+	// BulkMaxRepetitions is the starting max-repetitions value for GetBulk
+	// when UseGetBulk is true. A value of 0 selects the default (10, matching
+	// net-snmp's snmpbulkwalk -Cr). Halves on timeout, recovers on success.
+	// Ignored when UseGetBulk is false.
+	BulkMaxRepetitions int
 }

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -13,11 +13,17 @@ import (
 
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
+	"github.com/DataDog/datadog-agent/pkg/snmp/batchsize"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/gosnmp/gosnmp"
 )
+
+// defaultBulkMaxRepetitions is the starting max-repetitions value for GetBulk
+// during a device scan. Matches net-snmp's `snmpbulkwalk -Cr` default.
+const defaultBulkMaxRepetitions = 10
 
 func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *snmpparse.SNMPConfig, namespace string, scanParams snmpscan.ScanParams) error {
 	// Establish connection
@@ -61,8 +67,13 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 				snmp.LocalAddr, snmp.Port, errors.Join(errs...)),
 		)
 	}
+	bulkMaxRep := scanParams.BulkMaxRepetitions
+	if bulkMaxRep <= 0 {
+		bulkMaxRep = defaultBulkMaxRepetitions
+	}
 	err = s.runDeviceScan(ctx, snmp, namespace, deviceID,
-		scanParams.CallInterval, scanParams.MaxCallCount)
+		scanParams.CallInterval, scanParams.MaxCallCount,
+		scanParams.UseGetBulk, bulkMaxRep)
 	if err != nil {
 		errs := []error{err}
 
@@ -104,9 +115,19 @@ func (s snmpScannerImpl) runDeviceScan(
 	deviceID string,
 	callInterval time.Duration,
 	maxCallCount int,
+	useGetBulk bool,
+	bulkMaxRep int,
 ) error {
 	// execute the scan
-	pdus, err := gatherPDUs(ctx, snmpConnection, callInterval, maxCallCount)
+	var (
+		pdus []*gosnmp.SnmpPDU
+		err  error
+	)
+	if useGetBulk {
+		pdus, err = gatherPDUsWithBulk(ctx, snmpConnection, callInterval, maxCallCount, bulkMaxRep)
+	} else {
+		pdus, err = gatherPDUs(ctx, snmpConnection, callInterval, maxCallCount)
+	}
 	if err != nil {
 		return err
 	}
@@ -132,8 +153,13 @@ func (s snmpScannerImpl) runDeviceScan(
 	return nil
 }
 
-// gatherPDUs returns PDUs from the given SNMP device that should cover ever
+// gatherPDUs returns PDUs from the given SNMP device that should cover every
 // scalar value and at least one row of every table.
+//
+// Deprecated: This function uses SkipOIDRowsNaive which fabricates OIDs that may
+// not exist on the device. This can cause infinite loops on devices that respond
+// incorrectly to non-existent OIDs, or crashes on devices that can't handle
+// malformed table indices. Use gatherPDUsWithBulk instead via the UseGetBulk flag.
 func gatherPDUs(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval time.Duration, maxCallCount int) ([]*gosnmp.SnmpPDU, error) {
 	var pdus []*gosnmp.SnmpPDU
 	err := gosnmplib.ConditionalWalk(
@@ -151,4 +177,115 @@ func gatherPDUs(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval time.Dura
 		return nil, err
 	}
 	return pdus, nil
+}
+
+// bulkGetter is the GetBulk surface gatherPDUsWithBulk needs. Wrapping it in an
+// interface lets tests substitute a fake without depending on a live gosnmp.
+type bulkGetter interface {
+	GetBulk(oids []string, nonRepeaters uint8, maxRepetitions uint32) (*gosnmp.SnmpPacket, error)
+}
+
+// gatherPDUsWithBulk returns PDUs from the given SNMP device using GetBulk operations.
+// It walks the entire MIB tree but filters results to keep only one row per column.
+//
+// Key safety properties:
+//   - Never sends fabricated OIDs to the device - only OIDs the device has returned
+//   - Cannot cause infinite loops - tracks visited OIDs
+//   - Cannot crash devices - never sends malformed table indices
+//
+// Adaptive max-repetitions: on GetBulk error the value is halved and the same
+// OID is retried, so a device that times out at a high value can still be
+// walked. On success the value grows back toward bulkMaxRep.
+//
+// Trade-off: May be slower than gatherPDUs for devices with large tables (1000+ rows)
+// because it retrieves all rows before filtering.
+func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, callInterval time.Duration, maxCallCount int, bulkMaxRep int) ([]*gosnmp.SnmpPDU, error) {
+	var result []*gosnmp.SnmpPDU
+	seenColumns := make(map[string]bool)
+	visitedOIDs := make(map[string]bool)
+
+	// Start from the beginning of the MIB tree
+	oid := ".0.0"
+	requests := 0
+	maxRepOpt := batchsize.NewOptimizer(bulkMaxRep)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		default:
+		}
+
+		if callInterval > 0 {
+			time.Sleep(callInterval)
+		}
+
+		requests++
+		if maxCallCount > 0 && requests >= maxCallCount {
+			return result, fmt.Errorf("exceeded maximum request limit (%d)", maxCallCount)
+		}
+
+		// Use GetBulk with REAL OIDs only (never fabricated)
+		maxRep := uint32(maxRepOpt.BatchSize())
+		response, err := snmp.GetBulk([]string{oid}, 0, maxRep)
+		if err != nil {
+			shouldRetry := maxRepOpt.OnFailure()
+			log.Debugf("SNMP scan GetBulk at OID %s with max-rep %d failed, new max-rep is %d",
+				oid, maxRep, maxRepOpt.BatchSize())
+			if shouldRetry {
+				// Retry against the same OID at a smaller max-repetitions.
+				continue
+			}
+			return result, fmt.Errorf("GetBulk error at OID %s (max-rep=%d): %w", oid, maxRep, err)
+		}
+		oldMaxRep := maxRepOpt.BatchSize()
+		maxRepOpt.OnSuccess()
+		if newMaxRep := maxRepOpt.BatchSize(); newMaxRep != oldMaxRep {
+			log.Debugf("SNMP scan GetBulk at OID %s with max-rep %d success, new max-rep is %d",
+				oid, oldMaxRep, newMaxRep)
+		}
+
+		if len(response.Variables) == 0 {
+			// No more data
+			break
+		}
+
+		var lastOID string
+
+		for _, pdu := range response.Variables {
+			// End conditions
+			if pdu.Type == gosnmp.EndOfMibView ||
+				pdu.Type == gosnmp.NoSuchObject ||
+				pdu.Type == gosnmp.NoSuchInstance {
+				return result, nil
+			}
+
+			// Cycle detection - if we've seen this OID before, we're in a loop
+			if visitedOIDs[pdu.Name] {
+				return result, fmt.Errorf("cycle detected: OID %s already visited", pdu.Name)
+			}
+			visitedOIDs[pdu.Name] = true
+
+			lastOID = pdu.Name
+
+			// Column filtering - keep first row of each "column"
+			columnSig := gosnmplib.ExtractColumnSignature(pdu.Name)
+			if !seenColumns[columnSig] {
+				seenColumns[columnSig] = true
+				pduCopy := pdu // Copy to avoid aliasing issues
+				result = append(result, &pduCopy)
+			}
+		}
+
+		// Stuck detection - if we didn't advance, something is wrong
+		if lastOID == "" || lastOID == oid {
+			return result, fmt.Errorf("walk stuck at OID %s", oid)
+		}
+
+		// Use the last OID from the batch as the starting point for the next request.
+		// This OID came directly from the device, so it's always safe to use.
+		oid = lastOID
+	}
+
+	return result, nil
 }

--- a/comp/snmpscan/impl/devicescan_test.go
+++ b/comp/snmpscan/impl/devicescan_test.go
@@ -1,0 +1,276 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test
+
+package snmpscanimpl
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractColumnSignatureIntegration(t *testing.T) {
+	// Test that ExtractColumnSignature works correctly for filtering purposes
+	// This ensures the column.go and devicescan.go integration is correct
+
+	testCases := []struct {
+		name         string
+		oids         []string
+		expectedSigs int // Expected number of unique signatures
+	}{
+		{
+			name: "scalar OIDs each get unique signature",
+			oids: []string{
+				"1.3.6.1.2.1.1.1.0",
+				"1.3.6.1.2.1.1.2.0",
+				"1.3.6.1.2.1.1.3.0",
+			},
+			expectedSigs: 3,
+		},
+		{
+			name: "same column different rows (no 1 in index) get same signature",
+			oids: []string{
+				"1.3.6.1.2.1.2.2.1.2.2",
+				"1.3.6.1.2.1.2.2.1.2.100",
+				"1.3.6.1.2.1.2.2.1.2.200",
+			},
+			expectedSigs: 1,
+		},
+		{
+			name: "different columns get different signatures",
+			oids: []string{
+				"1.3.6.1.2.1.2.2.1.2.2", // ifDescr
+				"1.3.6.1.2.1.2.2.1.3.2", // ifType
+				"1.3.6.1.2.1.2.2.1.4.2", // ifMtu
+				"1.3.6.1.2.1.2.2.1.5.2", // ifSpeed
+			},
+			expectedSigs: 4,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sigs := make(map[string]bool)
+			for _, oid := range tc.oids {
+				sig := gosnmplib.ExtractColumnSignature(oid)
+				sigs[sig] = true
+			}
+			assert.Equal(t, tc.expectedSigs, len(sigs), "Expected %d unique signatures, got %d", tc.expectedSigs, len(sigs))
+		})
+	}
+}
+
+func TestGatherPDUsWithBulk_ContextCancellation(t *testing.T) {
+	// Test that the function respects context cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	snmp := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      161,
+		Community: "public",
+		Version:   gosnmp.Version2c,
+	}
+
+	_, err := gatherPDUsWithBulk(ctx, snmp, 0, 0, defaultBulkMaxRepetitions)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestGatherPDUsWithBulk_MaxCallCount(t *testing.T) {
+	// Test that max call count is enforced
+	// This is a unit test that doesn't require actual SNMP connection
+	// since it will hit the limit before making any real calls
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	snmp := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      161,
+		Community: "public",
+		Version:   gosnmp.Version2c,
+		Timeout:   10 * time.Millisecond,
+	}
+
+	// With maxCallCount=1, it should try one GetBulk, fail to connect,
+	// and return an error (either connection error or max count error)
+	_, err := gatherPDUsWithBulk(ctx, snmp, 0, 1, defaultBulkMaxRepetitions)
+	assert.Error(t, err)
+}
+
+// fakeBulkGetter is a scripted GetBulk for testing adaptive behavior.
+type fakeBulkGetter struct {
+	responses []bulkResponse
+	calls     []bulkCall
+}
+
+type bulkCall struct {
+	oid    string
+	maxRep uint32
+}
+
+type bulkResponse struct {
+	packet *gosnmp.SnmpPacket
+	err    error
+}
+
+func (f *fakeBulkGetter) GetBulk(oids []string, _ uint8, maxRep uint32) (*gosnmp.SnmpPacket, error) {
+	f.calls = append(f.calls, bulkCall{oid: oids[0], maxRep: maxRep})
+	if len(f.calls) > len(f.responses) {
+		return nil, errors.New("fakeBulkGetter: no more canned responses")
+	}
+	resp := f.responses[len(f.calls)-1]
+	return resp.packet, resp.err
+}
+
+// endOfMibPacket returns a packet that immediately ends the walk.
+func endOfMibPacket() *gosnmp.SnmpPacket {
+	return &gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{Name: ".0.0", Type: gosnmp.EndOfMibView},
+		},
+	}
+}
+
+func TestGatherPDUsWithBulk_AdaptsMaxRepOnFailure(t *testing.T) {
+	// First call at max-rep=10 times out; optimizer halves to 5; second call
+	// succeeds. Verify the OID didn't advance and the second call used a
+	// smaller max-rep.
+	fake := &fakeBulkGetter{
+		responses: []bulkResponse{
+			{err: errors.New("request timeout")},
+			{packet: endOfMibPacket()},
+		},
+	}
+
+	_, err := gatherPDUsWithBulk(context.Background(), fake, 0, 0, 10)
+	require.NoError(t, err)
+
+	require.Len(t, fake.calls, 2)
+	assert.Equal(t, ".0.0", fake.calls[0].oid)
+	assert.Equal(t, ".0.0", fake.calls[1].oid, "OID should not advance on retry")
+	assert.Equal(t, uint32(10), fake.calls[0].maxRep)
+	assert.Equal(t, uint32(5), fake.calls[1].maxRep, "max-rep should halve on failure")
+}
+
+func TestGatherPDUsWithBulk_GivesUpWhenMaxRepCannotShrink(t *testing.T) {
+	// Every call fails. The optimizer halves down to 1 and then has nowhere
+	// further to go, so OnFailure returns false and gatherPDUsWithBulk
+	// surfaces the error.
+	timeoutErr := errors.New("request timeout")
+	fake := &fakeBulkGetter{
+		responses: []bulkResponse{
+			{err: timeoutErr},
+			{err: timeoutErr},
+			{err: timeoutErr},
+			{err: timeoutErr},
+			{err: timeoutErr}, // floor at 1
+		},
+	}
+
+	_, err := gatherPDUsWithBulk(context.Background(), fake, 0, 0, 4)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request timeout")
+	// 4 → 2 → 1 → still 1 (OnFailure returns false): 3 calls.
+	assert.GreaterOrEqual(t, len(fake.calls), 2)
+}
+
+func TestColumnFilteringLogic(t *testing.T) {
+	// Test the column filtering logic in isolation
+	// Simulates what gatherPDUsWithBulk does internally
+
+	pdus := []gosnmp.SnmpPDU{
+		// Scalar OIDs
+		{Name: "1.3.6.1.2.1.1.1.0", Type: gosnmp.OctetString, Value: "System Description"},
+		{Name: "1.3.6.1.2.1.1.2.0", Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.9"},
+
+		// ifTable rows - should keep only first row of each column
+		{Name: "1.3.6.1.2.1.2.2.1.2.2", Type: gosnmp.OctetString, Value: "eth0"},
+		{Name: "1.3.6.1.2.1.2.2.1.2.3", Type: gosnmp.OctetString, Value: "eth1"}, // Same column, should filter
+		{Name: "1.3.6.1.2.1.2.2.1.3.2", Type: gosnmp.Integer, Value: 6},
+		{Name: "1.3.6.1.2.1.2.2.1.3.3", Type: gosnmp.Integer, Value: 6}, // Same column, should filter
+	}
+
+	// Simulate the filtering logic from gatherPDUsWithBulk
+	seenColumns := make(map[string]bool)
+	var result []*gosnmp.SnmpPDU
+
+	for _, pdu := range pdus {
+		columnSig := gosnmplib.ExtractColumnSignature(pdu.Name)
+		if !seenColumns[columnSig] {
+			seenColumns[columnSig] = true
+			pduCopy := pdu
+			result = append(result, &pduCopy)
+		}
+	}
+
+	// Should have:
+	// 2 scalar OIDs (each unique)
+	// 1 row from ifDescr column
+	// 1 row from ifType column
+	// Total: 4
+	assert.Equal(t, 4, len(result))
+
+	// Verify the kept PDUs
+	keptOIDs := make(map[string]bool)
+	for _, pdu := range result {
+		keptOIDs[pdu.Name] = true
+	}
+
+	assert.True(t, keptOIDs["1.3.6.1.2.1.1.1.0"], "Scalar OID should be kept")
+	assert.True(t, keptOIDs["1.3.6.1.2.1.1.2.0"], "Scalar OID should be kept")
+	assert.True(t, keptOIDs["1.3.6.1.2.1.2.2.1.2.2"], "First ifDescr row should be kept")
+	assert.True(t, keptOIDs["1.3.6.1.2.1.2.2.1.3.2"], "First ifType row should be kept")
+	assert.False(t, keptOIDs["1.3.6.1.2.1.2.2.1.2.3"], "Second ifDescr row should be filtered")
+	assert.False(t, keptOIDs["1.3.6.1.2.1.2.2.1.3.3"], "Second ifType row should be filtered")
+}
+
+func TestCycleDetectionLogic(t *testing.T) {
+	// Test that cycle detection works correctly
+	visitedOIDs := make(map[string]bool)
+
+	oids := []string{
+		"1.3.6.1.2.1.1.1.0",
+		"1.3.6.1.2.1.1.2.0",
+		"1.3.6.1.2.1.1.1.0", // Repeat - cycle!
+	}
+
+	var cycleDetected bool
+	for _, oid := range oids {
+		if visitedOIDs[oid] {
+			cycleDetected = true
+			break
+		}
+		visitedOIDs[oid] = true
+	}
+
+	assert.True(t, cycleDetected, "Should detect cycle when OID is repeated")
+}
+
+func TestEndOfMibDetection(t *testing.T) {
+	// Test that end-of-MIB conditions are handled correctly
+	endConditions := []gosnmp.Asn1BER{
+		gosnmp.EndOfMibView,
+		gosnmp.NoSuchObject,
+		gosnmp.NoSuchInstance,
+	}
+
+	for _, condition := range endConditions {
+		t.Run(condition.String(), func(t *testing.T) {
+			isEnd := condition == gosnmp.EndOfMibView ||
+				condition == gosnmp.NoSuchObject ||
+				condition == gosnmp.NoSuchInstance
+			assert.True(t, isEnd, "Should recognize %s as end condition", condition)
+		})
+	}
+}

--- a/pkg/snmp/batchsize/BUILD.bazel
+++ b/pkg/snmp/batchsize/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "batchsize",
+    srcs = [
+        "optimizer.go",
+        "testhelpers.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/snmp/batchsize",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "batchsize_test",
+    srcs = ["optimizer_test.go"],
+    embed = [":batchsize"],
+    gotags = ["test"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/pkg/snmp/batchsize/optimizer.go
+++ b/pkg/snmp/batchsize/optimizer.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package batchsize provides an adaptive feedback controller for an integer
+// "batch size" parameter. Callers report success or failure of each operation
+// and the controller halves on failure (with a floor at the last successful
+// value) and increments back toward the configured ceiling on success.
+//
+// The primitive is generic: callers decide what the integer represents
+// (number of OIDs per request, max-repetitions, etc.) and what counts as a
+// success or failure.
+package batchsize
+
+const (
+	onSuccessIncreaseValue  = 1
+	onFailureDecreaseFactor = 2
+
+	maxFailuresPerWindow = 2
+)
+
+// Optimizer is a feedback controller on a positive integer batch size.
+type Optimizer struct {
+	configBatchSize         int
+	batchSize               int
+	failuresByBatchSize     map[int]int
+	lastSuccessfulBatchSize int
+}
+
+// NewOptimizer returns an Optimizer starting at configBatchSize.
+func NewOptimizer(configBatchSize int) *Optimizer {
+	return &Optimizer{
+		configBatchSize:     configBatchSize,
+		batchSize:           configBatchSize,
+		failuresByBatchSize: make(map[int]int),
+	}
+}
+
+// BatchSize returns the current batch size.
+func (o *Optimizer) BatchSize() int {
+	return o.batchSize
+}
+
+// OnFailure halves the batch size (with a floor at 1, never crossing below
+// the last successful value) and returns whether the batch size changed.
+// A true return means a retry at the new size is worth attempting.
+func (o *Optimizer) OnFailure() bool {
+	o.failuresByBatchSize[o.batchSize]++
+
+	oldBatchSize := o.batchSize
+
+	newBatchSize := max(o.batchSize/onFailureDecreaseFactor, 1)
+	if oldBatchSize > o.lastSuccessfulBatchSize && newBatchSize < o.lastSuccessfulBatchSize {
+		newBatchSize = o.lastSuccessfulBatchSize
+	}
+
+	o.batchSize = newBatchSize
+
+	return oldBatchSize != newBatchSize
+}
+
+// OnSuccess increments the batch size toward the configured ceiling, skipping
+// sizes that have already failed too many times in the current failure window.
+func (o *Optimizer) OnSuccess() {
+	o.lastSuccessfulBatchSize = o.batchSize
+
+	if o.batchSize >= o.configBatchSize {
+		return
+	}
+
+	newBatchSize := min(o.batchSize+onSuccessIncreaseValue, o.configBatchSize)
+	if o.failuresByBatchSize[newBatchSize] >= maxFailuresPerWindow {
+		return
+	}
+
+	o.batchSize = newBatchSize
+}
+
+// RefreshFailures clears the failure-count map. Callers managing a failure
+// window should call this when the window expires.
+func (o *Optimizer) RefreshFailures() {
+	o.failuresByBatchSize = make(map[int]int)
+}

--- a/pkg/snmp/batchsize/optimizer_test.go
+++ b/pkg/snmp/batchsize/optimizer_test.go
@@ -1,0 +1,235 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package batchsize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Optimizer_OnFailure(t *testing.T) {
+	tests := []struct {
+		name              string
+		optimizer         *Optimizer
+		expectedOptimizer *Optimizer
+		expectedChanged   bool
+	}{
+		{
+			name: "batch size is 1",
+			optimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       1,
+				failuresByBatchSize: map[int]int{
+					4: 1,
+					2: 1,
+				},
+				lastSuccessfulBatchSize: 1,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       1,
+				failuresByBatchSize: map[int]int{
+					4: 1,
+					2: 1,
+					1: 1,
+				},
+				lastSuccessfulBatchSize: 1,
+			},
+			expectedChanged: false,
+		},
+		{
+			name: "new batch size is lesser than the last successful batch size",
+			optimizer: &Optimizer{
+				configBatchSize:         4,
+				batchSize:               4,
+				failuresByBatchSize:     map[int]int{},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       3,
+				failuresByBatchSize: map[int]int{
+					4: 1,
+				},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "batch size is equal to the last successful batch size",
+			optimizer: &Optimizer{
+				configBatchSize:         4,
+				batchSize:               3,
+				failuresByBatchSize:     map[int]int{},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       3 / onFailureDecreaseFactor,
+				failuresByBatchSize: map[int]int{
+					3: 1,
+				},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "batch size is lesser to the last successful batch size",
+			optimizer: &Optimizer{
+				configBatchSize:         4,
+				batchSize:               2,
+				failuresByBatchSize:     map[int]int{},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       2 / onFailureDecreaseFactor,
+				failuresByBatchSize: map[int]int{
+					2: 1,
+				},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "batch size is greater than the last successful batch size",
+			optimizer: &Optimizer{
+				configBatchSize:         10,
+				batchSize:               10,
+				failuresByBatchSize:     map[int]int{},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       10 / onFailureDecreaseFactor,
+				failuresByBatchSize: map[int]int{
+					10: 1,
+				},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "batch size should be decreased",
+			optimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       4,
+				failuresByBatchSize: map[int]int{
+					4: 1,
+				},
+				lastSuccessfulBatchSize: 0,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       4 / onFailureDecreaseFactor,
+				failuresByBatchSize: map[int]int{
+					4: 2,
+				},
+				lastSuccessfulBatchSize: 0,
+			},
+			expectedChanged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := tt.optimizer.OnFailure()
+			assert.Equal(t, tt.expectedOptimizer, tt.optimizer)
+			assert.Equal(t, tt.expectedChanged, changed)
+		})
+	}
+}
+
+func Test_Optimizer_OnSuccess(t *testing.T) {
+	tests := []struct {
+		name              string
+		optimizer         *Optimizer
+		expectedOptimizer *Optimizer
+	}{
+		{
+			name: "new batch size has too much failures",
+			optimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       6,
+				failuresByBatchSize: map[int]int{
+					7: maxFailuresPerWindow + 1,
+				},
+				lastSuccessfulBatchSize: 5,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       6,
+				failuresByBatchSize: map[int]int{
+					7: maxFailuresPerWindow + 1,
+				},
+				lastSuccessfulBatchSize: 6,
+			},
+		},
+		{
+			name: "batch size is config batch size",
+			optimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       10,
+				failuresByBatchSize: map[int]int{
+					6: 1,
+				},
+				lastSuccessfulBatchSize: 9,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       10,
+				failuresByBatchSize: map[int]int{
+					6: 1,
+				},
+				lastSuccessfulBatchSize: 10,
+			},
+		},
+		{
+			name: "batch size should be increased",
+			optimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       6,
+				failuresByBatchSize: map[int]int{
+					6: 1,
+				},
+				lastSuccessfulBatchSize: 9,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       6 + onSuccessIncreaseValue,
+				failuresByBatchSize: map[int]int{
+					6: 1,
+				},
+				lastSuccessfulBatchSize: 6,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.optimizer.OnSuccess()
+			assert.Equal(t, tt.expectedOptimizer, tt.optimizer)
+		})
+	}
+}
+
+func Test_Optimizer_BatchSize(t *testing.T) {
+	o := NewOptimizer(5)
+	assert.Equal(t, 5, o.BatchSize())
+	o.OnFailure()
+	assert.Equal(t, 2, o.BatchSize())
+}
+
+func Test_Optimizer_RefreshFailures(t *testing.T) {
+	o := &Optimizer{
+		configBatchSize:     4,
+		batchSize:           2,
+		failuresByBatchSize: map[int]int{4: 3, 2: 1},
+	}
+	o.RefreshFailures()
+	assert.Equal(t, map[int]int{}, o.failuresByBatchSize)
+}

--- a/pkg/snmp/batchsize/testhelpers.go
+++ b/pkg/snmp/batchsize/testhelpers.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package batchsize
+
+// NewOptimizerForTest constructs an Optimizer with explicit internal state for
+// use in tests in other packages. Not for production use.
+func NewOptimizerForTest(configBatchSize, batchSize int, failures map[int]int, lastSuccessfulBatchSize int) *Optimizer {
+	if failures == nil {
+		failures = make(map[int]int)
+	}
+	return &Optimizer{
+		configBatchSize:         configBatchSize,
+		batchSize:               batchSize,
+		failuresByBatchSize:     failures,
+		lastSuccessfulBatchSize: lastSuccessfulBatchSize,
+	}
+}
+
+// FailuresByBatchSize exposes the internal failure map for assertions in tests.
+func (o *Optimizer) FailuresByBatchSize() map[int]int {
+	return o.failuresByBatchSize
+}
+
+// LastSuccessfulBatchSize exposes the internal last-successful tracker for assertions in tests.
+func (o *Optimizer) LastSuccessfulBatchSize() int {
+	return o.lastSuccessfulBatchSize
+}
+
+// SetFailuresByBatchSize replaces the internal failure map. For tests only.
+func (o *Optimizer) SetFailuresByBatchSize(failures map[int]int) {
+	o.failuresByBatchSize = failures
+}

--- a/pkg/snmp/gosnmplib/BUILD.bazel
+++ b/pkg/snmp/gosnmplib/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "gosnmplib",
     srcs = [
         "cmp.go",
+        "column.go",
         "errors.go",
         "gosnmp_auth.go",
         "gosnmp_log.go",
@@ -24,6 +25,7 @@ go_test(
     name = "gosnmplib_test",
     srcs = [
         "cmp_test.go",
+        "column_test.go",
         "gosnmp_auth_test.go",
         "gosnmp_log_test.go",
         "gosnmp_utils_test.go",

--- a/pkg/snmp/gosnmplib/column.go
+++ b/pkg/snmp/gosnmplib/column.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package gosnmplib
+
+import (
+	"strings"
+)
+
+// ExtractColumnSignature returns a string identifying the "column" of a table OID.
+// This is used for filtering duplicate rows when walking SNMP tables, NOT for
+// constructing new OIDs to send to devices.
+//
+// The algorithm uses the same heuristic as SkipOIDRowsNaive (finding the last ".1."
+// which typically marks the table entry), but the result is only used as a local
+// grouping key. Even if the heuristic misidentifies the column boundary, the worst
+// case is that we keep extra rows - we never send fabricated OIDs to devices.
+//
+// For scalar OIDs (ending in .0), the entire OID is returned as its own "column".
+func ExtractColumnSignature(oid string) string {
+	oid = strings.TrimLeft(oid, ".")
+
+	// Scalar OIDs (ending in .0) are their own column
+	if strings.HasSuffix(oid, ".0") {
+		return oid
+	}
+
+	// Find the last ".1." which typically marks the table entry
+	// This is the same heuristic as SkipOIDRowsNaive
+	idx := strings.LastIndex(oid, ".1.")
+	if idx == -1 {
+		// Not a table OID (no .1. found), treat entire OID as column
+		return oid
+	}
+
+	// Extract table OID (everything before .1.)
+	tableOID := oid[:idx]
+
+	// Extract the part after .1. (column number + row index)
+	rest := oid[idx+3:] // +3 to skip ".1."
+
+	// Get just the column number (first segment after .1.)
+	parts := strings.SplitN(rest, ".", 2)
+	if len(parts) == 0 {
+		return oid
+	}
+
+	// Column signature = tableOID.1.columnNumber
+	return tableOID + ".1." + parts[0]
+}

--- a/pkg/snmp/gosnmplib/column_test.go
+++ b/pkg/snmp/gosnmplib/column_test.go
@@ -1,0 +1,160 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package gosnmplib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractColumnSignature(t *testing.T) {
+	// The key property we need is CONSISTENCY: all rows from the same column
+	// should get the same signature. The exact signature value doesn't matter
+	// for filtering purposes - what matters is that grouping works correctly.
+
+	tests := []struct {
+		name     string
+		oid      string
+		expected string
+	}{
+		// Scalar OIDs (ending in .0) should return the full OID
+		{
+			name:     "scalar sysDescr",
+			oid:      "1.3.6.1.2.1.1.1.0",
+			expected: "1.3.6.1.2.1.1.1.0",
+		},
+		{
+			name:     "scalar with leading dot",
+			oid:      ".1.3.6.1.2.1.1.1.0",
+			expected: "1.3.6.1.2.1.1.1.0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ExtractColumnSignature(tc.oid)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestExtractColumnSignature_SameColumnGrouping(t *testing.T) {
+	// Test that rows from the same column get grouped together when possible.
+	// Note: The LastIndex(".1.") heuristic has limitations for simple tables where
+	// row indices contain "1" as a component. This is acceptable because:
+	// 1. We never send fabricated OIDs to devices (safety maintained)
+	// 2. Worst case is we keep extra rows (safe, just less efficient)
+
+	testCases := []struct {
+		name string
+		oids []string // All OIDs in this list should produce the same signature
+	}{
+		{
+			// For simple tables, rows that don't have "1" in the index will group correctly
+			name: "ifTable column 2 - rows without 1 in index",
+			oids: []string{
+				"1.3.6.1.2.1.2.2.1.2.2",
+				"1.3.6.1.2.1.2.2.1.2.100",
+				"1.3.6.1.2.1.2.2.1.2.200",
+			},
+		},
+		{
+			name: "ifTable column 3 - rows without 1 in index",
+			oids: []string{
+				"1.3.6.1.2.1.2.2.1.3.2",
+				"1.3.6.1.2.1.2.2.1.3.100",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.oids) < 2 {
+				t.Skip("Need at least 2 OIDs to test grouping")
+			}
+
+			firstSig := ExtractColumnSignature(tc.oids[0])
+			for _, oid := range tc.oids[1:] {
+				sig := ExtractColumnSignature(oid)
+				assert.Equal(t, firstSig, sig, "All rows from same column should have same signature. OID: %s", oid)
+			}
+		})
+	}
+}
+
+func TestExtractColumnSignature_DifferentColumnsAreDifferent(t *testing.T) {
+	// Different columns should produce different signatures
+
+	testCases := []struct {
+		name string
+		oid1 string
+		oid2 string
+	}{
+		{
+			name: "ifIndex vs ifDescr",
+			oid1: "1.3.6.1.2.1.2.2.1.1.1",
+			oid2: "1.3.6.1.2.1.2.2.1.2.1",
+		},
+		{
+			name: "ifDescr vs ifType",
+			oid1: "1.3.6.1.2.1.2.2.1.2.1",
+			oid2: "1.3.6.1.2.1.2.2.1.3.1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sig1 := ExtractColumnSignature(tc.oid1)
+			sig2 := ExtractColumnSignature(tc.oid2)
+			assert.NotEqual(t, sig1, sig2, "Different columns should have different signatures")
+		})
+	}
+}
+
+func TestExtractColumnSignature_ComplexIndexTables(t *testing.T) {
+	// For complex index tables, the heuristic groups based on the last ".1." pattern.
+	// This provides reasonable grouping for many complex tables, though not perfect.
+	// The key property is CONSISTENCY within the same grouping pattern.
+
+	t.Run("inetCidrRouteTable rows with same prefix pattern", func(t *testing.T) {
+		// These two OIDs have the same structure up to and after the last ".1."
+		// They differ only after the last ".1.X" pattern (in the 172.21.X.X part)
+		oid1 := "1.3.6.1.2.1.4.24.7.1.1.1.4.0.0.0.0.0.2.0.0.1.4.172.21.200.192"
+		oid2 := "1.3.6.1.2.1.4.24.7.1.1.1.4.0.0.0.0.0.2.0.0.1.4.172.21.211.204"
+
+		sig1 := ExtractColumnSignature(oid1)
+		sig2 := ExtractColumnSignature(oid2)
+		// Both should find last ".1." at "...0.0.1.4..." and produce same signature
+		assert.Equal(t, sig1, sig2, "Rows with same prefix pattern should have same signature")
+	})
+
+	t.Run("ipNetToPhysicalTable consistency check", func(t *testing.T) {
+		// For ipNetToPhysicalTable, the last ".1." may be in the IP portion
+		// which can cause different grouping. We verify consistency within
+		// rows that have the same ".1." position.
+		oid1 := "1.3.6.1.2.1.4.35.1.4.1000007.1.4.192.168.2.50"
+		oid2 := "1.3.6.1.2.1.4.35.1.4.1000007.1.4.192.168.2.60"
+
+		sig1 := ExtractColumnSignature(oid1)
+		sig2 := ExtractColumnSignature(oid2)
+		// Both have last ".1." at "1000007.1.4" so should match
+		assert.Equal(t, sig1, sig2, "Rows with same last .1. position should have same signature")
+	})
+}
+
+func TestExtractColumnSignature_NoTableMarker(t *testing.T) {
+	// OIDs without .1. pattern should return the full OID
+	// (treated as their own unique "column")
+
+	oid := "1.3.6.4.2.9.9.42.2.2.3.4" // No .1. pattern
+	result := ExtractColumnSignature(oid)
+	// The function finds the last .1. if any, otherwise returns the OID
+	// In this case there IS a .1. at "42.2.2" - wait no, there's no .1. here
+	// Let me check: 1.3.6.4.2.9.9.42.2.2.3.4
+	// There's no ".1." substring in this OID
+	assert.Equal(t, oid, result)
+}


### PR DESCRIPTION
## Summary

Adds `--use-getbulk` to `agent snmp scan` so the GetBulk-based walk from #49734 (Nouha) and #51023 (Florian) can be used today, with results sent through the existing `BatchDeviceScan` -> `sendPayload` pipeline so the NDM Profile Manager All Metrics table is populated.

Default behavior is unchanged: scans still use the existing `SkipOIDRowsNaive`-based walk and still report to the backend. Customers / operators opt into GetBulk per-invocation:

```bash
agent snmp scan <IP> --use-getbulk
agent snmp scan <IP> --use-getbulk --bulk-max-rep 5
```

This PR is the customer-facing intermediate step for [AGENT-16184](https://datadoghq.atlassian.net/browse/AGENT-16184). #49734 and #51023 remain the canonical path for making GetBulk the default once they merge.

## What's cherry-picked vs. new

Cherry-picked from #49734:
- `pkg/snmp/gosnmplib/column.go` (+ test) — `ExtractColumnSignature`.

Cherry-picked from #51023:
- `pkg/snmp/batchsize/` — adaptive halve-on-fail / +1-on-success controller.

New in this PR:
- `UseGetBulk` + `BulkMaxRepetitions` on `comp/snmpscan/def.ScanParams`.
- `--use-getbulk` and `--bulk-max-rep` flags on the CLI subcommand.
- `gatherPDUsWithBulk` (+ `bulkGetter` interface) and flag-based dispatch inside `runDeviceScan`. Both paths feed the existing batch/send loop.

Deliberately **not** brought over: the `comparisonModeEnabled` const and the `runDeviceScanComparison` harness. Comparison runs were useful upstream but they suppress backend reporting, which is the whole point of this change.

## Backward compatibility

- `ScanParams{}` zero values keep the existing path. The two non-CLI call sites (`comp/snmpscan/impl/snmpscan.go`, `comp/snmpscanmanager/impl/snmpscanmanager.go`) are unchanged and stay on the legacy walk.
- The `scan` subcommand stays `Hidden: true`.

## Test plan

- [x] `dda inv test --targets=./pkg/snmp/batchsize` — 11 pass
- [x] `dda inv test --targets=./pkg/snmp/gosnmplib` — 64 pass
- [x] `dda inv test --targets=./comp/snmpscan/...` — 13 pass
- [x] `dda inv test --targets=./cmd/agent/subcommands/snmp` — 4 pass
- [ ] Manual: `agent snmp scan <IP>` (default) — confirm legacy path still populates Profile Manager
- [ ] Manual: `agent snmp scan <IP> --use-getbulk` — confirm Profile Manager All Metrics table is populated, scan completes on banco BV's previously-failing devices (10.36.129.106, 10.38.33.33)
- [ ] Manual: `agent snmp scan <IP> --use-getbulk --bulk-max-rep 5` — adaptive batch size on 10.38.33.33

## Related

- AGENT-16184 (banco BV escalation)
- #49734 (Nouha — GetBulk-based walk)
- #51023 (Florian — configurable + adaptive `--bulk-max-rep`)

[AGENT-16184]: https://datadoghq.atlassian.net/browse/AGENT-16184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ