### PR TITLE
fix(containerimage): parse repoTag tag on last colon to support registry ports

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -22,6 +22,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	tracermetadata "github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata/model"
+	pkgimage "github.com/DataDog/datadog-agent/pkg/util/containers/image"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	gpuutil "github.com/DataDog/datadog-agent/pkg/util/gpu"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
@@ -364,7 +365,10 @@ func (c *WorkloadMetaCollector) handleContainerImage(ev workloadmeta.Event) []*t
 		repos[strings.SplitN(repoDigest, "@sha256:", 2)[0]] = struct{}{}
 	}
 	for _, repoTag := range image.RepoTags {
-		repos[strings.SplitN(repoTag, ":", 2)[0]] = struct{}{}
+		// Split on the last colon (after the last slash) so registries that
+		// include a port are parsed correctly.
+		repoName, _ := pkgimage.SplitRepoTag(repoTag)
+		repos[repoName] = struct{}{}
 	}
 	for repo := range repos {
 		repoSplitted := strings.Split(repo, "/")
@@ -373,9 +377,8 @@ func (c *WorkloadMetaCollector) handleContainerImage(ev workloadmeta.Event) []*t
 	}
 
 	for _, repoTag := range image.RepoTags {
-		repoTagSplitted := strings.SplitN(repoTag, ":", 2)
-		if len(repoTagSplitted) == 2 {
-			tagList.AddLow(tags.ImageTag, repoTagSplitted[1])
+		if _, tag := pkgimage.SplitRepoTag(repoTag); tag != "" {
+			tagList.AddLow(tags.ImageTag, tag)
 		}
 	}
 

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -3806,6 +3806,44 @@ func TestHandleContainerImage(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Registry hosts that include a port (e.g. `artifactory.local:443/...`)
+			// must not be split on the first colon, otherwise the image_tag value
+			// would incorrectly contain the port followed by the image path.
+			name: "registry with port",
+			image: workloadmeta.ContainerImageMetadata{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: entityID.ID,
+				},
+				RepoTags: []string{
+					"artifactory.local:443/team/service:2.54.3",
+				},
+				RepoDigests: []string{
+					"artifactory.local:443/team/service@sha256:ff5c1c9a1d939df9ef782c329eb88db50f3c5a80e7c9f90a30e549da6000adb6",
+				},
+				OS:           "linux",
+				OSVersion:    "1",
+				Architecture: "amd64",
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:               containerImageSource,
+					EntityID:             taggerEntityID,
+					HighCardTags:         []string{},
+					OrchestratorCardTags: []string{},
+					LowCardTags: []string{
+						"architecture:amd64",
+						"image_name:sha256:651c55002cd5deb06bde7258f6ec6e0ff7f4f17a648ce6e2ec01917da9ae5104",
+						"image_tag:2.54.3",
+						"os_name:linux",
+						"os_version:1",
+						"short_image:service",
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/collector/corechecks/containerimage/processor.go
+++ b/pkg/collector/corechecks/containerimage/processor.go
@@ -16,6 +16,7 @@ import (
 	eventplatform "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	queue "github.com/DataDog/datadog-agent/pkg/util/aggregatingqueue"
+	pkgimage "github.com/DataDog/datadog-agent/pkg/util/containers/image"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -123,7 +124,11 @@ func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
 		repos[strings.SplitN(repoDigest, "@sha256:", 2)[0]] = struct{}{}
 	}
 	for _, repoTag := range img.RepoTags {
-		repos[strings.SplitN(repoTag, ":", 2)[0]] = struct{}{}
+		// Split on the last colon (after the last slash) so registries that
+		// include a port (e.g. `myregistry.local:5000/foo/bar:1.2.3`) are
+		// parsed correctly.
+		repoName, _ := pkgimage.SplitRepoTag(repoTag)
+		repos[repoName] = struct{}{}
 	}
 
 	for repo := range repos {
@@ -138,8 +143,9 @@ func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
 
 		repoTags := make([]string, 0, len(img.RepoTags))
 		for _, repoTag := range img.RepoTags {
-			if strings.HasPrefix(repoTag, repo+":") {
-				repoTags = append(repoTags, strings.SplitN(repoTag, ":", 2)[1])
+			repoName, tag := pkgimage.SplitRepoTag(repoTag)
+			if repoName == repo && tag != "" {
+				repoTags = append(repoTags, tag)
 			}
 		}
 

--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -253,6 +253,58 @@ func TestProcessEvents(t *testing.T) {
 			},
 		},
 		{
+			// Registry hosts that include a port (e.g. `artifactory.local:443/...`)
+			// must not be split on the first colon, otherwise the registry host
+			// becomes the image name and the port becomes part of the tag.
+			name: "registry with port in repo tag",
+			inputEvents: []workloadmeta.Event{
+				{
+					Type: workloadmeta.EventTypeSet,
+					Entity: &workloadmeta.ContainerImageMetadata{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindContainerImageMetadata,
+							ID:   "sha256:ff5c1c9a1d939df9ef782c329eb88db50f3c5a80e7c9f90a30e549da6000adb6",
+						},
+						RepoTags: []string{
+							"artifactory.local:443/team/service:2.54.3",
+						},
+						RepoDigests: []string{
+							"artifactory.local:443/team/service@sha256:ff5c1c9a1d939df9ef782c329eb88db50f3c5a80e7c9f90a30e549da6000adb6",
+						},
+						SizeBytes:    42,
+						OS:           "linux",
+						OSVersion:    "1",
+						Architecture: "amd64",
+					},
+				},
+			},
+			expectedImages: []*model.ContainerImage{
+				{
+					Id: "artifactory.local:443/team/service@sha256:ff5c1c9a1d939df9ef782c329eb88db50f3c5a80e7c9f90a30e549da6000adb6",
+					DdTags: []string{
+						"image_id:artifactory.local:443/team/service@sha256:ff5c1c9a1d939df9ef782c329eb88db50f3c5a80e7c9f90a30e549da6000adb6",
+						"image_name:artifactory.local:443/team/service",
+						"short_image:service",
+						"image_tag:2.54.3",
+					},
+					Name:      "artifactory.local:443/team/service",
+					Registry:  "artifactory.local:443",
+					ShortName: "service",
+					RepoTags: []string{
+						"2.54.3",
+					},
+					Digest:      "sha256:ff5c1c9a1d939df9ef782c329eb88db50f3c5a80e7c9f90a30e549da6000adb6",
+					Size:        42,
+					RepoDigests: []string{"artifactory.local:443/team/service@sha256:ff5c1c9a1d939df9ef782c329eb88db50f3c5a80e7c9f90a30e549da6000adb6"},
+					Os: &model.ContainerImage_OperatingSystem{
+						Name:         "linux",
+						Version:      "1",
+						Architecture: "amd64",
+					},
+				},
+			},
+		},
+		{
 			// In containerd some images are created without a repo digest, and it's
 			// also possible to remove repo digests manually. To test that scenario, in
 			// this test, we define an image with 2 repo tags: one for the gcr.io

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/procfs"
 	sbomscanner "github.com/DataDog/datadog-agent/pkg/sbom/scanner"
 	queue "github.com/DataDog/datadog-agent/pkg/util/aggregatingqueue"
+	pkgimage "github.com/DataDog/datadog-agent/pkg/util/containers/image"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -391,7 +392,10 @@ func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata) {
 		repos[strings.SplitN(repoDigest, "@sha256:", 2)[0]] = struct{}{}
 	}
 	for _, repoTag := range img.RepoTags {
-		repos[strings.SplitN(repoTag, ":", 2)[0]] = struct{}{}
+		// Split on the last colon (after the last slash) so registries that
+		// include a port are parsed correctly.
+		repoName, _ := pkgimage.SplitRepoTag(repoTag)
+		repos[repoName] = struct{}{}
 	}
 
 	inUse := false
@@ -420,8 +424,9 @@ func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata) {
 
 		repoTags := make([]string, 0, len(img.RepoTags))
 		for _, repoTag := range img.RepoTags {
-			if strings.HasPrefix(repoTag, repo+":") {
-				repoTags = append(repoTags, strings.SplitN(repoTag, ":", 2)[1])
+			repoName, tag := pkgimage.SplitRepoTag(repoTag)
+			if repoName == repo && tag != "" {
+				repoTags = append(repoTags, tag)
 			}
 		}
 

--- a/pkg/util/containers/image/image.go
+++ b/pkg/util/containers/image/image.go
@@ -19,6 +19,24 @@ var (
 	ErrImageIsSha256 = errors.New("invalid image name (is a sha256)")
 )
 
+// SplitRepoTag splits a Docker-style "repoTag" string into the repository name
+// and the image tag. It correctly handles registries that include a port (for
+// example `myregistry.local:5000/foo/bar:1.2.3`), unlike a naive split on the
+// first colon.
+//
+// A colon is only considered a tag separator when it appears after the last
+// slash in the input — otherwise it is part of a registry `host:port`.
+// If no tag separator is found, the whole string is returned as the repo name
+// and the tag is empty.
+func SplitRepoTag(repoTag string) (string, string) {
+	lastColon := strings.LastIndex(repoTag, ":")
+	lastSlash := strings.LastIndex(repoTag, "/")
+	if lastSlash < lastColon {
+		return repoTag[:lastColon], repoTag[lastColon+1:]
+	}
+	return repoTag, ""
+}
+
 // SplitImageName splits a valid image name (from ResolveImageName) and returns:
 //   - the "long image name" with registry and prefix, without tag
 //   - the registry

--- a/pkg/util/containers/image/image_test.go
+++ b/pkg/util/containers/image/image_test.go
@@ -13,6 +13,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSplitRepoTag(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		source   string
+		repo     string
+		tag      string
+	}{
+		{"empty", "", "", ""},
+		{"no tag", "alpine", "alpine", ""},
+		{"simple", "nginx:latest", "nginx", "latest"},
+		{"with org", "datadog/agent:7.41.1-rc.1", "datadog/agent", "7.41.1-rc.1"},
+		{"public registry no port", "gcr.io/datadoghq/agent:7-rc", "gcr.io/datadoghq/agent", "7-rc"},
+		{"public registry no port no tag", "gcr.io/datadoghq/agent", "gcr.io/datadoghq/agent", ""},
+		{
+			"registry with port",
+			"myregistry.local:5000/foo/bar:1.2.3",
+			"myregistry.local:5000/foo/bar",
+			"1.2.3",
+		},
+		{
+			"registry with port no tag",
+			"myregistry.local:5000/foo/bar",
+			"myregistry.local:5000/foo/bar",
+			"",
+		},
+		{
+			"deeply nested registry with port",
+			"artifactory.local:443/team/sub-team/project/service:2.54.3",
+			"artifactory.local:443/team/sub-team/project/service",
+			"2.54.3",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, tag := SplitRepoTag(tc.source)
+			assert.Equal(t, tc.repo, repo)
+			assert.Equal(t, tc.tag, tag)
+		})
+	}
+}
+
 func TestSplitImageName(t *testing.T) {
 	for nb, tc := range []struct {
 		source    string

--- a/releasenotes/notes/fix-image-tag-registry-port-5cfc5f79962021ce.yaml
+++ b/releasenotes/notes/fix-image-tag-registry-port-5cfc5f79962021ce.yaml
@@ -1,0 +1,18 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a bug in container image reporting where image references whose
+    registry host included a port (for example
+    ``myregistry.local:5000/foo/bar:1.2.3``) were split on the first colon
+    instead of the tag separator. This caused the ``image_name`` and
+    ``image_tag`` tags, as well as the values shown in the Container Images
+    view, to be incorrect for such images. The repo and tag are now parsed
+    using the last colon following the last slash, matching standard image
+    reference rules.


### PR DESCRIPTION
## Summary

- Container image references whose registry host included a port (for example `myregistry.local:443/team/service:2.54.3`) were being split on the **first** colon when deriving `image_name`, `image_tag`, `short_image` and `registry`. The registry host became the image name and `port/.../repo:tag` became the tag, producing wrong tags and a wrong row in the Container Images view.
- Added a focused `SplitRepoTag` helper in `pkg/util/containers/image` that mirrors the existing `SplitImageName` logic: a colon is only treated as a tag separator when it appears after the last `/`. Used the helper in the three call sites that previously did `strings.SplitN(repoTag, ":", 2)`:
  - `comp/core/tagger/collectors/workloadmeta_extract.go` (`handleContainerImage`)
  - `pkg/collector/corechecks/containerimage/processor.go`
  - `pkg/collector/corechecks/sbom/processor.go`
- The `strings.HasPrefix(repoTag, repo+":")` filter in the containerimage and SBOM processors was also replaced by an exact-name comparison on the parsed repo, to avoid a similar prefix-match pitfall (e.g. `repo` = `foo` matching `repoTag` = `foo:bar/baz:1.2.3`).

## Reported by

Reported via Support: container image references that include a registry port (e.g. `:443` or `:5000`) were being parsed incorrectly, breaking the Container Images view and `image_name` / `image_tag` tags for those images.

## Test plan

- [x] New unit tests for `SplitRepoTag` covering simple, with-org, with-registry, registry-with-port, registry-with-port-no-tag, and a deeply-nested registry-with-port example.
- [x] New `registry with port in repo tag` case in `TestProcessEvents` (containerimage check) asserting:
  - `image_name:artifactory.local:443/team/service`
  - `image_tag:2.54.3`
  - `short_image:service`
  - `Registry: \"artifactory.local:443\"`
- [x] New `registry with port` case in `TestHandleContainerImage` (tagger) asserting `image_tag:2.54.3` and `short_image:service`.
- [x] `go vet -tags test` clean on all changed packages (incl. `trivy test` for the SBOM check).
- [x] Full test suites pass locally:
  - `go test -tags test ./pkg/util/containers/image/...`
  - `go test -tags test ./pkg/collector/corechecks/containerimage/...`
  - `go test -tags test ./comp/core/tagger/collectors/...`
  - `go test -tags \"trivy test\" ./pkg/collector/corechecks/sbom/...`

## Behaviour change / customer impact

For images whose registry contains a port, customers will now see correct `image_name`, `image_tag`, `short_image`, `registry` tags and Container Images entries. Dashboards / monitors that were unknowingly relying on the broken behaviour (e.g. `image_name:` truncated to just the registry host, or `image_tag:` containing the port + path) will need updating. Documented in the release note.