### PR TITLE
[CWS] add image-based container exclusion to security profile v2

### DIFF
--- a/pkg/config/schema/system-probe_schema.yaml
+++ b/pkg/config/schema/system-probe_schema.yaml
@@ -1852,8 +1852,7 @@ properties:
               excluded_images:
                 node_type: setting
                 type: array
-                default:
-                - datadog-agent:*
+                default: []
                 items:
                   type: string
           watch_dir:

--- a/pkg/config/schema/system-probe_schema.yaml
+++ b/pkg/config/schema/system-probe_schema.yaml
@@ -1849,6 +1849,13 @@ properties:
                 - connect
                 items:
                   type: string
+              excluded_images:
+                node_type: setting
+                type: array
+                default:
+                - datadog-agent:*
+                items:
+                  type: string
           watch_dir:
             node_type: setting
             type: boolean

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -125,6 +125,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 
 	// CWS - Security Profile V2
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.event_types", []string{"exec", "dns", "bind", "connect"})
+	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.excluded_images", []string{"datadog-agent:*"})
 
 	// CWS - Auto suppression
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.auto_suppression.enabled", true)

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -125,7 +125,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 
 	// CWS - Security Profile V2
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.event_types", []string{"exec", "dns", "bind", "connect"})
-	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.excluded_images", []string{"datadog-agent:*"})
+	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.excluded_images", []string{})
 
 	// CWS - Auto suppression
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.auto_suppression.enabled", true)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -315,6 +315,9 @@ type RuntimeSecurityConfig struct {
 	SecurityProfileCleanupDelay time.Duration
 	// SecurityProfileV2EventTypes defines the list of event types that should be captured by the V2 security profile manager
 	SecurityProfileV2EventTypes []model.EventType
+	// SecurityProfileV2ExcludedImages defines the list of "image_name:image_tag" entries excluded from V2 profiling.
+	// The tag may be "*" to match any tag for the given image name.
+	SecurityProfileV2ExcludedImages []string
 
 	// AnomalyDetectionEventTypes defines the list of events that should be allowed to generate anomaly detections
 	AnomalyDetectionEventTypes []model.EventType
@@ -644,6 +647,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		SecurityProfileNodeEvictionTimeout: pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.security_profile.node_eviction_timeout"),
 		SecurityProfileCleanupDelay:        pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.security_profile.profile_cleanup_delay"),
 		SecurityProfileV2EventTypes:        parseEventTypeStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.security_profile.v2.event_types")),
+		SecurityProfileV2ExcludedImages:    pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.security_profile.v2.excluded_images"),
 
 		// anomaly detection
 		AnomalyDetectionEventTypes:                   parseEventTypeStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.security_profile.anomaly_detection.event_types")),

--- a/pkg/security/security_profile/image_excluder.go
+++ b/pkg/security/security_profile/image_excluder.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package securityprofile holds security profile manager related files
+package securityprofile
+
+import (
+	"fmt"
+	"strings"
+)
+
+const imageTagWildcard = "*"
+
+// imageExcluder matches workloads against a configured list of
+// "image_name:image_tag" entries. The tag may be "*" to match any tag for a
+// given image name.
+type imageExcluder struct {
+	// name -> set of tags ("*" sentinel means any tag matches)
+	entries map[string]map[string]struct{}
+}
+
+// newImageExcluder parses the configured entries. Returns nil if the list is
+// empty (no-op excluder).
+func newImageExcluder(entries []string) (*imageExcluder, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	out := &imageExcluder{entries: make(map[string]map[string]struct{}, len(entries))}
+	for _, entry := range entries {
+		// Split on the last colon so registries with ":port" in the name survive.
+		idx := strings.LastIndex(entry, ":")
+		if idx <= 0 || idx == len(entry)-1 {
+			return nil, fmt.Errorf("invalid excluded_images entry %q: expected \"image_name:image_tag\"", entry)
+		}
+		name, tag := entry[:idx], entry[idx+1:]
+
+		tags, ok := out.entries[name]
+		if !ok {
+			tags = make(map[string]struct{})
+			out.entries[name] = tags
+		}
+		tags[tag] = struct{}{}
+	}
+	return out, nil
+}
+
+// IsExcluded reports whether the given (image_name, image_tag) pair matches
+// any configured entry. A nil receiver is a valid no-op excluder.
+func (e *imageExcluder) IsExcluded(imageName, imageTag string) bool {
+	if e == nil || imageName == "" {
+		return false
+	}
+	tags, ok := e.entries[imageName]
+	if !ok {
+		return false
+	}
+	if _, ok := tags[imageTagWildcard]; ok {
+		return true
+	}
+	_, ok = tags[imageTag]
+	return ok
+}

--- a/pkg/security/security_profile/image_excluder_test.go
+++ b/pkg/security/security_profile/image_excluder_test.go
@@ -1,0 +1,100 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package securityprofile holds security profile manager related files
+package securityprofile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewImageExcluder(t *testing.T) {
+	t.Run("empty list returns nil excluder", func(t *testing.T) {
+		e, err := newImageExcluder(nil)
+		require.NoError(t, err)
+		assert.Nil(t, e)
+
+		e, err = newImageExcluder([]string{})
+		require.NoError(t, err)
+		assert.Nil(t, e)
+	})
+
+	t.Run("rejects malformed entries", func(t *testing.T) {
+		cases := []string{
+			"no-colon",
+			":missing-name",
+			"missing-tag:",
+			":",
+			"",
+		}
+		for _, entry := range cases {
+			t.Run(entry, func(t *testing.T) {
+				_, err := newImageExcluder([]string{entry})
+				assert.Error(t, err)
+			})
+		}
+	})
+
+	t.Run("collects multiple tags per image", func(t *testing.T) {
+		e, err := newImageExcluder([]string{"ubuntu:20.04", "ubuntu:22.04"})
+		require.NoError(t, err)
+		require.NotNil(t, e)
+
+		assert.True(t, e.IsExcluded("ubuntu", "20.04"))
+		assert.True(t, e.IsExcluded("ubuntu", "22.04"))
+		assert.False(t, e.IsExcluded("ubuntu", "18.04"))
+	})
+
+	t.Run("registry with port parses on last colon", func(t *testing.T) {
+		e, err := newImageExcluder([]string{"registry.io:5000/team/app:v1"})
+		require.NoError(t, err)
+		require.NotNil(t, e)
+
+		assert.True(t, e.IsExcluded("registry.io:5000/team/app", "v1"))
+		assert.False(t, e.IsExcluded("registry.io", "5000/team/app:v1"))
+	})
+}
+
+func TestImageExcluder_IsExcluded(t *testing.T) {
+	e, err := newImageExcluder([]string{
+		"ubuntu:*",
+		"alpine:3.18",
+		"mycorp/internal:dev",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, e)
+
+	tests := []struct {
+		name     string
+		image    string
+		tag      string
+		excluded bool
+	}{
+		{"wildcard matches any tag", "ubuntu", "20.04", true},
+		{"wildcard matches empty tag", "ubuntu", "", true},
+		{"exact tag match", "alpine", "3.18", true},
+		{"exact tag mismatch", "alpine", "3.19", false},
+		{"image with slash exact match", "mycorp/internal", "dev", true},
+		{"image with slash tag mismatch", "mycorp/internal", "prod", false},
+		{"unknown image", "nginx", "latest", false},
+		{"empty image never matches", "", "20.04", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.excluded, e.IsExcluded(tc.image, tc.tag))
+		})
+	}
+}
+
+func TestImageExcluder_NilReceiver(t *testing.T) {
+	var e *imageExcluder
+	assert.False(t, e.IsExcluded("ubuntu", "20.04"))
+	assert.False(t, e.IsExcluded("", ""))
+}

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -86,6 +86,7 @@ type ManagerV2 struct {
 	pendingProfileRemovalsLock sync.Mutex
 
 	containerFilters workloadfilter.FilterBundle
+	imageExcluder    *imageExcluder
 }
 
 func NewManagerV2(cfg *config.Config, statsdClient statsd.ClientInterface, resolvers *resolvers.EBPFResolvers, kernelVersion *kernel.Version, dumpHandler backend.ActivityDumpHandler, sendAnomalyDetection func(*model.Event), hostname string, filterStore workloadfilter.Component) (*ManagerV2, error) {
@@ -125,6 +126,11 @@ func NewManagerV2(cfg *config.Config, statsdClient statsd.ClientInterface, resol
 		}
 	}
 
+	imgExcluder, err := newImageExcluder(cfg.RuntimeSecurity.SecurityProfileV2ExcludedImages)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't build security profile v2 image excluder: %w", err)
+	}
+
 	m := &ManagerV2{
 		config:                    cfg,
 		statsdClient:              statsdClient,
@@ -145,6 +151,7 @@ func NewManagerV2(cfg *config.Config, statsdClient statsd.ClientInterface, resol
 		resolvedCgroups:           make(map[containerutils.CGroupID]struct{}),
 		pendingProfileRemovals:    make(map[cgroupModel.WorkloadSelector]time.Time),
 		containerFilters:          containerFilter,
+		imageExcluder:             imgExcluder,
 	}
 
 	m.initMetricsMap()
@@ -753,6 +760,12 @@ func (m *ManagerV2) getOrCreateProfile(selector cgroupModel.WorkloadSelector, ev
 	containerName, imageName, podNamespace := utils.GetContainerFilterTags(event.ProcessContext.Process.ContainerContext.Tags)
 	if m.containerFilters != nil && m.containerFilters.IsExcluded(workloadfilter.CreateContainer("", containerName, imageName, workloadfilter.CreatePod("", "", podNamespace, nil, nil))) {
 		seclog.Debugf("workload %s excluded by container filter (container=%s image=%s namespace=%s)", selector.String(), containerName, imageName, podNamespace)
+		return nil, errors.New("workload excluded")
+	}
+
+	imageTag := utils.GetTagValue("image_tag", event.ProcessContext.Process.ContainerContext.Tags)
+	if m.imageExcluder.IsExcluded(imageName, imageTag) {
+		seclog.Debugf("workload %s excluded by image filter (image=%s tag=%s)", selector.String(), imageName, imageTag)
 		return nil, errors.New("workload excluded")
 	}
 


### PR DESCRIPTION
Add a v2-specific exclusion list of "image_name:image_tag" entries ("*" as tag wildcard) wired through
runtime_security_config.security_profile.v2.excluded_images. Excluded workloads are skipped in getOrCreateProfile before any load/create work. Defaults to "datadog-agent:*".

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
