### PR TITLE
revert CNM direct send default to false

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -407,7 +407,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	initCWSSystemProbeConfig(cfg)
 	initUSMSystemProbeConfig(cfg)
 
-	cfg.BindEnvAndSetDefault("network_config.direct_send", runtime.GOOS == "linux")
+	cfg.BindEnvAndSetDefault("network_config.direct_send", false)
 }
 
 func suffixHostEtc(suffix string) string {


### PR DESCRIPTION
### What does this PR do?

Reverts part of #48015 to keep CNM direct send as `false` by default.

### Motivation

The previous PR causes a disconnect between operator/chart and the agent. We have to change defaults starting with the operator/chart.

### Describe how you validated your changes

### Additional Notes
