### PR TITLE
Use Fabric DNS for Depot Go API

### DIFF
--- a/.adms/go/gitlab.yaml
+++ b/.adms/go/gitlab.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT
 
 variables:
-    GOPROXY: "https://depot-read-api-go.us1.ddbuild.io/magicmirror/magicmirror/@current/|https://depot-read-api-go.us1.ddbuild.io/magicmirror/testing/@current/|https://depot-read-api-go.us1.ddbuild.io/magicmirror/magicmirror/@current/|https://depot-read-api-go.us1.ddbuild.io/magicmirror/testing/@current/|https://depot-read-api-go.us1.ddbuild.io/magicmirror/magicmirror/@current/|https://depot-read-api-go.us1.ddbuild.io/magicmirror/testing/@current/"
+    GOPROXY: "https://depot-read-api-go.rapid-dependency-management-depot.all-clusters.local-dc.fabric.dog:8443/magicmirror/magicmirror/@current/|https://depot-read-api-go.us1.ddbuild.io/magicmirror/magicmirror/@current/|https://depot-read-api-go.us1.ddbuild.io/magicmirror/testing/@current/|https://depot-read-api-go.us1.ddbuild.io/magicmirror/magicmirror/@current/|https://depot-read-api-go.us1.ddbuild.io/magicmirror/testing/@current/|https://depot-read-api-go.us1.ddbuild.io/magicmirror/magicmirror/@current/|https://depot-read-api-go.us1.ddbuild.io/magicmirror/testing/@current/"
     GONOSUMDB: "github.com/DataDog,go.ddbuild.io"
     GOPRIVATE: ""


### PR DESCRIPTION
### What does this PR do?
Switch to Depot Go's Fabric DNS endpoint for resolving Go packages, which is more performant and reliable than ISP.

### Motivation
We have done the same in `dd-go` and `dd-source` and seen positive results, virtually eliminating all 5xx errors in CI https://app.datadoghq.com/s/yB5yjZ/sq2-xp4-63r

### Describe how you validated your changes
Since this only affects CI, we will validate by checking whether this PR's CI passes.

### Additional Notes
