### PR TITLE
chore(renovate): Update configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -117,6 +117,12 @@
       },
       {
         "matchManagers": ["gomod"],
+        "matchDepNames": ["github.com/DataDog/rshell"],
+        "minimumReleaseAge": null,
+        "prPriority": 10
+      },
+      {
+        "matchManagers": ["gomod"],
         "matchDepNames": ["github.com/aws/aws-sdk-go-v2{,/**}"],
         "groupName": "aws-sdk-go-v2"
       },

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
       "go": "1.25.10"
     },
     "constraintsFiltering": "strict",
-    "minimumReleaseAge": "4 days",
+    "minimumReleaseAge": "7 days",
     "prConcurrentLimit": 20,
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
       "go": "1.25.10"
     },
     "constraintsFiltering": "strict",
-    "minimumReleaseAge": "7 days",
+    "minimumReleaseAge": "4 days",
+    "prConcurrentLimit": 20,
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
     "gitIgnoredAuthors": ["200755185+dd-octo-sts[bot]@users.noreply.github.com"],


### PR DESCRIPTION
### What does this PR do?
2 updates in the configuration:
- reduce minimumReleaseAge to 4d and raise prConcurrentLimit to 20. The reduction on minimumAge is to have more buffer in the worst case of a critical CVE: we have 14d to solve them and even if we ship in a patch release, as we have only 2 per week right now, if the CVE is identified as critical d-1 it would require more manual actions.
- Skip the global minimumReleaseAge and raise prPriority so a PR is created as soon as a new rshell version is published.

### Motivation
Faster dependency updates

### Describe how you validated your changes
Configuration updates, no test available

### Additional Notes
