### PR TITLE
chore(deps): Update libgcrypt to 1.12.2

### DIFF
--- a/deps/docs/updating_deps.md
+++ b/deps/docs/updating_deps.md
@@ -57,7 +57,7 @@ Skip if Step 1 detected Renovate mode. Otherwise read **[bump-version.md](bump-v
 
 Runs in **both** modes — Renovate updates the pin but not the BUILD file's own version strings.
 
-- Upstream package version: top-level `VERSION = "..."` constants and `expand_template` substitutions (`@VERSION@`, `@VERSION_NUMBER@`).
+- Upstream package version: top-level `VERSION = "..."` constants and `expand_template` substitutions (`@VERSION@`, `@VERSION_NUMBER@`). If a top-level version constant exists, `expand_template` substitution values must reference it (`"@VERSION@": VERSION`) rather than duplicating the string.
 - SO version: the `version = "..."` argument on `dd_cc_packaged` / `cc_shared_library` (names `lib<name>.so.X.Y.Z`). For autotools deps, derive from `configure.ac`'s `LIB<NAME>_LT_CURRENT/_AGE/_REVISION` via Linux libtool's `(CURRENT - AGE).AGE.REVISION`. **Use `configure.ac`, not the bundled `configure`** — tarballs occasionally ship a stale `configure`. For CMake deps, read `SOVERSION` / `VERSION` from `CMakeLists.txt`.
 
 ---

--- a/deps/gcrypt/config-linux-aarch64.h
+++ b/deps/gcrypt/config-linux-aarch64.h
@@ -12,8 +12,11 @@
 /* Defined if --disable-asm was used to configure */
 /* #undef ASM_DISABLED */
 
-/* GIT commit id revision used to build this package */
-#define BUILD_REVISION "737cc636"
+/* Git full commit id used to build this package */
+#define BUILD_COMMITID ""
+
+/* GIT shortened commit id used to build this package */
+#define BUILD_REVISION "efc34643"
 
 /* The time this package was configured for a build */
 #define BUILD_TIMESTAMP "<none>"
@@ -97,6 +100,12 @@
 /* Defined if the mlock() call does not work */
 /* #undef HAVE_BROKEN_MLOCK */
 
+/* Define to 1 if __riscv_vaes*_vs intrinsics are broken */
+/* #undef HAVE_BROKEN_VAES_VS_INTRINSIC */
+
+/* Define to 1 if __riscv_vsha2cl intrinsics are broken */
+/* #undef HAVE_BROKEN_VSHA2CL_INTRINSIC */
+
 /* Defined if compiler has '__builtin_bswap32' intrinsic */
 #define HAVE_BUILTIN_BSWAP32 1
 
@@ -138,6 +147,15 @@
 /* Defined if underlying compiler supports PowerPC AltiVec/VSX/crypto
    intrinsics with extra GCC flags */
 /* #undef HAVE_COMPATIBLE_CC_PPC_ALTIVEC_WITH_CFLAGS */
+
+/* Defined if underlying compiler supports RISC-V vector intrinsics */
+/* Defined if underlying compiler supports RISC-V vector cryptography
+   intrinsics */
+/* #undef HAVE_COMPATIBLE_CC_RISCV_VECTOR_CRYPTO_INTRINSICS */
+
+/* Defined if underlying compiler supports RISC-V vector cryptography
+   intrinsics with extra GCC flags */
+/* #undef HAVE_COMPATIBLE_CC_RISCV_VECTOR_CRYPTO_INTRINSICS_WITH_CFLAGS */
 
 /* Defined if underlying compiler supports RISC-V vector intrinsics */
 /* #undef HAVE_COMPATIBLE_CC_RISCV_VECTOR_INTRINSICS */
@@ -538,7 +556,7 @@
 #define PACKAGE_NAME "libgcrypt"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libgcrypt 1.11.2"
+#define PACKAGE_STRING "libgcrypt 1.12.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libgcrypt"
@@ -547,7 +565,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.11.2"
+#define PACKAGE_VERSION "1.12.2"
 
 /* A human readable text with the name of the OS */
 #define PRINTABLE_OS_NAME "GNU/Linux"
@@ -610,6 +628,9 @@
 
 /* Defined if this module should be included */
 #define USE_DES 1
+
+/* Defined if this module should be included */
+/* #undef USE_DILITHIUM */
 
 /* Defined if this module should be included */
 #define USE_DSA 1
@@ -802,7 +823,7 @@
 #define USE_WHIRLPOOL 1
 
 /* Version number of package */
-#define VERSION "1.11.2"
+#define VERSION "1.12.2"
 
 /* Defined if compiled symbols have a leading underscore */
 /* #undef WITH_SYMBOL_UNDERSCORE */

--- a/deps/gcrypt/config-linux-x86_64.h
+++ b/deps/gcrypt/config-linux-x86_64.h
@@ -12,8 +12,11 @@
 /* Defined if --disable-asm was used to configure */
 /* #undef ASM_DISABLED */
 
-/* GIT commit id revision used to build this package */
-#define BUILD_REVISION "737cc636"
+/* Git full commit id used to build this package */
+#define BUILD_COMMITID ""
+
+/* GIT shortened commit id used to build this package */
+#define BUILD_REVISION "efc34643"
 
 /* The time this package was configured for a build */
 #define BUILD_TIMESTAMP "<none>"
@@ -97,6 +100,12 @@
 /* Defined if the mlock() call does not work */
 /* #undef HAVE_BROKEN_MLOCK */
 
+/* Define to 1 if __riscv_vaes*_vs intrinsics are broken */
+/* #undef HAVE_BROKEN_VAES_VS_INTRINSIC */
+
+/* Define to 1 if __riscv_vsha2cl intrinsics are broken */
+/* #undef HAVE_BROKEN_VSHA2CL_INTRINSIC */
+
 /* Defined if compiler has '__builtin_bswap32' intrinsic */
 #define HAVE_BUILTIN_BSWAP32 1
 
@@ -138,6 +147,15 @@
 /* Defined if underlying compiler supports PowerPC AltiVec/VSX/crypto
    intrinsics with extra GCC flags */
 /* #undef HAVE_COMPATIBLE_CC_PPC_ALTIVEC_WITH_CFLAGS */
+
+/* Defined if underlying compiler supports RISC-V vector intrinsics */
+/* Defined if underlying compiler supports RISC-V vector cryptography
+   intrinsics */
+/* #undef HAVE_COMPATIBLE_CC_RISCV_VECTOR_CRYPTO_INTRINSICS */
+
+/* Defined if underlying compiler supports RISC-V vector cryptography
+   intrinsics with extra GCC flags */
+/* #undef HAVE_COMPATIBLE_CC_RISCV_VECTOR_CRYPTO_INTRINSICS_WITH_CFLAGS */
 
 /* Defined if underlying compiler supports RISC-V vector intrinsics */
 /* #undef HAVE_COMPATIBLE_CC_RISCV_VECTOR_INTRINSICS */
@@ -538,7 +556,7 @@
 #define PACKAGE_NAME "libgcrypt"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libgcrypt 1.11.2"
+#define PACKAGE_STRING "libgcrypt 1.12.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libgcrypt"
@@ -547,7 +565,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.11.2"
+#define PACKAGE_VERSION "1.12.2"
 
 /* A human readable text with the name of the OS */
 #define PRINTABLE_OS_NAME "GNU/Linux"
@@ -610,6 +628,9 @@
 
 /* Defined if this module should be included */
 #define USE_DES 1
+
+/* Defined if this module should be included */
+/* #undef USE_DILITHIUM */
 
 /* Defined if this module should be included */
 #define USE_DSA 1
@@ -802,7 +823,7 @@
 #define USE_WHIRLPOOL 1
 
 /* Version number of package */
-#define VERSION "1.11.2"
+#define VERSION "1.12.2"
 
 /* Defined if compiled symbols have a leading underscore */
 /* #undef WITH_SYMBOL_UNDERSCORE */

--- a/deps/gcrypt/gcrypt.BUILD.bazel
+++ b/deps/gcrypt/gcrypt.BUILD.bazel
@@ -24,7 +24,7 @@ package_metadata(
     ],
     purl = purl_for_generic(
         download_url = "https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-{version}.tar.bz2",
-        package = "gpg-error",
+        package = "libgcrypt",
         version = VERSION,
     ),
 )

--- a/deps/gcrypt/gcrypt.BUILD.bazel
+++ b/deps/gcrypt/gcrypt.BUILD.bazel
@@ -14,7 +14,7 @@ package(
     default_visibility = ["//packages:__subpackages__"],
 )
 
-VERSION = "1.10.2"
+VERSION = "1.12.2"
 
 package_metadata(
     name = "package_metadata",
@@ -58,8 +58,8 @@ expand_template(
     name = "gcrypt_h",
     out = "src/gcrypt.h",
     substitutions = {
-        "@VERSION@": "1.11.2",
-        "@VERSION_NUMBER@": "0x010b02",
+        "@VERSION@": "1.12.2",
+        "@VERSION_NUMBER@": "0x010c02",
     },
     template = ":src/gcrypt.h.in",
 )
@@ -217,11 +217,15 @@ cc_library(
         "mpi/mpih-mul.c",
         "mpi/mpih-pow.c",
         "mpi/mpiutil.c",
+        "random/random.h",
+        "src/cipher-proto.h",
+        "src/cipher.h",
         "src/const-time.h",
         "src/context.h",
         "src/ec-context.h",
         "src/g10lib.h",
         "src/gcrypt-int.h",
+        "src/gcrypt-testapi.h",
         "src/mpi.h",
         "src/types.h",
         "src/visibility.h",
@@ -383,6 +387,7 @@ _CIPHER_COMMON_SRCS = [
     "random/random.h",
     "src/gcrypt-testapi.h",
     "src/cipher-proto.h",
+    "src/hwf-common.h",
     "cipher/bithelp.h",
     "cipher/bufhelp.h",
     "src/const-time.h",
@@ -605,6 +610,7 @@ cc_library(
                    "cipher/rijndael-ssse3-amd64-asm.S",
                    "cipher/rijndael-vaes-avx2-amd64.S",
                    "cipher/rijndael-vaes-avx2-i386.S",
+                   "cipher/rijndael-vaes-avx512-amd64.S",
                    "cipher/rijndael-vaes-i386.c",
                    "cipher/salsa20-amd64.S",
                    "cipher/serpent-avx2-amd64.S",
@@ -767,7 +773,7 @@ pkg_files(
 dd_cc_packaged(
     name = "gcrypt_pkg",
     input = ":gcrypt",
-    version = "20.4.2",
+    version = "20.7.2",
     installed_files = [":hdr_files"],
     visibility = ["//visibility:public"],
 )

--- a/deps/gcrypt/gcrypt.BUILD.bazel
+++ b/deps/gcrypt/gcrypt.BUILD.bazel
@@ -58,7 +58,7 @@ expand_template(
     name = "gcrypt_h",
     out = "src/gcrypt.h",
     substitutions = {
-        "@VERSION@": "1.12.2",
+        "@VERSION@": VERSION,
         "@VERSION_NUMBER@": "0x010c02",
     },
     template = ":src/gcrypt.h.in",

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -279,10 +279,10 @@ http_archive(
         "config-linux-aarch64.h": "//deps:gcrypt/config-linux-aarch64.h",
         "BUILD.bazel": "//deps:gcrypt/gcrypt.BUILD.bazel",
     },
-    sha256 = "6ba59dd192270e8c1d22ddb41a07d95dcdbc1f0fb02d03c4b54b235814330aac",
-    strip_prefix = "libgcrypt-1.11.2",
+    sha256 = "7ce33c2492221a0436f96a8500215e9f3e3dcb5fd26a757cd415e7a843babd5e",
+    strip_prefix = "libgcrypt-1.12.2",
     urls = [
-        "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.11.2.tar.bz2",
+        "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.12.2.tar.bz2",
     ],
 )
 

--- a/releasenotes/notes/update-libgcrypt-to-1.12.2-66f87c8709973898.yaml
+++ b/releasenotes/notes/update-libgcrypt-to-1.12.2-66f87c8709973898.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Update ``libgcrypt`` to 1.12.2.


### PR DESCRIPTION
### What does this PR do?

Bumps `libgcrypt` from 1.11.2 to 1.12.2.

Files touched:
- `deps/repos.MODULE.bazel` — new sha256 / strip_prefix / URLs
- `deps/gcrypt/gcrypt.BUILD.bazel` — `VERSION`, `@VERSION@`, `@VERSION_NUMBER@`; one new x86_64 source (`cipher/rijndael-vaes-avx512-amd64.S`); 5 transitive headers added to existing `srcs` to satisfy new `#include` lines upstream added (`hwf-common.h`, `cipher.h`, `cipher-proto.h`, `random.h`, `gcrypt-testapi.h`)
- `deps/gcrypt/config-linux-{x86_64,aarch64}.h` — version macros updated; 6 new template entries propagated (`BUILD_COMMITID=""`, four RISC-V `HAVE_*` left undefined, `USE_DILITHIUM` left undefined to avoid pulling the new post-quantum signature module into the binary)
- `releasenotes/notes/update-libgcrypt-to-1.12.2-*.yaml` — reno release note

The 1.12.0 release added `Dilithium` (post-quantum signature) as a default-on pubkey cipher and several `BUILD_COMMITID` / RISC-V probes — those are intentionally left disabled here to keep the binary size unchanged.

### Motivation

POC for the new `update-3rd-party-libs` skill (#51341). This PR is the result of running that skill end-to-end against a real outdated dep — the skill's design and a couple of its docs were refined based on what surfaced during this run.

### Describe how you validated your changes

- `bazel build @gcrypt//:gcrypt @gcrypt//:libgcrypt @gcrypt//:install` — Linux x86_64, passes.
- `bazel build //packages/agent/linux:everything` — passes; openscap (the direct downstream consumer of libgcrypt) relinks successfully.
- `gpg --verify` on the upstream tarball against Werner Koch's release-signing key (`6DAA 6E64 A76D 2840 571B 4902 5288 97B8 2640 3ADA`, fingerprint cross-checked against `gnupg.org/signature_key.html`); the previously-pinned 1.11.2 sha256 also recomputes to the existing pin, confirming the trust chain end-to-end.

Aarch64 build not exercised locally.

### Additional Notes

Drive-by fix: the BUILD file's `VERSION = "1.10.2"` constant was stale (the actual pin was 1.11.2). Now consistent.