### PR TITLE
[observer] Fix event report payload

### DIFF
--- a/comp/anomalydetection/reporter/impl/notify.go
+++ b/comp/anomalydetection/reporter/impl/notify.go
@@ -51,12 +51,11 @@ const (
 
 	// changeEventIntegrationID identifies the publishing integration. The
 	// `edge-intelligence` integration is registered upstream in
-	// integrations-internal-core#3240 (source_type_id 78252213) and the
-	// event-management intake derives source_type from this value. We also
-	// emit changeEventSourceTypeID explicitly so the intake can validate the
-	// pairing without a registry lookup.
+	// integrations-internal-core#3240 and the event-management intake derives
+	// source_type from this value. The v2 Events API schema does not accept
+	// source_type_id as a field at $.data.attributes — integration_id alone
+	// is sufficient for routing.
 	changeEventIntegrationID = "edge-intelligence"
-	changeEventSourceTypeID  = 78252213
 
 	// changedResourceType is the resource classification carried in
 	// data.attributes.attributes.changed_resource.type.
@@ -171,16 +170,15 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 // buildChangeEventPayload returns the v2 Events API JSON envelope for a
 // correlation. Keys mirror the schema produced by datadog-api-client-go's
 // EventCreateRequestPayload (data.type=event, data.attributes.{title, message,
-// category, integration_id, source_type_id, tags, timestamp, aggregation_key,
-// attributes}). integration_id pins the publisher to the `edge-intelligence`
-// integration so the event-management intake can route and authorize the event.
+// category, integration_id, tags, timestamp, aggregation_key, attributes}).
+// integration_id pins the publisher to the `edge-intelligence` integration so
+// the event-management intake can route and authorize the event.
 func buildChangeEventPayload(c observerdef.ActiveCorrelation, msg, ts, aggKey, host string) map[string]any {
 	attrs := map[string]any{
 		"title":           c.Title,
 		"message":         msg,
 		"category":        "change",
 		"integration_id":  changeEventIntegrationID,
-		"source_type_id":  changeEventSourceTypeID,
 		"tags":            BuildEventTags(c),
 		"timestamp":       ts,
 		"aggregation_key": aggKey,

--- a/comp/anomalydetection/reporter/impl/payload_test.go
+++ b/comp/anomalydetection/reporter/impl/payload_test.go
@@ -19,10 +19,10 @@ import (
 // TestBuildChangeEventPayload_WireShape asserts the JSON envelope produced for
 // the event-management intake matches the v2 Events API ChangeEvent schema we
 // used to obtain via datadog-api-client-go, including the edge-intelligence
-// routing metadata (integration_id, source_type_id) and the anomaly resource
-// type. The contract here is the wire format, not the helper functions: if the
-// intake changes field names or the SME-agreed values shift, we want this test
-// to fail loudly.
+// routing metadata (integration_id) and the anomaly resource type. The
+// contract here is the wire format, not the helper functions: if the intake
+// changes field names or the SME-agreed values shift, we want this test to
+// fail loudly.
 func TestBuildChangeEventPayload_WireShape(t *testing.T) {
 	c := observerdef.ActiveCorrelation{
 		Pattern: "kernel_bottleneck",
@@ -64,9 +64,9 @@ func TestBuildChangeEventPayload_WireShape(t *testing.T) {
 	assert.Equal(t, "my-test-host", attrs["host"])
 
 	// edge-intelligence routing: must be present and locked to the registered
-	// values from integrations-internal-core#3240.
+	// value from integrations-internal-core#3240.
 	assert.Equal(t, "edge-intelligence", attrs["integration_id"])
-	assert.EqualValues(t, 78252213, attrs["source_type_id"])
+	assert.NotContains(t, attrs, "source_type_id", "source_type_id must not be sent; routing relies on integration_id alone")
 
 	tags, ok := attrs["tags"].([]any)
 	assert.True(t, ok, "tags must be a JSON array")


### PR DESCRIPTION
### What does this PR do?

Remove `source_type_id` from the change event payload sent to the v2 Events API.

### Motivation

Payloads with this field are rejected, the app is automatically associated from the tags.

### Describe how you validated your changes

### Additional Notes