### PR TITLE
test: update IMAGES_GIT_REF for ddot-ebpf-python-lockfile

### DIFF
--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -19,7 +19,7 @@
     # Constant variables
     - export RELEASE_STAGING=""
     - export DYNAMIC_BUILD_RENDER_RULES="agent-build-only"
-    - export IMAGES_GIT_REF="master"
+    - export IMAGES_GIT_REF="florent.clarret/agent/barx-1856-ddot-ebpf-python-lockfile"
     # Job specific variables
     - export BASE_RELEASE_TAG="${CI_COMMIT_REF_NAME//\//-}"
     - export RELEASE_TAG="${BASE_RELEASE_TAG}${RELEASE_TAG_SUFFIX}${RELEASE_TAG_COMPRESSION_SUFFIX}"


### PR DESCRIPTION
### What does this PR do?

Updates `IMAGES_GIT_REF` in the internal image deploy pipeline to point to the test branch `florent.clarret/agent/barx-1856-ddot-ebpf-python-lockfile` in [DataDog/images](https://github.com/DataDog/images).

### Motivation

Testing [DataDog/images#10015](https://github.com/DataDog/images/pull/10015).

### Describe how you validated your changes

This PR triggers the CI pipeline using the images branch under test.

### Additional Notes

This is a temporary test PR and should not be merged.