### PR TITLE
[CWS] Fix estimation function + improve metrics

### DIFF
--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -1845,6 +1845,10 @@ properties:
                 default: []
                 items:
                   type: string
+              max_dump_size:
+                node_type: setting
+                type: integer
+                default: 5120
           watch_dir:
             node_type: setting
             type: boolean

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -126,6 +126,11 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// CWS - Security Profile V2
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.event_types", []string{"exec", "dns", "bind", "connect"})
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.excluded_images", []string{})
+	// V2-only max profile size, evaluated against the accurate heap footprint (HeapSize) rather
+	// than the legacy shallow estimate driven by activity_dump.max_dump_size. Defaults to 5 MB
+	// because the new measurement counts strings, slice backings and map buckets that V1's
+	// estimate ignored, so equivalent profile content reports ~3× higher than under V1.
+	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.max_dump_size", 5120)
 
 	// CWS - Auto suppression
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.auto_suppression.enabled", true)

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -126,10 +126,6 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// CWS - Security Profile V2
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.event_types", []string{"exec", "dns", "bind", "connect"})
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.excluded_images", []string{})
-	// V2-only max profile size, evaluated against the accurate heap footprint (HeapSize) rather
-	// than the legacy shallow estimate driven by activity_dump.max_dump_size. Defaults to 5 MB
-	// because the new measurement counts strings, slice backings and map buckets that V1's
-	// estimate ignored, so equivalent profile content reports ~3× higher than under V1.
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.max_dump_size", 5120)
 
 	// CWS - Auto suppression

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -318,6 +318,10 @@ type RuntimeSecurityConfig struct {
 	// SecurityProfileV2ExcludedImages defines the list of "image_name:image_tag" entries excluded from V2 profiling.
 	// The tag may be "*" to match any tag for the given image name.
 	SecurityProfileV2ExcludedImages []string
+	// SecurityProfileV2MaxDumpSize returns the V2-only max profile size in bytes. Evaluated against
+	// HeapSize() (accurate heap footprint) rather than the legacy shallow ApproximateSize() that
+	// V1's ActivityDumpMaxDumpSize uses.
+	SecurityProfileV2MaxDumpSize func() int
 
 	// AnomalyDetectionEventTypes defines the list of events that should be allowed to generate anomaly detections
 	AnomalyDetectionEventTypes []model.EventType
@@ -648,6 +652,10 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		SecurityProfileCleanupDelay:        pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.security_profile.profile_cleanup_delay"),
 		SecurityProfileV2EventTypes:        parseEventTypeStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.security_profile.v2.event_types")),
 		SecurityProfileV2ExcludedImages:    pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.security_profile.v2.excluded_images"),
+		SecurityProfileV2MaxDumpSize: func() int {
+			mds := max(pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.security_profile.v2.max_dump_size"), ADMinMaxDumSize)
+			return mds * (1 << 10)
+		},
 
 		// anomaly detection
 		AnomalyDetectionEventTypes:                   parseEventTypeStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.security_profile.anomaly_detection.event_types")),

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -318,9 +318,7 @@ type RuntimeSecurityConfig struct {
 	// SecurityProfileV2ExcludedImages defines the list of "image_name:image_tag" entries excluded from V2 profiling.
 	// The tag may be "*" to match any tag for the given image name.
 	SecurityProfileV2ExcludedImages []string
-	// SecurityProfileV2MaxDumpSize returns the V2-only max profile size in bytes. Evaluated against
-	// HeapSize() (accurate heap footprint) rather than the legacy shallow ApproximateSize() that
-	// V1's ActivityDumpMaxDumpSize uses.
+	// SecurityProfileV2MaxDumpSize returns the V2-only max profile size in bytes.
 	SecurityProfileV2MaxDumpSize func() int
 
 	// AnomalyDetectionEventTypes defines the list of events that should be allowed to generate anomaly detections

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -584,20 +584,10 @@ var (
 	// Tags: -
 	MetricSecurityProfileV2CleanupProfilesRemoved = newRuntimeMetric(".security_profile_v2.cleanup.profiles_removed")
 
-	// MetricSecurityProfileV2LocalStorageProfileSizeOnDisk is the name of the metric used to report the on-disk size of each
-	// individual security profile stored locally.
-	// Tags: image_name, image_tag
-	// Deprecated: use MetricSecurityProfileV2ProfileSize with storage:disk tag instead (manager_v2 path).
-	MetricSecurityProfileV2LocalStorageProfileSizeOnDisk = newAgentMetric(".security_profile_v2.local_storage.profile_size_on_disk")
-
-	// MetricSecurityProfileV2ProfileInMemorySize is the name of the metric used to report the estimated in-memory size
-	// of each active security profile.
-	// Tags: image_name, image_tag
-	// Deprecated: use MetricSecurityProfileV2ProfileSize with storage:ram tag instead (manager_v2 path).
-	MetricSecurityProfileV2ProfileInMemorySize = newRuntimeMetric(".security_profile_v2.profile_in_memory_size")
-
 	// MetricSecurityProfileV2ProfileSize is the unified size metric for active security profiles.
-	// Tags: image_name, image_tag, storage (ram|disk)
+	// Tags: profile_image_name, profile_image_tag, storage (ram|disk).
+	// Note: profile_image_* is used instead of image_* to avoid collision with Datadog's
+	// container auto-tagging (the submitting agent's own image_name gets stamped on metrics).
 	MetricSecurityProfileV2ProfileSize = newRuntimeMetric(".security_profile_v2.profile_size")
 
 	// Event sampling metrics (kernel-side)

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -584,6 +584,16 @@ var (
 	// Tags: -
 	MetricSecurityProfileV2CleanupProfilesRemoved = newRuntimeMetric(".security_profile_v2.cleanup.profiles_removed")
 
+	// MetricSecurityProfileV2LocalStorageProfileSizeOnDisk is the name of the metric used to report the on-disk size of each
+	// individual security profile stored locally.
+	// Tags: image_name, image_tag
+	MetricSecurityProfileV2LocalStorageProfileSizeOnDisk = newAgentMetric(".security_profile_v2.local_storage.profile_size_on_disk")
+
+	// MetricSecurityProfileV2ProfileInMemorySize is the name of the metric used to report the estimated in-memory size
+	// of each active security profile.
+	// Tags: image_name, image_tag
+	MetricSecurityProfileV2ProfileInMemorySize = newRuntimeMetric(".security_profile_v2.profile_in_memory_size")
+
 	// Event sampling metrics (kernel-side)
 
 	// MetricEventSampleTotal is the name of the metric used to report total events that hit the sampling logic in kernel

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -587,12 +587,18 @@ var (
 	// MetricSecurityProfileV2LocalStorageProfileSizeOnDisk is the name of the metric used to report the on-disk size of each
 	// individual security profile stored locally.
 	// Tags: image_name, image_tag
+	// Deprecated: use MetricSecurityProfileV2ProfileSize with storage:disk tag instead (manager_v2 path).
 	MetricSecurityProfileV2LocalStorageProfileSizeOnDisk = newAgentMetric(".security_profile_v2.local_storage.profile_size_on_disk")
 
 	// MetricSecurityProfileV2ProfileInMemorySize is the name of the metric used to report the estimated in-memory size
 	// of each active security profile.
 	// Tags: image_name, image_tag
+	// Deprecated: use MetricSecurityProfileV2ProfileSize with storage:ram tag instead (manager_v2 path).
 	MetricSecurityProfileV2ProfileInMemorySize = newRuntimeMetric(".security_profile_v2.profile_in_memory_size")
+
+	// MetricSecurityProfileV2ProfileSize is the unified size metric for active security profiles.
+	// Tags: image_name, image_tag, storage (ram|disk)
+	MetricSecurityProfileV2ProfileSize = newRuntimeMetric(".security_profile_v2.profile_size")
 
 	// Event sampling metrics (kernel-side)
 

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -302,11 +302,6 @@ var (
 	// Tags: -
 	MetricActivityDumpLocalStorageDeleted = newAgentMetric(".activity_dump.local_storage.deleted")
 
-	// MetricActivityDumpLocalStorageSizeOnDisk is the name of the metric used to track the size that the profiles are
-	// using on disk
-	// Tags: -
-	MetricActivityDumpLocalStorageSizeOnDisk = newRuntimeMetric(".activity_dump.local_storage.size_on_disk")
-
 	// SBOM resolver metrics
 
 	// MetricSBOMResolverActiveSBOMs is the name of the metric used to report the count of SBOMs kept in memory

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -345,6 +345,8 @@ func (at *ActivityTree) ComputeActivityTreeStats() {
 
 		fnodes = fnodes[1:]
 	}
+
+	at.recomputeSizeBytes()
 }
 
 // IsEmpty returns true if the tree is empty
@@ -719,6 +721,7 @@ func (at *ActivityTree) insertBranch(parent ProcessNodeParent, branchToInsert []
 			// insert the new node in the list of children
 			at.Stats.counts[model.ExecEventType].addedCount[generationType].Inc()
 			at.Stats.ProcessNodes++
+			at.Stats.SizeBytes += matchingNode.size()
 
 			parent = matchingNode
 		}
@@ -847,6 +850,7 @@ func (at *ActivityTree) rebaseTree(parent ProcessNodeParent, childIndexToRebase 
 			childrenCursor.AppendChild(n)
 		}
 		at.Stats.ProcessNodes++
+		at.Stats.SizeBytes += n.size()
 		at.Stats.counts[model.ExecEventType].addedCount[generationType].Inc()
 
 		childrenCursor = n
@@ -970,6 +974,53 @@ func (at *ActivityTree) TagAllNodes(imageTag string, timestamp time.Time) {
 	}
 }
 
+// recomputeSizeBytes walks the full tree and resets Stats.SizeBytes to the accurate current value.
+// This is called after evictions where tracking incremental decrements would be too complex.
+func (at *ActivityTree) recomputeSizeBytes() {
+	var total int64
+	openList := make([]*ProcessNode, len(at.ProcessNodes))
+	copy(openList, at.ProcessNodes)
+	for len(openList) > 0 {
+		pn := openList[len(openList)-1]
+		openList = openList[:len(openList)-1]
+		total += pn.size()
+		for _, fn := range pn.Files {
+			total += fileSubtreeSizeBytes(fn)
+		}
+		for _, dns := range pn.DNSNames {
+			total += dns.size()
+		}
+		for _, imds := range pn.IMDSEvents {
+			total += imds.size()
+		}
+		for _, sock := range pn.Sockets {
+			total += sock.size()
+		}
+		for _, sc := range pn.Syscalls {
+			total += sc.size()
+		}
+		for _, cap := range pn.Capabilities {
+			total += cap.size()
+		}
+		for _, device := range pn.NetworkDevices {
+			for _, flow := range device.FlowNodes {
+				total += flow.size()
+			}
+		}
+		openList = append(openList, pn.Children...)
+	}
+	at.Stats.SizeBytes = total
+}
+
+// fileSubtreeSizeBytes recursively sums the size of a FileNode and all its descendants.
+func fileSubtreeSizeBytes(fn *FileNode) int64 {
+	total := fn.size()
+	for _, child := range fn.Children {
+		total += fileSubtreeSizeBytes(child)
+	}
+	return total
+}
+
 // EvictImageTag will remove every trace of the given image tag from the tree
 func (at *ActivityTree) EvictImageTag(imageTag string) {
 	// purge the cookies which todays are never set. TODO: once they'll get used, recompute them here
@@ -991,6 +1042,7 @@ func (at *ActivityTree) EvictImageTag(imageTag string) {
 	}
 	at.ProcessNodes = newProcessNodes
 	at.removeImageTag(imageTag)
+	at.recomputeSizeBytes()
 }
 
 func (at *ActivityTree) visitProcessNode(processNode *ProcessNode, cb func(processNode *ProcessNode)) {
@@ -1118,6 +1170,10 @@ func (at *ActivityTree) EvictUnusedNodes(before time.Time, filepathsInProcessCac
 			at.ProcessNodes = append(at.ProcessNodes[:i], at.ProcessNodes[i+1:]...)
 			totalEvicted++
 		}
+	}
+
+	if totalEvicted > 0 {
+		at.recomputeSizeBytes()
 	}
 
 	return totalEvicted

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -975,7 +975,7 @@ func (at *ActivityTree) TagAllNodes(imageTag string, timestamp time.Time) {
 }
 
 // recomputeSizeBytes walks the full tree and resets Stats.SizeBytes to the accurate current value.
-// This is called after evictions where tracking incremental decrements would be too complex.
+// Called only from ComputeActivityTreeStats to periodically correct any accumulated drift.
 func (at *ActivityTree) recomputeSizeBytes() {
 	var total int64
 	openList := make([]*ProcessNode, len(at.ProcessNodes))
@@ -1021,6 +1021,47 @@ func fileSubtreeSizeBytes(fn *FileNode) int64 {
 	return total
 }
 
+// processNodeOwnActivitySize returns the size of all activity nodes directly owned by pn,
+// excluding child process nodes. Used when a process node is removed entirely and its
+// activity nodes were not individually evicted (early-return path in EvictUnusedNodes).
+func processNodeOwnActivitySize(pn *ProcessNode) int64 {
+	var total int64
+	for _, fn := range pn.Files {
+		total += fileSubtreeSizeBytes(fn)
+	}
+	for _, dns := range pn.DNSNames {
+		total += dns.size()
+	}
+	for _, imds := range pn.IMDSEvents {
+		total += imds.size()
+	}
+	for _, sock := range pn.Sockets {
+		total += sock.size()
+	}
+	for _, sc := range pn.Syscalls {
+		total += sc.size()
+	}
+	for _, cap := range pn.Capabilities {
+		total += cap.size()
+	}
+	for _, device := range pn.NetworkDevices {
+		for _, flow := range device.FlowNodes {
+			total += flow.size()
+		}
+	}
+	return total
+}
+
+// processSubtreeSizeBytes returns the total size of pn plus all its descendants (activity nodes and child
+// process nodes recursively). Used when an entire process subtree is removed at once.
+func processSubtreeSizeBytes(pn *ProcessNode) int64 {
+	total := pn.size() + processNodeOwnActivitySize(pn)
+	for _, child := range pn.Children {
+		total += processSubtreeSizeBytes(child)
+	}
+	return total
+}
+
 // EvictImageTag will remove every trace of the given image tag from the tree
 func (at *ActivityTree) EvictImageTag(imageTag string) {
 	// purge the cookies which todays are never set. TODO: once they'll get used, recompute them here
@@ -1034,15 +1075,18 @@ func (at *ActivityTree) EvictImageTag(imageTag string) {
 	// recompute also the full list of DNSNames and Syscalls when evicting nodes
 	DNSNames := utils.NewStringKeys(nil)
 	SyscallsMask := make(map[int]int)
+	var removedBytes int64
 	newProcessNodes := []*ProcessNode{}
 	for _, node := range at.ProcessNodes {
-		if shouldRemoveNode := node.EvictImageTag(imageTagID, DNSNames, SyscallsMask); !shouldRemoveNode {
+		shouldRemoveNode, nodeRemoved := node.EvictImageTag(imageTagID, DNSNames, SyscallsMask)
+		if !shouldRemoveNode {
 			newProcessNodes = append(newProcessNodes, node)
 		}
+		removedBytes += nodeRemoved
 	}
 	at.ProcessNodes = newProcessNodes
 	at.removeImageTag(imageTag)
-	at.recomputeSizeBytes()
+	at.Stats.SizeBytes -= removedBytes
 }
 
 func (at *ActivityTree) visitProcessNode(processNode *ProcessNode, cb func(processNode *ProcessNode)) {
@@ -1160,20 +1204,18 @@ func (at *ActivityTree) EvictUnusedNodes(before time.Time, filepathsInProcessCac
 			continue
 		}
 
-		// Evict unused nodes
-		evicted := node.EvictUnusedNodes(before, filepathsInProcessCache, profileImageName, profileImageTag, profileImageTagID)
+		evicted, removedBytes := node.EvictUnusedNodes(before, filepathsInProcessCache, profileImageName, profileImageTag, profileImageTagID)
 		totalEvicted += evicted
+		at.Stats.SizeBytes -= removedBytes
 
-		// If the process node itself has no image tags left after eviction, remove it entirely
+		// If the process node itself has no image tags left after eviction, remove it entirely.
+		// EvictUnusedNodes returns early for such nodes without evicting their own activity nodes,
+		// so we account for those here.
 		if node.SeenIsEmpty() {
-			// Remove the node
+			at.Stats.SizeBytes -= node.size() + processNodeOwnActivitySize(node)
 			at.ProcessNodes = append(at.ProcessNodes[:i], at.ProcessNodes[i+1:]...)
 			totalEvicted++
 		}
-	}
-
-	if totalEvicted > 0 {
-		at.recomputeSizeBytes()
 	}
 
 	return totalEvicted

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -1209,10 +1209,11 @@ func (at *ActivityTree) EvictUnusedNodes(before time.Time, filepathsInProcessCac
 		at.Stats.SizeBytes -= removedBytes
 
 		// If the process node itself has no image tags left after eviction, remove it entirely.
-		// EvictUnusedNodes returns early for such nodes without evicting their own activity nodes,
-		// so we account for those here.
+		// Subtract the full remaining subtree size: the node may still hold its own activity nodes
+		// (early-return path skipped them) and live descendants (process-cache fallback kept them
+		// around), all of which get dropped when we splice it out of at.ProcessNodes.
 		if node.SeenIsEmpty() {
-			at.Stats.SizeBytes -= node.size() + processNodeOwnActivitySize(node)
+			at.Stats.SizeBytes -= processSubtreeSizeBytes(node)
 			at.ProcessNodes = append(at.ProcessNodes[:i], at.ProcessNodes[i+1:]...)
 			totalEvicted++
 		}

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -1003,6 +1003,7 @@ func (at *ActivityTree) recomputeSizeBytes() {
 			total += cap.size()
 		}
 		for _, device := range pn.NetworkDevices {
+			total += device.size()
 			for _, flow := range device.FlowNodes {
 				total += flow.size()
 			}
@@ -1045,6 +1046,7 @@ func processNodeOwnActivitySize(pn *ProcessNode) int64 {
 		total += cap.size()
 	}
 	for _, device := range pn.NetworkDevices {
+		total += device.size()
 		for _, flow := range device.FlowNodes {
 			total += flow.size()
 		}

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -992,6 +992,7 @@ func (at *ActivityTree) recomputeSizeBytes() {
 // fileSubtreeSizeBytes recursively sums the size of a FileNode and all its descendants.
 func fileSubtreeSizeBytes(fn *FileNode) int64 {
 	total := fn.size()
+	a
 	for _, child := range fn.Children {
 		total += fileSubtreeSizeBytes(child)
 	}
@@ -1187,9 +1188,6 @@ func (at *ActivityTree) EvictUnusedNodes(before time.Time, filepathsInProcessCac
 		at.Stats.SizeBytes -= removedBytes
 
 		// If the process node itself has no image tags left after eviction, remove it entirely.
-		// Subtract the full remaining subtree size: the node may still hold its own activity nodes
-		// (early-return path skipped them) and live descendants (process-cache fallback kept them
-		// around), all of which get dropped when we splice it out of at.ProcessNodes.
 		if node.SeenIsEmpty() {
 			at.Stats.SizeBytes -= processSubtreeSizeBytes(node)
 			at.ProcessNodes = append(at.ProcessNodes[:i], at.ProcessNodes[i+1:]...)

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -983,31 +983,7 @@ func (at *ActivityTree) recomputeSizeBytes() {
 	for len(openList) > 0 {
 		pn := openList[len(openList)-1]
 		openList = openList[:len(openList)-1]
-		total += pn.size()
-		for _, fn := range pn.Files {
-			total += fileSubtreeSizeBytes(fn)
-		}
-		for _, dns := range pn.DNSNames {
-			total += dns.size()
-		}
-		for _, imds := range pn.IMDSEvents {
-			total += imds.size()
-		}
-		for _, sock := range pn.Sockets {
-			total += sock.size()
-		}
-		for _, sc := range pn.Syscalls {
-			total += sc.size()
-		}
-		for _, cap := range pn.Capabilities {
-			total += cap.size()
-		}
-		for _, device := range pn.NetworkDevices {
-			total += device.size()
-			for _, flow := range device.FlowNodes {
-				total += flow.size()
-			}
-		}
+		total += pn.size() + processNodeOwnActivitySize(pn)
 		openList = append(openList, pn.Children...)
 	}
 	at.Stats.SizeBytes = total

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -992,7 +992,7 @@ func (at *ActivityTree) recomputeSizeBytes() {
 // fileSubtreeSizeBytes recursively sums the size of a FileNode and all its descendants.
 func fileSubtreeSizeBytes(fn *FileNode) int64 {
 	total := fn.size()
-	a
+
 	for _, child := range fn.Children {
 		total += fileSubtreeSizeBytes(child)
 	}

--- a/pkg/security/security_profile/activity_tree/activity_tree_stats.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_stats.go
@@ -10,7 +10,6 @@ package activitytree
 
 import (
 	"fmt"
-	"unsafe"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.uber.org/atomic"
@@ -29,6 +28,10 @@ type Stats struct {
 	SyscallNodes    int64
 	FlowNodes       int64
 	CapabilityNodes int64
+
+	// SizeBytes is an incremental estimate of the tree's heap size in bytes.
+	// It is updated at every insertion and recomputed from scratch after evictions.
+	SizeBytes int64
 
 	counts map[model.EventType]*statsPerEventType
 }
@@ -67,18 +70,10 @@ func NewActivityTreeNodeStats() *Stats {
 	return ats
 }
 
-// ApproximateSize returns an approximation of the size of the tree
+// ApproximateSize returns the tracked in-memory size of the tree in bytes.
+// This value is updated incrementally at insertion time and recomputed after evictions.
 func (stats *Stats) ApproximateSize() int64 {
-	var total int64
-	total += stats.ProcessNodes * int64(unsafe.Sizeof(ProcessNode{})) // 1024
-	total += stats.FileNodes * int64(unsafe.Sizeof(FileNode{}))       // 80
-	total += stats.DNSNodes * int64(unsafe.Sizeof(DNSNode{}))         // 24
-	total += stats.SocketNodes * int64(unsafe.Sizeof(SocketNode{}))   // 40
-	total += stats.IMDSNodes * int64(unsafe.Sizeof(IMDSNode{}))
-	total += stats.SyscallNodes * int64(unsafe.Sizeof(SyscallNode{}))
-	total += stats.FlowNodes * int64(unsafe.Sizeof(FlowNode{}))
-	total += stats.CapabilityNodes * int64(unsafe.Sizeof(CapabilityNode{}))
-	return total
+	return stats.SizeBytes
 }
 
 // SendStats sends metrics to Datadog

--- a/pkg/security/security_profile/activity_tree/activity_tree_stats.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_stats.go
@@ -72,16 +72,16 @@ func NewActivityTreeNodeStats() *Stats {
 	return ats
 }
 
-// ApproximateSize returns the tracked in-memory size of the tree in bytes.
-// Production paths update SizeBytes incrementally on insert and periodically through
-// recomputeSizeBytes. Some callers (FakeOverweight, test fixtures, code that hydrates
-// a Stats from a proto without running through Insert) build a Stats with non-zero
-// counts but zero SizeBytes; for those we fall back to the old per-type shallow estimate
-// so overweight checks and the load controller keep working until the next recompute.
+// ApproximateSize returns the legacy shallow size estimate of the tree in bytes:
+// node counts × struct header sizes. This is what V1 (legacy Manager / ActivityDump
+// path) has always used to drive `activity_dump.max_dump_size` and
+// `anomaly_detection.unstable_profile_size_threshold`, and the behavior is preserved
+// verbatim so V1 deployments don't shift.
+//
+// V2 must call HeapSize() instead — it returns the incrementally-tracked real heap
+// footprint (strings, slice backings, map buckets) populated by Insert/Evict paths
+// and corrected by recomputeSizeBytes.
 func (stats *Stats) ApproximateSize() int64 {
-	if stats.SizeBytes > 0 {
-		return stats.SizeBytes
-	}
 	var total int64
 	total += stats.ProcessNodes * int64(unsafe.Sizeof(ProcessNode{}))
 	total += stats.FileNodes * int64(unsafe.Sizeof(FileNode{}))
@@ -92,6 +92,22 @@ func (stats *Stats) ApproximateSize() int64 {
 	total += stats.FlowNodes * int64(unsafe.Sizeof(FlowNode{}))
 	total += stats.CapabilityNodes * int64(unsafe.Sizeof(CapabilityNode{}))
 	return total
+}
+
+// HeapSize returns the tree's tracked real heap footprint in bytes (strings, slice
+// backings, map buckets, struct headers). Used by V2 callers for max-size checks and
+// the profile_size RAM metric.
+//
+// SizeBytes is maintained incrementally by Insert and Evict paths and periodically
+// corrected by recomputeSizeBytes (called from ComputeActivityTreeStats). When SizeBytes
+// hasn't been populated yet — proto rehydration before recompute fires, FakeOverweight,
+// hand-built test fixtures — we fall back to ApproximateSize so overweight checks and
+// the load controller still produce a usable number.
+func (stats *Stats) HeapSize() int64 {
+	if stats.SizeBytes > 0 {
+		return stats.SizeBytes
+	}
+	return stats.ApproximateSize()
 }
 
 // SendStats sends metrics to Datadog

--- a/pkg/security/security_profile/activity_tree/activity_tree_stats.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_stats.go
@@ -29,11 +29,7 @@ type Stats struct {
 	SyscallNodes    int64
 	FlowNodes       int64
 	CapabilityNodes int64
-
-	// SizeBytes is an incremental estimate of the tree's heap size in bytes.
-	// Updated at every insertion and decremented incrementally during eviction.
-	// Periodically corrected by recomputeSizeBytes via ComputeActivityTreeStats.
-	SizeBytes int64
+	SizeBytes       int64
 
 	counts map[model.EventType]*statsPerEventType
 }
@@ -72,21 +68,13 @@ func NewActivityTreeNodeStats() *Stats {
 	return ats
 }
 
-// ApproximateSize returns the legacy shallow size estimate of the tree in bytes:
-// node counts × struct header sizes. This is what V1 (legacy Manager / ActivityDump
-// path) has always used to drive `activity_dump.max_dump_size` and
-// `anomaly_detection.unstable_profile_size_threshold`, and the behavior is preserved
-// verbatim so V1 deployments don't shift.
-//
-// V2 must call HeapSize() instead — it returns the incrementally-tracked real heap
-// footprint (strings, slice backings, map buckets) populated by Insert/Evict paths
-// and corrected by recomputeSizeBytes.
+// ApproximateSize returns an approximation of the size of the tree
 func (stats *Stats) ApproximateSize() int64 {
 	var total int64
-	total += stats.ProcessNodes * int64(unsafe.Sizeof(ProcessNode{}))
-	total += stats.FileNodes * int64(unsafe.Sizeof(FileNode{}))
-	total += stats.DNSNodes * int64(unsafe.Sizeof(DNSNode{}))
-	total += stats.SocketNodes * int64(unsafe.Sizeof(SocketNode{}))
+	total += stats.ProcessNodes * int64(unsafe.Sizeof(ProcessNode{})) // 1024
+	total += stats.FileNodes * int64(unsafe.Sizeof(FileNode{}))       // 80
+	total += stats.DNSNodes * int64(unsafe.Sizeof(DNSNode{}))         // 24
+	total += stats.SocketNodes * int64(unsafe.Sizeof(SocketNode{}))   // 40
 	total += stats.IMDSNodes * int64(unsafe.Sizeof(IMDSNode{}))
 	total += stats.SyscallNodes * int64(unsafe.Sizeof(SyscallNode{}))
 	total += stats.FlowNodes * int64(unsafe.Sizeof(FlowNode{}))
@@ -94,20 +82,11 @@ func (stats *Stats) ApproximateSize() int64 {
 	return total
 }
 
-// HeapSize returns the tree's tracked real heap footprint in bytes (strings, slice
+// HeapSize returns the tree's tracked estimated heap footprint in bytes (strings, slice
 // backings, map buckets, struct headers). Used by V2 callers for max-size checks and
 // the profile_size RAM metric.
-//
-// SizeBytes is maintained incrementally by Insert and Evict paths and periodically
-// corrected by recomputeSizeBytes (called from ComputeActivityTreeStats). When SizeBytes
-// hasn't been populated yet — proto rehydration before recompute fires, FakeOverweight,
-// hand-built test fixtures — we fall back to ApproximateSize so overweight checks and
-// the load controller still produce a usable number.
 func (stats *Stats) HeapSize() int64 {
-	if stats.SizeBytes > 0 {
-		return stats.SizeBytes
-	}
-	return stats.ApproximateSize()
+	return stats.SizeBytes
 }
 
 // SendStats sends metrics to Datadog

--- a/pkg/security/security_profile/activity_tree/activity_tree_stats.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_stats.go
@@ -10,6 +10,7 @@ package activitytree
 
 import (
 	"fmt"
+	"unsafe"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.uber.org/atomic"
@@ -72,9 +73,19 @@ func NewActivityTreeNodeStats() *Stats {
 }
 
 // ApproximateSize returns the tracked in-memory size of the tree in bytes.
-// This value is updated incrementally at insertion time and recomputed after evictions.
+// Production paths update SizeBytes incrementally on insert and periodically through
+// recomputeSizeBytes. Some callers (FakeOverweight, test fixtures, legacy code that
+// pre-populates only node counts) build a Stats with non-zero counts but zero SizeBytes;
+// for those we fall back to the shallow per-process estimate the metric used before
+// becoming incremental, so overweight checks and the load controller keep working.
 func (stats *Stats) ApproximateSize() int64 {
-	return stats.SizeBytes
+	if stats.SizeBytes > 0 {
+		return stats.SizeBytes
+	}
+	if stats.ProcessNodes > 0 {
+		return stats.ProcessNodes * int64(unsafe.Sizeof(ProcessNode{}))
+	}
+	return 0
 }
 
 // SendStats sends metrics to Datadog

--- a/pkg/security/security_profile/activity_tree/activity_tree_stats.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_stats.go
@@ -74,18 +74,24 @@ func NewActivityTreeNodeStats() *Stats {
 
 // ApproximateSize returns the tracked in-memory size of the tree in bytes.
 // Production paths update SizeBytes incrementally on insert and periodically through
-// recomputeSizeBytes. Some callers (FakeOverweight, test fixtures, legacy code that
-// pre-populates only node counts) build a Stats with non-zero counts but zero SizeBytes;
-// for those we fall back to the shallow per-process estimate the metric used before
-// becoming incremental, so overweight checks and the load controller keep working.
+// recomputeSizeBytes. Some callers (FakeOverweight, test fixtures, code that hydrates
+// a Stats from a proto without running through Insert) build a Stats with non-zero
+// counts but zero SizeBytes; for those we fall back to the old per-type shallow estimate
+// so overweight checks and the load controller keep working until the next recompute.
 func (stats *Stats) ApproximateSize() int64 {
 	if stats.SizeBytes > 0 {
 		return stats.SizeBytes
 	}
-	if stats.ProcessNodes > 0 {
-		return stats.ProcessNodes * int64(unsafe.Sizeof(ProcessNode{}))
-	}
-	return 0
+	var total int64
+	total += stats.ProcessNodes * int64(unsafe.Sizeof(ProcessNode{}))
+	total += stats.FileNodes * int64(unsafe.Sizeof(FileNode{}))
+	total += stats.DNSNodes * int64(unsafe.Sizeof(DNSNode{}))
+	total += stats.SocketNodes * int64(unsafe.Sizeof(SocketNode{}))
+	total += stats.IMDSNodes * int64(unsafe.Sizeof(IMDSNode{}))
+	total += stats.SyscallNodes * int64(unsafe.Sizeof(SyscallNode{}))
+	total += stats.FlowNodes * int64(unsafe.Sizeof(FlowNode{}))
+	total += stats.CapabilityNodes * int64(unsafe.Sizeof(CapabilityNode{}))
+	return total
 }
 
 // SendStats sends metrics to Datadog

--- a/pkg/security/security_profile/activity_tree/activity_tree_stats.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_stats.go
@@ -86,6 +86,9 @@ func (stats *Stats) ApproximateSize() int64 {
 // backings, map buckets, struct headers). Used by V2 callers for max-size checks and
 // the profile_size RAM metric.
 func (stats *Stats) HeapSize() int64 {
+	if stats.SizeBytes == 0 {
+		return stats.ApproximateSize()
+	}
 	return stats.SizeBytes
 }
 

--- a/pkg/security/security_profile/activity_tree/activity_tree_stats.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_stats.go
@@ -30,7 +30,8 @@ type Stats struct {
 	CapabilityNodes int64
 
 	// SizeBytes is an incremental estimate of the tree's heap size in bytes.
-	// It is updated at every insertion and recomputed from scratch after evictions.
+	// Updated at every insertion and decremented incrementally during eviction.
+	// Periodically corrected by recomputeSizeBytes via ComputeActivityTreeStats.
 	SizeBytes int64
 
 	counts map[model.EventType]*statsPerEventType

--- a/pkg/security/security_profile/activity_tree/capability_node.go
+++ b/pkg/security/security_profile/activity_tree/capability_node.go
@@ -8,7 +8,10 @@
 // Package activitytree holds activitytree related files
 package activitytree
 
-import "time"
+import (
+	"time"
+	"unsafe"
+)
 
 // CapabilityNode stores capabilities usage information for a process in the activity tree.
 type CapabilityNode struct {
@@ -17,6 +20,11 @@ type CapabilityNode struct {
 
 	Capability uint64 // The capability number
 	Capable    bool   // Whether the process was capable of using the capability
+}
+
+// size returns the shallow heap size of this node.
+func (cn *CapabilityNode) size() int64 {
+	return int64(unsafe.Sizeof(*cn))
 }
 
 // NewCapabilityNode creates a new CapabilityNode

--- a/pkg/security/security_profile/activity_tree/capability_node.go
+++ b/pkg/security/security_profile/activity_tree/capability_node.go
@@ -22,9 +22,10 @@ type CapabilityNode struct {
 	Capable    bool   // Whether the process was capable of using the capability
 }
 
-// size returns the shallow heap size of this node.
+// size approximates this node's heap footprint: struct overhead plus the NodeBase.seen
+// backing slice. No other heap-allocated fields.
 func (cn *CapabilityNode) size() int64 {
-	return int64(unsafe.Sizeof(*cn))
+	return int64(unsafe.Sizeof(*cn)) + seenBytes(cn.NodeBase)
 }
 
 // NewCapabilityNode creates a new CapabilityNode

--- a/pkg/security/security_profile/activity_tree/capability_node.go
+++ b/pkg/security/security_profile/activity_tree/capability_node.go
@@ -22,8 +22,7 @@ type CapabilityNode struct {
 	Capable    bool   // Whether the process was capable of using the capability
 }
 
-// size approximates this node's heap footprint: struct overhead plus the NodeBase.seen
-// backing slice. No other heap-allocated fields.
+// size approximates this node's heap footprint
 func (cn *CapabilityNode) size() int64 {
 	return int64(unsafe.Sizeof(*cn)) + seenBytes(cn.NodeBase)
 }

--- a/pkg/security/security_profile/activity_tree/dns_node.go
+++ b/pkg/security/security_profile/activity_tree/dns_node.go
@@ -24,9 +24,15 @@ type DNSNode struct {
 	Requests       []model.DNSEvent
 }
 
-// size returns the shallow heap size of this node.
+// size approximates this node's heap footprint: struct overhead, the backing arrays of
+// Requests and MatchedRules, each request's Question.Name string, and the NodeBase.seen
+// slice. DNSEvent itself is a value type embedded in the Requests slice so its scalar
+// fields are already covered by the slice's element-size accounting.
 func (dn *DNSNode) size() int64 {
 	s := int64(unsafe.Sizeof(*dn))
+	s += seenBytes(dn.NodeBase)
+	s += sliceBackingBytes(cap(dn.Requests), unsafe.Sizeof(model.DNSEvent{}))
+	s += sliceBackingBytes(cap(dn.MatchedRules), unsafe.Sizeof((*model.MatchedRule)(nil)))
 	for _, req := range dn.Requests {
 		s += int64(len(req.Question.Name))
 	}

--- a/pkg/security/security_profile/activity_tree/dns_node.go
+++ b/pkg/security/security_profile/activity_tree/dns_node.go
@@ -10,6 +10,7 @@ package activitytree
 
 import (
 	"strings"
+	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -21,6 +22,15 @@ type DNSNode struct {
 	MatchedRules   []*model.MatchedRule
 	GenerationType NodeGenerationType
 	Requests       []model.DNSEvent
+}
+
+// size returns the shallow heap size of this node.
+func (dn *DNSNode) size() int64 {
+	s := int64(unsafe.Sizeof(*dn))
+	for _, req := range dn.Requests {
+		s += int64(len(req.Question.Name))
+	}
+	return s
 }
 
 // NewDNSNode returns a new DNSNode instance

--- a/pkg/security/security_profile/activity_tree/dns_node.go
+++ b/pkg/security/security_profile/activity_tree/dns_node.go
@@ -24,10 +24,7 @@ type DNSNode struct {
 	Requests       []model.DNSEvent
 }
 
-// size approximates this node's heap footprint: struct overhead, the backing arrays of
-// Requests and MatchedRules, each request's Question.Name string, and the NodeBase.seen
-// slice. DNSEvent itself is a value type embedded in the Requests slice so its scalar
-// fields are already covered by the slice's element-size accounting.
+// size approximates this node's heap footprint
 func (dn *DNSNode) size() int64 {
 	s := int64(unsafe.Sizeof(*dn))
 	s += seenBytes(dn.NodeBase)

--- a/pkg/security/security_profile/activity_tree/file_node.go
+++ b/pkg/security/security_profile/activity_tree/file_node.go
@@ -207,18 +207,20 @@ func (fn *FileNode) tagAllNodes(imageTagID uint64, timestamp time.Time) {
 	}
 }
 
-func (fn *FileNode) evictImageTag(imageTagID uint64) bool {
+func (fn *FileNode) evictImageTag(imageTagID uint64) (bool, int64) {
 	if !fn.HasImageTag(imageTagID) {
-		return false
+		return false, 0
 	}
-	evicted := fn.EvictImageTag(imageTagID)
-	if evicted {
-		return true
+	if fn.EvictImageTag(imageTagID) {
+		return true, fileSubtreeSizeBytes(fn)
 	}
+	var removed int64
 	for filename, child := range fn.Children {
-		if shouldRemoveNode := child.evictImageTag(imageTagID); shouldRemoveNode {
+		shouldRemove, childRemoved := child.evictImageTag(imageTagID)
+		if shouldRemove {
 			delete(fn.Children, filename)
 		}
+		removed += childRemoved
 	}
-	return false
+	return false, removed
 }

--- a/pkg/security/security_profile/activity_tree/file_node.go
+++ b/pkg/security/security_profile/activity_tree/file_node.go
@@ -41,14 +41,28 @@ type OpenNode struct {
 	Mode  uint32
 }
 
-// size returns the shallow heap size of this node: struct overhead plus key string fields.
+// size approximates this node's own heap footprint: struct overhead, the strings it
+// carries (Name, the full FileEvent path/basename/filesystem/package metadata, hashes),
+// the OpenNode pointer payload, the MatchedRules backing slice, the NodeBase.seen slice,
+// and the bucket overhead of the Children map. Children FileNodes themselves are
+// counted separately by fileSubtreeSizeBytes.
 func (fn *FileNode) size() int64 {
 	s := int64(unsafe.Sizeof(*fn))
+	s += seenBytes(fn.NodeBase)
 	s += int64(len(fn.Name))
 	if fn.File != nil {
 		s += int64(len(fn.File.PathnameStr))
 		s += int64(len(fn.File.BasenameStr))
+		s += int64(len(fn.File.Filesystem))
+		s += int64(len(fn.File.PkgName))
+		s += int64(len(fn.File.PkgVersion))
+		s += stringSliceBytes(fn.File.Hashes)
 	}
+	if fn.Open != nil {
+		s += int64(unsafe.Sizeof(*fn.Open))
+	}
+	s += sliceBackingBytes(cap(fn.MatchedRules), unsafe.Sizeof((*model.MatchedRule)(nil)))
+	s += stringMapBytes(fn.Children)
 	return s
 }
 

--- a/pkg/security/security_profile/activity_tree/file_node.go
+++ b/pkg/security/security_profile/activity_tree/file_node.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -38,6 +39,17 @@ type OpenNode struct {
 	model.SyscallEvent
 	Flags uint32
 	Mode  uint32
+}
+
+// size returns the shallow heap size of this node: struct overhead plus key string fields.
+func (fn *FileNode) size() int64 {
+	s := int64(unsafe.Sizeof(*fn))
+	s += int64(len(fn.Name))
+	if fn.File != nil {
+		s += int64(len(fn.File.PathnameStr))
+		s += int64(len(fn.File.BasenameStr))
+	}
+	return s
 }
 
 // NewFileNode returns a new FileActivityNode instance
@@ -174,8 +186,10 @@ func (fn *FileNode) InsertFileEvent(fileEvent *model.FileEvent, event *model.Eve
 			break
 		}
 		if len(currentPath) <= nextParentIndex+1 {
-			currentFn.Children[parent] = NewFileNode(fileEvent, event, parent, imageTagID, generationType, reducedPath, resolvers)
+			leafNode := NewFileNode(fileEvent, event, parent, imageTagID, generationType, reducedPath, resolvers)
+			currentFn.Children[parent] = leafNode
 			stats.FileNodes++
+			stats.SizeBytes += leafNode.size()
 			break
 		}
 		newChild := NewFileNode(nil, nil, parent, imageTagID, generationType, "", resolvers)

--- a/pkg/security/security_profile/activity_tree/file_node.go
+++ b/pkg/security/security_profile/activity_tree/file_node.go
@@ -194,6 +194,7 @@ func (fn *FileNode) InsertFileEvent(fileEvent *model.FileEvent, event *model.Eve
 		}
 		newChild := NewFileNode(nil, nil, parent, imageTagID, generationType, "", resolvers)
 		currentFn.Children[parent] = newChild
+		stats.SizeBytes += newChild.size()
 		currentFn = newChild
 		currentPath = currentPath[nextParentIndex:]
 	}

--- a/pkg/security/security_profile/activity_tree/file_node.go
+++ b/pkg/security/security_profile/activity_tree/file_node.go
@@ -51,12 +51,7 @@ func (fn *FileNode) size() int64 {
 	s += seenBytes(fn.NodeBase)
 	s += int64(len(fn.Name))
 	if fn.File != nil {
-		s += int64(len(fn.File.PathnameStr))
-		s += int64(len(fn.File.BasenameStr))
-		s += int64(len(fn.File.Filesystem))
-		s += int64(len(fn.File.PkgName))
-		s += int64(len(fn.File.PkgVersion))
-		s += stringSliceBytes(fn.File.Hashes)
+		s += fileEventStringsBytes(fn.File)
 	}
 	if fn.Open != nil {
 		s += int64(unsafe.Sizeof(*fn.Open))

--- a/pkg/security/security_profile/activity_tree/file_node.go
+++ b/pkg/security/security_profile/activity_tree/file_node.go
@@ -41,11 +41,7 @@ type OpenNode struct {
 	Mode  uint32
 }
 
-// size approximates this node's own heap footprint: struct overhead, the strings it
-// carries (Name, the full FileEvent path/basename/filesystem/package metadata, hashes),
-// the OpenNode pointer payload, the MatchedRules backing slice, the NodeBase.seen slice,
-// and the bucket overhead of the Children map. Children FileNodes themselves are
-// counted separately by fileSubtreeSizeBytes.
+// size approximates this node's own heap footprint
 func (fn *FileNode) size() int64 {
 	s := int64(unsafe.Sizeof(*fn))
 	s += seenBytes(fn.NodeBase)

--- a/pkg/security/security_profile/activity_tree/flow_node.go
+++ b/pkg/security/security_profile/activity_tree/flow_node.go
@@ -37,11 +37,10 @@ func NewFlowNode(flow model.Flow, event *model.Event, generationType NodeGenerat
 	return node
 }
 
-func (node *FlowNode) addFlow(flow model.Flow, event *model.Event, imageTagID uint64) {
-	node.AppendImageTagID(imageTagID, event.ResolveEventTime())
+func (fn *FlowNode) addFlow(flow model.Flow, event *model.Event, imageTagID uint64) {
+	fn.AppendImageTagID(imageTagID, event.ResolveEventTime())
 
 	// add metrics
-	node.Flow.Egress.Add(flow.Egress)
-	node.Flow.Ingress.Add(flow.Ingress)
-
+	fn.Flow.Egress.Add(flow.Egress)
+	fn.Flow.Ingress.Add(flow.Ingress)
 }

--- a/pkg/security/security_profile/activity_tree/flow_node.go
+++ b/pkg/security/security_profile/activity_tree/flow_node.go
@@ -21,9 +21,11 @@ type FlowNode struct {
 	Flow           model.Flow
 }
 
-// size returns the shallow heap size of this node.
+// size approximates this node's heap footprint. Flow itself is a value type composed of
+// numeric fields and netip.AddrPort (which carries no heap allocation), so the only
+// extra contribution beyond the struct is the NodeBase.seen backing slice.
 func (fn *FlowNode) size() int64 {
-	return int64(unsafe.Sizeof(*fn))
+	return int64(unsafe.Sizeof(*fn)) + seenBytes(fn.NodeBase)
 }
 
 // NewFlowNode returns a new FlowNode instance

--- a/pkg/security/security_profile/activity_tree/flow_node.go
+++ b/pkg/security/security_profile/activity_tree/flow_node.go
@@ -9,6 +9,8 @@
 package activitytree
 
 import (
+	"unsafe"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
@@ -17,6 +19,11 @@ type FlowNode struct {
 	NodeBase
 	GenerationType NodeGenerationType
 	Flow           model.Flow
+}
+
+// size returns the shallow heap size of this node.
+func (fn *FlowNode) size() int64 {
+	return int64(unsafe.Sizeof(*fn))
 }
 
 // NewFlowNode returns a new FlowNode instance

--- a/pkg/security/security_profile/activity_tree/flow_node.go
+++ b/pkg/security/security_profile/activity_tree/flow_node.go
@@ -21,9 +21,7 @@ type FlowNode struct {
 	Flow           model.Flow
 }
 
-// size approximates this node's heap footprint. Flow itself is a value type composed of
-// numeric fields and netip.AddrPort (which carries no heap allocation), so the only
-// extra contribution beyond the struct is the NodeBase.seen backing slice.
+// size approximates this node's heap footprint
 func (fn *FlowNode) size() int64 {
 	return int64(unsafe.Sizeof(*fn)) + seenBytes(fn.NodeBase)
 }

--- a/pkg/security/security_profile/activity_tree/imds_node.go
+++ b/pkg/security/security_profile/activity_tree/imds_node.go
@@ -9,6 +9,8 @@
 package activitytree
 
 import (
+	"unsafe"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
@@ -18,6 +20,15 @@ type IMDSNode struct {
 	MatchedRules   []*model.MatchedRule
 	GenerationType NodeGenerationType
 	Event          model.IMDSEvent
+}
+
+// size returns the shallow heap size of this node.
+func (in *IMDSNode) size() int64 {
+	s := int64(unsafe.Sizeof(*in))
+	s += int64(len(in.Event.CloudProvider))
+	s += int64(len(in.Event.Type))
+	s += int64(len(in.Event.URL))
+	return s
 }
 
 // NewIMDSNode creates a new IMDSNode instance

--- a/pkg/security/security_profile/activity_tree/imds_node.go
+++ b/pkg/security/security_profile/activity_tree/imds_node.go
@@ -22,12 +22,24 @@ type IMDSNode struct {
 	Event          model.IMDSEvent
 }
 
-// size returns the shallow heap size of this node.
+// size approximates this node's heap footprint: struct overhead plus every IMDSEvent
+// string (cloud provider, URL, host, user agent, server header, AWS credential fields)
+// and the MatchedRules + NodeBase backing slices.
 func (in *IMDSNode) size() int64 {
 	s := int64(unsafe.Sizeof(*in))
-	s += int64(len(in.Event.CloudProvider))
+	s += seenBytes(in.NodeBase)
 	s += int64(len(in.Event.Type))
+	s += int64(len(in.Event.CloudProvider))
 	s += int64(len(in.Event.URL))
+	s += int64(len(in.Event.Host))
+	s += int64(len(in.Event.UserAgent))
+	s += int64(len(in.Event.Server))
+	s += int64(len(in.Event.AWS.SecurityCredentials.Code))
+	s += int64(len(in.Event.AWS.SecurityCredentials.Type))
+	s += int64(len(in.Event.AWS.SecurityCredentials.AccessKeyID))
+	s += int64(len(in.Event.AWS.SecurityCredentials.LastUpdated))
+	s += int64(len(in.Event.AWS.SecurityCredentials.ExpirationRaw))
+	s += sliceBackingBytes(cap(in.MatchedRules), unsafe.Sizeof((*model.MatchedRule)(nil)))
 	return s
 }
 

--- a/pkg/security/security_profile/activity_tree/imds_node.go
+++ b/pkg/security/security_profile/activity_tree/imds_node.go
@@ -22,9 +22,7 @@ type IMDSNode struct {
 	Event          model.IMDSEvent
 }
 
-// size approximates this node's heap footprint: struct overhead plus every IMDSEvent
-// string (cloud provider, URL, host, user agent, server header, AWS credential fields)
-// and the MatchedRules + NodeBase backing slices.
+// size approximates this node's heap footprint
 func (in *IMDSNode) size() int64 {
 	s := int64(unsafe.Sizeof(*in))
 	s += seenBytes(in.NodeBase)

--- a/pkg/security/security_profile/activity_tree/network_device_node.go
+++ b/pkg/security/security_profile/activity_tree/network_device_node.go
@@ -68,8 +68,10 @@ func (netdevice *NetworkDeviceNode) insertNetworkFlowMonitorEvent(event *model.N
 				return newFlow
 			}
 			// create new entry
-			netdevice.FlowNodes[flow.GetFiveTuple()] = NewFlowNode(flow, evt, generationType, imageTagID)
+			flowNode := NewFlowNode(flow, evt, generationType, imageTagID)
+			netdevice.FlowNodes[flow.GetFiveTuple()] = flowNode
 			stats.FlowNodes++
+			stats.SizeBytes += flowNode.size()
 		}
 	}
 

--- a/pkg/security/security_profile/activity_tree/network_device_node.go
+++ b/pkg/security/security_profile/activity_tree/network_device_node.go
@@ -10,6 +10,7 @@ package activitytree
 
 import (
 	"time"
+	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
@@ -21,6 +22,16 @@ type NetworkDeviceNode struct {
 	Context        model.NetworkDeviceContext
 	// FlowNodes are indexed by source IPPortContexts
 	FlowNodes map[model.FiveTuple]*FlowNode
+}
+
+// size approximates this node's own heap footprint: struct overhead, the FlowNodes map
+// bucket overhead, and the MatchedRules backing slice. FlowNodes themselves are walked
+// separately by the activity-tree size accounting.
+func (netdevice *NetworkDeviceNode) size() int64 {
+	s := int64(unsafe.Sizeof(*netdevice))
+	s += fixedKeyMapBytes(netdevice.FlowNodes)
+	s += sliceBackingBytes(cap(netdevice.MatchedRules), unsafe.Sizeof((*model.MatchedRule)(nil)))
+	return s
 }
 
 // NewNetworkDeviceNode returns a new NetworkDeviceNode instance

--- a/pkg/security/security_profile/activity_tree/network_device_node.go
+++ b/pkg/security/security_profile/activity_tree/network_device_node.go
@@ -39,14 +39,15 @@ func (netdevice *NetworkDeviceNode) appendImageTag(imageTagID uint64, timestamp 
 	}
 }
 
-func (netdevice *NetworkDeviceNode) evictImageTag(imageTagID uint64) bool {
+func (netdevice *NetworkDeviceNode) evictImageTag(imageTagID uint64) (bool, int64) {
+	var removed int64
 	for key, flow := range netdevice.FlowNodes {
 		if flow.EvictImageTag(imageTagID) {
+			removed += flow.size()
 			delete(netdevice.FlowNodes, key)
 		}
 	}
-
-	return len(netdevice.FlowNodes) == 0
+	return len(netdevice.FlowNodes) == 0, removed
 }
 
 func (netdevice *NetworkDeviceNode) insertNetworkFlowMonitorEvent(event *model.NetworkFlowMonitorEvent, evt *model.Event, dryRun bool, rules []*model.MatchedRule, generationType NodeGenerationType, imageTagID uint64, stats *Stats) bool {

--- a/pkg/security/security_profile/activity_tree/network_device_node.go
+++ b/pkg/security/security_profile/activity_tree/network_device_node.go
@@ -24,9 +24,7 @@ type NetworkDeviceNode struct {
 	FlowNodes map[model.FiveTuple]*FlowNode
 }
 
-// size approximates this node's own heap footprint: struct overhead, the FlowNodes map
-// bucket overhead, and the MatchedRules backing slice. FlowNodes themselves are walked
-// separately by the activity-tree size accounting.
+// size approximates this node's own heap footprint
 func (netdevice *NetworkDeviceNode) size() int64 {
 	s := int64(unsafe.Sizeof(*netdevice))
 	s += fixedKeyMapBytes(netdevice.FlowNodes)

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -610,10 +610,11 @@ func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCach
 		removedBytes += childRemoved
 
 		// If the child process node itself has no image tags left after eviction, remove it entirely.
-		// EvictUnusedNodes returns early for such nodes without evicting their own activity nodes,
-		// so we account for those here.
+		// We must subtract the full remaining subtree size here: the child can still hold its own
+		// activity nodes (early-return path skipped them) and live descendants (process-cache fallback
+		// kept them around), all of which get dropped when we splice it out of pn.Children.
 		if child.SeenIsEmpty() {
-			removedBytes += child.size() + processNodeOwnActivitySize(child)
+			removedBytes += processSubtreeSizeBytes(child)
 			pn.Children = append(pn.Children[:i], pn.Children[i+1:]...)
 			totalEvicted++
 		}
@@ -635,7 +636,7 @@ func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCach
 	_ = pn.NodeBase.EvictBeforeTimestamp(before)
 
 	// If the process node itself can be evicted, return early.
-	// The caller will subtract pn.size() + processNodeOwnActivitySize(pn) when it removes this node.
+	// The caller will subtract the remaining subtree size when it removes this node.
 	if len(pn.Children) == 0 && pn.SeenIsEmpty() {
 		return totalEvicted, removedBytes
 	}

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 
@@ -52,6 +53,15 @@ type ProcessNode struct {
 	Syscalls     []*SyscallNode
 	Capabilities []*CapabilityNode
 	Children     []*ProcessNode
+}
+
+// size returns the shallow heap size of this node: struct overhead plus key string fields.
+func (pn *ProcessNode) size() int64 {
+	s := int64(unsafe.Sizeof(*pn))
+	s += int64(len(pn.Process.FileEvent.PathnameStr))
+	s += int64(len(pn.Process.FileEvent.BasenameStr))
+	s += int64(len(pn.Process.Argv0))
+	return s
 }
 
 // NewProcessNode returns a new ProcessNode instance
@@ -236,9 +246,11 @@ newSyscallLoop:
 			// exit early
 			break
 		}
-		pn.Syscalls = append(pn.Syscalls, NewSyscallNode(int(newSyscall), e.ResolveEventTime(), imageTagID, Runtime))
+		sn := NewSyscallNode(int(newSyscall), e.ResolveEventTime(), imageTagID, Runtime)
+		pn.Syscalls = append(pn.Syscalls, sn)
 		syscallMask[int(newSyscall)] = int(newSyscall)
 		stats.SyscallNodes++
+		stats.SizeBytes += sn.size()
 	}
 
 	return hasNewSyscalls
@@ -275,6 +287,7 @@ func (pn *ProcessNode) InsertFileEvent(fileEvent *model.FileEvent, event *model.
 			node := NewFileNode(fileEvent, event, parent, imageTagID, generationType, filePath, resolvers)
 			node.MatchedRules = model.AppendMatchedRule(node.MatchedRules, event.Rules)
 			stats.FileNodes++
+			stats.SizeBytes += node.size()
 			pn.Files[parent] = node
 		} else {
 			// This is an intermediary node in the branch that leads to the leaf we want to add. Create a node without the
@@ -282,6 +295,7 @@ func (pn *ProcessNode) InsertFileEvent(fileEvent *model.FileEvent, event *model.
 			newChild := NewFileNode(nil, nil, parent, imageTagID, generationType, filePath, resolvers)
 			newChild.InsertFileEvent(fileEvent, event, filePath[nextParentIndex:], imageTagID, generationType, stats, dryRun, filePath, resolvers)
 			stats.FileNodes++
+			stats.SizeBytes += newChild.size()
 			pn.Files[parent] = newChild
 		}
 	}
@@ -334,8 +348,10 @@ func (pn *ProcessNode) InsertDNSEvent(evt *model.Event, imageTagID uint64, gener
 		return true
 	}
 
-	pn.DNSNames[evt.DNS.Question.Name] = NewDNSNode(&evt.DNS, evt, evt.Rules, generationType, imageTagID)
+	dnsNode = NewDNSNode(&evt.DNS, evt, evt.Rules, generationType, imageTagID)
+	pn.DNSNames[evt.DNS.Question.Name] = dnsNode
 	stats.DNSNodes++
+	stats.SizeBytes += dnsNode.size()
 	return true
 }
 
@@ -350,8 +366,10 @@ func (pn *ProcessNode) InsertIMDSEvent(evt *model.Event, imageTagID uint64, gene
 
 	if !dryRun {
 		// create new node
-		pn.IMDSEvents[evt.IMDS] = NewIMDSNode(&evt.IMDS, evt, evt.Rules, generationType, imageTagID)
+		imdsNode := NewIMDSNode(&evt.IMDS, evt, evt.Rules, generationType, imageTagID)
+		pn.IMDSEvents[evt.IMDS] = imdsNode
 		stats.IMDSNodes++
+		stats.SizeBytes += imdsNode.size()
 	}
 	return true
 }
@@ -390,6 +408,7 @@ func (pn *ProcessNode) InsertBindEvent(evt *model.Event, imageTagID uint64, gene
 		sock = NewSocketNode(evtFamily, generationType)
 		if !dryRun {
 			stats.SocketNodes++
+			stats.SizeBytes += sock.size()
 			pn.Sockets = append(pn.Sockets, sock)
 		}
 		newNode = true
@@ -429,6 +448,7 @@ nextCapability:
 		capabilityNode := NewCapabilityNode(capability, capable, evt.ResolveEventTime(), imageTagID, Runtime)
 		pn.Capabilities = append(pn.Capabilities, capabilityNode)
 		stats.CapabilityNodes++
+		stats.SizeBytes += capabilityNode.size()
 	}
 
 	return hasNewCapabilitiesUsage

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -55,12 +55,37 @@ type ProcessNode struct {
 	Children     []*ProcessNode
 }
 
-// size returns the shallow heap size of this node: struct overhead plus key string fields.
+// size approximates the in-memory heap footprint of this process node, excluding the
+// child nodes it owns (those are counted separately by processNodeOwnActivitySize and
+// processSubtreeSizeBytes). It charges for:
+//   - struct overhead (covered by unsafe.Sizeof)
+//   - all major string content reachable from model.Process (argv, envs, exe path, comm,
+//     container tags, credentials, ...) which the previous shallow estimate ignored
+//   - backing arrays of the Sockets/Syscalls/Capabilities/Children/MatchedRules slices
+//   - the bucket overhead of the Files / DNSNames / IMDSEvents / NetworkDevices maps
+//   - the NodeBase.seen slice
+//
+// Map/slice values themselves (the *FileNode, *DNSNode, etc.) are NOT counted here —
+// each child node's own size() is summed by the activity-tree size accounting paths.
 func (pn *ProcessNode) size() int64 {
 	s := int64(unsafe.Sizeof(*pn))
-	s += int64(len(pn.Process.FileEvent.PathnameStr))
-	s += int64(len(pn.Process.FileEvent.BasenameStr))
-	s += int64(len(pn.Process.Argv0))
+	s += seenBytes(pn.NodeBase)
+	s += processStringsBytes(&pn.Process)
+
+	// Backing arrays for direct-children slices. We charge for the slice slots only;
+	// the nodes pointed to are accounted for by their own size() invocations.
+	s += sliceBackingBytes(cap(pn.Sockets), unsafe.Sizeof((*SocketNode)(nil)))
+	s += sliceBackingBytes(cap(pn.Syscalls), unsafe.Sizeof((*SyscallNode)(nil)))
+	s += sliceBackingBytes(cap(pn.Capabilities), unsafe.Sizeof((*CapabilityNode)(nil)))
+	s += sliceBackingBytes(cap(pn.Children), unsafe.Sizeof((*ProcessNode)(nil)))
+	s += sliceBackingBytes(cap(pn.MatchedRules), unsafe.Sizeof((*model.MatchedRule)(nil)))
+
+	// Map bucket overhead. We use stringMapBytes for string-keyed maps (it adds the key
+	// content too) and fixedKeyMapBytes for struct-keyed maps where the key has no heap.
+	s += stringMapBytes(pn.Files)
+	s += stringMapBytes(pn.DNSNames)
+	s += fixedKeyMapBytes(pn.IMDSEvents)
+	s += fixedKeyMapBytes(pn.NetworkDevices)
 	return s
 }
 
@@ -383,8 +408,11 @@ func (pn *ProcessNode) InsertNetworkFlowMonitorEvent(evt *model.Event, imageTagI
 
 	if !dryRun {
 		newNode := NewNetworkDeviceNode(&evt.NetworkFlowMonitor.Device, generationType)
-		newNode.insertNetworkFlowMonitorEvent(&evt.NetworkFlowMonitor, evt, dryRun, evt.Rules, generationType, imageTagID, stats)
 		pn.NetworkDevices[evt.NetworkFlowMonitor.Device] = newNode
+		// Charge for the device struct itself before its first flow is inserted; the
+		// flow's own size is added by insertNetworkFlowMonitorEvent below.
+		stats.SizeBytes += newNode.size()
+		newNode.insertNetworkFlowMonitorEvent(&evt.NetworkFlowMonitor, evt, dryRun, evt.Rules, generationType, imageTagID, stats)
 	}
 	return true
 }
@@ -540,10 +568,13 @@ func (pn *ProcessNode) EvictImageTag(imageTagID uint64, DNSNames *utils.StringKe
 	// Evict image tag from network device nodes
 	for key, device := range pn.NetworkDevices {
 		shouldRemove, deviceRemoved := device.evictImageTag(imageTagID)
+		removed += deviceRemoved
 		if shouldRemove {
+			// Account for the device wrapper itself, which mirrors the size charged
+			// when the device was first inserted in InsertNetworkFlowMonitorEvent.
+			removed += device.size()
 			delete(pn.NetworkDevices, key)
 		}
-		removed += deviceRemoved
 	}
 
 	newSockets := []*SocketNode{}

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -500,26 +500,31 @@ func (pn *ProcessNode) TagAllNodes(imageTagID uint64, timestamp time.Time) {
 }
 
 // EvictImageTag will remove every trace of this image tag, and returns true if the process node should be removed
-// also, recompute the list of dnsnames and syscalls
-func (pn *ProcessNode) EvictImageTag(imageTagID uint64, DNSNames *utils.StringKeys, SyscallsMask map[int]int) bool {
+// (along with the number of bytes freed) also, recompute the list of dnsnames and syscalls
+func (pn *ProcessNode) EvictImageTag(imageTagID uint64, DNSNames *utils.StringKeys, SyscallsMask map[int]int) (bool, int64) {
 	if !pn.HasImageTag(imageTagID) {
-		return false // this node doesn't have the tag, and all its children/files/dns/etc shouldn't have it either
+		return false, 0 // this node doesn't have the tag, and all its children/files/dns/etc shouldn't have it either
 	}
 	IsNodeEmpty := pn.NodeBase.EvictImageTag(imageTagID)
 	if IsNodeEmpty {
 		// if we removed the last tag, remove entirely the process node from the tree
-		return true
+		return true, processSubtreeSizeBytes(pn)
 	}
 
+	var removed int64
+
 	for filename, file := range pn.Files {
-		if shouldRemoveNode := file.evictImageTag(imageTagID); shouldRemoveNode {
+		shouldRemove, fileRemoved := file.evictImageTag(imageTagID)
+		if shouldRemove {
 			delete(pn.Files, filename)
 		}
+		removed += fileRemoved
 	}
 
 	// Evict image tag from dns nodes
 	for question, dns := range pn.DNSNames {
 		if shouldRemoveNode := dns.evictImageTag(imageTagID, DNSNames); shouldRemoveNode {
+			removed += dns.size()
 			delete(pn.DNSNames, question)
 		}
 	}
@@ -527,21 +532,26 @@ func (pn *ProcessNode) EvictImageTag(imageTagID uint64, DNSNames *utils.StringKe
 	// Evict image tag from IMDS nodes
 	for key, imds := range pn.IMDSEvents {
 		if shouldRemoveNode := imds.EvictImageTag(imageTagID); shouldRemoveNode {
+			removed += imds.size()
 			delete(pn.IMDSEvents, key)
 		}
 	}
 
 	// Evict image tag from network device nodes
 	for key, device := range pn.NetworkDevices {
-		if shouldRemoveNode := device.evictImageTag(imageTagID); shouldRemoveNode {
+		shouldRemove, deviceRemoved := device.evictImageTag(imageTagID)
+		if shouldRemove {
 			delete(pn.NetworkDevices, key)
 		}
+		removed += deviceRemoved
 	}
 
 	newSockets := []*SocketNode{}
 	for _, sock := range pn.Sockets {
 		if shouldRemoveNode := sock.evictImageTag(imageTagID); !shouldRemoveNode {
 			newSockets = append(newSockets, sock)
+		} else {
+			removed += sock.size()
 		}
 	}
 	pn.Sockets = newSockets
@@ -551,6 +561,8 @@ func (pn *ProcessNode) EvictImageTag(imageTagID uint64, DNSNames *utils.StringKe
 		if shouldRemove := scall.EvictImageTag(imageTagID); !shouldRemove {
 			newSyscalls = append(newSyscalls, scall)
 			SyscallsMask[scall.Syscall] = scall.Syscall
+		} else {
+			removed += scall.size()
 		}
 	}
 	pn.Syscalls = newSyscalls
@@ -559,25 +571,31 @@ func (pn *ProcessNode) EvictImageTag(imageTagID uint64, DNSNames *utils.StringKe
 	for _, capabilityNode := range pn.Capabilities {
 		if shouldRemove := capabilityNode.EvictImageTag(imageTagID); !shouldRemove {
 			newCapabilities = append(newCapabilities, capabilityNode)
+		} else {
+			removed += capabilityNode.size()
 		}
 	}
 	pn.Capabilities = newCapabilities
 
 	newChildren := []*ProcessNode{}
 	for _, child := range pn.Children {
-		if shouldRemoveNode := child.EvictImageTag(imageTagID, DNSNames, SyscallsMask); !shouldRemoveNode {
+		shouldRemoveNode, childRemoved := child.EvictImageTag(imageTagID, DNSNames, SyscallsMask)
+		if !shouldRemoveNode {
 			newChildren = append(newChildren, child)
 		}
+		removed += childRemoved
 	}
 	pn.Children = newChildren
-	return false
+	return false, removed
 }
 
 // EvictUnusedNodes evicts all child nodes that haven't been touched since the given timestamp
-// and returns the total number of process nodes evicted, a node is only evicted if all its children are evictable.
+// and returns the total number of process nodes evicted and the total bytes freed.
+// A node is only evicted if all its children are evictable.
 // profileImageTagID is the pre-resolved internal ID for the profile's image tag (0 means unknown/no tag).
-func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCache map[ImageProcessKey]bool, profileImageName string, profileImageTag string, profileImageTagID uint64) int {
+func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCache map[ImageProcessKey]bool, profileImageName string, profileImageTag string, profileImageTagID uint64) (int, int64) {
 	totalEvicted := 0
+	var removedBytes int64
 
 	key := ImageProcessKey{
 		ImageName: profileImageName,
@@ -587,11 +605,15 @@ func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCach
 	// First, recursively evict unused nodes from children
 	for i := len(pn.Children) - 1; i >= 0; i-- {
 		child := pn.Children[i]
-		evicted := child.EvictUnusedNodes(before, filepathsInProcessCache, profileImageName, profileImageTag, profileImageTagID)
+		evicted, childRemoved := child.EvictUnusedNodes(before, filepathsInProcessCache, profileImageName, profileImageTag, profileImageTagID)
 		totalEvicted += evicted
+		removedBytes += childRemoved
 
-		// If the child process node itself has no image tags left after eviction, remove it entirely
+		// If the child process node itself has no image tags left after eviction, remove it entirely.
+		// EvictUnusedNodes returns early for such nodes without evicting their own activity nodes,
+		// so we account for those here.
 		if child.SeenIsEmpty() {
+			removedBytes += child.size() + processNodeOwnActivitySize(child)
 			pn.Children = append(pn.Children[:i], pn.Children[i+1:]...)
 			totalEvicted++
 		}
@@ -612,11 +634,10 @@ func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCach
 
 	_ = pn.NodeBase.EvictBeforeTimestamp(before)
 
-	// If the process node itself can be evicted
+	// If the process node itself can be evicted, return early.
+	// The caller will subtract pn.size() + processNodeOwnActivitySize(pn) when it removes this node.
 	if len(pn.Children) == 0 && pn.SeenIsEmpty() {
-		return totalEvicted
-		// No need to evict the activity nodes, since this process node will be removed entirely
-
+		return totalEvicted, removedBytes
 	}
 
 	// Evict unused syscall nodes
@@ -624,6 +645,7 @@ func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCach
 		syscallNode := pn.Syscalls[i]
 		if syscallNode.NodeBase.EvictBeforeTimestamp(before) > 0 {
 			if syscallNode.SeenIsEmpty() {
+				removedBytes += syscallNode.size()
 				pn.Syscalls = append(pn.Syscalls[:i], pn.Syscalls[i+1:]...)
 			}
 		}
@@ -633,6 +655,7 @@ func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCach
 	for path, fileNode := range pn.Files {
 		if fileNode.NodeBase.EvictBeforeTimestamp(before) > 0 {
 			if fileNode.SeenIsEmpty() {
+				removedBytes += fileSubtreeSizeBytes(fileNode)
 				delete(pn.Files, path)
 			}
 		}
@@ -642,6 +665,7 @@ func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCach
 	for name, dnsNode := range pn.DNSNames {
 		if dnsNode.NodeBase.EvictBeforeTimestamp(before) > 0 {
 			if dnsNode.SeenIsEmpty() {
+				removedBytes += dnsNode.size()
 				delete(pn.DNSNames, name)
 			}
 		}
@@ -651,6 +675,7 @@ func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCach
 	for event, imdsNode := range pn.IMDSEvents {
 		if imdsNode.NodeBase.EvictBeforeTimestamp(before) > 0 {
 			if imdsNode.SeenIsEmpty() {
+				removedBytes += imdsNode.size()
 				delete(pn.IMDSEvents, event)
 			}
 		}
@@ -663,6 +688,7 @@ func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCach
 		socketNode := pn.Sockets[i]
 		if socketNode.NodeBase.EvictBeforeTimestamp(before) > 0 {
 			if socketNode.SeenIsEmpty() {
+				removedBytes += socketNode.size()
 				pn.Sockets = append(pn.Sockets[:i], pn.Sockets[i+1:]...)
 			}
 		}
@@ -673,10 +699,11 @@ func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCach
 		capabilityNode := pn.Capabilities[i]
 		if capabilityNode.NodeBase.EvictBeforeTimestamp(before) > 0 {
 			if capabilityNode.SeenIsEmpty() {
+				removedBytes += capabilityNode.size()
 				pn.Capabilities = append(pn.Capabilities[:i], pn.Capabilities[i+1:]...)
 			}
 		}
 	}
 
-	return totalEvicted
+	return totalEvicted, removedBytes
 }

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -56,17 +56,7 @@ type ProcessNode struct {
 }
 
 // size approximates the in-memory heap footprint of this process node, excluding the
-// child nodes it owns (those are counted separately by processNodeOwnActivitySize and
-// processSubtreeSizeBytes). It charges for:
-//   - struct overhead (covered by unsafe.Sizeof)
-//   - all major string content reachable from model.Process (argv, envs, exe path, comm,
-//     container tags, credentials, ...) which the previous shallow estimate ignored
-//   - backing arrays of the Sockets/Syscalls/Capabilities/Children/MatchedRules slices
-//   - the bucket overhead of the Files / DNSNames / IMDSEvents / NetworkDevices maps
-//   - the NodeBase.seen slice
-//
-// Map/slice values themselves (the *FileNode, *DNSNode, etc.) are NOT counted here —
-// each child node's own size() is summed by the activity-tree size accounting paths.
+// child nodes it owns
 func (pn *ProcessNode) size() int64 {
 	s := int64(unsafe.Sizeof(*pn))
 	s += seenBytes(pn.NodeBase)
@@ -368,9 +358,6 @@ func (pn *ProcessNode) InsertDNSEvent(evt *model.Event, imageTagID uint64, gener
 			}
 		}
 
-		// Snapshot size around the append: DNSNode.size() includes every Question.Name
-		// and the Requests slice's backing capacity, both of which can grow here. Using a
-		// before/after delta keeps SizeBytes honest even when append doubles the cap.
 		sizeBefore := dnsNode.size()
 		dnsNode.Requests = append(dnsNode.Requests, evt.DNS)
 		stats.SizeBytes += dnsNode.size() - sizeBefore
@@ -446,7 +433,7 @@ func (pn *ProcessNode) InsertBindEvent(evt *model.Event, imageTagID uint64, gene
 		newNode = true
 	}
 
-	// Insert bind event (charges Stats.SizeBytes for any new BindNode it appends).
+	// Insert bind event
 	if sock.InsertBindEvent(&evt.Bind, evt, imageTagID, generationType, evt.Rules, stats, dryRun) {
 		newNode = true
 	}
@@ -532,7 +519,7 @@ func (pn *ProcessNode) TagAllNodes(imageTagID uint64, timestamp time.Time) {
 }
 
 // EvictImageTag will remove every trace of this image tag, and returns true if the process node should be removed
-// (along with the number of bytes freed) also, recompute the list of dnsnames and syscalls
+// also, recompute the list of dnsnames and syscalls
 func (pn *ProcessNode) EvictImageTag(imageTagID uint64, DNSNames *utils.StringKeys, SyscallsMask map[int]int) (bool, int64) {
 	if !pn.HasImageTag(imageTagID) {
 		return false, 0 // this node doesn't have the tag, and all its children/files/dns/etc shouldn't have it either
@@ -574,8 +561,6 @@ func (pn *ProcessNode) EvictImageTag(imageTagID uint64, DNSNames *utils.StringKe
 		shouldRemove, deviceRemoved := device.evictImageTag(imageTagID)
 		removed += deviceRemoved
 		if shouldRemove {
-			// Account for the device wrapper itself, which mirrors the size charged
-			// when the device was first inserted in InsertNetworkFlowMonitorEvent.
 			removed += device.size()
 			delete(pn.NetworkDevices, key)
 		}
@@ -583,9 +568,6 @@ func (pn *ProcessNode) EvictImageTag(imageTagID uint64, DNSNames *utils.StringKe
 
 	newSockets := []*SocketNode{}
 	for _, sock := range pn.Sockets {
-		// evictImageTag mutates sn.Bind in place and reports the bytes dropped from
-		// individual BindNodes. If the socket itself is now empty we additionally
-		// charge for the socket wrapper struct.
 		shouldRemoveNode, bindBytes := sock.evictImageTag(imageTagID)
 		removed += bindBytes
 		if shouldRemoveNode {
@@ -650,9 +632,6 @@ func (pn *ProcessNode) EvictUnusedNodes(before time.Time, filepathsInProcessCach
 		removedBytes += childRemoved
 
 		// If the child process node itself has no image tags left after eviction, remove it entirely.
-		// We must subtract the full remaining subtree size here: the child can still hold its own
-		// activity nodes (early-return path skipped them) and live descendants (process-cache fallback
-		// kept them around), all of which get dropped when we splice it out of pn.Children.
 		if child.SeenIsEmpty() {
 			removedBytes += processSubtreeSizeBytes(child)
 			pn.Children = append(pn.Children[:i], pn.Children[i+1:]...)

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -368,8 +368,12 @@ func (pn *ProcessNode) InsertDNSEvent(evt *model.Event, imageTagID uint64, gener
 			}
 		}
 
-		// insert the new request
+		// Snapshot size around the append: DNSNode.size() includes every Question.Name
+		// and the Requests slice's backing capacity, both of which can grow here. Using a
+		// before/after delta keeps SizeBytes honest even when append doubles the cap.
+		sizeBefore := dnsNode.size()
 		dnsNode.Requests = append(dnsNode.Requests, evt.DNS)
+		stats.SizeBytes += dnsNode.size() - sizeBefore
 		return true
 	}
 
@@ -442,8 +446,8 @@ func (pn *ProcessNode) InsertBindEvent(evt *model.Event, imageTagID uint64, gene
 		newNode = true
 	}
 
-	// Insert bind event
-	if sock.InsertBindEvent(&evt.Bind, evt, imageTagID, generationType, evt.Rules, dryRun) {
+	// Insert bind event (charges Stats.SizeBytes for any new BindNode it appends).
+	if sock.InsertBindEvent(&evt.Bind, evt, imageTagID, generationType, evt.Rules, stats, dryRun) {
 		newNode = true
 	}
 
@@ -579,11 +583,16 @@ func (pn *ProcessNode) EvictImageTag(imageTagID uint64, DNSNames *utils.StringKe
 
 	newSockets := []*SocketNode{}
 	for _, sock := range pn.Sockets {
-		if shouldRemoveNode := sock.evictImageTag(imageTagID); !shouldRemoveNode {
-			newSockets = append(newSockets, sock)
-		} else {
+		// evictImageTag mutates sn.Bind in place and reports the bytes dropped from
+		// individual BindNodes. If the socket itself is now empty we additionally
+		// charge for the socket wrapper struct.
+		shouldRemoveNode, bindBytes := sock.evictImageTag(imageTagID)
+		removed += bindBytes
+		if shouldRemoveNode {
 			removed += sock.size()
+			continue
 		}
+		newSockets = append(newSockets, sock)
 	}
 	pn.Sockets = newSockets
 

--- a/pkg/security/security_profile/activity_tree/size_test.go
+++ b/pkg/security/security_profile/activity_tree/size_test.go
@@ -11,6 +11,7 @@ package activitytree
 import (
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,18 +138,21 @@ func populateRichTree(t *testing.T, tree *ActivityTree, tagID uint64) *ProcessNo
 	return root
 }
 
-// TestSizeBytes_EmptyTree confirms an empty tree reports zero so the metric doesn't lie
-// when no profile data exists yet.
+// TestSizeBytes_EmptyTree confirms an empty tree reports zero on both the legacy V1
+// estimate (ApproximateSize) and the V2 accurate estimate (HeapSize) so neither metric
+// lies when no profile data exists yet.
 func TestSizeBytes_EmptyTree(t *testing.T) {
 	tree := newSizeTestTree()
 	assert.Equal(t, int64(0), tree.Stats.SizeBytes)
 	assert.Equal(t, int64(0), tree.Stats.ApproximateSize())
+	assert.Equal(t, int64(0), tree.Stats.HeapSize())
 }
 
-// TestSizeBytes_FallbackUsesAllNodeTypes locks in the regression fix: when SizeBytes hasn't
-// been populated (proto rehydration, test fixtures), ApproximateSize must account for every
-// node type, not just ProcessNodes.
-func TestSizeBytes_FallbackUsesAllNodeTypes(t *testing.T) {
+// TestApproximateSize_LegacyShallowSemantics locks in V1's legacy behavior: ApproximateSize
+// is *only* node counts × struct header sizes, regardless of SizeBytes. V1 thresholds
+// (activity_dump.max_dump_size, anomaly_detection.unstable_profile_size_threshold) are
+// tuned against this number — any drift here shifts production V1 behavior silently.
+func TestApproximateSize_LegacyShallowSemantics(t *testing.T) {
 	tests := []struct {
 		name  string
 		stats Stats
@@ -164,21 +168,42 @@ func TestSizeBytes_FallbackUsesAllNodeTypes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, int64(0), tt.stats.SizeBytes)
 			assert.Greater(t, tt.stats.ApproximateSize(), int64(0),
-				"fallback path should contribute for %s", tt.name)
+				"every counted node type must contribute to ApproximateSize for %s", tt.name)
 		})
 	}
 }
 
-// TestSizeBytes_FallbackPrefersIncremental verifies that once SizeBytes is populated the
-// fallback path is skipped — incremental tracking is the source of truth.
-func TestSizeBytes_FallbackPrefersIncremental(t *testing.T) {
+// TestApproximateSize_IgnoresSizeBytes nails down V1's invariant: ApproximateSize never
+// consults SizeBytes, even when it's set. If a future refactor wires SizeBytes into
+// ApproximateSize, V1 max-size and unstable-threshold behavior would change without anyone
+// touching the V1 config knobs.
+func TestApproximateSize_IgnoresSizeBytes(t *testing.T) {
+	stats := Stats{ProcessNodes: 1, SizeBytes: 999999}
+	expected := int64(unsafe.Sizeof(ProcessNode{}))
+	assert.Equal(t, expected, stats.ApproximateSize(),
+		"ApproximateSize must stay on the legacy shallow path (count × unsafe.Sizeof)")
+}
+
+// TestHeapSize_PrefersIncremental verifies V2's accurate path: once SizeBytes is populated,
+// HeapSize returns it directly. Falls back to ApproximateSize only when SizeBytes is zero
+// (test fixtures, proto rehydration before recompute fires).
+func TestHeapSize_PrefersIncremental(t *testing.T) {
 	stats := Stats{
 		ProcessNodes: 1000, // would dominate the fallback
 		SizeBytes:    42,
 	}
-	assert.Equal(t, int64(42), stats.ApproximateSize())
+	assert.Equal(t, int64(42), stats.HeapSize())
+}
+
+// TestHeapSize_FallsBackToApproximateSize verifies V2's fallback: when SizeBytes hasn't
+// been populated yet, HeapSize must still produce a non-zero number so the V2 max-size
+// check and the profile_size metric stay useful until recomputeSizeBytes runs.
+func TestHeapSize_FallsBackToApproximateSize(t *testing.T) {
+	stats := Stats{ProcessNodes: 1}
+	require.Equal(t, int64(0), stats.SizeBytes)
+	assert.Equal(t, stats.ApproximateSize(), stats.HeapSize(),
+		"HeapSize must fall back to ApproximateSize when SizeBytes is unset")
 }
 
 // TestSizeBytes_IncrementalUndercountsByBoundedDrift documents the production design: the

--- a/pkg/security/security_profile/activity_tree/size_test.go
+++ b/pkg/security/security_profile/activity_tree/size_test.go
@@ -1,0 +1,296 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package activitytree holds activitytree related files
+package activitytree
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+// newSizeTestTree builds an ActivityTree via NewActivityTree (so the cookie cache and
+// SyscallsMask are wired up correctly — EvictImageTag panics otherwise) and the test
+// validator used by the rest of the suite.
+func newSizeTestTree() *ActivityTree {
+	return NewActivityTree(activityTreeInsertTestValidator{}, nil, "security_profile")
+}
+
+// newSizeTestProcessNode returns a ProcessNode populated enough that size() exercises every
+// branch in processStringsBytes — exec path, interpreter path, argv/envs, container, creds.
+func newSizeTestProcessNode(name string) *ProcessNode {
+	return &ProcessNode{
+		NodeBase:       NewNodeBase(),
+		Files:          map[string]*FileNode{},
+		DNSNames:       map[string]*DNSNode{},
+		IMDSEvents:     map[model.IMDSEvent]*IMDSNode{},
+		NetworkDevices: map[model.NetworkDeviceContext]*NetworkDeviceNode{},
+		Process: model.Process{
+			FileEvent: model.FileEvent{
+				PathnameStr: "/usr/bin/" + name,
+				BasenameStr: name,
+				Filesystem:  "ext4",
+				PkgName:     "coreutils",
+				PkgVersion:  "9.4",
+				Hashes:      []string{"sha256:deadbeef"},
+			},
+			LinuxBinprm: model.LinuxBinprm{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/usr/bin/python3",
+					BasenameStr: "python3",
+					Filesystem:  "ext4",
+					PkgName:     "python3",
+					PkgVersion:  "3.12",
+					Hashes:      []string{"sha256:cafef00d"},
+				},
+			},
+			Argv0:   name,
+			Comm:    name,
+			TTYName: "pts/0",
+			Argv:    []string{"--flag", "value"},
+			Envs:    []string{"PATH=/usr/bin"},
+			Envp:    []string{"HOME=/root"},
+			ContainerContext: model.ContainerContext{
+				ContainerID: containerutils.ContainerID("container-" + name),
+				Tags:        []string{"env:test", "service:" + name},
+			},
+			CGroup: model.CGroupContext{CGroupID: containerutils.CGroupID("cgroup-" + name)},
+			Credentials: model.Credentials{
+				User: "root", Group: "root",
+				EUser: "root", EGroup: "root",
+				FSUser: "root", FSGroup: "root",
+			},
+		},
+	}
+}
+
+// newFileOpenEvent returns the smallest event payload that drives InsertFileEvent.
+func newFileOpenEvent(path string) *model.Event {
+	return &model.Event{
+		BaseEvent: model.BaseEvent{FieldHandlers: &model.FakeFieldHandlers{}},
+		Open: model.OpenEvent{
+			File: model.FileEvent{IsPathnameStrResolved: true, PathnameStr: path},
+		},
+	}
+}
+
+func newDNSEvent(name string, qtype uint16) *model.Event {
+	return &model.Event{
+		BaseEvent: model.BaseEvent{FieldHandlers: &model.FakeFieldHandlers{}},
+		DNS: model.DNSEvent{
+			Question: model.DNSQuestion{Name: name, Type: qtype},
+		},
+	}
+}
+
+func newBindEvent(port uint16) *model.Event {
+	return &model.Event{
+		BaseEvent: model.BaseEvent{FieldHandlers: &model.FakeFieldHandlers{}},
+		Bind: model.BindEvent{
+			Addr:       model.IPPortContext{Port: port},
+			AddrFamily: unix.AF_INET,
+		},
+	}
+}
+
+// populateRichTree adds a varied mix of nodes to the tree using the public Insert*Event
+// methods so SizeBytes is updated incrementally. Returns the root ProcessNode for callers
+// that want to mutate it further.
+func populateRichTree(t *testing.T, tree *ActivityTree, tagID uint64) *ProcessNode {
+	t.Helper()
+	root := newSizeTestProcessNode("root")
+	root.AppendImageTagID(tagID, time.Now())
+	tree.ProcessNodes = []*ProcessNode{root}
+
+	for _, path := range []string{"/etc/passwd", "/var/log/syslog", "/tmp/a/b/c/d"} {
+		evt := newFileOpenEvent(path)
+		root.InsertFileEvent(&evt.Open.File, evt, tagID, Runtime, tree.Stats, false, nil, nil)
+	}
+
+	for _, name := range []string{"datadoghq.com", "example.org"} {
+		evt := newDNSEvent(name, 1)
+		root.InsertDNSEvent(evt, tagID, Runtime, tree.Stats, tree.DNSNames, false, 0)
+	}
+
+	for _, port := range []uint16{80, 443, 8080} {
+		evt := newBindEvent(port)
+		root.InsertBindEvent(evt, tagID, Runtime, tree.Stats, false)
+	}
+
+	child := newSizeTestProcessNode("child")
+	child.AppendImageTagID(tagID, time.Now())
+	child.Parent = root
+	root.Children = append(root.Children, child)
+	tree.Stats.ProcessNodes++
+	tree.Stats.SizeBytes += child.size()
+	return root
+}
+
+// TestSizeBytes_EmptyTree confirms an empty tree reports zero so the metric doesn't lie
+// when no profile data exists yet.
+func TestSizeBytes_EmptyTree(t *testing.T) {
+	tree := newSizeTestTree()
+	assert.Equal(t, int64(0), tree.Stats.SizeBytes)
+	assert.Equal(t, int64(0), tree.Stats.ApproximateSize())
+}
+
+// TestSizeBytes_FallbackUsesAllNodeTypes locks in the regression fix: when SizeBytes hasn't
+// been populated (proto rehydration, test fixtures), ApproximateSize must account for every
+// node type, not just ProcessNodes.
+func TestSizeBytes_FallbackUsesAllNodeTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		stats Stats
+	}{
+		{"process_only", Stats{ProcessNodes: 1}},
+		{"file_only", Stats{FileNodes: 10}},
+		{"dns_only", Stats{DNSNodes: 5}},
+		{"socket_only", Stats{SocketNodes: 3}},
+		{"imds_only", Stats{IMDSNodes: 2}},
+		{"syscall_only", Stats{SyscallNodes: 4}},
+		{"flow_only", Stats{FlowNodes: 7}},
+		{"capability_only", Stats{CapabilityNodes: 6}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, int64(0), tt.stats.SizeBytes)
+			assert.Greater(t, tt.stats.ApproximateSize(), int64(0),
+				"fallback path should contribute for %s", tt.name)
+		})
+	}
+}
+
+// TestSizeBytes_FallbackPrefersIncremental verifies that once SizeBytes is populated the
+// fallback path is skipped — incremental tracking is the source of truth.
+func TestSizeBytes_FallbackPrefersIncremental(t *testing.T) {
+	stats := Stats{
+		ProcessNodes: 1000, // would dominate the fallback
+		SizeBytes:    42,
+	}
+	assert.Equal(t, int64(42), stats.ApproximateSize())
+}
+
+// TestSizeBytes_IncrementalUndercountsByBoundedDrift documents the production design: the
+// incremental tracker undercounts slightly because slice/map backing-array growth on parent
+// containers isn't re-measured on each insert. recomputeSizeBytes is the source of truth and
+// is intentionally heavier. We assert (a) incremental <= recompute (never overshoots) and
+// (b) drift stays small relative to the total — if either condition breaks, an insert path
+// either started double-charging or stopped charging entirely.
+func TestSizeBytes_IncrementalUndercountsByBoundedDrift(t *testing.T) {
+	tree := newSizeTestTree()
+	tagID := tree.GetOrInsertImageTag("v1")
+	populateRichTree(t, tree, tagID)
+
+	incremental := tree.Stats.SizeBytes
+	tree.recomputeSizeBytes()
+	canonical := tree.Stats.SizeBytes
+
+	require.Greater(t, canonical, int64(0), "non-empty tree should report non-zero size")
+	assert.LessOrEqual(t, incremental, canonical,
+		"incremental tracker (%d) should never exceed recompute (%d) — that would mean an insert path double-charged",
+		incremental, canonical)
+	// Drift comes from parent-container growth (Children/Sockets/Bind slice cap doubling,
+	// Files/DNSNames/IMDSEvents map bucket overhead). It must stay a small fraction of the
+	// total or the metric stops being useful before recompute corrects it.
+	assert.Less(t, canonical-incremental, canonical/2,
+		"drift (%d) shouldn't exceed half the canonical size (%d)", canonical-incremental, canonical)
+}
+
+// TestSizeBytes_EvictImageTag_RecomputesToZero asserts the most important invariant for
+// the metric: once every tag is evicted and the tree is empty, recompute (the source of
+// truth) reports zero. The incremental tracker may carry a small residual from backing-array
+// growth not paid for at insert time — we let recompute reset it, which is how production
+// works (recompute runs on every ComputeActivityTreeStats).
+func TestSizeBytes_EvictImageTag_RecomputesToZero(t *testing.T) {
+	tree := newSizeTestTree()
+	tagID := tree.GetOrInsertImageTag("v1")
+	populateRichTree(t, tree, tagID)
+	require.Greater(t, tree.Stats.SizeBytes, int64(0))
+
+	tree.EvictImageTag("v1")
+
+	assert.Empty(t, tree.ProcessNodes, "every process node should have been evicted")
+	tree.recomputeSizeBytes()
+	assert.Equal(t, int64(0), tree.Stats.SizeBytes,
+		"recompute on an empty tree must yield zero (got %d) — anything else means recompute is leaking",
+		tree.Stats.SizeBytes)
+}
+
+// TestSizeBytes_EvictUnusedNodes_RecomputesToZero is the same invariant via the time-based
+// eviction path. Push the cutoff far into the future so every node is stale, then verify
+// recompute lands on zero.
+func TestSizeBytes_EvictUnusedNodes_RecomputesToZero(t *testing.T) {
+	tree := newSizeTestTree()
+	tagID := tree.GetOrInsertImageTag("v1")
+	populateRichTree(t, tree, tagID)
+	require.Greater(t, tree.Stats.SizeBytes, int64(0))
+
+	tree.EvictUnusedNodes(time.Now().Add(24*time.Hour), nil, "test-image", "v1")
+
+	assert.Empty(t, tree.ProcessNodes, "every process node should have been evicted")
+	tree.recomputeSizeBytes()
+	assert.Equal(t, int64(0), tree.Stats.SizeBytes,
+		"recompute on an empty tree must yield zero (got %d)", tree.Stats.SizeBytes)
+}
+
+// TestSizeBytes_DNSAppendChargesIncrementally locks in the invariant that adding a second
+// query type to an existing DNSNode (which appends to dnsNode.Requests rather than
+// allocating a new node) updates Stats.SizeBytes. The append path uses a before/after
+// snapshot of dnsNode.size() — if a refactor drops that snapshot, recompute would diverge
+// from incremental and eviction would over-subtract, causing the metric to drift negative.
+// See process_node.go InsertDNSEvent for the snapshot.
+func TestSizeBytes_DNSAppendChargesIncrementally(t *testing.T) {
+	tree := newSizeTestTree()
+	tagID := tree.GetOrInsertImageTag("v1")
+	root := newSizeTestProcessNode("root")
+	root.AppendImageTagID(tagID, time.Now())
+	tree.ProcessNodes = []*ProcessNode{root}
+
+	// First request: creates the DNSNode.
+	first := newDNSEvent("api.datadoghq.com", 1) // A record
+	root.InsertDNSEvent(first, tagID, Runtime, tree.Stats, tree.DNSNames, false, 0)
+	sizeAfterFirst := tree.Stats.SizeBytes
+	require.Greater(t, sizeAfterFirst, int64(0))
+
+	// Second request for the same name but a different type: appends to dnsNode.Requests.
+	// The new Question.Name length plus any slice-cap growth must show up in SizeBytes.
+	second := newDNSEvent("api.datadoghq.com", 28) // AAAA record
+	root.InsertDNSEvent(second, tagID, Runtime, tree.Stats, tree.DNSNames, false, 0)
+	sizeAfterSecond := tree.Stats.SizeBytes
+
+	assert.Greater(t, sizeAfterSecond, sizeAfterFirst,
+		"appending a second DNS request (different type, same name) must grow Stats.SizeBytes — "+
+			"otherwise recompute will diverge and eviction will over-subtract")
+
+	// Recompute is the ground truth; incremental must still track within bounded drift.
+	tree.recomputeSizeBytes()
+	assert.LessOrEqual(t, sizeAfterSecond, tree.Stats.SizeBytes,
+		"incremental (%d) should not exceed recompute (%d) after the append",
+		sizeAfterSecond, tree.Stats.SizeBytes)
+}
+
+// TestSizeBytes_RecomputeIsIdempotent: calling recomputeSizeBytes twice on the same tree
+// must produce the same number. Guards against accidental += instead of = in recompute.
+func TestSizeBytes_RecomputeIsIdempotent(t *testing.T) {
+	tree := newSizeTestTree()
+	tagID := tree.GetOrInsertImageTag("v1")
+	populateRichTree(t, tree, tagID)
+
+	tree.recomputeSizeBytes()
+	first := tree.Stats.SizeBytes
+	tree.recomputeSizeBytes()
+	second := tree.Stats.SizeBytes
+
+	assert.Equal(t, first, second, "recomputeSizeBytes must be idempotent")
+}

--- a/pkg/security/security_profile/activity_tree/size_util.go
+++ b/pkg/security/security_profile/activity_tree/size_util.go
@@ -1,0 +1,124 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package activitytree holds activitytree related files
+package activitytree
+
+import (
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+// These helpers exist so each node's size() can approximate its real heap footprint
+// (backing arrays, map buckets, string content) instead of only the shallow struct size.
+// The result is still an estimate — Go does not expose map bucket sizes — but it tracks
+// real RAM usage closely enough to drive the `ActivityDumpMaxDumpSize` budget and the
+// per-profile `storage:ram` metric without lying to operators.
+//
+// Constants here are intentionally conservative: when in doubt we round up so the
+// metric overshoots a little rather than undershooting by 5-10x.
+const (
+	stringHeaderBytes = int64(unsafe.Sizeof(""))
+	// mapHeaderBytes approximates the runtime.hmap struct (count, flags, hash0, buckets pointer, ...).
+	mapHeaderBytes = int64(48)
+	// mapPerEntryBytes accounts for bucket+tophash+padding overhead Go layers on top of K+V.
+	// Real value depends on bucket fill but ~16 bytes per entry is a reasonable middle ground.
+	mapPerEntryBytes = int64(16)
+)
+
+// stringSliceBytes returns the heap bytes used by a []string: backing array slots + content.
+func stringSliceBytes(ss []string) int64 {
+	if cap(ss) == 0 {
+		return 0
+	}
+	n := int64(cap(ss)) * stringHeaderBytes
+	for _, s := range ss {
+		n += int64(len(s))
+	}
+	return n
+}
+
+// stringMapBytes approximates the heap used by a map[string]V where V is a pointer.
+// Each entry pays for the key string header+content and a pointer-sized value slot.
+func stringMapBytes[V any](m map[string]V) int64 {
+	if len(m) == 0 {
+		return 0
+	}
+	valSize := int64(unsafe.Sizeof(*new(V)))
+	n := mapHeaderBytes + int64(len(m))*(stringHeaderBytes+valSize+mapPerEntryBytes)
+	for k := range m {
+		n += int64(len(k))
+	}
+	return n
+}
+
+// fixedKeyMapBytes approximates the heap used by a map with a fixed-size key (struct or
+// scalar — no heap pointers in K). Used for maps keyed by e.g. model.IMDSEvent or
+// model.FiveTuple where the key has no allocated content.
+func fixedKeyMapBytes[K comparable, V any](m map[K]V) int64 {
+	if len(m) == 0 {
+		return 0
+	}
+	keySize := int64(unsafe.Sizeof(*new(K)))
+	valSize := int64(unsafe.Sizeof(*new(V)))
+	return mapHeaderBytes + int64(len(m))*(keySize+valSize+mapPerEntryBytes)
+}
+
+// sliceBackingBytes returns the heap bytes used by a slice's backing array, excluding
+// anything the elements themselves point at. Pass `unsafe.Sizeof(elem)` for the element size.
+func sliceBackingBytes(slcCap int, elemSize uintptr) int64 {
+	return int64(slcCap) * int64(elemSize)
+}
+
+// seenBytes returns the heap bytes used by a NodeBase's seen slice.
+func seenBytes(b NodeBase) int64 {
+	return int64(cap(b.seen)) * int64(unsafe.Sizeof(seenEntry{}))
+}
+
+// fileEventStringsBytes counts every heap-allocated string carried by a model.FileEvent
+// (path/basename/filesystem/package metadata + hashes backing). Shared by the main exec
+// FileEvent and the LinuxBinprm interpreter FileEvent so both contribute the same way.
+func fileEventStringsBytes(fe *model.FileEvent) int64 {
+	var n int64
+	n += int64(len(fe.PathnameStr))
+	n += int64(len(fe.BasenameStr))
+	n += int64(len(fe.Filesystem))
+	n += int64(len(fe.PkgName))
+	n += int64(len(fe.PkgVersion))
+	n += stringSliceBytes(fe.Hashes)
+	return n
+}
+
+// processStringsBytes counts the major string allocations on a model.Process. These are
+// the fields that actually consume non-trivial heap on long-running workloads — full argv,
+// env vars, container tags, credentials labels, etc. — and that the previous shallow
+// size() ignored.
+func processStringsBytes(p *model.Process) int64 {
+	var n int64
+	n += fileEventStringsBytes(&p.FileEvent)
+	n += fileEventStringsBytes(&p.LinuxBinprm.FileEvent)
+
+	n += int64(len(p.Argv0))
+	n += int64(len(p.Comm))
+	n += int64(len(p.TTYName))
+	n += stringSliceBytes(p.Argv)
+	n += stringSliceBytes(p.Envs)
+	n += stringSliceBytes(p.Envp)
+
+	n += int64(len(p.ContainerContext.ContainerID))
+	n += stringSliceBytes(p.ContainerContext.Tags)
+	n += int64(len(p.CGroup.CGroupID))
+
+	n += int64(len(p.Credentials.User))
+	n += int64(len(p.Credentials.Group))
+	n += int64(len(p.Credentials.EUser))
+	n += int64(len(p.Credentials.EGroup))
+	n += int64(len(p.Credentials.FSUser))
+	n += int64(len(p.Credentials.FSGroup))
+	return n
+}

--- a/pkg/security/security_profile/activity_tree/socket_node.go
+++ b/pkg/security/security_profile/activity_tree/socket_node.go
@@ -35,10 +35,25 @@ type SocketNode struct {
 	Bind           []*BindNode
 }
 
-// size returns the shallow heap size of this node.
+// size approximates this node's heap footprint, including all owned BindNodes.
+// Unlike the *Node siblings, SocketNode's children (BindNodes) are not separately walked
+// by the activity-tree size accounting, so they are folded in here. We count the Bind
+// slice's backing array plus each BindNode's struct, IP string, MatchedRules backing
+// array, and NodeBase.seen slice.
 func (sn *SocketNode) size() int64 {
 	s := int64(unsafe.Sizeof(*sn))
+	s += seenBytes(sn.NodeBase)
 	s += int64(len(sn.Family))
+	s += sliceBackingBytes(cap(sn.Bind), unsafe.Sizeof((*BindNode)(nil)))
+	for _, bind := range sn.Bind {
+		if bind == nil {
+			continue
+		}
+		s += int64(unsafe.Sizeof(*bind))
+		s += seenBytes(bind.NodeBase)
+		s += int64(len(bind.IP))
+		s += sliceBackingBytes(cap(bind.MatchedRules), unsafe.Sizeof((*model.MatchedRule)(nil)))
+	}
 	return s
 }
 

--- a/pkg/security/security_profile/activity_tree/socket_node.go
+++ b/pkg/security/security_profile/activity_tree/socket_node.go
@@ -9,6 +9,8 @@
 package activitytree
 
 import (
+	"unsafe"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
@@ -31,6 +33,13 @@ type SocketNode struct {
 	Family         string
 	GenerationType NodeGenerationType
 	Bind           []*BindNode
+}
+
+// size returns the shallow heap size of this node.
+func (sn *SocketNode) size() int64 {
+	s := int64(unsafe.Sizeof(*sn))
+	s += int64(len(sn.Family))
+	return s
 }
 
 // Matches returns true if BindNodes matches

--- a/pkg/security/security_profile/activity_tree/socket_node.go
+++ b/pkg/security/security_profile/activity_tree/socket_node.go
@@ -36,24 +36,31 @@ type SocketNode struct {
 }
 
 // size approximates this node's heap footprint, including all owned BindNodes.
-// Unlike the *Node siblings, SocketNode's children (BindNodes) are not separately walked
-// by the activity-tree size accounting, so they are folded in here. We count the Bind
-// slice's backing array plus each BindNode's struct, IP string, MatchedRules backing
-// array, and NodeBase.seen slice.
+// SocketNode's children (BindNodes) are not separately walked by the activity-tree
+// size accounting (recomputeSizeBytes/processNodeOwnActivitySize), so they are folded
+// in here. Incremental insert/evict paths must use bindSize() for individual binds
+// and only charge sn.size() at socket creation time.
 func (sn *SocketNode) size() int64 {
 	s := int64(unsafe.Sizeof(*sn))
 	s += seenBytes(sn.NodeBase)
 	s += int64(len(sn.Family))
 	s += sliceBackingBytes(cap(sn.Bind), unsafe.Sizeof((*BindNode)(nil)))
 	for _, bind := range sn.Bind {
-		if bind == nil {
-			continue
-		}
-		s += int64(unsafe.Sizeof(*bind))
-		s += seenBytes(bind.NodeBase)
-		s += int64(len(bind.IP))
-		s += sliceBackingBytes(cap(bind.MatchedRules), unsafe.Sizeof((*model.MatchedRule)(nil)))
+		s += bindSize(bind)
 	}
+	return s
+}
+
+// bindSize approximates the heap footprint of a single BindNode: struct overhead, the
+// IP string, the MatchedRules backing slice, and the NodeBase.seen slice.
+func bindSize(bn *BindNode) int64 {
+	if bn == nil {
+		return 0
+	}
+	s := int64(unsafe.Sizeof(*bn))
+	s += seenBytes(bn.NodeBase)
+	s += int64(len(bn.IP))
+	s += sliceBackingBytes(cap(bn.MatchedRules), unsafe.Sizeof((*model.MatchedRule)(nil)))
 	return s
 }
 
@@ -67,22 +74,29 @@ func (sn *SocketNode) Matches(toMatch *SocketNode) bool {
 	return sn.Family == toMatch.Family
 }
 
-func (sn *SocketNode) evictImageTag(imageTagID uint64) bool {
-	newBind := []*BindNode{}
+// evictImageTag removes the imageTag from each owned BindNode, dropping binds that have
+// no remaining tags. Returns (socketIsEmpty, bytesRemoved) where bytesRemoved is the sum
+// of bindSize() for every dropped BindNode — the caller subtracts this from Stats.SizeBytes
+// and additionally subtracts sn.size() if the socket itself ends up empty.
+func (sn *SocketNode) evictImageTag(imageTagID uint64) (bool, int64) {
+	var removed int64
+	newBind := sn.Bind[:0]
 	for _, bind := range sn.Bind {
-		if shouldRemoveNode := bind.EvictImageTag(imageTagID); !shouldRemoveNode {
-			newBind = append(newBind, bind)
+		if bind.EvictImageTag(imageTagID) {
+			removed += bindSize(bind)
+			continue
 		}
-	}
-	if len(newBind) == 0 {
-		return true
+		newBind = append(newBind, bind)
 	}
 	sn.Bind = newBind
-	return false
+	return len(newBind) == 0, removed
 }
 
-// InsertBindEvent inserts a bind even inside a socket node
-func (sn *SocketNode) InsertBindEvent(evt *model.BindEvent, event *model.Event, imageTagID uint64, generationType NodeGenerationType, rules []*model.MatchedRule, dryRun bool) bool {
+// InsertBindEvent inserts a bind event inside a socket node. When a new BindNode is
+// created the caller-provided stats is charged its size, keeping Stats.SizeBytes honest
+// for bind-heavy workloads where the previous accounting only charged the socket once
+// at creation time and ignored subsequent binds.
+func (sn *SocketNode) InsertBindEvent(evt *model.BindEvent, event *model.Event, imageTagID uint64, generationType NodeGenerationType, rules []*model.MatchedRule, stats *Stats, dryRun bool) bool {
 	evtIP := utils.GetIPStringFromIPNet(evt.Addr.IPNet)
 	for _, n := range sn.Bind {
 		if evt.Addr.Port == n.Port && evtIP == n.IP && evt.Protocol == n.Protocol {
@@ -110,6 +124,9 @@ func (sn *SocketNode) InsertBindEvent(evt *model.BindEvent, event *model.Event, 
 
 		node.AppendImageTagID(imageTagID, event.ResolveEventTime())
 		sn.Bind = append(sn.Bind, node)
+		if stats != nil {
+			stats.SizeBytes += bindSize(node)
+		}
 	}
 	return true
 }

--- a/pkg/security/security_profile/activity_tree/socket_node.go
+++ b/pkg/security/security_profile/activity_tree/socket_node.go
@@ -80,6 +80,8 @@ func (sn *SocketNode) Matches(toMatch *SocketNode) bool {
 // and additionally subtracts sn.size() if the socket itself ends up empty.
 func (sn *SocketNode) evictImageTag(imageTagID uint64) (bool, int64) {
 	var removed int64
+	// Filter in place, then clear the tail so we don't pin evicted *BindNode pointers in the
+	// backing array (they'd otherwise stay alive until the SocketNode itself is GC'd).
 	newBind := sn.Bind[:0]
 	for _, bind := range sn.Bind {
 		if bind.EvictImageTag(imageTagID) {
@@ -88,6 +90,7 @@ func (sn *SocketNode) evictImageTag(imageTagID uint64) (bool, int64) {
 		}
 		newBind = append(newBind, bind)
 	}
+	clear(sn.Bind[len(newBind):])
 	sn.Bind = newBind
 	return len(newBind) == 0, removed
 }
@@ -95,7 +98,8 @@ func (sn *SocketNode) evictImageTag(imageTagID uint64) (bool, int64) {
 // InsertBindEvent inserts a bind event inside a socket node. When a new BindNode is
 // created the caller-provided stats is charged its size, keeping Stats.SizeBytes honest
 // for bind-heavy workloads where the previous accounting only charged the socket once
-// at creation time and ignored subsequent binds.
+// at creation time and ignored subsequent binds. stats must be non-nil — same contract as
+// every other Insert*Event method.
 func (sn *SocketNode) InsertBindEvent(evt *model.BindEvent, event *model.Event, imageTagID uint64, generationType NodeGenerationType, rules []*model.MatchedRule, stats *Stats, dryRun bool) bool {
 	evtIP := utils.GetIPStringFromIPNet(evt.Addr.IPNet)
 	for _, n := range sn.Bind {
@@ -124,9 +128,7 @@ func (sn *SocketNode) InsertBindEvent(evt *model.BindEvent, event *model.Event, 
 
 		node.AppendImageTagID(imageTagID, event.ResolveEventTime())
 		sn.Bind = append(sn.Bind, node)
-		if stats != nil {
-			stats.SizeBytes += bindSize(node)
-		}
+		stats.SizeBytes += bindSize(node)
 	}
 	return true
 }

--- a/pkg/security/security_profile/activity_tree/syscalls_node.go
+++ b/pkg/security/security_profile/activity_tree/syscalls_node.go
@@ -20,9 +20,10 @@ type SyscallNode struct {
 	Syscall        int
 }
 
-// size returns the shallow heap size of this node.
+// size approximates this node's heap footprint: struct overhead plus the NodeBase.seen
+// backing slice. No other heap-allocated fields.
 func (sn *SyscallNode) size() int64 {
-	return int64(unsafe.Sizeof(*sn))
+	return int64(unsafe.Sizeof(*sn)) + seenBytes(sn.NodeBase)
 }
 
 // NewSyscallNode returns a new SyscallNode instance

--- a/pkg/security/security_profile/activity_tree/syscalls_node.go
+++ b/pkg/security/security_profile/activity_tree/syscalls_node.go
@@ -10,6 +10,7 @@ package activitytree
 
 import (
 	"time"
+	"unsafe"
 )
 
 // SyscallNode is used to store a syscall node
@@ -17,6 +18,11 @@ type SyscallNode struct {
 	NodeBase
 	GenerationType NodeGenerationType
 	Syscall        int
+}
+
+// size returns the shallow heap size of this node.
+func (sn *SyscallNode) size() int64 {
+	return int64(unsafe.Sizeof(*sn))
 }
 
 // NewSyscallNode returns a new SyscallNode instance

--- a/pkg/security/security_profile/manager_test.go
+++ b/pkg/security/security_profile/manager_test.go
@@ -952,8 +952,24 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 		},
 	}
 
+	// syncSizeBytes derives Stats.SizeBytes from ProcessNodes so the fixtures still drive
+	// ApproximateSize() the way they used to before it was switched to read SizeBytes directly.
+	syncSizeBytes := func(dumps ...[]*dump.ActivityDump) {
+		nodeSize := int64(unsafe.Sizeof(activity_tree.ProcessNode{}))
+		for _, list := range dumps {
+			for _, d := range list {
+				if d.Profile == nil || d.Profile.ActivityTree == nil || d.Profile.ActivityTree.Stats == nil {
+					continue
+				}
+				d.Profile.ActivityTree.Stats.SizeBytes = d.Profile.ActivityTree.Stats.ProcessNodes * nodeSize
+			}
+		}
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			syncSizeBytes(tt.fields.activeDumps, tt.overweightDumps, tt.activeDumps)
+
 			adm := &Manager{
 				activeDumps: tt.fields.activeDumps,
 				config: &config.Config{
@@ -1802,6 +1818,9 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 				secprof.LoadedNano.Store(uint64(t0.UnixNano()))
 			}
 			secprof.ActivityTree.Stats.ProcessNodes += ti.addFakeProcessNodes
+			// keep SizeBytes in sync with ProcessNodes: ApproximateSize() now reads SizeBytes directly
+			// instead of recomputing from per-node counts.
+			secprof.ActivityTree.Stats.SizeBytes += ti.addFakeProcessNodes * int64(unsafe.Sizeof(activity_tree.ProcessNode{}))
 			ctx := secprof.GetVersionContextIndex(0)
 			if ctx == nil {
 				t.Fatal(errors.New("profile should have one ctx"))

--- a/pkg/security/security_profile/manager_test.go
+++ b/pkg/security/security_profile/manager_test.go
@@ -952,24 +952,8 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 		},
 	}
 
-	// syncSizeBytes derives Stats.SizeBytes from ProcessNodes so the fixtures still drive
-	// ApproximateSize() the way they used to before it was switched to read SizeBytes directly.
-	syncSizeBytes := func(dumps ...[]*dump.ActivityDump) {
-		nodeSize := int64(unsafe.Sizeof(activity_tree.ProcessNode{}))
-		for _, list := range dumps {
-			for _, d := range list {
-				if d.Profile == nil || d.Profile.ActivityTree == nil || d.Profile.ActivityTree.Stats == nil {
-					continue
-				}
-				d.Profile.ActivityTree.Stats.SizeBytes = d.Profile.ActivityTree.Stats.ProcessNodes * nodeSize
-			}
-		}
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			syncSizeBytes(tt.fields.activeDumps, tt.overweightDumps, tt.activeDumps)
-
 			adm := &Manager{
 				activeDumps: tt.fields.activeDumps,
 				config: &config.Config{
@@ -1818,9 +1802,6 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 				secprof.LoadedNano.Store(uint64(t0.UnixNano()))
 			}
 			secprof.ActivityTree.Stats.ProcessNodes += ti.addFakeProcessNodes
-			// keep SizeBytes in sync with ProcessNodes: ApproximateSize() now reads SizeBytes directly
-			// instead of recomputing from per-node counts.
-			secprof.ActivityTree.Stats.SizeBytes += ti.addFakeProcessNodes * int64(unsafe.Sizeof(activity_tree.ProcessNode{}))
 			ctx := secprof.GetVersionContextIndex(0)
 			if ctx == nil {
 				t.Fatal(errors.New("profile should have one ctx"))

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -609,8 +609,8 @@ func (m *ManagerV2) SendStats() error {
 	m.profilesLock.Lock()
 	for selector, p := range m.profiles {
 		tags := []string{
-			"image_name:" + selector.Image,
-			"image_tag:" + selector.Tag,
+			"profile_image_name:" + selector.Image,
+			"profile_image_tag:" + selector.Tag,
 			"storage:ram",
 		}
 		if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileV2ProfileSize, float64(p.ComputeInMemorySize()), tags, 1.0); err != nil {
@@ -622,8 +622,8 @@ func (m *ManagerV2) SendStats() error {
 
 	for selector, size := range diskSizes {
 		tags := []string{
-			"image_name:" + selector.Image,
-			"image_tag:" + selector.Tag,
+			"profile_image_name:" + selector.Image,
+			"profile_image_tag:" + selector.Tag,
 			"storage:disk",
 		}
 		if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileV2ProfileSize, float64(size), tags, 1.0); err != nil {

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -604,8 +604,8 @@ func (m *ManagerV2) SendStats() error {
 	}
 
 	// Per-profile size (RAM and disk reported under the same metric, differentiated by storage tag).
-	// Snapshot the active-profiles map under the lock and then call ComputeInMemorySize / statsd
-	// outside it — ComputeInMemorySize takes the per-profile lock, and we don't want to hold
+	// Snapshot the active-profiles map under the lock and then call ComputeHeapSize / statsd
+	// outside it — ComputeHeapSize takes the per-profile lock, and we don't want to hold
 	// profilesLock across that or across the statsd send.
 	type profileEntry struct {
 		selector cgroupModel.WorkloadSelector
@@ -624,7 +624,7 @@ func (m *ManagerV2) SendStats() error {
 			"profile_image_tag:" + entry.selector.Tag,
 			"storage:ram",
 		}
-		if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileV2ProfileSize, float64(entry.profile.ComputeInMemorySize()), tags, 1.0); err != nil {
+		if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileV2ProfileSize, float64(entry.profile.ComputeHeapSize()), tags, 1.0); err != nil {
 			return err
 		}
 	}
@@ -682,9 +682,11 @@ func (m *ManagerV2) insertEventIntoProfile(event *model.Event) (*profile.Profile
 	workload := m.getOrCreateWorkload(event, selector, workloadID)
 	m.linkWorkloadToProfile(secprof, workload)
 
-	// Check if profile has reached max size
+	// Check if profile has reached max size. V2 uses its own knob evaluated against the
+	// accurate heap footprint — V1's activity_dump.max_dump_size keeps its legacy shallow
+	// semantics for ActivityDump/legacy Manager paths.
 	// TODO: we should handle this in a better way
-	if secprof.ActivityTree.Stats.ApproximateSize() >= int64(m.config.RuntimeSecurity.ActivityDumpMaxDumpSize()) {
+	if secprof.ActivityTree.Stats.HeapSize() >= int64(m.config.RuntimeSecurity.SecurityProfileV2MaxDumpSize()) {
 		m.incrementEventFilteringStat(event.GetEventType(), model.ProfileAtMaxSize, NA)
 		m.eventsDroppedMaxSize.Inc()
 		return nil, false

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -603,19 +603,33 @@ func (m *ManagerV2) SendStats() error {
 		}
 	}
 
-	// Per-profile in-memory size
+	// Per-profile size (RAM and disk reported under the same metric, differentiated by storage tag)
+	diskSizes := m.localStorage.SizesBySelector()
+
 	m.profilesLock.Lock()
 	for selector, p := range m.profiles {
 		tags := []string{
 			"image_name:" + selector.Image,
 			"image_tag:" + selector.Tag,
+			"storage:ram",
 		}
-		if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileV2ProfileInMemorySize, float64(p.ComputeInMemorySize()), tags, 1.0); err != nil {
+		if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileV2ProfileSize, float64(p.ComputeInMemorySize()), tags, 1.0); err != nil {
 			m.profilesLock.Unlock()
 			return err
 		}
 	}
 	m.profilesLock.Unlock()
+
+	for selector, size := range diskSizes {
+		tags := []string{
+			"image_name:" + selector.Image,
+			"image_tag:" + selector.Tag,
+			"storage:disk",
+		}
+		if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileV2ProfileSize, float64(size), tags, 1.0); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -603,6 +603,20 @@ func (m *ManagerV2) SendStats() error {
 		}
 	}
 
+	// Per-profile in-memory size
+	m.profilesLock.Lock()
+	for selector, p := range m.profiles {
+		tags := []string{
+			"image_name:" + selector.Image,
+			"image_tag:" + selector.Tag,
+		}
+		if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileV2ProfileInMemorySize, float64(p.ComputeInMemorySize()), tags, 1.0); err != nil {
+			m.profilesLock.Unlock()
+			return err
+		}
+	}
+	m.profilesLock.Unlock()
+
 	return nil
 }
 

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -838,7 +838,8 @@ func (m *ManagerV2) loadProfileFromStorage(selector cgroupModel.WorkloadSelector
 		return nil, false
 	}
 
-	// Profile was loaded successfully
+	// Profile was loaded successfully; recompute stats so SizeBytes reflects the loaded tree.
+	secprof.ActivityTree.ComputeActivityTreeStats()
 	secprof.SetTreeType(secprof, "security_profile")
 
 	// Update metadata with current event context for proper matching

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -603,24 +603,38 @@ func (m *ManagerV2) SendStats() error {
 		}
 	}
 
-	// Per-profile size (RAM and disk reported under the same metric, differentiated by storage tag)
-	diskSizes := m.localStorage.SizesBySelector()
-
+	// Per-profile size (RAM and disk reported under the same metric, differentiated by storage tag).
+	// Snapshot the active-profiles map under the lock and then call ComputeInMemorySize / statsd
+	// outside it — ComputeInMemorySize takes the per-profile lock, and we don't want to hold
+	// profilesLock across that or across the statsd send.
+	type profileEntry struct {
+		selector cgroupModel.WorkloadSelector
+		profile  *profile.Profile
+	}
 	m.profilesLock.Lock()
+	ramEntries := make([]profileEntry, 0, len(m.profiles))
 	for selector, p := range m.profiles {
-		tags := []string{
-			"profile_image_name:" + selector.Image,
-			"profile_image_tag:" + selector.Tag,
-			"storage:ram",
-		}
-		if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileV2ProfileSize, float64(p.ComputeInMemorySize()), tags, 1.0); err != nil {
-			m.profilesLock.Unlock()
-			return err
-		}
+		ramEntries = append(ramEntries, profileEntry{selector: selector, profile: p})
 	}
 	m.profilesLock.Unlock()
 
-	for selector, size := range diskSizes {
+	for _, entry := range ramEntries {
+		tags := []string{
+			"profile_image_name:" + entry.selector.Image,
+			"profile_image_tag:" + entry.selector.Tag,
+			"storage:ram",
+		}
+		if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileV2ProfileSize, float64(entry.profile.ComputeInMemorySize()), tags, 1.0); err != nil {
+			return err
+		}
+	}
+
+	for selector, size := range m.localStorage.SizesBySelector() {
+		// Skip entries with an unresolved selector: the on-disk file is tracked for cleanup
+		// but emitting metrics with empty image/tag tags pollutes cardinality without adding signal.
+		if !selector.IsReady() {
+			continue
+		}
 		tags := []string{
 			"profile_image_name:" + selector.Image,
 			"profile_image_tag:" + selector.Tag,

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -279,11 +279,22 @@ func (p *Profile) Insert(event *model.Event, insertMissingProcesses bool, imageT
 	return p.ActivityTree.Insert(event, insertMissingProcesses, imageTag, generationType, resolvers)
 }
 
-// ComputeInMemorySize returns the size of a dump in memory
+// ComputeInMemorySize returns the legacy shallow size estimate of the profile in memory
+// (node counts × struct header sizes). Kept for V1 (legacy Manager / ActivityDump) which
+// has tuned its thresholds against this number — do not change its semantics.
 func (p *Profile) ComputeInMemorySize() int64 {
 	p.Lock()
 	defer p.Unlock()
 	return p.ActivityTree.Stats.ApproximateSize()
+}
+
+// ComputeHeapSize returns the profile's incrementally-tracked real heap footprint in
+// bytes (strings, slice backings, map buckets, struct headers). V2 uses this for its
+// max-size check and the profile_size metric.
+func (p *Profile) ComputeHeapSize() int64 {
+	p.Lock()
+	defer p.Unlock()
+	return p.ActivityTree.Stats.HeapSize()
 }
 
 // FakeOverweight fakes an overweight profile

--- a/pkg/security/security_profile/storage/directory.go
+++ b/pkg/security/security_profile/storage/directory.go
@@ -62,9 +62,33 @@ func createDir(dir string) error {
 	return nil
 }
 
-func fileHasProfileExtension(path string) bool {
-	format, err := config.ParseStorageFormat(filepath.Ext(path))
-	return err == nil && format == config.Profile
+// fileHasKnownStorageExtension returns true when the file extension matches any of the
+// configured storage formats. The Directory needs to track every persisted format so that
+// LRU eviction (which deletes files from disk) and the per-selector disk metric remain
+// accurate regardless of which format is configured.
+func fileHasKnownStorageExtension(path string) bool {
+	_, err := config.ParseStorageFormat(filepath.Ext(path))
+	return err == nil
+}
+
+// pickProfileFile returns the file path best suited to decode back into a Profile.
+// .profile is preferred because the SecurityProfile proto round-trips the selector
+// directly; the other formats (SecDump) only carry it indirectly through tags.
+func pickProfileFile(paths []string) string {
+	var fallback string
+	for _, path := range paths {
+		format, err := config.ParseStorageFormat(filepath.Ext(path))
+		if err != nil {
+			continue
+		}
+		if format == config.Profile {
+			return path
+		}
+		if fallback == "" {
+			fallback = path
+		}
+	}
+	return fallback
 }
 
 type profileFile struct {
@@ -103,7 +127,7 @@ func NewDirectory(directoryPath string, maxProfiles int) (*Directory, error) {
 
 	var fileSlice []*profileFile
 	for _, file := range files {
-		if !fileHasProfileExtension(file.Name()) {
+		if !fileHasKnownStorageExtension(file.Name()) {
 			continue
 		}
 
@@ -134,22 +158,23 @@ func NewDirectory(directoryPath string, maxProfiles int) (*Directory, error) {
 	})
 
 	for _, file := range fileSlice {
-		pProto, err := profile.LoadProtoFromFile(file.path)
-		if err != nil {
+		p := profile.New()
+		if err := p.Decode(file.path); err != nil {
 			seclog.Warnf("failed to load profile from file [%s]: %s", file.path, err)
 			continue
 		}
-		if pProto.Metadata == nil {
+		if p.Metadata.Name == "" {
 			seclog.Warnf("profile loaded from file [%s] has no metadata", file.path)
 			continue
 		}
-		if pProto.Selector == nil {
+		selector := p.GetWorkloadSelector()
+		if selector == nil {
 			seclog.Warnf("profile loaded from file [%s] has no selector", file.path)
 			continue
 		}
 
-		profiles.Add(pProto.Metadata.Name, &profileEntry{
-			selector:  cgroupModel.ProtoToWorkloadSelector(pProto.Selector),
+		profiles.Add(p.Metadata.Name, &profileEntry{
+			selector:  *selector,
 			filePaths: []string{file.path},
 		})
 	}
@@ -238,18 +263,21 @@ func (d *Directory) Load(wls *cgroupModel.WorkloadSelector, p *profile.Profile) 
 	defer d.profilesLock.RUnlock()
 
 	for _, entry := range d.profiles.Values() {
-		if entry.selector.Match(*wls) {
-			for _, file := range entry.filePaths {
-				if !fileHasProfileExtension(file) {
-					continue
-				}
-
-				if err := p.Decode(file); err != nil {
-					return false, fmt.Errorf("failed to decode profile [%s]: %s", file, err)
-				}
-				return true, nil
-			}
+		if !entry.selector.Match(*wls) {
+			continue
 		}
+
+		// Prefer the .profile format because it round-trips the selector explicitly via the
+		// SecurityProfile proto. Other formats (json/protobuf/dot) encode SecDump, which only
+		// preserves the selector indirectly through tags.
+		chosen := pickProfileFile(entry.filePaths)
+		if chosen == "" {
+			continue
+		}
+		if err := p.Decode(chosen); err != nil {
+			return false, fmt.Errorf("failed to decode profile [%s]: %s", chosen, err)
+		}
+		return true, nil
 	}
 
 	return false, nil

--- a/pkg/security/security_profile/storage/directory.go
+++ b/pkg/security/security_profile/storage/directory.go
@@ -260,6 +260,25 @@ func (d *Directory) GetStorageType() config.StorageType {
 	return config.LocalStorage
 }
 
+// SizesBySelector returns the on-disk size in bytes of each stored profile, keyed by workload selector.
+// Multiple file formats for the same selector are summed together.
+func (d *Directory) SizesBySelector() map[cgroupModel.WorkloadSelector]int64 {
+	d.profilesLock.RLock()
+	defer d.profilesLock.RUnlock()
+
+	result := make(map[cgroupModel.WorkloadSelector]int64, d.profiles.Len())
+	for _, entry := range d.profiles.Values() {
+		var size int64
+		for _, filePath := range entry.filePaths {
+			if info, err := os.Stat(filePath); err == nil {
+				size += info.Size()
+			}
+		}
+		result[entry.selector] += size
+	}
+	return result
+}
+
 // SendTelemetry sends telemetry for the current storage
 func (d *Directory) SendTelemetry(sender statsd.ClientInterface) {
 	d.profilesLock.RLock()

--- a/pkg/security/security_profile/storage/directory.go
+++ b/pkg/security/security_profile/storage/directory.go
@@ -279,6 +279,31 @@ func (d *Directory) SizesBySelector() map[cgroupModel.WorkloadSelector]int64 {
 	return result
 }
 
+// totalSizeOnDisk scans the directory and sums the size of every file with a known storage format
+// extension. Used for the aggregate disk-usage metric because the LRU only tracks the primary
+// .profile files even when other formats (e.g. .json) are configured and persisted alongside.
+func (d *Directory) totalSizeOnDisk() int64 {
+	files, err := os.ReadDir(d.directoryPath)
+	if err != nil {
+		seclog.Warnf("couldn't list files in %s, %s metric may be inaccurate: %v", d.directoryPath, metrics.MetricActivityDumpLocalStorageSizeOnDisk, err)
+		return 0
+	}
+
+	var total int64
+	for _, file := range files {
+		fullpath := filepath.Join(d.directoryPath, file.Name())
+		if _, err := config.ParseStorageFormat(filepath.Ext(fullpath)); err != nil {
+			continue
+		}
+		info, err := os.Stat(fullpath)
+		if err != nil {
+			continue
+		}
+		total += info.Size()
+	}
+	return total
+}
+
 // SendTelemetry sends telemetry for the current storage
 func (d *Directory) SendTelemetry(sender statsd.ClientInterface) {
 	d.profilesLock.RLock()
@@ -286,7 +311,6 @@ func (d *Directory) SendTelemetry(sender statsd.ClientInterface) {
 		_ = sender.Gauge(metrics.MetricActivityDumpLocalStorageCount, float64(count), nil, 1.0)
 	}
 
-	var totalSizeOnDisk int64
 	for _, entry := range d.profiles.Values() {
 		var profileSize int64
 		for _, filePath := range entry.filePaths {
@@ -294,7 +318,6 @@ func (d *Directory) SendTelemetry(sender statsd.ClientInterface) {
 				profileSize += info.Size()
 			}
 		}
-		totalSizeOnDisk += profileSize
 		tags := []string{
 			"image_name:" + entry.selector.Image,
 			"image_tag:" + entry.selector.Tag,
@@ -307,7 +330,7 @@ func (d *Directory) SendTelemetry(sender statsd.ClientInterface) {
 		_ = sender.Count(metrics.MetricActivityDumpLocalStorageDeleted, int64(count), nil, 1.0)
 	}
 
-	_ = sender.Gauge(metrics.MetricActivityDumpLocalStorageSizeOnDisk, float64(totalSizeOnDisk), nil, 1.0)
+	_ = sender.Gauge(metrics.MetricActivityDumpLocalStorageSizeOnDisk, float64(d.totalSizeOnDisk()), nil, 1.0)
 }
 
 func compressWithGZip(filename string, rawBuf []byte) (*bytes.Buffer, error) {

--- a/pkg/security/security_profile/storage/directory.go
+++ b/pkg/security/security_profile/storage/directory.go
@@ -255,36 +255,6 @@ func (d *Directory) Load(wls *cgroupModel.WorkloadSelector, p *profile.Profile) 
 	return false, nil
 }
 
-func (d *Directory) getProfilesSizeOnDisk() uint64 {
-	var ret uint64
-
-	files, err := os.ReadDir(d.directoryPath)
-	if err != nil {
-		seclog.Warnf("couldn't list the files in %s. The %s metric is reporting incorrect data for this host", d.directoryPath, metrics.MetricActivityDumpLocalStorageSizeOnDisk)
-		return 0
-	}
-
-	for _, file := range files {
-		fullpath := filepath.Join(d.directoryPath, file.Name())
-
-		_, err := config.ParseStorageFormat(filepath.Ext(fullpath))
-		// skip files that don't have any of our storage formats
-		if err != nil {
-			continue
-		}
-
-		s, err := os.Stat(fullpath)
-		if err != nil {
-			seclog.Warnf("couldn't stat the file %s. The %s metric is likely to be reporting incorrect data for this host", fullpath, metrics.MetricActivityDumpLocalStorageSizeOnDisk)
-			continue
-		}
-
-		ret += uint64(s.Size())
-	}
-
-	return ret
-}
-
 // GetStorageType returns the storage type
 func (d *Directory) GetStorageType() config.StorageType {
 	return config.LocalStorage
@@ -293,20 +263,32 @@ func (d *Directory) GetStorageType() config.StorageType {
 // SendTelemetry sends telemetry for the current storage
 func (d *Directory) SendTelemetry(sender statsd.ClientInterface) {
 	d.profilesLock.RLock()
-	// send the count of dumps stored locally
 	if count := d.profiles.Len(); count > 0 {
 		_ = sender.Gauge(metrics.MetricActivityDumpLocalStorageCount, float64(count), nil, 1.0)
 	}
+
+	var totalSizeOnDisk int64
+	for _, entry := range d.profiles.Values() {
+		var profileSize int64
+		for _, filePath := range entry.filePaths {
+			if info, err := os.Stat(filePath); err == nil {
+				profileSize += info.Size()
+			}
+		}
+		totalSizeOnDisk += profileSize
+		tags := []string{
+			"image_name:" + entry.selector.Image,
+			"image_tag:" + entry.selector.Tag,
+		}
+		_ = sender.Gauge(metrics.MetricSecurityProfileV2LocalStorageProfileSizeOnDisk, float64(profileSize), tags, 1.0)
+	}
 	d.profilesLock.RUnlock()
 
-	// send the count of recently deleted dumps
 	if count := d.deletedCount.Swap(0); count > 0 {
 		_ = sender.Count(metrics.MetricActivityDumpLocalStorageDeleted, int64(count), nil, 1.0)
 	}
 
-	// send the total size on disk used by the profiles
-	sizeOnDisk := d.getProfilesSizeOnDisk()
-	_ = sender.Gauge(metrics.MetricActivityDumpLocalStorageSizeOnDisk, float64(sizeOnDisk), nil, 1.0)
+	_ = sender.Gauge(metrics.MetricActivityDumpLocalStorageSizeOnDisk, float64(totalSizeOnDisk), nil, 1.0)
 }
 
 func compressWithGZip(filename string, rawBuf []byte) (*bytes.Buffer, error) {

--- a/pkg/security/security_profile/storage/directory.go
+++ b/pkg/security/security_profile/storage/directory.go
@@ -310,20 +310,6 @@ func (d *Directory) SendTelemetry(sender statsd.ClientInterface) {
 	if count := d.profiles.Len(); count > 0 {
 		_ = sender.Gauge(metrics.MetricActivityDumpLocalStorageCount, float64(count), nil, 1.0)
 	}
-
-	for _, entry := range d.profiles.Values() {
-		var profileSize int64
-		for _, filePath := range entry.filePaths {
-			if info, err := os.Stat(filePath); err == nil {
-				profileSize += info.Size()
-			}
-		}
-		tags := []string{
-			"image_name:" + entry.selector.Image,
-			"image_tag:" + entry.selector.Tag,
-		}
-		_ = sender.Gauge(metrics.MetricSecurityProfileV2LocalStorageProfileSizeOnDisk, float64(profileSize), tags, 1.0)
-	}
 	d.profilesLock.RUnlock()
 
 	if count := d.deletedCount.Swap(0); count > 0 {

--- a/pkg/security/security_profile/storage/directory.go
+++ b/pkg/security/security_profile/storage/directory.go
@@ -62,33 +62,43 @@ func createDir(dir string) error {
 	return nil
 }
 
-// fileHasKnownStorageExtension returns true when the file extension matches any of the
-// configured storage formats. The Directory needs to track every persisted format so that
-// LRU eviction (which deletes files from disk) and the per-selector disk metric remain
-// accurate regardless of which format is configured.
-func fileHasKnownStorageExtension(path string) bool {
+// fileHasProfileExtension returns true when the file extension is the .profile format.
+// Only .profile files create LRU entries and drive profile retention (capped at maxProfiles):
+// the SecurityProfile proto round-trips the selector directly, whereas the other formats
+// (json/protobuf/dot SecDumps) only carry it indirectly. Counting other formats here would
+// shrink effective retention and pull undecodable files into the load path, so they never
+// create entries on their own — they are only attached to an existing profile's entry.
+func fileHasProfileExtension(path string) bool {
+	format, err := config.ParseStorageFormat(filepath.Ext(path))
+	return err == nil && format == config.Profile
+}
+
+// fileHasStorageExtension returns true when the file extension matches any persisted storage
+// format. Used to gather every on-disk file belonging to a profile so the disk-size metric
+// (SizesBySelector) and the eviction callback account for all formats, not just .profile.
+func fileHasStorageExtension(path string) bool {
 	_, err := config.ParseStorageFormat(filepath.Ext(path))
 	return err == nil
 }
 
-// pickProfileFile returns the file path best suited to decode back into a Profile.
-// .profile is preferred because the SecurityProfile proto round-trips the selector
-// directly; the other formats (SecDump) only carry it indirectly through tags.
+// profileNameFromFile returns the profile name encoded in a storage filename. Persist writes
+// files as "<name>.<format>" (with an optional ".gz" suffix), so the name is the filename
+// with those extensions stripped. This lets us group sibling formats of the same profile.
+func profileNameFromFile(filename string) string {
+	filename = strings.TrimSuffix(filename, ".gz")
+	return strings.TrimSuffix(filename, filepath.Ext(filename))
+}
+
+// pickProfileFile returns the .profile file path among the given paths, or "" if none.
+// Only the .profile format round-trips the SecurityProfile proto (and thus the selector),
+// so it is the only format decoded back into a Profile during Load.
 func pickProfileFile(paths []string) string {
-	var fallback string
 	for _, path := range paths {
-		format, err := config.ParseStorageFormat(filepath.Ext(path))
-		if err != nil {
-			continue
-		}
-		if format == config.Profile {
+		if fileHasProfileExtension(path) {
 			return path
 		}
-		if fallback == "" {
-			fallback = path
-		}
 	}
-	return fallback
+	return ""
 }
 
 type profileFile struct {
@@ -125,9 +135,13 @@ func NewDirectory(directoryPath string, maxProfiles int) (*Directory, error) {
 		}
 	}
 
-	var fileSlice []*profileFile
+	// Gather every persisted storage file grouped by profile name. All formats are tracked
+	// (not just .profile) so SizesBySelector() and the eviction callback account for the full
+	// on-disk footprint, but only .profile files create LRU entries below.
+	filePathsByName := make(map[string][]string)
+	var profileFiles []*profileFile
 	for _, file := range files {
-		if !fileHasKnownStorageExtension(file.Name()) {
+		if !fileHasStorageExtension(file.Name()) {
 			continue
 		}
 
@@ -141,14 +155,19 @@ func NewDirectory(directoryPath string, maxProfiles int) (*Directory, error) {
 			continue
 		}
 
-		fileSlice = append(fileSlice, &profileFile{
-			path:  filepath.Join(directoryPath, file.Name()),
-			mTime: fileInfo.ModTime(),
-		})
+		fullPath := filepath.Join(directoryPath, file.Name())
+		filePathsByName[profileNameFromFile(file.Name())] = append(filePathsByName[profileNameFromFile(file.Name())], fullPath)
+
+		if fileHasProfileExtension(file.Name()) {
+			profileFiles = append(profileFiles, &profileFile{
+				path:  fullPath,
+				mTime: fileInfo.ModTime(),
+			})
+		}
 	}
 
-	// sort from oldest to newest
-	slices.SortFunc(fileSlice, func(a, b *profileFile) int {
+	// sort from oldest to newest so the most recent profiles survive the LRU cap
+	slices.SortFunc(profileFiles, func(a, b *profileFile) int {
 		if a.mTime.Equal(b.mTime) {
 			return 0
 		} else if a.mTime.Before(b.mTime) {
@@ -157,45 +176,32 @@ func NewDirectory(directoryPath string, maxProfiles int) (*Directory, error) {
 		return 1
 	})
 
-	for _, file := range fileSlice {
-		p := profile.New()
-		if err := p.Decode(file.path); err != nil {
+	for _, file := range profileFiles {
+		pProto, err := profile.LoadProtoFromFile(file.path)
+		if err != nil {
 			seclog.Warnf("failed to load profile from file [%s]: %s", file.path, err)
 			continue
 		}
-		if p.Metadata.Name == "" {
+		if pProto.Metadata == nil {
 			seclog.Warnf("profile loaded from file [%s] has no metadata", file.path)
 			continue
 		}
-		// GetWorkloadSelector may return a non-nil pointer to a zero-value selector
-		// (SecDump-formatted files with no Tags and no ContainerID/CGroupID), so we
-		// can't trust non-nil alone — check IsReady before treating it as usable.
-		selector := p.GetWorkloadSelector()
-
-		// Multiple persisted formats for the same profile share an LRU entry so
-		// SizesBySelector() can sum them and the eviction callback can delete every
-		// sibling file. Peek (not Get) avoids reordering the LRU during init.
-		if existing, ok := profiles.Peek(p.Metadata.Name); ok {
-			existing.filePaths = append(existing.filePaths, file.path)
-			// Upgrade a not-ready selector if a later file (e.g. the .profile sibling)
-			// gives us a usable one, so Load() can match the entry.
-			if !existing.selector.IsReady() && selector != nil && selector.IsReady() {
-				existing.selector = *selector
-			}
+		if pProto.Selector == nil {
+			seclog.Warnf("profile loaded from file [%s] has no selector", file.path)
 			continue
 		}
-		// First time we see this profile name. Register the entry even when the
-		// selector isn't ready yet: a later sibling format can still upgrade it, and
-		// keeping the file in the LRU ensures eviction will clean every on-disk format
-		// (and SizesBySelector() can account for it). selector.IsReady() gates
-		// matching during Load() so a non-ready entry is invisible to lookups.
-		var sel cgroupModel.WorkloadSelector
-		if selector != nil {
-			sel = *selector
+
+		// Attach every persisted format of this profile (json/protobuf/dot siblings) so the
+		// disk-size metric counts them and eviction removes them all. Fall back to just the
+		// .profile file if the naming is unexpected and no siblings were grouped.
+		paths := filePathsByName[pProto.Metadata.Name]
+		if len(paths) == 0 {
+			paths = []string{file.path}
 		}
-		profiles.Add(p.Metadata.Name, &profileEntry{
-			selector:  sel,
-			filePaths: []string{file.path},
+
+		profiles.Add(pProto.Metadata.Name, &profileEntry{
+			selector:  cgroupModel.ProtoToWorkloadSelector(pProto.Selector),
+			filePaths: paths,
 		})
 	}
 

--- a/pkg/security/security_profile/storage/directory.go
+++ b/pkg/security/security_profile/storage/directory.go
@@ -62,43 +62,17 @@ func createDir(dir string) error {
 	return nil
 }
 
-// fileHasProfileExtension returns true when the file extension is the .profile format.
-// Only .profile files create LRU entries and drive profile retention (capped at maxProfiles):
-// the SecurityProfile proto round-trips the selector directly, whereas the other formats
-// (json/protobuf/dot SecDumps) only carry it indirectly. Counting other formats here would
-// shrink effective retention and pull undecodable files into the load path, so they never
-// create entries on their own — they are only attached to an existing profile's entry.
 func fileHasProfileExtension(path string) bool {
 	format, err := config.ParseStorageFormat(filepath.Ext(path))
 	return err == nil && format == config.Profile
 }
 
-// fileHasStorageExtension returns true when the file extension matches any persisted storage
-// format. Used to gather every on-disk file belonging to a profile so the disk-size metric
-// (SizesBySelector) and the eviction callback account for all formats, not just .profile.
-func fileHasStorageExtension(path string) bool {
-	_, err := config.ParseStorageFormat(filepath.Ext(path))
-	return err == nil
-}
-
 // profileNameFromFile returns the profile name encoded in a storage filename. Persist writes
-// files as "<name>.<format>" (with an optional ".gz" suffix), so the name is the filename
-// with those extensions stripped. This lets us group sibling formats of the same profile.
+// files as "<name>.<format>" (with an optional ".gz" suffix), so the name is the filename with
+// those extensions stripped. Used to attribute an on-disk file back to its profile selector.
 func profileNameFromFile(filename string) string {
 	filename = strings.TrimSuffix(filename, ".gz")
 	return strings.TrimSuffix(filename, filepath.Ext(filename))
-}
-
-// pickProfileFile returns the .profile file path among the given paths, or "" if none.
-// Only the .profile format round-trips the SecurityProfile proto (and thus the selector),
-// so it is the only format decoded back into a Profile during Load.
-func pickProfileFile(paths []string) string {
-	for _, path := range paths {
-		if fileHasProfileExtension(path) {
-			return path
-		}
-	}
-	return ""
 }
 
 type profileFile struct {
@@ -135,13 +109,9 @@ func NewDirectory(directoryPath string, maxProfiles int) (*Directory, error) {
 		}
 	}
 
-	// Gather every persisted storage file grouped by profile name. All formats are tracked
-	// (not just .profile) so SizesBySelector() and the eviction callback account for the full
-	// on-disk footprint, but only .profile files create LRU entries below.
-	filePathsByName := make(map[string][]string)
-	var profileFiles []*profileFile
+	var fileSlice []*profileFile
 	for _, file := range files {
-		if !fileHasStorageExtension(file.Name()) {
+		if !fileHasProfileExtension(file.Name()) {
 			continue
 		}
 
@@ -155,19 +125,14 @@ func NewDirectory(directoryPath string, maxProfiles int) (*Directory, error) {
 			continue
 		}
 
-		fullPath := filepath.Join(directoryPath, file.Name())
-		filePathsByName[profileNameFromFile(file.Name())] = append(filePathsByName[profileNameFromFile(file.Name())], fullPath)
-
-		if fileHasProfileExtension(file.Name()) {
-			profileFiles = append(profileFiles, &profileFile{
-				path:  fullPath,
-				mTime: fileInfo.ModTime(),
-			})
-		}
+		fileSlice = append(fileSlice, &profileFile{
+			path:  filepath.Join(directoryPath, file.Name()),
+			mTime: fileInfo.ModTime(),
+		})
 	}
 
-	// sort from oldest to newest so the most recent profiles survive the LRU cap
-	slices.SortFunc(profileFiles, func(a, b *profileFile) int {
+	// sort from oldest to newest
+	slices.SortFunc(fileSlice, func(a, b *profileFile) int {
 		if a.mTime.Equal(b.mTime) {
 			return 0
 		} else if a.mTime.Before(b.mTime) {
@@ -176,7 +141,7 @@ func NewDirectory(directoryPath string, maxProfiles int) (*Directory, error) {
 		return 1
 	})
 
-	for _, file := range profileFiles {
+	for _, file := range fileSlice {
 		pProto, err := profile.LoadProtoFromFile(file.path)
 		if err != nil {
 			seclog.Warnf("failed to load profile from file [%s]: %s", file.path, err)
@@ -191,17 +156,9 @@ func NewDirectory(directoryPath string, maxProfiles int) (*Directory, error) {
 			continue
 		}
 
-		// Attach every persisted format of this profile (json/protobuf/dot siblings) so the
-		// disk-size metric counts them and eviction removes them all. Fall back to just the
-		// .profile file if the naming is unexpected and no siblings were grouped.
-		paths := filePathsByName[pProto.Metadata.Name]
-		if len(paths) == 0 {
-			paths = []string{file.path}
-		}
-
 		profiles.Add(pProto.Metadata.Name, &profileEntry{
 			selector:  cgroupModel.ProtoToWorkloadSelector(pProto.Selector),
-			filePaths: paths,
+			filePaths: []string{file.path},
 		})
 	}
 
@@ -289,24 +246,60 @@ func (d *Directory) Load(wls *cgroupModel.WorkloadSelector, p *profile.Profile) 
 	defer d.profilesLock.RUnlock()
 
 	for _, entry := range d.profiles.Values() {
-		if !entry.selector.Match(*wls) {
-			continue
-		}
+		if entry.selector.Match(*wls) {
+			for _, file := range entry.filePaths {
+				if !fileHasProfileExtension(file) {
+					continue
+				}
 
-		// Prefer the .profile format because it round-trips the selector explicitly via the
-		// SecurityProfile proto. Other formats (json/protobuf/dot) encode SecDump, which only
-		// preserves the selector indirectly through tags.
-		chosen := pickProfileFile(entry.filePaths)
-		if chosen == "" {
-			continue
+				if err := p.Decode(file); err != nil {
+					return false, fmt.Errorf("failed to decode profile [%s]: %s", file, err)
+				}
+				return true, nil
+			}
 		}
-		if err := p.Decode(chosen); err != nil {
-			return false, fmt.Errorf("failed to decode profile [%s]: %s", chosen, err)
-		}
-		return true, nil
 	}
 
 	return false, nil
+}
+
+// SizesBySelector returns the on-disk size in bytes used by each stored profile, keyed by
+// workload selector. It walks the directory and attributes every storage-format file to the
+// selector of the profile it belongs to (matched by file name), so all persisted formats of a
+// profile (e.g. .profile + .json) are summed together.
+func (d *Directory) SizesBySelector() map[cgroupModel.WorkloadSelector]int64 {
+	d.profilesLock.RLock()
+	selectorByName := make(map[string]cgroupModel.WorkloadSelector, d.profiles.Len())
+	for _, name := range d.profiles.Keys() {
+		if entry, ok := d.profiles.Peek(name); ok {
+			selectorByName[name] = entry.selector
+		}
+	}
+	d.profilesLock.RUnlock()
+
+	result := make(map[cgroupModel.WorkloadSelector]int64, len(selectorByName))
+	files, err := os.ReadDir(d.directoryPath)
+	if err != nil {
+		seclog.Warnf("couldn't list files in %s, %s metric may be inaccurate: %v", d.directoryPath, metrics.MetricSecurityProfileV2ProfileSize, err)
+		return result
+	}
+
+	for _, file := range files {
+		if _, err := config.ParseStorageFormat(filepath.Ext(file.Name())); err != nil {
+			continue
+		}
+		selector, ok := selectorByName[profileNameFromFile(file.Name())]
+		if !ok {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(d.directoryPath, file.Name()))
+		if err != nil {
+			continue
+		}
+		result[selector] += info.Size()
+	}
+
+	return result
 }
 
 // GetStorageType returns the storage type
@@ -314,63 +307,19 @@ func (d *Directory) GetStorageType() config.StorageType {
 	return config.LocalStorage
 }
 
-// SizesBySelector returns the on-disk size in bytes of each stored profile, keyed by workload selector.
-// Multiple file formats for the same selector are summed together.
-func (d *Directory) SizesBySelector() map[cgroupModel.WorkloadSelector]int64 {
-	d.profilesLock.RLock()
-	defer d.profilesLock.RUnlock()
-
-	result := make(map[cgroupModel.WorkloadSelector]int64, d.profiles.Len())
-	for _, entry := range d.profiles.Values() {
-		var size int64
-		for _, filePath := range entry.filePaths {
-			if info, err := os.Stat(filePath); err == nil {
-				size += info.Size()
-			}
-		}
-		result[entry.selector] += size
-	}
-	return result
-}
-
-// totalSizeOnDisk scans the directory and sums the size of every file with a known storage format
-// extension. Used for the aggregate disk-usage metric because the LRU only tracks the primary
-// .profile files even when other formats (e.g. .json) are configured and persisted alongside.
-func (d *Directory) totalSizeOnDisk() int64 {
-	files, err := os.ReadDir(d.directoryPath)
-	if err != nil {
-		seclog.Warnf("couldn't list files in %s, %s metric may be inaccurate: %v", d.directoryPath, metrics.MetricActivityDumpLocalStorageSizeOnDisk, err)
-		return 0
-	}
-
-	var total int64
-	for _, file := range files {
-		fullpath := filepath.Join(d.directoryPath, file.Name())
-		if _, err := config.ParseStorageFormat(filepath.Ext(fullpath)); err != nil {
-			continue
-		}
-		info, err := os.Stat(fullpath)
-		if err != nil {
-			continue
-		}
-		total += info.Size()
-	}
-	return total
-}
-
 // SendTelemetry sends telemetry for the current storage
 func (d *Directory) SendTelemetry(sender statsd.ClientInterface) {
 	d.profilesLock.RLock()
+	// send the count of dumps stored locally
 	if count := d.profiles.Len(); count > 0 {
 		_ = sender.Gauge(metrics.MetricActivityDumpLocalStorageCount, float64(count), nil, 1.0)
 	}
 	d.profilesLock.RUnlock()
 
+	// send the count of recently deleted dumps
 	if count := d.deletedCount.Swap(0); count > 0 {
 		_ = sender.Count(metrics.MetricActivityDumpLocalStorageDeleted, int64(count), nil, 1.0)
 	}
-
-	_ = sender.Gauge(metrics.MetricActivityDumpLocalStorageSizeOnDisk, float64(d.totalSizeOnDisk()), nil, 1.0)
 }
 
 func compressWithGZip(filename string, rawBuf []byte) (*bytes.Buffer, error) {

--- a/pkg/security/security_profile/storage/directory.go
+++ b/pkg/security/security_profile/storage/directory.go
@@ -167,14 +167,34 @@ func NewDirectory(directoryPath string, maxProfiles int) (*Directory, error) {
 			seclog.Warnf("profile loaded from file [%s] has no metadata", file.path)
 			continue
 		}
+		// GetWorkloadSelector may return a non-nil pointer to a zero-value selector
+		// (SecDump-formatted files with no Tags and no ContainerID/CGroupID), so we
+		// can't trust non-nil alone — check IsReady before treating it as usable.
 		selector := p.GetWorkloadSelector()
-		if selector == nil {
-			seclog.Warnf("profile loaded from file [%s] has no selector", file.path)
+
+		// Multiple persisted formats for the same profile share an LRU entry so
+		// SizesBySelector() can sum them and the eviction callback can delete every
+		// sibling file. Peek (not Get) avoids reordering the LRU during init.
+		if existing, ok := profiles.Peek(p.Metadata.Name); ok {
+			existing.filePaths = append(existing.filePaths, file.path)
+			// Upgrade a not-ready selector if a later file (e.g. the .profile sibling)
+			// gives us a usable one, so Load() can match the entry.
+			if !existing.selector.IsReady() && selector != nil && selector.IsReady() {
+				existing.selector = *selector
+			}
 			continue
 		}
-
+		// First time we see this profile name. Register the entry even when the
+		// selector isn't ready yet: a later sibling format can still upgrade it, and
+		// keeping the file in the LRU ensures eviction will clean every on-disk format
+		// (and SizesBySelector() can account for it). selector.IsReady() gates
+		// matching during Load() so a non-ready entry is invisible to lookups.
+		var sel cgroupModel.WorkloadSelector
+		if selector != nil {
+			sel = *selector
+		}
 		profiles.Add(p.Metadata.Name, &profileEntry{
-			selector:  *selector,
+			selector:  sel,
 			filePaths: []string{file.path},
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

* Make the estimation function calculate the size of the ActivityTree based on the contents of the inserted node.
* Create a metric to report size in memory per dump

### Motivation

The previous estimation function was reading values very far away from the real value. This PR makes a better approximation.

Also, improves visibility of what each workload are keeping in memory and disk

### Describe how you validated your changes

### Additional Notes
