### PR TITLE
[PROF-14735] Use DD_SERVICE instead of the command to detect the service in ddprofiling extension

### DIFF
--- a/comp/otelcol/ddprofilingextension/impl/config.go
+++ b/comp/otelcol/ddprofilingextension/impl/config.go
@@ -18,13 +18,13 @@ type Config struct {
 // ProfilerOptions defines settings relevant to the profiler.
 type ProfilerOptions struct {
 	// Service the profiler will report with.
-	// Default: BuildInfo.Command (e.g. otel-agent)
+	// Default: DD_SERVICE, then BuildInfo.Command (e.g. otel-agent)
 	Service string `mapstructure:"service"`
 	// Env the profiler will report with.
-	// Default: none
+	// Default: DD_ENV, then none
 	Env string `mapstructure:"env"`
 	// Version the profiler will report with.
-	// Default: BuildInfo.Version (e.g. v0.117.0)
+	// Default: DD_VERSION, then BuildInfo.Version (e.g. v0.117.0)
 	Version string `mapstructure:"version"`
 	// Period in seconds the profiler will report with.
 	// Default: 60s

--- a/comp/otelcol/ddprofilingextension/impl/config.schema.yaml
+++ b/comp/otelcol/ddprofilingextension/impl/config.schema.yaml
@@ -4,7 +4,7 @@ $defs:
     type: object
     properties:
       env:
-        description: 'Env the profiler will report with. Default: none'
+        description: 'Env the profiler will report with. Default: DD_ENV, then none'
         type: string
       period:
         description: 'Period in seconds the profiler will report with. Default: 60s'
@@ -15,10 +15,10 @@ $defs:
         items:
           type: string
       service:
-        description: 'Service the profiler will report with. Default: BuildInfo.Command (e.g. otel-agent)'
+        description: 'Service the profiler will report with. Default: DD_SERVICE, then BuildInfo.Command (e.g. otel-agent)'
         type: string
       version:
-        description: 'Version the profiler will report with. Default: BuildInfo.Version (e.g. v0.117.0)'
+        description: 'Version the profiler will report with. Default: DD_VERSION, then BuildInfo.Version (e.g. v0.117.0)'
         type: string
 description: Config contains the config of the profiler.
 type: object

--- a/comp/otelcol/ddprofilingextension/impl/extension.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension.go
@@ -111,26 +111,26 @@ func (e *ddExtension) buildProfilerOptions() []profiler.Option {
 	}
 	profilerOptions = append(profilerOptions, profiler.WithProfileTypes(defaultProfileTypes...))
 
-	if service, ok := nonBlankEnv(ddServiceEnvVar); ok {
-		profilerOptions = append(profilerOptions, profiler.WithService(service))
-	} else if e.cfg.ProfilerOptions.Service != "" {
+	if e.cfg.ProfilerOptions.Service != "" {
 		profilerOptions = append(profilerOptions, profiler.WithService(e.cfg.ProfilerOptions.Service))
+	} else if service, ok := nonBlankEnv(ddServiceEnvVar); ok {
+		profilerOptions = append(profilerOptions, profiler.WithService(service))
 	} else {
 		profilerOptions = append(profilerOptions, profiler.WithService(e.info.Command))
 	}
 
-	if version, ok := nonBlankEnv(ddVersionEnvVar); ok {
-		profilerOptions = append(profilerOptions, profiler.WithVersion(version))
-	} else if e.cfg.ProfilerOptions.Version != "" {
+	if e.cfg.ProfilerOptions.Version != "" {
 		profilerOptions = append(profilerOptions, profiler.WithVersion(e.cfg.ProfilerOptions.Version))
+	} else if version, ok := nonBlankEnv(ddVersionEnvVar); ok {
+		profilerOptions = append(profilerOptions, profiler.WithVersion(version))
 	} else {
 		profilerOptions = append(profilerOptions, profiler.WithVersion(e.info.Version))
 	}
 
-	if env, ok := nonBlankEnv(ddEnvEnvVar); ok {
-		profilerOptions = append(profilerOptions, profiler.WithEnv(env))
-	} else if e.cfg.ProfilerOptions.Env != "" {
+	if e.cfg.ProfilerOptions.Env != "" {
 		profilerOptions = append(profilerOptions, profiler.WithEnv(e.cfg.ProfilerOptions.Env))
+	} else if env, ok := nonBlankEnv(ddEnvEnvVar); ok {
+		profilerOptions = append(profilerOptions, profiler.WithEnv(env))
 	}
 
 	if e.cfg.ProfilerOptions.Period > 0 {

--- a/comp/otelcol/ddprofilingextension/impl/extension.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension.go
@@ -9,6 +9,8 @@ package ddprofilingextensionimpl
 import (
 	"context"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	corelog "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -24,6 +26,12 @@ var (
 	_               extension.Extension = (*ddExtension)(nil)
 	_               component.Config    = (*Config)(nil)
 	defaultEndpoint                     = "7501"
+)
+
+const (
+	ddServiceEnvVar = "DD_SERVICE"
+	ddEnvEnvVar     = "DD_ENV"
+	ddVersionEnvVar = "DD_VERSION"
 )
 
 // ddExtension is a basic OpenTelemetry Collector extension.
@@ -103,19 +111,25 @@ func (e *ddExtension) buildProfilerOptions() []profiler.Option {
 	}
 	profilerOptions = append(profilerOptions, profiler.WithProfileTypes(defaultProfileTypes...))
 
-	if e.cfg.ProfilerOptions.Service != "" {
+	if service, ok := nonBlankEnv(ddServiceEnvVar); ok {
+		profilerOptions = append(profilerOptions, profiler.WithService(service))
+	} else if e.cfg.ProfilerOptions.Service != "" {
 		profilerOptions = append(profilerOptions, profiler.WithService(e.cfg.ProfilerOptions.Service))
 	} else {
 		profilerOptions = append(profilerOptions, profiler.WithService(e.info.Command))
 	}
 
-	if e.cfg.ProfilerOptions.Version != "" {
+	if version, ok := nonBlankEnv(ddVersionEnvVar); ok {
+		profilerOptions = append(profilerOptions, profiler.WithVersion(version))
+	} else if e.cfg.ProfilerOptions.Version != "" {
 		profilerOptions = append(profilerOptions, profiler.WithVersion(e.cfg.ProfilerOptions.Version))
 	} else {
 		profilerOptions = append(profilerOptions, profiler.WithVersion(e.info.Version))
 	}
 
-	if e.cfg.ProfilerOptions.Env != "" {
+	if env, ok := nonBlankEnv(ddEnvEnvVar); ok {
+		profilerOptions = append(profilerOptions, profiler.WithEnv(env))
+	} else if e.cfg.ProfilerOptions.Env != "" {
 		profilerOptions = append(profilerOptions, profiler.WithEnv(e.cfg.ProfilerOptions.Env))
 	}
 
@@ -124,6 +138,14 @@ func (e *ddExtension) buildProfilerOptions() []profiler.Option {
 	}
 
 	return profilerOptions
+}
+
+func nonBlankEnv(key string) (string, bool) {
+	value, ok := os.LookupEnv(key)
+	if !ok || strings.TrimSpace(value) == "" {
+		return "", false
+	}
+	return value, true
 }
 
 func (e *ddExtension) Shutdown(ctx context.Context) error {


### PR DESCRIPTION
### What does this PR do?

This PR ensures that ddprofiling resolves service, env, and version from DD_* before the existing fallback.

### Motivation

We want Go profiles to resolve the same service, env, and version as the host-profiler profiles.

### Describe how you validated your changes

[Tested locally](https://dd.datad0g.com/profiling/explorer?query=host%3Ai-0a4063ecad23b3f52%20service%3Ahost-profiler-tintin&agg_m=%40prof_ebpf_cpu_cores&agg_m_source=base&agg_t=sum&extra_search_fields=%7B%22filters_query%22%3A%22%22%2C%22sample_type%22%3A%22cpu-time%22%7D&fromUser=true&my_code=disabled&refresh_mode=paused&selected_tf=1779874174000%2C1779874429000&viz=flame_graph&from_ts=1779873942825&to_ts=1779874842825&live=false)

Tested on relenv:
- [Bundled nightly](https://ddstaging.datadoghq.com/profiling/explorer?query=perf.container.type%3Amain%20AND%20perf.lang.native.deployment%3Arp-native-fullhost-bundled%20AND%20perf.configuration%3Adefault%20perf.sub.configuration%3Acandidate-all%20-perf.tracer.version%3A%2A&index=&my_code=disabled&selected_tf=1779876111000%2C1779876262951&viz=flame_graph&start=1779872662951&end=1779876262951&paused=true)
- [Bundled devtest](https://ddstaging.datadoghq.com/profiling/explorer?query=perf.container.type%3Amain%20AND%20perf.lang.native.deployment%3Arp-native-fullhost-bundled%20AND%20perf.configuration%3Adefault%20perf.sub.configuration%3Acandidate-experimental%20-perf.tracer.version%3A%2A&fromUser=true&index=&my_code=disabled&selected_tf=1779876249000%2C1779876402000&viz=flame_graph&start=1779872919735&end=1779876519735&paused=true)
- [Standalone nightly](https://ddstaging.datadoghq.com/profiling/explorer?query=perf.container.type%3Amain%20AND%20perf.lang.native.deployment%3Arp-native-fullhost-standalone%20AND%20perf.configuration%3Adefault%20perf.sub.configuration%3Acandidate-all%20-perf.tracer.version%3A%2A&fromUser=true&index=&my_code=disabled&selected_tf=1779876327000%2C1779876414000&viz=flame_graph&start=1779872928408&end=1779876528408&paused=true)
- [Standalone devtest](https://ddstaging.datadoghq.com/profiling/explorer?query=perf.container.type%3Amain%20AND%20perf.lang.native.deployment%3Arp-native-fullhost-standalone%20AND%20perf.configuration%3Adefault%20perf.sub.configuration%3Acandidate-experimental%20-perf.tracer.version%3A%2A%20service%3Ahost-profiler-standalone-devtest&agg_m=%40prof_core_cpu_cores&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=sum&fromUser=true&my_code=disabled&selected_tf=1779876293000%2C1779876485000&top_n=100&top_o=top&viz=flame_graph&x_missing=true&start=1779872885484&end=1779876485484&paused=true)


### Additional Notes
