### PR TITLE
Add path-scoped Claude _rule_ for Bazel matters

### DIFF
--- a/.claude/rules/bazel.md
+++ b/.claude/rules/bazel.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - ".bazel*"
+  - "bazel/**"
+  - "deps/**"
+  - "**/*.{bazel,bzl}"
+---
+
+# Bazel
+
+Ingest bazel/AGENTS.md prior to any Bazel-related activity:
+- reading or editing Bazel files,
+- running `bazel` commands,
+- inspecting Bazel-managed directories.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -945,7 +945,7 @@
 /comp/anomalydetection/                  @DataDog/q-branch # Useful for AGENTS.md files etc. at the root of all AD components
 
 # AI-related files
-/.claude/rules/bazel.md               @DataDog/agent-build @DataDog/agent-devx
+/.claude/rules/bazel.md               @DataDog/agent-build
 /.claude/skills/explain-lading-config @DataDog/single-machine-performance
 
 # Temporary during Bazel migration

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -945,6 +945,7 @@
 /comp/anomalydetection/                  @DataDog/q-branch # Useful for AGENTS.md files etc. at the root of all AD components
 
 # AI-related files
+/.claude/rules/bazel.md               @DataDog/agent-build @DataDog/agent-devx
 /.claude/skills/explain-lading-config @DataDog/single-machine-performance
 
 # Temporary during Bazel migration


### PR DESCRIPTION
### What does this PR do?
Add `.claude/rules/bazel.md`, a path-scoped Claude Code _rule_ that instructs Claude to injest `bazel/AGENTS.md` before reading or editing any Bazel-related file.

### Motivation
Claude does not systematically load `bazel/AGENTS.md` when touching Bazel-related files, leading to mistakes the document is meant to prevent:
- gardening `BUILD.bazel` files by hand instead of running `gazelle`,
- writing `genrules` with non-portable scripts instead of leveraging `native_binary`/`run_binary`,
- etc.

A path-scoped rule loads only when a matching file is in scope, so the directive is delivered at the moment it is needed without inflating context the rest of the time.

Outcome of 4th item in the "AI Dev Week 1" project ideas: https://datadoghq.atlassian.net/wiki/spaces/ABLD/pages/6638142056/Week+1+-+May+25th+to+29th#%F0%9F%92%A1-Project-Ideas

### Describe how you validated your changes
- in a fresh session, ran `/memory` with no Bazel file touched: `.claude/rules/bazel.md` is not listed, confirming **conditional loading**,
- in a fresh session, asked what to do before reading any `BUILD.bazel` file: Claude mentioned to read `bazel/AGENTS.md` **as instructed**,
- in another fresh session, asked to remove default package visibility from the root `BUILD.bazel`: Claude indeed consulted `bazel/AGENTS.md` and started **applying its guidance**.

### Additional Notes
Frontmatter key is `paths:` per https://code.claude.com/docs/en/memory#path-specific-rules, not `globs:`.
The sibling .claude/rules/allium.md uses `globs:` and is therefore loading unconditionally => left as-is for a separate change:
- #51380.