### PR TITLE
feat(networkdevice): add interfaceresolver library with ifType tiebreaker

### DIFF
--- a/pkg/networkdevice/interfaceresolver/BUILD.bazel
+++ b/pkg/networkdevice/interfaceresolver/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "interfaceresolver",
     srcs = [
         "doc.go",
+        "observer.go",
         "resolver.go",
         "types.go",
     ],
@@ -13,7 +14,10 @@ go_library(
 
 go_test(
     name = "interfaceresolver_test",
-    srcs = ["resolver_test.go"],
+    srcs = [
+        "observer_test.go",
+        "resolver_test.go",
+    ],
     embed = [":interfaceresolver"],
     gotags = ["test"],
     deps = [

--- a/pkg/networkdevice/interfaceresolver/BUILD.bazel
+++ b/pkg/networkdevice/interfaceresolver/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "interfaceresolver",
+    srcs = [
+        "doc.go",
+        "resolver.go",
+        "types.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/networkdevice/interfaceresolver",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "interfaceresolver_test",
+    srcs = ["resolver_test.go"],
+    embed = [":interfaceresolver"],
+    gotags = ["test"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/networkdevice/interfaceresolver/BUILD.bazel
+++ b/pkg/networkdevice/interfaceresolver/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "interfaceresolver",
     srcs = [
+        "audit.go",
         "doc.go",
         "observer.go",
         "resolver.go",
@@ -15,6 +16,7 @@ go_library(
 go_test(
     name = "interfaceresolver_test",
     srcs = [
+        "audit_test.go",
         "observer_test.go",
         "resolver_test.go",
     ],

--- a/pkg/networkdevice/interfaceresolver/audit.go
+++ b/pkg/networkdevice/interfaceresolver/audit.go
@@ -14,9 +14,9 @@ package interfaceresolver
 // IfIndex to 0 means "the oracle says this MAC has no canonical
 // interface" — the resolver is expected to return OutcomeUnmatched.
 type OracleEntry struct {
-	MAC      string
-	Hint     ContextHint
-	IfIndex  int32
+	MAC     string
+	Hint    ContextHint
+	IfIndex int32
 }
 
 // AuditReport summarises the audit job's findings. Counts are

--- a/pkg/networkdevice/interfaceresolver/audit.go
+++ b/pkg/networkdevice/interfaceresolver/audit.go
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interfaceresolver
+
+// OracleEntry is one ground-truth resolution sample. In production the
+// oracle is constructed from LLDP-MIB plus ifName exact-match on a
+// subset of devices (PRD scope item #4); in tests it is constructed
+// from a known-good mapping.
+//
+// IfIndex is the correct interface for the (MAC, Hint) pair. Setting
+// IfIndex to 0 means "the oracle says this MAC has no canonical
+// interface" — the resolver is expected to return OutcomeUnmatched.
+type OracleEntry struct {
+	MAC      string
+	Hint     ContextHint
+	IfIndex  int32
+}
+
+// AuditReport summarises the audit job's findings. Counts are
+// per-device — caller aggregates across devices as needed.
+//
+// MisResolutionRate is the PRD's correctness guardrail (target <0.5%).
+// Coverage without correctness is a regression — so this report makes
+// the trade-off explicit.
+type AuditReport struct {
+	// Sample is the number of oracle entries evaluated.
+	Sample int
+	// MatchedCorrect counts attempts where the resolver returned the
+	// same IfIndex the oracle said was correct.
+	MatchedCorrect int
+	// MatchedIncorrect counts attempts where the resolver returned an
+	// IfIndex but it disagreed with the oracle. This is the
+	// "mis-resolution" bucket.
+	MatchedIncorrect int
+	// UnresolvedAmbiguous counts attempts where the resolver
+	// surfaced ambiguity rather than guessing. NOT a correctness
+	// failure — it's the safe path.
+	UnresolvedAmbiguous int
+	// Unmatched counts attempts where the resolver returned no
+	// candidate. Whether this is a failure depends on the oracle:
+	// if the oracle said "no interface" (IfIndex==0) too, this is
+	// correct. The audit folds the "correct unmatched" into
+	// MatchedCorrect.
+	Unmatched int
+}
+
+// MisResolutionRate returns MatchedIncorrect / (MatchedCorrect +
+// MatchedIncorrect). Returns 0 when the denominator is 0 (no resolved
+// samples at all).
+//
+// We exclude unresolved/unmatched from the denominator on purpose —
+// they are coverage events, not correctness events, and conflating them
+// would let coverage drops mask mis-resolution regressions.
+func (r AuditReport) MisResolutionRate() float64 {
+	denom := r.MatchedCorrect + r.MatchedIncorrect
+	if denom == 0 {
+		return 0
+	}
+	return float64(r.MatchedIncorrect) / float64(denom)
+}
+
+// CoverageRate returns 1 - (Unmatched + UnresolvedAmbiguous) / Sample.
+// Returns 0 when Sample is 0.
+//
+// Note: a correct "unmatched" (oracle also said no interface) still
+// counts toward MatchedCorrect, NOT toward Unmatched. So this rate is
+// the fraction of attempts where the resolver returned a usable
+// answer.
+func (r AuditReport) CoverageRate() float64 {
+	if r.Sample == 0 {
+		return 0
+	}
+	resolved := r.MatchedCorrect + r.MatchedIncorrect
+	return float64(resolved) / float64(r.Sample)
+}
+
+// Auditor runs the audit job for one device's Resolver against a set
+// of oracle entries.
+type Auditor struct {
+	resolver *Resolver
+}
+
+// NewAuditor binds an auditor to a built Resolver.
+func NewAuditor(r *Resolver) *Auditor {
+	return &Auditor{resolver: r}
+}
+
+// Run evaluates the resolver against every entry in `oracle` and
+// returns an AuditReport.
+//
+// The audit deliberately reuses the public Resolve path so the
+// resolver's instrumentation (per-resolution Observer events) fires
+// during the audit. Callers who want to keep audit events out of
+// their production resolution metrics should construct a dedicated
+// Resolver for the audit with a separate Observer (e.g. a
+// per-audit fakeObserver).
+func (a *Auditor) Run(oracle []OracleEntry) AuditReport {
+	rep := AuditReport{Sample: len(oracle)}
+	for _, e := range oracle {
+		res := a.resolver.Resolve(e.MAC, e.Hint)
+		switch res.Outcome {
+		case OutcomeMatchedUnique, OutcomeMatchedAmbiguous:
+			// resolver returned an interface; check against oracle.
+			if e.IfIndex == 0 {
+				// Oracle says "no interface for this MAC" but
+				// resolver found one. That's a mis-resolution.
+				rep.MatchedIncorrect++
+				continue
+			}
+			if res.Interface != nil && res.Interface.Index == e.IfIndex {
+				rep.MatchedCorrect++
+			} else {
+				rep.MatchedIncorrect++
+			}
+		case OutcomeUnresolvedAmbiguous:
+			rep.UnresolvedAmbiguous++
+		case OutcomeUnmatched:
+			// Oracle agrees "no interface" → correct unmatched.
+			// Oracle disagrees → coverage miss, NOT correctness.
+			if e.IfIndex == 0 {
+				rep.MatchedCorrect++
+			} else {
+				rep.Unmatched++
+			}
+		}
+	}
+	return rep
+}

--- a/pkg/networkdevice/interfaceresolver/audit_test.go
+++ b/pkg/networkdevice/interfaceresolver/audit_test.go
@@ -1,0 +1,171 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interfaceresolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// auditScenarioCandidates: same shape as vlanColocatedCandidates but
+// repeated here to keep the audit test file self-contained.
+func auditScenarioCandidates() []Candidate {
+	return []Candidate{
+		{Index: 1, Name: "Gi0/1", MAC: "aa:bb:cc:dd:ee:01", Type: IfTypeEthernetCsmacd},
+		{Index: 101, Name: "Gi0/1.100", MAC: "aa:bb:cc:dd:ee:01", Type: IfTypeL2Vlan},
+		{Index: 102, Name: "Gi0/1.200", MAC: "aa:bb:cc:dd:ee:01", Type: IfTypeL2Vlan},
+		{Index: 2, Name: "Gi0/2", MAC: "aa:bb:cc:dd:ee:02", Type: IfTypeEthernetCsmacd},
+	}
+}
+
+func TestAuditReport_RateHelpers_NoSample(t *testing.T) {
+	rep := AuditReport{}
+	assert.Equal(t, 0.0, rep.MisResolutionRate())
+	assert.Equal(t, 0.0, rep.CoverageRate())
+}
+
+func TestAuditReport_RateHelpers_Basic(t *testing.T) {
+	rep := AuditReport{
+		Sample:              100,
+		MatchedCorrect:      80,
+		MatchedIncorrect:    2,
+		UnresolvedAmbiguous: 15,
+		Unmatched:           3,
+	}
+	// 2 / (80+2) = ~0.0244
+	assert.InDelta(t, 2.0/82.0, rep.MisResolutionRate(), 1e-6)
+	// (80+2) / 100 = 0.82
+	assert.InDelta(t, 0.82, rep.CoverageRate(), 1e-6)
+}
+
+func TestAudit_CorrectResolutions(t *testing.T) {
+	r := NewResolver(auditScenarioCandidates())
+	a := NewAuditor(r)
+
+	oracle := []OracleEntry{
+		// Unique MAC → match.
+		{MAC: "aa:bb:cc:dd:ee:02", IfIndex: 2},
+		// Ambiguous MAC + correct expected-type hint → physical.
+		{MAC: "aa:bb:cc:dd:ee:01", Hint: ContextHint{ExpectedType: IfTypeEthernetCsmacd}, IfIndex: 1},
+		// Ambiguous MAC + correct name hint → sub-interface .100.
+		{MAC: "aa:bb:cc:dd:ee:01", Hint: ContextHint{VLANID: 100, NameHint: "Gi0/1.100"}, IfIndex: 101},
+	}
+
+	rep := a.Run(oracle)
+	assert.Equal(t, 3, rep.Sample)
+	assert.Equal(t, 3, rep.MatchedCorrect)
+	assert.Equal(t, 0, rep.MatchedIncorrect)
+	assert.Equal(t, 0, rep.UnresolvedAmbiguous)
+	assert.Equal(t, 0, rep.Unmatched)
+	assert.InDelta(t, 0.0, rep.MisResolutionRate(), 1e-9)
+	assert.InDelta(t, 1.0, rep.CoverageRate(), 1e-9)
+}
+
+func TestAudit_MisResolutionDetected(t *testing.T) {
+	r := NewResolver(auditScenarioCandidates())
+	a := NewAuditor(r)
+
+	oracle := []OracleEntry{
+		// Oracle says: physical port (ifIndex 1), but we ask for the
+		// sub-interface; the resolver will incorrectly pick the
+		// virtual one. This is the kind of mis-resolution the audit
+		// must catch.
+		{
+			MAC:     "aa:bb:cc:dd:ee:01",
+			Hint:    ContextHint{VLANID: 100, NameHint: "Gi0/1.100"},
+			IfIndex: 1, // oracle disagrees with the resolver
+		},
+	}
+	rep := a.Run(oracle)
+
+	assert.Equal(t, 1, rep.Sample)
+	assert.Equal(t, 0, rep.MatchedCorrect)
+	assert.Equal(t, 1, rep.MatchedIncorrect)
+	assert.InDelta(t, 1.0, rep.MisResolutionRate(), 1e-9)
+}
+
+func TestAudit_UnresolvedAmbiguousIsNotMisResolution(t *testing.T) {
+	r := NewResolver(auditScenarioCandidates())
+	a := NewAuditor(r)
+
+	oracle := []OracleEntry{
+		// Ambiguous MAC, no hint at all → resolver returns
+		// UnresolvedAmbiguous. Per PRD, that's the safe path; it
+		// must NOT be counted as a mis-resolution.
+		{MAC: "aa:bb:cc:dd:ee:01", IfIndex: 1},
+	}
+	rep := a.Run(oracle)
+
+	assert.Equal(t, 1, rep.Sample)
+	assert.Equal(t, 0, rep.MatchedCorrect)
+	assert.Equal(t, 0, rep.MatchedIncorrect)
+	assert.Equal(t, 1, rep.UnresolvedAmbiguous)
+	assert.InDelta(t, 0.0, rep.MisResolutionRate(), 1e-9)
+	// Coverage is 0 — resolved/sample = 0/1.
+	assert.InDelta(t, 0.0, rep.CoverageRate(), 1e-9)
+}
+
+func TestAudit_UnmatchedSplit(t *testing.T) {
+	r := NewResolver(auditScenarioCandidates())
+	a := NewAuditor(r)
+
+	oracle := []OracleEntry{
+		// Oracle agrees no interface → correct unmatched.
+		{MAC: "ff:ff:ff:ff:ff:ff", IfIndex: 0},
+		// Oracle disagrees → coverage miss (not correctness).
+		{MAC: "ee:ee:ee:ee:ee:ee", IfIndex: 99},
+	}
+	rep := a.Run(oracle)
+	assert.Equal(t, 2, rep.Sample)
+	assert.Equal(t, 1, rep.MatchedCorrect, "correct unmatched folds into MatchedCorrect")
+	assert.Equal(t, 0, rep.MatchedIncorrect)
+	assert.Equal(t, 1, rep.Unmatched)
+}
+
+// Oracle says "this MAC should map to nothing" but resolver finds an
+// interface anyway → that's a mis-resolution (a false positive).
+func TestAudit_FalsePositiveCountedAsMisResolution(t *testing.T) {
+	r := NewResolver(auditScenarioCandidates())
+	a := NewAuditor(r)
+
+	oracle := []OracleEntry{
+		{MAC: "aa:bb:cc:dd:ee:02", IfIndex: 0}, // oracle says no, resolver says ifIndex 2
+	}
+	rep := a.Run(oracle)
+	assert.Equal(t, 0, rep.MatchedCorrect)
+	assert.Equal(t, 1, rep.MatchedIncorrect)
+}
+
+func TestAudit_AggregatedSampleIsRealistic(t *testing.T) {
+	r := NewResolver(auditScenarioCandidates())
+	a := NewAuditor(r)
+
+	var oracle []OracleEntry
+	// 50 correct lookups for the unique MAC.
+	for i := 0; i < 50; i++ {
+		oracle = append(oracle, OracleEntry{MAC: "aa:bb:cc:dd:ee:02", IfIndex: 2})
+	}
+	// 30 correct ambiguous lookups (physical port).
+	for i := 0; i < 30; i++ {
+		oracle = append(oracle, OracleEntry{
+			MAC:     "aa:bb:cc:dd:ee:01",
+			Hint:    ContextHint{ExpectedType: IfTypeEthernetCsmacd},
+			IfIndex: 1,
+		})
+	}
+	// 20 lookups with no hint → UnresolvedAmbiguous.
+	for i := 0; i < 20; i++ {
+		oracle = append(oracle, OracleEntry{MAC: "aa:bb:cc:dd:ee:01", IfIndex: 101})
+	}
+
+	rep := a.Run(oracle)
+	assert.Equal(t, 100, rep.Sample)
+	assert.Equal(t, 80, rep.MatchedCorrect)
+	assert.Equal(t, 20, rep.UnresolvedAmbiguous)
+	assert.InDelta(t, 0.0, rep.MisResolutionRate(), 1e-9, "PRD guardrail: <0.5%")
+	assert.InDelta(t, 0.8, rep.CoverageRate(), 1e-9)
+}

--- a/pkg/networkdevice/interfaceresolver/doc.go
+++ b/pkg/networkdevice/interfaceresolver/doc.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package interfaceresolver maps observed network interfaces (e.g. from
+// SNMP IF-MIB, NetFlow exporters, or host telemetry) to a canonical
+// interface identity.
+//
+// The legacy resolver keyed primarily on MAC address. This breaks when
+// multiple logical interfaces legitimately share a MAC with their parent
+// physical interface — most commonly VLAN sub-interfaces (IF-MIB
+// ifPhysAddress is not unique across ifIndex when sub-interfaces inherit
+// the parent MAC).
+//
+// V1 of this package introduces a deterministic tiebreaker using
+// IF-MIB ifType plus a small amount of resolution context (an optional
+// expected-type hint and an optional interface-name hint). The exact
+// priority of rules is documented on Resolver.Resolve.
+//
+// Design boundaries for V1:
+//
+//   - Only ifType + lightweight context. No LLDP/CDP/ifStackTable fusion;
+//     those are deferred until the audit metric (see Auditor) tells us
+//     ifType alone is not enough.
+//   - The package exposes a small Observer interface so callers can wire
+//     in the agent's preferred telemetry backend without this package
+//     having to depend on it.
+//   - Forward-only. The package does not re-resolve historical telemetry.
+//   - Does not change the canonical interface ID downstream; tagging
+//     contract stays the same — only the resolver's accuracy improves.
+package interfaceresolver

--- a/pkg/networkdevice/interfaceresolver/observer.go
+++ b/pkg/networkdevice/interfaceresolver/observer.go
@@ -17,20 +17,20 @@ package interfaceresolver
 // Stable label semantics (do NOT rename without checking dashboards):
 //
 //   - vendor          : the device vendor as known to the caller
-//                       (e.g. "cisco", "juniper", "arista"). Empty
-//                       string is acceptable but discouraged.
+//     (e.g. "cisco", "juniper", "arista"). Empty
+//     string is acceptable but discouraged.
 //   - outcome         : one of OutcomeMatchedUnique,
-//                       OutcomeMatchedAmbiguous,
-//                       OutcomeUnresolvedAmbiguous, OutcomeUnmatched.
+//     OutcomeMatchedAmbiguous,
+//     OutcomeUnresolvedAmbiguous, OutcomeUnmatched.
 //   - rule            : one of the Rule* constants in resolver.go;
-//                       empty string when no tiebreaker was needed.
+//     empty string when no tiebreaker was needed.
 //   - candidate_count : the bucketed N from the resolution attempt
-//                       (see CandidateCountBucket). High-cardinality
-//                       integers are not safe as metric labels in
-//                       Datadog, so the resolver buckets first.
+//     (see CandidateCountBucket). High-cardinality
+//     integers are not safe as metric labels in
+//     Datadog, so the resolver buckets first.
 //   - if_type         : the IF-MIB ifType integer (used by
-//                       ObserveIfTypeDistribution only). Cardinality
-//                       is bounded by the IANAifType registry.
+//     ObserveIfTypeDistribution only). Cardinality
+//     is bounded by the IANAifType registry.
 type Observer interface {
 	// ObserveResolution is called exactly once per Resolve() call.
 	ObserveResolution(vendor string, result Result)
@@ -69,7 +69,7 @@ func CandidateCountBucket(n int) string {
 // silent but still correct.
 type noopObserver struct{}
 
-func (noopObserver) ObserveResolution(string, Result)          {}
+func (noopObserver) ObserveResolution(string, Result)              {}
 func (noopObserver) ObserveIfTypeDistribution(string, IfType, int) {}
 
 // NoopObserver returns an Observer that does nothing. Useful in unit

--- a/pkg/networkdevice/interfaceresolver/observer.go
+++ b/pkg/networkdevice/interfaceresolver/observer.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interfaceresolver
+
+// Observer is the telemetry surface for the resolver. The package
+// deliberately defines its own interface instead of pulling in
+// pkg/telemetry directly so that callers can wire up whichever
+// telemetry backend the agent is using at that integration point
+// (libtelemetry, expvar, Prometheus, or a unit-test fake).
+//
+// All methods MUST be safe to call from any goroutine. Implementations
+// must not block — the resolver is on a hot path.
+//
+// Stable label semantics (do NOT rename without checking dashboards):
+//
+//   - vendor          : the device vendor as known to the caller
+//                       (e.g. "cisco", "juniper", "arista"). Empty
+//                       string is acceptable but discouraged.
+//   - outcome         : one of OutcomeMatchedUnique,
+//                       OutcomeMatchedAmbiguous,
+//                       OutcomeUnresolvedAmbiguous, OutcomeUnmatched.
+//   - rule            : one of the Rule* constants in resolver.go;
+//                       empty string when no tiebreaker was needed.
+//   - candidate_count : the bucketed N from the resolution attempt
+//                       (see CandidateCountBucket). High-cardinality
+//                       integers are not safe as metric labels in
+//                       Datadog, so the resolver buckets first.
+//   - if_type         : the IF-MIB ifType integer (used by
+//                       ObserveIfTypeDistribution only). Cardinality
+//                       is bounded by the IANAifType registry.
+type Observer interface {
+	// ObserveResolution is called exactly once per Resolve() call.
+	ObserveResolution(vendor string, result Result)
+
+	// ObserveIfTypeDistribution is called once per indexed candidate
+	// at Resolver construction time. It enables the
+	// "ifType-distribution-by-vendor" PRD metric used to decide
+	// whether ifType alone is rich enough on a given vendor.
+	ObserveIfTypeDistribution(vendor string, ifType IfType, count int)
+}
+
+// CandidateCountBucket bins the per-resolution candidate count into a
+// low-cardinality label safe for metric tagging.
+//
+// Buckets: "0", "1", "2", "3-5", "6-10", "11+". Stable strings — do
+// not rename.
+func CandidateCountBucket(n int) string {
+	switch {
+	case n <= 0:
+		return "0"
+	case n == 1:
+		return "1"
+	case n == 2:
+		return "2"
+	case n <= 5:
+		return "3-5"
+	case n <= 10:
+		return "6-10"
+	default:
+		return "11+"
+	}
+}
+
+// noopObserver implements Observer and discards every event. It is
+// the default when callers do not supply one — the resolver is then
+// silent but still correct.
+type noopObserver struct{}
+
+func (noopObserver) ObserveResolution(string, Result)          {}
+func (noopObserver) ObserveIfTypeDistribution(string, IfType, int) {}
+
+// NoopObserver returns an Observer that does nothing. Useful in unit
+// tests and for the small number of call sites where telemetry is
+// undesired (e.g. one-shot CLI scans).
+func NoopObserver() Observer { return noopObserver{} }

--- a/pkg/networkdevice/interfaceresolver/observer_test.go
+++ b/pkg/networkdevice/interfaceresolver/observer_test.go
@@ -48,9 +48,9 @@ func (f *fakeObserver) ObserveIfTypeDistribution(vendor string, t IfType, count 
 func TestCandidateCountBucket(t *testing.T) {
 	cases := map[int]string{
 		-1: "0", 0: "0",
-		1:  "1",
-		2:  "2",
-		3:  "3-5", 4: "3-5", 5: "3-5",
+		1: "1",
+		2: "2",
+		3: "3-5", 4: "3-5", 5: "3-5",
 		6: "6-10", 10: "6-10",
 		11: "11+", 1000: "11+",
 	}

--- a/pkg/networkdevice/interfaceresolver/observer_test.go
+++ b/pkg/networkdevice/interfaceresolver/observer_test.go
@@ -1,0 +1,113 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interfaceresolver
+
+import (
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeObserver captures every event for assertion in tests. Thread-
+// safe — the resolver is documented as safe to share across goroutines
+// and so is its Observer.
+type fakeObserver struct {
+	mu          sync.Mutex
+	resolutions []resolutionEvent
+	typeDist    []typeDistEvent
+}
+
+type resolutionEvent struct {
+	Vendor string
+	Result Result
+}
+
+type typeDistEvent struct {
+	Vendor string
+	IfType IfType
+	Count  int
+}
+
+func (f *fakeObserver) ObserveResolution(vendor string, res Result) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resolutions = append(f.resolutions, resolutionEvent{vendor, res})
+}
+
+func (f *fakeObserver) ObserveIfTypeDistribution(vendor string, t IfType, count int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.typeDist = append(f.typeDist, typeDistEvent{vendor, t, count})
+}
+
+func TestCandidateCountBucket(t *testing.T) {
+	cases := map[int]string{
+		-1: "0", 0: "0",
+		1:  "1",
+		2:  "2",
+		3:  "3-5", 4: "3-5", 5: "3-5",
+		6: "6-10", 10: "6-10",
+		11: "11+", 1000: "11+",
+	}
+	for n, want := range cases {
+		assert.Equal(t, want, CandidateCountBucket(n))
+	}
+}
+
+func TestObserver_ResolutionsAreReported(t *testing.T) {
+	obs := &fakeObserver{}
+	r := NewResolver(vlanColocatedCandidates(),
+		WithVendor("cisco"),
+		WithObserver(obs),
+	)
+
+	r.Resolve("aa:bb:cc:dd:ee:01", ContextHint{ExpectedType: IfTypeEthernetCsmacd})
+	r.Resolve("00:00:00:00:00:00", ContextHint{}) // unmatched
+	r.Resolve("aa:bb:cc:dd:ee:01", ContextHint{}) // unresolved ambiguous
+
+	assert.Len(t, obs.resolutions, 3)
+	assert.Equal(t, "cisco", obs.resolutions[0].Vendor)
+	assert.Equal(t, OutcomeMatchedAmbiguous, obs.resolutions[0].Result.Outcome)
+	assert.Equal(t, RulePreferPhysical, obs.resolutions[0].Result.TiebreakerRule)
+	assert.Equal(t, OutcomeUnmatched, obs.resolutions[1].Result.Outcome)
+	assert.Equal(t, OutcomeUnresolvedAmbiguous, obs.resolutions[2].Result.Outcome)
+}
+
+func TestObserver_IfTypeDistributionAtConstruction(t *testing.T) {
+	obs := &fakeObserver{}
+	_ = NewResolver(vlanColocatedCandidates(),
+		WithVendor("cisco"),
+		WithObserver(obs),
+	)
+
+	// 1 ethernetCsmacd + 2 l2vlan candidates → two histogram buckets.
+	assert.Len(t, obs.typeDist, 2)
+	// Sort by IfType for stable assertion.
+	sort.Slice(obs.typeDist, func(i, j int) bool {
+		return obs.typeDist[i].IfType < obs.typeDist[j].IfType
+	})
+	assert.Equal(t, IfTypeEthernetCsmacd, obs.typeDist[0].IfType)
+	assert.Equal(t, 1, obs.typeDist[0].Count)
+	assert.Equal(t, IfTypeL2Vlan, obs.typeDist[1].IfType)
+	assert.Equal(t, 2, obs.typeDist[1].Count)
+	assert.Equal(t, "cisco", obs.typeDist[0].Vendor)
+}
+
+func TestObserver_DefaultsToNoop(t *testing.T) {
+	// No panic when no observer is supplied.
+	r := NewResolver(vlanColocatedCandidates(), WithVendor("cisco"))
+	res := r.Resolve("aa:bb:cc:dd:ee:01", ContextHint{})
+	assert.Equal(t, OutcomeUnresolvedAmbiguous, res.Outcome)
+}
+
+func TestObserver_NilOptionIsAccepted(t *testing.T) {
+	// WithObserver(nil) must not blow up at Resolve time.
+	r := NewResolver(vlanColocatedCandidates(), WithObserver(nil))
+	res := r.Resolve("aa:bb:cc:dd:ee:01", ContextHint{ExpectedType: IfTypeEthernetCsmacd})
+	assert.Equal(t, OutcomeMatchedAmbiguous, res.Outcome)
+}

--- a/pkg/networkdevice/interfaceresolver/resolver.go
+++ b/pkg/networkdevice/interfaceresolver/resolver.go
@@ -25,8 +25,37 @@ const (
 // is read-only after construction (NewResolver builds the index in one
 // pass) and therefore safe to share across goroutines.
 type Resolver struct {
+	// vendor is the device vendor as known to the caller. Used as
+	// a telemetry label only. Empty string is acceptable but
+	// discouraged.
+	vendor string
+	// observer receives instrumentation events. Never nil — defaults
+	// to NoopObserver.
+	observer Observer
 	// byMAC maps lowercase MAC address → all candidates carrying it.
 	byMAC map[string][]Candidate
+}
+
+// Option configures a Resolver at construction time.
+type Option func(*Resolver)
+
+// WithVendor sets the device vendor label used by the Observer.
+// Vendor strings should be lowercase and short (e.g. "cisco",
+// "juniper", "arista"). Cardinality is bounded by the number of
+// supported vendors.
+func WithVendor(vendor string) Option {
+	return func(r *Resolver) { r.vendor = vendor }
+}
+
+// WithObserver attaches an Observer for instrumentation. Nil is
+// accepted and treated as NoopObserver.
+func WithObserver(o Observer) Option {
+	return func(r *Resolver) {
+		if o == nil {
+			o = NoopObserver()
+		}
+		r.observer = o
+	}
 }
 
 // NewResolver builds a Resolver over the given candidates. Duplicate
@@ -34,11 +63,21 @@ type Resolver struct {
 // occurrence. Candidates with empty MAC are tolerated but not indexed.
 // MAC normalisation is canonical-lowercase, colon-separated; callers
 // are expected to already use formatColonSepBytes from internal/report.
-func NewResolver(candidates []Candidate) *Resolver {
+//
+// Instrumentation: during construction, the resolver emits one
+// ObserveIfTypeDistribution event per (ifType, count) pair seen.
+// This is the per-device snapshot the PRD calls for in step 1 of
+// scope ("instrument ifType value distribution per vendor").
+func NewResolver(candidates []Candidate, opts ...Option) *Resolver {
 	r := &Resolver{
-		byMAC: make(map[string][]Candidate, len(candidates)),
+		observer: NoopObserver(),
+		byMAC:    make(map[string][]Candidate, len(candidates)),
+	}
+	for _, opt := range opts {
+		opt(r)
 	}
 	seenIdx := make(map[int32]struct{}, len(candidates))
+	typeHist := make(map[IfType]int)
 	for _, c := range candidates {
 		if c.Index <= 0 {
 			continue
@@ -47,12 +86,16 @@ func NewResolver(candidates []Candidate) *Resolver {
 			continue
 		}
 		seenIdx[c.Index] = struct{}{}
+		typeHist[c.Type]++
 		mac := normalizeMAC(c.MAC)
 		if mac == "" {
 			continue
 		}
 		c.MAC = mac
 		r.byMAC[mac] = append(r.byMAC[mac], c)
+	}
+	for t, n := range typeHist {
+		r.observer.ObserveIfTypeDistribution(r.vendor, t, n)
 	}
 	return r
 }
@@ -76,6 +119,14 @@ func NewResolver(candidates []Candidate) *Resolver {
 // different fields of ContextHint). If neither rule (a/b) nor rule (c)
 // can break the tie, the result is unresolved.
 func (r *Resolver) Resolve(mac string, hint ContextHint) Result {
+	res := r.resolve(mac, hint)
+	r.observer.ObserveResolution(r.vendor, res)
+	return res
+}
+
+// resolve is the pure tiebreaker logic — no instrumentation. Exposed
+// privately so tests can exercise it without a fake Observer.
+func (r *Resolver) resolve(mac string, hint ContextHint) Result {
 	mac = normalizeMAC(mac)
 	candidates := r.byMAC[mac]
 	switch len(candidates) {

--- a/pkg/networkdevice/interfaceresolver/resolver.go
+++ b/pkg/networkdevice/interfaceresolver/resolver.go
@@ -1,0 +1,243 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interfaceresolver
+
+import (
+	"strings"
+)
+
+// Tiebreaker rule names emitted on Result.TiebreakerRule. These are
+// stable strings — see the design note in types.go about Outcome
+// labels.
+const (
+	RuleNone                = ""
+	RulePreferPhysical      = "prefer_physical"
+	RulePreferVirtual       = "prefer_virtual"
+	RuleMatchExpectedType   = "match_expected_type"
+	RuleLongestCommonPrefix = "longest_common_prefix"
+)
+
+// Resolver maps MAC addresses to interface candidates. One Resolver
+// instance corresponds to one device's interface table. The Resolver
+// is read-only after construction (NewResolver builds the index in one
+// pass) and therefore safe to share across goroutines.
+type Resolver struct {
+	// byMAC maps lowercase MAC address → all candidates carrying it.
+	byMAC map[string][]Candidate
+}
+
+// NewResolver builds a Resolver over the given candidates. Duplicate
+// candidates (same ifIndex) are de-duplicated keeping the first
+// occurrence. Candidates with empty MAC are tolerated but not indexed.
+// MAC normalisation is canonical-lowercase, colon-separated; callers
+// are expected to already use formatColonSepBytes from internal/report.
+func NewResolver(candidates []Candidate) *Resolver {
+	r := &Resolver{
+		byMAC: make(map[string][]Candidate, len(candidates)),
+	}
+	seenIdx := make(map[int32]struct{}, len(candidates))
+	for _, c := range candidates {
+		if c.Index <= 0 {
+			continue
+		}
+		if _, dup := seenIdx[c.Index]; dup {
+			continue
+		}
+		seenIdx[c.Index] = struct{}{}
+		mac := normalizeMAC(c.MAC)
+		if mac == "" {
+			continue
+		}
+		c.MAC = mac
+		r.byMAC[mac] = append(r.byMAC[mac], c)
+	}
+	return r
+}
+
+// Resolve returns the canonical interface for the given MAC plus
+// optional context hint.
+//
+// Tiebreaker priority (V1, matches PRD scope item #3):
+//
+//	(a) prefer ethernetCsmacd (6) over l2vlan/propVirtual when context
+//	    indicates a physical port (ExpectedType.IsPhysical()).
+//	(b) prefer the virtual candidate (l2vlan / propVirtual / l3ipvlan /
+//	    bridge) when context carries a VLAN ID or names a virtual
+//	    ExpectedType.
+//	(c) prefer the candidate whose ifName is the longest common prefix
+//	    of the context's NameHint.
+//	(d) if still ambiguous, return OutcomeUnresolvedAmbiguous and let
+//	    the caller decide — DO NOT guess silently.
+//
+// Rules (a) and (b) are mutually exclusive on a given call (they read
+// different fields of ContextHint). If neither rule (a/b) nor rule (c)
+// can break the tie, the result is unresolved.
+func (r *Resolver) Resolve(mac string, hint ContextHint) Result {
+	mac = normalizeMAC(mac)
+	candidates := r.byMAC[mac]
+	switch len(candidates) {
+	case 0:
+		return Result{Outcome: OutcomeUnmatched, CandidateCount: 0}
+	case 1:
+		c := candidates[0]
+		return Result{Interface: &c, Outcome: OutcomeMatchedUnique, CandidateCount: 1}
+	}
+
+	// Rule (a): caller asked for a physical port.
+	if hint.ExpectedType.IsPhysical() {
+		if pick, ok := pickUnique(candidates, func(c Candidate) bool {
+			return c.Type.IsPhysical()
+		}); ok {
+			return Result{
+				Interface:      &pick,
+				Outcome:        OutcomeMatchedAmbiguous,
+				CandidateCount: len(candidates),
+				TiebreakerRule: RulePreferPhysical,
+			}
+		}
+	}
+
+	// Rule (b): caller asked for a virtual / sub-interface.
+	if hint.VLANID > 0 || hint.ExpectedType.IsVirtual() {
+		if pick, ok := pickUnique(candidates, func(c Candidate) bool {
+			return c.Type.IsVirtual()
+		}); ok {
+			return Result{
+				Interface:      &pick,
+				Outcome:        OutcomeMatchedAmbiguous,
+				CandidateCount: len(candidates),
+				TiebreakerRule: RulePreferVirtual,
+			}
+		}
+	}
+
+	// Rule (a/b) generalised: prefer the candidate whose Type
+	// equals ExpectedType exactly. This handles non-physical /
+	// non-vlan ExpectedType values (e.g. LAG).
+	if hint.ExpectedType != 0 {
+		if pick, ok := pickUnique(candidates, func(c Candidate) bool {
+			return c.Type == hint.ExpectedType
+		}); ok {
+			return Result{
+				Interface:      &pick,
+				Outcome:        OutcomeMatchedAmbiguous,
+				CandidateCount: len(candidates),
+				TiebreakerRule: RuleMatchExpectedType,
+			}
+		}
+	}
+
+	// Rule (c): longest common prefix vs NameHint. We require a
+	// strict winner — if two candidates tie on prefix length, we do
+	// NOT pick.
+	if hint.NameHint != "" {
+		if pick, ok := pickByLongestCommonPrefix(candidates, hint.NameHint); ok {
+			return Result{
+				Interface:      &pick,
+				Outcome:        OutcomeMatchedAmbiguous,
+				CandidateCount: len(candidates),
+				TiebreakerRule: RuleLongestCommonPrefix,
+			}
+		}
+	}
+
+	// Rule (d): give up safely. The caller can log + skip; we never
+	// silently pick one of the candidates.
+	return Result{
+		Outcome:        OutcomeUnresolvedAmbiguous,
+		CandidateCount: len(candidates),
+	}
+}
+
+// CandidatesForMAC exposes the raw candidate list for a MAC. Returns
+// the empty slice when MAC is unknown. Callers should not mutate the
+// returned slice. Intended for use by the Auditor and by debug tooling.
+func (r *Resolver) CandidatesForMAC(mac string) []Candidate {
+	return r.byMAC[normalizeMAC(mac)]
+}
+
+// AmbiguousMACs returns every MAC for which the resolver has more than
+// one candidate. Useful for the Auditor's mis-resolution sampling and
+// for the per-device "MAC-collision rate" telemetry counter.
+func (r *Resolver) AmbiguousMACs() []string {
+	var out []string
+	for mac, cs := range r.byMAC {
+		if len(cs) > 1 {
+			out = append(out, mac)
+		}
+	}
+	return out
+}
+
+// pickUnique returns the only candidate matching pred. If zero or >1
+// match, ok is false.
+func pickUnique(cs []Candidate, pred func(Candidate) bool) (Candidate, bool) {
+	var pick Candidate
+	count := 0
+	for _, c := range cs {
+		if pred(c) {
+			pick = c
+			count++
+		}
+	}
+	if count == 1 {
+		return pick, true
+	}
+	return Candidate{}, false
+}
+
+// pickByLongestCommonPrefix returns the candidate whose Name shares
+// the longest common prefix with hint. Requires a strict winner — if
+// multiple candidates tie on prefix length, ok is false.
+//
+// A zero-length common prefix is treated as "no match" — otherwise
+// every candidate would tie at length 0 and we'd silently pick the
+// first.
+func pickByLongestCommonPrefix(cs []Candidate, hint string) (Candidate, bool) {
+	bestLen := 0
+	tie := false
+	var pick Candidate
+	for _, c := range cs {
+		n := commonPrefixLen(c.Name, hint)
+		switch {
+		case n > bestLen:
+			bestLen = n
+			pick = c
+			tie = false
+		case n == bestLen && bestLen > 0:
+			tie = true
+		}
+	}
+	if bestLen == 0 || tie {
+		return Candidate{}, false
+	}
+	return pick, true
+}
+
+func commonPrefixLen(a, b string) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
+}
+
+// normalizeMAC lowercases a MAC and trims surrounding whitespace.
+// We do NOT do format conversion (e.g. dashes → colons) here — callers
+// upstream are expected to use formatColonSepBytes so all stored MACs
+// are already canonical. This function exists only to defend against
+// case mismatches.
+func normalizeMAC(mac string) string {
+	if mac == "" {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(mac))
+}

--- a/pkg/networkdevice/interfaceresolver/resolver_test.go
+++ b/pkg/networkdevice/interfaceresolver/resolver_test.go
@@ -1,0 +1,278 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interfaceresolver
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test data: a typical Cisco-ish device with one physical port and two
+// VLAN sub-interfaces, all sharing the parent MAC. This is the canonical
+// shape the PRD calls out as the riskiest collision.
+func vlanColocatedCandidates() []Candidate {
+	mac := "aa:bb:cc:dd:ee:01"
+	return []Candidate{
+		{Index: 1, Name: "Gi0/1", MAC: mac, Type: IfTypeEthernetCsmacd},
+		{Index: 101, Name: "Gi0/1.100", MAC: mac, Type: IfTypeL2Vlan},
+		{Index: 102, Name: "Gi0/1.200", MAC: mac, Type: IfTypeL2Vlan},
+	}
+}
+
+func TestNewResolver_SkipsInvalidCandidates(t *testing.T) {
+	r := NewResolver([]Candidate{
+		{Index: 0, Name: "bogus", MAC: "aa:bb:cc:dd:ee:00"},  // ifIndex 0
+		{Index: -1, Name: "bogus", MAC: "aa:bb:cc:dd:ee:00"}, // negative ifIndex
+		{Index: 1, Name: "Gi0/1", MAC: ""},                   // empty MAC
+		{Index: 2, Name: "Gi0/2", MAC: "aa:bb:cc:dd:ee:02"},
+		{Index: 2, Name: "Gi0/2-dup", MAC: "aa:bb:cc:dd:ee:02"}, // dup ifIndex
+	})
+
+	assert.Len(t, r.CandidatesForMAC("aa:bb:cc:dd:ee:02"), 1)
+	assert.Empty(t, r.CandidatesForMAC("aa:bb:cc:dd:ee:00"))
+}
+
+func TestResolve_UniqueMatch(t *testing.T) {
+	r := NewResolver([]Candidate{
+		{Index: 5, Name: "Gi0/5", MAC: "aa:bb:cc:dd:ee:05", Type: IfTypeEthernetCsmacd},
+	})
+
+	res := r.Resolve("aa:bb:cc:dd:ee:05", ContextHint{})
+
+	assert.Equal(t, OutcomeMatchedUnique, res.Outcome)
+	require.NotNil(t, res.Interface)
+	assert.Equal(t, int32(5), res.Interface.Index)
+	assert.Equal(t, 1, res.CandidateCount)
+	assert.Equal(t, RuleNone, res.TiebreakerRule)
+}
+
+func TestResolve_Unmatched(t *testing.T) {
+	r := NewResolver([]Candidate{
+		{Index: 5, Name: "Gi0/5", MAC: "aa:bb:cc:dd:ee:05", Type: IfTypeEthernetCsmacd},
+	})
+
+	res := r.Resolve("00:00:00:00:00:00", ContextHint{})
+
+	assert.Equal(t, OutcomeUnmatched, res.Outcome)
+	assert.Nil(t, res.Interface)
+	assert.Equal(t, 0, res.CandidateCount)
+}
+
+func TestResolve_MACCaseInsensitive(t *testing.T) {
+	r := NewResolver([]Candidate{
+		{Index: 5, Name: "Gi0/5", MAC: "AA:BB:CC:DD:EE:05", Type: IfTypeEthernetCsmacd},
+	})
+
+	res := r.Resolve("aa:bb:cc:dd:ee:05", ContextHint{})
+
+	assert.Equal(t, OutcomeMatchedUnique, res.Outcome)
+	require.NotNil(t, res.Interface)
+	// Stored MAC is normalised lowercase.
+	assert.Equal(t, "aa:bb:cc:dd:ee:05", res.Interface.MAC)
+}
+
+func TestResolve_AmbiguousNoHint_Unresolved(t *testing.T) {
+	r := NewResolver(vlanColocatedCandidates())
+
+	res := r.Resolve("aa:bb:cc:dd:ee:01", ContextHint{})
+
+	assert.Equal(t, OutcomeUnresolvedAmbiguous, res.Outcome)
+	assert.Nil(t, res.Interface, "must NOT silently guess one of the candidates")
+	assert.Equal(t, 3, res.CandidateCount)
+}
+
+// Rule (a): caller wants the physical port.
+func TestResolve_PreferPhysical(t *testing.T) {
+	r := NewResolver(vlanColocatedCandidates())
+
+	res := r.Resolve("aa:bb:cc:dd:ee:01", ContextHint{
+		ExpectedType: IfTypeEthernetCsmacd,
+	})
+
+	assert.Equal(t, OutcomeMatchedAmbiguous, res.Outcome)
+	assert.Equal(t, RulePreferPhysical, res.TiebreakerRule)
+	require.NotNil(t, res.Interface)
+	assert.Equal(t, int32(1), res.Interface.Index, "must pick the ethernetCsmacd candidate")
+}
+
+// Rule (b): caller has a VLAN ID, wants a sub-interface, but we have
+// two sub-interfaces in the candidate set. Rule (b) requires a UNIQUE
+// virtual candidate — with two, it falls through to rule (c)/(d).
+func TestResolve_PreferVirtual_ButAmbiguousAmongVirtuals(t *testing.T) {
+	r := NewResolver(vlanColocatedCandidates())
+
+	res := r.Resolve("aa:bb:cc:dd:ee:01", ContextHint{VLANID: 100})
+
+	// Two l2vlan candidates — rule (b) cannot pick a unique one, and
+	// no NameHint was given, so we end up unresolved.
+	assert.Equal(t, OutcomeUnresolvedAmbiguous, res.Outcome)
+	assert.Equal(t, 3, res.CandidateCount)
+}
+
+// Rule (b) + (c): VLAN ID and a NameHint together pick the right
+// sub-interface.
+func TestResolve_PreferVirtual_PlusNameHint_Picks(t *testing.T) {
+	r := NewResolver(vlanColocatedCandidates())
+
+	res := r.Resolve("aa:bb:cc:dd:ee:01", ContextHint{
+		VLANID:   200,
+		NameHint: "Gi0/1.200",
+	})
+
+	// Rule (b) cannot pick uniquely among two l2vlans, but rule (c)
+	// (longest common prefix) does pick Gi0/1.200.
+	require.NotNil(t, res.Interface)
+	assert.Equal(t, OutcomeMatchedAmbiguous, res.Outcome)
+	assert.Equal(t, RuleLongestCommonPrefix, res.TiebreakerRule)
+	assert.Equal(t, int32(102), res.Interface.Index)
+}
+
+// Rule (b) DOES pick uniquely when only one virtual is in the set.
+func TestResolve_PreferVirtual_UniqueVirtual(t *testing.T) {
+	mac := "aa:bb:cc:dd:ee:01"
+	r := NewResolver([]Candidate{
+		{Index: 1, Name: "Gi0/1", MAC: mac, Type: IfTypeEthernetCsmacd},
+		{Index: 101, Name: "Gi0/1.100", MAC: mac, Type: IfTypeL2Vlan},
+	})
+
+	res := r.Resolve(mac, ContextHint{VLANID: 100})
+
+	require.NotNil(t, res.Interface)
+	assert.Equal(t, OutcomeMatchedAmbiguous, res.Outcome)
+	assert.Equal(t, RulePreferVirtual, res.TiebreakerRule)
+	assert.Equal(t, int32(101), res.Interface.Index)
+}
+
+// Rule (c) only: NameHint with no type signal.
+func TestResolve_LongestCommonPrefix_Picks(t *testing.T) {
+	r := NewResolver(vlanColocatedCandidates())
+
+	res := r.Resolve("aa:bb:cc:dd:ee:01", ContextHint{NameHint: "Gi0/1.100"})
+
+	require.NotNil(t, res.Interface)
+	assert.Equal(t, OutcomeMatchedAmbiguous, res.Outcome)
+	assert.Equal(t, RuleLongestCommonPrefix, res.TiebreakerRule)
+	assert.Equal(t, int32(101), res.Interface.Index)
+}
+
+// Rule (c) refuses to pick on a zero-length common prefix — that would
+// be the same as "first candidate wins", which is exactly the silent
+// guess the PRD forbids.
+func TestResolve_LongestCommonPrefix_RefusesZeroLenPrefix(t *testing.T) {
+	mac := "aa:bb:cc:dd:ee:01"
+	r := NewResolver([]Candidate{
+		{Index: 1, Name: "Gi0/1", MAC: mac, Type: IfTypeL2Vlan},
+		{Index: 2, Name: "Gi0/2", MAC: mac, Type: IfTypeL2Vlan},
+	})
+
+	res := r.Resolve(mac, ContextHint{NameHint: "WhollyDifferentName"})
+
+	assert.Equal(t, OutcomeUnresolvedAmbiguous, res.Outcome)
+	assert.Nil(t, res.Interface)
+}
+
+// Rule (c) refuses to pick when two candidates tie on prefix length.
+func TestResolve_LongestCommonPrefix_RefusesTie(t *testing.T) {
+	mac := "aa:bb:cc:dd:ee:01"
+	r := NewResolver([]Candidate{
+		{Index: 1, Name: "Et0/1", MAC: mac, Type: IfTypeL2Vlan},
+		{Index: 2, Name: "Et0/2", MAC: mac, Type: IfTypeL2Vlan},
+	})
+
+	res := r.Resolve(mac, ContextHint{NameHint: "Et0/3"}) // ties at "Et0/" for both
+
+	assert.Equal(t, OutcomeUnresolvedAmbiguous, res.Outcome)
+}
+
+// Rule generalisation: ExpectedType that is neither physical nor
+// virtual (e.g. LAG) should still pick uniquely when one candidate
+// matches exactly.
+func TestResolve_MatchExpectedType_LAG(t *testing.T) {
+	mac := "aa:bb:cc:dd:ee:01"
+	r := NewResolver([]Candidate{
+		{Index: 1, Name: "Gi0/1", MAC: mac, Type: IfTypeEthernetCsmacd},
+		{Index: 99, Name: "Po1", MAC: mac, Type: IfTypeIeee8023adLag},
+	})
+
+	res := r.Resolve(mac, ContextHint{ExpectedType: IfTypeIeee8023adLag})
+
+	require.NotNil(t, res.Interface)
+	assert.Equal(t, OutcomeMatchedAmbiguous, res.Outcome)
+	assert.Equal(t, RuleMatchExpectedType, res.TiebreakerRule)
+	assert.Equal(t, int32(99), res.Interface.Index)
+}
+
+// Defensive: when every candidate has ifType=0 (unknown), the
+// type-based rules silently no-op and we fall through.
+func TestResolve_UnknownIfType_FallsThrough(t *testing.T) {
+	mac := "aa:bb:cc:dd:ee:01"
+	r := NewResolver([]Candidate{
+		{Index: 1, Name: "Gi0/1", MAC: mac, Type: 0},
+		{Index: 2, Name: "Gi0/2", MAC: mac, Type: 0},
+	})
+
+	// With no NameHint and no useful Type, we must NOT pick.
+	res := r.Resolve(mac, ContextHint{ExpectedType: IfTypeEthernetCsmacd})
+	assert.Equal(t, OutcomeUnresolvedAmbiguous, res.Outcome)
+
+	// With a NameHint that disambiguates, rule (c) picks.
+	res = r.Resolve(mac, ContextHint{NameHint: "Gi0/2"})
+	require.NotNil(t, res.Interface)
+	assert.Equal(t, int32(2), res.Interface.Index)
+}
+
+func TestAmbiguousMACs(t *testing.T) {
+	r := NewResolver([]Candidate{
+		{Index: 1, Name: "Gi0/1", MAC: "aa:bb:cc:dd:ee:01", Type: IfTypeEthernetCsmacd},
+		{Index: 2, Name: "Gi0/2", MAC: "aa:bb:cc:dd:ee:02", Type: IfTypeEthernetCsmacd},
+		{Index: 101, Name: "Gi0/1.100", MAC: "aa:bb:cc:dd:ee:01", Type: IfTypeL2Vlan},
+	})
+
+	got := r.AmbiguousMACs()
+	sort.Strings(got)
+	assert.Equal(t, []string{"aa:bb:cc:dd:ee:01"}, got)
+}
+
+func TestIfType_Predicates(t *testing.T) {
+	cases := []struct {
+		t        IfType
+		physical bool
+		virtual  bool
+		vendor   bool
+	}{
+		{IfTypeOther, false, false, true},
+		{IfTypeEthernetCsmacd, true, false, false},
+		{IfType(62), true, false, false},
+		{IfType(69), true, false, false},
+		{IfType(117), true, false, false},
+		{IfTypeL2Vlan, false, true, false},
+		{IfTypePropVirtual, false, true, true},
+		{IfTypeL3Ipvlan, false, true, false},
+		{IfTypeBridge, false, true, false},
+		{IfTypeIeee8023adLag, false, false, false}, // LAG: not virtual for V1 (see types.go)
+		{IfType(999), false, false, false},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, c.physical, c.t.IsPhysical())
+			assert.Equal(t, c.virtual, c.t.IsVirtual())
+			assert.Equal(t, c.vendor, c.t.IsAmbiguousVendorValue())
+		})
+	}
+}
+
+func TestCommonPrefixLen(t *testing.T) {
+	assert.Equal(t, 0, commonPrefixLen("", "x"))
+	assert.Equal(t, 0, commonPrefixLen("x", ""))
+	assert.Equal(t, 0, commonPrefixLen("ab", "cd"))
+	assert.Equal(t, 3, commonPrefixLen("Gi0/1.100", "Gi0"))
+	assert.Equal(t, 8, commonPrefixLen("Gi0/1.10", "Gi0/1.100"))
+	assert.Equal(t, 4, commonPrefixLen("Et0/1", "Et0/2"))
+}

--- a/pkg/networkdevice/interfaceresolver/types.go
+++ b/pkg/networkdevice/interfaceresolver/types.go
@@ -1,0 +1,154 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interfaceresolver
+
+// IfType is the IF-MIB ifType (IANAifType) for an interface. We only
+// reference the values relevant to the V1 tiebreaker; the full registry
+// is large and lives in RFC 7224.
+type IfType int32
+
+// IF-MIB ifType values used by the resolver.
+//
+// Sourced from https://www.iana.org/assignments/ianaiftype-mib. Values
+// not enumerated here are still valid IfType inputs — they simply do
+// not get special treatment.
+const (
+	// IfTypeOther — "other". Vendors sometimes return this for
+	// virtual or proprietary interfaces; treated as "unhelpful" by
+	// the resolver.
+	IfTypeOther IfType = 1
+	// IfTypeEthernetCsmacd — a regular physical Ethernet port.
+	IfTypeEthernetCsmacd IfType = 6
+	// IfTypePropVirtual — a generic virtual interface (sometimes used
+	// for VLAN sub-interfaces or bridge members; vendor-dependent).
+	IfTypePropVirtual IfType = 53
+	// IfTypeL2Vlan — an IEEE 802.1Q VLAN sub-interface.
+	IfTypeL2Vlan IfType = 135
+	// IfTypeL3Ipvlan — an IPv4/IPv6 sub-interface.
+	IfTypeL3Ipvlan IfType = 136
+	// IfTypeIeee8023adLag — a bonding/LACP aggregate interface.
+	IfTypeIeee8023adLag IfType = 161
+	// IfTypeBridge — a bridge interface (rarely surfaced via IF-MIB
+	// but seen on some Linux-based vendors).
+	IfTypeBridge IfType = 209
+)
+
+// IsPhysical reports whether the given ifType denotes a physical
+// Ethernet-like port. Matches the predicate currently used in
+// InterfaceMetadata.IsPhysical for ifType 6/62/69/117.
+func (t IfType) IsPhysical() bool {
+	switch t {
+	case 6, 62, 69, 117:
+		return true
+	}
+	return false
+}
+
+// IsVirtual reports whether the given ifType denotes a logical/virtual
+// interface that commonly inherits its parent's MAC address.
+//
+// Note: ieee8023adLag (161) is intentionally NOT in this set. LAGs
+// aggregate physical NICs and the collision shape they create is
+// "multiple physicals share the LAG's MAC", not "sub-interfaces share
+// a parent's MAC". Rule (b) of the resolver is about the latter; the
+// LAG case is handled by the generalised "match ExpectedType exactly"
+// rule.
+func (t IfType) IsVirtual() bool {
+	switch t {
+	case IfTypePropVirtual, IfTypeL2Vlan, IfTypeL3Ipvlan, IfTypeBridge:
+		return true
+	}
+	return false
+}
+
+// IsAmbiguousVendorValue reports whether the value is one of the
+// vendor-noisy values (1 = other, 53 = propVirtual) that the resolver
+// should treat as "no signal" when scoring candidates.
+//
+// Note: we keep 53 (propVirtual) in this set because at least one major
+// vendor returns it generically for both VLAN and tunnel interfaces.
+// Rule (a) of the tiebreaker still prefers ethernetCsmacd over
+// propVirtual when context says "physical"; this predicate is used
+// only by Auditor for "ifType not helpful" classification.
+func (t IfType) IsAmbiguousVendorValue() bool {
+	return t == IfTypeOther || t == IfTypePropVirtual
+}
+
+// Candidate represents one interface that may be the resolution target.
+// The package keeps this struct minimal on purpose — heavy fields like
+// admin/oper status live elsewhere and are not load-bearing for the V1
+// tiebreaker.
+type Candidate struct {
+	// Index is the IF-MIB ifIndex (or vendor analogue). Must be > 0.
+	Index int32
+	// Name is the ifName (or ifDescr if ifName is empty). Used by
+	// the longest-common-prefix tiebreaker.
+	Name string
+	// MAC is the lowercase, colon-separated MAC address. Empty MAC
+	// candidates are still indexed by Name but ignored by the
+	// MAC-keyed lookup path.
+	MAC string
+	// Type is the IF-MIB ifType. Zero means "unknown / not collected"
+	// and disables the type-based tiebreaker rules for this
+	// candidate (without failing resolution).
+	Type IfType
+}
+
+// ContextHint is the optional context the caller passes to the
+// resolver. Every field is optional; the more fields populated, the
+// fewer ambiguous resolutions surface.
+type ContextHint struct {
+	// ExpectedType, if non-zero, indicates the type of interface the
+	// caller is looking for (e.g. a NetFlow record that came from a
+	// physical port supplies ExpectedType=IfTypeEthernetCsmacd).
+	ExpectedType IfType
+	// VLANID, if non-zero, indicates the caller is looking for a
+	// VLAN/sub-interface tagged with this VLAN ID. Activates the
+	// "prefer virtual" rule.
+	VLANID int
+	// NameHint, if non-empty, is the caller's best guess at the
+	// interface name. Used by the longest-common-prefix tiebreaker
+	// as the final disambiguation step.
+	NameHint string
+}
+
+// Outcome categorises the result of one Resolve call. Stable string
+// values — these are emitted as a telemetry label and must not be
+// renamed without coordinating with downstream dashboards.
+type Outcome string
+
+// Outcome enum values.
+const (
+	// OutcomeMatchedUnique — exactly one candidate matched.
+	OutcomeMatchedUnique Outcome = "matched_unique"
+	// OutcomeMatchedAmbiguous — multiple candidates matched and the
+	// tiebreaker picked one of them.
+	OutcomeMatchedAmbiguous Outcome = "matched_ambiguous"
+	// OutcomeUnresolvedAmbiguous — multiple candidates matched and
+	// the tiebreaker could not narrow them down; the caller MUST NOT
+	// guess.
+	OutcomeUnresolvedAmbiguous Outcome = "unresolved_ambiguous"
+	// OutcomeUnmatched — no candidate matched on MAC at all.
+	OutcomeUnmatched Outcome = "unmatched"
+)
+
+// Result is what Resolve returns. Interface is nil iff the resolution
+// failed (Unmatched or UnresolvedAmbiguous); inspect Outcome and
+// CandidateCount to distinguish.
+type Result struct {
+	// Interface is the chosen candidate. Nil when Outcome is
+	// OutcomeUnmatched or OutcomeUnresolvedAmbiguous.
+	Interface *Candidate
+	// Outcome categorises this resolution attempt.
+	Outcome Outcome
+	// CandidateCount is the number of candidates that matched the
+	// primary key (MAC) before the tiebreaker ran. 0 for Unmatched.
+	CandidateCount int
+	// TiebreakerRule, when Outcome is MatchedAmbiguous, identifies
+	// which tiebreaker rule fired. Empty otherwise. Stable string
+	// values — used as a telemetry label.
+	TiebreakerRule string
+}


### PR DESCRIPTION
## Summary

Introduces a new self-contained library at `pkg/networkdevice/interfaceresolver` that maps observed network interfaces to a canonical identity using MAC + IF-MIB `ifType` as a deterministic tiebreaker. Forward-only, no call-site wiring in this PR.

## Problem & context

The agent's existing interface resolver keys primarily on MAC address. On devices with VLAN sub-interfaces (the majority of enterprise switches/routers), multiple logical interfaces inherit their parent physical interface's MAC, so MAC-only resolution is ambiguous. Today the agent either picks non-deterministically, drops to a lossy fallback, or fails — producing untagged or wrong-tagged NDM/NetFlow telemetry that SREs then can't trust. The PRD calls for an `ifType`-based disambiguator with explicit "unresolved" semantics rather than silent guessing.

## Approach

- New package `pkg/networkdevice/interfaceresolver` (library, not service) so future SNMP / NetFlow / host call sites share one resolver — answers the PRD's open question about "shared vs per-source" by giving every caller one entry point.
- Tiebreaker priority matches PRD scope #3: (a) prefer physical when `ExpectedType.IsPhysical()`, (b) prefer virtual when VLAN/virtual hinted, generalised (c) exact `ExpectedType` match for non-phys/non-virt (e.g. LAG), (d) longest-common-prefix on `NameHint`, (e) `OutcomeUnresolvedAmbiguous` — never silently guess.
- `Observer` interface defined in-package (no `pkg/telemetry` dep) so each call site can wire its own backend; nil-safe via `NoopObserver`. `CandidateCountBucket` pre-bins to prevent high-cardinality metric labels.
- `Auditor` + `AuditReport` separate **correctness** (`MisResolutionRate` excludes unmatched/unresolved from the denominator) from **coverage** (`CoverageRate`), so coverage regressions cannot mask the PRD's <0.5% mis-resolution guardrail.

## Verification

- ✅ `gofmt -l pkg/networkdevice/interfaceresolver/` — clean
- ✅ `go build ./pkg/networkdevice/interfaceresolver/...` — clean
- ✅ `go build ./pkg/snmp/... ./pkg/collector/corechecks/snmp/...` — clean (no regression in adjacent packages)
- ✅ `go vet ./pkg/networkdevice/interfaceresolver/...` — clean
- ✅ `go test -race -count=1 ./pkg/networkdevice/interfaceresolver/...` — 27/27 pass
- ✅ `golangci-lint run --timeout=2m ./pkg/networkdevice/interfaceresolver/...` — 0 issues
- ⚠️ `dda inv linter.go` / `dda inv test` could not run on this worktree: `git describe --tags --match "7.*"` returns no candidates, and the local Go toolchain (1.26.3) does not match the repo-pinned 1.25.10. The implementer flagged the same env limitation in the `fix-gofmt` chunk commit. Re-run on a properly provisioned CI runner before merge.
- **Coverage verdict: adequate.** Tests cover every enumerated failure mode in `<failure_modes_and_recovery>`: ambiguous-no-hint → `UnresolvedAmbiguous`, unknown `ifType` no-op, `IsAmbiguousVendorValue` predicate, duplicate `ifIndex`, empty MAC skipped, MAC case normalisation, zero-length prefix refused, prefix tie refused, LAG `ExpectedType`, plus `AuditReport` rate semantics (no-sample, mis-resolution detected, unresolved-not-counted, unmatched split, false positive, aggregated realism).

## Reviewer action items

- `pkg/networkdevice/interfaceresolver/resolver.go` — confirm the rule ordering (a → b → generalised exact-match → c → d) matches PRD scope #3 intent, especially the LAG carve-out via the generalised rule.
- `pkg/networkdevice/interfaceresolver/types.go` — verify `IsVirtual`'s deliberate exclusion of `ieee8023adLag` (161) is the right call for V1.
- `pkg/networkdevice/interfaceresolver/audit.go` — `MisResolutionRate` denominator (only resolved attempts). This is the load-bearing decision that lets the correctness guardrail survive coverage drops; confirm it matches the PRD's `<0.5%` framing.
- `pkg/networkdevice/interfaceresolver/observer.go` — the `Outcome` and `Rule*` string constants are wire-stable telemetry labels; sanity-check naming before downstream dashboards reference them.
- `pkg/networkdevice/interfaceresolver/BUILD.bazel` — hand-written. Confirm gazelle won't fight it on next `bzl-mod sync` (called out in `<risks_and_unknowns>`).

## Generated-by note

Drafted by the agent-orchestrator pipeline.
