### PR TITLE
Add passthrough for genresources track in the EVP intake

### DIFF
--- a/comp/forwarder/eventplatform/def/component.go
+++ b/comp/forwarder/eventplatform/def/component.go
@@ -37,6 +37,8 @@ const (
 	EventTypeContainerImages = "container-images"
 	// EventTypeContainerSBOM represents a container SBOM event
 	EventTypeContainerSBOM = "container-sbom"
+	// EventTypeGenResources represents a generic resources event
+	EventTypeGenResources = "genresources"
 	// EventTypeSoftwareInventory represents a software inventory event
 	EventTypeSoftwareInventory = "software-inventory"
 	// EventTypeEventManagement represents an event for the Event Management API

--- a/comp/forwarder/eventplatform/impl/epforwarder.go
+++ b/comp/forwarder/eventplatform/impl/epforwarder.go
@@ -278,6 +278,18 @@ func getPassthroughPipelines() []passthroughPipelineDesc {
 			defaultInputChanSize: 1000,
 		},
 		{
+			eventType:                     eventplatform.EventTypeGenResources,
+			category:                      "Generic Resources",
+			contentType:                   logshttp.ProtobufContentType,
+			endpointsConfigPrefix:         "genresources.",
+			hostnameEndpointPrefix:        "resources-intake.",
+			intakeTrackType:               "genresources",
+			defaultBatchMaxConcurrentSend: 10,
+			defaultBatchMaxContentSize:    pkgconfigsetup.DefaultBatchMaxContentSize,
+			defaultBatchMaxSize:           pkgconfigsetup.DefaultBatchMaxSize,
+			defaultInputChanSize:          pkgconfigsetup.DefaultInputChanSize,
+		},
+		{
 			eventType:                     eventplatform.EventTypeSynthetics,
 			category:                      "Synthetics",
 			contentType:                   logshttp.JSONContentType,

--- a/comp/forwarder/eventplatform/impl/epforwarder_test.go
+++ b/comp/forwarder/eventplatform/impl/epforwarder_test.go
@@ -19,7 +19,6 @@ import (
 	laconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	logscompressionfxmock "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -50,25 +49,26 @@ func TestEventPlatformForwarderTestSuite(t *testing.T) {
 }
 
 func (suite *EventPlatformForwarderTestSuite) TestGetPassthroughPipelinesIncludesGenresources() {
-	var genresourcesDesc *passthroughPipelineDesc
+	var genresourcesDesc passthroughPipelineDesc
+	found := false
 	for _, desc := range getPassthroughPipelines() {
 		if desc.eventType == eventplatform.EventTypeGenResources {
-			desc := desc
-			genresourcesDesc = &desc
+			genresourcesDesc = desc
+			found = true
 			break
 		}
 	}
 
-	suite.Require().NotNil(genresourcesDesc)
+	suite.Require().True(found)
 	suite.Equal("Generic Resources", genresourcesDesc.category)
 	suite.Equal(logshttp.ProtobufContentType, genresourcesDesc.contentType)
 	suite.Equal("genresources.", genresourcesDesc.endpointsConfigPrefix)
 	suite.Equal("resources-intake.", genresourcesDesc.hostnameEndpointPrefix)
 	suite.Equal(laconfig.IntakeTrackType("genresources"), genresourcesDesc.intakeTrackType)
 	suite.Equal(10, genresourcesDesc.defaultBatchMaxConcurrentSend)
-	suite.Equal(pkgconfigsetup.DefaultBatchMaxContentSize, genresourcesDesc.defaultBatchMaxContentSize)
-	suite.Equal(pkgconfigsetup.DefaultBatchMaxSize, genresourcesDesc.defaultBatchMaxSize)
-	suite.Equal(pkgconfigsetup.DefaultInputChanSize, genresourcesDesc.defaultInputChanSize)
+	suite.Equal(5000000, genresourcesDesc.defaultBatchMaxContentSize)
+	suite.Equal(1000, genresourcesDesc.defaultBatchMaxSize)
+	suite.Equal(100, genresourcesDesc.defaultInputChanSize)
 }
 
 func (suite *EventPlatformForwarderTestSuite) TestNewHTTPPassthroughPipelineCompression() {

--- a/comp/forwarder/eventplatform/impl/epforwarder_test.go
+++ b/comp/forwarder/eventplatform/impl/epforwarder_test.go
@@ -12,11 +12,14 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	secretsnoopimpl "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl"
+	eventplatform "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/def"
 	eventplatformreceiver "github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/def"
 	eventplatformreceivermock "github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/mock"
+	logshttp "github.com/DataDog/datadog-agent/comp/logs-library/client/http"
 	laconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	logscompressionfxmock "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -44,6 +47,28 @@ func (suite *EventPlatformForwarderTestSuite) SetupTest() {
 
 func TestEventPlatformForwarderTestSuite(t *testing.T) {
 	suite.Run(t, new(EventPlatformForwarderTestSuite))
+}
+
+func (suite *EventPlatformForwarderTestSuite) TestGetPassthroughPipelinesIncludesGenresources() {
+	var genresourcesDesc *passthroughPipelineDesc
+	for _, desc := range getPassthroughPipelines() {
+		if desc.eventType == eventplatform.EventTypeGenResources {
+			desc := desc
+			genresourcesDesc = &desc
+			break
+		}
+	}
+
+	suite.Require().NotNil(genresourcesDesc)
+	suite.Equal("Generic Resources", genresourcesDesc.category)
+	suite.Equal(logshttp.ProtobufContentType, genresourcesDesc.contentType)
+	suite.Equal("genresources.", genresourcesDesc.endpointsConfigPrefix)
+	suite.Equal("resources-intake.", genresourcesDesc.hostnameEndpointPrefix)
+	suite.Equal(laconfig.IntakeTrackType("genresources"), genresourcesDesc.intakeTrackType)
+	suite.Equal(10, genresourcesDesc.defaultBatchMaxConcurrentSend)
+	suite.Equal(pkgconfigsetup.DefaultBatchMaxContentSize, genresourcesDesc.defaultBatchMaxContentSize)
+	suite.Equal(pkgconfigsetup.DefaultBatchMaxSize, genresourcesDesc.defaultBatchMaxSize)
+	suite.Equal(pkgconfigsetup.DefaultInputChanSize, genresourcesDesc.defaultInputChanSize)
 }
 
 func (suite *EventPlatformForwarderTestSuite) TestNewHTTPPassthroughPipelineCompression() {

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -53,6 +53,7 @@ var EventPlatformNameTranslations = map[string]string{
 	"dbm-activity":               "Database Monitoring Activity Samples",
 	"dbm-metadata":               "Database Monitoring Metadata Samples",
 	"dbm-health":                 "Database Monitoring Health Events",
+	"genresources":               "Generic Resources",
 	"network-devices-metadata":   "Network Devices Metadata",
 	"network-devices-netflow":    "Network Devices NetFlow",
 	"network-devices-snmp-traps": "SNMP Traps",

--- a/pkg/collector/check/stats/stats_test.go
+++ b/pkg/collector/check/stats/stats_test.go
@@ -115,28 +115,34 @@ func TestTranslateEventPlatformEventTypes(t *testing.T) {
 	original := map[string]interface{}{
 		"EventPlatformEvents": map[string]interface{}{
 			"dbm-samples":  12,
+			"genresources": 56,
 			"unknown-type": 34,
 		},
 		"EventPlatformEventsErrors": map[string]interface{}{
 			"dbm-samples":  12,
+			"genresources": 56,
 			"unknown-type": 34,
 		},
 		"SomeOtherKey": map[string]interface{}{
 			"dbm-samples":  12,
+			"genresources": 56,
 			"unknown-type": 34,
 		},
 	}
 	expected := map[string]interface{}{
 		"EventPlatformEvents": map[string]interface{}{
 			"Database Monitoring Query Samples": 12,
+			"Generic Resources":                 56,
 			"unknown-type":                      34,
 		},
 		"EventPlatformEventsErrors": map[string]interface{}{
 			"Database Monitoring Query Samples": 12,
+			"Generic Resources":                 56,
 			"unknown-type":                      34,
 		},
 		"SomeOtherKey": map[string]interface{}{
 			"dbm-samples":  12,
+			"genresources": 56,
 			"unknown-type": 34,
 		},
 	}

--- a/pkg/config/schema/core_schema.yaml
+++ b/pkg/config/schema/core_schema.yaml
@@ -14362,6 +14362,122 @@ properties:
     type: string
     default: ''
     comment: Forwarder storage on disk
+  genresources:
+    node_type: section
+    type: object
+    properties:
+      additional_endpoints:
+        node_type: setting
+        type: array
+        default: []
+        items:
+          type: object
+      batch_max_concurrent_send:
+        node_type: setting
+        type: number
+        default: 0
+        tags:
+        - golang_type:int
+      batch_max_content_size:
+        node_type: setting
+        type: number
+        default: 5000000
+        tags:
+        - golang_type:int
+      batch_max_size:
+        node_type: setting
+        type: number
+        default: 1000
+        tags:
+        - golang_type:int
+      batch_wait:
+        node_type: setting
+        type: number
+        default: 5
+        tags:
+        - golang_type:float64
+      compression_kind:
+        node_type: setting
+        type: string
+        default: zstd
+      compression_level:
+        node_type: setting
+        type: number
+        default: 6
+        tags:
+        - golang_type:int
+      connection_reset_interval:
+        node_type: setting
+        type: number
+        default: 0
+        tags:
+        - golang_type:int
+      dd_url:
+        node_type: setting
+        type: string
+        default: ''
+      dev_mode_no_ssl:
+        node_type: setting
+        type: boolean
+        default: false
+        tags:
+        - no-env
+      input_chan_size:
+        node_type: setting
+        type: number
+        default: 100
+        tags:
+        - golang_type:int
+      logs_dd_url:
+        node_type: setting
+        type: string
+        default: ''
+      logs_no_ssl:
+        node_type: setting
+        type: boolean
+        default: false
+      sender_backoff_base:
+        node_type: setting
+        type: number
+        default: 1
+        tags:
+        - golang_type:float64
+      sender_backoff_factor:
+        node_type: setting
+        type: number
+        default: 2
+        tags:
+        - golang_type:float64
+      sender_backoff_max:
+        node_type: setting
+        type: number
+        default: 120
+        tags:
+        - golang_type:float64
+      sender_recovery_interval:
+        node_type: setting
+        type: number
+        default: 2
+        tags:
+        - golang_type:int
+      sender_recovery_reset:
+        node_type: setting
+        type: boolean
+        default: false
+      use_compression:
+        node_type: setting
+        type: boolean
+        default: true
+      use_v2_api:
+        node_type: setting
+        type: boolean
+        default: true
+      zstd_compression_level:
+        node_type: setting
+        type: number
+        default: 1
+        tags:
+        - golang_type:int
   go_core_dump:
     node_type: setting
     type: boolean

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -811,6 +811,9 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("sbom.enabled", false)
 	bindEnvAndSetLogsConfigKeys(config, "sbom.")
 
+	// Generic resources configuration
+	bindEnvAndSetLogsConfigKeys(config, "genresources.")
+
 	// Synthetics configuration
 	config.BindEnvAndSetDefault("synthetics.collector.enabled", false)
 	config.BindEnvAndSetDefault("synthetics.collector.workers", 4)

--- a/releasenotes/notes/add-passthrough-for-genresources-evp-track-368dd2a29d0deb26.yaml
+++ b/releasenotes/notes/add-passthrough-for-genresources-evp-track-368dd2a29d0deb26.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add passthrough entry for genresources EVP intake track.

--- a/tasks/schema/lint_exceptions.yaml
+++ b/tasks/schema/lint_exceptions.yaml
@@ -13,6 +13,9 @@ no_default:
   - dogstatsd_mapper_profiles
   - event_monitoring_config.network_process.max_processes_tracked
   - fleet_policies_dir
+  - genresources.additional_endpoints
+  - genresources.dd_url
+  - genresources.logs_dd_url
   - ha_agent.group
   - http_dial_fallback_delay
   - internal_profiling.profile_dd_url
@@ -59,6 +62,9 @@ no_type:
   - dogstatsd_mapper_profiles
   - event_monitoring_config.network_process.max_processes_tracked
   - fleet_policies_dir
+  - genresources.additional_endpoints
+  - genresources.dd_url
+  - genresources.logs_dd_url
   - ha_agent.group
   - http_dial_fallback_delay
   - internal_profiling.profile_dd_url

--- a/tasks/schema/lint_exceptions.yaml
+++ b/tasks/schema/lint_exceptions.yaml
@@ -13,9 +13,6 @@ no_default:
   - dogstatsd_mapper_profiles
   - event_monitoring_config.network_process.max_processes_tracked
   - fleet_policies_dir
-  - genresources.additional_endpoints
-  - genresources.dd_url
-  - genresources.logs_dd_url
   - ha_agent.group
   - http_dial_fallback_delay
   - internal_profiling.profile_dd_url
@@ -62,9 +59,6 @@ no_type:
   - dogstatsd_mapper_profiles
   - event_monitoring_config.network_process.max_processes_tracked
   - fleet_policies_dir
-  - genresources.additional_endpoints
-  - genresources.dd_url
-  - genresources.logs_dd_url
   - ha_agent.group
   - http_dial_fallback_delay
   - internal_profiling.profile_dd_url


### PR DESCRIPTION
What does this PR do?
Add an entry to the passthrough for the genresources EVP track.
https://datadoghq.atlassian.net/wiki/spaces/EP/pages/652018344/Intake+releases

Motivation
To submit data to data store via general resource track of EVP. Original PR was here, but I messed up with git: https://github.com/DataDog/datadog-agent/pull/50963
