### PR TITLE
[NDMC-173] SNMP topology: prefer physical iface on LLDP multi-match

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -553,6 +553,9 @@ func singlePhysicalCandidateSharingMAC(candidates map[int32]interfaceCandidate) 
 	var physicalCount int
 	var sharedMAC string
 	for _, c := range candidates {
+		if c.macAddress == "" {
+			return interfaceCandidate{}, false
+		}
 		if sharedMAC == "" {
 			sharedMAC = c.macAddress
 		} else if c.macAddress != sharedMAC {
@@ -566,7 +569,7 @@ func singlePhysicalCandidateSharingMAC(candidates map[int32]interfaceCandidate) 
 			}
 		}
 	}
-	return found, physicalCount == 1 && sharedMAC != ""
+	return found, physicalCount == 1
 }
 
 func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]map[string][]interfaceCandidate, localInterfaceIDType string, localInterfaceID string) string {

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -473,6 +473,12 @@ func buildNetworkTopologyMetadataWithCDP(deviceID string, store *metadata.Store,
 
 		remoteDeviceAddress := getRemDeviceAddressByCDPRemIndex(store, strIndex)
 
+		// CDP's local-side identifier is the ifIndex itself (cdpCacheIfIndex
+		// is taken straight from the OID index), so there is no multi-match
+		// ambiguity here — no need for the physical-preference tiebreaker
+		// used by the LLDP path in resolveLocalInterface. If CDP ever gains
+		// a smart-resolution fallback by other id types, route it through
+		// resolveLocalInterface to inherit the tiebreaker.
 		resolvedLocalInterfaceID := deviceID + ":" + cdpCacheIfIndex
 
 		// remEntryUniqueID: The combination of cdpCacheIfIndex and cdpCacheDeviceIndex is expected to be unique for each entry in cdpCacheTable
@@ -536,7 +542,16 @@ func getRemDeviceAddressIfIPType(store *metadata.Store, strIndex string, address
 	return ""
 }
 
-func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]map[string][]int32, localInterfaceIDType string, localInterfaceID string) string {
+// interfaceCandidate represents one candidate interface match during local
+// interface resolution. `isPhysical` mirrors `InterfaceMetadata.IsPhysical`
+// (set today from ifType ∈ {6, 62, 69, 117}); a nil/false value is treated as
+// non-physical so the physical-preference tiebreaker is conservative.
+type interfaceCandidate struct {
+	ifIndex    int32
+	isPhysical bool
+}
+
+func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]map[string][]interfaceCandidate, localInterfaceIDType string, localInterfaceID string) string {
 	if localInterfaceID == "" {
 		return ""
 	}
@@ -546,51 +561,86 @@ func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]ma
 		// "smart resolution" by multiple types when localInterfaceIDType is not provided (which is often the case).
 		// CAVEAT: In case the smart resolution returns false positives, the solution is to configure the device to provide a proper localInterfaceIDType.
 		// The order of `typesToTry` has been arbitrary define (not sure if there is an order that can lead to lower false positive).
+		//
+		// TIEBREAKER: when multiple candidates match (commonly a physical
+		// interface sharing a MAC with one or more virtual interfaces — e.g.
+		// sub-interfaces, VLAN SVIs, LAG members layered on top of an
+		// Ethernet port), the neighbor's LLDP/CDP frame almost always
+		// originated on the physical port — virtual interfaces are local
+		// abstractions invisible on the wire. We therefore prefer the
+		// physical candidate (ifType ∈ {6, 62, 69, 117} per
+		// `InterfaceMetadata.IsPhysical`) when exactly one physical
+		// candidate is present. Multi-physical collisions (e.g.
+		// misconfigured LAGs) still fall back to the historical
+		// "return empty + trace" behavior. See NDMC-173.
 		typesToTry = []string{"mac_address", "interface_name", "interface_alias", "interface_index"}
 	} else {
 		typesToTry = []string{localInterfaceIDType}
 	}
-	matchedIfIndexesMap := make(map[int32]struct{})
+	matchedCandidates := make(map[int32]interfaceCandidate)
 	for _, idType := range typesToTry {
 		interfaceIndexByIDValue, ok := interfaceIndexByIDType[idType]
 		if ok {
-			ifIndexes, ok := interfaceIndexByIDValue[localInterfaceID]
+			candidates, ok := interfaceIndexByIDValue[localInterfaceID]
 			if ok {
-				for _, ifIndex := range ifIndexes {
-					matchedIfIndexesMap[ifIndex] = struct{}{}
+				for _, candidate := range candidates {
+					matchedCandidates[candidate.ifIndex] = candidate
 				}
 			}
 		}
 	}
-	if len(matchedIfIndexesMap) == 1 {
+	if len(matchedCandidates) == 1 {
 		var matchedIfIndexes []int32
-		for key := range matchedIfIndexesMap {
+		for key := range matchedCandidates {
 			matchedIfIndexes = append(matchedIfIndexes, key)
 		}
 		interfaceID := deviceID + ":" + strconv.Itoa(int(matchedIfIndexes[0]))
 		log.Tracef("[local interface resolution] found 1 matching interface (idType=%s, id=%s) resolved to interface_id `%s`", localInterfaceIDType, localInterfaceID, interfaceID)
 		return interfaceID
-	} else if len(matchedIfIndexesMap) > 1 {
-		log.Tracef("[local interface resolution] expected 1 matching interface but found %d (idType=%s, id=%s): %+v", len(matchedIfIndexesMap), localInterfaceIDType, localInterfaceID, matchedIfIndexesMap)
+	} else if len(matchedCandidates) > 1 {
+		// Multi-match tiebreaker: if exactly one of the matched candidates
+		// is a physical interface, prefer it. See comment block above.
+		physicalCandidates := make([]interfaceCandidate, 0, 1)
+		for _, c := range matchedCandidates {
+			if c.isPhysical {
+				physicalCandidates = append(physicalCandidates, c)
+			}
+		}
+		if len(physicalCandidates) == 1 {
+			physical := physicalCandidates[0]
+			interfaceID := deviceID + ":" + strconv.Itoa(int(physical.ifIndex))
+			matchedIfIndexes := make([]int32, 0, len(matchedCandidates))
+			for k := range matchedCandidates {
+				matchedIfIndexes = append(matchedIfIndexes, k)
+			}
+			log.Tracef("[local interface resolution] physical-preference tiebreaker: found %d matching interfaces (candidates=%+v, idType=%s, id=%s), resolved to physical interface_id `%s`", len(matchedCandidates), matchedIfIndexes, localInterfaceIDType, localInterfaceID, interfaceID)
+			return interfaceID
+		}
+		log.Tracef("[local interface resolution] expected 1 matching interface but found %d (idType=%s, id=%s): %+v (physical_candidates=%d)", len(matchedCandidates), localInterfaceIDType, localInterfaceID, matchedCandidates, len(physicalCandidates))
 	} else {
 		log.Tracef("[local interface resolution] expected 1 matching interface but found 0 (idType=%s, id=%s)", localInterfaceIDType, localInterfaceID)
 	}
 	return ""
 }
 
-func buildInterfaceIndexByIDType(interfaces []devicemetadata.InterfaceMetadata) map[string]map[string][]int32 {
-	interfaceIndexByIDType := make(map[string]map[string][]int32) // map[ID_TYPE]map[ID_VALUE]IF_INDEX
+func buildInterfaceIndexByIDType(interfaces []devicemetadata.InterfaceMetadata) map[string]map[string][]interfaceCandidate {
+	interfaceIndexByIDType := make(map[string]map[string][]interfaceCandidate) // map[ID_TYPE]map[ID_VALUE][]interfaceCandidate
 	for _, idType := range []string{"mac_address", "interface_name", "interface_alias", "interface_index"} {
-		interfaceIndexByIDType[idType] = make(map[string][]int32)
+		interfaceIndexByIDType[idType] = make(map[string][]interfaceCandidate)
 	}
 	for _, devInterface := range interfaces {
-		interfaceIndexByIDType["mac_address"][devInterface.MacAddress] = append(interfaceIndexByIDType["mac_address"][devInterface.MacAddress], devInterface.Index)
-		interfaceIndexByIDType["interface_name"][devInterface.Name] = append(interfaceIndexByIDType["interface_name"][devInterface.Name], devInterface.Index)
-		interfaceIndexByIDType["interface_alias"][devInterface.Alias] = append(interfaceIndexByIDType["interface_alias"][devInterface.Alias], devInterface.Index)
+		// nil or false IsPhysical → non-physical, used by the
+		// physical-preference tiebreaker in resolveLocalInterface.
+		isPhysical := devInterface.IsPhysical != nil && *devInterface.IsPhysical
+		candidate := interfaceCandidate{ifIndex: devInterface.Index, isPhysical: isPhysical}
+
+		interfaceIndexByIDType["mac_address"][devInterface.MacAddress] = append(interfaceIndexByIDType["mac_address"][devInterface.MacAddress], candidate)
+		interfaceIndexByIDType["interface_name"][devInterface.Name] = append(interfaceIndexByIDType["interface_name"][devInterface.Name], candidate)
+		interfaceIndexByIDType["interface_alias"][devInterface.Alias] = append(interfaceIndexByIDType["interface_alias"][devInterface.Alias], candidate)
 
 		// interface_index is not a type defined by LLDP, it's used in local interface "smart resolution" when the idType is not present
 		strIndex := strconv.Itoa(int(devInterface.Index))
-		interfaceIndexByIDType["interface_index"][strIndex] = append(interfaceIndexByIDType["interface_index"][strIndex], devInterface.Index)
+		interfaceIndexByIDType["interface_index"][strIndex] = append(interfaceIndexByIDType["interface_index"][strIndex], candidate)
 	}
 	return interfaceIndexByIDType
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -473,12 +473,6 @@ func buildNetworkTopologyMetadataWithCDP(deviceID string, store *metadata.Store,
 
 		remoteDeviceAddress := getRemDeviceAddressByCDPRemIndex(store, strIndex)
 
-		// CDP's local-side identifier is the ifIndex itself (cdpCacheIfIndex
-		// is taken straight from the OID index), so there is no multi-match
-		// ambiguity here — no need for the physical-preference tiebreaker
-		// used by the LLDP path in resolveLocalInterface. If CDP ever gains
-		// a smart-resolution fallback by other id types, route it through
-		// resolveLocalInterface to inherit the tiebreaker.
 		resolvedLocalInterfaceID := deviceID + ":" + cdpCacheIfIndex
 
 		// remEntryUniqueID: The combination of cdpCacheIfIndex and cdpCacheDeviceIndex is expected to be unique for each entry in cdpCacheTable
@@ -542,13 +536,37 @@ func getRemDeviceAddressIfIPType(store *metadata.Store, strIndex string, address
 	return ""
 }
 
-// interfaceCandidate represents one candidate interface match during local
-// interface resolution. `isPhysical` mirrors `InterfaceMetadata.IsPhysical`
-// (set today from ifType ∈ {6, 62, 69, 117}); a nil/false value is treated as
-// non-physical so the physical-preference tiebreaker is conservative.
 type interfaceCandidate struct {
 	ifIndex    int32
 	isPhysical bool
+	macAddress string
+}
+
+// singlePhysicalCandidateSharingMAC returns the sole physical candidate among
+// candidates iff (a) all candidates share the same non-empty MAC and (b)
+// exactly one of them is physical. The shared-MAC precondition is what makes
+// the physical-preference choice sound: LLDP frames originate on the physical
+// port, virtual siblings sharing a MAC (sub-interfaces, VLAN SVIs, LAG
+// members) are invisible on the wire.
+func singlePhysicalCandidateSharingMAC(candidates map[int32]interfaceCandidate) (interfaceCandidate, bool) {
+	var found interfaceCandidate
+	var physicalCount int
+	var sharedMAC string
+	for _, c := range candidates {
+		if sharedMAC == "" {
+			sharedMAC = c.macAddress
+		} else if c.macAddress != sharedMAC {
+			return interfaceCandidate{}, false
+		}
+		if c.isPhysical {
+			found = c
+			physicalCount++
+			if physicalCount > 1 {
+				return interfaceCandidate{}, false
+			}
+		}
+	}
+	return found, physicalCount == 1 && sharedMAC != ""
 }
 
 func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]map[string][]interfaceCandidate, localInterfaceIDType string, localInterfaceID string) string {
@@ -561,18 +579,6 @@ func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]ma
 		// "smart resolution" by multiple types when localInterfaceIDType is not provided (which is often the case).
 		// CAVEAT: In case the smart resolution returns false positives, the solution is to configure the device to provide a proper localInterfaceIDType.
 		// The order of `typesToTry` has been arbitrary define (not sure if there is an order that can lead to lower false positive).
-		//
-		// TIEBREAKER: when multiple candidates match (commonly a physical
-		// interface sharing a MAC with one or more virtual interfaces — e.g.
-		// sub-interfaces, VLAN SVIs, LAG members layered on top of an
-		// Ethernet port), the neighbor's LLDP/CDP frame almost always
-		// originated on the physical port — virtual interfaces are local
-		// abstractions invisible on the wire. We therefore prefer the
-		// physical candidate (ifType ∈ {6, 62, 69, 117} per
-		// `InterfaceMetadata.IsPhysical`) when exactly one physical
-		// candidate is present. Multi-physical collisions (e.g.
-		// misconfigured LAGs) still fall back to the historical
-		// "return empty + trace" behavior. See NDMC-173.
 		typesToTry = []string{"mac_address", "interface_name", "interface_alias", "interface_index"}
 	} else {
 		typesToTry = []string{localInterfaceIDType}
@@ -598,25 +604,12 @@ func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]ma
 		log.Tracef("[local interface resolution] found 1 matching interface (idType=%s, id=%s) resolved to interface_id `%s`", localInterfaceIDType, localInterfaceID, interfaceID)
 		return interfaceID
 	} else if len(matchedCandidates) > 1 {
-		// Multi-match tiebreaker: if exactly one of the matched candidates
-		// is a physical interface, prefer it. See comment block above.
-		physicalCandidates := make([]interfaceCandidate, 0, 1)
-		for _, c := range matchedCandidates {
-			if c.isPhysical {
-				physicalCandidates = append(physicalCandidates, c)
-			}
-		}
-		if len(physicalCandidates) == 1 {
-			physical := physicalCandidates[0]
+		if physical, ok := singlePhysicalCandidateSharingMAC(matchedCandidates); ok {
 			interfaceID := deviceID + ":" + strconv.Itoa(int(physical.ifIndex))
-			matchedIfIndexes := make([]int32, 0, len(matchedCandidates))
-			for k := range matchedCandidates {
-				matchedIfIndexes = append(matchedIfIndexes, k)
-			}
-			log.Tracef("[local interface resolution] physical-preference tiebreaker: found %d matching interfaces (candidates=%+v, idType=%s, id=%s), resolved to physical interface_id `%s`", len(matchedCandidates), matchedIfIndexes, localInterfaceIDType, localInterfaceID, interfaceID)
+			log.Tracef("[local interface resolution] resolved %d candidates to single physical interface_id `%s` (idType=%s, id=%s)", len(matchedCandidates), interfaceID, localInterfaceIDType, localInterfaceID)
 			return interfaceID
 		}
-		log.Tracef("[local interface resolution] expected 1 matching interface but found %d (idType=%s, id=%s): %+v (physical_candidates=%d)", len(matchedCandidates), localInterfaceIDType, localInterfaceID, matchedCandidates, len(physicalCandidates))
+		log.Tracef("[local interface resolution] expected 1 matching interface but found %d (idType=%s, id=%s): %+v", len(matchedCandidates), localInterfaceIDType, localInterfaceID, matchedCandidates)
 	} else {
 		log.Tracef("[local interface resolution] expected 1 matching interface but found 0 (idType=%s, id=%s)", localInterfaceIDType, localInterfaceID)
 	}
@@ -629,10 +622,12 @@ func buildInterfaceIndexByIDType(interfaces []devicemetadata.InterfaceMetadata) 
 		interfaceIndexByIDType[idType] = make(map[string][]interfaceCandidate)
 	}
 	for _, devInterface := range interfaces {
-		// nil or false IsPhysical → non-physical, used by the
-		// physical-preference tiebreaker in resolveLocalInterface.
 		isPhysical := devInterface.IsPhysical != nil && *devInterface.IsPhysical
-		candidate := interfaceCandidate{ifIndex: devInterface.Index, isPhysical: isPhysical}
+		candidate := interfaceCandidate{
+			ifIndex:    devInterface.Index,
+			isPhysical: isPhysical,
+			macAddress: devInterface.MacAddress,
+		}
 
 		interfaceIndexByIDType["mac_address"][devInterface.MacAddress] = append(interfaceIndexByIDType["mac_address"][devInterface.MacAddress], candidate)
 		interfaceIndexByIDType["interface_name"][devInterface.Name] = append(interfaceIndexByIDType["interface_name"][devInterface.Name], candidate)

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -1193,27 +1193,27 @@ func Test_getRemManIPAddrByLLDPRemIndexAndLLDPRemLocalPortNum(t *testing.T) {
 }
 
 func Test_resolveLocalInterface(t *testing.T) {
-	interfaceIndexByIDType := map[string]map[string][]int32{
+	interfaceIndexByIDType := map[string]map[string][]interfaceCandidate{
 		"mac_address": {
-			"00:00:00:00:00:01": []int32{1},
-			"00:00:00:00:00:02": []int32{2},
-			"00:00:00:00:00:03": []int32{3, 4},
+			"00:00:00:00:00:01": {{ifIndex: 1}},
+			"00:00:00:00:00:02": {{ifIndex: 2}},
+			"00:00:00:00:00:03": {{ifIndex: 3}, {ifIndex: 4}},
 		},
 		"interface_name": {
-			"eth1": []int32{1},
-			"eth2": []int32{2},
-			"eth3": []int32{3}, // eth3 is both a name and alias, and reference the same interface
-			"eth4": []int32{4}, // eth4 is both a name and alias, and reference two different interfaces
+			"eth1": {{ifIndex: 1}},
+			"eth2": {{ifIndex: 2}},
+			"eth3": {{ifIndex: 3}}, // eth3 is both a name and alias, and reference the same interface
+			"eth4": {{ifIndex: 4}}, // eth4 is both a name and alias, and reference two different interfaces
 		},
 		"interface_alias": {
-			"alias1": []int32{1},
-			"alias2": []int32{2},
-			"eth3":   []int32{3},
-			"eth4":   []int32{44},
+			"alias1": {{ifIndex: 1}},
+			"alias2": {{ifIndex: 2}},
+			"eth3":   {{ifIndex: 3}},
+			"eth4":   {{ifIndex: 44}},
 		},
 		"interface_index": {
-			"1": []int32{1},
-			"2": []int32{2},
+			"1": {{ifIndex: 1}},
+			"2": {{ifIndex: 2}},
 		},
 	}
 	deviceID := "default:1.2.3.4"
@@ -1306,6 +1306,8 @@ func Test_resolveLocalInterface(t *testing.T) {
 
 func Test_buildInterfaceIndexByIDType(t *testing.T) {
 	// Arrange
+	truePtr := true
+	falsePtr := false
 	interfaces := []metadata.InterfaceMetadata{
 		{
 			DeviceID:   "default:1.2.3.4",
@@ -1313,6 +1315,7 @@ func Test_buildInterfaceIndexByIDType(t *testing.T) {
 			MacAddress: "00:00:00:00:00:01",
 			Name:       "eth1",
 			Alias:      "alias1",
+			IsPhysical: &truePtr,
 		},
 		{
 			DeviceID:   "default:1.2.3.4",
@@ -1320,13 +1323,25 @@ func Test_buildInterfaceIndexByIDType(t *testing.T) {
 			MacAddress: "00:00:00:00:00:02",
 			Name:       "eth2",
 			Alias:      "alias2",
+			IsPhysical: &truePtr,
 		},
 		{
+			// Virtual sub-interface sharing a MAC with ifIndex 2 — exercise
+			// the physical/virtual classification carried into the index.
 			DeviceID:   "default:1.2.3.4",
 			Index:      3,
 			MacAddress: "00:00:00:00:00:02",
 			Name:       "eth3",
 			Alias:      "alias3",
+			IsPhysical: &falsePtr,
+		},
+		{
+			// IsPhysical nil → treated as non-physical by the tiebreaker.
+			DeviceID:   "default:1.2.3.4",
+			Index:      4,
+			MacAddress: "00:00:00:00:00:04",
+			Name:       "eth4",
+			Alias:      "alias4",
 		},
 	}
 
@@ -1334,28 +1349,139 @@ func Test_buildInterfaceIndexByIDType(t *testing.T) {
 	interfaceIndexByIDType := buildInterfaceIndexByIDType(interfaces)
 
 	// Assert
-	expectedInterfaceIndexByIDType := map[string]map[string][]int32{
+	expectedInterfaceIndexByIDType := map[string]map[string][]interfaceCandidate{
 		"mac_address": {
-			"00:00:00:00:00:01": []int32{1},
-			"00:00:00:00:00:02": []int32{2, 3},
+			"00:00:00:00:00:01": {{ifIndex: 1, isPhysical: true}},
+			"00:00:00:00:00:02": {{ifIndex: 2, isPhysical: true}, {ifIndex: 3, isPhysical: false}},
+			"00:00:00:00:00:04": {{ifIndex: 4, isPhysical: false}},
 		},
 		"interface_name": {
-			"eth1": []int32{1},
-			"eth2": []int32{2},
-			"eth3": []int32{3},
+			"eth1": {{ifIndex: 1, isPhysical: true}},
+			"eth2": {{ifIndex: 2, isPhysical: true}},
+			"eth3": {{ifIndex: 3, isPhysical: false}},
+			"eth4": {{ifIndex: 4, isPhysical: false}},
 		},
 		"interface_alias": {
-			"alias1": []int32{1},
-			"alias2": []int32{2},
-			"alias3": []int32{3},
+			"alias1": {{ifIndex: 1, isPhysical: true}},
+			"alias2": {{ifIndex: 2, isPhysical: true}},
+			"alias3": {{ifIndex: 3, isPhysical: false}},
+			"alias4": {{ifIndex: 4, isPhysical: false}},
 		},
 		"interface_index": {
-			"1": []int32{1},
-			"2": []int32{2},
-			"3": []int32{3},
+			"1": {{ifIndex: 1, isPhysical: true}},
+			"2": {{ifIndex: 2, isPhysical: true}},
+			"3": {{ifIndex: 3, isPhysical: false}},
+			"4": {{ifIndex: 4, isPhysical: false}},
 		},
 	}
 	assert.Equal(t, expectedInterfaceIndexByIDType, interfaceIndexByIDType)
+}
+
+// Test_resolveLocalInterface_physicalPreferenceTiebreaker covers the
+// multi-match tiebreaker matrix from the PRD:
+//   (a) 1 physical + N virtual    → resolve to the physical
+//   (b) 0 physical (all-virtual)  → unchanged: empty + trace
+//   (c) ≥2 physical               → unchanged: empty + trace
+//   (d) 1 physical via different idType match (smart resolution)
+func Test_resolveLocalInterface_physicalPreferenceTiebreaker(t *testing.T) {
+	deviceID := "default:1.2.3.4"
+
+	// Shared fixture:
+	//   ifIndex 10 = physical Ethernet
+	//   ifIndex 11 = sub-interface on top of 10 (virtual, shares MAC)
+	//   ifIndex 12 = another virtual sibling (loopback-ish, shares MAC too)
+	//   ifIndex 20 = physical Ethernet B
+	//   ifIndex 21 = physical Ethernet C (used for the 2-physical collision case)
+	//   ifIndex 30, 31 = two virtuals sharing a MAC (no physical at all)
+	macPhysicalPlusVirtuals := "aa:bb:cc:00:00:10"
+	macAllVirtual := "aa:bb:cc:00:00:30"
+	macTwoPhysical := "aa:bb:cc:00:00:20"
+	macSingle := "aa:bb:cc:00:00:99"
+
+	interfaceIndexByIDType := map[string]map[string][]interfaceCandidate{
+		"mac_address": {
+			macPhysicalPlusVirtuals: {
+				{ifIndex: 10, isPhysical: true},
+				{ifIndex: 11, isPhysical: false},
+				{ifIndex: 12, isPhysical: false},
+			},
+			macAllVirtual: {
+				{ifIndex: 30, isPhysical: false},
+				{ifIndex: 31, isPhysical: false},
+			},
+			macTwoPhysical: {
+				{ifIndex: 20, isPhysical: true},
+				{ifIndex: 21, isPhysical: true},
+			},
+			macSingle: {
+				{ifIndex: 99, isPhysical: true},
+			},
+		},
+		"interface_name": {
+			// Same-named pair where the physical wins on a name lookup.
+			"GigabitEthernet1/0/1": {
+				{ifIndex: 10, isPhysical: true},
+				{ifIndex: 11, isPhysical: false},
+			},
+		},
+		"interface_alias": {},
+		"interface_index": {},
+	}
+
+	tests := []struct {
+		name        string
+		localIDType string
+		localID     string
+		expectedID  string
+	}{
+		{
+			name:        "(a) physical + 1 virtual MAC collision -> resolves to physical",
+			localIDType: "mac_address",
+			localID:     macPhysicalPlusVirtuals,
+			expectedID:  "default:1.2.3.4:10",
+		},
+		{
+			name:        "(a) physical + 1 virtual MAC collision via smart resolution -> resolves to physical",
+			localIDType: "", // smart resolution
+			localID:     macPhysicalPlusVirtuals,
+			expectedID:  "default:1.2.3.4:10",
+		},
+		{
+			name:        "(b) all-virtual MAC collision -> empty (no tiebreaker possible)",
+			localIDType: "mac_address",
+			localID:     macAllVirtual,
+			expectedID:  "",
+		},
+		{
+			name:        "(c) two-physical MAC collision -> empty (out of scope per PRD)",
+			localIDType: "mac_address",
+			localID:     macTwoPhysical,
+			expectedID:  "",
+		},
+		{
+			name:        "(c) two-physical MAC collision via smart resolution -> empty",
+			localIDType: "",
+			localID:     macTwoPhysical,
+			expectedID:  "",
+		},
+		{
+			name:        "(d) single-match happy path unchanged",
+			localIDType: "mac_address",
+			localID:     macSingle,
+			expectedID:  "default:1.2.3.4:99",
+		},
+		{
+			name:        "(d) tiebreaker applies to interface_name idType too",
+			localIDType: "interface_name",
+			localID:     "GigabitEthernet1/0/1",
+			expectedID:  "default:1.2.3.4:10",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedID, resolveLocalInterface(deviceID, interfaceIndexByIDType, tt.localIDType, tt.localID))
+		})
+	}
 }
 
 func Test_metricSender_reportNetworkDeviceMetadata_withInterfaceTypeAndIsPhysical(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -1416,6 +1416,11 @@ func Test_resolveLocalInterface_physicalPreferenceTiebreaker(t *testing.T) {
 				{ifIndex: 50, isPhysical: true, macAddress: macSharedByName},
 				{ifIndex: 51, isPhysical: false, macAddress: macSharedByName},
 			},
+			// One candidate carries a MAC, the other does not — must not tiebreak.
+			"Mixed1/0/1": {
+				{ifIndex: 60, isPhysical: true, macAddress: macSharedByName},
+				{ifIndex: 61, isPhysical: false},
+			},
 		},
 		"interface_alias": {},
 		"interface_index": {},
@@ -1474,6 +1479,12 @@ func Test_resolveLocalInterface_physicalPreferenceTiebreaker(t *testing.T) {
 			localIDType: "interface_name",
 			localID:     "Ten1/0/1-shared",
 			expectedID:  "default:1.2.3.4:50",
+		},
+		{
+			name:        "interface_name multi-match with one empty MAC stays unresolved",
+			localIDType: "interface_name",
+			localID:     "Mixed1/0/1",
+			expectedID:  "",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -1326,8 +1326,7 @@ func Test_buildInterfaceIndexByIDType(t *testing.T) {
 			IsPhysical: &truePtr,
 		},
 		{
-			// Virtual sub-interface sharing a MAC with ifIndex 2 — exercise
-			// the physical/virtual classification carried into the index.
+			// Virtual sub-interface sharing a MAC with ifIndex 2.
 			DeviceID:   "default:1.2.3.4",
 			Index:      3,
 			MacAddress: "00:00:00:00:00:02",
@@ -1351,78 +1350,71 @@ func Test_buildInterfaceIndexByIDType(t *testing.T) {
 	// Assert
 	expectedInterfaceIndexByIDType := map[string]map[string][]interfaceCandidate{
 		"mac_address": {
-			"00:00:00:00:00:01": {{ifIndex: 1, isPhysical: true}},
-			"00:00:00:00:00:02": {{ifIndex: 2, isPhysical: true}, {ifIndex: 3, isPhysical: false}},
-			"00:00:00:00:00:04": {{ifIndex: 4, isPhysical: false}},
+			"00:00:00:00:00:01": {{ifIndex: 1, isPhysical: true, macAddress: "00:00:00:00:00:01"}},
+			"00:00:00:00:00:02": {{ifIndex: 2, isPhysical: true, macAddress: "00:00:00:00:00:02"}, {ifIndex: 3, isPhysical: false, macAddress: "00:00:00:00:00:02"}},
+			"00:00:00:00:00:04": {{ifIndex: 4, isPhysical: false, macAddress: "00:00:00:00:00:04"}},
 		},
 		"interface_name": {
-			"eth1": {{ifIndex: 1, isPhysical: true}},
-			"eth2": {{ifIndex: 2, isPhysical: true}},
-			"eth3": {{ifIndex: 3, isPhysical: false}},
-			"eth4": {{ifIndex: 4, isPhysical: false}},
+			"eth1": {{ifIndex: 1, isPhysical: true, macAddress: "00:00:00:00:00:01"}},
+			"eth2": {{ifIndex: 2, isPhysical: true, macAddress: "00:00:00:00:00:02"}},
+			"eth3": {{ifIndex: 3, isPhysical: false, macAddress: "00:00:00:00:00:02"}},
+			"eth4": {{ifIndex: 4, isPhysical: false, macAddress: "00:00:00:00:00:04"}},
 		},
 		"interface_alias": {
-			"alias1": {{ifIndex: 1, isPhysical: true}},
-			"alias2": {{ifIndex: 2, isPhysical: true}},
-			"alias3": {{ifIndex: 3, isPhysical: false}},
-			"alias4": {{ifIndex: 4, isPhysical: false}},
+			"alias1": {{ifIndex: 1, isPhysical: true, macAddress: "00:00:00:00:00:01"}},
+			"alias2": {{ifIndex: 2, isPhysical: true, macAddress: "00:00:00:00:00:02"}},
+			"alias3": {{ifIndex: 3, isPhysical: false, macAddress: "00:00:00:00:00:02"}},
+			"alias4": {{ifIndex: 4, isPhysical: false, macAddress: "00:00:00:00:00:04"}},
 		},
 		"interface_index": {
-			"1": {{ifIndex: 1, isPhysical: true}},
-			"2": {{ifIndex: 2, isPhysical: true}},
-			"3": {{ifIndex: 3, isPhysical: false}},
-			"4": {{ifIndex: 4, isPhysical: false}},
+			"1": {{ifIndex: 1, isPhysical: true, macAddress: "00:00:00:00:00:01"}},
+			"2": {{ifIndex: 2, isPhysical: true, macAddress: "00:00:00:00:00:02"}},
+			"3": {{ifIndex: 3, isPhysical: false, macAddress: "00:00:00:00:00:02"}},
+			"4": {{ifIndex: 4, isPhysical: false, macAddress: "00:00:00:00:00:04"}},
 		},
 	}
 	assert.Equal(t, expectedInterfaceIndexByIDType, interfaceIndexByIDType)
 }
 
-// Test_resolveLocalInterface_physicalPreferenceTiebreaker covers the
-// multi-match tiebreaker matrix from the PRD:
-//
-//	(a) 1 physical + N virtual    → resolve to the physical
-//	(b) 0 physical (all-virtual)  → unchanged: empty + trace
-//	(c) ≥2 physical               → unchanged: empty + trace
-//	(d) 1 physical via different idType match (smart resolution)
 func Test_resolveLocalInterface_physicalPreferenceTiebreaker(t *testing.T) {
 	deviceID := "default:1.2.3.4"
 
-	// Shared fixture:
-	//   ifIndex 10 = physical Ethernet
-	//   ifIndex 11 = sub-interface on top of 10 (virtual, shares MAC)
-	//   ifIndex 12 = another virtual sibling (loopback-ish, shares MAC too)
-	//   ifIndex 20 = physical Ethernet B
-	//   ifIndex 21 = physical Ethernet C (used for the 2-physical collision case)
-	//   ifIndex 30, 31 = two virtuals sharing a MAC (no physical at all)
 	macPhysicalPlusVirtuals := "aa:bb:cc:00:00:10"
 	macAllVirtual := "aa:bb:cc:00:00:30"
 	macTwoPhysical := "aa:bb:cc:00:00:20"
 	macSingle := "aa:bb:cc:00:00:99"
 
+	macSharedByName := "aa:bb:cc:00:00:50"
+
 	interfaceIndexByIDType := map[string]map[string][]interfaceCandidate{
 		"mac_address": {
 			macPhysicalPlusVirtuals: {
-				{ifIndex: 10, isPhysical: true},
-				{ifIndex: 11, isPhysical: false},
-				{ifIndex: 12, isPhysical: false},
+				{ifIndex: 10, isPhysical: true, macAddress: macPhysicalPlusVirtuals},
+				{ifIndex: 11, isPhysical: false, macAddress: macPhysicalPlusVirtuals},
+				{ifIndex: 12, isPhysical: false, macAddress: macPhysicalPlusVirtuals},
 			},
 			macAllVirtual: {
-				{ifIndex: 30, isPhysical: false},
-				{ifIndex: 31, isPhysical: false},
+				{ifIndex: 30, isPhysical: false, macAddress: macAllVirtual},
+				{ifIndex: 31, isPhysical: false, macAddress: macAllVirtual},
 			},
 			macTwoPhysical: {
-				{ifIndex: 20, isPhysical: true},
-				{ifIndex: 21, isPhysical: true},
+				{ifIndex: 20, isPhysical: true, macAddress: macTwoPhysical},
+				{ifIndex: 21, isPhysical: true, macAddress: macTwoPhysical},
 			},
 			macSingle: {
-				{ifIndex: 99, isPhysical: true},
+				{ifIndex: 99, isPhysical: true, macAddress: macSingle},
 			},
 		},
 		"interface_name": {
-			// Same-named pair where the physical wins on a name lookup.
+			// Same-name collision with NO shared MAC — must not tiebreak.
 			"GigabitEthernet1/0/1": {
 				{ifIndex: 10, isPhysical: true},
 				{ifIndex: 11, isPhysical: false},
+			},
+			// Same-name collision where candidates share a MAC — must tiebreak.
+			"Ten1/0/1-shared": {
+				{ifIndex: 50, isPhysical: true, macAddress: macSharedByName},
+				{ifIndex: 51, isPhysical: false, macAddress: macSharedByName},
 			},
 		},
 		"interface_alias": {},
@@ -1436,46 +1428,52 @@ func Test_resolveLocalInterface_physicalPreferenceTiebreaker(t *testing.T) {
 		expectedID  string
 	}{
 		{
-			name:        "(a) physical + 1 virtual MAC collision -> resolves to physical",
+			name:        "one physical + virtuals on same MAC resolves to physical",
 			localIDType: "mac_address",
 			localID:     macPhysicalPlusVirtuals,
 			expectedID:  "default:1.2.3.4:10",
 		},
 		{
-			name:        "(a) physical + 1 virtual MAC collision via smart resolution -> resolves to physical",
-			localIDType: "", // smart resolution
+			name:        "one physical + virtuals via smart resolution resolves to physical",
+			localIDType: "",
 			localID:     macPhysicalPlusVirtuals,
 			expectedID:  "default:1.2.3.4:10",
 		},
 		{
-			name:        "(b) all-virtual MAC collision -> empty (no tiebreaker possible)",
+			name:        "all-virtual collision stays unresolved",
 			localIDType: "mac_address",
 			localID:     macAllVirtual,
 			expectedID:  "",
 		},
 		{
-			name:        "(c) two-physical MAC collision -> empty (out of scope per PRD)",
+			name:        "multi-physical collision stays unresolved",
 			localIDType: "mac_address",
 			localID:     macTwoPhysical,
 			expectedID:  "",
 		},
 		{
-			name:        "(c) two-physical MAC collision via smart resolution -> empty",
+			name:        "multi-physical collision via smart resolution stays unresolved",
 			localIDType: "",
 			localID:     macTwoPhysical,
 			expectedID:  "",
 		},
 		{
-			name:        "(d) single-match happy path unchanged",
+			name:        "single-match happy path unchanged",
 			localIDType: "mac_address",
 			localID:     macSingle,
 			expectedID:  "default:1.2.3.4:99",
 		},
 		{
-			name:        "(d) tiebreaker applies to interface_name idType too",
+			name:        "interface_name multi-match without shared MAC stays unresolved",
 			localIDType: "interface_name",
 			localID:     "GigabitEthernet1/0/1",
-			expectedID:  "default:1.2.3.4:10",
+			expectedID:  "",
+		},
+		{
+			name:        "interface_name multi-match with shared MAC resolves to physical",
+			localIDType: "interface_name",
+			localID:     "Ten1/0/1-shared",
+			expectedID:  "default:1.2.3.4:50",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -1379,10 +1379,11 @@ func Test_buildInterfaceIndexByIDType(t *testing.T) {
 
 // Test_resolveLocalInterface_physicalPreferenceTiebreaker covers the
 // multi-match tiebreaker matrix from the PRD:
-//   (a) 1 physical + N virtual    → resolve to the physical
-//   (b) 0 physical (all-virtual)  → unchanged: empty + trace
-//   (c) ≥2 physical               → unchanged: empty + trace
-//   (d) 1 physical via different idType match (smart resolution)
+//
+//	(a) 1 physical + N virtual    → resolve to the physical
+//	(b) 0 physical (all-virtual)  → unchanged: empty + trace
+//	(c) ≥2 physical               → unchanged: empty + trace
+//	(d) 1 physical via different idType match (smart resolution)
 func Test_resolveLocalInterface_physicalPreferenceTiebreaker(t *testing.T) {
 	deviceID := "default:1.2.3.4"
 


### PR DESCRIPTION
## What

When LLDP local-interface resolution finds >1 candidate ifIndex on a shared identifier (typically a physical port plus virtual siblings — sub-interfaces, VLAN SVIs, LAG members — sharing a MAC), prefer the physical candidate if exactly one is physical **and** all candidates share a non-empty MAC. Falls back to the historical empty + trace behavior on multi-physical collisions or when the shared-MAC precondition does not hold.

## Why

LLDP advertises one neighbor per physical link, but resolution against the device's own interface table can match several ifIndex rows that share an identifier (MAC, name, alias, ifIndex string). The historical "more than one match → unresolved" behavior loses the topology edge in the common case where the extra matches are virtual siblings of a single physical port.

## Scope

- `resolveLocalInterface` gains the tiebreaker on its existing `>1 match` branch via `singlePhysicalCandidateSharingMAC`.
- `interfaceCandidate` now carries `macAddress` alongside `ifIndex` / `isPhysical` so the helper can enforce the shared-MAC precondition. The precondition is what makes the tiebreaker sound: cross-idType smart resolution can produce candidates that don't actually share a MAC, in which case "prefer the physical one" would be guessing rather than disambiguating.
- "Physical" = `InterfaceMetadata.IsPhysical`, derived from `ifType ∈ {6, 62, 69, 117}` (set in `buildNetworkInterfacesMetadata`, PR #45735).
- Multi-physical collisions (e.g. misconfigured LAGs) and candidates that don't share a MAC still fall through to the historical empty + trace behavior.
- CDP is unchanged: `cdpCacheIfIndex` is the ifIndex itself — no ambiguity.

## Known limitation

Custom user profiles that override the `interface` metadata config without including `type` collect no `ifType`, so `IsPhysical` is nil and the tiebreaker degrades to historical behavior. Default profiles are unaffected.

## Verification

- `dda inv test --targets=./pkg/collector/corechecks/snmp/internal/report` — 195/195 pass.
- `Test_resolveLocalInterface_physicalPreferenceTiebreaker` covers:
  - Single physical among virtual siblings sharing a MAC → resolves to the physical ifIndex.
  - Multi-physical collision → unresolved.
  - All-virtual multi-match → unresolved.
  - Single-match path is untouched.
  - `interface_name` multi-match without shared MAC → unresolved.
  - `interface_name` multi-match with shared MAC → resolves to physical (proves the tiebreaker isn't `mac_address`-idType only).
- `Test_buildInterfaceIndexByIDType` covers `IsPhysical` nil → non-physical and MAC plumbing onto candidates.