### PR TITLE
[EBPF] Add metrics validator filter

### DIFF
--- a/pkg/collector/corechecks/gpu/spec/metrics-validator/client.go
+++ b/pkg/collector/corechecks/gpu/spec/metrics-validator/client.go
@@ -135,10 +135,10 @@ func splitScalarColumns(columns []datadogV2.ScalarColumn) ([]scalarResult, error
 	return results, nil
 }
 
-func (c *metricsClient) queryDeviceCount(config gpuspec.GPUConfig, fromTS, toTS int64) (int, error) {
+func (c *metricsClient) queryDeviceCount(config gpuspec.GPUConfig, queryFilter string, fromTS, toTS int64) (int, error) {
 	columns, err := c.runScalarQueries(
 		[]datadogV2.ScalarQuery{
-			buildScalarQuery("q0", fmt.Sprintf("avg:gpu.device.total{%s} by {gpu_uuid}", config.TagFilter()), datadogV2.METRICSAGGREGATOR_AVG),
+			buildScalarQuery("q0", fmt.Sprintf("avg:gpu.device.total{%s} by {gpu_uuid}", queryFilter), datadogV2.METRICSAGGREGATOR_AVG),
 		},
 		fromTS,
 		toTS,
@@ -198,10 +198,10 @@ func (c *metricsClient) queryExpectedMetricPresenceForGPUConfig(metricName strin
 	return observations, nil
 }
 
-func (c *metricsClient) listObservedGPUMetricsForGPUConfig(config gpuspec.GPUConfig, lookbackSeconds int64, metricPrefix string) (map[string]struct{}, error) {
+func (c *metricsClient) listObservedGPUMetricsForGPUConfig(config gpuspec.GPUConfig, queryFilter string, lookbackSeconds int64, metricPrefix string) (map[string]struct{}, error) {
 	metrics := map[string]struct{}{}
 	options := datadogV2.NewListTagConfigurationsOptionalParameters().
-		WithFilterTags(config.TagFilter()).
+		WithFilterTags(queryFilter).
 		WithFilterQueried(true).
 		WithWindowSeconds(max(lookbackSeconds, int64(3600))).
 		WithPageSize(1000) // we don't have that many metrics, no need to paginate

--- a/pkg/collector/corechecks/gpu/spec/metrics-validator/main.go
+++ b/pkg/collector/corechecks/gpu/spec/metrics-validator/main.go
@@ -20,12 +20,14 @@ func main() {
 	var site string
 	var lookbackSeconds int64
 	var outputFile string
+	var metricFilter string
 
 	exitCode := 0
 
 	flag.StringVar(&site, "site", "", "Datadog site")
 	flag.Int64Var(&lookbackSeconds, "lookback-seconds", 3600, "Metrics lookback window in seconds")
 	flag.StringVar(&outputFile, "output-file", "", "Write JSON results to the given file instead of stdout")
+	flag.StringVar(&metricFilter, "metric-filter", "", "Additional Datadog metric filter expression, ANDed with the GPU config filter")
 	flag.Parse()
 
 	if err := validateFlags(site, lookbackSeconds, outputFile); err != nil {
@@ -38,7 +40,7 @@ func main() {
 		log.Fatalf("gpu metrics validation failed: %v", err)
 	}
 
-	results, err := computeValidation(apiKey, appKey, site, lookbackSeconds)
+	results, err := computeValidation(apiKey, appKey, site, lookbackSeconds, metricFilter)
 	if err != nil {
 		log.Printf("gpu metrics validation failed: %v", err)
 		exitCode = 1

--- a/pkg/collector/corechecks/gpu/spec/metrics-validator/main.go
+++ b/pkg/collector/corechecks/gpu/spec/metrics-validator/main.go
@@ -27,7 +27,7 @@ func main() {
 	flag.StringVar(&site, "site", "", "Datadog site")
 	flag.Int64Var(&lookbackSeconds, "lookback-seconds", 3600, "Metrics lookback window in seconds")
 	flag.StringVar(&outputFile, "output-file", "", "Write JSON results to the given file instead of stdout")
-	flag.StringVar(&metricFilter, "metric-filter", "", "Datadog metric filter expression. Defaults to the GPU config filter")
+	flag.StringVar(&metricFilter, "metric-filter", "", "Additional Datadog metric filter expression, ANDed with the GPU config filter")
 	flag.Parse()
 
 	if err := validateFlags(site, lookbackSeconds, outputFile); err != nil {

--- a/pkg/collector/corechecks/gpu/spec/metrics-validator/main.go
+++ b/pkg/collector/corechecks/gpu/spec/metrics-validator/main.go
@@ -27,7 +27,7 @@ func main() {
 	flag.StringVar(&site, "site", "", "Datadog site")
 	flag.Int64Var(&lookbackSeconds, "lookback-seconds", 3600, "Metrics lookback window in seconds")
 	flag.StringVar(&outputFile, "output-file", "", "Write JSON results to the given file instead of stdout")
-	flag.StringVar(&metricFilter, "metric-filter", "", "Additional Datadog metric filter expression, ANDed with the GPU config filter")
+	flag.StringVar(&metricFilter, "metric-filter", "", "Datadog metric filter expression. Defaults to the GPU config filter")
 	flag.Parse()
 
 	if err := validateFlags(site, lookbackSeconds, outputFile); err != nil {

--- a/pkg/collector/corechecks/gpu/spec/metrics-validator/validation.go
+++ b/pkg/collector/corechecks/gpu/spec/metrics-validator/validation.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"log"
 	"maps"
-	"strings"
 	"sync"
 	"time"
 
@@ -67,7 +66,10 @@ func validateGPUConfig(client *metricsClient, specs *gpuspec.Specs, config gpusp
 	expectedMetricsMap := gpuspec.ExpectedMetricsForConfig(specs, config, gpuspec.ValidationOptions{
 		WorkloadActive: true,
 	})
-	queryFilter := combineMetricFilters(config.TagFilter(), metricFilter)
+	queryFilter := config.TagFilter()
+	if metricFilter != "" {
+		queryFilter = metricFilter
+	}
 
 	var err error
 	result.DeviceCount, err = client.queryDeviceCount(config, queryFilter, fromTS, toTS)
@@ -193,16 +195,4 @@ func validateGPUConfig(client *metricsClient, specs *gpuspec.Specs, config gpusp
 	result.State = determineResultState(result)
 
 	return result, allErrors
-}
-
-func combineMetricFilters(filters ...string) string {
-	parts := make([]string, 0, len(filters))
-	for _, filter := range filters {
-		filter = strings.TrimSpace(filter)
-		if filter == "" {
-			continue
-		}
-		parts = append(parts, filter)
-	}
-	return strings.Join(parts, " AND ")
 }

--- a/pkg/collector/corechecks/gpu/spec/metrics-validator/validation.go
+++ b/pkg/collector/corechecks/gpu/spec/metrics-validator/validation.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"maps"
+	"strings"
 	"sync"
 	"time"
 
@@ -66,10 +67,7 @@ func validateGPUConfig(client *metricsClient, specs *gpuspec.Specs, config gpusp
 	expectedMetricsMap := gpuspec.ExpectedMetricsForConfig(specs, config, gpuspec.ValidationOptions{
 		WorkloadActive: true,
 	})
-	queryFilter := config.TagFilter()
-	if metricFilter != "" {
-		queryFilter = metricFilter
-	}
+	queryFilter := combineMetricFilters(config.TagFilter(), metricFilter)
 
 	var err error
 	result.DeviceCount, err = client.queryDeviceCount(config, queryFilter, fromTS, toTS)
@@ -195,4 +193,16 @@ func validateGPUConfig(client *metricsClient, specs *gpuspec.Specs, config gpusp
 	result.State = determineResultState(result)
 
 	return result, allErrors
+}
+
+func combineMetricFilters(filters ...string) string {
+	parts := make([]string, 0, len(filters))
+	for _, filter := range filters {
+		filter = strings.TrimSpace(filter)
+		if filter == "" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("(%s)", filter))
+	}
+	return strings.Join(parts, " AND ")
 }

--- a/pkg/collector/corechecks/gpu/spec/metrics-validator/validation.go
+++ b/pkg/collector/corechecks/gpu/spec/metrics-validator/validation.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"maps"
+	"strings"
 	"sync"
 	"time"
 
@@ -21,7 +22,7 @@ import (
 
 const metricQueryConcurrency = 4
 
-func computeValidation(apiKey, appKey, site string, lookbackSeconds int64) (orgValidationResults, error) {
+func computeValidation(apiKey, appKey, site string, lookbackSeconds int64, metricFilter string) (orgValidationResults, error) {
 	specs, err := gpuspec.LoadSpecs()
 	if err != nil {
 		return orgValidationResults{}, fmt.Errorf("load specs: %w", err)
@@ -40,7 +41,7 @@ func computeValidation(apiKey, appKey, site string, lookbackSeconds int64) (orgV
 	var allErrors error
 	for _, config := range configs {
 		log.Printf("validating gpu config %s/%s", config.Architecture, config.DeviceMode)
-		result, err := validateGPUConfig(client, specs, config, fromTS, now)
+		result, err := validateGPUConfig(client, specs, config, metricFilter, fromTS, now)
 		if err != nil {
 			allErrors = errors.Join(allErrors, fmt.Errorf("validate gpu config %+v: %w", config, err))
 		}
@@ -54,7 +55,7 @@ func computeValidation(apiKey, appKey, site string, lookbackSeconds int64) (orgV
 	}, allErrors
 }
 
-func validateGPUConfig(client *metricsClient, specs *gpuspec.Specs, config gpuspec.GPUConfig, fromTS, toTS int64) (gpuConfigValidationResult, error) {
+func validateGPUConfig(client *metricsClient, specs *gpuspec.Specs, config gpuspec.GPUConfig, metricFilter string, fromTS, toTS int64) (gpuConfigValidationResult, error) {
 	result := gpuConfigValidationResult{
 		Config: config,
 		State:  validationStateMissing,
@@ -66,9 +67,10 @@ func validateGPUConfig(client *metricsClient, specs *gpuspec.Specs, config gpusp
 	expectedMetricsMap := gpuspec.ExpectedMetricsForConfig(specs, config, gpuspec.ValidationOptions{
 		WorkloadActive: true,
 	})
+	queryFilter := combineMetricFilters(config.TagFilter(), metricFilter)
 
 	var err error
-	result.DeviceCount, err = client.queryDeviceCount(config, fromTS, toTS)
+	result.DeviceCount, err = client.queryDeviceCount(config, queryFilter, fromTS, toTS)
 	if err != nil {
 		return result, fmt.Errorf("validate gpu config %+v: %w", config, err)
 	}
@@ -96,7 +98,7 @@ func validateGPUConfig(client *metricsClient, specs *gpuspec.Specs, config gpusp
 
 		// Get the metric values
 		group.Go(func() error {
-			metricObservations, err := client.queryExpectedMetricPresenceForGPUConfig(prefixedMetricName, requiredTags, config.TagFilter(), fromTS, toTS, validatesValues)
+			metricObservations, err := client.queryExpectedMetricPresenceForGPUConfig(prefixedMetricName, requiredTags, queryFilter, fromTS, toTS, validatesValues)
 			if err != nil {
 				return fmt.Errorf("query expected metric presence for %s: %w", metricName, err)
 			}
@@ -116,7 +118,7 @@ func validateGPUConfig(client *metricsClient, specs *gpuspec.Specs, config gpusp
 
 		// Also get tag values for the metric
 		group.Go(func() error {
-			metricTags, err := client.fetchMetricAllTags(prefixedMetricName, requiredTags, tagLookbackSeconds, config.TagFilter())
+			metricTags, err := client.fetchMetricAllTags(prefixedMetricName, requiredTags, tagLookbackSeconds, queryFilter)
 			if err != nil {
 				return fmt.Errorf("fetch metric tags for %s: %w", metricName, err)
 			}
@@ -137,7 +139,7 @@ func validateGPUConfig(client *metricsClient, specs *gpuspec.Specs, config gpusp
 				"gpu_": {},
 			}
 
-			allGpuTags, err := client.fetchMetricAllTags(prefixedMetricName, wantedTags, tagLookbackSeconds, config.TagFilter())
+			allGpuTags, err := client.fetchMetricAllTags(prefixedMetricName, wantedTags, tagLookbackSeconds, queryFilter)
 			if err != nil {
 				return fmt.Errorf("fetch metric tags for %s: %w", metricName, err)
 			}
@@ -169,7 +171,7 @@ func validateGPUConfig(client *metricsClient, specs *gpuspec.Specs, config gpusp
 	}
 
 	// Get any other metrics that were emitted with the GPU prefix but aren't in the expected metrics
-	liveMetrics, err := client.listObservedGPUMetricsForGPUConfig(config, max(toTS-fromTS, int64(0)), specs.Metrics.MetricPrefix)
+	liveMetrics, err := client.listObservedGPUMetricsForGPUConfig(config, queryFilter, max(toTS-fromTS, int64(0)), specs.Metrics.MetricPrefix)
 	if err != nil {
 		allErrors = errors.Join(allErrors, fmt.Errorf("error listing observed gpu metrics: %w", err))
 	}
@@ -191,4 +193,16 @@ func validateGPUConfig(client *metricsClient, specs *gpuspec.Specs, config gpusp
 	result.State = determineResultState(result)
 
 	return result, allErrors
+}
+
+func combineMetricFilters(filters ...string) string {
+	parts := make([]string, 0, len(filters))
+	for _, filter := range filters {
+		filter = strings.TrimSpace(filter)
+		if filter == "" {
+			continue
+		}
+		parts = append(parts, filter)
+	}
+	return strings.Join(parts, " AND ")
 }

--- a/tasks/gpu.py
+++ b/tasks/gpu.py
@@ -36,9 +36,10 @@ def build_binary(ctx, package: str, output_path: str, label: str) -> str:
     help={
         "lookback_seconds": "Metrics lookback window in seconds",
         "org": "Datadog org filter: prod, staging. If not provided, use all configured orgs",
+        "metric_filter": "Additional Datadog metric filter expression, ANDed with the GPU config filter",
     },
 )
-def validate_metrics(ctx, lookback_seconds=3600, org: str | None = None):
+def validate_metrics(ctx, lookback_seconds=3600, org: str | None = None, metric_filter: str | None = None):
     """
     Validate live GPU metrics for the selected Datadog org(s).
     """
@@ -72,6 +73,8 @@ def validate_metrics(ctx, lookback_seconds=3600, org: str | None = None):
                     f"--lookback-seconds {int(lookback_seconds)} "
                     f"--output-file {shlex.quote(tmp.name)}"
                 )
+                if metric_filter:
+                    command += f" --metric-filter {shlex.quote(metric_filter)}"
                 print(" - running validator...")
                 res = ctx.run(command, warn=True)
                 result = validation_results_from_dict(json.load(tmp), site=VALIDATOR_SITE)

--- a/tasks/gpu.py
+++ b/tasks/gpu.py
@@ -36,7 +36,7 @@ def build_binary(ctx, package: str, output_path: str, label: str) -> str:
     help={
         "lookback_seconds": "Metrics lookback window in seconds",
         "org": "Datadog org filter: prod, staging. If not provided, use all configured orgs",
-        "metric_filter": "Additional Datadog metric filter expression, ANDed with the GPU config filter",
+        "metric_filter": "Datadog metric filter expression. Defaults to the GPU config filter",
     },
 )
 def validate_metrics(ctx, lookback_seconds=3600, org: str | None = None, metric_filter: str | None = None):

--- a/tasks/gpu.py
+++ b/tasks/gpu.py
@@ -36,7 +36,7 @@ def build_binary(ctx, package: str, output_path: str, label: str) -> str:
     help={
         "lookback_seconds": "Metrics lookback window in seconds",
         "org": "Datadog org filter: prod, staging. If not provided, use all configured orgs",
-        "metric_filter": "Datadog metric filter expression. Defaults to the GPU config filter",
+        "metric_filter": "Additional Datadog metric filter expression, ANDed with the GPU config filter",
     },
 )
 def validate_metrics(ctx, lookback_seconds=3600, org: str | None = None, metric_filter: str | None = None):


### PR DESCRIPTION
### What does this PR do?

Adds a custom metric filter to `dda inv gpu.validate-metrics` so live GPU metric validation can be scoped to a host or other Datadog tag filter.

### Motivation

Targeted validation is needed when checking one GPU node without unrelated metric series affecting the result.

### Describe how you validated your changes

Validated against live A100, H100, and B200 GPU nodes with short lookback windows.

### Additional Notes