### PR TITLE
ci: disable static_quality_gates on release branches and PRs targeting them

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,9 @@
 .if_release_branch: &if_release_branch
   if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
 
+.if_pr_targeting_release_branch: &if_pr_targeting_release_branch
+  if: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^[0-9]+\.[0-9]+\.x$/
+
 .if_mergequeue: &if_mergequeue
   if: $CI_COMMIT_BRANCH =~ /^mq-working-branch-/
 
@@ -637,6 +640,14 @@ workflow:
 .on_main_or_release_branch:
   - <<: *if_main_branch
   - <<: *if_release_branch
+
+.except_release_branch:
+  - <<: *if_release_branch
+    when: never
+
+.except_pr_targeting_release_branch:
+  - <<: *if_pr_targeting_release_branch
+    when: never
 
 .not_on_release_branch_or_tagged_commit:
   - <<: *if_release_branch

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -3,8 +3,10 @@ static_quality_gates:
     default: false
   stage: functional_test
   rules:
+    - !reference [.except_release_branch]
+    - !reference [.except_pr_targeting_release_branch]
     - !reference [.except_coverage_pipeline] # Coverage pipeline creates a special artifact that will not pass the quality gate
-    - !reference [.on_main_or_release_branch]
+    - !reference [.on_main]
     - !reference [.on_mergequeue]
     - !reference [.on_dev_branches_with_artifact_changes]
     - changes:


### PR DESCRIPTION
### What does this PR do?

Disables the `static_quality_gates` CI job on release branches and on PRs targeting release branches.

### Motivation

Fixes [BARX-1735](https://datadoghq.atlassian.net/browse/BARX-1735). Static quality gates have been causing failures on backport requests and release candidate builds. Size checks should only be enforced on `main`, not on release branches.

### Describe how you validated your changes

Rule logic review:
- `.except_pr_targeting_release_branch` fires `when: never` for both direct pushes on release branches (`CI_COMMIT_BRANCH`) and MR pipelines targeting release branches (`CI_MERGE_REQUEST_TARGET_BRANCH_NAME`), using the same `/^[0-9]+\.[0-9]+\.x$/` pattern as `*if_release_branch`.
- `!reference [.on_main_or_release_branch]` replaced by `!reference [.on_main]` so the job no longer triggers on direct pushes to release branches either.

### Additional Notes

Two new reusable anchors added to `.gitlab-ci.yml`:
- `.if_pr_targeting_release_branch` — condition for MRs targeting a release branch
- `.except_pr_targeting_release_branch` — combines both `when: never` guards (commit branch + MR target branch)

[BARX-1735]: https://datadoghq.atlassian.net/browse/BARX-1735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ