### PR TITLE
chore(rar): add support for remote agents exposing their gRPC endpoint over UDS

### DIFF
--- a/comp/core/remoteagent/helper/serverhelper.go
+++ b/comp/core/remoteagent/helper/serverhelper.go
@@ -11,7 +11,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -41,9 +43,11 @@ type UnimplementedRemoteAgentServer struct {
 	config config.Component
 
 	// server infos
-	agentFlavor string
-	displayName string
-	services    []string
+	agentFlavor       string
+	displayName       string
+	services          []string
+	registeredAPIURI  string
+	cleanupSocketPath string
 
 	// communication components
 	ipcComp         ipc.Component
@@ -72,8 +76,8 @@ func NewUnimplementedRemoteAgentServer(ipcComp ipc.Component, log log.Component,
 		return nil, errors.New("displayName is required")
 	}
 
-	// Listen on a random port
-	listener, err := listener.GetListener("127.0.0.1:0")
+	// create the listener at a random port
+	ral, err := buildRemoteAgentListener("https://127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}
@@ -81,6 +85,10 @@ func NewUnimplementedRemoteAgentServer(ipcComp ipc.Component, log log.Component,
 	agentClient, err := newAgentSecureClient(ipcComp, agentIpcAddress, config, log)
 	if err != nil {
 		log.Errorf("failed to create agent client: %v", err)
+		if ral.cleanupSocketPath != "" {
+			_ = os.Remove(ral.cleanupSocketPath)
+		}
+		_ = ral.listener.Close()
 		return nil, err
 	}
 
@@ -91,8 +99,10 @@ func NewUnimplementedRemoteAgentServer(ipcComp ipc.Component, log log.Component,
 		agentIpcAddress:        agentIpcAddress,
 		agentFlavor:            agentFlavor,
 		displayName:            displayName,
+		registeredAPIURI:       ral.apiEndpointURI,
+		cleanupSocketPath:      ral.cleanupSocketPath,
 		agentClient:            agentClient,
-		listener:               listener,
+		listener:               ral.listener,
 		grpcServer:             nil,
 		defaultRefreshInterval: 5 * time.Second,
 		queryTimeout:           config.GetDuration("remote_agent.registry.query_timeout"),
@@ -232,7 +242,107 @@ func (s *UnimplementedRemoteAgentServer) Start() {
 func (s *UnimplementedRemoteAgentServer) stop() {
 	s.cancel()
 	s.wg.Wait()
+	if s.cleanupSocketPath != "" {
+		if err := os.Remove(s.cleanupSocketPath); err != nil && !os.IsNotExist(err) {
+			s.log.Warnf("failed to remove remote agent UDS socket %q: %v", s.cleanupSocketPath, err)
+		}
+	}
 	s.log.Debug("remoteAgentServer stopped")
+}
+
+// remoteAgentListener bundles the inbound listener for a remote agent with the
+// derived metadata needed by the registration loop and shutdown logic.
+type remoteAgentListener struct {
+	// listener is the net.Listener the gRPC server should Serve on.
+	listener net.Listener
+
+	// apiEndpointURI is the value advertised to the Core Agent in the
+	// RegisterRemoteAgent RPC (e.g. "https://127.0.0.1:50051" or
+	// "unix:///var/run/datadog/remote-agent.sock").
+	apiEndpointURI string
+
+	// cleanupSocketPath, when non-empty, is the filesystem path of a UDS that
+	// must be removed when the listener is shut down. It is empty for TCP listeners.
+	cleanupSocketPath string
+}
+
+// buildRemoteAgentListener creates the inbound listener for a remote agent and computes
+// the api_endpoint_uri that should be advertised to the Core Agent.
+//
+// listenURI follows the scheme conventions documented on
+// NewUnimplementedRemoteAgentServer. When listenURI is empty, the helper retains its original
+// behaviour: a TCP listener on a random localhost port, advertised with the explicit
+// "https://" scheme prefix.
+func buildRemoteAgentListener(listenURI string) (*remoteAgentListener, error) {
+	scheme, rest, hasScheme := strings.Cut(listenURI, "://")
+	if !hasScheme {
+		return nil, fmt.Errorf("invalid remote agent listen URI %q: missing scheme (expected https://, unix://, or http://)", listenURI)
+	}
+
+	switch strings.ToLower(scheme) {
+	case "unix":
+		socketPath, err := unixSocketPath(rest)
+		if err != nil {
+			return nil, err
+		}
+		if err := removeStaleSocket(socketPath); err != nil {
+			return nil, err
+		}
+		l, err := net.Listen("unix", socketPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to listen on UDS %q: %w", socketPath, err)
+		}
+		if err := os.Chmod(socketPath, 0700); err != nil {
+			_ = l.Close()
+			_ = os.Remove(socketPath)
+			return nil, fmt.Errorf("failed to restrict permissions on UDS %q: %w", socketPath, err)
+		}
+		return &remoteAgentListener{listener: l, apiEndpointURI: listenURI, cleanupSocketPath: socketPath}, nil
+	case "https":
+		l, err := listener.GetListener(rest)
+		if err != nil {
+			return nil, err
+		}
+		return &remoteAgentListener{listener: l, apiEndpointURI: "https://" + l.Addr().String()}, nil
+	case "http":
+		// http:// is permitted by the protocol but the helper itself always serves TLS,
+		// so we refuse to set up a server that advertises plaintext to the registry.
+		return nil, errors.New("http:// scheme is not supported on the remote agent server side (use https:// or unix://)")
+	default:
+		return nil, fmt.Errorf("unsupported remote agent listen URI scheme %q", scheme)
+	}
+}
+
+// unixSocketPath extracts the filesystem path from the rest of a "unix://" URI.
+// Both "unix:///abs/path" (rest = "/abs/path") and the legacy "unix://abs/path" forms
+// are accepted; relative paths are rejected since gRPC's unix resolver requires absolute paths.
+func unixSocketPath(rest string) (string, error) {
+	if rest == "" {
+		return "", errors.New("invalid unix:// URI: empty socket path")
+	}
+	// gRPC's unix scheme supports both unix:///abs and unix:/abs forms; net.Listen needs the plain path.
+	path := rest
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return path, nil
+}
+
+func removeStaleSocket(socketPath string) error {
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to stat existing socket path %q: %w", socketPath, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("refusing to bind UDS at %q: path exists and is not a socket", socketPath)
+	}
+	if err := os.Remove(socketPath); err != nil {
+		return fmt.Errorf("failed to remove stale UDS at %q: %w", socketPath, err)
+	}
+	return nil
 }
 
 func newAgentSecureClient(ipcComp ipc.Component, agentIpcAddress string, cfg config.Component, log log.Component) (pbcore.AgentSecureClient, error) {
@@ -280,7 +390,7 @@ func (s *UnimplementedRemoteAgentServer) registerWithAgent() (string, time.Durat
 	registerReq := &pbcore.RegisterRemoteAgentRequest{
 		Flavor:         s.agentFlavor,
 		DisplayName:    s.displayName,
-		ApiEndpointUri: s.listener.Addr().String(),
+		ApiEndpointUri: s.registeredAPIURI,
 		Services:       s.services,
 	}
 

--- a/comp/core/remoteagent/helper/serverhelper_test.go
+++ b/comp/core/remoteagent/helper/serverhelper_test.go
@@ -8,6 +8,10 @@ package helper
 import (
 	"context"
 	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -29,6 +33,108 @@ import (
 	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
 )
+
+// shortUDSDir returns a short-path temp directory suitable for UDS sockets.
+// macOS limits sun_path to 104 bytes; the default t.TempDir() on macOS
+// produces paths that easily blow past that with long test names.
+func shortUDSDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "rar-uds-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func TestBuildRemoteAgentListener(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		_, err := buildRemoteAgentListener("")
+		require.Error(t, err)
+	})
+
+	t.Run("https", func(t *testing.T) {
+		ral, err := buildRemoteAgentListener("https://127.0.0.1:0")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = ral.listener.Close() })
+
+		assert.Empty(t, ral.cleanupSocketPath)
+		assert.True(t, strings.HasPrefix(ral.apiEndpointURI, "https://127.0.0.1:"), "got %q", ral.apiEndpointURI)
+		assert.NotEqual(t, "https://127.0.0.1:0", ral.apiEndpointURI, "random port should be resolved")
+	})
+
+	t.Run("unix", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("UDS not supported on Windows")
+		}
+		socketPath := filepath.Join(shortUDSDir(t), "ra.sock")
+		listenURI := "unix://" + socketPath
+
+		ral, err := buildRemoteAgentListener(listenURI)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = ral.listener.Close() })
+
+		assert.Equal(t, listenURI, ral.apiEndpointURI, "unix URI should round-trip into the advertised URI")
+		assert.Equal(t, socketPath, ral.cleanupSocketPath)
+
+		info, err := os.Stat(socketPath)
+		require.NoError(t, err)
+		assert.True(t, info.Mode()&os.ModeSocket != 0, "expected a socket at %q", socketPath)
+		assert.Equal(t, os.FileMode(0700), info.Mode().Perm(), "socket should be owner-only")
+	})
+
+	t.Run("unix_stale", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("UDS not supported on Windows")
+		}
+		socketPath := filepath.Join(shortUDSDir(t), "s.sock")
+
+		// Pre-create a socket and close it without unlinking the on-disk file, to
+		// simulate a process that crashed and left a stale socket inode behind.
+		first, err := net.Listen("unix", socketPath)
+		require.NoError(t, err)
+		first.(*net.UnixListener).SetUnlinkOnClose(false)
+		require.NoError(t, first.Close())
+		info, err := os.Stat(socketPath)
+		require.NoError(t, err)
+		require.NotZero(t, info.Mode()&os.ModeSocket, "precondition: stale socket file should exist on disk")
+
+		ral, err := buildRemoteAgentListener("unix://" + socketPath)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = ral.listener.Close() })
+		assert.Equal(t, socketPath, ral.cleanupSocketPath)
+	})
+
+	t.Run("unix_non_socket_file", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("UDS not supported on Windows")
+		}
+		filePath := filepath.Join(shortUDSDir(t), "f")
+		require.NoError(t, os.WriteFile(filePath, []byte("hi"), 0600))
+
+		_, err := buildRemoteAgentListener("unix://" + filePath)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a socket")
+	})
+
+	t.Run("http_rejected", func(t *testing.T) {
+		_, err := buildRemoteAgentListener("http://127.0.0.1:0")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "http:// scheme is not supported")
+	})
+
+	t.Run("missing_scheme", func(t *testing.T) {
+		// listenURI must be either empty (legacy) or scheme-prefixed; a bare "host:port" is rejected
+		// to keep callsites unambiguous.
+		_, err := buildRemoteAgentListener("127.0.0.1:0")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing scheme")
+	})
+
+	t.Run("unsupported_scheme", func(t *testing.T) {
+		_, err := buildRemoteAgentListener("vsock://2:50051")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported remote agent listen URI scheme")
+	})
+}
 
 // TestNoSessionIDReturnsError tests that requests to the remote agent server
 // return errors when no session ID is set (i.e., before registration completes)

--- a/comp/core/remoteagent/impl-process/remoteagent.go
+++ b/comp/core/remoteagent/impl-process/remoteagent.go
@@ -15,7 +15,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	remoteagent "github.com/DataDog/datadog-agent/comp/core/remoteagent/def"
 	"github.com/DataDog/datadog-agent/comp/core/remoteagent/helper"
-	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"

--- a/comp/core/remoteagentregistry/impl/client.go
+++ b/comp/core/remoteagentregistry/impl/client.go
@@ -17,7 +17,6 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/google/uuid"
@@ -98,9 +97,6 @@ func (ra *remoteAgentRegistry) newRemoteAgentClient(registration *remoteagentreg
 // Supported schemes (defined in datadog/remoteagent/remoteagent.proto):
 //   - "unix:///path"    — UDS, TLS preserved (filesystem perms gate access, TLS protects on-wire bytes).
 //   - "https://host:port" — TCP with TLS.
-//   - "http://host:port"  — TCP without TLS. Honored for local dev/test only.
-//   - bare "host:port"    — treated as "https://host:port" for backwards compatibility with
-//     remote agents written before the scheme prefix was required.
 func resolveDialTarget(endpointURI string, tlsConfig *tls.Config) (string, credentials.TransportCredentials, error) {
 	tlsCreds := credentials.NewTLS(tlsConfig)
 
@@ -116,10 +112,8 @@ func resolveDialTarget(endpointURI string, tlsConfig *tls.Config) (string, crede
 		return endpointURI, tlsCreds, nil
 	case "https":
 		return rest, tlsCreds, nil
-	case "http":
-		return rest, insecure.NewCredentials(), nil
 	default:
-		return "", nil, fmt.Errorf("unsupported api_endpoint_uri scheme %q (expected one of: unix, https, http)", scheme)
+		return "", nil, fmt.Errorf("unsupported api_endpoint_uri scheme %q (expected one of: unix, https)", scheme)
 	}
 }
 

--- a/comp/core/remoteagentregistry/impl/client.go
+++ b/comp/core/remoteagentregistry/impl/client.go
@@ -7,6 +7,7 @@ package remoteagentregistryimpl
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"slices"
@@ -16,6 +17,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/google/uuid"
@@ -54,8 +56,13 @@ type remoteAgentClient struct {
 }
 
 func (ra *remoteAgentRegistry) newRemoteAgentClient(registration *remoteagentregistry.RegistrationData) (*remoteAgentClient, error) {
-	conn, err := grpc.NewClient(registration.APIEndpointURI,
-		grpc.WithTransportCredentials(credentials.NewTLS(ra.ipc.GetTLSClientConfig())),
+	target, transportCreds, err := resolveDialTarget(registration.APIEndpointURI, ra.ipc.GetTLSClientConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := grpc.NewClient(target,
+		grpc.WithTransportCredentials(transportCreds),
 		grpc.WithPerRPCCredentials(ddgrpc.NewBearerTokenAuth(ra.ipc.GetAuthToken())),
 		// Set on the higher side to account for the fact that flare file data could be larger than the default 4MB limit.
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(64*1024*1024)),
@@ -83,6 +90,37 @@ func (ra *remoteAgentRegistry) newRemoteAgentClient(registration *remoteagentreg
 	client.services = registration.Services
 
 	return client, nil
+}
+
+// resolveDialTarget translates a remote agent's advertised api_endpoint_uri into
+// a gRPC dial target plus the transport credentials to use for the connection.
+//
+// Supported schemes (defined in datadog/remoteagent/remoteagent.proto):
+//   - "unix:///path"    — UDS, TLS preserved (filesystem perms gate access, TLS protects on-wire bytes).
+//   - "https://host:port" — TCP with TLS.
+//   - "http://host:port"  — TCP without TLS. Honored for local dev/test only.
+//   - bare "host:port"    — treated as "https://host:port" for backwards compatibility with
+//     remote agents written before the scheme prefix was required.
+func resolveDialTarget(endpointURI string, tlsConfig *tls.Config) (string, credentials.TransportCredentials, error) {
+	tlsCreds := credentials.NewTLS(tlsConfig)
+
+	scheme, rest, hasScheme := strings.Cut(endpointURI, "://")
+	if !hasScheme {
+		// No scheme: backwards-compat path, treat as host:port over TLS.
+		return endpointURI, tlsCreds, nil
+	}
+
+	switch strings.ToLower(scheme) {
+	case "unix":
+		// gRPC's built-in unix resolver expects the original "unix://" target string.
+		return endpointURI, tlsCreds, nil
+	case "https":
+		return rest, tlsCreds, nil
+	case "http":
+		return rest, insecure.NewCredentials(), nil
+	default:
+		return "", nil, fmt.Errorf("unsupported api_endpoint_uri scheme %q (expected one of: unix, https, http)", scheme)
+	}
 }
 
 // close closes the remote agent client and its connection

--- a/comp/core/remoteagentregistry/impl/client_test.go
+++ b/comp/core/remoteagentregistry/impl/client_test.go
@@ -7,13 +7,16 @@ package remoteagentregistryimpl
 
 import (
 	"context"
+	"crypto/tls"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	grpcStatus "google.golang.org/grpc/status"
 
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
@@ -234,6 +237,69 @@ func TestRemoteAgentServiceDiscovery(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, remoteAgent.services, testCase.expectedServices)
 			component.agentMapMu.Unlock()
+		})
+	}
+}
+
+func TestResolveDialTarget(t *testing.T) {
+	tlsConfig := &tls.Config{ServerName: "test"}
+	insecureCredsType := insecure.NewCredentials().Info().SecurityProtocol
+
+	testCases := []struct {
+		name            string
+		endpointURI     string
+		wantTarget      string
+		wantSecProtocol string
+		wantErrContains string
+	}{
+		{
+			name:            "bare host:port (backwards compat) uses TLS",
+			endpointURI:     "127.0.0.1:50051",
+			wantTarget:      "127.0.0.1:50051",
+			wantSecProtocol: "tls",
+		},
+		{
+			name:            "https:// strips scheme and uses TLS",
+			endpointURI:     "https://127.0.0.1:50051",
+			wantTarget:      "127.0.0.1:50051",
+			wantSecProtocol: "tls",
+		},
+		{
+			name:            "unix:// passes target through unchanged and uses TLS",
+			endpointURI:     "unix:///var/run/datadog/remote-agent.sock",
+			wantTarget:      "unix:///var/run/datadog/remote-agent.sock",
+			wantSecProtocol: "tls",
+		},
+		{
+			name:            "http:// strips scheme and uses insecure credentials",
+			endpointURI:     "http://127.0.0.1:50051",
+			wantTarget:      "127.0.0.1:50051",
+			wantSecProtocol: insecureCredsType,
+		},
+		{
+			name:            "uppercase scheme is normalized",
+			endpointURI:     "HTTPS://127.0.0.1:50051",
+			wantTarget:      "127.0.0.1:50051",
+			wantSecProtocol: "tls",
+		},
+		{
+			name:            "unsupported scheme is rejected",
+			endpointURI:     "vsock://2:50051",
+			wantErrContains: "unsupported api_endpoint_uri scheme",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			target, creds, err := resolveDialTarget(tc.endpointURI, tlsConfig)
+			if tc.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantTarget, target)
+			assert.Equal(t, tc.wantSecProtocol, creds.Info().SecurityProtocol)
 		})
 	}
 }

--- a/comp/core/remoteagentregistry/impl/client_test.go
+++ b/comp/core/remoteagentregistry/impl/client_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	grpcStatus "google.golang.org/grpc/status"
 
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
@@ -243,7 +242,6 @@ func TestRemoteAgentServiceDiscovery(t *testing.T) {
 
 func TestResolveDialTarget(t *testing.T) {
 	tlsConfig := &tls.Config{ServerName: "test"}
-	insecureCredsType := insecure.NewCredentials().Info().SecurityProtocol
 
 	testCases := []struct {
 		name            string
@@ -271,19 +269,18 @@ func TestResolveDialTarget(t *testing.T) {
 			wantSecProtocol: "tls",
 		},
 		{
-			name:            "http:// strips scheme and uses insecure credentials",
-			endpointURI:     "http://127.0.0.1:50051",
-			wantTarget:      "127.0.0.1:50051",
-			wantSecProtocol: insecureCredsType,
-		},
-		{
 			name:            "uppercase scheme is normalized",
 			endpointURI:     "HTTPS://127.0.0.1:50051",
 			wantTarget:      "127.0.0.1:50051",
 			wantSecProtocol: "tls",
 		},
 		{
-			name:            "unsupported scheme is rejected",
+			name:            "unsupported scheme is rejected (insecure)",
+			endpointURI:     "http://127.0.0.1:50051",
+			wantErrContains: "unsupported api_endpoint_uri scheme",
+		},
+		{
+			name:            "unsupported scheme is rejected (specialized)",
 			endpointURI:     "vsock://2:50051",
 			wantErrContains: "unsupported api_endpoint_uri scheme",
 		},

--- a/comp/core/remoteagentregistry/impl/registry_test.go
+++ b/comp/core/remoteagentregistry/impl/registry_test.go
@@ -9,6 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -96,6 +99,63 @@ func TestGetRegisteredAgentsIdleTimeout(t *testing.T) {
 
 	agents = component.GetRegisteredAgents()
 	require.Len(t, agents, 0)
+}
+
+// TestRegistryDialsUDSRemoteAgent verifies the end-to-end UDS path: a remote agent
+// registers with a "unix:///path" api_endpoint_uri, and the registry then dials it
+// over a UDS connection to fetch status.
+func TestRegistryDialsUDSRemoteAgent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("UDS not supported on Windows")
+	}
+
+	provides, lc, cfg, _, ipcComp := buildComponent(t)
+	cfg.SetWithoutSource("remote_agent.registry.query_timeout", 2*time.Second)
+
+	component := provides.Comp.(*remoteAgentRegistry)
+	require.NoError(t, lc.Start(context.Background()))
+	t.Cleanup(func() { _ = lc.Stop(context.Background()) })
+
+	// macOS limits sun_path to 104 bytes; use a short fixed prefix instead of t.TempDir().
+	udsDir, err := os.MkdirTemp("/tmp", "rar-uds-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(udsDir) })
+	socketPath := filepath.Join(udsDir, "a.sock")
+	udsListener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+
+	agent := buildRemoteAgentOnListener(t, ipcComp, udsListener, "unix://"+socketPath,
+		"uds-agent", "UDS Agent", "9999",
+		withStatusProvider(map[string]string{"transport": "uds"}, nil),
+	)
+
+	sessionID, _, err := component.RegisterRemoteAgent(&agent.RegistrationData)
+	require.NoError(t, err)
+	agent.registeredSessionID = sessionID
+
+	// Issue a status RPC via the registry's normal call path and verify the response
+	// came from the UDS-backed agent.
+	type statusResult struct {
+		flavor string
+		fields map[string]string
+		err    error
+	}
+	results := callAgentsForService(component, StatusServiceName,
+		func(ctx context.Context, rac *remoteAgentClient, opts ...grpc.CallOption) (*pb.GetStatusDetailsResponse, error) {
+			return rac.GetStatusDetails(ctx, &pb.GetStatusDetailsRequest{}, opts...)
+		},
+		func(reg remoteagent.RegisteredAgent, resp *pb.GetStatusDetailsResponse, err error) statusResult {
+			if err != nil || resp == nil || resp.MainSection == nil {
+				return statusResult{flavor: reg.Flavor, err: err}
+			}
+			return statusResult{flavor: reg.Flavor, fields: resp.MainSection.Fields}
+		},
+	)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].err)
+	assert.Equal(t, "uds-agent", results[0].flavor)
+	assert.Equal(t, "uds", results[0].fields["transport"])
 }
 
 func TestDisabled(t *testing.T) {
@@ -245,6 +305,20 @@ func withFakeSessionID(fakeSessionID string) func(*grpc.Server, *testRemoteAgent
 }
 
 func buildRemoteAgent(t *testing.T, ipcComp ipc.Component, agentFlavor string, agentName string, agentPID string, mockProviders ...mockProvider) *testRemoteAgentServer {
+	// Default to a random localhost TCP port; the advertised api_endpoint_uri is the
+	// bare host:port form (backwards-compatible default for the registry client).
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	return buildRemoteAgentOnListener(t, ipcComp, listener, listener.Addr().String(), agentFlavor, agentName, agentPID, mockProviders...)
+}
+
+// buildRemoteAgentOnListener is like buildRemoteAgent but reuses a caller-supplied
+// listener, letting tests exercise non-TCP transports (e.g. UDS).
+//
+// apiEndpointURI is recorded verbatim in RegistrationData and must match what the
+// registry-side client expects to dial — e.g. "unix:///path/to/sock" for UDS or
+// "https://host:port" for TLS-over-TCP.
+func buildRemoteAgentOnListener(t *testing.T, ipcComp ipc.Component, listener net.Listener, apiEndpointURI string, agentFlavor string, agentName string, agentPID string, mockProviders ...mockProvider) *testRemoteAgentServer {
 	testServer := &testRemoteAgentServer{
 		RegistrationData: remoteagent.RegistrationData{
 			AgentFlavor:      agentFlavor,
@@ -253,10 +327,6 @@ func buildRemoteAgent(t *testing.T, ipcComp ipc.Component, agentFlavor string, a
 			Services:         []string{}, // Will be populated by mock providers
 		},
 	}
-
-	// Make sure we can listen on the intended address.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
 
 	// Create delay interceptor that uses testServer.responseDelay
 	delayInterceptor := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
@@ -314,12 +384,14 @@ func buildRemoteAgent(t *testing.T, ipcComp ipc.Component, agentFlavor string, a
 
 	t.Cleanup(server.Stop)
 
-	testServer.RegistrationData.APIEndpointURI = listener.Addr().String()
+	testServer.RegistrationData.APIEndpointURI = apiEndpointURI
 	testServer.server = server
 
 	// block until the server is started
 	// initializing a dummy echo client to make sure the server is started
-	client, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(credentials.NewTLS(ipcComp.GetTLSClientConfig())))
+	probeTarget, probeCreds, err := resolveDialTarget(apiEndpointURI, ipcComp.GetTLSClientConfig())
+	require.NoError(t, err)
+	client, err := grpc.NewClient(probeTarget, grpc.WithTransportCredentials(probeCreds))
 	require.NoError(t, err)
 	echoClient := echo.NewEchoClient(client)
 	_, err = echoClient.UnaryEcho(context.Background(), &echo.EchoRequest{}, grpc.WaitForReady(true))

--- a/pkg/proto/datadog/remoteagent/remoteagent.proto
+++ b/pkg/proto/datadog/remoteagent/remoteagent.proto
@@ -34,7 +34,7 @@ message RegisterRemoteAgentRequest {
 message RegisterRemoteAgentResponse {
   // UUID for the remote agent session.
   //
-  // This represents the unique session between the remote agent and the remote agent registry. The remote agent MUSt
+  // This represents the unique session between the remote agent and the remote agent registry. The remote agent MUST
   // include the session ID in all responses to the remote agent registry, specified as a metadata header named
   // `session_id`.
   string session_id = 1;

--- a/pkg/proto/datadog/remoteagent/remoteagent.proto
+++ b/pkg/proto/datadog/remoteagent/remoteagent.proto
@@ -4,11 +4,10 @@ package datadog.remoteagent.v1;
 
 option go_package = "pkg/proto/pbgo/core"; // golang
 
-// This message contains fields that identify a Remote Agent instance.
 message RegisterRemoteAgentRequest {
   // Process ID of the remote agent.
   string pid = 1;
-  // Flavor of the remoteAgent
+  // Flavor of the remote agent.
   //
   // This should be a stable, unique name for the agent instance (e.g., "otel_agent").
   string flavor = 2;
@@ -18,23 +17,26 @@ message RegisterRemoteAgentRequest {
   string display_name = 3;
   // gRPC endpoint address where the remote agent can be reached.
   //
-  // MUST be a valid gRPC endpoint address, such as "localhost:4317".
-  // MUST expose the `RemoteAgent` service.
-  // MUST be prefixed by the transport layer if not TCP (e.g., "unix:///opt/datadog-agent/run/trace-agent.sock").
-  //     Currently supported transport layers: ["tcp"]
-  // MUST be secured with TLS if using TCP, and SHOULD present a valid certificate where possible.
+  // MUST expose the `RemoteAgent` service, and MUST specify the scheme of the transport.
+  //
+  // Supported schemes:
+  // - "https://host:port" for TCP with TLS (recommended for network endpoints).
+  // - "unix:///absolute/path" for Unix domain socket with TLS.
+  //
+  // SHOULD present a valid certificate where possible.
   string api_endpoint_uri = 4;
-
   // List of services that the remote agent supports.
-  // service name MUST be the full name of the service, such as "datadog.remoteagent.status.v1.StatusProvider".
+  //
+  // Service names MUST be the full name of the gRPC service, such as "datadog.remoteagent.status.v1.StatusProvider".
   repeated string services = 5;
 }
 
 message RegisterRemoteAgentResponse {
-  // UUID representing the current connection between the remoteAgentRegistry and the remoteAgent.
+  // UUID for the remote agent session.
   //
-  // The remoteAgent MUST include its session_id in all the response to the remoteAgentRegistry
-  // as a metadata named `session_id`. 
+  // This represents the unique session between the remote agent and the remote agent registry. The remote agent MUSt
+  // include the session ID in all responses to the remote agent registry, specified as a metadata header named
+  // `session_id`.
   string session_id = 1;
   // Recommended refresh interval for the remote agent.
   //
@@ -46,7 +48,8 @@ message RegisterRemoteAgentResponse {
 }
 
 message RefreshRemoteAgentRequest {
-  // UUID representing the current connection between the remoteAgentRegistry and the remoteAgent.
+  // UUID of the remote agent session to refresh.
   string session_id = 1;
 }
+
 message RefreshRemoteAgentResponse {}

--- a/pkg/proto/pbgo/core/remoteagent.pb.go
+++ b/pkg/proto/pbgo/core/remoteagent.pb.go
@@ -21,12 +21,11 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// This message contains fields that identify a Remote Agent instance.
 type RegisterRemoteAgentRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Process ID of the remote agent.
 	Pid string `protobuf:"bytes,1,opt,name=pid,proto3" json:"pid,omitempty"`
-	// Flavor of the remoteAgent
+	// Flavor of the remote agent.
 	//
 	// This should be a stable, unique name for the agent instance (e.g., "otel_agent").
 	Flavor string `protobuf:"bytes,2,opt,name=flavor,proto3" json:"flavor,omitempty"`
@@ -36,16 +35,17 @@ type RegisterRemoteAgentRequest struct {
 	DisplayName string `protobuf:"bytes,3,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
 	// gRPC endpoint address where the remote agent can be reached.
 	//
-	// MUST be a valid gRPC endpoint address, such as "localhost:4317".
-	// MUST expose the `RemoteAgent` service.
-	// MUST be prefixed by the transport layer if not TCP (e.g., "unix:///opt/datadog-agent/run/trace-agent.sock").
+	// MUST expose the `RemoteAgent` service, and MUST specify the scheme of the transport.
 	//
-	//	Currently supported transport layers: ["tcp"]
+	// Supported schemes:
+	// - "https://host:port" for TCP with TLS (recommended for network endpoints).
+	// - "unix:///absolute/path" for Unix domain socket with TLS.
 	//
-	// MUST be secured with TLS if using TCP, and SHOULD present a valid certificate where possible.
+	// SHOULD present a valid certificate where possible.
 	ApiEndpointUri string `protobuf:"bytes,4,opt,name=api_endpoint_uri,json=apiEndpointUri,proto3" json:"api_endpoint_uri,omitempty"`
 	// List of services that the remote agent supports.
-	// service name MUST be the full name of the service, such as "datadog.remoteagent.status.v1.StatusProvider".
+	//
+	// Service names MUST be the full name of the gRPC service, such as "datadog.remoteagent.status.v1.StatusProvider".
 	Services      []string `protobuf:"bytes,5,rep,name=services,proto3" json:"services,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -118,10 +118,11 @@ func (x *RegisterRemoteAgentRequest) GetServices() []string {
 
 type RegisterRemoteAgentResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// UUID representing the current connection between the remoteAgentRegistry and the remoteAgent.
+	// UUID for the remote agent session.
 	//
-	// The remoteAgent MUST include its session_id in all the response to the remoteAgentRegistry
-	// as a metadata named `session_id`.
+	// This represents the unique session between the remote agent and the remote agent registry. The remote agent MUSt
+	// include the session ID in all responses to the remote agent registry, specified as a metadata header named
+	// `session_id`.
 	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	// Recommended refresh interval for the remote agent.
 	//
@@ -180,7 +181,7 @@ func (x *RegisterRemoteAgentResponse) GetRecommendedRefreshIntervalSecs() uint32
 
 type RefreshRemoteAgentRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// UUID representing the current connection between the remoteAgentRegistry and the remoteAgent.
+	// UUID of the remote agent session to refresh.
 	SessionId     string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/pkg/proto/pbgo/core/remoteagent.pb.go
+++ b/pkg/proto/pbgo/core/remoteagent.pb.go
@@ -120,7 +120,7 @@ type RegisterRemoteAgentResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// UUID for the remote agent session.
 	//
-	// This represents the unique session between the remote agent and the remote agent registry. The remote agent MUSt
+	// This represents the unique session between the remote agent and the remote agent registry. The remote agent MUST
 	// include the session ID in all responses to the remote agent registry, specified as a metadata header named
 	// `session_id`.
 	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`


### PR DESCRIPTION
### What does this PR do?

This PR adds support for remote agents to expose their gRPC service, used by Remote Agent Registry, over UDS instead of only TCP.

### Motivation

Currently, remote agents have to expose their gRPC endpoint over TCP in order for RAR to be able to call back and run any necessary operations. This necessitates listening on a local port, which either must be chosen ahead of time or delegated to the OS for selection. While delegating to the OS makes it easier to avoid picking an already-bound port, it doesn't 100% avoid the risk of port conflicts with a customer's existing workloads, and it also makes it harder to discover where to connect if any manual debugging is necessary.

Additionally, exposing these endpoints on a local port allows other, unrelated processes to poke at them, which is unnecessary and only serves to increase the attack surface available to potentially malicious actors.

In contrast, we can listen on UDS sockets which provides both a stable listen address that we can depend on without clashing with customer workloads, _and_ provides a smidge of extra security in the form of being able to apply traditional Unix file permissions to the socket.

### Describe how you validated your changes

- Existing unit tests.
- New unit tests for ensuring we only allow `https` or `unix` for the listen address.

### Additional Notes

- I've tried to more strongly enforce some of the existing invariants here, like rejecting listen addresses that have no scheme or don't have `https://`/`unix://` to indicate that we only deal with secure endpoints. I realize _some_ of that is still kind of murky (`unix://` doesn't imply TLS like `https://` does) but hopefully the incremental nature of improvement here shines through... 😅
- I updated some of the documentation for `remoteagent.proto` itself to have a consistent voice/style, but it's not germane to the actual change at hand.