### PR TITLE
static-quality-gates: surface zero on-wire docker sizes

### DIFF
--- a/tasks/static_quality_gates/gates.py
+++ b/tasks/static_quality_gates/gates.py
@@ -15,7 +15,7 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime
 from io import UnsupportedOperation
-from typing import Protocol
+from typing import Any, Protocol
 
 import yaml
 from invoke import Context
@@ -103,6 +103,21 @@ def read_byte_input(byte_input: str | int) -> int:
         return string_to_byte(byte_input)
     else:
         return byte_input
+
+
+def _sum_manifest_sizes(node: Any) -> int:
+    """Recursively sum every `size` field found in a manifest tree."""
+    if isinstance(node, list):
+        return sum(_sum_manifest_sizes(item) for item in node)
+    if isinstance(node, dict):
+        total = 0
+        for key, value in node.items():
+            if key == "size":
+                total += value
+            else:
+                total += _sum_manifest_sizes(value)
+        return total
+    return 0
 
 
 class StaticQualityGateError(Exception):
@@ -427,13 +442,16 @@ class DockerArtifactMeasurer:
     def _calculate_image_wire_size(self, ctx: Context, image_url: str) -> int:
         """Calculate Docker image compressed size using manifest inspection"""
         manifest_output = ctx.run(
-            "DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect -v "
-            + image_url
-            + " | grep size | awk -F ':' '{sum+=$NF} END {printf(\"%d\",sum)}'",
-            hide=True,
+            f"DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect -v {image_url}",
+            hide="out",
+            warn=True,
         )
-
-        return int(manifest_output.stdout)
+        if manifest_output.exited != 0:
+            raise InfraError(f"Docker manifest inspect failed to retrieve {image_url}. Retrying... (infra flake)")
+        wire_size = _sum_manifest_sizes(json.loads(manifest_output.stdout))
+        if wire_size <= 0:
+            raise StaticQualityGateError(f"Docker manifest for {image_url} reported a wire size of {wire_size} bytes")
+        return wire_size
 
     def _calculate_image_disk_size(self, ctx: Context, image_url: str) -> int:
         """Calculate Docker image uncompressed size by pulling and extracting"""

--- a/tasks/unit_tests/static_quality_gates/gates_tests.py
+++ b/tasks/unit_tests/static_quality_gates/gates_tests.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import unittest
@@ -5,6 +6,7 @@ from unittest.mock import MagicMock, mock_open, patch
 
 from invoke import MockContext, Result
 
+from tasks.libs.package.size import InfraError
 from tasks.static_quality_gates.gates import (
     ArtifactMeasurement,
     DockerArtifactMeasurer,
@@ -416,6 +418,57 @@ class TestDockerArtifactMeasurer(unittest.TestCase):
             with self.assertRaises(StaticQualityGateError) as context:
                 self.measurer._get_image_url(config)
             self.assertIn("Missing CI_PIPELINE_ID, CI_COMMIT_SHORT_SHA", str(context.exception))
+
+    def test_calculate_image_wire_size_sums_manifest_sizes(self):
+        self.mock_ctx.run.return_value = Result(
+            stdout=json.dumps(
+                [
+                    {
+                        "Ref": "gcr.io/datadoghq/agent:7@sha256:aaa",
+                        "Descriptor": {"size": 1, "platform": {"architecture": "amd64", "os": "linux"}},
+                        "Raw": "eyJzaXplIjoxfQ==",
+                        "SchemaV2Manifest": {
+                            "config": {"size": 10},
+                            "layers": [{"size": 100}],
+                        },
+                    },
+                    {
+                        "Ref": "gcr.io/datadoghq/agent:7@sha256:bbb",
+                        "Descriptor": {"size": 1_000, "platform": {"architecture": "arm64", "os": "linux"}},
+                        "Raw": "eyJzaXplIjoyfQ==",
+                        "SchemaV2Manifest": {
+                            "config": {"size": 10_000},
+                            "layers": [{"size": 100_000}],
+                        },
+                    },
+                ]
+            )
+        )
+
+        self.assertEqual(self.measurer._calculate_image_wire_size(self.mock_ctx, "img"), 111_111)
+
+    def test_calculate_image_wire_size_zero_result_raises(self):
+        """Test the silent-zero condition the earlier `grep size | awk` reported as a sane 0-byte image now fails"""
+        self.mock_ctx.run.return_value = Result(stdout=json.dumps([]))
+
+        with self.assertRaises(StaticQualityGateError) as cm:
+            self.measurer._calculate_image_wire_size(self.mock_ctx, "img")
+        self.assertIn("wire size of 0 bytes", str(cm.exception))
+
+    def test_calculate_image_wire_size_invalid_json_raises(self):
+        """Test invalid JSON outputs ignored by earlier `grep | awk` pipeline are now reported as such"""
+        self.mock_ctx.run.return_value = Result(stdout="not json")
+
+        with self.assertRaises(json.JSONDecodeError):
+            self.measurer._calculate_image_wire_size(self.mock_ctx, "img")
+
+    def test_calculate_image_wire_size_non_zero_exit_raises_infra_error(self):
+        """Test `docker manifest inspect` non-zero exit codes swallowed by earlier `grep | awk` are now retriable"""
+        self.mock_ctx.run.return_value = Result(exited=1)
+
+        with self.assertRaises(InfraError) as cm:
+            self.measurer._calculate_image_wire_size(self.mock_ctx, "img")
+        self.assertIn("Docker manifest inspect failed to retrieve img", str(cm.exception))
 
 
 class TestStaticQualityGate(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?
Replace the `docker manifest inspect -v | grep size | awk` shell pipeline used to compute the on-wire size of CI agent docker images with a JSON parse, and raise appropriate exceptions when the resulting sum doesn't evaluate to a positive value.

### Motivation
The old shell pipeline silently coerced any failure of `docker manifest inspect` (registry hiccup, manifest not yet propagated, transient auth issue) into a `0`: grep on empty input matches nothing, awk's `END { printf "%d", sum }` always prints `0`, the pipeline exit status is awk's `0`, and `int("0")` returns `0`.
The gate then emits `datadog.agent.static_quality_gate.on_wire_size = 0` for that commit and reports success.

Once such a zero lands on `main`, every PR whose merge-base hits that commit has its per-PR delta computed against `0`, which makes the delta equal the entire current on-wire size and trips the `5 MiB` per-PR threshold.
We just observed this with commit 316aa8cafa79 on `main`: 0 MiB on-wire was recorded for `docker_agent_arm64`, and downstream PRs failed the gate with a spurious `+256.54 MiB on-wire` delta even though their changes were unrelated to the image - at least:
- `main`: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1715286108
- dev branch: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1715496719

The sibling `_calculate_image_disk_size` already raises on `crane pull` failure: this aligns `_calculate_image_wire_size` with the same **fail-fast** behavior.

### Describe how you validated your changes
- reproduced the silent-zero locally: `... | grep size | awk ...` returns `0` and exits `0` when the docker step fails or produces no matching lines,
- added 4 unit tests on `DockerArtifactMeasurer`:
  - sum across a realistic multi-arch manifest (top-level array, `Descriptor.size`, `Raw` base64 string, `SchemaV2Manifest` `config.size` and `layers[].size`), values chosen as distinct powers of 10 so the expected sum reads `111111`,
  - empty manifest list raises `StaticQualityGateError` with `wire size of 0 bytes`,
  - non-JSON output propagates `json.JSONDecodeError`,
  - non-zero `docker manifest inspect` propagates to `InfraError` (retriable).

### Additional Notes
`hide="out"` keeps `stderr` visible in CI logs so that future docker failures land in the job output.
`warn=true` prevents `invoke` from raising its own `UnexpectedExit` and instead allows us to ask for a retry.
Behavior for healthy single-arch images is unchanged: the recursive sum over `size` integer fields produces the same total as the prior `grep | awk` pipeline.