### PR TITLE
chore(deps): remove usage of golang.org/x/exp/constraints

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/utils.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/utils.go
@@ -11,9 +11,13 @@ import (
 	"math"
 	"math/bits"
 	"os"
-
-	"golang.org/x/exp/constraints"
 )
+
+// integer is the set of all integer types, mirroring constraints.Integer from golang.org/x/exp.
+type integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
 
 var (
 	pageSize  = os.Getpagesize()
@@ -21,12 +25,12 @@ var (
 )
 
 // round x up to the nearest power of y
-func roundUp[T constraints.Integer](x, y T) T {
+func roundUp[T integer](x, y T) T {
 	return ((x + (y - 1)) / y) * y
 }
 
 // round x up to the nearest power of y, where y is a power of 2
-func roundUpPow2[T constraints.Integer](x, y T) T {
+func roundUpPow2[T integer](x, y T) T {
 	return ((x - 1) | (y - 1)) + 1
 }
 
@@ -35,10 +39,10 @@ func roundUpNearestPow2(x uint32) uint32 {
 	return uint32(1) << bits.Len32(x-1)
 }
 
-func pageAlign[T constraints.Integer](x T) T {
+func pageAlign[T integer](x T) T {
 	return align(x, T(pageSize))
 }
 
-func align[T constraints.Integer](x, a T) T {
+func align[T integer](x, a T) T {
 	return (x + (a - 1)) & ^(a - 1)
 }

--- a/pkg/collector/corechecks/gpu/nvidia/helpers.go
+++ b/pkg/collector/corechecks/gpu/nvidia/helpers.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
-	"golang.org/x/exp/constraints"
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -50,9 +49,11 @@ func boolToFloat(val bool) float64 {
 	return 0
 }
 
-// number interface for numeric type constraints
+// number is the set of all integer and floating-point types.
 type number interface {
-	constraints.Integer | constraints.Float
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64
 }
 
 // readNumberFromBuffer reads a number from a binary reader and converts it to the target type

--- a/pkg/util/maps/BUILD.bazel
+++ b/pkg/util/maps/BUILD.bazel
@@ -8,5 +8,4 @@ go_library(
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/util/maps",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_exp//constraints"],
 )

--- a/pkg/util/maps/map.go
+++ b/pkg/util/maps/map.go
@@ -6,7 +6,11 @@
 // Package maps provides utility functions for dealing with maps
 package maps
 
-import "golang.org/x/exp/constraints"
+// integer is the set of all integer types, mirroring constraints.Integer from golang.org/x/exp.
+type integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
 
 // Map transforms keys and values from the provided into map into a copy using the given mapping functions.
 func Map[K1, K2 comparable, V1, V2 any](m map[K1]V1, kmap func(x K1) K2, vmap func(x V1) V2) map[K2]V2 {
@@ -33,7 +37,7 @@ func MapKeys[K1, K2 comparable, V any](m map[K1]V, kmap func(x K1) K2) map[K2]V 
 }
 
 // CastIntegerKeys transforms keys from the provided map into a copy using integer casting.
-func CastIntegerKeys[K1, K2 constraints.Integer, V any](m map[K1]V) map[K2]V {
+func CastIntegerKeys[K1, K2 integer, V any](m map[K1]V) map[K2]V {
 	if m == nil {
 		return nil
 	}


### PR DESCRIPTION
### What does this PR do?

Replaces the three direct imports of `golang.org/x/exp/constraints` with inline type constraint definitions.

### Motivation

`golang.org/x/exp` is an experimental package not intended as a stable long-term dependency. The `constraints` sub-package provides type constraint interfaces (`Integer`, `Float`) that can be trivially defined inline using standard Go generics syntax — no external package is needed.

`x/exp/mmap` (used in a test utility) is kept; only the `constraints` sub-package usages are removed.

### Describe how you validated your changes

CI — no behavior change; the inlined constraints are identical to the ones from `x/exp/constraints`.

### Additional Notes

`golang.org/x/exp` remains in `go.mod` for `x/exp/mmap`.