### PR TITLE
chore(deps): replace github.com/mitchellh/mapstructure with go-viper/mapstructure/v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,8 @@ linters:
               desc: "use the std maps package instead (Keys/Values need slices.Collect wrapping)"
             - pkg: "github.com/aws/aws-sdk-go/"
               desc: "use the v2 sdk instead"
+            - pkg: "github.com/mitchellh/mapstructure"
+              desc: "use github.com/go-viper/mapstructure/v2 instead (maintained continuation)"
         multierror:
           files:
             - $all

--- a/cmd/secret-generic-connector/backend/akeyless/BUILD.bazel
+++ b/cmd/secret-generic-connector/backend/akeyless/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/secret-generic-connector/secret",
-        "@com_github_mitchellh_mapstructure//:mapstructure",
+        "@com_github_go_viper_mapstructure_v2//:mapstructure",
     ],
 )
 

--- a/cmd/secret-generic-connector/backend/akeyless/vault.go
+++ b/cmd/secret-generic-connector/backend/akeyless/vault.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/secret-generic-connector/secret"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 // BackendConfig is the configuration for a akeyless backend

--- a/cmd/secret-generic-connector/backend/aws/BUILD.bazel
+++ b/cmd/secret-generic-connector/backend/aws/BUILD.bazel
@@ -18,7 +18,7 @@ go_library(
         "@com_github_aws_aws_sdk_go_v2_service_secretsmanager//:secretsmanager",
         "@com_github_aws_aws_sdk_go_v2_service_ssm//:ssm",
         "@com_github_aws_aws_sdk_go_v2_service_sts//:sts",
-        "@com_github_mitchellh_mapstructure//:mapstructure",
+        "@com_github_go_viper_mapstructure_v2//:mapstructure",
     ],
 )
 

--- a/cmd/secret-generic-connector/backend/aws/secrets.go
+++ b/cmd/secret-generic-connector/backend/aws/secrets.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/DataDog/datadog-agent/cmd/secret-generic-connector/secret"
 )

--- a/cmd/secret-generic-connector/backend/aws/ssm.go
+++ b/cmd/secret-generic-connector/backend/aws/ssm.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/DataDog/datadog-agent/cmd/secret-generic-connector/secret"
 )

--- a/cmd/secret-generic-connector/backend/azure/BUILD.bazel
+++ b/cmd/secret-generic-connector/backend/azure/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "@com_github_azure_azure_sdk_for_go_sdk_azcore//:azcore",
         "@com_github_azure_azure_sdk_for_go_sdk_azidentity//:azidentity",
         "@com_github_azure_azure_sdk_for_go_sdk_security_keyvault_azsecrets//:azsecrets",
-        "@com_github_mitchellh_mapstructure//:mapstructure",
+        "@com_github_go_viper_mapstructure_v2//:mapstructure",
     ],
 )
 

--- a/cmd/secret-generic-connector/backend/azure/keyvault.go
+++ b/cmd/secret-generic-connector/backend/azure/keyvault.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 	"github.com/DataDog/datadog-agent/cmd/secret-generic-connector/secret"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 // keyvaultClient is an interface that defines the methods we use from the ssm client

--- a/cmd/secret-generic-connector/backend/file/BUILD.bazel
+++ b/cmd/secret-generic-connector/backend/file/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/secret-generic-connector/secret",
-        "@com_github_mitchellh_mapstructure//:mapstructure",
+        "@com_github_go_viper_mapstructure_v2//:mapstructure",
         "@in_yaml_go_yaml_v2//:yaml",
     ],
 )

--- a/cmd/secret-generic-connector/backend/file/json.go
+++ b/cmd/secret-generic-connector/backend/file/json.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/DataDog/datadog-agent/cmd/secret-generic-connector/secret"
 )

--- a/cmd/secret-generic-connector/backend/file/text.go
+++ b/cmd/secret-generic-connector/backend/file/text.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/DataDog/datadog-agent/cmd/secret-generic-connector/secret"
 )

--- a/cmd/secret-generic-connector/backend/file/yaml.go
+++ b/cmd/secret-generic-connector/backend/file/yaml.go
@@ -13,7 +13,7 @@ import (
 
 	yaml "go.yaml.in/yaml/v2"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/DataDog/datadog-agent/cmd/secret-generic-connector/secret"
 )

--- a/cmd/secret-generic-connector/backend/gcp/BUILD.bazel
+++ b/cmd/secret-generic-connector/backend/gcp/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/secret-generic-connector/secret",
-        "@com_github_mitchellh_mapstructure//:mapstructure",
+        "@com_github_go_viper_mapstructure_v2//:mapstructure",
         "@org_golang_x_oauth2//:oauth2",
         "@org_golang_x_oauth2//google",
     ],

--- a/cmd/secret-generic-connector/backend/gcp/secrets.go
+++ b/cmd/secret-generic-connector/backend/gcp/secrets.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/secret-generic-connector/secret"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )

--- a/cmd/secret-generic-connector/backend/hashicorp/BUILD.bazel
+++ b/cmd/secret-generic-connector/backend/hashicorp/BUILD.bazel
@@ -7,12 +7,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/secret-generic-connector/secret",
+        "@com_github_go_viper_mapstructure_v2//:mapstructure",
         "@com_github_hashicorp_vault_api//:api",
         "@com_github_hashicorp_vault_api_auth_approle//:approle",
         "@com_github_hashicorp_vault_api_auth_aws//:aws",
         "@com_github_hashicorp_vault_api_auth_ldap//:ldap",
         "@com_github_hashicorp_vault_api_auth_userpass//:userpass",
-        "@com_github_mitchellh_mapstructure//:mapstructure",
         "@com_github_qri_io_jsonpointer//:jsonpointer",
     ],
 )

--- a/cmd/secret-generic-connector/backend/hashicorp/vault.go
+++ b/cmd/secret-generic-connector/backend/hashicorp/vault.go
@@ -17,12 +17,12 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/secret-generic-connector/secret"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/api/auth/approle"
 	"github.com/hashicorp/vault/api/auth/aws"
 	"github.com/hashicorp/vault/api/auth/ldap"
 	"github.com/hashicorp/vault/api/auth/userpass"
-	"github.com/mitchellh/mapstructure"
 	"github.com/qri-io/jsonpointer"
 )
 

--- a/cmd/secret-generic-connector/backend/kubernetes/BUILD.bazel
+++ b/cmd/secret-generic-connector/backend/kubernetes/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
     deps = [
         "//cmd/secret-generic-connector/backend/file",
         "//cmd/secret-generic-connector/secret",
-        "@com_github_mitchellh_mapstructure//:mapstructure",
+        "@com_github_go_viper_mapstructure_v2//:mapstructure",
     ],
 )
 

--- a/cmd/secret-generic-connector/backend/kubernetes/secrets.go
+++ b/cmd/secret-generic-connector/backend/kubernetes/secrets.go
@@ -21,7 +21,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/DataDog/datadog-agent/cmd/secret-generic-connector/secret"
 )

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -232,7 +232,6 @@ use_repo(
     "com_github_microsoft_go_winio",
     "com_github_microsoft_hcsshim",
     "com_github_miekg_dns",
-    "com_github_mitchellh_mapstructure",
     "com_github_moby_docker_image_spec",
     "com_github_moby_moby_api",
     "com_github_moby_moby_client",

--- a/go.mod
+++ b/go.mod
@@ -973,7 +973,6 @@ require (
 	github.com/hashicorp/vault/api/auth/ldap v0.11.0
 	github.com/hashicorp/vault/api/auth/userpass v0.11.0
 	github.com/jarcoal/httpmock v1.4.1
-	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/moby/moby/api v1.54.2
 	github.com/moby/moby/client v0.4.1
 	github.com/modelcontextprotocol/go-sdk v1.6.0
@@ -1153,6 +1152,7 @@ require (
 	github.com/linkdata/deadlock v0.5.5 // indirect
 	github.com/mattn/go-zglob v0.0.2-0.20191112051448-a8912a37f9e7 // indirect
 	github.com/minio/simdjson-go v0.4.5 // indirect
+	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
 	github.com/mitchellh/pointerstructure v1.2.1 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/nexus-rpc/sdk-go v0.5.1 // indirect


### PR DESCRIPTION
### What does this PR do?

Replaces all direct imports of `github.com/mitchellh/mapstructure` with `github.com/go-viper/mapstructure/v2` in `cmd/secret-generic-connector`.

### Motivation

`go-viper/mapstructure/v2` is the maintained continuation of `mitchellh/mapstructure` (the original author transferred ownership). The only function used is `mapstructure.Decode`, which has an identical signature in v2. `go-viper/mapstructure/v2` was already a direct dependency; this removes the redundant older import.

### Describe how you validated your changes

CI — pure import path rename, no behavior change.

### Additional Notes
