### PR TITLE
Ignore /vendor in bazel repo-wide rules.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -672,6 +672,7 @@ exports_files(glob(
 # gazelle:exclude tools/gdb
 # gazelle:exclude tools/go-update
 # gazelle:exclude tools/retry_file_dump
+# gazelle:exclude vendor
 
 # ======= TESTDATA EXCLUDES =======
 # gazelle:exclude **/testdata/**/*.go

--- a/bazel/buildifier/BUILD.bazel
+++ b/bazel/buildifier/BUILD.bazel
@@ -7,6 +7,7 @@ exclude_patterns = [
     # style as the upstream has it makes merging it back easier.
     "./third_party/*",
     "./deps/*/overlay/*",
+    "./vendor/*",
 ]
 
 buildifier(


### PR DESCRIPTION
**What this does**
`/vendor` gets filled with Go files during some `dda` commands. If you run gazelle with vendor populated, gazelle will try to put build files there and update the world to use them.

Likewise, if a go package also happens to have bazel configuration, and it is vendored, we should not impose our buildifier rules on it.

**Testing**
- Make sure I have things in vendor
```
$ find vendor -name '*.go' | wc
  35958   35958 2633575
```
- bazel run //:gazelle
- verify that it did not create BUILD.bazel files in /vendor and that nothing else was modified.