### PR TITLE
pkg/util/trivy: stop pairing layer fields by slice index

### DIFF
--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -75,6 +75,7 @@ type ContainerdItf interface {
 	IsSandbox(namespace string, ctn containerd.Container) (bool, error)
 	MountImage(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image, targetDir string) (func(context.Context) error, error)
 	Mounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, func(context.Context) error, error)
+	MountsWithSnapshotter(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, string, func(context.Context) error, error)
 }
 
 // ContainerdUtil is the util used to interact with the Containerd api.
@@ -391,6 +392,14 @@ func (c *ContainerdUtil) IsSandbox(namespace string, ctn containerd.Container) (
 
 // Mounts retrieves mounts and returns a function to clean the snapshot and release the lease. The lease is already released in error cases.
 func (c *ContainerdUtil) Mounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, func(context.Context) error, error) {
+	mounts, _, cleanup, err := c.MountsWithSnapshotter(ctx, expiration, namespace, img)
+	return mounts, cleanup, err
+}
+
+// MountsWithSnapshotter is like Mounts but also returns the snapshotter name
+// backing the mounts, so callers that need to talk to the same SnapshotService
+// (e.g. to verify the snapshot's parent chain) don't have to re-probe.
+func (c *ContainerdUtil) MountsWithSnapshotter(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, string, func(context.Context) error, error) {
 	snapshotter := "nydus"
 	ctx = namespaces.WithNamespace(ctx, namespace)
 
@@ -399,17 +408,17 @@ func (c *ContainerdUtil) Mounts(ctx context.Context, expiration time.Duration, n
 	if err != nil {
 		snapshotter = containerd.DefaultSnapshotter
 		if imgUnpacked, err = img.IsUnpacked(ctx, snapshotter); err != nil {
-			return nil, nil, fmt.Errorf("unable to check if image named: %s is unpacked, err: %w", img.Name(), err)
+			return nil, "", nil, fmt.Errorf("unable to check if image named: %s is unpacked, err: %w", img.Name(), err)
 		}
 	}
 	if !imgUnpacked {
-		return nil, nil, fmt.Errorf("unable to scan image named: %s, image is not unpacked for snapshotter %s", img.Name(), snapshotter)
+		return nil, "", nil, fmt.Errorf("unable to scan image named: %s, image is not unpacked for snapshotter %s", img.Name(), snapshotter)
 	}
 
 	// Getting image id
 	imgConfig, err := img.Config(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to get image config for image named: %s, err: %w", img.Name(), err)
+		return nil, "", nil, fmt.Errorf("unable to get image config for image named: %s, err: %w", img.Name(), err)
 	}
 	imageID := imgConfig.Digest.String()
 
@@ -422,7 +431,7 @@ func (c *ContainerdUtil) Mounts(ctx context.Context, expiration time.Duration, n
 		}),
 	)
 	if err != nil && !errdefs.IsAlreadyExists(err) {
-		return nil, nil, fmt.Errorf("unable to get a lease, err: %w", err)
+		return nil, "", nil, fmt.Errorf("unable to get a lease, err: %w", err)
 	}
 
 	// Getting top layer image id
@@ -431,7 +440,7 @@ func (c *ContainerdUtil) Mounts(ctx context.Context, expiration time.Duration, n
 		if err := done(ctx); err != nil {
 			log.Warnf("Unable to cancel containerd lease with id: %s, err: %v", imageID, err)
 		}
-		return nil, nil, fmt.Errorf("unable to get layers digests for image: %s, err: %w", imageID, err)
+		return nil, "", nil, fmt.Errorf("unable to get layers digests for image: %s, err: %w", imageID, err)
 	}
 	chainID := identity.ChainID(diffIDs).String()
 	// Creating snapshot for the top layer
@@ -441,7 +450,7 @@ func (c *ContainerdUtil) Mounts(ctx context.Context, expiration time.Duration, n
 		if err := done(ctx); err != nil {
 			log.Warnf("Unable to cancel containerd lease with id: %s, err: %v", imageID, err)
 		}
-		return nil, nil, fmt.Errorf("unable to build snapshot for image: %s, err: %w", imageID, err)
+		return nil, "", nil, fmt.Errorf("unable to build snapshot for image: %s, err: %w", imageID, err)
 	}
 	cleanSnapshot := func(ctx context.Context) error {
 		return s.Remove(ctx, imageID)
@@ -455,7 +464,7 @@ func (c *ContainerdUtil) Mounts(ctx context.Context, expiration time.Duration, n
 		if err := done(ctx); err != nil {
 			log.Warnf("Unable to cancel containerd lease with id: %s, err: %v", imageID, err)
 		}
-		return nil, nil, fmt.Errorf("No snapshots returned for image: %s", imageID)
+		return nil, "", nil, fmt.Errorf("No snapshots returned for image: %s", imageID)
 	}
 
 	if env.IsContainerized() {
@@ -486,7 +495,7 @@ func (c *ContainerdUtil) Mounts(ctx context.Context, expiration time.Duration, n
 		}
 	}
 
-	return mounts, func(ctx context.Context) error {
+	return mounts, snapshotter, func(ctx context.Context) error {
 		ctx = namespaces.WithNamespace(ctx, namespace)
 		if err := cleanSnapshot(ctx); err != nil {
 			log.Warnf("Unable to clean snapshot with id: %s, err: %v", imageID, err)

--- a/pkg/util/containerd/fake/containerd_util.go
+++ b/pkg/util/containerd/fake/containerd_util.go
@@ -49,6 +49,7 @@ type MockedContainerdClient struct {
 	MockIsSandbox             func(namespace string, ctn containerd.Container) (bool, error)
 	MockMountImage            func(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image, targetDir string) (func(context.Context) error, error)
 	MockMounts                func(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, func(context.Context) error, error)
+	MockMountsWithSnapshotter func(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, string, func(context.Context) error, error)
 }
 
 // Close is a mock method
@@ -174,4 +175,9 @@ func (client *MockedContainerdClient) MountImage(ctx context.Context, expiration
 // Mounts is a mock method
 func (client *MockedContainerdClient) Mounts(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, func(context.Context) error, error) {
 	return client.MockMounts(ctx, expiration, namespace, img)
+}
+
+// MountsWithSnapshotter is a mock method
+func (client *MockedContainerdClient) MountsWithSnapshotter(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image) ([]mount.Mount, string, func(context.Context) error, error) {
+	return client.MockMountsWithSnapshotter(ctx, expiration, namespace, img)
 }

--- a/pkg/util/trivy/containerd.go
+++ b/pkg/util/trivy/containerd.go
@@ -14,21 +14,25 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/archive"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/snapshots"
 	refdocker "github.com/distribution/reference"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	dimage "github.com/moby/moby/api/types/image"
 	dclient "github.com/moby/moby/client"
 	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/samber/lo"
 
@@ -37,6 +41,12 @@ import (
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+// errLayerChainMismatch fires when the snapshotter's parent chain for an
+// image's top chainID does not match the chain we computed from
+// rootfs.diff_ids. We refuse to scan rather than silently pair the wrong
+// path with each DiffID.
+var errLayerChainMismatch = errors.New("snapshotter chain does not match image config")
 
 // ContainerdCollector defines the conttainerd collector name
 const ContainerdCollector = "containerd"
@@ -237,7 +247,12 @@ func (c *Collector) ScanContainerdImageFromSnapshotter(ctx context.Context, imgM
 	}
 	imageID := imgMeta.ID
 
-	mounts, cleanLease, err := client.Mounts(ctx, expiration, imgMeta.Namespace, img)
+	// img.RootFS, images.Manifest and SnapshotService all read from the
+	// content store and snapshotter, which containerd indexes per
+	// namespace. The outer ctx may not yet carry one.
+	ctx = namespaces.WithNamespace(ctx, imgMeta.Namespace)
+
+	mounts, snapshotter, cleanLease, err := client.MountsWithSnapshotter(ctx, expiration, imgMeta.Namespace, img)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get mounts for image %s, err: %w", imgMeta.ID, err)
 	}
@@ -247,24 +262,22 @@ func (c *Collector) ScanContainerdImageFromSnapshotter(ctx context.Context, imgM
 		}
 	}()
 
-	layers := extractLayersFromOverlayFSMounts(mounts)
-	if len(layers) == 0 {
-		return nil, fmt.Errorf("unable to extract layers from overlayfs mounts %+v for image %s", mounts, imgMeta.ID)
-	}
-
-	// RootFS.Layers is bottom-up; overlay mount syntax is top-down.
-	for i, j := 0, len(layers)-1; i < j; i, j = i+1, j-1 {
-		layers[i], layers[j] = layers[j], layers[i]
-	}
-
-	fakeContainer, err := newFakeContainer(layers, imgMeta, fanalImage.inspect.RootFS.Layers)
+	diffIDs, err := img.RootFS(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to read diff_ids for image %s: %w", imgMeta.ID, err)
+	}
+	manifest, err := images.Manifest(ctx, img.ContentStore(), img.Target(), img.Platform())
+	if err != nil {
+		return nil, fmt.Errorf("unable to read manifest for image %s: %w", imgMeta.ID, err)
+	}
+	layers, err := buildContainerdLayerPaths(ctx, client.RawClient().SnapshotService(snapshotter), img.Name(), diffIDs, manifest, mounts)
+	if err != nil {
+		return nil, fmt.Errorf("unable to pair layer paths for image %s: %w", imgMeta.ID, err)
 	}
 
-	report, err := c.scanOverlayFS(ctx, layers, &fakeContainerdContainer{
+	report, err := c.scanOverlayFS(ctx, lo.Map(layers, func(l ftypes.LayerPath, _ int) string { return l.Path }), &fakeContainerdContainer{
 		image:         fanalImage,
-		fakeContainer: fakeContainer,
+		fakeContainer: newFakeContainer(layers, imgMeta),
 	}, imgMeta, scanOptions)
 
 	return report, err
@@ -324,15 +337,107 @@ func (c *Collector) ScanContainerdImageFromFilesystem(ctx context.Context, imgMe
 
 func extractLayersFromOverlayFSMounts(mounts []mount.Mount) []string {
 	var layers []string
-	for _, mount := range mounts {
-		for _, opt := range mount.Options {
+	for _, mnt := range mounts {
+		var fromOverlay bool
+		for _, opt := range mnt.Options {
 			for _, prefix := range []string{"upperdir=", "lowerdir="} {
 				trimmedOpt := strings.TrimPrefix(opt, prefix)
 				if trimmedOpt != opt {
 					layers = append(layers, strings.Split(trimmedOpt, ":")...)
+					fromOverlay = true
 				}
 			}
 		}
+		// A single-layer image is exposed by containerd as a single bind mount
+		// (no lowerdir/upperdir overlay options); its only layer is the source.
+		if !fromOverlay && mnt.Type == "bind" && mnt.Source != "" {
+			layers = append(layers, mnt.Source)
+		}
 	}
 	return layers
+}
+
+// computeChainIDs returns the chainID at each level of diffIDs, in
+// image-config (bottom-up) order. It copies first because
+// identity.ChainIDs mutates its argument in place.
+func computeChainIDs(diffIDs []digest.Digest) []digest.Digest {
+	if len(diffIDs) == 0 {
+		return nil
+	}
+	out := slices.Clone(diffIDs)
+	identity.ChainIDs(out)
+	return out
+}
+
+// snapshotterStat is the slice of snapshots.Snapshotter we use, kept
+// small so tests can stub it without the whole snapshotter surface.
+type snapshotterStat interface {
+	Stat(ctx context.Context, key string) (snapshots.Info, error)
+}
+
+// verifyChainAgainstSnapshotter confirms the snapshotter's stored parent
+// chain matches chainIDs, catching a snapshotter / image-config
+// disagreement before we pair LayerPaths off it.
+func verifyChainAgainstSnapshotter(ctx context.Context, s snapshotterStat, chainIDs []digest.Digest) error {
+	for i := len(chainIDs) - 1; i >= 0; i-- {
+		info, err := s.Stat(ctx, chainIDs[i].String())
+		if err != nil {
+			return fmt.Errorf("snapshotter stat for %s: %w", chainIDs[i], err)
+		}
+		var wantParent string
+		if i > 0 {
+			wantParent = chainIDs[i-1].String()
+		}
+		if info.Parent != wantParent {
+			return fmt.Errorf("%w: chainID %s has Parent=%q, expected %q",
+				errLayerChainMismatch, chainIDs[i], info.Parent, wantParent)
+		}
+	}
+	return nil
+}
+
+// buildContainerdLayerPaths returns one LayerPath per layer in
+// image-config (bottom-up) order. It takes resolved OCI inputs rather
+// than a containerd.Image so it stays testable. The manifest can
+// legally have a different length than diff_ids; when it does, Digest
+// is left empty rather than risk pairing a wrong one.
+func buildContainerdLayerPaths(
+	ctx context.Context,
+	s snapshotterStat,
+	imgName string,
+	diffIDs []digest.Digest,
+	manifest ocispec.Manifest,
+	mounts []mount.Mount,
+) ([]ftypes.LayerPath, error) {
+	if len(diffIDs) == 0 {
+		return nil, fmt.Errorf("image %s has no diff_ids", imgName)
+	}
+	if err := verifyChainAgainstSnapshotter(ctx, s, computeChainIDs(diffIDs)); err != nil {
+		return nil, err
+	}
+
+	topDown := extractLayersFromOverlayFSMounts(mounts)
+	if len(topDown) != len(diffIDs) {
+		return nil, fmt.Errorf("%w: %d paths vs %d diff_ids", errLayerCountMismatch, len(topDown), len(diffIDs))
+	}
+
+	digestsAligned := len(manifest.Layers) == len(diffIDs)
+	if !digestsAligned {
+		log.Warnf("image %s: manifest has %d layers, diff_ids has %d; emitting SBOM without LayerDigest",
+			imgName, len(manifest.Layers), len(diffIDs))
+	}
+
+	out := make([]ftypes.LayerPath, len(diffIDs))
+	for i := range diffIDs {
+		lp := ftypes.LayerPath{
+			DiffID: diffIDs[i].String(),
+			// overlay lowerdir is top-down; flip to image-config bottom-up.
+			Path: topDown[len(topDown)-1-i],
+		}
+		if digestsAligned {
+			lp.Digest = manifest.Layers[i].Digest.String()
+		}
+		out[i] = lp
+	}
+	return out, nil
 }

--- a/pkg/util/trivy/crio.go
+++ b/pkg/util/trivy/crio.go
@@ -18,7 +18,34 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/crio"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/samber/lo"
 )
+
+// buildCRIOLayerPaths pairs each CRI-O lowerDir with its non-empty
+// imgMeta.Layers entry. GetCRIOImageLayers builds the paths by
+// prepending as it walks imgMeta.Layers in image-config order, so
+// lowerDirs comes out top-to-base while the filtered layers stay
+// base-to-top; walk lowerDirs in reverse to realign them.
+func buildCRIOLayerPaths(imgMeta *workloadmeta.ContainerImageMetadata, lowerDirs []string) ([]ftypes.LayerPath, error) {
+	nonEmpty := lo.Filter(imgMeta.Layers, func(layer workloadmeta.ContainerImageLayer, _ int) bool {
+		return layer.DiffID != ""
+	})
+	if len(nonEmpty) != len(lowerDirs) {
+		return nil, fmt.Errorf("%w: %d lowerDirs vs %d non-empty imgMeta layers",
+			errLayerCountMismatch, len(lowerDirs), len(nonEmpty))
+	}
+	n := len(lowerDirs)
+	out := make([]ftypes.LayerPath, n)
+	for i := 0; i < n; i++ {
+		dir := lowerDirs[n-1-i]
+		out[i] = ftypes.LayerPath{
+			DiffID: "sha256:" + filepath.Base(filepath.Dir(dir)),
+			Digest: nonEmpty[i].DiffID,
+			Path:   dir,
+		}
+	}
+	return out, nil
+}
 
 type fakeCRIOContainer struct {
 	*fakeContainer
@@ -33,9 +60,10 @@ func (c *fakeCRIOContainer) ConfigFile() (*v1.ConfigFile, error) {
 		Architecture: c.imgMeta.Architecture,
 		OS:           c.imgMeta.OS,
 	}
-	configFile.RootFS.DiffIDs = make([]v1.Hash, len(c.layerIDs))
-	for i, diffID := range c.layerIDs {
-		configFile.RootFS.DiffIDs[i], _ = v1.NewHash(diffID)
+	diffIDs := c.diffIDs()
+	configFile.RootFS.DiffIDs = make([]v1.Hash, len(diffIDs))
+	for i, d := range diffIDs {
+		configFile.RootFS.DiffIDs[i], _ = v1.NewHash(d)
 	}
 
 	for _, layer := range c.imgMeta.Layers {
@@ -82,17 +110,12 @@ func (c *Collector) ScanCRIOImageFromOverlayFS(ctx context.Context, imgMeta *wor
 		return nil, fmt.Errorf("failed to retrieve layer directories: %w", err)
 	}
 
-	diffIDs := make([]string, 0, len(lowerDirs))
-	for _, dir := range lowerDirs {
-		diffIDs = append(diffIDs, "sha256:"+filepath.Base(filepath.Dir(dir)))
-	}
-
-	fc, err := newFakeContainer(lowerDirs, imgMeta, diffIDs)
+	layers, err := buildCRIOLayerPaths(imgMeta, lowerDirs)
 	if err != nil {
 		return nil, err
 	}
 	report, err := c.scanOverlayFS(ctx, lowerDirs, &fakeCRIOContainer{
-		fakeContainer: fc,
+		fakeContainer: newFakeContainer(layers, imgMeta),
 	}, imgMeta, scanOptions)
 	if err != nil {
 		return nil, err

--- a/pkg/util/trivy/docker.go
+++ b/pkg/util/trivy/docker.go
@@ -20,8 +20,42 @@ import (
 	containersimage "github.com/DataDog/datadog-agent/pkg/util/containers/image"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 
+	dimage "github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
 )
+
+// buildDockerLayerPaths pairs DiffID and Path from the same overlay2
+// inspect response. Digest is left empty: the daemon exposes no
+// reliable per-layer manifest digest, and Trivy does not need one.
+func buildDockerLayerPaths(inspect dimage.InspectResponse) ([]ftypes.LayerPath, error) {
+	var paths []string
+	if dirs, ok := inspect.GraphDriver.Data["LowerDir"]; ok && dirs != "" {
+		parts := strings.Split(dirs, ":")
+		for i := len(parts) - 1; i >= 0; i-- {
+			paths = append(paths, parts[i])
+		}
+	}
+	if dirs, ok := inspect.GraphDriver.Data["UpperDir"]; ok && dirs != "" {
+		paths = append(paths, strings.Split(dirs, ":")...)
+	}
+
+	if env.IsContainerized() {
+		for i, p := range paths {
+			paths[i] = containersimage.SanitizeHostPath(p)
+		}
+	}
+
+	diffIDs := inspect.RootFS.Layers
+	if len(paths) != len(diffIDs) {
+		return nil, fmt.Errorf("%w: %d paths vs %d diff_ids", errLayerCountMismatch, len(paths), len(diffIDs))
+	}
+
+	out := make([]ftypes.LayerPath, len(diffIDs))
+	for i := range diffIDs {
+		out[i] = ftypes.LayerPath{DiffID: diffIDs[i], Path: paths[i]}
+	}
+	return out, nil
+}
 
 // DockerCollector defines the docker collector name
 const DockerCollector = "docker"
@@ -96,35 +130,20 @@ func (c *Collector) ScanDockerImage(ctx context.Context, imgMeta *workloadmeta.C
 	}
 
 	if scanOptions.OverlayFsScan && fanalImage.inspect.GraphDriver.Name == "overlay2" {
-		// LowerDir is top-down without the topmost layer; UpperDir is the topmost.
-		var layers []string
-		if layerDirs, ok := fanalImage.inspect.GraphDriver.Data["LowerDir"]; ok {
-			parts := strings.Split(layerDirs, ":")
-			for i := len(parts) - 1; i >= 0; i-- {
-				layers = append(layers, parts[i])
-			}
-		}
-
-		if layerDirs, ok := fanalImage.inspect.GraphDriver.Data["UpperDir"]; ok {
-			layers = append(layers, strings.Split(layerDirs, ":")...)
-		}
-
-		if env.IsContainerized() {
-			for i, layer := range layers {
-				layers[i] = containersimage.SanitizeHostPath(layer)
-			}
-		}
-
-		fc, err := newFakeContainer(layers, imgMeta, fanalImage.inspect.RootFS.Layers)
+		layers, err := buildDockerLayerPaths(fanalImage.inspect)
 		if err != nil {
-			return nil, "overlayfs", err
+			return nil, "overlayfs", fmt.Errorf("unable to pair layer paths for image %s: %w", imgMeta.ID, err)
 		}
 		fakeContainer := &fakeDockerContainer{
 			image:         fanalImage,
-			fakeContainer: fc,
+			fakeContainer: newFakeContainer(layers, imgMeta),
 		}
 
-		report, err := c.scanOverlayFS(ctx, layers, fakeContainer, imgMeta, scanOptions)
+		paths := make([]string, len(layers))
+		for i, l := range layers {
+			paths[i] = l.Path
+		}
+		report, err := c.scanOverlayFS(ctx, paths, fakeContainer, imgMeta, scanOptions)
 		if err != nil {
 			return nil, "overlayfs", err
 		}

--- a/pkg/util/trivy/layers_containerd_test.go
+++ b/pkg/util/trivy/layers_containerd_test.go
@@ -1,0 +1,235 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy && containerd
+
+package trivy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/errdefs"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// canonicalEmptyDiffID is sha256 of an empty tar. Trivy used to
+// special-case this value because the old positional pairing kept
+// reusing it across images sharing the same canonical empty layer.
+const canonicalEmptyDiffID = "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+
+// d wraps digest.FromString for terser test fixtures.
+func d(s string) digest.Digest { return digest.FromString(s) }
+
+func TestComputeChainIDs(t *testing.T) {
+	// computeChainIDs must copy before delegating to identity.ChainIDs
+	// (which mutates in place) and return the whole chain bottom-up, with
+	// the base chainID equal to the base diff_id.
+	diffIDs := []digest.Digest{d("base"), d("mid"), d("top")}
+	orig := append([]digest.Digest{}, diffIDs...)
+
+	got := computeChainIDs(diffIDs)
+
+	require.Len(t, got, len(diffIDs))
+	assert.Equal(t, diffIDs[0], got[0])
+	for i := range orig {
+		require.Equal(t, orig[i], diffIDs[i])
+	}
+
+	assert.Nil(t, computeChainIDs(nil))
+}
+
+// fakeSnapshotter is a minimal snapshotterStat. An unset entry returns
+// ErrNotFound, mirroring containerd's behaviour for unknown chainIDs.
+type fakeSnapshotter struct {
+	infos map[string]snapshots.Info
+}
+
+func (f *fakeSnapshotter) Stat(_ context.Context, key string) (snapshots.Info, error) {
+	if info, ok := f.infos[key]; ok {
+		return info, nil
+	}
+	return snapshots.Info{}, errdefs.ErrNotFound
+}
+
+// snapshotterFromChain populates a fakeSnapshotter so Stat(chain[i])
+// returns Parent=chain[i-1] (and empty Parent for the base).
+func snapshotterFromChain(chain []digest.Digest) *fakeSnapshotter {
+	infos := make(map[string]snapshots.Info, len(chain))
+	for i, c := range chain {
+		info := snapshots.Info{Name: c.String()}
+		if i > 0 {
+			info.Parent = chain[i-1].String()
+		}
+		infos[c.String()] = info
+	}
+	return &fakeSnapshotter{infos: infos}
+}
+
+func TestVerifyChainAgainstSnapshotter(t *testing.T) {
+	chain := []digest.Digest{d("c0"), d("c0c1"), d("c0c1c2")}
+
+	t.Run("happy_path", func(t *testing.T) {
+		require.NoError(t, verifyChainAgainstSnapshotter(t.Context(), snapshotterFromChain(chain), chain))
+	})
+
+	t.Run("missing_snapshot", func(t *testing.T) {
+		f := snapshotterFromChain(chain)
+		delete(f.infos, chain[1].String())
+		err := verifyChainAgainstSnapshotter(t.Context(), f, chain)
+		require.ErrorIs(t, err, errdefs.ErrNotFound)
+	})
+
+	t.Run("wrong_parent", func(t *testing.T) {
+		f := snapshotterFromChain(chain)
+		f.infos[chain[1].String()] = snapshots.Info{
+			Name:   chain[1].String(),
+			Parent: d("not-the-parent").String(),
+		}
+		err := verifyChainAgainstSnapshotter(t.Context(), f, chain)
+		require.ErrorIs(t, err, errLayerChainMismatch)
+	})
+
+	t.Run("base_has_nonempty_parent", func(t *testing.T) {
+		f := snapshotterFromChain(chain)
+		f.infos[chain[0].String()] = snapshots.Info{
+			Name:   chain[0].String(),
+			Parent: "uh-oh",
+		}
+		err := verifyChainAgainstSnapshotter(t.Context(), f, chain)
+		require.ErrorIs(t, err, errLayerChainMismatch)
+	})
+}
+
+// manifestForDiffIDs builds an OCI manifest with one Descriptor per
+// diff_id. Layer Digests in the manifest are derived from a separate
+// namespace so a positional confusion of Digest with DiffID is
+// detectable in the assertions below.
+func manifestForDiffIDs(diffIDs []digest.Digest) ocispec.Manifest {
+	layers := make([]ocispec.Descriptor, len(diffIDs))
+	for i := range diffIDs {
+		layers[i] = ocispec.Descriptor{
+			Digest:    d("blob-" + diffIDs[i].String()),
+			MediaType: ocispec.MediaTypeImageLayerGzip,
+			Size:      int64(1024 * (i + 1)),
+		}
+	}
+	return ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Layers:    layers,
+	}
+}
+
+// mountsFromTopDownPaths wraps paths in a single overlay mount option.
+func mountsFromTopDownPaths(paths []string) []mount.Mount {
+	return []mount.Mount{{
+		Type:    "overlay",
+		Source:  "overlay",
+		Options: []string{"lowerdir=" + strings.Join(paths, ":")},
+	}}
+}
+
+func TestBuildContainerdLayerPaths(t *testing.T) {
+	const imgName = "test-image"
+
+	// Five-layer image with the canonical empty-layer DiffID in the
+	// middle, exercising a historical failure mode.
+	diffIDs := []digest.Digest{
+		d("base"),
+		d("apt-deps"),
+		digest.Digest(canonicalEmptyDiffID),
+		d("rails"),
+		d("entrypoint"),
+	}
+	manifest := manifestForDiffIDs(diffIDs)
+	topDownPaths := []string{
+		"/snap/path-entrypoint",
+		"/snap/path-rails",
+		"/snap/path-canonical-empty",
+		"/snap/path-apt-deps",
+		"/snap/path-base",
+	}
+	chain := computeChainIDs(diffIDs)
+	snap := snapshotterFromChain(chain)
+
+	t.Run("happy_path", func(t *testing.T) {
+		got, err := buildContainerdLayerPaths(t.Context(), snap, imgName, diffIDs, manifest, mountsFromTopDownPaths(topDownPaths))
+		require.NoError(t, err)
+		require.Len(t, got, len(diffIDs))
+		for i, want := range []struct {
+			diffID digest.Digest
+			path   string
+		}{
+			{diffIDs[0], "/snap/path-base"},
+			{diffIDs[1], "/snap/path-apt-deps"},
+			{diffIDs[2], "/snap/path-canonical-empty"},
+			{diffIDs[3], "/snap/path-rails"},
+			{diffIDs[4], "/snap/path-entrypoint"},
+		} {
+			assert.Equal(t, want.diffID.String(), got[i].DiffID)
+			assert.Equal(t, want.path, got[i].Path)
+			assert.Equal(t, manifest.Layers[i].Digest.String(), got[i].Digest)
+			assert.NotEqualf(t, got[i].DiffID, got[i].Digest, "[%d] manifest digest must differ from diff_id", i)
+		}
+	})
+
+	t.Run("count_mismatch_paths_too_few", func(t *testing.T) {
+		_, err := buildContainerdLayerPaths(t.Context(), snap, imgName, diffIDs, manifest, mountsFromTopDownPaths(topDownPaths[:3]))
+		require.ErrorIs(t, err, errLayerCountMismatch)
+	})
+
+	t.Run("count_mismatch_paths_too_many", func(t *testing.T) {
+		extra := append([]string{}, topDownPaths...)
+		extra = append(extra, "/snap/path-spurious-upper")
+		_, err := buildContainerdLayerPaths(t.Context(), snap, imgName, diffIDs, manifest, mountsFromTopDownPaths(extra))
+		require.ErrorIs(t, err, errLayerCountMismatch)
+	})
+
+	t.Run("empty_diff_ids", func(t *testing.T) {
+		_, err := buildContainerdLayerPaths(t.Context(), snap, imgName, nil, manifest, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("manifest_short_keeps_diffid_path_drops_digest", func(t *testing.T) {
+		shortManifest := manifestForDiffIDs(diffIDs[:3])
+		got, err := buildContainerdLayerPaths(t.Context(), snap, imgName, diffIDs, shortManifest, mountsFromTopDownPaths(topDownPaths))
+		require.NoError(t, err)
+		for i := range got {
+			assert.NotEmptyf(t, got[i].DiffID, "[%d] DiffID is empty", i)
+			assert.NotEmptyf(t, got[i].Path, "[%d] Path is empty", i)
+			assert.Emptyf(t, got[i].Digest, "[%d] Digest = %q, want empty when manifest is short", i, got[i].Digest)
+		}
+	})
+
+	t.Run("snapshotter_chain_mismatch", func(t *testing.T) {
+		badSnap := snapshotterFromChain(chain)
+		badSnap.infos[chain[2].String()] = snapshots.Info{
+			Name:   chain[2].String(),
+			Parent: d("not-the-parent").String(),
+		}
+		_, err := buildContainerdLayerPaths(t.Context(), badSnap, imgName, diffIDs, manifest, mountsFromTopDownPaths(topDownPaths))
+		require.ErrorIs(t, err, errLayerChainMismatch)
+	})
+
+	t.Run("never_emits_wrong_pair", func(t *testing.T) {
+		// Invariant: no LayerPath.Digest should ever equal any DiffID.
+		// The desync we guard against took exactly that shape.
+		got, err := buildContainerdLayerPaths(t.Context(), snap, imgName, diffIDs, manifest, mountsFromTopDownPaths(topDownPaths))
+		require.NoError(t, err)
+		diffIDSet := make(map[string]struct{}, len(diffIDs))
+		for _, x := range diffIDs {
+			diffIDSet[x.String()] = struct{}{}
+		}
+		for i, lp := range got {
+			assert.NotContainsf(t, diffIDSet, lp.Digest, "[%d] LayerPath.Digest = %q is also a DiffID; pairing desync", i, lp.Digest)
+		}
+	})
+}

--- a/pkg/util/trivy/layers_crio_test.go
+++ b/pkg/util/trivy/layers_crio_test.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy && crio
+
+package trivy
+
+import (
+	"testing"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCRIOLayerPaths(t *testing.T) {
+	// Distinct value namespaces for the path-encoded DiffID and the
+	// imgMeta layer DiffID so a positional swap is detectable -- the
+	// same-name fixtures of the original test let an off-by-one go silently.
+	imgMeta := &workloadmeta.ContainerImageMetadata{
+		Layers: []workloadmeta.ContainerImageLayer{
+			{DiffID: "sha256:digest_base"},
+			{DiffID: ""}, // empty-history marker; must be skipped
+			{DiffID: "sha256:digest_middle"},
+			{DiffID: "sha256:digest_top"},
+		},
+	}
+	// GetCRIOImageLayers prepends each path while iterating
+	// imgMeta.Layers, so its output is top-to-base.
+	lowerDirs := []string{
+		"/var/lib/containers/storage/overlay/diff_top/diff",
+		"/var/lib/containers/storage/overlay/diff_middle/diff",
+		"/var/lib/containers/storage/overlay/diff_base/diff",
+	}
+
+	t.Run("happy_path_pairs_in_image_config_order", func(t *testing.T) {
+		got, err := buildCRIOLayerPaths(imgMeta, lowerDirs)
+		require.NoError(t, err)
+		want := []struct{ diffID, digest, path string }{
+			{"sha256:diff_base", "sha256:digest_base", "/var/lib/containers/storage/overlay/diff_base/diff"},
+			{"sha256:diff_middle", "sha256:digest_middle", "/var/lib/containers/storage/overlay/diff_middle/diff"},
+			{"sha256:diff_top", "sha256:digest_top", "/var/lib/containers/storage/overlay/diff_top/diff"},
+		}
+		require.Len(t, got, len(want))
+		for i, w := range want {
+			assert.Equal(t, w.diffID, got[i].DiffID)
+			assert.Equal(t, w.digest, got[i].Digest)
+			assert.Equal(t, w.path, got[i].Path)
+		}
+	})
+
+	t.Run("count_mismatch_extra_lower_dir", func(t *testing.T) {
+		extra := append([]string{}, lowerDirs...)
+		extra = append(extra, "/var/lib/containers/storage/overlay/diff_spurious/diff")
+		_, err := buildCRIOLayerPaths(imgMeta, extra)
+		require.ErrorIs(t, err, errLayerCountMismatch)
+	})
+
+	t.Run("count_mismatch_short_lower_dir", func(t *testing.T) {
+		_, err := buildCRIOLayerPaths(imgMeta, lowerDirs[:1])
+		require.ErrorIs(t, err, errLayerCountMismatch)
+	})
+}

--- a/pkg/util/trivy/layers_docker_test.go
+++ b/pkg/util/trivy/layers_docker_test.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy && docker
+
+package trivy
+
+import (
+	"testing"
+
+	dimage "github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/api/types/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dockerInspect builds a synthetic docker InspectResponse modelling an
+// overlay2-backed image. lower is a colon-joined chain of paths
+// (top-down except the topmost, per docker daemon convention), upper
+// is the topmost path. diffIDs is in image-config (bottom-up) order.
+func dockerInspect(lower, upper string, diffIDs []string) dimage.InspectResponse {
+	return dimage.InspectResponse{
+		GraphDriver: &storage.DriverData{
+			Name: "overlay2",
+			Data: map[string]string{
+				"LowerDir": lower,
+				"UpperDir": upper,
+			},
+		},
+		RootFS: dimage.RootFS{Layers: diffIDs},
+	}
+}
+
+func TestBuildDockerLayerPaths(t *testing.T) {
+	diffIDs := []string{
+		"sha256:base",
+		"sha256:mid1",
+		"sha256:mid2",
+		"sha256:top",
+	}
+
+	t.Run("happy_path_pairs_diffid_with_path", func(t *testing.T) {
+		// LowerDir is top-down without the topmost: mid2 -> mid1 -> base.
+		// UpperDir is the topmost (top).
+		// After reversal in buildDockerLayerPaths the slice is:
+		//   [base, mid1, mid2, top]
+		inspect := dockerInspect("/dock/mid2:/dock/mid1:/dock/base", "/dock/top", diffIDs)
+		got, err := buildDockerLayerPaths(inspect)
+		require.NoError(t, err)
+
+		wantPaths := []string{"/dock/base", "/dock/mid1", "/dock/mid2", "/dock/top"}
+		require.Len(t, diffIDs, len(got))
+		for i := range got {
+			assert.Equal(t, diffIDs[i], got[i].DiffID)
+			assert.Equal(t, wantPaths[i], got[i].Path)
+			// Docker daemon does not expose per-layer manifest digests
+			// reliably; the builder leaves Digest empty rather than
+			// risk pairing a wrong one.
+			assert.Empty(t, got[i].Digest)
+		}
+	})
+
+	t.Run("count_mismatch_too_few_paths", func(t *testing.T) {
+		inspect := dockerInspect("/dock/mid1:/dock/base", "/dock/top", diffIDs) // 3 paths, 4 diff_ids
+		_, err := buildDockerLayerPaths(inspect)
+		require.ErrorIs(t, err, errLayerCountMismatch)
+	})
+
+	t.Run("count_mismatch_too_many_paths", func(t *testing.T) {
+		inspect := dockerInspect("/dock/spurious:/dock/mid2:/dock/mid1:/dock/base", "/dock/top", diffIDs) // 5 paths
+		_, err := buildDockerLayerPaths(inspect)
+		require.ErrorIs(t, err, errLayerCountMismatch)
+	})
+
+	t.Run("only_upperdir_single_layer", func(t *testing.T) {
+		inspect := dockerInspect("", "/dock/only", []string{"sha256:only"})
+		got, err := buildDockerLayerPaths(inspect)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "/dock/only", got[0].Path)
+		assert.Equal(t, "sha256:only", got[0].DiffID)
+	})
+}

--- a/pkg/util/trivy/overlayfs.go
+++ b/pkg/util/trivy/overlayfs.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -21,53 +22,37 @@ import (
 	"github.com/DataDog/ddtrivy"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/samber/lo"
 )
 
+// errLayerCountMismatch means the overlayfs mount (or the docker / crio
+// equivalent) exposed a different number of layer paths than the image
+// config has diff_ids. They are 1:1 by the OCI spec, so a divergence
+// means an upstream invariant broke and we refuse to scan rather than
+// guess a pairing.
+var errLayerCountMismatch = errors.New("overlayfs mount layer count does not match image config")
+
+// fakeContainer adapts a pre-paired set of LayerPaths into the
+// ftypes.Container surface Trivy expects. It carries imgMeta separately
+// so the CRI-O wrapper can read its History entries for ConfigFile().
 type fakeContainer struct {
-	layerIDs   []string
-	imgMeta    *workloadmeta.ContainerImageMetadata
-	layerPaths []string
-	layers     []ftypes.LayerPath
+	imgMeta *workloadmeta.ContainerImageMetadata
+	layers  []ftypes.LayerPath
 }
 
-// layerIDs and layerPaths must both be in image-config order (bottom-up);
-// paths from overlay mount syntax must be reversed by the caller, else each
-// DiffID is paired with the wrong layer and trivy's DiffID-keyed blob cache
-// gets poisoned. Empty-layer history markers in imgMeta.Layers are filtered
-// to keep the i-th non-empty entry aligned with layerIDs[i].
-func newFakeContainer(layerPaths []string, imgMeta *workloadmeta.ContainerImageMetadata, layerIDs []string) (*fakeContainer, error) {
-	imageLayers := lo.Filter(imgMeta.Layers, func(layer workloadmeta.ContainerImageLayer, _ int) bool {
-		return layer.DiffID != ""
-	})
-	// Path / DiffID alignment must be exact: these are what trivy looks up.
-	// imageLayers feeds the optional Digest annotation; tolerate the Docker
-	// fallback in layersFromDockerHistoryAndInspect that can emit more
-	// non-empty entries than RootFS.Layers.
-	if len(layerIDs) != len(layerPaths) || len(layerIDs) > len(imageLayers) {
-		return nil, fmt.Errorf("mismatch count for layer IDs, paths and image layers (ids=%d, paths=%d, layers=%d)",
-			len(layerIDs), len(layerPaths), len(imageLayers))
+// newFakeContainer wraps an already-paired LayerPath slice. The caller
+// builds each {DiffID, Digest, Path} triple; this constructor does no
+// further validation, so any desync here came from the caller.
+func newFakeContainer(layers []ftypes.LayerPath, imgMeta *workloadmeta.ContainerImageMetadata) *fakeContainer {
+	return &fakeContainer{imgMeta: imgMeta, layers: layers}
+}
+
+// diffIDs returns the DiffIDs of c's layers in image-config (bottom-up) order.
+func (c *fakeContainer) diffIDs() []string {
+	out := make([]string, len(c.layers))
+	for i, l := range c.layers {
+		out[i] = l.DiffID
 	}
-
-	log.Debugf("create fake container with paths=%v", layerPaths)
-
-	layers := make([]ftypes.LayerPath, len(layerIDs))
-	for i, id := range layerIDs {
-		diffID, _ := v1.NewHash(id)
-		layers[i] = ftypes.LayerPath{
-			DiffID: diffID.String(),
-			Path:   layerPaths[i],
-			Digest: imageLayers[i].DiffID,
-		}
-	}
-
-	return &fakeContainer{
-		layerIDs:   layerIDs,
-		imgMeta:    imgMeta,
-		layerPaths: layerPaths,
-		layers:     layers,
-	}, nil
+	return out
 }
 
 func (c *fakeContainer) LayerByDiffID(hash string) (ftypes.LayerPath, error) {
@@ -89,7 +74,7 @@ func (c *fakeContainer) LayerByDigest(hash string) (ftypes.LayerPath, error) {
 }
 
 func (c *fakeContainer) Layers() []ftypes.LayerPath {
-	return c.layers
+	return slices.Clone(c.layers)
 }
 
 func (c *Collector) scanOverlayFS(ctx context.Context, layers []string, ctr ftypes.Container, imgMeta *workloadmeta.ContainerImageMetadata, scanOptions sbom.ScanOptions) (*Report, error) {

--- a/pkg/util/trivy/overlayfs_test.go
+++ b/pkg/util/trivy/overlayfs_test.go
@@ -11,68 +11,51 @@ import (
 	"testing"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFakeContainer(t *testing.T) {
+func TestFakeContainerLookups(t *testing.T) {
 	const snapshotsBase = "/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots"
-	layerIDs := []string{
+	diffIDs := []string{
 		"sha256:d543b8cad89e3428ac8852a13cb2dbfaf55b1e10fd95a9753e51faf393d60e81",
 		"sha256:7b1349c98b6929b220fd1ed89c7255c6a8a7557c448cf7fda8dcfbad37fa4549",
 		"sha256:1608fb7c693049b6edc16af0542d923cd8542f7039bfca161600e9142055dcfb",
-		"sha256:3c516036f954ffb308f505c5bbea2099110f84d3f7b76940e4eade80691194b7",
-		"sha256:a2ff3eeada006822f19570505fa99db3e6410addac86394fba4ba9304230cfeb",
-		"sha256:20bde7516cdbeccc4625f1691140d63ed8e3fc46a0f593163b48020de88b8c3e",
-		"sha256:b7d0da6041ab2b567cab384374652b82beddd560b7d59540463a7ce3e600274c",
-		"sha256:9b33b108c42d01575feac410e94f500e01cf2552df064a019a7b27184d8371ff",
-		"sha256:24586912362b7671f6b5e8e1a78194f340653f1df0376cd415e09832b2be40fb",
-		"sha256:384eaa6554ab5ccf7d8462698e5b86b98014aa1c8c8a7d8457f8854148941aad",
-		"sha256:1a651b5627b77ee65c117e801b759506cc6f4c907a0784aa0e0280e001386df8",
-		"sha256:0c11dc029b3c6cd8b02788f49f0d0a9bbc353cebb900869fd401e74f2e0ac8fd",
-		"sha256:f8a6696ef6df5fb297d4f1cd3ef877c836a3e269b566b415f47cf3cdf5b14c97",
-		"sha256:7c6bc12b66c3f9059ff7c6665f75916c2533e829476ff0ec351850f9d3f32233",
-		"sha256:873b790faaaaa245c52fba066b70c5a7b3d427d2068d72756738c7741b4b7031",
 	}
-	// Snapshot IDs grow with layer creation; smallest at the bottom.
-	layersPath := []string{
+	digests := []string{
+		"sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		"sha256:2222222222222222222222222222222222222222222222222222222222222222",
+		"sha256:3333333333333333333333333333333333333333333333333333333333333333",
+	}
+	paths := []string{
 		snapshotsBase + "/134/fs",
 		snapshotsBase + "/135/fs",
 		snapshotsBase + "/136/fs",
-		snapshotsBase + "/137/fs",
-		snapshotsBase + "/138/fs",
-		snapshotsBase + "/139/fs",
-		snapshotsBase + "/140/fs",
-		snapshotsBase + "/141/fs",
-		snapshotsBase + "/142/fs",
-		snapshotsBase + "/143/fs",
-		snapshotsBase + "/144/fs",
-		snapshotsBase + "/145/fs",
-		snapshotsBase + "/146/fs",
-		snapshotsBase + "/147/fs",
-		snapshotsBase + "/148/fs",
-	}
-	// One empty-layer history marker exercises the filter.
-	imageMeta := &workloadmeta.ContainerImageMetadata{
-		Layers: []workloadmeta.ContainerImageLayer{
-			{DiffID: ""},
-		},
-	}
-	for _, id := range layerIDs {
-		imageMeta.Layers = append(imageMeta.Layers, workloadmeta.ContainerImageLayer{DiffID: id})
 	}
 
-	c, err := newFakeContainer(layersPath, imageMeta, layerIDs)
-	if err != nil {
-		t.Fatal(err)
+	layers := make([]ftypes.LayerPath, len(diffIDs))
+	for i := range diffIDs {
+		layers[i] = ftypes.LayerPath{DiffID: diffIDs[i], Digest: digests[i], Path: paths[i]}
 	}
+	c := newFakeContainer(layers, &workloadmeta.ContainerImageMetadata{})
 
-	for i, id := range layerIDs {
+	for i, id := range diffIDs {
 		got, err := c.LayerByDiffID(id)
-		if err != nil {
-			t.Errorf("LayerByDiffID(%s): %v", id, err)
+		if !assert.NoErrorf(t, err, "LayerByDiffID(%s)", id) {
 			continue
 		}
-		assert.Equal(t, layersPath[i], got.Path, "DiffID %s", id)
-		assert.Equal(t, id, got.Digest, "DiffID %s digest", id)
+		assert.Equal(t, paths[i], got.Path)
+		assert.Equal(t, digests[i], got.Digest)
 	}
+
+	for i, d := range digests {
+		got, err := c.LayerByDigest(d)
+		if !assert.NoErrorf(t, err, "LayerByDigest(%s)", d) {
+			continue
+		}
+		assert.Equal(t, diffIDs[i], got.DiffID)
+	}
+
+	_, err := c.LayerByDiffID("sha256:doesnotexist")
+	assert.Error(t, err)
 }

--- a/pkg/util/trivy/trivy_test.go
+++ b/pkg/util/trivy/trivy_test.go
@@ -54,6 +54,19 @@ func TestExtractLayersFromOverlayFSMounts(t *testing.T) {
 			},
 			want: []string{"/path/to/upper1", "/path/to/lower1", "/path/to/lower2"},
 		},
+		{
+			// A single-layer image is exposed by containerd as a single bind mount
+			// (no lowerdir/upperdir); its only layer is the mount source.
+			name:   "Single-layer bind mount",
+			mounts: []mount.Mount{{Type: "bind", Source: "/path/to/snapshots/132/fs", Options: []string{"ro", "rbind"}}},
+			want:   []string{"/path/to/snapshots/132/fs"},
+		},
+		{
+			// Overlay options take precedence; the mount source is not a layer path.
+			name:   "Overlay mount source ignored",
+			mounts: []mount.Mount{{Type: "overlay", Source: "overlay", Options: []string{"lowerdir=/path/to/lower"}}},
+			want:   []string{"/path/to/lower"},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, extractLayersFromOverlayFSMounts(tt.mounts))


### PR DESCRIPTION
A layer's ftypes.LayerPath was assembled by indexing three unrelated
slices at the same position: the config's diff_ids, the overlay mount
paths, and workloadmeta's layers. Nothing kept those in the same order,
so any drift paired one layer's DiffID with another's path or digest.
Trivy keys its blob cache on DiffID, so a bad pairing poisoned the
on-disk cache and survived agent restarts.

Build each LayerPath from data that is already together, and refuse to
scan when the inputs disagree:

- containerd: read diff_ids and the manifest from the image config,
  then walk the snapshotter's parent chain to confirm it matches the
  chainIDs the diff_ids produce. Digest is the real manifest digest.
  These reads are namespaced: containerd stores content and snapshots
  per namespace, and the incoming context may not carry one. A
  single-layer image is exposed as one bind mount with no
  upperdir/lowerdir overlay options, so its mount source is taken as
  the sole layer path; without this it yields zero paths and is
  wrongly rejected as a count mismatch.
- docker: take DiffID and Path from the same inspect response; leave
  Digest empty, since the daemon has no reliable per-layer digest.
- crio: pair the path-derived DiffID with the non-empty workloadmeta
  layers, reversing lowerDirs (returned top-to-base) to realign them.

Two sentinels make a mismatch fatal: errLayerCountMismatch (paths vs
diff_ids) and errLayerChainMismatch (snapshotter chain vs config).

The old test reused one value for both DiffID and Digest and could not
catch a swap. The new per-runtime tests give every field a distinct
value and stub the snapshotter with a small fake, so a pairing or
chain-check regression fails loudly. TestExtractLayersFromOverlayFSMounts
also covers the single-layer bind-mount case.

