### PR TITLE
Fix `.claude/rules/allium.md` filter

### DIFF
--- a/.claude/rules/allium.md
+++ b/.claude/rules/allium.md
@@ -1,5 +1,6 @@
 ---
-globs: "**/*.allium"
+paths:
+  - "**/*.allium"
 ---
 
 # Allium language


### PR DESCRIPTION
### What does this PR do?
Fix the frontmatter key of a Claude rule: `paths:`, not `globs:`, per https://code.claude.com/docs/en/memory#path-specific-rules.

### Motivation
With the wrong key, the rule has been loading unconditionally (more tokens).

### Describe how you validated your changes
Running the `/memory` command no longer preloads `.claude/rules/allium.md` (and implied dependencies).

### Additional Notes
Spotted while working on a parallel rule (#51353).
