### PR TITLE
trace-agent: populate version from container tags in stats payloads

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -485,7 +485,7 @@ func (a *Agent) Process(p *api.Payload) {
 		a.TracerPayloadModifier.Modify(p.TracerPayload)
 	}
 
-	gitCommitSha, imageTag := version.GetVersionDataFromContainerTags(p.ContainerTags)
+	gitCommitSha, imageTag, appVersion := version.GetVersionDataFromContainerTags(p.ContainerTags)
 
 	a.discardSpans(p)
 
@@ -555,7 +555,7 @@ func (a *Agent) Process(p *api.Payload) {
 
 		a.setPayloadAttributes(p, root, chunk)
 
-		pt := processedTrace(p, chunk, root, imageTag, gitCommitSha)
+		pt := processedTrace(p, chunk, root, imageTag, gitCommitSha, appVersion)
 		if !p.ClientComputedStats {
 			statsInput.Traces = append(statsInput.Traces, *pt.Clone())
 		}
@@ -664,7 +664,7 @@ func (a *Agent) ProcessV1(p *api.PayloadV1) {
 		}
 	}
 
-	gitCommitSha, imageTag := version.GetVersionDataFromContainerTags(p.ContainerTags)
+	gitCommitSha, imageTag, appVersion := version.GetVersionDataFromContainerTags(p.ContainerTags)
 
 	// TODO: Implement this when we support v1 on serverless
 	// a.discardSpans(p)
@@ -732,7 +732,7 @@ func (a *Agent) ProcessV1(p *api.PayloadV1) {
 			traceutil.ComputeTopLevelV1(chunk)
 		}
 
-		pt := processedTraceV1(p, chunk, root, imageTag, gitCommitSha)
+		pt := processedTraceV1(p, chunk, root, imageTag, gitCommitSha, appVersion)
 		if !p.ClientComputedStats {
 			statsInput.Traces = append(statsInput.Traces, *pt.Clone())
 		}
@@ -843,7 +843,7 @@ func normalizeAPMModeSpanTag(apmMode string) string {
 }
 
 // processedTrace creates a ProcessedTrace based on the provided chunk, root, containerID, and agent config.
-func processedTrace(p *api.Payload, chunk *pb.TraceChunk, root *pb.Span, imageTag string, gitCommitSha string) *traceutil.ProcessedTrace {
+func processedTrace(p *api.Payload, chunk *pb.TraceChunk, root *pb.Span, imageTag string, gitCommitSha string, appVersion string) *traceutil.ProcessedTrace {
 	pt := &traceutil.ProcessedTrace{
 		TraceChunk:             chunk,
 		Root:                   root,
@@ -859,11 +859,15 @@ func processedTrace(p *api.Payload, chunk *pb.TraceChunk, root *pb.Span, imageTa
 	if pt.GitCommitSha == "" {
 		pt.GitCommitSha = gitCommitSha
 	}
+	// Only override AppVersion if it was not set in the tracer payload or span tags.
+	if pt.AppVersion == "" {
+		pt.AppVersion = appVersion
+	}
 	return pt
 }
 
 // processedTrace creates a ProcessedTrace based on the provided chunk, root, containerID, and agent config.
-func processedTraceV1(p *api.PayloadV1, chunk *idx.InternalTraceChunk, root *idx.InternalSpan, imageTag string, gitCommitSha string) *traceutil.ProcessedTraceV1 {
+func processedTraceV1(p *api.PayloadV1, chunk *idx.InternalTraceChunk, root *idx.InternalSpan, imageTag string, gitCommitSha string, appVersion string) *traceutil.ProcessedTraceV1 {
 	pt := &traceutil.ProcessedTraceV1{
 		TraceChunk:             chunk,
 		Root:                   root,
@@ -877,6 +881,10 @@ func processedTraceV1(p *api.PayloadV1, chunk *idx.InternalTraceChunk, root *idx
 	pt.ImageTag = imageTag
 	if payloadGitCommitSha, ok := p.TracerPayload.GetAttributeAsString("_dd.git.commit.sha"); ok {
 		pt.GitCommitSha = payloadGitCommitSha
+	}
+	// Only override AppVersion if it was not set in the tracer payload.
+	if pt.AppVersion == "" {
+		pt.AppVersion = appVersion
 	}
 	return pt
 }

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -4172,7 +4172,7 @@ func TestProcessedTrace(t *testing.T) {
 			},
 			ClientDroppedP0s: 1,
 		}
-		pt := processedTrace(apiPayload, chunk, root, "abc", "abc123")
+		pt := processedTrace(apiPayload, chunk, root, "abc", "abc123", "")
 		expectedPt := &traceutil.ProcessedTrace{
 			TraceChunk:             chunk,
 			Root:                   root,
@@ -4208,7 +4208,7 @@ func TestProcessedTrace(t *testing.T) {
 			},
 			ClientDroppedP0s: 1,
 		}
-		pt := processedTrace(apiPayload, chunk, root, "abc", "def456")
+		pt := processedTrace(apiPayload, chunk, root, "abc", "def456", "")
 		expectedPt := &traceutil.ProcessedTrace{
 			TraceChunk:             chunk,
 			Root:                   root,
@@ -4220,6 +4220,55 @@ func TestProcessedTrace(t *testing.T) {
 			ClientDroppedP0sWeight: 1,
 		}
 		assert.Equal(t, expectedPt, pt)
+	})
+
+	t.Run("app version comes from container tag when not set in payload or span", func(t *testing.T) {
+		root := &pb.Span{
+			Service:  "testsvc",
+			Name:     "parent",
+			TraceID:  1,
+			SpanID:   1,
+			Start:    time.Now().Add(-time.Second).UnixNano(),
+			Duration: time.Millisecond.Nanoseconds(),
+		}
+		chunk := testutil.TraceChunkWithSpan(root)
+		apiPayload := &api.Payload{
+			TracerPayload: &pb.TracerPayload{
+				Env:         "test",
+				Hostname:    "test-host",
+				ContainerID: "1",
+				Chunks:      []*pb.TraceChunk{chunk},
+			},
+			ClientDroppedP0s: 1,
+		}
+		pt := processedTrace(apiPayload, chunk, root, "img-from-ctag", "sha-from-ctag", "ver-from-ctag")
+		assert.Equal(t, "ver-from-ctag", pt.AppVersion)
+		assert.Equal(t, "sha-from-ctag", pt.GitCommitSha)
+		assert.Equal(t, "img-from-ctag", pt.ImageTag)
+	})
+
+	t.Run("payload app version overrides container tag", func(t *testing.T) {
+		root := &pb.Span{
+			Service:  "testsvc",
+			Name:     "parent",
+			TraceID:  1,
+			SpanID:   1,
+			Start:    time.Now().Add(-time.Second).UnixNano(),
+			Duration: time.Millisecond.Nanoseconds(),
+		}
+		chunk := testutil.TraceChunkWithSpan(root)
+		apiPayload := &api.Payload{
+			TracerPayload: &pb.TracerPayload{
+				Env:         "test",
+				Hostname:    "test-host",
+				ContainerID: "1",
+				Chunks:      []*pb.TraceChunk{chunk},
+				AppVersion:  "payload-version",
+			},
+			ClientDroppedP0s: 1,
+		}
+		pt := processedTrace(apiPayload, chunk, root, "", "", "ctag-version")
+		assert.Equal(t, "payload-version", pt.AppVersion)
 	})
 
 	t.Run("no results from container lookup", func(t *testing.T) {
@@ -4248,7 +4297,7 @@ func TestProcessedTrace(t *testing.T) {
 			},
 			ClientDroppedP0s: 1,
 		}
-		pt := processedTrace(apiPayload, chunk, root, "", "")
+		pt := processedTrace(apiPayload, chunk, root, "", "", "")
 		expectedPt := &traceutil.ProcessedTrace{
 			TraceChunk:             chunk,
 			Root:                   root,

--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -214,7 +214,7 @@ func (a *ClientStatsAggregator) flushPayloads(p []*pb.ClientStatsPayload) {
 
 func (a *ClientStatsAggregator) setVersionDataFromContainerTags(p *pb.ClientStatsPayload) {
 	// No need to go any further if we already have the information in the payload.
-	if p.ImageTag != "" && p.GitCommitSha != "" {
+	if p.ImageTag != "" && p.GitCommitSha != "" && p.Version != "" {
 		return
 	}
 	if p.ContainerID != "" {
@@ -222,13 +222,16 @@ func (a *ClientStatsAggregator) setVersionDataFromContainerTags(p *pb.ClientStat
 		if err != nil {
 			log.Error("Client stats aggregator is unable to resolve container ID (%s) to container tags: %v", p.ContainerID, err)
 		} else {
-			gitCommitSha, imageTag := version.GetVersionDataFromContainerTags(cTags)
+			gitCommitSha, imageTag, appVersion := version.GetVersionDataFromContainerTags(cTags)
 			// Only override if the payload's original values were empty strings.
 			if p.ImageTag == "" {
 				p.ImageTag = imageTag
 			}
 			if p.GitCommitSha == "" {
 				p.GitCommitSha = gitCommitSha
+			}
+			if p.Version == "" {
+				p.Version = appVersion
 			}
 		}
 	}

--- a/pkg/trace/stats/client_stats_aggregator_test.go
+++ b/pkg/trace/stats/client_stats_aggregator_test.go
@@ -605,16 +605,6 @@ func TestAggregationVersionData(t *testing.T) {
 		a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
 		require.Len(t, msw.payloads, 1)
 
-		// Add the expected gitCommitSha and imageTag on c1, c2, c3, and cDefault for these assertions.
-		c1.GitCommitSha = "sha-from-container-tags"
-		c1.ImageTag = "image-tag-from-container-tags"
-		c2.GitCommitSha = "sha-from-container-tags"
-		c2.ImageTag = "image-tag-from-container-tags"
-		c3.GitCommitSha = "sha-from-container-tags"
-		c3.ImageTag = "image-tag-from-container-tags"
-		cDefault.GitCommitSha = "sha-from-container-tags"
-		cDefault.ImageTag = "image-tag-from-container-tags"
-
 		aggCounts := msw.payloads[0]
 		assertAggCountsPayload(t, aggCounts)
 
@@ -639,6 +629,54 @@ func TestAggregationVersionData(t *testing.T) {
 		assert.Equal("image-tag-from-container-tags", aggCounts.Stats[0].ImageTag)
 		assert.Equal("sha-from-container-tags", aggCounts.Stats[0].GitCommitSha)
 		assert.Len(a.buckets, 0)
+	})
+
+	t.Run("version comes from container tags when not set in payload", func(t *testing.T) {
+		assert := assert.New(t)
+		a := newTestAggregator()
+		msw := &mockStatsWriter{}
+		a.writer = msw
+		cfg := config.New()
+		cfg.ContainerTags = func(_ string) ([]string, error) {
+			return []string{"git.commit.sha:sha-from-container-tags", "image_tag:image-tag-from-container-tags", "version:version-from-container-tags"}, nil
+		}
+		a.conf = cfg
+		testTime := time.Unix(time.Now().Unix(), 0)
+
+		bak := BucketsAggregationKey{Service: "s", Name: "test.op"}
+		c1 := payloadWithCounts(testTime, bak, "1", "", "", "", "", 11, 7, 100)
+
+		a.add(testTime, deepCopy(c1))
+		a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
+		require.Len(t, msw.payloads, 1)
+
+		aggCounts := msw.payloads[0]
+		assert.Equal("version-from-container-tags", aggCounts.Stats[0].Version)
+		assert.Equal("image-tag-from-container-tags", aggCounts.Stats[0].ImageTag)
+		assert.Equal("sha-from-container-tags", aggCounts.Stats[0].GitCommitSha)
+	})
+
+	t.Run("payload version overrides container tags", func(t *testing.T) {
+		assert := assert.New(t)
+		a := newTestAggregator()
+		msw := &mockStatsWriter{}
+		a.writer = msw
+		cfg := config.New()
+		cfg.ContainerTags = func(_ string) ([]string, error) {
+			return []string{"version:version-from-container-tags"}, nil
+		}
+		a.conf = cfg
+		testTime := time.Unix(time.Now().Unix(), 0)
+
+		bak := BucketsAggregationKey{Service: "s", Name: "test.op"}
+		c1 := payloadWithCounts(testTime, bak, "1", "payload-version", "", "", "", 11, 7, 100)
+
+		a.add(testTime, deepCopy(c1))
+		a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
+		require.Len(t, msw.payloads, 1)
+
+		aggCounts := msw.payloads[0]
+		assert.Equal("payload-version", aggCounts.Stats[0].Version)
 	})
 
 	t.Run("payload git commit sha and image tag override container tags", func(t *testing.T) {

--- a/pkg/trace/version/version.go
+++ b/pkg/trace/version/version.go
@@ -17,10 +17,11 @@ const (
 	gitCommitShaField     = "_dd.git.commit.sha"
 	gitCommitShaTagPrefix = "git.commit.sha:"
 	imageTagPrefix        = "image_tag:"
+	versionTagPrefix      = "version:"
 )
 
-// GetVersionDataFromContainerTags will return the git commit sha and image tag from container tags, if present.
-func GetVersionDataFromContainerTags(cTags []string) (gitCommitSha, imageTag string) {
+// GetVersionDataFromContainerTags will return the git commit sha, image tag, and app version from container tags, if present.
+func GetVersionDataFromContainerTags(cTags []string) (gitCommitSha, imageTag, appVersion string) {
 	for _, t := range cTags {
 		if gitCommitSha == "" {
 			if sha, ok := strings.CutPrefix(t, gitCommitShaTagPrefix); ok {
@@ -32,11 +33,16 @@ func GetVersionDataFromContainerTags(cTags []string) (gitCommitSha, imageTag str
 				imageTag = image
 			}
 		}
-		if gitCommitSha != "" && imageTag != "" {
+		if appVersion == "" {
+			if v, ok := strings.CutPrefix(t, versionTagPrefix); ok {
+				appVersion = v
+			}
+		}
+		if gitCommitSha != "" && imageTag != "" && appVersion != "" {
 			break
 		}
 	}
-	return gitCommitSha, imageTag
+	return gitCommitSha, imageTag, appVersion
 }
 
 // GetGitCommitShaFromTrace returns the first "git_commit_sha" tag found in trace t.

--- a/pkg/trace/version/version_test.go
+++ b/pkg/trace/version/version_test.go
@@ -15,14 +15,32 @@ import (
 )
 
 func TestGetVersionDataFromContainerTags(t *testing.T) {
-	t.Run("ok", func(t *testing.T) {
-		cTags := []string{"some_tag:blah", "image_tag:x", "git.commit.sha:y"}
-		gitCommitSha, imageTag := GetVersionDataFromContainerTags(cTags)
+	t.Run("all fields present", func(t *testing.T) {
+		cTags := []string{"some_tag:blah", "image_tag:x", "git.commit.sha:y", "version:1.2.3"}
+		gitCommitSha, imageTag, appVersion := GetVersionDataFromContainerTags(cTags)
 		assert.Equal(t, "x", imageTag)
 		assert.Equal(t, "y", gitCommitSha)
-		gitCommitSha, imageTag = GetVersionDataFromContainerTags([]string{})
+		assert.Equal(t, "1.2.3", appVersion)
+	})
+	t.Run("empty tags", func(t *testing.T) {
+		gitCommitSha, imageTag, appVersion := GetVersionDataFromContainerTags([]string{})
 		assert.Equal(t, "", imageTag)
 		assert.Equal(t, "", gitCommitSha)
+		assert.Equal(t, "", appVersion)
+	})
+	t.Run("version tag only", func(t *testing.T) {
+		cTags := []string{"some_tag:blah", "version:2.0.0"}
+		gitCommitSha, imageTag, appVersion := GetVersionDataFromContainerTags(cTags)
+		assert.Equal(t, "", imageTag)
+		assert.Equal(t, "", gitCommitSha)
+		assert.Equal(t, "2.0.0", appVersion)
+	})
+	t.Run("no version tag", func(t *testing.T) {
+		cTags := []string{"image_tag:x", "git.commit.sha:y"}
+		gitCommitSha, imageTag, appVersion := GetVersionDataFromContainerTags(cTags)
+		assert.Equal(t, "x", imageTag)
+		assert.Equal(t, "y", gitCommitSha)
+		assert.Equal(t, "", appVersion)
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

Extract `version` from container tags when not populated by the tracer.

`GetVersionDataFromContainerTags` already extracted `git.commit.sha:` and `image_tag:` from container tags to enrich stats payloads, but ignored the `version:` tag that unified service tagging puts there. When the tracer doesn't set a version and the backend has to infer it by concatenating `imageTag + "_" + gitCommitSha`, customers whose image tags already embed the short SHA end up with duplicated suffixes (e.g. `106436641-0072d3a_0072d3a`).

This adds `version:` extraction to `GetVersionDataFromContainerTags` and uses it as a fallback in both the client-computed stats path (`ClientStatsAggregator.setVersionDataFromContainerTags`) and the agent-computed stats path (`processedTrace`/`processedTraceV1`), consistent with how the other two fields are handled.

### Motivation

Fixes version tag duplication reported in https://dd.slack.com/archives/C08C0CC8BNG/p1778079387571529 (tracked in APMSTS-1323).

### Describe how you validated your changes

Added unit tests in covering the new extraction, the fallback behavior, and that payload values still take precedence over container tags.

### Additional Notes