### PR TITLE
feat(config): register missing data_plane config keys

### DIFF
--- a/pkg/config/schema/core_schema.yaml
+++ b/pkg/config/schema/core_schema.yaml
@@ -12881,9 +12881,7 @@ properties:
         node_type: setting
         type: string
         default: tcp://0.0.0.0:5100
-        comment: |-
-          Listen addresses must use a URL scheme ("tcp://") so ADP's ListenAddress parser does not
-          misinterpret a bare "host:port" as a Unix socket path (see saluki-io ListenAddress::try_from).
+        comment: Listen addresses must include a URL scheme (e.g. "tcp://").
       dogstatsd:
         node_type: section
         type: object

--- a/pkg/config/schema/core_schema.yaml
+++ b/pkg/config/schema/core_schema.yaml
@@ -12877,6 +12877,13 @@ properties:
     node_type: section
     type: object
     properties:
+      api_listen_address:
+        node_type: setting
+        type: string
+        default: tcp://0.0.0.0:5100
+        comment: |-
+          Listen addresses must use a URL scheme ("tcp://") so ADP's ListenAddress parser does not
+          misinterpret a bare "host:port" as a Unix socket path (see saluki-io ListenAddress::try_from).
       dogstatsd:
         node_type: section
         type: object
@@ -12890,6 +12897,10 @@ properties:
         type: boolean
         default: false
         comment: Data Plane
+      log_file:
+        node_type: setting
+        type: string
+        default: /opt/datadog-agent/logs/agent-data-plane.log
       otlp:
         node_type: section
         type: object
@@ -12906,6 +12917,22 @@ properties:
                 node_type: setting
                 type: boolean
                 default: false
+              logs:
+                node_type: section
+                type: object
+                properties:
+                  enabled:
+                    node_type: setting
+                    type: boolean
+                    default: true
+              metrics:
+                node_type: section
+                type: object
+                properties:
+                  enabled:
+                    node_type: setting
+                    type: boolean
+                    default: true
               receiver:
                 node_type: section
                 type: object
@@ -12925,6 +12952,34 @@ properties:
                             comment: When the ADP OTLP proxy is enabled, ADP owns
                               the gRPC endpoint configured for the receiver (default
                               :4317) and the core agent uses the endpoint below
+              traces:
+                node_type: section
+                type: object
+                properties:
+                  enabled:
+                    node_type: setting
+                    type: boolean
+                    default: true
+      remote_agent_enabled:
+        node_type: setting
+        type: boolean
+        default: true
+      secure_api_listen_address:
+        node_type: setting
+        type: string
+        default: tcp://0.0.0.0:5101
+      telemetry_enabled:
+        node_type: setting
+        type: boolean
+        default: false
+      telemetry_listen_addr:
+        node_type: setting
+        type: string
+        default: tcp://0.0.0.0:5102
+      use_new_config_stream_endpoint:
+        node_type: setting
+        type: boolean
+        default: true
   data_streams:
     node_type: section
     type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1052,8 +1052,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("data_plane.enabled", false)
 	config.BindEnvAndSetDefault("data_plane.use_new_config_stream_endpoint", true)
 	config.BindEnvAndSetDefault("data_plane.remote_agent_enabled", true)
-	// Listen addresses must use a URL scheme ("tcp://") so ADP's ListenAddress parser does not
-	// misinterpret a bare "host:port" as a Unix socket path (see saluki-io ListenAddress::try_from).
+	// Listen addresses must include a URL scheme (e.g. "tcp://").
 	config.BindEnvAndSetDefault("data_plane.api_listen_address", "tcp://0.0.0.0:5100")
 	config.BindEnvAndSetDefault("data_plane.secure_api_listen_address", "tcp://0.0.0.0:5101")
 	config.BindEnvAndSetDefault("data_plane.telemetry_enabled", false)

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1050,9 +1050,21 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 
 	// Data Plane
 	config.BindEnvAndSetDefault("data_plane.enabled", false)
+	config.BindEnvAndSetDefault("data_plane.use_new_config_stream_endpoint", true)
+	config.BindEnvAndSetDefault("data_plane.remote_agent_enabled", true)
+	// Listen addresses must use a URL scheme ("tcp://") so ADP's ListenAddress parser does not
+	// misinterpret a bare "host:port" as a Unix socket path (see saluki-io ListenAddress::try_from).
+	config.BindEnvAndSetDefault("data_plane.api_listen_address", "tcp://0.0.0.0:5100")
+	config.BindEnvAndSetDefault("data_plane.secure_api_listen_address", "tcp://0.0.0.0:5101")
+	config.BindEnvAndSetDefault("data_plane.telemetry_enabled", false)
+	config.BindEnvAndSetDefault("data_plane.telemetry_listen_addr", "tcp://0.0.0.0:5102")
+	config.BindEnvAndSetDefault("data_plane.log_file", DefaultDataPlaneLogFile)
 	config.BindEnvAndSetDefault("data_plane.dogstatsd.enabled", true)
 	config.BindEnvAndSetDefault("data_plane.otlp.enabled", false)
 	config.BindEnvAndSetDefault("data_plane.otlp.proxy.enabled", false)
+	config.BindEnvAndSetDefault("data_plane.otlp.proxy.traces.enabled", true)
+	config.BindEnvAndSetDefault("data_plane.otlp.proxy.metrics.enabled", true)
+	config.BindEnvAndSetDefault("data_plane.otlp.proxy.logs.enabled", true)
 	// When the ADP OTLP proxy is enabled, ADP owns the gRPC endpoint configured for the receiver (default :4317) and the core agent uses the endpoint below
 	config.BindEnvAndSetDefault("data_plane.otlp.proxy.receiver.protocols.grpc.endpoint", "127.0.0.1:4319")
 

--- a/pkg/config/setup/config_darwin.go
+++ b/pkg/config/setup/config_darwin.go
@@ -26,6 +26,8 @@ const (
 	DefaultHostProfilerLogFile = "/opt/datadog-agent/logs/host-profiler.log"
 	// DefaultPrivateActionRunnerLogFile is the default private-action-runner log file
 	DefaultPrivateActionRunnerLogFile = "/opt/datadog-agent/logs/private-action-runner.log"
+	// DefaultDataPlaneLogFile is the default log file used by the data-plane agent if not configured
+	DefaultDataPlaneLogFile = "/opt/datadog-agent/logs/agent-data-plane.log"
 	// DefaultSystemProbeAddress is the default unix socket path to be used for connecting to the system probe
 	DefaultSystemProbeAddress     = "/opt/datadog-agent/run/sysprobe.sock"
 	defaultSystemProbeLogFilePath = "/opt/datadog-agent/logs/system-probe.log"

--- a/pkg/config/setup/config_nix.go
+++ b/pkg/config/setup/config_nix.go
@@ -50,6 +50,8 @@ const (
 	DefaultHostProfilerLogFile = "/var/log/datadog/host-profiler.log"
 	// DefaultPrivateActionRunnerLogFile is the default private-action-runner log file
 	DefaultPrivateActionRunnerLogFile = "/var/log/datadog/private-action-runner.log"
+	// DefaultDataPlaneLogFile is the default log file used by the data-plane agent if not configured
+	DefaultDataPlaneLogFile = "/var/log/datadog/agent-data-plane.log"
 	// defaultSystemProbeLogFilePath is the default system-probe log file
 	defaultSystemProbeLogFilePath = "/var/log/datadog/system-probe.log"
 	// defaultStatsdSocket is the default Unix Domain Socket path on which statsd will listen

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -876,6 +876,21 @@ data_plane:
 	})
 }
 
+func TestDataPlaneDefaults(t *testing.T) {
+	cfg := confFromYAML(t, "")
+
+	assert.True(t, cfg.GetBool("data_plane.use_new_config_stream_endpoint"))
+	assert.True(t, cfg.GetBool("data_plane.remote_agent_enabled"))
+	assert.Equal(t, "tcp://0.0.0.0:5100", cfg.GetString("data_plane.api_listen_address"))
+	assert.Equal(t, "tcp://0.0.0.0:5101", cfg.GetString("data_plane.secure_api_listen_address"))
+	assert.False(t, cfg.GetBool("data_plane.telemetry_enabled"))
+	assert.Equal(t, "tcp://0.0.0.0:5102", cfg.GetString("data_plane.telemetry_listen_addr"))
+	assert.Equal(t, DefaultDataPlaneLogFile, cfg.GetString("data_plane.log_file"))
+	assert.True(t, cfg.GetBool("data_plane.otlp.proxy.traces.enabled"))
+	assert.True(t, cfg.GetBool("data_plane.otlp.proxy.metrics.enabled"))
+	assert.True(t, cfg.GetBool("data_plane.otlp.proxy.logs.enabled"))
+}
+
 func TestUsePodmanLogsAndDockerPathOverride(t *testing.T) {
 	// If use_podman_logs is true and docker_path_override is set, the config should return an error
 	datadogYaml := `

--- a/pkg/config/setup/config_windows.go
+++ b/pkg/config/setup/config_windows.go
@@ -31,6 +31,8 @@ var (
 	DefaultHostProfilerLogFile = "C:\\ProgramData\\Datadog\\logs\\host-profiler.log"
 	// DefaultPrivateActionRunnerLogFile is the default private-action-runner log file
 	DefaultPrivateActionRunnerLogFile = "C:\\ProgramData\\Datadog\\logs\\private-action-runner.log"
+	// DefaultDataPlaneLogFile is the default log file used by the data-plane agent if not configured
+	DefaultDataPlaneLogFile = "C:\\ProgramData\\Datadog\\logs\\agent-data-plane.log"
 	// DefaultSystemProbeAddress is the default address to be used for connecting to the system probe
 	DefaultSystemProbeAddress = `\\.\pipe\dd_system_probe`
 	// defaultSystemProbeLogFilePath is the default system probe log file
@@ -61,6 +63,7 @@ func osinit() {
 		DefaultOTelAgentLogFile = filepath.Join(pd, "logs", "otel-agent.log")
 		DefaultHostProfilerLogFile = filepath.Join(pd, "logs", "host-profiler.log")
 		DefaultPrivateActionRunnerLogFile = filepath.Join(pd, "logs", "private-action-runner.log")
+		DefaultDataPlaneLogFile = filepath.Join(pd, "logs", "agent-data-plane.log")
 	}
 
 	// The install path is configurable on Windows, so fetch the path from the registry


### PR DESCRIPTION
## Summary

Several configuration keys that the Agent Data Plane reads under the `data_plane` namespace were absent from the Core Agent's `BindEnvAndSetDefault` registration and `core_schema.yaml`, causing environment variables like `DD_DATA_PLANE_TELEMETRY_ENABLED` to be silently ignored. This adds the missing registrations and regenerates the schema. Listen address defaults use explicit `"tcp://"` scheme prefixes, which is required by ADP's address parser.

Closes: https://github.com/DataDog/saluki/issues/1649

## Test plan

- [x] `dda inv test --targets=./pkg/config/setup` passes (311 tests, including new `TestDataPlaneDefaults`)
- [x] `dda inv test --targets=./pkg/config/schema` passes (6 tests)
- [ ] E2E `TestInstallScript/*/DogStatsD_port_bound_ADP_enabled` (run with `RUN_E2E_TESTS=on`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)