### PR TITLE
[Backport 7.80.x] Update docker util initialization to ping

### DIFF
--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -84,10 +84,11 @@ func ConnectToDocker(ctx context.Context) (*client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Looks like docker is not actually doing a call to server when `NewClient` is called
-	// Forcing it to verify server availability by calling Info()
-	_, err = cli.Info(ctx, client.InfoOptions{})
-	if err != nil {
+	// client.New does not actually contact the daemon. Force a round-trip
+	// to verify availability. safeInfo tolerates daemons that emit invalid
+	// CIDRs in /info's DefaultAddressPools, which would otherwise fail the
+	// strict netip.Prefix decoding introduced by the moby v29 client.
+	if _, err := cli.Ping(ctx, client.PingOptions{}); err != nil {
 		return nil, err
 	}
 

--- a/releasenotes/notes/docker-connect-use-ping-3495904de9c2c3e5.yaml
+++ b/releasenotes/notes/docker-connect-use-ping-3495904de9c2c3e5.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Use the Docker daemon's ``/ping`` endpoint instead of ``/info`` to verify
+    connectivity during ``DockerUtil`` initialization. Some daemons emit
+    ``DefaultAddressPools[].Base`` values in ``/info`` that are not valid CIDRs,
+    which fail the strict ``netip.Prefix`` decoding introduced by the moby v29
+    client and previously caused ``DockerUtil`` to fail to initialize. This
+    cascaded into the Docker workloadmeta collector and the Docker core check
+    being unavailable, leading to missing container/image tags on metrics and
+    traces from Docker containers.


### PR DESCRIPTION
Backport #51128 into `7.80.x`