### PR TITLE
Emit PDBs for Go binaries and ship them in .debug.zip

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -122,6 +122,7 @@ build do
   else
     copy 'bin/agent/ddtray.exe', "#{install_dir}/bin/agent"
     copy 'bin/agent/agent.exe', "#{install_dir}/bin/agent"
+    copy 'bin/agent/agent.exe.pdb', "#{install_dir}/bin/agent"
     copy 'bin/agent/dist', "#{install_dir}/bin/agent"
     mkdir "#{install_dir}/bin/scripts/"
     copy "#{project_dir}/omnibus/windows-scripts/iis-instrumentation.bat", "#{install_dir}/bin/scripts/"
@@ -139,6 +140,7 @@ build do
   elsif windows_target?
     command "dda inv -- -e installer.build #{fips_args} --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     move 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"
+    move 'bin/installer/installer.exe.pdb', "#{install_dir}/datadog-installer.exe.pdb"
   end
 
   if linux_target?
@@ -155,6 +157,7 @@ build do
 
   if windows_target?
     copy 'bin/trace-agent/trace-agent.exe', "#{install_dir}/bin/agent"
+    copy 'bin/trace-agent/trace-agent.exe.pdb', "#{install_dir}/bin/agent"
   else
     copy 'bin/trace-agent/trace-agent', "#{install_dir}/embedded/bin"
   end
@@ -166,6 +169,7 @@ build do
 
   if windows_target?
     copy 'bin/process-agent/process-agent.exe', "#{install_dir}/bin/agent"
+    copy 'bin/process-agent/process-agent.exe.pdb', "#{install_dir}/bin/agent"
   elsif not heroku_target?
     copy 'bin/process-agent/process-agent', "#{install_dir}/embedded/bin"
   end
@@ -176,6 +180,7 @@ build do
 
     if windows_target?
       copy 'bin/privateactionrunner/privateactionrunner.exe', "#{install_dir}/bin/agent"
+      copy 'bin/privateactionrunner/privateactionrunner.exe.pdb', "#{install_dir}/bin/agent"
     elsif not heroku_target?
       copy 'bin/privateactionrunner/privateactionrunner', "#{install_dir}/embedded/bin"
     end
@@ -192,6 +197,7 @@ build do
 
     if windows_target?
       copy 'bin/system-probe/system-probe.exe', "#{install_dir}/bin/agent"
+      copy 'bin/system-probe/system-probe.exe.pdb', "#{install_dir}/bin/agent"
     else
       copy "bin/system-probe/system-probe", "#{install_dir}/embedded/bin"
     end
@@ -243,6 +249,7 @@ build do
     command "dda inv -- -e security-agent.build #{fips_args} --install-path=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
     if windows_target?
       copy 'bin/security-agent/security-agent.exe', "#{install_dir}/bin/agent"
+      copy 'bin/security-agent/security-agent.exe.pdb', "#{install_dir}/bin/agent"
     else
       copy 'bin/security-agent/security-agent', "#{install_dir}/embedded/bin"
     end

--- a/omnibus/config/software/datadog-iot-agent.rb
+++ b/omnibus/config/software/datadog-iot-agent.rb
@@ -64,6 +64,7 @@ build do
 
       mkdir "#{Omnibus::Config.source_dir()}/datadog-iot-agent/src/github.com/DataDog/datadog-agent/bin/agent"
       copy 'bin/trace-agent/trace-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-iot-agent/src/github.com/DataDog/datadog-agent/bin/agent/trace-agent.exe"
+      copy 'bin/trace-agent/trace-agent.exe.pdb', "#{Omnibus::Config.source_dir()}/datadog-iot-agent/src/github.com/DataDog/datadog-agent/bin/agent/trace-agent.exe.pdb"
     end
   end
 end

--- a/omnibus/config/software/datadog-otel-agent.rb
+++ b/omnibus/config/software/datadog-otel-agent.rb
@@ -68,6 +68,7 @@ build do
     command "dda inv -- -e otel-agent.build --flavor #{flavor_arg}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
 
     copy File.join('bin', 'otel-agent', binary_name), embedded_bin_dir
+    copy File.join('bin', 'otel-agent', "#{binary_name}.pdb"), embedded_bin_dir if windows_target?
     move 'bin/otel-agent/dist/otel-config.yaml', File.join(conf_dir, 'otel-config.yaml.example')
 
     if fips_mode?

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -67,5 +67,6 @@ build do
   elsif windows_target?
     command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     copy 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"
+    copy 'bin/installer/installer.exe.pdb', "#{install_dir}/datadog-installer.exe.pdb"
   end
 end

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -195,6 +195,45 @@ module Omnibus
     expose :chmod_before_packaging
   end
 
+  # On Windows, the Go linker emits a companion .pdb next to each .exe so
+  # that Windows-native tools (cdb, WPA, xperf) can resolve Go symbols. The
+  # .pdb belongs in the same .debug.zip artifact as the existing .debug
+  # (full-symbols copy of each stripped binary), not in the main MSI/ZIP —
+  # PDBs are large and only useful for crash analysis.
+  #
+  # Hook into the strip lifecycle: before omnibus' Windows stripper zips up
+  # the .debug/ tree, walk every binary registered via
+  # `windows_symbol_stripping_file` and move its `.exe.pdb` companion into
+  # the same `.debug/` location the strip output goes (mirroring the
+  # absolute install_dir path, with the drive letter stripped — same layout
+  # the upstream stripper computes for the .debug files).
+  module StripperPDBRelocator
+    def strip_windows
+      relocate_pdb_companions
+      super
+    end
+
+    private
+
+    def relocate_pdb_companions
+      symboldir = File.join(project.install_dir, ".debug")
+      Array(project.windows_symbol_stripping_files).each do |executable|
+        source_exe = executable.strip
+        pdb = "#{source_exe}.pdb"
+        next unless File.exist?(pdb)
+
+        rel = pdb.dup
+        rel = rel[2..rel.length - 1] if rel[1] == ":"
+        target = File.join(symboldir, rel)
+
+        FileUtils.mkdir_p(File.dirname(target))
+        FileUtils.mv(pdb, target)
+      end
+    end
+  end
+
+  Stripper.prepend(StripperPDBRelocator)
+
   # Notarize and staple the .pkg after it is signed. Without this, Gatekeeper
   # rejects the .pkg when extracted from the .dmg (e.g. by Homebrew), because
   # the notarization ticket only covers the outer .dmg, not the .pkg inside it.
@@ -298,5 +337,6 @@ module Omnibus
       command *args, **kwargs, cwd: File.join(Omnibus::Config.project_root, "..")
     end
     expose :command_on_repo_root
+
   end
 end

--- a/tasks/libs/common/go.py
+++ b/tasks/libs/common/go.py
@@ -74,6 +74,29 @@ def download_go_dependencies(
                 future.result()  # Raises if module failed
 
 
+def _with_pdb_extldflag(ldflags: str, bin_path: str) -> str:
+    """
+    Insert ``-Wl,--pdb=<abs(bin_path)>.pdb`` into the linker's external-
+    linker flags so mingw ld emits a PDB next to the binary.
+
+    `tasks/libs/common/utils.py:get_build_flags` emits its accumulated
+    extldflags as a single-quoted whole arg ``'-extldflags=...'``. If
+    that group is present we splice our flag in just before the closing
+    quote, so the Go linker still sees one ``-extldflags=`` token (it
+    honors only the last one). Otherwise we append a fresh
+    ``'-extldflags=<our flag>'``.
+    """
+    pdb_flag = f"-Wl,--pdb={os.path.abspath(bin_path)}.pdb"
+    open_marker = "'-extldflags="
+    open_idx = ldflags.find(open_marker)
+    if open_idx != -1:
+        close_idx = ldflags.find("'", open_idx + len(open_marker))
+        if close_idx != -1:
+            return ldflags[:close_idx] + " " + pdb_flag + ldflags[close_idx:]
+    suffix = f" '-extldflags={pdb_flag}'"
+    return (ldflags + suffix) if ldflags else suffix.lstrip()
+
+
 def go_build(
     ctx: Context,
     entrypoint: str | Path,
@@ -91,6 +114,19 @@ def go_build(
     coverage: bool = False,
     trimpath: bool = True,
 ) -> Result:
+    # When targeting Windows with a known output path, ensure the parent
+    # directory exists and ask mingw ld to emit a PDB next to the binary
+    # so cdb/WPA/xperf can resolve Go symbols. ld writes the PDB during
+    # the link step — before `go build` copies the .exe to bin_path —
+    # which is why the pre-create is needed.
+    target_is_windows = (
+        sys.platform == "win32" or (env or {}).get("GOOS") == "windows" or os.getenv("GOOS") == "windows"
+    )
+    if bin_path and target_is_windows:
+        os.makedirs(os.path.dirname(os.path.abspath(str(bin_path))) or ".", exist_ok=True)
+        if os.environ.get("DD_GO_PDB", "1") != "0":
+            ldflags = _with_pdb_extldflag(ldflags or "", str(bin_path))
+
     cmd = "go build"
     if coverage:
         cmd += " -cover -covermode=atomic"

--- a/tasks/systray.py
+++ b/tasks/systray.py
@@ -49,7 +49,7 @@ def build(ctx, debug=False, console=False, rebuild=False, race=False, go_mod="re
     else:
         subsystem = 'windows'
     ldflags += f"-X {REPO_PATH}/cmd/systray/command/command.subsystem={subsystem} "
-    ldflags += f"-linkmode external -extldflags '-Wl,--subsystem,{subsystem}' "
+    ldflags += f"-linkmode external '-extldflags=-Wl,--subsystem,{subsystem}' "
     go_build(
         ctx,
         f"{REPO_PATH}/cmd/systray",

--- a/tasks/unit_tests/libs/common/go_tests.py
+++ b/tasks/unit_tests/libs/common/go_tests.py
@@ -1,10 +1,11 @@
+import os
 import sys
 import unittest
 from unittest.mock import MagicMock, call, patch
 
 from invoke import Result
 
-from tasks.libs.common.go import go_build
+from tasks.libs.common.go import _with_pdb_extldflag, go_build
 
 
 class TestGoBuild(unittest.TestCase):
@@ -95,3 +96,44 @@ class TestGoBuild(unittest.TestCase):
         self.assertEqual(result.exited, 1)
         mock_exists.assert_not_called()
         mock_chown.assert_not_called()
+
+
+class TestWithPDBExtldflag(unittest.TestCase):
+    """
+    The helper splices `-Wl,--pdb=...` into the existing
+    `'-extldflags=...'` group emitted by ``get_build_flags`` — Go's linker
+    honors only the last `-extldflags=`, so a clean append would silently
+    drop other flags in that group.
+    """
+
+    def test_no_existing_ldflags(self):
+        out = _with_pdb_extldflag("", "bin/agent/agent.exe")
+        self.assertTrue(out.startswith("'-extldflags="))
+        self.assertIn(os.path.abspath("bin/agent/agent.exe.pdb"), out)
+        self.assertEqual(out.count("-extldflags="), 1)
+
+    def test_existing_ldflags_no_extldflags(self):
+        out = _with_pdb_extldflag("-X main.foo=bar", "bin/agent/agent.exe")
+        self.assertIn("-X main.foo=bar", out)
+        self.assertEqual(out.count("-extldflags="), 1)
+        self.assertIn("-Wl,--pdb=", out)
+
+    def test_splices_into_single_quoted_extldflags(self):
+        ld = "-X main.foo=bar '-extldflags=-Wl,--version-script=foo.map -Wl,-z,lazy ' "
+        out = _with_pdb_extldflag(ld, "bin/agent/agent.exe")
+        # Must still have exactly one -extldflags= (Go honors the last).
+        self.assertEqual(out.count("-extldflags="), 1)
+        # Prior flags preserved inside the group.
+        self.assertIn("-Wl,--version-script=foo.map", out)
+        self.assertIn("-Wl,-z,lazy", out)
+        # Our flag inserted before the closing quote.
+        self.assertIn("-Wl,--pdb=", out)
+        # Closing quote still present after the splice.
+        self.assertIn("' ", out[out.index("-extldflags=") :])
+
+    def test_uses_absolute_path(self):
+        # Linker writes the PDB during link, before `go build` copies the
+        # .exe to its final location — an absolute path means we don't
+        # depend on the linker's CWD.
+        out = _with_pdb_extldflag("", "bin/agent/agent.exe")
+        self.assertIn(os.path.abspath("bin/agent/agent.exe.pdb"), out)


### PR DESCRIPTION
### What does this PR do?

Build asks mingw `ld` to emit a `.pdb` next to every Windows Go binary (`-Wl,--pdb=...` injected in `go_build`). Omnibus stages the `.pdb` files into the existing `.debug.zip` and keeps them out of MSI/ZIP/OCI.

### Motivation

cdb / WPA / xperf only read PDBs, not DWARF. Today Windows crash dumps and ETW traces show Go frames as `<module>+0xNNN`. After this, they resolve to `agent!main.run` etc. from the PDB shipped in `.debug.zip`.

### Describe how you validated your changes

Built every Windows Go binary locally; cdb resolves `<module>!main.main` from each `.pdb`. 4 new unit tests on the extldflags splice helper. 
full omnibus `.debug.zip` produced by CI includes `.pdb` files, output .zip and .msi do not.

### Additional Notes

Only works for cgo builds (external linking via gcc/ld). Pure-Go binaries don't run a host linker and won't get a PDB — `secret-generic-connector` non-FIPS is the only such binary in the agent today. Requires the mingw toolchain with `ld --pdb=` support.