### PR TITLE
add ebpf CO-RE internal telemetry

### DIFF
--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -469,9 +469,9 @@ func TestRun(t *testing.T) {
 
 	a.start()
 
-	// Default configuration has 5 jobs with different schedules:
+	// Default configuration has 6 jobs with different schedules:
 	fmt.Println(r.(*runnerMock).jobs)
-	assert.Equal(t, 5, len(r.(*runnerMock).jobs))
+	assert.Equal(t, 6, len(r.(*runnerMock).jobs))
 
 	// Verify we have the expected number of profiles across all jobs
 	totalProfiles := 0
@@ -479,8 +479,8 @@ func TestRun(t *testing.T) {
 		totalProfiles += len(job.profiles)
 	}
 	fmt.Println(totalProfiles)
-	// Default config has 16 profiles total (checks, logs-and-metrics, database, synthetics, connectivity, service-discovery, runtime-started, runtime-running, hostname, rtloader, otlp, procmgr, trace-agent, gpu, cluster-agent, injector)
-	assert.Equal(t, 16, totalProfiles)
+	// Default config has 17 profiles total (checks, logs-and-metrics, database, synthetics, connectivity, service-discovery, runtime-started, runtime-running, hostname, rtloader, otlp, procmgr, trace-agent, gpu, cluster-agent, injector, ebpf)
+	assert.Equal(t, 17, totalProfiles)
 }
 
 func TestReportMetricBasic(t *testing.T) {

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -397,3 +397,41 @@ profiles:
     start_after: 30
     iterations: 0
     period: 900
+- name: ebpf
+  metric:
+    exclude:
+      zero_metric: true
+    metrics:
+      - name: ebpf.core.load.success
+        preserve_tags:
+          - platform
+          - platform_version
+          - kernel
+          - arch
+          - asset
+          - btf_type
+      - name: ebpf.core.load.error
+        preserve_tags:
+          - platform
+          - platform_version
+          - kernel
+          - arch
+          - asset
+          - error_type
+      - name: ebpf.core.remote_config.success
+        preserve_tags:
+          - platform
+          - platform_version
+          - kernel
+          - arch
+      - name: ebpf.core.remote_config.error
+        preserve_tags:
+          - platform
+          - platform_version
+          - kernel
+          - arch
+          - error_type
+  schedule:
+    start_after: 300 # 5 minutes
+    iterations: 0
+    period: 900

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -402,7 +402,7 @@ profiles:
     exclude:
       zero_metric: true
     metrics:
-      - name: ebpf.core.load.success
+      - name: ebpf.core_load_success
         preserve_tags:
           - platform
           - platform_version
@@ -410,7 +410,7 @@ profiles:
           - arch
           - asset
           - btf_type
-      - name: ebpf.core.load.error
+      - name: ebpf.core_load_error
         preserve_tags:
           - platform
           - platform_version
@@ -418,13 +418,13 @@ profiles:
           - arch
           - asset
           - error_type
-      - name: ebpf.core.remote_config.success
+      - name: ebpf.core_remoteconfig_success
         preserve_tags:
           - platform
           - platform_version
           - kernel
           - arch
-      - name: ebpf.core.remote_config.error
+      - name: ebpf.core_remoteconfig_error
         preserve_tags:
           - platform
           - platform_version
@@ -433,5 +433,5 @@ profiles:
           - error_type
   schedule:
     start_after: 300 # 5 minutes
-    iterations: 0
+    iterations: 1
     period: 900

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -203,10 +203,10 @@ func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetry
 		"injector__pe_injection_context_cleanedup",
 
 		// eBPF metrics
-		"ebpf__core__load__success",
-		"ebpf__core__load__error",
-		"ebpf__core__remote_config__success",
-		"ebpf__core__remote_config__error",
+		"ebpf__core_load_success",
+		"ebpf__core_load_error",
+		"ebpf__core_remoteconfig_success",
+		"ebpf__core_remoteconfig_error",
 	))
 	if err != nil {
 		return nil, err

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -201,6 +201,12 @@ func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetry
 		"injector__pe_memory_allocation_failures",
 		"injector__pe_injection_context_allocated",
 		"injector__pe_injection_context_cleanedup",
+
+		// eBPF metrics
+		"ebpf__core__load__success",
+		"ebpf__core__load__error",
+		"ebpf__core__remote_config__success",
+		"ebpf__core__remote_config__error",
 	))
 	if err != nil {
 		return nil, err

--- a/pkg/ebpf/BUILD.bazel
+++ b/pkg/ebpf/BUILD.bazel
@@ -173,6 +173,8 @@ go_library(
     srcs = [
         "btf.go",
         "co_re.go",
+        "co_re_load.go",
+        "co_re_load_testutil.go",
         "co_re_telemetry.go",
         "co_re_unsupported.go",
         "common.go",
@@ -205,6 +207,7 @@ go_library(
     deps = [
         "//comp/core/telemetry/def",
         "//comp/core/telemetry/impl",
+        "//comp/core/telemetry/impl/noops",
         "//comp/remote-config/rcclient/def",
         "//pkg/config/setup",
         "//pkg/config/utils",
@@ -281,6 +284,7 @@ go_test(
     tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
+        "//comp/core/telemetry/impl/noops",
         "//pkg/config/remote/data",
         "//pkg/ebpf/bytecode",
         "//pkg/ebpf/ebpftest",  # keep

--- a/pkg/ebpf/btf.go
+++ b/pkg/ebpf/btf.go
@@ -154,14 +154,8 @@ func platformTag(platform btfPlatform) string {
 func initBTFLoader(cfg *Config, rcclient rcclient.Component, telemetrycomp telemetry.Component) (*orderedBTFLoader, error) {
 	var err error
 	platform, _ := getBTFPlatform()
-	platformVersion, err := kernel.PlatformVersion()
-	if err != nil {
-		return nil, err
-	}
-	kernelVersion, err := kernel.Release()
-	if err != nil {
-		return nil, err
-	}
+	platformVersion, _ := kernel.PlatformVersion()
+	kernelVersion, _ := kernel.Release()
 	arch, err := kernel.Machine()
 	if err != nil {
 		return nil, err
@@ -319,9 +313,9 @@ func (b *orderedBTFLoader) checkforBTF(extractDir string) (*returnBTF, error) {
 }
 
 func (b *orderedBTFLoader) loadEmbedded(_ context.Context) (*returnBTF, error) {
-	if b.platform == "" {
+	if b.platform == "" || b.platformVersion == "" || b.kernelVersion == "" {
 		plat, _ := kernel.Platform()
-		log.Warnf("unsupported BTF platform: %s", plat)
+		log.Warnf("unsupported BTF platform/version/release: %s/%s/%s", plat, b.platformVersion, b.kernelVersion)
 		return nil, nil
 	}
 

--- a/pkg/ebpf/btf.go
+++ b/pkg/ebpf/btf.go
@@ -181,8 +181,8 @@ func initBTFLoader(cfg *Config, rcclient rcclient.Component, telemetrycomp telem
 			rcSuccess telemetry.Counter
 			rcErrors  telemetry.Counter
 		}{
-			rcSuccess: telemetrycomp.NewCounter("ebpf__core__remoteconfig", "success", []string{"platform", "platform_version", "kernel", "arch"}, "count of CO-RE remote config BTF successes"),
-			rcErrors:  telemetrycomp.NewCounter("ebpf__core__remoteconfig", "error", []string{"platform", "platform_version", "kernel", "arch", "error_type"}, "count of CO-RE remote config BTF errors"),
+			rcSuccess: telemetrycomp.NewCounter("ebpf", "core_remoteconfig_success", []string{"platform", "platform_version", "kernel", "arch"}, "count of CO-RE remote config BTF successes"),
+			rcErrors:  telemetrycomp.NewCounter("ebpf", "core_remoteconfig_error", []string{"platform", "platform_version", "kernel", "arch", "error_type"}, "count of CO-RE remote config BTF errors"),
 		},
 	}
 	btfLoader.loadFunc = funcs.CacheWithCallback[returnBTF](btfLoader.get, loadKernelSpec.Flush)

--- a/pkg/ebpf/btf.go
+++ b/pkg/ebpf/btf.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cilium/ebpf/btf"
 
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
 	"github.com/DataDog/datadog-agent/pkg/util/archive"
 	"github.com/DataDog/datadog-agent/pkg/util/funcs"
@@ -130,9 +131,37 @@ type orderedBTFLoader struct {
 	rcclient       rcclient.Component
 	rcTimeout      time.Duration
 	rcDownloadHost string
+
+	platform        btfPlatform
+	platformVersion string
+	kernelVersion   string
+	arch            string
+	fixedtags       []string
+	telemetry       struct {
+		rcSuccess telemetry.Counter
+		rcErrors  telemetry.Counter
+	}
 }
 
-func initBTFLoader(cfg *Config, rcclient rcclient.Component) *orderedBTFLoader {
+func initBTFLoader(cfg *Config, rcclient rcclient.Component, telemetrycomp telemetry.Component) (*orderedBTFLoader, error) {
+	var err error
+	platform, err := getBTFPlatform()
+	if err != nil {
+		return nil, err
+	}
+	platformVersion, err := kernel.PlatformVersion()
+	if err != nil {
+		return nil, err
+	}
+	kernelVersion, err := kernel.Release()
+	if err != nil {
+		return nil, err
+	}
+	arch, err := kernel.Machine()
+	if err != nil {
+		return nil, err
+	}
+
 	btfLoader := &orderedBTFLoader{
 		userBTFPath:    cfg.BTFPath,
 		embeddedDir:    filepath.Join(cfg.BPFDir, "co-re", "btf"),
@@ -142,10 +171,23 @@ func initBTFLoader(cfg *Config, rcclient rcclient.Component) *orderedBTFLoader {
 		rcclient:       rcclient,
 		rcTimeout:      cfg.RemoteConfigBTFTimeout,
 		rcDownloadHost: cfg.RemoteConfigBTFDownloadHost,
+
+		platform:        platform,
+		platformVersion: platformVersion,
+		kernelVersion:   kernelVersion,
+		arch:            arch,
+		fixedtags:       []string{platform.String(), platformVersion, kernelVersion, arch},
+		telemetry: struct {
+			rcSuccess telemetry.Counter
+			rcErrors  telemetry.Counter
+		}{
+			rcSuccess: telemetrycomp.NewCounter("ebpf__core__remoteconfig", "success", []string{"platform", "platform_version", "kernel", "arch"}, "count of CO-RE remote config BTF successes"),
+			rcErrors:  telemetrycomp.NewCounter("ebpf__core__remoteconfig", "error", []string{"platform", "platform_version", "kernel", "arch", "error_type"}, "count of CO-RE remote config BTF errors"),
+		},
 	}
 	btfLoader.loadFunc = funcs.CacheWithCallback[returnBTF](btfLoader.get, loadKernelSpec.Flush)
 	btfLoader.delayedFlusher = time.AfterFunc(btfFlushDelay, btfLoader.Flush)
-	return btfLoader
+	return btfLoader, nil
 }
 
 type btfLoaderFunc func(context.Context) (*returnBTF, error)

--- a/pkg/ebpf/btf.go
+++ b/pkg/ebpf/btf.go
@@ -143,12 +143,17 @@ type orderedBTFLoader struct {
 	}
 }
 
+func platformTag(platform btfPlatform) string {
+	tagPlatform := platform.String()
+	if tagPlatform == "" {
+		tagPlatform, _ = kernel.Platform()
+	}
+	return tagPlatform
+}
+
 func initBTFLoader(cfg *Config, rcclient rcclient.Component, telemetrycomp telemetry.Component) (*orderedBTFLoader, error) {
 	var err error
-	platform, err := getBTFPlatform()
-	if err != nil {
-		return nil, err
-	}
+	platform, _ := getBTFPlatform()
 	platformVersion, err := kernel.PlatformVersion()
 	if err != nil {
 		return nil, err
@@ -176,7 +181,7 @@ func initBTFLoader(cfg *Config, rcclient rcclient.Component, telemetrycomp telem
 		platformVersion: platformVersion,
 		kernelVersion:   kernelVersion,
 		arch:            arch,
-		fixedtags:       []string{platform.String(), platformVersion, kernelVersion, arch},
+		fixedtags:       []string{platformTag(platform), platformVersion, kernelVersion, arch},
 		telemetry: struct {
 			rcSuccess telemetry.Counter
 			rcErrors  telemetry.Counter
@@ -314,18 +319,20 @@ func (b *orderedBTFLoader) checkforBTF(extractDir string) (*returnBTF, error) {
 }
 
 func (b *orderedBTFLoader) loadEmbedded(_ context.Context) (*returnBTF, error) {
+	if b.platform == "" {
+		plat, _ := kernel.Platform()
+		log.Warnf("unsupported BTF platform: %s", plat)
+		return nil, nil
+	}
+
 	btfRelativeEmbeddedFilename, err := b.embeddedPath()
 	if err != nil {
 		return nil, err
 	}
-	kernelVersion, err := kernel.Release()
-	if err != nil {
-		return nil, fmt.Errorf("kernel release: %s", err)
-	}
 	// <relative_path_in_tarball>/<kernel_version>
-	extractDir := filepath.Join(filepath.Dir(btfRelativeEmbeddedFilename), kernelVersion)
+	extractDir := filepath.Join(filepath.Dir(btfRelativeEmbeddedFilename), b.kernelVersion)
 	absExtractDir := filepath.Join(b.btfOutputDir, extractDir)
-	absExtractFile := filepath.Join(absExtractDir, kernelVersion+".btf")
+	absExtractFile := filepath.Join(absExtractDir, b.kernelVersion+".btf")
 
 	// If we've previously extracted the BTF file in question, we can just load it
 	ret, err := b.checkforBTF(extractDir)
@@ -367,19 +374,7 @@ func (b *orderedBTFLoader) loadEmbedded(_ context.Context) (*returnBTF, error) {
 }
 
 func (b *orderedBTFLoader) embeddedPath() (string, error) {
-	platform, err := getBTFPlatform()
-	if err != nil {
-		return "", fmt.Errorf("BTF platform: %s", err)
-	}
-	platformVersion, err := kernel.PlatformVersion()
-	if err != nil {
-		return "", fmt.Errorf("platform version: %s", err)
-	}
-	kernelVersion, err := kernel.Release()
-	if err != nil {
-		return "", fmt.Errorf("kernel release: %s", err)
-	}
-	return b.getEmbeddedBTF(platform, platformVersion, kernelVersion)
+	return b.getEmbeddedBTF(b.platform, b.platformVersion, b.kernelVersion)
 }
 
 var kernelVersionPatterns = []struct {

--- a/pkg/ebpf/btf_test.go
+++ b/pkg/ebpf/btf_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
 )
 
 func TestEmbeddedBTFMatch(t *testing.T) {
@@ -30,7 +32,8 @@ func TestEmbeddedBTFMatch(t *testing.T) {
 
 	for subset, ext := range subsets {
 		t.Run(subset, func(t *testing.T) {
-			loader := initBTFLoader(&Config{}, nil)
+			loader, err := initBTFLoader(&Config{}, nil, telemetryimpl.GetCompatComponent())
+			require.NoError(t, err)
 			loader.embeddedDir = filepath.Join(cd, "testdata", subset)
 
 			tests := []struct {
@@ -68,7 +71,8 @@ func TestEmbeddedBTFMatch(t *testing.T) {
 }
 
 func TestBTFTelemetry(t *testing.T) {
-	loader := initBTFLoader(NewConfig(), nil)
+	loader, err := initBTFLoader(&Config{}, nil, telemetryimpl.GetCompatComponent())
+	require.NoError(t, err)
 	ret, result, err := loader.Get()
 	require.NoError(t, err)
 	require.NotNil(t, ret)

--- a/pkg/ebpf/btf_test.go
+++ b/pkg/ebpf/btf_test.go
@@ -71,12 +71,12 @@ func TestEmbeddedBTFMatch(t *testing.T) {
 }
 
 func TestBTFTelemetry(t *testing.T) {
-	loader, err := initBTFLoader(&Config{}, nil, telemetryimpl.GetCompatComponent())
+	loader, err := initBTFLoader(NewConfig(), nil, telemetryimpl.GetCompatComponent())
 	require.NoError(t, err)
 	ret, result, err := loader.Get()
-	require.NoError(t, err)
-	require.NotNil(t, ret)
-	require.NotEqual(t, COREResult(BtfNotFound), result)
+	assert.NoError(t, err)
+	assert.NotNil(t, ret)
+	assert.NotEqual(t, COREResult(BtfNotFound), result)
 }
 
 func curDir() (string, error) {

--- a/pkg/ebpf/co_re.go
+++ b/pkg/ebpf/co_re.go
@@ -76,7 +76,7 @@ func (c *coreAssetLoader) reportTelemetry(assetName string, result COREResult) {
 	StoreCORETelemetryForAsset(assetName, result)
 
 	// capacity should match number of tags
-	tags := make([]string, 0, len(c.fixedtags)+2)
+	tags := make([]string, len(c.fixedtags), len(c.fixedtags)+2)
 	copy(tags, c.fixedtags)
 	tags = append(tags, assetName)
 	switch BTFResult(result) {

--- a/pkg/ebpf/co_re.go
+++ b/pkg/ebpf/co_re.go
@@ -18,39 +18,16 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 type coreAssetLoader struct {
 	coreDir   string
 	btfLoader *orderedBTFLoader
+	fixedtags []string
 	telemetry struct {
 		success telemetry.Counter
 		error   telemetry.Counter
 	}
-}
-
-// LoadCOREAsset attempts to find kernel BTF, reads the CO-RE object file, and then calls the callback function with the
-// asset and BTF options pre-filled. You should attempt to load the CO-RE program in the startFn func for telemetry to
-// be correctly recorded.
-func LoadCOREAsset(filename string, startFn func(bytecode.AssetReader, manager.Options) error) error {
-	loader, err := coreLoader(NewConfig(), nil)
-	if err != nil {
-		return err
-	}
-	return loader.loadCOREAsset(filename, startFn)
-}
-
-// GetBTFLoaderInfo Returns where the ebpf BTF files were sourced from
-func GetBTFLoaderInfo() (string, error) {
-	loader, err := coreLoader(NewConfig(), nil)
-	if err != nil {
-		return "", err
-	}
-
-	metadataStr := loader.btfLoader.resultMetadata.String()
-	infoStr := fmt.Sprintf("btfLoader result: %d\n%s", loader.btfLoader.result, metadataStr)
-	return infoStr, nil
 }
 
 func (c *coreAssetLoader) loadCOREAsset(filename string, startFn func(bytecode.AssetReader, manager.Options) error) error {
@@ -98,27 +75,10 @@ func (c *coreAssetLoader) loadCOREAsset(filename string, startFn func(bytecode.A
 func (c *coreAssetLoader) reportTelemetry(assetName string, result COREResult) {
 	StoreCORETelemetryForAsset(assetName, result)
 
-	var err error
-	platform, err := getBTFPlatform()
-	if err != nil {
-		return
-	}
-	platformVersion, err := kernel.PlatformVersion()
-	if err != nil {
-		return
-	}
-	kernelVersion, err := kernel.Release()
-	if err != nil {
-		return
-	}
-	arch, err := kernel.Machine()
-	if err != nil {
-		return
-	}
-
 	// capacity should match number of tags
-	tags := make([]string, 0, 6)
-	tags = append(tags, platform.String(), platformVersion, kernelVersion, arch, assetName)
+	tags := make([]string, 0, len(c.fixedtags)+2)
+	copy(tags, c.fixedtags)
+	tags = append(tags, assetName)
 	switch BTFResult(result) {
 	case SuccessCustomBTF:
 		tags = append(tags, "custom")

--- a/pkg/ebpf/co_re.go
+++ b/pkg/ebpf/co_re.go
@@ -23,7 +23,6 @@ import (
 type coreAssetLoader struct {
 	coreDir   string
 	btfLoader *orderedBTFLoader
-	fixedtags []string
 	telemetry struct {
 		success telemetry.Counter
 		error   telemetry.Counter
@@ -76,8 +75,8 @@ func (c *coreAssetLoader) reportTelemetry(assetName string, result COREResult) {
 	StoreCORETelemetryForAsset(assetName, result)
 
 	// capacity should match number of tags
-	tags := make([]string, len(c.fixedtags), len(c.fixedtags)+2)
-	copy(tags, c.fixedtags)
+	tags := make([]string, len(c.btfLoader.fixedtags), len(c.btfLoader.fixedtags)+2)
+	copy(tags, c.btfLoader.fixedtags)
 	tags = append(tags, assetName)
 	switch BTFResult(result) {
 	case SuccessCustomBTF:

--- a/pkg/ebpf/co_re_load.go
+++ b/pkg/ebpf/co_re_load.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux_bpf && !test
+
+package ebpf
+
+import (
+	"errors"
+	"fmt"
+
+	manager "github.com/DataDog/ebpf-manager"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
+)
+
+// LoadCOREAsset attempts to find kernel BTF, reads the CO-RE object file, and then calls the callback function with the
+// asset and BTF options pre-filled. You should attempt to load the CO-RE program in the startFn func for telemetry to
+// be correctly recorded.
+func LoadCOREAsset(filename string, startFn func(bytecode.AssetReader, manager.Options) error) error {
+	loader := getCORELoader()
+	if loader == nil {
+		return errors.New("CO-RE loader not setup")
+	}
+	return loader.loadCOREAsset(filename, startFn)
+}
+
+// GetBTFLoaderInfo Returns where the ebpf BTF files were sourced from
+func GetBTFLoaderInfo() (string, error) {
+	loader := getCORELoader()
+	if loader == nil {
+		return "", errors.New("CO-RE loader not setup")
+	}
+
+	metadataStr := loader.btfLoader.resultMetadata.String()
+	infoStr := fmt.Sprintf("btfLoader result: %d\n%s", loader.btfLoader.result, metadataStr)
+	return infoStr, nil
+}

--- a/pkg/ebpf/co_re_load_testutil.go
+++ b/pkg/ebpf/co_re_load_testutil.go
@@ -31,7 +31,7 @@ func LoadCOREAsset(filename string, startFn func(bytecode.AssetReader, manager.O
 func GetBTFLoaderInfo() (string, error) {
 	loader, err := coreLoader(NewConfig(), nil, telemetryimpl.GetCompatComponent())
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	metadataStr := loader.btfLoader.resultMetadata.String()

--- a/pkg/ebpf/co_re_load_testutil.go
+++ b/pkg/ebpf/co_re_load_testutil.go
@@ -19,6 +19,7 @@ import (
 // LoadCOREAsset attempts to find kernel BTF, reads the CO-RE object file, and then calls the callback function with the
 // asset and BTF options pre-filled. You should attempt to load the CO-RE program in the startFn func for telemetry to
 // be correctly recorded.
+// This test version will not use remote config and has a no-op telemetry component.
 func LoadCOREAsset(filename string, startFn func(bytecode.AssetReader, manager.Options) error) error {
 	loader, err := coreLoader(NewConfig(), nil, telemetryimpl.GetCompatComponent())
 	if err != nil {

--- a/pkg/ebpf/co_re_load_testutil.go
+++ b/pkg/ebpf/co_re_load_testutil.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf && test
+
+package ebpf
+
+import (
+	"fmt"
+
+	manager "github.com/DataDog/ebpf-manager"
+
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
+)
+
+// LoadCOREAsset attempts to find kernel BTF, reads the CO-RE object file, and then calls the callback function with the
+// asset and BTF options pre-filled. You should attempt to load the CO-RE program in the startFn func for telemetry to
+// be correctly recorded.
+func LoadCOREAsset(filename string, startFn func(bytecode.AssetReader, manager.Options) error) error {
+	loader, err := coreLoader(NewConfig(), nil, telemetryimpl.GetCompatComponent())
+	if err != nil {
+		return err
+	}
+	return loader.loadCOREAsset(filename, startFn)
+}
+
+// GetBTFLoaderInfo Returns where the ebpf BTF files were sourced from
+func GetBTFLoaderInfo() (string, error) {
+	loader, err := coreLoader(NewConfig(), nil, telemetryimpl.GetCompatComponent())
+	if err != nil {
+		return err
+	}
+
+	metadataStr := loader.btfLoader.resultMetadata.String()
+	infoStr := fmt.Sprintf("btfLoader result: %d\n%s", loader.btfLoader.result, metadataStr)
+	return infoStr, nil
+}

--- a/pkg/ebpf/ebpf.go
+++ b/pkg/ebpf/ebpf.go
@@ -56,7 +56,6 @@ func coreLoader(cfg *Config, rcclient rcclient.Component, telemetrycomp telemetr
 	core.loader = &coreAssetLoader{
 		coreDir:   filepath.Join(cfg.BPFDir, "co-re"),
 		btfLoader: btfLoader,
-		fixedtags: []string{platformTag(btfLoader.platform), btfLoader.platformVersion, btfLoader.kernelVersion, btfLoader.arch},
 		telemetry: struct {
 			success telemetry.Counter
 			error   telemetry.Counter

--- a/pkg/ebpf/ebpf.go
+++ b/pkg/ebpf/ebpf.go
@@ -61,8 +61,8 @@ func coreLoader(cfg *Config, rcclient rcclient.Component, telemetrycomp telemetr
 			success telemetry.Counter
 			error   telemetry.Counter
 		}{
-			success: telemetrycomp.NewCounter("ebpf__core__load", "success", []string{"platform", "platform_version", "kernel", "arch", "asset", "btf_type"}, "count of CO-RE load successes"),
-			error:   telemetrycomp.NewCounter("ebpf__core__load", "error", []string{"platform", "platform_version", "kernel", "arch", "asset", "error_type"}, "count of CO-RE load errors"),
+			success: telemetrycomp.NewCounter("ebpf", "core_load_success", []string{"platform", "platform_version", "kernel", "arch", "asset", "btf_type"}, "count of CO-RE load successes"),
+			error:   telemetrycomp.NewCounter("ebpf", "core_load_error", []string{"platform", "platform_version", "kernel", "arch", "asset", "error_type"}, "count of CO-RE load errors"),
 		},
 	}
 	return core.loader, nil

--- a/pkg/ebpf/ebpf.go
+++ b/pkg/ebpf/ebpf.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
-	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
 )
 
@@ -26,15 +25,19 @@ var core struct {
 
 // Setup initializes CO-RE and BTF loaders with the provided config.
 // [Reset] must be called first if you want a different config to take effect
-func Setup(cfg *Config, rcclient rcclient.Component) error {
-	_, err := coreLoader(cfg, rcclient)
+func Setup(cfg *Config, rcclient rcclient.Component, telemetry telemetry.Component) error {
+	_, err := coreLoader(cfg, rcclient, telemetry)
 	return err
 }
 
-func coreLoader(cfg *Config, rcclient rcclient.Component) (*coreAssetLoader, error) {
+func getCORELoader() *coreAssetLoader {
 	core.RLock()
-	loader := core.loader
-	core.RUnlock()
+	defer core.RUnlock()
+	return core.loader
+}
+
+func coreLoader(cfg *Config, rcclient rcclient.Component, telemetrycomp telemetry.Component) (*coreAssetLoader, error) {
+	loader := getCORELoader()
 	if loader != nil {
 		return loader, nil
 	}
@@ -44,15 +47,22 @@ func coreLoader(cfg *Config, rcclient rcclient.Component) (*coreAssetLoader, err
 	if err := rlimit.RemoveMemlock(); err != nil {
 		return nil, fmt.Errorf("rlimit memlock: %w", err)
 	}
+
+	btfLoader, err := initBTFLoader(cfg, rcclient, telemetrycomp)
+	if err != nil {
+		return nil, err
+	}
+
 	core.loader = &coreAssetLoader{
 		coreDir:   filepath.Join(cfg.BPFDir, "co-re"),
-		btfLoader: initBTFLoader(cfg, rcclient),
+		btfLoader: btfLoader,
+		fixedtags: []string{btfLoader.platform.String(), btfLoader.platformVersion, btfLoader.kernelVersion, btfLoader.arch},
 		telemetry: struct {
 			success telemetry.Counter
 			error   telemetry.Counter
 		}{
-			success: telemetryimpl.GetCompatComponent().NewCounter("ebpf__core__load", "success", []string{"platform", "platform_version", "kernel", "arch", "asset", "btf_type"}, "count of CO-RE load successes"),
-			error:   telemetryimpl.GetCompatComponent().NewCounter("ebpf__core__load", "error", []string{"platform", "platform_version", "kernel", "arch", "asset", "error_type"}, "count of CO-RE load errors"),
+			success: telemetrycomp.NewCounter("ebpf__core__load", "success", []string{"platform", "platform_version", "kernel", "arch", "asset", "btf_type"}, "count of CO-RE load successes"),
+			error:   telemetrycomp.NewCounter("ebpf__core__load", "error", []string{"platform", "platform_version", "kernel", "arch", "asset", "error_type"}, "count of CO-RE load errors"),
 		},
 	}
 	return core.loader, nil

--- a/pkg/ebpf/ebpf.go
+++ b/pkg/ebpf/ebpf.go
@@ -56,7 +56,7 @@ func coreLoader(cfg *Config, rcclient rcclient.Component, telemetrycomp telemetr
 	core.loader = &coreAssetLoader{
 		coreDir:   filepath.Join(cfg.BPFDir, "co-re"),
 		btfLoader: btfLoader,
-		fixedtags: []string{btfLoader.platform.String(), btfLoader.platformVersion, btfLoader.kernelVersion, btfLoader.arch},
+		fixedtags: []string{platformTag(btfLoader.platform), btfLoader.platformVersion, btfLoader.kernelVersion, btfLoader.arch},
 		telemetry: struct {
 			success telemetry.Counter
 			error   telemetry.Counter

--- a/pkg/ebpf/rc_btf.go
+++ b/pkg/ebpf/rc_btf.go
@@ -83,9 +83,9 @@ func (b *orderedBTFLoader) loadRemoteConfig(ctx context.Context) (*returnBTF, er
 		log.Warnf("unsupported BTF architecture: %s", runtime.GOARCH)
 		return nil, nil
 	}
-	if b.platform == "" {
+	if b.platform == "" || b.platformVersion == "" || b.kernelVersion == "" {
 		plat, _ := kernel.Platform()
-		log.Warnf("unsupported BTF platform: %s", plat)
+		log.Warnf("unsupported BTF platform/version/release: %s/%s/%s", plat, b.platformVersion, b.kernelVersion)
 		return nil, nil
 	}
 

--- a/pkg/ebpf/rc_btf.go
+++ b/pkg/ebpf/rc_btf.go
@@ -130,6 +130,8 @@ func (b *orderedBTFLoader) loadRemoteConfig(ctx context.Context) (*returnBTF, er
 				errorTags = append(errorTags, "timeout")
 			} else if errors.Is(err, errBTFNotInCatalog) {
 				errorTags = append(errorTags, "not_in_catalog")
+			} else if errors.Is(err, errBTFCatalogUnmarshal) {
+				errorTags = append(errorTags, "catalog_unmarshal")
 			} else if errors.Is(err, errBTFHashMismatch) {
 				errorTags = append(errorTags, "hash_mismatch")
 			} else if errors.Is(err, errBTFDownload) {

--- a/pkg/ebpf/rc_btf.go
+++ b/pkg/ebpf/rc_btf.go
@@ -208,7 +208,7 @@ func (r *rcBTFLoader) processEntry(entry *btfEntry) (*returnBTF, error) {
 	btfURL := fmt.Sprintf("%s/btfs/%s/%s/%s/%s.btf.tar.xz", r.b.rcDownloadHost, r.platform, r.platformVersion, r.arch, r.kernelVersion)
 	btfTarballBuffer, err := r.downloadFile(btfURL, entry.SHA256)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", errBTFDownload, err)
+		return nil, fmt.Errorf("%w: %w", errBTFDownload, err)
 	}
 
 	// extract in-memory tarball to regular BTF output directory

--- a/pkg/ebpf/rc_btf.go
+++ b/pkg/ebpf/rc_btf.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/util/archive"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -80,6 +81,11 @@ func (b *orderedBTFLoader) loadRemoteConfig(ctx context.Context) (*returnBTF, er
 	arch := rcArchitecture()
 	if arch == "" {
 		log.Warnf("unsupported BTF architecture: %s", runtime.GOARCH)
+		return nil, nil
+	}
+	if b.platform == "" {
+		plat, _ := kernel.Platform()
+		log.Warnf("unsupported BTF platform: %s", plat)
 		return nil, nil
 	}
 

--- a/pkg/ebpf/rc_btf.go
+++ b/pkg/ebpf/rc_btf.go
@@ -114,7 +114,7 @@ func (b *orderedBTFLoader) loadRemoteConfig(ctx context.Context) (*returnBTF, er
 	// ensure we get the correct error (if any) from the context
 	err := ctx.Err()
 	if rbtf == nil {
-		errorTags := make([]string, 0, len(b.fixedtags)+1)
+		errorTags := make([]string, len(b.fixedtags), len(b.fixedtags)+1)
 		copy(errorTags, b.fixedtags)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {

--- a/pkg/ebpf/rc_btf.go
+++ b/pkg/ebpf/rc_btf.go
@@ -23,8 +23,16 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/util/archive"
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	errBTFCatalogUnmarshal = errors.New("unmarshal BTF catalog")
+	errBTFNotInCatalog     = errors.New("BTF not in catalog")
+	errBTFDownload         = errors.New("BTF download")
+	errBTFExtract          = errors.New("extract kernel BTF from tarball")
+	errBTFHashMismatch     = errors.New("BTF hash mismatch")
+	errBTFLoad             = errors.New("BTF load")
 )
 
 type btfCatalog struct {
@@ -75,19 +83,6 @@ func (b *orderedBTFLoader) loadRemoteConfig(ctx context.Context) (*returnBTF, er
 		return nil, nil
 	}
 
-	platform, err := getBTFPlatform()
-	if err != nil {
-		return nil, fmt.Errorf("BTF platform: %s", err)
-	}
-	platformVersion, err := kernel.PlatformVersion()
-	if err != nil {
-		return nil, fmt.Errorf("platform version: %s", err)
-	}
-	kernelVersion, err := kernel.Release()
-	if err != nil {
-		return nil, fmt.Errorf("kernel release: %s", err)
-	}
-
 	ctx, cancelCause := context.WithCancelCause(ctx)
 	ctx, cancel := context.WithTimeout(ctx, b.rcTimeout)
 	defer cancel()
@@ -96,9 +91,9 @@ func (b *orderedBTFLoader) loadRemoteConfig(ctx context.Context) (*returnBTF, er
 		b:               b,
 		ctx:             ctx,
 		cancelCause:     cancelCause,
-		platform:        platform,
-		platformVersion: platformVersion,
-		kernelVersion:   kernelVersion,
+		platform:        b.platform,
+		platformVersion: b.platformVersion,
+		kernelVersion:   b.kernelVersion,
 		arch:            arch,
 		result:          make(chan *returnBTF),
 	}
@@ -117,9 +112,35 @@ func (b *orderedBTFLoader) loadRemoteConfig(ctx context.Context) (*returnBTF, er
 	}
 
 	// ensure we get the correct error (if any) from the context
-	err = ctx.Err()
-	if errors.Is(err, context.Canceled) {
-		err = context.Cause(ctx)
+	err := ctx.Err()
+	if rbtf == nil {
+		errorTags := make([]string, 0, len(b.fixedtags)+1)
+		copy(errorTags, b.fixedtags)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				err = context.Cause(ctx)
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				errorTags = append(errorTags, "timeout")
+			} else if errors.Is(err, errBTFNotInCatalog) {
+				errorTags = append(errorTags, "not_in_catalog")
+			} else if errors.Is(err, errBTFHashMismatch) {
+				errorTags = append(errorTags, "hash_mismatch")
+			} else if errors.Is(err, errBTFDownload) {
+				errorTags = append(errorTags, "download")
+			} else if errors.Is(err, errBTFExtract) {
+				errorTags = append(errorTags, "extract")
+			} else if errors.Is(err, errBTFLoad) {
+				errorTags = append(errorTags, "load")
+			} else {
+				errorTags = append(errorTags, "unknown")
+			}
+		} else {
+			errorTags = append(errorTags, "not_in_catalog")
+		}
+		b.telemetry.rcErrors.Inc(errorTags...)
+	} else {
+		b.telemetry.rcSuccess.Inc(b.fixedtags...)
 	}
 	return rbtf, err
 }
@@ -139,6 +160,7 @@ type rcBTFLoader struct {
 
 func (r *rcBTFLoader) rcCallback(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
 	var rbtf *returnBTF
+	var allErrors []error
 	for k, config := range update {
 		// we should ACK all updates, even if we find a result or error earlier
 		if r.ctx.Err() != nil || r.ignoreUpdates.Load() || rbtf != nil {
@@ -150,6 +172,7 @@ func (r *rcBTFLoader) rcCallback(update map[string]state.RawConfig, applyStateCa
 		if err != nil {
 			log.Errorf("BTF remote config key %q: %s", k, err)
 			applyStateCallback(k, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+			allErrors = append(allErrors, err)
 			continue
 		}
 
@@ -158,13 +181,18 @@ func (r *rcBTFLoader) rcCallback(update map[string]state.RawConfig, applyStateCa
 			if err != nil {
 				log.Error(err)
 				applyStateCallback(k, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+				allErrors = append(allErrors, err)
 				continue
 			}
 		}
 		applyStateCallback(k, state.ApplyStatus{State: state.ApplyStateAcknowledged})
 	}
 	if rbtf == nil {
-		r.cancelCause(fmt.Errorf("no BTF in catalog found for %s/%s/%s/%s", r.arch, r.platform, r.platformVersion, r.kernelVersion))
+		if allErrors != nil {
+			r.cancelCause(errors.Join(allErrors...))
+		} else {
+			r.cancelCause(fmt.Errorf("%w for %s/%s/%s/%s", errBTFNotInCatalog, r.arch, r.platform, r.platformVersion, r.kernelVersion))
+		}
 		return
 	}
 	r.result <- rbtf
@@ -174,7 +202,7 @@ func (r *rcBTFLoader) processEntry(entry *btfEntry) (*returnBTF, error) {
 	btfURL := fmt.Sprintf("%s/btfs/%s/%s/%s/%s.btf.tar.xz", r.b.rcDownloadHost, r.platform, r.platformVersion, r.arch, r.kernelVersion)
 	btfTarballBuffer, err := r.downloadFile(btfURL, entry.SHA256)
 	if err != nil {
-		return nil, fmt.Errorf("BTF download: %s", err)
+		return nil, fmt.Errorf("%w: %s", errBTFDownload, err)
 	}
 
 	// extract in-memory tarball to regular BTF output directory
@@ -182,16 +210,20 @@ func (r *rcBTFLoader) processEntry(entry *btfEntry) (*returnBTF, error) {
 	extractDir := filepath.Join(filepath.Dir(relPath), r.kernelVersion)
 	absExtractDir := filepath.Join(r.b.btfOutputDir, extractDir)
 	if err := archive.TarXZExtractAllReader(btfTarballBuffer, absExtractDir); err != nil {
-		return nil, fmt.Errorf("extract kernel BTF from tarball: %w", err)
+		return nil, fmt.Errorf("%w: %s", errBTFExtract, err)
 	}
-	return r.b.checkforBTF(extractDir)
+	rbtf, err := r.b.checkforBTF(extractDir)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", errBTFLoad, err)
+	}
+	return rbtf, nil
 }
 
 func (r *rcBTFLoader) findEntry(config state.RawConfig) (*btfEntry, error) {
 	var catalog btfCatalog
 	err := json.Unmarshal(config.Config, &catalog)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshal BTF catalog: %s", err)
+		return nil, fmt.Errorf("%w: %s", errBTFCatalogUnmarshal, err)
 	}
 
 	var entry *btfEntry
@@ -229,7 +261,7 @@ func (r *rcBTFLoader) downloadFile(url string, hash string) (*bytes.Reader, erro
 
 	calcHash := hex.EncodeToString(h.Sum(nil))
 	if calcHash != hash {
-		return nil, fmt.Errorf("hash for %s mismatch: expected %s, got %s", url, hash, calcHash)
+		return nil, fmt.Errorf("%w for %s: expected %s, got %s", errBTFHashMismatch, url, hash, calcHash)
 	}
 	return bytes.NewReader(memOut.Bytes()), nil
 }

--- a/pkg/ebpf/rc_btf_test.go
+++ b/pkg/ebpf/rc_btf_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -57,9 +58,10 @@ func TestRemoteConfigBTFTimeout(t *testing.T) {
 	mockRC := &mockRCClient{t: t, sub: func(product data.Product, _ func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus))) {
 		require.Equal(t, string(product), state.ProductBTFDD)
 	}}
-	loader := initBTFLoader(cfg, mockRC)
+	loader, err := initBTFLoader(cfg, mockRC, telemetryimpl.GetCompatComponent())
+	require.NoError(t, err)
 
-	_, err := loader.loadRemoteConfig(t.Context())
+	_, err = loader.loadRemoteConfig(t.Context())
 	assert.True(t, errors.Is(err, context.DeadlineExceeded))
 }
 
@@ -182,7 +184,8 @@ func TestRemoteConfigBTFFoundEntry(t *testing.T) {
 			}()
 		},
 	}
-	loader := initBTFLoader(cfg, mockRC)
+	loader, err := initBTFLoader(cfg, mockRC, telemetryimpl.GetCompatComponent())
+	require.NoError(t, err)
 	ret, err := loader.loadRemoteConfig(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, ret.vmlinux)
@@ -211,7 +214,8 @@ func TestRemoteConfigBTFHashMismatch(t *testing.T) {
 			}()
 		},
 	}
-	loader := initBTFLoader(cfg, mockRC)
+	loader, err := initBTFLoader(cfg, mockRC, telemetryimpl.GetCompatComponent())
+	require.NoError(t, err)
 	ret, err := loader.loadRemoteConfig(t.Context())
 	require.Error(t, err)
 	require.Nil(t, ret)
@@ -240,7 +244,8 @@ func TestRemoteConfigBTFMissingEntry(t *testing.T) {
 			}()
 		},
 	}
-	loader := initBTFLoader(cfg, mockRC)
+	loader, err := initBTFLoader(cfg, mockRC, telemetryimpl.GetCompatComponent())
+	require.NoError(t, err)
 	ret, err := loader.loadRemoteConfig(t.Context())
 	require.Error(t, err)
 	require.Nil(t, ret)

--- a/pkg/ebpf/verifier/stats.go
+++ b/pkg/ebpf/verifier/stats.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/names"
@@ -53,6 +54,10 @@ func BuildVerifierStats(opts *StatsOptions) (*StatsResult, map[string]struct{}, 
 	}
 	if kversion < kernel.VersionCode(4, 15, 0) {
 		return nil, nil, fmt.Errorf("Kernel %s does not expose verifier statistics", kversion)
+	}
+	err = ddebpf.Setup(ddebpf.NewConfig(), nil, telemetryimpl.GetCompatComponent())
+	if err != nil {
+		return nil, nil, fmt.Errorf("ebpf setup: %s", err)
 	}
 
 	failedToLoad := make(map[string]struct{})

--- a/pkg/system-probe/api/module/loader.go
+++ b/pkg/system-probe/api/module/loader.go
@@ -81,7 +81,7 @@ func Register(cfg *sysconfigtypes.Config, httpMux *http.ServeMux, factories []*F
 		enabledModulesFactories = append(enabledModulesFactories, factory)
 	}
 
-	if err := preRegister(cfg, rcclient, enabledModulesFactories); err != nil {
+	if err := preRegister(cfg, rcclient, deps.Telemetry, enabledModulesFactories); err != nil {
 		return fmt.Errorf("error in pre-register hook: %w", err)
 	}
 

--- a/pkg/system-probe/api/module/loader_linux.go
+++ b/pkg/system-probe/api/module/loader_linux.go
@@ -33,9 +33,10 @@ func isEBPFOptional(factories []*Factory) bool {
 	return false
 }
 
-func preRegister(_ *sysconfigtypes.Config, rcclient rcclient.Component, telemetry telemetry.Component, moduleFactories []*Factory) error {
+func preRegister(cfg *sysconfigtypes.Config, rcclient rcclient.Component, telemetry telemetry.Component, moduleFactories []*Factory) error {
 	needed := isEBPFRequired(moduleFactories)
-	if needed || isEBPFOptional(moduleFactories) {
+	contentionWillLoad := cfg.TelemetryEnabled && ebpf.ContentionCollector != nil
+	if needed || isEBPFOptional(moduleFactories) || contentionWillLoad {
 		err := ebpf.Setup(ebpf.NewConfig(), rcclient, telemetry)
 		if err != nil && !needed {
 			log.Warnf("ignoring eBPF setup error: %v", err)

--- a/pkg/system-probe/api/module/loader_linux.go
+++ b/pkg/system-probe/api/module/loader_linux.go
@@ -8,6 +8,7 @@
 package module
 
 import (
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
@@ -32,10 +33,10 @@ func isEBPFOptional(factories []*Factory) bool {
 	return false
 }
 
-func preRegister(_ *sysconfigtypes.Config, rcclient rcclient.Component, moduleFactories []*Factory) error {
+func preRegister(_ *sysconfigtypes.Config, rcclient rcclient.Component, telemetry telemetry.Component, moduleFactories []*Factory) error {
 	needed := isEBPFRequired(moduleFactories)
 	if needed || isEBPFOptional(moduleFactories) {
-		err := ebpf.Setup(ebpf.NewConfig(), rcclient)
+		err := ebpf.Setup(ebpf.NewConfig(), rcclient, telemetry)
 		if err != nil && !needed {
 			log.Warnf("ignoring eBPF setup error: %v", err)
 			return nil

--- a/pkg/system-probe/api/module/loader_unsupported.go
+++ b/pkg/system-probe/api/module/loader_unsupported.go
@@ -8,11 +8,12 @@
 package module
 
 import (
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
 )
 
-func preRegister(_ *sysconfigtypes.Config, _ rcclient.Component, _ []*Factory) error {
+func preRegister(_ *sysconfigtypes.Config, _ rcclient.Component, _ telemetry.Component, _ []*Factory) error {
 	return nil
 }
 

--- a/pkg/system-probe/api/module/loader_windows.go
+++ b/pkg/system-probe/api/module/loader_windows.go
@@ -8,13 +8,14 @@ package module
 import (
 	"fmt"
 
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
 	"github.com/DataDog/datadog-agent/pkg/network/driver"
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func preRegister(_ *sysconfigtypes.Config, _ rcclient.Component, _ []*Factory) error {
+func preRegister(_ *sysconfigtypes.Config, _ rcclient.Component, _ telemetry.Component, _ []*Factory) error {
 	if err := driver.Init(); err != nil {
 		return fmt.Errorf("failed to load driver subsystem: %v", err)
 	}

--- a/releasenotes/notes/sysprobe-core-telemetry-8b488e2ad3b32ba0.yaml
+++ b/releasenotes/notes/sysprobe-core-telemetry-8b488e2ad3b32ba0.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add ``ebpf.core_load_success``, ``ebpf.core_load_error``, ``ebpf.core_remoteconfig_success``, and ``ebpf.core_remoteconfig_error`` to internal telemetry.


### PR DESCRIPTION
### What does this PR do?

Add `ebpf.core_load_success`, `ebpf.core_load_error`, `ebpf.core_remoteconfig_success`, and `ebpf.core_remoteconfig_error` to internal telemetry. Tags about the Linux kernel environment and error types are included.

### Motivation

Reporting on:
- the success/failure of eBPF CO-RE loading
- IF remote config BTF is needed, report on the success/failure of that.

### Describe how you validated your changes

### Additional Notes
