### PR TITLE
[ABLD-387] Bring Go `msgp` generator under `bazel`

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1978,6 +1978,10 @@
             "https://files.pythonhosted.org/packages/ee/db/7aa11b44bae4e7474feb1201d8dee04fabe5651c7cb51409ebda94a4ed67/nh3-0.3.0-cp38-abi3-musllinux_1_2_armv7l.whl": "b0612ccf5de8a480cf08f047b08f9d3fecc12e63d2ee91769cb19d7290614c23",
             "https://files.pythonhosted.org/packages/f3/ba/59e204d90727c25b253856e456ea61265ca810cda8ee802c35f3fadaab00/nh3-0.3.0-cp313-cp313t-musllinux_1_2_armv7l.whl": "e90883f9f85288f423c77b3f5a6f4486375636f25f793165112679a7b6363b35"
           },
+          "patch-ng": {
+            "https://files.pythonhosted.org/packages/2c/ef/c60c07b2f9d973672608815e4c176943146c353d3b60fdab914a6dcd44e8/patch_ng-1.19.1-py3-none-any.whl": "d45fd47b3f74b48c3e336690341876bb26244a077a06f5f7e6e47c19c15c1ca4",
+            "https://files.pythonhosted.org/packages/da/b6/8ea8095f964f93567bbe28709298b30104ad418b50d4217538387bf48f7d/patch_ng-1.19.1.tar.gz": "036a3cc00134ec53f37e92333958ee75e117f2e62a5ec2b85c7122e5e815c29e"
+          },
           "pkginfo": {
             "https://files.pythonhosted.org/packages/24/03/e26bf3d6453b7fda5bd2b84029a426553bb373d6277ef6b5ac8863421f87/pkginfo-1.12.1.2.tar.gz": "5cd957824ac36f140260964eba3c6be6442a8359b8c48f4adf90210f33a04b7b",
             "https://files.pythonhosted.org/packages/fa/3d/f4f2ba829efb54b6cd2d91349c7463316a9cc55a43fc980447416c88540f/pkginfo-1.12.1.2-py3-none-any.whl": "c783ac885519cab2c34927ccfa6bf64b5a704d7c69afaea583dd9b7afe969343"
@@ -2128,6 +2132,7 @@
           "mdurl": "/simple/mdurl/",
           "more_itertools": "/simple/more-itertools/",
           "nh3": "/simple/nh3/",
+          "patch_ng": "/simple/patch-ng/",
           "pkginfo": "/simple/pkginfo/",
           "pycparser": "/simple/pycparser/",
           "pygments": "/simple/pygments/",

--- a/bazel/rules/go_msgp/defs.bzl
+++ b/bazel/rules/go_msgp/defs.bzl
@@ -23,12 +23,13 @@ def _impl(name, directives, io, out, out_test, patch_strip, patches, src, visibi
         tool = "@com_github_tinylib_msgp//:msgp",
     )
     for i, patch in enumerate(patches):
-        orig, files[out] = ":{}".format(files[out]), "{}_patch{}/{}".format(name, i, out)
+        cur = files[out]
+        files[out] = "{}_patch{}/{}".format(name, i, out)
         run_binary(
             name = "{}_patch{}".format(name, i),
-            args = ["-p{}".format(patch_strip), "$(execpath {})".format(orig), "$(execpath {})".format(patch), "$@"],
+            args = ["-p{}".format(patch_strip), "$(execpath :{})".format(cur), "$(execpath {})".format(patch), "$@"],
             outs = [files[out]],
-            srcs = [orig, patch],
+            srcs = [":{}".format(cur), patch],
             tool = "//bazel/rules/patch",
         )
     native.exports_files(files.keys(), visibility)

--- a/bazel/rules/go_msgp/defs.bzl
+++ b/bazel/rules/go_msgp/defs.bzl
@@ -5,8 +5,12 @@ Each call runs `msgp` on `src` to produce `out` with any `patches` applied in or
 
 load("@bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@bazel_skylib//rules:select_file.bzl", "select_file")
 
-def _impl(name, directives, io, out, out_test, patch_strip, patches, src, visibility):
+def _impl(name, directives, io, out, out_test, patch_strip, patches, src, src_file, visibility):
+    if src_file:
+        select_file(name = "{}_src".format(name), srcs = src, subpath = src_file)
+        src = ":{}_src".format(name)
     files = {out: "{}_msgp/{}".format(name, out)}
     if out_test:
         files[out_test] = "{}_msgp/{}".format(name, out_test)
@@ -49,5 +53,6 @@ go_msgp = macro(
         "patch_strip": attr.int(configurable = False),
         "patches": attr.label_list(configurable = False),
         "src": attr.label(mandatory = True, allow_single_file = True, configurable = False),
+        "src_file": attr.string(configurable = False),
     },
 )

--- a/bazel/rules/go_msgp/defs.bzl
+++ b/bazel/rules/go_msgp/defs.bzl
@@ -22,14 +22,18 @@ def _impl(name, directives, io, out, out_test, patch_strip, patches, src, visibi
         srcs = [src],
         tool = "@com_github_tinylib_msgp//:msgp",
     )
-    for i, patch in enumerate(patches):
-        cur = files[out]
-        files[out] = "{}_patch{}/{}".format(name, i, out)
+    if patches:
+        orig = files[out]
+        files[out] = "{}_patched/{}".format(name, out)
         run_binary(
-            name = "{}_patch{}".format(name, i),
-            args = ["-p{}".format(patch_strip), "$(execpath :{})".format(cur), "$(execpath {})".format(patch), "$@"],
+            name = "{}_patched".format(name),
+            args = [
+                "-p{}".format(patch_strip),
+                "$(execpath :{})".format(orig),
+                "$@",
+            ] + ["$(execpath {})".format(p) for p in patches],
             outs = [files[out]],
-            srcs = [":{}".format(cur), patch],
+            srcs = [":{}".format(orig)] + patches,
             tool = "//bazel/rules/patch",
         )
     native.exports_files(files.keys(), visibility)

--- a/bazel/rules/go_msgp/defs.bzl
+++ b/bazel/rules/go_msgp/defs.bzl
@@ -1,0 +1,48 @@
+"""`msgp` marshaller generation with optional in-pipeline patches, diff-tested against the source tree.
+
+Each call runs `msgp` on `src` to produce `out` with any `patches` applied in order, and `out_test` if specified.
+"""
+
+load("@bazel_lib//lib:run_binary.bzl", "run_binary")
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
+
+def _impl(name, directives, io, out, out_test, patch_strip, patches, src, visibility):
+    files = {out: "{}_msgp/{}".format(name, out)}
+    if out_test:
+        files[out_test] = "{}_msgp/{}".format(name, out_test)
+    run_binary(
+        name = "{}_msgp".format(name),
+        args = [
+            "-file=$(execpath {})".format(src),
+            "-io={}".format(io),
+            "-o=$(execpath :{})".format(files[out]),
+            "-tests={}".format(out_test in files),
+        ] + ["-d='{}'".format(d) for d in directives],
+        outs = files.values(),
+        srcs = [src],
+        tool = "@com_github_tinylib_msgp//:msgp",
+    )
+    for i, patch in enumerate(patches):
+        orig, files[out] = ":{}".format(files[out]), "{}_patch{}/{}".format(name, i, out)
+        run_binary(
+            name = "{}_patch{}".format(name, i),
+            args = ["-p{}".format(patch_strip), "$(execpath {})".format(orig), "$(execpath {})".format(patch), "$@"],
+            outs = [files[out]],
+            srcs = [orig, patch],
+            tool = "//bazel/rules/patch",
+        )
+    native.exports_files(files.keys(), visibility)
+    write_source_files(name = name, files = files, check_that_out_file_exists = False, visibility = ["//visibility:public"])
+
+go_msgp = macro(
+    implementation = _impl,
+    attrs = {
+        "directives": attr.string_list(configurable = False),
+        "io": attr.bool(configurable = False),
+        "out": attr.string(mandatory = True, configurable = False),
+        "out_test": attr.string(configurable = False),
+        "patch_strip": attr.int(configurable = False),
+        "patches": attr.label_list(configurable = False),
+        "src": attr.label(mandatory = True, allow_single_file = True, configurable = False),
+    },
+)

--- a/bazel/rules/go_msgp/use-go-format.patch
+++ b/bazel/rules/go_msgp/use-go-format.patch
@@ -1,0 +1,62 @@
+--- a/printer/print.go	2026-05-28 09:44:36
++++ b/printer/print.go	2026-05-28 10:02:05
+@@ -12,7 +12,7 @@
+ 
+ 	"github.com/tinylib/msgp/gen"
+ 	"github.com/tinylib/msgp/parse"
+-	"golang.org/x/tools/imports"
++	gofmt "go/format"
+ )
+ 
+ var Logf func(s string, v ...any)
+@@ -56,7 +56,7 @@
+ }
+ 
+ func format(file string, data []byte) error {
+-	out, err := imports.Process(file, data, nil)
++	out, err := gofmt.Source(data)
+ 	if err != nil {
+ 		return err
+ 	}
+@@ -90,17 +90,7 @@
+ 	outbuf := bytes.NewBuffer(make([]byte, 0, 4096))
+ 	writePkgHeader(outbuf, f.Package)
+ 
+-	myImports := []string{"github.com/tinylib/msgp/msgp"}
+-	for _, imp := range f.Imports {
+-		if imp.Name != nil {
+-			// have an alias, include it.
+-			myImports = append(myImports, imp.Name.Name+` `+imp.Path.Value)
+-		} else {
+-			myImports = append(myImports, imp.Path.Value)
+-		}
+-	}
+-	dedup := dedupImports(myImports)
+-	writeImportHeader(outbuf, dedup...)
++	writeImportHeader(outbuf, "github.com/tinylib/msgp/msgp")
+ 
+ 	writeLimitConstants(outbuf, file, f)
+ 
+@@ -110,9 +100,9 @@
+ 		testbuf = bytes.NewBuffer(make([]byte, 0, 4096))
+ 		writePkgHeader(testbuf, f.Package)
+ 		if mode&(gen.Encode|gen.Decode) != 0 {
+-			writeImportHeader(testbuf, "bytes", "github.com/tinylib/msgp/msgp", "testing")
++			writeImportHeader(testbuf, "bytes", "testing", "\n", "github.com/tinylib/msgp/msgp")
+ 		} else {
+-			writeImportHeader(testbuf, "github.com/tinylib/msgp/msgp", "testing")
++			writeImportHeader(testbuf, "testing", "\n", "github.com/tinylib/msgp/msgp")
+ 		}
+ 		testwr = testbuf
+ 	}
+@@ -132,6 +122,10 @@
+ func writeImportHeader(b *bytes.Buffer, imports ...string) {
+ 	b.WriteString("import (\n")
+ 	for _, im := range imports {
++		if im == "\n" {
++			b.WriteString(im)
++			continue
++		}
+ 		if im[len(im)-1] == '"' {
+ 			// support aliased imports
+ 			fmt.Fprintf(b, "\t%s\n", im)

--- a/bazel/rules/patch/BUILD.bazel
+++ b/bazel/rules/patch/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@py_dev_requirements//:requirements.bzl", "requirement")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+
+py_binary(
+    name = "patch",
+    srcs = ["patch.py"],
+    visibility = ["//visibility:public"],
+    deps = [requirement("patch-ng")],
+)

--- a/bazel/rules/patch/patch.py
+++ b/bazel/rules/patch/patch.py
@@ -1,0 +1,23 @@
+"""Bridges patch_ng's in-place semantics to Bazel's "one action -> declared output" model."""
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import patch_ng
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("src", type=Path)
+parser.add_argument("patch", type=Path)
+parser.add_argument("out", type=Path)
+parser.add_argument("-p", "--strip", type=int)
+args = parser.parse_args()
+
+patch_ng.logger.addHandler(patch_ng.streamhandler)
+if not (patchset := patch_ng.fromfile(args.patch)):
+    sys.exit(f"cannot parse: {args.patch}")
+
+shutil.copyfile(args.src, args.out)
+if not patchset.apply(strip=args.strip, root=args.out.parent):
+    sys.exit(f"patch failed: {args.patch}")

--- a/bazel/rules/patch/patch.py
+++ b/bazel/rules/patch/patch.py
@@ -9,15 +9,15 @@ import patch_ng
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("src", type=Path)
-parser.add_argument("patch", type=Path)
 parser.add_argument("out", type=Path)
+parser.add_argument("patches", type=Path, nargs="+")
 parser.add_argument("-p", "--strip", type=int)
 args = parser.parse_args()
 
 patch_ng.logger.addHandler(patch_ng.streamhandler)
-if not (patchset := patch_ng.fromfile(args.patch)):
-    sys.exit(f"cannot parse: {args.patch}")
-
 shutil.copyfile(args.src, args.out)
-if not patchset.apply(strip=args.strip, root=args.out.parent):
-    sys.exit(f"patch failed: {args.patch}")
+for patch in args.patches:
+    if not (patchset := patch_ng.fromfile(patch)):
+        sys.exit(f"cannot parse: {patch}")
+    if not patchset.apply(strip=args.strip, root=args.out.parent):
+        sys.exit(f"patch failed: {patch}")

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -499,6 +499,13 @@ go_deps.module_override(
     path = "github.com/favadi/protoc-go-inject-tag",
 )
 
+# Swap msgp's `imports.Process` for `format.Source` (equivalent on msgp's output), removing the need for executing `go`
+go_deps.module_override(
+    patch_strip = 1,
+    patches = ["//bazel/rules/go_msgp:use-go-format.patch"],
+    path = "github.com/tinylib/msgp",
+)
+
 use_repo_rule("//bazel/rules/go_fast:repo.bzl", "go_fast")(name = "go_fast")
 
 use_repo_rule("//bazel/rules/go_sdk_overrides:repo.bzl", "go_sdk_overrides")(name = "go_sdk_overrides")

--- a/deps/py_dev_requirements.txt
+++ b/deps/py_dev_requirements.txt
@@ -1,2 +1,3 @@
 invoke==2.2.1
+patch-ng==1.19.1
 pyyaml==6.0.3

--- a/deps/py_dev_requirements_lock.txt
+++ b/deps/py_dev_requirements_lock.txt
@@ -8,6 +8,10 @@ invoke==2.2.1 \
     --hash=sha256:2413bc441b376e5cd3f55bb5d364f973ad8bdd7bf87e53c79de3c11bf3feecc8 \
     --hash=sha256:515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707
     # via -r deps/py_dev_requirements.txt
+patch-ng==1.19.1 \
+    --hash=sha256:036a3cc00134ec53f37e92333958ee75e117f2e62a5ec2b85c7122e5e815c29e \
+    --hash=sha256:d45fd47b3f74b48c3e336690341876bb26244a077a06f5f7e6e47c19c15c1ca4
+    # via -r deps/py_dev_requirements.txt
 pyyaml==6.0.3 \
     --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \
     --hash=sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a \

--- a/pkg/proto/BUILD.bazel
+++ b/pkg/proto/BUILD.bazel
@@ -11,6 +11,8 @@ go_library(
 write_source_files(
     name = "write_all",
     additional_update_targets = [
+        "//pkg/proto/msgpgo:key_gen",
+        "//pkg/proto/pbgo/core:remoteconfig_gen",
         "//pkg/proto/pbgo/core:write_pb_go",
         "//pkg/proto/pbgo/dogstatsdhttp:write_pb_go",
         "//pkg/proto/pbgo/languagedetection:write_pb_go",
@@ -20,6 +22,11 @@ write_source_files(
         "//pkg/proto/pbgo/privateactionrunner/privateactions:write_pb_go",
         "//pkg/proto/pbgo/process:write_pb_go",
         "//pkg/proto/pbgo/sbom:write_pb_go",
+        "//pkg/proto/pbgo/trace:agent_payload_gen",
+        "//pkg/proto/pbgo/trace:span_gen",
+        "//pkg/proto/pbgo/trace:stats_gen",
+        "//pkg/proto/pbgo/trace:trace_gen",
+        "//pkg/proto/pbgo/trace:tracer_payload_gen",
         "//pkg/proto/pbgo/trace:write_pb_go",
         "//pkg/proto/pbgo/trace/idx:write_pb_go",
     ],

--- a/pkg/proto/msgpgo/BUILD.bazel
+++ b/pkg/proto/msgpgo/BUILD.bazel
@@ -1,4 +1,13 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("//bazel/rules/go_msgp:defs.bzl", "go_msgp")
+
+go_msgp(
+    name = "key_gen",
+    src = "key.go",
+    out = "key_gen.go",
+    io = True,
+    out_test = "key_gen_test.go",
+)
 
 go_library(
     name = "msgpgo",

--- a/pkg/proto/patches/BUILD.bazel
+++ b/pkg/proto/patches/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files(
+    glob(["*.patch"]),
+    visibility = ["//pkg/proto/pbgo/trace:__pkg__"],
+)

--- a/pkg/proto/pbgo/core/BUILD.bazel
+++ b/pkg/proto/pbgo/core/BUILD.bazel
@@ -1,5 +1,26 @@
+load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("//bazel/rules/go_msgp:defs.bzl", "go_msgp")
 load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
+
+filegroup(
+    name = "config_go_proto_srcs",
+    srcs = ["//pkg/proto/datadog/remoteconfig:config_go_proto"],
+    output_group = "go_generated_srcs",
+)
+
+select_file(
+    name = "remoteconfig_pb_go",
+    srcs = ":config_go_proto_srcs",
+    subpath = "remoteconfig.pb.go",
+)
+
+go_msgp(
+    name = "remoteconfig_gen",
+    src = ":remoteconfig_pb_go",
+    out = "remoteconfig_gen.go",
+    out_test = "remoteconfig_gen_test.go",
+)
 
 write_pb_go(
     name = "write_pb_go",

--- a/pkg/proto/pbgo/core/BUILD.bazel
+++ b/pkg/proto/pbgo/core/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 load("//bazel/rules/go_msgp:defs.bzl", "go_msgp")
 load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
@@ -9,17 +8,12 @@ filegroup(
     output_group = "go_generated_srcs",
 )
 
-select_file(
-    name = "remoteconfig_pb_go",
-    srcs = ":config_go_proto_srcs",
-    subpath = "remoteconfig.pb.go",
-)
-
 go_msgp(
     name = "remoteconfig_gen",
-    src = ":remoteconfig_pb_go",
+    src = ":config_go_proto_srcs",
     out = "remoteconfig_gen.go",
     out_test = "remoteconfig_gen_test.go",
+    src_file = "remoteconfig.pb.go",
 )
 
 write_pb_go(

--- a/pkg/proto/pbgo/trace/BUILD.bazel
+++ b/pkg/proto/pbgo/trace/BUILD.bazel
@@ -1,6 +1,83 @@
 # gazelle:write_pb_go //pkg/proto/datadog/trace:trace_go_proto //pkg/proto/datadog/trace:trace_go_proto_tagged
+load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("//bazel/rules/go_msgp:defs.bzl", "go_msgp")
 load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
+
+filegroup(
+    name = "trace_go_proto_tagged_srcs",
+    srcs = ["//pkg/proto/datadog/trace:trace_go_proto_tagged"],
+    output_group = "go_generated_srcs",
+)
+
+select_file(
+    name = "agent_payload_pb_go",
+    srcs = ":trace_go_proto_tagged_srcs",
+    subpath = "agent_payload.pb.go",
+)
+
+go_msgp(
+    name = "agent_payload_gen",
+    src = ":agent_payload_pb_go",
+    out = "agent_payload_gen.go",
+    directives = ["limit arrays:500000 maps:500000"],
+    out_test = "agent_payload_gen_test.go",
+)
+
+select_file(
+    name = "span_pb_go",
+    srcs = ":trace_go_proto_tagged_srcs",
+    subpath = "span.pb.go",
+)
+
+go_msgp(
+    name = "span_gen",
+    src = ":span_pb_go",
+    out = "span_gen.go",
+    directives = ["limit arrays:500000 maps:500000"],
+    out_test = "span_gen_test.go",
+    patch_strip = 4,
+    patches = [
+        "//pkg/proto/patches:0001-Customize-msgpack-parsing.patch",
+        "//pkg/proto/patches:0002-Make-nil-map-deserialization-retrocompatible.patch",
+    ],
+)
+
+select_file(
+    name = "stats_pb_go",
+    srcs = ":trace_go_proto_tagged_srcs",
+    subpath = "stats.pb.go",
+)
+
+go_msgp(
+    name = "stats_gen",
+    src = ":stats_pb_go",
+    out = "stats_gen.go",
+    directives = ["limit arrays:500000 maps:500000"],
+    io = True,
+    out_test = "stats_gen_test.go",
+)
+
+go_msgp(
+    name = "trace_gen",
+    src = "trace.go",
+    out = "trace_gen.go",
+    out_test = "trace_gen_test.go",
+)
+
+select_file(
+    name = "tracer_payload_pb_go",
+    srcs = ":trace_go_proto_tagged_srcs",
+    subpath = "tracer_payload.pb.go",
+)
+
+go_msgp(
+    name = "tracer_payload_gen",
+    src = ":tracer_payload_pb_go",
+    out = "tracer_payload_gen.go",
+    directives = ["limit arrays:500000 maps:500000"],
+    out_test = "tracer_payload_gen_test.go",
+)
 
 write_pb_go(
     name = "write_pb_go",

--- a/pkg/proto/pbgo/trace/BUILD.bazel
+++ b/pkg/proto/pbgo/trace/BUILD.bazel
@@ -1,5 +1,4 @@
 # gazelle:write_pb_go //pkg/proto/datadog/trace:trace_go_proto //pkg/proto/datadog/trace:trace_go_proto_tagged
-load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 load("//bazel/rules/go_msgp:defs.bzl", "go_msgp")
 load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
@@ -10,29 +9,18 @@ filegroup(
     output_group = "go_generated_srcs",
 )
 
-select_file(
-    name = "agent_payload_pb_go",
-    srcs = ":trace_go_proto_tagged_srcs",
-    subpath = "agent_payload.pb.go",
-)
-
 go_msgp(
     name = "agent_payload_gen",
-    src = ":agent_payload_pb_go",
+    src = ":trace_go_proto_tagged_srcs",
     out = "agent_payload_gen.go",
     directives = ["limit arrays:500000 maps:500000"],
     out_test = "agent_payload_gen_test.go",
-)
-
-select_file(
-    name = "span_pb_go",
-    srcs = ":trace_go_proto_tagged_srcs",
-    subpath = "span.pb.go",
+    src_file = "agent_payload.pb.go",
 )
 
 go_msgp(
     name = "span_gen",
-    src = ":span_pb_go",
+    src = ":trace_go_proto_tagged_srcs",
     out = "span_gen.go",
     directives = ["limit arrays:500000 maps:500000"],
     out_test = "span_gen_test.go",
@@ -41,21 +29,17 @@ go_msgp(
         "//pkg/proto/patches:0001-Customize-msgpack-parsing.patch",
         "//pkg/proto/patches:0002-Make-nil-map-deserialization-retrocompatible.patch",
     ],
-)
-
-select_file(
-    name = "stats_pb_go",
-    srcs = ":trace_go_proto_tagged_srcs",
-    subpath = "stats.pb.go",
+    src_file = "span.pb.go",
 )
 
 go_msgp(
     name = "stats_gen",
-    src = ":stats_pb_go",
+    src = ":trace_go_proto_tagged_srcs",
     out = "stats_gen.go",
     directives = ["limit arrays:500000 maps:500000"],
     io = True,
     out_test = "stats_gen_test.go",
+    src_file = "stats.pb.go",
 )
 
 go_msgp(
@@ -65,18 +49,13 @@ go_msgp(
     out_test = "trace_gen_test.go",
 )
 
-select_file(
-    name = "tracer_payload_pb_go",
-    srcs = ":trace_go_proto_tagged_srcs",
-    subpath = "tracer_payload.pb.go",
-)
-
 go_msgp(
     name = "tracer_payload_gen",
-    src = ":tracer_payload_pb_go",
+    src = ":trace_go_proto_tagged_srcs",
     out = "tracer_payload_gen.go",
     directives = ["limit arrays:500000 maps:500000"],
     out_test = "tracer_payload_gen_test.go",
+    src_file = "tracer_payload.pb.go",
 )
 
 write_pb_go(

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import ast
-import os
 import shlex
 import shutil
 import subprocess
@@ -132,33 +130,3 @@ def bazel(
     if capture_stderr:
         return (result.stdout or "") + (result.stderr or "")
     return result.stdout
-
-
-class BazelTools:
-    """Hermetic Bazel-managed tool paths; populated once on first instantiation."""
-
-    _paths = {}
-
-    def __new__(cls, ctx):
-        if not cls._paths:
-            labels = ("@com_github_tinylib_msgp//:msgp", "@rules_go//go")
-            bazel(ctx, "build", *labels)
-            root = bazel(ctx, "info", "execution_root", capture_output=True).strip()
-            for line in bazel(
-                ctx,
-                "cquery",
-                f"config(set({' '.join(labels)}), target)",
-                "--output=starlark",
-                "--starlark:expr=target.label.name,target.files_to_run.executable.path",
-                capture_output=True,
-            ).splitlines():
-                name, path = ast.literal_eval(line)
-                cls._paths[name] = Path(root, path)
-        return super().__new__(cls)
-
-    def __getattr__(self, name):
-        return self._paths[name]
-
-    @property
-    def go_env(self):
-        return {"PATH": f"{self._paths['go_bin_runner'].parent}{os.pathsep}{os.getenv('PATH', '')}"}

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -1,9 +1,8 @@
-import os
 import re
 
 from invoke import Exit, task
 
-from tasks.libs.build.bazel import BazelTools, bazel
+from tasks.libs.build.bazel import bazel
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.git import get_unstaged_files, get_untracked_files
 
@@ -12,65 +11,12 @@ from tasks.libs.common.git import get_unstaged_files, get_untracked_files
 def generate(ctx, pre_commit=False):
     """
     Generates protobuf definitions in pkg/proto
-
-    We must build the packages one at a time due to protoc-gen-go limitations
     """
     proto_file = re.compile(r"pkg/proto/.*(\.pb|_gen(_test)?)\.go$")
     old_unstaged_proto_files = set(get_unstaged_files(ctx, re_filter=proto_file, include_deleted_files=True))
     old_untracked_proto_files = set(get_untracked_files(ctx, re_filter=proto_file))
-    bt = BazelTools(ctx)
-    base = os.path.dirname(os.path.abspath(__file__))
-    repo_root = os.path.abspath(os.path.join(base, ".."))
-    proto_root = os.path.join(repo_root, "pkg", "proto")
 
     bazel(ctx, "run", "//pkg/proto:write_all")
-
-    # Generate messagepack marshallers
-    # msgp targets (file, io)
-    msgp_targets = {
-        'pbgo/trace': [
-            ('trace.go', False),
-            ('span.pb.go', False),
-            ('stats.pb.go', True),
-            ('tracer_payload.pb.go', False),
-            ('agent_payload.pb.go', False),
-        ],
-        'pbgo/core': [('remoteconfig.pb.go', False)],
-        'msgpgo': [('key.go', True)],
-    }
-    # Per-file extra directives, keyed by (pkg, src).
-    # stats.pb.go is protoc-generated so the limit directive cannot live in the
-    # file itself; pass it on the command line instead.
-    msgp_file_directives = {
-        ('pbgo/trace', 'stats.pb.go'): '-d "limit arrays:500000 maps:500000"',
-        ('pbgo/trace', 'span.pb.go'): '-d "limit arrays:500000 maps:500000"',
-        ('pbgo/trace', 'tracer_payload.pb.go'): '-d "limit arrays:500000 maps:500000"',
-        ('pbgo/trace', 'agent_payload.pb.go'): '-d "limit arrays:500000 maps:500000"',
-    }
-    for pkg, files in msgp_targets.items():
-        for src, io_gen in files:
-            dst = os.path.splitext(os.path.basename(src))[0]  # .go
-            dst = os.path.splitext(dst)[0]  # .pb
-            extra_flags = msgp_file_directives.get((pkg, src), '')
-            ctx.run(
-                f"{bt.msgp} -file {proto_root}/{pkg}/{src} -o={proto_root}/{pkg}/{dst}_gen.go -io={io_gen} {extra_flags}",
-                env=bt.go_env,
-            )
-
-    # Apply msgp patches
-    # msgp patches key is `pkg` : (patch, destination)
-    #     if `destination` is `None` diff will target inherent patch files
-    msgp_patches = {
-        'pbgo/trace': [
-            ('0001-Customize-msgpack-parsing.patch', '-p4'),
-            ('0002-Make-nil-map-deserialization-retrocompatible.patch', '-p4'),
-        ],
-    }
-    for pkg, patches in msgp_patches.items():
-        for patch in patches:
-            patch_file = os.path.join(proto_root, "patches", patch[0])
-            switches = patch[1] if patch[1] else ''
-            ctx.run(f'git apply {switches} --unsafe-paths --directory="{proto_root}/{pkg}" {patch_file}')
 
     # Check the generated files were properly committed
     current_unstaged_proto_files = set(get_unstaged_files(ctx, re_filter=proto_file, include_deleted_files=True))


### PR DESCRIPTION
### What does this PR do?
tl;dr: **this completes the `bazel`ification of `tasks/protobuf.py`.**

In this instance, `tasks/protobuf.py` no longer shells out to the `msgp` binary nor to `git apply` for the 7 message-pack marshallers under `pkg/proto//`.
They are now produced by regular `bazel` targets and verified against the source tree via `write_source_files`'s diff test.

The change introduces:
- a `go_msgp` symbolic macro under `bazel/rules/go_msgp/` that invokes `@com_github_tinylib_msgp//:msgp` on a single Go source and optionally pipes the main output through one or more patch steps before `write_source_files`,
- a standalone, reusable, patch-applier rule under `bazel/rules/patch/`, consisting in a thin `py_binary` wrapping `patch-ng` with a `bazel`-suitable `<src> <out> <patch...>` + `-p`/`--strip` shape.
  `patch-ng` is a ~50KB pure-Python wheel that avoids depending on host/platform-specific `patch[.exe]` flavors since `ctx.patch` is only available in repository rules,
- a `go_deps.module_override` for `github.com/tinylib/msgp` pointing at `use-go-format.patch`: msgp's printer is patched to avoid `exec.Command("go", ...)` at runtime,
- one `go_msgp` call per marshaller in `pkg/proto/pbgo/{core,trace}/BUILD.bazel`, with `span_gen` additionally passing the 2 `.patch` files to apply.

`tasks/protobuf.py` drops the `msgp` + `git apply` loops, and the now-orphan `BazelTools` class is removed from
`tasks/libs/build/bazel.py`.

### Motivation
Bring the last code generator in `pkg/proto/pbgo/` under `bazel`'s diff-test umbrella so every `_gen.go` in the tree enjoys the same regen guarantee as `.pb.go` files.

### Describe how you validated your changes
- `bazel test //...` passes (12 new diff tests, including the patched `span_gen.go`),
- `dda inv protobuf.generate` runs a single  `bazel run` line and reports no changes on a clean tree.

### Additional Notes
This change will allow us to remove the `protobuf_test` job in a follow-up PR, because its now work is covered by `bazel:test:*` jobs (they include diff test targets).
Conversely, it makes sense to keep the `dda inv protobuf.generate` task as a pre-commit hook.