### PR TITLE
feat(snmp): add named credentials for reusable SNMP auth config

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -83,6 +83,19 @@ var uptimeMetricConfig = profiledefinition.MetricsConfig{Symbol: profiledefiniti
 // DeviceDigest is the digest of a minimal config used for autodiscovery
 type DeviceDigest string
 
+// CredentialConfig holds reusable SNMP authentication parameters that can be
+// defined once in init_config and referenced by name from instances.
+type CredentialConfig struct {
+	CommunityString string `yaml:"community_string"`
+	SnmpVersion     string `yaml:"snmp_version"`
+	User            string `yaml:"user"`
+	AuthProtocol    string `yaml:"authProtocol"`
+	AuthKey         string `yaml:"authKey"`
+	PrivProtocol    string `yaml:"privProtocol"`
+	PrivKey         string `yaml:"privKey"`
+	ContextName     string `yaml:"context_name"`
+}
+
 // InitConfig is used to deserialize integration init config
 type InitConfig struct {
 	Profiles              profile.ProfileConfigMap          `yaml:"profiles"`
@@ -98,6 +111,8 @@ type InitConfig struct {
 	Namespace             string                            `yaml:"namespace"`
 	PingConfig            snmpintegration.PackedPingConfig  `yaml:"ping"`
 	Loader                string                            `yaml:"loader"`
+	// NamedCredentials defines reusable credential sets referenced by instances via credential_ref.
+	NamedCredentials map[string]CredentialConfig `yaml:"named_credentials"`
 }
 
 // InstanceConfig is used to deserialize integration instance config
@@ -159,6 +174,10 @@ type InstanceConfig struct {
 	// `interface_configs` option is not supported by SNMP corecheck autodiscovery (`network_address`)
 	// it's only supported for single device instance (`ip_address`)
 	InterfaceConfigs InterfaceConfigs `yaml:"interface_configs"`
+
+	// CredentialRef references a named credential defined in init_config.named_credentials.
+	// Fields set directly on the instance take precedence over the referenced credential.
+	CredentialRef string `yaml:"credential_ref"`
 }
 
 // CheckConfig holds config needed for an integration instance to run
@@ -294,6 +313,40 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	err = yaml.Unmarshal(rawInstance, &instance)
 	if err != nil {
 		return nil, err
+	}
+
+	// Resolve named credential ref before any instance fields are consumed.
+	// Instance-level fields take precedence: only apply named credential values
+	// where the instance has not already set them.
+	if instance.CredentialRef != "" {
+		cred, ok := initConfig.NamedCredentials[instance.CredentialRef]
+		if !ok {
+			return nil, fmt.Errorf("credential_ref %q not found in init_config.named_credentials", instance.CredentialRef)
+		}
+		if instance.CommunityString == "" {
+			instance.CommunityString = cred.CommunityString
+		}
+		if instance.SnmpVersion == "" {
+			instance.SnmpVersion = cred.SnmpVersion
+		}
+		if instance.User == "" {
+			instance.User = cred.User
+		}
+		if instance.AuthProtocol == "" {
+			instance.AuthProtocol = cred.AuthProtocol
+		}
+		if instance.AuthKey == "" {
+			instance.AuthKey = cred.AuthKey
+		}
+		if instance.PrivProtocol == "" {
+			instance.PrivProtocol = cred.PrivProtocol
+		}
+		if instance.PrivKey == "" {
+			instance.PrivKey = cred.PrivKey
+		}
+		if instance.ContextName == "" {
+			instance.ContextName = cred.ContextName
+		}
 	}
 
 	c := &CheckConfig{}

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -2274,3 +2274,85 @@ func TestRCConflict(t *testing.T) {
 	_, err = config.BuildProfile("1.2.3.4.5.6")
 	require.ErrorContains(t, err, "has the same sysObjectID (1.2.3.4.*)")
 }
+
+func TestNamedCredentials(t *testing.T) {
+	setupHostname(t)
+	profile.SetConfdPathAndCleanProfiles()
+
+	t.Run("credential_ref applies named credential", func(t *testing.T) {
+		// language=yaml
+		rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+credential_ref: creds_v3
+`)
+		// language=yaml
+		rawInitConfig := []byte(`
+named_credentials:
+  creds_v3:
+    snmp_version: "3"
+    user: admin
+    authProtocol: SHA
+    authKey: authsecret
+    privProtocol: AES
+    privKey: privsecret
+    context_name: myctx
+`)
+		config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "3", config.SnmpVersion)
+		assert.Equal(t, "admin", config.User)
+		assert.Equal(t, "SHA", config.AuthProtocol)
+		assert.Equal(t, "authsecret", config.AuthKey)
+		assert.Equal(t, "AES", config.PrivProtocol)
+		assert.Equal(t, "privsecret", config.PrivKey)
+		assert.Equal(t, "myctx", config.ContextName)
+	})
+
+	t.Run("instance fields take precedence over credential_ref", func(t *testing.T) {
+		// language=yaml
+		rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+credential_ref: creds_v2
+community_string: override
+`)
+		// language=yaml
+		rawInitConfig := []byte(`
+named_credentials:
+  creds_v2:
+    community_string: default
+`)
+		config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "override", config.CommunityString)
+	})
+
+	t.Run("unknown credential_ref returns error", func(t *testing.T) {
+		// language=yaml
+		rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+credential_ref: nonexistent
+`)
+		// language=yaml
+		rawInitConfig := []byte(`
+named_credentials:
+  creds_v2:
+    community_string: public
+`)
+		_, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `credential_ref "nonexistent" not found in init_config.named_credentials`)
+	})
+
+	t.Run("no credential_ref behaves as before", func(t *testing.T) {
+		// language=yaml
+		rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+community_string: public
+`)
+		// language=yaml
+		rawInitConfig := []byte(``)
+		config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "public", config.CommunityString)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `CredentialConfig` struct holding all SNMP auth fields (`community_string`, `snmp_version`, `user`, `authProtocol`, `authKey`, `privProtocol`, `privKey`, `context_name`)
- Adds `named_credentials` map to `init_config`, allowing credential sets to be defined once and referenced by name
- Adds `credential_ref` field to instance config to reference a named credential
- Instance-level fields always take precedence over the referenced credential — fully backward compatible

## Usage

```yaml
init_config:
  named_credentials:
    creds_v3:
      user: admin
      authProtocol: SHA
      authKey: authsecret
      privProtocol: AES
      privKey: privsecret

instances:
  - ip_address: 10.0.0.1
    credential_ref: creds_v3
  - ip_address: 10.0.0.2
    credential_ref: creds_v3
  - ip_address: 10.0.0.3
    credential_ref: creds_v3
    authKey: different_key   # overrides just this field
```

## Test plan

- [ ] `credential_ref` applies all fields from the named credential
- [ ] Instance-level fields take precedence over `credential_ref`
- [ ] Unknown `credential_ref` returns a clear error
- [ ] Instances without `credential_ref` are unaffected (backward compatibility)

All four cases covered by `TestNamedCredentials` in `config_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)