### PR TITLE
Drop `gobind`/`gomobile` Android leftovers

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -36,7 +36,6 @@ overrides:
   "github.com/bhmj/xpression": MIT
 
 exceptions:
-  - "golang.org/x/mobile/..."
   - "golang.org/x/tools/..."
   - "golang.org/x/mod/..."
   - "golang.org/x/xerrors/..."

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -446,7 +446,6 @@ use_repo(
     "org_golang_x_arch",
     "org_golang_x_crypto",
     "org_golang_x_exp",
-    "org_golang_x_mobile",
     "org_golang_x_mod",
     "org_golang_x_net",
     "org_golang_x_oauth2",

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/uber-go/gopatch v0.4.0
 	github.com/vektra/mockery/v3 v3.7.0
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
-	golang.org/x/mobile v0.0.0-20231127183840-76ac6878050a
 	golang.org/x/perf v0.0.0-20250909190841-7e13e04d9366
 	gotest.tools/gotestsum v1.13.0
 )

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -630,8 +630,6 @@ golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl
 golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 h1:qWFG1Dj7TBjOjOvhEOkmyGPVoquqUKnIU0lEVLp8xyk=
 golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358/go.mod h1:4Mzdyp/6jzw9auFDJ3OMF5qksa7UvPnzKqTVGcb04ms=
-golang.org/x/mobile v0.0.0-20231127183840-76ac6878050a h1:sYbmY3FwUWCBTodZL1S3JUuOvaW6kM2o+clDzzDNBWg=
-golang.org/x/mobile v0.0.0-20231127183840-76ac6878050a/go.mod h1:Ede7gF0KGoHlj822RtphAHK1jLdrcuRBZg0sF1Q+SPc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -21,8 +21,6 @@ import (
 	_ "github.com/uber-go/gopatch"
 	_ "github.com/vektra/mockery/v3"
 	_ "github.com/wadey/gocovmerge"
-	_ "golang.org/x/mobile/cmd/gobind"
-	_ "golang.org/x/mobile/cmd/gomobile"
 	_ "golang.org/x/perf/cmd/benchstat"
 	_ "gotest.tools/gotestsum"
 )


### PR DESCRIPTION
### What does this PR do?
Remove `golang.org/x/mobile/cmd/{gobind,gomobile}` from `internal/tools/tools.go`, the accompanying `org_golang_x_mobile` use_repo entry from `deps/go.MODULE.bazel`, the `golang.org/x/mobile/...` exception from `.wwhrd.yml`, and the `golang.org/x/mobile` direct require from `internal/tools/go.mod` all fall out via `dda inv tidy`.

### Motivation
Both tools served Android APK builds (`tasks/android.py`, `cmd/agent/android/`), all of which were retired in #13699 (2022-10-06, "This was never shipped, and while it builds it is unlikely to actually work").
The tool registrations were left behind, pulling `golang.org/x/mobile` into the tools module for 3+ years with no caller.

### Describe how you validated your changes
- `dda inv tidy` is a no-op on the resulting tree,
- `dda inv generate-licenses` reports no `golang.org/x/mobile` skips (confirming the `.wwhrd.yml` exception was already unreachable),
- `dda inv lint-licenses` passes.

### Additional Notes
The two `golang.org/x/mobile v0.0.0-.../go.mod h1:` lines in the root `go.sum` are left in place: they're MVS verification hashes that Go needs to integrity-check the go.mod of old `golang.org/x/exp` versions in our dep graph (which transitively mention `x/mobile`), and `go mod tidy` re-adds them when removed.
They'll disappear naturally when the underlying `x/exp` pins shift to post-1.17 versions.