### PR TITLE
FIPS DDOT on bare-metal

### DIFF
--- a/.gitlab/build/packaging/oci.yml
+++ b/.gitlab/build/packaging/oci.yml
@@ -85,21 +85,20 @@
             mkdir -p "${DDOT_EXTENSION_DIR}/etc"
             echo "Extracting DDOT ${DDOT_INPUT_FILE} -> ${DDOT_EXTENSION_DIR}"
             tar xJf "${DDOT_INPUT_FILE}" --strip-components=2 -C "${DDOT_EXTENSION_DIR}" opt/
-            tar xJf "${DDOT_INPUT_FILE}" --strip-components=1 -C "${DDOT_EXTENSION_DIR}/etc" etc/ 2>/dev/null || true
+            tar xJf "${DDOT_INPUT_FILE}" --strip-components=1 -C "${DDOT_EXTENSION_DIR}/etc" etc/
             EXTRA_FLAGS="--configs ${INPUT_DIR}/etc/datadog-agent --installer ${INSTALLER_INPUT_DIR}/opt/datadog-packages/datadog-installer/${PACKAGE_VERSION}/bin/installer/installer --extension ddot=${DDOT_EXTENSION_DIR}"
           else
             echo "DDOT artifact not found, skipping DDOT extension"
             EXTRA_FLAGS="--configs ${INPUT_DIR}/etc/datadog-agent --installer ${INSTALLER_INPUT_DIR}/opt/datadog-packages/datadog-installer/${PACKAGE_VERSION}/bin/installer/installer"
           fi
 
-          # Extract DDOT FIPS
+          # Extract DDOT FIPS — only bundled into the FIPS variant manifest, not the base manifest
           if DDOT_FIPS_INPUT_FILE=$(resolve_artifact "DDOT FIPS" "${OMNIBUS_PACKAGE_DIR}datadog-fips-agent-ddot-*${ARCH}.tar.xz"); then
             DDOT_FIPS_EXTENSION_DIR="/tmp/ddot_fips_extension_${ARCH}"
             mkdir -p "${DDOT_FIPS_EXTENSION_DIR}/etc"
             echo "Extracting DDOT FIPS ${DDOT_FIPS_INPUT_FILE} -> ${DDOT_FIPS_EXTENSION_DIR}"
             tar xJf "${DDOT_FIPS_INPUT_FILE}" --strip-components=2 -C "${DDOT_FIPS_EXTENSION_DIR}" opt/
-            tar xJf "${DDOT_FIPS_INPUT_FILE}" --strip-components=1 -C "${DDOT_FIPS_EXTENSION_DIR}/etc" etc/ 2>/dev/null || true
-            EXTRA_FLAGS="${EXTRA_FLAGS} --extension ddot-fips=${DDOT_FIPS_EXTENSION_DIR}"
+            tar xJf "${DDOT_FIPS_INPUT_FILE}" --strip-components=1 -C "${DDOT_FIPS_EXTENSION_DIR}/etc" etc/
           else
             echo "DDOT FIPS artifact not found, skipping DDOT FIPS extension"
           fi

--- a/.gitlab/build/packaging/oci.yml
+++ b/.gitlab/build/packaging/oci.yml
@@ -80,28 +80,21 @@
           tar xJf ${INSTALLER_INPUT_FILE} -C ${INSTALLER_INPUT_DIR}
 
           # Extract DDOT
-          if DDOT_INPUT_FILE=$(resolve_artifact "DDOT" "${OMNIBUS_PACKAGE_DIR}datadog-agent-ddot-*${ARCH}.tar.xz"); then
-            DDOT_EXTENSION_DIR="/tmp/ddot_extension_${ARCH}"
-            mkdir -p "${DDOT_EXTENSION_DIR}/etc"
-            echo "Extracting DDOT ${DDOT_INPUT_FILE} -> ${DDOT_EXTENSION_DIR}"
-            tar xJf "${DDOT_INPUT_FILE}" --strip-components=2 -C "${DDOT_EXTENSION_DIR}" opt/
-            tar xJf "${DDOT_INPUT_FILE}" --strip-components=1 -C "${DDOT_EXTENSION_DIR}/etc" etc/
-            EXTRA_FLAGS="--configs ${INPUT_DIR}/etc/datadog-agent --installer ${INSTALLER_INPUT_DIR}/opt/datadog-packages/datadog-installer/${PACKAGE_VERSION}/bin/installer/installer --extension ddot=${DDOT_EXTENSION_DIR}"
-          else
-            echo "DDOT artifact not found, skipping DDOT extension"
-            EXTRA_FLAGS="--configs ${INPUT_DIR}/etc/datadog-agent --installer ${INSTALLER_INPUT_DIR}/opt/datadog-packages/datadog-installer/${PACKAGE_VERSION}/bin/installer/installer"
-          fi
+          DDOT_INPUT_FILE=$(resolve_artifact "DDOT" "${OMNIBUS_PACKAGE_DIR}datadog-agent-ddot-*${ARCH}.tar.xz") || exit 1
+          DDOT_EXTENSION_DIR="/tmp/ddot_extension_${ARCH}"
+          mkdir -p "${DDOT_EXTENSION_DIR}/etc"
+          echo "Extracting DDOT ${DDOT_INPUT_FILE} -> ${DDOT_EXTENSION_DIR}"
+          tar xJf "${DDOT_INPUT_FILE}" --strip-components=2 -C "${DDOT_EXTENSION_DIR}" opt/
+          tar xJf "${DDOT_INPUT_FILE}" --strip-components=1 -C "${DDOT_EXTENSION_DIR}/etc" etc/
+          EXTRA_FLAGS="--configs ${INPUT_DIR}/etc/datadog-agent --installer ${INSTALLER_INPUT_DIR}/opt/datadog-packages/datadog-installer/${PACKAGE_VERSION}/bin/installer/installer --extension ddot=${DDOT_EXTENSION_DIR}"
 
           # Extract DDOT FIPS — only bundled into the FIPS variant manifest, not the base manifest
-          if DDOT_FIPS_INPUT_FILE=$(resolve_artifact "DDOT FIPS" "${OMNIBUS_PACKAGE_DIR}datadog-fips-agent-ddot-*${ARCH}.tar.xz"); then
-            DDOT_FIPS_EXTENSION_DIR="/tmp/ddot_fips_extension_${ARCH}"
-            mkdir -p "${DDOT_FIPS_EXTENSION_DIR}/etc"
-            echo "Extracting DDOT FIPS ${DDOT_FIPS_INPUT_FILE} -> ${DDOT_FIPS_EXTENSION_DIR}"
-            tar xJf "${DDOT_FIPS_INPUT_FILE}" --strip-components=2 -C "${DDOT_FIPS_EXTENSION_DIR}" opt/
-            tar xJf "${DDOT_FIPS_INPUT_FILE}" --strip-components=1 -C "${DDOT_FIPS_EXTENSION_DIR}/etc" etc/
-          else
-            echo "DDOT FIPS artifact not found, skipping DDOT FIPS extension"
-          fi
+          DDOT_FIPS_INPUT_FILE=$(resolve_artifact "DDOT FIPS" "${OMNIBUS_PACKAGE_DIR}datadog-fips-agent-ddot-*${ARCH}.tar.xz") || exit 1
+          DDOT_FIPS_EXTENSION_DIR="/tmp/ddot_fips_extension_${ARCH}"
+          mkdir -p "${DDOT_FIPS_EXTENSION_DIR}/etc"
+          echo "Extracting DDOT FIPS ${DDOT_FIPS_INPUT_FILE} -> ${DDOT_FIPS_EXTENSION_DIR}"
+          tar xJf "${DDOT_FIPS_INPUT_FILE}" --strip-components=2 -C "${DDOT_FIPS_EXTENSION_DIR}" opt/
+          tar xJf "${DDOT_FIPS_INPUT_FILE}" --strip-components=1 -C "${DDOT_FIPS_EXTENSION_DIR}/etc" etc/
         fi
         if [ "${OCI_PRODUCT}" = "datadog-installer" ]; then
           EXTRA_FLAGS="--installer ${INPUT_DIR}/${INSTALL_DIR}/bin/installer/installer"
@@ -129,10 +122,7 @@
           mkdir -p ${FIPS_INPUT_DIR}
           echo "Extracting FIPS agent ${FIPS_INPUT_FILE} -> ${FIPS_INPUT_DIR}"
           tar xJf ${FIPS_INPUT_FILE} -C ${FIPS_INPUT_DIR}
-          FIPS_EXTRA_FLAGS="--configs ${FIPS_INPUT_DIR}/etc/datadog-agent --installer ${INSTALLER_INPUT_DIR}/opt/datadog-packages/datadog-installer/${PACKAGE_VERSION}/bin/installer/installer"
-          if [ -d "${DDOT_FIPS_EXTENSION_DIR:-/nonexistent}" ]; then
-            FIPS_EXTRA_FLAGS="${FIPS_EXTRA_FLAGS} --extension ddot=${DDOT_FIPS_EXTENSION_DIR}"
-          fi
+          FIPS_EXTRA_FLAGS="--configs ${FIPS_INPUT_DIR}/etc/datadog-agent --installer ${INSTALLER_INPUT_DIR}/opt/datadog-packages/datadog-installer/${PACKAGE_VERSION}/bin/installer/installer --extension ddot=${DDOT_FIPS_EXTENSION_DIR}"
           echo "Creating FIPS OCI layer -> ${OUTPUT_DIR}/${FIPS_OUTPUT_FILE}"
           datadog-package create \
             --version ${PACKAGE_VERSION} \
@@ -147,8 +137,8 @@
         fi
 
         rm -f ${INPUT_FILE}
-        if [ "${OCI_PRODUCT}" = "datadog-agent" ] && [ -n "$DDOT_INPUT_FILE" ]; then
-          rm -f ${DDOT_INPUT_FILE}
+        if [ "${OCI_PRODUCT}" = "datadog-agent" ]; then
+          rm -f ${INSTALLER_INPUT_FILE} ${DDOT_INPUT_FILE} ${DDOT_FIPS_INPUT_FILE}
         fi
       done
     - echo "Aggregating all layers into one package -> ${MERGED_FILE}"

--- a/.gitlab/build/packaging/oci.yml
+++ b/.gitlab/build/packaging/oci.yml
@@ -131,7 +131,7 @@
           tar xJf ${FIPS_INPUT_FILE} -C ${FIPS_INPUT_DIR}
           FIPS_EXTRA_FLAGS="--configs ${FIPS_INPUT_DIR}/etc/datadog-agent --installer ${INSTALLER_INPUT_DIR}/opt/datadog-packages/datadog-installer/${PACKAGE_VERSION}/bin/installer/installer"
           if [ -d "${DDOT_FIPS_EXTENSION_DIR:-/nonexistent}" ]; then
-            FIPS_EXTRA_FLAGS="${FIPS_EXTRA_FLAGS} --extension ddot-fips=${DDOT_FIPS_EXTENSION_DIR}"
+            FIPS_EXTRA_FLAGS="${FIPS_EXTRA_FLAGS} --extension ddot=${DDOT_FIPS_EXTENSION_DIR}"
           fi
           echo "Creating FIPS OCI layer -> ${OUTPUT_DIR}/${FIPS_OUTPUT_FILE}"
           datadog-package create \

--- a/pkg/fleet/installer/env/BUILD.bazel
+++ b/pkg/fleet/installer/env/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["env.go"],
     importpath = "github.com/DataDog/datadog-agent/pkg/fleet/installer/env",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_net//http/httpproxy"],
+    deps = [
+        "//pkg/fips",
+        "@org_golang_x_net//http/httpproxy",
+    ],
 )
 
 go_test(

--- a/pkg/fleet/installer/env/BUILD.bazel
+++ b/pkg/fleet/installer/env/BUILD.bazel
@@ -16,5 +16,8 @@ go_test(
     srcs = ["env_test.go"],
     embed = [":env"],
     gotags = ["test"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "//pkg/fips",
+        "@com_github_stretchr_testify//assert",
+    ],
 )

--- a/pkg/fleet/installer/env/env.go
+++ b/pkg/fleet/installer/env/env.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	"golang.org/x/net/http/httpproxy"
+
+	pkgfips "github.com/DataDog/datadog-agent/pkg/fips"
 )
 
 const (
@@ -276,6 +278,12 @@ func FromEnv() *Env {
 	splitFunc := func(c rune) bool {
 		return c == ','
 	}
+	// thisBinaryIsFips is true when the installer is running as the FIPS-compiled agent binary
+	// (embedded/bin/installer is a symlink to the agent binary in DEB/RPM packages).
+	thisBinaryIsFips, _ := pkgfips.Enabled()
+	// fipsIsRequested is true when the caller explicitly sets DD_FIPS_MODE=true,
+	// which is the signal used by the fleet OCI install path.
+	fipsIsRequested := strings.ToLower(os.Getenv(envFIPSMode)) == "true"
 
 	return &Env{
 		APIKey:               getEnvOrDefault(envAPIKey, defaultEnv.APIKey),
@@ -345,7 +353,7 @@ func FromEnv() *Env {
 
 		IsCentos6:    DetectCentos6(),
 		IsFromDaemon: os.Getenv(envIsFromDaemon) == "true",
-		FIPSMode:     strings.ToLower(os.Getenv(envFIPSMode)) == "true",
+		FIPSMode:     fipsIsRequested || thisBinaryIsFips,
 	}
 }
 

--- a/pkg/fleet/installer/env/env_test.go
+++ b/pkg/fleet/installer/env/env_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	pkgfips "github.com/DataDog/datadog-agent/pkg/fips"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -339,6 +340,10 @@ func TestToEnv(t *testing.T) {
 }
 
 func TestFromEnvFIPSMode(t *testing.T) {
+	thisBinaryIsFips, _ := pkgfips.Enabled()
+	if thisBinaryIsFips {
+		t.Skip("DD_FIPS_MODE env var is irrelevant when the binary itself is FIPS-compiled")
+	}
 	tests := []struct {
 		value    string
 		expected bool

--- a/pkg/fleet/installer/go.mod
+++ b/pkg/fleet/installer/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0
+	github.com/DataDog/datadog-agent/pkg/fips v0.0.0
 	github.com/DataDog/datadog-agent/pkg/template v0.73.2
 	github.com/DataDog/datadog-agent/pkg/util/log v0.73.2
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.68.3

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -501,6 +501,7 @@ func TestNoOutsideImport(t *testing.T) {
 		"pkg/util/winutil", // Needed for Windows
 		"pkg/config/setup", // Needed for extensions
 		"pkg/template",
+		"pkg/fips", // Needed to detect FIPS-compiled binaries at runtime
 	}
 
 	// Walk the directory tree

--- a/releasenotes/notes/fips-ddot-baremetal-446af2ea0ab8dfc8.yaml
+++ b/releasenotes/notes/fips-ddot-baremetal-446af2ea0ab8dfc8.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Fleet installer: When FIPS mode is specified or when the Datadog FIPS Agent is installed via DEB/RPM,
+    with OTel Collector enabled, the installer now automatically selects the
+    FIPS-compiled DDOT (Datadog Distribution of OpenTelemetry) extension from
+    the OCI registry.


### PR DESCRIPTION
### What does this PR do?
1. Remove the now-extraneous fips-ddot extension layer to the non-FIPS installer OCI image
2. Rename the one in the FIPS variant of installer OCI image to `ddot`, making the variant symmetrical
3. Make it so that the install script, having installed the `datadog-fips-agent` rpm/deb, will install the FIPS variant of DDOT during post-install script

### Motivation

[OTAGENT-1010](https://datadoghq.atlassian.net/browse/OTAGENT-1010?atlOrigin=eyJpIjoiM2E4OTI0YzUzNWVlNDlhZThiYjM4ZmE2YTg1YTQ4MzUiLCJwIjoiaiJ9)

### Describe how you validated your changes

I don't know yet how to test this without making a release

### Additional Notes

Context:
- https://github.com/DataDog/datadog-agent/pull/49520
- https://github.com/DataDog/datadog-agent/pull/50604

[OTAGENT-1010]: https://datadoghq.atlassian.net/browse/OTAGENT-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ