### PR TITLE
fix(remoteagentregistry): register collector synchronously on start

### DIFF
--- a/comp/core/remoteagentregistry/impl/registry.go
+++ b/comp/core/remoteagentregistry/impl/registry.go
@@ -76,7 +76,7 @@ func newRegistry(reqs Requires) *remoteAgentRegistry {
 
 	reqs.Lifecycle.Append(compdef.Hook{
 		OnStart: func(context.Context) error {
-			go registry.start()
+			registry.start()
 			return nil
 		},
 		OnStop: func(context.Context) error {


### PR DESCRIPTION
### What does this PR do?

Removes the `go` keyword from `go registry.start()` in `OnStart`, making the call synchronous.

### Motivation

Fixes a flaky test reported in [AGENTRUN-1320](https://datadoghq.atlassian.net/browse/AGENTRUN-1320) and [AGENTRUN-1321](https://datadoghq.atlassian.net/browse/AGENTRUN-1321): `TestMalformedMetricEdgeCases/very_large_histogram_bucket_count` was failing on CI with "Histogram with many buckets should be present", meaning no remote agent metrics were returned by `Gather()`.

`OnStart` calls `go registry.start()` and returns immediately without waiting for it to finish. Inside `start()`, `registerCollector()` registers the custom Prometheus collector responsible for fetching and forwarding remote agent metrics. 

Because `start()` runs in a goroutine, `registerCollector()` may not have been called yet by the time `Gather()` is invoked. In tests, `lc.Start()` triggers `OnStart` and returns immediately, after which the test registers the remote agent and calls Gather() directly. There is no synchronization point between the goroutine and `Gather()`. With no collector registered, `Gather()` returns no remote agent metrics.

This was confirmed by CI logs showing the test failure assertion appearing before `[Info] Remote Agent registry started.`, which is logged inside `start()` after `registerCollector()`:

```
services_test.go:1581: Histogram with many buckets should be present
[Info] Remote Agent registry started.
```

### Describe how you validated your changes

Added an artificial `time.Sleep` right before `registerCollector()` to reliably reproduce the issue locally. The exact failure was stably reproduced with the exact same error message ("Histogram with many buckets should be present"). With the fix applied, all 56 tests in the package passed consistently even with the sleep still in place.

### Additional Notes
Fixes [AGENTRUN-1320](https://datadoghq.atlassian.net/browse/AGENTRUN-1320) and [AGENTRUN-1321](https://datadoghq.atlassian.net/browse/AGENTRUN-1321)