### PR TITLE
[anomalydetection] Rework log config and add per-source rate limiting

### DIFF
--- a/comp/anomalydetection/internal/logsfilter/BUILD.bazel
+++ b/comp/anomalydetection/internal/logsfilter/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "logsfilter",
+    srcs = ["logsfilter.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/internal/logsfilter",
+    visibility = ["//comp/anomalydetection:__subpackages__"],
+)
+
+go_test(
+    name = "logsfilter_test",
+    srcs = ["logsfilter_test.go"],
+    embed = [":logsfilter"],
+    gotags = ["test"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/comp/anomalydetection/internal/logsfilter/logsfilter.go
+++ b/comp/anomalydetection/internal/logsfilter/logsfilter.go
@@ -1,0 +1,141 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package logsfilter provides shared log-filtering primitives (severity
+// bucketing and fixed-window rate limiting) used by both the observer and
+// logssource components of the anomaly-detection subsystem.
+package logsfilter
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// RateWindowDuration is the fixed window size used by RateWindow.
+const RateWindowDuration = 10 * time.Second
+
+// PriorityBucket represents a log's severity level as a comparable integer.
+// Higher value = more severe. The numeric values mirror pkg/util/log/types.LogLevel
+// (itself based on slog.Level) so the ordering is consistent with the agent's
+// own log-level system — copied here to avoid a dependency on that package.
+type PriorityBucket int
+
+const (
+	TracePriority    PriorityBucket = -8 // slog.LevelDebug - 4
+	DebugPriority    PriorityBucket = -4 // slog.LevelDebug
+	InfoPriority     PriorityBucket = 0  // slog.LevelInfo
+	WarnPriority     PriorityBucket = 4  // slog.LevelWarn
+	ErrorPriority    PriorityBucket = 8  // slog.LevelError
+	CriticalPriority PriorityBucket = 12 // slog.LevelError + 4
+	OffPriority      PriorityBucket = 16 // slog.LevelError + 8  — blocks everything
+)
+
+// BucketForStatus maps a log status string to a PriorityBucket.
+// Unrecognised status strings are treated as InfoPriority so they are
+// forwarded under the medium (info) rate budget.
+func BucketForStatus(status string) PriorityBucket {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "emergency", "alert", "critical", "fatal":
+		return CriticalPriority
+	case "error":
+		return ErrorPriority
+	case "warn", "warning", "notice":
+		return WarnPriority
+	case "debug":
+		return DebugPriority
+	case "trace":
+		return TracePriority
+	default: // info, and any unrecognised string
+		return InfoPriority
+	}
+}
+
+// MinBucketForSeverity maps a min_severity config value to the lowest
+// PriorityBucket a log must reach to be forwarded.
+//
+//   - "" (empty) → passes everything (TracePriority - 1)
+//   - "trace" → TracePriority and above
+//   - "debug" → DebugPriority and above
+//   - "info" → InfoPriority and above
+//   - "warn" / "warning" → WarnPriority and above
+//   - "error" → ErrorPriority and above
+//   - "critical" / "fatal" / equivalents → CriticalPriority and above
+//   - "off" → OffPriority (blocks everything)
+//   - unrecognised non-empty string → WarnPriority (safe default)
+func MinBucketForSeverity(minSeverity string) PriorityBucket {
+	switch strings.ToLower(strings.TrimSpace(minSeverity)) {
+	case "":
+		return TracePriority - 1 // below TracePriority → all logs pass
+	case "trace":
+		return TracePriority
+	case "debug":
+		return DebugPriority
+	case "info":
+		return InfoPriority
+	case "warn", "warning":
+		return WarnPriority
+	case "error":
+		return ErrorPriority
+	case "critical", "fatal", "alert", "emergency":
+		return CriticalPriority
+	case "off":
+		return OffPriority
+	default:
+		return WarnPriority // safe default for unrecognised values
+	}
+}
+
+// RateTierForBucket maps a PriorityBucket to one of three rate-limit tiers
+// ("low", "medium", "high") used by the max_rate_* config keys.
+func RateTierForBucket(b PriorityBucket) string {
+	switch {
+	case b >= WarnPriority:
+		return "high"
+	case b >= InfoPriority:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+// RateWindow is a fixed-window rate limiter. It allows at most
+// maxRate * RateWindowDuration.Seconds() messages per window.
+// A maxRate of -1 means unlimited (no cap); 0 drops all messages.
+// The minimum effective rate is 1/RateWindowDuration.Seconds() (0.1/s for a
+// 10-second window); rates below that floor allow at most 1 message per window.
+type RateWindow struct {
+	mu          sync.Mutex
+	windowStart time.Time
+	count       int64
+}
+
+// Allow returns true if the message should be forwarded.
+// maxRatePerSec == -1 means unlimited; 0 drops everything.
+func (w *RateWindow) Allow(maxRatePerSec float64) bool {
+	if maxRatePerSec < 0 {
+		return true
+	}
+	if maxRatePerSec == 0 {
+		return false
+	}
+	// Kept as float64 to avoid silent truncation for sub-0.1/s rates.
+	maxPerWindow := maxRatePerSec * RateWindowDuration.Seconds()
+
+	now := time.Now()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.windowStart.IsZero() || now.Sub(w.windowStart) >= RateWindowDuration {
+		w.windowStart = now
+		w.count = 0
+	}
+
+	if float64(w.count) < maxPerWindow {
+		w.count++
+		return true
+	}
+	return false
+}

--- a/comp/anomalydetection/internal/logsfilter/logsfilter_test.go
+++ b/comp/anomalydetection/internal/logsfilter/logsfilter_test.go
@@ -1,0 +1,143 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package logsfilter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateWindowResetAfterExpiry(t *testing.T) {
+	var w RateWindow
+	for i := 0; i < 10; i++ {
+		assert.True(t, w.Allow(1.0))
+	}
+	assert.False(t, w.Allow(1.0), "window should be full after 10 messages at 1/s")
+
+	w.mu.Lock()
+	w.windowStart = time.Now().Add(-RateWindowDuration - time.Millisecond)
+	w.mu.Unlock()
+
+	assert.True(t, w.Allow(1.0), "should allow after window expires")
+}
+
+func TestPriorityBucketOrdering(t *testing.T) {
+	// Values mirror pkg/util/log/types.LogLevel — verify the ordering is correct.
+	assert.Less(t, int(TracePriority), int(DebugPriority))
+	assert.Less(t, int(DebugPriority), int(InfoPriority))
+	assert.Less(t, int(InfoPriority), int(WarnPriority))
+	assert.Less(t, int(WarnPriority), int(ErrorPriority))
+	assert.Less(t, int(ErrorPriority), int(CriticalPriority))
+	assert.Less(t, int(CriticalPriority), int(OffPriority))
+}
+
+func TestBucketForStatus(t *testing.T) {
+	cases := []struct {
+		status string
+		want   PriorityBucket
+	}{
+		{"trace", TracePriority},
+		{"TRACE", TracePriority},
+		{"debug", DebugPriority},
+		{"info", InfoPriority},
+		{"", InfoPriority}, // unrecognised → info
+		{"unknown", InfoPriority},
+		{"notice", WarnPriority},
+		{"warn", WarnPriority},
+		{"warning", WarnPriority},
+		{"error", ErrorPriority},
+		{"critical", CriticalPriority},
+		{"fatal", CriticalPriority},
+		{"alert", CriticalPriority},
+		{"emergency", CriticalPriority},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, BucketForStatus(tc.status), "BucketForStatus(%q)", tc.status)
+	}
+}
+
+func TestMinBucketForSeverity(t *testing.T) {
+	// empty → below TracePriority (passes everything)
+	assert.Less(t, int(MinBucketForSeverity("")), int(TracePriority))
+
+	assert.Equal(t, TracePriority, MinBucketForSeverity("trace"))
+	assert.Equal(t, DebugPriority, MinBucketForSeverity("debug"))
+	assert.Equal(t, InfoPriority, MinBucketForSeverity("info"))
+	assert.Equal(t, WarnPriority, MinBucketForSeverity("warn"))
+	assert.Equal(t, WarnPriority, MinBucketForSeverity("warning"))
+	assert.Equal(t, ErrorPriority, MinBucketForSeverity("error"))
+	assert.Equal(t, CriticalPriority, MinBucketForSeverity("critical"))
+	assert.Equal(t, CriticalPriority, MinBucketForSeverity("fatal"))
+	assert.Equal(t, OffPriority, MinBucketForSeverity("off"))
+	// unrecognised → WarnPriority (safe default)
+	assert.Equal(t, WarnPriority, MinBucketForSeverity("garbage"))
+}
+
+func TestMinSeverityGatesCorrectly(t *testing.T) {
+	cases := []struct {
+		minSeverity string
+		passStatus  []string
+		dropStatus  []string
+	}{
+		{
+			minSeverity: "trace",
+			passStatus:  []string{"trace", "debug", "info", "warn", "error", "critical"},
+			dropStatus:  []string{},
+		},
+		{
+			minSeverity: "debug",
+			passStatus:  []string{"debug", "info", "warn", "error", "critical"},
+			dropStatus:  []string{"trace"},
+		},
+		{
+			minSeverity: "info",
+			passStatus:  []string{"info", "notice", "warn", "error", "critical"},
+			dropStatus:  []string{"trace", "debug"},
+		},
+		{
+			minSeverity: "warn",
+			passStatus:  []string{"warn", "notice", "error", "critical"},
+			dropStatus:  []string{"trace", "debug", "info"},
+		},
+		{
+			minSeverity: "error",
+			passStatus:  []string{"error", "critical", "fatal"},
+			dropStatus:  []string{"trace", "debug", "info", "warn"},
+		},
+		{
+			minSeverity: "critical",
+			passStatus:  []string{"critical", "fatal", "alert", "emergency"},
+			dropStatus:  []string{"trace", "debug", "info", "warn", "error"},
+		},
+		{
+			minSeverity: "off",
+			passStatus:  []string{},
+			dropStatus:  []string{"trace", "debug", "info", "warn", "error", "critical"},
+		},
+	}
+	for _, tc := range cases {
+		minBucket := MinBucketForSeverity(tc.minSeverity)
+		for _, s := range tc.passStatus {
+			assert.GreaterOrEqual(t, int(BucketForStatus(s)), int(minBucket),
+				"min_severity=%q: %q should pass", tc.minSeverity, s)
+		}
+		for _, s := range tc.dropStatus {
+			assert.Less(t, int(BucketForStatus(s)), int(minBucket),
+				"min_severity=%q: %q should be dropped", tc.minSeverity, s)
+		}
+	}
+}
+
+func TestRateTierForBucket(t *testing.T) {
+	assert.Equal(t, "low", RateTierForBucket(TracePriority))
+	assert.Equal(t, "low", RateTierForBucket(DebugPriority))
+	assert.Equal(t, "medium", RateTierForBucket(InfoPriority))
+	assert.Equal(t, "high", RateTierForBucket(WarnPriority))
+	assert.Equal(t, "high", RateTierForBucket(ErrorPriority))
+	assert.Equal(t, "high", RateTierForBucket(CriticalPriority))
+}

--- a/comp/anomalydetection/logssource/impl/logssource.go
+++ b/comp/anomalydetection/logssource/impl/logssource.go
@@ -117,7 +117,11 @@ func NewComponent(deps Requires) (Provides, error) {
 		pauseFilter = fs.GetContainerPausedFilters()
 	}
 
-	sampler := newLogSamplerFromConfig(deps.Config, nil)
+	var samplerOnDropped func(source, priority string)
+	if obsOk {
+		samplerOnDropped = obs.RecordSamplerDropped
+	}
+	sampler := newLogSamplerFromConfig(deps.Config, samplerOnDropped)
 	pipeline := newObserverPipeline(deps.Config, processingRules, deps.Hostname, observerHandle, sampler)
 	logSources := sources.NewLogSources()
 	tracker := tailers.NewTailerTracker()

--- a/comp/anomalydetection/logssource/impl/logssource.go
+++ b/comp/anomalydetection/logssource/impl/logssource.go
@@ -69,11 +69,11 @@ type logssourceComponent struct{}
 //
 // anomaly_detection.logs.enabled is the main toggle for all log ingestion:
 // setting it to false disables container, kubelet, and agent-internal logs
-// (observer's agent_logs tap).
+// (observer's internal log tap).
 // anomaly_detection.logs.containers.enabled controls workloadmeta generic
 // container sources and AD-scheduled container log configs.
 // anomaly_detection.logs.kubelet.enabled controls the kubelet journald source.
-// anomaly_detection.agent_logs.enabled additionally controls the agent-internal
+// anomaly_detection.logs.internal.enabled additionally controls the agent-internal
 // log tap and defaults to true when logs.enabled is true.
 //
 // The component is a no-op when any of these are true:

--- a/comp/anomalydetection/logssource/impl/logssource.go
+++ b/comp/anomalydetection/logssource/impl/logssource.go
@@ -117,7 +117,8 @@ func NewComponent(deps Requires) (Provides, error) {
 		pauseFilter = fs.GetContainerPausedFilters()
 	}
 
-	pipeline := newObserverPipeline(deps.Config, processingRules, deps.Hostname, observerHandle)
+	sampler := newLogSamplerFromConfig(deps.Config, nil)
+	pipeline := newObserverPipeline(deps.Config, processingRules, deps.Hostname, observerHandle, sampler)
 	logSources := sources.NewLogSources()
 	tracker := tailers.NewTailerTracker()
 	launchersMgr := launchers.NewLaunchers(logSources, pipeline, deps.Auditor, tracker)

--- a/comp/anomalydetection/logssource/impl/pipeline.go
+++ b/comp/anomalydetection/logssource/impl/pipeline.go
@@ -26,6 +26,7 @@ type observerPipeline struct {
 	outputChan     chan *message.Message
 	drainDone      chan struct{}
 	observerHandle observer.Handle
+	sampler        *logSampler
 }
 
 func newObserverPipeline(
@@ -33,6 +34,7 @@ func newObserverPipeline(
 	processingRules []*logsconfig.ProcessingRule,
 	hostname hostnameinterface.Component,
 	observerHandle observer.Handle,
+	sampler *logSampler,
 ) *observerPipeline {
 	chanSize := cfg.GetInt("logs_config.message_channel_size")
 	inputChan := make(chan *message.Message, chanSize)
@@ -56,6 +58,7 @@ func newObserverPipeline(
 		outputChan:     outputChan,
 		drainDone:      make(chan struct{}),
 		observerHandle: observerHandle,
+		sampler:        sampler,
 	}
 }
 
@@ -66,7 +69,9 @@ func (p *observerPipeline) start() {
 	go func() {
 		defer close(p.drainDone)
 		for msg := range p.outputChan {
-			p.observerHandle.ObserveLog(&messageLogView{msg: msg})
+			if p.sampler == nil || p.sampler.ShouldForward(msg) {
+				p.observerHandle.ObserveLog(&messageLogView{msg: msg})
+			}
 		}
 	}()
 	p.proc.Start()

--- a/comp/anomalydetection/logssource/impl/sampling.go
+++ b/comp/anomalydetection/logssource/impl/sampling.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package logssourceimpl
+
+import (
+	"github.com/DataDog/datadog-agent/comp/anomalydetection/internal/logsfilter"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// sourceRateLimits holds the min_severity gate and per-priority max rates for
+// one log source. MaxRate values are in logs/second; -1 means unlimited, 0 drops all.
+type sourceRateLimits struct {
+	minSeverity   string
+	maxRateHigh   float64 // logs/s for high-priority (warn and above); -1 = unlimited, 0 = drop all
+	maxRateMedium float64 // logs/s for medium-priority (info); -1 = unlimited, 0 = drop all
+	maxRateLow    float64 // logs/s for low-priority (trace/debug); -1 = unlimited, 0 = drop all
+}
+
+// logSampler applies per-source min_severity gating and rate limiting to log
+// messages before they are forwarded to the observer. A fixed 10-second window
+// is used per (source, priority) pair.
+type logSampler struct {
+	kubelet    sourceRateLimits
+	containers sourceRateLimits
+
+	kubeletHigh     logsfilter.RateWindow
+	kubeletMedium   logsfilter.RateWindow
+	kubeletLow      logsfilter.RateWindow
+	containerHigh   logsfilter.RateWindow
+	containerMedium logsfilter.RateWindow
+	containerLow    logsfilter.RateWindow
+
+	// onDropped is called with (source, priority) when a log is dropped by the
+	// rate limiter. It does NOT fire for min_severity drops. May be nil.
+	onDropped func(source, priority string)
+}
+
+// newLogSampler constructs a logSampler. onDropped is called on every
+// rate-limit drop and may be nil.
+func newLogSampler(kubelet, containers sourceRateLimits, onDropped func(source, priority string)) *logSampler {
+	return &logSampler{
+		kubelet:    kubelet,
+		containers: containers,
+		onDropped:  onDropped,
+	}
+}
+
+// newLogSamplerFromConfig reads anomaly_detection.logs.kubelet.* and
+// anomaly_detection.logs.containers.* from the agent config and returns a
+// logSampler ready for use. onDropped is wired to the observer component so
+// rate-limit drops are recorded in the shared sampler_dropped counter.
+func newLogSamplerFromConfig(cfg pkgconfigmodel.Reader, onDropped func(source, priority string)) *logSampler {
+	kubelet := sourceRateLimits{
+		minSeverity:   cfg.GetString("anomaly_detection.logs.kubelet.min_severity"),
+		maxRateHigh:   cfg.GetFloat64("anomaly_detection.logs.kubelet.max_rate_high_priority"),
+		maxRateMedium: cfg.GetFloat64("anomaly_detection.logs.kubelet.max_rate_medium_priority"),
+		maxRateLow:    cfg.GetFloat64("anomaly_detection.logs.kubelet.max_rate_low_priority"),
+	}
+	containers := sourceRateLimits{
+		minSeverity:   cfg.GetString("anomaly_detection.logs.containers.min_severity"),
+		maxRateHigh:   cfg.GetFloat64("anomaly_detection.logs.containers.max_rate_high_priority"),
+		maxRateMedium: cfg.GetFloat64("anomaly_detection.logs.containers.max_rate_medium_priority"),
+		maxRateLow:    cfg.GetFloat64("anomaly_detection.logs.containers.max_rate_low_priority"),
+	}
+	return newLogSampler(kubelet, containers, onDropped)
+}
+
+// ShouldForward returns true if the message should be forwarded to the observer.
+// Source is detected via the "source:kubelet" tag injected by kubelet_source.go;
+// everything else is treated as a container log.
+func (s *logSampler) ShouldForward(msg *message.Message) bool {
+	if isKubeletMessage(msg) {
+		return s.shouldForwardSource(msg.GetStatus(), s.kubelet, "kubelet",
+			&s.kubeletHigh, &s.kubeletMedium, &s.kubeletLow)
+	}
+	return s.shouldForwardSource(msg.GetStatus(), s.containers, "containers",
+		&s.containerHigh, &s.containerMedium, &s.containerLow)
+}
+
+func (s *logSampler) shouldForwardSource(status string, limits sourceRateLimits, source string, highW, mediumW, lowW *logsfilter.RateWindow) bool {
+	bucket := logsfilter.BucketForStatus(status)
+	if bucket < logsfilter.MinBucketForSeverity(limits.minSeverity) {
+		return false
+	}
+	tier := logsfilter.RateTierForBucket(bucket)
+	var allowed bool
+	switch tier {
+	case "high":
+		allowed = highW.Allow(limits.maxRateHigh)
+	case "medium":
+		allowed = mediumW.Allow(limits.maxRateMedium)
+	default:
+		allowed = lowW.Allow(limits.maxRateLow)
+	}
+	if allowed {
+		return true
+	}
+	if s.onDropped != nil {
+		s.onDropped(source, tier)
+	}
+	return false
+}
+
+// isKubeletMessage reports whether msg originates from the kubelet journald source.
+func isKubeletMessage(msg *message.Message) bool {
+	for _, t := range msg.Tags() {
+		if t == "source:kubelet" {
+			return true
+		}
+	}
+	return false
+}

--- a/comp/anomalydetection/logssource/impl/sampling_test.go
+++ b/comp/anomalydetection/logssource/impl/sampling_test.go
@@ -168,14 +168,16 @@ func TestShouldForwardRateLimitTriggerOnDropped(t *testing.T) {
 	s := newLogSampler(limits, limits, onDropped)
 
 	for i := 0; i < 20; i++ {
-		s.ShouldForward(newMsg("warn"))  // high tier
-		s.ShouldForward(newMsg("info"))  // medium tier
-		s.ShouldForward(newMsg("debug")) // low tier
+		s.ShouldForward(newMsg("warn"))                   // high tier
+		s.ShouldForward(newMsg("info"))                   // medium tier
+		s.ShouldForward(newMsg("debug"))                  // low tier
+		s.ShouldForward(newMsg("warn", "source:kubelet")) // high tier + kubelet
 	}
 
 	assert.Equal(t, 10, drops["containers/high"], "10 high-tier drops expected")
 	assert.Equal(t, 10, drops["containers/medium"], "10 medium-tier drops expected")
 	assert.Equal(t, 10, drops["containers/low"], "10 low-tier drops expected")
+	assert.Equal(t, 10, drops["kubelet/high"], "10 high-tier drops expected for kubelet")
 }
 
 func TestShouldForwardSeverityFilteredDropsDoNotFireOnDropped(t *testing.T) {

--- a/comp/anomalydetection/logssource/impl/sampling_test.go
+++ b/comp/anomalydetection/logssource/impl/sampling_test.go
@@ -1,0 +1,205 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package logssourceimpl
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/anomalydetection/internal/logsfilter"
+	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/stretchr/testify/assert"
+)
+
+// newMsg returns a minimal message with the given status and optional extra tags.
+// A non-nil LogsConfig is required to avoid nil-pointer dereference in Origin.Tags().
+func newMsg(status string, tags ...string) *message.Message {
+	src := sources.NewLogSource("test", &logsconfig.LogsConfig{})
+	origin := message.NewOrigin(src)
+	origin.SetTags(tags)
+	return message.NewMessage([]byte("test"), origin, status, 0)
+}
+
+// --- logsfilter.RateWindow ---
+
+func TestRateWindowUnlimited(t *testing.T) {
+	var w logsfilter.RateWindow
+	for i := 0; i < 1000; i++ {
+		assert.True(t, w.Allow(-1), "unlimited (-1) should always allow")
+	}
+}
+
+func TestRateWindowDropAll(t *testing.T) {
+	var w logsfilter.RateWindow
+	for i := 0; i < 10; i++ {
+		assert.False(t, w.Allow(0), "rate=0 should drop everything")
+	}
+}
+
+func TestRateWindowCapEnforced(t *testing.T) {
+	var w logsfilter.RateWindow
+	// 5/s over 10s window = 50 messages per window
+	allowed := 0
+	for i := 0; i < 100; i++ {
+		if w.Allow(5.0) {
+			allowed++
+		}
+	}
+	assert.Equal(t, 50, allowed, "exactly 50 messages should be allowed in a 10s window at 5/s")
+}
+
+func TestRateWindowExhausted(t *testing.T) {
+	var w logsfilter.RateWindow
+	// Allow 1/s (10 per window), exhaust the window, verify the 11th is blocked.
+	for i := 0; i < 10; i++ {
+		assert.True(t, w.Allow(1.0))
+	}
+	assert.False(t, w.Allow(1.0), "window should be full after 10 messages")
+	// Window-reset behaviour after expiry is covered by logsfilter_test.go.
+}
+
+func TestRateWindowSubTenthPerSecond(t *testing.T) {
+	var w logsfilter.RateWindow
+	// 0.05/s → maxPerWindow = 0.5 → only 1 message allowed per window
+	assert.True(t, w.Allow(0.05), "first message should pass")
+	assert.False(t, w.Allow(0.05), "second message should be dropped (floor: 1/window)")
+}
+
+// --- logSampler / ShouldForward ---
+
+func TestShouldForwardTraceTreatedLikeDebug(t *testing.T) {
+	// With no min_severity filtering, trace passes just like debug.
+	s := newLogSampler(
+		sourceRateLimits{maxRateHigh: -1, maxRateMedium: -1, maxRateLow: -1},
+		sourceRateLimits{maxRateHigh: -1, maxRateMedium: -1, maxRateLow: -1},
+		nil,
+	)
+	assert.True(t, s.ShouldForward(newMsg("trace")), "trace must pass when no min_severity gate")
+	assert.True(t, s.ShouldForward(newMsg("debug")), "debug must pass when no min_severity gate")
+}
+
+func TestShouldForwardMinSeverityAllLevels(t *testing.T) {
+	cases := []struct {
+		minSeverity string
+		pass        []string
+		drop        []string
+	}{
+		{
+			minSeverity: "trace",
+			pass:        []string{"trace", "debug", "info", "warn", "error", "critical"},
+			drop:        []string{},
+		},
+		{
+			minSeverity: "debug",
+			pass:        []string{"debug", "info", "warn", "error"},
+			drop:        []string{"trace"},
+		},
+		{
+			minSeverity: "warn",
+			pass:        []string{"warn", "error", "critical"},
+			drop:        []string{"trace", "debug", "info"},
+		},
+		{
+			minSeverity: "error",
+			pass:        []string{"error", "critical", "fatal"},
+			drop:        []string{"trace", "debug", "info", "warn"},
+		},
+	}
+	for _, tc := range cases {
+		limits := sourceRateLimits{minSeverity: tc.minSeverity, maxRateHigh: -1, maxRateMedium: -1, maxRateLow: -1}
+		s := newLogSampler(limits, limits, nil)
+		for _, status := range tc.pass {
+			assert.True(t, s.ShouldForward(newMsg(status)), "min_severity=%q: %q should pass", tc.minSeverity, status)
+		}
+		for _, status := range tc.drop {
+			assert.False(t, s.ShouldForward(newMsg(status)), "min_severity=%q: %q should be dropped", tc.minSeverity, status)
+		}
+	}
+}
+
+func TestShouldForwardUnlimitedPassesAll(t *testing.T) {
+	s := newLogSampler(
+		sourceRateLimits{maxRateHigh: -1, maxRateMedium: -1, maxRateLow: -1},
+		sourceRateLimits{maxRateHigh: -1, maxRateMedium: -1, maxRateLow: -1},
+		nil,
+	)
+	for _, status := range []string{"trace", "debug", "info", "warn", "error", "critical"} {
+		assert.True(t, s.ShouldForward(newMsg(status)), "unlimited: %s should pass", status)
+	}
+}
+
+func TestShouldForwardMinSeverityGate(t *testing.T) {
+	limits := sourceRateLimits{
+		minSeverity:   "warn",
+		maxRateHigh:   -1,
+		maxRateMedium: -1,
+		maxRateLow:    -1,
+	}
+	s := newLogSampler(limits, limits, nil)
+
+	assert.False(t, s.ShouldForward(newMsg("debug")))
+	assert.False(t, s.ShouldForward(newMsg("info")))
+	assert.True(t, s.ShouldForward(newMsg("warn")))
+	assert.True(t, s.ShouldForward(newMsg("error")))
+}
+
+func TestShouldForwardKubeletVsContainer(t *testing.T) {
+	kubeletLimits := sourceRateLimits{maxRateHigh: -1, maxRateMedium: -1, maxRateLow: 0} // drop debug for kubelet
+	containerLimits := sourceRateLimits{maxRateHigh: -1, maxRateMedium: -1, maxRateLow: -1}
+	s := newLogSampler(kubeletLimits, containerLimits, nil)
+
+	kubeletMsg := newMsg("debug", "source:kubelet")
+	containerMsg := newMsg("debug") // no kubelet tag
+
+	assert.False(t, s.ShouldForward(kubeletMsg), "kubelet debug dropped by kubelet limits")
+	assert.True(t, s.ShouldForward(containerMsg), "container debug passes container limits")
+}
+
+func TestShouldForwardRateLimitTriggerOnDropped(t *testing.T) {
+	drops := map[string]int{}
+	onDropped := func(source, priority string) {
+		drops[source+"/"+priority]++
+	}
+	limits := sourceRateLimits{maxRateHigh: 1.0, maxRateMedium: 1.0, maxRateLow: 1.0} // 10/window each
+	s := newLogSampler(limits, limits, onDropped)
+
+	for i := 0; i < 20; i++ {
+		s.ShouldForward(newMsg("warn"))  // high tier
+		s.ShouldForward(newMsg("info"))  // medium tier
+		s.ShouldForward(newMsg("debug")) // low tier
+	}
+
+	assert.Equal(t, 10, drops["containers/high"], "10 high-tier drops expected")
+	assert.Equal(t, 10, drops["containers/medium"], "10 medium-tier drops expected")
+	assert.Equal(t, 10, drops["containers/low"], "10 low-tier drops expected")
+}
+
+func TestShouldForwardSeverityFilteredDropsDoNotFireOnDropped(t *testing.T) {
+	var dropped []string
+	onDropped := func(_ string, priority string) {
+		dropped = append(dropped, priority)
+	}
+	// min_severity="warn": trace/debug/info are filtered before reaching the rate limiter
+	limits := sourceRateLimits{minSeverity: "warn", maxRateHigh: -1, maxRateMedium: -1, maxRateLow: -1}
+	s := newLogSampler(limits, limits, onDropped)
+
+	for i := 0; i < 50; i++ {
+		s.ShouldForward(newMsg("trace"))
+		s.ShouldForward(newMsg("debug"))
+		s.ShouldForward(newMsg("info"))
+	}
+
+	assert.Empty(t, dropped, "severity-filtered drops must never fire onDropped")
+}
+
+func TestShouldForwardDropAllRate(t *testing.T) {
+	limits := sourceRateLimits{maxRateHigh: 0, maxRateMedium: 0, maxRateLow: 0}
+	s := newLogSampler(limits, limits, nil)
+	assert.False(t, s.ShouldForward(newMsg("warn")))
+	assert.False(t, s.ShouldForward(newMsg("info")))
+	assert.False(t, s.ShouldForward(newMsg("debug")))
+}

--- a/comp/anomalydetection/observer/def/component.go
+++ b/comp/anomalydetection/observer/def/component.go
@@ -18,6 +18,12 @@ type Component interface {
 	// The source name is used to identify where observations originate.
 	GetHandle(name string) Handle
 
+	// RecordSamplerDropped increments the rate-limiter dropped counter for the
+	// given source ("internal", "kubelet", "containers") and priority ("high",
+	// "medium", "low"). Only rate-limit drops are counted; min_severity drops
+	// are intentional and not tracked here.
+	RecordSamplerDropped(source, priority string)
+
 	// DumpMetrics writes all stored metrics to the specified file (for debugging).
 	DumpMetrics(path string) error
 }

--- a/comp/anomalydetection/observer/impl/BUILD.bazel
+++ b/comp/anomalydetection/observer/impl/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/impl",
     visibility = ["//visibility:public"],
     deps = [
+        "//comp/anomalydetection/internal/logsfilter",
         "//comp/anomalydetection/observer/def",
         "//comp/anomalydetection/observer/impl/patterns",
         "//comp/anomalydetection/recorder/def",

--- a/comp/anomalydetection/observer/impl/agent_logs.go
+++ b/comp/anomalydetection/observer/impl/agent_logs.go
@@ -8,37 +8,53 @@ package observerimpl
 import (
 	"encoding/json"
 	"strings"
-	"sync/atomic"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/anomalydetection/internal/logsfilter"
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // installAgentLogTap registers a pkg/util/log observer that forwards agent-internal
-// log lines into the observer pipeline.  WARN/ERROR/CRITICAL are always forwarded;
-// INFO/DEBUG/TRACE are sampled at the provided rates (0.0–1.0).
-func installAgentLogTap(handle observerdef.Handle, sampleInfo, sampleDebug, sampleTrace float64) {
+// log lines into the observer pipeline. Logs below minSeverity are dropped before
+// any rate-limiting. The three max rates are in logs/second over a 10-second
+// window: maxRateHigh (warn/error/critical), maxRateMedium (info), maxRateLow
+// (trace/debug). -1 means unlimited; 0 drops all.
+// onDropped is called with the priority bucket name ("high", "medium", "low")
+// when a log is dropped by the rate limiter. It is NOT called for min_severity
+// drops. It may be nil.
+func installAgentLogTap(handle observerdef.Handle, minSeverity string, maxRateHigh, maxRateMedium, maxRateLow float64, onDropped func(priority string)) {
 	baseTags := []string{"source:datadog-agent"}
+	minBucket := logsfilter.MinBucketForSeverity(minSeverity)
 
-	var infoN, debugN, traceN uint64
-	shouldSample := func(level pkglog.LogLevel) bool {
-		switch level {
-		case pkglog.WarnLvl, pkglog.ErrorLvl, pkglog.CriticalLvl:
-			return true
-		case pkglog.InfoLvl:
-			return samplePass(sampleInfo, atomic.AddUint64(&infoN, 1))
-		case pkglog.DebugLvl:
-			return samplePass(sampleDebug, atomic.AddUint64(&debugN, 1))
-		case pkglog.TraceLvl:
-			return samplePass(sampleTrace, atomic.AddUint64(&traceN, 1))
-		default:
-			return samplePass(sampleInfo, atomic.AddUint64(&infoN, 1))
+	var highW, mediumW, lowW logsfilter.RateWindow
+	shouldForward := func(level pkglog.LogLevel) (bool, string) {
+		bucket := logsfilter.BucketForStatus(strings.ToLower(level.String()))
+		if bucket < minBucket {
+			return false, "" // severity-filtered: intentional, not counted as rate-limit drop
 		}
+		tier := logsfilter.RateTierForBucket(bucket)
+		var allowed bool
+		switch tier {
+		case "high":
+			allowed = highW.Allow(maxRateHigh)
+		case "medium":
+			allowed = mediumW.Allow(maxRateMedium)
+		default:
+			allowed = lowW.Allow(maxRateLow)
+		}
+		if allowed {
+			return true, ""
+		}
+		return false, tier
 	}
 
 	pkglog.SetLogObserver(func(level pkglog.LogLevel, message string) {
-		if !shouldSample(level) {
+		forward, droppedPriority := shouldForward(level)
+		if !forward {
+			if droppedPriority != "" && onDropped != nil {
+				onDropped(droppedPriority)
+			}
 			return
 		}
 		tags := make([]string, 0, 3)
@@ -58,23 +74,6 @@ func installAgentLogTap(handle observerdef.Handle, sampleInfo, sampleDebug, samp
 			timestampMs: time.Now().UnixMilli(),
 		})
 	})
-}
-
-// samplePass returns true at approximately rate (0.0–1.0) of calls, using a
-// deterministic modulo counter so the sampling distribution is even.
-func samplePass(rate float64, n uint64) bool {
-	if rate <= 0 {
-		return false
-	}
-	if rate >= 1 {
-		return true
-	}
-	const denom = 1000
-	threshold := uint64(rate * denom)
-	if threshold == 0 {
-		threshold = 1
-	}
-	return (n % denom) < threshold
 }
 
 // agentLogView is a minimal observerdef.LogView implementation for agent-internal logs.

--- a/comp/anomalydetection/observer/impl/agent_logs_test.go
+++ b/comp/anomalydetection/observer/impl/agent_logs_test.go
@@ -38,7 +38,8 @@ func TestInstallAgentLogTap(t *testing.T) {
 	t.Cleanup(func() { pkglog.SetLogObserver(nil) })
 
 	h := &captureHandle{}
-	installAgentLogTap(h, 1.0, 1.0, 1.0) // all rates = 1.0 → forward everything
+	// -1 = unlimited for all priorities, no min_severity → forward everything including trace
+	installAgentLogTap(h, "", -1, -1, -1, nil)
 
 	simulateLogEmit(pkglog.InfoLvl, "test info message")
 	simulateLogEmit(pkglog.WarnLvl, "test warn message")
@@ -62,69 +63,147 @@ func TestInstallAgentLogTap(t *testing.T) {
 	assert.Equal(t, "debug", h.logs[2].GetStatus())
 }
 
-func TestInstallAgentLogTapSampling(t *testing.T) {
+func TestInstallAgentLogTapTraceTreatedLikeDebug(t *testing.T) {
 	t.Cleanup(func() { pkglog.SetLogObserver(nil) })
 
 	h := &captureHandle{}
-	// Only forward WARN+ and 50% of INFO; block all DEBUG/TRACE
-	installAgentLogTap(h, 0.5, 0.0, 0.0)
+	// min_severity="" → no filtering; trace falls into the low-priority bucket (same as debug).
+	installAgentLogTap(h, "", -1, -1, -1, nil)
 
-	// Emit 1000 INFO lines — roughly 500 should pass
-	for i := 0; i < 1000; i++ {
+	simulateLogEmit(pkglog.TraceLvl, "trace message")
+	simulateLogEmit(pkglog.DebugLvl, "debug message")
+	simulateLogEmit(pkglog.InfoLvl, "info message")
+
+	require.Len(t, h.logs, 3, "trace, debug, and info must all be forwarded when min_severity is empty")
+	assert.Equal(t, "trace", h.logs[0].GetStatus())
+	assert.Equal(t, "debug", h.logs[1].GetStatus())
+	assert.Equal(t, "info", h.logs[2].GetStatus())
+}
+
+func TestInstallAgentLogTapTraceFilteredByMinSeverity(t *testing.T) {
+	t.Cleanup(func() { pkglog.SetLogObserver(nil) })
+
+	h := &captureHandle{}
+	var droppedPriorities []string
+	// min_severity="warn" (default) → trace and debug are filtered before rate-limiting.
+	installAgentLogTap(h, "warn", -1, -1, -1, func(priority string) {
+		droppedPriorities = append(droppedPriorities, priority)
+	})
+
+	simulateLogEmit(pkglog.TraceLvl, "trace message")
+	simulateLogEmit(pkglog.DebugLvl, "debug message")
+	simulateLogEmit(pkglog.WarnLvl, "warn message")
+
+	assert.Len(t, h.logs, 1, "only warn should be forwarded with min_severity=warn")
+	assert.Equal(t, "warn", h.logs[0].GetStatus())
+	assert.Empty(t, droppedPriorities, "severity-filtered drops must not trigger onDropped")
+}
+
+func TestInstallAgentLogTapDebugMinSeverity(t *testing.T) {
+	t.Cleanup(func() { pkglog.SetLogObserver(nil) })
+
+	h := &captureHandle{}
+	// min_severity="debug" → trace is filtered out, debug and above pass.
+	installAgentLogTap(h, "debug", -1, -1, -1, nil)
+
+	simulateLogEmit(pkglog.TraceLvl, "trace message")
+	simulateLogEmit(pkglog.DebugLvl, "debug message")
+	simulateLogEmit(pkglog.InfoLvl, "info message")
+
+	require.Len(t, h.logs, 2, "debug and info should pass; trace should be filtered")
+	assert.Equal(t, "debug", h.logs[0].GetStatus())
+	assert.Equal(t, "info", h.logs[1].GetStatus())
+}
+
+func TestInstallAgentLogTapSeverityFilterDoesNotTriggerOnDropped(t *testing.T) {
+	t.Cleanup(func() { pkglog.SetLogObserver(nil) })
+
+	var dropped []string
+	h := &captureHandle{}
+	installAgentLogTap(h, "error", -1, -1, -1, func(priority string) {
+		dropped = append(dropped, priority)
+	})
+
+	simulateLogEmit(pkglog.TraceLvl, "trace")
+	simulateLogEmit(pkglog.DebugLvl, "debug")
+	simulateLogEmit(pkglog.InfoLvl, "info")
+	simulateLogEmit(pkglog.WarnLvl, "warn")
+
+	assert.Empty(t, h.logs, "no logs should be forwarded below min_severity=error")
+	assert.Empty(t, dropped, "severity-filtered drops must not fire onDropped")
+}
+
+func TestInstallAgentLogTapErrorMinSeverity(t *testing.T) {
+	t.Cleanup(func() { pkglog.SetLogObserver(nil) })
+
+	h := &captureHandle{}
+	// min_severity="error" → only error/critical pass; warn is filtered out.
+	installAgentLogTap(h, "error", -1, -1, -1, nil)
+
+	simulateLogEmit(pkglog.WarnLvl, "warn message")
+	simulateLogEmit(pkglog.ErrorLvl, "error message")
+	simulateLogEmit(pkglog.CriticalLvl, "critical message")
+
+	require.Len(t, h.logs, 2, "only error and critical should pass min_severity=error")
+	assert.Equal(t, "error", h.logs[0].GetStatus())
+	assert.Equal(t, "critical", h.logs[1].GetStatus())
+}
+
+func TestInstallAgentLogTapRateLimit(t *testing.T) {
+	t.Cleanup(func() { pkglog.SetLogObserver(nil) })
+
+	var droppedPriorities []string
+	h := &captureHandle{}
+	// maxRateHigh=-1 (unlimited), maxRateMedium=10 (→100 per 10s window), maxRateLow=0.1 (→1 per 10s window)
+	installAgentLogTap(h, "", -1, 10, 0.1, func(priority string) {
+		droppedPriorities = append(droppedPriorities, priority)
+	})
+
+	// Emit 200 INFO — should be capped at 100 (10 logs/s × 10s window)
+	for i := 0; i < 200; i++ {
 		simulateLogEmit(pkglog.InfoLvl, "info")
 	}
-	// DEBUG should be completely dropped
-	for i := 0; i < 100; i++ {
+	// Emit 10 DEBUG — should be capped at 1 (0.1 logs/s × 10s window)
+	for i := 0; i < 10; i++ {
 		simulateLogEmit(pkglog.DebugLvl, "debug")
 	}
-	// WARN always passes
-	simulateLogEmit(pkglog.WarnLvl, "warn")
-	simulateLogEmit(pkglog.ErrorLvl, "error")
-	simulateLogEmit(pkglog.CriticalLvl, "critical")
+	// Emit 50 WARN — should all pass (unlimited)
+	for i := 0; i < 50; i++ {
+		simulateLogEmit(pkglog.WarnLvl, "warn")
+	}
 
-	infoCount := 0
+	var infoCount, debugCount, warnCount int
 	for _, l := range h.logs {
-		if l.GetStatus() == "info" {
+		switch l.GetStatus() {
+		case "info":
 			infoCount++
+		case "debug":
+			debugCount++
+		case "warn":
+			warnCount++
 		}
 	}
-	// ~500 info, 0 debug, 3 warn+
-	assert.InDelta(t, 500, infoCount, 50, "expected ~50%% of INFO to be sampled")
 
-	// No debug should pass
-	for _, l := range h.logs {
-		assert.NotEqual(t, "debug", l.GetStatus())
-	}
+	assert.Equal(t, 100, infoCount, "info should be rate-limited to 100 per 10s window")
+	assert.Equal(t, 1, debugCount, "debug should be rate-limited to 1 per 10s window")
+	assert.Equal(t, 50, warnCount, "warn should not be rate-limited (unlimited)")
 
-	// All warn/error/critical should pass
-	warnish := 0
-	for _, l := range h.logs {
-		s := l.GetStatus()
-		if s == "warn" || s == "error" || s == "critical" {
-			warnish++
+	// Verify onDropped was called for rate-limited logs
+	mediumDropped := 0
+	lowDropped := 0
+	for _, p := range droppedPriorities {
+		switch p {
+		case "medium":
+			mediumDropped++
+		case "low":
+			lowDropped++
 		}
 	}
-	assert.Equal(t, 3, warnish)
+	assert.Equal(t, 100, mediumDropped, "100 info logs should have fired onDropped(medium)")
+	assert.Equal(t, 9, lowDropped, "9 debug logs should have fired onDropped(low)")
 }
 
-func TestSamplePass(t *testing.T) {
-	// rate=0 → never pass
-	for n := uint64(1); n <= 10; n++ {
-		assert.False(t, samplePass(0, n))
-	}
-	// rate=1 → always pass
-	for n := uint64(1); n <= 10; n++ {
-		assert.True(t, samplePass(1.0, n))
-	}
-	// rate=0.5 → roughly half
-	passes := 0
-	for n := uint64(1); n <= 1000; n++ {
-		if samplePass(0.5, n) {
-			passes++
-		}
-	}
-	assert.InDelta(t, 500, passes, 10)
-}
+// RateWindow unit tests live in comp/anomalydetection/internal/logsfilter/logsfilter_test.go.
 
 // simulateLogEmit calls the registered LogObserver directly, simulating what
 // maybeObserve does inside pkg/util/log at every emit site.

--- a/comp/anomalydetection/observer/impl/ingest_metrics_disabled_test.go
+++ b/comp/anomalydetection/observer/impl/ingest_metrics_disabled_test.go
@@ -69,8 +69,8 @@ func TestObserverDropsMetricsWhenIngestMetricsDisabled(t *testing.T) {
 	})
 
 	drop.ObserveLog(&logObs{
-		content:     "Request completed in 45ms",
-		status:      "info",
+		content:     "Request failed with unexpected error",
+		status:      "error",
 		tags:        []string{"service:web"},
 		timestampMs: 1_000_000,
 	})

--- a/comp/anomalydetection/observer/impl/log_pattern_extractor.go
+++ b/comp/anomalydetection/observer/impl/log_pattern_extractor.go
@@ -6,7 +6,6 @@
 package observerimpl
 
 import (
-	"strings"
 	"time"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
@@ -177,17 +176,6 @@ func (e *LogPatternExtractor) SetObserverTelemetry(t *observerTelemetry) {
 	e.telemetry = t
 }
 
-// logSeverityIsWarnPlus returns true when the log should be clustered: warning
-func logSeverityIsWarnPlus(log observerdef.LogView) bool {
-	status := strings.ToLower(strings.TrimSpace(log.GetStatus()))
-	switch status {
-	case "warn", "warning", "error", "critical", "fatal", "alert", "emergency":
-		return true
-	default:
-		return false
-	}
-}
-
 // ProcessLog clusters the log message and emits a count metric for its pattern.
 func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) observerdef.LogMetricsExtractorOutput {
 	logUnixSec := log.GetTimestampUnixMilli() / 1000
@@ -200,9 +188,6 @@ func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) observerdef.Lo
 	}
 	if gc.clustersEvicted > 0 && e.telemetry != nil {
 		e.telemetry.recordLogPatternCountDelta(e.Name(), -float64(gc.clustersEvicted))
-	}
-	if !logSeverityIsWarnPlus(log) {
-		return result
 	}
 	message := log.GetContent()
 	groupTags := tagsForPatternGrouping(log.Tags(), log.GetHostname())

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -286,10 +286,10 @@ func NewComponent(deps Requires) Provides {
 
 	// Wire agent-internal logs into the observer via the pkg/util/log tap.
 	// anomaly_detection.logs.enabled is the parent gate; without it,
-	// agent_logs are also disabled. anomaly_detection.agent_logs.enabled
+	// internal logs are also disabled. anomaly_detection.logs.internal.enabled
 	// defaults to true when unset (explicit false disables it).
 	logsEnabled := !cfg.IsConfigured("anomaly_detection.logs.enabled") || cfg.GetBool("anomaly_detection.logs.enabled")
-	agentLogsEnabled := !cfg.IsConfigured("anomaly_detection.agent_logs.enabled") || cfg.GetBool("anomaly_detection.agent_logs.enabled")
+	agentLogsEnabled := !cfg.IsConfigured("anomaly_detection.logs.internal.enabled") || cfg.GetBool("anomaly_detection.logs.internal.enabled")
 	if (analysisEnabled || recorderEnabled) && logsEnabled && agentLogsEnabled {
 		sampleInfo := cfg.GetFloat64("anomaly_detection.agent_logs.sample_rate_info")
 		sampleDebug := cfg.GetFloat64("anomaly_detection.agent_logs.sample_rate_debug")

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -162,6 +162,7 @@ func settingsFromAgentConfig(catalog *componentCatalog, cfg config.Component) Co
 type disabledObserver struct{}
 
 func (*disabledObserver) GetHandle(_ string) observerdef.Handle { return &noopObserveHandle{} }
+func (*disabledObserver) RecordSamplerDropped(_, _ string)      {}
 func (*disabledObserver) DumpMetrics(_ string) error            { return nil }
 
 // NewComponent creates an observer.Component.
@@ -595,6 +596,12 @@ func (h *noopObserveHandle) ObserveMetricAndReportDrop(_ observerdef.MetricView)
 }
 func (h *noopObserveHandle) ObserveLog(_ observerdef.LogView) {}
 
+// RecordSamplerDropped increments the rate-limiter dropped counter.
+func (o *observerImpl) RecordSamplerDropped(source, priority string) {
+	if o.telemetry != nil {
+		o.telemetry.recordSamplerDropped(source, priority)
+	}
+}
 
 // DumpMetrics writes all stored metrics to the specified file as JSON.
 func (o *observerImpl) DumpMetrics(path string) error {

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -291,11 +291,14 @@ func NewComponent(deps Requires) Provides {
 	logsEnabled := !cfg.IsConfigured("anomaly_detection.logs.enabled") || cfg.GetBool("anomaly_detection.logs.enabled")
 	agentLogsEnabled := !cfg.IsConfigured("anomaly_detection.logs.internal.enabled") || cfg.GetBool("anomaly_detection.logs.internal.enabled")
 	if (analysisEnabled || recorderEnabled) && logsEnabled && agentLogsEnabled {
-		sampleInfo := cfg.GetFloat64("anomaly_detection.agent_logs.sample_rate_info")
-		sampleDebug := cfg.GetFloat64("anomaly_detection.agent_logs.sample_rate_debug")
-		sampleTrace := cfg.GetFloat64("anomaly_detection.agent_logs.sample_rate_trace")
+		minSeverity := cfg.GetString("anomaly_detection.logs.internal.min_severity")
+		maxRateHigh := cfg.GetFloat64("anomaly_detection.logs.internal.max_rate_high_priority")
+		maxRateMedium := cfg.GetFloat64("anomaly_detection.logs.internal.max_rate_medium_priority")
+		maxRateLow := cfg.GetFloat64("anomaly_detection.logs.internal.max_rate_low_priority")
 		agentLogsHandle := obs.GetHandle("agent-internal-logs")
-		installAgentLogTap(agentLogsHandle, sampleInfo, sampleDebug, sampleTrace)
+		installAgentLogTap(agentLogsHandle, minSeverity, maxRateHigh, maxRateMedium, maxRateLow, func(priority string) {
+			obsTelemetry.recordSamplerDropped("internal", priority)
+		})
 		deps.Lifecycle.Append(compdef.Hook{
 			OnStop: func(_ context.Context) error {
 				pkglog.SetLogObserver(nil)
@@ -591,6 +594,7 @@ func (h *noopObserveHandle) ObserveMetricAndReportDrop(_ observerdef.MetricView)
 	return false
 }
 func (h *noopObserveHandle) ObserveLog(_ observerdef.LogView) {}
+
 
 // DumpMetrics writes all stored metrics to the specified file as JSON.
 func (o *observerImpl) DumpMetrics(path string) error {

--- a/comp/anomalydetection/observer/impl/telemetry.go
+++ b/comp/anomalydetection/observer/impl/telemetry.go
@@ -24,6 +24,7 @@ const (
 	telemetryStorageSeriesEvicted            = "observer.storage.series_evicted"              // Number of storage series evicted to enforce bounds.
 	telemetryStorageCapacityHit              = "observer.storage.capacity_hit"                // Number of times storage capacity eviction was triggered.
 	telemetryAdvanceSkipped                  = "observer.scheduler.advance_skipped"           // Number of advance requests skipped as already analyzed.
+	telemetryLogsSamplerDropped              = "observer.logs.sampler_dropped"                // Logs dropped by the source sampler before reaching the observer, by source and priority.
 )
 
 type observerTelemetry struct {
@@ -42,6 +43,7 @@ type observerTelemetry struct {
 	storageEvicted   telemetry.Counter
 	storageCapHit    telemetry.Counter
 	advanceSkipped   telemetry.Counter
+	samplerDropped   telemetry.Counter
 
 	inFlightInternal   atomic.Int64
 	inFlightKubelet    atomic.Int64
@@ -122,6 +124,12 @@ func newObserverTelemetry(telemetryComp telemetry.Component) *observerTelemetry 
 			[]string{"reason"},
 			"Number of skipped advance requests by trigger reason",
 		),
+		samplerDropped: telemetryComp.NewCounter(
+			"observer",
+			telemetryLogsSamplerDropped,
+			[]string{"source", "priority"},
+			"Logs dropped by the source sampler (rate limit or min_severity) before reaching the observer",
+		),
 	}
 }
 
@@ -189,6 +197,10 @@ func (t *observerTelemetry) recordStorageCapacityHit() {
 
 func (t *observerTelemetry) recordAdvanceSkipped(reason string) {
 	t.advanceSkipped.Add(1, reason)
+}
+
+func (t *observerTelemetry) recordSamplerDropped(source, priority string) {
+	t.samplerDropped.Add(1, source, priority)
 }
 
 func (t *observerTelemetry) inFlightCounter(logSource string) *atomic.Int64 {

--- a/pkg/aggregator/observer_handle_test.go
+++ b/pkg/aggregator/observer_handle_test.go
@@ -55,6 +55,8 @@ func (c *recordingComponent) GetHandle(_ string) observer.Handle {
 	return c.handle
 }
 
+func (c *recordingComponent) RecordSamplerDropped(_, _ string) {}
+
 func (c *recordingComponent) DumpMetrics(_ string) error {
 	return nil
 }

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -5960,7 +5960,7 @@ properties:
     node_type: section
     type: object
     properties:
-      agent_logs:
+      logs:
         node_type: section
         type: object
         properties:
@@ -5968,25 +5968,106 @@ properties:
             node_type: setting
             type: boolean
             default: true
-            comment: Agent-internal log sampling. Warn+ are never sampled.
-          sample_rate_debug:
-            node_type: setting
-            type: number
-            default: 0.05
-            tags:
-            - golang_type:float64
-          sample_rate_info:
-            node_type: setting
-            type: number
-            default: 0.2
-            tags:
-            - golang_type:float64
-          sample_rate_trace:
-            node_type: setting
-            type: number
-            default: 0
-            tags:
-            - golang_type:float64
+            comment: Master switch for all log ingestion (internal, kubelet, containers).
+          internal:
+            node_type: section
+            type: object
+            properties:
+              enabled:
+                node_type: setting
+                type: boolean
+                default: true
+                comment: Forward agent-internal log lines to the anomaly-detection observer.
+              min_severity:
+                node_type: setting
+                type: string
+                default: warn
+                comment: Minimum log level to forward (trace/debug/info/warn/error/critical). Logs below this level are dropped before rate-limiting.
+              max_rate_high_priority:
+                node_type: setting
+                type: number
+                default: -1
+                comment: Max logs/s for warn/error/critical. -1 = unlimited, 0 = drop all.
+                tags:
+                - golang_type:float64
+              max_rate_medium_priority:
+                node_type: setting
+                type: number
+                default: 100
+                comment: Max logs/s for info. -1 = unlimited, 0 = drop all.
+                tags:
+                - golang_type:float64
+              max_rate_low_priority:
+                node_type: setting
+                type: number
+                default: 1
+                comment: Max logs/s for trace/debug. -1 = unlimited, 0 = drop all.
+                tags:
+                - golang_type:float64
+          kubelet:
+            node_type: section
+            type: object
+            properties:
+              enabled:
+                node_type: setting
+                type: boolean
+                default: true
+                comment: Forward kubelet journald logs to the anomaly-detection observer.
+              min_severity:
+                node_type: setting
+                type: string
+                default: warn
+                comment: Minimum log level to forward.
+              max_rate_high_priority:
+                node_type: setting
+                type: number
+                default: -1
+                tags:
+                - golang_type:float64
+              max_rate_medium_priority:
+                node_type: setting
+                type: number
+                default: 100
+                tags:
+                - golang_type:float64
+              max_rate_low_priority:
+                node_type: setting
+                type: number
+                default: 1
+                tags:
+                - golang_type:float64
+          containers:
+            node_type: section
+            type: object
+            properties:
+              enabled:
+                node_type: setting
+                type: boolean
+                default: true
+                comment: Forward container logs to the anomaly-detection observer.
+              min_severity:
+                node_type: setting
+                type: string
+                default: warn
+                comment: Minimum log level to forward.
+              max_rate_high_priority:
+                node_type: setting
+                type: number
+                default: -1
+                tags:
+                - golang_type:float64
+              max_rate_medium_priority:
+                node_type: setting
+                type: number
+                default: 100
+                tags:
+                - golang_type:float64
+              max_rate_low_priority:
+                node_type: setting
+                type: number
+                default: 1
+                tags:
+                - golang_type:float64
       debug:
         node_type: section
         type: object
@@ -6123,33 +6204,6 @@ properties:
         default: false
         comment: Master switch. When false the entire anomaly detection subsystem
           is a no-op.
-      logs:
-        node_type: section
-        type: object
-        properties:
-          containers:
-            node_type: section
-            type: object
-            properties:
-              enabled:
-                node_type: setting
-                type: boolean
-                default: true
-          enabled:
-            node_type: setting
-            type: boolean
-            default: true
-            comment: |-
-              Log ingestion gate. When false, container/journald logs are not routed
-              into the anomaly detection pipeline (recording is unaffected).
-          kubelet:
-            node_type: section
-            type: object
-            properties:
-              enabled:
-                node_type: setting
-                type: boolean
-                default: true
       metrics:
         node_type: section
         type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -2076,8 +2076,8 @@ func anomalyDetection(config pkgconfigmodel.Setup) {
 	// Log-derived virtual metrics are unaffected.
 	config.BindEnvAndSetDefault("anomaly_detection.metrics.enabled", true)
 
-	// Agent-internal log sampling. Warn+ are never sampled.
-	config.BindEnvAndSetDefault("anomaly_detection.agent_logs.enabled", true)
+	// Agent-internal log tap.
+	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.enabled", true)
 	config.BindEnvAndSetDefault("anomaly_detection.agent_logs.sample_rate_info", 0.2)
 	config.BindEnvAndSetDefault("anomaly_detection.agent_logs.sample_rate_debug", 0.05)
 	config.BindEnvAndSetDefault("anomaly_detection.agent_logs.sample_rate_trace", 0.0)

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -2065,22 +2065,39 @@ func anomalyDetection(config pkgconfigmodel.Setup) {
 	// Master switch. When false the entire anomaly detection subsystem is a no-op.
 	config.BindEnvAndSetDefault("anomaly_detection.enabled", false)
 
-	// Log ingestion gate. When false, container/journald logs are not routed
-	// into the anomaly detection pipeline (recording is unaffected).
+	// Log ingestion gate. When false, all log sources (container, kubelet, internal)
+	// are not routed into the anomaly detection pipeline (recording is unaffected).
 	config.BindEnvAndSetDefault("anomaly_detection.logs.enabled", true)
 	config.BindEnvAndSetDefault("anomaly_detection.logs.containers.enabled", true)
 	config.BindEnvAndSetDefault("anomaly_detection.logs.kubelet.enabled", true)
+
+	// Internal agent log tap.
+	// min_severity is the minimum level forwarded (logs below it are dropped before sampling).
+	// max_rate_* are in logs/second measured over a 10-second fixed window and apply
+	// after the min_severity gate. -1 means unlimited (no cap); 0 drops all logs of that priority.
+	// high_priority = warn/error/critical, medium_priority = info, low_priority = debug.
+	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.enabled", true)
+	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.min_severity", "warn")
+	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.max_rate_high_priority", -1.0) // unlimited
+	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.max_rate_medium_priority", 100.0)
+	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.max_rate_low_priority", 1.0)
+
+	// Kubelet journald log rate limits (enabled flag already set above).
+	config.BindEnvAndSetDefault("anomaly_detection.logs.kubelet.min_severity", "warn")
+	config.BindEnvAndSetDefault("anomaly_detection.logs.kubelet.max_rate_high_priority", -1.0) // unlimited
+	config.BindEnvAndSetDefault("anomaly_detection.logs.kubelet.max_rate_medium_priority", 100.0)
+	config.BindEnvAndSetDefault("anomaly_detection.logs.kubelet.max_rate_low_priority", 1.0)
+
+	// Container log rate limits (enabled flag already set above).
+	config.BindEnvAndSetDefault("anomaly_detection.logs.containers.min_severity", "warn")
+	config.BindEnvAndSetDefault("anomaly_detection.logs.containers.max_rate_high_priority", -1.0) // unlimited
+	config.BindEnvAndSetDefault("anomaly_detection.logs.containers.max_rate_medium_priority", 100.0)
+	config.BindEnvAndSetDefault("anomaly_detection.logs.containers.max_rate_low_priority", 1.0)
 
 	// Metrics ingestion gate. When false, externally-ingested metrics
 	// (DogStatsD, check samplers) are dropped at the handle factory.
 	// Log-derived virtual metrics are unaffected.
 	config.BindEnvAndSetDefault("anomaly_detection.metrics.enabled", true)
-
-	// Agent-internal log tap.
-	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.enabled", true)
-	config.BindEnvAndSetDefault("anomaly_detection.agent_logs.sample_rate_info", 0.2)
-	config.BindEnvAndSetDefault("anomaly_detection.agent_logs.sample_rate_debug", 0.05)
-	config.BindEnvAndSetDefault("anomaly_detection.agent_logs.sample_rate_trace", 0.0)
 
 	// Anomaly event reporting. Keep false during evaluation / shadow mode.
 	config.BindEnvAndSetDefault("anomaly_detection.reporting.enabled", false)

--- a/test/new-e2e/tests/anomalydetection/anomalydetection_nix_test.go
+++ b/test/new-e2e/tests/anomalydetection/anomalydetection_nix_test.go
@@ -8,7 +8,7 @@
 //
 //   - anomalydetection_nix_test.go — reporter tests: DSD-spike (CUSUM) and file-log-spike (BOCPD)
 //   - defaults_nix_test.go        — observer disabled by default (no observer telemetry metrics)
-//   - config_matrix_nix_test.go   — sub-gate independence (metrics/logs/agent_logs gates)
+//   - config_matrix_nix_test.go   — sub-gate independence (metrics/logs/internal gates)
 //   - shutdown_nix_test.go        — graceful shutdown under DSD load (no panic/crash)
 package anomalydetection
 
@@ -55,8 +55,8 @@ anomaly_detection:
     enabled: true
   logs:
     enabled: false
-  agent_logs:
-    enabled: false
+    internal:
+      enabled: false
   detectors:
     cusum:
       enabled: true
@@ -201,8 +201,8 @@ anomaly_detection:
     enabled: true
     containers:
       min_severity: ""  # plain file logs have no severity; accept all levels
-  agent_logs:
-    enabled: false
+    internal:
+      enabled: false
   detectors:
     bocpd:
       warmup_points: 20

--- a/test/new-e2e/tests/anomalydetection/anomalydetection_nix_test.go
+++ b/test/new-e2e/tests/anomalydetection/anomalydetection_nix_test.go
@@ -199,6 +199,8 @@ anomaly_detection:
     enabled: false
   logs:
     enabled: true
+    containers:
+      min_severity: ""  # plain file logs have no severity; accept all levels
   agent_logs:
     enabled: false
   detectors:

--- a/test/new-e2e/tests/anomalydetection/config_matrix_nix_test.go
+++ b/test/new-e2e/tests/anomalydetection/config_matrix_nix_test.go
@@ -7,7 +7,7 @@ package anomalydetection
 
 // Item 7 — sub-gate independence matrix (master=on in all cases).
 //
-// Three independent sub-gates (metrics.enabled, logs.enabled, agent_logs.enabled)
+// Three independent sub-gates (metrics.enabled, logs.enabled, logs.internal.enabled)
 // sit under anomaly_detection.enabled=true. This file verifies that each sub-gate
 // activates or suppresses the correct path independently. The master=off case is
 // covered by defaults_nix_test.go.
@@ -48,8 +48,8 @@ anomaly_detection:
     enabled: false
   logs:
     enabled: false
-  agent_logs:
-    enabled: false
+    internal:
+      enabled: false
 `
 	e2e.Run(t, &metricsOffLogsOffSuite{}, e2e.WithProvisioner(
 		awshost.Provisioner(
@@ -66,7 +66,7 @@ func (s *metricsOffLogsOffSuite) TestWarningPresent() {
 
 	tel := observerTelemetryOutput(s)
 	assert.False(s.T(), containsMetric(tel, telemetryLogsIngested),
-		"no log ingestion telemetry expected when logs and agent_logs are disabled")
+		"no log ingestion telemetry expected when logs and logs.internal are disabled")
 	assert.False(s.T(), containsMetric(tel, telemetryReportsEmitted),
 		"no reports expected when both metrics and logs ingestion are disabled")
 }
@@ -90,8 +90,8 @@ anomaly_detection:
     enabled: true
   logs:
     enabled: false
-  agent_logs:
-    enabled: false
+    internal:
+      enabled: false
 `
 	e2e.Run(t, &metricsOnLogsOffSuite{}, e2e.WithProvisioner(
 		awshost.Provisioner(
@@ -108,7 +108,7 @@ func (s *metricsOnLogsOffSuite) TestSubGateIndependence() {
 	assert.True(s.T(), containsMetric(tel, telemetrySeriesCount),
 		"metrics path should expose series telemetry when enabled")
 	assert.False(s.T(), containsMetricWithTag(tel, telemetryLogsIngested, "log_source", "internal"),
-		"internal log ingestion should not be active when agent_logs is disabled")
+		"internal log ingestion should not be active when logs.internal is disabled")
 }
 
 // --- Case 3: metrics=off, logs=on ----------------------------------------
@@ -128,8 +128,9 @@ anomaly_detection:
   enabled: true
   metrics:
     enabled: false
-  agent_logs:
-    enabled: true
+  logs:
+    internal:
+      enabled: true
 `
 	e2e.Run(t, &metricsOffLogsOnSuite{}, e2e.WithProvisioner(
 		awshost.Provisioner(
@@ -139,13 +140,13 @@ anomaly_detection:
 }
 
 // TestLogTapActiveMetricsWarningPresent verifies internal log ingestion telemetry
-// appears when agent_logs.enabled=true and metrics ingest is disabled.
+// appears when logs.internal.enabled=true and metrics ingest is disabled.
 func (s *metricsOffLogsOnSuite) TestLogTapActiveMetricsWarningPresent() {
 	waitForObserverReady(s)
 	s.EventuallyWithT(func(c *assert.CollectT) {
 		tel := observerTelemetryOutput(s)
 		assert.True(c, containsMetricWithTag(tel, telemetryLogsIngested, "log_source", "internal"),
-			"internal log ingestion should be active when agent_logs is enabled")
+			"internal log ingestion should be active when logs.internal is enabled")
 	}, 2*time.Minute, 3*time.Second)
 }
 
@@ -166,8 +167,9 @@ anomaly_detection:
   enabled: true
   metrics:
     enabled: true
-  agent_logs:
-    enabled: true
+  logs:
+    internal:
+      enabled: true
 `
 	e2e.Run(t, &allGatesOnSuite{}, e2e.WithProvisioner(
 		awshost.Provisioner(


### PR DESCRIPTION
## Overview

This PR reworks the log settings for the anomaly detection observer component.
It is structured as 3 logical commits to make review straightforward:

1. **Config rename** – rename the `agent_logs` config key to `logs.internal` and group all log source settings under a single `logs` section.
2. **Per-source filtering & rate limiting** – add `min_severity` and `max_rate_{high,medium,low}_priority` controls for each log source (internal, kubelet, containers).
3. **Telemetry** – add an `observer.logs.sampler_dropped` counter per source and priority tier.

---

## Configuration

### `anomaly_detection.logs`

```yaml
anomaly_detection:
  logs:
    enabled: true

    # Internal agent logs
    internal:
      enabled: true
      min_severity: "warn"          # trace | debug | info | warn | error | critical | off
      max_rate_high_priority: -1    # warn/error/critical – unlimited
      max_rate_medium_priority: 100 # info – 100 logs/s
      max_rate_low_priority: 1      # trace/debug – 1 log/s

    # Kubelet journald logs
    kubelet:
      enabled: true
      min_severity: "warn"
      max_rate_high_priority: -1
      max_rate_medium_priority: 100
      max_rate_low_priority: 1

    # Container logs
    containers:
      enabled: true
      min_severity: "warn"
      max_rate_high_priority: -1
      max_rate_medium_priority: 100
      max_rate_low_priority: 1
```

### Severity levels

`min_severity` accepts any standard log level string. Logs strictly below the
configured threshold are dropped before rate-limiting (and do **not** count
toward the `sampler_dropped` telemetry):

| `min_severity` | Passes                                         |
|----------------|------------------------------------------------|
| `"trace"`      | trace, debug, info, warn, error, critical      |
| `"debug"`      | debug, info, warn, error, critical             |
| `"info"`       | info, warn, error, critical                    |
| `"warn"`       | warn, error, critical *(default)*              |
| `"error"`      | error, critical                                |
| `"critical"`   | critical only                                  |
| `"off"`        | nothing                                        |

### Priority tiers (for rate limiting)

Each log is bucketed into one of three rate-limiting tiers regardless of
`min_severity`. The tier numeric values mirror `pkg/util/log/types.LogLevel`
(copied, no dependency):

| Tier     | Covers                          | Rate key                       |
|----------|---------------------------------|--------------------------------|
| `high`   | warn, error, critical           | `max_rate_high_priority`       |
| `medium` | info (and unrecognised)         | `max_rate_medium_priority`     |
| `low`    | trace, debug                    | `max_rate_low_priority`        |

Rate values are in **logs/second** over a rolling 10-second window.
`-1` means unlimited; `0` drops all logs in that tier.

---

## Testing

- `comp/anomalydetection/internal/logsfilter/logsfilter_test.go`: ordering invariant, `BucketForStatus` for all 13 string variants, `MinBucketForSeverity` for every level + `"off"` + garbage input, full gate semantics table for all 7 thresholds (`trace`→`off`), `RateTierForBucket` for all buckets.
- `comp/anomalydetection/logssource/impl/sampling_test.go`: `RateWindow` edge cases (unlimited, drop-all, cap enforced, sub-0.1/s floor, window expiry), `ShouldForward` min_severity for all 4 threshold levels, all three rate tiers firing `onDropped`, explicit assertion that severity-filtered drops never fire `onDropped`, kubelet-vs-container source routing.
- `comp/anomalydetection/observer/impl/agent_logs_test.go`: end-to-end with real `pkglog` observer for `min_severity` = `""`, `"debug"`, `"warn"`, `"error"`; rate limiting with `onDropped`; explicit assertion that severity-filtered drops never fire `onDropped`.