### PR TITLE
[Backport 7.80.x] [VULN-83424] Bump containerd to v1.7.32 to mitigate CVE-2026-46680

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -205,7 +205,7 @@ require (
 	github.com/cloudflare/cbpfc v0.0.0-20260219140841-0661ad29132c
 	github.com/cloudfoundry-community/go-cfclient/v2 v2.0.1-0.20230503155151-3d15366c5820
 	github.com/containerd/cgroups/v3 v3.1.3
-	github.com/containerd/containerd v1.7.31
+	github.com/containerd/containerd v1.7.32
 	github.com/containerd/containerd/api v1.9.0
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/typeurl/v2 v2.2.3
@@ -1216,13 +1216,21 @@ require (
 // TODO(songy23): remove this once https://github.com/kubernetes/apiserver/commit/b887c9ebecf558a2001fc5c5dbd5c87fd672500c is brought to agent
 replace go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0
 
-// containerd v1.7.30 (latest v1.x) uses runtime-spec types with int64 fields (not *int64).
-// runtime-spec v1.3.0 changed LinuxPids.Limit to *int64, breaking containerd v1.7.30.
-// containerd/cgroups/v3 v3.1.2 also expects *int64 (runtime-spec v1.3.0), so we must
-// downgrade both: pin runtime-spec to v1.2.0 (int64) and cgroups/v3 to v3.0.5 (also int64).
+// containerd v1.7.x and containerd/v2 v2.0.x use runtime-spec types with
+// int64 fields, but runtime-spec v1.3.0 changed LinuxPids.Limit to *int64,
+// breaking those containerd lines. containerd/cgroups/v3 v3.1.x also requires
+// runtime-spec v1.3.0, so we pin both back: runtime-spec to v1.2.0 and
+// cgroups/v3 to v3.0.5.
 replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.2.0
 
 replace github.com/containerd/cgroups/v3 => github.com/containerd/cgroups/v3 v3.0.5
+
+// CVE-2026-46680: containerd/v2 is pulled in transitively (Trivy imports
+// containerd/v2/client, and the OPA fork brings in v2.1.x). v2.1.x is EOL
+// with no fix; pin to v2.0.9, which still uses runtime-spec v1.2.0 and so
+// matches the pin above. v2.2.4+ would force runtime-spec v1.3.0, conflicting
+// with that pin.
+replace github.com/containerd/containerd/v2 => github.com/containerd/containerd/v2 v2.0.9
 
 replace github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be => github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe
 

--- a/go.sum
+++ b/go.sum
@@ -3007,12 +3007,12 @@ github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 h1:sDMmm+q/3+Bu
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
-github.com/containerd/containerd v1.7.31 h1:jn3IMuTV4Bb1Uwb0MFPW2ASJAD3W1lh6QqqZHIZwDh4=
-github.com/containerd/containerd v1.7.31/go.mod h1:jdwD6s/BhV4XVJGrvtziNPVA+83n66TwptVaPKprq4E=
+github.com/containerd/containerd v1.7.32 h1:S54xuVcPxeLaYgaRABtpJ2VyVUVsy0IGf7qHBs+sbY8=
+github.com/containerd/containerd v1.7.32/go.mod h1:jdwD6s/BhV4XVJGrvtziNPVA+83n66TwptVaPKprq4E=
 github.com/containerd/containerd/api v1.9.0 h1:HZ/licowTRazus+wt9fM6r/9BQO7S0vD5lMcWspGIg0=
 github.com/containerd/containerd/api v1.9.0/go.mod h1:GhghKFmTR3hNtyznBoQ0EMWr9ju5AqHjcZPsSpTKutI=
-github.com/containerd/containerd/v2 v2.1.3 h1:eMD2SLcIQPdMlnlNF6fatlrlRLAeDaiGPGwmRKLZKNs=
-github.com/containerd/containerd/v2 v2.1.3/go.mod h1:8C5QV9djwsYDNhxfTCFjWtTBZrqjditQ4/ghHSYjnHM=
+github.com/containerd/containerd/v2 v2.0.9 h1:BtjYFk0SHtDQs8SXRQhPT+WZia18rLaHobekf5YFmrQ=
+github.com/containerd/containerd/v2 v2.0.9/go.mod h1:YdMdboz+mhlo+CQYGaLyUuqJBGlaz2OV2SA6dEMjvuo=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/releasenotes/notes/bump-containerd-CVE-2026-46680-f23090a1f54ac03e.yaml
+++ b/releasenotes/notes/bump-containerd-CVE-2026-46680-f23090a1f54ac03e.yaml
@@ -1,0 +1,7 @@
+---
+security:
+  - |
+    Bumped containerd dependencies to mitigate CVE-2026-46680:
+    ``github.com/containerd/containerd`` to v1.7.32 and pinned
+    ``github.com/containerd/containerd/v2`` to v2.0.9 (the EOL v2.1.x line
+    has no fix).


### PR DESCRIPTION
### What does this PR do?

Backport of #51308 onto `7.80.x`.

Mitigates [CVE-2026-46680](https://github.com/containerd/containerd/security/advisories/GHSA-fqw6-gf59-qr4w) (containerd `User`-field overflow allowing Kubernetes `runAsNonRoot` bypass):

* Bumps `github.com/containerd/containerd` from `v1.7.31` to `v1.7.32`.
* Pins `github.com/containerd/containerd/v2` to `v2.0.9` via a `replace` directive (the `v2.1.x` line is EOL with no fix per the upstream advisory; `v2.0.9` was chosen over `v2.2.4` / `v2.3.1` to stay compatible with the existing `runtime-spec => v1.2.0` pin needed by `containerd v1.7.x`).
* Refreshes the existing `runtime-spec` / `cgroups/v3` replace-comment block.

### Motivation

JIRA: [VULN-83424](https://datadoghq.atlassian.net/browse/VULN-83424) — `[datadog-agent] CVE-2026-46680` (severity **High**).

The auto-backport workflow on `main` PR #51308 reported a `go.sum` merge conflict; this PR resolves it by regenerating `go.sum` via `dda inv tidy`. `go.mod` merged cleanly.

### Describe how you validated your changes

* Cherry-picked merge commit `fc16cc76a1d54d86f34ca0c05ae891bf7f35f02c` onto `7.80.x`.
* `dda inv tidy` regenerates `go.sum` cleanly (only `containerd v1.7.32` and `containerd/v2 v2.0.9` entries differ; no `v2.1.3` left).
* The validation work performed on `main` (compile checks on `pkg/util/trivy`, `pkg/util/containerd`, `pkg/compliance`; upstream advisory cross-check) applies unchanged here.

### Possible Drawbacks / Trade-offs

Same as the `main` PR. The `containerd/v2 => v2.0.9` downgrade can be lifted once the `runtime-spec v1.2.0` pin is no longer required (i.e., once `containerd v1.7.x` is dropped from the build).

### Additional Notes

Security release note shipped as a `security:` reno entry per repo convention.

[VULN-83424]: https://datadoghq.atlassian.net/browse/VULN-83424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ