### PR TITLE
workloadmeta crio: report the OCI config digest as the image ID

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/crio/crio_test.go
+++ b/comp/core/workloadmeta/collectors/internal/crio/crio_test.go
@@ -437,7 +437,7 @@ func TestGenerateImageEventFromContainer(t *testing.T) {
 				Type:   workloadmeta.EventTypeSet,
 				Source: workloadmeta.SourceRuntime,
 				Entity: &workloadmeta.ContainerImageMetadata{
-					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:123abc"},
+					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:image123"},
 					EntityMeta: workloadmeta.EntityMeta{
 						Name:   "myrepo/myimage:latest",
 						Labels: map[string]string{"label1": "value1", "label2": "value2"},
@@ -481,7 +481,7 @@ func TestGenerateImageEventFromContainer(t *testing.T) {
 				Type:   workloadmeta.EventTypeSet,
 				Source: workloadmeta.SourceRuntime,
 				Entity: &workloadmeta.ContainerImageMetadata{
-					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "image123"},
+					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:image123"},
 					EntityMeta: workloadmeta.EntityMeta{
 						Name: "",
 					},
@@ -569,8 +569,8 @@ func TestOptimizedImageCollection(t *testing.T) {
 				}, nil
 			},
 			existingImages: map[string]*workloadmeta.ContainerImageMetadata{
-				"sha256:hash1": {
-					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:hash1"},
+				"sha256:image1": {
+					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:image1"},
 					EntityMeta: workloadmeta.EntityMeta{
 						Name: "repo/image1:latest",
 					},
@@ -792,8 +792,8 @@ func TestPullWithImageCollectionEnabled(t *testing.T) {
 				return nil, errors.New("unexpected call")
 			},
 			existingImages: map[string]*workloadmeta.ContainerImageMetadata{
-				"sha256:123abc": {
-					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:123abc"},
+				"sha256:image123": {
+					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:image123"},
 					EntityMeta: workloadmeta.EntityMeta{
 						Name: "myrepo/myimage:latest",
 					},

--- a/comp/core/workloadmeta/collectors/internal/crio/image.go
+++ b/comp/core/workloadmeta/collectors/internal/crio/image.go
@@ -56,15 +56,14 @@ func (c *collector) convertImageToEvent(img *v1.Image, info map[string]string, n
 	if len(img.GetRepoTags()) > 0 {
 		name = img.GetRepoTags()[0]
 	}
-	imgID := img.GetId()
-	imgInfo := parseImageInfo(info, crio.GetOverlayImagePath(), imgID)
+	rawID := img.GetId()
+	imgInfo := parseImageInfo(info, crio.GetOverlayImagePath(), rawID)
 
-	imgIDAsDigest, err := parseDigests(img.GetRepoDigests())
-	if err == nil {
-		imgID = imgIDAsDigest
-	} else if c.sbomCollectionIsEnabled() {
-		log.Warnf("Failed to parse digest for image with ID %s: %v. As a result, SBOM vulnerabilities may not be properly linked to this image.", imgID, err)
-	}
+	// The image ID is the OCI config digest: containers-storage keys each image
+	// by it (so rawID is that digest), and containerd reports the same identity.
+	// Normalize to sha256: form. This previously used the manifest RepoDigest,
+	// which diverged from containerd and from the config digest crane resolves.
+	imgID := normalizeImageID(rawID)
 
 	imgMeta := workloadmeta.ContainerImageMetadata{
 		EntityID: workloadmeta.EntityID{
@@ -102,6 +101,16 @@ func generateUnsetImageEvent(seenID workloadmeta.EntityID) *workloadmeta.Collect
 			EntityID: seenID,
 		},
 	}
+}
+
+// normalizeImageID returns the OCI config digest in sha256: form. CRI-O's image
+// ID (the containers-storage image ID) is that config digest, sometimes without
+// the algorithm prefix.
+func normalizeImageID(id string) string {
+	if id != "" && !strings.HasPrefix(id, "sha256:") {
+		return "sha256:" + id
+	}
+	return id
 }
 
 // parseDigests extracts the SHA from the image reference digest.
@@ -229,12 +238,10 @@ func (c *collector) generateImageEventsFromImageList(ctx context.Context) ([]wor
 	allImageIDs := make([]workloadmeta.EntityID, 0, len(images))
 
 	for _, img := range images {
-		// Extract the image ID - prefer digest over the raw ID (same logic as convertImageToEvent)
+		// The image ID is the OCI config digest (what GetId returns), normalized to
+		// sha256 form, matching convertImageToEvent.
 		rawID := img.GetId()
-		imgID := rawID
-		if imgIDAsDigest, err := parseDigests(img.GetRepoDigests()); err == nil {
-			imgID = imgIDAsDigest
-		}
+		imgID := normalizeImageID(rawID)
 
 		// Always track with the computed ID (same as what convertImageToEvent would use)
 		entityID := workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: imgID}

--- a/comp/core/workloadmeta/collectors/internal/crio/image_test.go
+++ b/comp/core/workloadmeta/collectors/internal/crio/image_test.go
@@ -138,7 +138,7 @@ func TestConvertImageToEvent(t *testing.T) {
 				Entity: &workloadmeta.ContainerImageMetadata{
 					EntityID: workloadmeta.EntityID{
 						Kind: workloadmeta.KindContainerImageMetadata,
-						ID:   "sha256:abc123", // Should use digest, not raw ID
+						ID:   "sha256:image123", // config digest (the image Id), sha256 normalized
 					},
 					EntityMeta: workloadmeta.EntityMeta{
 						Name:      "myrepo/myimage:latest",
@@ -181,7 +181,7 @@ func TestConvertImageToEvent(t *testing.T) {
 			},
 		},
 		{
-			name: "Image without digest falls back to raw ID",
+			name: "Image ID is normalized to sha256 regardless of repo digests",
 			image: &v1.Image{
 				Id:          "image123",
 				RepoTags:    []string{"myrepo/myimage:latest"},
@@ -195,7 +195,7 @@ func TestConvertImageToEvent(t *testing.T) {
 				Entity: &workloadmeta.ContainerImageMetadata{
 					EntityID: workloadmeta.EntityID{
 						Kind: workloadmeta.KindContainerImageMetadata,
-						ID:   "image123", // Should use raw ID when no digest
+						ID:   "sha256:image123", // image Id normalized to sha256, independent of repo digests
 					},
 					EntityMeta: workloadmeta.EntityMeta{
 						Name:      "myrepo/myimage:latest",
@@ -221,7 +221,7 @@ func TestConvertImageToEvent(t *testing.T) {
 				Entity: &workloadmeta.ContainerImageMetadata{
 					EntityID: workloadmeta.EntityID{
 						Kind: workloadmeta.KindContainerImageMetadata,
-						ID:   "sha256:abc123",
+						ID:   "sha256:image123",
 					},
 					EntityMeta: workloadmeta.EntityMeta{
 						Name:      "", // No name when no repo tags
@@ -337,8 +337,8 @@ func TestGenerateImageEventsFromImageList(t *testing.T) {
 				}, nil
 			},
 			existingImages: map[string]*workloadmeta.ContainerImageMetadata{
-				"sha256:hash1": {
-					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:hash1"},
+				"sha256:image1": {
+					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:image1"},
 				},
 			},
 			expectedEvents: 1, // Only image2 creates an event (image1 is skipped entirely)
@@ -389,7 +389,7 @@ func TestGenerateImageEventsFromImageList(t *testing.T) {
 			expectedError:  false,
 		},
 		{
-			name: "ID format mismatch - image stored with digest ID but lookup uses raw ID",
+			name: "Image stored with the sha256 normalized config ID is skipped",
 			mockListImages: func(_ context.Context) ([]*v1.Image, error) {
 				return []*v1.Image{
 					{
@@ -409,8 +409,8 @@ func TestGenerateImageEventsFromImageList(t *testing.T) {
 				}, nil
 			},
 			existingImages: map[string]*workloadmeta.ContainerImageMetadata{
-				"sha256:digestid456": {
-					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:digestid456"},
+				"sha256:rawid123": {
+					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:rawid123"},
 				},
 			},
 			expectedEvents: 0, // No event created - image exists and is skipped
@@ -503,8 +503,8 @@ func TestGenerateImageEventsFromImageList(t *testing.T) {
 				}, nil
 			},
 			existingImages: map[string]*workloadmeta.ContainerImageMetadata{
-				"sha256:digestid1": { // Image1 stored with digest ID
-					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:digestid1"},
+				"sha256:rawid1": { // Image1 stored with config digest ID
+					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "sha256:rawid1"},
 				},
 				"rawid2": { // Image2 stored with raw ID (dangling)
 					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainerImageMetadata, ID: "rawid2"},


### PR DESCRIPTION
The crio collector derived the image ID from the manifest RepoDigest, so crio
SBOMs reported a different ImageID than containerd, which uses the OCI config
digest. containers-storage already keys each image by that config digest (what
GetId returns), so use it, normalized to sha256: form. The backend joins
vulnerabilities by diff_id, so changing the image ID is safe.

