### PR TITLE
kubelet client: use the `/healthz` route to check kubelet connection

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet_client.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client.go
@@ -120,13 +120,14 @@ func newForConfig(config kubeletClientConfig, timeout time.Duration) (*kubeletCl
 }
 
 func (kc *kubeletClient) checkConnection(ctx context.Context) error {
-	_, statusCode, err := kc.query(ctx, "/spec")
+	_, statusCode, err := kc.query(ctx, "/healthz")
 	if err != nil {
 		return err
 	}
 
+	// unauthorized error, we can reach it but it's likely a token error
 	if statusCode == http.StatusUnauthorized {
-		return fmt.Errorf("unauthorized to request test kubelet endpoint (/spec) - token used: %t", kc.config.token != "")
+		return fmt.Errorf("unauthorized to request test kubelet endpoint (/healthz) - token used: %t", kc.config.token != "")
 	}
 
 	return nil
@@ -279,10 +280,11 @@ func getKubeletClient(ctx context.Context) (*kubeletClient, error) {
 	if kubeletHTTPSPort > 0 {
 		httpsErr = checkKubeletConnection(ctx, "https", kubeletHTTPSPort, kubeletPathPrefix, potentialHosts, &clientConfig)
 		if httpsErr != nil {
-			log.Debug("Impossible to reach Kubelet through HTTPS")
 			if kubeletHTTPPort <= 0 {
 				return nil, httpsErr
 			}
+
+			log.Warnf("Impossible to reach Kubelet through HTTPS, fallback to HTTP, err=%s", httpsErr.Error())
 		} else {
 			return newForConfig(clientConfig, kubeletTimeout)
 		}

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -261,7 +261,7 @@ func (suite *KubeletTestSuite) TestLocateKubeletHTTP() {
 	select {
 	case r := <-kubelet.Requests:
 		require.Equal(suite.T(), "GET", r.Method)
-		require.Equal(suite.T(), "/spec", r.URL.Path)
+		require.Equal(suite.T(), "/healthz", r.URL.Path)
 	case <-time.After(2 * time.Second):
 		require.FailNow(suite.T(), "Timeout on receive channel")
 	}

--- a/releasenotes/notes/kubelet-use-healthz-check-connection-8c99737ac722b08d.yaml
+++ b/releasenotes/notes/kubelet-use-healthz-check-connection-8c99737ac722b08d.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    use the ``/healthz`` route to check and validate kubelet connection,
+    instead of the deprecated ``/spec`` route.
+


### PR DESCRIPTION
### What does this PR do?
In order to validate the kubelet client can reach kubelet, remove the use of the deprecated route `/spec` and use the route `/healthz`.

Deprecated changelog for kubelet: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md search for line `Remove cAdvisor json metrics api collected by Kubelet`

### Motivation


This is the 1st change out of 3 to improve the kubelet client.
See related PR #50681

deprecated since v1.21.0 (released 28/06/22 )
https://kubernetes.io/releases/1.21/

### Describe how you validated your changes

run the tests

### Additional Notes
