### PR TITLE
Frank.spano rcasync

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -504,7 +504,12 @@ func start(log log.Component,
 			subscribeAgentTask(rcClient, config, statusComponent, diagnoseComp, ipc)
 			rcClient.Start()
 			defer func() {
-				rcClient.Close()
+				// Bound the wait: Close blocks until in-flight listener
+				// callbacks return, and a stuck listener (e.g. a long-running
+				// AGENT_TASK) must not hang cluster-agent shutdown.
+				if !rcClient.CloseTimeout(5 * time.Second) {
+					pkglog.Warnf("remote-config client did not drain within 5s on shutdown; a listener is likely stuck")
+				}
 			}()
 		}
 	}

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -486,6 +486,9 @@ func start(log log.Component,
 		if config.GetBool("autoscaling.cluster.enabled") {
 			products = append(products, state.ProductClusterAutoscalingValues)
 		}
+		if config.GetBool("kubeactions.enabled") {
+			products = append(products, state.ProductK8SActions)
+		}
 		if config.GetBool("admission_controller.auto_instrumentation.enabled") || config.GetBool("apm_config.instrumentation.enabled") {
 			products = append(products, state.ProductGradualRollout)
 		}
@@ -502,23 +505,6 @@ func start(log log.Component,
 			rcClient.Start()
 			defer func() {
 				rcClient.Close()
-			}()
-		}
-	}
-
-	// Dedicated RC client for K8S_ACTIONS. Isolates its pollLoop from the
-	// shared client (autoscaling, APM tracing, agent tasks, etc.) so a slow
-	// listener on the leader cannot delay action delivery past ActionTTL.
-	var rcClientKubeActions *rcclient.Client
-	if rcEnabled && isSet && config.GetBool("kubeactions.enabled") {
-		var err error
-		rcClientKubeActions, err = initializeRemoteConfigClient(rcserv, config, clusterName, clusterID, state.ProductK8SActions)
-		if err != nil {
-			log.Errorf("Failed to start dedicated remote-config client for K8S_ACTIONS: %v", err)
-		} else {
-			rcClientKubeActions.Start()
-			defer func() {
-				rcClientKubeActions.Close()
 			}()
 		}
 	}
@@ -609,12 +595,12 @@ func start(log log.Component,
 	// Kubernetes Actions
 	var kubeactionsRetriever *kubeactions.ConfigRetriever
 	if config.GetBool("kubeactions.enabled") {
-		if rcClientKubeActions == nil {
+		if rcClient == nil {
 			return errors.New("remote config is disabled or failed to initialize, remote config is a required dependency for kubeactions")
 		}
 		log.Infof("[KubeActions] Starting with cluster_id=%s, cluster_name=%s", clusterID, clusterName)
 
-		if kubeactionsRetriever, err = kubeactions.Setup(mainCtx, apiCl.Cl, apiCl.DynamicCl, clusterName, clusterID, le.IsLeader, rcClientKubeActions, epForwarder); err != nil {
+		if kubeactionsRetriever, err = kubeactions.Setup(mainCtx, apiCl.Cl, apiCl.DynamicCl, clusterName, clusterID, le.IsLeader, rcClient, epForwarder); err != nil {
 			return fmt.Errorf("Error while starting kubernetes actions: %v", err)
 		}
 		log.Info("Kubernetes actions subsystem started successfully")

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -486,9 +486,6 @@ func start(log log.Component,
 		if config.GetBool("autoscaling.cluster.enabled") {
 			products = append(products, state.ProductClusterAutoscalingValues)
 		}
-		if config.GetBool("kubeactions.enabled") {
-			products = append(products, state.ProductK8SActions)
-		}
 		if config.GetBool("admission_controller.auto_instrumentation.enabled") || config.GetBool("apm_config.instrumentation.enabled") {
 			products = append(products, state.ProductGradualRollout)
 		}
@@ -505,6 +502,23 @@ func start(log log.Component,
 			rcClient.Start()
 			defer func() {
 				rcClient.Close()
+			}()
+		}
+	}
+
+	// Dedicated RC client for K8S_ACTIONS. Isolates its pollLoop from the
+	// shared client (autoscaling, APM tracing, agent tasks, etc.) so a slow
+	// listener on the leader cannot delay action delivery past ActionTTL.
+	var rcClientKubeActions *rcclient.Client
+	if rcEnabled && isSet && config.GetBool("kubeactions.enabled") {
+		var err error
+		rcClientKubeActions, err = initializeRemoteConfigClient(rcserv, config, clusterName, clusterID, state.ProductK8SActions)
+		if err != nil {
+			log.Errorf("Failed to start dedicated remote-config client for K8S_ACTIONS: %v", err)
+		} else {
+			rcClientKubeActions.Start()
+			defer func() {
+				rcClientKubeActions.Close()
 			}()
 		}
 	}
@@ -595,12 +609,12 @@ func start(log log.Component,
 	// Kubernetes Actions
 	var kubeactionsRetriever *kubeactions.ConfigRetriever
 	if config.GetBool("kubeactions.enabled") {
-		if rcClient == nil {
+		if rcClientKubeActions == nil {
 			return errors.New("remote config is disabled or failed to initialize, remote config is a required dependency for kubeactions")
 		}
 		log.Infof("[KubeActions] Starting with cluster_id=%s, cluster_name=%s", clusterID, clusterName)
 
-		if kubeactionsRetriever, err = kubeactions.Setup(mainCtx, apiCl.Cl, apiCl.DynamicCl, clusterName, clusterID, le.IsLeader, rcClient, epForwarder); err != nil {
+		if kubeactionsRetriever, err = kubeactions.Setup(mainCtx, apiCl.Cl, apiCl.DynamicCl, clusterName, clusterID, le.IsLeader, rcClientKubeActions, epForwarder); err != nil {
 			return fmt.Errorf("Error while starting kubernetes actions: %v", err)
 		}
 		log.Info("Kubernetes actions subsystem started successfully")

--- a/comp/remote-config/rcclient/impl/rcclient.go
+++ b/comp/remote-config/rcclient/impl/rcclient.go
@@ -33,6 +33,9 @@ import (
 )
 
 const (
+	// rcCloseTimeout bounds how long shutdown waits for in-flight remote-config
+	// listener callbacks to drain when the lifecycle context carries no deadline.
+	rcCloseTimeout          = 5 * time.Second
 	agentTaskTimeout        = 5 * time.Minute
 	failoverMetricsSetting  = "multi_region_failover.failover_metrics"
 	failoverLogsSetting     = "multi_region_failover.failover_logs"
@@ -139,8 +142,21 @@ func NewRemoteConfigClient(deps Dependencies) (rcclient.Component, error) {
 	}
 
 	deps.Lc.Append(compdef.Hook{
-		OnStop: func(context.Context) error {
-			rc.client.Close()
+		OnStop: func(ctx context.Context) error {
+			// Client.Close blocks until every listener callback in flight has
+			// returned. A stuck listener (e.g. a long-running AGENT_TASK) must
+			// not hang shutdown, so bound the wait by the lifecycle context's
+			// deadline (falling back to a short default). The poll loop is
+			// always canceled regardless of whether workers drain in time.
+			timeout := rcCloseTimeout
+			if deadline, ok := ctx.Deadline(); ok {
+				if d := time.Until(deadline); d > 0 {
+					timeout = d
+				}
+			}
+			if !rc.client.CloseTimeout(timeout) {
+				pkglog.Warnf("remote-config client did not drain within %s on shutdown; a listener is likely stuck", timeout)
+			}
 			return nil
 		},
 	})

--- a/comp/remote-config/rcclient/impl/rcclient.go
+++ b/comp/remote-config/rcclient/impl/rcclient.go
@@ -365,7 +365,10 @@ func (rc *rcClient) Subscribe(product data.Product, fn func(update map[string]st
 }
 
 func (rc *rcClient) agentConfigUpdateCallback(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
-	mergedConfig, err := state.MergeRCAgentConfig(rc.client.UpdateApplyStatus, updates)
+	// Use the version-bound callback handed to this update, not the raw
+	// client.UpdateApplyStatus: the former drops a stale ack if a newer config
+	// version landed while we were processing. See Client.boundApplyStatus.
+	mergedConfig, err := state.MergeRCAgentConfig(applyStateCallback, updates)
 	if err != nil {
 		return
 	}
@@ -451,7 +454,9 @@ func (rc *rcClient) agentTaskUpdateCallback(updates map[string]state.RawConfig, 
 			defer pkglog.Debugf("Agent task %s completed", configPath)
 			task, err := types.ParseConfigAgentTask(c.Config, c.Metadata)
 			if err != nil {
-				rc.client.UpdateApplyStatus(configPath, state.ApplyStatus{
+				// Version-bound callback (not the raw client method) so a stale
+				// parse-error ack can't land on a newer config version.
+				applyStateCallback(configPath, state.ApplyStatus{
 					State: state.ApplyStateError,
 					Error: err.Error(),
 				})

--- a/pkg/clusteragent/kubeactions/action_store.go
+++ b/pkg/clusteragent/kubeactions/action_store.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// ActionTTL is how long actions are valid for execution
-	ActionTTL = 1 * time.Minute
+	ActionTTL = 2 * time.Minute
 	// RecordRetentionTTL is how long action records are kept in memory (24 hours)
 	// This allows for inspection and debugging of executed actions
 	RecordRetentionTTL = 24 * time.Hour

--- a/pkg/clusteragent/kubeactions/action_store.go
+++ b/pkg/clusteragent/kubeactions/action_store.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// ActionTTL is how long actions are valid for execution
-	ActionTTL = 2 * time.Minute
+	ActionTTL = 1 * time.Minute
 	// RecordRetentionTTL is how long action records are kept in memory (24 hours)
 	// This allows for inspection and debugging of executed actions
 	RecordRetentionTTL = 24 * time.Hour

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -13,6 +13,7 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"errors"
+	"os"
 	"slices"
 	"sync"
 	"time"
@@ -430,12 +431,27 @@ func (c *Client) pollLoop() {
 	logLimit := log.NewLogLimit(5, time.Minute)
 	interval := 0 * time.Second
 
+	// TEMP DEBUG (kube-actions): capture pod hostname once so we can correlate
+	// log lines with the current leader (see `kubectl get lease datadog-agent-leader-election`).
+	debugHost, _ := os.Hostname()
+	lastUpdateEnd := time.Now()
+
 	for {
 		select {
 		case <-c.ctx.Done():
 			return
 		case <-time.After(interval):
+			// TEMP DEBUG (kube-actions): log every pollLoop iteration to measure
+			// time spent inside update() (gRPC fetch + serial listener dispatch).
+			// `gap` is wall-clock time since the previous update() returned — a
+			// gap >> pollInterval means a listener (most likely workload
+			// autoscaling reconcile) blocked the loop on this pod.
+			updateStart := time.Now()
+			gap := updateStart.Sub(lastUpdateEnd)
 			err := c.update()
+			lastUpdateEnd = time.Now()
+			log.Infof("[RC-DEBUG] pollLoop host=%s products=%v gap=%s duration=%s err=%v",
+				debugHost, c.products, gap, lastUpdateEnd.Sub(updateStart), err)
 			if err != nil {
 				consecutiveFailures++
 				if status.Code(err) == codes.Unimplemented {

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -422,6 +422,19 @@ func (c *Client) UpdateApplyStatus(cfgPath string, status state.ApplyStatus) {
 	c.state.UpdateApplyStatus(cfgPath, status)
 }
 
+// UpdateApplyStatusIfVersion is the version-checked counterpart of
+// UpdateApplyStatus, for callers that ack outside of the OnUpdate callback
+// (e.g. a separate load/apply cycle that already holds the config's version).
+// It writes the status only if the repository still holds expectedVersion for
+// cfgPath, and drops the write otherwise so a stale ack can't land on a newer
+// version. Returns true if the status was applied.
+//
+// Listeners that ack from within OnUpdate should instead use the callback they
+// are handed — it is already bound to the snapshot's versions.
+func (c *Client) UpdateApplyStatusIfVersion(cfgPath string, expectedVersion uint64, status state.ApplyStatus) bool {
+	return c.state.UpdateApplyStatusIfVersion(cfgPath, expectedVersion, status)
+}
+
 // SetAgentName updates the agent name of the RC client
 // should only be used by the fx component
 func (c *Client) SetAgentName(agentName string) {

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -13,7 +13,6 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"errors"
-	"os"
 	"slices"
 	"sync"
 	"time"
@@ -354,13 +353,47 @@ func (c *Client) Start() {
 // After Close returns, no further OnUpdate or OnStateChange callback will
 // fire — callers can safely tear down resources their listeners depend on.
 // In-flight callbacks at the moment of Close run to completion before Close
-// returns; a stuck listener will therefore stall shutdown indefinitely (this
-// is the same hazard that existed for the poll loop before this refactor).
+// returns; a stuck listener will therefore stall shutdown indefinitely. Use
+// CloseTimeout when the caller can't tolerate that — e.g. agent shutdown.
 //
 // A client that has been closed cannot be restarted.
 func (c *Client) Close() {
-	c.closeFn()
+	c.cancelUnderLock()
 	c.wg.Wait()
+}
+
+// CloseTimeout is like Close but bounds how long it will wait for in-flight
+// listener callbacks to finish. It returns true if all workers drained within
+// the timeout, false if at least one is still running (in which case the
+// dispatcher goroutine is leaked — its listener should be considered stuck).
+//
+// The client context is always canceled before returning, so the poll loop
+// itself exits regardless of the result.
+func (c *Client) CloseTimeout(timeout time.Duration) bool {
+	c.cancelUnderLock()
+	done := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// cancelUnderLock cancels the client context with c.m held. Holding the lock
+// here is what makes SubscribeAll's "ctx.Err() != nil ⇒ skip wg.Add" check
+// race-free: any SubscribeAll that observes a nil ctx error under c.m is
+// guaranteed to complete its wg.Add(1) before this function (and therefore
+// before wg.Wait) runs, so sync.WaitGroup's "Add concurrent with Wait when
+// counter is zero" panic is impossible.
+func (c *Client) cancelUnderLock() {
+	c.m.Lock()
+	c.closeFn()
+	c.m.Unlock()
 }
 
 // GetClientID gets the client ID
@@ -395,11 +428,18 @@ func (c *Client) SubscribeAll(product string, listener Listener) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	// If Close has already canceled the context, there's no poll loop to
-	// dispatch updates and nothing for a worker to do. Dropping the
-	// subscription quietly is the right behaviour — adding more goroutines to
-	// the wg after Close has been called could leak past the Wait barrier.
+	// Race-free shutdown gate: Close cancels c.ctx while holding c.m (see
+	// cancelUnderLock). Because this check and the c.wg.Add(1) below also run
+	// under c.m, either:
+	//   (a) we observe a nil ctx error here and complete wg.Add before Close
+	//       can begin wg.Wait, or
+	//   (b) Close already canceled the ctx, we observe the error, and skip
+	//       wg.Add entirely.
+	// Without this serialization, wg.Add concurrent with wg.Wait at counter=0
+	// would panic. Log loudly because subscribing after Close is almost
+	// always a caller lifecycle bug.
 	if c.ctx.Err() != nil {
+		log.Warnf("remote-config: SubscribeAll(product=%s) called after Close; subscription dropped", product)
 		return
 	}
 
@@ -476,27 +516,12 @@ func (c *Client) pollLoop() {
 	logLimit := log.NewLogLimit(5, time.Minute)
 	interval := 0 * time.Second
 
-	// TEMP DEBUG (kube-actions): capture pod hostname once so we can correlate
-	// log lines with the current leader (see `kubectl get lease datadog-agent-leader-election`).
-	debugHost, _ := os.Hostname()
-	lastUpdateEnd := time.Now()
-
 	for {
 		select {
 		case <-c.ctx.Done():
 			return
 		case <-time.After(interval):
-			// TEMP DEBUG (kube-actions): log every pollLoop iteration to measure
-			// time spent inside update() (gRPC fetch + serial listener dispatch).
-			// `gap` is wall-clock time since the previous update() returned — a
-			// gap >> pollInterval means a listener (most likely workload
-			// autoscaling reconcile) blocked the loop on this pod.
-			updateStart := time.Now()
-			gap := updateStart.Sub(lastUpdateEnd)
 			err := c.update()
-			lastUpdateEnd = time.Now()
-			log.Infof("[RC-DEBUG] pollLoop host=%s products=%v gap=%s duration=%s err=%v",
-				debugHost, c.products, gap, lastUpdateEnd.Sub(updateStart), err)
 			if err != nil {
 				consecutiveFailures++
 				if status.Code(err) == codes.Unimplemented {
@@ -760,6 +785,12 @@ type listenerEntry struct {
 
 	// Fields below are owned by the dispatcher (poll loop side) for writes and
 	// the worker for reads/resets. mu protects them.
+	//
+	// Lock ordering: Client.m must always be acquired BEFORE listenerEntry.mu.
+	// The schedule* helpers are called from update()/broadcastStateChange with
+	// c.m held; no code path takes the reverse order, and adding one would
+	// risk a deadlock. The worker's run loop never acquires c.m, which keeps
+	// this discipline easy to maintain.
 	mu                 sync.Mutex
 	pendingConfigs     map[string]state.RawConfig
 	pendingApplyStatus func(string, state.ApplyStatus)

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -13,6 +13,7 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"errors"
+	"maps"
 	"slices"
 	"sync"
 	"time"
@@ -639,20 +640,27 @@ func (c *Client) update() error {
 			continue
 		}
 		// Snapshot once per product. state.GetConfigs returns a fresh map
-		// (see pkg/remoteconfig/state/configs.go), so it's safe to hand off
-		// to workers without further synchronization.
+		// (see pkg/remoteconfig/state/configs.go).
 		configs := c.state.GetConfigs(product)
 		// Bind the apply-status callback to the versions in *this* snapshot.
 		// A slow Listener.OnUpdate may finish after the next poll has already
 		// replaced the configs at these paths; without version-binding, the
 		// late ApplyStatus would stamp the new version's metadata with the
 		// result of processing the old config (see
-		// state.Repository.UpdateApplyStatusIfVersion).
+		// state.Repository.UpdateApplyStatusIfVersion). The closure only reads
+		// the captured versions and routes through a synchronized repository
+		// method, so it is safe to share across this product's listeners.
 		applyStatus := c.boundApplyStatus(configs)
 		for _, entry := range productListeners {
 			if response.ConfigStatus == pbgo.ConfigStatus_CONFIG_STATUS_OK ||
 				!entry.listener.ShouldIgnoreSignatureExpiration() {
-				entry.scheduleUpdate(configs, applyStatus)
+				// Hand each listener its own map so concurrent workers can't
+				// race on a shared instance if a listener mutates its input.
+				// This is a shallow clone — it isolates map-level mutations
+				// (add/delete/replace), matching the per-listener isolation the
+				// synchronous code provided. Config bodies ([]byte) are still
+				// shared, exactly as before; they must be treated read-only.
+				entry.scheduleUpdate(maps.Clone(configs), applyStatus)
 			}
 		}
 	}

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -13,8 +13,10 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -359,8 +361,11 @@ func (c *Client) Start() {
 //
 // A client that has been closed cannot be restarted.
 func (c *Client) Close() {
+	log.Infof("RC-ASYNC Close: canceling poll loop and waiting for all workers to drain (unbounded)")
 	c.cancelUnderLock()
+	start := time.Now()
 	c.wg.Wait()
+	log.Infof("RC-ASYNC Close: all workers drained in %s", time.Since(start))
 }
 
 // CloseTimeout is like Close but bounds how long it will wait for in-flight
@@ -371,16 +376,20 @@ func (c *Client) Close() {
 // The client context is always canceled before returning, so the poll loop
 // itself exits regardless of the result.
 func (c *Client) CloseTimeout(timeout time.Duration) bool {
+	log.Infof("RC-ASYNC CloseTimeout(%s): canceling poll loop and waiting for workers to drain", timeout)
 	c.cancelUnderLock()
 	done := make(chan struct{})
+	start := time.Now()
 	go func() {
 		c.wg.Wait()
 		close(done)
 	}()
 	select {
 	case <-done:
+		log.Infof("RC-ASYNC CloseTimeout: all workers drained in %s", time.Since(start))
 		return true
 	case <-time.After(timeout):
+		log.Infof("RC-ASYNC CloseTimeout: TIMED OUT after %s — at least one listener is stuck; leaking its worker", timeout)
 		return false
 	}
 }
@@ -471,6 +480,7 @@ func (c *Client) SubscribeAll(product string, listener Listener) {
 		entry.run(c.ctx)
 	}()
 	c.listeners[product] = append(c.listeners[product], entry)
+	log.Infof("RC-ASYNC SubscribeAll product=%s (%T) — worker spawned, now %d listener(s) for this product", product, listener, len(c.listeners[product]))
 }
 
 // Subscribe subscribes to config updates of a product.
@@ -517,6 +527,7 @@ func (c *Client) startFn() {
 		log.Warnf("remote-config: Start called after Close; poll loop not started")
 		return
 	}
+	log.Infof("RC-ASYNC starting poll loop: client_id=%s products=%v poll_interval=%s", c.ID, c.products, c.pollInterval)
 	c.wg.Add(1)
 	go func() {
 		defer c.wg.Done()
@@ -612,10 +623,15 @@ func (c *Client) update() error {
 		return err
 	}
 
+	// RC-ASYNC: time the fetch so a slow/blocking gRPC call is visible.
+	fetchStart := time.Now()
 	response, err := c.configFetcher.ClientGetConfigs(c.ctx, req)
 	if err != nil {
+		log.Infof("RC-ASYNC fetch failed after %s: %v", time.Since(fetchStart), err)
 		return err
 	}
+	log.Infof("RC-ASYNC fetched configs in %s: config_status=%s target_files=%d",
+		time.Since(fetchStart), response.ConfigStatus, len(response.TargetFiles))
 
 	// applyUpdate runs WITHOUT c.m: state.Repository synchronizes its own
 	// `configs` (configsMu) and `metadata` (metadataMu), so the poll loop's
@@ -624,11 +640,14 @@ func (c *Client) update() error {
 	// verification never blocks SubscribeAll / SetAgentName / GetConfigs.
 	changedProducts, err := c.applyUpdate(response)
 	if err != nil {
+		log.Infof("RC-ASYNC applyUpdate error: %v", err)
 		return err
 	}
 	if len(changedProducts) == 0 {
+		log.Infof("RC-ASYNC no changed products this poll (nothing to dispatch)")
 		return nil
 	}
+	log.Infof("RC-ASYNC applyUpdate produced changed_products=%v", changedProducts)
 
 	// c.m is taken only for the dispatch below, which reads Client-owned state
 	// (c.listeners). It is never held across listener work — scheduleUpdate
@@ -642,6 +661,8 @@ func (c *Client) update() error {
 		// Snapshot once per product. state.GetConfigs returns a fresh map
 		// (see pkg/remoteconfig/state/configs.go).
 		configs := c.state.GetConfigs(product)
+		log.Infof("RC-ASYNC dispatching product=%s configs=%d listeners=%d versions=%s",
+			product, len(configs), len(productListeners), formatConfigVersions(configs))
 		// Bind the apply-status callback to the versions in *this* snapshot.
 		// A slow Listener.OnUpdate may finish after the next poll has already
 		// replaced the configs at these paths; without version-binding, the
@@ -660,11 +681,24 @@ func (c *Client) update() error {
 				// (add/delete/replace), matching the per-listener isolation the
 				// synchronous code provided. Config bodies ([]byte) are still
 				// shared, exactly as before; they must be treated read-only.
+				log.Infof("RC-ASYNC staging update for listener product=%s (%T)", product, entry.listener)
 				entry.scheduleUpdate(maps.Clone(configs), applyStatus)
+			} else {
+				log.Infof("RC-ASYNC skipping listener product=%s (signature expired, listener opts out)", product)
 			}
 		}
 	}
 	return nil
+}
+
+// formatConfigVersions renders "path=version" pairs for logging. RC-ASYNC debug
+// helper only; safe to remove with the RC-ASYNC log lines.
+func formatConfigVersions(configs map[string]state.RawConfig) string {
+	parts := make([]string, 0, len(configs))
+	for path, cfg := range configs {
+		parts = append(parts, fmt.Sprintf("%s@v%d", path, cfg.Metadata.Version))
+	}
+	return "[" + strings.Join(parts, " ") + "]"
 }
 
 // boundApplyStatus returns an apply-status callback that drops writes for any
@@ -682,10 +716,13 @@ func (c *Client) boundApplyStatus(snapshot map[string]state.RawConfig) func(stri
 		if !ok {
 			// Path was not in the snapshot the listener received; nothing to
 			// safely write to. Drop.
+			log.Infof("RC-ASYNC apply-status DROPPED (unknown path) path=%s state=%d (not in the snapshot this listener received)", path, status.State)
 			return
 		}
-		if !c.state.UpdateApplyStatusIfVersion(path, expected, status) {
-			log.Debugf("remote-config: dropped stale apply-status for %s (expected v=%d superseded by newer update)", path, expected)
+		if c.state.UpdateApplyStatusIfVersion(path, expected, status) {
+			log.Infof("RC-ASYNC apply-status APPLIED path=%s v=%d state=%d", path, expected, status.State)
+		} else {
+			log.Infof("RC-ASYNC apply-status DROPPED (stale version) path=%s expected_v=%d state=%d (superseded by a newer update before the listener acked)", path, expected, status.State)
 		}
 	}
 }
@@ -701,11 +738,14 @@ func (c *Client) broadcastStateChange(connected bool) {
 	}
 	c.m.Lock()
 	defer c.m.Unlock()
+	n := 0
 	for _, productListeners := range c.listeners {
 		for _, entry := range productListeners {
 			entry.scheduleStateChange(connected)
+			n++
 		}
 	}
+	log.Infof("RC-ASYNC broadcastStateChange(connected=%t) staged for %d listener(s)", connected, n)
 }
 
 func containsProduct(products []string, product string) bool {
@@ -861,9 +901,15 @@ func (e *listenerEntry) scheduleUpdate(configs map[string]state.RawConfig, apply
 	e.mu.Lock()
 	// Overwrite any not-yet-consumed payload: the freshest snapshot supersedes
 	// older ones — that's the point of coalescing.
+	coalesced := e.pendingConfigs != nil
 	e.pendingConfigs = configs
 	e.pendingApplyStatus = applyStatus
 	e.mu.Unlock()
+	if coalesced {
+		// The worker hadn't drained the previous payload yet — it's a slow
+		// listener and we just collapsed an intermediate update into the latest.
+		log.Infof("RC-ASYNC COALESCED update for product=%s (worker still busy; previous snapshot superseded before delivery)", e.product)
+	}
 	e.signal()
 }
 
@@ -891,6 +937,7 @@ func (e *listenerEntry) run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			log.Infof("RC-ASYNC worker exiting product=%s (%T) — context canceled", e.product, e.listener)
 			return
 		case <-e.wake:
 			e.mu.Lock()
@@ -923,10 +970,17 @@ func (e *listenerEntry) deliver(stateChange *bool, configs map[string]state.RawC
 	}()
 
 	if stateChange != nil {
+		log.Infof("RC-ASYNC -> OnStateChange(connected=%t) product=%s (%T)", *stateChange, e.product, e.listener)
 		e.listener.OnStateChange(*stateChange)
 	}
 	if configs != nil {
+		log.Infof("RC-ASYNC -> OnUpdate product=%s (%T) configs=%d — calling listener", e.product, e.listener, len(configs))
+		start := time.Now()
 		e.listener.OnUpdate(configs, applyStatus)
+		elapsed := time.Since(start)
+		// A long elapsed here is the slow-listener case the async dispatch is
+		// designed to tolerate — it no longer blocks polling or other listeners.
+		log.Infof("RC-ASYNC <- OnUpdate returned product=%s (%T) took=%s", e.product, e.listener, elapsed)
 	}
 }
 

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -401,7 +401,13 @@ func (c *Client) GetClientID() string {
 	return c.ID
 }
 
-// UpdateApplyStatus updates the config's metadata to reflect its applied status
+// UpdateApplyStatus updates the config's metadata to reflect its applied status.
+//
+// This is the non-version-checked variant: it writes by path only. Listeners
+// reacting to an update should prefer the apply-status callback passed into
+// OnUpdate, which is version-bound to the snapshot they received and therefore
+// safe against a newer config version landing while they process — see
+// Client.boundApplyStatus and state.Repository.UpdateApplyStatusIfVersion.
 func (c *Client) UpdateApplyStatus(cfgPath string, status state.ApplyStatus) {
 	c.state.UpdateApplyStatus(cfgPath, status)
 }
@@ -499,6 +505,17 @@ func (c *Client) SetInstallerState(state *pbgo.ClientUpdater) {
 }
 
 func (c *Client) startFn() {
+	// Guard wg.Add against a Close that races Start: like SubscribeAll, the
+	// check and the Add run under c.m, and cancelUnderLock cancels under c.m.
+	// So either we Add before Close begins wg.Wait, or we observe the canceled
+	// ctx and skip starting the poll loop entirely — never wg.Add concurrent
+	// with wg.Wait at counter zero (which panics).
+	c.m.Lock()
+	defer c.m.Unlock()
+	if c.ctx.Err() != nil {
+		log.Warnf("remote-config: Start called after Close; poll loop not started")
+		return
+	}
 	c.wg.Add(1)
 	go func() {
 		defer c.wg.Done()
@@ -599,13 +616,11 @@ func (c *Client) update() error {
 		return err
 	}
 
-	// applyUpdate mutates c.state (configs map); the lock is held both to keep
-	// listeners stable for the snapshot/dispatch below and to serialize this
-	// mutation with any concurrent external readers of c.state (e.g. the
-	// public Client.GetConfigs, which also takes c.m).
-	c.m.Lock()
-	defer c.m.Unlock()
-
+	// applyUpdate runs WITHOUT c.m: state.Repository synchronizes its own
+	// `configs` (configsMu) and `metadata` (metadataMu), so the poll loop's
+	// mutation here is already safe against concurrent readers such as the
+	// public Client.GetConfigs. Keeping it off c.m means a poll's TUF
+	// verification never blocks SubscribeAll / SetAgentName / GetConfigs.
 	changedProducts, err := c.applyUpdate(response)
 	if err != nil {
 		return err
@@ -614,22 +629,57 @@ func (c *Client) update() error {
 		return nil
 	}
 
+	// c.m is taken only for the dispatch below, which reads Client-owned state
+	// (c.listeners). It is never held across listener work — scheduleUpdate
+	// just stages a payload and signals a worker.
+	c.m.Lock()
+	defer c.m.Unlock()
 	for product, productListeners := range c.listeners {
 		if !containsProduct(changedProducts, product) {
 			continue
 		}
-		// Snapshot once per product while still holding c.m — state.GetConfigs
-		// returns a fresh map (see pkg/remoteconfig/state/configs.go), so it is
-		// safe to hand off to workers without further synchronization.
+		// Snapshot once per product. state.GetConfigs returns a fresh map
+		// (see pkg/remoteconfig/state/configs.go), so it's safe to hand off
+		// to workers without further synchronization.
 		configs := c.state.GetConfigs(product)
+		// Bind the apply-status callback to the versions in *this* snapshot.
+		// A slow Listener.OnUpdate may finish after the next poll has already
+		// replaced the configs at these paths; without version-binding, the
+		// late ApplyStatus would stamp the new version's metadata with the
+		// result of processing the old config (see
+		// state.Repository.UpdateApplyStatusIfVersion).
+		applyStatus := c.boundApplyStatus(configs)
 		for _, entry := range productListeners {
 			if response.ConfigStatus == pbgo.ConfigStatus_CONFIG_STATUS_OK ||
 				!entry.listener.ShouldIgnoreSignatureExpiration() {
-				entry.scheduleUpdate(configs, c.state.UpdateApplyStatus)
+				entry.scheduleUpdate(configs, applyStatus)
 			}
 		}
 	}
 	return nil
+}
+
+// boundApplyStatus returns an apply-status callback that drops writes for any
+// config path whose version no longer matches the one in the supplied
+// snapshot. This is the load-bearing piece for correctness against slow
+// listeners: a stale callback from an in-progress OnUpdate must not overwrite
+// the apply status of a newer config version.
+func (c *Client) boundApplyStatus(snapshot map[string]state.RawConfig) func(string, state.ApplyStatus) {
+	versions := make(map[string]uint64, len(snapshot))
+	for path, cfg := range snapshot {
+		versions[path] = cfg.Metadata.Version
+	}
+	return func(path string, status state.ApplyStatus) {
+		expected, ok := versions[path]
+		if !ok {
+			// Path was not in the snapshot the listener received; nothing to
+			// safely write to. Drop.
+			return
+		}
+		if !c.state.UpdateApplyStatusIfVersion(path, expected, status) {
+			log.Debugf("remote-config: dropped stale apply-status for %s (expected v=%d superseded by newer update)", path, expected)
+		}
+	}
 }
 
 // broadcastStateChange dispatches an OnStateChange signal to every registered

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -118,6 +118,10 @@ type Client struct {
 	startupSync sync.Once
 	ctx         context.Context
 	closeFn     context.CancelFunc
+	// wg tracks every goroutine spawned by the client (poll loop + per-listener
+	// dispatchers). Close blocks on wg.Wait so callers can rely on "no more
+	// listener callbacks fire after Close returns."
+	wg sync.WaitGroup
 
 	lastUpdateError   error
 	backoffPolicy     backoff.Policy
@@ -127,7 +131,7 @@ type Client struct {
 
 	state *state.Repository
 
-	listeners map[string][]Listener
+	listeners map[string][]*listenerEntry
 
 	// Elements that can be changed during the execution of listeners
 	// They are atomics so that they don't have to share the top-level mutex
@@ -331,7 +335,7 @@ func newClient(cf ConfigFetcher, opts ...func(opts *Options)) (*Client, error) {
 		installerState: installerState,
 		state:          repository,
 		backoffPolicy:  backoffPolicy,
-		listeners:      make(map[string][]Listener),
+		listeners:      make(map[string][]*listenerEntry),
 		configFetcher:  cf,
 	}, nil
 }
@@ -344,11 +348,19 @@ func (c *Client) Start() {
 	c.startupSync.Do(c.startFn)
 }
 
-// Close terminates the client's poll loop.
+// Close terminates the client's poll loop and waits for every dispatcher
+// goroutine to drain.
 //
-// A client that has been closed cannot be restarted
+// After Close returns, no further OnUpdate or OnStateChange callback will
+// fire — callers can safely tear down resources their listeners depend on.
+// In-flight callbacks at the moment of Close run to completion before Close
+// returns; a stuck listener will therefore stall shutdown indefinitely (this
+// is the same hazard that existed for the poll loop before this refactor).
+//
+// A client that has been closed cannot be restarted.
 func (c *Client) Close() {
 	c.closeFn()
+	c.wg.Wait()
 }
 
 // GetClientID gets the client ID
@@ -371,10 +383,25 @@ func (c *Client) SetAgentName(agentName string) {
 	}
 }
 
-// SubscribeAll subscribes to all events (config updates, state changed, ...)
+// SubscribeAll subscribes to all events (config updates, state changed, ...).
+//
+// Each subscription gets its own dispatcher goroutine. OnUpdate / OnStateChange
+// calls into the listener are serialized per-listener but run independently of
+// the poll loop and of other listeners — a slow listener cannot delay polling
+// or block other subscribers. Signals are coalescing (cap=1): if multiple poll
+// iterations arrive before the listener drains, only the freshest snapshot is
+// delivered.
 func (c *Client) SubscribeAll(product string, listener Listener) {
 	c.m.Lock()
 	defer c.m.Unlock()
+
+	// If Close has already canceled the context, there's no poll loop to
+	// dispatch updates and nothing for a worker to do. Dropping the
+	// subscription quietly is the right behaviour — adding more goroutines to
+	// the wg after Close has been called could leak past the Wait barrier.
+	if c.ctx.Err() != nil {
+		return
+	}
 
 	// Make sure the product belongs to the list of requested product
 	knownProduct := slices.Contains(c.products, product)
@@ -382,7 +409,21 @@ func (c *Client) SubscribeAll(product string, listener Listener) {
 		c.products = append(c.products, product)
 	}
 
-	c.listeners[product] = append(c.listeners[product], listener)
+	entry := &listenerEntry{
+		listener: listener,
+		product:  product,
+		wake:     make(chan struct{}, 1),
+	}
+	// The worker is tied to the client's ctx, so Close() cancellation tears it
+	// down. Spawning here (rather than at Start) means subscribers that register
+	// before Start still get a worker — wake signals just queue until update()
+	// fires for the first time.
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		entry.run(c.ctx)
+	}()
+	c.listeners[product] = append(c.listeners[product], entry)
 }
 
 // Subscribe subscribes to config updates of a product.
@@ -418,7 +459,11 @@ func (c *Client) SetInstallerState(state *pbgo.ClientUpdater) {
 }
 
 func (c *Client) startFn() {
-	go c.pollLoop()
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.pollLoop()
+	}()
 }
 
 // pollLoop is the main polling loop of the client.
@@ -476,13 +521,7 @@ func (c *Client) pollLoop() {
 						}
 					}
 				} else {
-					c.m.Lock()
-					for _, productListeners := range c.listeners {
-						for _, listener := range productListeners {
-							listener.OnStateChange(false)
-						}
-					}
-					c.m.Unlock()
+					c.broadcastStateChange(false)
 
 					c.lastUpdateError = err
 					c.backoffErrorCount = c.backoffPolicy.IncError(c.backoffErrorCount)
@@ -491,13 +530,7 @@ func (c *Client) pollLoop() {
 			} else {
 				log.Debugf("update successful: successful_first_run:%t, consecutive failures:%d", successfulFirstRun, consecutiveFailures)
 				if c.lastUpdateError != nil {
-					c.m.Lock()
-					for _, productListeners := range c.listeners {
-						for _, listener := range productListeners {
-							listener.OnStateChange(true)
-						}
-					}
-					c.m.Unlock()
+					c.broadcastStateChange(true)
 				}
 
 				// record and report that the first update was successful
@@ -526,6 +559,10 @@ func (c *Client) pollLoop() {
 // update requests a config updates from the agent via the secure grpc channel and
 // applies that update, informing any registered listeners of any config state changes
 // that occurred.
+//
+// Listener dispatch is asynchronous: each listener owns a worker goroutine,
+// and update() only enqueues a coalescing wake-up. update() never blocks on
+// listener work, so a slow listener cannot delay polling.
 func (c *Client) update() error {
 	req, err := c.newUpdateRequest()
 	if err != nil {
@@ -537,29 +574,55 @@ func (c *Client) update() error {
 		return err
 	}
 
+	// applyUpdate mutates c.state (configs map); the lock is held both to keep
+	// listeners stable for the snapshot/dispatch below and to serialize this
+	// mutation with any concurrent external readers of c.state (e.g. the
+	// public Client.GetConfigs, which also takes c.m).
+	c.m.Lock()
+	defer c.m.Unlock()
+
 	changedProducts, err := c.applyUpdate(response)
 	if err != nil {
 		return err
 	}
-	// We don't want to force the products to reload config if nothing changed
-	// in the latest update.
 	if len(changedProducts) == 0 {
 		return nil
 	}
 
-	c.m.Lock()
-	defer c.m.Unlock()
 	for product, productListeners := range c.listeners {
-		if containsProduct(changedProducts, product) {
-			for _, listener := range productListeners {
-				if response.ConfigStatus == pbgo.ConfigStatus_CONFIG_STATUS_OK ||
-					!listener.ShouldIgnoreSignatureExpiration() {
-					listener.OnUpdate(c.state.GetConfigs(product), c.state.UpdateApplyStatus)
-				}
+		if !containsProduct(changedProducts, product) {
+			continue
+		}
+		// Snapshot once per product while still holding c.m — state.GetConfigs
+		// returns a fresh map (see pkg/remoteconfig/state/configs.go), so it is
+		// safe to hand off to workers without further synchronization.
+		configs := c.state.GetConfigs(product)
+		for _, entry := range productListeners {
+			if response.ConfigStatus == pbgo.ConfigStatus_CONFIG_STATUS_OK ||
+				!entry.listener.ShouldIgnoreSignatureExpiration() {
+				entry.scheduleUpdate(configs, c.state.UpdateApplyStatus)
 			}
 		}
 	}
 	return nil
+}
+
+// broadcastStateChange dispatches an OnStateChange signal to every registered
+// listener via its worker goroutine. Like update(), this is non-blocking — the
+// poll loop is never held up by listener work.
+func (c *Client) broadcastStateChange(connected bool) {
+	// Best-effort skip post-Close: the workers may have already exited and
+	// signaling them just leaves dead wake messages in their channels until GC.
+	if c.ctx.Err() != nil {
+		return
+	}
+	c.m.Lock()
+	defer c.m.Unlock()
+	for _, productListeners := range c.listeners {
+		for _, entry := range productListeners {
+			entry.scheduleStateChange(connected)
+		}
+	}
 }
 
 func containsProduct(products []string, product string) bool {
@@ -668,6 +731,114 @@ func (c *Client) newUpdateRequest() (*pbgo.ClientGetConfigsRequest, error) {
 	}
 
 	return req, nil
+}
+
+// listenerEntry holds a registered Listener and the dispatcher goroutine that
+// delivers events to it. One entry per Subscribe / SubscribeAll call.
+//
+// Dispatch contract:
+//   - Calls into the wrapped Listener (OnUpdate, OnStateChange) are always
+//     serialized for a given entry — the worker is single-threaded.
+//   - Wake signals are coalescing (wake has cap=1). If multiple poll
+//     iterations enqueue work before the worker drains, the worker sees only
+//     the most-recently-staged payload. This is the property that protects the
+//     poll loop from a slow listener: pending iterations collapse instead of
+//     piling up.
+//   - OnStateChange similarly carries only the latest known state. Rapid
+//     toggles can be lost; this matches the existing behaviour of
+//     pollLoop, which only fires OnStateChange on transitions.
+//   - When the client context is canceled (Client.Close), the worker exits
+//     after finishing any in-flight callback. A pending wake that arrives
+//     after cancellation is discarded — the worker prefers ctx.Done.
+type listenerEntry struct {
+	listener Listener
+	product  string
+
+	// wake signals "drain pending fields". cap=1 + non-blocking sender =
+	// coalescing semantics; queued signals don't grow unbounded.
+	wake chan struct{}
+
+	// Fields below are owned by the dispatcher (poll loop side) for writes and
+	// the worker for reads/resets. mu protects them.
+	mu                 sync.Mutex
+	pendingConfigs     map[string]state.RawConfig
+	pendingApplyStatus func(string, state.ApplyStatus)
+	pendingStateChange *bool
+}
+
+// scheduleUpdate stages a new OnUpdate payload and wakes the worker.
+// Called from the poll loop with c.m held.
+func (e *listenerEntry) scheduleUpdate(configs map[string]state.RawConfig, applyStatus func(string, state.ApplyStatus)) {
+	e.mu.Lock()
+	// Overwrite any not-yet-consumed payload: the freshest snapshot supersedes
+	// older ones — that's the point of coalescing.
+	e.pendingConfigs = configs
+	e.pendingApplyStatus = applyStatus
+	e.mu.Unlock()
+	e.signal()
+}
+
+// scheduleStateChange stages an OnStateChange and wakes the worker. The latest
+// staged value wins.
+func (e *listenerEntry) scheduleStateChange(connected bool) {
+	v := connected
+	e.mu.Lock()
+	e.pendingStateChange = &v
+	e.mu.Unlock()
+	e.signal()
+}
+
+func (e *listenerEntry) signal() {
+	select {
+	case e.wake <- struct{}{}:
+	default:
+		// A wake is already queued; the worker will pick up the freshest fields
+		// when it drains. Dropping here is intentional.
+	}
+}
+
+// run is the dispatcher loop. Exits when ctx is canceled.
+func (e *listenerEntry) run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-e.wake:
+			e.mu.Lock()
+			configs := e.pendingConfigs
+			applyStatus := e.pendingApplyStatus
+			stateChange := e.pendingStateChange
+			e.pendingConfigs = nil
+			e.pendingApplyStatus = nil
+			e.pendingStateChange = nil
+			e.mu.Unlock()
+
+			e.deliver(stateChange, configs, applyStatus)
+		}
+	}
+}
+
+// deliver invokes the listener callbacks for a single drain. Wrapped in its
+// own function so the deferred recover() runs after each delivery, not at the
+// end of run(); a panicking listener stays subscribed and keeps receiving
+// future updates, and the process is not torn down by one buggy callback.
+//
+// OnStateChange runs first: it conveys whether RC is currently reachable,
+// which a listener may want to know before processing the accompanying
+// OnUpdate (if any).
+func (e *listenerEntry) deliver(stateChange *bool, configs map[string]state.RawConfig, applyStatus func(string, state.ApplyStatus)) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("remote-config listener for product=%s panicked, dropping this update: %v", e.product, r)
+		}
+	}()
+
+	if stateChange != nil {
+		e.listener.OnStateChange(*stateChange)
+	}
+	if configs != nil {
+		e.listener.OnUpdate(configs, applyStatus)
+	}
 }
 
 type listener struct {

--- a/pkg/config/remote/client/client_test.go
+++ b/pkg/config/remote/client/client_test.go
@@ -423,6 +423,153 @@ func TestClient_SubscribeAfterCloseIsNoop(t *testing.T) {
 	c.m.Unlock()
 }
 
+// TestClient_SubscribeAllRegistersWorkerTrackedByWg verifies the
+// SubscribeAll → worker-goroutine → wg path end-to-end: after a real
+// SubscribeAll, Close() must drain the dispatcher (a future refactor that
+// forgets to wg.Add on the worker would hang or race here).
+func TestClient_SubscribeAllRegistersWorkerTrackedByWg(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &Client{
+		ctx:       ctx,
+		closeFn:   cancel,
+		listeners: make(map[string][]*listenerEntry),
+	}
+
+	l := &mockListener{}
+	c.SubscribeAll("p", l)
+
+	c.m.Lock()
+	require.Len(t, c.listeners["p"], 1, "SubscribeAll should register exactly one entry")
+	require.Contains(t, c.products, "p", "SubscribeAll should track the product")
+	c.m.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		c.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not return — worker goroutine is not tracked in wg")
+	}
+}
+
+// TestClient_SubscribeAllRaceWithClose hammers concurrent SubscribeAll/Close
+// to verify the wg.Add ↔ wg.Wait race documented in cancelUnderLock cannot
+// trigger sync.WaitGroup's "Add concurrent with Wait" panic. Run with -race.
+func TestClient_SubscribeAllRaceWithClose(t *testing.T) {
+	for iter := 0; iter < 50; iter++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		c := &Client{
+			ctx:       ctx,
+			closeFn:   cancel,
+			listeners: make(map[string][]*listenerEntry),
+		}
+
+		var wg sync.WaitGroup
+		// Fire several SubscribeAll calls in parallel with Close. Whichever
+		// wins, none of them must panic.
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				c.SubscribeAll("p", &mockListener{})
+			}()
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.Close()
+		}()
+		wg.Wait()
+
+		// Drain any worker that won the race.
+		c.Close()
+	}
+}
+
+// TestClient_RecoveryStateChangeDeliveredBeforeUpdate covers the
+// error→success transition that pollLoop fires: broadcastStateChange(true) is
+// staged, then update() stages a fresh OnUpdate. When both land in a single
+// drain, the listener must see OnStateChange first so it knows RC is back
+// before processing the accompanying snapshot.
+func TestClient_RecoveryStateChangeDeliveredBeforeUpdate(t *testing.T) {
+	ordered := make(chan string, 4)
+	l := &deliveryOrderListener{ch: ordered}
+
+	gateOpen := make(chan struct{})
+	l.gate = gateOpen
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	c := &Client{
+		ctx:       ctx,
+		closeFn:   cancel,
+		listeners: make(map[string][]*listenerEntry),
+	}
+
+	entry := &listenerEntry{listener: l, wake: make(chan struct{}, 1)}
+	go entry.run(ctx)
+	c.listeners["p"] = []*listenerEntry{entry}
+
+	// Park the worker inside a sentinel OnUpdate so the recovery signals
+	// accumulate in pending fields.
+	entry.scheduleUpdate(map[string]state.RawConfig{"warm": {}}, nil)
+	require.Eventually(t, l.inGate, time.Second, 5*time.Millisecond)
+
+	// Recovery path: pollLoop calls broadcastStateChange(true) right before
+	// the next successful update() dispatches its snapshot.
+	c.broadcastStateChange(true)
+	entry.scheduleUpdate(map[string]state.RawConfig{"recovered": {}}, nil)
+
+	close(gateOpen)
+
+	require.Eventually(t, func() bool { return len(ordered) >= 3 },
+		time.Second, 5*time.Millisecond)
+	got := drainChan(ordered)
+	assert.Equal(t, []string{"update", "state", "update"}, got,
+		"on recovery, OnStateChange(true) must precede the OnUpdate in the same drain")
+}
+
+// TestClient_CloseTimeout verifies that CloseTimeout returns false promptly
+// when a listener is stuck, and true once it finishes. Either way the client
+// context is canceled.
+func TestClient_CloseTimeout(t *testing.T) {
+	release := make(chan struct{})
+	l := &mockListener{onUpdateHook: func() { <-release }}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &Client{
+		ctx:       ctx,
+		closeFn:   cancel,
+		listeners: make(map[string][]*listenerEntry),
+	}
+	entry := &listenerEntry{listener: l, wake: make(chan struct{}, 1)}
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		entry.run(c.ctx)
+	}()
+	c.listeners["p"] = []*listenerEntry{entry}
+
+	entry.scheduleUpdate(map[string]state.RawConfig{}, nil)
+	require.Eventually(t, func() bool { return l.inflight.Load() == 1 },
+		time.Second, 5*time.Millisecond)
+
+	start := time.Now()
+	ok := c.CloseTimeout(50 * time.Millisecond)
+	elapsed := time.Since(start)
+	assert.False(t, ok, "CloseTimeout should report failure when listener is stuck")
+	assert.Less(t, elapsed, 200*time.Millisecond, "CloseTimeout overshot its deadline")
+	assert.Error(t, c.ctx.Err(), "ctx should be canceled even on timeout")
+
+	// Release the listener and verify a follow-up CloseTimeout drains cleanly.
+	close(release)
+	assert.True(t, c.CloseTimeout(time.Second),
+		"CloseTimeout should report success once listeners finish")
+}
+
 // TestClient_BroadcastStateChange_NonBlocking confirms broadcastStateChange
 // returns promptly even when a listener's worker is busy.
 func TestClient_BroadcastStateChange_NonBlocking(t *testing.T) {

--- a/pkg/config/remote/client/client_test.go
+++ b/pkg/config/remote/client/client_test.go
@@ -1,0 +1,467 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package client
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+)
+
+// mockListener captures OnUpdate / OnStateChange calls and (optionally) injects
+// latency or counts concurrency.
+type mockListener struct {
+	mu           sync.Mutex
+	updates      []map[string]state.RawConfig
+	stateChanges []bool
+
+	onUpdateHook func()
+
+	inflight    atomic.Int32
+	maxInflight atomic.Int32
+}
+
+func (m *mockListener) OnUpdate(configs map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
+	n := m.inflight.Add(1)
+	for {
+		prev := m.maxInflight.Load()
+		if n <= prev || m.maxInflight.CompareAndSwap(prev, n) {
+			break
+		}
+	}
+	defer m.inflight.Add(-1)
+
+	if m.onUpdateHook != nil {
+		m.onUpdateHook()
+	}
+
+	m.mu.Lock()
+	m.updates = append(m.updates, configs)
+	m.mu.Unlock()
+}
+
+func (m *mockListener) OnStateChange(connected bool) {
+	m.mu.Lock()
+	m.stateChanges = append(m.stateChanges, connected)
+	m.mu.Unlock()
+}
+
+func (*mockListener) ShouldIgnoreSignatureExpiration() bool { return true }
+
+func (m *mockListener) updateCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.updates)
+}
+
+func (m *mockListener) stateChangeCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.stateChanges)
+}
+
+// newTestEntry wires up a listenerEntry with a dispatcher goroutine that
+// terminates when the test ends.
+func newTestEntry(t *testing.T, l Listener) *listenerEntry {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	e := &listenerEntry{
+		listener: l,
+		wake:     make(chan struct{}, 1),
+	}
+	go e.run(ctx)
+	return e
+}
+
+func TestListenerEntry_DeliversUpdate(t *testing.T) {
+	l := &mockListener{}
+	e := newTestEntry(t, l)
+
+	snapshot := map[string]state.RawConfig{"path/a": {}}
+	e.scheduleUpdate(snapshot, nil)
+
+	require.Eventually(t, func() bool { return l.updateCount() == 1 },
+		time.Second, 5*time.Millisecond)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	assert.Equal(t, snapshot, l.updates[0])
+}
+
+func TestListenerEntry_DeliversStateChange(t *testing.T) {
+	l := &mockListener{}
+	e := newTestEntry(t, l)
+
+	e.scheduleStateChange(false)
+
+	require.Eventually(t, func() bool { return l.stateChangeCount() == 1 },
+		time.Second, 5*time.Millisecond)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	assert.Equal(t, []bool{false}, l.stateChanges)
+}
+
+// TestListenerEntry_CoalescesUpdates verifies that schedules arriving while the
+// worker is busy collapse into a single delivery carrying the freshest
+// snapshot.
+func TestListenerEntry_CoalescesUpdates(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	firstCall := atomic.Bool{}
+
+	l := &mockListener{
+		onUpdateHook: func() {
+			// Block the first OnUpdate so subsequent schedules pile up. Later
+			// calls fall through immediately.
+			if firstCall.CompareAndSwap(false, true) {
+				close(started)
+				<-release
+			}
+		},
+	}
+	e := newTestEntry(t, l)
+
+	s1 := map[string]state.RawConfig{"a": {Config: []byte("1")}}
+	s2 := map[string]state.RawConfig{"b": {Config: []byte("2")}}
+	s3 := map[string]state.RawConfig{"c": {Config: []byte("3")}}
+
+	e.scheduleUpdate(s1, nil)
+	<-started // first OnUpdate is now blocked
+
+	// While blocked, push two more schedules. Only the latest snapshot should
+	// be visible when the worker resumes.
+	e.scheduleUpdate(s2, nil)
+	e.scheduleUpdate(s3, nil)
+
+	close(release)
+
+	require.Eventually(t, func() bool { return l.updateCount() == 2 },
+		time.Second, 5*time.Millisecond)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	assert.Equal(t, s1, l.updates[0])
+	assert.Equal(t, s3, l.updates[1], "expected s2 to be coalesced away")
+}
+
+// TestListenerEntry_SerialDispatch asserts that the worker never invokes
+// OnUpdate concurrently with itself for the same entry, even under a flood of
+// schedules.
+func TestListenerEntry_SerialDispatch(t *testing.T) {
+	l := &mockListener{
+		onUpdateHook: func() { time.Sleep(2 * time.Millisecond) },
+	}
+	e := newTestEntry(t, l)
+
+	for i := 0; i < 100; i++ {
+		e.scheduleUpdate(map[string]state.RawConfig{}, nil)
+	}
+
+	// Wait for the worker to drain whatever wasn't coalesced.
+	require.Eventually(t, func() bool { return l.inflight.Load() == 0 && l.updateCount() >= 1 },
+		2*time.Second, 5*time.Millisecond)
+
+	assert.Equal(t, int32(1), l.maxInflight.Load(),
+		"OnUpdate must never run concurrently for the same listener")
+}
+
+// TestListenerEntry_StateChangeBeforeUpdate confirms that when both an
+// OnStateChange and an OnUpdate are pending in a single drain, the state
+// change is delivered first.
+func TestListenerEntry_StateChangeBeforeUpdate(t *testing.T) {
+	ordered := make(chan string, 4)
+	l := &deliveryOrderListener{ch: ordered}
+
+	// Spawn entry but DO NOT consume yet — we want both signals staged before
+	// the worker drains. We do this by holding the worker via a hook on the
+	// first iteration. Instead we just schedule both back-to-back; since
+	// scheduleUpdate signals only after the field is set, and the worker won't
+	// start draining instantly, both fields land before a single wake fires.
+	//
+	// To guarantee both land in the same drain, prime the worker via a busy
+	// hook on a sentinel call first.
+	gateOpen := make(chan struct{})
+	l.gate = gateOpen
+
+	e := newTestEntry(t, l)
+
+	// Sentinel: enqueue an update that blocks the worker so the next two
+	// schedules accumulate in pending fields.
+	e.scheduleUpdate(map[string]state.RawConfig{"warm": {}}, nil)
+	// Wait for the worker to be inside the sentinel call.
+	require.Eventually(t, func() bool { return l.inGate() }, time.Second, 5*time.Millisecond)
+
+	// Stage both fields while the worker is parked.
+	e.scheduleStateChange(true)
+	e.scheduleUpdate(map[string]state.RawConfig{"hot": {}}, nil)
+
+	// Release the worker.
+	close(gateOpen)
+
+	// Expect: sentinel update, then state change, then hot update.
+	require.Eventually(t, func() bool { return len(ordered) >= 3 },
+		time.Second, 5*time.Millisecond)
+
+	got := drainChan(ordered)
+	assert.Equal(t, []string{"update", "state", "update"}, got)
+}
+
+func drainChan(ch chan string) []string {
+	out := []string{}
+	for {
+		select {
+		case v := <-ch:
+			out = append(out, v)
+		default:
+			return out
+		}
+	}
+}
+
+// deliveryOrderListener records the sequence of OnUpdate vs OnStateChange calls
+// and lets the test park the worker inside the first OnUpdate.
+type deliveryOrderListener struct {
+	ch chan string
+
+	mu   sync.Mutex
+	gate <-chan struct{}
+	in   bool
+}
+
+func (d *deliveryOrderListener) inGate() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.in
+}
+
+func (d *deliveryOrderListener) OnUpdate(_ map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
+	d.mu.Lock()
+	gate := d.gate
+	d.gate = nil
+	if gate != nil {
+		d.in = true
+	}
+	d.mu.Unlock()
+
+	if gate != nil {
+		<-gate
+		d.mu.Lock()
+		d.in = false
+		d.mu.Unlock()
+	}
+	d.ch <- "update"
+}
+
+func (d *deliveryOrderListener) OnStateChange(_ bool) {
+	d.ch <- "state"
+}
+
+func (*deliveryOrderListener) ShouldIgnoreSignatureExpiration() bool { return true }
+
+// TestListenerEntry_ExitsOnContextCancel verifies the dispatcher goroutine
+// exits when the client context is canceled.
+func TestListenerEntry_ExitsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	e := &listenerEntry{
+		listener: &mockListener{},
+		wake:     make(chan struct{}, 1),
+	}
+	done := make(chan struct{})
+	go func() {
+		e.run(ctx)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not exit after ctx cancel")
+	}
+}
+
+// TestListenerEntry_SignalDoesNotBlock asserts that scheduleUpdate is
+// non-blocking even when the worker is stuck inside OnUpdate. This is the
+// load-bearing property: a slow listener cannot delay the poll loop.
+func TestListenerEntry_SignalDoesNotBlock(t *testing.T) {
+	stuck := make(chan struct{})
+	l := &mockListener{
+		onUpdateHook: func() { <-stuck },
+	}
+	e := newTestEntry(t, l)
+	t.Cleanup(func() { close(stuck) })
+
+	// Park the worker inside OnUpdate.
+	e.scheduleUpdate(map[string]state.RawConfig{}, nil)
+	require.Eventually(t, func() bool { return l.inflight.Load() == 1 },
+		time.Second, 5*time.Millisecond)
+
+	// Now flood scheduleUpdate calls — none should block on the stuck worker.
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for i := 0; i < 10_000; i++ {
+		e.scheduleUpdate(map[string]state.RawConfig{}, nil)
+	}
+	require.True(t, time.Now().Before(deadline),
+		"scheduleUpdate blocked while worker was stuck — this defeats the whole design")
+}
+
+// TestListenerEntry_RecoversFromPanic verifies that a panicking listener does
+// not kill the dispatcher goroutine — subsequent updates still get delivered.
+func TestListenerEntry_RecoversFromPanic(t *testing.T) {
+	calls := atomic.Int32{}
+	l := &mockListener{
+		onUpdateHook: func() {
+			if calls.Add(1) == 1 {
+				panic("boom")
+			}
+		},
+	}
+	e := newTestEntry(t, l)
+
+	e.scheduleUpdate(map[string]state.RawConfig{"a": {}}, nil)
+	// Wait for the panicking call to be observed by the listener counter.
+	require.Eventually(t, func() bool { return calls.Load() >= 1 },
+		time.Second, 5*time.Millisecond)
+
+	// Schedule a second update; if the dispatcher survived the panic, it
+	// should be delivered.
+	e.scheduleUpdate(map[string]state.RawConfig{"b": {}}, nil)
+	require.Eventually(t, func() bool { return calls.Load() >= 2 },
+		time.Second, 5*time.Millisecond)
+}
+
+// TestClient_CloseWaitsForInflightCallback verifies that Close blocks until
+// any in-flight OnUpdate finishes — callers can rely on "no callbacks after
+// Close returns" when tearing down listener-owned resources.
+func TestClient_CloseWaitsForInflightCallback(t *testing.T) {
+	release := make(chan struct{})
+	finished := atomic.Bool{}
+	l := &mockListener{
+		onUpdateHook: func() {
+			<-release
+			finished.Store(true)
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &Client{
+		ctx:       ctx,
+		closeFn:   cancel,
+		listeners: make(map[string][]*listenerEntry),
+	}
+
+	entry := &listenerEntry{listener: l, wake: make(chan struct{}, 1)}
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		entry.run(c.ctx)
+	}()
+	c.listeners["p"] = []*listenerEntry{entry}
+
+	// Park the worker inside OnUpdate.
+	entry.scheduleUpdate(map[string]state.RawConfig{}, nil)
+	require.Eventually(t, func() bool { return l.inflight.Load() == 1 },
+		time.Second, 5*time.Millisecond)
+
+	// Close should not return until OnUpdate finishes.
+	closeReturned := make(chan struct{})
+	go func() {
+		c.Close()
+		close(closeReturned)
+	}()
+
+	select {
+	case <-closeReturned:
+		t.Fatal("Close returned while OnUpdate was still in flight")
+	case <-time.After(50 * time.Millisecond):
+		// expected: Close is blocked on wg.Wait
+	}
+
+	close(release)
+
+	select {
+	case <-closeReturned:
+		// expected: Close unblocked after callback finished
+	case <-time.After(time.Second):
+		t.Fatal("Close did not return after callback finished")
+	}
+	assert.True(t, finished.Load(), "OnUpdate did not run to completion")
+}
+
+// TestClient_SubscribeAfterCloseIsNoop verifies that registering a listener
+// after Close has run does not spawn a goroutine that survives the wg.Wait
+// barrier — the subscription is silently dropped.
+func TestClient_SubscribeAfterCloseIsNoop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &Client{
+		ctx:       ctx,
+		closeFn:   cancel,
+		listeners: make(map[string][]*listenerEntry),
+	}
+
+	c.Close() // cancels ctx, Wait returns immediately (wg is empty)
+
+	l := &mockListener{}
+	c.SubscribeAll("p", l)
+
+	// No worker should have been spawned, no entry registered.
+	c.m.Lock()
+	assert.Empty(t, c.listeners["p"], "post-Close SubscribeAll should not register a listener")
+	c.m.Unlock()
+}
+
+// TestClient_BroadcastStateChange_NonBlocking confirms broadcastStateChange
+// returns promptly even when a listener's worker is busy.
+func TestClient_BroadcastStateChange_NonBlocking(t *testing.T) {
+	stuck := make(chan struct{})
+	slow := &mockListener{onUpdateHook: func() { <-stuck }}
+	fast := &mockListener{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		close(stuck)
+		cancel()
+	})
+
+	c := &Client{
+		ctx:       ctx,
+		listeners: make(map[string][]*listenerEntry),
+	}
+
+	mkEntry := func(l Listener) *listenerEntry {
+		e := &listenerEntry{listener: l, wake: make(chan struct{}, 1)}
+		go e.run(ctx)
+		return e
+	}
+	eSlow := mkEntry(slow)
+	eFast := mkEntry(fast)
+	c.listeners["slow"] = []*listenerEntry{eSlow}
+	c.listeners["fast"] = []*listenerEntry{eFast}
+
+	// Park the slow worker inside OnUpdate.
+	eSlow.scheduleUpdate(map[string]state.RawConfig{}, nil)
+	require.Eventually(t, func() bool { return slow.inflight.Load() == 1 },
+		time.Second, 5*time.Millisecond)
+
+	start := time.Now()
+	c.broadcastStateChange(true)
+	elapsed := time.Since(start)
+	assert.Less(t, elapsed, 50*time.Millisecond, "broadcastStateChange blocked on slow listener")
+
+	// The fast listener should still observe the state change promptly.
+	require.Eventually(t, func() bool { return fast.stateChangeCount() == 1 },
+		time.Second, 5*time.Millisecond)
+}

--- a/pkg/config/remote/client/client_test.go
+++ b/pkg/config/remote/client/client_test.go
@@ -15,8 +15,40 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 )
+
+// blockingFetcher is a ConfigFetcher that lets a test gate the gRPC call.
+// It is used to assert what Client.update() does — and does not — hold the
+// client mutex around. See the lock-discipline tests at the bottom of this
+// file.
+type blockingFetcher struct {
+	started chan struct{} // closed when ClientGetConfigs is entered
+	release chan struct{} // signaled to let ClientGetConfigs return
+	resp    *pbgo.ClientGetConfigsResponse
+	err     error
+}
+
+func newBlockingFetcher() *blockingFetcher {
+	return &blockingFetcher{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		resp:    &pbgo.ClientGetConfigsResponse{}, // empty: applyUpdate returns no changes, but lock discipline still applies
+	}
+}
+
+func (f *blockingFetcher) ClientGetConfigs(_ context.Context, _ *pbgo.ClientGetConfigsRequest) (*pbgo.ClientGetConfigsResponse, error) {
+	// Signal once; subsequent calls just proceed without blocking so the
+	// poll loop can keep iterating.
+	select {
+	case <-f.started:
+	default:
+		close(f.started)
+		<-f.release
+	}
+	return f.resp, f.err
+}
 
 // mockListener captures OnUpdate / OnStateChange calls and (optionally) injects
 // latency or counts concurrency.
@@ -611,4 +643,240 @@ func TestClient_BroadcastStateChange_NonBlocking(t *testing.T) {
 	// The fast listener should still observe the state change promptly.
 	require.Eventually(t, func() bool { return fast.stateChangeCount() == 1 },
 		time.Second, 5*time.Millisecond)
+}
+
+// --- Lock discipline tests --------------------------------------------------
+//
+// These tests pin the invariant that Client.update() releases c.m for its
+// long-running steps (the gRPC fetch and the subsequent applyUpdate / TUF
+// verification). Holding c.m across those steps would block every other
+// Client API that takes c.m — SubscribeAll, SetAgentName, GetConfigs,
+// broadcastStateChange — for the full duration of a poll iteration. That
+// regression has been introduced before; these tests guard against it
+// returning.
+//
+// Pre-PR locking discipline (preserved by this PR):
+//
+//	update():
+//	  newUpdateRequest()        // c.state.CurrentState() — no c.m
+//	    ↳ briefly takes c.m to copy c.products
+//	  configFetcher.ClientGetConfigs(...)  // no c.m, may take seconds
+//	  applyUpdate(response)                // no c.m, TUF verification
+//	  c.m.Lock(); dispatch loop; c.m.Unlock()
+//
+// state.Repository is partly thread-safe (metadata is a sync.Map), but configs
+// and TUF state are NOT — only the single poll-loop goroutine writes them.
+// The lock discipline above is what makes that safe in practice.
+
+// TestClient_LockNotHeldDuringFetch verifies that c.m is free while the
+// gRPC fetch is in flight. Concretely: a blocking ConfigFetcher parks the
+// poll loop inside ClientGetConfigs, and during that window we must be
+// able to take c.m via every public API that touches it.
+//
+// If a future refactor hoists c.m above the fetcher call, this test deadlocks
+// (each public API blocks until the fetcher returns).
+func TestClient_LockNotHeldDuringFetch(t *testing.T) {
+	fetcher := newBlockingFetcher()
+	c, err := NewClient(fetcher, WithoutTufVerification(), WithAgent("test", "0.0"))
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	c.Start()
+
+	select {
+	case <-fetcher.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ConfigFetcher.ClientGetConfigs was never called")
+	}
+
+	// While the fetcher is blocked, every c.m-taking API must return
+	// promptly. We run each under a deadline so a regression manifests as
+	// a clean failure instead of a hung test.
+	done := make(chan string, 4)
+
+	go func() {
+		c.SubscribeAll("APM_SAMPLING", &mockListener{})
+		done <- "SubscribeAll"
+	}()
+	go func() {
+		c.SetAgentName("agent")
+		done <- "SetAgentName"
+	}()
+	go func() {
+		_ = c.GetConfigs("APM_SAMPLING")
+		done <- "GetConfigs"
+	}()
+	go func() {
+		c.broadcastStateChange(true)
+		done <- "broadcastStateChange"
+	}()
+
+	deadline := time.After(500 * time.Millisecond)
+	got := map[string]bool{}
+	for len(got) < 4 {
+		select {
+		case name := <-done:
+			got[name] = true
+		case <-deadline:
+			t.Fatalf("c.m appears held during fetch — only completed: %v", got)
+		}
+	}
+
+	// Unblock the fetcher so the poll loop can finish cleanly.
+	close(fetcher.release)
+}
+
+// TestClient_DispatchLoopHoldsLockBriefly verifies the lock-window after the
+// fetch returns. Once applyUpdate completes, update() does take c.m to
+// iterate listeners — that window must be short and must not block on
+// listener work. The slow-listener case is covered by the dispatcher tests;
+// here we assert the lock isn't held for an unbounded time relative to a
+// single iteration.
+func TestClient_DispatchLoopHoldsLockBriefly(t *testing.T) {
+	fetcher := newBlockingFetcher()
+	c, err := NewClient(fetcher, WithoutTufVerification(), WithAgent("test", "0.0"))
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	// Subscribe a listener that would block forever if dispatch were
+	// synchronous. With the async dispatcher this only parks the worker,
+	// not the poll loop / lock.
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+	c.SubscribeAll("APM_SAMPLING", &mockListener{onUpdateHook: func() { <-block }})
+
+	c.Start()
+	select {
+	case <-fetcher.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("poll loop never reached fetch")
+	}
+
+	// Release the fetcher and immediately race a SubscribeAll against the
+	// dispatch lock window. The dispatch is non-blocking even if a listener
+	// is permanently stuck (block channel held open), so this must return
+	// fast.
+	close(fetcher.release)
+
+	settled := make(chan struct{})
+	go func() {
+		c.SubscribeAll("APM_TRACING", &mockListener{})
+		close(settled)
+	}()
+	select {
+	case <-settled:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("SubscribeAll blocked on dispatch lock window — listener work leaked under c.m?")
+	}
+}
+
+// TestClient_BoundApplyStatusVersionCheck verifies the closure returned by
+// boundApplyStatus drops writes for paths NOT present in the snapshot it was
+// built from, and forwards writes for paths that are present. This guards the
+// version-binding wiring; the underlying version-vs-version comparison is
+// exhaustively tested in state.TestUpdateApplyStatusIfVersion.
+func TestClient_BoundApplyStatusVersionCheck(t *testing.T) {
+	repo, err := state.NewUnverifiedRepository()
+	require.NoError(t, err)
+	c := &Client{state: repo}
+
+	// Snapshot containing one path at v1. The closure must remember v1.
+	snapshot := map[string]state.RawConfig{
+		"datadog/2/APM_SAMPLING/known/x": {Metadata: state.Metadata{Version: 1}},
+	}
+	bound := c.boundApplyStatus(snapshot)
+
+	// Unknown path: the closure must drop the write without panicking and
+	// without touching the repository.
+	bound("datadog/2/APM_SAMPLING/unknown/y",
+		state.ApplyStatus{State: state.ApplyStateError, Error: "should be dropped"})
+
+	// Known path: the closure forwards to UpdateApplyStatusIfVersion. Since
+	// no metadata is loaded in the empty repository, the underlying call
+	// returns false — we only care here that the wiring invoked it without
+	// panic. The end-to-end "stale ack rejected" guarantee is covered by
+	// state.TestUpdateApplyStatusIfVersion.
+	bound("datadog/2/APM_SAMPLING/known/x",
+		state.ApplyStatus{State: state.ApplyStateAcknowledged})
+}
+
+// TestClient_ConcurrentSubscribeWhilePolling is a stress test that runs the
+// real poll loop with a fast (non-blocking) fetcher and hammers it with
+// concurrent SubscribeAll / SetAgentName / GetConfigs calls. Under -race this
+// catches any reintroduction of the c.m / c.state locking confusion the PR
+// review flagged. It does not assert exact behavior — only that no deadlock,
+// panic, or data race occurs.
+func TestClient_ConcurrentSubscribeWhilePolling(t *testing.T) {
+	fetcher := &blockingFetcher{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		resp:    &pbgo.ClientGetConfigsResponse{},
+	}
+	close(fetcher.release) // never block
+
+	c, err := NewClient(fetcher, WithoutTufVerification(), WithAgent("test", "0.0"))
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+	c.Start()
+
+	products := []string{"APM_SAMPLING", "APM_TRACING", "ASM_FEATURES", "LIVE_DEBUGGING"}
+
+	var wg sync.WaitGroup
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				p := products[i%len(products)]
+				c.SubscribeAll(p, &mockListener{})
+				_ = c.GetConfigs(p)
+				c.SetAgentName("agent")
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestClient_SubscribeDuringClose races SubscribeAll against Close to exercise
+// the wg.Add-vs-wg.Wait window mellon85 flagged: SubscribeAll does wg.Add(1)
+// for its dispatcher, and Close does wg.Wait(). If the gate (the ctx.Err()
+// check under c.m in SubscribeAll, paired with cancelUnderLock holding c.m)
+// were removed, a wg.Add concurrent with wg.Wait at counter zero would panic
+// with "WaitGroup is reused before previous Wait has returned" / "negative
+// counter". Run under -race; the harness reports any data race on c.listeners
+// or the WaitGroup. It asserts no panic/deadlock rather than exact behavior.
+func TestClient_SubscribeDuringClose(t *testing.T) {
+	for iter := 0; iter < 200; iter++ {
+		fetcher := &blockingFetcher{
+			started: make(chan struct{}),
+			release: make(chan struct{}),
+			resp:    &pbgo.ClientGetConfigsResponse{},
+		}
+		close(fetcher.release) // never block the poll loop
+
+		c, err := NewClient(fetcher, WithoutTufVerification(), WithAgent("test", "0.0"))
+		require.NoError(t, err)
+		c.Start()
+
+		// Fire SubscribeAll concurrently with Close. Whichever wins, the
+		// outcome must be safe: either the subscription registers before the
+		// ctx is canceled (its wg.Add completes before wg.Wait begins), or it
+		// observes the canceled ctx and is dropped. Neither may panic.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			c.SubscribeAll("APM_SAMPLING", &mockListener{})
+		}()
+		go func() {
+			defer wg.Done()
+			c.Close()
+		}()
+		wg.Wait()
+
+		// A SubscribeAll that lands after Close must be dropped, never leaving
+		// a leaked dispatcher behind (Close already returned from wg.Wait).
+		c.SubscribeAll("APM_TRACING", &mockListener{})
+	}
 }

--- a/pkg/config/remote/client/rcasync_harness_test.go
+++ b/pkg/config/remote/client/rcasync_harness_test.go
@@ -1,0 +1,135 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+//go:build test
+
+package client
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// This file is a MANUAL, LOCAL harness for eyeballing the RC-ASYNC behaviour
+// without a real remote-config backend or a staging deploy. It reuses the
+// scripted fetcher + payload builders from rcasync_scripted_test.go and adds
+// console logging so you can watch — via the RC-ASYNC log lines — what happens
+// when a listener hangs while newer versions of another product arrive.
+//
+// It is gated behind an env var so it never runs in CI (it sleeps for several
+// seconds on purpose). Run it locally with:
+//
+//	RC_ASYNC_HARNESS=1 dda inv test --targets=./pkg/config/remote/client -v
+//
+// or, equivalently, with the raw toolchain (the `test` build tag is required
+// for the console-logger helper):
+//
+//	RC_ASYNC_HARNESS=1 go test -tags test -v -run TestRCAsyncLocalHarness ./pkg/config/remote/client/
+//
+// The automated, always-on version of this guarantee lives in
+// rcasync_scripted_test.go (TestClient_HungListenerDoesNotBlockOthers). This
+// harness is throwaway scaffolding — delete it along with the RC-ASYNC log
+// lines once the behaviour is confirmed.
+
+func TestRCAsyncLocalHarness(t *testing.T) {
+	if os.Getenv("RC_ASYNC_HARNESS") == "" {
+		t.Skip("manual harness; set RC_ASYNC_HARNESS=1 to run")
+	}
+
+	// Send RC-ASYNC (and all other) logs to stdout at info so they're visible.
+	logger, err := log.LoggerFromWriterWithMinLevel(os.Stdout, log.InfoLvl)
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	log.SetupLogger(logger, "info")
+
+	const (
+		autoscaling = state.ProductContainerAutoscalingSettings
+		k8sactions  = state.ProductK8SActions
+	)
+
+	// The script: one poll per k8s-actions version bump. Each poll re-sends the
+	// FULL active set (as real RC does), so nothing looks "removed". Autoscaling
+	// stays at v1 the whole time; k8s-actions bumps v1..v6 across the polls.
+	const k8sBumps = 6
+	script := make([]*pbgo.ClientGetConfigsResponse, k8sBumps)
+	for i := 0; i < k8sBumps; i++ {
+		script[i] = buildResponse(uint64(i+1),
+			harnessConfig{autoscaling, "autoscaler-1", 1, `{"name":"autoscaler-1","v":1}`},
+			harnessConfig{k8sactions, "action-1", uint64(i + 1), fmt.Sprintf(`{"action":"scale","v":%d}`, i+1)},
+		)
+	}
+	fetcher := &scriptedFetcher{script: script}
+
+	c, err := NewClient(fetcher,
+		WithoutTufVerification(),
+		WithAgent("harness", "0.0"),
+		WithPollInterval(500*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	// HUNG listener: container autoscaling. Its OnUpdate blocks indefinitely on
+	// `hang` — simulating a listener that never returns (deadlock, stuck syscall,
+	// waiting on a torn-down dependency, etc.). The whole point of the async
+	// dispatcher is that this must NOT stall the poll loop or any other listener.
+	hang := make(chan struct{})
+	c.Subscribe(autoscaling, func(configs map[string]state.RawConfig, applyState func(string, state.ApplyStatus)) {
+		log.Infof("RC-ASYNC [harness] >>> AUTOSCALING listener ENTERED OnUpdate (%d configs) and is now HANGING FOREVER", len(configs))
+		<-hang // never closed during the observation window
+		log.Infof("RC-ASYNC [harness] <<< AUTOSCALING listener released")
+		for p := range configs {
+			applyState(p, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+		}
+	})
+
+	// Healthy listener: kubernetes actions. Acks immediately. We expect it to
+	// keep receiving every k8s-actions version while autoscaling is wedged.
+	var k8sDeliveries atomic.Int32
+	c.Subscribe(k8sactions, func(configs map[string]state.RawConfig, applyState func(string, state.ApplyStatus)) {
+		for p, cfg := range configs {
+			k8sDeliveries.Add(1)
+			log.Infof("RC-ASYNC [harness] K8S-ACTIONS listener got %s @v%d — acking immediately", p, cfg.Metadata.Version)
+			applyState(p, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+		}
+	})
+
+	log.Infof("RC-ASYNC [harness] ===== starting client; autoscaling will hang, k8s-actions should keep flowing =====")
+	c.Start()
+
+	// Observation window: long enough for all k8s-actions bumps to be delivered
+	// while autoscaling is stuck in its very first OnUpdate.
+	time.Sleep(5 * time.Second)
+
+	got := k8sDeliveries.Load()
+	log.Infof("RC-ASYNC [harness] ===== observed %d k8s-actions deliveries while autoscaling was hung (expected %d) =====", got, k8sBumps)
+	if int(got) < k8sBumps {
+		t.Errorf("expected k8s-actions to keep flowing while autoscaling hung: got %d deliveries, want >= %d", got, k8sBumps)
+	}
+
+	// Shutdown with a STUCK listener: Close would block forever, so use
+	// CloseTimeout. It must return false (autoscaling is still wedged) and leak
+	// only that one worker — the poll loop and the healthy worker still tear down.
+	log.Infof("RC-ASYNC [harness] ===== CloseTimeout(2s) with autoscaling still hung =====")
+	drained := c.CloseTimeout(2 * time.Second)
+	log.Infof("RC-ASYNC [harness] CloseTimeout returned drained=%t (expected false — a listener is stuck)", drained)
+	if drained {
+		t.Error("expected CloseTimeout to report NOT drained while a listener is hung")
+	}
+
+	// Release the wedged listener so the leaked goroutine can exit cleanly now
+	// that the observation is done (good hygiene; not part of the assertion).
+	close(hang)
+	time.Sleep(200 * time.Millisecond)
+	log.Infof("RC-ASYNC [harness] ===== done =====")
+}

--- a/pkg/config/remote/client/rcasync_scripted_test.go
+++ b/pkg/config/remote/client/rcasync_scripted_test.go
@@ -1,0 +1,157 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package client
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+)
+
+// scriptedFetcher is a ConfigFetcher that returns a pre-built response per poll:
+// poll 1 -> script[0], poll 2 -> script[1], etc. Once the script is exhausted it
+// repeats the last payload (real RC re-sends the current active set every poll;
+// an empty payload would instead look like "all configs deleted").
+type scriptedFetcher struct {
+	script []*pbgo.ClientGetConfigsResponse
+	calls  atomic.Int32
+}
+
+func (f *scriptedFetcher) ClientGetConfigs(_ context.Context, _ *pbgo.ClientGetConfigsRequest) (*pbgo.ClientGetConfigsResponse, error) {
+	n := int(f.calls.Add(1)) - 1
+	if n < len(f.script) {
+		return f.script[n], nil
+	}
+	return f.script[len(f.script)-1], nil
+}
+
+// harnessConfig describes one config file to embed in a scripted response.
+type harnessConfig struct {
+	product  string
+	configID string
+	version  uint64
+	body     string
+}
+
+func (hc harnessConfig) path() string {
+	// datadog/<org>/<PRODUCT>/<configID>/<name>
+	return fmt.Sprintf("datadog/2/%s/%s/config", hc.product, hc.configID)
+}
+
+// buildResponse assembles a ClientGetConfigsResponse the unverified Update path
+// accepts: a TUF "targets" blob (signatures are NOT checked without TUF
+// verification, but per-file sha256 + length ARE), plus the raw bodies.
+func buildResponse(targetsVersion uint64, configs ...harnessConfig) *pbgo.ClientGetConfigsResponse {
+	targetEntries := map[string]any{}
+	files := make([]*pbgo.File, 0, len(configs))
+	clientConfigs := make([]string, 0, len(configs))
+
+	for _, c := range configs {
+		raw := []byte(c.body)
+		sum := sha256.Sum256(raw)
+		targetEntries[c.path()] = map[string]any{
+			"length": len(raw),
+			"hashes": map[string]string{"sha256": hex.EncodeToString(sum[:])},
+			"custom": map[string]any{"v": c.version},
+		}
+		files = append(files, &pbgo.File{Path: c.path(), Raw: raw})
+		clientConfigs = append(clientConfigs, c.path())
+	}
+
+	signed := map[string]any{
+		"_type":        "targets",
+		"spec_version": "1.0",
+		"version":      targetsVersion,
+		"expires":      "2032-10-24T15:10:45.097315-04:00",
+		"targets":      targetEntries,
+		"custom":       map[string]any{"opaque_backend_state": "eyJmb28iOiAiYmFyIn0="},
+	}
+	signedBytes, _ := json.Marshal(signed)
+	envelope, _ := json.Marshal(map[string]any{"signed": json.RawMessage(signedBytes), "signatures": []any{}})
+
+	return &pbgo.ClientGetConfigsResponse{
+		Targets:       envelope,
+		TargetFiles:   files,
+		ClientConfigs: clientConfigs,
+		ConfigStatus:  pbgo.ConfigStatus_CONFIG_STATUS_OK,
+	}
+}
+
+// TestClient_HungListenerDoesNotBlockOthers is the always-on regression for the
+// headline guarantee of the async dispatcher: a listener that hangs forever in
+// OnUpdate must NOT stall the poll loop or any other listener, and shutdown must
+// stay bounded (Close would block forever, so CloseTimeout must report it).
+//
+// It drives the real poll loop + dispatch via a scripted fetcher: one product's
+// listener wedges on its first OnUpdate, while a second product's version is
+// bumped on every poll. The healthy listener must receive every bump regardless.
+func TestClient_HungListenerDoesNotBlockOthers(t *testing.T) {
+	const (
+		hungProduct    = state.ProductContainerAutoscalingSettings
+		healthyProduct = state.ProductK8SActions
+		bumps          = 5
+	)
+
+	script := make([]*pbgo.ClientGetConfigsResponse, bumps)
+	for i := 0; i < bumps; i++ {
+		script[i] = buildResponse(uint64(i+1),
+			harnessConfig{hungProduct, "a", 1, `{"v":1}`}, // never changes
+			harnessConfig{healthyProduct, "b", uint64(i + 1), fmt.Sprintf(`{"v":%d}`, i+1)},
+		)
+	}
+	fetcher := &scriptedFetcher{script: script}
+
+	c, err := NewClient(fetcher,
+		WithoutTufVerification(),
+		WithAgent("test", "0.0"),
+		WithPollInterval(5*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	// Wedged listener: blocks forever in OnUpdate until we release it at the end.
+	hang := make(chan struct{})
+	var entered atomic.Bool
+	c.Subscribe(hungProduct, func(_ map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
+		entered.Store(true)
+		<-hang
+	})
+
+	// Healthy listener: must keep receiving every version bump.
+	var healthyDeliveries atomic.Int32
+	c.Subscribe(healthyProduct, func(configs map[string]state.RawConfig, applyState func(string, state.ApplyStatus)) {
+		for p := range configs {
+			healthyDeliveries.Add(1)
+			applyState(p, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+		}
+	})
+
+	c.Start()
+
+	require.Eventually(t, entered.Load, 2*time.Second, time.Millisecond,
+		"wedged listener never entered OnUpdate")
+	require.Eventually(t, func() bool { return healthyDeliveries.Load() >= bumps }, 2*time.Second, time.Millisecond,
+		"healthy listener stopped receiving updates while another listener was hung")
+
+	// Shutdown must not hang. Close would block forever on the wedged listener,
+	// so CloseTimeout must report not-drained within the bound.
+	require.False(t, c.CloseTimeout(100*time.Millisecond),
+		"CloseTimeout should report not-drained while a listener is hung")
+
+	// Release the wedged worker so nothing leaks past the test, then a full
+	// Close drains cleanly (ctx is already canceled; the worker exits at once).
+	close(hang)
+	c.Close()
+}

--- a/pkg/remoteconfig/state/repository.go
+++ b/pkg/remoteconfig/state/repository.go
@@ -85,6 +85,28 @@ type Repository struct {
 	// Config file storage
 	metadata sync.Map // map[string]Metadata
 	configs  map[string]map[string]interface{}
+
+	// configsMu guards the `configs` map (and its inner maps), which—unlike
+	// metadata—is a plain map with no built-in synchronization. The poll loop
+	// mutates it via applyUpdateResult while readers (GetConfigs and the typed
+	// per-product accessors) run on other goroutines. Without this lock a
+	// reader concurrent with an Update is an immediate "concurrent map
+	// read/write" fatal crash.
+	//
+	// Lock ordering: acquire configsMu BEFORE metadataMu. Only applyUpdateResult
+	// takes both; no path takes them in the reverse order.
+	configsMu sync.RWMutex
+
+	// metadataMu serializes metadata writes (Update's applyUpdateResult and
+	// UpdateApplyStatusIfVersion) so the latter's "check version then write
+	// status" is atomic against config-version bumps. Plain UpdateApplyStatus
+	// also takes this lock so a non-version-checked status write can't
+	// interleave between a check and a write.
+	//
+	// Reads (Load / Range) intentionally do NOT take this lock; sync.Map's
+	// own atomicity is sufficient for them, and CurrentState's Range is
+	// called on the request path where blocking is undesirable.
+	metadataMu sync.Mutex
 }
 
 // NewRepository creates a new remote config repository that will track
@@ -178,17 +200,27 @@ func (r *Repository) Update(update Update) ([]string, error) {
 
 	result := newUpdateResult()
 
-	// 2: Check the config list and mark any missing configs as "to be removed"
+	// 2: Check the config list and mark any missing configs as "to be removed".
+	// Snapshot the currently-stored paths under the read lock, then process
+	// them without it (the per-path work below can return errors, which makes a
+	// held lock awkward, and parseConfigPath doesn't touch r.configs).
+	r.configsMu.RLock()
+	storedPaths := make([]string, 0, len(r.configs))
 	for _, configs := range r.configs {
 		for path := range configs {
-			if _, ok := clientConfigsMap[path]; !ok {
-				result.removed = append(result.removed, path)
-				parsedPath, err := parseConfigPath(path)
-				if err != nil {
-					return nil, err
-				}
-				result.productsUpdated[parsedPath.Product] = true
+			storedPaths = append(storedPaths, path)
+		}
+	}
+	r.configsMu.RUnlock()
+
+	for _, path := range storedPaths {
+		if _, ok := clientConfigsMap[path]; !ok {
+			result.removed = append(result.removed, path)
+			parsedPath, err := parseConfigPath(path)
+			if err != nil {
+				return nil, err
 			}
+			result.productsUpdated[parsedPath.Product] = true
 		}
 	}
 
@@ -296,7 +328,10 @@ func (r *Repository) Update(update Update) ([]string, error) {
 // wasn't and which errors occurred while processing.
 // Note: it is the responsibility of the caller to ensure that no new Update() call was made between
 // the first Update() call and the call to UpdateApplyStatus() so as to keep the repository state accurate.
+// Prefer UpdateApplyStatusIfVersion for callers that may be running concurrently with Update().
 func (r *Repository) UpdateApplyStatus(cfgPath string, status ApplyStatus) {
+	r.metadataMu.Lock()
+	defer r.metadataMu.Unlock()
 	if val, ok := r.metadata.Load(cfgPath); ok {
 		if m, ok := val.(Metadata); ok {
 			m.ApplyStatus = status
@@ -305,13 +340,59 @@ func (r *Repository) UpdateApplyStatus(cfgPath string, status ApplyStatus) {
 	}
 }
 
+// UpdateApplyStatusIfVersion is a version-checked variant of UpdateApplyStatus.
+// It writes status only if the stored metadata for cfgPath still has the
+// expected version. It returns true if the status was applied, false if the
+// stored metadata is missing or has been replaced by a newer version (a stale
+// write was dropped).
+//
+// This exists for asynchronous callers — typically a slow Listener.OnUpdate
+// that finishes processing a snapshot after the next Update() has already
+// landed. Without the version check, the late ApplyStatus would be stamped
+// onto the newer config version's metadata, causing the next request to the
+// backend to report a wrong apply state for that version.
+//
+// The check-then-store is atomic against both Update() (via applyUpdateResult,
+// which acquires the same lock for its metadata writes) and against other
+// UpdateApplyStatus[IfVersion] callers.
+func (r *Repository) UpdateApplyStatusIfVersion(cfgPath string, expectedVersion uint64, status ApplyStatus) bool {
+	r.metadataMu.Lock()
+	defer r.metadataMu.Unlock()
+	val, ok := r.metadata.Load(cfgPath)
+	if !ok {
+		return false
+	}
+	m, ok := val.(Metadata)
+	if !ok {
+		return false
+	}
+	if m.Version != expectedVersion {
+		return false
+	}
+	m.ApplyStatus = status
+	r.metadata.Store(cfgPath, m)
+	return true
+}
+
+// getConfigs returns a shallow copy of the stored configs for a product.
+//
+// It returns a copy (not the live inner map) so callers can iterate without
+// holding configsMu: the values are immutable config objects that are
+// replaced—never mutated in place—by applyUpdateResult, so copying the map
+// references is sufficient to make the snapshot safe.
 func (r *Repository) getConfigs(product string) map[string]interface{} {
+	r.configsMu.RLock()
+	defer r.configsMu.RUnlock()
 	configs, ok := r.configs[product]
 	if !ok {
 		return nil
 	}
 
-	return configs
+	cp := make(map[string]interface{}, len(configs))
+	for path, config := range configs {
+		cp[path] = config
+	}
+	return cp
 }
 
 // applyUpdateResult changes the state of the client based on the given update.
@@ -319,6 +400,15 @@ func (r *Repository) getConfigs(product string) map[string]interface{} {
 // The update is guaranteed to succeed at this point, having been vetted and the details
 // needed to apply the update stored in the `updateResult`.
 func (r *Repository) applyUpdateResult(_ Update, result updateResult) {
+	// Hold configsMu across the configs mutations so concurrent readers
+	// (GetConfigs / typed accessors) never observe a half-applied update, and
+	// metadataMu across the metadata Store/Delete loops so a concurrent
+	// UpdateApplyStatusIfVersion call cannot observe a stale version between
+	// its check and its write. Ordering: configsMu before metadataMu.
+	r.configsMu.Lock()
+	defer r.configsMu.Unlock()
+	r.metadataMu.Lock()
+	defer r.metadataMu.Unlock()
 	// 4.b Save all the updated and new config files
 	for product, configs := range result.changed {
 		for path, config := range configs {

--- a/pkg/remoteconfig/state/repository_test.go
+++ b/pkg/remoteconfig/state/repository_test.go
@@ -1207,3 +1207,66 @@ func TestRepositoryConcurrentUpdateAndGetConfigs(t *testing.T) {
 	close(stop)
 	wg.Wait()
 }
+
+// TestRepositoryConcurrentApplyStatusAndUpdate exercises metadataMu under
+// contention: ackers call UpdateApplyStatusIfVersion / UpdateApplyStatus from
+// several goroutines while the main goroutine bumps the config version via
+// Update. metadataMu is what makes each check-then-store atomic against
+// applyUpdateResult's metadata writes — without it, a stale ack's read-modify-
+// store could resurrect an old version's metadata (the exact corruption the
+// async dispatcher would otherwise cause). Must pass under -race.
+func TestRepositoryConcurrentApplyStatusAndUpdate(t *testing.T) {
+	ta := newTestArtifacts()
+	r := ta.repository
+
+	file := newCWSDDFile()
+	path, _, data := addCWSDDFile("test", 1, file, ta.targets)
+	b := signTargets(ta.key, ta.targets)
+	_, err := r.Update(Update{
+		TUFTargets:    b,
+		TargetFiles:   map[string][]byte{path: data},
+		ClientConfigs: []string{path},
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 6; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					// Interleave a stale-version ack (v1, almost always
+					// superseded) and a plain by-path ack.
+					r.UpdateApplyStatusIfVersion(path, 1, ApplyStatus{State: ApplyStateAcknowledged})
+					r.UpdateApplyStatus(path, ApplyStatus{State: ApplyStateAcknowledged})
+				}
+			}
+		}()
+	}
+
+	for v := 2; v <= 60; v++ {
+		_, _, d := addCWSDDFile("test", int64(v), []byte("body"), ta.targets)
+		bb := signTargets(ta.key, ta.targets)
+		_, err := r.Update(Update{
+			TUFTargets:    bb,
+			TargetFiles:   map[string][]byte{path: d},
+			ClientConfigs: []string{path},
+		})
+		require.NoError(t, err)
+	}
+
+	close(stop)
+	wg.Wait()
+
+	// The version must be the latest the writer applied — a concurrent stale
+	// ack must never have rolled it back — and a stale-version ack is rejected.
+	require.EqualValues(t, 60, r.GetConfigs(ProductCWSDD)[path].Metadata.Version)
+	require.False(t, r.UpdateApplyStatusIfVersion(path, 1,
+		ApplyStatus{State: ApplyStateAcknowledged}),
+		"a stale (v1) ack must be rejected after the version advanced")
+}

--- a/pkg/remoteconfig/state/repository_test.go
+++ b/pkg/remoteconfig/state/repository_test.go
@@ -8,10 +8,12 @@ package state
 import (
 	"encoding/base64"
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewRepositoryWithNilRoot(t *testing.T) {
@@ -1075,4 +1077,133 @@ func TestUpdateMetadataOnlyWhenHashUnchangedVersionIncreased(t *testing.T) {
 	assert.Equal(t, 1, len(state.CachedFiles))
 	assert.EqualValues(t, 3, state.Configs[0].Version)
 	assert.Equal(t, initialApplyStatusUnverified, state.Configs[0].ApplyStatus)
+}
+
+// TestUpdateApplyStatusIfVersion verifies the version-checked apply-status
+// write: it must apply when the version matches, refuse to apply (and not
+// mutate state) when the version has been bumped, and refuse for unknown
+// paths. This is the load-bearing guarantee that protects the async listener
+// dispatcher in pkg/config/remote/client from stamping stale acks onto newer
+// config versions.
+func TestUpdateApplyStatusIfVersion(t *testing.T) {
+	ta := newTestArtifacts()
+	r := ta.repository
+
+	// Install v1.
+	file := newCWSDDFile()
+	path, _, data := addCWSDDFile("test", 1, file, ta.targets)
+	b := signTargets(ta.key, ta.targets)
+	_, err := r.Update(Update{
+		TUFTargets:    b,
+		TargetFiles:   map[string][]byte{path: data},
+		ClientConfigs: []string{path},
+	})
+	require.NoError(t, err)
+
+	stored := r.GetConfigs(ProductCWSDD)[path]
+	require.EqualValues(t, 1, stored.Metadata.Version)
+	v1 := stored.Metadata.Version
+
+	// liveStatus reads the authoritative apply-status from CurrentState
+	// (sync.Map metadata), which is what's sent back to the backend in
+	// ConfigStates. GetConfigs returns the Metadata embedded in RawConfig
+	// at Update() time, which is not refreshed by apply-status writes —
+	// that's existing behavior shared by UpdateApplyStatus.
+	liveStatus := func() ApplyStatus {
+		s, err := r.CurrentState()
+		require.NoError(t, err)
+		for _, c := range s.Configs {
+			parsed, _ := parseConfigPath(path)
+			if c.ID == parsed.ConfigID && c.Product == parsed.Product {
+				return c.ApplyStatus
+			}
+		}
+		t.Fatalf("config %s not found in CurrentState", path)
+		return ApplyStatus{}
+	}
+
+	// Matching version: applied.
+	wantV1 := ApplyStatus{State: ApplyStateAcknowledged}
+	require.True(t, r.UpdateApplyStatusIfVersion(path, v1, wantV1))
+	assert.Equal(t, wantV1, liveStatus())
+
+	// Bump to v2.
+	_, _, data2 := addCWSDDFile("test", 2, []byte("v2-body"), ta.targets)
+	b = signTargets(ta.key, ta.targets)
+	_, err = r.Update(Update{
+		TUFTargets:    b,
+		TargetFiles:   map[string][]byte{path: data2},
+		ClientConfigs: []string{path},
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, r.GetConfigs(ProductCWSDD)[path].Metadata.Version)
+
+	// Capture v2 status to prove a stale v1 ack does not mutate it.
+	beforeStale := liveStatus()
+
+	// Stale (v1) ack arrives after v2 landed: dropped, no mutation.
+	staleStatus := ApplyStatus{State: ApplyStateError, Error: "should be dropped"}
+	require.False(t, r.UpdateApplyStatusIfVersion(path, v1, staleStatus))
+	assert.Equal(t, beforeStale, liveStatus(),
+		"stale apply-status must not overwrite newer version's status")
+
+	// Unknown path: dropped.
+	require.False(t, r.UpdateApplyStatusIfVersion("datadog/2/CWS_DD/no-such-config/x", 1,
+		ApplyStatus{State: ApplyStateAcknowledged}))
+
+	// v2 ack: applied.
+	wantV2 := ApplyStatus{State: ApplyStateError, Error: "v2 failed"}
+	require.True(t, r.UpdateApplyStatusIfVersion(path, 2, wantV2))
+	assert.Equal(t, wantV2, liveStatus())
+}
+
+// TestRepositoryConcurrentUpdateAndGetConfigs exercises configsMu: it hammers
+// GetConfigs (read) from many goroutines while the main goroutine drives
+// Update (write) repeatedly. This mirrors production, where GetConfigs is a
+// public method called off the poll-loop goroutine (e.g. the cluster-agent
+// admission provider's leader loop) concurrently with the poll loop applying
+// updates. Before configsMu, the unsynchronized `configs` map made this an
+// immediate "concurrent map read and map write" fatal crash; the test must
+// pass cleanly under -race.
+//
+// Note: CurrentState and the TUF-state fields are intentionally NOT exercised
+// concurrently here — in production they are only ever touched by the single
+// poll-loop goroutine (via newUpdateRequest), so they need no locking.
+func TestRepositoryConcurrentUpdateAndGetConfigs(t *testing.T) {
+	ta := newTestArtifacts()
+	r := ta.repository
+
+	file := newCWSDDFile()
+	path, _, _ := addCWSDDFile("test", 1, file, ta.targets)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = r.GetConfigs(ProductCWSDD)
+				}
+			}
+		}()
+	}
+
+	for v := 1; v <= 50; v++ {
+		_, _, data := addCWSDDFile("test", int64(v), []byte("body"), ta.targets)
+		b := signTargets(ta.key, ta.targets)
+		_, err := r.Update(Update{
+			TUFTargets:    b,
+			TargetFiles:   map[string][]byte{path: data},
+			ClientConfigs: []string{path},
+		})
+		require.NoError(t, err)
+	}
+
+	close(stop)
+	wg.Wait()
 }

--- a/pkg/security/rconfig/policies.go
+++ b/pkg/security/rconfig/policies.go
@@ -203,10 +203,10 @@ func (r *RCPolicyProvider) LoadPolicies(macroFilters []rules.MacroFilter, ruleFi
 		rawConfig := r.lastDefaults[cfgPath]
 
 		if err := load(rules.DefaultPolicyType, rawConfig.Metadata.ID, rawConfig.Config); err != nil {
-			r.client.UpdateApplyStatus(cfgPath, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+			r.client.UpdateApplyStatusIfVersion(cfgPath, rawConfig.Metadata.Version, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
 			errs = multierror.Append(errs, err)
 		} else {
-			r.client.UpdateApplyStatus(cfgPath, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+			r.client.UpdateApplyStatusIfVersion(cfgPath, rawConfig.Metadata.Version, state.ApplyStatus{State: state.ApplyStateAcknowledged})
 		}
 	}
 
@@ -214,10 +214,10 @@ func (r *RCPolicyProvider) LoadPolicies(macroFilters []rules.MacroFilter, ruleFi
 		rawConfig := r.lastCustoms[cfgPath]
 
 		if err := load(rules.CustomPolicyType, rawConfig.Metadata.ID, rawConfig.Config); err != nil {
-			r.client.UpdateApplyStatus(cfgPath, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+			r.client.UpdateApplyStatusIfVersion(cfgPath, rawConfig.Metadata.Version, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
 			errs = multierror.Append(errs, err)
 		} else {
-			r.client.UpdateApplyStatus(cfgPath, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+			r.client.UpdateApplyStatusIfVersion(cfgPath, rawConfig.Metadata.Version, state.ApplyStatus{State: state.ApplyStateAcknowledged})
 		}
 	}
 
@@ -225,10 +225,10 @@ func (r *RCPolicyProvider) LoadPolicies(macroFilters []rules.MacroFilter, ruleFi
 		rawConfig := r.lastRemediations[cfgPath]
 
 		if err := load(rules.RemediationPolicyType, rawConfig.Metadata.ID, rawConfig.Config); err != nil {
-			r.client.UpdateApplyStatus(cfgPath, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+			r.client.UpdateApplyStatusIfVersion(cfgPath, rawConfig.Metadata.Version, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
 			errs = multierror.Append(errs, err)
 		} else {
-			r.client.UpdateApplyStatus(cfgPath, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+			r.client.UpdateApplyStatusIfVersion(cfgPath, rawConfig.Metadata.Version, state.ApplyStatus{State: state.ApplyStateAcknowledged})
 		}
 	}
 

--- a/pkg/trace/remoteconfighandler/remote_config_handler.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler.go
@@ -159,7 +159,11 @@ func (h *RemoteConfigHandler) mrfUpdateCallback(updates map[string]state.RawConf
 }
 
 func (h *RemoteConfigHandler) onAgentConfigUpdate(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
-	mergedConfig, err := state.MergeRCAgentConfig(h.client.UpdateApplyStatus, updates)
+	// Use the apply-status callback handed to this update, not the raw
+	// client.UpdateApplyStatus: the former is version-bound to the snapshot we
+	// were given, so a slow update here can't stamp a stale ack onto a newer
+	// config version that landed in the meantime.
+	mergedConfig, err := state.MergeRCAgentConfig(applyStateCallback, updates)
 	if err != nil {
 		log.Debugf("couldn't merge the agent config from remote configuration: %s", err)
 		return


### PR DESCRIPTION
Motivation - Currently, the rc client in the cluster agent dispatches configs synchronously to all products describe. If even 1 listener, in 1 product is slow/blocking/stuck - none of the other products will receive their configs. I observed blocking as long as 5 minutes on the ap2 cluster with autoscaling enabled. The removes the responsibility being placed on the subscribing products to complete their work in a non-blocking manner. 

1. Commit 206302a2362bd772316815e152fdfcfab5b105e9 is just logging and a manual confirmation test harness - it will be removed before merge.

2. Below is a detailed walkthrough of the changes.
 # Remote Config async dispatch — call-chain walkthrough

A follow-the-callpath tour of the RC client after the async-dispatch change.
Top-down through each flow, calling out the locks and the WaitGroup only where
they actually matter, then a diagram and a concrete timeline.

File references point at `pkg/config/remote/client/client.go` and
`pkg/remoteconfig/state/repository.go`.

---

The shared state and the things that guard it. Keep this next to you as you read:

| Guard | Lives on | Protects | Held during |
|---|---|---|---|
| `c.m` (`sync.Mutex`) | `Client` | Client-owned fields: `listeners`, `products`, `agentName` | short, Client-internal sections only — **never** across a listener callback or the gRPC fetch |
| `listenerEntry.mu` (`sync.Mutex`) | each `listenerEntry` | the `pending*` handoff fields | a few lines, on both producer and worker side |
| `configsMu` (`sync.RWMutex`) | `state.Repository` | the `configs` map | RLock while copying a snapshot; Lock while an `Update` rewrites configs |
| `metadataMu` (`sync.Mutex`) | `state.Repository` | the read-modify-write of `metadata` apply-status | the check-then-store in apply-status, and the metadata writes in an `Update` |
| `c.wg` (`sync.WaitGroup`) | `Client` | "have all goroutines exited?" | counts the poll loop + one worker per subscription; `Wait()`ed in `Close` |

And the two **families of goroutines**:

- **One poll-loop goroutine** — fetches, applies, and *stages* work. Never runs listener code.
- **N worker goroutines** — one per `Subscribe`, each the only thing that ever calls into its listener.

The entire design is: the poll loop and the workers are decoupled by a 1-slot
channel, so the poll loop can never be blocked by a listener.

---

## A. Startup — where the goroutines are born

### `Start()` → `startFn()`

```
Start()  -> startupSync.Do(startFn)
startFn():
    c.m.Lock()
    if c.ctx.Err() != nil { return }   // Close already happened → don't start
    c.wg.Add(1)                        // count the poll loop
    go pollLoop()                      // defer c.wg.Done()
    c.m.Unlock()
```

The reason `startFn` takes `c.m` is subtle and it's the same trick used
everywhere `wg.Add` appears: **`Close` cancels the context while holding `c.m`**
(see `cancelUnderLock`). So either we run first — observe a live ctx and finish
`wg.Add(1)` before `Close` can begin `wg.Wait()` — or `Close` ran first, we see
the cancelled ctx, and skip the `Add` entirely. That serialization is what makes
"`Add` concurrent with `Wait` at counter 0" (a `sync.WaitGroup` panic)
impossible.

### `SubscribeAll(product, listener)`

```
SubscribeAll():
    c.m.Lock(); defer c.m.Unlock()
    if c.ctx.Err() != nil { return }        // same shutdown gate
    append product to c.products
    entry := &listenerEntry{ wake: make(chan struct{}, 1), ... }
    c.wg.Add(1)                              // count this worker
    go entry.run(c.ctx)                      // defer c.wg.Done()
    c.listeners[product] = append(..., entry)
```

Every subscription spawns its **own** worker right here, tied to `c.ctx`. Note
the worker is born even if you subscribe *before* `Start()` — it just blocks
waiting for a wake that won't come until the first poll.

---

## B. One poll iteration — the poll-loop side

### `pollLoop()`

```
for {
  select {
  case <-c.ctx.Done(): return           // shutdown
  case <-time.After(interval):
      err := c.update()                 // <-- the whole iteration
      ... backoff / broadcastStateChange on connectivity transitions ...
  }
}
```

No lock is held across the `select`. The interval grows with backoff on errors.

### `update()` — the spine

```
update():
    req := c.newUpdateRequest()                    // briefly takes c.m to copy c.products
    resp := c.configFetcher.ClientGetConfigs(ctx, req)   // <-- NO LOCK. gRPC. can take seconds.
    changedProducts := c.applyUpdate(resp)         // <-- NO c.m (see below)
    if len(changedProducts) == 0 { return }

    c.m.Lock(); defer c.m.Unlock()                 // <-- lock taken ONLY for dispatch
    for product, listeners := range c.listeners {
        if product not changed { continue }
        configs := c.state.GetConfigs(product)      // takes configsMu.RLock internally
        applyStatus := c.boundApplyStatus(configs)  // captures path->version, no lock
        for entry := range listeners {
            entry.scheduleUpdate(maps.Clone(configs), applyStatus)  // stage + wake
        }
    }
```

Three things to notice about locking here, because this is the heart of the change:

1. **The gRPC fetch holds nothing.** A slow/blocking backend can't wedge `c.m`.
2. **`applyUpdate` holds nothing of the Client's.** It mutates the Repository,
   which now guards its *own* state. That's why a poll's TUF verification doesn't
   block `SubscribeAll`/`GetConfigs`.
3. **`c.m` is taken only for the dispatch loop**, which reads `c.listeners`. It is
   held only long enough to copy a snapshot and drop a wake signal into each
   worker's channel — it is **never** held across a listener callback.

### Into the Repository: `applyUpdate` → `Repository.Update`

```
Repository.Update():
    [unverified mode: parse targets JSON; verified mode: check TUF signatures]
    configsMu.RLock(); snapshot stored paths; configsMu.RUnlock()   // step 2
    [for each config: hash/length check, parse]
    applyUpdateResult(...)                                          // commit
```

`applyUpdateResult` is the one place that takes **both** Repository locks, always
in this order:

```
applyUpdateResult():
    configsMu.Lock(); defer configsMu.Unlock()      // outer
    metadataMu.Lock(); defer metadataMu.Unlock()    // inner
    ... write r.configs[...] and r.metadata.Store/Delete ...
```

`Repository.Update` is only ever called from the poll-loop goroutine (single
writer). So `configsMu` exists purely to keep that writer from racing **readers
on other goroutines** — e.g. someone calling the public `Client.GetConfigs` →
`getConfigs`, which takes `configsMu.RLock()` and returns a *copy*. Without that
lock, a reader iterating `r.configs` while the poll loop writes it is a hard
`concurrent map read and map write` crash.

### The handoff: `scheduleUpdate` + the wake channel

```
scheduleUpdate(configs, applyStatus):
    e.mu.Lock()
    coalesced := e.pendingConfigs != nil      // was a prior payload still un-drained?
    e.pendingConfigs = configs                // overwrite — freshest wins
    e.pendingApplyStatus = applyStatus
    e.mu.Unlock()
    e.signal()

signal():
    select {
    case e.wake <- struct{}{}:    // wake has cap 1
    default:                      // already a token queued → drop, worker will see latest
    }
```

This is the decoupling point. The poll loop **stages** the latest snapshot under
`entry.mu` and drops a single token into a cap-1 channel. If the worker is busy
(slow listener), the prior pending payload is simply overwritten — that's
**coalescing** — and the extra wake token is dropped. The poll loop returns
immediately regardless of what the worker is doing.

---

## C. The worker side — the only place listener code runs

### `run(ctx)`

```
run(ctx):
    for {
      select {
      case <-ctx.Done(): return            // Close cancelled us
      case <-e.wake:
          e.mu.Lock()
          configs, applyStatus, stateChange := drain pending; clear pending
          e.mu.Unlock()
          e.deliver(stateChange, configs, applyStatus)   // <-- NO lock held here
      }
    }
```

The worker grabs the latest pending under `entry.mu`, **releases it**, then calls
the listener. The listener callback runs with *no* lock held — that's
deliberate: a listener that hangs holds nothing, so it can't block the poll loop
(which only ever touches `entry.mu` for the few lines in `scheduleUpdate`).

### `deliver` → `listener.OnUpdate` → the apply-status callback

```
deliver():
    defer recover()                          // a panicking listener stays subscribed
    if stateChange != nil { listener.OnStateChange(*stateChange) }
    if configs != nil     { listener.OnUpdate(configs, applyStatus) }
```

Inside `OnUpdate`, when the listener acks a config, it calls the `applyStatus`
closure that `boundApplyStatus` built for *this* snapshot:

### `boundApplyStatus` → `Repository.UpdateApplyStatusIfVersion`

```
boundApplyStatus(snapshot) returns:
    func(path, status):
        expected := snapshot[path].version       // captured at dispatch time
        if path not in snapshot { drop }
        if !UpdateApplyStatusIfVersion(path, expected, status) { log "DROPPED stale" }

UpdateApplyStatusIfVersion(path, expected, status):
    metadataMu.Lock(); defer metadataMu.Unlock()
    m := metadata.Load(path)
    if m.Version != expected { return false }     // a newer version landed → drop
    m.ApplyStatus = status; metadata.Store(path, m)
    return true
```

This is the version-binding fix. The worker may finish `OnUpdate` long after the
next poll bumped the version. `metadataMu` makes the "check version, then store"
atomic against the poll loop's `applyUpdateResult` (which takes the same lock).
If the version moved, the stale ack is dropped instead of corrupting the newer
version's metadata.

---

## D. Connectivity changes — `broadcastStateChange`

When the poll loop detects a connect/disconnect transition it calls:

```
broadcastStateChange(connected):
    if c.ctx.Err() != nil { return }       // best-effort skip post-Close
    c.m.Lock(); defer c.m.Unlock()
    for entry := range all listeners:
        entry.scheduleStateChange(connected)   // same entry.mu + wake path
```

Same shape as dispatch: take `c.m` to read `c.listeners`, stage onto each worker,
never block. `scheduleStateChange` stages `pendingStateChange` and signals the
same wake channel — so a worker can drain a state-change and an update in one
`deliver` (state-change first).

---

## E. Shutdown — `Close` / `CloseTimeout`

```
Close():
    cancelUnderLock()      // c.m.Lock(); c.closeFn(); c.m.Unlock()
    c.wg.Wait()            // block until poll loop + ALL workers have returned

CloseTimeout(d):
    cancelUnderLock()
    go { c.wg.Wait(); close(done) }
    select { case <-done: return true; case <-time.After(d): return false }
```

`cancelUnderLock` cancels `c.ctx`. That causes:

- the **poll loop** to fall out of its `select` (`<-c.ctx.Done()`) and return → `wg.Done()`,
- each **worker** to return at its next `select` → `wg.Done()` — but a worker
  *currently inside* `OnUpdate` finishes the callback first (you can't preempt it).

So `Close()` blocks until every in-flight callback returns — which is why a
**hung** listener would hang `Close` forever, and why the shutdown callers use
`CloseTimeout`, which bounds the wait and returns `false` (leaking just that one
stuck worker) instead of hanging the whole agent.

The `c.m` in `cancelUnderLock` is the other half of the `wg.Add`/`wg.Wait` race
guard: it pairs with the `c.m`-guarded `Add`s in `startFn`/`SubscribeAll`.

---

## Lock ordering — why there's no deadlock

There's a strict acyclic order:

```
c.m  ─►  configsMu  ─►  metadataMu
  └──►  listenerEntry.mu
```

- `update()`/`broadcastStateChange` hold `c.m` and then reach for `configsMu`
  (via `GetConfigs`) and `entry.mu` (via `schedule*`).
- `applyUpdateResult` takes `configsMu` then `metadataMu`, and **never** touches `c.m`.
- `UpdateApplyStatusIfVersion` (called from worker goroutines) takes only
  `metadataMu`, never `c.m` or `configsMu`.

Nothing ever acquires these in the reverse direction, so no cycle exists. The one
case worth checking — a public `GetConfigs` holding `c.m` and waiting on
`configsMu.RLock` while the poll loop holds `configsMu.Lock` in
`applyUpdateResult` — is safe, because `applyUpdateResult` never waits on `c.m`,
so it always makes progress and releases.

---


## Concrete timeline: slow listener + a version bump

This is the scenario from the local harness — autoscaling is slow, k8s-actions
bumps underneath it:

```
t=0  POLL #1
     fetch → applyUpdate: autoscaler@v1, action@v1  (configsMu/metadataMu write)
     c.m.Lock
       dispatch AUTOSCALING: scheduleUpdate(v1)  → wake token → [entry.mu] pending=v1
       dispatch K8S:         scheduleUpdate(v1)  → wake token
     c.m.Unlock
     AUTOSCALING worker: drain v1, deliver → OnUpdate(v1) ……… (blocks, slow)
     K8S worker:         drain v1, deliver → OnUpdate(v1) → cb → UpdateApplyStatusIfVersion(v1)=APPLIED

t=1  POLL #2   (autoscaling worker STILL inside OnUpdate(v1))
     fetch → applyUpdate: action@v2 changed  (autoscaler unchanged → not dispatched)
     c.m.Lock  dispatch K8S: scheduleUpdate(v2)  c.m.Unlock
     K8S worker: deliver → OnUpdate(v2) → cb → CAS(v2)=APPLIED      ← k8s keeps flowing
     ► poll loop never waited on autoscaling.

t=2  POLL #3   (autoscaling STILL inside OnUpdate(v1))
     applyUpdate: autoscaler@v2 (bumped) + action@v3
     dispatch AUTOSCALING: scheduleUpdate(v2)
        [entry.mu] pendingConfigs was non-nil → COALESCED (v2 replaces the never-drained v?)
     dispatch K8S: scheduleUpdate(v3) → APPLIED

t=6  autoscaling OnUpdate(v1) finally returns
     listener calls cb for v1 → UpdateApplyStatusIfVersion(expected=v1) :
        current metadata is v2  →  returns false  →  "DROPPED stale" ✔
     worker loops, drains pending=v2, deliver → OnUpdate(v2) → cb(v2)=APPLIED
     ► converges to the current version; the stale v1 ack never corrupts v2.

Close() at shutdown:
     cancelUnderLock → ctx cancelled
       poll loop exits; K8S worker exits at its select
       AUTOSCALING worker exits only after its current OnUpdate returns
     wg.Wait() returns once all three Done().   (CloseTimeout bounds this.)
```

That timeline touches every guard: `configsMu`/`metadataMu` on the write at each
poll, `c.m` around each dispatch, `entry.mu` + the cap-1 `wake` channel doing the
coalescing handoff, `metadataMu` doing the version CAS that drops the stale v1
ack, and `c.wg` gating shutdown.

The fastest way to *watch* this exact sequence is the harness
(`RC_ASYNC_HARNESS=1 …`) — its `RC-ASYNC` log lines are emitted at precisely the
call-path points described above (`dispatching` → `staging` → `COALESCED` →
`-> OnUpdate` → `apply-status DROPPED/APPLIED` → `<- OnUpdate returned`).

