### PR TITLE
Extract custom logic out of common_settings.go

### DIFF
--- a/pkg/config/buildschema/config.go
+++ b/pkg/config/buildschema/config.go
@@ -304,7 +304,7 @@ func (b *builder) Stringify(_ model.Source, _ ...model.StringifyOption) string {
 }
 
 func (b *builder) Set(_ string, _ interface{}, _ model.Source) {
-	b.notImplemented()
+	// pass
 }
 
 func (b *builder) SetWithoutSource(_ string, _ interface{}) {

--- a/pkg/config/setup/BUILD.bazel
+++ b/pkg/config/setup/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "config_nix.go",
         "config_test_accessor.go",
         "config_windows.go",
+        "fixup_init.go",
         "ipc_address.go",
         "multi_region_failover.go",
         "otlp.go",

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -55,7 +55,11 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.features", []string{}, "DD_APM_FEATURES")
 	config.BindEnvAndSetDefault("apm_config.max_catalog_entries", 0)
 
-	bindVectorOptions(config, Traces)
+	// Vector options for traces
+	config.BindEnvAndSetDefault("observability_pipelines_worker.traces.enabled", false)
+	config.BindEnvAndSetDefault("observability_pipelines_worker.traces.url", "")
+	config.BindEnvAndSetDefault("vector.traces.enabled", false)
+	config.BindEnvAndSetDefault("vector.traces.url", "")
 
 	config.BindEnvAndSetDefault("apm_config.enabled", true, "DD_APM_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.receiver_enabled", true, "DD_APM_RECEIVER_ENABLED")

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -15,7 +15,6 @@ import (
 	pkgconfigenv "github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfighelper "github.com/DataDog/datadog-agent/pkg/config/helper"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func initCoreAgentFull(config pkgconfigmodel.Setup) {

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -7,8 +7,6 @@
 package setup
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -599,7 +597,6 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("external_metrics_provider.split_batches_with_backoff", false)  // Splits batches and runs queries with errors individually with an exponential backoff
 	config.BindEnvAndSetDefault("external_metrics_provider.num_workers", 2)                     // Number of workers spawned by controller (only when CRD is used)
 	config.BindEnvAndSetDefault("external_metrics_provider.max_parallel_queries", 10)           // Maximum number of parallel queries sent to Datadog simultaneously
-	pkgconfigmodel.AddOverrideFunc(sanitizeExternalMetricsProviderChunkSize)
 	// DatadogInstrumentation controller
 	config.BindEnvAndSetDefault("instrumentation_crd_controller.enabled", false)
 	// Cluster check Autodiscovery
@@ -1000,11 +997,6 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("appsec.proxy.auto_detect", true)
 	config.BindEnvAndSetDefault("appsec.proxy.proxies", []string{})
 
-	setupProcesses(config)
-
-	// Private Action Runner configuration
-	setupPrivateActionRunner(config)
-
 	// Installer configuration
 	config.BindEnvAndSetDefault("remote_updates", true)
 	config.BindEnvAndSetDefault("installer.mirror", "")
@@ -1118,11 +1110,6 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("hostprofiler.health_metrics.enabled", true)
 	config.BindEnvAndSetDefault("hostprofiler.health_metrics.target", "127.0.0.1:8889")
 	config.BindEnvAndSetDefault("hostprofiler.hpflare.port", 7778)
-
-	// Remote Flags system
-	remoteflags(config)
-
-	anomalyDetection(config)
 }
 
 func agent(config pkgconfigmodel.Setup) {
@@ -1318,30 +1305,6 @@ func agent(config pkgconfigmodel.Setup) {
 	// Event Management v2 API
 	// https://docs.datadoghq.com/api/latest/events#post-an-event
 	bindEnvAndSetLogsConfigKeys(config, "event_management.forwarder.")
-
-	pkgconfigmodel.AddOverrideFunc(toggleDefaultPayloads)
-	pkgconfigmodel.AddOverrideFunc(applyInfrastructureModeOverrides)
-	pkgconfigmodel.AddOverrideFunc(ApplyUseDogstatsdSuppression)
-}
-
-// ApplyUseDogstatsdSuppression is a post-load override that, when
-// use_dogstatsd is false, forces data_plane.dogstatsd.enabled to false
-// so the Agent Data Plane process (which reads the latter via the
-// config stream) skips its DogStatsD source. data_plane.enabled is
-// intentionally left alone so other ADP pipelines (e.g. OTLP) keep
-// working independently of the DogStatsD master toggle.
-//
-// It is registered as an override func (runs after datadog.yaml loads) and
-// also called explicitly after fleet policy merging, because fleet policies
-// are applied after the initial override pass.
-//
-// Matches the truth table at
-// https://github.com/DataDog/saluki/issues/1334#issuecomment-4292253054.
-func ApplyUseDogstatsdSuppression(config pkgconfigmodel.Config) {
-	if !config.GetBool("use_dogstatsd") && config.GetBool("data_plane.dogstatsd.enabled") {
-		log.Infof("Forcing data_plane.dogstatsd.enabled=false because use_dogstatsd=false")
-		config.Set("data_plane.dogstatsd.enabled", false, pkgconfigmodel.SourceAgentRuntime)
-	}
 }
 
 func fleet(config pkgconfigmodel.Setup) {
@@ -1451,46 +1414,9 @@ func autoconfig(config pkgconfigmodel.Setup) {
 }
 
 func containerSyspath(config pkgconfigmodel.Setup) {
-	procfsPathDefault := ""
-	containerProcRootDefault := ""
-	containerCgroupRootDefault := ""
-
-	if pkgconfigenv.IsContainerized() {
-		// In serverless-containerized environments (e.g Fargate)
-		// it's impossible to mount host volumes.
-		// Make sure the host paths exist before setting-up the default values.
-		// Fallback to the container paths if host paths aren't mounted.
-		if pathExists("/host/proc") {
-			procfsPathDefault = "/host/proc"
-			containerProcRootDefault = "/host/proc"
-
-			// Used by some librairies (like gopsutil)
-			if v := os.Getenv("HOST_PROC"); v == "" {
-				os.Setenv("HOST_PROC", "/host/proc")
-			}
-		} else {
-			procfsPathDefault = "/proc"
-			containerProcRootDefault = "/proc"
-		}
-		if pathExists("/host/sys/fs/cgroup/") {
-			containerCgroupRootDefault = "/host/sys/fs/cgroup/"
-		} else {
-			containerCgroupRootDefault = "/sys/fs/cgroup/"
-		}
-	} else {
-		containerProcRootDefault = "/proc"
-		// for amazon linux the cgroup directory on host is /cgroup/
-		// we pick memory.stat to make sure it exists and not empty
-		if _, err := os.Stat("/cgroup/memory/memory.stat"); !os.IsNotExist(err) {
-			containerCgroupRootDefault = "/cgroup/"
-		} else {
-			containerCgroupRootDefault = "/sys/fs/cgroup/"
-		}
-	}
-
-	config.BindEnvAndSetDefault("procfs_path", procfsPathDefault)
-	config.BindEnvAndSetDefault("container_proc_root", containerProcRootDefault)
-	config.BindEnvAndSetDefault("container_cgroup_root", containerCgroupRootDefault)
+	config.BindEnvAndSetDefault("procfs_path", "")
+	config.BindEnvAndSetDefault("container_proc_root", "")
+	config.BindEnvAndSetDefault("container_cgroup_root", "")
 	config.BindEnvAndSetDefault("container_pid_mapper", "")
 
 	config.BindEnvAndSetDefault("ignore_host_etc", false)
@@ -1926,8 +1852,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection_tagging", true)
 
 	// Number of logs pipeline instances. Defaults to number of logical CPU cores as defined by GOMAXPROCS or 4, whichever is lower.
-	logsPipelines := min(4, runtime.GOMAXPROCS(0))
-	config.BindEnvAndSetDefault("logs_config.pipelines", logsPipelines)
+	config.BindEnvAndSetDefault("logs_config.pipelines", 4)
 
 	// If true, the agent looks for container logs in the location used by podman, rather
 	// than docker.  This is a temporary configuration parameter to support podman logs until
@@ -1997,16 +1922,14 @@ func logsagent(config pkgconfigmodel.Setup) {
 
 // vector integration
 func vector(config pkgconfigmodel.Setup) {
-	bindVectorOptions(config, Metrics)
-	bindVectorOptions(config, Logs)
-}
-
-func bindVectorOptions(config pkgconfigmodel.Setup, datatype string) {
-	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.enabled", datatype), false)
-	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.url", datatype), "")
-
-	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.enabled", datatype), false)
-	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.url", datatype), "")
+	config.BindEnvAndSetDefault("observability_pipelines_worker.metrics.enabled", false)
+	config.BindEnvAndSetDefault("observability_pipelines_worker.metrics.url", "")
+	config.BindEnvAndSetDefault("vector.metrics.enabled", false)
+	config.BindEnvAndSetDefault("vector.metrics.url", "")
+	config.BindEnvAndSetDefault("observability_pipelines_worker.logs.enabled", false)
+	config.BindEnvAndSetDefault("observability_pipelines_worker.logs.url", "")
+	config.BindEnvAndSetDefault("vector.logs.enabled", false)
+	config.BindEnvAndSetDefault("vector.logs.url", "")
 }
 
 func cloudfoundry(config pkgconfigmodel.Setup) {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1502,7 +1502,7 @@ func applyInfrastructureModeOverrides(config pkgconfigmodel.Config) {
 	}
 }
 
-// applyUseDogstatsdSuppression is a post-load override that, when
+// ApplyUseDogstatsdSuppression is a post-load override that, when
 // use_dogstatsd is false, forces data_plane.dogstatsd.enabled to false
 // so the Agent Data Plane process (which reads the latter via the
 // config stream) skips its DogStatsD source. data_plane.enabled is
@@ -1515,7 +1515,7 @@ func applyInfrastructureModeOverrides(config pkgconfigmodel.Config) {
 //
 // Matches the truth table at
 // https://github.com/DataDog/saluki/issues/1334#issuecomment-4292253054.
-func applyUseDogstatsdSuppression(config pkgconfigmodel.Config) {
+func ApplyUseDogstatsdSuppression(config pkgconfigmodel.Config) {
 	if !config.GetBool("use_dogstatsd") && config.GetBool("data_plane.dogstatsd.enabled") {
 		log.Infof("Forcing data_plane.dogstatsd.enabled=false because use_dogstatsd=false")
 		config.Set("data_plane.dogstatsd.enabled", false, pkgconfigmodel.SourceAgentRuntime)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -320,9 +320,13 @@ func InitConfigObjects(cliPath string, defaultDir string) {
 	SetDatadog(create.NewConfig("datadog", configLib))          // nolint: forbidigo // legitimate use of SetDatadog
 	SetSystemProbe(create.NewConfig("system-probe", configLib)) // nolint: forbidigo // legitimate use of SetDatadog
 
-	// Configuration defaults
+	// Configuration defaults, should only be logic-free calls to BindEnvAndSetDefault / BindEnv / SetDefault
 	initConfig()
 
+	// Post-init fixups, custom logic to tweak certain settings
+	fixupInitConfig()
+
+	// Build the environment variable layer
 	datadog.(pkgconfigmodel.BuildableConfig).BuildSchema()
 	systemProbe.(pkgconfigmodel.BuildableConfig).BuildSchema()
 
@@ -342,14 +346,30 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// Add them to common_settings.go instead
 	// -------------------------------------------------------------
 
-	// Settings that are shared in common between serverless and core-agent, split up by feature / product
+	// Settings that are shared in common between serverless and the full agent, split up by feature / product
 	initCommonConfigComponents(config)
-	// Settings just for the core-agent in general
+	// Settings just for the full agent in general
 	initCoreAgentFull(config)
+	// Settings associated with a feature / product that only appear in the full agent, not in serverless
+	initFullAgentOnlyComponents(config)
 }
 
+// settings shared by full agent and serverless
 func initCommonConfigComponents(config pkgconfigmodel.Setup) {
 	for _, f := range commonConfigComponents {
+		f(config)
+	}
+}
+
+// settings that are only initialized by the full agent, not serverless
+func initFullAgentOnlyComponents(config pkgconfigmodel.Setup) {
+	comps := []func(pkgconfigmodel.Setup){
+		setupProcesses,
+		setupPrivateActionRunner,
+		remoteflags,
+		anomalyDetection,
+	}
+	for _, f := range comps {
 		f(config)
 	}
 }
@@ -1479,6 +1499,26 @@ func applyInfrastructureModeOverrides(config pkgconfigmodel.Config) {
 		config.Set("integration.enabled", false, pkgconfigmodel.SourceInfraMode)
 		// Avoid detailed ECS task metadata collection when not collecting infrastructure.
 		config.Set("ecs_task_collection_enabled", false, pkgconfigmodel.SourceInfraMode)
+	}
+}
+
+// applyUseDogstatsdSuppression is a post-load override that, when
+// use_dogstatsd is false, forces data_plane.dogstatsd.enabled to false
+// so the Agent Data Plane process (which reads the latter via the
+// config stream) skips its DogStatsD source. data_plane.enabled is
+// intentionally left alone so other ADP pipelines (e.g. OTLP) keep
+// working independently of the DogStatsD master toggle.
+//
+// It is registered as an override func (runs after datadog.yaml loads) and
+// also called explicitly after fleet policy merging, because fleet policies
+// are applied after the initial override pass.
+//
+// Matches the truth table at
+// https://github.com/DataDog/saluki/issues/1334#issuecomment-4292253054.
+func applyUseDogstatsdSuppression(config pkgconfigmodel.Config) {
+	if !config.GetBool("use_dogstatsd") && config.GetBool("data_plane.dogstatsd.enabled") {
+		log.Infof("Forcing data_plane.dogstatsd.enabled=false because use_dogstatsd=false")
+		config.Set("data_plane.dogstatsd.enabled", false, pkgconfigmodel.SourceAgentRuntime)
 	}
 }
 

--- a/pkg/config/setup/config_init.go
+++ b/pkg/config/setup/config_init.go
@@ -14,3 +14,12 @@ func initConfig() {
 	sysprobe := GlobalSystemProbeConfigBuilder()
 	InitSystemProbeConfig(sysprobe)
 }
+
+func fixupInitConfig() {
+	ddcfg := Datadog()
+	fixupInitCommonConfigComponents(ddcfg)
+	fixupInitFullAgentOnlyComponents(ddcfg)
+
+	sysprobe := SystemProbe()
+	fixupInitSystemProbe(sysprobe)
+}

--- a/pkg/config/setup/config_init_serverless.go
+++ b/pkg/config/setup/config_init_serverless.go
@@ -11,3 +11,8 @@ func initConfig() {
 	ddcfg := GlobalConfigBuilder()
 	initCommonConfigComponents(ddcfg)
 }
+
+func fixupInitConfig {
+	ddcfg := Datadog()
+	fixupInitCommonConfigComponents(ddcfg)
+}

--- a/pkg/config/setup/config_init_serverless.go
+++ b/pkg/config/setup/config_init_serverless.go
@@ -12,7 +12,7 @@ func initConfig() {
 	initCommonConfigComponents(ddcfg)
 }
 
-func fixupInitConfig {
+func fixupInitConfig() {
 	ddcfg := Datadog()
 	fixupInitCommonConfigComponents(ddcfg)
 }

--- a/pkg/config/setup/fixup_init.go
+++ b/pkg/config/setup/fixup_init.go
@@ -71,7 +71,7 @@ func fixupInitCommonConfigComponents(config pkgconfigmodel.Config) {
 	fixupLogsAgent(config)
 	pkgconfigmodel.AddOverrideFunc(toggleDefaultPayloads)
 	pkgconfigmodel.AddOverrideFunc(applyInfrastructureModeOverrides)
-	pkgconfigmodel.AddOverrideFunc(applyUseDogstatsdSuppression)
+	pkgconfigmodel.AddOverrideFunc(ApplyUseDogstatsdSuppression)
 }
 
 // called only for full-agent, NOT serverless-init, after declaring settings

--- a/pkg/config/setup/fixup_init.go
+++ b/pkg/config/setup/fixup_init.go
@@ -75,10 +75,10 @@ func fixupInitCommonConfigComponents(config pkgconfigmodel.Config) {
 }
 
 // called only for full-agent, NOT serverless-init, after declaring settings
-func fixupInitFullAgentOnlyComponents(config pkgconfigmodel.Config) {
+func fixupInitFullAgentOnlyComponents(_ pkgconfigmodel.Config) {
 	pkgconfigmodel.AddOverrideFunc(sanitizeExternalMetricsProviderChunkSize)
 }
 
 // called only for system-probe, after declaring settings
-func fixupInitSystemProbe(config pkgconfigmodel.Config) {
+func fixupInitSystemProbe(_ pkgconfigmodel.Config) {
 }

--- a/pkg/config/setup/fixup_init.go
+++ b/pkg/config/setup/fixup_init.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package setup defines the configuration of the agent
+package setup
+
+import (
+	"os"
+	"runtime"
+
+	pkgconfigenv "github.com/DataDog/datadog-agent/pkg/config/env"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+func fixupContainerSyspath(config pkgconfigmodel.Config) {
+	procfsPathDefault := ""
+	containerProcRootDefault := ""
+	containerCgroupRootDefault := ""
+
+	if pkgconfigenv.IsContainerized() {
+		// In serverless-containerized environments (e.g Fargate)
+		// it's impossible to mount host volumes.
+		// Make sure the host paths exist before setting-up the default values.
+		// Fallback to the container paths if host paths aren't mounted.
+		if pathExists("/host/proc") {
+			procfsPathDefault = "/host/proc"
+			containerProcRootDefault = "/host/proc"
+
+			// Used by some librairies (like gopsutil)
+			if v := os.Getenv("HOST_PROC"); v == "" {
+				os.Setenv("HOST_PROC", "/host/proc")
+			}
+		} else {
+			procfsPathDefault = "/proc"
+			containerProcRootDefault = "/proc"
+		}
+		if pathExists("/host/sys/fs/cgroup/") {
+			containerCgroupRootDefault = "/host/sys/fs/cgroup/"
+		} else {
+			containerCgroupRootDefault = "/sys/fs/cgroup/"
+		}
+	} else {
+		containerProcRootDefault = "/proc"
+		// for amazon linux the cgroup directory on host is /cgroup/
+		// we pick memory.stat to make sure it exists and not empty
+		if _, err := os.Stat("/cgroup/memory/memory.stat"); !os.IsNotExist(err) {
+			containerCgroupRootDefault = "/cgroup/"
+		} else {
+			containerCgroupRootDefault = "/sys/fs/cgroup/"
+		}
+	}
+
+	config.Set("procfs_path", procfsPathDefault, pkgconfigmodel.SourceConfigPostInit)
+	config.Set("container_proc_root", containerProcRootDefault, pkgconfigmodel.SourceConfigPostInit)
+	config.Set("container_cgroup_root", containerCgroupRootDefault, pkgconfigmodel.SourceConfigPostInit)
+}
+
+func fixupLogsAgent(config pkgconfigmodel.Config) {
+	// Number of logs pipeline instances. Defaults to number of logical CPU cores as defined by GOMAXPROCS or 4, whichever is lower.
+	maxProcs := runtime.GOMAXPROCS(0)
+	if maxProcs < 4 {
+		config.Set("logs_config.pipelines", maxProcs, pkgconfigmodel.SourceConfigPostInit)
+	}
+}
+
+// always called, for both full-agent and serverless-init, after declaring settings
+func fixupInitCommonConfigComponents(config pkgconfigmodel.Config) {
+	fixupContainerSyspath(config)
+	fixupLogsAgent(config)
+	pkgconfigmodel.AddOverrideFunc(toggleDefaultPayloads)
+	pkgconfigmodel.AddOverrideFunc(applyInfrastructureModeOverrides)
+	pkgconfigmodel.AddOverrideFunc(applyUseDogstatsdSuppression)
+}
+
+// called only for full-agent, NOT serverless-init, after declaring settings
+func fixupInitFullAgentOnlyComponents(config pkgconfigmodel.Config) {
+	pkgconfigmodel.AddOverrideFunc(sanitizeExternalMetricsProviderChunkSize)
+}
+
+// called only for system-probe, after declaring settings
+func fixupInitSystemProbe(config pkgconfigmodel.Config) {
+}

--- a/pkg/config/setup/fixup_init.go
+++ b/pkg/config/setup/fixup_init.go
@@ -52,16 +52,16 @@ func fixupContainerSyspath(config pkgconfigmodel.Config) {
 		}
 	}
 
-	config.Set("procfs_path", procfsPathDefault, pkgconfigmodel.SourceConfigPostInit)
-	config.Set("container_proc_root", containerProcRootDefault, pkgconfigmodel.SourceConfigPostInit)
-	config.Set("container_cgroup_root", containerCgroupRootDefault, pkgconfigmodel.SourceConfigPostInit)
+	config.Set("procfs_path", procfsPathDefault, pkgconfigmodel.SourceDefault)
+	config.Set("container_proc_root", containerProcRootDefault, pkgconfigmodel.SourceDefault)
+	config.Set("container_cgroup_root", containerCgroupRootDefault, pkgconfigmodel.SourceDefault)
 }
 
 func fixupLogsAgent(config pkgconfigmodel.Config) {
 	// Number of logs pipeline instances. Defaults to number of logical CPU cores as defined by GOMAXPROCS or 4, whichever is lower.
 	maxProcs := runtime.GOMAXPROCS(0)
 	if maxProcs < 4 {
-		config.Set("logs_config.pipelines", maxProcs, pkgconfigmodel.SourceConfigPostInit)
+		config.Set("logs_config.pipelines", maxProcs, pkgconfigmodel.SourceDefault)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Create a `fixupInit` phase, move custom logic into it, and out of common_settings.go

### Motivation

We are aiming to make the code in common_settings.go use *only* calls to BindEnvAndSetDefault, in order to replace it with schema-based codegen. This will allow the config schema to become the source of truth for defining settings.

This is part 1 of this work, so it only targets common_settings.go, as establishes a design pattern. Part 2 will extract the same imperative code from similar files (apm.go, multi_region_failover.go, process.go, etc).

Custom logic moves to the `fixupInit*` class of functions. These correspond to a new phase of config setup called `fixitInit` which happens after `init` but before the `datadog.yaml` file is loaded. See [current order of phases here](https://datadoghq.atlassian.net/wiki/spaces/ACFG/pages/6767446489/Initialization+Steps+of+the+Datadog+Agent+Config).

### Describe how you validated your changes

Using CI should be enough. Ideally this change is a strict refactoring that only moves function call order around.

### Additional Notes
