### PR TITLE
use softinv-intake as the default subdomain for ai-usage monitoring

### DIFF
--- a/cmd/ai_prompt_logger/README.md
+++ b/cmd/ai_prompt_logger/README.md
@@ -40,7 +40,7 @@ On a **packaged Windows** agent (MSI), Chrome is pointed directly at **`bin\agen
 EVP / Agent URL behaviour (defaults):
 
 - URL: `{trace_agent_url}/evp_proxy/v{evp_proxy_api_version}/api/v2/aiusage` (defaults match trace receiver / EVP v2).
-- Header: `X-Datadog-EVP-Subdomain: {ai_usage_evp_subdomain}` (default `event-platform-intake`).
+- Header: `X-Datadog-EVP-Subdomain: {ai_usage_evp_subdomain}` (default `softinv-intake`).
 - The Agent injects `DD-API-KEY` and forwards to the dedicated AI usage intake for your site.
 
 Ensure the Agent is listening on the trace port (default `127.0.0.1:8126`) with EVP proxy enabled.

--- a/cmd/ai_prompt_logger/ai_usage_native_host.yaml.example
+++ b/cmd/ai_prompt_logger/ai_usage_native_host.yaml.example
@@ -18,5 +18,5 @@ trace_agent_url: "http://127.0.0.1:8126"
 evp_proxy_api_version: 2
 
 # AI usage EVP intake subdomain header.
-ai_usage_evp_subdomain: "event-platform-intake"
+ai_usage_evp_subdomain: "softinv-intake"
 

--- a/cmd/ai_prompt_logger/src/datadog.rs
+++ b/cmd/ai_prompt_logger/src/datadog.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 const CONFIG_BASENAME: &str = "ai_usage_native_host.yaml";
-const AI_USAGE_EVP_SUBDOMAIN: &str = "event-platform-intake";
+const AI_USAGE_EVP_SUBDOMAIN: &str = "softinv-intake";
 const AI_USAGE_EVP_PATH: &str = "/api/v2/aiusage";
 
 /// Cap for connect + full request so the native host thread cannot block indefinitely
@@ -49,7 +49,7 @@ impl DatadogClient {
     /// - `trace_agent_url` (default `http://127.0.0.1:8126`; use **http** only — the local trace
     ///   receiver is plain HTTP and this binary has no TLS client)
     /// - `evp_proxy_api_version` (default `2`)
-    /// - `ai_usage_evp_subdomain` (default `event-platform-intake`)
+    /// - `ai_usage_evp_subdomain` (default `softinv-intake`)
     ///
     /// No `DD_API_KEY` is required here; the Agent injects the key when forwarding.
     pub fn load(config_path: Option<PathBuf>) -> Self {


### PR DESCRIPTION
### What does this PR do?
This PR changes the default subdomain to `softinv-intake` for AI-usage monitoring.

### Motivation
[WINA-2759](https://datadoghq.atlassian.net/browse/WINA-2759)

### Describe how you validated your changes
Collect logs from the ai-usage monitoring Chrome native messaging host and ensure the default subdomain is `softinv-intake`.

### Additional Notes


[WINA-2759]: https://datadoghq.atlassian.net/browse/WINA-2759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ