### PR TITLE
Collapse pkg/proto/**/*.pb.go regen to one `bazel run`

### DIFF
--- a/bazel/rules/go_mockgen/defs.bzl
+++ b/bazel/rules/go_mockgen/defs.bzl
@@ -39,7 +39,7 @@ def _impl(name, importpath, out, prefix, src, visibility):
         raw = ":{}".format(raw),
     )
     native.exports_files([out], visibility)
-    write_source_file(name = name, in_file = ":{}".format(stripped), out_file = out, check_that_out_file_exists = False)
+    write_source_file(name = name, in_file = ":{}".format(stripped), out_file = out, check_that_out_file_exists = False, visibility = ["//visibility:public"])
 
 go_mockgen = macro(
     implementation = _impl,

--- a/bazel/rules/write_pb_go/defs.bzl
+++ b/bazel/rules/write_pb_go/defs.bzl
@@ -16,4 +16,4 @@ def write_pb_go(name, srcs):
             file = "{}_{}".format(group, j)
             select_file(name = file, srcs = ":{}".format(group), subpath = out)
             files[out] = file
-    write_source_files(name = name, files = files)
+    write_source_files(name = name, files = files, visibility = ["//visibility:public"])

--- a/pkg/proto/pbgo/BUILD.bazel
+++ b/pkg/proto/pbgo/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
+
+write_source_files(
+    name = "write_all",
+    additional_update_targets = [
+        "//pkg/proto/pbgo/core:write_pb_go",
+        "//pkg/proto/pbgo/dogstatsdhttp:write_pb_go",
+        "//pkg/proto/pbgo/languagedetection:write_pb_go",
+        "//pkg/proto/pbgo/mocks/core:api_mockgen",
+        "//pkg/proto/pbgo/privateactionrunner/actionsclient:write_pb_go",
+        "//pkg/proto/pbgo/privateactionrunner/errorcode:write_pb_go",
+        "//pkg/proto/pbgo/privateactionrunner/privateactions:write_pb_go",
+        "//pkg/proto/pbgo/process:write_pb_go",
+        "//pkg/proto/pbgo/sbom:write_pb_go",
+        "//pkg/proto/pbgo/trace:write_pb_go",
+        "//pkg/proto/pbgo/trace/idx:write_pb_go",
+    ],
+)

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -24,18 +24,7 @@ def generate(ctx, pre_commit=False):
     proto_root = os.path.join(repo_root, "pkg", "proto")
     pbgo_dir = os.path.join(proto_root, "pbgo")
 
-    print(f"generating protobuf code from: {proto_root}")
-    bazel(ctx, "run", "//pkg/proto/pbgo/core:write_pb_go")
-    bazel(ctx, "run", "//pkg/proto/pbgo/dogstatsdhttp:write_pb_go")
-    bazel(ctx, "run", "//pkg/proto/pbgo/languagedetection:write_pb_go")
-    bazel(ctx, "run", "//pkg/proto/pbgo/mocks/core:api_mockgen")
-    bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/actionsclient:write_pb_go")
-    bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/errorcode:write_pb_go")
-    bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/privateactions:write_pb_go")
-    bazel(ctx, "run", "//pkg/proto/pbgo/process:write_pb_go")
-    bazel(ctx, "run", "//pkg/proto/pbgo/sbom:write_pb_go")
-    bazel(ctx, "run", "//pkg/proto/pbgo/trace:write_pb_go")
-    bazel(ctx, "run", "//pkg/proto/pbgo/trace/idx:write_pb_go")
+    bazel(ctx, "run", "//pkg/proto/pbgo:write_all")
 
     # Generate messagepack marshallers
     # msgp targets (file, io)


### PR DESCRIPTION
### What does this PR do?
Apply the `write_all` recipe documented at https://registry.bazel.build/docs/bazel_lib#lib-write_source_files-bzl: introduce `//pkg/proto/pbgo:write_all`, a single `write_source_files` umbrella that aggregates every `write_pb_go` and `go_mockgen` entry under `pkg/proto/pbgo/...`.
=> replace a dozen of sequential `bazel run` calls in `tasks/protobuf.generate` with one single invocation.

### Motivation
Each `bazel run` pays the client startup overhead.
Measured locally (with the legacy `msgp` regen still in place):
- before: ~9s
- after: ~6s (1.5x speedup)

This will be even more beneficial when `msgp` targets get fully `bazel`ified (2.2x speedup).

Another thing: it's possible to (re)generate the list of additional targets by means of a non-hermetic task, which I'll propose in a next PR.

### Describe how you validated your changes
- ran `dda inv protobuf.generate`: output identical to prior runs,
- timed both versions: warm cache, 10 samples each.

### Additional Notes
`write_pb_go` and `go_mockgen` now mark their generated `write_source_file(s)` as `visibility = ["//visibility:public"]` so the umbrella can reference them across package boundaries.
`visibility:public` is favored over something more granular for 2 reasons:
1. `write_pb_go` and `go_mockgen` are not tailored to `//pkg/proto/pbgo`. For instance, `write_pb_go` is used in `//pkg/security/proto/api`.
2. the `write_all` target is currenly sitting in `//pkg/proto/pbgo` but is likely to be extended/moved to the root BUILD.bazel file.