### PR TITLE
packaging/aix: inherit caller LIBPATH in agent wrappers

### DIFF
--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -10,6 +10,7 @@
 
 <!-- Add entries here for changes not yet in a release. -->
 
+- Agent and trace-agent wrappers now append the caller's `LIBPATH` to the agent's own library search path, so operator-set paths (e.g. custom driver directories) are visible to the agent at runtime
 - Bundle `pymqi` in the package so the `ibm_mq` and `ibm_ace` checks work out of the box (no manual `pip install` required); IBM MQ Client 9.1+ must be installed on the target host at runtime
 - Go checks: bundle `conf.yaml.example` and `conf.yaml.default` from integrations-core for all Go checks that have them, supplementing the agent-repo config (agent-repo takes precedence on filename conflicts)
 - Keep Python headers (`embedded/include/`) in the package so users can build C extension packages (e.g. `ibm_db` for the DB2 check) against the embedded Python, matching Linux/macOS omnibus behaviour

--- a/packaging/aix/agent-wrapper.sh
+++ b/packaging/aix/agent-wrapper.sh
@@ -5,6 +5,6 @@
 # The agent binary's loader section has the build-host staging path baked in
 # (a Go/ld limitation on AIX); this wrapper sets the correct installed paths
 # so the binary works when invoked directly, not just via SRC.
-export LIBPATH=/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/mqm/lib64:/opt/mqm/lib:/usr/mqm/lib64:/usr/mqm/lib:/opt/ibm/db2/clidriver/lib:/opt/freeware/lib64:/opt/freeware/lib
+export LIBPATH=/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/mqm/lib64:/opt/mqm/lib:/usr/mqm/lib64:/usr/mqm/lib:/opt/ibm/db2/clidriver/lib:/opt/freeware/lib64:/opt/freeware/lib${LIBPATH:+:$LIBPATH}
 export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:"${PATH}"
 exec /opt/datadog-agent/bin/agent/agent-bin "$@"

--- a/packaging/aix/trace-agent-wrapper.sh
+++ b/packaging/aix/trace-agent-wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-export LIBPATH=/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/mqm/lib64:/opt/mqm/lib:/usr/mqm/lib64:/usr/mqm/lib:/opt/ibm/db2/clidriver/lib:/opt/freeware/lib64:/opt/freeware/lib
+export LIBPATH=/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/mqm/lib64:/opt/mqm/lib:/usr/mqm/lib64:/usr/mqm/lib:/opt/ibm/db2/clidriver/lib:/opt/freeware/lib64:/opt/freeware/lib${LIBPATH:+:$LIBPATH}
 export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:"${PATH}"
 exec /opt/datadog-agent/embedded/bin/trace-agent-bin "$@"


### PR DESCRIPTION
### What does this PR do?

Appends `${LIBPATH:+:$LIBPATH}` to the `LIBPATH` export in both `agent-wrapper.sh` and `trace-agent-wrapper.sh`.

### Motivation

The wrappers previously set a fixed LIBPATH, silently discarding any `LIBPATH` the operator had configured before starting the agent. This means site-specific library paths (custom driver directories, IBM product paths not covered by the hardcoded list) are invisible to the agent at runtime.

Using `${LIBPATH:+:$LIBPATH}` appends the caller's value only when it is non-empty, so the behaviour is unchanged when LIBPATH is unset (the common case when starting via SRC).

### Describe how you validated your changes

Local validation

### Additional Notes

N/A