### PR TITLE
packaging/aix: invoke pip via python -m pip in stage 02

### DIFF
--- a/packaging/aix/stages/02-python.sh
+++ b/packaging/aix/stages/02-python.sh
@@ -418,7 +418,7 @@ log "Bootstrapping pip using staging Python executable"
 log "ensurepip complete."
 
 log "Upgrading pip to 26.1, setuptools to 75.1.0, and installing wheel"
-"$EMBEDDED_DESTDIR/bin/pip${PYTHON_MAJ_MIN}" install --upgrade "pip==26.1" "setuptools==75.1.0" "wheel"
+"$EMBEDDED_DESTDIR/bin/python${PYTHON_MAJ_MIN}" -m pip install --upgrade "pip==26.1" "setuptools==75.1.0" "wheel"
 log "pip bootstrap complete."
 
 # ─── Step 7b: Create AIX .a archive wrapper for libpython${PYTHON_MAJ_MIN}.so ─────────────


### PR DESCRIPTION
### What does this PR do?

Replaces `"$EMBEDDED_DESTDIR/bin/pip${PYTHON_MAJ_MIN}" install ...` with `"$EMBEDDED_DESTDIR/bin/python${PYTHON_MAJ_MIN}" -m pip install ...` in stage 02.

### Motivation

In Python 3.13, `make install` places the pip package in `site-packages/` but does **not** create the `bin/pip3.13` wrapper script. When `ensurepip` then runs and finds pip already present, it also skips creating the script. The build then fails trying to invoke `pip3.13` directly as it doesn't exist yet.

The `bin/pip3.13` script is created as a side effect of pip upgrading itself (the very next step). Using `python -m pip` for that upgrade step avoids the chicken-and-egg problem: it doesn't need the wrapper to exist, and after it runs, the wrapper is created and available for all subsequent stages.

### Describe how you validated your changes

Reproduced the failure (stage 02 exits 1 with "not found" on builds where Python 3.13 pre-populates pip in site-packages) and confirmed the fix unblocks the build.

### Additional Notes

N/A