### PR TITLE
Add RAR API to refresh the configuration

### DIFF
--- a/comp/api/grpcserver/impl-agent/grpc.go
+++ b/comp/api/grpcserver/impl-agent/grpc.go
@@ -76,6 +76,7 @@ type server struct {
 	capture             replay.Component
 	pidMap              pidmap.Component
 	remoteAgentRegistry remoteagentregistry.Component
+	secrets             secrets.Component
 	autodiscovery       autodiscovery.Component
 	configComp          config.Component
 	telemetry           telemetry.Component
@@ -134,6 +135,7 @@ func (s *server) BuildServer() http.Handler {
 		capture:              s.capture,
 		pidMap:               s.pidMap,
 		remoteAgentRegistry:  s.remoteAgentRegistry,
+		secrets:              s.secrets,
 		autodiscovery:        s.autodiscovery,
 		configComp:           s.configComp,
 		configStreamServer:   configstreamServer.NewServer(s.configComp, s.configStream, s.remoteAgentRegistry),
@@ -162,6 +164,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 			capture:             reqs.Capture,
 			pidMap:              reqs.PidMap,
 			remoteAgentRegistry: reqs.RemoteAgentRegistry,
+			secrets:             reqs.SecretResolver,
 			autodiscovery:       reqs.AutoConfig,
 			configComp:          reqs.Cfg,
 			telemetry:           reqs.Telemetry,

--- a/comp/api/grpcserver/impl-agent/server.go
+++ b/comp/api/grpcserver/impl-agent/server.go
@@ -21,6 +21,7 @@ import (
 	configstreamServer "github.com/DataDog/datadog-agent/comp/core/configstream/server"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerProto "github.com/DataDog/datadog-agent/comp/core/tagger/proto"
 	taggerserver "github.com/DataDog/datadog-agent/comp/core/tagger/server"
@@ -57,6 +58,7 @@ type serverSecure struct {
 	capture              dsdReplay.Component
 	pidMap               pidmap.Component
 	remoteAgentRegistry  remoteagentregistry.Component
+	secrets              secrets.Component
 	autodiscovery        autodiscovery.Component
 	configComp           config.Component
 	configStreamServer   *configstreamServer.Server
@@ -243,6 +245,19 @@ func (s *serverSecure) RefreshRemoteAgent(_ context.Context, in *pb.RefreshRemot
 		return nil, status.Error(codes.NotFound, "no remote agent found with session ID")
 	}
 	return &pb.RefreshRemoteAgentResponse{}, nil
+}
+
+func (s *serverSecure) RequestConfigUpdates(ctx context.Context, _ *pb.RequestConfigUpdatesRequest) (*pb.RequestConfigUpdatesResponse, error) {
+	sessionID, err := configstreamServer.ValidateSessionID(ctx, s.remoteAgentRegistry, "requesting config updates")
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("RequestConfigUpdates authorized for remote agent with session_id: %s", sessionID)
+
+	s.secrets.Refresh()
+
+	return &pb.RequestConfigUpdatesResponse{}, nil
 }
 
 func (s *serverSecure) AutodiscoveryStreamConfig(_ *emptypb.Empty, out pb.AgentSecure_AutodiscoveryStreamConfigServer) error {

--- a/comp/core/configstream/server/BUILD.bazel
+++ b/comp/core/configstream/server/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "server",
-    srcs = ["server.go"],
+    srcs = [
+        "server.go",
+        "session.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/comp/core/configstream/server",
     visibility = ["//visibility:public"],
     deps = [

--- a/comp/core/configstream/server/server.go
+++ b/comp/core/configstream/server/server.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
@@ -41,28 +40,9 @@ func NewServer(cfg config.Component, comp configstream.Component, registry remot
 // StreamConfigEvents handles the gRPC streaming logic.
 // It requires the caller to be a registered remote agent (RAR-gated).
 func (s *Server) StreamConfigEvents(req *pb.ConfigStreamRequest, stream pb.AgentSecure_StreamConfigEventsServer) error {
-	if s.registry == nil {
-		return status.Error(codes.Unimplemented, "remote agent registry not enabled")
-	}
-
-	// Extract session_id from gRPC metadata
-	md, ok := metadata.FromIncomingContext(stream.Context())
-	if !ok {
-		return status.Error(codes.Unauthenticated, "missing gRPC metadata")
-	}
-
-	sessionIDs := md.Get("session_id")
-	if len(sessionIDs) == 0 {
-		return status.Error(codes.Unauthenticated, "session_id required in metadata: remote agent must register with RAR before subscribing to config stream")
-	}
-	sessionID := sessionIDs[0]
-
-	if sessionID == "" {
-		return status.Error(codes.Unauthenticated, "session_id cannot be empty: remote agent must register with RAR before subscribing to config stream")
-	}
-
-	if !s.registry.RefreshRemoteAgent(sessionID) {
-		return status.Errorf(codes.PermissionDenied, "session_id '%s' not found: remote agent must register with RAR before subscribing to config stream", sessionID)
+	sessionID, err := ValidateSessionID(stream.Context(), s.registry, "subscribing to config stream")
+	if err != nil {
+		return err
 	}
 
 	log.Infof("Config stream authorized for remote agent with session_id: %s (name: %s)", sessionID, req.Name)

--- a/comp/core/configstream/server/server_test.go
+++ b/comp/core/configstream/server/server_test.go
@@ -65,9 +65,9 @@ func (m *mockRemoteAgentRegistry) RegisterRemoteAgent(_ *remoteagentregistry.Reg
 	return "test-session-id", 30, nil
 }
 
-func (m *mockRemoteAgentRegistry) RefreshRemoteAgent(_ string) bool {
-	// Always return true for tests (agent is registered)
-	return true
+func (m *mockRemoteAgentRegistry) RefreshRemoteAgent(sessionID string) bool {
+	args := m.Called(sessionID)
+	return args.Bool(0)
 }
 
 func (m *mockRemoteAgentRegistry) GetRegisteredAgents() []remoteagentregistry.RegisteredAgent {
@@ -78,19 +78,24 @@ func (m *mockRemoteAgentRegistry) GetRegisteredAgentStatuses() []remoteagentregi
 	return nil
 }
 
-func setupTest(ctx context.Context, t *testing.T, sessionID string) (*Server, *mockComp, *mockStream, chan *pb.ConfigEvent) {
+// newTestServer returns a fresh Server backed by a new mockComp and mockRemoteAgentRegistry.
+// Callers add mock expectations on the returned registry and comp before use.
+func newTestServer(t *testing.T) (*Server, *mockComp, *mockRemoteAgentRegistry) {
 	cfg := configmock.New(t)
 	cfg.Set("remote_agent.configstream.sleep_interval", 10*time.Millisecond, model.SourceAgentRuntime)
-
 	comp := &mockComp{}
+	rar := &mockRemoteAgentRegistry{}
+	return NewServer(cfg, comp, rar), comp, rar
+}
+
+func setupTest(ctx context.Context, t *testing.T, sessionID string) (*Server, *mockComp, *mockStream, chan *pb.ConfigEvent) {
+	server, comp, rar := newTestServer(t)
 
 	md := metadata.New(map[string]string{"session_id": sessionID})
 	ctxWithMetadata := metadata.NewIncomingContext(ctx, md)
 	stream := &mockStream{ctx: ctxWithMetadata}
 
-	mockRAR := &mockRemoteAgentRegistry{}
-
-	server := NewServer(cfg, comp, mockRAR)
+	rar.On("RefreshRemoteAgent", sessionID).Return(true)
 	eventsCh := make(chan *pb.ConfigEvent, 1)
 
 	return server, comp, stream, eventsCh
@@ -182,13 +187,7 @@ func TestRARAuthorization(t *testing.T) {
 	}
 
 	t.Run("rejects request with missing metadata", func(t *testing.T) {
-		cfg := configmock.New(t)
-		cfg.Set("remote_agent.configstream.sleep_interval", 10*time.Millisecond, model.SourceAgentRuntime)
-		comp := &mockComp{}
-		mockRAR := &mockRemoteAgentRegistry{}
-		server := NewServer(cfg, comp, mockRAR)
-
-		// Context without metadata
+		server, _, _ := newTestServer(t)
 		stream := &mockStream{ctx: context.Background()}
 
 		err := server.StreamConfigEvents(testReq, stream)
@@ -198,15 +197,8 @@ func TestRARAuthorization(t *testing.T) {
 	})
 
 	t.Run("rejects request with missing session_id in metadata", func(t *testing.T) {
-		cfg := configmock.New(t)
-		cfg.Set("remote_agent.configstream.sleep_interval", 10*time.Millisecond, model.SourceAgentRuntime)
-		comp := &mockComp{}
-		mockRAR := &mockRemoteAgentRegistry{}
-		server := NewServer(cfg, comp, mockRAR)
-
-		// Context with metadata but no session_id
-		md := metadata.New(map[string]string{})
-		ctx := metadata.NewIncomingContext(context.Background(), md)
+		server, _, _ := newTestServer(t)
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{}))
 		stream := &mockStream{ctx: ctx}
 
 		err := server.StreamConfigEvents(testReq, stream)
@@ -216,20 +208,26 @@ func TestRARAuthorization(t *testing.T) {
 	})
 
 	t.Run("rejects request with empty session_id", func(t *testing.T) {
-		cfg := configmock.New(t)
-		cfg.Set("remote_agent.configstream.sleep_interval", 10*time.Millisecond, model.SourceAgentRuntime)
-		comp := &mockComp{}
-		mockRAR := &mockRemoteAgentRegistry{}
-		server := NewServer(cfg, comp, mockRAR)
-
-		// Context with empty session_id
-		md := metadata.New(map[string]string{"session_id": ""})
-		ctx := metadata.NewIncomingContext(context.Background(), md)
+		server, _, _ := newTestServer(t)
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{"session_id": ""}))
 		stream := &mockStream{ctx: ctx}
 
 		err := server.StreamConfigEvents(testReq, stream)
 		assert.Error(t, err)
 		assert.Equal(t, codes.Unauthenticated, status.Code(err))
 		require.ErrorContains(t, err, "session_id cannot be empty")
+	})
+
+	t.Run("rejects request with unknown session_id", func(t *testing.T) {
+		server, _, rar := newTestServer(t)
+		rar.On("RefreshRemoteAgent", "unknown-session").Return(false).Once()
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{"session_id": "unknown-session"}))
+		stream := &mockStream{ctx: ctx}
+
+		err := server.StreamConfigEvents(testReq, stream)
+		assert.Error(t, err)
+		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		require.ErrorContains(t, err, "session_id 'unknown-session' not found")
+		rar.AssertExpectations(t)
 	})
 }

--- a/comp/core/configstream/server/session.go
+++ b/comp/core/configstream/server/session.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package server
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
+)
+
+// ValidateSessionID extracts and validates the remote-agent session from gRPC metadata.
+// As a side effect it calls RefreshRemoteAgent, extending the session heartbeat so that
+// any RAR-gated RPC also acts as a liveness ping.
+func ValidateSessionID(ctx context.Context, registry remoteagentregistry.Component, action string) (string, error) {
+	if registry == nil {
+		return "", status.Error(codes.Unimplemented, "remote agent registry not enabled")
+	}
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", status.Error(codes.Unauthenticated, "missing gRPC metadata")
+	}
+
+	sessionIDs := md.Get("session_id")
+	if len(sessionIDs) == 0 {
+		return "", status.Errorf(codes.Unauthenticated, "session_id required in metadata: remote agent must register with RAR before %s", action)
+	}
+
+	sessionID := sessionIDs[0]
+	if sessionID == "" {
+		return "", status.Errorf(codes.Unauthenticated, "session_id cannot be empty: remote agent must register with RAR before %s", action)
+	}
+
+	if !registry.RefreshRemoteAgent(sessionID) {
+		return "", status.Errorf(codes.PermissionDenied, "session_id '%s' not found: remote agent must register with RAR before %s", sessionID, action)
+	}
+
+	return sessionID, nil
+}

--- a/pkg/proto/datadog/api/v1/api.proto
+++ b/pkg/proto/datadog/api/v1/api.proto
@@ -59,6 +59,9 @@ service AgentSecure {
     // Refresh a remote agent.
     rpc RefreshRemoteAgent(datadog.remoteagent.v1.RefreshRemoteAgentRequest) returns (datadog.remoteagent.v1.RefreshRemoteAgentResponse);
 
+    // Requests that the core agent reconcile refreshable config sources.
+    rpc RequestConfigUpdates(datadog.remoteagent.v1.RequestConfigUpdatesRequest) returns (datadog.remoteagent.v1.RequestConfigUpdatesResponse);
+
     // Subscribes to autodiscovery config updates
     rpc AutodiscoveryStreamConfig(google.protobuf.Empty) returns (stream datadog.autodiscovery.AutodiscoveryStreamResponse);
 

--- a/pkg/proto/datadog/remoteagent/remoteagent.proto
+++ b/pkg/proto/datadog/remoteagent/remoteagent.proto
@@ -50,3 +50,7 @@ message RefreshRemoteAgentRequest {
   string session_id = 1;
 }
 message RefreshRemoteAgentResponse {}
+
+message RequestConfigUpdatesRequest {}
+
+message RequestConfigUpdatesResponse {}

--- a/pkg/proto/pbgo/core/api.pb.go
+++ b/pkg/proto/pbgo/core/api.pb.go
@@ -27,7 +27,7 @@ const file_datadog_api_v1_api_proto_rawDesc = "" +
 	"\n" +
 	"\x18datadog/api/v1/api.proto\x12\x0edatadog.api.v1\x1a\x1cdatadog/model/v1/model.proto\x1a%datadog/remoteagent/remoteagent.proto\x1a'datadog/remoteconfig/remoteconfig.proto\x1a'datadog/workloadmeta/workloadmeta.proto\x1a+datadog/workloadfilter/workloadfilter.proto\x1a)datadog/autodiscovery/autodiscovery.proto\x1a'datadog/kubemetadata/kubemetadata.proto\x1a\x1bgoogle/protobuf/empty.proto2Z\n" +
 	"\x05Agent\x12Q\n" +
-	"\vGetHostname\x12!.datadog.model.v1.HostnameRequest\x1a\x1f.datadog.model.v1.HostnameReply2\xab\x10\n" +
+	"\vGetHostname\x12!.datadog.model.v1.HostnameRequest\x1a\x1f.datadog.model.v1.HostnameReply2\xaf\x11\n" +
 	"\vAgentSecure\x12c\n" +
 	"\x14TaggerStreamEntities\x12#.datadog.model.v1.StreamTagsRequest\x1a$.datadog.model.v1.StreamTagsResponse0\x01\x12\xa2\x01\n" +
 	"'TaggerGenerateContainerIDFromOriginInfo\x12:.datadog.model.v1.GenerateContainerIDFromOriginInfoRequest\x1a;.datadog.model.v1.GenerateContainerIDFromOriginInfoResponse\x12`\n" +
@@ -42,7 +42,8 @@ const file_datadog_api_v1_api_proto_rawDesc = "" +
 	"\x10ResetConfigState\x12\x16.google.protobuf.Empty\x1a(.datadog.config.ResetStateConfigResponse\x12\x81\x01\n" +
 	"\x1aWorkloadmetaStreamEntities\x12/.datadog.workloadmeta.WorkloadmetaStreamRequest\x1a0.datadog.workloadmeta.WorkloadmetaStreamResponse0\x01\x12~\n" +
 	"\x13RegisterRemoteAgent\x122.datadog.remoteagent.v1.RegisterRemoteAgentRequest\x1a3.datadog.remoteagent.v1.RegisterRemoteAgentResponse\x12{\n" +
-	"\x12RefreshRemoteAgent\x121.datadog.remoteagent.v1.RefreshRemoteAgentRequest\x1a2.datadog.remoteagent.v1.RefreshRemoteAgentResponse\x12i\n" +
+	"\x12RefreshRemoteAgent\x121.datadog.remoteagent.v1.RefreshRemoteAgentRequest\x1a2.datadog.remoteagent.v1.RefreshRemoteAgentResponse\x12\x81\x01\n" +
+	"\x14RequestConfigUpdates\x123.datadog.remoteagent.v1.RequestConfigUpdatesRequest\x1a4.datadog.remoteagent.v1.RequestConfigUpdatesResponse\x12i\n" +
 	"\x19AutodiscoveryStreamConfig\x12\x16.google.protobuf.Empty\x1a2.datadog.autodiscovery.AutodiscoveryStreamResponse0\x01\x12O\n" +
 	"\vGetHostTags\x12 .datadog.model.v1.HostTagRequest\x1a\x1e.datadog.model.v1.HostTagReply\x12\\\n" +
 	"\x12StreamConfigEvents\x12%.datadog.model.v1.ConfigStreamRequest\x1a\x1d.datadog.model.v1.ConfigEvent0\x01\x12\x87\x01\n" +
@@ -62,28 +63,30 @@ var file_datadog_api_v1_api_proto_goTypes = []any{
 	(*WorkloadmetaStreamRequest)(nil),                 // 9: datadog.workloadmeta.WorkloadmetaStreamRequest
 	(*RegisterRemoteAgentRequest)(nil),                // 10: datadog.remoteagent.v1.RegisterRemoteAgentRequest
 	(*RefreshRemoteAgentRequest)(nil),                 // 11: datadog.remoteagent.v1.RefreshRemoteAgentRequest
-	(*HostTagRequest)(nil),                            // 12: datadog.model.v1.HostTagRequest
-	(*ConfigStreamRequest)(nil),                       // 13: datadog.model.v1.ConfigStreamRequest
-	(*WorkloadFilterEvaluateRequest)(nil),             // 14: datadog.workloadfilter.WorkloadFilterEvaluateRequest
-	(*KubeMetadataStreamRequest)(nil),                 // 15: datadog.kubemetadata.KubeMetadataStreamRequest
-	(*HostnameReply)(nil),                             // 16: datadog.model.v1.HostnameReply
-	(*StreamTagsResponse)(nil),                        // 17: datadog.model.v1.StreamTagsResponse
-	(*GenerateContainerIDFromOriginInfoResponse)(nil), // 18: datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
-	(*FetchEntityResponse)(nil),                       // 19: datadog.model.v1.FetchEntityResponse
-	(*CaptureTriggerResponse)(nil),                    // 20: datadog.model.v1.CaptureTriggerResponse
-	(*TaggerStateResponse)(nil),                       // 21: datadog.model.v1.TaggerStateResponse
-	(*ClientGetConfigsResponse)(nil),                  // 22: datadog.config.ClientGetConfigsResponse
-	(*GetStateConfigResponse)(nil),                    // 23: datadog.config.GetStateConfigResponse
-	(*ConfigSubscriptionResponse)(nil),                // 24: datadog.config.ConfigSubscriptionResponse
-	(*ResetStateConfigResponse)(nil),                  // 25: datadog.config.ResetStateConfigResponse
-	(*WorkloadmetaStreamResponse)(nil),                // 26: datadog.workloadmeta.WorkloadmetaStreamResponse
-	(*RegisterRemoteAgentResponse)(nil),               // 27: datadog.remoteagent.v1.RegisterRemoteAgentResponse
-	(*RefreshRemoteAgentResponse)(nil),                // 28: datadog.remoteagent.v1.RefreshRemoteAgentResponse
-	(*AutodiscoveryStreamResponse)(nil),               // 29: datadog.autodiscovery.AutodiscoveryStreamResponse
-	(*HostTagReply)(nil),                              // 30: datadog.model.v1.HostTagReply
-	(*ConfigEvent)(nil),                               // 31: datadog.model.v1.ConfigEvent
-	(*WorkloadFilterEvaluateResponse)(nil),            // 32: datadog.workloadfilter.WorkloadFilterEvaluateResponse
-	(*KubeMetadataStreamResponse)(nil),                // 33: datadog.kubemetadata.KubeMetadataStreamResponse
+	(*RequestConfigUpdatesRequest)(nil),               // 12: datadog.remoteagent.v1.RequestConfigUpdatesRequest
+	(*HostTagRequest)(nil),                            // 13: datadog.model.v1.HostTagRequest
+	(*ConfigStreamRequest)(nil),                       // 14: datadog.model.v1.ConfigStreamRequest
+	(*WorkloadFilterEvaluateRequest)(nil),             // 15: datadog.workloadfilter.WorkloadFilterEvaluateRequest
+	(*KubeMetadataStreamRequest)(nil),                 // 16: datadog.kubemetadata.KubeMetadataStreamRequest
+	(*HostnameReply)(nil),                             // 17: datadog.model.v1.HostnameReply
+	(*StreamTagsResponse)(nil),                        // 18: datadog.model.v1.StreamTagsResponse
+	(*GenerateContainerIDFromOriginInfoResponse)(nil), // 19: datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
+	(*FetchEntityResponse)(nil),                       // 20: datadog.model.v1.FetchEntityResponse
+	(*CaptureTriggerResponse)(nil),                    // 21: datadog.model.v1.CaptureTriggerResponse
+	(*TaggerStateResponse)(nil),                       // 22: datadog.model.v1.TaggerStateResponse
+	(*ClientGetConfigsResponse)(nil),                  // 23: datadog.config.ClientGetConfigsResponse
+	(*GetStateConfigResponse)(nil),                    // 24: datadog.config.GetStateConfigResponse
+	(*ConfigSubscriptionResponse)(nil),                // 25: datadog.config.ConfigSubscriptionResponse
+	(*ResetStateConfigResponse)(nil),                  // 26: datadog.config.ResetStateConfigResponse
+	(*WorkloadmetaStreamResponse)(nil),                // 27: datadog.workloadmeta.WorkloadmetaStreamResponse
+	(*RegisterRemoteAgentResponse)(nil),               // 28: datadog.remoteagent.v1.RegisterRemoteAgentResponse
+	(*RefreshRemoteAgentResponse)(nil),                // 29: datadog.remoteagent.v1.RefreshRemoteAgentResponse
+	(*RequestConfigUpdatesResponse)(nil),              // 30: datadog.remoteagent.v1.RequestConfigUpdatesResponse
+	(*AutodiscoveryStreamResponse)(nil),               // 31: datadog.autodiscovery.AutodiscoveryStreamResponse
+	(*HostTagReply)(nil),                              // 32: datadog.model.v1.HostTagReply
+	(*ConfigEvent)(nil),                               // 33: datadog.model.v1.ConfigEvent
+	(*WorkloadFilterEvaluateResponse)(nil),            // 34: datadog.workloadfilter.WorkloadFilterEvaluateResponse
+	(*KubeMetadataStreamResponse)(nil),                // 35: datadog.kubemetadata.KubeMetadataStreamResponse
 }
 var file_datadog_api_v1_api_proto_depIdxs = []int32{
 	0,  // 0: datadog.api.v1.Agent.GetHostname:input_type -> datadog.model.v1.HostnameRequest
@@ -101,33 +104,35 @@ var file_datadog_api_v1_api_proto_depIdxs = []int32{
 	9,  // 12: datadog.api.v1.AgentSecure.WorkloadmetaStreamEntities:input_type -> datadog.workloadmeta.WorkloadmetaStreamRequest
 	10, // 13: datadog.api.v1.AgentSecure.RegisterRemoteAgent:input_type -> datadog.remoteagent.v1.RegisterRemoteAgentRequest
 	11, // 14: datadog.api.v1.AgentSecure.RefreshRemoteAgent:input_type -> datadog.remoteagent.v1.RefreshRemoteAgentRequest
-	7,  // 15: datadog.api.v1.AgentSecure.AutodiscoveryStreamConfig:input_type -> google.protobuf.Empty
-	12, // 16: datadog.api.v1.AgentSecure.GetHostTags:input_type -> datadog.model.v1.HostTagRequest
-	13, // 17: datadog.api.v1.AgentSecure.StreamConfigEvents:input_type -> datadog.model.v1.ConfigStreamRequest
-	14, // 18: datadog.api.v1.AgentSecure.WorkloadFilterEvaluate:input_type -> datadog.workloadfilter.WorkloadFilterEvaluateRequest
-	15, // 19: datadog.api.v1.AgentSecure.StreamKubeMetadata:input_type -> datadog.kubemetadata.KubeMetadataStreamRequest
-	16, // 20: datadog.api.v1.Agent.GetHostname:output_type -> datadog.model.v1.HostnameReply
-	17, // 21: datadog.api.v1.AgentSecure.TaggerStreamEntities:output_type -> datadog.model.v1.StreamTagsResponse
-	18, // 22: datadog.api.v1.AgentSecure.TaggerGenerateContainerIDFromOriginInfo:output_type -> datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
-	19, // 23: datadog.api.v1.AgentSecure.TaggerFetchEntity:output_type -> datadog.model.v1.FetchEntityResponse
-	20, // 24: datadog.api.v1.AgentSecure.DogstatsdCaptureTrigger:output_type -> datadog.model.v1.CaptureTriggerResponse
-	21, // 25: datadog.api.v1.AgentSecure.DogstatsdSetTaggerState:output_type -> datadog.model.v1.TaggerStateResponse
-	22, // 26: datadog.api.v1.AgentSecure.ClientGetConfigs:output_type -> datadog.config.ClientGetConfigsResponse
-	23, // 27: datadog.api.v1.AgentSecure.GetConfigState:output_type -> datadog.config.GetStateConfigResponse
-	22, // 28: datadog.api.v1.AgentSecure.ClientGetConfigsHA:output_type -> datadog.config.ClientGetConfigsResponse
-	23, // 29: datadog.api.v1.AgentSecure.GetConfigStateHA:output_type -> datadog.config.GetStateConfigResponse
-	24, // 30: datadog.api.v1.AgentSecure.CreateConfigSubscription:output_type -> datadog.config.ConfigSubscriptionResponse
-	25, // 31: datadog.api.v1.AgentSecure.ResetConfigState:output_type -> datadog.config.ResetStateConfigResponse
-	26, // 32: datadog.api.v1.AgentSecure.WorkloadmetaStreamEntities:output_type -> datadog.workloadmeta.WorkloadmetaStreamResponse
-	27, // 33: datadog.api.v1.AgentSecure.RegisterRemoteAgent:output_type -> datadog.remoteagent.v1.RegisterRemoteAgentResponse
-	28, // 34: datadog.api.v1.AgentSecure.RefreshRemoteAgent:output_type -> datadog.remoteagent.v1.RefreshRemoteAgentResponse
-	29, // 35: datadog.api.v1.AgentSecure.AutodiscoveryStreamConfig:output_type -> datadog.autodiscovery.AutodiscoveryStreamResponse
-	30, // 36: datadog.api.v1.AgentSecure.GetHostTags:output_type -> datadog.model.v1.HostTagReply
-	31, // 37: datadog.api.v1.AgentSecure.StreamConfigEvents:output_type -> datadog.model.v1.ConfigEvent
-	32, // 38: datadog.api.v1.AgentSecure.WorkloadFilterEvaluate:output_type -> datadog.workloadfilter.WorkloadFilterEvaluateResponse
-	33, // 39: datadog.api.v1.AgentSecure.StreamKubeMetadata:output_type -> datadog.kubemetadata.KubeMetadataStreamResponse
-	20, // [20:40] is the sub-list for method output_type
-	0,  // [0:20] is the sub-list for method input_type
+	12, // 15: datadog.api.v1.AgentSecure.RequestConfigUpdates:input_type -> datadog.remoteagent.v1.RequestConfigUpdatesRequest
+	7,  // 16: datadog.api.v1.AgentSecure.AutodiscoveryStreamConfig:input_type -> google.protobuf.Empty
+	13, // 17: datadog.api.v1.AgentSecure.GetHostTags:input_type -> datadog.model.v1.HostTagRequest
+	14, // 18: datadog.api.v1.AgentSecure.StreamConfigEvents:input_type -> datadog.model.v1.ConfigStreamRequest
+	15, // 19: datadog.api.v1.AgentSecure.WorkloadFilterEvaluate:input_type -> datadog.workloadfilter.WorkloadFilterEvaluateRequest
+	16, // 20: datadog.api.v1.AgentSecure.StreamKubeMetadata:input_type -> datadog.kubemetadata.KubeMetadataStreamRequest
+	17, // 21: datadog.api.v1.Agent.GetHostname:output_type -> datadog.model.v1.HostnameReply
+	18, // 22: datadog.api.v1.AgentSecure.TaggerStreamEntities:output_type -> datadog.model.v1.StreamTagsResponse
+	19, // 23: datadog.api.v1.AgentSecure.TaggerGenerateContainerIDFromOriginInfo:output_type -> datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
+	20, // 24: datadog.api.v1.AgentSecure.TaggerFetchEntity:output_type -> datadog.model.v1.FetchEntityResponse
+	21, // 25: datadog.api.v1.AgentSecure.DogstatsdCaptureTrigger:output_type -> datadog.model.v1.CaptureTriggerResponse
+	22, // 26: datadog.api.v1.AgentSecure.DogstatsdSetTaggerState:output_type -> datadog.model.v1.TaggerStateResponse
+	23, // 27: datadog.api.v1.AgentSecure.ClientGetConfigs:output_type -> datadog.config.ClientGetConfigsResponse
+	24, // 28: datadog.api.v1.AgentSecure.GetConfigState:output_type -> datadog.config.GetStateConfigResponse
+	23, // 29: datadog.api.v1.AgentSecure.ClientGetConfigsHA:output_type -> datadog.config.ClientGetConfigsResponse
+	24, // 30: datadog.api.v1.AgentSecure.GetConfigStateHA:output_type -> datadog.config.GetStateConfigResponse
+	25, // 31: datadog.api.v1.AgentSecure.CreateConfigSubscription:output_type -> datadog.config.ConfigSubscriptionResponse
+	26, // 32: datadog.api.v1.AgentSecure.ResetConfigState:output_type -> datadog.config.ResetStateConfigResponse
+	27, // 33: datadog.api.v1.AgentSecure.WorkloadmetaStreamEntities:output_type -> datadog.workloadmeta.WorkloadmetaStreamResponse
+	28, // 34: datadog.api.v1.AgentSecure.RegisterRemoteAgent:output_type -> datadog.remoteagent.v1.RegisterRemoteAgentResponse
+	29, // 35: datadog.api.v1.AgentSecure.RefreshRemoteAgent:output_type -> datadog.remoteagent.v1.RefreshRemoteAgentResponse
+	30, // 36: datadog.api.v1.AgentSecure.RequestConfigUpdates:output_type -> datadog.remoteagent.v1.RequestConfigUpdatesResponse
+	31, // 37: datadog.api.v1.AgentSecure.AutodiscoveryStreamConfig:output_type -> datadog.autodiscovery.AutodiscoveryStreamResponse
+	32, // 38: datadog.api.v1.AgentSecure.GetHostTags:output_type -> datadog.model.v1.HostTagReply
+	33, // 39: datadog.api.v1.AgentSecure.StreamConfigEvents:output_type -> datadog.model.v1.ConfigEvent
+	34, // 40: datadog.api.v1.AgentSecure.WorkloadFilterEvaluate:output_type -> datadog.workloadfilter.WorkloadFilterEvaluateResponse
+	35, // 41: datadog.api.v1.AgentSecure.StreamKubeMetadata:output_type -> datadog.kubemetadata.KubeMetadataStreamResponse
+	21, // [21:42] is the sub-list for method output_type
+	0,  // [0:21] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/pkg/proto/pbgo/core/api_grpc.pb.go
+++ b/pkg/proto/pbgo/core/api_grpc.pb.go
@@ -142,6 +142,7 @@ const (
 	AgentSecure_WorkloadmetaStreamEntities_FullMethodName              = "/datadog.api.v1.AgentSecure/WorkloadmetaStreamEntities"
 	AgentSecure_RegisterRemoteAgent_FullMethodName                     = "/datadog.api.v1.AgentSecure/RegisterRemoteAgent"
 	AgentSecure_RefreshRemoteAgent_FullMethodName                      = "/datadog.api.v1.AgentSecure/RefreshRemoteAgent"
+	AgentSecure_RequestConfigUpdates_FullMethodName                    = "/datadog.api.v1.AgentSecure/RequestConfigUpdates"
 	AgentSecure_AutodiscoveryStreamConfig_FullMethodName               = "/datadog.api.v1.AgentSecure/AutodiscoveryStreamConfig"
 	AgentSecure_GetHostTags_FullMethodName                             = "/datadog.api.v1.AgentSecure/GetHostTags"
 	AgentSecure_StreamConfigEvents_FullMethodName                      = "/datadog.api.v1.AgentSecure/StreamConfigEvents"
@@ -177,6 +178,8 @@ type AgentSecureClient interface {
 	RegisterRemoteAgent(ctx context.Context, in *RegisterRemoteAgentRequest, opts ...grpc.CallOption) (*RegisterRemoteAgentResponse, error)
 	// Refresh a remote agent.
 	RefreshRemoteAgent(ctx context.Context, in *RefreshRemoteAgentRequest, opts ...grpc.CallOption) (*RefreshRemoteAgentResponse, error)
+	// Requests that the core agent reconcile refreshable config sources.
+	RequestConfigUpdates(ctx context.Context, in *RequestConfigUpdatesRequest, opts ...grpc.CallOption) (*RequestConfigUpdatesResponse, error)
 	// Subscribes to autodiscovery config updates
 	AutodiscoveryStreamConfig(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AutodiscoveryStreamResponse], error)
 	// Get the host tags
@@ -358,6 +361,16 @@ func (c *agentSecureClient) RefreshRemoteAgent(ctx context.Context, in *RefreshR
 	return out, nil
 }
 
+func (c *agentSecureClient) RequestConfigUpdates(ctx context.Context, in *RequestConfigUpdatesRequest, opts ...grpc.CallOption) (*RequestConfigUpdatesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RequestConfigUpdatesResponse)
+	err := c.cc.Invoke(ctx, AgentSecure_RequestConfigUpdates_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *agentSecureClient) AutodiscoveryStreamConfig(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AutodiscoveryStreamResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &AgentSecure_ServiceDesc.Streams[3], AgentSecure_AutodiscoveryStreamConfig_FullMethodName, cOpts...)
@@ -463,6 +476,8 @@ type AgentSecureServer interface {
 	RegisterRemoteAgent(context.Context, *RegisterRemoteAgentRequest) (*RegisterRemoteAgentResponse, error)
 	// Refresh a remote agent.
 	RefreshRemoteAgent(context.Context, *RefreshRemoteAgentRequest) (*RefreshRemoteAgentResponse, error)
+	// Requests that the core agent reconcile refreshable config sources.
+	RequestConfigUpdates(context.Context, *RequestConfigUpdatesRequest) (*RequestConfigUpdatesResponse, error)
 	// Subscribes to autodiscovery config updates
 	AutodiscoveryStreamConfig(*emptypb.Empty, grpc.ServerStreamingServer[AutodiscoveryStreamResponse]) error
 	// Get the host tags
@@ -524,6 +539,9 @@ func (UnimplementedAgentSecureServer) RegisterRemoteAgent(context.Context, *Regi
 }
 func (UnimplementedAgentSecureServer) RefreshRemoteAgent(context.Context, *RefreshRemoteAgentRequest) (*RefreshRemoteAgentResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RefreshRemoteAgent not implemented")
+}
+func (UnimplementedAgentSecureServer) RequestConfigUpdates(context.Context, *RequestConfigUpdatesRequest) (*RequestConfigUpdatesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RequestConfigUpdates not implemented")
 }
 func (UnimplementedAgentSecureServer) AutodiscoveryStreamConfig(*emptypb.Empty, grpc.ServerStreamingServer[AutodiscoveryStreamResponse]) error {
 	return status.Error(codes.Unimplemented, "method AutodiscoveryStreamConfig not implemented")
@@ -788,6 +806,24 @@ func _AgentSecure_RefreshRemoteAgent_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AgentSecure_RequestConfigUpdates_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RequestConfigUpdatesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentSecureServer).RequestConfigUpdates(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AgentSecure_RequestConfigUpdates_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentSecureServer).RequestConfigUpdates(ctx, req.(*RequestConfigUpdatesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _AgentSecure_AutodiscoveryStreamConfig_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(emptypb.Empty)
 	if err := stream.RecvMsg(m); err != nil {
@@ -907,6 +943,10 @@ var AgentSecure_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RefreshRemoteAgent",
 			Handler:    _AgentSecure_RefreshRemoteAgent_Handler,
+		},
+		{
+			MethodName: "RequestConfigUpdates",
+			Handler:    _AgentSecure_RequestConfigUpdates_Handler,
 		},
 		{
 			MethodName: "GetHostTags",

--- a/pkg/proto/pbgo/core/remoteagent.pb.go
+++ b/pkg/proto/pbgo/core/remoteagent.pb.go
@@ -259,6 +259,78 @@ func (*RefreshRemoteAgentResponse) Descriptor() ([]byte, []int) {
 	return file_datadog_remoteagent_remoteagent_proto_rawDescGZIP(), []int{3}
 }
 
+type RequestConfigUpdatesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequestConfigUpdatesRequest) Reset() {
+	*x = RequestConfigUpdatesRequest{}
+	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequestConfigUpdatesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequestConfigUpdatesRequest) ProtoMessage() {}
+
+func (x *RequestConfigUpdatesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequestConfigUpdatesRequest.ProtoReflect.Descriptor instead.
+func (*RequestConfigUpdatesRequest) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteagent_remoteagent_proto_rawDescGZIP(), []int{4}
+}
+
+type RequestConfigUpdatesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequestConfigUpdatesResponse) Reset() {
+	*x = RequestConfigUpdatesResponse{}
+	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequestConfigUpdatesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequestConfigUpdatesResponse) ProtoMessage() {}
+
+func (x *RequestConfigUpdatesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequestConfigUpdatesResponse.ProtoReflect.Descriptor instead.
+func (*RequestConfigUpdatesResponse) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteagent_remoteagent_proto_rawDescGZIP(), []int{5}
+}
+
 var File_datadog_remoteagent_remoteagent_proto protoreflect.FileDescriptor
 
 const file_datadog_remoteagent_remoteagent_proto_rawDesc = "" +
@@ -277,7 +349,9 @@ const file_datadog_remoteagent_remoteagent_proto_rawDesc = "" +
 	"\x19RefreshRemoteAgentRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\"\x1c\n" +
-	"\x1aRefreshRemoteAgentResponseB\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
+	"\x1aRefreshRemoteAgentResponse\"\x1d\n" +
+	"\x1bRequestConfigUpdatesRequest\"\x1e\n" +
+	"\x1cRequestConfigUpdatesResponseB\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
 
 var (
 	file_datadog_remoteagent_remoteagent_proto_rawDescOnce sync.Once
@@ -291,12 +365,14 @@ func file_datadog_remoteagent_remoteagent_proto_rawDescGZIP() []byte {
 	return file_datadog_remoteagent_remoteagent_proto_rawDescData
 }
 
-var file_datadog_remoteagent_remoteagent_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_datadog_remoteagent_remoteagent_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_datadog_remoteagent_remoteagent_proto_goTypes = []any{
-	(*RegisterRemoteAgentRequest)(nil),  // 0: datadog.remoteagent.v1.RegisterRemoteAgentRequest
-	(*RegisterRemoteAgentResponse)(nil), // 1: datadog.remoteagent.v1.RegisterRemoteAgentResponse
-	(*RefreshRemoteAgentRequest)(nil),   // 2: datadog.remoteagent.v1.RefreshRemoteAgentRequest
-	(*RefreshRemoteAgentResponse)(nil),  // 3: datadog.remoteagent.v1.RefreshRemoteAgentResponse
+	(*RegisterRemoteAgentRequest)(nil),   // 0: datadog.remoteagent.v1.RegisterRemoteAgentRequest
+	(*RegisterRemoteAgentResponse)(nil),  // 1: datadog.remoteagent.v1.RegisterRemoteAgentResponse
+	(*RefreshRemoteAgentRequest)(nil),    // 2: datadog.remoteagent.v1.RefreshRemoteAgentRequest
+	(*RefreshRemoteAgentResponse)(nil),   // 3: datadog.remoteagent.v1.RefreshRemoteAgentResponse
+	(*RequestConfigUpdatesRequest)(nil),  // 4: datadog.remoteagent.v1.RequestConfigUpdatesRequest
+	(*RequestConfigUpdatesResponse)(nil), // 5: datadog.remoteagent.v1.RequestConfigUpdatesResponse
 }
 var file_datadog_remoteagent_remoteagent_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -317,7 +393,7 @@ func file_datadog_remoteagent_remoteagent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_remoteagent_remoteagent_proto_rawDesc), len(file_datadog_remoteagent_remoteagent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/proto/pbgo/mocks/core/api_mockgen.pb.go
+++ b/pkg/proto/pbgo/mocks/core/api_mockgen.pb.go
@@ -385,6 +385,26 @@ func (mr *MockAgentSecureClientMockRecorder) RegisterRemoteAgent(ctx, in interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterRemoteAgent", reflect.TypeOf((*MockAgentSecureClient)(nil).RegisterRemoteAgent), varargs...)
 }
 
+// RequestConfigUpdates mocks base method.
+func (m *MockAgentSecureClient) RequestConfigUpdates(ctx context.Context, in *core.RequestConfigUpdatesRequest, opts ...grpc.CallOption) (*core.RequestConfigUpdatesResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RequestConfigUpdates", varargs...)
+	ret0, _ := ret[0].(*core.RequestConfigUpdatesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RequestConfigUpdates indicates an expected call of RequestConfigUpdates.
+func (mr *MockAgentSecureClientMockRecorder) RequestConfigUpdates(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestConfigUpdates", reflect.TypeOf((*MockAgentSecureClient)(nil).RequestConfigUpdates), varargs...)
+}
+
 // ResetConfigState mocks base method.
 func (m *MockAgentSecureClient) ResetConfigState(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*core.ResetStateConfigResponse, error) {
 	m.ctrl.T.Helper()
@@ -729,6 +749,21 @@ func (m *MockAgentSecureServer) RegisterRemoteAgent(arg0 context.Context, arg1 *
 func (mr *MockAgentSecureServerMockRecorder) RegisterRemoteAgent(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterRemoteAgent", reflect.TypeOf((*MockAgentSecureServer)(nil).RegisterRemoteAgent), arg0, arg1)
+}
+
+// RequestConfigUpdates mocks base method.
+func (m *MockAgentSecureServer) RequestConfigUpdates(arg0 context.Context, arg1 *core.RequestConfigUpdatesRequest) (*core.RequestConfigUpdatesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequestConfigUpdates", arg0, arg1)
+	ret0, _ := ret[0].(*core.RequestConfigUpdatesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RequestConfigUpdates indicates an expected call of RequestConfigUpdates.
+func (mr *MockAgentSecureServerMockRecorder) RequestConfigUpdates(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestConfigUpdates", reflect.TypeOf((*MockAgentSecureServer)(nil).RequestConfigUpdates), arg0, arg1)
 }
 
 // ResetConfigState mocks base method.


### PR DESCRIPTION
### What does this PR do?

Add an RPC method which allows Remote Agents to request Core Agent to refresh its configuration.

This is a generic method which currently invokes secrets updates.

### Motivation

We have a specific corner case when customers use a secret management tool to handle their API keys. When these secret-managed keys expire, and our transactions return 403, we can request a value update from the secrets manager. Unfortunately, Remote Agents weren't able to do that until now. With this change, Remote Agents can use the new API to ask Core Agent to refresh its configuration, which internally means secrets renewal. If there are any updates to the stored values, we distribute the update to Remote Agents via configstream.

### Describe how you validated your changes

Full end-to-end validation will be done from ADP side which is the main consumer of this new feature.

### Additional Notes

- AGTMETRICS-504