### PR TITLE
Fix pkg/compliance/dbconfig/loader_test flake

### DIFF
--- a/pkg/compliance/dbconfig/loader_test.go
+++ b/pkg/compliance/dbconfig/loader_test.go
@@ -108,7 +108,7 @@ func launchFakeProcess(ctx context.Context, t *testing.T, procname string, args 
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer pipeR.Close()
+	t.Cleanup(func() { pipeR.Close() }) // outlive the function so child doesn't SIGPIPE (empty /proc/<pid>/cmdline)
 	defer pipeW.Close()
 
 	args = append([]string{"-test.run=TestDBConfigLaunchFakeProcess", "--"}, args...)


### PR DESCRIPTION
### What does this PR do?
Close the fake process's pipe **read** end via `t.Cleanup` instead of a `defer` in the `launchFakeProcess` test helper function.

### Motivation
`TestPGConfParsingCustom` failed intermittently, with the config-file `port`/`max_connections` winning over the CLI `--port`/`--max_connections` overrides.

Root cause: the helper's `defer pipeR.Close()` fired as soon as the helper function returned, mid-test, while a goroutine still drained the child's stdout.
With no live read end, the fake "postgres" child took a SIGPIPE on its next write and turned into a zombie. A zombie has no `mm`, so `/proc/<pid>/cmdline` read back empty, `parseCmdline` found no flags, and the overrides were lost:
```
==================== Test output for //pkg/compliance/dbconfig:dbconfig_test:
1780044177518672978 [Info] config lib used: nodetreemodel
1780044178159150807 [Info] config lib used: nodetreemodel
--- FAIL: TestPGConfParsingCustom (1.30s)
    loader_test.go:260:
        	Error Trace:	pkg/compliance/dbconfig/loader_test.go:260
        	Error:      	Not equal:
        	            	expected: "5000"
        	            	actual  : "4000"

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-5000
        	            	+4000
        	Test:       	TestPGConfParsingCustom
    loader_test.go:272:
        	Error Trace:	pkg/compliance/dbconfig/loader_test.go:272
        	Error:      	Not equal:
        	            	expected: "9999"
        	            	actual  : "5432"

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-9999
        	            	+5432
        	Test:       	TestPGConfParsingCustom
FAIL
================================================================================
```
The read end must outlive the helper: `t.Cleanup` closes it at test end, and on `t.Fatal` too.

### Describe how you validated your changes
Reproduced at ~5% by looping the test binary uncached; 0 failures in 500 runs after the fix, and 30/30 under `bazel test --nocache_test_results`.

### Additional Notes
Conversely, the **write** end stays a `defer`: the parent's copy is unused once the child inherits its own at `Start`.