### PR TITLE
[NDM] [SNMP] Disambiguate duplicate-MAC local interfaces by ifType

### DIFF
--- a/pkg/collector/corechecks/snmp/integration_topology_test.go
+++ b/pkg/collector/corechecks/snmp/integration_topology_test.go
@@ -68,6 +68,7 @@ profiles:
 	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
+	sender.On("Count", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return() // datadog.snmp.topology.local_interface_resolution
 	sender.On("Commit").Return()
 
 	packet := gosnmp.SnmpPacket{
@@ -839,6 +840,7 @@ profiles:
 	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
+	sender.On("Count", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return() // datadog.snmp.topology.local_interface_resolution
 	sender.On("Commit").Return()
 
 	packet := gosnmp.SnmpPacket{
@@ -1600,6 +1602,7 @@ profiles:
 	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
+	sender.On("Count", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return() // datadog.snmp.topology.local_interface_resolution
 	sender.On("Commit").Return()
 
 	packet := gosnmp.SnmpPacket{
@@ -2362,6 +2365,7 @@ profiles:
 	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
+	sender.On("Count", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return() // datadog.snmp.topology.local_interface_resolution
 	sender.On("Commit").Return()
 
 	packet := gosnmp.SnmpPacket{

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -35,6 +35,47 @@ const topologyLinkSourceTypeCDP = "cdp"
 const ciscoNetworkProtocolIPv4 = "1"
 const ciscoNetworkProtocolIPv6 = "20"
 
+// localInterfaceResolutionMetric is emitted once per CDP/LLDP local-interface
+// resolution attempt, tagged with `outcome:<bucket>` and `id_type:<type>`,
+// so we can size the post-release impact of the physical-interface tiebreak
+// (see resolveLocalInterface).
+const localInterfaceResolutionMetric = "datadog.snmp.topology.local_interface_resolution"
+
+// Local-interface resolution outcome buckets. Values are stable label
+// strings (≤5 cardinality) — see the topology.local_interface_resolution
+// metric.
+const (
+	localIfaceResolutionResolvedUnique           = "resolved_unique"
+	localIfaceResolutionResolvedPhysicalTiebreak = "resolved_physical_tiebreak"
+	localIfaceResolutionUnresolvedMultiPhysical  = "unresolved_multi_physical"
+	localIfaceResolutionUnresolvedNoPhysical     = "unresolved_no_physical"
+	localIfaceResolutionUnresolvedNoMatch        = "unresolved_no_match"
+)
+
+// physicalEthernetIfTypes is the canonical set of IF-MIB ifType values
+// (RFC 7224 IANAifType) that NDM treats as "physical ethernet":
+//   - 6   ethernetCsmacd
+//   - 62  fastEther
+//   - 69  fastEtherFX
+//   - 117 gigabitEthernet
+//
+// Shared between buildNetworkInterfacesMetadata (which sets
+// InterfaceMetadata.IsPhysical) and resolveLocalInterface (which uses
+// it as a tiebreak when one MAC is shared by a physical and one or more
+// virtual interfaces, e.g. SVIs / port-channels).
+var physicalEthernetIfTypes = map[int32]bool{
+	6:   true,
+	62:  true,
+	69:  true,
+	117: true,
+}
+
+// isPhysicalEthernetIfType reports whether the IF-MIB ifType represents a
+// physical ethernet interface. See physicalEthernetIfTypes.
+func isPhysicalEthernetIfType(ifType int32) bool {
+	return physicalEthernetIfTypes[ifType]
+}
+
 const inetAddressUnknown = "0"
 const inetAddressIPv4 = "1"
 
@@ -73,7 +114,7 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 
 	interfaces := buildNetworkInterfacesMetadata(config.DeviceID, metadataStore)
 	ipAddresses := buildNetworkIPAddressesMetadata(config.DeviceID, metadataStore)
-	topologyLinks := buildNetworkTopologyMetadata(config.DeviceID, metadataStore, interfaces)
+	topologyLinks := ms.buildNetworkTopologyMetadata(config.DeviceID, metadataStore, interfaces, metricTags)
 	vpnTunnels := buildVPNTunnelsMetadata(config.DeviceID, metadataStore)
 
 	metadataPayloads := devicemetadata.BatchPayloads(integrations.SNMP, config.Namespace, config.ResolvedSubnetName, collectTime, devicemetadata.PayloadMetadataBatchSize, devices, interfaces, ipAddresses, topologyLinks, vpnTunnels, nil, diagnoses)
@@ -309,11 +350,12 @@ func buildNetworkInterfacesMetadata(deviceID string, store *metadata.Store) []de
 		name := store.GetColumnAsString("interface.name", strIndex)
 		ifType := int32(store.GetColumnAsFloat("interface.type", strIndex))
 
-		// Compute is_physical based on ifType
-		// Physical ethernet types: 6 (ethernetCsmacd), 62 (fastEther), 69 (fastEtherFX), 117 (gigabitEthernet)
+		// Compute is_physical based on ifType. The canonical physical-ethernet
+		// ifType set lives in physicalEthernetIfTypes; reuse it here and in
+		// resolveLocalInterface so both stay in sync.
 		var isPhysical *bool
 		if ifType != 0 {
-			physical := ifType == 6 || ifType == 62 || ifType == 69 || ifType == 117
+			physical := isPhysicalEthernetIfType(ifType)
 			isPhysical = &physical
 		}
 
@@ -361,22 +403,26 @@ func buildNetworkIPAddressesMetadata(deviceID string, store *metadata.Store) []d
 	return ipAddresses
 }
 
-func buildNetworkTopologyMetadata(deviceID string, store *metadata.Store, interfaces []devicemetadata.InterfaceMetadata) []devicemetadata.TopologyLinkMetadata {
+// buildNetworkTopologyMetadata is a method on *MetricSender so that the LLDP
+// path can emit the local-interface resolution telemetry counter
+// (localInterfaceResolutionMetric). The CDP path resolves locally from
+// cdpCacheIfIndex (no ambiguity), so no telemetry is emitted there.
+func (ms *MetricSender) buildNetworkTopologyMetadata(deviceID string, store *metadata.Store, interfaces []devicemetadata.InterfaceMetadata, metricTags []string) []devicemetadata.TopologyLinkMetadata {
 	if store == nil {
 		// it's expected that the value store is nil if we can't reach the device
 		// in that case, we just return a nil slice.
 		return nil
 	}
 
-	links := buildNetworkTopologyMetadataWithLLDP(deviceID, store, interfaces)
+	links := ms.buildNetworkTopologyMetadataWithLLDP(deviceID, store, interfaces, metricTags)
 	if len(links) == 0 {
 		links = buildNetworkTopologyMetadataWithCDP(deviceID, store, interfaces)
 	}
 	return links
 }
 
-func buildNetworkTopologyMetadataWithLLDP(deviceID string, store *metadata.Store, interfaces []devicemetadata.InterfaceMetadata) []devicemetadata.TopologyLinkMetadata {
-	interfaceIndexByIDType := buildInterfaceIndexByIDType(interfaces)
+func (ms *MetricSender) buildNetworkTopologyMetadataWithLLDP(deviceID string, store *metadata.Store, interfaces []devicemetadata.InterfaceMetadata, metricTags []string) []devicemetadata.TopologyLinkMetadata {
+	interfaceIndexByIDType, interfaceByIndex := buildInterfaceIndexByIDType(interfaces)
 
 	remManAddrByLLDPRemIndexAndLLDPRemLocalPortNum := getRemManIPAddrByLLDPRemIndexAndLLDPRemLocalPortNum(store.GetColumnIndexes("lldp_remote_management.interface_id_type"))
 
@@ -410,7 +456,8 @@ func buildNetworkTopologyMetadataWithLLDP(deviceID string, store *metadata.Store
 		localInterfaceIDType := lldp.PortIDSubTypeMap[store.GetColumnAsString("lldp_local.interface_id_type", localPortNum)]
 		localInterfaceID := formatID(localInterfaceIDType, store, "lldp_local.interface_id", localPortNum)
 
-		resolvedLocalInterfaceID := resolveLocalInterface(deviceID, interfaceIndexByIDType, localInterfaceIDType, localInterfaceID)
+		resolvedLocalInterfaceID, resolutionOutcome := resolveLocalInterface(deviceID, interfaceIndexByIDType, interfaceByIndex, localInterfaceIDType, localInterfaceID)
+		ms.emitLocalInterfaceResolutionMetric(resolutionOutcome, localInterfaceIDType, metricTags)
 
 		// remEntryUniqueID: The combination of localPortNum and lldpRemIndex is expected to be unique for each entry in
 		//                   lldpRemTable. We don't include lldpRemTimeMark (used for filtering only recent data) since it can change often.
@@ -536,9 +583,31 @@ func getRemDeviceAddressIfIPType(store *metadata.Store, strIndex string, address
 	return ""
 }
 
-func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]map[string][]int32, localInterfaceIDType string, localInterfaceID string) string {
+// resolveLocalInterface maps a CDP/LLDP-reported local-side identifier to a
+// concrete local interface_id. It returns the resolved interface_id (empty
+// string when no unique resolution is possible) and a stable outcome bucket
+// used for telemetry tagging — see localInterfaceResolutionMetric for the
+// allowed bucket values.
+//
+// Disambiguation rules:
+//   - 0 matches → "unresolved_no_match", "".
+//   - 1 match → "resolved_unique", "<deviceID>:<ifIndex>".
+//   - >1 matches → partition candidates by InterfaceMetadata.IsPhysical (see
+//     physicalEthernetIfTypes). Exactly one physical wins
+//     ("resolved_physical_tiebreak"); 0 physical → "unresolved_no_physical";
+//     ≥2 physical → "unresolved_multi_physical". This matches the framing in
+//     the BSSID RFC (II/6664785860): physical interfaces are the
+//     overwhelmingly likely correct mapping when MACs collide with virtual
+//     interfaces (SVIs, sub-interfaces, port-channels), and any false
+//     positive is at minimum no worse than the previous "drop entirely"
+//     behavior. The telemetry bucket lets us measure the resolved_physical_tiebreak
+//     rate post-release.
+//
+// interfaceByIndex is consulted as a defensive lookup; an ifIndex missing
+// from it (or with IsPhysical == nil) is treated as non-physical (R2).
+func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]map[string][]int32, interfaceByIndex map[int32]devicemetadata.InterfaceMetadata, localInterfaceIDType string, localInterfaceID string) (string, string) {
 	if localInterfaceID == "" {
-		return ""
+		return "", localIfaceResolutionUnresolvedNoMatch
 	}
 
 	var typesToTry []string
@@ -569,20 +638,76 @@ func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]ma
 		}
 		interfaceID := deviceID + ":" + strconv.Itoa(int(matchedIfIndexes[0]))
 		log.Tracef("[local interface resolution] found 1 matching interface (idType=%s, id=%s) resolved to interface_id `%s`", localInterfaceIDType, localInterfaceID, interfaceID)
-		return interfaceID
-	} else if len(matchedIfIndexesMap) > 1 {
-		log.Tracef("[local interface resolution] expected 1 matching interface but found %d (idType=%s, id=%s): %+v", len(matchedIfIndexesMap), localInterfaceIDType, localInterfaceID, matchedIfIndexesMap)
-	} else {
-		log.Tracef("[local interface resolution] expected 1 matching interface but found 0 (idType=%s, id=%s)", localInterfaceIDType, localInterfaceID)
+		return interfaceID, localIfaceResolutionResolvedUnique
 	}
-	return ""
+	if len(matchedIfIndexesMap) > 1 {
+		// >1 match: try the physical-interface tiebreak. The common cause is
+		// a physical interface sharing a MAC with one or more virtual
+		// interfaces (SVIs, sub-interfaces, port-channel members).
+		var physicalCandidates []int32
+		for ifIndex := range matchedIfIndexesMap {
+			iface, ok := interfaceByIndex[ifIndex]
+			if !ok {
+				continue
+			}
+			// IsPhysical is *bool; nil → treat as non-physical (R2).
+			if iface.IsPhysical != nil && *iface.IsPhysical {
+				physicalCandidates = append(physicalCandidates, ifIndex)
+			}
+		}
+		switch len(physicalCandidates) {
+		case 1:
+			interfaceID := deviceID + ":" + strconv.Itoa(int(physicalCandidates[0]))
+			log.Tracef("[local interface resolution] found %d matching interfaces (idType=%s, id=%s), physical-interface tiebreak resolved to interface_id `%s`", len(matchedIfIndexesMap), localInterfaceIDType, localInterfaceID, interfaceID)
+			return interfaceID, localIfaceResolutionResolvedPhysicalTiebreak
+		case 0:
+			log.Tracef("[local interface resolution] expected 1 matching interface but found %d (idType=%s, id=%s), 0 physical candidates: %+v", len(matchedIfIndexesMap), localInterfaceIDType, localInterfaceID, matchedIfIndexesMap)
+			return "", localIfaceResolutionUnresolvedNoPhysical
+		default:
+			log.Tracef("[local interface resolution] expected 1 matching interface but found %d (idType=%s, id=%s), %d physical candidates (cannot tiebreak): %+v", len(matchedIfIndexesMap), localInterfaceIDType, localInterfaceID, len(physicalCandidates), matchedIfIndexesMap)
+			return "", localIfaceResolutionUnresolvedMultiPhysical
+		}
+	}
+	log.Tracef("[local interface resolution] expected 1 matching interface but found 0 (idType=%s, id=%s)", localInterfaceIDType, localInterfaceID)
+	return "", localIfaceResolutionUnresolvedNoMatch
 }
 
-func buildInterfaceIndexByIDType(interfaces []devicemetadata.InterfaceMetadata) map[string]map[string][]int32 {
+// emitLocalInterfaceResolutionMetric emits one Count sample per local
+// interface resolution attempt, tagged with `outcome:<bucket>` and
+// `id_type:<id_type|smart>`. Cardinality is bounded: outcome has 5 values
+// (see localIfaceResolution* constants); id_type is one of the LLDP
+// PortIDSubTypeMap values or "smart" when the device did not report an
+// id type. Safe to call with a nil/uninitialized sender (no-op).
+func (ms *MetricSender) emitLocalInterfaceResolutionMetric(outcome, localInterfaceIDType string, metricTags []string) {
+	if ms == nil || ms.sender == nil {
+		return
+	}
+	idTypeTag := localInterfaceIDType
+	if idTypeTag == "" {
+		idTypeTag = "smart"
+	}
+	tags := make([]string, 0, len(metricTags)+2)
+	tags = append(tags, metricTags...)
+	tags = append(tags, "outcome:"+outcome, "id_type:"+idTypeTag)
+	ms.sender.Count(localInterfaceResolutionMetric, 1, ms.hostname, tags)
+}
+
+// buildInterfaceIndexByIDType returns two parallel lookup structures used by
+// resolveLocalInterface:
+//   - interfaceIndexByIDType: map[ID_TYPE]map[ID_VALUE][]IF_INDEX, the bare
+//     identifier→ifIndex lookup.
+//   - interfaceByIndex: map[IF_INDEX]InterfaceMetadata, used by the
+//     physical-vs-virtual tiebreak in resolveLocalInterface when more than
+//     one ifIndex matches a single identifier (e.g. duplicate MAC).
+//
+// The second map is intentionally small (one entry per interface) and reuses
+// the InterfaceMetadata slice that the caller already has on the heap.
+func buildInterfaceIndexByIDType(interfaces []devicemetadata.InterfaceMetadata) (map[string]map[string][]int32, map[int32]devicemetadata.InterfaceMetadata) {
 	interfaceIndexByIDType := make(map[string]map[string][]int32) // map[ID_TYPE]map[ID_VALUE]IF_INDEX
 	for _, idType := range []string{"mac_address", "interface_name", "interface_alias", "interface_index"} {
 		interfaceIndexByIDType[idType] = make(map[string][]int32)
 	}
+	interfaceByIndex := make(map[int32]devicemetadata.InterfaceMetadata, len(interfaces))
 	for _, devInterface := range interfaces {
 		interfaceIndexByIDType["mac_address"][devInterface.MacAddress] = append(interfaceIndexByIDType["mac_address"][devInterface.MacAddress], devInterface.Index)
 		interfaceIndexByIDType["interface_name"][devInterface.Name] = append(interfaceIndexByIDType["interface_name"][devInterface.Name], devInterface.Index)
@@ -591,8 +716,10 @@ func buildInterfaceIndexByIDType(interfaces []devicemetadata.InterfaceMetadata) 
 		// interface_index is not a type defined by LLDP, it's used in local interface "smart resolution" when the idType is not present
 		strIndex := strconv.Itoa(int(devInterface.Index))
 		interfaceIndexByIDType["interface_index"][strIndex] = append(interfaceIndexByIDType["interface_index"][strIndex], devInterface.Index)
+
+		interfaceByIndex[devInterface.Index] = devInterface
 	}
-	return interfaceIndexByIDType
+	return interfaceIndexByIDType, interfaceByIndex
 }
 
 func buildLLDPRemoteKey(localPortNum, lldpRemIndex string) string {

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
+	internalmetadata "github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/metadata"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
 )
 
@@ -1193,11 +1194,18 @@ func Test_getRemManIPAddrByLLDPRemIndexAndLLDPRemLocalPortNum(t *testing.T) {
 }
 
 func Test_resolveLocalInterface(t *testing.T) {
+	truePtr := true
+	falsePtr := false
 	interfaceIndexByIDType := map[string]map[string][]int32{
 		"mac_address": {
 			"00:00:00:00:00:01": []int32{1},
 			"00:00:00:00:00:02": []int32{2},
 			"00:00:00:00:00:03": []int32{3, 4},
+			// Physical-tiebreak scenarios:
+			"aa:bb:cc:dd:ee:01": []int32{10, 100}, // 10 physical, 100 virtual → tiebreak
+			"aa:bb:cc:dd:ee:02": []int32{20, 200}, // both virtual → unresolved_no_physical
+			"aa:bb:cc:dd:ee:03": []int32{30, 300}, // both physical → unresolved_multi_physical
+			"aa:bb:cc:dd:ee:04": []int32{40, 400}, // 40 physical, 400 has IsPhysical=nil (treated non-physical)
 		},
 		"interface_name": {
 			"eth1": []int32{1},
@@ -1216,90 +1224,162 @@ func Test_resolveLocalInterface(t *testing.T) {
 			"2": []int32{2},
 		},
 	}
+	interfaceByIndex := map[int32]metadata.InterfaceMetadata{
+		1:  {Index: 1, Type: 6, IsPhysical: &truePtr},
+		2:  {Index: 2, Type: 6, IsPhysical: &truePtr},
+		3:  {Index: 3, Type: 6, IsPhysical: &truePtr},
+		4:  {Index: 4, Type: 6, IsPhysical: &truePtr},
+		44: {Index: 44, Type: 6, IsPhysical: &truePtr}, // present so eth4 multi-match has 2 physical candidates
+		// Multi-match cases — IsPhysical drives the tiebreak.
+		10:  {Index: 10, Type: 6, IsPhysical: &truePtr},    // physical
+		100: {Index: 100, Type: 53, IsPhysical: &falsePtr}, // virtual (propVirtual)
+		20:  {Index: 20, Type: 24, IsPhysical: &falsePtr},  // loopback
+		200: {Index: 200, Type: 53, IsPhysical: &falsePtr}, // virtual
+		30:  {Index: 30, Type: 6, IsPhysical: &truePtr},
+		300: {Index: 300, Type: 117, IsPhysical: &truePtr},
+		40:  {Index: 40, Type: 6, IsPhysical: &truePtr},
+		400: {Index: 400, Type: 0, IsPhysical: nil}, // ifType not collected → nil
+	}
 	deviceID := "default:1.2.3.4"
 
 	tests := []struct {
-		name        string
-		localIDType string
-		localID     string
-		expectedID  string
+		name            string
+		localIDType     string
+		localID         string
+		expectedID      string
+		expectedOutcome string
 	}{
 		{
-			name:        "mac_address",
-			localIDType: "mac_address",
-			localID:     "00:00:00:00:00:01",
-			expectedID:  "default:1.2.3.4:1",
+			name:            "mac_address",
+			localIDType:     "mac_address",
+			localID:         "00:00:00:00:00:01",
+			expectedID:      "default:1.2.3.4:1",
+			expectedOutcome: localIfaceResolutionResolvedUnique,
 		},
 		{
-			name:        "mac_address cannot resolve due to multiple results",
-			localIDType: "mac_address",
-			localID:     "00:00:00:00:00:03",
-			expectedID:  "",
+			name:            "mac_address multi-match all physical: unresolved_multi_physical",
+			localIDType:     "mac_address",
+			localID:         "00:00:00:00:00:03",
+			expectedID:      "",
+			expectedOutcome: localIfaceResolutionUnresolvedMultiPhysical,
 		},
 		{
-			name:        "interface_name",
-			localIDType: "interface_name",
-			localID:     "eth2",
-			expectedID:  "default:1.2.3.4:2",
+			name:            "interface_name",
+			localIDType:     "interface_name",
+			localID:         "eth2",
+			expectedID:      "default:1.2.3.4:2",
+			expectedOutcome: localIfaceResolutionResolvedUnique,
 		},
 		{
-			name:        "interface_alias",
-			localIDType: "interface_alias",
-			localID:     "alias2",
-			expectedID:  "default:1.2.3.4:2",
+			name:            "interface_alias",
+			localIDType:     "interface_alias",
+			localID:         "alias2",
+			expectedID:      "default:1.2.3.4:2",
+			expectedOutcome: localIfaceResolutionResolvedUnique,
 		},
 		{
-			name:        "mac_address by trying",
-			localIDType: "",
-			localID:     "00:00:00:00:00:01",
-			expectedID:  "default:1.2.3.4:1",
+			name:            "mac_address by trying",
+			localIDType:     "",
+			localID:         "00:00:00:00:00:01",
+			expectedID:      "default:1.2.3.4:1",
+			expectedOutcome: localIfaceResolutionResolvedUnique,
 		},
 		{
-			name:        "interface_name by trying",
-			localIDType: "",
-			localID:     "eth2",
-			expectedID:  "default:1.2.3.4:2",
+			name:            "interface_name by trying",
+			localIDType:     "",
+			localID:         "eth2",
+			expectedID:      "default:1.2.3.4:2",
+			expectedOutcome: localIfaceResolutionResolvedUnique,
 		},
 		{
-			name:        "interface_alias by trying",
-			localIDType: "",
-			localID:     "alias2",
-			expectedID:  "default:1.2.3.4:2",
+			name:            "interface_alias by trying",
+			localIDType:     "",
+			localID:         "alias2",
+			expectedID:      "default:1.2.3.4:2",
+			expectedOutcome: localIfaceResolutionResolvedUnique,
 		},
 		{
-			name:        "interface_alias+interface_name match with same interface should resolve",
-			localIDType: "",
-			localID:     "eth3",
-			expectedID:  "default:1.2.3.4:3",
+			name:            "interface_alias+interface_name match with same interface should resolve",
+			localIDType:     "",
+			localID:         "eth3",
+			expectedID:      "default:1.2.3.4:3",
+			expectedOutcome: localIfaceResolutionResolvedUnique,
 		},
 		{
-			name:        "interface_alias+interface_name match with different interface should not resolve",
-			localIDType: "",
-			localID:     "eth4",
-			expectedID:  "",
+			name:            "interface_alias+interface_name match with different interface (both physical) should not resolve",
+			localIDType:     "",
+			localID:         "eth4",
+			expectedID:      "",
+			expectedOutcome: localIfaceResolutionUnresolvedMultiPhysical,
 		},
 		{
-			name:        "interface_index by trying",
-			localIDType: "",
-			localID:     "2",
-			expectedID:  "default:1.2.3.4:2",
+			name:            "interface_index by trying",
+			localIDType:     "",
+			localID:         "2",
+			expectedID:      "default:1.2.3.4:2",
+			expectedOutcome: localIfaceResolutionResolvedUnique,
 		},
 		{
-			name:        "mac_address not found",
-			localIDType: "mac_address",
-			localID:     "00:00:00:00:00:99",
-			expectedID:  "",
+			name:            "mac_address not found",
+			localIDType:     "mac_address",
+			localID:         "00:00:00:00:00:99",
+			expectedID:      "",
+			expectedOutcome: localIfaceResolutionUnresolvedNoMatch,
 		},
 		{
-			name:        "invalid",
-			localIDType: "invalid_type",
-			localID:     "invalidID",
-			expectedID:  "",
+			name:            "empty localInterfaceID",
+			localIDType:     "mac_address",
+			localID:         "",
+			expectedID:      "",
+			expectedOutcome: localIfaceResolutionUnresolvedNoMatch,
+		},
+		{
+			name:            "invalid",
+			localIDType:     "invalid_type",
+			localID:         "invalidID",
+			expectedID:      "",
+			expectedOutcome: localIfaceResolutionUnresolvedNoMatch,
+		},
+		// PRD success criterion #1 + scope item 5b: multi-match with exactly
+		// one physical → physical wins.
+		{
+			name:            "mac_address multi-match physical+virtual: physical tiebreak wins",
+			localIDType:     "mac_address",
+			localID:         "aa:bb:cc:dd:ee:01",
+			expectedID:      "default:1.2.3.4:10",
+			expectedOutcome: localIfaceResolutionResolvedPhysicalTiebreak,
+		},
+		// PRD scope item 5c: multi-match with zero physical → unresolved.
+		{
+			name:            "mac_address multi-match all virtual: unresolved_no_physical",
+			localIDType:     "mac_address",
+			localID:         "aa:bb:cc:dd:ee:02",
+			expectedID:      "",
+			expectedOutcome: localIfaceResolutionUnresolvedNoPhysical,
+		},
+		// PRD scope item 5d: multi-match with multiple physical → unresolved.
+		{
+			name:            "mac_address multi-match multiple physical: unresolved_multi_physical",
+			localIDType:     "mac_address",
+			localID:         "aa:bb:cc:dd:ee:03",
+			expectedID:      "",
+			expectedOutcome: localIfaceResolutionUnresolvedMultiPhysical,
+		},
+		// PRD scope item 5e + R2: nil IsPhysical treated as non-physical, so
+		// the only physical candidate wins the tiebreak.
+		{
+			name:            "mac_address multi-match physical+nil-IsPhysical: physical tiebreak wins (nil treated non-physical)",
+			localIDType:     "mac_address",
+			localID:         "aa:bb:cc:dd:ee:04",
+			expectedID:      "default:1.2.3.4:40",
+			expectedOutcome: localIfaceResolutionResolvedPhysicalTiebreak,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expectedID, resolveLocalInterface(deviceID, interfaceIndexByIDType, tt.localIDType, tt.localID))
+			gotID, gotOutcome := resolveLocalInterface(deviceID, interfaceIndexByIDType, interfaceByIndex, tt.localIDType, tt.localID)
+			assert.Equal(t, tt.expectedID, gotID)
+			assert.Equal(t, tt.expectedOutcome, gotOutcome)
 		})
 	}
 }
@@ -1331,7 +1411,7 @@ func Test_buildInterfaceIndexByIDType(t *testing.T) {
 	}
 
 	// Act
-	interfaceIndexByIDType := buildInterfaceIndexByIDType(interfaces)
+	interfaceIndexByIDType, interfaceByIndex := buildInterfaceIndexByIDType(interfaces)
 
 	// Assert
 	expectedInterfaceIndexByIDType := map[string]map[string][]int32{
@@ -1356,6 +1436,63 @@ func Test_buildInterfaceIndexByIDType(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expectedInterfaceIndexByIDType, interfaceIndexByIDType)
+
+	// interfaceByIndex carries the full InterfaceMetadata payload so
+	// resolveLocalInterface can apply the physical-vs-virtual tiebreak.
+	expectedInterfaceByIndex := map[int32]metadata.InterfaceMetadata{
+		1: interfaces[0],
+		2: interfaces[1],
+		3: interfaces[2],
+	}
+	assert.Equal(t, expectedInterfaceByIndex, interfaceByIndex)
+}
+
+// Test_buildNetworkTopologyMetadataWithLLDP_physicalTiebreak is the
+// integration-style test called for in PRD scope item 6 / success criterion #1.
+// It constructs an LLDP fixture where the locally-reported MAC `aa:bb:cc:dd:ee:ff`
+// is shared by ifIndex 1 (ifType 6, ethernetCsmacd → physical) and ifIndex 100
+// (ifType 53, propVirtual → virtual). Before this change, the resolver dropped
+// the local interface entirely; with the physical-tiebreak it picks ifIndex 1
+// and emits a `resolved_physical_tiebreak` telemetry sample.
+func Test_buildNetworkTopologyMetadataWithLLDP_physicalTiebreak(t *testing.T) {
+	truePtr := true
+	falsePtr := false
+	interfaces := []metadata.InterfaceMetadata{
+		{DeviceID: "default:1.2.3.4", Index: 1, MacAddress: "aa:bb:cc:dd:ee:ff", Name: "Gi1/0/1", Type: 6, IsPhysical: &truePtr},
+		{DeviceID: "default:1.2.3.4", Index: 100, MacAddress: "aa:bb:cc:dd:ee:ff", Name: "Vlan100", Type: 53, IsPhysical: &falsePtr},
+	}
+
+	// Build a metadata.Store with one LLDP remote entry whose local-port-num
+	// references the colliding MAC via lldp_local.interface_id_type=3
+	// (mac_address per lldp.PortIDSubTypeMap). The full lldp_remote index is
+	// "<timeMark>.<localPortNum>.<lldpRemIndex>"; using 1.5.7.
+	store := internalmetadata.NewMetadataStore()
+	const remoteIdx = "1.5.7"
+	const localPortNum = "5"
+	store.AddColumnValue("lldp_remote.interface_id", remoteIdx, valuestore.ResultValue{Value: "RemotePort1"})
+	store.AddColumnValue("lldp_remote.interface_id_type", remoteIdx, valuestore.ResultValue{Value: "5"}) // interface_name
+	store.AddColumnValue("lldp_remote.chassis_id", remoteIdx, valuestore.ResultValue{Value: []byte{0xde, 0xad, 0xbe, 0xef, 0x00, 0x01}})
+	store.AddColumnValue("lldp_remote.chassis_id_type", remoteIdx, valuestore.ResultValue{Value: "4"}) // mac_address
+	store.AddColumnValue("lldp_remote.device_name", remoteIdx, valuestore.ResultValue{Value: "peer-sw"})
+	// The local-side identifier is the colliding MAC; idType 3 = mac_address.
+	store.AddColumnValue("lldp_local.interface_id_type", localPortNum, valuestore.ResultValue{Value: "3"})
+	store.AddColumnValue("lldp_local.interface_id", localPortNum, valuestore.ResultValue{Value: []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}})
+
+	sender := mocksender.NewMockSender("testID")
+	sender.On("Count", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	ms := &MetricSender{hostname: "test", sender: sender}
+
+	links := ms.buildNetworkTopologyMetadataWithLLDP("default:1.2.3.4", store, interfaces, []string{"snmp_device:1.2.3.4"})
+
+	require.Len(t, links, 1)
+	// The physical interface (ifIndex 1) wins the tiebreak.
+	assert.Equal(t, "default:1.2.3.4:1", links[0].Local.Interface.DDID)
+	// Telemetry: one Count sample with outcome=resolved_physical_tiebreak.
+	sender.AssertMetric(t, "Count", localInterfaceResolutionMetric, 1, "test", []string{
+		"snmp_device:1.2.3.4",
+		"outcome:" + localIfaceResolutionResolvedPhysicalTiebreak,
+		"id_type:mac_address",
+	})
 }
 
 func Test_metricSender_reportNetworkDeviceMetadata_withInterfaceTypeAndIsPhysical(t *testing.T) {

--- a/releasenotes/notes/snmp-topology-physical-interface-tiebreak-6de27490abcd1234.yaml
+++ b/releasenotes/notes/snmp-topology-physical-interface-tiebreak-6de27490abcd1234.yaml
@@ -1,0 +1,22 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    SNMP topology: when an LLDP-reported local-side identifier (typically a
+    MAC address) matches more than one local interface on the polled device
+    — common when a physical interface shares its MAC with virtual interfaces
+    such as SVIs, sub-interfaces, or port-channel members — the agent now
+    breaks the tie in favor of the physical ethernet interface
+    (IF-MIB ``ifType`` 6, 62, 69, or 117) and emits the topology link with
+    the physical interface's ``interface_id``. Previously the link was
+    reported with no local interface attribution. A new in-agent telemetry
+    metric ``datadog.snmp.topology.local_interface_resolution`` (tags:
+    ``outcome:<resolved_unique|resolved_physical_tiebreak|unresolved_multi_physical|unresolved_no_physical|unresolved_no_match>``
+    and ``id_type:<lldp_id_type|smart>``) records each resolution attempt so
+    the impact of the tiebreak can be measured post-release.


### PR DESCRIPTION
## Summary

When the SNMP integration receives an LLDP-reported local-side identifier (typically a MAC address) that matches more than one local interface on the polled device, the resolver previously logged a trace and emitted the topology link with **no** local-interface attribution. This is a common pattern — physical interfaces share MACs with SVIs, sub-interfaces, and port-channel members on Cisco IOS-XE, NX-OS, and multi-context firewalls (AGENT-15992, II/2778661557, II/6664785860).

This PR adds a physical-vs-virtual tiebreak in `resolveLocalInterface`: when exactly one candidate has `IsPhysical == true` (IF-MIB `ifType` ∈ {6, 62, 69, 117}), the link resolves to that interface. All other cases (0 / ≥2 physical candidates, or `IsPhysical == nil`) preserve the previous unresolved behavior, but now go into distinct telemetry buckets.

### Approach

- Extract the `{6, 62, 69, 117}` physical-ethernet `ifType` set into a single `physicalEthernetIfTypes` lookup, shared between `buildNetworkInterfacesMetadata` and the new tiebreak path so the two consumers cannot drift.
- Plumb a sidecar `map[int32]InterfaceMetadata` from `buildInterfaceIndexByIDType` into `resolveLocalInterface` (signature change), so the bare ifIndex lookup stays intact and the resolver only needs the extra metadata when it actually has to disambiguate.
- On multi-match, partition candidates by `IsPhysical` (nil treated as non-physical per PRD R2) and apply the tiebreak. The unresolved branch is split into `unresolved_no_physical` vs `unresolved_multi_physical` for sizing.
- Promote `buildNetworkTopologyMetadata{,WithLLDP}` to `*MetricSender` methods so a new `emitLocalInterfaceResolutionMetric` helper can submit one `Count` sample per resolution attempt — `datadog.snmp.topology.local_interface_resolution`, tagged `outcome:<bucket>` + `id_type:<lldp_subtype|smart>`.

### Verification

QA checks (this PR):

- ✅ `go build ./pkg/snmp/... ./pkg/collector/corechecks/snmp/...` — clean
- ✅ `go vet -tags=test ./pkg/snmp/... ./pkg/collector/corechecks/snmp/...` — clean
- ✅ `go test -tags=test ./pkg/snmp/... ./pkg/collector/corechecks/snmp/...` — all packages pass
- ✅ `golangci-lint run --build-tags=test ./pkg/collector/corechecks/snmp/...` — 0 issues
- ✅ Coverage: all PRD failure modes covered — single match, multi-match with 1 physical (5b), 0 physical (5c), ≥2 physical (5d), nil `IsPhysical` (5e), plus the integration-style `Test_buildNetworkTopologyMetadataWithLLDP_physicalTiebreak` for the colliding-MAC fixture (scope item 6).

Reviewer action items:

- [ ] Sanity-check the chosen outcome bucket names (they ship as metric tag values and are hard to change later).
- [ ] Confirm whether the tiebreak should be limited to `mac_address` or apply to all idTypes (it applies to all, per the spec's resolution of PRD open question #2; revisit if there is a known idType where the tiebreak is wrong).
- [ ] Confirm we do not want a `snmp.topology.physical_interface_tiebreak` config gate for the first release (PRD open question #1; the spec deliberately leans on the new telemetry instead).

---

Drafted by the agent-orchestrator pipeline.
