### PR TITLE
packaging/aix: add ibm_db clidriver path to agent wrapper LIBPATH

### DIFF
--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -11,6 +11,7 @@
 <!-- Add entries here for changes not yet in a release. -->
 
 - Agent and trace-agent wrappers now append the caller's `LIBPATH` to the agent's own library search path, so operator-set paths (e.g. custom driver directories) are visible to the agent at runtime
+- Agent and trace-agent wrappers include the `ibm_db` clidriver path (`embedded/lib/python3.13/site-packages/clidriver/lib`) in LIBPATH so the `ibm_db2` check can load `libdb2` at runtime after `pip install ibm_db`
 - Bundle `pymqi` in the package so the `ibm_mq` and `ibm_ace` checks work out of the box (no manual `pip install` required); IBM MQ Client 9.1+ must be installed on the target host at runtime
 - Go checks: bundle `conf.yaml.example` and `conf.yaml.default` from integrations-core for all Go checks that have them, supplementing the agent-repo config (agent-repo takes precedence on filename conflicts)
 - Keep Python headers (`embedded/include/`) in the package so users can build C extension packages (e.g. `ibm_db` for the DB2 check) against the embedded Python, matching Linux/macOS omnibus behaviour

--- a/packaging/aix/agent-wrapper.sh
+++ b/packaging/aix/agent-wrapper.sh
@@ -5,6 +5,6 @@
 # The agent binary's loader section has the build-host staging path baked in
 # (a Go/ld limitation on AIX); this wrapper sets the correct installed paths
 # so the binary works when invoked directly, not just via SRC.
-export LIBPATH=/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/mqm/lib64:/opt/mqm/lib:/usr/mqm/lib64:/usr/mqm/lib:/opt/ibm/db2/clidriver/lib:/opt/freeware/lib64:/opt/freeware/lib${LIBPATH:+:$LIBPATH}
+export LIBPATH=/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/mqm/lib64:/opt/mqm/lib:/usr/mqm/lib64:/usr/mqm/lib:/opt/ibm/db2/clidriver/lib:/opt/datadog-agent/embedded/lib/python3.13/site-packages/clidriver/lib:/opt/freeware/lib64:/opt/freeware/lib${LIBPATH:+:$LIBPATH}
 export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:"${PATH}"
 exec /opt/datadog-agent/bin/agent/agent-bin "$@"

--- a/packaging/aix/trace-agent-wrapper.sh
+++ b/packaging/aix/trace-agent-wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-export LIBPATH=/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/mqm/lib64:/opt/mqm/lib:/usr/mqm/lib64:/usr/mqm/lib:/opt/ibm/db2/clidriver/lib:/opt/freeware/lib64:/opt/freeware/lib${LIBPATH:+:$LIBPATH}
+export LIBPATH=/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/mqm/lib64:/opt/mqm/lib:/usr/mqm/lib64:/usr/mqm/lib:/opt/ibm/db2/clidriver/lib:/opt/datadog-agent/embedded/lib/python3.13/site-packages/clidriver/lib:/opt/freeware/lib64:/opt/freeware/lib${LIBPATH:+:$LIBPATH}
 export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:"${PATH}"
 exec /opt/datadog-agent/embedded/bin/trace-agent-bin "$@"


### PR DESCRIPTION
### What does this PR do?

Adds `/opt/datadog-agent/embedded/lib/python3.13/site-packages/clidriver/lib` to the `LIBPATH` export in both `agent-wrapper.sh` and `trace-agent-wrapper.sh`.

### Motivation

When a customer installs `ibm_db` via the embedded pip (`pip install ibm_db`), the IBM DB2 CLI driver is placed at `embedded/lib/python3.13/site-packages/clidriver/lib/`. The `ibm_db2` check loads `libdb2.a(shr_64.o)` from that path at runtime, but the path is not in the agent wrapper's LIBPATH, causing an ImportError when the check runs.

Adding the path fixes this. AIX silently ignores non-existent LIBPATH entries, so the entry is a no-op when `ibm_db` has not been installed.

### Describe how you validated your changes

Validated as part of the ibm_db2 check testing on AIX 7.2 and 7.3.

### Additional Notes

The path is Python-version-specific (`python3.13`). It will need to be updated when the embedded Python version is bumped.