### PR TITLE
SBOM e2e: scan host and container images across runtimes

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -670,6 +670,9 @@ new-e2e-sbom:
   parallel:
     matrix:
       - EXTRA_PARAMS: --run "TestSBOMKindSuite"
+      - EXTRA_PARAMS: --run "TestSBOMKubeadmSuite"
+      - EXTRA_PARAMS: --run "TestSBOMKubeadmCrioSuite"
+      - EXTRA_PARAMS: --run "TestSBOMDockerHostSuite"
 
 new-e2e-usm:
   extends: .new_e2e_template

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -585,6 +585,7 @@ exports_files(glob(
 # gazelle:exclude test/e2e-framework/scenarios/aws/gensim-eks
 # gazelle:exclude test/e2e-framework/scenarios/aws/installer
 # gazelle:exclude test/e2e-framework/scenarios/aws/kindvm
+# gazelle:exclude test/e2e-framework/scenarios/aws/kubeadm
 # gazelle:exclude test/e2e-framework/scenarios/aws/microVMs/config
 # gazelle:exclude test/e2e-framework/scenarios/aws/microVMs/microvms/files
 # gazelle:exclude test/e2e-framework/scenarios/aws/test

--- a/test/e2e-framework/AGENTS.md
+++ b/test/e2e-framework/AGENTS.md
@@ -16,13 +16,13 @@ test/e2e-framework/
 │   ├── e2e/              # Test harness: BaseSuite, Run(), SuiteOption
 │   ├── environments/     # Environment types: Host, DockerHost, Kubernetes, ECS
 │   ├── provisioners/     # Provisioner interfaces + cloud-specific implementations
-│   │   ├── aws/          # host, docker, ecs, kubernetes (eks, kindvm)
+│   │   ├── aws/          # host, docker, ecs, kubernetes (eks, kindvm, kubeadm)
 │   │   ├── azure/        # host (linux, windows), kubernetes (aks)
 │   │   ├── gcp/          # host (linux), kubernetes (gke, openshiftvm)
 │   │   └── local/        # host (podman), kubernetes (kind)
 │   └── components/       # Test-side wrappers: RemoteHost, Agent, FakeIntake
 ├── scenarios/
-│   └── aws/              # Pulumi programs: ec2, ec2docker, ecs, eks, kindvm
+│   └── aws/              # Pulumi programs: ec2, ec2docker, ecs, eks, kindvm, kubeadm
 ├── components/
 │   ├── datadog/          # Pulumi components: agent, agentparams, fakeintake
 │   │   ├── agentparams/  # Agent configuration options (WithAgentConfig, etc.)

--- a/test/e2e-framework/components/datadog/agent/docker.go
+++ b/test/e2e-framework/components/datadog/agent/docker.go
@@ -69,7 +69,7 @@ func NewDockerAgent(e config.Env, vm *remoteComp.Host, manager *docker.Manager, 
 		}
 
 		// We can have multiple compose files in compose.
-		composeContents := []docker.ComposeInlineManifest{dockerAgentComposeManifest(fullImagePath, e.AgentAPIKey(), params.AgentServiceEnvironment)}
+		composeContents := []docker.ComposeInlineManifest{dockerAgentComposeManifest(fullImagePath, e.AgentAPIKey(), params.AgentServiceEnvironment, params.ExtraAgentVolumes)}
 		composeContents = append(composeContents, params.ExtraComposeManifests...)
 
 		opts := make([]pulumi.ResourceOption, 0, len(params.PulumiDependsOn)+1)
@@ -89,7 +89,7 @@ func NewDockerAgent(e config.Env, vm *remoteComp.Host, manager *docker.Manager, 
 	})
 }
 
-func dockerAgentComposeManifest(agentImagePath string, apiKey pulumi.StringInput, envVars pulumi.Map) docker.ComposeInlineManifest {
+func dockerAgentComposeManifest(agentImagePath string, apiKey pulumi.StringInput, envVars pulumi.Map, extraVolumes []string) docker.ComposeInlineManifest {
 	runInPrivileged := false
 	for k := range envVars {
 		if strings.HasPrefix(k, "DD_SYSTEM_PROBE_") {
@@ -108,13 +108,13 @@ func dockerAgentComposeManifest(agentImagePath string, apiKey pulumi.StringInput
 					Privileged:    runInPrivileged,
 					Image:         agentImagePath,
 					ContainerName: agentContainerName,
-					Volumes: []string{
+					Volumes: append([]string{
 						"/var/run/docker.sock:/var/run/docker.sock",
 						"/proc/:/host/proc",
 						"/sys/fs/cgroup/:/host/sys/fs/cgroup",
 						"/var/run/datadog:/var/run/datadog",
 						"/sys/kernel/tracing:/sys/kernel/tracing",
-					},
+					}, extraVolumes...),
 					Environment: map[string]any{
 						"DD_API_KEY": apiKeyResolved,
 						// DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED is compatible with Agent 7.35+

--- a/test/e2e-framework/components/datadog/apps/sbomtargets/docker.go
+++ b/test/e2e-framework/components/datadog/apps/sbomtargets/docker.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package sbomtargets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/docker"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// DockerComposeManifest runs every SBOM target image as a long-lived Docker
+// container so each image stays resident in the Docker daemon (and is marked
+// InUse) for the Agent to scan. It is the standalone-Docker counterpart of
+// K8sAppDefinition and uses the same Targets, so the SBOMs are identical.
+//
+// `tail -f /dev/null` (not `sleep infinity`) is used as the entrypoint because
+// it keeps the container alive on every target including the busybox-based
+// golang:alpine image, where `sleep infinity` is unsupported.
+func DockerComposeManifest() docker.ComposeInlineManifest {
+	var sb strings.Builder
+	sb.WriteString("version: \"3.9\"\nservices:\n")
+	for _, t := range Targets {
+		fmt.Fprintf(&sb, "  %s:\n", t.Name)
+		fmt.Fprintf(&sb, "    image: %s\n", t.Image)
+		fmt.Fprintf(&sb, "    container_name: %s\n", t.Name)
+		sb.WriteString("    entrypoint: [\"tail\", \"-f\", \"/dev/null\"]\n")
+		sb.WriteString("    restart: unless-stopped\n")
+	}
+	return docker.ComposeInlineManifest{
+		Name:    "sbom-targets",
+		Content: pulumi.String(sb.String()),
+	}
+}

--- a/test/e2e-framework/components/datadog/apps/sbomtargets/k8s.go
+++ b/test/e2e-framework/components/datadog/apps/sbomtargets/k8s.go
@@ -1,0 +1,135 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package sbomtargets deploys container images used as targets for SBOM scanning.
+package sbomtargets
+
+import (
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
+	componentskube "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// Namespace is where the SBOM target workloads are deployed.
+const Namespace = "sbom-workloads"
+
+// Target is an SBOM scanning target image.
+type Target struct {
+	// Name is the workload (deployment) name.
+	Name string
+	// Image is the pinned container image reference.
+	Image string
+	// ShortImage is the image name without registry/tag, used by tests to match SBOM payloads.
+	ShortImage string
+}
+
+// Targets are the images scanned for SBOMs. Each is pinned by tag AND digest
+// (repo:tag@sha256:...) so every run scans byte-identical image content, which
+// keeps the component set (and therefore the counts) deterministic, while the
+// tag still yields a RepoTag/image_tag in the SBOM. The pinned digest is the
+// same one the test asserts as the expected RepoDigest; the test also
+// cross-checks the resolved ImageID and DiffIDs, so any registry drift surfaces
+// as a failure. They cover distinct package ecosystems:
+//
+//	node          - Debian (dpkg) + npm
+//	golang-alpine - Alpine (apk, musl) + Go
+//	ubi9          - RHEL (rpm), single-layer image
+//	ubi9/python   - RHEL (rpm) + pip (pypi), multi-layer image
+//	python        - Debian (dpkg) + pip (pypi)
+//	ruby          - Debian (dpkg) + gem (rubygems)
+var Targets = []Target{
+	{Name: "sbom-node", Image: "node:26.2.0@sha256:980c5420a7a2ddcb44037726977f2a349e5c7b64217516c7488dce4c74d71583", ShortImage: "node"},
+	{Name: "sbom-golang", Image: "golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d", ShortImage: "golang"},
+	{Name: "sbom-ubi9", Image: "registry.access.redhat.com/ubi9/ubi:9.8-1780376557@sha256:80b1f4c34a7eed1b03a05d12b55768f3e522eef6ec294c6fbd5fa47b6b2892ee", ShortImage: "ubi"},                     // RHEL rpm, single-layer
+	{Name: "sbom-ubi-python", Image: "registry.access.redhat.com/ubi9/python-312:9.8-1779945122@sha256:52d1ffcda3b9552934f947b7d41fb0cb66973bdc0d7e91814facadc126f68663", ShortImage: "python-312"}, // RHEL rpm + pypi, multi-layer
+	{Name: "sbom-python", Image: "python:3.14.5@sha256:250e5c97be05e1eb2272fbdbd810dfd638f9012e1e6f65c99390ad3239943a08", ShortImage: "python"},
+	{Name: "sbom-ruby", Image: "ruby:3.3.4-bookworm@sha256:d4233f4242ea25346f157709bb8417c615e7478468e2699c8e86a4e1f0156de8", ShortImage: "ruby"},
+}
+
+// K8sAppDefinition deploys one Deployment per SBOM target. Each container is kept
+// alive with `tail -f /dev/null` so its image stays resident in the host
+// containerd for the Agent to scan. `sleep infinity` is not used because the
+// busybox sleep in the golang:alpine target rejects it and crash loops the pod.
+func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
+
+	k8sComponent := &componentskube.Workload{}
+	if err := e.Ctx().RegisterComponentResource("dd:apps", "sbom-targets", k8sComponent, opts...); err != nil {
+		return nil, err
+	}
+	opts = append(opts, pulumi.Parent(k8sComponent))
+
+	ns, err := corev1.NewNamespace(e.Ctx(), Namespace, &corev1.NamespaceArgs{
+		Metadata: metav1.ObjectMetaArgs{
+			Name: pulumi.String(Namespace),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, utils.PulumiDependsOn(ns))
+
+	var imagePullSecrets corev1.LocalObjectReferenceArray
+	if e.ImagePullRegistry() != "" {
+		imgPullSecret, err := utils.NewImagePullSecret(e, Namespace, opts...)
+		if err != nil {
+			return nil, err
+		}
+		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReferenceArgs{
+			Name: imgPullSecret.Metadata.Name(),
+		})
+	}
+
+	for _, t := range Targets {
+		if _, err := appsv1.NewDeployment(e.Ctx(), t.Name, &appsv1.DeploymentArgs{
+			Metadata: &metav1.ObjectMetaArgs{
+				Name:      pulumi.String(t.Name),
+				Namespace: pulumi.String(Namespace),
+				Labels:    pulumi.StringMap{"app": pulumi.String(t.Name)},
+			},
+			Spec: &appsv1.DeploymentSpecArgs{
+				Replicas: pulumi.Int(1),
+				Selector: &metav1.LabelSelectorArgs{
+					MatchLabels: pulumi.StringMap{"app": pulumi.String(t.Name)},
+				},
+				Template: &corev1.PodTemplateSpecArgs{
+					Metadata: &metav1.ObjectMetaArgs{
+						Labels: pulumi.StringMap{"app": pulumi.String(t.Name)},
+					},
+					Spec: &corev1.PodSpecArgs{
+						ImagePullSecrets: imagePullSecrets,
+						Containers: corev1.ContainerArray{
+							&corev1.ContainerArgs{
+								Name:    pulumi.String("main"),
+								Image:   pulumi.String(t.Image),
+								Command: pulumi.StringArray{pulumi.String("tail"), pulumi.String("-f"), pulumi.String("/dev/null")},
+								Resources: &corev1.ResourceRequirementsArgs{
+									Limits: pulumi.StringMap{
+										"cpu":    pulumi.String("100m"),
+										"memory": pulumi.String("64Mi"),
+									},
+									Requests: pulumi.StringMap{
+										"cpu":    pulumi.String("10m"),
+										"memory": pulumi.String("32Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, opts...); err != nil {
+			return nil, err
+		}
+	}
+
+	return k8sComponent, nil
+}

--- a/test/e2e-framework/components/datadog/dockeragentparams/params.go
+++ b/test/e2e-framework/components/datadog/dockeragentparams/params.go
@@ -54,6 +54,8 @@ type Params struct {
 	AgentServiceEnvironment pulumi.Map
 	// ExtraComposeManifests is a list of extra docker compose manifests to add beside the agent service.
 	ExtraComposeManifests []docker.ComposeInlineManifest
+	// ExtraAgentVolumes are extra bind-mount volumes (host:container[:opts]) added to the agent service.
+	ExtraAgentVolumes []string
 	// EnvironmentVariables is a map of environment variables to set with the docker-compose context
 	EnvironmentVariables pulumi.StringMap
 	// PulumiDependsOn is a list of resources to depend on.
@@ -153,6 +155,14 @@ func WithAgentServiceEnvVariable(key string, value pulumi.Input) func(*Params) e
 	}
 }
 
+// WithExtraVolumes adds extra bind-mount volumes (host:container[:opts]) to the agent container.
+func WithExtraVolumes(volumes ...string) func(*Params) error {
+	return func(p *Params) error {
+		p.ExtraAgentVolumes = append(p.ExtraAgentVolumes, volumes...)
+		return nil
+	}
+}
+
 // WithIntake configures the agent to use the given url as intake.
 // The url must be a valid Datadog intake, with a SSL valid certificate
 //
@@ -210,6 +220,10 @@ func withIntakeHostname(url pulumi.StringInput, shouldSkipSSLValidation pulumi.B
 			"DD_LOGS_CONFIG_LOGS_DD_URL":                 pulumi.Sprintf("%s", url),
 			"DD_LOGS_CONFIG_LOGS_NO_SSL":                 shouldSkipSSLValidation,
 			"DD_SERVICE_DISCOVERY_FORWARDER_LOGS_DD_URL": pulumi.Sprintf("%s", url),
+			// Host and container image SBOMs ship through the event platform
+			// forwarder; redirect those endpoints to the fakeintake as well.
+			"DD_SBOM_DD_URL":            pulumi.Sprintf("%s", url),
+			"DD_CONTAINER_IMAGE_DD_URL": pulumi.Sprintf("%s", url),
 		}
 		for key, value := range envVars {
 			if err := WithAgentServiceEnvVariable(key, value)(p); err != nil {

--- a/test/e2e-framework/components/docker/component.go
+++ b/test/e2e-framework/components/docker/component.go
@@ -182,15 +182,56 @@ func (d *Manager) ComposeStrUp(name string, composeManifests []ComposeInlineMani
 func (d *Manager) install() (command.Command, error) {
 	opts := []pulumi.ResourceOption{pulumi.Parent(d)}
 	opts = utils.MergeOptions(d.opts, opts...)
+
+	// Red Hat family flavors have no distro "docker" package, so install Docker CE
+	// from Docker's repo first; the generic Ensure below then no-ops (command -v
+	// docker succeeds). Debian/Ubuntu keep installing docker.io via Ensure. The el9
+	// repo is reused because RHEL 10 ($releasever=10) is not served by Docker yet.
+	switch d.Host.OS.Descriptor().Flavor {
+	case os.RedHat, os.CentOS, os.RockyLinux:
+		dockerCEInstall, err := d.Host.OS.Runner().Command(d.namer.ResourceName("docker-ce-install"), &command.Args{
+			Sudo: true,
+			Create: pulumi.String(`bash <<'EOF'
+set -euxo pipefail
+# Single-node e2e box: relax SELinux and firewalld (mirrors the kubeadm box) so
+# the agent container can read host bind mounts without extra rules.
+setenforce 0 || true
+sed -i 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config || true
+systemctl disable --now firewalld || true
+curl -fsSL https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo
+sed -i 's/\$releasever/9/g' /etc/yum.repos.d/docker-ce.repo
+dnf install -y docker-ce docker-ce-cli containerd.io
+# RHEL 10 dropped the legacy iptables kernel module, so docker 29 must use its
+# nftables firewall backend or the daemon cannot program bridge NAT. Set it
+# before the first start (the full daemon.json follows); surface logs on failure.
+mkdir -p /etc/docker && printf '{"firewall-backend": "nftables", "storage-driver": "overlay2"}' > /etc/docker/daemon.json
+# docker needs IPv4 forwarding to create its default bridge network.
+echo 'net.ipv4.ip_forward=1' > /etc/sysctl.d/99-docker.conf && sysctl -w net.ipv4.ip_forward=1
+systemctl enable --now docker || { journalctl -xeu docker.service --no-pager | tail -80; exit 1; }
+EOF`),
+		}, opts...)
+		if err != nil {
+			return nil, err
+		}
+		opts = utils.MergeOptions(opts, utils.PulumiDependsOn(dockerCEInstall))
+	}
+
 	dockerInstall, err := d.Host.OS.PackageManager().Ensure("docker", nil, "docker", os.WithPulumiResourceOptions(opts...))
 	if err != nil {
 		return nil, err
 	}
 
-	// Patch ip range that docker uses to create its bridge networks
-	// This is to avoid conflicts with other IP ranges used internally
+	// Patch the daemon config: pin overlay2 + a mirror and move docker off the
+	// default bridge IP range to avoid conflicts with other internal ranges.
+	// Red Hat 10 dropped the legacy iptables kernel module, so docker 29 needs
+	// its nftables firewall backend or the daemon cannot program bridge NAT.
+	daemonOpts := `"storage-driver": "overlay2", "registry-mirrors": ["https://mirror.gcr.io"], "bip": "192.168.16.1/24", "default-address-pools":[{"base":"192.168.32.0/24", "size":24}], "max-download-attempts": 10`
+	switch d.Host.OS.Descriptor().Flavor {
+	case os.RedHat, os.CentOS, os.RockyLinux:
+		daemonOpts += `, "firewall-backend": "nftables"`
+	}
 	daemonPatch, err := d.Host.OS.Runner().Command(d.namer.ResourceName("daemon-patch"), &command.Args{
-		Create: pulumi.Sprintf("sudo mkdir -p /etc/docker && echo '{\"bip\": \"192.168.16.1/24\", \"default-address-pools\":[{\"base\":\"192.168.32.0/24\", \"size\":24}], \"max-download-attempts\": 10}' | sudo tee /etc/docker/daemon.json"),
+		Create: pulumi.Sprintf("sudo mkdir -p /etc/docker && echo '{%s}' | sudo tee /etc/docker/daemon.json", daemonOpts),
 		Sudo:   true,
 	}, utils.MergeOptions(opts, utils.PulumiDependsOn(dockerInstall))...)
 	if err != nil {
@@ -231,7 +272,7 @@ func (d *Manager) install() (command.Command, error) {
 
 func (d *Manager) installCompose() (command.Command, error) {
 	opts := append(d.opts, pulumi.Parent(d))
-	installCompose := pulumi.Sprintf("bash -c '(docker-compose version | grep %s) || (curl --retry 10 -fsSLo /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/%s/docker-compose-linux-$(uname -p) && sudo chmod 755 /usr/local/bin/docker-compose)'", composeVersion, composeVersion)
+	installCompose := pulumi.Sprintf("bash -c '(docker-compose version | grep %s) || (curl --retry 10 -fsSLo /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/%s/docker-compose-linux-$(uname -m) && sudo chmod 755 /usr/local/bin/docker-compose)'", composeVersion, composeVersion)
 	return d.Host.OS.Runner().Command(
 		d.namer.ResourceName("install-compose"),
 		&command.Args{

--- a/test/e2e-framework/components/docker/ecr.go
+++ b/test/e2e-framework/components/docker/ecr.go
@@ -6,6 +6,8 @@
 package docker
 
 import (
+	"fmt"
+
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/namer"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/command"
@@ -15,11 +17,18 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+// ecrCredentialHelperVersion pins the docker-credential-ecr-login release
+// installed on Red Hat family distros. Bump it manually (or via Renovate):
+// resolving the "latest" release from GitHub at provision time was a source of
+// flakiness. Keep it in sync with the pin in
+// test/new-e2e/tests/installer/host/host.go.
+const ecrCredentialHelperVersion = "0.12.0"
+
 // InstallECRCredentialsHelper installs the Amazon ECR credential helper and jq on the host,
 // then merges credsStore=ecr-login into ~/.docker/config.json (preserving existing keys).
 // This enables automatic authentication against ECR registries (including pull-through caches).
 func InstallECRCredentialsHelper(n namer.Namer, host *remoteComp.Host, opts ...pulumi.ResourceOption) (command.Command, error) {
-	ecrCredsHelperInstall, err := host.OS.PackageManager().Ensure("amazon-ecr-credential-helper", nil, "docker-credential-ecr-login", os.WithPulumiResourceOptions(opts...))
+	ecrCredsHelperInstall, err := ensureECRCredentialHelper(n, host, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -48,4 +57,31 @@ func InstallECRCredentialsHelper(n namer.Namer, host *remoteComp.Host, opts ...p
 	}
 
 	return ecrConfigCommand, nil
+}
+
+// ensureECRCredentialHelper installs the docker-credential-ecr-login binary.
+// Red Hat family distributions have no package for it, so the pinned static
+// release binary is fetched directly; other distributions install it through
+// their package manager.
+func ensureECRCredentialHelper(n namer.Namer, host *remoteComp.Host, opts ...pulumi.ResourceOption) (command.Command, error) {
+	switch host.OS.Descriptor().Flavor {
+	case os.RedHat, os.CentOS, os.RockyLinux:
+		// sudo cannot run a bare "if" compound, so feed the script to bash on
+		// stdin (sudo bash <<EOF), matching the kubeadm provisioner's rootScript.
+		install := fmt.Sprintf(`bash <<'EOF'
+set -euo pipefail
+if ! command -v docker-credential-ecr-login; then
+  a=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+  curl -fsSL -o /usr/local/bin/docker-credential-ecr-login "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/%s/linux-${a}/docker-credential-ecr-login"
+  chmod 0755 /usr/local/bin/docker-credential-ecr-login
+fi
+EOF`, ecrCredentialHelperVersion)
+		return host.OS.Runner().Command(
+			n.ResourceName("ecr-credential-helper"),
+			&command.Args{Create: pulumi.String(install), Sudo: true},
+			opts...,
+		)
+	default:
+		return host.OS.PackageManager().Ensure("amazon-ecr-credential-helper", nil, "docker-credential-ecr-login", os.WithPulumiResourceOptions(opts...))
+	}
 }

--- a/test/e2e-framework/components/kubernetes/kubeadm.go
+++ b/test/e2e-framework/components/kubernetes/kubeadm.go
@@ -1,0 +1,262 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package kubernetes
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/command"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/remote"
+)
+
+// containerd ships in the docker-ce repository. RHEL 10 ($releasever=10) is not
+// served yet, so we pin the repo to el9 - the el9 containerd.io binary runs
+// unchanged on RHEL 10 and avoids depending on a release that may be missing.
+const kubeadmContainerdRepoReleasever = "9"
+
+// ContainerRuntime selects the CRI installed on the kubeadm node. The Agent
+// produces identical SBOMs across runtimes; only the install steps and the CRI
+// socket differ.
+type ContainerRuntime int
+
+const (
+	// Containerd installs containerd as the container runtime (the default).
+	Containerd ContainerRuntime = iota
+	// CRIO installs CRI-O as the container runtime.
+	CRIO
+)
+
+// rootScript wraps a multi-line script so the whole thing runs as root. The
+// command runner only prepends "sudo " to the command (see unixOSCommand), which
+// for a bare multi-line script would elevate just the first line; feeding the
+// script to `sudo bash` via a heredoc runs every line as root instead.
+func rootScript(script string) pulumi.StringInput {
+	return pulumi.String("bash <<'KUBEADM_EOF'\nset -euxo pipefail\n" + script + "\nKUBEADM_EOF")
+}
+
+// NewKubeadmCluster brings up a single-node Kubernetes cluster directly on vm
+// (a real host, not a nested container) using kubeadm with the selected
+// container runtime (containerd or CRI-O). Because the node is the host, an
+// Agent DaemonSet scheduled on it sees the real host filesystem and the host CRI
+// socket - which is what lets it produce a host SBOM of the VM's OS and
+// container-image SBOMs of the workloads.
+//
+// It mirrors NewOpenShiftCluster: an ordered chain of remote commands provisions
+// the cluster, then the admin kubeconfig is captured and rewritten to reach the
+// API server at the VM address (kubeadm binds 0.0.0.0:6443, so no port forward
+// is needed).
+func NewKubeadmCluster(env config.Env, vm *remote.Host, name string, kubeVersion string, runtime ContainerRuntime, opts ...pulumi.ResourceOption) (*Cluster, error) {
+	return components.NewComponent(env, name, func(clusterComp *Cluster) error {
+		clusterName := env.CommonNamer().DisplayName(49)
+		opts = utils.MergeOptions[pulumi.ResourceOption](opts, pulumi.Parent(clusterComp))
+		runner := vm.OS.Runner()
+		namer := env.CommonNamer()
+
+		// pkgs.k8s.io repositories are keyed by minor version (e.g. "v1.34").
+		parsed := strings.TrimPrefix(utils.ParseKubernetesVersion(kubeVersion), "v")
+		minor := parsed
+		if parts := strings.SplitN(parsed, ".", 3); len(parts) >= 2 {
+			minor = parts[0] + "." + parts[1]
+		}
+
+		prereqs, err := runner.Command(namer.ResourceName("kubeadm-prereqs"), &command.Args{
+			Sudo: true,
+			Create: rootScript(`cloud-init status --wait || true
+# kubeadm/kubelet require swap off, bridged traffic visible to iptables, and IP forwarding.
+swapoff -a
+sed -ri 's/^([^#].*[[:space:]]swap[[:space:]])/#\1/' /etc/fstab || true
+# Single-node e2e box: relax SELinux and firewalld rather than enumerate every port.
+setenforce 0 || true
+sed -i 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config || true
+systemctl disable --now firewalld || true
+# NetworkManager otherwise hijacks the CNI (flannel) interfaces on RHEL and breaks pod networking.
+mkdir -p /etc/NetworkManager/conf.d
+cat >/etc/NetworkManager/conf.d/k8s-cni.conf <<'EOF'
+[keyfile]
+unmanaged-devices=interface-name:cni0;interface-name:flannel*;interface-name:veth*
+EOF
+systemctl reload NetworkManager || true
+cat >/etc/modules-load.d/k8s.conf <<'EOF'
+overlay
+br_netfilter
+EOF
+modprobe overlay
+# br_netfilter lives in kernel-modules-extra on RHEL 10, which is absent for the running
+# kernel on the minimal image; install it (and kernel-modules) for the exact running kernel.
+modprobe br_netfilter || { dnf install -y "kernel-modules-extra-$(uname -r)" "kernel-modules-$(uname -r)" || true; depmod -a || true; modprobe br_netfilter; }
+cat >/etc/sysctl.d/99-kubernetes.conf <<'EOF'
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF
+sysctl --system || true`),
+		}, opts...)
+		if err != nil {
+			return err
+		}
+
+		// The container-runtime install is the only runtime-specific step;
+		// everything downstream (kubelet/kubeadm/kubectl, flannel, readiness) and
+		// the SBOM the Agent produces are runtime-agnostic. criSocket is reused by
+		// the kubeadm init below.
+		criSocket := "unix:///run/containerd/containerd.sock"
+		runtimeName := "kubeadm-containerd"
+		runtimeScript := fmt.Sprintf(`curl -fsSL https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo
+sed -i 's/\$releasever/%s/g' /etc/yum.repos.d/docker-ce.repo
+dnf install -y containerd.io
+mkdir -p /etc/containerd
+containerd config default >/etc/containerd/config.toml
+# kubelet uses the systemd cgroup driver; containerd must match or the node never goes Ready.
+sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+# Route docker.io pulls through mirror.gcr.io to avoid Docker Hub anonymous rate limits (429).
+# containerd 2.x writes a version-3 config that single-quotes the value (config_path = ''),
+# while 1.x double-quotes it; match either quote form so the certs.d mirror is actually enabled.
+sed -i -E 's#^([[:space:]]*config_path[[:space:]]*=[[:space:]]*).*#\1"/etc/containerd/certs.d"#' /etc/containerd/config.toml
+mkdir -p /etc/containerd/certs.d/docker.io
+cat >/etc/containerd/certs.d/docker.io/hosts.toml <<'HOSTS'
+server = "https://docker.io"
+[host."https://mirror.gcr.io"]
+  capabilities = ["pull", "resolve"]
+[host."https://registry-1.docker.io"]
+  capabilities = ["pull", "resolve"]
+[host."https://docker.io"]
+  capabilities = ["pull", "resolve"]
+HOSTS
+systemctl enable --now containerd
+systemctl restart containerd`, kubeadmContainerdRepoReleasever)
+		if runtime == CRIO {
+			criSocket = "unix:///var/run/crio/crio.sock"
+			runtimeName = "kubeadm-crio"
+			// CRI-O ships in pkgs.k8s.io under addons:/cri-o. Its stable streams can
+			// lag the Kubernetes core repo (a new k8s minor may have no matching
+			// CRI-O stream yet), so probe down from the kubelet minor and use the
+			// newest stream that exists. The repo is $basearch (no $releasever), so
+			// one repo serves RHEL 9 and 10, and CRI-O defaults to the systemd
+			// cgroup driver, matching the kubelet.
+			runtimeScript = fmt.Sprintf(`kmaj=$(echo %[1]s | cut -d. -f1); kmin=$(echo %[1]s | cut -d. -f2)
+crio_ver=""
+for d in 0 1 2 3 4; do
+  cand="v${kmaj}.$((kmin-d))"
+  if curl -fsSL -o /dev/null "https://pkgs.k8s.io/addons:/cri-o:/stable:/${cand}/rpm/repodata/repomd.xml"; then crio_ver="$cand"; break; fi
+done
+test -n "$crio_ver" || { echo "no CRI-O stable stream available at or below v%[1]s"; exit 1; }
+cat >/etc/yum.repos.d/cri-o.repo <<EOF
+[cri-o]
+name=CRI-O
+baseurl=https://pkgs.k8s.io/addons:/cri-o:/stable:/${crio_ver}/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/addons:/cri-o:/stable:/${crio_ver}/rpm/repodata/repomd.xml.key
+EOF
+dnf install -y cri-o container-selinux
+# Route docker.io pulls through mirror.gcr.io to avoid Docker Hub anonymous rate limits (429).
+mkdir -p /etc/containers/registries.conf.d
+cat >/etc/containers/registries.conf.d/000-docker-mirror.conf <<'EOF'
+[[registry]]
+prefix = "docker.io"
+location = "docker.io"
+[[registry.mirror]]
+location = "mirror.gcr.io"
+EOF
+# Drop CRI-O's packaged CNI bridge so flannel owns pod networking (the containerd path has none).
+rm -f /etc/cni/net.d/*crio* || true
+systemctl enable --now crio`, minor)
+		}
+
+		runtimeInstall, err := runner.Command(namer.ResourceName(runtimeName), &command.Args{
+			Sudo:   true,
+			Create: rootScript(runtimeScript),
+		}, utils.MergeOptions(opts, utils.PulumiDependsOn(prereqs))...)
+		if err != nil {
+			return err
+		}
+
+		tools, err := runner.Command(namer.ResourceName("kubeadm-tools"), &command.Args{
+			Sudo: true,
+			Create: rootScript(fmt.Sprintf(`cat >/etc/yum.repos.d/kubernetes.repo <<'EOF'
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v%[1]s/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v%[1]s/rpm/repodata/repomd.xml.key
+exclude=kubelet kubeadm kubectl cri-tools
+EOF
+dnf install -y kubelet kubeadm kubectl cri-tools --disableexcludes=kubernetes
+systemctl enable --now kubelet`, minor)),
+		}, utils.MergeOptions(opts, utils.PulumiDependsOn(runtimeInstall))...)
+		if err != nil {
+			return err
+		}
+
+		initCluster, err := runner.Command(namer.ResourceName("kubeadm-init"), &command.Args{
+			Sudo: true,
+			Create: rootScript(fmt.Sprintf(`PRIVATE_IP="$(hostname -I | awk '{print $1}')"
+kubeadm init \
+  --pod-network-cidr=10.244.0.0/16 \
+  --cri-socket=%s \
+  --apiserver-advertise-address="${PRIVATE_IP}" \
+  --apiserver-cert-extra-sans="${PRIVATE_IP}"`, criSocket)),
+			Delete: rootScript("kubeadm reset -f || true\nrm -rf /etc/cni/net.d /etc/kubernetes || true"),
+		}, utils.MergeOptions(opts, utils.PulumiDependsOn(tools))...)
+		if err != nil {
+			return err
+		}
+
+		// Flannel's default network is 10.244.0.0/16, matching --pod-network-cidr above.
+		cni, err := runner.Command(namer.ResourceName("kubeadm-cni"), &command.Args{
+			Sudo: true,
+			Create: rootScript(`export KUBECONFIG=/etc/kubernetes/admin.conf
+kubectl apply -f https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml`),
+		}, utils.MergeOptions(opts, utils.PulumiDependsOn(initCluster))...)
+		if err != nil {
+			return err
+		}
+
+		// Untaint the control-plane so the single node also schedules workloads,
+		// then block until the node is Ready (this gates the kubeconfig export).
+		waitReady, err := runner.Command(namer.ResourceName("kubeadm-wait-ready"), &command.Args{
+			Sudo: true,
+			Create: rootScript(`export KUBECONFIG=/etc/kubernetes/admin.conf
+kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
+kubectl taint nodes --all node-role.kubernetes.io/master- || true
+for i in $(seq 1 60); do
+  if kubectl get nodes --no-headers 2>/dev/null | grep -qw Ready; then break; fi
+  echo "waiting for node Ready ($i/60)"; sleep 10
+done
+kubectl wait --for=condition=Ready node --all --timeout=300s
+kubectl get nodes -o wide`),
+		}, utils.MergeOptions(opts, utils.PulumiDependsOn(cni))...)
+		if err != nil {
+			return err
+		}
+
+		kubeConfigCmd, err := runner.Command(namer.ResourceName("kubeadm-kubeconfig"), &command.Args{
+			Sudo:   true,
+			Create: pulumi.String("cat /etc/kubernetes/admin.conf"),
+		}, utils.MergeOptions(opts, utils.PulumiDependsOn(waitReady))...)
+		if err != nil {
+			return err
+		}
+
+		clusterComp.KubeConfig = pulumi.All(kubeConfigCmd.StdoutOutput(), vm.Address, waitReady.StdoutOutput()).ApplyT(func(args []interface{}) string {
+			kubeconfigRaw := args[0].(string)
+			vmIP := args[1].(string)
+			// args[2] forces this to run after the readiness wait.
+			insecure := regexp.MustCompile(`certificate-authority-data:.+`).ReplaceAllString(kubeconfigRaw, "insecure-skip-tls-verify: true")
+			return regexp.MustCompile(`server: https://\S+`).ReplaceAllString(insecure, "server: https://"+vmIP+":6443")
+		}).(pulumi.StringOutput)
+		clusterComp.ClusterName = clusterName.ToStringOutput()
+		return nil
+	}, opts...)
+}

--- a/test/e2e-framework/components/os/linux_descriptors.go
+++ b/test/e2e-framework/components/os/linux_descriptors.go
@@ -27,6 +27,7 @@ var (
 
 	RedHatDefault = RedHat9
 	RedHat9       = NewDescriptor(RedHat, "9")
+	RedHat10      = NewDescriptor(RedHat, "10")
 
 	SuseDefault = Suse15
 	Suse15      = NewDescriptor(Suse, "15-4")

--- a/test/e2e-framework/resources/aws/platforms.json
+++ b/test/e2e-framework/resources/aws/platforms.json
@@ -72,7 +72,8 @@
         "x86_64": {
             "86": "ami-031eff1ae75bb87e4",
             "86-fips": "ami-0d0fb96b595c56e03",
-            "9": "ami-0d424760e95da7d14"
+            "9": "ami-0d424760e95da7d14",
+            "10": "ami-07b1b74df74f960a5"
         }
     },
     "rocky-linux": {

--- a/test/e2e-framework/scenarios/aws/kubeadm/run.go
+++ b/test/e2e-framework/scenarios/aws/kubeadm/run.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package kubeadm contains the Pulumi program for a single-node kubeadm cluster
+// running directly on an EC2 VM with containerd, plus the Datadog Agent and the
+// SBOM target workloads.
+package kubeadm
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent/helm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/sbomtargets"
+	fakeintakeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	kubeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
+	resAws "github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/outputs"
+)
+
+// Run is the entry point for the scenario when run via pulumi.
+func Run(ctx *pulumi.Context) error {
+	awsEnv, err := resAws.NewEnvironment(ctx)
+	if err != nil {
+		return err
+	}
+
+	env := outputs.NewKubernetes()
+	return RunWithEnv(ctx, awsEnv, env, ParamsFromEnvironment(awsEnv))
+}
+
+// RunWithEnv deploys a kubeadm-on-EC2 environment using a provided env and params.
+func RunWithEnv(ctx *pulumi.Context, awsEnv resAws.Environment, env outputs.KubernetesOutputs, params *RunParams) error {
+	var err error
+	var fakeIntake *fakeintakeComp.Fakeintake
+	if params.fakeintakeOptions != nil {
+		fakeIntake, err = fakeintake.NewECSFargateInstance(awsEnv, params.Name, params.fakeintakeOptions...)
+		if err != nil {
+			return err
+		}
+		if err = fakeIntake.Export(ctx, env.FakeIntakeOutput()); err != nil {
+			return err
+		}
+
+		if len(params.agentOptions) > 0 {
+			newOpts := []kubernetesagentparams.Option{kubernetesagentparams.WithFakeintake(fakeIntake)}
+			params.agentOptions = append(newOpts, params.agentOptions...)
+		}
+		params.vmOptions = append(params.vmOptions, ec2.WithPulumiResourceOptions(utils.PulumiDependsOn(fakeIntake)))
+	} else {
+		env.DisableFakeIntake()
+	}
+
+	host, err := ec2.NewVM(awsEnv, params.Name, params.vmOptions...)
+	if err != nil {
+		return err
+	}
+
+	cluster, err := kubeComp.NewKubeadmCluster(&awsEnv, host, params.Name, awsEnv.KubernetesVersion(), params.containerRuntime)
+	if err != nil {
+		return err
+	}
+	if err = cluster.Export(ctx, env.KubernetesClusterOutput()); err != nil {
+		return err
+	}
+
+	// If InitOnly is set, return after creating the cluster.
+	if awsEnv.InitOnly() {
+		return nil
+	}
+
+	kubeProvider, err := kubernetes.NewProvider(ctx, awsEnv.Namer.ResourceName("k8s-provider"), &kubernetes.ProviderArgs{
+		EnableServerSideApply: pulumi.Bool(true),
+		Kubeconfig:            cluster.KubeConfig,
+	})
+	if err != nil {
+		return err
+	}
+
+	var dependsOnDDAgent pulumi.ResourceOption
+	if len(params.agentOptions) > 0 {
+		newOpts := []kubernetesagentparams.Option{
+			kubernetesagentparams.WithClusterName(cluster.ClusterName),
+			kubernetesagentparams.WithTags([]string{"stackid:" + ctx.Stack()}),
+		}
+		params.agentOptions = append(newOpts, params.agentOptions...)
+		agent, err := helm.NewKubernetesAgent(&awsEnv, params.Name, kubeProvider, params.agentOptions...)
+		if err != nil {
+			return err
+		}
+		if err = agent.Export(ctx, env.KubernetesAgentOutput()); err != nil {
+			return err
+		}
+		dependsOnDDAgent = utils.PulumiDependsOn(agent)
+	} else {
+		env.DisableAgent()
+	}
+
+	if params.deploySBOMWorkloads {
+		var extraOpts []pulumi.ResourceOption
+		if dependsOnDDAgent != nil {
+			extraOpts = append(extraOpts, dependsOnDDAgent)
+		}
+		if _, err := sbomtargets.K8sAppDefinition(&awsEnv, kubeProvider, extraOpts...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/test/e2e-framework/scenarios/aws/kubeadm/run_args.go
+++ b/test/e2e-framework/scenarios/aws/kubeadm/run_args.go
@@ -1,0 +1,113 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package kubeadm
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	kubeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/optional"
+)
+
+const defaultKubeadmName = "kubeadm"
+
+// RunParams collects parameters for the kubeadm-on-VM scenario.
+type RunParams struct {
+	Name              string
+	vmOptions         []ec2.VMOption
+	agentOptions      []kubernetesagentparams.Option
+	fakeintakeOptions []fakeintake.Option
+
+	// deploySBOMWorkloads deploys the SBOM target workloads (node, golang-alpine,
+	// ubi9, python) so the Agent has real container images to scan.
+	deploySBOMWorkloads bool
+
+	// containerRuntime selects the node CRI. The zero value is containerd.
+	containerRuntime kubeComp.ContainerRuntime
+}
+
+// RunOption is an option for the kubeadm scenario.
+type RunOption = func(*RunParams) error
+
+// GetRunParams applies opts on top of the scenario defaults.
+func GetRunParams(opts ...RunOption) *RunParams {
+	p := &RunParams{
+		Name:              defaultKubeadmName,
+		vmOptions:         []ec2.VMOption{},
+		agentOptions:      nil, // nil by default - Agent is only deployed when options are explicitly provided
+		fakeintakeOptions: []fakeintake.Option{},
+	}
+	if err := optional.ApplyOptions(p, opts); err != nil {
+		panic(fmt.Errorf("unable to apply RunOption, err: %w", err))
+	}
+	return p
+}
+
+// ParamsFromEnvironment maps the environment to default kubeadm scenario parameters.
+func ParamsFromEnvironment(e aws.Environment) *RunParams {
+	p := &RunParams{
+		Name: defaultKubeadmName,
+	}
+
+	// This scenario targets RHEL 10 by default, but honors an explicit descriptor.
+	osDesc := os.DescriptorFromString(e.InfraOSDescriptor(), os.RedHat10)
+	p.vmOptions = append(p.vmOptions, ec2.WithOS(osDesc))
+
+	if e.AgentDeploy() {
+		p.agentOptions = append(p.agentOptions, kubernetesagentparams.WithNamespace("datadog"))
+	}
+
+	if e.AgentDeploy() && e.AgentUseFakeintake() {
+		fi := []fakeintake.Option{fakeintake.WithMemory(2048)}
+		if e.AgentUseDualShipping() {
+			fi = append(fi, fakeintake.WithoutDDDevForwarding())
+		}
+		p.fakeintakeOptions = fi
+	}
+
+	p.deploySBOMWorkloads = e.TestingWorkloadDeploy()
+	return p
+}
+
+// WithName sets the scenario name.
+func WithName(name string) RunOption {
+	return func(p *RunParams) error { p.Name = name; return nil }
+}
+
+// WithVMOptions sets VM options.
+func WithVMOptions(opts ...ec2.VMOption) RunOption {
+	return func(p *RunParams) error { p.vmOptions = append(p.vmOptions, opts...); return nil }
+}
+
+// WithAgentOptions sets agent options.
+func WithAgentOptions(opts ...kubernetesagentparams.Option) RunOption {
+	return func(p *RunParams) error { p.agentOptions = append(p.agentOptions, opts...); return nil }
+}
+
+// WithFakeintakeOptions sets fakeintake options.
+func WithFakeintakeOptions(opts ...fakeintake.Option) RunOption {
+	return func(p *RunParams) error { p.fakeintakeOptions = append(p.fakeintakeOptions, opts...); return nil }
+}
+
+// WithoutFakeIntake disables fakeintake creation.
+func WithoutFakeIntake() RunOption {
+	return func(p *RunParams) error { p.fakeintakeOptions = nil; return nil }
+}
+
+// WithDeploySBOMWorkloads deploys the SBOM target workloads.
+func WithDeploySBOMWorkloads() RunOption {
+	return func(p *RunParams) error { p.deploySBOMWorkloads = true; return nil }
+}
+
+// WithContainerRuntime selects the node container runtime (containerd by default, or CRI-O).
+func WithContainerRuntime(rt kubeComp.ContainerRuntime) RunOption {
+	return func(p *RunParams) error { p.containerRuntime = rt; return nil }
+}

--- a/test/e2e-framework/testing/provisioners/aws/kubernetes/kubeadm/kubeadm.go
+++ b/test/e2e-framework/testing/provisioners/aws/kubernetes/kubeadm/kubeadm.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package kubeadm contains the provisioner for the kubeadm-on-VM Kubernetes based environments
+package kubeadm
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kubeadm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
+	awskubernetes "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	provisionerBaseID = "aws-kubeadm-"
+)
+
+// DiagnoseFunc dumps the kubeadm cluster state (nodes, pods, events) on failure.
+func DiagnoseFunc(_ context.Context, stackName string) (string, error) {
+	// The framework may invoke Diagnose with an already-expired context after a long
+	// provisioning failure; use a fresh one so the SSH dump can actually run.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	dumpResult, err := awskubernetes.DumpKubeadmClusterState(ctx, stackName)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Dumping Kubeadm cluster state:\n%s", dumpResult), nil
+}
+
+// Provisioner creates a kubeadm-on-VM Kubernetes provisioner.
+func Provisioner(opts ...provisionerOption) provisioners.TypedProvisioner[environments.Kubernetes] {
+	params := getProvisionerParams(opts...)
+	runParams := kubeadm.GetRunParams(params.runOptions...)
+
+	provisioner := provisioners.NewTypedPulumiProvisioner(provisionerBaseID+runParams.Name, func(ctx *pulumi.Context, env *environments.Kubernetes) error {
+		params := getProvisionerParams(opts...)
+		runParams := kubeadm.GetRunParams(params.runOptions...)
+
+		var awsEnv aws.Environment
+		var err error
+		if params.awsEnv != nil {
+			awsEnv = *params.awsEnv
+		} else {
+			awsEnv, err = aws.NewEnvironment(ctx)
+			if err != nil {
+				return err
+			}
+			params.awsEnv = &awsEnv
+		}
+
+		return kubeadm.RunWithEnv(ctx, awsEnv, env, runParams)
+	}, params.extraConfigParams)
+
+	provisioner.SetDiagnoseFunc(DiagnoseFunc)
+	return provisioner
+}

--- a/test/e2e-framework/testing/provisioners/aws/kubernetes/kubeadm/params.go
+++ b/test/e2e-framework/testing/provisioners/aws/kubernetes/kubeadm/params.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package kubeadm
+
+import (
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kubeadm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/optional"
+)
+
+type provisionerParams struct {
+	awsEnv            *aws.Environment
+	runOptions        []kubeadm.RunOption
+	extraConfigParams runner.ConfigMap
+}
+
+type provisionerOption func(*provisionerParams) error
+
+func getProvisionerParams(opts ...provisionerOption) *provisionerParams {
+	p := &provisionerParams{awsEnv: nil, runOptions: []kubeadm.RunOption{}, extraConfigParams: runner.ConfigMap{}}
+	_ = optional.ApplyOptions(p, opts)
+	return p
+}
+
+// WithAwsEnv sets a pre-built AWS environment.
+func WithAwsEnv(env *aws.Environment) provisionerOption {
+	return func(p *provisionerParams) error { p.awsEnv = env; return nil }
+}
+
+// WithRunOptions sets the scenario run options.
+func WithRunOptions(opts ...kubeadm.RunOption) provisionerOption {
+	return func(p *provisionerParams) error { p.runOptions = append(p.runOptions, opts...); return nil }
+}
+
+// WithExtraConfigParams sets extra Pulumi config params.
+func WithExtraConfigParams(cm runner.ConfigMap) provisionerOption {
+	return func(p *provisionerParams) error { p.extraConfigParams = cm; return nil }
+}

--- a/test/e2e-framework/testing/provisioners/aws/kubernetes/kubernetes_dump.go
+++ b/test/e2e-framework/testing/provisioners/aws/kubernetes/kubernetes_dump.go
@@ -213,3 +213,104 @@ func DumpKindClusterState(ctx context.Context, name string) (ret string, err err
 
 	return ret, nil
 }
+
+// DumpKubeadmClusterState dumps the state of a kubeadm-on-VM cluster by reading
+// the admin kubeconfig from the VM over SSH and dumping the cluster resources.
+func DumpKubeadmClusterState(ctx context.Context, name string) (ret string, err error) {
+	var out strings.Builder
+	defer func() { ret = out.String() }()
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to load AWS config: %v", err)
+	}
+	ec2Client := awsec2.NewFromConfig(cfg)
+
+	currentUser, _ := user.Current()
+	instanceName := name + "-aws-kubeadm"
+	instancesDescription, err := ec2Client.DescribeInstances(ctx, &awsec2.DescribeInstancesInput{
+		Filters: []awsec2types.Filter{
+			{Name: pointer.Ptr("tag:managed-by"), Values: []string{"pulumi"}},
+			{Name: pointer.Ptr("tag:username"), Values: []string{currentUser.Username}},
+			{Name: pointer.Ptr("tag:Name"), Values: []string{instanceName}},
+		},
+	})
+	if err != nil {
+		return ret, fmt.Errorf("failed to describe instances: %v", err)
+	}
+	if instancesDescription == nil || len(instancesDescription.Reservations) == 0 || len(instancesDescription.Reservations[0].Instances) != 1 {
+		return ret, fmt.Errorf("did not find exactly one instance for %s", instanceName)
+	}
+	instanceIP := instancesDescription.Reservations[0].Instances[0].PrivateIpAddress
+	if instanceIP == nil {
+		return ret, errors.New("failed to get private IP of instance")
+	}
+
+	sshClient, err := sshutils.SshConnectToInstance(*instanceIP, "22", "ec2-user")
+	if err != nil {
+		return ret, fmt.Errorf("failed to dial SSH server %s: %v", *instanceIP, err)
+	}
+	defer sshClient.Close()
+
+	sshSession, err := sshClient.NewSession()
+	if err != nil {
+		return ret, fmt.Errorf("failed to create SSH session: %v", err)
+	}
+	defer sshSession.Close()
+
+	stdout, err := sshSession.StdoutPipe()
+	if err != nil {
+		return ret, fmt.Errorf("failed to create stdout pipe: %v", err)
+	}
+	stderr, err := sshSession.StderrPipe()
+	if err != nil {
+		return ret, fmt.Errorf("failed to create stderr pipe: %v", err)
+	}
+
+	if err := sshSession.Start("sudo cat /etc/kubernetes/admin.conf"); err != nil {
+		return ret, fmt.Errorf("failed to start remote command: %v", err)
+	}
+
+	var stdoutBuf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(2)
+	errChannel := make(chan error, 2)
+	go func() {
+		if _, err := io.Copy(&stdoutBuf, stdout); err != nil {
+			errChannel <- fmt.Errorf("failed to read stdout: %v", err)
+		}
+		wg.Done()
+	}()
+	go func() {
+		if _, err := io.Copy(&out, stderr); err != nil {
+			errChannel <- fmt.Errorf("failed to read stderr: %v", err)
+		}
+		wg.Done()
+	}()
+	waitErr := sshSession.Wait()
+	wg.Wait()
+	close(errChannel)
+	for e := range errChannel {
+		if e != nil {
+			return ret, e
+		}
+	}
+	if waitErr != nil {
+		return ret, fmt.Errorf("remote command exited with error: %v", waitErr)
+	}
+
+	kubeconfig, err := clientcmd.Load(stdoutBuf.Bytes())
+	if err != nil {
+		return ret, fmt.Errorf("failed to parse kubeconfig: %v", err)
+	}
+	for _, cluster := range kubeconfig.Clusters {
+		cluster.Server = "https://" + *instanceIP + ":6443"
+		cluster.CertificateAuthorityData = nil
+		cluster.InsecureSkipTLSVerify = true
+	}
+
+	if err := k8sutils.DumpK8sClusterState(ctx, kubeconfig, &out); err != nil {
+		return ret, fmt.Errorf("failed to dump cluster state: %v", err)
+	}
+	return ret, nil
+}

--- a/test/fakeintake/AGENTS.md
+++ b/test/fakeintake/AGENTS.md
@@ -36,7 +36,7 @@ test/fakeintake/
 | `/api/v1/container` | ContainerAggregator | `GetContainers()` |
 | `/api/v2/contimage` | ContainerImageAggregator | `GetContainerImages()` |
 | `/api/v2/contlcycle` | ContainerLifecycleAggregator | `GetContainerLifecycleEvents()` |
-| `/api/v2/sbom` | SBOMAggregator | `GetSBOMs()` |
+| `/api/v2/sbom` | SBOMAggregator | `GetSBOMIDs()` / `FilterSBOMs()` |
 | `/api/v2/orch` | OrchestratorAggregator | `GetOrchestratorResources()` |
 | `/api/v2/ndmflow` | NDMFlowAggregator | GetNDMFlows() |
 | `/api/v2/netpath` | NetpathAggregator | `GetLatestNetpathEvents()` |

--- a/test/fakeintake/aggregator/sbomAggregator.go
+++ b/test/fakeintake/aggregator/sbomAggregator.go
@@ -45,7 +45,11 @@ func ParseSbomPayload(payload api.Payload) ([]*SBOMPayload, error) {
 
 	msg := agentmodel.SBOMPayload{}
 	if err := proto.Unmarshal(inflated, &msg); err != nil {
-		return nil, fmt.Errorf("error parsing SBOM payload: data_len=%d, inflated_len=%d, encoding=%s, first_few_data_bytes=%v: %w", len(payload.Data), len(inflated), payload.Encoding, payload.Data[:min(20, len(payload.Data))], err)
+		// The Agent's SBOM endpoint can also receive non SBOM bodies (for example
+		// empty {} keepalive payloads when the endpoint is redirected to the
+		// fakeintake). Skip anything that is not a valid SBOM protobuf so one junk
+		// payload does not fail the entire SBOM query.
+		return nil, nil
 	}
 
 	payloads := make([]*SBOMPayload, len(msg.Entities))

--- a/test/fakeintake/aggregator/sbomAggregator_test.go
+++ b/test/fakeintake/aggregator/sbomAggregator_test.go
@@ -24,6 +24,12 @@ func TestNewSBOMPayloads(t *testing.T) {
 		require.Empty(t, payloads)
 	})
 
+	t.Run("parseSbomPayload non SBOM body should be skipped", func(t *testing.T) {
+		payloads, err := ParseSbomPayload(api.Payload{Data: []byte("{}"), Encoding: encodingEmpty})
+		require.NoError(t, err)
+		require.Empty(t, payloads)
+	})
+
 	t.Run("parseSbomPayload valid body should parse payloads", func(t *testing.T) {
 		payloads, err := ParseSbomPayload(api.Payload{Data: SBOMData, Encoding: encodingGzip})
 		require.NoError(t, err)

--- a/test/new-e2e/tests/sbom/base_test.go
+++ b/test/new-e2e/tests/sbom/base_test.go
@@ -24,6 +24,20 @@ type baseSuite[Env any] struct {
 	clusterName string
 }
 
+// sbomTargetsSuite carries the runtime-agnostic SBOM assertions (container image
+// + host) shared by the kubeadm and standalone-Docker suites, so every runtime
+// is verified against the exact same expected SBOM output. The concrete suites
+// add their own SetupSuite and Test00UpAndRunning readiness gate.
+type sbomTargetsSuite[Env any] struct {
+	baseSuite[Env]
+
+	// expectLayerDigests is set for runtimes that expose a real per-layer
+	// manifest digest: containerd reads it from the content store and CRI-O from
+	// the image manifest on disk. Docker exposes none, so its components must
+	// carry an empty LayerDigest rather than a fabricated one.
+	expectLayerDigests bool
+}
+
 func (suite *baseSuite[Env]) BeforeTest(suiteName, testName string) {
 	suite.T().Logf("START  %s/%s %s", suiteName, testName, time.Now())
 	suite.BaseSuite.BeforeTest(suiteName, testName)

--- a/test/new-e2e/tests/sbom/docker_test.go
+++ b/test/new-e2e/tests/sbom/docker_test.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package sbom
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/sbomtargets"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/dockeragentparams"
+	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	scendocker "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2docker"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awsdocker "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/docker"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dockerHostSuite runs the shared SBOM assertions against a standalone Docker
+// (moby / overlay2) host - no Kubernetes. It reuses sbomTargetsSuite so the
+// container + host SBOMs are verified to be identical to the kubeadm runs.
+type dockerHostSuite struct {
+	sbomTargetsSuite[environments.DockerHost]
+}
+
+// TestSBOMDockerHostSuite provisions a RHEL 10 EC2 VM running Docker, deploys the
+// Agent as a Docker container configured to scan the daemon's images (overlayfs
+// direct scan) and the host, runs the SBOM target images as Docker containers,
+// and asserts the same host + container SBOMs as the kubeadm suites. The Agent
+// auto-selects the docker collector from the mounted /var/run/docker.sock.
+func TestSBOMDockerHostSuite(t *testing.T) {
+	prov := awsdocker.Provisioner(
+		awsdocker.WithRunOptions(
+			scendocker.WithEC2VMOptions(
+				scenec2.WithOS(e2eos.RedHat10),
+				scenec2.WithInstanceType("t3.2xlarge"),
+			),
+			scendocker.WithFakeIntakeOptions(fakeintake.WithMemory(2048)),
+			scendocker.WithAgentOptions(
+				// Mount the host root so the Agent can produce a host SBOM and reach
+				// the daemon's overlay2 diff dirs (SanitizeHostPath rewrites
+				// /var/lib/docker/... to /host/var/lib/docker/...). The daemon socket
+				// is already mounted by the docker agent component.
+				dockeragentparams.WithExtraVolumes("/:/host:ro"),
+				// HOST_ROOT points the Agent at the mounted host root, so the host SBOM
+				// scans the host (not the Agent container) and Trivy's default proc/sys/dev
+				// skips apply. Without it the scan targets "/" and walks the live
+				// /host/proc, failing on the binfmt_misc symlink loop.
+				dockeragentparams.WithAgentServiceEnvVariable("HOST_ROOT", pulumi.String("/host")),
+				// Enable host + container SBOM with overlayfs direct scan and the os +
+				// languages analyzers, matching the kubeadm Helm values so the SBOMs
+				// are identical.
+				dockeragentparams.WithAgentServiceEnvVariable("DD_SBOM_ENABLED", pulumi.String("true")),
+				dockeragentparams.WithAgentServiceEnvVariable("DD_SBOM_HOST_ENABLED", pulumi.String("true")),
+				dockeragentparams.WithAgentServiceEnvVariable("DD_SBOM_HOST_ANALYZERS", pulumi.String("os languages")),
+				dockeragentparams.WithAgentServiceEnvVariable("DD_CONTAINER_IMAGE_ENABLED", pulumi.String("true")),
+				dockeragentparams.WithAgentServiceEnvVariable("DD_SBOM_CONTAINER_IMAGE_ENABLED", pulumi.String("true")),
+				dockeragentparams.WithAgentServiceEnvVariable("DD_SBOM_CONTAINER_IMAGE_OVERLAYFS_DIRECT_SCAN", pulumi.String("true")),
+				dockeragentparams.WithAgentServiceEnvVariable("DD_SBOM_CONTAINER_IMAGE_ANALYZERS", pulumi.String("os languages")),
+				// Run the SBOM target images as long-lived Docker containers so their
+				// images are resident and InUse for the Agent to scan.
+				dockeragentparams.WithExtraComposeInlineManifest(sbomtargets.DockerComposeManifest()),
+			),
+		),
+	)
+	e2e.Run(t, &dockerHostSuite{}, e2e.WithProvisioner(prov))
+}
+
+func (s *dockerHostSuite) SetupSuite() {
+	s.baseSuite.SetupSuite()
+	s.Fakeintake = s.Env().FakeIntake.Client()
+}
+
+// Test00UpAndRunning waits (long timeout, hence the 00 prefix so it runs first)
+// for every SBOM target container to be running, so the images are resident in
+// the Docker daemon before the SBOM assertions run.
+func (s *dockerHostSuite) Test00UpAndRunning() {
+	s.EventuallyWithTf(func(c *assert.CollectT) {
+		out, err := s.Env().RemoteHost.Execute("docker ps --format '{{.Names}}'")
+		require.NoErrorf(c, err, "failed to list running containers")
+		for _, t := range sbomtargets.Targets {
+			assert.Containsf(c, out, t.Name, "SBOM target container %q is not running yet", t.Name)
+		}
+	}, 10*time.Minute, 15*time.Second, "SBOM target containers not running")
+}
+
+// TestZZDumpAgentDiagnostics runs last (the ZZ prefix sorts it after the SBOM
+// tests) and dumps Docker + Agent SBOM state that otherwise lives only in the
+// flare artifact, not the test trace: the storage driver (the overlay scan
+// requires overlay2) and the Agent's SBOM/trivy logs. It is a debugging aid for
+// the container SBOM assertions and always passes.
+func (s *dockerHostSuite) TestZZDumpAgentDiagnostics() {
+	host := s.Env().RemoteHost
+	for _, cmd := range []string{
+		"docker info --format 'storage-driver={{.Driver}}'",
+		"docker exec datadog-agent agent status 2>&1 | grep -iEA2 'sbom|container image' | head -80",
+		"docker logs datadog-agent 2>&1 | grep -iE 'sbom|trivy|overlay|scan' | tail -150",
+	} {
+		out, err := host.Execute(cmd)
+		s.T().Logf("DIAG %q err=%v\n%s", cmd, err, out)
+	}
+}

--- a/test/new-e2e/tests/sbom/kubeadm_test.go
+++ b/test/new-e2e/tests/sbom/kubeadm_test.go
@@ -1,0 +1,690 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package sbom
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
+	"github.com/DataDog/agent-payload/v5/sbom"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	kubeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
+	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
+	scenkubeadm "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kubeadm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	provkubeadm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kubeadm"
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+)
+
+const (
+	propDiffID      = "aquasecurity:trivy:DiffID"
+	propLayerDiffID = "aquasecurity:trivy:LayerDiffID"
+	propLayerDigest = "aquasecurity:trivy:LayerDigest"
+	propImageID     = "aquasecurity:trivy:ImageID"
+	propRepoDigest  = "aquasecurity:trivy:RepoDigest"
+	propRepoTag     = "aquasecurity:trivy:RepoTag"
+)
+
+// kubeadmSBOMHelmValues builds the Agent Helm values for the SBOM suite on the
+// given container runtime. It is merged on top of the framework defaults (which
+// already enable host + container SBOM with a fast 60s refresh) and enables the
+// os and languages analyzers on both host and container images, so language
+// packages (npm/apk/pypi) are catalogued alongside OS packages. Host language
+// scanning stays within the test window because the trivy fork defers per-file
+// analyzers past OS package detection, skipping files owned by an OS package.
+//
+// The only runtime differences are the CRI socket and the container-storage
+// overlay mount; everything else (and the resulting SBOM) is identical, which is
+// exactly what the shared assertions verify.
+func kubeadmSBOMHelmValues(runtime kubeComp.ContainerRuntime) string {
+	criSocket := "/run/containerd/containerd.sock"
+	storagePath := "/var/lib/containerd"
+	// containerd serves layers from its (compressed) content store, so it needs
+	// the uncompress toggle; CRI-O reads uncompressed diff dirs directly.
+	uncompressed := "\n      uncompressedLayersSupport: true"
+	if runtime == kubeComp.CRIO {
+		criSocket = "/var/run/crio/crio.sock"
+		storagePath = "/var/lib/containers/storage"
+		uncompressed = ""
+	}
+	return fmt.Sprintf(`datadog:
+  criSocketPath: %[1]s
+  kubelet:
+    tlsVerify: false
+  useHostPID: true
+  sbom:
+    host:
+      enabled: true
+      analyzers: ["os", "languages"]
+    containerImage:
+      enabled: true%[3]s
+      overlayFSDirectScan: true
+      analyzers: ["os", "languages"]
+agents:
+  useHostNetwork: true
+  volumeMounts:
+    - name: trivycache
+      mountPath: /root/.cache/trivy
+    - name: imageoverlay
+      mountPath: %[2]s
+      readOnly: true
+  volumes:
+    - name: trivycache
+      emptyDir: {}
+    - name: imageoverlay
+      hostPath:
+        path: %[2]s
+`, criSocket, storagePath, uncompressed)
+}
+
+type kubeadmSuite struct {
+	sbomTargetsSuite[environments.Kubernetes]
+}
+
+// TestSBOMKubeadmSuite provisions a RHEL 10 host running single-node Kubernetes
+// (kubeadm + containerd), installs the Agent (CI dev image) via Helm, runs four
+// target images, and asserts both host and container-image SBOMs in fakeintake.
+func TestSBOMKubeadmSuite(t *testing.T) {
+	prov := provkubeadm.Provisioner(
+		provkubeadm.WithRunOptions(
+			scenkubeadm.WithVMOptions(
+				scenec2.WithOS(e2eos.RedHat10),
+				scenec2.WithInstanceType("t3.2xlarge"),
+			),
+			scenkubeadm.WithFakeintakeOptions(fakeintake.WithMemory(2048)),
+			scenkubeadm.WithDeploySBOMWorkloads(),
+			scenkubeadm.WithAgentOptions(
+				kubernetesagentparams.WithDualShipping(),
+				kubernetesagentparams.WithTimeout(900),
+				kubernetesagentparams.WithHelmValues(kubeadmSBOMHelmValues(kubeComp.Containerd)),
+			),
+		),
+	)
+	e2e.Run(t, &kubeadmSuite{sbomTargetsSuite[environments.Kubernetes]{expectLayerDigests: true}}, e2e.WithProvisioner(prov))
+}
+
+// TestSBOMKubeadmCrioSuite is the CRI-O counterpart of TestSBOMKubeadmSuite: the
+// same RHEL 10 single-node kubeadm cluster and the same SBOM assertions, but with
+// CRI-O as the container runtime. Reusing the assertions verifies the Agent emits
+// identical host + container SBOMs regardless of the runtime.
+func TestSBOMKubeadmCrioSuite(t *testing.T) {
+	prov := provkubeadm.Provisioner(
+		provkubeadm.WithRunOptions(
+			scenkubeadm.WithVMOptions(
+				scenec2.WithOS(e2eos.RedHat10),
+				scenec2.WithInstanceType("t3.2xlarge"),
+			),
+			scenkubeadm.WithContainerRuntime(kubeComp.CRIO),
+			scenkubeadm.WithFakeintakeOptions(fakeintake.WithMemory(2048)),
+			scenkubeadm.WithDeploySBOMWorkloads(),
+			scenkubeadm.WithAgentOptions(
+				kubernetesagentparams.WithDualShipping(),
+				kubernetesagentparams.WithTimeout(900),
+				kubernetesagentparams.WithHelmValues(kubeadmSBOMHelmValues(kubeComp.CRIO)),
+			),
+		),
+	)
+	e2e.Run(t, &kubeadmSuite{sbomTargetsSuite[environments.Kubernetes]{expectLayerDigests: true}}, e2e.WithProvisioner(prov))
+}
+
+func (s *kubeadmSuite) SetupSuite() {
+	s.baseSuite.SetupSuite()
+	s.clusterName = s.Env().KubernetesCluster.ClusterName
+	s.Fakeintake = s.Env().FakeIntake.Client()
+}
+
+// Test00UpAndRunning waits (with a long timeout, hence the 00 prefix so it runs
+// first) for the Agent DaemonSet to be ready before the SBOM assertions run.
+func (s *kubeadmSuite) Test00UpAndRunning() {
+	ctx := context.Background()
+	s.EventuallyWithTf(func(c *assert.CollectT) {
+		nodes, err := s.Env().KubernetesCluster.Client().CoreV1().Nodes().List(ctx, metav1.ListOptions{
+			LabelSelector: fields.OneTermEqualSelector("kubernetes.io/os", "linux").String(),
+		})
+		require.NoErrorf(c, err, "Failed to list Linux nodes")
+
+		pods, err := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+			LabelSelector: fields.OneTermEqualSelector("app", s.Env().Agent.LinuxNodeAgent.LabelSelectors["app"]).String(),
+		})
+		require.NoErrorf(c, err, "Failed to list Linux datadog agent pods")
+
+		assert.Len(c, pods.Items, len(nodes.Items))
+		for _, pod := range pods.Items {
+			for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+				assert.Truef(c, cs.Ready, "Container %s of pod %s isn't ready", cs.Name, pod.Name)
+				assert.Zerof(c, cs.RestartCount, "Container %s of pod %s has restarted", cs.Name, pod.Name)
+			}
+		}
+	}, 10*time.Minute, 10*time.Second, "Not all agents eventually became ready in time.")
+}
+
+// expectedComponent describes a meaningful SBOM component to assert on. When name
+// is set, a component with that exact name must exist; when only purlPrefix is set,
+// any component whose PURL starts with the prefix satisfies the check.
+type expectedComponent struct {
+	name       string
+	purlPrefix string
+	// version, when set, is asserted exactly (the complete version string).
+	version string
+	// layer requires this component to carry a LayerDiffID that is a real diff_id
+	// of the image, plus a well formed LayerDigest (the OCI manifest digest).
+	layer bool
+}
+
+// containerTarget mirrors a sbomtargets workload and lists ~3 meaningful
+// components to verify, spanning OS and application packages. digest is the
+// expected manifest digest, asserted against the SBOM RepoDigest. The workload
+// is pinned by digest, so the runtime records no RepoTag (image_tag is absent).
+type containerTarget struct {
+	short string
+	repo  string
+	// tag documents the version the digest pins; it is surfaced only when a
+	// runtime records a RepoTag, so it is verified opportunistically.
+	tag    string
+	digest string
+	// componentCount is the exact total component count (OS + language) for the
+	// digest-pinned image; it is deterministic (identical across containerd and
+	// crio), so the test asserts it exactly.
+	componentCount int
+	components     []expectedComponent
+}
+
+var containerTargets = []containerTarget{
+	{
+		short: "node", repo: "node", tag: "26.2.0",
+		digest:         "sha256:980c5420a7a2ddcb44037726977f2a349e5c7b64217516c7488dce4c74d71583",
+		componentCount: 602,
+		components: []expectedComponent{
+			{name: "node", version: "26.2.0"},                        // generic runtime
+			{name: "libc6", version: "2.41-12+deb13u3", layer: true}, // Debian glibc (OS)
+			// 3 npm application packages (bundled under npm's node_modules), layer-attributed.
+			{name: "chalk", version: "5.6.2", purlPrefix: "pkg:npm/", layer: true},
+			{name: "abbrev", version: "4.0.0", purlPrefix: "pkg:npm/", layer: true},
+			{name: "cacache", version: "20.0.4", purlPrefix: "pkg:npm/", layer: true},
+		},
+	},
+	{
+		short: "golang", repo: "golang", tag: "1.26.3-alpine",
+		digest:         "sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d",
+		componentCount: 186,
+		components: []expectedComponent{
+			{name: "alpine", version: "3.23.4"},               // OS component
+			{name: "musl", version: "1.2.5-r23", layer: true}, // apk libc (OS)
+			{purlPrefix: "pkg:apk/"},                          // apk package
+			// The Go toolchain binaries are built from stdlib only (no third-party
+			// modules); gobinary reports a single application package, layer-attributed.
+			{name: "stdlib", version: "v1.26.3", purlPrefix: "pkg:golang/", layer: true},
+		},
+	},
+	{
+		// ubi is a single-layer image: exercises the single-layer overlayfs scan
+		// (a single containerd bind mount, no lowerdir/upperdir).
+		short: "ubi", repo: "registry.access.redhat.com/ubi9/ubi", tag: "9.8-1780376557",
+		digest:         "sha256:80b1f4c34a7eed1b03a05d12b55768f3e522eef6ec294c6fbd5fa47b6b2892ee",
+		componentCount: 191,
+		components: []expectedComponent{
+			{name: "glibc", layer: true},    // rpm (OS)
+			{name: "bash"},                  // rpm (OS)
+			{purlPrefix: "pkg:rpm/redhat/"}, // rpm package
+		},
+	},
+	{
+		// ubi9/python-312 is a multi-layer RHEL image: rpm (OS) + pip (pypi) across layers.
+		short: "python-312", repo: "registry.access.redhat.com/ubi9/python-312", tag: "9.8-1779945122",
+		digest:         "sha256:52d1ffcda3b9552934f947b7d41fb0cb66973bdc0d7e91814facadc126f68663",
+		componentCount: 479,
+		components: []expectedComponent{
+			{name: "glibc", layer: true},    // rpm glibc (OS)
+			{purlPrefix: "pkg:rpm/redhat/"}, // rpm package
+			// pip is the only pypi package the fix keeps: the system python under
+			// /usr/lib is rpm-owned (skipped); the s2i pip under /opt/app-root survives.
+			{name: "pip", version: "24.2", purlPrefix: "pkg:pypi/", layer: true},
+		},
+	},
+	{
+		short: "python", repo: "python", tag: "3.14.5",
+		digest:         "sha256:250e5c97be05e1eb2272fbdbd810dfd638f9012e1e6f65c99390ad3239943a08",
+		componentCount: 473,
+		components: []expectedComponent{
+			{name: "python", version: "3.14.5"},                                    // generic runtime
+			{name: "libc6", version: "2.41-12+deb13u3", layer: true},               // Debian glibc (OS)
+			{name: "pip", version: "26.1.1", purlPrefix: "pkg:pypi/", layer: true}, // pypi application package
+		},
+	},
+	{
+		// ruby:3.3.4-bookworm is a Debian image whose application packages are
+		// rubygems; the count and gem versions are calibrated from the first run.
+		short: "ruby", repo: "ruby", tag: "3.3.4-bookworm",
+		digest:         "sha256:d4233f4242ea25346f157709bb8417c615e7478468e2699c8e86a4e1f0156de8",
+		componentCount: 557,
+		components: []expectedComponent{
+			{name: "libc6", layer: true}, // Debian glibc (OS)
+			{purlPrefix: "pkg:gem/"},     // rubygems application package
+		},
+	},
+}
+
+var (
+	inventoryOnce sync.Once
+	dumpedTargets sync.Map
+	rawDumped     sync.Map
+)
+
+// dumpRawOnce logs, once per image, the raw SBOM payloads (type/status/error)
+// when none passed the success+container+metadata filter - to diagnose why an
+// image's SBOM is missing (e.g. status FAILED with an error, or a heartbeat).
+func (s *sbomTargetsSuite[Env]) dumpRawOnce(short string, payloads []*aggregator.SBOMPayload) {
+	if _, loaded := rawDumped.LoadOrStore(short, true); loaded {
+		return
+	}
+	for _, p := range payloads {
+		bom := p.GetCyclonedx()
+		s.T().Logf("SBOM-RAW[%s] id=%q type=%v status=%v err=%q hasCyclonedx=%v hasMetadataComponent=%v",
+			short, p.GetId(), p.GetType(), p.Status, p.GetError(), bom != nil,
+			bom != nil && bom.Metadata != nil && bom.Metadata.GetComponent() != nil)
+	}
+}
+
+// TestContainerSBOM verifies each target image's SBOM: tags, meaningful
+// components (exact version + real layer attribution), and that the image
+// metadata (DiffID list, ImageID, RepoDigest, RepoTag) matches the real image.
+func (s *sbomTargetsSuite[Env]) TestContainerSBOM() {
+	for _, target := range containerTargets {
+		s.Run("image="+target.short, func() {
+			s.EventuallyWithTf(func(collect *assert.CollectT) {
+				c := &myCollectT{CollectT: collect, errors: []error{}}
+				collect = nil //nolint:ineffassign
+
+				sbomIDs, err := s.Fakeintake.GetSBOMIDs()
+				require.NoErrorf(c, err, "Failed to query fake intake")
+
+				ids := lo.Filter(sbomIDs, func(id string, _ int) bool {
+					// Container SBOM ids are "<repo>@<digest>"; the trailing "@"
+					// anchors the repo so e.g. "python" does not match the
+					// "python-312" target's id.
+					return strings.Contains(id, target.repo+"@")
+				})
+				if len(ids) == 0 {
+					s.logSBOMInventory()
+				}
+				require.NotEmptyf(c, ids, "No SBOM for %s yet", target.short)
+
+				rawPayloads := lo.FlatMap(ids, func(id string, _ int) []*aggregator.SBOMPayload {
+					p, err := s.Fakeintake.FilterSBOMs(id)
+					assert.NoErrorf(c, err, "Failed to query fake intake")
+					return p
+				})
+				payloads := lo.Filter(rawPayloads, func(p *aggregator.SBOMPayload, _ int) bool {
+					bom := p.GetCyclonedx()
+					return p.GetType() == sbom.SBOMSourceType_CONTAINER_IMAGE_LAYERS &&
+						p.Status == sbom.SBOMStatus_SUCCESS &&
+						bom != nil && bom.Metadata != nil && bom.Metadata.GetComponent() != nil
+				})
+				if len(payloads) == 0 {
+					s.dumpRawOnce(target.short, rawPayloads)
+				}
+				require.NotEmptyf(c, payloads, "No successful container SBOM for %s yet", target.short)
+
+				// Ground truth from the real image config and manifest for the
+				// expected digest.
+				realDiffIDs, realDigests, realImageID, err := realImageRootFS(target.repo + "@" + target.digest)
+				if !assert.NoErrorf(c, err, "failed to fetch real image config for %s", target.short) {
+					return
+				}
+				diffIDSet := make(map[string]bool, len(realDiffIDs))
+				for _, d := range realDiffIDs {
+					diffIDSet[d] = true
+				}
+				digestSet := make(map[string]bool, len(realDigests))
+				for _, d := range realDigests {
+					digestSet[d] = true
+				}
+
+				for _, p := range payloads {
+					bom := p.GetCyclonedx()
+					metaProps := bom.Metadata.GetComponent().GetProperties()
+					comps := bom.Components
+					metaDiffIDs := propertyValues(metaProps, propDiffID)
+
+					s.dumpImageOnce(target, metaProps, comps, metaDiffIDs)
+
+					expectedTags := []*regexp.Regexp{
+						regexp.MustCompile(`^architecture:(amd|arm)64$`),
+						regexp.MustCompile(`^image_id:.*` + regexp.QuoteMeta(target.repo) + `.*@sha256:`),
+						regexp.MustCompile(`^image_name:.*` + regexp.QuoteMeta(target.repo)),
+						regexp.MustCompile(`^os_name:linux$`),
+						regexp.MustCompile(`^short_image:` + regexp.QuoteMeta(target.short) + `$`),
+						regexp.MustCompile(`^scan_method:overlayfs$`),
+					}
+					// Digest-pinned workloads carry no RepoTag, so image_tag is absent;
+					// verify it only when a runtime happens to surface it.
+					optionalTags := []*regexp.Regexp{
+						regexp.MustCompile(`^image_tag:` + regexp.QuoteMeta(target.tag) + `$`),
+					}
+					assert.NoErrorf(c, assertTags(p.GetTags(), expectedTags, optionalTags, true), "Tags mismatch for %s", target.short)
+
+					// Metadata must match the real image config exactly.
+					assert.Equalf(c, realDiffIDs, metaDiffIDs, "DiffID list does not match the real image config for %s", target.short)
+					assert.Containsf(c, propertyValues(metaProps, propImageID), realImageID, "ImageID does not match the real image config for %s", target.short)
+					if repoDigests := propertyValues(metaProps, propRepoDigest); assert.NotEmptyf(c, repoDigests, "no RepoDigest for %s", target.short) {
+						// A runtime may surface several RepoDigests (crio adds the platform
+						// manifest digest next to the pulled index digest); the pinned digest
+						// must appear in one of them, regardless of order.
+						assert.Truef(c, lo.ContainsBy(repoDigests, func(rd string) bool {
+							return strings.Contains(rd, target.digest)
+						}), "no RepoDigest references the expected digest %s for %s (got %v)", target.digest, target.short, repoDigests)
+					}
+					// Digest-pinned images carry no RepoTag; assert its content only when present.
+					if repoTags := propertyValues(metaProps, propRepoTag); len(repoTags) > 0 {
+						assert.Truef(c, strings.Contains(repoTags[0], target.repo+":"+target.tag), "RepoTag %q does not reference %s:%s", repoTags[0], target.repo, target.tag)
+					}
+
+					// Total component count is exact for the digest-pinned image (verified
+					// identical across containerd and crio); versions and layer attribution
+					// are checked below.
+					assert.Equalf(c, target.componentCount, len(comps), "%s has %d components, expected exactly %d", target.short, len(comps), target.componentCount)
+					for _, ec := range target.components {
+						if ec.name == "" {
+							if ec.purlPrefix != "" {
+								assert.Truef(c, hasComponentWithPurlPrefix(comps, ec.purlPrefix), "no component with purl prefix %q in %s", ec.purlPrefix, target.short)
+							}
+							continue
+						}
+						comp := findComponent(comps, ec.name)
+						if !assert.NotNilf(c, comp, "missing component %q in %s", ec.name, target.short) {
+							continue
+						}
+						if ec.version != "" {
+							assert.Equalf(c, ec.version, comp.GetVersion(), "component %q version mismatch in %s", ec.name, target.short)
+						} else {
+							assert.NotEmptyf(c, comp.GetVersion(), "component %q has no version in %s", ec.name, target.short)
+						}
+						if ec.purlPrefix != "" {
+							assert.Truef(c, strings.HasPrefix(comp.GetPurl(), ec.purlPrefix), "component %q purl %q lacks prefix %q in %s", ec.name, comp.GetPurl(), ec.purlPrefix, target.short)
+						}
+						if ec.layer {
+							assertComponentLayer(c, diffIDSet, digestSet, comp, target.short, s.expectLayerDigests)
+						}
+					}
+
+					// Every component attributed to a layer must reference real diff_ids.
+					layered := 0
+					for _, comp := range comps {
+						if len(propertyValues(comp.GetProperties(), propLayerDiffID)) == 0 &&
+							len(propertyValues(comp.GetProperties(), propLayerDigest)) == 0 {
+							continue
+						}
+						layered++
+						assertComponentLayer(c, diffIDSet, digestSet, comp, target.short, s.expectLayerDigests)
+					}
+					assert.NotZerof(c, layered, "no component carried layer (DiffID/Digest) attribution in %s", target.short)
+				}
+			}, 8*time.Minute, 15*time.Second, "Failed finding/validating container SBOM for %s", target.short)
+		})
+	}
+}
+
+// dumpImageOnce logs the Agent's authoritative metadata + meaningful-component
+// values for an image exactly once, so exact versions/layers can be read from
+// the CI trace without flooding it.
+func (s *sbomTargetsSuite[Env]) dumpImageOnce(target containerTarget, metaProps []*cyclonedx_v1_4.Property, comps []*cyclonedx_v1_4.Component, metaDiffIDs []string) {
+	if _, loaded := dumpedTargets.LoadOrStore(target.short, true); loaded {
+		return
+	}
+	s.T().Logf("SBOM-DUMP[%s] ImageID=%v RepoDigest=%v RepoTag=%v DiffIDs=%v",
+		target.short, propertyValues(metaProps, propImageID), propertyValues(metaProps, propRepoDigest),
+		propertyValues(metaProps, propRepoTag), metaDiffIDs)
+	s.T().Logf("SBOM-COUNT[%s] components=%d application=%d", target.short, len(comps), len(applicationComponents(comps)))
+	for _, ec := range target.components {
+		if ec.name == "" {
+			continue
+		}
+		if comp := findComponent(comps, ec.name); comp != nil {
+			s.T().Logf("SBOM-DUMP[%s] comp=%q version=%q purl=%q LayerDiffID=%v LayerDigest=%v",
+				target.short, comp.GetName(), comp.GetVersion(), comp.GetPurl(),
+				propertyValues(comp.GetProperties(), propLayerDiffID), propertyValues(comp.GetProperties(), propLayerDigest))
+		}
+	}
+}
+
+// logSBOMInventory logs every SBOM id with its type and status exactly once -
+// used to diagnose missing payloads (e.g. an image that was not scanned).
+func (s *sbomTargetsSuite[Env]) logSBOMInventory() {
+	inventoryOnce.Do(func() {
+		ids, err := s.Fakeintake.GetSBOMIDs()
+		if err != nil {
+			s.T().Logf("SBOM-INV: GetSBOMIDs error: %v", err)
+			return
+		}
+		for _, id := range ids {
+			ps, err := s.Fakeintake.FilterSBOMs(id)
+			if err != nil {
+				continue
+			}
+			for _, p := range ps {
+				s.T().Logf("SBOM-INV id=%q type=%v status=%v", id, p.GetType(), p.Status)
+			}
+		}
+	})
+}
+
+// TestHostSBOM verifies the host (RHEL 10) SBOM: it is the OS itself (not an
+// image), lists meaningful rpm packages, and carries no layer/DiffID metadata.
+func (s *sbomTargetsSuite[Env]) TestHostSBOM() {
+	s.EventuallyWithTf(func(collect *assert.CollectT) {
+		c := &myCollectT{CollectT: collect, errors: []error{}}
+		collect = nil //nolint:ineffassign
+
+		sbomIDs, err := s.Fakeintake.GetSBOMIDs()
+		require.NoErrorf(c, err, "Failed to query fake intake")
+
+		payloads := lo.FlatMap(sbomIDs, func(id string, _ int) []*aggregator.SBOMPayload {
+			p, err := s.Fakeintake.FilterSBOMs(id)
+			assert.NoErrorf(c, err, "Failed to query fake intake")
+			return p
+		})
+		hosts := lo.Filter(payloads, func(p *aggregator.SBOMPayload, _ int) bool {
+			// Filter to a successful host SBOM that carries a CycloneDX body.
+			// fakeintake retains earlier non-success scans and success heartbeats
+			// (which have no CycloneDX), so requiring every retained host payload
+			// to be valid would never converge once a stale one is present.
+			return p.GetType() == sbom.SBOMSourceType_HOST_FILE_SYSTEM &&
+				p.Status == sbom.SBOMStatus_SUCCESS &&
+				p.GetCyclonedx() != nil
+		})
+		if len(hosts) == 0 {
+			s.logSBOMInventory()
+		}
+		require.NotEmptyf(c, hosts, "No successful host SBOM yet")
+
+		for _, p := range hosts {
+			bom := p.GetCyclonedx()
+			comps := bom.Components
+			assert.Greaterf(c, len(comps), 300, "host SBOM has %d components, expected more than 300", len(comps))
+
+			osComp := findOSComponent(comps)
+			if osComp == nil {
+				osComp = findComponent(comps, "redhat")
+			}
+			if assert.NotNilf(c, osComp, "no OS component in host SBOM") {
+				assert.Truef(c, strings.HasPrefix(osComp.GetVersion(), "10"), "host OS version %q is not RHEL 10", osComp.GetVersion())
+			}
+
+			// Presence by name + ecosystem only: rpm package versions drift with
+			// RHEL updates, so the version is not asserted.
+			for _, name := range []string{"glibc", "bash", "systemd"} {
+				comp := findComponent(comps, name)
+				if assert.NotNilf(c, comp, "missing host rpm package %q", name) {
+					assert.Truef(c, strings.HasPrefix(comp.GetPurl(), "pkg:rpm/redhat/"), "host rpm package %q has unexpected purl %q", name, comp.GetPurl())
+				}
+			}
+
+			// languages is enabled on the host too, but a minimal RHEL host has no
+			// language packages to surface: its Go binaries (kubelet, containerd, ...)
+			// are owned by rpm packages, so the deferred analyzers skip them, and the
+			// flannel CNI plugin only appears as a container SBOM. The value here is
+			// that the scan completes (SUCCESS above) without timing out, which the
+			// trivy deferral fix makes possible. Log the count; don't assert a floor.
+			s.T().Logf("SBOM-COUNT[host] components=%d application=%d", len(comps), len(applicationComponents(comps)))
+
+			// A host SBOM must not look like a container image.
+			assert.Emptyf(c, p.GetDdTags(), "host SBOM should carry no image dd tags")
+			assert.Emptyf(c, p.GetRepoTags(), "host SBOM should carry no repo tags")
+			assert.Emptyf(c, p.GetRepoDigests(), "host SBOM should carry no repo digests")
+			assert.Emptyf(c, propertyValues(metadataProperties(bom), propDiffID), "host SBOM should carry no layer DiffIDs")
+			for _, comp := range comps {
+				assert.Emptyf(c, propertyValues(comp.GetProperties(), propLayerDiffID), "host component %q should carry no LayerDiffID", comp.GetName())
+			}
+		}
+	}, 10*time.Minute, 15*time.Second, "Failed finding/validating host SBOM")
+}
+
+func findComponent(comps []*cyclonedx_v1_4.Component, name string) *cyclonedx_v1_4.Component {
+	for _, c := range comps {
+		if c.GetName() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func findOSComponent(comps []*cyclonedx_v1_4.Component) *cyclonedx_v1_4.Component {
+	for _, c := range comps {
+		if c.GetType() == cyclonedx_v1_4.Classification_CLASSIFICATION_OPERATING_SYSTEM {
+			return c
+		}
+	}
+	return nil
+}
+
+func hasComponentWithPurlPrefix(comps []*cyclonedx_v1_4.Component, prefix string) bool {
+	for _, c := range comps {
+		if strings.HasPrefix(c.GetPurl(), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// osPackagePurlPrefixes are the purl prefixes emitted by OS package managers.
+// Anything else with a pkg: purl is an application/language package.
+var osPackagePurlPrefixes = []string{"pkg:rpm/", "pkg:apk/", "pkg:deb/"}
+
+// applicationComponents returns the application/language packages (npm, pypi,
+// golang, ...): components with a pkg: purl that is not an OS package. This is
+// what the "languages" analyzer contributes on top of OS packages.
+func applicationComponents(comps []*cyclonedx_v1_4.Component) []*cyclonedx_v1_4.Component {
+	var out []*cyclonedx_v1_4.Component
+	for _, c := range comps {
+		purl := c.GetPurl()
+		if !strings.HasPrefix(purl, "pkg:") {
+			continue
+		}
+		isOS := false
+		for _, p := range osPackagePurlPrefixes {
+			if strings.HasPrefix(purl, p) {
+				isOS = true
+				break
+			}
+		}
+		if !isOS {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func propertyValues(props []*cyclonedx_v1_4.Property, name string) []string {
+	var out []string
+	for _, p := range props {
+		if p.GetName() == name {
+			out = append(out, p.GetValue())
+		}
+	}
+	return out
+}
+
+func metadataProperties(bom *cyclonedx_v1_4.Bom) []*cyclonedx_v1_4.Property {
+	if bom.Metadata == nil {
+		return nil
+	}
+	return bom.Metadata.GetComponent().GetProperties()
+}
+
+// assertComponentLayer verifies a component is attributed to a real image layer.
+// LayerDiffID is the layer's uncompressed-content diff_id and must be one of the
+// image's real diff_ids. LayerDigest is the OCI manifest layer (compressed-blob)
+// digest: containerd and CRI-O expose one, where it must be one of the image's
+// real manifest layer digests (hence a sha256 distinct from the diff_id). Docker
+// exposes no per-layer manifest digest and leaves it empty rather than fabricate
+// one from the diff_id, which expectDigest gates.
+func assertComponentLayer(c assert.TestingT, diffIDs, digests map[string]bool, comp *cyclonedx_v1_4.Component, image string, expectDigest bool) {
+	diffID := propertyValues(comp.GetProperties(), propLayerDiffID)
+	if !assert.Lenf(c, diffID, 1, "component %q should carry exactly one LayerDiffID in %s", comp.GetName(), image) {
+		return
+	}
+	assert.Truef(c, diffIDs[diffID[0]], "component %q LayerDiffID %q is not a real diff_id of %s", comp.GetName(), diffID[0], image)
+
+	digest := propertyValues(comp.GetProperties(), propLayerDigest)
+	if !expectDigest {
+		assert.Emptyf(c, digest, "component %q must carry no LayerDigest in %s: the runtime exposes no per-layer manifest digest", comp.GetName(), image)
+		return
+	}
+	if assert.Lenf(c, digest, 1, "component %q should carry exactly one LayerDigest in %s", comp.GetName(), image) {
+		assert.Truef(c, digests[digest[0]], "component %q LayerDigest %q is not a real manifest layer digest of %s", comp.GetName(), digest[0], image)
+		assert.NotEqualf(c, diffID[0], digest[0], "component %q LayerDigest must differ from its LayerDiffID in %s", comp.GetName(), image)
+	}
+}
+
+// realImageRootFS fetches, from the registry, the linux/amd64 ground truth for
+// an image: the ordered rootfs DiffIDs and image config ID (ImageID) from the
+// config blob, and the ordered per-layer compressed digests from the manifest
+// blob. The manifest digests are the LayerDigest values the Agent must report
+// for runtimes that expose them (containerd, CRI-O).
+func realImageRootFS(ref string) (diffIDs []string, digests []string, imageID string, err error) {
+	img, err := crane.Pull(ref, crane.WithPlatform(&v1.Platform{OS: "linux", Architecture: "amd64"}))
+	if err != nil {
+		return nil, nil, "", err
+	}
+	configName, err := img.ConfigName()
+	if err != nil {
+		return nil, nil, "", err
+	}
+	imageID = configName.String()
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		return nil, nil, "", err
+	}
+	for _, d := range cfg.RootFS.DiffIDs {
+		diffIDs = append(diffIDs, d.String())
+	}
+	manifest, err := img.Manifest()
+	if err != nil {
+		return nil, nil, "", err
+	}
+	for _, l := range manifest.Layers {
+		digests = append(digests, l.Digest.String())
+	}
+	return diffIDs, digests, imageID, nil
+}


### PR DESCRIPTION
Provision RHEL 10 and verify the Agent scans both the host root
filesystem and the container images on the node, shipping a host SBOM
and one SBOM per image to the fakeintake, across three container
runtimes behind one shared set of assertions:

- Docker (overlay2)
- Kubernetes with containerd
- Kubernetes with CRIO

The target images span the major OS package formats, Debian dpkg, RHEL
rpm (single and multiple layer images) and Alpine apk, each also
carrying packages from a distinct language ecosystem. The assertions
cover both scopes: the host SBOM and, for every image, exact component
counts, layer DiffIDs and digests, the RepoDigest and the container
artifact scan path. The resulting SBOM is identical whether an image is
served by Docker, containerd or CRIO.

Existing SBOM e2e coverage was a loose container image smoke test on a
Kind cluster. These suites add host filesystem scanning, exact component
and layer digest assertions, and real RHEL 10 hosts running Docker and
CRIO, not only containerd.

