### PR TITLE
Ensure SMP comparison image exists before submitting job

### DIFF
--- a/.gitlab/childs/smp-regression-child-pipeline.yml
+++ b/.gitlab/childs/smp-regression-child-pipeline.yml
@@ -150,7 +150,7 @@ stages:
       if ! aws ecr describe-images --region us-west-2 --profile single-machine-performance \
         --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_TEAM_ID}-agent" \
         --image-ids imageTag="${CI_COMMIT_SHA}-7-full-amd64" > /dev/null 2>&1; then
-        echo "ERROR: Comparison image ${COMPARISON_IMAGE} not found in ECR. Rerun the `single_machine_performance-full-amd64-a7` if it ran more than 4 days ago."
+        echo "ERROR: Comparison image ${COMPARISON_IMAGE} not found in ECR. Rerun the single_machine_performance-full-amd64-a7 if it ran more than 4 days ago."
         datadog-ci tag --level job --tags smp_failure_mode:"missing-comparison-image"
         exit 1
       fi

--- a/.gitlab/childs/smp-regression-child-pipeline.yml
+++ b/.gitlab/childs/smp-regression-child-pipeline.yml
@@ -145,6 +145,15 @@ stages:
     - echo "${BASELINE_SHA} | ${BASELINE_IMAGE}"
     - COMPARISON_IMAGE=${SMP_ECR_URL}/${SMP_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-full-amd64
     - echo "${CI_COMMIT_SHA} | ${COMPARISON_IMAGE}"
+    # Verify the comparison image exists in ECR before submitting the SMP job.
+    - |
+      if ! aws ecr describe-images --region us-west-2 --profile single-machine-performance \
+        --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_TEAM_ID}-agent" \
+        --image-ids imageTag="${CI_COMMIT_SHA}-7-full-amd64" > /dev/null 2>&1; then
+        echo "ERROR: Comparison image ${COMPARISON_IMAGE} not found in ECR."
+        datadog-ci tag --level job --tags smp_failure_mode:"missing-comparison-image"
+        exit 1
+      fi
     - SMP_TAGS="ci_pipeline_id=${PARENT_PIPELINE_ID},ci_job_id=${CI_JOB_ID},ci_commit_branch=${CI_COMMIT_BRANCH},purpose=agent_ci"
     - echo "Tags passed through SMP are ${SMP_TAGS}"
     - RUST_LOG="info,aws_config::profile::credentials=error"

--- a/.gitlab/childs/smp-regression-child-pipeline.yml
+++ b/.gitlab/childs/smp-regression-child-pipeline.yml
@@ -150,7 +150,7 @@ stages:
       if ! aws ecr describe-images --region us-west-2 --profile single-machine-performance \
         --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_TEAM_ID}-agent" \
         --image-ids imageTag="${CI_COMMIT_SHA}-7-full-amd64" > /dev/null 2>&1; then
-        echo "ERROR: Comparison image ${COMPARISON_IMAGE} not found in ECR."
+        echo "ERROR: Comparison image ${COMPARISON_IMAGE} not found in ECR. Rerun the `single_machine_performance-full-amd64-a7` if it ran more than 4 days ago."
         datadog-ci tag --level job --tags smp_failure_mode:"missing-comparison-image"
         exit 1
       fi


### PR DESCRIPTION
### What does this PR do?
Ensure SMP comparison image exists before submitting job

### Motivation
Faster feedback to the user in case they are retrying an older pipeline

### Describe how you validated your changes
Changes covered by existing CI jobs.

### Additional Notes
Test run https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1724308331
