### PR TITLE
feat(fleet): add WithExpectedExitCodes to TracedCmd to suppress span noise for routine checks

### DIFF
--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -140,6 +140,9 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 		return fmt.Errorf("failed to open target directory: %w", err)
 	}
 
+	// robocopy exit codes 1-7 indicate successful copies with various informational statuses.
+	// Only codes >=8 indicate copy errors.
+	// https://learn.microsoft.com/en-us/troubleshoot/windows-server/backup-and-storage/return-codes-used-robocopy-utility
 	cmd := telemetry.CommandContext(
 		ctx,
 		"robocopy",
@@ -148,7 +151,7 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 		sourcePath,
 		targetPath,
 		"*.yaml",
-	)
+	).WithExpectedExitCodes(1, 2, 3, 4, 5, 6, 7)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/pkg/fleet/installer/packages/apminject/app_armor.go
+++ b/pkg/fleet/installer/packages/apminject/app_armor.go
@@ -97,7 +97,13 @@ func setupAppArmor(ctx context.Context) (err error) {
 	}
 
 	// check if apparmor is running properly by executing aa-status
-	if err = telemetry.CommandContext(ctx, "aa-status").Run(); err != nil {
+	// https://manpages.ubuntu.com/manpages/noble/man8/aa-status.8.html
+	if err = telemetry.CommandContext(ctx, "aa-status").
+		WithExpectedExitCodes(
+			1, // apparmor not enabled/loaded
+			2, // apparmor enabled but no policy loaded
+			3, // apparmor control files unavailable under /sys/kernel/security/ (common in containers)
+		).Run(); err != nil {
 		// no-op is apparmor is not running properly
 		return nil
 	}

--- a/pkg/fleet/installer/packages/packagemanager/package_manager.go
+++ b/pkg/fleet/installer/packages/packagemanager/package_manager.go
@@ -52,11 +52,31 @@ func RemovePackage(ctx context.Context, pkg string) (err error) {
 	var removeCmd *telemetry.TracedCmd
 	if dpkgInstalled {
 		removeCmd = telemetry.CommandContext(ctx, "dpkg", "-r", pkg)
-		packageInstalled = telemetry.CommandContext(ctx, "dpkg", "-s", pkg).Run() == nil
+		checkErr := telemetry.CommandContext(ctx, "dpkg", "-s", pkg).
+			WithExpectedExitCodes(
+				1, // package not installed — https://man7.org/linux/man-pages/man1/dpkg.1.html
+			).Run()
+		if checkErr != nil {
+			exitErr := &exec.ExitError{}
+			if !errors.As(checkErr, &exitErr) || exitErr.ExitCode() != 1 {
+				return fmt.Errorf("failed to check if package %s is installed: %w", pkg, checkErr)
+			}
+		}
+		packageInstalled = checkErr == nil
 	}
 	if rpmInstalled {
 		removeCmd = telemetry.CommandContext(ctx, "rpm", "-e", pkg)
-		packageInstalled = telemetry.CommandContext(ctx, "rpm", "-q", pkg).Run() == nil
+		checkErr := telemetry.CommandContext(ctx, "rpm", "-q", pkg).
+			WithExpectedExitCodes(
+				1, // package not installed — https://man7.org/linux/man-pages/man8/rpm.8.html
+			).Run()
+		if checkErr != nil {
+			exitErr := &exec.ExitError{}
+			if !errors.As(checkErr, &exitErr) || exitErr.ExitCode() != 1 {
+				return fmt.Errorf("failed to check if package %s is installed: %w", pkg, checkErr)
+			}
+		}
+		packageInstalled = checkErr == nil
 	}
 	if !packageInstalled {
 		return nil

--- a/pkg/fleet/installer/packages/service/systemd/systemd.go
+++ b/pkg/fleet/installer/packages/service/systemd/systemd.go
@@ -58,7 +58,13 @@ func StopUnits(ctx context.Context, units ...string) error {
 // StopUnit starts a systemd unit
 func StopUnit(ctx context.Context, unit string, args ...string) error {
 	args = append([]string{"stop", unit}, args...)
-	err := telemetry.CommandContext(ctx, "systemctl", args...).Run()
+	err := telemetry.CommandContext(ctx, "systemctl", args...).
+		WithExpectedExitCodes(
+			5,   // unit not loaded — https://github.com/systemd/systemd/issues/25708
+			143, // self-stop via SIGTERM (128+15), see handleSystemdSelfStops
+			// Note: signal-killed processes (ExitCode -1) are not registered here;
+			// handleSystemdSelfStops filters SIGTERM-specifically via WaitStatus.
+		).Run()
 	exitErr := &exec.ExitError{}
 	if !errors.As(err, &exitErr) {
 		return err
@@ -81,7 +87,12 @@ func StartUnit(ctx context.Context, unit string, args ...string) error {
 		return nil
 	}
 	args = append([]string{"start", unit}, args...)
-	err = telemetry.CommandContext(ctx, "systemctl", args...).Run()
+	err = telemetry.CommandContext(ctx, "systemctl", args...).
+		WithExpectedExitCodes(
+			143, // self-stop via SIGTERM (128+15), see handleSystemdSelfStops
+			// Note: signal-killed processes (ExitCode -1) are not registered here;
+			// handleSystemdSelfStops filters SIGTERM-specifically via WaitStatus.
+		).Run()
 	return handleSystemdSelfStops(err)
 }
 
@@ -96,7 +107,12 @@ func RestartUnit(ctx context.Context, unit string, args ...string) error {
 		return nil
 	}
 	args = append([]string{"restart", unit}, args...)
-	err = telemetry.CommandContext(ctx, "systemctl", args...).Run()
+	err = telemetry.CommandContext(ctx, "systemctl", args...).
+		WithExpectedExitCodes(
+			143, // self-stop via SIGTERM (128+15), see handleSystemdSelfStops
+			// Note: signal-killed processes (ExitCode -1) are not registered here;
+			// handleSystemdSelfStops filters SIGTERM-specifically via WaitStatus.
+		).Run()
 	return handleSystemdSelfStops(err)
 }
 
@@ -125,13 +141,20 @@ func DisableUnits(ctx context.Context, units ...string) error {
 
 // DisableUnit disables a systemd unit
 func DisableUnit(ctx context.Context, unit string) error {
-	enabledErr := telemetry.CommandContext(ctx, "systemctl", "is-enabled", "--quiet", unit).Run()
+	enabledErr := telemetry.CommandContext(ctx, "systemctl", "is-enabled", "--quiet", unit).
+		WithExpectedExitCodes(
+			1, // unit is not enabled (disabled, masked, static, etc.) — https://man7.org/linux/man-pages/man1/systemctl.1.html
+			4, // no such unit file — https://man7.org/linux/man-pages/man1/systemctl.1.html
+		).Run()
 	if enabledErr != nil {
 		// unit is already disabled or doesn't exist, we can return fast
 		return nil
 	}
 
-	err := telemetry.CommandContext(ctx, "systemctl", "disable", "--force", unit).Run()
+	err := telemetry.CommandContext(ctx, "systemctl", "disable", "--force", unit).
+		WithExpectedExitCodes(
+			5, // unit not loaded — https://github.com/systemd/systemd/issues/25708
+		).Run()
 	exitErr := &exec.ExitError{}
 	if !errors.As(err, &exitErr) {
 		return err

--- a/pkg/fleet/installer/packages/service/upstart/upstart.go
+++ b/pkg/fleet/installer/packages/service/upstart/upstart.go
@@ -18,7 +18,10 @@ import (
 
 // Restart restarts an upstart service using initctl
 func Restart(ctx context.Context, name string) error {
-	errStart := telemetry.CommandContext(ctx, "initctl", "start", name).Run()
+	errStart := telemetry.CommandContext(ctx, "initctl", "start", name).
+		WithExpectedExitCodes(
+			1, // job already running; restart is the fallback path — https://manpages.ubuntu.com/manpages/noble/man8/initctl.8.html
+		).Run()
 	if errStart == nil {
 		return nil
 	}

--- a/pkg/fleet/installer/telemetry/BUILD.bazel
+++ b/pkg/fleet/installer/telemetry/BUILD.bazel
@@ -22,7 +22,10 @@ go_library(
 
 go_test(
     name = "telemetry_test",
-    srcs = ["telemetry_test.go"],
+    srcs = [
+        "cmd_wrapper_test.go",
+        "telemetry_test.go",
+    ],
     embed = [":telemetry"],
     gotags = ["test"],
     deps = [

--- a/pkg/fleet/installer/telemetry/BUILD.bazel
+++ b/pkg/fleet/installer/telemetry/BUILD.bazel
@@ -22,10 +22,10 @@ go_library(
 
 go_test(
     name = "telemetry_test",
-    srcs = [
-        "cmd_wrapper_test.go",
-        "telemetry_test.go",
-    ],
+    srcs = ["telemetry_test.go"] + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["cmd_wrapper_test.go"],
+    }),
     embed = [":telemetry"],
     gotags = ["test"],
     deps = [

--- a/pkg/fleet/installer/telemetry/BUILD.bazel
+++ b/pkg/fleet/installer/telemetry/BUILD.bazel
@@ -22,10 +22,10 @@ go_library(
 
 go_test(
     name = "telemetry_test",
-    srcs = ["telemetry_test.go"] + select({
-        "@platforms//os:windows": [],
-        "//conditions:default": ["cmd_wrapper_test.go"],
-    }),
+    srcs = [
+        "cmd_wrapper_test.go",
+        "telemetry_test.go",
+    ],
     embed = [":telemetry"],
     gotags = ["test"],
     deps = [

--- a/pkg/fleet/installer/telemetry/cmd_wrapper.go
+++ b/pkg/fleet/installer/telemetry/cmd_wrapper.go
@@ -18,7 +18,8 @@ import (
 // TracedCmd is a wrapper around exec.Cmd that adds telemetry
 type TracedCmd struct {
 	*exec.Cmd
-	span *Span
+	span          *Span
+	expectedCodes map[int]struct{}
 }
 
 // CommandContext runs a command using exec.CommandContext and adds telemetry
@@ -28,14 +29,33 @@ func CommandContext(ctx context.Context, name string, args ...string) *TracedCmd
 	span.SetTag("args", strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, name, args...)
 	return &TracedCmd{
-		Cmd:  cmd,
-		span: span,
+		Cmd:           cmd,
+		span:          span,
+		expectedCodes: map[int]struct{}{0: {}},
 	}
+}
+
+// WithExpectedExitCodes marks exit codes that should NOT flag the span as an
+// error. The exit_code tag is still recorded and the error is still returned to
+// the caller; only the span's error flag is suppressed for these codes.
+// Exit code 0 (success) is always treated as expected.
+func (c *TracedCmd) WithExpectedExitCodes(codes ...int) *TracedCmd {
+	for _, code := range codes {
+		c.expectedCodes[code] = struct{}{}
+	}
+	return c
 }
 
 // Run runs the command and finishes the span
 func (c *TracedCmd) Run() (err error) {
-	defer func() { c.span.Finish(err) }()
+	var expectedExit bool
+	defer func() {
+		if expectedExit {
+			c.span.Finish(nil)
+			return
+		}
+		c.span.Finish(err)
+	}()
 	var stderr bytes.Buffer
 	var stdout bytes.Buffer
 	if c.Cmd.Stderr != nil {
@@ -52,7 +72,12 @@ func (c *TracedCmd) Run() (err error) {
 	if err != nil {
 		exitErr := &exec.ExitError{}
 		if errors.As(err, &exitErr) {
-			c.span.SetTag("exit_code", exitErr.ExitCode())
+			code := exitErr.ExitCode()
+			c.span.SetTag("exit_code", code)
+			if _, ok := c.expectedCodes[code]; ok {
+				expectedExit = true
+				c.span.SetTag("expected_exit_code", true)
+			}
 		}
 		return fmt.Errorf("%s\n%s\n%w", stdout.String(), stderr.String(), err)
 	}

--- a/pkg/fleet/installer/telemetry/cmd_wrapper_test.go
+++ b/pkg/fleet/installer/telemetry/cmd_wrapper_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
+//go:build !windows
+
 package telemetry
 
 import (

--- a/pkg/fleet/installer/telemetry/cmd_wrapper_test.go
+++ b/pkg/fleet/installer/telemetry/cmd_wrapper_test.go
@@ -3,21 +3,29 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-//go:build !windows
-
 package telemetry
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// exitCodeCmd returns a TracedCmd that exits with the given code, cross-platform.
+func exitCodeCmd(ctx context.Context, code int) *TracedCmd {
+	if runtime.GOOS == "windows" {
+		return CommandContext(ctx, "cmd.exe", "/c", fmt.Sprintf("exit %d", code))
+	}
+	return CommandContext(ctx, "sh", "-c", fmt.Sprintf("exit %d", code))
+}
+
 func TestTracedCmdRunSuccess(t *testing.T) {
 	ctx := context.Background()
-	cmd := CommandContext(ctx, "sh", "-c", "exit 0")
+	cmd := exitCodeCmd(ctx, 0)
 	err := cmd.Run()
 	require.NoError(t, err)
 	assert.Equal(t, int32(0), cmd.span.span.Error)
@@ -25,7 +33,7 @@ func TestTracedCmdRunSuccess(t *testing.T) {
 
 func TestTracedCmdRunErrorUnexpected(t *testing.T) {
 	ctx := context.Background()
-	cmd := CommandContext(ctx, "sh", "-c", "exit 1")
+	cmd := exitCodeCmd(ctx, 1)
 	err := cmd.Run()
 	require.Error(t, err)
 	assert.Equal(t, int32(1), cmd.span.span.Error)
@@ -35,7 +43,7 @@ func TestTracedCmdRunErrorUnexpected(t *testing.T) {
 
 func TestTracedCmdRunErrorExpected(t *testing.T) {
 	ctx := context.Background()
-	cmd := CommandContext(ctx, "sh", "-c", "exit 1").WithExpectedExitCodes(1)
+	cmd := exitCodeCmd(ctx, 1).WithExpectedExitCodes(1)
 	err := cmd.Run()
 	// The error is still returned to the caller
 	require.Error(t, err)
@@ -49,7 +57,7 @@ func TestTracedCmdRunExpectedNonZeroAndZeroSuccess(t *testing.T) {
 	ctx := context.Background()
 
 	// expected non-zero exit: span not an error, but error still returned
-	cmdErr := CommandContext(ctx, "sh", "-c", "exit 5").WithExpectedExitCodes(5)
+	cmdErr := exitCodeCmd(ctx, 5).WithExpectedExitCodes(5)
 	err := cmdErr.Run()
 	require.Error(t, err)
 	assert.Equal(t, int32(0), cmdErr.span.span.Error)
@@ -57,7 +65,7 @@ func TestTracedCmdRunExpectedNonZeroAndZeroSuccess(t *testing.T) {
 	assert.Equal(t, "true", cmdErr.span.span.Meta["expected_exit_code"])
 
 	// exit 0 with unrelated expected codes: still succeeds, no expected_exit_code tag
-	cmdOk := CommandContext(ctx, "sh", "-c", "exit 0").WithExpectedExitCodes(5)
+	cmdOk := exitCodeCmd(ctx, 0).WithExpectedExitCodes(5)
 	require.NoError(t, cmdOk.Run())
 	assert.Equal(t, int32(0), cmdOk.span.span.Error)
 	assert.NotContains(t, cmdOk.span.span.Meta, "expected_exit_code")
@@ -66,7 +74,7 @@ func TestTracedCmdRunExpectedNonZeroAndZeroSuccess(t *testing.T) {
 func TestTracedCmdWithExpectedExitCodesAccumulates(t *testing.T) {
 	ctx := context.Background()
 	// Chained calls should accumulate: both 1 and 2 become expected
-	cmd := CommandContext(ctx, "sh", "-c", "exit 2").
+	cmd := exitCodeCmd(ctx, 2).
 		WithExpectedExitCodes(1).
 		WithExpectedExitCodes(2)
 	err := cmd.Run()
@@ -79,7 +87,7 @@ func TestTracedCmdWithExpectedExitCodesAccumulates(t *testing.T) {
 func TestTracedCmdRunUnexpectedCodeAmongExpected(t *testing.T) {
 	ctx := context.Background()
 	// exit 2 is not in the expected set (only 1 and 5 are)
-	cmd := CommandContext(ctx, "sh", "-c", "exit 2").WithExpectedExitCodes(1, 5)
+	cmd := exitCodeCmd(ctx, 2).WithExpectedExitCodes(1, 5)
 	err := cmd.Run()
 	require.Error(t, err)
 	assert.Equal(t, int32(1), cmd.span.span.Error)

--- a/pkg/fleet/installer/telemetry/cmd_wrapper_test.go
+++ b/pkg/fleet/installer/telemetry/cmd_wrapper_test.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTracedCmdRunSuccess(t *testing.T) {
+	ctx := context.Background()
+	cmd := CommandContext(ctx, "sh", "-c", "exit 0")
+	err := cmd.Run()
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), cmd.span.span.Error)
+}
+
+func TestTracedCmdRunErrorUnexpected(t *testing.T) {
+	ctx := context.Background()
+	cmd := CommandContext(ctx, "sh", "-c", "exit 1")
+	err := cmd.Run()
+	require.Error(t, err)
+	assert.Equal(t, int32(1), cmd.span.span.Error)
+	assert.Equal(t, float64(1), cmd.span.span.Metrics["exit_code"])
+	assert.NotContains(t, cmd.span.span.Meta, "expected_exit_code")
+}
+
+func TestTracedCmdRunErrorExpected(t *testing.T) {
+	ctx := context.Background()
+	cmd := CommandContext(ctx, "sh", "-c", "exit 1").WithExpectedExitCodes(1)
+	err := cmd.Run()
+	// The error is still returned to the caller
+	require.Error(t, err)
+	// But the span is not marked as an error
+	assert.Equal(t, int32(0), cmd.span.span.Error)
+	assert.Equal(t, float64(1), cmd.span.span.Metrics["exit_code"])
+	assert.Equal(t, "true", cmd.span.span.Meta["expected_exit_code"])
+}
+
+func TestTracedCmdRunExpectedNonZeroAndZeroSuccess(t *testing.T) {
+	ctx := context.Background()
+
+	// expected non-zero exit: span not an error, but error still returned
+	cmdErr := CommandContext(ctx, "sh", "-c", "exit 5").WithExpectedExitCodes(5)
+	err := cmdErr.Run()
+	require.Error(t, err)
+	assert.Equal(t, int32(0), cmdErr.span.span.Error)
+	assert.Equal(t, float64(5), cmdErr.span.span.Metrics["exit_code"])
+	assert.Equal(t, "true", cmdErr.span.span.Meta["expected_exit_code"])
+
+	// exit 0 with unrelated expected codes: still succeeds, no expected_exit_code tag
+	cmdOk := CommandContext(ctx, "sh", "-c", "exit 0").WithExpectedExitCodes(5)
+	require.NoError(t, cmdOk.Run())
+	assert.Equal(t, int32(0), cmdOk.span.span.Error)
+	assert.NotContains(t, cmdOk.span.span.Meta, "expected_exit_code")
+}
+
+func TestTracedCmdWithExpectedExitCodesAccumulates(t *testing.T) {
+	ctx := context.Background()
+	// Chained calls should accumulate: both 1 and 2 become expected
+	cmd := CommandContext(ctx, "sh", "-c", "exit 2").
+		WithExpectedExitCodes(1).
+		WithExpectedExitCodes(2)
+	err := cmd.Run()
+	require.Error(t, err)
+	assert.Equal(t, int32(0), cmd.span.span.Error)
+	assert.Equal(t, float64(2), cmd.span.span.Metrics["exit_code"])
+	assert.Equal(t, "true", cmd.span.span.Meta["expected_exit_code"])
+}
+
+func TestTracedCmdRunUnexpectedCodeAmongExpected(t *testing.T) {
+	ctx := context.Background()
+	// exit 2 is not in the expected set (only 1 and 5 are)
+	cmd := CommandContext(ctx, "sh", "-c", "exit 2").WithExpectedExitCodes(1, 5)
+	err := cmd.Run()
+	require.Error(t, err)
+	assert.Equal(t, int32(1), cmd.span.span.Error)
+	assert.Equal(t, float64(2), cmd.span.span.Metrics["exit_code"])
+	assert.NotContains(t, cmd.span.span.Meta, "expected_exit_code")
+}


### PR DESCRIPTION
## Intent

Routine installer commands (`systemctl is-enabled`, `dpkg -s`, `rpm -q`, `aa-status`, `initctl start`) legitimately exit non-zero in normal situations. These were all emitting span errors, generating ~480M false-positive error spans/month in `service:datadog-installer`.

## High-level changes

- Add `WithExpectedExitCodes(...int) *TracedCmd` to `TracedCmd` in `pkg/fleet/installer/telemetry/cmd_wrapper.go`; suppresses `span.Error = 1` for declared exit codes while still returning the error to the caller
- Exit code `0` is always expected (seeded at construction in `CommandContext`)
- Annotate 8 call sites across 4 files with documented expected exit codes (each with a man-page or upstream-issue link)
- Add `cmd_wrapper_test.go` covering success, unexpected error, expected error, accumulation (chained calls), and mixed-set scenarios
- Fix `package_manager.go` to distinguish "package not installed" (exit 1) from system errors on `dpkg -s` / `rpm -q`

## Surface changes

No surface changes. `TracedCmd` is internal to the installer; `WithExpectedExitCodes` is a new method that callers must opt into.

## Automated review results

| Agent | Findings | Fixed | Remaining |
|-------|----------|-------|-----------|
| Go Best Practices | 3 (dead code, test coverage, dead capacity hint) | 3 | 0 |
| Go Code Reviewer (7 sub-reviewers) | 7 (contract clarity, `-1` over-suppression, test precision, error swallowing, comment nit) | 6 | 0 |

## Testing guidelines

```
# Unit tests
dda inv test --targets=./pkg/fleet/installer/telemetry

# Compilation check for annotated call sites
dda inv test --targets=./pkg/fleet/installer/packages/...
```

Post-merge validation: re-run `aggregate_spans` query on `service:datadog-installer operation_name:exec.* status:error` grouped by `resource_name`/`@exit_code` and confirm the systemctl 5/1/4, dpkg 1, rpm 1, and aa-status 2 buckets drop sharply while spans still appear (now `status:ok`) with `exit_code` and `expected_exit_code` tags.