### PR TITLE
Reduce AGENTS.md size to cut per-session token cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,11 +254,7 @@ TODO: Describe specific strategies for managing modules, including any invoke
 tasks.
 
 ## Platform Support
-- **Linux**: Full support (amd64, arm64)
-- **Windows**: Full support (Server 2016+, Windows 10+)
-- **macOS**: Supported
-- **AIX**: No support in this codebase yet, but we are working towards it.
-- **Container**: Docker, Kubernetes, ECS, containerd, and more
+Ships on Linux (amd64, arm64), Windows (amd64), and macOS (amd64, arm64), plus containers (Docker/Kubernetes/ECS/containerd). AIX is not yet supported but in progress.
 
 ## Best Practices
 1. **Always run linters before committing**: `dda inv linter.go`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,13 +256,6 @@ tasks.
 ## Platform Support
 Ships on Linux (amd64, arm64), Windows (amd64), and macOS (amd64, arm64), plus containers (Docker/Kubernetes/ECS/containerd). AIX is not yet supported but in progress.
 
-## Best Practices
-1. **Always run linters before committing**: `dda inv linter.go`
-2. **Always test your changes**: `dda inv test --targets=<your_package>` `bazel test //pkg/... //comp/...`
-3. **Follow Go conventions**: Use gofmt, follow project structure
-4. **Update documentation**: Keep docs in sync with code changes
-6. **Check for security implications**: Review security-sensitive changes carefully
-
 ## Troubleshooting Development Issues
 
 ### Common Build Issues

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,9 +230,7 @@ Secondary CI: pull-request/repository-configuration checks and release automatio
 
 ### Contributing
 PRs should follow `.github/PULL_REQUEST_TEMPLATE.md` and the guidelines in
-`docs/public/guidelines/` (contributing, coding style, components, etc.). When
-a PR changes behavior, configuration options, or APIs, update the corresponding
-documentation in the same PR — not as a follow-up.
+`docs/public/guidelines/` (contributing, coding style, components, etc.).
 
 ## Code Review
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,57 +54,16 @@ build the relevant component with `dda inv *.build`.
 
 ### Common Commands
 
-#### Building
-
 ```bash
-# install dda on mac OS
-brew install --cask dda
-
-# Install development tools
-dda inv install-tools
-
-# Build the main agent
-dda inv agent.build --build-exclude=systemd
-
-# Build specific components
-dda inv dogstatsd.build
-dda inv trace-agent.build
-dda inv system-probe.build
-
-# Build specific packages
-bazel build //packages/agent/linux:debian
-
-# Keep BUILD.bazel files in sync with go dependencies
-dda inv tidy
-```
-
-#### Testing
-```bash
-# Run all tests
-dda inv test
-
-# Test specific package
-dda inv test --targets=./pkg/aggregator
-bazel test //pkg/aggregator/...
-
-# Run Go linters
-dda inv linter.go
-
-# Run all linters
-dda inv linter.all
-```
-
-#### Running Locally
-```bash
-# Create dev config with testing API key
-echo "api_key: 0000001" > dev/dist/datadog.yaml
-
-# Run the agent
-./bin/agent/agent run -c bin/agent/dist/datadog.yaml
+dda inv install-tools                                 # one-time: install dev tooling
+dda inv agent.build --build-exclude=systemd           # build the main agent
+dda inv <component>.build                             # build a component (dogstatsd, trace-agent, system-probe, …)
+dda inv linter.all                                    # run all linters
+./bin/agent/agent run -c bin/agent/dist/datadog.yaml  # run the built agent
 ```
 
 ### Development Configuration
-The development configuration file should be placed at `dev/dist/datadog.yaml`. After building, it gets copied to `bin/agent/dist/datadog.yaml`.
+Place the dev config at `dev/dist/datadog.yaml` (e.g. `echo "api_key: 0000001" > dev/dist/datadog.yaml`); after building it is copied to `bin/agent/dist/datadog.yaml`.
 
 ## Key Components
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ The Datadog Agent collects metrics, traces, logs, and security events and forwar
 
 - `/packages/` - The declarations of what goes into each package we build for distribution.
 
-- `/omnibus/` - The legacy build system. Still in used, but we are trying not to add to it.
+- `/omnibus/` - The legacy build system. Still in use, but we are trying not to add to it.
 
 
 ## Development Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,9 +164,7 @@ Key Bazel macros:
 ## Testing Strategy
 
 ### Unit Tests
-- Go tests run via `dda inv test` (not raw `go test`)
-- Python tests using pytest
-- Run with `dda inv test --targets=<package>`
+Go tests run via `dda inv test --targets=<package>` (see the `dda inv` table above) or `bazel test //pkg/... //comp/...`; Python checks use pytest.
 
 ### End-to-End Tests
 - E2E tests live in `test/new-e2e/tests/` and use the framework in `test/e2e-framework/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,37 +129,7 @@ The development configuration file should be placed at `dev/dist/datadog.yaml`. 
 - Quick reference: `.cursor/rules/system_probe_modules.mdc` for common patterns and pitfalls
 
 ### eBPF Bazel Build
-
-eBPF programs, runtime compilation bundles, and cgo godefs type definitions
-are built with Bazel. Two convenience targets in `pkg/ebpf/BUILD.bazel`
-cover the most common workflows:
-
-```bash
-# Build every eBPF .o program and runtime flattened .c file at once
-bazel build //pkg/ebpf:all_ebpf_programs
-
-# Verify all committed cgo godefs files are up to date.
-# Covers both Linux and Windows targets; incompatible tests are
-# skipped automatically via target_compatible_with.
-bazel test //pkg/ebpf:verify_generated_files
-```
-
-When a `verify_generated_files` test fails, run the corresponding
-`write_source_file` target to update the committed file:
-
-```bash
-# Update a single cgo godefs output
-bazel run //pkg/ebpf:types_godefs
-```
-
-Runtime compilation integrity hash files (`pkg/ebpf/bytecode/runtime/*.go`) are
-`.gitignored` and generated during the build by `bazel_build_ebpf()`.  To update
-one locally: `bazel run //pkg/ebpf/bytecode:<name>_verify`.
-
-Key Bazel macros:
-- `ebpf_prog` / `ebpf_program_suite` (`bazel/rules/ebpf/ebpf.bzl`) — compile `.c` → `.o`
-- `cgo_godefs` (`bazel/rules/ebpf/cgo_godefs.bzl`) — `go tool cgo -godefs` + `write_source_file` verification
-- `runtime_compilation_bundle` (`bazel/rules/ebpf/runtime_compilation.bzl`) — flatten headers + generate integrity hash `.go` file
+eBPF programs, runtime-compilation bundles, and cgo godefs are built with Bazel — see `bazel/AGENTS.md` (§ eBPF programs and code generation).
 
 ## Testing Strategy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,21 +179,10 @@ Go build tags control feature inclusion, some examples are:
 
 #### Fetching CI job logs locally
 
-`gitlab.ddbuild.io` is gated behind Google OAuth, so `curl` and similar
-unauthenticated HTTP clients receive an auth redirect instead of the trace.
-Use the in-repo invoke task to print a job's full log:
-
-```bash
-dda inv gitlab.print-job-trace <job_id>
-```
-
-The job ID is the trailing path component of any
-`https://gitlab.ddbuild.io/datadog/datadog-agent/builds/<job_id>` URL —
-those appear in the `dd-gitlab/*` rows of `gh pr checks <pr_number> --repo
-DataDog/datadog-agent`. Authentication is handled by `dda` via the
-`agent-ci-gitlab-short-lived-tokens` feature flag, so no manual token setup
-is required. Run `dda inv -l | grep gitlab` for related tasks
-(`gitlab.print-job`, `gitlab.print-pipeline`, ...).
+`gitlab.ddbuild.io` is OAuth-gated, so `curl` can't fetch traces. Use
+`dda inv gitlab.print-job-trace <job_id>` (`dda` handles auth). The `<job_id>`
+is the trailing path of a `.../builds/<job_id>` URL, found in the `dd-gitlab/*`
+rows of `gh pr checks <pr_number>`. See `dda inv -l | grep gitlab` for more.
 
 ### GitHub Actions
 Secondary CI: pull-request/repository-configuration checks and release automation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,6 @@ Go tests run via `dda inv test --targets=<package>` (see the `dda inv` table abo
 - Run locally: `dda inv new-e2e-tests.run --targets=./tests/<area>/...`
 
 ### Linting
-- Go: golangci-lint via `dda inv linter.go`
 - Python: various linters via `dda inv linter.python`
 - YAML: yamllint
 - Shell: shellcheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ Go tests run via `dda inv test --targets=<package>` (see the `dda inv` table abo
 ### End-to-End Tests
 - E2E tests live in `test/new-e2e/tests/` and use the framework in `test/e2e-framework/`
 - Tests provision real AWS, GCP or Azure infrastructure, deploy the agent, and assert payloads
-  arrive in **fakeintake** (a mock Datadog intake). By default the fakeintake forwards payloads to `dddev` org account.
+  arrive in **fakeintake**. By default it forwards payloads to `dddev` org account.
 - Key docs: `test/e2e-framework/AGENTS.md` (framework), `test/fakeintake/AGENTS.md`
   (intake mock), `docs/public/how-to/test/e2e.md` (setup & running)
 - Use `/write-e2e` skill or read those docs directly to write new E2E tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Datadog Agent - Project Overview for AI coding assistant
 
 ## Project Summary
-The Datadog Agent is a comprehensive monitoring and observability agent written primarily in Go. It collects metrics, traces, logs, and security events from systems and applications, forwarding them to the Datadog platform. This is the main repository for Agent versions 6 and 7.
+The Datadog Agent collects metrics, traces, logs, and security events and forwards them to the Datadog platform. Written primarily in Go; this is the main repository for Agent versions 6 and 7.
 
 ## Project Structure
 
@@ -17,20 +17,8 @@ The Datadog Agent is a comprehensive monitoring and observability agent written 
   - `privateactionrunner/` - Executing actions
 
 - `/pkg/` - Core Go packages and libraries
-  - `aggregator/` - Metrics aggregation
-  - `collector/` - Check scheduling and execution
-  - `config/` - Configuration management
-  - `logs/` - Log collection and processing
-  - `metrics/` - Metrics types and handling
-  - `network/` - Network monitoring
-  - `security/` - Security monitoring components
-  - `trace/` - APM tracing components
 
-- `/comp/` - Component-based architecture modules
-  - `core/` - Core components
-  - `metadata/` - Metadata collection
-  - `logs/` - Log components
-  - `trace/` - Trace components
+- `/comp/` - Component-based architecture modules (Fx components)
 
 - `/tasks/` - Python invoke tasks for development
   - Build, test, lint, and deployment automation
@@ -198,12 +186,7 @@ Key Bazel macros:
 ## Build System
 
 ### Invoke Tasks
-The project uses Python's Invoke framework with custom tasks. Main task categories:
-- `agent.*` - Core agent tasks
-- `test` - Testing tasks
-- `linter.*` - Linting tasks
-- `docker.*` - Docker image tasks
-- `release.*` - Release management
+The project uses Python's Invoke framework for custom tasks. Run `dda inv -l` to list them.
 
 ### Build Tags
 Go build tags control feature inclusion, some examples are:
@@ -215,18 +198,10 @@ Go build tags control feature inclusion, some examples are:
 - and MANY more, refer to ./tasks/build_tags.py for a full reference.
 
 ## Important Files
-
-### Configuration
 - `datadog.yaml` - Main agent configuration
 - `modules.yml` - Go module definitions
 - `release.json` - Release version information
 - `.gitlab-ci.yml` - CI/CD pipeline configuration
-
-### Documentation
-- `/docs/` - Internal documentation
-- `/docs/dev/` - Developer guides
-- `README.md` - Project overview
-- `CONTRIBUTING.md` - Contribution guidelines
 
 ## CI/CD Pipeline
 
@@ -254,9 +229,7 @@ is required. Run `dda inv -l | grep gitlab` for related tasks
 (`gitlab.print-job`, `gitlab.print-pipeline`, ...).
 
 ### GitHub Actions
-- Secondary CI for specific workflows
-- Tests about the pull-request settings or repository configuration
-- Release automation workflows
+Secondary CI: pull-request/repository-configuration checks and release automation.
 
 ### Contributing
 PRs should follow `.github/PULL_REQUEST_TEMPLATE.md` and the guidelines in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,11 +207,6 @@ See the marketplace README for installation instructions.
 - Never commit API keys or secrets
 - Use secret backend for credentials
 
-## Module System
-The project uses Go modules with multiple sub-modules.
-TODO: Describe specific strategies for managing modules, including any invoke
-tasks.
-
 ## Platform Support
 Ships on Linux (amd64, arm64), Windows (amd64), and macOS (amd64, arm64), plus containers (Docker/Kubernetes/ECS/containerd). AIX is not yet supported but in progress.
 

--- a/bazel/AGENTS.md
+++ b/bazel/AGENTS.md
@@ -951,6 +951,39 @@ Use `query` / `cquery` to investigate build size regressions before profiling ex
 - Many new targets configured → diamond dependencies or platform proliferation.
 - Many new actions created → check `aquery --output=summary`.
 
+## eBPF programs and code generation
+
+eBPF programs, runtime compilation bundles, and cgo godefs type definitions
+are built with Bazel. Two convenience targets in `pkg/ebpf/BUILD.bazel`
+cover the most common workflows:
+
+```bash
+# Build every eBPF .o program and runtime flattened .c file at once
+bazel build //pkg/ebpf:all_ebpf_programs
+
+# Verify all committed cgo godefs files are up to date.
+# Covers both Linux and Windows targets; incompatible tests are
+# skipped automatically via target_compatible_with.
+bazel test //pkg/ebpf:verify_generated_files
+```
+
+When a `verify_generated_files` test fails, run the corresponding
+`write_source_file` target to update the committed file:
+
+```bash
+# Update a single cgo godefs output
+bazel run //pkg/ebpf:types_godefs
+```
+
+Runtime compilation integrity hash files (`pkg/ebpf/bytecode/runtime/*.go`) are
+`.gitignored` and generated during the build by `bazel_build_ebpf()`.  To update
+one locally: `bazel run //pkg/ebpf/bytecode:<name>_verify`.
+
+Key Bazel macros:
+- `ebpf_prog` / `ebpf_program_suite` (`bazel/rules/ebpf/ebpf.bzl`) — compile `.c` → `.o`
+- `cgo_godefs` (`bazel/rules/ebpf/cgo_godefs.bzl`) — `go tool cgo -godefs` + `write_source_file` verification
+- `runtime_compilation_bundle` (`bazel/rules/ebpf/runtime_compilation.bzl`) — flatten headers + generate integrity hash `.go` file
+
 ## See also
 
 - [Rust in the Datadog Agent](../docs/public/guidelines/languages/RUST.md)


### PR DESCRIPTION
### What does this PR do?

Trims the repo-root `AGENTS.md` from **397 → 267 lines (−33%)** without losing actionable guidance. Changes are split into focused, one-per-item commits:

- **Filler / low-signal prose** removed (summary, `/pkg`+`/comp` glosses, Invoke-task list, generic Important-Files entries, GitHub Actions bullets).
- **Duplicated instructions** stated once (Unit Tests, Go linting, fakeintake definition, "update docs in same PR", Platform Support, and the redundant Best Practices block — which also had a `1-2-3-4-6` numbering bug).
- **eBPF Bazel build** details relocated to `bazel/AGENTS.md` (verbatim), which the file-hierarchy note already designates as the Bazel home; root keeps a one-line pointer.
- **"Fetching CI job logs"** compressed in place (~17→4 lines) — kept here rather than delegated to skills, since those CI skills are marketplace plugins, not part of this repo.
- **"Common Commands"** cookbook compacted (~50→6 lines): kept the canonical build/run/linter-all commands, dropped setup-only and table-duplicated lines.
- **Fixes**: typo ("in used" → "in use") and removal of the stub `Module System` section (heading + unfilled `TODO:` placeholder).

### Motivation

`AGENTS.md` is loaded into every AI coding session. Filler, duplication, and niche content that belongs in sub-`AGENTS.md` files cost tokens on every new session while analyzing instructions that aren't needed.

### Describe how you validated your changes

- Verified all removed content is either restated elsewhere in the repo (quoted in each commit body) or relocated (eBPF → `bazel/AGENTS.md`).

### Additional Notes

Each removal commit quotes the canonical source that makes the deleted text redundant, so reviewers can verify nothing actionable was lost.