### PR TITLE
[EBPF] gpu: fix panic when there are ports that do not support nvlink fields

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/helpers.go
+++ b/pkg/collector/corechecks/gpu/nvidia/helpers.go
@@ -257,7 +257,7 @@ func portIsAlwaysSupported(_ int) ([]*Metric, error) {
 func getSupportedNvlinkPorts(device ddnvml.Device, metricCollector func(int) ([]*Metric, error)) ([]int, error) {
 	totalPorts, err := GetNVLinkCount(device)
 	if err != nil {
-		if ddnvml.IsAPIUnsupportedOnDevice(err, device) {
+		if ddnvml.IsAPIUnsupportedOnDevice(err, device) || errors.Is(err, errUnsupportedDevice) {
 			return nil, fmt.Errorf("%w: get NVLink link count: %w", errUnsupportedDevice, err)
 		}
 		return nil, fmt.Errorf("get NVLink link count: %w", err)
@@ -274,7 +274,7 @@ func getSupportedNvlinkPorts(device ddnvml.Device, metricCollector func(int) ([]
 		if err != nil {
 			portErrors = append(portErrors, fmt.Errorf("collect metrics for port %d: %w", port, err))
 
-			if ddnvml.IsAPIUnsupportedOnDevice(err, device) {
+			if ddnvml.IsAPIUnsupportedOnDevice(err, device) || errors.Is(err, errUnsupportedDevice) {
 				// only ignore ports if the error is because the API is unsupported
 				continue
 			}

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
@@ -158,6 +158,11 @@ func (c *nvlinkFieldsCollector) Collect() ([]*Metric, error) {
 }
 
 func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
+	// Metrics might have been removed in the previous run, so we check if there are any metrics to collect.
+	if len(c.metrics) == 0 {
+		return nil, fmt.Errorf("%w: no metrics to collect", errUnsupportedDevice)
+	}
+
 	fields := make([]nvml.FieldValue, len(c.metrics))
 	for i, metric := range c.metrics {
 		fields[i].FieldId = metric.fieldValueID
@@ -219,6 +224,11 @@ func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
 		if fieldValueMetric.addTotalMetric {
 			c.totals[fieldValueMetric.fieldValueID] += value
 		}
+	}
+
+	if len(c.metrics) == 0 {
+		// All metrics were removed, so we return an error to indicate that the device is unsupported.
+		return nil, fmt.Errorf("%w: no metrics to collect", errUnsupportedDevice)
 	}
 
 	return metrics, errors.Join(errs...)

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -194,6 +194,40 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 	require.NotContains(t, requestedFieldsByScope[1], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
 }
 
+func TestNVLinkFieldsCollectorCollectDoesNotPanicWhenMetricsBecomeEmpty(t *testing.T) {
+	device := setupMockDevice(t, func(d *mock.Device) *mock.Device {
+		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
+			if len(fv) == 0 {
+				panic("GetFieldValues called with empty fields")
+			}
+			for i := range fv {
+				fv[i].NvmlReturn = uint32(nvml.ERROR_NOT_SUPPORTED)
+			}
+			return nvml.SUCCESS
+		}
+		return d
+	})
+
+	collector := &nvlinkFieldsCollector{
+		device: device,
+		ports:  []int{1, 2},
+		metrics: []nvlinkFieldValueMetric{
+			{
+				name:         "nvlink.tx.discards",
+				fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
+				metricType:   metrics.GaugeType,
+			},
+		},
+	}
+
+	var err error
+	require.NotPanics(t, func() {
+		_, err = collector.Collect()
+	})
+	require.ErrorIs(t, err, errUnsupportedDevice)
+	require.ErrorContains(t, err, "no metrics to collect")
+}
+
 func TestFieldsCollector_NvlinkSpeedPriority(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
### What does this PR do?

Fix a panic in a rare case where there could be NVLink links but none of the field values were supported.

### Motivation

Fix a panic

### Describe how you validated your changes

Manually checked in the instance where it was failing, added a unit test to cover the regression.

### Additional Notes
