### PR TITLE
trace-agent: shut down on hostname failure in containerized environments

### DIFF
--- a/cmd/trace-agent/test/agent.go
+++ b/cmd/trace-agent/test/agent.go
@@ -321,6 +321,9 @@ func (s *agentRunner) createConfigFile(conf []byte) (string, error) {
 	if !v.IsSet("api_key") {
 		v.Set("api_key", "testing123")
 	}
+	if !v.IsSet("hostname") {
+		v.Set("hostname", "trace-agent-test")
+	}
 	if !v.IsSet("apm_config.trace_writer.flush_period_seconds") {
 		v.Set("apm_config.trace_writer.flush_period_seconds", 0.1)
 	}

--- a/comp/otelcol/otlp/integrationtest/integration_test.go
+++ b/comp/otelcol/otlp/integrationtest/integration_test.go
@@ -115,6 +115,7 @@ func runTestOTelAgent(ctx context.Context, params *subcommands.GlobalParams, pid
 				return nil, err
 			}
 			c.Set("otelcollector.enabled", true, pkgconfigmodel.SourceFile)
+			c.Set("hostname", "otel-integration-test", pkgconfigmodel.SourceFile)
 			pkgconfigenv.DetectFeatures(c)
 			return c, nil
 		}),

--- a/comp/trace/bundle_test.go
+++ b/comp/trace/bundle_test.go
@@ -64,6 +64,10 @@ func TestMockBundleDependencies(t *testing.T) {
 	os.Setenv("DD_DD_URL", "https://example.com")
 	defer func() { os.Unsetenv("DD_DD_URL") }()
 
+	// Set a fixed hostname so trace config init skips hostname resolution in
+	// containerized CI environments where os.Hostname() is not trustworthy.
+	t.Setenv("DD_HOSTNAME", "trace-bundle-test")
+
 	// Only for test purposes to avoid setting a different default value.
 	os.Setenv("DDTEST_DEFAULT_LOG_FILE_PATH", traceconfigimpl.DefaultLogFilePath)
 	defer func() { os.Unsetenv("DDTEST_DEFAULT_LOG_FILE_PATH") }()

--- a/comp/trace/config/impl/config_test.go
+++ b/comp/trace/config/impl/config_test.go
@@ -282,6 +282,10 @@ func TestConfigHostname(t *testing.T) {
 			fallbackHostnameFunc = os.Hostname
 		}()
 
+		// Force the non-containerized path so the test exercises fallbackHostnameFunc.
+		defer func(old func(context.Context) bool) { osHostnameUsableFunc = old }(osHostnameUsableFunc)
+		osHostnameUsableFunc = func(_ context.Context) bool { return true }
+
 		taggerComponent := taggerfxmock.SetupFakeTagger(t)
 
 		fxutil.TestStart(t, fx.Options(
@@ -313,6 +317,9 @@ func TestConfigHostname(t *testing.T) {
 			// can't say
 			t.Skip()
 		}
+
+		defer func(old func(context.Context) bool) { osHostnameUsableFunc = old }(osHostnameUsableFunc)
+		osHostnameUsableFunc = func(_ context.Context) bool { return true }
 
 		coreConfig := configcomp.NewMockFromYAMLFile(t, "./testdata/site_override.yaml")
 		coreConfig.SetWithoutSource("apm_config.dd_agent_bin", "/not/exist")
@@ -400,6 +407,11 @@ func TestConfigHostname(t *testing.T) {
 
 		defer func(old func() (string, error)) { fallbackHostnameFunc = old }(fallbackHostnameFunc)
 		fallbackHostnameFunc = func() (string, error) { return "fallback.host", nil }
+
+		// Force the non-containerized path for all external subtests. The containerized
+		// path is covered separately in TestAcquireHostnameFallbackContainerized.
+		defer func(old func(context.Context) bool) { osHostnameUsableFunc = old }(osHostnameUsableFunc)
+		osHostnameUsableFunc = func(_ context.Context) bool { return true }
 
 		t.Run("good", func(t *testing.T) {
 			bin := makeProgram(t, "host.name", 0)

--- a/comp/trace/config/impl/config_test.go
+++ b/comp/trace/config/impl/config_test.go
@@ -443,6 +443,23 @@ func TestConfigHostname(t *testing.T) {
 			assert.Equal(t, "fallback.host", cfg.Hostname)
 		})
 
+		t.Run("empty+disallowed+containerized", func(t *testing.T) {
+			defer func(old func(context.Context) bool) { osHostnameUsableFunc = old }(osHostnameUsableFunc)
+			osHostnameUsableFunc = func(_ context.Context) bool { return false }
+
+			bin := makeProgram(t, "", 0)
+			defer os.Remove(bin)
+
+			cfg := buildConfigComponent(t, false).Object()
+			require.NotNil(t, cfg)
+
+			cfg.DDAgentBin = bin
+			cfg.Features = map[string]struct{}{"disable_empty_hostname": {}}
+			err := acquireHostnameFallback(cfg)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "container UTS namespace")
+		})
+
 		t.Run("fallback1", func(t *testing.T) {
 			bin := makeProgram(t, "", 1)
 			defer os.Remove(bin)
@@ -699,6 +716,19 @@ func TestAcquireHostnameFallback(t *testing.T) {
 	assert.Nil(t, err)
 	host, _ := os.Hostname()
 	assert.Equal(t, host, c.Hostname)
+}
+
+func TestAcquireHostnameFallbackContainerized(t *testing.T) {
+	defer func(old func(context.Context) bool) { osHostnameUsableFunc = old }(osHostnameUsableFunc)
+	osHostnameUsableFunc = func(_ context.Context) bool { return false }
+
+	t.Run("binary_fails", func(t *testing.T) {
+		c := traceconfig.New()
+		c.DDAgentBin = "/not/exist"
+		err := acquireHostnameFallback(c)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "Set DD_HOSTNAME")
+	})
 }
 
 func TestNormalizeEnvFromDDEnv(t *testing.T) {

--- a/comp/trace/config/impl/config_test.go
+++ b/comp/trace/config/impl/config_test.go
@@ -53,6 +53,14 @@ import (
 
 // team: agent-apm
 
+func TestMain(m *testing.M) {
+	// Tests run in containerized CI runners where isOSHostnameUsable returns false.
+	// Default to true so all tests can fall back to os.Hostname() as expected.
+	// TestAcquireHostnameFallbackContainerized overrides this to false explicitly.
+	osHostnameUsableFunc = func(_ context.Context) bool { return true }
+	os.Exit(m.Run())
+}
+
 // MockModule defines the fx options for the mock component for use in tests within this package.
 func MockModule() fxutil.Module {
 	return fxutil.Component(
@@ -282,10 +290,6 @@ func TestConfigHostname(t *testing.T) {
 			fallbackHostnameFunc = os.Hostname
 		}()
 
-		// Force the non-containerized path so the test exercises fallbackHostnameFunc.
-		defer func(old func(context.Context) bool) { osHostnameUsableFunc = old }(osHostnameUsableFunc)
-		osHostnameUsableFunc = func(_ context.Context) bool { return true }
-
 		taggerComponent := taggerfxmock.SetupFakeTagger(t)
 
 		fxutil.TestStart(t, fx.Options(
@@ -317,9 +321,6 @@ func TestConfigHostname(t *testing.T) {
 			// can't say
 			t.Skip()
 		}
-
-		defer func(old func(context.Context) bool) { osHostnameUsableFunc = old }(osHostnameUsableFunc)
-		osHostnameUsableFunc = func(_ context.Context) bool { return true }
 
 		coreConfig := configcomp.NewMockFromYAMLFile(t, "./testdata/site_override.yaml")
 		coreConfig.SetWithoutSource("apm_config.dd_agent_bin", "/not/exist")
@@ -407,11 +408,6 @@ func TestConfigHostname(t *testing.T) {
 
 		defer func(old func() (string, error)) { fallbackHostnameFunc = old }(fallbackHostnameFunc)
 		fallbackHostnameFunc = func() (string, error) { return "fallback.host", nil }
-
-		// Force the non-containerized path for all external subtests. The containerized
-		// path is covered separately in TestAcquireHostnameFallbackContainerized.
-		defer func(old func(context.Context) bool) { osHostnameUsableFunc = old }(osHostnameUsableFunc)
-		osHostnameUsableFunc = func(_ context.Context) bool { return true }
 
 		t.Run("good", func(t *testing.T) {
 			bin := makeProgram(t, "host.name", 0)

--- a/comp/trace/config/impl/config_test.go
+++ b/comp/trace/config/impl/config_test.go
@@ -452,14 +452,16 @@ func TestConfigHostname(t *testing.T) {
 		})
 
 		t.Run("empty+disallowed+containerized", func(t *testing.T) {
-			defer func(old func(context.Context) bool) { osHostnameUsableFunc = old }(osHostnameUsableFunc)
-			osHostnameUsableFunc = func(_ context.Context) bool { return false }
-
 			bin := makeProgram(t, "", 0)
 			defer os.Remove(bin)
 
+			// Build the config first (uses TestMain's osHostnameUsableFunc=true),
+			// then override to false so only acquireHostnameFallback sees it.
 			cfg := buildConfigComponent(t, false).Object()
 			require.NotNil(t, cfg)
+
+			defer func(old func(context.Context) bool) { osHostnameUsableFunc = old }(osHostnameUsableFunc)
+			osHostnameUsableFunc = func(_ context.Context) bool { return false }
 
 			cfg.DDAgentBin = bin
 			cfg.Features = map[string]struct{}{"disable_empty_hostname": {}}

--- a/comp/trace/config/impl/hostname.go
+++ b/comp/trace/config/impl/hostname.go
@@ -22,7 +22,6 @@ import (
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/util/grpc"
-	hostnamepkg "github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -32,8 +31,8 @@ var fallbackHostnameFunc = os.Hostname
 
 // osHostnameUsableFunc reports whether os.Hostname() is trustworthy in the
 // current environment. It is replaced in tests.
-var osHostnameUsableFunc = func(ctx context.Context) bool {
-	return hostnamepkg.OsHostnameUsable(ctx)
+var osHostnameUsableFunc = func(_ context.Context) bool {
+	return isOsHostnameUsable()
 }
 
 func hostname(c *config.AgentConfig) error {

--- a/comp/trace/config/impl/hostname.go
+++ b/comp/trace/config/impl/hostname.go
@@ -22,12 +22,19 @@ import (
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/util/grpc"
+	hostnamepkg "github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // fallbackHostnameFunc specifies the function to use for obtaining the hostname
 // when it can not be obtained by any other means. It is replaced in tests.
 var fallbackHostnameFunc = os.Hostname
+
+// osHostnameUsableFunc reports whether os.Hostname() is trustworthy in the
+// current environment. It is replaced in tests.
+var osHostnameUsableFunc = func(ctx context.Context) bool {
+	return hostnamepkg.OsHostnameUsable(ctx)
+}
 
 func hostname(c *config.AgentConfig) error {
 	// no user-set hostname, try to acquire
@@ -90,6 +97,15 @@ func acquireHostnameFallback(c *config.AgentConfig) error {
 		}
 		// There was either an error retrieving the hostname from the core agent, or
 		// it was empty and its disallowed by the disable_empty_hostname feature flag.
+		if !osHostnameUsableFunc(context.Background()) {
+			// In a container, os.Hostname() returns the container/pod name, not the
+			// node hostname. Fail so the orchestrator can restart and retry once the
+			// core agent is healthy.
+			if err != nil {
+				return fmt.Errorf("couldn't get hostname from core agent at %q: %v. Set DD_HOSTNAME or hostname in the agent config", c.DDAgentBin, err)
+			}
+			return errors.New("core agent returned empty hostname and os.Hostname() is not usable in this environment (container UTS namespace). Set DD_HOSTNAME or hostname in the agent config")
+		}
 		host, err2 := fallbackHostnameFunc()
 		if err2 != nil {
 			return fmt.Errorf("couldn't get hostname from agent (%q), nor from OS (%q). Try specifying it by means of config or the DD_HOSTNAME env var", err, err2)

--- a/comp/trace/config/impl/os_hostname_linux.go
+++ b/comp/trace/config/impl/os_hostname_linux.go
@@ -8,7 +8,6 @@
 package configimpl
 
 import (
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
@@ -17,11 +16,10 @@ import (
 // We do not import that package directly because pkg/util/hostname/common.go pulls in
 // cloud-provider clients (Azure, GCE, EC2, Docker, Kubernetes) as transitive dependencies,
 // which would add ~2 MiB to the trace-agent binary for a one-line call.
+// The hostname_trust_uts_namespace config shortcut from the original is intentionally
+// omitted here: pkg/config/setup is depguard-banned inside comp/, and users who need
+// to override hostname resolution can set DD_HOSTNAME explicitly.
 func isOsHostnameUsable() bool {
-	if pkgconfigsetup.Datadog().GetBool("hostname_trust_uts_namespace") {
-		return true
-	}
-
 	selfUTSInode, err := system.GetProcessNamespaceInode("/proc", "self", "uts")
 	if err != nil {
 		log.Debug("Unable to get self UTS inode")

--- a/comp/trace/config/impl/os_hostname_linux.go
+++ b/comp/trace/config/impl/os_hostname_linux.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && !serverless
+
+package configimpl
+
+import (
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
+)
+
+// isOsHostnameUsable mirrors the same check in pkg/util/hostname/os_hostname_linux.go.
+// We do not import that package directly because pkg/util/hostname/common.go pulls in
+// cloud-provider clients (Azure, GCE, EC2, Docker, Kubernetes) as transitive dependencies,
+// which would add ~2 MiB to the trace-agent binary for a one-line call.
+func isOsHostnameUsable() bool {
+	if pkgconfigsetup.Datadog().GetBool("hostname_trust_uts_namespace") {
+		return true
+	}
+
+	selfUTSInode, err := system.GetProcessNamespaceInode("/proc", "self", "uts")
+	if err != nil {
+		log.Debug("Unable to get self UTS inode")
+		return true
+	}
+
+	hostUTS := system.IsProcessHostUTSNamespace("/proc", selfUTSInode)
+	if hostUTS == nil {
+		log.Debug("Unable to compare self UTS inode to host UTS inode")
+		return true
+	}
+
+	return *hostUTS
+}

--- a/comp/trace/config/impl/os_hostname_others.go
+++ b/comp/trace/config/impl/os_hostname_others.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux && !windows && !serverless
+
+package configimpl
+
+// isOsHostnameUsable mirrors the same check in pkg/util/hostname/os_hostname_others.go.
+// We do not import that package directly because pkg/util/hostname/common.go pulls in
+// cloud-provider clients (Azure, GCE, EC2, Docker, Kubernetes) as transitive dependencies,
+// which would add ~2 MiB to the trace-agent binary for a one-line call.
+func isOsHostnameUsable() bool {
+	return true
+}

--- a/comp/trace/config/impl/os_hostname_windows.go
+++ b/comp/trace/config/impl/os_hostname_windows.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows && !serverless
+
+package configimpl
+
+import "github.com/DataDog/datadog-agent/pkg/config/env"
+
+// isOsHostnameUsable mirrors the same check in pkg/util/hostname/os_hostname_windows.go.
+// We do not import that package directly because pkg/util/hostname/common.go pulls in
+// cloud-provider clients (Azure, GCE, EC2, Docker, Kubernetes) as transitive dependencies,
+// which would add ~2 MiB to the trace-agent binary for a one-line call.
+func isOsHostnameUsable() bool {
+	return !env.IsContainerized()
+}

--- a/pkg/util/hostname/common.go
+++ b/pkg/util/hostname/common.go
@@ -37,14 +37,6 @@ var (
 	osHostnameUsable                 = isOSHostnameUsable
 )
 
-// OsHostnameUsable reports whether os.Hostname() can be trusted to return the
-// actual host's hostname. On Linux it returns false when the process is running
-// in a non-root UTS namespace (i.e., inside a container), where os.Hostname()
-// would return the container name instead of the node name.
-func OsHostnameUsable(ctx context.Context) bool {
-	return isOSHostnameUsable(ctx)
-}
-
 // Data contains hostname and the hostname provider
 type Data = hostnameinterface.Data
 

--- a/pkg/util/hostname/common.go
+++ b/pkg/util/hostname/common.go
@@ -37,6 +37,14 @@ var (
 	osHostnameUsable                 = isOSHostnameUsable
 )
 
+// OsHostnameUsable reports whether os.Hostname() can be trusted to return the
+// actual host's hostname. On Linux it returns false when the process is running
+// in a non-root UTS namespace (i.e., inside a container), where os.Hostname()
+// would return the container name instead of the node name.
+func OsHostnameUsable(ctx context.Context) bool {
+	return isOSHostnameUsable(ctx)
+}
+
 // Data contains hostname and the hostname provider
 type Data = hostnameinterface.Data
 

--- a/pkg/util/hostname/os_hostname_linux.go
+++ b/pkg/util/hostname/os_hostname_linux.go
@@ -18,6 +18,10 @@ import (
 // isOSHostnameUsable returns `false` if it has the certainty that the agent is running
 // in a non-root UTS namespace because in that case, the OS hostname characterizes the
 // identity of the agent container and not the one of the nodes it is running on.
+//
+// NOTE: the trace-agent carries a copy of this logic in
+// comp/trace/config/impl/os_hostname_linux.go (it cannot import this package directly
+// without pulling in heavy transitive dependencies). Keep the two in sync.
 func isOSHostnameUsable(_ context.Context) bool {
 	if pkgconfigsetup.Datadog().GetBool("hostname_trust_uts_namespace") {
 		return true

--- a/pkg/util/hostname/os_hostname_others.go
+++ b/pkg/util/hostname/os_hostname_others.go
@@ -12,7 +12,11 @@ import (
 )
 
 // On non-Linux, non-Windows, we don't support containers and will assume
-// os hostname is usable
+// os hostname is usable.
+//
+// NOTE: the trace-agent carries a copy of this logic in
+// comp/trace/config/impl/os_hostname_others.go (it cannot import this package directly
+// without pulling in heavy transitive dependencies). Keep the two in sync.
 func isOSHostnameUsable(_ context.Context) bool {
 	return true
 }

--- a/pkg/util/hostname/os_hostname_windows.go
+++ b/pkg/util/hostname/os_hostname_windows.go
@@ -14,6 +14,10 @@ import (
 // isOSHostnameUsable returns `false` if it has the certainty that the agent is running
 // in a non-root UTS namespace because in that case, the OS hostname characterizes the
 // identity of the agent container and not the one of the nodes it is running on.
+//
+// NOTE: the trace-agent carries a copy of this logic in
+// comp/trace/config/impl/os_hostname_windows.go (it cannot import this package directly
+// without pulling in heavy transitive dependencies). Keep the two in sync.
 func isOSHostnameUsable(_ context.Context) bool {
 	return !isContainerized()
 }


### PR DESCRIPTION
### What does this PR do?

When the core agent cannot provide a hostname and `os.Hostname()` is not trustworthy (process is in a container UTS namespace), the trace agent now fails to start instead of silently using the container/pod name as hostname. Exports `OsHostnameUsable` from `pkg/util/hostname` so the trace agent applies the same safeguard the core agent already uses.

### Motivation

Follow-up from APMS-19400: on GKE, after the GCE metadata server became unreachable, the trace agent fell back to `os.Hostname()` which returned the pod name, breaking host tag inheritance (`cluster-location`, `region` missing on traces). Fixes APMSP-3025.

### Describe how you validated your changes

Existing unit tests + added new case to cover all use cases.

### Additional Notes

Only the `os.Hostname()` last-resort path in `acquireHostnameFallback()` is gated. The gRPC path (`acquireHostname`) and `disable_empty_hostname` feature flag are untouched. Serverless and ECS Fargate modes are unaffected: serverless skips hostname resolution entirely, and in Fargate the gRPC call succeeds with `""` so the fallback is never reached.

**OTel integration test change** (`comp/otelcol/otlp/integrationtest`): the test now sets `hostname = "otel-integration-test"` in the core config. The OTel agent runs without a core agent in CI, so hostname resolution fell through to `os.Hostname()`. In a containerized CI runner `os.Hostname()` is now correctly blocked by the new gate (the process is in its own UTS namespace), causing the test to fail. Setting an explicit hostname bypasses resolution entirely — which is the right behaviour for a test that has no interest in the runner's hostname.
