### PR TITLE
[CWS] make flags approvers win over parent-basename path approvers

### DIFF
--- a/pkg/security/probe/kfilters/approvers_test.go
+++ b/pkg/security/probe/kfilters/approvers_test.go
@@ -231,6 +231,78 @@ func TestApproverParentWildcardBasename(t *testing.T) {
 	}
 }
 
+// TestApproverParentBasenameWeightVsFlags ensures that a coarse parent-basename path
+// approver (which can only push the parent directory name to the kernel) does not shadow
+// a more selective flags approver. The path field weight is lowered to 20 via
+// FilterWeightFnc, so open.flags (weight 100) is preferred over the path field.
+func TestApproverParentBasenameWeightVsFlags(t *testing.T) {
+	enabled := map[eval.EventType]bool{"*": true}
+
+	ruleOpts, evalOpts := rules.NewBothOpts(enabled)
+
+	rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
+	rules.AddTestRuleExpr(t, rs, `open.file.path =~ "/var/run/secrets/*" && open.flags & O_CREAT > 0`)
+	capabilities, exists := allCapabilities["open"]
+	if !exists {
+		t.Fatal("no capabilities for open")
+	}
+	approvers, _, _, err := rs.GetEventTypeApprovers("open", capabilities)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if values, exists := approvers["open.file.path"]; exists {
+		t.Fatalf("expected no path approver, the flags approver should be preferred: %v", values)
+	}
+
+	values, exists := approvers["open.flags"]
+	if !exists || len(values) != 1 {
+		t.Fatalf("expected flags approver not found: %v", values)
+	}
+
+	valueInt, ok := values[0].Value.(int)
+	if !ok {
+		t.Fatalf("expected int value, got %v", values[0].Value)
+	}
+	assert.Equal(t, unix.O_CREAT, valueInt, "expected O_CREAT flags approver, got %d", valueInt)
+}
+
+// TestApproverLeafBasenameWeightVsFlags ensures that a precise leaf-basename path approver
+// still wins over a flags approver. The basename wildcard has a long enough prefix to be a
+// useful kernel approver, so the path field keeps its full weight (300) and is preferred
+// over open.flags (weight 100).
+func TestApproverLeafBasenameWeightVsFlags(t *testing.T) {
+	enabled := map[eval.EventType]bool{"*": true}
+
+	ruleOpts, evalOpts := rules.NewBothOpts(enabled)
+
+	rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
+	rules.AddTestRuleExpr(t, rs, `open.file.path =~ "/var/run/secret*" && open.flags & O_CREAT > 0`)
+	capabilities, exists := allCapabilities["open"]
+	if !exists {
+		t.Fatal("no capabilities for open")
+	}
+	approvers, _, _, err := rs.GetEventTypeApprovers("open", capabilities)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if values, exists := approvers["open.flags"]; exists {
+		t.Fatalf("expected no flags approver, the path approver should be preferred: %v", values)
+	}
+
+	values, exists := approvers["open.file.path"]
+	if !exists || len(values) != 1 {
+		t.Fatalf("expected path approver not found: %v", values)
+	}
+
+	valueString, ok := values[0].Value.(string)
+	if !ok {
+		t.Fatalf("expected string value, got %v", values[0].Value)
+	}
+	assert.Equal(t, "/var/run/secret*", valueString)
+}
+
 func TestApproverInUpperLayer(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
 

--- a/pkg/security/probe/kfilters/capabilities_linux.go
+++ b/pkg/security/probe/kfilters/capabilities_linux.go
@@ -83,6 +83,25 @@ func buildFileCapabilities(event string, fields ...string) rules.FieldCapabiliti
 				TypeBitmask:  eval.ScalarValueType | eval.PatternValueType | eval.GlobValueType,
 				ValidateFnc:  validatePathFilter,
 				FilterWeight: 300,
+				// FilterWeightFnc adjusts the path approver weight depending on what can actually
+				// be pushed to the kernel. A precise leaf-basename approver keeps the full weight,
+				// while a coarse parent-basename approver is demoted below the flags approvers.
+				FilterWeightFnc: func(value rules.FilterValue) int {
+					strValue, ok := value.Value.(string)
+					if !ok {
+						// only string paths can be demoted to a parent-basename approver; keep the full weight
+						return 300
+					}
+					// the leaf basename is a usable kernel approver (a plain basename, or a wildcard
+					// with a prefix of at least patternPrefixSize bytes): keep the full weight
+					if validateBasenameFilter(path.Base(strValue)) {
+						return 300
+					}
+					// otherwise only the parent directory basename can be pushed to the kernel, which is
+					// a coarse approver: weigh it below the flags approvers (open.flags is 100,
+					// open.file.in_upper_layer is 50) so a more selective field is preferred when available
+					return 20
+				},
 			},
 			{
 				Field:        event + "." + field + ".name",

--- a/pkg/security/probe/kfilters/report.go
+++ b/pkg/security/probe/kfilters/report.go
@@ -184,9 +184,24 @@ func ComputeFilters(config *config.Config, rs *rules.RuleSet) (*FilterReport, er
 				continue
 			}
 
+			// effectiveWeight mirrors getApprovers: for capabilities whose weight depends on
+			// the actual filter values (e.g. a coarse parent-basename path approver weighs less
+			// than a precise leaf-basename one), take the minimum weight across the field values
+			// present in the rule set instead of the static FilterWeight.
+			effectiveWeight := func(cap *rules.FieldCapability) int {
+				weight := cap.FilterWeight
+				if cap.FilterWeightFnc != nil {
+					for _, value := range rs.GetFieldValues(cap.Field) {
+						filterValue := rules.FilterValue{Field: cap.Field, Value: value.Value, Type: value.Type, Mode: cap.FilterMode}
+						weight = min(weight, cap.FilterWeightFnc(filterValue))
+					}
+				}
+				return weight
+			}
+
 			// try to convert the most efficient approver so that weak approvers are still backed by a discarder
 			sort.Slice(evtCapabilities, func(i, j int) bool {
-				return evtCapabilities[i].FilterWeight > evtCapabilities[j].FilterWeight
+				return effectiveWeight(evtCapabilities[i]) > effectiveWeight(evtCapabilities[j])
 			})
 
 			for _, evtCapability := range evtCapabilities {

--- a/pkg/security/secl/rules/approvers.go
+++ b/pkg/security/secl/rules/approvers.go
@@ -269,6 +269,8 @@ func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) 
 			var filterValues FilterValues
 			var bitmasks []int
 
+			filterWeight := fieldCap.FilterWeight
+
 			for _, value := range rule.GetFieldValues(field) {
 				// TODO: handle range for bitmask field, for now ignore range value
 				if fieldCap.TypeBitmask&eval.BitmaskValueType == eval.BitmaskValueType && value.Type == eval.RangeValueType {
@@ -292,6 +294,13 @@ func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) 
 							continue LOOP
 						}
 						filterValues = filterValues.Merge(filterValue)
+
+						// we need to take the min weight of the approver value
+						// in case of multiple values with different weights
+						// open.file.path in ["/etc/passwd", "/var/*] && open.flags == O_RDWR
+						if fieldCap.FilterWeightFnc != nil {
+							filterWeight = min(filterWeight, fieldCap.FilterWeightFnc(filterValue))
+						}
 					}
 				case eval.BitmaskValueType:
 					bitmasks = append(bitmasks, value.Value.(int))
@@ -311,6 +320,10 @@ func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) 
 						continue LOOP
 					}
 					filterValues = filterValues.Merge(filterValue)
+
+					if fieldCap.FilterWeightFnc != nil {
+						filterWeight = min(filterWeight, fieldCap.FilterWeightFnc(filterValue))
+					}
 				}
 			}
 
@@ -318,10 +331,10 @@ func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) 
 				continue
 			}
 
-			if bestFilterValues == nil || fieldCap.FilterWeight > bestFilterWeight {
+			if bestFilterValues == nil || filterWeight > bestFilterWeight {
 				bestFilterField = field
 				bestFilterValues = filterValues
-				bestFilterWeight = fieldCap.FilterWeight
+				bestFilterWeight = filterWeight
 				bestFilterMode = fieldCap.FilterMode
 			}
 		}

--- a/pkg/security/secl/rules/capabilities.go
+++ b/pkg/security/secl/rules/capabilities.go
@@ -29,6 +29,7 @@ type FieldCapability struct {
 	TypeBitmask            eval.FieldValueType
 	ValidateFnc            func(FilterValue) bool
 	FilterWeight           int
+	FilterWeightFnc        func(FilterValue) int
 	FilterMode             FilterMode
 	RangeFilterValue       *RangeFilterValue
 	HandleNotApproverValue func(valueType eval.FieldValueType, value interface{}) (eval.FieldValueType, interface{}, bool)


### PR DESCRIPTION
When a path approver can only be expressed kernel-side as a parent-basename filter (e.g. open.file.path =~ "/var/run/secrets/*", where only the "secrets" directory name can be pushed down), it is a coarse filter that should not be preferred over a more selective approver such as open.flags.

Add a per-value FilterWeightFnc hook on FieldCapability so the path field reports a low weight (20) for parent-basename approvers and keeps its full weight (300) for precise leaf-basename ones. getApprovers takes the minimum weight across a field's values, and ComputeFilters applies the same logic when ordering capabilities for ApproverOnly conversion.

Add tests covering both the parent-basename (flags win) and leaf-basename (path wins) cases.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
