### PR TITLE
[CWS] Add DNS responses (+fixes)

### DIFF
--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -413,6 +413,20 @@ Workload Protection events for Linux systems have the following JSON schema:
                 "code": {
                     "type": "integer",
                     "description": "RCode is the response code present in the response"
+                },
+                "ips": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "description": "IPs is the list of IP addresses resolved by the DNS response"
+                },
+                "cnames": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "description": "CNames is the list of CNAME targets returned by the DNS response"
                 }
             },
             "additionalProperties": false,
@@ -3232,6 +3246,20 @@ Workload Protection events for Linux systems have the following JSON schema:
         "code": {
             "type": "integer",
             "description": "RCode is the response code present in the response"
+        },
+        "ips": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array",
+            "description": "IPs is the list of IP addresses resolved by the DNS response"
+        },
+        "cnames": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array",
+            "description": "CNames is the list of CNAME targets returned by the DNS response"
         }
     },
     "additionalProperties": false,
@@ -3247,6 +3275,8 @@ Workload Protection events for Linux systems have the following JSON schema:
 | Field | Description |
 | ----- | ----------- |
 | `code` | RCode is the response code present in the response |
+| `ips` | IPs is the list of IP addresses resolved by the DNS response |
+| `cnames` | CNames is the list of CNAME targets returned by the DNS response |
 
 
 ## `EventContext`

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -402,6 +402,20 @@
         "code": {
           "type": "integer",
           "description": "RCode is the response code present in the response"
+        },
+        "ips": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "IPs is the list of IP addresses resolved by the DNS response"
+        },
+        "cnames": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "CNames is the list of CNAME targets returned by the DNS response"
         }
       },
       "additionalProperties": false,

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -776,7 +776,9 @@ A DNS request was sent
 | [`dns.question.name.length`](#common-string-length-doc) | Length of the corresponding element |
 | [`dns.question.name.root_domain`](#common-string-root_domain-doc) | Root domain of the corresponding element |
 | [`dns.question.type`](#dns-question-type-doc) | a two octet code which specifies the DNS question type |
+| [`dns.response.cnames`](#dns-response-cnames-doc) | CNAME targets returned by the DNS response |
 | [`dns.response.code`](#dns-response-code-doc) | Response code of the DNS response according to RFC 1035 |
+| [`dns.response.ips`](#dns-response-ips-doc) | IP addresses resolved by the DNS response |
 | [`network.destination.ip`](#common-ipportcontext-ip-doc) | IP address |
 | [`network.destination.is_public`](#common-ipportcontext-is_public-doc) | Whether the IP address belongs to a public network |
 | [`network.destination.port`](#common-ipportcontext-port-doc) | Port number |
@@ -4108,6 +4110,13 @@ Constants: [DNS qtypes](#dns-qtypes)
 
 
 
+### `dns.response.cnames` {#dns-response-cnames-doc}
+Type: string
+
+Definition: CNAME targets returned by the DNS response
+
+
+
 ### `dns.response.code` {#dns-response-code-doc}
 Type: int
 
@@ -4115,6 +4124,13 @@ Definition: Response code of the DNS response according to RFC 1035
 
 
 Constants: [DNS Responses](#dns-responses)
+
+
+
+### `dns.response.ips` {#dns-response-ips-doc}
+Type: IP/CIDR
+
+Definition: IP addresses resolved by the DNS response
 
 
 

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -2677,9 +2677,19 @@
           "property_doc_link": "dns-question-type-doc"
         },
         {
+          "name": "dns.response.cnames",
+          "definition": "CNAME targets returned by the DNS response",
+          "property_doc_link": "dns-response-cnames-doc"
+        },
+        {
           "name": "dns.response.code",
           "definition": "Response code of the DNS response according to RFC 1035",
           "property_doc_link": "dns-response-code-doc"
+        },
+        {
+          "name": "dns.response.ips",
+          "definition": "IP addresses resolved by the DNS response",
+          "property_doc_link": "dns-response-ips-doc"
         },
         {
           "name": "network.destination.ip",
@@ -15737,6 +15747,18 @@
       "examples": []
     },
     {
+      "name": "dns.response.cnames",
+      "link": "dns-response-cnames-doc",
+      "type": "string",
+      "definition": "CNAME targets returned by the DNS response",
+      "prefixes": [
+        "dns.response"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
       "name": "dns.response.code",
       "link": "dns-response-code-doc",
       "type": "int",
@@ -15746,6 +15768,18 @@
       ],
       "constants": "DNS Responses",
       "constants_link": "dns-responses",
+      "examples": []
+    },
+    {
+      "name": "dns.response.ips",
+      "link": "dns-response-ips-doc",
+      "type": "IP/CIDR",
+      "definition": "IP addresses resolved by the DNS response",
+      "prefixes": [
+        "dns.response"
+      ],
+      "constants": "",
+      "constants_link": "",
       "examples": []
     },
     {

--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -2245,6 +2245,14 @@ properties:
             - DD_EVENT_MONITORING_CONFIG_DNS_RESOLUTION_ENABLED
             - DD_RUNTIME_SECURITY_CONFIG_DNS_RESOLUTION_ENABLED
             tags: []
+          cname_max_depth:
+            node_type: setting
+            type: number
+            default: 2
+            env_vars:
+            - DD_EVENT_MONITORING_CONFIG_DNS_RESOLUTION_CNAME_MAX_DEPTH
+            - DD_RUNTIME_SECURITY_CONFIG_DNS_RESOLUTION_CNAME_MAX_DEPTH
+            tags: []
       enable_all_probes:
         node_type: setting
         type: boolean

--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -2247,8 +2247,9 @@ properties:
             tags: []
           cname_max_depth:
             node_type: setting
-            type: number
+            type: integer
             default: 2
+            minimum: 0
             env_vars:
             - DD_EVENT_MONITORING_CONFIG_DNS_RESOLUTION_CNAME_MAX_DEPTH
             - DD_RUNTIME_SECURITY_CONFIG_DNS_RESOLUTION_CNAME_MAX_DEPTH

--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -2237,6 +2237,14 @@ properties:
             - DD_EVENT_MONITORING_CONFIG_DNS_RESOLUTION_CACHE_SIZE
             - DD_RUNTIME_SECURITY_CONFIG_DNS_RESOLUTION_CACHE_SIZE
             tags: []
+          cname_max_depth:
+            node_type: setting
+            type: integer
+            default: 2
+            env_vars:
+            - DD_EVENT_MONITORING_CONFIG_DNS_RESOLUTION_CNAME_MAX_DEPTH
+            - DD_RUNTIME_SECURITY_CONFIG_DNS_RESOLUTION_CNAME_MAX_DEPTH
+            tags: []
           enabled:
             node_type: setting
             type: boolean
@@ -2244,15 +2252,6 @@ properties:
             env_vars:
             - DD_EVENT_MONITORING_CONFIG_DNS_RESOLUTION_ENABLED
             - DD_RUNTIME_SECURITY_CONFIG_DNS_RESOLUTION_ENABLED
-            tags: []
-          cname_max_depth:
-            node_type: setting
-            type: integer
-            default: 2
-            minimum: 0
-            env_vars:
-            - DD_EVENT_MONITORING_CONFIG_DNS_RESOLUTION_CNAME_MAX_DEPTH
-            - DD_RUNTIME_SECURITY_CONFIG_DNS_RESOLUTION_CNAME_MAX_DEPTH
             tags: []
       enable_all_probes:
         node_type: setting

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -300,6 +300,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.pid_cache_size", 10000)
 	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.dns_resolution.cache_size", 1024)
 	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.dns_resolution.enabled", true)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.dns_resolution.cname_max_depth", 2)
 	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.events_stats.tags_cardinality", "high")
 	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.custom_sensitive_words", []string{})
 	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.custom_sensitive_regexps", []string{})

--- a/pkg/security/generators/accessors/accessors.go
+++ b/pkg/security/generators/accessors/accessors.go
@@ -179,6 +179,7 @@ func handleBasic(module *common.Module, field seclField, name, alias, aliasPrefi
 		GettersOnly:  field.gettersOnly,
 		Ref:          field.ref,
 		RestrictedTo: restrictedTo,
+		DefaultValue: field.defaultValue,
 	}
 
 	module.Fields[alias] = newStructField
@@ -285,6 +286,7 @@ func handleNonEmbedded(module *common.Module, field seclField, aliasPrefix, alia
 		SetHandler:    field.setHandler,
 		AliasPrefix:   aliasPrefix,
 		Alias:         alias,
+		DefaultValue:  field.defaultValue,
 	}
 }
 
@@ -346,6 +348,7 @@ func handleIterator(module *common.Module, field seclField, fieldType, iterator,
 		Ref:              field.ref,
 		RestrictedTo:     restrictedTo,
 		ReadOnly:         field.readOnly,
+		DefaultValue:     field.defaultValue,
 	}
 
 	lengthField := addLengthOpField(module, alias, module.Iterators[alias])
@@ -398,6 +401,7 @@ func handleFieldWithHandler(module *common.Module, field seclField, aliasPrefix,
 		Ref:              field.ref,
 		RestrictedTo:     restrictedTo,
 		ReadOnly:         field.readOnly,
+		DefaultValue:     field.defaultValue,
 	}
 	module.Fields[alias] = newStructField
 
@@ -458,6 +462,7 @@ type seclField struct {
 	gettersOnly            bool //  a field that is not exposed via SECL, but still has an accessor generated
 	ref                    string
 	readOnly               bool
+	defaultValue           string
 }
 
 func parseFieldDef(def string) (seclField, error) {
@@ -494,6 +499,8 @@ func parseFieldDef(def string) (seclField, error) {
 				field.check = value
 			case "set_handler":
 				field.setHandler = value
+			case "default":
+				field.defaultValue = value
 			case "opts":
 				for opt := range strings.SplitSeq(value, "|") {
 					switch opt {

--- a/pkg/security/generators/accessors/common/types.go
+++ b/pkg/security/generators/accessors/common/types.go
@@ -84,6 +84,7 @@ type StructField struct {
 	RestrictedTo     []string
 	IsIterator       bool
 	ReadOnly         bool
+	DefaultValue     string
 }
 
 // GetEvaluatorType returns the evaluator type name
@@ -117,6 +118,10 @@ func (sf *StructField) GetEvaluatorType() string {
 
 // GetDefaultReturnValue returns default value for the given return type
 func (sf *StructField) GetDefaultReturnValue() string {
+	if sf.DefaultValue != "" {
+		return sf.DefaultValue
+	}
+
 	if sf.ReturnType == "int" {
 		if sf.Iterator != nil || sf.IsArray {
 			return "[]int{}"
@@ -129,7 +134,7 @@ func (sf *StructField) GetDefaultReturnValue() string {
 		return "false"
 	} else if sf.ReturnType == "net.IPNet" {
 		if sf.IsArray {
-			return "&eval.CIDRValues{}"
+			return "[]net.IPNet{}"
 		}
 		return "net.IPNet{}"
 	} else if sf.Iterator != nil || sf.IsArray {

--- a/pkg/security/generators/event_deep_copy/event_deep_copy.tmpl
+++ b/pkg/security/generators/event_deep_copy/event_deep_copy.tmpl
@@ -11,6 +11,8 @@ package {{.Name}}
 
 import (
 	{{if has "go:build unix" .BuildTags}}
+	"net"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/utils"
 	"github.com/google/gopacket"
 	{{end}}

--- a/pkg/security/generators/event_deep_copy/event_deep_copy.tmpl
+++ b/pkg/security/generators/event_deep_copy/event_deep_copy.tmpl
@@ -170,7 +170,13 @@ func {{$funcName}}(fieldToCopy {{$fullType}}) {{$fullType}} {
 			{{- $elemTypePrefix := ""}}
 			{{- if $isPtr}}{{$elemTypePrefix = "*"}}{{end}}
 	copied := make([]{{$elemTypePrefix}}{{$node.Field.OrigType}}, len(fieldToCopy))
-			{{- if $node.Field.IsBasic}}
+			{{- if and $node.Field.IsBasic (eq $node.Field.OrigType "net.IPNet")}}
+	for i := range fieldToCopy {
+		copied[i] = fieldToCopy[i]
+		copied[i].IP = append(net.IP(nil), fieldToCopy[i].IP...)
+		copied[i].Mask = append(net.IPMask(nil), fieldToCopy[i].Mask...)
+	}
+			{{- else if $node.Field.IsBasic}}
 	for i := range fieldToCopy {
 		copied[i] = fieldToCopy[i]
 	}

--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -162,6 +162,9 @@ type Config struct {
 	// DNSResolverCacheSize is the numer of entries in the DNS resolver LRU cache
 	DNSResolverCacheSize int
 
+	// DNSResolverCnameMaxDepth is the maximum CNAME chain depth followed when resolving an IP to hostnames
+	DNSResolverCnameMaxDepth int
+
 	// DNSResolutionEnabled resolving DNS names from IP addresses
 	DNSResolutionEnabled bool
 
@@ -225,6 +228,7 @@ func NewConfig() (*Config, error) {
 		StatsPollingInterval:        time.Duration(getInt("events_stats.polling_interval")) * time.Second,
 		SyscallsMonitorEnabled:      getBool("syscalls_monitor.enabled"),
 		DNSResolverCacheSize:        getInt("dns_resolution.cache_size"),
+		DNSResolverCnameMaxDepth:    getInt("dns_resolution.cname_max_depth"),
 		DNSResolutionEnabled:        getBool("dns_resolution.enabled"),
 
 		// runtime compilation

--- a/pkg/security/probe/discarders_linux.go
+++ b/pkg/security/probe/discarders_linux.go
@@ -581,6 +581,11 @@ func applyDNSDefaultDropMaskFromRules(manager *manager.Manager, rs *rules.RuleSe
 
 		isDiscarder := true
 		for _, r := range bucket.GetRules() {
+			if ruleNeedsFullDNSResponse(r) {
+				isDiscarder = false
+				break
+			}
+
 			ok, err := r.PartialEval(ctx, "dns.response.code")
 			if err != nil {
 				var nf *eval.ErrFieldNotFound
@@ -590,7 +595,7 @@ func applyDNSDefaultDropMaskFromRules(manager *manager.Manager, rs *rules.RuleSe
 				isDiscarder = false
 				break
 			}
-			if ok || ruleNeedsFullDNSResponse(r) {
+			if ok {
 				isDiscarder = false
 				break
 			}
@@ -606,6 +611,13 @@ func applyDNSDefaultDropMaskFromRules(manager *manager.Manager, rs *rules.RuleSe
 
 func ruleNeedsFullDNSResponse(rule *rules.Rule) bool {
 	fields := rule.GetFields()
+
+	for _, field := range fields {
+		if strings.HasPrefix(field, "dns.response.") && field != "dns.response.code" {
+			return true
+		}
+	}
+
 	return slices.Contains(fields, "dns.response.code") && len(fields) > 1
 }
 

--- a/pkg/security/probe/discarders_linux.go
+++ b/pkg/security/probe/discarders_linux.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"math"
 	"path"
-	"slices"
 	"strings"
 	"time"
 
@@ -581,15 +580,16 @@ func applyDNSDefaultDropMaskFromRules(manager *manager.Manager, rs *rules.RuleSe
 
 		isDiscarder := true
 		for _, r := range bucket.GetRules() {
-			if ruleNeedsFullDNSResponse(r) {
-				isDiscarder = false
-				break
-			}
+			needsFullResponse := ruleNeedsFullDNSResponse(r)
 
 			ok, err := r.PartialEval(ctx, "dns.response.code")
 			if err != nil {
 				var nf *eval.ErrFieldNotFound
 				if errors.As(err, &nf) {
+					if needsFullResponse {
+						isDiscarder = false
+						break
+					}
 					continue
 				}
 				isDiscarder = false
@@ -610,15 +610,13 @@ func applyDNSDefaultDropMaskFromRules(manager *manager.Manager, rs *rules.RuleSe
 }
 
 func ruleNeedsFullDNSResponse(rule *rules.Rule) bool {
-	fields := rule.GetFields()
-
-	for _, field := range fields {
+	for _, field := range rule.GetFields() {
 		if strings.HasPrefix(field, "dns.response.") && field != "dns.response.code" {
 			return true
 		}
 	}
 
-	return slices.Contains(fields, "dns.response.code") && len(fields) > 1
+	return false
 }
 
 func prCtlDiscarder(_ *rules.RuleSet, event *model.Event, probe *EBPFProbe, _ Discarder) (bool, error) {

--- a/pkg/security/probe/discarders_linux.go
+++ b/pkg/security/probe/discarders_linux.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -589,7 +590,7 @@ func applyDNSDefaultDropMaskFromRules(manager *manager.Manager, rs *rules.RuleSe
 				isDiscarder = false
 				break
 			}
-			if ok {
+			if ok || ruleNeedsFullDNSResponse(r) {
 				isDiscarder = false
 				break
 			}
@@ -601,6 +602,11 @@ func applyDNSDefaultDropMaskFromRules(manager *manager.Manager, rs *rules.RuleSe
 	}
 
 	return setDNSDiscarderMask(manager, ^allowMask)
+}
+
+func ruleNeedsFullDNSResponse(rule *rules.Rule) bool {
+	fields := rule.GetFields()
+	return slices.Contains(fields, "dns.response.code") && len(fields) > 1
 }
 
 func prCtlDiscarder(_ *rules.RuleSet, event *model.Event, probe *EBPFProbe, _ Discarder) (bool, error) {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3828,7 +3828,7 @@ func dnsAnswerIPNet(answer layers.DNSResourceRecord) (net.IPNet, bool) {
 		return net.IPNet{IP: append(net.IP(nil), ip...), Mask: net.CIDRMask(32, 32)}, true
 	case layers.DNSTypeAAAA:
 		ip := answer.IP.To16()
-		if ip == nil || ip.To4() != nil {
+		if ip == nil {
 			return net.IPNet{}, false
 		}
 		return net.IPNet{IP: append(net.IP(nil), ip...), Mask: net.CIDRMask(128, 128)}, true

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -1662,12 +1663,14 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 					Payload: trimRightZeros(data[offset:]),
 				}
 			} else {
-				p.addToDNSResolver(p.dnsLayer)
+				ips, cnames := p.addToDNSResolver(p.dnsLayer)
 				event.Type = uint32(model.DNSEventType) // remap to regular DNS event type
 				event.DNS = model.DNSEvent{
 					ID: p.dnsLayer.ID,
 					Response: &model.DNSResponse{
 						ResponseCode: uint8(p.dnsLayer.ResponseCode),
+						IPs:          ips,
+						CNames:       cnames,
 					},
 				}
 				if len(p.dnsLayer.Questions) != 0 {
@@ -2590,8 +2593,14 @@ func (p *EBPFProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.FilterReport, boo
 		return nil, false, err
 	}
 
-	if err := applyDNSDefaultDropMaskFromRules(p.Manager, rs); err != nil {
-		seclog.Warnf("failed to apply DNS default-drop mask: %v", err)
+	if p.config.Probe.EnableDiscarders {
+		if err := applyDNSDefaultDropMaskFromRules(p.Manager, rs); err != nil {
+			seclog.Warnf("failed to apply DNS default-drop mask: %v", err)
+		}
+	} else {
+		if err := setDNSDiscarderMask(p.Manager, 0); err != nil {
+			seclog.Warnf("failed to disable DNS default-drop mask: %v", err)
+		}
 	}
 
 	fpb := newFilterPolicyBlock()
@@ -3781,19 +3790,51 @@ func (p *EBPFProbe) newOpenEventFromReplay(entry *model.ProcessCacheEntry, snaps
 	return event
 }
 
-func (p *EBPFProbe) addToDNSResolver(dnsLayer *layers.DNS) {
+func (p *EBPFProbe) addToDNSResolver(dnsLayer *layers.DNS) ([]net.IPNet, []string) {
+	var ips []net.IPNet
+	var cnames []string
+
 	for _, answer := range dnsLayer.Answers {
-		if answer.Type == layers.DNSTypeCNAME {
-			p.Resolvers.DNSResolver.AddNewCname(string(answer.CNAME), string(answer.Name))
-		} else if answer.Type == layers.DNSTypeA || answer.Type == layers.DNSTypeAAAA {
+		switch answer.Type {
+		case layers.DNSTypeCNAME:
+			cname := string(answer.CNAME)
+			cnames = append(cnames, cname)
+			p.Resolvers.DNSResolver.AddNewCname(cname, string(answer.Name))
+		case layers.DNSTypeA, layers.DNSTypeAAAA:
 			ip, ok := netip.AddrFromSlice(answer.IP)
 			if ok {
 				p.Resolvers.DNSResolver.AddNew(string(answer.Name), ip)
 			} else {
-				seclog.Errorf("DNS response with an invalid IP received: %v", ip)
+				seclog.Errorf("DNS response with an invalid IP received: %v", answer.IP)
+				continue
+			}
+
+			if ipNet, ok := dnsAnswerIPNet(answer); ok {
+				ips = append(ips, ipNet)
 			}
 		}
 	}
+
+	return ips, cnames
+}
+
+func dnsAnswerIPNet(answer layers.DNSResourceRecord) (net.IPNet, bool) {
+	switch answer.Type {
+	case layers.DNSTypeA:
+		ip := answer.IP.To4()
+		if ip == nil {
+			return net.IPNet{}, false
+		}
+		return net.IPNet{IP: append(net.IP(nil), ip...), Mask: net.CIDRMask(32, 32)}, true
+	case layers.DNSTypeAAAA:
+		ip := answer.IP.To16()
+		if ip == nil || ip.To4() != nil {
+			return net.IPNet{}, false
+		}
+		return net.IPNet{IP: append(net.IP(nil), ip...), Mask: net.CIDRMask(128, 128)}, true
+	}
+
+	return net.IPNet{}, false
 }
 
 func trimRightZeros(b []byte) []byte {

--- a/pkg/security/probe/probe_ebpf_test.go
+++ b/pkg/security/probe/probe_ebpf_test.go
@@ -9,8 +9,10 @@
 package probe
 
 import (
+	"net"
 	"testing"
 
+	"github.com/google/gopacket/layers"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -26,6 +28,19 @@ func newTestEBPFProbe() *EBPFProbe {
 		return &model.Event{}
 	})
 	return p
+}
+
+func TestDNSAnswerIPNet(t *testing.T) {
+	t.Run("accept IPv4-mapped IPv6 AAAA answer", func(t *testing.T) {
+		ipNet, ok := dnsAnswerIPNet(layers.DNSResourceRecord{
+			Type: layers.DNSTypeAAAA,
+			IP:   net.ParseIP("::ffff:192.0.2.1"),
+		})
+
+		assert.True(t, ok)
+		assert.Equal(t, net.ParseIP("::ffff:192.0.2.1").To16(), ipNet.IP)
+		assert.Equal(t, net.CIDRMask(128, 128), ipNet.Mask)
+	})
 }
 
 func TestGetPoolEvent(t *testing.T) {

--- a/pkg/security/resolvers/dns/resolver.go
+++ b/pkg/security/resolvers/dns/resolver.go
@@ -151,40 +151,56 @@ func (r *Resolver) SendStats() error {
 	}
 
 	hits := r.resolverStats.cacheHits.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, hits, tags, 1.0)
+	if err := r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, hits, tags, 1.0); err != nil {
+		return fmt.Errorf("failed to send %s: %w", metrics.MetricDNSResolverIPResolverCache, err)
+	}
 
 	cnameHits := r.cnameStats.cacheHits.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameHits, tags, 1.0)
+	if err := r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameHits, tags, 1.0); err != nil {
+		return fmt.Errorf("failed to send %s: %w", metrics.MetricDNSResolverCnameResolverCache, err)
+	}
 
 	tags = []string{
 		"result:miss",
 	}
 
 	misses := r.resolverStats.cacheMisses.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, misses, tags, 1.0)
+	if err := r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, misses, tags, 1.0); err != nil {
+		return fmt.Errorf("failed to send %s: %w", metrics.MetricDNSResolverIPResolverCache, err)
+	}
 
 	cnameMisses := r.cnameStats.cacheMisses.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameMisses, tags, 1.0)
+	if err := r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameMisses, tags, 1.0); err != nil {
+		return fmt.Errorf("failed to send %s: %w", metrics.MetricDNSResolverCnameResolverCache, err)
+	}
 
 	tags = []string{
 		"result:insertion",
 	}
 
 	insertions := r.resolverStats.cacheInsertions.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, insertions, tags, 1.0)
+	if err := r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, insertions, tags, 1.0); err != nil {
+		return fmt.Errorf("failed to send %s: %w", metrics.MetricDNSResolverIPResolverCache, err)
+	}
 
 	cnameInsertions := r.cnameStats.cacheInsertions.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameInsertions, tags, 1.0)
+	if err := r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameInsertions, tags, 1.0); err != nil {
+		return fmt.Errorf("failed to send %s: %w", metrics.MetricDNSResolverCnameResolverCache, err)
+	}
 
 	tags = []string{
 		"result:eviction",
 	}
 
 	evictions := r.resolverStats.cacheEvictions.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, evictions, tags, 1.0)
+	if err := r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, evictions, tags, 1.0); err != nil {
+		return fmt.Errorf("failed to send %s: %w", metrics.MetricDNSResolverIPResolverCache, err)
+	}
 
 	cnameEvictions := r.cnameStats.cacheEvictions.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameEvictions, tags, 1.0)
+	if err := r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameEvictions, tags, 1.0); err != nil {
+		return fmt.Errorf("failed to send %s: %w", metrics.MetricDNSResolverCnameResolverCache, err)
+	}
 
 	return nil
 }

--- a/pkg/security/resolvers/dns/resolver.go
+++ b/pkg/security/resolvers/dns/resolver.go
@@ -39,9 +39,14 @@ type Resolver struct {
 
 // NewDNSResolver returns a new resolver
 func NewDNSResolver(cfg *config.Config, statsdClient statsd.ClientInterface) (*Resolver, error) {
+	cnameMaxDepth := cfg.DNSResolverCnameMaxDepth
+	if cnameMaxDepth < 0 {
+		cnameMaxDepth = 0
+	}
+
 	ret := &Resolver{
 		statsdClient:  statsdClient,
-		cnameMaxDepth: cfg.DNSResolverCnameMaxDepth,
+		cnameMaxDepth: cnameMaxDepth,
 		resolverStats: &CacheStats{},
 		cnameStats:    &CacheStats{},
 	}
@@ -71,7 +76,7 @@ func NewDNSResolver(cfg *config.Config, statsdClient statsd.ClientInterface) (*R
 
 // fillWithCnames Recursively fills the set with all the cname aliases for the hostname
 func (r *Resolver) fillWithCnames(hostname string, hostnames *[]string, depth int) {
-	if depth == 0 {
+	if depth <= 0 {
 		return
 	}
 

--- a/pkg/security/resolvers/dns/resolver.go
+++ b/pkg/security/resolvers/dns/resolver.go
@@ -147,7 +147,7 @@ func (r *Resolver) AddNewCname(cname string, hostname string) {
 // SendStats sends the DNS resolver metrics
 func (r *Resolver) SendStats() error {
 	tags := []string{
-		"hit",
+		"result:hit",
 	}
 
 	hits := r.resolverStats.cacheHits.Swap(0)
@@ -157,7 +157,7 @@ func (r *Resolver) SendStats() error {
 	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameHits, tags, 1.0)
 
 	tags = []string{
-		"miss",
+		"result:miss",
 	}
 
 	misses := r.resolverStats.cacheMisses.Swap(0)
@@ -167,7 +167,7 @@ func (r *Resolver) SendStats() error {
 	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameMisses, tags, 1.0)
 
 	tags = []string{
-		"insertion",
+		"result:insertion",
 	}
 
 	insertions := r.resolverStats.cacheInsertions.Swap(0)
@@ -177,7 +177,7 @@ func (r *Resolver) SendStats() error {
 	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameInsertions, tags, 1.0)
 
 	tags = []string{
-		"eviction",
+		"result:eviction",
 	}
 
 	evictions := r.resolverStats.cacheEvictions.Swap(0)

--- a/pkg/security/resolvers/dns/resolver.go
+++ b/pkg/security/resolvers/dns/resolver.go
@@ -151,40 +151,40 @@ func (r *Resolver) SendStats() error {
 	}
 
 	hits := r.resolverStats.cacheHits.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, hits, tags, 1.0)
+	_ = r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, hits, tags, 1.0)
 
 	cnameHits := r.cnameStats.cacheHits.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, cnameHits, tags, 1.0)
+	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameHits, tags, 1.0)
 
 	tags = []string{
 		"miss",
 	}
 
 	misses := r.resolverStats.cacheMisses.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, misses, tags, 1.0)
+	_ = r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, misses, tags, 1.0)
 
 	cnameMisses := r.cnameStats.cacheMisses.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, cnameMisses, tags, 1.0)
+	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameMisses, tags, 1.0)
 
 	tags = []string{
 		"insertion",
 	}
 
 	insertions := r.resolverStats.cacheInsertions.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, insertions, tags, 1.0)
+	_ = r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, insertions, tags, 1.0)
 
 	cnameInsertions := r.cnameStats.cacheInsertions.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, cnameInsertions, tags, 1.0)
+	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameInsertions, tags, 1.0)
 
 	tags = []string{
 		"eviction",
 	}
 
 	evictions := r.resolverStats.cacheEvictions.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, evictions, tags, 1.0)
+	_ = r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, evictions, tags, 1.0)
 
 	cnameEvictions := r.cnameStats.cacheEvictions.Swap(0)
-	_ = r.statsdClient.Count(metrics.MetricDNSResolverIPResolverCache, cnameEvictions, tags, 1.0)
+	_ = r.statsdClient.Count(metrics.MetricDNSResolverCnameResolverCache, cnameEvictions, tags, 1.0)
 
 	return nil
 }

--- a/pkg/security/resolvers/dns/resolver.go
+++ b/pkg/security/resolvers/dns/resolver.go
@@ -31,6 +31,7 @@ type CacheStats struct {
 type Resolver struct {
 	cache         *lru.Cache[netip.Addr, []string]
 	cnameCache    *lru.Cache[string, []string]
+	cnameMaxDepth int
 	statsdClient  statsd.ClientInterface
 	resolverStats *CacheStats
 	cnameStats    *CacheStats
@@ -40,6 +41,7 @@ type Resolver struct {
 func NewDNSResolver(cfg *config.Config, statsdClient statsd.ClientInterface) (*Resolver, error) {
 	ret := &Resolver{
 		statsdClient:  statsdClient,
+		cnameMaxDepth: cfg.DNSResolverCnameMaxDepth,
 		resolverStats: &CacheStats{},
 		cnameStats:    &CacheStats{},
 	}
@@ -96,7 +98,7 @@ func (r *Resolver) HostListFromIP(addr netip.Addr) []string {
 		var allHosts []string
 		for _, hostname := range hostnames {
 			allHosts = append(allHosts, hostname)
-			r.fillWithCnames(hostname, &allHosts, 2)
+			r.fillWithCnames(hostname, &allHosts, r.cnameMaxDepth)
 		}
 
 		return allHosts

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -1995,15 +1995,44 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "dns.response.cnames":
+		return &eval.StringArrayEvaluator{
+			OpOverrides: []*eval.OpOverrides{eval.CaseInsensitiveCmp},
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.DNS.HasResponse() {
+					return []string{}
+				}
+				return ev.DNS.Response.CNames
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "dns.response.code":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				if !ev.DNS.HasResponse() {
-					return 0
+					return -1
 				}
 				return int(ev.DNS.Response.ResponseCode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "dns.response.ips":
+		return &eval.CIDRArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.DNS.HasResponse() {
+					return []net.IPNet{}
+				}
+				return ev.DNS.Response.IPs
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -37357,7 +37386,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"dns.question.name.length",
 		"dns.question.name.root_domain",
 		"dns.question.type",
+		"dns.response.cnames",
 		"dns.response.code",
+		"dns.response.ips",
 		"event.async",
 		"event.hostname",
 		"event.origin",
@@ -39856,8 +39887,12 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "dns", reflect.String, "string", false, nil
 	case "dns.question.type":
 		return "dns", reflect.Int, "int", false, nil
+	case "dns.response.cnames":
+		return "dns", reflect.String, "string", true, nil
 	case "dns.response.code":
 		return "dns", reflect.Int, "int", false, nil
+	case "dns.response.ips":
+		return "dns", reflect.Struct, "net.IPNet", true, nil
 	case "event.async":
 		return "", reflect.Bool, "bool", false, nil
 	case "event.hostname":
@@ -44522,11 +44557,29 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return &eval.ErrFieldReadOnly{Field: "dns.question.name.root_domain"}
 	case "dns.question.type":
 		return ev.setUint16FieldValue("dns.question.type", &ev.DNS.Question.Type, value)
+	case "dns.response.cnames":
+		if ev.DNS.Response == nil {
+			ev.DNS.Response = &DNSResponse{}
+		}
+		return ev.setStringArrayFieldValue("dns.response.cnames", &ev.DNS.Response.CNames, value)
 	case "dns.response.code":
 		if ev.DNS.Response == nil {
 			ev.DNS.Response = &DNSResponse{}
 		}
 		return ev.setUint8FieldValue("dns.response.code", &ev.DNS.Response.ResponseCode, value)
+	case "dns.response.ips":
+		if ev.DNS.Response == nil {
+			ev.DNS.Response = &DNSResponse{}
+		}
+		switch rv := value.(type) {
+		case net.IPNet:
+			ev.DNS.Response.IPs = append(ev.DNS.Response.IPs, rv)
+		case []net.IPNet:
+			ev.DNS.Response.IPs = append(ev.DNS.Response.IPs, rv...)
+		default:
+			return &eval.ErrValueTypeMismatch{Field: "dns.response.ips"}
+		}
+		return nil
 	case "event.async":
 		return ev.setBoolFieldValue("event.async", &ev.Async, value)
 	case "event.hostname":

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -729,6 +729,8 @@ func deepCopyIPNetArr(fieldToCopy []net.IPNet) []net.IPNet {
 	copied := make([]net.IPNet, len(fieldToCopy))
 	for i := range fieldToCopy {
 		copied[i] = fieldToCopy[i]
+		copied[i].IP = append(net.IP(nil), fieldToCopy[i].IP...)
+		copied[i].Mask = append(net.IPMask(nil), fieldToCopy[i].Mask...)
 	}
 	return copied
 }

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/utils"
 	"github.com/google/gopacket"
+	"net"
 )
 
 // DeepCopy creates a deep copy of the Event where the copy shares nothing with the original
@@ -716,7 +717,29 @@ func deepCopyDNSResponsePtr(fieldToCopy *DNSResponse) *DNSResponse {
 		return nil
 	}
 	copied := &DNSResponse{}
+	copied.CNames = deepCopystringArr(fieldToCopy.CNames)
+	copied.IPs = deepCopyIPNetArr(fieldToCopy.IPs)
 	copied.ResponseCode = fieldToCopy.ResponseCode
+	return copied
+}
+func deepCopyIPNetArr(fieldToCopy []net.IPNet) []net.IPNet {
+	if fieldToCopy == nil {
+		return nil
+	}
+	copied := make([]net.IPNet, len(fieldToCopy))
+	for i := range fieldToCopy {
+		copied[i] = fieldToCopy[i]
+	}
+	return copied
+}
+func deepCopybyteArr(fieldToCopy []byte) []byte {
+	if fieldToCopy == nil {
+		return nil
+	}
+	copied := make([]byte, len(fieldToCopy))
+	for i := range fieldToCopy {
+		copied[i] = fieldToCopy[i]
+	}
 	return copied
 }
 func deepCopyExecEvent(fieldToCopy ExecEvent) ExecEvent {
@@ -751,16 +774,6 @@ func deepCopyExitEvent(fieldToCopy ExitEvent) ExitEvent {
 func deepCopyFailedDNSEvent(fieldToCopy FailedDNSEvent) FailedDNSEvent {
 	copied := FailedDNSEvent{}
 	copied.Payload = deepCopybyteArr(fieldToCopy.Payload)
-	return copied
-}
-func deepCopybyteArr(fieldToCopy []byte) []byte {
-	if fieldToCopy == nil {
-		return nil
-	}
-	copied := make([]byte, len(fieldToCopy))
-	for i := range fieldToCopy {
-		copied[i] = fieldToCopy[i]
-	}
 	return copied
 }
 func deepCopyIMDSEvent(fieldToCopy IMDSEvent) IMDSEvent {

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -732,16 +732,6 @@ func deepCopyIPNetArr(fieldToCopy []net.IPNet) []net.IPNet {
 	}
 	return copied
 }
-func deepCopybyteArr(fieldToCopy []byte) []byte {
-	if fieldToCopy == nil {
-		return nil
-	}
-	copied := make([]byte, len(fieldToCopy))
-	for i := range fieldToCopy {
-		copied[i] = fieldToCopy[i]
-	}
-	return copied
-}
 func deepCopyExecEvent(fieldToCopy ExecEvent) ExecEvent {
 	copied := ExecEvent{}
 	copied.FileMetadata = deepCopyFileMetadata(fieldToCopy.FileMetadata)
@@ -774,6 +764,16 @@ func deepCopyExitEvent(fieldToCopy ExitEvent) ExitEvent {
 func deepCopyFailedDNSEvent(fieldToCopy FailedDNSEvent) FailedDNSEvent {
 	copied := FailedDNSEvent{}
 	copied.Payload = deepCopybyteArr(fieldToCopy.Payload)
+	return copied
+}
+func deepCopybyteArr(fieldToCopy []byte) []byte {
+	if fieldToCopy == nil {
+		return nil
+	}
+	copied := make([]byte, len(fieldToCopy))
+	for i := range fieldToCopy {
+		copied[i] = fieldToCopy[i]
+	}
 	return copied
 }
 func deepCopyIMDSEvent(fieldToCopy IMDSEvent) IMDSEvent {

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -707,7 +707,9 @@ type FailedDNSEvent struct {
 
 // DNSResponse represents a DNS response event
 type DNSResponse struct {
-	ResponseCode uint8 `field:"code"` // SECLDoc[code] Definition:`Response code of the DNS response according to RFC 1035` Constants:`DNS Responses`
+	ResponseCode uint8       `field:"code,default:-1"`                              // SECLDoc[code] Definition:`Response code of the DNS response according to RFC 1035` Constants:`DNS Responses`
+	IPs          []net.IPNet `field:"ips"`                                          // SECLDoc[ips] Definition:`IP addresses resolved by the DNS response`
+	CNames       []string    `field:"cnames" op_override:"eval.CaseInsensitiveCmp"` // SECLDoc[cnames] Definition:`CNAME targets returned by the DNS response`
 }
 
 // Matches returns true if the two DNS events matches

--- a/pkg/security/secl/schemas/dns.schema.json
+++ b/pkg/security/secl/schemas/dns.schema.json
@@ -69,6 +69,18 @@
                         "properties": {
                             "code": {
                                 "type": "number"
+                            },
+                            "ips": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "cnames": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
                     }

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -707,7 +707,9 @@ type FailedDNSEvent struct {
 
 // DNSResponse represents a DNS response event
 type DNSResponse struct {
-	ResponseCode uint8 `field:"code"` // SECLDoc[code] Definition:`Response code of the DNS response according to RFC 1035` Constants:`DNS Responses`
+	ResponseCode uint8       `field:"code,default:-1"`                              // SECLDoc[code] Definition:`Response code of the DNS response according to RFC 1035` Constants:`DNS Responses`
+	IPs          []net.IPNet `field:"ips"`                                          // SECLDoc[ips] Definition:`IP addresses resolved by the DNS response`
+	CNames       []string    `field:"cnames" op_override:"eval.CaseInsensitiveCmp"` // SECLDoc[cnames] Definition:`CNAME targets returned by the DNS response`
 }
 
 // Matches returns true if the two DNS events matches

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -224,6 +224,10 @@ type DNSEventSerializer struct {
 type DNSResponseEventSerializer struct {
 	// RCode is the response code present in the response
 	RCode uint8 `json:"code"`
+	// IPs is the list of IP addresses resolved by the DNS response
+	IPs []string `json:"ips,omitempty"`
+	// CNames is the list of CNAME targets returned by the DNS response
+	CNames []string `json:"cnames,omitempty"`
 }
 
 // ExitEventSerializer serializes an exit event to JSON
@@ -404,11 +408,25 @@ func newDNSEventSerializer(d *model.DNSEvent) *DNSEventSerializer {
 
 	if d.HasResponse() {
 		ret.Response = &DNSResponseEventSerializer{
-			RCode: d.Response.ResponseCode,
+			RCode:  d.Response.ResponseCode,
+			IPs:    newDNSResponseIPsSerializer(d.Response),
+			CNames: d.Response.CNames,
 		}
 	}
 
 	return ret
+}
+
+func newDNSResponseIPsSerializer(response *model.DNSResponse) []string {
+	if len(response.IPs) == 0 {
+		return nil
+	}
+
+	ips := make([]string, 0, len(response.IPs))
+	for _, ip := range response.IPs {
+		ips = append(ips, utils.GetIPStringFromIPNet(ip))
+	}
+	return ips
 }
 
 // nolint: deadcode, unused

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -407,26 +407,22 @@ func newDNSEventSerializer(d *model.DNSEvent) *DNSEventSerializer {
 	}
 
 	if d.HasResponse() {
+		var ips []string
+		if len(d.Response.IPs) > 0 {
+			ips = make([]string, 0, len(d.Response.IPs))
+			for _, ip := range d.Response.IPs {
+				ips = append(ips, utils.GetIPStringFromIPNet(ip))
+			}
+		}
+
 		ret.Response = &DNSResponseEventSerializer{
 			RCode:  d.Response.ResponseCode,
-			IPs:    newDNSResponseIPsSerializer(d.Response),
+			IPs:    ips,
 			CNames: d.Response.CNames,
 		}
 	}
 
 	return ret
-}
-
-func newDNSResponseIPsSerializer(response *model.DNSResponse) []string {
-	if len(response.IPs) == 0 {
-		return nil
-	}
-
-	ips := make([]string, 0, len(response.IPs))
-	for _, ip := range response.IPs {
-		ips = append(ips, utils.GetIPStringFromIPNet(ip))
-	}
-	return ips
 }
 
 // nolint: deadcode, unused

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -3015,6 +3015,60 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(
 			} else {
 				out.RCode = uint8(in.Uint8())
 			}
+		case "ips":
+			if in.IsNull() {
+				in.Skip()
+				out.IPs = nil
+			} else {
+				in.Delim('[')
+				if out.IPs == nil {
+					if !in.IsDelim(']') {
+						out.IPs = make([]string, 0, 4)
+					} else {
+						out.IPs = []string{}
+					}
+				} else {
+					out.IPs = (out.IPs)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v41 string
+					if in.IsNull() {
+						in.Skip()
+					} else {
+						v41 = string(in.String())
+					}
+					out.IPs = append(out.IPs, v41)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "cnames":
+			if in.IsNull() {
+				in.Skip()
+				out.CNames = nil
+			} else {
+				in.Delim('[')
+				if out.CNames == nil {
+					if !in.IsDelim(']') {
+						out.CNames = make([]string, 0, 4)
+					} else {
+						out.CNames = []string{}
+					}
+				} else {
+					out.CNames = (out.CNames)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v42 string
+					if in.IsNull() {
+						in.Skip()
+					} else {
+						v42 = string(in.String())
+					}
+					out.CNames = append(out.CNames, v42)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -3033,6 +3087,34 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(
 		const prefix string = ",\"code\":"
 		out.RawString(prefix[1:])
 		out.Uint8(uint8(in.RCode))
+	}
+	if len(in.IPs) != 0 {
+		const prefix string = ",\"ips\":"
+		out.RawString(prefix)
+		{
+			out.RawByte('[')
+			for v43, v44 := range in.IPs {
+				if v43 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v44))
+			}
+			out.RawByte(']')
+		}
+	}
+	if len(in.CNames) != 0 {
+		const prefix string = ",\"cnames\":"
+		out.RawString(prefix)
+		{
+			out.RawByte('[')
+			for v45, v46 := range in.CNames {
+				if v45 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v46))
+			}
+			out.RawByte(']')
+		}
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/tests/dns_response_test.go
+++ b/pkg/security/tests/dns_response_test.go
@@ -58,7 +58,7 @@ func TestDNSResponse(t *testing.T) {
 	ruleDefsRcodeOK := []*rules.RuleDefinition{
 		{
 			ID:         "dns_response_ok",
-			Expression: `dns.response.code == NOERROR && dns.question.name == "www.datadoghq.eu"`,
+			Expression: `dns.response.code == NOERROR && dns.question.name == "www.datadoghq.eu" && dns.response.ips in [34.149.115.158]`,
 		},
 	}
 
@@ -89,6 +89,9 @@ func TestDNSResponse(t *testing.T) {
 			assert.Equal(t, "dns", event.GetType(), "wrong event type")
 			assert.Equal(t, "www.datadoghq.eu", event.DNS.Question.Name, "wrong domain name")
 			assert.Equal(t, uint8(model.DNSResponseCodeConstants["NOERROR"]), event.DNS.Response.ResponseCode, "wrong response code")
+			assert.Len(t, event.DNS.Response.IPs, 1, "wrong resolved IP count")
+			assert.Equal(t, "34.149.115.158", event.DNS.Response.IPs[0].IP.String(), "wrong resolved IP")
+			assert.Empty(t, event.DNS.Response.CNames, "unexpected CNAMEs")
 
 			test.validateDNSSchema(t, event)
 		}, "dns_response_ok")

--- a/pkg/security/tests/dns_response_test.go
+++ b/pkg/security/tests/dns_response_test.go
@@ -69,6 +69,13 @@ func TestDNSResponse(t *testing.T) {
 		},
 	}
 
+	ruleDefsResponseIPOnly := []*rules.RuleDefinition{
+		{
+			ID:         "dns_response_ip_only",
+			Expression: `dns.response.ips in [34.149.115.158]`,
+		},
+	}
+
 	test, err := newTestModule(t, nil, ruleDefsRcodeOK, withStaticOpts(testOpts{
 		dnsPort: DNSPort,
 	}))
@@ -95,6 +102,31 @@ func TestDNSResponse(t *testing.T) {
 
 			test.validateDNSSchema(t, event)
 		}, "dns_response_ok")
+	})
+	test.Close()
+
+	test, err = newTestModule(t, nil, ruleDefsResponseIPOnly, withStaticOpts(testOpts{
+		dnsPort: DNSPort,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("catch-dns-response-ip-only", func(t *testing.T) {
+		test.WaitSignalFromRule(t, func() error {
+			hexDump := "00000000000000000000000008004500004ef53c40000111862c7f0000357f00000115b18bb0003a96af5ac281800001000100000000037777770964617461646f6768710265750000010001c00c000100010000003c00042295739e"
+			err = injectHexDump("lo", hexDump)
+
+			return nil
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "dns_response_ip_only")
+			assert.Equal(t, "dns", event.GetType(), "wrong event type")
+			assert.Equal(t, "www.datadoghq.eu", event.DNS.Question.Name, "wrong domain name")
+			assert.Len(t, event.DNS.Response.IPs, 1, "wrong resolved IP count")
+			assert.Equal(t, "34.149.115.158", event.DNS.Response.IPs[0].IP.String(), "wrong resolved IP")
+
+			test.validateDNSSchema(t, event)
+		}, "dns_response_ip_only")
 	})
 	test.Close()
 


### PR DESCRIPTION
### What does this PR do?

This PR enhances DNS response handling in CWS/runtime-security by exposing resolved IP addresses and CNAME targets on DNS response events.

It adds:
- `dns.response.ips` as an IP/CIDR SECL field and JSON field
- `dns.response.cnames` as a string array SECL field and JSON field
- DNS response schema and documentation updates
- a configurable CNAME resolution depth for the DNS resolver
- safer SECL default handling for `dns.response.code` so DNS questions do not match `NOERROR` response rules
- DNS resolver metric fixes for metric names, tag formatting, and StatsD error propagation

It also ensures DNS response drop masks respect disabled discarders and avoids dropping full DNS responses needed by rules that combine `dns.response.code` with other fields.

### Motivation

DNS response events currently expose the response code but not the actual resolved IPs or CNAMEs, making it difficult to write rules based on DNS resolution results.

This PR enables rules such as:

`dns.response.code == NOERROR && dns.response.ips in [1.2.3.4]`

It also fixes misleading DNS resolver metrics and prevents DNS question events from incorrectly matching `dns.response.code == NOERROR`.

### Describe how you validated your changes

Manual validation was also performed with direct DNS queries such as `nslookup perdu.com 8.8.8.8`, confirming that A and AAAA responses include the expected `dns.response.ips` values and match rules using `process.file.name in ["nslookup", "dig"]`.

### Additional Notes

When applications use a local resolver such as `systemd-resolved`, DNS response events may be attributed to the resolver process instead of the original client process. Direct DNS queries to a specific resolver, for example with `dig @8.8.8.8` or `nslookup <domain> 8.8.8.8`, are useful for validating process-scoped DNS response rules.