### PR TITLE
[WP] Fix filtersToProgs with wrong instructions cap

### DIFF
--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -179,6 +179,10 @@ func FilterToInsts(index int, filter Filter, opts ProgOpts) (asm.Instructions, e
 	return insts, nil
 }
 
+// we want to creates progs like that
+// prog1 -> tc1 -> footer -> prog2 -> tc2 -> footer -> progN -> footer
+// where each prog is like this
+// header -> filter 1 -> tc1 -> filter 2 -> tc2 -> ... -> filter n -> footer
 func filtersToProgs(filters []Filter, opts ProgOpts, headerInsts, footerInsts asm.Instructions) ([]asm.Instructions, *multierror.Error) {
 	var (
 		progInsts []asm.Instructions
@@ -186,10 +190,6 @@ func filtersToProgs(filters []Filter, opts ProgOpts, headerInsts, footerInsts as
 		tailCalls int
 		header    bool
 	)
-
-	isMaxSizeExceeded := func(filterInsts, tailCallInsts asm.Instructions) bool {
-		return len(filterInsts)+len(tailCallInsts)+len(footerInsts) > opts.MaxProgSize
-	}
 
 	for i, filter := range filters {
 		filterInsts, err := FilterToInsts(i, filter, opts)
@@ -200,35 +200,29 @@ func filtersToProgs(filters []Filter, opts ProgOpts, headerInsts, footerInsts as
 
 		var tailCallInsts asm.Instructions
 
-		// insert tail call to the current filter if not the last prog
-		if i+1 < len(filters) {
-			tailCallInsts = asm.Instructions{
-				asm.Mov.Reg(asm.R1, opts.ctxSaveReg),
-				asm.LoadMapPtr(asm.R2, opts.tailCallMapFd),
-				asm.Mov.Imm(asm.R3, int32(probes.TCRawPacketFilterKey+uint32(tailCalls)+1)),
-				asm.FnTailCall.Call(),
-			}
+		tailCallInsts = asm.Instructions{
+			asm.Mov.Reg(asm.R1, opts.ctxSaveReg),
+			asm.LoadMapPtr(asm.R2, opts.tailCallMapFd),
+			asm.Mov.Imm(asm.R3, int32(probes.TCRawPacketFilterKey+uint32(tailCalls)+1)),
+			asm.FnTailCall.Call(),
 		}
 
 		// single program exceeded the limit
-		if isMaxSizeExceeded(filterInsts, tailCallInsts) {
+		if len(headerInsts)+len(filterInsts)+len(tailCallInsts)+len(footerInsts) > opts.MaxProgSize {
 			mErr = multierror.Append(mErr, fmt.Errorf("max number of intructions exceeded for rule `%s`", filter.RuleID))
 			continue
 		}
-
 		if !header {
 			progInsts = append(progInsts, headerInsts)
 			header = true
 		}
-		progInsts[tailCalls] = append(progInsts[tailCalls], filterInsts...)
-
 		// max size exceeded, generate a new tail call
-		if isMaxSizeExceeded(progInsts[tailCalls], tailCallInsts) {
+		if len(progInsts[tailCalls])+len(filterInsts)+len(tailCallInsts)+len(footerInsts) > opts.MaxProgSize {
+			// check if the max number of tail calls has been reached
 			if opts.MaxTailCalls != 0 && tailCalls >= opts.MaxTailCalls {
 				mErr = multierror.Append(mErr, fmt.Errorf("maximum allowed tail calls reach: %d vs %d", tailCalls, opts.MaxTailCalls))
 				break
 			}
-
 			// insert tail call to the current filter if not the last prog
 			progInsts[tailCalls] = append(progInsts[tailCalls], tailCallInsts...)
 
@@ -239,8 +233,15 @@ func filtersToProgs(filters []Filter, opts ProgOpts, headerInsts, footerInsts as
 			header = false
 			tailCalls++
 		}
-	}
+		// check again if it's a header in case of a split
+		if !header {
+			progInsts = append(progInsts, headerInsts)
+			header = true
+		}
+		progInsts[tailCalls] = append(progInsts[tailCalls], filterInsts...)
 
+	}
+	// insert the event sender instructions for the last prog that was created
 	if tailCalls < len(progInsts) && header {
 		progInsts[tailCalls] = append(progInsts[tailCalls], footerInsts...)
 	}

--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -182,7 +182,7 @@ func FilterToInsts(index int, filter Filter, opts ProgOpts) (asm.Instructions, e
 // we want to creates progs like that
 // prog1 -> tc1 -> footer -> prog2 -> tc2 -> footer -> progN -> footer
 // where each prog is like this
-// header -> filter 1 -> tc1 -> filter 2 -> tc2 -> ... -> filter n -> footer
+// header -> filter 1 -> filter 2 -> ... -> filter n -> footer
 func filtersToProgs(filters []Filter, opts ProgOpts, headerInsts, footerInsts asm.Instructions) ([]asm.Instructions, *multierror.Error) {
 	var (
 		progInsts []asm.Instructions

--- a/pkg/security/ebpf/tests/raw_packet_test.go
+++ b/pkg/security/ebpf/tests/raw_packet_test.go
@@ -22,7 +22,11 @@ import (
 )
 
 const (
-	instLen = 60
+	// Len tailCallInsts: 4
+	// Len headerInsts: 14
+	// Len filterInsts: 36
+	// Len footerInsts: 8
+	instLen = 62
 )
 
 func testRawPacketFilter(t *testing.T, filters []rawpacket.Filter, progName string, expRetCode int64, expProgNum int, opts rawpacket.ProgOpts, catchCompilerError bool) {

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -799,6 +799,11 @@ func TestRawPacketFilter(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, progSpecs)
 
+		for _, prog := range progSpecs {
+			// check if len of proc insturctions is lower than the limit
+			assert.Less(t, len(prog.Instructions), opts.MaxProgSize)
+		}
+
 		colSpec := ebpf.CollectionSpec{
 			Programs: make(map[string]*ebpf.ProgramSpec),
 		}
@@ -831,7 +836,7 @@ func TestRawPacketFilter(t *testing.T) {
 
 		opts := rawpacket.DefaultProgOpts()
 		opts.MaxProgSize = 4000
-		opts.NopInstLen = 3500
+		opts.NopInstLen = 1000
 		runTest(t, filters, opts)
 	})
 }


### PR DESCRIPTION
### What does this PR do?
Fix the function `filtersToProgs`.

### Motivation
The function was intended to generate programs capped at 4,000 instructions. However, the algorithm would split the program only after adding the filter that caused the instruction limit to be exceeded.

### Describe how you validated your changes
Here is an example of the sizes of the progs before and after the fix.

```
=== RUN   TestRawPacketFilter/all-with-limit
len(prog.Instructions): 7142
len(prog.Instructions): 7126
len(prog.Instructions): 7146
len(prog.Instructions): 7102
len(prog.Instructions): 7138
len(prog.Instructions): 3555

```

After the fix the test fails because we need more than 5 tail calls.

```
=== RUN   TestRawPacketFilter/all-with-limit
    network_test.go:799:
        	Error Trace:	/Users/theo.putegnat/dd/datadog-agent/pkg/security/tests/network_test.go:799
        	            				/Users/theo.putegnat/dd/datadog-agent/pkg/security/tests/network_test.go:841
        	Error:      	Received unexpected error:
        	            	1 error occurred:
        	            		* maximum allowed tail calls reach: 5 vs 5

        	Test:       	TestRawPacketFilter/all-with-limit
len(prog.Instructions): 3591
len(prog.Instructions): 3577
len(prog.Instructions): 3562
len(prog.Instructions): 3590
len(prog.Instructions): 3572
len(prog.Instructions): 3596

```

For example, the first filter contains 87 instructions (3,500 NOPs), including all the additional instructions. After the fix, the instruction count increases by 4 due to the insertion of the tail call.