### PR TITLE
fix(sqg): SUSE gates were measuring the non-SUSE RPM

### DIFF
--- a/tasks/static_quality_gates/gates.py
+++ b/tasks/static_quality_gates/gates.py
@@ -337,6 +337,9 @@ class PackageArtifactMeasurer:
         package_dir = os.environ['OMNIBUS_PACKAGE_DIR']
         if config.os == "windows":
             package_dir = f"{package_dir}/pipeline-{os.environ['CI_PIPELINE_ID']}"
+        elif config.os == "suse":
+            # SUSE producer jobs relocate their RPM to OMNIBUS_PACKAGE_DIR_SUSE.
+            package_dir = os.environ['OMNIBUS_PACKAGE_DIR_SUSE']
 
         # Map architecture for certain OSes
         arch = config.arch

--- a/tasks/unit_tests/static_quality_gates/gates_tests.py
+++ b/tasks/unit_tests/static_quality_gates/gates_tests.py
@@ -235,13 +235,13 @@ class TestPackageArtifactMeasurer(unittest.TestCase):
 
         self.assertIn("Couldn't find any DEB file", str(cm.exception))
 
-    @patch.dict('os.environ', {'OMNIBUS_PACKAGE_DIR': '/test/pkg'})
+    @patch.dict('os.environ', {'OMNIBUS_PACKAGE_DIR': '/test/pkg', 'OMNIBUS_PACKAGE_DIR_SUSE': '/test/suse/pkg'})
     def test_find_package_path_patterns(self):
         test_cases = [
             ("static_quality_gate_agent_deb_amd64", "/test/pkg/datadog-agent_7*amd64.deb"),
             ("static_quality_gate_agent_deb_amd64_fips", "/test/pkg/datadog-fips-agent_7*amd64.deb"),
             ("static_quality_gate_iot_agent_rpm_arm64", "/test/pkg/datadog-iot-agent-7*aarch64.rpm"),
-            ("static_quality_gate_dogstatsd_suse_amd64", "/test/pkg/datadog-dogstatsd-7*x86_64.rpm"),
+            ("static_quality_gate_dogstatsd_suse_amd64", "/test/suse/pkg/datadog-dogstatsd-7*x86_64.rpm"),
             ("static_quality_gate_agent_heroku_amd64", "/test/pkg/datadog-heroku-agent_7*amd64.deb"),
         ]
 


### PR DESCRIPTION
### What does this PR do?

`PackageArtifactMeasurer._find_package_by_pattern` (`tasks/static_quality_gates/gates.py`) hard-coded `\$OMNIBUS_PACKAGE_DIR` for every gate except Windows. SUSE producer jobs relocate their RPM to `\$OMNIBUS_PACKAGE_DIR_SUSE` after build, leaving only the regular (non-SUSE) RPM in `\$OMNIBUS_PACKAGE_DIR` — which is what the SQG job's measurer has been picking up for all SUSE gates. Add a SUSE branch to look in the right directory.

### Motivation

Found while validating an unrelated SQG change ([job 1724003013](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1724003013) ran the legacy measurer alongside a new S3-report-based one). Telltale signature in that comparison output: every SUSE gate's measured wire size was identical *to the byte* to its non-SUSE counterpart for the same arch / fips flavor:

| OLD measurement (bytes) | `*_rpm_*` | `*_suse_*` |
|---|---:|---:|
| `agent_*_amd64` | 187634065 | **187634065** |
| `agent_*_amd64_fips` | 177773021 | **177773021** |
| `agent_*_arm64` | 168845993 | **168845993** |
| `agent_*_arm64_fips` | 160376365 | **160376365** |
| `dogstatsd_*_amd64` | 8382529 | **8382529** |
| `iot_agent_*_amd64` | 12305449 | **12305449** |

After this fix the SUSE measurements should diverge from the regular RPM ones by a few hundred bytes to ~20 KB (the difference between regular and SUSE RPM metadata). The differences are well within current thresholds, so no threshold bumps are expected.

### Describe how you validated your changes

- Side-by-side measurement in [job 1724003013](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1724003013) confirmed the deltas above; SQG passes with the new (correct) values.