### PR TITLE
antithesis(logs): file tailer drops and re-reads logs (rotation, seek, multi-line)

### DIFF
--- a/pkg/logs/tailers/file/antithesis_multiline_rotation_demo_test.go
+++ b/pkg/logs/tailers/file/antithesis_multiline_rotation_demo_test.go
@@ -1,0 +1,269 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// Antithesis bug *demonstration* (not a fix), gated behind the `antithesis_demo`
+// build tag so it never runs in normal CI.  Run with:
+//
+//	go test -tags "antithesis_demo test" \
+//	    -run TestAntithesisMultilineRotationDiscard \
+//	    ./pkg/logs/tailers/file/ -v
+//
+// Property under test: multiline-not-split-across-pipelines
+//
+// Hypothesis (from scratchbook): StopAfterFileRotation() cancels forwardContext
+// (via stopForward()) BEFORE decoder.Stop() flushes the aggregated multiline
+// event. forwardMessages() selects on <-forwardContext.Done() and discards any
+// messages pushed by Flush() after the context is already cancelled. A multiline
+// event buffered in the aggregator at rotation time is therefore silently dropped.
+//
+// Setup — how multiline aggregation is confirmed:
+//   - A ProcessingRule of type "multi_line" with pattern "^BEGIN:" is set on the
+//     source.  The RegexAggregator in the decoder will hold any line whose content
+//     starts with "BEGIN:" as the start of a group, appending all following
+//     non-matching (continuation) lines into a single combined message.
+//   - A group is only emitted when the NEXT header line arrives or Flush() fires.
+//   - We write ONE header + TWO continuation lines and wait for nothing more to
+//     arrive before triggering rotation, so the combined event stays buffered.
+//   - Control test (TestAntithesisMultilineAggregationControl): same pattern but
+//     we wait > flushTimeout and assert the combined event IS delivered.
+//
+// Rotation test:
+//   - closeTimeout is set to 200 ms (well under the 1 s flushTimeout).
+//   - Output channel is large (1000) so there is no backpressure — the *only*
+//     reason for loss is the forwardContext cancellation race.
+//   - We call StopAfterFileRotation() 50 ms after writing, ensuring the timer
+//     fires (cancelling forwardContext) before decoder.Stop()/Flush() runs.
+//   - We then wait for tailer.done and drain the output channel.
+//   - A combined event in the output proves delivery. Its absence proves the bug.
+//
+// EXPECTED OUTCOME FOR BUG TEST: FAILS — the combined event is discarded.
+// EXPECTED OUTCOME FOR CONTROL:  PASSES — the combined event is delivered.
+
+package file
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	auditormock "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/opener"
+)
+
+// multilineRotationTestBed sets up a tailer with a multi_line ProcessingRule
+// so that lines starting with "BEGIN:" are aggregated with their continuations.
+// The flushTimeout is configurable via the global config mock.
+// closeTimeout is set by the caller on the returned tailer.
+func multilineRotationTestBed(t *testing.T, dir string) (*Tailer, chan *message.Message, *os.File) {
+	t.Helper()
+
+	// Use a short aggregation timeout (2 s) so the control test doesn't wait too long,
+	// but still >> closeTimeout (200 ms) so the rotation test fires before flush.
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("logs_config.aggregation_timeout", 2000) // 2 000 ms
+
+	re := regexp.MustCompile(`^BEGIN:`)
+	rule := &config.ProcessingRule{
+		Type:    config.MultiLine,
+		Name:    "stacktrace_header",
+		Pattern: "BEGIN:",
+		Regex:   re,
+	}
+
+	path := filepath.Join(dir, fmt.Sprintf("ml-rotation-%d.log", time.Now().UnixNano()))
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create log file: %v", err)
+	}
+
+	src := sources.NewReplaceableSource(sources.NewLogSource("", &config.LogsConfig{
+		Type:            config.FileType,
+		Path:            path,
+		ProcessingRules: []*config.ProcessingRule{rule},
+	}))
+	info := status.NewInfoRegistry()
+
+	outputChan := make(chan *message.Message, 1000) // large — no backpressure
+
+	tailer := NewTailer(&TailerOptions{
+		OutputChan:      outputChan,
+		File:            NewFile(path, src.UnderlyingSource(), false),
+		SleepDuration:   5 * time.Millisecond,
+		Decoder:         decoder.NewDecoderFromSource(src, info),
+		Info:            info,
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
+		Registry:        auditormock.NewMockRegistry(),
+		FileOpener:      opener.NewFileOpener(),
+	})
+
+	return tailer, outputChan, f
+}
+
+// drainMessages reads everything currently available on outputChan without blocking.
+func drainMessages(outputChan chan *message.Message) []*message.Message {
+	var msgs []*message.Message
+	for {
+		select {
+		case m := <-outputChan:
+			msgs = append(msgs, m)
+		default:
+			return msgs
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// Control test — proves multiline aggregation actually works.
+// Writes header + 2 continuation lines, waits > flushTimeout, expects ONE
+// combined message with all three lines joined.  If this passes, aggregation
+// is engaged and the rotation test result is meaningful.
+// --------------------------------------------------------------------------
+
+func TestAntithesisMultilineAggregationControl(t *testing.T) {
+	dir := t.TempDir()
+	tailer, outputChan, f := multilineRotationTestBed(t, dir)
+	defer f.Close()
+
+	tailer.closeTimeout = 60 * time.Second // normal stop, not rotation
+	if err := tailer.StartFromBeginning(); err != nil {
+		t.Fatalf("start tailer: %v", err)
+	}
+	defer tailer.Stop()
+
+	// Write: one header + two continuations, then a SECOND header to trigger flush
+	// of the first group (ensures aggregation is tested without relying solely on timeout).
+	lines := []string{
+		"BEGIN: exception in goroutine main\n",
+		"    at pkg/foo/bar.go:42\n",
+		"    at pkg/foo/baz.go:17\n",
+		"BEGIN: second event (triggers flush of first)\n",
+	}
+	for _, l := range lines {
+		if _, err := f.WriteString(l); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	// Wait for the first combined event to arrive (flush triggered by second header).
+	var got *message.Message
+	select {
+	case got = <-outputChan:
+	case <-time.After(3 * time.Second):
+		t.Fatal("CONTROL FAILED: no message received within 3s — multiline aggregation did not engage")
+	}
+
+	content := string(got.GetContent())
+	t.Logf("CONTROL: received message: %q", content)
+
+	if !strings.HasPrefix(content, "BEGIN: exception") {
+		t.Fatalf("CONTROL FAILED: first message does not start with header: %q", content)
+	}
+	if !strings.Contains(content, "pkg/foo/bar.go") || !strings.Contains(content, "pkg/foo/baz.go") {
+		t.Fatalf("CONTROL FAILED: continuation lines missing from aggregated message: %q", content)
+	}
+
+	t.Logf("CONTROL PASSED: aggregation confirmed — header + continuations combined into one message")
+}
+
+// --------------------------------------------------------------------------
+// Bug demonstration — rotation discards buffered multiline event.
+// Writes header + 2 continuation lines (NO following header), triggers
+// StopAfterFileRotation() 50 ms later (before flushTimeout fires), and
+// checks whether the combined event is delivered.
+// EXPECTED TO FAIL — demonstrating the silent discard.
+// --------------------------------------------------------------------------
+
+func TestAntithesisMultilineRotationDiscard(t *testing.T) {
+	dir := t.TempDir()
+	tailer, outputChan, f := multilineRotationTestBed(t, dir)
+	defer f.Close()
+
+	// closeTimeout << flushTimeout (2 s): the stopForward goroutine cancels
+	// forwardContext ~200 ms after rotation, well before decoder.Stop()/Flush()
+	// would emit the buffered group.
+	tailer.closeTimeout = 200 * time.Millisecond
+
+	if err := tailer.StartFromBeginning(); err != nil {
+		t.Fatalf("start tailer: %v", err)
+	}
+
+	// Write the multiline event: header + 2 continuation lines.
+	// No second header follows — the group stays buffered in RegexAggregator.
+	event := []string{
+		"BEGIN: NullPointerException in thread main\n",
+		"    at com.example.Foo.run(Foo.java:10)\n",
+		"    at com.example.Bar.call(Bar.java:5)\n",
+	}
+	for _, l := range event {
+		if _, err := f.WriteString(l); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	// Let the tailer read all three lines (sleepDuration is 5 ms; 50 ms is plenty).
+	time.Sleep(50 * time.Millisecond)
+
+	// Simulate file rotation.  closeTimeout=200 ms means stopForward() will fire
+	// ~200 ms from now, cancelling forwardContext BEFORE decoder.Stop()/Flush().
+	tailer.StopAfterFileRotation()
+
+	// Wait for the tailer to finish.
+	select {
+	case <-tailer.done:
+	case <-time.After(tailer.closeTimeout + 5*time.Second):
+		t.Fatal("tailer did not stop within the expected window")
+	}
+
+	// Drain whatever made it to the output channel.
+	msgs := drainMessages(outputChan)
+	t.Logf("received %d message(s) after rotation", len(msgs))
+	for i, m := range msgs {
+		t.Logf("  msg[%d]: %q", i, string(m.GetContent()))
+	}
+
+	// Look for the combined multiline event.
+	var found bool
+	for _, m := range msgs {
+		c := string(m.GetContent())
+		if strings.HasPrefix(c, "BEGIN: NullPointerException") &&
+			strings.Contains(c, "Foo.java:10") &&
+			strings.Contains(c, "Bar.java:5") {
+			found = true
+			t.Logf("combined event delivered: %q", c)
+			break
+		}
+	}
+
+	if !found {
+		// Report what (if anything) was delivered.
+		var delivered []string
+		for _, m := range msgs {
+			delivered = append(delivered, string(m.GetContent()))
+		}
+		t.Fatalf(
+			"BUG DEMONSTRATED (multiline-not-split-across-pipelines): "+
+				"multiline event buffered in RegexAggregator at rotation time was "+
+				"silently discarded — stopForward() cancelled forwardContext before "+
+				"decoder.Stop()/Flush() could push the combined event. "+
+				"Messages actually delivered (%d): %v",
+			len(delivered), delivered,
+		)
+	}
+
+	t.Logf("HYPOTHESIS REFUTED: combined multiline event was delivered despite rotation")
+}

--- a/pkg/logs/tailers/file/antithesis_rotation_loss_demo_test.go
+++ b/pkg/logs/tailers/file/antithesis_rotation_loss_demo_test.go
@@ -1,0 +1,122 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// This file is an Antithesis bug *demonstration*, not a fix. It is gated behind
+// the `antithesis_demo` build tag so it never runs in normal CI. Run it with:
+//
+//	go test -tags antithesis_demo -run TestAntithesisRotationUnderBackpressureLoss \
+//	    ./pkg/logs/tailers/file/ -v
+//
+// It demonstrates property `backpressure-no-rotation-loss` from the Antithesis
+// research catalog: when a file rotates while the pipeline is backpressured, log
+// lines that were read but not yet forwarded are silently discarded when the
+// rotation close-timeout fires (`Tailer.StopAfterFileRotation` cancels
+// `forwardContext` before the in-flight messages drain). No data-loss metric beyond
+// the coarse per-rotation `BytesMissed` is emitted, and the lines never reach the
+// output. The test ASSERTS at-least-once delivery and is EXPECTED TO FAIL, proving
+// the loss.
+
+package file
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	auditormock "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/opener"
+)
+
+func TestAntithesisRotationUnderBackpressureLoss(t *testing.T) {
+	const (
+		totalLines  = 50
+		outChanSize = 3 // small => downstream backpressures quickly
+	)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tailer.log")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+
+	// Write more lines than the output channel can hold so the pipeline backs up.
+	for i := 0; i < totalLines; i++ {
+		if _, err := f.WriteString(fmt.Sprintf("L%05d\n", i)); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	outputChan := make(chan *message.Message, outChanSize)
+	src := sources.NewReplaceableSource(sources.NewLogSource("", &config.LogsConfig{
+		Type: config.FileType,
+		Path: path,
+	}))
+	info := status.NewInfoRegistry()
+
+	tailer := NewTailer(&TailerOptions{
+		OutputChan:      outputChan,
+		File:            NewFile(path, src.UnderlyingSource(), false),
+		SleepDuration:   10 * time.Millisecond,
+		Decoder:         decoder.NewDecoderFromSource(src, info),
+		Info:            info,
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
+		Registry:        auditormock.NewMockRegistry(),
+		FileOpener:      opener.NewFileOpener(),
+	})
+	// Short rotation close-timeout so the demo runs quickly (default is 60s).
+	tailer.closeTimeout = 1 * time.Second
+
+	if err := tailer.StartFromBeginning(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Let the tailer read the file and fill/​block on the output channel
+	// (downstream is intentionally NOT draining => backpressure).
+	time.Sleep(300 * time.Millisecond)
+
+	// The file rotates while the tailer is backpressured.
+	tailer.StopAfterFileRotation()
+
+	// Wait for the tailer to fully stop (closeTimeout governs the drop).
+	select {
+	case <-tailer.done:
+	case <-time.After(tailer.closeTimeout + 10*time.Second):
+		t.Fatal("tailer did not stop")
+	}
+
+	// Drain whatever actually made it to the output.
+	received := map[string]bool{}
+	for {
+		select {
+		case msg := <-outputChan:
+			received[string(msg.GetContent())] = true
+		default:
+			goto done
+		}
+	}
+done:
+
+	t.Logf("delivered %d / %d lines after rotation-under-backpressure", len(received), totalLines)
+
+	// Property backpressure-no-rotation-loss: every written line is delivered at
+	// least once. EXPECTED TO FAIL — demonstrating silent loss on rotation.
+	if len(received) != totalLines {
+		t.Fatalf("BUG DEMONSTRATED (backpressure-no-rotation-loss): %d of %d lines "+
+			"silently dropped on file rotation under backpressure; only %d delivered",
+			totalLines-len(received), totalLines, len(received))
+	}
+}

--- a/pkg/logs/tailers/file/antithesis_seek_error_demo_test.go
+++ b/pkg/logs/tailers/file/antithesis_seek_error_demo_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// Antithesis bug *demonstration* (not a fix), gated behind `antithesis_demo`. Run:
+//
+//	go test -tags "antithesis_demo test" -run TestAntithesisSeekErrorOffsetRegression \
+//	    ./pkg/logs/tailers/file/ -v
+//
+// Demonstrates property `offset-no-regression-on-seek-error`: when the lseek that
+// positions a resuming tailer at its saved offset fails (a filesystem fault),
+// `tailer_nix.go` does `ret, _ := f.Seek(offset, whence)` — discarding the error and
+// storing `ret` (0) as the read offset. The tailer re-reads the file from the start,
+// re-delivering every already-consumed line (an unbounded duplicate storm). The
+// experiment resumes from a mid-file offset behind a Seek-failing file and the test
+// ASSERTS no line before the resume offset is re-delivered. EXPECTED TO FAIL.
+//
+// The fault injection and experiment live in antithesis_demo_support.go so the SUT
+// harness (pkg/logs/cmd/antithesis-rotation-demo) shares the exact same code.
+
+package file
+
+import (
+	"testing"
+)
+
+func TestAntithesisSeekErrorOffsetRegression(t *testing.T) {
+	res, err := RunSeekErrorExperiment(t.TempDir())
+	if err != nil {
+		t.Fatalf("experiment error: %v", err)
+	}
+	t.Logf("resumed from line %d; delivered %d messages; first=%q",
+		res.ResumeLine, res.DeliveredCount, res.FirstLine)
+
+	if res.Regressed {
+		t.Fatalf("BUG DEMONSTRATED (offset-no-regression-on-seek-error): seek failed, the "+
+			"error was discarded, offset regressed to 0, and already-consumed lines "+
+			"(L00000..) were re-delivered. Resume from line %d was ignored.", res.ResumeLine)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds tests that show the file tailer losing or repeating log lines. They run the real tailer and are off in normal CI (`antithesis_demo` build tag):

- **Loss on rotation under load** — when the agent is behind and a log file rotates, lines it already read but hadn't sent are thrown away. The "bytes missed" metric doesn't catch it, because those bytes were read. Antithesis hit this 41,043 times.
- **Whole file re-read on a seek error** — if seeking to the saved position fails, the error is ignored and the tailer starts over at the top, re-sending everything. Antithesis hit this 39,673 times.
- **Multi-line logs cut at rotation** — a stack trace still being assembled when a file rotates is dropped instead of sent.

### Motivation

Part of the logs-agent Antithesis work. The runnable program and the shared test helper these use live in the harness PR (#51515), just below this in the stack.

### Describe how you validated your changes

`go test -tags "antithesis_demo test" -run TestAntithesis ./pkg/logs/tailers/file/ -v`. The tests fail on purpose — the failure is the bug. Two were also confirmed on Antithesis.

### Additional Notes

Just the three bug tests; the program and helper moved to #51515. Doesn't run in normal CI; meant to fail. No agent code changed.
