### PR TITLE
antithesis(logs): pipeline failover hangs/crashes on shutdown and reorders logs

### DIFF
--- a/comp/logs-library/pipeline/antithesis_no_send_on_closed_demo_test.go
+++ b/comp/logs-library/pipeline/antithesis_no_send_on_closed_demo_test.go
@@ -1,0 +1,297 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// Antithesis bug *demonstration* (not a fix), gated behind `antithesis_demo`. Run:
+//
+//	go test -tags "antithesis_demo test" \
+//	    -run "TestAntithesisNoSendOnClosedOnShutdown" \
+//	    ./comp/logs-library/pipeline/ -v -timeout 10s \
+//	    2>&1 | grep -vE "^[0-9]{16} \[Info\]"
+//
+// Demonstrates property `no-send-on-closed-on-shutdown` (Path 1):
+//
+// In pipeline-failover mode, `forwardWithFailover` (provider.go:361) performs a
+// plain blocking send:
+//
+//	p.pipelines[primaryPipelineIndex].InputChan <- msg
+//
+// `provider.Stop()` (provider.go:283-300) first closes all routerChannels, then
+// calls `p.forwarderWaitGroup.Wait()`. If the forwarder goroutine is blocked at
+// line 361 (because `pipeline.InputChan` is full and the processor is not draining
+// it), the `Wait()` hangs forever — `p.forwarderWaitGroup.Wait()` has NO timeout.
+//
+// Sub-test 1 (TestAntithesisForwarderHangsOnFullInputChan):
+//
+//	Demonstrates the hang: forwarder is blocked at line 361 when Stop() is called.
+//	Stop() returns only after the timeout that this test imposes — never on its own.
+//	EXPECTED TO FAIL with "BUG DEMONSTRATED … Stop() hung".
+//
+// Sub-test 2 (TestAntithesisForwarderPanicsOnInputChanClose):
+//
+//	Demonstrates the panic: reproduces the Antithesis scenario where an external
+//	force (e.g. the grace-period forceClose → destinationsCtx.Stop() eventually
+//	flowing back to close InputChan, or a concurrent Stop() call) closes
+//	`pipeline.InputChan` while the forwarder goroutine is mid-send. The goroutine
+//	was blocked at line 361; the close fires first; the goroutine resumes and sends
+//	to a closed channel → panic: send on closed channel.
+//	EXPECTED TO FAIL with "BUG DEMONSTRATED … panic: send on closed channel".
+//
+// Both sub-tests assert clean shutdown (no hang, no panic). They are EXPECTED TO FAIL.
+
+package pipeline
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
+	"github.com/DataDog/datadog-agent/comp/logs-library/sender"
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	compressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// blockingSender is a PipelineComponent whose input channel is never drained.
+// When the pipeline strategy tries to send a payload to the sender, it blocks
+// indefinitely (channel full). This backs up the strategy, which backs up the
+// processor, which backs up pipeline.InputChan — causing forwardWithFailover to
+// block at the plain send on line 361 of provider.go.
+type blockingSender struct {
+	inputChan chan *message.Payload
+	monitor   metrics.PipelineMonitor
+}
+
+func newBlockingSender() *blockingSender {
+	return &blockingSender{
+		// Size 0: the very first send from the strategy will block the sender goroutine.
+		inputChan: make(chan *message.Payload, 0),
+		monitor:   metrics.NewTelemetryPipelineMonitor(),
+	}
+}
+
+func (b *blockingSender) Start()                              {}
+func (b *blockingSender) Stop()                               {}
+func (b *blockingSender) In() chan *message.Payload           { return b.inputChan }
+func (b *blockingSender) PipelineMonitor() metrics.PipelineMonitor { return b.monitor }
+
+// createBlockingProviderWithFailover creates a provider with failover enabled
+// and a blocking sender so that pipeline.InputChan fills up and the forwarder
+// goroutine blocks at provider.go:361.
+func createBlockingProviderWithFailover(t *testing.T) *provider {
+	cfg := configmock.New(t)
+	cfg.SetWithoutSource("logs_config.pipeline_failover.enabled", true)
+	// Unbuffered message channel: the very first message will fill it if the
+	// processor cannot forward to the strategy immediately.
+	cfg.SetWithoutSource("logs_config.message_channel_size", 0)
+	// Unbuffered router channel: the router goroutine (tailer) will also block
+	// as soon as the forwarder isn't reading.
+	cfg.SetWithoutSource("logs_config.pipeline_failover.router_channel_size", 0)
+
+	endpoints := config.NewMockEndpointsWithOptions(
+		[]config.Endpoint{config.NewMockEndpoint()},
+		map[string]interface{}{"use_http": true},
+	)
+
+	p := newProvider(
+		1, // single pipeline so primaryPipelineIndex == routerIndex == 0
+		&diagnostic.BufferedMessageReceiver{},
+		nil, // no processing rules
+		endpoints,
+		nil, // no hostname
+		cfg,
+		compressionfx.NewMockCompressor(),
+		sender.NewServerlessMeta(false),
+		newBlockingSender(),
+	).(*provider)
+
+	p.Start()
+	return p
+}
+
+// callWithTimeout runs f() in a goroutine.
+// Returns ("ok", panicVal) if f() returns within timeout, or ("hang", nil) if not.
+func callWithTimeout(f func(), timeout time.Duration) (outcome string, panicVal interface{}) {
+	done := make(chan interface{}, 1)
+	go func() {
+		defer func() { done <- recover() }()
+		f()
+	}()
+	select {
+	case p := <-done:
+		return "ok", p
+	case <-time.After(timeout):
+		return "hang", nil
+	}
+}
+
+// TestAntithesisForwarderHangsOnFullInputChan demonstrates that provider.Stop()
+// hangs indefinitely when forwardWithFailover is blocked at the plain send on
+// provider.go:361.
+//
+// Sequence:
+//  1. The blocking sender never drains payloads, causing the pipeline's strategy
+//     to block, backing up the processor, filling InputChan.
+//  2. We send one message to the router channel. The forwarder goroutine picks it
+//     up, trySendToPipeline returns false (all InputChans full), and the goroutine
+//     blocks at `p.pipelines[0].InputChan <- msg` (provider.go:361).
+//  3. We call Stop(). Stop() closes routerChannels (line 287) — this does NOT
+//     wake the goroutine (it is blocked on InputChan, not on the router channel).
+//  4. Stop() calls forwarderWaitGroup.Wait() (line 289) — hangs forever because
+//     the forwarder goroutine never reaches forwarderWaitGroup.Done().
+//
+// Property: no-send-on-closed-on-shutdown. EXPECTED TO FAIL.
+func TestAntithesisForwarderHangsOnFullInputChan(t *testing.T) {
+	p := createBlockingProviderWithFailover(t)
+
+	// Get the router channel for pipeline 0.
+	routerChan := p.routerChannels[0]
+
+	// Send one message. The forwarder goroutine will read it from the router
+	// channel and then attempt to send it to pipeline.InputChan. Since the
+	// sender never drains, the strategy and processor are all backed up and
+	// InputChan will block. Give it a moment to reach the blocking state.
+	go func() {
+		routerChan <- makeTestMsg("block-me")
+	}()
+
+	// Wait for the forwarder goroutine to reach the blocking send on InputChan.
+	// (The router channel has size 0, so this goroutine will itself block until
+	// the forwarder reads from the router — meaning the forwarder has received
+	// the message and moved on to the blocking InputChan send.)
+	time.Sleep(100 * time.Millisecond)
+
+	// Now call Stop(). If the bug is present, Stop() closes routerChannels then
+	// waits on forwarderWaitGroup.Wait() — which never returns.
+	const stopTimeout = 500 * time.Millisecond
+	outcome, panicVal := callWithTimeout(p.Stop, stopTimeout)
+
+	switch outcome {
+	case "hang":
+		t.Fatalf(
+			"BUG DEMONSTRATED (no-send-on-closed-on-shutdown / hang): "+
+				"provider.Stop() hung for >%v — forwardWithFailover goroutine is "+
+				"blocked at provider.go:361 (`p.pipelines[0].InputChan <- msg`, a "+
+				"plain blocking send with no select/stop signal). "+
+				"provider.Stop() (provider.go:287-289) closes routerChannels then calls "+
+				"forwarderWaitGroup.Wait() — but the goroutine is blocked on InputChan, "+
+				"not on the router channel, so it never reaches forwarderWaitGroup.Done(). "+
+				"Fix: replace the plain send with a select that also listens on a stop channel.",
+			stopTimeout,
+		)
+	case "ok":
+		if panicVal != nil {
+			t.Fatalf(
+				"BUG DEMONSTRATED (no-send-on-closed-on-shutdown / panic): "+
+					"provider.Stop() panicked: %v",
+				panicVal,
+			)
+		}
+		// Stop() returned cleanly — no hang on this run (e.g. the blocking
+		// condition was not triggered in time). Test passes.
+	}
+}
+
+// TestAntithesisForwarderPanicsOnInputChanClose demonstrates the send-on-closed-
+// channel panic that occurs when an external force closes pipeline.InputChan
+// while a goroutine is mid-send on it — the exact mechanism at provider.go:361.
+//
+// Background: the `forwardWithFailover` goroutine blocks at line 361:
+//
+//	p.pipelines[primaryPipelineIndex].InputChan <- msg  // plain send, no select
+//
+// Under Antithesis CPU-pause or when the outer grace-period watchdog (agent.go
+// stopComponents, ~35 s) fires, it calls forceClose → destinationsCtx.Stop() →
+// (eventually) processor.Stop() (processor.go:132: close(p.inputChan)) while the
+// forwarder goroutine is still blocked on that channel.  The goroutine resumes
+// after the close and immediately panics: send on closed channel.
+//
+// Because the panic occurs inside the forwardWithFailover goroutine (not in the
+// goroutine calling close()), we cannot catch it with a defer/recover in this test
+// without modifying production code. Instead this test demonstrates the precise
+// underlying mechanism: a goroutine blocked on a channel send PANICS when the
+// channel is closed by a concurrent goroutine, using a local channel that mirrors
+// what InputChan is.  It then cross-references the production code path.
+//
+// Property: no-send-on-closed-on-shutdown. EXPECTED TO FAIL.
+func TestAntithesisForwarderPanicsOnInputChanClose(t *testing.T) {
+	// Construct the exact Go channel race that provider.go:361 exhibits.
+	//
+	// - ch models pipeline.InputChan (unbuffered, as set in createBlockingProviderWithFailover)
+	// - senderGoroutine models forwardWithFailover blocked at line 361
+	// - closerGoroutine models processor.Stop() (processor.go:132: close(p.inputChan))
+	//
+	// The panic happens in the sender goroutine, not the closer goroutine. Without
+	// a recover() in the sender goroutine, this would crash the test binary. We wrap
+	// the sender goroutine with recover() to capture the panic value and report it.
+	ch := make(chan *message.Message, 0) // mirrors unbuffered InputChan
+	msg := makeTestMsg("panic-me")
+
+	// Channel to receive the panic value from the sender goroutine.
+	panicCh := make(chan interface{}, 1)
+
+	// Sender goroutine: blocks on ch <- msg (mirrors forwardWithFailover line 361).
+	// If ch is closed while this goroutine is blocked, Go runtime fires a panic
+	// "send on closed channel" in this goroutine.
+	go func() {
+		defer func() { panicCh <- recover() }()
+		ch <- msg // blocks until someone reads OR channel is closed
+	}()
+
+	// Give the sender goroutine time to reach the blocked state on ch <- msg.
+	time.Sleep(50 * time.Millisecond)
+
+	// Closer goroutine: closes ch (mirrors processor.Stop → close(p.inputChan)).
+	// This does NOT panic in the closer goroutine, but DOES panic in the sender.
+	go func() {
+		close(ch) // processor.go:132 equivalent
+	}()
+
+	// Collect the panic value from the sender goroutine.
+	select {
+	case panicVal := <-panicCh:
+		if panicVal != nil {
+			t.Fatalf(
+				"BUG DEMONSTRATED (no-send-on-closed-on-shutdown / panic): "+
+					"a goroutine blocked on `ch <- msg` (mirroring forwardWithFailover "+
+					"provider.go:361: `p.pipelines[primaryPipelineIndex].InputChan <- msg`) "+
+					"panicked when a concurrent goroutine closed the channel: %v\n\n"+
+					"Production code path:\n"+
+					"  1. forwardWithFailover blocks at provider.go:361 on InputChan <- msg\n"+
+					"  2. provider.Stop() (line 287) closes routerChannels — does not unblock\n"+
+					"     the forwarder (it is blocked on InputChan, not routerChannels)\n"+
+					"  3. provider.Stop() (line 289) calls forwarderWaitGroup.Wait() — hangs\n"+
+					"  4. After 30 s grace period, agent.go:stopComponents calls forceClose\n"+
+					"     → destinationsCtx.Stop() → processor.Stop() (processor.go:132)\n"+
+					"     → close(p.inputChan) — the SAME channel the forwarder is blocked on\n"+
+					"  5. forwardWithFailover goroutine resumes and immediately panics:\n"+
+					"     'send on closed channel' — crashing the entire agent process\n\n"+
+					"Fix: replace the plain send at provider.go:361 with a select that "+
+					"also listens on a stop/context channel so the forwarder can be "+
+					"interrupted cleanly before InputChan is closed.",
+				panicVal,
+			)
+		}
+		// Sender goroutine returned without panic — timing not tight enough.
+		// The mechanism proof is still valid; see comment above.
+		t.Log("sender goroutine exited cleanly (no panic captured) — " +
+			"channel close may have raced before the send reached the blocked state. " +
+			"The mechanism is still demonstrated: closing a channel while a goroutine " +
+			"is blocked sending to it always panics. Re-run for a more reliable trigger.")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("BUG DEMONSTRATED (no-send-on-closed-on-shutdown / hang): " +
+			"sender goroutine did not produce a result within 500ms — " +
+			"neither the send completed nor did the close unblock it. " +
+			"This indicates a hang in the mechanism test itself.")
+	}
+}
+
+// makeTestMsg creates a minimal *message.Message for use in provider tests.
+func makeTestMsg(content string) *message.Message {
+	return message.NewMessage([]byte(content), nil, "info", time.Now().UnixNano())
+}

--- a/comp/logs-library/pipeline/failover_ordering_repro_test.go
+++ b/comp/logs-library/pipeline/failover_ordering_repro_test.go
@@ -1,0 +1,323 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// Package pipeline provides log processing pipeline functionality.
+//
+// failover_ordering_repro_test.go — Antithesis demo: per-source ordering violation
+// under pipeline failover.
+//
+// Property under test: per-source-ordering-preserved
+//
+//	README:156 states "Each pipeline handles messages in-order, so assigning each
+//	input to a single pipeline ensures that input's messages will be delivered to
+//	the intake in-order."
+//
+// Suspected violation (provider.go:353-388):
+//
+//	With pipeline_failover.enabled=true, trySendToPipeline iterates through all
+//	pipelines using non-blocking sends. If the primary pipeline's InputChan is
+//	full (backpressured), the message is routed to a secondary pipeline. If a
+//	later message from the same source finds the primary pipeline still full, it
+//	too gets rerouted. The two pipelines drain independently, so the secondary
+//	pipeline may deliver its message BEFORE the primary finishes draining.
+//	Result: output order no longer matches submission order for a single source.
+//
+// Run with:
+//
+//	go test -tags "antithesis_demo test" \
+//	    -run TestFailoverCrossesSourceAcrossPipelines \
+//	    ./comp/logs-library/pipeline/ -v
+package pipeline
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"go.uber.org/atomic"
+
+	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// newPipelineForRepro builds a Pipeline stub with only InputChan and pipelineMonitor
+// populated. The processor and strategy fields are nil — we intentionally never call
+// Start()/Stop() on these stubs; we read directly from InputChan in the test.
+// NoopPipelineMonitor.GetCapacityMonitor returns nil, but CapacityMonitor.AddIngress
+// has a nil guard (capacity_monitor.go:47-50), so no panic occurs.
+func newPipelineForRepro(chanSize int) *Pipeline {
+	return &Pipeline{
+		InputChan:       make(chan *message.Message, chanSize),
+		pipelineMonitor: metrics.NewNoopPipelineMonitor("repro"),
+	}
+}
+
+// newSeqMsg returns a message whose raw content is the given label string.
+// origin is nil — none of the routing functions inspect message origin.
+func newSeqMsg(label string) *message.Message {
+	return message.NewMessage([]byte(label), nil, "info", time.Now().UnixNano())
+}
+
+// TestFailoverCrossesSourceAcrossPipelines is the deterministic core repro.
+//
+// Strategy: construct a minimal provider struct (no real sender/processor) with
+// failoverEnabled=true and 2 pipelines whose InputChans each hold exactly 1 msg.
+// Then:
+//
+//  1. Call trySendToPipeline(MSG-1, primary=0).
+//     Pipeline 0 is empty → non-blocking send succeeds → MSG-1 in p0 (p0 now full).
+//
+//  2. Call trySendToPipeline(MSG-2, primary=0).
+//     Pipeline 0 is full → non-blocking send fails → tries pipeline 1 (empty) →
+//     MSG-2 in p1. Cross-pipeline assignment confirmed.
+//
+//  3. Drain pipeline 1 first (fast pipeline), then pipeline 0 (slow/stalled).
+//     Output order: [MSG-2, MSG-1] — reversed from submission order [MSG-1, MSG-2].
+//
+// The test FAILS with a clear diagnostic when reordering is detected.
+// In the current implementation this ALWAYS fails deterministically.
+func TestFailoverCrossesSourceAcrossPipelines(t *testing.T) {
+	// InputChan size = 1: MSG-1 fills p0 completely, forcing MSG-2 to p1.
+	const chanSize = 1
+
+	p0 := newPipelineForRepro(chanSize)
+	p1 := newPipelineForRepro(chanSize)
+
+	// Construct a provider directly — no real sender, processor, or goroutines.
+	prov := &provider{
+		pipelines:            []*Pipeline{p0, p1},
+		currentPipelineIndex: atomic.NewUint32(0),
+		currentRouterIndex:   atomic.NewUint32(0),
+		failoverEnabled:      true,
+	}
+
+	msg1 := newSeqMsg("MSG-1")
+	msg2 := newSeqMsg("MSG-2")
+
+	// ── Step 1: route MSG-1 ──────────────────────────────────────────────────
+	// Pipeline 0 is empty → attempt 0 succeeds → MSG-1 lands in p0.
+	if !prov.trySendToPipeline(msg1, 0) {
+		t.Fatal("trySendToPipeline(MSG-1): expected success on empty pipeline 0")
+	}
+	if len(p0.InputChan) != 1 || len(p1.InputChan) != 0 {
+		t.Fatalf("after MSG-1: p0=%d (want 1), p1=%d (want 0)",
+			len(p0.InputChan), len(p1.InputChan))
+	}
+	t.Logf("After MSG-1: p0.InputChan=%d/1, p1.InputChan=%d/1",
+		len(p0.InputChan), len(p1.InputChan))
+
+	// ── Step 2: route MSG-2 ──────────────────────────────────────────────────
+	// Pipeline 0 is now FULL (capacity=1).
+	// trySendToPipeline iterates:
+	//   attempt 0 → p0 full → default branch (continue)        [provider.go:383]
+	//   attempt 1 → p1 empty → succeeds → MSG-2 in p1.         [provider.go:378]
+	if !prov.trySendToPipeline(msg2, 0) {
+		t.Fatal("trySendToPipeline(MSG-2): expected failover success on pipeline 1")
+	}
+	if len(p0.InputChan) != 1 || len(p1.InputChan) != 1 {
+		t.Fatalf("after MSG-2: p0=%d (want 1), p1=%d (want 1)",
+			len(p0.InputChan), len(p1.InputChan))
+	}
+	t.Logf("After MSG-2: p0.InputChan=%d/1 (holds MSG-1), p1.InputChan=%d/1 (holds MSG-2)",
+		len(p0.InputChan), len(p1.InputChan))
+	t.Logf("Cross-pipeline split confirmed: MSG-1→pipeline-0, MSG-2→pipeline-1")
+
+	// ── Step 3: differential drain ───────────────────────────────────────────
+	// Simulate pipeline 1 draining faster than pipeline 0 — the real-world
+	// trigger is network backpressure on p0's destination while p1 flows freely.
+	var got []string
+
+	select {
+	case m := <-p1.InputChan: // fast pipeline drains first
+		got = append(got, string(m.GetContent()))
+	default:
+		t.Fatal("pipeline 1 unexpectedly empty")
+	}
+	select {
+	case m := <-p0.InputChan: // slow pipeline drains second
+		got = append(got, string(m.GetContent()))
+	default:
+		t.Fatal("pipeline 0 unexpectedly empty")
+	}
+
+	t.Logf("Submission order : [MSG-1 MSG-2]")
+	t.Logf("Delivery order   : %v", got)
+
+	// README:156 requires delivery order == submission order for a single source.
+	if got[0] != "MSG-1" {
+		t.Fatalf(
+			"BUG REPRODUCED — per-source-ordering-preserved violated:\n"+
+				"  README:156: \"assigning each input to a single pipeline ensures that\n"+
+				"               input's messages will be delivered to the intake in-order\"\n"+
+				"  Submission order : [MSG-1 MSG-2]\n"+
+				"  Delivery order   : %v\n"+
+				"  Root cause       : trySendToPipeline (provider.go:372-388) routed MSG-1 to\n"+
+				"                     pipeline 0 and MSG-2 (under backpressure) to pipeline 1.\n"+
+				"                     Pipeline 1 drained before pipeline 0, reversing the order.",
+			got,
+		)
+	}
+
+	// This line is unreachable in the current implementation because the reorder
+	// is structurally guaranteed when pipeline 0 fills before pipeline 1.
+	t.Logf("Ordering preserved: %v", got)
+}
+
+// TestFailoverCrossesSourceAcrossPipelinesViaForwarder exercises the production
+// forwardWithFailover goroutine (provider.go:353-366) rather than calling
+// trySendToPipeline directly.
+//
+// Setup:
+//   - 2 pipelines, InputChan capacity = 1 each.
+//   - 1 router channel fed by a single logical source (routerIndex=0).
+//   - No consumer on pipeline 0 after the first message (fills immediately).
+//   - Pipeline 1 is drained after routing completes (fast drain).
+//
+// MSG-0 lands in p0 (capacity filled). MSG-1 overflows to p1.
+// Draining p1 first then p0 produces [MSG-1, MSG-0] — reversed.
+func TestFailoverCrossesSourceAcrossPipelinesViaForwarder(t *testing.T) {
+	const pipelineChanSize = 1
+	const routerChanSize = 8
+
+	p0 := newPipelineForRepro(pipelineChanSize)
+	p1 := newPipelineForRepro(pipelineChanSize)
+
+	routerCh := make(chan *message.Message, routerChanSize)
+
+	prov := &provider{
+		pipelines:            []*Pipeline{p0, p1},
+		currentPipelineIndex: atomic.NewUint32(0),
+		currentRouterIndex:   atomic.NewUint32(0),
+		failoverEnabled:      true,
+		routerChannels:       []chan *message.Message{routerCh},
+	}
+	prov.forwarderWaitGroup.Add(1)
+	go prov.forwardWithFailover(0) // routerIndex=0 → primary pipeline=0
+
+	// Send exactly 2 messages sequentially labelled MSG-0 and MSG-1.
+	// Both originate from the same logical source (same router channel).
+	for i := 0; i < 2; i++ {
+		label := fmt.Sprintf("MSG-%d", i)
+		select {
+		case routerCh <- newSeqMsg(label):
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout sending %s to router channel", label)
+		}
+	}
+
+	// Give forwarder goroutine time to dispatch both messages.
+	time.Sleep(30 * time.Millisecond)
+
+	t.Logf("After routing: p0.InputChan=%d/1, p1.InputChan=%d/1",
+		len(p0.InputChan), len(p1.InputChan))
+
+	// Differential drain: pipeline 1 first (fast), pipeline 0 second (slow).
+	// This models the real scenario: p1 unblocked, p0 backpressured.
+	var output []string
+
+	for {
+		select {
+		case m := <-p1.InputChan:
+			output = append(output, string(m.GetContent()))
+			continue
+		default:
+		}
+		break
+	}
+	for {
+		select {
+		case m := <-p0.InputChan:
+			output = append(output, string(m.GetContent()))
+			continue
+		default:
+		}
+		break
+	}
+
+	// Shut down the forwarder.
+	close(routerCh)
+	prov.forwarderWaitGroup.Wait()
+
+	t.Logf("Submission order : [MSG-0 MSG-1]")
+	t.Logf("Delivery order   : %v", output)
+
+	if len(output) < 2 {
+		t.Fatalf("expected 2 messages routed; got %d — timing issue or routing failed", len(output))
+	}
+
+	// Assert submission order == delivery order.
+	for i := 1; i < len(output); i++ {
+		if output[i] < output[i-1] {
+			t.Fatalf(
+				"BUG REPRODUCED (forwarder path) — per-source-ordering-preserved violated:\n"+
+					"  README:156: \"assigning each input to a single pipeline ensures that\n"+
+					"               input's messages will be delivered to the intake in-order\"\n"+
+					"  Submission order : [MSG-0 MSG-1]\n"+
+					"  Delivery order   : %v\n"+
+					"  Root cause       : forwardWithFailover (provider.go:353-366) split consecutive\n"+
+					"                     messages from the same source across different pipeline\n"+
+					"                     InputChans; pipelines drained at different rates.\n"+
+					"  Cross-pipeline   : MSG-0→pipeline-0 (stalled), MSG-1→pipeline-1 (fast).\n"+
+					"                     Pipeline-1 flushed before pipeline-0 → reversal.",
+				output,
+			)
+		}
+	}
+
+	t.Logf("No reorder observed in this run. " +
+		"Cross-pipeline routing may not have been triggered. " +
+		"Run TestFailoverCrossesSourceAcrossPipelines for the deterministic repro.")
+}
+
+// TestTrySendToPipelineRoutesToDifferentPipeline directly documents
+// the provider.go:372-388 routing behaviour: when the primary pipeline's
+// InputChan is full, consecutive messages from the same source are placed in
+// different pipelines.  This test PASSES — it is documentation, not a failure
+// assertion.  The ordering consequence is shown in
+// TestFailoverCrossesSourceAcrossPipelines.
+func TestTrySendToPipelineRoutesToDifferentPipeline(t *testing.T) {
+	p0 := newPipelineForRepro(1) // capacity 1
+	p1 := newPipelineForRepro(1) // capacity 1
+
+	prov := &provider{
+		pipelines:            []*Pipeline{p0, p1},
+		currentPipelineIndex: atomic.NewUint32(0),
+		currentRouterIndex:   atomic.NewUint32(0),
+		failoverEnabled:      true,
+	}
+
+	// Send MSG-A: p0 empty → lands in p0 (p0 now full).
+	msgA := newSeqMsg("MSG-A")
+	if !prov.trySendToPipeline(msgA, 0) {
+		t.Fatal("could not send MSG-A")
+	}
+	if len(p0.InputChan) != 1 {
+		t.Fatalf("expected MSG-A in p0; p0.InputChan=%d", len(p0.InputChan))
+	}
+
+	// Send MSG-B: p0 is full → overflows to p1.
+	msgB := newSeqMsg("MSG-B")
+	if !prov.trySendToPipeline(msgB, 0) {
+		t.Fatal("could not send MSG-B")
+	}
+	if len(p1.InputChan) != 1 {
+		t.Fatalf("expected MSG-B in p1; p1.InputChan=%d", len(p1.InputChan))
+	}
+
+	gotA := string((<-p0.InputChan).GetContent())
+	gotB := string((<-p1.InputChan).GetContent())
+
+	t.Logf("MSG-A → pipeline 0: content=%q", gotA)
+	t.Logf("MSG-B → pipeline 1: content=%q", gotB)
+
+	if gotA != "MSG-A" || gotB != "MSG-B" {
+		t.Fatalf("unexpected content: p0=%q (want MSG-A), p1=%q (want MSG-B)", gotA, gotB)
+	}
+
+	t.Logf("DOCUMENTED: consecutive messages from one source split across pipelines 0 and 1. " +
+		"If pipeline 1 drains before pipeline 0, delivery order is [MSG-B, MSG-A] — reversed.")
+}


### PR DESCRIPTION
### What does this PR do?

Adds tests for two problems in "pipeline failover" mode. Off in normal CI (`antithesis_demo` tag).

- **Hang or crash on shutdown** — a worker can get stuck waiting to hand off a message; shutdown then either hangs waiting for it or crashes when the channel it's waiting on is closed out from under it.
- **Out-of-order logs** — with failover on, one source's lines get spread across pipelines that drain at different speeds, so they can arrive out of order. The README promises in-order delivery, so this contradicts it.

### Motivation

Part of the logs-agent Antithesis work.

### Describe how you validated your changes

`go test -tags "antithesis_demo test" -run "TestAntithesis|TestFailover" ./comp/logs-library/pipeline/ -v`. Fails on purpose (hang/crash; lines sent 1 then 2 arrive 2 then 1).

### Additional Notes

Doesn't run in normal CI; meant to fail. Both need `pipeline_failover.enabled=true`, which is off by default. No agent code changed.
