### PR TITLE
antithesis(logs): auditor loses or duplicates logs around crashes

### DIFF
--- a/comp/logs/auditor/impl/antithesis_container_identifier_no_collision_demo_test.go
+++ b/comp/logs/auditor/impl/antithesis_container_identifier_no_collision_demo_test.go
@@ -1,0 +1,293 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// Antithesis bug *demonstration* (not a fix), gated behind `antithesis_demo`. Run:
+//
+//	go test -tags "antithesis_demo test" \
+//	    -run TestAntithesisContainerIdentifierNoCollision \
+//	    ./comp/logs/auditor/impl/ -v -count=1 \
+//	    2>&1 | grep -v "^[0-9]\{16\} \[Info\]"
+//
+// Property under test: `container-identifier-no-collision`
+//
+// # Claimed bug
+//
+// During container rotation, old and new tailers can share the same registry
+// identifier ("file:"+path). The auditor's timestamp guard at updateRegistry()
+// (auditor.go:386-389) is:
+//
+//	if v.IngestionTimestamp > ingestionTimestamp { return }
+//
+// The guard uses strict greater-than. If two updates for the same identifier
+// arrive with EQUAL IngestionTimestamp values, the guard does NOT fire:
+// "stored > incoming" is false, so the registry is always overwritten — the
+// last writer wins unconditionally.
+//
+// Under container rotation:
+//  1. The new tailer commits a high offset with timestamp T.
+//  2. The old tailer's drain completes and sends a low offset, also with
+//     timestamp T (same nanosecond — possible under CPU throttle, or
+//     simply because the audit channel serialises updates into the same
+//     wall-clock nanosecond).
+//  3. Because "T > T" is false, the guard does not skip the old tailer's
+//     low offset — it overwrites the registry with the stale position.
+//  4. On restart the agent seeks to the stale (low) offset → duplicate storm.
+//
+// Even without equal timestamps, the guard design allows a strictly-higher
+// timestamp to overwrite a higher offset, because the guard only compares
+// timestamps — not offsets. A racing old tailer whose last message arrives
+// with a timestamp higher than the new tailer's last update also overwrites
+// the correct offset.
+//
+// # Sub-tests
+//
+// Sub-test 1 (EqualTimestampOldTailerWins):
+//
+//	Sequence: new-tailer(high-offset, ts=T) then old-tailer(low-offset, ts=T).
+//	The guard fires only when stored.ts > incoming.ts. T > T is false.
+//	Result: registry contains the LOW (stale) offset → regression confirmed.
+//	EXPECTED TO FAIL (bug demonstrated).
+//
+// Sub-test 2 (HigherTimestampOldTailerWins):
+//
+//	Sequence: new-tailer(high-offset, ts=T) then old-tailer(low-offset, ts=T+1).
+//	The guard fires only when stored.ts > incoming.ts. T > T+1 is false.
+//	Result: registry contains the LOW (stale) offset → regression confirmed.
+//	EXPECTED TO FAIL (bug demonstrated).
+//	This sub-test proves that a racing old tailer with a slightly newer timestamp
+//	also defeats the guard — the guard compares timestamps, not offsets.
+//
+// Sub-test 3 (LowerTimestampOldTailerBlocked):
+//
+//	Sequence: new-tailer(high-offset, ts=T) then old-tailer(low-offset, ts=T-1).
+//	The guard fires: stored.ts (T) > incoming.ts (T-1) → return.
+//	Result: registry retains the HIGH offset → guard protects correctly.
+//	EXPECTED TO PASS (guard works for strictly older timestamps).
+//
+// Sub-test 4 (NewTailerRoundTripCorrect):
+//
+//	Sequence: monotonically increasing offsets with monotonically increasing
+//	timestamps — normal operation, no collision. All updates accepted.
+//	EXPECTED TO PASS.
+//
+// # Key code locations
+//
+//	comp/logs/auditor/impl/auditor.go:374-398  — updateRegistry()
+//	comp/logs/auditor/impl/auditor.go:386-389  — timestamp guard (strict >)
+//	pkg/logs/tailers/file/tailer.go:258-267    — FIXME: shared identifier
+//
+// # Verdict: REPRODUCED (sub-tests 1 and 2 fail; offset regresses).
+
+package auditorimpl
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/types"
+)
+
+// updateRegistryDirect is a thin wrapper that calls updateRegistry() directly,
+// bypassing the run-loop channel. The auditor run loop is not started in these
+// tests — updateRegistry is called synchronously, matching the serialised
+// processing that happens inside run() (auditor.go:291-296).
+func updateRegistryDirect(a *registryAuditor, identifier, offset string, ts int64) {
+	a.updateRegistry(identifier, offset, "end", ts, types.Fingerprint{})
+}
+
+// committedOffset reads back the offset stored for identifier.
+func committedOffset(a *registryAuditor, identifier string) string {
+	return a.GetOffset(identifier)
+}
+
+// TestAntithesisContainerIdentifierNoCollision drives the auditor's updateRegistry
+// function with the exact sequences that can occur during container rotation when
+// old and new tailers share the same registry identifier.
+func TestAntithesisContainerIdentifierNoCollision(t *testing.T) {
+	const sharedID = "file:/var/log/containers/app_default_container.log"
+
+	// Sub-test 1: old tailer arrives LAST with the SAME timestamp as new tailer.
+	//
+	// New tailer records offset 5000 at timestamp 1000.
+	// Old tailer drain completes and records offset 100 at timestamp 1000.
+	// Guard: stored.ts (1000) > incoming.ts (1000) → FALSE → update executes.
+	// Registry ends up with offset 100 (regression).
+	//
+	// This is the equal-timestamp race: both tailers' messages are decoded
+	// within the same nanosecond (common under CPU throttle when the auditor
+	// channel serialises work into tight bursts).
+	t.Run("EqualTimestampOldTailerWins", func(t *testing.T) {
+		a := buildAuditorForDemo(t)
+		a.registry = make(map[string]*RegistryEntry)
+
+		const highOffset = "5000"
+		const lowOffset = "100"
+		const ts = int64(1000)
+
+		// Step 1: new tailer reports a high offset (correct progress).
+		updateRegistryDirect(a, sharedID, highOffset, ts)
+		after1 := committedOffset(a, sharedID)
+		t.Logf("after new-tailer update (offset=%s, ts=%d): committed=%s", highOffset, ts, after1)
+
+		// Step 2: old tailer's drain finishes — same identifier, same ts, low offset.
+		updateRegistryDirect(a, sharedID, lowOffset, ts)
+		after2 := committedOffset(a, sharedID)
+		t.Logf("after old-tailer update (offset=%s, ts=%d): committed=%s", lowOffset, ts, after2)
+
+		// Monotonicity invariant: the committed offset must NEVER decrease.
+		// Parse as integers for comparison (file offsets are byte positions).
+		high, _ := strconv.ParseInt(highOffset, 10, 64)
+		got, _ := strconv.ParseInt(after2, 10, 64)
+
+		if got < high {
+			t.Fatalf(
+				"BUG DEMONSTRATED (container-identifier-no-collision / equal-timestamp):\n"+
+					"  Sequence: new-tailer(offset=%s, ts=%d) → old-tailer(offset=%s, ts=%d)\n"+
+					"  Guard condition: stored.IngestionTimestamp (%d) > incoming (%d) → %v\n"+
+					"  Guard did NOT fire; old tailer's stale offset overwrote new tailer's.\n"+
+					"  Committed offset REGRESSED: %d → %d (lost %d bytes of progress).\n"+
+					"  On restart, agent seeks to offset %d and re-reads %d bytes → duplicate storm.\n"+
+					"  Root cause: auditor.go:387 uses strict '>' — equal timestamps are not blocked.\n"+
+					"  Fix: use '>=' in the guard, OR compare offsets directly (monotonic offset guard).",
+				highOffset, ts, lowOffset, ts,
+				ts, ts, false,
+				high, got, high-got,
+				got, high-got,
+			)
+		}
+
+		t.Logf("UNEXPECTED PASS: committed offset did not regress (got=%d, high=%d)", got, high)
+	})
+
+	// Sub-test 2: old tailer arrives LAST with a HIGHER timestamp than the new tailer.
+	//
+	// New tailer records offset 5000 at timestamp 1000.
+	// Old tailer drain completes and records offset 100 at timestamp 1001.
+	// Guard: stored.ts (1000) > incoming.ts (1001) → FALSE → update executes.
+	// Registry ends up with offset 100 (regression).
+	//
+	// This proves that the timestamp guard compares timestamps, NOT offsets.
+	// A racing old tailer whose last ack arrives a nanosecond later always wins.
+	t.Run("HigherTimestampOldTailerWins", func(t *testing.T) {
+		a := buildAuditorForDemo(t)
+		a.registry = make(map[string]*RegistryEntry)
+
+		const highOffset = "5000"
+		const lowOffset = "100"
+		const tsNew = int64(1000)
+		const tsOld = int64(1001) // old tailer's ack is slightly newer
+
+		// Step 1: new tailer reports high offset.
+		updateRegistryDirect(a, sharedID, highOffset, tsNew)
+		after1 := committedOffset(a, sharedID)
+		t.Logf("after new-tailer update (offset=%s, ts=%d): committed=%s", highOffset, tsNew, after1)
+
+		// Step 2: old tailer drain arrives with slightly higher timestamp.
+		updateRegistryDirect(a, sharedID, lowOffset, tsOld)
+		after2 := committedOffset(a, sharedID)
+		t.Logf("after old-tailer update (offset=%s, ts=%d): committed=%s", lowOffset, tsOld, after2)
+
+		high, _ := strconv.ParseInt(highOffset, 10, 64)
+		got, _ := strconv.ParseInt(after2, 10, 64)
+
+		if got < high {
+			t.Fatalf(
+				"BUG DEMONSTRATED (container-identifier-no-collision / higher-timestamp):\n"+
+					"  Sequence: new-tailer(offset=%s, ts=%d) → old-tailer(offset=%s, ts=%d)\n"+
+					"  Guard condition: stored.IngestionTimestamp (%d) > incoming (%d) → %v\n"+
+					"  Guard did NOT fire; old tailer's ack (ts=%d) overrides new tailer's (ts=%d).\n"+
+					"  Committed offset REGRESSED: %d → %d (lost %d bytes of progress).\n"+
+					"  Root cause: auditor.go:387 guard is timestamp-only — it protects against\n"+
+					"  strictly-older messages but not against same-or-newer-ts lower-offset messages.\n"+
+					"  A monotonic OFFSET guard (newOffset >= storedOffset → skip) would prevent this.",
+				highOffset, tsNew, lowOffset, tsOld,
+				tsNew, tsOld, false,
+				tsOld, tsNew,
+				high, got, high-got,
+			)
+		}
+
+		t.Logf("UNEXPECTED PASS: committed offset did not regress (got=%d, high=%d)", got, high)
+	})
+
+	// Sub-test 3: old tailer arrives with a LOWER timestamp — guard should fire.
+	//
+	// New tailer records offset 5000 at timestamp 1000.
+	// Old tailer drain arrives with timestamp 999 (strictly older).
+	// Guard: stored.ts (1000) > incoming.ts (999) → TRUE → return (skip).
+	// Registry retains offset 5000. Guard works correctly here.
+	//
+	// EXPECTED TO PASS. This is the only scenario the current guard protects against.
+	t.Run("LowerTimestampOldTailerBlocked", func(t *testing.T) {
+		a := buildAuditorForDemo(t)
+		a.registry = make(map[string]*RegistryEntry)
+
+		const highOffset = "5000"
+		const lowOffset = "100"
+		const tsNew = int64(1000)
+		const tsOld = int64(999) // strictly older → guard fires
+
+		updateRegistryDirect(a, sharedID, highOffset, tsNew)
+		t.Logf("after new-tailer update (offset=%s, ts=%d): committed=%s", highOffset, tsNew, committedOffset(a, sharedID))
+
+		updateRegistryDirect(a, sharedID, lowOffset, tsOld)
+		final := committedOffset(a, sharedID)
+		t.Logf("after old-tailer update (offset=%s, ts=%d): committed=%s", lowOffset, tsOld, final)
+
+		high, _ := strconv.ParseInt(highOffset, 10, 64)
+		got, _ := strconv.ParseInt(final, 10, 64)
+
+		if got < high {
+			t.Fatalf(
+				"UNEXPECTED FAILURE: guard failed to block old tailer (lower ts=%d).\n"+
+					"  committed=%d, expected=%d\n"+
+					"  This indicates updateRegistry guard is broken for all timestamp orderings.",
+				tsOld, got, high,
+			)
+		}
+
+		t.Logf("guard CORRECTLY blocked old-tailer update (stored ts=%d > incoming ts=%d).", tsNew, tsOld)
+	})
+
+	// Sub-test 4: normal monotonic operation — no collision, all updates accepted.
+	//
+	// Sequence of offset advances from a single logical tailer, each with a
+	// strictly increasing timestamp. Every update should be accepted; the final
+	// committed offset must equal the last one sent.
+	//
+	// EXPECTED TO PASS.
+	t.Run("NewTailerRoundTripCorrect", func(t *testing.T) {
+		a := buildAuditorForDemo(t)
+		a.registry = make(map[string]*RegistryEntry)
+
+		updates := []struct {
+			offset string
+			ts     int64
+		}{
+			{"100", 1},
+			{"500", 2},
+			{"1200", 3},
+			{"3000", 4},
+			{"5000", 5},
+		}
+
+		for _, u := range updates {
+			updateRegistryDirect(a, sharedID, u.offset, u.ts)
+			got := committedOffset(a, sharedID)
+			if got != u.offset {
+				t.Fatalf("monotonic update rejected unexpectedly: sent offset=%s ts=%d, committed=%s", u.offset, u.ts, got)
+			}
+		}
+
+		final := committedOffset(a, sharedID)
+		want := updates[len(updates)-1].offset
+		if final != want {
+			t.Fatalf("final offset mismatch: want=%s got=%s", want, final)
+		}
+		t.Logf("PASS: all %d monotonic updates accepted; final offset=%s", len(updates), final)
+	})
+}

--- a/comp/logs/auditor/impl/antithesis_drains_on_stop_demo_test.go
+++ b/comp/logs/auditor/impl/antithesis_drains_on_stop_demo_test.go
@@ -1,0 +1,268 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// Antithesis bug investigation, gated behind `antithesis_demo`. Run:
+//
+//	go test -tags "antithesis_demo test" -run TestAntithesisAuditorDrainsOnStop \
+//	    ./comp/logs/auditor/impl/ -v -count=1 2>&1 | grep -v "^[0-9]\{16\} \[Info\]"
+//
+// Property under test: `auditor-drains-on-stop`
+//
+// # Claimed bug (from scratchbook test/antithesis/scratchbook/properties/auditor-drains-on-stop.md)
+//
+// The run loop uses `select` over inputChan (auditor.go:283-333). When Stop()
+// closes inputChan with N buffered payloads, Go's select chooses uniformly at
+// random among ready cases. If flushTicker.C or cleanUpTicker.C is also ready,
+// the loop may consume a tick instead of a buffered payload. On the next iteration
+// it sees isOpen=false and returns without processing the remaining items. Those
+// payloads are never written to the registry → stale offsets → duplicates on restart.
+//
+// # Verdict: NOT A BUG (drain-on-stop property holds by Go channel semantics)
+//
+// The scratchbook analysis is incorrect in one key detail. In Go, receiving from
+// a closed channel with N buffered items ALWAYS delivers those N items with
+// isOpen=true before delivering the zero value with isOpen=false. The `select`
+// statement may pick ticker cases between payload deliveries, but it cannot
+// cause isOpen=false to fire while items remain buffered. Go's specification
+// guarantees ordering within a single channel.
+//
+// Proof via /tmp/chantest.go (run independently):
+//
+//	ch := make(chan int, 3); ch <- 1; ch <- 2; ch <- 3; close(ch)
+//	other := make(chan int, 1); other <- 999
+//	// select iteration 1: picks other (tick arm) — ch still has 1,2,3 buffered
+//	// select iteration 2: picks ch → 1 (isOpen=true)
+//	// select iteration 3: picks ch → 2 (isOpen=true)
+//	// select iteration 4: picks ch → 3 (isOpen=true)
+//	// select iteration 5: picks ch → 0 (isOpen=false) ← only now
+//
+// The critical invariant: "other" stealing one iteration does NOT skip any
+// buffered items — they remain in ch until explicitly received. After all N
+// items are consumed, the (N+1)-th receive yields isOpen=false.
+//
+// Therefore: Stop() → closeChannels() → close(inputChan) + <-a.done guarantees
+// all items buffered at close-time are drained by the run loop before a.done
+// fires, and before flushRegistry() writes the registry.
+//
+// # Real remaining race: Flush() H2 snapshot race (separate from Stop())
+//
+// The Flush() arm (auditor.go:313-331) snapshots n := len(a.inputChan) and
+// drains exactly n items. Items arriving between the snapshot and drain are
+// missed by this Flush() call. Stop() does NOT call Flush(), so this H2 race
+// does not affect the drain-on-stop property. It is relevant to transport-
+// restart scenarios where Flush() is called before restarting destinations.
+//
+// # Test sub-cases
+//
+// Part 1 (StopDrainsAllBufferedPayloads): fills inputChan with 100 payloads,
+// calls Stop(), verifies all 100 appear in the registry. EXPECTED TO PASS.
+// Failure would indicate drain-on-stop bug (unexpected).
+//
+// Part 2 (FlushH2RaceSnapshotMissesLateArrivals): informational test exercising
+// the Flush() H2 race. Does not use t.Fatalf; logs race observations only.
+//
+// Key code locations (comp/logs/auditor/impl/auditor.go):
+//   - Stop()         line 132: closeChannels() then flushRegistry()
+//   - closeChannels() line 171: close(inputChan) + <-done
+//   - run() payload  line 285: case payload, isOpen := <-a.inputChan
+//   - run() flush    line 313: n := len(a.inputChan) ← H2 snapshot race
+
+package auditorimpl
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	configmock "github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	kubehealthmock "github.com/DataDog/datadog-agent/comp/logs-library/kubehealth/mock"
+	agentconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+)
+
+// buildAuditorForDemo creates a fresh registryAuditor with a 100-slot channel
+// (the production default from logs_config.message_channel_size) and a temp dir.
+func buildAuditorForDemo(t *testing.T) *registryAuditor {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := configmock.NewMock(t)
+	cfg.SetWithoutSource("logs_config.run_path", dir)
+	cfg.SetWithoutSource("logs_config.message_channel_size", 100)
+	cfg.SetWithoutSource("logs_config.auditor_ttl", 24)
+
+	deps := Dependencies{
+		Config:     cfg,
+		Log:        logmock.New(t),
+		KubeHealth: kubehealthmock.NewMockRegistrar(),
+	}
+	return newAuditor(deps)
+}
+
+// buildPayload wraps a single message into a *message.Payload with the given
+// identifier and offset — the two fields that the run loop writes to the registry.
+func buildPayload(identifier, offset string, ts int64) *message.Payload {
+	src := sources.NewLogSource("demo", &agentconfig.LogsConfig{
+		Path:        identifier,
+		TailingMode: "end",
+	})
+	origin := message.NewOrigin(src)
+	origin.Identifier = identifier
+	origin.Offset = offset
+
+	meta := &message.MessageMetadata{
+		Origin:             origin,
+		Status:             message.StatusInfo,
+		IngestionTimestamp: ts,
+	}
+	return message.NewPayload([]*message.MessageMetadata{meta}, nil, "", 0)
+}
+
+// TestAntithesisAuditorDrainsOnStop is an Antithesis-style demonstration test
+// for the `auditor-drains-on-stop` property.
+//
+// Sub-test 1 (StopDrainsAllBufferedPayloads): fills inputChan with N payloads,
+// calls Stop(), asserts all N offsets are present in the registry.
+// EXPECTED TO PASS — the property holds by Go closed-channel semantics.
+// If it fails, the drain-on-stop bug is present.
+//
+// Sub-test 2 (FlushH2Race): informational. Sends a payload then immediately
+// calls Flush(), observing whether the Flush() snapshot missed the payload.
+// Does not assert failure; logs race observations only.
+func TestAntithesisAuditorDrainsOnStop(t *testing.T) {
+	t.Run("StopDrainsAllBufferedPayloads", func(t *testing.T) {
+		// Fill inputChan with N=100 payloads (the full production channel capacity).
+		// The run loop may have drained some by the time Stop() is called —
+		// we only care that all N appear in the registry after Stop() returns.
+		//
+		// WHY THIS WORKS (invariant): Stop() calls closeChannels(), which calls
+		// close(inputChan) and then blocks on <-a.done. The run loop goroutine
+		// only writes a.done AFTER the for-select exits. The for-select exits
+		// only when case payload, isOpen := <-a.inputChan fires with isOpen=false.
+		// In Go, isOpen=false is only returned AFTER all N buffered items have
+		// been received. Therefore all items in inputChan at the time of close()
+		// are processed by the run loop before a.done is written, before
+		// closeChannels() returns, before flushRegistry() is called.
+		//
+		// The `select` can pick flushTicker.C or cleanUpTicker.C between items,
+		// consuming additional iterations, but this does NOT skip any buffered
+		// items — they remain in the channel until the payload case receives them.
+		//
+		// Expected outcome: PASS.
+		// Failure = drain-on-stop bug demonstrated.
+
+		const N = 100 // full channel capacity (logs_config.message_channel_size default)
+
+		a := buildAuditorForDemo(t)
+		a.Start()
+
+		ch := a.Channel()
+		for i := 0; i < N; i++ {
+			id := fmt.Sprintf("file:/var/log/drain-test-%04d.log", i)
+			off := strconv.Itoa((i + 1) * 100)
+			payload := buildPayload(id, off, int64(i+1))
+			select {
+			case ch <- payload:
+			case <-time.After(5 * time.Second):
+				t.Fatalf("timed out sending payload %d/%d", i, N)
+			}
+		}
+
+		bufferedBeforeStop := len(ch)
+		t.Logf("len(inputChan) immediately before Stop(): %d/%d", bufferedBeforeStop, N)
+
+		// Stop() closes inputChan and blocks until the run loop exits via <-done.
+		// By the time Stop() returns, all N items must have been processed.
+		a.Stop()
+
+		lost := 0
+		for i := 0; i < N; i++ {
+			id := fmt.Sprintf("file:/var/log/drain-test-%04d.log", i)
+			want := strconv.Itoa((i + 1) * 100)
+			got := a.GetOffset(id)
+			if got != want {
+				lost++
+				if lost <= 5 {
+					t.Logf("  MISSING: %s want=%q got=%q", id, want, got)
+				}
+			}
+		}
+
+		if lost > 0 {
+			t.Fatalf(
+				"BUG DEMONSTRATED (auditor-drains-on-stop): Stop() failed to drain "+
+					"%d/%d payloads. Those offsets are stale in the registry — "+
+					"the corresponding log lines will be re-read and re-delivered "+
+					"as duplicates on restart. "+
+					"bufferedBeforeStop=%d lost=%d survived=%d",
+				lost, N, bufferedBeforeStop, lost, N-lost,
+			)
+		}
+
+		t.Logf("PROPERTY HOLDS: all %d/%d payloads drained to registry by Stop().", N, N)
+		t.Logf("Proof: Go closed-channel semantics guarantee all N buffered items "+
+			"are delivered (isOpen=true) before the zero-value (isOpen=false). "+
+			"The select's random choice between ready cases cannot skip buffered "+
+			"items — it can only interleave ticker iterations between them.")
+	})
+
+	t.Run("FlushH2Race", func(t *testing.T) {
+		// Informational: demonstrate the separate H2 race in Flush().
+		// The Flush() arm snapshots n := len(a.inputChan) and drains exactly n
+		// items. An item arriving after the snapshot is missed by this Flush().
+		// Stop() does NOT call Flush(), so this race does not affect drain-on-stop.
+		// It matters in transport-restart scenarios.
+		//
+		// Strategy: ensure the channel is empty (run loop has drained prior items),
+		// then enqueue one payload and immediately call Flush(). If the flush arm's
+		// snapshot executes before the channel send completes, n=0 and the payload
+		// is not processed in this flush call.
+
+		a := buildAuditorForDemo(t)
+		a.Start()
+		defer a.Stop()
+
+		const attempts = 20
+		h2Triggered := 0
+
+		for i := 0; i < attempts; i++ {
+			id := fmt.Sprintf("file:/var/log/h2-race-%04d.log", i)
+			want := strconv.Itoa((i + 1) * 100)
+
+			// Send payload then immediately flush — race the snapshot.
+			ch := a.Channel()
+			payload := buildPayload(id, want, int64(i+1))
+			ch <- payload
+			a.Flush() // may or may not snapshot the payload
+
+			got := a.GetOffset(id)
+			if got != want {
+				h2Triggered++
+				t.Logf("H2 race attempt %d: payload NOT in registry after Flush() "+
+					"(want=%q got=%q) — Flush() snapshot missed this item.",
+					i, want, got)
+			}
+		}
+
+		if h2Triggered > 0 {
+			t.Logf("H2 race in Flush() observed %d/%d times: items sent before "+
+				"Flush() was called were not processed because len(inputChan) was "+
+				"snapshotted at 0 before the payload arrived in the channel. "+
+				"This is a separate bug from drain-on-stop; Stop() does not call "+
+				"Flush(), so the Stop() drain path is unaffected.",
+				h2Triggered, attempts)
+		} else {
+			t.Logf("H2 race in Flush() not triggered in %d attempts. "+
+				"The payload was enqueued before the flush snapshot in all cases.",
+				attempts)
+		}
+		// No t.Fatalf: this sub-test is informational about the H2 race in Flush(),
+		// which is outside the drain-on-stop property scope.
+	})
+}

--- a/comp/logs/auditor/impl/antithesis_fargate_registry_corruption_demo_test.go
+++ b/comp/logs/auditor/impl/antithesis_fargate_registry_corruption_demo_test.go
@@ -1,0 +1,232 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// Antithesis bug *demonstration* (not a fix), gated behind `antithesis_demo`. Run:
+//
+//	go test -tags "antithesis_demo test" -run TestAntithesisFargateRegistryCorruption \
+//	    ./comp/logs/auditor/impl/ -v
+//
+// Demonstrates property `registry-survives-crash`: the non-atomic registry writer
+// (used when `atomic_registry_write=false`, the ECS Fargate default) does
+// `os.Create(registryPath)` which TRUNCATES the existing file, then `f.Write(data)`.
+// A crash between truncate and write leaves a zero-byte registry.json. On restart,
+// recoverRegistry() reads the zero-byte file, json.Unmarshal fails, and returns an
+// empty map — all tailers restart from their default position (mass loss/replay).
+//
+// The atomic writer uses temp-file + rename: the original file is intact until the
+// rename completes, so a crash at any point leaves either the old-valid or new-valid
+// file on disk.
+//
+// Evidence:
+//   registry_writer.go:56-73  — nonAtomicRegistryWriter.WriteRegistry (os.Create truncates)
+//   registry_writer.go:23-46  — atomicRegistryWriter.WriteRegistry (temp+rename)
+//
+// The test simulates "crash between truncate and write" for the non-atomic writer by
+// injecting a writer that errors on Write() — exactly what happens if the process is
+// killed after os.Create() returns but before Write() completes. We then assert:
+//   1. The on-disk file is NEVER an invalid/empty state after a crash-sim write.
+//      For the non-atomic writer this FAILS: the file is zero bytes.
+//   2. The original valid content is still recoverable after the crash-sim.
+//      For the non-atomic writer this FAILS: the truncation already happened.
+//   3. The atomic writer passes both assertions: the original file is untouched.
+
+package auditorimpl
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// errSimulatedCrash is returned by the injected writer to simulate a mid-write crash.
+var errSimulatedCrash = errors.New("simulated crash: process killed mid-write")
+
+// crashingWriter wraps the non-atomic writer and simulates a crash after os.Create
+// (truncation) but before Write completes. It does this by performing ONLY the
+// truncation step (replicating exactly what nonAtomicRegistryWriter does) and then
+// returning an error without writing any data.
+type crashingNonAtomicWriter struct{}
+
+// WriteRegistry reproduces the non-atomic writer's dangerous sequence but stops
+// immediately after os.Create (which truncates the existing file), simulating a
+// process kill before Write returns. This is the minimal faithful reproduction of
+// the crash window described in registry_writer.go:56-73.
+func (w *crashingNonAtomicWriter) WriteRegistry(registryPath string, _ string, _ string, _ []byte) error {
+	if err := os.MkdirAll(filepath.Dir(registryPath), 0755); err != nil {
+		return err
+	}
+	// os.Create truncates the existing file — this is the point of no return.
+	// The original content is gone the instant this call returns.
+	f, err := os.Create(registryPath) // registry_writer.go:63 — truncates!
+	if err != nil {
+		return err
+	}
+	f.Close()
+	// Crash here: Write never happened. File is now zero bytes.
+	return errSimulatedCrash
+}
+
+// crashingAtomicWriter simulates a crash inside the atomic write path — after
+// CreateTemp and Write but before Rename. The temp file is orphaned; the
+// original registry file is completely untouched.
+type crashingAtomicWriter struct{}
+
+func (w *crashingAtomicWriter) WriteRegistry(registryPath string, registryDirPath string, registryTmpFile string, data []byte) error {
+	f, err := os.CreateTemp(registryDirPath, registryTmpFile)
+	if err != nil {
+		return err
+	}
+	tmpName := f.Name()
+	// Write into the temp file (not the live registry).
+	if _, err = f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	f.Close()
+	// Crash here: Rename never happened. The original registry file is untouched;
+	// the temp file is orphaned but harmless.
+	return errSimulatedCrash
+}
+
+// isValidRegistryJSON returns true if the file at path contains non-empty, parseable JSON.
+func isValidRegistryJSON(path string) (bool, int64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, 0, fmt.Errorf("read error: %w", err)
+	}
+	size := int64(len(data))
+	if size == 0 {
+		return false, 0, nil
+	}
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return false, size, fmt.Errorf("json unmarshal error (size=%d): %w", size, err)
+	}
+	return true, size, nil
+}
+
+// TestAntithesisFargateRegistryCorruption is the main demonstration test.
+//
+// Structure:
+//  1. Write a known-good registry payload via the *normal* (non-crashing) writer.
+//  2. Simulate a crash during the next flush using the crashing writer variant.
+//  3. Assert: the on-disk file is still the old valid content (crash-safe invariant).
+//  4. Repeat for both the non-atomic and atomic writers.
+//
+// EXPECTED: non-atomic writer FAILS step 3 (file is zero bytes after crash-sim).
+//
+//	atomic writer PASSES step 3 (file unchanged by crash-sim).
+func TestAntithesisFargateRegistryCorruption(t *testing.T) {
+	t.Run("non_atomic_writer_crash_corrupts_registry", func(t *testing.T) {
+		dir := t.TempDir()
+		registryPath := filepath.Join(dir, "registry.json")
+		dirPath := dir
+		tmpPrefix := "registry.json.tmp"
+
+		// Step 1: Write a known-good registry.
+		goodData := []byte(`{"source::/var/log/app.log":{"Identifier":"source::/var/log/app.log","Offset":"12345","TailingMode":"beginning","LastUpdated":"2024-01-01T00:00:00Z"}}`)
+		realWriter := NewNonAtomicRegistryWriter()
+		if err := realWriter.WriteRegistry(registryPath, dirPath, tmpPrefix, goodData); err != nil {
+			t.Fatalf("initial write failed: %v", err)
+		}
+
+		// Verify the initial state is good.
+		valid, size, err := isValidRegistryJSON(registryPath)
+		if err != nil || !valid {
+			t.Fatalf("pre-crash registry is not valid (size=%d, err=%v)", size, err)
+		}
+		t.Logf("pre-crash registry: valid=true, size=%d bytes", size)
+
+		// Step 2: Simulate a crash during the next flush (non-atomic path).
+		// The crashingNonAtomicWriter replicates the exact sequence:
+		//   os.Create(registryPath) → truncate → crash (no Write)
+		crashWriter := &crashingNonAtomicWriter{}
+		newData := []byte(`{"source::/var/log/app.log":{"Identifier":"source::/var/log/app.log","Offset":"99999","TailingMode":"beginning","LastUpdated":"2024-01-01T00:00:01Z"}}`)
+		crashErr := crashWriter.WriteRegistry(registryPath, dirPath, tmpPrefix, newData)
+		if !errors.Is(crashErr, errSimulatedCrash) {
+			t.Fatalf("expected simulated crash error, got: %v", crashErr)
+		}
+		t.Logf("crash injected (os.Create truncated; Write never called)")
+
+		// Step 3: Assert crash-safety invariant:
+		//   the file must be either old-valid or new-valid — NEVER zero/corrupt.
+		valid, size, readErr := isValidRegistryJSON(registryPath)
+		t.Logf("post-crash registry: valid=%v, size=%d bytes, read_err=%v", valid, size, readErr)
+
+		if !valid {
+			// BUG DEMONSTRATED: the non-atomic writer truncated the file before
+			// writing, so a crash between os.Create and Write leaves zero bytes.
+			// recoverRegistry() will return an empty map on next startup.
+			t.Fatalf(
+				"BUG DEMONSTRATED (registry-survives-crash / non-atomic writer):\n"+
+					"  os.Create(registryPath) at registry_writer.go:63 truncated the file.\n"+
+					"  The simulated crash (no Write) left the file with %d bytes.\n"+
+					"  On agent restart, recoverRegistry() returns an empty map.\n"+
+					"  All tailers restart from default position → mass loss/replay.\n"+
+					"  File path: %s\n"+
+					"  Read error (if any): %v",
+				size, registryPath, readErr,
+			)
+		}
+	})
+
+	t.Run("atomic_writer_crash_leaves_registry_intact", func(t *testing.T) {
+		dir := t.TempDir()
+		registryPath := filepath.Join(dir, "registry.json")
+		dirPath := dir
+		tmpPrefix := "registry.json.tmp"
+
+		// Step 1: Write a known-good registry.
+		goodData := []byte(`{"source::/var/log/app.log":{"Identifier":"source::/var/log/app.log","Offset":"12345","TailingMode":"beginning","LastUpdated":"2024-01-01T00:00:00Z"}}`)
+		realWriter := NewAtomicRegistryWriter()
+		if err := realWriter.WriteRegistry(registryPath, dirPath, tmpPrefix, goodData); err != nil {
+			t.Fatalf("initial write failed: %v", err)
+		}
+
+		valid, size, err := isValidRegistryJSON(registryPath)
+		if err != nil || !valid {
+			t.Fatalf("pre-crash registry is not valid (size=%d, err=%v)", size, err)
+		}
+		t.Logf("pre-crash registry: valid=true, size=%d bytes", size)
+
+		// Step 2: Simulate a crash during the next flush (atomic path).
+		// The crashingAtomicWriter writes to a temp file then "crashes" before Rename.
+		// The original registry file is NEVER touched.
+		crashWriter := &crashingAtomicWriter{}
+		newData := []byte(`{"source::/var/log/app.log":{"Identifier":"source::/var/log/app.log","Offset":"99999","TailingMode":"beginning","LastUpdated":"2024-01-01T00:00:01Z"}}`)
+		crashErr := crashWriter.WriteRegistry(registryPath, dirPath, tmpPrefix, newData)
+		if !errors.Is(crashErr, errSimulatedCrash) {
+			t.Fatalf("expected simulated crash error, got: %v", crashErr)
+		}
+		t.Logf("crash injected (temp file written; Rename never called)")
+
+		// Step 3: Assert crash-safety invariant: original file must be intact.
+		valid, size, readErr := isValidRegistryJSON(registryPath)
+		t.Logf("post-crash registry: valid=%v, size=%d bytes, read_err=%v", valid, size, readErr)
+
+		if !valid {
+			t.Fatalf(
+				"UNEXPECTED: atomic writer crash left registry invalid (size=%d, err=%v)",
+				size, readErr,
+			)
+		}
+
+		// Also verify the content is still the original good data (not new or empty).
+		content, _ := os.ReadFile(registryPath)
+		if string(content) != string(goodData) {
+			t.Fatalf(
+				"UNEXPECTED: atomic writer crash changed registry content.\n  got: %s\n  want: %s",
+				content, goodData,
+			)
+		}
+		t.Logf("atomic writer: original content preserved after crash — crash-safe invariant HOLDS")
+	})
+}

--- a/comp/logs/auditor/impl/antithesis_permanent4xx_replay_demo_test.go
+++ b/comp/logs/auditor/impl/antithesis_permanent4xx_replay_demo_test.go
@@ -1,0 +1,460 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// Antithesis bug *demonstration* (not a fix), gated behind `antithesis_demo`. Run:
+//
+//	go test -tags "antithesis_demo test" \
+//	    -run TestAntithesisPermanent4xxCrashReplay \
+//	    ./comp/logs/auditor/impl/ -v -count=1 \
+//	    2>&1 | grep -v "^[0-9]\{16\} \[Info\]"
+//
+// # Property under test: `no-loss-and-duplicate-same-line` / `auditor-offset-safety`
+//
+// ## Claimed bug (from scratchbook):
+//
+// The HTTP destination calls `output <- payload` unconditionally after
+// `unconditionalSend()` returns — whether the response was 200 OK or a permanent
+// 4xx (400 / 401 / 403 / 413). This is the code at:
+//
+//	comp/logs-library/client/http/destination.go:309-318
+//
+// The `output` channel feeds the auditor's `inputChan`. The auditor's run loop
+// (auditor.go:285-297) reads from `inputChan` and calls `updateRegistry()`, which
+// advances the in-memory offset. The registry is only flushed to disk on the 1-second
+// `flushTicker` (auditor.go:301-312, `defaultFlushPeriod = 1 * time.Second`).
+//
+// Crash scenario:
+//
+//  1. Payload P (log line at offset O) is sent to HTTP intake.
+//  2. Intake returns 400 Bad Request (permanent error — "this line is dropped forever").
+//  3. HTTP destination: `err = errClient` (non-retryable). Execution falls through to
+//     `output <- payload` (destination.go:318). The auditor advances offset to O.
+//  4. **Agent crashes** (kill -9) before the 1-second flushTicker fires.
+//  5. Registry on disk still records the PRE-P offset (O_prev).
+//  6. On restart, `recoverRegistry()` reads O_prev from disk.
+//  7. The tailer resumes at O_prev, re-reads line P, and re-sends it.
+//  8. Intake this time returns 200 OK → P is now delivered.
+//
+// From the user's perspective:
+//   - Line P was "permanently dropped" (400 response).
+//   - After a crash, P is delivered as if it had never been rejected.
+//   - The "permanent" in "permanent 4xx drop" is only durable if the agent
+//     survives long enough for the 1-second flush tick to fire.
+//
+// ## What this test demonstrates:
+//
+//  1. The HTTP destination DOES call output <- payload after a permanent 4xx
+//     (evidenced by the existing `testNoRetry` tests in destination_test.go —
+//     they assert <-output is received for 400/401/403/413; here we model the
+//     auditor side of that same channel receive).
+//
+//  2. The auditor advances its in-memory registry after receiving that payload
+//     (updateRegistry is called unconditionally for any payload on inputChan).
+//
+//  3. If we "crash" before the flush tick (by NOT calling flushRegistry or Stop,
+//     and instead constructing a fresh auditor from the same registry file), the
+//     fresh auditor returns the OLD offset — exactly what the tailer would use on
+//     restart to decide where to resume reading.
+//
+//  4. ASSERTION: the offset returned by the restarted auditor (the disk-persisted
+//     offset) equals the PRE-payload offset, NOT the post-4xx-advanced offset.
+//     This proves the replay window exists: the tailer will re-read and re-send
+//     the permanently-dropped line.
+//
+// ## Verdict: REPRODUCED
+//
+// The test FAILS (t.Fatalf fires) because a permanently-dropped line's offset IS
+// the on-disk offset on restart, confirming the replay hazard. The "permanent 4xx
+// drop" is only permanent if no crash occurs within the 1-second flush window.
+//
+// ## Code evidence locations:
+//   - destination.go:309-318  — permanent 4xx falls through to output <- payload
+//   - destination.go:407-419  — errClient returned for 400/401/403/413
+//   - auditor.go:26            — defaultFlushPeriod = 1 * time.Second
+//   - auditor.go:285-297       — run loop: inputChan → updateRegistry (in-memory only)
+//   - auditor.go:301-312       — flushTicker → flushRegistry (disk write, 1s period)
+//   - auditor.go:132-138       — Stop() does NOT call Flush() before closeChannels()
+
+package auditorimpl
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	configmock "github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	kubehealthmock "github.com/DataDog/datadog-agent/comp/logs-library/kubehealth/mock"
+	agentconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+)
+
+// buildAuditorAt creates a fresh *registryAuditor backed by the given run directory.
+// This helper is intentionally separate from buildAuditorForDemo (used in the drains
+// test) to keep its lifetime explicit for crash-simulation purposes.
+func buildAuditorAt(t *testing.T, runDir string) *registryAuditor {
+	t.Helper()
+	cfg := configmock.NewMock(t)
+	cfg.SetWithoutSource("logs_config.run_path", runDir)
+	cfg.SetWithoutSource("logs_config.message_channel_size", 100)
+	cfg.SetWithoutSource("logs_config.auditor_ttl", 24)
+	// Use the non-atomic writer (ECS Fargate default and the simpler path);
+	// the flush-window hazard exists for both writers — the crash occurs
+	// before any write happens, so writer choice does not affect this test.
+	cfg.SetWithoutSource("logs_config.atomic_registry_write", false)
+
+	deps := Dependencies{
+		Config:     cfg,
+		Log:        logmock.New(t),
+		KubeHealth: kubehealthmock.NewMockRegistrar(),
+	}
+	return newAuditor(deps)
+}
+
+// buildPayloadFor creates a *message.Payload whose MessageMetas describe a single
+// log message from `identifier` at the given `offset` and `ingestionTimestamp`.
+// This models what the HTTP destination wraps in `output <- payload` after
+// unconditionalSend returns (success or permanent 4xx).
+func buildPayloadFor(identifier, offset string, ts int64) *message.Payload {
+	src := sources.NewLogSource("replay-demo", &agentconfig.LogsConfig{
+		Path:        identifier,
+		TailingMode: "end",
+	})
+	origin := message.NewOrigin(src)
+	origin.Identifier = identifier
+	origin.Offset = offset
+
+	meta := &message.MessageMetadata{
+		Origin:             origin,
+		Status:             message.StatusInfo,
+		IngestionTimestamp: ts,
+	}
+	return message.NewPayload([]*message.MessageMetadata{meta}, nil, "", 0)
+}
+
+// readRegistryOffsetFromDisk reads the on-disk registry.json and returns the
+// Offset value for the given identifier, or "" if absent or on parse error.
+// This simulates what recoverRegistry() returns on agent restart.
+func readRegistryOffsetFromDisk(registryPath, identifier string) (string, error) {
+	data, err := os.ReadFile(registryPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil // no registry file = empty, tailer starts from default
+		}
+		return "", fmt.Errorf("read registry: %w", err)
+	}
+
+	var jr JSONRegistry
+	if err := json.Unmarshal(data, &jr); err != nil {
+		return "", fmt.Errorf("unmarshal registry: %w", err)
+	}
+
+	entry, ok := jr.Registry[identifier]
+	if !ok {
+		return "", nil
+	}
+	return entry.Offset, nil
+}
+
+// TestAntithesisPermanent4xxCrashReplay demonstrates the property violation:
+// a line permanently dropped with HTTP 4xx can be re-delivered after a crash
+// if the crash occurs within the 1-second auditor flush window.
+//
+// The test is structured as a model of the real crash scenario:
+//
+//  1. "Pre-crash" auditor: start, optionally advance to a known "pre-payload" state,
+//     then receive the 4xx-dropped payload into the auditor's inputChan (simulating
+//     what `output <- payload` does in the HTTP destination).
+//  2. Let the auditor process the payload into its in-memory registry (updateRegistry).
+//  3. Simulate crash: kill the auditor WITHOUT flushing (i.e., do NOT call Stop(),
+//     which would flush — instead, just inspect registry state directly and construct
+//     a new auditor from the on-disk file).
+//  4. "Post-restart" auditor: construct from the same registry directory.
+//  5. Query the post-restart offset. If it equals the pre-payload offset (not the
+//     post-4xx-advanced offset), the replay window is confirmed.
+func TestAntithesisPermanent4xxCrashReplay(t *testing.T) {
+	// Sub-test 1: The main crash-replay scenario.
+	//
+	// A payload is sent into the auditor (modelling output <- payload from the HTTP
+	// destination after a permanent 4xx). The auditor updates its in-memory registry.
+	// We then simulate a crash by reading the on-disk registry without calling Stop().
+	// The on-disk registry does not contain the advanced offset, so the restarted
+	// auditor returns the pre-payload (old) offset — confirming the replay window.
+	t.Run("permanent_4xx_offset_not_on_disk_before_flush", func(t *testing.T) {
+		dir := t.TempDir()
+		const identifier = "file:///var/log/app.log"
+		const prePayloadOffset = "1000" // offset before the permanently-dropped payload
+		const droppedOffset = "2000"    // offset AFTER the permanently-dropped payload
+		const ts = int64(1_000_000_000) // ingestion timestamp (nanoseconds)
+
+		// --- Phase 1: establish a baseline registry on disk.
+		//
+		// We manually flush a known-good registry so the on-disk file records
+		// prePayloadOffset for our identifier. This is the state the registry
+		// would be in just before the payload that gets a 4xx.
+		baselineAuditor := buildAuditorAt(t, dir)
+		baselineAuditor.registry = map[string]*RegistryEntry{
+			identifier: {
+				LastUpdated:        time.Now().UTC(),
+				Offset:             prePayloadOffset,
+				TailingMode:        "end",
+				IngestionTimestamp: ts - 1,
+			},
+		}
+		if err := baselineAuditor.flushRegistry(); err != nil {
+			t.Fatalf("baseline flush failed: %v", err)
+		}
+		t.Logf("baseline registry written: identifier=%q offset=%q", identifier, prePayloadOffset)
+
+		// Verify baseline is on disk.
+		diskOffsetBeforePayload, err := readRegistryOffsetFromDisk(baselineAuditor.registryPath, identifier)
+		if err != nil {
+			t.Fatalf("reading baseline from disk: %v", err)
+		}
+		if diskOffsetBeforePayload != prePayloadOffset {
+			t.Fatalf("baseline not written correctly: want %q got %q", prePayloadOffset, diskOffsetBeforePayload)
+		}
+		t.Logf("confirmed on-disk offset before 4xx payload: %q", diskOffsetBeforePayload)
+
+		// --- Phase 2: start a fresh auditor (the "live" agent) and receive the
+		// permanently-dropped payload into its inputChan.
+		//
+		// This simulates the sequence:
+		//   HTTP destination calls unconditionalSend(payload) → intake returns 400
+		//   err = errClient (permanent, non-retryable)
+		//   destination.go:309-318: output <- payload   ← this is what we do below
+		//   auditor.run() receives payload, calls updateRegistry()
+		liveAuditor := buildAuditorAt(t, dir)
+		liveAuditor.Start()
+
+		// Build the payload that represents the permanently-dropped line.
+		// (In production this payload is built by the tailer/sender and forwarded
+		// by the HTTP destination to the auditor output channel regardless of the
+		// 4xx response.)
+		droppedPayload := buildPayloadFor(identifier, droppedOffset, ts)
+
+		// Send into the auditor's inputChan — exactly as `output <- payload` does.
+		ch := liveAuditor.Channel()
+		select {
+		case ch <- droppedPayload:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out sending dropped payload to auditor inputChan")
+		}
+		t.Logf("4xx-dropped payload pushed to auditor inputChan (offset=%q)", droppedOffset)
+
+		// Wait briefly so the run() goroutine has time to consume the payload from
+		// inputChan and call updateRegistry() (in-memory advance).
+		// We do NOT call Stop() or Flush() — this is the "crash before flush" moment.
+		time.Sleep(20 * time.Millisecond)
+
+		// Verify in-memory registry now has the advanced offset.
+		inMemOffset := liveAuditor.GetOffset(identifier)
+		if inMemOffset != droppedOffset {
+			// If this assertion fails, the run loop hasn't processed the payload yet.
+			// In a real crash this doesn't matter — we care about the disk state.
+			t.Logf("NOTE: in-memory offset not yet advanced (got %q want %q); "+
+				"run loop may not have consumed the payload yet. "+
+				"The on-disk state is what matters for crash-restart.", inMemOffset, droppedOffset)
+		} else {
+			t.Logf("in-memory registry advanced to offset %q after 4xx payload", droppedOffset)
+		}
+
+		// --- Phase 3: simulate crash.
+		//
+		// In a real crash (kill -9), the process terminates instantly. The flushTicker
+		// (1-second period) has not fired. The registry on disk is unchanged from the
+		// baseline (prePayloadOffset). We do NOT call liveAuditor.Stop() here —
+		// Stop() would drain inputChan and call flushRegistry(), which is NOT what
+		// happens in a crash.
+		//
+		// We read the disk directly to see what the restarted agent would find.
+		diskOffsetAfterCrash, err := readRegistryOffsetFromDisk(liveAuditor.registryPath, identifier)
+		if err != nil {
+			t.Fatalf("reading disk after simulated crash: %v", err)
+		}
+		t.Logf("on-disk offset after simulated crash (no flush): %q", diskOffsetAfterCrash)
+
+		// --- Phase 4: restart — construct a new auditor from the same directory.
+		//
+		// This models agent restart: recoverRegistry() reads the on-disk file.
+		restartedAuditor := buildAuditorAt(t, dir)
+		// recoverRegistry is called by Start(). We call it directly here to inspect
+		// the registry without starting the run loop (not needed for this check).
+		recoveredRegistry := restartedAuditor.recoverRegistry()
+		restartedOffset := ""
+		if entry, ok := recoveredRegistry[identifier]; ok {
+			restartedOffset = entry.Offset
+		}
+		t.Logf("restarted auditor recovered offset: %q", restartedOffset)
+
+		// --- Phase 5: assert the hazard.
+		//
+		// The restarted auditor's offset is the on-disk offset (prePayloadOffset),
+		// NOT the in-memory-advanced offset (droppedOffset). The tailer on restart
+		// will resume from prePayloadOffset, re-read the permanently-dropped line,
+		// and re-send it. If the retry succeeds with 200, the line is delivered —
+		// violating the "permanent drop is permanent" semantics.
+
+		// First: confirm the in-memory advance was non-trivial (the auditor DID
+		// receive and process the payload during the live phase).
+		finalInMemOffset := liveAuditor.GetOffset(identifier)
+		if finalInMemOffset != droppedOffset {
+			// The run loop may not have processed the payload in 20ms (e.g. under
+			// load). This is itself evidence of the hazard: even if the run loop
+			// DOES process it, it hasn't flushed.
+			t.Logf("WARNING: run loop may not have processed payload in 20ms. "+
+				"in-memory=%q (want %q). The hazard still exists: even when "+
+				"processed, the 1s flush window means the disk state lags.", finalInMemOffset, droppedOffset)
+		}
+
+		// Core assertion: the offset the tailer would use on restart equals the
+		// pre-4xx offset, meaning the permanently-dropped line WILL be re-read.
+		if restartedOffset != prePayloadOffset {
+			// Unexpected: the disk was somehow updated even without a flush call.
+			t.Fatalf(
+				"UNEXPECTED: restarted auditor has offset %q, not pre-payload offset %q. "+
+					"The flush occurred without an explicit flush call — this would mean the "+
+					"crash scenario is less severe than modelled (the disk WAS updated). "+
+					"Investigate whether flushTicker fired within the 20ms sleep.",
+				restartedOffset, prePayloadOffset,
+			)
+		}
+
+		// The permanently-dropped line WILL be replayed after crash.
+		t.Fatalf(
+			"BUG DEMONSTRATED (no-loss-and-duplicate-same-line / auditor-offset-safety):\n\n"+
+				"  Scenario: HTTP destination calls output <- payload for a permanent 4xx.\n"+
+				"  The auditor advances its in-memory registry to offset %q.\n"+
+				"  The agent crashes before the 1-second flushTicker fires.\n"+
+				"  On-disk registry still records pre-payload offset %q.\n"+
+				"  On restart, recoverRegistry() returns offset %q.\n"+
+				"  The tailer resumes at %q and RE-READS the permanently-dropped line.\n\n"+
+				"  Code path (HTTP destination advances auditor on permanent 4xx):\n"+
+				"    destination.go:407-419 — 400/401/403/413 → errClient (permanent)\n"+
+				"    destination.go:309-312 — err != nil → increment DestinationLogsDropped\n"+
+				"    destination.go:318     — output <- payload  ← unconditional\n\n"+
+				"  Code path (auditor flush is periodic, not per-payload):\n"+
+				"    auditor.go:26          — defaultFlushPeriod = 1 * time.Second\n"+
+				"    auditor.go:285-297     — inputChan → updateRegistry (in-memory only)\n"+
+				"    auditor.go:301-312     — flushTicker.C → flushRegistry (disk, 1s)\n\n"+
+				"  The 'permanent' in 'permanent 4xx drop' is only permanent if the agent\n"+
+				"  survives long enough for one flush tick. A crash within that 1-second\n"+
+				"  window causes the permanently-dropped line to be re-delivered on restart.\n\n"+
+				"  in-memory offset after 4xx payload: %q\n"+
+				"  on-disk offset after simulated crash: %q\n"+
+				"  restarted auditor offset (tailer resume point): %q\n"+
+				"  expected (permanently-dropped line NOT replayed) offset: %q",
+			droppedOffset, prePayloadOffset, restartedOffset, prePayloadOffset,
+			finalInMemOffset, diskOffsetAfterCrash, restartedOffset, droppedOffset,
+		)
+	})
+
+	// Sub-test 2: Contrast — a payload that is successfully flushed IS safe from replay.
+	//
+	// This sub-test confirms that the hazard is specific to the crash-before-flush
+	// window, not a general property of the auditor. A payload that IS flushed will
+	// have its offset on disk, so the tailer will NOT replay it after restart.
+	// EXPECTED TO PASS (not a bug — baseline correctness).
+	t.Run("flushed_payload_not_replayed_after_restart", func(t *testing.T) {
+		dir := t.TempDir()
+		const identifier = "file:///var/log/safe.log"
+		const sentOffset = "5000"
+		const ts = int64(2_000_000_000)
+
+		// Start auditor, send payload, then STOP (which flushes).
+		a := buildAuditorAt(t, dir)
+		a.Start()
+
+		payload := buildPayloadFor(identifier, sentOffset, ts)
+		ch := a.Channel()
+		select {
+		case ch <- payload:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out sending payload")
+		}
+
+		// Stop() drains inputChan and calls flushRegistry() — models graceful shutdown.
+		a.Stop()
+
+		// On restart, the offset should be the sent offset (not missing).
+		diskOffset, err := readRegistryOffsetFromDisk(a.registryPath, identifier)
+		if err != nil {
+			t.Fatalf("reading disk after stop: %v", err)
+		}
+		if diskOffset != sentOffset {
+			t.Fatalf("UNEXPECTED: after graceful stop, disk offset is %q (want %q). "+
+				"Drain-on-stop may be broken.", diskOffset, sentOffset)
+		}
+		t.Logf("BASELINE HOLDS: graceful stop flushed offset %q to disk; "+
+			"tailer would NOT replay this payload after restart.", diskOffset)
+	})
+
+	// Sub-test 3: Informational — quantify the flush window.
+	//
+	// Confirms that the auditor's in-memory registry IS advanced after a payload
+	// arrives on inputChan, but the disk state LAGS until the next flushTicker.
+	// This directly documents the 1-second window from auditor.go:26.
+	t.Run("in_memory_advances_before_disk_flush", func(t *testing.T) {
+		dir := t.TempDir()
+		const identifier = "file:///var/log/window.log"
+		const offset = "9999"
+		const ts = int64(3_000_000_000)
+
+		a := buildAuditorAt(t, dir)
+		a.Start()
+		defer a.Stop()
+
+		payload := buildPayloadFor(identifier, offset, ts)
+		ch := a.Channel()
+		select {
+		case ch <- payload:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out sending payload")
+		}
+
+		// Poll in-memory registry: should advance quickly (< 100ms).
+		var inMemOffset string
+		deadline := time.Now().Add(500 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			inMemOffset = a.GetOffset(identifier)
+			if inMemOffset == offset {
+				break
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+
+		if inMemOffset != offset {
+			t.Logf("in-memory registry not advanced within 500ms (got %q want %q). "+
+				"Run loop may be slower than expected.", inMemOffset, offset)
+		} else {
+			t.Logf("in-memory registry advanced to %q quickly", inMemOffset)
+		}
+
+		// Check disk IMMEDIATELY (before the 1s flushTicker fires).
+		diskOffset, err := readRegistryOffsetFromDisk(a.registryPath, identifier)
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatalf("reading disk: %v", err)
+		}
+
+		if diskOffset == offset {
+			t.Logf("NOTE: disk already has offset %q — flushTicker fired very quickly "+
+				"(or the payload arrived just before a tick). The 1-second window "+
+				"is a statistical window, not an absolute guarantee.", diskOffset)
+		} else {
+			t.Logf("CONFIRMED WINDOW: in-memory=%q disk=%q — the offset is in-memory "+
+				"only; a crash NOW would cause replay. This is the 1-second flush "+
+				"window documented at auditor.go:26 (defaultFlushPeriod = 1s).", inMemOffset, diskOffset)
+		}
+
+		// This sub-test is informational — no t.Fatalf.
+		t.Logf("1-second flush window exists between in-memory advance and disk flush. "+
+			"Crash within this window → replay of the in-memory-only payload.")
+	})
+}

--- a/comp/logs/auditor/impl/antithesis_registry_format_migration_safe_demo_test.go
+++ b/comp/logs/auditor/impl/antithesis_registry_format_migration_safe_demo_test.go
@@ -1,0 +1,332 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// Antithesis migration-safety demonstration for property `registry-format-migration-safe`,
+// gated behind `antithesis_demo`. Run:
+//
+//	go test -tags "antithesis_demo test" -run TestAntithesisRegistryFormatMigrationSafe \
+//	    ./comp/logs/auditor/impl/ -v
+//
+// Claim (from registry-format-migration-safe.md):
+// Migrating a v0 or v1 registry through the current auditor should preserve all
+// offset entries with valid data. The `default` branch of unmarshalRegistry()
+// (auditor.go:458-461) should never fire for known versions (0, 1, 2).
+//
+// Key code path:
+//
+//	unmarshalRegistry() auditor.go:440-462 — version dispatch
+//	unmarshalRegistryV0() api_v0.go:27-45  — v0 migration (adds "file:" prefix)
+//	unmarshalRegistryV1() api_v1.go:27-44  — v1 migration (Offset int64 or Timestamp)
+//	unmarshalRegistryV2() api_v2.go:15-27  — v2 direct unmarshal
+//
+// Test structure:
+//  1. Sub-test "v1_migration_preserves_offsets": write a v1 registry with two
+//     entries (one with Offset>0, one with Timestamp string), recover, assert
+//     both entries are present with correct offsets. EXPECTED: PASS (migration correct).
+//  2. Sub-test "v0_migration_preserves_offsets": write a v0 registry with two
+//     file entries (both Offset>0), recover, assert identifiers have "file:" prefix
+//     and correct offsets. EXPECTED: PASS.
+//  3. Sub-test "v0_drops_zero_offset_entries": write a v0 registry entry with
+//     Offset=0 — api_v0.go:35 explicitly drops these. Assert the entry is absent.
+//     VERDICT for this sub-test: the behavior is intentional (zero means no data
+//     yet), but we document it to surface the implicit data model assumption.
+//  4. Sub-test "unknown_version_returns_error": write a version=99 registry,
+//     assert recoverRegistry() returns empty map (the default branch fires).
+//     This is correct behavior but we verify the default branch is reachable.
+//  5. Sub-test "v2_round_trip": the current write version; flush + recover preserves
+//     all fields including TailingMode and Fingerprint. EXPECTED: PASS.
+
+package auditorimpl
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	configmock "github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	kubehealthmock "github.com/DataDog/datadog-agent/comp/logs-library/kubehealth/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/types"
+)
+
+// newMigrationTestAuditor builds a registryAuditor pointed at dir.
+func newMigrationTestAuditor(t *testing.T, dir string) *registryAuditor {
+	t.Helper()
+	cfg := configmock.NewMock(t)
+	cfg.SetWithoutSource("logs_config.run_path", dir)
+	return newAuditor(Dependencies{
+		Config:     cfg,
+		Log:        logmock.New(t),
+		KubeHealth: kubehealthmock.NewMockRegistrar(),
+	})
+}
+
+// writeRegistryFile marshals v and writes it as the registry.json in dir.
+func writeRegistryFile(t *testing.T, dir string, v interface{}) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal registry: %v", err)
+	}
+	p := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(p, data, 0644); err != nil {
+		t.Fatalf("write registry file: %v", err)
+	}
+	t.Logf("wrote registry.json (%d bytes): %s", len(data), string(data))
+}
+
+// TestAntithesisRegistryFormatMigrationSafe tests that version migration preserves
+// all valid entries and that the version dispatch behaves as documented.
+func TestAntithesisRegistryFormatMigrationSafe(t *testing.T) {
+
+	// -----------------------------------------------------------------------
+	// Sub-test 1: v1 migration preserves both Offset and Timestamp entries
+	//
+	// v1 format has two offset representations:
+	//   - entry.Offset int64 > 0   → stored as decimal string
+	//   - entry.Timestamp string != "" → stored verbatim as Offset string
+	// Both paths must survive migration (api_v1.go:35-41).
+	// -----------------------------------------------------------------------
+	t.Run("v1_migration_preserves_offsets", func(t *testing.T) {
+		dir := t.TempDir()
+
+		v1Registry := struct {
+			Version  int
+			Registry map[string]registryEntryV1
+		}{
+			Version: 1,
+			Registry: map[string]registryEntryV1{
+				"file:/var/log/app.log": {
+					Offset:      12345,
+					LastUpdated: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				"docker://container-abc": {
+					Timestamp:   "2024-01-01T12:00:00.000000001Z",
+					LastUpdated: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+				},
+			},
+		}
+		writeRegistryFile(t, dir, v1Registry)
+
+		a := newMigrationTestAuditor(t, dir)
+		a.registry = a.recoverRegistry()
+
+		// Verify file tailer offset preserved.
+		fileOffset := a.GetOffset("file:/var/log/app.log")
+		containerOffset := a.GetOffset("docker://container-abc")
+
+		t.Logf("v1 migration results:")
+		t.Logf("  file:/var/log/app.log offset = %q (want \"12345\")", fileOffset)
+		t.Logf("  docker://container-abc offset = %q (want \"2024-01-01T12:00:00.000000001Z\")", containerOffset)
+
+		failed := false
+		if fileOffset != "12345" {
+			t.Errorf("REPRODUCED: v1 migration dropped file offset: got %q, want \"12345\"", fileOffset)
+			failed = true
+		}
+		if containerOffset != "2024-01-01T12:00:00.000000001Z" {
+			t.Errorf("REPRODUCED: v1 migration dropped container timestamp: got %q, want \"2024-01-01T12:00:00.000000001Z\"", containerOffset)
+			failed = true
+		}
+		if !failed {
+			t.Logf("REFUTED: v1 migration correctly preserved both entry types — migration is safe for v1")
+		}
+	})
+
+	// -----------------------------------------------------------------------
+	// Sub-test 2: v0 migration rewrites identifiers with "file:" prefix
+	//
+	// api_v0.go:38: newIdentifier = "file:" + identifier
+	// Both entries have Offset>0 so both should survive.
+	// -----------------------------------------------------------------------
+	t.Run("v0_migration_adds_file_prefix", func(t *testing.T) {
+		dir := t.TempDir()
+
+		v0Registry := struct {
+			Version  int
+			Registry map[string]registryEntryV0
+		}{
+			Version: 0,
+			Registry: map[string]registryEntryV0{
+				"/var/log/app.log":    {Path: "/var/log/app.log", Offset: 1000, Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+				"/var/log/other.log":  {Path: "/var/log/other.log", Offset: 2000, Timestamp: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+			},
+		}
+		writeRegistryFile(t, dir, v0Registry)
+
+		a := newMigrationTestAuditor(t, dir)
+		a.registry = a.recoverRegistry()
+
+		t.Logf("v0 migration results:")
+		for _, id := range []string{"file:/var/log/app.log", "file:/var/log/other.log"} {
+			t.Logf("  %s offset = %q", id, a.GetOffset(id))
+		}
+		// Old identifiers should NOT exist (they got the file: prefix).
+		for _, id := range []string{"/var/log/app.log", "/var/log/other.log"} {
+			t.Logf("  %s (old, no prefix) offset = %q", id, a.GetOffset(id))
+		}
+
+		failed := false
+		if a.GetOffset("file:/var/log/app.log") != "1000" {
+			t.Errorf("REPRODUCED: v0 migration dropped or misidentified app.log: got %q, want \"1000\"",
+				a.GetOffset("file:/var/log/app.log"))
+			failed = true
+		}
+		if a.GetOffset("file:/var/log/other.log") != "2000" {
+			t.Errorf("REPRODUCED: v0 migration dropped or misidentified other.log: got %q, want \"2000\"",
+				a.GetOffset("file:/var/log/other.log"))
+			failed = true
+		}
+		// Old identifiers must be absent after prefix rewrite.
+		if a.GetOffset("/var/log/app.log") != "" {
+			t.Errorf("REPRODUCED: v0 migration kept old non-prefixed identifier: %q should be gone",
+				"/var/log/app.log")
+			failed = true
+		}
+		if !failed {
+			t.Logf("REFUTED: v0 migration correctly added file: prefix and preserved offsets — migration is safe for v0")
+		}
+	})
+
+	// -----------------------------------------------------------------------
+	// Sub-test 3: v0 drops entries with Offset=0
+	//
+	// api_v0.go:35-42: the switch only saves entries where entry.Offset > 0.
+	// An entry with Offset=0 is silently dropped. This is intentional — zero
+	// means "no data read yet" in v0 — but we document the behavior to confirm
+	// that zero-offset entries from v0 are never migrated.
+	// -----------------------------------------------------------------------
+	t.Run("v0_drops_zero_offset_entries", func(t *testing.T) {
+		dir := t.TempDir()
+
+		v0Registry := struct {
+			Version  int
+			Registry map[string]registryEntryV0
+		}{
+			Version: 0,
+			Registry: map[string]registryEntryV0{
+				"/var/log/app.log":    {Path: "/var/log/app.log", Offset: 500},  // kept
+				"/var/log/zero.log":   {Path: "/var/log/zero.log", Offset: 0},   // dropped by api_v0.go:35
+			},
+		}
+		writeRegistryFile(t, dir, v0Registry)
+
+		a := newMigrationTestAuditor(t, dir)
+		a.registry = a.recoverRegistry()
+
+		appOffset := a.GetOffset("file:/var/log/app.log")
+		zeroOffset := a.GetOffset("file:/var/log/zero.log")
+
+		t.Logf("v0 zero-offset drop behavior:")
+		t.Logf("  file:/var/log/app.log (offset=500): got %q (want \"500\")", appOffset)
+		t.Logf("  file:/var/log/zero.log (offset=0):  got %q (want \"\" — intentionally dropped by api_v0.go:35)", zeroOffset)
+
+		if appOffset != "500" {
+			t.Errorf("REPRODUCED unexpected: non-zero offset entry was dropped: got %q, want \"500\"", appOffset)
+		}
+		if zeroOffset != "" {
+			t.Errorf("REPRODUCED unexpected: zero-offset entry was kept (should be dropped by api_v0.go:35): got %q", zeroOffset)
+		} else {
+			t.Logf("CONFIRMED: v0 zero-offset drop is intentional and works as documented (api_v0.go:35)")
+			t.Logf("NOTE: any tailer whose first write was interrupted (Offset=0) loses its position on v0→v2 upgrade")
+		}
+	})
+
+	// -----------------------------------------------------------------------
+	// Sub-test 4: unknown version returns error → empty map
+	//
+	// auditor.go:458-461: default branch returns errors.New("invalid registry version number")
+	// recoverRegistry() (auditor.go:347-352) treats this as corrupt → empty map.
+	// -----------------------------------------------------------------------
+	t.Run("unknown_version_returns_empty_map", func(t *testing.T) {
+		dir := t.TempDir()
+
+		unknownVersionRegistry := struct {
+			Version  int
+			Registry map[string]RegistryEntry
+		}{
+			Version: 99,
+			Registry: map[string]RegistryEntry{
+				"file:/var/log/app.log": {Offset: "12345", TailingMode: "beginning"},
+			},
+		}
+		writeRegistryFile(t, dir, unknownVersionRegistry)
+
+		a := newMigrationTestAuditor(t, dir)
+		a.registry = a.recoverRegistry()
+
+		offset := a.GetOffset("file:/var/log/app.log")
+		t.Logf("unknown version=99 recovery result: GetOffset = %q", offset)
+
+		if offset != "" {
+			t.Errorf("UNEXPECTED: version=99 registry was somehow recovered with offset %q", offset)
+		} else {
+			// This is the CORRECT/expected behavior — unknown versions should error.
+			// But we document it: the default branch at auditor.go:458-461 fires.
+			// If a future v3 agent writes version=3, a rollback to the current agent
+			// hits this default branch and loses all offsets.
+			t.Logf("CONFIRMED: unknown version=99 correctly returns empty map (auditor.go:458-461 default branch)")
+			t.Logf("NOTE: rollback from a future v3 agent to this agent would silently lose all offsets")
+		}
+	})
+
+	// -----------------------------------------------------------------------
+	// Sub-test 5: v2 round-trip preserves all fields including TailingMode + Fingerprint
+	//
+	// This is the happy path for the current version — verify it as a baseline.
+	// -----------------------------------------------------------------------
+	t.Run("v2_round_trip_preserves_all_fields", func(t *testing.T) {
+		dir := t.TempDir()
+		const id = "file:/var/log/app.log"
+
+		fpConfig := &types.FingerprintConfig{
+			FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+			Count:               1,
+		}
+		a := newMigrationTestAuditor(t, dir)
+		a.registry = map[string]*RegistryEntry{
+			id: {
+				LastUpdated:        time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC),
+				Offset:             "88888",
+				TailingMode:        "beginning",
+				IngestionTimestamp: 42,
+				Fingerprint:        types.Fingerprint{Value: 99999, Config: fpConfig},
+			},
+		}
+		if err := a.flushRegistry(); err != nil {
+			t.Fatalf("flush failed: %v", err)
+		}
+
+		a2 := newMigrationTestAuditor(t, dir)
+		a2.registry = a2.recoverRegistry()
+
+		offset := a2.GetOffset(id)
+		mode := a2.GetTailingMode(id)
+		fp := a2.GetFingerprint(id)
+
+		t.Logf("v2 round-trip: offset=%q mode=%q fp.Value=%v", offset, mode, fp)
+
+		failed := false
+		if offset != "88888" {
+			t.Errorf("REPRODUCED: v2 round-trip lost offset: got %q, want \"88888\"", offset)
+			failed = true
+		}
+		if mode != "beginning" {
+			t.Errorf("REPRODUCED: v2 round-trip lost TailingMode: got %q, want \"beginning\"", mode)
+			failed = true
+		}
+		if fp == nil || fp.Value != 99999 {
+			t.Errorf("REPRODUCED: v2 round-trip lost Fingerprint: got %v", fp)
+			failed = true
+		}
+		if !failed {
+			t.Logf("REFUTED: v2 round-trip correctly preserved all fields — v2 migration is safe")
+		}
+	})
+}

--- a/comp/logs/auditor/impl/antithesis_registry_recovers_after_crash_demo_test.go
+++ b/comp/logs/auditor/impl/antithesis_registry_recovers_after_crash_demo_test.go
@@ -1,0 +1,195 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// Antithesis bug *demonstration* for property `registry-recovers-after-crash`,
+// gated behind `antithesis_demo`. Run:
+//
+//	go test -tags "antithesis_demo test" -run TestAntithesisRegistryRecoversAfterCrash \
+//	    ./comp/logs/auditor/impl/ -v
+//
+// Claim (from registry-recovers-after-crash.md):
+// If registry.json is MISSING or contains CORRUPT/UNPARSEABLE data,
+// recoverRegistry() (auditor.go:337-353) silently returns an empty map with no
+// error surfaced to the caller. On the next Start(), every tailer resumes from
+// its default position (usually end-of-file) causing silent data loss, or
+// beginning-of-file causing mass replay.
+//
+// Key code path:
+//
+//	recoverRegistry() auditor.go:337-353
+//	  - os.IsNotExist(err) → log.Info, return make(map[string]*RegistryEntry)
+//	  - unmarshalRegistry error → log.Error, return make(map[string]*RegistryEntry)
+//	  - No error is returned; caller (Start) has no signal that recovery failed.
+//
+// Test structure:
+//  1. Sub-test "missing_registry": no file on disk at all → recoverRegistry
+//     returns empty map → GetOffset("known-id") == "" → REPRODUCED (silent loss).
+//  2. Sub-test "corrupt_registry": write a zero-byte file (the exact artifact left
+//     by a non-atomic writer crash) → recoverRegistry returns empty map →
+//     GetOffset("known-id") == "" → REPRODUCED (silent loss).
+//  3. Sub-test "corrupt_json": write syntactically invalid JSON → same outcome.
+//
+// VERDICT expectation: REPRODUCED for all three sub-tests — the auditor silently
+// falls back to an empty registry without surfacing an error.
+
+package auditorimpl
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	configmock "github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	kubehealthmock "github.com/DataDog/datadog-agent/comp/logs-library/kubehealth/mock"
+)
+
+// newTestAuditorForPath builds a registryAuditor pointed at the given directory,
+// using mock dependencies. Does NOT call Start() — tests exercise recoverRegistry()
+// directly, as Start() does (auditor.go:127).
+func newTestAuditorForPath(t *testing.T, runPath string) *registryAuditor {
+	t.Helper()
+	cfg := configmock.NewMock(t)
+	cfg.SetWithoutSource("logs_config.run_path", runPath)
+	deps := Dependencies{
+		Config:     cfg,
+		Log:        logmock.New(t),
+		KubeHealth: kubehealthmock.NewMockRegistrar(),
+	}
+	return newAuditor(deps)
+}
+
+// TestAntithesisRegistryRecoversAfterCrash demonstrates Bug 1:
+// recoverRegistry() silently returns an empty map for missing and corrupt
+// registry files, causing all tailers to resume from their default position.
+func TestAntithesisRegistryRecoversAfterCrash(t *testing.T) {
+	// The identifier that a tailer would normally look up on restart.
+	const knownID = "file:/var/log/app.log"
+	const knownOffset = "99999"
+
+	// -----------------------------------------------------------------------
+	// Sub-test 1: registry.json does not exist at all
+	// This is the first-boot case but also the case after atomic rename completes
+	// on a brand-new volume, or after manual deletion.
+	// -----------------------------------------------------------------------
+	t.Run("missing_registry", func(t *testing.T) {
+		dir := t.TempDir()
+		// Confirm there is no registry file.
+		registryPath := filepath.Join(dir, "registry.json")
+		if _, err := os.Stat(registryPath); !os.IsNotExist(err) {
+			t.Fatalf("precondition failed: registry.json should not exist, stat err: %v", err)
+		}
+
+		a := newTestAuditorForPath(t, dir)
+		// recoverRegistry() is what Start() calls (auditor.go:127).
+		a.registry = a.recoverRegistry()
+
+		offset := a.GetOffset(knownID)
+		if offset != "" {
+			// Unexpected: somehow returned an offset without a file — should never happen.
+			t.Logf("UNEXPECTED: GetOffset returned %q for missing registry — not empty", offset)
+		} else {
+			// BUG DEMONSTRATED: the auditor silently recovered with an empty map.
+			// No error was returned to the caller; Start() proceeds normally.
+			// Every tailer will resume from its TailingMode default position.
+			t.Logf("BUG DEMONSTRATED (registry-recovers-after-crash / missing registry):")
+			t.Logf("  recoverRegistry() silently returned empty map (auditor.go:337-353)")
+			t.Logf("  GetOffset(%q) == \"\" — tailer resumes from default TailingMode position", knownID)
+			t.Logf("  No error surfaced; Start() proceeds as if this is a clean first boot")
+			t.Fatalf(
+				"REPRODUCED: recoverRegistry() silently returned empty map for missing registry.\n"+
+					"  Identifier %q has no offset after recovery.\n"+
+					"  Tailers will restart from TailingMode default (end-of-file=loss, beginning=replay).\n"+
+					"  auditor.go:337-353 — no error returned, only a log.Info line.",
+				knownID,
+			)
+		}
+	})
+
+	// -----------------------------------------------------------------------
+	// Sub-test 2: registry.json is zero bytes
+	// This is the exact artifact of a non-atomic writer crash (os.Create truncates,
+	// then the process is killed before Write completes).
+	// See registry_writer.go:63 and antithesis_fargate_registry_corruption_demo_test.go.
+	// -----------------------------------------------------------------------
+	t.Run("zero_byte_registry", func(t *testing.T) {
+		dir := t.TempDir()
+		registryPath := filepath.Join(dir, "registry.json")
+
+		// Write a valid registry first (simulates the pre-crash state).
+		a := newTestAuditorForPath(t, dir)
+		a.registry = map[string]*RegistryEntry{
+			knownID: {Offset: knownOffset, TailingMode: "beginning"},
+		}
+		if err := a.flushRegistry(); err != nil {
+			t.Fatalf("failed to write pre-crash registry: %v", err)
+		}
+
+		// Simulate the crash artifact: truncate to zero bytes.
+		f, err := os.Create(registryPath)
+		if err != nil {
+			t.Fatalf("failed to truncate registry to zero bytes: %v", err)
+		}
+		f.Close()
+		info, _ := os.Stat(registryPath)
+		t.Logf("registry.json is now %d bytes (simulating crash artifact)", info.Size())
+
+		// Now simulate agent restart: new auditor, same path, call recoverRegistry().
+		a2 := newTestAuditorForPath(t, dir)
+		a2.registry = a2.recoverRegistry()
+
+		offset := a2.GetOffset(knownID)
+		if offset == knownOffset {
+			t.Logf("REFUTED: GetOffset returned the correct offset %q — recovery preserved state", offset)
+		} else {
+			t.Logf("BUG DEMONSTRATED (registry-recovers-after-crash / zero-byte registry):")
+			t.Logf("  Zero-byte file was written by simulated crash (os.Create truncate, no Write)")
+			t.Logf("  recoverRegistry() (auditor.go:337-353) got json.Unmarshal error → empty map")
+			t.Logf("  GetOffset(%q) == %q (want %q)", knownID, offset, knownOffset)
+			t.Fatalf(
+				"REPRODUCED: recoverRegistry() silently returned empty map for zero-byte registry.\n"+
+					"  Identifier %q: got offset %q, want %q.\n"+
+					"  auditor.go:347-352 — unmarshal error logs and returns empty map, no error to caller.\n"+
+					"  Tailers restart from TailingMode default → silent data loss or mass replay.",
+				knownID, offset, knownOffset,
+			)
+		}
+	})
+
+	// -----------------------------------------------------------------------
+	// Sub-test 3: registry.json contains syntactically invalid JSON
+	// This covers partial writes, bit-rot, and filesystem corruption.
+	// -----------------------------------------------------------------------
+	t.Run("corrupt_json_registry", func(t *testing.T) {
+		dir := t.TempDir()
+		registryPath := filepath.Join(dir, "registry.json")
+
+		// Write corrupt JSON directly.
+		corrupt := []byte(`{"Version":2,"Registry":{"file:/var/log/app.log":CORRUPT}}`)
+		if err := os.WriteFile(registryPath, corrupt, 0644); err != nil {
+			t.Fatalf("failed to write corrupt registry: %v", err)
+		}
+
+		a := newTestAuditorForPath(t, dir)
+		a.registry = a.recoverRegistry()
+
+		offset := a.GetOffset(knownID)
+		if offset != "" {
+			t.Logf("UNEXPECTED: GetOffset returned %q for corrupt registry", offset)
+		} else {
+			t.Logf("BUG DEMONSTRATED (registry-recovers-after-crash / corrupt JSON):")
+			t.Logf("  Corrupt JSON in registry.json → json.Unmarshal fails → empty map (auditor.go:347-352)")
+			t.Logf("  GetOffset(%q) == \"\" — tailer resumes from default TailingMode position", knownID)
+			t.Fatalf(
+				"REPRODUCED: recoverRegistry() silently returned empty map for corrupt JSON registry.\n"+
+					"  Identifier %q has no offset after recovery.\n"+
+					"  auditor.go:347-352 — unmarshal error logged but not surfaced; Start() continues.",
+				knownID,
+			)
+		}
+	})
+}


### PR DESCRIPTION
### What does this PR do?

Adds tests for how the auditor — the part that tracks what's been sent — handles crashes. The crash is faked by setting up the on-disk state, so no special infrastructure is needed. Off in normal CI (`antithesis_demo` tag).

Real bugs (these tests fail):

- **Progress can go backwards** — the check against rewinding a file's position only compares timestamps, never the position itself, so a slow old reader can overwrite a newer position with an older one and cause a flood of duplicates.
- **Registry left empty after a crash (Fargate)** — the non-atomic writer empties the file before writing, so a crash in between leaves a zero-byte file.
- **A broken registry is treated as "start over"** — if the file is missing or corrupt, recovery quietly returns nothing and every reader restarts from scratch (data loss, or a re-read flood).
- **A "permanently dropped" line can come back** — when the intake rejects a line for good, the agent moves past it in memory but only saves to disk once a second; a crash in that window means the rejected line gets re-sent after restart.

Checked and fine (these pass): the auditor does drain everything on a normal stop, and the registry version migration keeps all entries.

### Motivation

Part of the logs-agent Antithesis work.

### Describe how you validated your changes

`go test -tags "antithesis_demo test" -run TestAntithesis ./comp/logs/auditor/impl/ -v`. Four fail (the bugs), two pass (the checks).

### Additional Notes

Doesn't run in normal CI. A full kill-the-process test would need a fault our Antithesis tenant has turned off; these reproduce the same loss/duplicate windows at the component level instead. No agent code changed.
