### PR TITLE
antithesis(logs): container races drop logs and mislabel metadata

### DIFF
--- a/comp/logs-library/processor/antithesis_stale_origin_metadata_demo_test.go
+++ b/comp/logs-library/processor/antithesis_stale_origin_metadata_demo_test.go
@@ -1,0 +1,272 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// Antithesis bug demonstration (not a fix), gated behind `antithesis_demo`. Run:
+//
+//	go test -tags "antithesis_demo test" \
+//	    -run TestAntithesisStaleOriginMetadata \
+//	    ./comp/logs-library/processor/ -v -timeout 10s \
+//	    2>&1 | grep -vE "^[0-9]{16} \[Info\]"
+//
+// Demonstrates property `log-metadata-not-corrupted`:
+//
+// # Background — the stale-origin hazard
+//
+// Both filterMRFMessages (processor.go:236) and the JSON encoder (json.go:67)
+// resolve the service name by calling msg.Origin.Service() at processing time:
+//
+//	// origin.go:154-161
+//	func (o *Origin) Service() string {
+//	    if o == nil || o.LogSource == nil {
+//	        return ""
+//	    }
+//	    if o.LogSource.Config.Service != "" {
+//	        return o.LogSource.Config.Service  // reads live field — NOT a snapshot
+//	    }
+//	    return o.service
+//	}
+//
+// The LogSource.Config pointer is shared between the message's Origin and the
+// live source registry. Under container churn (rapid container create/destroy),
+// the AD scheduler replaces or mutates Config fields on the live LogSource while
+// messages from the old container are still in-flight in the pipeline channel.
+//
+// # What this test does
+//
+//  1. Creates a LogSource with Config.Service = "svc-a" (simulating container A).
+//  2. Creates a message whose Origin points at that source.
+//  3. Sends the message into the processor's inputChan.
+//  4. Before the message is processed, mutates Config.Service to "svc-b"
+//     (simulating container churn: the same LogSource object gets a new service
+//     name from an updated AD annotation, or the Config pointer is reused for
+//     container B).
+//  5. Lets the processor run.
+//  6. Asserts the delivered message carries service "svc-a" (the value valid at
+//     read time). FAILS if it carries "svc-b" (stale/wrong metadata).
+//
+// Sub-test 2 repeats the same sequence for the MRF allowlist path: a message
+// from "billing-service" is in-flight when the source is mutated to
+// "payment-service". The message should be MRF-tagged because its service was
+// in the allowlist at creation time. It will NOT be tagged because
+// filterMRFMessages reads the mutated value.
+//
+// EXPECTED TO FAIL on both sub-tests.
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package processor
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
+	agentconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+)
+
+// makeStaleOriginProcessor builds a minimal Processor with real channels and the
+// real JSON encoder. The configChan is pre-seeded with a zero failoverConfig so
+// that the processor does not block on the configChan read in run().
+func makeStaleOriginProcessor(encoder Encoder) (*Processor, chan *message.Message, chan *message.Message) {
+	inputChan := make(chan *message.Message, 10)
+	outputChan := make(chan *message.Message, 10)
+
+	p := &Processor{
+		inputChan:                 inputChan,
+		outputChan:                outputChan,
+		processingRules:           nil,
+		encoder:                   encoder,
+		done:                      make(chan struct{}, 1),
+		diagnosticMessageReceiver: &diagnostic.NoopMessageReceiver{},
+		hostname:                  nil,
+		pipelineMonitor:           metrics.NewNoopPipelineMonitor("antithesis-stale-origin"),
+		utilization:               metrics.NewNoopPipelineMonitor("antithesis-stale-origin").MakeUtilizationMonitor("antithesis-stale-origin", "antithesis-stale-origin"),
+		instanceID:                "antithesis-stale-origin",
+		configChan:                make(chan failoverConfig, 1),
+	}
+	// Pre-seed configChan so run() picks up the initial failoverConfig immediately.
+	p.configChan <- failoverConfig{}
+	return p, inputChan, outputChan
+}
+
+// serviceFromEncoded decodes the JSON-encoded message payload and returns the
+// "service" field. The processor's JSON encoder writes the final wire payload
+// (json.go:62-76); the delivered message is in StateEncoded with its content set
+// to the encoded bytes.
+func serviceFromEncoded(t *testing.T, msg *message.Message) string {
+	t.Helper()
+	var payload struct {
+		Service string `json:"service"`
+	}
+	if err := json.Unmarshal(msg.GetContent(), &payload); err != nil {
+		t.Fatalf("failed to decode encoded message payload: %v\ncontent: %s", err, msg.GetContent())
+	}
+	return payload.Service
+}
+
+// TestAntithesisStaleOriginMetadata_JSONService demonstrates that the JSON
+// encoder reads LogSource.Config.Service at encode time (json.go:67), not at
+// message creation time. When Config.Service is mutated between message creation
+// and encode, the delivered payload carries the wrong (mutated) service.
+//
+// EXPECTED TO FAIL: asserts service == "svc-a"; actual will be "svc-b".
+func TestAntithesisStaleOriginMetadata_JSONService(t *testing.T) {
+	// Step 1 — build source with initial service name (container A).
+	cfg := &agentconfig.LogsConfig{
+		Service: "svc-a",
+		Source:  "test-src",
+		Type:    "file",
+		Path:    "/tmp/test.log",
+	}
+	src := sources.NewLogSource("container-a", cfg)
+
+	// Step 2 — create message whose Origin points at that source.
+	msg := message.NewMessageWithSource([]byte("log line from container A"), "info", src, 0)
+
+	// Step 3 — feed message into processor BEFORE starting it, so we can
+	// mutate the source while the message is already buffered in inputChan.
+	p, inputChan, outputChan := makeStaleOriginProcessor(JSONEncoder)
+	inputChan <- msg
+
+	// Step 4 — simulate container churn: the AD scheduler mutates the
+	// Config.Service field on the same LogSource object (or reuses the
+	// Config pointer for a new container). The message is already in-flight.
+	//
+	// In production this race is probabilistic (bounded by AD scan interval,
+	// ~5 s). Here we make it deterministic by mutating before the processor
+	// goroutine runs.
+	src.Config.Service = "svc-b" // container churn / source mutation
+
+	// Step 5 — start processor and let it drain.
+	p.Start()
+	defer p.Stop()
+
+	// Step 6 — wait for the delivered message.
+	select {
+	case delivered := <-outputChan:
+		gotService := serviceFromEncoded(t, delivered)
+
+		// The service on the delivered wire payload must match the value that
+		// was valid when the log line was READ (svc-a), not the value that was
+		// set by the churn (svc-b).
+		if gotService == "svc-a" {
+			t.Logf("NOT A BUG: service correctly captured at creation time: %q", gotService)
+		} else {
+			t.Fatalf(
+				"BUG DEMONSTRATED (log-metadata-not-corrupted / JSON service field): "+
+					"message was created with LogSource.Config.Service = %q. "+
+					"Config.Service was mutated to %q (simulating container churn) "+
+					"while the message was in-flight in the processor's inputChan. "+
+					"The JSON encoder (json.go:67) called msg.Origin.Service() at "+
+					"encode time and read the MUTATED value. "+
+					"Delivered payload has service = %q (expected %q). "+
+					"Root cause: Origin.Service() (origin.go:157-159) reads "+
+					"o.LogSource.Config.Service directly — no snapshot is taken at "+
+					"message creation time. Under container churn the live Config "+
+					"field races with in-flight messages.",
+				"svc-a", "svc-b", gotService, "svc-a",
+			)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for processor output — message was dropped")
+	}
+}
+
+// TestAntithesisStaleOriginMetadata_MRFRouting demonstrates that
+// filterMRFMessages (processor.go:236) reads LogSource.Config.Service at
+// processing time. When Config.Service is mutated between message creation and
+// filterMRFMessages execution, the MRF routing decision is based on the wrong
+// (mutated) service name.
+//
+// Scenario:
+//   - "billing-service" is in the MRF allowlist → messages should be MRF-tagged.
+//   - The source is mutated to "payment-service" while the message is in-flight.
+//   - filterMRFMessages reads "payment-service", finds it NOT in the allowlist,
+//     and does NOT tag the message IsMRFAllow = true.
+//
+// EXPECTED TO FAIL: asserts IsMRFAllow == true; actual will be false.
+func TestAntithesisStaleOriginMetadata_MRFRouting(t *testing.T) {
+	// Step 1 — build source with service that IS in the MRF allowlist.
+	cfg := &agentconfig.LogsConfig{
+		Service: "billing-service",
+		Source:  "billing-src",
+		Type:    "file",
+		Path:    "/tmp/billing.log",
+	}
+	src := sources.NewLogSource("billing-container", cfg)
+
+	// Step 2 — create the message.
+	msg := message.NewMessageWithSource([]byte("billing log line"), "info", src, 0)
+
+	// Step 3 — build processor with MRF failover active and allowlist = {"billing-service"}.
+	inputChan := make(chan *message.Message, 10)
+	outputChan := make(chan *message.Message, 10)
+
+	p := &Processor{
+		inputChan:       inputChan,
+		outputChan:      outputChan,
+		processingRules: nil,
+		encoder:         JSONEncoder,
+		done:            make(chan struct{}, 1),
+		diagnosticMessageReceiver: &diagnostic.NoopMessageReceiver{},
+		hostname:        nil,
+		pipelineMonitor: metrics.NewNoopPipelineMonitor("antithesis-mrf"),
+		utilization:     metrics.NewNoopPipelineMonitor("antithesis-mrf").MakeUtilizationMonitor("antithesis-mrf", "antithesis-mrf"),
+		instanceID:      "antithesis-mrf",
+		configChan:      make(chan failoverConfig, 1),
+	}
+	// Pre-seed configChan with MRF active and billing-service in the allowlist.
+	p.configChan <- failoverConfig{
+		isFailoverActive: true,
+		failoverServiceAllowlist: map[string]struct{}{
+			"billing-service": {},
+		},
+	}
+
+	// Step 4 — enqueue message.
+	inputChan <- msg
+
+	// Step 5 — simulate container churn: billing-service container is replaced
+	// by payment-service container before the processor drains the queue.
+	src.Config.Service = "payment-service" // churn: same LogSource, new service
+
+	// Step 6 — start processor and let it drain.
+	p.Start()
+	defer p.Stop()
+
+	// Step 7 — check MRF tag on the delivered message.
+	select {
+	case delivered := <-outputChan:
+		if delivered.IsMRFAllow {
+			t.Logf("NOT A BUG: message correctly MRF-tagged based on original service")
+		} else {
+			t.Fatalf(
+				"BUG DEMONSTRATED (log-metadata-not-corrupted / MRF routing): "+
+					"message was created with LogSource.Config.Service = %q "+
+					"(in MRF allowlist). Config.Service was mutated to %q (simulating "+
+					"container churn) while the message was in-flight. "+
+					"filterMRFMessages (processor.go:236) called msg.Origin.Service() "+
+					"at processing time and read the MUTATED value %q. "+
+					"Since %q is NOT in the allowlist, IsMRFAllow was not set. "+
+					"The message will be dropped by the MRF secondary region instead "+
+					"of being forwarded. "+
+					"Root cause: Origin.Service() (origin.go:157-159) reads the live "+
+					"LogSource.Config.Service — no snapshot is taken at message creation.",
+				"billing-service", "payment-service", "payment-service", "payment-service",
+			)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for processor output — message was dropped")
+	}
+}

--- a/pkg/logs/schedulers/ad/container_collect_all_race_test.go
+++ b/pkg/logs/schedulers/ad/container_collect_all_race_test.go
@@ -1,0 +1,205 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+// Package ad provides autodiscovery-based log scheduling.
+package ad
+
+// TestContainerCollectAllStartupRaceGap exercises the generic→annotated
+// source-swap sequence at the AD scheduler level and asserts:
+//
+//  1. No wrong-metadata window: while the CCA source is the only active
+//     source for container "abc123", no annotated source is simultaneously
+//     active (i.e., the sequence is strictly add-CCA → remove-CCA →
+//     add-annotated, not add-CCA → add-annotated → remove-CCA).
+//
+//  2. Gap window exists: between RemoveSource(CCA) and AddSource(annotated)
+//     the active-source count for "abc123" drops to zero.  This proves the
+//     hazard is real and not mitigated at the scheduler level.
+//
+// The test FAILS on assertion (2) if the gap exists (the bug is present) so
+// that a failing test output is a reproduction of the race.
+// Assertion (1) passes to show the ordering is correct (no wrong-metadata
+// window where both sources are simultaneously present and the annotated one
+// is newer).
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// trackingSourceManager wraps MockSourceManager and records the active source
+// count for a specific container identifier at each AddSource / RemoveSource
+// call.  This lets the test observe the gap window.
+type trackingSourceManager struct {
+	schedulers.MockSourceManager
+	containerID    string
+	snapshots      []int // active source count for containerID at each event
+	minActiveCount int   // minimum observed active count after initial add
+}
+
+func (t *trackingSourceManager) activeCountForContainer() int {
+	count := 0
+	for _, src := range t.Sources {
+		if src.Config.Identifier == t.containerID {
+			count++
+		}
+	}
+	return count
+}
+
+func (t *trackingSourceManager) AddSource(source *sourcesPkg.LogSource) {
+	t.Sources = append(t.Sources, source)
+	t.MockSourceManager.AddSource(source)
+	n := t.activeCountForContainer()
+	t.snapshots = append(t.snapshots, n)
+}
+
+func (t *trackingSourceManager) RemoveSource(source *sourcesPkg.LogSource) {
+	// Remove from live Sources slice (by pointer equality, like the real impl)
+	for i, s := range t.Sources {
+		if s == source {
+			t.Sources = append(t.Sources[:i], t.Sources[i+1:]...)
+			break
+		}
+	}
+	t.MockSourceManager.RemoveSource(source)
+	n := t.activeCountForContainer()
+	t.snapshots = append(t.snapshots, n)
+	// Track the minimum count after initial setup so we can detect zero.
+	if t.minActiveCount > n {
+		t.minActiveCount = n
+	}
+}
+
+func (t *trackingSourceManager) GetSources() []*sourcesPkg.LogSource {
+	srcs := make([]*sourcesPkg.LogSource, len(t.Sources))
+	copy(srcs, t.Sources)
+	return srcs
+}
+
+func (t *trackingSourceManager) AddService(svc *service.Service) {
+	t.MockSourceManager.AddService(svc)
+}
+
+func (t *trackingSourceManager) RemoveService(svc *service.Service) {
+	t.MockSourceManager.RemoveService(svc)
+}
+
+// TestContainerCollectAllStartupRaceGap is the main race-window test.
+func TestContainerCollectAllStartupRaceGap(t *testing.T) {
+	const containerID = "abc1230000000000000000000000000000000000000000000000000000000000"
+	const serviceID = "docker://" + containerID
+
+	// --- Build the CCA (container_collect_all) integration config.
+	// This is what AD delivers when container_collect_all is enabled and no
+	// annotated config is present yet.  The Provider is set to
+	// names.KubeContainer, which is what config_poller sets when the
+	// ContainerConfigProvider streams a config.
+	ccaConfig := integration.Config{
+		Name:          "container_collect_all",
+		LogsConfig:    []byte(`[{}]`),
+		ADIdentifiers: []string{serviceID},
+		Provider:      names.KubeContainer, // set by config_poller.stream() line 113
+		ServiceID:     serviceID,
+	}
+
+	// --- Build the annotated integration config.
+	// This is what AD delivers when the pod/container annotation arrives.
+	annotatedConfig := integration.Config{
+		Name:          "myapp",
+		LogsConfig:    []byte(`[{"service":"myapp","source":"python"}]`),
+		ADIdentifiers: []string{serviceID},
+		Provider:      names.KubeContainer,
+		ServiceID:     serviceID,
+	}
+
+	// --- Scheduler under test (no real AD component needed)
+	sch := New(nil).(*Scheduler)
+	mgr := &trackingSourceManager{
+		containerID:    containerID,
+		minActiveCount: 999, // will be updated on first RemoveSource
+	}
+	sch.mgr = mgr
+
+	// Step 1: AD schedules the CCA config (no annotated config yet).
+	sch.Schedule([]integration.Config{ccaConfig})
+
+	require.Equal(t, 1, len(mgr.Events), "expected one AddSource event after scheduling CCA config")
+	require.True(t, mgr.Events[0].Add, "first event should be AddSource")
+
+	ccaSource := mgr.Events[0].Source
+	require.NotNil(t, ccaSource)
+	assert.Equal(t, "container_collect_all", ccaSource.Name, "CCA source name should be container_collect_all")
+	assert.Equal(t, containerID, ccaSource.Config.Identifier, "CCA source identifier should match container")
+	// CCA source has no service or source annotation — generic metadata.
+	assert.Equal(t, "", ccaSource.Config.Service, "CCA source should have no service tag")
+	assert.Equal(t, "", ccaSource.Config.Source, "CCA source should have no source tag")
+
+	// Record the post-add snapshot index so we can check ordering.
+	addCCAIdx := len(mgr.snapshots) - 1
+
+	// Reset the minimum active count tracker to measure only after the
+	// initial CCA source is present.
+	mgr.minActiveCount = mgr.snapshots[addCCAIdx]
+
+	// Step 2: AD unschedules the CCA config (annotated config arrived).
+	// The AD scheduler matches by Identifier.
+	sch.Unschedule([]integration.Config{ccaConfig})
+
+	require.Equal(t, 2, len(mgr.Events), "expected a RemoveSource event after unscheduling CCA config")
+	require.False(t, mgr.Events[1].Add, "second event should be RemoveSource")
+	assert.Equal(t, ccaSource, mgr.Events[1].Source, "removed source pointer should match previously added CCA source")
+
+	removeCCAIdx := len(mgr.snapshots) - 1
+
+	// Step 3: AD schedules the annotated config.
+	sch.Schedule([]integration.Config{annotatedConfig})
+
+	require.Equal(t, 3, len(mgr.Events), "expected an AddSource event after scheduling annotated config")
+	require.True(t, mgr.Events[2].Add, "third event should be AddSource")
+
+	annotatedSource := mgr.Events[2].Source
+	require.NotNil(t, annotatedSource)
+	assert.Equal(t, "myapp", annotatedSource.Name, "annotated source name should be myapp")
+	assert.Equal(t, "myapp", annotatedSource.Config.Service, "annotated source should carry service tag")
+	assert.Equal(t, "python", annotatedSource.Config.Source, "annotated source should carry source tag")
+
+	addAnnotatedIdx := len(mgr.snapshots) - 1
+
+	// --- Assert correct ordering (no wrong-metadata window) ---
+	// The event sequence must be: add-CCA → remove-CCA → add-annotated.
+	// The annotated source must NOT have been added before the CCA was removed.
+	assert.True(t, addCCAIdx < removeCCAIdx && removeCCAIdx < addAnnotatedIdx,
+		"ordering must be: AddSource(CCA) < RemoveSource(CCA) < AddSource(annotated); "+
+			"got addCCA=%d removeCCA=%d addAnnotated=%d",
+		addCCAIdx, removeCCAIdx, addAnnotatedIdx,
+	)
+
+	// --- Assert the gap window: active count reaches zero between remove and add ---
+	// At removeCCAIdx snapshot the count for container abc123 should be 0.
+	countAtRemoval := mgr.snapshots[removeCCAIdx]
+	t.Logf("Active source count snapshots: %v", mgr.snapshots)
+	t.Logf("Count at CCA removal: %d (want 0 to prove gap)", countAtRemoval)
+	t.Logf("Count at annotated add: %d (want 1)", mgr.snapshots[addAnnotatedIdx])
+
+	// This assertion FAILS if the gap exists (i.e., countAtRemoval == 0).
+	// A test failure here IS the reproduction of the bug:
+	// there is a window where the container has no active log source.
+	assert.NotEqual(t, 0, countAtRemoval,
+		"BUG REPRODUCED: gap window detected — after RemoveSource(CCA) and before "+
+			"AddSource(annotated), the container '%s' has NO active log source. "+
+			"Log lines written during this window are not collected.",
+		containerID,
+	)
+}

--- a/pkg/logs/sources/sources_ordering_bug_test.go
+++ b/pkg/logs/sources/sources_ordering_bug_test.go
@@ -1,0 +1,119 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build antithesis_demo
+
+package sources
+
+// TestContainerAddRemoveSourceOrdering_OrphanedSource reproduces the
+// container-addremovesource-ordering logical ordering hole deterministically.
+//
+// The bug: WrappedSource.Start() does `go Sources.AddSource(src)` and
+// Stop() does `go Sources.RemoveSource(src)` — both fire-and-forget goroutines
+// (pkg/logs/launchers/container/tailerfactory/tailers/source.go:34,42).
+//
+// For a container that starts and then immediately stops, the Go scheduler may
+// run the Stop goroutine before the Start goroutine, producing the sequence:
+//
+//   1. RemoveSource(s)  — no-op because s is not yet in the list
+//      (sources.go:87-94: sourceFound stays false, no subscriber notified)
+//   2. AddSource(s)     — unconditionally appends s to s.sources (sources.go:56)
+//
+// After both operations, s is permanently present in LogSources even though
+// the container has stopped. No subsequent RemoveSource will ever be called,
+// so the source is orphaned: a launcher will discover it via GetSources() or
+// a subscription and tail a dead container indefinitely.
+//
+// This test exercises that exact ordering directly — no goroutine scheduling
+// tricks needed — and asserts the CORRECT post-condition: after a
+// start-then-stop lifecycle, the source must NOT be present in LogSources.
+// The test demonstrates the bug by showing the source IS present (orphaned).
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerAddRemoveSourceOrdering_OrphanedSource(t *testing.T) {
+	// --- Setup ---
+	ls := NewLogSources()
+	src := NewLogSource("container-xyz", &config.LogsConfig{Type: "docker"})
+
+	// --- Reproduce the race-produced ordering deterministically ---
+	//
+	// Normal (non-racy) order:  AddSource → RemoveSource → 0 sources
+	// Bug-inducing (racy) order: RemoveSource → AddSource → 1 source (orphan)
+	//
+	// We call them in the racy order directly. This is exactly what happens
+	// when the Go scheduler runs the Stop goroutine before the Start goroutine.
+
+	// Step 1: Stop fires first — RemoveSource is a no-op (src not yet present).
+	// sources.go:87-94: the loop finds nothing, sourceFound stays false,
+	// no subscriber is notified, the slice is unchanged.
+	ls.RemoveSource(src)
+
+	sourcesAfterRemove := ls.GetSources()
+	assert.Equal(t, 0, len(sourcesAfterRemove),
+		"RemoveSource on absent source should be a no-op: 0 sources expected after remove-only")
+
+	// Step 2: Start fires second — AddSource unconditionally appends to s.sources.
+	// sources.go:56: `s.sources = append(s.sources, source)` runs regardless of
+	// whether RemoveSource already ran. The source is now in the list permanently.
+	ls.AddSource(src)
+
+	sourcesAfterAdd := ls.GetSources()
+
+	// CORRECT post-condition: a container that started and then immediately
+	// stopped should leave ZERO sources in LogSources. The container is gone;
+	// tailing it is incorrect.
+	correctCount := 0
+
+	// ACTUAL post-condition under the bug: 1 source remains (orphaned).
+	// Any launcher calling GetSources() or receiving via a subscription will
+	// find the dead container's source and begin (or continue) tailing it.
+	buggyCount := 1
+
+	orphanCount := len(sourcesAfterAdd)
+
+	t.Logf("sources present after Remove-then-Add lifecycle: %d", orphanCount)
+	t.Logf("correct (expected): %d — buggy (actual): %d", correctCount, buggyCount)
+
+	if orphanCount == buggyCount {
+		t.Logf("BUG REPRODUCED: source is ORPHANED in LogSources after container stop")
+		t.Logf("  The racy Remove-before-Add ordering left src=%q permanently in the store.", src.Name)
+		t.Logf("  LogSources.RemoveSource (sources.go:84-113) is a no-op when the source")
+		t.Logf("  is absent; LogSources.AddSource (sources.go:53-78) always appends (line 56).")
+		t.Logf("  WrappedSource.Start/Stop both use fire-and-forget goroutines (source.go:34,42),")
+		t.Logf("  so this ordering is reachable in production under scheduler pressure.")
+	}
+
+	// Assert the CORRECT behaviour. This will FAIL (demonstrating the bug)
+	// because orphanCount == 1, not 0.
+	assert.Equal(t, correctCount, orphanCount,
+		"FAIL: %d orphaned source(s) remain after a start-then-stop lifecycle; "+
+			"expected 0. The racy Remove-before-Add ordering (source.go:34,42) leaves "+
+			"the source permanently in LogSources (sources.go:56 always appends).",
+		orphanCount)
+}
+
+// TestContainerAddRemoveSourceOrdering_NormalOrder verifies the happy path:
+// when AddSource runs before RemoveSource (the intended ordering), no source
+// is left behind. This is the non-racy case that already works correctly.
+func TestContainerAddRemoveSourceOrdering_NormalOrder(t *testing.T) {
+	ls := NewLogSources()
+	src := NewLogSource("container-xyz", &config.LogsConfig{Type: "docker"})
+
+	// Normal order: Add then Remove.
+	ls.AddSource(src)
+	assert.Equal(t, 1, len(ls.GetSources()), "source should be present after AddSource")
+
+	ls.RemoveSource(src)
+	assert.Equal(t, 0, len(ls.GetSources()),
+		"source should be absent after RemoveSource: correct normal-order lifecycle")
+
+	t.Logf("Normal order (Add-then-Remove): %d sources remain — correct", len(ls.GetSources()))
+}


### PR DESCRIPTION
### What does this PR do?

Adds tests for three container/Kubernetes timing problems. Each is reproduced reliably by running the steps in the bad order directly, so there's no container runtime or flaky timing involved. Off in normal CI (`antithesis_demo` tag).

- **A stopped container keeps being tailed** — start and stop run in the background; if stop runs before start, the cleanup does nothing and the source is left behind, tailing a dead container.
- **A gap at startup** — switching a container from the generic catch-all source to its real one isn't atomic, so for a moment it has no source at all, and lines written then are missed.
- **Wrong metadata under churn** — the service name is read at send time from the live config, so if a container is replaced while a line is in flight, the line gets the wrong `service` tag (and can be routed to the wrong region).

### Motivation

Part of the logs-agent Antithesis work. Containers/Kubernetes are the main place the agent runs.

### Describe how you validated your changes

`go test -tags "antithesis_demo test" -run "TestContainer|TestAntithesisStaleOrigin" ./pkg/logs/sources/ ./pkg/logs/schedulers/ad/ ./comp/logs-library/processor/ -v`. All fail on purpose.

### Additional Notes

Doesn't run in normal CI; meant to fail. No agent code changed.
