### PR TITLE
[WP] Fix IMDS credentials serialization

### DIFF
--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -702,8 +702,8 @@ func (fh *EBPFFieldHandlers) ResolveProcessCmdArgv(ev *model.Event, process *mod
 }
 
 // ResolveAWSSecurityCredentials resolves and updates the AWS security credentials of the input process entry
-func (fh *EBPFFieldHandlers) ResolveAWSSecurityCredentials(e *model.Event) []model.AWSSecurityCredentials {
-	return fh.resolvers.ProcessResolver.FetchAWSSecurityCredentials(e)
+func (fh *EBPFFieldHandlers) ResolveAWSSecurityCredentials(e *model.Event, process *model.Process) []model.AWSSecurityCredentials {
+	return fh.resolvers.ProcessResolver.FetchAWSSecurityCredentials(e, process)
 }
 
 // ResolveSyscallCtxArgs resolve syscall ctx

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -437,7 +437,7 @@ func (fh *EBPFLessFieldHandlers) ResolveProcessCmdArgv(ev *model.Event, process 
 }
 
 // ResolveAWSSecurityCredentials resolves and updates the AWS security credentials of the input process entry
-func (fh *EBPFLessFieldHandlers) ResolveAWSSecurityCredentials(_ *model.Event) []model.AWSSecurityCredentials {
+func (fh *EBPFLessFieldHandlers) ResolveAWSSecurityCredentials(_ *model.Event, _ *model.Process) []model.AWSSecurityCredentials {
 	return nil
 }
 

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1507,30 +1507,27 @@ func (p *EBPFResolver) UpdateAWSSecurityCredentials(pid uint32, e *model.Event) 
 	}
 }
 
-// FetchAWSSecurityCredentials returns the list of AWS Security Credentials valid at the time of the event, and prunes
-// expired entries
-func (p *EBPFResolver) FetchAWSSecurityCredentials(e *model.Event) []model.AWSSecurityCredentials {
+// FetchAWSSecurityCredentials returns the list of AWS Security Credentials valid at the time of the event for the
+// provided process, and prunes expired entries. Credentials are attributed to the process that made the IMDS request,
+// so only that process should report them (not its ancestors).
+func (p *EBPFResolver) FetchAWSSecurityCredentials(e *model.Event, process *model.Process) []model.AWSSecurityCredentials {
 	p.Lock()
 	defer p.Unlock()
 
-	entry := p.entryCache[e.ProcessContext.Pid]
-	if entry != nil {
-		// check if we should delete
-		var toDelete []int
-		for id, key := range entry.AWSSecurityCredentials {
-			if key.Expiration.Before(e.ResolveEventTime()) {
-				toDelete = append([]int{id}, toDelete...)
-			}
+	// check if we should delete
+	var toDelete []int
+	for id, key := range process.AWSSecurityCredentials {
+		if key.Expiration.Before(e.ResolveEventTime()) {
+			toDelete = append([]int{id}, toDelete...)
 		}
-
-		// delete expired entries
-		for _, id := range toDelete {
-			entry.AWSSecurityCredentials = append(entry.AWSSecurityCredentials[0:id], entry.AWSSecurityCredentials[id+1:]...)
-		}
-
-		return entry.AWSSecurityCredentials
 	}
-	return nil
+
+	// delete expired entries
+	for _, id := range toDelete {
+		process.AWSSecurityCredentials = append(process.AWSSecurityCredentials[0:id], process.AWSSecurityCredentials[id+1:]...)
+	}
+
+	return process.AWSSecurityCredentials
 }
 
 // Start starts the resolver

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -1268,3 +1268,68 @@ func TestTryReparentFromKernelPPid(t *testing.T) {
 		assert.Equal(t, int64(0), resolver.reparentFailedStats[metrics.ReparentCallpathKernelPPid].Load())
 	})
 }
+
+// TestAWSSecurityCredentialsScopedToProcess ensures AWS security credentials
+// obtained from an IMDS request are attributed only to the process that made
+// the request, and never leak onto its ancestors. This is a regression test
+// for a serialization bug where FetchAWSSecurityCredentials ignored the
+// process being serialized and always returned the triggering process's
+// credentials, causing them to be reported for every ancestor.
+func TestAWSSecurityCredentialsScopedToProcess(t *testing.T) {
+	resolver, err := newResolver()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// parent(pid:3) -> child(pid:4); the child performs the IMDS request
+	parent := newFakeForkEvent(0, 3, 123, resolver)
+	child := newFakeForkEvent(3, 4, 123, resolver)
+
+	resolver.AddForkEntry(parent, model.CGroupContext{}, nil)
+	resolver.AddForkEntry(child, model.CGroupContext{}, nil)
+	assert.Equal(t, parent.ProcessCacheEntry, child.ProcessCacheEntry.Ancestor)
+
+	// the child receives credentials from an IMDS v2 response
+	child.IMDS.AWS.SecurityCredentials = model.AWSSecurityCredentials{
+		Code:        "Success",
+		Type:        "AWS-HMAC",
+		AccessKeyID: "AKIAIOSFODNN7EXAMPLE",
+		Expiration:  time.Now().Add(time.Hour),
+	}
+	resolver.UpdateAWSSecurityCredentials(child.ProcessCacheEntry.Pid, child)
+
+	// the requesting process reports the credentials
+	childCreds := resolver.FetchAWSSecurityCredentials(child, &child.ProcessCacheEntry.Process)
+	assert.Len(t, childCreds, 1, "the requesting process should report its credentials")
+	if len(childCreds) == 1 {
+		assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", childCreds[0].AccessKeyID)
+	}
+
+	// the ancestor must NOT report the child's credentials, even though the
+	// event's process context still points to the child
+	parentCreds := resolver.FetchAWSSecurityCredentials(child, &parent.ProcessCacheEntry.Process)
+	assert.Empty(t, parentCreds, "ancestors must not report the requesting process's credentials")
+}
+
+// TestAWSSecurityCredentialsExpiration ensures expired credentials are pruned
+// from the owning process on fetch.
+func TestAWSSecurityCredentialsExpiration(t *testing.T) {
+	resolver, err := newResolver()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proc := newFakeForkEvent(0, 3, 123, resolver)
+	resolver.AddForkEntry(proc, model.CGroupContext{}, nil)
+
+	proc.IMDS.AWS.SecurityCredentials = model.AWSSecurityCredentials{
+		Code:        "Success",
+		Type:        "AWS-HMAC",
+		AccessKeyID: "AKIAIOSFODNN7EXAMPLE",
+		Expiration:  proc.ResolveEventTime().Add(-time.Hour),
+	}
+	resolver.UpdateAWSSecurityCredentials(proc.ProcessCacheEntry.Pid, proc)
+
+	creds := resolver.FetchAWSSecurityCredentials(proc, &proc.ProcessCacheEntry.Process)
+	assert.Empty(t, creds, "expired credentials should be pruned on fetch")
+}

--- a/pkg/security/secl/model/model_helpers_unix.go
+++ b/pkg/security/secl/model/model_helpers_unix.go
@@ -395,7 +395,7 @@ func (dfh *FakeFieldHandlers) ResolveHashes(_ EventType, _ *Process, _ *FileEven
 func (dfh *FakeFieldHandlers) ResolveK8SUserSessionContext(_ *Event, _ *K8SSessionContext) {}
 
 // ResolveAWSSecurityCredentials resolves and updates the AWS security credentials of the input process entry
-func (dfh *FakeFieldHandlers) ResolveAWSSecurityCredentials(_ *Event) []AWSSecurityCredentials {
+func (dfh *FakeFieldHandlers) ResolveAWSSecurityCredentials(_ *Event, _ *Process) []AWSSecurityCredentials {
 	return nil
 }
 
@@ -419,6 +419,6 @@ type ExtraFieldHandlers interface {
 	BaseExtraFieldHandlers
 	ResolveHashes(eventType EventType, process *Process, file *FileEvent) []string
 	ResolveK8SUserSessionContext(event *Event, evtCtx *K8SSessionContext)
-	ResolveAWSSecurityCredentials(event *Event) []AWSSecurityCredentials
+	ResolveAWSSecurityCredentials(event *Event, process *Process) []AWSSecurityCredentials
 	ResolveSyscallCtxArgs(ev *Event, e *SyscallContext)
 }

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -1014,7 +1014,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 			psSerializer.UserSession = newUserSessionContextSerializer(&ps.UserSession, e)
 		}
 
-		awsSecurityCredentials := e.FieldHandlers.ResolveAWSSecurityCredentials(e)
+		awsSecurityCredentials := e.FieldHandlers.ResolveAWSSecurityCredentials(e, ps)
 		if len(awsSecurityCredentials) > 0 {
 			for _, creds := range awsSecurityCredentials {
 				psSerializer.AWSSecurityCredentials = append(psSerializer.AWSSecurityCredentials, newAWSSecurityCredentialsSerializer(&creds))


### PR DESCRIPTION
### What does this PR do?

Fixes the serialization of AWS security credentials captured from IMDS traffic so that they are only reported on the process that actually made the IMDS request, instead of being duplicated onto every ancestor of that process.

Concretely:

- `FetchAWSSecurityCredentials` now takes the `*model.Process` being serialized and returns (and prunes) that process's own credentials, instead of always looking up the credentials of the event's triggering PID (`e.ProcessContext.Pid`).
- `ResolveAWSSecurityCredentials` (the `ExtraFieldHandlers` interface and its `EBPF`, `EBPFLess`, and `Fake` implementations) now forwards the process being serialized.
- The serializer (`newProcessSerializer`) passes the process it is currently serializing (`ps`) to the resolver, so each process and each ancestor reports only its own credentials.

### Motivation

AWS security credentials parsed from an IMDS v2 response are attributed, by design, only to the process cache entry of the process that made the request — `UpdateAWSSecurityCredentials` appends them to a single entry, and `Fork()` does not copy them to children.

However, the serializer mis-attributed them. `newProcessSerializer(ps, e)` is invoked once for the triggering process and once per ancestor, but the credential lookup ignored the `ps` argument and re-resolved from the event:

```go
awsSecurityCredentials := e.FieldHandlers.ResolveAWSSecurityCredentials(e)
```

That resolver was hard-keyed to `e.ProcessContext.Pid`, so every ancestor serialization re-fetched the **triggering** process's credentials and attached them to that ancestor. In production this surfaced as the same `aws_security_credentials` block (access key ID + metadata) appearing on the requesting process and on all of its ancestors (e.g. `entrypoint.sh`, `runc`, `containerd-shim`, `systemd`).

### Describe how you validated your changes

- Added a regression test `TestAWSSecurityCredentialsScopedToProcess` that builds a `parent -> child` lineage, has the child receive IMDS credentials, and asserts the credentials are returned for the child but **not** for the ancestor — even though the event's process context still points to the child (the exact condition that previously leaked them).
- Added `TestAWSSecurityCredentialsExpiration` to confirm expired credentials are still pruned on fetch, now per-process.
- `dda inv test --targets=./pkg/security/resolvers/process` — pass.
- `dda inv test --targets=./pkg/security/serializers` — pass.
- `dda inv test --targets=./pkg/security/secl/model` — pass.

### Additional Notes

- This is Linux-only: the credential serialization path lives in `serializers_linux.go` and the `ResolveAWSSecurityCredentials` field handler is declared in the Unix-only `ExtraFieldHandlers` interface. The `seclwin` model carries the `AWSSecurityCredentials` struct but no Windows serialization path uses it, so there is no Windows impact.
- Per-process expiry pruning is preserved: `FetchAWSSecurityCredentials` now prunes the slice on the process it is handed (still under the resolver lock) rather than on the triggering PID's entry.