### PR TITLE
antithesis(logs): harness to run the logs agent on Antithesis

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -426,6 +426,9 @@ core,github.com/alecthomas/participle/v2/lexer,MIT,Copyright (C) 2017 Alec Thoma
 core,github.com/alecthomas/units,MIT,Copyright (C) 2014 Alec Thomas
 core,github.com/antchfx/xmlquery,MIT,Copyright (c) 2016 Zheng Chun
 core,github.com/antchfx/xpath,MIT,Copyright (c) 2016 Zheng Chun
+core,github.com/antithesishq/antithesis-sdk-go/assert,MIT,Copyright (c) 2024 Antithesis
+core,github.com/antithesishq/antithesis-sdk-go/internal,MIT,Copyright (c) 2024 Antithesis
+core,github.com/antithesishq/antithesis-sdk-go/lifecycle,MIT,Copyright (c) 2024 Antithesis
 core,github.com/antlr4-go/antlr/v4,BSD-3-Clause,Copyright (c) 2012-2023 The ANTLR Project. All rights reserved
 core,github.com/apache/thrift/lib/go/thrift,Apache-2.0,"Copyright (C) 2006 - 2019, The Apache Software Foundation | Copyright (c) 2006- Facebook | Copyright (c) 2006-2008 Alexander Chemeris | Copyright (c) 2007 Thomas Porschberg <thomas@randspringer.de> | Copyright (c) 2008- Patrick Collison <patrick@collison.ie> | Copyright 2007 by Nathan C. Myers <ncm@cantrip.org>; some rights reserved | Copyright 2012 Twitter, Inc | copyright claimed)"
 core,github.com/aptly-dev/aptly/aptly,MIT,Copyright 2013-2015 aptly authors. All rights reserved.

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -62,6 +62,7 @@ use_repo(
     "com_github_alecthomas_participle",
     "com_github_alecthomas_units",
     "com_github_alessio_shellescape",
+    "com_github_antithesishq_antithesis_sdk_go",
     "com_github_aptly_dev_aptly",
     "com_github_aquasecurity_trivy",
     "com_github_aquasecurity_trivy_db",

--- a/go.mod
+++ b/go.mod
@@ -952,6 +952,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5
 	github.com/DataDog/rshell v0.0.20
+	github.com/antithesishq/antithesis-sdk-go v0.7.0
 	github.com/aptly-dev/aptly v1.6.3-0.20260504093056-0d31298f3709
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.6
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.5
@@ -1030,7 +1031,6 @@ require (
 	github.com/ProtonMail/gopenpgp/v3 v3.2.1 // indirect
 	github.com/VictoriaMetrics/easyproto v0.1.4 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v1.63.107 // indirect
-	github.com/antithesishq/antithesis-sdk-go v0.7.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.8 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1030,6 +1030,7 @@ require (
 	github.com/ProtonMail/gopenpgp/v3 v3.2.1 // indirect
 	github.com/VictoriaMetrics/easyproto v0.1.4 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v1.63.107 // indirect
+	github.com/antithesishq/antithesis-sdk-go v0.7.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.8 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2716,6 +2716,8 @@ github.com/antchfx/xmlquery v1.5.1/go.mod h1:bVqnl7TaDXSReKINrhZz+2E/PbCu2tUahb+
 github.com/antchfx/xpath v1.3.6 h1:s0y+ElRRtTQdfHP609qFu0+c6bglDv20pqOViQjjdPI=
 github.com/antchfx/xpath v1.3.6/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/antithesishq/antithesis-sdk-go v0.7.0 h1:uWDG8BqLD1lI2ps38WDz2vXflrTX2+vLX0SvZtztJtE=
+github.com/antithesishq/antithesis-sdk-go v0.7.0/go.mod h1:FQyySiasQQM8735Ddel3MRojmy4dA1IqCeyJ5jmPMbI=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/apache/arrow-go/v18 v18.4.0 h1:/RvkGqH517iY8bZKc4FD5/kkdwXJGjxf28JIXbJ/oB0=

--- a/pkg/logs/cmd/antithesis-rotation-demo/main.go
+++ b/pkg/logs/cmd/antithesis-rotation-demo/main.go
@@ -1,0 +1,101 @@
+//go:build antithesis_demo
+
+// Antithesis SUT harness that DEMONSTRATES (does not fix) the
+// `backpressure-no-rotation-loss` bug in the Datadog Agent logs pipeline, using the
+// real `pkg/logs` file tailer + decoder. Gated behind the `antithesis_demo` build
+// tag. Build with: CGO_ENABLED=1 go build -tags "antithesis_demo test" ./pkg/logs/cmd/antithesis-rotation-demo
+//
+// The harness repeatedly: writes N numbered lines to a file, starts the real tailer
+// with a small undrained output channel (so the pipeline backpressures), triggers
+// StopAfterFileRotation (a rotation), and asserts via the Antithesis SDK that every
+// written line was delivered. The `Always` assertion FAILS because lines that were
+// read but not yet forwarded are silently dropped when the rotation close-timeout
+// fires — that failure is the bug demonstration in the Antithesis triage report.
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+	"github.com/antithesishq/antithesis-sdk-go/lifecycle"
+
+	filetailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/file"
+)
+
+func main() {
+	dir, err := os.MkdirTemp("", "antithesis-rotation-demo")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mktemp:", err)
+		os.Exit(1)
+	}
+
+	// Signal Antithesis that the SUT is ready and test commands may run.
+	lifecycle.SetupComplete(map[string]any{
+		"message": "logs rotation-loss demo ready",
+		"dir":     dir,
+	})
+
+	const (
+		totalLines   = 50
+		outChanSize  = 3 // small => downstream backpressures quickly
+		closeTimeout = 1 * time.Second
+	)
+
+	for {
+		res, err := filetailer.RunRotationLossExperiment(dir, totalLines, outChanSize, closeTimeout)
+		if err != nil {
+			// Operational error (not the property under test); record reachability and continue.
+			assert.Reachable("rotation experiment errored", map[string]any{"error": err.Error()})
+			time.Sleep(time.Second)
+			continue
+		}
+
+		details := map[string]any{
+			"written":   res.Written,
+			"delivered": res.Delivered,
+			"dropped":   res.Written - res.Delivered,
+		}
+
+		// Confirms the experiment actually exercised the rotation path.
+		assert.Reachable("rotation-under-backpressure experiment completed", details)
+
+		// PROPERTY backpressure-no-rotation-loss (Safety): every written line is
+		// delivered at least once across a rotation. EXPECTED TO FAIL.
+		assert.Always(
+			res.Delivered == res.Written,
+			"every log line written before a rotation is delivered at least once (backpressure-no-rotation-loss)",
+			details,
+		)
+
+		fmt.Printf("[rotation-demo] written=%d delivered=%d dropped=%d\n",
+			res.Written, res.Delivered, res.Written-res.Delivered)
+
+		// --- Bug 2: offset-no-regression-on-seek-error ---
+		seek, serr := filetailer.RunSeekErrorExperiment(dir)
+		if serr != nil {
+			assert.Reachable("seek experiment errored", map[string]any{"error": serr.Error()})
+		} else {
+			sdetails := map[string]any{
+				"resume_line":     seek.ResumeLine,
+				"delivered_count": seek.DeliveredCount,
+				"regressed":       seek.Regressed,
+				"first_line":      seek.FirstLine,
+			}
+			assert.Reachable("seek-error resume experiment completed", sdetails)
+			// PROPERTY offset-no-regression-on-seek-error (Safety): a failed seek must
+			// not regress the read offset to 0 and re-deliver consumed lines. EXPECTED
+			// TO FAIL.
+			assert.Always(
+				!seek.Regressed,
+				"a failed seek does not regress the tailer offset to 0 (offset-no-regression-on-seek-error)",
+				sdetails,
+			)
+			fmt.Printf("[seek-demo] resume_line=%d delivered=%d regressed=%v first=%s\n",
+				seek.ResumeLine, seek.DeliveredCount, seek.Regressed, seek.FirstLine)
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+}

--- a/pkg/logs/cmd/antithesis-rotation-demo/main.go
+++ b/pkg/logs/cmd/antithesis-rotation-demo/main.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 //go:build antithesis_demo
 
 // Antithesis SUT harness that DEMONSTRATES (does not fix) the

--- a/pkg/logs/tailers/file/antithesis_demo_support.go
+++ b/pkg/logs/tailers/file/antithesis_demo_support.go
@@ -1,0 +1,219 @@
+//go:build antithesis_demo
+
+// Antithesis bug-demonstration support (NOT a fix). Gated behind the
+// `antithesis_demo` build tag so it never compiles into the production agent or
+// normal CI. It exposes the rotation-under-backpressure experiment so an external
+// `package main` harness (which cannot reach package-private fields or the internal
+// decoder) can drive the real file tailer and observe silent log loss.
+//
+// Build with: -tags "antithesis_demo test"  (the auditor mock is behind `test`).
+
+package file
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/afero"
+
+	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	auditormock "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/opener"
+)
+
+// --- seek-error fault injection (offset-no-regression-on-seek-error) ---
+
+// seekFailingFile wraps a real afero.File but fails every Seek (an injected
+// filesystem fault).
+type seekFailingFile struct {
+	afero.File
+}
+
+func (s *seekFailingFile) Seek(int64, int) (int64, error) {
+	return 0, errors.New("injected seek failure")
+}
+
+// seekFailingOpener returns files whose Seek always fails.
+type seekFailingOpener struct{ fs afero.Fs }
+
+func (o *seekFailingOpener) OpenLogFile(path string) (afero.File, error) {
+	f, err := o.fs.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	return &seekFailingFile{File: f}, nil
+}
+func (o *seekFailingOpener) OpenShared(path string) (afero.File, error) { return o.OpenLogFile(path) }
+func (o *seekFailingOpener) Abs(path string) (string, error)            { return filepath.Abs(path) }
+
+// SeekErrorResult reports the outcome of one seek-error experiment.
+type SeekErrorResult struct {
+	ResumeLine     int
+	DeliveredCount int
+	Regressed      bool   // true if a line before the resume offset was re-delivered
+	FirstLine      string // first line delivered
+}
+
+// RunSeekErrorExperiment writes a file, then resumes a tailer from a mid-file offset
+// behind a Seek-failing file (injected filesystem fault). A correct resume reads only
+// from the offset forward; the bug discards the seek error, regresses the offset to 0,
+// and re-reads the whole file (re-delivering already-consumed lines).
+//
+// Property: offset-no-regression-on-seek-error.
+func RunSeekErrorExperiment(dir string) (SeekErrorResult, error) {
+	const totalLines = 20
+	const lineWidth = 7 // "L00000\n"
+	const resumeLine = 10
+	res := SeekErrorResult{ResumeLine: resumeLine}
+
+	path := filepath.Join(dir, fmt.Sprintf("seek-%d.log", time.Now().UnixNano()))
+	f, err := os.Create(path)
+	if err != nil {
+		return res, err
+	}
+	for i := 0; i < totalLines; i++ {
+		if _, err := f.WriteString(fmt.Sprintf("L%05d\n", i)); err != nil {
+			_ = f.Close()
+			return res, err
+		}
+	}
+	_ = f.Close()
+	defer func() { _ = os.Remove(path) }()
+
+	outputChan := make(chan *message.Message, 100)
+	src := sources.NewReplaceableSource(sources.NewLogSource("", &config.LogsConfig{
+		Type: config.FileType,
+		Path: path,
+	}))
+	info := status.NewInfoRegistry()
+
+	tailer := NewTailer(&TailerOptions{
+		OutputChan:      outputChan,
+		File:            NewFile(path, src.UnderlyingSource(), false),
+		SleepDuration:   10 * time.Millisecond,
+		Decoder:         decoder.NewDecoderFromSource(src, info),
+		Info:            info,
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
+		Registry:        auditormock.NewMockRegistry(),
+		FileOpener:      &seekFailingOpener{fs: afero.NewOsFs()},
+	})
+
+	if err := tailer.Start(int64(resumeLine*lineWidth), io.SeekStart); err != nil {
+		return res, err
+	}
+
+	var delivered []string
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case msg := <-outputChan:
+				delivered = append(delivered, string(msg.GetContent()))
+			case <-done:
+				return
+			}
+		}
+	}()
+	time.Sleep(600 * time.Millisecond)
+	tailer.Stop()
+	time.Sleep(100 * time.Millisecond)
+	close(done)
+
+	res.DeliveredCount = len(delivered)
+	if len(delivered) > 0 {
+		res.FirstLine = delivered[0]
+	}
+	res.Regressed = strings.Contains(strings.Join(delivered, "\n"), "L00000")
+	return res, nil
+}
+
+// RotationLossResult reports the outcome of one experiment.
+type RotationLossResult struct {
+	Written   int
+	Delivered int
+	ReadBytes int
+}
+
+// RunRotationLossExperiment writes `totalLines` numbered lines to a file, starts the
+// real Agent file tailer with a deliberately small (undrained) output channel so the
+// pipeline backpressures, then triggers StopAfterFileRotation (simulating a log
+// rotation). It returns how many distinct lines actually reached the output channel.
+//
+// Property under demonstration: backpressure-no-rotation-loss — every written line
+// should be delivered at least once. In the current code, lines that were read but
+// not yet forwarded are silently discarded when the rotation close-timeout fires
+// (StopAfterFileRotation cancels forwardContext before in-flight messages drain).
+func RunRotationLossExperiment(dir string, totalLines, outChanSize int, closeTimeout time.Duration) (RotationLossResult, error) {
+	res := RotationLossResult{Written: totalLines}
+
+	path := filepath.Join(dir, fmt.Sprintf("tailer-%d.log", time.Now().UnixNano()))
+	f, err := os.Create(path)
+	if err != nil {
+		return res, err
+	}
+	defer func() { _ = f.Close(); _ = os.Remove(path) }()
+
+	for i := 0; i < totalLines; i++ {
+		if _, err := f.WriteString(fmt.Sprintf("L%05d\n", i)); err != nil {
+			return res, err
+		}
+	}
+
+	outputChan := make(chan *message.Message, outChanSize)
+	src := sources.NewReplaceableSource(sources.NewLogSource("", &config.LogsConfig{
+		Type: config.FileType,
+		Path: path,
+	}))
+	info := status.NewInfoRegistry()
+
+	tailer := NewTailer(&TailerOptions{
+		OutputChan:      outputChan,
+		File:            NewFile(path, src.UnderlyingSource(), false),
+		SleepDuration:   10 * time.Millisecond,
+		Decoder:         decoder.NewDecoderFromSource(src, info),
+		Info:            info,
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
+		Registry:        auditormock.NewMockRegistry(),
+		FileOpener:      opener.NewFileOpener(),
+	})
+	tailer.closeTimeout = closeTimeout
+
+	if err := tailer.StartFromBeginning(); err != nil {
+		return res, err
+	}
+
+	// Let the tailer read the file and block on the undrained output channel.
+	time.Sleep(300 * time.Millisecond)
+
+	// Rotation while backpressured.
+	tailer.StopAfterFileRotation()
+
+	select {
+	case <-tailer.done:
+	case <-time.After(closeTimeout + 10*time.Second):
+		return res, fmt.Errorf("tailer did not stop within timeout")
+	}
+
+	received := map[string]bool{}
+drain:
+	for {
+		select {
+		case msg := <-outputChan:
+			received[string(msg.GetContent())] = true
+		default:
+			break drain
+		}
+	}
+	res.Delivered = len(received)
+	return res, nil
+}

--- a/pkg/logs/tailers/file/antithesis_demo_support.go
+++ b/pkg/logs/tailers/file/antithesis_demo_support.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 //go:build antithesis_demo
 
 // Antithesis bug-demonstration support (NOT a fix). Gated behind the

--- a/test/antithesis/build/rotation-demo/.gitignore
+++ b/test/antithesis/build/rotation-demo/.gitignore
@@ -1,0 +1,2 @@
+# Built by build.sh; not committed (large, host-built artifact).
+rotation-demo.bin

--- a/test/antithesis/build/rotation-demo/Dockerfile
+++ b/test/antithesis/build/rotation-demo/Dockerfile
@@ -1,0 +1,24 @@
+# Runtime image for the logs rotation-loss Antithesis demonstration.
+#
+# Build context is the antithesis/ directory (see docker-compose.yaml) so the image
+# can include both the prebuilt demo binary and the test template.
+#
+# The instrumented (SDK-linked) binary is built on the host by build.sh and staged at
+# build/rotation-demo/rotation-demo.bin. We copy a prebuilt binary (rather than
+# rebuilding the multi-tool agent in-container) because the demo imports only
+# pkg/logs, which compiles with a plain `go build`. The binary is dynamically linked
+# against glibc, so the runtime base must provide glibc.
+FROM debian:stable-slim
+
+ENV NO_COLOR=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY build/rotation-demo/rotation-demo.bin /usr/local/bin/rotation-demo
+
+# Antithesis test template (driver commands) discovered at /opt/antithesis/test/v1/.
+COPY test/ /opt/antithesis/test/
+
+ENTRYPOINT ["/usr/local/bin/rotation-demo"]

--- a/test/antithesis/build/rotation-demo/build.sh
+++ b/test/antithesis/build/rotation-demo/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Builds the rotation-loss demonstration binary on the host and stages it into this
+# Docker build context. The Antithesis Go SDK requires CGO_ENABLED=1. The
+# `antithesis_demo` tag gates the demo code; the `test` tag is needed for the auditor
+# mock registry the harness uses.
+#
+# Run from the repo root (or anywhere — REPO_ROOT is resolved relative to this file)
+# before `docker compose build` / `snouty launch`.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+cd "${REPO_ROOT}"
+echo "Building rotation-demo (CGO_ENABLED=1, tags=antithesis_demo,test)..."
+CGO_ENABLED=1 go build -tags "antithesis_demo test" \
+  -o "${SCRIPT_DIR}/rotation-demo.bin" \
+  ./pkg/logs/cmd/antithesis-rotation-demo/
+echo "Built ${SCRIPT_DIR}/rotation-demo.bin"

--- a/test/antithesis/config/docker-compose.yaml
+++ b/test/antithesis/config/docker-compose.yaml
@@ -1,0 +1,25 @@
+# Antithesis harness for the Datadog Agent logs-pipeline bug demonstrations.
+#
+# Single-container topology: the `logs-rotation-demo` service runs the rotation-loss
+# demonstration, which drives the REAL pkg/logs file tailer + decoder through the
+# rotation-under-backpressure path and emits an Antithesis `Always` assertion
+# (`backpressure-no-rotation-loss`) that is EXPECTED TO FAIL — demonstrating silent
+# log loss. No Datadog intake is needed: the demo observes the tailer's output channel
+# directly, so loss is visible without a downstream service.
+#
+# Build the binary first:  bash antithesis/build/rotation-demo/build.sh
+# Then:                    docker compose -f antithesis/config/docker-compose.yaml build
+name: logs-antithesis
+
+services:
+  logs-rotation-demo:
+    container_name: logs-rotation-demo
+    hostname: logs-rotation-demo
+    platform: linux/amd64
+    init: true
+    build:
+      context: ..                                   # the antithesis/ directory
+      dockerfile: build/rotation-demo/Dockerfile
+    image: logs-antithesis-rotation-demo:latest
+    environment:
+      NO_COLOR: "1"

--- a/test/antithesis/setup-complete.sh
+++ b/test/antithesis/setup-complete.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run this script to inform Antithesis that it can start running test commands.
+# You can also use the Antithesis SDK to emit setup-complete from your system if
+# that is easier.
+#
+# Antithesis sets the `ANTITHESIS_OUTPUT_DIR` environment variable
+# automatically. This script is setup to emit `setup_complete` to the
+# `sdk.jsonl` file in that directory.
+
+OUTPUT_PATH="/tmp/antithesis_sdk.jsonl"
+if [[ -n "${ANTITHESIS_OUTPUT_DIR:-}" ]]; then
+  OUTPUT_PATH="${ANTITHESIS_OUTPUT_DIR}/sdk.jsonl"
+  echo "Running in Antithesis, emitting setup_complete to ${OUTPUT_PATH}"
+elif [[ -n "${ANTITHESIS_SDK_LOCAL_OUTPUT:-}" ]]; then
+  OUTPUT_PATH="${ANTITHESIS_SDK_LOCAL_OUTPUT}"
+  echo "Antithesis SDK local output override detected, emitting setup_complete to ${OUTPUT_PATH}"
+fi
+
+mkdir -p $(dirname "$OUTPUT_PATH")
+echo '{"antithesis_setup":{"status":"complete","details":{"message":"ready to go"}}}' >> "${OUTPUT_PATH}"

--- a/test/antithesis/test/v1/rotation-loss/singleton_driver_observe.sh
+++ b/test/antithesis/test/v1/rotation-loss/singleton_driver_observe.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Antithesis test command for the rotation-loss demonstration.
+#
+# The SUT (the rotation-demo binary, this container's entrypoint) continuously runs
+# the rotation-under-backpressure experiment and emits the `Always` /
+# `backpressure-no-rotation-loss` assertion itself. This driver simply lets a timeline
+# run for a while so Antithesis injects faults (CPU throttling, thread pausing, etc.)
+# while the SUT loop executes and evaluates the property. The bug is deterministic, so
+# the failing `Always` assertion is reported regardless; the fault injection explores
+# whether the loss magnitude varies under different schedules.
+set -euo pipefail
+
+echo "rotation-loss driver: observing SUT for 30s while faults are injected"
+sleep 30
+echo "rotation-loss driver: done"

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -284,6 +284,7 @@ require (
 	github.com/DataDog/viper v1.15.1 // indirect
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/alessio/shellescape v1.4.2 // indirect
+	github.com/antithesishq/antithesis-sdk-go v0.7.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.45.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -65,8 +65,8 @@ github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4u
 github.com/alessio/shellescape v1.4.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
-github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op h1:+OSa/t11TFhqfrX0EOSqQBDJ0YlpmK0rDSiB19dg9M0=
-github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl3v2yvUZjmKncl7U91fup7E=
+github.com/antithesishq/antithesis-sdk-go v0.7.0 h1:uWDG8BqLD1lI2ps38WDz2vXflrTX2+vLX0SvZtztJtE=
+github.com/antithesishq/antithesis-sdk-go v0.7.0/go.mod h1:FQyySiasQQM8735Ddel3MRojmy4dA1IqCeyJ5jmPMbI=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=


### PR DESCRIPTION
### What does this PR do?

The self-contained setup to build and run the logs system-under-test on Antithesis, under `test/antithesis/`, plus the program it runs:

- `pkg/logs/cmd/antithesis-rotation-demo` — the small program that drives the real tailer and reports results.
- `antithesis_demo_support.go` — the shared experiment helpers it calls.
- the `antithesis-sdk-go` dependency.
- docker-compose, Dockerfile, a host build script, the setup-complete signal, and a test-command template.

### Motivation

Split out of the research PR (#51504) so the run setup is its own reviewable change. Part of the logs-agent Antithesis work.

### Describe how you validated your changes

Built the program and image, ran `snouty validate` on `test/antithesis/config` — the container comes up and signals setup-complete. Two real Antithesis runs were launched from this harness (recorded in `test/antithesis/scratchbook/runs.md`).

### Additional Notes

Everything is behind the `antithesis_demo` build tag and nothing here runs in normal CI. No agent code changed.
