### PR TITLE
Rename @datadog/agent-all team to @datadog/agent-community-eng

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -303,7 +303,7 @@
 /docs/public/architecture/dogstatsd/                         @DataDog/agent-metric-pipelines
 /docs/public/guidelines/deprecated-components-documentation/ @DataDog/agent-runtimes
 
-# These files are owned by all teams, but assigning them to @DataDog/agent-all causes a lot of spam
+# These files are owned by all teams, but assigning them to @DataDog/agent-community-eng causes a lot of spam
 # Assigning them to a group that doesn't exist means nobody will receive notifications for them, but
 # that should be fine since rarely we make PRs that only change those files alone.
 /go.mod                                 # do not notify anyone

--- a/.github/workflows/assess-permissions.yml
+++ b/.github/workflows/assess-permissions.yml
@@ -5,13 +5,13 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: 'Which permissions to assess: "repo" or "agent-all"'
+        description: 'Which permissions to assess: "repo" or "agent-community-eng"'
         required: true
         default: 'repo'
         type: choice
         options:
           - repo
-          - agent-all
+          - agent-community-eng
   schedule:
     - cron: '0 4 2 * *' # At 4 UTC every 2nd day of the month (out of business hours for rate limiting)
     - cron: '0 6 2 * *' # Later for the simple permission display
@@ -51,7 +51,7 @@ jobs:
 
   assess_agent_all_permission:
     runs-on: ubuntu-latest
-    if: github.event.schedule == '0 4 2 * *' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'agent-all')
+    if: github.event.schedule == '0 4 2 * *' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'agent-community-eng')
     environment:
       name: main
     steps:
@@ -69,8 +69,8 @@ jobs:
         with:
           features: legacy-tasks legacy-github
 
-      - name: Assess agent-all Permissions
+      - name: Assess agent-community-eng Permissions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
-        run: dda inv -- -e github.check-permissions --name agent-all --check team
+        run: dda inv -- -e github.check-permissions --name agent-community-eng --check team

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -24,7 +24,7 @@ from tasks.libs.pipeline.notifications import DEFAULT_SLACK_CHANNEL, GITHUB_SLAC
 from tasks.libs.releasing.version import current_version
 from tasks.libs.types.types import PermissionCheck
 
-ALL_TEAMS = '@datadog/agent-all'
+ALL_TEAMS = '@datadog/agent-community-eng'
 
 
 def _update_windows_runner_version(new_version=None, repo="ci-platform-machine-images"):

--- a/tasks/libs/pipeline/github_jira_map.yaml
+++ b/tasks/libs/pipeline/github_jira_map.yaml
@@ -27,7 +27,7 @@
 '@datadog/serverless-azure-gcp': SVLS
 '@datadog/remote-config': RC
 '@datadog/fleet': FA
-'@datadog/agent-all': DEFAULT_JIRA_PROJECT
+'@datadog/agent-community-eng': DEFAULT_JIRA_PROJECT
 '@datadog/ebpf-platform': EBPF
 '@datadog/cloud-network-monitoring': CNM
 '@datadog/network-path': NETPATH

--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -11,7 +11,7 @@
   review:
     name: '#action-platform-reviews'
     id: 'C0AG2UCHUKZ'
-'@datadog/agent-all':
+'@datadog/agent-community-eng':
   notification:
     name: '#datadog-agent-pipelines'
     id: 'CR5TV8QBY'

--- a/tasks/unit_tests/pipeline_lib_tests.py
+++ b/tasks/unit_tests/pipeline_lib_tests.py
@@ -11,11 +11,11 @@ from tasks.libs.types.types import FailedJobReason, FailedJobType
 class TestLoadAndValidate(unittest.TestCase):
     def test_files_loaded_correctly(self):
         # Assert that a couple of expected entries are there, including one that uses DEFAULT_JIRA_PROJECT
-        self.assertEqual(notifications.GITHUB_JIRA_MAP['@datadog/agent-all'], "AGNTR")
+        self.assertEqual(notifications.GITHUB_JIRA_MAP['@datadog/agent-community-eng'], "AGNTR")
         self.assertEqual(notifications.GITHUB_JIRA_MAP['@datadog/agent-devx'], "ACIX")
 
         # Assert that a couple of expected entries are there, including one that uses DEFAULT_SLACK_PROJECT
-        self.assertEqual(notifications.GITHUB_SLACK_MAP['@datadog/agent-all'], "#datadog-agent-pipelines")
+        self.assertEqual(notifications.GITHUB_SLACK_MAP['@datadog/agent-community-eng'], "#datadog-agent-pipelines")
         self.assertEqual(notifications.GITHUB_SLACK_MAP['@datadog/agent-devx'], "#agent-devx-ops")
 
 

--- a/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
+++ b/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
@@ -275,7 +275,7 @@
 /docs/public/architecture/dogstatsd/                         @DataDog/agent-metric-pipelines
 /docs/public/guidelines/deprecated-components-documentation/ @DataDog/agent-runtimes
 
-# These files are owned by all teams, but assigning them to @DataDog/agent-all causes a lot of spam
+# These files are owned by all teams, but assigning them to @DataDog/agent-community-eng causes a lot of spam
 # Assigning them to a group that doesn't exist means nobody will receive notifications for them, but
 # that should be fine since rarely we make PRs that only change those files alone.
 /go.mod                                 # do not notify anyone


### PR DESCRIPTION
## Summary

Renames all references to the `@datadog/agent-all` GitHub team to `@datadog/agent-community-eng` as part of the team rename effort across the DataDog org.