### PR TITLE
[CNM-5386] socket__dns_filter performance improvement and config fixes

### DIFF
--- a/pkg/config/schema/system-probe_schema.yaml
+++ b/pkg/config/schema/system-probe_schema.yaml
@@ -623,7 +623,11 @@ properties:
         items:
           type: number
         visibility: public
-        description: A list of ports that should be monitored for DNS traffic.
+        description: |-
+          A list of ports that should be monitored for DNS traffic. At most 8
+          distinct ports are monitored. Configurations with more than 8 distinct
+          ports are truncated to the first 8 sorted ascending. Ports 80 and 443
+          are rejected to avoid capturing high-volume non-DNS traffic.
         example: |2-
 
             - 53

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	pkgconfighelper "github.com/DataDog/datadog-agent/pkg/config/helper"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
@@ -200,6 +201,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("system_probe_config.max_dns_stats", 20000)
 	cfg.BindEnvAndSetDefault("system_probe_config.dns_timeout_in_s", 15)
 	cfg.BindEnvAndSetDefault("network_config.dns_monitoring_ports", []int{53})
+	pkgconfighelper.ParseEnvSplitCommaAndSpace("network_config.dns_monitoring_ports", cfg)
 
 	cfg.BindEnvAndSetDefault("system_probe_config.enable_conntrack", true)
 	cfg.BindEnvAndSetDefault("system_probe_config.conntrack_max_state_size", 65536*2)

--- a/pkg/config/system-probe_template.yaml
+++ b/pkg/config/system-probe_template.yaml
@@ -66,8 +66,11 @@
 #   enabled: false
 
 #   # @param dns_monitoring_ports - list of integers - optional - default: [53]
-#   # @env DD_NETWORK_CONFIG_DNS_MONITORING_PORTS - space-separated list of integers - optional - default: "53"
-#   # A list of ports that should be monitored for DNS traffic.
+#   # @env DD_NETWORK_CONFIG_DNS_MONITORING_PORTS - comma or space-separated list of integers - optional - default: "53"
+#   # A list of ports that should be monitored for DNS traffic. At most 8
+#   # distinct ports are monitored. Configurations with more than 8 distinct
+#   # ports are truncated to the first 8 sorted ascending. Ports 80 and 443
+#   # are rejected to avoid capturing high-volume non-DNS traffic.
 #
 #   dns_monitoring_ports:
 #     - 53

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"time"
 
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -26,7 +28,26 @@ const (
 
 	defaultUDPTimeoutSeconds       = 30
 	defaultUDPStreamTimeoutSeconds = 120
+
+	// DNSPortsMax is the maximum number of distinct DNS ports the BPF filter
+	// can monitor. Matches DNS_PORTS_MAX in pkg/network/ebpf/c/prebuilt/dns.c.
+	// 8 covers every realistic configuration (53 + mDNS/LLMNR + the
+	// 1053/8053/9053/10053 unprivileged CoreDNS family + a spare slot).
+	DNSPortsMax = 8
+
+	dnsModuleName = "network_tracer__dns"
 )
+
+// dnsTelemetry holds counters surfaced via agent telemetry for the DNS
+// monitoring port-list sanitization performed in config.New().
+var dnsTelemetry = struct {
+	portsDropped telemetry.Counter
+}{
+	telemetryimpl.GetCompatComponent().NewCounter(
+		dnsModuleName, "ports_dropped", []string{"reason"},
+		"Times an entry was dropped from the configured DNS port list (reason=invalid|http|truncated)",
+	),
+}
 
 // Config stores all flags used by the network eBPF tracer
 type Config struct {
@@ -332,19 +353,47 @@ func New() *Config {
 
 	if err := structure.UnmarshalKey(cfg, sysconfig.FullKeyPath(netNS, "dns_monitoring_ports"), &c.DNSMonitoringPortList); err != nil {
 		log.Warnf("failed to parse dns_monitoring_ports: %v", err)
+		// Clear any partial state the unmarshaler may have written (e.g.
+		// a single-element [0] from a failed string-to-int conversion) so
+		// the len == 0 fallback below restores the documented default.
+		c.DNSMonitoringPortList = nil
 	}
 
 	if len(c.DNSMonitoringPortList) == 0 {
 		c.DNSMonitoringPortList = []int{53}
 	}
 
+	dnsPortsKey := sysconfig.FullKeyPath(netNS, "dns_monitoring_ports")
 	c.DNSMonitoringPortList = slices.DeleteFunc(c.DNSMonitoringPortList, func(port int) bool {
-		isHTTP := port == 80 || port == 443
-		if isHTTP {
-			log.Warnf("CNM detected and removed HTTP port %d from %s, which is unsupported due to the large volume of traffic it would capture", port, sysconfig.FullKeyPath(netNS, "dns_monitoring_ports"))
+		if port < 1 || port > 65535 {
+			log.Warnf("CNM detected and removed invalid port %d from %s (must be 1-65535)", port, dnsPortsKey)
+			dnsTelemetry.portsDropped.Inc("invalid")
+			return true
 		}
-		return isHTTP
+		if port == 80 || port == 443 {
+			log.Warnf("CNM detected and removed HTTP port %d from %s, which is unsupported due to the large volume of traffic it would capture", port, dnsPortsKey)
+			dnsTelemetry.portsDropped.Inc("http")
+			return true
+		}
+		return false
 	})
+	// Sort + dedup before applying the slot cap.
+	slices.Sort(c.DNSMonitoringPortList)
+	c.DNSMonitoringPortList = slices.Compact(c.DNSMonitoringPortList)
+	if len(c.DNSMonitoringPortList) > DNSPortsMax {
+		dropped := slices.Clone(c.DNSMonitoringPortList[DNSPortsMax:])
+		c.DNSMonitoringPortList = c.DNSMonitoringPortList[:DNSPortsMax]
+		log.Warnf(
+			"%s has %d distinct entries, exceeding the maximum of %d. "+
+				"Monitoring only %v (sorted ascending). Ports %v will NOT be monitored. "+
+				"File a feature request with Datadog if you need to monitor more than %d DNS ports.",
+			dnsPortsKey, len(c.DNSMonitoringPortList)+len(dropped), DNSPortsMax,
+			c.DNSMonitoringPortList, dropped, DNSPortsMax,
+		)
+		for range dropped {
+			dnsTelemetry.portsDropped.Inc("truncated")
+		}
+	}
 
 	if !c.EnableProcessEventMonitoring {
 		log.Info("network process event monitoring disabled")

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -588,7 +588,7 @@ func TestDNSMonitoringPorts(t *testing.T) {
 		mockSystemProbe := mock.NewSystemProbe(t)
 		mockSystemProbe.SetWithoutSource("network_config.dns_monitoring_ports", []int{8053, 5353})
 		cfg := New()
-		assert.Equal(t, []int{8053, 5353}, cfg.DNSMonitoringPortList)
+		assert.Equal(t, []int{5353, 8053}, cfg.DNSMonitoringPortList)
 	})
 
 	t.Run("via YAML - http ports should be removed", func(t *testing.T) {
@@ -598,5 +598,85 @@ func TestDNSMonitoringPorts(t *testing.T) {
 		mockSystemProbe.SetWithoutSource("network_config.dns_monitoring_ports", []int{53, 443, 5353, 80})
 		cfg := New()
 		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via YAML - invalid ports should be removed", func(t *testing.T) {
+		// Ports outside 1-65535 are soft-dropped at config load.
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.dns_monitoring_ports", []int{53, 0, -1, 65536, 99999, 5353})
+		cfg := New()
+		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via YAML - all-invalid list yields empty list (no fallback to 53)", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.dns_monitoring_ports", []int{0, 80, 443, 99999})
+		cfg := New()
+		assert.Empty(t, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via YAML - duplicates deduplicated", func(t *testing.T) {
+		// Repeat entries are deduplicated.
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.dns_monitoring_ports", []int{5353, 53, 53, 5353, 53})
+		cfg := New()
+		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via YAML - more than DNSPortsMax distinct ports truncates", func(t *testing.T) {
+		// 9 distinct ports exceeds DNSPortsMax = 8. After sort-ascending,
+		// the highest port (1008) is dropped.
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.dns_monitoring_ports", []int{53, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008})
+		cfg := New()
+		assert.Equal(t, []int{53, 1001, 1002, 1003, 1004, 1005, 1006, 1007}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via YAML - dedup applies before truncation cap", func(t *testing.T) {
+		// 33 raw entries but only 2 distinct (32×53 + 5353).
+		ports := make([]int, 0, 33)
+		for i := 0; i < 32; i++ {
+			ports = append(ports, 53)
+		}
+		ports = append(ports, 5353)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.dns_monitoring_ports", ports)
+		cfg := New()
+		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - space-separated", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "1 2 3 4 5 6 7 53")
+		cfg := New()
+		assert.Equal(t, []int{1, 2, 3, 4, 5, 6, 7, 53}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - comma-separated", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "53,5353,8053")
+		cfg := New()
+		assert.Equal(t, []int{53, 5353, 8053}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - mixed comma and space", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "53, 5353 8053")
+		cfg := New()
+		assert.Equal(t, []int{53, 5353, 8053}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - single port", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "5353")
+		cfg := New()
+		assert.Equal(t, []int{5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - invalid content falls back to default", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "not-a-port")
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
 	})
 }

--- a/pkg/network/dns/ebpf.go
+++ b/pkg/network/dns/ebpf.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const probeUID = "dns"
@@ -54,11 +55,27 @@ func newEBPFProgram(c *config.Config) (*ebpfProgram, error) {
 func (e *ebpfProgram) Init() error {
 	defer e.bytecode.Close()
 
-	var constantEditors []manager.ConstantEditor
+	// The port list has already been sanitized in config.New(): invalid and
+	// HTTP ports dropped, sorted, deduplicated, and truncated to DNSPortsMax.
+	// Trust the input here.
+	ports := e.cfg.DNSMonitoringPortList
+	log.Infof("DNS monitoring ports: %v", ports)
+
+	constantEditors := make([]manager.ConstantEditor, 0, config.DNSPortsMax+1)
 	if e.cfg.CollectDNSStats {
 		constantEditors = append(constantEditors, manager.ConstantEditor{
 			Name:  "dns_stats_enabled",
 			Value: uint64(1),
+		})
+	}
+	for i := 0; i < config.DNSPortsMax; i++ {
+		var val uint64
+		if i < len(ports) {
+			val = uint64(uint16(ports[i]))
+		}
+		constantEditors = append(constantEditors, manager.ConstantEditor{
+			Name:  fmt.Sprintf("dns_port_%d", i),
+			Value: val,
 		})
 	}
 
@@ -82,32 +99,6 @@ func (e *ebpfProgram) Init() error {
 	})
 	if err == nil {
 		ddebpf.AddNameMappings(e.Manager, "npm_dns")
-
-		dnsPortsMap, _, err := e.Manager.GetMap("dns_ports")
-		if err != nil {
-			return fmt.Errorf("getting dns_ports map: %w", err)
-		}
-
-		// clear out existing entries, because if the user changes the config
-		// to remove a port, the map will still be there with the old config
-		var key uint16
-		iter := dnsPortsMap.Iterate()
-		for iter.Next(&key, nil) {
-			if err := dnsPortsMap.Delete(&key); err != nil {
-				return fmt.Errorf("error deleting dns port %d: %w", key, err)
-			}
-		}
-		if err := iter.Err(); err != nil {
-			return fmt.Errorf("error iterating dns_ports map: %w", err)
-		}
-
-		val := uint8(1)
-		for _, p := range e.cfg.DNSMonitoringPortList {
-			port := uint16(p)
-			if err := dnsPortsMap.Put(&port, &val); err != nil {
-				return fmt.Errorf("error putting dns port %d: %w", p, err)
-			}
-		}
 	}
 	return err
 }

--- a/pkg/network/dns/snooper_test.go
+++ b/pkg/network/dns/snooper_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/filter"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil/testdns"
@@ -333,6 +334,126 @@ func TestDNSOverCustomPort(t *testing.T) {
 		}
 		return allStats[key] != nil
 	}, 3*time.Second, 10*time.Millisecond, "missing DNS data for key %+v", key)
+}
+
+// TestDNSExceedsMaxPortsTruncates verifies that configuring more distinct
+// DNS ports than the BPF program supports (DNS_PORTS_MAX = 8) truncates the
+// list at config-load time rather than failing.
+// Confirms that:
+//   - reverseDNS init still succeeds (no error)
+//   - traffic to one of the first 8 (sorted ascending) ports IS captured
+//   - traffic to a dropped port (slot index >= 8) is NOT captured
+func TestDNSExceedsMaxPortsTruncates(t *testing.T) {
+	// 9 distinct ports, sorted ascending: 53, 1001, 1002, ..., 1008.
+	// DNSPortsMax = 8, so port 1008 (slot index 8 after sort) is dropped.
+	mock.NewSystemProbe(t).SetWithoutSource(
+		"network_config.dns_monitoring_ports",
+		[]int{53, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008},
+	)
+	cfg := config.New()
+	cfg.CollectDNSStats = true
+	cfg.CollectLocalDNS = true
+	cfg.DNSTimeout = 1 * time.Second
+
+	rdns, err := NewReverseDNS(cfg, nil)
+	require.NoError(t, err, "exceeding DNSPortsMax should truncate, not error")
+	err = rdns.Start()
+	require.NoError(t, err)
+	reverseDNS := rdns.(*dnsMonitor)
+	defer reverseDNS.Close()
+	statKeeper := reverseDNS.statKeeper
+
+	// Traffic to port 1007 (the last kept slot, index 7) MUST be captured.
+	shutdownKept, portKept := newTestServerOnPort(t, localhost, "udp", 1007)
+	defer shutdownKept()
+	queryIPKept, queryPortKept, repsKept, err := testdns.SendDNSQueriesOnPort([]string{"golang.org"}, net.ParseIP(localhost), strconv.Itoa(int(portKept)), "udp")
+	require.NoError(t, err)
+	require.NotNil(t, repsKept[0])
+	keyKept := getKey(queryIPKept, queryPortKept, localhost, syscall.IPPROTO_UDP)
+	require.Eventually(t, func() bool {
+		return statKeeper.Snapshot()[keyKept] != nil
+	}, 3*time.Second, 10*time.Millisecond, "kept port 1007 (slot 7) should have been captured")
+
+	// Traffic to port 1008 (the dropped port) MUST NOT be captured.
+	shutdownDropped, portDropped := newTestServerOnPort(t, localhost, "udp", 1008)
+	defer shutdownDropped()
+	queryIPDropped, queryPortDropped, repsDropped, err := testdns.SendDNSQueriesOnPort([]string{"golang.org"}, net.ParseIP(localhost), strconv.Itoa(int(portDropped)), "udp")
+	require.NoError(t, err)
+	require.NotNil(t, repsDropped[0])
+	keyDropped := getKey(queryIPDropped, queryPortDropped, localhost, syscall.IPPROTO_UDP)
+	require.Never(t, func() bool {
+		return statKeeper.Snapshot()[keyDropped] != nil
+	}, 500*time.Millisecond, 10*time.Millisecond, "dropped port 1008 (beyond slot 7) should NOT be captured")
+}
+
+// TestDNSDeduplicatesPorts verifies that duplicate entries in
+// DNSMonitoringPortList do not consume LOAD_CONSTANT slots.
+func TestDNSDeduplicatesPorts(t *testing.T) {
+	// 33 raw entries, but only 2 distinct (53 ×32 + 5353 ×1). Must succeed
+	// because after deduplication only two slots are needed.
+	ports := make([]int, 0, 33)
+	for i := 0; i < 32; i++ {
+		ports = append(ports, 53)
+	}
+	ports = append(ports, 5353)
+	mock.NewSystemProbe(t).SetWithoutSource("network_config.dns_monitoring_ports", ports)
+	cfg := config.New()
+	cfg.CollectDNSStats = true
+	cfg.CollectLocalDNS = true
+	cfg.DNSTimeout = 1 * time.Second
+
+	rdns, err := NewReverseDNS(cfg, nil)
+	require.NoError(t, err, "33 raw entries with only 2 distinct ports should pass dedup-then-cap check")
+	err = rdns.Start()
+	require.NoError(t, err)
+	reverseDNS := rdns.(*dnsMonitor)
+	defer reverseDNS.Close()
+
+	// Send DNS to the duplicate-of-53 port and to the non-duplicate 5353
+	// to confirm both distinct ports actually made it into BPF slots.
+	statKeeper := reverseDNS.statKeeper
+	shutdown, port := newTestServerOnPort(t, localhost, "udp", 5353)
+	defer shutdown()
+	queryIP, queryPort, reps, err := testdns.SendDNSQueriesOnPort([]string{"golang.org"}, net.ParseIP(localhost), strconv.Itoa(int(port)), "udp")
+	require.NoError(t, err)
+	require.NotNil(t, reps[0])
+	key := getKey(queryIP, queryPort, localhost, syscall.IPPROTO_UDP)
+	require.Eventually(t, func() bool {
+		return statKeeper.Snapshot()[key] != nil
+	}, 3*time.Second, 10*time.Millisecond, "duplicate-laden config should still capture the distinct non-default port")
+}
+
+// TestDNSOverLastSlot verifies that a port assigned to the highest
+// LOAD_CONSTANT slot (slot index 7 with DNS_PORTS_MAX = 8) is matched by
+// the BPF scan.
+func TestDNSOverLastSlot(t *testing.T) {
+	cfg := testConfig()
+	cfg.CollectDNSStats = true
+	cfg.CollectLocalDNS = true
+	cfg.DNSTimeout = 1 * time.Second
+	// 8 distinct ports, sorted ascending. Port 10053 ends up at slot
+	// index 7 (the last slot). Sending DNS traffic to that port must be
+	// captured.
+	cfg.DNSMonitoringPortList = []int{53, 1053, 5053, 5353, 5355, 8053, 9053, 10053}
+
+	rdns, err := NewReverseDNS(cfg, nil)
+	require.NoError(t, err)
+	err = rdns.Start()
+	require.NoError(t, err)
+	reverseDNS := rdns.(*dnsMonitor)
+	defer reverseDNS.Close()
+
+	statKeeper := reverseDNS.statKeeper
+	shutdown, port := newTestServerOnPort(t, localhost, "udp", 10053)
+	defer shutdown()
+	queryIP, queryPort, reps, err := testdns.SendDNSQueriesOnPort([]string{"golang.org"}, net.ParseIP(localhost), strconv.Itoa(int(port)), "udp")
+	require.NoError(t, err)
+	require.NotNil(t, reps[0])
+
+	key := getKey(queryIP, queryPort, localhost, syscall.IPPROTO_UDP)
+	require.Eventually(t, func() bool {
+		return statKeeper.Snapshot()[key] != nil
+	}, 3*time.Second, 10*time.Millisecond, "missing DNS data for port 10053 (slot index 7) — likely a regression in the unrolled is_dns_port scan or ConstantEditor emission")
 }
 
 func newTestServer(t *testing.T, ip string, protocol string) (func(), uint16) {

--- a/pkg/network/ebpf/c/prebuilt/dns.c
+++ b/pkg/network/ebpf/c/prebuilt/dns.c
@@ -7,16 +7,38 @@
 #include "offsets.h"
 #include "ip.h"
 
+// DNS_PORTS_MAX is the maximum number of distinct DNS ports the filter can
+// be configured to monitor. Must stay in sync with dnsPortsMax in
+// pkg/network/dns/ebpf.go.
+#define DNS_PORTS_MAX 8
+
+// is_dns_port returns true iff port matches one of the configured DNS ports.
+// Configured ports are loaded at agent startup as a sorted ascending
+// sequence of LOAD_CONSTANT values dns_port_0..dns_port_{DNS_PORTS_MAX-1},
+// with a zero sentinel after the last real entry.
+static __always_inline bool is_dns_port(__u16 port) {
+#define DNS_PORT_SLOT(n)                              \
+    do {                                              \
+        __u64 p = 0;                                  \
+        LOAD_CONSTANT("dns_port_" #n, p);             \
+        if (p == 0 || (__u16)p > port) return false;  \
+        if (port == (__u16)p) return true;            \
+    } while (0)
+    DNS_PORT_SLOT(0);
+    DNS_PORT_SLOT(1);
+    DNS_PORT_SLOT(2);
+    DNS_PORT_SLOT(3);
+    DNS_PORT_SLOT(4);
+    DNS_PORT_SLOT(5);
+    DNS_PORT_SLOT(6);
+    DNS_PORT_SLOT(7);
+#undef DNS_PORT_SLOT
+    return false;
+}
+
 // This function is meant to be used as a BPF_PROG_TYPE_SOCKET_FILTER.
 // When attached to a RAW_SOCKET, this code filters out everything but DNS traffic.
 // All structs referenced here are kernel independent as they simply map protocol headers (Ethernet, IP and UDP).
-struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
-    __uint(max_entries, 32);
-    __type(key, __u16);
-    __type(value, __u8);
-} dns_ports SEC(".maps");
-
 SEC("socket/dns_filter")
 int socket__dns_filter(struct __sk_buff* skb) {
     skb_info_t skb_info;
@@ -26,14 +48,11 @@ int socket__dns_filter(struct __sk_buff* skb) {
         return 0;
     }
 
-    __u16 sport = tup.sport;
-    __u16 dport = tup.dport;
-
-    if (bpf_map_lookup_elem(&dns_ports, &sport) != NULL) {
+    if (is_dns_port(tup.sport)) {
         return -1;
     }
 
-    if (dns_stats_enabled() && bpf_map_lookup_elem(&dns_ports, &dport) != NULL) {
+    if (dns_stats_enabled() && is_dns_port(tup.dport)) {
         return -1;
     }
 


### PR DESCRIPTION

### What does this PR do?
Replaces the two per-packet bpf_map_lookup_elem helper calls in socket__dns_filter with an 8-slot unrolled scan of LOAD_CONSTANT slots rewritten at agent startup. Eliminates the helper-call dispatch on every skb that reaches the netns RX path (millions/sec on busy nodes), while preserving https://github.com/DataDog/datadog-agent/pull/43756's configurable-port behavior.

Default [53] case terminates in 2 register-immediate compares (slot 0 = 53, slot 1 = 0 sentinel exit). Worst case (8 ports, no match) is ~8 compares per port lookup, still well below the ~30-40 ns of a single helper call. Configs with >8 ports now fail at Init() with a clear warning rather than silently truncating.

DNS_PORTS_MAX = 8 sized for the realistic distribution (53 + mDNS + LLMNR + 1053/8053/9053/10053 + 2 spare ≥ 99.999% coverage); the hash map's max_entries of 32 was substantially larger than any plausible configuration.

config: fix DD_NETWORK_CONFIG_DNS_MONITORING_PORTS env-var parsing The agent's system-probe template documents the DNS port list as a "space-separated list of integers" env var, but no env-split transformer was registered for the binding. Without one, the nodetreemodel config library treated the entire env value as a single string, failed to unmarshal it as []int, and left
DNSMonitoringPortList in a partial-parse state (a single element [0]) but the partial-parse [0] then skipped the len == 0 fallback to [53], silently breaking DNS monitoring entirely.

Register ParseEnvSplitCommaAndSpace for network_config.dns_monitoring_ports.

On UnmarshalKey failure, reset DNSMonitoringPortList to nil so the len == 0 fallback to [53] fires correctly.

Add test coverage in pkg/network/config/config_test.go: five new TestDNSMonitoringPorts subtests covering the env-var paths.

Replace dns_ports hash map with LOAD_CONSTANT 8-slot scan to eliminates the BPF helper-call dispatch on every skb that reaches the netns RX path (~2.5M/sec on busy nodes) while preserving

Soft-drop invalid/excess DNS ports at config load. Replaces the previous hard-fail on out-of-range ports (port<1 || port>65535) with soft-drop matching the existing HTTP-port precedent: log a WARN, increment a telemetry counter, exclude the entry. Surfaces the unified counter network_tracer__dns.ports_dropped tagged by reason (invalid|http|truncated).

ebpf.go's Init() now trusts the pre-sanitized list and uses the exported config.DNSPortsMax constant. Adds config-layer subtests for invalid drop, all-invalid empty list, dedup, truncation at DNSPortsMax, and dedup-applies-before-cap. Updates the BPF-side TestDNS{ExceedsMax PortsTruncates,DeduplicatesPorts} tests to seed via mock SetWithoutSource
+ config.New() so the config-layer filter runs naturally; removes TestDNSInvalidPortFailsLoad which no longer applies (soft-drop, not hard-fail).

### Motivation
To reclaim socket__dns_filter performance regression introduced in https://github.com/DataDog/datadog-agent/pull/43756, while maintaining the same configurable multi-port DNS monitoring functionality added with that PR.

### Describe how you validated your changes
Unit tests, manual config and performance tests on AKS cluster.


### Additional Notes
