### PR TITLE
ksm: route .total aggregation through cluster-agent

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api/agent"
 	v1 "github.com/DataDog/datadog-agent/cmd/cluster-agent/api/v1"
+	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api/v1/ksmaggregation"
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api/v1/languagedetection"
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api/v2/series"
 	"github.com/DataDog/datadog-agent/comp/api/grpcserver/helpers"
@@ -73,6 +74,9 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 
 	// API V1 Language Detection APIs
 	languagedetection.InstallLanguageDetectionEndpoints(ctx, apiRouter, w, cfg)
+
+	// API V1 KSM Aggregation APIs
+	ksmaggregation.InstallKSMAggregationEndpoints(ctx, apiRouter, cfg)
 
 	// API V2 Series APIs
 	v2ApiRouter := http.NewServeMux()
@@ -200,6 +204,7 @@ func isExternalPath(path string) bool {
 	return strings.HasPrefix(path, "/api/v1/metadata/") && len(strings.Split(path, "/")) == 7 || // support for agents < 6.5.0
 		path == "/version" ||
 		path == "/api/v1/languagedetection" ||
+		path == "/api/v1/ksmaggregation" ||
 		path == "/api/v2/series" ||
 		strings.HasPrefix(path, "/api/v1/annotations/node/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/cf/apps") && len(strings.Split(path, "/")) == 5 ||

--- a/cmd/cluster-agent/api/v1/ksmaggregation/handler.go
+++ b/cmd/cluster-agent/api/v1/ksmaggregation/handler.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package ksmaggregation implements the cluster-agent side of KSM node-aggregate
+// collection. Node agents POST their per-node KSM partial to this endpoint; the
+// cluster-agent stores them and combines them into the authoritative .total series.
+package ksmaggregation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/ksmaggregation"
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const handlerName = "ksm-aggregation-handler"
+
+type handler struct {
+	store      *ksmaggregation.PartialStore
+	enabled    bool
+	partialTTL time.Duration
+}
+
+// InstallKSMAggregationEndpoints registers the /ksmaggregation endpoint on the
+// cluster-agent API router. The handler is wrapped with the leader-proxy so that
+// a partial received by a follower is forwarded to the leader, whose process-local
+// store is the one the cluster_aggregates_only check reads from.
+func InstallKSMAggregationEndpoints(_ context.Context, r *http.ServeMux, cfg config.Component) {
+	h := &handler{
+		store:      ksmaggregation.GetStore(),
+		enabled:    cfg.GetBool("kubernetes_state_core.cluster_aggregates.enabled"),
+		partialTTL: time.Duration(cfg.GetInt("kubernetes_state_core.cluster_aggregates.partial_ttl_seconds")) * time.Second,
+	}
+	leaderHandler := api.WithLeaderProxyHandler(handlerName, h.preHandler, h.leaderHandler)
+	r.HandleFunc("POST /ksmaggregation", api.WithTelemetryWrapper(handlerName, leaderHandler))
+}
+
+// preHandler runs on both leader and followers; it validates the request before
+// it is either forwarded to the leader or handled locally.
+func (h *handler) preHandler(w http.ResponseWriter, r *http.Request) bool {
+	if !h.enabled {
+		http.Error(w, "KSM cluster aggregates feature is disabled", http.StatusServiceUnavailable)
+		return false
+	}
+	if r.Body == nil {
+		http.Error(w, "request body is empty", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+// leaderHandler runs only on the leader: it stores the node partial and returns the verdict.
+func (h *handler) leaderHandler(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to read body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	var req clusteragent.KSMNodePartialRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, fmt.Sprintf("failed to unmarshal body: %v", err), http.StatusBadRequest)
+		return
+	}
+	if req.NodeName == "" {
+		http.Error(w, "node_name is required", http.StatusBadRequest)
+		return
+	}
+
+	partial := ksmaggregation.NodePartial{Metrics: make(map[string][]ksmaggregation.AggValue, len(req.Metrics))}
+	for metricName, vals := range req.Metrics {
+		aggVals := make([]ksmaggregation.AggValue, len(vals))
+		for i, v := range vals {
+			aggVals[i] = ksmaggregation.AggValue{Labels: v.Labels, Value: v.Value}
+		}
+		partial.Metrics[metricName] = aggVals
+	}
+	h.store.Upsert(req.NodeName, partial)
+
+	reporting := h.store.ReportingNodes(h.partialTTL)
+	// Only tell the node to suppress its local .total while the cluster_aggregates_only
+	// check is an active emitter. The active window is set by the emitter itself (a small
+	// multiple of its own interval, via MarkEmitterRun) — short and self-tracking, so a
+	// stalled emitter lets nodes resume local emission within ~one interval rather than
+	// going silent. Separate from the (longer) partial freshness TTL used for the combine.
+	emitterActive := ksmaggregation.EmitterActive()
+	log.Debugf("KSM aggregation: stored partial for %s; %d nodes reporting; emitter active=%t", req.NodeName, reporting, emitterActive)
+
+	reply := clusteragent.KSMNodePartialReply{
+		Accepted:      true,
+		SuppressLocal: emitterActive,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(reply); err != nil {
+		log.Warnf("KSM aggregation: failed to encode reply: %v", err)
+	}
+}

--- a/cmd/cluster-agent/api/v1/ksmaggregation/handler_nocompile.go
+++ b/cmd/cluster-agent/api/v1/ksmaggregation/handler_nocompile.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !kubeapiserver
+
+// Package ksmaggregation is a no-op stub on builds without kubeapiserver support;
+// the real KSM node-aggregate endpoint is only compiled with the kubeapiserver tag.
+package ksmaggregation
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+)
+
+// InstallKSMAggregationEndpoints is a no-op on builds without kubeapiserver support.
+func InstallKSMAggregationEndpoints(_ context.Context, _ *http.ServeMux, _ config.Component) {}

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -335,10 +335,14 @@ func start(log log.Component,
 		return err
 	}
 
-	// Setup the leader forwarder for autoscaling failover store, language detection and cluster checks
+	// Setup the leader forwarder for autoscaling failover store, language detection,
+	// cluster checks, and KSM cluster-aggregate partials. The KSM aggregation endpoint
+	// forwards follower-received partials to the leader, so it needs the forwarder even
+	// when none of the other features are enabled.
 	if config.GetBool("cluster_checks.enabled") ||
 		(config.GetBool("language_detection.enabled") && config.GetBool("language_detection.reporting.enabled")) ||
-		config.GetBool("autoscaling.failover.enabled") {
+		config.GetBool("autoscaling.failover.enabled") ||
+		config.GetBool("kubernetes_state_core.cluster_aggregates.enabled") {
 		apidca.NewGlobalLeaderForwarder(
 			config.GetInt("cluster_agent.cmd_port"),
 			config.GetInt("cluster_agent.max_leader_connections"),

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
@@ -228,6 +228,10 @@ func (f *FakeDCAClient) PostLanguageMetadata(_ context.Context, _ *pbgo.ParentLa
 	panic("implement me")
 }
 
+func (f *FakeDCAClient) PostKSMAggregates(_ context.Context, _ clusteragent.KSMNodePartialRequest) (clusteragent.KSMNodePartialReply, error) {
+	return clusteragent.KSMNodePartialReply{}, nil
+}
+
 func (f *FakeDCAClient) SupportsNamespaceMetadataCollection() bool {
 	panic("implement me")
 }

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -139,6 +139,10 @@ func (f *FakeDCAClient) PostLanguageMetadata(_ context.Context, _ *pbgo.ParentLa
 	panic("implement me")
 }
 
+func (f *FakeDCAClient) PostKSMAggregates(_ context.Context, _ clusteragent.KSMNodePartialRequest) (clusteragent.KSMNodePartialReply, error) {
+	return clusteragent.KSMNodePartialReply{}, nil
+}
+
 func (f *FakeDCAClient) SupportsNamespaceMetadataCollection() bool {
 	return f.LocalVersion.Major >= 7 && f.LocalVersion.Minor >= 55
 }

--- a/comp/languagedetection/client/impl/client_test.go
+++ b/comp/languagedetection/client/impl/client_test.go
@@ -29,6 +29,7 @@ import (
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -39,6 +40,10 @@ type MockDCAClient struct {
 func (m *MockDCAClient) PostLanguageMetadata(_ context.Context, request *pbgo.ParentLanguageAnnotationRequest) error {
 	go func() { m.respCh <- request }()
 	return nil
+}
+
+func (m *MockDCAClient) PostKSMAggregates(_ context.Context, _ clusteragent.KSMNodePartialRequest) (clusteragent.KSMNodePartialReply, error) {
+	return clusteragent.KSMNodePartialReply{}, nil
 }
 
 func newTestClient(t *testing.T) (*languageDetectionClientImpl, chan *pbgo.ParentLanguageAnnotationRequest) {

--- a/pkg/clusteragent/ksmaggregation/BUILD.bazel
+++ b/pkg/clusteragent/ksmaggregation/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "ksmaggregation",
+    srcs = ["store.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/clusteragent/ksmaggregation",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/kubestatemetrics/store"],
+)
+
+go_test(
+    name = "ksmaggregation_test",
+    srcs = ["store_test.go"],
+    embed = [":ksmaggregation"],
+    gotags = ["test"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/pkg/clusteragent/ksmaggregation/store.go
+++ b/pkg/clusteragent/ksmaggregation/store.go
@@ -1,0 +1,173 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package ksmaggregation implements the cluster-agent side of the KSM
+// node-aggregate collection: it stores per-node partials pushed by node agents
+// and combines them into metric families for the cluster_aggregates_only check.
+package ksmaggregation
+
+import (
+	"sync"
+	"time"
+
+	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
+)
+
+// AggValue is a single aggregated value with its source labels, pushed by a node agent.
+type AggValue struct {
+	Labels map[string]string `json:"labels"`
+	Value  float64           `json:"value"`
+}
+
+// NodePartial is the set of pre-aggregated source metrics sent by one node agent.
+// Keys are the 4 cluster-aggregate source metric names; values are per-label sums
+// across all pods local to that node.
+type NodePartial struct {
+	// Metrics maps source metric name → label+value pairs (one per distinct label set)
+	Metrics map[string][]AggValue `json:"metrics"`
+}
+
+type nodeEntry struct {
+	partial   NodePartial
+	updatedAt time.Time
+}
+
+// PartialStore is a thread-safe, node-keyed store of KSM partial aggregates.
+type PartialStore struct {
+	mu      sync.RWMutex
+	entries map[string]*nodeEntry
+}
+
+var (
+	globalStore     *PartialStore
+	globalStoreOnce sync.Once
+
+	emitterMu          sync.RWMutex
+	emitterActiveUntil time.Time // the cluster_aggregates_only check is considered an active emitter until this time
+)
+
+// GetStore returns the singleton PartialStore for this process.
+func GetStore() *PartialStore {
+	globalStoreOnce.Do(func() {
+		globalStore = &PartialStore{
+			entries: make(map[string]*nodeEntry),
+		}
+	})
+	return globalStore
+}
+
+// MarkEmitterRun records that the cluster_aggregates_only check just emitted the combined
+// .total family, and that it should be considered an active emitter for activeWindow.
+// Called once per check run on the leader; activeWindow is derived from the check's own
+// collection interval (a small multiple), so a stalled emitter expires within ~one interval
+// — no separate TTL config needed.
+func MarkEmitterRun(activeWindow time.Duration) {
+	emitterMu.Lock()
+	defer emitterMu.Unlock()
+	emitterActiveUntil = time.Now().Add(activeWindow)
+}
+
+// EmitterActive reports whether the cluster_aggregates_only check has emitted recently
+// enough (within the window set by the last MarkEmitterRun). The endpoint only tells node
+// agents to suppress their local .total when this is true, so nodes never go silent before
+// an authoritative emitter exists, and resume local emission within one interval if it stalls.
+func EmitterActive() bool {
+	emitterMu.RLock()
+	defer emitterMu.RUnlock()
+	return !emitterActiveUntil.IsZero() && time.Now().Before(emitterActiveUntil)
+}
+
+// Upsert stores or replaces the partial for the given node.
+func (s *PartialStore) Upsert(nodeName string, partial NodePartial) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[nodeName] = &nodeEntry{
+		partial:   partial,
+		updatedAt: time.Now(),
+	}
+}
+
+// ReportingNodes returns the count of nodes that have pushed a partial within ttl.
+func (s *PartialStore) ReportingNodes(ttl time.Duration) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cutoff := time.Now().Add(-ttl)
+	n := 0
+	for _, e := range s.entries {
+		if e.updatedAt.After(cutoff) {
+			n++
+		}
+	}
+	return n
+}
+
+// GetCombined sums all live node partials (within ttl) into metric families
+// shaped for processMetrics in cluster_aggregates_only mode. Entries older than
+// ttl are pruned from the store (a node that stopped reporting — e.g. removed by
+// autoscaling — would otherwise keep its partial in memory forever). This is the
+// store's cleanup path; it runs once per cluster_aggregates_only check interval.
+func (s *PartialStore) GetCombined(ttl time.Duration) map[string][]ksmstore.DDMetricsFam {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cutoff := time.Now().Add(-ttl)
+
+	// combined maps metric_name → (label_key → summed value)
+	// label_key is a canonical string of the labels map for dedup/sum
+	type labelKey = [5]string // ns, container, owner_kind, owner_name, resource
+	type combinedMap = map[labelKey]*combinedEntry
+	perMetric := make(map[string]combinedMap)
+
+	for node, e := range s.entries {
+		if !e.updatedAt.After(cutoff) {
+			delete(s.entries, node) // prune stale node; safe to delete during range in Go
+			continue
+		}
+		for metricName, values := range e.partial.Metrics {
+			cm, ok := perMetric[metricName]
+			if !ok {
+				cm = make(combinedMap)
+				perMetric[metricName] = cm
+			}
+			for _, v := range values {
+				k := labelKey{
+					v.Labels["namespace"],
+					v.Labels["container"],
+					v.Labels["owner_kind"],
+					v.Labels["owner_name"],
+					v.Labels["resource"],
+				}
+				if existing, found := cm[k]; found {
+					existing.value += v.Value
+				} else {
+					cm[k] = &combinedEntry{labels: v.Labels, value: v.Value}
+				}
+			}
+		}
+	}
+
+	result := make(map[string][]ksmstore.DDMetricsFam, len(perMetric))
+	for metricName, cm := range perMetric {
+		ddMetrics := make([]ksmstore.DDMetric, 0, len(cm))
+		for _, ce := range cm {
+			ddMetrics = append(ddMetrics, ksmstore.DDMetric{
+				Labels: ce.labels,
+				Val:    ce.value,
+			})
+		}
+		result[metricName] = []ksmstore.DDMetricsFam{{
+			Name:        metricName,
+			ListMetrics: ddMetrics,
+		}}
+	}
+	return result
+}
+
+type combinedEntry struct {
+	labels map[string]string
+	value  float64
+}

--- a/pkg/clusteragent/ksmaggregation/store_test.go
+++ b/pkg/clusteragent/ksmaggregation/store_test.go
@@ -1,0 +1,98 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package ksmaggregation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func cpuPartial(value float64) NodePartial {
+	return NodePartial{Metrics: map[string][]AggValue{
+		"kube_pod_container_resource_with_owner_tag_requests": {
+			{Labels: map[string]string{
+				"namespace": "kube-system", "container": "kindnet-cni",
+				"owner_kind": "DaemonSet", "owner_name": "kindnet", "resource": "cpu",
+			}, Value: value},
+		},
+	}}
+}
+
+func newStore() *PartialStore { return &PartialStore{entries: make(map[string]*nodeEntry)} }
+
+func TestGetCombined_SumsAcrossNodes(t *testing.T) {
+	s := newStore()
+	s.Upsert("node-a", cpuPartial(0.1))
+	s.Upsert("node-b", cpuPartial(0.1))
+	s.Upsert("node-c", cpuPartial(0.1))
+
+	combined := s.GetCombined(time.Minute)
+	fam := combined["kube_pod_container_resource_with_owner_tag_requests"]
+	if assert.Len(t, fam, 1) && assert.Len(t, fam[0].ListMetrics, 1) {
+		assert.InDelta(t, 0.3, fam[0].ListMetrics[0].Val, 1e-9, "three nodes × 0.1 should sum to 0.3")
+	}
+	assert.Equal(t, 3, s.ReportingNodes(time.Minute))
+}
+
+func TestUpsert_LastValueWinsPerNode(t *testing.T) {
+	s := newStore()
+	s.Upsert("node-a", cpuPartial(0.1))
+	s.Upsert("node-a", cpuPartial(0.5)) // retry / new value replaces, not adds
+	s.Upsert("node-b", cpuPartial(0.1))
+
+	fam := s.GetCombined(time.Minute)["kube_pod_container_resource_with_owner_tag_requests"]
+	assert.InDelta(t, 0.6, fam[0].ListMetrics[0].Val, 1e-9, "node-a replaced (0.5) + node-b (0.1)")
+}
+
+func TestGetCombined_ExcludesStalePartials(t *testing.T) {
+	s := newStore()
+	s.Upsert("node-a", cpuPartial(0.1))
+	// force node-a's entry to be stale
+	s.entries["node-a"].updatedAt = time.Now().Add(-10 * time.Minute)
+	s.Upsert("node-b", cpuPartial(0.1))
+
+	fam := s.GetCombined(time.Minute)["kube_pod_container_resource_with_owner_tag_requests"]
+	assert.InDelta(t, 0.1, fam[0].ListMetrics[0].Val, 1e-9, "stale node-a excluded; only node-b counts")
+	assert.Equal(t, 1, s.ReportingNodes(time.Minute))
+	// stale node-a must be pruned from the store, not just skipped (no memory leak on churn)
+	s.mu.RLock()
+	_, stillThere := s.entries["node-a"]
+	s.mu.RUnlock()
+	assert.False(t, stillThere, "stale node-a should be deleted from the store by GetCombined")
+}
+
+func TestGetCombined_KeepsDistinctSeriesSeparate(t *testing.T) {
+	s := newStore()
+	s.Upsert("node-a", NodePartial{Metrics: map[string][]AggValue{
+		"kube_pod_container_resource_with_owner_tag_requests": {
+			{Labels: map[string]string{"namespace": "ns1", "container": "c", "owner_kind": "Deployment", "owner_name": "a", "resource": "cpu"}, Value: 0.2},
+			{Labels: map[string]string{"namespace": "ns2", "container": "c", "owner_kind": "Deployment", "owner_name": "b", "resource": "cpu"}, Value: 0.3},
+		},
+	}})
+	fam := s.GetCombined(time.Minute)["kube_pod_container_resource_with_owner_tag_requests"]
+	assert.Len(t, fam[0].ListMetrics, 2, "different owners must remain distinct series")
+}
+
+func TestEmitterHeartbeat(t *testing.T) {
+	// fresh process: no emit recorded yet
+	emitterMu.Lock()
+	emitterActiveUntil = time.Time{}
+	emitterMu.Unlock()
+	assert.False(t, EmitterActive(), "no emit yet → inactive")
+
+	MarkEmitterRun(time.Minute) // active window = 1 min
+	assert.True(t, EmitterActive(), "just emitted → active within window")
+
+	// simulate the active window having elapsed (emitter stalled)
+	emitterMu.Lock()
+	emitterActiveUntil = time.Now().Add(-time.Second)
+	emitterMu.Unlock()
+	assert.False(t, EmitterActive(), "window elapsed → inactive")
+}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -36,6 +36,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/ksmaggregation"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
@@ -45,6 +46,7 @@ import (
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	kubestatemetrics "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	hostnameUtil "github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
@@ -125,6 +127,17 @@ const (
 	// enabled on the node agents, because unassigned pods cannot be collected
 	// from node agents.
 	clusterUnassignedPodCollection podCollectionMode = "cluster_unassigned"
+
+	// clusterAggregatesOnlyPodCollection is the authoritative source for the
+	// cluster-aggregate `.total` metric family. It does NOT collect pods from the
+	// API server or the kubelet: it reads the per-node partials that node agents
+	// (in node_kubelet / cluster_unassigned mode) push to the cluster-agent via
+	// POST /api/v1/ksmaggregation, combines them (see runClusterAgentAggregatesOnly
+	// reading ksmaggregation.GetStore().GetCombined), and emits only the `.total`
+	// aggregators (no per-pod metrics). Meant to run on the cluster-agent leader;
+	// node agents suppress these aggregators so the cluster sees exactly one
+	// authoritative source.
+	clusterAggregatesOnlyPodCollection podCollectionMode = "cluster_aggregates_only"
 )
 
 // KSMConfig contains the check config parameters
@@ -230,7 +243,10 @@ type KSMConfig struct {
 	UseAPIServerCache bool `yaml:"use_apiserver_cache"`
 
 	// PodCollectionMode defines how pods are collected.
-	// Accepted values are: "default", "node_kubelet", and "cluster_unassigned".
+	// Accepted values are: "default", "node_kubelet", "cluster_unassigned", and
+	// "cluster_aggregates_only" (cluster-agent: emit the combined .total family from
+	// node-pushed partials — requires node agents in node_kubelet to push, see
+	// kubernetes_state_core.cluster_aggregates.enabled).
 	PodCollectionMode podCollectionMode `yaml:"pod_collection_mode"`
 }
 
@@ -257,6 +273,10 @@ type KSMCheck struct {
 	rolloutTracker             *customresources.RolloutTracker
 	customResourceDiscoverer   *ksmDiscovery.CRDiscoverer
 	namespaceTagsErrorLogLimit *log.Limit
+
+	// ksmAggSuppressLocal caches the last suppress_local verdict from the cluster-agent
+	// (updated each interval by the node-side partial push in node_kubelet mode).
+	ksmAggSuppressLocal bool
 }
 
 // JoinsConfigWithoutLabelsMapping contains the config parameters for label joins
@@ -325,7 +345,11 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 	// Prepare labels mapper
 	k.mergeLabelsMapper(defaultLabelsMapper())
 
-	if k.instance.usesCustomResourceMetrics() && k.instance.PodCollectionMode != nodeKubeletPodCollection {
+	// Start custom resource discovery if not running in a mode that only
+	// consumes pods from workloadmeta (no API discovery needed in those modes).
+	if k.instance.usesCustomResourceMetrics() &&
+		k.instance.PodCollectionMode != nodeKubeletPodCollection &&
+		k.instance.PodCollectionMode != clusterAggregatesOnlyPodCollection {
 		k.customResourceDiscoverer = customresources.StartDiscovery()
 	}
 
@@ -365,14 +389,26 @@ func (k *KSMCheck) buildStores() error {
 
 	k.configurePodCollection(builder, k.instance.Collectors)
 
+	// cluster_aggregates_only emits .total from the pushed node-partial store
+	// (see runClusterAgentAggregatesOnly), not from any KSM metric store. Skip all
+	// store / API-server / custom-resource discovery: it is unnecessary and would
+	// nil-deref the (intentionally nil) API client in discoverCustomResources.
+	// Note: configurePodCollection above may have reset the mode to default on a
+	// node-agent/CLC runner, so this check runs after it.
+	if k.instance.PodCollectionMode == clusterAggregatesOnlyPodCollection {
+		k.setupLabelsAndAnnotationsAsTagsFunc()
+		k.allStores = nil
+		return nil
+	}
+
 	var collectors []string
 	var apiServerClient *apiserver.APIClient
 	var resources []*v1.APIResourceList
 
 	switch k.instance.PodCollectionMode {
 	case nodeKubeletPodCollection:
-		// In this case we don't need to set up anything related to the API
-		// server.
+		// In this workloadmeta-backed mode we don't need to set up anything
+		// related to the API server.
 		collectors = []string{"pods"}
 		k.setupLabelsAndAnnotationsAsTagsFunc()
 	case defaultPodCollection, clusterUnassignedPodCollection:
@@ -726,6 +762,14 @@ func (k *KSMCheck) Run() error {
 
 	defer sender.Commit()
 
+	// cluster_aggregates_only: no pod store; reads combined node partials from the
+	// global PartialStore populated by the /api/v1/ksmaggregation endpoint.
+	if k.instance.PodCollectionMode == clusterAggregatesOnlyPodCollection {
+		k.runClusterAgentAggregatesOnly(sender)
+		k.sendTelemetry(sender)
+		return nil
+	}
+
 	labelJoiner := newLabelJoiner(k.instance.labelJoins)
 	for _, stores := range k.allStores {
 		for _, store := range stores {
@@ -739,6 +783,32 @@ func (k *KSMCheck) Run() error {
 				labelJoiner.insertFamilies(metrics)
 			}
 		}
+	}
+
+	// node_kubelet / cluster_unassigned: gather the cluster-aggregate source families
+	// from ALL stores into a single per-node partial and push it once per run. The 4
+	// source families live in the extended-pods store, so gathering across stores
+	// avoids a later non-source store overwriting a valid partial with an empty one.
+	// The returned suppress_local verdict (cached in k.ksmAggSuppressLocal) is read by
+	// processMetrics below to decide whether to drop the local .total emission.
+	isNodeSide := k.instance.PodCollectionMode == nodeKubeletPodCollection ||
+		k.instance.PodCollectionMode == clusterUnassignedPodCollection
+	if isNodeSide && k.agentConfig.GetBool("kubernetes_state_core.cluster_aggregates.enabled") {
+		combined := make(map[string][]ksmstore.DDMetricsFam)
+		for _, stores := range k.allStores {
+			for _, store := range stores {
+				ms, ok := store.(*ksmstore.MetricsStore)
+				if !ok {
+					continue
+				}
+				for name, fams := range ms.Push(ksmstore.GetAllFamilies, ksmstore.GetAllMetrics) {
+					if isClusterAggregateSourceMetric(name) {
+						combined[name] = append(combined[name], fams...)
+					}
+				}
+			}
+		}
+		k.buildAndPushPartial(combined)
 	}
 
 	currentTime := time.Now()
@@ -772,8 +842,31 @@ func (k *KSMCheck) Cancel() {
 
 // processMetrics attaches tags and forwards metrics to the aggregator
 func (k *KSMCheck) processMetrics(sender sender.Sender, metrics map[string][]ksmstore.DDMetricsFam, labelJoiner *labelJoiner, now time.Time) {
+	// In node_kubelet / cluster_unassigned mode the per-node partial is built and pushed
+	// once per check run (across all stores) in Run(); here we only apply the resulting
+	// suppress_local verdict so the node drops its local .total when the cluster-agent is
+	// the authoritative emitter. While the feature is off or the push failed, the verdict
+	// is false and the node keeps emitting .total locally (pre-fix under-report, never silent).
+	isNodeSide := k.instance.PodCollectionMode == nodeKubeletPodCollection ||
+		k.instance.PodCollectionMode == clusterUnassignedPodCollection
+	featureEnabled := k.agentConfig.GetBool("kubernetes_state_core.cluster_aggregates.enabled")
+	suppressClusterAggregates := isNodeSide && featureEnabled && k.ksmAggSuppressLocal
+
+	// In cluster_aggregates_only mode, the check emits only the .total family
+	// (via aggregator flush). Skip per-pod transformer/mapper dispatch to avoid
+	// double-emission of per-pod metrics already produced by node-agents.
+	aggregatesOnly := k.instance.PodCollectionMode == clusterAggregatesOnlyPodCollection
 	for _, metricsList := range metrics {
 		for _, metricFamily := range metricsList {
+			if suppressClusterAggregates && isClusterAggregateSourceMetric(metricFamily.Name) {
+				continue
+			}
+			// In cluster_aggregates_only mode accumulate only the four .total source
+			// metrics. Accumulating other aggregators (e.g. pod.count) would double-count
+			// with node-agents which already emit those metrics individually.
+			if aggregatesOnly && !isClusterAggregateSourceMetric(metricFamily.Name) {
+				continue
+			}
 			// First check for aggregator, because the check use _labels metrics to aggregate values.
 			if aggregator, found := k.metricAggregators[metricFamily.Name]; found {
 				for _, m := range metricFamily.ListMetrics {
@@ -781,6 +874,9 @@ func (k *KSMCheck) processMetrics(sender sender.Sender, metrics map[string][]ksm
 				}
 				// Some metrics can be aggregated and consumed as-is or by a transformer.
 				// So, let’s continue the processing.
+			}
+			if aggregatesOnly {
+				continue
 			}
 			if transform, found := k.metricTransformers[metricFamily.Name]; found {
 				lMapperOverride := labelsMapperOverride(metricFamily.Name)
@@ -1102,10 +1198,140 @@ func (k *KSMCheck) configurePodCollection(builder *kubestatemetrics.Builder, col
 		} else {
 			builder.WithUnassignedPodsCollection()
 		}
+	case clusterAggregatesOnlyPodCollection:
+		// Only the cluster-agent maintains the workloadmeta kubeapiserver pod store this
+		// mode reads from. CLC runners are node-agent processes (catalog-core, no
+		// kubeapiserver collector), so reject them too — otherwise the check would read
+		// an empty store and emit empty .total. Fall back to default (full apiserver
+		// watch), which still produces a correct single-source .total wherever it lands.
+		// cluster_aggregates_only reads from the in-memory node partial store (populated
+		// by POST /api/v1/ksmaggregation) — no pod informer or WLM pod store needed.
+		// Reject node-agents and CLC runners: they lack the partial store and should
+		// fall back to default (single full-pod check → correct single-source .total).
+		if k.isRunningOnNodeAgent || k.isCLCRunner {
+			log.Warnf("cluster_aggregates_only is only supported on the cluster agent, falling back to the default mode")
+			k.instance.PodCollectionMode = defaultPodCollection
+		}
+		// No builder wiring needed: Run() handles this mode directly via runClusterAgentAggregatesOnly.
 	default:
 		log.Warnf("invalid pod collection mode %q, falling back to the default mode", k.instance.PodCollectionMode)
 		k.instance.PodCollectionMode = defaultPodCollection
 	}
+}
+
+// aggLabelKeys are the labels the cluster-agent groups .total by; the node pre-aggregates
+// to exactly these so the pushed partial is owner-shaped, not per-pod. Other source labels
+// (pod, uid, node, unit) are dropped — the cluster-agent re-keys on these and ignores them.
+var aggLabelKeys = []string{"namespace", "container", "owner_kind", "owner_name", "resource"}
+
+// buildAndPushPartial folds the cluster-aggregate source families (already gathered
+// across all stores by Run()) into a single per-node partial and synchronously pushes
+// it to the cluster-agent once per check run. Per source family, per-pod/per-container
+// metrics are summed by {namespace, container, owner_kind, owner_name, resource} so the
+// payload is proportional to distinct owners on the node, not to pod count, and carries
+// no per-pod identity. The reply's suppress_local verdict is cached in k.ksmAggSuppressLocal
+// for the current interval. If the push fails (DCA unreachable, feature disabled),
+// suppress_local stays false so the node continues emitting .total locally (pre-fix
+// under-report, never silent). The metrics argument is expected to contain only source
+// families; the guard below is defensive.
+func (k *KSMCheck) buildAndPushPartial(metrics map[string][]ksmstore.DDMetricsFam) {
+	type aggKey [5]string // namespace, container, owner_kind, owner_name, resource
+	partial := make(map[string][]clusteragent.KSMAggValue)
+	for metricName, famList := range metrics {
+		if !isClusterAggregateSourceMetric(metricName) {
+			continue
+		}
+		sums := make(map[aggKey]float64)
+		for _, fam := range famList {
+			for _, m := range fam.ListMetrics {
+				k := aggKey{m.Labels["namespace"], m.Labels["container"],
+					m.Labels["owner_kind"], m.Labels["owner_name"], m.Labels["resource"]}
+				sums[k] += m.Val
+			}
+		}
+		vals := make([]clusteragent.KSMAggValue, 0, len(sums))
+		for kk, v := range sums {
+			labels := make(map[string]string, len(aggLabelKeys))
+			for i, key := range aggLabelKeys {
+				labels[key] = kk[i]
+			}
+			vals = append(vals, clusteragent.KSMAggValue{Labels: labels, Value: v})
+		}
+		if len(vals) > 0 {
+			partial[metricName] = vals
+		}
+	}
+
+	nodeName, err := hostnameUtil.Get(context.Background())
+	if err != nil {
+		// Clear the cached verdict so a prior suppress=true doesn't keep dropping local
+		// .total while we're no longer pushing (same as the DCA-client error paths below).
+		k.ksmAggSuppressLocal = false
+		log.Debugf("KSM aggregation: could not get hostname: %v — skipping partial push", err)
+		return
+	}
+
+	dcaClient, err := clusteragent.GetClusterAgentClient()
+	if err != nil {
+		log.Debugf("KSM aggregation: could not get DCA client: %v — falling back to local .total", err)
+		k.ksmAggSuppressLocal = false
+		return
+	}
+
+	// The cluster_unassigned instance (CLC runner) may run on a host that also runs a
+	// node_kubelet agent; if both pushed under the same node name, the store's per-node
+	// Upsert would let one overwrite the other (dropping that node's resources from the
+	// combined .total). Give the unassigned contribution a reserved key — node names are
+	// DNS-1123 and cannot contain ':' — so the two never collide.
+	sourceKey := nodeName
+	if k.instance.PodCollectionMode == clusterUnassignedPodCollection {
+		sourceKey = "cluster-unassigned:" + nodeName
+	}
+
+	req := clusteragent.KSMNodePartialRequest{
+		NodeName: sourceKey,
+		Metrics:  partial,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	reply, err := dcaClient.PostKSMAggregates(ctx, req)
+	if err != nil {
+		log.Debugf("KSM aggregation: partial push failed: %v — falling back to local .total", err)
+		k.ksmAggSuppressLocal = false
+		return
+	}
+	k.ksmAggSuppressLocal = reply.SuppressLocal
+}
+
+// runClusterAgentAggregatesOnly feeds combined node partials from the global
+// PartialStore into the KSM aggregators and flushes the .total family. It is
+// called from Run() instead of the normal allStores loop when the mode is
+// cluster_aggregates_only, so that no WLM pod watch is needed.
+func (k *KSMCheck) runClusterAgentAggregatesOnly(sender sender.Sender) {
+	partialTTL := time.Duration(k.agentConfig.GetInt("kubernetes_state_core.cluster_aggregates.partial_ttl_seconds")) * time.Second
+	combined := ksmaggregation.GetStore().GetCombined(partialTTL)
+	if len(combined) == 0 {
+		log.Debugf("KSM cluster_aggregates_only: no node partials yet — skipping .total flush")
+		return
+	}
+	lj := newLabelJoiner(k.instance.labelJoins)
+	k.processMetrics(sender, combined, lj, time.Now())
+	// flush only the 4 cluster-aggregate aggregators; the map key is the KSM source metric name
+	for ksmName, agg := range k.metricAggregators {
+		if isClusterAggregateSourceMetric(ksmName) {
+			agg.flush(sender, k, lj)
+		}
+	}
+	// Heartbeat: now that we've actually emitted the combined .total, the endpoint may
+	// tell node agents to suppress their local emission. The active window is derived from
+	// this check's own interval (3×, floored), so if the emitter stalls nodes resume local
+	// emission within ~one interval — no separate TTL config needed.
+	activeWindow := 3 * k.Interval()
+	if activeWindow <= 0 {
+		activeWindow = 90 * time.Second
+	}
+	ksmaggregation.MarkEmitterRun(activeWindow)
 }
 
 // processTelemetry accumulates the telemetry metric values, it can be called multiple times
@@ -1190,6 +1416,7 @@ func KubeStateMetricsFactoryWithParam(labelsMapper map[string]string, labelJoins
 func newKSMCheck(base core.CheckBase, instance *KSMConfig, tagger tagger.Component, wmeta workloadmeta.Component) *KSMCheck {
 	k := &KSMCheck{
 		CheckBase:                  base,
+		agentConfig:                pkgconfigsetup.Datadog(),
 		instance:                   instance,
 		telemetry:                  newTelemetryCache(),
 		tagger:                     tagger,

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -444,3 +444,20 @@ func defaultMetricAggregators() map[string]metricAggregator {
 		),
 	}
 }
+
+// clusterAggregateSourceMetrics are the 4 KSM source metric families whose
+// aggregated outputs (.total) are emitted by the cluster-agent exclusively in
+// node_kubelet/cluster_aggregates_only topology.
+var clusterAggregateSourceMetrics = map[string]struct{}{
+	"kube_pod_container_resource_with_owner_tag_requests":      {},
+	"kube_pod_container_resource_with_owner_tag_limits":        {},
+	"kube_pod_init_container_resource_with_owner_tag_requests": {},
+	"kube_pod_init_container_resource_with_owner_tag_limits":   {},
+}
+
+// isClusterAggregateSourceMetric returns true when name is one of the 4 source
+// families whose .total aggregation must come from a single authoritative source.
+func isClusterAggregateSourceMetric(name string) bool {
+	_, ok := clusterAggregateSourceMetrics[name]
+	return ok
+}

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -323,6 +323,18 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("cluster_agent.max_leader_connections", 100)
 	config.BindEnvAndSetDefault("cluster_agent.client_reconnect_period_seconds", 1200)
 	config.BindEnvAndSetDefault("cluster_agent.collect_kubernetes_tags", false)
+	// Enables KSM cluster-aggregate (.total) collection via node-agent → cluster-agent
+	// push: node agents push per-node partials and suppress local .total emission; the
+	// cluster-agent combines them into the authoritative series. MUST be set cluster-wide
+	// — on BOTH the node agents (so they push + suppress) and the cluster-agent (so it
+	// serves the endpoint + runs the emitter) — alongside pod_collection_mode:
+	// cluster_aggregates_only on the cluster-agent. If set only on the cluster-agent, no
+	// node partials are pushed and no .total is produced.
+	config.BindEnvAndSetDefault("kubernetes_state_core.cluster_aggregates.enabled", false)
+	// How long a pushed per-node partial is considered fresh by the cluster-agent. Must
+	// exceed the node KSM collection interval; partials older than this are dropped from
+	// the combined .total. Default 300s tolerates intervals well above the 15s default.
+	config.BindEnvAndSetDefault("kubernetes_state_core.cluster_aggregates.partial_ttl_seconds", 300)
 	config.BindEnvAndSetDefault("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude", []string{
 		`^kubectl\.kubernetes\.io\/last-applied-configuration$`,
 		`^ad\.datadoghq\.com\/([[:alnum:]]+\.)?(checks|check_names|init_configs|instances)$`,

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -43,6 +43,7 @@ const (
 	// RealIPHeader refers to the cluster level check runner ip passed in the request headers
 	RealIPHeader          = "X-Real-Ip"
 	languageDetectionPath = "api/v1/languagedetection"
+	ksmAggregationPath    = "api/v1/ksmaggregation"
 )
 
 var globalClusterAgentClient *DCAClient
@@ -89,7 +90,27 @@ type DCAClientInterface interface {
 	GetKubernetesClusterID() (string, error)
 
 	PostLanguageMetadata(ctx context.Context, data *pbgo.ParentLanguageAnnotationRequest) error
+	PostKSMAggregates(ctx context.Context, req KSMNodePartialRequest) (KSMNodePartialReply, error)
 	SupportsNamespaceMetadataCollection() bool
+}
+
+// KSMAggValue is a single label+value pair from a node's pre-aggregated KSM source metric.
+type KSMAggValue struct {
+	Labels map[string]string `json:"labels"`
+	Value  float64           `json:"value"`
+}
+
+// KSMNodePartialRequest is sent by a node agent to the cluster-agent to contribute its
+// share of the cluster-wide KSM .total aggregates.
+type KSMNodePartialRequest struct {
+	NodeName string                   `json:"node_name"`
+	Metrics  map[string][]KSMAggValue `json:"metrics"` // source_metric_name → []label+val
+}
+
+// KSMNodePartialReply is the cluster-agent's response to a KSMNodePartialRequest.
+type KSMNodePartialReply struct {
+	Accepted      bool `json:"accepted"`
+	SuppressLocal bool `json:"suppress_local"` // true → node should drop its local .total
 }
 
 // DCAClient is required to query the API of Datadog cluster agent
@@ -495,6 +516,24 @@ func (c *DCAClient) PostLanguageMetadata(ctx context.Context, data *pbgo.ParentL
 	// query https://host:port/api/v1/languagedetection without expecting a response
 	_, err = c.doQuery(ctx, languageDetectionPath, "POST", bytes.NewBuffer(queryBody), false, false)
 	return err
+}
+
+// PostKSMAggregates sends a node-local KSM partial to the cluster-agent and returns the
+// verdict (whether this node should suppress its local .total emission).
+func (c *DCAClient) PostKSMAggregates(ctx context.Context, req KSMNodePartialRequest) (KSMNodePartialReply, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return KSMNodePartialReply{}, err
+	}
+	respBody, err := c.doQuery(ctx, ksmAggregationPath, "POST", bytes.NewBuffer(body), true, false)
+	if err != nil {
+		return KSMNodePartialReply{}, err
+	}
+	var reply KSMNodePartialReply
+	if err := json.Unmarshal(respBody, &reply); err != nil {
+		return KSMNodePartialReply{}, err
+	}
+	return reply, nil
 }
 
 // SupportsNamespaceMetadataCollection returns true only if the cluster agent supports collecting namespace metadata


### PR DESCRIPTION
Multi-node node_kubelet mode silently under-reports the kubernetes_state.{container,initcontainer}.<res>_{requested,limit}.total family. Every node-agent emits the same metric with the same reduced tag set ([namespace, container, owner_name, owner_kind] — no host/pod/ node), so the backend's same-timestamp same-tags collision rule keeps only one value. V

### Split architecture:
  - Node-agents in node_kubelet: keep per-pod emission for local scheduled pods, suppress .total accumulation.
  - CLC runner in cluster_unassigned: keep per-pod emission for unscheduled pods only, suppress .total accumulation.
  - Cluster-agent in a new pod_collection_mode: sole authoritative source for the .total family, sourced from workloadmeta's kubeapiserver collector (no new apiserver watch).


### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
