### PR TITLE
test(usm): skip 10mb response body case on Windows

### DIFF
--- a/pkg/network/usm/monitor_common_test.go
+++ b/pkg/network/usm/monitor_common_test.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	nethttp "net/http"
 	"net/url"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -323,6 +324,9 @@ func runHTTPMonitorIntegrationWithResponseBodyTest(t *testing.T, params commonTe
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if runtime.GOOS == "windows" && tt.requestBodySize == 10*mb {
+				t.Skip("flaky on Windows")
+			}
 			serverAddr := fmt.Sprintf("127.0.0.1:%d", params.serverPort)
 
 			monitor := params.setupMonitor(t)


### PR DESCRIPTION
### What does this PR do?
The 10mb body subtest of TestHTTPMonitorIntegrationWithResponseBodyCommon is flaky on Windows. Skip it there while keeping coverage on Linux.

### Motivation
the test's failure breaks ci, temporary until will get fixed [#incident-55370]

### Describe how you validated your changes
check on ci run
### Additional Notes
<img width="1439" height="352" alt="image" src="https://github.com/user-attachments/assets/9c3e7809-7a9a-4dda-8058-4d5599c6aa34" />
