### PR TITLE
Fix EMR false-positive error spans

### DIFF
--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -177,29 +177,28 @@ func resolveEmrClusterName(s *common.Setup, jobFlowID string) string {
 	emrResponseRaw, err := common.ExecuteCommandWithTimeout(s, "aws", "emr", "describe-cluster", "--cluster-id", jobFlowID)
 	if err != nil {
 		log.Warnf("error describing emr cluster, using cluster id as name: %v", err)
-		setEmrClusterNameSpanTags(span, jobFlowID, "job flow ID", "AWS EMR describe-cluster failed; using job flow ID as cluster name", err.Error())
+		setEmrClusterNameSpanTags(span, "job_flow_id", "AWS EMR describe-cluster failed; using job flow ID as cluster name", err.Error())
 		err = nil
 		return jobFlowID
 	}
 	var response emrResponse
 	if err = json.Unmarshal(emrResponseRaw, &response); err != nil {
 		log.Warnf("error unmarshalling AWS EMR response,  using cluster id as name: %v", err)
-		setEmrClusterNameSpanTags(span, jobFlowID, "job flow ID", "Could not parse AWS EMR describe-cluster response; using job flow ID as cluster name", err.Error())
+		setEmrClusterNameSpanTags(span, "job_flow_id", "Could not parse AWS EMR describe-cluster response; using job flow ID as cluster name", err.Error())
 		err = nil
 		return jobFlowID
 	}
 	clusterName := response.Cluster.Name
 	if clusterName == "" {
 		log.Warn("clusterName is empty, using cluster id as name")
-		setEmrClusterNameSpanTags(span, jobFlowID, "job flow ID", "AWS EMR describe-cluster returned an empty cluster name; using job flow ID as cluster name", "")
+		setEmrClusterNameSpanTags(span, "job_flow_id", "AWS EMR describe-cluster returned an empty cluster name; using job flow ID as cluster name", "")
 		return jobFlowID
 	}
-	setEmrClusterNameSpanTags(span, clusterName, "AWS EMR describe-cluster", "Resolved cluster name from AWS EMR describe-cluster", "")
+	setEmrClusterNameSpanTags(span, "aws_emr_describe_cluster", "Resolved cluster name from AWS EMR describe-cluster", "")
 	return clusterName
 }
 
-func setEmrClusterNameSpanTags(span *telemetry.Span, clusterName, source, reason, errorMessage string) {
-	span.SetTag("cluster_name", clusterName)
+func setEmrClusterNameSpanTags(span *telemetry.Span, source, reason, errorMessage string) {
 	span.SetTag("cluster_name_source", source)
 	span.SetTag("cluster_name_resolution_reason", reason)
 	if errorMessage != "" {

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -177,31 +177,34 @@ func resolveEmrClusterName(s *common.Setup, jobFlowID string) string {
 	emrResponseRaw, err := common.ExecuteCommandWithTimeout(s, "aws", "emr", "describe-cluster", "--cluster-id", jobFlowID)
 	if err != nil {
 		log.Warnf("error describing emr cluster, using cluster id as name: %v", err)
-		setEmrClusterNameSpanTags(span, jobFlowID, "job_flow_id", "aws_emr_describe_cluster_failed")
+		setEmrClusterNameSpanTags(span, jobFlowID, "job flow ID", "AWS EMR describe-cluster failed; using job flow ID as cluster name", err.Error())
 		err = nil
 		return jobFlowID
 	}
 	var response emrResponse
 	if err = json.Unmarshal(emrResponseRaw, &response); err != nil {
 		log.Warnf("error unmarshalling AWS EMR response,  using cluster id as name: %v", err)
-		setEmrClusterNameSpanTags(span, jobFlowID, "job_flow_id", "aws_emr_describe_cluster_response_unmarshal_failed")
+		setEmrClusterNameSpanTags(span, jobFlowID, "job flow ID", "Could not parse AWS EMR describe-cluster response; using job flow ID as cluster name", err.Error())
 		err = nil
 		return jobFlowID
 	}
 	clusterName := response.Cluster.Name
 	if clusterName == "" {
 		log.Warn("clusterName is empty, using cluster id as name")
-		setEmrClusterNameSpanTags(span, jobFlowID, "job_flow_id", "aws_emr_describe_cluster_returned_empty_name")
+		setEmrClusterNameSpanTags(span, jobFlowID, "job flow ID", "AWS EMR describe-cluster returned an empty cluster name; using job flow ID as cluster name", "")
 		return jobFlowID
 	}
-	setEmrClusterNameSpanTags(span, clusterName, "aws_emr_describe_cluster", "resolved_from_aws_emr_describe_cluster")
+	setEmrClusterNameSpanTags(span, clusterName, "AWS EMR describe-cluster", "Resolved cluster name from AWS EMR describe-cluster", "")
 	return clusterName
 }
 
-func setEmrClusterNameSpanTags(span *telemetry.Span, clusterName, source, reason string) {
+func setEmrClusterNameSpanTags(span *telemetry.Span, clusterName, source, reason, errorMessage string) {
 	span.SetTag("cluster_name", clusterName)
 	span.SetTag("cluster_name_source", source)
 	span.SetTag("cluster_name_resolution_reason", reason)
+	if errorMessage != "" {
+		span.SetTag("cluster_name_resolution_error_message", errorMessage)
+	}
 }
 
 func enableEmrLogs(s *common.Setup) {

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -177,21 +177,31 @@ func resolveEmrClusterName(s *common.Setup, jobFlowID string) string {
 	emrResponseRaw, err := common.ExecuteCommandWithTimeout(s, "aws", "emr", "describe-cluster", "--cluster-id", jobFlowID)
 	if err != nil {
 		log.Warnf("error describing emr cluster, using cluster id as name: %v", err)
+		setEmrClusterNameSpanTags(span, jobFlowID, "job_flow_id", "aws_emr_describe_cluster_failed")
 		err = nil
 		return jobFlowID
 	}
 	var response emrResponse
 	if err = json.Unmarshal(emrResponseRaw, &response); err != nil {
 		log.Warnf("error unmarshalling AWS EMR response,  using cluster id as name: %v", err)
+		setEmrClusterNameSpanTags(span, jobFlowID, "job_flow_id", "aws_emr_describe_cluster_response_unmarshal_failed")
 		err = nil
 		return jobFlowID
 	}
 	clusterName := response.Cluster.Name
 	if clusterName == "" {
 		log.Warn("clusterName is empty, using cluster id as name")
+		setEmrClusterNameSpanTags(span, jobFlowID, "job_flow_id", "aws_emr_describe_cluster_returned_empty_name")
 		return jobFlowID
 	}
+	setEmrClusterNameSpanTags(span, clusterName, "aws_emr_describe_cluster", "resolved_from_aws_emr_describe_cluster")
 	return clusterName
+}
+
+func setEmrClusterNameSpanTags(span *telemetry.Span, clusterName, source, reason string) {
+	span.SetTag("cluster_name", clusterName)
+	span.SetTag("cluster_name_source", source)
+	span.SetTag("cluster_name_resolution_reason", reason)
 }
 
 func enableEmrLogs(s *common.Setup) {

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -177,11 +177,13 @@ func resolveEmrClusterName(s *common.Setup, jobFlowID string) string {
 	emrResponseRaw, err := common.ExecuteCommandWithTimeout(s, "aws", "emr", "describe-cluster", "--cluster-id", jobFlowID)
 	if err != nil {
 		log.Warnf("error describing emr cluster, using cluster id as name: %v", err)
+		err = nil
 		return jobFlowID
 	}
 	var response emrResponse
 	if err = json.Unmarshal(emrResponseRaw, &response); err != nil {
 		log.Warnf("error unmarshalling AWS EMR response,  using cluster id as name: %v", err)
+		err = nil
 		return jobFlowID
 	}
 	clusterName := response.Cluster.Name


### PR DESCRIPTION
<!-- dd-meta {"pullId":"92107e7c-2229-4598-b001-6cd32d627100","source":"chat","resourceId":"8126152f-3a46-4077-8ba8-90d55c1daefe","workflowId":"f0e42f5b-ec0a-4e00-a5b9-993b4bbf2c6d","codeChangeId":"f0e42f5b-ec0a-4e00-a5b9-993b4bbf2c6d","sourceType":"assistant"} -->
### What does this PR do?

Fixes false-positive error spans in the `resolveEmrClusterName` function by setting `err = nil` before returning in graceful fallback paths. When the AWS EMR API call fails due to missing IAM credentials (common on worker nodes), the function gracefully falls back to using the jobFlowID as the cluster name, but the span was still being marked as an error.

### Motivation

The `resolveEmrClusterName` function was generating ~150K false-positive error spans per week because `span.Finish(err)` was called with a non-nil error value even though the error was handled gracefully. Exit codes 254/255 from the AWS EMR API are expected on EMR worker nodes without proper IAM credentials, and the function correctly falls back to an alternative behavior. These should not be tracked as errors.

### Describe how you validated your changes

This fix follows the same pattern applied in PR #51491 for similar false-positive spans in dpkg/rpm/aa-status code paths. The changes are minimal and surgical:
- Add `err = nil` after the `ExecuteCommandWithTimeout` error check (line 180)
- Add `err = nil` after the `json.Unmarshal` error check (line 187)

This ensures the deferred `span.Finish(nil)` call marks the span as successful in these graceful fallback scenarios.

### Additional Notes

- Related to PR #51491 which addressed similar false positives in other code paths
- Expected impact: elimination of ~150K false-positive error spans per week
