### PR TITLE
chore(renovate): enable full merge confidence badges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended", ":enablePreCommit", "schedule:nonOfficeHours"],
+    "extends": ["config:recommended", "mergeConfidence:all-badges", ":enablePreCommit", "schedule:nonOfficeHours"],
     "constraints": {
       "go": "1.25.10"
     },


### PR DESCRIPTION
### What does this PR do?

Explicitly enables Renovate's full Merge Confidence badge preset so supported Mend-hosted Renovate PRs include all badge columns, including Adoption.

### Motivation

Mend-hosted Renovate adds all Merge Confidence badges by default, but config:recommended applies the narrower age-confidence badge preset. Reapplying mergeConfidence:all-badges after config:recommended restores the expected Adoption badge for supported datasources.

It should add the adoption badge when supported.
For instance: https://developer.mend.io/api/mc/badges/adoption/go/github.com%2fopen-policy-agent%2fopa/v1.16.2?slim=true

More details in https://docs.renovatebot.com/merge-confidence/.