### PR TITLE
[USMON-1493] usm: postgres: use DirectConsumer for event delivery

### DIFF
--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -1006,6 +1006,10 @@ properties:
             node_type: setting
             type: integer
             default: 160
+          use_direct_consumer:
+            node_type: setting
+            type: boolean
+            default: false
       process_service_inference:
         node_type: section
         type: object

--- a/pkg/config/setup/system_probe_usm.go
+++ b/pkg/config/setup/system_probe_usm.go
@@ -118,6 +118,7 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("service_monitoring_config.postgres.enabled", false)
 	cfg.BindEnvAndSetDefault("service_monitoring_config.postgres.max_stats_buffered", 100000)
 	cfg.BindEnvAndSetDefault("service_monitoring_config.postgres.max_telemetry_buffer", 160)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.postgres.use_direct_consumer", false)
 
 	// ========================================
 	// Redis Protocol Configuration

--- a/pkg/network/config/usm_config.go
+++ b/pkg/network/config/usm_config.go
@@ -138,6 +138,11 @@ type USMConfig struct {
 	// MaxPostgresTelemetryBuffer represents the maximum size of the telemetry buffer size for Postgres
 	MaxPostgresTelemetryBuffer int
 
+	// PostgresUseDirectConsumer forces the use of direct consumer for Postgres monitoring instead of batch consumer
+	// When true, direct consumer is used if kernel supports it (>=5.8.0), otherwise falls back to batch consumer
+	// When false (default), batch consumer is always used regardless of kernel version
+	PostgresUseDirectConsumer bool
+
 	// ========================================
 	// Redis Protocol Configuration
 	// ========================================
@@ -227,6 +232,7 @@ func NewUSMConfig(cfg model.Config) *USMConfig {
 		EnablePostgresMonitoring:   cfg.GetBool(sysconfig.FullKeyPath(smNS, "postgres", "enabled")),
 		MaxPostgresStatsBuffered:   cfg.GetInt(sysconfig.FullKeyPath(smNS, "postgres", "max_stats_buffered")),
 		MaxPostgresTelemetryBuffer: cfg.GetInt(sysconfig.FullKeyPath(smNS, "postgres", "max_telemetry_buffer")),
+		PostgresUseDirectConsumer:  cfg.GetBool(sysconfig.FullKeyPath(smNS, "postgres", "use_direct_consumer")),
 
 		// Redis Protocol Configuration
 		EnableRedisMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "redis", "enabled")),

--- a/pkg/network/config/usm_config_test.go
+++ b/pkg/network/config/usm_config_test.go
@@ -1782,3 +1782,28 @@ func TestHTTPUseDirectConsumer(t *testing.T) {
 		assert.True(t, cfg.HTTPUseDirectConsumer)
 	})
 }
+
+func TestPostgresUseDirectConsumer(t *testing.T) {
+	t.Run("default value", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		cfg := New()
+
+		assert.False(t, cfg.PostgresUseDirectConsumer)
+	})
+
+	t.Run("via YAML", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetInTest("service_monitoring_config.postgres.use_direct_consumer", true)
+		cfg := New()
+
+		assert.True(t, cfg.PostgresUseDirectConsumer)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_POSTGRES_USE_DIRECT_CONSUMER", "true")
+		cfg := New()
+
+		assert.True(t, cfg.PostgresUseDirectConsumer)
+	})
+}

--- a/pkg/network/ebpf/c/protocols/helpers/pktbuf.h
+++ b/pkg/network/ebpf/c/protocols/helpers/pktbuf.h
@@ -82,6 +82,22 @@ static __always_inline __maybe_unused u32 pktbuf_data_end(pktbuf_t pkt)
     return 0;
 }
 
+// Returns the underlying program context for the packet, suitable as the
+// first argument to bpf_perf_event_output (the socket-filter skb for SKB
+// packets, the uprobe pt_regs for TLS packets).
+static __always_inline __maybe_unused void* pktbuf_get_ctx(pktbuf_t pkt)
+{
+    switch (pkt.type) {
+    case PKTBUF_SKB:
+        return (void *)pkt.skb;
+    case PKTBUF_TLS:
+        return (void *)pkt.ctx;
+    }
+
+    pktbuf_invalid_operation();
+    return NULL;
+}
+
 static __always_inline long pktbuf_load_bytes_with_telemetry(pktbuf_t pkt, u32 offset, void *to, u32 len)
 {
     switch (pkt.type) {

--- a/pkg/network/ebpf/c/protocols/postgres/decoding.h
+++ b/pkg/network/ebpf/c/protocols/postgres/decoding.h
@@ -17,7 +17,7 @@ PKTBUF_READ_INTO_BUFFER(postgres_query, POSTGRES_BUFFER_SIZE, BLK_SIZE)
 
 // Enqueues a batch of events to the user-space. To spare stack size, we take a scratch buffer from the map, copy
 // the connection tuple and the transaction to it, and then enqueue the event.
-static __always_inline void postgres_batch_enqueue_wrapper(conn_tuple_t *tuple, postgres_transaction_t *tx) {
+static __always_inline void postgres_batch_enqueue_wrapper(void *ctx, conn_tuple_t *tuple, postgres_transaction_t *tx) {
     u32 zero = 0;
     postgres_event_t *event = bpf_map_lookup_elem(&postgres_scratch_buffer, &zero);
     if (!event) {
@@ -26,7 +26,18 @@ static __always_inline void postgres_batch_enqueue_wrapper(conn_tuple_t *tuple, 
 
     bpf_memcpy(&event->tuple, tuple, sizeof(conn_tuple_t));
     bpf_memcpy(&event->tx, tx, sizeof(postgres_transaction_t));
-    postgres_batch_enqueue(event);
+
+    // Check which consumer type to use based on kernel version capability
+    __u64 postgres_use_direct_consumer = 0;
+    LOAD_CONSTANT("postgres_use_direct_consumer", postgres_use_direct_consumer);
+
+    if (postgres_use_direct_consumer) {
+        // Direct consumer path - use perf/ring buffer output (kernel >= 5.8)
+        postgres_output_event(ctx, event);
+    } else {
+        // Batch consumer path - use map-based batching (kernel < 5.8)
+        postgres_batch_enqueue(event);
+    }
 }
 
 // Reads a message header from the given context. Returns true if the header was read successfully, false otherwise.
@@ -59,9 +70,9 @@ static __always_inline void handle_new_query(pktbuf_t pkt, conn_tuple_t *conn_tu
 
 // Handles a command complete message by enqueuing the transaction and deleting it from the in-flight map.
 // The format of the command complete message is described here: https://www.postgresql.org/docs/current/protocol-message-formats.html#PROTOCOL-MESSAGE-FORMATS-COMMANDCOMPLETE
-static __always_inline void handle_command_complete(conn_tuple_t *conn_tuple, postgres_transaction_t *transaction) {
+static __always_inline void handle_command_complete(void *ctx, conn_tuple_t *conn_tuple, postgres_transaction_t *transaction) {
     transaction->response_last_seen = bpf_ktime_get_ns();
-    postgres_batch_enqueue_wrapper(conn_tuple, transaction);
+    postgres_batch_enqueue_wrapper(ctx, conn_tuple, transaction);
     bpf_map_delete_elem(&postgres_in_flight, conn_tuple);
 }
 
@@ -286,7 +297,7 @@ static __always_inline bool handle_response(pktbuf_t pkt, conn_tuple_t conn_tupl
     iteration_value->total_msg_count += messages_count;
 
     if (found_command_complete) {
-        handle_command_complete(&conn_tuple, transaction);
+        handle_command_complete(pktbuf_get_ctx(pkt), &conn_tuple, transaction);
         update_msg_count_telemetry(pg_msg_counts, iteration_value->total_msg_count);
 
         return 0;

--- a/pkg/network/ebpf/c/protocols/postgres/usm-events.h
+++ b/pkg/network/ebpf/c/protocols/postgres/usm-events.h
@@ -1,6 +1,7 @@
 #ifndef __POSTGRES_USM_EVENTS_H
 #define __POSTGRES_USM_EVENTS_H
 
+#include "protocols/direct_consumer.h"
 #include "protocols/events.h"
 #include "protocols/postgres/types.h"
 
@@ -8,5 +9,8 @@
 #define POSTGRES_BATCH_SIZE (MAX_BATCH_SIZE(postgres_event_t))
 
 USM_EVENTS_INIT(postgres, postgres_event_t, POSTGRES_BATCH_SIZE);
+
+// Initialize DirectConsumer utilities for Postgres protocol
+USM_DIRECT_CONSUMER_INIT(postgres, postgres_event_t, postgres_batch_events)
 
 #endif

--- a/pkg/network/protocols/postgres/protocol.go
+++ b/pkg/network/protocols/postgres/protocol.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -52,7 +53,8 @@ const (
 type protocol struct {
 	cfg                   *config.Config
 	telemetry             *Telemetry
-	eventsConsumer        *events.BatchConsumer[postgresebpf.EbpfEvent]
+	consumer              *events.KernelAdaptiveConsumer[postgresebpf.EbpfEvent]
+	useDirectConsumer     bool
 	mapCleaner            *ddebpf.MapCleaner[netebpf.ConnTuple, postgresebpf.EbpfTx]
 	statskeeper           *StatKeeper
 	kernelTelemetry       *kernelTelemetry // retrieves Postgres metrics from kernel
@@ -156,14 +158,29 @@ func newPostgresProtocol(mgr *manager.Manager, cfg *config.Config) (protocols.Pr
 		return nil, nil
 	}
 
-	return &protocol{
+	p := &protocol{
 		cfg:                   cfg,
 		telemetry:             NewTelemetry(cfg),
 		statskeeper:           NewStatkeeper(cfg),
 		kernelTelemetry:       newKernelTelemetry(),
 		kernelTelemetryStopCh: make(chan struct{}),
 		mgr:                   mgr,
-	}, nil
+	}
+
+	// Create adaptive consumer that determines kernel version and callback internally
+	if err := p.createAdaptiveConsumer(); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Modifiers implements the ModifierProvider interface
+func (p *protocol) Modifiers() []ddebpf.Modifier {
+	if p.consumer == nil {
+		return nil
+	}
+	return p.consumer.Modifiers()
 }
 
 // Name returns the name of the protocol.
@@ -177,31 +194,47 @@ func (p *protocol) ConfigureOptions(opts *manager.Options) {
 		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
 		EditorFlag: manager.EditMaxEntries,
 	}
-	netifProbeID := manager.ProbeIdentificationPair{
-		EBPFFuncName: netifProbe,
-		UID:          eventStream,
+
+	// Only activate the flush tracepoint when using BatchConsumer.
+	// DirectConsumer doesn't need it since it uses direct event output.
+	if !p.useDirectConsumer {
+		netifProbeID := manager.ProbeIdentificationPair{
+			EBPFFuncName: netifProbe,
+			UID:          eventStream,
+		}
+		if usmconfig.ShouldUseNetifReceiveSKBCoreKprobe() {
+			netifProbeID.EBPFFuncName = netifProbe414
+		}
+		opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: netifProbeID})
+	} else {
+		// When using DirectConsumer, exclude flush probes to avoid loading/verifying them
+		opts.ExcludedFunctions = append(opts.ExcludedFunctions, netifProbe, netifProbe414)
 	}
-	if usmconfig.ShouldUseNetifReceiveSKBCoreKprobe() {
-		netifProbeID.EBPFFuncName = netifProbe414
-	}
-	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: netifProbeID})
+
 	utils.EnableOption(opts, "postgres_monitoring_enabled")
+	utils.AddBoolConst(opts, p.useDirectConsumer, "postgres_use_direct_consumer")
+
 	// Configure event stream
 	events.Configure(p.cfg, eventStream, p.mgr, opts)
 }
 
 // PreStart runs setup required before starting the protocol.
 func (p *protocol) PreStart() (err error) {
-	p.eventsConsumer, err = events.NewBatchConsumer(
-		eventStream,
-		p.mgr,
-		p.processPostgres,
-	)
-	if err != nil {
-		return
+	// If using BatchConsumer, create it now (after manager initialization).
+	// The DirectConsumer is already created in the factory via createAdaptiveConsumer().
+	if !p.useDirectConsumer {
+		batchConsumer, err := events.NewBatchConsumer(eventStream, p.mgr, p.processPostgres)
+		if err != nil {
+			return err
+		}
+		p.consumer = events.NewKernelAdaptiveConsumer[postgresebpf.EbpfEvent](
+			batchConsumer,
+			[]ddebpf.Modifier{}, // BatchConsumer needs no modifiers
+		)
 	}
 
-	p.eventsConsumer.Start()
+	// Start the consumer (works for both DirectConsumer and BatchConsumer)
+	p.consumer.Start()
 
 	return
 }
@@ -219,8 +252,8 @@ func (p *protocol) Stop() {
 	// mapCleaner handles nil pointer receivers
 	p.mapCleaner.Stop()
 
-	if p.eventsConsumer != nil {
-		p.eventsConsumer.Stop()
+	if p.consumer != nil {
+		p.consumer.Stop()
 	}
 	if p.kernelTelemetryStopCh != nil {
 		close(p.kernelTelemetryStopCh)
@@ -258,7 +291,7 @@ func (p *protocol) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map) {
 
 // GetStats returns a map of Postgres stats and a callback to clean resources.
 func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
-	p.eventsConsumer.Sync()
+	p.consumer.Sync()
 	p.kernelTelemetry.Log()
 
 	stats := p.statskeeper.GetAndResetAllStats()
@@ -285,6 +318,48 @@ func (p *protocol) processPostgres(events []postgresebpf.EbpfEvent) {
 		p.statskeeper.Process(eventWrapper)
 		p.telemetry.Count(tx, eventWrapper)
 	}
+}
+
+func (p *protocol) processPostgresDirect(event *postgresebpf.EbpfEvent) {
+	eventWrapper := NewEventWrapper(event)
+	p.statskeeper.Process(eventWrapper)
+	p.telemetry.Count(event, eventWrapper)
+}
+
+// createAdaptiveConsumer creates the appropriate consumer based on configuration and kernel version
+// and determines which callback method to use internally.
+func (p *protocol) createAdaptiveConsumer() error {
+	// Check if direct consumer is explicitly requested via configuration
+	if p.cfg.PostgresUseDirectConsumer {
+		if events.SupportsDirectConsumer() {
+			// Use DirectConsumer for kernel ≥5.8 (supports bpf_perf_event_output in socket filters)
+			directConsumer, err := events.NewDirectConsumer(eventStream, p.processPostgresDirect, p.cfg)
+			if err != nil {
+				return err
+			}
+			p.consumer = events.NewKernelAdaptiveConsumer[postgresebpf.EbpfEvent](
+				directConsumer,
+				[]ddebpf.Modifier{&directConsumer.EventHandler},
+			)
+			p.useDirectConsumer = true
+			log.Debugf("Postgres monitoring: using direct consumer (requested via configuration)")
+		} else {
+			// Fall back to BatchConsumer on unsupported kernels
+			kernelVersion, err := kernel.HostVersion()
+			if err != nil {
+				log.Warnf("Postgres monitoring: direct consumer requested but unable to determine kernel version (%v), falling back to batch consumer", err)
+			} else {
+				log.Warnf("Postgres monitoring: direct consumer requested but kernel version %v < 5.8.0, falling back to batch consumer", kernelVersion)
+			}
+			p.useDirectConsumer = false
+		}
+	} else {
+		// Default behavior: use BatchConsumer regardless of kernel version
+		log.Debugf("Postgres monitoring: using batch consumer (default behavior)")
+		p.useDirectConsumer = false
+	}
+
+	return nil
 }
 
 func (p *protocol) setupMapCleaner() {

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/postgres"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/postgres/ebpf"
@@ -768,6 +769,69 @@ func getPostgresDefaultTestConfiguration(enableTLS bool) *config.Config {
 	cfg.GoTLSExcludeSelf = false
 	cfg.BypassEnabled = true
 	return cfg
+}
+
+// TestDirectConsumerFunctionality verifies that Postgres stats are captured when the
+// direct consumer is enabled (kernel >= 5.8.0), for both plaintext and GoTLS traffic,
+// mirroring the batch-consumer path. The TLS case also exercises the uprobe emit path
+// (pktbuf_get_ctx -> postgres_output_event with a pt_regs context).
+func (s *postgresProtocolParsingSuite) TestDirectConsumerFunctionality() {
+	t := s.T()
+
+	// Skip test if kernel version doesn't support direct consumer
+	if !events.SupportsDirectConsumer() {
+		t.Skip("Direct consumer requires kernel >= 5.8.0")
+	}
+
+	for name, isTLS := range map[string]bool{"without TLS": false, "with TLS": true} {
+		t.Run(name, func(t *testing.T) {
+			if isTLS && !gotlstestutil.GoTLSSupported(t, config.New()) {
+				t.Skip("GoTLS not supported for this setup")
+			}
+			s.testDirectConsumerFunctionality(t, isTLS)
+		})
+	}
+}
+
+func (s *postgresProtocolParsingSuite) testDirectConsumerFunctionality(t *testing.T, isTLS bool) {
+	serverHost := "127.0.0.1"
+	serverAddress := net.JoinHostPort(serverHost, postgresPort)
+	require.NoError(t, postgres.RunServer(t, serverHost, postgresPort, isTLS))
+	waitForPostgresServer(t, serverAddress, isTLS)
+
+	// With non-TLS, packets are seen twice (Docker), so the expected count is doubled.
+	// In the TLS case the data comes from uprobes on the binary, so it is seen once.
+	adjustCount := func(count int) int {
+		if isTLS {
+			return count
+		}
+		return count * 2
+	}
+
+	// Enable the direct consumer for Postgres.
+	cfg := getPostgresDefaultTestConfiguration(isTLS)
+	cfg.PostgresUseDirectConsumer = true
+
+	monitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
+	if isTLS {
+		utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, os.Getpid(), utils.ManualTracingFallbackEnabled)
+	}
+
+	pg, err := postgres.NewPGXClient(postgres.ConnectionOptions{
+		ServerAddress: serverAddress,
+		EnableTLS:     isTLS,
+	})
+	require.NoError(t, err)
+	require.NoError(t, pg.Ping())
+	t.Cleanup(pg.Close)
+
+	require.NoError(t, pg.RunQuery(createTableQuery))
+
+	validatePostgres(t, monitor, map[string]map[postgres.Operation]int{
+		"dummy": {
+			postgres.CreateTableOP: adjustCount(1),
+		},
+	}, isTLS)
 }
 
 func validatePostgres(t *testing.T, monitor *Monitor, expectedStats map[string]map[postgres.Operation]int, tls bool) {


### PR DESCRIPTION
### What does this PR do?

Migrates USM's Postgres protocol from the legacy batch-map event-delivery path
to the **DirectConsumer**, gated behind a new per-protocol config flag
`service_monitoring_config.postgres.use_direct_consumer` (default `false`).

When enabled on a supported kernel (>= 5.8), Postgres events are written
straight from the eBPF socket-filter/uprobe programs to a perf/ring buffer via
`pkg/ebpf/perf.EventHandler`, instead of being accumulated in per-CPU batch
maps and flushed by the `netif_receive_skb` probe. On older kernels the
protocol transparently falls back to the existing batch consumer.

This is the Postgres step of extending the DirectConsumer mechanism (built for
HTTP in USMON-1458, PR #39774) to all USM protocols.

### Motivation

The batch path is heavy and fragile: extra maps (`postgres_batches`,
`postgres_batch_state`), a flush probe, offset bookkeeping, userspace
map-walking, a known race between the socket-filter and uprobe (TLS) flush
paths, and poor built-in telemetry. On modern kernels socket filters can write
directly to perf/ring buffers, which removes the batch maps and flush probe,
eliminates the flush race, and gives lost-event / ring-buffer telemetry for
free.

### Describe how you validated your changes

- New config unit test in `pkg/network/config/usm_config_test.go` covering the
  `postgres.use_direct_consumer` flag (default off, env/yaml override).
- New `TestDirectConsumerFunctionality` in `pkg/network/usm/postgres_monitor_test.go`
  exercising the direct path end-to-end.
- Batch-path regression: existing Postgres monitor tests still pass with the
  flag off.
- Built and ran locally on an ubuntu-24 / kernel 6.8 box in both
  `runtime_compiled` and `CO-RE` load modes; `system-probe.build` and
  `linter.go` clean.

### Additional Notes

- Default-off, internal tuning flag; no behavior change unless explicitly
  enabled. No release note for now, matching the HTTP precedent (PR #39774).
- Adds a small `pktbuf_get_ctx()` helper in
  `pkg/network/ebpf/c/protocols/helpers/pktbuf.h` to thread the program ctx
  through the skb/TLS-agnostic emit path so the direct output helper can write
  to the perf buffer.
- Opening as a **draft** to let CI run before requesting review.
