### PR TITLE
Extend `bazel` credential helper to interactive use cases

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,6 +15,8 @@ startup --max_idle_secs=28800 # Keep the server alive for at most 8 hours of ina
 # Common options -------------------------------------------------------------------------------------------------------
 common --@rules_python//python/config_settings:bootstrap_impl=script # https://github.com/bazel-contrib/rules_python/blob/main/BZLMOD_SUPPORT.md
 common --check_direct_dependencies=error # Escalate any bypassed `bazel_dep` to a resolution failure
+common --credential_helper_cache_duration=55m # Refresh a little earlier than the Vault OIDC token TTL (1h)
+common --credential_helper_timeout=2m # Interactive Vault login might involve a browser and exceed the 10s default
 common --enable_platform_specific_config # Supported OS identifiers are linux, macos, windows, freebsd, and openbsd
 common --experimental_disk_cache_gc_max_size=30G # Cap applied whenever --disk_cache is also set, no-op otherwise. Override in user.bazelrc (50G good, 100G ideal)
 common --experimental_proto_descriptor_sets_include_source_info # Preserve comments in generated pb.go
@@ -41,16 +43,19 @@ common:lint --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=
 
 # Linux config ---------------------------------------------------------------------------------------------------------
 common:linux --credential_helper=buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog=%workspace%/bazel/tools/credential-helper
+common:linux --credential_helper=buildbarn-frontend-datadog-agent.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper
 common:linux --strategy=sandboxed
 
 # macOS config ---------------------------------------------------------------------------------------------------------
 common:macos --credential_helper=buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog=%workspace%/bazel/tools/credential-helper
+common:macos --credential_helper=buildbarn-frontend-datadog-agent.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper
 common:macos --features=-macos_default_link_flags # https://github.com/bazelbuild/bazel/issues/23312
 common:macos --macos_minimum_os=12.0 # Keep in sync with https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
 common:macos --strategy=sandboxed
 
 # Windows config -------------------------------------------------------------------------------------------------------
 common:windows --credential_helper=buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog=%workspace%/bazel/tools/credential-helper.bat
+common:windows --credential_helper=buildbarn-frontend-datadog-agent.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper.bat
 common:windows --strategy=standalone # Valid values are: [dynamic_worker, standalone, dynamic, remote, worker, local]
 # rules_python 1.9.0 transitions enable_runfiles to `true` for every py_ target on Windows. Pre-setting it here makes
 # that transition a no-op, so Bazel deduplicates python_win and avoids 2 concurrent MSBuild racing on shared resources.

--- a/bazel/tools/credential-helper
+++ b/bazel/tools/credential-helper
@@ -3,8 +3,30 @@ set -euo pipefail
 
 # Credential Helpers Specification: https://github.com/EngFlow/credential-helper-spec/blob/main/spec.md
 IFS= read -d '' -r _ ||:
+
+write_auth_headers() {
+  printf '{"headers":{"Authorization":["Bearer %s"]}}' "$1"
+}
+
 if [ -n "${BUILDBARN_ID_TOKEN-}" ]; then
-    printf '{"headers":{"Authorization":["Bearer %s"]}}' "$BUILDBARN_ID_TOKEN"
+  # Preset token: always honor it
+  write_auth_headers "$BUILDBARN_ID_TOKEN"
+elif [ -n "${CI-}" ]; then
+  # CI: never attempt interactive Vault login, but let `bazel` honor any applicable --remote_local_fallback* options
+  printf '{}'
 else
-    printf '{}'
+  # Dev: mint a Vault OIDC token, logging in if needed, cached by `bazel` as per --credential_helper_cache_duration
+  VAULT_ADDR="${VAULT_ADDR:-https://vault.us1.ddbuild.staging.dog}"
+  fetch_token() {
+    vault read -address="$VAULT_ADDR" -field=token identity/oidc/token/buildbarn
+  }
+  if ! token=$(fetch_token); then
+    >&2 vault login -address="$VAULT_ADDR" -method=oidc
+    token=$(fetch_token)
+  fi
+  if [ -z "$token" ]; then
+    >&2 echo "Vault returned an empty token!"
+    exit 1
+  fi
+  write_auth_headers "$token"
 fi

--- a/bazel/tools/credential-helper
+++ b/bazel/tools/credential-helper
@@ -16,7 +16,7 @@ elif [ -n "${CI-}" ]; then
   printf '{}'
 else
   # Dev: mint a Vault OIDC token, logging in if needed, cached by `bazel` as per --credential_helper_cache_duration
-  VAULT_ADDR="${VAULT_ADDR:-https://vault.us1.ddbuild.staging.dog}"
+  VAULT_ADDR="${VAULT_ADDR:-https://vault.us1.ddbuild.io}"
   fetch_token() {
     vault read -address="$VAULT_ADDR" -field=token identity/oidc/token/buildbarn
   }

--- a/bazel/tools/credential-helper.bat
+++ b/bazel/tools/credential-helper.bat
@@ -17,7 +17,7 @@ if defined CI (
 )
 
 :: Dev: mint a Vault OIDC token, logging in if needed, cached by `bazel` as per --credential_helper_cache_duration
-if not defined VAULT_ADDR set "VAULT_ADDR=https://vault.us1.ddbuild.staging.dog"
+if not defined VAULT_ADDR set "VAULT_ADDR=https://vault.us1.ddbuild.io"
 call :fetch_token
 if defined token (
   call :write_auth_headers "%token%"

--- a/bazel/tools/credential-helper.bat
+++ b/bazel/tools/credential-helper.bat
@@ -1,9 +1,42 @@
 @echo off
+setlocal
 
 :: Credential Helpers Specification: https://github.com/EngFlow/credential-helper-spec/blob/main/spec.md
 set /p _=
+
+:: Preset token: always honor it
 if defined BUILDBARN_ID_TOKEN (
-    echo {"headers":{"Authorization":["Bearer %BUILDBARN_ID_TOKEN%"]}}
-) else (
-    echo {}
+  call :write_auth_headers "%BUILDBARN_ID_TOKEN%"
+  exit /b 0
 )
+
+:: CI: never attempt interactive Vault login, but let `bazel` honor any applicable --remote_local_fallback* options
+if defined CI (
+  echo {}
+  exit /b 0
+)
+
+:: Dev: mint a Vault OIDC token, logging in if needed, cached by `bazel` as per --credential_helper_cache_duration
+if not defined VAULT_ADDR set "VAULT_ADDR=https://vault.us1.ddbuild.staging.dog"
+call :fetch_token
+if defined token (
+  call :write_auth_headers "%token%"
+  exit /b 0
+)
+>&2 vault login -address="%VAULT_ADDR%" -method=oidc || exit /b 1
+call :fetch_token
+if defined token (
+  call :write_auth_headers "%token%"
+  exit /b 0
+)
+>&2 echo Vault returned an empty token!
+exit /b 1
+
+:fetch_token
+set "token="
+for /f "usebackq delims=" %%t in (`vault read -address "%VAULT_ADDR%" -field token identity/oidc/token/buildbarn`) do set "token=%%t"
+goto :eof
+
+:write_auth_headers
+echo {"headers":{"Authorization":["Bearer %~1"]}}
+goto :eof


### PR DESCRIPTION
### What does this PR do?
Extend the existing per-OS Buildbarn credential helpers to also serve the frontend host (`buildbarn-frontend-datadog-agent.us1.ddbuild.io`), adding a Vault OIDC path for developer builds.
Rather than adding a separate "laptop-only" helper wired onto `common:cache`, the frontend host joins the edge-cache host in the per-OS `--credential_helper` stanzas, so each OS keeps a single helper covering both hosts.

Each helper resolves credentials in the same order:
1. an injected `BUILDBARN_ID_TOKEN` first
2. when `CI` is set, `{}` (so CI never attempts interactive auth and `bazel` falls back per `--remote_local_fallback*`)
3. otherwise a Vault OIDC token, logging in if needed and failing if the token comes back empty.

There is no need for an additional on-disk token cache since `bazel` already caches a helper's response, so
`--credential_helper_cache_duration=55m` keeps that just under the 1h OIDC token TTL.

### Motivation
https://github.com/DataDog/datadog-agent/pull/51364#discussion_r3324088852:
- serve both hosts from the helpers that already exist,
- gate interactive Vault login out of CI via the `CI` variable `tools/bazel*` scripts already rely  on,
- support Linux, macOS and Windows from a single helper per OS family.

### Describe how you validated your changes
- shellcheck clean on the POSIX helper,
- exercised every POSIX branch locally against a fake `vault`: injected token, CI, session reuse, login-then-fetch, login failure, empty token,
- drove the Windows `.bat` on a VM against a fake `vault.exe` that asserts the flag values it receives: the same branches behave identically, and `vault login` output stays off stdout.

### Additional Notes
`VAULT_ADDR` and other constants (e.g, the 55 minute-duration) match those of #51364.