### PR TITLE
Skip extensions RemoveAll when DB missing

### DIFF
--- a/pkg/fleet/installer/packages/extensions/extensions.go
+++ b/pkg/fleet/installer/packages/extensions/extensions.go
@@ -329,8 +329,13 @@ func RemoveAll(ctx context.Context, pkg string, isExperiment bool, hooks Extensi
 	defer func() { span.Finish(err) }()
 	span.SetTag("package_name", pkg)
 
+	dbPath := filepath.Join(ExtensionsDBDir, "extensions.db")
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return nil
+	}
+
 	// Open & lock the extensions database
-	db, err := newExtensionsDB(filepath.Join(ExtensionsDBDir, "extensions.db"))
+	db, err := newExtensionsDB(dbPath)
 	if err != nil {
 		return fmt.Errorf("could not create extensions db: %w", err)
 	}

--- a/pkg/fleet/installer/packages/extensions/extensions_test.go
+++ b/pkg/fleet/installer/packages/extensions/extensions_test.go
@@ -263,3 +263,13 @@ func TestHookErrorPropagation(t *testing.T) {
 	require.Error(t, err, "hook failure should return error")
 	assert.Contains(t, err.Error(), "hook failed", "error should contain hook failure message")
 }
+
+// TestRemoveAllMissingDB verifies that RemoveAll is a no-op when the extensions
+// database file does not exist. This guards against the prerm hook failing on
+// hosts where extensions were never initialized.
+func TestRemoveAllMissingDB(t *testing.T) {
+	ExtensionsDBDir = filepath.Join(t.TempDir(), "does-not-exist")
+
+	err := RemoveAll(context.Background(), "datadog-agent", false, &mockHooks{})
+	require.NoError(t, err, "RemoveAll should return nil when the extensions DB does not exist")
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"54272b39-2504-432b-88ab-bc5048eae12f","source":"chat","resourceId":"687b9807-0ea3-4aa0-8276-72a77f1f30a6","workflowId":"c7e5ee76-306a-4327-9826-f117cff41266","codeChangeId":"c7e5ee76-306a-4327-9826-f117cff41266","sourceType":"assistant"} -->
### What does this PR do?

Makes `extensions.RemoveAll` a no-op when the extensions database file does not exist, mirroring the guard already present in `extensions.DeletePackage`.

### Motivation

On hosts where extensions were never initialized, `/opt/datadog-packages/run/extensions.db` does not exist. During the agent `prerm` hook, `removeAgentExtensions` calls `RemoveAll` first, which unconditionally tried to open the DB and failed with `could not create extensions db: ... no such file or directory`. This produced ~101K error spans/week (Error Tracking issue 6d8bb53e-2942-11f1-b9a4-da7ad0900002, versions 7.79.0 through 7.81.0-devel). `DeletePackage` already guards against the missing file at pkg/fleet/installer/packages/extensions/extensions.go lines 72-75; `RemoveAll` simply needed the same check.

### Describe how you validated your changes

- Added unit test `TestRemoveAllMissingDB` that points `ExtensionsDBDir` at a non-existent directory and asserts `RemoveAll` returns `nil`.
- Ran `go test ./pkg/fleet/installer/packages/extensions/` — all tests pass.
- Ran `gofmt -l` and `go vet` on the touched files — no issues.

### Additional Notes

The fix replaces the inline `filepath.Join` with a `dbPath` variable so it can be reused by the `os.Stat` guard and the subsequent `newExtensionsDB` call, identical to the pattern in `DeletePackage`.
