### PR TITLE
Add dependency overrides to bazel-loaded release.json

### DIFF
--- a/bazel/repo/BUILD.bazel
+++ b/bazel/repo/BUILD.bazel
@@ -1,1 +1,5 @@
 """Local repository rules."""
+
+load(":release_json_test.bzl", "release_json_test_suite")
+
+release_json_test_suite(name = "release_json_tests")

--- a/bazel/repo/release_json.bzl
+++ b/bazel/repo/release_json.bzl
@@ -1,5 +1,9 @@
 """Import release.json so we can use these global constants.
 
+It can also take variables from the environment to replace values given for
+the "dependencies" field, such that they can be overridden
+(requires --repo_env=VAR_NAME for each field for this to have an effect)
+
 Usage:
     release_json = use_repo_rule("//bazel/repo:release_json.bzl", "release_json")
     # Give it a private name so that we don't run the risk of conflicting with a future OSS module.
@@ -21,9 +25,26 @@ exports_files(
 )
 """
 
+def read_effective_release_json(rctx, release_json_label):
+    """Read contents release.json file with environment overrides applied.
+
+    This is intended as a common entry point for repository rules to use
+    to get values from release.json.
+
+    Requires --repo_env=VAR_NAME for variables to be actually overridden.
+    """
+    release_json = json.decode(rctx.read(rctx.path(release_json_label)))
+
+    # Override dependencies with values from the environment
+    release_json["dependencies"] = {
+        dep_key: rctx.getenv(dep_key) or release_json["dependencies"][dep_key]
+        for dep_key in release_json["dependencies"]
+    }
+    return release_json
+
 def _release_json_impl(rctx):
     rctx.file("BUILD.bazel", BUILD_FILE_CONTENT)
-    release_json = json.decode(rctx.read(rctx.path(rctx.attr._release_json)))
+    release_json = read_effective_release_json(rctx, rctx.attr._release_json)
     rctx.file("release_json.bzl", """release_json = %s\n""" % str(release_json))
 
 release_json = repository_rule(

--- a/bazel/repo/release_json_test.bzl
+++ b/bazel/repo/release_json_test.bzl
@@ -1,0 +1,74 @@
+"""Tests for release_json repository helpers."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":release_json.bzl", "read_effective_release_json")
+
+def _fake_path(label):
+    return label
+
+def _make_fake_read(contents):
+    def _fake_read(path):
+        if path != "fake/release.json":
+            fail("unexpected path: %s" % path)
+        return contents
+
+    return _fake_read
+
+def _make_fake_getenv(env):
+    def _fake_getenv(key, default = None):
+        return env.get(key, default)
+
+    return _fake_getenv
+
+def _fake_rctx(env, release_json_contents):
+    return struct(
+        path = _fake_path,
+        read = _make_fake_read(release_json_contents),
+        getenv = _make_fake_getenv(env),
+    )
+
+def _read_effective_release_json_applies_dependency_overrides_impl(ctx):
+    env = unittest.begin(ctx)
+    release_json_contents = json.encode({
+        "base_branch": "main",
+        "current_milestone": "7.81.0",
+        "dependencies": {
+            "OVERRIDDEN_DEPENDENCY": "to-override",
+            "UNCHANGED_DEPENDENCY": "stable",
+            "EMPTY_OVERRIDE": "not-overridden",
+        },
+    })
+
+    release_json = read_effective_release_json(
+        _fake_rctx({"OVERRIDDEN_DEPENDENCY": "from-env", "EMPTY_OVERRIDE": ""}, release_json_contents),
+        "fake/release.json",
+    )
+
+    asserts.equals(
+        env,
+        "from-env",
+        release_json["dependencies"]["OVERRIDDEN_DEPENDENCY"],
+    )
+    asserts.equals(
+        env,
+        "stable",
+        release_json["dependencies"]["UNCHANGED_DEPENDENCY"],
+    )
+    asserts.equals(
+        env,
+        "not-overridden",
+        release_json["dependencies"]["EMPTY_OVERRIDE"],
+    )
+    asserts.equals(env, "main", release_json["base_branch"])
+
+    return unittest.end(env)
+
+_read_effective_release_json_applies_dependency_overrides_test = unittest.make(
+    _read_effective_release_json_applies_dependency_overrides_impl,
+)
+
+def release_json_test_suite(name):
+    unittest.suite(
+        name,
+        _read_effective_release_json_applies_dependency_overrides_test,
+    )

--- a/deps/jmxfetch/module_utils.bzl
+++ b/deps/jmxfetch/module_utils.bzl
@@ -15,6 +15,7 @@ Usage:
 
 load("@bazel_tools//tools/build_defs/repo:cache.bzl", "DEFAULT_CANONICAL_ID_ENV", "get_default_canonical_id")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "get_auth")
+load("//bazel/repo:release_json.bzl", "read_effective_release_json")
 
 get_jmxfetch_using_release_constants_attrs = {
     "executable": attr.bool(
@@ -92,7 +93,7 @@ def parse_jmxfetch_version(version):
 
 def _get_jmxfetch_using_release_constants_impl(rctx):
     """Implementation of the get_jmxfetch_using_release_constants rule."""
-    release_info = json.decode(rctx.read(rctx.path(rctx.attr._release_info)))
+    release_info = read_effective_release_json(rctx, rctx.attr._release_info)
     vars = release_info["dependencies"]
 
     version = vars["JMXFETCH_VERSION"]

--- a/deps/security_agent_policies/module_utils.bzl
+++ b/deps/security_agent_policies/module_utils.bzl
@@ -14,6 +14,7 @@ Usage:
 
 load("@bazel_tools//tools/build_defs/repo:cache.bzl", "DEFAULT_CANONICAL_ID_ENV", "get_default_canonical_id")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "get_auth")
+load("//bazel/repo:release_json.bzl", "read_effective_release_json")
 
 _get_security_agent_policies_attrs = {
     "canonical_id": attr.string(),
@@ -22,7 +23,7 @@ _get_security_agent_policies_attrs = {
 
 def _get_security_agent_policies_impl(rctx):
     """Implementation of the get_security_agent_policies_using_release_constants rule."""
-    release_info = json.decode(rctx.read(rctx.path(rctx.attr._release_info)))
+    release_info = read_effective_release_json(rctx, rctx.attr._release_info)
     vars = release_info["dependencies"]
 
     version = vars["SECURITY_AGENT_POLICIES_VERSION"]  # e.g. "v0.77.0"

--- a/deps/windows/module_utils.bzl
+++ b/deps/windows/module_utils.bzl
@@ -16,6 +16,7 @@ Usage:
 
 load("@bazel_tools//tools/build_defs/repo:cache.bzl", "DEFAULT_CANONICAL_ID_ENV", "get_default_canonical_id")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "get_auth")
+load("//bazel/repo:release_json.bzl", "read_effective_release_json")
 
 get_file_using_release_constants_attrs = {
     "executable": attr.bool(
@@ -60,7 +61,7 @@ filegroup(
 
 def _get_file_using_release_constants_impl(rctx):
     """Implementation of the get_file_using_release_constants rule."""
-    release_info = json.decode(rctx.read(rctx.path(rctx.attr._release_info)))
+    release_info = read_effective_release_json(rctx, rctx.attr._release_info)
     vars = release_info["dependencies"]
     repo_root = rctx.path(".")
     forbidden_files = [


### PR DESCRIPTION
### What does this PR do?

- Adds env var based overrides to existing repo rule that exposes the data from release.json
- Adds a centralized function to do that same overriding, such that it can be used by other repo rules.
- Makes existing repo rules that read release.json go through this centralized function, such that they can opt in to this override (depending on whether the variable is made explicitly available via `--repo_env`).

### Motivation

Part of [ABLD-260](https://datadoghq.atlassian.net/browse/ABLD-260).

While migrating the installation of integrations-core, we need to be able to reproduce the existing behavior, where the integrations-core version is picked up from release.json but can be overridden via env vars (for triggered pipelines).

Also, I wanted to have a centralized way to implement the bazel-equivalent of https://github.com/DataDog/datadog-agent/blob/7a66b636bfb0689c3636a7c287d819d6604743f0/tasks/libs/dependencies.py#L10-L31

### Describe how you validated your changes

I added tests to the function to exercise the main possible cases. I did some local testing with debug printing to confirm that the replacement works (when --repo_env is used as needed).

### Additional Notes

There's no actual behavior change as part of this PR for repo rules that now read the release.json through this new function instead of directly.


[ABLD-260]: https://datadoghq.atlassian.net/browse/ABLD-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ