### PR TITLE
[USMON-1493] usm: kafka: use DirectConsumer for event delivery

### DIFF
--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -968,6 +968,10 @@ properties:
             node_type: setting
             type: integer
             default: 100000
+          use_direct_consumer:
+            node_type: setting
+            type: boolean
+            default: false
       kernel_buffer_pages:
         node_type: setting
         type: integer

--- a/pkg/config/setup/system_probe_usm.go
+++ b/pkg/config/setup/system_probe_usm.go
@@ -112,6 +112,8 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// For backward compatibility
 	cfg.BindEnvAndSetDefault("service_monitoring_config.max_kafka_stats_buffered", 100000)
 
+	cfg.BindEnvAndSetDefault("service_monitoring_config.kafka.use_direct_consumer", false)
+
 	// ========================================
 	// PostgreSQL Protocol Configuration
 	// ========================================

--- a/pkg/network/config/usm_config.go
+++ b/pkg/network/config/usm_config.go
@@ -125,6 +125,11 @@ type USMConfig struct {
 	// MaxKafkaStatsBuffered represents the maximum number of Kafka stats we'll buffer in memory
 	MaxKafkaStatsBuffered int
 
+	// KafkaUseDirectConsumer forces the use of direct consumer for Kafka monitoring instead of batch consumer
+	// When true, direct consumer is used if kernel supports it (>=5.8.0), otherwise falls back to batch consumer
+	// When false (default), batch consumer is always used regardless of kernel version
+	KafkaUseDirectConsumer bool
+
 	// ========================================
 	// Postgres Protocol Configuration
 	// ========================================
@@ -220,8 +225,9 @@ func NewUSMConfig(cfg model.Config) *USMConfig {
 		HTTP2DynamicTableMapCleanerInterval: time.Duration(cfg.GetInt(sysconfig.FullKeyPath(smNS, "http2", "dynamic_table_map_cleaner_interval_seconds"))) * time.Second,
 
 		// Kafka Protocol Configuration
-		EnableKafkaMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "kafka", "enabled")),
-		MaxKafkaStatsBuffered: cfg.GetInt(sysconfig.FullKeyPath(smNS, "kafka", "max_stats_buffered")),
+		EnableKafkaMonitoring:  cfg.GetBool(sysconfig.FullKeyPath(smNS, "kafka", "enabled")),
+		MaxKafkaStatsBuffered:  cfg.GetInt(sysconfig.FullKeyPath(smNS, "kafka", "max_stats_buffered")),
+		KafkaUseDirectConsumer: cfg.GetBool(sysconfig.FullKeyPath(smNS, "kafka", "use_direct_consumer")),
 
 		// Postgres Protocol Configuration
 		EnablePostgresMonitoring:   cfg.GetBool(sysconfig.FullKeyPath(smNS, "postgres", "enabled")),

--- a/pkg/network/config/usm_config_test.go
+++ b/pkg/network/config/usm_config_test.go
@@ -1782,3 +1782,28 @@ func TestHTTPUseDirectConsumer(t *testing.T) {
 		assert.True(t, cfg.HTTPUseDirectConsumer)
 	})
 }
+
+func TestKafkaUseDirectConsumer(t *testing.T) {
+	t.Run("default value", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		cfg := New()
+
+		assert.False(t, cfg.KafkaUseDirectConsumer)
+	})
+
+	t.Run("via YAML", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetInTest("service_monitoring_config.kafka.use_direct_consumer", true)
+		cfg := New()
+
+		assert.True(t, cfg.KafkaUseDirectConsumer)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_KAFKA_USE_DIRECT_CONSUMER", "true")
+		cfg := New()
+
+		assert.True(t, cfg.KafkaUseDirectConsumer)
+	})
+}

--- a/pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h
+++ b/pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h
@@ -9,7 +9,7 @@
 
 // forward declaration
 static __always_inline bool kafka_allow_packet(skb_info_t *skb_info);
-static __always_inline bool kafka_process(conn_tuple_t *tup, kafka_info_t *kafka, pktbuf_t pkt, kafka_telemetry_t *kafka_tel);
+static __always_inline bool kafka_process(void *ctx, conn_tuple_t *tup, kafka_info_t *kafka, pktbuf_t pkt, kafka_telemetry_t *kafka_tel);
 static __always_inline bool kafka_process_response(void *ctx, conn_tuple_t *tup, kafka_info_t *kafka, pktbuf_t pkt, skb_info_t *skb_info);
 static __always_inline void update_topic_name_size_telemetry(kafka_telemetry_t *kafka_tel, __u64 size);
 
@@ -88,7 +88,7 @@ int socket__kafka_filter(struct __sk_buff* skb) {
         return 0;
     }
 
-    (void)kafka_process(&tup, kafka, pkt, kafka_tel);
+    (void)kafka_process(skb, &tup, kafka, pkt, kafka_tel);
     return 0;
 }
 
@@ -120,7 +120,7 @@ int uprobe__kafka_tls_filter(struct pt_regs *ctx) {
         return 0;
     }
 
-    kafka_process(&tup, kafka, pkt, kafka_tel);
+    kafka_process(ctx, &tup, kafka, pkt, kafka_tel);
     return 0;
 }
 
@@ -142,7 +142,7 @@ int uprobe__kafka_tls_termination(struct pt_regs *ctx) {
 
 PKTBUF_READ_INTO_BUFFER(topic_name_parser, TOPIC_NAME_MAX_STRING_SIZE, BLK_SIZE)
 
-static __always_inline void kafka_batch_enqueue_wrapper(kafka_info_t *kafka, conn_tuple_t *tup, kafka_transaction_t *transaction) {
+static __always_inline void kafka_batch_enqueue_wrapper(void *ctx, kafka_info_t *kafka, conn_tuple_t *tup, kafka_transaction_t *transaction) {
     kafka_event_t *event = &kafka->event;
 
     bpf_memcpy(&event->tup, tup, sizeof(conn_tuple_t));
@@ -152,7 +152,23 @@ static __always_inline void kafka_batch_enqueue_wrapper(kafka_info_t *kafka, con
         bpf_memcpy(&event->transaction, transaction, sizeof(kafka_transaction_t));
     }
 
+#if KAFKA_DIRECT_CONSUMER_ENABLED
+    // Check which consumer type to use based on kernel version capability
+    __u64 kafka_use_direct_consumer = 0;
+    LOAD_CONSTANT("kafka_use_direct_consumer", kafka_use_direct_consumer);
+
+    if (kafka_use_direct_consumer) {
+        // Direct consumer path - use perf/ring buffer output (kernel >= 5.8)
+        kafka_output_event(ctx, event);
+    } else {
+        // Batch consumer path - use map-based batching (kernel < 5.8)
+        kafka_batch_enqueue(event);
+    }
+#else
+    // Direct consumer compiled out (see KAFKA_DIRECT_CONSUMER_ENABLED); batch path only.
+    (void)ctx;
     kafka_batch_enqueue(event);
+#endif
 }
 
 enum parse_result {
@@ -1197,7 +1213,7 @@ static __always_inline enum parse_result kafka_continue_parse_response(void *ctx
 
         if (ret == RET_DONE) {
             extra_debug("enqueue, records_count %d, error_code %d",  response->transaction.records_count, response->transaction.error_code);
-            kafka_batch_enqueue_wrapper(kafka, tup, &response->transaction);
+            kafka_batch_enqueue_wrapper(ctx, kafka, tup, &response->transaction);
             return ret;
         }
     } else {
@@ -1214,7 +1230,7 @@ static __always_inline enum parse_result kafka_continue_parse_response(void *ctx
                 extra_debug("enqueue from new condition, records_count %d, error_code %d",
                     response->transaction.records_count,
                     response->partition_error_code);
-                kafka_batch_enqueue_wrapper(kafka, tup, &response->transaction);
+                kafka_batch_enqueue_wrapper(ctx, kafka, tup, &response->transaction);
                 response->transaction.records_count = 0;
                 response->transaction.error_code = 0;
                 return ret;
@@ -1226,7 +1242,7 @@ static __always_inline enum parse_result kafka_continue_parse_response(void *ctx
         if (ret == RET_DONE) {
             if (response->partitions_count == 0) {
                 extra_debug("enqueue, records_count %d",  response->transaction.records_count);
-                kafka_batch_enqueue_wrapper(kafka, tup, &response->transaction);
+                kafka_batch_enqueue_wrapper(ctx, kafka, tup, &response->transaction);
                 return ret;
             }
 
@@ -1357,7 +1373,7 @@ enum parser_level level, u32 min_api_version, u32 max_api_version, u32 target_ap
         // we have.
         if (response->transaction.records_count) {
             extra_debug("enqueue (loop exceeded), records_count %d", response->transaction.records_count);
-            kafka_batch_enqueue_wrapper(kafka, tup, &response->transaction);
+            kafka_batch_enqueue_wrapper(ctx, kafka, tup, &response->transaction);
         }
         break;
     }
@@ -1586,7 +1602,7 @@ static __always_inline bool kafka_process_response(void *ctx, conn_tuple_t *tup,
 
         if (response->transaction.records_count) {
             extra_debug("enqueue (broken stream), records_count %d", response->transaction.records_count);
-            kafka_batch_enqueue_wrapper(kafka, tup, &response->transaction);
+            kafka_batch_enqueue_wrapper(ctx, kafka, tup, &response->transaction);
         }
 
         bpf_map_delete_elem(&kafka_response, tup);
@@ -1596,7 +1612,7 @@ static __always_inline bool kafka_process_response(void *ctx, conn_tuple_t *tup,
     return kafka_process_new_response(ctx, tup, kafka, pkt, skb_info);
 }
 
-static __always_inline bool kafka_process(conn_tuple_t *tup, kafka_info_t *kafka, pktbuf_t pkt, kafka_telemetry_t *kafka_tel) {
+static __always_inline bool kafka_process(void *ctx, conn_tuple_t *tup, kafka_info_t *kafka, pktbuf_t pkt, kafka_telemetry_t *kafka_tel) {
     /*
         We perform Kafka request validation as we can get kafka traffic that is not relevant for parsing (unsupported requests, responses, etc)
     */
@@ -1782,7 +1798,7 @@ static __always_inline bool kafka_process(conn_tuple_t *tup, kafka_info_t *kafka
 
     if (kafka_header.api_key == KAFKA_PRODUCE && produce_required_acks == 0) {
         // If we have a produce request with required acks set to 0, we can enqueue it immediately, as there will be no produce response.
-        kafka_batch_enqueue_wrapper(kafka, tup, kafka_transaction);
+        kafka_batch_enqueue_wrapper(ctx, kafka, tup, kafka_transaction);
         return true;
     }
 

--- a/pkg/network/ebpf/c/protocols/kafka/usm-events.h
+++ b/pkg/network/ebpf/c/protocols/kafka/usm-events.h
@@ -2,11 +2,31 @@
 #define __KAFKA_USM_EVENTS
 
 #include "protocols/kafka/types.h"
+#include "protocols/direct_consumer.h"
 #include "protocols/events.h"
 
 // This controls the number of Kafka transactions read from userspace at a time
 #define KAFKA_BATCH_SIZE (MAX_BATCH_SIZE(kafka_event_t))
 
 USM_EVENTS_INIT(kafka, kafka_event_t, KAFKA_BATCH_SIZE);
+
+// The DirectConsumer emit path is inlined into kafka_batch_enqueue_wrapper, which the Kafka v12
+// fetch-response parser inlines at every enqueue site (~6x). The extra instructions push the
+// program past the 4096-instruction verifier limit (BPF_MAXINSNS) on kernels < 5.2 - the dead
+// branch counts toward program size even though LOAD_CONSTANT prunes it at verify time.
+// DirectConsumer also requires kernel >= 5.8 (perf/ringbuf output from socket filters), so compile
+// it out where it cannot be used: prebuilt objects load on every kernel (including < 5.2), and
+// runtime-compiled objects built for kernels < 5.8. CO-RE objects only load where BTF is present
+// (>= 5.x, well above the 4096-insn limit) so they keep the path.
+#if defined(COMPILE_PREBUILT) || (defined(COMPILE_RUNTIME) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
+#define KAFKA_DIRECT_CONSUMER_ENABLED 0
+#else
+#define KAFKA_DIRECT_CONSUMER_ENABLED 1
+#endif
+
+#if KAFKA_DIRECT_CONSUMER_ENABLED
+// Initialize DirectConsumer utilities for Kafka protocol
+USM_DIRECT_CONSUMER_INIT(kafka, kafka_event_t, kafka_batch_events)
+#endif
 
 #endif

--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -32,7 +33,8 @@ type protocol struct {
 	telemetry          *Telemetry
 	statkeeper         *StatKeeper
 	inFlightMapCleaner *ddebpf.MapCleaner[KafkaTransactionKey, KafkaTransaction]
-	eventsConsumer     *events.BatchConsumer[EbpfTx]
+	consumer           *events.KernelAdaptiveConsumer[EbpfTx]
+	useDirectConsumer  bool
 
 	kernelTelemetry            *kernelTelemetry
 	kernelTelemetryStopChannel chan struct{}
@@ -248,13 +250,28 @@ func newKafkaProtocol(mgr *manager.Manager, cfg *config.Config) (protocols.Proto
 		return nil, nil
 	}
 
-	return &protocol{
+	p := &protocol{
 		cfg:                        cfg,
 		telemetry:                  NewTelemetry(),
 		kernelTelemetry:            newKernelTelemetry(),
 		kernelTelemetryStopChannel: make(chan struct{}),
 		mgr:                        mgr,
-	}, nil
+	}
+
+	// Create adaptive consumer that determines kernel version and callback internally
+	if err := p.createAdaptiveConsumer(); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Modifiers implements the ModifierProvider interface
+func (p *protocol) Modifiers() []ddebpf.Modifier {
+	if p.consumer == nil {
+		return nil
+	}
+	return p.consumer.Modifiers()
 }
 
 // Name returns the name of the protocol.
@@ -283,32 +300,46 @@ func (p *protocol) ConfigureOptions(opts *manager.Options) {
 		Flags:      mapFlags,
 		EditorFlag: editorFlag,
 	}
-	netifProbeID := manager.ProbeIdentificationPair{
-		EBPFFuncName: netifProbe,
-		UID:          eventStreamName,
+	// Only activate the flush tracepoint when using BatchConsumer.
+	// DirectConsumer doesn't need it since it uses direct event output.
+	if !p.useDirectConsumer {
+		netifProbeID := manager.ProbeIdentificationPair{
+			EBPFFuncName: netifProbe,
+			UID:          eventStreamName,
+		}
+		if usmconfig.ShouldUseNetifReceiveSKBCoreKprobe() {
+			netifProbeID.EBPFFuncName = netifProbe414
+		}
+		opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: netifProbeID})
+	} else {
+		// When using DirectConsumer, exclude flush probes to avoid loading/verifying them
+		opts.ExcludedFunctions = append(opts.ExcludedFunctions, netifProbe, netifProbe414)
 	}
-	if usmconfig.ShouldUseNetifReceiveSKBCoreKprobe() {
-		netifProbeID.EBPFFuncName = netifProbe414
-	}
-	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: netifProbeID})
+
 	events.Configure(p.cfg, eventStreamName, p.mgr, opts)
 	utils.EnableOption(opts, "kafka_monitoring_enabled")
+	utils.AddBoolConst(opts, p.useDirectConsumer, "kafka_use_direct_consumer")
 }
 
 // PreStart creates the kafka events consumer and starts it.
 func (p *protocol) PreStart() error {
-	var err error
-	p.eventsConsumer, err = events.NewBatchConsumer(
-		eventStreamName,
-		p.mgr,
-		p.processKafka,
-	)
-	if err != nil {
-		return err
+	// If using BatchConsumer, create it now (after manager initialization).
+	// The DirectConsumer is already created in the factory via createAdaptiveConsumer().
+	if !p.useDirectConsumer {
+		batchConsumer, err := events.NewBatchConsumer(eventStreamName, p.mgr, p.processKafka)
+		if err != nil {
+			return err
+		}
+		p.consumer = events.NewKernelAdaptiveConsumer[EbpfTx](
+			batchConsumer,
+			[]ddebpf.Modifier{}, // BatchConsumer needs no modifiers
+		)
 	}
 
 	p.statkeeper = NewStatkeeper(p.cfg, p.telemetry)
-	p.eventsConsumer.Start()
+
+	// Start the consumer (works for both DirectConsumer and BatchConsumer)
+	p.consumer.Start()
 
 	return nil
 }
@@ -323,8 +354,8 @@ func (p *protocol) PostStart() error {
 func (p *protocol) Stop() {
 	// inFlightMapCleaner handles nil receiver pointers.
 	p.inFlightMapCleaner.Stop()
-	if p.eventsConsumer != nil {
-		p.eventsConsumer.Stop()
+	if p.consumer != nil {
+		p.consumer.Stop()
 	}
 	if p.kernelTelemetryStopChannel != nil {
 		close(p.kernelTelemetryStopChannel)
@@ -369,6 +400,54 @@ func (p *protocol) processKafka(events []EbpfTx) {
 	}
 }
 
+func (p *protocol) processKafkaDirect(event *EbpfTx) {
+	p.telemetry.Count(&event.Transaction)
+	p.statkeeper.Process(event)
+}
+
+// createAdaptiveConsumer creates the appropriate consumer based on configuration and kernel version
+// and determines which callback method to use internally.
+func (p *protocol) createAdaptiveConsumer() error {
+	// Check if direct consumer is explicitly requested via configuration
+	if p.cfg.KafkaUseDirectConsumer {
+		// The eBPF direct-emit path is compiled out of the prebuilt object (it would push the
+		// Kafka v12 parser past the 4096-instruction verifier limit on kernels < 5.2). Only CO-RE
+		// and runtime-compiled objects keep it, so don't enable the userspace DirectConsumer when
+		// neither is available, otherwise we'd read from a ring buffer the program never writes to.
+		if !p.cfg.EnableCORE && !p.cfg.EnableRuntimeCompiler {
+			log.Warnf("Kafka monitoring: direct consumer requested but neither CO-RE nor runtime compilation is enabled; the prebuilt object does not emit direct events, falling back to batch consumer")
+			p.useDirectConsumer = false
+		} else if events.SupportsDirectConsumer() {
+			// Use DirectConsumer for kernel ≥5.8 (supports bpf_perf_event_output in socket filters)
+			directConsumer, err := events.NewDirectConsumer(eventStreamName, p.processKafkaDirect, p.cfg)
+			if err != nil {
+				return err
+			}
+			p.consumer = events.NewKernelAdaptiveConsumer[EbpfTx](
+				directConsumer,
+				[]ddebpf.Modifier{&directConsumer.EventHandler},
+			)
+			p.useDirectConsumer = true
+			log.Debugf("Kafka monitoring: using direct consumer (requested via configuration)")
+		} else {
+			// Fall back to BatchConsumer on unsupported kernels
+			kernelVersion, err := kernel.HostVersion()
+			if err != nil {
+				log.Warnf("Kafka monitoring: direct consumer requested but unable to determine kernel version (%v), falling back to batch consumer", err)
+			} else {
+				log.Warnf("Kafka monitoring: direct consumer requested but kernel version %v < 5.8.0, falling back to batch consumer", kernelVersion)
+			}
+			p.useDirectConsumer = false
+		}
+	} else {
+		// Default behavior: use BatchConsumer regardless of kernel version
+		log.Debugf("Kafka monitoring: using batch consumer (default behavior)")
+		p.useDirectConsumer = false
+	}
+
+	return nil
+}
+
 func (p *protocol) setupInFlightMapCleaner() error {
 	kafkaInFlight, _, err := p.mgr.GetMap(inFlightMap)
 	if err != nil {
@@ -393,7 +472,7 @@ func (p *protocol) setupInFlightMapCleaner() error {
 // The format of the stats:
 // [source, dest tuple, request path] -> RequestStats object
 func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
-	p.eventsConsumer.Sync()
+	p.consumer.Sync()
 	p.telemetry.Log()
 	stats := p.statkeeper.GetAndResetAllStats()
 	return &protocols.ProtocolStats{

--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -24,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -405,47 +404,51 @@ func (p *protocol) processKafkaDirect(event *EbpfTx) {
 	p.statkeeper.Process(event)
 }
 
-// createAdaptiveConsumer creates the appropriate consumer based on configuration and kernel version
-// and determines which callback method to use internally.
+// createAdaptiveConsumer creates the appropriate consumer (DirectConsumer or BatchConsumer)
+// based on configuration, and determines which callback method to use internally. When the
+// BatchConsumer is used it is created later, in PreStart.
 func (p *protocol) createAdaptiveConsumer() error {
-	// Check if direct consumer is explicitly requested via configuration
-	if p.cfg.KafkaUseDirectConsumer {
-		// The eBPF direct-emit path is compiled out of the prebuilt object (it would push the
-		// Kafka v12 parser past the 4096-instruction verifier limit on kernels < 5.2). Only CO-RE
-		// and runtime-compiled objects keep it, so don't enable the userspace DirectConsumer when
-		// neither is available, otherwise we'd read from a ring buffer the program never writes to.
-		if !p.cfg.EnableCORE && !p.cfg.EnableRuntimeCompiler {
-			log.Warnf("Kafka monitoring: direct consumer requested but neither CO-RE nor runtime compilation is enabled; the prebuilt object does not emit direct events, falling back to batch consumer")
-			p.useDirectConsumer = false
-		} else if events.SupportsDirectConsumer() {
-			// Use DirectConsumer for kernel ≥5.8 (supports bpf_perf_event_output in socket filters)
-			directConsumer, err := events.NewDirectConsumer(eventStreamName, p.processKafkaDirect, p.cfg)
-			if err != nil {
-				return err
-			}
-			p.consumer = events.NewKernelAdaptiveConsumer[EbpfTx](
-				directConsumer,
-				[]ddebpf.Modifier{&directConsumer.EventHandler},
-			)
-			p.useDirectConsumer = true
-			log.Debugf("Kafka monitoring: using direct consumer (requested via configuration)")
+	if !shouldUseDirectConsumer(p.cfg) {
+		if p.cfg.KafkaUseDirectConsumer {
+			log.Warnf("Kafka monitoring: direct consumer requested but not usable (kernel < 5.8, or the prebuilt object may be loaded, which has the Kafka direct path compiled out); falling back to batch consumer")
 		} else {
-			// Fall back to BatchConsumer on unsupported kernels
-			kernelVersion, err := kernel.HostVersion()
-			if err != nil {
-				log.Warnf("Kafka monitoring: direct consumer requested but unable to determine kernel version (%v), falling back to batch consumer", err)
-			} else {
-				log.Warnf("Kafka monitoring: direct consumer requested but kernel version %v < 5.8.0, falling back to batch consumer", kernelVersion)
-			}
-			p.useDirectConsumer = false
+			log.Debugf("Kafka monitoring: using batch consumer (default behavior)")
 		}
-	} else {
-		// Default behavior: use BatchConsumer regardless of kernel version
-		log.Debugf("Kafka monitoring: using batch consumer (default behavior)")
 		p.useDirectConsumer = false
+		return nil
 	}
 
+	// Use DirectConsumer for kernel >= 5.8 (supports bpf_perf_event_output in socket filters).
+	directConsumer, err := events.NewDirectConsumer(eventStreamName, p.processKafkaDirect, p.cfg)
+	if err != nil {
+		return err
+	}
+	p.consumer = events.NewKernelAdaptiveConsumer[EbpfTx](
+		directConsumer,
+		[]ddebpf.Modifier{&directConsumer.EventHandler},
+	)
+	p.useDirectConsumer = true
+	log.Debugf("Kafka monitoring: using direct consumer (requested via configuration)")
 	return nil
+}
+
+// shouldUseDirectConsumer reports whether Kafka should use the DirectConsumer. It requires a
+// kernel >= 5.8.0 (for perf/ring-buffer output from socket filters) and an eBPF object that
+// keeps the Kafka direct-emit path. The prebuilt object compiles that path out (it would
+// otherwise exceed the 4096-instruction verifier limit on kernels < 5.2), so direct is only
+// safe when the prebuilt object cannot be the one that loads: a CO-RE or runtime-compiled
+// build is selected (prebuilt is not the sole option) AND prebuilt fallback is disabled (a
+// CO-RE/runtime load failure cannot silently drop to prebuilt). With both held, the loader
+// either loads a CO-RE/runtime-compiled object (which keep the direct path) or errors out;
+// it never silently lands on prebuilt.
+func shouldUseDirectConsumer(cfg *config.Config) bool {
+	if !cfg.KafkaUseDirectConsumer {
+		return false
+	}
+	if !events.SupportsDirectConsumer() {
+		return false
+	}
+	return (cfg.EnableCORE || cfg.EnableRuntimeCompiler) && !cfg.AllowPrebuiltFallback
 }
 
 func (p *protocol) setupInFlightMapCleaner() error {

--- a/pkg/network/protocols/kafka/protocol_test.go
+++ b/pkg/network/protocols/kafka/protocol_test.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
+)
+
+// TestShouldUseDirectConsumer verifies that the DirectConsumer is only selected when the
+// loaded eBPF object cannot be the prebuilt one (which has the Kafka direct-emit path
+// compiled out). In particular, with prebuilt fallback enabled a CO-RE/runtime load failure
+// could silently drop to prebuilt, so Kafka must use the batch consumer in that case.
+func TestShouldUseDirectConsumer(t *testing.T) {
+	if !events.SupportsDirectConsumer() {
+		t.Skip("direct consumer requires kernel >= 5.8.0")
+	}
+
+	// CO-RE enabled, prebuilt fallback disabled: prebuilt can never load, so direct is safe.
+	newCfg := func() *config.Config {
+		c := config.New()
+		c.KafkaUseDirectConsumer = true
+		c.EnableCORE = true
+		c.EnableRuntimeCompiler = false
+		c.AllowPrebuiltFallback = false
+		return c
+	}
+
+	require.True(t, shouldUseDirectConsumer(newCfg()),
+		"CO-RE enabled and prebuilt fallback disabled: prebuilt cannot load, direct is safe")
+
+	cfgFallback := newCfg()
+	cfgFallback.AllowPrebuiltFallback = true
+	require.False(t, shouldUseDirectConsumer(cfgFallback),
+		"prebuilt fallback enabled: a CO-RE/runtime load failure could drop to the prebuilt object (direct path compiled out), so use the batch consumer")
+
+	cfgPrebuiltOnly := newCfg()
+	cfgPrebuiltOnly.EnableCORE = false
+	cfgPrebuiltOnly.EnableRuntimeCompiler = false
+	require.False(t, shouldUseDirectConsumer(cfgPrebuiltOnly),
+		"neither CO-RE nor runtime enabled: prebuilt is the only option, use the batch consumer")
+
+	cfgNotRequested := newCfg()
+	cfgNotRequested.KafkaUseDirectConsumer = false
+	require.False(t, shouldUseDirectConsumer(cfgNotRequested),
+		"direct consumer not requested: use the batch consumer")
+}

--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/kafka"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
@@ -546,6 +547,113 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 			tt.testBody(t, &tt.context, monitor)
 		})
 	}
+}
+
+// TestDirectConsumerFunctionality verifies that Kafka stats are captured when the
+// direct consumer is enabled (kernel >= 5.8.0), for both plaintext and GoTLS traffic,
+// mirroring the batch-consumer path. The TLS case also exercises the uprobe emit path.
+func (s *KafkaProtocolParsingSuite) TestDirectConsumerFunctionality() {
+	t := s.T()
+
+	if !events.SupportsDirectConsumer() {
+		t.Skip("Direct consumer requires kernel >= 5.8.0")
+	}
+
+	for mode, name := range map[bool]string{false: "without TLS", true: "with TLS"} {
+		t.Run(name, func(t *testing.T) {
+			if mode && !gotlsutils.GoTLSSupported(t, NewUSMEmptyConfig()) {
+				t.Skip("GoTLS not supported for this setup")
+			}
+			s.testDirectConsumerFunctionality(t, mode)
+		})
+	}
+}
+
+func (s *KafkaProtocolParsingSuite) testDirectConsumerFunctionality(t *testing.T, tls bool) {
+	const (
+		targetHost = "127.0.0.1"
+		serverHost = "127.0.0.1"
+		unixPath   = "/tmp/transparent.sock"
+	)
+
+	port := kafkaPort
+	if tls {
+		port = kafkaTLSPort
+	}
+
+	serverAddress := net.JoinHostPort(serverHost, port)
+	targetAddress := net.JoinHostPort(targetHost, port)
+
+	dialFn := func(ctx context.Context, _, _ string) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "unix", unixPath)
+	}
+
+	// With non-TLS, packets are seen twice (Docker), so the expected count is doubled.
+	// In the TLS case the data comes from uprobes on the binary, so it is seen once.
+	fixCount := func(count int) int {
+		if tls {
+			return count
+		}
+		return count * 2
+	}
+
+	version := kversion.V2_5_0()
+	produceVersion, found := version.LookupMaxKeyVersion(kafka.ProduceAPIKey)
+	require.True(t, found)
+	fetchVersion, found := version.LookupMaxKeyVersion(kafka.FetchAPIKey)
+	require.True(t, found)
+
+	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, serverAddress, tls, false)
+	t.Cleanup(cancel)
+	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
+
+	// Enable the direct consumer for Kafka.
+	cfg := getDefaultTestConfiguration(tls)
+	cfg.KafkaUseDirectConsumer = true
+
+	monitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
+	if tls && cfg.EnableGoTLSSupport {
+		utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+	}
+
+	topicName := s.getTopicName()
+	client, err := kafka.NewClient(kafka.Options{
+		ServerAddress: targetAddress,
+		DialFn:        dialFn,
+		CustomOptions: []kgo.Opt{
+			kgo.MaxVersions(version),
+			kgo.RecordPartitioner(kgo.ManualPartitioner()),
+			kgo.ClientID("xk6-kafka_linux_amd64@foobar (github.com/segmentio/kafka-go)"),
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Client.Close() })
+	require.NoError(t, client.CreateTopic(topicName))
+
+	ctxTimeout, cancelTimeout := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancelTimeout()
+
+	record := &kgo.Record{Topic: topicName, Value: []byte("Hello Kafka!")}
+	require.NoError(t, client.Client.ProduceSync(ctxTimeout, record).FirstErr(), "record had a produce error while synchronously producing")
+
+	req := kmsg.NewFetchRequest()
+	topic := kmsg.NewFetchRequestTopic()
+	topic.Topic = topicName
+	partition := kmsg.NewFetchRequestTopicPartition()
+	partition.PartitionMaxBytes = 1024
+	topic.Partitions = append(topic.Partitions, partition)
+	req.Topics = append(req.Topics, topic)
+	_, err = req.RequestWith(ctxTimeout, client.Client)
+	require.NoError(t, err)
+
+	getAndValidateKafkaStats(t, monitor, fixCount(2), topicName, kafkaParsingValidation{
+		expectedNumberOfProduceRequests: fixCount(1),
+		expectedNumberOfFetchRequests:   fixCount(1),
+		expectedAPIVersionProduce:       int(produceVersion),
+		expectedAPIVersionFetch:         int(fetchVersion),
+		tlsEnabled:                      tls,
+	}, kafkaSuccessErrorCode)
 }
 
 func generateFetchRequest(apiVersion int, topic string) kmsg.FetchRequest {


### PR DESCRIPTION
### What does this PR do?

Migrates USM's Kafka protocol from the legacy batch-map event-delivery path to
the **DirectConsumer**, gated behind a new per-protocol config flag
`service_monitoring_config.kafka.use_direct_consumer` (default `false`).

When enabled on a supported kernel (>= 5.8), Kafka events are written straight
from the eBPF socket-filter/uprobe programs to a perf/ring buffer via
`pkg/ebpf/perf.EventHandler`, instead of being accumulated in per-CPU batch
maps and flushed by the `netif_receive_skb` probe. On older kernels the
protocol transparently falls back to the existing batch consumer.

This is the Kafka step of extending the DirectConsumer mechanism (built for
HTTP in USMON-1458, PR #39774) to all USM protocols.

### Motivation

The batch path is heavy and fragile: extra maps (`kafka_batches`,
`kafka_batch_state`), a flush probe, offset bookkeeping, userspace map-walking,
a known race between the socket-filter and uprobe (TLS) flush paths, and poor
built-in telemetry. On modern kernels socket filters can write directly to
perf/ring buffers, which removes the batch maps and flush probe, eliminates the
flush race, and gives lost-event / ring-buffer telemetry for free.

### Describe how you validated your changes

- New config unit test in `pkg/network/config/usm_config_test.go` covering the
  `kafka.use_direct_consumer` flag (default off, env/yaml override).
- New `TestDirectConsumerFunctionality` in `pkg/network/usm/kafka_monitor_test.go`
  exercising the direct path end-to-end (plaintext + TLS, which traces an
  external proxy).
- Batch-path regression: existing Kafka monitor tests still pass with the flag
  off.
- Built and ran locally on an ubuntu-24 / kernel 6.8 box in both
  `runtime_compiled` and `CO-RE` load modes; `system-probe.build` and
  `linter.go` clean.

### Additional Notes

- Default-off, internal tuning flag; no behavior change unless explicitly
  enabled. No release note for now, matching the HTTP precedent (PR #39774).
- The eBPF DirectConsumer constant is protocol-specific
  (`kafka_use_direct_consumer`) so it can be toggled independently of HTTP and
  the other protocols (they share a single USM eBPF object).
- Opening as a **draft** to let CI run before requesting review.
