### PR TITLE
[USMON-1493] usm: http2: use DirectConsumer for event delivery

### DIFF
--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -929,6 +929,10 @@ properties:
             node_type: setting
             type: boolean
             default: false
+          use_direct_consumer:
+            node_type: setting
+            type: boolean
+            default: false
       http2_dynamic_table_map_cleaner_interval_seconds:
         node_type: setting
         type: integer

--- a/pkg/config/setup/system_probe_usm.go
+++ b/pkg/config/setup/system_probe_usm.go
@@ -96,6 +96,7 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// Tree structure
 	cfg.BindEnvAndSetDefault("service_monitoring_config.http2.enabled", false)
 	cfg.BindEnvAndSetDefault("service_monitoring_config.http2.dynamic_table_map_cleaner_interval_seconds", 30)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http2.use_direct_consumer", false)
 
 	// Legacy bindings for backward compatibility (deprecated)
 	cfg.BindEnvAndSetDefault("service_monitoring_config.enable_http2_monitoring", false)

--- a/pkg/network/config/usm_config.go
+++ b/pkg/network/config/usm_config.go
@@ -115,6 +115,11 @@ type USMConfig struct {
 	// HTTP2DynamicTableMapCleanerInterval is the interval to run the cleaner function
 	HTTP2DynamicTableMapCleanerInterval time.Duration
 
+	// HTTP2UseDirectConsumer forces the use of direct consumer for HTTP2 monitoring instead of batch consumer
+	// When true, direct consumer is used if kernel supports it (>=5.8.0), otherwise falls back to batch consumer
+	// When false (default), batch consumer is always used regardless of kernel version
+	HTTP2UseDirectConsumer bool
+
 	// ========================================
 	// Kafka Protocol Configuration
 	// ========================================
@@ -218,6 +223,7 @@ func NewUSMConfig(cfg model.Config) *USMConfig {
 		// HTTP2 Protocol Configuration
 		EnableHTTP2Monitoring:               cfg.GetBool(sysconfig.FullKeyPath(smNS, "http2", "enabled")),
 		HTTP2DynamicTableMapCleanerInterval: time.Duration(cfg.GetInt(sysconfig.FullKeyPath(smNS, "http2", "dynamic_table_map_cleaner_interval_seconds"))) * time.Second,
+		HTTP2UseDirectConsumer:              cfg.GetBool(sysconfig.FullKeyPath(smNS, "http2", "use_direct_consumer")),
 
 		// Kafka Protocol Configuration
 		EnableKafkaMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "kafka", "enabled")),

--- a/pkg/network/config/usm_config_test.go
+++ b/pkg/network/config/usm_config_test.go
@@ -1782,3 +1782,28 @@ func TestHTTPUseDirectConsumer(t *testing.T) {
 		assert.True(t, cfg.HTTPUseDirectConsumer)
 	})
 }
+
+func TestHTTP2UseDirectConsumer(t *testing.T) {
+	t.Run("default value", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		cfg := New()
+
+		assert.False(t, cfg.HTTP2UseDirectConsumer)
+	})
+
+	t.Run("via YAML", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetInTest("service_monitoring_config.http2.use_direct_consumer", true)
+		cfg := New()
+
+		assert.True(t, cfg.HTTP2UseDirectConsumer)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP2_USE_DIRECT_CONSUMER", "true")
+		cfg := New()
+
+		assert.True(t, cfg.HTTP2UseDirectConsumer)
+	})
+}

--- a/pkg/network/ebpf/c/protocols/direct_consumer.h
+++ b/pkg/network/ebpf/c/protocols/direct_consumer.h
@@ -4,6 +4,13 @@
 #include "bpf_telemetry.h"
 #include "bpf_builtins.h"
 
+// Stringify helper for building per-stream LOAD_CONSTANT names (e.g.
+// "http2_ringbuffer_wakeup_size"). Mirrors events.h; guarded so it does not
+// clash when both headers are included in the same translation unit.
+#ifndef _STR
+#define _STR(x) #x
+#endif
+
 /* USM_DIRECT_CONSUMER_INIT defines utility functions for DirectConsumer pattern.
    DirectConsumer is used for kernel >= 5.8 where events are sent directly via
    bpf_perf_event_output/bpf_ringbuf_output instead of map-based batching.
@@ -20,7 +27,10 @@
 #define USM_DIRECT_CONSUMER_INIT(name, event_type, map_name)                                                \
     static __always_inline __u64 name##_get_ringbuf_flags(size_t data_size) {                               \
         __u64 ringbuffer_wakeup_size = 0;                                                                   \
-        LOAD_CONSTANT("ringbuffer_wakeup_size", ringbuffer_wakeup_size);                                    \
+        /* Per-stream constant: protocols with two simultaneous streams (e.g. http2 +     \
+           terminated_http2) need independent wakeup thresholds, so the name is namespaced \
+           by `name` to match the Go side (NewDirectConsumer installs <proto>_ringbuffer_wakeup_size). */ \
+        LOAD_CONSTANT(_STR(name##_ringbuffer_wakeup_size), ringbuffer_wakeup_size);                                    \
         if (ringbuffer_wakeup_size == 0) {                                                                  \
             return 0;                                                                                       \
         }                                                                                                   \

--- a/pkg/network/ebpf/c/protocols/http2/decoding-common.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-common.h
@@ -124,7 +124,7 @@ static __always_inline void update_path_size_telemetry(http2_telemetry_t *http2_
 // stream, before it actually enqueues the stream's stats.
 //
 // See RFC 7540 section 5.1: https://datatracker.ietf.org/doc/html/rfc7540#section-5.1
-static __always_inline void handle_end_of_stream(http2_stream_t *current_stream, http2_stream_key_t *http2_stream_key_template, http2_telemetry_t *http2_tel) {
+static __always_inline void handle_end_of_stream(void *ctx, http2_stream_t *current_stream, http2_stream_key_t *http2_stream_key_template, http2_telemetry_t *http2_tel) {
     // We want to see the EOS twice for a given stream: one for the client, one for the server.
     if (!current_stream->end_of_stream_seen) {
         current_stream->end_of_stream_seen = true;
@@ -139,8 +139,18 @@ static __always_inline void handle_end_of_stream(http2_stream_t *current_stream,
     if (event) {
         event->tuple = http2_stream_key_template->tup;
         event->stream = *current_stream;
-        // enqueue
-        http2_batch_enqueue(event);
+
+        // Check which consumer type to use based on kernel version capability
+        __u64 http2_use_direct_consumer = 0;
+        LOAD_CONSTANT("http2_use_direct_consumer", http2_use_direct_consumer);
+
+        if (http2_use_direct_consumer) {
+            // Direct consumer path - use perf/ring buffer output (kernel >= 5.8)
+            http2_output_event(ctx, event);
+        } else {
+            // Batch consumer path - use map-based batching (kernel < 5.8)
+            http2_batch_enqueue(event);
+        }
     }
 
     bpf_map_delete_elem(&http2_in_flight, http2_stream_key_template);

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -131,7 +131,7 @@ int uprobe__http2_tls_eos_parser(struct pt_regs *ctx) {
 
     pktbuf_t pkt = pktbuf_from_tls(ctx, &dispatcher_args_copy);
 
-    eos_parser(pkt, &dispatcher_args_copy, &dispatcher_args_copy.tup);
+    eos_parser(ctx, pkt, &dispatcher_args_copy, &dispatcher_args_copy.tup);
 
     return 0;
 }
@@ -149,7 +149,16 @@ int uprobe__http2_tls_termination(struct pt_regs *ctx) {
 
     bpf_map_delete_elem(&tls_http2_iterations, &args->tup);
 
-    terminated_http2_batch_enqueue(&args->tup);
+    // Check which consumer type to use based on kernel version capability
+    __u64 http2_use_direct_consumer = 0;
+    LOAD_CONSTANT("http2_use_direct_consumer", http2_use_direct_consumer);
+    if (http2_use_direct_consumer) {
+        // Direct consumer path - use perf/ring buffer output (kernel >= 5.8)
+        terminated_http2_output_event(ctx, &args->tup);
+    } else {
+        // Batch consumer path - use map-based batching (kernel < 5.8)
+        terminated_http2_batch_enqueue(&args->tup);
+    }
     // Deleting the entry for the original tuple.
     bpf_map_delete_elem(&http2_incomplete_frames, &args->tup);
     bpf_map_delete_elem(&http2_dynamic_counter_table, &args->tup);

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -757,7 +757,16 @@ int socket__http2_handle_first_frame(struct __sk_buff *skb) {
         // Deleting the entry for the original tuple.
         bpf_map_delete_elem(&http2_incomplete_frames, &dispatcher_args_copy.tup);
         bpf_map_delete_elem(&http2_dynamic_counter_table, &dispatcher_args_copy.tup);
-        terminated_http2_batch_enqueue(&dispatcher_args_copy.tup);
+        // Check which consumer type to use based on kernel version capability
+        __u64 http2_use_direct_consumer = 0;
+        LOAD_CONSTANT("http2_use_direct_consumer", http2_use_direct_consumer);
+        if (http2_use_direct_consumer) {
+            // Direct consumer path - use perf/ring buffer output (kernel >= 5.8)
+            terminated_http2_output_event(skb, &dispatcher_args_copy.tup);
+        } else {
+            // Batch consumer path - use map-based batching (kernel < 5.8)
+            terminated_http2_batch_enqueue(&dispatcher_args_copy.tup);
+        }
         // In case of local host, the protocol will be deleted for both (client->server) and (server->client),
         // so we won't reach for that path again in the code, so we're deleting the opposite side as well.
         flip_tuple(&dispatcher_args_copy.tup);
@@ -1108,7 +1117,7 @@ int socket__http2_dynamic_table_cleaner(struct __sk_buff *skb) {
     return 0;
 }
 
-static __always_inline void eos_parser(pktbuf_t pkt, void *map_key, conn_tuple_t *tup) {
+static __always_inline void eos_parser(void *ctx, pktbuf_t pkt, void *map_key, conn_tuple_t *tup) {
     const __u32 zero = 0;
 
     pktbuf_map_lookup_option_t http2_iterations_array[] = {
@@ -1190,7 +1199,7 @@ static __always_inline void eos_parser(pktbuf_t pkt, void *map_key, conn_tuple_t
         } else if ((current_frame.frame.flags & HTTP2_END_OF_STREAM) == HTTP2_END_OF_STREAM) {
             __sync_fetch_and_add(&http2_tel->end_of_stream, 1);
         }
-        handle_end_of_stream(current_stream, &http2_ctx->http2_stream_key, http2_tel);
+        handle_end_of_stream(ctx, current_stream, &http2_ctx->http2_stream_key, http2_tel);
 
         // If we reached here, it means that we saw End Of Stream. If the End of Stream came from a request,
         // thus we except it to have a valid path and method. If the End of Stream came from a response, we except it to
@@ -1239,7 +1248,7 @@ int socket__http2_eos_parser(struct __sk_buff *skb) {
 
     pktbuf_t pkt = pktbuf_from_skb(skb, &dispatcher_args_copy.skb_info);
 
-    eos_parser(pkt, &dispatcher_args_copy, &dispatcher_args_copy.tup);
+    eos_parser(skb, pkt, &dispatcher_args_copy, &dispatcher_args_copy.tup);
     return 0;
 }
 #endif

--- a/pkg/network/ebpf/c/protocols/http2/usm-events.h
+++ b/pkg/network/ebpf/c/protocols/http2/usm-events.h
@@ -2,10 +2,16 @@
 #define __HTTP2_USM_EVENTS_H
 
 #include "protocols/http2/decoding-defs.h"
+#include "protocols/direct_consumer.h"
 #include "protocols/events.h"
 
 USM_EVENTS_INIT(http2, http2_event_t, HTTP2_BATCH_SIZE);
 
 USM_EVENTS_INIT(terminated_http2, conn_tuple_t, HTTP2_TERMINATED_BATCH_SIZE);
+
+// Initialize DirectConsumer utilities for both HTTP/2 event streams (a single
+// service_monitoring_config.http2.use_direct_consumer flag controls both).
+USM_DIRECT_CONSUMER_INIT(http2, http2_event_t, http2_batch_events)
+USM_DIRECT_CONSUMER_INIT(terminated_http2, conn_tuple_t, terminated_http2_batch_events)
 
 #endif

--- a/pkg/network/protocols/events/direct_consumer.go
+++ b/pkg/network/protocols/events/direct_consumer.go
@@ -152,7 +152,12 @@ func NewDirectConsumer[V any](proto string, callback func(*V), config *config.Co
 		mode,
 		perf.SendTelemetry(config.InternalTelemetryEnabled),
 		perf.RingBufferEnabledConstantName("ringbuffers_enabled"),
-		perf.RingBufferWakeupSize("ringbuffer_wakeup_size", ringBufferWakeupSize),
+		// Namespace the wakeup-size constant per stream. The size is derived from the
+		// event type (eventSize above), so protocols with two simultaneous streams
+		// (e.g. http2 + terminated_http2) compute different values; a shared constant
+		// name would let one stream's EventHandler overwrite the other's threshold.
+		// Must match the eBPF side: LOAD_CONSTANT(_STR(name##_ringbuffer_wakeup_size)).
+		perf.RingBufferWakeupSize(proto+"_ringbuffer_wakeup_size", ringBufferWakeupSize),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create event handler for protocol %s: %w", proto, err)

--- a/pkg/network/protocols/http2/dynamic_table.go
+++ b/pkg/network/protocols/http2/dynamic_table.go
@@ -18,6 +18,8 @@ import (
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -28,8 +30,10 @@ const (
 type DynamicTable struct {
 	cfg *config.Config
 
-	// terminatedConnectionsEventsConsumer is the consumer used to receive terminated connections events from the kernel.
-	terminatedConnectionsEventsConsumer *events.BatchConsumer[netebpf.ConnTuple]
+	// consumer is the consumer used to receive terminated connections events from the kernel.
+	consumer *events.KernelAdaptiveConsumer[netebpf.ConnTuple]
+	// useDirectConsumer indicates whether the direct consumer is used for the terminated connections stream.
+	useDirectConsumer bool
 	// terminatedConnections is the list of terminated connections received from the kernel.
 	terminatedConnections []netebpf.ConnTuple
 	// terminatedConnectionMux is used to protect the terminated connections list from concurrent access.
@@ -39,10 +43,56 @@ type DynamicTable struct {
 }
 
 // NewDynamicTable creates a new dynamic table.
-func NewDynamicTable(cfg *config.Config) *DynamicTable {
-	return &DynamicTable{
+func NewDynamicTable(cfg *config.Config) (*DynamicTable, error) {
+	dt := &DynamicTable{
 		cfg: cfg,
 	}
+
+	// Create adaptive consumer that determines kernel version and callback internally
+	if err := dt.createAdaptiveConsumer(); err != nil {
+		return nil, err
+	}
+
+	return dt, nil
+}
+
+// createAdaptiveConsumer creates the appropriate consumer (direct or batch) for the
+// terminated connections stream, based on configuration and kernel version.
+func (dt *DynamicTable) createAdaptiveConsumer() error {
+	if dt.cfg.HTTP2UseDirectConsumer {
+		if events.SupportsDirectConsumer() {
+			directConsumer, err := events.NewDirectConsumer(terminatedConnectionsEventStream, dt.processTerminatedConnectionsDirect, dt.cfg)
+			if err != nil {
+				return err
+			}
+			dt.consumer = events.NewKernelAdaptiveConsumer[netebpf.ConnTuple](
+				directConsumer,
+				[]ddebpf.Modifier{&directConsumer.EventHandler},
+			)
+			dt.useDirectConsumer = true
+			log.Debugf("HTTP2 terminated connections monitoring: using direct consumer (requested via configuration)")
+		} else {
+			kernelVersion, err := kernel.HostVersion()
+			if err != nil {
+				log.Warnf("HTTP2 terminated connections monitoring: direct consumer requested but unable to determine kernel version (%v), falling back to batch consumer", err)
+			} else {
+				log.Warnf("HTTP2 terminated connections monitoring: direct consumer requested but kernel version %v < 5.8.0, falling back to batch consumer", kernelVersion)
+			}
+			dt.useDirectConsumer = false
+		}
+	} else {
+		dt.useDirectConsumer = false
+	}
+
+	return nil
+}
+
+// Modifiers returns the eBPF manager modifiers required by the terminated connections consumer.
+func (dt *DynamicTable) Modifiers() []ddebpf.Modifier {
+	if dt.consumer == nil {
+		return nil
+	}
+	return dt.consumer.Modifiers()
 }
 
 // configureOptions configures the perf handler options for the map cleaner.
@@ -51,17 +101,21 @@ func (dt *DynamicTable) configureOptions(mgr *manager.Manager, opts *manager.Opt
 }
 
 // preStart sets up the terminated connections events consumer.
-func (dt *DynamicTable) preStart(mgr *manager.Manager) (err error) {
-	dt.terminatedConnectionsEventsConsumer, err = events.NewBatchConsumer(
-		terminatedConnectionsEventStream,
-		mgr,
-		dt.processTerminatedConnections,
-	)
-	if err != nil {
-		return
+func (dt *DynamicTable) preStart(mgr *manager.Manager) error {
+	// If using BatchConsumer, create it now (after manager initialization).
+	// The DirectConsumer is already created in NewDynamicTable via createAdaptiveConsumer().
+	if !dt.useDirectConsumer {
+		batchConsumer, err := events.NewBatchConsumer(terminatedConnectionsEventStream, mgr, dt.processTerminatedConnections)
+		if err != nil {
+			return err
+		}
+		dt.consumer = events.NewKernelAdaptiveConsumer[netebpf.ConnTuple](
+			batchConsumer,
+			[]ddebpf.Modifier{}, // BatchConsumer needs no modifiers
+		)
 	}
 
-	dt.terminatedConnectionsEventsConsumer.Start()
+	dt.consumer.Start()
 
 	return nil
 }
@@ -76,6 +130,14 @@ func (dt *DynamicTable) processTerminatedConnections(events []netebpf.ConnTuple)
 	dt.terminatedConnectionMux.Lock()
 	defer dt.terminatedConnectionMux.Unlock()
 	dt.terminatedConnections = append(dt.terminatedConnections, events...)
+}
+
+// processTerminatedConnectionsDirect processes a single terminated connection received
+// from the kernel via the direct consumer.
+func (dt *DynamicTable) processTerminatedConnectionsDirect(event *netebpf.ConnTuple) {
+	dt.terminatedConnectionMux.Lock()
+	defer dt.terminatedConnectionMux.Unlock()
+	dt.terminatedConnections = append(dt.terminatedConnections, *event)
 }
 
 // setupDynamicTableMapCleaner sets up the map cleaner used to clear entries of terminated connections from the kernel map.
@@ -93,7 +155,7 @@ func (dt *DynamicTable) setupDynamicTableMapCleaner(mgr *manager.Manager, cfg *c
 	terminatedConnectionsMap := make(map[netebpf.ConnTuple]struct{})
 	mapCleaner.Start(cfg.HTTP2DynamicTableMapCleanerInterval,
 		func() bool {
-			dt.terminatedConnectionsEventsConsumer.Sync()
+			dt.consumer.Sync()
 			dt.terminatedConnectionMux.Lock()
 			for _, conn := range dt.terminatedConnections {
 				terminatedConnectionsMap[conn] = struct{}{}
@@ -133,7 +195,7 @@ func (dt *DynamicTable) setupDynamicTableMapCleaner(mgr *manager.Manager, cfg *c
 func (dt *DynamicTable) stop() {
 	dt.mapCleaner.Stop()
 
-	if dt.terminatedConnectionsEventsConsumer != nil {
-		dt.terminatedConnectionsEventsConsumer.Stop()
+	if dt.consumer != nil {
+		dt.consumer.Stop()
 	}
 }

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -34,7 +35,8 @@ type Protocol struct {
 	telemetry               *http.Telemetry
 	statkeeper              *http.StatKeeper
 	http2InFlightMapCleaner *ddebpf.MapCleaner[HTTP2StreamKey, HTTP2Stream]
-	eventsConsumer          *events.BatchConsumer[EbpfTx]
+	eventsConsumer          *events.KernelAdaptiveConsumer[EbpfTx]
+	useDirectConsumer       bool
 
 	// http2Telemetry is used to retrieve metrics from the kernel
 	http2Telemetry             *kernelTelemetry
@@ -225,14 +227,38 @@ func newHTTP2Protocol(mgr *manager.Manager, cfg *config.Config) (protocols.Proto
 	telemetry := http.NewTelemetry("http2")
 	http2KernelTelemetry := newHTTP2KernelTelemetry()
 
-	return &Protocol{
+	dynamicTable, err := NewDynamicTable(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &Protocol{
 		cfg:                        cfg,
 		mgr:                        mgr,
 		telemetry:                  telemetry,
 		http2Telemetry:             http2KernelTelemetry,
 		kernelTelemetryStopChannel: make(chan struct{}),
-		dynamicTable:               NewDynamicTable(cfg),
-	}, nil
+		dynamicTable:               dynamicTable,
+	}
+
+	// Create adaptive consumer for the main HTTP/2 stream (determines kernel version
+	// and callback internally). The dynamic table's consumer is created in NewDynamicTable.
+	if err := p.createAdaptiveConsumer(); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Modifiers implements the ModifierProvider interface, combining the modifiers of both
+// HTTP/2 event streams (the main stream and the dynamic table's terminated connections stream).
+func (p *Protocol) Modifiers() []ddebpf.Modifier {
+	var modifiers []ddebpf.Modifier
+	if p.eventsConsumer != nil {
+		modifiers = append(modifiers, p.eventsConsumer.Modifiers()...)
+	}
+	modifiers = append(modifiers, p.dynamicTable.Modifiers()...)
+	return modifiers
 }
 
 // Name returns the protocol name.
@@ -275,15 +301,24 @@ func (p *Protocol) ConfigureOptions(opts *manager.Options) {
 		EditorFlag: manager.EditMaxEntries,
 	}
 
-	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          eventStream,
-			EBPFFuncName: netifProbe,
-		},
-	})
+	// Only activate the flush tracepoint when using BatchConsumer. DirectConsumer
+	// doesn't need it (both http2 streams emit events directly). A single
+	// http2_use_direct_consumer flag controls both streams, so they share this probe.
+	if !p.useDirectConsumer {
+		opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          eventStream,
+				EBPFFuncName: netifProbe,
+			},
+		})
+	} else {
+		opts.ExcludedFunctions = append(opts.ExcludedFunctions, netifProbe)
+	}
+
 	utils.EnableOption(opts, "http2_monitoring_enabled")
 	utils.EnableOption(opts, "terminated_http2_monitoring_enabled")
-	// Configure event stream
+	utils.AddBoolConst(opts, p.useDirectConsumer, "http2_use_direct_consumer")
+	// Configure event streams (main + terminated connections)
 	events.Configure(p.cfg, eventStream, p.mgr, opts)
 	p.dynamicTable.configureOptions(p.mgr, opts)
 }
@@ -292,13 +327,17 @@ func (p *Protocol) ConfigureOptions(opts *manager.Options) {
 // Additional initialisation steps, such as starting an event consumer,
 // should be performed here.
 func (p *Protocol) PreStart() (err error) {
-	p.eventsConsumer, err = events.NewBatchConsumer(
-		eventStream,
-		p.mgr,
-		p.processHTTP2,
-	)
-	if err != nil {
-		return
+	// If using BatchConsumer, create it now (after manager initialization).
+	// The DirectConsumer is already created in the factory via createAdaptiveConsumer().
+	if !p.useDirectConsumer {
+		batchConsumer, err := events.NewBatchConsumer(eventStream, p.mgr, p.processHTTP2)
+		if err != nil {
+			return err
+		}
+		p.eventsConsumer = events.NewKernelAdaptiveConsumer[EbpfTx](
+			batchConsumer,
+			[]ddebpf.Modifier{}, // BatchConsumer needs no modifiers
+		)
 	}
 
 	if err = p.dynamicTable.preStart(p.mgr); err != nil {
@@ -419,6 +458,46 @@ func (p *Protocol) processHTTP2(events []EbpfTx) {
 		p.telemetry.Count(eventWrapper)
 		p.statkeeper.Process(eventWrapper)
 	}
+}
+
+func (p *Protocol) processHTTP2Direct(event *EbpfTx) {
+	eventWrapper := &EventWrapper{
+		EbpfTx: event,
+	}
+	p.telemetry.Count(eventWrapper)
+	p.statkeeper.Process(eventWrapper)
+}
+
+// createAdaptiveConsumer creates the appropriate consumer (direct or batch) for the
+// main HTTP/2 stream, based on configuration and kernel version.
+func (p *Protocol) createAdaptiveConsumer() error {
+	if p.cfg.HTTP2UseDirectConsumer {
+		if events.SupportsDirectConsumer() {
+			directConsumer, err := events.NewDirectConsumer(eventStream, p.processHTTP2Direct, p.cfg)
+			if err != nil {
+				return err
+			}
+			p.eventsConsumer = events.NewKernelAdaptiveConsumer[EbpfTx](
+				directConsumer,
+				[]ddebpf.Modifier{&directConsumer.EventHandler},
+			)
+			p.useDirectConsumer = true
+			log.Debugf("HTTP2 monitoring: using direct consumer (requested via configuration)")
+		} else {
+			kernelVersion, err := kernel.HostVersion()
+			if err != nil {
+				log.Warnf("HTTP2 monitoring: direct consumer requested but unable to determine kernel version (%v), falling back to batch consumer", err)
+			} else {
+				log.Warnf("HTTP2 monitoring: direct consumer requested but kernel version %v < 5.8.0, falling back to batch consumer", kernelVersion)
+			}
+			p.useDirectConsumer = false
+		}
+	} else {
+		log.Debugf("HTTP2 monitoring: using batch consumer (default behavior)")
+		p.useDirectConsumer = false
+	}
+
+	return nil
 }
 
 func (p *Protocol) setupHTTP2InFlightMapCleaner() {

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
 	usmhttp "github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	usmhttp2 "github.com/DataDog/datadog-agent/pkg/network/protocols/http2"
@@ -169,6 +170,66 @@ func (s *usmHTTP2Suite) TestHTTP2DynamicTableCleanup() {
 	count := utils.CountMapEntries(t, dynamicTableMap)
 	require.GreaterOrEqual(t, count, 0)
 
+	require.Eventually(t, func() bool {
+		return utils.CountMapEntries(t, dynamicTableMap) == 0
+	}, cfg.HTTP2DynamicTableMapCleanerInterval*4, time.Millisecond*100)
+}
+
+// TestDirectConsumerFunctionality verifies that HTTP/2 stats are captured when the
+// direct consumer is enabled (kernel >= 5.8.0), exercising BOTH HTTP/2 event streams:
+// the main stream (request stats) and the terminated_http2 stream (which drives the
+// dynamic table cleanup). Runs for both plaintext and GoTLS traffic.
+func (s *usmHTTP2Suite) TestDirectConsumerFunctionality() {
+	t := s.T()
+
+	if !events.SupportsDirectConsumer() {
+		t.Skip("Direct consumer requires kernel >= 5.8.0")
+	}
+
+	cfg := s.getCfg()
+	cfg.HTTP2UseDirectConsumer = true
+	cfg.HTTP2DynamicTableMapCleanerInterval = 5 * time.Second
+
+	// Start local server and register its cleanup.
+	t.Cleanup(usmhttp2.StartH2CServer(t, authority, s.isTLS))
+
+	// Start the proxy server.
+	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS, false)
+	t.Cleanup(cancel)
+	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
+
+	monitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
+	if s.isTLS {
+		utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+	}
+
+	clients := getHTTP2UnixClientArray(2, unixPath)
+	for i := 0; i < usmhttp2.HTTP2TerminatedBatchSize; i++ {
+		req, err := clients[i%2].Post(fmt.Sprintf("%s/test-%d", http2SrvAddr, i+1), "application/json", bytes.NewReader([]byte("test")))
+		require.NoError(t, err, "could not make request")
+		_ = req.Body.Close()
+	}
+
+	// Main stream: verify request stats are captured via the direct consumer.
+	matches := PrintableInt(0)
+	require.Eventuallyf(t, func() bool {
+		matches = PrintableInt(0)
+		for key, stat := range getHTTPLikeProtocolStats(t, monitor, protocols.HTTP2) {
+			if (key.DstPort == srvPort || key.SrcPort == srvPort) && key.Method == usmhttp.MethodPost && strings.HasPrefix(key.Path.Content.Get(), "/test") {
+				matches.Add(stat.Data[200].Count)
+			}
+		}
+		return matches.Load() == usmhttp2.HTTP2TerminatedBatchSize
+	}, time.Second*10, time.Millisecond*100, "%v != %v", &matches, usmhttp2.HTTP2TerminatedBatchSize)
+
+	for _, client := range clients {
+		client.CloseIdleConnections()
+	}
+
+	// Terminated stream: closing connections should be delivered via the direct
+	// consumer and drive the dynamic table cleanup to empty.
+	dynamicTableMap, _, err := monitor.ebpfProgram.GetMap("http2_dynamic_table")
+	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		return utils.CountMapEntries(t, dynamicTableMap) == 0
 	}, cfg.HTTP2DynamicTableMapCleanerInterval*4, time.Millisecond*100)


### PR DESCRIPTION
### What does this PR do?

Migrates USM's HTTP/2 protocol from the legacy batch-map event-delivery path to
the **DirectConsumer**, gated behind a new per-protocol config flag
`service_monitoring_config.http2.use_direct_consumer` (default `false`).

When enabled on a supported kernel (>= 5.8), HTTP/2 events are written straight
from the eBPF programs to a perf/ring buffer via `pkg/ebpf/perf.EventHandler`,
instead of being accumulated in per-CPU batch maps and flushed by the
`netif_receive_skb` probe. On older kernels the protocol transparently falls
back to the existing batch consumer.

HTTP/2 has **two event streams** — the main stream (`http2`) and terminated
connections (`terminated_http2`, which drives dynamic-table cleanup). Both are
migrated to the direct path, controlled by the single
`http2.use_direct_consumer` flag.

This is the HTTP/2 step of extending the DirectConsumer mechanism (built for
HTTP in USMON-1458, PR #39774) to all USM protocols.

### Motivation

The batch path is heavy and fragile: extra maps, a flush probe, offset
bookkeeping, userspace map-walking, a known race between the socket-filter and
uprobe (TLS) flush paths, and poor built-in telemetry. On modern kernels socket
filters can write directly to perf/ring buffers, which removes the batch maps
and flush probe, eliminates the flush race, and gives lost-event / ring-buffer
telemetry for free.

### Describe how you validated your changes

- New config unit test in `pkg/network/config/usm_config_test.go` covering the
  `http2.use_direct_consumer` flag (default off, env/yaml override).
- New `TestDirectConsumerFunctionality` in `pkg/network/usm/usm_http2_monitor_test.go`
  exercising both direct streams end-to-end (plaintext + TLS, which traces an
  external proxy).
- Batch-path regression: existing HTTP/2 monitor tests still pass with the flag
  off.
- Built and ran locally on an ubuntu-24 / kernel 6.8 box in both
  `runtime_compiled` and `CO-RE` load modes; `system-probe.build` and
  `linter.go` clean.

### Additional Notes

- Default-off, internal tuning flag; no behavior change unless explicitly
  enabled. No release note for now, matching the HTTP precedent (PR #39774).
- The eBPF DirectConsumer constant is protocol-specific
  (`http2_use_direct_consumer`) so it can be toggled independently of HTTP and
  the other protocols (they share a single USM eBPF object). A single flag
  controls both HTTP/2 streams.
- Opening as a **draft** to let CI run before requesting review.
