### PR TITLE
[USMON-1493] usm: redis: use DirectConsumer for event delivery

### DIFF
--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -1040,6 +1040,10 @@ properties:
             node_type: setting
             type: boolean
             default: false
+          use_direct_consumer:
+            node_type: setting
+            type: boolean
+            default: false
       tls:
         node_type: section
         type: object

--- a/pkg/config/setup/system_probe_usm.go
+++ b/pkg/config/setup/system_probe_usm.go
@@ -125,6 +125,7 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("service_monitoring_config.redis.enabled", false)
 	cfg.BindEnvAndSetDefault("service_monitoring_config.redis.track_resources", false)
 	cfg.BindEnvAndSetDefault("service_monitoring_config.redis.max_stats_buffered", 100000)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.redis.use_direct_consumer", false)
 
 	// ========================================
 	// Native TLS Configuration

--- a/pkg/network/config/usm_config.go
+++ b/pkg/network/config/usm_config.go
@@ -151,6 +151,11 @@ type USMConfig struct {
 	// MaxRedisStatsBuffered represents the maximum number of Redis stats we'll buffer in memory
 	MaxRedisStatsBuffered int
 
+	// RedisUseDirectConsumer forces the use of direct consumer for Redis monitoring instead of batch consumer
+	// When true, direct consumer is used if kernel supports it (>=5.8.0), otherwise falls back to batch consumer
+	// When false (default), batch consumer is always used regardless of kernel version
+	RedisUseDirectConsumer bool
+
 	// ========================================
 	// Native TLS Configuration (OpenSSL, GnuTLS, LibCrypto)
 	// ========================================
@@ -229,9 +234,10 @@ func NewUSMConfig(cfg model.Config) *USMConfig {
 		MaxPostgresTelemetryBuffer: cfg.GetInt(sysconfig.FullKeyPath(smNS, "postgres", "max_telemetry_buffer")),
 
 		// Redis Protocol Configuration
-		EnableRedisMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "redis", "enabled")),
-		RedisTrackResources:   cfg.GetBool(sysconfig.FullKeyPath(smNS, "redis", "track_resources")),
-		MaxRedisStatsBuffered: cfg.GetInt(sysconfig.FullKeyPath(smNS, "redis", "max_stats_buffered")),
+		EnableRedisMonitoring:  cfg.GetBool(sysconfig.FullKeyPath(smNS, "redis", "enabled")),
+		RedisTrackResources:    cfg.GetBool(sysconfig.FullKeyPath(smNS, "redis", "track_resources")),
+		MaxRedisStatsBuffered:  cfg.GetInt(sysconfig.FullKeyPath(smNS, "redis", "max_stats_buffered")),
+		RedisUseDirectConsumer: cfg.GetBool(sysconfig.FullKeyPath(smNS, "redis", "use_direct_consumer")),
 
 		// TLS Configuration
 		EnableNativeTLSMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "tls", "native", "enabled")),

--- a/pkg/network/config/usm_config_test.go
+++ b/pkg/network/config/usm_config_test.go
@@ -1782,3 +1782,28 @@ func TestHTTPUseDirectConsumer(t *testing.T) {
 		assert.True(t, cfg.HTTPUseDirectConsumer)
 	})
 }
+
+func TestRedisUseDirectConsumer(t *testing.T) {
+	t.Run("default value", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		cfg := New()
+
+		assert.False(t, cfg.RedisUseDirectConsumer)
+	})
+
+	t.Run("via YAML", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetInTest("service_monitoring_config.redis.use_direct_consumer", true)
+		cfg := New()
+
+		assert.True(t, cfg.RedisUseDirectConsumer)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_REDIS_USE_DIRECT_CONSUMER", "true")
+		cfg := New()
+
+		assert.True(t, cfg.RedisUseDirectConsumer)
+	})
+}

--- a/pkg/network/ebpf/c/protocols/redis/decoding.h
+++ b/pkg/network/ebpf/c/protocols/redis/decoding.h
@@ -211,7 +211,7 @@ static void __always_inline redis_tcp_termination(conn_tuple_t *tup) {
 
 // Enqueues a batch of events to the user-space. To spare stack size, we take a scratch buffer from the map, copy
 // the connection tuple and the transaction to it, and then enqueue the event.
-static __always_inline void redis_batch_enqueue_wrapper(conn_tuple_t *tuple, redis_transaction_t *tx) {
+static __always_inline void redis_batch_enqueue_wrapper(void *ctx, conn_tuple_t *tuple, redis_transaction_t *tx) {
     u32 zero = 0;
     redis_event_t *event = bpf_map_lookup_elem(&redis_scratch_buffer, &zero);
     if (!event) {
@@ -220,12 +220,23 @@ static __always_inline void redis_batch_enqueue_wrapper(conn_tuple_t *tuple, red
 
     bpf_memcpy(&event->tuple, tuple, sizeof(conn_tuple_t));
     bpf_memcpy(&event->tx, tx, sizeof(redis_transaction_t));
-    redis_batch_enqueue(event);
+
+    // Check which consumer type to use based on kernel version capability
+    __u64 redis_use_direct_consumer = 0;
+    LOAD_CONSTANT("redis_use_direct_consumer", redis_use_direct_consumer);
+
+    if (redis_use_direct_consumer) {
+        // Direct consumer path - use perf/ring buffer output (kernel >= 5.8)
+        redis_output_event(ctx, event);
+    } else {
+        // Batch consumer path - use map-based batching (kernel < 5.8)
+        redis_batch_enqueue(event);
+    }
 }
 
 // Enqueues a batch of events to the user-space. To spare stack size, we take a scratch buffer from the map, copy
 // the connection tuple and the transaction to it, and then enqueue the event.
-static __always_inline void redis_with_key_batch_enqueue_wrapper(conn_tuple_t *tuple, redis_transaction_t *tx, redis_key_data_t *key) {
+static __always_inline void redis_with_key_batch_enqueue_wrapper(void *ctx, conn_tuple_t *tuple, redis_transaction_t *tx, redis_key_data_t *key) {
     u32 zero = 0;
     redis_with_key_event_t *event = bpf_map_lookup_elem(&redis_with_key_scratch_buffer, &zero);
     if (!event) {
@@ -235,7 +246,18 @@ static __always_inline void redis_with_key_batch_enqueue_wrapper(conn_tuple_t *t
     bpf_memcpy(&event->header.tuple, tuple, sizeof(conn_tuple_t));
     bpf_memcpy(&event->header.tx, tx, sizeof(redis_transaction_t));
     bpf_memcpy(&event->key, key, sizeof(redis_key_data_t));
-    redis_with_key_batch_enqueue(event);
+
+    // Check which consumer type to use based on kernel version capability
+    __u64 redis_use_direct_consumer = 0;
+    LOAD_CONSTANT("redis_use_direct_consumer", redis_use_direct_consumer);
+
+    if (redis_use_direct_consumer) {
+        // Direct consumer path - use perf/ring buffer output (kernel >= 5.8)
+        redis_with_key_output_event(ctx, event);
+    } else {
+        // Batch consumer path - use map-based batching (kernel < 5.8)
+        redis_with_key_batch_enqueue(event);
+    }
 }
 
 // Checks if a byte represents a valid RESP (Redis Serialization Protocol) response type prefix.
@@ -274,7 +296,7 @@ static __always_inline bool is_resp_error(char first_byte) {
 
 // Processes Redis response messages and validates their format.
 // Handles all RESP2 and RESP3 response types for comprehensive monitoring coverage.
-static void __always_inline process_redis_response(pktbuf_t pkt, conn_tuple_t *tup, redis_transaction_t *transaction) {
+static void __always_inline process_redis_response(void *ctx, pktbuf_t pkt, conn_tuple_t *tup, redis_transaction_t *transaction) {
     redis_key_data_t *key = NULL;
     redis_key_data_t empty_key = {};  // For PING commands when resource tracking is enabled
     if (is_redis_with_key_monitoring_enabled()) {
@@ -316,9 +338,9 @@ enqueue:
     // When resource tracking is enabled, ALL commands (including PING) go to the keyed stream
     // PING commands use an empty key, GET/SET commands use their actual keys
     if (is_redis_with_key_monitoring_enabled()) {
-        redis_with_key_batch_enqueue_wrapper(tup, transaction, key);
+        redis_with_key_batch_enqueue_wrapper(ctx, tup, transaction, key);
     } else {
-        redis_batch_enqueue_wrapper(tup, transaction);
+        redis_batch_enqueue_wrapper(ctx, tup, transaction);
     }
 cleanup:
     bpf_map_delete_elem(&redis_in_flight, tup);
@@ -348,7 +370,7 @@ int socket__redis_process(struct __sk_buff *skb) {
     if (transaction == NULL) {
         process_redis_request(pkt, &conn_tuple, NO_TAGS);
     } else {
-        process_redis_response(pkt, &conn_tuple, transaction);
+        process_redis_response(skb, pkt, &conn_tuple, transaction);
     }
 
     return 0;
@@ -374,7 +396,7 @@ int uprobe__redis_tls_process(struct pt_regs *ctx) {
     if (transaction == NULL) {
         process_redis_request(pkt, &tup, (__u8)args->tags);
     } else {
-        process_redis_response(pkt, &tup, transaction);
+        process_redis_response(ctx, pkt, &tup, transaction);
     }
     return 0;
 }

--- a/pkg/network/ebpf/c/protocols/redis/usm-events.h
+++ b/pkg/network/ebpf/c/protocols/redis/usm-events.h
@@ -1,11 +1,17 @@
 #ifndef __REDIS_USM_EVENTS_H
 #define __REDIS_USM_EVENTS_H
 
+#include "protocols/direct_consumer.h"
 #include "protocols/events.h"
 #include "protocols/redis/types.h"
 
 USM_EVENTS_INIT(redis_with_key, redis_with_key_event_t, REDIS_WITH_KEY_BATCH_SIZE);
 USM_EVENTS_INIT(redis, redis_event_t, REDIS_BATCH_SIZE);
+
+// Initialize DirectConsumer utilities for both Redis event streams (a single
+// service_monitoring_config.redis.use_direct_consumer flag controls both).
+USM_DIRECT_CONSUMER_INIT(redis_with_key, redis_with_key_event_t, redis_with_key_batch_events)
+USM_DIRECT_CONSUMER_INIT(redis, redis_event_t, redis_batch_events)
 
 // Returns true if any of the reids monitoring modes is enabled.
 static __always_inline bool is_redis_enabled() {

--- a/pkg/network/protocols/redis/protocol.go
+++ b/pkg/network/protocols/redis/protocol.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -42,8 +43,9 @@ const (
 
 type protocol struct {
 	cfg                 *config.Config
-	eventsConsumer      *events.BatchConsumer[EbpfEvent]
-	keyedEventsConsumer *events.BatchConsumer[EbpfKeyedEvent]
+	eventsConsumer      *events.KernelAdaptiveConsumer[EbpfEvent]
+	keyedEventsConsumer *events.KernelAdaptiveConsumer[EbpfKeyedEvent]
+	useDirectConsumer   bool
 	mapCleaner          *ddebpf.MapCleaner[netebpf.ConnTuple, EbpfTx]
 	statskeeper         *StatsKeeper
 	mgr                 *manager.Manager
@@ -112,11 +114,74 @@ func newRedisProtocol(mgr *manager.Manager, cfg *config.Config) (protocols.Proto
 		return nil, nil
 	}
 
-	return &protocol{
+	p := &protocol{
 		cfg:         cfg,
 		statskeeper: NewStatsKeeper(cfg),
 		mgr:         mgr,
-	}, nil
+	}
+
+	// Create adaptive consumer that determines kernel version and callback internally
+	if err := p.createAdaptiveConsumer(); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Modifiers implements the ModifierProvider interface. Only one of the two Redis
+// streams (keyed or unkeyed) is active at a time, selected by RedisTrackResources.
+func (p *protocol) Modifiers() []ddebpf.Modifier {
+	if p.eventsConsumer != nil {
+		return p.eventsConsumer.Modifiers()
+	}
+	if p.keyedEventsConsumer != nil {
+		return p.keyedEventsConsumer.Modifiers()
+	}
+	return nil
+}
+
+// createAdaptiveConsumer creates the appropriate consumer (direct or batch) for the
+// active Redis stream, based on configuration and kernel version. The active stream
+// (keyed vs unkeyed) is selected by RedisTrackResources.
+func (p *protocol) createAdaptiveConsumer() error {
+	if !p.cfg.RedisUseDirectConsumer {
+		log.Debugf("Redis monitoring: using batch consumer (default behavior)")
+		return nil
+	}
+
+	if !events.SupportsDirectConsumer() {
+		kernelVersion, err := kernel.HostVersion()
+		if err != nil {
+			log.Warnf("Redis monitoring: direct consumer requested but unable to determine kernel version (%v), falling back to batch consumer", err)
+		} else {
+			log.Warnf("Redis monitoring: direct consumer requested but kernel version %v < 5.8.0, falling back to batch consumer", kernelVersion)
+		}
+		return nil
+	}
+
+	if p.cfg.RedisTrackResources {
+		directConsumer, err := events.NewDirectConsumer(keyedEventStream, p.processKeyedRedisDirect, p.cfg)
+		if err != nil {
+			return err
+		}
+		p.keyedEventsConsumer = events.NewKernelAdaptiveConsumer[EbpfKeyedEvent](
+			directConsumer,
+			[]ddebpf.Modifier{&directConsumer.EventHandler},
+		)
+	} else {
+		directConsumer, err := events.NewDirectConsumer(name, p.processRedisDirect, p.cfg)
+		if err != nil {
+			return err
+		}
+		p.eventsConsumer = events.NewKernelAdaptiveConsumer[EbpfEvent](
+			directConsumer,
+			[]ddebpf.Modifier{&directConsumer.EventHandler},
+		)
+	}
+	p.useDirectConsumer = true
+	log.Debugf("Redis monitoring: using direct consumer (requested via configuration)")
+
+	return nil
 }
 
 // Name returns the name of the protocol.
@@ -139,14 +204,23 @@ func (p *protocol) ConfigureOptions(opts *manager.Options) {
 		Flags:      mapFlags,
 		EditorFlag: editorFlag,
 	}
-	netifProbeID := manager.ProbeIdentificationPair{
-		EBPFFuncName: netifProbe,
-		UID:          name,
+	// Only activate the flush tracepoint when using BatchConsumer. DirectConsumer
+	// doesn't need it since it emits events directly. A single redis_use_direct_consumer
+	// flag controls whichever Redis stream is active.
+	if !p.useDirectConsumer {
+		netifProbeID := manager.ProbeIdentificationPair{
+			EBPFFuncName: netifProbe,
+			UID:          name,
+		}
+		if usmconfig.ShouldUseNetifReceiveSKBCoreKprobe() {
+			netifProbeID.EBPFFuncName = netifProbe414
+		}
+		opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: netifProbeID})
+	} else {
+		opts.ExcludedFunctions = append(opts.ExcludedFunctions, netifProbe, netifProbe414)
 	}
-	if usmconfig.ShouldUseNetifReceiveSKBCoreKprobe() {
-		netifProbeID.EBPFFuncName = netifProbe414
-	}
-	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: netifProbeID})
+
+	utils.AddBoolConst(opts, p.useDirectConsumer, "redis_use_direct_consumer")
 
 	if p.cfg.RedisTrackResources {
 		utils.EnableOption(opts, "redis_with_key_monitoring_enabled")
@@ -168,25 +242,35 @@ func (p *protocol) ConfigureOptions(opts *manager.Options) {
 }
 
 func (p *protocol) PreStart() (err error) {
-	if p.cfg.RedisTrackResources {
-		p.keyedEventsConsumer, err = events.NewBatchConsumer(
-			keyedEventStream,
-			p.mgr,
-			p.processKeyedRedis,
-		)
-		if err != nil {
-			return
+	// If using BatchConsumer, create it now (after manager initialization) for the
+	// active stream. The DirectConsumer is already created in the factory.
+	if !p.useDirectConsumer {
+		if p.cfg.RedisTrackResources {
+			batchConsumer, err := events.NewBatchConsumer(keyedEventStream, p.mgr, p.processKeyedRedis)
+			if err != nil {
+				return err
+			}
+			p.keyedEventsConsumer = events.NewKernelAdaptiveConsumer[EbpfKeyedEvent](
+				batchConsumer,
+				[]ddebpf.Modifier{}, // BatchConsumer needs no modifiers
+			)
+		} else {
+			batchConsumer, err := events.NewBatchConsumer(name, p.mgr, p.processRedis)
+			if err != nil {
+				return err
+			}
+			p.eventsConsumer = events.NewKernelAdaptiveConsumer[EbpfEvent](
+				batchConsumer,
+				[]ddebpf.Modifier{}, // BatchConsumer needs no modifiers
+			)
 		}
+	}
+
+	// Start whichever consumer is active (works for both DirectConsumer and BatchConsumer).
+	if p.keyedEventsConsumer != nil {
 		p.keyedEventsConsumer.Start()
-	} else {
-		p.eventsConsumer, err = events.NewBatchConsumer(
-			name,
-			p.mgr,
-			p.processRedis,
-		)
-		if err != nil {
-			return
-		}
+	}
+	if p.eventsConsumer != nil {
 		p.eventsConsumer.Start()
 	}
 	return
@@ -268,12 +352,22 @@ func (p *protocol) processKeyedRedis(events []EbpfKeyedEvent) {
 	}
 }
 
+func (p *protocol) processKeyedRedisDirect(event *EbpfKeyedEvent) {
+	eventWrapper := NewEventWrapper(&event.Header, &event.Key)
+	p.statskeeper.Process(eventWrapper)
+}
+
 func (p *protocol) processRedis(events []EbpfEvent) {
 	for i := range events {
 		tx := &events[i]
 		eventWrapper := NewEventWrapper(tx, nil)
 		p.statskeeper.Process(eventWrapper)
 	}
+}
+
+func (p *protocol) processRedisDirect(event *EbpfEvent) {
+	eventWrapper := NewEventWrapper(event, nil)
+	p.statskeeper.Process(eventWrapper)
 }
 
 func (p *protocol) setupMapCleaner() {

--- a/pkg/network/usm/redis_monitor_test.go
+++ b/pkg/network/usm/redis_monitor_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/redis"
 	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
 	ebpftls "github.com/DataDog/datadog-agent/pkg/network/protocols/tls"
@@ -123,6 +124,118 @@ func (s *redisProtocolParsingSuite) TestDecoding() {
 			testRedisDecoding(t, tt.isTLS, tt.protocolVersion, tt.trackResources)
 		})
 	}
+}
+
+// TestDirectConsumerFunctionality verifies that Redis stats are captured when the
+// direct consumer is enabled (kernel >= 5.8.0). It is table-driven over the
+// RedisTrackResources dimension so that BOTH direct streams are exercised: the
+// unkeyed "redis" stream (trackResources=false) and the keyed "redis_with_key"
+// stream (trackResources=true), each for plaintext and GoTLS traffic.
+func (s *redisProtocolParsingSuite) TestDirectConsumerFunctionality() {
+	t := s.T()
+
+	if !events.SupportsDirectConsumer() {
+		t.Skip("Direct consumer requires kernel >= 5.8.0")
+	}
+
+	tests := []struct {
+		name           string
+		isTLS          bool
+		trackResources bool
+	}{
+		{name: "without TLS unkeyed", isTLS: false, trackResources: false},
+		{name: "without TLS keyed", isTLS: false, trackResources: true},
+		{name: "with TLS unkeyed", isTLS: true, trackResources: false},
+		{name: "with TLS keyed", isTLS: true, trackResources: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.isTLS && !gotlstestutil.GoTLSSupported(t, NewUSMEmptyConfig()) {
+				t.Skip("GoTLS not supported for this setup")
+			}
+			s.testDirectConsumerFunctionality(t, tt.isTLS, tt.trackResources)
+		})
+	}
+}
+
+func (s *redisProtocolParsingSuite) testDirectConsumerFunctionality(t *testing.T, isTLS, trackResources bool) {
+	const version = 2
+	serverHost := "127.0.0.1"
+	serverAddress := net.JoinHostPort(serverHost, redisPort)
+	require.NoError(t, redis.RunServer(t, serverHost, redisPort, isTLS))
+	waitForRedisServer(t, serverAddress, isTLS, version)
+
+	cfg := getRedisDefaultTestConfiguration(isTLS)
+	cfg.RedisTrackResources = trackResources
+	cfg.RedisUseDirectConsumer = true
+	monitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
+	if isTLS {
+		utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, os.Getpid(), utils.ManualTracingFallbackEnabled)
+	}
+
+	// With non-TLS, packets are seen twice (Docker), so the expected count is doubled.
+	adjustCount := func(count int) int {
+		if isTLS {
+			return count
+		}
+		return count * 2
+	}
+
+	// Establish the connection while the monitor is paused so the client handshake
+	// (HELLO/CLIENT SETINFO) is not captured.
+	require.NoError(t, monitor.Pause())
+	dialer := &net.Dialer{}
+	redisClient, err := redis.NewClient(serverAddress, dialer, isTLS, version)
+	require.NoError(t, err)
+	require.NotNil(t, redisClient)
+	require.NoError(t, redisClient.Ping(context.Background()).Err())
+	t.Cleanup(func() {
+		redisClient.Close()
+		cleanProtocolMaps(t, "redis", monitor.ebpfProgram.Manager.Manager)
+	})
+	require.NoError(t, monitor.Resume())
+	// Wait until the monitor is actually capturing before sending the counted traffic.
+	// A fixed sleep is flaky: on a slow/loaded CI host the direct consumer may not be
+	// ready within the window and the PING/SET/GET below get missed. Probe with throwaway
+	// PINGs and drain their stats (GetProtocolStats resets on read) so the readiness
+	// traffic does not count toward the assertion.
+	require.Eventually(t, func() bool {
+		if err := redisClient.Ping(context.Background()).Err(); err != nil {
+			return false
+		}
+		statsObj, cleaners := monitor.GetProtocolStats()
+		defer cleaners()
+		_, ok := statsObj[protocols.Redis]
+		return ok
+	}, 5*time.Second, 100*time.Millisecond, "redis monitor did not start capturing after resume")
+
+	// One captured warmup PING, then a SET and a GET.
+	require.NoError(t, redisClient.Ping(context.Background()).Err())
+	require.NoError(t, redisClient.Set(context.Background(), "test-key", "test-value", 0).Err())
+	val, err := redisClient.Get(context.Background(), "test-key").Result()
+	require.NoError(t, err)
+	require.Equal(t, "test-value", val)
+	require.NoError(t, monitor.Pause())
+
+	keyName := ""
+	if trackResources {
+		keyName = "test-key"
+	}
+	expected := map[string]map[redis.CommandType]int{
+		keyName: {
+			redis.GetCommand: adjustCount(1),
+			redis.SetCommand: adjustCount(1),
+		},
+	}
+	// PING has no key; with resource tracking it lands under the empty key.
+	if keyName == "" {
+		expected[""][redis.PingCommand] = adjustCount(1)
+	} else {
+		expected[""] = map[redis.CommandType]int{
+			redis.PingCommand: adjustCount(1),
+		}
+	}
+	validateRedis(t, monitor, expected, isTLS)
 }
 
 func waitForRedisServer(t *testing.T, serverAddress string, enableTLS bool, version int) {


### PR DESCRIPTION
### What does this PR do?

Migrates USM's Redis protocol from the legacy batch-map event-delivery path to
the **DirectConsumer**, gated behind a new per-protocol config flag
`service_monitoring_config.redis.use_direct_consumer` (default `false`).

When enabled on a supported kernel (>= 5.8), Redis events are written straight
from the eBPF programs to a perf/ring buffer via `pkg/ebpf/perf.EventHandler`,
instead of being accumulated in per-CPU batch maps and flushed by the
`netif_receive_skb` probe. On older kernels the protocol transparently falls
back to the existing batch consumer.

Redis has **two mutually-exclusive event streams** — unkeyed (`redis`) and
keyed (`redis_with_key`, selected by `redis.track_resources`); only one is
active at a time. Both are migrated to the direct path, controlled by the
single `redis.use_direct_consumer` flag.

This is the Redis step of extending the DirectConsumer mechanism (built for
HTTP in USMON-1458, PR #39774) to all USM protocols.

### Motivation

The batch path is heavy and fragile: extra maps, a flush probe, offset
bookkeeping, userspace map-walking, a known race between the socket-filter and
uprobe (TLS) flush paths, and poor built-in telemetry. On modern kernels socket
filters can write directly to perf/ring buffers, which removes the batch maps
and flush probe, eliminates the flush race, and gives lost-event / ring-buffer
telemetry for free.

### Describe how you validated your changes

- New config unit test in `pkg/network/config/usm_config_test.go` covering the
  `redis.use_direct_consumer` flag (default off, env/yaml override).
- New `TestDirectConsumerFunctionality` in `pkg/network/usm/redis_monitor_test.go`,
  table-driven over `track_resources` so both direct streams (unkeyed + keyed)
  are exercised.
- Batch-path regression: existing Redis monitor tests still pass with the flag
  off.
- Built and ran locally on an ubuntu-24 / kernel 6.8 box in both
  `runtime_compiled` and `CO-RE` load modes; `system-probe.build` and
  `linter.go` clean.

### Additional Notes

- Default-off, internal tuning flag; no behavior change unless explicitly
  enabled. No release note for now, matching the HTTP precedent (PR #39774).
- The eBPF DirectConsumer constant is protocol-specific
  (`redis_use_direct_consumer`) so it can be toggled independently of HTTP and
  the other protocols (they share a single USM eBPF object). A single flag
  controls whichever Redis stream is active.
- Opening as a **draft** to let CI run before requesting review.
