### PR TITLE
feat(cluster-agent): add hpa_label_selector to filter HPAs for external metrics autogen

### DIFF
--- a/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher.go
@@ -48,7 +48,7 @@ type AutoscalerWatcher struct {
 	autogenEnabled          bool
 	autogenExpirationPeriod time.Duration
 	autogenNamespace        string
-	hpaLabelSelector        labels.Selector
+	autogenLabelSelector    labels.Selector
 	autoscalerLister        cache.GenericLister
 	autoscalerListerSynced  cache.InformerSynced
 	wpaLister               cache.GenericLister
@@ -76,7 +76,7 @@ func NewAutoscalerWatcher(
 	autogenEnabled bool,
 	autogenExpirationPeriodHours int64,
 	autogenNamespace string,
-	hpaLabelSelector labels.Selector,
+	autogenLabelSelector labels.Selector,
 	client kubernetes.Interface,
 	informer informers.SharedInformerFactory,
 	wpaInformer dynamic_informer.DynamicSharedInformerFactory,
@@ -119,8 +119,8 @@ func NewAutoscalerWatcher(
 		wpaListerSynced = wpaInformer.ForResource(gvr).Informer().HasSynced
 	}
 
-	if hpaLabelSelector == nil {
-		hpaLabelSelector = labels.Everything()
+	if autogenLabelSelector == nil {
+		autogenLabelSelector = labels.Everything()
 	}
 
 	autoscalerWatcher := &AutoscalerWatcher{
@@ -128,7 +128,7 @@ func NewAutoscalerWatcher(
 		autogenEnabled:          autogenEnabled,
 		autogenExpirationPeriod: time.Duration(autogenExpirationPeriodHours) * time.Hour,
 		autogenNamespace:        autogenNamespace,
-		hpaLabelSelector:        hpaLabelSelector,
+		autogenLabelSelector:    autogenLabelSelector,
 		autoscalerLister:        autoscalerLister,
 		autoscalerListerSynced:  autoscalerListerSynced,
 		wpaLister:               wpaLister,
@@ -292,6 +292,7 @@ func (w *AutoscalerWatcher) getAutoscalerReferences() (map[string]*externalMetri
 				continue
 			}
 
+			allowAutogen := w.autogenLabelSelector.Matches(labels.Set(wpa.Labels))
 			for _, metric := range wpa.Spec.Metrics {
 				if metric.External == nil {
 					continue
@@ -299,10 +300,9 @@ func (w *AutoscalerWatcher) getAutoscalerReferences() (map[string]*externalMetri
 
 				external := metric.External
 				ref := buildAutoscalerReference(autoscalerWPAKindKey, wpa.ObjectMeta)
-				// WPAs are not filtered by the HPA label selector, so autogeneration is always allowed.
-				ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.MetricName, external.MetricSelector, true)
+				ddMetricID, metricName, metricLabels, ok := w.extractAutoscalerReference(external.MetricName, external.MetricSelector, allowAutogen)
 				if ok {
-					addAutoscalerReference(ddMetricID, ref, metricName, labels)
+					addAutoscalerReference(ddMetricID, ref, metricName, metricLabels)
 				}
 			}
 		}
@@ -332,7 +332,7 @@ func (w *AutoscalerWatcher) processHPAReference(addAutoscalerReference addAutosc
 }
 
 func (w *AutoscalerWatcher) processHPAv2beta1Reference(addAutoscalerReference addAutoscalerReferenceFn, hpa *autoscalingv2beta1.HorizontalPodAutoscaler) {
-	allowAutogen := w.hpaLabelSelector.Matches(labels.Set(hpa.Labels))
+	allowAutogen := w.autogenLabelSelector.Matches(labels.Set(hpa.Labels))
 	ref := buildAutoscalerReference(autoscalerHPAKindKey, hpa.ObjectMeta)
 	for _, metric := range hpa.Spec.Metrics {
 		if metric.Type != autoscalingv2beta1.ExternalMetricSourceType || metric.External == nil {
@@ -348,7 +348,7 @@ func (w *AutoscalerWatcher) processHPAv2beta1Reference(addAutoscalerReference ad
 }
 
 func (w *AutoscalerWatcher) processHPAv2beta2Reference(addAutoscalerReference addAutoscalerReferenceFn, hpa *autoscalingv2beta2.HorizontalPodAutoscaler) {
-	allowAutogen := w.hpaLabelSelector.Matches(labels.Set(hpa.Labels))
+	allowAutogen := w.autogenLabelSelector.Matches(labels.Set(hpa.Labels))
 	ref := buildAutoscalerReference(autoscalerHPAKindKey, hpa.ObjectMeta)
 	for _, metric := range hpa.Spec.Metrics {
 		if metric.Type != autoscalingv2beta2.ExternalMetricSourceType || metric.External == nil {
@@ -364,7 +364,7 @@ func (w *AutoscalerWatcher) processHPAv2beta2Reference(addAutoscalerReference ad
 }
 
 func (w *AutoscalerWatcher) processHPAv2Reference(addAutoscalerReference addAutoscalerReferenceFn, hpa *autoscalingv2.HorizontalPodAutoscaler) {
-	allowAutogen := w.hpaLabelSelector.Matches(labels.Set(hpa.Labels))
+	allowAutogen := w.autogenLabelSelector.Matches(labels.Set(hpa.Labels))
 	ref := buildAutoscalerReference(autoscalerHPAKindKey, hpa.ObjectMeta)
 	for _, metric := range hpa.Spec.Metrics {
 		if metric.Type != autoscalingv2.ExternalMetricSourceType || metric.External == nil {

--- a/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher.go
@@ -48,6 +48,7 @@ type AutoscalerWatcher struct {
 	autogenEnabled          bool
 	autogenExpirationPeriod time.Duration
 	autogenNamespace        string
+	hpaLabelSelector        labels.Selector
 	autoscalerLister        cache.GenericLister
 	autoscalerListerSynced  cache.InformerSynced
 	wpaLister               cache.GenericLister
@@ -75,6 +76,7 @@ func NewAutoscalerWatcher(
 	autogenEnabled bool,
 	autogenExpirationPeriodHours int64,
 	autogenNamespace string,
+	hpaLabelSelector labels.Selector,
 	client kubernetes.Interface,
 	informer informers.SharedInformerFactory,
 	wpaInformer dynamic_informer.DynamicSharedInformerFactory,
@@ -117,11 +119,16 @@ func NewAutoscalerWatcher(
 		wpaListerSynced = wpaInformer.ForResource(gvr).Informer().HasSynced
 	}
 
+	if hpaLabelSelector == nil {
+		hpaLabelSelector = labels.Everything()
+	}
+
 	autoscalerWatcher := &AutoscalerWatcher{
 		refreshPeriod:           refreshPeriod,
 		autogenEnabled:          autogenEnabled,
 		autogenExpirationPeriod: time.Duration(autogenExpirationPeriodHours) * time.Hour,
 		autogenNamespace:        autogenNamespace,
+		hpaLabelSelector:        hpaLabelSelector,
 		autoscalerLister:        autoscalerLister,
 		autoscalerListerSynced:  autoscalerListerSynced,
 		wpaLister:               wpaLister,
@@ -292,7 +299,8 @@ func (w *AutoscalerWatcher) getAutoscalerReferences() (map[string]*externalMetri
 
 				external := metric.External
 				ref := buildAutoscalerReference(autoscalerWPAKindKey, wpa.ObjectMeta)
-				ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.MetricName, external.MetricSelector)
+				// WPAs are not filtered by the HPA label selector, so autogeneration is always allowed.
+				ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.MetricName, external.MetricSelector, true)
 				if ok {
 					addAutoscalerReference(ddMetricID, ref, metricName, labels)
 				}
@@ -324,18 +332,15 @@ func (w *AutoscalerWatcher) processHPAReference(addAutoscalerReference addAutosc
 }
 
 func (w *AutoscalerWatcher) processHPAv2beta1Reference(addAutoscalerReference addAutoscalerReferenceFn, hpa *autoscalingv2beta1.HorizontalPodAutoscaler) {
+	allowAutogen := w.hpaLabelSelector.Matches(labels.Set(hpa.Labels))
+	ref := buildAutoscalerReference(autoscalerHPAKindKey, hpa.ObjectMeta)
 	for _, metric := range hpa.Spec.Metrics {
-		if metric.Type != autoscalingv2beta1.ExternalMetricSourceType {
-			continue
-		}
-
-		if metric.External == nil {
+		if metric.Type != autoscalingv2beta1.ExternalMetricSourceType || metric.External == nil {
 			continue
 		}
 
 		external := metric.External
-		ref := buildAutoscalerReference(autoscalerHPAKindKey, hpa.ObjectMeta)
-		ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.MetricName, external.MetricSelector)
+		ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.MetricName, external.MetricSelector, allowAutogen)
 		if ok {
 			addAutoscalerReference(ddMetricID, ref, metricName, labels)
 		}
@@ -343,18 +348,15 @@ func (w *AutoscalerWatcher) processHPAv2beta1Reference(addAutoscalerReference ad
 }
 
 func (w *AutoscalerWatcher) processHPAv2beta2Reference(addAutoscalerReference addAutoscalerReferenceFn, hpa *autoscalingv2beta2.HorizontalPodAutoscaler) {
+	allowAutogen := w.hpaLabelSelector.Matches(labels.Set(hpa.Labels))
+	ref := buildAutoscalerReference(autoscalerHPAKindKey, hpa.ObjectMeta)
 	for _, metric := range hpa.Spec.Metrics {
-		if metric.Type != autoscalingv2beta2.ExternalMetricSourceType {
-			continue
-		}
-
-		if metric.External == nil {
+		if metric.Type != autoscalingv2beta2.ExternalMetricSourceType || metric.External == nil {
 			continue
 		}
 
 		external := metric.External
-		ref := buildAutoscalerReference(autoscalerHPAKindKey, hpa.ObjectMeta)
-		ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.Metric.Name, external.Metric.Selector)
+		ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.Metric.Name, external.Metric.Selector, allowAutogen)
 		if ok {
 			addAutoscalerReference(ddMetricID, ref, metricName, labels)
 		}
@@ -362,18 +364,15 @@ func (w *AutoscalerWatcher) processHPAv2beta2Reference(addAutoscalerReference ad
 }
 
 func (w *AutoscalerWatcher) processHPAv2Reference(addAutoscalerReference addAutoscalerReferenceFn, hpa *autoscalingv2.HorizontalPodAutoscaler) {
+	allowAutogen := w.hpaLabelSelector.Matches(labels.Set(hpa.Labels))
+	ref := buildAutoscalerReference(autoscalerHPAKindKey, hpa.ObjectMeta)
 	for _, metric := range hpa.Spec.Metrics {
-		if metric.Type != autoscalingv2.ExternalMetricSourceType {
-			continue
-		}
-
-		if metric.External == nil {
+		if metric.Type != autoscalingv2.ExternalMetricSourceType || metric.External == nil {
 			continue
 		}
 
 		external := metric.External
-		ref := buildAutoscalerReference(autoscalerHPAKindKey, hpa.ObjectMeta)
-		ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.Metric.Name, external.Metric.Selector)
+		ddMetricID, metricName, labels, ok := w.extractAutoscalerReference(external.Metric.Name, external.Metric.Selector, allowAutogen)
 		if ok {
 			addAutoscalerReference(ddMetricID, ref, metricName, labels)
 		}
@@ -383,6 +382,7 @@ func (w *AutoscalerWatcher) processHPAv2Reference(addAutoscalerReference addAuto
 func (w *AutoscalerWatcher) extractAutoscalerReference(
 	externalMetricName string,
 	externalMetricSelector *metav1.LabelSelector,
+	allowAutogen bool,
 ) (
 	ddMetricID string,
 	metricName string,
@@ -391,8 +391,9 @@ func (w *AutoscalerWatcher) extractAutoscalerReference(
 ) {
 	ddMetricID, parsed, hasPrefix := metricNameToDatadogMetricID(externalMetricName)
 	if parsed {
+		// datadogmetric@ references are always tracked regardless of hpaLabelSelector — the selector controls autogen only.
 		return ddMetricID, "", nil, true
-	} else if !hasPrefix && w.autogenEnabled {
+	} else if !hasPrefix && w.autogenEnabled && allowAutogen {
 		// We were not able to parse name as DatadogMetric ID.
 		// It will be considered as a normal metricName +
 		// labels

--- a/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher_test.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher_test.go
@@ -132,6 +132,14 @@ func newFakeHorizontalPodAutoscalerWithLabels(ns, name string, hpaLabels map[str
 }
 
 func newFakeWatermarkPodAutoscaler(ns, name string, metrics []interface{}) *unstructured.Unstructured {
+	return newFakeWatermarkPodAutoscalerWithLabels(ns, name, nil, metrics)
+}
+
+func newFakeWatermarkPodAutoscalerWithLabels(ns, name string, wpaLabels map[string]string, metrics []interface{}) *unstructured.Unstructured {
+	labelsMap := map[string]interface{}{}
+	for k, v := range wpaLabels {
+		labelsMap[k] = v
+	}
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "datadoghq.com/v1alpha1",
@@ -139,6 +147,7 @@ func newFakeWatermarkPodAutoscaler(ns, name string, metrics []interface{}) *unst
 			"metadata": map[string]interface{}{
 				"name":      name,
 				"namespace": ns,
+				"labels":    labelsMap,
 			},
 			"spec": map[string]interface{}{
 				"metrics": metrics,
@@ -495,7 +504,7 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412"))
 }
 
-func TestHPALabelSelectorFiltering(t *testing.T) {
+func TestAutoscalerAutogenLabelSelectorFiltering(t *testing.T) {
 	f := newAutoscalerFixture(t)
 
 	f.hpaLister = []*autoscaler.HorizontalPodAutoscaler{
@@ -509,7 +518,7 @@ func TestHPALabelSelectorFiltering(t *testing.T) {
 				},
 			},
 		}),
-		// hpa1 does NOT match label selector, but has datadogmetric@ reference — included via OR
+		// hpa1 does NOT match label selector, but has datadogmetric@ reference — included via direct reference
 		newFakeHorizontalPodAutoscalerWithLabels("ns0", "hpa1", map[string]string{"app.kubernetes.io/managed-by": "keda-operator"}, []autoscaler.MetricSpec{
 			{
 				Type: autoscaler.ExternalMetricSourceType,
@@ -530,6 +539,37 @@ func TestHPALabelSelectorFiltering(t *testing.T) {
 		}),
 	}
 
+	f.wpaLister = []*unstructured.Unstructured{
+		// wpa0 matches label selector, no datadogmetric@ reference — included via label match
+		newFakeWatermarkPodAutoscalerWithLabels("ns0", "wpa0", map[string]string{"team": "infra"}, []interface{}{
+			map[string]interface{}{
+				"external": map[string]interface{}{
+					"metricName": "docker.cpu.usage",
+					"metricSelector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"bar": "foo",
+						},
+					},
+				},
+				"type": "External",
+			},
+		}),
+		// wpa1 does NOT match label selector and has no datadogmetric@ reference — excluded
+		newFakeWatermarkPodAutoscalerWithLabels("ns0", "wpa1", map[string]string{"app.kubernetes.io/managed-by": "keda-operator"}, []interface{}{
+			map[string]interface{}{
+				"external": map[string]interface{}{
+					"metricName": "keda_wpa_metric",
+					"metricSelector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"queue": "jobs",
+						},
+					},
+				},
+				"type": "External",
+			},
+		}),
+	}
+
 	ddm := model.DatadogMetricInternal{
 		ID:         "default/dd-metric-ref",
 		Active:     false,
@@ -541,7 +581,7 @@ func TestHPALabelSelectorFiltering(t *testing.T) {
 	ddm.SetQueries("metric query ref")
 	f.store.Set("default/dd-metric-ref", ddm, "utest")
 
-	// Parse a selector that excludes HPAs with app.kubernetes.io/managed-by=keda-operator
+	// Parse a selector that excludes autoscalers with app.kubernetes.io/managed-by=keda-operator
 	selector, err := labels.Parse("app.kubernetes.io/managed-by!=keda-operator")
 	assert.NoError(t, err)
 
@@ -556,12 +596,20 @@ func TestHPALabelSelectorFiltering(t *testing.T) {
 	// Check all store entries for autoscaler references
 	foundHpa0Ref := false
 	foundHpa2Ref := false
+	foundWpa0Ref := false
+	foundWpa1Ref := false
 	for _, m := range f.store.GetAll() {
 		if m.AutoscalerReferences == "hpa:ns0/hpa0" {
 			foundHpa0Ref = true
 		}
 		if m.AutoscalerReferences == "hpa:ns0/hpa2" {
 			foundHpa2Ref = true
+		}
+		if m.AutoscalerReferences == "wpa:ns0/wpa0" {
+			foundWpa0Ref = true
+		}
+		if m.AutoscalerReferences == "wpa:ns0/wpa1" {
+			foundWpa1Ref = true
 		}
 	}
 
@@ -576,4 +624,10 @@ func TestHPALabelSelectorFiltering(t *testing.T) {
 
 	// hpa2 should be excluded — no label match, no datadogmetric@ reference
 	assert.False(t, foundHpa2Ref, "hpa2 should be excluded (no label match and no datadogmetric@ reference)")
+
+	// wpa0 matched label selector — should be included and create autogen metric
+	assert.True(t, foundWpa0Ref, "wpa0 should be included (matches label selector)")
+
+	// wpa1 should be excluded — no label match, no datadogmetric@ reference
+	assert.False(t, foundWpa1Ref, "wpa1 should be excluded (no label match and no datadogmetric@ reference)")
 }

--- a/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher_test.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher_test.go
@@ -16,6 +16,7 @@ import (
 	autoscaler "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	dynamic_informer "k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/dynamic/fake"
@@ -60,7 +61,7 @@ func newAutoscalerFixture(t *testing.T) *autoscalerFixture {
 	}
 }
 
-func (f *autoscalerFixture) newAutoscalerWatcher() (*AutoscalerWatcher, kube_informer.SharedInformerFactory, dynamic_informer.DynamicSharedInformerFactory) {
+func (f *autoscalerFixture) newAutoscalerWatcher(selector labels.Selector) (*AutoscalerWatcher, kube_informer.SharedInformerFactory, dynamic_informer.DynamicSharedInformerFactory) {
 	for _, hpa := range f.hpaLister {
 		f.kubeObjects = append(f.kubeObjects, hpa)
 	}
@@ -85,7 +86,7 @@ func (f *autoscalerFixture) newAutoscalerWatcher() (*AutoscalerWatcher, kube_inf
 	wpaClient := fake.NewSimpleDynamicClient(scheme, f.wpaObjects...)
 	wpaInformer := dynamic_informer.NewDynamicSharedInformerFactory(wpaClient, noResyncPeriodFunc())
 
-	autoscalerWatcher, err := NewAutoscalerWatcher(0, true, 1, "default", kubeClient, kubeInformer, wpaInformer, getIsLeaderFunction(true), &f.store)
+	autoscalerWatcher, err := NewAutoscalerWatcher(0, true, 1, "default", selector, kubeClient, kubeInformer, wpaInformer, getIsLeaderFunction(true), &f.store)
 	if err != nil {
 		return nil, nil, nil
 	}
@@ -104,7 +105,7 @@ func (f *autoscalerFixture) newAutoscalerWatcher() (*AutoscalerWatcher, kube_inf
 }
 
 func (f *autoscalerFixture) runWatcherUpdate() {
-	autoscalerWatcher, kubeInformer, wpaInformer := f.newAutoscalerWatcher()
+	autoscalerWatcher, kubeInformer, wpaInformer := f.newAutoscalerWatcher(nil)
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	kubeInformer.Start(stopCh)
@@ -114,10 +115,15 @@ func (f *autoscalerFixture) runWatcherUpdate() {
 }
 
 func newFakeHorizontalPodAutoscaler(ns, name string, metrics []autoscaler.MetricSpec) *autoscaler.HorizontalPodAutoscaler {
+	return newFakeHorizontalPodAutoscalerWithLabels(ns, name, nil, metrics)
+}
+
+func newFakeHorizontalPodAutoscalerWithLabels(ns, name string, hpaLabels map[string]string, metrics []autoscaler.MetricSpec) *autoscaler.HorizontalPodAutoscaler {
 	return &autoscaler.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
 			Name:      name,
+			Labels:    hpaLabels,
 		},
 		Spec: autoscaler.HorizontalPodAutoscalerSpec{
 			Metrics: metrics,
@@ -381,7 +387,7 @@ func TestDisableDatadogMetricAutogen(t *testing.T) {
 		}),
 	}
 
-	autoscalerWatcher, kubeInformer, wpaInformer := f.newAutoscalerWatcher()
+	autoscalerWatcher, kubeInformer, wpaInformer := f.newAutoscalerWatcher(nil)
 	autoscalerWatcher.autogenEnabled = false
 
 	stopCh := make(chan struct{})
@@ -487,4 +493,87 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 	}
 	ddm.SetQueries("avg:docker.cpu.usage{bar:foo}.rollup(30)")
 	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412"))
+}
+
+func TestHPALabelSelectorFiltering(t *testing.T) {
+	f := newAutoscalerFixture(t)
+
+	f.hpaLister = []*autoscaler.HorizontalPodAutoscaler{
+		// hpa0 matches label selector, no datadogmetric@ reference — included via label match
+		newFakeHorizontalPodAutoscalerWithLabels("ns0", "hpa0", map[string]string{"team": "infra"}, []autoscaler.MetricSpec{
+			{
+				Type: autoscaler.ExternalMetricSourceType,
+				External: &autoscaler.ExternalMetricSource{
+					MetricName:     "requests_per_s",
+					MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kube_container_name": "app"}},
+				},
+			},
+		}),
+		// hpa1 does NOT match label selector, but has datadogmetric@ reference — included via OR
+		newFakeHorizontalPodAutoscalerWithLabels("ns0", "hpa1", map[string]string{"app.kubernetes.io/managed-by": "keda-operator"}, []autoscaler.MetricSpec{
+			{
+				Type: autoscaler.ExternalMetricSourceType,
+				External: &autoscaler.ExternalMetricSource{
+					MetricName: "datadogmetric@default:dd-metric-ref",
+				},
+			},
+		}),
+		// hpa2 does NOT match label selector and has no datadogmetric@ reference — excluded
+		newFakeHorizontalPodAutoscalerWithLabels("ns0", "hpa2", map[string]string{"app.kubernetes.io/managed-by": "keda-operator"}, []autoscaler.MetricSpec{
+			{
+				Type: autoscaler.ExternalMetricSourceType,
+				External: &autoscaler.ExternalMetricSource{
+					MetricName:     "keda_metric",
+					MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"queue": "jobs"}},
+				},
+			},
+		}),
+	}
+
+	ddm := model.DatadogMetricInternal{
+		ID:         "default/dd-metric-ref",
+		Active:     false,
+		Valid:      true,
+		Value:      20.0,
+		UpdateTime: time.Now(),
+		Error:      nil,
+	}
+	ddm.SetQueries("metric query ref")
+	f.store.Set("default/dd-metric-ref", ddm, "utest")
+
+	// Parse a selector that excludes HPAs with app.kubernetes.io/managed-by=keda-operator
+	selector, err := labels.Parse("app.kubernetes.io/managed-by!=keda-operator")
+	assert.NoError(t, err)
+
+	autoscalerWatcher, kubeInformer, wpaInformer := f.newAutoscalerWatcher(selector)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	kubeInformer.Start(stopCh)
+	wpaInformer.Start(stopCh)
+
+	autoscalerWatcher.processAutoscalers()
+
+	// Check all store entries for autoscaler references
+	foundHpa0Ref := false
+	foundHpa2Ref := false
+	for _, m := range f.store.GetAll() {
+		if m.AutoscalerReferences == "hpa:ns0/hpa0" {
+			foundHpa0Ref = true
+		}
+		if m.AutoscalerReferences == "hpa:ns0/hpa2" {
+			foundHpa2Ref = true
+		}
+	}
+
+	// hpa0 matched label selector — should be included and create autogen metric
+	assert.True(t, foundHpa0Ref, "hpa0 should be included (matches label selector)")
+
+	// hpa1 has datadogmetric@ reference — dd-metric-ref should be active despite failing label selector
+	refMetric := f.store.Get("default/dd-metric-ref")
+	assert.NotNil(t, refMetric)
+	assert.True(t, refMetric.Active)
+	assert.Equal(t, "hpa:ns0/hpa1", refMetric.AutoscalerReferences)
+
+	// hpa2 should be excluded — no label match, no datadogmetric@ reference
+	assert.False(t, foundHpa2Ref, "hpa2 should be excluded (no label match and no datadogmetric@ reference)")
 }

--- a/pkg/clusteragent/autoscaling/externalmetrics/provider.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/provider.go
@@ -86,14 +86,14 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient, d
 	}
 	go metricsRetriever.Run(ctx.Done())
 
-	selectorStr := pkgconfigsetup.Datadog().GetString("external_metrics_provider.hpa_label_selector")
-	var hpaLabelSelector labels.Selector
-	hpaLabelSelector, err = labels.Parse(selectorStr)
+	selectorStr := pkgconfigsetup.Datadog().GetString("external_metrics_provider.autoscaler_autogen_label_selector")
+	var autoscalerAutogenLabelSelector labels.Selector
+	autoscalerAutogenLabelSelector, err = labels.Parse(selectorStr)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse external_metrics_provider.hpa_label_selector %q: %v", selectorStr, err)
+		return nil, fmt.Errorf("unable to parse external_metrics_provider.autoscaler_autogen_label_selector %q: %v", selectorStr, err)
 	}
 	if selectorStr != "" {
-		log.Infof("HPA label selector configured: %s", selectorStr)
+		log.Infof("Autoscaler autogen label selector configured: %s", selectorStr)
 	}
 
 	var wpaInformer dynamicinformer.DynamicSharedInformerFactory
@@ -108,7 +108,7 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient, d
 		autogenEnabled,
 		autogenExpirationPeriodHours,
 		autogenNamespace,
-		hpaLabelSelector,
+		autoscalerAutogenLabelSelector,
 		apiCl.Cl,
 		apiCl.InformerFactory,
 		wpaInformer,

--- a/pkg/clusteragent/autoscaling/externalmetrics/provider.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/provider.go
@@ -86,6 +86,16 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient, d
 	}
 	go metricsRetriever.Run(ctx.Done())
 
+	selectorStr := pkgconfigsetup.Datadog().GetString("external_metrics_provider.hpa_label_selector")
+	var hpaLabelSelector labels.Selector
+	hpaLabelSelector, err = labels.Parse(selectorStr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse external_metrics_provider.hpa_label_selector %q: %v", selectorStr, err)
+	}
+	if selectorStr != "" {
+		log.Infof("HPA label selector configured: %s", selectorStr)
+	}
+
 	var wpaInformer dynamicinformer.DynamicSharedInformerFactory
 	if wpaEnabled {
 		wpaInformer = apiCl.DynamicInformerFactory
@@ -98,6 +108,7 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient, d
 		autogenEnabled,
 		autogenExpirationPeriodHours,
 		autogenNamespace,
+		hpaLabelSelector,
 		apiCl.Cl,
 		apiCl.InformerFactory,
 		wpaInformer,

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -573,30 +573,30 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("hpa_configmap_name", "datadog-custom-metrics")
 	config.BindEnvAndSetDefault("external_metrics_provider.enabled", false)
 	config.BindEnvAndSetDefault("external_metrics_provider.port", 8443)
-	config.BindEnvAndSetDefault("external_metrics_provider.endpoint", "")                       // Override the Datadog API endpoint to query external metrics from
-	config.BindEnvAndSetDefault("external_metrics_provider.api_key", "")                        // Override the Datadog API Key for external metrics endpoint
-	config.BindEnvAndSetDefault("external_metrics_provider.app_key", "")                        // Override the Datadog APP Key for external metrics endpoint
-	config.SetDefault("external_metrics_provider.endpoints", []interface{}{})                   // List of redundant endpoints to query external metrics from
-	config.BindEnvAndSetDefault("external_metrics_provider.refresh_period", 30)                 // value in seconds. Frequency of calls to Datadog to refresh metric values
-	config.BindEnvAndSetDefault("external_metrics_provider.batch_window", 10)                   // value in seconds. Batch the events from the Autoscalers informer to push updates to the ConfigMap (GlobalStore)
-	config.BindEnvAndSetDefault("external_metrics_provider.max_age", 120)                       // value in seconds. 4 cycles from the Autoscaler controller (up to Kubernetes 1.11) is enough to consider a metric stale
-	config.BindEnvAndSetDefault("external_metrics_provider.query_validity_period", 30)          // value in seconds. Represents grace period to account for delay between metric is resolved and when autoscaling controllers query for it
-	config.BindEnvAndSetDefault("external_metrics.aggregator", "avg")                           // aggregator used for the external metrics. Choose from [avg,sum,max,min]
-	config.BindEnvAndSetDefault("external_metrics_provider.max_time_window", 60*60*24)          // Maximum window to query to get the metric from Datadog.
-	config.BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)                  // Window to query to get the metric from Datadog.
-	config.BindEnvAndSetDefault("external_metrics_provider.rollup", 30)                         // Bucket size to circumvent time aggregation side effects.
-	config.BindEnvAndSetDefault("external_metrics_provider.wpa_controller", false)              // Activates the controller for Watermark Pod Autoscalers.
-	config.BindEnvAndSetDefault("external_metrics_provider.use_datadogmetric_crd", false)       // Use DatadogMetric CRD with custom Datadog Queries instead of ConfigMap
-	config.BindEnvAndSetDefault("external_metrics_provider.enable_datadogmetric_autogen", true) // Enables autogeneration of DatadogMetrics when the DatadogMetric CRD is in use
-	config.BindEnvAndSetDefault("external_metrics_provider.hpa_label_selector", "")             // Label selector to filter which HPAs the DCA watches (e.g. "app.kubernetes.io/managed-by!=not-dca")
-	config.BindEnvAndSetDefault("kubernetes_event_collection_timeout", 100)                     // timeout between two successful event collections in milliseconds.
-	config.BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)                     // value in seconds. Default to 5 minutes
-	config.BindEnvAndSetDefault("external_metrics_provider.config", map[string]string{})        // list of options that can be used to configure the external metrics server
-	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30)        // value in seconds
-	config.BindEnvAndSetDefault("external_metrics_provider.chunk_size", 35)                     // Maximum number of queries to batch when querying Datadog.
-	config.BindEnvAndSetDefault("external_metrics_provider.split_batches_with_backoff", false)  // Splits batches and runs queries with errors individually with an exponential backoff
-	config.BindEnvAndSetDefault("external_metrics_provider.num_workers", 2)                     // Number of workers spawned by controller (only when CRD is used)
-	config.BindEnvAndSetDefault("external_metrics_provider.max_parallel_queries", 10)           // Maximum number of parallel queries sent to Datadog simultaneously
+	config.BindEnvAndSetDefault("external_metrics_provider.endpoint", "")                          // Override the Datadog API endpoint to query external metrics from
+	config.BindEnvAndSetDefault("external_metrics_provider.api_key", "")                           // Override the Datadog API Key for external metrics endpoint
+	config.BindEnvAndSetDefault("external_metrics_provider.app_key", "")                           // Override the Datadog APP Key for external metrics endpoint
+	config.SetDefault("external_metrics_provider.endpoints", []interface{}{})                      // List of redundant endpoints to query external metrics from
+	config.BindEnvAndSetDefault("external_metrics_provider.refresh_period", 30)                    // value in seconds. Frequency of calls to Datadog to refresh metric values
+	config.BindEnvAndSetDefault("external_metrics_provider.batch_window", 10)                      // value in seconds. Batch the events from the Autoscalers informer to push updates to the ConfigMap (GlobalStore)
+	config.BindEnvAndSetDefault("external_metrics_provider.max_age", 120)                          // value in seconds. 4 cycles from the Autoscaler controller (up to Kubernetes 1.11) is enough to consider a metric stale
+	config.BindEnvAndSetDefault("external_metrics_provider.query_validity_period", 30)             // value in seconds. Represents grace period to account for delay between metric is resolved and when autoscaling controllers query for it
+	config.BindEnvAndSetDefault("external_metrics.aggregator", "avg")                              // aggregator used for the external metrics. Choose from [avg,sum,max,min]
+	config.BindEnvAndSetDefault("external_metrics_provider.max_time_window", 60*60*24)             // Maximum window to query to get the metric from Datadog.
+	config.BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)                     // Window to query to get the metric from Datadog.
+	config.BindEnvAndSetDefault("external_metrics_provider.rollup", 30)                            // Bucket size to circumvent time aggregation side effects.
+	config.BindEnvAndSetDefault("external_metrics_provider.wpa_controller", false)                 // Activates the controller for Watermark Pod Autoscalers.
+	config.BindEnvAndSetDefault("external_metrics_provider.use_datadogmetric_crd", false)          // Use DatadogMetric CRD with custom Datadog Queries instead of ConfigMap
+	config.BindEnvAndSetDefault("external_metrics_provider.enable_datadogmetric_autogen", true)    // Enables autogeneration of DatadogMetrics when the DatadogMetric CRD is in use
+	config.BindEnvAndSetDefault("external_metrics_provider.autoscaler_autogen_label_selector", "") // Label selector to filter which HPAs and WPAs the DCA generates DatadogMetrics for (e.g. "app.kubernetes.io/managed-by!=keda-operator")
+	config.BindEnvAndSetDefault("kubernetes_event_collection_timeout", 100)                        // timeout between two successful event collections in milliseconds.
+	config.BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)                        // value in seconds. Default to 5 minutes
+	config.BindEnvAndSetDefault("external_metrics_provider.config", map[string]string{})           // list of options that can be used to configure the external metrics server
+	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30)           // value in seconds
+	config.BindEnvAndSetDefault("external_metrics_provider.chunk_size", 35)                        // Maximum number of queries to batch when querying Datadog.
+	config.BindEnvAndSetDefault("external_metrics_provider.split_batches_with_backoff", false)     // Splits batches and runs queries with errors individually with an exponential backoff
+	config.BindEnvAndSetDefault("external_metrics_provider.num_workers", 2)                        // Number of workers spawned by controller (only when CRD is used)
+	config.BindEnvAndSetDefault("external_metrics_provider.max_parallel_queries", 10)              // Maximum number of parallel queries sent to Datadog simultaneously
 	// DatadogInstrumentation controller
 	config.BindEnvAndSetDefault("instrumentation_crd_controller.enabled", false)
 	// Cluster check Autodiscovery

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -588,6 +588,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("external_metrics_provider.wpa_controller", false)              // Activates the controller for Watermark Pod Autoscalers.
 	config.BindEnvAndSetDefault("external_metrics_provider.use_datadogmetric_crd", false)       // Use DatadogMetric CRD with custom Datadog Queries instead of ConfigMap
 	config.BindEnvAndSetDefault("external_metrics_provider.enable_datadogmetric_autogen", true) // Enables autogeneration of DatadogMetrics when the DatadogMetric CRD is in use
+	config.BindEnvAndSetDefault("external_metrics_provider.hpa_label_selector", "")             // Label selector to filter which HPAs the DCA watches (e.g. "app.kubernetes.io/managed-by!=not-dca")
 	config.BindEnvAndSetDefault("kubernetes_event_collection_timeout", 100)                     // timeout between two successful event collections in milliseconds.
 	config.BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)                     // value in seconds. Default to 5 minutes
 	config.BindEnvAndSetDefault("external_metrics_provider.config", map[string]string{})        // list of options that can be used to configure the external metrics server

--- a/releasenotes-dca/notes/ext-metrics-autogen-label-selector-a6c534ec22109875.yaml
+++ b/releasenotes-dca/notes/ext-metrics-autogen-label-selector-a6c534ec22109875.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add ``external_metrics_provider.autoscaler_autogen_label_selector`` configuration option to the Cluster Agent.
+    When set, only HPAs and WPAs matching the label selector trigger autogeneration of ``DatadogMetric`` objects.
+    Autoscalers with explicit ``datadogmetric@`` references are always tracked regardless of the selector.
+    This allows filtering out autoscalers managed by other controllers (e.g. KEDA) to avoid creating unwanted ``DatadogMetric`` objects.


### PR DESCRIPTION
### What does this PR do?

Adds a new ``external_metrics_provider.hpa_label_selector`` configuration option to the Cluster Agent's external metrics provider. When set, only HPAs whose labels match the selector can trigger autogeneration of `DatadogMetric` objects. HPAs with explicit `datadogmetric@namespace/name` references are always tracked regardless of the selector.

### Motivation

In clusters where multiple autoscalers coexist (e.g. Datadog DCA and KEDA), the DCA would previously autogenerate `DatadogMetric` objects for every HPA using raw metric names — including HPAs managed by KEDA. This created noise and could cause conflicts. The label selector lets operators scope which HPAs the DCA "owns" for autogeneration purposes.

Example configuration to exclude KEDA-managed HPAs:
```yaml
external_metrics_provider:
  hpa_label_selector: "app.kubernetes.io/managed-by!=keda-operator"
```

### Describe how you validated your changes

Deploy Cluster Agent with external metrics enabled. Set `external_metrics_provider.hpa_label_selector`, observe that Autogen `DatadogMetric` are not generated for these HPAs but HPAs referencing explicit `DatadogMetric` should still work (even if they have label)

### Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)