### PR TITLE
[codex] Use local rshell path modes for PAR POC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ replace (
 	// spf13/viper v1.21.0 requires cast v1.10.0 functions (ToUintSlice, ToFloat64Slice) that
 	// do not exist in the DataDog/cast v1.8.0 fork. Pin viper to v1.20.1 which uses cast v1.7.1.
 	github.com/spf13/viper => github.com/spf13/viper v1.20.1
+	// POC: use the local rshell path-mode branch for private action runner testing.
+	github.com/DataDog/rshell => /Users/matthew.deguzman/worktrees/rshell-path-modes-poc
 	// To update the Datadog/opentelemetry-ebpf-profiler dependency on latest commit on datadog branch, change the following line to:
 	// replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler datadog
 	// and run `go mod tidy` then `dda inv tidy`


### PR DESCRIPTION
## Summary

This is a draft POC branch for building a custom agent/PAR against the local rshell path-mode branch.

- adds a temporary `go.mod` replace for `github.com/DataDog/rshell`
- points that replace at `/Users/matthew.deguzman/worktrees/rshell-path-modes-poc`
- lets the private action runner rshell bundle resolve the local rshell implementation with `:ro` / `:rw` path-mode parsing

## Notes

This is intentionally not production dependency wiring. The replace uses a local absolute path so this branch is for custom local agent builds only. Before merging anything real, we should replace this with a tagged rshell release or pinned module version once the rshell PR lands.

## Validation

- `go list -m -json github.com/DataDog/rshell`
- `go test ./pkg/privateactionrunner/bundles/remoteaction/rshell`