### PR TITLE
Bring all references to Python version related constants to a single place

### DIFF
--- a/bazel/repo/constants_repo.bzl
+++ b/bazel/repo/constants_repo.bzl
@@ -1,0 +1,34 @@
+"""Generate a repository containing Starlark constants.
+
+Usage:
+    constants_repo = use_repo_rule("//bazel/repo:constants_repo.bzl", "constants_repo")
+    constants_repo(
+        name = "my_constants",
+        items = {
+            "FOO": "bar",
+        },
+    )
+
+    load("@my_constants//:constants.bzl", "FOO")
+"""
+
+BUILD_FILE_CONTENT = """
+exports_files(["constants.bzl"])
+"""
+
+def _constants_repo_impl(rctx):
+    rctx.file("BUILD.bazel", BUILD_FILE_CONTENT)
+
+    content = "".join([
+        "{} = {}\n".format(key, json.encode(value))
+        for key, value in sorted(rctx.attr.items.items())
+    ])
+    rctx.file("constants.bzl", content)
+
+constants_repo = repository_rule(
+    implementation = _constants_repo_impl,
+    attrs = {
+        "items": attr.string_dict(mandatory = True, doc = "Map of constant names to values."),
+    },
+    doc = """Generate a repository containing a constants.bzl file.""",
+)

--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -7,6 +7,7 @@ load("@//deps/openssl:version.bzl", "OPENSSL_VERSION")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@bazel_skylib//rules:select_file.bzl", "select_file")
+load("@cpython_versions//:constants.bzl", "PYTHON_MAJOR_MINOR", "PYTHON_MAJOR_MINOR_FLAT")
 load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
@@ -22,9 +23,6 @@ python_externals = {
     "libffi": "3.4.4",
     "tcltk": "8.6.15.0",
 }
-
-VERSION_STR = "3.13"
-VERSION_STR_FLAT = VERSION_STR.replace(".", "")
 
 # These rules will make it easier to get a reference to their folder via $(location)
 # and they add the version in the folder name (as some of the vcxproj stuff relies on that)
@@ -95,7 +93,7 @@ run_binary(
         for file in [
             "python.exe",
             "python3.dll",
-            "python{}.dll".format(VERSION_STR_FLAT),
+            "python{}.dll".format(PYTHON_MAJOR_MINOR_FLAT),
             "pythonw.exe",
             "vcruntime140.dll",
             "vcruntime140_1.dll",
@@ -125,13 +123,13 @@ select_file(
 select_file(
     name = "python_win_lib",
     srcs = "python_win",
-    subpath = "build/python{}.dll".format(VERSION_STR_FLAT),
+    subpath = "build/python{}.dll".format(PYTHON_MAJOR_MINOR_FLAT),
     visibility = ["//visibility:public"],
 )
 
 cc_import(
-    name = "_python313_dll",
-    shared_library = "build/python{}.dll".format(VERSION_STR_FLAT),
+    name = "_python_dll",
+    shared_library = "build/python{}.dll".format(PYTHON_MAJOR_MINOR_FLAT),
     visibility = ["//visibility:private"],
 )
 
@@ -141,7 +139,7 @@ cc_library(
     name = "lib_win",
     hdrs = [":headers_win"],
     includes = ["build/include"],
-    deps = [":_python313_dll"],
+    deps = [":_python_dll"],
     visibility = ["//visibility:public"],
 )
 
@@ -151,12 +149,12 @@ filegroup(
 )
 
 UNIX_BINS = [
-    "pip{}".format(VERSION_STR),
-    "python{}".format(VERSION_STR),
+    "pip{}".format(PYTHON_MAJOR_MINOR),
+    "python{}".format(PYTHON_MAJOR_MINOR),
 ]
 
-LINUX_SO = "libpython{}.so.1.0".format(VERSION_STR)
-MACOS_DYLIB = "libpython{}.dylib".format(VERSION_STR)
+LINUX_SO = "libpython{}.so.1.0".format(PYTHON_MAJOR_MINOR)
+MACOS_DYLIB = "libpython{}.dylib".format(PYTHON_MAJOR_MINOR)
 
 python_deps = {
     "libffi": "-lffi",
@@ -233,7 +231,7 @@ configure_make(
     lib_source = ":all_srcs",
     out_binaries = UNIX_BINS,
     out_data_dirs = [
-        "lib/python{}".format(VERSION_STR),
+        "lib/python{}".format(PYTHON_MAJOR_MINOR),
     ],
     out_data_files = select({
         "@platforms//os:linux": [
@@ -273,7 +271,7 @@ configure_make(
         "@xz//:lzma_pkg",
         "@zlib//:z_pkg",
     ],
-    includes = ["python{}".format(VERSION_STR)],
+    includes = ["python{}".format(PYTHON_MAJOR_MINOR)],
     targets = [
         # Build in parallel but install without parallel execution
         # (see https://github.com/python/cpython/issues/109796)
@@ -300,7 +298,7 @@ configure_make(
       --sandbox-prefix "$$BUILD_TMPDIR/$$INSTALL_PREFIX" \
       $$INSTALLDIR/lib/python{version}/_sysconfigdata__*.py
     """.format(
-        version = VERSION_STR,
+        version = PYTHON_MAJOR_MINOR,
     ),
 )
 
@@ -316,9 +314,9 @@ foreign_cc_shared_wrapper(
 foreign_cc_runnable(
     name = "python_unix_runnable",
     input = ":python_unix",
-    binary_path = "bin/python{}".format(VERSION_STR),
+    binary_path = "bin/python{}".format(PYTHON_MAJOR_MINOR),
     patch_globs = [
-        "lib/python{}/lib-dynload/*.so".format(VERSION_STR),
+        "lib/python{}/lib-dynload/*.so".format(PYTHON_MAJOR_MINOR),
     ],
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
@@ -370,13 +368,13 @@ dd_collect_dependencies(
 select_file(
     name = "python_lib_dir_group_unix",
     srcs = ":python_unix",
-    subpath = "lib/python{}".format(VERSION_STR),
+    subpath = "lib/python{}".format(PYTHON_MAJOR_MINOR),
 )
 
 select_file(
     name = "python3_bin",
     srcs = ":python_unix",
-    subpath = "bin/python{}".format(VERSION_STR),
+    subpath = "bin/python{}".format(PYTHON_MAJOR_MINOR),
     visibility = ["//visibility:public"],
 )
 
@@ -389,14 +387,14 @@ copy_to_directory(
         "**/*.exe",
         "**/Makefile",
     ],
-    root_paths = ["python_unix/lib/python{}".format(VERSION_STR)],
-    out = "python{}".format(VERSION_STR),
+    root_paths = ["python_unix/lib/python{}".format(PYTHON_MAJOR_MINOR)],
+    out = "python{}".format(PYTHON_MAJOR_MINOR),
 )
 
 filegroup(
     name = "pip_exec",
     srcs = [":python_unix"],
-    output_group = "pip{}".format(VERSION_STR),
+    output_group = "pip{}".format(PYTHON_MAJOR_MINOR),
 )
 
 genrule(
@@ -409,21 +407,21 @@ genrule(
 dd_agent_expand_template(
     name = "patch_pip_interpreter",
     template = ":patch_pip_shebang",
-    out = "pip{}".format(VERSION_STR),
+    out = "pip{}".format(PYTHON_MAJOR_MINOR),
 )
 
 # Create symlinks for libpython (rules_pkg 1.2+ supports symlinks in pkg_install)
 pkg_mklink(
     name = "libpython_symlink",
-    link_name = "lib/libpython{}.so".format(VERSION_STR),
+    link_name = "lib/libpython{}.so".format(PYTHON_MAJOR_MINOR),
     target = LINUX_SO,
     attributes = pkg_attributes("0644"),
 )
 
 BIN_SYMLINKS = {
-    "bin/python3": "python{}".format(VERSION_STR),
+    "bin/python3": "python{}".format(PYTHON_MAJOR_MINOR),
     "bin/python": "python3",
-    "bin/pip3": "pip{}".format(VERSION_STR),
+    "bin/pip3": "pip{}".format(PYTHON_MAJOR_MINOR),
     "bin/pip": "pip3",
 }
 
@@ -495,7 +493,7 @@ dd_cc_packaged(
     installed_files = [":_python_pkg_common_files"],
     installed_executables = {
         ":python3_bin": "bin",
-        ":python_lib_dir_unix": "lib/python{}".format(VERSION_STR),
+        ":python_lib_dir_unix": "lib/python{}".format(PYTHON_MAJOR_MINOR),
     } | select({
         "@platforms//os:linux": {":python_stable_lib_linux": "lib"},
         "//conditions:default": {},

--- a/deps/cpython/cpython.MODULE.bazel
+++ b/deps/cpython/cpython.MODULE.bazel
@@ -1,6 +1,21 @@
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+constants_repo = use_repo_rule("//bazel/repo:constants_repo.bzl", "constants_repo")
+
 PYTHON_VERSION = "3.13.13"
+
+PYTHON_MAJOR_MINOR = ".".join(PYTHON_VERSION.split(".")[:2])
+
+PYTHON_MAJOR_MINOR_FLAT = PYTHON_MAJOR_MINOR.replace(".", "")
+
+constants_repo(
+    name = "cpython_versions",
+    items = {
+        "PYTHON_MAJOR_MINOR": PYTHON_MAJOR_MINOR,
+        "PYTHON_MAJOR_MINOR_FLAT": PYTHON_MAJOR_MINOR_FLAT,
+        "PYTHON_VERSION": PYTHON_VERSION,
+    },
+)
 
 http_archive(
     name = "cpython",

--- a/rtloader/BUILD.bazel
+++ b/rtloader/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@cpython_versions//:constants.bzl", "PYTHON_MAJOR_MINOR")
 load("@rules_cc//cc:cc_static_library.bzl", "cc_static_library")
 load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library", "cc_shared_library")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
@@ -108,9 +109,9 @@ dd_agent_expand_template(
     name = "constants_gen",
     out = "constants.h",
     substitutions = {
-        # TODO(agent-build): either get rid of the need for this substitution or
-        # use a single source of truth for the version
-        "@Python3_STDLIB@": "{install_dir}/embedded/lib/python3.13",
+        # TODO(agent-build): This fallback value is probably never used in practice.
+        # We could consider removing it in the future.
+        "@Python3_STDLIB@": "{{install_dir}}/embedded/lib/python{}".format(PYTHON_MAJOR_MINOR),
     },
     template = "three/constants.h.in",
 )


### PR DESCRIPTION
### What does this PR do?

Adds a repository rule to share constants from MODULE files to BUILD files, and uses it to unify the sources of truth for python version related constants.

### Motivation

I'm about to add yet another place where this version is relevant (integrations-core lockfiles include the python version in their name, [ABLD-260](https://datadoghq.atlassian.net/browse/ABLD-260)).

### Describe how you validated your changes

Build and tests pass.

### Additional Notes

This is a surprisingly tricky problem, because MODULE.bazel files can't get data from any other file at all, making sharing very difficult.

The only solutions that would give us any hope of better centralization would probably be:
- Centralize all http_archive's in a single place, selectively expose constants if build rules actually needed (which is actually fairly uncommon, probably, beyond the case of Python specifically).
- Use custom repo_rules and/or module extensions to wrap http_archive (like https://github.com/DataDog/datadog-agent/pull/43376 implemented, but never got merged). This is the only way to create an `all_deps.bzl` file of sorts that would also be readable by rules if needed.

This PR addresses the problem locally to be able to stop the bleeding when it comes to Python version references – any other solution will be deferred to future work.

[ABLD-260]: https://datadoghq.atlassian.net/browse/ABLD-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ