### PR TITLE
add octo sts policies for release dashboard

### DIFF
--- a/.github/chainguard/release-dashboard-api-staging.sts.yaml
+++ b/.github/chainguard/release-dashboard-api-staging.sts.yaml
@@ -3,5 +3,5 @@ issuer: https://vault.us1.staging.dog/v1/identity/oidc
 subject: rapid-agent-delivery.release-dashboard-api@kubernetes.us1.staging.dog
 
 permissions:
-	contents: read
-	pull_requests: read
+  contents: read
+  pull_requests: read

--- a/.github/chainguard/release-dashboard-api-staging.sts.yaml
+++ b/.github/chainguard/release-dashboard-api-staging.sts.yaml
@@ -1,0 +1,7 @@
+# Issued to: rapid-agent-delivery/release-dashboard-api on us1 staging
+issuer: https://vault.us1.staging.dog/v1/identity/oidc
+subject: rapid-agent-delivery.release-dashboard-api@kubernetes.us1.staging.dog
+
+permissions:
+	contents: read
+	pull_requests: read

--- a/.github/chainguard/release-dashboard-api.sts.yaml
+++ b/.github/chainguard/release-dashboard-api.sts.yaml
@@ -1,0 +1,7 @@
+# Issued to: rapid-agent-delivery/release-dashboard-api on us1 prod
+issuer: https://vault.us1.prod.dog/v1/identity/oidc
+subject: rapid-agent-delivery.release-dashboard-api@kubernetes.us1.prod.dog
+
+permissions:
+	contents: read
+	pull_requests: read

--- a/.github/chainguard/release-dashboard-api.sts.yaml
+++ b/.github/chainguard/release-dashboard-api.sts.yaml
@@ -3,5 +3,5 @@ issuer: https://vault.us1.prod.dog/v1/identity/oidc
 subject: rapid-agent-delivery.release-dashboard-api@kubernetes.us1.prod.dog
 
 permissions:
-	contents: read
-	pull_requests: read
+  contents: read
+  pull_requests: read


### PR DESCRIPTION
### What does this PR do?
add dd-octo-sts polcies so we can perform read queries to the API from release dashboard

### Describe how you validated your changes
can only test the policy works after merging changes
