### PR TITLE
Improve Windows buildifier runner runfiles lookup

### DIFF
--- a/bazel/patches/buildifier-runner-bat-template.patch
+++ b/bazel/patches/buildifier-runner-bat-template.patch
@@ -2,18 +2,28 @@ diff --git a/buildifier/runner.bat.template b/buildifier/runner.bat.template
 index 13ca3fa..3c8882f 100644
 --- a/buildifier/runner.bat.template
 +++ b/buildifier/runner.bat.template
-@@ -11,7 +11,28 @@ set stripped_args=%stripped_args:'=%
+@@ -11,7 +11,38 @@ set stripped_args=%stripped_args:'=%
  rem Get the absolute path to the buildifier executable
 -for /f "tokens=2" %%i in ('findstr /r "\<buildifier\.exe\>" MANIFEST') do (set buildifier_abs_path=%%i)
++set "manifest_file="
 +if exist MANIFEST (
 +    set manifest_file=MANIFEST
 +) else if exist "%RUNFILES_MANIFEST_FILE%" (
 +    set "manifest_file=%RUNFILES_MANIFEST_FILE:/=\%"
-+) else (
++) else if exist "%~f0.runfiles\MANIFEST" (
++    set "manifest_file=%~f0.runfiles\MANIFEST"
++) else if exist "%TEST_SRCDIR%\MANIFEST" (
++    set "manifest_file=%TEST_SRCDIR%\MANIFEST"
++)
++if not defined manifest_file (
 +    >&2 echo Error: manifest file not found
 +    exit /b 1
 +)
 +for /f "tokens=2" %%i in ('findstr /r "\<buildifier\.exe\>" "%manifest_file%"') do (set buildifier_abs_path=%%i)
++if not defined buildifier_abs_path (
++    >&2 echo Error: buildifier.exe not found in manifest
++    exit /b 1
++)
  
  powershell ^
 +function Should-Exclude($Path)^
@@ -32,7 +42,7 @@ index 13ca3fa..3c8882f 100644
      Where-Object {^
 +        (^
          $_.Name -eq 'BUILD.bazel' `^
-@@ -28,2 +49,3 @@ $Files = Get-ChildItem -LiteralPath '%BUILD_WORKSPACE_DIRECTORY:/=\%' -Recurse -
+@@ -28,2 +59,3 @@ $Files = Get-ChildItem -LiteralPath '%BUILD_WORKSPACE_DIRECTORY:/=\%' -Recurse -
          -or $_.Name -clike 'WORKSPACE.*.oss'^
 +        ) -and -not (Should-Exclude $_.FullName)^
      };^


### PR DESCRIPTION
### What does this PR do?

This makes the Windows `buildifier` runner a little more forgiving about where it finds its runfiles manifest.

As a Windows user, I hit cases where `bazel run //bazel/buildifier` did not have a plain `MANIFEST` file in the current working directory, even though Bazel had produced the runfiles manifest next to the generated `.bat` runner. The existing patch already handled `RUNFILES_MANIFEST_FILE`, but not the adjacent `.runfiles\MANIFEST` layout used by `bazel run`, or the `%TEST_SRCDIR%\MANIFEST` layout used by tests.

This change updates the runner to look for the manifest in a few concrete places before failing:

- `MANIFEST`
- `%RUNFILES_MANIFEST_FILE%`
- `%~f0.runfiles\MANIFEST`
- `%TEST_SRCDIR%\MANIFEST`

Once it finds the manifest, it still resolves `buildifier.exe` from that manifest as before.

### Motivation

This avoids needing local workarounds like passing `--enable_runfiles=false` just to run or test the buildifier wrapper on Windows. It also keeps the lookup manifest-based, rather than scanning the runfiles tree, which makes failures faster and less surprising.

### Additional Notes

I ran the following for testing:

- `bazelisk run //bazel/buildifier`
- `bazelisk test //bazel/buildifier:test`