### PR TITLE
[DSCVR-438] Demo: config file ingestion pipeline (agent-side)

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -127,6 +127,8 @@ import (
 	healthplatformfx "github.com/DataDog/datadog-agent/comp/healthplatform/fx"
 	healthplatformimpl "github.com/DataDog/datadog-agent/comp/healthplatform/impl"
 	hostProfilerFlareFx "github.com/DataDog/datadog-agent/comp/host-profiler/flare/fx"
+	configingestiondef "github.com/DataDog/datadog-agent/comp/discovery/configingestion/def"
+	configingestionfx "github.com/DataDog/datadog-agent/comp/discovery/configingestion/fx"
 	langDetectionCl "github.com/DataDog/datadog-agent/comp/languagedetection/client/def"
 	langDetectionClimpl "github.com/DataDog/datadog-agent/comp/languagedetection/client/fx"
 	"github.com/DataDog/datadog-agent/comp/logs"
@@ -292,6 +294,7 @@ func run(log log.Component,
 	logReceiver option.Option[integrations.Component],
 	_ netflowServer.Component,
 	_ option.Option[langDetectionCl.Component],
+	_ option.Option[configingestiondef.Component],
 	_ internalAPI.Component,
 	_ packagesigning.Component,
 	_ systemprobemetadata.Component,
@@ -506,6 +509,7 @@ func getSharedFxOption() fx.Option {
 		}),
 		logs.Bundle(),
 		langDetectionClimpl.Module(),
+		configingestionfx.Module(),
 		metadata.Bundle(),
 		orchestratorForwarderImpl.Module(orchestratorForwarderImpl.NewDefaultParams()),
 		eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -931,6 +931,7 @@ func convertModelServiceToService(modelService *model.Service) *workloadmeta.Ser
 		UDPPorts:                 modelService.UDPPorts,
 		APMInstrumentation:       modelService.APMInstrumentation,
 		LogFiles:                 logFiles,
+		ConfigFiles:              modelService.ConfigFiles,
 		UST: workloadmeta.UST{
 			Service: modelService.UST.Service,
 			Env:     modelService.UST.Env,

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1692,6 +1692,10 @@ type Service struct {
 	// LogFiles are the log files associated with this service
 	LogFiles []string `proto:"ignore"`
 
+	// ConfigFiles are the configuration files associated with this service, discovered
+	// from the process command line and well-known paths.
+	ConfigFiles []string `proto:"ignore"`
+
 	// GeneratedNameSource indicates the source of the generated name
 	GeneratedNameSource string
 

--- a/comp/discovery/configingestion/def/BUILD.bazel
+++ b/comp/discovery/configingestion/def/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "def",
+    srcs = ["component.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/discovery/configingestion/def",
+    visibility = ["//visibility:public"],
+)

--- a/comp/discovery/configingestion/def/component.go
+++ b/comp/discovery/configingestion/def/component.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package configingestion provides experimental config file discovery and ingestion.
+package configingestion
+
+// team: agent-discovery
+
+// Component is the config file ingestion component interface.
+// It has no exported methods; lifecycle is managed via Fx hooks.
+type Component interface{}

--- a/comp/discovery/configingestion/fx/BUILD.bazel
+++ b/comp/discovery/configingestion/fx/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/discovery/configingestion/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/discovery/configingestion/def",
+        "//comp/discovery/configingestion/impl",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/discovery/configingestion/fx/fx.go
+++ b/comp/discovery/configingestion/fx/fx.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package fx provides the fx module for the config ingestion component.
+package fx
+
+import (
+	configingestiondef "github.com/DataDog/datadog-agent/comp/discovery/configingestion/def"
+	configingestionimpl "github.com/DataDog/datadog-agent/comp/discovery/configingestion/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the Fx options for the config ingestion component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			configingestionimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[configingestiondef.Component](),
+	)
+}

--- a/comp/discovery/configingestion/impl/BUILD.bazel
+++ b/comp/discovery/configingestion/impl/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "impl",
+    srcs = ["impl.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/discovery/configingestion/impl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/core/log/def",
+        "//comp/def",
+        "//comp/discovery/configingestion/def",
+        "//pkg/discovery/configingestion",
+        "//pkg/util/option",
+        "@//comp/core/workloadmeta/def",
+        "@//pkg/util/hostname",
+    ],
+)

--- a/comp/discovery/configingestion/impl/impl.go
+++ b/comp/discovery/configingestion/impl/impl.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package configingestionimpl implements the config ingestion Fx component.
+package configingestionimpl
+
+import (
+	"context"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	configingestiondef "github.com/DataDog/datadog-agent/comp/discovery/configingestion/def"
+	"github.com/DataDog/datadog-agent/pkg/discovery/configingestion"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+// hostnameResolutionTimeout caps the hostname lookup during Fx initialization
+// so a slow DNS query does not block agent startup indefinitely.
+const hostnameResolutionTimeout = 3 * time.Second
+
+// Requires defines the Fx dependencies.
+type Requires struct {
+	Lifecycle    compdef.Lifecycle
+	Config       config.Component
+	Log          log.Component
+	Workloadmeta workloadmeta.Component
+}
+
+// Provides defines the Fx outputs.
+type Provides struct {
+	Comp option.Option[configingestiondef.Component]
+}
+
+type impl struct {
+	watcher *configingestion.Watcher
+	log     log.Component
+}
+
+// NewComponent creates the config ingestion component.
+func NewComponent(reqs Requires) (Provides, error) {
+	if !reqs.Config.GetBool("discovery.config_ingestion.enabled") {
+		return Provides{Comp: option.None[configingestiondef.Component]()}, nil
+	}
+
+	intakeURL := reqs.Config.GetString("discovery.config_ingestion.intake_url")
+	// Re-use the agent's main API key. The key is read from the main agent
+	// config (datadog.yaml), consistent with discovery.config_ingestion.* keys
+	// which are registered there as well (see pkg/config/setup/system_probe.go
+	// until they are moved to the main config setup in a follow-up).
+	apiKey := reqs.Config.GetString("api_key")
+
+	hostCtx, cancel := context.WithTimeout(context.Background(), hostnameResolutionTimeout)
+	defer cancel()
+	hostID, err := hostname.Get(hostCtx)
+	if err != nil {
+		hostID = "unknown"
+		reqs.Log.Warnf("configingestion: could not determine hostname: %v", err)
+	}
+
+	w := configingestion.NewWatcher(reqs.Workloadmeta, configingestion.Config{
+		IntakeURL: intakeURL,
+		APIKey:    apiKey,
+		HostID:    hostID,
+	})
+
+	c := &impl{watcher: w, log: reqs.Log}
+
+	reqs.Lifecycle.Append(compdef.Hook{
+		OnStart: c.start,
+		OnStop:  c.stop,
+	})
+
+	return Provides{Comp: option.New[configingestiondef.Component](c)}, nil
+}
+
+func (c *impl) start(_ context.Context) error {
+	c.log.Info("Starting config file ingestion watcher")
+	// Use context.Background() so the watcher goroutine is not tied to the
+	// short-lived Fx OnStart context, which is cancelled once startup completes.
+	// The goroutine is stopped explicitly by stop() via Watcher.Stop().
+	// TODO(DSCVR Phase D): if Watcher.Start gains an error return, surface it here.
+	c.watcher.Start(context.Background())
+	return nil
+}
+
+func (c *impl) stop(_ context.Context) error {
+	// Stop cancels the goroutine context and waits for the goroutine to exit,
+	// guaranteeing workloadmeta resources are not accessed after this returns.
+	c.watcher.Stop()
+	return nil
+}

--- a/docs/dev/2026-06-01-DSCVR-438-spec.md
+++ b/docs/dev/2026-06-01-DSCVR-438-spec.md
@@ -1,0 +1,703 @@
+# DSCVR-438 — Config File Ingestion Demo: Implementation Spec
+
+**Branch:** new clean branch from `main` (see Branching Strategy below)
+**Date:** 2026-06-01  
+**Status:** Draft — pending implementation  
+**Scope:** Demo only. Not production-ready. No dedup, no retry, no historical storage.
+
+---
+
+## Task Context
+
+### What and why
+
+The DSCVR initiative (Config File Ingestion) wants to prove an end-to-end pipeline:
+
+```
+Agent detects config files from running processes
+  → redacts sensitive values
+  → ships via EvP to the experimental backend (DataDog/experimental PR #9989)
+  → worker writes raw blobs to UnifiedKV config_blobs_v1
+  → worker writes parsed facts to config_facts_v1
+  → queryable via SQL: "which hosts have Redis without maxmemory configured?"
+```
+
+The Rust discovery engine (`pkg/discovery/module/rust/src/configs.rs`) already detects config
+file paths from process cmdlines and well-known fallbacks. Those paths surface in
+`model.Service.ConfigFiles` (Go FFI bridge: `pkg/discovery/module/impl_rust_linux.go`).
+However, `ConfigFiles` is not yet in `workloadmeta.Service`, so no in-agent component can
+currently see them.
+
+This spec covers the minimal glue to make the pipeline work end-to-end for a demo.
+Redis is the first integration (it has the well-known fallback `/etc/redis/redis.conf`
+plus cmdline detection).
+
+### What is explicitly out of scope for this demo
+- Production deduplication or change-only emit
+- Retry logic or reliable delivery guarantees
+- Periodic re-read of config files (only shipped once per process discovery event)
+- New `auto_conf.yaml` or Configuration Discovery integration
+- Any frontend work (separate PR)
+- Extending well-known configs beyond `redis-server`
+
+---
+
+## Branching Strategy
+
+The previous experimental branches (`marta/discovery-config-sender`, `marta/discovery-config-detection`) contain useful work but also unrelated commits. This PR starts clean from `main` and cherry-picks only what's needed.
+
+**What to cherry-pick:**
+
+| Commit | What it is | Include? |
+|--------|-----------|----------|
+| `e2a6780a070` | Rust `configs.rs` cmdline detection + FFI bridge + `model.Service.ConfigFiles` | ✅ yes |
+| `27a89cee6c4` | Well-known fallback for `redis-server` in `configs.rs` | ✅ yes |
+| `bbf51974ff2` | Standalone `configsender` tool (`pkg/discovery/tools/configsender/`) | ❌ no — not needed for the in-agent approach |
+
+The redaction, envelope, content-type, and HTTP sender logic from that tool is re-implemented fresh inside `pkg/discovery/configingestion/` as part of this PR, so nothing useful is lost.
+
+---
+
+## Implementation Plan
+
+### Agent setup (before starting)
+
+```bash
+gh api user -q '.login'   # get your GitHub username for worktree name
+```
+
+Use `EnterWorktree` with name `feat/<username>/DSCVR-438-config-ingestion-demo`.
+
+Then, from the worktree:
+
+```bash
+# Start clean from main
+git checkout main
+git pull
+
+# Cherry-pick only the two Rust detection commits
+git cherry-pick e2a6780a070   # configs.rs cmdline detection + FFI + model field
+git cherry-pick 27a89cee6c4   # redis-server well-known fallback
+```
+
+All remaining code in this spec is **net-new** on top of those two cherry-picks.
+
+---
+
+### Step 1 — Wire ConfigFiles through workloadmeta
+
+**2 files, ~5 lines total. Must be done first — nothing else can proceed without this.**
+
+#### `comp/core/workloadmeta/def/types.go`
+
+In the `Service` struct (around line 1695, after `LogFiles []string`):
+
+```go
+// ConfigFiles are the configuration files associated with this service, discovered
+// from the process command line and well-known paths.
+ConfigFiles []string `proto:"ignore"`
+```
+
+Pattern: identical to the existing `LogFiles` field directly above it.
+
+#### `comp/core/workloadmeta/collectors/internal/process/process_collector.go`
+
+In `convertModelServiceToService()` (~line 930), add inside the returned struct:
+
+```go
+ConfigFiles: modelService.ConfigFiles,
+```
+
+Do **not** add ConfigFiles to the heartbeat update section (~lines 471–475). Cmdline is
+immutable for a running process; config file paths are discovered once and never change.
+LogFiles are in the heartbeat section because they're dynamic; ConfigFiles must not be.
+
+---
+
+### Step 2 — Create the core watcher package
+
+**New directory:** `pkg/discovery/configingestion/`
+
+This is a plain Go package (not Fx, not main) containing the discovery and shipping logic.
+
+#### `pkg/discovery/configingestion/watcher.go`
+
+```go
+package configingestion
+
+import (
+    "context"
+    "crypto/sha256"
+    "encoding/hex"
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+    "os"
+    "regexp"
+    "strings"
+    "sync"
+    "unicode/utf8"
+
+    workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+    "github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+    maxFileBytes = 256 * 1024
+    httpTimeout  = 10 * time.Second
+)
+
+// Config holds the runtime configuration for the watcher.
+type Config struct {
+    IntakeURL   string
+    APIKey      string
+    HostID      string
+}
+
+// Watcher subscribes to workloadmeta Process events and ships discovered config files to EvP.
+type Watcher struct {
+    store  workloadmeta.Component
+    cfg    Config
+
+    seenFiles map[string]struct{} // keyed by file path; prevents double-shipping
+    pidFiles  map[int32][]string  // PID → file paths (for cleanup on unset)
+    mu        sync.Mutex
+
+    cancel context.CancelFunc
+}
+
+// NewWatcher returns a new Watcher.
+func NewWatcher(store workloadmeta.Component, cfg Config) *Watcher {
+    return &Watcher{
+        store:     store,
+        cfg:       cfg,
+        seenFiles: make(map[string]struct{}),
+        pidFiles:  make(map[int32][]string),
+    }
+}
+
+// Start subscribes to workloadmeta and begins processing events in a goroutine.
+func (w *Watcher) Start(ctx context.Context) {
+    ctx, w.cancel = context.WithCancel(ctx)
+
+    filter := workloadmeta.NewFilterBuilder().
+        AddKindWithEntityFilter(workloadmeta.KindProcess, func(e workloadmeta.Entity) bool {
+            p, ok := e.(*workloadmeta.Process)
+            return ok && p.Service != nil && p.ContainerID == "" && len(p.Service.ConfigFiles) > 0
+        }).
+        Build()
+
+    ch := w.store.Subscribe("config-ingestion", workloadmeta.NormalPriority, filter)
+
+    go func() {
+        defer w.store.Unsubscribe(ch)
+        for {
+            select {
+            case <-ctx.Done():
+                return
+            case bundle, ok := <-ch:
+                if !ok {
+                    return
+                }
+                bundle.Acknowledge()
+                w.handleBundle(bundle)
+            }
+        }
+    }()
+}
+
+// Stop cancels the subscription goroutine.
+func (w *Watcher) Stop() {
+    if w.cancel != nil {
+        w.cancel()
+    }
+}
+
+func (w *Watcher) handleBundle(bundle workloadmeta.EventBundle) {
+    w.mu.Lock()
+    defer w.mu.Unlock()
+
+    for _, ev := range bundle.Events {
+        process, ok := ev.Entity.(*workloadmeta.Process)
+        if !ok {
+            continue
+        }
+
+        switch ev.Type {
+        case workloadmeta.EventTypeSet:
+            var shipped []string
+            for _, path := range process.Service.ConfigFiles {
+                if _, alreadySeen := w.seenFiles[path]; alreadySeen {
+                    continue
+                }
+                integration := integrationFromService(process.Service)
+                if err := w.ship(path, integration); err != nil {
+                    log.Warnf("configingestion: failed to ship %s: %v", path, err)
+                    continue
+                }
+                w.seenFiles[path] = struct{}{}
+                shipped = append(shipped, path)
+            }
+            if len(shipped) > 0 {
+                w.pidFiles[process.Pid] = shipped
+            }
+
+        case workloadmeta.EventTypeUnset:
+            // Don't remove from seenFiles — if the same file is re-discovered by another
+            // process later, we've already shipped it and don't need to re-send.
+            delete(w.pidFiles, process.Pid)
+        }
+    }
+}
+
+func (w *Watcher) ship(path, integration string) error {
+    f, err := os.Open(path)
+    if err != nil {
+        return fmt.Errorf("open: %w", err)
+    }
+    defer f.Close()
+
+    raw, err := io.ReadAll(io.LimitReader(f, maxFileBytes+1))
+    if err != nil {
+        return fmt.Errorf("read: %w", err)
+    }
+    if len(raw) > maxFileBytes {
+        return fmt.Errorf("file exceeds 256 KiB limit")
+    }
+
+    // UTF-8 guard — reject binary files.
+    probe := raw
+    if len(probe) > 128 {
+        probe = probe[:128]
+    }
+    if !utf8.Valid(probe) {
+        return fmt.Errorf("file does not appear to be UTF-8 text")
+    }
+
+    content := redactSensitive(string(raw))
+    ct := detectContentType(integration, path)
+
+    envelope := buildEnvelope(w.cfg.HostID, integration, "app_native", path, ct, content)
+
+    body, err := json.Marshal(envelope)
+    if err != nil {
+        return fmt.Errorf("marshal: %w", err)
+    }
+
+    return postEnvelope(w.cfg.IntakeURL, w.cfg.APIKey, body)
+}
+```
+
+Key decisions documented inline:
+- Filter: only processes with `Service != nil`, no container (can't read their files), and non-empty ConfigFiles
+- On EventTypeSet: ship each unseen path, add to seenFiles
+- On EventTypeUnset: only clean pidFiles — seenFiles is never cleared (dedup is permanent for the demo)
+- `os.Open` is used directly (no privileged client) since this is a demo; production would use `privilegedlogsclient`
+
+#### Supporting files in `pkg/discovery/configingestion/`
+
+The standalone `configsender` tool is **not included** in this PR. The following files are written fresh in the new package — the logic is identical to what was in the tool but lives here as a proper importable library.
+
+**`envelope.go`** — EvP envelope structs and builder:
+
+```go
+type envelope struct {
+    Service string  `json:"service"`
+    Project string  `json:"project"`
+    Tags    string  `json:"ddtags"`
+    Message string  `json:"message"`
+    Data    payload `json:"data"`
+}
+
+type payload struct {
+    HostID       string `json:"host_id"`
+    Integration  string `json:"integration"`
+    ConfigSource string `json:"config_source"`
+    Filename     string `json:"filename"`
+    ContentType  string `json:"content_type"`
+    Raw          string `json:"raw"`
+    Digest       string `json:"digest"`
+}
+
+func buildEnvelope(hostID, integration, source, filename, contentType, raw string) envelope {
+    sum := sha256.Sum256([]byte(raw))
+    return envelope{
+        Service: "configingestion-agent",
+        Project: "config-ingestion-poc",
+        Tags:    fmt.Sprintf("config-ingestion-poc,source:agent,host:%s", hostID),
+        Message: fmt.Sprintf("%s %s config from %s (%s)", integration, source, hostID, filepath.Base(filename)),
+        Data: payload{
+            HostID: hostID, Integration: integration, ConfigSource: source,
+            Filename: filename, ContentType: contentType, Raw: raw,
+            Digest: hex.EncodeToString(sum[:]),
+        },
+    }
+}
+```
+
+Note: `service` field is `"configingestion-agent"` (not `"demoalpha-worker"` which is the backend worker name). Confirm with the team whether the track configuration in PR #9989 requires a specific value.
+
+**`redact.go`** — two compiled regexes matching the patterns from the previous experimental tool:
+- Pattern 1 (`key: value` / `key=value`, YAML/ini style): redacts the value group, preserves trailing comments
+- Pattern 2 (`key value`, redis.conf style): same
+- Sensitive keywords: `password`, `passwd`, `secret`, `token`, `api[_-]?key`, `access[_-]?key`, `private[_-]?key`, `requirepass`, `masterauth`, `credentials?`, `auth[_-]?token`
+- Replacement: `[REDACTED]`
+
+**`content_type.go`** — detects content type from file extension + integration:
+- `.yaml` / `.yml` → `"yaml"`
+- `.json` → `"json"`
+- integration=`"redis"` + (base=`redis.conf` or ext=`.conf`) → `"redis_conf"`
+- Everything else → `""` (worker will still accept it; no parser runs)
+
+**`sender.go`** — HTTP POST to EvP intake:
+- Method: POST, timeout: 10s
+- Headers: `Content-Type: application/json`, `DD-API-KEY: <key>` (omitted if empty)
+- Success: any 2xx; error: non-2xx with first 512 bytes of body in the error message
+
+**`integration.go`** — maps `GeneratedName` to integration name (mirrors `process_log.go`'s fixup table):
+
+```go
+var generatedNameToIntegration = map[string]string{
+    "redis-server": "redis",
+    "mysqld":       "mysql",
+    "postgres":     "postgresql",
+    "mongod":       "mongodb",
+    "nginx":        "nginx",
+}
+
+func integrationFromService(svc *workloadmeta.Service) string {
+    if svc == nil {
+        return "unknown"
+    }
+    if mapped, ok := generatedNameToIntegration[strings.ToLower(svc.GeneratedName)]; ok {
+        return mapped
+    }
+    return strings.ToLower(svc.GeneratedName)
+}
+```
+
+#### `pkg/discovery/configingestion/watcher_test.go`
+
+Cover at minimum:
+- `handleBundle` with EventTypeSet: new path is shipped and added to seenFiles
+- `handleBundle` with EventTypeSet: already-seen path is skipped
+- `handleBundle` with EventTypeUnset: pidFiles entry removed, seenFiles unchanged
+- `ship()` with a binary file: returns an error (UTF-8 guard)
+- `ship()` with a file over 256 KiB: returns an error
+- `integrationFromService()`: GeneratedName → integration mapping
+- Redact patterns (inherited from configsender tests; add at least one redis.conf case)
+
+---
+
+### Step 3 — Create the Fx component
+
+**Pattern:** `comp/languagedetection/client/impl/client.go` exactly.
+**New directory:** `comp/discovery/configingestion/`
+
+#### `comp/discovery/configingestion/def/component.go`
+
+```go
+// Package configingestion provides experimental config file discovery and ingestion.
+package configingestion
+
+// team: agent-discovery
+
+// Component is the config file ingestion component interface.
+// It has no exported methods; lifecycle is managed via Fx hooks.
+type Component interface{}
+```
+
+#### `comp/discovery/configingestion/impl/impl.go`
+
+```go
+package configingestionimpl
+
+import (
+    "context"
+
+    "github.com/DataDog/datadog-agent/comp/core/config"
+    log "github.com/DataDog/datadog-agent/comp/core/log/def"
+    workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+    compdef "github.com/DataDog/datadog-agent/comp/def"
+    configingestion "github.com/DataDog/datadog-agent/comp/discovery/configingestion/def"
+    "github.com/DataDog/datadog-agent/pkg/discovery/configingestion"
+    "github.com/DataDog/datadog-agent/pkg/util/hostname"
+    "github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+// Requires defines the Fx dependencies.
+type Requires struct {
+    Lifecycle    compdef.Lifecycle
+    Config       config.Component
+    Log          log.Component
+    Workloadmeta workloadmeta.Component
+}
+
+// Provides defines the Fx outputs.
+type Provides struct {
+    Comp option.Option[configingestion.Component]
+}
+
+type impl struct {
+    watcher *configingestion.Watcher
+    log     log.Component
+}
+
+// NewComponent creates the config ingestion component.
+func NewComponent(reqs Requires) (Provides, error) {
+    if !reqs.Config.GetBool("discovery.config_ingestion.enabled") {
+        return Provides{Comp: option.None[configingestion.Component]()}, nil
+    }
+
+    intakeURL := reqs.Config.GetString("discovery.config_ingestion.intake_url")
+    apiKey    := reqs.Config.GetString("api_key") // reuse the agent's main API key
+
+    hostID, err := hostname.Get(context.Background())
+    if err != nil {
+        hostID = "unknown"
+        reqs.Log.Warnf("configingestion: could not determine hostname: %v", err)
+    }
+
+    w := configingestion.NewWatcher(reqs.Workloadmeta, configingestion.Config{
+        IntakeURL: intakeURL,
+        APIKey:    apiKey,
+        HostID:    hostID,
+    })
+
+    c := &impl{watcher: w, log: reqs.Log}
+
+    reqs.Lifecycle.Append(compdef.Hook{
+        OnStart: c.start,
+        OnStop:  c.stop,
+    })
+
+    return Provides{Comp: option.New[configingestion.Component](c)}, nil
+}
+
+func (c *impl) start(ctx context.Context) error {
+    c.log.Info("Starting config file ingestion watcher")
+    c.watcher.Start(ctx)
+    return nil
+}
+
+func (c *impl) stop(_ context.Context) error {
+    c.watcher.Stop()
+    return nil
+}
+```
+
+#### `comp/discovery/configingestion/fx/fx.go`
+
+```go
+package fx
+
+import (
+    configingestion "github.com/DataDog/datadog-agent/comp/discovery/configingestion/def"
+    configingestionimpl "github.com/DataDog/datadog-agent/comp/discovery/configingestion/impl"
+    "github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the Fx options for the config ingestion component.
+func Module() fxutil.Module {
+    return fxutil.Component(
+        fxutil.ProvideComponentConstructor(
+            configingestionimpl.NewComponent,
+        ),
+        fxutil.ProvideOptional[configingestion.Component](),
+    )
+}
+```
+
+---
+
+### Step 4 — Register config keys
+
+Find the config registration file (likely `pkg/config/setup/config.go` or
+`pkg/config/setup/process.go`). Add:
+
+```go
+config.BindEnv("discovery.config_ingestion.enabled")
+config.SetDefault("discovery.config_ingestion.enabled", false)
+
+config.BindEnv("discovery.config_ingestion.intake_url")
+config.SetDefault("discovery.config_ingestion.intake_url",
+    "https://all-internal-intake-logs.staging.dog/v2/track/demoalpha/org/47653")
+```
+
+The API key reuses the existing `api_key` config key — no new key needed.
+The host ID is resolved at runtime from `hostname.Get()`.
+
+Grep for an existing `discovery.` prefix registration to find the right file:
+```bash
+grep -r '"discovery\.' pkg/config/setup/ --include="*.go" -l
+```
+
+---
+
+### Step 5 — Wire into the agent
+
+Find where optional background components are added to the agent's Fx graph.
+Look for where `languagedetectionclient.Module()` is added as a reference:
+
+```bash
+grep -r "languagedetection" cmd/agent/ --include="*.go" -l
+```
+
+Add the config ingestion module in the same location:
+
+```go
+import configingestionfx "github.com/DataDog/datadog-agent/comp/discovery/configingestion/fx"
+
+// In the fx.Options(...) or fxutil.Component(...) block:
+configingestionfx.Module(),
+```
+
+---
+
+### Step 6 — BUILD.bazel files
+
+Each new package needs a `BUILD.bazel`. Use `dda inv tidy` after creating the Go files
+to auto-generate them, then verify they look correct. The binary has no unusual deps:
+stdlib + workloadmeta + testify for tests.
+
+---
+
+## Libraries, Components, and Patterns
+
+| Purpose | Path | Key symbol |
+|---------|------|------------|
+| Workloadmeta subscription | `comp/core/workloadmeta/def/` | `Component.Subscribe()`, `EventBundle`, `FilterBuilder` |
+| Workloadmeta Process entity | `comp/core/workloadmeta/def/types.go` | `Process`, `Service.ConfigFiles` |
+| Fx lifecycle hooks | `comp/def/` | `Lifecycle`, `Hook{OnStart, OnStop}` |
+| Optional Fx output | `pkg/util/option/` | `option.New[T]()`, `option.None[T]()` |
+| Fx component pattern | `comp/languagedetection/client/impl/client.go` | `Requires`, `Provides`, `NewComponent()` |
+| Fx module pattern | `comp/languagedetection/client/fx/fx.go` | `Module()`, `fxutil.ProvideComponentConstructor` |
+| WM subscription pattern | `comp/core/autodiscovery/providers/process_log.go` | `processEventsInner()`, filter construction |
+| Config key registration | `pkg/config/setup/config.go` | `config.SetDefault()`, `config.BindEnv()` |
+| Hostname resolution | `pkg/util/hostname/` | `hostname.Get(ctx)` |
+| HTTP POST | `pkg/discovery/configingestion/sender.go` | `postEnvelope()` — implement fresh (see spec above for contract) |
+| Redaction | `pkg/discovery/configingestion/redact.go` | `redactSensitive()` — implement fresh (see sensitive keyword list above) |
+| Content type | `pkg/discovery/configingestion/content_type.go` | `detectContentType()` — implement fresh (see logic above) |
+| Envelope | `pkg/discovery/configingestion/envelope.go` | `buildEnvelope()` — implement fresh (see struct above) |
+
+The standalone `configsender` tool (`pkg/discovery/tools/configsender/`) is **not on this branch** and must not be cherry-picked. The logic above is re-implemented fresh in the new package.
+
+---
+
+## EvP Backend Contract
+
+From DataDog/experimental PR #9989:
+
+| Field | Value |
+|-------|-------|
+| Intake URL (demo) | `https://all-internal-intake-logs.staging.dog/v2/track/demoalpha/org/47653` |
+| Intake URL (Phase A) | `https://all-internal-intake-logs.staging.dog/v2/track/agentdiscovery/org/47653` |
+| HTTP method | POST |
+| Headers | `Content-Type: application/json`, `DD-API-KEY: <key>` |
+| Envelope `service` | `"demoalpha-worker"` (confirm with team; this is the worker name) |
+| Envelope `project` | `"config-ingestion-poc"` |
+| Content types parsed | `yaml`, `json`, `redis_conf` |
+| UKV table (blobs) | `config_blobs_v1` — stores raw file + hash |
+| UKV table (facts) | `config_facts_v1` — stores parsed JSON + present_keys index |
+
+The `present_keys` format is `\|key1\|key2\|key3\|` (pipe-delimited, sorted, wrapped).
+Enables SQL `LIKE '%|maxmemory|%'` queries without unpacking JSON.
+
+---
+
+## Acceptance Criteria
+
+| # | Criterion | How to verify |
+|---|-----------|---------------|
+| AC1 | `workloadmeta.Service.ConfigFiles` is populated for a Redis process | Add debug log in watcher.handleBundle; run agent against a redis-server process |
+| AC2 | Config file is read and its content is present in the envelope | Dry-run mode: set `--dry-run` or log the envelope before POST |
+| AC3 | `requirepass` value is redacted to `[REDACTED]` | Unit test in watcher_test.go; check logged envelope |
+| AC4 | Content type `redis_conf` is correctly detected | Unit test; check envelope.data.content_type |
+| AC5 | EvP POST returns HTTP 200 | Log the response code in `postEnvelope` |
+| AC6 | Row appears in `config_blobs_v1` | `ukvcli` query (see below) |
+| AC7 | Row appears in `config_facts_v1` with non-empty `present_keys` | `ukvcli` query (see below) |
+| AC8 | Component does not start when `discovery.config_ingestion.enabled: false` | Check agent startup logs; no "Starting config file ingestion" line |
+| AC9 | Binary files are rejected (no send attempt) | Unit test with 128 bytes of random binary |
+| AC10 | Files over 256 KiB are rejected | Unit test with oversized content |
+
+---
+
+## Verification Checklist
+
+### Unit tests (run locally)
+```bash
+dda inv test --targets=./pkg/discovery/configingestion/...
+dda inv test --targets=./comp/discovery/configingestion/...
+```
+
+### Build check
+```bash
+dda inv agent.build --build-exclude=systemd
+```
+
+### Manual end-to-end (Linux, requires running redis-server and system-probe)
+
+1. Add to `dev/dist/datadog.yaml`:
+   ```yaml
+   discovery.config_ingestion.enabled: true
+   discovery.config_ingestion.intake_url: "https://all-internal-intake-logs.staging.dog/v2/track/demoalpha/org/47653"
+   api_key: "<staging-key>"
+   ```
+
+2. Start a Redis process:
+   ```bash
+   redis-server /etc/redis/redis.conf &
+   ```
+
+3. Run the agent:
+   ```bash
+   ./bin/agent/agent run -c bin/agent/dist/datadog.yaml
+   ```
+
+4. Wait ~30s for process discovery. Check agent logs for:
+   ```
+   Starting config file ingestion watcher
+   configingestion: shipping /etc/redis/redis.conf (integration=redis)
+   ```
+
+5. Query UKV via `ukvcli` (internal tooling — ask the DSCVR backend team):
+   ```sql
+   SELECT host_id, filename, content_type FROM config_blobs_v1
+   WHERE org_id = 47653 AND integration = 'redis';
+
+   SELECT host_id, present_keys FROM config_facts_v1
+   WHERE org_id = 47653 AND integration = 'redis';
+   ```
+
+6. Confirm `requirepass` is absent from the `raw` column (redacted):
+   ```sql
+   SELECT raw FROM config_blobs_v1 WHERE org_id = 47653 AND integration = 'redis';
+   -- Should show [REDACTED] in place of the actual password value
+   ```
+
+### Dry-run mode (macOS friendly, no system-probe needed)
+The existing `pkg/discovery/tools/configsender/` tool can be used to validate the envelope
+and EvP POST independently:
+```bash
+DD_API_KEY=<key> ./bin/configsender \
+  --dry-run \
+  --host-id=$(hostname) \
+  --integration=redis \
+  --source=app_native \
+  /etc/redis/redis.conf
+```
+
+---
+
+## Known Limitations of This Demo
+
+| Limitation | Production fix (Phase D) |
+|------------|--------------------------|
+| `os.Open` — requires agent to have read access to config files | Use `privilegedlogsclient.Open()` (same as process_log.go) |
+| Ships every file once on discovery; no re-send on config change | Periodic re-read with content-hash dedup |
+| seenFiles map grows unbounded | LRU eviction; re-send if process restarts with same file |
+| No retry on HTTP failure | Exponential backoff + dead-letter queue |
+| `demoalpha` EvP track — shared, can stave | Phase A: dedicated `agentdiscovery` track |
+| Envelope `service` field hardcoded | Controlled by EvP track configuration |
+| Linux-only (Rust configs.rs reads `/proc`) | macOS: use configsender tool manually for demo |

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -350,8 +350,12 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// Discovery config
 	cfg.BindEnvAndSetDefault("discovery.enabled", runtime.GOOS == "linux")
 	cfg.BindEnvAndSetDefault("discovery.use_system_probe_lite", runtime.GOOS == "linux")
+	cfg.BindEnvAndSetDefault("discovery.use_rust_library", false)
 	cfg.BindEnvAndSetDefault("discovery.cpu_usage_update_delay", "60s")
 	cfg.BindEnvAndSetDefault("discovery.service_collection_interval", "60s")
+	cfg.BindEnvAndSetDefault("discovery.config_ingestion.enabled", false)
+	cfg.BindEnvAndSetDefault("discovery.config_ingestion.intake_url",
+		"https://all-internal-intake-logs.staging.dog/v2/track/demoalpha/org/47653")
 
 	// Privileged Logs config
 	cfg.BindEnvAndSetDefault("privileged_logs.enabled", false)

--- a/pkg/discovery/configingestion/BUILD.bazel
+++ b/pkg/discovery/configingestion/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "configingestion",
+    srcs = [
+        "content_type.go",
+        "envelope.go",
+        "integration.go",
+        "redact.go",
+        "sender.go",
+        "watcher.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/discovery/configingestion",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/log",
+        "@//comp/core/workloadmeta/def",
+    ],
+)
+
+go_test(
+    name = "configingestion_test",
+    srcs = ["watcher_test.go"],
+    embed = [":configingestion"],
+    gotags = ["test"],
+    deps = [
+        "@//comp/core/workloadmeta/def",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/discovery/configingestion/content_type.go
+++ b/pkg/discovery/configingestion/content_type.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package configingestion
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// contentTypeUnknown is returned when no parser is registered for the file.
+// The EvP worker still accepts the file; it simply skips structured parsing.
+const contentTypeUnknown = ""
+
+func detectContentType(integration, path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+
+	switch ext {
+	case ".yaml", ".yml":
+		return "yaml"
+	case ".json":
+		return "json"
+	case ".conf":
+		// Only redis has a registered .conf parser; other integrations are unrecognised.
+		if integration == "redis" {
+			return "redis_conf"
+		}
+	}
+
+	return contentTypeUnknown
+}

--- a/pkg/discovery/configingestion/envelope.go
+++ b/pkg/discovery/configingestion/envelope.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package configingestion
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+)
+
+const (
+	envelopeService = "configingestion-agent"
+	envelopeProject = "config-ingestion-poc"
+)
+
+type envelope struct {
+	Service string  `json:"service"`
+	Project string  `json:"project"`
+	Tags    string  `json:"ddtags"`
+	Message string  `json:"message"`
+	Data    payload `json:"data"`
+}
+
+type payload struct {
+	HostID       string `json:"host_id"`
+	Integration  string `json:"integration"`
+	ConfigSource string `json:"config_source"`
+	Filename     string `json:"filename"`
+	ContentType  string `json:"content_type"`
+	Raw          string `json:"raw"`
+	Digest       string `json:"digest"`
+}
+
+func buildEnvelope(hostID, integration, source, filename, contentType, raw string) envelope {
+	sum := sha256.Sum256([]byte(raw))
+	return envelope{
+		Service: envelopeService,
+		Project: envelopeProject,
+		// TODO(DSCVR Phase D): make tags config-driven rather than hardcoded.
+		Tags: fmt.Sprintf("config-ingestion-poc,source:agent,host:%s", hostID),
+		Message: fmt.Sprintf("%s %s config from %s (%s)", integration, source, hostID, filepath.Base(filename)),
+		Data: payload{
+			HostID:       hostID,
+			Integration:  integration,
+			ConfigSource: source,
+			Filename:     filename,
+			ContentType:  contentType,
+			Raw:          raw,
+			Digest:       hex.EncodeToString(sum[:]),
+		},
+	}
+}

--- a/pkg/discovery/configingestion/integration.go
+++ b/pkg/discovery/configingestion/integration.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package configingestion
+
+import (
+	"strings"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+var generatedNameToIntegration = map[string]string{
+	"redis-server": "redis",
+	"mysqld":       "mysql",
+	"postgres":     "postgresql",
+	"mongod":       "mongodb",
+	"nginx":        "nginx",
+}
+
+func integrationFromService(svc *workloadmeta.Service) string {
+	if svc == nil {
+		return "unknown"
+	}
+	if mapped, ok := generatedNameToIntegration[strings.ToLower(svc.GeneratedName)]; ok {
+		return mapped
+	}
+	return strings.ToLower(svc.GeneratedName)
+}

--- a/pkg/discovery/configingestion/redact.go
+++ b/pkg/discovery/configingestion/redact.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package configingestion
+
+import "regexp"
+
+const sensitiveKeyword = `(?i)(?:password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|requirepass|masterauth|credentials?|auth[_-]?token)`
+
+// sensitiveRe matches sensitive key-value pairs in a single pass, covering:
+//   - YAML/ini style:    key: value   or   key=value
+//   - redis.conf style:  key value
+//
+// Using a single regex eliminates double-redaction. The word boundary (\b)
+// prevents false positives on keys that merely contain a sensitive word
+// (e.g. "notapassword"). The separator group ($2) is preserved so that the
+// original formatting (colon, equals, space) is unchanged.
+var sensitiveRe = regexp.MustCompile(
+	`(?m)\b(` + sensitiveKeyword + `)(\s*[:=]\s*|\s+)(\S+)`,
+)
+
+func redactSensitive(content string) string {
+	return sensitiveRe.ReplaceAllString(content, `$1$2[REDACTED]`)
+}

--- a/pkg/discovery/configingestion/sender.go
+++ b/pkg/discovery/configingestion/sender.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package configingestion
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func postEnvelope(ctx context.Context, client *http.Client, intakeURL, apiKey string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, intakeURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		req.Header.Set("DD-API-KEY", apiKey)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http post: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Drain the body on the success path so the TCP connection is returned to
+	// the pool. On non-2xx paths the ReadAll below reads up to 512 bytes first;
+	// this defer then drains whatever remains.
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body) }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// %q safely escapes any non-UTF-8 bytes a proxy or error page might return.
+		preview, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))
+		if readErr != nil {
+			return fmt.Errorf("http %d (body unreadable: %w)", resp.StatusCode, readErr)
+		}
+		return fmt.Errorf("http %d: %q", resp.StatusCode, preview)
+	}
+	return nil
+}

--- a/pkg/discovery/configingestion/watcher.go
+++ b/pkg/discovery/configingestion/watcher.go
@@ -1,0 +1,213 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package configingestion subscribes to workloadmeta Process events and ships
+// discovered config files to the EvP intake.
+package configingestion
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	maxFileBytes       = 256 * 1024
+	configSourceNative = "app_native"
+)
+
+// Config holds the runtime configuration for the watcher.
+type Config struct {
+	IntakeURL string
+	APIKey    string
+	HostID    string
+}
+
+// shipTask collects the data needed to ship one config file outside the lock.
+type shipTask struct {
+	pid         int32
+	path        string
+	integration string
+}
+
+// Watcher subscribes to workloadmeta Process events and ships discovered config files to EvP.
+type Watcher struct {
+	store  workloadmeta.Component
+	cfg    Config
+	client *http.Client
+
+	// seenFiles is keyed by file path; dedup is permanent for the demo lifetime.
+	seenFiles map[string]struct{}
+	// pidFiles maps PID → shipped paths for cleanup on EventTypeUnset.
+	pidFiles map[int32][]string
+	mu       sync.Mutex
+
+	// cancel is initialized to a no-op in NewWatcher and replaced under mu in Start.
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	startOnce sync.Once // ensures Start is called at most once
+}
+
+// NewWatcher returns a new Watcher ready to Start.
+func NewWatcher(store workloadmeta.Component, cfg Config) *Watcher {
+	return &Watcher{
+		store:     store,
+		cfg:       cfg,
+		client:    &http.Client{Timeout: 10 * time.Second},
+		seenFiles: make(map[string]struct{}),
+		pidFiles:  make(map[int32][]string),
+		cancel:    func() {}, // no-op until Start sets the real cancel
+	}
+}
+
+// Start subscribes to workloadmeta and processes events in a background goroutine.
+// The goroutine runs until Stop is called. Calling Start more than once panics.
+//
+// TODO(DSCVR Phase D): change the return type to error and return instead of
+// panicking, so Fx OnStart hooks can surface the failure cleanly rather than
+// producing an opaque stack trace through the Fx startup machinery.
+func (w *Watcher) Start(ctx context.Context) {
+	called := false
+	w.startOnce.Do(func() { called = true })
+	if !called {
+		panic("configingestion.Watcher.Start called more than once")
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	w.mu.Lock()
+	w.cancel = cancel
+	w.mu.Unlock()
+
+	filter := workloadmeta.NewFilterBuilder().
+		AddKindWithEntityFilter(workloadmeta.KindProcess, func(e workloadmeta.Entity) bool {
+			p, ok := e.(*workloadmeta.Process)
+			return ok && p.Service != nil && p.ContainerID == "" && len(p.Service.ConfigFiles) > 0
+		}).
+		Build()
+
+	ch := w.store.Subscribe("config-ingestion", workloadmeta.NormalPriority, filter)
+
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		defer w.store.Unsubscribe(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case bundle, ok := <-ch:
+				if !ok {
+					return
+				}
+				bundle.Acknowledge()
+				w.handleBundle(ctx, bundle)
+			}
+		}
+	}()
+}
+
+// Stop cancels the background goroutine and waits for it to exit before returning.
+// This ensures workloadmeta resources are not accessed after Stop returns.
+func (w *Watcher) Stop() {
+	w.mu.Lock()
+	w.cancel()
+	w.mu.Unlock()
+	w.wg.Wait()
+}
+
+func (w *Watcher) handleBundle(ctx context.Context, bundle workloadmeta.EventBundle) {
+	// Collect work under the lock, then perform I/O outside to avoid holding
+	// the mutex during potentially slow HTTP calls.
+	w.mu.Lock()
+	var toShip []shipTask
+	// pending guards against shipping the same path twice when a single bundle
+	// contains multiple EventTypeSet events referencing the same file.
+	pending := make(map[string]struct{})
+	for _, ev := range bundle.Events {
+		process, ok := ev.Entity.(*workloadmeta.Process)
+		if !ok {
+			continue
+		}
+		switch ev.Type {
+		case workloadmeta.EventTypeSet:
+			if process.Service == nil {
+				continue
+			}
+			integration := integrationFromService(process.Service)
+			for _, path := range process.Service.ConfigFiles {
+				if _, alreadySeen := w.seenFiles[path]; alreadySeen {
+					continue
+				}
+				if _, alreadyPending := pending[path]; alreadyPending {
+					continue
+				}
+				pending[path] = struct{}{}
+				toShip = append(toShip, shipTask{pid: process.Pid, path: path, integration: integration})
+			}
+		case workloadmeta.EventTypeUnset:
+			// Don't remove from seenFiles — dedup is permanent for the demo.
+			delete(w.pidFiles, process.Pid)
+		}
+	}
+	w.mu.Unlock()
+
+	// Note: handleBundle is called from a single goroutine (the subscriber loop
+	// in Start), so the window between the dedup check above and the seenFiles
+	// update below is not a TOCTOU race in practice. Any future change to
+	// parallelize shipping must re-evaluate this invariant.
+	for _, task := range toShip {
+		if err := w.ship(ctx, task.path, task.integration); err != nil {
+			log.Warnf("configingestion: failed to ship %s: %v", task.path, err)
+			continue
+		}
+		log.Infof("configingestion: shipped %s (integration=%s)", task.path, task.integration)
+		w.mu.Lock()
+		w.seenFiles[task.path] = struct{}{}
+		w.pidFiles[task.pid] = append(w.pidFiles[task.pid], task.path)
+		w.mu.Unlock()
+	}
+}
+
+func (w *Watcher) ship(ctx context.Context, path, integration string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+	defer f.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(f, maxFileBytes+1))
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	if len(raw) > maxFileBytes {
+		return fmt.Errorf("file exceeds %d KiB limit", maxFileBytes/1024)
+	}
+
+	// Validate the full content — config files must be UTF-8 text.
+	if !utf8.Valid(raw) {
+		return errors.New("file does not appear to be UTF-8 text")
+	}
+
+	content := redactSensitive(string(raw))
+	ct := detectContentType(integration, path)
+	env := buildEnvelope(w.cfg.HostID, integration, configSourceNative, path, ct, content)
+
+	body, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	return postEnvelope(ctx, w.client, w.cfg.IntakeURL, w.cfg.APIKey, body)
+}

--- a/pkg/discovery/configingestion/watcher_test.go
+++ b/pkg/discovery/configingestion/watcher_test.go
@@ -1,0 +1,366 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package configingestion
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockStore implements the workloadmeta.Component methods used by Watcher.
+// Unused methods are satisfied by embedding the interface; they panic if called.
+type mockStore struct {
+	workloadmeta.Component
+	ch chan workloadmeta.EventBundle
+}
+
+func (m *mockStore) Subscribe(_ string, _ workloadmeta.SubscriberPriority, _ *workloadmeta.Filter) chan workloadmeta.EventBundle {
+	return m.ch
+}
+
+func (m *mockStore) Unsubscribe(_ chan workloadmeta.EventBundle) {}
+
+// newTestWatcher creates a Watcher pointing at srv (or with an empty URL if srv
+// is nil). The store uses a nil channel so Start must not be called; for
+// lifecycle tests use newTestWatcherWithStore instead.
+func newTestWatcher(t *testing.T, srv *httptest.Server) *Watcher {
+	t.Helper()
+	url := ""
+	if srv != nil {
+		url = srv.URL
+	}
+	store := &mockStore{ch: nil}
+	return NewWatcher(store, Config{IntakeURL: url, APIKey: "test-key", HostID: "test-host"})
+}
+
+// newTestWatcherWithStore creates a Watcher backed by a real mockStore channel,
+// suitable for tests that call Start/Stop.
+func newTestWatcherWithStore(t *testing.T) (*Watcher, chan workloadmeta.EventBundle) {
+	t.Helper()
+	ch := make(chan workloadmeta.EventBundle)
+	store := &mockStore{ch: ch}
+	w := NewWatcher(store, Config{IntakeURL: "http://localhost", APIKey: "k", HostID: "h"})
+	return w, ch
+}
+
+func makeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "redis*.conf")
+	require.NoError(t, err)
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+// --- Start/Stop lifecycle ---
+
+func TestWatcher_StartStop_GoroutineExits(t *testing.T) {
+	w, _ := newTestWatcherWithStore(t)
+	// ch is intentionally not closed or sent on; Stop() cancels the context
+	// which drives goroutine exit via the ctx.Done() select arm.
+	w.Start(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		w.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// goroutine exited cleanly — no leak
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return within 2 seconds — goroutine leak suspected")
+	}
+}
+
+// --- handleBundle ---
+
+func TestHandleBundle_NewPathIsShipped(t *testing.T) {
+	var shipped atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		shipped.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	path := makeTempConfig(t, "bind 127.0.0.1\n")
+	w := newTestWatcher(t, srv)
+
+	w.handleBundle(context.Background(), workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.Process{
+					Pid: 1,
+					Service: &workloadmeta.Service{
+						GeneratedName: "redis-server",
+						ConfigFiles:   []string{path},
+					},
+				},
+			},
+		},
+	})
+
+	assert.Equal(t, int32(1), shipped.Load())
+	// handleBundle returns synchronously, so no lock needed to inspect maps.
+	assert.Contains(t, w.seenFiles, path)
+	assert.Contains(t, w.pidFiles[1], path)
+}
+
+func TestHandleBundle_AlreadySeenPathIsSkipped(t *testing.T) {
+	var shipped atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		shipped.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	path := makeTempConfig(t, "bind 127.0.0.1\n")
+	w := newTestWatcher(t, srv)
+	w.seenFiles[path] = struct{}{}
+
+	w.handleBundle(context.Background(), workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.Process{
+					Pid: 2,
+					Service: &workloadmeta.Service{
+						GeneratedName: "redis-server",
+						ConfigFiles:   []string{path},
+					},
+				},
+			},
+		},
+	})
+
+	assert.Equal(t, int32(0), shipped.Load())
+}
+
+func TestHandleBundle_SamePathInSameBundleShippedOnce(t *testing.T) {
+	var shipped atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		shipped.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	path := makeTempConfig(t, "bind 127.0.0.1\n")
+	w := newTestWatcher(t, srv)
+
+	// Two Set events in the same bundle reference the same path (different PIDs).
+	// The path must be shipped exactly once.
+	w.handleBundle(context.Background(), workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.Process{
+					Pid:     10,
+					Service: &workloadmeta.Service{GeneratedName: "redis-server", ConfigFiles: []string{path}},
+				},
+			},
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.Process{
+					Pid:     11,
+					Service: &workloadmeta.Service{GeneratedName: "redis-server", ConfigFiles: []string{path}},
+				},
+			},
+		},
+	})
+
+	assert.Equal(t, int32(1), shipped.Load(), "same path in one bundle must be shipped only once")
+	assert.Contains(t, w.seenFiles, path)
+}
+
+func TestHandleBundle_NilServiceIsSkipped(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	// Must not panic when Service is nil.
+	w.handleBundle(context.Background(), workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{Type: workloadmeta.EventTypeSet, Entity: &workloadmeta.Process{Pid: 5, Service: nil}},
+		},
+	})
+	assert.Empty(t, w.seenFiles)
+}
+
+func TestHandleBundle_UnsetRemovesPidFilesNotSeenFiles(t *testing.T) {
+	path := makeTempConfig(t, "bind 127.0.0.1\n")
+	w := newTestWatcher(t, nil)
+	w.seenFiles[path] = struct{}{}
+	w.pidFiles[3] = []string{path}
+
+	w.handleBundle(context.Background(), workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeUnset,
+				Entity: &workloadmeta.Process{
+					Pid:     3,
+					Service: &workloadmeta.Service{GeneratedName: "redis-server", ConfigFiles: []string{path}},
+				},
+			},
+		},
+	})
+
+	assert.NotContains(t, w.pidFiles, int32(3))
+	assert.Contains(t, w.seenFiles, path)
+}
+
+// --- ship ---
+
+func TestShip_NonExistentFileReturnsError(t *testing.T) {
+	w := newTestWatcher(t, nil)
+	err := w.ship(context.Background(), "/nonexistent/does-not-exist.conf", "redis")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open")
+}
+
+func TestShip_BinaryFileRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "binary.bin")
+	data := make([]byte, 128)
+	for i := range data {
+		data[i] = 0xFF
+	}
+	require.NoError(t, os.WriteFile(path, data, 0600))
+
+	w := newTestWatcher(t, nil)
+	err := w.ship(context.Background(), path, "redis")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "UTF-8")
+}
+
+func TestShip_Non2xxResponseIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	path := makeTempConfig(t, "bind 127.0.0.1\n")
+	w := newTestWatcher(t, srv)
+	err := w.ship(context.Background(), path, "redis")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestShip_OversizedFileRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.conf")
+	require.NoError(t, os.WriteFile(path, []byte(strings.Repeat("a", maxFileBytes+1)), 0600))
+
+	w := newTestWatcher(t, nil)
+	err := w.ship(context.Background(), path, "redis")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("%d KiB", maxFileBytes/1024))
+}
+
+// --- integrationFromService ---
+
+func TestIntegrationFromService_KnownNames(t *testing.T) {
+	cases := []struct {
+		generatedName string
+		want          string
+	}{
+		{"redis-server", "redis"},
+		{"Redis-Server", "redis"},
+		{"mysqld", "mysql"},
+		{"postgres", "postgresql"},
+		{"mongod", "mongodb"},
+		{"nginx", "nginx"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.generatedName, func(t *testing.T) {
+			assert.Equal(t, tc.want, integrationFromService(&workloadmeta.Service{GeneratedName: tc.generatedName}))
+		})
+	}
+}
+
+func TestIntegrationFromService_UnknownName(t *testing.T) {
+	assert.Equal(t, "myapp", integrationFromService(&workloadmeta.Service{GeneratedName: "MyApp"}))
+}
+
+func TestIntegrationFromService_Nil(t *testing.T) {
+	assert.Equal(t, "unknown", integrationFromService(nil))
+}
+
+// --- redactSensitive ---
+
+func TestRedactSensitive_RequirepassRedacted(t *testing.T) {
+	out := redactSensitive("requirepass supersecret\nbind 127.0.0.1\n")
+	assert.Contains(t, out, "[REDACTED]")
+	assert.NotContains(t, out, "supersecret")
+	assert.Contains(t, out, "bind 127.0.0.1")
+}
+
+func TestRedactSensitive_YAMLPasswordRedacted(t *testing.T) {
+	out := redactSensitive("password: mypass123\nhost: localhost\n")
+	assert.Contains(t, out, "[REDACTED]")
+	assert.NotContains(t, out, "mypass123")
+	assert.Contains(t, out, "host: localhost")
+}
+
+func TestRedactSensitive_NoSensitiveKeys(t *testing.T) {
+	input := "bind 127.0.0.1\nmaxmemory 100mb\n"
+	assert.Equal(t, input, redactSensitive(input))
+}
+
+func TestRedactSensitive_WordBoundaryPreventsFalsePositives(t *testing.T) {
+	// Keys that merely contain a sensitive substring must not be redacted.
+	input := "notapassword: value\nmy_api_key_length: 32\n"
+	out := redactSensitive(input)
+	assert.Equal(t, input, out)
+}
+
+func TestRedactSensitive_SinglePassNoDuplication(t *testing.T) {
+	// Verify that YAML-style lines (key: value) are redacted exactly once
+	// and the separator format is preserved.
+	out := redactSensitive("password: secret\n")
+	assert.Equal(t, "password: [REDACTED]\n", out)
+	assert.Equal(t, 1, strings.Count(out, "[REDACTED]"))
+}
+
+// --- detectContentType ---
+
+func TestDetectContentType(t *testing.T) {
+	cases := []struct {
+		integration string
+		path        string
+		want        string
+		note        string
+	}{
+		{"redis", "/etc/redis/redis.conf", "redis_conf", ""},
+		{"redis", "/etc/redis/custom.conf", "redis_conf", "any .conf for redis"},
+		// Only redis has a registered .conf parser; other integrations are unrecognised.
+		{"nginx", "/etc/nginx/nginx.conf", contentTypeUnknown, "nginx parser not yet registered"},
+		{"redis", "/etc/redis/config.yaml", "yaml", ""},
+		{"mysql", "/etc/mysql/my.json", "json", ""},
+		{"anything", "/path/to/file.yml", "yaml", ""},
+		{"anything", "/path/to/file.txt", contentTypeUnknown, ""},
+		// TOML and ini are not yet supported.
+		{"anything", "/path/to/file.toml", contentTypeUnknown, "toml not yet registered"},
+	}
+	for _, tc := range cases {
+		name := fmt.Sprintf("%s_%s", tc.integration, filepath.Base(tc.path))
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, detectContentType(tc.integration, tc.path))
+		})
+	}
+}

--- a/pkg/discovery/core/config.go
+++ b/pkg/discovery/core/config.go
@@ -8,6 +8,8 @@
 // Package core provides the core functionality for service discovery.
 package core
 
+import pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+
 const (
 	// MaxCommLen is maximum command name length to process when checking for non-reportable commands,
 	// is one byte less (excludes end of line) than the maximum of /proc/<pid>/comm
@@ -17,9 +19,14 @@ const (
 
 // DiscoveryConfig holds the configuration for service discovery.
 type DiscoveryConfig struct {
+	// UseRustLibrary selects the Rust-backed libdd_discovery implementation
+	// (requires linux_bpf build tag and the compiled Rust library).
+	UseRustLibrary bool
 }
 
 // NewConfig creates a new DiscoveryConfig with default values.
 func NewConfig() *DiscoveryConfig {
-	return &DiscoveryConfig{}
+	return &DiscoveryConfig{
+		UseRustLibrary: pkgconfigsetup.SystemProbe().GetBool("discovery.use_rust_library"),
+	}
 }

--- a/pkg/discovery/model/model.go
+++ b/pkg/discovery/model/model.go
@@ -14,6 +14,7 @@ import (
 type Service struct {
 	PID                      int                             `json:"pid"`
 	LogFiles                 []string                        `json:"log_files,omitempty"`
+	ConfigFiles              []string                        `json:"config_files,omitempty"`
 	GeneratedName            string                          `json:"generated_name"`
 	GeneratedNameSource      string                          `json:"generated_name_source"`
 	AdditionalGeneratedNames []string                        `json:"additional_generated_names"`

--- a/pkg/discovery/module/impl_linux.go
+++ b/pkg/discovery/module/impl_linux.go
@@ -66,6 +66,8 @@ type discovery struct {
 func NewDiscoveryModule(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 	cfg := core.NewConfig()
 
+	InitDiscoveryLogger()
+
 	d := &discovery{
 		core: core.Discovery{
 			Config: cfg,
@@ -534,6 +536,11 @@ func (s *discovery) getPorts(context parsingContext, pid int32, sockets []uint64
 func (s *discovery) getServices(params core.Params) (*model.ServicesResponse, error) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
+
+	if s.config.UseRustLibrary {
+		return rustGetServices(params)
+	}
+
 	response := &model.ServicesResponse{
 		Services: make([]model.Service, 0),
 	}

--- a/pkg/discovery/module/impl_rust_linux.go
+++ b/pkg/discovery/module/impl_rust_linux.go
@@ -1,0 +1,157 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf && cgo
+
+package module
+
+/*
+#cgo CFLAGS:  -I${SRCDIR}/rust/include
+#cgo LDFLAGS: -L${SRCDIR}/rust -L${SRCDIR}/rust/target/release -ldd_discovery
+#include "dd_discovery.h"
+*/
+import "C"
+
+import (
+	"errors"
+	"math"
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/discovery/core"
+	"github.com/DataDog/datadog-agent/pkg/discovery/model"
+	tracermetadata "github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata/model"
+)
+
+// errRustLibraryPanicked is returned when libdd_discovery caught a Rust panic
+// at the FFI boundary and returned NULL.
+var errRustLibraryPanicked = errors.New("libdd_discovery returned NULL (panic caught at FFI boundary)")
+
+// InitDiscoveryLogger is a no-op placeholder. A full Rust→Go log bridge can
+// be wired here in a follow-up by calling C.dd_discovery_init_logger with a
+// CGo-exported callback that forwards records to pkg/util/log.
+func InitDiscoveryLogger() {}
+
+// rustGetServices invokes the Rust library with the given PID lists and
+// copies the response into Go-owned memory.
+func rustGetServices(params core.Params) (*model.ServicesResponse, error) {
+	newPidsPtr, newPidsLen := pidSlice(params.NewPids)
+	hbPidsPtr, hbPidsLen := pidSlice(params.HeartbeatPids)
+
+	result := C.dd_discovery_get_services(newPidsPtr, newPidsLen, hbPidsPtr, hbPidsLen)
+	if result == nil {
+		return nil, errRustLibraryPanicked
+	}
+	defer C.dd_discovery_free(result)
+
+	response := &model.ServicesResponse{
+		Services: make([]model.Service, 0, int(result.services_len)),
+	}
+
+	for _, svc := range sliceFromC(result.services, result.services_len) {
+		response.Services = append(response.Services, convertRustService(&svc))
+	}
+
+	for _, pid := range sliceFromC(result.injected_pids, result.injected_pids_len) {
+		response.InjectedPIDs = append(response.InjectedPIDs, int(pid))
+	}
+
+	for _, pid := range sliceFromC(result.gpu_pids, result.gpu_pids_len) {
+		response.GPUPIDs = append(response.GPUPIDs, int(pid))
+	}
+
+	return response, nil
+}
+
+func pidSlice(pids []int32) (*C.int32_t, C.size_t) {
+	if len(pids) == 0 {
+		return nil, 0
+	}
+	return (*C.int32_t)(unsafe.Pointer(&pids[0])), C.size_t(len(pids))
+}
+
+func sliceFromC[T any](data *T, length C.size_t) []T {
+	if data == nil || length == 0 {
+		return nil
+	}
+	return unsafe.Slice(data, length)
+}
+
+func fromDDStr(s C.struct_dd_str) string {
+	if s.data == nil || s.len == 0 {
+		return ""
+	}
+	if s.len > math.MaxInt32 {
+		return ""
+	}
+	return C.GoStringN(s.data, C.int(s.len))
+}
+
+func convertRustService(svc *C.struct_dd_service) model.Service {
+	result := model.Service{
+		PID:                 int(svc.pid),
+		GeneratedName:       fromDDStr(svc.generated_name),
+		GeneratedNameSource: fromDDStr(svc.generated_name_source),
+		APMInstrumentation:  bool(svc.apm_instrumentation),
+		Language:            fromDDStr(svc.language),
+		UST: model.UST{
+			Service: fromDDStr(svc.ust.service),
+			Env:     fromDDStr(svc.ust.env),
+			Version: fromDDStr(svc.ust.version),
+		},
+	}
+
+	if names := sliceFromC(svc.additional_generated_names.data, svc.additional_generated_names.len); len(names) > 0 {
+		result.AdditionalGeneratedNames = make([]string, len(names))
+		for i, n := range names {
+			result.AdditionalGeneratedNames[i] = fromDDStr(n)
+		}
+	}
+
+	for _, m := range sliceFromC(svc.tracer_metadata.data, svc.tracer_metadata.len) {
+		result.TracerMetadata = append(result.TracerMetadata, tracermetadata.TracerMetadata{
+			SchemaVersion:  uint8(m.schema_version),
+			RuntimeID:      fromDDStr(m.runtime_id),
+			TracerLanguage: fromDDStr(m.tracer_language),
+			TracerVersion:  fromDDStr(m.tracer_version),
+			Hostname:       fromDDStr(m.hostname),
+			ServiceName:    fromDDStr(m.service_name),
+			ServiceEnv:     fromDDStr(m.service_env),
+			ServiceVersion: fromDDStr(m.service_version),
+			ProcessTags:    fromDDStr(m.process_tags),
+			ContainerID:    fromDDStr(m.container_id),
+			LogsCollected:  bool(m.logs_collected),
+		})
+	}
+
+	if ports := sliceFromC(svc.tcp_ports.data, svc.tcp_ports.len); len(ports) > 0 {
+		result.TCPPorts = make([]uint16, len(ports))
+		for i, p := range ports {
+			result.TCPPorts[i] = uint16(p)
+		}
+	}
+
+	if ports := sliceFromC(svc.udp_ports.data, svc.udp_ports.len); len(ports) > 0 {
+		result.UDPPorts = make([]uint16, len(ports))
+		for i, p := range ports {
+			result.UDPPorts[i] = uint16(p)
+		}
+	}
+
+	if logs := sliceFromC(svc.log_files.data, svc.log_files.len); len(logs) > 0 {
+		result.LogFiles = make([]string, len(logs))
+		for i, l := range logs {
+			result.LogFiles[i] = fromDDStr(l)
+		}
+	}
+
+	if configs := sliceFromC(svc.config_files.data, svc.config_files.len); len(configs) > 0 {
+		result.ConfigFiles = make([]string, len(configs))
+		for i, c := range configs {
+			result.ConfigFiles[i] = fromDDStr(c)
+		}
+	}
+
+	return result
+}

--- a/pkg/discovery/module/impl_rust_stub_linux.go
+++ b/pkg/discovery/module/impl_rust_stub_linux.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && !linux_bpf
+
+package module
+
+import (
+	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/discovery/core"
+	"github.com/DataDog/datadog-agent/pkg/discovery/model"
+)
+
+// InitDiscoveryLogger is a no-op in builds without the Rust library.
+func InitDiscoveryLogger() {}
+
+// rustGetServices is a stub for builds without the Rust library.
+func rustGetServices(_ core.Params) (*model.ServicesResponse, error) {
+	return nil, errors.New("rust library not available in this build (requires linux_bpf)")
+}

--- a/pkg/discovery/module/rust/include/dd_discovery.h
+++ b/pkg/discovery/module/rust/include/dd_discovery.h
@@ -76,6 +76,7 @@ struct dd_service {
   struct dd_u16_slice tcp_ports;
   struct dd_u16_slice udp_ports;
   struct dd_strs log_files;
+  struct dd_strs config_files;
   bool apm_instrumentation;
   struct dd_str language;
 };

--- a/pkg/discovery/module/rust/src/configs.rs
+++ b/pkg/discovery/module/rust/src/configs.rs
@@ -1,0 +1,335 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//! Discovery of on-disk config files for a target process.
+//!
+//! Counterpart to `procfs::fd::get_log_files`: log files are typically held
+//! open and discoverable via `/proc/<pid>/fd/`, but config files are read
+//! once at startup and closed. We instead inspect the process command line
+//! for well-known "config" flags (`-c`, `--config`, `--config-file`, etc.)
+//! and treat the adjacent argument (or the `--flag=value` inline form) as
+//! a candidate path. The candidate is then verified to actually exist inside
+//! the target process's mount namespace via the caller-provided `SubDirFs`
+//! (typically rooted at `/proc/<pid>/root/`), which uses cap-std to reject
+//! `..` traversal and symlink escapes.
+//!
+//! When the cmdline-scan finds nothing, we fall back to a small table of
+//! well-known paths keyed off `argv[0]`'s basename. This is necessary for
+//! services that take their config as a positional argument and/or overwrite
+//! argv at startup, so the original path is unrecoverable from
+//! `/proc/<pid>/cmdline` — `redis-server` is the canonical case (it rewrites
+//! argv to display the listen address). Follow-ups can extend the table
+//! and add env-var-based location hints (Spring `SPRING_CONFIG_LOCATIONS`,
+//! `JAVA_TOOL_OPTIONS -Dconfig.file=…`).
+
+use std::collections::HashSet;
+
+use crate::fs::SubDirFs;
+use crate::procfs::Cmdline;
+
+/// Short-form flags (`-c value`, `-f value`) that introduce a config path.
+const SHORT_CONFIG_FLAGS: &[&str] = &["-c", "-f"];
+
+/// Long-form flag names (without the leading `--`) recognised in both
+/// separated (`--config value`) and inline (`--config=value`) forms.
+const LONG_CONFIG_FLAGS: &[&str] = &["config", "config-file", "conf-file", "configFile"];
+
+/// Per-exe fallback table: matched against `argv[0]`'s basename when the
+/// cmdline-scan finds nothing. Paths are tried in order and all that exist
+/// inside the sandbox are reported.
+const WELL_KNOWN_CONFIGS: &[(&str, &[&str])] =
+    &[("redis-server", &["/etc/redis/redis.conf", "/etc/redis.conf"])];
+
+/// Extract config-file paths referenced by the process command line.
+///
+/// Returns absolute paths that (a) appear after a known config flag in
+/// `cmdline` and (b) actually exist inside the `fs` sandbox. The result
+/// is deduplicated and order-preserving (first occurrence wins).
+///
+/// Relative paths are skipped: the process's cwd is ambiguous in this
+/// context (cap-std would resolve relative paths against the sandbox root,
+/// not the process's cwd, which would silently produce wrong results).
+///
+/// When the cmdline-scan finds nothing, falls back to `WELL_KNOWN_CONFIGS`
+/// keyed off `argv[0]`'s basename, so daemons that take a positional config
+/// path or rewrite argv (e.g. `redis-server`) can still be discovered.
+pub fn get_config_files(cmdline: &Cmdline, fs: &SubDirFs) -> Vec<String> {
+    if cmdline.is_empty() {
+        return Vec::new();
+    }
+
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for candidate in extract_candidates(cmdline) {
+        if !candidate.starts_with('/') {
+            continue;
+        }
+        // Reject `..` components. The kernel clamps `..` at the filesystem
+        // root, so cap-std's sandbox is not actually escapable through this
+        // path — but the reported string is later handed to a downstream
+        // ingester that may re-resolve it outside the sandbox, so we keep
+        // the reported path free of traversal segments.
+        if candidate.split('/').any(|c| c == "..") {
+            continue;
+        }
+        if !seen.insert(candidate.clone()) {
+            continue;
+        }
+        if fs.exists(&candidate) {
+            result.push(candidate);
+        }
+    }
+
+    if result.is_empty() {
+        result.extend(well_known_fallback(cmdline, fs));
+    }
+
+    result
+}
+
+/// Probe the well-known-paths table for the current `argv[0]`. Returns the
+/// subset of registered paths that exist inside the sandbox.
+fn well_known_fallback(cmdline: &Cmdline, fs: &SubDirFs) -> Vec<String> {
+    let Some(exe) = argv0_basename(cmdline) else {
+        return Vec::new();
+    };
+    WELL_KNOWN_CONFIGS
+        .iter()
+        .find(|(name, _)| *name == exe)
+        .map(|(_, paths)| {
+            paths
+                .iter()
+                .filter(|p| fs.exists(p))
+                .map(|p| (*p).to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Basename of `argv[0]`, or `None` if cmdline is empty / argv[0] is empty.
+fn argv0_basename(cmdline: &Cmdline) -> Option<&str> {
+    let argv0 = cmdline.args().next()?;
+    if argv0.is_empty() {
+        return None;
+    }
+    Some(argv0.rsplit('/').next().unwrap_or(argv0))
+}
+
+/// Parse cmdline args, returning all path-like tokens that follow a known
+/// config flag (separated form) or are attached via `--flag=value`.
+fn extract_candidates(cmdline: &Cmdline) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut iter = cmdline.args().peekable();
+    while let Some(arg) = iter.next() {
+        // Inline form: `--config=/etc/myapp.yaml`
+        if let Some(rest) = arg.strip_prefix("--")
+            && let Some((key, value)) = rest.split_once('=')
+            && LONG_CONFIG_FLAGS.contains(&key)
+            && !value.is_empty()
+        {
+            out.push(value.to_string());
+            continue;
+        }
+
+        // Separated form: `-c /etc/redis/redis.conf` or `--config /path`
+        if is_separated_config_flag(arg)
+            && let Some(&value) = iter.peek()
+            && !value.is_empty()
+            && !value.starts_with('-')
+        {
+            out.push(value.to_string());
+            iter.next();
+        }
+    }
+    out
+}
+
+fn is_separated_config_flag(arg: &str) -> bool {
+    SHORT_CONFIG_FLAGS.contains(&arg)
+        || arg
+            .strip_prefix("--")
+            .is_some_and(|k| LONG_CONFIG_FLAGS.contains(&k))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmdline;
+
+    fn host_root_fs() -> SubDirFs {
+        SubDirFs::new("/").expect("open / as SubDirFs root")
+    }
+
+    #[test]
+    fn separated_short_flag() {
+        let cmd = cmdline!["redis-server", "-c", "/etc/redis/redis.conf"];
+        assert_eq!(extract_candidates(&cmd), vec!["/etc/redis/redis.conf"]);
+    }
+
+    #[test]
+    fn separated_long_flag() {
+        let cmd = cmdline!["mongod", "--config", "/etc/mongod.conf"];
+        assert_eq!(extract_candidates(&cmd), vec!["/etc/mongod.conf"]);
+    }
+
+    #[test]
+    fn inline_long_flag() {
+        let cmd = cmdline!["myapp", "--config=/etc/myapp.yaml"];
+        assert_eq!(extract_candidates(&cmd), vec!["/etc/myapp.yaml"]);
+    }
+
+    #[test]
+    fn camel_case_long_flag() {
+        let cmd = cmdline!["mongod", "--configFile=/etc/mongod.conf"];
+        assert_eq!(extract_candidates(&cmd), vec!["/etc/mongod.conf"]);
+    }
+
+    #[test]
+    fn multiple_flags_preserve_order() {
+        let cmd = cmdline![
+            "kafka-server",
+            "-f",
+            "/etc/kafka/server.properties",
+            "--config-file",
+            "/etc/kafka/extra.conf",
+        ];
+        assert_eq!(
+            extract_candidates(&cmd),
+            vec!["/etc/kafka/server.properties", "/etc/kafka/extra.conf",],
+        );
+    }
+
+    #[test]
+    fn flag_with_no_following_value_is_ignored() {
+        let cmd = cmdline!["foo", "--config"];
+        assert!(extract_candidates(&cmd).is_empty());
+    }
+
+    #[test]
+    fn flag_followed_by_another_flag_is_ignored() {
+        let cmd = cmdline!["foo", "-c", "-f", "/etc/x.conf"];
+        assert_eq!(extract_candidates(&cmd), vec!["/etc/x.conf"]);
+    }
+
+    #[test]
+    fn unknown_flag_is_ignored() {
+        let cmd = cmdline!["foo", "--bogus", "/etc/x.conf"];
+        assert!(extract_candidates(&cmd).is_empty());
+    }
+
+    #[test]
+    fn inline_with_empty_value_is_ignored() {
+        let cmd = cmdline!["foo", "--config="];
+        assert!(extract_candidates(&cmd).is_empty());
+    }
+
+    #[test]
+    fn empty_cmdline_returns_empty() {
+        let cmd = cmdline![];
+        assert!(get_config_files(&cmd, &host_root_fs()).is_empty());
+    }
+
+    #[test]
+    fn relative_paths_are_skipped() {
+        let cmd = cmdline!["app", "-c", "relative/path.yaml"];
+        assert!(get_config_files(&cmd, &host_root_fs()).is_empty());
+    }
+
+    #[test]
+    fn dot_dot_components_are_rejected() {
+        let cmd = cmdline!["app", "-c", "/etc/../../etc/passwd"];
+        assert!(get_config_files(&cmd, &host_root_fs()).is_empty());
+
+        let cmd = cmdline!["app", "--config=/..//root/.bashrc"];
+        assert!(get_config_files(&cmd, &host_root_fs()).is_empty());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn existence_filter_drops_missing_paths_and_dedupes() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let real = temp_dir.path().join("real.conf");
+        fs::write(&real, "key=value\n").expect("write conf");
+        let real_str = real.to_str().expect("utf-8 path").to_string();
+
+        let cmd = Cmdline::from(
+            &[
+                "app",
+                "-c",
+                real_str.as_str(),
+                "--config",
+                real_str.as_str(),
+                "-f",
+                "/this/path/does/not/exist.conf",
+            ][..],
+        );
+
+        let got = get_config_files(&cmd, &host_root_fs());
+        assert_eq!(got.len(), 1, "expected dedup + existence filter, got: {got:?}");
+        assert!(got.first().is_some_and(|p| p.ends_with("real.conf")));
+    }
+
+    #[test]
+    fn argv0_basename_handles_paths_and_plain_names() {
+        assert_eq!(
+            argv0_basename(&cmdline!["redis-server"]),
+            Some("redis-server"),
+        );
+        assert_eq!(
+            argv0_basename(&cmdline!["/usr/bin/redis-server", "127.0.0.1:6379"]),
+            Some("redis-server"),
+        );
+        assert_eq!(argv0_basename(&cmdline![]), None);
+    }
+
+    #[test]
+    fn well_known_fallback_only_fires_for_known_exes() {
+        let cmd = cmdline!["nginx", "-g", "daemon off;"];
+        assert!(get_config_files(&cmd, &host_root_fs()).is_empty());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn well_known_fallback_finds_redis_conf() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let redis_dir = temp_dir.path().join("etc").join("redis");
+        fs::create_dir_all(&redis_dir).expect("create /etc/redis");
+        fs::write(redis_dir.join("redis.conf"), "port 6379\n").expect("write redis.conf");
+
+        let sandboxed = SubDirFs::new(temp_dir.path()).expect("open sandbox");
+
+        let cmd = cmdline!["redis-server", "127.0.0.1:6379"];
+        assert_eq!(
+            get_config_files(&cmd, &sandboxed),
+            vec!["/etc/redis/redis.conf".to_string()],
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn well_known_fallback_skipped_when_cmdline_already_matched() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let explicit = temp_dir.path().join("custom.conf");
+        fs::write(&explicit, "x\n").expect("write custom.conf");
+        let redis_dir = temp_dir.path().join("etc").join("redis");
+        fs::create_dir_all(&redis_dir).expect("create /etc/redis");
+        fs::write(redis_dir.join("redis.conf"), "y\n").expect("write redis.conf");
+
+        let sandboxed = SubDirFs::new(temp_dir.path()).expect("open sandbox");
+
+        let explicit_abs = format!("/{}", explicit.strip_prefix(temp_dir.path()).unwrap().display());
+        let cmd = Cmdline::from(&["redis-server", "-c", explicit_abs.as_str()][..]);
+        assert_eq!(get_config_files(&cmd, &sandboxed), vec![explicit_abs]);
+    }
+}

--- a/pkg/discovery/module/rust/src/ffi.rs
+++ b/pkg/discovery/module/rust/src/ffi.rs
@@ -93,6 +93,7 @@ pub struct dd_service {
     pub tcp_ports: dd_u16_slice,
     pub udp_ports: dd_u16_slice,
     pub log_files: dd_strs,
+    pub config_files: dd_strs,
     pub apm_instrumentation: bool,
     pub language: dd_str,
 }
@@ -252,6 +253,7 @@ impl From<Service> for dd_service {
             tcp_ports: vec_u16_to_slice(svc.tcp_ports),
             udp_ports: vec_u16_to_slice(svc.udp_ports),
             log_files: dd_strs::from(svc.log_files),
+            config_files: dd_strs::from(svc.config_files),
             apm_instrumentation: svc.apm_instrumentation,
             language: dd_str::from(svc.language),
         }
@@ -479,6 +481,7 @@ unsafe fn free_dd_service(service: &dd_service) {
         tcp_ports,
         udp_ports,
         log_files,
+        config_files,
         apm_instrumentation: _,
         language,
     } = service;
@@ -492,6 +495,7 @@ unsafe fn free_dd_service(service: &dd_service) {
         free_dd_u16_slice(tcp_ports);
         free_dd_u16_slice(udp_ports);
         free_dd_strs(log_files);
+        free_dd_strs(config_files);
         free_dd_str(language);
     }
 }
@@ -687,6 +691,7 @@ mod tests {
                 tcp_ports: Some(vec![8080, 8443]),
                 udp_ports: Some(vec![9000]),
                 log_files: vec!["/var/log/app.log".to_string()],
+                config_files: vec!["/etc/app/app.conf".to_string()],
                 apm_instrumentation: true,
                 language: Some(Language::Python),
             }],
@@ -816,6 +821,7 @@ mod tests {
                 tcp_ports: None,
                 udp_ports: Some(vec![]),
                 log_files: vec![],
+                config_files: vec![],
                 apm_instrumentation: false,
                 language: None,
             }],

--- a/pkg/discovery/module/rust/src/lib.rs
+++ b/pkg/discovery/module/rust/src/lib.rs
@@ -22,6 +22,7 @@
 mod apm;
 mod binary;
 mod comm;
+mod configs;
 mod envs;
 mod ephemeral;
 mod errors;

--- a/pkg/discovery/module/rust/src/services.rs
+++ b/pkg/discovery/module/rust/src/services.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 
 use crate::apm;
 use crate::comm;
+use crate::configs;
 use crate::envs;
 use crate::fs::SubDirFs;
 use crate::language::Language;
@@ -51,6 +52,8 @@ pub struct Service {
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub log_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub config_files: Vec<String>,
     pub apm_instrumentation: bool,
     pub language: Option<Language>,
 }
@@ -171,6 +174,7 @@ fn get_service(
     // Open filesystem for the process at /proc/<pid>/root
     let proc_root = procfs::root_path().join(pid.to_string()).join("root");
     let fs = SubDirFs::new(&proc_root).ok()?;
+    let config_files = configs::get_config_files(&cmdline, &fs);
 
     // Create detection context for service name generation
     let mut ctx = service_name::DetectionContext::new(pid, envs.clone(), &fs);
@@ -193,12 +197,15 @@ fn get_service(
         tcp_ports,
         udp_ports,
         log_files,
+        config_files,
         apm_instrumentation,
         language,
     })
 }
 
 // GPU state is not re-detected on heartbeat; the caller preserves it from the initial detection.
+// Config files are also not re-discovered: they're derived from cmdline which is stable for the
+// lifetime of the process. Callers should retain config_files from the initial new_pids response.
 fn get_heartbeat_service(pid: i32, context: &mut ParsingContext) -> Option<Service> {
     let open_files_info = procfs::fd::get_open_files_info(pid).ok()?;
 


### PR DESCRIPTION
## Summary

> **Demo-only PR — not for merge.** This is a proof-of-concept to validate the agent side of the config file ingestion pipeline end-to-end before the Phase D architecture decision.

### What this does

Wires together the full agent-side pipeline for the DSCVR-438 config ingestion demo:

```
Agent detects config files from running processes (Rust)
  → ConfigFiles surfaced in workloadmeta.Service
  → configingestion Fx component subscribes to process events
  → reads file, redacts secrets, builds EvP envelope
  → POSTs to experimental intake (DataDog/experimental#9989)
  → worker writes to config_blobs_v1 / config_facts_v1
```

Redis is the first integration (well-known fallback `/etc/redis/redis.conf` + cmdline detection).

### Changes

- **`comp/core/workloadmeta/def/types.go`** — adds `ConfigFiles []string` to `Service` struct
- **`comp/core/workloadmeta/.../process_collector.go`** — wires `ConfigFiles` in `convertModelServiceToService()`
- **`pkg/discovery/module/rust/src/configs.rs`** — Rust cmdline detection + redis-server well-known fallback
- **`pkg/discovery/module/impl_rust_linux.go`** + FFI bridge — surfaces config paths into `model.Service.ConfigFiles`
- **`pkg/discovery/configingestion/`** — core watcher package: redaction, envelope, sender, content-type detection
- **`comp/discovery/configingestion/`** — Fx component (def/impl/fx) wiring the watcher into the agent lifecycle
- **`pkg/config/setup/system_probe.go`** — registers `discovery.config_ingestion.{enabled,intake_url}` config keys
- **`cmd/agent/subcommands/run/command.go`** — adds `configingestionfx.Module()` to the agent Fx graph
- **`docs/dev/2026-06-01-DSCVR-438-spec.md`** — implementation spec for this demo

### Known limitations (intentional for demo scope)

| Limitation | Production fix |
|------------|---------------|
| `os.Open` — agent needs read access | Use `privilegedlogsclient.Open()` |
| Ships file once; no re-send on change | Periodic re-read with content-hash dedup |
| `seenFiles` map grows unbounded | LRU eviction |
| No retry on HTTP failure | Exponential backoff |
| `demoalpha` EvP track shared | Dedicated `agentdiscovery` track (Phase A) |

### Test plan

- [ ] `dda inv test --targets=./pkg/discovery/configingestion/...`
- [ ] `dda inv test --targets=./comp/discovery/configingestion/...`
- [ ] `dda inv agent.build --build-exclude=systemd`
- [ ] Manual end-to-end with redis-server + system-probe (Linux)
- [ ] Verify `config_blobs_v1` / `config_facts_v1` rows via `ukvcli` with Emilio's worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)