### PR TITLE
fix(proto): move write_all to repo root and include all write_pb_go targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
 # Global build settings
 
-load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_file", "write_source_files")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
@@ -945,4 +945,31 @@ config_setting(
     flag_values = {
         "//:release": "True",
     },
+)
+
+# bazel run //:write_all regenerates all protobuf-generated Go files in the repo.
+write_source_files(
+    name = "write_all",
+    additional_update_targets = [
+        "//comp/forwarder/defaultforwarder/internal/retry:write_pb_go",
+        "//pkg/proto/msgpgo:key_gen",
+        "//pkg/proto/pbgo/core:remoteconfig_gen",
+        "//pkg/proto/pbgo/core:write_pb_go",
+        "//pkg/proto/pbgo/dogstatsdhttp:write_pb_go",
+        "//pkg/proto/pbgo/languagedetection:write_pb_go",
+        "//pkg/proto/pbgo/mocks/core:api_mockgen",
+        "//pkg/proto/pbgo/privateactionrunner/actionsclient:write_pb_go",
+        "//pkg/proto/pbgo/privateactionrunner/errorcode:write_pb_go",
+        "//pkg/proto/pbgo/privateactionrunner/privateactions:write_pb_go",
+        "//pkg/proto/pbgo/process:write_pb_go",
+        "//pkg/proto/pbgo/sbom:write_pb_go",
+        "//pkg/proto/pbgo/trace:agent_payload_gen",
+        "//pkg/proto/pbgo/trace:span_gen",
+        "//pkg/proto/pbgo/trace:stats_gen",
+        "//pkg/proto/pbgo/trace:trace_gen",
+        "//pkg/proto/pbgo/trace:tracer_payload_gen",
+        "//pkg/proto/pbgo/trace:write_pb_go",
+        "//pkg/proto/pbgo/trace/idx:write_pb_go",
+        "//pkg/security/proto/api:write_pb_go",
+    ],
 )

--- a/pkg/proto/BUILD.bazel
+++ b/pkg/proto/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -6,28 +5,4 @@ go_library(
     srcs = ["empty.go"],
     importpath = "github.com/DataDog/datadog-agent/pkg/proto",
     visibility = ["//visibility:public"],
-)
-
-write_source_files(
-    name = "write_all",
-    additional_update_targets = [
-        "//pkg/proto/msgpgo:key_gen",
-        "//pkg/proto/pbgo/core:remoteconfig_gen",
-        "//pkg/proto/pbgo/core:write_pb_go",
-        "//pkg/proto/pbgo/dogstatsdhttp:write_pb_go",
-        "//pkg/proto/pbgo/languagedetection:write_pb_go",
-        "//pkg/proto/pbgo/mocks/core:api_mockgen",
-        "//pkg/proto/pbgo/privateactionrunner/actionsclient:write_pb_go",
-        "//pkg/proto/pbgo/privateactionrunner/errorcode:write_pb_go",
-        "//pkg/proto/pbgo/privateactionrunner/privateactions:write_pb_go",
-        "//pkg/proto/pbgo/process:write_pb_go",
-        "//pkg/proto/pbgo/sbom:write_pb_go",
-        "//pkg/proto/pbgo/trace:agent_payload_gen",
-        "//pkg/proto/pbgo/trace:span_gen",
-        "//pkg/proto/pbgo/trace:stats_gen",
-        "//pkg/proto/pbgo/trace:trace_gen",
-        "//pkg/proto/pbgo/trace:tracer_payload_gen",
-        "//pkg/proto/pbgo/trace:write_pb_go",
-        "//pkg/proto/pbgo/trace/idx:write_pb_go",
-    ],
 )

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -12,11 +12,11 @@ def generate(ctx, pre_commit=False):
     """
     Generates protobuf definitions in pkg/proto
     """
-    proto_file = re.compile(r"pkg/proto/.*(\.pb|_gen(_test)?)\.go$")
+    proto_file = re.compile(r".*(\.pb|_gen(_test)?)\.go$")
     old_unstaged_proto_files = set(get_unstaged_files(ctx, re_filter=proto_file, include_deleted_files=True))
     old_untracked_proto_files = set(get_untracked_files(ctx, re_filter=proto_file))
 
-    bazel(ctx, "run", "//pkg/proto:write_all")
+    bazel(ctx, "run", "//:write_all")
 
     # Check the generated files were properly committed
     current_unstaged_proto_files = set(get_unstaged_files(ctx, re_filter=proto_file, include_deleted_files=True))


### PR DESCRIPTION
### What does this PR do?

Moves the `write_all` Bazel target from `//pkg/proto:write_all` to `//:write_all` (repo root `BUILD.bazel`) and adds two `write_pb_go` targets that were previously missing:

- `//comp/forwarder/defaultforwarder/internal/retry:write_pb_go`
- `//pkg/security/proto/api:write_pb_go`

Updates `dda inv protobuf.generate` to invoke `//:write_all` and to track all `*.pb.go`/`*_gen.go` files (not just those under `pkg/proto/`).

### Motivation

The root is the natural home for a target that aggregates proto generation across the whole repo — it improves discoverability and avoids the need to reach into `pkg/proto` for a repo-wide operation.

Two `write_pb_go` targets outside `pkg/proto/` were not covered by the previous `//pkg/proto:write_all`, causing the Bazel `write_pb_go_test` CI jobs to fail when `google.golang.org/protobuf` was bumped (the generated files in those packages were left on the old version).

Found while investigating a CI failure caused by #51566.

### Describe how you validated your changes

Pre-commit hooks pass locally.

### Additional Notes

Found by Claude Code.