### PR TITLE
[WP] Log raw packet filter compile errors instead of failing all filters

### DIFF
--- a/pkg/security/ebpf/tests/raw_packet_test.go
+++ b/pkg/security/ebpf/tests/raw_packet_test.go
@@ -336,3 +336,31 @@ func TestRawPacketDropAction(t *testing.T) {
 		testRawPacketDropAction(t, filters, "test/raw_packet_drop_action", probes.TCActUnspec, 1, rawpacket.DefaultProgOpts(), true)
 	})
 }
+
+// TestRawPacketActionWithInvalidFilter ensures that when a set of filters contains an
+// invalid BPF expression alongside a valid one, the invalid filter is skipped while the
+// valid filter is still compiled into a program (the number of generated programs is not 0).
+func TestRawPacketActionWithInvalidFilter(t *testing.T) {
+	filters := []rawpacket.Filter{
+		{
+			RuleID:    "invalid",
+			BPFFilter: "((( invalid bpf syntax",
+			Policy:    rawpacket.PolicyDrop,
+			CGroupPathKey: model.PathKey{
+				Inode: 456,
+			},
+		},
+		{
+			RuleID:    "valid",
+			BPFFilter: "tcp dst port 5555 and tcp[tcpflags] == tcp-syn",
+			Policy:    rawpacket.PolicyDrop,
+			CGroupPathKey: model.PathKey{
+				Inode: 456,
+			},
+		},
+	}
+
+	// catchCompilerError is false: the invalid filter is expected to fail compilation and
+	// be skipped, but the valid filter should still produce a single program (and match).
+	testRawPacketDropAction(t, filters, "test/raw_packet_drop_action", 255, 1, rawpacket.DefaultProgOpts(), false)
+}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -798,16 +798,23 @@ func (p *EBPFProbe) applyRawPacketActionFilters(applyFromRuleset bool) error {
 		return err
 	}
 
+	var errs *multierror.Error
+
 	var progSpecs []*lib.ProgramSpec
 	if len(p.rawPacketActionFilters) > 0 {
 		progSpecs, err = rawpacket.DropActionsToProgramSpecs(rawPacketEventMap.FD(), routerMap.FD(), p.rawPacketActionFilters, opts)
+		// if there is an error, keep it but we still want to load the valid programs
 		if err != nil {
-			return err
+			errs = multierror.Append(errs, err)
 		}
 	}
 
 	// add or close if none
-	return p.setupRawPacketProgs(progSpecs, probes.TCRawPacketDropActionKey, probes.RawPacketMaxTailCall, &p.rawPacketActionCollection, applyFromRuleset)
+	if err := p.setupRawPacketProgs(progSpecs, probes.TCRawPacketDropActionKey, probes.RawPacketMaxTailCall, &p.rawPacketActionCollection, applyFromRuleset); err != nil {
+		errs = multierror.Append(errs, err)
+	}
+
+	return errs.ErrorOrNil()
 }
 
 func (p *EBPFProbe) addRawPacketActionFilter(actionFilter rawpacket.Filter) error {


### PR DESCRIPTION
### What does this PR do?
When compiling raw-packet drop eBPF programs, log errors from `DropActionsToProgramSpecs` but still load successfully compiled programs. Adds `TestRawPacketActionWithInvalidFilter` to verify a valid filter keeps working when another rule has invalid BPF.

### Motivation
A single invalid network filter used to abort `applyRawPacketActionFilters`, so no drop programs were loaded even when other filters compiled fine. We now log the failure and apply the valid filters.

The test `TestRawPacketActionWithInvalidFilter` create a wrong filter and a valid one and then check that the valid one is still applied. Before this PR, the test would have failed.
