### PR TITLE
trace: remove evp proxy appkey injection

### DIFF
--- a/comp/trace/config/impl/setup.go
+++ b/comp/trace/config/impl/setup.go
@@ -656,12 +656,6 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "evp_proxy_config.api_key"; core.IsConfigured(k) {
 		c.EVPProxy.APIKey = core.GetString(k)
 	}
-	if k := "evp_proxy_config.app_key"; core.IsSet(k) {
-		c.EVPProxy.ApplicationKey = core.GetString(k)
-	} else {
-		// Default to the agent-wide app_key if set
-		c.EVPProxy.ApplicationKey = core.GetString("app_key")
-	}
 	if k := "evp_proxy_config.additional_endpoints"; core.IsConfigured(k) {
 		c.EVPProxy.AdditionalEndpoints = core.GetStringMapStringSlice(k)
 	}

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -126,7 +126,6 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 
 	subdomain := req.Header.Get("X-Datadog-EVP-Subdomain")
 	containerID := t.containerIDProvider.GetContainerID(req.Context(), req.Header)
-	needsAppKey := (strings.ToLower(req.Header.Get("X-Datadog-NeedsAppKey")) == "true")
 
 	// Sanitize the input, don't accept any valid URL but just some limited subset
 	if len(subdomain) == 0 {
@@ -141,10 +140,6 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	}
 	if !isValidQueryString(req.URL.RawQuery) {
 		return nil, fmt.Errorf("EVPProxy: invalid query string: %s", req.URL.RawQuery)
-	}
-
-	if needsAppKey && t.conf.EVPProxy.ApplicationKey == "" {
-		return nil, errors.New("EVPProxy: ApplicationKey needed but not set")
 	}
 
 	// We don't want to forward arbitrary headers, create a copy of the input headers and clear them
@@ -176,9 +171,6 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	req.Header.Set("X-Datadog-AgentDefaultEnv", t.conf.DefaultEnv)
 	log.Debugf("Setting headers X-Datadog-Hostnames=%s, X-Datadog-AgentDefaultEnv=%s for evp proxy", t.conf.Hostname, t.conf.DefaultEnv)
 	req.Header.Set(header.ContainerID, containerID)
-	if needsAppKey {
-		req.Header.Set("DD-APPLICATION-KEY", t.conf.EVPProxy.ApplicationKey)
-	}
 	if t.conf.ErrorTrackingStandalone {
 		req.Header.Set("X-Datadog-Error-Tracking-Standalone", "true")
 	}

--- a/pkg/trace/api/evp_proxy_test.go
+++ b/pkg/trace/api/evp_proxy_test.go
@@ -419,52 +419,6 @@ func TestEVPProxyForwarder(t *testing.T) {
 		assert.Equal(t, endpoints[0].APIKey, "override_api_key")
 	})
 
-	t.Run("appkey", func(t *testing.T) {
-		conf := newTestReceiverConfig()
-		conf.Site = "us3.datadoghq.com"
-		conf.Endpoints[0].APIKey = "test_api_key"
-		conf.EVPProxy.ApplicationKey = "test_application_key"
-
-		req := httptest.NewRequest("POST", "/mypath/mysubpath", bytes.NewReader(randBodyBuf))
-		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
-		req.Header.Set("X-Datadog-NeedsAppKey", "true")
-		proxyreqs, resp, logs := sendRequestThroughForwarderWithMockRoundTripper(conf, req, stats)
-
-		resp.Body.Close()
-		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", strconv.Itoa(resp.StatusCode))
-		require.Len(t, proxyreqs, 1)
-		assert.Equal(t, "test_application_key", proxyreqs[0].Header.Get("DD-APPLICATION-KEY"))
-		assert.Equal(t, "", logs)
-	})
-
-	t.Run("missing-appkey", func(t *testing.T) {
-		stats.Reset()
-
-		conf := newTestReceiverConfig()
-		conf.Site = "us3.datadoghq.com"
-		conf.Endpoints[0].APIKey = "test_api_key"
-
-		req := httptest.NewRequest("POST", "/mypath/mysubpath", bytes.NewReader(randBodyBuf))
-		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
-		req.Header.Set("X-Datadog-NeedsAppKey", "true")
-		proxyreqs, resp, logs := sendRequestThroughForwarderWithMockRoundTripper(conf, req, stats)
-
-		resp.Body.Close()
-		require.Len(t, proxyreqs, 0)
-		require.Equal(t, http.StatusBadGateway, resp.StatusCode, "Got: ", strconv.Itoa(resp.StatusCode))
-		require.Contains(t, logs, "ApplicationKey needed but not set")
-
-		// check metrics
-		expectedTags := []string{
-			"subdomain:my.subdomain",
-		}
-		require.Len(t, stats.CountCalls, 3)
-		assert.Equal(t, "datadog.trace_agent.evp_proxy.request_error", stats.CountCalls[2].Name)
-		assert.Equal(t, float64(1), stats.CountCalls[2].Value)
-		assert.Equal(t, float64(1), stats.CountCalls[2].Rate)
-		assert.ElementsMatch(t, expectedTags, stats.CountCalls[2].Tags)
-	})
-
 	t.Run("headerfilter", func(t *testing.T) {
 		stats.Reset()
 

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -303,8 +303,6 @@ type EVPProxy struct {
 	DDURL string
 	// APIKey is the main API Key (defaults to the main API key).
 	APIKey string `json:"-"` // Never marshal this field
-	// ApplicationKey to be used for requests with the X-Datadog-NeedsAppKey set (defaults to the top-level Application Key).
-	ApplicationKey string `json:"-"` // Never marshal this field
 	// AdditionalEndpoints is a map of additional Datadog sites to API keys.
 	AdditionalEndpoints map[string][]string
 	// MaxPayloadSize indicates the size at which payloads will be rejected, in bytes.

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -168,7 +168,6 @@ func testInit(t *testing.T, serverConfig *tls.Config) *config.AgentConfig {
 	conf.TelemetryConfig.Endpoints[0].APIKey = "key1"
 	conf.Proxy = nil
 	conf.EVPProxy.APIKey = "evp_api_key"
-	conf.EVPProxy.ApplicationKey = "evp_app_key"
 	conf.EVPProxy.AdditionalEndpoints = clearAddEp
 	conf.ProfilingProxy.AdditionalEndpoints = clearAddEp
 	conf.DebuggerProxy.APIKey = "debugger_proxy_key"
@@ -512,8 +511,6 @@ func TestInfoConfig(t *testing.T) {
 	}
 	assert.Equal("", confCopy.EVPProxy.APIKey, "EVP API Key should *NEVER* be exported")
 	conf.EVPProxy.APIKey = ""
-	assert.Equal("", confCopy.EVPProxy.ApplicationKey, "EVP APP Key should *NEVER* be exported")
-	conf.EVPProxy.ApplicationKey = ""
 	assert.Equal("", confCopy.DebuggerProxy.APIKey, "Debugger Proxy API Key should *NEVER* be exported")
 	conf.DebuggerProxy.APIKey = ""
 	assert.Equal("", confCopy.DebuggerIntakeProxy.APIKey, "Debugger Intake Proxy API Key should *NEVER* be exported")

--- a/releasenotes/notes/apm-evp-proxy-remove-app-key-b9ba979ffcd6c873.yaml
+++ b/releasenotes/notes/apm-evp-proxy-remove-app-key-b9ba979ffcd6c873.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    APM : The ``evp_proxy_config.app_key`` configuration option has been removed,
+    along with support for the ``X-Datadog-NeedsAppKey`` request header in the
+    trace-agent EVP proxy. The EVP proxy no longer attaches an Application key to
+    forwarded requests.


### PR DESCRIPTION
### What does this PR do?

Removes injection of `DD-APPLICATION-KEY` in the evp proxy.

### Motivation
It's not used by anyone and could be misused.

### Describe how you validated your changes

### Additional Notes
