### PR TITLE
truncation: split detector and windows event from truncatable contract.

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/truncation.allium
+++ b/pkg/logs/internal/decoder/preprocessor/truncation.allium
@@ -1,12 +1,15 @@
 -- allium: 3
 -- truncation.allium
 
--- Scope: Per-emission truncation behaviour shared by aggregators in
---   the Datadog Agent's logs preprocessor pipeline. Captures the
---   common "if the content exceeds a size threshold, decorate it
---   with `...TRUNCATED...` marker bytes and propagate a carry-over
---   signal so the next emission can decorate its head accordingly"
---   pattern.
+-- Scope: Per-emission truncation decoration behaviour shared across
+--   the Datadog Agent's logs pipeline. Captures the common "if the
+--   content exceeds a size threshold, decorate it with `...TRUNCATED...`
+--   marker bytes and propagate a carry-over signal so the next
+--   emission can decorate its head accordingly" pattern. Fulfilled
+--   by: SingleLineHandler and MultiLineHandler (legacy decoder
+--   handlers, paths A and B), PassThroughAggregator, RegexAggregator,
+--   DetectingAggregator, and CombiningAggregator (preprocessor
+--   aggregators, paths C / D / E).
 -- Includes: The Truncatable contract (the abstract truncation
 --   operation), marker semantics, carry-over state across consecutive
 --   calls, upstream-truncation-flag propagation, tag-on-truncation
@@ -25,15 +28,25 @@
 --     this is observable in current implementations but is an
 --     implementation choice rather than a Truncatable promise. Callers
 --     should not rely on it.
---   - Framer-level truncation marking (line_parser.go's
---     `isBufferTruncated` signal). The framer marks input messages
---     but does not decorate them; Truncatable consumes that signal
---     via the `upstream_truncated` input.
---   - Truncation in components outside the preprocessor (the legacy
---     decoder-level handlers, the windows-event 128 KB truncation).
---     The same Truncatable contract conceptually applies, but the
---     fulfilling declarations are deferred until those components
---     are spec'd.
+--   - Detection-only behaviour, which produces an IsTruncated flag
+--     without adding marker bytes. The framer
+--     (pkg/logs/internal/framer) and the MultiLineParser
+--     (pkg/logs/internal/decoder/line_parser.go) signal detected
+--     overflow via this flag, which Truncatable consumes through
+--     the upstream_truncated input. Detection has its own contract
+--     at truncation_detector.allium (fulfilled by framer);
+--     MultiLineParser is a stateful accumulator with its own
+--     surface spec. Both sites have separate surface specs and
+--     property test coverage as part of the same refactor effort.
+--   - The Windows event 128 KB truncation pathway, which is
+--     single-stage, has no carry-over, and detects truncation
+--     retroactively by scanning for marker presence. It does not
+--     compose with the rest of the logs pipeline and has its own
+--     spec at windows_event_truncation.allium.
+--   - Aggregator-level concerns that surround truncation but are
+--     not part of it: CombiningAggregator's no_aggregate-resets-carry
+--     and overflow-explosion behaviours are described in
+--     combining_aggregator.allium, not here.
 
 ------------------------------------------------------------
 -- Value Types
@@ -103,6 +116,17 @@ contract Truncatable {
         -- current call is also over-threshold: a call that receives
         -- carry-over and is also over-threshold produces content
         -- decorated at both ends.
+
+    @invariant CarryoverConsumed
+        -- The new_carryover output is determined solely by the
+        -- current call's input — specifically by whether the
+        -- content is over threshold OR upstream_truncated is true.
+        -- The prior_carryover input does NOT propagate into
+        -- new_carryover: a call with prior_carryover=true but
+        -- under-threshold non-upstream-truncated content produces
+        -- new_carryover=false. Carry-over does not "stick" across
+        -- emissions once the input returns under threshold; it is
+        -- consumed when read.
 
     @invariant UpstreamFlagPropagation
         -- The upstream_truncated input behaves equivalently to

--- a/pkg/logs/internal/decoder/preprocessor/truncation_detector.allium
+++ b/pkg/logs/internal/decoder/preprocessor/truncation_detector.allium
@@ -1,0 +1,122 @@
+-- allium: 3
+-- truncation_detector.allium
+
+-- Scope: The per-decision truncation detection operation: observing
+--   whether input content exceeds a size threshold and producing an
+--   IsTruncated signal without adding marker bytes. Distinct from
+--   Truncatable (which decorates content with marker bytes and
+--   maintains carry-over state); the detector is the upstream signal
+--   source that Truncatable consumes via its upstream_truncated
+--   input. Fulfilled by: the framer at pkg/logs/internal/framer.
+-- Includes: The TruncationDetector contract, the DetectionResult
+--   value type, the byte-boundary cut semantics, the flag-only
+--   guarantee.
+-- Excludes:
+--   - Marker byte decoration. The `...TRUNCATED...` marker bytes are
+--     not added by detection sites; they are added by Truncatable
+--     fulfillers downstream. This contract explicitly forbids marker
+--     addition (see FlagOnly).
+--   - Carry-over state across consecutive calls. Detection is a
+--     pure per-call decision; the detector holds no state. Stateful
+--     accumulators (e.g. MultiLineParser at
+--     pkg/logs/internal/decoder/line_parser.go) USE detection
+--     internally at emission boundaries but are not themselves
+--     TruncationDetector fulfillers — they are described in their
+--     own surface specs.
+--   - The threshold value, which is per-instance configuration
+--     supplied by the caller rather than part of the contract.
+--   - UTF-8-aware cutting. The framer cuts content at byte boundary;
+--     UTF-8 boundary awareness is a fulfiller-specific concern. The
+--     Windows event 128 KB truncation uses UTF-8-aware cutting and
+--     is described separately at windows_event_truncation.allium.
+--   - The mechanism by which the IsTruncated flag flows downstream
+--     (set on message metadata, consumed by Truncatable). The
+--     consuming side is described in truncation.allium under the
+--     UpstreamFlagPropagation invariant.
+
+------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+value DetectionResult {
+    -- The output of applying detection to one piece of content.
+    --
+    -- content:      the (possibly cut) bytes to be emitted
+    --               downstream. When the input exceeds threshold,
+    --               this is the first `threshold` bytes of the
+    --               input (cut at byte boundary). When the input is
+    --               at or under threshold, this equals the input.
+    -- is_truncated: whether the input exceeded threshold. Mirrored
+    --               onto the emitted message's IsTruncated metadata
+    --               flag by fulfillers; consumed downstream by
+    --               Truncatable fulfillers via their
+    --               upstream_truncated input.
+    content: String
+    is_truncated: Boolean
+}
+
+------------------------------------------------------------
+-- Contracts
+------------------------------------------------------------
+
+contract TruncationDetector {
+    -- Determine whether input content exceeds a size threshold,
+    -- producing the (possibly cut) content along with an
+    -- is_truncated flag. The contract is per-call: each invocation
+    -- is a pure function of its inputs, with no carry-over state
+    -- between calls. Marker decoration is explicitly out of scope
+    -- (see FlagOnly).
+    --
+    -- This contract is the upstream half of the truncation pipeline.
+    -- The downstream half is Truncatable (at truncation.allium),
+    -- which consumes the is_truncated signal via its
+    -- upstream_truncated input and applies the `...TRUNCATED...`
+    -- marker bytes.
+    detect:
+        (content: String,
+         threshold: Integer) -> DetectionResult
+
+    @invariant PassThroughUnderThreshold
+        -- When the input content's length is at or under the
+        -- threshold, the output content equals the input content
+        -- (byte-for-byte) and is_truncated is false. The detector
+        -- does not modify under-threshold inputs.
+
+    @invariant CutAtThresholdOverLimit
+        -- When the input content's length exceeds the threshold,
+        -- the output content is the first `threshold` bytes of the
+        -- input (cut at byte boundary) and is_truncated is true.
+        -- The detector cuts at byte position threshold regardless
+        -- of multi-byte character boundaries; UTF-8 awareness is
+        -- not part of this contract.
+
+    @invariant FlagOnly
+        -- The detector adds no marker bytes to the content. The
+        -- only signal of detected truncation is the is_truncated
+        -- flag in DetectionResult. Fulfillers MUST NOT prepend or
+        -- append the `...TRUNCATED...` marker — that is the
+        -- exclusive responsibility of Truncatable fulfillers
+        -- downstream.
+
+    @invariant Determinism
+        -- Given identical (content, threshold) inputs, the
+        -- detector produces identical DetectionResult outputs.
+        -- The detector holds no state between calls.
+
+    @guidance
+        -- This contract describes the abstract per-decision
+        -- detection operation. The framer at
+        -- pkg/logs/internal/framer is the canonical fulfiller —
+        -- it applies detection per frame, cutting raw byte input
+        -- at contentLenLimit when a newline is not found within
+        -- the limit.
+        --
+        -- The MultiLineParser at
+        -- pkg/logs/internal/decoder/line_parser.go is NOT a
+        -- direct fulfiller of this contract. It is a stateful
+        -- accumulator that conceptually applies detection at
+        -- emission boundaries (when its buffer reaches lineLimit),
+        -- but its accumulator state, deferred-reset semantics,
+        -- and buffer lifecycle are described in its own surface
+        -- spec rather than through this contract.
+}

--- a/pkg/logs/internal/decoder/preprocessor/windows_event_truncation.allium
+++ b/pkg/logs/internal/decoder/preprocessor/windows_event_truncation.allium
@@ -1,0 +1,187 @@
+-- allium: 3
+-- windows_event_truncation.allium
+
+-- Scope: The truncation pathway for the "message" field of a
+--   Windows Event Log record after XML-to-structured-message
+--   conversion. A single-stage truncation: a fixed byte limit, a
+--   UTF-8-aware cut, an appended tail marker, and a retroactive
+--   marker-scan detection step. The pathway is stateless per
+--   message and does not compose with the rest of the logs
+--   pipeline. Lives in pkg/logs/util/windowsevent.
+-- Includes: The WindowsEventTruncator entity, the
+--   WindowsEventTruncation surface and its @guarantees, the
+--   asymmetry between write-side and detect-side handling of the
+--   marker byte sequence, the UTF-8-aware truncation semantics.
+-- Excludes:
+--   - The Truncatable contract at truncation.allium and the
+--     TruncationDetector contract at truncation_detector.allium.
+--     This pathway does not fulfil either: it has no carry-over
+--     state and applies marker decoration in the same stage as
+--     the size-based cut, rather than separating detection from
+--     decoration.
+--   - The XML parsing, EventID normalisation, binary field
+--     decoding and other transforms performed in
+--     transform.go's NewMapXMLWithOptions. Those are orthogonal
+--     to truncation.
+--   - The serialisation pathway after MapToMessage produces a
+--     message.Message (forwarder, intake, etc.). The IsTruncated
+--     flag set on the message flows downstream like any other
+--     message flag; the consuming side is not described here.
+--   - Other fields of the Windows Event Log record (Binary, Data,
+--     System, EventID, etc.). The 128 KB limit applies ONLY to
+--     the Datadog-added "message" field; other fields may exceed
+--     it without truncation markers.
+--   - The literal byte value of the truncation marker
+--     (`...TRUNCATED...`). The marker byte sequence is owned by
+--     the agent's message package and is treated here as an
+--     opaque constant shared with Truncatable.
+
+------------------------------------------------------------
+-- Entities
+------------------------------------------------------------
+
+entity WindowsEventTruncator {
+    -- The truncation operation applied to the Windows event
+    -- message field. Stateless per message: there is no carry-
+    -- over between successive calls and no buffered content
+    -- across messages. Configuration is fixed at construction.
+    --
+    -- max_message_bytes: the byte threshold above which the
+    --                    message field is truncated. Hardcoded
+    --                    to 131,072 (128 KB) in transform.go's
+    --                    maxMessageBytes constant. NOT
+    --                    per-source configurable.
+    max_message_bytes: Integer
+}
+
+------------------------------------------------------------
+-- Surfaces
+------------------------------------------------------------
+
+surface WindowsEventTruncation {
+    -- The boundary between the Windows event log map (after XML
+    -- parsing) and the downstream structured-message
+    -- serialisation. Two distinct operations cross this
+    -- boundary: a write-side operation that applies size-based
+    -- truncation when the message field is set, and a
+    -- read-side operation that retroactively detects truncation
+    -- by scanning the resulting string for the marker byte
+    -- sequence. The two are coupled by the shared marker but
+    -- are not symmetric — the write side appends only, while
+    -- the read side scans both boundaries.
+
+    context op: WindowsEventTruncator
+
+    exposes:
+        op.max_message_bytes
+
+    @guarantee LimitFixed
+        -- The op.max_message_bytes threshold is the literal value
+        -- 131,072 (128 * 1024). It is a Go-side constant
+        -- (maxMessageBytes in transform.go) and not configurable
+        -- per log source. Other truncation pathways in the agent
+        -- (preprocessor aggregators, legacy decoder handlers,
+        -- framer) take their limit as a per-instance parameter;
+        -- this one does not.
+
+    @guarantee PassThroughUnderLimit
+        -- When the input message's byte length is at or under
+        -- op.max_message_bytes, the message field is stored
+        -- byte-for-byte unchanged. No marker is appended; the
+        -- IsTruncated flag derived from a later read-side scan
+        -- is false (no marker to find).
+
+    @guarantee UTF8AwareCutAtLimit
+        -- When the input message's byte length exceeds
+        -- op.max_message_bytes, the content is cut to at most
+        -- op.max_message_bytes bytes at a UTF-8 character
+        -- boundary (via stringUtil.TruncateUTF8). The cut never
+        -- splits a multi-byte UTF-8 sequence — this is a
+        -- distinguishing property from the framer-level cut,
+        -- which is purely byte-positional.
+
+    @guarantee TailMarkerOnOverflow
+        -- When the size-based cut is applied, the
+        -- `...TRUNCATED...` marker bytes are appended to the
+        -- end of the cut content. The marker is NEVER prepended
+        -- by the write side: head-marker decoration is
+        -- exclusively a Truncatable concept and does not occur
+        -- in the Windows event pathway.
+
+    @guarantee NoCarryOver
+        -- Each message is handled independently of any prior
+        -- message. There is no rolling truncation state across
+        -- successive calls to SetMessage; a message that
+        -- overflows leaves no signal on the next message. The
+        -- truncator holds no mutable state between operations.
+
+    @guarantee RetroactiveDetection
+        -- The IsTruncated flag on the resulting
+        -- message.Message is determined NOT by tracking whether
+        -- the write side applied truncation, but by RETROACTIVELY
+        -- scanning the message field for the marker byte
+        -- sequence at the time of message construction (in
+        -- MapToMessage's hasTruncatedFlag call). This is a
+        -- distinguishing property from every other truncation
+        -- pathway in the agent: elsewhere, IsTruncated is
+        -- carried as a flag from the moment truncation is
+        -- detected; here it is rediscovered at serialisation
+        -- time.
+
+    @guarantee MarkerScanAtBothBoundaries
+        -- The retroactive marker scan checks BOTH the head and
+        -- the tail of the message string. A marker present at
+        -- either boundary causes IsTruncated to be set. This is
+        -- asymmetric to the write side: the write side only
+        -- appends (tail), but the read side accepts a marker at
+        -- either end. Messages that arrive already
+        -- head-decorated (from any upstream source) are
+        -- recognised as truncated.
+
+    @guarantee EmptyMessageIsNoop
+        -- An empty input message (zero-length string) causes
+        -- SetMessage to short-circuit without storing,
+        -- truncating, or appending a marker. The retroactive
+        -- detection on a never-set message field yields
+        -- IsTruncated=false (no string to scan, or the empty
+        -- string fails the length check in hasTruncatedFlag).
+
+    @guarantee NoComposition
+        -- The Windows event truncation pathway does NOT compose
+        -- with the rest of the logs pipeline. Windows event
+        -- messages are constructed via MapToMessage and do not
+        -- pass through the decoder's framer, line_parser,
+        -- legacy decoder handlers, or preprocessor aggregators.
+        -- The IsTruncated flag set here is the message's only
+        -- truncation signal; no further marker decoration or
+        -- carry-over occurs downstream.
+
+    @guarantee Determinism
+        -- Given identical input message content and identical
+        -- max_message_bytes, SetMessage and the subsequent
+        -- hasTruncatedFlag scan produce identical results: the
+        -- same stored message bytes and the same IsTruncated
+        -- flag value. The pathway holds no state between calls.
+
+    @guidance
+        -- The write-side / read-side asymmetry is a current
+        -- design choice that should be preserved across any
+        -- future refactor. The read side's both-boundaries scan
+        -- exists to recognise truncation markers that may have
+        -- been applied by code paths the Windows event pathway
+        -- did not originate — for example, content propagated
+        -- from a different truncation pathway and embedded into
+        -- the Windows event message field. A refactor that
+        -- consolidated this with other truncation pathways
+        -- would need to preserve the both-boundaries scan
+        -- semantics OR demonstrate that no current upstream
+        -- emits head-decorated content into this pathway.
+        --
+        -- This is the only truncation site in the agent that
+        -- detects via marker scan rather than flag propagation.
+        -- Property tests anchored to RetroactiveDetection and
+        -- MarkerScanAtBothBoundaries should be a refactor
+        -- safety net: a consolidated truncation utility must
+        -- preserve these semantics if Windows event continues to
+        -- use it.
+}


### PR DESCRIPTION
### What does this PR do?

  Restructures the truncation contract layer into three contracts instead of one:

  - **`TruncationDetector`** (new, `truncation_detector.allium`) — detection-only operation. Given content and a size threshold, produces (possibly cut) content and a flag; does NOT add marker bytes.
  - **`WindowsEventTruncation`** (new, `windows_event_truncation.allium`) — standalone Windows event pathway. Single-stage, no carry-over, retroactive marker scan.
  - **`Truncatable`** (existing, scope tightened) — the decoration operation only. Naming clarified; carry-over semantics refined.

  Also adds the **`CarryoverConsumed`** invariant to `Truncatable`: a carry-over signal is consumed by the next emission and never silently persists.

  ### Motivation

  This PR establishes the foundation of the **Truncation Safety Net** stack — specs and property tests covering truncation behaviour across **the entire logs pipeline** (framer, line parser, decoder handlers,
  preprocessor aggregators, and Windows event), not just the preprocessor.

  The safety net is a prerequisite for a future refactor extracting the inlined truncation logic into a shared helper. **No production code paths are modified** by this stack.

  For the full scope (9 sites across 4 directories), the 3-contract layering rationale, the 9-surface conformance table, the 5 load-bearing divergences, and the test inventory, see the [**Truncation Safety Net**
  Confluence page](https://datadoghq.atlassian.net/wiki/spaces/~712020c20dd82e15fd4ed5bcd968f8d10d9578/pages/6759220118/Truncation+Safety+Net).

  The original `truncation.allium` mixed three distinct operations: detection (which the framer does), decoration (which the handlers and aggregators do), and the entirely separate Windows event pathway. Splitting
  them lets each fulfiller declare conformance to the contract it actually fits.

  ### Describe how you validated your changes

  - `allium check` clean on all three contract files.
  - Existing surfaces still reference `Truncatable`; no surface-level test impact (surfaces are retrofitted to the new contracts in later PRs in this stack).

  ### Additional Notes

  - Foundation PR for the Truncation Safety Net graphite stack.
  - The 6 surfaces that will declare `fulfils Truncatable` (SingleLineHandler, MultiLineHandler, PassThroughAggregator, RegexAggregator, DetectingAggregator, CombiningAggregator) are introduced/updated in
  subsequent PRs in this stack.
  - Spec-only PR. Zero `.go` files touched.