### PR TITLE
aggregator surfaces: declare fulfils Truncatable on conformers, pin divergences elsewhere

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/combining_aggregator.allium
+++ b/pkg/logs/internal/decoder/preprocessor/combining_aggregator.allium
@@ -327,6 +327,44 @@ surface CombiningAggregation {
         -- bucket_content_len could reach line_limit — they just
         -- don't arise under the dispatch defined here.
 
+    @guarantee CombinedEmissionUpstreamFlagIgnored
+        -- The COMBINED-emission path (the bucket-flush procedure
+        -- producing a combined message of two or more lines)
+        -- does NOT honour the upstream IsTruncated flag of any
+        -- contributing line. The bucket-flush invocation of
+        -- apply_truncation passes shouldTruncate = (bucket_
+        -- content_len >= line_limit) only — the per-input
+        -- upstream IsTruncated flags are not OR'd into this
+        -- argument. As a consequence, a combined emission of
+        -- lines where SOME contributors arrived with
+        -- ParsingExtra.IsTruncated=true (e.g. from the framer)
+        -- but the combined buffer stays under line_limit emits
+        -- with IsTruncated=false — the upstream signals are
+        -- DROPPED.
+        --
+        -- The SINGLE-LINE emission path (emit_single, invoked
+        -- for noAggregate labels, aggregate-on-empty-bucket
+        -- lines, exploded individual lines, and oversized
+        -- start_group lines) DOES honour the upstream
+        -- IsTruncated flag — it passes shouldTruncate =
+        -- (length(content) > line_limit OR msg.is_truncated
+        -- upstream). The behavioural asymmetry between the
+        -- two paths is intentional and reflects how the
+        -- bucket accumulation is currently implemented.
+        --
+        -- Consequence for Truncatable conformance:
+        -- CombiningAggregator therefore does NOT declare
+        -- fulfils Truncatable. The single-line path
+        -- structurally conforms to the contract; the
+        -- combined-emission path does not (UpstreamFlagPropagation
+        -- violated). A refactor preserving observable
+        -- behaviour must preserve this asymmetry. A refactor
+        -- that begins propagating upstream flags into the
+        -- combined-emission apply_truncation invocation would
+        -- be a deliberate behaviour change, producing
+        -- additional IsTruncated=true emissions for combined
+        -- buckets containing upstream-flagged contributors.
+
     @guidance
         -- Per-call dispatch when process is invoked with
         -- arguments (msg, label, tokens) on a CombiningAggregator

--- a/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.allium
+++ b/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.allium
@@ -42,6 +42,7 @@
 --     aggregator's behavioural contract.
 
 use "./aggregator.allium" as aggregator
+use "./truncation.allium" as truncation
 
 ------------------------------------------------------------
 -- Entities
@@ -116,6 +117,7 @@ surface DetectingAggregation {
 
     contracts:
         fulfils Aggregator
+        fulfils Truncatable
 
     @guarantee Determinism
         -- The Aggregator contract's Determinism invariant holds:
@@ -218,27 +220,85 @@ surface DetectingAggregation {
         -- The aggregate and noAggregate labels never buffer: their
         -- current message is always emitted on the same call.
 
-    @guarantee SingleLineTruncationFlow
-        -- The truncation handling applied to every emission is
-        -- identical in shape to PassThroughAggregator's: a rolling
-        -- should_truncate carry, the truncation marker prepended
-        -- if the prior emission triggered truncation, the marker
-        -- appended if THIS emission's content exceeds line_limit
-        -- or arrives with the upstream-is-truncated flag, the
-        -- emitted message's is_truncated flag set when either
-        -- direction's marker was applied, and the truncation-
-        -- reason tag with value "single_line" attached when
-        -- tag_truncated_logs is true.
-        --
-        -- Each emission updates the should_truncate carry
-        -- independently; the carry follows the SEQUENCE of
-        -- emissions, not the sequence of process calls. (Notably:
-        -- a process call that emits both a previous pending
-        -- message AND the current message — the aggregate or
-        -- noAggregate branch when a pending exists — runs the
-        -- truncation flow twice within the same call, with the
-        -- second emission's prepend driven by the first
-        -- emission's freshly-set carry.)
+    @guarantee PassThroughUnderThreshold
+        -- (Inherited from Truncatable.) When an emission's
+        -- input content is at or under agg.line_limit AND the
+        -- input's ParsingExtra.IsTruncated is false AND
+        -- agg.should_truncate is false at emission entry, the
+        -- emitted content equals the whitespace-trimmed input,
+        -- ParsingExtra.IsTruncated is false, no truncation tag
+        -- is added, and agg.should_truncate remains false.
+
+    @guarantee TailMarkerOnOverThreshold
+        -- (Inherited from Truncatable.) When an emission's
+        -- input content exceeds agg.line_limit OR the input's
+        -- ParsingExtra.IsTruncated is true, the emitted
+        -- content has the truncation marker appended,
+        -- ParsingExtra.IsTruncated is true on the emission,
+        -- and agg.should_truncate is true after the emission.
+
+    @guarantee HeadMarkerOnCarryover
+        -- (Inherited from Truncatable.) When agg.should_truncate
+        -- is true at an emission's entry, the emitted content
+        -- has the truncation marker prepended, and
+        -- ParsingExtra.IsTruncated is true on the emission.
+        -- The head marker is independent of the tail marker;
+        -- both may apply on the same emission.
+
+    @guarantee CarryoverConsumed
+        -- (Inherited from Truncatable.) The new value of
+        -- agg.should_truncate after an emission is determined
+        -- SOLELY by that emission's input — whether the content
+        -- exceeds agg.line_limit OR the input's
+        -- ParsingExtra.IsTruncated is true. The value at
+        -- emission entry does NOT propagate forward.
+
+    @guarantee UpstreamFlagPropagation
+        -- (Inherited from Truncatable.) The input's
+        -- ParsingExtra.IsTruncated being true is equivalent
+        -- to the input being over-threshold — both trigger
+        -- tail marker decoration and set agg.should_truncate
+        -- after the emission.
+
+    @guarantee TagOnTruncation
+        -- (Inherited from Truncatable.) When an emission
+        -- carries any truncation marker,
+        -- ParsingExtra.IsTruncated is set true on the
+        -- emission. When agg.tag_truncated_logs is true, a
+        -- truncation-reason tag is appended to
+        -- ParsingExtra.Tags (see TagReasonSingleLine for the
+        -- tag value).
+
+    @guarantee MarkerLiteral
+        -- (Inherited from Truncatable.) The marker bytes
+        -- prepended and appended are the literal byte
+        -- sequence `...TRUNCATED...` from the agent's
+        -- message package (message.TruncatedFlag).
+
+    @guarantee TagReasonSingleLine
+        -- The truncation-reason tag value applied by this
+        -- aggregator is always the literal string
+        -- "single_line". Identical to PassThroughAggregator's
+        -- and SingleLineHandler's tag reason. Note that this
+        -- is the TRUNCATION tag — distinct from the
+        -- "auto_multiline_detected:true" detection tag
+        -- handled by MultiLineDetectionTag, which is
+        -- orthogonal to truncation.
+
+    @guarantee PerEmissionTruncationFlow
+        -- The Truncatable contract is fulfilled at every
+        -- emission boundary. A single process call may emit
+        -- multiple messages (the aggregate or noAggregate
+        -- branch when a pending message exists emits both
+        -- the pending and the current message), and the
+        -- Truncatable apply operation runs INDEPENDENTLY for
+        -- each emission in sequence. The agg.should_truncate
+        -- carry follows the SEQUENCE of emissions, not the
+        -- sequence of process calls: a process call that
+        -- produces two emissions runs the apply operation
+        -- twice, with the second emission's prior_carryover
+        -- being whatever the first emission's apply operation
+        -- set as new_carryover.
 
     @guidance
         -- Per-call dispatch when process is invoked with arguments
@@ -294,27 +354,23 @@ surface DetectingAggregation {
         -- is_empty procedure:
         --   Return the negation of pending_message_present.
         --
-        -- SingleLineTruncationFlow (applied to each emission):
-        --   The content transformation matches PassThroughAggregator's
-        --   per-call procedure. Given (emit_msg, emit_tokens):
+        -- emit_via_truncatable (applied to each emission):
+        --   Given (emit_msg, emit_tokens):
         --
-        --   1. Capture should_truncate as prepend_marker, then
-        --      recompute should_truncate: it becomes true iff
-        --      emit_msg.content.length > line_limit OR
-        --      emit_msg.is_truncated is already true.
-        --   2. Trim leading and trailing whitespace from
-        --      emit_msg.content.
-        --   3. If prepend_marker: prepend the truncation marker
-        --      to the trimmed content.
-        --   4. If should_truncate (recomputed): append the
-        --      truncation marker.
-        --   5. If either prepend_marker or should_truncate: mark
-        --      emit_msg.is_truncated true and — when
-        --      tag_truncated_logs is true — append the
-        --      truncation-reason tag with value "single_line".
-        --   6. Replace emit_msg.content with the transformed
-        --      bytes and append (emit_msg, emit_tokens) to the
-        --      collected slice.
+        --   1. Apply the Truncatable contract's apply operation
+        --      to emit_msg.content with
+        --      threshold=agg.line_limit,
+        --      upstream_truncated=emit_msg.ParsingExtra.IsTruncated,
+        --      prior_carryover=agg.should_truncate. The contract
+        --      handles whitespace trimming, head/tail marker
+        --      placement, ParsingExtra.IsTruncated setting, and
+        --      tag application (with tag reason "single_line")
+        --      per its invariants.
+        --   2. Overwrite agg.should_truncate with the contract's
+        --      returned new_carryover.
+        --   3. Replace emit_msg.content with the contract's
+        --      returned bytes and append (emit_msg, emit_tokens)
+        --      to the collected slice.
         --
         -- The truncation flow runs independently for each
         -- emission; chained emissions within a single process

--- a/pkg/logs/internal/decoder/preprocessor/multiline_json_aggregator.allium
+++ b/pkg/logs/internal/decoder/preprocessor/multiline_json_aggregator.allium
@@ -29,6 +29,17 @@
 --   - Telemetry counters (TlmAutoMultilineJSONAggregatorFlush)
 --   - Per-source decoder configuration that selects this
 --     aggregator and constructs its dependencies
+--   - Byte-marker (`...TRUNCATED...`) truncation. This
+--     aggregator does NOT perform byte-marker truncation:
+--     its size-limit handling (FlushOnSizeLimit) emits
+--     buffered messages unmodified rather than cutting and
+--     decorating them, and no message emitted by this
+--     aggregator has IsTruncated set or a truncation-reason
+--     tag added by its own logic (such flags or tags inherit
+--     from upstream stages unchanged). The Truncatable
+--     contract at truncation.allium does not apply here; the
+--     JSONAggregator's domain is JSON-shape aggregation, not
+--     byte-length enforcement.
 
 use "./json_aggregator.allium" as json_aggregator
 

--- a/pkg/logs/internal/decoder/preprocessor/pass_through_aggregator.allium
+++ b/pkg/logs/internal/decoder/preprocessor/pass_through_aggregator.allium
@@ -30,6 +30,7 @@
 --     specific config key.
 
 use "./aggregator.allium" as aggregator
+use "./truncation.allium" as truncation
 
 ------------------------------------------------------------
 -- Entities
@@ -75,6 +76,7 @@ surface PassThroughAggregation {
 
     contracts:
         fulfils Aggregator
+        fulfils Truncatable
 
     @guarantee Determinism
         -- The Aggregator contract's Determinism invariant holds:
@@ -143,51 +145,116 @@ surface PassThroughAggregation {
         -- message. PassThroughAggregator does not modify, replace,
         -- recompute or reorder the tokens.
 
+    @guarantee PassThroughUnderThreshold
+        -- (Inherited from Truncatable.) When the input content's
+        -- length is at or under agg.line_limit AND the input's
+        -- ParsingExtra.IsTruncated is false AND agg.should_truncate
+        -- is false at call entry, the emitted message's content
+        -- equals the whitespace-trimmed input content (no marker
+        -- prepend or append), ParsingExtra.IsTruncated is false on
+        -- the emission, no truncation-reason tag is added, and
+        -- agg.should_truncate remains false at call exit.
+
+    @guarantee TailMarkerOnOverThreshold
+        -- (Inherited from Truncatable.) When the input content's
+        -- length exceeds agg.line_limit OR the input's
+        -- ParsingExtra.IsTruncated is true, the emitted message's
+        -- content has the truncation marker appended after
+        -- whitespace trim, ParsingExtra.IsTruncated is true on
+        -- the emission, and agg.should_truncate is true at call
+        -- exit.
+
+    @guarantee HeadMarkerOnCarryover
+        -- (Inherited from Truncatable.) When agg.should_truncate
+        -- is true at call entry, the emitted message's content
+        -- has the truncation marker prepended (before any tail
+        -- marker that this call may also append), and
+        -- ParsingExtra.IsTruncated is true on the emission. The
+        -- head marker is independent of whether the current
+        -- input is also over-threshold; both markers may apply
+        -- on the same emission.
+
+    @guarantee CarryoverConsumed
+        -- (Inherited from Truncatable.) The new value of
+        -- agg.should_truncate at call exit is determined SOLELY
+        -- by the current call's input — whether the content
+        -- exceeds agg.line_limit OR the input's
+        -- ParsingExtra.IsTruncated is true. The value at call
+        -- entry does NOT propagate into the exit value. A call
+        -- with agg.should_truncate=true at entry but under-
+        -- threshold non-upstream-truncated content produces
+        -- agg.should_truncate=false at exit.
+
+    @guarantee UpstreamFlagPropagation
+        -- (Inherited from Truncatable.) The input's
+        -- ParsingExtra.IsTruncated being true is equivalent to
+        -- the input being over-threshold — both trigger the
+        -- tail marker, set ParsingExtra.IsTruncated on the
+        -- emission, and set agg.should_truncate=true at call
+        -- exit.
+
+    @guarantee TagOnTruncation
+        -- (Inherited from Truncatable.) When the emission carries
+        -- any truncation marker (head, tail, or both),
+        -- ParsingExtra.IsTruncated is set to true. When the
+        -- global logs_config.tag_truncated_logs configuration is
+        -- true, a truncation-reason tag is appended to
+        -- ParsingExtra.Tags (see TagReasonSingleLine for the tag
+        -- value).
+
+    @guarantee MarkerLiteral
+        -- (Inherited from Truncatable.) The marker bytes prepended
+        -- and appended are the literal byte sequence
+        -- `...TRUNCATED...` from the agent's message package
+        -- (message.TruncatedFlag).
+
+    @guarantee TagReasonSingleLine
+        -- The truncation-reason tag value applied by this
+        -- aggregator is always the literal string "single_line"
+        -- (via message.TruncatedReasonTag("single_line")). The
+        -- reason value is not configurable and does not depend
+        -- on input content, label, or pipeline state. Identical
+        -- to SingleLineHandler's tag reason — reflects the
+        -- structural parallelism between PassThroughAggregator
+        -- (preprocessor) and SingleLineHandler (legacy decoder).
+
     @guidance
-        -- Per-call procedure when process is invoked with arguments
-        -- (msg, label, tokens) on a PassThroughAggregator instance:
+        -- Per-call procedure when process is invoked with
+        -- arguments (msg, label, tokens) on a
+        -- PassThroughAggregator instance:
         --
-        -- 1. Capture the current should_truncate value as
-        --    `prepend_marker` (a local variable name for clarity).
+        -- 1. Apply the Truncatable contract's apply operation to
+        --    msg.content with threshold=agg.line_limit,
+        --    upstream_truncated=msg.ParsingExtra.IsTruncated,
+        --    prior_carryover=agg.should_truncate. The contract
+        --    handles whitespace trimming, head/tail marker
+        --    placement, is_truncated flag setting, and tag
+        --    application per its invariants. The tag reason value
+        --    supplied to TagOnTruncation is "single_line" (see
+        --    TagReasonSingleLine).
         --
-        -- 2. Recompute should_truncate for the next call. It
-        --    becomes true if either:
-        --      - the input msg.content exceeds line_limit in byte
-        --        length, OR
-        --      - the input msg.is_truncated is already true.
-        --    Otherwise should_truncate becomes false.
+        --    The contract returns the (possibly decorated)
+        --    content and the new_carryover value. The new
+        --    carryover overwrites agg.should_truncate.
         --
-        -- 3. Trim leading and trailing whitespace from the input
-        --    content. This is unconditional; it applies whether or
-        --    not the line was truncated.
+        -- 2. Replace msg.content with the contract's returned
+        --    bytes and emit one AggregatedMessageWithTokens
+        --    pairing the (now-mutated) input message with the
+        --    tokens argument.
         --
-        -- 4. If prepend_marker is true, prepend the truncation
-        --    marker to the trimmed content.
+        -- The aggregator mutates the input message in place
+        -- rather than copying. Callers that need to retain the
+        -- original bytes must capture them before invoking
+        -- process. The label argument is consumed but has no
+        -- effect (LabelIgnored).
         --
-        -- 5. If should_truncate is true (i.e., this line itself
-        --    triggers truncation), append the truncation marker to
-        --    the content.
-        --
-        -- 6. If either prepend_marker or should_truncate is true,
-        --    mark the emitted message as truncated and — when the
-        --    runtime's truncated-log tagging is enabled — attach
-        --    a truncation-reason tag identifying this aggregator
-        --    as the source.
-        --
-        -- 7. Replace the input message's content with the
-        --    transformed bytes and emit a single
-        --    AggregatedMessageWithTokens pairing the (now-mutated)
-        --    message with the tokens argument.
-        --
-        -- The aggregator mutates the input message in place rather
-        -- than copying. Callers that need to retain the original
-        -- bytes must capture them before invoking process.
-        --
-        -- Note on rolling state: should_truncate carries one bit
-        -- of information from one call to the next. The mapping
-        -- is: "did the previous line trigger truncation? If so,
-        -- prepend a marker to this line as a visual continuation."
-        -- The carry exists so that the marker forms a complete
-        -- pair around any genuinely oversized content (marker
-        -- after the oversized line, marker before the next line).
+        -- Note on rolling state: agg.should_truncate carries one
+        -- bit of information from one call to the next via the
+        -- contract's prior_carryover input. The mapping is: "did
+        -- the previous emission trigger truncation? If so,
+        -- prepend a marker to this emission as a visual
+        -- continuation." The carry exists so that the marker
+        -- forms a complete pair around any genuinely oversized
+        -- content (tail marker after the oversized line, head
+        -- marker before the next line).
 }

--- a/pkg/logs/internal/decoder/preprocessor/regex_aggregator.allium
+++ b/pkg/logs/internal/decoder/preprocessor/regex_aggregator.allium
@@ -292,6 +292,33 @@ surface RegexAggregation {
         -- when the runtime's tag-truncated-logs configuration
         -- is enabled.
 
+    @guarantee UpstreamFlagIgnored
+        -- The input message's ParsingExtra.IsTruncated flag
+        -- is NOT read by process and does NOT influence any
+        -- truncation decision. An input already marked
+        -- truncated by upstream stages (e.g. by the framer)
+        -- is accumulated into the buffer the same as any
+        -- other input; its truncation signal is dropped.
+        --
+        -- This is a DEVIATION from the Truncatable contract's
+        -- UpstreamFlagPropagation invariant. RegexAggregator
+        -- therefore does NOT declare fulfils Truncatable: only
+        -- the buffer-overflow side of TailMarkerOnOverThreshold
+        -- holds (via MidAggregateTruncation); the
+        -- upstream-truncated side does not.
+        --
+        -- The deviation is current behaviour. A refactor
+        -- preserving observable behaviour must preserve the
+        -- upstream-flag-ignoring semantics; a refactor that
+        -- begins propagating the upstream flag would be a
+        -- deliberate behaviour change, producing additional
+        -- IsTruncated=true emissions for inputs that the
+        -- framer already marked. Identical in shape to
+        -- MultiLineHandler's UpstreamFlagIgnored — both
+        -- aggregators operate buffer-level rather than
+        -- per-input, and both inherit this deviation from
+        -- that pattern.
+
     @guidance
         -- Per-call procedure when process is invoked with
         -- arguments (msg, label, tokens) on a RegexAggregator


### PR DESCRIPTION
  ### What does this PR do?

  Retrofits the 4 existing preprocessor aggregator surface specs to declare conformance (or documented divergence) against the new `Truncatable` contract:

  - **`pass_through_aggregator.allium`** — adds `fulfils Truncatable`; spells out the 7 inherited @guarantees.
  - **`detecting_aggregator.allium`** — adds `fulfils Truncatable`; spells out inherited @guarantees. Per-emission truncation flow within a single Process call.
  - **`regex_aggregator.allium`** — declares conformance with the **`UpstreamFlagIgnored`** divergence: buffer-overflow-only truncation; upstream flag ignored on emission.
  - **`combining_aggregator.allium`** — introduces the bucket.flush() vs bucket.emitSingle() asymmetry @guarantees. (These are renamed/scope-broadened in a later cleanup PR — see additional notes.)

  Also adds an `Excludes:` clarification to `multiline_json_aggregator.allium` noting that the JSON aggregator deliberately does NOT do byte-marker truncation and is out of scope for Truncatable.

  ### Motivation

  Continues the **Truncation Safety Net** stack. The 4 preprocessor aggregator surfaces existed before this stack; this PR is the keystone that wires them into the new contract layer.

  Full context: [**Truncation Safety Net** Confluence page](https://datadoghq.atlassian.net/wiki/spaces/~712020c20dd82e15fd4ed5bcd968f8d10d9578/pages/6759220118/Truncation+Safety+Net).

  ### Describe how you validated your changes

  - `allium check` clean across all 5 modified files.
  - Property tests anchoring to the new @guarantees land in the four `_proptests` branches later in this stack (one per aggregator).

  ### Additional Notes

  - **Scope note (multiline_json_aggregator):** the `Excludes:` text added there is documentation hygiene clarifying out-of-scope behaviour — not a Truncatable fulfilment edit, since JSON aggregator doesn't do
  byte-marker truncation. Reviewers may expect this branch to only touch aggregators that DO fulfil; calling out the exception explicitly.
  - **CombiningAggregator @guarantees are refined later in the stack:** the `BucketFlushIgnoresUpstreamFlag` / `EmitSingleHonorsUpstreamFlag` text introduced here is broadened from "combined-emission only" to "all
  5 bucket.flush() invocation paths" in `cmetz/truncation_safety_net_cleanup`. Two-stage shape is intentional — that subsequent rewrite is load-bearing enough that it deserves to be reviewable on its own.
  - Spec-only PR.
