### PR TITLE
add PassThroughAggregator Truncatable property tests

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/pass_through_aggregator_proptest_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/pass_through_aggregator_proptest_test.go
@@ -12,6 +12,7 @@ import (
 
 	"pgregory.net/rapid"
 
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
@@ -261,6 +262,327 @@ func TestPassThroughAggregator_ByteConservation_Property(t *testing.T) {
 		if stripped != expectedCore {
 			t.Fatalf("ByteConservation violated: stripped %q != trimmed input %q (full output %q)",
 				stripped, expectedCore, out)
+		}
+	})
+}
+
+// TestPassThroughAggregator_PassThroughUnderThreshold_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee PassThroughUnderThreshold — (inherited from
+//	                                            Truncatable) under-
+//	                                            threshold + no carry
+//	                                            + no upstream flag ⇒
+//	                                            no markers, IsTruncated
+//	                                            false.
+//
+// A single process call on a fresh aggregator whose content is
+// strictly under line_limit and whose ParsingExtra.IsTruncated
+// is false emits trim-spaced content with no truncation markers
+// and IsTruncated=false.
+func TestPassThroughAggregator_PassThroughUnderThreshold_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(50, 200).Draw(t, "lineLimit")
+		raw := rapid.SliceOfN(
+			rapid.SampledFrom([]byte("abcdef 0123\t")),
+			0, lineLimit/2,
+		).Draw(t, "raw")
+		label := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "label")
+
+		ag := NewPassThroughAggregator(lineLimit)
+		in := passThroughInput{content: raw, upstreamIsTruncated: false, label: label}
+		content, isTruncated, _ := runOne(ag, in)
+
+		marker := message.TruncatedFlag
+		if bytes.HasPrefix(content, marker) {
+			t.Fatalf("PassThroughUnderThreshold violated: head marker present in %q", content)
+		}
+		if bytes.HasSuffix(content, marker) {
+			t.Fatalf("PassThroughUnderThreshold violated: tail marker present in %q", content)
+		}
+		if isTruncated {
+			t.Fatal("PassThroughUnderThreshold violated: IsTruncated=true on under-threshold non-upstream input")
+		}
+		expected := bytes.TrimSpace(raw)
+		if !bytes.Equal(content, expected) {
+			t.Fatalf("PassThroughUnderThreshold violated: content %q != trimmed input %q", content, expected)
+		}
+	})
+}
+
+// TestPassThroughAggregator_TailMarkerOnOverThreshold_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee TailMarkerOnOverThreshold — (inherited from
+//	                                            Truncatable) content
+//	                                            over threshold ⇒
+//	                                            tail marker,
+//	                                            IsTruncated true.
+//
+// A single process call on a fresh aggregator whose content has
+// byte length strictly greater than line_limit emits content
+// ending with the truncation marker and IsTruncated=true.
+func TestPassThroughAggregator_TailMarkerOnOverThreshold_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(5, 100).Draw(t, "lineLimit")
+		extra := rapid.IntRange(1, 60).Draw(t, "extra")
+		raw := rapid.SliceOfN(
+			rapid.SampledFrom([]byte("abcdef0123")),
+			lineLimit+extra, lineLimit+extra,
+		).Draw(t, "raw")
+		label := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "label")
+
+		ag := NewPassThroughAggregator(lineLimit)
+		in := passThroughInput{content: raw, upstreamIsTruncated: false, label: label}
+		content, isTruncated, _ := runOne(ag, in)
+
+		marker := message.TruncatedFlag
+		if !bytes.HasSuffix(content, marker) {
+			t.Fatalf("TailMarkerOnOverThreshold violated: no tail marker in %q", content)
+		}
+		if bytes.HasPrefix(content, marker) {
+			t.Fatalf("TailMarkerOnOverThreshold violated: unexpected head marker on fresh aggregator in %q", content)
+		}
+		if !isTruncated {
+			t.Fatal("TailMarkerOnOverThreshold violated: IsTruncated=false on over-threshold input")
+		}
+	})
+}
+
+// TestPassThroughAggregator_HeadMarkerOnCarryover_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee HeadMarkerOnCarryover — (inherited from
+//	                                        Truncatable) prior carry
+//	                                        ⇒ head marker on next
+//	                                        emission, IsTruncated
+//	                                        true.
+//
+// After a process call that truncates (setting carry=true), the
+// NEXT process call's emission begins with the truncation marker
+// and IsTruncated=true, even when its own content is under
+// threshold and not upstream-flagged.
+func TestPassThroughAggregator_HeadMarkerOnCarryover_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(5, 100).Draw(t, "lineLimit")
+		extra := rapid.IntRange(1, 60).Draw(t, "extra")
+		first := rapid.SliceOfN(
+			rapid.SampledFrom([]byte("abcdef0123")),
+			lineLimit+extra, lineLimit+extra,
+		).Draw(t, "first")
+		second := rapid.SliceOfN(
+			rapid.SampledFrom([]byte("xyzwv98765")),
+			1, lineLimit/2+1,
+		).Draw(t, "second")
+		labelA := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "labelA")
+		labelB := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "labelB")
+
+		ag := NewPassThroughAggregator(lineLimit)
+		runOne(ag, passThroughInput{content: first, upstreamIsTruncated: false, label: labelA})
+		content, isTruncated, _ := runOne(ag, passThroughInput{content: second, upstreamIsTruncated: false, label: labelB})
+
+		marker := message.TruncatedFlag
+		if !bytes.HasPrefix(content, marker) {
+			t.Fatalf("HeadMarkerOnCarryover violated: no head marker on second emission %q", content)
+		}
+		if bytes.HasSuffix(content, marker) {
+			t.Fatalf("HeadMarkerOnCarryover violated: unexpected tail marker on under-threshold second emission %q", content)
+		}
+		if !isTruncated {
+			t.Fatal("HeadMarkerOnCarryover violated: IsTruncated=false on emission with head marker")
+		}
+	})
+}
+
+// TestPassThroughAggregator_CarryoverConsumed_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee CarryoverConsumed — (inherited from Truncatable)
+//	                                    carry is determined solely
+//	                                    by current input; prior
+//	                                    carry does not propagate.
+//
+// After a process call that sets carry (over-threshold input),
+// a next call under threshold and not upstream-flagged consumes
+// the carry (emitting with head marker) and the THIRD call must
+// NOT carry the marker — verifying carry reset on emission 2.
+func TestPassThroughAggregator_CarryoverConsumed_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(5, 100).Draw(t, "lineLimit")
+		extra := rapid.IntRange(1, 60).Draw(t, "extra")
+		first := rapid.SliceOfN(
+			rapid.SampledFrom([]byte("abcdef0123")),
+			lineLimit+extra, lineLimit+extra,
+		).Draw(t, "first")
+		second := rapid.SliceOfN(
+			rapid.SampledFrom([]byte("xyzwv98765")),
+			1, lineLimit/2+1,
+		).Draw(t, "second")
+		third := rapid.SliceOfN(
+			rapid.SampledFrom([]byte("pqrstu43210")),
+			1, lineLimit/2+1,
+		).Draw(t, "third")
+		labelA := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "labelA")
+		labelB := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "labelB")
+		labelC := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "labelC")
+
+		ag := NewPassThroughAggregator(lineLimit)
+		runOne(ag, passThroughInput{content: first, upstreamIsTruncated: false, label: labelA})
+		contentB, _, _ := runOne(ag, passThroughInput{content: second, upstreamIsTruncated: false, label: labelB})
+		contentC, isTruncatedC, _ := runOne(ag, passThroughInput{content: third, upstreamIsTruncated: false, label: labelC})
+
+		marker := message.TruncatedFlag
+
+		// Precondition: emission 2 should carry the head marker.
+		if !bytes.HasPrefix(contentB, marker) {
+			t.Fatalf("CarryoverConsumed precondition: emission 2 should have head marker; got %q", contentB)
+		}
+
+		// The point: emission 3 must NOT carry a head marker.
+		if bytes.HasPrefix(contentC, marker) {
+			t.Fatalf("CarryoverConsumed violated: emission 3 carries head marker after emission 2 should have consumed it; content %q", contentC)
+		}
+		if bytes.HasSuffix(contentC, marker) {
+			t.Fatalf("CarryoverConsumed violated: emission 3 has tail marker on under-threshold input; content %q", contentC)
+		}
+		if isTruncatedC {
+			t.Fatal("CarryoverConsumed violated: emission 3 IsTruncated=true on clean under-threshold input")
+		}
+	})
+}
+
+// TestPassThroughAggregator_UpstreamFlagPropagation_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee UpstreamFlagPropagation — (inherited from
+//	                                          Truncatable) upstream
+//	                                          IsTruncated true
+//	                                          behaves like over-
+//	                                          threshold: tail marker,
+//	                                          carry set, IsTruncated
+//	                                          true.
+//
+// On a fresh aggregator, an under-threshold input whose
+// ParsingExtra.IsTruncated=true emits with the tail marker and
+// IsTruncated=true. The next emission (under-threshold, no flag)
+// carries the head marker (carry was set by emission 1).
+func TestPassThroughAggregator_UpstreamFlagPropagation_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(10, 100).Draw(t, "lineLimit")
+		raw := rapid.SliceOfN(
+			rapid.SampledFrom([]byte("abcdef0123")),
+			1, lineLimit/2,
+		).Draw(t, "raw")
+		raw2 := rapid.SliceOfN(
+			rapid.SampledFrom([]byte("uvwxy67890")),
+			1, lineLimit/2,
+		).Draw(t, "raw2")
+		labelA := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "labelA")
+		labelB := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "labelB")
+
+		ag := NewPassThroughAggregator(lineLimit)
+		contentA, isTruncatedA, _ := runOne(ag, passThroughInput{content: raw, upstreamIsTruncated: true, label: labelA})
+		contentB, _, _ := runOne(ag, passThroughInput{content: raw2, upstreamIsTruncated: false, label: labelB})
+
+		marker := message.TruncatedFlag
+
+		// Emission 1: under-threshold but upstream-flagged → tail
+		// marker, IsTruncated=true.
+		if !bytes.HasSuffix(contentA, marker) {
+			t.Fatalf("UpstreamFlagPropagation violated: no tail marker on emission 1 (upstream flag) %q", contentA)
+		}
+		if !isTruncatedA {
+			t.Fatal("UpstreamFlagPropagation violated: emission 1 IsTruncated=false despite upstream flag")
+		}
+
+		// Emission 2: under-threshold, unflagged, but carry was
+		// set by emission 1 → head marker.
+		if !bytes.HasPrefix(contentB, marker) {
+			t.Fatalf("UpstreamFlagPropagation violated: emission 2 missing head marker after upstream-flagged carry; content %q", contentB)
+		}
+	})
+}
+
+// TestPassThroughAggregator_TagOnTruncation_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee TagOnTruncation — (inherited from Truncatable)
+//	                                  when global
+//	                                  logs_config.tag_truncated_logs
+//	                                  is true, a truncation-reason
+//	                                  tag is added iff IsTruncated
+//	                                  is set on the emission.
+//	    @guarantee TagReasonSingleLine — tag value is "single_line".
+//
+// With the global config enabled, every emission whose
+// IsTruncated is true carries exactly one ParsingExtra.Tags
+// entry equal to message.TruncatedReasonTag("single_line").
+// Emissions with IsTruncated=false carry no tag.
+func TestPassThroughAggregator_TagOnTruncation_Property(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("logs_config.tag_truncated_logs", true)
+	expectedTag := message.TruncatedReasonTag("single_line")
+
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(1, 200).Draw(t, "lineLimit")
+		calls := rapid.SliceOfN(genPassThroughInput(), 1, 10).Draw(t, "calls")
+
+		ag := NewPassThroughAggregator(lineLimit)
+		for i, in := range calls {
+			msg := message.NewMessage(append([]byte(nil), in.content...), nil, message.StatusInfo, 0)
+			msg.RawDataLen = len(in.content)
+			msg.ParsingExtra.IsTruncated = in.upstreamIsTruncated
+			emitted := ag.Process(msg, in.label, in.tokens)
+			if len(emitted) != 1 {
+				t.Fatalf("call %d: expected 1 emission, got %d", i, len(emitted))
+			}
+			e := emitted[0].Msg
+			if e.ParsingExtra.IsTruncated {
+				if len(e.ParsingExtra.Tags) != 1 || e.ParsingExtra.Tags[0] != expectedTag {
+					t.Fatalf("TagOnTruncation/TagReasonSingleLine violated at call %d: IsTruncated=true but tags=%v (want [%q])", i, e.ParsingExtra.Tags, expectedTag)
+				}
+			} else {
+				if len(e.ParsingExtra.Tags) != 0 {
+					t.Fatalf("TagOnTruncation violated at call %d: IsTruncated=false but tags=%v (want none)", i, e.ParsingExtra.Tags)
+				}
+			}
+		}
+	})
+}
+
+// TestPassThroughAggregator_TagDisabledNoTag_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee TagOnTruncation — (inherited from Truncatable)
+//	                                  when global
+//	                                  logs_config.tag_truncated_logs
+//	                                  is false, NO truncation-reason
+//	                                  tag is added regardless of
+//	                                  IsTruncated.
+//
+// With the global config disabled, no emission carries a
+// truncation-reason tag, even when markers are applied and
+// IsTruncated is set.
+func TestPassThroughAggregator_TagDisabledNoTag_Property(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("logs_config.tag_truncated_logs", false)
+
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(1, 200).Draw(t, "lineLimit")
+		calls := rapid.SliceOfN(genPassThroughInput(), 1, 10).Draw(t, "calls")
+
+		ag := NewPassThroughAggregator(lineLimit)
+		for i, in := range calls {
+			msg := message.NewMessage(append([]byte(nil), in.content...), nil, message.StatusInfo, 0)
+			msg.RawDataLen = len(in.content)
+			msg.ParsingExtra.IsTruncated = in.upstreamIsTruncated
+			emitted := ag.Process(msg, in.label, in.tokens)
+			if len(emitted) != 1 {
+				t.Fatalf("call %d: expected 1 emission, got %d", i, len(emitted))
+			}
+			if len(emitted[0].Msg.ParsingExtra.Tags) != 0 {
+				t.Fatalf("TagOnTruncation (disabled) violated at call %d: tags=%v (want none)", i, emitted[0].Msg.ParsingExtra.Tags)
+			}
 		}
 	})
 }


### PR DESCRIPTION
  ### What does this PR do?

  Adds `pkg/logs/internal/decoder/preprocessor/pass_through_aggregator_proptest_test.go` with **13 property tests** anchored to `pass_through_aggregator.allium`'s @guarantees, covering all 7 Truncatable inherited
  invariants plus surface-specific NoGrouping / LabelIgnored / TokensForwarded.

  ### Motivation

  Continues the **Truncation Safety Net** stack. PassThroughAggregator is structurally identical to SingleLineHandler from the Truncatable contract's perspective; pinning it confirms the conformance and gives a
  side-by-side reference.

  Full context: [**Truncation Safety Net** Confluence page](https://datadoghq.atlassian.net/wiki/spaces/~712020c20dd82e15fd4ed5bcd968f8d10d9578/pages/6759220118/Truncation+Safety+Net).

  ### Describe how you validated your changes

  - Default 100 iterations green; **10,000-iteration validation pass** green (2026-05-21).
  - `dda inv test --targets=./pkg/logs/internal/decoder/preprocessor` clean.

  ### Additional Notes

  - Test-only PR.