### PR TITLE
add CombiningAggregator Truncatable property tests

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/combining_aggregator_proptest_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/combining_aggregator_proptest_test.go
@@ -6,6 +6,7 @@
 package preprocessor
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -227,6 +228,420 @@ func TestCombiningAggregator_NoAggregateClearsCarry_Property(t *testing.T) {
 		emittedContent := string(emitted[0].Msg.GetContent())
 		if strings.HasPrefix(emittedContent, string(message.TruncatedFlag)) {
 			t.Fatalf("NoAggregateResetsCarry violated: no_aggregate emission has prepended marker (content=%q)", emittedContent)
+		}
+	})
+}
+
+// combiningCapture is a deep-copied snapshot of one emission's
+// observable state, including the full tag list (the existing
+// combiningEmission tracks only tag count). Used for tests that
+// must compare emissions across Process calls — required by the
+// Aggregator contract's ResultLifetime invariant.
+type combiningCapture struct {
+	content     []byte
+	isTruncated bool
+	isMultiLine bool
+	tags        []string
+}
+
+func captureCombiningEmissions(emitted []AggregatedMessageWithTokens) []combiningCapture {
+	out := make([]combiningCapture, len(emitted))
+	for i, e := range emitted {
+		out[i] = combiningCapture{
+			content:     append([]byte(nil), e.Msg.GetContent()...),
+			isTruncated: e.Msg.ParsingExtra.IsTruncated,
+			isMultiLine: e.Msg.ParsingExtra.IsMultiLine,
+			tags:        append([]string(nil), e.Msg.ParsingExtra.Tags...),
+		}
+	}
+	return out
+}
+
+func msgWithFlag(content string, isTruncated bool) *message.Message {
+	m := newMessage(content)
+	m.ParsingExtra.IsTruncated = isTruncated
+	return m
+}
+
+// TestCombiningAggregator_PassThroughUnderThreshold_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee ByteConservation — emissions whose buffered
+//	                                   content stays under
+//	                                   line_limit carry no
+//	                                   truncation markers.
+//
+// A single-line noAggregate emission under threshold (no carry,
+// no upstream flag) emits with no markers and IsTruncated=false.
+// This pins the baseline clean-emission case for the bucket.flush
+// single-line path.
+func TestCombiningAggregator_PassThroughUnderThreshold_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(50, 200).Draw(t, "lineLimit")
+		content := strings.Repeat("a", rapid.IntRange(1, lineLimit/2).Draw(t, "len"))
+
+		ag := NewCombiningAggregator(lineLimit, false, false, status.NewInfoRegistry())
+		emitted := captureCombiningEmissions(ag.Process(newMessage(content), noAggregate, nil))
+
+		if len(emitted) != 1 {
+			t.Fatalf("expected 1 emission for fitting noAggregate, got %d", len(emitted))
+		}
+		e := emitted[0]
+		marker := message.TruncatedFlag
+		if bytes.Contains(e.content, marker) {
+			t.Fatalf("PassThroughUnderThreshold violated: marker found in clean emission %q", e.content)
+		}
+		if e.isTruncated {
+			t.Fatalf("PassThroughUnderThreshold violated: IsTruncated=true on clean emission %q", e.content)
+		}
+	})
+}
+
+// TestCombiningAggregator_SingleLineOversizedTailMarker_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee StartGroupBoundary — a startGroup whose own
+//	                                     RawDataLen is at or above
+//	                                     line_limit triggers an
+//	                                     immediate single-line
+//	                                     flush via the truncation
+//	                                     flow.
+//
+// An oversized startGroup is emitted immediately with the tail
+// marker appended (single-line truncated emission via
+// bucket.flush with contentLen >= lineLimit).
+func TestCombiningAggregator_SingleLineOversizedTailMarker_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(5, 50).Draw(t, "lineLimit")
+		oversized := strings.Repeat("x", lineLimit+rapid.IntRange(1, 30).Draw(t, "extra"))
+
+		ag := NewCombiningAggregator(lineLimit, false, false, status.NewInfoRegistry())
+		emitted := captureCombiningEmissions(ag.Process(newMessage(oversized), startGroup, nil))
+
+		if len(emitted) != 1 {
+			t.Fatalf("expected 1 emission for oversized startGroup, got %d", len(emitted))
+		}
+		e := emitted[0]
+		marker := message.TruncatedFlag
+		if !bytes.HasSuffix(e.content, marker) {
+			t.Fatalf("SingleLineOversizedTailMarker violated: no tail marker on oversized startGroup emission %q", e.content)
+		}
+		if !e.isTruncated {
+			t.Fatal("SingleLineOversizedTailMarker violated: IsTruncated=false on truncated emission")
+		}
+	})
+}
+
+// TestCombiningAggregator_HeadMarkerOnCarryover_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee TruncationTagging — the should_truncate carry
+//	                                    propagates the head marker
+//	                                    to the next emission.
+//
+// After an oversized startGroup sets the carry, the next
+// emission (here an aggregate-on-empty-bucket under threshold)
+// receives the head marker. The carry transcends bucket lifecycle.
+func TestCombiningAggregator_HeadMarkerOnCarryover_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(20, 60).Draw(t, "lineLimit")
+		oversized := strings.Repeat("x", lineLimit+rapid.IntRange(1, 30).Draw(t, "extra"))
+		nextLen := rapid.IntRange(1, 5).Draw(t, "nextLen")
+		next := strings.Repeat("a", nextLen)
+
+		ag := NewCombiningAggregator(lineLimit, false, false, status.NewInfoRegistry())
+		// Oversized startGroup: emits single-line truncated, carry set.
+		first := captureCombiningEmissions(ag.Process(newMessage(oversized), startGroup, nil))
+		if len(first) != 1 {
+			return // skip degenerate
+		}
+		// Next aggregate-on-empty-bucket: under threshold, carry
+		// is consumed → head marker.
+		second := captureCombiningEmissions(ag.Process(newMessage(next), aggregate, nil))
+
+		if len(second) != 1 {
+			t.Fatalf("expected 1 emission for aggregate-on-empty, got %d", len(second))
+		}
+		e := second[0]
+		marker := message.TruncatedFlag
+		if !bytes.HasPrefix(e.content, marker) {
+			t.Fatalf("HeadMarkerOnCarryover violated: no head marker on emission after carry; content %q", e.content)
+		}
+		if !e.isTruncated {
+			t.Fatal("HeadMarkerOnCarryover violated: IsTruncated=false on emission with head marker")
+		}
+	})
+}
+
+// TestCombiningAggregator_CombinedEmissionUpstreamFlagIgnored_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee CombinedEmissionUpstreamFlagIgnored — the
+//	                                                      bucket.flush
+//	                                                      path does
+//	                                                      NOT honour
+//	                                                      upstream
+//	                                                      IsTruncated
+//	                                                      flags on
+//	                                                      contributing
+//	                                                      lines.
+//
+// LOAD-BEARING for the refactor safety net. A combined emission
+// of 2+ lines where the LATER contributor (not the leader)
+// arrived with upstream IsTruncated=true MUST emit with no
+// markers and IsTruncated=false (assuming no overflow). The
+// upstream signal from non-leader contributors is fully dropped
+// — both content-wise (no markers) and flag-wise (since the
+// emitted message's IsTruncated mirrors only the leader's
+// pre-emit state, which here is false).
+func TestCombiningAggregator_CombinedEmissionUpstreamFlagIgnored_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := 200 // large, no overflow
+		leaderLen := rapid.IntRange(1, 20).Draw(t, "leaderLen")
+		flaggedLen := rapid.IntRange(1, 20).Draw(t, "flaggedLen")
+		leader := strings.Repeat("l", leaderLen)
+		flagged := strings.Repeat("f", flaggedLen)
+
+		ag := NewCombiningAggregator(lineLimit, false, false, status.NewInfoRegistry())
+		// Leader: startGroup, no flag.
+		ag.Process(newMessage(leader), startGroup, nil)
+		// Continuation: aggregate, UPSTREAM-FLAGGED.
+		ag.Process(msgWithFlag(flagged, true), aggregate, nil)
+		// Trigger emission via boundary.
+		emitted := captureCombiningEmissions(ag.Process(newMessage("trigger"), startGroup, nil))
+
+		if len(emitted) != 1 {
+			t.Fatalf("expected 1 combined emission, got %d", len(emitted))
+		}
+		e := emitted[0]
+		marker := message.TruncatedFlag
+		if bytes.Contains(e.content, marker) {
+			t.Fatalf("CombinedEmissionUpstreamFlagIgnored violated: combined emission contains marker — upstream flag on contributor was honoured; content %q", e.content)
+		}
+		if e.isTruncated {
+			t.Fatalf("CombinedEmissionUpstreamFlagIgnored violated: combined emission IsTruncated=true — upstream flag propagated; content %q", e.content)
+		}
+		if !e.isMultiLine {
+			t.Fatal("CombinedEmissionUpstreamFlagIgnored precondition: emission should be multi-line (lineCount > 1)")
+		}
+	})
+}
+
+// TestCombiningAggregator_ExplosionPathHonorsUpstream_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee OverflowExplosion — the explosion path uses the
+//	                                    bucket.emitSingle procedure
+//	                                    which DOES honour upstream
+//	                                    IsTruncated for each emitted
+//	                                    line.
+//
+// When the wouldOverflowBucket guard fires, the bucket is
+// exploded into individual emissions via bucket.emitSingle. The
+// current aggregate line (the one that triggered overflow) is
+// then emitted via bucket.emitSingle as well. emit_single
+// honours upstream IsTruncated, so a flagged current line
+// emits with the tail marker even when content is under
+// line_limit on its own.
+func TestCombiningAggregator_ExplosionPathHonorsUpstream_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(15, 40).Draw(t, "lineLimit")
+		// Build up a bucket close to overflow capacity, then
+		// trigger overflow with a flagged line that's under
+		// threshold on its own.
+		leader := strings.Repeat("l", lineLimit/3)
+		cont := strings.Repeat("c", lineLimit/3)
+		flaggedLen := rapid.IntRange(1, lineLimit/4).Draw(t, "flaggedLen")
+		flagged := strings.Repeat("f", flaggedLen)
+
+		ag := NewCombiningAggregator(lineLimit, false, false, status.NewInfoRegistry())
+		ag.Process(newMessage(leader), startGroup, nil)
+		ag.Process(newMessage(cont), aggregate, nil)
+		// Bucket now ~ 2/3 lineLimit. Next aggregate pushes over.
+		emitted := captureCombiningEmissions(ag.Process(msgWithFlag(flagged, true), aggregate, nil))
+
+		// Explosion: emits 2 buffered lines + the current line.
+		// Skip if we didn't actually hit explosion (e.g. the
+		// projected size didn't cross lineLimit due to rapid's
+		// chosen sizes).
+		if len(emitted) < 3 {
+			return
+		}
+		marker := message.TruncatedFlag
+		// The LAST emission is the current msg (flagged, under
+		// threshold by itself). It should have tail marker due
+		// to upstream flag propagating through emitSingle.
+		last := emitted[len(emitted)-1]
+		if !bytes.HasSuffix(last.content, marker) {
+			t.Fatalf("ExplosionPathHonorsUpstream violated: no tail marker on flagged current line emission %q", last.content)
+		}
+		if !last.isTruncated {
+			t.Fatal("ExplosionPathHonorsUpstream violated: IsTruncated=false on flagged emission")
+		}
+	})
+}
+
+// TestCombiningAggregator_TruncationTaggingSingleLine_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee TruncationTagging — single-line truncated
+//	                                    emissions receive the
+//	                                    "single_line" reason tag
+//	                                    when tag_truncated_logs is
+//	                                    true.
+//
+// With per-aggregator tag_truncated_logs=true at construction,
+// an oversized startGroup emits with the "single_line"
+// truncation-reason tag (the bucket.flush path with lineCount=1
+// hardcodes truncatedReason="single_line").
+func TestCombiningAggregator_TruncationTaggingSingleLine_Property(t *testing.T) {
+	expectedTag := message.TruncatedReasonTag("single_line")
+	autoMultilineTag := message.TruncatedReasonTag("auto_multiline")
+
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(5, 50).Draw(t, "lineLimit")
+		oversized := strings.Repeat("x", lineLimit+rapid.IntRange(1, 30).Draw(t, "extra"))
+
+		ag := NewCombiningAggregator(lineLimit, true, false, status.NewInfoRegistry())
+		emitted := captureCombiningEmissions(ag.Process(newMessage(oversized), startGroup, nil))
+
+		if len(emitted) != 1 {
+			t.Fatalf("expected 1 emission for oversized startGroup, got %d", len(emitted))
+		}
+		e := emitted[0]
+		hasSingleLine := false
+		for _, tag := range e.tags {
+			if tag == expectedTag {
+				hasSingleLine = true
+			}
+			if tag == autoMultilineTag {
+				t.Fatalf("TruncationTaggingSingleLine violated: single-line emission has %q tag (should be %q); tags=%v", autoMultilineTag, expectedTag, e.tags)
+			}
+		}
+		if !hasSingleLine {
+			t.Fatalf("TruncationTaggingSingleLine violated: single-line truncated emission missing %q tag; tags=%v", expectedTag, e.tags)
+		}
+	})
+}
+
+// TestCombiningAggregator_TruncationTaggingAutoMultiline_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee TruncationTagging — combined truncated
+//	                                    emissions receive the
+//	                                    "auto_multiline" reason tag
+//	                                    when tag_truncated_logs is
+//	                                    true.
+//
+// A combined emission (lineCount > 1) carrying truncation
+// (via carry from a prior oversized emission) receives the
+// "auto_multiline" reason tag — distinct from the "single_line"
+// reason used for lineCount=1 emissions.
+func TestCombiningAggregator_TruncationTaggingAutoMultiline_Property(t *testing.T) {
+	expectedTag := message.TruncatedReasonTag("auto_multiline")
+	singleLineTag := message.TruncatedReasonTag("single_line")
+
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(30, 80).Draw(t, "lineLimit")
+		oversized := strings.Repeat("x", lineLimit+rapid.IntRange(1, 30).Draw(t, "extra"))
+		// Two short lines after carry: combined emission gets
+		// the head marker from carry, and lineCount=2 triggers
+		// the auto_multiline tag reason.
+		short1 := strings.Repeat("a", rapid.IntRange(1, 3).Draw(t, "s1Len"))
+		short2 := strings.Repeat("b", rapid.IntRange(1, 3).Draw(t, "s2Len"))
+
+		ag := NewCombiningAggregator(lineLimit, true, false, status.NewInfoRegistry())
+		// Oversized startGroup: emits single-line truncated,
+		// carry set.
+		ag.Process(newMessage(oversized), startGroup, nil)
+		// startGroup with short content: flushes nothing
+		// (prior bucket already empty after the oversized
+		// flush). Actually wait — bucket is empty after the
+		// oversized flush. Hmm.
+		// Use noAggregate to reset carry. NO — we WANT the
+		// carry. Use aggregate-on-empty instead.
+		ag.Process(newMessage(short1), aggregate, nil) // emits with head marker, lineCount=1
+		// Hmm that's already emitted. Let me restructure.
+		// To get a multi-line combined with carry, we need:
+		//   1. Carry set
+		//   2. Bucket buffers 2+ lines without overflow
+		//   3. Boundary flushes the combined message
+
+		// Reset and try again with the correct sequence.
+		ag = NewCombiningAggregator(lineLimit, true, false, status.NewInfoRegistry())
+		ag.Process(newMessage(oversized), startGroup, nil)            // emit + carry
+		ag.Process(newMessage("S"), startGroup, nil)                   // new group leader (no emit, carry still set)
+		ag.Process(newMessage(short1), aggregate, nil)                 // accumulate
+		ag.Process(newMessage(short2), aggregate, nil)                 // accumulate (2-line bucket)
+		emitted := captureCombiningEmissions(ag.Process(newMessage("T"), startGroup, nil)) // flush combined
+
+		if len(emitted) != 1 {
+			t.Fatalf("expected 1 combined emission, got %d", len(emitted))
+		}
+		e := emitted[0]
+		if !e.isMultiLine {
+			t.Fatal("TruncationTaggingAutoMultiline precondition: emission should be multi-line")
+		}
+		if !e.isTruncated {
+			t.Fatal("TruncationTaggingAutoMultiline precondition: emission should be truncated (carry head marker)")
+		}
+		hasAutoMultiline := false
+		for _, tag := range e.tags {
+			if tag == expectedTag {
+				hasAutoMultiline = true
+			}
+			if tag == singleLineTag {
+				t.Fatalf("TruncationTaggingAutoMultiline violated: combined truncated emission has %q tag (should be %q); tags=%v", singleLineTag, expectedTag, e.tags)
+			}
+		}
+		if !hasAutoMultiline {
+			t.Fatalf("TruncationTaggingAutoMultiline violated: combined truncated emission missing %q tag; tags=%v", expectedTag, e.tags)
+		}
+	})
+}
+
+// TestCombiningAggregator_MultiLineSourceTag_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee MultiLineTagging — combined emissions of 2+
+//	                                   lines set is_multi_line=true
+//	                                   AND, when tag_multi_line_logs
+//	                                   is true, append the multi-line
+//	                                   source tag with value
+//	                                   "auto_multiline".
+//
+// A 2+ line combined emission with tag_multi_line_logs=true at
+// construction carries the multi-line source tag.
+func TestCombiningAggregator_MultiLineSourceTag_Property(t *testing.T) {
+	multiLineTag := message.MultiLineSourceTag("auto_multiline")
+
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := 200
+		nContinuations := rapid.IntRange(1, 4).Draw(t, "nContinuations")
+
+		ag := NewCombiningAggregator(lineLimit, false, true, status.NewInfoRegistry())
+		ag.Process(newMessage("leader"), startGroup, nil)
+		for i := 0; i < nContinuations; i++ {
+			ag.Process(newMessage("more"), aggregate, nil)
+		}
+		emitted := captureCombiningEmissions(ag.Process(newMessage("trigger"), startGroup, nil))
+
+		if len(emitted) != 1 {
+			t.Fatalf("expected 1 combined emission, got %d", len(emitted))
+		}
+		e := emitted[0]
+		if !e.isMultiLine {
+			t.Fatal("MultiLineSourceTag precondition: emission should be multi-line")
+		}
+		hasTag := false
+		for _, tag := range e.tags {
+			if tag == multiLineTag {
+				hasTag = true
+				break
+			}
+		}
+		if !hasTag {
+			t.Fatalf("MultiLineSourceTag violated: %d-line combined emission missing tag %q; tags=%v", 1+nContinuations, multiLineTag, e.tags)
 		}
 	})
 }


### PR DESCRIPTION
  ### What does this PR do?

  Adds `pkg/logs/internal/decoder/preprocessor/combining_aggregator_proptest_test.go` with **15 property tests** anchored to `combining_aggregator.allium`'s @guarantees, covering both Truncatable-conformant
  behaviour and the two CombiningAggregator-specific divergences:

  - **`BucketFlushIgnoresUpstreamFlag`** — `bucket.flush()` uses a size-only truncation check; upstream `IsTruncated` is not OR'd in.
  - **`EmitSingleHonorsUpstreamFlag`** — `bucket.emitSingle()` (the explosion path) DOES OR in the upstream flag.

  The asymmetry between these two paths is the most subtle of the 5 load-bearing divergences in the safety net.

  Surface-specific guarantees also covered: NoAggregateResetsCarry, OverflowExplosion, MultiLineTagging, TruncationTagging (reason `single_line` or `auto_multiline`).

  ### Motivation

  Continues the **Truncation Safety Net** stack. CombiningAggregator is the heaviest aggregator in the pipeline and the most subject to silent behavioural drift in a refactor. The bucket.flush vs bucket.emitSingle
  asymmetry is the most likely to be "fixed" by mistake, which would change observable behaviour for users.

  Full context: [**Truncation Safety Net** Confluence page](https://datadoghq.atlassian.net/wiki/spaces/~712020c20dd82e15fd4ed5bcd968f8d10d9578/pages/6759220118/Truncation+Safety+Net).

  ### Describe how you validated your changes

  - Default 100 iterations green; **10,000-iteration validation pass** green (2026-05-21).
  - `dda inv test --targets=./pkg/logs/internal/decoder/preprocessor` clean.

  ### Additional Notes

  - **Spec text for these guarantees gets refined in `cmetz/truncation_safety_net_cleanup`:** the cleanup PR renames `CombinedEmissionUpstreamFlagIgnored` → `BucketFlushIgnoresUpstreamFlag` and broadens the
  @guarantee from "combined-emission only" to "all 5 bucket.flush() invocation paths." The tests anchored here pick up the renamed names after the cleanup PR lands. Test bodies are unchanged.
  - Test-only PR otherwise.