### PR TITLE
add high-value gap-filler property tests for truncation surfaces

### DIFF
--- a/pkg/logs/internal/decoder/multiline_handler_proptest_test.go
+++ b/pkg/logs/internal/decoder/multiline_handler_proptest_test.go
@@ -8,6 +8,7 @@ package decoder
 import (
 	"bytes"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -470,6 +471,59 @@ func TestMultiLineHandler_TagDisabledNoTag_Property(t *testing.T) {
 				if tag == suppressedTag {
 					t.Fatalf("TagOnTruncation (disabled) violated at emission %d: found %q in tags=%v", i, suppressedTag, e.tags)
 				}
+			}
+		}
+	})
+}
+
+// TestMultiLineHandler_LineSeparator_Property anchors:
+//
+//	surface MultiLineHandling (multiline_handler.allium)
+//	    @guarantee LineSeparator — between consecutive input lines
+//	                                accumulated into the same
+//	                                buffer, the handler writes the
+//	                                EscapedLineFeed marker.
+//
+// A pattern-bounded group containing 2+ input lines emits content
+// where the EscapedLineFeed separator appears between adjacent
+// line contents. Separator bytes count toward buffered_content_len
+// for the overflow check.
+func TestMultiLineHandler_LineSeparator_Property(t *testing.T) {
+	re := regexp.MustCompile("^START")
+
+	rapid.Check(t, func(t *rapid.T) {
+		// Large limit so no overflow.
+		nContinuations := rapid.IntRange(1, 3).Draw(t, "nContinuations")
+		rig := newMultiLineTestRig(re, 1000)
+
+		// Build a sequence of distinct continuation lines so we
+		// can find them in the emission and verify a separator
+		// appears between them.
+		conts := make([]string, nContinuations)
+		for i := 0; i < nContinuations; i++ {
+			conts[i] = "cont" + string([]byte{byte('A' + i)})
+		}
+
+		rig.send("START leader", false)
+		for _, c := range conts {
+			rig.send(c, false)
+		}
+		rig.send("START next", false) // triggers emission
+
+		if len(rig.emitted) < 1 {
+			t.Fatal("expected at least 1 emission")
+		}
+		content := string(rig.emitted[0].content)
+		separator := string(message.EscapedLineFeed)
+
+		// Every pair of consecutive expected pieces (leader,
+		// conts[0], conts[1], ...) should have the separator
+		// between them.
+		pieces := append([]string{"START leader"}, conts...)
+		for i := 0; i < len(pieces)-1; i++ {
+			pair := pieces[i] + separator + pieces[i+1]
+			if !strings.Contains(content, pair) {
+				t.Fatalf("LineSeparator violated: expected %q (separator between %q and %q) in emission content %q", pair, pieces[i], pieces[i+1], content)
 			}
 		}
 	})

--- a/pkg/logs/internal/decoder/preprocessor/combining_aggregator_proptest_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/combining_aggregator_proptest_test.go
@@ -620,6 +620,137 @@ func TestCombiningAggregator_TruncationTaggingAutoMultiline_Property(t *testing.
 	})
 }
 
+// TestCombiningAggregator_StartGroupBoundary_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee StartGroupBoundary — a process call with the
+//	                                     start_group label flushes
+//	                                     any buffered bucket as a
+//	                                     combined emission and
+//	                                     then begins a new bucket
+//	                                     containing the current
+//	                                     message.
+//
+// After accumulating startGroup + aggregate(s) into a bucket, a
+// subsequent startGroup call emits the prior bucket as ONE
+// combined emission and starts a fresh accumulation with the
+// new startGroup line.
+func TestCombiningAggregator_StartGroupBoundary_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		nContinuations := rapid.IntRange(0, 3).Draw(t, "nContinuations")
+
+		ag := NewCombiningAggregator(200, false, false, status.NewInfoRegistry())
+		ag.Process(newMessage("S1 leader"), startGroup, nil)
+		for i := 0; i < nContinuations; i++ {
+			ag.Process(newMessage("cont"), aggregate, nil)
+		}
+		// New startGroup should flush prior bucket.
+		emitted := captureCombiningEmissions(ag.Process(newMessage("S2 leader"), startGroup, nil))
+
+		if len(emitted) != 1 {
+			t.Fatalf("StartGroupBoundary violated: expected exactly 1 emission (the prior bucket flushed), got %d", len(emitted))
+		}
+		// The emission should contain the leader's content.
+		if !bytes.Contains(emitted[0].content, []byte("S1 leader")) {
+			t.Fatalf("StartGroupBoundary violated: emission missing leader content; got %q", emitted[0].content)
+		}
+		// If continuations were added, emission should be multi-line.
+		if nContinuations > 0 && !emitted[0].isMultiLine {
+			t.Fatalf("StartGroupBoundary violated: %d-continuation emission not multi-line", nContinuations)
+		}
+	})
+}
+
+// TestCombiningAggregator_NoAggregateFlushes_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee NoAggregateFlushes — a process call with the
+//	                                     no_aggregate label flushes
+//	                                     any buffered bucket and
+//	                                     emits the current line as
+//	                                     a single-line message
+//	                                     (producing 1 or 2
+//	                                     emissions).
+//
+// After accumulating startGroup + aggregate(s) into a bucket, a
+// noAggregate call produces 2 emissions: the prior bucket (as a
+// combined message if 2+ lines, single-line if 1) and the
+// current noAggregate message as a single-line. With an empty
+// prior bucket, noAggregate produces just 1 emission.
+func TestCombiningAggregator_NoAggregateFlushes_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		nContinuations := rapid.IntRange(1, 3).Draw(t, "nContinuations")
+
+		ag := NewCombiningAggregator(200, false, false, status.NewInfoRegistry())
+		ag.Process(newMessage("S leader"), startGroup, nil)
+		for i := 0; i < nContinuations; i++ {
+			ag.Process(newMessage("cont"), aggregate, nil)
+		}
+		// noAggregate should flush prior bucket + emit current.
+		emitted := captureCombiningEmissions(ag.Process(newMessage("naX"), noAggregate, nil))
+
+		if len(emitted) != 2 {
+			t.Fatalf("NoAggregateFlushes violated: expected 2 emissions (prior bucket + current), got %d", len(emitted))
+		}
+		// Emission 1: the prior combined bucket.
+		if !bytes.Contains(emitted[0].content, []byte("S leader")) {
+			t.Fatalf("NoAggregateFlushes violated: emission 1 missing leader content; got %q", emitted[0].content)
+		}
+		if !emitted[0].isMultiLine {
+			t.Fatalf("NoAggregateFlushes violated: emission 1 with %d-line prior bucket should be multi-line", 1+nContinuations)
+		}
+		// Emission 2: the current noAggregate as single-line.
+		if !bytes.Contains(emitted[1].content, []byte("naX")) {
+			t.Fatalf("NoAggregateFlushes violated: emission 2 missing current message; got %q", emitted[1].content)
+		}
+		if emitted[1].isMultiLine {
+			t.Fatalf("NoAggregateFlushes violated: emission 2 (current noAggregate) should be single-line, got multi-line; content %q", emitted[1].content)
+		}
+	})
+}
+
+// TestCombiningAggregator_TokensFromAggregateLeader_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee TokensFromAggregateLeader — a combined
+//	                                            emission's tokens
+//	                                            are the tokens
+//	                                            passed alongside
+//	                                            the FIRST line of
+//	                                            the bucket (the
+//	                                            start_group line
+//	                                            that initiated the
+//	                                            group).
+//
+// Build a multi-line group with leader-tokens vs. continuation-
+// tokens. The boundary-flushed combined emission carries the
+// leader's tokens, not the continuation's.
+func TestCombiningAggregator_TokensFromAggregateLeader_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		leaderTokens := []Token{Token(1), Token(2), Token(3)}
+		contTokens := []Token{Token(7), Token(8)}
+
+		ag := NewCombiningAggregator(200, false, false, status.NewInfoRegistry())
+		ag.Process(newMessage("S leader"), startGroup, leaderTokens)
+		ag.Process(newMessage("cont"), aggregate, contTokens)
+		// Boundary triggers emission of the prior group.
+		emitted := ag.Process(newMessage("S next"), startGroup, []Token{Token(0)})
+
+		if len(emitted) != 1 {
+			t.Fatalf("expected 1 emission, got %d", len(emitted))
+		}
+		gotTokens := emitted[0].Tokens
+		if len(gotTokens) != len(leaderTokens) {
+			t.Fatalf("TokensFromAggregateLeader violated: emission has %d tokens, leader had %d", len(gotTokens), len(leaderTokens))
+		}
+		for i := range leaderTokens {
+			if gotTokens[i] != leaderTokens[i] {
+				t.Fatalf("TokensFromAggregateLeader violated: emission token[%d]=%v, expected leader token[%d]=%v (continuation had %v)", i, gotTokens[i], i, leaderTokens[i], contTokens)
+			}
+		}
+	})
+}
+
 // TestCombiningAggregator_MultiLineSourceTag_Property anchors:
 //
 //	surface CombiningAggregation (combining_aggregator.allium)

--- a/pkg/logs/internal/decoder/preprocessor/detecting_aggregator_proptest_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/detecting_aggregator_proptest_test.go
@@ -532,6 +532,111 @@ func TestDetectingAggregator_TagDisabledNoTag_Property(t *testing.T) {
 	})
 }
 
+// TestDetectingAggregator_StartGroupBufferedUntilNextCall_Property anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee StartGroupBufferedUntilNextCall — a process
+//	                                                  call with the
+//	                                                  start_group
+//	                                                  label flushes
+//	                                                  any pending
+//	                                                  message then
+//	                                                  buffers the
+//	                                                  current
+//	                                                  message; the
+//	                                                  start_group
+//	                                                  is NOT
+//	                                                  emitted on
+//	                                                  the call that
+//	                                                  received it.
+//
+// On a fresh aggregator, a startGroup call produces zero
+// emissions (the message is buffered as pending). The next call
+// (aggregate, noAggregate, or another startGroup) releases the
+// pending. A subsequent flush releases any final pending.
+func TestDetectingAggregator_StartGroupBufferedUntilNextCall_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		content := string(rapid.SliceOfN(
+			rapid.SampledFrom([]byte("abcdef0123")),
+			1, 20,
+		).Draw(t, "content"))
+
+		ag := NewDetectingAggregator(status.NewInfoRegistry(), 200, false, false)
+		emitted := ag.Process(makeDetectingMessage([]byte(content), false), startGroup, nil)
+		if len(emitted) != 0 {
+			t.Fatalf("StartGroupBufferedUntilNextCall violated: startGroup on fresh aggregator emitted %d messages, expected 0", len(emitted))
+		}
+
+		// Now release via flush.
+		flushed := ag.Flush()
+		if len(flushed) != 1 {
+			t.Fatalf("StartGroupBufferedUntilNextCall violated: expected flush to release the pending startGroup, got %d emissions", len(flushed))
+		}
+	})
+}
+
+// TestDetectingAggregator_MultiLineDetectionTag_Property anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee MultiLineDetectionTag — when a process call's
+//	                                        label is aggregate AND
+//	                                        a previous process call
+//	                                        buffered a message with
+//	                                        the start_group label,
+//	                                        the buffered message is
+//	                                        emitted with an
+//	                                        additional tag
+//	                                        "auto_multiline_detected:true".
+//
+// LOAD-BEARING for the refactor safety net. The detection tag is
+// the WHOLE PURPOSE of DetectingAggregator; if the refactor
+// changed when the tag is applied (e.g., applied unconditionally
+// or skipped), behaviour would silently drift.
+//
+// Sequence: startGroup buffers msg A. aggregate emits A (with
+// detection tag) and also emits B (without detection tag).
+func TestDetectingAggregator_MultiLineDetectionTag_Property(t *testing.T) {
+	detectionTag := "auto_multiline_detected:true"
+
+	rapid.Check(t, func(t *rapid.T) {
+		contentA := string(rapid.SliceOfN(
+			rapid.SampledFrom([]byte("abcdef")),
+			1, 10,
+		).Draw(t, "contentA"))
+		contentB := string(rapid.SliceOfN(
+			rapid.SampledFrom([]byte("ghijkl")),
+			1, 10,
+		).Draw(t, "contentB"))
+
+		ag := NewDetectingAggregator(status.NewInfoRegistry(), 200, false, false)
+		ag.Process(makeDetectingMessage([]byte(contentA), false), startGroup, nil)
+		emitted := captureDetectingEmissions(ag.Process(makeDetectingMessage([]byte(contentB), false), aggregate, nil))
+
+		if len(emitted) != 2 {
+			t.Fatalf("MultiLineDetectionTag setup: expected 2 emissions (pending + current), got %d", len(emitted))
+		}
+		// Emission 1: the pending startGroup, SHOULD have the
+		// detection tag.
+		hasTagOnFirst := false
+		for _, tag := range emitted[0].tags {
+			if tag == detectionTag {
+				hasTagOnFirst = true
+				break
+			}
+		}
+		if !hasTagOnFirst {
+			t.Fatalf("MultiLineDetectionTag violated: pending startGroup emission missing %q tag; tags=%v", detectionTag, emitted[0].tags)
+		}
+		// Emission 2: the current aggregate, should NOT have
+		// the detection tag.
+		for _, tag := range emitted[1].tags {
+			if tag == detectionTag {
+				t.Fatalf("MultiLineDetectionTag violated: current aggregate emission has unexpected %q tag (tag belongs only to detected start_group emissions); tags=%v", detectionTag, emitted[1].tags)
+			}
+		}
+	})
+}
+
 // TestDetectingAggregator_PerEmissionTruncationFlow_Property anchors:
 //
 //	surface DetectingAggregation (detecting_aggregator.allium)

--- a/pkg/logs/internal/decoder/preprocessor/regex_aggregator_proptest_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/regex_aggregator_proptest_test.go
@@ -612,6 +612,48 @@ func TestRegexAggregator_MultiLineTagging_Property(t *testing.T) {
 	})
 }
 
+// TestRegexAggregator_TokensFromAggregateLeader_Property anchors:
+//
+//	surface RegexAggregation (regex_aggregator.allium)
+//	    @guarantee TokensFromAggregateLeader — emitted tokens are
+//	                                            the tokens passed
+//	                                            alongside the FIRST
+//	                                            line of the
+//	                                            aggregate.
+//
+// LOAD-BEARING for the refactor safety net. The aggregator
+// stores firstLineTokens on the leader call and uses those at
+// flush time, NOT the last-contributor's tokens. If a refactor
+// swapped this to last-tokens or recomputed, downstream tagging
+// would silently drift.
+func TestRegexAggregator_TokensFromAggregateLeader_Property(t *testing.T) {
+	re := regexp.MustCompile(`^START`)
+
+	rapid.Check(t, func(t *rapid.T) {
+		leaderTokens := []Token{Token(1), Token(2), Token(3)}
+		continuationTokens := []Token{Token(7), Token(8)}
+
+		ag := NewRegexAggregator(re, 200, false, status.NewInfoRegistry(), "multi_line")
+		ag.Process(newMessage("START leader"), startGroup, leaderTokens)
+		ag.Process(newMessage("continuation"), aggregate, continuationTokens)
+		// Boundary triggers emission of the prior group.
+		emitted := ag.Process(newMessage("START next"), startGroup, []Token{Token(0)})
+
+		if len(emitted) != 1 {
+			t.Fatalf("expected 1 emission from boundary, got %d", len(emitted))
+		}
+		gotTokens := emitted[0].Tokens
+		if len(gotTokens) != len(leaderTokens) {
+			t.Fatalf("TokensFromAggregateLeader violated: emission has %d tokens, leader had %d", len(gotTokens), len(leaderTokens))
+		}
+		for i := range leaderTokens {
+			if gotTokens[i] != leaderTokens[i] {
+				t.Fatalf("TokensFromAggregateLeader violated: emission token[%d]=%v, expected leader token[%d]=%v (or did the aggregator forward continuation tokens %v?)", i, gotTokens[i], i, leaderTokens[i], continuationTokens)
+			}
+		}
+	})
+}
+
 // TestRegexAggregator_PreMatchSinglePass_Property anchors:
 //
 //	surface RegexAggregation (regex_aggregator.allium)

--- a/pkg/logs/internal/decoder/single_line_handler_proptest_test.go
+++ b/pkg/logs/internal/decoder/single_line_handler_proptest_test.go
@@ -500,6 +500,45 @@ func TestSingleLineHandler_TagOnTruncation_Property(t *testing.T) {
 	})
 }
 
+// TestSingleLineHandler_InputMessageMutated_Property anchors:
+//
+//	surface SingleLineHandling (single_line_handler.allium)
+//	    @guarantee InputMessageMutated — the input *message.Message
+//	                                      is mutated in place
+//	                                      before being passed to
+//	                                      outputFn; the handler
+//	                                      does not construct a new
+//	                                      message.
+//
+// LOAD-BEARING for the refactor safety net. If the refactor
+// switches from in-place mutation to allocation of new emission
+// messages, observable identity behaviour changes — any caller
+// retaining a reference to the input message would no longer see
+// the post-process modifications. This test verifies the pointer
+// passed to outputFn is the SAME as the input pointer.
+func TestSingleLineHandler_InputMessageMutated_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(1, 200).Draw(t, "lineLimit")
+		in := genSingleLineInput().Draw(t, "input")
+
+		var inputPtr *message.Message
+		var emittedPtr *message.Message
+		h := NewSingleLineHandler(func(m *message.Message) {
+			emittedPtr = m
+		}, lineLimit)
+
+		msg := message.NewMessage(append([]byte(nil), in.content...), nil, "", time.Now().UnixNano())
+		msg.RawDataLen = len(in.content)
+		msg.ParsingExtra.IsTruncated = in.upstreamIsTruncated
+		inputPtr = msg
+		h.process(msg)
+
+		if emittedPtr != inputPtr {
+			t.Fatalf("InputMessageMutated violated: emitted pointer %p differs from input pointer %p (handler allocated a new message instead of mutating in place)", emittedPtr, inputPtr)
+		}
+	})
+}
+
 // TestSingleLineHandler_TagDisabledNoTag_Property anchors:
 //
 //	surface SingleLineHandling (single_line_handler.allium)

--- a/pkg/logs/internal/framer/framer_proptest_test.go
+++ b/pkg/logs/internal/framer/framer_proptest_test.go
@@ -329,6 +329,72 @@ func TestFramer_NoCarryOverBetweenEmissions_Property(t *testing.T) {
 	})
 }
 
+// TestFramer_IsTruncatedOnEmittedFrame_Property anchors:
+//
+//	surface FramerTruncation (framer.allium)
+//	    @guarantee IsTruncatedOnEmittedFrame — the IsTruncated
+//	                                            flag is set on the
+//	                                            EMITTED frame's
+//	                                            ParsingExtra (a new
+//	                                            *message.Message
+//	                                            constructed by
+//	                                            emitFrame). The
+//	                                            original input
+//	                                            message's
+//	                                            IsTruncated flag
+//	                                            is not modified.
+//
+// LOAD-BEARING for the refactor safety net. If the refactor
+// changes the framer to mutate the input message in place
+// instead of constructing a new emission message, observable
+// identity behaviour changes — any caller retaining the input
+// would suddenly see truncation flags it didn't set. This test
+// pins the current "new message per frame" semantics.
+func TestFramer_IsTruncatedOnEmittedFrame_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(10, 50).Draw(t, "lineLimit")
+		// Oversized input forces force-cut → emission with
+		// IsTruncated=true.
+		excess := lineLimit + rapid.IntRange(1, 40).Draw(t, "excess")
+		body := make([]byte, excess)
+		for i := range body {
+			body[i] = 'y'
+		}
+
+		var emittedPtrs []*message.Message
+		fr := NewFramer(
+			func(m *message.Message, _ int) {
+				emittedPtrs = append(emittedPtrs, m)
+			},
+			UTF8Newline,
+			lineLimit,
+		)
+
+		input := message.NewMessage(body, nil, "", 0)
+		// Input deliberately starts with IsTruncated=false.
+		input.ParsingExtra.IsTruncated = false
+		fr.Process(input)
+
+		// Input's flag must be unchanged.
+		if input.ParsingExtra.IsTruncated {
+			t.Fatal("IsTruncatedOnEmittedFrame violated: input message's IsTruncated flipped to true (framer should not mutate the input)")
+		}
+		// At least one emission expected (force-cut).
+		if len(emittedPtrs) == 0 {
+			t.Fatal("expected at least 1 emission from oversized input, got 0")
+		}
+		// The emitted frame is a new message — different pointer
+		// from input — with IsTruncated=true.
+		first := emittedPtrs[0]
+		if first == input {
+			t.Fatal("IsTruncatedOnEmittedFrame violated: emitted frame is the SAME pointer as input (framer should construct a new message)")
+		}
+		if !first.ParsingExtra.IsTruncated {
+			t.Fatal("IsTruncatedOnEmittedFrame violated: emitted frame's IsTruncated=false on oversized input")
+		}
+	})
+}
+
 // TestFramer_DatagramEndOfProcessFlush_Property anchors:
 //
 //	surface FramerTruncation (framer.allium)

--- a/pkg/logs/util/windowsevent/windowsevent_proptest_test.go
+++ b/pkg/logs/util/windowsevent/windowsevent_proptest_test.go
@@ -267,6 +267,51 @@ func TestWindowsEvent_MarkerScanShortStringNotDetected_Property(t *testing.T) {
 	})
 }
 
+// TestWindowsEvent_RetroactiveDetection_Property anchors:
+//
+//	surface WindowsEventTruncation (windows_event_truncation.allium)
+//	    @guarantee RetroactiveDetection — IsTruncated is determined
+//	                                       NOT by tracking whether
+//	                                       SetMessage truncated,
+//	                                       but by SCANNING the
+//	                                       stored message field
+//	                                       for the marker at the
+//	                                       time of message
+//	                                       construction.
+//
+// LOAD-BEARING for the refactor safety net. If the refactor
+// changed detection to state-tracking (e.g., a per-Map "did we
+// truncate?" boolean), behaviour would diverge for messages
+// whose content naturally contains the marker substring at a
+// boundary. This test injects the marker into under-limit
+// content and verifies the resulting message is still detected
+// as truncated.
+func TestWindowsEvent_RetroactiveDetection_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// Under-limit content with the marker artificially
+		// placed at the tail boundary. SetMessage does NOT
+		// truncate (content is under 128KB), so no state is
+		// set indicating "we truncated."
+		bodyLen := rapid.IntRange(1, 200).Draw(t, "bodyLen")
+		body := strings.Repeat("x", bodyLen)
+		// Append the marker manually — this simulates content
+		// that already contained the marker for any reason.
+		injected := body + truncatedFlag
+
+		m := newTestMap()
+		if err := m.SetMessage(injected); err != nil {
+			t.Fatalf("SetMessage failed: %v", err)
+		}
+
+		// The flag must be detected from the marker presence,
+		// regardless of whether SetMessage actually applied
+		// truncation logic (it didn't, since len < limit).
+		if !hasTruncatedFlag(m.GetMessage()) {
+			t.Fatalf("RetroactiveDetection violated: marker present in stored content but hasTruncatedFlag returned false (detection should be marker-scan-based, not state-tracked); content=%q", m.GetMessage())
+		}
+	})
+}
+
 // TestWindowsEvent_NoCarryOver_Property anchors:
 //
 //	surface WindowsEventTruncation (windows_event_truncation.allium)


### PR DESCRIPTION
  ### What does this PR do?

  Adds property tests for high-leverage @guarantees that weren't directly anchored by the per-site proptest PRs earlier in this stack. No spec changes; pure test additions.

  **New tests by file:**

  - `single_line_handler_proptest_test.go` — `InputMessageMutated` (verifies in-place mutation of the input pointer)
  - `multiline_handler_proptest_test.go` — `LineSeparator` (verifies `EscapedLineFeed` between accumulated lines)
  - `detecting_aggregator_proptest_test.go` — `StartGroupBufferedUntilNextCall`, `MultiLineDetectionTag` (buffer/release semantics + the `auto_multiline_detected:true` tag)
  - `regex_aggregator_proptest_test.go` — `TokensFromAggregateLeader` (leader-token forwarding)
  - `combining_aggregator_proptest_test.go` — `StartGroupBoundary`, `NoAggregateFlushes`, `TokensFromAggregateLeader` (dispatch-table verification)
  - `framer_proptest_test.go` — `IsTruncatedOnEmittedFrame` (verifies a NEW emission message is constructed; input NOT mutated)
  - `windowsevent_proptest_test.go` — `RetroactiveDetection` (proves scan-based detection by injecting the marker into under-limit content)

  ### Motivation

  These @guarantees were called out as high-leverage for refactor safety. A refactor that changes the in-place vs new-pointer semantics, the line-separator behaviour, the auto-multiline tag, or the dispatch-table
  routing would silently change user-observable behaviour without these tests — and the per-site proptest PRs above didn't anchor them directly.

  Full context: [**Truncation Safety Net** Confluence page](https://datadoghq.atlassian.net/wiki/spaces/~712020c20dd82e15fd4ed5bcd968f8d10d9578/pages/6759220118/Truncation+Safety+Net) — see "High-value gap-fillers
  (added 2026-05-22)" section.

  ### Describe how you validated your changes

  - Default 100 iterations green for all 11 new tests.
  - **10,000-iteration validation pass** green (2026-05-21).
  - `dda inv test` clean across the three affected packages.

  ### Additional Notes

  - Final PR in the Truncation Safety Net graphite stack.
  - Pure test additions — no `.allium` changes, no production code changes.