### PR TITLE
[observer] Gate scanmw/scanwelch replay on visible point count

### DIFF
--- a/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
@@ -24,7 +24,8 @@ type scanmwStateKey struct {
 // (metrics_detector_bocpd.go). If more scan-based detectors are added,
 // consider extracting a shared scanSeriesState base.
 type scanmwSeriesState struct {
-	lastWriteGen int64
+	lastWriteGen       int64
+	lastProcessedCount int // visible point count (PointCountUpTo) at last Detect
 
 	// Segment tracking: only scan [segmentStartTime, dataTime].
 	// 0 initially (scan full history), advances to changepoint timestamp on fire.
@@ -156,8 +157,15 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 				d.series[sk] = state
 			}
 
-			// Skip if nothing was written since last Detect.
-			if status.writeGeneration == state.lastWriteGen {
+			// Skip unless at least MinSegment new points are visible since the
+			// last scan. Gating on visible point count (not WriteGeneration
+			// alone) is required for replay: storage may already hold future
+			// points, so WriteGeneration reaches its final value before the
+			// simulated dataTime has advanced far enough to expose them, which
+			// would otherwise suppress every scan. WriteGeneration is still
+			// checked to catch same-bucket merges that leave the count
+			// unchanged but move stored values. Mirrors the BOCPD replay gate.
+			if status.pointCount < state.lastProcessedCount+d.MinSegment && status.writeGeneration == state.lastWriteGen {
 				continue
 			}
 
@@ -173,6 +181,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 			})
 
 			if seriesMeta == nil || len(state.buf) < d.MinPoints {
+				state.lastProcessedCount = status.pointCount
 				state.lastWriteGen = status.writeGeneration
 				continue
 			}
@@ -184,6 +193,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 				state.segmentStartTime = state.buf[changeIdx].Timestamp - 1
 			}
 
+			state.lastProcessedCount = status.pointCount
 			state.lastWriteGen = status.writeGeneration
 		}
 	}

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanmw_test.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanmw_test.go
@@ -160,3 +160,35 @@ func TestScanMW_Reset(t *testing.T) {
 	assert.Empty(t, d.series, "reset should clear all state")
 	assert.Nil(t, d.cachedRefs, "reset should clear cached refs")
 }
+
+// TestScanMW_PreloadedReplayFiresAsDataTimeAdvances reproduces the testbench
+// replay path: all points are written to storage up front (so WriteGeneration
+// reaches its final value immediately), then Detect is called repeatedly with
+// an advancing dataTime that gradually exposes the history. A WriteGeneration-
+// only skip gate suppresses every scan after the first call here and detects
+// nothing; gating on visible point count keeps the detector scanning as the
+// data becomes visible. This is distinct from TestScanMW_IncrementalAdvance,
+// where each new point bumps WriteGeneration between Detect calls (the live
+// path).
+func TestScanMW_PreloadedReplayFiresAsDataTimeAdvances(t *testing.T) {
+	d := testScanMWDetector()
+	storage := newTimeSeriesStorage()
+
+	// Preload the entire series before any Detect call.
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	for i := 20; i < 40; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+
+	// Replay: advance dataTime one bucket at a time over preloaded storage.
+	var fired bool
+	for dataTime := int64(1); dataTime <= 40; dataTime++ {
+		if len(d.Detect(storage, dataTime).Anomalies) > 0 {
+			fired = true
+		}
+	}
+
+	assert.True(t, fired, "preloaded replay should detect the step change as dataTime advances")
+}

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
@@ -21,7 +21,8 @@ type scanwelchStateKey struct {
 // scanwelchSeriesState holds per-series streaming state for the ScanWelch detector.
 // Same pattern as scanmwSeriesState and BOCPD (metrics_detector_bocpd.go).
 type scanwelchSeriesState struct {
-	lastWriteGen int64
+	lastWriteGen       int64
+	lastProcessedCount int // visible point count (PointCountUpTo) at last Detect
 
 	// Segment tracking: only scan [segmentStartTime, dataTime].
 	segmentStartTime int64
@@ -146,8 +147,15 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 				d.series[sk] = state
 			}
 
-			// Skip if nothing was written since last Detect.
-			if status.writeGeneration == state.lastWriteGen {
+			// Skip unless at least MinSegment new points are visible since the
+			// last scan. Gating on visible point count (not WriteGeneration
+			// alone) is required for replay: storage may already hold future
+			// points, so WriteGeneration reaches its final value before the
+			// simulated dataTime has advanced far enough to expose them, which
+			// would otherwise suppress every scan. WriteGeneration is still
+			// checked to catch same-bucket merges that leave the count
+			// unchanged but move stored values. Mirrors the BOCPD replay gate.
+			if status.pointCount < state.lastProcessedCount+d.MinSegment && status.writeGeneration == state.lastWriteGen {
 				continue
 			}
 
@@ -163,6 +171,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 			})
 
 			if seriesMeta == nil || len(state.buf) < d.MinPoints {
+				state.lastProcessedCount = status.pointCount
 				state.lastWriteGen = status.writeGeneration
 				continue
 			}
@@ -174,6 +183,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 				state.segmentStartTime = state.buf[changeIdx].Timestamp - 1
 			}
 
+			state.lastProcessedCount = status.pointCount
 			state.lastWriteGen = status.writeGeneration
 		}
 	}

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanwelch_test.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanwelch_test.go
@@ -150,3 +150,35 @@ func TestScanWelch_Reset(t *testing.T) {
 	assert.Empty(t, d.series, "reset should clear all state")
 	assert.Nil(t, d.cachedRefs, "reset should clear cached refs")
 }
+
+// TestScanWelch_PreloadedReplayFiresAsDataTimeAdvances reproduces the testbench
+// replay path: all points are written to storage up front (so WriteGeneration
+// reaches its final value immediately), then Detect is called repeatedly with
+// an advancing dataTime that gradually exposes the history. A WriteGeneration-
+// only skip gate suppresses every scan after the first call here and detects
+// nothing; gating on visible point count keeps the detector scanning as the
+// data becomes visible. This is distinct from TestScanWelch_IncrementalAdvance,
+// where each new point bumps WriteGeneration between Detect calls (the live
+// path).
+func TestScanWelch_PreloadedReplayFiresAsDataTimeAdvances(t *testing.T) {
+	d := testScanWelchDetector()
+	storage := newTimeSeriesStorage()
+
+	// Preload the entire series before any Detect call.
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	for i := 20; i < 40; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+
+	// Replay: advance dataTime one bucket at a time over preloaded storage.
+	var fired bool
+	for dataTime := int64(1); dataTime <= 40; dataTime++ {
+		if len(d.Detect(storage, dataTime).Anomalies) > 0 {
+			fired = true
+		}
+	}
+
+	assert.True(t, fired, "preloaded replay should detect the step change as dataTime advances")
+}


### PR DESCRIPTION
### What does this PR do?

Makes the `scanmw` and `scanwelch` metric detectors gate their per-Detect skip on **visible point count** rather than `WriteGeneration` alone, so they behave correctly under testbench replay. This is the scan-detector equivalent of the replay-safe cursor BOCPD already received in #51083.

### Motivation

Both scan detectors skipped a `Detect` cycle whenever storage's `WriteGeneration` was unchanged since the last call:

```go
if status.writeGeneration == state.lastWriteGen {
    continue
}
```

During testbench replay (#51083) all points are preloaded up front, so `WriteGeneration` reaches its final value immediately — before the simulated `dataTime` has advanced far enough to expose the history. The gate then suppressed **every** scan after the first call and the detectors produced zero anomalies during replay.

The fix gates on visible point count: skip only when fewer than `MinSegment` new points are visible (`PointCountUpTo`) **and** `WriteGeneration` is unchanged. `WriteGeneration` is still checked so same-bucket merges that leave the count unchanged are not missed. `MinSegment` already exists on both detectors (default 12); `status.pointCount` is already fetched by `bulkSeriesStatus`, so no extra storage call is introduced.

Both detectors are **disabled by default** (`defaultEnabled: false`), so live behavior is unchanged: every live `Add` bumps `WriteGeneration`, so the added point-count term never changes the gate's outcome in the live path. The fix only affects replay, where it restores detection.

### Describe how you validated your changes

- `dda inv test --targets=./comp/anomalydetection/observer/impl` — **all pass** (420 tests, 1 pre-existing skip).
- Added `TestScanMW_PreloadedReplayFiresAsDataTimeAdvances` and the ScanWelch equivalent, which reproduce the preloaded-then-advancing-`dataTime` replay path (distinct from the existing `IncrementalAdvance` tests, where each new point bumps `WriteGeneration`). Verified both tests **fail on the old gate and pass on the fix**.
- Local eval over the 12 observer scenarios (testbench headless + scorer, sigma=30, mean-of-F1) reproduces the published matrix from #51322 **exactly**:

  | Detector | Mean F1 | Mean precision | Mean recall | Detections | Baseline FPs |
  |---|---:|---:|---:|---:|---:|
  | `scanmw,time_cluster` (before) | 0.0000 | 0.0000 | 0.0000 | 0 | 0 |
  | `scanmw,time_cluster` (after) | 0.0775 | 0.0524 | 0.8575 | 3754 | 728 |
  | `scanwelch,time_cluster` (before) | 0.0000 | 0.0000 | 0.0000 | 0 | 0 |
  | `scanwelch,time_cluster` (after) | 0.0729 | 0.0497 | 0.8535 | 4232 | 859 |

### Additional Notes

No user-facing behavior change (detectors disabled by default; live path unaffected) — proposing `changelog/no-changelog`.