### PR TITLE
[CONTP-1703] Add CRD waiting and fallback mechanism on instrumentation controller startup

### DIFF
--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -421,7 +421,8 @@ func (c *APIClient) connect() error {
 		pkgconfigsetup.Datadog().GetBool("instrumentation_crd_controller.enabled") ||
 		pkgconfigsetup.Datadog().GetBool("cluster_checks.enabled") ||
 		pkgconfigsetup.Datadog().GetBool("autoscaling.workload.enabled") ||
-		pkgconfigsetup.Datadog().GetBool("autoscaling.cluster.enabled") {
+		pkgconfigsetup.Datadog().GetBool("autoscaling.cluster.enabled") ||
+		pkgconfigsetup.Datadog().GetBool("instrumentation_crd_controller.enabled") {
 		c.DynamicInformerFactory = dynamicinformer.NewDynamicSharedInformerFactory(c.DynamicInformerCl, c.defaultInformerResyncPeriod)
 	}
 

--- a/pkg/util/kubernetes/apiserver/controllers/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers/controllers.go
@@ -14,6 +14,9 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/cenkalti/backoff/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -194,27 +197,85 @@ func startAutoscalersController(ctx *ControllerContext, c chan error) {
 	autoscalersController.runControllerLoop(ctx.StopCh)
 }
 
-// startDatadogInstrumentationController starts the shared DatadogInstrumentation reconciliation controller.
-func startDatadogInstrumentationController(ctx *ControllerContext, c chan error) {
-	controller, err := instrumentation.NewController(
-		ctx.DynamicUpdateClient,
-		ctx.DynamicInformerFactory,
-		ctx.InstrumentationHandlers,
-		ctx.IsLeaderFunc,
-	)
-	if err != nil {
-		c <- err
-		return
+// isInstrumentationCRDNotFound returns true if the error indicates the DatadogInstrumentation CRD
+// is not installed in the cluster (i.e., the API group is not registered).
+func isInstrumentationCRDNotFound(err error) bool {
+	status, ok := err.(*apierrors.StatusError)
+	if !ok {
+		return false
+	}
+	details := status.Status().Details
+	return status.Status().Reason == metav1.StatusReasonNotFound &&
+		details != nil &&
+		details.Group == instrumentation.DatadogInstrumentationGVR.Group
+}
+
+func tryCheckInstrumentationCRD(check checkAPI) error {
+	if err := check(); err != nil {
+		if isInstrumentationCRDNotFound(err) {
+			return err
+		}
+		log.Errorf("DatadogInstrumentation CRD check failed: not retryable: %s", err)
+		return backoff.Permanent(err)
+	}
+	log.Info("DatadogInstrumentation CRD check successful")
+	return nil
+}
+
+func waitForInstrumentationCRD(ctx context.Context, dynamicClient dynamic.Interface) {
+	exp := backoff.NewExponentialBackOff()
+	exp.InitialInterval = crdCheckInitialInterval
+	exp.RandomizationFactor = 0
+	exp.Multiplier = crdCheckMultiplier
+	exp.MaxInterval = crdCheckMaxInterval
+	exp.Reset()
+
+	check := func() error {
+		_, err := dynamicClient.Resource(instrumentation.DatadogInstrumentationGVR).List(context.TODO(), metav1.ListOptions{})
+		return err
 	}
 
+	attempt := 0
+	_, _ = backoff.Retry(ctx, func() (any, error) {
+		err := tryCheckInstrumentationCRD(check)
+		if err != nil && isInstrumentationCRDNotFound(err) {
+			attempt++
+			log.Warnf("DatadogInstrumentation CRD missing (attempt=%d): will retry", attempt)
+		}
+		return nil, err
+	}, backoff.WithBackOff(exp), backoff.WithMaxElapsedTime(crdCheckMaxElapsedTime))
+}
+
+// startDatadogInstrumentationController starts the shared DatadogInstrumentation reconciliation controller.
+// It waits asynchronously for the DatadogInstrumentation CRD to be installed before starting.
+func startDatadogInstrumentationController(ctx *ControllerContext, _ chan error) {
 	controllerCtx, cancel := context.WithCancel(context.Background())
 	go func() {
 		<-ctx.StopCh
 		cancel()
 	}()
 
-	go controller.Run(controllerCtx)
-	ctx.DynamicInformerFactory.Start(ctx.StopCh)
+	go func() {
+		waitForInstrumentationCRD(controllerCtx, ctx.DynamicClient)
+
+		if controllerCtx.Err() != nil {
+			return
+		}
+
+		controller, err := instrumentation.NewController(
+			ctx.DynamicUpdateClient,
+			ctx.DynamicInformerFactory,
+			ctx.InstrumentationHandlers,
+			ctx.IsLeaderFunc,
+		)
+		if err != nil {
+			log.Errorf("Failed to create DatadogInstrumentation controller: %v", err)
+			return
+		}
+
+		go controller.Run(controllerCtx)
+		ctx.DynamicInformerFactory.Start(ctx.StopCh)
+	}()
 }
 
 // registerServicesInformer registers the services informer.

--- a/pkg/util/kubernetes/apiserver/controllers/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers/controllers.go
@@ -10,13 +10,9 @@
 package controllers
 
 import (
-	"context"
 	"errors"
 	"sync"
 
-	"github.com/cenkalti/backoff/v5"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -195,87 +191,6 @@ func startAutoscalersController(ctx *ControllerContext, c chan error) {
 	go autoscalersController.runHPA(ctx.StopCh)
 
 	autoscalersController.runControllerLoop(ctx.StopCh)
-}
-
-// isInstrumentationCRDNotFound returns true if the error indicates the DatadogInstrumentation CRD
-// is not installed in the cluster (i.e., the API group is not registered).
-func isInstrumentationCRDNotFound(err error) bool {
-	status, ok := err.(*apierrors.StatusError)
-	if !ok {
-		return false
-	}
-	details := status.Status().Details
-	return status.Status().Reason == metav1.StatusReasonNotFound &&
-		details != nil &&
-		details.Group == instrumentation.DatadogInstrumentationGVR.Group
-}
-
-func tryCheckInstrumentationCRD(check checkAPI) error {
-	if err := check(); err != nil {
-		if isInstrumentationCRDNotFound(err) {
-			return err
-		}
-		log.Errorf("DatadogInstrumentation CRD check failed: not retryable: %s", err)
-		return backoff.Permanent(err)
-	}
-	log.Info("DatadogInstrumentation CRD check successful")
-	return nil
-}
-
-func waitForInstrumentationCRD(ctx context.Context, dynamicClient dynamic.Interface) {
-	exp := backoff.NewExponentialBackOff()
-	exp.InitialInterval = crdCheckInitialInterval
-	exp.RandomizationFactor = 0
-	exp.Multiplier = crdCheckMultiplier
-	exp.MaxInterval = crdCheckMaxInterval
-	exp.Reset()
-
-	check := func() error {
-		_, err := dynamicClient.Resource(instrumentation.DatadogInstrumentationGVR).List(context.TODO(), metav1.ListOptions{})
-		return err
-	}
-
-	attempt := 0
-	_, _ = backoff.Retry(ctx, func() (any, error) {
-		err := tryCheckInstrumentationCRD(check)
-		if err != nil && isInstrumentationCRDNotFound(err) {
-			attempt++
-			log.Warnf("DatadogInstrumentation CRD missing (attempt=%d): will retry", attempt)
-		}
-		return nil, err
-	}, backoff.WithBackOff(exp), backoff.WithMaxElapsedTime(crdCheckMaxElapsedTime))
-}
-
-// startDatadogInstrumentationController starts the shared DatadogInstrumentation reconciliation controller.
-// It waits asynchronously for the DatadogInstrumentation CRD to be installed before starting.
-func startDatadogInstrumentationController(ctx *ControllerContext, _ chan error) {
-	controllerCtx, cancel := context.WithCancel(context.Background())
-	go func() {
-		<-ctx.StopCh
-		cancel()
-	}()
-
-	go func() {
-		waitForInstrumentationCRD(controllerCtx, ctx.DynamicClient)
-
-		if controllerCtx.Err() != nil {
-			return
-		}
-
-		controller, err := instrumentation.NewController(
-			ctx.DynamicUpdateClient,
-			ctx.DynamicInformerFactory,
-			ctx.InstrumentationHandlers,
-			ctx.IsLeaderFunc,
-		)
-		if err != nil {
-			log.Errorf("Failed to create DatadogInstrumentation controller: %v", err)
-			return
-		}
-
-		go controller.Run(controllerCtx)
-		ctx.DynamicInformerFactory.Start(ctx.StopCh)
-	}()
 }
 
 // registerServicesInformer registers the services informer.

--- a/pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go
@@ -18,22 +18,9 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-// isInstrumentationCRDNotFound returns true if the error indicates the DatadogInstrumentation CRD
-// is not installed in the cluster (i.e., the API group is not registered).
-func isInstrumentationCRDNotFound(err error) bool {
-	status, ok := err.(*apierrors.StatusError)
-	if !ok {
-		return false
-	}
-	details := status.Status().Details
-	return status.Status().Reason == metav1.StatusReasonNotFound &&
-		details != nil &&
-		details.Group == instrumentation.DatadogInstrumentationGVR.Group
-}
-
 func tryCheckInstrumentationCRD(check checkAPI) error {
 	if err := check(); err != nil {
-		if isInstrumentationCRDNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return err
 		}
 		log.Errorf("DatadogInstrumentation CRD check failed: not retryable: %s", err)
@@ -43,7 +30,7 @@ func tryCheckInstrumentationCRD(check checkAPI) error {
 	return nil
 }
 
-func waitForInstrumentationCRD(ctx context.Context, dynamicClient dynamic.Interface) {
+func waitForInstrumentationCRD(ctx context.Context, dynamicClient dynamic.Interface) error {
 	exp := &backoff.ExponentialBackOff{
 		InitialInterval:     crdCheckInitialInterval,
 		RandomizationFactor: 0,
@@ -58,14 +45,15 @@ func waitForInstrumentationCRD(ctx context.Context, dynamicClient dynamic.Interf
 	}
 
 	attempt := 0
-	_, _ = backoff.Retry(ctx, func() (any, error) {
+	_, err := backoff.Retry(ctx, func() (any, error) {
 		err := tryCheckInstrumentationCRD(check)
-		if err != nil && isInstrumentationCRDNotFound(err) {
+		if err != nil && apierrors.IsNotFound(err) {
 			attempt++
 			log.Warnf("DatadogInstrumentation CRD missing (attempt=%d): will retry", attempt)
 		}
 		return nil, err
 	}, backoff.WithBackOff(exp), backoff.WithMaxElapsedTime(crdCheckMaxElapsedTime))
+	return err
 }
 
 // startDatadogInstrumentationController starts the shared DatadogInstrumentation reconciliation controller.
@@ -78,9 +66,8 @@ func startDatadogInstrumentationController(ctx *ControllerContext, _ chan error)
 	}()
 
 	go func() {
-		waitForInstrumentationCRD(controllerCtx, ctx.DynamicClient)
-
-		if controllerCtx.Err() != nil {
+		if err := waitForInstrumentationCRD(controllerCtx, ctx.DynamicClient); err != nil {
+			log.Warnf("DatadogInstrumentation controller will not start: %v", err)
 			return
 		}
 

--- a/pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/cenkalti/backoff/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+// isInstrumentationCRDNotFound returns true if the error indicates the DatadogInstrumentation CRD
+// is not installed in the cluster (i.e., the API group is not registered).
+func isInstrumentationCRDNotFound(err error) bool {
+	status, ok := err.(*apierrors.StatusError)
+	if !ok {
+		return false
+	}
+	details := status.Status().Details
+	return status.Status().Reason == metav1.StatusReasonNotFound &&
+		details != nil &&
+		details.Group == instrumentation.DatadogInstrumentationGVR.Group
+}
+
+func tryCheckInstrumentationCRD(check checkAPI) error {
+	if err := check(); err != nil {
+		if isInstrumentationCRDNotFound(err) {
+			return err
+		}
+		log.Errorf("DatadogInstrumentation CRD check failed: not retryable: %s", err)
+		return backoff.Permanent(err)
+	}
+	log.Info("DatadogInstrumentation CRD check successful")
+	return nil
+}
+
+func waitForInstrumentationCRD(ctx context.Context, dynamicClient dynamic.Interface) {
+	exp := &backoff.ExponentialBackOff{
+		InitialInterval:     crdCheckInitialInterval,
+		RandomizationFactor: 0,
+		Multiplier:          crdCheckMultiplier,
+		MaxInterval:         crdCheckMaxInterval,
+	}
+	exp.Reset()
+
+	check := func() error {
+		_, err := dynamicClient.Resource(instrumentation.DatadogInstrumentationGVR).List(context.TODO(), metav1.ListOptions{})
+		return err
+	}
+
+	attempt := 0
+	_, _ = backoff.Retry(ctx, func() (any, error) {
+		err := tryCheckInstrumentationCRD(check)
+		if err != nil && isInstrumentationCRDNotFound(err) {
+			attempt++
+			log.Warnf("DatadogInstrumentation CRD missing (attempt=%d): will retry", attempt)
+		}
+		return nil, err
+	}, backoff.WithBackOff(exp), backoff.WithMaxElapsedTime(crdCheckMaxElapsedTime))
+}
+
+// startDatadogInstrumentationController starts the shared DatadogInstrumentation reconciliation controller.
+// It waits asynchronously for the DatadogInstrumentation CRD to be installed before starting.
+func startDatadogInstrumentationController(ctx *ControllerContext, _ chan error) {
+	controllerCtx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-ctx.StopCh
+		cancel()
+	}()
+
+	go func() {
+		waitForInstrumentationCRD(controllerCtx, ctx.DynamicClient)
+
+		if controllerCtx.Err() != nil {
+			return
+		}
+
+		controller, err := instrumentation.NewController(
+			ctx.DynamicUpdateClient,
+			ctx.DynamicInformerFactory,
+			ctx.InstrumentationHandlers,
+			ctx.IsLeaderFunc,
+		)
+		if err != nil {
+			log.Errorf("Failed to create DatadogInstrumentation controller: %v", err)
+			return
+		}
+
+		go controller.Run(controllerCtx)
+		ctx.DynamicInformerFactory.Start(ctx.StopCh)
+	}()
+}

--- a/pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go
@@ -11,6 +11,7 @@ import (
 	"context"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/cenkalti/backoff/v5"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,7 +27,6 @@ func tryCheckInstrumentationCRD(check checkAPI) error {
 		}
 		return err
 	}
-	log.Info("DatadogInstrumentation CRD check successful")
 	return nil
 }
 
@@ -61,8 +61,12 @@ func waitForInstrumentationCRD(ctx context.Context, dynamicClient dynamic.Interf
 }
 
 // startDatadogInstrumentationController starts the shared DatadogInstrumentation reconciliation controller.
-// It waits asynchronously for the DatadogInstrumentation CRD to be installed before starting.
 func startDatadogInstrumentationController(ctx *ControllerContext, _ chan error) {
+	if !pkgconfigsetup.Datadog().GetBool("admission_controller.enabled") || !pkgconfigsetup.Datadog().GetBool("admission_controller.validation.enabled") {
+		log.Info("DatadogInstrumentation controller not starting, admission controller is needed to run.")
+		return
+	}
+
 	controllerCtx, cancel := context.WithCancel(context.Background())
 	go func() {
 		<-ctx.StopCh

--- a/pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go
@@ -20,8 +20,6 @@ import (
 
 func tryCheckInstrumentationCRD(check checkAPI) error {
 	if err := check(); err != nil {
-		// Only treat auth/permission failures as permanent — the CRD or apiserver may
-		// not be ready yet for any other reason (NotFound, 5xx, throttling, network errors).
 		if apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err) {
 			log.Errorf("DatadogInstrumentation CRD check failed: not retryable: %s", err)
 			return backoff.Permanent(err)
@@ -52,9 +50,9 @@ func waitForInstrumentationCRD(ctx context.Context, dynamicClient dynamic.Interf
 		if err != nil {
 			attempt++
 			if apierrors.IsNotFound(err) {
-				log.Warnf("DatadogInstrumentation CRD missing (attempt=%d): will retry", attempt)
+				log.Debugf("DatadogInstrumentation CRD missing (attempt=%d): will retry", attempt)
 			} else {
-				log.Warnf("DatadogInstrumentation CRD check failed transiently (attempt=%d): %v: will retry", attempt, err)
+				log.Debugf("DatadogInstrumentation CRD check failed transiently (attempt=%d): %v: will retry", attempt, err)
 			}
 		}
 		return nil, err
@@ -73,7 +71,7 @@ func startDatadogInstrumentationController(ctx *ControllerContext, _ chan error)
 
 	go func() {
 		if err := waitForInstrumentationCRD(controllerCtx, ctx.DynamicClient); err != nil {
-			log.Warnf("DatadogInstrumentation controller will not start: %v", err)
+			log.Infof("DatadogInstrumentation controller will not start: %v", err)
 			return
 		}
 

--- a/pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go
@@ -20,11 +20,13 @@ import (
 
 func tryCheckInstrumentationCRD(check checkAPI) error {
 	if err := check(); err != nil {
-		if apierrors.IsNotFound(err) {
-			return err
+		// Only treat auth/permission failures as permanent — the CRD or apiserver may
+		// not be ready yet for any other reason (NotFound, 5xx, throttling, network errors).
+		if apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err) {
+			log.Errorf("DatadogInstrumentation CRD check failed: not retryable: %s", err)
+			return backoff.Permanent(err)
 		}
-		log.Errorf("DatadogInstrumentation CRD check failed: not retryable: %s", err)
-		return backoff.Permanent(err)
+		return err
 	}
 	log.Info("DatadogInstrumentation CRD check successful")
 	return nil
@@ -47,9 +49,13 @@ func waitForInstrumentationCRD(ctx context.Context, dynamicClient dynamic.Interf
 	attempt := 0
 	_, err := backoff.Retry(ctx, func() (any, error) {
 		err := tryCheckInstrumentationCRD(check)
-		if err != nil && apierrors.IsNotFound(err) {
+		if err != nil {
 			attempt++
-			log.Warnf("DatadogInstrumentation CRD missing (attempt=%d): will retry", attempt)
+			if apierrors.IsNotFound(err) {
+				log.Warnf("DatadogInstrumentation CRD missing (attempt=%d): will retry", attempt)
+			} else {
+				log.Warnf("DatadogInstrumentation CRD check failed transiently (attempt=%d): %v: will retry", attempt, err)
+			}
 		}
 		return nil, err
 	}, backoff.WithBackOff(exp), backoff.WithMaxElapsedTime(crdCheckMaxElapsedTime))

--- a/pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go
@@ -53,7 +53,7 @@ func waitForInstrumentationCRD(ctx context.Context, dynamicClient dynamic.Interf
 	exp.Reset()
 
 	check := func() error {
-		_, err := dynamicClient.Resource(instrumentation.DatadogInstrumentationGVR).List(context.TODO(), metav1.ListOptions{})
+		_, err := dynamicClient.Resource(instrumentation.DatadogInstrumentationGVR).List(ctx, metav1.ListOptions{})
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do?

Adds a wait mechanism before starting the DatadogInstrumentation CRD (DDI) controller in case the CRD isn't installed on the cluster despite `instrumentation_crd_controller.enabled` being enabled. The wait uses an indefinite retry-backoff mechanism that's similar to autoscaling's WPA CRD wait mechanism.

### Motivation

We plan on turning on `instrumentation_crd_controller.enabled` by default and need to ensure the cluster agent operates fine in cases where the CRD hasn't been properly installed in the cluster. This wait mechanism handles that by waiting and should avoid any interruptions to the cluster agent's operation.

### Describe how you validated your changes

1. Deployed cluster agent with `DD` on a cluster without the `DatadogInstrumentation` CRD
2. Checked logs for wait attempts
3. Installed DDI crd
4. Checked logs for controller stop.

```
2026-06-04 17:31:45 UTC | CLUSTER | WARN | (pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go:58 in func2) | DatadogInstrumentation CRD missing (attempt=2): will retry                                                                                │
│ 2026-06-04 17:31:55 UTC | CLUSTER | WARN | (pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go:58 in func2) | DatadogInstrumentation CRD missing (attempt=3): will retry                                                                                │
│ 2026-06-04 17:32:15 UTC | CLUSTER | WARN | (pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go:58 in func2) | DatadogInstrumentation CRD missing (attempt=4): will retry                                                                                │
│ 2026-06-04 17:32:55 UTC | CLUSTER | WARN | (pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go:58 in func2) | DatadogInstrumentation CRD missing (attempt=5): will retry                                                                                │
│ 2026-06-04 17:34:15 UTC | CLUSTER | WARN | (pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go:58 in func2) | DatadogInstrumentation CRD missing (attempt=6): will retry                                                                                │
│ 2026-06-04 17:36:55 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/controllers/instrumentation_controller.go:35 in tryCheckInstrumentationCRD) | DatadogInstrumentation CRD check successful                                                                          │
│ 2026-06-04 17:36:55 UTC | CLUSTER | INFO | (pkg/clusteragent/instrumentation/controller.go:69 in Run) | Starting DatadogInstrumentation Controller (waiting for cache sync)                                                                                                  │
│ 2026-06-04 17:36:55 UTC | CLUSTER | INFO | (pkg/clusteragent/instrumentation/controller.go:77 in Run) | Started DatadogInstrumentation Controller (cache sync finished)
```

### Additional Notes
