### PR TITLE
Bump DCA sgc

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -47,10 +47,10 @@ static_quality_gate_docker_agent_jmx_arm64:
   max_on_disk_size: 989.8 MiB
   max_on_wire_size: 326.22 MiB
 static_quality_gate_docker_cluster_agent_amd64:
-  max_on_disk_size: 207.71 MiB
+  max_on_disk_size: 208.52 MiB
   max_on_wire_size: 73.5 MiB
 static_quality_gate_docker_cluster_agent_arm64:
-  max_on_disk_size: 221.21 MiB
+  max_on_disk_size: 221.85 MiB
   max_on_wire_size: 68.73 MiB
 static_quality_gate_docker_cws_instrumentation_amd64:
   max_on_disk_size: 7.19 MiB


### PR DESCRIPTION
### What does this PR do?

Bump SGC on DCA to counteract increase from new DatadogInstrumentation CRD handler feature: https://github.com/DataDog/datadog-agent/pull/50206.

Note: no new external dependencies were included, just update of the Datadog Operator dep and code for the handlers
