### PR TITLE
[CONTP-1460] Optimize object allocation in orchestrator process lifecycle

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/processors/common/base.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/common/base.go
@@ -17,7 +17,7 @@ import (
 type BaseHandlers struct{}
 
 //nolint:revive // TODO(CAPP) Fix revive linter
-func (BaseHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (BaseHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	return
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/common/base.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/common/base.go
@@ -34,6 +34,24 @@ func (BaseHandlers) BuildManifestMessageBody(ctx processors.ProcessorContext, re
 	return ExtractModelManifests(ctx, resourceManifests, groupSize)
 }
 
+// CloneResource returns the resource unchanged. Handlers that mutate resources
+// during ScrubBeforeExtraction, BeforeMarshalling, or ScrubBeforeMarshalling
+// must override this to return a deep copy so the informer cache is not corrupted.
+//
+//nolint:revive
+func (BaseHandlers) CloneResource(resource interface{}) interface{} {
+	return resource
+}
+
+// ResourceVersionFromRaw returns an empty string, indicating that the resource
+// version cannot be determined without model extraction. Override in handlers
+// where the version is directly available from the raw resource.
+//
+//nolint:revive
+func (BaseHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, _ interface{}) string {
+	return ""
+}
+
 //nolint:revive // TODO(CAPP) Fix revive linter
 func (BaseHandlers) GetNodeName(ctx processors.ProcessorContext, resource interface{}) string {
 	return ""

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go
@@ -35,10 +35,10 @@ func NewClusterRoleHandlers(tagger tagger.Component) *ClusterRoleHandlers {
 	return &ClusterRoleHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *ClusterRoleHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *ClusterRoleHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*rbacv1.ClusterRole)
 	m := resourceModel.(*model.ClusterRole)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go
@@ -113,10 +113,24 @@ func (h *ClusterRoleHandlers) ResourceList(ctx processors.ProcessorContext, list
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *ClusterRoleHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*rbacv1.ClusterRole).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *ClusterRoleHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*rbacv1.ClusterRole).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole_test.go
@@ -114,16 +114,16 @@ func TestClusterRoleHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*rbacv1.ClusterRole)
 	assert.True(t, ok)
 	assert.Equal(t, "clusterrole-1", resource1.Name)
-	assert.NotSame(t, clusterRole1, resource1) // Should be a copy
+	assert.Same(t, clusterRole1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*rbacv1.ClusterRole)
 	assert.True(t, ok)
 	assert.Equal(t, "clusterrole-2", resource2.Name)
-	assert.NotSame(t, clusterRole2, resource2) // Should be a copy
+	assert.Same(t, clusterRole2, resource2) // ResourceList returns raw informer references
 }
 
 func TestClusterRoleHandlers_ResourceUID(t *testing.T) {
@@ -423,4 +423,14 @@ func createTestClusterRole(name, namespace string) *rbacv1.ClusterRole {
 			},
 		},
 	}
+}
+
+func TestClusterRoleHandlers_CloneResource(t *testing.T) {
+	handlers := &ClusterRoleHandlers{}
+	original := createTestClusterRole("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*rbacv1.ClusterRole)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole_test.go
@@ -46,7 +46,7 @@ func TestClusterRoleHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewClusterRoleHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding.go
@@ -114,10 +114,24 @@ func (h *ClusterRoleBindingHandlers) ResourceList(ctx processors.ProcessorContex
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *ClusterRoleBindingHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*rbacv1.ClusterRoleBinding).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *ClusterRoleBindingHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*rbacv1.ClusterRoleBinding).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding.go
@@ -36,10 +36,10 @@ func NewClusterRoleBindingHandlers(tagger tagger.Component) *ClusterRoleBindingH
 	return &ClusterRoleBindingHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *ClusterRoleBindingHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *ClusterRoleBindingHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*rbacv1.ClusterRoleBinding)
 	m := resourceModel.(*model.ClusterRoleBinding)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding_test.go
@@ -114,16 +114,16 @@ func TestClusterRoleBindingHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*rbacv1.ClusterRoleBinding)
 	assert.True(t, ok)
 	assert.Equal(t, "clusterrolebinding-1", resource1.Name)
-	assert.NotSame(t, clusterRoleBinding1, resource1) // Should be a copy
+	assert.Same(t, clusterRoleBinding1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*rbacv1.ClusterRoleBinding)
 	assert.True(t, ok)
 	assert.Equal(t, "clusterrolebinding-2", resource2.Name)
-	assert.NotSame(t, clusterRoleBinding2, resource2) // Should be a copy
+	assert.Same(t, clusterRoleBinding2, resource2) // ResourceList returns raw informer references
 }
 
 func TestClusterRoleBindingHandlers_ResourceUID(t *testing.T) {
@@ -417,4 +417,14 @@ func createTestClusterRoleBinding(name, namespace string) *rbacv1.ClusterRoleBin
 			},
 		},
 	}
+}
+
+func TestClusterRoleBindingHandlers_CloneResource(t *testing.T) {
+	handlers := &ClusterRoleBindingHandlers{}
+	original := createTestClusterRoleBinding("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*rbacv1.ClusterRoleBinding)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding_test.go
@@ -46,7 +46,7 @@ func TestClusterRoleBindingHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewClusterRoleBindingHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cr.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cr.go
@@ -72,10 +72,24 @@ func (cr *CRHandlers) ResourceList(ctx processors.ProcessorContext, list interfa
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopyObject())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (cr *CRHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*unstructured.Unstructured).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (cr *CRHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*unstructured.Unstructured).GetResourceVersion()
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cr_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cr_test.go
@@ -55,16 +55,16 @@ func TestCRHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*unstructured.Unstructured)
 	assert.True(t, ok)
 	assert.Equal(t, "cr-1", resource1.GetName())
-	assert.NotSame(t, cr1, resource1) // Should be a copy
+	assert.Same(t, cr1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*unstructured.Unstructured)
 	assert.True(t, ok)
 	assert.Equal(t, "cr-2", resource2.GetName())
-	assert.NotSame(t, cr2, resource2) // Should be a copy
+	assert.Same(t, cr2, resource2) // ResourceList returns raw informer references
 }
 
 func TestCRHandlers_ResourceUID(t *testing.T) {
@@ -367,4 +367,14 @@ func createTestCustomResource(name, namespace string) *unstructured.Unstructured
 			},
 		},
 	}
+}
+
+func TestCRHandlers_CloneResource(t *testing.T) {
+	handlers := &CRHandlers{}
+	original := createTestCustomResource("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*unstructured.Unstructured)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/crd.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/crd.go
@@ -77,10 +77,24 @@ func (crd *CRDHandlers) ResourceList(ctx processors.ProcessorContext, list inter
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopyObject())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (crd *CRDHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*v1.CustomResourceDefinition).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (crd *CRDHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*v1.CustomResourceDefinition).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/crd_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/crd_test.go
@@ -55,16 +55,16 @@ func TestCRDHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*v1.CustomResourceDefinition)
 	assert.True(t, ok)
 	assert.Equal(t, "crd-1", resource1.Name)
-	assert.NotSame(t, crd1, resource1) // Should be a copy
+	assert.Same(t, crd1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*v1.CustomResourceDefinition)
 	assert.True(t, ok)
 	assert.Equal(t, "crd-2", resource2.Name)
-	assert.NotSame(t, crd2, resource2) // Should be a copy
+	assert.Same(t, crd2, resource2) // ResourceList returns raw informer references
 }
 
 func TestCRDHandlers_ResourceUID(t *testing.T) {
@@ -400,4 +400,14 @@ func createTestCustomResourceDefinition(name string) *v1.CustomResourceDefinitio
 			},
 		},
 	}
+}
+
+func TestCRDHandlers_CloneResource(t *testing.T) {
+	handlers := &CRDHandlers{}
+	original := createTestCustomResourceDefinition("test")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*v1.CustomResourceDefinition)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
@@ -35,10 +35,10 @@ func NewCronJobV1Handlers(tagger tagger.Component) *CronJobV1Handlers {
 	return &CronJobV1Handlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *CronJobV1Handlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *CronJobV1Handlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*batchv1.CronJob)
 	m := resourceModel.(*model.CronJob)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
@@ -113,10 +113,24 @@ func (h *CronJobV1Handlers) ResourceList(ctx processors.ProcessorContext, list i
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *CronJobV1Handlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*batchv1.CronJob).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *CronJobV1Handlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*batchv1.CronJob).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1_test.go
@@ -49,7 +49,7 @@ func TestCronJobV1Handlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewCronJobV1Handlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1_test.go
@@ -117,16 +117,16 @@ func TestCronJobV1Handlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*batchv1.CronJob)
 	assert.True(t, ok)
 	assert.Equal(t, "cronjob-1", resource1.Name)
-	assert.NotSame(t, cronJob1, resource1) // Should be a copy
+	assert.Same(t, cronJob1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*batchv1.CronJob)
 	assert.True(t, ok)
 	assert.Equal(t, "cronjob-2", resource2.Name)
-	assert.NotSame(t, cronJob2, resource2) // Should be a copy
+	assert.Same(t, cronJob2, resource2) // ResourceList returns raw informer references
 }
 
 func TestCronJobV1Handlers_ResourceUID(t *testing.T) {
@@ -440,4 +440,14 @@ func createTestCronJobV1(name, namespace string) *batchv1.CronJob {
 			LastSuccessfulTime: &lastSuccessfulTime,
 		},
 	}
+}
+
+func TestCronJobV1Handlers_CloneResource(t *testing.T) {
+	handlers := &CronJobV1Handlers{}
+	original := createTestCronJobV1("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*batchv1.CronJob)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
@@ -36,10 +36,10 @@ func NewCronJobV1Beta1Handlers(tagger tagger.Component) *CronJobV1Beta1Handlers 
 	return &CronJobV1Beta1Handlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *CronJobV1Beta1Handlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *CronJobV1Beta1Handlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*batchv1beta1.CronJob)
 	m := resourceModel.(*model.CronJob)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
@@ -114,10 +114,24 @@ func (h *CronJobV1Beta1Handlers) ResourceList(ctx processors.ProcessorContext, l
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *CronJobV1Beta1Handlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*batchv1beta1.CronJob).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *CronJobV1Beta1Handlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*batchv1beta1.CronJob).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1_test.go
@@ -118,16 +118,16 @@ func TestCronJobV1Beta1Handlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*batchv1beta1.CronJob)
 	assert.True(t, ok)
 	assert.Equal(t, "cronjob-1", resource1.Name)
-	assert.NotSame(t, cronJob1, resource1) // Should be a copy
+	assert.Same(t, cronJob1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*batchv1beta1.CronJob)
 	assert.True(t, ok)
 	assert.Equal(t, "cronjob-2", resource2.Name)
-	assert.NotSame(t, cronJob2, resource2) // Should be a copy
+	assert.Same(t, cronJob2, resource2) // ResourceList returns raw informer references
 }
 
 func TestCronJobV1Beta1Handlers_ResourceUID(t *testing.T) {
@@ -441,4 +441,14 @@ func createTestCronJobV1Beta1(name, namespace string) *batchv1beta1.CronJob {
 			LastSuccessfulTime: &lastSuccessfulTime,
 		},
 	}
+}
+
+func TestCronJobV1Beta1Handlers_CloneResource(t *testing.T) {
+	handlers := &CronJobV1Beta1Handlers{}
+	original := createTestCronJobV1Beta1("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*batchv1beta1.CronJob)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1_test.go
@@ -50,7 +50,7 @@ func TestCronJobV1Beta1Handlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewCronJobV1Beta1Handlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
@@ -114,10 +114,24 @@ func (h *DaemonSetHandlers) ResourceList(ctx processors.ProcessorContext, list i
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *DaemonSetHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*appsv1.DaemonSet).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *DaemonSetHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*appsv1.DaemonSet).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
@@ -36,10 +36,10 @@ func NewDaemonSetHandlers(tagger tagger.Component) *DaemonSetHandlers {
 	return &DaemonSetHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *DaemonSetHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *DaemonSetHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*appsv1.DaemonSet)
 	m := resourceModel.(*model.DaemonSet)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset_test.go
@@ -49,7 +49,7 @@ func TestDaemonSetHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewDaemonSetHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset_test.go
@@ -117,16 +117,16 @@ func TestDaemonSetHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*appsv1.DaemonSet)
 	assert.True(t, ok)
 	assert.Equal(t, "daemonset-1", resource1.Name)
-	assert.NotSame(t, daemonSet1, resource1) // Should be a copy
+	assert.Same(t, daemonSet1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*appsv1.DaemonSet)
 	assert.True(t, ok)
 	assert.Equal(t, "daemonset-2", resource2.Name)
-	assert.NotSame(t, daemonSet2, resource2) // Should be a copy
+	assert.Same(t, daemonSet2, resource2) // ResourceList returns raw informer references
 }
 
 func TestDaemonSetHandlers_ResourceUID(t *testing.T) {
@@ -442,4 +442,14 @@ func createTestDaemonSet(name, namespace string) *appsv1.DaemonSet {
 			},
 		},
 	}
+}
+
+func TestDaemonSetHandlers_CloneResource(t *testing.T) {
+	handlers := &DaemonSetHandlers{}
+	original := createTestDaemonSet("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*appsv1.DaemonSet)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
@@ -35,10 +35,10 @@ func NewDeploymentHandlers(tagger tagger.Component) *DeploymentHandlers {
 	return &DeploymentHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *DeploymentHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *DeploymentHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*appsv1.Deployment)
 	m := resourceModel.(*model.Deployment)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
@@ -110,10 +110,24 @@ func (h *DeploymentHandlers) ResourceList(ctx processors.ProcessorContext, list 
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *DeploymentHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*appsv1.Deployment).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *DeploymentHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*appsv1.Deployment).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment_test.go
@@ -116,16 +116,16 @@ func TestDeploymentHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*appsv1.Deployment)
 	assert.True(t, ok)
 	assert.Equal(t, "deployment-1", resource1.Name)
-	assert.NotSame(t, deployment1, resource1) // Should be a copy
+	assert.Same(t, deployment1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*appsv1.Deployment)
 	assert.True(t, ok)
 	assert.Equal(t, "deployment-2", resource2.Name)
-	assert.NotSame(t, deployment2, resource2) // Should be a copy
+	assert.Same(t, deployment2, resource2) // ResourceList returns raw informer references
 }
 
 func TestDeploymentHandlers_ResourceUID(t *testing.T) {
@@ -466,4 +466,14 @@ func createTestDeployment(name, namespace string) *appsv1.Deployment {
 			},
 		},
 	}
+}
+
+func TestDeploymentHandlers_CloneResource(t *testing.T) {
+	handlers := &DeploymentHandlers{}
+	original := createTestDeployment("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*appsv1.Deployment)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment_test.go
@@ -48,7 +48,7 @@ func TestDeploymentHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewDeploymentHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler.go
@@ -113,10 +113,24 @@ func (h *HorizontalPodAutoscalerHandlers) ResourceList(ctx processors.ProcessorC
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *HorizontalPodAutoscalerHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*v2.HorizontalPodAutoscaler).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *HorizontalPodAutoscalerHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*v2.HorizontalPodAutoscaler).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler.go
@@ -35,10 +35,10 @@ func NewHorizontalPodAutoscalerHandlers(tagger tagger.Component) *HorizontalPodA
 	return &HorizontalPodAutoscalerHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *HorizontalPodAutoscalerHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *HorizontalPodAutoscalerHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*v2.HorizontalPodAutoscaler)
 	m := resourceModel.(*model.HorizontalPodAutoscaler)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler_test.go
@@ -117,16 +117,16 @@ func TestHorizontalPodAutoscalerHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*v2.HorizontalPodAutoscaler)
 	assert.True(t, ok)
 	assert.Equal(t, "hpa-1", resource1.Name)
-	assert.NotSame(t, hpa1, resource1) // Should be a copy
+	assert.Same(t, hpa1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*v2.HorizontalPodAutoscaler)
 	assert.True(t, ok)
 	assert.Equal(t, "hpa-2", resource2.Name)
-	assert.NotSame(t, hpa2, resource2) // Should be a copy
+	assert.Same(t, hpa2, resource2) // ResourceList returns raw informer references
 }
 
 func TestHorizontalPodAutoscalerHandlers_ResourceUID(t *testing.T) {
@@ -547,4 +547,14 @@ func createTestHorizontalPodAutoscaler(name, namespace string) *v2.HorizontalPod
 			},
 		},
 	}
+}
+
+func TestHorizontalPodAutoscalerHandlers_CloneResource(t *testing.T) {
+	handlers := &HorizontalPodAutoscalerHandlers{}
+	original := createTestHorizontalPodAutoscaler("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*v2.HorizontalPodAutoscaler)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler_test.go
@@ -49,7 +49,7 @@ func TestHorizontalPodAutoscalerHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewHorizontalPodAutoscalerHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
@@ -114,10 +114,24 @@ func (h *IngressHandlers) ResourceList(ctx processors.ProcessorContext, list int
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *IngressHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*netv1.Ingress).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *IngressHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*netv1.Ingress).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
@@ -36,10 +36,10 @@ func NewIngressHandlers(tagger tagger.Component) *IngressHandlers {
 	return &IngressHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *IngressHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *IngressHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*netv1.Ingress)
 	m := resourceModel.(*model.Ingress)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress_test.go
@@ -117,16 +117,16 @@ func TestIngressHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*netv1.Ingress)
 	assert.True(t, ok)
 	assert.Equal(t, "ingress-1", resource1.Name)
-	assert.NotSame(t, ingress1, resource1) // Should be a copy
+	assert.Same(t, ingress1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*netv1.Ingress)
 	assert.True(t, ok)
 	assert.Equal(t, "ingress-2", resource2.Name)
-	assert.NotSame(t, ingress2, resource2) // Should be a copy
+	assert.Same(t, ingress2, resource2) // ResourceList returns raw informer references
 }
 
 func TestIngressHandlers_ResourceUID(t *testing.T) {
@@ -492,4 +492,14 @@ func createTestIngress(name, namespace string) *netv1.Ingress {
 			},
 		},
 	}
+}
+
+func TestIngressHandlers_CloneResource(t *testing.T) {
+	handlers := &IngressHandlers{}
+	original := createTestIngress("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*netv1.Ingress)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress_test.go
@@ -49,7 +49,7 @@ func TestIngressHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewIngressHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
@@ -114,10 +114,24 @@ func (h *JobHandlers) ResourceList(ctx processors.ProcessorContext, list interfa
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *JobHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*batchv1.Job).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *JobHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*batchv1.Job).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
@@ -36,10 +36,10 @@ func NewJobHandlers(tagger tagger.Component) *JobHandlers {
 	return &JobHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *JobHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *JobHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*batchv1.Job)
 	m := resourceModel.(*model.Job)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job_test.go
@@ -118,16 +118,16 @@ func TestJobHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*batchv1.Job)
 	assert.True(t, ok)
 	assert.Equal(t, "job-1", resource1.Name)
-	assert.NotSame(t, job1, resource1) // Should be a copy
+	assert.Same(t, job1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*batchv1.Job)
 	assert.True(t, ok)
 	assert.Equal(t, "job-2", resource2.Name)
-	assert.NotSame(t, job2, resource2) // Should be a copy
+	assert.Same(t, job2, resource2) // ResourceList returns raw informer references
 }
 
 func TestJobHandlers_ResourceUID(t *testing.T) {
@@ -484,4 +484,14 @@ func createTestJob(name, namespace string) *batchv1.Job {
 			},
 		},
 	}
+}
+
+func TestJobHandlers_CloneResource(t *testing.T) {
+	handlers := &JobHandlers{}
+	original := createTestJob("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*batchv1.Job)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job_test.go
@@ -50,7 +50,7 @@ func TestJobHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewJobHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/limitrange.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/limitrange.go
@@ -37,10 +37,10 @@ func NewLimitRangeHandlers(tagger tagger.Component) *LimitRangeHandlers {
 	return &LimitRangeHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *LimitRangeHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *LimitRangeHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*corev1.LimitRange)
 	m := resourceModel.(*model.LimitRange)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/limitrange.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/limitrange.go
@@ -113,10 +113,24 @@ func (h *LimitRangeHandlers) ResourceList(ctx processors.ProcessorContext, list 
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *LimitRangeHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*corev1.LimitRange).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *LimitRangeHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*corev1.LimitRange).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/limitrange_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/limitrange_test.go
@@ -48,7 +48,7 @@ func TestLimitRangeHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewLimitRangeHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/limitrange_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/limitrange_test.go
@@ -118,16 +118,16 @@ func TestLimitRangeHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*corev1.LimitRange)
 	assert.True(t, ok)
 	assert.Equal(t, "limitrange-1", resource1.Name)
-	assert.NotSame(t, limitRange1, resource1) // Should be a copy
+	assert.Same(t, limitRange1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*corev1.LimitRange)
 	assert.True(t, ok)
 	assert.Equal(t, "limitrange-2", resource2.Name)
-	assert.NotSame(t, limitRange2, resource2) // Should be a copy
+	assert.Same(t, limitRange2, resource2) // ResourceList returns raw informer references
 }
 
 func TestLimitRangeHandlers_ResourceUID(t *testing.T) {
@@ -440,4 +440,14 @@ func createTestLimitRange(name, namespace string) *corev1.LimitRange {
 			},
 		},
 	}
+}
+
+func TestLimitRangeHandlers_CloneResource(t *testing.T) {
+	handlers := &LimitRangeHandlers{}
+	original := createTestLimitRange("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*corev1.LimitRange)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace.go
@@ -115,10 +115,24 @@ func (h *NamespaceHandlers) ResourceList(ctx processors.ProcessorContext, list i
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *NamespaceHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*corev1.Namespace).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *NamespaceHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*corev1.Namespace).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace.go
@@ -37,10 +37,10 @@ func NewNamespaceHandlers(tagger tagger.Component) *NamespaceHandlers {
 	return &NamespaceHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *NamespaceHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *NamespaceHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*corev1.Namespace)
 	m := resourceModel.(*model.Namespace)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace_test.go
@@ -46,7 +46,7 @@ func TestNamespaceHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewNamespaceHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace_test.go
@@ -113,16 +113,16 @@ func TestNamespaceHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*corev1.Namespace)
 	assert.True(t, ok)
 	assert.Equal(t, "namespace-1", resource1.Name)
-	assert.NotSame(t, namespace1, resource1) // Should be a copy
+	assert.Same(t, namespace1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*corev1.Namespace)
 	assert.True(t, ok)
 	assert.Equal(t, "namespace-2", resource2.Name)
-	assert.NotSame(t, namespace2, resource2) // Should be a copy
+	assert.Same(t, namespace2, resource2) // ResourceList returns raw informer references
 }
 
 func TestNamespaceHandlers_ResourceUID(t *testing.T) {
@@ -416,4 +416,14 @@ func createTestNamespace(name string) *corev1.Namespace {
 			},
 		},
 	}
+}
+
+func TestNamespaceHandlers_CloneResource(t *testing.T) {
+	handlers := &NamespaceHandlers{}
+	original := createTestNamespace("test")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*corev1.Namespace)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy.go
@@ -35,10 +35,10 @@ func NewNetworkPolicyHandlers(tagger tagger.Component) *NetworkPolicyHandlers {
 	return &NetworkPolicyHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *NetworkPolicyHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *NetworkPolicyHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*netv1.NetworkPolicy)
 	m := resourceModel.(*model.NetworkPolicy)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy.go
@@ -113,10 +113,24 @@ func (h *NetworkPolicyHandlers) ResourceList(ctx processors.ProcessorContext, li
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *NetworkPolicyHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*netv1.NetworkPolicy).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *NetworkPolicyHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*netv1.NetworkPolicy).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy_test.go
@@ -118,16 +118,16 @@ func TestNetworkPolicyHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*networkingv1.NetworkPolicy)
 	assert.True(t, ok)
 	assert.Equal(t, "networkpolicy-1", resource1.Name)
-	assert.NotSame(t, networkPolicy1, resource1) // Should be a copy
+	assert.Same(t, networkPolicy1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*networkingv1.NetworkPolicy)
 	assert.True(t, ok)
 	assert.Equal(t, "networkpolicy-2", resource2.Name)
-	assert.NotSame(t, networkPolicy2, resource2) // Should be a copy
+	assert.Same(t, networkPolicy2, resource2) // ResourceList returns raw informer references
 }
 
 func TestNetworkPolicyHandlers_ResourceUID(t *testing.T) {
@@ -426,4 +426,14 @@ func createTestNetworkPolicy(name, namespace string) *networkingv1.NetworkPolicy
 			},
 		},
 	}
+}
+
+func TestNetworkPolicyHandlers_CloneResource(t *testing.T) {
+	handlers := &NetworkPolicyHandlers{}
+	original := createTestNetworkPolicy("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*networkingv1.NetworkPolicy)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy_test.go
@@ -50,7 +50,7 @@ func TestNetworkPolicyHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewNetworkPolicyHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
@@ -114,10 +114,24 @@ func (h *NodeHandlers) ResourceList(ctx processors.ProcessorContext, list interf
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *NodeHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*corev1.Node).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *NodeHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*corev1.Node).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
@@ -36,10 +36,10 @@ func NewNodeHandlers(tagger tagger.Component) *NodeHandlers {
 	return &NodeHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *NodeHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *NodeHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*corev1.Node)
 	m := resourceModel.(*model.Node)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node_test.go
@@ -116,16 +116,16 @@ func TestNodeHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*corev1.Node)
 	assert.True(t, ok)
 	assert.Equal(t, "node-1", resource1.Name)
-	assert.NotSame(t, node1, resource1) // Should be a copy
+	assert.Same(t, node1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*corev1.Node)
 	assert.True(t, ok)
 	assert.Equal(t, "node-2", resource2.Name)
-	assert.NotSame(t, node2, resource2) // Should be a copy
+	assert.Same(t, node2, resource2) // ResourceList returns raw informer references
 }
 
 func TestNodeHandlers_ResourceUID(t *testing.T) {
@@ -476,4 +476,14 @@ func createTestNode(name, namespace string) *corev1.Node {
 			},
 		},
 	}
+}
+
+func TestNodeHandlers_CloneResource(t *testing.T) {
+	handlers := &NodeHandlers{}
+	original := createTestNode("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*corev1.Node)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node_test.go
@@ -48,7 +48,7 @@ func TestNodeHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewNodeHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
@@ -36,10 +36,10 @@ func NewPersistentVolumeHandlers(tagger tagger.Component) *PersistentVolumeHandl
 	return &PersistentVolumeHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *PersistentVolumeHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *PersistentVolumeHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*corev1.PersistentVolume)
 	m := resourceModel.(*model.PersistentVolume)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
@@ -114,10 +114,24 @@ func (h *PersistentVolumeHandlers) ResourceList(ctx processors.ProcessorContext,
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *PersistentVolumeHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*corev1.PersistentVolume).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *PersistentVolumeHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*corev1.PersistentVolume).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume_test.go
@@ -117,16 +117,16 @@ func TestPersistentVolumeHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*corev1.PersistentVolume)
 	assert.True(t, ok)
 	assert.Equal(t, "test-pv", resource1.Name)
-	assert.NotSame(t, pv1, resource1) // Should be a copy
+	assert.Same(t, pv1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*corev1.PersistentVolume)
 	assert.True(t, ok)
 	assert.Equal(t, "pv2", resource2.Name)
-	assert.NotSame(t, pv2, resource2) // Should be a copy
+	assert.Same(t, pv2, resource2) // ResourceList returns raw informer references
 }
 
 func TestPersistentVolumeHandlers_ResourceUID(t *testing.T) {
@@ -446,4 +446,14 @@ func createTestPersistentVolume() *corev1.PersistentVolume {
 			Reason:  "test",
 		},
 	}
+}
+
+func TestPersistentVolumeHandlers_CloneResource(t *testing.T) {
+	handlers := &PersistentVolumeHandlers{}
+	original := createTestPersistentVolume()
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*corev1.PersistentVolume)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume_test.go
@@ -47,7 +47,7 @@ func TestPersistentVolumeHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewPersistentVolumeHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
@@ -36,10 +36,10 @@ func NewPersistentVolumeClaimHandlers(tagger tagger.Component) *PersistentVolume
 	return &PersistentVolumeClaimHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *PersistentVolumeClaimHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *PersistentVolumeClaimHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*corev1.PersistentVolumeClaim)
 	m := resourceModel.(*model.PersistentVolumeClaim)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
@@ -114,10 +114,24 @@ func (h *PersistentVolumeClaimHandlers) ResourceList(ctx processors.ProcessorCon
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *PersistentVolumeClaimHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*corev1.PersistentVolumeClaim).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *PersistentVolumeClaimHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*corev1.PersistentVolumeClaim).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim_test.go
@@ -119,16 +119,16 @@ func TestPersistentVolumeClaimHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*corev1.PersistentVolumeClaim)
 	assert.True(t, ok)
 	assert.Equal(t, "test-pvc", resource1.Name)
-	assert.NotSame(t, pvc1, resource1) // Should be a copy
+	assert.Same(t, pvc1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*corev1.PersistentVolumeClaim)
 	assert.True(t, ok)
 	assert.Equal(t, "pvc2", resource2.Name)
-	assert.NotSame(t, pvc2, resource2) // Should be a copy
+	assert.Same(t, pvc2, resource2) // ResourceList returns raw informer references
 }
 
 func TestPersistentVolumeClaimHandlers_ResourceUID(t *testing.T) {
@@ -430,4 +430,14 @@ func createTestPersistentVolumeClaim() *corev1.PersistentVolumeClaim {
 			},
 		},
 	}
+}
+
+func TestPersistentVolumeClaimHandlers_CloneResource(t *testing.T) {
+	handlers := &PersistentVolumeClaimHandlers{}
+	original := createTestPersistentVolumeClaim()
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*corev1.PersistentVolumeClaim)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim_test.go
@@ -49,7 +49,7 @@ func TestPersistentVolumeClaimHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewPersistentVolumeClaimHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -68,8 +68,8 @@ func (h *PodHandlers) BeforeMarshalling(ctx processors.ProcessorContext, resourc
 	return
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
-func (h *PodHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+// EnrichModel is a handler called before cache lookup.
+func (h *PodHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	pctx := ctx.(*processors.K8sProcessorContext)
 	r := resource.(*corev1.Pod)
 	m := resourceModel.(*model.Pod)

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -158,10 +158,26 @@ func (h *PodHandlers) ResourceList(ctx processors.ProcessorContext, list interfa
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *PodHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*corev1.Pod).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns an empty string because Pod uses a custom
+// resource version hash computed from the extracted model, not the native
+// Kubernetes ResourceVersion.
+//
+//nolint:revive
+func (h *PodHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, _ interface{}) string {
+	return ""
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod_test.go
@@ -100,16 +100,16 @@ func TestPodHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*corev1.Pod)
 	assert.True(t, ok)
 	assert.Equal(t, "pod-1", resource1.Name)
-	assert.NotSame(t, pod1, resource1) // Should be a copy
+	assert.Same(t, pod1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*corev1.Pod)
 	assert.True(t, ok)
 	assert.Equal(t, "pod-2", resource2.Name)
-	assert.NotSame(t, pod2, resource2) // Should be a copy
+	assert.Same(t, pod2, resource2) // ResourceList returns raw informer references
 }
 
 func TestPodHandlers_ResourceUID(t *testing.T) {
@@ -476,4 +476,14 @@ func createTestPod(name, namespace string) *corev1.Pod {
 			},
 		},
 	}
+}
+
+func TestPodHandlers_CloneResource(t *testing.T) {
+	handlers := &PodHandlers{}
+	original := createTestPod("test", "ns")
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*corev1.Pod)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/poddisruptionbudget.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/poddisruptionbudget.go
@@ -105,10 +105,20 @@ func (h *PodDisruptionBudgetHandlers) ResourceList(_ processors.ProcessorContext
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+func (h *PodDisruptionBudgetHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*policyv1.PodDisruptionBudget).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+func (h *PodDisruptionBudgetHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*policyv1.PodDisruptionBudget).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/poddisruptionbudget.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/poddisruptionbudget.go
@@ -35,10 +35,10 @@ func NewPodDisruptionBudgetHandlers(tagger tagger.Component) *PodDisruptionBudge
 	return &PodDisruptionBudgetHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *PodDisruptionBudgetHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *PodDisruptionBudgetHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*policyv1.PodDisruptionBudget)
 	m := resourceModel.(*model.PodDisruptionBudget)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/poddisruptionbudget_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/poddisruptionbudget_test.go
@@ -118,16 +118,16 @@ func TestPodDisruptionBudgetHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*policyv1.PodDisruptionBudget)
 	assert.True(t, ok)
 	assert.Equal(t, "test-pdb", resource1.Name)
-	assert.NotSame(t, pdb1, resource1) // Should be a copy
+	assert.Same(t, pdb1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*policyv1.PodDisruptionBudget)
 	assert.True(t, ok)
 	assert.Equal(t, "pdb2", resource2.Name)
-	assert.NotSame(t, pdb2, resource2) // Should be a copy
+	assert.Same(t, pdb2, resource2) // ResourceList returns raw informer references
 }
 
 func TestPodDisruptionBudgetHandlers_ResourceUID(t *testing.T) {
@@ -426,4 +426,14 @@ func createTestPodDisruptionBudget() *policyv1.PodDisruptionBudget {
 			},
 		},
 	}
+}
+
+func TestPodDisruptionBudgetHandlers_CloneResource(t *testing.T) {
+	handlers := &PodDisruptionBudgetHandlers{}
+	original := createTestPodDisruptionBudget()
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*policyv1.PodDisruptionBudget)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/poddisruptionbudget_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/poddisruptionbudget_test.go
@@ -48,7 +48,7 @@ func TestPodDisruptionBudgetHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewPodDisruptionBudgetHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
@@ -36,10 +36,10 @@ func NewReplicaSetHandlers(tagger tagger.Component) *ReplicaSetHandlers {
 	return &ReplicaSetHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *ReplicaSetHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *ReplicaSetHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*appsv1.ReplicaSet)
 	m := resourceModel.(*model.ReplicaSet)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
@@ -114,10 +114,24 @@ func (h *ReplicaSetHandlers) ResourceList(ctx processors.ProcessorContext, list 
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *ReplicaSetHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*appsv1.ReplicaSet).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *ReplicaSetHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*appsv1.ReplicaSet).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset_test.go
@@ -49,7 +49,7 @@ func TestReplicaSetHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewReplicaSetHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset_test.go
@@ -119,16 +119,16 @@ func TestReplicaSetHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*appsv1.ReplicaSet)
 	assert.True(t, ok)
 	assert.Equal(t, "test-rs", resource1.Name)
-	assert.NotSame(t, rs1, resource1) // Should be a copy
+	assert.Same(t, rs1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*appsv1.ReplicaSet)
 	assert.True(t, ok)
 	assert.Equal(t, "rs2", resource2.Name)
-	assert.NotSame(t, rs2, resource2) // Should be a copy
+	assert.Same(t, rs2, resource2) // ResourceList returns raw informer references
 }
 
 func TestReplicaSetHandlers_ResourceUID(t *testing.T) {
@@ -457,4 +457,14 @@ func createTestReplicaSet() *appsv1.ReplicaSet {
 			},
 		},
 	}
+}
+
+func TestReplicaSetHandlers_CloneResource(t *testing.T) {
+	handlers := &ReplicaSetHandlers{}
+	original := createTestReplicaSet()
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*appsv1.ReplicaSet)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
@@ -36,10 +36,10 @@ func NewRoleHandlers(tagger tagger.Component) *RoleHandlers {
 	return &RoleHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *RoleHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *RoleHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*rbacv1.Role)
 	m := resourceModel.(*model.Role)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
@@ -114,10 +114,24 @@ func (h *RoleHandlers) ResourceList(ctx processors.ProcessorContext, list interf
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *RoleHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*rbacv1.Role).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *RoleHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*rbacv1.Role).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role_test.go
@@ -47,7 +47,7 @@ func TestRoleHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewRoleHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role_test.go
@@ -117,16 +117,16 @@ func TestRoleHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*rbacv1.Role)
 	assert.True(t, ok)
 	assert.Equal(t, "test-role", resource1.Name)
-	assert.NotSame(t, role1, resource1) // Should be a copy
+	assert.Same(t, role1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*rbacv1.Role)
 	assert.True(t, ok)
 	assert.Equal(t, "role2", resource2.Name)
-	assert.NotSame(t, role2, resource2) // Should be a copy
+	assert.Same(t, role2, resource2) // ResourceList returns raw informer references
 }
 
 func TestRoleHandlers_ResourceUID(t *testing.T) {
@@ -407,4 +407,14 @@ func createTestRole() *rbacv1.Role {
 			},
 		},
 	}
+}
+
+func TestRoleHandlers_CloneResource(t *testing.T) {
+	handlers := &RoleHandlers{}
+	original := createTestRole()
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*rbacv1.Role)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
@@ -114,10 +114,24 @@ func (h *RoleBindingHandlers) ResourceList(ctx processors.ProcessorContext, list
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *RoleBindingHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*rbacv1.RoleBinding).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *RoleBindingHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*rbacv1.RoleBinding).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
@@ -36,10 +36,10 @@ func NewRoleBindingHandlers(tagger tagger.Component) *RoleBindingHandlers {
 	return &RoleBindingHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *RoleBindingHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *RoleBindingHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*rbacv1.RoleBinding)
 	m := resourceModel.(*model.RoleBinding)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding_test.go
@@ -119,16 +119,16 @@ func TestRoleBindingHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*rbacv1.RoleBinding)
 	assert.True(t, ok)
 	assert.Equal(t, "test-rolebinding", resource1.Name)
-	assert.NotSame(t, roleBinding1, resource1) // Should be a copy
+	assert.Same(t, roleBinding1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*rbacv1.RoleBinding)
 	assert.True(t, ok)
 	assert.Equal(t, "rolebinding2", resource2.Name)
-	assert.NotSame(t, roleBinding2, resource2) // Should be a copy
+	assert.Same(t, roleBinding2, resource2) // ResourceList returns raw informer references
 }
 
 func TestRoleBindingHandlers_ResourceUID(t *testing.T) {
@@ -406,4 +406,14 @@ func createTestRoleBinding() *rbacv1.RoleBinding {
 			},
 		},
 	}
+}
+
+func TestRoleBindingHandlers_CloneResource(t *testing.T) {
+	handlers := &RoleBindingHandlers{}
+	original := createTestRoleBinding()
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*rbacv1.RoleBinding)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding_test.go
@@ -47,7 +47,7 @@ func TestRoleBindingHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewRoleBindingHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
@@ -114,10 +114,24 @@ func (h *ServiceHandlers) ResourceList(ctx processors.ProcessorContext, list int
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *ServiceHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*corev1.Service).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *ServiceHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*corev1.Service).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
@@ -36,10 +36,10 @@ func NewServiceHandlers(tagger tagger.Component) *ServiceHandlers {
 	return &ServiceHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *ServiceHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *ServiceHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*corev1.Service)
 	m := resourceModel.(*model.Service)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service_test.go
@@ -121,16 +121,16 @@ func TestServiceHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*corev1.Service)
 	assert.True(t, ok)
 	assert.Equal(t, "test-service", resource1.Name)
-	assert.NotSame(t, service1, resource1) // Should be a copy
+	assert.Same(t, service1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*corev1.Service)
 	assert.True(t, ok)
 	assert.Equal(t, "service2", resource2.Name)
-	assert.NotSame(t, service2, resource2) // Should be a copy
+	assert.Same(t, service2, resource2) // ResourceList returns raw informer references
 }
 
 func TestServiceHandlers_ResourceUID(t *testing.T) {
@@ -414,4 +414,14 @@ func createTestService() *corev1.Service {
 		},
 		Status: corev1.ServiceStatus{},
 	}
+}
+
+func TestServiceHandlers_CloneResource(t *testing.T) {
+	handlers := &ServiceHandlers{}
+	original := createTestService()
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*corev1.Service)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service_test.go
@@ -48,7 +48,7 @@ func TestServiceHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewServiceHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
@@ -114,10 +114,24 @@ func (h *ServiceAccountHandlers) ResourceList(ctx processors.ProcessorContext, l
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *ServiceAccountHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*corev1.ServiceAccount).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *ServiceAccountHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*corev1.ServiceAccount).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
@@ -36,10 +36,10 @@ func NewServiceAccountHandlers(tagger tagger.Component) *ServiceAccountHandlers 
 	return &ServiceAccountHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *ServiceAccountHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *ServiceAccountHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*corev1.ServiceAccount)
 	m := resourceModel.(*model.ServiceAccount)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount_test.go
@@ -48,7 +48,7 @@ func TestServiceAccountHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewServiceAccountHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount_test.go
@@ -121,16 +121,16 @@ func TestServiceAccountHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*corev1.ServiceAccount)
 	assert.True(t, ok)
 	assert.Equal(t, "test-serviceaccount", resource1.Name)
-	assert.NotSame(t, serviceAccount1, resource1) // Should be a copy
+	assert.Same(t, serviceAccount1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*corev1.ServiceAccount)
 	assert.True(t, ok)
 	assert.Equal(t, "serviceaccount2", resource2.Name)
-	assert.NotSame(t, serviceAccount2, resource2) // Should be a copy
+	assert.Same(t, serviceAccount2, resource2) // ResourceList returns raw informer references
 }
 
 func TestServiceAccountHandlers_ResourceUID(t *testing.T) {
@@ -408,4 +408,14 @@ func createTestServiceAccount() *corev1.ServiceAccount {
 			},
 		},
 	}
+}
+
+func TestServiceAccountHandlers_CloneResource(t *testing.T) {
+	handlers := &ServiceAccountHandlers{}
+	original := createTestServiceAccount()
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*corev1.ServiceAccount)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
@@ -114,10 +114,24 @@ func (h *StatefulSetHandlers) ResourceList(ctx processors.ProcessorContext, list
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *StatefulSetHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*appsv1.StatefulSet).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *StatefulSetHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*appsv1.StatefulSet).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
@@ -36,10 +36,10 @@ func NewStatefulSetHandlers(tagger tagger.Component) *StatefulSetHandlers {
 	return &StatefulSetHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *StatefulSetHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *StatefulSetHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*appsv1.StatefulSet)
 	m := resourceModel.(*model.StatefulSet)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset_test.go
@@ -122,16 +122,16 @@ func TestStatefulSetHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*appsv1.StatefulSet)
 	assert.True(t, ok)
 	assert.Equal(t, "test-statefulset", resource1.Name)
-	assert.NotSame(t, statefulSet1, resource1) // Should be a copy
+	assert.Same(t, statefulSet1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*appsv1.StatefulSet)
 	assert.True(t, ok)
 	assert.Equal(t, "statefulset2", resource2.Name)
-	assert.NotSame(t, statefulSet2, resource2) // Should be a copy
+	assert.Same(t, statefulSet2, resource2) // ResourceList returns raw informer references
 }
 
 func TestStatefulSetHandlers_ResourceUID(t *testing.T) {
@@ -451,4 +451,14 @@ func createTestStatefulSet() *appsv1.StatefulSet {
 			},
 		},
 	}
+}
+
+func TestStatefulSetHandlers_CloneResource(t *testing.T) {
+	handlers := &StatefulSetHandlers{}
+	original := createTestStatefulSet()
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*appsv1.StatefulSet)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset_test.go
@@ -48,7 +48,7 @@ func TestStatefulSetHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewStatefulSetHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/storageclass.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/storageclass.go
@@ -37,10 +37,10 @@ func NewStorageClassHandlers(tagger tagger.Component) *StorageClassHandlers {
 	return &StorageClassHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *StorageClassHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *StorageClassHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*storagev1.StorageClass)
 	m := resourceModel.(*model.StorageClass)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/storageclass.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/storageclass.go
@@ -113,10 +113,24 @@ func (h *StorageClassHandlers) ResourceList(ctx processors.ProcessorContext, lis
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *StorageClassHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*storagev1.StorageClass).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *StorageClassHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*storagev1.StorageClass).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/storageclass_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/storageclass_test.go
@@ -125,16 +125,16 @@ func TestStorageClassHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*storagev1.StorageClass)
 	assert.True(t, ok)
 	assert.Equal(t, "test-storageclass", resource1.Name)
-	assert.NotSame(t, storageClass1, resource1) // Should be a copy
+	assert.Same(t, storageClass1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*storagev1.StorageClass)
 	assert.True(t, ok)
 	assert.Equal(t, "storageclass2", resource2.Name)
-	assert.NotSame(t, storageClass2, resource2) // Should be a copy
+	assert.Same(t, storageClass2, resource2) // ResourceList returns raw informer references
 }
 
 func TestStorageClassHandlers_ResourceUID(t *testing.T) {
@@ -438,4 +438,14 @@ func createTestStorageClass() *storagev1.StorageClass {
 			},
 		},
 	}
+}
+
+func TestStorageClassHandlers_CloneResource(t *testing.T) {
+	handlers := &StorageClassHandlers{}
+	original := createTestStorageClass()
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*storagev1.StorageClass)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/storageclass_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/storageclass_test.go
@@ -50,7 +50,7 @@ func TestStorageClassHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewStorageClassHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler.go
@@ -113,10 +113,24 @@ func (h *VerticalPodAutoscalerHandlers) ResourceList(ctx processors.ProcessorCon
 	resources = make([]interface{}, 0, len(resourceList))
 
 	for _, resource := range resourceList {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 
 	return resources
+}
+
+// CloneResource returns a deep copy of the resource.
+//
+//nolint:revive
+func (h *VerticalPodAutoscalerHandlers) CloneResource(resource interface{}) interface{} {
+	return resource.(*v1.VerticalPodAutoscaler).DeepCopy()
+}
+
+// ResourceVersionFromRaw returns the resource version from the raw resource.
+//
+//nolint:revive
+func (h *VerticalPodAutoscalerHandlers) ResourceVersionFromRaw(_ processors.ProcessorContext, resource interface{}) string {
+	return resource.(*v1.VerticalPodAutoscaler).ResourceVersion
 }
 
 // ResourceUID is a handler called to retrieve the resource UID.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler.go
@@ -35,10 +35,10 @@ func NewVerticalPodAutoscalerHandlers(tagger tagger.Component) *VerticalPodAutos
 	return &VerticalPodAutoscalerHandlers{tagger: tagger}
 }
 
-// BeforeCacheCheck is a handler called before cache lookup.
+// EnrichModel is a handler called before cache lookup.
 //
 //nolint:revive
-func (h *VerticalPodAutoscalerHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
+func (h *VerticalPodAutoscalerHandlers) EnrichModel(ctx processors.ProcessorContext, resource, resourceModel interface{}) (skip bool) {
 	r := resource.(*v1.VerticalPodAutoscaler)
 	m := resourceModel.(*model.VerticalPodAutoscaler)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler_test.go
@@ -52,7 +52,7 @@ func TestVerticalPodAutoscalerHandlers_BeforeCacheCheck(t *testing.T) {
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewVerticalPodAutoscalerHandlers(tagger)
 
-	skip := handlers.BeforeCacheCheck(ctx, resource, resourceModel)
+	skip := handlers.EnrichModel(ctx, resource, resourceModel)
 	assert.False(t, skip)
 	assert.Equal(t, []string{"tagger-tag:value"}, resourceModel.Tags)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler_test.go
@@ -126,16 +126,16 @@ func TestVerticalPodAutoscalerHandlers_ResourceList(t *testing.T) {
 	// Validate conversion
 	assert.Len(t, resources, 2)
 
-	// Verify deep copy was made
+	// Verify raw informer references are returned
 	resource1, ok := resources[0].(*v1.VerticalPodAutoscaler)
 	assert.True(t, ok)
 	assert.Equal(t, "test-vpa", resource1.Name)
-	assert.NotSame(t, vpa1, resource1) // Should be a copy
+	assert.Same(t, vpa1, resource1) // ResourceList returns raw informer references
 
 	resource2, ok := resources[1].(*v1.VerticalPodAutoscaler)
 	assert.True(t, ok)
 	assert.Equal(t, "vpa2", resource2.Name)
-	assert.NotSame(t, vpa2, resource2) // Should be a copy
+	assert.Same(t, vpa2, resource2) // ResourceList returns raw informer references
 }
 
 func TestVerticalPodAutoscalerHandlers_ResourceUID(t *testing.T) {
@@ -466,4 +466,14 @@ func createTestVerticalPodAutoscaler() *v1.VerticalPodAutoscaler {
 			},
 		},
 	}
+}
+
+func TestVerticalPodAutoscalerHandlers_CloneResource(t *testing.T) {
+	handlers := &VerticalPodAutoscalerHandlers{}
+	original := createTestVerticalPodAutoscaler()
+	cloned := handlers.CloneResource(original)
+	clonedTyped, ok := cloned.(*v1.VerticalPodAutoscaler)
+	assert.True(t, ok)
+	assert.NotSame(t, original, clonedTyped)
+	assert.Equal(t, original, clonedTyped)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
@@ -202,6 +202,20 @@ type Handlers interface {
 	// ScrubBeforeMarshalling replaces sensitive information in the resource
 	// before resource marshalling.
 	ScrubBeforeMarshalling(ctx ProcessorContext, resource interface{})
+
+	// CloneResource creates a deep copy of a resource before mutation begins.
+	// Called once per resource that passes the early cache check. Handlers that
+	// mutate resources during scrubbing or marshalling must return a deep copy
+	// so the informer cache is not corrupted.
+	CloneResource(resource interface{}) interface{}
+
+	// ResourceVersionFromRaw returns the resource version directly from the raw,
+	// unprocessed resource without requiring model extraction. An empty string
+	// signals that the version cannot be determined without extraction (e.g., Pods
+	// use a custom hash computed from the extracted model). When non-empty, the
+	// processor uses this for an early cache check that skips DeepCopy, model
+	// extraction, and tagger lookup for unchanged resources.
+	ResourceVersionFromRaw(ctx ProcessorContext, resource interface{}) string
 }
 
 // Processor is a generic resource processing component. It relies on a set of
@@ -245,15 +259,34 @@ func (p *Processor) Process(ctx ProcessorContext, list interface{}) (processResu
 	// Make sure to recover if a panic occurs.
 	defer RecoverOnPanic()
 
-	resourceList := p.h.ResourceList(ctx, list)
-	resourceMetadataModels := make([]interface{}, 0, len(resourceList))
-	resourceManifestModels := make([]interface{}, 0, len(resourceList))
+	// ResourceList now returns raw (uncopied) references from the informer cache.
+	rawList := p.h.ResourceList(ctx, list)
+	resourceMetadataModels := make([]interface{}, 0, len(rawList))
+	resourceManifestModels := make([]interface{}, 0, len(rawList))
 	now := ctx.GetClock().Now()
 
-	for _, resource := range resourceList {
+	for _, rawResource := range rawList {
+		// Attempt an early cache check on the raw resource before the expensive
+		// DeepCopy, model extraction, and tagger lookup. This fires for all typed
+		// k8s resources (every handler except Pod and ECS Task) where the resource
+		// version is available directly without model extraction.
+		cacheChecked := false
+		if rawVersion := p.h.ResourceVersionFromRaw(ctx, rawResource); rawVersion != "" {
+			uid := p.h.ResourceUID(ctx, rawResource)
+			if orchestrator.SkipKubernetesResource(uid, rawVersion, ctx.GetNodeType()) {
+				continue
+			}
+			cacheChecked = true
+		}
+
+		// Clone the raw resource before any mutation so the informer cache is
+		// not corrupted by scrubbing, Kind/APIVersion injection, or marshalling.
+		resource := p.h.CloneResource(rawResource)
+
 		if ctx.IsTerminatedResources() {
 			resource = insertDeletionTimestampIfPossible(resource, now)
 		}
+
 		// Scrub before extraction.
 		p.h.ScrubBeforeExtraction(ctx, resource)
 
@@ -265,12 +298,15 @@ func (p *Processor) Process(ctx ProcessorContext, list interface{}) (processResu
 			continue
 		}
 
-		// Cache check
 		resourceUID := p.h.ResourceUID(ctx, resource)
 		resourceVersion := p.h.ResourceVersion(ctx, resource, resourceMetadataModel)
 
-		if orchestrator.SkipKubernetesResource(resourceUID, resourceVersion, ctx.GetNodeType()) {
-			continue
+		// For handlers that could not pre-check (Pod with custom version hashing,
+		// ECS Task), perform the cache check now using the extracted model version.
+		if !cacheChecked {
+			if orchestrator.SkipKubernetesResource(resourceUID, resourceVersion, ctx.GetNodeType()) {
+				continue
+			}
 		}
 
 		// Execute code before marshalling.
@@ -288,7 +324,7 @@ func (p *Processor) Process(ctx ProcessorContext, list interface{}) (processResu
 			continue
 		}
 
-		// Stop sending yaml if manifest collecion is enabled
+		// Stop sending yaml if manifest collection is enabled
 		if !ctx.GetOrchestratorConfig().IsManifestCollectionEnabled {
 			// Execute code after marshalling.
 			if skip := p.h.AfterMarshalling(ctx, resource, resourceMetadataModel, yaml); skip {
@@ -321,7 +357,7 @@ func (p *Processor) Process(ctx ProcessorContext, list interface{}) (processResu
 		processResult.ManifestMessages = ChunkManifest(ctx, p.h.BuildManifestMessageBody, resourceManifestModels)
 	}
 
-	return processResult, len(resourceList), len(resourceMetadataModels)
+	return processResult, len(rawList), len(resourceMetadataModels)
 }
 
 // ChunkManifest is to chunk Manifest payloads

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
@@ -157,10 +157,10 @@ type Handlers interface {
 	// moves on to the next resource.
 	AfterMarshalling(ctx ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool)
 
-	// BeforeCacheCheck runs before the Processor does a cache lookup for the
+	// EnrichModel runs before the Processor does a cache lookup for the
 	// resource. If skip is true then the resource processing loop moves on to
 	// the next resource.
-	BeforeCacheCheck(ctx ProcessorContext, resource, resourceModel interface{}) (skip bool)
+	EnrichModel(ctx ProcessorContext, resource, resourceModel interface{}) (skip bool)
 
 	// BeforeMarshalling runs before the Processor marshals the resource to
 	// generate a manifest. If skip is true then the resource processing loop
@@ -294,7 +294,7 @@ func (p *Processor) Process(ctx ProcessorContext, list interface{}) (processResu
 		resourceMetadataModel := p.h.ExtractResource(ctx, resource)
 
 		// Execute code before cache check.
-		if skip := p.h.BeforeCacheCheck(ctx, resource, resourceMetadataModel); skip {
+		if skip := p.h.EnrichModel(ctx, resource, resourceMetadataModel); skip {
 			continue
 		}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor_handlers_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor_handlers_test.go
@@ -115,9 +115,19 @@ func (rh *TestResourceHandlers) ResourceList(ctx ProcessorContext, list any) (re
 	}
 	resources = make([]any, 0, len(list.([]*processorstest.Resource)))
 	for _, resource := range list.([]*processorstest.Resource) {
-		resources = append(resources, resource.DeepCopy())
+		resources = append(resources, resource)
 	}
 	return resources
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) CloneResource(resource any) any {
+	return resource.(*processorstest.Resource).DeepCopy()
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) ResourceVersionFromRaw(_ ProcessorContext, resource any) string {
+	return resource.(*processorstest.Resource).ResourceVersion
 }
 
 //nolint:revive

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor_handlers_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor_handlers_test.go
@@ -32,7 +32,7 @@ func (rh *TestResourceHandlers) AfterMarshalling(ctx ProcessorContext, resource,
 }
 
 //nolint:revive
-func (rh *TestResourceHandlers) BeforeCacheCheck(ctx ProcessorContext, resource, resourceModel any) (skip bool) {
+func (rh *TestResourceHandlers) EnrichModel(ctx ProcessorContext, resource, resourceModel any) (skip bool) {
 	if rh.SkipBeforeCacheCheck {
 		return true
 	}

--- a/releasenotes/notes/reduce-orchestrator-allocations-fa365c1a17eb9360.yaml
+++ b/releasenotes/notes/reduce-orchestrator-allocations-fa365c1a17eb9360.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Reduced memory allocation pressure in the orchestrator check by deferring
+    deep copies and model extraction until after a cache miss is confirmed, eliminating the
+    allocation cost for unchanged resources in steady-state clusters.


### PR DESCRIPTION
### What does this PR do?

Moves the `SkipKubernetesResource` cache check to run _before_ `DeepCopy` and model extraction in the orchestrator processor loop. Previously, every resource was eagerly deep-copied and fully extracted on every 10-second tick before the cache check had a chance to discard unchanged resources.

Two new `Handlers` interface methods enable this:
- `ResourceVersionFromRaw` — reads `ResourceVersion` directly from the raw informer object, with no allocation
- `CloneResource` — performs `DeepCopy` on demand, only after a cache miss

For `Pod`, which uses a custom computed hash requiring full extraction, the existing post-extraction cache check is preserved unchanged.

### Motivation

In steady state (the common case in production), most resources haven't changed between ticks. The old code paid the full cost of `DeepCopy` + protobuf extraction + tagger lookup for every object on every tick regardless. This produced sustained, cluster-size-proportional allocation pressure on the cluster agent.

### Describe how you validated your changes

Profiled two cluster-agent deployments against identical [KWOK](https://kwok.sigs.k8s.io/)-simulated clusters (100 fake nodes, 400 Deployments × 5 replicas). Cumulative alloc profiles captured at equal 40-minute run times.

#### Results

| Metric | v7.79.1 (baseline) | This branch | Reduction |
|---|---|---|---|
| `(*Processor).Process` cumulative | 1,784 MB | 254 MB | **~7x** |
| `(*ReplicaSetCollector).Run` cumulative | 622 MB | ~30 MB | **~20x** |
| `(*DeploymentCollector).Run` cumulative | 656 MB | ~40 MB | **~16x** |
| Orchestrator processor total | 1,926 MB | 374 MB | **~5x** |

The remaining ~374 MB is serialization of genuinely changed resources — expected and irreducible.

<details>
<summary>Raw pprof — v7.79.1 baseline (orchestrator/processors focus)</summary>

```
Total: 22,120 MB
Active filters: focus=orchestrator/processors
Showing nodes accounting for 1,926 MB (8.71% of total)

  334 MB  (*FieldsV1).DeepCopyInto
  259 MB  (*ObjectMeta).DeepCopyInto
  144 MB  (*PodSpec).DeepCopyInto
  120 MB  (*JSONSchemaProps).DeepCopy
  117 MB  (*Deployment).DeepCopy        ← every tick, every deployment
  113 MB  (*ReplicaSet).DeepCopy        ← every tick, every replicaset
   92 MB  (*NodeStatus).DeepCopyInto
   73 MB  (*Processor).Process (flat)   cum: 1,784 MB
```
</details>

<details>
<summary>Raw pprof — this branch (orchestrator/processors focus)</summary>

```
Total: 22,337 MB
Active filters: focus=orchestrator/processors
Showing nodes accounting for 374 MB (1.68% of total)

   47 MB  (*frozenConfig).Marshal       ← serialization of changed resources
   20 MB  (*FieldsV1).DeepCopyInto      ← only cache-miss objects cloned
   16 MB  (*ObjectMeta).DeepCopyInto
   10 MB  (*Deployment).DeepCopy        ← only on actual changes
    7 MB  (*ReplicaSet).DeepCopy        ← only on actual changes
   18 MB  (*Processor).Process (flat)   cum: 254 MB
```
</details>

**Cache hit / miss percentage is identical:**
<img width="1515" height="663" alt="image" src="https://github.com/user-attachments/assets/c32e82da-f2ca-4aed-b611-06db11dec6d0" />


### Additional Notes

Savings scale linearly with cluster size and are most pronounced in steady state. Larger clusters will see proportionally larger GC pressure reductions.