### PR TITLE
[CNM-5445] Fix DD_NETWORK_CONFIG_DNS_MONITORING_PORTS env var parsing.

### DIFF
--- a/pkg/config/schema/system-probe_schema.yaml
+++ b/pkg/config/schema/system-probe_schema.yaml
@@ -592,6 +592,7 @@ properties:
         type: array
         default:
         - 53
+        env_parser: json
         items:
           type: number
         visibility: public

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -200,6 +200,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("system_probe_config.max_dns_stats", 20000)
 	cfg.BindEnvAndSetDefault("system_probe_config.dns_timeout_in_s", 15)
 	cfg.BindEnvAndSetDefault("network_config.dns_monitoring_ports", []int{53})
+	cfg.ParseEnvJSON("network_config.dns_monitoring_ports", []int{})
 
 	cfg.BindEnvAndSetDefault("system_probe_config.enable_conntrack", true)
 	cfg.BindEnvAndSetDefault("system_probe_config.conntrack_max_state_size", 65536*2)

--- a/pkg/config/system-probe_template.yaml
+++ b/pkg/config/system-probe_template.yaml
@@ -66,7 +66,7 @@
 #   enabled: false
 
 #   # @param dns_monitoring_ports - list of integers - optional - default: [53]
-#   # @env DD_NETWORK_CONFIG_DNS_MONITORING_PORTS - space-separated list of integers - optional - default: "53"
+#   # @env DD_NETWORK_CONFIG_DNS_MONITORING_PORTS - JSON array of integers - optional - default: "[53]"
 #   # A list of ports that should be monitored for DNS traffic.
 #
 #   dns_monitoring_ports:

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -599,4 +599,39 @@ func TestDNSMonitoringPorts(t *testing.T) {
 		cfg := New()
 		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
 	})
+
+	t.Run("via ENV variable - JSON array of single port", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "[5353]")
+		cfg := New()
+		assert.Equal(t, []int{5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - JSON array of multiple ports", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "[1,2,3,4,5,6,7,53]")
+		cfg := New()
+		assert.Equal(t, []int{1, 2, 3, 4, 5, 6, 7, 53}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - invalid JSON falls back to default", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "not-a-port")
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - HTTP ports should be removed", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "[53,443,5353,80]")
+		cfg := New()
+		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - empty array falls back to default", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "[]")
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
+	})
 }


### PR DESCRIPTION
### What does this PR do?
Fix the parsing of the DD_NETWORK_CONFIG_DNS_MONITORING_PORTS env var.

### Motivation

### Describe how you validated your changes
Unit tests, manual config tests.

### Additional Notes
