### PR TITLE
chore(deps): mirror C/C++ third-party sources via ADMS/Depot, drop frozen S3 URLs

### DIFF
--- a/.adms/bazel/adms.mirror.cfg
+++ b/.adms/bazel/adms.mirror.cfg
@@ -26,16 +26,9 @@ allow raw.githubusercontent.com
 allow index.crates.io
 
 # This list is temporary. It should be upstreamed to basic adms support.
-allow dbus.freedesktop.org
-allow download.savannah.nongnu.org
-allow freetds.org
-allow ftp.rpm.org
-allow gnupg.org
-allow lua.org
 allow mirrors.edge.kernel.org
 allow mirrors.kernel.org
 allow sourceware.org
-allow sqlite.org
 
 # Our windows filters are not stored on an internal host.
 allow s3.amazonaws.com
@@ -113,6 +106,15 @@ rewrite (curl.se)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (curl.haxx.se)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 # Only open up the mozilla license. There is no need to accept the entire repo.
 rewrite (www.mozilla.org)/media/MPL/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/media/MPL/$2
+rewrite (dbus.freedesktop.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (download.savannah.nongnu.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (ftp.osuosl.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (gnupg.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (kerberos.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (packages.microsoft.com)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (www.freetds.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (www.lua.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (www.sqlite.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 
 # Rewrite Rules for External Hosts - Specific Language Ecosystems
 #######################################################################

--- a/deps/acl/BUILD.bazel
+++ b/deps/acl/BUILD.bazel
@@ -11,7 +11,6 @@ generate_module_bazel(
     strip_prefix = "acl-%s" % VERSION,
     tags = ["manual"],
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/acl-%s.tar.xz" % VERSION,
         "https://download.savannah.nongnu.org/releases/acl/acl-%s.tar.xz" % VERSION,
     ],
 )

--- a/deps/acl/acl.MODULE.bazel
+++ b/deps/acl/acl.MODULE.bazel
@@ -10,8 +10,5 @@ http_archive(
     },
     sha256 = "c0234042e17f11306c23c038b08e5e070edb7be44bef6697fb8734dcff1c66b1",
     strip_prefix = "acl-2.3.1",
-    urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/acl-2.3.1.tar.xz",
-        "https://download.savannah.nongnu.org/releases/acl/acl-2.3.1.tar.xz",
-    ],
+    url = "https://download.savannah.nongnu.org/releases/acl/acl-2.3.1.tar.xz",
 )

--- a/deps/msodbcsql18/msodbcsql18.MODULE.bazel
+++ b/deps/msodbcsql18/msodbcsql18.MODULE.bazel
@@ -7,7 +7,6 @@ http_file(
     name = "msodbcsql18_deb_amd64",
     sha256 = "f91004ce72fcd92e686154f90e2a80f4f86469e7cb5f42ef79cba79dc6727890",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/msodbcsql18/msodbcsql18_{}_amd64.deb".format(VERSION),
         "https://packages.microsoft.com/debian/11/prod/pool/main/m/msodbcsql18/msodbcsql18_{}_amd64.deb".format(VERSION),
     ],
 )
@@ -17,7 +16,6 @@ http_file(
     name = "msodbcsql18_deb_arm64",
     sha256 = "37e692b1517f1229042c743d0f2a7191e0dcb956bbc3785a895aaa6dc328467e",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/msodbcsql18/msodbcsql18_{}_arm64.deb".format(VERSION),
         "https://packages.microsoft.com/debian/11/prod/pool/main/m/msodbcsql18/msodbcsql18_{}_arm64.deb".format(VERSION),
     ],
 )

--- a/deps/pcre2.BUILD.bazel
+++ b/deps/pcre2.BUILD.bazel
@@ -23,9 +23,6 @@ package_metadata(
     purl = purl_for_generic(
         package = "libsepol",
         version = VERSION,
-        # It is OK to point to the download URL where you retrieved the file, rather than the
-        # canonical upstream version. It might even be preferable. PURLs are pretty much an
-        # instance of https://xkcd.com/927.
         download_url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.bz2",
     ),
 )

--- a/deps/pcre2.BUILD.bazel
+++ b/deps/pcre2.BUILD.bazel
@@ -26,7 +26,7 @@ package_metadata(
         # It is OK to point to the download URL where you retrieved the file, rather than the
         # canonical upstream version. It might even be preferable. PURLs are pretty much an
         # instance of https://xkcd.com/927.
-        download_url = "https://dd-agent-omnibus.s3.amazonaws.com/bazel/pcre2-{version}.tar.bz2",
+        download_url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.bz2",
     ),
 )
 

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -41,7 +41,6 @@ http_archive(
     sha256 = "507825b599356c10dca1cd720c9d0d0c9d5400b9de300af00e4d1ea150795543",
     strip_prefix = "xz-5.8.1",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/xz-5.8.1.tar.gz",
         "https://tukaani.org/xz/xz-5.8.1.tar.gz",
     ],
 )
@@ -52,7 +51,6 @@ http_archive(
     sha256 = "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23",
     strip_prefix = "zlib-1.3.1",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/zlib-1.3.1.tar.gz",
         "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz",
     ],
 )
@@ -67,7 +65,6 @@ http_archive(
     # The canonical source is in https://sourceware.org/pub/bzip2/, but the Bazel
     # team mirror is more reliable.
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/bzip2-1.0.8.tar.gz",
         "https://mirror.bazel.build/sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
     ],
 )
@@ -130,7 +127,6 @@ http_archive(
     sha256 = "bc9842a18898bfacb0ed1252c4febcc7e78fa139fd27fdc7a3e30d9d9356119b",
     strip_prefix = "libffi-3.4.8",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/libffi-3.4.8.tar.gz",
         "https://github.com/libffi/libffi/releases/download/v3.4.8/libffi-3.4.8.tar.gz",
     ],
 )
@@ -141,7 +137,6 @@ http_archive(
     sha256 = "78fdaf69924db780bac78546e43d9c44074bad798c2c415d0b9bb96d065ee8a2",
     strip_prefix = "libsepol-3.5",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/libsepol-3.5.tar.gz",
         "https://github.com/SELinuxProject/selinux/releases/download/3.5/libsepol-3.5.tar.gz",
     ],
 )
@@ -157,7 +152,6 @@ http_archive(
     sha256 = "15fbc5aba6beee0b17aecb04602ae39432393aba1ebd8e39b7cabf7db883299f",
     strip_prefix = "pcre2-10.46",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/pcre2-10.46.tar.bz2",
         "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.46/pcre2-10.46.tar.bz2",
     ],
 )
@@ -171,7 +165,6 @@ http_archive(
     sha256 = "c8e1a11dd5879a2788973c73589fbcf08606e85aeec095e516162495ead8ba68",
     strip_prefix = "util-linux-2.39.2",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/util-linux-2.39.2.tar.gz",
         "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.39/util-linux-2.39.2.tar.gz",
     ],
 )
@@ -195,7 +188,6 @@ http_archive(
     sha256 = "9a3a3705ac13a2ccca2de6d652b6356fead10f36fb33115c185c5ccdf29eec19",
     strip_prefix = "libselinux-3.5",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/libselinux-3.5.tar.gz",
         "https://github.com/SELinuxProject/selinux/releases/download/3.5/libselinux-3.5.tar.gz",
     ],
 )
@@ -206,7 +198,6 @@ http_archive(
     sha256 = "64de10e4c6b8b8379db7e87f58030f336ea747c0515f381132e810dbf84a86e7",
     strip_prefix = "patchelf-0.18.0",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/patchelf-0.18.0.tar.gz",
         "https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0.tar.gz",
     ],
 )
@@ -220,7 +211,6 @@ http_archive(
     sha256 = "9ebdfbfbca164ef72bdf5fd2a94a4e6dfb54ec39d2ef249aeb750a91ae361dfb",
     strip_prefix = "nghttp2-1.58.0",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/nghttp2-1.58.0.tar.gz",
         "https://github.com/nghttp2/nghttp2/releases/download/v1.58.0/nghttp2-1.58.0.tar.gz",
     ],
 )
@@ -231,8 +221,7 @@ http_archive(
     sha256 = "c25a4838fc8e4c1c8aacb8bd620edb3084a3d63bf8987fdad3ca2758c63240f9",
     strip_prefix = "popt-1.19",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/popt-1.19.tar.gz",
-        "http://ftp.rpm.org/popt/releases/popt-1.x/popt-1.19.tar.gz",
+        "https://ftp.osuosl.org/pub/rpm/popt/releases/popt-1.x/popt-1.19.tar.gz",
     ],
 )
 
@@ -242,7 +231,6 @@ http_archive(
     sha256 = "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4",
     strip_prefix = "yaml-0.2.5",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/yaml-0.2.5.tar.gz",
         "https://pyyaml.org/download/libyaml/yaml-0.2.5.tar.gz",
     ],
 )
@@ -257,7 +245,6 @@ http_archive(
     sha256 = "db448a626f9313a1a970d636767316a8da32aede70518b8050fa0de7947adc32",
     strip_prefix = "attr-2.5.1",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/attr-attr-2.5.1.tar.xz",
         "https://download.savannah.nongnu.org/releases/attr/attr-2.5.1.tar.xz",
     ],
 )
@@ -268,7 +255,6 @@ http_archive(
     sha256 = "eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3",
     strip_prefix = "zstd-1.5.7",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/zstd-1.5.7.tar.gz",
         "https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz",
     ],
 )
@@ -283,7 +269,6 @@ http_archive(
     sha256 = "82c3d2deb4ad96ad3925d6f9f124fe7205716055ab50e291116ef27975d169c0",
     strip_prefix = "libgpg-error-1.56",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/libgpg-error-1.56.tar.bz2",
         "https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.56.tar.bz2",
     ],
 )
@@ -298,7 +283,6 @@ http_archive(
     sha256 = "6ba59dd192270e8c1d22ddb41a07d95dcdbc1f0fb02d03c4b54b235814330aac",
     strip_prefix = "libgcrypt-1.11.2",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/libgcrypt-1.11.2.tar.bz2",
         "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.11.2.tar.bz2",
     ],
 )
@@ -316,7 +300,6 @@ http_archive(
     sha256 = "52833eac3d681c8b0c9a5a65f2ebd745b3a964f208fc748f977e44015a31b207",
     strip_prefix = "unixODBC-2.3.9",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/unixODBC-2.3.9.tar.gz",
         "https://www.unixodbc.org/unixODBC-2.3.9.tar.gz",
     ],
 )
@@ -331,7 +314,6 @@ http_archive(
     sha256 = "03d006f3537616833c16c53addcdc32a0eb20e55443cba4038307e3fa7d8d44b",
     strip_prefix = "libxml2-2.14.5",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/libxml2-2.14.5.tar.xz",
         "https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.5.tar.xz",
     ],
 )
@@ -346,7 +328,6 @@ http_archive(
     sha256 = "5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a",
     strip_prefix = "libxslt-1.1.43",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/libxslt-1.1.43.tar.xz",
         "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.43.tar.xz",
     ],
 )
@@ -363,7 +344,6 @@ http_archive(
     sha256 = "0ba2a1a4b16afe7bceb2c07e9ce99a8c2c3508e5dec290dbb643384bd6beb7e2",
     strip_prefix = "dbus-1.16.2",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/dbus-1.16.2.tar.xz",
         "https://dbus.freedesktop.org/releases/dbus/dbus-1.16.2.tar.xz",
     ],
 )
@@ -377,7 +357,6 @@ http_archive(
     sha256 = "7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88",
     strip_prefix = "lua-5.4.6",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/lua-5.4.6.tar.gz",
         "https://www.lua.org/ftp/lua-5.4.6.tar.gz",
     ],
 )
@@ -392,7 +371,6 @@ http_archive(
     sha256 = "d82e93b69b8aa205a616b62917a269322bf63a3eaafb3775014e61752b2013ea",
     strip_prefix = "xmlsec1-1.3.7",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/xmlsec1-1.3.7.tar.gz",
         "https://github.com/lsh123/xmlsec/releases/download/1.3.7/xmlsec1-1.3.7.tar.gz",
     ],
 )
@@ -407,7 +385,6 @@ http_archive(
     sha256 = "7d51e808138bd8f2ea59bd016f74c69497476eb8faada1067fcb8618ff813817",
     strip_prefix = "rpm-rpm-4.18.1-release",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/rpm-rpm-4.18.1-release.tar.gz",
         "https://github.com/rpm-software-management/rpm/archive/refs/tags/rpm-4.18.1-release.tar.gz",
     ],
 )
@@ -420,7 +397,6 @@ http_archive(
     sha256 = "b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35",
     strip_prefix = "krb5-1.21.3",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/krb5-1.21.3.tar.gz",
         "https://kerberos.org/dist/krb5/1.21/krb5-1.21.3.tar.gz",
     ],
 )
@@ -436,7 +412,6 @@ http_archive(
     sha256 = "eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90",
     strip_prefix = "openssl-3.0.9",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/openssl-3.0.9.tar.gz",
         "https://www.openssl.org/source/openssl-3.0.9.tar.gz",
     ],
 )


### PR DESCRIPTION
### What does this PR do?

Routes the `deps/` C/C++ source fetches through ADMS/Depot's pull-through cache (`rewrite` rules in `adms.mirror.cfg`) and drops the `dd-agent-omnibus` S3 mirror URLs. Also adds `kerberos.org` and `packages.microsoft.com`, which had no ADMS coverage, and repoints pcre2's SBOM `download_url` at its GitHub source.

### Motivation

Follow-up to the discussion on #51341. The `dd-agent-omnibus` S3 bucket is read-only, so the mirror URL was dead weight that only ever helped for already-uploaded versions. Depot is the intended mirror; a `rewrite` pull-through caches on first fetch, so it's the durable replacement.

### Additional Notes

popt moves from `ftp.rpm.org` to the `ftp.osuosl.org` mirror — the same tarball it redirects to (verified identical sha256), but with a valid HTTPS cert. `ftp.rpm.org` serves no usable cert, so neither Depot's pull-through nor a cold direct build can fetch it over HTTPS.