### PR TITLE
Bump Windows test storage

### DIFF
--- a/.gitlab/windows/build/source_test/windows.yml
+++ b/.gitlab/windows/build/source_test/windows.yml
@@ -19,7 +19,7 @@
     - >
       .\tools\ci\docker-run-with-bazel-cache.ps1
       -m 24576M
-      --storage-opt "size=50GB"
+      --storage-opt "size=100GB"
       -v "$(Get-Location):c:\mnt"
       -e DD_ENV=prod
       -e DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS


### PR DESCRIPTION
<!-- dd-meta {"pullId":"cc0ab397-e725-450e-a741-4aafce8cc064","source":"chat","resourceId":"3120e4fb-5dd2-4f85-a6dd-0f692e7edc24","workflowId":"872259dc-1f6d-4110-a532-287f78590cce","codeChangeId":"872259dc-1f6d-4110-a532-287f78590cce","sourceType":"slack"} -->
### What does this PR do?

Bumps the Windows source test Docker storage quota for `tests_windows-x64` from 50GB to 100GB.

### Motivation

The Windows unit test job has intermittently failed while linking Go test binaries with `ld.exe: final link failed: No space left on device` ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1731424120)). Representative failing runs still had hundreds of GiB free on the runner host C: drive, so the limiting factor appears to be the container storage quota rather than host disk capacity. Increasing the quota should reduce these infrastructure failures without requiring more runner disk.

### Describe how you validated your changes

CI passing. We'll only be able to see the actual impact after merging and monitoring for a while.

### Additional Notes

Note: the actual runner hosts had hundreds of GiB free when the jobs failed, which fully justifies this change.
---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/3120e4fb-5dd2-4f85-a6dd-0f692e7edc24)

Comment @datadog to request changes