### PR TITLE
Update helm chart version used by new-e2e tests

### DIFF
--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	HelmVersion = "3.217.1"
+	HelmVersion = "3.219.0"
 )
 
 // HelmInstallationArgs is the set of arguments for creating a new HelmInstallation component

--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	HelmVersion = "3.155.1"
+	HelmVersion = "3.217.1"
 )
 
 // HelmInstallationArgs is the set of arguments for creating a new HelmInstallation component

--- a/test/new-e2e/tests/otel/otel-agent/testdata/minimal-full-config-datadogextension.yml
+++ b/test/new-e2e/tests/otel/otel-agent/testdata/minimal-full-config-datadogextension.yml
@@ -86,7 +86,7 @@ extensions:
     gateway_destination: ""
     gateway_service: ""
     hostname: ""
-    installation_method: "" # TODO: change to "helm" after helm chart version bump
+    installation_method: kubernetes
     http:
       cors: null
       endpoint: localhost:9875

--- a/test/new-e2e/tests/otel/otel-agent/testdata/minimal-full-config.yml
+++ b/test/new-e2e/tests/otel/otel-agent/testdata/minimal-full-config.yml
@@ -86,7 +86,7 @@ extensions:
     gateway_destination: ""
     gateway_service: ""
     hostname: ""
-    installation_method: "" # TODO: change to "helm" after helm chart version bump
+    installation_method: kubernetes
     http:
       cors: null
       endpoint: localhost:9875

--- a/test/new-e2e/tests/otel/otel-agent/testdata/no-dd-exporter-full-config.yml
+++ b/test/new-e2e/tests/otel/otel-agent/testdata/no-dd-exporter-full-config.yml
@@ -78,7 +78,7 @@ extensions:
     gateway_destination: ""
     gateway_service: ""
     hostname: ""
-    installation_method: "" # TODO: change to "helm" after helm chart version bump
+    installation_method: kubernetes
     http:
       cors: null
       endpoint: localhost:9875

--- a/test/new-e2e/tests/ssi/ssi_test.go
+++ b/test/new-e2e/tests/ssi/ssi_test.go
@@ -358,9 +358,9 @@ func (v *ssiSuite) TestWorkloadSelection() {
 }
 
 func (v *ssiSuite) TestRegistryAllowList() {
-	// All three apps run in the same cluster with allow list = gcr.io/datadoghq.
-	// The default container registry for injector and library images is gcr.io/datadoghq.
-	// - "allowed": default injector and library, both from gcr.io/datadoghq — injection proceeds.
+	// All three apps run in the same cluster with allow list = registry.datadoghq.com.
+	// The default container registry for injector and library images is registry.datadoghq.com.
+	// - "allowed": default injector and library, both from registry.datadoghq.com — injection proceeds.
 	// - "injector-blocked": injector image overridden to fake.registry.invalid — injection blocked.
 	// - "library-blocked": injector is allowed, but python-lib.custom-image points to
 	//   fake.registry.invalid — injection blocked by library registry check.

--- a/test/new-e2e/tests/ssi/testdata/base.yaml
+++ b/test/new-e2e/tests/ssi/testdata/base.yaml
@@ -3,12 +3,6 @@ clusterAgent:
   admissionController:
     configMode: "hostip"
 
-# Temporary until the Datadog CSI driver is released
-datadog-csi-driver:
-  image:
-    repository: "registry.datadoghq.com/csi-driver"
-    tag: "1.2.0"
-
 datadog:
   csi:
     # Required: otherwise at the end of TestInjectionMode the CSI driver is removed before

--- a/test/new-e2e/tests/ssi/testdata/injection_mode.yaml
+++ b/test/new-e2e/tests/ssi/testdata/injection_mode.yaml
@@ -3,12 +3,6 @@ clusterAgent:
   admissionController:
     configMode: "hostip"
 
-# Temporary until the Datadog CSI driver is released
-datadog-csi-driver:
-  image:
-    repository: "registry.datadoghq.com/csi-driver"
-    tag: "1.2.0"
-
 datadog:
   csi:
     enabled: true

--- a/test/new-e2e/tests/ssi/testdata/registry_allow_list.yaml
+++ b/test/new-e2e/tests/ssi/testdata/registry_allow_list.yaml
@@ -4,9 +4,9 @@ clusterAgent:
     configMode: "hostip"
   env:
     - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY_ALLOW_LIST
-      value: "gcr.io/datadoghq"
+      value: "registry.datadoghq.com"
     # Disable gradual rollout so the injector resolves deterministically to
-    # gcr.io/datadoghq (the NoOpResolver). Without this, the rollout
+    # registry.datadoghq.com (the NoOpResolver). Without this, the rollout
     # resolver may return an image from a different registry, causing the
     # allow list check to block the "allowed" pod unexpectedly.
     - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_GRADUAL_ROLLOUT_ENABLED

--- a/test/new-e2e/tests/ssi/testdata/registry_allow_list.yaml
+++ b/test/new-e2e/tests/ssi/testdata/registry_allow_list.yaml
@@ -12,12 +12,6 @@ clusterAgent:
     - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_GRADUAL_ROLLOUT_ENABLED
       value: "false"
 
-# Temporary until the Datadog CSI driver is released
-datadog-csi-driver:
-  image:
-    repository: "registry.datadoghq.com/csi-driver"
-    tag: "1.2.0"
-
 datadog:
   csi:
     enabled: true


### PR DESCRIPTION
### What does this PR do?

Bump the Helm chart version used by new-e2e tests from `3.155.1` to `3.217.1` and update test fixtures impacted by chart changes.

### Motivation

Keep the new-e2e suite aligned with a recent Helm chart so we test against the chart actually shipped to users.

Two behaviour changes between `3.155.1` and `3.217.1` required test updates:

- **[#2682](https://github.com/DataDog/helm-charts/pull/2682)**: the admission controller container registry now follows `registryMigrationMode` and resolves to `registry.datadoghq.com` (instead of `gcr.io/datadoghq`) on migrated sites. The `TestRegistryAllowList/InjectionAllowedByAllowList` allow list is updated accordingly so the "allowed" case still matches the default registry.
- **[#2528](https://github.com/DataDog/helm-charts/pull/2528)**: the chart now sets `DD_OTELCOLLECTOR_INSTALLATION_METHOD=kubernetes` on the otel-agent container. The `installation_method` field in the OTel testdata is updated from `""` to `kubernetes` (this was already flagged with a TODO).

### Describe how you validated your changes

- `test/new-e2e/tests/ssi`: full suite green, including the three `TestRegistryAllowList` sub-tests.
- `test/new-e2e/tests/otel/otel-agent`: `TestOTelAgentMinimal` and `TestOTelAgentWithNoDDExporter` green (previously failing on the `installation_method` diff).

### Additional Notes

No production code change — test scaffolding and test fixtures only.