### PR TITLE
[autodiscovery/integration/config] Sort tags in MergeAdditionalTags to stabilize check IDs

### DIFF
--- a/comp/core/autodiscovery/integration/config.go
+++ b/comp/core/autodiscovery/integration/config.go
@@ -10,6 +10,7 @@ package integration
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -399,6 +400,8 @@ func (c *Data) MergeAdditionalTags(tags []string) error {
 	for k := range tagSet {
 		rawConfig["tags"] = append(rawConfig["tags"].([]string), k)
 	}
+	// sort the list of tags so the digest stays stable for identical configs
+	slices.Sort(rawConfig["tags"].([]string))
 	// modify original config
 	out, err := yaml.Marshal(&rawConfig)
 	if err != nil {

--- a/comp/core/autodiscovery/integration/config_test.go
+++ b/comp/core/autodiscovery/integration/config_test.go
@@ -112,12 +112,11 @@ func TestMergeAdditionalTags(t *testing.T) {
 
 	config.Instances[0].MergeAdditionalTags([]string{"foo", "bar"})
 
-	rawConfig := RawMap{}
-	err := yaml.Unmarshal(config.Instances[0], &rawConfig)
+	parsedConfig := CommonInstanceConfig{}
+	err := yaml.Unmarshal(config.Instances[0], &parsedConfig)
 	assert.Nil(t, err)
-	assert.Contains(t, rawConfig["tags"], "foo")
-	assert.Contains(t, rawConfig["tags"], "bar")
-	assert.Contains(t, rawConfig["tags"], "foo:bar")
+	expectedTags := []string{"bar", "foo", "foo:bar"} // Should be sorted so digest stays stable for identical configs
+	assert.Equal(t, expectedTags, parsedConfig.Tags)
 
 	config.Name = "foo"
 	config.InitConfig = Data("fooBarBaz")
@@ -125,11 +124,11 @@ func TestMergeAdditionalTags(t *testing.T) {
 
 	config.Instances[0].MergeAdditionalTags([]string{"foo", "bar"})
 
-	rawConfig = RawMap{}
-	err = yaml.Unmarshal(config.Instances[0], &rawConfig)
+	parsedConfig = CommonInstanceConfig{}
+	err = yaml.Unmarshal(config.Instances[0], &parsedConfig)
 	assert.Nil(t, err)
-	assert.Contains(t, rawConfig["tags"], "foo")
-	assert.Contains(t, rawConfig["tags"], "bar")
+	expectedTags = []string{"bar", "foo"} // Should be sorted so digest stays stable for identical configs
+	assert.Equal(t, expectedTags, parsedConfig.Tags)
 }
 
 func TestSetField(t *testing.T) {

--- a/releasenotes-dca/notes/stable-cluster-check-id-7d1e23c2408b8059.yaml
+++ b/releasenotes-dca/notes/stable-cluster-check-id-7d1e23c2408b8059.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Cluster checks now keep the same check ID across Cluster Agent restarts when
+    their configuration is unchanged.


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue with cluster check IDs.

The problem is that cluster check IDs change across Cluster Agent restarts even when the check configuration is unchanged. I think this doesn't cause any bugs, but it makes debugging a bit harder.

The root cause is that the `MergeAdditionalTags` function doesn't sort the tags. This causes different digests for identical configs. Notice that tags are sorted in a related function in the same file (`IntDigest`).

This PR addresses that root cause. Now cluster checks should keep the same check ID across Cluster Agent restarts when their configuration is unchanged.

### Describe how you validated your changes

I added a regression test. I also tested this locally on a kind cluster. I deployed the agent with KSM enabled, added some tags in the `datadog.tags` option in the helm chart, and verified that the check ID doesn't change across agent restarts. 
