### PR TITLE
Disable parallelism in TestKindSuite

### DIFF
--- a/test/new-e2e/tests/orchestrator/k8s_test.go
+++ b/test/new-e2e/tests/orchestrator/k8s_test.go
@@ -37,7 +37,6 @@ type k8sSuite struct {
 }
 
 func TestKindSuite(t *testing.T) {
-	t.Parallel()
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awskubernetes.KindProvisioner(
 			awskubernetes.WithDeployTestWorkload(),


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6e4dee43-9eec-4e16-9ee9-d8f83e1fc277","source":"chat","resourceId":"e8f27567-58b3-42aa-aaa7-9b919409c256","workflowId":"919b2b4f-7411-416c-811f-23c92cc3e459","codeChangeId":"919b2b4f-7411-416c-811f-23c92cc3e459","sourceType":"test-optimization"} -->
### What does this PR do?

Fixing `TestKindSuite` • [View in Test Optimization](https://app.datadoghq.com/ci/test/flaky?query=%40git.repository.id_v2%3A%22github.com%2Fdatadog%2Fdatadog-agent%22+%40test.name%3A%22TestKindSuite%22) • **Questions?** Ask in #code-gen-flaky-tests

Runs TestKindSuite serially by removing t.Parallel() to prevent concurrent environment provisioning conflicts in the Kind-based E2E Kubernetes orchestrator test.

### Motivation
The test was flaky due to shared resource contention when executed in parallel. Concurrent runs attempted to provision the same AWS/Kind environment and Pulumi stacks, leading to transient failures during stack updates and SSH connectivity. Symptoms included “failed to run update: exit status 255” and repeated “Dial N/100 failed: retrying” while waiting for cloud-init. 
- Impact: Flaked on 5 branches
- Last flaked branch: main
- Category: E2E Orchestrator (Kubernetes/Kind)

### Describe how you validated your changes
- Re-ran TestKindSuite multiple times with parallelism disabled; no flakes observed.
- Verified other E2E tests still pass and are unaffected by this change.

### Additional Notes
- Scope is limited to TestKindSuite; no changes to test logic or coverage.
- This reduces contention until we isolate shared resources (e.g., unique stack suffixes) if we revisit parallel execution later.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e8f27567-58b3-42aa-aaa7-9b919409c256)

Comment @datadog to request changes