### PR TITLE
bazel/AGENTS.md: fix set & float types claims

### DIFF
--- a/bazel/AGENTS.md
+++ b/bazel/AGENTS.md
@@ -282,7 +282,7 @@ BUILD files are configuration, not code — prioritize readability over deduplic
 Starlark is Python-like but with deliberate restrictions for hermeticity and parallelism. Key divergences:
 
 - No recursion, no `while`, no `yield`, no `class`, no `import` (use `load`), no `try`/`except`/`finally`.
-- No float or set types. No generator expressions. No implicit string concatenation.
+- `set` and `float` types exist (Bazel 8+), but there is no set literal syntax — `{...}` is always a dict, so build sets with `set([...])`. No generator expressions. No implicit string concatenation.
 - `for` and `if` statements are not allowed at the **top level** of a file — only inside functions. In BUILD files list
   comprehensions are allowed at top level.
 - Global variables become **immutable** once the file finishes loading. Values loaded from another `.bzl` file are


### PR DESCRIPTION
### What does this PR do?

Corrects the Starlark "Key divergences" bullet in `bazel/AGENTS.md`. It claimed "No float or set types," which is outdated — both exist as of Bazel 8 (this repo is on 9.1). Reworded to note the types exist but `{...}` is still a dict (no set-literal syntax; use `set([...])`).

### Motivation

Stale guidance leads contributors and AI agents to avoid `set`/`float` or hand-roll list-based set logic needlessly.

### Describe how you validated your changes

- Confirmed `set([...])`, `-`, `|`, and float arithmetic evaluate at loading phase under Bazel 9.1.0.

### Additional Notes