### PR TITLE
Fix flaky `TestSender/403_throttles_refresh` with `testing/synctest`

### DIFF
--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -368,12 +369,18 @@ func TestSender(t *testing.T) {
 	})
 
 	t.Run("403_throttles_refresh", func(t *testing.T) {
-		assert := assert.New(t)
-		server := newTestServer()
+		server := newTestServer() // outside the synctest bubble: its Accept loop never durably blocks
 		defer server.Close()
+		synctest.Test(t, syncTest403ThrottlesRefresh(server))
+	})
+}
+
+func syncTest403ThrottlesRefresh(server *testServer) func(*testing.T) {
+	return func(t *testing.T) {
+		assert := assert.New(t)
 		defer useBackoffDuration(time.Nanosecond)()
 
-		s, err := newTestSender(server.URL)
+		s, err := newInProcessTestSender(server)
 		assert.NoError(err)
 
 		callCount := 0
@@ -400,7 +407,7 @@ func TestSender(t *testing.T) {
 		assert.Equal(2, callCount, "third 403 after throttle should trigger refresh")
 
 		s.Stop()
-	})
+	}
 }
 
 func TestPayload(t *testing.T) {
@@ -494,14 +501,18 @@ func (r *mockRecorder) recordEvent(t eventType, data *eventData) {
 }
 
 func newTestSender(serverURL string) (*sender, error) {
+	cfg := config.New()
+	cfg.ConnectionResetInterval = 0
+	return newTestSenderWithClient(serverURL, cfg.NewHTTPClient())
+}
+
+func newTestSenderWithClient(serverURL string, client *config.ResetClient) (*sender, error) {
 	url, err := url.Parse(serverURL + "/")
 	if err != nil {
 		return nil, err
 	}
-	cfg := config.New()
-	cfg.ConnectionResetInterval = 0
 	scfg := &senderConfig{
-		client:     cfg.NewHTTPClient(),
+		client:     client,
 		url:        url,
 		maxConns:   100,
 		maxQueued:  40,
@@ -513,4 +524,18 @@ func newTestSender(serverURL string) (*sender, error) {
 	}
 	statsd := &statsd.NoOpClient{}
 	return newSender(scfg, apiKeyManager, statsd), nil
+}
+
+func newInProcessTestSender(server *testServer) (*sender, error) {
+	return newTestSenderWithClient(server.URL, config.NewResetClient(0, func() *http.Client {
+		return &http.Client{Transport: handlerTransport(server.ServeHTTP)}
+	}))
+}
+
+type handlerTransport http.HandlerFunc
+
+func (tr handlerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rec := httptest.NewRecorder()
+	tr(rec, req)
+	return rec.Result(), nil
 }


### PR DESCRIPTION
### What does this PR do?
Run the `403_throttles_refresh` subtest inside a `testing/synctest` "bubble" so the throttle interval is driven by the fake clock rather than a wall-clock `time.Sleep`.
Serve the test server in-process via a `handlerTransport` adapter so no TCP socket enters the bubble (a goroutine blocked on a network syscall is never durably blocked and would freeze the fake clock).

Extract the body into `syncTest403ThrottlesRefresh` and factor sender construction into `newTestSenderWithClient`, shared with the new `newInProcessTestSender`.

### Motivation
The subtest relied on real time: a 100ms throttle versus a 110ms `time.Sleep`, with each `Push` driving up to `maxRetries` refresh attempts.
Under CPU load the timing slipped and extra refreshes leaked through, failing the test intermittently.
Local example (`bazel test //pkg/trace/writer:writer_test`):
```
==================== Test output for //pkg/trace/writer:writer_test:
--- FAIL: TestSender (2.60s)
    --- FAIL: TestSender/403_throttles_refresh (0.38s)
        sender_test.go:400:
            	Error Trace:	pkg/trace/writer/sender_test.go:400
            	Error:      	Not equal:
            	            	expected: 2
            	            	actual  : 3
            	Test:       	TestSender/403_throttles_refresh
            	Messages:   	third 403 after throttle should trigger refresh
FAIL
================================================================================
```
CI example (`tests_windows-x64` job): https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1723990569#L3360

The fake clock removes the wall-clock dependency and makes the assertions deterministic, while slightly speeding up test execution.

### Describe how you validated your changes
Per-run wall time, 10 unloaded samples each:
```
go test -tags test -v -count 10 \
    -run TestSender/403_throttles_refresh$ ./pkg/trace/writer/
```
0.14 s before, <0.01 s after (virtual time collapses the sleep).

Failure ratio under CPU load: ~1/300 before, 0% after.

### Additional Notes
Worth a read: https://go.dev/blog/synctest.