### PR TITLE
Remove load balancer default from ECS fakeintake scenario

### DIFF
--- a/test/e2e-framework/components/datadog/agent/ecs.go
+++ b/test/e2e-framework/components/datadog/agent/ecs.go
@@ -273,6 +273,16 @@ func ecsFakeintakeAdditionalEndpointsEnv(fakeintake *fakeintake.Fakeintake) []ec
 			Name:  pulumi.StringPtr("DD_LOGS_CONFIG_USE_HTTP"),
 			Value: pulumi.StringPtr("true"),
 		},
+		ecs.TaskDefinitionKeyValuePairArgs{
+			Name: pulumi.StringPtr("DD_LOGS_CONFIG_LOGS_NO_SSL"),
+			Value: fakeintake.Scheme.ApplyT(func(scheme string) *string {
+				s := "false"
+				if scheme == "http" {
+					s = "true"
+				}
+				return &s
+			}).(pulumi.StringPtrOutput),
+		},
 	}
 }
 

--- a/test/e2e-framework/components/datadog/agent/ecs.go
+++ b/test/e2e-framework/components/datadog/agent/ecs.go
@@ -6,6 +6,8 @@
 package agent
 
 import (
+	"fmt"
+
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/ecsagentparams"
@@ -266,8 +268,14 @@ func ecsFakeintakeAdditionalEndpointsEnv(fakeintake *fakeintake.Fakeintake) []ec
 			Value: pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fakeintake.URL.ToStringOutput()),
 		},
 		ecs.TaskDefinitionKeyValuePairArgs{
-			Name:  pulumi.String("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS"),
-			Value: pulumi.Sprintf(`[{"host": "%s"}]`, fakeintake.Host),
+			Name: pulumi.String("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS"),
+			Value: pulumi.All(fakeintake.Host, fakeintake.Port, fakeintake.Scheme).ApplyT(func(args []interface{}) (string, error) {
+				host := args[0].(string)
+				port := args[1].(int)
+				scheme := args[2].(string)
+				useSSL := scheme != "http"
+				return fmt.Sprintf(`[{"host": %q, "port": %d, "use_ssl": %t}]`, host, port, useSSL), nil
+			}).(pulumi.StringOutput),
 		},
 		ecs.TaskDefinitionKeyValuePairArgs{
 			Name:  pulumi.StringPtr("DD_LOGS_CONFIG_USE_HTTP"),

--- a/test/e2e-framework/scenarios/aws/ecs/run_args.go
+++ b/test/e2e-framework/scenarios/aws/ecs/run_args.go
@@ -43,7 +43,7 @@ func GetRunParams(opts ...RunOption) *RunParams {
 	p := &RunParams{
 		Name:                    defaultECSName,
 		agentOptions:            []ecsagentparams.Option{},
-		fakeintakeOptions:       []scenfi.Option{scenfi.WithLoadBalancer()},
+		fakeintakeOptions:       []scenfi.Option{},
 		ecsOptions:              []Option{},
 		workloadAppFuncs:        []WorkloadAppFunc{},
 		fargateWorkloadAppFuncs: []FargateWorkloadAppFunc{},


### PR DESCRIPTION
The ECS scenario was the only one that unconditionally defaulted fakeintake to use a load balancer. This caused new-e2e-containers-ecs, new-e2e-process-ecs, and new-e2e-npm-docker jobs to always spin up a load balancer even after LB support was removed from fakeintake in #49978.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
