### PR TITLE
Bump Trivy fork to defer per file application analyzers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1241,7 +1241,7 @@ replace github.com/hashicorp/vault/sdk => github.com/hashicorp/vault/sdk v0.19.1
 // Use custom Trivy fork to reduce binary size
 // Pull in replacements needed by upstream Trivy
 // Maps to Trivy fork https://github.com/DataDog/trivy/pull/32
-replace github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20260513170708-3c7f1f6b38e8
+replace github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20260601163858-2f12eac6ff81
 
 // github.com/docker/docker v28 has known security vulnerabilities (CVE-2026-34040, CVE-2026-33997).
 // Pin to the 28.x branch head which includes the backported security fixes (not yet tagged).

--- a/go.sum
+++ b/go.sum
@@ -2595,8 +2595,8 @@ github.com/DataDog/rshell v0.0.20 h1:WO/GUY/SPplBBRU2wPVMLE8SCP4lZpFhVXu/h6KBzb0
 github.com/DataDog/rshell v0.0.20/go.mod h1:jZm0YIxCKYEyHJeSSH5rxqmlI1oUi+mXQF6Zf102q+k=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=
 github.com/DataDog/sketches-go v1.4.8/go.mod h1:a/wjRUqzqtGS8qRHRPDCs4EAQfmvPDZGDlMIF5mxXOE=
-github.com/DataDog/trivy v0.0.0-20260513170708-3c7f1f6b38e8 h1:SGspm+q7GP1LWZvvhx2NbkRjYWRowvTXvI/QXAbkrrg=
-github.com/DataDog/trivy v0.0.0-20260513170708-3c7f1f6b38e8/go.mod h1:Kb3o3UpLuPGtY1IDeNSi5Br2npMaFkqrYkvzk/7tLFE=
+github.com/DataDog/trivy v0.0.0-20260601163858-2f12eac6ff81 h1:GGzfDFX3hWCJgUQZwhwmY6S+LsQ0QYyKkQ67lsPp23E=
+github.com/DataDog/trivy v0.0.0-20260601163858-2f12eac6ff81/go.mod h1:Kb3o3UpLuPGtY1IDeNSi5Br2npMaFkqrYkvzk/7tLFE=
 github.com/DataDog/vault/api/auth/aws v0.0.0-20250716193101-44fb30472101 h1:aatle7zFb175XJ6iJvyr9a7Ipr1Dvpw4oy4MqL9v4GA=
 github.com/DataDog/vault/api/auth/aws v0.0.0-20250716193101-44fb30472101/go.mod h1:GRki58GuFuDh0GFVg280DZt3oCYxZG02ldDPtQ5FBoo=
 github.com/DataDog/viper v1.15.1 h1:kcdFE+qPndlWkhU4iEf/WpWQMCyVYHTv5HqvVf+SYJs=


### PR DESCRIPTION
### What does this PR do?

The fork now runs the per file application and language analyzers after OS package detection, so files owned by an OS package are skipped. This keeps host filesystem scans fast when languages are enabled and applies the exclusion uniformly across the host, container overlay and image scan paths.

### Motivation

### Describe how you validated your changes

### Additional Notes
