### PR TITLE
fix(deps): correct pcre2 SBOM purl package name

### DIFF
--- a/deps/pcre2.BUILD.bazel
+++ b/deps/pcre2.BUILD.bazel
@@ -21,7 +21,7 @@ package_metadata(
         ":license",
     ],
     purl = purl_for_generic(
-        package = "libsepol",
+        package = "pcre2",
         version = VERSION,
         # It is OK to point to the download URL where you retrieved the file, rather than the
         # canonical upstream version. It might even be preferable. PURLs are pretty much an


### PR DESCRIPTION
### What does this PR do?
Corrects the PURL `package` field in `deps/pcre2.BUILD.bazel` from `libsepol` to `pcre2`.

### Motivation
It's a copy-paste leftover; this file is the pcre2 overlay, so the SBOM/PURL metadata reported the wrong package.

### Describe how you validated your changes

### Additional Notes
