### PR TITLE
Fix regeneration gap for `pkg/discovery/tracermetadata/model/tracer_metadata_gen[_test].go`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -953,6 +953,7 @@ write_source_files(
     name = "write_all",
     additional_update_targets = [
         "//comp/forwarder/defaultforwarder/internal/retry:write_pb_go",
+        "//pkg/discovery/tracermetadata/model:tracer_metadata_gen",
         "//pkg/proto/msgpgo:key_gen",
         "//pkg/proto/pbgo/core:remoteconfig_gen",
         "//pkg/proto/pbgo/core:write_pb_go",

--- a/pkg/discovery/tracermetadata/model/BUILD.bazel
+++ b/pkg/discovery/tracermetadata/model/BUILD.bazel
@@ -1,10 +1,19 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("//bazel/rules/go_msgp:defs.bzl", "go_msgp")
 
 # Source-level export so the //pkg/security/secl/model:event_deep_copy_*
 # Bazel codegens can resolve tracermetadata.TracerMetadata.
 exports_files(
     ["tracer_metadata.go"],
     visibility = ["//pkg/security/secl/model:__pkg__"],
+)
+
+go_msgp(
+    name = "tracer_metadata_gen",
+    src = "tracer_metadata.go",
+    out = "tracer_metadata_gen.go",
+    io = True,
+    out_test = "tracer_metadata_gen_test.go",
 )
 
 go_library(


### PR DESCRIPTION
### What does this PR do?
Wire `pkg/discovery/tracermetadata/model/tracer_metadata.go` into a `go_msgp` target and pull `tracer_metadata_gen` into the repo-wide `//:write_all` umbrella (#51473), so the matching `tracer_metadata_gen.go` and `tracer_metadata_gen_test.go` get regenerated alongside the other `msgp`-generated files in the repo.

### Motivation
In the same vein as #51495: `pkg/discovery/tracermetadata/model/tracer_metadata_gen[_test].go` are `msgp`-generated but have had no regeneration mechanism since the file was introduced in #35865 (Apr. 2025): no `dda inv` task nor any other script (re)produces them.
Any change to `tracer_metadata.go` would drift silently from the marshaller used in production by
`pkg/discovery/tracermetadata/tracer_memfd.go` (`UnmarshalMsg` of the tracer metadata read from the `memfd` descriptor).

The gap was surfaced incidentally after running `find . -name '*.pb.go' -o -name '*_gen.go' | xargs rm -v` followed by `bazel run //:write_all` left this single file unrestored.

### Describe how you validated your changes
- `bazel run //:write_all` regenerates the two `_gen` files byte-identically,
- `bazel test //...` passes, including the auto-generated `tracer_metadata_gen_*_test` diff tests,
- consumers in `pkg/discovery/tracermetadata/{tracer_memfd.go,tracer_java_test.go}` continue to build against the unchanged `tracer_metadata_gen.go`.

### Additional Notes
`io = True` mirrors the original `msgp` invocation.