### PR TITLE
Refresh `pkg/proto/datadog/api/README.md`

### DIFF
--- a/pkg/proto/datadog/api/README.md
+++ b/pkg/proto/datadog/api/README.md
@@ -6,20 +6,19 @@ files, run the following from the repository root:
 dda inv protobuf.generate
 ```
 
-This invokes Bazel to resolve all required tools (`protoc`,
-`protoc-gen-go`, etc.) hermetically; they do not need to be
-installed separately. To build the tools directly with Bazel:
+This task is essentially a wrapper around:
 ```
-bazel build \
-  //bazel/toolchains/protoc \
-  @com_github_favadi_protoc_go_inject_tag//:protoc-go-inject-tag \
-  @org_uber_go_mock//mockgen \
-  @com_github_planetscale_vtprotobuf//cmd/protoc-gen-go-vtproto \
-  @com_github_tinylib_msgp//:msgp \
-  @org_golang_google_grpc_cmd_protoc_gen_go_grpc//:protoc-gen-go-grpc \
-  @org_golang_google_protobuf//cmd/protoc-gen-go \
-  @rules_go//go
+bazel run //:write_all
 ```
+
+The above Bazel command makes sure all required tools (`protoc`,
+`protoc-gen-go`, etc.) are built hermetically, then runs them and
+writes their (re)generated outputs back into the source tree.
+
+To add generated files to its scope, declare the relevant rule
+(`write_pb_go`, `go_msgp`, `go_mockgen`, etc.) in the package's
+`BUILD.bazel` file and insert its label into `//:write_all`'s
+`additional_update_targets` in the root `BUILD.bazel` file.
 
 ### Notes
 


### PR DESCRIPTION
### What does this PR do?
Update `pkg/proto/datadog/api/README.md` so it reflects the `bazel`-managed workflow that became the actual code path over time:
- replace the now obsolete `bazel build <one-tool-label-per-line>` recipe with the `//:write_all` umbrella the task actually invokes,
- tell contributors how to wire a new generator into the umbrella's scope.

### Motivation
New contributors landing on the README need (f)actual hints.

### Additional Notes
The doc was already flagged as stale in https://github.com/DataDog/datadog-agent/pull/51422#discussion_r3318486885, and has further drifted since the `//:write_all` umbrella moved up to the repo root (#51573) with cross-tree scope (`pkg/proto/...`, `pkg/security/proto/...`, `//comp/forwarder/defaultforwarder/...`, etc.)