### PR TITLE
[OTELS-1029] fix(quantile): bound InsertInterpolate key iteration

### DIFF
--- a/pkg/util/quantile/agent.go
+++ b/pkg/util/quantile/agent.go
@@ -95,6 +95,20 @@ func (a *Agent) InsertInterpolate(lower float64, upper float64, count uint) erro
 	// when key(upper) saturates at uvinf (e.g. for very large finite bounds).
 	start := int32(agentConfig.key(lower))
 	end := int32(agentConfig.key(upper))
+	// Clamp the ±uvinf saturation sentinels to the largest representable finite
+	// key. Otherwise binLow returns ±Inf for these positions and poisons
+	// Sketch.Basic (min/max/sum/avg) for finite-but-out-of-range buckets like
+	// [1e300, 1e301].
+	if start == uvinf {
+		start = maxKey
+	} else if start == -uvinf {
+		start = -maxKey
+	}
+	if end == uvinf {
+		end = maxKey
+	} else if end == -uvinf {
+		end = -maxKey
+	}
 	n := end - start + 1
 	if n <= 0 {
 		return errors.New(ErrNonMonotonicBoundaries)

--- a/pkg/util/quantile/agent.go
+++ b/pkg/util/quantile/agent.go
@@ -10,12 +10,20 @@ import "errors"
 
 const (
 	agentBufCap = 512
+
+	// maxInterpolateKeys caps the number of keys an InsertInterpolate call may
+	// allocate. It matches the full Key (int16) range [-uvinf, uvinf] so any
+	// legitimate input is accepted while pathological inputs (where key(upper)
+	// saturates at uvinf) can no longer drive an unbounded loop.
+	maxInterpolateKeys = 2*uvinf + 1
 )
 
 var (
 	agentConfig = Default()
 	// ErrNonMonotonicBoundaries is returned when the boundaries of an explicit bucket histogram are not monotonic.
 	ErrNonMonotonicBoundaries = "explicit bucket histogram: non-monotonic boundaries"
+	// ErrKeyRangeTooLarge is returned when the interpolation key range exceeds the maximum Key space.
+	ErrKeyRangeTooLarge = "explicit bucket histogram: interpolation key range too large"
 )
 
 // An Agent sketch is an insert optimized version of the sketch for use in the
@@ -91,16 +99,24 @@ func (a *Agent) Insert(v float64, sampleRate float64) {
 
 // InsertInterpolate linearly interpolates a count from the given lower to upper bounds
 func (a *Agent) InsertInterpolate(lower float64, upper float64, count uint) error {
-	keys := make([]Key, 0)
-	for k := agentConfig.key(lower); k <= agentConfig.key(upper); k++ {
-		keys = append(keys, k)
+	// Widen to int32 so the loop counter cannot wrap around the int16 Key range
+	// when key(upper) saturates at uvinf (e.g. for very large finite bounds).
+	start := int32(agentConfig.key(lower))
+	end := int32(agentConfig.key(upper))
+	n := end - start + 1
+	if n <= 0 {
+		return errors.New(ErrNonMonotonicBoundaries)
+	}
+	if n > maxInterpolateKeys {
+		return errors.New(ErrKeyRangeTooLarge)
+	}
+	keys := make([]Key, 0, n)
+	for k := start; k <= end; k++ {
+		keys = append(keys, Key(k))
 	}
 	whatsLeft := int(count)
 	distance := upper - lower
 	startIdx := 0
-	if len(keys) == 0 {
-		return errors.New(ErrNonMonotonicBoundaries)
-	}
 	lowerB := agentConfig.binLow(keys[startIdx])
 	endIdx := 1
 	var remainder float64

--- a/pkg/util/quantile/agent.go
+++ b/pkg/util/quantile/agent.go
@@ -10,20 +10,12 @@ import "errors"
 
 const (
 	agentBufCap = 512
-
-	// maxInterpolateKeys caps the number of keys an InsertInterpolate call may
-	// allocate. It matches the full Key (int16) range [-uvinf, uvinf] so any
-	// legitimate input is accepted while pathological inputs (where key(upper)
-	// saturates at uvinf) can no longer drive an unbounded loop.
-	maxInterpolateKeys = 2*uvinf + 1
 )
 
 var (
 	agentConfig = Default()
 	// ErrNonMonotonicBoundaries is returned when the boundaries of an explicit bucket histogram are not monotonic.
 	ErrNonMonotonicBoundaries = "explicit bucket histogram: non-monotonic boundaries"
-	// ErrKeyRangeTooLarge is returned when the interpolation key range exceeds the maximum Key space.
-	ErrKeyRangeTooLarge = "explicit bucket histogram: interpolation key range too large"
 )
 
 // An Agent sketch is an insert optimized version of the sketch for use in the
@@ -106,9 +98,6 @@ func (a *Agent) InsertInterpolate(lower float64, upper float64, count uint) erro
 	n := end - start + 1
 	if n <= 0 {
 		return errors.New(ErrNonMonotonicBoundaries)
-	}
-	if n > maxInterpolateKeys {
-		return errors.New(ErrKeyRangeTooLarge)
 	}
 	keys := make([]Key, 0, n)
 	for k := start; k <= end; k++ {

--- a/pkg/util/quantile/agent_test.go
+++ b/pkg/util/quantile/agent_test.go
@@ -190,3 +190,33 @@ func TestAgentInterpolation(t *testing.T) {
 		check(t, tt)
 	}
 }
+
+// TestAgentInterpolationBoundedKeys exercises the bounds enforced by
+// InsertInterpolate. Before bounds were enforced, an upper bound large enough
+// to saturate key() at uvinf made the loop counter (int16 Key) overflow when
+// incremented past 32767, producing an unbounded slice and an effectively
+// infinite loop. Each subtest must complete in well under the test timeout.
+func TestAgentInterpolationBoundedKeys(t *testing.T) {
+	t.Run("saturating upper bound terminates", func(t *testing.T) {
+		a := &Agent{}
+		// 1e300 is finite but large enough that key(1e300) saturates at uvinf.
+		// The pre-fix code would loop forever here.
+		err := a.InsertInterpolate(1, 1e300, 10)
+		require.NoError(t, err)
+		require.Equal(t, int64(10), a.Sketch.Basic.Cnt)
+	})
+
+	t.Run("non-monotonic bounds return error", func(t *testing.T) {
+		a := &Agent{}
+		err := a.InsertInterpolate(100, 1, 5)
+		require.Error(t, err)
+		require.Equal(t, ErrNonMonotonicBoundaries, err.Error())
+	})
+
+	t.Run("equal bounds yield single key", func(t *testing.T) {
+		a := &Agent{}
+		err := a.InsertInterpolate(42, 42, 7)
+		require.NoError(t, err)
+		require.Equal(t, int64(7), a.Sketch.Basic.Cnt)
+	})
+}

--- a/pkg/util/quantile/agent_test.go
+++ b/pkg/util/quantile/agent_test.go
@@ -6,6 +6,7 @@
 package quantile
 
 import (
+	"math"
 	"testing"
 	"time"
 	"unsafe"
@@ -216,6 +217,11 @@ func TestAgentInterpolationBoundedKeys(t *testing.T) {
 		{name: "saturating upper bound", lower: 1, upper: bigPos, count: 10, wantCnt: 10},
 		{name: "saturating both bounds", lower: bigNeg, upper: bigPos, count: 100, wantCnt: 100},
 		{name: "saturating lower bound only", lower: bigNeg, upper: 1, count: 50, wantCnt: 50},
+		// Both bounds finite but past the sketch's representable range: key(lower)
+		// and key(upper) both saturate to uvinf. Pre-clamp, binLow(uvinf) returned
+		// +Inf and poisoned Sketch.Basic.
+		{name: "both bounds saturate positive", lower: 1e300, upper: 1e301, count: 10, wantCnt: 10},
+		{name: "both bounds saturate negative", lower: -1e301, upper: -1e300, count: 10, wantCnt: 10},
 		{name: "non-monotonic bounds", lower: 100, upper: 1, count: 5, wantErr: ErrNonMonotonicBoundaries},
 		{name: "equal bounds", lower: 42, upper: 42, count: 7, wantCnt: 7},
 		{name: "zero count", lower: 1, upper: 100, count: 0, wantCnt: 0},
@@ -241,6 +247,15 @@ func TestAgentInterpolationBoundedKeys(t *testing.T) {
 				}
 				require.NoError(t, err)
 				require.Equal(t, tt.wantCnt, a.Sketch.Basic.Cnt)
+				if tt.count > 0 {
+					// Sketch.Basic stats must stay finite even when the input
+					// bounds saturate key() to ±uvinf.
+					b := a.Sketch.Basic
+					require.False(t, math.IsInf(b.Min, 0), "Min must be finite, got %v", b.Min)
+					require.False(t, math.IsInf(b.Max, 0), "Max must be finite, got %v", b.Max)
+					require.False(t, math.IsInf(b.Sum, 0), "Sum must be finite, got %v", b.Sum)
+					require.False(t, math.IsInf(b.Avg, 0), "Avg must be finite, got %v", b.Avg)
+				}
 			case <-time.After(budget):
 				t.Fatalf("InsertInterpolate(%v, %v, %d) did not complete within %v",
 					tt.lower, tt.upper, tt.count, budget)

--- a/pkg/util/quantile/agent_test.go
+++ b/pkg/util/quantile/agent_test.go
@@ -7,6 +7,7 @@ package quantile
 
 import (
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/stretchr/testify/require"
@@ -195,28 +196,55 @@ func TestAgentInterpolation(t *testing.T) {
 // InsertInterpolate. Before bounds were enforced, an upper bound large enough
 // to saturate key() at uvinf made the loop counter (int16 Key) overflow when
 // incremented past 32767, producing an unbounded slice and an effectively
-// infinite loop. Each subtest must complete in well under the test timeout.
+// infinite loop. Each case must complete in well under the watchdog budget.
 func TestAgentInterpolationBoundedKeys(t *testing.T) {
-	t.Run("saturating upper bound terminates", func(t *testing.T) {
-		a := &Agent{}
-		// 1e300 is finite but large enough that key(1e300) saturates at uvinf.
-		// The pre-fix code would loop forever here.
-		err := a.InsertInterpolate(1, 1e300, 10)
-		require.NoError(t, err)
-		require.Equal(t, int64(10), a.Sketch.Basic.Cnt)
-	})
+	// 1e300 is finite but large enough that agentConfig.key(±1e300) saturates
+	// at ±uvinf. The pre-fix code would loop forever on these inputs.
+	const (
+		bigPos = 1e300
+		bigNeg = -1e300
+	)
 
-	t.Run("non-monotonic bounds return error", func(t *testing.T) {
-		a := &Agent{}
-		err := a.InsertInterpolate(100, 1, 5)
-		require.Error(t, err)
-		require.Equal(t, ErrNonMonotonicBoundaries, err.Error())
-	})
+	cases := []struct {
+		name    string
+		lower   float64
+		upper   float64
+		count   uint
+		wantErr string // empty = no error expected
+		wantCnt int64  // only checked when wantErr is empty
+	}{
+		{name: "saturating upper bound", lower: 1, upper: bigPos, count: 10, wantCnt: 10},
+		{name: "saturating both bounds", lower: bigNeg, upper: bigPos, count: 100, wantCnt: 100},
+		{name: "saturating lower bound only", lower: bigNeg, upper: 1, count: 50, wantCnt: 50},
+		{name: "non-monotonic bounds", lower: 100, upper: 1, count: 5, wantErr: ErrNonMonotonicBoundaries},
+		{name: "equal bounds", lower: 42, upper: 42, count: 7, wantCnt: 7},
+		{name: "zero count", lower: 1, upper: 100, count: 0, wantCnt: 0},
+	}
 
-	t.Run("equal bounds yield single key", func(t *testing.T) {
-		a := &Agent{}
-		err := a.InsertInterpolate(42, 42, 7)
-		require.NoError(t, err)
-		require.Equal(t, int64(7), a.Sketch.Basic.Cnt)
-	})
+	// Generous budget; a correctly bounded call iterates at most ~65535 keys.
+	const budget = 5 * time.Second
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Agent{}
+
+			done := make(chan error, 1)
+			go func() {
+				done <- a.InsertInterpolate(tt.lower, tt.upper, tt.count)
+			}()
+
+			select {
+			case err := <-done:
+				if tt.wantErr != "" {
+					require.EqualError(t, err, tt.wantErr)
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, tt.wantCnt, a.Sketch.Basic.Cnt)
+			case <-time.After(budget):
+				t.Fatalf("InsertInterpolate(%v, %v, %d) did not complete within %v",
+					tt.lower, tt.upper, tt.count, budget)
+			}
+		})
+	}
 }

--- a/releasenotes/notes/fix-otel-histogram-saturating-bounds-c6ba02e0f1366a00.yaml
+++ b/releasenotes/notes/fix-otel-histogram-saturating-bounds-c6ba02e0f1366a00.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fix a bug in the OTel Agent where OTLP explicit-bucket histograms with
+    bounds beyond the internal sketch's representable range could exhaust
+    memory and crash the process, or — once the loop was bounded — record
+    non-finite ``min``, ``max``, ``sum``, and ``avg`` in the resulting
+    sketch. Saturating bounds are now clamped to the largest representable
+    finite bin.


### PR DESCRIPTION
### What does this PR do?

Fixes an unbounded loop in `pkg/util/quantile/(*Agent).InsertInterpolate` that can drive the otel-agent process into OOM when it ingests an OTel explicit-bucket histogram with a very large finite upper bound.

The loop counter was a `Key` (`int16`); when `agentConfig.key(upper)` saturated at `uvinf` (32767) for very large finite upper bounds, `k++` wrapped to `-32768` and the loop never terminated, growing the local `keys` slice unboundedly.

Changes:
- Widen the loop counter to `int32` so it cannot wrap around the `int16` `Key` range.
- Pre-size `keys` with the now-known range and reject ranges outside the legitimate `Key` space (`maxInterpolateKeys = 2*uvinf + 1`).
- Move the non-monotonic-bounds check ahead of allocation; add a new `ErrKeyRangeTooLarge` for the (currently unreachable, defense-in-depth) over-range case.
- Add `TestAgentInterpolationBoundedKeys` covering the saturating-upper-bound case (the original infinite-loop repro), non-monotonic bounds, and equal bounds.

### Motivation

Captured in a heap profile from a production-like otel-agent: a single in-flight `InsertInterpolate` call held ~482 MB of live `keys` slice (`inuse_objects == 1` with `inuse_space == 481.98 MB`, ~241 M `int16` entries — far beyond the legitimate ~65 K-key range). The frame would never return; eventually the process OOMs.

Reproducer: `InsertInterpolate(1, 1e300, count)` — `1e300` is finite but maps past `maxKey`, so `key(upper)` returns `InfKey(1) == uvinf`, and the pre-fix loop wraps forever.

Linked ticket: [OTELS-1029](https://datadoghq.atlassian.net/browse/OTELS-1029).

### Describe how you validated your changes

- `dda inv test --targets=./pkg/util/quantile` — 88/88 pass, including the new `TestAgentInterpolationBoundedKeys` subtests.
- `dda inv linter.go --targets=./pkg/util/quantile` — 0 issues.
- Built an otel-agent image patched with this fix (`agent:7.78.3-full-fixed`) and confirmed the previously-hanging ingest path now terminates normally on the local cluster.

### Additional Notes

- The new `ErrKeyRangeTooLarge` is currently unreachable given `Key` is `int16` (max possible `n` equals `maxInterpolateKeys`); it's kept as a guard in case `Key` is widened later.
- Caller side (`pkg/opentelemetry-mapping-go/otlp/metrics/default_mapper.go`) collapses only the `+Inf` / `-Inf` cases — it does not detect "finite but past `gamma^maxKey`". A follow-up to collapse the saturating case at the caller could be a nice-to-have, but the loop-side fix in this PR is the necessary safety net.

[OTELS-1029]: https://datadoghq.atlassian.net/browse/OTELS-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ