### PR TITLE
(fleet) use umask 0022 in the fleet setup script

### DIFF
--- a/pkg/fleet/installer/setup/install.sh
+++ b/pkg/fleet/installer/setup/install.sh
@@ -3,7 +3,7 @@
 # Copyright 2016-present Datadog, Inc.
 #
 set -euo pipefail
-umask 0
+umask 0022
 
 os=$(uname -s)
 arch=$(uname -m)


### PR DESCRIPTION
## Summary

This PR sets `umask 0022` at the top of the fleet setup script (`pkg/fleet/installer/setup/install.sh`), replacing the previous `umask 0`.

## Motivation

Running under `umask 0` caused the `/opt/datadog-packages/tmp` directory and the installer binary downloaded into it to be created world-writable. Setting `umask 0022` ensures the temp directory and the downloaded installer are created with restrictive permissions (`0755` for the directory, `0644` for files) before the installer binary is integrity-verified and executed.

## Tradeoffs

None — the directory and binary are still created and managed the same way; only their default permission bits are tightened.