### PR TITLE
[FA] fix(fleet): add GovCloud OCI registry (install.ddog-gov.com)

### DIFF
--- a/pkg/fleet/installer/env/env.go
+++ b/pkg/fleet/installer/env/env.go
@@ -235,6 +235,12 @@ type Env struct {
 	FIPSMode bool
 }
 
+// IsGovSite reports whether the configured site is a GovCloud site,
+// including org sub-sites such as us2.ddog-gov.com.
+func (e *Env) IsGovSite() bool {
+	return e.Site == "ddog-gov.com" || strings.HasSuffix(e.Site, ".ddog-gov.com")
+}
+
 func (e *Env) HasDefaultRegistryOverride() bool {
 	return e.RegistryOverride == defaultEnv.RegistryOverride
 }

--- a/pkg/fleet/installer/env/env_test.go
+++ b/pkg/fleet/installer/env/env_test.go
@@ -442,3 +442,24 @@ func TestAgentUserVars(t *testing.T) {
 		})
 	}
 }
+
+func TestIsGovSite(t *testing.T) {
+	tests := []struct {
+		site     string
+		expected bool
+	}{
+		{"ddog-gov.com", true},
+		{"us2.ddog-gov.com", true},
+		{"xxxx99.ddog-gov.com", true},
+		{"datadoghq.com", false},
+		{"datad0g.com", false},
+		{"evilddog-gov.com", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.site, func(t *testing.T) {
+			e := &Env{Site: tt.site}
+			assert.Equal(t, tt.expected, e.IsGovSite())
+		})
+	}
+}

--- a/pkg/fleet/installer/oci/download.go
+++ b/pkg/fleet/installer/oci/download.go
@@ -88,6 +88,9 @@ var (
 		"install.datadoghq.com",
 		"gcr.io/datadoghq",
 	}
+	defaultRegistriesGovCloud = []string{
+		"install.ddog-gov.com",
+	}
 )
 
 // LayerAnnotation is the annotation used to identify the layer.
@@ -223,8 +226,11 @@ func getRefAndKeychains(mainEnv *env.Env, url string) []urlWithKeychain {
 	}
 
 	defaultRegistries := defaultRegistriesProd
-	if mainEnv.Site == "datad0g.com" {
+	switch {
+	case mainEnv.Site == "datad0g.com":
 		defaultRegistries = defaultRegistriesStaging
+	case mainEnv.IsGovSite():
+		defaultRegistries = defaultRegistriesGovCloud
 	}
 	for _, additionalDefaultRegistry := range defaultRegistries {
 		refAndKeychain := getRefAndKeychain(&env.Env{RegistryOverride: additionalDefaultRegistry}, url)
@@ -459,9 +465,11 @@ func (d *DownloadedPackage) WriteOCILayout(dir string) (err error) {
 // Both base and FIPS flavors live under the same URL — flavor selection
 // happens at download time via Platform.Variant in downloadIndex.
 func PackageURL(env *env.Env, pkg string, version string) string {
-	switch env.Site {
-	case "datad0g.com":
+	switch {
+	case env.Site == "datad0g.com":
 		return fmt.Sprintf("oci://install.datad0g.com/%s-package:%s", strings.TrimPrefix(pkg, "datadog-"), version)
+	case env.IsGovSite():
+		return fmt.Sprintf("oci://install.ddog-gov.com/%s-package:%s", strings.TrimPrefix(pkg, "datadog-"), version)
 	default:
 		return fmt.Sprintf("oci://install.datadoghq.com/%s-package:%s", strings.TrimPrefix(pkg, "datadog-"), version)
 	}

--- a/pkg/fleet/installer/oci/download_test.go
+++ b/pkg/fleet/installer/oci/download_test.go
@@ -323,6 +323,8 @@ func TestPackageURL(t *testing.T) {
 	tests := []test{
 		{site: "datad0g.com", pkg: "datadog-agent", version: "latest", expected: "oci://install.datad0g.com/agent-package:latest"},
 		{site: "datadoghq.com", pkg: "datadog-agent", version: "1.2.3", expected: "oci://install.datadoghq.com/agent-package:1.2.3"},
+		{site: "ddog-gov.com", pkg: "datadog-agent", version: "latest", expected: "oci://install.ddog-gov.com/agent-package:latest"},
+		{site: "us2.ddog-gov.com", pkg: "datadog-agent", version: "latest", expected: "oci://install.ddog-gov.com/agent-package:latest"},
 	}
 
 	for _, tt := range tests {
@@ -438,6 +440,7 @@ func TestGetRefAndKeychains(t *testing.T) {
 		registryAuthOverride    string
 		expectedRefAndKeychains []urlWithKeychain
 		isProd                  bool
+		site                    string // overrides isProd when set
 	}
 
 	tests := []test{
@@ -477,6 +480,22 @@ func TestGetRefAndKeychains(t *testing.T) {
 				{ref: "mysuperregistry.tv/agent-package@sha256:1234", keychain: google.Keychain},
 			},
 		},
+		{
+			name: "no override - gov",
+			url:  "install.ddog-gov.com/agent-package:latest",
+			site: "ddog-gov.com",
+			expectedRefAndKeychains: []urlWithKeychain{
+				{ref: "install.ddog-gov.com/agent-package:latest", keychain: authn.DefaultKeychain},
+			},
+		},
+		{
+			name: "no override - gov sub-site",
+			url:  "install.ddog-gov.com/agent-package:latest",
+			site: "us2.ddog-gov.com",
+			expectedRefAndKeychains: []urlWithKeychain{
+				{ref: "install.ddog-gov.com/agent-package:latest", keychain: authn.DefaultKeychain},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -488,6 +507,9 @@ func TestGetRefAndKeychains(t *testing.T) {
 			}
 			if tt.isProd {
 				env.Site = "datadoghq.com"
+			}
+			if tt.site != "" {
+				env.Site = tt.site
 			}
 			actual := getRefAndKeychains(env, tt.url)
 			assert.Len(t, actual, len(tt.expectedRefAndKeychains))

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -119,6 +119,14 @@ Running the %s installation script (https://github.com/DataDog/datadog-agent/tre
 		},
 	}
 
+	// For GovCloud, remote_configuration.enabled defaults to false unless explicitly set.
+	// The installer daemon requires RC, so we must opt-in explicitly when bootstrapping.
+	if s.Env.IsGovSite() {
+		s.Config.DatadogYAML.RemoteConfiguration = &config.DatadogConfigRemoteConfiguration{
+			Enabled: config.BoolToPtr(true),
+		}
+	}
+
 	// Map DD_LOGS_ENABLED env var into datadog.yaml
 	if logsEnabledEnv := os.Getenv("DD_LOGS_ENABLED"); logsEnabledEnv != "" {
 		logsEnabled := strings.EqualFold(logsEnabledEnv, "true") || logsEnabledEnv == "1"

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -71,27 +71,33 @@ type Config struct {
 
 // DatadogConfig represents the configuration to write in /etc/datadog-agent/datadog.yaml
 type DatadogConfig struct {
-	APIKey               string                     `yaml:"api_key,omitempty"`
-	Hostname             string                     `yaml:"hostname,omitempty"`
-	Site                 string                     `yaml:"site,omitempty"`
-	Proxy                DatadogConfigProxy         `yaml:"proxy,omitempty"`
-	Env                  string                     `yaml:"env,omitempty"`
-	Tags                 []string                   `yaml:"tags,omitempty"`
-	ExtraTags            []string                   `yaml:"extra_tags,omitempty"`
-	LogsEnabled          *bool                      `yaml:"logs_enabled,omitempty"`
-	DJM                  DatadogConfigDJM           `yaml:"djm_config,omitempty"`
-	ProcessConfig        DatadogConfigProcessConfig `yaml:"process_config,omitempty"`
-	ExpectedTagsDuration string                     `yaml:"expected_tags_duration,omitempty"`
-	RemoteUpdates        *bool                      `yaml:"remote_updates,omitempty"`
-	Installer            DatadogConfigInstaller     `yaml:"installer,omitempty"`
-	DDURL                string                     `yaml:"dd_url,omitempty"`
-	LogsConfig           LogsConfig                 `yaml:"logs_config,omitempty"`
-	GPUCheck             GPUCheckConfig             `yaml:"gpu,omitempty"`
-	SBOM                 SBOMConfig                 `yaml:"sbom,omitempty"`
-	InfrastructureMode   string                     `yaml:"infrastructure_mode,omitempty"`
-	APMConfig            DatadogAPMConfig           `yaml:"apm_config,omitempty"`
-	AppKey               string                     `yaml:"app_key,omitempty"`
-	PrivateActionRunner  PrivateActionRunnerConfig  `yaml:"private_action_runner,omitempty"`
+	APIKey               string                            `yaml:"api_key,omitempty"`
+	Hostname             string                            `yaml:"hostname,omitempty"`
+	Site                 string                            `yaml:"site,omitempty"`
+	Proxy                DatadogConfigProxy                `yaml:"proxy,omitempty"`
+	Env                  string                            `yaml:"env,omitempty"`
+	Tags                 []string                          `yaml:"tags,omitempty"`
+	ExtraTags            []string                          `yaml:"extra_tags,omitempty"`
+	LogsEnabled          *bool                             `yaml:"logs_enabled,omitempty"`
+	DJM                  DatadogConfigDJM                  `yaml:"djm_config,omitempty"`
+	ProcessConfig        DatadogConfigProcessConfig        `yaml:"process_config,omitempty"`
+	ExpectedTagsDuration string                            `yaml:"expected_tags_duration,omitempty"`
+	RemoteUpdates        *bool                             `yaml:"remote_updates,omitempty"`
+	Installer            DatadogConfigInstaller            `yaml:"installer,omitempty"`
+	DDURL                string                            `yaml:"dd_url,omitempty"`
+	LogsConfig           LogsConfig                        `yaml:"logs_config,omitempty"`
+	GPUCheck             GPUCheckConfig                    `yaml:"gpu,omitempty"`
+	SBOM                 SBOMConfig                        `yaml:"sbom,omitempty"`
+	InfrastructureMode   string                            `yaml:"infrastructure_mode,omitempty"`
+	APMConfig            DatadogAPMConfig                  `yaml:"apm_config,omitempty"`
+	AppKey               string                            `yaml:"app_key,omitempty"`
+	PrivateActionRunner  PrivateActionRunnerConfig         `yaml:"private_action_runner,omitempty"`
+	RemoteConfiguration  *DatadogConfigRemoteConfiguration `yaml:"remote_configuration,omitempty"`
+}
+
+// DatadogConfigRemoteConfiguration represents the remote_configuration section of datadog.yaml
+type DatadogConfigRemoteConfiguration struct {
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // PrivateActionRunnerConfig represents the configuration for the private action runner

--- a/pkg/fleet/installer/setup/config/config_test.go
+++ b/pkg/fleet/installer/setup/config/config_test.go
@@ -303,6 +303,29 @@ logs_enabled: true
 	}, datadog)
 }
 
+func TestRemoteConfigurationEnabled(t *testing.T) {
+	tempDir := t.TempDir()
+	existing := `---
+api_key: "key"
+`
+	writeInitialDatadogConfig(t, tempDir, existing)
+
+	cfg := Config{}
+	cfg.DatadogYAML.APIKey = "key"
+	cfg.DatadogYAML.RemoteConfiguration = &DatadogConfigRemoteConfiguration{Enabled: BoolToPtr(true)}
+
+	err := WriteConfigs(cfg, tempDir)
+	assert.NoError(t, err)
+
+	datadog := readDatadogYAML(t, tempDir)
+	assert.Equal(t, map[string]interface{}{
+		"api_key": "key",
+		"remote_configuration": map[string]interface{}{
+			"enabled": true,
+		},
+	}, datadog)
+}
+
 func TestAllBasicEnvVars(t *testing.T) {
 	tempDir := t.TempDir()
 	existing := `---

--- a/pkg/fleet/installer/setup/install.sh
+++ b/pkg/fleet/installer/setup/install.sh
@@ -30,7 +30,15 @@ aarch64)
   ;;
 esac
 site=${DD_SITE:-datadoghq.com}
-installer_domain=${DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE:-$([[ "$site" == "datad0g.com" ]] && echo "install.datad0g.com" || echo "install.datadoghq.com")}
+if [[ -n "${DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE:-}" ]]; then
+  installer_domain="$DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE"
+elif [[ "$site" == "datad0g.com" ]]; then
+  installer_domain="install.datad0g.com"
+elif [[ "$site" == "ddog-gov.com" || "$site" == *.ddog-gov.com ]]; then
+  installer_domain="install.ddog-gov.com"
+else
+  installer_domain="install.datadoghq.com"
+fi
 installer_url="https://${installer_domain}/v2/PACKAGE_NAME/blobs/sha256:${installer_sha256}"
 
 tmp_dir="/opt/datadog-packages/tmp"


### PR DESCRIPTION
## Problem

`apt-get install datadog-agent` hangs indefinitely when `remote_updates=true` and `DD_SITE=ddog-gov.com`.

Two separate issues caused the failure:

1. **Wrong OCI registry**: `PackageURL` and `getRefAndKeychains` had no `ddog-gov.com` case, so they fell through to the commercial prod registries (`install.datadoghq.com` / `gcr.io/datadoghq`), which are unreachable from GovCloud hosts. The same gap existed in `install.sh` for the initial installer binary download.

2. **RC disabled by default on GovCloud**: `remote_configuration.enabled` defaults to `false` on GovCloud, but the fleet installer daemon requires RC to function. Without it, the bootstrap stalls waiting for a daemon that never becomes ready.

## Fix

**Commit 1 — OCI registry**: add a `ddog-gov.com` case in `PackageURL`, `getRefAndKeychains`, and `install.sh` pointing to `install.ddog-gov.com`, matching the pattern used for other sites (`datad0g.com` → `install.datad0g.com`, `datadoghq.com` → `install.datadoghq.com`).

**Commit 2 — RC opt-in**: set `remote_configuration.enabled: true` in the bootstrap-generated `datadog.yaml` when `DD_SITE=ddog-gov.com`, so the installer daemon can start correctly.

## Immediate workaround (before this lands)

```sh
DD_INSTALLER_REGISTRY_URL=install.ddog-gov.com \
DD_SITE=ddog-gov.com \
DD_API_KEY=<key> \
bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
```

`DD_INSTALLER_REGISTRY_URL` sets `RegistryOverride`, which short-circuits the default registry fallback in `getRefAndKeychains` and was confirmed to fix the hang.