### PR TITLE
[pod/mutator] add dd-trace-c library

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -291,6 +291,34 @@ func TestAutoinstrumentation(t *testing.T) {
 				containerNames: defaultContainerNames,
 			},
 		},
+		"pod with mutate label and c annotation should mutate": {
+			config: map[string]any{
+				"apm_config.instrumentation.enabled":     false,
+				"admission_controller.mutate_unlabelled": false,
+			},
+			pod: common.FakePodSpec{
+				Name:       defaultTestContainer,
+				NS:         "application",
+				ParentKind: "replicaset",
+				ParentName: "deployment-123",
+				Annotations: map[string]string{
+					"admission.datadoghq.com/c-lib.version": "v0",
+				},
+				Labels: map[string]string{
+					admissioncommon.EnabledLabelKey: "true",
+				},
+			}.Create(),
+			deployments:  defaultDeployments,
+			namespaces:   defaultNamespaces,
+			shouldMutate: true,
+			expected: &expected{
+				injectorVersion: defaultInjectorVersion,
+				libraryVersions: map[string]string{
+					"c": "v0",
+				},
+				containerNames: defaultContainerNames,
+			},
+		},
 		"pod with mutate label and ruby annotation should mutate": {
 			config: map[string]any{
 				"apm_config.instrumentation.enabled":     false,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -412,12 +412,14 @@ type pinnedLibraries struct {
 // given a registry.
 func getPinnedLibraries(libVersions map[string]string, registry string, checkDefaults bool) pinnedLibraries {
 	libs := []libInfo{}
+	defaultLanguages := defaultInjectedLanguagesMap()
 	allDefaults := true
 
 	for lang, version := range libVersions {
 		l := language(lang)
 		if !l.isSupported() {
 			log.Warnf("APM Instrumentation detected configuration for unsupported language: %s. Tracing library for %s will not be injected", lang, lang)
+			allDefaults = false
 			continue
 		}
 
@@ -425,14 +427,15 @@ func getPinnedLibraries(libVersions map[string]string, registry string, checkDef
 		log.Infof("Library version %s is specified for language %s, going to use %s", version, lang, info.image)
 		libs = append(libs, info)
 
-		if info.image != l.libImageName(registry, l.defaultLibVersion()) {
+		if !defaultLanguages[l] || info.image != l.libImageName(registry, l.defaultLibVersion()) {
 			allDefaults = false
 		}
+		delete(defaultLanguages, l)
 	}
 
 	return pinnedLibraries{
 		libs:             libs,
-		areSetToDefaults: checkDefaults && allDefaults && len(libs) == len(defaultInjectedLanguagesMap()),
+		areSetToDefaults: checkDefaults && allDefaults && len(defaultLanguages) == 0,
 	}
 }
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -432,7 +432,7 @@ func getPinnedLibraries(libVersions map[string]string, registry string, checkDef
 
 	return pinnedLibraries{
 		libs:             libs,
-		areSetToDefaults: checkDefaults && allDefaults && len(libs) == len(defaultSupportedLanguagesMap()),
+		areSetToDefaults: checkDefaults && allDefaults && len(libs) == len(defaultInjectedLanguagesMap()),
 	}
 }
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -453,6 +453,31 @@ func TestGetPinnedLibraries(t *testing.T) {
 			},
 		},
 		{
+			name: "default libs with explicit c lib",
+			libVersions: map[string]string{
+				"java":   "v1",
+				"python": "v4",
+				"js":     "v5",
+				"dotnet": "v3",
+				"ruby":   "v2",
+				"php":    "v1",
+				"c":      "v0",
+			},
+			checkDefaults: true,
+			expected: pinnedLibraries{
+				libs: []libInfo{
+					defaultLibInfo(java),
+					defaultLibInfo(python),
+					defaultLibInfo(js),
+					defaultLibInfo(dotnet),
+					defaultLibInfo(ruby),
+					defaultLibInfo(php),
+					defaultLibInfoWithVersion(c, "v0"),
+				},
+				areSetToDefaults: false,
+			},
+		},
+		{
 			name:          "default libs, one missing",
 			libVersions:   defaultLibrariesFor("java", "python", "js", "dotnet"),
 			checkDefaults: true,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -478,6 +478,29 @@ func TestGetPinnedLibraries(t *testing.T) {
 			},
 		},
 		{
+			name: "explicit c lib cannot substitute for missing default lib",
+			libVersions: map[string]string{
+				"java":   "v1",
+				"python": "v4",
+				"js":     "v5",
+				"dotnet": "v3",
+				"ruby":   "v2",
+				"c":      "v0",
+			},
+			checkDefaults: true,
+			expected: pinnedLibraries{
+				libs: []libInfo{
+					defaultLibInfo(java),
+					defaultLibInfo(python),
+					defaultLibInfo(js),
+					defaultLibInfo(dotnet),
+					defaultLibInfo(ruby),
+					defaultLibInfoWithVersion(c, "v0"),
+				},
+				areSetToDefaults: false,
+			},
+		},
+		{
 			name:          "default libs, one missing",
 			libVersions:   defaultLibrariesFor("java", "python", "js", "dotnet"),
 			checkDefaults: true,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -19,6 +19,7 @@ const (
 	dotnet language = "dotnet"
 	ruby   language = "ruby"
 	php    language = "php"
+	c      language = "c"
 )
 
 // language is lang-library we might be injecting.
@@ -71,11 +72,22 @@ var supportedLanguages = []language{
 	dotnet,
 	ruby,
 	php, // PHP only works with injection v2, no environment variables are set in any case
+	c,
 }
 
-func defaultSupportedLanguagesMap() map[language]bool {
+// defaultInjectedLanguages defines the languages included in the default/all bundle.
+var defaultInjectedLanguages = []language{
+	java,
+	js,
+	python,
+	dotnet,
+	ruby,
+	php,
+}
+
+func defaultInjectedLanguagesMap() map[language]bool {
 	m := map[language]bool{}
-	for _, l := range supportedLanguages {
+	for _, l := range defaultInjectedLanguages {
 		m[l] = true
 	}
 
@@ -101,6 +113,7 @@ var languageVersions = map[language]string{
 	ruby:   "v2", // https://datadoghq.atlassian.net/browse/APMON-1066
 	js:     "v5", // https://datadoghq.atlassian.net/browse/APMON-1065
 	php:    "v1", // https://datadoghq.atlassian.net/browse/APMON-1128
+	c:      "v0",
 }
 
 func (l language) defaultLibVersion() string {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/resources_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/resources_test.go
@@ -471,7 +471,7 @@ func TestInitContainerIsSidecar(t *testing.T) {
 }
 
 func TestIsLanguageSupported(t *testing.T) {
-	supportedLangs := []string{"java", "js", "python", "dotnet", "ruby", "php"}
+	supportedLangs := []string{"java", "js", "python", "dotnet", "ruby", "php", "c"}
 	for _, lang := range supportedLangs {
 		assert.True(t, libraryinjection.IsLanguageSupported(lang), "expected %s to be supported", lang)
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/volumes.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/volumes.go
@@ -58,6 +58,7 @@ var supportedLanguages = []string{
 	"dotnet",
 	"ruby",
 	"php",
+	"c",
 }
 
 // IsLanguageSupported checks if a language is supported for injection.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -489,11 +489,10 @@ func getEnabledLabel(pod *corev1.Pod) (bool, bool) {
 	return false, found
 }
 
-// getAllLatestDefaultLibraries returns all supported by APM Instrumentation tracing libraries
-// that should be enabled by default
+// getAllLatestDefaultLibraries returns the tracing libraries included in the default/all bundle.
 func getAllLatestDefaultLibraries(containerRegistry string) []libInfo {
 	var libsToInject []libInfo
-	for _, lang := range supportedLanguages {
+	for _, lang := range defaultInjectedLanguages {
 		libsToInject = append(libsToInject, lang.defaultLibInfo(containerRegistry, ""))
 	}
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -43,7 +43,7 @@ var (
 		"php":    "v1",
 	}
 
-	// TODO: Add new entry when a new language is supported
+	// Default bundle library image versions.
 	defaultLibImageVersions = map[language]string{
 		java:   "registry/dd-lib-java-init:" + defaultLibraries["java"],
 		js:     "registry/dd-lib-js-init:" + defaultLibraries["js"],


### PR DESCRIPTION
Add support for an additional opt-in library dd-trace-c that is not part of the defaultInjectedLanguages

QA done with: https://github.com/DataDog/injector-dev/pull/205

NB injection is adding just static files, actual injection can be done by
      - name: LD_PRELOAD
        value: "/opt/datadog/apm/library/c/libdd_autoinstrument.so"
or very soon with auto_inject
