### PR TITLE
Fix macOS flaky SNMP traps tests via port range

### DIFF
--- a/pkg/networkdevice/testutils/freeport.go
+++ b/pkg/networkdevice/testutils/freeport.go
@@ -35,11 +35,17 @@ func GetFreePort() (uint16, error) {
 	return uint16(portInt), nil
 }
 
-// UniqueTestPort returns a deterministic high-range UDP port derived from inputs,
+// UniqueTestPort returns a deterministic UDP port derived from inputs,
 // reducing the chance of collisions across concurrent tests without TOCTOU races.
 func UniqueTestPort(keys ...string) uint16 {
 	h := fnv.New32a()
 	h.Write([]byte(strings.Join(keys, "|")))
-	// Choose from 62000-63999 (typically outside Linux default ephemeral range)
-	return uint16(62000 + (h.Sum32() % 2000))
+	// Choose from 20000-29999. This range sits below the default ephemeral port
+	// ranges on every supported platform (Linux: 32768-60999, macOS/Windows:
+	// 49152-65535) and above the privileged range (<1024), so the OS will not
+	// hand out one of these ports as an ephemeral source port for another
+	// socket and steal it from the listener under test. A previous range of
+	// 62000-63999 was outside the Linux ephemeral range but inside the macOS one,
+	// which caused "bind: address already in use" flakes on macOS runners only.
+	return uint16(20000 + (h.Sum32() % 10000))
 }

--- a/pkg/networkdevice/testutils/freeport.go
+++ b/pkg/networkdevice/testutils/freeport.go
@@ -44,8 +44,6 @@ func UniqueTestPort(keys ...string) uint16 {
 	// ranges on every supported platform (Linux: 32768-60999, macOS/Windows:
 	// 49152-65535) and above the privileged range (<1024), so the OS will not
 	// hand out one of these ports as an ephemeral source port for another
-	// socket and steal it from the listener under test. A previous range of
-	// 62000-63999 was outside the Linux ephemeral range but inside the macOS one,
-	// which caused "bind: address already in use" flakes on macOS runners only.
+	// socket and steal it from the listener under test.
 	return uint16(20000 + (h.Sum32() % 10000))
 }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"483e9d4e-fcaf-4f97-a473-ccca4df601c6","source":"chat","resourceId":"4b47784a-3cc2-4743-80b3-277db7d403b5","workflowId":"90ad230b-40aa-49c1-9090-387317c2ddb3","codeChangeId":"90ad230b-40aa-49c1-9090-387317c2ddb3","sourceType":"slack"} -->
### What does this PR do?

Changes the deterministic UDP port range used by `UniqueTestPort` (in `pkg/networkdevice/testutils/freeport.go`) from 62000-63999 to 20000-29999, so the chosen ports fall outside the OS ephemeral port range on every supported platform.

### Motivation

`TestServerV3MultipleCredentials` and other SNMP traps listener/server tests fail intermittently on `tests_macos_gitlab_amd64` with `listen udp 127.0.0.1:<port>: bind: address already in use`.

- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1733031679
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1733382975

Root cause: `UniqueTestPort` derived a deterministic port in 62000-63999. That range lies entirely inside the macOS/Windows default ephemeral range (49152-65535), so the kernel can hand one of these ports to an outbound socket (e.g. the SNMP client connections the tests open) as its ephemeral source port. When the trap listener later tries to `bind()` that exact port, it fails. On Linux the ephemeral range is 32768-60999, so 62000+ is rarely taken — which is why the earlier deterministic-port fix (PR #49260) worked on Linux but not macOS. The failures are unrelated to PR #51623, which merely happened to be the merge-queue commit at the time of the alert.

The new range 20000-29999 is below the Linux (32768-60999) and macOS/Windows (49152-65535) ephemeral floors and above the privileged range (<1024), so the OS will not steal these ports. It also widens the space from 2000 to 10000 ports, reducing deterministic hash collisions.

### Changes

- Move `UniqueTestPort`'s deterministic range from 62000-63999 to 20000-29999.

### Describe how you validated your changes

- `go build -tags test ./pkg/networkdevice/testutils/` passes.
- `go test -tags test -run 'TestServerV3MultipleCredentials|TestServerV3BadCredentialsWithMultipleUsers' -count=5 ./comp/snmptraps/listener/impl/` passes.
- Full `./comp/snmptraps/listener/impl/` and `./comp/snmptraps/server/impl/` suites (both consumers of `UniqueTestPort`) pass.

### Additional Notes

The fix preserves the deterministic, TOCTOU-free design introduced in PR #49260; it only relocates the port window.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4b47784a-3cc2-4743-80b3-277db7d403b5)

Comment @datadog to request changes