### PR TITLE
perf(obfuscate): memoize parsed SQL obfuscation options

### DIFF
--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -246,6 +246,8 @@ var (
 	obfuscator       *obfuscate.Obfuscator
 	obfuscaterConfig obfuscate.Config // For testing purposes
 	obfuscatorLoader sync.Once
+
+	sqlConfigCache sync.Map // map[string]*sqlConfig
 )
 
 // lazyInitObfuscator initializes the obfuscator the first time it is used. We can't initialize during the package init
@@ -282,6 +284,20 @@ type sqlConfig struct {
 	ReturnJSONMetadata bool `json:"return_json_metadata"`
 }
 
+// loadSQLConfig returns the memoized parse of optStr; on a parse error it returns a
+// zero-value config and does not cache it.
+func loadSQLConfig(optStr string) (*sqlConfig, error) {
+	if v, ok := sqlConfigCache.Load(optStr); ok {
+		return v.(*sqlConfig), nil
+	}
+	c := &sqlConfig{}
+	if err := json.Unmarshal([]byte(optStr), c); err != nil {
+		return c, err
+	}
+	sqlConfigCache.Store(optStr, c)
+	return c, nil
+}
+
 // ObfuscateSQL obfuscates & normalizes the provided SQL query, writing the error into errResult if the operation
 // fails. An optional configuration may be passed to change the behavior of the obfuscator.
 //
@@ -292,8 +308,8 @@ func ObfuscateSQL(rawQuery, opts *C.char, errResult **C.char) *C.char {
 		// ensure we have a valid JSON string before unmarshalling
 		optStr = "{}"
 	}
-	var sqlOpts sqlConfig
-	if err := json.Unmarshal([]byte(optStr), &sqlOpts); err != nil {
+	sqlOpts, err := loadSQLConfig(optStr)
+	if err != nil {
 		log.Errorf("Failed to unmarshal obfuscation options: %s", err.Error())
 		*errResult = TrackedCString(err.Error())
 	}

--- a/pkg/collector/python/datadog_agent_test.go
+++ b/pkg/collector/python/datadog_agent_test.go
@@ -8,6 +8,7 @@
 package python
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -41,4 +42,40 @@ func TestEmitAgentTelemetry(t *testing.T) {
 
 func TestObfuscaterConfig(t *testing.T) {
 	testObfuscaterConfig(t)
+}
+
+func TestLoadSQLConfig(t *testing.T) {
+	testLoadSQLConfig(t)
+}
+
+func TestObfuscateSQL(t *testing.T) {
+	testObfuscateSQL(t)
+}
+
+// BenchmarkLoadSQLConfig compares the memoized lookup against the json.Unmarshal it replaces.
+func BenchmarkLoadSQLConfig(b *testing.B) {
+	optStr := `{"dbms":"postgresql","obfuscation_mode":"obfuscate_and_normalize","table_names":true,"collect_commands":true,"collect_comments":true,"keep_sql_alias":true,"dollar_quoted_func":true,"return_json_metadata":true}`
+
+	b.Run("Memoized", func(b *testing.B) {
+		if _, err := loadSQLConfig(optStr); err != nil { // prime the cache
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := loadSQLConfig(optStr); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("UnmarshalEachCall", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var c sqlConfig
+			if err := json.Unmarshal([]byte(optStr), &c); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }

--- a/pkg/collector/python/test_datadog_agent.go
+++ b/pkg/collector/python/test_datadog_agent.go
@@ -173,3 +173,85 @@ func testObfuscaterConfig(t *testing.T) {
 	}
 	assert.Equal(t, expected, obfuscaterConfig)
 }
+
+func testLoadSQLConfig(t *testing.T) {
+	optStr := `{"dbms":"postgresql","obfuscation_mode":"obfuscate_and_normalize","table_names":true,"return_json_metadata":true}`
+
+	c1, err := loadSQLConfig(optStr)
+	require.NoError(t, err)
+	require.NotNil(t, c1)
+	assert.Equal(t, obfuscate.ObfuscateAndNormalize, c1.ObfuscationMode)
+	assert.Equal(t, "postgresql", c1.DBMS)
+	assert.True(t, c1.TableNames)
+	assert.True(t, c1.ReturnJSONMetadata)
+
+	c2, err := loadSQLConfig(optStr)
+	require.NoError(t, err)
+	assert.Same(t, c1, c2, "identical options string should return the memoized *sqlConfig")
+
+	// memoized parse must equal a fresh json.Unmarshal (behavior preserved)
+	var fresh sqlConfig
+	require.NoError(t, json.Unmarshal([]byte(optStr), &fresh))
+	assert.Equal(t, fresh, *c1)
+
+	// a different options string gets its own config (no key collision)
+	mc, err := loadSQLConfig(`{"dbms":"mysql","obfuscation_mode":"obfuscate_only"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "mysql", mc.DBMS)
+	assert.Equal(t, obfuscate.ObfuscateOnly, mc.ObfuscationMode)
+	assert.NotSame(t, c1, mc)
+	again, _ := loadSQLConfig(optStr)
+	assert.Equal(t, "postgresql", again.DBMS)
+
+	badStr := `{not valid json`
+	bad, err := loadSQLConfig(badStr)
+	require.Error(t, err)
+	require.NotNil(t, bad)
+	_, cached := sqlConfigCache.Load(badStr)
+	assert.False(t, cached, "a failed parse must not be cached")
+}
+
+func testObfuscateSQL(t *testing.T) {
+	pkgconfigmodel.CleanOverride(t)
+	_ = pkgconfigmock.New(t)
+	// use a fresh, non-stopped obfuscator regardless of test ordering
+	obfuscator = obfuscate.NewObfuscator(obfuscate.Config{})
+	obfuscatorLoader.Do(func() {})
+
+	query := "SELECT * FROM users WHERE id = 123 AND name = 'alice'"
+	opts := `{"dbms":"postgresql","obfuscation_mode":"obfuscate_and_normalize","table_names":true,"return_json_metadata":true}`
+
+	var errMsg *C.char
+	res := C.GoString(ObfuscateSQL(C.CString(query), C.CString(opts), &errMsg))
+	require.Nil(t, errMsg)
+
+	var oq struct {
+		Query    string `json:"query"`
+		Metadata struct {
+			TablesCSV string `json:"tables_csv"`
+		} `json:"metadata"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(res), &oq))
+	assert.NotContains(t, oq.Query, "123")
+	assert.NotContains(t, oq.Query, "alice")
+	assert.Contains(t, oq.Query, "?")
+	assert.Contains(t, oq.Metadata.TablesCSV, "users")
+
+	// same query+options again (memo + cache) -> byte-identical output
+	errMsg = nil
+	res2 := C.GoString(ObfuscateSQL(C.CString(query), C.CString(opts), &errMsg))
+	require.Nil(t, errMsg)
+	assert.Equal(t, res, res2)
+
+	// return_json_metadata:false -> bare obfuscated SQL, not JSON
+	errMsg = nil
+	bare := C.GoString(ObfuscateSQL(C.CString(query), C.CString(`{"dbms":"postgresql","obfuscation_mode":"obfuscate_and_normalize"}`), &errMsg))
+	require.Nil(t, errMsg)
+	assert.NotContains(t, bare, "123")
+	assert.Error(t, json.Unmarshal([]byte(bare), &oq), "bare result should be raw SQL, not JSON")
+
+	// empty options -> defaults to "{}", must not error or panic
+	errMsg = nil
+	assert.NotEmpty(t, C.GoString(ObfuscateSQL(C.CString(query), C.CString(""), &errMsg)))
+	require.Nil(t, errMsg)
+}

--- a/releasenotes/notes/obfuscate-sql-options-memo-3d9e11ecfcd5de92.yaml
+++ b/releasenotes/notes/obfuscate-sql-options-memo-3d9e11ecfcd5de92.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Database Monitoring: the Agent now memoizes parsed SQL obfuscation options on
+    the Python obfuscation path, replacing a per-call ``json.Unmarshal`` of the
+    identical options string with a cached lookup.


### PR DESCRIPTION
### What does this PR do?

Memoizes the parsed SQL obfuscation options on the Python→Go obfuscation path. `ObfuscateSQL` previously called `json.Unmarshal` on the `options` JSON string on every call. It now parses each distinct options string once and serves a cached config when available.

### Motivation

DBM integrations (Postgres, MySQL, SQL Server, ClickHouse) call `datadog_agent.obfuscate_sql(query, options)` once per statement row, which is thousands of rows per collection interval, per database. Every call crossed the FFI into `ObfuscateSQL` and re-parsed the `options` JSON, even though that string is byte-identical on every call (it's built once during check setup and never changes per-call).

**Why this scope.** The options are initialized once per check instance and never mutated, so memoizing the parse keyed by the options string is a minimal, behavior-preserving change contained entirely in the Agent. 

A more thorough fix (eg., having each integration set/pass the options across the FFI once instead of re-serializing the same JSON per row) would touch every integration and raises FFI lifecycle and ownership questions (when options are initialized, how they're invalidated, multi-instance handling). That is a reasonable follow-up, but this PR captures most of the win with one localized, low-risk change.

### Describe how you validated your changes

**Unit tests & microbenchmark** (`pkg/collector/python`):
- `TestLoadSQLConfig` — valid options parse; an identical string returns the same memoized pointer; the memoized parse deep-equals a fresh `json.Unmarshal` (behavior preserved); a different options string gets its own config; invalid JSON errors and is **not** cached.
- `TestObfuscateSQL` — exercises the cgo entrypoint itself (previously untested): literal redaction, table extraction, JSON-vs-bare-SQL output, empty options, and a memo round-trip producing **byte-identical** output on repeated calls.
- `BenchmarkLoadSQLConfig`: **3559 ns / 576 B / 9 allocs → 30 ns / 0 B / 0 allocs** per call.

**End-to-end A/B on a local DBM stack** (Postgres and MySQL). Built BASE (`main`) and BRANCH, swapped only the Agent binary, and ran restart-interleaved windows against a frozen statement set (result cache ~100% hit, so both arms do byte-identical work, isolating the change). Sampled exact `runtime.MemStats` deltas per window, asserted equal work and a per-window binary-version check, and diffed the obfuscated output for byte-identical correctness.

**Postgres** (frozen ~8.3k statements, equal work within 0.2%):

| Metric | BASE | BRANCH | Δ |
|---|---:|---:|---:|
| Alloc rate (allocs/s) | 46,223 | 33,130 | **−28.3%** |
| Alloc rate (MB/s) | 8.8 | 7.6 | −14.1% |
| GC cycles/min | 11.0 | 9.3 | −15.2% |
| Heap live / goroutines / latency | — | — | flat (no regression) |

**MySQL** (frozen ~8.1k digests, equal work within 0.03%):

| Metric | BASE | BRANCH | Δ |
|---|---:|---:|---:|
| Alloc rate (allocs/s) | 34,717 | 19,927 | **−42.6%** |
| Alloc rate (MB/s) | 4.89 | 3.68 | −24.8% |
| GC cycles/min | 6.28 | 4.73 | −24.6% |
| GC pause (ms/min) | 0.78 | 0.50 | −36.0% |
| Heap live / heap objects / goroutines / latency | — | — | flat (no regression) |

Both: no goroutine or heap-object growth (no leak), a re-run of the BASE arm reproduced its allocation rate within ~1% (no drift), and the obfuscated output was byte-identical between arms across every shared query/digest. The win is larger on MySQL because it has no query-metrics delta cache, so the per-call parse was a bigger share of its total allocations.

<img width="1385" height="314" alt="Screenshot 2026-06-02 at 11 47 48 AM" src="https://github.com/user-attachments/assets/7f1a5a07-4ed6-4382-94c9-388aeee9d6ed" />


### Additional Notes

- **Bounded blast radius.** `sqlConfigCache` / `loadSQLConfig` are referenced only by `ObfuscateSQL`. Every other obfuscator entry point (trace-agent, OTel stats, the Oracle core check, exec-plan obfuscation) constructs its own `obfuscate.Obfuscator` and is untouched by this change.
- **Cache growth is safe.** The `sync.Map` is keyed by the raw options string and never evicts, but its cardinality is config-driven, not data-driven: every call site passes a fixed string built once per check instance — no query text, host, or timestamps in the key. A single Agent sees roughly one distinct string per uniquely-configured check (low single digits in practice; ~600 B/entry → kilobytes). If a future integration ever embedded variable data in the options, this can be swapped for a bounded LRU (`hashicorp/golang-lru`, already a dependency) in a few lines.
- **Thread-safety.** `ObfuscateSQL` runs under the Python GIL (one goroutine at a time); the `sync.Map` is additionally concurrency-safe.
- No new dependencies; no config flag.
