### PR TITLE
windows: publish agent PDBs to an S3 symbol server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -770,6 +770,7 @@
 /tasks/unit_tests/python_version_tests.py @DataDog/agent-integrations
 /tasks/unit_tests/kmt_tests.py          @DataDog/ebpf-platform
 /tasks/unit_tests/macos_tests.py        @DataDog/windows-products
+/tasks/unit_tests/winbuild_tests.py     @DataDog/windows-products
 /tasks/pkg_template.py                  @DataDog/agent-runtimes
 /tasks/cluster_agent_cloudfoundry.py    @DataDog/agent-integrations
 /tasks/devcontainer.py                  @DataDog/agent-devx @DataDog/container-platform

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -238,6 +238,11 @@ variables:
   TEST_KEYS_URL: apttesting.datad0g.com/test-keys
   INSTALLER_TESTING_S3_BUCKET: installtesting.datad0g.com
   WINDOWS_TESTING_S3_BUCKET: pipelines/A7/$CI_PIPELINE_ID
+  # Shared, accumulating Windows symbol server. Not pipeline-scoped: PDBs from
+  # every pipeline land here, deduplicated by symstore's GUID-indexed layout.
+  # Nested under pipelines/A7 to inherit the 30-day age policy.
+  # Symbols for release builds are handled by agent-release-management.
+  WINDOWS_SYMBOLS_S3_BUCKET: pipelines/A7/symbols
   WINDOWS_BUILDS_S3_BUCKET: $WIN_S3_BUCKET/builds
   WINDOWS_POWERSHELL_DIR: $CI_PROJECT_DIR/signed_scripts
   DEB_RPM_TESTING_BUCKET_BRANCH: testing # branch of the DEB_TESTING_S3_BUCKET and RPM_TESTING_S3_BUCKET repos to release to, 'testing'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -238,11 +238,14 @@ variables:
   TEST_KEYS_URL: apttesting.datad0g.com/test-keys
   INSTALLER_TESTING_S3_BUCKET: installtesting.datad0g.com
   WINDOWS_TESTING_S3_BUCKET: pipelines/A7/$CI_PIPELINE_ID
-  # Shared, accumulating Windows symbol server. Not pipeline-scoped: PDBs from
-  # every pipeline land here, deduplicated by symstore's GUID-indexed layout.
-  # Nested under pipelines/A7 to inherit the 30-day age policy.
+  # Shared, accumulating Windows symbol server.
+  # Not pipeline-scoped: PDBs from every pipeline land here, deduplicated by the
+  # GUID-indexed layout, and aged out by a 30-day lifecycle policy on this path.
+  # The path is all-lowercase on purpose: dbgeng (cdb/windbg) lowercases the
+  # symbol-server URL path it requests, and S3 keys are case-sensitive, so an
+  # uppercase path (e.g. A7) would 404.
   # Symbols for release builds are handled by agent-release-management.
-  WINDOWS_SYMBOLS_S3_BUCKET: pipelines/A7/symbols
+  WINDOWS_SYMBOLS_S3_BUCKET: pipelines/windows-symbols
   WINDOWS_BUILDS_S3_BUCKET: $WIN_S3_BUCKET/builds
   WINDOWS_POWERSHELL_DIR: $CI_PROJECT_DIR/signed_scripts
   DEB_RPM_TESTING_BUCKET_BRANCH: testing # branch of the DEB_TESTING_S3_BUCKET and RPM_TESTING_S3_BUCKET repos to release to, 'testing'

--- a/.gitlab/windows/deploy/deploy_packages/windows.yml
+++ b/.gitlab/windows/deploy/deploy_packages/windows.yml
@@ -21,6 +21,10 @@ deploy_packages_windows-x64-7:
       --include "datadog-installer-*-1-x86_64.zip"
       --include "datadog-installer-*-1-x86_64.exe"
       $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/
+    # Symbol-server layout for agent-release-management to publish
+    - $S3_CP_CMD
+      --recursive
+      $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID/symbols $S3_RELEASE_ARTIFACTS_URI/symbols/
     # TODO: When this snippet is removed, change upload destination in agent-release-management https://github.com/DataDog/agent-release-management/blob/27bcd404709e4e7aaea3b1d5f272fab5be999a57/ci/libraries/msi.sh#L862-L869
     - $S3_CP_CMD
       --recursive

--- a/.gitlab/windows/deploy/deploy_packages/windows.yml
+++ b/.gitlab/windows/deploy/deploy_packages/windows.yml
@@ -86,6 +86,12 @@ deploy_packages_windows-x64-7-fips:
       --include "datadog-fips-agent-7*.msi"
       --include "datadog-fips-agent-7*.debug.zip"
       $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/
+    # Symbol-server layout for agent-release-management to publish. FIPS PDBs
+    # have distinct GUIDs from the base agent, so they merge into the shared
+    # symbols/ prefix without collision.
+    - $S3_CP_CMD
+      --recursive
+      $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID/symbols $S3_RELEASE_ARTIFACTS_URI/symbols/
   artifacts:
     paths:
       - $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/windows/deploy/e2e_testing_deploy/windows.yml
+++ b/.gitlab/windows/deploy/e2e_testing_deploy/windows.yml
@@ -24,6 +24,13 @@ deploy_windows_testing-a7:
       $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET
       --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
       full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    # Publish the prebuilt symbol-server layout (generated in the Windows build
+    # job, where symstore.exe is available) to the shared symbol store.
+    - $S3_CP_CMD
+      --recursive
+      $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID/symbols s3://$WIN_S3_BUCKET/$WINDOWS_SYMBOLS_S3_BUCKET
+      --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+      full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_windows_testing-a7-fips:
   rules:
@@ -44,5 +51,12 @@ deploy_windows_testing-a7-fips:
       --exclude "*"
       --include "datadog-fips-agent-7.*.msi"
       $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET
+      --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+      full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    # Publish the prebuilt symbol-server layout (generated in the Windows build
+    # job, where symstore.exe is available) to the shared symbol store.
+    - $S3_CP_CMD
+      --recursive
+      $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID/symbols s3://$WIN_S3_BUCKET/$WINDOWS_SYMBOLS_S3_BUCKET
       --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
       full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732

--- a/tasks/unit_tests/winbuild_tests.py
+++ b/tasks/unit_tests/winbuild_tests.py
@@ -1,4 +1,6 @@
 import base64
+import contextlib
+import io
 import os
 import tempfile
 import unittest
@@ -114,15 +116,19 @@ class TestGenerateSymbolStore(unittest.TestCase):
                 z.writestr("opt/datadog-agent/bin/agent/agent.exe.pdb", _real_agent_pdb())
                 z.writestr("opt/datadog-agent/bin/agent/agent.exe.debug", "stripped binary")
 
-            generate_symbol_store(Context(), output_dir=tmp)
+            with contextlib.redirect_stdout(io.StringIO()):
+                generate_symbol_store(Context(), output_dir=tmp)
 
             expected = os.path.join(tmp, SYMBOL_STORE_DIR_NAME, "agent.exe.pdb", SAMPLE_KEY, "agent.exe.pdb")
             self.assertTrue(os.path.isfile(expected), f"missing symbol-store entry: {expected}")
 
     def test_no_debug_zip_is_noop(self):
         with tempfile.TemporaryDirectory() as tmp:
-            generate_symbol_store(Context(), output_dir=tmp)
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                generate_symbol_store(Context(), output_dir=tmp)
             self.assertFalse(os.path.exists(os.path.join(tmp, SYMBOL_STORE_DIR_NAME)))
+            self.assertIn("no .debug.zip found", out.getvalue())
 
 
 if __name__ == "__main__":

--- a/tasks/unit_tests/winbuild_tests.py
+++ b/tasks/unit_tests/winbuild_tests.py
@@ -1,0 +1,80 @@
+import os
+import tempfile
+import unittest
+import zipfile
+
+from tasks.winbuild import _extract_pdbs, _strip_symstore_metadata
+
+
+class TestExtractPdbs(unittest.TestCase):
+    def _make_debug_zip(self, path, entries):
+        with zipfile.ZipFile(path, "w") as z:
+            for name, data in entries.items():
+                z.writestr(name, data)
+
+    def test_extracts_only_pdbs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            zip_path = os.path.join(tmp, "datadog-agent-7.x.x-x86_64.debug.zip")
+            # .debug.zip mirrors install_dir and carries both stripped-binary
+            # .debug copies and the .pdb companions; only the latter are wanted.
+            self._make_debug_zip(
+                zip_path,
+                {
+                    "opt/datadog-agent/bin/agent/agent.exe.debug": "stripped binary",
+                    "opt/datadog-agent/bin/agent/agent.exe.pdb": "agent pdb",
+                    "opt/datadog-agent/embedded/foo.dll.debug": "stripped binary",
+                },
+            )
+            dest = os.path.join(tmp, "out")
+            pdbs = _extract_pdbs([zip_path], dest)
+
+        self.assertEqual(len(pdbs), 1)
+        self.assertTrue(pdbs[0].lower().endswith("agent.exe.pdb"))
+
+    def test_flattens_and_separates_archives(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            zip_a = os.path.join(tmp, "datadog-agent-7.x.x-x86_64.debug.zip")
+            zip_b = os.path.join(tmp, "datadog-installer-7.x.x-1-x86_64.debug.zip")
+            # Same PDB basename in two archives must not clobber each other:
+            # each archive extracts into its own subdirectory.
+            self._make_debug_zip(zip_a, {"opt/datadog-agent/bin/agent/agent.exe.pdb": "a"})
+            self._make_debug_zip(zip_b, {"opt/datadog-installer/agent.exe.pdb": "b"})
+            dest = os.path.join(tmp, "out")
+            pdbs = _extract_pdbs([zip_a, zip_b], dest)
+
+        self.assertEqual(len(pdbs), 2)
+        self.assertEqual(len(set(pdbs)), 2)
+        for p in pdbs:
+            self.assertEqual(os.path.basename(p), "agent.exe.pdb")
+
+
+class TestStripSymstoreMetadata(unittest.TestCase):
+    def test_removes_metadata_keeps_pdbs(self):
+        with tempfile.TemporaryDirectory() as store:
+            # A symstore tree: one indexed PDB plus transaction bookkeeping.
+            pdb_dir = os.path.join(store, "agent.exe.pdb", "ABCDEF1234567890ABCDEF12345678901")
+            os.makedirs(pdb_dir)
+            pdb_file = os.path.join(pdb_dir, "agent.exe.pdb")
+            with open(pdb_file, "w") as f:
+                f.write("symbols")
+            with open(os.path.join(pdb_dir, "refs.ptr"), "w") as f:
+                f.write("ref")
+
+            os.makedirs(os.path.join(store, "000Admin"))
+            with open(os.path.join(store, "000Admin", "history.txt"), "w") as f:
+                f.write("history")
+            for name in ("pingme.txt", "server.txt", "lastid.txt"):
+                with open(os.path.join(store, name), "w") as f:
+                    f.write("x")
+
+            _strip_symstore_metadata(store)
+
+            self.assertTrue(os.path.exists(pdb_file))
+            self.assertFalse(os.path.exists(os.path.join(store, "000Admin")))
+            self.assertFalse(os.path.exists(os.path.join(pdb_dir, "refs.ptr")))
+            for name in ("pingme.txt", "server.txt", "lastid.txt"):
+                self.assertFalse(os.path.exists(os.path.join(store, name)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tasks/unit_tests/winbuild_tests.py
+++ b/tasks/unit_tests/winbuild_tests.py
@@ -1,9 +1,67 @@
+import base64
 import os
 import tempfile
 import unittest
 import zipfile
 
-from tasks.winbuild import _extract_pdbs, _strip_symstore_metadata
+from invoke import Context
+
+from tasks.winbuild import (
+    SYMBOL_STORE_DIR_NAME,
+    _extract_pdbs,
+    _format_index_key,
+    _symbol_index_key,
+    generate_symbol_store,
+)
+
+# The symbol-server key agent.exe.pdb must map to, cross-checked against
+# agent.exe's PE RSDS debug-directory record.
+SAMPLE_KEY = "28431E7AF1452C82FFD31B5B0E3722C91"
+# GUID bytes (first three fields little-endian, as stored in the PDB) for the
+# _format_index_key transform test.
+SAMPLE_GUID = bytes.fromhex("7A1E432845F1822CFFD31B5B0E3722C9")
+
+# Real byte ranges from a production agent.exe.pdb (mingw `ld --pdb` output),
+# covering exactly the regions _symbol_index_key reads -- the MSF superblock,
+# the stream-directory block map, the directory prefix (stream count, sizes[0:2]
+# and stream 1's block list), and the PDB Info stream head (version, signature,
+# age, GUID). Everything else is zero-filled. Using real bytes rather than a
+# hand-built MSF keeps the test from baking in the same format assumptions as
+# the parser, so a shared mistake can't pass silently.
+_REAL_PDB_SIZE = 9216
+_REAL_PDB_RANGES = [
+    (32, "AAQAAAEAAADXUwAAsFUBAAAAAAADAAAA"),
+    (3072, "BAAAAAUAAAAGAAAA"),
+    (4096, "FgIAAAQAAABLAAAA"),
+    (6236, "BwAAAAgAAAA="),
+    (8192, "lC4xAbe9GWoBAAAAeh5DKEXxgiz/0xtbDjciyQ=="),
+]
+
+
+def _real_agent_pdb() -> bytes:
+    """Reconstruct the sparse agent.exe.pdb fixture from its real byte ranges."""
+    buf = bytearray(_REAL_PDB_SIZE)
+    for off, b64 in _REAL_PDB_RANGES:
+        raw = base64.b64decode(b64)
+        buf[off : off + len(raw)] = raw
+    return bytes(buf)
+
+
+class TestFormatIndexKey(unittest.TestCase):
+    def test_known_guid(self):
+        self.assertEqual(_format_index_key(SAMPLE_GUID, 1), SAMPLE_KEY)
+
+    def test_age_is_hex_uppercase_no_padding(self):
+        self.assertTrue(_format_index_key(SAMPLE_GUID, 26).endswith("1A"))
+
+
+class TestSymbolIndexKey(unittest.TestCase):
+    def test_parses_real_pdb(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pdb = os.path.join(tmp, "agent.exe.pdb")
+            with open(pdb, "wb") as f:
+                f.write(_real_agent_pdb())
+            self.assertEqual(_symbol_index_key(pdb), SAMPLE_KEY)
 
 
 class TestExtractPdbs(unittest.TestCase):
@@ -15,8 +73,8 @@ class TestExtractPdbs(unittest.TestCase):
     def test_extracts_only_pdbs(self):
         with tempfile.TemporaryDirectory() as tmp:
             zip_path = os.path.join(tmp, "datadog-agent-7.x.x-x86_64.debug.zip")
-            # .debug.zip mirrors install_dir and carries both stripped-binary
-            # .debug copies and the .pdb companions; only the latter are wanted.
+            # .debug.zip carries both stripped-binary .debug copies and the .pdb
+            # companions; only the latter are wanted.
             self._make_debug_zip(
                 zip_path,
                 {
@@ -48,32 +106,23 @@ class TestExtractPdbs(unittest.TestCase):
             self.assertEqual(os.path.basename(p), "agent.exe.pdb")
 
 
-class TestStripSymstoreMetadata(unittest.TestCase):
-    def test_removes_metadata_keeps_pdbs(self):
-        with tempfile.TemporaryDirectory() as store:
-            # A symstore tree: one indexed PDB plus transaction bookkeeping.
-            pdb_dir = os.path.join(store, "agent.exe.pdb", "ABCDEF1234567890ABCDEF12345678901")
-            os.makedirs(pdb_dir)
-            pdb_file = os.path.join(pdb_dir, "agent.exe.pdb")
-            with open(pdb_file, "w") as f:
-                f.write("symbols")
-            with open(os.path.join(pdb_dir, "refs.ptr"), "w") as f:
-                f.write("ref")
+class TestGenerateSymbolStore(unittest.TestCase):
+    def test_lays_out_two_tier_store(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            zip_path = os.path.join(tmp, "datadog-agent-7.x.x-x86_64.debug.zip")
+            with zipfile.ZipFile(zip_path, "w") as z:
+                z.writestr("opt/datadog-agent/bin/agent/agent.exe.pdb", _real_agent_pdb())
+                z.writestr("opt/datadog-agent/bin/agent/agent.exe.debug", "stripped binary")
 
-            os.makedirs(os.path.join(store, "000Admin"))
-            with open(os.path.join(store, "000Admin", "history.txt"), "w") as f:
-                f.write("history")
-            for name in ("pingme.txt", "server.txt", "lastid.txt"):
-                with open(os.path.join(store, name), "w") as f:
-                    f.write("x")
+            generate_symbol_store(Context(), output_dir=tmp)
 
-            _strip_symstore_metadata(store)
+            expected = os.path.join(tmp, SYMBOL_STORE_DIR_NAME, "agent.exe.pdb", SAMPLE_KEY, "agent.exe.pdb")
+            self.assertTrue(os.path.isfile(expected), f"missing symbol-store entry: {expected}")
 
-            self.assertTrue(os.path.exists(pdb_file))
-            self.assertFalse(os.path.exists(os.path.join(store, "000Admin")))
-            self.assertFalse(os.path.exists(os.path.join(pdb_dir, "refs.ptr")))
-            for name in ("pingme.txt", "server.txt", "lastid.txt"):
-                self.assertFalse(os.path.exists(os.path.join(store, name)))
+    def test_no_debug_zip_is_noop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            generate_symbol_store(Context(), output_dir=tmp)
+            self.assertFalse(os.path.exists(os.path.join(tmp, SYMBOL_STORE_DIR_NAME)))
 
 
 if __name__ == "__main__":

--- a/tasks/winbuild.py
+++ b/tasks/winbuild.py
@@ -103,12 +103,14 @@ def _symbol_index_key(pdb_path):
     This is the same key debuggers derive from the binary's RSDS debug-directory
     record, so symsrv finds the PDB at `<pdb>\\<key>\\<pdb>`.
 
-    We compute the key ourselves instead of shelling out to symstore.exe:
-    symstore (and symchk) reject the mingw `ld --pdb` PDBs the Go toolchain
-    emits with "unsupported format. ErrorLevel is 11" -- dbghelp's index-
-    extraction path can't parse them, at any dbghelp version. cdb/WinDbg/xperf
-    read the very same PDBs fine, so the PDBs are usable; only symstore's
-    indexer is not.
+    We compute the key ourselves rather than shelling out to symstore.exe. This
+    was originally written because symstore failed to index the agent PDBs with
+    "unsupported format, ErrorLevel 11" -- but that turned out to be the
+    binutils/ld 2.43 `--pdb` bug (cdb and xperf can't read those PDBs either),
+    and ld >= 2.44 fixes all of them. We keep the in-house indexer anyway: it's
+    straightforward, it works, and it avoids having to discard the extra
+    index/transaction files (000Admin, etc.) symstore would create alongside the
+    store.
 
     Reads only the blocks it needs (superblock, stream directory, PDB Info
     stream) by seeking, never loading the whole file -- PDBs can be hundreds of

--- a/tasks/winbuild.py
+++ b/tasks/winbuild.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import shutil
+import struct
 import tempfile
 import zipfile
 
@@ -56,30 +57,11 @@ def agent_package(
         os.path.join(OUTPUT_PATH, f"datadog-installer-{agent_version}-1-x86_64.exe"),
     )
 
-    # Build the symbol-server layout from the PDBs. This must run here, in the
-    # Windows build container: symstore.exe is only available during the build,
-    # not in the (Linux) deploy jobs that publish to S3.
+    # Build the symbol-server layout from the PDBs. Runs here, in the Windows
+    # build job, because the PDBs survive only inside the .debug.zip the build
+    # produces (omnibus deletes the on-disk .debug tree); the (Linux) deploy
+    # jobs then publish the prebuilt layout to S3.
     generate_symbol_store(ctx)
-
-
-def _find_symstore():
-    """
-    Locate symstore.exe: PATH first, then the Windows Kits Debuggers install
-    locations. Returns None if not found.
-    """
-    found = shutil.which("symstore")
-    if found:
-        return found
-
-    candidates = []
-    for base in (r"C:\Program Files (x86)\Windows Kits", r"C:\Program Files\Windows Kits"):
-        candidates.append(os.path.join(base, "10", "Debuggers", "x64", "symstore.exe"))
-        candidates.extend(glob.glob(os.path.join(base, "*", "Debuggers", "x64", "symstore.exe")))
-    for candidate in candidates:
-        if os.path.exists(candidate):
-            return candidate
-
-    return None
 
 
 def _extract_pdbs(debug_zips, dest_dir):
@@ -95,55 +77,88 @@ def _extract_pdbs(debug_zips, dest_dir):
         with zipfile.ZipFile(zip_path, "r") as archive:
             for info in archive.infolist():
                 if info.filename.lower().endswith(".pdb"):
-                    # symstore indexes by the PDB's own GUID, not its path, so
-                    # the source directory layout is irrelevant: flatten it.
+                    # The store path is derived from the PDB's own GUID, not its
+                    # source location, so the directory layout is irrelevant:
+                    # flatten to the basename.
                     info.filename = os.path.basename(info.filename)
                     pdbs.append(archive.extract(info, sub))
     return pdbs
 
 
-def _strip_symstore_metadata(store_dir):
+def _format_index_key(guid, age):
     """
-    Remove symstore transaction bookkeeping, leaving only the indexed PDBs. A
-    static S3 symbol server needs only the <pdb>/<GUID+age>/<pdb> tree; the
-    000Admin folder, root marker files, and per-transaction refs.ptr files are
-    symstore-internal and unused by debugger symbol lookups.
+    Format a 16-byte PDB GUID + age into the symbol-server directory key:
+    {Data1:08X}{Data2:04X}{Data3:04X}{Data4 bytes} (the first three GUID fields
+    are little-endian) followed by the age in uppercase hex.
     """
-    admin = os.path.join(store_dir, "000Admin")
-    if os.path.isdir(admin):
-        shutil.rmtree(admin)
-    for name in ("pingme.txt", "server.txt", "lastid.txt"):
-        path = os.path.join(store_dir, name)
-        if os.path.exists(path):
-            os.remove(path)
-    for refs in glob.glob(os.path.join(store_dir, "**", "refs.ptr"), recursive=True):
-        os.remove(refs)
+    d1, d2, d3 = struct.unpack_from("<IHH", guid, 0)
+    tail = "".join(f"{b:02X}" for b in guid[8:16])
+    return f"{d1:08X}{d2:04X}{d3:04X}{tail}{age:X}"
+
+
+def _symbol_index_key(pdb_path):
+    """
+    Compute the symbol-server index key (`<GUID><age>`) for a PDB by reading its
+    MSF "PDB Info" stream (stream 1: version, signature, age, 16-byte GUID).
+    This is the same key debuggers derive from the binary's RSDS debug-directory
+    record, so symsrv finds the PDB at `<pdb>\\<key>\\<pdb>`.
+
+    We compute the key ourselves instead of shelling out to symstore.exe:
+    symstore (and symchk) reject the mingw `ld --pdb` PDBs the Go toolchain
+    emits with "unsupported format. ErrorLevel is 11" -- dbghelp's index-
+    extraction path can't parse them, at any dbghelp version. cdb/WinDbg/xperf
+    read the very same PDBs fine, so the PDBs are usable; only symstore's
+    indexer is not.
+    """
+    with open(pdb_path, "rb") as f:
+        data = f.read()
+    block_size, _free, _nblocks, num_dir_bytes, _unk, block_map_addr = struct.unpack_from("<IIIIII", data, 32)
+
+    def block(i):
+        return data[i * block_size : (i + 1) * block_size]
+
+    # The stream directory itself is stored in blocks listed at block_map_addr.
+    num_dir_blocks = (num_dir_bytes + block_size - 1) // block_size
+    dir_blocks = struct.unpack_from(f"<{num_dir_blocks}I", block(block_map_addr), 0)
+    directory = b"".join(block(b) for b in dir_blocks)[:num_dir_bytes]
+
+    # Directory: u32 numStreams, u32 sizes[numStreams], then each stream's block
+    # list. Walk to stream 1 (the PDB Info stream).
+    num_streams = struct.unpack_from("<I", directory, 0)[0]
+    sizes = struct.unpack_from(f"<{num_streams}I", directory, 4)
+    off = 4 + 4 * num_streams
+    info = b""
+    for i, size in enumerate(sizes):
+        nblocks = 0 if size in (0, 0xFFFFFFFF) else (size + block_size - 1) // block_size
+        blocks = struct.unpack_from(f"<{nblocks}I", directory, off)
+        off += 4 * nblocks
+        if i == 1:
+            info = b"".join(block(b) for b in blocks)[:size]
+            break
+
+    age = struct.unpack_from("<I", info, 8)[0]
+    guid = info[12:28]
+    return _format_index_key(guid, age)
 
 
 @task
 def generate_symbol_store(ctx, output_dir=None, store_dir=None):
     """
-    Build a Windows symbol-server layout (<pdb>/<GUID+age>/<pdb>) from the agent
-    PDBs, using symstore.exe.
+    Build a Windows symbol-server layout (`<pdb>\\<GUID><age>\\<pdb>`) from the
+    agent PDBs, indexing them in pure Python (see _symbol_index_key for why we
+    don't use symstore.exe).
 
     PDBs are read from the *.debug.zip archives the build leaves in output_dir
     (omnibus deletes the on-disk .debug tree, so the archives are the only place
     the PDBs survive). The resulting tree is portable: any runner -- including
     the Linux agent-release-management release pipeline, which has no Windows
-    runners -- can publish it to S3 with `aws s3 cp --recursive`. Only PDBs are
-    indexed and symstore transaction metadata is removed, so the output holds
-    symbol files only.
+    runners -- can publish it to S3 with `aws s3 cp --recursive`.
 
-    No-ops with a warning when symstore.exe or the debug archives are absent
-    (e.g. local dev builds), so it never breaks a build.
+    No-ops with a warning when the debug archives are absent (e.g. local dev
+    builds), so it never breaks a build.
     """
     output_dir = output_dir or OUTPUT_PATH
     store_dir = store_dir or os.path.join(output_dir, SYMBOL_STORE_DIR_NAME)
-
-    symstore = _find_symstore()
-    if not symstore:
-        print(f'{color_message("Warning", Color.ORANGE)}: symstore.exe not found; skipping symbol store generation')
-        return
 
     debug_zips = glob.glob(os.path.join(output_dir, "*.debug.zip"))
     if not debug_zips:
@@ -160,16 +175,10 @@ def generate_symbol_store(ctx, output_dir=None, store_dir=None):
             )
             return
 
-        os.makedirs(store_dir, exist_ok=True)
-        # Pass the PDBs to symstore via a response file (one path per line) to
-        # stay clear of command-line length limits.
-        responsefile = os.path.join(tmp, "pdbs.txt")
-        with open(responsefile, "w") as f:
-            f.write("\n".join(pdbs))
+        for pdb in pdbs:
+            name = os.path.basename(pdb)
+            dest = os.path.join(store_dir, name, _symbol_index_key(pdb))
+            os.makedirs(dest, exist_ok=True)
+            shutil.copy2(pdb, os.path.join(dest, name))
 
-        # /t (product) is required by symstore but, like /v, only feeds the
-        # 000Admin index we discard -- so it's a throwaway literal here.
-        ctx.run(f'"{symstore}" add /f "@{responsefile}" /s "{store_dir}" /t datadog-agent /o')
-
-    _strip_symstore_metadata(store_dir)
     print(f"Symbol store generated at {store_dir}")

--- a/tasks/winbuild.py
+++ b/tasks/winbuild.py
@@ -109,32 +109,40 @@ def _symbol_index_key(pdb_path):
     extraction path can't parse them, at any dbghelp version. cdb/WinDbg/xperf
     read the very same PDBs fine, so the PDBs are usable; only symstore's
     indexer is not.
+
+    Reads only the blocks it needs (superblock, stream directory, PDB Info
+    stream) by seeking, never loading the whole file -- PDBs can be hundreds of
+    MB and the data we need is a tiny, scattered subset.
     """
     with open(pdb_path, "rb") as f:
-        data = f.read()
-    block_size, _free, _nblocks, num_dir_bytes, _unk, block_map_addr = struct.unpack_from("<IIIIII", data, 32)
 
-    def block(i):
-        return data[i * block_size : (i + 1) * block_size]
+        def read_block(idx):
+            f.seek(idx * block_size)
+            return f.read(block_size)
 
-    # The stream directory itself is stored in blocks listed at block_map_addr.
-    num_dir_blocks = (num_dir_bytes + block_size - 1) // block_size
-    dir_blocks = struct.unpack_from(f"<{num_dir_blocks}I", block(block_map_addr), 0)
-    directory = b"".join(block(b) for b in dir_blocks)[:num_dir_bytes]
+        # MSF superblock: block size and where the stream directory lives.
+        f.seek(32)
+        block_size, _free, _nblocks, num_dir_bytes, _unk, block_map_addr = struct.unpack("<IIIIII", f.read(24))
 
-    # Directory: u32 numStreams, u32 sizes[numStreams], then each stream's block
-    # list. Walk to stream 1 (the PDB Info stream).
-    num_streams = struct.unpack_from("<I", directory, 0)[0]
-    sizes = struct.unpack_from(f"<{num_streams}I", directory, 4)
-    off = 4 + 4 * num_streams
-    info = b""
-    for i, size in enumerate(sizes):
-        nblocks = 0 if size in (0, 0xFFFFFFFF) else (size + block_size - 1) // block_size
-        blocks = struct.unpack_from(f"<{nblocks}I", directory, off)
-        off += 4 * nblocks
-        if i == 1:
-            info = b"".join(block(b) for b in blocks)[:size]
-            break
+        # The directory's own blocks are listed in a single block at
+        # block_map_addr; concatenating them yields the stream directory.
+        num_dir_blocks = (num_dir_bytes + block_size - 1) // block_size
+        dir_blocks = struct.unpack_from(f"<{num_dir_blocks}I", read_block(block_map_addr), 0)
+        directory = b"".join(read_block(b) for b in dir_blocks)[:num_dir_bytes]
+
+        # Directory: u32 numStreams, u32 sizes[numStreams], then each stream's
+        # block list. Walk to stream 1 (the PDB Info stream).
+        num_streams = struct.unpack_from("<I", directory, 0)[0]
+        sizes = struct.unpack_from(f"<{num_streams}I", directory, 4)
+        off = 4 + 4 * num_streams
+        info = b""
+        for i, size in enumerate(sizes):
+            nblocks = 0 if size in (0, 0xFFFFFFFF) else (size + block_size - 1) // block_size
+            blocks = struct.unpack_from(f"<{nblocks}I", directory, off)
+            off += 4 * nblocks
+            if i == 1:
+                info = b"".join(read_block(b) for b in blocks)[:size]
+                break
 
     age = struct.unpack_from("<I", info, 8)[0]
     guid = info[12:28]

--- a/tasks/winbuild.py
+++ b/tasks/winbuild.py
@@ -1,9 +1,13 @@
+import glob
 import os
 import shutil
+import tempfile
+import zipfile
 
 from invoke.tasks import task
 
 from tasks.flavor import AgentFlavor
+from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.utils import get_version
 from tasks.msi import build as build_agent_msi
 from tasks.omnibus import build as omnibus_build
@@ -12,6 +16,8 @@ from tasks.omnibus import build as omnibus_build
 OUTPUT_PATH = os.path.join(os.getcwd(), "omnibus", "pkg")
 # Omnibus stores files here, e.g. C:\opt\datadog-agent, C:\opt\datadog-installer
 OPT_SOURCE_DIR = os.path.join("C:\\", "opt")
+# Subdirectory of OUTPUT_PATH that holds the generated symbol-server layout
+SYMBOL_STORE_DIR_NAME = "symbols"
 
 
 @task
@@ -49,3 +55,121 @@ def agent_package(
         os.path.join(OPT_SOURCE_DIR, "datadog-installer\\datadog-installer.exe"),
         os.path.join(OUTPUT_PATH, f"datadog-installer-{agent_version}-1-x86_64.exe"),
     )
+
+    # Build the symbol-server layout from the PDBs. This must run here, in the
+    # Windows build container: symstore.exe is only available during the build,
+    # not in the (Linux) deploy jobs that publish to S3.
+    generate_symbol_store(ctx)
+
+
+def _find_symstore():
+    """
+    Locate symstore.exe: PATH first, then the Windows Kits Debuggers install
+    locations. Returns None if not found.
+    """
+    found = shutil.which("symstore")
+    if found:
+        return found
+
+    candidates = []
+    for base in (r"C:\Program Files (x86)\Windows Kits", r"C:\Program Files\Windows Kits"):
+        candidates.append(os.path.join(base, "10", "Debuggers", "x64", "symstore.exe"))
+        candidates.extend(glob.glob(os.path.join(base, "*", "Debuggers", "x64", "symstore.exe")))
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+
+    return None
+
+
+def _extract_pdbs(debug_zips, dest_dir):
+    """
+    Extract every *.pdb from the given .debug.zip archives into dest_dir, one
+    subdirectory per archive to avoid basename collisions across archives. Only
+    PDB entries are read, so the (large) stripped-binary .debug entries are not
+    paid for. Returns the list of extracted PDB paths.
+    """
+    pdbs = []
+    for index, zip_path in enumerate(debug_zips):
+        sub = os.path.join(dest_dir, str(index))
+        with zipfile.ZipFile(zip_path, "r") as archive:
+            for info in archive.infolist():
+                if info.filename.lower().endswith(".pdb"):
+                    # symstore indexes by the PDB's own GUID, not its path, so
+                    # the source directory layout is irrelevant: flatten it.
+                    info.filename = os.path.basename(info.filename)
+                    pdbs.append(archive.extract(info, sub))
+    return pdbs
+
+
+def _strip_symstore_metadata(store_dir):
+    """
+    Remove symstore transaction bookkeeping, leaving only the indexed PDBs. A
+    static S3 symbol server needs only the <pdb>/<GUID+age>/<pdb> tree; the
+    000Admin folder, root marker files, and per-transaction refs.ptr files are
+    symstore-internal and unused by debugger symbol lookups.
+    """
+    admin = os.path.join(store_dir, "000Admin")
+    if os.path.isdir(admin):
+        shutil.rmtree(admin)
+    for name in ("pingme.txt", "server.txt", "lastid.txt"):
+        path = os.path.join(store_dir, name)
+        if os.path.exists(path):
+            os.remove(path)
+    for refs in glob.glob(os.path.join(store_dir, "**", "refs.ptr"), recursive=True):
+        os.remove(refs)
+
+
+@task
+def generate_symbol_store(ctx, output_dir=None, store_dir=None):
+    """
+    Build a Windows symbol-server layout (<pdb>/<GUID+age>/<pdb>) from the agent
+    PDBs, using symstore.exe.
+
+    PDBs are read from the *.debug.zip archives the build leaves in output_dir
+    (omnibus deletes the on-disk .debug tree, so the archives are the only place
+    the PDBs survive). The resulting tree is portable: any runner -- including
+    the Linux agent-release-management release pipeline, which has no Windows
+    runners -- can publish it to S3 with `aws s3 cp --recursive`. Only PDBs are
+    indexed and symstore transaction metadata is removed, so the output holds
+    symbol files only.
+
+    No-ops with a warning when symstore.exe or the debug archives are absent
+    (e.g. local dev builds), so it never breaks a build.
+    """
+    output_dir = output_dir or OUTPUT_PATH
+    store_dir = store_dir or os.path.join(output_dir, SYMBOL_STORE_DIR_NAME)
+
+    symstore = _find_symstore()
+    if not symstore:
+        print(f'{color_message("Warning", Color.ORANGE)}: symstore.exe not found; skipping symbol store generation')
+        return
+
+    debug_zips = glob.glob(os.path.join(output_dir, "*.debug.zip"))
+    if not debug_zips:
+        print(
+            f'{color_message("Warning", Color.ORANGE)}: no .debug.zip found in {output_dir}; skipping symbol store generation'
+        )
+        return
+
+    with tempfile.TemporaryDirectory() as tmp:
+        pdbs = _extract_pdbs(debug_zips, tmp)
+        if not pdbs:
+            print(
+                f'{color_message("Warning", Color.ORANGE)}: no PDBs found in debug archives; skipping symbol store generation'
+            )
+            return
+
+        os.makedirs(store_dir, exist_ok=True)
+        # Pass the PDBs to symstore via a response file (one path per line) to
+        # stay clear of command-line length limits.
+        responsefile = os.path.join(tmp, "pdbs.txt")
+        with open(responsefile, "w") as f:
+            f.write("\n".join(pdbs))
+
+        # /t (product) is required by symstore but, like /v, only feeds the
+        # 000Admin index we discard -- so it's a throwaway literal here.
+        ctx.run(f'"{symstore}" add /f "@{responsefile}" /s "{store_dir}" /t datadog-agent /o')
+
+    _strip_symstore_metadata(store_dir)
+    print(f"Symbol store generated at {store_dir}")

--- a/tasks/winbuildscripts/Build-AgentPackages.ps1
+++ b/tasks/winbuildscripts/Build-AgentPackages.ps1
@@ -84,6 +84,6 @@ Invoke-BuildScript `
     if ($BuildOutOfSource) {
         # Copy the resulting package to the mnt directory
         mkdir C:\mnt\omnibus\pkg\pipeline-$env:CI_PIPELINE_ID -Force -ErrorAction Stop | Out-Null
-        Copy-Item -Path ".\omnibus\pkg\*" -Destination "C:\mnt\omnibus\pkg\pipeline-$env:CI_PIPELINE_ID" -Force -ErrorAction Stop
+        Copy-Item -Path ".\omnibus\pkg\*" -Destination "C:\mnt\omnibus\pkg\pipeline-$env:CI_PIPELINE_ID" -Recurse -Force -ErrorAction Stop
     }
 }


### PR DESCRIPTION
### What does this PR do?

Generates a Windows symbol-server layout (`<pdb>/<GUID+age>/<pdb>`) from the agent PDBs and publishes it to S3:

- New `winbuild.generate-symbol-store` task runs in the Windows build job (the only place `symstore.exe` is available); the resulting tree is portable, so every publish is a plain `aws s3 cp --recursive`.
- Dev: `deploy_windows_testing-a7` (+fips) → `s3://dd-agent-mstesting/pipelines/windows-symbols` (shared, GUID-deduplicated, public-read).
  - symbols expire after 30 days (s3 bucket policy)
- Release handoff: `deploy_packages_windows-x64-7` → `$S3_RELEASE_ARTIFACTS_URI/symbols/`.

### Motivation

We want a Windows symbol server so crash dumps and live debugging can resolve symbols across builds. PDBs are produced and bundled into `.debug.zip` by #51395; this PR gets them onto a debugger-consumable S3 layout. Tracked in [WINA-2770](https://datadoghq.atlassian.net/browse/WINA-2770).

### Additional Notes

Manually verified that `cdb` and `xperf` resolve symbols against the generated store.

Follow-up ([WINA-2770](https://datadoghq.atlassian.net/browse/WINA-2770)): agent-release-management job to mirror `$S3_RELEASE_ARTIFACTS_URI/symbols/` to the release bucket (no Windows runner needed), and publish/document the symbol server URL + `_NT_SYMBOL_PATH`.

[WINA-2770]: https://datadoghq.atlassian.net/browse/WINA-2770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WINA-2770]: https://datadoghq.atlassian.net/browse/WINA-2770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ