### PR TITLE
[DSCVR-467] feat(discovery): detect enabled integrations via Autodiscovery

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -133,6 +133,8 @@ import (
 	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 
 	hostProfilerFlareFx "github.com/DataDog/datadog-agent/comp/host-profiler/flare/fx"
+	integrationdetectiondef "github.com/DataDog/datadog-agent/comp/discovery/integrationdetection/def"
+	integrationdetectionfx "github.com/DataDog/datadog-agent/comp/discovery/integrationdetection/fx"
 	langDetectionCl "github.com/DataDog/datadog-agent/comp/languagedetection/client/def"
 	langDetectionClimpl "github.com/DataDog/datadog-agent/comp/languagedetection/client/fx"
 	"github.com/DataDog/datadog-agent/comp/logs"
@@ -297,6 +299,7 @@ func run(log log.Component,
 	logReceiver option.Option[integrations.Component],
 	_ netflowServer.Component,
 	_ option.Option[langDetectionCl.Component],
+	_ option.Option[integrationdetectiondef.Component],
 	_ internalAPI.Component,
 	_ packagesigning.Component,
 	_ systemprobemetadata.Component,
@@ -518,6 +521,7 @@ func getSharedFxOption() fx.Option {
 		recordernoopfx.Module(),
 		reporterfx.Module(),
 		langDetectionClimpl.Module(),
+		integrationdetectionfx.Module(),
 		metadata.Bundle(),
 		orchestratorForwarderImpl.Module(orchestratorForwarderImpl.NewDefaultParams()),
 		eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),

--- a/comp/discovery/integrationdetection/def/BUILD.bazel
+++ b/comp/discovery/integrationdetection/def/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "def",
+    srcs = ["component.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/discovery/integrationdetection/def",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/discovery/integrationdetection",
+    ],
+)

--- a/comp/discovery/integrationdetection/def/component.go
+++ b/comp/discovery/integrationdetection/def/component.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package integrationdetection defines the integration detection component.
+// Enable by setting discovery.integration_detection.enabled=true in datadog.yaml.
+//
+// team: agent-discovery
+package integrationdetection
+
+import integrationdetectionpkg "github.com/DataDog/datadog-agent/pkg/discovery/integrationdetection"
+
+// EnabledIntegration is a type alias for the core package type. It allows
+// callers that only depend on this component interface to consume the returned
+// slice without importing the full implementation package. This component
+// interface is intended for read-only consumers; construction of
+// EnabledIntegration values is an implementation detail of the core package.
+type EnabledIntegration = integrationdetectionpkg.EnabledIntegration
+
+// Component exposes the live set of integrations detected via Autodiscovery events.
+type Component interface {
+	// EnabledIntegrations returns a snapshot of currently-enabled integrations.
+	// Returns nil when no integrations are detected or the component is disabled.
+	EnabledIntegrations() []EnabledIntegration
+}

--- a/comp/discovery/integrationdetection/fx/BUILD.bazel
+++ b/comp/discovery/integrationdetection/fx/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/discovery/integrationdetection/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/discovery/integrationdetection/def",
+        "//comp/discovery/integrationdetection/impl",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/discovery/integrationdetection/fx/fx.go
+++ b/comp/discovery/integrationdetection/fx/fx.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package fx provides the fx module for the integration detection component.
+package fx
+
+import (
+	integrationdetectiondef "github.com/DataDog/datadog-agent/comp/discovery/integrationdetection/def"
+	integrationdetectionimpl "github.com/DataDog/datadog-agent/comp/discovery/integrationdetection/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module returns the Fx options for the integration detection component.
+// It provides an optional integrationdetectiondef.Component, present only when
+// discovery.integration_detection.enabled is true in the agent configuration.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			integrationdetectionimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[integrationdetectiondef.Component](),
+	)
+}

--- a/comp/discovery/integrationdetection/impl/BUILD.bazel
+++ b/comp/discovery/integrationdetection/impl/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "impl",
+    srcs = ["impl.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/discovery/integrationdetection/impl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/autodiscovery",
+        "//comp/core/config",
+        "//comp/core/log/def",
+        "//comp/def",
+        "//comp/discovery/integrationdetection/def",
+        "//pkg/discovery/integrationdetection",
+        "//pkg/util/option",
+    ],
+)
+
+go_test(
+    name = "impl_test",
+    srcs = ["impl_test.go"],
+    embed = [":impl"],
+    gotags = ["test"],
+    deps = [
+        "//comp/core/autodiscovery",
+        "//comp/core/autodiscovery/integration",
+        "//comp/core/autodiscovery/providers/types",
+        "//comp/core/autodiscovery/scheduler",
+        "//comp/core/autodiscovery/telemetry",
+        "//comp/core/config",
+        "//comp/core/log/mock",
+        "//comp/def",
+        "//pkg/collector/check/id",
+        "//pkg/config/setup",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/comp/discovery/integrationdetection/impl/impl.go
+++ b/comp/discovery/integrationdetection/impl/impl.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package integrationdetectionimpl implements the integration detection Fx component.
+package integrationdetectionimpl
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	integrationdetectiondef "github.com/DataDog/datadog-agent/comp/discovery/integrationdetection/def"
+	"github.com/DataDog/datadog-agent/pkg/discovery/integrationdetection"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+// enabledKey is the config key that gates the integration detection component.
+const enabledKey = "discovery.integration_detection.enabled"
+
+// Requires lists the Fx dependencies of the integration detection component.
+type Requires struct {
+	Lifecycle compdef.Lifecycle
+	Config    config.Component
+	Log       log.Component
+	AC        autodiscovery.Component
+}
+
+// Provides lists the Fx outputs of the integration detection component.
+type Provides struct {
+	Comp option.Option[integrationdetectiondef.Component]
+}
+
+type impl struct {
+	detector *integrationdetection.Detector
+	log      log.Component
+}
+
+// NewComponent creates the integration detection component.
+func NewComponent(reqs Requires) (Provides, error) {
+	if !reqs.Config.GetBool(enabledKey) {
+		return Provides{Comp: option.None[integrationdetectiondef.Component]()}, nil
+	}
+	d := integrationdetection.NewDetector()
+	c := &impl{detector: d, log: reqs.Log}
+	// Copy AC out of reqs so the OnStart closure does not transitively retain
+	// the full Requires struct (and all its dependencies) after NewComponent returns.
+	ac := reqs.AC
+	reqs.Lifecycle.Append(compdef.Hook{
+		OnStart: func(_ context.Context) error {
+			// Registration happens here (not in the constructor) because the AD
+			// controller waits for workloadmeta to finish initialising before it
+			// begins dispatching events.
+			c.log.Info("Starting integration detection component")
+			d.Start(ac)
+			return nil
+		},
+		OnStop: c.stop, // OnStop Fx hook; calls d.Stop() and logs
+	})
+	return Provides{Comp: option.New[integrationdetectiondef.Component](c)}, nil
+}
+
+func (c *impl) stop(_ context.Context) error {
+	c.log.Info("Stopping integration detection component")
+	c.detector.Stop()
+	return nil
+}
+
+// EnabledIntegrations returns a live snapshot of enabled integrations.
+func (c *impl) EnabledIntegrations() []integrationdetectiondef.EnabledIntegration {
+	return c.detector.Snapshot()
+}

--- a/comp/discovery/integrationdetection/impl/impl_test.go
+++ b/comp/discovery/integrationdetection/impl/impl_test.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// The test build tag is required because this file references config.NewMock
+// and compdef.NewTestLifecycle, which are only compiled under //go:build test.
+// Use `dda inv test` or `go test -tags test` to run these tests.
+//
+//go:build test
+
+package integrationdetectionimpl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+// noopAD is a minimal autodiscovery.Component for tests that don't exercise
+// the AD scheduling path.
+type noopAD struct{}
+
+func (noopAD) AddConfigProvider(types.ConfigProvider, bool, time.Duration) {}
+func (noopAD) LoadAndRun(context.Context)                                   {}
+func (noopAD) GetAllConfigs() []integration.Config                          { return nil }
+func (noopAD) GetUnresolvedConfigs() []integration.Config                   { return nil }
+func (noopAD) AddListeners([]pkgconfigsetup.Listeners)                      {}
+func (noopAD) AddScheduler(string, scheduler.Scheduler, bool)               {}
+func (noopAD) RemoveScheduler(string)                                       {}
+func (noopAD) GetIDOfCheckWithEncryptedSecrets(id checkid.ID) checkid.ID    { return id }
+func (noopAD) GetAutodiscoveryErrors() map[string]map[string]types.ErrorMsgSet {
+	return nil
+}
+func (noopAD) AddConfigProviderFromCatalog(pkgconfigsetup.ConfigurationProviders) error { return nil }
+func (noopAD) GetTelemetryStore() *telemetry.Store                                      { return nil }
+func (noopAD) GetConfigCheck() integration.ConfigCheckResponse {
+	return integration.ConfigCheckResponse{}
+}
+
+var _ autodiscovery.Component = noopAD{}
+
+func requiresWithConfig(t *testing.T, enabled bool) (Requires, *compdef.TestLifecycle) {
+	t.Helper()
+	cfg := config.NewMock(t)
+	cfg.SetWithoutSource(enabledKey, enabled)
+	lc := compdef.NewTestLifecycle(t)
+	return Requires{
+		Lifecycle: lc,
+		Config:    cfg,
+		Log:       logmock.New(t),
+		AC:        noopAD{},
+	}, lc
+}
+
+func TestNewComponent_DisabledByConfig(t *testing.T) {
+	reqs, _ := requiresWithConfig(t, false) // lifecycle not needed: component is disabled
+	p, err := NewComponent(reqs)
+	require.NoError(t, err)
+	_, present := p.Comp.Get()
+	assert.False(t, present, "component must be absent when disabled")
+}
+
+func TestNewComponent_EnabledByConfig(t *testing.T) {
+	reqs, lc := requiresWithConfig(t, true)
+	p, err := NewComponent(reqs)
+	require.NoError(t, err)
+	comp, present := p.Comp.Get()
+	assert.True(t, present, "component must be present when enabled")
+
+	ctx := context.Background()
+	require.NoError(t, lc.Start(ctx))
+
+	// The component must be callable after lifecycle start without panicking;
+	// no integrations are scheduled in this unit test, so the result is nil.
+	assert.Nil(t, comp.EnabledIntegrations())
+
+	require.NoError(t, lc.Stop(ctx))
+}

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1001,6 +1001,9 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	// Datadog Agent Manager System Tray
 	config.BindEnvAndSetDefault("system_tray.log_file", "")
 
+	// Integration Detection
+	config.BindEnvAndSetDefault("discovery.integration_detection.enabled", false)
+
 	// Language Detection
 	config.BindEnvAndSetDefault("language_detection.enabled", false)
 	config.BindEnvAndSetDefault("language_detection.reporting.enabled", true)

--- a/pkg/discovery/integrationdetection/BUILD.bazel
+++ b/pkg/discovery/integrationdetection/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "integrationdetection",
+    srcs = [
+        "detector.go",
+        "integrations.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/discovery/integrationdetection",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/autodiscovery",
+        "//comp/core/autodiscovery/integration",
+        "//pkg/util/containers",
+    ],
+)
+
+go_test(
+    name = "integrationdetection_test",
+    srcs = ["detector_test.go"],
+    embed = [":integrationdetection"],
+    gotags = ["test"],
+    deps = [
+        "//comp/core/autodiscovery/integration",
+        "//comp/core/autodiscovery/providers/types",
+        "//comp/core/autodiscovery/scheduler",
+        "//comp/core/autodiscovery/telemetry",
+        "//pkg/collector/check/id",
+        "//pkg/config/setup",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/discovery/integrationdetection/detector.go
+++ b/pkg/discovery/integrationdetection/detector.go
@@ -1,0 +1,235 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package integrationdetection detects which integrations are enabled on a host
+// by subscribing to Autodiscovery schedule events.
+package integrationdetection
+
+import (
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+)
+
+// Scope indicates whether an integration instance runs on the host or in a container.
+type Scope string
+
+const (
+	// ScopeHost is for integrations running on the host (file-based or process-based AD).
+	ScopeHost Scope = "host"
+	// ScopeContainer is for integrations running inside a container.
+	ScopeContainer Scope = "container"
+)
+
+// EnabledIntegration is one scheduled integration instance detected by the Detector.
+// Multiple entries with the same Integration value may exist when a host runs more
+// than one instance of the same service (e.g. two Redis ports). Each is uniquely
+// identified by its Digest, which is the AD config digest.
+type EnabledIntegration struct {
+	Integration string // canonical name, e.g. "redis"
+	CheckName   string // AD check name, e.g. "redisdb"
+	Scope       Scope
+	Runtime     string // container runtime, e.g. "docker" (empty when Scope=host)
+	ContainerID string // (empty when Scope=host)
+	Digest      string // config.Digest(); uniquely identifies this instance
+}
+
+// Detector subscribes to Autodiscovery schedule events and maintains a live
+// snapshot of enabled integrations on the host.
+//
+// Lifecycle: Start must be called once to begin receiving events; Stop must be
+// called at most once to deregister. Start and Stop must NOT be called
+// concurrently — the Fx lifecycle contract (sequential OnStart/OnStop) provides
+// this guarantee in production. sync.Once guards enforce idempotency.
+//
+// A Detector must not be copied after first use (it embeds sync.RWMutex and
+// sync.Once).
+type Detector struct {
+	mu        sync.RWMutex
+	active    map[string]EnabledIntegration // keyed by config.Digest()
+	stopped   bool                          // set under mu before RemoveScheduler; guards stale post-Stop callbacks
+	ac        autodiscovery.Component       // written exactly once by Start's startOnce.Do (under mu); read exactly once by Stop's stopOnce.Do (under mu)
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+// NewDetector creates a Detector. Call Start to begin receiving AD events.
+func NewDetector() *Detector {
+	return &Detector{
+		active: make(map[string]EnabledIntegration),
+	}
+}
+
+// adScheduler bridges the scheduler.Scheduler interface to the Detector.
+type adScheduler struct{ d *Detector }
+
+func (s *adScheduler) Schedule(cfgs []integration.Config)   { s.d.schedule(cfgs) }
+func (s *adScheduler) Unschedule(cfgs []integration.Config) { s.d.unschedule(cfgs) }
+
+// Stop is an intentional no-op; must NOT forward to Detector.Stop — doing so
+// would create a double-stop path since the AD controller calls this when
+// deregistering. Use Detector.Stop() directly to deregister from AD.
+func (s *adScheduler) Stop() {}
+
+// Start registers with the AD controller and replays any already-scheduled configs.
+// Must be called from an Fx OnStart hook, not the constructor, so that the AD
+// controller has finished initialising before registration. Calling Start more
+// than once is a no-op (guarded by sync.Once).
+//
+// Start and Stop must not be called concurrently; the Fx lifecycle guarantees
+// this in production.
+func (d *Detector) Start(ac autodiscovery.Component) {
+	d.startOnce.Do(func() {
+		d.mu.Lock()
+		d.ac = ac
+		stopped := d.stopped // capture under the same lock — no second round-trip needed
+		d.mu.Unlock()
+
+		ac.AddScheduler("integration-detection", &adScheduler{d}, true)
+
+		// If Stop ran concurrently during AddScheduler, the scheduler was
+		// registered after RemoveScheduler was called. Detect this and
+		// immediately deregister to leave the detector in a clean stopped state.
+		// RemoveScheduler is idempotent (no-op on unknown names) so a double-call
+		// from the normal Stop path followed by this one is safe.
+		if stopped {
+			ac.RemoveScheduler("integration-detection")
+		}
+	})
+}
+
+// Stop deregisters from the AD controller and clears internal state. Calling
+// Stop more than once is a no-op (guarded by sync.Once).
+//
+// The stopped flag is set and d.ac is captured under the mutex in a single
+// critical section. This prevents a data race with concurrent Start callers and
+// ensures any Schedule callback that starts executing concurrently will see
+// stopped=true and bail out before writing to d.active.
+func (d *Detector) Stop() {
+	d.stopOnce.Do(func() {
+		d.mu.Lock()
+		d.stopped = true
+		ac := d.ac
+		clear(d.active) // reuse map memory rather than allocating a new one
+		d.mu.Unlock()
+
+		if ac != nil {
+			ac.RemoveScheduler("integration-detection")
+		}
+		// Note: any Schedule callback that acquired the write lock *before* Stop
+		// set d.stopped will have added an entry that is now cleared. This is
+		// intentional — the agent is shutting down and the data is discarded.
+	})
+}
+
+// Snapshot returns a copy of the currently enabled integrations, or nil when
+// no integrations are detected. The order of entries in the returned slice is
+// not defined. May return multiple entries with the same Integration value when
+// the host runs multiple instances of the same service.
+func (d *Detector) Snapshot() []EnabledIntegration {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return slices.Collect(maps.Values(d.active))
+}
+
+// schedule handles Schedule events from the AD controller.
+// Callbacks may arrive from the AD goroutine and must not block for extended periods.
+//
+// Note on Stop() interaction: Stop() sets d.stopped=true and calls RemoveScheduler
+// while holding the lock for the flag and clear operations (but not for
+// RemoveScheduler itself). A callback that arrives after d.stopped=true is set
+// will see the flag under the lock and return early, making the window safe.
+func (d *Detector) schedule(cfgs []integration.Config) {
+	// cfg.Digest() does YAML unmarshal+marshal + murmur3 hash per instance.
+	// Build the entries before acquiring the lock so the write-lock hold time
+	// covers only map writes, not per-config hashing and string ops.
+	type entry struct {
+		digest string
+		ei     EnabledIntegration
+	}
+	var entries []entry
+	for _, cfg := range cfgs {
+		if !cfg.IsCheckConfig() {
+			continue
+		}
+		canonical, ok := integrationForCheck(cfg.Name)
+		if !ok {
+			continue
+		}
+		scope, runtime, containerID := classifyServiceID(cfg.ServiceID)
+		digest := cfg.Digest()
+		entries = append(entries, entry{digest, EnabledIntegration{
+			Integration: canonical,
+			CheckName:   cfg.Name,
+			Scope:       scope,
+			Runtime:     runtime,
+			ContainerID: containerID,
+			Digest:      digest,
+		}})
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.stopped {
+		return
+	}
+	for _, e := range entries {
+		d.active[e.digest] = e.ei
+	}
+}
+
+// unschedule handles Unschedule events from the AD controller.
+// Callbacks may arrive from the AD goroutine and must not block for extended periods.
+func (d *Detector) unschedule(cfgs []integration.Config) {
+	// Precompute digests outside the lock — same reasoning as schedule().
+	// No stopped guard needed: delete on a cleared map is a no-op.
+	digests := make([]string, len(cfgs))
+	for i, cfg := range cfgs {
+		digests[i] = cfg.Digest()
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, digest := range digests {
+		delete(d.active, digest)
+	}
+}
+
+// classifyServiceID maps an AD ServiceID to its scope, runtime, and container ID.
+// There are three distinct forms:
+//   - "" → file-based static config (conf.d/); host scope
+//   - "process://<pid>" → process-based AD listener; host scope
+//   - "<runtime>://<id>" → container listener; container scope
+//
+// The process:// prefix is checked explicitly before falling through to
+// containers.SplitEntityName, which would otherwise misclassify it as a container
+// (IsEntityName matches any "://" string). Malformed "://" strings where
+// SplitEntityName returns an empty runtime or ID are treated as host scope.
+//
+// The function relies on containers.SplitEntityName returning ("", "") for any
+// input that is not a valid entity name (i.e. any string without exactly one
+// "://" separator). This is the trust boundary for the container classification:
+// strings that look like runtime IDs but are not (e.g. bare process://pid) are
+// caught by the explicit prefix checks above and never reach SplitEntityName.
+//
+// If a new AD service ID scheme is introduced (e.g. "kubernetes://..."), it
+// must be explicitly enumerated above the SplitEntityName call to prevent
+// misclassification as a container scope.
+func classifyServiceID(serviceID string) (scope Scope, runtime, containerID string) {
+	switch {
+	case serviceID == "" || strings.HasPrefix(serviceID, "process://"):
+		return ScopeHost, "", ""
+	default:
+		r, id := containers.SplitEntityName(serviceID)
+		if r == "" || id == "" {
+			return ScopeHost, "", ""
+		}
+		return ScopeContainer, r, id
+	}
+}

--- a/pkg/discovery/integrationdetection/detector_test.go
+++ b/pkg/discovery/integrationdetection/detector_test.go
@@ -1,0 +1,368 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package integrationdetection
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+// fakeAD captures the scheduler registered via AddScheduler, letting tests
+// call Schedule/Unschedule directly. Unused methods panic to surface mistakes.
+type fakeAD struct {
+	schedulerCh chan scheduler.Scheduler
+}
+
+func newFakeAD() *fakeAD {
+	return &fakeAD{schedulerCh: make(chan scheduler.Scheduler, 1)}
+}
+
+func (f *fakeAD) AddScheduler(_ string, s scheduler.Scheduler, _ bool) {
+	f.schedulerCh <- s
+}
+
+func (f *fakeAD) RemoveScheduler(_ string) {}
+
+// waitForScheduler blocks until AddScheduler has been called or the test finishes.
+func (f *fakeAD) waitForScheduler(t *testing.T) scheduler.Scheduler {
+	t.Helper()
+	select {
+	case s := <-f.schedulerCh:
+		return s
+	case <-t.Context().Done():
+		t.Fatalf("timed out waiting for scheduler registration: %v", t.Context().Err())
+		return nil // unreachable: t.Fatalf calls runtime.Goexit
+	}
+}
+
+// Unimplemented methods — panic to make accidental calls obvious.
+
+func (f *fakeAD) AddConfigProvider(types.ConfigProvider, bool, time.Duration) {
+	panic("not implemented")
+}
+func (f *fakeAD) LoadAndRun(context.Context)                              { panic("not implemented") }
+func (f *fakeAD) GetAllConfigs() []integration.Config                    { panic("not implemented") }
+func (f *fakeAD) GetUnresolvedConfigs() []integration.Config             { panic("not implemented") }
+func (f *fakeAD) AddListeners([]pkgconfigsetup.Listeners)                { panic("not implemented") }
+func (f *fakeAD) GetIDOfCheckWithEncryptedSecrets(checkid.ID) checkid.ID { panic("not implemented") }
+func (f *fakeAD) GetAutodiscoveryErrors() map[string]map[string]types.ErrorMsgSet {
+	panic("not implemented")
+}
+func (f *fakeAD) AddConfigProviderFromCatalog(pkgconfigsetup.ConfigurationProviders) error {
+	panic("not implemented")
+}
+func (f *fakeAD) GetTelemetryStore() *telemetry.Store            { panic("not implemented") }
+func (f *fakeAD) GetConfigCheck() integration.ConfigCheckResponse { panic("not implemented") }
+
+// makeConfig creates a minimal integration.Config for testing.
+// A non-empty Instances slice is required for IsCheckConfig() to return true.
+func makeConfig(name, serviceID string, isCheck bool) integration.Config {
+	cfg := integration.Config{
+		Name:      name,
+		ServiceID: serviceID,
+	}
+	if isCheck {
+		cfg.Instances = []integration.Data{[]byte("{}")}
+	}
+	return cfg
+}
+
+// startDetector creates a Detector, registers it with a fakeAD, and returns
+// both the detector and the captured scheduler for test use. It registers a
+// cleanup that calls d.Stop(); tests that call d.Stop() manually are safe
+// because Stop is guarded by sync.Once and the cleanup becomes a no-op.
+func startDetector(t *testing.T) (*Detector, scheduler.Scheduler) {
+	t.Helper()
+	d := NewDetector()
+	ac := newFakeAD()
+	d.Start(ac)
+	t.Cleanup(d.Stop)
+	return d, ac.waitForScheduler(t)
+}
+
+// --- integrationForCheck allowlist tests ---
+
+func TestIntegrationsAllowlist(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		checkName     string
+		wantCanon     string
+		wantSupported bool
+	}{
+		{checkName: "redisdb", wantCanon: "redis", wantSupported: true},
+		{checkName: "elastic", wantCanon: "elasticsearch", wantSupported: true},
+		{checkName: "nginx", wantCanon: "nginx", wantSupported: true},
+		{checkName: "etcd", wantCanon: "etcd", wantSupported: true},
+		{checkName: "unknown", wantCanon: "", wantSupported: false},
+		{checkName: "redis", wantCanon: "", wantSupported: false}, // binary name, not check name
+	}
+	for _, tc := range tests {
+		t.Run(tc.checkName, func(t *testing.T) {
+			t.Parallel()
+			canon, ok := integrationForCheck(tc.checkName)
+			assert.Equal(t, tc.wantSupported, ok)
+			assert.Equal(t, tc.wantCanon, canon)
+		})
+	}
+}
+
+// --- classifyServiceID unit tests ---
+
+func TestClassifyServiceID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		serviceID   string
+		wantScope   Scope
+		wantRuntime string
+		wantCID     string
+	}{
+		{
+			name:      "empty — file-based static config",
+			wantScope: ScopeHost,
+		},
+		{
+			name:      "process-based AD listener",
+			serviceID: "process://12345",
+			wantScope: ScopeHost,
+		},
+		{
+			name:        "docker container",
+			serviceID:   "docker://abc123",
+			wantScope:   ScopeContainer,
+			wantRuntime: "docker",
+			wantCID:     "abc123",
+		},
+		{
+			name:        "containerd container",
+			serviceID:   "containerd://def456",
+			wantScope:   ScopeContainer,
+			wantRuntime: "containerd",
+			wantCID:     "def456",
+		},
+		{
+			// Malformed "://" with no runtime or ID should not produce a ScopeContainer entry.
+			name:      "malformed — empty runtime and id",
+			serviceID: "://",
+			wantScope: ScopeHost,
+		},
+		{
+			// Malformed: non-empty ID but empty runtime — also treated as host.
+			name:      "malformed — empty runtime non-empty id",
+			serviceID: "://abc123",
+			wantScope: ScopeHost,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			scope, runtime, cid := classifyServiceID(tc.serviceID)
+			assert.Equal(t, tc.wantScope, scope)
+			assert.Equal(t, tc.wantRuntime, runtime)
+			assert.Equal(t, tc.wantCID, cid)
+		})
+	}
+}
+
+// --- Detector behaviour tests ---
+
+func TestDetector_SupportedCheckScheduled(t *testing.T) {
+	t.Parallel()
+	d, s := startDetector(t)
+
+	s.Schedule([]integration.Config{makeConfig("redisdb", "", true)})
+
+	snap := d.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, "redis", snap[0].Integration)
+	assert.Equal(t, "redisdb", snap[0].CheckName)
+	assert.Equal(t, ScopeHost, snap[0].Scope)
+	assert.Empty(t, snap[0].Runtime)
+	assert.Empty(t, snap[0].ContainerID)
+}
+
+func TestDetector_UnsupportedCheckNotInSnapshot(t *testing.T) {
+	t.Parallel()
+	d, s := startDetector(t)
+
+	s.Schedule([]integration.Config{makeConfig("myapp", "", true)})
+
+	assert.Nil(t, d.Snapshot())
+}
+
+func TestDetector_LogsOnlyConfigIgnored(t *testing.T) {
+	t.Parallel()
+	d, s := startDetector(t)
+
+	// isCheck=false → no Instances → IsCheckConfig() returns false.
+	s.Schedule([]integration.Config{makeConfig("redisdb", "", false)})
+
+	assert.Nil(t, d.Snapshot())
+}
+
+func TestDetector_ProcessBasedConfig(t *testing.T) {
+	t.Parallel()
+	d, s := startDetector(t)
+
+	s.Schedule([]integration.Config{makeConfig("redisdb", "process://12345", true)})
+
+	snap := d.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, ScopeHost, snap[0].Scope)
+	assert.Empty(t, snap[0].Runtime)
+	assert.Empty(t, snap[0].ContainerID)
+}
+
+func TestDetector_ContainerConfig(t *testing.T) {
+	t.Parallel()
+	d, s := startDetector(t)
+
+	s.Schedule([]integration.Config{makeConfig("redisdb", "docker://abc123", true)})
+
+	snap := d.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, ScopeContainer, snap[0].Scope)
+	assert.Equal(t, "docker", snap[0].Runtime)
+	assert.Equal(t, "abc123", snap[0].ContainerID)
+}
+
+func TestDetector_TwoInstancesSameIntegration(t *testing.T) {
+	t.Parallel()
+	d, s := startDetector(t)
+
+	// Two distinct configs — different ServiceIDs produce different digests.
+	cfg1 := makeConfig("redisdb", "process://1111", true)
+	cfg2 := makeConfig("redisdb", "process://2222", true)
+	s.Schedule([]integration.Config{cfg1, cfg2})
+
+	snap := d.Snapshot()
+	require.Len(t, snap, 2)
+	for _, ei := range snap {
+		assert.Equal(t, "redis", ei.Integration)
+	}
+	// Verify the two entries have distinct digests — the precondition for two
+	// separate map entries is that the configs produce different digests.
+	assert.NotEqual(t, snap[0].Digest, snap[1].Digest)
+}
+
+func TestDetector_ScheduleThenUnschedule(t *testing.T) {
+	t.Parallel()
+	d, s := startDetector(t)
+
+	cfg := makeConfig("redisdb", "", true)
+	s.Schedule([]integration.Config{cfg})
+	require.Len(t, d.Snapshot(), 1)
+
+	s.Unschedule([]integration.Config{cfg})
+	assert.Nil(t, d.Snapshot())
+}
+
+func TestDetector_DuplicateDigestDeduped(t *testing.T) {
+	t.Parallel()
+	d, s := startDetector(t)
+
+	cfg := makeConfig("redisdb", "", true)
+	s.Schedule([]integration.Config{cfg, cfg}) // same config twice
+
+	assert.Len(t, d.Snapshot(), 1)
+}
+
+func TestDetector_StopClearsMap(t *testing.T) {
+	t.Parallel()
+	d, s := startDetector(t)
+
+	s.Schedule([]integration.Config{makeConfig("redisdb", "", true)})
+	require.Len(t, d.Snapshot(), 1)
+
+	d.Stop()
+	assert.Nil(t, d.Snapshot())
+}
+
+func TestDetector_StaleCallbackAfterStop(t *testing.T) {
+	t.Parallel()
+	d, s := startDetector(t)
+
+	d.Stop()
+	// Simulate a stale Schedule callback arriving after Stop returns.
+	s.Schedule([]integration.Config{makeConfig("redisdb", "", true)})
+
+	assert.Nil(t, d.Snapshot())
+}
+
+func TestDetector_StartIdempotent(t *testing.T) {
+	t.Parallel()
+	ac1 := newFakeAD()
+	ac2 := newFakeAD()
+	d := NewDetector()
+	t.Cleanup(d.Stop)
+
+	d.Start(ac1)
+	_ = ac1.waitForScheduler(t)
+
+	// Second Start must be a no-op; ac2 must not receive a scheduler.
+	// The non-blocking select is correct here because Start is synchronous:
+	// startOnce.Do is already exhausted so it returns immediately without sending.
+	d.Start(ac2)
+	select {
+	case <-ac2.schedulerCh:
+		t.Fatal("second Start registered a scheduler — Start must be idempotent")
+	default:
+	}
+}
+
+// TestDetector_ConcurrentStopSchedule verifies that a concurrent Stop call
+// does not race with in-flight Schedule callbacks — the primary race condition
+// documented in the Detector struct comment. Run with `go test -race`.
+func TestDetector_ConcurrentStopSchedule(t *testing.T) {
+	t.Parallel()
+	cfg := makeConfig("redisdb", "", true)
+
+	// wg.Go is available from Go 1.25 (adds a task and spawns a goroutine).
+	var wg sync.WaitGroup
+	for range 10 {
+		// Each iteration uses a fresh detector to avoid the stopOnce guard
+		// preventing re-entry in subsequent iterations.
+		d := NewDetector()
+		t.Cleanup(d.Stop) // ensures deregistration even if the Stop goroutine loses the race
+		ac := newFakeAD()
+		d.Start(ac)
+		s := ac.waitForScheduler(t)
+
+		wg.Go(func() { s.Schedule([]integration.Config{cfg}) })
+		wg.Go(func() { d.Stop() })
+	}
+	wg.Wait()
+}
+
+// TestDetector_ConcurrentScheduleSnapshot exercises the race detector on
+// concurrent Schedule, Unschedule, and Snapshot calls. No specific final state
+// is asserted — the test verifies absence of data races only.
+// Run with `go test -race` to fully exercise the mutex paths.
+func TestDetector_ConcurrentScheduleSnapshot(t *testing.T) {
+	t.Parallel()
+	d, s := startDetector(t)
+
+	cfg := makeConfig("redisdb", "", true)
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Go(func() { s.Schedule([]integration.Config{cfg}) })
+		wg.Go(func() { s.Unschedule([]integration.Config{cfg}) })
+		wg.Go(func() { _ = d.Snapshot() })
+	}
+	wg.Wait()
+}

--- a/pkg/discovery/integrationdetection/integrations.go
+++ b/pkg/discovery/integrationdetection/integrations.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package integrationdetection
+
+// integrationForCheck returns the canonical Datadog integration name for a given
+// Autodiscovery check name (config.Name). The check name is NOT the daemon
+// binary name — e.g. "redisdb", not "redis-server". Verify actual names by
+// running `agent status` with each integration enabled.
+//
+// Returns ("", false) when the check name is not in the allowlist.
+// Adding a new integration requires only a new case here.
+//
+// TODO: extend this list as additional integrations are validated against real agent runs.
+func integrationForCheck(checkName string) (string, bool) {
+	switch checkName {
+	case "redisdb":
+		return "redis", true
+	case "elastic":
+		return "elasticsearch", true
+	case "nginx":
+		return "nginx", true
+	case "etcd":
+		return "etcd", true
+	default:
+		return "", false
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a new optional Fx component (`comp/discovery/integrationdetection`) that subscribes to the Autodiscovery scheduler and maintains a live snapshot of which integrations are currently active on the host.

**New packages:**
- `pkg/discovery/integrationdetection` — core `Detector` (pure domain logic, no Fx dependency); `EnabledIntegration` type; `classifyServiceID` helper
- `comp/discovery/integrationdetection/def` — `Component` interface exposing `EnabledIntegrations() []EnabledIntegration`
- `comp/discovery/integrationdetection/impl` — Fx component wiring, gated by config flag
- `comp/discovery/integrationdetection/fx` — Fx module

Gated by `discovery.integration_detection.enabled` (default: `false`).

### Motivation

Building block for the DSCVR-438 config ingestion pipeline. The `configingestion.Watcher` currently maps process binary names to integration names via a static table. This component provides a more authoritative source: the canonical integration name as known by Autodiscovery (e.g. `redisdb` check → `"redis"` integration), covering both file-based and process-based AD configs.

Feeds directly into the backend pipeline in DataDog/experimental#9989, which expects envelopes with `integration: "redis"` etc.

### Describe how you validated your changes

- 27 unit tests covering: allowlist mapping, scope classification (host/container/process/malformed), schedule/unschedule lifecycle, dedup, Stop/Start idempotency, stale-callback-after-Stop
- Two race-detector tests (`TestDetector_ConcurrentStopSchedule`, `TestDetector_ConcurrentScheduleSnapshot`) — run with `go test -race`
- Component-level tests for enabled/disabled config gate and Fx lifecycle

```bash
dda inv test --targets=./pkg/discovery/integrationdetection/... --race
dda inv test --targets=./comp/discovery/integrationdetection/... --race
```

### Additional Notes

- No consumer wires up `EnabledIntegrations()` yet (wired as `_` in `command.go`) — follow-up ticket will connect it to `configingestion.Watcher`
- Allowlist covers 4 integrations for now: redis, elasticsearch, nginx, etcd

https://datadoghq.atlassian.net/browse/DSCVR-467