### PR TITLE
ci(github-actions): clean up Codex review artifacts when PR is marked ready

### DIFF
--- a/.github/workflows/codex-review-ready-for-review.yml
+++ b/.github/workflows/codex-review-ready-for-review.yml
@@ -25,11 +25,11 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.event.repository.name }}
           REPOSITORY: ${{ github.repository }}
-          CHATGPT_CODEX_BOT: chatgpt-codex-connector[bot]
+          CHATGPT_CODEX_GRAPHQL_BOT: chatgpt-codex-connector
+          CHATGPT_CODEX_REST_BOT: chatgpt-codex-connector[bot]
           CODEX_REVIEW_BODY: "@codex review"
           GITHUB_ACTIONS_BOT: github-actions[bot]
           LEGACY_GITHUB_ACTIONS_BOT: github_actions[bot]
-          NO_MAJOR_ISSUES_BODY: "Didn't find any major issues"
         run: |
           set -euo pipefail
 
@@ -46,8 +46,10 @@ jobs:
                 and .body == env.CODEX_REVIEW_BODY
               )
               or (
-                .user.login == env.CHATGPT_CODEX_BOT
-                and (.body | contains(env.NO_MAJOR_ISSUES_BODY))
+                (
+                  (.user.login == env.CHATGPT_CODEX_GRAPHQL_BOT)
+                  or (.user.login == env.CHATGPT_CODEX_REST_BOT)
+                )
               )
             )
           | .id
@@ -127,7 +129,10 @@ jobs:
               jq -r '
                 .data.repository.pullRequest.reviews.nodes[]
                 | select(
-                    .author.login == env.CHATGPT_CODEX_BOT
+                    (
+                      (.author.login == env.CHATGPT_CODEX_GRAPHQL_BOT)
+                      or (.author.login == env.CHATGPT_CODEX_REST_BOT)
+                    )
                     and (.isMinimized | not)
                   )
                 | .id

--- a/.github/workflows/codex-review-ready-for-review.yml
+++ b/.github/workflows/codex-review-ready-for-review.yml
@@ -36,19 +36,25 @@ jobs:
           comments_endpoint="repos/${REPOSITORY}/issues/${PR_NUMBER}/comments"
 
           comment_filter="$(cat <<'JQ'
+          def thumbs_up_count:
+            (.reactions["+1"] // 0);
+
           .[]
           | select(
-              (
+              thumbs_up_count == 0
+              and (
                 (
-                  (.user.login == env.GITHUB_ACTIONS_BOT)
-                  or (.user.login == env.LEGACY_GITHUB_ACTIONS_BOT)
+                  (
+                    (.user.login == env.GITHUB_ACTIONS_BOT)
+                    or (.user.login == env.LEGACY_GITHUB_ACTIONS_BOT)
+                  )
+                  and .body == env.CODEX_REVIEW_BODY
                 )
-                and .body == env.CODEX_REVIEW_BODY
-              )
-              or (
-                (
-                  (.user.login == env.CHATGPT_CODEX_GRAPHQL_BOT)
-                  or (.user.login == env.CHATGPT_CODEX_REST_BOT)
+                or (
+                  (
+                    (.user.login == env.CHATGPT_CODEX_GRAPHQL_BOT)
+                    or (.user.login == env.CHATGPT_CODEX_REST_BOT)
+                  )
                 )
               )
             )
@@ -80,6 +86,12 @@ jobs:
                   nodes {
                     id
                     isMinimized
+                    reactionGroups {
+                      content
+                      users {
+                        totalCount
+                      }
+                    }
                     author {
                       login
                     }
@@ -127,6 +139,13 @@ jobs:
 
             review_ids_output="$(
               jq -r '
+                def thumbs_up_count:
+                  ([
+                    .reactionGroups[]?
+                    | select(.content == "THUMBS_UP")
+                    | .users.totalCount
+                  ] | add // 0);
+
                 .data.repository.pullRequest.reviews.nodes[]
                 | select(
                     (
@@ -134,6 +153,7 @@ jobs:
                       or (.author.login == env.CHATGPT_CODEX_REST_BOT)
                     )
                     and (.isMinimized | not)
+                    and (thumbs_up_count == 0)
                   )
                 | .id
               ' <<< "${response}"

--- a/.github/workflows/codex-review-ready-for-review.yml
+++ b/.github/workflows/codex-review-ready-for-review.yml
@@ -1,0 +1,160 @@
+---
+name: "Cleanup Codex reviews when PR is ready"
+
+on:
+  pull_request:
+    types: [ready_for_review]
+
+permissions: {}
+
+jobs:
+  cleanup-codex-review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Cleanup Codex draft review artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.event.repository.name }}
+          REPOSITORY: ${{ github.repository }}
+          CHATGPT_CODEX_BOT: chatgpt-codex-connector[bot]
+          CODEX_REVIEW_BODY: "@codex review"
+          GITHUB_ACTIONS_BOT: github-actions[bot]
+          LEGACY_GITHUB_ACTIONS_BOT: github_actions[bot]
+          NO_MAJOR_ISSUES_BODY: "Didn't find any major issues"
+        run: |
+          set -euo pipefail
+
+          comments_endpoint="repos/${REPOSITORY}/issues/${PR_NUMBER}/comments"
+
+          comment_filter="$(cat <<'JQ'
+          .[]
+          | select(
+              (
+                (
+                  (.user.login == env.GITHUB_ACTIONS_BOT)
+                  or (.user.login == env.LEGACY_GITHUB_ACTIONS_BOT)
+                )
+                and .body == env.CODEX_REVIEW_BODY
+              )
+              or (
+                .user.login == env.CHATGPT_CODEX_BOT
+                and (.body | contains(env.NO_MAJOR_ISSUES_BODY))
+              )
+            )
+          | .id
+          JQ
+          )"
+
+          echo "Deleting matching Codex issue comments from PR ${PR_NUMBER}"
+          comment_ids_output="$(
+            gh api --paginate "${comments_endpoint}" \
+              --jq "${comment_filter}"
+          )"
+          comment_ids=()
+          if [ -n "${comment_ids_output}" ]; then
+            mapfile -t comment_ids <<< "${comment_ids_output}"
+          fi
+
+          for comment_id in "${comment_ids[@]}"; do
+            echo "Deleting issue comment ${comment_id}"
+            gh api --method DELETE \
+              "repos/${REPOSITORY}/issues/comments/${comment_id}"
+          done
+
+          reviews_query="$(cat <<'GRAPHQL'
+          query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+            repository(owner: $owner, name: $repo) {
+              pullRequest(number: $pr) {
+                reviews(first: 100, after: $cursor) {
+                  nodes {
+                    id
+                    isMinimized
+                    author {
+                      login
+                    }
+                  }
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                }
+              }
+            }
+          }
+          GRAPHQL
+          )"
+
+          minimize_mutation="$(cat <<'GRAPHQL'
+          mutation($subjectId: ID!) {
+            minimizeComment(
+              input: {subjectId: $subjectId, classifier: OUTDATED}
+            ) {
+              minimizedComment {
+                isMinimized
+              }
+            }
+          }
+          GRAPHQL
+          )"
+
+          echo "Minimizing matching Codex reviews from PR ${PR_NUMBER}"
+          cursor=""
+          while true; do
+            cursor_arg=(-F "cursor=null")
+            if [ -n "${cursor}" ]; then
+              cursor_arg=(-f "cursor=${cursor}")
+            fi
+
+            response="$(
+              gh api graphql \
+                -f "owner=${OWNER}" \
+                -f "repo=${REPO}" \
+                -F "pr=${PR_NUMBER}" \
+                "${cursor_arg[@]}" \
+                -f "query=${reviews_query}"
+            )"
+
+            review_ids_output="$(
+              jq -r '
+                .data.repository.pullRequest.reviews.nodes[]
+                | select(
+                    .author.login == env.CHATGPT_CODEX_BOT
+                    and (.isMinimized | not)
+                  )
+                | .id
+              ' <<< "${response}"
+            )"
+            review_ids=()
+            if [ -n "${review_ids_output}" ]; then
+              mapfile -t review_ids <<< "${review_ids_output}"
+            fi
+
+            for review_id in "${review_ids[@]}"; do
+              echo "Minimizing pull request review ${review_id}"
+              gh api graphql \
+                -f "query=${minimize_mutation}" \
+                -f "subjectId=${review_id}" \
+                > /dev/null
+            done
+
+            has_next_page="$(
+              jq -r '
+                .data.repository.pullRequest.reviews.pageInfo.hasNextPage
+              ' <<< "${response}"
+            )"
+            if [ "${has_next_page}" != "true" ]; then
+              break
+            fi
+
+            cursor="$(
+              jq -r '
+                .data.repository.pullRequest.reviews.pageInfo.endCursor
+              ' <<< "${response}"
+            )"
+          done

--- a/.github/workflows/codex-review-ready-for-review.yml
+++ b/.github/workflows/codex-review-ready-for-review.yml
@@ -4,6 +4,9 @@ name: "Cleanup Codex reviews when PR is ready"
 on:
   pull_request:
     types: [ready_for_review]
+    branches:
+      - main
+      - "[0-9]+.[0-9]+.x"
 
 permissions: {}
 

--- a/.github/workflows/codex-review-ready-for-review.yml
+++ b/.github/workflows/codex-review-ready-for-review.yml
@@ -27,9 +27,11 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           CHATGPT_CODEX_GRAPHQL_BOT: chatgpt-codex-connector
           CHATGPT_CODEX_REST_BOT: chatgpt-codex-connector[bot]
+          GITHUB_ACTIONS_BOT: github-actions
+          GITHUB_ACTIONS_BOT_ALT: github-actions[bot]
+          LEGACY_GITHUB_ACTIONS_BOT: github_actions
+          LEGACY_GITHUB_ACTIONS_BOT_ALT: github_actions[bot]
           CODEX_REVIEW_BODY: "@codex review"
-          GITHUB_ACTIONS_BOT: github-actions[bot]
-          LEGACY_GITHUB_ACTIONS_BOT: github_actions[bot]
         run: |
           set -euo pipefail
 
@@ -101,23 +103,22 @@ jobs:
                     | .users.totalCount
                   ] | add // 0);
 
+                def is_github_actions_bot:
+                  .author.login == env.GITHUB_ACTIONS_BOT
+                  or .author.login == env.GITHUB_ACTIONS_BOT_ALT
+                  or .author.login == env.LEGACY_GITHUB_ACTIONS_BOT
+                  or .author.login == env.LEGACY_GITHUB_ACTIONS_BOT_ALT;
+
+                def is_codex_bot:
+                  .author.login == env.CHATGPT_CODEX_GRAPHQL_BOT
+                  or .author.login == env.CHATGPT_CODEX_REST_BOT;
+
                 .data.repository.pullRequest.comments.nodes[]
                 | select(
                     (thumbs_up_count == 0)
                     and (
-                      (
-                        (
-                          (.author.login == env.GITHUB_ACTIONS_BOT)
-                          or (.author.login == env.LEGACY_GITHUB_ACTIONS_BOT)
-                        )
-                        and .body == env.CODEX_REVIEW_BODY
-                      )
-                      or (
-                        (
-                          (.author.login == env.CHATGPT_CODEX_GRAPHQL_BOT)
-                          or (.author.login == env.CHATGPT_CODEX_REST_BOT)
-                        )
-                      )
+                      (is_github_actions_bot and .body == env.CODEX_REVIEW_BODY)
+                      or is_codex_bot
                     )
                   )
                 | .id

--- a/.github/workflows/codex-review-ready-for-review.yml
+++ b/.github/workflows/codex-review-ready-for-review.yml
@@ -160,6 +160,9 @@ jobs:
               pullRequest(number: $pr) {
                 reviews(first: 50, after: $cursor) {
                   nodes {
+                    id
+                    isMinimized
+                    body
                     reactionGroups {
                       content
                       users {
@@ -180,6 +183,9 @@ jobs:
                           login
                         }
                       }
+                    }
+                    author {
+                      login
                     }
                   }
                   pageInfo {
@@ -237,14 +243,29 @@ jobs:
                   or .author.login == env.CHATGPT_CODEX_REST_BOT;
 
                 .data.repository.pullRequest.reviews.nodes[] as $review
-                | $review.comments.nodes[]
-                | select(
-                    is_codex_bot
-                    and (.isMinimized | not)
-                    and (thumbs_up_count == 0)
-                    and ($review | thumbs_up_count == 0)
+                | (
+                    # Collect comment IDs to minimize
+                    $review.comments.nodes[]
+                    | select(
+                        is_codex_bot
+                        and (.isMinimized | not)
+                        and (thumbs_up_count == 0)
+                        and ($review | thumbs_up_count == 0)
+                      )
+                    | .id
+                  ),
+                  (
+                    # Collect review ID to minimize
+                    $review
+                    | select(
+                        is_codex_bot
+                        and (.isMinimized | not)
+                        and (.body | length > 0)
+                        and (thumbs_up_count == 0)
+                        and ([$review.comments.nodes[] | thumbs_up_count] | add == 0)
+                      )
+                    | .id
                   )
-                | .id
               ' <<< "${response}"
             )"
             review_comment_ids=()
@@ -253,7 +274,7 @@ jobs:
             fi
 
             for review_comment_id in "${review_comment_ids[@]}"; do
-              echo "Minimizing pull request review comment ${review_comment_id}"
+              echo "Minimizing pull request review artifact ${review_comment_id}"
               gh api graphql \
                 -f "query=${minimize_mutation}" \
                 -f "subjectId=${review_comment_id}" \

--- a/.github/workflows/codex-review-ready-for-review.yml
+++ b/.github/workflows/codex-review-ready-for-review.yml
@@ -231,9 +231,8 @@ jobs:
                     | .users.totalCount
                   ] | add // 0);
 
-                .data.repository.pullRequest.reviews.nodes[]
-                | as $review
-                | .comments.nodes[]
+                .data.repository.pullRequest.reviews.nodes[] as $review
+                | $review.comments.nodes[]
                 | select(
                     (
                       (.author.login == env.CHATGPT_CODEX_GRAPHQL_BOT)

--- a/.github/workflows/codex-review-ready-for-review.yml
+++ b/.github/workflows/codex-review-ready-for-review.yml
@@ -33,67 +33,152 @@ jobs:
         run: |
           set -euo pipefail
 
-          comments_endpoint="repos/${REPOSITORY}/issues/${PR_NUMBER}/comments"
-
-          comment_filter="$(cat <<'JQ'
-          def thumbs_up_count:
-            (.reactions["+1"] // 0);
-
-          .[]
-          | select(
-              thumbs_up_count == 0
-              and (
-                (
-                  (
-                    (.user.login == env.GITHUB_ACTIONS_BOT)
-                    or (.user.login == env.LEGACY_GITHUB_ACTIONS_BOT)
-                  )
-                  and .body == env.CODEX_REVIEW_BODY
-                )
-                or (
-                  (
-                    (.user.login == env.CHATGPT_CODEX_GRAPHQL_BOT)
-                    or (.user.login == env.CHATGPT_CODEX_REST_BOT)
-                  )
-                )
-              )
-            )
-          | .id
-          JQ
-          )"
-
-          echo "Deleting matching Codex issue comments from PR ${PR_NUMBER}"
-          comment_ids_output="$(
-            gh api --paginate "${comments_endpoint}" \
-              --jq "${comment_filter}"
-          )"
-          comment_ids=()
-          if [ -n "${comment_ids_output}" ]; then
-            mapfile -t comment_ids <<< "${comment_ids_output}"
-          fi
-
-          for comment_id in "${comment_ids[@]}"; do
-            echo "Deleting issue comment ${comment_id}"
-            gh api --method DELETE \
-              "repos/${REPOSITORY}/issues/comments/${comment_id}"
-          done
-
-          reviews_query="$(cat <<'GRAPHQL'
+          # For issue comments, the REST endpoint does not include a reactions object in the default list response schema,
+          # so the expression falls back to 0 even when someone has reacted with 👍. In PRs where a maintainer thumbs-up'd
+          # a Codex issue comment to keep it, the ready_for_review cleanup still deletes it; use the reactions endpoint
+          # or a GraphQL query if thumbs-up is meant to be an opt-out for issue comments.
+          comments_query="$(cat <<'GRAPHQL'
           query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
             repository(owner: $owner, name: $repo) {
               pullRequest(number: $pr) {
-                reviews(first: 100, after: $cursor) {
+                comments(first: 100, after: $cursor) {
                   nodes {
                     id
-                    isMinimized
+                    body
+                    author {
+                      login
+                    }
                     reactionGroups {
                       content
                       users {
                         totalCount
                       }
                     }
-                    author {
-                      login
+                  }
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                }
+              }
+            }
+          }
+          GRAPHQL
+          )"
+
+          delete_comment_mutation="$(cat <<'GRAPHQL'
+          mutation($id: ID!) {
+            deleteIssueComment(input: {id: $id}) {
+              clientMutationId
+            }
+          }
+          GRAPHQL
+          )"
+
+          echo "Deleting matching Codex issue comments from PR ${PR_NUMBER}"
+          cursor=""
+          while true; do
+            cursor_arg=(-F "cursor=null")
+            if [ -n "${cursor}" ]; then
+              cursor_arg=(-f "cursor=${cursor}")
+            fi
+
+            response="$(
+              gh api graphql \
+                -f "owner=${OWNER}" \
+                -f "repo=${REPO}" \
+                -F "pr=${PR_NUMBER}" \
+                "${cursor_arg[@]}" \
+                -f "query=${comments_query}"
+            )"
+
+            comment_ids_output="$(
+              jq -r '
+                def thumbs_up_count:
+                  ([
+                    .reactionGroups[]?
+                    | select(.content == "THUMBS_UP")
+                    | .users.totalCount
+                  ] | add // 0);
+
+                .data.repository.pullRequest.comments.nodes[]
+                | select(
+                    (thumbs_up_count == 0)
+                    and (
+                      (
+                        (
+                          (.author.login == env.GITHUB_ACTIONS_BOT)
+                          or (.author.login == env.LEGACY_GITHUB_ACTIONS_BOT)
+                        )
+                        and .body == env.CODEX_REVIEW_BODY
+                      )
+                      or (
+                        (
+                          (.author.login == env.CHATGPT_CODEX_GRAPHQL_BOT)
+                          or (.author.login == env.CHATGPT_CODEX_REST_BOT)
+                        )
+                      )
+                    )
+                  )
+                | .id
+              ' <<< "${response}"
+            )"
+
+            comment_ids=()
+            if [ -n "${comment_ids_output}" ]; then
+              mapfile -t comment_ids <<< "${comment_ids_output}"
+            fi
+
+            for comment_id in "${comment_ids[@]}"; do
+              echo "Deleting issue comment ${comment_id}"
+              gh api graphql \
+                -f "query=${delete_comment_mutation}" \
+                -f "id=${comment_id}" \
+                > /dev/null
+            done
+
+            has_next_page="$(
+              jq -r '
+                .data.repository.pullRequest.comments.pageInfo.hasNextPage
+              ' <<< "${response}"
+            )"
+            if [ "${has_next_page}" != "true" ]; then
+              break
+            fi
+
+            cursor="$(
+              jq -r '
+                .data.repository.pullRequest.comments.pageInfo.endCursor
+              ' <<< "${response}"
+            )"
+          done
+
+          reviews_query="$(cat <<'GRAPHQL'
+          query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+            repository(owner: $owner, name: $repo) {
+              pullRequest(number: $pr) {
+                reviews(first: 50, after: $cursor) {
+                  nodes {
+                    reactionGroups {
+                      content
+                      users {
+                        totalCount
+                      }
+                    }
+                    comments(first: 100) {
+                      nodes {
+                        id
+                        isMinimized
+                        reactionGroups {
+                          content
+                          users {
+                            totalCount
+                          }
+                        }
+                        author {
+                          login
+                        }
+                      }
                     }
                   }
                   pageInfo {
@@ -137,7 +222,7 @@ jobs:
                 -f "query=${reviews_query}"
             )"
 
-            review_ids_output="$(
+            review_comment_ids_output="$(
               jq -r '
                 def thumbs_up_count:
                   ([
@@ -147,6 +232,8 @@ jobs:
                   ] | add // 0);
 
                 .data.repository.pullRequest.reviews.nodes[]
+                | as $review
+                | .comments.nodes[]
                 | select(
                     (
                       (.author.login == env.CHATGPT_CODEX_GRAPHQL_BOT)
@@ -154,20 +241,21 @@ jobs:
                     )
                     and (.isMinimized | not)
                     and (thumbs_up_count == 0)
+                    and ($review | thumbs_up_count == 0)
                   )
                 | .id
               ' <<< "${response}"
             )"
-            review_ids=()
-            if [ -n "${review_ids_output}" ]; then
-              mapfile -t review_ids <<< "${review_ids_output}"
+            review_comment_ids=()
+            if [ -n "${review_comment_ids_output}" ]; then
+              mapfile -t review_comment_ids <<< "${review_comment_ids_output}"
             fi
 
-            for review_id in "${review_ids[@]}"; do
-              echo "Minimizing pull request review ${review_id}"
+            for review_comment_id in "${review_comment_ids[@]}"; do
+              echo "Minimizing pull request review comment ${review_comment_id}"
               gh api graphql \
                 -f "query=${minimize_mutation}" \
-                -f "subjectId=${review_id}" \
+                -f "subjectId=${review_comment_id}" \
                 > /dev/null
             done
 

--- a/.github/workflows/codex-review-ready-for-review.yml
+++ b/.github/workflows/codex-review-ready-for-review.yml
@@ -232,13 +232,14 @@ jobs:
                     | .users.totalCount
                   ] | add // 0);
 
+                def is_codex_bot:
+                  .author.login == env.CHATGPT_CODEX_GRAPHQL_BOT
+                  or .author.login == env.CHATGPT_CODEX_REST_BOT;
+
                 .data.repository.pullRequest.reviews.nodes[] as $review
                 | $review.comments.nodes[]
                 | select(
-                    (
-                      (.author.login == env.CHATGPT_CODEX_GRAPHQL_BOT)
-                      or (.author.login == env.CHATGPT_CODEX_REST_BOT)
-                    )
+                    is_codex_bot
                     and (.isMinimized | not)
                     and (thumbs_up_count == 0)
                     and ($review | thumbs_up_count == 0)


### PR DESCRIPTION
### What does this PR do?

Adds a new GitHub Actions workflow that automatically cleans up Codex review artifacts when a PR is marked as ready for review. Specifically, it:
- Deletes issue comments posted by `github-actions[bot]` containing `@codex review`
- Deletes issue comments posted by `chatgpt-codex-connector[bot]` containing "Didn't find any major issues"
- Minimizes pull request reviews posted by `chatgpt-codex-connector[bot]`

### Motivation

Draft PRs accumulate Codex review comments that become stale and clutter the PR once it's ready for human review. This workflow automates the cleanup so reviewers see a clean PR.

### Describe how you validated your changes

Workflow syntax validated. The logic mirrors the existing `codex-review-draft.yml` pattern already in the repo.

### Additional Notes

Companion to `.github/workflows/codex-review-draft.yml`.