### PR TITLE
[CNM-5445] Fix DD_NETWORK_CONFIG_DNS_MONITORING_PORTS env var parsing.

### DIFF
--- a/pkg/config/schema/system-probe_schema.yaml
+++ b/pkg/config/schema/system-probe_schema.yaml
@@ -592,6 +592,7 @@ properties:
         type: array
         default:
         - 53
+        env_parser: space_separated
         items:
           type: number
         visibility: public

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -200,6 +200,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("system_probe_config.max_dns_stats", 20000)
 	cfg.BindEnvAndSetDefault("system_probe_config.dns_timeout_in_s", 15)
 	cfg.BindEnvAndSetDefault("network_config.dns_monitoring_ports", []int{53})
+	cfg.ParseEnvSplitSpace("network_config.dns_monitoring_ports")
 
 	cfg.BindEnvAndSetDefault("system_probe_config.enable_conntrack", true)
 	cfg.BindEnvAndSetDefault("system_probe_config.conntrack_max_state_size", 65536*2)

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -334,17 +334,22 @@ func New() *Config {
 		log.Warnf("failed to parse dns_monitoring_ports: %v", err)
 	}
 
+	dnsPortsKey := sysconfig.FullKeyPath(netNS, "dns_monitoring_ports")
+	c.DNSMonitoringPortList = slices.DeleteFunc(c.DNSMonitoringPortList, func(port int) bool {
+		if port < 1 || port > 65535 {
+			log.Warnf("CNM detected and removed invalid port %d from %s (must be 1-65535)", port, dnsPortsKey)
+			return true
+		}
+		if port == 80 || port == 443 {
+			log.Warnf("CNM detected and removed HTTP port %d from %s, which is unsupported due to the large volume of traffic it would capture", port, dnsPortsKey)
+			return true
+		}
+		return false
+	})
+
 	if len(c.DNSMonitoringPortList) == 0 {
 		c.DNSMonitoringPortList = []int{53}
 	}
-
-	c.DNSMonitoringPortList = slices.DeleteFunc(c.DNSMonitoringPortList, func(port int) bool {
-		isHTTP := port == 80 || port == 443
-		if isHTTP {
-			log.Warnf("CNM detected and removed HTTP port %d from %s, which is unsupported due to the large volume of traffic it would capture", port, sysconfig.FullKeyPath(netNS, "dns_monitoring_ports"))
-		}
-		return isHTTP
-	})
 
 	if !c.EnableProcessEventMonitoring {
 		log.Info("network process event monitoring disabled")

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -599,4 +599,102 @@ func TestDNSMonitoringPorts(t *testing.T) {
 		cfg := New()
 		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
 	})
+
+	t.Run("via YAML - out-of-range ports should be removed", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.dns_monitoring_ports", []int{53, 0, -1, 65536, 99999, 5353})
+		cfg := New()
+		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - single port 53", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "53")
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - single port non-53", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "5353")
+		cfg := New()
+		assert.Equal(t, []int{5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - multiple ports including 53", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "53 5353")
+		cfg := New()
+		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - multiple ports excluding 53", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "8053 5353")
+		cfg := New()
+		assert.Equal(t, []int{8053, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - space-separated multiple ports", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "1 2 3 4 5 6 7 53")
+		cfg := New()
+		assert.Equal(t, []int{1, 2, 3, 4, 5, 6, 7, 53}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - HTTP ports should be removed", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "53 443 5353 80")
+		cfg := New()
+		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - out-of-range ports should be removed", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "53 -1 65536 99999 5353")
+		cfg := New()
+		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - empty string falls back to default", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "")
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - invalid token falls back to default", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "not-a-port")
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - invalid tokens are dropped from the list", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "53 not-a-port 5353")
+		cfg := New()
+		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - all HTTP ports fall back to default", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "80 443")
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - all zeros fall back to default", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "0 0")
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via ENV variable - all invalid tokens fall back to default", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "not-a-port also-bad")
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
+	})
 }

--- a/releasenotes/notes/fix-dns-monitoring-ports-env-var-parsing-ff8248724d1dc10c.yaml
+++ b/releasenotes/notes/fix-dns-monitoring-ports-env-var-parsing-ff8248724d1dc10c.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix ``DD_NETWORK_CONFIG_DNS_MONITORING_PORTS`` parsing so the env var now
+    accepts a space-separated list of integers (for example ``"53 5353"``).
+    Single-value forms (``"53"``) continue to work. Previously, multi-port
+    values configured via env silently fell through to ``[0]`` and disabled
+    DNS monitoring.

--- a/tasks/schema/template.py
+++ b/tasks/schema/template.py
@@ -259,6 +259,13 @@ def _get_node_types_and_default(full_name, node, os_target):
         env_type = _env_type_for_json(node)
     elif env_parser in _ENV_PARSER_ENV_TYPES:
         env_type = _ENV_PARSER_ENV_TYPES[env_parser]
+        # The _ENV_PARSER_ENV_TYPES phrasing assumes string elements. When the
+        # underlying array holds integers, keep the integer phrasing so the
+        # @env doc matches the value users must supply.
+        # Check the raw schema "type"/"items" rather than node_type, which may
+        # have been overridden above by a golang_type tag (e.g. []int).
+        if node.get("type") == "array" and node.get("items", {}).get("type") == "number":
+            env_type = env_type.replace("list of strings", "list of integers")
     return yaml_type, env_type, default
 
 


### PR DESCRIPTION

### What does this PR do?
Fix DD_NETWORK_CONFIG_DNS_MONITORING_PORTS env var parsing.

The env var transformer was missing, so a multi-port value like "53 5353" silently fell through to [0] via mapstructure's string-to-int coercion, disabling DNS monitoring entirely. Single-port values like "53" happened to work by accident.

Use ParseEnvSplitSpace so the env var explicitly accepts a space-separated list of integers. Both single-value ("53") and multi-port ("53 5353") forms now work.

Drop unparseable elements (mapstructure fills them with 0) from the resulting list so that a typo in one token does not disable the other configured ports. Port 0 is reserved, so the zero filter also drops any literal 0 in config.

### Motivation

### Describe how you validated your changes
Unit tests and manual config tests.

### Additional Notes
