### PR TITLE
Fix flaky `TestProcessStatsTimeout` with `testing/synctest`

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/golang/mock/gomock" //nolint:depguard // required by datadog-go/v5 statsd mocks compiled against golang/mock
@@ -3601,10 +3602,6 @@ func TestMergeDuplicates(t *testing.T) {
 }
 
 func TestProcessStatsTimeout(t *testing.T) {
-	if os.Getenv("CI") == "true" && runtime.GOOS == "darwin" {
-		t.Skip("TestProcessStatsTimeout is known to fail on the macOS Gitlab runners.")
-	}
-
 	cfg := config.New()
 	cfg.Endpoints[0].APIKey = "test"
 	ctx, cancel := context.WithCancel(context.Background())
@@ -3613,7 +3610,7 @@ func TestProcessStatsTimeout(t *testing.T) {
 
 	statsPayload := testutil.StatsPayloadSample()
 
-	t.Run("context_timeout", func(t *testing.T) {
+	syncTestContextTimeout := func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		defer cancel()
 
@@ -3627,11 +3624,11 @@ func TestProcessStatsTimeout(t *testing.T) {
 		assert.Equal(t, context.DeadlineExceeded, err)
 
 		// Should timeout around 50ms, not hang indefinitely
-		assert.Less(t, elapsed, 100*time.Millisecond, "ProcessStats should respect context timeout")
-		assert.Greater(t, elapsed, 45*time.Millisecond, "ProcessStats should wait for context timeout")
-	})
+		assert.Equal(t, 50*time.Millisecond, elapsed, "ProcessStats should respect context timeout")
+	}
+	t.Run("context_timeout", func(t *testing.T) { synctest.Test(t, syncTestContextTimeout) })
 
-	t.Run("context_cancelled", func(t *testing.T) {
+	syncTestContextCancelled := func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		agnt.ClientStatsAggregator.In = make(chan *pb.ClientStatsPayload) // unbuffered channel, will block
@@ -3650,9 +3647,9 @@ func TestProcessStatsTimeout(t *testing.T) {
 		assert.Equal(t, context.Canceled, err)
 
 		// Should be cancelled around 30ms
-		assert.Less(t, elapsed, 60*time.Millisecond, "ProcessStats should respect context cancellation")
-		assert.Greater(t, elapsed, 25*time.Millisecond, "ProcessStats should wait for context cancellation")
-	})
+		assert.Equal(t, 30*time.Millisecond, elapsed, "ProcessStats should respect context cancellation")
+	}
+	t.Run("context_cancelled", func(t *testing.T) { synctest.Test(t, syncTestContextCancelled) })
 
 	t.Run("successful_processing", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)


### PR DESCRIPTION
### What does this PR do?
Run the timing-sensitive subtests of `TestProcessStatsTimeout` (`context_timeout` and `context_cancelled`) inside a `testing/synctest` "bubble" so the context deadline and cancellation are driven by the fake clock rather than wall-clock scheduling.

Extract each subtest body into a local functor passed to `synctest.Test`, and drop the macOS Gitlab skip[^1], obsolete now that **the fake clock makes the test deterministic on every platform**.

With virtual time the elapsed duration is exact, so each `assert.Less`/`assert.Greater` window collapses to one `assert.Equal`.

### Motivation
The subtests asserted that the elapsed wall-clock time fell within a narrow window around the deadline (`45ms < elapsed < 100ms` for the 50ms timeout).
Both bounds are fragile, and the test flaked in both directions:
- under CPU load the woken goroutine is rescheduled late and **overshoots the upper bound**, e.g. on my machine:
  ```
    agent_test.go:3630:
        	Error Trace:    pkg/trace/agent/agent_test.go:3630
        	Error:          "128.843937ms" is not less than "100ms"
        	Test:           TestProcessStatsTimeout/context_timeout
        	Messages:       ProcessStats should respect context timeout
  ```
- with a coarse or early-firing timer it **undershoots the lower bound**, e.g. on a [macOS Gitlab runner](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1285899883#L2085):
  ```
    agent_test.go:3525:
        	Error Trace:	/Users/ec2-user/builds/t3_kJ5gyy/0/DataDog/datadog-agent/pkg/trace/agent/agent_test.go:3525
        	Error:      	"44.677167ms" is not greater than "45ms"
        	Test:       	TestProcessStatsTimeout/context_timeout
        	Messages:   	ProcessStats should wait for context timeout
  ```
  ... which is why the test was skipped there[^1].

Inside a `synctest` bubble the fake clock advances to the deadline as soon as every goroutine is durably blocked, so the elapsed time is exactly the deadline on every platform.
That removes both failure directions and makes the macOS skip obsolete.

### Describe how you validated your changes
- failure ratio, full `agent_test` binary run with all cores pinned by busy loops: ~3% before, 0% after,
- per-run wall time, 10 unloaded samples of `TestProcessStatsTimeout`: 0.08s before, <0.01s after (virtual time collapses the sleeps).

### Additional Notes
Worth a read: https://go.dev/blog/synctest.

[^1]: The guard was introduced in #44162, prompted by repeated CI failures on macOS runners.