### PR TITLE
Skip private action runner graph startup when disabled

### DIFF
--- a/cmd/privateactionrunner/subcommands/run/command.go
+++ b/cmd/privateactionrunner/subcommands/run/command.go
@@ -9,6 +9,9 @@ package run
 import (
 	"context"
 	"errors"
+	"fmt"
+	"path"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/remotehostnameimpl"
 	"github.com/spf13/cobra"
@@ -17,10 +20,15 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/privateactionrunner/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	delegatedauthnooptypes "github.com/DataDog/datadog-agent/comp/core/delegatedauth/noop-impl/types"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
+	secretsimpl "github.com/DataDog/datadog-agent/comp/core/secrets/impl"
+	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
 	settings "github.com/DataDog/datadog-agent/comp/core/settings/def"
 	settingsfx "github.com/DataDog/datadog-agent/comp/core/settings/fx"
+	telemetrynoopsimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
 	eventplatform "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/def"
 	eventplatformfx "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/fx"
 	eventplatformreceiverimpl "github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/impl"
@@ -31,8 +39,11 @@ import (
 	rcclientfx "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/fx"
 	rcservicefx "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/fx"
 	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
+	pkgconfigcreate "github.com/DataDog/datadog-agent/pkg/config/create"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -44,6 +55,14 @@ type cliParams struct {
 // runPrivateActionRunner runs the private action runner with the given configuration and context.
 // This function is shared between the CLI run command and the Windows service.
 func runPrivateActionRunner(ctx context.Context, confPath string, extraConfFiles []string) error {
+	enabled, err := parEnabled(confPath, extraConfFiles)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		return nil
+	}
+
 	fxOptions := []fx.Option{
 		// Provide context for cancellation (Windows service uses this for graceful shutdown)
 		fx.Provide(func() context.Context { return ctx }),
@@ -80,11 +99,74 @@ func runPrivateActionRunner(ctx context.Context, confPath string, extraConfFiles
 		privateactionrunnerfx.Module(),
 	}
 
-	err := fxutil.Run(fxOptions...)
+	err = fxutil.Run(fxOptions...)
 	if errors.Is(err, privateactionrunner.ErrNotEnabled) {
 		return nil
 	}
 	return err
+}
+
+// parEnabled loads enough config to decide whether the PAR Fx graph should be built.
+func parEnabled(confPath string, extraConfFiles []string) (bool, error) {
+	return parEnabledWithSecretResolver(confPath, extraConfFiles, func() secrets.Component {
+		return secretsimpl.NewEnabledResolver(telemetrynoopsimpl.GetCompatComponent())
+	})
+}
+
+func parEnabledWithSecretResolver(confPath string, extraConfFiles []string, newSecretResolver func() secrets.Component) (bool, error) {
+	cfg, err := loadPARPreflightConfig(confPath, extraConfFiles, &secretnooptypes.SecretNoop{})
+	if err != nil {
+		return false, err
+	}
+	if parEnablementUsesSecret(cfg) {
+		cfg, err = loadPARPreflightConfig(confPath, extraConfFiles, newSecretResolver())
+		if err != nil {
+			return false, err
+		}
+	}
+	return privateactionrunner.IsEnabled(cfg), nil
+}
+
+func loadPARPreflightConfig(confPath string, extraConfFiles []string, secretResolver secrets.Component) (pkgconfigmodel.BuildableConfig, error) {
+	cfg := pkgconfigcreate.NewConfig("datadog", "")
+	pkgconfigsetup.InitConfig(cfg)
+	cfg.BuildSchema()
+
+	if confPath != "" {
+		cfg.AddConfigPath(confPath)
+		if strings.HasSuffix(confPath, ".yaml") || strings.HasSuffix(confPath, ".yml") {
+			cfg.SetConfigFile(confPath)
+		}
+	}
+	if defaultConfPath := defaultpaths.GetDefaultConfPath(); defaultConfPath != "" {
+		cfg.AddConfigPath(defaultConfPath)
+	}
+	if err := cfg.AddExtraConfigPaths(extraConfFiles); err != nil {
+		return nil, err
+	}
+
+	err := pkgconfigsetup.LoadDatadog(cfg, secretResolver, &delegatedauthnooptypes.DelegatedAuthNoop{}, pkgconfigsetup.SystemProbe().GetEnvVars())
+	if err != nil && (!errors.Is(err, pkgconfigmodel.ErrConfigFileNotFound) || confPath != "") {
+		return nil, fmt.Errorf("unable to load Datadog config file: %w", err)
+	}
+
+	if fleetPoliciesDirPath := cfg.GetString("fleet_policies_dir"); fleetPoliciesDirPath != "" {
+		if err := cfg.MergeFleetPolicy(path.Join(fleetPoliciesDirPath, "datadog.yaml")); err != nil {
+			return nil, err
+		}
+		pkgconfigsetup.ApplyUseDogstatsdSuppression(cfg)
+	}
+
+	return cfg, nil
+}
+
+func parEnablementUsesSecret(cfg pkgconfigmodel.Reader) bool {
+	value, ok := cfg.Get(privateactionrunner.PAREnabled).(string)
+	if !ok {
+		return false
+	}
+	value = strings.Trim(value, " \t")
+	return strings.HasPrefix(value, "ENC[") && strings.HasSuffix(value, "]")
 }
 
 // Commands returns a slice of subcommands for the 'private-action-runner' command.

--- a/cmd/privateactionrunner/subcommands/run/command_test.go
+++ b/cmd/privateactionrunner/subcommands/run/command_test.go
@@ -10,25 +10,27 @@ package run
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
+	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/privateactionrunner/command"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
+	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestPrivateActionRunnerRunCommand(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
-		// Test when PAR is disabled - should exit cleanly without calling fxutil.Run
 		commands := Commands(newGlobalParamsTest(t, false))
 		err := commands[0].RunE(nil, []string{"run"})
 		require.NoError(t, err)
 	})
 
 	t.Run("enabled", func(t *testing.T) {
-		// Test when PAR is enabled - should call fxutil.Run
 		fxutil.TestRun(t, func() error {
 			commands := Commands(newGlobalParamsTest(t, true))
 			return commands[0].RunE(nil, []string{"run"})
@@ -36,21 +38,143 @@ func TestPrivateActionRunnerRunCommand(t *testing.T) {
 	})
 }
 
+func TestParEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		configEnabled bool
+		envValue      string
+		wantEnabled   bool
+	}{
+		{
+			name:          "yaml disabled",
+			configEnabled: false,
+			wantEnabled:   false,
+		},
+		{
+			name:          "yaml enabled",
+			configEnabled: true,
+			wantEnabled:   true,
+		},
+		{
+			name:          "env enables PAR",
+			configEnabled: false,
+			envValue:      "true",
+			wantEnabled:   true,
+		},
+		{
+			name:          "env disables PAR",
+			configEnabled: true,
+			envValue:      "false",
+			wantEnabled:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envValue != "" {
+				t.Setenv("DD_PRIVATE_ACTION_RUNNER_ENABLED", tc.envValue)
+			}
+			assertParEnabled(t, writeTestConfig(t, tc.configEnabled), nil, tc.wantEnabled)
+		})
+	}
+
+	t.Run("extra config file overrides main config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		mainPath := filepath.Join(tmpDir, "datadog.yaml")
+		extraPath := filepath.Join(tmpDir, "extra.yaml")
+		writeConfigAt(t, mainPath, false, "")
+		writeConfigAt(t, extraPath, true, "")
+		assertParEnabled(t, mainPath, []string{extraPath}, true)
+	})
+
+	t.Run("fleet policy overrides main config", func(t *testing.T) {
+		mainPath, fleetDir := newConfigWithFleetDir(t, false)
+		writeConfigAt(t, filepath.Join(fleetDir, "datadog.yaml"), true, "")
+		assertParEnabled(t, mainPath, nil, true)
+	})
+
+	t.Run("fleet policy overrides env var", func(t *testing.T) {
+		t.Setenv("DD_PRIVATE_ACTION_RUNNER_ENABLED", "false")
+		mainPath, fleetDir := newConfigWithFleetDir(t, false)
+		writeConfigAt(t, filepath.Join(fleetDir, "datadog.yaml"), true, "")
+		assertParEnabled(t, mainPath, nil, true)
+	})
+
+	for _, tc := range []struct {
+		name        string
+		secretValue string
+		wantEnabled bool
+	}{
+		{name: "secret backend enables PAR", secretValue: "true", wantEnabled: true},
+		{name: "secret backend disables PAR", secretValue: "false", wantEnabled: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTestConfigValue(t, "ENC[par_enabled]", "secret_backend_command: test_secret_backend\n")
+			resolver := secretsmock.New(t)
+			resolver.SetSecrets(map[string]string{"par_enabled": tc.secretValue})
+
+			enabled, err := parEnabledWithSecretResolver(path, nil, func() secrets.Component {
+				return resolver
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantEnabled, enabled)
+		})
+	}
+
+	t.Run("explicit confPath that does not exist is fatal", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+		enabled, err := parEnabled(missing, nil)
+		require.Error(t, err, "an explicit --cfgpath that doesn't exist must be surfaced, not silently treated as disabled")
+		assert.False(t, enabled)
+	})
+}
+
+func assertParEnabled(t *testing.T, confPath string, extraConfFiles []string, wantEnabled bool) {
+	t.Helper()
+	enabled, err := parEnabled(confPath, extraConfFiles)
+	require.NoError(t, err)
+	assert.Equal(t, wantEnabled, enabled)
+}
+
 func newGlobalParamsTest(t *testing.T, enabled bool) *command.GlobalParams {
-	// Create minimal config for private action runner testing
-	configPath := path.Join(t.TempDir(), "datadog.yaml")
+	return &command.GlobalParams{
+		ConfFilePath: writeTestConfig(t, enabled),
+	}
+}
+
+func writeTestConfig(t *testing.T, enabled bool) string {
+	configPath := filepath.Join(t.TempDir(), "datadog.yaml")
+	writeConfigAt(t, configPath, enabled, "")
+	return configPath
+}
+
+func writeTestConfigValue(t *testing.T, enabledValue string, extraTopLevel string) string {
+	configPath := filepath.Join(t.TempDir(), "datadog.yaml")
+	writeConfigValueAt(t, configPath, enabledValue, extraTopLevel)
+	return configPath
+}
+
+func writeConfigAt(t *testing.T, configPath string, enabled bool, extraTopLevel string) {
+	writeConfigValueAt(t, configPath, strconv.FormatBool(enabled), extraTopLevel)
+}
+
+func writeConfigValueAt(t *testing.T, configPath string, enabledValue string, extraTopLevel string) {
 	configContent := `
 hostname: test
 private_action_runner:
-  enabled: %v
+  enabled: %s
   private_key: test_private_key
   urn: test_urn
 api_key: test_key
-`
-	err := os.WriteFile(configPath, []byte(fmt.Sprintf(configContent, enabled)), 0644)
+%s`
+	err := os.WriteFile(configPath, []byte(fmt.Sprintf(configContent, enabledValue, extraTopLevel)), 0644)
 	require.NoError(t, err)
+}
 
-	return &command.GlobalParams{
-		ConfFilePath: configPath,
-	}
+func newConfigWithFleetDir(t *testing.T, mainEnabled bool) (string, string) {
+	tmpDir := t.TempDir()
+	mainPath := filepath.Join(tmpDir, "datadog.yaml")
+	fleetDir := filepath.Join(tmpDir, "fleet")
+	require.NoError(t, os.Mkdir(fleetDir, 0755))
+	writeConfigAt(t, mainPath, mainEnabled, fmt.Sprintf("fleet_policies_dir: %s\n", fleetDir))
+	return mainPath, fleetDir
 }

--- a/comp/privateactionrunner/def/component.go
+++ b/comp/privateactionrunner/def/component.go
@@ -17,6 +17,15 @@ type Component interface {
 // ErrNotEnabled is returned when the private action runner is not enabled
 var ErrNotEnabled = errors.New("private action runner is not enabled")
 
+type configReader interface {
+	GetBool(string) bool
+}
+
+// IsEnabled reports whether the private action runner is enabled in an already-loaded config.
+func IsEnabled(cfg configReader) bool {
+	return cfg.GetBool(PAREnabled)
+}
+
 // Configuration keys for the private action runner.
 // Duplicated from pkg/config/setup/privateactionrunner.go because comp/
 // packages cannot import pkg/config/setup (depguard rule).

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -47,11 +47,6 @@ const (
 	maxStartupWaitTimeout = 15 * time.Second
 )
 
-// isEnabled checks if the private action runner is enabled in the configuration
-func isEnabled(cfg config.Component) bool {
-	return cfg.GetBool(privateactionrunner.PAREnabled)
-}
-
 // Requires defines the dependencies for the privateactionrunner component
 type Requires struct {
 	Config        config.Component
@@ -94,7 +89,7 @@ type PrivateActionRunner struct {
 // NewComponent creates a new privateactionrunner component
 func NewComponent(reqs Requires) (Provides, error) {
 	ctx := context.Background()
-	if !isEnabled(reqs.Config) {
+	if !privateactionrunner.IsEnabled(reqs.Config) {
 		reqs.Log.Info("private-action-runner is not enabled. Set private_action_runner.enabled: true in your datadog.yaml file or set the environment variable DD_PRIVATE_ACTION_RUNNER_ENABLED=true.")
 		reqs.Log.Flush()
 		return Provides{}, privateactionrunner.ErrNotEnabled

--- a/comp/privateactionrunner/status/statusimpl/status.go
+++ b/comp/privateactionrunner/status/statusimpl/status.go
@@ -89,7 +89,7 @@ func (s statusProvider) getStatusInfo() map[string]interface{} {
 func (s statusProvider) populateStatus(stats map[string]interface{}) {
 	parStatus := make(map[string]interface{})
 
-	enabled := s.config.GetBool(par.PAREnabled)
+	enabled := par.IsEnabled(s.config)
 	parStatus["Enabled"] = enabled
 
 	if enabled {

--- a/releasenotes/notes/par-skip-fx-when-disabled-876ef454111a1396.yaml
+++ b/releasenotes/notes/par-skip-fx-when-disabled-876ef454111a1396.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    When the Private Action Runner is disabled, the ``privateactionrunner``
+    binary now short-circuits before constructing its component graph instead
+    of initializing dependencies that are only needed when it runs. This
+    silences spurious startup errors, including the ``invalid compression set``
+    line previously written to ``private-action-runner.log``.


### PR DESCRIPTION
### What does this PR do?

Short-circuits the `privateactionrunner` binary before constructing the full Fx graph when `private_action_runner.enabled` resolves to false.

This prevents disabled PAR startup from initializing dependencies that are only needed when PAR runs, including Event Platform/logs compression, which silences spurious startup errors such as `invalid compression set` in `private-action-runner.log`.

The preflight check:
- loads the effective Datadog config before building the PAR graph
- honors env vars, extra config files, and fleet policy config
- uses noop secrets first
- only invokes the real secret resolver if `private_action_runner.enabled` itself is `ENC[...]`

### Motivation

In the Docker/s6 flow, the PAR process can start even when PAR is disabled. Today it builds the full Fx graph before PAR's component-level enablement check runs, so unrelated dependencies can log errors during startup even though PAR eventually exits disabled.

### Describe how you validated your changes

- `dda inv test --targets=./cmd/privateactionrunner/subcommands/run`
- `dda inv linter.go --targets=./cmd/privateactionrunner/subcommands/run,./comp/privateactionrunner/def,./comp/privateactionrunner/impl,./comp/privateactionrunner/status/statusimpl`
- `dda inv privateactionrunner.build`
- pre-push hooks: `go-mod-tidy`, `go-mod-replace`, `go-test`, `go-linter`

### Additional Notes

Options considered:

1. Local preflight loader using lower-level config primitives
   - Pros: avoids starting Fx before the decision; uses an isolated config object; keeps secret handling conservative; small PAR-local change.
   - Cons: duplicates part of `comp/core/config.setupConfig`; can drift if core config loading changes.
   - Current PR uses this as the tactical implementation.

2. Minimal Fx preflight graph
   - Pros: reuses the normal `comp/core/config` setup path and still avoids Event Platform/the larger PAR graph.
   - Cons: starts/stops a preliminary Fx app and uses `GlobalConfigBuilder()`, so it mutates process-global config during preflight.

3. Long-term shared isolated config-loading helper
   - Pros: best long-term shape: shared config setup without starting Fx and without PAR-owned loading logic.
   - Cons: broader shared core config API change; needs careful naming/docs and config-library/secret behavior review.

