### PR TITLE
remove exclusion for cluster agent in agent-health config validation

### DIFF
--- a/comp/healthplatform/issues/invalidconfig/check.go
+++ b/comp/healthplatform/issues/invalidconfig/check.go
@@ -3,10 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build !jetson && (!clusterchecks || test)
+//go:build !jetson
 
 // Package invalidconfig reports datadog.yaml schema violations through the Agent Health Platform.
-// Excluded from the IoT Agent and Cluster Agent builds to stay under the binary size budget.
+// Excluded from the IoT Agent build to stay under the binary size budget.
 package invalidconfig
 
 import (

--- a/comp/healthplatform/issues/invalidconfig/invalidconfig_test.go
+++ b/comp/healthplatform/issues/invalidconfig/invalidconfig_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build !jetson && (!clusterchecks || test)
+//go:build !jetson
 
 package invalidconfig
 

--- a/comp/healthplatform/issues/invalidconfig/issue.go
+++ b/comp/healthplatform/issues/invalidconfig/issue.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build !jetson && (!clusterchecks || test)
+//go:build !jetson
 
 package invalidconfig
 

--- a/comp/healthplatform/issues/invalidconfig/module.go
+++ b/comp/healthplatform/issues/invalidconfig/module.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build !jetson && (!clusterchecks || test)
+//go:build !jetson
 
 package invalidconfig
 

--- a/comp/healthplatform/issues/invalidconfig/stub.go
+++ b/comp/healthplatform/issues/invalidconfig/stub.go
@@ -3,9 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build jetson || (clusterchecks && !test)
+//go:build jetson
 
 // Package invalidconfig is an empty stub keeping the package importable on IoT
-// Agent (jetson) and Cluster Agent builds where the real validator is excluded
-// to stay under the binary size budget.
+// Agent (jetson) builds where the real validator is excluded to stay under
+// the binary size budget.
 package invalidconfig

--- a/tasks/cluster_agent_helpers.py
+++ b/tasks/cluster_agent_helpers.py
@@ -7,6 +7,7 @@ import shutil
 
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import REPO_PATH, bin_name, get_build_flags, get_version
+from tasks.schema.generate import compress as schema_compress
 
 
 def build_common(
@@ -29,6 +30,8 @@ def build_common(
 
     # We rely on the go libs embedded in the debian stretch image to build dynamically
     ldflags, gcflags, env = get_build_flags(ctx, static=False)
+
+    schema_compress(ctx)
 
     go_build(
         ctx,


### PR DESCRIPTION
### What does this PR do?
removed the stub and build tags which excluded the cluster-agent from config validation via agent-health which were added in the interim due to a failing static quality gate.

### Motivation
We don't want the Cluster Agent excluded from config validation and using the schema. We have an exception for adding the schema to the datadog-agent,

### Describe how you validated your changes
CI

### Additional Notes
