### PR TITLE
rebal algo minimal

### DIFF
--- a/pkg/clusteragent/clusterchecks/checks_distribution.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution.go
@@ -16,6 +16,7 @@ import (
 type CheckStatus struct {
 	WorkersNeeded float64
 	Runner        string
+	CheckName     string
 }
 
 // RunnerStatus represents the status of a check runner
@@ -90,19 +91,32 @@ func (distribution *checksDistribution) leastBusyRunner(preferredRunner string, 
 	return leastBusyRunner
 }
 
-func (distribution *checksDistribution) addToLeastBusy(checkID string, workersNeeded float64, preferredRunner string, excludeRunner string) {
+func (distribution *checksDistribution) addToLeastBusy(checkID, checkName string, workersNeeded float64, preferredRunner string, excludeRunner string) {
 	leastBusy := distribution.leastBusyRunner(preferredRunner, excludeRunner)
 	if leastBusy == "" {
 		return
 	}
 
-	distribution.addCheck(checkID, workersNeeded, leastBusy)
+	distribution.addCheck(checkID, checkName, workersNeeded, leastBusy)
 }
 
-func (distribution *checksDistribution) addCheck(checkID string, workersNeeded float64, runner string) {
-	distribution.Checks[checkID] = &CheckStatus{
+// addCheck records a config in the distribution. Calling it again with the
+// same key (digest) — typically when currentDistribution sees multiple
+// instances of the same config on a node — accumulates WorkersNeeded into
+// the existing entry rather than overwriting it.
+func (distribution *checksDistribution) addCheck(digest, checkName string, workersNeeded float64, runner string) {
+	if existing, found := distribution.Checks[digest]; found {
+		existing.WorkersNeeded += workersNeeded
+		if runnerInfo, ok := distribution.Runners[runner]; ok {
+			runnerInfo.WorkersUsed += workersNeeded
+		}
+		return
+	}
+
+	distribution.Checks[digest] = &CheckStatus{
 		WorkersNeeded: workersNeeded,
 		Runner:        runner,
+		CheckName:     checkName,
 	}
 
 	runnerInfo, runnerExists := distribution.Runners[runner]

--- a/pkg/clusteragent/clusterchecks/checks_distribution_test.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution_test.go
@@ -150,10 +150,10 @@ func TestAddToLeastBusy(t *testing.T) {
 			distribution := newChecksDistribution(test.existingRunners)
 
 			for checkID, checkStatus := range test.existingChecks {
-				distribution.addCheck(checkID, checkStatus.WorkersNeeded, checkStatus.Runner)
+				distribution.addCheck(checkID, checkStatus.CheckName, checkStatus.WorkersNeeded, checkStatus.Runner)
 			}
 
-			distribution.addToLeastBusy("newCheck", 10, test.preferredRunner, "")
+			distribution.addToLeastBusy("newCheck", "newCheck", 10, test.preferredRunner, "")
 
 			assert.Equal(t, test.expectedPlacement, distribution.runnerForCheck("newCheck"))
 		})
@@ -165,7 +165,7 @@ func TestAddCheck(t *testing.T) {
 		"runner1": 4,
 	})
 
-	distribution.addCheck("check1", 3, "runner1")
+	distribution.addCheck("check1", "check1", 3, "runner1")
 	assert.Equal(t, "runner1", distribution.runnerForCheck("check1"))
 	assert.Equal(t, 3.0, distribution.workersNeededForCheck("check1"))
 }
@@ -178,10 +178,10 @@ func TestChecksSortedByWorkersNeeded(t *testing.T) {
 		"runner3": 4,
 	})
 
-	distribution.addCheck("check1", 3, "runner1")
-	distribution.addCheck("check2", 1, "runner1")
-	distribution.addCheck("check3", 4, "runner2")
-	distribution.addCheck("check4", 2, "runner3")
+	distribution.addCheck("check1", "check1", 3, "runner1")
+	distribution.addCheck("check2", "check2", 1, "runner1")
+	distribution.addCheck("check3", "check3", 4, "runner2")
+	distribution.addCheck("check4", "check4", 2, "runner3")
 
 	assert.Equal(t, []string{"check3", "check1", "check4", "check2"}, distribution.checksSortedByWorkersNeeded())
 
@@ -191,10 +191,10 @@ func TestChecksSortedByWorkersNeeded(t *testing.T) {
 		"runner2": 4,
 	})
 
-	distribution.addCheck("check_B", 1, "runner1")
-	distribution.addCheck("check_A", 1, "runner2")
-	distribution.addCheck("check_C", 1, "runner1")
-	distribution.addCheck("check_Z", 2, "runner2")
+	distribution.addCheck("check_B", "check_B", 1, "runner1")
+	distribution.addCheck("check_A", "check_A", 1, "runner2")
+	distribution.addCheck("check_C", "check_C", 1, "runner1")
+	distribution.addCheck("check_Z", "check_Z", 2, "runner2")
 
 	assert.Equal(t, []string{"check_Z", "check_A", "check_B", "check_C"}, distribution.checksSortedByWorkersNeeded())
 }
@@ -206,10 +206,10 @@ func TestNumEmptyRunners(t *testing.T) {
 	})
 	assert.Equal(t, 2, distribution.numEmptyRunners())
 
-	distribution.addCheck("check1", 1, "runner1")
+	distribution.addCheck("check1", "check1", 1, "runner1")
 	assert.Equal(t, 1, distribution.numEmptyRunners())
 
-	distribution.addCheck("check2", 1, "runner2")
+	distribution.addCheck("check2", "check2", 1, "runner2")
 	assert.Equal(t, 0, distribution.numEmptyRunners())
 }
 
@@ -220,13 +220,13 @@ func TestNumRunnersWithHighUtilization(t *testing.T) {
 	})
 	assert.Equal(t, 0, distribution.numRunnersWithHighUtilization())
 
-	distribution.addCheck("check1", 1, "runner1") // runner 1 at 25%
+	distribution.addCheck("check1", "check1", 1, "runner1") // runner 1 at 25%
 	assert.Equal(t, 0, distribution.numRunnersWithHighUtilization())
 
-	distribution.addCheck("check2", 2.5, "runner1") // runner 1 at 3.5/4=0.875, above threshold
+	distribution.addCheck("check2", "check2", 2.5, "runner1") // runner 1 at 3.5/4=0.875, above threshold
 	assert.Equal(t, 1, distribution.numRunnersWithHighUtilization())
 
-	distribution.addCheck("check3", 2, "runner2") // runner 2 at 100%
+	distribution.addCheck("check3", "check3", 2, "runner2") // runner 2 at 100%
 	assert.Equal(t, 2, distribution.numRunnersWithHighUtilization())
 }
 
@@ -237,10 +237,10 @@ func TestUtilizationStdDev(t *testing.T) {
 		"runner2": 4,
 		"runner3": 4,
 	})
-	distribution.addCheck("check1", 1, "runner1")
-	distribution.addCheck("check2", 2, "runner1")
-	distribution.addCheck("check3", 2, "runner2")
-	distribution.addCheck("check4", 4, "runner3")
+	distribution.addCheck("check1", "check1", 1, "runner1")
+	distribution.addCheck("check2", "check2", 2, "runner1")
+	distribution.addCheck("check3", "check3", 2, "runner2")
+	distribution.addCheck("check4", "check4", 4, "runner3")
 
 	// The avg utilization is (0.75 + 0.5 + 1)/3 = 0.75
 	// The variance is ((0.75-0.75)^2 + (0.5-0.75)^2 + (1-0.75)^2)/3 = 0.125/3

--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -240,12 +240,3 @@ func (d *dispatcher) patchConfiguration(in integration.Config) (integration.Conf
 
 	return out, nil
 }
-
-// getConfigAndDigest returns config and digest of a check by checkID
-func (d *dispatcher) getConfigAndDigest(checkID string) (integration.Config, string) {
-	d.store.RLock()
-	defer d.store.RUnlock()
-
-	digest := d.store.idToDigest[checkid.ID(checkID)]
-	return d.store.digestToConfig[digest], digest
-}

--- a/pkg/clusteragent/clusterchecks/dispatcher_isolate.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_isolate.go
@@ -7,7 +7,10 @@
 
 package clusterchecks
 
-import "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+import (
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+)
 
 func (d *dispatcher) isolateCheck(isolateCheckID string) types.IsolateResponse {
 	// Update stats prior to starting isolate to ensure all checks are accounted for
@@ -24,7 +27,12 @@ func (d *dispatcher) isolateCheck(isolateCheckID string) types.IsolateResponse {
 		}
 	}
 
-	isolateNode := currentDistribution.runnerForCheck(isolateCheckID)
+	// Distribution is keyed by digest; translate the caller's checkID.
+	d.store.RLock()
+	isolateDigest := d.store.idToDigest[checkid.ID(isolateCheckID)]
+	d.store.RUnlock()
+
+	isolateNode := currentDistribution.runnerForCheck(isolateDigest)
 	if isolateNode == "" {
 		return types.IsolateResponse{
 			CheckID:    isolateCheckID,
@@ -36,19 +44,18 @@ func (d *dispatcher) isolateCheck(isolateCheckID string) types.IsolateResponse {
 
 	proposedDistribution := newChecksDistribution(currentDistribution.runnerWorkers())
 
-	for _, checkID := range currentDistribution.checksSortedByWorkersNeeded() {
-		if checkID == isolateCheckID {
-			// Keep the check to be isolated on its current runner
+	for _, digest := range currentDistribution.checksSortedByWorkersNeeded() {
+		if digest == isolateDigest {
+			// Keep the config to be isolated on its current runner
 			continue
 		}
 
-		workersNeededForCheck := currentDistribution.workersNeededForCheck(checkID)
-		runnerForCheck := currentDistribution.runnerForCheck(checkID)
-
+		check := currentDistribution.Checks[digest]
 		proposedDistribution.addToLeastBusy(
-			checkID,
-			workersNeededForCheck,
-			runnerForCheck,
+			digest,
+			check.CheckName,
+			check.WorkersNeeded,
+			check.Runner,
 			isolateNode,
 		)
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -100,21 +100,60 @@ func (d *dispatcher) updateDiff(avg int) map[string]int {
 	return diffMap
 }
 
-// pickCheckToMove select the most appropriate check to move from a node to another.
-// A check Xi running on a node N is chosen to move to another node if it satisfies the following
-// Weight(Xi) >  Weight(Xj) (for each j != i, 0 <= j < len(weights))
-// where Weight(X) is the busyness value caused by running the check X.
-func (d *dispatcher) pickCheckToMove(nodeName string) (string, int, error) {
+// pickConfigToMove selects the most appropriate check config to move off
+// the given node. Per-instance weights are aggregated by config digest so
+// that the algorithm operates on whole configs — the dispatcher schedules
+// and moves every instance of a config together, so the true cost of
+// moving is the sum of the instances' weights.
+//
+// Returns the picked config's digest (used to drive moveConfig), a
+// representative instance checkID (used for the public RebalanceResponse
+// where exposing the opaque digest would be unfriendly), and the aggregate
+// weight.
+func (d *dispatcher) pickConfigToMove(nodeName string) (digest, repCheckID string, weight int, err error) {
 	d.store.RLock()
 	node, found := d.store.getNodeStore(nodeName)
-	d.store.RUnlock()
-
 	if !found {
+		d.store.RUnlock()
 		log.Debugf("Node %s not found in store. Won't consider moving check", nodeName)
-		return "", -1, fmt.Errorf("node %s not found in store", nodeName)
+		return "", "", -1, fmt.Errorf("node %s not found in store", nodeName)
 	}
 
-	return node.GetMostWeightedClusterCheck(busynessFunc)
+	node.RLock()
+	weightsByDigest := make(map[string]int, len(node.clcRunnerStats))
+	representativeByDigest := make(map[string]string, len(node.clcRunnerStats))
+	for checkID, stats := range node.clcRunnerStats {
+		if !stats.IsClusterCheck {
+			continue
+		}
+		dig, ok := d.store.idToDigest[checkid.ID(checkID)]
+		if !ok {
+			continue
+		}
+		weightsByDigest[dig] += busynessFunc(stats)
+		if existing, seen := representativeByDigest[dig]; !seen || checkID < existing {
+			representativeByDigest[dig] = checkID
+		}
+	}
+	node.RUnlock()
+	d.store.RUnlock()
+
+	if len(weightsByDigest) == 0 {
+		log.Debugf("Node %s has no cluster check stats", nodeName)
+		return "", "", -1, fmt.Errorf("no cluster checks found on node %s", nodeName)
+	}
+
+	bestDigest := ""
+	bestWeight := 0
+	firstItr := true
+	for dig, w := range weightsByDigest {
+		if firstItr || w > bestWeight {
+			bestDigest = dig
+			bestWeight = w
+			firstItr = false
+		}
+	}
+	return bestDigest, representativeByDigest[bestDigest], bestWeight, nil
 }
 
 // pickNode select the most appropriate node to receive a specific check.
@@ -139,37 +178,60 @@ func pickNode(diffMap map[string]int, sourceNode string) string {
 	return pickedNode
 }
 
-// moveCheck moves a check by its ID from a node to another
-func (d *dispatcher) moveCheck(src, dest, checkID string) error {
-	log.Debugf("Moving %s from %s to %s", checkID, src, dest)
+// moveConfig moves a config by its digest from a node to another
+func (d *dispatcher) moveConfig(src, dest, digest string) error {
+	log.Debugf("Moving config %s from %s to %s", digest, src, dest)
 
 	d.store.RLock()
 	destNode, destFound := d.store.getNodeStore(dest)
 	sourceNode, srcFound := d.store.getNodeStore(src)
+	config, configFound := d.store.digestToConfig[digest]
+	// Collect every checkID sharing this digest so we can transfer all of
+	// their runner stats, not just one instance's.
+	var instanceIDs []string
+	for id, dig := range d.store.idToDigest {
+		if dig == digest {
+			instanceIDs = append(instanceIDs, string(id))
+		}
+	}
 	d.store.RUnlock()
 
+	if !configFound {
+		return fmt.Errorf("no config registered for digest %s", digest)
+	}
 	if !destFound || !srcFound {
-		log.Debugf("Nodes not found in store: %s, %s. Check %s will not move", src, dest, checkID)
+		log.Debugf("Nodes not found in store: %s, %s. Config %s will not move", src, dest, digest)
 		return fmt.Errorf("node %s not found", src)
 	}
 
-	runnerStats, err := sourceNode.GetRunnerStats(checkID)
-	if err != nil {
-		log.Debugf("Cannot get runner stats on node %s, check %s will not move", src, checkID)
-		return err
+	// Transfer per-instance runner stats. A missing instance on the source
+	// is non-fatal — its stats just haven't been reported yet — but we
+	// require at least one to succeed before mutating the config-level
+	// registration below.
+	var firstErr error
+	movedAny := false
+	for _, id := range instanceIDs {
+		stats, err := sourceNode.GetRunnerStats(id)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		destNode.AddRunnerStats(id, stats)
+		sourceNode.RemoveRunnerStats(id)
+		movedAny = true
+	}
+	if !movedAny {
+		log.Debugf("Cannot get runner stats on node %s for config %s; will not move", src, digest)
+		return firstErr
 	}
 
-	destNode.AddRunnerStats(checkID, runnerStats)
-	sourceNode.RemoveRunnerStats(checkID)
-
-	config, digest := d.getConfigAndDigest(checkID)
-	log.Tracef("Moving check %s with digest %s and config %s from %s to %s", checkID, digest, config.String(), src, dest)
-
+	log.Tracef("Moving config %s (%s) from %s to %s", digest, config.String(), src, dest)
 	d.removeConfig(digest)
 	d.addConfig(config, dest)
 
-	log.Debugf("Check %s moved from %s to %s", checkID, src, dest)
-
+	log.Debugf("Config %s moved from %s to %s", digest, src, dest)
 	return nil
 }
 
@@ -216,11 +278,11 @@ func (d *dispatcher) rebalanceUsingBusyness() []types.RebalanceResponse {
 
 	for _, nodeWeight := range weights {
 		for diffMap[nodeWeight.nodeName] > 0 {
-			// try to move checks from a node only of the node busyness is above the average
+			// try to move configs from a node only if the node busyness is above the average
 			sourceNodeName := nodeWeight.nodeName
-			checkID, checkWeight, err := d.pickCheckToMove(sourceNodeName)
+			digest, repCheckID, configWeight, err := d.pickConfigToMove(sourceNodeName)
 			if err != nil {
-				log.Debugf("Cannot pick a check to move from node %s: %v", sourceNodeName, err)
+				log.Debugf("Cannot pick a config to move from node %s: %v", sourceNodeName, err)
 				break
 			}
 
@@ -228,27 +290,27 @@ func (d *dispatcher) rebalanceUsingBusyness() []types.RebalanceResponse {
 			sourceDiff := diffMap[sourceNodeName]
 			destDiff := diffMap[destNodeName]
 
-			// move a check to a new node only if it keeps the
+			// move a config to a new node only if it keeps the
 			// busyness of the new node lower than the original
 			// node's busyness multiplied by the tolerationMargin
 			// value the toleration margin is used to lean towards
 			// stability over perfectly optimal balance
-			if destDiff+checkWeight < int(float64(sourceDiff)*tolerationMargin) {
+			if destDiff+configWeight < int(float64(sourceDiff)*tolerationMargin) {
 				rebalancingDecisions.Inc(le.JoinLeaderValue)
-				err = d.moveCheck(sourceNodeName, destNodeName, checkID)
+				err = d.moveConfig(sourceNodeName, destNodeName, digest)
 				if err != nil {
-					log.Debugf("Cannot move check %s: %v", checkID, err)
+					log.Debugf("Cannot move config %s: %v", digest, err)
 					continue
 				}
 
 				successfulRebalancing.Inc(le.JoinLeaderValue)
-				log.Tracef("Check %s with weight %d moved, total avg: %d, source diff: %d, dest diff: %d",
-					checkID, checkWeight, totalAvg, sourceDiff, destDiff)
-				// diffMap needs to be updated on every check moved
+				log.Tracef("Config %s with weight %d moved, total avg: %d, source diff: %d, dest diff: %d",
+					digest, configWeight, totalAvg, sourceDiff, destDiff)
+				// diffMap needs to be updated on every move
 				diffMap = d.updateDiff(totalAvg)
 				checksMoved = append(checksMoved, types.RebalanceResponse{
-					CheckID:        checkID,
-					CheckWeight:    checkWeight,
+					CheckID:        repCheckID,
+					CheckWeight:    configWeight,
 					SourceNodeName: sourceNodeName,
 					SourceDiff:     sourceDiff,
 					DestNodeName:   destNodeName,
@@ -326,24 +388,25 @@ func (d *dispatcher) rebalanceUsingUtilization(force bool) []types.RebalanceResp
 
 	// First all the checks that are excluded from rebalancing are added to the
 	// same runner where they are currently running.
-	for checkID, check := range currentChecksDistribution.Checks {
-		checkName := checkid.IDToCheckName(checkid.ID(checkID))
-		if _, excluded := d.excludedChecksFromDispatching[checkName]; excluded {
-			proposedDistribution.addCheck(checkID, check.WorkersNeeded, check.Runner)
+	for digest, check := range currentChecksDistribution.Checks {
+		if _, excluded := d.excludedChecksFromDispatching[check.CheckName]; excluded {
+			proposedDistribution.addCheck(digest, check.CheckName, check.WorkersNeeded, check.Runner)
 		}
 	}
 
 	// Place the checks that are not excluded from rebalancing
-	for _, checkID := range currentChecksDistribution.checksSortedByWorkersNeeded() {
-		checkName := checkid.IDToCheckName(checkid.ID(checkID))
-		if _, excluded := d.excludedChecksFromDispatching[checkName]; !excluded {
-			proposedDistribution.addToLeastBusy(
-				checkID,
-				currentChecksDistribution.workersNeededForCheck(checkID),
-				currentChecksDistribution.runnerForCheck(checkID),
-				"",
-			)
+	for _, digest := range currentChecksDistribution.checksSortedByWorkersNeeded() {
+		check := currentChecksDistribution.Checks[digest]
+		if _, excluded := d.excludedChecksFromDispatching[check.CheckName]; excluded {
+			continue
 		}
+		proposedDistribution.addToLeastBusy(
+			digest,
+			check.CheckName,
+			check.WorkersNeeded,
+			check.Runner,
+			"",
+		)
 	}
 
 	// We don't calculate the optimal distribution, so it might be worse than
@@ -389,14 +452,21 @@ func (d *dispatcher) currentDistribution() checksDistribution {
 
 	distribution := newChecksDistribution(currentWorkersPerRunner)
 
+	// Group runner-reported per-instance stats by config digest
 	for nodeName, nodeStoreInfo := range d.store.nodes {
 		for checkID, stats := range nodeStoreInfo.clcRunnerStats {
 			if !stats.IsClusterCheck {
 				continue
 			}
 
+			// Skip checks that the dispatcher doesn't own
+			digest, ok := d.store.idToDigest[checkid.ID(checkID)]
+			if !ok {
+				continue
+			}
+			conf := d.store.digestToConfig[digest]
+
 			minCollectionInterval := defaults.DefaultCheckInterval
-			conf := d.store.digestToConfig[d.store.idToDigest[checkid.ID(checkID)]]
 			if len(conf.Instances) > 0 {
 				commonOptions := integration.CommonInstanceConfig{}
 				err := yaml.Unmarshal(conf.Instances[0], &commonOptions)
@@ -413,18 +483,41 @@ func (d *dispatcher) currentDistribution() checksDistribution {
 				workersNeeded = 1
 			}
 
-			distribution.addCheck(checkID, workersNeeded, nodeName)
+			distribution.addCheck(digest, conf.Name, workersNeeded, nodeName)
 		}
 	}
 
 	return distribution
 }
 
+// representativeCheckID returns one instance checkID belonging to the given
+// config digest, chosen alphabetically for determinism. Used to translate a
+// digest-keyed distribution entry back into a checkID for the public
+// RebalanceResponse.
+func (d *dispatcher) representativeCheckID(digest string) string {
+	d.store.RLock()
+	defer d.store.RUnlock()
+	best := ""
+	for id, dig := range d.store.idToDigest {
+		if dig != digest {
+			continue
+		}
+		s := string(id)
+		if best == "" || s < best {
+			best = s
+		}
+	}
+	return best
+}
+
 func (d *dispatcher) applyDistribution(proposedDistribution checksDistribution, currentDistribution checksDistribution) []types.RebalanceResponse {
 	var checksMoved []types.RebalanceResponse
 
-	for checkID, checkStatus := range proposedDistribution.Checks {
-		currentNode := currentDistribution.runnerForCheck(checkID)
+	// proposedDistribution.Checks is keyed by config digest.
+	for digest, checkStatus := range proposedDistribution.Checks {
+		repCheckID := d.representativeCheckID(digest)
+
+		currentNode := currentDistribution.runnerForCheck(digest)
 		proposedNode := checkStatus.Runner
 
 		if proposedNode == currentNode {
@@ -433,9 +526,9 @@ func (d *dispatcher) applyDistribution(proposedDistribution checksDistribution, 
 
 		rebalancingDecisions.Inc(le.JoinLeaderValue)
 
-		err := d.moveCheck(currentNode, proposedNode, checkID)
+		err := d.moveConfig(currentNode, proposedNode, digest)
 		if err != nil {
-			log.Warnf("Cannot move check %s: %v", checkID, err)
+			log.Warnf("Cannot move config %s: %v", digest, err)
 			continue
 		}
 
@@ -444,7 +537,7 @@ func (d *dispatcher) applyDistribution(proposedDistribution checksDistribution, 
 		checksMoved = append(
 			checksMoved,
 			types.RebalanceResponse{
-				CheckID:        checkID,
+				CheckID:        repCheckID,
 				SourceNodeName: currentNode,
 				DestNodeName:   proposedNode,
 			},

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -9,6 +9,7 @@ package clusterchecks
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1412,30 +1413,182 @@ func TestRebalance(t *testing.T) {
 			}
 			dispatcher.clcRunnersClient = mockClient
 
-			// prepare store
+			// Prepare store. Each cluster-check in the test data is
+			// registered as a real one-instance config via addConfig (so
+			// idToDigest / digestToConfig / digestToNode all get populated
+			// the way production runs would populate them). The mock
+			// runner client returns stats keyed by the real BuildID-derived
+			// checkIDs. Non-cluster checks bypass addConfig and stay keyed
+			// by their synthetic IDs in the mock — they contribute to node
+			// busyness but never become rebalance candidates.
 			dispatcher.store.active = true
 			for node, store := range tc.in {
-				// Give each node a unique IP so the mock can distinguish them
 				nodeIP := fmt.Sprintf("10.0.0.%d", len(mockClient.testStats)+1)
 				dispatcher.store.nodes[node] = newNodeStore(node, nodeIP)
-				// setup input
-				dispatcher.store.nodes[node].clcRunnerStats = store.clcRunnerStats
-				// Store the test data in the mock so it can return it
-				mockClient.testStats[nodeIP] = store.clcRunnerStats
+				wireStats := types.CLCRunnersStats{}
+				for syntheticID, stats := range store.clcRunnerStats {
+					if !stats.IsClusterCheck {
+						wireStats[syntheticID] = stats
+						continue
+					}
+					config := makeRebalanceTestConfig(syntheticID)
+					dispatcher.addConfig(config, node)
+					realID := checkid.BuildID(config.Name, config.FastDigest(), config.Instances[0], config.InitConfig)
+					wireStats[string(realID)] = stats
+				}
+				mockClient.testStats[nodeIP] = wireStats
+				// Seed the node's local cache too so the assertion below
+				// observes the pre-rebalance state if the algorithm doesn't
+				// move anything.
+				dispatcher.store.nodes[node].clcRunnerStats = wireStats
 			}
 
 			// Use busyness-based rebalancing directly for these legacy tests
 			// (preserves test coverage for busyness algorithm while allowing utilization as default)
 			dispatcher.rebalanceUsingBusyness()
 
-			// assert runner stats repartition is updated correctly
+			// Compare placement by check name — the test data uses synthetic
+			// names ("checkA0", "checkB1") which map 1:1 to config names,
+			// and IDToCheckName recovers them from the real BuildID-derived
+			// IDs in clcRunnerStats.
 			for node, store := range tc.out {
-				assert.EqualValues(t, store.clcRunnerStats, dispatcher.store.nodes[node].clcRunnerStats)
+				expected := checkNamesIn(store.clcRunnerStats)
+				actual := checkNamesIn(dispatcher.store.nodes[node].clcRunnerStats)
+				assert.Equal(t, expected, actual, "node %s placement", node)
 			}
 
 			requireNotLocked(t, dispatcher.store)
 		})
 	}
+}
+
+// makeRebalanceTestConfig returns a one-instance config whose Name is the
+// synthetic identifier used in TestRebalance tables. addConfig registers it
+// and stores a digest-keyed entry; IDToCheckName(realID) recovers the name
+// later for placement assertions.
+func makeRebalanceTestConfig(name string) integration.Config {
+	return integration.Config{
+		Name:       name,
+		InitConfig: integration.Data("{}"),
+		Instances:  []integration.Data{integration.Data("{}")},
+	}
+}
+
+// makeMultiInstanceTestConfig returns a config with `instances` distinct
+// instances, each with unique Data so BuildID produces distinct checkIDs.
+func makeMultiInstanceTestConfig(name string, instances int) integration.Config {
+	cfg := integration.Config{
+		Name:       name,
+		InitConfig: integration.Data("{}"),
+	}
+	for i := 0; i < instances; i++ {
+		cfg.Instances = append(cfg.Instances, integration.Data(fmt.Sprintf(`{"i":%d}`, i)))
+	}
+	return cfg
+}
+
+// instanceCheckIDs returns the per-instance checkIDs the dispatcher would
+// compute for a config — same path as addConfig uses.
+func instanceCheckIDs(cfg integration.Config) []checkid.ID {
+	ids := make([]checkid.ID, 0, len(cfg.Instances))
+	fastDigest := cfg.FastDigest()
+	for _, inst := range cfg.Instances {
+		ids = append(ids, checkid.BuildID(cfg.Name, fastDigest, inst, cfg.InitConfig))
+	}
+	return ids
+}
+
+// checkNamesIn returns the sorted set of check names present in a stats
+// map. Non-cluster checks (whose checkIDs aren't real BuildID outputs) are
+// excluded.
+func checkNamesIn(stats types.CLCRunnersStats) []string {
+	names := []string{}
+	for id, s := range stats {
+		if !s.IsClusterCheck {
+			continue
+		}
+		names = append(names, checkid.IDToCheckName(checkid.ID(id)))
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestRebalanceUsingBusyness_MultiInstanceConfigIsAtomicAndIdempotent
+// covers the two key properties of the per-config rebalance fix:
+//   - a config with multiple instances is treated as a single movable unit
+//     (one move reported, all instances migrated together);
+//   - once placement is balanced, a second rebalance is a no-op.
+func TestRebalanceUsingBusyness_MultiInstanceConfigIsAtomicAndIdempotent(t *testing.T) {
+	// Hardcoded weights to keep the math independent of defaults.
+	originalCheckExecutionTimeWeight := checkExecutionTimeWeight
+	originalMetricSamplesWeight := checkMetricSamplesWeight
+	checkExecutionTimeWeight = 0.8
+	checkMetricSamplesWeight = 0.2
+	defer func() {
+		checkExecutionTimeWeight = originalCheckExecutionTimeWeight
+		checkMetricSamplesWeight = originalMetricSamplesWeight
+	}()
+
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	dispatcher := newDispatcher(fakeTagger)
+	mockClient := &rebalanceTestClcRunnerClient{testStats: map[string]types.CLCRunnersStats{}}
+	dispatcher.clcRunnersClient = mockClient
+	dispatcher.store.active = true
+
+	nodeAIP := "10.0.0.1"
+	nodeBIP := "10.0.0.2"
+	dispatcher.store.nodes["A"] = newNodeStore("A", nodeAIP)
+	dispatcher.store.nodes["B"] = newNodeStore("B", nodeBIP)
+
+	// Node A starts with everything:
+	//   - a 3-instance "postgres" config; per-instance busyness = 80
+	//     → aggregate config busyness = 240
+	//   - a single-instance "heavy" config; busyness = 100
+	multiConfig := makeMultiInstanceTestConfig("postgres", 3)
+	heavyConfig := makeRebalanceTestConfig("heavy")
+	dispatcher.addConfig(multiConfig, "A")
+	dispatcher.addConfig(heavyConfig, "A")
+
+	multiIDs := instanceCheckIDs(multiConfig)
+	heavyID := instanceCheckIDs(heavyConfig)[0]
+
+	initial := types.CLCRunnersStats{}
+	for _, id := range multiIDs {
+		initial[string(id)] = types.CLCRunnerStats{AverageExecutionTime: 80, IsClusterCheck: true}
+	}
+	initial[string(heavyID)] = types.CLCRunnerStats{AverageExecutionTime: 100, IsClusterCheck: true}
+	mockClient.testStats[nodeAIP] = initial
+	mockClient.testStats[nodeBIP] = types.CLCRunnersStats{}
+
+	// First pass: the multi-instance config should move from A to B as a
+	// single atomic unit.
+	moves := dispatcher.rebalanceUsingBusyness()
+	require.Len(t, moves, 1, "expected exactly one move; multi-instance config should move as a unit")
+
+	bStats := dispatcher.store.nodes["B"].clcRunnerStats
+	for _, id := range multiIDs {
+		assert.Contains(t, bStats, string(id), "instance %s should have followed its config to B", id)
+	}
+	aStats := dispatcher.store.nodes["A"].clcRunnerStats
+	assert.Contains(t, aStats, string(heavyID), "heavy config should remain on A")
+	for _, id := range multiIDs {
+		assert.NotContains(t, aStats, string(id), "instance %s should no longer be on A", id)
+	}
+
+	// Sync the mock to the dispatcher's post-move state so the next
+	// updateRunnersStats reflects reality rather than reseting back to the
+	// initial layout (the mock is otherwise stateless).
+	for _, node := range dispatcher.store.nodes {
+		snapshot := types.CLCRunnersStats{}
+		for k, v := range node.clcRunnerStats {
+			snapshot[k] = v
+		}
+		mockClient.testStats[node.clientIP] = snapshot
+	}
+
+	// Second pass: already balanced, so nothing should move.
+	moves = dispatcher.rebalanceUsingBusyness()
+	assert.Empty(t, moves, "second rebalance should be a no-op once placement is balanced")
 }
 
 func TestMoveCheck(t *testing.T) {
@@ -1486,7 +1639,7 @@ func TestMoveCheck(t *testing.T) {
 			dispatcher.store.nodes[tc.check.node].clcRunnerStats = types.CLCRunnersStats{string(id): types.CLCRunnerStats{}}
 
 			// move check
-			err := dispatcher.moveCheck(tc.check.node, tc.dest, string(id))
+			err := dispatcher.moveConfig(tc.check.node, tc.dest, tc.check.config.Digest())
 
 			// assert no error
 			assert.Nil(t, err)
@@ -1658,25 +1811,25 @@ func TestRebalanceIsWorthIt(t *testing.T) {
 	// The proposed solution is worth it if it leaves less unused runners
 
 	currentDistribution := newChecksDistribution(workersPerRunner)
-	currentDistribution.addCheck("check1", 1, "runner1")
-	currentDistribution.addCheck("check2", 1, "runner1")
+	currentDistribution.addCheck("check1", "check1", 1, "runner1")
+	currentDistribution.addCheck("check2", "check2", 1, "runner1")
 
 	proposedDistribution := newChecksDistribution(workersPerRunner)
-	proposedDistribution.addCheck("check1", 1, "runner1")
-	proposedDistribution.addCheck("check2", 1, "runner2")
+	proposedDistribution.addCheck("check1", "check1", 1, "runner1")
+	proposedDistribution.addCheck("check2", "check2", 1, "runner2")
 
 	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10))
 
 	// The proposed	solution is worth it if it has fewer runners with a high utilization
 	currentDistribution = newChecksDistribution(workersPerRunner)
-	currentDistribution.addCheck("check1", 1, "runner1")
-	currentDistribution.addCheck("check2", 1, "runner1")
-	currentDistribution.addCheck("check3", 1, "runner1")
+	currentDistribution.addCheck("check1", "check1", 1, "runner1")
+	currentDistribution.addCheck("check2", "check2", 1, "runner1")
+	currentDistribution.addCheck("check3", "check3", 1, "runner1")
 
 	proposedDistribution = newChecksDistribution(workersPerRunner)
-	proposedDistribution.addCheck("check1", 1, "runner1")
-	proposedDistribution.addCheck("check2", 1, "runner2")
-	proposedDistribution.addCheck("check3", 1, "runner3")
+	proposedDistribution.addCheck("check1", "check1", 1, "runner1")
+	proposedDistribution.addCheck("check2", "check2", 1, "runner2")
+	proposedDistribution.addCheck("check3", "check3", 1, "runner3")
 
 	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10))
 }


### PR DESCRIPTION
### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes

The unit test `TestRebalanceUsingBusyness_MultiInstanceConfigIsAtomicAndIdempotent` highlights the bug here.

Before this fix, it would split up the postgres check which is defined within 1 config:
```
Distribution after first pass:
Node A: map[postgres:9ac4e3cbe183470d:{80 0 0 0 0 true false  0 0 0 0 0 0 0} postgres:b4175ecbefaad40c:{80 0 0 0 0 true false  0 0 0 0 0 0 0}]
Node B: map[heavy:e919df663de2b6f7:{100 0 0 0 0 true false  0 0 0 0 0 0 0} postgres:a58714cbe8331072:{80 0 0 0 0 true false  0 0 0 0 0 0 0}]
```

However, now, we are moving the entire 3 instances of postgres within the same config together 🙏 