### PR TITLE
[cluster-agent] Rebalancing Algorithm Bug for Multi Instance Configs

### DIFF
--- a/pkg/cli/subcommands/clusterchecks/command.go
+++ b/pkg/cli/subcommands/clusterchecks/command.go
@@ -165,8 +165,8 @@ func rebalance(_ log.Component, client ipc.HTTPClient, cliParams *cliParams) err
 	fmt.Printf("%d cluster checks rebalanced successfully\n", len(checksMoved))
 
 	for _, check := range checksMoved {
-		fmt.Printf("Check %s with weight %d moved from node %s to %s. source diff: %d, dest diff: %d\n",
-			check.CheckID, check.CheckWeight, check.SourceNodeName, check.DestNodeName, check.SourceDiff, check.DestDiff)
+		fmt.Printf("Config %s with weight %d moved from node %s to %s. source diff: %d, dest diff: %d\n",
+			check.Digest, check.CheckWeight, check.SourceNodeName, check.DestNodeName, check.SourceDiff, check.DestDiff)
 	}
 
 	return nil

--- a/pkg/cli/subcommands/clusterchecks/command.go
+++ b/pkg/cli/subcommands/clusterchecks/command.go
@@ -165,8 +165,8 @@ func rebalance(_ log.Component, client ipc.HTTPClient, cliParams *cliParams) err
 	fmt.Printf("%d cluster checks rebalanced successfully\n", len(checksMoved))
 
 	for _, check := range checksMoved {
-		fmt.Printf("Config %s with weight %d moved from node %s to %s. source diff: %d, dest diff: %d\n",
-			check.Digest, check.CheckWeight, check.SourceNodeName, check.DestNodeName, check.SourceDiff, check.DestDiff)
+		fmt.Printf("Config %s (%s) with weight %d moved from node %s to %s. source diff: %d, dest diff: %d\n",
+			check.Digest, check.CheckName, check.CheckWeight, check.SourceNodeName, check.DestNodeName, check.SourceDiff, check.DestDiff)
 	}
 
 	return nil

--- a/pkg/clusteragent/clusterchecks/checks_distribution.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution.go
@@ -26,7 +26,9 @@ type ConfigStatus struct {
 type RunnerStatus struct {
 	Workers     int
 	WorkersUsed float64
-	NumChecks   int
+	// Note: this is different from the number of configs
+	// because a config can contain multiple check instances
+	NumChecks int
 }
 
 func (ns RunnerStatus) utilization() float64 {
@@ -121,13 +123,17 @@ func (distribution *configsDistribution) addConfig(digest, checkName string, wor
 		}
 		distribution.Configs[digest] = configInfo
 	}
-	configInfo.WorkersNeeded += workersNeeded
 
-	// Expect condition to never be true
+	// Prioritize the new assigned runner over the existing one
+	// Note: this edge case should never happen in practice
 	if configInfo.Runner != runner {
-		log.Warnf("configsDistribution.addConfig: digest %s already placed on runner %q, but received conflicting assignment to %q; workers credited to %q",
-			digest, configInfo.Runner, runner, runner)
+		log.Warnf("digest %s already placed on runner %q, but received conflicting assignment to %q",
+			digest, configInfo.Runner, runner)
+		distribution.Runners[configInfo.Runner].WorkersUsed -= configInfo.WorkersNeeded
+		configInfo.Runner = runner
 	}
+
+	configInfo.WorkersNeeded += workersNeeded
 }
 
 func (distribution *configsDistribution) runnerWorkers() map[string]int {

--- a/pkg/clusteragent/clusterchecks/checks_distribution.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution.go
@@ -10,12 +10,16 @@ package clusterchecks
 import (
 	"math"
 	"sort"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// CheckStatus represents the status of a check
-type CheckStatus struct {
+// ConfigStatus is one config's entry in a distribution.
+// WorkersNeeded is summed across the config's instances.
+type ConfigStatus struct {
 	WorkersNeeded float64
 	Runner        string
+	CheckName     string
 }
 
 // RunnerStatus represents the status of a check runner
@@ -33,14 +37,14 @@ func (ns RunnerStatus) utilization() float64 {
 	return ns.WorkersUsed / (float64)(ns.Workers)
 }
 
-// checksDistribution represents the placement of cluster checks across the
-// different runners of a cluster
-type checksDistribution struct {
-	Checks  map[string]*CheckStatus
+// configsDistribution represents the placement of cluster check configs
+// across the runners of a cluster. Each entry is keyed by config digest.
+type configsDistribution struct {
+	Configs map[string]*ConfigStatus
 	Runners map[string]*RunnerStatus
 }
 
-func newChecksDistribution(workersPerRunner map[string]int) checksDistribution {
+func newConfigsDistribution(workersPerRunner map[string]int) configsDistribution {
 	runners := map[string]*RunnerStatus{}
 	for runnerName, runnerWorkers := range workersPerRunner {
 		runners[runnerName] = &RunnerStatus{
@@ -50,8 +54,8 @@ func newChecksDistribution(workersPerRunner map[string]int) checksDistribution {
 		}
 	}
 
-	return checksDistribution{
-		Checks:  map[string]*CheckStatus{},
+	return configsDistribution{
+		Configs: map[string]*ConfigStatus{},
 		Runners: runners,
 	}
 }
@@ -59,15 +63,14 @@ func newChecksDistribution(workersPerRunner map[string]int) checksDistribution {
 // leastBusyRunner returns the runner with the lowest utilization. If there are
 // several options, it gives preference to preferredRunner. If preferredRunner
 // is not among the runners with the lowest utilization, it gives precedence to
-// the runner with the lowest number of checks deployed. excludeRunner can be set
-// to avoid assigning a check to a specific runner.
-func (distribution *checksDistribution) leastBusyRunner(preferredRunner string, excludeRunner string) string {
+// the runner with the lowest number of configs deployed. excludeRunner can be
+// set to avoid assigning a config to a specific runner.
+func (distribution *configsDistribution) leastBusyRunner(preferredRunner string, excludeRunner string) string {
 	leastBusyRunner := ""
 	minUtilization := 0.0
 	numChecksLeastBusyRunner := 0
 
 	for runnerName, runnerStatus := range distribution.Runners {
-		// Allow exclusion of a runner from selection
 		if runnerName == excludeRunner {
 			continue
 		}
@@ -90,34 +93,44 @@ func (distribution *checksDistribution) leastBusyRunner(preferredRunner string, 
 	return leastBusyRunner
 }
 
-func (distribution *checksDistribution) addToLeastBusy(checkID string, workersNeeded float64, preferredRunner string, excludeRunner string) {
+func (distribution *configsDistribution) addToLeastBusy(digest, checkName string, workersNeeded float64, preferredRunner string, excludeRunner string) {
 	leastBusy := distribution.leastBusyRunner(preferredRunner, excludeRunner)
 	if leastBusy == "" {
 		return
 	}
 
-	distribution.addCheck(checkID, workersNeeded, leastBusy)
+	distribution.addConfig(digest, checkName, workersNeeded, leastBusy)
 }
 
-func (distribution *checksDistribution) addCheck(checkID string, workersNeeded float64, runner string) {
-	distribution.Checks[checkID] = &CheckStatus{
-		WorkersNeeded: workersNeeded,
-		Runner:        runner,
-	}
-
+func (distribution *configsDistribution) addConfig(digest, checkName string, workersNeeded float64, runner string) {
+	// Initialize the runner and attribute work
 	runnerInfo, runnerExists := distribution.Runners[runner]
-	if runnerExists {
-		runnerInfo.WorkersUsed += workersNeeded
-		runnerInfo.NumChecks++
-	} else {
-		distribution.Runners[runner] = &RunnerStatus{
-			WorkersUsed: workersNeeded,
-			NumChecks:   1,
+	if !runnerExists {
+		runnerInfo = &RunnerStatus{}
+		distribution.Runners[runner] = runnerInfo
+	}
+	runnerInfo.WorkersUsed += workersNeeded
+	runnerInfo.NumChecks++
+
+	// Initialize the config and attribute work
+	configInfo, configExists := distribution.Configs[digest]
+	if !configExists {
+		configInfo = &ConfigStatus{
+			Runner:    runner,
+			CheckName: checkName,
 		}
+		distribution.Configs[digest] = configInfo
+	}
+	configInfo.WorkersNeeded += workersNeeded
+
+	// Expect condition to never be true
+	if configInfo.Runner != runner {
+		log.Warnf("configsDistribution.addConfig: digest %s already placed on runner %q, but received conflicting assignment to %q; workers credited to %q",
+			digest, configInfo.Runner, runner, runner)
 	}
 }
 
-func (distribution *checksDistribution) runnerWorkers() map[string]int {
+func (distribution *configsDistribution) runnerWorkers() map[string]int {
 	res := map[string]int{}
 
 	for runnerName, runnerStatus := range distribution.Runners {
@@ -127,82 +140,73 @@ func (distribution *checksDistribution) runnerWorkers() map[string]int {
 	return res
 }
 
-func (distribution *checksDistribution) runnerForCheck(checkID string) string {
-	if checkInfo, found := distribution.Checks[checkID]; found {
-		return checkInfo.Runner
+func (distribution *configsDistribution) runnerForConfig(digest string) string {
+	if info, found := distribution.Configs[digest]; found {
+		return info.Runner
 	}
-
 	return ""
 }
 
-func (distribution *checksDistribution) workersNeededForCheck(checkID string) float64 {
-	if checkInfo, found := distribution.Checks[checkID]; found {
-		return checkInfo.WorkersNeeded
+func (distribution *configsDistribution) workersNeededForConfig(digest string) float64 {
+	if info, found := distribution.Configs[digest]; found {
+		return info.WorkersNeeded
 	}
-
 	return 0
 }
 
-// Note: if there are several checks with the same number of workers needed,
-// they are returned in alphabetical order.
-// When distributing the checks, having the same order will help in minimizing
-// the number of re-schedules.
-func (distribution *checksDistribution) checksSortedByWorkersNeeded() []string {
-	var checks []struct {
-		checkID       string
+// configsSortedByWorkersNeeded returns config digests by descending
+// workersNeeded, with ties broken alphabetically to keep placement stable.
+func (distribution *configsDistribution) configsSortedByWorkersNeeded() []string {
+	var configs []struct {
+		digest        string
 		workersNeeded float64
 	}
 
-	for checkID, checkStatus := range distribution.Checks {
-		checks = append(checks, struct {
-			checkID       string
+	for digest, info := range distribution.Configs {
+		configs = append(configs, struct {
+			digest        string
 			workersNeeded float64
 		}{
-			checkID:       checkID,
-			workersNeeded: checkStatus.WorkersNeeded,
+			digest:        digest,
+			workersNeeded: info.WorkersNeeded,
 		})
 	}
 
-	sort.Slice(checks, func(i, j int) bool {
-		if checks[i].workersNeeded == checks[j].workersNeeded {
-			return checks[i].checkID < checks[j].checkID
+	sort.Slice(configs, func(i, j int) bool {
+		if configs[i].workersNeeded == configs[j].workersNeeded {
+			return configs[i].digest < configs[j].digest
 		}
-
-		return checks[i].workersNeeded > checks[j].workersNeeded
+		return configs[i].workersNeeded > configs[j].workersNeeded
 	})
 
-	var res []string
-	for _, check := range checks {
-		res = append(res, check.checkID)
+	res := make([]string, 0, len(configs))
+	for _, c := range configs {
+		res = append(res, c.digest)
 	}
 	return res
 }
 
-func (distribution *checksDistribution) numEmptyRunners() int {
+func (distribution *configsDistribution) numEmptyRunners() int {
 	empty := 0
-
 	for _, runnerStatus := range distribution.Runners {
 		if runnerStatus.NumChecks == 0 {
 			empty++
 		}
 	}
-
 	return empty
 }
 
-func (distribution *checksDistribution) numRunnersWithHighUtilization() int {
+func (distribution *configsDistribution) numRunnersWithHighUtilization() int {
 	withHighUtilization := 0
-
 	for _, runnerStatus := range distribution.Runners {
 		if runnerStatus.utilization() > 0.8 {
 			withHighUtilization++
 		}
 	}
-
 	return withHighUtilization
 }
 
-func (distribution *checksDistribution) utilizationStdDev() float64 {
+func (distribution *configsDistribution) utilizationStdDev() float64 {
 	totalUtilization := 0.0
 	for _, runnerStatus := range distribution.Runners {
 		totalUtilization += runnerStatus.utilization()

--- a/pkg/clusteragent/clusterchecks/checks_distribution.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution.go
@@ -130,6 +130,7 @@ func (distribution *configsDistribution) addConfig(digest, checkName string, wor
 		log.Warnf("digest %s already placed on runner %q, but received conflicting assignment to %q",
 			digest, configInfo.Runner, runner)
 		distribution.Runners[configInfo.Runner].WorkersUsed -= configInfo.WorkersNeeded
+		runnerInfo.WorkersUsed += configInfo.WorkersNeeded
 		configInfo.Runner = runner
 	}
 

--- a/pkg/clusteragent/clusterchecks/checks_distribution_test.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution_test.go
@@ -59,7 +59,7 @@ func TestAddToLeastBusy(t *testing.T) {
 	tests := []struct {
 		name              string
 		existingRunners   map[string]int
-		existingChecks    map[string]CheckStatus
+		existingChecks    map[string]ConfigStatus
 		preferredRunner   string
 		expectedPlacement string
 	}{
@@ -70,7 +70,7 @@ func TestAddToLeastBusy(t *testing.T) {
 				"runner2": 4,
 				"runner3": 4,
 			},
-			existingChecks: map[string]CheckStatus{
+			existingChecks: map[string]ConfigStatus{
 				"check1": {WorkersNeeded: 3, Runner: "runner1"},
 				"check2": {WorkersNeeded: 1, Runner: "runner2"},
 				"check3": {WorkersNeeded: 2, Runner: "runner3"},
@@ -85,7 +85,7 @@ func TestAddToLeastBusy(t *testing.T) {
 				"runner2": 4,
 				"runner3": 4,
 			},
-			existingChecks: map[string]CheckStatus{
+			existingChecks: map[string]ConfigStatus{
 				"check1": {WorkersNeeded: 3, Runner: "runner1"},
 				"check2": {WorkersNeeded: 1, Runner: "runner2"},
 				"check3": {WorkersNeeded: 1, Runner: "runner3"},
@@ -100,7 +100,7 @@ func TestAddToLeastBusy(t *testing.T) {
 				"runner2": 4,
 				"runner3": 4,
 			},
-			existingChecks: map[string]CheckStatus{
+			existingChecks: map[string]ConfigStatus{
 				"check1": {WorkersNeeded: 3, Runner: "runner1"},
 				"check2": {WorkersNeeded: 2, Runner: "runner2"},
 				"check3": {WorkersNeeded: 1, Runner: "runner3"},
@@ -116,7 +116,7 @@ func TestAddToLeastBusy(t *testing.T) {
 				"runner2": 4,
 				"runner3": 4,
 			},
-			existingChecks: map[string]CheckStatus{
+			existingChecks: map[string]ConfigStatus{
 				"check1": {WorkersNeeded: 3, Runner: "runner1"}, // runner1: util 0.75, 1 check
 				"check2": {WorkersNeeded: 1, Runner: "runner2"}, // runner2: util 0.5,  2 checks
 				"check3": {WorkersNeeded: 1, Runner: "runner2"},
@@ -130,7 +130,7 @@ func TestAddToLeastBusy(t *testing.T) {
 			existingRunners: map[string]int{
 				"runner1": 4,
 			},
-			existingChecks: map[string]CheckStatus{
+			existingChecks: map[string]ConfigStatus{
 				"check1": {WorkersNeeded: 3, Runner: "runner1"},
 			},
 			preferredRunner:   "",
@@ -139,7 +139,7 @@ func TestAddToLeastBusy(t *testing.T) {
 		{
 			name:              "no runners",
 			existingRunners:   map[string]int{},
-			existingChecks:    map[string]CheckStatus{},
+			existingChecks:    map[string]ConfigStatus{},
 			preferredRunner:   "",
 			expectedPlacement: "",
 		},
@@ -147,100 +147,100 @@ func TestAddToLeastBusy(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			distribution := newChecksDistribution(test.existingRunners)
+			distribution := newConfigsDistribution(test.existingRunners)
 
 			for checkID, checkStatus := range test.existingChecks {
-				distribution.addCheck(checkID, checkStatus.WorkersNeeded, checkStatus.Runner)
+				distribution.addConfig(checkID, checkStatus.CheckName, checkStatus.WorkersNeeded, checkStatus.Runner)
 			}
 
-			distribution.addToLeastBusy("newCheck", 10, test.preferredRunner, "")
+			distribution.addToLeastBusy("newCheck", "newCheck", 10, test.preferredRunner, "")
 
-			assert.Equal(t, test.expectedPlacement, distribution.runnerForCheck("newCheck"))
+			assert.Equal(t, test.expectedPlacement, distribution.runnerForConfig("newCheck"))
 		})
 	}
 }
 
 func TestAddCheck(t *testing.T) {
-	distribution := newChecksDistribution(map[string]int{
+	distribution := newConfigsDistribution(map[string]int{
 		"runner1": 4,
 	})
 
-	distribution.addCheck("check1", 3, "runner1")
-	assert.Equal(t, "runner1", distribution.runnerForCheck("check1"))
-	assert.Equal(t, 3.0, distribution.workersNeededForCheck("check1"))
+	distribution.addConfig("check1", "check1", 3, "runner1")
+	assert.Equal(t, "runner1", distribution.runnerForConfig("check1"))
+	assert.Equal(t, 3.0, distribution.workersNeededForConfig("check1"))
 }
 
 func TestChecksSortedByWorkersNeeded(t *testing.T) {
 	// Standard case
-	distribution := newChecksDistribution(map[string]int{
+	distribution := newConfigsDistribution(map[string]int{
 		"runner1": 4,
 		"runner2": 4,
 		"runner3": 4,
 	})
 
-	distribution.addCheck("check1", 3, "runner1")
-	distribution.addCheck("check2", 1, "runner1")
-	distribution.addCheck("check3", 4, "runner2")
-	distribution.addCheck("check4", 2, "runner3")
+	distribution.addConfig("check1", "check1", 3, "runner1")
+	distribution.addConfig("check2", "check2", 1, "runner1")
+	distribution.addConfig("check3", "check3", 4, "runner2")
+	distribution.addConfig("check4", "check4", 2, "runner3")
 
-	assert.Equal(t, []string{"check3", "check1", "check4", "check2"}, distribution.checksSortedByWorkersNeeded())
+	assert.Equal(t, []string{"check3", "check1", "check4", "check2"}, distribution.configsSortedByWorkersNeeded())
 
 	// Sorted alphabetically when the number of workers is the same
-	distribution = newChecksDistribution(map[string]int{
+	distribution = newConfigsDistribution(map[string]int{
 		"runner1": 4,
 		"runner2": 4,
 	})
 
-	distribution.addCheck("check_B", 1, "runner1")
-	distribution.addCheck("check_A", 1, "runner2")
-	distribution.addCheck("check_C", 1, "runner1")
-	distribution.addCheck("check_Z", 2, "runner2")
+	distribution.addConfig("check_B", "check_B", 1, "runner1")
+	distribution.addConfig("check_A", "check_A", 1, "runner2")
+	distribution.addConfig("check_C", "check_C", 1, "runner1")
+	distribution.addConfig("check_Z", "check_Z", 2, "runner2")
 
-	assert.Equal(t, []string{"check_Z", "check_A", "check_B", "check_C"}, distribution.checksSortedByWorkersNeeded())
+	assert.Equal(t, []string{"check_Z", "check_A", "check_B", "check_C"}, distribution.configsSortedByWorkersNeeded())
 }
 
 func TestNumEmptyRunners(t *testing.T) {
-	distribution := newChecksDistribution(map[string]int{
+	distribution := newConfigsDistribution(map[string]int{
 		"runner1": 4,
 		"runner2": 2,
 	})
 	assert.Equal(t, 2, distribution.numEmptyRunners())
 
-	distribution.addCheck("check1", 1, "runner1")
+	distribution.addConfig("check1", "check1", 1, "runner1")
 	assert.Equal(t, 1, distribution.numEmptyRunners())
 
-	distribution.addCheck("check2", 1, "runner2")
+	distribution.addConfig("check2", "check2", 1, "runner2")
 	assert.Equal(t, 0, distribution.numEmptyRunners())
 }
 
 func TestNumRunnersWithHighUtilization(t *testing.T) {
-	distribution := newChecksDistribution(map[string]int{
+	distribution := newConfigsDistribution(map[string]int{
 		"runner1": 4,
 		"runner2": 2,
 	})
 	assert.Equal(t, 0, distribution.numRunnersWithHighUtilization())
 
-	distribution.addCheck("check1", 1, "runner1") // runner 1 at 25%
+	distribution.addConfig("check1", "check1", 1, "runner1") // runner 1 at 25%
 	assert.Equal(t, 0, distribution.numRunnersWithHighUtilization())
 
-	distribution.addCheck("check2", 2.5, "runner1") // runner 1 at 3.5/4=0.875, above threshold
+	distribution.addConfig("check2", "check2", 2.5, "runner1") // runner 1 at 3.5/4=0.875, above threshold
 	assert.Equal(t, 1, distribution.numRunnersWithHighUtilization())
 
-	distribution.addCheck("check3", 2, "runner2") // runner 2 at 100%
+	distribution.addConfig("check3", "check3", 2, "runner2") // runner 2 at 100%
 	assert.Equal(t, 2, distribution.numRunnersWithHighUtilization())
 }
 
 func TestUtilizationStdDev(t *testing.T) {
 	// Define runner1 with 3 workers needed, runner2 with 5, runner3 with 8, and runner4 with 0
-	distribution := newChecksDistribution(map[string]int{
+	distribution := newConfigsDistribution(map[string]int{
 		"runner1": 4,
 		"runner2": 4,
 		"runner3": 4,
 	})
-	distribution.addCheck("check1", 1, "runner1")
-	distribution.addCheck("check2", 2, "runner1")
-	distribution.addCheck("check3", 2, "runner2")
-	distribution.addCheck("check4", 4, "runner3")
+	distribution.addConfig("check1", "check1", 1, "runner1")
+	distribution.addConfig("check2", "check2", 2, "runner1")
+	distribution.addConfig("check3", "check3", 2, "runner2")
+	distribution.addConfig("check4", "check4", 4, "runner3")
 
 	// The avg utilization is (0.75 + 0.5 + 1)/3 = 0.75
 	// The variance is ((0.75-0.75)^2 + (0.5-0.75)^2 + (1-0.75)^2)/3 = 0.125/3

--- a/pkg/clusteragent/clusterchecks/checks_distribution_test.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution_test.go
@@ -230,6 +230,29 @@ func TestNumRunnersWithHighUtilization(t *testing.T) {
 	assert.Equal(t, 2, distribution.numRunnersWithHighUtilization())
 }
 
+func TestAddConfigConflictTransfersAccumulatedWeight(t *testing.T) {
+	distribution := newConfigsDistribution(map[string]int{
+		"runner1": 4,
+		"runner2": 4,
+	})
+
+	// Two instances of digestA are processed on runner1 first.
+	distribution.addConfig("digestA", "configA", 2.0, "runner1")
+	distribution.addConfig("digestA", "configA", 1.5, "runner1")
+	assert.InDelta(t, 3.5, distribution.Runners["runner1"].WorkersUsed, 0.001)
+	assert.InDelta(t, 0.0, distribution.Runners["runner2"].WorkersUsed, 0.001)
+
+	// Conflicting assignment of digestA to runner2
+	distribution.addConfig("digestA", "configA", 3.0, "runner2")
+
+	// All accumulated weight for digestA (3.5) must transfer from runner1 to runner2,
+	// plus the new instance weight (3.0).
+	assert.InDelta(t, 0.0, distribution.Runners["runner1"].WorkersUsed, 0.001)
+	assert.InDelta(t, 6.5, distribution.Runners["runner2"].WorkersUsed, 0.001)
+	assert.InDelta(t, 6.5, distribution.Configs["digestA"].WorkersNeeded, 0.001)
+	assert.Equal(t, "runner2", distribution.Configs["digestA"].Runner)
+}
+
 func TestUtilizationStdDev(t *testing.T) {
 	// Define runner1 with 3 workers needed, runner2 with 5, runner3 with 8, and runner4 with 0
 	distribution := newConfigsDistribution(map[string]int{

--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -240,12 +240,3 @@ func (d *dispatcher) patchConfiguration(in integration.Config) (integration.Conf
 
 	return out, nil
 }
-
-// getConfigAndDigest returns config and digest of a check by checkID
-func (d *dispatcher) getConfigAndDigest(checkID string) (integration.Config, string) {
-	d.store.RLock()
-	defer d.store.RUnlock()
-
-	digest := d.store.idToDigest[checkid.ID(checkID)]
-	return d.store.digestToConfig[digest], digest
-}

--- a/pkg/clusteragent/clusterchecks/dispatcher_isolate.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_isolate.go
@@ -7,7 +7,10 @@
 
 package clusterchecks
 
-import "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+import (
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+)
 
 func (d *dispatcher) isolateCheck(isolateCheckID string) types.IsolateResponse {
 	// Update stats prior to starting isolate to ensure all checks are accounted for
@@ -24,7 +27,15 @@ func (d *dispatcher) isolateCheck(isolateCheckID string) types.IsolateResponse {
 		}
 	}
 
-	isolateNode := currentDistribution.runnerForCheck(isolateCheckID)
+	// Distribution is keyed by digest; translate the caller's checkID.
+	d.store.RLock()
+	isolateDigest, isolateKnown := d.store.idToDigest[checkid.ID(isolateCheckID)]
+	d.store.RUnlock()
+
+	isolateNode := ""
+	if isolateKnown {
+		isolateNode = currentDistribution.runnerForConfig(isolateDigest)
+	}
 	if isolateNode == "" {
 		return types.IsolateResponse{
 			CheckID:    isolateCheckID,
@@ -34,21 +45,20 @@ func (d *dispatcher) isolateCheck(isolateCheckID string) types.IsolateResponse {
 		}
 	}
 
-	proposedDistribution := newChecksDistribution(currentDistribution.runnerWorkers())
+	proposedDistribution := newConfigsDistribution(currentDistribution.runnerWorkers())
 
-	for _, checkID := range currentDistribution.checksSortedByWorkersNeeded() {
-		if checkID == isolateCheckID {
-			// Keep the check to be isolated on its current runner
+	for _, digest := range currentDistribution.configsSortedByWorkersNeeded() {
+		if digest == isolateDigest {
+			// Keep the config to be isolated on its current runner
 			continue
 		}
 
-		workersNeededForCheck := currentDistribution.workersNeededForCheck(checkID)
-		runnerForCheck := currentDistribution.runnerForCheck(checkID)
-
+		config := currentDistribution.Configs[digest]
 		proposedDistribution.addToLeastBusy(
-			checkID,
-			workersNeededForCheck,
-			runnerForCheck,
+			digest,
+			config.CheckName,
+			config.WorkersNeeded,
+			config.Runner,
 			isolateNode,
 		)
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -100,21 +100,46 @@ func (d *dispatcher) updateDiff(avg int) map[string]int {
 	return diffMap
 }
 
-// pickCheckToMove select the most appropriate check to move from a node to another.
-// A check Xi running on a node N is chosen to move to another node if it satisfies the following
-// Weight(Xi) >  Weight(Xj) (for each j != i, 0 <= j < len(weights))
-// where Weight(X) is the busyness value caused by running the check X.
-func (d *dispatcher) pickCheckToMove(nodeName string) (string, int, error) {
+// pickConfigToMove returns the digest of the heaviest config on the node,
+// with weight summed across the config's instances.
+func (d *dispatcher) pickConfigToMove(nodeName string) (string, int, error) {
 	d.store.RLock()
 	node, found := d.store.getNodeStore(nodeName)
-	d.store.RUnlock()
-
 	if !found {
-		log.Debugf("Node %s not found in store. Won't consider moving check", nodeName)
+		d.store.RUnlock()
+		log.Debugf("Node %s not found in store. Won't consider moving config", nodeName)
 		return "", -1, fmt.Errorf("node %s not found in store", nodeName)
 	}
 
-	return node.GetMostWeightedClusterCheck(busynessFunc)
+	node.RLock()
+	weightsByDigest := make(map[string]int, len(node.clcRunnerStats))
+	for checkID, stats := range node.clcRunnerStats {
+		if !stats.IsClusterCheck {
+			continue
+		}
+		digest, ok := d.store.idToDigest[checkid.ID(checkID)]
+		if !ok {
+			continue
+		}
+		weightsByDigest[digest] += busynessFunc(stats)
+	}
+	node.RUnlock()
+	d.store.RUnlock()
+
+	if len(weightsByDigest) == 0 {
+		log.Debugf("Node %s has no cluster check stats", nodeName)
+		return "", -1, fmt.Errorf("no cluster checks found on node %s", nodeName)
+	}
+
+	bestDigest := ""
+	bestWeight := 0
+	for digest, weight := range weightsByDigest {
+		if weight >= bestWeight {
+			bestDigest = digest
+			bestWeight = weight
+		}
+	}
+	return bestDigest, bestWeight, nil
 }
 
 // pickNode select the most appropriate node to receive a specific check.
@@ -139,37 +164,72 @@ func pickNode(diffMap map[string]int, sourceNode string) string {
 	return pickedNode
 }
 
-// moveCheck moves a check by its ID from a node to another
-func (d *dispatcher) moveCheck(src, dest, checkID string) error {
-	log.Debugf("Moving %s from %s to %s", checkID, src, dest)
+// moveCheck moves a config by its digest from a node to another
+func (d *dispatcher) moveConfig(src, dest, digest string) error {
+	log.Debugf("Moving config %s from %s to %s", digest, src, dest)
 
-	d.store.RLock()
+	d.store.Lock()
+	defer d.store.Unlock()
+
 	destNode, destFound := d.store.getNodeStore(dest)
 	sourceNode, srcFound := d.store.getNodeStore(src)
-	d.store.RUnlock()
+	config, configFound := d.store.digestToConfig[digest]
+	var instanceIDs []string
+	for checkID, checkDigest := range d.store.idToDigest {
+		if checkDigest == digest {
+			instanceIDs = append(instanceIDs, string(checkID))
+		}
+	}
 
 	if !destFound || !srcFound {
-		log.Debugf("Nodes not found in store: %s, %s. Check %s will not move", src, dest, checkID)
+		log.Debugf("Nodes not found in store: %s, %s. Config %s will not move", src, dest, digest)
 		return fmt.Errorf("node %s not found", src)
 	}
-
-	runnerStats, err := sourceNode.GetRunnerStats(checkID)
-	if err != nil {
-		log.Debugf("Cannot get runner stats on node %s, check %s will not move", src, checkID)
-		return err
+	if !configFound {
+		return fmt.Errorf("no config registered for digest %s", digest)
+	}
+	if len(instanceIDs) == 0 {
+		return fmt.Errorf("no instances registered for digest %s", digest)
 	}
 
-	destNode.AddRunnerStats(checkID, runnerStats)
-	sourceNode.RemoveRunnerStats(checkID)
+	// Move per-instance runner stats
+	var firstErr error
+	movedAny := false
+	for _, checkID := range instanceIDs {
+		stats, err := sourceNode.GetRunnerStats(checkID)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		destNode.AddRunnerStats(checkID, stats)
+		sourceNode.RemoveRunnerStats(checkID)
+		movedAny = true
+	}
+	if !movedAny {
+		log.Debugf("Cannot get runner stats on node %s for config %s; will not move", src, digest)
+		return firstErr
+	}
 
-	config, digest := d.getConfigAndDigest(checkID)
-	log.Tracef("Moving check %s with digest %s and config %s from %s to %s", checkID, digest, config.String(), src, dest)
+	// Reassign the config at the node level.
+	d.store.digestToNode[digest] = dest
 
-	d.removeConfig(digest)
-	d.addConfig(config, dest)
+	sourceNode.Lock()
+	sourceNode.removeConfig(digest)
+	sourceNode.Unlock()
 
-	log.Debugf("Check %s moved from %s to %s", checkID, src, dest)
+	destNode.Lock()
+	destNode.addConfig(config)
+	destNode.Unlock()
 
+	// Re-key configsInfo from src to dest.
+	for _, checkID := range instanceIDs {
+		configsInfo.Delete(src, config.Name, checkID, le.JoinLeaderValue)
+		configsInfo.Set(1.0, dest, config.Name, checkID, le.JoinLeaderValue)
+	}
+
+	log.Debugf("Config %s moved from %s to %s", digest, src, dest)
 	return nil
 }
 
@@ -216,11 +276,11 @@ func (d *dispatcher) rebalanceUsingBusyness() []types.RebalanceResponse {
 
 	for _, nodeWeight := range weights {
 		for diffMap[nodeWeight.nodeName] > 0 {
-			// try to move checks from a node only of the node busyness is above the average
+			// try to move configs from a node only if the node busyness is above the average
 			sourceNodeName := nodeWeight.nodeName
-			checkID, checkWeight, err := d.pickCheckToMove(sourceNodeName)
+			digest, configWeight, err := d.pickConfigToMove(sourceNodeName)
 			if err != nil {
-				log.Debugf("Cannot pick a check to move from node %s: %v", sourceNodeName, err)
+				log.Debugf("Cannot pick a config to move from node %s: %v", sourceNodeName, err)
 				break
 			}
 
@@ -228,27 +288,27 @@ func (d *dispatcher) rebalanceUsingBusyness() []types.RebalanceResponse {
 			sourceDiff := diffMap[sourceNodeName]
 			destDiff := diffMap[destNodeName]
 
-			// move a check to a new node only if it keeps the
+			// move a config to a new node only if it keeps the
 			// busyness of the new node lower than the original
 			// node's busyness multiplied by the tolerationMargin
 			// value the toleration margin is used to lean towards
 			// stability over perfectly optimal balance
-			if destDiff+checkWeight < int(float64(sourceDiff)*tolerationMargin) {
+			if destDiff+configWeight < int(float64(sourceDiff)*tolerationMargin) {
 				rebalancingDecisions.Inc(le.JoinLeaderValue)
-				err = d.moveCheck(sourceNodeName, destNodeName, checkID)
+				err = d.moveConfig(sourceNodeName, destNodeName, digest)
 				if err != nil {
-					log.Debugf("Cannot move check %s: %v", checkID, err)
+					log.Debugf("Cannot move config %s: %v", digest, err)
 					continue
 				}
 
 				successfulRebalancing.Inc(le.JoinLeaderValue)
-				log.Tracef("Check %s with weight %d moved, total avg: %d, source diff: %d, dest diff: %d",
-					checkID, checkWeight, totalAvg, sourceDiff, destDiff)
-				// diffMap needs to be updated on every check moved
+				log.Tracef("Config %s with weight %d moved, total avg: %d, source diff: %d, dest diff: %d",
+					digest, configWeight, totalAvg, sourceDiff, destDiff)
+				// diffMap needs to be updated on every move
 				diffMap = d.updateDiff(totalAvg)
 				checksMoved = append(checksMoved, types.RebalanceResponse{
-					CheckID:        checkID,
-					CheckWeight:    checkWeight,
+					Digest:         digest,
+					CheckWeight:    configWeight,
 					SourceNodeName: sourceNodeName,
 					SourceDiff:     sourceDiff,
 					DestNodeName:   destNodeName,
@@ -320,41 +380,41 @@ func (d *dispatcher) rebalanceUsingUtilization(force bool) []types.RebalanceResp
 		rebalancingDuration.Set(time.Since(start).Seconds(), le.JoinLeaderValue)
 	}()
 
-	currentChecksDistribution := d.currentDistribution()
+	currentConfigsDistribution := d.currentDistribution()
 
-	proposedDistribution := newChecksDistribution(currentChecksDistribution.runnerWorkers())
+	proposedDistribution := newConfigsDistribution(currentConfigsDistribution.runnerWorkers())
 
-	// First all the checks that are excluded from rebalancing are added to the
-	// same runner where they are currently running.
-	for checkID, check := range currentChecksDistribution.Checks {
-		checkName := checkid.IDToCheckName(checkid.ID(checkID))
-		if _, excluded := d.excludedChecksFromDispatching[checkName]; excluded {
-			proposedDistribution.addCheck(checkID, check.WorkersNeeded, check.Runner)
+	// Pin excluded configs to their current runner.
+	for digest, config := range currentConfigsDistribution.Configs {
+		if _, excluded := d.excludedChecksFromDispatching[config.CheckName]; excluded {
+			proposedDistribution.addConfig(digest, config.CheckName, config.WorkersNeeded, config.Runner)
 		}
 	}
 
-	// Place the checks that are not excluded from rebalancing
-	for _, checkID := range currentChecksDistribution.checksSortedByWorkersNeeded() {
-		checkName := checkid.IDToCheckName(checkid.ID(checkID))
-		if _, excluded := d.excludedChecksFromDispatching[checkName]; !excluded {
-			proposedDistribution.addToLeastBusy(
-				checkID,
-				currentChecksDistribution.workersNeededForCheck(checkID),
-				currentChecksDistribution.runnerForCheck(checkID),
-				"",
-			)
+	// Place the rest greedily by descending workersNeeded.
+	for _, digest := range currentConfigsDistribution.configsSortedByWorkersNeeded() {
+		config := currentConfigsDistribution.Configs[digest]
+		if _, excluded := d.excludedChecksFromDispatching[config.CheckName]; excluded {
+			continue
 		}
+		proposedDistribution.addToLeastBusy(
+			digest,
+			config.CheckName,
+			config.WorkersNeeded,
+			config.Runner,
+			"",
+		)
 	}
 
 	// We don't calculate the optimal distribution, so it might be worse than
 	// the current one or not good enough so that it's worth it to schedule and
 	// unschedule checks. When that's the case, return without moving any
 	// checks.
-	currentUtilizationStdDev := currentChecksDistribution.utilizationStdDev()
+	currentUtilizationStdDev := currentConfigsDistribution.utilizationStdDev()
 	proposedUtilizationStdDev := proposedDistribution.utilizationStdDev()
 	minPercImprovement := pkgconfigsetup.Datadog().GetInt("cluster_checks.rebalance_min_percentage_improvement")
 
-	if force || rebalanceIsWorthIt(currentChecksDistribution, proposedDistribution, minPercImprovement) {
+	if force || rebalanceIsWorthIt(currentConfigsDistribution, proposedDistribution, minPercImprovement) {
 
 		jsonDistribution, _ := json.Marshal(proposedDistribution)
 
@@ -368,40 +428,51 @@ func (d *dispatcher) rebalanceUsingUtilization(force bool) []types.RebalanceResp
 
 		setPredictedUtilization(proposedDistribution)
 
-		return d.applyDistribution(proposedDistribution, currentChecksDistribution)
+		return d.applyDistribution(proposedDistribution, currentConfigsDistribution)
 	}
 
 	log.Debugf("Didn't find a distribution better enough so that rescheduling checks is worth it (current utilization stddev: %.3f, found utilization stddev: %.3f)",
 		currentUtilizationStdDev, proposedUtilizationStdDev)
-	setPredictedUtilization(currentChecksDistribution)
+	setPredictedUtilization(currentConfigsDistribution)
 	return nil
 }
 
-func (d *dispatcher) currentDistribution() checksDistribution {
+func (d *dispatcher) currentDistribution() configsDistribution {
 	currentWorkersPerRunner := map[string]int{}
 
-	d.store.Lock()
-	defer d.store.Unlock()
+	d.store.RLock()
+	defer d.store.RUnlock()
 
 	for nodeName, nodeInfo := range d.store.nodes {
 		currentWorkersPerRunner[nodeName] = nodeInfo.workers
 	}
 
-	distribution := newChecksDistribution(currentWorkersPerRunner)
+	distribution := newConfigsDistribution(currentWorkersPerRunner)
 
 	for nodeName, nodeStoreInfo := range d.store.nodes {
+		// Take the node's read lock while iterating its stats — moveConfig
+		// mutates clcRunnerStats under only node.Lock (without the store
+		// lock), so the store RLock alone doesn't prevent a data race.
+		nodeStoreInfo.RLock()
 		for checkID, stats := range nodeStoreInfo.clcRunnerStats {
 			if !stats.IsClusterCheck {
 				continue
 			}
 
+			// Group by digest so the algorithm operates on whole configs.
+			// Skip checkIDs the dispatcher doesn't own.
+			digest, ok := d.store.idToDigest[checkid.ID(checkID)]
+			if !ok {
+				log.Debugf("No digest registered for check ID %s on node %s; skipping in distribution", checkID, nodeName)
+				continue
+			}
+			conf := d.store.digestToConfig[digest]
+
 			minCollectionInterval := defaults.DefaultCheckInterval
-			conf := d.store.digestToConfig[d.store.idToDigest[checkid.ID(checkID)]]
 			if len(conf.Instances) > 0 {
 				commonOptions := integration.CommonInstanceConfig{}
 				err := yaml.Unmarshal(conf.Instances[0], &commonOptions)
 				if err != nil {
-					// Assume default
 					log.Errorf("error getting min collection interval for check ID %s: %v", checkID, err)
 				} else if commonOptions.MinCollectionInterval != 0 {
 					minCollectionInterval = time.Duration(commonOptions.MinCollectionInterval) * time.Second
@@ -413,19 +484,20 @@ func (d *dispatcher) currentDistribution() checksDistribution {
 				workersNeeded = 1
 			}
 
-			distribution.addCheck(checkID, workersNeeded, nodeName)
+			distribution.addConfig(digest, conf.Name, workersNeeded, nodeName)
 		}
+		nodeStoreInfo.RUnlock()
 	}
 
 	return distribution
 }
 
-func (d *dispatcher) applyDistribution(proposedDistribution checksDistribution, currentDistribution checksDistribution) []types.RebalanceResponse {
+func (d *dispatcher) applyDistribution(proposedDistribution configsDistribution, currentDistribution configsDistribution) []types.RebalanceResponse {
 	var checksMoved []types.RebalanceResponse
 
-	for checkID, checkStatus := range proposedDistribution.Checks {
-		currentNode := currentDistribution.runnerForCheck(checkID)
-		proposedNode := checkStatus.Runner
+	for digest, config := range proposedDistribution.Configs {
+		currentNode := currentDistribution.runnerForConfig(digest)
+		proposedNode := config.Runner
 
 		if proposedNode == currentNode {
 			continue
@@ -433,9 +505,9 @@ func (d *dispatcher) applyDistribution(proposedDistribution checksDistribution, 
 
 		rebalancingDecisions.Inc(le.JoinLeaderValue)
 
-		err := d.moveCheck(currentNode, proposedNode, checkID)
+		err := d.moveConfig(currentNode, proposedNode, digest)
 		if err != nil {
-			log.Warnf("Cannot move check %s: %v", checkID, err)
+			log.Warnf("Cannot move config %s: %v", digest, err)
 			continue
 		}
 
@@ -444,7 +516,7 @@ func (d *dispatcher) applyDistribution(proposedDistribution checksDistribution, 
 		checksMoved = append(
 			checksMoved,
 			types.RebalanceResponse{
-				CheckID:        checkID,
+				Digest:         digest,
 				SourceNodeName: currentNode,
 				DestNodeName:   proposedNode,
 			},
@@ -454,13 +526,13 @@ func (d *dispatcher) applyDistribution(proposedDistribution checksDistribution, 
 	return checksMoved
 }
 
-func setPredictedUtilization(distribution checksDistribution) {
+func setPredictedUtilization(distribution configsDistribution) {
 	for runnerName, runnerStatus := range distribution.Runners {
 		predictedUtilization.Set(runnerStatus.utilization(), runnerName, le.JoinLeaderValue)
 	}
 }
 
-func rebalanceIsWorthIt(currentDistribution checksDistribution, proposedDistribution checksDistribution, minPercImprovement int) bool {
+func rebalanceIsWorthIt(currentDistribution configsDistribution, proposedDistribution configsDistribution, minPercImprovement int) bool {
 	// If the current utilization stddev is already good enough, consider that
 	// rescheduling checks is not worth it, unless the new distribution has
 	// fewer runners with a high utilization or leaves fewer runners empty.

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -166,6 +166,10 @@ func pickNode(diffMap map[string]int, sourceNode string) string {
 
 // moveCheck moves a config by its digest from a node to another
 func (d *dispatcher) moveConfig(src, dest, digest string) error {
+	if src == dest {
+		return nil
+	}
+
 	log.Debugf("Moving config %s from %s to %s", digest, src, dest)
 
 	d.store.Lock()
@@ -450,9 +454,6 @@ func (d *dispatcher) currentDistribution() configsDistribution {
 	distribution := newConfigsDistribution(currentWorkersPerRunner)
 
 	for nodeName, nodeStoreInfo := range d.store.nodes {
-		// Take the node's read lock while iterating its stats — moveConfig
-		// mutates clcRunnerStats under only node.Lock (without the store
-		// lock), so the store RLock alone doesn't prevent a data race.
 		nodeStoreInfo.RLock()
 		for checkID, stats := range nodeStoreInfo.clcRunnerStats {
 			if !stats.IsClusterCheck {
@@ -517,6 +518,7 @@ func (d *dispatcher) applyDistribution(proposedDistribution configsDistribution,
 			checksMoved,
 			types.RebalanceResponse{
 				Digest:         digest,
+				CheckName:      config.CheckName,
 				SourceNodeName: currentNode,
 				DestNodeName:   proposedNode,
 			},

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -422,17 +422,19 @@ func (d *dispatcher) rebalanceUsingUtilization(force bool) []types.RebalanceResp
 
 		jsonDistribution, _ := json.Marshal(proposedDistribution)
 
+		calculatedMoves := d.applyDistribution(proposedDistribution, currentConfigsDistribution)
+		numOfMoves, numOfConfigs, numOfRunners := len(calculatedMoves), len(proposedDistribution.Configs), len(proposedDistribution.Runners)
+
+		prefixMessage := "Found a better distribution for the cluster checks. "
 		if force {
-			log.Infof("Forcing rebalance proposed distribution for the cluster checks. Utilization stdDev of proposed distribution: %.3f. StdDev of current distribution: %.3f. Proposed distribution: %s",
-				proposedUtilizationStdDev, currentUtilizationStdDev, jsonDistribution)
-		} else {
-			log.Infof("Found a better distribution for the cluster checks. Utilization stdDev of proposed distribution: %.3f. StdDev of current distribution: %.3f. Proposed distribution: %s",
-				proposedUtilizationStdDev, currentUtilizationStdDev, jsonDistribution)
+			prefixMessage = "Forcing rebalance proposed distribution for the cluster checks. "
 		}
 
-		setPredictedUtilization(proposedDistribution)
+		log.Infof("%s Moving %d checks out of %d configs on %d runners. Utilization stdDev of proposed distribution: %.3f. StdDev of current distribution: %.3f. Proposed distribution: %s",
+			prefixMessage, numOfMoves, numOfConfigs, numOfRunners, proposedUtilizationStdDev, currentUtilizationStdDev, jsonDistribution)
 
-		return d.applyDistribution(proposedDistribution, currentConfigsDistribution)
+		setPredictedUtilization(proposedDistribution)
+		return calculatedMoves
 	}
 
 	log.Debugf("Didn't find a distribution better enough so that rescheduling checks is worth it (current utilization stddev: %.3f, found utilization stddev: %.3f)",

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -1422,6 +1422,18 @@ func TestRebalance(t *testing.T) {
 				dispatcher.store.nodes[node].clcRunnerStats = store.clcRunnerStats
 				// Store the test data in the mock so it can return it
 				mockClient.testStats[nodeIP] = store.clcRunnerStats
+				// Each cluster-check ID is its own single-instance config
+				// (digest == checkID). Skip non-cluster checks so
+				// updateRunnersStats doesn't flip their IsClusterCheck flag.
+				for checkID, stats := range store.clcRunnerStats {
+					if !stats.IsClusterCheck {
+						continue
+					}
+					digest := checkID
+					dispatcher.store.idToDigest[checkid.ID(checkID)] = digest
+					dispatcher.store.digestToConfig[digest] = integration.Config{Name: checkID}
+					dispatcher.store.digestToNode[digest] = node
+				}
 			}
 
 			// Use busyness-based rebalancing directly for these legacy tests
@@ -1485,8 +1497,8 @@ func TestMoveCheck(t *testing.T) {
 			dispatcher.addConfig(tc.check.config, tc.check.node)
 			dispatcher.store.nodes[tc.check.node].clcRunnerStats = types.CLCRunnersStats{string(id): types.CLCRunnerStats{}}
 
-			// move check
-			err := dispatcher.moveCheck(tc.check.node, tc.dest, string(id))
+			// move config
+			err := dispatcher.moveConfig(tc.check.node, tc.dest, tc.check.config.Digest())
 
 			// assert no error
 			assert.Nil(t, err)
@@ -1554,7 +1566,7 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 	//   - Fill the store manually to avoid having to fetch the information from
 	//   the API exposed by the check runners.
 	//   - Use basic example with only 3 checks and 2 runners because there are
-	//   other tests specific for the checksDistribution struct that test more
+	//   other tests specific for the configsDistribution struct that test more
 	//   complex scenarios.
 
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
@@ -1636,9 +1648,9 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 	assert.Equal(t, expectedStatsNode1, testDispatcher.store.nodes["node1"].clcRunnerStats)
 	assert.Equal(t, expectedStatsNode2, testDispatcher.store.nodes["node2"].clcRunnerStats)
 
-	// Check response
+	// Moves are reported by the moved config's digest.
 	require.Len(t, checksMoved, 1)
-	assert.Equal(t, "check2", checksMoved[0].CheckID)
+	assert.Equal(t, "digest2", checksMoved[0].Digest)
 	assert.Equal(t, "node1", checksMoved[0].SourceNodeName)
 	assert.Equal(t, "node2", checksMoved[0].DestNodeName)
 
@@ -1646,6 +1658,169 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 	// changes in the checks stats.
 	checksMoved = testDispatcher.rebalanceUsingUtilization(false)
 	assert.Empty(t, checksMoved)
+}
+
+// Verifies the utilization algorithm treats a config's instances as a single
+// unit: one entry in the distribution, and never split across runners.
+func TestRebalanceUsingUtilization_GroupsInstancesByConfig(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	testDispatcher := newDispatcher(fakeTagger)
+
+	mockClient := &rebalanceTestClcRunnerClient{
+		testStats: make(map[string]types.CLCRunnersStats),
+	}
+	testDispatcher.clcRunnersClient = mockClient
+	testDispatcher.advancedDispatching.Store(true)
+
+	testDispatcher.store.active = true
+	testDispatcher.store.nodes["node1"] = newNodeStore("node1", "10.0.0.1")
+	testDispatcher.store.nodes["node1"].workers = pkgconfigsetup.DefaultNumWorkers
+	testDispatcher.store.nodes["node2"] = newNodeStore("node2", "10.0.0.2")
+	testDispatcher.store.nodes["node2"].workers = pkgconfigsetup.DefaultNumWorkers
+
+	node1Stats := map[string]types.CLCRunnerStats{
+		"checkM0": {AverageExecutionTime: 2000, IsClusterCheck: true},
+		"checkM1": {AverageExecutionTime: 2000, IsClusterCheck: true},
+	}
+	node2Stats := map[string]types.CLCRunnerStats{
+		"checkL0": {AverageExecutionTime: 200, IsClusterCheck: true},
+	}
+	testDispatcher.store.nodes["node1"].clcRunnerStats = node1Stats
+	testDispatcher.store.nodes["node2"].clcRunnerStats = node2Stats
+	mockClient.testStats["10.0.0.1"] = node1Stats
+	mockClient.testStats["10.0.0.2"] = node2Stats
+
+	// checkM0 and checkM1 are two instances of one config.
+	testDispatcher.store.idToDigest = map[checkid.ID]string{
+		"checkM0": "digestMulti",
+		"checkM1": "digestMulti",
+		"checkL0": "digestLight",
+	}
+	testDispatcher.store.digestToConfig = map[string]integration.Config{
+		"digestMulti": {Name: "multi"},
+		"digestLight": {Name: "light"},
+	}
+	testDispatcher.store.digestToNode = map[string]string{
+		"digestMulti": "node1",
+		"digestLight": "node2",
+	}
+
+	// One entry per config in the distribution; multi's workers are summed.
+	dist := testDispatcher.currentDistribution()
+	require.Len(t, dist.Configs, 2)
+	require.Contains(t, dist.Configs, "digestMulti")
+	require.Contains(t, dist.Configs, "digestLight")
+	assert.Equal(t, "node1", dist.Configs["digestMulti"].Runner)
+	assert.InDelta(t, dist.Configs["digestMulti"].WorkersNeeded, dist.Configs["digestLight"].WorkersNeeded*20, 0.0001)
+
+	// Force the rebalance so the worth-it check doesn't short-circuit it.
+	checksMoved := testDispatcher.rebalanceUsingUtilization(true)
+	requireNotLocked(t, testDispatcher.store)
+
+	// At most one move; if there is one, both instances follow it.
+	assert.LessOrEqual(t, len(checksMoved), 1)
+	for _, mv := range checksMoved {
+		assert.Equal(t, "digestMulti", mv.Digest)
+		destStats := testDispatcher.store.nodes[mv.DestNodeName].clcRunnerStats
+		assert.Contains(t, destStats, "checkM0")
+		assert.Contains(t, destStats, "checkM1")
+		srcStats := testDispatcher.store.nodes[mv.SourceNodeName].clcRunnerStats
+		assert.NotContains(t, srcStats, "checkM0")
+		assert.NotContains(t, srcStats, "checkM1")
+	}
+}
+
+// Verifies that two configs sharing a check name but with different digests
+// (e.g., two postgres configs monitoring different databases) get separate
+// distribution entries and are moved independently.
+func TestCurrentDistribution_SeparatesConfigsByDigest(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	testDispatcher := newDispatcher(fakeTagger)
+	testDispatcher.store.active = true
+	testDispatcher.store.nodes["node1"] = newNodeStore("node1", "10.0.0.1")
+	testDispatcher.store.nodes["node1"].workers = pkgconfigsetup.DefaultNumWorkers
+
+	testDispatcher.store.nodes["node1"].clcRunnerStats = map[string]types.CLCRunnerStats{
+		"checkPgA": {AverageExecutionTime: 1000, IsClusterCheck: true},
+		"checkPgB": {AverageExecutionTime: 1000, IsClusterCheck: true},
+	}
+	// Same check name, two different digests — two distinct configs.
+	testDispatcher.store.idToDigest = map[checkid.ID]string{
+		"checkPgA": "digestPgA",
+		"checkPgB": "digestPgB",
+	}
+	testDispatcher.store.digestToConfig = map[string]integration.Config{
+		"digestPgA": {Name: "postgres"},
+		"digestPgB": {Name: "postgres"},
+	}
+	testDispatcher.store.digestToNode = map[string]string{
+		"digestPgA": "node1",
+		"digestPgB": "node1",
+	}
+
+	dist := testDispatcher.currentDistribution()
+	require.Len(t, dist.Configs, 2)
+	require.Contains(t, dist.Configs, "digestPgA")
+	require.Contains(t, dist.Configs, "digestPgB")
+	assert.Equal(t, "postgres", dist.Configs["digestPgA"].CheckName)
+	assert.Equal(t, "postgres", dist.Configs["digestPgB"].CheckName)
+}
+
+// Verifies pickConfigToMove aggregates weight by digest so a multi-instance
+// config can outrank a single-instance one with higher per-check weight.
+func TestRebalanceUsingBusyness_GroupsInstancesByConfig(t *testing.T) {
+	originalCheckExecutionTimeWeight := checkExecutionTimeWeight
+	originalMetricSamplesWeight := checkMetricSamplesWeight
+	checkExecutionTimeWeight = 0.8
+	checkMetricSamplesWeight = 0.2
+	defer func() {
+		checkExecutionTimeWeight = originalCheckExecutionTimeWeight
+		checkMetricSamplesWeight = originalMetricSamplesWeight
+	}()
+
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	testDispatcher := newDispatcher(fakeTagger)
+
+	mockClient := &rebalanceTestClcRunnerClient{
+		testStats: make(map[string]types.CLCRunnersStats),
+	}
+	testDispatcher.clcRunnersClient = mockClient
+
+	testDispatcher.store.active = true
+	testDispatcher.store.nodes["A"] = newNodeStore("A", "10.0.0.1")
+	testDispatcher.store.nodes["B"] = newNodeStore("B", "10.0.0.2")
+
+	// Per-checkID, checkH0 (250) looks heaviest; aggregated per-config,
+	// digestMulti (3 × 125) outweighs digestHeavy.
+	nodeAStats := map[string]types.CLCRunnerStats{
+		"checkH0": {AverageExecutionTime: 250, MetricSamples: 0, IsClusterCheck: true},
+		"checkM0": {AverageExecutionTime: 125, MetricSamples: 0, IsClusterCheck: true},
+		"checkM1": {AverageExecutionTime: 125, MetricSamples: 0, IsClusterCheck: true},
+		"checkM2": {AverageExecutionTime: 125, MetricSamples: 0, IsClusterCheck: true},
+	}
+	testDispatcher.store.nodes["A"].clcRunnerStats = nodeAStats
+	mockClient.testStats["10.0.0.1"] = nodeAStats
+	mockClient.testStats["10.0.0.2"] = types.CLCRunnersStats{}
+
+	testDispatcher.store.idToDigest = map[checkid.ID]string{
+		"checkH0": "digestHeavy",
+		"checkM0": "digestMulti",
+		"checkM1": "digestMulti",
+		"checkM2": "digestMulti",
+	}
+	testDispatcher.store.digestToConfig = map[string]integration.Config{
+		"digestHeavy": {Name: "heavy", Instances: []integration.Data{integration.Data("")}},
+		"digestMulti": {Name: "multi", Instances: []integration.Data{integration.Data("a"), integration.Data("b"), integration.Data("c")}},
+	}
+	testDispatcher.store.digestToNode = map[string]string{
+		"digestHeavy": "A",
+		"digestMulti": "A",
+	}
+
+	digest, weight, err := testDispatcher.pickConfigToMove("A")
+	require.NoError(t, err)
+	assert.Equal(t, "digestMulti", digest)
+	assert.Greater(t, weight, 200)
 }
 
 func TestRebalanceIsWorthIt(t *testing.T) {
@@ -1657,26 +1832,26 @@ func TestRebalanceIsWorthIt(t *testing.T) {
 
 	// The proposed solution is worth it if it leaves less unused runners
 
-	currentDistribution := newChecksDistribution(workersPerRunner)
-	currentDistribution.addCheck("check1", 1, "runner1")
-	currentDistribution.addCheck("check2", 1, "runner1")
+	currentDistribution := newConfigsDistribution(workersPerRunner)
+	currentDistribution.addConfig("check1", "check1", 1, "runner1")
+	currentDistribution.addConfig("check2", "check2", 1, "runner1")
 
-	proposedDistribution := newChecksDistribution(workersPerRunner)
-	proposedDistribution.addCheck("check1", 1, "runner1")
-	proposedDistribution.addCheck("check2", 1, "runner2")
+	proposedDistribution := newConfigsDistribution(workersPerRunner)
+	proposedDistribution.addConfig("check1", "check1", 1, "runner1")
+	proposedDistribution.addConfig("check2", "check2", 1, "runner2")
 
 	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10))
 
 	// The proposed	solution is worth it if it has fewer runners with a high utilization
-	currentDistribution = newChecksDistribution(workersPerRunner)
-	currentDistribution.addCheck("check1", 1, "runner1")
-	currentDistribution.addCheck("check2", 1, "runner1")
-	currentDistribution.addCheck("check3", 1, "runner1")
+	currentDistribution = newConfigsDistribution(workersPerRunner)
+	currentDistribution.addConfig("check1", "check1", 1, "runner1")
+	currentDistribution.addConfig("check2", "check2", 1, "runner1")
+	currentDistribution.addConfig("check3", "check3", 1, "runner1")
 
-	proposedDistribution = newChecksDistribution(workersPerRunner)
-	proposedDistribution.addCheck("check1", 1, "runner1")
-	proposedDistribution.addCheck("check2", 1, "runner2")
-	proposedDistribution.addCheck("check3", 1, "runner3")
+	proposedDistribution = newConfigsDistribution(workersPerRunner)
+	proposedDistribution.addConfig("check1", "check1", 1, "runner1")
+	proposedDistribution.addConfig("check2", "check2", 1, "runner2")
+	proposedDistribution.addConfig("check3", "check3", 1, "runner3")
 
 	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10))
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -1660,9 +1660,11 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 	assert.Empty(t, checksMoved)
 }
 
-// Verifies the utilization algorithm treats a config's instances as a single
-// unit: one entry in the distribution, and never split across runners.
-func TestRebalanceUsingUtilization_GroupsInstancesByConfig(t *testing.T) {
+// Verifies two things: currentDistribution groups each config's instances under
+// one entry (summing their workersNeeded), and when two heavy multi-instance
+// configs are stacked on node1 alongside a lightweight config on node2, the
+// utilization rebalancer moves one heavy config to node2, spreading the load.
+func TestRebalanceUsingUtilization_GroupsAndSpreadsMultiInstanceConfigs(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	testDispatcher := newDispatcher(fakeTagger)
 
@@ -1678,56 +1680,107 @@ func TestRebalanceUsingUtilization_GroupsInstancesByConfig(t *testing.T) {
 	testDispatcher.store.nodes["node2"] = newNodeStore("node2", "10.0.0.2")
 	testDispatcher.store.nodes["node2"].workers = pkgconfigsetup.DefaultNumWorkers
 
+	// node1: two heavy multi-instance configs. node2: one lightweight config.
 	node1Stats := map[string]types.CLCRunnerStats{
-		"checkM0": {AverageExecutionTime: 2000, IsClusterCheck: true},
-		"checkM1": {AverageExecutionTime: 2000, IsClusterCheck: true},
+		"checkA0": {AverageExecutionTime: 3750, IsClusterCheck: true},
+		"checkA1": {AverageExecutionTime: 250, IsClusterCheck: true},
+		"checkB0": {AverageExecutionTime: 3750, IsClusterCheck: true},
+		"checkB1": {AverageExecutionTime: 250, IsClusterCheck: true},
 	}
 	node2Stats := map[string]types.CLCRunnerStats{
-		"checkL0": {AverageExecutionTime: 200, IsClusterCheck: true},
+		"checkL0": {AverageExecutionTime: 500, IsClusterCheck: true},
 	}
 	testDispatcher.store.nodes["node1"].clcRunnerStats = node1Stats
 	testDispatcher.store.nodes["node2"].clcRunnerStats = node2Stats
 	mockClient.testStats["10.0.0.1"] = node1Stats
 	mockClient.testStats["10.0.0.2"] = node2Stats
 
-	// checkM0 and checkM1 are two instances of one config.
+	// checkA0/checkA1 → digestMultiA; checkB0/checkB1 → digestMultiB; checkL0 → digestLight.
 	testDispatcher.store.idToDigest = map[checkid.ID]string{
-		"checkM0": "digestMulti",
-		"checkM1": "digestMulti",
+		"checkA0": "digestMultiA",
+		"checkA1": "digestMultiA",
+		"checkB0": "digestMultiB",
+		"checkB1": "digestMultiB",
 		"checkL0": "digestLight",
 	}
 	testDispatcher.store.digestToConfig = map[string]integration.Config{
-		"digestMulti": {Name: "multi"},
-		"digestLight": {Name: "light"},
+		"digestMultiA": {Name: "multiA"},
+		"digestMultiB": {Name: "multiB"},
+		"digestLight":  {Name: "light"},
 	}
 	testDispatcher.store.digestToNode = map[string]string{
-		"digestMulti": "node1",
-		"digestLight": "node2",
+		"digestMultiA": "node1",
+		"digestMultiB": "node1",
+		"digestLight":  "node2",
 	}
 
-	// One entry per config in the distribution; multi's workers are summed.
+	// Verify currentDistribution groups each config's instances into one entry.
 	dist := testDispatcher.currentDistribution()
-	require.Len(t, dist.Configs, 2)
-	require.Contains(t, dist.Configs, "digestMulti")
+	require.Len(t, dist.Configs, 3)
+	require.Contains(t, dist.Configs, "digestMultiA")
+	require.Contains(t, dist.Configs, "digestMultiB")
 	require.Contains(t, dist.Configs, "digestLight")
-	assert.Equal(t, "node1", dist.Configs["digestMulti"].Runner)
-	assert.InDelta(t, dist.Configs["digestMulti"].WorkersNeeded, dist.Configs["digestLight"].WorkersNeeded*20, 0.0001)
+	assert.Equal(t, "node1", dist.Configs["digestMultiA"].Runner)
+	assert.Equal(t, "node1", dist.Configs["digestMultiB"].Runner)
+	assert.Equal(t, "node2", dist.Configs["digestLight"].Runner)
+	// This ensures that the tracking of workersNeeded is accurate relative to 1 instance configs.
+	assert.InDelta(t, dist.Configs["digestMultiA"].WorkersNeeded, dist.Configs["digestLight"].WorkersNeeded*8, 0.001)
+	assert.InDelta(t, dist.Configs["digestMultiB"].WorkersNeeded, dist.Configs["digestLight"].WorkersNeeded*8, 0.001)
 
-	// Force the rebalance so the worth-it check doesn't short-circuit it.
 	checksMoved := testDispatcher.rebalanceUsingUtilization(true)
 	requireNotLocked(t, testDispatcher.store)
+	require.NotEmpty(t, checksMoved)
 
-	// At most one move; if there is one, both instances follow it.
-	assert.LessOrEqual(t, len(checksMoved), 1)
-	for _, mv := range checksMoved {
-		assert.Equal(t, "digestMulti", mv.Digest)
-		destStats := testDispatcher.store.nodes[mv.DestNodeName].clcRunnerStats
-		assert.Contains(t, destStats, "checkM0")
-		assert.Contains(t, destStats, "checkM1")
-		srcStats := testDispatcher.store.nodes[mv.SourceNodeName].clcRunnerStats
-		assert.NotContains(t, srcStats, "checkM0")
-		assert.NotContains(t, srcStats, "checkM1")
+	node1After := testDispatcher.store.nodes["node1"].clcRunnerStats
+	node2After := testDispatcher.store.nodes["node2"].clcRunnerStats
+
+	// Each multi config's instances must remain together — no splitting.
+	_, a0OnNode1 := node1After["checkA0"]
+	_, a1OnNode1 := node1After["checkA1"]
+	assert.Equal(t, a0OnNode1, a1OnNode1, "digestMultiA instances must stay together")
+	_, b0OnNode1 := node1After["checkB0"]
+	_, b1OnNode1 := node1After["checkB1"]
+	assert.Equal(t, b0OnNode1, b1OnNode1, "digestMultiB instances must stay together")
+
+	// The two heavy configs must end up on different nodes.
+	assert.NotEqual(t, a0OnNode1, b0OnNode1, "digestMultiA and digestMultiB should be on different nodes after rebalance")
+
+	// Every heavy instance is on exactly one node.
+	for _, checkID := range []string{"checkA0", "checkA1", "checkB0", "checkB1"} {
+		_, onNode1 := node1After[checkID]
+		_, onNode2 := node2After[checkID]
+		assert.True(t, onNode1 || onNode2, "check %s should be on one of the nodes", checkID)
+		assert.False(t, onNode1 && onNode2, "check %s should not be on both nodes", checkID)
 	}
+
+	// Phase 2: reduce the exec time of the heavy instance that is NOT co-located with
+	// checkL0. This lightens one multi config, creating an imbalance that should
+	// cause digestLight to move to the lighter side.
+	_, checkL0OnNode1 := node1After["checkL0"]
+	var heavyNodeName string
+	if checkL0OnNode1 {
+		heavyNodeName = "node2"
+	} else {
+		heavyNodeName = "node1"
+	}
+
+	heavyNodeStats := testDispatcher.store.nodes[heavyNodeName].clcRunnerStats
+	var reducedCheckID string
+	if _, ok := heavyNodeStats["checkA0"]; ok {
+		reducedCheckID = "checkA0"
+	} else {
+		reducedCheckID = "checkB0"
+	}
+	s := heavyNodeStats[reducedCheckID]
+	s.AverageExecutionTime = 250
+	heavyNodeStats[reducedCheckID] = s
+
+	checksMoved2 := testDispatcher.rebalanceUsingUtilization(true)
+	requireNotLocked(t, testDispatcher.store)
+
+	// The lighter multi config now has far less work than the other; digestLight should migrate to balance the load.
+	require.Len(t, checksMoved2, 1)
+	assert.Equal(t, "digestLight", checksMoved2[0].Digest)
 }
 
 // Verifies that two configs sharing a check name but with different digests

--- a/pkg/clusteragent/clusterchecks/handler_api.go
+++ b/pkg/clusteragent/clusterchecks/handler_api.go
@@ -112,7 +112,7 @@ func (h *Handler) RebalanceClusterChecks(force bool) ([]types.RebalanceResponse,
 
 	for _, decision := range rebalancingDecisions {
 		response = append(response, types.RebalanceResponse{
-			CheckID:        decision.CheckID,
+			Digest:         decision.Digest,
 			CheckWeight:    decision.CheckWeight,
 			SourceNodeName: decision.SourceNodeName,
 			SourceDiff:     decision.SourceDiff,

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -185,31 +185,3 @@ func (s *nodeStore) GetBusyness(busynessFunc func(stats types.CLCRunnerStats) in
 	}
 	return busyness
 }
-
-// GetMostWeightedClusterCheck returns the Cluster Check with the most weight on the node
-// The nodeStore handles thread safety for this public method
-func (s *nodeStore) GetMostWeightedClusterCheck(busynessFunc func(stats types.CLCRunnerStats) int) (string, int, error) {
-	s.RLock()
-	defer s.RUnlock()
-	if len(s.clcRunnerStats) == 0 {
-		log.Debugf("Node %s has no check stats", s.name)
-		return "", -1, fmt.Errorf("node %s has no check stats", s.name)
-	}
-	firstItr := true
-	checkID := ""
-	checkWeight := 0
-	for id, stats := range s.clcRunnerStats {
-		busyness := busynessFunc(stats)
-		if (busyness > checkWeight || firstItr) && stats.IsClusterCheck {
-			// Only consider Cluster Checks
-			checkWeight = busyness
-			checkID = id
-			firstItr = false
-		}
-	}
-	if firstItr {
-		log.Debugf("Node %s has no check stats for cluster checks: %v", s.name, s.clcRunnerStats)
-		return "", -1, fmt.Errorf("no cluster checks found on node %s", s.name)
-	}
-	return checkID, checkWeight, nil
-}

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -43,7 +43,7 @@ type StatusResponse struct {
 
 // RebalanceResponse holds the DCA response for a rebalancing request
 type RebalanceResponse struct {
-	CheckID     string `json:"check_id"`
+	Digest      string `json:"digest"`
 	CheckWeight int    `json:"check_weight"`
 
 	SourceNodeName string `json:"source_node_name"`

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -44,6 +44,7 @@ type StatusResponse struct {
 // RebalanceResponse holds the DCA response for a rebalancing request
 type RebalanceResponse struct {
 	Digest      string `json:"digest"`
+	CheckName   string `json:"check_name"`
 	CheckWeight int    `json:"check_weight"`
 
 	SourceNodeName string `json:"source_node_name"`

--- a/releasenotes-dca/notes/clc-rebalance-digest-grouping-753a3238dabef7cd.yaml
+++ b/releasenotes-dca/notes/clc-rebalance-digest-grouping-753a3238dabef7cd.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed the Cluster Agent's cluster check rebalancing algorithm to operate
+    on configuration digests rather than individual instance IDs. Previously,
+    multi-instance configurations could be incorrectly split across different
+    runners, causing inaccurate workload estimates and suboptimal rebalancing
+    decisions.


### PR DESCRIPTION
### What does this PR do?

Refactors the cluster checks rebalancing algorithm to operate on **config digests** instead of individual check instance IDs. Each config is now treated as an atomic unit wher its instances are always placed and moved together to the same destination runner.

### Motivation

Previously, two instances of the same config (e.g., two PostgreSQL checks with different instances) would be treated as independent units in the distribution. The dispatcher side only ever dispatched instances as 1 unit with the same config. This mismatch between the algorithm and dispatcher led to bad data being used in algorithm decisons.

### Describe how you validated your changes

Unit tests and CI.

Particularly `TestRebalanceUsingUtilization_GroupsAndSpreadsMultiInstanceConfigs` shows the exact story we want to see with multi instance checks being properly considered in the algorithm as 1 unit.

<img width="1463" height="441" alt="image" src="https://github.com/user-attachments/assets/8d75900b-5f86-43f9-aa56-47e9d33e8d06" />

When you run this test case on main you get the following with checks from the same config being split up.

```
Forcing rebalance proposed distribution for the cluster checks. Utilization stdDev of proposed distribution: 0.000. StdDev of current distribution: 0.062. Proposed distribution: 
{"Checks":{"checkA0":{"WorkersNeeded":0.25,"Runner":"node1"},"checkA1":{"WorkersNeeded":0.016666666666666666,"Runner":"node1"},"checkB0":{"WorkersNeeded":0.25,"Runner":"node2"},"checkB1":{"WorkersNeeded":0.016666666666666666,"Runner":"node1"},"checkL0":{"WorkersNeeded":0.03333333333333333,"Runner":"node2"}},"Runners":{"node1":{"Workers":4,"WorkersUsed":0.2833333333333333,"NumChecks":3},"node2":{"Workers":4,"WorkersUsed":0.2833333333333333,"NumChecks":2}}}
```