### PR TITLE
[CONTP-1460] fix(ksm): Pass cancelable context to CR Discoverer client

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/cr.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/cr.go
@@ -117,7 +117,7 @@ func (d customResourceDecoder) Decode(v interface{}) error {
 }
 
 // StartDiscovery starts the custom resource discovery and returns a discoverer instance
-func StartDiscovery() *discovery.CRDiscoverer {
+func StartDiscovery(ctx context.Context) *discovery.CRDiscoverer {
 	discovererInstance := &discovery.CRDiscoverer{
 		CRDsAddEventsCounter:    crdsAddEventsCounter,
 		CRDsUpdateEventsCounter: crdsUpdateEventsCounter,
@@ -130,7 +130,7 @@ func StartDiscovery() *discovery.CRDiscoverer {
 		panic(err)
 	}
 
-	if err := discovererInstance.StartDiscovery(context.Background(), clientConfig); err != nil {
+	if err := discovererInstance.StartDiscovery(ctx, clientConfig); err != nil {
 		log.Errorf("failed to start custom resource discovery: %v", err)
 	}
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -330,7 +330,7 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 
 	if k.instance.usesCustomResourceMetrics() && k.instance.PodCollectionMode != nodeKubeletPodCollection {
 		k.crMu.Lock()
-		if k.customResourceDiscoverer == nil {
+		if k.cancelCR == nil {
 			ctx, cancel := context.WithCancel(context.Background())
 			k.customResourceDiscoverer = customresources.StartDiscovery(ctx)
 			k.cancelCR = cancel
@@ -785,7 +785,6 @@ func (k *KSMCheck) Cancel() {
 		log.Infof("Shutting down custom resource informers")
 		k.cancelCR()
 		k.cancelCR = nil
-		k.customResourceDiscoverer = nil
 	}
 	k.crMu.Unlock()
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/samber/lo"
@@ -243,6 +244,8 @@ type KSMCheck struct {
 	telemetry                  *telemetryCache
 	tagger                     tagger.Component
 	cancel                     context.CancelFunc
+	cancelCR                   context.CancelFunc
+	crMu                       sync.Mutex
 	isCLCRunner                bool
 	isRunningOnNodeAgent       bool
 	clusterIDTagValue          string
@@ -326,7 +329,13 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 	k.mergeLabelsMapper(defaultLabelsMapper())
 
 	if k.instance.usesCustomResourceMetrics() && k.instance.PodCollectionMode != nodeKubeletPodCollection {
-		k.customResourceDiscoverer = customresources.StartDiscovery()
+		k.crMu.Lock()
+		if k.customResourceDiscoverer == nil {
+			ctx, cancel := context.WithCancel(context.Background())
+			k.customResourceDiscoverer = customresources.StartDiscovery(ctx)
+			k.cancelCR = cancel
+		}
+		k.crMu.Unlock()
 	}
 
 	// Retry configuration steps related to API Server in check executions if necessary
@@ -663,18 +672,21 @@ func (k *KSMCheck) Run() error {
 
 	// Check if the custom resource discoverer was updated and rebuild KSM if needed
 	// Only check if discoverer was initialized (not in node_kubelet mode)
-	if k.customResourceDiscoverer != nil {
+	k.crMu.Lock()
+	discoverer := k.customResourceDiscoverer
+	k.crMu.Unlock()
+	if discoverer != nil {
 		wasUpdated := false
-		k.customResourceDiscoverer.SafeRead(func() {
-			wasUpdated = k.customResourceDiscoverer.WasUpdated
+		discoverer.SafeRead(func() {
+			wasUpdated = discoverer.WasUpdated
 		})
 
 		if wasUpdated {
 			if err := k.buildStores(); err != nil {
 				log.Errorf("Failed to rebuild KSM: %v", err)
 			}
-			k.customResourceDiscoverer.SafeWrite(func() {
-				k.customResourceDiscoverer.WasUpdated = false
+			discoverer.SafeWrite(func() {
+				discoverer.WasUpdated = false
 			})
 		}
 	}
@@ -768,6 +780,14 @@ func (k *KSMCheck) Cancel() {
 	if k.cancel != nil {
 		k.cancel()
 	}
+	k.crMu.Lock()
+	if k.cancelCR != nil {
+		log.Infof("Shutting down custom resource informers")
+		k.cancelCR()
+		k.cancelCR = nil
+		k.customResourceDiscoverer = nil
+	}
+	k.crMu.Unlock()
 }
 
 // processMetrics attaches tags and forwards metrics to the aggregator

--- a/releasenotes/notes/fix-ksm-crd-informer-leak-44597f3caf5a1b66.yaml
+++ b/releasenotes/notes/fix-ksm-crd-informer-leak-44597f3caf5a1b66.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Fixes a memory leak in the Kubernetes State Core check where Kubernetes watch connections and their cached data
+    were not released when the check was unscheduled. In environments with frequent check rescheduling, this caused
+    memory to grow unboundedly over time.


### PR DESCRIPTION
### What does this PR do?

Fixes a goroutine and memory leak in the KSM core check's custom resource (CR) discoverer. When the check was unscheduled, the `CRDiscoverer` and its underlying Kubernetes watch informer were never stopped, leaving them running indefinitely. Each check reschedule (caused by CLC runner rebalancing) compounded the leak by creating an additional zombie discoverer.

`StartDiscovery` was previously called with `context.Background()`, which produces a nil `Done()` channel. The upstream `CRDiscoverer.StartDiscovery` spawns a goroutine that does `for range ctx.Done()` to close a stopper channel — with a nil channel this goroutine blocks forever, the stopper is never closed, and `informer.Run(stopper)` never terminates. Additionally, `Cancel()` only stopped the KSM metrics store informers; it never touched the `CRDiscoverer`.

### Motivation

A refactor introduced in #43315 (agent 7.74.0) added `CRDiscoverer` as a member of `KSMCheck#Configure`, passing a non-cancellable context to the CR discoverer and creating the memory leak path.

Large customers have seen periodic memory growth in their cluster check runners correlating with check rebalancing. Notably, memory did not drop proportionally after a KSM check was unscheduled from a CLC runner pod. While debugging ee identified zombie `CRDiscoverer` goroutines and their `StreamWatcher`s remain after unscheduling, accumulating over time as checks are rescheduled.

### Describe how you validated your changes

<details>
<summary><strong>Reproduction steps</strong></summary>

#### 1. Prerequisites

- Local k8s cluster (minikube/kind/colima)
- [`injector-dev`](https://github.com/DataDog/injector-dev) configured with a local build (or setup your k8s cluster &  build agent yourself)
- `capture_profile.sh` and `fake_setup.sh` scripts

<details><summary>capture_profile.sh</summary>
<p>

```sh
#!/bin/bash
# Usage: ./capture_profiles.sh <output_dir> [--context <kube-context>] [--namespace <namespace>] [--port <local-port-base>]
#
# Finds all cluster-checks-runner pods, and for each one port-forwards its pprof
# endpoint and captures both a heap and goroutine profile into <output_dir>.
# Output files are named <pod-name>-heap.pprof and <pod-name>-goroutine.txt.

set -euo pipefail

OUTPUT_DIR=""
KUBE_CONTEXT=""
NAMESPACE=""
LOCAL_PORT_BASE="15100"

usage() {
  echo "Usage: $0 <output_dir> [--context <kube-context>] [--namespace <namespace>] [--port <local-port-base>]"
  exit 1
}

while [[ $# -gt 0 ]]; do
  case "$1" in
    --context)   KUBE_CONTEXT="$2"; shift 2 ;;
    --namespace) NAMESPACE="$2"; shift 2 ;;
    --port)      LOCAL_PORT_BASE="$2"; shift 2 ;;
    -*)          echo "Unknown flag: $1"; usage ;;
    *)
      if [[ -z "$OUTPUT_DIR" ]]; then
        OUTPUT_DIR="$1"; shift
      else
        echo "Unexpected argument: $1"; usage
      fi
      ;;
  esac
done

if [[ -z "$OUTPUT_DIR" ]]; then
  usage
fi

mkdir -p "$OUTPUT_DIR"

KUBECTL_ARGS=()
if [[ -n "$KUBE_CONTEXT" ]]; then
  KUBECTL_ARGS+=(--context "$KUBE_CONTEXT")
fi

# Auto-discover namespace if not provided
if [[ -z "$NAMESPACE" ]]; then
  echo "Searching for datadog-agent-clusterchecks pods across all namespaces..."
  NAMESPACE=$(kubectl "${KUBECTL_ARGS[@]}" get pods -A \
    --field-selector=status.phase=Running \
    -o custom-columns="NS:.metadata.namespace,NAME:.metadata.name" --no-headers \
    | grep "datadog-agent-clusterchecks" | head -1 | awk '{print $1}')

  if [[ -z "$NAMESPACE" ]]; then
    echo "Error: could not find any running datadog-agent-clusterchecks pods. Use --namespace to specify."
    exit 1
  fi
fi

PODS=($(kubectl "${KUBECTL_ARGS[@]}" -n "$NAMESPACE" get pods \
  -o custom-columns="NAME:.metadata.name" --no-headers \
  | grep "datadog-agent-clusterchecks"))

if [[ ${#PODS[@]} -eq 0 ]]; then
  echo "Error: no running datadog-agent-clusterchecks pods found in namespace '$NAMESPACE'."
  exit 1
fi

echo "Found ${#PODS[@]} datadog-agent-clusterchecks pod(s) in namespace '$NAMESPACE':"
for POD in "${PODS[@]}"; do echo "  $POD"; done

REMOTE_PORT=5000
TIMESTAMP=$(date +%Y%m%d-%H%M%S)

capture_pod() {
  local POD="$1"
  local LOCAL_PORT="$2"
  local PF_PID=""

  cleanup_pf() {
    if [[ -n "$PF_PID" ]]; then
      kill "$PF_PID" 2>/dev/null || true
    fi
  }
  trap cleanup_pf RETURN

  echo "[$POD] Starting port-forward $LOCAL_PORT -> $REMOTE_PORT ..."
  kubectl "${KUBECTL_ARGS[@]}" -n "$NAMESPACE" port-forward "$POD" "${LOCAL_PORT}:${REMOTE_PORT}" \
    >/dev/null 2>&1 &
  PF_PID=$!

  # Wait for port-forward to be ready
  for i in $(seq 1 15); do
    if curl -sf "http://localhost:${LOCAL_PORT}/debug/pprof/" -o /dev/null 2>/dev/null; then
      break
    fi
    if [[ $i -eq 15 ]]; then
      echo "[$POD] Error: port-forward did not become ready in time."
      return 1
    fi
    sleep 1
  done

  local HEAP_FILE="$OUTPUT_DIR/${TIMESTAMP}-${POD}-heap.pprof"
  local GOROUTINE_FILE="$OUTPUT_DIR/${TIMESTAMP}-${POD}-goroutine.txt"

  echo "[$POD] Capturing heap profile -> $HEAP_FILE"
  curl -sf "http://localhost:${LOCAL_PORT}/debug/pprof/heap" -o "$HEAP_FILE"

  echo "[$POD] Capturing goroutine profile -> $GOROUTINE_FILE"
  curl -sf "http://localhost:${LOCAL_PORT}/debug/pprof/goroutine?debug=1" -o "$GOROUTINE_FILE"

  echo "[$POD] Done."
  echo "[$POD]   Heap:      go tool pprof $HEAP_FILE"
  echo "[$POD]   Goroutines: grep -c 'StreamWatcher' $GOROUTINE_FILE"
}

PORT_OFFSET=0
for POD in "${PODS[@]}"; do
  LOCAL_PORT=$((LOCAL_PORT_BASE + PORT_OFFSET))
  capture_pod "$POD" "$LOCAL_PORT"
  PORT_OFFSET=$((PORT_OFFSET + 1))
done

echo ""
echo "All profiles written to: $OUTPUT_DIR"
echo ""
echo "Quick leak check across all pods:"
echo "  StreamWatcher goroutines:"
grep -c "StreamWatcher" "$OUTPUT_DIR"/${TIMESTAMP}-*-goroutine.txt 2>/dev/null || true
echo "  CRDiscoverer nil-chan goroutines:"
grep -c "CRDiscoverer.*StartDiscovery" "$OUTPUT_DIR"/${TIMESTAMP}-*-goroutine.txt 2>/dev/null || true
```

</p>
</details> 

<details><summary>create_fake_crds.sh</summary>
<p>

```sh
#!/bin/bash
# Usage: ./create_fake_crds.sh [--count N] [--context <kube-context>] [--delete]
#
# Creates (or deletes) N fake CRDs to inflate the CRD watch stream and informer
# cache size, amplifying the KSM CR discoverer heap leak for profiling purposes.
# Each CRD has a non-trivial schema so the serialized object is meaningfully large.

set -euo pipefail

COUNT=200
KUBE_CONTEXT=""
DELETE=false

usage() {
  echo "Usage: $0 [--count N] [--context <kube-context>] [--delete]"
  exit 1
}

while [[ $# -gt 0 ]]; do
  case "$1" in
    --count)   COUNT="$2"; shift 2 ;;
    --context) KUBE_CONTEXT="$2"; shift 2 ;;
    --delete)  DELETE=true; shift ;;
    *) echo "Unknown flag: $1"; usage ;;
  esac
done

KUBECTL_ARGS=()
if [[ -n "$KUBE_CONTEXT" ]]; then
  KUBECTL_ARGS+=(--context "$KUBE_CONTEXT")
fi

if $DELETE; then
  echo "Deleting $COUNT fake CRDs..."
  for i in $(seq 1 "$COUNT"); do
    kubectl "${KUBECTL_ARGS[@]}" delete crd "fakeleakresource${i}s.ksm-leak-test.io" --ignore-not-found
  done
  echo "Done."
  exit 0
fi

echo "Creating $COUNT fake CRDs..."
for i in $(seq 1 "$COUNT"); do
  kubectl "${KUBECTL_ARGS[@]}" apply -f - <<EOF
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: fakeleakresource${i}s.ksm-leak-test.io
  labels:
    ksm-leak-test: "true"
spec:
  group: ksm-leak-test.io
  names:
    kind: FakeLeakResource${i}
    plural: fakeleakresource${i}s
    singular: fakeleakresource${i}
  scope: Namespaced
  versions:
    - name: v1
      served: true
      storage: true
      schema:
        openAPIV3Schema:
          type: object
          properties:
            spec:
              type: object
              properties:
                replicas:  { type: integer }
                image:     { type: string }
                env:       { type: array, items: { type: object, x-kubernetes-preserve-unknown-fields: true } }
                resources: { type: object, x-kubernetes-preserve-unknown-fields: true }
                config:    { type: object, x-kubernetes-preserve-unknown-fields: true }
            status:
              type: object
              properties:
                ready:       { type: boolean }
                readyReplicas: { type: integer }
                conditions:
                  type: array
                  items:
                    type: object
                    properties:
                      type:               { type: string }
                      status:             { type: string }
                      lastTransitionTime: { type: string }
                      reason:             { type: string }
                      message:            { type: string }
EOF
done

echo ""
echo "Created $COUNT fake CRDs (group: ksm-leak-test.io)"
echo "Total CRDs in cluster: $(kubectl "${KUBECTL_ARGS[@]}" get crd --no-headers | wc -l)"
echo ""
echo "Clean up when done: $0 --delete --count $COUNT"
```

</p>
</details> 

#### 2. Inflate the CRD count

More CRDs = larger informer cache = more visible heap impact. Use the included script to create fake CRDs:

```bash
./create_fake_crds.sh --count 200
```

#### 3. Deploy the agent

Theis scenario configures two CLC runner replicas with KSM sharding enabled and a custom resource metric over `CustomResourceDefinition` objects. A fake HTTP service is also deployed to provide a second non-KSM cluster check, so that after rebalancing one runner holds only `http_check` with no KSM — making the goroutine state unambiguous.

```yaml
platform:
  type: "minikube"
  name: "ksm-leak"
  reset: false
helm:
  versions:
    agent:
      build: {}
    cluster_agent:
      build: {}
    injector: "0.60.0"
  manifests:
    - path: fake-http-service.yaml
      namespace: "default"
  config:
    clusterChecksRunner:
      enabled: true
      replicas: 2
      image:
        tag: "7535965" # THE SAME TAG AS THE CORE AGENT BUILT
    datadog:
      clusterName: <YOUR_CLUSTER_NAME>
      operator:
        enabled: false
      csi:
        enabled: false
      clusterChecks:
        enabled: true
      kubelet:
        tlsVerify: false
      clusterTagger:
        collectKubernetesTags: true
      # KSM check with a custom resource — just needs to be non-empty
      # any CRD that exists in the cluster works
      kubeStateMetricsCore:
        enabled: true
        useClusterCheckRunners: true
        collectCrMetrics:
          - groupVersionKind:
              group: "apiextensions.k8s.io"
              version: "v1"
              kind: "CustomResourceDefinition"
            metrics:
              - name: "ready"
                type: Gauge
                each:
                  type: Gauge
                  gauge:
                    path: [status, conditions, "[type=NamesAccepted]", status]
    clusterAgent:
      env:
        - name: DD_CLUSTER_CHECKS_KSM_SHARDING_ENABLED
          value: "true"
```

```bash
# Buggy version (pre-fix)
injector-dev apply -f workloads/ksm-leak/scenario.yaml

# Fixed version
injector-dev apply -f workloads/ksm-leak/scenario.yaml --build
```

#### 4. Capture baseline profiles (no rebalancing)

```bash
./capture_profiles.sh ./profiles/baseline
```

#### 5. Force rebalancing

You can force KSM checks to 'move around' by constantly isolating various checks so that the KSM checks are pushed to the other to make room for the isolated check. Having a non-KSM check here is **essential to ensure the final state has at least 1 runner without any KSM checks**

```bash
agent clusterchecks isolate --checkID <CHECK_ID>
```

Repeat 3–5 times to accumulate leaked goroutines in the buggy version.

#### 6. Capture post-move profiles

```bash
./capture_profiles.sh ./profiles/after_moves
```

#### 7. Inspect results

```bash
# Leaked StreamWatcher goroutines per pod (grows each cycle in buggy version)
grep -c "StreamWatcher" ./profiles/after_moves/*-goroutine.txt

# Permanently-blocked nil-chan goroutines (absent in fixed version)
grep -c "CRDiscoverer.*StartDiscovery" ./profiles/after_moves/*-goroutine.txt

# Heap top
go tool pprof -top ./profiles/after_moves/<pod>-heap.pprof | grep -E "StreamWatcher|objectInterface"
```

</details>

#### Expectations

The key signal is a CLC runner pod that **had** KSM scheduled but then had it moved away to another runner. In the fixed version that pod should show zero leaked goroutines; in the buggy version each prior scheduling leaves behind a zombie.

| | Buggy (pre-fix) | Fixed |
|---|---|---|
| `StreamWatcher.receive` goroutines on pod that lost KSM | accumulates per reschedule | **0** |
| `CRDiscoverer.StartDiscovery.func3` goroutines (nil-chan blocked) | accumulates per reschedule | **0** |
| `StreamWatcher.receive` goroutines on pod actively running KSM | N active + N leaked | N active only |
| Heap from `objectInterface` allocations | grows with each reschedule cycle | stable |

#### Goroutine Differnce
**Before:** ([dump showing orphaned goroutines](https://github.com/user-attachments/files/28570318/20260603-155911-datadog-agent-clusterchecks-67796557d7-gfhmm-goroutine.txt))
```
5 @ 0x48a3e0 0x41e6dc 0x41e4f4 0x221e654 0x492d24
#	0x221e653	k8s.io/kube-state-metrics/v2/pkg/discovery.(*CRDiscoverer).StartDiscovery.func3+0x33	k8s.io/kube-state-metrics/v2@v2.13.1-0.20241025121156-110f03d7331f/pkg/discovery/discovery.go:108
....
5 @ 0x48a3e0 0x48bf00 0x48bee1 0x4ac504 0x90f404 0x91a36c 0x77ca7c 0x552a64 0x5526c0 0x5524ac 0x11235a4 0x1148ba0 0x1148ea4 0xee6d3c 0x492d24
#	0x48bee0	sync.runtime_notifyListWait+0x120						runtime/sema.go:606
#	0x4ac503	sync.(*Cond).Wait+0xa3								sync/cond.go:71
#	0x90f403	golang.org/x/net/http2.(*pipe).Read+0xf3					golang.org/x/net@v0.55.0/http2/pipe.go:76
#	0x91a36b	golang.org/x/net/http2.transportResponseBody.Read+0x4b				golang.org/x/net@v0.55.0/http2/transport.go:2180
#	0x77ca7b	net/http.(*cancelTimerBody).Read+0x2b						net/http/client.go:973
#	0x552a63	encoding/json.(*Decoder).refill+0x143						encoding/json/stream.go:167
#	0x5526bf	encoding/json.(*Decoder).readValue+0x6f						encoding/json/stream.go:142
#	0x5524ab	encoding/json.(*Decoder).Decode+0x5b						encoding/json/stream.go:65
#	0x11235a3	k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read+0x153		k8s.io/apimachinery@v0.35.3/pkg/util/framer/framer.go:151
#	0x1148b9f	k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode+0x7f	k8s.io/apimachinery@v0.35.3/pkg/runtime/serializer/streaming/streaming.go:77
#	0x1148ea3	k8s.io/client-go/rest/watch.(*Decoder).Decode+0x53				k8s.io/client-go@v0.35.3/rest/watch/decoder.go:49
#	0xee6d3b	k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive+0xbb			k8s.io/apimachinery@v0.35.3/pkg/watch/streamwatcher.go:114
```

**After:** ([dump showing no leaked goroutines](https://github.com/user-attachments/files/28570394/20260603-160659-datadog-agent-clusterchecks-fffbc986-csmd4-goroutine.txt)) 
```
# Nothing Found
```

#### Heap Difference
**Before:** Screenshot shows leftover `StreamWatcher.receive` live heap memory
<img width="1303" height="495" alt="image" src="https://github.com/user-attachments/assets/40766bc5-b172-4339-81af-345880882769" />

**After:** All objects cleaned up
<img width="1816" height="370" alt="Screenshot 2026-06-03 at 4 32 25 PM" src="https://github.com/user-attachments/assets/bf3594c0-29e5-4a19-828b-2b786b7dd017" />
