### PR TITLE
validate system probe config using schema and raise issues to agent health

### DIFF
--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//comp/healthplatform/issues/checkfailure",
         "//comp/healthplatform/issues/dockerpermissions",
         "//comp/healthplatform/issues/invalidconfig",
+        "//comp/healthplatform/issues/invalidsysprobeconfig",
         "//comp/healthplatform/issues/rofspermissions",
         "//comp/healthplatform/runner/def",
         "//comp/healthplatform/runner/fx",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -26,11 +26,12 @@ import (
 	// Issue modules register themselves via init(); imported here for side effects.
 	registrydef "github.com/DataDog/datadog-agent/comp/healthplatform/issueregistry/def"
 	registryfx "github.com/DataDog/datadog-agent/comp/healthplatform/issueregistry/fx"
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"    // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"      // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions" // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/invalidconfig"     // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"   // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"        // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"          // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"     // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/invalidconfig"         // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/invalidsysprobeconfig" // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"       // registers templates via init()
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 	runnerfx "github.com/DataDog/datadog-agent/comp/healthplatform/runner/fx"
 	schedulerdef "github.com/DataDog/datadog-agent/comp/healthplatform/scheduler/def"

--- a/comp/healthplatform/bundle_test.go
+++ b/comp/healthplatform/bundle_test.go
@@ -277,7 +277,7 @@ func TestIssueStateLifecycleForwarded(t *testing.T) {
 // match or restart-based issue resolution silently breaks.
 func TestAllModulesIssueNameMatchesBuiltIssueName(t *testing.T) {
 	cfg := config.NewMock(t)
-	mods := issues.GetAllModules(cfg)
+	mods := issues.GetAllModules(issues.ModuleDeps{Config: cfg})
 	require.NotEmpty(t, mods, "no modules registered")
 	for _, mod := range mods {
 		issue, err := mod.BuildIssue(map[string]string{})

--- a/comp/healthplatform/issueregistry/impl/BUILD.bazel
+++ b/comp/healthplatform/issueregistry/impl/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
+        "//comp/core/sysprobeconfig/def",
         "//comp/healthplatform/issueregistry/def",
         "//comp/healthplatform/issues",
         "//comp/healthplatform/runner/def",

--- a/comp/healthplatform/issueregistry/impl/BUILD.bazel
+++ b/comp/healthplatform/issueregistry/impl/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
+        "//comp/core/hostname/hostnameinterface/def",
         "//comp/core/sysprobeconfig/def",
         "//comp/healthplatform/issueregistry/def",
         "//comp/healthplatform/issues",

--- a/comp/healthplatform/issueregistry/impl/registry.go
+++ b/comp/healthplatform/issueregistry/impl/registry.go
@@ -8,6 +8,7 @@ package issueregistryimpl
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	sysprobeconfig "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/def"
 	registrydef "github.com/DataDog/datadog-agent/comp/healthplatform/issueregistry/def"
 	issuesmod "github.com/DataDog/datadog-agent/comp/healthplatform/issues"
@@ -18,6 +19,7 @@ import (
 type Requires struct {
 	Config         config.Component
 	SysProbeConfig sysprobeconfig.Component `optional:"true"`
+	Hostname       hostnameinterface.Component
 }
 
 type registryImpl struct {
@@ -30,6 +32,7 @@ func New(reqs Requires) registrydef.Component {
 	deps := issuesmod.ModuleDeps{
 		Config:         reqs.Config,
 		SysProbeConfig: reqs.SysProbeConfig,
+		Hostname:       reqs.Hostname,
 	}
 	for _, module := range issuesmod.GetAllModules(deps) {
 		r.RegisterModule(module)

--- a/comp/healthplatform/issueregistry/impl/registry.go
+++ b/comp/healthplatform/issueregistry/impl/registry.go
@@ -8,6 +8,7 @@ package issueregistryimpl
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	sysprobeconfig "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/def"
 	registrydef "github.com/DataDog/datadog-agent/comp/healthplatform/issueregistry/def"
 	issuesmod "github.com/DataDog/datadog-agent/comp/healthplatform/issues"
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
@@ -15,7 +16,8 @@ import (
 
 // Requires defines the dependencies for the registry component.
 type Requires struct {
-	Config config.Component
+	Config         config.Component
+	SysProbeConfig sysprobeconfig.Component `optional:"true"`
 }
 
 type registryImpl struct {
@@ -25,7 +27,11 @@ type registryImpl struct {
 // New creates the issue registry, instantiating all self-registered modules.
 func New(reqs Requires) registrydef.Component {
 	r := issuesmod.NewRegistry()
-	for _, module := range issuesmod.GetAllModules(reqs.Config) {
+	deps := issuesmod.ModuleDeps{
+		Config:         reqs.Config,
+		SysProbeConfig: reqs.SysProbeConfig,
+	}
+	for _, module := range issuesmod.GetAllModules(deps) {
 		r.RegisterModule(module)
 	}
 	return &registryImpl{inner: r}

--- a/comp/healthplatform/issues/BUILD.bazel
+++ b/comp/healthplatform/issues/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
+        "//comp/core/hostname/hostnameinterface/def",
         "//comp/core/sysprobeconfig/def",
         "//comp/healthplatform/runner/def",
         "@com_github_datadog_agent_payload_v5//healthplatform",

--- a/comp/healthplatform/issues/BUILD.bazel
+++ b/comp/healthplatform/issues/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
+        "//comp/core/sysprobeconfig/def",
         "//comp/healthplatform/runner/def",
         "@com_github_datadog_agent_payload_v5//healthplatform",
     ],

--- a/comp/healthplatform/issues/admissionprobe/BUILD.bazel
+++ b/comp/healthplatform/issues/admissionprobe/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe",
     visibility = ["//visibility:public"],
     deps = [
-        "//comp/core/config",
         "//comp/healthplatform/issues",
         "//comp/healthplatform/runner/def",
         "@com_github_datadog_agent_payload_v5//healthplatform",
@@ -23,6 +22,7 @@ dd_agent_go_test(
     srcs = ["issue_test.go"],
     embed = [":admissionprobe"],
     deps = [
+        "//comp/healthplatform/issues",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/comp/healthplatform/issues/admissionprobe/issue_test.go
+++ b/comp/healthplatform/issues/admissionprobe/issue_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	healthplatform "github.com/DataDog/agent-payload/v5/healthplatform"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,7 +76,7 @@ func TestBuildIssue_Extra(t *testing.T) {
 }
 
 func TestNewModule(t *testing.T) {
-	m := NewModule(nil)
+	m := NewModule(issues.ModuleDeps{})
 	assert.Equal(t, IssueName, m.IssueName())
 	issue, err := m.BuildIssue(map[string]string{})
 	require.NoError(t, err)

--- a/comp/healthplatform/issues/admissionprobe/module.go
+++ b/comp/healthplatform/issues/admissionprobe/module.go
@@ -10,7 +10,6 @@ package admissionprobe
 
 import (
 	"github.com/DataDog/agent-payload/v5/healthplatform"
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 )
@@ -33,7 +32,7 @@ type admissionProbeModule struct {
 }
 
 // NewModule creates a new admission probe issue module.
-func NewModule(config.Component) issues.Module {
+func NewModule(issues.ModuleDeps) issues.Module {
 	return &admissionProbeModule{
 		template: &AdmissionProbeIssue{},
 	}

--- a/comp/healthplatform/issues/checkfailure/BUILD.bazel
+++ b/comp/healthplatform/issues/checkfailure/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure",
     visibility = ["//visibility:public"],
     deps = [
-        "//comp/core/config",
         "//comp/healthplatform/issues",
         "//comp/healthplatform/runner/def",
         "@com_github_datadog_agent_payload_v5//healthplatform",

--- a/comp/healthplatform/issues/checkfailure/module.go
+++ b/comp/healthplatform/issues/checkfailure/module.go
@@ -10,7 +10,6 @@ package checkfailure
 
 import (
 	"github.com/DataDog/agent-payload/v5/healthplatform"
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 )
@@ -32,7 +31,7 @@ type checkFailureModule struct {
 }
 
 // NewModule creates a new check failure issue module
-func NewModule(config.Component) issues.Module {
+func NewModule(issues.ModuleDeps) issues.Module {
 	return &checkFailureModule{
 		template: NewCheckFailureIssue(),
 	}

--- a/comp/healthplatform/issues/dockerpermissions/BUILD.bazel
+++ b/comp/healthplatform/issues/dockerpermissions/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions",
     visibility = ["//visibility:public"],
     deps = [
-        "//comp/core/config",
         "//comp/healthplatform/issues",
         "//comp/healthplatform/runner/def",
         "//pkg/template/text",

--- a/comp/healthplatform/issues/dockerpermissions/module.go
+++ b/comp/healthplatform/issues/dockerpermissions/module.go
@@ -9,7 +9,6 @@ package dockerpermissions
 
 import (
 	"github.com/DataDog/agent-payload/v5/healthplatform"
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 )
@@ -33,7 +32,7 @@ type dockerPermissionsModule struct {
 }
 
 // NewModule creates a new Docker permissions issue module
-func NewModule(config.Component) issues.Module {
+func NewModule(issues.ModuleDeps) issues.Module {
 	return &dockerPermissionsModule{
 		template: NewDockerPermissionIssue(),
 	}

--- a/comp/healthplatform/issues/invalidconfig/module.go
+++ b/comp/healthplatform/issues/invalidconfig/module.go
@@ -30,8 +30,8 @@ type invalidConfigModule struct {
 }
 
 // NewModule captures the config so the once-only startup check can read it.
-func NewModule(cfg config.Component) issues.Module {
-	return &invalidConfigModule{cfg: cfg, checker: newChecker(cfg)}
+func NewModule(deps issues.ModuleDeps) issues.Module {
+	return &invalidConfigModule{cfg: deps.Config, checker: newChecker(deps.Config)}
 }
 
 func (m *invalidConfigModule) IssueName() string {

--- a/comp/healthplatform/issues/invalidsysprobeconfig/BUILD.bazel
+++ b/comp/healthplatform/issues/invalidsysprobeconfig/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
+        "//comp/core/hostname/hostnameinterface/def",
         "//comp/core/sysprobeconfig/def",
         "//comp/healthplatform/issues",
         "//comp/healthplatform/runner/def",
@@ -31,6 +32,8 @@ dd_agent_go_test(
     embed = [":invalidsysprobeconfig"],
     deps = [
         "//comp/core/config",
+        "//comp/core/hostname/hostnameinterface/def",
+        "//comp/core/hostname/hostnameinterface/mock",
         "//comp/core/sysprobeconfig/mock",
         "//pkg/config/model",
         "@com_github_stretchr_testify//assert",

--- a/comp/healthplatform/issues/invalidsysprobeconfig/BUILD.bazel
+++ b/comp/healthplatform/issues/invalidsysprobeconfig/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "invalidsysprobeconfig",
+    srcs = [
+        "check.go",
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/invalidsysprobeconfig",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/core/sysprobeconfig/def",
+        "//comp/healthplatform/issues",
+        "//comp/healthplatform/runner/def",
+        "//pkg/config/model",
+        "//pkg/config/schema",
+        "//pkg/util/log",
+        "//pkg/util/scrubber",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@in_yaml_go_yaml_v3//:yaml",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)
+
+dd_agent_go_test(
+    name = "invalidsysprobeconfig_test",
+    srcs = ["invalidsysprobeconfig_test.go"],
+    embed = [":invalidsysprobeconfig"],
+    deps = [
+        "//comp/core/config",
+        "//comp/core/sysprobeconfig/mock",
+        "//pkg/config/model",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/comp/healthplatform/issues/invalidsysprobeconfig/check.go
+++ b/comp/healthplatform/issues/invalidsysprobeconfig/check.go
@@ -6,11 +6,14 @@
 package invalidsysprobeconfig
 
 import (
+	"context"
 	"fmt"
+	"hash/fnv"
 	"strconv"
 
 	"go.yaml.in/yaml/v3"
 
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	sysprobeconfig "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/def"
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -21,11 +24,21 @@ import (
 
 // checker validates the customer-provided system-probe config against the schema.
 type checker struct {
-	cfg sysprobeconfig.Component
+	cfg      sysprobeconfig.Component
+	hostname hostnameinterface.Component
 }
 
-func newChecker(cfg sysprobeconfig.Component) *checker {
-	return &checker{cfg: cfg}
+func newChecker(cfg sysprobeconfig.Component, hostname hostnameinterface.Component) *checker {
+	return &checker{cfg: cfg, hostname: hostname}
+}
+
+// instanceIssueID scopes IssueID to this host and config file so the recommendations
+// service (which keys on orgID + issueID, ignoring hostname) keeps per-host violations
+// distinct instead of collapsing them into a single case.
+func (c *checker) instanceIssueID() string {
+	h := fnv.New64a()
+	fmt.Fprintf(h, "%s\x00%s", c.hostname.GetSafe(context.Background()), c.cfg.ConfigFileUsed())
+	return fmt.Sprintf("%s:%016x", IssueID, h.Sum64())
 }
 
 func (c *checker) Run() ([]runnerdef.IssueReport, error) {
@@ -51,7 +64,7 @@ func (c *checker) validate() ([]runnerdef.IssueReport, error) {
 	}
 	return []runnerdef.IssueReport{
 		{
-			IssueID:   IssueID,
+			IssueID:   c.instanceIssueID(),
 			IssueName: IssueName,
 			Source:    "system-probe",
 			Context: func() map[string]string {

--- a/comp/healthplatform/issues/invalidsysprobeconfig/check.go
+++ b/comp/healthplatform/issues/invalidsysprobeconfig/check.go
@@ -1,0 +1,119 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package invalidsysprobeconfig
+
+import (
+	"fmt"
+	"strconv"
+
+	"go.yaml.in/yaml/v3"
+
+	sysprobeconfig "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/def"
+	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/config/schema"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
+)
+
+// checker validates the customer-provided system-probe config against the schema.
+type checker struct {
+	cfg sysprobeconfig.Component
+}
+
+func newChecker(cfg sysprobeconfig.Component) *checker {
+	return &checker{cfg: cfg}
+}
+
+func (c *checker) Run() ([]runnerdef.IssueReport, error) {
+	return c.validate()
+}
+
+func (c *checker) validate() ([]runnerdef.IssueReport, error) {
+	raw := customerConfig(c.cfg)
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	normalized, err := normalizeForSchema(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalidsysprobeconfig: normalize config: %w", err)
+	}
+	errs, schemaErr := schema.ValidateSystemProbeConfig(normalized)
+	if schemaErr != nil {
+		pkglog.Warnf("invalidsysprobeconfig: schema validator unavailable; skipping check: %v", schemaErr)
+		return nil, schemaErr
+	}
+	if len(errs) == 0 {
+		return nil, nil
+	}
+	return []runnerdef.IssueReport{
+		{
+			IssueID:   IssueID,
+			IssueName: IssueName,
+			Source:    "system-probe",
+			Context: func() map[string]string {
+				ctx := map[string]string{
+					contextKeyConfigPath: c.cfg.ConfigFileUsed(),
+					contextKeyErrorCount: strconv.Itoa(len(errs)),
+				}
+				for i, e := range errs {
+					ctx[contextErrorKey(i)] = e
+				}
+				return ctx
+			}(),
+		},
+	}, nil
+}
+
+// customerConfig returns only the values the customer set in the system-probe config
+// (file, env, CLI, ...etc). It merges the source layers in priority order, skipping defaults,
+// secrets, and the agent-runtime layer that Adjust() writes to so the schema sees the
+// customer's actual configuration, not values rewritten by post-load processing.
+func customerConfig(cfg sysprobeconfig.Component) map[string]any {
+	bySource := cfg.AllSettingsBySource()
+	merged := map[string]any{}
+	for _, src := range model.Sources { // ascending priority: higher layers win
+		switch src {
+		case model.SourceDefault, model.SourceSecret, model.SourceAgentRuntime:
+			continue
+		}
+		if layer, ok := bySource[src].(map[string]any); ok {
+			deepMerge(merged, layer)
+		}
+	}
+	return merged
+}
+
+// deepMerge recursively merges src into dst: nested maps are merged, everything else overwrites.
+func deepMerge(dst, src map[string]any) {
+	for k, v := range src {
+		if sv, ok := v.(map[string]any); ok {
+			if dv, ok := dst[k].(map[string]any); ok {
+				deepMerge(dv, sv)
+				continue
+			}
+		}
+		dst[k] = v
+	}
+}
+
+// normalizeForSchema coerces a Go-native config map into JSON-native types via
+// a YAML round-trip. ScrubYaml strips any accidental secret-like values
+func normalizeForSchema(in map[string]any) (map[string]any, error) {
+	b, err := yaml.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+	scrubbed, err := scrubber.ScrubYaml(b)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := yaml.Unmarshal(scrubbed, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/comp/healthplatform/issues/invalidsysprobeconfig/invalidsysprobeconfig_test.go
+++ b/comp/healthplatform/issues/invalidsysprobeconfig/invalidsysprobeconfig_test.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package invalidsysprobeconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	sysprobeconfigmock "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+// A valid system-probe setting passes the schema → no report.
+func TestCheck_HealthyConfigReturnsNil(t *testing.T) {
+	reports, err := newChecker(sysprobeconfigmock.NewMock(t)).Run()
+	require.NoError(t, err)
+	assert.Empty(t, reports)
+}
+
+// A string in an integer-typed field violates the schema → one report.
+func TestCheck_SchemaViolationProducesReport(t *testing.T) {
+	cfg := sysprobeconfigmock.NewMockWithOverrides(t, map[string]interface{}{
+		"system_probe_config.health_port": "not-an-integer",
+	})
+	reports, err := newChecker(cfg).Run()
+	require.NoError(t, err)
+	require.Len(t, reports, 1)
+	assert.Equal(t, IssueID, reports[0].IssueID)
+	assert.Equal(t, IssueName, reports[0].IssueName)
+	assert.Equal(t, "system-probe", reports[0].Source)
+}
+
+// The core guarantee: we validate the customer's config, not values that Adjust() rewrites
+// at the agent-runtime layer. A bad file value must survive the merge and be seen by the check.
+func TestCustomerConfig_SkipsAgentRuntime(t *testing.T) {
+	cfg := sysprobeconfigmock.NewMock(t)
+	cfg.Set("system_probe_config.health_port", "not-an-integer", model.SourceFile) // customer's value
+	cfg.Set("system_probe_config.health_port", 5558, model.SourceAgentRuntime)     // Adjust's repair
+
+	got := customerConfig(cfg)
+	spc, _ := got["system_probe_config"].(map[string]any)
+	require.NotNil(t, spc)
+	assert.Equal(t, "not-an-integer", spc["health_port"], "the customer's file value must survive, not Adjust's runtime repair")
+}
+
+// Locks the dedup contract that distinguishes this issue from invalid-config.
+func TestBuildIssue_LocksContract(t *testing.T) {
+	issue, err := InvalidSysprobeConfigIssue{}.BuildIssue(map[string]string{
+		contextKeyConfigPath: "/etc/datadog-agent/system-probe.yaml",
+		contextKeyErrorCount: "1",
+		contextErrorKey(0):   "at '/system_probe_config/health_port': got string, want integer",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, IssueName, issue.GetIssueName())
+	assert.Equal(t, "system-probe", issue.GetLocation())
+	assert.Equal(t, []string{"config", "schema", "system-probe"}, issue.GetTags())
+	assert.Contains(t, issue.GetTitle(), "Datadog System-Probe Configuration")
+	assert.Contains(t, issue.GetTitle(), "system-probe.yaml")
+}
+
+// Without system-probe config the startup check must NOT register, or the bundle would
+// resolve a real persisted issue without ever validating.
+func TestBuiltInStartupHealthCheck_SkippedWhenSysprobeAbsent(t *testing.T) {
+	m := &invalidSysprobeConfigModule{datadog: config.NewMock(t), checker: newChecker(nil)}
+	assert.Nil(t, m.BuiltInStartupHealthCheck())
+}
+
+// The check is gated behind health_platform.invalidsysprobeconfig_check.enabled.
+func TestBuiltInStartupHealthCheck_GatedByFlag(t *testing.T) {
+	sp := sysprobeconfigmock.NewMockWithOverrides(t, map[string]interface{}{
+		"system_probe_config.health_port": "not-an-integer",
+	})
+	dd := config.NewMock(t)
+	m := &invalidSysprobeConfigModule{datadog: dd, checker: newChecker(sp)}
+
+	// Enabled (default) → violation surfaces.
+	reports, err := m.BuiltInStartupHealthCheck().Fn()
+	require.NoError(t, err)
+	require.Len(t, reports, 1)
+
+	// Disabled → suppressed.
+	dd.Set("health_platform.invalidsysprobeconfig_check.enabled", false, model.SourceAgentRuntime)
+	reports, err = m.BuiltInStartupHealthCheck().Fn()
+	require.NoError(t, err)
+	assert.Empty(t, reports)
+}

--- a/comp/healthplatform/issues/invalidsysprobeconfig/invalidsysprobeconfig_test.go
+++ b/comp/healthplatform/issues/invalidsysprobeconfig/invalidsysprobeconfig_test.go
@@ -12,13 +12,20 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
+	hostnamemock "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/mock"
 	sysprobeconfigmock "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
+func testHostname(name string) hostnameinterface.Component {
+	hn, _ := hostnamemock.NewMock(hostnamemock.MockHostname(name))
+	return hn
+}
+
 // A valid system-probe setting passes the schema → no report.
 func TestCheck_HealthyConfigReturnsNil(t *testing.T) {
-	reports, err := newChecker(sysprobeconfigmock.NewMock(t)).Run()
+	reports, err := newChecker(sysprobeconfigmock.NewMock(t), testHostname("h")).Run()
 	require.NoError(t, err)
 	assert.Empty(t, reports)
 }
@@ -28,12 +35,27 @@ func TestCheck_SchemaViolationProducesReport(t *testing.T) {
 	cfg := sysprobeconfigmock.NewMockWithOverrides(t, map[string]interface{}{
 		"system_probe_config.health_port": "not-an-integer",
 	})
-	reports, err := newChecker(cfg).Run()
+	reports, err := newChecker(cfg, testHostname("h")).Run()
 	require.NoError(t, err)
 	require.Len(t, reports, 1)
-	assert.Equal(t, IssueID, reports[0].IssueID)
+	assert.Regexp(t, `^invalid-system-probe-config:[0-9a-f]{16}$`, reports[0].IssueID)
 	assert.Equal(t, IssueName, reports[0].IssueName)
 	assert.Equal(t, "system-probe", reports[0].Source)
+}
+
+// The reported IssueID is scoped per host so the recommendations service keeps each host's
+// violation distinct instead of collapsing them into one case.
+func TestInstanceIssueID_UniquePerHost(t *testing.T) {
+	cfg := sysprobeconfigmock.NewMockWithOverrides(t, map[string]interface{}{
+		"system_probe_config.health_port": "not-an-integer",
+	})
+	a, err := newChecker(cfg, testHostname("host-a")).Run()
+	require.NoError(t, err)
+	b, err := newChecker(cfg, testHostname("host-b")).Run()
+	require.NoError(t, err)
+	require.Len(t, a, 1)
+	require.Len(t, b, 1)
+	assert.NotEqual(t, a[0].IssueID, b[0].IssueID, "issue id must differ per host")
 }
 
 // The core guarantee: we validate the customer's config, not values that Adjust() rewrites
@@ -67,7 +89,7 @@ func TestBuildIssue_LocksContract(t *testing.T) {
 // Without system-probe config the startup check must NOT register, or the bundle would
 // resolve a real persisted issue without ever validating.
 func TestBuiltInStartupHealthCheck_SkippedWhenSysprobeAbsent(t *testing.T) {
-	m := &invalidSysprobeConfigModule{datadog: config.NewMock(t), checker: newChecker(nil)}
+	m := &invalidSysprobeConfigModule{datadog: config.NewMock(t), checker: newChecker(nil, nil)}
 	assert.Nil(t, m.BuiltInStartupHealthCheck())
 }
 
@@ -77,7 +99,7 @@ func TestBuiltInStartupHealthCheck_GatedByFlag(t *testing.T) {
 		"system_probe_config.health_port": "not-an-integer",
 	})
 	dd := config.NewMock(t)
-	m := &invalidSysprobeConfigModule{datadog: dd, checker: newChecker(sp)}
+	m := &invalidSysprobeConfigModule{datadog: dd, checker: newChecker(sp, testHostname("h"))}
 
 	// Enabled (default) → violation surfaces.
 	reports, err := m.BuiltInStartupHealthCheck().Fn()

--- a/comp/healthplatform/issues/invalidsysprobeconfig/issue.go
+++ b/comp/healthplatform/issues/invalidsysprobeconfig/issue.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package invalidsysprobeconfig
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	contextKeyConfigPath = "config_path"
+	contextKeyErrors     = "errors"
+	contextKeyErrorCount = "error_count"
+	contextKeyImpact     = "impact"
+)
+
+// contextErrorKey returns the Context key for the i-th error line.
+func contextErrorKey(i int) string {
+	return "error." + strconv.Itoa(i)
+}
+
+// InvalidSysprobeConfigIssue is the template for "invalid-system-probe-config" issues.
+type InvalidSysprobeConfigIssue struct{}
+
+// BuildIssue decodes the IssueReport.Context and builds the proto Issue.
+func (InvalidSysprobeConfigIssue) BuildIssue(ctx map[string]string) (*healthplatform.Issue, error) {
+	path := ctx[contextKeyConfigPath]
+	if path == "" {
+		path = "(unknown path)"
+	}
+	count, _ := strconv.Atoi(ctx[contextKeyErrorCount])
+
+	errLines := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		if v := ctx[contextErrorKey(i)]; v != "" {
+			errLines = append(errLines, v)
+		}
+	}
+
+	suffix := ""
+	if count != 1 {
+		suffix = "s"
+	}
+	desc := fmt.Sprintf("Found %d schema violation%s in %s", count, suffix, path)
+	if len(errLines) > 0 {
+		desc += ": " + strings.Join(errLines, "; ")
+	} else {
+		desc += "."
+	}
+
+	// Group messages by JSON path, as []any so structpb can consume them directly.
+	errMap := make(map[string]any, len(errLines))
+	for _, line := range errLines {
+		// Schema errors have the form: at '<path>': <message>
+		// Strip the "at '" prefix and trailing "'" to get a bare JSON path.
+		before, msg, _ := strings.Cut(line, ": ")
+		errPath := strings.TrimSuffix(strings.TrimPrefix(before, "at '"), "'")
+		msgs, _ := errMap[errPath].([]any)
+		errMap[errPath] = append(msgs, msg)
+	}
+
+	extra, _ := structpb.NewStruct(map[string]any{
+		contextKeyConfigPath: path,
+		contextKeyErrorCount: count,
+		contextKeyErrors:     errMap,
+		contextKeyImpact:     "The Datadog system-probe may apply defaults for incorrectly-typed fields and may not behave as configured.",
+	})
+
+	return &healthplatform.Issue{
+		IssueName:   IssueName,
+		Title:       fmt.Sprintf("Datadog System-Probe Configuration Has %d Schema Violation%s in %s", count, suffix, filepath.Base(path)),
+		Description: desc,
+		Category:    "configuration",
+		Location:    "system-probe",
+		Severity:    healthplatform.IssueSeverity_ISSUE_SEVERITY_MEDIUM,
+		Source:      "config",
+		Extra:       extra,
+		Tags:        []string{"config", "schema", "system-probe"},
+		Remediation: &healthplatform.Remediation{
+			Summary: "Fix each schema violation in the system-probe configuration, then restart the Datadog Agent.",
+			Steps: []*healthplatform.RemediationStep{
+				{Order: 1, Text: fmt.Sprintf("Open %s in an editor.", path)},
+				{Order: 2, Text: "Fix each violation listed in the description."},
+				{Order: 3, Text: "Restart the Datadog Agent."},
+				{Order: 4, Text: "Run `datadog-agent diagnose` to confirm the configuration is now valid."},
+			},
+		},
+	}, nil
+}

--- a/comp/healthplatform/issues/invalidsysprobeconfig/module.go
+++ b/comp/healthplatform/issues/invalidsysprobeconfig/module.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package invalidsysprobeconfig reports system-probe.yaml schema violations through the Agent Health Platform.
+package invalidsysprobeconfig
+
+import (
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
+)
+
+const (
+	// IssueName is the human-readable issue name for system-probe configuration-schema violations.
+	IssueName = "Invalid System-Probe Config"
+	// IssueID is the stable instance identifier / registry key (kebab-case).
+	IssueID = "invalid-system-probe-config"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+type invalidSysprobeConfigModule struct {
+	datadog config.Component // holds the feature flag (system-probe config has no health_platform keys)
+	checker *checker
+}
+
+// NewModule captures the configs so the once-only startup check can read them.
+func NewModule(deps issues.ModuleDeps) issues.Module {
+	return &invalidSysprobeConfigModule{datadog: deps.Config, checker: newChecker(deps.SysProbeConfig)}
+}
+
+func (m *invalidSysprobeConfigModule) IssueName() string {
+	return IssueName
+}
+
+func (m *invalidSysprobeConfigModule) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	return InvalidSysprobeConfigIssue{}.BuildIssue(context)
+}
+
+// BuiltInPeriodicHealthCheck returns nil as schema validation runs only at startup
+func (m *invalidSysprobeConfigModule) BuiltInPeriodicHealthCheck() *runnerdef.BuiltInPeriodicHealthCheck {
+	return nil
+}
+
+// BuiltInStartupHealthCheck runs system-probe schema validation once at agent startup.
+// It returns nil when system-probe config isn't bundled (e.g. commands that don't load it),
+// so the bundle doesn't resolve a real persisted issue without ever validating.
+func (m *invalidSysprobeConfigModule) BuiltInStartupHealthCheck() *runnerdef.BuiltInHealthCheck {
+	if m.checker.cfg == nil {
+		return nil
+	}
+	return &runnerdef.BuiltInHealthCheck{
+		Source: "system-probe",
+		Fn: func() ([]runnerdef.IssueReport, error) {
+			if !m.datadog.GetBool("health_platform.invalidsysprobeconfig_check.enabled") {
+				return nil, nil
+			}
+			return m.checker.Run()
+		},
+	}
+}

--- a/comp/healthplatform/issues/invalidsysprobeconfig/module.go
+++ b/comp/healthplatform/issues/invalidsysprobeconfig/module.go
@@ -32,7 +32,7 @@ type invalidSysprobeConfigModule struct {
 
 // NewModule captures the configs so the once-only startup check can read them.
 func NewModule(deps issues.ModuleDeps) issues.Module {
-	return &invalidSysprobeConfigModule{datadog: deps.Config, checker: newChecker(deps.SysProbeConfig)}
+	return &invalidSysprobeConfigModule{datadog: deps.Config, checker: newChecker(deps.SysProbeConfig, deps.Hostname)}
 }
 
 func (m *invalidSysprobeConfigModule) IssueName() string {

--- a/comp/healthplatform/issues/module.go
+++ b/comp/healthplatform/issues/module.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/agent-payload/v5/healthplatform"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	sysprobeconfig "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/def"
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 )
@@ -28,6 +29,7 @@ import (
 type ModuleDeps struct {
 	Config         config.Component
 	SysProbeConfig sysprobeconfig.Component
+	Hostname       hostnameinterface.Component
 }
 
 // ModuleFactory is a function that creates a new Module instance

--- a/comp/healthplatform/issues/module.go
+++ b/comp/healthplatform/issues/module.go
@@ -19,11 +19,19 @@ import (
 
 	"github.com/DataDog/agent-payload/v5/healthplatform"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	sysprobeconfig "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/def"
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 )
 
+// ModuleDeps carries the dependencies available to every issue module.
+// SysProbeConfig is optional: it is nil in commands that don't bundle system-probe config.
+type ModuleDeps struct {
+	Config         config.Component
+	SysProbeConfig sysprobeconfig.Component
+}
+
 // ModuleFactory is a function that creates a new Module instance
-type ModuleFactory func(config config.Component) Module
+type ModuleFactory func(deps ModuleDeps) Module
 
 var (
 	moduleFactories   []ModuleFactory
@@ -40,13 +48,13 @@ func RegisterModuleFactory(factory ModuleFactory) {
 
 // GetAllModules creates and returns all registered modules.
 // Each call creates new module instances.
-func GetAllModules(config config.Component) []Module {
+func GetAllModules(deps ModuleDeps) []Module {
 	moduleFactoriesMu.Lock()
 	defer moduleFactoriesMu.Unlock()
 
 	modules := make([]Module, 0, len(moduleFactories))
 	for _, factory := range moduleFactories {
-		modules = append(modules, factory(config))
+		modules = append(modules, factory(deps))
 	}
 	return modules
 }

--- a/comp/healthplatform/issues/rofspermissions/module.go
+++ b/comp/healthplatform/issues/rofspermissions/module.go
@@ -38,10 +38,10 @@ type rofsPermissionsModule struct {
 }
 
 // NewModule creates a new ROFS permissions issue module
-func NewModule(conf config.Component) issues.Module {
+func NewModule(deps issues.ModuleDeps) issues.Module {
 	return &rofsPermissionsModule{
 		template: NewRofsPermissionIssue(),
-		conf:     conf,
+		conf:     deps.Config,
 	}
 }
 

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8327,6 +8327,14 @@ properties:
             node_type: setting
             type: boolean
             default: true
+      invalidsysprobeconfig_check:
+        node_type: section
+        type: object
+        properties:
+          enabled:
+            node_type: setting
+            type: boolean
+            default: true
       persist_on_kubernetes:
         node_type: setting
         type: boolean

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1237,6 +1237,7 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("health_platform.persist_on_kubernetes", false)
 	config.BindEnvAndSetDefault("health_platform.forwarder.interval", 15*time.Minute)
 	config.BindEnvAndSetDefault("health_platform.invalidconfig_check.enabled", true)
+	config.BindEnvAndSetDefault("health_platform.invalidsysprobeconfig_check.enabled", true)
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
 	config.BindEnvAndSetDefault("win_skip_com_init", false)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)

--- a/releasenotes/notes/agent-health-invalid-system-probe-config-08538ed0f07a7b62.yaml
+++ b/releasenotes/notes/agent-health-invalid-system-probe-config-08538ed0f07a7b62.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On startup the Datadog Agent now validates the system-probe configuration against its
+    schema and reports any violations through the Agent Health pipeline. Only the values the
+    customer set in the configuration are validated. This can be disabled with
+    ``health_platform.invalidsysprobeconfig_check.enabled``.


### PR DESCRIPTION
### What does this PR do?
On agent startup, we now validate the customers config of the system-probe using its schema, and then raise all validation issues with the config to the agent-health platform. Gated behind `health_platform.invalidsysprobeconfig_check.enabled`. Mirrors the existing invalid-config check.

### Motivation
By raising config errors to the users, they can easily and better find issues with their config, preventing future issues.

### Describe how you validated your changes
run the agent and sysprobe with an invalid config:
I used max_tracked_connections because the agent's Adjust() "repairs" it at runtime so it proves we validate what the user wrote, not the post-adjusted value.
`system-probe.yaml`:
```
system_probe_config:
  max_tracked_connections: 'not-a-number'
```
run the agent:
```
dda inv agent.build --build-exclude=systemd

./bin/agent/agent run -c dev/dist/datadog.yaml --sysprobecfgpath dev/dist 2>&1 \
  | grep --color=always --line-buffered -iE 'health.?platform|system-probe|schema violation|cleared issue|sent.*report|failed to send'
```
check logs:
```
 CORE | INFO | (comp/healthplatform/store/impl/store.go:538 in handleIssueStateChange) | Health platform: NEW issue from config: Datadog System-Probe Configuration Has 1 Schema Violation in system-probe.yaml (ISSUE_SEVERITY_MEDIUM)
```
confirm the exact violation via diagnose:
`./bin/agent/agent diagnose show-payload health-issues -c dev/dist/datadog.yaml`
check fleet:

<img width="1052" height="89" alt="image" src="https://github.com/user-attachments/assets/69570429-97ec-41f8-8ebb-8838417ba676" />



### Additional Notes
