### PR TITLE
stickiness for checks rebal

### DIFF
--- a/pkg/clusteragent/clusterchecks/checks_distribution.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution.go
@@ -61,7 +61,11 @@ func newChecksDistribution(workersPerRunner map[string]int) checksDistribution {
 // is not among the runners with the lowest utilization, it gives precedence to
 // the runner with the lowest number of checks deployed. excludeRunner can be set
 // to avoid assigning a check to a specific runner.
-func (distribution *checksDistribution) leastBusyRunner(preferredRunner string, excludeRunner string) string {
+//
+// stickinessFactor adds a discount to preferredRunner's effective utilization
+// before comparison: discount = (workersNeeded + stickinessFactor) / runner.Workers.
+// This raises the bar a check must clear before being moved off its current runner.
+func (distribution *checksDistribution) leastBusyRunner(preferredRunner string, excludeRunner string, workersNeeded float64, stickinessFactor float64) string {
 	leastBusyRunner := ""
 	minUtilization := 0.0
 	numChecksLeastBusyRunner := 0
@@ -73,6 +77,17 @@ func (distribution *checksDistribution) leastBusyRunner(preferredRunner string, 
 		}
 
 		runnerUtilization := runnerStatus.utilization()
+
+		// Apply stickiness discount to the check's current runner
+		if runnerName == preferredRunner && stickinessFactor > 0 && runnerStatus.Workers > 0 {
+			// Use a constant discount + scale on the check's own size (to help larger checks stick)
+			discount := workersNeeded + stickinessFactor
+			runnerUtilization -= discount
+		}
+
+		// Note: in theory the discount becomes the runner utilization difference
+		// we accept as tolerable between busiest and least busy runner.
+
 		runnerNumChecks := runnerStatus.NumChecks
 
 		selectRunner := (leastBusyRunner == "") ||
@@ -90,8 +105,8 @@ func (distribution *checksDistribution) leastBusyRunner(preferredRunner string, 
 	return leastBusyRunner
 }
 
-func (distribution *checksDistribution) addToLeastBusy(checkID string, workersNeeded float64, preferredRunner string, excludeRunner string) {
-	leastBusy := distribution.leastBusyRunner(preferredRunner, excludeRunner)
+func (distribution *checksDistribution) addToLeastBusy(checkID string, workersNeeded float64, preferredRunner string, excludeRunner string, stickinessFactor float64) {
+	leastBusy := distribution.leastBusyRunner(preferredRunner, excludeRunner, workersNeeded, stickinessFactor)
 	if leastBusy == "" {
 		return
 	}

--- a/pkg/clusteragent/clusterchecks/checks_distribution_test.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution_test.go
@@ -153,7 +153,86 @@ func TestAddToLeastBusy(t *testing.T) {
 				distribution.addCheck(checkID, checkStatus.WorkersNeeded, checkStatus.Runner)
 			}
 
-			distribution.addToLeastBusy("newCheck", 10, test.preferredRunner, "")
+			distribution.addToLeastBusy("newCheck", 10, test.preferredRunner, "", 0)
+
+			assert.Equal(t, test.expectedPlacement, distribution.runnerForCheck("newCheck"))
+		})
+	}
+}
+
+func TestAddToLeastBusyWithStickiness(t *testing.T) {
+	tests := []struct {
+		name              string
+		existingRunners   map[string]int
+		existingChecks    map[string]CheckStatus
+		checkWorkersNeeded float64
+		preferredRunner   string
+		stickinessFactor  float64
+		expectedPlacement string
+	}{
+		{
+			name: "stickiness keeps check on current runner when gap is small",
+			existingRunners: map[string]int{
+				"runner1": 10,
+				"runner2": 10,
+			},
+			existingChecks: map[string]CheckStatus{
+				// runner1: 5/10 = 0.5 util, runner2: 4/10 = 0.4 util
+				"check1": {WorkersNeeded: 5, Runner: "runner1"},
+				"check2": {WorkersNeeded: 4, Runner: "runner2"},
+			},
+			checkWorkersNeeded: 1,
+			preferredRunner:    "runner1",
+			// discount = (1 + 1.5) / 10 = 0.25, effective runner1 util = 0.5 - 0.25 = 0.25
+			// runner2 util = 0.4, so runner1 effective (0.25) < runner2 (0.4) → stays on runner1
+			stickinessFactor:  1.5,
+			expectedPlacement: "runner1",
+		},
+		{
+			name: "stickiness overridden when gap exceeds discount",
+			existingRunners: map[string]int{
+				"runner1": 10,
+				"runner2": 10,
+			},
+			existingChecks: map[string]CheckStatus{
+				// runner1: 8/10 = 0.8 util, runner2: 1/10 = 0.1 util
+				"check1": {WorkersNeeded: 8, Runner: "runner1"},
+				"check2": {WorkersNeeded: 1, Runner: "runner2"},
+			},
+			checkWorkersNeeded: 1,
+			preferredRunner:    "runner1",
+			// discount = (1 + 1.5) / 10 = 0.25, effective runner1 util = 0.8 - 0.25 = 0.55
+			// runner2 util = 0.1, so runner2 (0.1) < runner1 effective (0.55) → moves to runner2
+			stickinessFactor:  1.5,
+			expectedPlacement: "runner2",
+		},
+		{
+			name: "zero stickiness factor behaves like no stickiness",
+			existingRunners: map[string]int{
+				"runner1": 10,
+				"runner2": 10,
+			},
+			existingChecks: map[string]CheckStatus{
+				// runner1: 5/10 = 0.5 util, runner2: 4/10 = 0.4 util
+				"check1": {WorkersNeeded: 5, Runner: "runner1"},
+				"check2": {WorkersNeeded: 4, Runner: "runner2"},
+			},
+			checkWorkersNeeded: 1,
+			preferredRunner:    "runner1",
+			stickinessFactor:   0,
+			expectedPlacement:  "runner2", // runner2 is strictly less busy, no discount applied
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			distribution := newChecksDistribution(test.existingRunners)
+
+			for checkID, checkStatus := range test.existingChecks {
+				distribution.addCheck(checkID, checkStatus.WorkersNeeded, checkStatus.Runner)
+			}
+
+			distribution.addToLeastBusy("newCheck", test.checkWorkersNeeded, test.preferredRunner, "", test.stickinessFactor)
 
 			assert.Equal(t, test.expectedPlacement, distribution.runnerForCheck("newCheck"))
 		})

--- a/pkg/clusteragent/clusterchecks/dispatcher_isolate.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_isolate.go
@@ -50,6 +50,7 @@ func (d *dispatcher) isolateCheck(isolateCheckID string) types.IsolateResponse {
 			workersNeededForCheck,
 			runnerForCheck,
 			isolateNode,
+			0, // no stickiness during forced isolation
 		)
 	}
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -41,6 +41,7 @@ type dispatcher struct {
 	advancedDispatching              atomic.Bool
 	excludedChecks                   map[string]struct{}
 	excludedChecksFromDispatching    map[string]struct{}
+	stickinessFactor                 float64
 	rebalancingPeriod                time.Duration
 	ksmSharding                      *ksmShardingManager
 	ksmShardingMutex                 sync.Mutex          // Protects ksmShardedConfigs
@@ -54,6 +55,7 @@ func newDispatcher(tagger tagger.Component) *dispatcher {
 	}
 	d.nodeExpirationSeconds = pkgconfigsetup.Datadog().GetInt64("cluster_checks.node_expiration_timeout")
 	d.unscheduledCheckThresholdSeconds = pkgconfigsetup.Datadog().GetInt64("cluster_checks.unscheduled_check_threshold")
+	d.stickinessFactor = pkgconfigsetup.Datadog().GetFloat64("cluster_checks.rebalance_stickiness_factor")
 
 	if d.unscheduledCheckThresholdSeconds < d.nodeExpirationSeconds {
 		log.Warnf("The unscheduled_check_threshold value should be larger than node_expiration_timeout, setting it to the same value")

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -342,6 +342,7 @@ func (d *dispatcher) rebalanceUsingUtilization(force bool) []types.RebalanceResp
 				currentChecksDistribution.workersNeededForCheck(checkID),
 				currentChecksDistribution.runnerForCheck(checkID),
 				"",
+				d.stickinessFactor,
 			)
 		}
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -1648,6 +1648,102 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 	assert.Empty(t, checksMoved)
 }
 
+func TestRebalanceUsingUtilizationStickinessFactor(t *testing.T) {
+	// Scenario:
+	//   node1: checkA1 (9000ms → 0.6 workers) + checkA2 (6000ms → 0.4 workers) — heavy runner
+	//   node2: checkB1 (1500ms → 0.1 workers) — light runner
+	//
+	// The default check interval is 15s, so workersNeeded = execTime / 15000.
+	//
+	// With stickinessFactor=0 the utilization gap is large enough that rebalancing is
+	// worth it and checkA2 moves from node1 to node2.
+	//
+	// With stickinessFactor=5 the discount applied to node1's effective utilization
+	// is large enough to keep checkA2 on node1 so the proposed distribution equals
+	// the current one, so no moves happen.
+	tests := []struct {
+		name             string
+		stickinessFactor float64
+		checkA2OnNode1   bool
+	}{
+		{
+			name:             "no stickiness: checkA2 moves to balance utilization",
+			stickinessFactor: 0,
+			checkA2OnNode1:   false,
+		},
+		{
+			name:             "stickiness factor 5: checkA2 stays on current runner",
+			stickinessFactor: 5,
+			checkA2OnNode1:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeTagger := taggerfxmock.SetupFakeTagger(t)
+			testDispatcher := newDispatcher(fakeTagger)
+			testDispatcher.advancedDispatching.Store(true)
+			testDispatcher.stickinessFactor = tc.stickinessFactor
+
+			mockClient := &rebalanceTestClcRunnerClient{
+				testStats: make(map[string]types.CLCRunnersStats),
+			}
+			testDispatcher.clcRunnersClient = mockClient
+
+			testDispatcher.store.active = true
+			testDispatcher.store.nodes["node1"] = newNodeStore("node1", "10.0.0.1")
+			testDispatcher.store.nodes["node1"].workers = pkgconfigsetup.DefaultNumWorkers
+			testDispatcher.store.nodes["node2"] = newNodeStore("node2", "10.0.0.2")
+			testDispatcher.store.nodes["node2"].workers = pkgconfigsetup.DefaultNumWorkers
+
+			node1Stats := types.CLCRunnersStats{
+				"checkA1": {AverageExecutionTime: 9000, IsClusterCheck: true}, // 0.6 workers
+				"checkA2": {AverageExecutionTime: 6000, IsClusterCheck: true}, // 0.4 workers
+			}
+			node2Stats := types.CLCRunnersStats{
+				"checkB1": {AverageExecutionTime: 1500, IsClusterCheck: true}, // 0.1 workers
+			}
+			testDispatcher.store.nodes["node1"].clcRunnerStats = node1Stats
+			testDispatcher.store.nodes["node2"].clcRunnerStats = node2Stats
+			mockClient.testStats["10.0.0.1"] = node1Stats
+			mockClient.testStats["10.0.0.2"] = node2Stats
+
+			testDispatcher.store.idToDigest = map[checkid.ID]string{
+				"checkA1": "digestA1",
+				"checkA2": "digestA2",
+				"checkB1": "digestB1",
+			}
+			testDispatcher.store.digestToConfig = map[string]integration.Config{
+				"digestA1": {},
+				"digestA2": {},
+				"digestB1": {},
+			}
+			testDispatcher.store.digestToNode = map[string]string{
+				"digestA1": "node1",
+				"digestA2": "node1",
+				"digestB1": "node2",
+			}
+
+			testDispatcher.rebalanceUsingUtilization(false)
+
+			requireNotLocked(t, testDispatcher.store)
+
+			if tc.checkA2OnNode1 {
+				assert.Contains(t, testDispatcher.store.nodes["node1"].clcRunnerStats, "checkA2", "checkA2 should stay on node1 with stickiness")
+				assert.NotContains(t, testDispatcher.store.nodes["node2"].clcRunnerStats, "checkA2", "checkA2 should not move to node2 with stickiness")
+			} else {
+				assert.NotContains(t, testDispatcher.store.nodes["node1"].clcRunnerStats, "checkA2", "checkA2 should have moved off node1")
+				assert.Contains(t, testDispatcher.store.nodes["node2"].clcRunnerStats, "checkA2", "checkA2 should have moved to node2")
+			}
+
+			// checkA1 always stays on node1 (placed first into empty runners, preferred wins the tie)
+			assert.Contains(t, testDispatcher.store.nodes["node1"].clcRunnerStats, "checkA1")
+			// checkB1 always stays on node2
+			assert.Contains(t, testDispatcher.store.nodes["node2"].clcRunnerStats, "checkB1")
+		})
+	}
+}
+
 func TestRebalanceIsWorthIt(t *testing.T) {
 	workersPerRunner := map[string]int{
 		"runner1": 3,

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -609,6 +609,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", true)
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_with_utilization", true)
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_percentage_improvement", 10) // Experimental. Subject to change. Rebalance only if the distribution found improves the current one by this.
+	config.BindEnvAndSetDefault("cluster_checks.rebalance_stickiness_factor", 0.0) // Experimental. Subject to change. Fixed worker-unit bonus added to a check's own workersNeeded to discount its current runner's utilization before considering a move. 0 disables stickiness.
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks_from_dispatching", []string{})


### PR DESCRIPTION
### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes

When creating a new distribution, this add some bias to keep checks on their pre-existing randomly assigned node. We define a stickiness factor. This is the amount of discount we give to a check when it's being assigned onto it's previous node. We can also think of this as the maximum drift that we can accept between the busiest and least busy runner.

For instance, if the stickiness factor is set to 5, we could send up with an allocation on each node that work sums to [100.01, 102.30, 104.95, 103.23] even if we have actually thousands of checks that are of the size <0.1 that could theoretically be moved around to make everything more even like [102.42, 102.35, 102.55, 102.39]. The stickiness factor of 5 allows a check to still pick it's previously assigned running only up until the difference between the other runs hits the factor.