### PR TITLE
absolute rebal improvement

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -353,8 +353,9 @@ func (d *dispatcher) rebalanceUsingUtilization(force bool) []types.RebalanceResp
 	currentUtilizationStdDev := currentChecksDistribution.utilizationStdDev()
 	proposedUtilizationStdDev := proposedDistribution.utilizationStdDev()
 	minPercImprovement := pkgconfigsetup.Datadog().GetInt("cluster_checks.rebalance_min_percentage_improvement")
+	minAbsImprovement := pkgconfigsetup.Datadog().GetFloat64("cluster_checks.rebalance_min_absolute_improvement")
 
-	if force || rebalanceIsWorthIt(currentChecksDistribution, proposedDistribution, minPercImprovement) {
+	if force || rebalanceIsWorthIt(currentChecksDistribution, proposedDistribution, minPercImprovement, minAbsImprovement) {
 
 		jsonDistribution, _ := json.Marshal(proposedDistribution)
 
@@ -460,15 +461,27 @@ func setPredictedUtilization(distribution checksDistribution) {
 	}
 }
 
-func rebalanceIsWorthIt(currentDistribution checksDistribution, proposedDistribution checksDistribution, minPercImprovement int) bool {
-	// If the current utilization stddev is already good enough, consider that
-	// rescheduling checks is not worth it, unless the new distribution has
-	// fewer runners with a high utilization or leaves fewer runners empty.
-	if currentDistribution.utilizationStdDev() < 0.1 {
-		return proposedDistribution.numRunnersWithHighUtilization() < currentDistribution.numRunnersWithHighUtilization() ||
-			proposedDistribution.numEmptyRunners() < currentDistribution.numEmptyRunners()
+// rebalanceIsWorthIt returns true when the proposed distribution is good enough
+// to justify the cost of rescheduling checks.
+//
+// Fast path: always accept if the proposed distribution leaves fewer runners empty.
+//
+// Otherwise both gates must pass:
+//  1. Percentage gate: utilization stdDev must improve by at least minPercImprovement%.
+//  2. Absolute gate (when minAbsoluteUtilizationImprovement > 0): utilization stdDev must
+//     improve by at least that amount in absolute terms (0–1 scale), preventing rebalances
+//     that are only a tiny shuffle in an already nearly-balanced cluster.
+
+func rebalanceIsWorthIt(currentDistribution checksDistribution, proposedDistribution checksDistribution, minPercImprovement int, minAbsoluteUtilizationImprovement float64) bool {
+	// Always accept a rebalance if it leaves fewer runners empty.
+	if proposedDistribution.numEmptyRunners() < currentDistribution.numEmptyRunners() {
+		return true
 	}
 
-	maxStdDevAccepted := currentDistribution.utilizationStdDev() * ((100 - float64(minPercImprovement)) / 100)
-	return proposedDistribution.utilizationStdDev() < maxStdDevAccepted
+	current := currentDistribution.utilizationStdDev()
+	proposed := proposedDistribution.utilizationStdDev()
+	improvement := current - proposed
+	// both percentage + absolute gates must clear: we select the stricter of the two
+	minRequired := max(0, current*float64(minPercImprovement)/100, minAbsoluteUtilizationImprovement)
+	return improvement > minRequired
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -1665,7 +1665,7 @@ func TestRebalanceIsWorthIt(t *testing.T) {
 	proposedDistribution.addCheck("check1", 1, "runner1")
 	proposedDistribution.addCheck("check2", 1, "runner2")
 
-	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10))
+	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10, 0))
 
 	// The proposed	solution is worth it if it has fewer runners with a high utilization
 	currentDistribution = newChecksDistribution(workersPerRunner)
@@ -1678,5 +1678,66 @@ func TestRebalanceIsWorthIt(t *testing.T) {
 	proposedDistribution.addCheck("check2", 1, "runner2")
 	proposedDistribution.addCheck("check3", 1, "runner3")
 
-	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10))
+	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10, 0))
+}
+
+func TestRebalanceIsWorthItAbsoluteUtilizationImprovement(t *testing.T) {
+	// Setup:
+	//   runner1: 3.0 of 4 workers used → utilization 0.75
+	//   runner2: 1.0 of 4 workers used → utilization 0.25
+	//   utilizationStdDev = sqrt(((0.75-0.5)^2 + (0.25-0.5)^2)/2) = 0.25
+	//
+	// Proposed (perfectly balanced):
+	//   runner1: 2.0 → utilization 0.50
+	//   runner2: 2.0 → utilization 0.50
+	//   utilizationStdDev = 0.0 → absolute improvement = 0.25
+	workersPerRunner := map[string]int{"runner1": 4, "runner2": 4}
+
+	currentDistribution := newChecksDistribution(workersPerRunner)
+	currentDistribution.addCheck("check1", 2.0, "runner1")
+	currentDistribution.addCheck("check2", 1.0, "runner1")
+	currentDistribution.addCheck("check3", 1.0, "runner2")
+
+	proposedDistribution := newChecksDistribution(workersPerRunner)
+	proposedDistribution.addCheck("check1", 2.0, "runner1")
+	proposedDistribution.addCheck("check2", 1.0, "runner2")
+	proposedDistribution.addCheck("check3", 1.0, "runner2")
+
+	tests := []struct {
+		name     string
+		minPerc  int
+		minAbs   float64
+		expected bool
+	}{
+		{
+			name:     "min=0 accepts: percentage gate requires 0.025, actual 0.25 clears it",
+			minPerc:  10,
+			minAbs:   0,
+			expected: true,
+		},
+		{
+			name:     "min=0.1 accepts: absolute gate requires 0.1, actual 0.25 clears it",
+			minPerc:  10,
+			minAbs:   0.1,
+			expected: true,
+		},
+		{
+			name:     "min=0.25 rejects: absolute gate requires 0.25, actual 0.25 does not strictly exceed it",
+			minPerc:  10,
+			minAbs:   0.25,
+			expected: false,
+		},
+		{
+			name:     "min=0.3 rejects: absolute gate requires 0.3, actual 0.25 falls short",
+			minPerc:  10,
+			minAbs:   0.3,
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, rebalanceIsWorthIt(currentDistribution, proposedDistribution, tc.minPerc, tc.minAbs))
+		})
+	}
 }

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -609,7 +609,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", true)
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_with_utilization", true)
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_percentage_improvement", 10) // Experimental. Subject to change. Rebalance only if the distribution found improves the current one by this.
-	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_absolute_improvement", 1)    // Experimental. Subject to change. Minimum improvement in utilization stdDev required before a rebalance is applied.
+	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_absolute_improvement", 0.1)  // Experimental. Subject to change. Minimum improvement in utilization stdDev (0–1 scale) required before a rebalance is applied. 0 disables the floor.
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks_from_dispatching", []string{})

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -609,6 +609,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", true)
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_with_utilization", true)
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_percentage_improvement", 10) // Experimental. Subject to change. Rebalance only if the distribution found improves the current one by this.
+	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_absolute_improvement", 1)    // Experimental. Subject to change. Minimum improvement in utilization stdDev required before a rebalance is applied.
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks_from_dispatching", []string{})


### PR DESCRIPTION
### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes

This is meant to make the existing % stddev improvement less sensitive. When the standard deviation is near 0, then any change can trigger a rebalance even if it's not really that significant. This is why we propose also having an absolute minimum improvement factor. The exact default value would need to be refined, but you can think of it like this.

If we set `rebalance_min_absolute_improvement=0.1`, this is claiming that we reject any rebalance which doesn't decrease the standard deviation by at least 0.1. This means that we are 95% confident that the difference between the least busy and most busy worker would be 0.4.