### PR TITLE
fix(installer/telemetry): disable endpoint on 4xx to avoid repeated warnings

### DIFF
--- a/pkg/fleet/installer/telemetry/client.go
+++ b/pkg/fleet/installer/telemetry/client.go
@@ -31,8 +31,9 @@ const (
 )
 
 type endpoint struct {
-	APIKey string `json:"-"`
-	Host   string
+	APIKey   string `json:"-"`
+	Host     string
+	disabled bool // set on 4xx to avoid repeated warnings for permanently unavailable endpoints
 }
 
 type client struct {
@@ -228,6 +229,9 @@ func (c *client) sendPayload(requestType requestType, payload interface{}) {
 		group.Add(1)
 		go func(e *endpoint) {
 			defer group.Done()
+			if e.disabled {
+				return
+			}
 			url := fmt.Sprintf("%s%s", e.Host, telemetryEndpoint)
 			req, err := http.NewRequest("POST", url, bytes.NewReader(serializedPayload))
 			if err != nil {
@@ -250,7 +254,12 @@ func (c *client) sendPayload(requestType requestType, payload interface{}) {
 				return
 			}
 			defer resp.Body.Close()
-			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+				// 4xx is a permanent client error (e.g. endpoint doesn't exist on GovCloud).
+				// Disable this endpoint to avoid repeating the warning on every flush.
+				e.disabled = true
+				log.Debugf("telemetry endpoint %s returned %s, disabling", url, resp.Status)
+			} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 				log.Warnf("failed to send telemetry payload to endpoint %s: %s", url, resp.Status)
 			}
 			_, _ = io.Copy(io.Discard, resp.Body)


### PR DESCRIPTION
## Problem

On GovCloud (`ddog-gov.com`), the APM telemetry endpoint (`instrumentation-telemetry-intake.ddog-gov.com/api/v2/apmtelemetry`) doesn't exist and returns 404. The installer logs a `Warnf` on every flush (every minute for the lifetime of the installer daemon), producing noisy and confusing output:

```
failed to send telemetry payload to endpoint https://instrumentation-telemetry-intake.ddog-gov.com/api/v2/apmtelemetry: 404 Not Found
```

A 4xx response is a permanent client error — retrying will never succeed.

## Fix

On the first 4xx response, mark the endpoint as `disabled`. Subsequent `sendPayload` calls skip that endpoint silently. 5xx responses (transient server errors) continue to log at `Warn` level as before.

The `disabled` flag lives on the `endpoint` struct. Each endpoint's goroutine is the only writer for its own flag so no mutex is needed.

## Test

Install on a GovCloud VM with `DD_REMOTE_UPDATES=true DD_SITE=ddog-gov.com`:
- Before: `journalctl -u datadog-agent-installer` fills with `Warnf` lines every minute
- After: one `Debugf` line on first flush, then silence

🤖 Generated with [Claude Code](https://claude.com/claude-code)