### PR TITLE
Add Cargo.lock and Cargo.toml file as trigger for procmg_rust_tests

### DIFF
--- a/.gitlab/build/source_test/procmgr.yml
+++ b/.gitlab/build/source_test/procmgr.yml
@@ -12,6 +12,7 @@ procmgr_rust_tests:
     - changes:
         paths:
           - pkg/procmgr/rust/**/*
+          - Cargo.lock
         compare_to: $COMPARE_TO_BRANCH
   script:
     - cd pkg/procmgr/rust

--- a/.gitlab/build/source_test/procmgr.yml
+++ b/.gitlab/build/source_test/procmgr.yml
@@ -13,6 +13,7 @@ procmgr_rust_tests:
         paths:
           - pkg/procmgr/rust/**/*
           - Cargo.lock
+          - Cargo.toml
         compare_to: $COMPARE_TO_BRANCH
   script:
     - cd pkg/procmgr/rust


### PR DESCRIPTION
### What does this PR do?

Adds Cargo.lock and Cargo.toml files as trigger for procmgr_rust_tests.

### Motivation

https://github.com/DataDog/datadog-agent/pull/51659, which broke this job, landed on main because it didn't trigger the job on the PR. This is a short-term remediation to prevent this from happening again.

### Describe how you validated your changes

### Additional Notes
