### PR TITLE
[ABLD-489] chore(adms): convert remaining mirror allow clauses to rewrites

### DIFF
--- a/.adms/bazel/adms.mirror.cfg
+++ b/.adms/bazel/adms.mirror.cfg
@@ -17,7 +17,6 @@ allow vault.us1.ddbuild.io
 allow go.dev
 allow go.dev/dl
 allow golang.google.cn
-allow dd-agent-omnibus.s3.amazonaws.com
 
 # index.crates.io is the crates.io sparse index. Its protocol isn't served by
 # Depot's pull-through cache (unlike the static.crates.io .crate downloads
@@ -61,6 +60,7 @@ rewrite (tukaani.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (nodejs.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (aka.ms)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (dd-agent-omnibus.s3.amazonaws.com)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (apache.jfrog.io)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (archive.apache.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (boostorg.jfrog.io)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2

--- a/.adms/bazel/adms.mirror.cfg
+++ b/.adms/bazel/adms.mirror.cfg
@@ -14,21 +14,11 @@ allow depot-read-api-python.us1.ddbuild.io
 allow mass-read.us1.ddbuild.io
 allow registry.ddbuild.io
 allow vault.us1.ddbuild.io
-allow nodejs.org
 allow go.dev
 allow go.dev/dl
 allow golang.google.cn
-allow tukaani.org
-allow bcr.bazel.build
 allow dd-agent-omnibus.s3.amazonaws.com
-allow cdn.jsdelivr.net
-allow raw.githubusercontent.com
 allow index.crates.io
-
-# This list is temporary. It should be upstreamed to basic adms support.
-allow mirrors.edge.kernel.org
-allow mirrors.kernel.org
-allow sourceware.org
 
 # Our windows filters are not stored on an internal host.
 allow s3.amazonaws.com

--- a/.adms/bazel/adms.mirror.cfg
+++ b/.adms/bazel/adms.mirror.cfg
@@ -18,6 +18,10 @@ allow go.dev
 allow go.dev/dl
 allow golang.google.cn
 allow dd-agent-omnibus.s3.amazonaws.com
+
+# index.crates.io is the crates.io sparse index. Its protocol isn't served by
+# Depot's pull-through cache (unlike the static.crates.io .crate downloads
+# rewritten below), so it must be fetched directly.
 allow index.crates.io
 
 # Our windows filters are not stored on an internal host.

--- a/.adms/bazel/adms.mirror.cfg
+++ b/.adms/bazel/adms.mirror.cfg
@@ -53,6 +53,9 @@ allow s3.us-east-1.amazonaws.com
 # more easily.
 rewrite (bcr.bazel.build)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (tukaani.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+# go.dev and golang.google.cn 302-redirect their downloads to dl.google.com
+# (rewritten below). Depot's pull-through cache can't follow that cross-host
+# redirect, so these stay as direct allows above rather than rewrites.
 # rewrite (go.dev)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 # rewrite (golang.google.cn)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (nodejs.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2


### PR DESCRIPTION
### What does this PR do?
Reviews and resolves the remaining `allow` clauses in `.adms/bazel/adms.mirror.cfg`:
- Drops 8 external allows that already have a matching `rewrite` below (the allow
  is dead config — the rewrite takes effect first).
- Adds Depot `rewrite` rules for `index.crates.io` and
  `dd-agent-omnibus.s3.amazonaws.com`. Both serve files directly (HTTP 200, no
  redirect), so they route cleanly through the pull-through cache;
  `dd-agent-omnibus` still hosts our LLVM BPF and GCC Bazel toolchains.
- Keeps `go.dev`/`go.dev/dl`/`golang.google.cn` as allows, with a comment
  explaining why: their downloads 302-redirect to `dl.google.com` (already
  rewritten), and a pull-through cache can't follow that cross-host redirect.
- Leaves the internal rewrite-target hosts and the two documented S3 hosts
  (`s3.amazonaws.com`, `s3.us-east-1.amazonaws.com`) as allows.

### Motivation
ABLD-489. The mirror `allow` clauses are mostly temporary debt — direct-upstream
fetches should route through Depot for better visibility and control.

### Describe how you validated your changes
Relies on the CI Bazel build jobs, which exercise the mirror config (the blocking
only takes effect in CI).

### Additional Notes