### PR TITLE
feat(healthplatform): report CNM/USM eBPF probe init failures from system-probe via gRPC

### DIFF
--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -65,8 +65,9 @@ func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDepe
 		reportNetworkProbeInitFailure(deps, initErr, ncfg.NPMEnabled, ncfg.ServiceMonitoringEnabled)
 		return nil, initErr
 	}
-	// Tracer initialized successfully: resolve any stale USM issue.
-	resolveNetworkProbeUSMIssue(deps)
+	// Tracer initialized: check if USM was silently skipped (CNM starts on 4.4+,
+	// USM requires 4.14+) and report/resolve accordingly.
+	checkAndReportUSMState(deps, ncfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var connsSender sender.Sender

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -49,8 +49,8 @@ func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDepe
 		reportNetworkProbeInitFailure(deps, initErr, ncfg.NPMEnabled, ncfg.ServiceMonitoringEnabled)
 		return nil, initErr
 	}
-	// Kernel is supported: resolve only the kernel issue before attempting tracer init.
-	resolveNetworkProbeKernelIssue(deps)
+	// Kernel is supported — defer resolving the kernel issue until after tracer init so
+	// that the async resolve goroutine cannot race with and overwrite a subsequent failure report.
 
 	if ncfg.NPMEnabled {
 		log.Info("enabling cloud network monitoring (CNM)")
@@ -62,11 +62,15 @@ func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDepe
 	t, err := tracer.NewTracer(ncfg, deps.Telemetry, deps.Statsd)
 	if err != nil {
 		initErr := categorizeTracerError(err)
+		// Report the failure synchronously first, then resolve the kernel issue.
+		// The kernel IS supported, so the kernel issue should be cleared, but the
+		// report must land in the store before the resolve goroutine fires.
 		reportNetworkProbeInitFailure(deps, initErr, ncfg.NPMEnabled, ncfg.ServiceMonitoringEnabled)
+		resolveNetworkProbeKernelIssue(deps)
 		return nil, initErr
 	}
-	// Tracer initialized: check if USM was silently skipped (CNM starts on 4.4+,
-	// USM requires 4.14+) and report/resolve accordingly.
+	// Tracer fully initialized: resolve the kernel issue and check USM state.
+	resolveNetworkProbeKernelIssue(deps)
 	checkAndReportUSMState(deps, ncfg)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -59,11 +59,13 @@ func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDepe
 	t, err := tracer.NewTracer(ncfg, deps.Telemetry, deps.Statsd)
 	if err != nil {
 		initErr := categorizeTracerError(err)
-		// Report the failure synchronously first, then resolve the kernel issue.
-		// The kernel IS supported, so the kernel issue should be cleared, but the
-		// report must land in the store before the resolve goroutine fires.
-		reportNetworkProbeInitFailure(deps, initErr, ncfg.NPMEnabled, ncfg.ServiceMonitoringEnabled)
+		// Start the kernel-issue resolve goroutine before the blocking report so
+		// it has time to deliver while the process is alive. reportNetworkProbeInitFailure
+		// blocks for up to ReportMaxWait (30 s); the resolve goroutine fires after its
+		// 2 s initial backoff, giving it ~28 s before system-probe may exit.
+		// The two operations target different issue IDs so there is no store race.
 		resolveNetworkProbeKernelIssue(deps)
+		reportNetworkProbeInitFailure(deps, initErr, ncfg.NPMEnabled, ncfg.ServiceMonitoringEnabled)
 		return nil, initErr
 	}
 	// Tracer fully initialized: resolve the kernel issue and check USM state.

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -30,6 +30,12 @@ import (
 // ErrSysprobeUnsupported is the unsupported error prefix, for error-class matching from callers
 var ErrSysprobeUnsupported = errors.New("system-probe unsupported")
 
+// Sentinel errors that categorize probe-init failures for targeted remediation in health issues.
+var (
+	errNetworkProbeKernelUnsupported = errors.New("kernel version not supported by network probe")
+	errNetworkProbeUSMUnsupported    = errors.New("USM not supported on this kernel")
+)
+
 const inactivityLogDuration = 10 * time.Minute
 const inactivityRestartDuration = 20 * time.Minute
 const maxConntrackDumpSize = 3000
@@ -39,11 +45,15 @@ func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDepe
 
 	// Checking whether the current OS + kernel version is supported by the tracer
 	if supported, err := tracer.IsTracerSupportedByOS(ncfg.ExcludedBPFLinuxVersions); !supported {
-		return nil, fmt.Errorf("%w: %s", ErrSysprobeUnsupported, err)
+		initErr := fmt.Errorf("%w: %w: %s", ErrSysprobeUnsupported, errNetworkProbeKernelUnsupported, err)
+		reportNetworkProbeInitFailure(deps, initErr, ncfg.NPMEnabled, ncfg.ServiceMonitoringEnabled)
+		return nil, initErr
 	}
+	// Kernel is supported: resolve only the kernel issue before attempting tracer init.
+	resolveNetworkProbeKernelIssue(deps)
 
 	if ncfg.NPMEnabled {
-		log.Info("enabling network performance monitoring (NPM)")
+		log.Info("enabling cloud network monitoring (CNM)")
 	}
 	if ncfg.ServiceMonitoringEnabled {
 		log.Info("enabling universal service monitoring (USM)")
@@ -51,8 +61,12 @@ func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDepe
 
 	t, err := tracer.NewTracer(ncfg, deps.Telemetry, deps.Statsd)
 	if err != nil {
-		return nil, err
+		initErr := categorizeTracerError(err)
+		reportNetworkProbeInitFailure(deps, initErr, ncfg.NPMEnabled, ncfg.ServiceMonitoringEnabled)
+		return nil, initErr
 	}
+	// Tracer initialized successfully: resolve any stale USM issue.
+	resolveNetworkProbeUSMIssue(deps)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var connsSender sender.Sender
@@ -95,7 +109,10 @@ type networkTracer struct {
 }
 
 func (nt *networkTracer) GetStats() map[string]any {
-	stats, _ := nt.tracer.GetStats()
+	stats, err := nt.tracer.GetStats()
+	if err != nil {
+		log.Debugf("network tracer: error getting stats: %v", err)
+	}
 	return stats
 }
 

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -30,11 +30,8 @@ import (
 // ErrSysprobeUnsupported is the unsupported error prefix, for error-class matching from callers
 var ErrSysprobeUnsupported = errors.New("system-probe unsupported")
 
-// Sentinel errors that categorize probe-init failures for targeted remediation in health issues.
-var (
-	errNetworkProbeKernelUnsupported = errors.New("kernel version not supported by network probe")
-	errNetworkProbeUSMUnsupported    = errors.New("USM not supported on this kernel")
-)
+// errNetworkProbeKernelUnsupported is reported when the OS kernel version check fails.
+var errNetworkProbeKernelUnsupported = errors.New("kernel version not supported by network probe")
 
 const inactivityLogDuration = 10 * time.Minute
 const inactivityRestartDuration = 20 * time.Minute

--- a/cmd/system-probe/modules/network_tracer_errcat_linux.go
+++ b/cmd/system-probe/modules/network_tracer_errcat_linux.go
@@ -11,7 +11,9 @@ import (
 	"errors"
 	"fmt"
 
+	networkconfig "github.com/DataDog/datadog-agent/pkg/network/config"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 )
 
 // categorizeTracerError wraps err with one of the sentinel errors defined in network_tracer.go
@@ -22,5 +24,20 @@ func categorizeTracerError(err error) error {
 		return fmt.Errorf("%w: %w", errNetworkProbeUSMUnsupported, err)
 	default:
 		return err
+	}
+}
+
+// checkAndReportUSMState detects when tracer.NewTracer succeeds but USM was silently
+// skipped because the kernel is < 4.14 (CNM can start on 4.4+, USM requires 4.14+).
+// Reports a USM issue if USM is enabled but unsupported; resolves any stale USM issue otherwise.
+func checkAndReportUSMState(deps module.FactoryDependencies, ncfg *networkconfig.Config) {
+	if !ncfg.ServiceMonitoringEnabled {
+		resolveNetworkProbeUSMIssue(deps)
+		return
+	}
+	if usmErr := usmconfig.CheckUSMSupported(ncfg); usmErr != nil {
+		reportNetworkProbeInitFailure(deps, fmt.Errorf("%w: %w", errNetworkProbeUSMUnsupported, usmErr), ncfg.NPMEnabled, ncfg.ServiceMonitoringEnabled)
+	} else {
+		resolveNetworkProbeUSMIssue(deps)
 	}
 }

--- a/cmd/system-probe/modules/network_tracer_errcat_linux.go
+++ b/cmd/system-probe/modules/network_tracer_errcat_linux.go
@@ -16,7 +16,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 )
 
-// categorizeTracerError wraps err with one of the sentinel errors defined in network_tracer.go
+// errNetworkProbeUSMUnsupported is reported when USM requires a newer kernel than the one running.
+var errNetworkProbeUSMUnsupported = errors.New("USM not supported on this kernel")
+
+// categorizeTracerError wraps err with one of the sentinel errors defined in this package
 // so that buildNetworkProbeIssue can select targeted remediation steps.
 func categorizeTracerError(err error) error {
 	switch {

--- a/cmd/system-probe/modules/network_tracer_errcat_linux.go
+++ b/cmd/system-probe/modules/network_tracer_errcat_linux.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && linux_bpf
+
+package modules
+
+import (
+	"errors"
+	"fmt"
+
+	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
+)
+
+// categorizeTracerError wraps err with one of the sentinel errors defined in network_tracer.go
+// so that buildNetworkProbeIssue can select targeted remediation steps.
+func categorizeTracerError(err error) error {
+	switch {
+	case errors.Is(err, usmconfig.ErrNotSupported):
+		return fmt.Errorf("%w: %w", errNetworkProbeUSMUnsupported, err)
+	default:
+		return err
+	}
+}

--- a/cmd/system-probe/modules/network_tracer_errcat_other.go
+++ b/cmd/system-probe/modules/network_tracer_errcat_other.go
@@ -20,6 +20,4 @@ func categorizeTracerError(err error) error {
 
 // checkAndReportUSMState is a no-op on non-Linux platforms where the USM silent-skip
 // scenario (CNM starts, USM silently disabled on kernel < 4.14) cannot occur.
-func checkAndReportUSMState(deps module.FactoryDependencies, _ *networkconfig.Config) {
-	resolveNetworkProbeUSMIssue(deps)
-}
+func checkAndReportUSMState(_ module.FactoryDependencies, _ *networkconfig.Config) {}

--- a/cmd/system-probe/modules/network_tracer_errcat_other.go
+++ b/cmd/system-probe/modules/network_tracer_errcat_other.go
@@ -7,8 +7,19 @@
 
 package modules
 
+import (
+	networkconfig "github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
+)
+
 // categorizeTracerError returns err unchanged on platforms where eBPF verifier and USM
 // failures cannot occur (Windows, Darwin).
 func categorizeTracerError(err error) error {
 	return err
+}
+
+// checkAndReportUSMState is a no-op on non-Linux platforms where the USM silent-skip
+// scenario (CNM starts, USM silently disabled on kernel < 4.14) cannot occur.
+func checkAndReportUSMState(deps module.FactoryDependencies, _ *networkconfig.Config) {
+	resolveNetworkProbeUSMIssue(deps)
 }

--- a/cmd/system-probe/modules/network_tracer_errcat_other.go
+++ b/cmd/system-probe/modules/network_tracer_errcat_other.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build (windows && npm) || darwin
+
+package modules
+
+// categorizeTracerError returns err unchanged on platforms where eBPF verifier and USM
+// failures cannot occur (Windows, Darwin).
+func categorizeTracerError(err error) error {
+	return err
+}

--- a/cmd/system-probe/modules/network_tracer_health.go
+++ b/cmd/system-probe/modules/network_tracer_health.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build (linux && linux_bpf) || (windows && npm) || darwin
+//go:build linux && linux_bpf
 
 package modules
 
@@ -37,9 +37,9 @@ func networkProbeIssueIDFor(initErr error) string {
 func networkProbeIssueNameFor(initErr error) string {
 	switch {
 	case errors.Is(initErr, errNetworkProbeKernelUnsupported):
-		return "Network Probe Kernel Version Unsupported"
+		return "Network Probe Kernel Unsupported"
 	case errors.Is(initErr, errNetworkProbeUSMUnsupported):
-		return "Network Probe USM Kernel Version Unsupported"
+		return "Network Probe USM Unsupported"
 	}
 	return ""
 }
@@ -132,7 +132,7 @@ func networkProbeRemediation(initErr error) *healthplatformpayload.Remediation {
 				{Order: 1, Text: "Check system-probe logs: journalctl -u datadog-agent-sysprobe or /var/log/datadog/system-probe.log"},
 				{Order: 2, Text: "Check the kernel version: uname -r (CNM requires >= 4.4, USM requires >= 4.14)"},
 				{Order: 3, Text: "Upgrade the host kernel or disable the unsupported feature in system-probe.yaml"},
-				{Order: 4, Text: "Restart after fixing: systemctl restart datadog-agent-sysprobe"},
+				{Order: 4, Text: "Restart after fixing: sudo systemctl restart datadog-agent-sysprobe"},
 			},
 		}
 	case errors.Is(initErr, errNetworkProbeUSMUnsupported):
@@ -142,7 +142,7 @@ func networkProbeRemediation(initErr error) *healthplatformpayload.Remediation {
 				{Order: 1, Text: "Check system-probe logs: journalctl -u datadog-agent-sysprobe or /var/log/datadog/system-probe.log"},
 				{Order: 2, Text: "Check the kernel version: uname -r (USM requires >= 4.14)"},
 				{Order: 3, Text: "Upgrade the host kernel or disable USM (service_monitoring_config.enabled: false) in datadog.yaml"},
-				{Order: 4, Text: "Restart after fixing: systemctl restart datadog-agent-sysprobe"},
+				{Order: 4, Text: "Restart after fixing: sudo systemctl restart datadog-agent-sysprobe"},
 			},
 		}
 	}

--- a/cmd/system-probe/modules/network_tracer_health.go
+++ b/cmd/system-probe/modules/network_tracer_health.go
@@ -1,0 +1,150 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build (linux && linux_bpf) || (windows && npm) || darwin
+
+package modules
+
+import (
+	"errors"
+	"strconv"
+
+	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/healthreporter"
+)
+
+// Per-error-type issue IDs so each failure mode has an independent lifecycle.
+const (
+	networkProbeKernelIssueID = "network-probe-kernel-unsupported"
+	networkProbeUSMIssueID    = "network-probe-usm-unsupported"
+)
+
+// networkProbeIssueIDFor returns the issue ID for a known failure type, or "" for unrecognized errors.
+func networkProbeIssueIDFor(initErr error) string {
+	switch {
+	case errors.Is(initErr, errNetworkProbeKernelUnsupported):
+		return networkProbeKernelIssueID
+	case errors.Is(initErr, errNetworkProbeUSMUnsupported):
+		return networkProbeUSMIssueID
+	}
+	return ""
+}
+
+// networkProbeIssueNameFor returns the human-readable issue name for a known failure type.
+func networkProbeIssueNameFor(initErr error) string {
+	switch {
+	case errors.Is(initErr, errNetworkProbeKernelUnsupported):
+		return "Network Probe Kernel Version Unsupported"
+	case errors.Is(initErr, errNetworkProbeUSMUnsupported):
+		return "Network Probe USM Kernel Version Unsupported"
+	}
+	return ""
+}
+
+// reportNetworkProbeInitFailure sends a fully-built health issue to the core agent for known
+// failure types. Unrecognized errors are not reported (they are already logged by the caller).
+func reportNetworkProbeInitFailure(deps module.FactoryDependencies, initErr error, npmEnabled, usmEnabled bool) {
+	issue := buildNetworkProbeIssue(initErr, npmEnabled, usmEnabled)
+	if issue == nil {
+		return
+	}
+	healthreporter.New(deps.Ipc).ReportWithRetry(issue)
+}
+
+// resolveNetworkProbeKernelIssue clears the kernel-unsupported issue once the kernel check passes.
+func resolveNetworkProbeKernelIssue(deps module.FactoryDependencies) {
+	healthreporter.New(deps.Ipc).ResolveWithRetry(networkProbeKernelIssueID)
+}
+
+// resolveNetworkProbeUSMIssue clears the USM issue once the tracer initializes successfully.
+func resolveNetworkProbeUSMIssue(deps module.FactoryDependencies) {
+	healthreporter.New(deps.Ipc).ResolveWithRetry(networkProbeUSMIssueID)
+}
+
+// buildNetworkProbeIssue returns a health issue for a known failure type, or nil for unrecognized errors.
+func buildNetworkProbeIssue(initErr error, npmEnabled, usmEnabled bool) *healthplatformpayload.Issue {
+	issueID := networkProbeIssueIDFor(initErr)
+	if issueID == "" {
+		return nil
+	}
+
+	errStr := "unknown error"
+	if initErr != nil {
+		errStr = initErr.Error()
+	}
+
+	var which string
+	if errors.Is(initErr, errNetworkProbeUSMUnsupported) {
+		// USM-specific failure: only USM is affected regardless of whether CNM is also enabled.
+		which = "USM"
+	} else {
+		// Kernel-level failure: the entire tracer is affected, report all enabled features.
+		switch {
+		case npmEnabled && usmEnabled:
+			which = "CNM and USM"
+		case npmEnabled:
+			which = "CNM"
+		case usmEnabled:
+			which = "USM"
+		default:
+			which = "network monitoring"
+		}
+	}
+
+	extra := healthreporter.StringStruct(map[string]string{
+		"error":       errStr,
+		"npm_enabled": strconv.FormatBool(npmEnabled),
+		"usm_enabled": strconv.FormatBool(usmEnabled),
+	})
+
+	tags := []string{"system-probe", "ebpf", "network-monitoring"}
+	if npmEnabled {
+		tags = append(tags, "npm", "cnm")
+	}
+	if usmEnabled {
+		tags = append(tags, "usm")
+	}
+
+	return &healthplatformpayload.Issue{
+		Id:          issueID,
+		IssueName:   networkProbeIssueNameFor(initErr),
+		Title:       which + " eBPF Probe Failed to Initialize",
+		Description: which + " is enabled but the eBPF network probe failed to load: " + errStr,
+		Category:    "runtime",
+		Location:    "system-probe",
+		Severity:    healthplatformpayload.IssueSeverity_ISSUE_SEVERITY_HIGH,
+		Source:      "system-probe",
+		Extra:       extra,
+		Tags:        tags,
+		Remediation: networkProbeRemediation(initErr),
+	}
+}
+
+func networkProbeRemediation(initErr error) *healthplatformpayload.Remediation {
+	switch {
+	case errors.Is(initErr, errNetworkProbeKernelUnsupported):
+		return &healthplatformpayload.Remediation{
+			Summary: "The running kernel does not meet the minimum version requirements for this feature.",
+			Steps: []*healthplatformpayload.RemediationStep{
+				{Order: 1, Text: "Check system-probe logs: journalctl -u datadog-agent-sysprobe or /var/log/datadog/system-probe.log"},
+				{Order: 2, Text: "Check the kernel version: uname -r (CNM requires >= 4.4, USM requires >= 4.14)"},
+				{Order: 3, Text: "Upgrade the host kernel or disable the unsupported feature in system-probe.yaml"},
+				{Order: 4, Text: "Restart after fixing: systemctl restart datadog-agent-sysprobe"},
+			},
+		}
+	case errors.Is(initErr, errNetworkProbeUSMUnsupported):
+		return &healthplatformpayload.Remediation{
+			Summary: "Universal Service Monitoring (USM) requires a newer kernel than the one running.",
+			Steps: []*healthplatformpayload.RemediationStep{
+				{Order: 1, Text: "Check system-probe logs: journalctl -u datadog-agent-sysprobe or /var/log/datadog/system-probe.log"},
+				{Order: 2, Text: "Check the kernel version: uname -r (USM requires >= 4.14)"},
+				{Order: 3, Text: "Upgrade the host kernel or disable USM (service_monitoring_config.enabled: false) in datadog.yaml"},
+				{Order: 4, Text: "Restart after fixing: systemctl restart datadog-agent-sysprobe"},
+			},
+		}
+	}
+	return nil
+}

--- a/cmd/system-probe/modules/network_tracer_health_other.go
+++ b/cmd/system-probe/modules/network_tracer_health_other.go
@@ -15,6 +15,3 @@ func reportNetworkProbeInitFailure(_ module.FactoryDependencies, _ error, _, _ b
 
 // resolveNetworkProbeKernelIssue is a no-op on Windows and Darwin.
 func resolveNetworkProbeKernelIssue(_ module.FactoryDependencies) {}
-
-// resolveNetworkProbeUSMIssue is a no-op on Windows and Darwin.
-func resolveNetworkProbeUSMIssue(_ module.FactoryDependencies) {}

--- a/cmd/system-probe/modules/network_tracer_health_other.go
+++ b/cmd/system-probe/modules/network_tracer_health_other.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build (windows && npm) || darwin
+
+package modules
+
+import "github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
+
+// reportNetworkProbeInitFailure is a no-op on Windows and Darwin: health issues for
+// eBPF probe init failures are Linux-specific and carry Linux remediation steps.
+func reportNetworkProbeInitFailure(_ module.FactoryDependencies, _ error, _, _ bool) {}
+
+// resolveNetworkProbeKernelIssue is a no-op on Windows and Darwin.
+func resolveNetworkProbeKernelIssue(_ module.FactoryDependencies) {}
+
+// resolveNetworkProbeUSMIssue is a no-op on Windows and Darwin.
+func resolveNetworkProbeUSMIssue(_ module.FactoryDependencies) {}

--- a/pkg/system-probe/healthreporter/BUILD.bazel
+++ b/pkg/system-probe/healthreporter/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "healthreporter",
+    srcs = ["reporter.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/system-probe/healthreporter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/ipc/def",
+        "//pkg/config/setup",
+        "//pkg/proto/pbgo/core",
+        "//pkg/util/grpc",
+        "//pkg/util/log",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/pkg/system-probe/healthreporter/BUILD.bazel
+++ b/pkg/system-probe/healthreporter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "healthreporter",
@@ -13,6 +13,22 @@ go_library(
         "//pkg/util/log",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)
+
+go_test(
+    name = "healthreporter_test",
+    srcs = ["reporter_test.go"],
+    embed = [":healthreporter"],
+    gotags = ["test"],
+    deps = [
+        "//pkg/proto/pbgo/core",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_protobuf//types/known/emptypb",
         "@org_golang_google_protobuf//types/known/structpb",
     ],
 )

--- a/pkg/system-probe/healthreporter/reporter.go
+++ b/pkg/system-probe/healthreporter/reporter.go
@@ -1,0 +1,145 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package healthreporter provides a reusable gRPC client for system-probe modules
+// to report and resolve health issues via the core agent's AgentSecure endpoint.
+// Any module that detects a runtime failure can instantiate a Reporter and call
+// ReportWithRetry / ResolveWithRetry without duplicating connection or retry logic.
+package healthreporter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
+	ipcdef "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	ddgrpc "github.com/DataDog/datadog-agent/pkg/util/grpc"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// DefaultCallTimeout caps a single gRPC call attempt.
+	DefaultCallTimeout = 5 * time.Second
+	// DefaultMaxWait is how long ResolveWithRetry keeps retrying.
+	// Long enough to cover the common case where system-probe starts before the
+	// core agent gRPC server is ready.
+	DefaultMaxWait = 3 * time.Minute
+	// ReportMaxWait caps how long ReportWithRetry will block when retrying.
+	// Callers are typically on the module-init failure path and system-probe exits
+	// right after, so we cannot rely on a background goroutine surviving long enough.
+	ReportMaxWait = 30 * time.Second
+)
+
+// Reporter sends health issues and resolutions to the core agent via the
+// AgentSecure ReportHealthIssue / ResolveHealthIssue gRPC endpoints.
+type Reporter struct {
+	ipc         ipcdef.Component
+	callTimeout time.Duration
+	maxWait     time.Duration
+}
+
+// New returns a Reporter that uses the given IPC component for mTLS and auth.
+func New(ipc ipcdef.Component) *Reporter {
+	return &Reporter{
+		ipc:         ipc,
+		callTimeout: DefaultCallTimeout,
+		maxWait:     DefaultMaxWait,
+	}
+}
+
+// ReportWithRetry sends issue to the core agent, blocking with exponential backoff
+// for up to ReportMaxWait. Blocking is intentional: callers are typically on a
+// module-init failure path where system-probe exits immediately after, so a background
+// goroutine would be killed before it could deliver the report.
+func (r *Reporter) ReportWithRetry(issue *healthplatformpayload.Issue) {
+	r.retryWithBackoff("report "+issue.GetId(), ReportMaxWait, func() error {
+		return r.Report(context.Background(), issue)
+	})
+}
+
+// ResolveWithRetry clears issueID on the core agent in a background goroutine,
+// retrying with exponential backoff until the call succeeds or DefaultMaxWait elapses.
+func (r *Reporter) ResolveWithRetry(issueID string) {
+	go r.retryWithBackoff("resolve "+issueID, r.maxWait, func() error {
+		return r.Resolve(context.Background(), issueID)
+	})
+}
+
+// Report sends a single ReportHealthIssue RPC. The caller is responsible for
+// any retry / timeout policy.
+func (r *Reporter) Report(ctx context.Context, issue *healthplatformpayload.Issue) error {
+	client, err := r.newClient()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, r.callTimeout)
+	defer cancel()
+	_, err = client.ReportHealthIssue(ctx, &pb.ReportHealthIssueRequest{Issue: issue})
+	return err
+}
+
+// Resolve sends a single ResolveHealthIssue RPC. The caller is responsible for
+// any retry / timeout policy.
+func (r *Reporter) Resolve(ctx context.Context, issueID string) error {
+	client, err := r.newClient()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, r.callTimeout)
+	defer cancel()
+	_, err = client.ResolveHealthIssue(ctx, &pb.ResolveHealthIssueRequest{IssueId: issueID})
+	return err
+}
+
+func (r *Reporter) newClient() (pb.AgentSecureClient, error) {
+	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
+	if err != nil {
+		return nil, fmt.Errorf("get IPC address: %w", err)
+	}
+	return ddgrpc.GetDDAgentSecureClient(
+		context.Background(),
+		ipcAddress,
+		pkgconfigsetup.GetIPCPort(),
+		r.ipc.GetTLSClientConfig().Clone(),
+		grpc.WithPerRPCCredentials(ddgrpc.NewBearerTokenAuth(r.ipc.GetAuthToken())),
+	)
+}
+
+// StringStruct converts a map[string]string to a *structpb.Struct suitable for
+// the Extra field of a health issue. Any system-probe module building an issue
+// can use this instead of reimplementing the conversion.
+func StringStruct(fields map[string]string) *structpb.Struct {
+	pb := make(map[string]*structpb.Value, len(fields))
+	for k, v := range fields {
+		pb[k] = structpb.NewStringValue(v)
+	}
+	return &structpb.Struct{Fields: pb}
+}
+
+func (r *Reporter) retryWithBackoff(op string, maxWait time.Duration, fn func() error) {
+	deadline := time.Now().Add(maxWait)
+	backoff := 2 * time.Second
+	for {
+		err := fn()
+		if err == nil {
+			return
+		}
+		log.Warnf("health platform: %s failed (will retry in %s): %v", op, backoff, err)
+		if time.Now().After(deadline) {
+			log.Warnf("health platform: gave up on %s after %s", op, maxWait)
+			return
+		}
+		time.Sleep(backoff)
+		if backoff < 30*time.Second {
+			backoff *= 2
+		}
+	}
+}

--- a/pkg/system-probe/healthreporter/reporter.go
+++ b/pkg/system-probe/healthreporter/reporter.go
@@ -44,6 +44,8 @@ type Reporter struct {
 	ipc         ipcdef.Component
 	callTimeout time.Duration
 	maxWait     time.Duration
+	// newClientFn overrides newClient when set; used in tests to inject a mock.
+	newClientFn func() (pb.AgentSecureClient, error)
 }
 
 // New returns a Reporter that uses the given IPC component for mTLS and auth.
@@ -111,6 +113,9 @@ func (r *Reporter) Resolve(ctx context.Context, issueID string) error {
 }
 
 func (r *Reporter) newClient() (pb.AgentSecureClient, error) {
+	if r.newClientFn != nil {
+		return r.newClientFn()
+	}
 	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return nil, fmt.Errorf("get IPC address: %w", err)

--- a/pkg/system-probe/healthreporter/reporter.go
+++ b/pkg/system-probe/healthreporter/reporter.go
@@ -55,14 +55,25 @@ func New(ipc ipcdef.Component) *Reporter {
 	}
 }
 
-// ReportWithRetry sends issue to the core agent, blocking with exponential backoff
-// for up to ReportMaxWait. Blocking is intentional: callers are typically on a
-// module-init failure path where system-probe exits immediately after, so a background
-// goroutine would be killed before it could deliver the report.
+// ReportWithRetry sends issue to the core agent. It first blocks for ReportMaxWait (30s)
+// so the report survives if system-probe exits immediately after a module-init failure.
+// If undelivered after that window but system-probe is still running (other modules are
+// loaded), it continues retrying in a background goroutine for the remaining DefaultMaxWait.
 func (r *Reporter) ReportWithRetry(issue *healthplatformpayload.Issue) {
-	r.retryWithBackoff("report "+issue.GetId(), ReportMaxWait, func() error {
+	op := "report " + issue.GetId()
+	if r.retryWithBackoff(op, ReportMaxWait, func() error {
 		return r.Report(context.Background(), issue)
-	})
+	}) {
+		return
+	}
+	// Synchronous window exhausted without success — keep retrying in the background
+	// for the rest of DefaultMaxWait in case the process stays alive.
+	remaining := r.maxWait - ReportMaxWait
+	if remaining > 0 {
+		go r.retryWithBackoff(op, remaining, func() error {
+			return r.Report(context.Background(), issue)
+		})
+	}
 }
 
 // ResolveWithRetry clears issueID on the core agent in a background goroutine,
@@ -124,18 +135,20 @@ func StringStruct(fields map[string]string) *structpb.Struct {
 	return &structpb.Struct{Fields: pb}
 }
 
-func (r *Reporter) retryWithBackoff(op string, maxWait time.Duration, fn func() error) {
+// retryWithBackoff retries fn with exponential backoff until it succeeds or maxWait elapses.
+// Returns true if fn succeeded, false if the deadline was reached.
+func (r *Reporter) retryWithBackoff(op string, maxWait time.Duration, fn func() error) bool {
 	deadline := time.Now().Add(maxWait)
 	backoff := 2 * time.Second
 	for {
 		err := fn()
 		if err == nil {
-			return
+			return true
 		}
 		log.Warnf("health platform: %s failed (will retry in %s): %v", op, backoff, err)
 		if time.Now().After(deadline) {
 			log.Warnf("health platform: gave up on %s after %s", op, maxWait)
-			return
+			return false
 		}
 		time.Sleep(backoff)
 		if backoff < 30*time.Second {

--- a/pkg/system-probe/healthreporter/reporter_test.go
+++ b/pkg/system-probe/healthreporter/reporter_test.go
@@ -1,0 +1,301 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package healthreporter
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+)
+
+// mockClient implements pb.AgentSecureClient with configurable Report/Resolve handlers.
+// All other methods panic — they are not exercised by these tests.
+type mockClient struct {
+	reportFn  func(context.Context, *pb.ReportHealthIssueRequest, ...grpc.CallOption) (*emptypb.Empty, error)
+	resolveFn func(context.Context, *pb.ResolveHealthIssueRequest, ...grpc.CallOption) (*emptypb.Empty, error)
+}
+
+func (m *mockClient) ReportHealthIssue(ctx context.Context, in *pb.ReportHealthIssueRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return m.reportFn(ctx, in, opts...)
+}
+func (m *mockClient) ResolveHealthIssue(ctx context.Context, in *pb.ResolveHealthIssueRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return m.resolveFn(ctx, in, opts...)
+}
+
+// Unused methods — panic to catch unexpected calls.
+func (m *mockClient) TaggerStreamEntities(context.Context, *pb.StreamTagsRequest, ...grpc.CallOption) (grpc.ServerStreamingClient[pb.StreamTagsResponse], error) {
+	panic("unexpected call")
+}
+func (m *mockClient) TaggerGenerateContainerIDFromOriginInfo(context.Context, *pb.GenerateContainerIDFromOriginInfoRequest, ...grpc.CallOption) (*pb.GenerateContainerIDFromOriginInfoResponse, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) TaggerFetchEntity(context.Context, *pb.FetchEntityRequest, ...grpc.CallOption) (*pb.FetchEntityResponse, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) DogstatsdCaptureTrigger(context.Context, *pb.CaptureTriggerRequest, ...grpc.CallOption) (*pb.CaptureTriggerResponse, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) DogstatsdSetTaggerState(context.Context, *pb.TaggerState, ...grpc.CallOption) (*pb.TaggerStateResponse, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) ClientGetConfigs(context.Context, *pb.ClientGetConfigsRequest, ...grpc.CallOption) (*pb.ClientGetConfigsResponse, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) GetConfigState(context.Context, *emptypb.Empty, ...grpc.CallOption) (*pb.GetStateConfigResponse, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) ClientGetConfigsHA(context.Context, *pb.ClientGetConfigsRequest, ...grpc.CallOption) (*pb.ClientGetConfigsResponse, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) GetConfigStateHA(context.Context, *emptypb.Empty, ...grpc.CallOption) (*pb.GetStateConfigResponse, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) CreateConfigSubscription(context.Context, ...grpc.CallOption) (grpc.BidiStreamingClient[pb.ConfigSubscriptionRequest, pb.ConfigSubscriptionResponse], error) {
+	panic("unexpected call")
+}
+func (m *mockClient) ResetConfigState(context.Context, *emptypb.Empty, ...grpc.CallOption) (*pb.ResetStateConfigResponse, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) WorkloadmetaStreamEntities(context.Context, *pb.WorkloadmetaStreamRequest, ...grpc.CallOption) (grpc.ServerStreamingClient[pb.WorkloadmetaStreamResponse], error) {
+	panic("unexpected call")
+}
+func (m *mockClient) RegisterRemoteAgent(context.Context, *pb.RegisterRemoteAgentRequest, ...grpc.CallOption) (*pb.RegisterRemoteAgentResponse, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) RefreshRemoteAgent(context.Context, *pb.RefreshRemoteAgentRequest, ...grpc.CallOption) (*pb.RefreshRemoteAgentResponse, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) AutodiscoveryStreamConfig(context.Context, *emptypb.Empty, ...grpc.CallOption) (grpc.ServerStreamingClient[pb.AutodiscoveryStreamResponse], error) {
+	panic("unexpected call")
+}
+func (m *mockClient) GetHostTags(context.Context, *pb.HostTagRequest, ...grpc.CallOption) (*pb.HostTagReply, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) StreamConfigEvents(context.Context, *pb.ConfigStreamRequest, ...grpc.CallOption) (grpc.ServerStreamingClient[pb.ConfigEvent], error) {
+	panic("unexpected call")
+}
+func (m *mockClient) WorkloadFilterEvaluate(context.Context, *pb.WorkloadFilterEvaluateRequest, ...grpc.CallOption) (*pb.WorkloadFilterEvaluateResponse, error) {
+	panic("unexpected call")
+}
+func (m *mockClient) StreamKubeMetadata(context.Context, *pb.KubeMetadataStreamRequest, ...grpc.CallOption) (grpc.ServerStreamingClient[pb.KubeMetadataStreamResponse], error) {
+	panic("unexpected call")
+}
+
+// newReporter returns a Reporter with the mock client injected, short timeouts for tests.
+func newReporter(client pb.AgentSecureClient) *Reporter {
+	return &Reporter{
+		callTimeout: 500 * time.Millisecond,
+		maxWait:     2 * time.Second,
+		newClientFn: func() (pb.AgentSecureClient, error) { return client, nil },
+	}
+}
+
+// ============================================================================
+// retryWithBackoff
+// ============================================================================
+
+func TestRetryWithBackoff_SuccessOnFirstTry(t *testing.T) {
+	r := &Reporter{maxWait: 5 * time.Second}
+	calls := 0
+	ok := r.retryWithBackoff("op", 5*time.Second, func() error {
+		calls++
+		return nil
+	})
+	assert.True(t, ok)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryWithBackoff_RetryOnError(t *testing.T) {
+	r := &Reporter{maxWait: 5 * time.Second}
+	var calls atomic.Int32
+	sentinel := errors.New("transient")
+	ok := r.retryWithBackoff("op", 5*time.Second, func() error {
+		if calls.Add(1) < 3 {
+			return sentinel
+		}
+		return nil
+	})
+	assert.True(t, ok)
+	assert.GreaterOrEqual(t, int(calls.Load()), 3)
+}
+
+func TestRetryWithBackoff_DeadlineExceeded(t *testing.T) {
+	r := &Reporter{maxWait: 100 * time.Millisecond}
+	calls := 0
+	ok := r.retryWithBackoff("op", 100*time.Millisecond, func() error {
+		calls++
+		return errors.New("always failing")
+	})
+	assert.False(t, ok)
+	assert.GreaterOrEqual(t, calls, 1)
+}
+
+// ============================================================================
+// Report / Resolve
+// ============================================================================
+
+func TestReport_Success(t *testing.T) {
+	var got *pb.ReportHealthIssueRequest
+	client := &mockClient{
+		reportFn: func(_ context.Context, in *pb.ReportHealthIssueRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			got = in
+			return &emptypb.Empty{}, nil
+		},
+	}
+	r := newReporter(client)
+	issue := &healthplatformpayload.Issue{Id: "test-issue", IssueName: "Test"}
+	err := r.Report(context.Background(), issue)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "test-issue", got.Issue.Id)
+}
+
+func TestReport_Error(t *testing.T) {
+	client := &mockClient{
+		reportFn: func(_ context.Context, _ *pb.ReportHealthIssueRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			return nil, errors.New("rpc error")
+		},
+	}
+	r := newReporter(client)
+	err := r.Report(context.Background(), &healthplatformpayload.Issue{Id: "x", IssueName: "X"})
+	assert.Error(t, err)
+}
+
+func TestResolve_Success(t *testing.T) {
+	var gotID string
+	client := &mockClient{
+		resolveFn: func(_ context.Context, in *pb.ResolveHealthIssueRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			gotID = in.IssueId
+			return &emptypb.Empty{}, nil
+		},
+	}
+	r := newReporter(client)
+	err := r.Resolve(context.Background(), "my-issue")
+	require.NoError(t, err)
+	assert.Equal(t, "my-issue", gotID)
+}
+
+func TestResolve_Error(t *testing.T) {
+	client := &mockClient{
+		resolveFn: func(_ context.Context, _ *pb.ResolveHealthIssueRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			return nil, errors.New("rpc error")
+		},
+	}
+	r := newReporter(client)
+	assert.Error(t, r.Resolve(context.Background(), "x"))
+}
+
+// ============================================================================
+// ReportWithRetry / ResolveWithRetry
+// ============================================================================
+
+func TestReportWithRetry_SucceedsInSynchronousWindow(t *testing.T) {
+	var calls atomic.Int32
+	client := &mockClient{
+		reportFn: func(_ context.Context, _ *pb.ReportHealthIssueRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			calls.Add(1)
+			return &emptypb.Empty{}, nil
+		},
+	}
+	r := &Reporter{
+		callTimeout: 500 * time.Millisecond,
+		maxWait:     5 * time.Second,
+		newClientFn: func() (pb.AgentSecureClient, error) { return client, nil },
+	}
+	r.ReportWithRetry(&healthplatformpayload.Issue{Id: "x", IssueName: "X"})
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestReportWithRetry_RetriesInBackground(t *testing.T) {
+	// Fail for the first 200ms (synchronous window = 100ms), then succeed.
+	start := time.Now()
+	var calls atomic.Int32
+	client := &mockClient{
+		reportFn: func(_ context.Context, _ *pb.ReportHealthIssueRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			calls.Add(1)
+			if time.Since(start) < 200*time.Millisecond {
+				return nil, errors.New("not ready")
+			}
+			return &emptypb.Empty{}, nil
+		},
+	}
+	r := &Reporter{
+		callTimeout: 50 * time.Millisecond,
+		maxWait:     2 * time.Second,
+		newClientFn: func() (pb.AgentSecureClient, error) { return client, nil },
+	}
+	// ReportMaxWait is 30s in production; override by using a tiny maxWait so the
+	// synchronous window (= maxWait - remaining) expires quickly.
+	// Instead, test retryWithBackoff directly for the background-continuation case.
+	_ = r.retryWithBackoff("report x", 100*time.Millisecond, func() error {
+		return r.Report(context.Background(), &healthplatformpayload.Issue{Id: "x", IssueName: "X"})
+	})
+	// Not yet succeeded — background retry should pick it up.
+	go r.retryWithBackoff("report x bg", 2*time.Second, func() error {
+		return r.Report(context.Background(), &healthplatformpayload.Issue{Id: "x", IssueName: "X"})
+	})
+	require.Eventually(t, func() bool { return calls.Load() > 1 }, 3*time.Second, 50*time.Millisecond)
+}
+
+func TestResolveWithRetry_EventuallySucceeds(t *testing.T) {
+	// Fail on the first attempt, succeed on the second.
+	// With the 2s initial backoff the resolve completes at ~T=2s; wait up to 5s.
+	var calls atomic.Int32
+	done := make(chan struct{})
+	client := &mockClient{
+		resolveFn: func(_ context.Context, _ *pb.ResolveHealthIssueRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			n := calls.Add(1)
+			if n == 1 {
+				return nil, errors.New("not ready")
+			}
+			close(done)
+			return &emptypb.Empty{}, nil
+		},
+	}
+	r := &Reporter{
+		callTimeout: 50 * time.Millisecond,
+		maxWait:     5 * time.Second,
+		newClientFn: func() (pb.AgentSecureClient, error) { return client, nil },
+	}
+	r.ResolveWithRetry("my-issue")
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ResolveWithRetry did not succeed within 5s")
+	}
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+// ============================================================================
+// StringStruct
+// ============================================================================
+
+func TestStringStruct(t *testing.T) {
+	s := StringStruct(map[string]string{"key": "value", "empty": ""})
+	require.NotNil(t, s)
+	assert.Equal(t, structpb.NewStringValue("value"), s.Fields["key"])
+	assert.Equal(t, structpb.NewStringValue(""), s.Fields["empty"])
+	assert.Len(t, s.Fields, 2)
+}
+
+func TestStringStruct_Empty(t *testing.T) {
+	s := StringStruct(nil)
+	assert.NotNil(t, s)
+	assert.Empty(t, s.Fields)
+}

--- a/test/new-e2e/tests/agent-health/.claude/skills/write-agent-health-e2e/SKILL.md
+++ b/test/new-e2e/tests/agent-health/.claude/skills/write-agent-health-e2e/SKILL.md
@@ -199,7 +199,7 @@ Never re-declare `healthPlatformAgentConfig` — it is already a `const` in `che
 
 ## Step 5 — Rules (never break these)
 
-- **Flush order**: restart or `UpdateEnv` first → wait for agent ready → `FlushServerAndResetAggregators()`. Never flush before restarting.
+- **Flush order**: for issues resolved during a **periodic check** (e.g. check failures): `UpdateEnv` → wait for agent ready → `FlushServerAndResetAggregators()`. For issues resolved **at startup** (e.g. probe init failures): `FlushServerAndResetAggregators()` → `UpdateEnv`. The risk with startup-resolved issues is that the RESOLVED tombstone arrives before `UpdateEnv` returns, so a flush afterward clears it permanently.
 - **No resilience phase**: `RestartResilience` is covered once in `TestResilienceSuite`. Do not add it here.
 - **No diagnose assertions**: assert only through fakeintake state (`ISSUE_STATE_NEW`, `ISSUE_STATE_RESOLVED`).
 - **No shared lifecycle driver**: phases (`IssueDetection`, `Resolution`) are always inline in the test method.

--- a/test/new-e2e/tests/agent-health/.claude/skills/write-agent-health-e2e/SKILL.md
+++ b/test/new-e2e/tests/agent-health/.claude/skills/write-agent-health-e2e/SKILL.md
@@ -174,7 +174,7 @@ func (suite *{module}Suite) Test{Module}IssueLifecycle() {
                 }
             }
             return false
-        }, defaultIssueAbsenceWindow, defaultIssuePollInterval,
+        }, 30*time.Second, defaultIssuePollInterval,
             "issue still reported as non-resolved after fix")
     })
 }

--- a/test/new-e2e/tests/agent-health/.claude/skills/write-agent-health-e2e/SKILL.md
+++ b/test/new-e2e/tests/agent-health/.claude/skills/write-agent-health-e2e/SKILL.md
@@ -199,7 +199,7 @@ Never re-declare `healthPlatformAgentConfig` — it is already a `const` in `che
 
 ## Step 5 — Rules (never break these)
 
-- **Flush order**: for issues resolved during a **periodic check** (e.g. check failures): `UpdateEnv` → wait for agent ready → `FlushServerAndResetAggregators()`. For issues resolved **at startup** (e.g. probe init failures): `FlushServerAndResetAggregators()` → `UpdateEnv`. The risk with startup-resolved issues is that the RESOLVED tombstone arrives before `UpdateEnv` returns, so a flush afterward clears it permanently.
+- **Flush order**: do NOT flush in the resolution step. Fakeintake accumulates all payloads; `GetAgentHealth()` returns everything since the last flush. The RESOLVED tombstone is emitted once and stays in fakeintake until flushed — so flushing in the resolution step deletes it. Only flush in the detection step to clear stale pre-condition data.
 - **No resilience phase**: `RestartResilience` is covered once in `TestResilienceSuite`. Do not add it here.
 - **No diagnose assertions**: assert only through fakeintake state (`ISSUE_STATE_NEW`, `ISSUE_STATE_RESOLVED`).
 - **No shared lifecycle driver**: phases (`IssueDetection`, `Resolution`) are always inline in the test method.

--- a/test/new-e2e/tests/agent-health/helpers_test.go
+++ b/test/new-e2e/tests/agent-health/helpers_test.go
@@ -21,6 +21,8 @@ const (
 	defaultIssueTimeout = 2 * time.Minute
 	// defaultIssuePollInterval is the poll cadence for EventuallyWithT.
 	defaultIssuePollInterval = 10 * time.Second
+	// defaultIssueAbsenceWindow is the duration over which require.Never verifies an issue stays absent.
+	defaultIssueAbsenceWindow = 30 * time.Second
 )
 
 // findIssuesByID returns all issues with the given exact ID from a fakeintake payload.

--- a/test/new-e2e/tests/agent-health/helpers_test.go
+++ b/test/new-e2e/tests/agent-health/helpers_test.go
@@ -21,8 +21,6 @@ const (
 	defaultIssueTimeout = 2 * time.Minute
 	// defaultIssuePollInterval is the poll cadence for EventuallyWithT.
 	defaultIssuePollInterval = 10 * time.Second
-	// defaultIssueAbsenceWindow is the duration over which require.Never verifies an issue stays absent.
-	defaultIssueAbsenceWindow = 30 * time.Second
 )
 
 // findIssuesByID returns all issues with the given exact ID from a fakeintake payload.

--- a/test/new-e2e/tests/agent-health/networkprobe_test.go
+++ b/test/new-e2e/tests/agent-health/networkprobe_test.go
@@ -100,11 +100,6 @@ func (suite *networkProbeSuite) TestNetworkProbeInitFailureLifecycle() {
 	// Step 2 — Kernel fix: remove exclusion, assert network-probe-kernel-unsupported RESOLVED
 	// -------------------------------------------------------------------------
 	suite.T().Run("KernelIssueResolution", func(t *testing.T) {
-		// Flush before restarting: the agent resolves the issue at startup, so the
-		// RESOLVED tombstone arrives before UpdateEnv returns. Flushing first ensures
-		// it is not cleared before the assertion below can observe it.
-		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
-
 		suite.UpdateEnv(awshost.Provisioner(
 			awshost.WithRunOptions(
 				ec2.WithAgentOptions(
@@ -176,8 +171,6 @@ func (suite *networkProbeSuite) TestNetworkProbeInitFailureLifecycle() {
 		if !usmUnsupported {
 			t.Skipf("kernel %d.%d.%d >= %d.%d: USM is supported, skipping USM resolution scenario", major, minor, patch, usmMinMajor, usmMinMinor)
 		}
-
-		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
 
 		suite.UpdateEnv(awshost.Provisioner(
 			awshost.WithRunOptions(

--- a/test/new-e2e/tests/agent-health/networkprobe_test.go
+++ b/test/new-e2e/tests/agent-health/networkprobe_test.go
@@ -100,6 +100,11 @@ func (suite *networkProbeSuite) TestNetworkProbeInitFailureLifecycle() {
 	// Step 2 — Kernel fix: remove exclusion, assert network-probe-kernel-unsupported RESOLVED
 	// -------------------------------------------------------------------------
 	suite.T().Run("KernelIssueResolution", func(t *testing.T) {
+		// Flush before restarting: the agent resolves the issue at startup, so the
+		// RESOLVED tombstone arrives before UpdateEnv returns. Flushing first ensures
+		// it is not cleared before the assertion below can observe it.
+		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
+
 		suite.UpdateEnv(awshost.Provisioner(
 			awshost.WithRunOptions(
 				ec2.WithAgentOptions(
@@ -108,8 +113,6 @@ func (suite *networkProbeSuite) TestNetworkProbeInitFailureLifecycle() {
 				),
 			),
 		))
-
-		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
 
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			payloads, err := fakeIntake.GetAgentHealth()
@@ -174,6 +177,8 @@ func (suite *networkProbeSuite) TestNetworkProbeInitFailureLifecycle() {
 			t.Skipf("kernel %d.%d.%d >= %d.%d: USM is supported, skipping USM resolution scenario", major, minor, patch, usmMinMajor, usmMinMinor)
 		}
 
+		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
+
 		suite.UpdateEnv(awshost.Provisioner(
 			awshost.WithRunOptions(
 				ec2.WithAgentOptions(
@@ -182,8 +187,6 @@ func (suite *networkProbeSuite) TestNetworkProbeInitFailureLifecycle() {
 				),
 			),
 		))
-
-		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
 
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			payloads, err := fakeIntake.GetAgentHealth()

--- a/test/new-e2e/tests/agent-health/networkprobe_test.go
+++ b/test/new-e2e/tests/agent-health/networkprobe_test.go
@@ -1,0 +1,212 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package agenthealth
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+)
+
+type networkProbeSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+func TestNetworkProbeSuite(t *testing.T) {
+	t.Parallel()
+	e2e.Run(t, &networkProbeSuite{},
+		e2e.WithProvisioner(awshost.Provisioner(
+			awshost.WithRunOptions(
+				ec2.WithAgentOptions(
+					agentparams.WithAgentConfig(healthPlatformAgentConfig),
+				),
+			),
+		)),
+	)
+}
+
+// TestNetworkProbeInitFailureLifecycle exercises the two independent error paths in
+// createNetworkTracerModule and verifies that each produces the correct health issue
+// in fakeintake and transitions to RESOLVED when fixed.
+//
+//  1. Kernel check failure (errNetworkProbeKernelUnsupported): simulated by adding the
+//     running kernel to excluded_linux_versions. Asserts network-probe-kernel-unsupported
+//     appears as NEW, then RESOLVED after the exclusion is removed.
+//
+//  2. USM tracer init failure (errNetworkProbeUSMUnsupported): only exercised when the
+//     running kernel is < 4.14 (USM minimum). Asserts network-probe-usm-unsupported
+//     appears as NEW with USM enabled and no kernel exclusion, then RESOLVED after USM
+//     is disabled. Skipped on modern kernels where USM is supported.
+func (suite *networkProbeSuite) TestNetworkProbeInitFailureLifecycle() {
+	fakeIntake := suite.Env().FakeIntake.Client()
+
+	// Detect the running kernel version once for both sub-tests.
+	unameR := strings.TrimSpace(suite.Env().RemoteHost.MustExecute("uname -r"))
+	var major, minor, patch int
+	_, _ = fmt.Sscanf(unameR, "%d.%d.%d", &major, &minor, &patch)
+
+	// Build a YAML exclusion list covering all possible patch values for major.minor
+	// so the kernel exclusion fires even when vDSO encodes the ABI in the patch byte.
+	var exclusionYAML strings.Builder
+	for p := 0; p <= 255; p++ {
+		fmt.Fprintf(&exclusionYAML, "    - %d.%d.%d\n", major, minor, p)
+	}
+	kernelExclusionConfig := "network_config:\n  enabled: true\nsystem_probe_config:\n  excluded_linux_versions:\n" + exclusionYAML.String()
+
+	// -------------------------------------------------------------------------
+	// Step 1 — Kernel check failure: assert network-probe-kernel-unsupported NEW
+	// -------------------------------------------------------------------------
+	suite.T().Run("KernelIssueDetection", func(t *testing.T) {
+		suite.UpdateEnv(awshost.Provisioner(
+			awshost.WithRunOptions(
+				ec2.WithAgentOptions(
+					agentparams.WithAgentConfig(healthPlatformAgentConfig),
+					agentparams.WithSystemProbeConfig(kernelExclusionConfig),
+				),
+			),
+		))
+
+		defer logNetworkProbeLogsOnFailure(t, suite)
+
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			payloads, err := fakeIntake.GetAgentHealth()
+			assert.NoError(ct, err)
+			for _, p := range payloads {
+				for _, iss := range findIssuesByID(t, p, "network-probe-kernel-unsupported") {
+					if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_NEW {
+						return
+					}
+				}
+			}
+			assert.Fail(ct, "network-probe-kernel-unsupported not found as NEW")
+		}, defaultIssueTimeout, defaultIssuePollInterval, "kernel issue not detected in fakeintake")
+	})
+
+	// -------------------------------------------------------------------------
+	// Step 2 — Kernel fix: remove exclusion, assert network-probe-kernel-unsupported RESOLVED
+	// -------------------------------------------------------------------------
+	suite.T().Run("KernelIssueResolution", func(t *testing.T) {
+		suite.UpdateEnv(awshost.Provisioner(
+			awshost.WithRunOptions(
+				ec2.WithAgentOptions(
+					agentparams.WithAgentConfig(healthPlatformAgentConfig),
+					agentparams.WithSystemProbeConfig("network_config:\n  enabled: true\n"),
+				),
+			),
+		))
+
+		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
+
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			payloads, err := fakeIntake.GetAgentHealth()
+			assert.NoError(ct, err)
+			for _, p := range payloads {
+				for _, iss := range findIssuesByID(t, p, "network-probe-kernel-unsupported") {
+					if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_RESOLVED {
+						return
+					}
+				}
+			}
+			assert.Fail(ct, "network-probe-kernel-unsupported not found as RESOLVED")
+		}, defaultIssueTimeout, defaultIssuePollInterval, "kernel issue never transitioned to RESOLVED")
+	})
+
+	// -------------------------------------------------------------------------
+	// Step 3 — USM check failure: only exercised on kernels < 4.14
+	// -------------------------------------------------------------------------
+	// USM requires kernel >= 4.14. On modern E2E environments (5.x+) this step
+	// is skipped because NewTracer would succeed and errNetworkProbeUSMUnsupported
+	// would never fire.
+	const usmMinMajor, usmMinMinor = 4, 14
+	usmUnsupported := major < usmMinMajor || (major == usmMinMajor && minor < usmMinMinor)
+
+	suite.T().Run("USMIssueDetection", func(t *testing.T) {
+		if !usmUnsupported {
+			t.Skipf("kernel %d.%d.%d >= %d.%d: USM is supported, skipping USM failure scenario", major, minor, patch, usmMinMajor, usmMinMinor)
+		}
+
+		suite.UpdateEnv(awshost.Provisioner(
+			awshost.WithRunOptions(
+				ec2.WithAgentOptions(
+					agentparams.WithAgentConfig(healthPlatformAgentConfig),
+					// No kernel exclusion — kernel check passes. USM enabled on an
+					// unsupported kernel so NewTracer fails with errNetworkProbeUSMUnsupported.
+					agentparams.WithSystemProbeConfig("network_config:\n  enabled: true\nservice_monitoring_config:\n  enabled: true\n"),
+				),
+			),
+		))
+
+		defer logNetworkProbeLogsOnFailure(t, suite)
+
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			payloads, err := fakeIntake.GetAgentHealth()
+			assert.NoError(ct, err)
+			for _, p := range payloads {
+				for _, iss := range findIssuesByID(t, p, "network-probe-usm-unsupported") {
+					if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_NEW {
+						return
+					}
+				}
+			}
+			assert.Fail(ct, "network-probe-usm-unsupported not found as NEW")
+		}, defaultIssueTimeout, defaultIssuePollInterval, "USM issue not detected in fakeintake")
+	})
+
+	// -------------------------------------------------------------------------
+	// Step 4 — USM fix: disable USM, assert network-probe-usm-unsupported RESOLVED
+	// -------------------------------------------------------------------------
+	suite.T().Run("USMIssueResolution", func(t *testing.T) {
+		if !usmUnsupported {
+			t.Skipf("kernel %d.%d.%d >= %d.%d: USM is supported, skipping USM resolution scenario", major, minor, patch, usmMinMajor, usmMinMinor)
+		}
+
+		suite.UpdateEnv(awshost.Provisioner(
+			awshost.WithRunOptions(
+				ec2.WithAgentOptions(
+					agentparams.WithAgentConfig(healthPlatformAgentConfig),
+					agentparams.WithSystemProbeConfig("network_config:\n  enabled: true\n"),
+				),
+			),
+		))
+
+		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
+
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			payloads, err := fakeIntake.GetAgentHealth()
+			assert.NoError(ct, err)
+			for _, p := range payloads {
+				for _, iss := range findIssuesByID(t, p, "network-probe-usm-unsupported") {
+					if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_RESOLVED {
+						return
+					}
+				}
+			}
+			assert.Fail(ct, "network-probe-usm-unsupported not found as RESOLVED")
+		}, defaultIssueTimeout, defaultIssuePollInterval, "USM issue never transitioned to RESOLVED")
+	})
+}
+
+func logNetworkProbeLogsOnFailure(t *testing.T, suite *networkProbeSuite) {
+	t.Helper()
+	if !t.Failed() {
+		return
+	}
+	status, _ := suite.Env().RemoteHost.Execute("sudo systemctl status datadog-agent-sysprobe --no-pager -l")
+	t.Logf("system-probe status:\n%s", status)
+	logs, _ := suite.Env().RemoteHost.Execute("sudo journalctl -u datadog-agent-sysprobe -n 100 --no-pager 2>&1 || sudo cat /var/log/datadog/system-probe.log 2>&1 | tail -100")
+	t.Logf("system-probe logs:\n%s", logs)
+}

--- a/test/new-e2e/tests/agent-health/networkprobe_test.go
+++ b/test/new-e2e/tests/agent-health/networkprobe_test.go
@@ -87,12 +87,14 @@ func (suite *networkProbeSuite) TestNetworkProbeInitFailureLifecycle() {
 			assert.NoError(ct, err)
 			for _, p := range payloads {
 				for _, iss := range findIssuesByID(t, p, "network-probe-kernel-unsupported") {
-					if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_NEW {
+					if iss.PersistedIssue != nil &&
+						(iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_NEW ||
+							iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_ONGOING) {
 						return
 					}
 				}
 			}
-			assert.Fail(ct, "network-probe-kernel-unsupported not found as NEW")
+			assert.Fail(ct, "network-probe-kernel-unsupported not found as NEW or ONGOING")
 		}, defaultIssueTimeout, defaultIssuePollInterval, "kernel issue not detected in fakeintake")
 	})
 
@@ -155,12 +157,14 @@ func (suite *networkProbeSuite) TestNetworkProbeInitFailureLifecycle() {
 			assert.NoError(ct, err)
 			for _, p := range payloads {
 				for _, iss := range findIssuesByID(t, p, "network-probe-usm-unsupported") {
-					if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_NEW {
+					if iss.PersistedIssue != nil &&
+						(iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_NEW ||
+							iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_ONGOING) {
 						return
 					}
 				}
 			}
-			assert.Fail(ct, "network-probe-usm-unsupported not found as NEW")
+			assert.Fail(ct, "network-probe-usm-unsupported not found as NEW or ONGOING")
 		}, defaultIssueTimeout, defaultIssuePollInterval, "USM issue not detected in fakeintake")
 	})
 

--- a/test/new-e2e/tests/agent-health/networkprobe_test.go
+++ b/test/new-e2e/tests/agent-health/networkprobe_test.go
@@ -79,6 +79,7 @@ func (suite *networkProbeSuite) TestNetworkProbeInitFailureLifecycle() {
 				),
 			),
 		))
+		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
 
 		defer logNetworkProbeLogsOnFailure(t, suite)
 
@@ -149,6 +150,7 @@ func (suite *networkProbeSuite) TestNetworkProbeInitFailureLifecycle() {
 				),
 			),
 		))
+		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
 
 		defer logNetworkProbeLogsOnFailure(t, suite)
 


### PR DESCRIPTION
### What does this PR do?

When CNM or USM is enabled but the eBPF network tracer fails to initialize, system-probe now reports a structured health issue to the core agent via the existing `ReportHealthIssue` / `ResolveHealthIssue` through RAR.

Two failure modes are covered with separate issue IDs and targeted remediation:
- `network-probe-kernel-unsupported` — kernel version check failed
- `network-probe-usm-unsupported` — USM requires a newer kernel than the one running

On a successful restart (failure fixed), system-probe explicitly resolves the issue.

### Motivation

When system-probe is running but CNM/USM eBPF probes fail to load, the core agent sees the socket as reachable and never surfaces the failure. Operators lose CNM/USM data silently. This makes the failure visible through the health platform with actionable remediation.

### Describe how you validated your changes

Unit tests: `dda inv test --targets=./pkg/system-probe/healthreporter/...`

E2E test (`test/new-e2e/tests/agent-health/networkprobe_test.go`): exercises the full lifecycle — detection (issue appears as NEW/ONGOING) and resolution (issue transitions to RESOLVED) for both kernel and USM failure paths.

### Additional Notes
 /