### PR TITLE
configfilesdiscovery: add docker config reader

### DIFF
--- a/comp/core/configfilesdiscovery/impl/BUILD.bazel
+++ b/comp/core/configfilesdiscovery/impl/BUILD.bazel
@@ -4,6 +4,8 @@ go_library(
     name = "impl",
     srcs = [
         "configfilesdiscovery.go",
+        "docker_reader.go",
+        "docker_reader_nodocker.go",
         "scheduler.go",
         "types.go",
     ],
@@ -16,13 +18,31 @@ go_library(
         "//comp/core/configfilesdiscovery/def",
         "//comp/core/workloadmeta/def",
         "//comp/def",
+        "//pkg/util/docker",
         "//pkg/util/log",
     ],
 )
 
 go_test(
+    name = "docker_reader_test",
+    srcs = ["docker_reader_test.go"],
+    embed = [":impl"],
+    gotags = [
+        "docker",
+        "test",
+    ],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)
+
+go_test(
     name = "impl_test",
-    srcs = ["configfilesdiscovery_test.go"],
+    srcs = [
+        "configfilesdiscovery_test.go",
+        "docker_reader_test.go",
+    ],
     embed = [":impl"],
     gotags = ["test"],
     deps = [

--- a/comp/core/configfilesdiscovery/impl/configfilesdiscovery.go
+++ b/comp/core/configfilesdiscovery/impl/configfilesdiscovery.go
@@ -41,9 +41,13 @@ func newComponent(
 	ad autodiscovery.Component,
 	resolver targetResolver,
 ) *component {
+	readers := map[RuntimeType]configReaderFactory{
+		RuntimeDocker: newDockerConfigReader,
+	}
+	collectors := map[string]configCollector{}
 	return &component{
 		ad:        ad,
-		scheduler: newADScheduler(resolver),
+		scheduler: newADScheduler(resolver, readers, collectors),
 	}
 }
 

--- a/comp/core/configfilesdiscovery/impl/configfilesdiscovery_test.go
+++ b/comp/core/configfilesdiscovery/impl/configfilesdiscovery_test.go
@@ -7,6 +7,7 @@ package configfilesdiscoveryimpl
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -196,9 +197,11 @@ func TestResolveTargetDetectsRuntime(t *testing.T) {
 func TestSchedulerDispatchesRegisteredIntegrationsOnly(t *testing.T) {
 	collector := &recordingConfigCollector{}
 	readerFactory := &recordingConfigReaderFactory{reader: fakeConfigReader{runtime: RuntimeHost}}
-	withConfigCollectors(t, map[string]configCollector{"redis": collector})
-	withConfigReaders(t, map[RuntimeType]configReaderFactory{RuntimeHost: readerFactory.Build})
-	s := newADScheduler(targetResolver{})
+	s := newADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeHost: readerFactory.Build},
+		map[string]configCollector{"redis": collector},
+	)
 	defer s.Stop()
 
 	s.Schedule([]integration.Config{
@@ -218,9 +221,11 @@ func TestSchedulerDispatchesRegisteredIntegrationsOnly(t *testing.T) {
 
 func TestSchedulerContinuesAfterInvalidConfigInBatch(t *testing.T) {
 	collector := &recordingConfigCollector{}
-	withConfigCollectors(t, map[string]configCollector{"redis": collector})
-	withConfigReaders(t, map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})})
-	s := newADScheduler(targetResolver{})
+	s := newADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]configCollector{"redis": collector},
+	)
 	defer s.Stop()
 
 	s.Schedule([]integration.Config{
@@ -237,9 +242,11 @@ func TestSchedulerRunsCollectorOutsideScheduleCallback(t *testing.T) {
 		unblock: make(chan struct{}),
 	}
 	readerFactory := &recordingConfigReaderFactory{reader: fakeConfigReader{runtime: RuntimeHost}}
-	withConfigCollectors(t, map[string]configCollector{"redis": collector})
-	withConfigReaders(t, map[RuntimeType]configReaderFactory{RuntimeHost: readerFactory.Build})
-	s := newADScheduler(targetResolver{})
+	s := newADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeHost: readerFactory.Build},
+		map[string]configCollector{"redis": collector},
+	)
 	defer s.Stop()
 
 	returned := make(chan struct{})
@@ -350,6 +357,18 @@ func (r fakeConfigReader) Runtime() RuntimeType {
 	return r.runtime
 }
 
+func (r fakeConfigReader) ReadFile(context.Context, string) (ConfigFile, error) {
+	return ConfigFile{}, errors.New("not implemented")
+}
+
+func (r fakeConfigReader) ReadEnvVars(context.Context, []string) (map[string]string, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r fakeConfigReader) ReadCommandline(context.Context) (TargetCommandline, error) {
+	return TargetCommandline{}, errors.New("not implemented")
+}
+
 func fakeConfigReaderFactory(reader ConfigReader) configReaderFactory {
 	return func(target) (ConfigReader, error) {
 		return reader, nil
@@ -375,26 +394,6 @@ func (f *recordingConfigReaderFactory) recordedTargets() []target {
 	targets := make([]target, len(f.targets))
 	copy(targets, f.targets)
 	return targets
-}
-
-func withConfigCollectors(t *testing.T, collectors map[string]configCollector) {
-	t.Helper()
-
-	oldCollectors := configCollectors
-	configCollectors = collectors
-	t.Cleanup(func() {
-		configCollectors = oldCollectors
-	})
-}
-
-func withConfigReaders(t *testing.T, readers map[RuntimeType]configReaderFactory) {
-	t.Helper()
-
-	oldReaders := configReaders
-	configReaders = readers
-	t.Cleanup(func() {
-		configReaders = oldReaders
-	})
 }
 
 func newWorkloadMetaMock(t *testing.T) workloadmetamock.Mock {

--- a/comp/core/configfilesdiscovery/impl/docker_reader.go
+++ b/comp/core/configfilesdiscovery/impl/docker_reader.go
@@ -213,7 +213,10 @@ func cleanTarPath(filePath string) string {
 }
 
 func readLimitedFileContent(r io.Reader, limit int) ([]byte, bool, error) {
-	// Read one byte past the limit so files exactly at the limit are not marked truncated.
+	// Read one byte past the returned content limit so we can tell callers whether the
+	// file was truncated or not. Reading only limit bytes does not allow us to distinguish
+	// a file exactly at the limit from a larger file, since the limited reader returns EOF
+	// in both cases.
 	content, err := io.ReadAll(io.LimitReader(r, int64(limit)+1))
 	if err != nil {
 		return nil, false, err

--- a/comp/core/configfilesdiscovery/impl/docker_reader.go
+++ b/comp/core/configfilesdiscovery/impl/docker_reader.go
@@ -1,0 +1,273 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build docker
+
+package configfilesdiscoveryimpl
+
+import (
+	"archive/tar"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+
+	dockerutil "github.com/DataDog/datadog-agent/pkg/util/docker"
+)
+
+const maxConfigFileSize = 1024 * 1024 // 1MiB
+
+// dockerConfigClient is a narrow Docker interface; reader tests mock it so tar
+// decoding, env filtering, and command-line extraction are tested without a
+// Docker daemon.
+type dockerConfigClient interface {
+	getFile(context.Context, string, string) (io.ReadCloser, error)
+	getEnv(context.Context, string) ([]string, error)
+	getCommandline(context.Context, string) (TargetCommandline, error)
+}
+
+func newDockerConfigClient() (dockerConfigClient, error) {
+	util, err := dockerutil.GetDockerUtil()
+	if err != nil {
+		return nil, err
+	}
+	return dockerUtilConfigClient{util: util}, nil
+}
+
+type dockerConfigReader struct {
+	containerID string
+	client      dockerConfigClient
+}
+
+func newDockerConfigReader(t target) (ConfigReader, error) {
+	return newDockerConfigReaderWithClientFactory(t, newDockerConfigClient)
+}
+
+func newDockerConfigReaderWithClientFactory(t target, newClient func() (dockerConfigClient, error)) (ConfigReader, error) {
+	if t.runtime != RuntimeDocker {
+		return nil, fmt.Errorf("unsupported runtime %q", t.runtime)
+	}
+	if t.entityID == "" {
+		return nil, errors.New("empty docker container id")
+	}
+
+	client, err := newClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return newDockerConfigReaderWithClient(t.entityID, client), nil
+}
+
+func newDockerConfigReaderWithClient(containerID string, client dockerConfigClient) ConfigReader {
+	return &dockerConfigReader{
+		containerID: containerID,
+		client:      client,
+	}
+}
+
+func (r *dockerConfigReader) Runtime() RuntimeType {
+	return RuntimeDocker
+}
+
+func (r *dockerConfigReader) ReadFile(ctx context.Context, filePath string) (ConfigFile, error) {
+	cleanPath, err := cleanContainerFilePath(filePath)
+	if err != nil {
+		return ConfigFile{}, err
+	}
+
+	body, err := r.client.getFile(ctx, r.containerID, cleanPath)
+	if err != nil {
+		return ConfigFile{}, fmt.Errorf("copy config file from docker container: %w", err)
+	}
+	defer body.Close()
+
+	return readConfigFileFromDockerArchive(body, cleanPath)
+}
+
+func (r *dockerConfigReader) ReadEnvVars(ctx context.Context, names []string) (map[string]string, error) {
+	if len(names) == 0 {
+		return map[string]string{}, nil
+	}
+
+	envEntries, err := r.client.getEnv(ctx, r.containerID)
+	if err != nil {
+		return nil, fmt.Errorf("get docker container env: %w", err)
+	}
+
+	return filterEnvVars(envEntries, names), nil
+}
+
+func (r *dockerConfigReader) ReadCommandline(ctx context.Context) (TargetCommandline, error) {
+	commandline, err := r.client.getCommandline(ctx, r.containerID)
+	if err != nil {
+		return TargetCommandline{}, fmt.Errorf("get docker container command line: %w", err)
+	}
+
+	return commandline, nil
+}
+
+func readConfigFileFromDockerArchive(r io.Reader, requestedPath string) (ConfigFile, error) {
+	content, truncated, err := readRegularFileFromTar(r, requestedPath)
+	if err != nil {
+		return ConfigFile{}, err
+	}
+
+	return ConfigFile{
+		Path:      requestedPath,
+		Content:   content,
+		Truncated: truncated,
+	}, nil
+}
+
+func filterEnvVars(envEntries []string, names []string) map[string]string {
+	wanted := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		wanted[name] = struct{}{}
+	}
+
+	env := make(map[string]string)
+	for _, entry := range envEntries {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if _, ok := wanted[name]; !ok {
+			continue
+		}
+		env[name] = value
+	}
+
+	return env
+}
+
+func readRegularFileFromTar(r io.Reader, requestedPath string) ([]byte, bool, error) {
+	tr := tar.NewReader(r)
+
+	header, err := tr.Next()
+	if err == io.EOF {
+		return nil, false, errors.New("empty docker archive")
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("read docker archive: %w", err)
+	}
+
+	if !isRegularTarEntry(header) {
+		return nil, false, fmt.Errorf("docker archive entry %q is not a regular file", header.Name)
+	}
+	if !matchesRequestedPath(header.Name, requestedPath) {
+		return nil, false, fmt.Errorf("docker archive entry %q does not match requested path %q", header.Name, requestedPath)
+	}
+
+	content, truncated, err := readLimitedFileContent(tr, maxConfigFileSize)
+	if err != nil {
+		return nil, false, fmt.Errorf("read docker archive entry %q: %w", header.Name, err)
+	}
+	if truncated {
+		return content, true, nil
+	}
+
+	next, err := tr.Next()
+	if err != io.EOF {
+		if err != nil {
+			return nil, false, fmt.Errorf("read docker archive: %w", err)
+		}
+		return nil, false, fmt.Errorf("ambiguous docker archive includes multiple entries: %q and %q", header.Name, next.Name)
+	}
+
+	return content, false, nil
+}
+
+func cleanContainerFilePath(filePath string) (string, error) {
+	if filePath == "" {
+		return "", errors.New("empty config file path")
+	}
+	if !path.IsAbs(filePath) {
+		return "", fmt.Errorf("config file path %q is not absolute", filePath)
+	}
+	for _, elem := range strings.Split(filePath, "/") {
+		if elem == ".." {
+			return "", fmt.Errorf("config file path %q contains parent traversal", filePath)
+		}
+	}
+	return path.Clean(filePath), nil
+}
+
+func isRegularTarEntry(header *tar.Header) bool {
+	// tar.Reader normalizes the legacy NUL regular-file marker to TypeReg.
+	return header.Typeflag == tar.TypeReg
+}
+
+func matchesRequestedPath(entryName string, requestedPath string) bool {
+	entryPath := cleanTarPath(entryName)
+	requested := cleanTarPath(requestedPath)
+	return entryPath == requested || entryPath == path.Base(requested)
+}
+
+func cleanTarPath(filePath string) string {
+	return strings.TrimPrefix(path.Clean(filePath), "/")
+}
+
+func readLimitedFileContent(r io.Reader, limit int) ([]byte, bool, error) {
+	// Read one byte past the limit so files exactly at the limit are not marked truncated.
+	content, err := io.ReadAll(io.LimitReader(r, int64(limit)+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if len(content) <= limit {
+		return content, false, nil
+	}
+	return content[:limit], true, nil
+}
+
+type dockerUtilConfigClient struct {
+	util *dockerutil.DockerUtil
+}
+
+func (c dockerUtilConfigClient) getFile(ctx context.Context, containerID string, path string) (io.ReadCloser, error) {
+	return c.util.CopyFromContainer(ctx, containerID, path)
+}
+
+func (c dockerUtilConfigClient) getEnv(ctx context.Context, containerID string) ([]string, error) {
+	container, err := c.util.Inspect(ctx, containerID, false)
+	if err != nil {
+		return nil, err
+	}
+	if container.Config == nil {
+		return nil, nil
+	}
+	return container.Config.Env, nil
+}
+
+func (c dockerUtilConfigClient) getCommandline(ctx context.Context, containerID string) (TargetCommandline, error) {
+	container, err := c.util.Inspect(ctx, containerID, false)
+	if err != nil {
+		return TargetCommandline{}, err
+	}
+
+	workingDir := ""
+	if container.Config != nil {
+		workingDir = container.Config.WorkingDir
+	}
+	return targetCommandlineFromDockerConfig(container.Path, container.Args, workingDir), nil
+}
+
+func targetCommandlineFromDockerConfig(commandPath string, commandArgs []string, workingDir string) TargetCommandline {
+	args := make([]string, 0, len(commandArgs)+1)
+	if commandPath != "" {
+		args = append(args, commandPath)
+	}
+	args = append(args, commandArgs...)
+	if workingDir == "" {
+		workingDir = "/"
+	}
+
+	return TargetCommandline{
+		Args:       args,
+		WorkingDir: workingDir,
+	}
+}

--- a/comp/core/configfilesdiscovery/impl/docker_reader_nodocker.go
+++ b/comp/core/configfilesdiscovery/impl/docker_reader_nodocker.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build !docker
+
+package configfilesdiscoveryimpl
+
+import "errors"
+
+func newDockerConfigReader(target) (ConfigReader, error) {
+	return nil, errors.New("no config reader for runtime")
+}

--- a/comp/core/configfilesdiscovery/impl/docker_reader_test.go
+++ b/comp/core/configfilesdiscovery/impl/docker_reader_test.go
@@ -1,0 +1,480 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build docker
+
+package configfilesdiscoveryimpl
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerReaderReportsRuntime(t *testing.T) {
+	reader := newDockerConfigReaderWithClient("container-id", &fakeDockerClient{})
+
+	assert.Equal(t, RuntimeDocker, reader.Runtime())
+}
+
+func TestNewDockerConfigReaderRejectsInvalidTargets(t *testing.T) {
+	tests := []struct {
+		name   string
+		target target
+	}{
+		{
+			name:   "non docker runtime",
+			target: target{runtime: RuntimeHost, entityID: "container-id"},
+		},
+		{
+			name:   "empty container id",
+			target: target{runtime: RuntimeDocker},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader, err := newDockerConfigReader(tt.target)
+
+			require.Error(t, err)
+			assert.Nil(t, reader)
+		})
+	}
+}
+
+func TestNewDockerConfigReaderSurfacesDockerClientErrors(t *testing.T) {
+	expectedErr := errors.New("docker unavailable")
+	newClient := func() (dockerConfigClient, error) {
+		return nil, expectedErr
+	}
+
+	reader, err := newDockerConfigReaderWithClientFactory(target{runtime: RuntimeDocker, entityID: "container-id"}, newClient)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Nil(t, reader)
+}
+
+func TestDockerReaderReadFileReturnsFullContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+	}{
+		{
+			name:    "below limit",
+			content: []byte("port 6379\n"),
+		},
+		{
+			name:    "at limit",
+			content: bytes.Repeat([]byte("a"), maxConfigFileSize),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeDockerClient{
+				copyBody: closeTracker(tarArchive(t, tarEntry{
+					name:    "redis.conf",
+					mode:    0o600,
+					content: tt.content,
+				})),
+			}
+			reader := newDockerConfigReaderWithClient("container-id", client)
+
+			file, err := reader.ReadFile(context.Background(), "/etc/redis/redis.conf")
+
+			require.NoError(t, err)
+			assert.Equal(t, "/etc/redis/redis.conf", file.Path)
+			assert.Equal(t, tt.content, file.Content)
+			assert.False(t, file.Truncated)
+			require.Len(t, client.copyCalls, 1)
+			assert.Equal(t, dockerCopyCall{
+				containerID: "container-id",
+				path:        "/etc/redis/redis.conf",
+			}, client.copyCalls[0])
+		})
+	}
+}
+
+func TestDockerReaderReadFileTruncatesLargeContent(t *testing.T) {
+	content := bytes.Repeat([]byte("a"), maxConfigFileSize+1)
+	client := &fakeDockerClient{
+		copyBody: closeTracker(tarArchive(t, tarEntry{
+			name:    "redis.conf",
+			mode:    0o600,
+			content: content,
+		})),
+	}
+	reader := newDockerConfigReaderWithClient("container-id", client)
+
+	file, err := reader.ReadFile(context.Background(), "/etc/redis/redis.conf")
+
+	require.NoError(t, err)
+	assert.Equal(t, "/etc/redis/redis.conf", file.Path)
+	assert.Equal(t, content[:maxConfigFileSize], file.Content)
+	assert.True(t, file.Truncated)
+}
+
+func TestDockerReaderReadFileClosesArchiveBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		archive []byte
+	}{
+		{
+			name: "success",
+			archive: tarArchive(t, tarEntry{
+				name:    "redis.conf",
+				mode:    0o600,
+				content: []byte("port 6379\n"),
+			}),
+		},
+		{
+			name: "truncation",
+			archive: tarArchive(t, tarEntry{
+				name:    "redis.conf",
+				mode:    0o600,
+				content: bytes.Repeat([]byte("a"), maxConfigFileSize+1),
+			}),
+		},
+		{
+			name: "read error",
+			archive: tarArchive(t, tarEntry{
+				name:     "redis.conf",
+				typeflag: tar.TypeSymlink,
+				linkname: "target.conf",
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := closeTracker(tt.archive)
+			client := &fakeDockerClient{copyBody: body}
+			reader := newDockerConfigReaderWithClient("container-id", client)
+
+			_, _ = reader.ReadFile(context.Background(), "/etc/redis/redis.conf")
+
+			assert.True(t, body.closed)
+		})
+	}
+}
+
+func TestDockerReaderReadFileErrors(t *testing.T) {
+	copyErr := errors.New("copy failed")
+	tests := []struct {
+		name          string
+		path          string
+		copyBody      io.ReadCloser
+		copyErr       error
+		wantCopyCalls int
+		wantErrorIs   error
+	}{
+		{
+			name:          "empty path",
+			path:          "",
+			wantCopyCalls: 0,
+		},
+		{
+			name:          "relative path",
+			path:          "etc/redis/redis.conf",
+			wantCopyCalls: 0,
+		},
+		{
+			name:          "parent traversal",
+			path:          "/etc/../redis/redis.conf",
+			wantCopyCalls: 0,
+		},
+		{
+			name:          "copy error",
+			path:          "/etc/redis/redis.conf",
+			copyErr:       copyErr,
+			wantCopyCalls: 1,
+			wantErrorIs:   copyErr,
+		},
+		{
+			name: "directory",
+			path: "/etc/redis",
+			copyBody: closeTracker(tarArchive(t, tarEntry{
+				name:     "redis",
+				typeflag: tar.TypeDir,
+				mode:     0o755,
+			})),
+			wantCopyCalls: 1,
+		},
+		{
+			name:          "empty archive",
+			path:          "/etc/redis/redis.conf",
+			copyBody:      closeTracker(tarArchive(t)),
+			wantCopyCalls: 1,
+		},
+		{
+			name:          "invalid archive",
+			path:          "/etc/redis/redis.conf",
+			copyBody:      closeTracker([]byte("not a tar archive")),
+			wantCopyCalls: 1,
+		},
+		{
+			name: "symlink",
+			path: "/etc/redis/redis.conf",
+			copyBody: closeTracker(tarArchive(t, tarEntry{
+				name:     "redis.conf",
+				typeflag: tar.TypeSymlink,
+				linkname: "target.conf",
+			})),
+			wantCopyCalls: 1,
+		},
+		{
+			name: "ambiguous archive",
+			path: "/etc/redis/redis.conf",
+			copyBody: closeTracker(tarArchive(t,
+				tarEntry{name: "redis.conf", mode: 0o600, content: []byte("first")},
+				tarEntry{name: "redis.conf.bak", mode: 0o600, content: []byte("second")},
+			)),
+			wantCopyCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeDockerClient{
+				copyBody: tt.copyBody,
+				copyErr:  tt.copyErr,
+			}
+			reader := newDockerConfigReaderWithClient("container-id", client)
+
+			file, err := reader.ReadFile(context.Background(), tt.path)
+
+			require.Error(t, err)
+			assert.Empty(t, file)
+			if tt.wantErrorIs != nil {
+				assert.ErrorIs(t, err, tt.wantErrorIs)
+			}
+			assert.Len(t, client.copyCalls, tt.wantCopyCalls)
+		})
+	}
+}
+
+func TestDockerReaderReadEnvVarsSkipsInspectForEmptyWhitelist(t *testing.T) {
+	client := &fakeDockerClient{}
+	reader := newDockerConfigReaderWithClient("container-id", client)
+
+	env, err := reader.ReadEnvVars(context.Background(), nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, env)
+	assert.Empty(t, client.getEnvCalls)
+}
+
+func TestDockerReaderReadEnvVarsFiltersRequestedNames(t *testing.T) {
+	client := &fakeDockerClient{
+		env: []string{
+			"REDIS_PASSWORD=first",
+			"MALFORMED",
+			"WITH_EQUALS=a=b=c",
+			"EMPTY=",
+			"REDIS_PASSWORD=last",
+			"UNREQUESTED=value",
+		},
+	}
+	reader := newDockerConfigReaderWithClient("container-id", client)
+
+	env, err := reader.ReadEnvVars(context.Background(), []string{
+		"REDIS_PASSWORD",
+		"WITH_EQUALS",
+		"EMPTY",
+		"MISSING",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"REDIS_PASSWORD": "last",
+		"WITH_EQUALS":    "a=b=c",
+		"EMPTY":          "",
+	}, env)
+	assert.Equal(t, []string{"container-id"}, client.getEnvCalls)
+}
+
+func TestDockerReaderReadEnvVarsSurfacesGetEnvErrors(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	client := &fakeDockerClient{getEnvErr: expectedErr}
+	reader := newDockerConfigReaderWithClient("container-id", client)
+
+	env, err := reader.ReadEnvVars(context.Background(), []string{"REDIS_PASSWORD"})
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Nil(t, env)
+	assert.Equal(t, []string{"container-id"}, client.getEnvCalls)
+}
+
+func TestDockerReaderReadCommandlineReturnsTargetCommandline(t *testing.T) {
+	client := &fakeDockerClient{
+		commandPath: "/usr/local/bin/redis-server",
+		commandArgs: []string{
+			"/usr/local/etc/redis/redis.conf",
+			"--loglevel",
+			"warning",
+		},
+		workingDir: "/usr/local/etc/redis",
+	}
+	reader := newDockerConfigReaderWithClient("container-id", client)
+
+	commandline, err := reader.ReadCommandline(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, TargetCommandline{
+		Args: []string{
+			"/usr/local/bin/redis-server",
+			"/usr/local/etc/redis/redis.conf",
+			"--loglevel",
+			"warning",
+		},
+		WorkingDir: "/usr/local/etc/redis",
+	}, commandline)
+	assert.Equal(t, []string{"container-id"}, client.getCommandlineCalls)
+}
+
+func TestDockerReaderReadCommandlineAllowsEmptyCommandPath(t *testing.T) {
+	client := &fakeDockerClient{
+		commandArgs: []string{"redis-server"},
+	}
+	reader := newDockerConfigReaderWithClient("container-id", client)
+
+	commandline, err := reader.ReadCommandline(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, TargetCommandline{Args: []string{"redis-server"}, WorkingDir: "/"}, commandline)
+}
+
+func TestDockerReaderReadCommandlineDefaultsEmptyWorkingDirToRoot(t *testing.T) {
+	client := &fakeDockerClient{
+		commandPath: "redis-server",
+		commandArgs: []string{
+			"redis.conf",
+		},
+	}
+	reader := newDockerConfigReaderWithClient("container-id", client)
+
+	commandline, err := reader.ReadCommandline(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, TargetCommandline{
+		Args:       []string{"redis-server", "redis.conf"},
+		WorkingDir: "/",
+	}, commandline)
+}
+
+func TestDockerReaderReadCommandlineSurfacesGetCommandlineErrors(t *testing.T) {
+	expectedErr := errors.New("command line unavailable")
+	client := &fakeDockerClient{getCommandlineErr: expectedErr}
+	reader := newDockerConfigReaderWithClient("container-id", client)
+
+	commandline, err := reader.ReadCommandline(context.Background())
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, commandline)
+	assert.Equal(t, []string{"container-id"}, client.getCommandlineCalls)
+}
+
+type fakeDockerClient struct {
+	copyCalls           []dockerCopyCall
+	copyBody            io.ReadCloser
+	copyErr             error
+	getEnvCalls         []string
+	env                 []string
+	getEnvErr           error
+	getCommandlineCalls []string
+	commandPath         string
+	commandArgs         []string
+	workingDir          string
+	getCommandlineErr   error
+}
+
+type dockerCopyCall struct {
+	containerID string
+	path        string
+}
+
+func (c *fakeDockerClient) getFile(_ context.Context, containerID string, path string) (io.ReadCloser, error) {
+	c.copyCalls = append(c.copyCalls, dockerCopyCall{containerID: containerID, path: path})
+	if c.copyErr != nil {
+		return nil, c.copyErr
+	}
+	return c.copyBody, nil
+}
+
+func (c *fakeDockerClient) getEnv(_ context.Context, containerID string) ([]string, error) {
+	c.getEnvCalls = append(c.getEnvCalls, containerID)
+	if c.getEnvErr != nil {
+		return nil, c.getEnvErr
+	}
+	return c.env, nil
+}
+
+func (c *fakeDockerClient) getCommandline(_ context.Context, containerID string) (TargetCommandline, error) {
+	c.getCommandlineCalls = append(c.getCommandlineCalls, containerID)
+	if c.getCommandlineErr != nil {
+		return TargetCommandline{}, c.getCommandlineErr
+	}
+	return targetCommandlineFromDockerConfig(c.commandPath, c.commandArgs, c.workingDir), nil
+}
+
+type trackingReadCloser struct {
+	*bytes.Reader
+	closed bool
+}
+
+func closeTracker(content []byte) *trackingReadCloser {
+	return &trackingReadCloser{Reader: bytes.NewReader(content)}
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+type tarEntry struct {
+	name     string
+	typeflag byte
+	mode     int64
+	linkname string
+	content  []byte
+}
+
+func tarArchive(t *testing.T, entries ...tarEntry) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, entry := range entries {
+		typeflag := entry.typeflag
+		if typeflag == 0 {
+			typeflag = tar.TypeReg
+		}
+		mode := entry.mode
+		if mode == 0 {
+			mode = 0o600
+		}
+		header := &tar.Header{
+			Name:     entry.name,
+			Typeflag: typeflag,
+			Mode:     mode,
+			Size:     int64(len(entry.content)),
+			Linkname: entry.linkname,
+		}
+		require.NoError(t, tw.WriteHeader(header))
+		if len(entry.content) > 0 {
+			_, err := io.Copy(tw, bytes.NewReader(entry.content))
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, tw.Close())
+
+	return buf.Bytes()
+}

--- a/comp/core/configfilesdiscovery/impl/scheduler.go
+++ b/comp/core/configfilesdiscovery/impl/scheduler.go
@@ -20,7 +20,9 @@ const (
 )
 
 type adScheduler struct {
-	resolver targetResolver
+	resolver   targetResolver
+	readers    map[RuntimeType]configReaderFactory
+	collectors map[string]configCollector
 
 	ctx             context.Context
 	cancel          context.CancelFunc
@@ -42,10 +44,12 @@ type configCollectionWork struct {
 // Autodiscovery calls this scheduler when integration configs appear or
 // disappear; this component only uses the scheduled configs as triggers for
 // one-shot config collection.
-func newADScheduler(resolver targetResolver) *adScheduler {
+func newADScheduler(resolver targetResolver, readers map[RuntimeType]configReaderFactory, collectors map[string]configCollector) *adScheduler {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &adScheduler{
 		resolver:        resolver,
+		readers:         readers,
+		collectors:      collectors,
 		ctx:             ctx,
 		cancel:          cancel,
 		collectionQueue: make(chan configCollectionWork, configCollectionQueueSize),
@@ -66,13 +70,13 @@ func (s *adScheduler) Schedule(configs []integration.Config) {
 			continue
 		}
 
-		collector, ok := configCollectors[config.Name]
+		collector, ok := s.collectors[config.Name]
 		if !ok {
 			log.Debugf("config files discovery has no collector for integration %q service %q", config.Name, config.ServiceID)
 			continue
 		}
 
-		readerFactory, ok := configReaders[target.runtime]
+		readerFactory, ok := s.readers[target.runtime]
 		if !ok {
 			log.Debugf("config files discovery has no config reader for integration %q service %q runtime %q", config.Name, config.ServiceID, target.runtime)
 			continue

--- a/comp/core/configfilesdiscovery/impl/types.go
+++ b/comp/core/configfilesdiscovery/impl/types.go
@@ -30,9 +30,25 @@ type target struct {
 	entityID string
 }
 
+// ConfigFile is the content read from a runtime-specific config file path.
+type ConfigFile struct {
+	Path      string
+	Content   []byte
+	Truncated bool
+}
+
+// TargetCommandline is the command line used to start the target service.
+type TargetCommandline struct {
+	Args       []string
+	WorkingDir string
+}
+
 // ConfigReader is the runtime-specific config access layer used by config collectors.
 type ConfigReader interface {
 	Runtime() RuntimeType
+	ReadFile(context.Context, string) (ConfigFile, error)
+	ReadEnvVars(context.Context, []string) (map[string]string, error)
+	ReadCommandline(context.Context) (TargetCommandline, error)
 }
 
 type configReaderFactory func(target) (ConfigReader, error)
@@ -40,10 +56,6 @@ type configReaderFactory func(target) (ConfigReader, error)
 type configCollector interface {
 	Run(context.Context, ConfigReader) error
 }
-
-var configReaders = map[RuntimeType]configReaderFactory{}
-
-var configCollectors = map[string]configCollector{}
 
 type targetResolver struct {
 	store workloadmeta.Component

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -137,11 +137,26 @@ func (d *DockerUtil) RawClient() *client.Client {
 // CopyFromContainer wraps the Docker archive API for a single path.
 // The caller is responsible for closing the returned archive stream.
 func (d *DockerUtil) CopyFromContainer(ctx context.Context, containerID string, path string) (io.ReadCloser, error) {
+	ctx, cancel := context.WithTimeout(ctx, d.queryTimeout)
 	result, err := d.cli.CopyFromContainer(ctx, containerID, client.CopyFromContainerOptions{SourcePath: path})
 	if err != nil {
+		cancel()
 		return nil, err
 	}
-	return result.Content, nil
+	return readCloserWithCancel{
+		ReadCloser: result.Content,
+		cancel:     cancel,
+	}, nil
+}
+
+type readCloserWithCancel struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (r readCloserWithCancel) Close() error {
+	r.cancel()
+	return r.ReadCloser.Close()
 }
 
 // RawContainerList wraps around the docker client's ContainerList method.

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -134,6 +134,16 @@ func (d *DockerUtil) RawClient() *client.Client {
 	return d.cli
 }
 
+// CopyFromContainer wraps the Docker archive API for a single path.
+// The caller is responsible for closing the returned archive stream.
+func (d *DockerUtil) CopyFromContainer(ctx context.Context, containerID string, path string) (io.ReadCloser, error) {
+	result, err := d.cli.CopyFromContainer(ctx, containerID, client.CopyFromContainerOptions{SourcePath: path})
+	if err != nil {
+		return nil, err
+	}
+	return result.Content, nil
+}
+
 // RawContainerList wraps around the docker client's ContainerList method.
 // Value validation and error handling are the caller's responsibility.
 func (d *DockerUtil) RawContainerList(ctx context.Context, options client.ContainerListOptions) ([]dcontainer.Summary, error) {


### PR DESCRIPTION
### What does this PR do?

This PR adds a Docker reader for config discovery. This uses our docker utils (and extending them to add support for `CopyFromContainer` i.e the mechanism used by `docker cp`) to read requested files from the container, as well as getting the container environment.

The `CopyFromContainer` returns a tar archive stream as specified in [Docker's documentation](https://docs.docker.com/reference/cli/docker/container/cp/#examples), which the reader decodes before returning to the caller.

### Motivation

DSCVR-455

### Describe how you validated your changes

Covered by unit tests + manual tested as part of implementing Redis' config collector

### Additional Notes
