### PR TITLE
[CWS] Keep TC program mapping if detaching failed

### DIFF
--- a/pkg/security/resolvers/tc/resolver.go
+++ b/pkg/security/resolvers/tc/resolver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 )
 
 // ProgramKey is used to uniquely identify a tc program
@@ -165,10 +166,18 @@ func (tcr *Resolver) SetupNewTCClassifierWithNetNSHandle(device model.NetDevice,
 
 // detachHook detaches and deletes a TC hook from the resolver, needs to be called with the lock held
 func (tcr *Resolver) detachHook(tcKey ProgramKey, entry programEntry, m *manager.Manager) {
+	if err := m.DetachHook(entry.probe.ProbeIdentificationPair); err != nil {
+		seclog.Errorf("couldn't detach TC classifier %s: %v", entry.probe.ProbeIdentificationPair, err)
+		return
+	}
+
+	// only remove the program mapping if the ebpf-manager successfully detached the eBPF programs
+	// otherwise SetupNewTCClassifierWithNetNSHandle might try to recreate the probe when it already exists
+	// from the ebpf-manager PoV.
+	// TODO(yoanngh): fix this ebpf-manager/tc resolver desync
+
 	ddebpf.RemoveProgramID(entry.programID, "cws")
 	delete(tcr.programs, tcKey)
-
-	_ = m.DetachHook(entry.probe.ProbeIdentificationPair)
 }
 
 // FlushNetworkNamespaceID flushes network ID


### PR DESCRIPTION
### What does this PR do?

- Only remove the program mapping from the TC resolver if the ebpf-manager successfully detached the eBPF program.
- Log `DetachHook` errors

### Motivation

Avoid trying to recreate the probe when it already exists from the ebpf-manager PoV.

```
error setting up new tc classifier on snapshot: 2 errors occurred:
	* couldn't clone {UID:security EBPFFuncName:classifier_egress}: couldn't add probe {UID:security_classifier_egress_3761_4026535934 EBPFFuncName:classifier_egress}: the provided identification pair already exists
	* couldn't clone {UID:security EBPFFuncName:classifier_ingress}: couldn't add probe {UID:security_classifier_ingress_3761_4026535934 EBPFFuncName:classifier_ingress}: the provided identification pair already exists
```

### Describe how you validated your changes

### Additional Notes
