### PR TITLE
docs(notifications): note agent-configuration review opt-out

### DIFF
--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -37,6 +37,8 @@
     name: '#agent-configuration-ops'
     id: 'C08A85VGC8P'
   review:
+    # DO NOT FILL IN - team opted out of PR review notifications, see:
+    # https://github.com/DataDog/datadog-agent/pull/51716#issuecomment-4610991841
     name: ''
     id: ''
 '@datadog/agent-cspm':


### PR DESCRIPTION
### What does this PR do?
Add a comment in the `review` block of `agent-configuration` in `github_slack_map.yaml` explaining that the blank channel is intentional, so a next contributor does not try to fill it in again.

### Motivation
The empty `review` entry looks like a misconfiguration: the `ask-review` task treats a falsy channel as "skip", so it reads as a silently dropped notification.
But it is in fact a **deliberate opt-out at the team's request**, as established when an attempt to populate it was declined (https://github.com/DataDog/datadog-agent/pull/51716#issuecomment-4610991841).
With [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) in mind, this setting seems specific enough that it should be documented to spare future readers the same frustration.

### Additional Notes
`#agent-configuration` (https://dd.enterprise.slack.com/archives/C04U1B77E84) is the _de facto_ active team channel where we're expected to file our PR review requests by hand.