### PR TITLE
kubernetes-actions: remove output format option from get resource

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -593,7 +593,7 @@ func start(log log.Component,
 		}
 		log.Infof("[KubeActions] Starting with cluster_id=%s, cluster_name=%s", clusterID, clusterName)
 
-		if kubeactionsRetriever, err = kubeactions.Setup(mainCtx, apiCl.Cl, clusterName, clusterID, le.IsLeader, rcClient, epForwarder); err != nil {
+		if kubeactionsRetriever, err = kubeactions.Setup(mainCtx, apiCl.Cl, apiCl.DynamicCl, clusterName, clusterID, le.IsLeader, rcClient, epForwarder); err != nil {
 			return fmt.Errorf("Error while starting kubernetes actions: %v", err)
 		}
 		log.Info("Kubernetes actions subsystem started successfully")

--- a/pkg/clusteragent/kubeactions/BUILD.bazel
+++ b/pkg/clusteragent/kubeactions/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/remoteconfig/state",
         "//pkg/util/log",
         "@com_github_datadog_agent_payload_v5//kubeactions",
+        "@io_k8s_client_go//dynamic",
         "@io_k8s_client_go//kubernetes",
         "@org_golang_google_protobuf//encoding/protojson",
     ],

--- a/pkg/clusteragent/kubeactions/executors/BUILD.bazel
+++ b/pkg/clusteragent/kubeactions/executors/BUILD.bazel
@@ -19,9 +19,10 @@ go_library(
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/equality",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/runtime/schema",
         "@io_k8s_apimachinery//pkg/types",
+        "@io_k8s_client_go//dynamic",
         "@io_k8s_client_go//kubernetes",
-        "@io_k8s_sigs_yaml//:yaml",
     ],
 )
 
@@ -41,8 +42,11 @@ go_test(
         "@io_k8s_api//apps/v1:apps",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured",
         "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_apimachinery//pkg/runtime/schema",
         "@io_k8s_apimachinery//pkg/types",
+        "@io_k8s_client_go//dynamic/fake",
         "@io_k8s_client_go//kubernetes",
         "@io_k8s_client_go//kubernetes/fake",
         "@io_k8s_client_go//testing",

--- a/pkg/clusteragent/kubeactions/executors/get_resource.go
+++ b/pkg/clusteragent/kubeactions/executors/get_resource.go
@@ -10,14 +10,16 @@ package executors
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
+	"path"
+	"slices"
 	"strings"
 
-	"k8s.io/client-go/kubernetes"
-
-	"sigs.k8s.io/yaml"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 
 	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
 )
@@ -29,8 +31,10 @@ const (
 	maxResourceOutputSize int = 1.5 * 1024 * 1024 // 1.5MB
 )
 
+var protectedResourceKinds = []string{"secret", "secrets"}
+
 type GetResourceExecutor struct {
-	clientset kubernetes.Interface
+	dynamicClient dynamic.Interface
 }
 
 // Ensure interface compliance at compile time
@@ -42,10 +46,14 @@ var (
 )
 
 // NewGetResourceExecutor creates a new GetResourceExecutor
-func NewGetResourceExecutor(clientset kubernetes.Interface) *GetResourceExecutor {
+func NewGetResourceExecutor(dynamicClient dynamic.Interface) *GetResourceExecutor {
 	return &GetResourceExecutor{
-		clientset: clientset,
+		dynamicClient: dynamicClient,
 	}
+}
+
+func getResourceName(kind, namespace, name string) string {
+	return path.Join(kind, namespace, name)
 }
 
 // Execute retrieves the specified Kubernetes resource and returns it as JSON string in the message field of ExecutionResult
@@ -63,60 +71,56 @@ func (e *GetResourceExecutor) Execute(ctx context.Context, action *kubeactions.K
 		}
 	}
 
-	// prevent the executor from being used to get secrets for security reasons, even if the user has permissions to do so, we don't want to allow that
-	if strings.Contains(kind, "secret") {
+	// prevent the executor from being used to get protected resources for security reasons, even if the user has permissions to do so, we don't want to allow that
+	if slices.Contains(protectedResourceKinds, strings.ToLower(kind)) {
 		return ExecutionResult{
 			Status:  StatusFailed,
-			Message: "getting secrets is not allowed for security reasons",
+			Message: fmt.Sprintf("getting %s is not allowed for security reasons", kind),
 		}
 	}
 
-	// build the raw REST request to get the resource as unstructured JSON
-	var path string
-
-	// the api version for core resources does not contain a '/'.
-	// and the path for core resources is /api/....
-	// as for all other resources the path is /apis/...
-	var apiPrefix string
-	if !strings.Contains(apiVersion, "/") {
-		apiPrefix = "/api"
+	// parse apiVersion into group and version for the dynamic client.
+	// core resources have no group (e.g. "v1"), others use "group/version" (e.g. "apps/v1").
+	var group, version string
+	if parts := strings.SplitN(apiVersion, "/", 2); len(parts) == 2 {
+		group, version = parts[0], parts[1]
 	} else {
-		apiPrefix = "/apis"
+		version = apiVersion
 	}
 
-	// resource.GetApiVersion() returns group/version, it will automagically handle adding the group prefix if needed
-	// or not adding it for core resources
-	if namespace == "" {
-		path, _ = url.JoinPath(apiPrefix, apiVersion, kind, name)
-	} else {
-		path, _ = url.JoinPath(apiPrefix, apiVersion, "namespaces", namespace, kind, name)
-	}
+	resourceName := getResourceName(kind, namespace, name)
+
+	gvr := schema.GroupVersionResource{Group: group, Version: version, Resource: kind}
 
 	ctx, cancel := context.WithTimeout(ctx, defaultExecutorTimeout)
 	defer cancel()
 
-	data, err := e.clientset.CoreV1().RESTClient().Get().AbsPath(path).Do(ctx).Raw()
+	obj, err := e.dynamicClient.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return ExecutionResult{
 			Status:  StatusFailed,
-			Message: fmt.Sprintf("failed to get resource: %v -- raw response body: %s", err, string(data)),
+			Message: fmt.Sprintf("failed to get resource %s: %v", resourceName, err),
 		}
 	}
 
-	outputFormat := "json"
-	if output := action.GetGetResource_().GetOutputFormat(); output != "" {
-		outputFormat = strings.ToLower(output)
-	}
-
-	output, err := formatOutput(data, outputFormat)
+	data, err := obj.MarshalJSON()
 	if err != nil {
 		return ExecutionResult{
 			Status:  StatusFailed,
-			Message: fmt.Sprintf("failed to format output to %s: %v", outputFormat, err),
+			Message: fmt.Sprintf("failed to marshal resource %s to JSON: %v", resourceName, err),
 		}
 	}
 
-	output = bytes.TrimSpace(output)
+	buff := bytes.Buffer{}
+
+	// try to compact the JSON data
+	if json.Compact(&buff, data) != nil {
+		// if the JSON data is not compactable, we will use the original data
+		buff.Reset()
+		buff.Write(data)
+	}
+
+	output := bytes.TrimSpace(buff.Bytes())
 	if len(output) > maxResourceOutputSize {
 		return ExecutionResult{
 			Status:  StatusFailed,
@@ -126,25 +130,9 @@ func (e *GetResourceExecutor) Execute(ctx context.Context, action *kubeactions.K
 
 	return ExecutionResult{
 		Status:  StatusSuccess,
-		Message: fmt.Sprintf("get resource %s/%s success", kind, name),
+		Message: fmt.Sprintf("get resource %s success", resourceName),
 		Payloads: map[string][]byte{
-			namespace + "/" + name: output,
+			resourceName: output,
 		},
-	}
-}
-
-func formatOutput(data []byte, format string) ([]byte, error) {
-	switch format {
-	case "json":
-		return data, nil
-	case "yaml":
-		jsonData := data
-		yamlData, err := yaml.JSONToYAML(jsonData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert resource JSON to YAML: %v", err)
-		}
-		return yamlData, nil
-	default:
-		return nil, ErrUnsupportedFormat
 	}
 }

--- a/pkg/clusteragent/kubeactions/executors/get_resource_test.go
+++ b/pkg/clusteragent/kubeactions/executors/get_resource_test.go
@@ -8,71 +8,174 @@
 package executors
 
 import (
-	"errors"
+	"strings"
 	"testing"
+
+	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
-var testPodJSON = []byte(`{
-    "apiVersion": "v1",
-    "kind": "Pod",
-    "metadata": {
-        "name": "test-pod",
-        "namespace": "default"
-    },
-    "spec": {
-        "containers": [
-            {
-                "name": "test-container",
-                "image": "busybox",
-                "command": ["sleep", "3600"]
-            }
-        ]
-    }
-}`)
+// expected max resource output size and over-sized resource bytes
+const (
+	wantMaxResourceOutputSize int = 1.5 * 1024 * 1024
+	overSizedResourceBytes    int = 2 * 1024 * 1024
+)
 
-func TestOutputFormat(t *testing.T) {
+// configMapGVR is the GroupVersionResource the executor builds for a
+// "configmaps" kind with apiVersion "v1".
+var configMapGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+// newGetResourceClient creates a fake dynamic client seeded with the given
+// unstructured objects. The configmaps list kind is registered so the fake
+// client can resolve the GVR used by the executor.
+func newGetResourceClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			configMapGVR: "ConfigMapList",
+		},
+		objects...,
+	)
+}
+
+// newUnstructuredConfigMap builds an unstructured ConfigMap with the provided data.
+func newUnstructuredConfigMap(namespace, name string, data map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"data": data,
+		},
+	}
+}
+
+// makeGetResourceAction builds a get_resource KubeAction targeting the given resource.
+func makeGetResourceAction(apiVersion, kind, namespace, name string) *kubeactions.KubeAction {
+	return &kubeactions.KubeAction{
+		Resource: &kubeactions.KubeResource{
+			ApiVersion: apiVersion,
+			Kind:       kind,
+			Namespace:  namespace,
+			Name:       name,
+		},
+		Action: &kubeactions.KubeAction_GetResource_{
+			GetResource_: &kubeactions.GetResourceParams{},
+		},
+	}
+}
+
+func TestGetResourceExecute(t *testing.T) {
 	tests := []struct {
+		testName     string
+		objects      []runtime.Object
+		apiVersion   string
+		kind         string
+		namespace    string
 		name         string
-		input        []byte
-		outputFormat string
-		expectErr    bool
+		wantStatus   string
+		wantContains string
+		// wantPayloadKey is the exact key the payload to expect in the ExecutionResult
+		wantPayloadKey string
+		// wantPayloadJSON is the exact (compacted) JSON to expect in the ExecutionResult
+		wantPayloadJSON string
 	}{
 		{
-			name:         "from json to json",
-			input:        testPodJSON,
-			outputFormat: "json",
-			expectErr:    false,
+			testName:        "nominal: existing resource is returned",
+			objects:         []runtime.Object{newUnstructuredConfigMap("default", "my-config", map[string]interface{}{"key": "value"})},
+			apiVersion:      "v1",
+			kind:            "configmaps",
+			namespace:       "default",
+			name:            "my-config",
+			wantStatus:      StatusSuccess,
+			wantContains:    "get resource configmaps/default/my-config success",
+			wantPayloadKey:  "configmaps/default/my-config",
+			wantPayloadJSON: `{"apiVersion":"v1","data":{"key":"value"},"kind":"ConfigMap","metadata":{"name":"my-config","namespace":"default"}}`,
 		},
 		{
-			name:         "from json to yaml",
-			input:        testPodJSON,
-			outputFormat: "yaml",
-			expectErr:    false,
+			testName:     "kind does not exist",
+			objects:      nil,
+			apiVersion:   "v1",
+			kind:         "widgets",
+			namespace:    "default",
+			name:         "my-widget",
+			wantStatus:   StatusFailed,
+			wantContains: "failed to get resource widgets/default/my-widget",
 		},
 		{
-			name:         "unsupported format",
-			input:        testPodJSON,
-			outputFormat: "xml",
-			expectErr:    true,
+			testName:     "apiVersion does not exist",
+			objects:      []runtime.Object{newUnstructuredConfigMap("default", "my-config", map[string]interface{}{"key": "value"})},
+			apiVersion:   "v2beta1",
+			kind:         "configmaps",
+			namespace:    "default",
+			name:         "my-config",
+			wantStatus:   StatusFailed,
+			wantContains: "failed to get resource configmaps/default/my-config",
+		},
+		{
+			testName: "resource too large",
+			objects: []runtime.Object{newUnstructuredConfigMap("default", "big-config", map[string]interface{}{
+				"payload": strings.Repeat("a", overSizedResourceBytes),
+			})},
+			apiVersion:   "v1",
+			kind:         "configmaps",
+			namespace:    "default",
+			name:         "big-config",
+			wantStatus:   StatusFailed,
+			wantContains: "resource is too large",
+		},
+		{
+			testName:     "missing apiVersion is rejected",
+			objects:      nil,
+			apiVersion:   "",
+			kind:         "configmaps",
+			namespace:    "default",
+			name:         "my-config",
+			wantStatus:   StatusFailed,
+			wantContains: "apiVersion is required",
+		},
+		{
+			testName:     "protected resource kind is rejected",
+			objects:      nil,
+			apiVersion:   "v1",
+			kind:         "secrets",
+			namespace:    "default",
+			name:         "my-secret",
+			wantStatus:   StatusFailed,
+			wantContains: "not allowed for security reasons",
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// test the output format conversion
-			_, err := formatOutput(tt.input, tt.outputFormat)
+		t.Run(tt.testName, func(t *testing.T) {
+			client := newGetResourceClient(tt.objects...)
+			executor := NewGetResourceExecutor(client)
 
-			// we don't compare the output because the yaml output can have unordered fields.
-			// we only ensure it does not fail
-			if err != nil {
-				if !tt.expectErr {
-					t.Errorf("exccpected a result, unexpected error: %v", err)
-				}
+			action := makeGetResourceAction(tt.apiVersion, tt.kind, tt.namespace, tt.name)
+			result := executor.Execute(t.Context(), action)
 
-				// with unsuported format we expect an error
-				if !errors.Is(err, ErrUnsupportedFormat) {
-					t.Errorf("expected ErrUnsupportedFormat, got: %v", err)
-				}
+			assert.Equal(t, tt.wantStatus, result.Status)
+			if tt.wantContains != "" {
+				assert.Contains(t, result.Message, tt.wantContains)
+			}
+
+			if tt.wantPayloadJSON != "" {
+				require.Len(t, result.Payloads, 1)
+				require.Contains(t, result.Payloads, tt.wantPayloadKey)
+
+				payload := result.Payloads[tt.wantPayloadKey]
+				assert.LessOrEqual(t, len(payload), wantMaxResourceOutputSize)
+				assert.JSONEq(t, tt.wantPayloadJSON, string(payload))
+			} else {
+				assert.Empty(t, result.Payloads)
 			}
 		})
 	}

--- a/pkg/clusteragent/kubeactions/setup.go
+++ b/pkg/clusteragent/kubeactions/setup.go
@@ -11,6 +11,7 @@ import (
 	"context"
 
 	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
 	eventplatform "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/def"
@@ -19,14 +20,14 @@ import (
 )
 
 // Setup initializes the kubeactions subsystem with all executors registered
-func Setup(ctx context.Context, clientset kubernetes.Interface, clusterName, clusterID string, isLeader func() bool, rcClient RcClient, epForwarderComp eventplatform.Component) (*ConfigRetriever, error) {
+func Setup(ctx context.Context, clientset kubernetes.Interface, dynamicClient dynamic.Interface, clusterName, clusterID string, isLeader func() bool, rcClient RcClient, epForwarderComp eventplatform.Component) (*ConfigRetriever, error) {
 	log.Infof("[KubeActions] Setting up Kubernetes actions subsystem")
 
 	// Create the executor registry
 	registry := NewExecutorRegistry(clientset)
 
 	// Register all action executors
-	registerExecutors(registry, clientset)
+	registerExecutors(registry, clientset, dynamicClient)
 
 	// Create in-memory action store with TTL-based expiration
 	store := NewActionStore(ctx)
@@ -59,10 +60,10 @@ func (a *executorAdapter) Execute(ctx context.Context, action *kubeactions.KubeA
 }
 
 // registerExecutors registers all available action executors
-func registerExecutors(registry *ExecutorRegistry, clientset kubernetes.Interface) {
+func registerExecutors(registry *ExecutorRegistry, clientset kubernetes.Interface, dynamicClient dynamic.Interface) {
 	registry.Register("delete_pod", &executorAdapter{exec: executors.NewDeletePodExecutor(clientset)})
 	registry.Register("restart_deployment", &executorAdapter{exec: executors.NewRestartDeploymentExecutor(clientset)})
 	registry.Register("patch_deployment", &executorAdapter{exec: executors.NewPatchDeploymentExecutor(clientset)})
 	registry.Register("rollback_deployment", &executorAdapter{exec: executors.NewRollbackDeploymentExecutor(clientset)})
-	registry.Register("get_resource", &executorAdapter{exec: executors.NewGetResourceExecutor(clientset)})
+	registry.Register("get_resource", &executorAdapter{exec: executors.NewGetResourceExecutor(dynamicClient)})
 }


### PR DESCRIPTION
### What does this PR do?

Removed the option to choose the output format from the `get_resource` action, as it is not needed anymore and the output will always be stored as JSON.

removed the associated tests that were only here to test the output format.

Use a dynamic client to get the resource, this is safer to use kubernetes provided client to resolve the type we are trying to get instead of manually building the REST API route to call.

### Motivation

- use kubernetes provided client to fetch resources instead of building a manual API route that could fail in the future
- the new returned object is compacted to reduce storage space
- improved the resource naming, it's used in the DB to identify the object, use the kind+namespace+name to make it unique per cluster per org.


### Describe how you validated your changes

added a small unit test
run the action itselft

### Additional Notes

CONTINT-5273