### PR TITLE
deps: update libxml2 to 2.15.3 and libxslt to 1.1.45

### DIFF
--- a/deps/libxml2/config-linux-arm64.h
+++ b/deps/libxml2/config-linux-arm64.h
@@ -31,12 +31,6 @@
 /* Define if readline library is available */
 /* #undef HAVE_LIBREADLINE */
 
-/* Define to 1 if you have the <lzma.h> header file. */
-#define HAVE_LZMA_H 1
-
-/* Define to 1 if you have the <poll.h> header file. */
-/* #undef HAVE_POLL_H */
-
 /* Define to 1 if you have the <pthread.h> header file. */
 #define HAVE_PTHREAD_H 1
 
@@ -83,7 +77,7 @@
 #define PACKAGE_NAME "libxml2"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxml2 2.14.5"
+#define PACKAGE_STRING "libxml2 2.15.3"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxml2"
@@ -92,7 +86,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.14.5"
+#define PACKAGE_VERSION "2.15.3"
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -100,7 +94,7 @@
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "2.14.5"
+#define VERSION "2.15.3"
 
 /* System configuration directory (/etc) */
 #define XML_SYSCONFDIR "/opt/datadog-agent/embedded/etc"

--- a/deps/libxml2/config-linux-x86_64.h
+++ b/deps/libxml2/config-linux-x86_64.h
@@ -31,12 +31,6 @@
 /* Define if readline library is available */
 /* #undef HAVE_LIBREADLINE */
 
-/* Define to 1 if you have the <lzma.h> header file. */
-#define HAVE_LZMA_H 1
-
-/* Define to 1 if you have the <poll.h> header file. */
-/* #undef HAVE_POLL_H */
-
 /* Define to 1 if you have the <pthread.h> header file. */
 #define HAVE_PTHREAD_H 1
 
@@ -83,7 +77,7 @@
 #define PACKAGE_NAME "libxml2"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxml2 2.14.5"
+#define PACKAGE_STRING "libxml2 2.15.3"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxml2"
@@ -92,7 +86,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.14.5"
+#define PACKAGE_VERSION "2.15.3"
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -100,7 +94,7 @@
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "2.14.5"
+#define VERSION "2.15.3"
 
 /* System configuration directory (/etc) */
 #define XML_SYSCONFDIR "/opt/datadog-agent/embedded/etc"

--- a/deps/libxml2/overlay.BUILD.bazel
+++ b/deps/libxml2/overlay.BUILD.bazel
@@ -6,7 +6,7 @@ load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
-VERSION = "2.14.5"
+VERSION = "2.15.3"
 
 PUBLIC_HEADERS = glob(["include/libxml/*.h"]) + [":xmlversion_h"]
 
@@ -33,7 +33,7 @@ expand_template(
     out = "include/libxml/xmlversion.h",
     substitutions = {
         "@VERSION@": VERSION,
-        "@LIBXML_VERSION_NUMBER@": "21405",
+        "@LIBXML_VERSION_NUMBER@": "21503",
         "@LIBXML_VERSION_EXTRA@": "",
         "@WITH_THREADS@": "1",
         "@WITH_THREAD_ALLOC@": "0",
@@ -62,7 +62,6 @@ expand_template(
         "@WITH_OUTPUT@": "1",
         "@WITH_PUSH@": "1",
         "@WITH_WRITER@": "1",
-        "@WITH_LZMA@": "1",
     } | select({
         "@platforms//os:linux": {"@MODULE_EXTENSION@": ".so"},
         "@platforms//os:macos": {"@MODULE_EXTENSION@": ".dylib"},
@@ -106,8 +105,6 @@ cc_library(
         "xmlsave.c",
         "pattern.c",
         "xmlregexp.c",
-        "xmlunicode.c",
-        "xzlib.c",
         "relaxng.c",
         "xinclude.c",
         "xlink.c",
@@ -118,8 +115,11 @@ cc_library(
         "xmlreader.c",
         "xmlwriter.c",
         "xpath.c",
-        "iso8859x.inc",
-        "html5ent.inc",
+        "codegen/charset.inc",
+        "codegen/escape.inc",
+        "codegen/html5ent.inc",
+        "codegen/ranges.inc",
+        "codegen/unicode.inc",
         "c14n.c",
     ] + glob(["include/private/*.h"]),
     hdrs = PUBLIC_HEADERS,
@@ -128,7 +128,6 @@ cc_library(
     ],
     deps = [
         "@zlib//:zlib",
-        "@xz//:liblzma",
     ],
     includes = [
         "include/libxml",
@@ -152,7 +151,6 @@ cc_shared_library(
     visibility = ["//visibility:public"],
     dynamic_deps = [
         "@zlib//:z_pkg",
-        "@xz//:lzma_pkg",
     ],
 )
 
@@ -165,7 +163,7 @@ pkg_files(
 dd_cc_packaged(
     name = "xml2_pkg",
     input = ":xml2",
-    version = "16.0.5",
+    version = "16.1.3",
     installed_files = [":headers"],
     visibility = ["//visibility:public"],
 )

--- a/deps/libxslt/config-linux-arm64.h
+++ b/deps/libxslt/config-linux-arm64.h
@@ -107,7 +107,7 @@
 #define PACKAGE_NAME "libxslt"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxslt 1.1.43"
+#define PACKAGE_STRING "libxslt 1.1.45"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxslt"
@@ -116,7 +116,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.1.43"
+#define PACKAGE_VERSION "1.1.45"
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -212,7 +212,7 @@
 
 
 /* Version number of package */
-#define VERSION "1.1.43"
+#define VERSION "1.1.45"
 
 /* Define if debugging support is enabled */
 /* #undef WITH_DEBUGGER */

--- a/deps/libxslt/config-linux-x86_64.h
+++ b/deps/libxslt/config-linux-x86_64.h
@@ -107,7 +107,7 @@
 #define PACKAGE_NAME "libxslt"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxslt 1.1.43"
+#define PACKAGE_STRING "libxslt 1.1.45"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxslt"
@@ -116,7 +116,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.1.43"
+#define PACKAGE_VERSION "1.1.45"
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -212,7 +212,7 @@
 
 
 /* Version number of package */
-#define VERSION "1.1.43"
+#define VERSION "1.1.45"
 
 /* Define if debugging support is enabled */
 /* #undef WITH_DEBUGGER */

--- a/deps/libxslt/overlay.BUILD.bazel
+++ b/deps/libxslt/overlay.BUILD.bazel
@@ -6,7 +6,7 @@ load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
-XSLT_VERSION = "1.1.43"
+XSLT_VERSION = "1.1.45"
 EXSLT_VERSION = "0.8.25"
 
 license(
@@ -32,7 +32,7 @@ expand_template(
     out = "libxslt/xsltconfig.h",
     substitutions = {
         "@VERSION@": XSLT_VERSION,
-        "@LIBXSLT_VERSION_NUMBER@": "10143",
+        "@LIBXSLT_VERSION_NUMBER@": "10145",
         "@LIBXSLT_VERSION_EXTRA@": "",
         "@WITH_XSLT_DEBUG@": "0",
         "@WITH_TRIO@": "0",
@@ -57,6 +57,7 @@ _PUBLIC_XSLT_HDRS = [
     "libxslt/security.h",
     "libxslt/templates.h",
     "libxslt/transform.h",
+    "libxslt/transformInternals.h",
     "libxslt/variables.h",
     "libxslt/xslt.h",
     "libxslt/xsltexports.h",
@@ -201,7 +202,7 @@ pkg_files(
 dd_cc_packaged(
     name = "exslt_pkg",
     input = ":exslt",
-    version = "0.8.24",
+    version = "0.8.25",
     installed_files = [":exslt_headers"],
     visibility = ["//visibility:public"],
 )

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -325,10 +325,10 @@ http_archive(
         "config-linux-arm64.h": "//deps:libxslt/config-linux-arm64.h",
         "BUILD.bazel": "//deps:libxslt/overlay.BUILD.bazel",
     },
-    sha256 = "5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a",
-    strip_prefix = "libxslt-1.1.43",
+    sha256 = "9acfe68419c4d06a45c550321b3212762d92f41465062ca4ea19e632ee5d216e",
+    strip_prefix = "libxslt-1.1.45",
     urls = [
-        "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.43.tar.xz",
+        "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.45.tar.xz",
     ],
 )
 

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -311,10 +311,10 @@ http_archive(
         "config-linux-arm64.h": "//deps:libxml2/config-linux-arm64.h",
         "BUILD.bazel": "//deps:libxml2/overlay.BUILD.bazel",
     },
-    sha256 = "03d006f3537616833c16c53addcdc32a0eb20e55443cba4038307e3fa7d8d44b",
-    strip_prefix = "libxml2-2.14.5",
+    sha256 = "78262a6e7ac170d6528ebfe2efccdf220191a5af6a6cd61ea4a9a9a5042c7a07",
+    strip_prefix = "libxml2-2.15.3",
     urls = [
-        "https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.5.tar.xz",
+        "https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.3.tar.xz",
     ],
 )
 

--- a/packaging/aix/stages/01-native-libs.sh
+++ b/packaging/aix/stages/01-native-libs.sh
@@ -66,7 +66,7 @@ ZLIB_VERSION="1.3.1"
 BZIP2_VERSION="1.0.8"
 OPENSSL_VERSION="3.5.6"
 XZ_VERSION="5.8.1"
-LIBXML2_VERSION="2.14.5"    # built from source (AIX Toolbox also available but we build)
+LIBXML2_VERSION="2.15.3"    # built from source (AIX Toolbox also available but we build)
 LIBXSLT_VERSION="1.1.45"   # from AIX Toolbox (yum install libxslt-devel; source build fails on AIX)
 
 # These are sourced from AIX Toolbox (build from source fails on AIX)


### PR DESCRIPTION
### What does this PR do?

Updates two vendored GNOME libraries together, since libxslt 1.1.45 requires
libxml2 >= 2.15.1.

**libxml2 2.14.5 -> 2.15.3** (Bazel overlay + AIX source build), reconciling the
overlay and checked-in config headers with the release:

- Bumps the `http_archive` pin (sha256 from GNOME's `.sha256sum` sidecar) and the
  AIX `LIBXML2_VERSION`.
- Drops LZMA support, removed upstream in 2.15: removes `xzlib.c`, the
  `@WITH_LZMA@` toggle, `HAVE_LZMA_H`, and the `@xz` dependency.
- Follows the source reorg: drops `xmlunicode.c` (merged into `xmlregexp.c`) and
  the root `.inc` files; adds the relocated `codegen/*.inc`.
- Drops `HAVE_POLL_H` (removed from the config template)
- SO version 16.0.5 -> 16.1.3.

**libxslt 1.1.43 -> 1.1.45** (Bazel overlay + checked-in config headers):

- Bumps the `http_archive` pin (sha256 from GNOME's `.sha256sum` sidecar).
- Refreshes version-bearing fields: `XSLT_VERSION`, `LIBXSLT_VERSION_NUMBER`
  (10145), `PACKAGE_*`/`VERSION` in both linux config headers, and the libexslt
  SO version (0.8.24 -> 0.8.25).
- Adds the new public header `transformInternals.h`.
- No `HAVE_*`/feature changes — `config.h.in` is byte-identical between releases.

### Motivation

Keep the vendored libxml2 and libxslt current with upstream bug fixes. libxslt
1.1.45 raises its minimum libxml2 to >= 2.15.1, so the two bumps ship together.

### Describe how you validated your changes

- `bazel build @libxml2//:xml2 :libxml2 :xml2_pkg`
- `bazel build @libxslt//:xslt :exslt :install`
- `bazel build //packages/agent/linux:everything`
