### PR TITLE
[CONTP-1704] Add pod_name to cluster-agent metadata payload

### DIFF
--- a/comp/metadata/clusteragent/impl/cluster_agent.go
+++ b/comp/metadata/clusteragent/impl/cluster_agent.go
@@ -140,6 +140,13 @@ func (dca *datadogclusteragent) initMetadata() {
 	dca.metadata["agent_version"] = version.AgentVersion
 	dca.metadata["agent_startup_time_ms"] = pkgconfigsetup.StartTime.UnixMilli()
 	dca.metadata["flavor"] = flavor.GetFlavor()
+
+	podName, err := common.GetSelfPodName()
+	if err != nil {
+		dca.log.Debugf("Could not determine cluster-agent pod name: %s", err)
+		podName = ""
+	}
+	dca.metadata["pod_name"] = podName
 }
 
 func (dca *datadogclusteragent) getFeatureConfigs() {

--- a/releasenotes-dca/notes/cluster-agent-metadata-pod-name-dc25426d7031b4dd.yaml
+++ b/releasenotes-dca/notes/cluster-agent-metadata-pod-name-dc25426d7031b4dd.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Cluster Agent now reports its own pod name as ``pod_name`` in its
+    inventory metadata payload (``datadog_cluster_agent_metadata``), providing
+    a stable per-replica identifier for each Cluster Agent.


### PR DESCRIPTION
### What does this PR do?
Report the cluster-agent's own pod name in the inventory metadata (datadog_cluster_agent_metadata.pod_name), sourced from common.GetSelfPodName() (DD_POD_NAME). This gives each cluster-agent replica a stable per-replica identity that maps to its leader-election holder identity and the datadog_cluster_agent.pod_name schema field.

### Motivation

- Recently, the cluster agent metadata table supports agent uuid as a key instead of cluster id.  As a result, all dca pods are displayed in the table, the only difference is IS_LEADER field
- On the other side, backend doesn’t have mapping from uuid → pod_name → rc_client_id. This blocks FA fetching leader pod flare file
- While we can get all flares from customer’s cluster agents, it is still preferable to have the ability to send only leader pod.
- To do so, a pod_name field should be added to datadog_cluster_agent table for FA to join with RC table and k8s_pods table.

### Describe how you validated your changes
1. Agent flare cluster-agent-metadata.json should have this field
2.  Queried the DCA's own inventory endpoint from inside the pod:
```
  curl -s -k -H "Authorization: Bearer <ipc token>" https://localhost:5005/metadata/cluster-agent
```
 Confirmed the payload now contains:
  "pod_name": "datadog-cluster-agent-xxxx"

### Additional Notes
