### PR TITLE
Trim vestigial blank imports from `generate_tools.go`

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2492,10 +2492,7 @@ core,github.com/tidwall/pretty,MIT,Copyright (c) 2017 Josh Baker
 core,github.com/tidwall/sjson,MIT,Copyright (c) 2016 Josh Baker
 core,github.com/tilinna/clock,MIT,Copyright (c) 2018 Timo Linna
 core,github.com/tinylib/msgp,MIT,Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated | Copyright (c) 2014 Philip Hofer
-core,github.com/tinylib/msgp/gen,MIT,Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated | Copyright (c) 2014 Philip Hofer
 core,github.com/tinylib/msgp/msgp,MIT,Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated | Copyright (c) 2014 Philip Hofer
-core,github.com/tinylib/msgp/parse,MIT,Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated | Copyright (c) 2014 Philip Hofer
-core,github.com/tinylib/msgp/printer,MIT,Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated | Copyright (c) 2014 Philip Hofer
 core,github.com/tklauser/go-sysconf,BSD-3-Clause,"Copyright (c) 2018-2022, Tobias Klauser"
 core,github.com/tklauser/numcpus,Apache-2.0,Copyright 2018 Tobias Klauser
 core,github.com/tmthrgd/go-hex,BSD-3-Clause,"Copyright (c) 2005-2016, Wojciech Muła | Copyright (c) 2012 The Go Authors. All rights reserved | Copyright (c) 2016, Tom Thorogood"

--- a/generate_tools.go
+++ b/generate_tools.go
@@ -13,10 +13,5 @@ package tools
 import (
 	_ "github.com/go-delve/delve/pkg/goversion"
 	_ "github.com/mailru/easyjson/easyjson"
-	_ "github.com/tinylib/msgp"
 	_ "golang.org/x/tools/cmd/stringer"
-
-	_ "github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
-	_ "github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils"
-	_ "github.com/DataDog/datadog-agent/pkg/network/go/lutgen"
 )


### PR DESCRIPTION
### What does this PR do?
Drop 4 blank imports from `generate_tools.go`:
- `github.com/tinylib/msgp`
- `github.com/DataDog/datadog-agent/pkg/network/go/bininspect`
- `github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils`
- `github.com/DataDog/datadog-agent/pkg/network/go/lutgen`

### Motivation
- `msgp` definition was redundant with that in [`internal/tools/proto/tools.go`](https://github.com/DataDog/datadog-agent/blob/624332c6141ac1064eabf71cb5448d6a5eea1d96/internal/tools/proto/tools.go#L19), and the module is anyway pinned in the root `go.mod` by hand-written imports needed to consume the generated code (hence its cleanup in #51719 - see detailed rationales there),
- the 3 first-party packages live in the root `datadog-agent` Go module, so `go mod tidy` could never have pruned them[^1]. They are also already imported by hand-written code:
  - `bininspect` by `pkg/network/usm/ebpf_gotls{,_helpers}.go`
  - `dwarfutils` and `lutgen` by `pkg/network/go/goid/internal/generate_goid_lut.go`.

The primary regeneration path is `bazel run //:write_all` anyway, but the 4 `//go:generate go run github.com/tinylib/msgp ...` directives (3 in `pkg/proto/pbgo/trace/trace.go`, 1 in `pkg/discovery/tracermetadata/model/tracer_metadata.go`) **keep working unchanged**: `go run` resolves the binary against `go.mod`, which still pins the module via these importers.

### Describe how you validated your changes
- `dda inv tidy`: no `go.mod`, `go.sum` nor `MODULE.bazel.lock` change,
- `dda inv generate-licenses`: `LICENSE-3rdparty.csv` shrinks by 3 rows corresponding to `msgp`'s internal sub-packages (`gen`, `parse` and `printer`), none of which are linked into any agent deliverable (build-time only).

### Additional Notes
The three remaining third-party blank imports in `generate_tools.go` (`delve/pkg/goversion`, `easyjson`, `stringer`) deserve a separate look.

[^1]:  The `tools.go` pattern only exists to prevent `go mod tidy` from pruning **third-party** `require` entries that are not imported in the code, whereas **first-party** packages by definition live in the same module as `generate_tools.go`: no `require` entry => nothing to prune. In other words, the 3 blank imports were inert from day one.