### PR TITLE
fix(e2e/discovery): remove flaky startup log assertion from testLogs

### DIFF
--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -120,7 +120,6 @@ func (s *linuxTestSuite) testLogs(t *testing.T) {
 
 		assert.NotEmpty(c, logs, "Expected to find logs from python-svc-dd service")
 
-		foundStartupLog := false
 		foundRequestLog := false
 
 		for _, log := range logs {
@@ -134,15 +133,11 @@ func (s *linuxTestSuite) testLogs(t *testing.T) {
 			assert.Contains(c, log.Tags, "version:2.1")
 			assert.Contains(c, log.Tags, "env:prod")
 
-			if log.Message == "Server is running on http://0.0.0.0:8082" {
-				foundStartupLog = true
-			}
 			if log.Message == "GET /test" {
 				foundRequestLog = true
 			}
 		}
 
-		assert.True(c, foundStartupLog, "Should find startup log message")
 		assert.True(c, foundRequestLog, "Should find request log message")
 	}, 2*time.Minute, 10*time.Second)
 


### PR DESCRIPTION
### What does this PR do?

Removes the assertion that checks for the startup log message (`"Server is running on http://0.0.0.0:8082"`) in `testLogs`. The test still asserts that a `GET /test` log (explicitly triggered by `curl` inside the test) arrives in fakeintake with the correct service, source, and tag metadata.

### Motivation

Tracked in [DSCVR-470](https://datadoghq.atlassian.net/browse/DSCVR-470). The startup log assertion was racy: the startup log is written when `python-svc` starts (before `UpdateEnv`), and the new agent may discover and ship it to fakeintake during the ~30 s sleep inside `validateDiscoveryMode` (system-probe mode). The subsequent `FlushServerAndResetAggregators` then wipes it, so `testLogs` never sees it.

The `GET /test` log is triggered inside `testLogs` itself (after the flush) and covers the same correctness properties — log collection works, the log file is discovered, and the payload is tagged correctly. The startup log check adds nothing that the request log check does not already cover, because each service restart creates a fresh log file at a new PID-based path, so the agent always reads from position 0 regardless.

### Describe how you validated your changes

Investigated via GitLab job logs (`dda inv gitlab.print-job-trace`) and CI test history (`pup cicd tests search`). The failure occurred once in 30 days on an unrelated Bazel dependency bump, confirming it was a timing flake rather than a regression.

[DSCVR-470]: https://datadoghq.atlassian.net/browse/DSCVR-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ