### PR TITLE
chore(skills): set default model to sonnet

### DIFF
--- a/.agents/skills/allium/SKILL.md
+++ b/.agents/skills/allium/SKILL.md
@@ -5,6 +5,7 @@ version: 3
 auto_trigger:
   - file_patterns: ["**/*.allium"]
   - keywords: ["allium", "allium spec", "allium specification", ".allium file"]
+model: sonnet
 ---
 
 # Allium

--- a/.agents/skills/allium/skills/distill/SKILL.md
+++ b/.agents/skills/allium/skills/distill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: distill
 description: "Extract an Allium specification from an existing codebase. Use when the user has existing code and wants to distil behaviour into a spec, reverse engineer a specification from implementation, generate a spec from code, turn implementation into a behavioural specification, or document what a codebase does in Allium terms."
+model: sonnet
 ---
 
 # Distillation guide

--- a/.agents/skills/allium/skills/elicit/SKILL.md
+++ b/.agents/skills/allium/skills/elicit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: elicit
 description: "Run a structured discovery session to build an Allium specification through conversation. Use when the user wants to create a new spec from scratch, elicit or gather requirements, capture domain behaviour, specify a feature or system, define what a system should do, or is describing functionality and needs help shaping it into a specification."
+model: sonnet
 ---
 
 # Elicitation

--- a/.agents/skills/allium/skills/propagate/SKILL.md
+++ b/.agents/skills/allium/skills/propagate/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: propagate
 description: "Generate tests from Allium specifications. Use when the user wants to propagate tests, generate test files from a spec, write tests for a specification, create property-based tests, produce state machine tests, check test coverage against spec obligations, or understand what tests a specification requires."
+model: sonnet
 ---
 
 # Propagation

--- a/.claude/skills/agent-supply-chain-newsletter/SKILL.md
+++ b/.claude/skills/agent-supply-chain-newsletter/SKILL.md
@@ -2,6 +2,7 @@
 name: agent-supply-chain-newsletter
 description: Generate the Agent Supply Chain newsletter by researching team activity on GitHub and Confluence, then creating a Confluence draft and Gmail draft
 argument-hint: "<period e.g. 'February-March 2026'>"
+model: sonnet
 ---
 
 Generate the Agent Supply Chain newsletter for the period **$ARGUMENTS** by researching what team members accomplished on GitHub and Confluence, then producing both a Confluence blog post draft and a Gmail draft.

--- a/.claude/skills/auto-jira/SKILL.md
+++ b/.claude/skills/auto-jira/SKILL.md
@@ -2,6 +2,7 @@
 name: auto-jira
 description: Autonomously work on Jira backlog tickets, creating PRs and shepherding them to merge
 argument-hint: "<BOARD-KEY> [--max-cards N] [--before-date YYYY-MM-DD] [--exclude word1,word2]"
+model: sonnet
 ---
 
 ## Overview

--- a/.claude/skills/create-component/SKILL.md
+++ b/.claude/skills/create-component/SKILL.md
@@ -3,6 +3,7 @@ name: create-component
 description: Create a new Fx component using the modern def/fx/impl pattern (NOT legacy)
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 argument-hint: "<bundle>/<component-name> [--team team-name] [--with-params] [--with-lifecycle] [--with-mock]"
+model: sonnet
 ---
 
 Create a new Fx component following the **modern** (new-style) pattern with separate `def/`, `fx/`, and `impl/` sub-packages.

--- a/.claude/skills/create-config-field/SKILL.md
+++ b/.claude/skills/create-config-field/SKILL.md
@@ -3,6 +3,7 @@ name: create-config-field
 description: Add a new configuration field to the Datadog Agent (datadog.yaml)
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 argument-hint: "[config.key.name]"
+model: sonnet
 ---
 
 Add a new configuration field to a Datadog Agent. This involves registering the key with defaults/env bindings in Go, and optionally documenting it in the config template.

--- a/.claude/skills/create-core-check/SKILL.md
+++ b/.claude/skills/create-core-check/SKILL.md
@@ -3,6 +3,7 @@ name: create-core-check
 description: Create a new Go core check that collects metrics and sends them to Datadog
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 argument-hint: "[check-name]"
+model: sonnet
 ---
 
 Create a new Go-based core check for the Datadog Agent. Core checks collect metrics, service checks, or events and send them to Datadog at regular intervals.

--- a/.claude/skills/create-go-module/SKILL.md
+++ b/.claude/skills/create-go-module/SKILL.md
@@ -3,6 +3,7 @@ name: create-go-module
 description: Create a new Go module in the agent repository
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 argument-hint: "[module-path]"
+model: sonnet
 ---
 
 Create a new Go module in the datadog-agent multi-module repository. This repo has 100+ Go modules managed via `modules.yml` and inter-module `replace` directives.

--- a/.claude/skills/create-invoke-task/SKILL.md
+++ b/.claude/skills/create-invoke-task/SKILL.md
@@ -3,6 +3,7 @@ name: create-invoke-task
 description: Create a new Python invoke task for the dda CLI
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 argument-hint: "[namespace] [task-name]"
+model: sonnet
 ---
 
 Create a new invoke task accessible via `dda inv <namespace>.<task-name>`.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -4,6 +4,7 @@ description: Create a pull request for the current branch with proper labels and
 disable-model-invocation: true
 allowed-tools: Bash, Read, Glob
 argument-hint: "[--real] [additional labels...]"
+model: sonnet
 ---
 
 Create a pull request for the current branch following the Datadog Agent contributing guidelines.

--- a/.claude/skills/create-release-note/SKILL.md
+++ b/.claude/skills/create-release-note/SKILL.md
@@ -3,6 +3,7 @@ name: create-release-note
 description: Create a reno release note for a PR or change
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 argument-hint: "[topic]"
+model: sonnet
 ---
 
 Create a release note file using the reno format. Release notes are **mandatory** for all PRs unless labeled `changelog/no-changelog`.

--- a/.claude/skills/create-runtime-setting/SKILL.md
+++ b/.claude/skills/create-runtime-setting/SKILL.md
@@ -3,6 +3,7 @@ name: create-runtime-setting
 description: Create a new RuntimeSetting that can be changed at runtime via `agent config set/get` and the config API
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 argument-hint: "[setting-name]"
+model: sonnet
 ---
 
 Create a new RuntimeSetting implementation for the Datadog Agent. RuntimeSettings are settings that can be read and changed at runtime via:

--- a/.claude/skills/create-status-provider/SKILL.md
+++ b/.claude/skills/create-status-provider/SKILL.md
@@ -3,6 +3,7 @@ name: create-status-provider
 description: Add a new section to the agent status output (agent status command)
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 argument-hint: "[provider-name]"
+model: sonnet
 ---
 
 Add a new status provider to the Datadog Agent. Status providers contribute sections to the `agent status` output in JSON, plain text, and HTML formats.

--- a/.claude/skills/create-subcommand/SKILL.md
+++ b/.claude/skills/create-subcommand/SKILL.md
@@ -3,6 +3,7 @@ name: create-subcommand
 description: Add a new CLI subcommand to an agent binary (agent, cluster-agent, etc.)
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 argument-hint: "[agent] [subcommand-name]"
+model: sonnet
 ---
 
 Add a new CLI subcommand to a Datadog Agent binary. Each agent binary uses Cobra commands registered via a central `subcommands.go` file.

--- a/.claude/skills/explain-lading-config/SKILL.md
+++ b/.claude/skills/explain-lading-config/SKILL.md
@@ -3,6 +3,7 @@ name: explain-lading-config
 description: Explains a lading.yaml config file from the regression test suite, using the lading Rust source as ground truth for field meanings and defaults.
 user_invocable: true
 argument-hint: "[experiment name]"
+model: sonnet
 ---
 
 # explain-lading-config

--- a/.claude/skills/quality-gate-size-analysis/SKILL.md
+++ b/.claude/skills/quality-gate-size-analysis/SKILL.md
@@ -2,6 +2,7 @@
 name: quality-gate-size-analysis
 description: Analyze static quality gate on-disk size changes, correlate with Confluence exception records and GitHub PRs by milestone
 argument-hint: "<time-range e.g. 3mo, 6mo> [optional: specific release e.g. 7.77]"
+model: sonnet
 ---
 
 Analyze the agent's static quality gate on-disk size metrics, pull approved exception records from Confluence, fetch PR data from GitHub with milestone-based release attribution, and produce a cross-referenced report.

--- a/.claude/skills/review-pr-comments/SKILL.md
+++ b/.claude/skills/review-pr-comments/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: review-pr-comments
 description: Review and triage PR review comments on the current branch — groups threads by file, separates bots from humans, walks through unresolved comments interactively
+model: sonnet
 ---
 
 # Review PR Comments

--- a/.claude/skills/run-e2e/SKILL.md
+++ b/.claude/skills/run-e2e/SKILL.md
@@ -3,6 +3,7 @@ name: run-e2e
 description: Run E2E tests locally using the new-e2e framework with Pulumi-based infrastructure
 allowed-tools: Bash, Read, Glob, Grep
 argument-hint: "<test-path-or-name> [--run TestName] [--keep-stack] [--configparams key=value]"
+model: sonnet
 ---
 
 Run E2E tests from `test/new-e2e/tests/` using `dda inv new-e2e-tests.run`.

--- a/.claude/skills/run-jira/SKILL.md
+++ b/.claude/skills/run-jira/SKILL.md
@@ -2,6 +2,7 @@
 name: run-jira
 description: Fetch a Jira issue and propose an implementation plan based on codebase analysis
 argument-hint: "<JIRA-KEY e.g. ACTP-1234>"
+model: sonnet
 ---
 
 Fetch the Jira issue **$ARGUMENTS** from the Datadog Atlassian instance and use it as the basis for a codebase analysis and implementation proposal.

--- a/.claude/skills/write-e2e/SKILL.md
+++ b/.claude/skills/write-e2e/SKILL.md
@@ -3,6 +3,7 @@ name: write-e2e
 description: Write E2E tests for the Datadog Agent using the new-e2e framework with fakeintake assertions
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 argument-hint: "<feature-or-check-name> [--platform linux|windows|both] [--env host|docker|k8s]"
+model: sonnet
 ---
 
 Write end-to-end tests for the Datadog Agent using the `test/e2e-framework/` framework.


### PR DESCRIPTION
This PR sets the model to sonnet for all skills that do not already have a model key specified in the frontmatter.
