### PR TITLE
[ABLD-387] Add missing `gazelle` extension for `go_msgp`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -757,6 +757,7 @@ gazelle_binary(
     languages = DEFAULT_LANGUAGES + [
         "//bazel/rules/cws_codegen:gazelle_extension",
         "//bazel/rules/go_build_tags:gazelle_extension",
+        "//bazel/rules/go_msgp:gazelle_extension",
         "//bazel/rules/go_stringer:gazelle_extension",
         "//bazel/rules/write_pb_go:gazelle_extension",
     ],

--- a/bazel/rules/go_msgp/BUILD.bazel
+++ b/bazel/rules/go_msgp/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@rules_go//go:def.bzl", "go_library")
+
+# strip the leading _ solely meant to prevent `go mod tidy` from adding @gazelle deps to the root go.mod
+copy_file(
+    name = "gazelle_extension_src",
+    src = "_gazelle_extension.go",
+    out = "gazelle_extension.go",
+)
+
+# prevent `bazel run //:gazelle` from removing @gazelle deps (reentrancy guard)
+# gazelle:ignore
+go_library(
+    name = "gazelle_extension",
+    srcs = [":gazelle_extension_src"],
+    importpath = "github.com/DataDog/datadog-agent/bazel/rules/go_msgp",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@gazelle//language",
+        "@gazelle//rule",
+    ],
+)

--- a/bazel/rules/go_msgp/_gazelle_extension.go
+++ b/bazel/rules/go_msgp/_gazelle_extension.go
@@ -1,0 +1,147 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package go_msgp
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+const name = "go_msgp"
+
+type lang struct {
+	language.BaseLang
+}
+
+//goland:noinspection GoUnusedExportedFunction
+func NewLanguage() language.Language {
+	return &lang{}
+}
+
+func (*lang) Name() string {
+	return name
+}
+
+func (*lang) Kinds() map[string]rule.KindInfo {
+	return map[string]rule.KindInfo{
+		name: {
+			MatchAttrs: []string{"out"},
+			MergeableAttrs: map[string]bool{ // always replicate //go:generate args
+				"io":       true,
+				"out_test": true,
+			},
+			NonEmptyAttrs: map[string]bool{"out": true, "src": true},
+		},
+	}
+}
+
+func (*lang) KnownDirectives() []string {
+	return []string{name}
+}
+
+func (*lang) Loads() []rule.LoadInfo {
+	return []rule.LoadInfo{{
+		Name:    fmt.Sprintf("//bazel/rules/%s:defs.bzl", name),
+		Symbols: []string{name},
+	}}
+}
+
+func (*lang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
+	if args.File != nil {
+		for _, d := range args.File.Directives {
+			if d.Key == name && d.Value == "off" {
+				return language.GenerateResult{}
+			}
+		}
+	}
+	var liveRules []*rule.Rule
+	for _, f := range args.RegularFiles {
+		if !strings.HasSuffix(f, ".go") {
+			continue
+		}
+		directives, err := readDirectives(filepath.Join(args.Dir, f))
+		if err != nil {
+			continue
+		}
+		liveRules = append(liveRules, directives...)
+	}
+	return language.GenerateResult{
+		Gen:     liveRules,
+		Imports: make([]interface{}, len(liveRules)),
+	}
+}
+
+func readDirectives(src string) ([]*rule.Rule, error) {
+	f, err := os.Open(src)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	var directives []*rule.Rule
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		goGenerate, ok := strings.CutPrefix(scanner.Text(), "//go:generate ")
+		if !ok {
+			continue
+		}
+		if directive := parseDirective(goGenerate, filepath.Base(src)); directive != nil {
+			directives = append(directives, directive)
+		}
+	}
+	return directives, scanner.Err()
+}
+
+func parseDirective(goGenerate, src string) *rule.Rule {
+	fields := strings.Fields(goGenerate)
+	var args []string
+	for i, field := range fields {
+		if strings.HasPrefix(path.Base(field), "msgp") {
+			args = fields[i+1:]
+			break
+		}
+	}
+	if args == nil {
+		return nil
+	}
+
+	fs := flag.NewFlagSet("msgp", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	file := fs.String("file", "", "")
+	output := fs.String("o", "", "")
+	ioBool := fs.Bool("io", true, "")
+	testsBool := fs.Bool("tests", true, "")
+	if err := fs.Parse(args); err != nil {
+		return nil
+	}
+	srcFile := *file
+	if srcFile == "" {
+		srcFile = src
+	}
+	out := *output
+	if out == "" {
+		out = strings.TrimSuffix(srcFile, ".go") + "_gen.go"
+	}
+
+	directive := rule.NewRule(name, strings.TrimSuffix(out, ".go"))
+	directive.SetAttr("src", srcFile)
+	directive.SetAttr("out", out)
+	if *ioBool {
+		directive.SetAttr("io", true)
+	}
+	if *testsBool {
+		directive.SetAttr("out_test", strings.TrimSuffix(out, ".go")+"_test.go")
+	}
+	return directive
+}


### PR DESCRIPTION
### What does this PR do?
The new `go_msgp` Gazelle language extension, closely inspired by the existing `go_stringer` one, auto-injects `go_msgp(...)` build rules from `//go:generate go run github.com/tinylib/msgp ...` directives.

### Motivation
Remove the need for hand-authoring a `go_msgp` Bazel build target each time one adds a `//go:generate` directive to the Go source code.

This is a follow-up of #51410 that was missing a Gazelle extension because I didn't notice the `//go:generate` directives on `github.com/tinylib/msgp` for which there exist 4 occurrences in 2 source files:
https://github.com/DataDog/datadog-agent/blob/709ede5dfd4ad2485d19047e6366e68388030809/pkg/discovery/tracermetadata/model/tracer_metadata.go#L6
https://github.com/DataDog/datadog-agent/blob/709ede5dfd4ad2485d19047e6366e68388030809/pkg/proto/pbgo/trace/trace.go#L12-L14

### Describe how you validated your changes
- `bazel run //:gazelle` on the current tree: no diff,
- removed `tracer_metadata_gen` from `pkg/discovery/tracermetadata/model/BUILD.bazel`, ran `bazel run //:gazelle`: the rule was re-injected with correct `attrs`.

### Additional Notes
Follow-ups:
- add detection and removal of stales rules (full parity with `go_stringer`) once the four currently hand-crafted `go_msgp` rules without a matching `//go:generate` directive have one: `agent_payload_gen` and `stats_gen` in `pkg/proto/pbgo/trace/trace.go`, `key_gen` in `pkg/proto/msgpgo/key.go`, and `remoteconfig_gen` in `pkg/proto/pbgo/core/` (which has no hand-written `.go` file to host a directive, so either a placeholder file or a per-BUILD `# gazelle:go_msgp off`),
- merge directives for  `.go` files carrying both `//go:generate msgp` AND package-level `//msgp:` lines.