### PR TITLE
[CWS] Silence scoped variable actions when scope is unavailable

### DIFF
--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -24,6 +24,9 @@ var (
 	variableRegex         = regexp.MustCompile(`\${[^}]*}`)
 	fieldReferenceRegex   = regexp.MustCompile(`%{[^}]*}`)
 	errAppendNotSupported = errors.New("append is not supported")
+	// ErrScopeNotAvailable is returned when a scoped variable operation cannot be
+	// applied because the current event does not provide the requested scope.
+	ErrScopeNotAvailable = errors.New("scope not available")
 )
 
 // Telemetry tracks the values of evaluation metrics
@@ -1129,7 +1132,7 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 	setVariable := func(ctx *Context, value any) error {
 		scope := v.scoper(ctx)
 		if scope == nil {
-			return fmt.Errorf("`%s` scoper failed to scope variable '%s'", v.scoperName, name)
+			return fmt.Errorf("%w: `%s` scoper failed to scope variable '%s'", ErrScopeNotAvailable, v.scoperName, name)
 		}
 		key := scope.Hash()
 

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -36,6 +36,19 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/schemas"
 )
 
+type countingLogger struct {
+	errors []string
+}
+
+func (l *countingLogger) Infof(_ string, _ ...interface{})  {}
+func (l *countingLogger) Tracef(_ string, _ ...interface{}) {}
+func (l *countingLogger) Warnf(_ string, _ ...interface{})  {}
+func (l *countingLogger) Debugf(_ string, _ ...interface{}) {}
+func (l *countingLogger) Errorf(format string, params ...interface{}) {
+	l.errors = append(l.errors, fmt.Sprintf(format, params...))
+}
+func (l *countingLogger) IsTracing() bool { return false }
+
 func savePolicy(filename string, testPolicy *PolicyDef) error {
 	yamlBytes, err := yaml.Marshal(testPolicy)
 	if err != nil {
@@ -642,61 +655,87 @@ func TestActionSetVariableSize(t *testing.T) {
 }
 
 func TestActionSetEmptyScope(t *testing.T) {
-	testPolicy := &PolicyDef{
-		Rules: []*RuleDefinition{{
-			ID:         "test_rule",
-			Expression: `open.file.path == "/tmp/test"`,
-			Actions: []*ActionDefinition{
-				{
-					Set: &SetDefinition{
-						Name:   "scopedvar1",
-						Append: true,
-						Value:  "bar",
-						Size:   1,
-						Scope:  "process",
+	for _, tc := range []struct {
+		name          string
+		scope         Scope
+		variableName  string
+		variableStore string
+	}{
+		{
+			name:          "process",
+			scope:         ScopeProcess,
+			variableName:  "scopedvar1",
+			variableStore: "process.scopedvar1",
+		},
+		{
+			name:          "cgroup",
+			scope:         ScopeCGroup,
+			variableName:  "scopedvar1",
+			variableStore: "cgroup.scopedvar1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testPolicy := &PolicyDef{
+				Rules: []*RuleDefinition{{
+					ID:         "test_rule",
+					Expression: `open.file.path == "/tmp/test"`,
+					Actions: []*ActionDefinition{
+						{
+							Set: &SetDefinition{
+								Name:   tc.variableName,
+								Append: true,
+								Value:  "bar",
+								Size:   1,
+								Scope:  tc.scope,
+							},
+						},
 					},
-				},
-			},
-		}},
+				}},
+			}
+
+			tmpDir := t.TempDir()
+
+			if err := savePolicy(filepath.Join(tmpDir, "test.policy"), testPolicy); err != nil {
+				t.Fatal(err)
+			}
+
+			provider, err := NewPoliciesDirProvider(tmpDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			loader := NewPolicyLoader(provider)
+
+			rs := newRuleSet()
+			logger := &countingLogger{}
+			rs.logger = logger
+			if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+				t.Error(err)
+			}
+
+			opts := rs.evalOpts
+
+			existingScopedVariable := opts.VariableStore.Get(tc.variableStore)
+			assert.NotNil(t, existingScopedVariable)
+			stringArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
+			assert.NotNil(t, stringArrayScopedVar)
+			assert.True(t, ok)
+
+			event := model.NewFakeEvent()
+			event.Type = uint32(model.FileOpenEventType)
+			event.SetFieldValue("open.file.path", "/tmp/test")
+
+			ctx := eval.NewContext(event)
+			if !rs.Evaluate(event) {
+				t.Errorf("Expected event to match rule")
+			}
+
+			assert.Empty(t, logger.errors)
+
+			value, set := stringArrayScopedVar.GetValue(ctx, false)
+			assert.Nil(t, value)
+			assert.False(t, set)
+		})
 	}
-
-	tmpDir := t.TempDir()
-
-	if err := savePolicy(filepath.Join(tmpDir, "test.policy"), testPolicy); err != nil {
-		t.Fatal(err)
-	}
-
-	provider, err := NewPoliciesDirProvider(tmpDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	loader := NewPolicyLoader(provider)
-
-	rs := newRuleSet()
-	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
-		t.Error(err)
-	}
-
-	opts := rs.evalOpts
-
-	existingScopedVariable := opts.VariableStore.Get("process.scopedvar1")
-	assert.NotNil(t, existingScopedVariable)
-	stringArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
-	assert.NotNil(t, stringArrayScopedVar)
-	assert.True(t, ok)
-
-	event := model.NewFakeEvent()
-	event.Type = uint32(model.FileOpenEventType)
-	event.SetFieldValue("open.file.path", "/tmp/test")
-
-	ctx := eval.NewContext(event)
-	if !rs.Evaluate(event) {
-		t.Errorf("Expected event to match rule")
-	}
-
-	value, set := stringArrayScopedVar.GetValue(ctx, false)
-	assert.Nil(t, value)
-	assert.False(t, set)
 }
 
 func TestVariableFieldConflictProtection(t *testing.T) {

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -1056,10 +1056,16 @@ func (rs *RuleSet) runSetActions(_ eval.Event, ctx *eval.Context, rule *Rule) er
 				}
 				if action.Def.Set.Append {
 					if err := mutable.Append(ctx, value); err != nil {
+						if errors.Is(err, eval.ErrScopeNotAvailable) {
+							break
+						}
 						return fmt.Errorf("append is not supported for type `%s` with variable `%s` in rule `%s`: %w", reflect.TypeOf(value), name, rule.ID, err)
 					}
 				} else {
 					if err := mutable.Set(ctx, value); err != nil {
+						if errors.Is(err, eval.ErrScopeNotAvailable) {
+							break
+						}
 						return err
 					}
 				}


### PR DESCRIPTION
### What does this PR do?

Silences SECL scoped variable set/append action errors when the requested scope is unavailable. Missing scopes are now tagged with a dedicated `ErrScopeNotAvailable` error and ignored by set action execution.

### Motivation

Cgroup-scoped variables may be set or read on events that do not have a cgroup scope. In that case, the rule still matches but the action previously emitted noisy error logs.

Some customers running AKS/AzureLinux3.0 (with some cgroup context resolution issues) are suffering a large flood of this log. This PR aims at at least fix this flood log issue (the cgroup resolution issue will be addressed in another PR)

### Describe how you validated your changes

Added unit coverage for empty process and cgroup scopes, including an assertion that no error log is emitted.

Validated with:
`dda inv test --targets=./pkg/security/secl/rules --extra-args='-run TestActionSetEmptyScope'`

### Additional Notes

None.