### PR TITLE
comp/core/workloadmeta: rename ContainerImageLayer.Digest to DiffID

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -456,11 +456,12 @@ func getLayersWithHistory(ocispecImage ocispec.Image, manifest ocispec.Manifest)
 
 	historyIndex := 0
 	for manifestIndex, manifestLayer := range manifest.Layers {
-		// Prefer the diffID for the current layer, but fall back to the digest as it appears in the
-		// manifest in the event of a mismatch.
-		digest := manifestLayer.Digest.String()
+		// DiffID is the OCI rootfs diff_id. When the image config is
+		// short of one (off-spec), fall back to the manifest layer
+		// digest -- a wrong-but-best-effort value rather than empty.
+		diffID := manifestLayer.Digest.String()
 		if manifestIndex < len(ocispecImage.RootFS.DiffIDs) {
-			digest = ocispecImage.RootFS.DiffIDs[manifestIndex].String()
+			diffID = ocispecImage.RootFS.DiffIDs[manifestIndex].String()
 		}
 		// Append all empty layers encountered before a non-empty layer
 		for historyIndex < len(ocispecImage.History) {
@@ -486,7 +487,7 @@ func getLayersWithHistory(ocispecImage ocispec.Image, manifest ocispec.Manifest)
 		// Create and append the layer with manifest and matched history
 		layer := workloadmeta.ContainerImageLayer{
 			MediaType: manifestLayer.MediaType,
-			Digest:    digest,
+			DiffID:    diffID,
 			SizeBytes: manifestLayer.Size,
 			URLs:      manifestLayer.URLs,
 			History:   history,

--- a/comp/core/workloadmeta/collectors/internal/containerd/image_test.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_test.go
@@ -152,7 +152,7 @@ func TestGetLayersWithHistory(t *testing.T) {
 	assert.Equal(t, []workloadmeta.ContainerImageLayer{
 		{
 			MediaType: ocispec.MediaTypeImageLayer,
-			Digest:    digest.FromString("abc").String(),
+			DiffID:    digest.FromString("abc").String(),
 			SizeBytes: 1,
 			History: &ocispec.History{
 				Comment:    "not-empty1",
@@ -173,7 +173,7 @@ func TestGetLayersWithHistory(t *testing.T) {
 		},
 		{
 			MediaType: ocispec.MediaTypeImageLayer,
-			Digest:    digest.FromString("def").String(),
+			DiffID:    digest.FromString("def").String(),
 			SizeBytes: 2,
 			History: &ocispec.History{
 				Comment:    "not-empty2",
@@ -188,7 +188,7 @@ func TestGetLayersWithHistory(t *testing.T) {
 		},
 		{
 			MediaType: ocispec.MediaTypeImageLayer,
-			Digest:    digest.FromString("ghi").String(),
+			DiffID:    digest.FromString("ghi").String(),
 			SizeBytes: 3,
 			History: &ocispec.History{
 				Comment:    "not-empty3",
@@ -209,7 +209,7 @@ func TestGetLayersWithHistory(t *testing.T) {
 		},
 		{
 			MediaType: ocispec.MediaTypeImageLayer,
-			Digest:    digest.FromString("jkl").String(),
+			DiffID:    digest.FromString("jkl").String(),
 			SizeBytes: 4,
 		},
 	}, layers)

--- a/comp/core/workloadmeta/collectors/internal/crio/crio_test.go
+++ b/comp/core/workloadmeta/collectors/internal/crio/crio_test.go
@@ -449,12 +449,12 @@ func TestGenerateImageEventFromContainer(t *testing.T) {
 					Variant:      "v8",
 					Layers: []workloadmeta.ContainerImageLayer{
 						{
-							Digest:    "sha256:layer1digest",
+							DiffID:    "sha256:layer1digest",
 							History:   &imgspecs.History{Created: &time1, CreatedBy: "command1", Author: "author1", Comment: "Layer 1 comment"},
 							SizeBytes: 0,
 						},
 						{
-							Digest:    "sha256:layer2digest",
+							DiffID:    "sha256:layer2digest",
 							History:   &imgspecs.History{Created: &time2, CreatedBy: "command2", Author: "author2", Comment: "Layer 2 comment"},
 							SizeBytes: 0,
 						},

--- a/comp/core/workloadmeta/collectors/internal/crio/image.go
+++ b/comp/core/workloadmeta/collectors/internal/crio/image.go
@@ -178,7 +178,7 @@ func parseImageInfo(info map[string]string, layerFilePath string, imgID string) 
 
 				// Create and append the layer with the matched history
 				layer := workloadmeta.ContainerImageLayer{
-					Digest:  layerDigest,
+					DiffID:  layerDigest,
 					History: historyEntry,
 				}
 

--- a/comp/core/workloadmeta/collectors/internal/crio/image_test.go
+++ b/comp/core/workloadmeta/collectors/internal/crio/image_test.go
@@ -157,7 +157,7 @@ func TestConvertImageToEvent(t *testing.T) {
 					Variant:      "v1",
 					Layers: []workloadmeta.ContainerImageLayer{
 						{
-							Digest: "sha256:layer1",
+							DiffID: "sha256:layer1",
 							History: &imgspecs.History{
 								Created:    parseTime("2023-01-01T00:00:00Z"),
 								CreatedBy:  "command1",
@@ -167,7 +167,7 @@ func TestConvertImageToEvent(t *testing.T) {
 							},
 						},
 						{
-							Digest: "sha256:layer2",
+							DiffID: "sha256:layer2",
 							History: &imgspecs.History{
 								Created:    parseTime("2023-01-02T00:00:00Z"),
 								CreatedBy:  "command2",
@@ -261,7 +261,7 @@ func TestConvertImageToEvent(t *testing.T) {
 			require.Equal(t, len(expectedImg.Layers), len(actualImg.Layers))
 			for i, expectedLayer := range expectedImg.Layers {
 				actualLayer := actualImg.Layers[i]
-				assert.Equal(t, expectedLayer.Digest, actualLayer.Digest)
+				assert.Equal(t, expectedLayer.DiffID, actualLayer.DiffID)
 				if expectedLayer.History != nil && actualLayer.History != nil {
 					assert.Equal(t, expectedLayer.History.CreatedBy, actualLayer.History.CreatedBy)
 					assert.Equal(t, expectedLayer.History.Author, actualLayer.History.Author)
@@ -605,7 +605,7 @@ func TestParseImageInfo(t *testing.T) {
 				},
 				layers: []workloadmeta.ContainerImageLayer{
 					{
-						Digest: "sha256:layer1",
+						DiffID: "sha256:layer1",
 						History: &imgspecs.History{
 							Created:    parseTime("2023-01-01T00:00:00Z"),
 							CreatedBy:  "command1",
@@ -615,7 +615,7 @@ func TestParseImageInfo(t *testing.T) {
 						},
 					},
 					{
-						Digest: "sha256:layer2",
+						DiffID: "sha256:layer2",
 						History: &imgspecs.History{
 							Created:    parseTime("2023-01-02T00:00:00Z"),
 							CreatedBy:  "command2",
@@ -657,7 +657,7 @@ func TestParseImageInfo(t *testing.T) {
 			require.Equal(t, len(tt.expected.layers), len(result.layers))
 			for i, expectedLayer := range tt.expected.layers {
 				actualLayer := result.layers[i]
-				assert.Equal(t, expectedLayer.Digest, actualLayer.Digest)
+				assert.Equal(t, expectedLayer.DiffID, actualLayer.DiffID)
 				if expectedLayer.History != nil && actualLayer.History != nil {
 					assert.Equal(t, expectedLayer.History.CreatedBy, actualLayer.History.CreatedBy)
 					assert.Equal(t, expectedLayer.History.Author, actualLayer.History.Author)

--- a/comp/core/workloadmeta/collectors/internal/docker/docker.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker.go
@@ -709,8 +709,8 @@ func layersFromDockerHistoryAndInspect(history []image.HistoryResponseItem, insp
 		shouldAssignDigests = false
 	}
 
-	// inspectIdx tracks the current RootFS layer ID index (in Docker, this corresponds to the Diff ID of a layer)
-	// NOTE: Docker returns the RootFS layers in chronological order
+	// inspectIdx tracks the current RootFS layer index (in Docker, RootFS.Layers
+	// holds diff_ids in chronological order).
 	inspectIdx := 0
 
 	// Docker returns the history layers in reverse-chronological order
@@ -719,20 +719,20 @@ func layersFromDockerHistoryAndInspect(history []image.HistoryResponseItem, insp
 		isEmptyLayer := history[i].Size == 0
 		isInheritedLayer := isInheritedLayer(history[i])
 
-		digest := ""
+		diffID := ""
 		if shouldAssignDigests && (isInheritedLayer || !isEmptyLayer) {
 			if isInheritedLayer {
-				log.Debugf("detected an inherited layer for image ID: \"%s\", assigning it digest: \"%s\"", inspect.ID, inspect.RootFS.Layers[inspectIdx])
+				log.Debugf("detected an inherited layer for image ID: \"%s\", assigning it diff_id: \"%s\"", inspect.ID, inspect.RootFS.Layers[inspectIdx])
 			}
-			digest = inspect.RootFS.Layers[inspectIdx]
+			diffID = inspect.RootFS.Layers[inspectIdx]
 			inspectIdx++
 		} else {
 			// Fallback to previous behavior
-			digest = history[i].ID
+			diffID = history[i].ID
 		}
 
 		layer := workloadmeta.ContainerImageLayer{
-			Digest:    digest,
+			DiffID:    diffID,
 			SizeBytes: history[i].Size,
 			History: &v1.History{
 				Created:    &created,

--- a/comp/core/workloadmeta/collectors/internal/docker/docker_test.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker_test.go
@@ -108,7 +108,7 @@ func Test_LayersFromDockerHistoryAndInspect(t *testing.T) {
 			},
 			expected: []workloadmeta.ContainerImageLayer{
 				{
-					Digest:    layerID,
+					DiffID:    layerID,
 					SizeBytes: nonEmptySize,
 					History: &v1.History{
 						Created:    &baseTime,
@@ -133,7 +133,7 @@ func Test_LayersFromDockerHistoryAndInspect(t *testing.T) {
 			},
 			expected: []workloadmeta.ContainerImageLayer{
 				{
-					Digest:    layerID,
+					DiffID:    layerID,
 					SizeBytes: emptySize,
 					History: &v1.History{
 						Created:    &baseTime,
@@ -192,7 +192,7 @@ func Test_LayersFromDockerHistoryAndInspect(t *testing.T) {
 			},
 			expected: []workloadmeta.ContainerImageLayer{
 				{
-					Digest:    "1",
+					DiffID:    "1",
 					SizeBytes: emptySize,
 					History: &v1.History{
 						Created:    &baseTime,
@@ -208,7 +208,7 @@ func Test_LayersFromDockerHistoryAndInspect(t *testing.T) {
 					},
 				},
 				{
-					Digest:    "2",
+					DiffID:    "2",
 					SizeBytes: nonEmptySize,
 					History: &v1.History{
 						Created:    &baseTime,
@@ -240,7 +240,7 @@ func Test_LayersFromDockerHistoryAndInspect(t *testing.T) {
 			},
 			expected: []workloadmeta.ContainerImageLayer{
 				{
-					Digest:    "",
+					DiffID:    "",
 					SizeBytes: nonEmptySize,
 					History: &v1.History{
 						Created:    &baseTime,
@@ -249,7 +249,7 @@ func Test_LayersFromDockerHistoryAndInspect(t *testing.T) {
 					},
 				},
 				{
-					Digest:    "abc",
+					DiffID:    "abc",
 					SizeBytes: nonEmptySize,
 					History: &v1.History{
 						Created:    &baseTime,

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1542,7 +1542,7 @@ type ContainerImageMetadata struct {
 // ContainerImageLayer represents a layer of a container image
 type ContainerImageLayer struct {
 	MediaType string
-	Digest    string
+	DiffID    string
 	SizeBytes int64
 	URLs      []string
 	History   *v1.History `proto:"ignore"`
@@ -1663,7 +1663,7 @@ func (layer ContainerImageLayer) String() string {
 	var sb strings.Builder
 
 	_, _ = fmt.Fprintln(&sb, "Media Type:", layer.MediaType)
-	_, _ = fmt.Fprintln(&sb, "Digest:", layer.Digest)
+	_, _ = fmt.Fprintln(&sb, "Diff ID:", layer.DiffID)
 	_, _ = fmt.Fprintln(&sb, "Size in bytes:", layer.SizeBytes)
 	_, _ = fmt.Fprintln(&sb, "URLs:", layer.URLs)
 

--- a/comp/core/workloadmeta/proto/proto.go
+++ b/comp/core/workloadmeta/proto/proto.go
@@ -420,7 +420,7 @@ func protoContainerImageMetadataFromWorkloadmetaContainerImageMetadata(container
 	for _, layer := range containerImageMetadata.Layers {
 		protoLayers = append(protoLayers, &pb.ContainerImageLayer{
 			MediaType: layer.MediaType,
-			Digest:    layer.Digest,
+			DiffID:    layer.DiffID,
 			SizeBytes: layer.SizeBytes,
 			Urls:      layer.URLs,
 		})
@@ -1269,7 +1269,7 @@ func toWorkloadmetaContainerImageMetadata(protoContainerImageMetadata *pb.Contai
 	for _, protoLayer := range protoContainerImageMetadata.Layers {
 		layers = append(layers, workloadmeta.ContainerImageLayer{
 			MediaType: protoLayer.MediaType,
-			Digest:    protoLayer.Digest,
+			DiffID:    protoLayer.DiffID,
 			SizeBytes: protoLayer.SizeBytes,
 			URLs:      protoLayer.Urls,
 		})

--- a/pkg/collector/corechecks/containerimage/processor.go
+++ b/pkg/collector/corechecks/containerimage/processor.go
@@ -88,8 +88,12 @@ func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
 		modelLayer := &model.ContainerImage_ContainerImageLayer{
 			Urls:      layer.URLs,
 			MediaType: layer.MediaType,
-			Digest:    layer.Digest,
-			Size:      layer.SizeBytes,
+			// The agent-payload field is named "Digest" but has carried
+			// diff_id semantics since this collector existed. Keep emitting
+			// the diff_id so the backend join against trivy vulnerability
+			// records (also keyed on diff_id) continues to match.
+			Digest: layer.DiffID,
+			Size:   layer.SizeBytes,
 		}
 
 		if layer.History != nil {

--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -64,7 +64,7 @@ func TestProcessEvents(t *testing.T) {
 						Layers: []workloadmeta.ContainerImageLayer{
 							{
 								MediaType: "media",
-								Digest:    "digest_layer_1",
+								DiffID:    "digest_layer_1",
 								SizeBytes: 43,
 								URLs:      []string{"url"},
 								History: &v1.History{
@@ -73,7 +73,7 @@ func TestProcessEvents(t *testing.T) {
 							},
 							{
 								MediaType: "media",
-								Digest:    "digest_layer_2",
+								DiffID:    "digest_layer_2",
 								URLs:      []string{"url"},
 								SizeBytes: 44,
 								History: &v1.History{
@@ -283,7 +283,7 @@ func TestProcessEvents(t *testing.T) {
 						Layers: []workloadmeta.ContainerImageLayer{
 							{
 								MediaType: "media",
-								Digest:    "digest_layer_1",
+								DiffID:    "digest_layer_1",
 								SizeBytes: 43,
 								URLs:      []string{"url"},
 								History: &v1.History{
@@ -292,7 +292,7 @@ func TestProcessEvents(t *testing.T) {
 							},
 							{
 								MediaType: "media",
-								Digest:    "digest_layer_2",
+								DiffID:    "digest_layer_2",
 								URLs:      []string{"url"},
 								SizeBytes: 44,
 								History: &v1.History{

--- a/pkg/proto/datadog/workloadmeta/workloadmeta.proto
+++ b/pkg/proto/datadog/workloadmeta/workloadmeta.proto
@@ -61,7 +61,7 @@ message ContainerImage {
 
 message ContainerImageLayer {
   string mediaType = 1;
-  string digest = 2;
+  string diffID = 2;
   int64 sizeBytes = 3;
   repeated string urls = 4;
 }

--- a/pkg/proto/pbgo/core/workloadmeta.pb.go
+++ b/pkg/proto/pbgo/core/workloadmeta.pb.go
@@ -755,7 +755,7 @@ func (x *ContainerImage) GetRepoDigest() string {
 type ContainerImageLayer struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	MediaType     string                 `protobuf:"bytes,1,opt,name=mediaType,proto3" json:"mediaType,omitempty"`
-	Digest        string                 `protobuf:"bytes,2,opt,name=digest,proto3" json:"digest,omitempty"`
+	DiffID        string                 `protobuf:"bytes,2,opt,name=diffID,proto3" json:"diffID,omitempty"`
 	SizeBytes     int64                  `protobuf:"varint,3,opt,name=sizeBytes,proto3" json:"sizeBytes,omitempty"`
 	Urls          []string               `protobuf:"bytes,4,rep,name=urls,proto3" json:"urls,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -799,9 +799,9 @@ func (x *ContainerImageLayer) GetMediaType() string {
 	return ""
 }
 
-func (x *ContainerImageLayer) GetDigest() string {
+func (x *ContainerImageLayer) GetDiffID() string {
 	if x != nil {
-		return x.Digest
+		return x.DiffID
 	}
 	return ""
 }
@@ -2576,7 +2576,7 @@ const file_datadog_workloadmeta_workloadmeta_proto_rawDesc = "" +
 	"repoDigest\"}\n" +
 	"\x13ContainerImageLayer\x12\x1c\n" +
 	"\tmediaType\x18\x01 \x01(\tR\tmediaType\x12\x16\n" +
-	"\x06digest\x18\x02 \x01(\tR\x06digest\x12\x1c\n" +
+	"\x06diffID\x18\x02 \x01(\tR\x06diffID\x12\x1c\n" +
 	"\tsizeBytes\x18\x03 \x01(\x03R\tsizeBytes\x12\x12\n" +
 	"\x04urls\x18\x04 \x03(\tR\x04urls\"\x85\x04\n" +
 	"\x16ContainerImageMetadata\x12F\n" +

--- a/pkg/util/crio/crio_util.go
+++ b/pkg/util/crio/crio_util.go
@@ -148,19 +148,19 @@ func (c *clientImpl) GetPodStatus(ctx context.Context, podSandboxID string) (*v1
 func (c *clientImpl) GetCRIOImageLayers(imgMeta *workloadmeta.ContainerImageMetadata) ([]string, error) {
 	var lowerDirs []string
 
-	digestToIDMap, err := c.buildDigestToIDMap(imgMeta)
+	diffIDToIDMap, err := c.buildDiffIDToIDMap(imgMeta)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build digest to ID map: %w", err)
+		return nil, fmt.Errorf("failed to build diff_id to ID map: %w", err)
 	}
 
 	// Construct the list of lowerDirs by mapping each layer to its corresponding `diff` directory path
 	for _, layer := range imgMeta.Layers {
-		if layer.Digest == "" { // Skip empty layers
+		if layer.DiffID == "" { // Skip empty layers
 			continue
 		}
-		layerID, found := digestToIDMap[layer.Digest]
+		layerID, found := diffIDToIDMap[layer.DiffID]
 		if !found {
-			return nil, fmt.Errorf("layer ID not found for digest %s", layer.Digest)
+			return nil, fmt.Errorf("layer ID not found for diff_id %s", layer.DiffID)
 		}
 
 		layerPath := filepath.Join(GetOverlayPath(), layerID, "diff")
@@ -232,8 +232,8 @@ func (c *clientImpl) connect() error {
 	return nil
 }
 
-// buildDigestToIDMap creates a map of layer digests to IDs for the layers in imgMeta.
-func (c *clientImpl) buildDigestToIDMap(imgMeta *workloadmeta.ContainerImageMetadata) (map[string]string, error) {
+// buildDiffIDToIDMap creates a map of layer diff_ids to CRI-O layer IDs for the layers in imgMeta.
+func (c *clientImpl) buildDiffIDToIDMap(imgMeta *workloadmeta.ContainerImageMetadata) (map[string]string, error) {
 	file, err := os.Open(GetOverlayLayersPath())
 	if err != nil {
 		return nil, fmt.Errorf("failed to open layers.json: %w", err)
@@ -250,21 +250,21 @@ func (c *clientImpl) buildDigestToIDMap(imgMeta *workloadmeta.ContainerImageMeta
 		return nil, fmt.Errorf("failed to parse layers.json: %w", err)
 	}
 
-	neededDigests := make(map[string]struct{})
+	neededDiffIDs := make(map[string]struct{})
 	for _, layer := range imgMeta.Layers {
-		if layer.Digest != "" { // Skip empty layers
-			neededDigests[layer.Digest] = struct{}{}
+		if layer.DiffID != "" { // Skip empty layers
+			neededDiffIDs[layer.DiffID] = struct{}{}
 		}
 	}
 
-	digestToIDMap := make(map[string]string)
+	diffIDToIDMap := make(map[string]string)
 	for _, layer := range layers {
-		if _, found := neededDigests[layer.DiffDigest]; found {
-			digestToIDMap[layer.DiffDigest] = layer.ID
+		if _, found := neededDiffIDs[layer.DiffDigest]; found {
+			diffIDToIDMap[layer.DiffDigest] = layer.ID
 		}
 	}
 
-	return digestToIDMap, nil
+	return diffIDToIDMap, nil
 }
 
 // ListImages retrieves all images available in the CRI-O runtime.

--- a/pkg/util/trivy/overlayfs.go
+++ b/pkg/util/trivy/overlayfs.go
@@ -39,7 +39,7 @@ type fakeContainer struct {
 // to keep the i-th non-empty entry aligned with layerIDs[i].
 func newFakeContainer(layerPaths []string, imgMeta *workloadmeta.ContainerImageMetadata, layerIDs []string) (*fakeContainer, error) {
 	imageLayers := lo.Filter(imgMeta.Layers, func(layer workloadmeta.ContainerImageLayer, _ int) bool {
-		return layer.Digest != ""
+		return layer.DiffID != ""
 	})
 	// Path / DiffID alignment must be exact: these are what trivy looks up.
 	// imageLayers feeds the optional Digest annotation; tolerate the Docker
@@ -58,7 +58,7 @@ func newFakeContainer(layerPaths []string, imgMeta *workloadmeta.ContainerImageM
 		layers[i] = ftypes.LayerPath{
 			DiffID: diffID.String(),
 			Path:   layerPaths[i],
-			Digest: imageLayers[i].Digest,
+			Digest: imageLayers[i].DiffID,
 		}
 	}
 

--- a/pkg/util/trivy/overlayfs_test.go
+++ b/pkg/util/trivy/overlayfs_test.go
@@ -54,11 +54,11 @@ func TestFakeContainer(t *testing.T) {
 	// One empty-layer history marker exercises the filter.
 	imageMeta := &workloadmeta.ContainerImageMetadata{
 		Layers: []workloadmeta.ContainerImageLayer{
-			{Digest: ""},
+			{DiffID: ""},
 		},
 	}
 	for _, id := range layerIDs {
-		imageMeta.Layers = append(imageMeta.Layers, workloadmeta.ContainerImageLayer{Digest: id})
+		imageMeta.Layers = append(imageMeta.Layers, workloadmeta.ContainerImageLayer{DiffID: id})
 	}
 
 	c, err := newFakeContainer(layersPath, imageMeta, layerIDs)


### PR DESCRIPTION
This field has held the rootfs diff_id, not the manifest digest, ever since
#33641 (e0da7ddbfa) switched containerd over. The name has been lying about
its contents to every reader since.

Rename it to DiffID so the type says what it carries and the compiler points
at every call site. The workloadmeta protobuf field is renamed to match; the
wire format keys on its field ID (2), which is unchanged, so it stays
compatible. processor.go still sends the diff_id in the agent payload's Digest,
where the backend joins it to Trivy vulnerability records.

