### PR TITLE
fix(e2e): clear stale Pulumi workspace YAMLs on new-e2e-tests.clean -s

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -1402,6 +1402,22 @@ def _clean_stacks(ctx: Context, skip_destroy: bool):
         print(f"🗑️ Removing stack {stack}")
         _remove_stack(ctx, stack)
 
+    _clean_workspaces()
+
+
+def _clean_workspaces():
+    """Remove Pulumi workspace directories from the system temp dir.
+
+    These hold Pulumi.<stack>.yaml files that cache stack config between runs.
+    Stale keys persist here even after removing values from
+    ~/.test_infra_config.yaml, causing failures on the next run.
+    """
+    workspace_root = Path(tempfile.gettempdir()) / "pulumi-workspace"
+    if not workspace_root.exists():
+        return
+    shutil.rmtree(workspace_root)
+    print(f"🗑️  Deleted stale workspace configs: {workspace_root}")
+
 
 def _get_existing_stacks(ctx: Context) -> list[str]:
     e2e_stacks: list[str] = []


### PR DESCRIPTION
## Summary

Pulumi workspace directories under \`\$(tempdir)/pulumi-workspace\` persist between runs and hold \`Pulumi.<stack>.yaml\` files that cache stack config. Stale keys — e.g. \`ddinfra:aws/defaultPrivateKeyPath\` left over when \`privateKeyPath\` was previously set in \`~/.test_infra_config.yaml\` — survive there even after removing the field from the config file. On the next run \`DefaultPrivateKeyPath()\` returns the stale path, the framework reads the passphrase-protected key, and the provider fails with _"this private key is passphrase protected"_.

Fix: delete the entire workspace root when the user runs \`dda inv new-e2e-tests.clean -s\` so the next run starts from a clean slate.

## Test plan

- [ ] Run an e2e test with \`privateKeyPath\` set in \`~/.test_infra_config.yaml\`, then remove it and run \`dda inv new-e2e-tests.clean -s\` — verify the workspace directory is gone
- [ ] Re-run the test against the same stack — verify no passphrase error