### PR TITLE
Add optional tag assertion to a newly added tag to the http_check

### DIFF
--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -249,6 +249,7 @@ func (suite *eksSuite) TestNginxFargate() {
 		Expect: testMetricExpectArgs{
 			Tags: &[]string{
 				`^cluster_name:`,
+				`^http_status_code:200$`,
 				`^instance:My_Nginx$`,
 				`^kube_cluster_name:`,
 				"^kube_distribution:eks$",

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -249,7 +249,6 @@ func (suite *eksSuite) TestNginxFargate() {
 		Expect: testMetricExpectArgs{
 			Tags: &[]string{
 				`^cluster_name:`,
-				`^http_status_code:200$`,
 				`^instance:My_Nginx$`,
 				`^kube_cluster_name:`,
 				"^kube_distribution:eks$",
@@ -257,6 +256,12 @@ func (suite *eksSuite) TestNginxFargate() {
 				`^kube_namespace:workload-nginx-fargate$`,
 				`^kube_service:nginx$`,
 				`^url:http://`,
+			},
+		},
+		Optional: testMetricExpectArgs{
+			Tags: &[]string{
+				`^http_status_code:200$`,
+				`stackid:.*`,
 			},
 		},
 	})

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -760,6 +760,7 @@ func (suite *k8sSuite) TestNginx() {
 		Expect: testMetricExpectArgs{
 			Tags: suite.testClusterTags([]string{
 				`^cluster_name:`,
+				`^http_status_code:200$`,
 				`^instance:My_Nginx$`,
 				`^kube_cluster_name:`,
 				`^orch_cluster_id:`,

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -760,7 +760,6 @@ func (suite *k8sSuite) TestNginx() {
 		Expect: testMetricExpectArgs{
 			Tags: suite.testClusterTags([]string{
 				`^cluster_name:`,
-				`^http_status_code:200$`,
 				`^instance:My_Nginx$`,
 				`^kube_cluster_name:`,
 				`^orch_cluster_id:`,
@@ -768,6 +767,12 @@ func (suite *k8sSuite) TestNginx() {
 				`^kube_service:nginx$`,
 				`^url:http://`,
 			}),
+		},
+		Optional: testMetricExpectArgs{
+			Tags: &[]string{
+				`^http_status_code:200$`,
+				`stackid:.*`,
+			},
 		},
 	})
 


### PR DESCRIPTION
### What does this PR do?
The http_check got updated here to ship a new tag:
https://github.com/DataDog/integrations-core/pull/23731

Seems like test are failing here because it's not expecting the new tag.
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1737393138
