### PR TITLE
kubelet util: simplify the call to get nodeName at init.

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -82,7 +82,8 @@ type KubeUtil struct {
 
 func (ku *KubeUtil) init() error {
 	var err error
-	ku.kubeletClient, err = getKubeletClient(context.Background())
+	ctx := context.Background()
+	ku.kubeletClient, err = getKubeletClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -118,10 +119,15 @@ func (ku *KubeUtil) init() error {
 
 	if pkgconfigsetup.Datadog().GetBool("kubelet_use_api_server") {
 		ku.useAPIServer = true
-		ku.kubeletClient.config.nodeName, err = ku.GetNodename(context.Background())
+
+		// the method getNodeNameFromStatsSummary will get the node name from the stats summary
+		// and cache it in the kubeletClient.config.nodeName on success.
+		nodeName, err := ku.getNodeNameFromStatsSummary(ctx)
 		if err != nil {
 			return err
 		}
+
+		log.Debugf("got node name from kubelet: %s", nodeName)
 	}
 
 	return nil
@@ -202,16 +208,12 @@ func (ku *KubeUtil) GetNodename(ctx context.Context) (string, error) {
 	var nodeName string
 
 	if ku.useAPIServer {
-		if ku.kubeletClient.config.nodeName != "" {
-			nodeName = ku.kubeletClient.config.nodeName
-		} else {
-			stats, err := ku.GetLocalStatsSummary(ctx)
-			if err == nil && stats.Node.NodeName != "" {
-				nodeName = stats.Node.NodeName
-			} else {
-				return "", fmt.Errorf("failed to get kubernetes nodename from %s: %w", kubeletStatsSummary, err)
-			}
+		var err error
+		nodeName, err = ku.getNodeNameFromStatsSummary(ctx)
+		if err != nil {
+			return "", err
 		}
+
 	} else {
 		pods, err := ku.GetLocalPodList(ctx)
 		if err != nil {
@@ -387,6 +389,27 @@ func (ku *KubeUtil) GetLocalPodList(ctx context.Context) ([]*Pod, error) {
 // which were expired and therefore removed from the list when it was generated.
 func (ku *KubeUtil) GetLocalPodListWithMetadata(ctx context.Context) (*PodList, error) {
 	return ku.getLocalPodList(ctx)
+}
+
+// getNodeNameFromStatsSummary gets the node name from the stats summary API
+// and caches it in the kubeletClient.config.nodeName on success.
+func (ku *KubeUtil) getNodeNameFromStatsSummary(ctx context.Context) (string, error) {
+	if ku.kubeletClient.config.nodeName != "" {
+		return ku.kubeletClient.config.nodeName, nil
+	}
+
+	stats, err := ku.GetLocalStatsSummary(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get kubernetes nodename from %s: %w", kubeletStatsSummary, err)
+	}
+
+	if stats.Node.NodeName == "" {
+		return "", fmt.Errorf("failed to get kubernetes nodename from %s, node name is empty", kubeletStatsSummary)
+	}
+
+	ku.kubeletClient.config.nodeName = stats.Node.NodeName // cache the node name
+
+	return stats.Node.NodeName, nil
 }
 
 // GetLocalStatsSummary returns node and pod stats from kubelet

--- a/pkg/util/kubernetes/kubelet/kubelet_client.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client.go
@@ -109,8 +109,9 @@ func newForConfig(config kubeletClientConfig, timeout time.Duration) (*kubeletCl
 
 	// Defaulting timeout
 	if timeout == 0 {
-		httpClient.Timeout = 30 * time.Second
+		timeout = 30 * time.Second
 	}
+	httpClient.Timeout = timeout
 
 	return &kubeletClient{
 		client:     httpClient,


### PR DESCRIPTION
### What does this PR do?

At init, when the flag `use_api_server` is set, we only go through one code path in `getNodeName`, simplify that by using a new method that only does that and use it at init and in the previously used code path.

This is a no–op change for now, but it's part of a larger change that requires the init function of kubelet util to be split and so that part of the code must be reduced to a simpler path.

See https://github.com/DataDog/datadog-agent/pull/50681 which contains all the final changes including this one.

### Motivation

### Describe how you validated your changes

### Additional Notes
