### PR TITLE
fix(logs): disable symlink following for process_log-discovered paths

### DIFF
--- a/comp/core/autodiscovery/providers/process_log.go
+++ b/comp/core/autodiscovery/providers/process_log.go
@@ -219,7 +219,7 @@ func checkFileReadable(logPath string) error {
 	// Check readability with the privileged logs client to match what the
 	// log tailer uses.  That client can use the privileged logs module in
 	// system-probe if it is available.
-	file, err := privilegedlogsclient.Open(logPath)
+	file, err := privilegedlogsclient.OpenNoFollow(logPath)
 	if err != nil {
 		log.Infof("Discovered log file %s could not be opened: %v", logPath, err)
 		return err

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -147,6 +147,12 @@ type LogsConfig struct {
 	IntegrationSource string `mapstructure:"integration_source" json:"integration_source" yaml:"integration_source"`
 	// IntegrationFileIndex is the index of the integration file that contains this source.
 	IntegrationSourceIndex int `mapstructure:"integration_source_index" json:"integration_source_index" yaml:"integration_source_index"`
+
+	// NoFollow is true when this file source must not follow symlinks.  Set by the AD
+	// scheduler for sources discovered by the process_log provider, whose paths come from
+	// /proc/<pid>/fd and are canonical at discovery time — any symlink found later
+	// indicates an attacker-controlled swap.  Never parsed from config.
+	NoFollow bool `json:"-" yaml:"-" mapstructure:"-"`
 }
 
 // SourceAutoMultiLineOptions defines per-source auto multi-line detection overrides.

--- a/pkg/logs/internal/util/opener/BUILD.bazel
+++ b/pkg/logs/internal/util/opener/BUILD.bazel
@@ -23,67 +23,51 @@ go_library(
     ],
     deps = select({
         "@rules_go//go/platform:aix": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:android": [
             "//pkg/privileged-logs/client",
-            "//pkg/privileged-logs/common",
         ],
         "@rules_go//go/platform:darwin": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:dragonfly": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:freebsd": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:illumos": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:ios": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:js": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/privileged-logs/client",
-            "//pkg/privileged-logs/common",
         ],
         "@rules_go//go/platform:netbsd": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:openbsd": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:osx": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:plan9": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:qnx": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:solaris": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:windows": [
-            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "//conditions:default": [],

--- a/pkg/logs/internal/util/opener/BUILD.bazel
+++ b/pkg/logs/internal/util/opener/BUILD.bazel
@@ -23,51 +23,67 @@ go_library(
     ],
     deps = select({
         "@rules_go//go/platform:aix": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:android": [
             "//pkg/privileged-logs/client",
+            "//pkg/privileged-logs/common",
         ],
         "@rules_go//go/platform:darwin": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:dragonfly": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:freebsd": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:illumos": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:ios": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:js": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/privileged-logs/client",
+            "//pkg/privileged-logs/common",
         ],
         "@rules_go//go/platform:netbsd": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:openbsd": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:osx": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:plan9": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:qnx": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:solaris": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "@rules_go//go/platform:windows": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/filesystem",
         ],
         "//conditions:default": [],

--- a/pkg/logs/internal/util/opener/open_linux.go
+++ b/pkg/logs/internal/util/opener/open_linux.go
@@ -17,6 +17,12 @@ func OpenLogFile(path string) (*os.File, error) {
 	return privilegedlogsclient.Open(path)
 }
 
+// OpenLogFileNoFollow opens a file with the privileged logs client without
+// following symbolic links in any path component.
+func OpenLogFileNoFollow(path string) (*os.File, error) {
+	return privilegedlogsclient.OpenNoFollow(path)
+}
+
 // StatLogFile stats a log file with the privileged logs client
 func StatLogFile(path string) (os.FileInfo, error) {
 	return privilegedlogsclient.Stat(path)

--- a/pkg/logs/internal/util/opener/open_other.go
+++ b/pkg/logs/internal/util/opener/open_other.go
@@ -9,14 +9,23 @@
 package opener
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 )
 
-// OpenLogFile opens a file with filesystem.OpenShared
+// OpenLogFile opens a file with filesystem.OpenShared.
+// On non-Linux platforms we don't need to support symlink rejection since it's
+// only needed for process_log-discovered paths which are currently only
+// supported on Linux.
 func OpenLogFile(path string) (*os.File, error) {
 	return filesystem.OpenShared(path)
+}
+
+// OpenLogFileNoFollow is not supported on non-Linux platforms.
+func OpenLogFileNoFollow(path string) (*os.File, error) {
+	return nil, fmt.Errorf("opener: no-follow open is not supported on non-Linux platforms: %s", path)
 }
 
 // StatLogFile stats a log file

--- a/pkg/logs/internal/util/opener/open_other.go
+++ b/pkg/logs/internal/util/opener/open_other.go
@@ -9,7 +9,6 @@
 package opener
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
@@ -23,9 +22,12 @@ func OpenLogFile(path string) (*os.File, error) {
 	return filesystem.OpenShared(path)
 }
 
-// OpenLogFileNoFollow is not supported on non-Linux platforms.
+// OpenLogFileNoFollow falls back to a regular open on non-Linux platforms:
+// symlink rejection is only needed for process_log-discovered paths, and
+// process_log discovery (based on /proc/<pid>/fd) is Linux-only, so this path
+// is not reachable with an untrusted, attacker-controlled symlink swap here.
 func OpenLogFileNoFollow(path string) (*os.File, error) {
-	return nil, fmt.Errorf("opener: no-follow open is not supported on non-Linux platforms: %s", path)
+	return filesystem.OpenShared(path)
 }
 
 // StatLogFile stats a log file

--- a/pkg/logs/launchers/container/tailerfactory/file.go
+++ b/pkg/logs/launchers/container/tailerfactory/file.go
@@ -122,7 +122,9 @@ func (tf *factory) makeDockerFileSource(source *sources.LogSource) (*sources.Log
 	}
 
 	// check access to the file; if it is not readable, then returning an error will
-	// try to fall back to reading from a socket.
+	// try to fall back to reading from a socket.  Container log paths (e.g.
+	// /var/log/pods/…) are symlinks created by the container runtime intentionally,
+	// so symlink-following is correct here.
 	f, err := opener.OpenLogFile(path)
 	if err != nil {
 		// (this error already has the form 'open <path>: ..' so needs no further embellishment)
@@ -155,6 +157,7 @@ func (tf *factory) makeDockerFileSource(source *sources.LogSource) (*sources.Log
 		AutoMultiLineSamples:          source.Config.AutoMultiLineSamples,
 		ExperimentalAdaptiveSampling:  source.Config.ExperimentalAdaptiveSampling,
 		ExperimentalNoisyLogDetection: source.Config.ExperimentalNoisyLogDetection,
+		NoFollow:                      source.Config.NoFollow,
 	})
 
 	// inform the file launcher that it should expect docker-formatted content
@@ -276,6 +279,7 @@ func (tf *factory) makeK8sFileSource(source *sources.LogSource) (*sources.LogSou
 			AutoMultiLineSamples:          source.Config.AutoMultiLineSamples,
 			ExperimentalAdaptiveSampling:  source.Config.ExperimentalAdaptiveSampling,
 			ExperimentalNoisyLogDetection: source.Config.ExperimentalNoisyLogDetection,
+			NoFollow:                      source.Config.NoFollow,
 		})
 
 	switch source.Config.Type {

--- a/pkg/logs/launchers/file/BUILD.bazel
+++ b/pkg/logs/launchers/file/BUILD.bazel
@@ -62,6 +62,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:android": [
@@ -98,6 +99,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:dragonfly": [
@@ -115,6 +117,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:freebsd": [
@@ -132,6 +135,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:illumos": [
@@ -149,6 +153,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:ios": [
@@ -166,6 +171,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:js": [
@@ -183,6 +189,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:linux": [
@@ -219,6 +226,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:openbsd": [
@@ -236,6 +244,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:osx": [
@@ -253,6 +262,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:plan9": [
@@ -270,6 +280,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:qnx": [
@@ -287,6 +298,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:solaris": [
@@ -304,6 +316,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/opener",
             "//pkg/logs/util/testutils",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "//conditions:default": [],

--- a/pkg/logs/launchers/file/launcher_privileged_logs_test.go
+++ b/pkg/logs/launchers/file/launcher_privileged_logs_test.go
@@ -78,6 +78,10 @@ func (s *PrivilegedLogsTestSetupStrategy) Setup(t *testing.T) TestSetupResult {
 			return privilegedlogstest.WithParentPermFixup(t, name, func() error {
 				return os.Remove(name)
 			})
+		}, symlink: func(oldname, newname string) error {
+			return privilegedlogstest.WithParentPermFixup(t, newname, func() error {
+				return os.Symlink(oldname, newname)
+			})
 		}}}
 }
 
@@ -97,6 +101,17 @@ func TestPrivilegedLogsLauncherTestSuiteWithConfigID(t *testing.T) {
 	s := new(PrivilegedLogsLauncherTestSuite)
 	s.configID = "123456789"
 	suite.Run(t, s)
+}
+
+// TestPrivilegedLogsLauncherNoFollowSymlink runs the NoFollow symlink policy
+// test (defined in launcher_test.go) against the privileged-logs path.  The files
+// live in unsearchable directories, so the unprivileged open fails and the launcher
+// falls back to system-probe; the swapped symlink must be rejected there with
+// O_NOFOLLOW rather than followed.
+func TestPrivilegedLogsLauncherNoFollowSymlink(t *testing.T) {
+	strategy := &PrivilegedLogsTestSetupStrategy{}
+	res := strategy.Setup(t)
+	runLauncherNoFollowSymlinkTest(t, res.TestOps, res.TestDirs[0])
 }
 
 func TestPrivilegedLogsLauncherScanStartNewTailer(t *testing.T) {

--- a/pkg/logs/launchers/file/launcher_test.go
+++ b/pkg/logs/launchers/file/launcher_test.go
@@ -11,11 +11,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
@@ -43,9 +45,10 @@ type RegularTestSetupStrategy struct{}
 func (s *RegularTestSetupStrategy) Setup(t *testing.T) TestSetupResult {
 	return TestSetupResult{TestDirs: []string{t.TempDir(), t.TempDir()},
 		TestOps: TestOps{
-			create: os.Create,
-			rename: os.Rename,
-			remove: os.Remove,
+			create:  os.Create,
+			rename:  os.Rename,
+			remove:  os.Remove,
+			symlink: os.Symlink,
 		}}
 }
 
@@ -116,9 +119,10 @@ type TestSetupStrategy interface {
 }
 
 type TestOps struct {
-	create func(name string) (*os.File, error)
-	rename func(oldPath, newPath string) error
-	remove func(name string) error
+	create  func(name string) (*os.File, error)
+	rename  func(oldPath, newPath string) error
+	remove  func(name string) error
+	symlink func(oldname, newname string) error
 }
 
 type TestSetupResult struct {
@@ -543,6 +547,148 @@ func runLauncherScanStartNewTailerTest(t *testing.T, testDirs []string) {
 		msg = <-outputChan
 		assert.Equal(t, "world", string(msg.GetContent()))
 	}
+}
+
+// runLauncherNoFollowSymlinkTest verifies the symlink policy that the launcher
+// applies to file sources with NoFollow=true, at both file open sites: the
+// initial open and the rotation re-open.
+//
+// process_log paths come from /proc/<pid>/fd and are canonical at discovery time,
+// so any symlink that appears later on the path indicates an attacker-controlled
+// swap.  A source with NoFollow=true must therefore refuse to open a symlinked
+// path, while an ordinary source (NoFollow=false) must keep following symlinks,
+// since admin-configured log paths may legitimately be symlinks.
+//
+// The test drives full launcher scans, so under the privileged-logs suite (run as
+// root with unsearchable directories) it also exercises the system-probe
+// fd-transfer path: the open happens in system-probe, which must honour O_NOFOLLOW.
+//
+// All files use a .log name so that the privileged-logs module's allow-list (which
+// permits any *.log file) accepts them; the only behavioural difference under test
+// is whether the symlink is followed or rejected.
+func runLauncherNoFollowSymlinkTest(t *testing.T, ops TestOps, testDir string) {
+	cfg := configmock.New(t)
+	t.Cleanup(status.Clear)
+
+	// createEmpty creates an empty file at path.  The files are empty (like
+	// runLauncherFileRotationTest) so that started tailers never block sending to
+	// the pipeline channel, which lets launcher.cleanup() stop them; and they use a
+	// .log name so the privileged-logs module's allow-list (any *.log file) accepts
+	// them.  The only behaviour under test is whether a symlink is followed or rejected.
+	createEmpty := func(path string) {
+		f, err := ops.create(path)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	// targetPath is the file an attacker would point a swapped symlink at.
+	targetPath := testDir + "/target.log"
+	createEmpty(targetPath)
+
+	// swapToSymlink replaces the file at path with a symlink to targetPath, simulating
+	// an attacker swapping the discovered path after the agent first opened it.
+	swapToSymlink := func(path string) {
+		require.NoError(t, ops.remove(path))
+		require.NoError(t, ops.symlink(targetPath, path))
+	}
+
+	// newLauncher builds a launcher tailing a single exact-path source.
+	newLauncher := func(path string, noFollow bool) *Launcher {
+		launcher := createLauncher(t, launcherTestOptions{openFilesLimit: 2})
+		launcher.pipelineProvider = mock.NewMockProvider()
+		launcher.registry = auditorMock.NewMockRegistry()
+		source := sources.NewLogSource("", &config.LogsConfig{
+			Type:     config.FileType,
+			Path:     path,
+			NoFollow: noFollow,
+		})
+		launcher.activeSources = append(launcher.activeSources, source)
+		status.Clear()
+		status.InitStatus(cfg, testutils.CreateSources([]*sources.LogSource{source}))
+		return launcher
+	}
+	scan := func(l *Launcher) {
+		l.resolveActiveTailers(l.fileProvider.FilesToTail(context.Background(), l.validatePodContainerID, l.activeSources, l.registry))
+	}
+
+	t.Run("initial open", func(t *testing.T) {
+		realPath := testDir + "/init_real.log"
+		createEmpty(realPath)
+		l := newLauncher(realPath, true)
+		scan(l)
+		assert.Equal(t, 1, l.tailers.Count(), "noFollow source should tail a real file")
+		assert.True(t, l.tailers.Contains(realPath))
+		l.cleanup()
+
+		symlinkPath := testDir + "/init_symlink.log"
+		require.NoError(t, ops.symlink(targetPath, symlinkPath))
+
+		l = newLauncher(symlinkPath, true)
+		scan(l)
+		assert.Equal(t, 0, l.tailers.Count(), "noFollow source must reject a symlinked path")
+		l.cleanup()
+
+		l = newLauncher(symlinkPath, false)
+		scan(l)
+		assert.Equal(t, 1, l.tailers.Count(), "follow-symlinks source should follow a symlink")
+		assert.True(t, l.tailers.Contains(symlinkPath))
+		l.cleanup()
+	})
+
+	t.Run("rotation", func(t *testing.T) {
+		// noFollow: a path swapped to a symlink after the tailer started must be
+		// rejected on the rotation re-open, dropping the tailer.
+		plPath := testDir + "/rot_pl.log"
+		createEmpty(plPath)
+		l := newLauncher(plPath, true)
+		scan(l)
+		require.Equal(t, 1, l.tailers.Count(), "noFollow tailer should start on the real file")
+		plTailer, ok := l.tailers.Get(plPath)
+		require.True(t, ok)
+
+		swapToSymlink(plPath)
+		didRotate, err := plTailer.DidRotate()
+		assert.Error(t, err, "DidRotate must fail when the path became a symlink")
+		assert.False(t, didRotate)
+
+		scan(l)
+		assert.Equal(t, 0, l.tailers.Count(),
+			"noFollow tailer must drop when the path becomes a symlink on rotation")
+		l.cleanup()
+
+		// follow-symlinks: the rotation re-open still follows the symlink.
+		nplPath := testDir + "/rot_npl.log"
+		createEmpty(nplPath)
+		l = newLauncher(nplPath, false)
+		scan(l)
+		require.Equal(t, 1, l.tailers.Count(), "follow-symlinks tailer should start on the real file")
+		nplTailer, ok := l.tailers.Get(nplPath)
+		require.True(t, ok)
+
+		swapToSymlink(nplPath)
+		didRotate, err = nplTailer.DidRotate()
+		assert.NoError(t, err)
+		assert.True(t, didRotate, "follow-symlinks rotation should be detected and followed")
+
+		scan(l)
+		assert.Equal(t, 1, l.tailers.Count(),
+			"follow-symlinks tailer should follow the symlink across rotation")
+		assert.True(t, l.tailers.Contains(nplPath))
+		l.cleanup()
+	})
+}
+
+// TestLauncherNoFollowSymlink runs the NoFollow symlink policy test with the
+// ordinary (unprivileged) opener.  The privileged-logs suite runs the same helper
+// against the system-probe fd-transfer path; see launcher_privileged_logs_test.go.
+func TestLauncherNoFollowSymlink(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		// NoFollow is only enforced on Linux; on other platforms the opener
+		// rejects the policy outright (see opener.OpenLogFile for non-Linux).
+		t.Skip("NoFollow symlink rejection is only supported on Linux")
+	}
+	res := (&RegularTestSetupStrategy{}).Setup(t)
+	runLauncherNoFollowSymlinkTest(t, res.TestOps, res.TestDirs[0])
 }
 
 func runLauncherScanStartNewTailerForEmptyFileTest(t *testing.T, testDirs []string) {

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -262,6 +262,14 @@ func CreateSources(config integration.Config) ([]*sourcesPkg.LogSource, error) {
 
 		cfg.IntegrationSourceIndex = index
 		cfg.IntegrationSource = config.Source
+		if config.Provider == names.ProcessLog {
+			// process_log paths come from readlink(/proc/<pid>/fd/<n>).  The Linux
+			// kernel resolves all symlinks at file-open time, so the string in
+			// /proc/fd is already canonical — any symlink that appears later was
+			// planted after discovery and indicates an attacker-controlled swap.
+			// NoFollow tells the file tailer to open with O_NOFOLLOW on each component.
+			cfg.NoFollow = true
+		}
 
 		if service != nil {
 			// a config defined in a container label or a pod annotation does not always contain a type,

--- a/pkg/logs/schedulers/ad/scheduler_test.go
+++ b/pkg/logs/schedulers/ad/scheduler_test.go
@@ -496,3 +496,59 @@ func TestCreateSourcesWithNilConfigurations(t *testing.T) {
 		})
 	}
 }
+
+// TestNoFollowFlagSetOnConfig verifies that sources created from a process_log
+// provider have NoFollow=true, and that sources from other providers do not.
+// This flag is used by the file tailer to enforce O_NOFOLLOW opens, preventing
+// symlink-swap attacks on process_log-discovered paths.
+func TestNoFollowFlagSetOnConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		provider     string
+		expectedFlag bool
+	}{
+		{
+			name:         "process_log provider sets NoFollow=true",
+			provider:     names.ProcessLog,
+			expectedFlag: true,
+		},
+		{
+			name:         "file provider does not set NoFollow",
+			provider:     names.File,
+			expectedFlag: false,
+		},
+		{
+			name:         "kubernetes provider does not set NoFollow",
+			provider:     names.Kubernetes,
+			expectedFlag: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logsConfig []byte
+			var serviceID string
+
+			if tt.provider == names.File {
+				logsConfig = []byte("logs:\n  - type: file\n    path: /var/log/app.log\n    service: svc\n")
+				serviceID = ""
+			} else {
+				logsConfig = []byte(`[{"type":"file","path":"/var/log/app.log","service":"svc"}]`)
+				serviceID = tt.provider + ":///var/log/app.log"
+			}
+
+			cfg := integration.Config{
+				LogsConfig: logsConfig,
+				Provider:   tt.provider,
+				Name:       "test-config",
+				ServiceID:  serviceID,
+			}
+
+			sources, err := CreateSources(cfg)
+			require.NoError(t, err)
+			require.Len(t, sources, 1)
+			assert.Equal(t, tt.expectedFlag, sources[0].Config.NoFollow,
+				"Config.NoFollow should be %v for provider %q", tt.expectedFlag, tt.provider)
+		})
+	}
+}

--- a/pkg/logs/tailers/file/fingerprint.go
+++ b/pkg/logs/tailers/file/fingerprint.go
@@ -103,7 +103,7 @@ func (f *fingerprinterImpl) ComputeFingerprintFromConfig(filepath string, finger
 	if fingerprintConfig != nil && fingerprintConfig.FingerprintStrategy == types.FingerprintStrategyDisabled {
 		return newInvalidFingerprint(fingerprintConfig), nil
 	}
-	return f.computeFingerprint(filepath, fingerprintConfig)
+	return f.computeFingerprint(filepath, fingerprintConfig, false)
 }
 
 // ComputeFingerprint computes the fingerprint for the given file path
@@ -114,6 +114,11 @@ func (f *fingerprinterImpl) ComputeFingerprint(file *File) (*types.Fingerprint, 
 	if file == nil {
 		log.Warnf("file is nil, skipping fingerprinting")
 		return newInvalidFingerprint(nil), nil
+	}
+
+	noFollow := false
+	if file.Source.Config().NoFollow {
+		noFollow = true
 	}
 
 	fileFingerprintConfig := file.Source.Config().FingerprintConfig
@@ -134,12 +139,12 @@ func (f *fingerprinterImpl) ComputeFingerprint(file *File) (*types.Fingerprint, 
 			return newInvalidFingerprint(fingerprintConfig), nil
 		}
 
-		return f.computeFingerprint(file.Path, fingerprintConfig)
+		return f.computeFingerprint(file.Path, fingerprintConfig, noFollow)
 	}
 
 	// If per-source config exists but no strategy is set, or no per-source config exists,
 	// fall back to global config
-	return f.computeFingerprint(file.Path, &f.globalConfig)
+	return f.computeFingerprint(file.Path, &f.globalConfig, noFollow)
 }
 
 // ComputeFingerprintFromHandle computes the fingerprint for the given os.File using the provided config.
@@ -171,12 +176,17 @@ func (f *fingerprinterImpl) ComputeFingerprintFromHandle(osFile afero.File, fing
 }
 
 // computeFingerprint computes the fingerprint for the given file path
-func (f *fingerprinterImpl) computeFingerprint(filePath string, fingerprintConfig *types.FingerprintConfig) (*types.Fingerprint, error) {
+func (f *fingerprinterImpl) computeFingerprint(filePath string, fingerprintConfig *types.FingerprintConfig, noFollow bool) (*types.Fingerprint, error) {
 	if fingerprintConfig == nil {
 		return newInvalidFingerprint(nil), nil
 	}
 
-	fpFile, err := f.fileOpener.OpenLogFile(filePath)
+	openLogFile := f.fileOpener.OpenLogFile
+	if noFollow {
+		openLogFile = f.fileOpener.OpenLogFileNoFollow
+	}
+
+	fpFile, err := openLogFile(filePath)
 	if err != nil {
 		log.Warnf("could not open file for fingerprinting %s: %v", filePath, err)
 		return newInvalidFingerprint(fingerprintConfig), err

--- a/pkg/logs/tailers/file/rotate_nix.go
+++ b/pkg/logs/tailers/file/rotate_nix.go
@@ -22,7 +22,7 @@ import (
 // - removed and recreated
 // - truncated
 func (t *Tailer) DidRotate() (bool, error) {
-	f, err := t.fileOpener.OpenLogFile(t.fullpath)
+	f, err := t.openLogFile(t.fullpath)
 	if err != nil {
 		return false, fmt.Errorf("open %q: %w", t.fullpath, err)
 	}

--- a/pkg/logs/tailers/file/rotate_windows.go
+++ b/pkg/logs/tailers/file/rotate_windows.go
@@ -18,7 +18,7 @@ import (
 // On Windows, log rotation is identified by the file size being smaller
 // than the last offset read.
 func (t *Tailer) DidRotate() (bool, error) {
-	f, err := t.fileOpener.OpenLogFile(t.fullpath)
+	f, err := t.openLogFile(t.fullpath)
 	if err != nil {
 		return false, fmt.Errorf("open %q: %w", t.fullpath, err)
 	}

--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -133,6 +133,9 @@ type Tailer struct {
 	registry        auditor.Registry
 	CapacityMonitor *metrics.CapacityMonitor
 	fileOpener      opener.FileOpener
+
+	// noFollow controls whether openLogFile rejects symbolic links.
+	noFollow bool
 }
 
 // TailerOptions holds all possible parameters that NewTailer requires in addition to optional parameters that can be optionally passed into. This can be used for more optional parameters if required in future
@@ -182,6 +185,11 @@ func NewTailer(opts *TailerOptions) *Tailer {
 	movingSum := util.NewMovingSum(timeWindow, bucketSize, clock.New())
 	opts.Info.Register(movingSum)
 
+	noFollow := false
+	if cfg := opts.File.Source.Config(); cfg != nil && cfg.NoFollow {
+		noFollow = true
+	}
+
 	t := &Tailer{
 		file:                         opts.File,
 		outputChan:                   opts.OutputChan,
@@ -209,6 +217,7 @@ func NewTailer(opts *TailerOptions) *Tailer {
 		CapacityMonitor:              opts.CapacityMonitor,
 		registry:                     opts.Registry,
 		fileOpener:                   opts.FileOpener,
+		noFollow:                     noFollow,
 	}
 
 	if fileRotated {
@@ -453,6 +462,15 @@ func (t *Tailer) GetDetectedPattern() *regexp.Regexp {
 	return t.decoder.GetDetectedPattern()
 }
 
+// openLogFile opens a log file using this tailer's no-follow setting. All open
+// sites (initial open, rotation re-open) must call this helper.
+func (t *Tailer) openLogFile(path string) (afero.File, error) {
+	if t.noFollow {
+		return t.fileOpener.OpenLogFileNoFollow(path)
+	}
+	return t.fileOpener.OpenLogFile(path)
+}
+
 // wait lets the tailer sleep for a bit
 func (t *Tailer) wait() {
 	time.Sleep(t.sleepDuration)
@@ -463,9 +481,11 @@ func (t *Tailer) recordBytes(n int64) {
 	t.bytesRead.Add(n)
 }
 
-// ReplaceSource replaces the current source
+// ReplaceSource replaces the current source and refreshes open-policy state
+// derived from the source config (e.g. NoFollow).
 func (t *Tailer) ReplaceSource(newSource *sources.LogSource) {
 	t.file.Source.Replace(newSource)
+	t.noFollow = newSource.Config != nil && newSource.Config.NoFollow
 }
 
 // Source gets the source (currently only used for testing)

--- a/pkg/logs/tailers/file/tailer_nix.go
+++ b/pkg/logs/tailers/file/tailer_nix.go
@@ -28,7 +28,7 @@ func (t *Tailer) setup(offset int64, whence int) error {
 
 	log.Info("Opening", t.file.Path, "for tailer key", t.file.GetScanKey())
 
-	f, err := t.fileOpener.OpenLogFile(fullpath)
+	f, err := t.openLogFile(fullpath)
 	if err != nil {
 		return err
 	}

--- a/pkg/logs/tailers/file/tailer_test.go
+++ b/pkg/logs/tailers/file/tailer_test.go
@@ -689,3 +689,54 @@ func TestNoGoLeakWithNonBlockingStop(t *testing.T) {
 
 	// The deferred goleak.VerifyNone() will detect if goroutine leaked
 }
+
+// TestReplaceSourceRefreshesNoFollow verifies that ReplaceSource updates the
+// tailer's noFollow setting to match the new source's NoFollow flag.
+func TestReplaceSourceRefreshesNoFollow(t *testing.T) {
+	testDir := t.TempDir()
+	testPath := filepath.Join(testDir, "tailer.log")
+	f, err := os.Create(testPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	info := status.NewInfoRegistry()
+	makeSource := func(noFollow bool) *sources.LogSource {
+		return sources.NewLogSource("", &config.LogsConfig{
+			Type:     config.FileType,
+			Path:     testPath,
+			NoFollow: noFollow,
+		})
+	}
+
+	tailerOptions := &TailerOptions{
+		OutputChan:      make(chan *message.Message, chanSize),
+		File:            NewFile(testPath, makeSource(false), false),
+		SleepDuration:   10 * time.Millisecond,
+		Decoder:         decoder.NewDecoderFromSource(sources.NewReplaceableSource(makeSource(false)), info),
+		Info:            info,
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
+		Registry:        auditor.NewMockRegistry(),
+		FileOpener:      opener.NewFileOpener(),
+	}
+
+	tailer := NewTailer(tailerOptions)
+
+	// Initial state: NoFollow=false.
+	if tailer.noFollow {
+		t.Fatal("expected noFollow to be false initially")
+	}
+
+	// Replace with NoFollow=true.
+	tailer.ReplaceSource(makeSource(true))
+	if !tailer.noFollow {
+		t.Fatal("expected noFollow to be true after NoFollow=true source")
+	}
+
+	// Replace again with NoFollow=false.
+	tailer.ReplaceSource(makeSource(false))
+	if tailer.noFollow {
+		t.Fatal("expected noFollow to be false after NoFollow=false source")
+	}
+}

--- a/pkg/logs/tailers/file/tailer_windows.go
+++ b/pkg/logs/tailers/file/tailer_windows.go
@@ -30,7 +30,7 @@ func (t *Tailer) setup(offset int64, whence int) error {
 	t.tags = t.buildTailerTags()
 
 	log.Info("Opening ", t.fullpath)
-	f, err := t.fileOpener.OpenLogFile(t.fullpath)
+	f, err := t.openLogFile(t.fullpath)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (t *Tailer) readAvailable() (int, error) {
 	for {
 		if f == nil {
 			var err error
-			f, err = t.fileOpener.OpenLogFile(t.fullpath)
+			f, err = t.openLogFile(t.fullpath)
 			if err != nil {
 				return bytes, err
 			}

--- a/pkg/logs/util/opener/BUILD.bazel
+++ b/pkg/logs/util/opener/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/logs/internal/util/opener",
+        "//pkg/privileged-logs/common",
         "//pkg/util/filesystem",
         "@com_github_spf13_afero//:afero",
     ],

--- a/pkg/logs/util/opener/BUILD.bazel
+++ b/pkg/logs/util/opener/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/logs/internal/util/opener",
-        "//pkg/privileged-logs/common",
         "//pkg/util/filesystem",
         "@com_github_spf13_afero//:afero",
     ],

--- a/pkg/logs/util/opener/open.go
+++ b/pkg/logs/util/opener/open.go
@@ -18,6 +18,7 @@ import (
 // FileOpener is an interface that defines the method to open a log file.
 type FileOpener interface {
 	OpenLogFile(path string) (afero.File, error)
+	OpenLogFileNoFollow(path string) (afero.File, error)
 	OpenShared(path string) (afero.File, error)
 	Abs(path string) (string, error)
 }
@@ -37,6 +38,12 @@ type fileOpenerImpl struct {
 // function should be used instead. This will minimize avoidable error logs for failed privilege escalation attempts.
 func (f *fileOpenerImpl) OpenLogFile(path string) (afero.File, error) {
 	return internalOpener.OpenLogFile(path)
+}
+
+// OpenLogFileNoFollow opens a log file without following symbolic links in any
+// path component.
+func (f *fileOpenerImpl) OpenLogFileNoFollow(path string) (afero.File, error) {
+	return internalOpener.OpenLogFileNoFollow(path)
 }
 
 // OpenShared utilizes an os-specific implementation to open a generic file in a shared mode.

--- a/pkg/logs/util/opener/open_mock.go
+++ b/pkg/logs/util/opener/open_mock.go
@@ -41,6 +41,15 @@ func (m *MockFileOpener) OpenShared(path string) (afero.File, error) {
 
 // OpenLogFile returns the specified mock file or an error if the file was not added to the mock opener.
 func (m *MockFileOpener) OpenLogFile(path string) (afero.File, error) {
+	return m.openLogFile(path)
+}
+
+// OpenLogFileNoFollow returns the specified mock file or an error if the file was not added to the mock opener.
+func (m *MockFileOpener) OpenLogFileNoFollow(path string) (afero.File, error) {
+	return m.openLogFile(path)
+}
+
+func (m *MockFileOpener) openLogFile(path string) (afero.File, error) {
 	file, ok := m.MockedFiles[path]
 	if !ok {
 		return nil, fmt.Errorf("file not found: [ %s ]", path)

--- a/pkg/privileged-logs/client/BUILD.bazel
+++ b/pkg/privileged-logs/client/BUILD.bazel
@@ -9,15 +9,57 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/pkg/privileged-logs/client",
     visibility = ["//visibility:public"],
     deps = select({
+        "@rules_go//go/platform:aix": [
+            "//pkg/privileged-logs/common",
+        ],
         "@rules_go//go/platform:android": [
             "//pkg/config/setup",
             "//pkg/privileged-logs/common",
             "//pkg/util/log",
         ],
+        "@rules_go//go/platform:darwin": [
+            "//pkg/privileged-logs/common",
+        ],
+        "@rules_go//go/platform:dragonfly": [
+            "//pkg/privileged-logs/common",
+        ],
+        "@rules_go//go/platform:freebsd": [
+            "//pkg/privileged-logs/common",
+        ],
+        "@rules_go//go/platform:illumos": [
+            "//pkg/privileged-logs/common",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//pkg/privileged-logs/common",
+        ],
+        "@rules_go//go/platform:js": [
+            "//pkg/privileged-logs/common",
+        ],
         "@rules_go//go/platform:linux": [
             "//pkg/config/setup",
             "//pkg/privileged-logs/common",
             "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:netbsd": [
+            "//pkg/privileged-logs/common",
+        ],
+        "@rules_go//go/platform:openbsd": [
+            "//pkg/privileged-logs/common",
+        ],
+        "@rules_go//go/platform:osx": [
+            "//pkg/privileged-logs/common",
+        ],
+        "@rules_go//go/platform:plan9": [
+            "//pkg/privileged-logs/common",
+        ],
+        "@rules_go//go/platform:qnx": [
+            "//pkg/privileged-logs/common",
+        ],
+        "@rules_go//go/platform:solaris": [
+            "//pkg/privileged-logs/common",
+        ],
+        "@rules_go//go/platform:windows": [
+            "//pkg/privileged-logs/common",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/privileged-logs/client/BUILD.bazel
+++ b/pkg/privileged-logs/client/BUILD.bazel
@@ -9,57 +9,15 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/pkg/privileged-logs/client",
     visibility = ["//visibility:public"],
     deps = select({
-        "@rules_go//go/platform:aix": [
-            "//pkg/privileged-logs/common",
-        ],
         "@rules_go//go/platform:android": [
             "//pkg/config/setup",
             "//pkg/privileged-logs/common",
             "//pkg/util/log",
         ],
-        "@rules_go//go/platform:darwin": [
-            "//pkg/privileged-logs/common",
-        ],
-        "@rules_go//go/platform:dragonfly": [
-            "//pkg/privileged-logs/common",
-        ],
-        "@rules_go//go/platform:freebsd": [
-            "//pkg/privileged-logs/common",
-        ],
-        "@rules_go//go/platform:illumos": [
-            "//pkg/privileged-logs/common",
-        ],
-        "@rules_go//go/platform:ios": [
-            "//pkg/privileged-logs/common",
-        ],
-        "@rules_go//go/platform:js": [
-            "//pkg/privileged-logs/common",
-        ],
         "@rules_go//go/platform:linux": [
             "//pkg/config/setup",
             "//pkg/privileged-logs/common",
             "//pkg/util/log",
-        ],
-        "@rules_go//go/platform:netbsd": [
-            "//pkg/privileged-logs/common",
-        ],
-        "@rules_go//go/platform:openbsd": [
-            "//pkg/privileged-logs/common",
-        ],
-        "@rules_go//go/platform:osx": [
-            "//pkg/privileged-logs/common",
-        ],
-        "@rules_go//go/platform:plan9": [
-            "//pkg/privileged-logs/common",
-        ],
-        "@rules_go//go/platform:qnx": [
-            "//pkg/privileged-logs/common",
-        ],
-        "@rules_go//go/platform:solaris": [
-            "//pkg/privileged-logs/common",
-        ],
-        "@rules_go//go/platform:windows": [
-            "//pkg/privileged-logs/common",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/privileged-logs/client/open.go
+++ b/pkg/privileged-logs/client/open.go
@@ -11,22 +11,32 @@ package client
 import (
 	"errors"
 	"os"
+	"syscall"
 
 	"bytes"
 	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
-	"syscall"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/privileged-logs/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// OpenPrivileged opens a file in system-probe and returns the file descriptor
-// This function uses a custom HTTP client that can handle file descriptor transfer
+// OpenPrivileged opens a file in system-probe and returns the file descriptor.
+// This function uses a custom HTTP client that can handle file descriptor transfer.
 func OpenPrivileged(socketPath string, filePath string) (*os.File, error) {
+	return openPrivileged(socketPath, filePath, false)
+}
+
+// OpenPrivilegedNoFollow opens a file in system-probe without following symbolic
+// links in any path component.
+func OpenPrivilegedNoFollow(socketPath string, filePath string) (*os.File, error) {
+	return openPrivileged(socketPath, filePath, true)
+}
+
+func openPrivileged(socketPath string, filePath string, noFollow bool) (*os.File, error) {
 	// Create a new connection instead of reusing the shared connection from
 	// pkg/system-probe/api/client/client.go, since the connection is hijacked
 	// from the control of the HTTP server library on the server side.  It also
@@ -39,7 +49,8 @@ func OpenPrivileged(socketPath string, filePath string) (*os.File, error) {
 	defer conn.Close()
 
 	req := common.OpenFileRequest{
-		Path: filePath,
+		Path:     filePath,
+		NoFollow: noFollow,
 	}
 
 	reqBody, err := json.Marshal(req)
@@ -111,7 +122,7 @@ func OpenPrivileged(socketPath string, filePath string) (*os.File, error) {
 	return nil, errors.New("no file descriptor received")
 }
 
-func maybeOpenPrivileged(path string, originalError error) (*os.File, error) {
+func maybeOpenPrivileged(path string, originalError error, noFollow bool) (*os.File, error) {
 	enabled := pkgconfigsetup.SystemProbe().GetBool("privileged_logs.enabled")
 	if !enabled {
 		return nil, originalError
@@ -120,7 +131,7 @@ func maybeOpenPrivileged(path string, originalError error) (*os.File, error) {
 	log.Debugf("Permission denied, opening file with system-probe: %v", path)
 
 	socketPath := pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")
-	file, spErr := OpenPrivileged(socketPath, path)
+	file, spErr := openPrivileged(socketPath, path, noFollow)
 	log.Tracef("Opened file with system-probe: %v, err: %v", path, spErr)
 	if spErr != nil {
 		return nil, fmt.Errorf("failed to open file with system-probe: %w, original error: %w", spErr, originalError)
@@ -129,20 +140,34 @@ func maybeOpenPrivileged(path string, originalError error) (*os.File, error) {
 	return file, nil
 }
 
-// Open attempts to open a file, and if it fails due to permissions, it opens
-// the file using system-probe if the privileged logs module is available.
+// Open attempts to open a file with normal path resolution. If opening fails
+// with permission denied, the file may be opened via system-probe when
+// privileged logs is enabled.
 func Open(path string) (*os.File, error) {
-	file, err := os.Open(path)
+	return open(path, false)
+}
+
+// OpenNoFollow attempts to open a file without following symbolic links in any
+// path component. If opening fails with permission denied, the file may be
+// opened via system-probe with the same no-follow behavior.
+func OpenNoFollow(path string) (*os.File, error) {
+	return open(path, true)
+}
+
+func open(path string, noFollow bool) (*os.File, error) {
+	var file *os.File
+	var err error
+
+	if noFollow {
+		file, err = common.OpenPathWithoutSymlinks(path)
+	} else {
+		file, err = os.Open(path)
+	}
 	if err == nil || !errors.Is(err, os.ErrPermission) {
 		return file, err
 	}
 
-	file, err = maybeOpenPrivileged(path, err)
-	if err != nil {
-		return nil, err
-	}
-
-	return file, nil
+	return maybeOpenPrivileged(path, err, noFollow)
 }
 
 // Stat attempts to stat a file, and if it fails due to permissions, it opens
@@ -154,7 +179,7 @@ func Stat(path string) (os.FileInfo, error) {
 		return info, err
 	}
 
-	file, err := maybeOpenPrivileged(path, err)
+	file, err := maybeOpenPrivileged(path, err, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/privileged-logs/client/open_other.go
+++ b/pkg/privileged-logs/client/open_other.go
@@ -9,12 +9,28 @@
 package client
 
 import (
+	"fmt"
 	"os"
 )
 
 // Open provides a fallback for non-Linux platforms where the privileged logs module is not available.
 func Open(path string) (*os.File, error) {
 	return os.Open(path)
+}
+
+// OpenNoFollow is not supported on non-Linux platforms.
+func OpenNoFollow(path string) (*os.File, error) {
+	return nil, fmt.Errorf("privileged-logs client: no-follow open is not supported on non-Linux platforms: %s", path)
+}
+
+// OpenPrivileged is not supported on non-Linux platforms.
+func OpenPrivileged(_, _ string) (*os.File, error) {
+	return nil, os.ErrUnsupported
+}
+
+// OpenPrivilegedNoFollow is not supported on non-Linux platforms.
+func OpenPrivilegedNoFollow(_, _ string) (*os.File, error) {
+	return nil, os.ErrUnsupported
 }
 
 // Stat provides a fallback for non-Linux platforms where the privileged logs module is not available.

--- a/pkg/privileged-logs/client/open_other.go
+++ b/pkg/privileged-logs/client/open_other.go
@@ -10,7 +10,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"os"
 )
 
@@ -19,9 +18,12 @@ func Open(path string) (*os.File, error) {
 	return os.Open(path)
 }
 
-// OpenNoFollow is not supported on non-Linux platforms.
+// OpenNoFollow falls back to a regular open on non-Linux platforms: symlink
+// rejection is only needed for process_log-discovered paths, and process_log
+// discovery (based on /proc/<pid>/fd) is Linux-only, so this path is not
+// reachable with an untrusted, attacker-controlled symlink swap here.
 func OpenNoFollow(path string) (*os.File, error) {
-	return nil, fmt.Errorf("privileged-logs client: no-follow open is not supported on non-Linux platforms: %s", path)
+	return os.Open(path)
 }
 
 // OpenPrivileged is not supported on non-Linux platforms.

--- a/pkg/privileged-logs/client/open_other.go
+++ b/pkg/privileged-logs/client/open_other.go
@@ -9,6 +9,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"os"
 )
@@ -25,12 +26,12 @@ func OpenNoFollow(path string) (*os.File, error) {
 
 // OpenPrivileged is not supported on non-Linux platforms.
 func OpenPrivileged(_, _ string) (*os.File, error) {
-	return nil, os.ErrUnsupported
+	return nil, errors.ErrUnsupported
 }
 
 // OpenPrivilegedNoFollow is not supported on non-Linux platforms.
 func OpenPrivilegedNoFollow(_, _ string) (*os.File, error) {
-	return nil, os.ErrUnsupported
+	return nil, errors.ErrUnsupported
 }
 
 // Stat provides a fallback for non-Linux platforms where the privileged logs module is not available.

--- a/pkg/privileged-logs/common/BUILD.bazel
+++ b/pkg/privileged-logs/common/BUILD.bazel
@@ -1,8 +1,38 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "common",
-    srcs = ["types.go"],
+    srcs = [
+        "open_linux.go",
+        "types.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/pkg/privileged-logs/common",
     visibility = ["//visibility:public"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "common_test",
+    srcs = ["open_linux_test.go"],
+    embed = [":common"],
+    gotags = ["test"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/privileged-logs/common/BUILD.bazel
+++ b/pkg/privileged-logs/common/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "common",
@@ -19,11 +20,10 @@ go_library(
     }),
 )
 
-go_test(
+dd_agent_go_test(
     name = "common_test",
     srcs = ["open_linux_test.go"],
     embed = [":common"],
-    gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:android": [
             "@com_github_stretchr_testify//assert",

--- a/pkg/privileged-logs/common/open_linux.go
+++ b/pkg/privileged-logs/common/open_linux.go
@@ -5,7 +5,7 @@
 
 //go:build linux
 
-package module
+package common
 
 import (
 	"fmt"
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// openPathWithoutSymlinks opens a file by traversing each path component with
+// OpenPathWithoutSymlinks opens a file by traversing each path component with
 // O_NOFOLLOW, to ensure that the actual filesystem structure matches the path
 // passed to the function.  On newer kernels, this could be done with openat2(2)
 // and RESOLVE_NO_SYMLINKS.
@@ -25,7 +25,11 @@ import (
 // os.OpenInRoot(), since all of those follow symlinks on the root directory
 // itself, but for our use case, the root directory itself can not be trusted to
 // not have changed since the time the path was validated.
-func openPathWithoutSymlinks(path string) (*os.File, error) {
+//
+// This function is used both by the privileged-logs module (server side,
+// root-running system-probe) and by the privileged-logs client (agent side),
+// to defend against symlink-swap attacks on process_log-discovered file paths.
+func OpenPathWithoutSymlinks(path string) (*os.File, error) {
 	if !filepath.IsAbs(path) {
 		return nil, fmt.Errorf("path must be absolute: %s", path)
 	}

--- a/pkg/privileged-logs/common/open_linux.go
+++ b/pkg/privileged-logs/common/open_linux.go
@@ -37,7 +37,14 @@ func OpenPathWithoutSymlinks(path string) (*os.File, error) {
 	// Split path into components
 	parts := strings.Split(filepath.Clean(path), string(filepath.Separator))
 
-	dirFd, err := unix.Open("/", unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_DIRECTORY, 0)
+	// Directory components are opened with O_PATH rather than O_RDONLY.
+	// O_PATH only requires search (execute) permission to traverse into a
+	// directory, matching the permission check that a plain os.Open(path)
+	// would perform on the same directories.  O_RDONLY additionally
+	// requires read permission on every directory component, which would
+	// wrongly reject files under directories that are traversable but not
+	// listable (e.g. mode 0711).
+	dirFd, err := unix.Open("/", unix.O_PATH|unix.O_NOFOLLOW|unix.O_DIRECTORY, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open root directory: %w", err)
 	}
@@ -54,7 +61,7 @@ func OpenPathWithoutSymlinks(path string) (*os.File, error) {
 			continue
 		}
 
-		newFd, err := unix.Openat(dirFd, parts[i], unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_DIRECTORY, 0)
+		newFd, err := unix.Openat(dirFd, parts[i], unix.O_PATH|unix.O_NOFOLLOW|unix.O_DIRECTORY, 0)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open directory component %s: %w", parts[i], err)
 		}
@@ -64,7 +71,9 @@ func OpenPathWithoutSymlinks(path string) (*os.File, error) {
 		dirFd = newFd
 	}
 
-	// Open the final file component with O_NOFOLLOW
+	// Open the final file component with O_NOFOLLOW. dirFd was opened with
+	// O_PATH, so this openat still enforces the normal read-permission check
+	// on the file itself.
 	fileName := parts[len(parts)-1]
 	fileFd, err := unix.Openat(dirFd, fileName, unix.O_RDONLY|unix.O_NOFOLLOW, 0)
 	if err != nil {

--- a/pkg/privileged-logs/common/open_linux_test.go
+++ b/pkg/privileged-logs/common/open_linux_test.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenPathWithoutSymlinksNoSymlink(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "test.log")
+	require.NoError(t, os.WriteFile(logFile, []byte("hello"), 0644))
+
+	f, err := OpenPathWithoutSymlinks(logFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	buf := make([]byte, 5)
+	n, err := f.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(buf[:n]))
+}
+
+func TestOpenPathWithoutSymlinksSymlinkInFile(t *testing.T) {
+	dir := t.TempDir()
+	realFile := filepath.Join(dir, "real.log")
+	require.NoError(t, os.WriteFile(realFile, []byte("secret"), 0644))
+
+	link := filepath.Join(dir, "link.log")
+	require.NoError(t, os.Symlink(realFile, link))
+
+	f, err := OpenPathWithoutSymlinks(link)
+	assert.Error(t, err)
+	assert.Nil(t, f)
+	// O_NOFOLLOW on the final component should give ELOOP
+	assert.ErrorIs(t, err, syscall.ELOOP)
+}
+
+func TestOpenPathWithoutSymlinksSymlinkInParentDirectory(t *testing.T) {
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "real")
+	require.NoError(t, os.Mkdir(realDir, 0755))
+
+	logFile := filepath.Join(realDir, "test.log")
+	require.NoError(t, os.WriteFile(logFile, []byte("hello"), 0644))
+
+	linkDir := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink(realDir, linkDir))
+
+	f, err := OpenPathWithoutSymlinks(filepath.Join(linkDir, "test.log"))
+	assert.Error(t, err)
+	assert.Nil(t, f)
+	// O_DIRECTORY|O_NOFOLLOW on a symlinked directory component is rejected.
+	assert.ErrorIs(t, err, syscall.ENOTDIR)
+}
+
+func TestOpenPathWithoutSymlinksSymlinkSwap(t *testing.T) {
+	// Simulate the attacker scenario: open a real file, swap it to a symlink,
+	// confirm the second open is rejected.
+	dir := t.TempDir()
+	realFile := filepath.Join(dir, "real.log")
+	require.NoError(t, os.WriteFile(realFile, []byte("benign"), 0644))
+
+	// First open should succeed (path is a real file at this point)
+	f, err := OpenPathWithoutSymlinks(realFile)
+	require.NoError(t, err)
+	f.Close()
+
+	// Attacker swaps the file for a symlink to a sensitive target
+	sensitiveFile := filepath.Join(dir, "sensitive.dat")
+	require.NoError(t, os.WriteFile(sensitiveFile, []byte("SECRET"), 0644))
+	require.NoError(t, os.Remove(realFile))
+	require.NoError(t, os.Symlink(sensitiveFile, realFile))
+
+	// Second open must fail with ELOOP, not return the sensitive file
+	f2, err := OpenPathWithoutSymlinks(realFile)
+	assert.Error(t, err)
+	assert.Nil(t, f2)
+	assert.ErrorIs(t, err, syscall.ELOOP)
+}

--- a/pkg/privileged-logs/common/types.go
+++ b/pkg/privileged-logs/common/types.go
@@ -9,6 +9,12 @@ package common
 // OpenFileRequest represents a request to open a file and transfer its file descriptor
 type OpenFileRequest struct {
 	Path string `json:"path"`
+	// NoFollow, when true, asks the module to open the file without following any
+	// symbolic links in the path.  This is used for process_log-discovered paths,
+	// which are canonical at discovery time; a symlink found later indicates an
+	// attacker-controlled swap.  When false (the default), symbolic links are
+	// resolved as usual.
+	NoFollow bool `json:"no_follow,omitempty"`
 }
 
 // OpenFileResponse represents the response from the file descriptor transfer

--- a/pkg/privileged-logs/module/BUILD.bazel
+++ b/pkg/privileged-logs/module/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     srcs = [
         "handler.go",
         "module.go",
-        "open.go",
         "validate.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/privileged-logs/module",
@@ -17,14 +16,12 @@ go_library(
             "//pkg/system-probe/api/module",
             "//pkg/util/log",
             "@com_github_hashicorp_golang_lru_v2//simplelru",
-            "@org_golang_x_sys//unix",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/privileged-logs/common",
             "//pkg/system-probe/api/module",
             "//pkg/util/log",
             "@com_github_hashicorp_golang_lru_v2//simplelru",
-            "@org_golang_x_sys//unix",
         ],
         "//conditions:default": [],
     }),
@@ -40,11 +37,13 @@ dd_agent_go_test(
     embed = [":module"],
     deps = select({
         "@rules_go//go/platform:android": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/log",
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:linux": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/log",
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",

--- a/pkg/privileged-logs/module/handler.go
+++ b/pkg/privileged-logs/module/handler.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/privileged-logs/common"
@@ -85,7 +86,12 @@ func (f *privilegedLogsModule) openFileHandler(w http.ResponseWriter, r *http.Re
 
 	f.logFileAccess(req.Path)
 
-	file, err := validateAndOpen(req.Path)
+	var file *os.File
+	if req.NoFollow {
+		file, err = validateAndOpenNoFollow(req.Path)
+	} else {
+		file, err = validateAndOpen(req.Path)
+	}
 	if err != nil {
 		f.sendErrorResponse(unixConn, err.Error())
 		return

--- a/pkg/privileged-logs/module/open_test.go
+++ b/pkg/privileged-logs/module/open_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/privileged-logs/common"
 )
 
 // openPathWithoutSymlinksAndCheckFDs wraps openPathWithoutSymlinks and verifies
@@ -23,7 +25,7 @@ func openPathWithoutSymlinksAndCheckFDs(t *testing.T, path string) (*os.File, er
 	t.Helper()
 	fdsBefore := countOpenFDs(t)
 
-	file, err := openPathWithoutSymlinks(path)
+	file, err := common.OpenPathWithoutSymlinks(path)
 
 	if err != nil {
 		fdsAfter := countOpenFDs(t)

--- a/pkg/privileged-logs/module/validate.go
+++ b/pkg/privileged-logs/module/validate.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/DataDog/datadog-agent/pkg/privileged-logs/common"
 )
 
 func isAllowed(path, allowedPrefix string) bool {
@@ -59,18 +61,9 @@ func isTextFile(file *os.File) bool {
 }
 
 func validateAndOpenWithPrefix(path, allowedPrefix string, toctou func()) (*os.File, error) {
-	if path == "" {
-		return nil, errors.New("empty file path provided")
-	}
-
-	if !filepath.IsAbs(path) {
-		return nil, fmt.Errorf("relative path not allowed: %s", path)
-	}
-
-	// Resolve symbolic links for the path and file name checks.
-	resolvedPath, err := filepath.EvalSymlinks(path)
+	resolvedPath, err := resolveFollowPath(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve path %s: %w", path, err)
+		return nil, err
 	}
 
 	// Callback for tests to change the filesystem after we called EvalSymlinks,
@@ -79,16 +72,58 @@ func validateAndOpenWithPrefix(path, allowedPrefix string, toctou func()) (*os.F
 		toctou()
 	}
 
-	var file *os.File
+	return validateResolvedAndOpen(resolvedPath, allowedPrefix)
+}
 
+func validateAndOpenNoFollowWithPrefix(path, allowedPrefix string) (*os.File, error) {
+	resolvedPath, err := resolveNoFollowPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return validateResolvedAndOpen(resolvedPath, allowedPrefix)
+}
+
+func resolveFollowPath(path string) (string, error) {
+	if path == "" {
+		return "", errors.New("empty file path provided")
+	}
+
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("relative path not allowed: %s", path)
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve path %s: %w", path, err)
+	}
+	return resolvedPath, nil
+}
+
+func resolveNoFollowPath(path string) (string, error) {
+	if path == "" {
+		return "", errors.New("empty file path provided")
+	}
+
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("relative path not allowed: %s", path)
+	}
+
+	// In no-follow mode the caller guarantees the path is canonical. Skip
+	// EvalSymlinks entirely: open every component with O_NOFOLLOW so that a
+	// symlink planted after the agent's discovery check causes an immediate error.
+	return filepath.Clean(path), nil
+}
+
+func validateResolvedAndOpen(resolvedPath, allowedPrefix string) (*os.File, error) {
 	if !isAllowed(resolvedPath, allowedPrefix) {
 		return nil, fmt.Errorf("non-log file not allowed: %s", resolvedPath)
 	}
 
 	// We use openPathWithoutSymlinks on the resolved path to verify each
 	// component with O_NOFOLLOW to ensure that none of the path components
-	// were replaced with symlinks after we called EvalSymlinks.
-	file, err = openPathWithoutSymlinks(resolvedPath)
+	// were replaced with symlinks after we called EvalSymlinks (follow mode),
+	// or to enforce that the path has no symlinks at all (no-follow mode).
+	file, err := common.OpenPathWithoutSymlinks(resolvedPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open path %s: %w", resolvedPath, err)
 	}
@@ -115,4 +150,8 @@ func validateAndOpenWithPrefix(path, allowedPrefix string, toctou func()) (*os.F
 
 func validateAndOpen(path string) (*os.File, error) {
 	return validateAndOpenWithPrefix(path, "/var/log/", nil)
+}
+
+func validateAndOpenNoFollow(path string) (*os.File, error) {
+	return validateAndOpenNoFollowWithPrefix(path, "/var/log/")
 }

--- a/pkg/privileged-logs/module/validate_test.go
+++ b/pkg/privileged-logs/module/validate_test.go
@@ -810,3 +810,35 @@ func TestValidateAndOpenWithPrefixTOCTOUFileSymlink(t *testing.T) {
 	assert.Nil(t, file)
 	assert.True(t, toctouCalled)
 }
+
+// TestValidateAndOpenWithPrefixNoFollowRejectsSymlink verifies that when noFollow
+// is true, validateAndOpenWithPrefix refuses to open a path that is (or has
+// become) a symlink, even when the symlink target would be allow-listed.  This
+// closes the residual TOCTOU where an attacker swaps a process_log-discovered file
+// to a symlink pointing at a root-readable log that the module would normally allow.
+func TestValidateAndOpenWithPrefixNoFollowRejectsSymlink(t *testing.T) {
+	testDir := t.TempDir()
+
+	// A real log file to discover initially
+	logFile := filepath.Join(testDir, "app.log")
+	require.NoError(t, os.WriteFile(logFile, []byte("log content"), 0644))
+
+	// Attacker swaps app.log for a symlink to an allow-listed target
+	targetLog := filepath.Join(testDir, "secret.log")
+	require.NoError(t, os.WriteFile(targetLog, []byte("secret content"), 0644))
+
+	require.NoError(t, os.Remove(logFile))
+	require.NoError(t, os.Symlink(targetLog, logFile))
+
+	// In noFollow mode the symlink must be rejected even though the target ends in .log
+	file, err := validateAndOpenNoFollowWithPrefix(logFile, testDir+"/")
+	assert.Error(t, err)
+	assert.Nil(t, file)
+
+	// In standard (follow) mode the symlink would succeed
+	file2, err2 := validateAndOpenWithPrefix(logFile, testDir+"/", nil)
+	if err2 == nil {
+		// accepted as expected in follow mode
+		file2.Close()
+	}
+}

--- a/pkg/privileged-logs/test/privileged_logs_test.go
+++ b/pkg/privileged-logs/test/privileged_logs_test.go
@@ -159,6 +159,35 @@ func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_Symlink() {
 	assertOpenPrivilegedContent(s.T(), s.handler.SocketPath, symlinkPath, testContent)
 }
 
+func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_OpenPrivilegedNoFollowRealFile() {
+	testContent := "real log content"
+	realLogFile := createTestFile(s.T(), s.tempDir, "real-nosymlink.log", testContent)
+
+	file, err := client.OpenPrivilegedNoFollow(s.handler.SocketPath, realLogFile)
+	require.NoError(s.T(), err)
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), testContent, string(data))
+}
+
+func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_OpenPrivilegedNoFollowRejectsSymlink() {
+	testContent := "real log content"
+	realLogFile := createTestFile(s.T(), s.tempDir, "real-reject.log", testContent)
+
+	symlinkPath := filepath.Join(s.tempDir, "fake-reject.log")
+	err := WithParentPermFixup(s.T(), symlinkPath, func() error {
+		return os.Symlink(realLogFile, symlinkPath)
+	})
+	require.NoError(s.T(), err)
+
+	file, err := client.OpenPrivilegedNoFollow(s.handler.SocketPath, symlinkPath)
+	require.Error(s.T(), err)
+	assert.Nil(s.T(), file)
+	assert.Contains(s.T(), err.Error(), "too many levels of symbolic links")
+}
+
 func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_SymlinkToNonLogFile() {
 	nonLogFile := createTestFile(s.T(), s.tempDir, "secret_nonlog.txt", "secret content")
 
@@ -189,6 +218,40 @@ func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_OpenFallback() {
 
 	assertClientOpenContent(s.T(), upperLogFile, testContent)
 	assertClientStatInfo(s.T(), upperLogFile, int64(len(testContent)))
+}
+
+func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_OpenFallbackNoFollow() {
+	testContent := "test content"
+	testFile := createTestFile(s.T(), s.tempDir, "restricted-nosymlink.log", testContent)
+
+	setupSystemProbeConfig(s.T(), s.handler.SocketPath, true)
+
+	file, err := client.OpenNoFollow(testFile)
+	require.NoError(s.T(), err)
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), testContent, string(data))
+}
+
+func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_OpenFallbackNoFollowRejectsSymlink() {
+	testContent := "test content"
+	realLogFile := createTestFile(s.T(), s.tempDir, "restricted-real.log", testContent)
+
+	symlinkPath := filepath.Join(s.tempDir, "restricted-link.log")
+	err := WithParentPermFixup(s.T(), symlinkPath, func() error {
+		return os.Symlink(realLogFile, symlinkPath)
+	})
+	require.NoError(s.T(), err)
+
+	setupSystemProbeConfig(s.T(), s.handler.SocketPath, true)
+
+	file, err := client.OpenNoFollow(symlinkPath)
+	require.Error(s.T(), err)
+	assert.Nil(s.T(), file)
+	assert.Contains(s.T(), err.Error(), "failed to open file with system-probe")
+	assert.Contains(s.T(), err.Error(), "too many levels of symbolic links")
 }
 
 func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_OpenFallbackError() {


### PR DESCRIPTION
### What does this PR do?

Hardens the log tailer against symlink-following for log paths discovered via the `process_log` autodiscovery provider.

- Adds a `NoFollow bool` field to `LogsConfig` (`comp/logs/agent/config/integration_config.go`), set by the AD scheduler whenever a source's provider is `process_log` (`pkg/logs/schedulers/ad/scheduler.go`).
- Adds `OpenLogFileNoFollow` / `OpenNoFollow` / `OpenPrivilegedNoFollow` variants across the file-opener stack (`pkg/logs/internal/util/opener`, `pkg/logs/util/opener`, `pkg/privileged-logs/client`), all backed by a new `common.OpenPathWithoutSymlinks` helper (`pkg/privileged-logs/common/open_linux.go`) that walks each path component with `O_NOFOLLOW`. This helper is shared by both the privileged-logs client (agent side) and the privileged-logs module (system-probe side), so the no-follow behavior is enforced whether or not privileged log collection is used.
- The file tailer (`pkg/logs/tailers/file/tailer.go`) and fingerprinter (`pkg/logs/tailers/file/fingerprint.go`) now route through a `noFollow`-aware open on every open site (initial open, rotation re-open, fingerprinting), driven by `Source.Config().NoFollow`. `Tailer.ReplaceSource` refreshes this flag when a source is replaced.
- `NoFollow` is propagated to container/k8s-derived sources in `pkg/logs/launchers/container/tailerfactory/file.go`. Container/pod log paths (e.g. `/var/log/pods/…`) are intentionally symlinked by the runtime, so those sources continue to follow symlinks as before — only `process_log`-originated sources get `NoFollow`.
- `checkFileReadable` in the `process_log` provider (`comp/core/autodiscovery/providers/process_log.go`) uses the no-follow open when validating a discovered path is readable.

Other log sources (`file`, `kubernetes`, etc.) are unaffected: their paths are explicitly specified by the user, and it's up to the user to ensure such a path isn't swapped for a symlink by an untrusted party.

### Motivation

Paths discovered via `process_log` come from `readlink(/proc/<pid>/fd/<n>)`. The kernel resolves all symlinks at the time the target process opened that fd, so the string returned is already canonical — if a symlink appears at that path later, it was planted after discovery by something other than the process that owns the fd. Since the agent otherwise follows symlinks when tailing, an unprivileged attacker able to write to the resolved path could swap it for a symlink and get the agent to tail an arbitrary `dd-agent`-readable file (or a root-readable one, if privileged log collection is enabled).

Rejecting symlinks for this specific, narrow case (`process_log`-discovered paths only) closes that gap without changing behavior for any other log collection method that legitimately relies on symlinks.

Tracked internally in DSCVR-475.

### Describe how you validated your changes

Added unit tests covering both the policy and the low-level enforcement:
- `TestNoFollowFlagSetOnConfig` (`pkg/logs/schedulers/ad/scheduler_test.go`): sources from `process_log` get `NoFollow=true`; sources from `file`/`kubernetes` do not.
- `TestReplaceSourceRefreshesNoFollow` (`pkg/logs/tailers/file/tailer_test.go`): `ReplaceSource` updates the tailer's no-follow state.
- `TestOpenPathWithoutSymlinks*` (`pkg/privileged-logs/common/open_linux_test.go`): no symlink present, symlink as the final component, symlink in a parent directory, and the swap scenario (open succeeds, file removed and replaced with a symlink, second open is rejected with `ELOOP`).
- `TestLauncherNoFollowSymlink` / `TestPrivilegedLogsLauncherNoFollowSymlink` (`pkg/logs/launchers/file/launcher_test.go`, `launcher_privileged_logs_test.go`): end-to-end launcher coverage for both the unprivileged and system-probe-backed (privileged logs) open paths.

### Additional Notes

`names.ProcessLog` (the autodiscovery provider name constant) is unchanged — it identifies the provider, not the config flag.