### PR TITLE
CSI-1694: Disabling S3 Strategy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -375,7 +375,8 @@ variables:
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 
   # Job cloning strategy
-  GIT_STRATEGY: "s3"
+  GIT_STRATEGY: "fetch"
+  DISABLE_GIT_CACHE: true
 
   # Job stage attempts (see https://docs.gitlab.com/ee/ci/runners/configure_runners.html#job-stages-attempts)
   ARTIFACT_DOWNLOAD_ATTEMPTS: 2

--- a/.gitlab/build/source_test/golang_deps_diff.yml
+++ b/.gitlab/build/source_test/golang_deps_diff.yml
@@ -12,7 +12,7 @@ golang_deps_diff:
   needs: ["go_deps"]
   variables:
     KUBERNETES_CPU_REQUEST: 8
-    OVERRIDE_GIT_STRATEGY: "clone" # needed because this job uses `git merge-base`
+    GIT_STRATEGY: "clone" # needed because this job uses `git merge-base`
     KUBERNETES_MEMORY_REQUEST: "16Gi"
     KUBERNETES_MEMORY_LIMIT: "16Gi"
   before_script:

--- a/.gitlab/deploy/conditions.yml
+++ b/.gitlab/deploy/conditions.yml
@@ -163,7 +163,7 @@
     # Windows runners don't support the s3 strategy
     # Clone is required since cancelled Windows jobs with fetch strategy
     # can cause CIEXE-1152 which makes the runner unusable.
-    OVERRIDE_GIT_STRATEGY: "clone"
+    GIT_STRATEGY: "clone"
     # Avoid using ~/.aws/credentials to avoid conflicts with other CI jobs
     # this env var is understood by both ci-identities-gitlab-job-client.exe and aws.exe
     AWS_SHARED_CREDENTIALS_FILE: ${CI_PROJECT_DIR}\.aws\credentials-by-job-id\${CI_JOB_ID}
@@ -182,7 +182,7 @@
     # Windows runners don't support the s3 strategy
     # Clone is required since cancelled Windows jobs with fetch strategy
     # can cause CIEXE-1152 which makes the runner unusable.
-    OVERRIDE_GIT_STRATEGY: "clone"
+    GIT_STRATEGY: "clone"
     # Avoid using ~/.aws/credentials to avoid conflicts with other CI jobs
     # this env var is understood by both ci-identities-gitlab-job-client.exe and aws.exe
     AWS_SHARED_CREDENTIALS_FILE: ${CI_PROJECT_DIR}\.aws\credentials-by-job-id\${CI_JOB_ID}
@@ -204,7 +204,7 @@
     # Windows runners don't support the s3 strategy
     # Clone is required since cancelled Windows jobs with fetch strategy
     # can cause CIEXE-1152 which makes the runner unusable.
-    OVERRIDE_GIT_STRATEGY: "clone"
+    GIT_STRATEGY: "clone"
     # Avoid using ~/.aws/credentials to avoid conflicts with other CI jobs
     # this env var is understood by both ci-identities-gitlab-job-client.exe and aws.exe
     AWS_SHARED_CREDENTIALS_FILE: ${CI_PROJECT_DIR}\.aws\credentials-by-job-id\${CI_JOB_ID}

--- a/.gitlab/test/functional_test/files_inventory_check.yml
+++ b/.gitlab/test/functional_test/files_inventory_check.yml
@@ -10,7 +10,7 @@ files_inventory_check:
   tags: ["arch:amd64", "specific:true"]
   variables:
     GIT_DEPTH: 0
-    OVERRIDE_GIT_STRATEGY: clone
+    GIT_STRATEGY: clone
   needs:
     - agent_deb-x64-a7
   before_script:

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -84,7 +84,7 @@ static_quality_gates:
     expire_in: 1 week
   variables:
     GIT_DEPTH: 0
-    OVERRIDE_GIT_STRATEGY: "clone" # needed because this job uses git merge-base
+    GIT_STRATEGY: "clone" # needed because this job uses git merge-base
     KUBERNETES_CPU_REQUEST: 8
 
 manual_gate_threshold_update:

--- a/.gitlab/windows/deploy/container_build/agent7.yml
+++ b/.gitlab/windows/deploy/container_build/agent7.yml
@@ -95,7 +95,7 @@ docker_build_agent7_windows:
         WITH_JMX: "true"
   tags: [$WINDOWS_RUNNER]
   variables:
-    OVERRIDE_GIT_STRATEGY: "clone"
+    GIT_STRATEGY: "clone"
 
 # FIPS builds: ltsc2022 only (with/without JMX)
 docker_build_fips_agent7_windows:
@@ -110,4 +110,4 @@ docker_build_fips_agent7_windows:
         WITH_JMX: "true"
   tags: [$WINDOWS_RUNNER]
   variables:
-    OVERRIDE_GIT_STRATEGY: "clone"
+    GIT_STRATEGY: "clone"


### PR DESCRIPTION
With the introduction of gitretriever we no longer need the S3 strategy. Metric to track: https://app.datadoghq.com/s/yB5yjZ/45h-gma-i7n
