### PR TITLE
workspace(S4): switch to base-compat feature (platform split)

### DIFF
--- a/.devcontainer/datadog/default/features/datadog-agent/WORKSPACE_S2.md
+++ b/.devcontainer/datadog/default/features/datadog-agent/WORKSPACE_S2.md
@@ -1,0 +1,71 @@
+# Workspace S2: Drop `bits` Pre-Bake (group-ownership)
+
+## Problem
+
+The `dev-env-workspace` buildimage (post-PR #1089 in `datadog-agent-buildimages`) pre-bakes the
+`bits` user (UID 2000) so toolchains owned `root:build-shared` are writable at runtime. The
+mandatory Datadog Workspace `base` devcontainer feature unconditionally runs
+`useradd --uid 2000 bits` at provision time. This collision (`useradd: user 'bits' already
+exists`) breaks workspace provisioning.
+
+## Solution
+
+Remove the `bits` user pre-bake from the buildimage entirely. Let the `base` feature create `bits`
+at runtime as it was always designed to do. Restore toolchain write access via `build-shared` group
+membership, granted by the agent's own devcontainer feature after the base feature runs.
+
+**Why this works:** every baked toolchain is already `root:build-shared` with setgid directories
+(`fix-shared-perms.sh`). The existing `dd-build` and `dd` users access all toolchains (RVM, Rust,
+Go, Conda) via `build-shared` membership alone — never via user ownership. `bits` is identical.
+
+## Changes
+
+### `datadog-agent-buildimages` — `dev-envs/linux/variants/workspaces/setup.sh`
+Removed the `bits` user pre-bake block:
+- `useradd ... --groups users,build-shared,sudo bits`
+- `if getent group docker; then usermod -a -G docker bits; fi`
+- `seed_home "${bits_home}" bits dog`
+- `install -d -m 700 -o bits -g dog "${bits_home}/.ssh"`
+- `passwd -d bits` / `usermod -U bits`
+
+Kept everything unrelated to `bits` (`dog` user, sudoers, zshenv). `build-shared` (GID 9001) is
+created in `linux/Dockerfile:371` and survives — not touched here.
+
+### `datadog-agent` — `.devcontainer/datadog/default/features/datadog-agent/install.sh`
+Replaced the unguarded `usermod -aG docker bits` with guarded forms for both groups:
+```sh
+getent group docker >/dev/null && usermod -aG docker bits
+getent group build-shared >/dev/null && usermod -aG build-shared bits
+```
+The `getent` guard makes this a clean no-op on stock workspace images where these buildimage-only
+groups are absent (confirmed live on a stock workspace: exit 0, no change).
+
+## Tested (2026-06-03, image `v116490909-fc35a1a5`)
+
+| Test | Result |
+|---|---|
+| Collision proof: `useradd bits` on post-#1089 image | `useradd: user 'bits' already exists` ✅ |
+| File A: `userdel -r bits` removes pre-baked user | `bits removed ✓` ✅ |
+| Base feature `useradd` succeeds after de-bake | `useradd bits succeeded (no collision) ✓` ✅ |
+| File B: `usermod -aG build-shared bits` adds membership | `bits in build-shared ✓` ✅ |
+| RVM gem write as bits (fresh exec, login shell) | `GEM_HOME=/opt/dd/rvm/gems/ruby-2.7.2` write PASS ✅ |
+| Rustup dir write as bits (`/opt/dd/rustup`) | PASS ✅ |
+| Go build as bits (`GOPATH=/var/config/dd/go`) | PASS ✅ |
+| Stock-workspace guard: no-op when `build-shared` absent | exit 0 ✅ |
+
+## Adoption (next steps)
+
+1. This PR (File B) is already merged — it is a **no-op** on the current pre-#1089 pinned image.
+2. Merge `datadog-agent-buildimages` PR (File A) → new image tag published.
+3. In `datadog-agent`: bump `prebuild-devcontainer.json` to new tag → regenerate composite →
+   update `devcontainer.json` digest.
+
+**Never bump the image tag before File B is merged.** See
+`.claude/plans/workspace-s2-group-ownership.md` for the full ordering invariant and acceptance
+gate (orchestrator provision must complete green before adoption step 3).
+
+## Scope
+
+Fixes P1 (collision) only. Does not address P2 (base feature installing its managed tools onto the
+buildimage — a separate stewardship question). See `workspace-solution-options.md` for the full
+solution comparison including the S4 split-feature path (P2-complete but higher cost).

--- a/.devcontainer/datadog/default/features/datadog-agent/devcontainer-feature.json
+++ b/.devcontainer/datadog/default/features/datadog-agent/devcontainer-feature.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "name": "Datadog Agent Development Environment",
     "description": "Configures the Datadog Agent development environment for the bits user, cleaning the base image for it to work in workspaces.",
-    "installsAfter": ["registry.ddbuild.io/workspaces/features/base"],
+    "installsAfter": ["registry.ddbuild.io/workspaces/features/base-compat"],
     "postCreateCommand": {
         "datadog-agent": "/opt/doghome/devcontainer/features/datadog-agent/lifecycle/postCreate.sh"
     }

--- a/.devcontainer/datadog/default/features/datadog-agent/install.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/install.sh
@@ -5,8 +5,17 @@ featureDir=$(cd "$(dirname "$0")"; pwd)
 # Get claude from the buildimages /root/.local/bin
 cp /root/.local/bin/claude /home/bits/.local/bin/claude
 
-# Add bits user to the docker group. This should probably be handled by the base feature. But not working for now.
-usermod -aG docker bits
+# Add bits to docker and build-shared groups. Both groups are buildimage-specific
+# (created in linux/Dockerfile) and absent on stock workspace images; the getent
+# guard makes this a clean no-op on stock bases. Runs after `installsAfter: base`
+# ensures bits exists before this feature runs.
+# build-shared (GID 9001): grants write access to group-owned toolchain trees
+#   (RVM at /opt/dd/rvm, rustup at /opt/dd/rustup, go cache at /var/config/dd/go,
+#    conda at /opt/dd/conda). All owned root:build-shared with setgid dirs.
+#   The base feature creates bits with primary group `dog` only; without this
+#   line bits cannot write into any toolchain cache.
+getent group docker >/dev/null && usermod -aG docker bits
+getent group build-shared >/dev/null && usermod -aG build-shared bits
 
 # Copy lifecycle scripts into the image
 install -d /opt/doghome/devcontainer/features/datadog-agent/lifecycle

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,7 +1,7 @@
 {
-    // Trigger build: 2026-05-04 10:25
+    // Trigger build: 2026-06-03 (S2: adopt post-#1089 image, bits no longer pre-baked)
     "name": "Datadog Agent Development Container",
-    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace:v110159745-8628883e",
+    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace:v116490909-fc35a1a5",
     "features": {
         "registry.ddbuild.io/workspaces/features/base:0.4.100410934": {},
         "./features/datadog-agent": {}

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,9 +1,9 @@
 {
-    // Trigger build: 2026-06-03 (S2: adopt post-#1089 image, bits no longer pre-baked)
+    // Trigger build: 2026-06-03 (S4 Phase 2: switch to base-compat feature)
     "name": "Datadog Agent Development Container",
     "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace:v116490909-fc35a1a5",
     "features": {
-        "registry.ddbuild.io/workspaces/features/base:0.4.100410934": {},
+        "registry.ddbuild.io/workspaces/features/base-compat:0.1.<BUILD_ID>": {},
         "./features/datadog-agent": {}
     },
     "forwardPorts": [22],


### PR DESCRIPTION
## Summary

Phase 2 of the S4 workspace plan: switch the agent's workspace prebuild from `workspaces/features/base` to `workspaces/features/base-compat`.

`base-compat` is a new minimal devcontainer feature (in `dd-source`) that installs only the provisioner contract — `adduser.sh`, `setup_ide_backends.sh`, `install_dotfiles.sh`, lifecycle hooks — without creating users or running apt. This means the `base` feature no longer mutates the managed buildimage with its own tool versions.

**Depends on S2 merging first** (this branch builds on `nick/workspace-s2-drop-bits-prebake`). The only unique commit in this PR is the `base-compat` switch.

## Changes

- `prebuild-devcontainer.json`: `workspaces/features/base:0.4.x` → `workspaces/features/base-compat:0.1.<BUILD_ID>` _(replace `<BUILD_ID>` after `dd-source` PR publishes)_
- `devcontainer-feature.json`: `installsAfter` updated to `base-compat`

## Related PRs

- **S2 (prerequisite, this repo)**: https://github.com/DataDog/datadog-agent/pull/51753
- **`dd-source` (platform)**: https://github.com/DataDog/dd-source/pull/458460 — implements `base-compat` feature and `useradd` guard
- **`datadog-agent-buildimages`**: https://github.com/DataDog/datadog-agent-buildimages/pull/1187

## Known blocker

`base-compat` requires the platform build verifier (`devcontainer.go:66-105`) to accept the `base-compat` feature ID, or the image to carry the `dog.infra.workspace.base-image` label. Needs platform team sign-off before this can go to production. See `dd-source` PR for details.

## Test plan

- [ ] `bazel build //domains/devcontainers/features/base-compat` + `tar tf` — confirm 3 sbin scripts at correct paths
- [ ] `base-compat` precondition check: fails fast on image without `bits` user
- [ ] DinD smoke test: `docker ps` works inside workspace (validates `dependsOn`)
- [ ] Full E2E: provision workspace, `dda inv install-tools` + `dda inv agent.build` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)