### PR TITLE
installer: enable process_config toggles via env vars in default script

### DIFF
--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -121,7 +121,25 @@ type DatadogConfigDJM struct {
 
 // DatadogConfigProcessConfig represents the configuration for the process agent
 type DatadogConfigProcessConfig struct {
-	ExpvarPort int `yaml:"expvar_port,omitempty"`
+	ExpvarPort          int                            `yaml:"expvar_port,omitempty"`
+	ProcessCollection   DatadogConfigProcessCollection `yaml:"process_collection,omitempty"`
+	ContainerCollection DatadogConfigProcessContainer  `yaml:"container_collection,omitempty"`
+	ProcessDiscovery    DatadogConfigProcessDiscovery  `yaml:"process_discovery,omitempty"`
+}
+
+// DatadogConfigProcessCollection represents the configuration for live process collection
+type DatadogConfigProcessCollection struct {
+	Enabled *bool `yaml:"enabled,omitempty"`
+}
+
+// DatadogConfigProcessContainer represents the configuration for container collection
+type DatadogConfigProcessContainer struct {
+	Enabled *bool `yaml:"enabled,omitempty"`
+}
+
+// DatadogConfigProcessDiscovery represents the configuration for process discovery
+type DatadogConfigProcessDiscovery struct {
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // DatadogConfigInstaller represents the configuration for the installer

--- a/pkg/fleet/installer/setup/config/config_test.go
+++ b/pkg/fleet/installer/setup/config/config_test.go
@@ -92,6 +92,36 @@ env: "old_env"
 	}, datadog)
 }
 
+// Tests that writing a process_config toggle merges into an existing
+// process_config block rather than clobbering its other keys.
+func TestMergeProcessConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	oldConfig := `---
+api_key: "0987654321"
+process_config:
+  expvar_port: 6063
+  container_collection:
+    enabled: false
+`
+	writeInitialDatadogConfig(t, tempDir, oldConfig)
+	config := Config{}
+	config.DatadogYAML.APIKey = "0987654321" // Required field
+	config.DatadogYAML.ProcessConfig.ProcessCollection.Enabled = BoolToPtr(true)
+
+	err := WriteConfigs(config, tempDir)
+	assert.NoError(t, err)
+
+	datadog := readDatadogYAML(t, tempDir)
+	assert.Equal(t, map[string]interface{}{
+		"api_key": "0987654321",
+		"process_config": map[string]interface{}{
+			"expvar_port":          6063,                                      // pre-existing key preserved
+			"container_collection": map[string]interface{}{"enabled": false}, // pre-existing subkey preserved
+			"process_collection":   map[string]interface{}{"enabled": true},  // newly added
+		},
+	}, datadog)
+}
+
 // Tests that existing API key is not overwritten if not provided again to setup command
 func TestKeepExistingAPIKey(t *testing.T) {
 	tempDir := t.TempDir()

--- a/pkg/fleet/installer/setup/config/config_test.go
+++ b/pkg/fleet/installer/setup/config/config_test.go
@@ -676,3 +676,50 @@ infrastructure_mode: "full"
 		"infrastructure_mode": "end_user_device",
 	}, datadog)
 }
+
+func TestProcessConfigMarshal(t *testing.T) {
+	// With each toggle set, the nested process_config keys are emitted with the
+	// expected boolean values.
+	cfg := DatadogConfig{
+		ProcessConfig: DatadogConfigProcessConfig{
+			ProcessCollection:   DatadogConfigProcessCollection{Enabled: BoolToPtr(true)},
+			ContainerCollection: DatadogConfigProcessContainer{Enabled: BoolToPtr(false)},
+			ProcessDiscovery:    DatadogConfigProcessDiscovery{Enabled: BoolToPtr(true)},
+		},
+	}
+	out, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	var got map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(out, &got))
+	assert.Equal(t, map[string]interface{}{
+		"process_config": map[string]interface{}{
+			"process_collection":   map[string]interface{}{"enabled": true},
+			"container_collection": map[string]interface{}{"enabled": false},
+			"process_discovery":    map[string]interface{}{"enabled": true},
+		},
+	}, got)
+
+	// A single toggle set emits only that nested key, leaving the others omitted.
+	single := DatadogConfig{
+		ProcessConfig: DatadogConfigProcessConfig{
+			ProcessCollection: DatadogConfigProcessCollection{Enabled: BoolToPtr(true)},
+		},
+	}
+	out, err = yaml.Marshal(single)
+	require.NoError(t, err)
+	got = nil
+	require.NoError(t, yaml.Unmarshal(out, &got))
+	assert.Equal(t, map[string]interface{}{
+		"process_config": map[string]interface{}{
+			"process_collection": map[string]interface{}{"enabled": true},
+		},
+	}, got)
+
+	// An empty DatadogConfig must not emit a process_config block (omitempty on
+	// the value sub-structs keeps unset toggles out of the written file).
+	out, err = yaml.Marshal(DatadogConfig{})
+	require.NoError(t, err)
+	got = nil
+	require.NoError(t, yaml.Unmarshal(out, &got))
+	assert.Empty(t, got)
+}

--- a/pkg/fleet/installer/setup/config/config_test.go
+++ b/pkg/fleet/installer/setup/config/config_test.go
@@ -115,7 +115,7 @@ process_config:
 	assert.Equal(t, map[string]interface{}{
 		"api_key": "0987654321",
 		"process_config": map[string]interface{}{
-			"expvar_port":          6063,                                      // pre-existing key preserved
+			"expvar_port":          6063,                                     // pre-existing key preserved
 			"container_collection": map[string]interface{}{"enabled": false}, // pre-existing subkey preserved
 			"process_collection":   map[string]interface{}{"enabled": true},  // newly added
 		},

--- a/pkg/fleet/installer/setup/defaultscript/BUILD.bazel
+++ b/pkg/fleet/installer/setup/defaultscript/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "defaultscript",
@@ -13,5 +13,18 @@ go_library(
         "//pkg/fleet/installer/setup/common",
         "//pkg/fleet/installer/setup/config",
         "//pkg/version",
+    ],
+)
+
+go_test(
+    name = "defaultscript_test",
+    srcs = ["default_script_test.go"],
+    embed = [":defaultscript"],
+    gotags = ["test"],
+    deps = [
+        "//pkg/fleet/installer/setup/common",
+        "//pkg/fleet/installer/setup/config",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/fleet/installer/setup/defaultscript/default_script.go
+++ b/pkg/fleet/installer/setup/defaultscript/default_script.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
@@ -98,7 +99,9 @@ func SetupDefaultScript(s *common.Setup) error {
 	// Config management
 	setConfigTags(s)
 	setConfigSecurityProducts(s)
-	setConfigProcessAgent(s)
+	if err := setConfigProcessAgent(s); err != nil {
+		return err
+	}
 
 	if url, ok := os.LookupEnv("DD_URL"); ok {
 		s.Config.DatadogYAML.DDURL = url
@@ -161,18 +164,36 @@ func setConfigSecurityProducts(s *common.Setup) {
 // setConfigProcessAgent sets the process_config collection toggles from environment variables.
 // Each toggle honors both the canonical DD_PROCESS_CONFIG_* name and the historical
 // DD_PROCESS_AGENT_* alias the agent itself accepts (see pkg/config/setup/process.go).
-// Values are parsed as explicit true/false (not presence-only) because container_collection
+// Values are parsed as explicit booleans (not presence-only) because container_collection
 // and process_discovery default to true at runtime, so a presence-only var could not disable them.
-func setConfigProcessAgent(s *common.Setup) {
-	if val, ok := lookupEnvAny("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", "DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED"); ok {
-		s.Config.DatadogYAML.ProcessConfig.ProcessCollection.Enabled = config.BoolToPtr(strings.ToLower(val) == "true")
+func setConfigProcessAgent(s *common.Setup) error {
+	var err error
+	if s.Config.DatadogYAML.ProcessConfig.ProcessCollection.Enabled, err = processToggle("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", "DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED"); err != nil {
+		return err
 	}
-	if val, ok := lookupEnvAny("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", "DD_PROCESS_AGENT_CONTAINER_COLLECTION_ENABLED"); ok {
-		s.Config.DatadogYAML.ProcessConfig.ContainerCollection.Enabled = config.BoolToPtr(strings.ToLower(val) == "true")
+	if s.Config.DatadogYAML.ProcessConfig.ContainerCollection.Enabled, err = processToggle("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", "DD_PROCESS_AGENT_CONTAINER_COLLECTION_ENABLED"); err != nil {
+		return err
 	}
-	if val, ok := lookupEnvAny("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", "DD_PROCESS_AGENT_PROCESS_DISCOVERY_ENABLED"); ok {
-		s.Config.DatadogYAML.ProcessConfig.ProcessDiscovery.Enabled = config.BoolToPtr(strings.ToLower(val) == "true")
+	if s.Config.DatadogYAML.ProcessConfig.ProcessDiscovery.Enabled, err = processToggle("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", "DD_PROCESS_AGENT_PROCESS_DISCOVERY_ENABLED"); err != nil {
+		return err
 	}
+	return nil
+}
+
+// processToggle reads the first set environment variable in names and coerces it to a
+// boolean using strconv.ParseBool, so the same truthy/falsy values the agent accepts
+// (e.g. "1"/"0", "true"/"false") are honored. It returns nil when none are set, and an
+// error when the value is not a valid boolean rather than silently treating it as false.
+func processToggle(names ...string) (*bool, error) {
+	val, ok := lookupEnvAny(names...)
+	if !ok {
+		return nil, nil
+	}
+	enabled, err := strconv.ParseBool(val)
+	if err != nil {
+		return nil, fmt.Errorf("invalid boolean value %q for %s: %w", val, names[0], err)
+	}
+	return config.BoolToPtr(enabled), nil
 }
 
 // lookupEnvAny returns the value of the first environment variable in names that is set.

--- a/pkg/fleet/installer/setup/defaultscript/default_script.go
+++ b/pkg/fleet/installer/setup/defaultscript/default_script.go
@@ -74,6 +74,12 @@ var (
 		"DD_LOGS_ENABLED",
 		"DD_PRIVATE_ACTION_RUNNER_ENABLED",
 		"DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST",
+		"DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED",
+		"DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED",
+		"DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED",
+		"DD_PROCESS_AGENT_CONTAINER_COLLECTION_ENABLED",
+		"DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED",
+		"DD_PROCESS_AGENT_PROCESS_DISCOVERY_ENABLED",
 	}
 )
 
@@ -92,6 +98,7 @@ func SetupDefaultScript(s *common.Setup) error {
 	// Config management
 	setConfigTags(s)
 	setConfigSecurityProducts(s)
+	setConfigProcessAgent(s)
 
 	if url, ok := os.LookupEnv("DD_URL"); ok {
 		s.Config.DatadogYAML.DDURL = url
@@ -149,6 +156,34 @@ func setConfigSecurityProducts(s *common.Setup) {
 		s.Config.SystemProbeYAML.RuntimeSecurityConfig.SBOM.Enabled = config.BoolToPtr(true)
 		s.Config.SystemProbeYAML.RuntimeSecurityConfig.SBOM.Host.Enabled = config.BoolToPtr(true)
 	}
+}
+
+// setConfigProcessAgent sets the process_config collection toggles from environment variables.
+// Each toggle honors both the canonical DD_PROCESS_CONFIG_* name and the historical
+// DD_PROCESS_AGENT_* alias the agent itself accepts (see pkg/config/setup/process.go).
+// Values are parsed as explicit true/false (not presence-only) because container_collection
+// and process_discovery default to true at runtime, so a presence-only var could not disable them.
+func setConfigProcessAgent(s *common.Setup) {
+	if val, ok := lookupEnvAny("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", "DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED"); ok {
+		s.Config.DatadogYAML.ProcessConfig.ProcessCollection.Enabled = config.BoolToPtr(strings.ToLower(val) == "true")
+	}
+	if val, ok := lookupEnvAny("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", "DD_PROCESS_AGENT_CONTAINER_COLLECTION_ENABLED"); ok {
+		s.Config.DatadogYAML.ProcessConfig.ContainerCollection.Enabled = config.BoolToPtr(strings.ToLower(val) == "true")
+	}
+	if val, ok := lookupEnvAny("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", "DD_PROCESS_AGENT_PROCESS_DISCOVERY_ENABLED"); ok {
+		s.Config.DatadogYAML.ProcessConfig.ProcessDiscovery.Enabled = config.BoolToPtr(strings.ToLower(val) == "true")
+	}
+}
+
+// lookupEnvAny returns the value of the first environment variable in names that is set.
+// The canonical name should be listed first so it wins when multiple aliases are set.
+func lookupEnvAny(names ...string) (string, bool) {
+	for _, name := range names {
+		if val, ok := os.LookupEnv(name); ok {
+			return val, true
+		}
+	}
+	return "", false
 }
 
 // setConfigInstallerDaemon sets the daemon in the configuration

--- a/pkg/fleet/installer/setup/defaultscript/default_script_test.go
+++ b/pkg/fleet/installer/setup/defaultscript/default_script_test.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package defaultscript
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/common"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/config"
+)
+
+func TestSetConfigProcessAgent(t *testing.T) {
+	tests := []struct {
+		name                string
+		env                 map[string]string
+		processCollection   *bool
+		containerCollection *bool
+		processDiscovery    *bool
+	}{
+		{
+			name: "unset leaves all nil",
+			env:  map[string]string{},
+		},
+		{
+			name:              "process collection enabled",
+			env:               map[string]string{"DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED": "true"},
+			processCollection: config.BoolToPtr(true),
+		},
+		{
+			name:              "process collection explicitly disabled",
+			env:               map[string]string{"DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED": "false"},
+			processCollection: config.BoolToPtr(false),
+		},
+		{
+			name:                "container collection via process_agent alias",
+			env:                 map[string]string{"DD_PROCESS_AGENT_CONTAINER_COLLECTION_ENABLED": "true"},
+			containerCollection: config.BoolToPtr(true),
+		},
+		{
+			name:             "process discovery disabled",
+			env:              map[string]string{"DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED": "false"},
+			processDiscovery: config.BoolToPtr(false),
+		},
+		{
+			name: "canonical name wins over alias",
+			env: map[string]string{
+				"DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED": "true",
+				"DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED":  "false",
+			},
+			processCollection: config.BoolToPtr(true),
+		},
+		{
+			name: "all three set",
+			env: map[string]string{
+				"DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED":   "true",
+				"DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED": "false",
+				"DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED":    "false",
+			},
+			processCollection:   config.BoolToPtr(true),
+			containerCollection: config.BoolToPtr(false),
+			processDiscovery:    config.BoolToPtr(false),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			s := &common.Setup{}
+			setConfigProcessAgent(s)
+
+			pc := s.Config.DatadogYAML.ProcessConfig
+			assert.Equal(t, tc.processCollection, pc.ProcessCollection.Enabled, "process_collection.enabled")
+			assert.Equal(t, tc.containerCollection, pc.ContainerCollection.Enabled, "container_collection.enabled")
+			assert.Equal(t, tc.processDiscovery, pc.ProcessDiscovery.Enabled, "process_discovery.enabled")
+		})
+	}
+}

--- a/pkg/fleet/installer/setup/defaultscript/default_script_test.go
+++ b/pkg/fleet/installer/setup/defaultscript/default_script_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/common"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/config"
@@ -21,6 +22,7 @@ func TestSetConfigProcessAgent(t *testing.T) {
 		processCollection   *bool
 		containerCollection *bool
 		processDiscovery    *bool
+		expectErr           bool
 	}{
 		{
 			name: "unset leaves all nil",
@@ -32,9 +34,24 @@ func TestSetConfigProcessAgent(t *testing.T) {
 			processCollection: config.BoolToPtr(true),
 		},
 		{
+			name:              "process collection enabled with 1",
+			env:               map[string]string{"DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED": "1"},
+			processCollection: config.BoolToPtr(true),
+		},
+		{
+			name:              "process collection disabled with 0",
+			env:               map[string]string{"DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED": "0"},
+			processCollection: config.BoolToPtr(false),
+		},
+		{
 			name:              "process collection explicitly disabled",
 			env:               map[string]string{"DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED": "false"},
 			processCollection: config.BoolToPtr(false),
+		},
+		{
+			name:      "invalid boolean value is rejected",
+			env:       map[string]string{"DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED": "yes"},
+			expectErr: true,
 		},
 		{
 			name:                "container collection via process_agent alias",
@@ -74,7 +91,12 @@ func TestSetConfigProcessAgent(t *testing.T) {
 			}
 
 			s := &common.Setup{}
-			setConfigProcessAgent(s)
+			err := setConfigProcessAgent(s)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 
 			pc := s.Config.DatadogYAML.ProcessConfig
 			assert.Equal(t, tc.processCollection, pc.ProcessCollection.Enabled, "process_collection.enabled")

--- a/releasenotes/notes/installer-process-collection-env-vars-3f9a1c7b2e4d6a08.yaml
+++ b/releasenotes/notes/installer-process-collection-env-vars-3f9a1c7b2e4d6a08.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    Installer: The default install script now honors the
+    ``DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED``,
+    ``DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED``, and
+    ``DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED`` environment variables
+    (and their ``DD_PROCESS_AGENT_*`` aliases) to set the corresponding
+    ``process_config`` collection toggles in ``datadog.yaml`` at install time


### PR DESCRIPTION
### What does this PR do?

Adds three `process_config` env vars to the fleet installer default script, on Linux and Windows:

| Env var (canonical + alias) | Config key written |
|---|---|
| `DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED` / `DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED` | `process_config.process_collection.enabled` |
| `DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED` / `DD_PROCESS_AGENT_CONTAINER_COLLECTION_ENABLED` | `process_config.container_collection.enabled` |
| `DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED` / `DD_PROCESS_AGENT_PROCESS_DISCOVERY_ENABLED` | `process_config.process_discovery.enabled` |

Values are parsed as explicit `true`/`false` (the latter two default to `true` at runtime, so presence-only wouldn't allow disabling). Unset vars write nothing.

### Motivation

There was no way to set live process collection (or the related toggles) at install time; users had to edit `datadog.yaml` and restart. The names reuse the agent's existing `DD_PROCESS_CONFIG_*` / `DD_PROCESS_AGENT_*` aliases.

### Describe how you validated your changes

- Added `TestSetConfigProcessAgent` (env → config: true/false/alias/precedence/unset), `TestProcessConfigMarshal` (YAML values; unset emits no block), and `TestMergeProcessConfig` (new toggle merges into an existing `process_config` block without clobbering `expvar_port`).
- Ran the built `installer.exe` on a Windows VM with `DD_NO_AGENT_INSTALL=1`; confirmed the toggles (including an explicit `false` and an `_AGENT_` alias) landed in `datadog.yaml`, and that an unset run wrote no block.
