### PR TITLE
[WP] Use best effort for mount hook points

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -346,7 +346,7 @@ int hook_make_visible(ctx_t *ctx) {
     }
 
     struct mount *newmnt = (struct mount *)CTX_PARM1(ctx);
-    // check if this mount has already been processed
+    // check if this mount has already been processed by another hook
     if (syscall->mount.newmnt == newmnt) {
         return 0;
     }
@@ -370,7 +370,7 @@ int hook_attach_mnt(ctx_t *ctx) {
     }
 
     struct mount *newmnt = (struct mount *)CTX_PARM1(ctx);
-    // check if this mount has already been processed
+        // check if this mount has already been processed by another hook
     if (syscall->mount.newmnt == newmnt) {
         return 0;
     }
@@ -394,7 +394,7 @@ int hook___attach_mnt(ctx_t *ctx) {
     }
 
     struct mount *newmnt = (struct mount *)CTX_PARM1(ctx);
-    // check if this mount has already been processed by the hook on attach_mnt
+        // check if this mount has already been processed by another hook
     if (syscall->mount.newmnt == newmnt) {
         return 0;
     }
@@ -417,7 +417,7 @@ int hook_mnt_set_mountpoint(ctx_t *ctx) {
     }
 
     struct mount *newmnt = (struct mount *)CTX_PARM3(ctx);
-    // check if this mount has already been processed
+        // check if this mount has already been processed by another hook
     if (syscall->mount.newmnt == newmnt) {
         return 0;
     }
@@ -484,7 +484,7 @@ int hook_attach_recursive_mnt(ctx_t *ctx) {
     }
 
     struct mount *newmnt = (struct mount *)CTX_PARM1(ctx);
-    // check if this mount has already been processed
+        // check if this mount has already been processed by another hook
     if (syscall->mount.newmnt == newmnt) {
         return 0;
     }
@@ -510,7 +510,7 @@ int hook_propagate_mnt(ctx_t *ctx) {
     }
 
     struct mount *newmnt = (struct mount *)CTX_PARM3(ctx);
-    // check if this mount has already been processed
+        // check if this mount has already been processed by another hook
     if (syscall->mount.newmnt == newmnt) {
         return 0;
     }

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -248,14 +248,28 @@ func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.Eve
 			}},
 
 			// Mount probes
-			&manager.AllOf{Selectors: []manager.ProbesSelector{
+			// The following functions may be inlined, partially inlined, or rewritten as ISRA clones.
+			// A OneOf selector is insufficient here, as some symbols may still be present even when the
+			// corresponding code has effectively been inlined, making the hook point ineffective.
+			// Therefore, we use a best-effort selector to ensure that mount operations
+			// are captured regardless of which hook point is used.
+			// Event deduplication is handled in the C code to prevent the same mount operation from being
+			// processed multiple times.
+			&manager.BestEffort{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_attach_recursive_mnt"),
 				hookFunc("hook_propagate_mnt"),
+				hookFunc("hook_attach_mnt"),
+				hookFunc("hook___attach_mnt"),
+				hookFunc("hook_make_visible"),
+				hookFunc("hook_mnt_set_mountpoint"),
+			}},
+			// The previous considerations do not apply to this mount hook point.
+			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_security_sb_umount"),
 				hookFunc("hook_clone_mnt"),
-				hookFunc("rethook_clone_mnt"),
 				hookFunc("hook_mnt_change_mountpoint"),
 				hookFunc("hook_cleanup_mnt"),
+				hookFunc("rethook_clone_mnt"),
 			}},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
 				hookFunc("rethook_alloc_vfsmnt"),
@@ -267,12 +281,6 @@ func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.Eve
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "umount", hasFentry, Exit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unshare", hasFentry, EntryAndExit)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "pivot_root", hasFentry, EntryAndExit)},
-			&manager.OneOf{Selectors: []manager.ProbesSelector{
-				hookFunc("hook_attach_mnt"),
-				hookFunc("hook___attach_mnt"),
-				hookFunc("hook_make_visible"),
-				hookFunc("hook_mnt_set_mountpoint"),
-			}},
 
 			// Rename probes
 			&manager.AllOf{Selectors: []manager.ProbesSelector{


### PR DESCRIPTION
### What does this PR do?
This PR switches the following mount-related hook points to a best-effort selection strategy: 
- hook_attach_recursive_mnt
- hook_propagate_mnt
- hook_attach_mnt
- hook___attach_mnt
- hook_make_visible
- hook_mnt_set_mountpoint 

### Motivation
On some kernels (for example attach_recursive_mnt on kernel >= 6.18), some functions may be inlined, partially inlined, or rewritten as ISRA clones. A OneOf selector is insufficient in this case: a symbol may still be present even though the corresponding code has effectively been inlined, making the hook point ineffective (the program attaches but is never triggered).

By using a BestEffort selector covering all the possible hook points, we ensure that mount operations are properly captured regardless of which hook point is actually available on the kernel, while relying on eBPF-side deduplication to avoid duplicates.

