### PR TITLE
e2e-framework: add v1.1.0 WorkloadAllowlist for datadog-csi-driver

### DIFF
--- a/test/e2e-framework/scenarios/gcp/gke/workloadcsiallowlist.yaml
+++ b/test/e2e-framework/scenarios/gcp/gke/workloadcsiallowlist.yaml
@@ -61,3 +61,73 @@ matchingCriteria:
     - hostPath:
         path: /var/run/datadog
       name: dsd-socket
+---
+apiVersion: auto.gke.io/v1
+kind: WorkloadAllowlist
+metadata:
+  annotations:
+    autopilot.gke.io/no-connect: "true"
+  name: datadog-datadog-csi-driver-daemonset-exemption-v1.1.0
+exemptions:
+  - autogke-no-write-mode-hostpath
+  - autogke-no-host-port
+  - autogke-default-linux-capabilities
+  - autogke-disallow-privilege
+matchingCriteria:
+  containers:
+    - env:
+        - name: NODE_ID
+        - name: DD_APM_ENABLED
+      envFrom:
+        - secretRef:
+            name: ^datadog-.*
+      image: ^(eu\.|asia\.)?gcr\.io\/datadoghq\/csi-driver(:[0-9]+\.[0-9]+\.[0-9]+)?$
+      name: csi-node-driver
+      securityContext:
+        privileged: true # privileged security context is needed to perform volume mounts on other pods.
+      args:
+        - --apm-host-socket-path=/var/run/datadog/apm.socket
+        - --dsd-host-socket-path=/var/run/datadog/dsd.socket
+      volumeMounts:
+        - name: plugin-dir # stores the socket on which CSI node server service is exposed. It is created by the node server and needs to be writeable.
+          mountPath: /csi
+        - name: storage-dir # stores the data and database for the CSI driver.
+          mountPath: /var/lib/datadog-csi-driver
+        - name: apm-socket
+          mountPath: /var/run/datadog
+          readOnly: true
+        - mountPath: /var/lib/kubelet/pods # write mode is required to perform a volume mount. csi driver has to create a subdirectory under /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~csi/datadog/mount.
+          name: mountpoint-dir
+    - name: csi-node-driver-registrar
+      image: ^k8s\.gcr\.io/sig-storage/csi-node-driver-registrar(:[0-9]+\.[0-9]+\.[0-9]+)?$
+      args:
+        - "--csi-address=$(ADDRESS)"
+        - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+      env:
+        - name: ADDRESS
+        - name: DRIVER_REG_SOCK_PATH
+      volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+          readOnly: true
+        - name: registration-dir
+          mountPath: /registration # registration-dir needs to be writeable to store the registration information and register the driver with kubelet.
+  volumes:
+    - name: plugin-dir
+      hostPath:
+        path: /var/lib/kubelet/plugins/datadog.csi/driver
+    - name: storage-dir
+      hostPath:
+        path: /var/lib/kubelet/plugins/datadog.csi/storage
+    - name: registration-dir
+      hostPath:
+        path: /var/lib/kubelet/plugins_registry
+    - hostPath:
+        path: /var/lib/kubelet/pods
+      name: mountpoint-dir
+    - hostPath:
+        path: /var/run/datadog
+      name: apm-socket
+    - hostPath:
+        path: /var/run/datadog
+      name: dsd-socket


### PR DESCRIPTION
### What does this PR do?

Adds the `datadog-datadog-csi-driver-daemonset-exemption-v1.1.0` `WorkloadAllowlist` as a second YAML document in `test/e2e-framework/scenarios/gcp/gke/workloadcsiallowlist.yaml`, alongside the existing `v1.0.1` document.

### Motivation

The `datadog-csi-driver` Helm chart bumped its embedded `WorkloadAllowlist` from `v1.0.1` to `v1.1.0` (new `storage-dir` host volume + tightened image/env regexes) and its pre-install `AllowlistSynchronizer` hook now points at the `v1.1.0` manifest. On GKE Autopilot, this makes Warden reject the chart's DaemonSet on clusters that only have the older `v1.0.1` allowlist materialized — which is currently the case for the helm-charts e2e Autopilot job.

Shipping both documents in the fixture keeps test runs that still install the `v1.0.1`-era chart working while unblocking the newer ones.

### Describe how you validated your changes

- `yaml.safe_load_all` parses the file as 2 documents, both `kind: WorkloadAllowlist`.
- The added document is bit-for-bit identical to the manifest rendered by the latest `charts/datadog-csi-driver` Helm chart on GKE Autopilot.
- Will be exercised end-to-end by the helm-charts e2e GKE Autopilot CSI job once paired with [DataDog/helm-charts#<PR>](https://github.com/DataDog/helm-charts/pull/<TBD>).

### Additional Notes

Pure test fixture change — no production code path is affected.