### PR TITLE
e2e-framework: truncate GCP resource label values to 63 bytes

### DIFF
--- a/test/e2e-framework/resources/gcp/environment.go
+++ b/test/e2e-framework/resources/gcp/environment.go
@@ -22,6 +22,12 @@ const (
 	gcpConfigNamespace = "gcp"
 	gcpNamerNamespace  = "gcp"
 
+	// MaxResourceLabelValueLen is the maximum length allowed by GCP for a
+	// resource label value (in bytes). Values longer than this are rejected
+	// by the API with `Resource_labels.value must be less than 63 bytes`.
+	// See https://cloud.google.com/resource-manager/docs/labels-overview.
+	MaxResourceLabelValueLen = 63
+
 	// GCP Infra
 	DDInfraDefaultPublicKeyPath            = "gcp/defaultPublicKeyPath"
 	DDInfraDefaultPrivateKeyPath           = "gcp/defaultPrivateKeyPath"
@@ -69,7 +75,11 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 	defaultLabels := env.ResourcesTags()
 	defaultLabels = defaultLabels.ToStringMapOutput().ApplyT(func(labels map[string]string) map[string]string {
 		for k, v := range labels {
-			labels[k] = strings.ReplaceAll(strings.ToLower(v), ".", "-")
+			v = strings.ReplaceAll(strings.ToLower(v), ".", "-")
+			if len(v) > MaxResourceLabelValueLen {
+				v = v[:MaxResourceLabelValueLen]
+			}
+			labels[k] = v
 		}
 		return labels
 	}).(pulumi.StringMapOutput)

--- a/test/e2e-framework/resources/gcp/gke/cluster.go
+++ b/test/e2e-framework/resources/gcp/gke/cluster.go
@@ -30,7 +30,11 @@ func NewCluster(e gcp.Environment, name string, autopilot bool, opts ...pulumi.R
 	clusterLabels := e.ResourcesTags()
 	clusterLabels = clusterLabels.ToStringMapOutput().ApplyT(func(labels map[string]string) map[string]string {
 		for k, v := range labels {
-			labels[k] = strings.ReplaceAll(strings.ToLower(v), ".", "-")
+			v = strings.ReplaceAll(strings.ToLower(v), ".", "-")
+			if len(v) > gcp.MaxResourceLabelValueLen {
+				v = v[:gcp.MaxResourceLabelValueLen]
+			}
+			labels[k] = v
 		}
 
 		return labels


### PR DESCRIPTION
### What does this PR do?

Truncates the values of GCP resource labels computed in `test/e2e-framework` to 63 bytes (the GCP API limit), in both places where `e.ResourcesTags()` is materialised before being handed off to a Pulumi resource:

- `test/e2e-framework/resources/gcp/environment.go` — `DefaultLabels` passed to the GCP provider (applies to every GCP resource created through it).
- `test/e2e-framework/resources/gcp/gke/cluster.go` — `ResourceLabels` set explicitly on the GKE `container.Cluster` (which doesn't inherit `DefaultLabels`).

The maximum length is defined as a new exported `gcp.MaxResourceLabelValueLen = 63` constant, mirroring how `MaxGkeClusterNameLen` already caps the cluster name on the same code path.

### Motivation

GCP rejects resource label values longer than 63 bytes with `Resource_labels.value must be less than 63 bytes`. The `stack` label added by `DefaultResourceTags()` (in [#48951](https://github.com/DataDog/datadog-agent/pull/48951)) is set to `Ctx().Stack()`, which on CI takes the form `ci-${CI_PIPELINE_ID}-${CI_JOB_ID}-e2e-<TypeName>-<hash>` and overflows the limit for suites whose Go type name is on the longer side.

This currently breaks GKE Autopilot e2e jobs in `helm-charts` (e.g. `TestGKEAutopilotSystemProbeSuite` produces a 65-character stack name); the only short-term workaround on the consumer side is `e2e.WithStackName(...)`, which is fragile because every new long-named suite has to opt in. Truncating at the framework level fixes the issue once and for all and matches the GCP `labels-overview` spec.

### Describe how you validated your changes

- `cd test/e2e-framework && GOWORK=off go vet ./resources/gcp/... ./scenarios/gcp/...` passes.
- Visually inspected the diff to confirm the truncation happens after the existing lowercasing / dot-to-dash substitution, so the constraint of staying ≤ 63 bytes is enforced on the final value.
- Will be exercised end-to-end by re-running the `helm-charts` GKE Autopilot suites against this branch once the corresponding consumer PR drops its `WithStackName` override.

### Additional Notes

Reference: https://cloud.google.com/resource-manager/docs/labels-overview ("Maximum length: 63 bytes" for label values).

This is purely a test-infra change, no production code path is affected.