### PR TITLE
fix(apm-inject): gate systemd preload mode behind DD_APM_INSTRUMENTAT…

### DIFF
--- a/pkg/fleet/installer/env/env.go
+++ b/pkg/fleet/installer/env/env.go
@@ -54,26 +54,27 @@ const (
 	envFIPSMode = "DD_FIPS_MODE"
 
 	// install script
-	envApmInstrumentationEnabled   = "DD_APM_INSTRUMENTATION_ENABLED"
-	envRuntimeMetricsEnabled       = "DD_RUNTIME_METRICS_ENABLED"
-	envLogsInjection               = "DD_LOGS_INJECTION"
-	envAPMTracingEnabled           = "DD_APM_TRACING_ENABLED"
-	envProfilingEnabled            = "DD_PROFILING_ENABLED"
-	envDataStreamsEnabled          = "DD_DATA_STREAMS_ENABLED"
-	envAppsecEnabled               = "DD_APPSEC_ENABLED"
-	envIastEnabled                 = "DD_IAST_ENABLED"
-	envDataJobsEnabled             = "DD_DATA_JOBS_ENABLED"
-	envAppsecScaEnabled            = "DD_APPSEC_SCA_ENABLED"
-	envInfrastructureMode          = "DD_INFRASTRUCTURE_MODE"
-	envAppKey                      = "DD_APP_KEY"
-	envPAREnabled                  = "DD_PRIVATE_ACTION_RUNNER_ENABLED"
-	envPARActionsAllowlist         = "DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST"
-	envTracerLogsCollectionEnabled = "DD_APP_LOGS_COLLECTION_ENABLED"
-	envRumEnabled                  = "DD_RUM_ENABLED"
-	envRumApplicationID            = "DD_RUM_APPLICATION_ID"
-	envRumClientToken              = "DD_RUM_CLIENT_TOKEN"
-	envRumRemoteConfigurationID    = "DD_RUM_REMOTE_CONFIGURATION_ID"
-	envRumSite                     = "DD_RUM_SITE"
+	envApmInstrumentationEnabled     = "DD_APM_INSTRUMENTATION_ENABLED"
+	envAPMInstrumentationPreloadMode = "DD_APM_INSTRUMENTATION_PRELOAD_MODE"
+	envRuntimeMetricsEnabled         = "DD_RUNTIME_METRICS_ENABLED"
+	envLogsInjection                 = "DD_LOGS_INJECTION"
+	envAPMTracingEnabled             = "DD_APM_TRACING_ENABLED"
+	envProfilingEnabled              = "DD_PROFILING_ENABLED"
+	envDataStreamsEnabled            = "DD_DATA_STREAMS_ENABLED"
+	envAppsecEnabled                 = "DD_APPSEC_ENABLED"
+	envIastEnabled                   = "DD_IAST_ENABLED"
+	envDataJobsEnabled               = "DD_DATA_JOBS_ENABLED"
+	envAppsecScaEnabled              = "DD_APPSEC_SCA_ENABLED"
+	envInfrastructureMode            = "DD_INFRASTRUCTURE_MODE"
+	envAppKey                        = "DD_APP_KEY"
+	envPAREnabled                    = "DD_PRIVATE_ACTION_RUNNER_ENABLED"
+	envPARActionsAllowlist           = "DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST"
+	envTracerLogsCollectionEnabled   = "DD_APP_LOGS_COLLECTION_ENABLED"
+	envRumEnabled                    = "DD_RUM_ENABLED"
+	envRumApplicationID              = "DD_RUM_APPLICATION_ID"
+	envRumClientToken                = "DD_RUM_CLIENT_TOKEN"
+	envRumRemoteConfigurationID      = "DD_RUM_REMOTE_CONFIGURATION_ID"
+	envRumSite                       = "DD_RUM_SITE"
 )
 
 // Windows MSI options
@@ -109,21 +110,22 @@ var defaultEnv = Env{
 	DefaultPackagesVersionOverride: map[string]string{},
 
 	InstallScript: InstallScriptEnv{
-		APMInstrumentationEnabled: "",
-		RuntimeMetricsEnabled:     nil,
-		LogsInjection:             nil,
-		APMTracingEnabled:         nil,
-		ProfilingEnabled:          "",
-		DataStreamsEnabled:        nil,
-		AppsecEnabled:             nil,
-		IastEnabled:               nil,
-		DataJobsEnabled:           nil,
-		AppsecScaEnabled:          nil,
-		RumEnabled:                nil,
-		RumApplicationID:          "",
-		RumClientToken:            "",
-		RumRemoteConfigurationID:  "",
-		RumSite:                   "",
+		APMInstrumentationEnabled:     "",
+		RuntimeMetricsEnabled:         nil,
+		LogsInjection:                 nil,
+		APMTracingEnabled:             nil,
+		ProfilingEnabled:              "",
+		DataStreamsEnabled:            nil,
+		AppsecEnabled:                 nil,
+		IastEnabled:                   nil,
+		DataJobsEnabled:               nil,
+		AppsecScaEnabled:              nil,
+		RumEnabled:                    nil,
+		RumApplicationID:              "",
+		RumClientToken:                "",
+		RumRemoteConfigurationID:      "",
+		RumSite:                       "",
+		APMInstrumentationPreloadMode: "",
 	},
 }
 
@@ -144,6 +146,9 @@ const (
 	APMInstrumentationEnabledIIS = "iis"
 	// APMInstrumentationNotSet is the default value when the environment variable is not set.
 	APMInstrumentationNotSet = "not_set"
+
+	// APMInstrumentationPreloadModeSystemd enables the systemd-based ld.so.preload management for host injection.
+	APMInstrumentationPreloadModeSystemd = "systemd"
 )
 
 // MsiParamsEnv contains the environment variables for options that are passed to the MSI.
@@ -180,6 +185,11 @@ type InstallScriptEnv struct {
 	RumClientToken           string
 	RumRemoteConfigurationID string
 	RumSite                  string
+
+	// APMInstrumentationPreloadMode controls the mechanism used for host injection.
+	// Set to APMInstrumentationPreloadModeSystemd to use systemd-managed ld.so.preload.
+	// When empty (default), the direct file-write approach is used.
+	APMInstrumentationPreloadMode string
 }
 
 // Env contains the configuration for the installer.
@@ -322,22 +332,23 @@ func FromEnv() *Env {
 		},
 
 		InstallScript: InstallScriptEnv{
-			APMInstrumentationEnabled:   getEnvOrDefault(envApmInstrumentationEnabled, APMInstrumentationNotSet),
-			RuntimeMetricsEnabled:       getBoolEnv(envRuntimeMetricsEnabled),
-			LogsInjection:               getBoolEnv(envLogsInjection),
-			APMTracingEnabled:           getBoolEnv(envAPMTracingEnabled),
-			ProfilingEnabled:            getEnvOrDefault(envProfilingEnabled, ""),
-			DataStreamsEnabled:          getBoolEnv(envDataStreamsEnabled),
-			AppsecEnabled:               getBoolEnv(envAppsecEnabled),
-			IastEnabled:                 getBoolEnv(envIastEnabled),
-			DataJobsEnabled:             getBoolEnv(envDataJobsEnabled),
-			AppsecScaEnabled:            getBoolEnv(envAppsecScaEnabled),
-			TracerLogsCollectionEnabled: getBoolEnv(envTracerLogsCollectionEnabled),
-			RumEnabled:                  getBoolEnv(envRumEnabled),
-			RumApplicationID:            getEnvOrDefault(envRumApplicationID, ""),
-			RumClientToken:              getEnvOrDefault(envRumClientToken, ""),
-			RumRemoteConfigurationID:    getEnvOrDefault(envRumRemoteConfigurationID, ""),
-			RumSite:                     getEnvOrDefault(envRumSite, ""),
+			APMInstrumentationEnabled:     getEnvOrDefault(envApmInstrumentationEnabled, APMInstrumentationNotSet),
+			RuntimeMetricsEnabled:         getBoolEnv(envRuntimeMetricsEnabled),
+			LogsInjection:                 getBoolEnv(envLogsInjection),
+			APMTracingEnabled:             getBoolEnv(envAPMTracingEnabled),
+			ProfilingEnabled:              getEnvOrDefault(envProfilingEnabled, ""),
+			DataStreamsEnabled:            getBoolEnv(envDataStreamsEnabled),
+			AppsecEnabled:                 getBoolEnv(envAppsecEnabled),
+			IastEnabled:                   getBoolEnv(envIastEnabled),
+			DataJobsEnabled:               getBoolEnv(envDataJobsEnabled),
+			AppsecScaEnabled:              getBoolEnv(envAppsecScaEnabled),
+			TracerLogsCollectionEnabled:   getBoolEnv(envTracerLogsCollectionEnabled),
+			RumEnabled:                    getBoolEnv(envRumEnabled),
+			RumApplicationID:              getEnvOrDefault(envRumApplicationID, ""),
+			RumClientToken:                getEnvOrDefault(envRumClientToken, ""),
+			RumRemoteConfigurationID:      getEnvOrDefault(envRumRemoteConfigurationID, ""),
+			RumSite:                       getEnvOrDefault(envRumSite, ""),
+			APMInstrumentationPreloadMode: getEnvOrDefault(envAPMInstrumentationPreloadMode, ""),
 		},
 
 		Tags: append(
@@ -393,6 +404,7 @@ func (e *InstallScriptEnv) ToEnv(env []string) []string {
 	env = appendStringEnv(env, envRumClientToken, e.RumClientToken, "")
 	env = appendStringEnv(env, envRumRemoteConfigurationID, e.RumRemoteConfigurationID, "")
 	env = appendStringEnv(env, envRumSite, e.RumSite, "")
+	env = appendStringEnv(env, envAPMInstrumentationPreloadMode, e.APMInstrumentationPreloadMode, "")
 	return env
 }
 

--- a/pkg/fleet/installer/packages/apminject/apm_inject.go
+++ b/pkg/fleet/installer/packages/apminject/apm_inject.go
@@ -150,26 +150,31 @@ func (a *InjectorInstaller) Instrument(ctx context.Context) (retErr error) {
 			return err
 		}
 		if systemdRunning {
-			// The service manages /etc/ld.so.preload via ExecStart/ExecStop on
-			// every boot. We also call InstrumentLDPreload directly here so the
-			// current boot is covered: if the service started successfully its
-			// ExecStart already wrote the entry and this becomes a no-op; if the
-			// service failed to start (non-fatal, e.g. during initial install
-			// before the agent is running), this writes the entry directly.
-			mgr := NewSystemdServiceManager()
-			if err := mgr.Setup(ctx); err != nil {
-				return err
+			if a.Env.InstallScript.APMInstrumentationPreloadMode == env.APMInstrumentationPreloadModeSystemd {
+				// The service manages /etc/ld.so.preload via ExecStart/ExecStop on
+				// every boot. We also call InstrumentLDPreload directly here so the
+				// current boot is covered: if the service started successfully its
+				// ExecStart already wrote the entry and this becomes a no-op; if the
+				// service failed to start (non-fatal, e.g. during initial install
+				// before the agent is running), this writes the entry directly.
+				mgr := NewSystemdServiceManager()
+				if err := mgr.Setup(ctx); err != nil {
+					return err
+				}
+				a.rollbacks = append(a.rollbacks, func() error {
+					return mgr.Uninstall(ctx)
+				})
+			} else {
+				// Explicit opt-out: remove any previously-installed service so that
+				// future boots use direct ld.so.preload management, not the service.
+				// Uninstall is idempotent when no service file is present.
+				if err := NewSystemdServiceManager().Uninstall(ctx); err != nil {
+					return err
+				}
 			}
-			a.rollbacks = append(a.rollbacks, func() error {
-				return mgr.Uninstall(ctx)
-			})
-			if err := a.InstrumentLDPreload(ctx); err != nil {
-				return err
-			}
-		} else {
-			if err := a.InstrumentLDPreload(ctx); err != nil {
-				return err
-			}
+		}
+		if err := a.InstrumentLDPreload(ctx); err != nil {
+			return err
 		}
 	}
 
@@ -203,18 +208,22 @@ func (a *InjectorInstaller) Uninstrument(ctx context.Context) error {
 	errs := []error{}
 
 	if shouldInstrumentHost(a.Env) {
+		// Always attempt to remove the systemd service when systemd is running.
+		// Uninstall is idempotent: if no service file is present it returns nil.
+		// This handles the case where the service was installed with
+		// DD_APM_INSTRUMENTATION_PRELOAD_MODE=systemd but uninstrument is called
+		// without that env var (e.g. plain `datadog-installer apm uninstrument host`).
 		systemdRunning, err := systemd.IsRunning()
 		if err != nil {
 			errs = append(errs, err)
 		} else if systemdRunning {
 			errs = append(errs, NewSystemdServiceManager().Uninstall(ctx))
-			// Safety net: explicitly remove the ld.so.preload entry even if the
-			// service's ExecStop did not run (e.g. service was in a failed state
-			// when stopped). UninstrumentLDPreload is pure file I/O and idempotent.
-			errs = append(errs, a.UninstrumentLDPreload(ctx))
-		} else {
-			errs = append(errs, a.UninstrumentLDPreload(ctx))
 		}
+		// Safety net: always remove the ld.so.preload entry directly.
+		// In systemd mode this covers the case where the service's ExecStop did not
+		// run (e.g. the service was in a failed state). In direct mode it is the
+		// sole removal path. UninstrumentLDPreload is idempotent.
+		errs = append(errs, a.UninstrumentLDPreload(ctx))
 	}
 
 	if shouldInstrumentDocker(a.Env) {

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -572,7 +572,7 @@ func (s *packageApmInjectSuite) TestSystemdService() {
 		s.T().Skip("systemd is not running as PID 1 on this host")
 	}
 
-	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=host", "DD_APM_INSTRUMENTATION_LIBRARIES=python")
+	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=host", "DD_APM_INSTRUMENTATION_LIBRARIES=python", "DD_APM_INSTRUMENTATION_PRELOAD_MODE=systemd")
 	defer s.Purge()
 
 	// After install: service is enabled (will start on next boot) and ld.so.preload is
@@ -676,7 +676,7 @@ func (s *packageApmInjectSuite) TestSystemdServiceStopBrokenInjector() {
 		s.T().Skip("systemd is not running as PID 1 on this host")
 	}
 
-	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=host", "DD_APM_INSTRUMENTATION_LIBRARIES=python")
+	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=host", "DD_APM_INSTRUMENTATION_LIBRARIES=python", "DD_APM_INSTRUMENTATION_PRELOAD_MODE=systemd")
 	defer s.Purge()
 
 	s.host.WaitForUnitActive(s.T(), "datadog-apm-inject.service")


### PR DESCRIPTION
…ION_PRELOAD_MODE

The systemd-managed ld.so.preload feature introduced in #49380 now requires DD_APM_INSTRUMENTATION_PRELOAD_MODE=systemd to activate. Without the variable the installer falls back to the direct file-write approach, preserving the previous default behavior.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
