### PR TITLE
fix(appsec/nginx): run injected init container as non-root UID

### DIFF
--- a/pkg/clusteragent/appsec/config/config.go
+++ b/pkg/clusteragent/appsec/config/config.go
@@ -107,6 +107,12 @@ type Nginx struct {
 	// ModuleMountPath is where the .so module is mounted in the controller container
 	// Default: "/modules_mount"
 	ModuleMountPath string
+	// InitRunAsUser/InitRunAsGroup set the init container's RunAsUser/RunAsGroup.
+	// The default init image declares no USER (runs as root) and would be rejected
+	// under RunAsNonRoot, so a non-root UID/GID must be supplied. A negative value
+	// leaves the field unset, honoring a custom InitImage's own USER.
+	InitRunAsUser  int64
+	InitRunAsGroup int64
 }
 
 func (p Processor) String() string {
@@ -252,6 +258,8 @@ func FromComponent(cfg config.Component, logger log.Component) Config {
 	nginxConfig := Nginx{
 		InitImage:       cfg.GetString("admission_controller.appsec.nginx.init_image"),
 		ModuleMountPath: cfg.GetString("admission_controller.appsec.nginx.module_mount_path"),
+		InitRunAsUser:   int64(cfg.GetInt("admission_controller.appsec.nginx.init_run_as_user")),
+		InitRunAsGroup:  int64(cfg.GetInt("admission_controller.appsec.nginx.init_run_as_group")),
 	}
 
 	staticLabels := map[string]string{

--- a/pkg/clusteragent/appsec/nginx/sidecar.go
+++ b/pkg/clusteragent/appsec/nginx/sidecar.go
@@ -54,17 +54,6 @@ const (
 	labelNameValue      = "ingress-nginx"
 	labelComponentKey   = "app.kubernetes.io/component"
 	labelComponentValue = "controller"
-
-	// initContainerRunAsUser/Group pin the init container to a non-root identity.
-	// The datadog/ingress-nginx-injection image declares no USER (defaults to
-	// root), so RunAsNonRoot alone makes the kubelet reject the container with
-	// "container has runAsNonRoot and image will run as root". An explicit
-	// non-root UID/GID is required. We reuse ingress-nginx's own well-known
-	// www-data identity (101:82) so the copied module file ownership matches the
-	// controller container that consumes it; the module is world-readable
-	// regardless, so this only needs to be any non-zero ID.
-	initContainerRunAsUser  int64 = 101
-	initContainerRunAsGroup int64 = 82
 )
 
 var _ appsecconfig.SidecarInjectionPattern = (*nginxSidecarPattern)(nil)
@@ -168,7 +157,7 @@ func (n *nginxSidecarPattern) MutatePod(pod *corev1.Pod, ns string, client dynam
 		},
 	})
 
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, buildInitContainer(initImageRef, moduleMountPath))
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, buildInitContainer(initImageRef, moduleMountPath, n.config.Nginx.InitRunAsUser, n.config.Nginx.InitRunAsGroup))
 
 	// Add volume mount to controller container
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
@@ -310,7 +299,27 @@ func imageIsFullyQualified(image string) bool {
 
 // buildInitContainer creates the init container spec that copies the nginx-datadog module.
 // image must be a fully-qualified image reference including the tag (e.g. "repo/image:tag").
-func buildInitContainer(image, moduleMountPath string) corev1.Container {
+//
+// runAsUser/runAsGroup set the container's non-root identity. The stock init
+// image declares no USER (runs as root), which the kubelet rejects under
+// RunAsNonRoot ("container has runAsNonRoot and image will run as root"), so a
+// non-root UID/GID is required for it. A negative value leaves the respective
+// field unset so a custom image's own USER is honored.
+func buildInitContainer(image, moduleMountPath string, runAsUser, runAsGroup int64) corev1.Container {
+	sc := &corev1.SecurityContext{
+		RunAsNonRoot:             ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+	if runAsUser >= 0 {
+		sc.RunAsUser = ptr.To(runAsUser)
+	}
+	if runAsGroup >= 0 {
+		sc.RunAsGroup = ptr.To(runAsGroup)
+	}
 	return corev1.Container{
 		Name:    initContainerName,
 		Image:   image,
@@ -321,15 +330,6 @@ func buildInitContainer(image, moduleMountPath string) corev1.Container {
 				MountPath: moduleMountPath,
 			},
 		},
-		SecurityContext: &corev1.SecurityContext{
-			RunAsNonRoot:             ptr.To(true),
-			RunAsUser:                ptr.To(initContainerRunAsUser),
-			RunAsGroup:               ptr.To(initContainerRunAsGroup),
-			AllowPrivilegeEscalation: ptr.To(false),
-			ReadOnlyRootFilesystem:   ptr.To(true),
-			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"ALL"},
-			},
-		},
+		SecurityContext: sc,
 	}
 }

--- a/pkg/clusteragent/appsec/nginx/sidecar.go
+++ b/pkg/clusteragent/appsec/nginx/sidecar.go
@@ -54,6 +54,17 @@ const (
 	labelNameValue      = "ingress-nginx"
 	labelComponentKey   = "app.kubernetes.io/component"
 	labelComponentValue = "controller"
+
+	// initContainerRunAsUser/Group pin the init container to a non-root identity.
+	// The datadog/ingress-nginx-injection image declares no USER (defaults to
+	// root), so RunAsNonRoot alone makes the kubelet reject the container with
+	// "container has runAsNonRoot and image will run as root". An explicit
+	// non-root UID/GID is required. We reuse ingress-nginx's own well-known
+	// www-data identity (101:82) so the copied module file ownership matches the
+	// controller container that consumes it; the module is world-readable
+	// regardless, so this only needs to be any non-zero ID.
+	initContainerRunAsUser  int64 = 101
+	initContainerRunAsGroup int64 = 82
 )
 
 var _ appsecconfig.SidecarInjectionPattern = (*nginxSidecarPattern)(nil)
@@ -312,6 +323,8 @@ func buildInitContainer(image, moduleMountPath string) corev1.Container {
 		},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsNonRoot:             ptr.To(true),
+			RunAsUser:                ptr.To(initContainerRunAsUser),
+			RunAsGroup:               ptr.To(initContainerRunAsGroup),
 			AllowPrivilegeEscalation: ptr.To(false),
 			ReadOnlyRootFilesystem:   ptr.To(true),
 			Capabilities: &corev1.Capabilities{

--- a/pkg/clusteragent/appsec/nginx/sidecar_test.go
+++ b/pkg/clusteragent/appsec/nginx/sidecar_test.go
@@ -187,6 +187,17 @@ func TestMutatePod(t *testing.T) {
 	assert.Equal(t, "datadog/ingress-nginx-injection:v1.15.1", ic.Image)
 	assert.Equal(t, []string{"/bin/sh", "/datadog/init_module.sh", "/modules_mount"}, ic.Command)
 
+	// The injection image runs as root, so RunAsNonRoot must be paired with an
+	// explicit non-root UID/GID or the kubelet rejects the container with
+	// "container has runAsNonRoot and image will run as root".
+	require.NotNil(t, ic.SecurityContext)
+	require.NotNil(t, ic.SecurityContext.RunAsNonRoot)
+	assert.True(t, *ic.SecurityContext.RunAsNonRoot)
+	require.NotNil(t, ic.SecurityContext.RunAsUser, "RunAsUser must be set so kubelet accepts a root image under RunAsNonRoot")
+	assert.NotZero(t, *ic.SecurityContext.RunAsUser, "RunAsUser must be non-zero (non-root)")
+	require.NotNil(t, ic.SecurityContext.RunAsGroup)
+	assert.NotZero(t, *ic.SecurityContext.RunAsGroup)
+
 	// Verify volume was added
 	require.Len(t, pod.Spec.Volumes, 1)
 	assert.Equal(t, moduleVolumeName, pod.Spec.Volumes[0].Name)

--- a/pkg/clusteragent/appsec/nginx/sidecar_test.go
+++ b/pkg/clusteragent/appsec/nginx/sidecar_test.go
@@ -42,6 +42,8 @@ func newTestNginxSidecarPattern(t *testing.T) (*nginxSidecarPattern, *dynamicfak
 			Nginx: appsecconfig.Nginx{
 				InitImage:       "datadog/ingress-nginx-injection",
 				ModuleMountPath: "/modules_mount",
+				InitRunAsUser:   101,
+				InitRunAsGroup:  82,
 			},
 		},
 		Injection: appsecconfig.Injection{
@@ -683,4 +685,55 @@ func TestMutatePod_EmptyConfigMapNameRefused(t *testing.T) {
 	assert.False(t, mutated)
 	assert.Empty(t, pod.Spec.InitContainers)
 	assert.Empty(t, pod.Spec.Volumes)
+}
+
+func TestBuildInitContainerRunAsConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		runAsUser      int64
+		runAsGroup     int64
+		wantUserSet    bool
+		wantUserValue  int64
+		wantGroupSet   bool
+		wantGroupValue int64
+	}{
+		{
+			name:           "non-negative IDs are applied (root image needs explicit non-root UID)",
+			runAsUser:      101,
+			runAsGroup:     82,
+			wantUserSet:    true,
+			wantUserValue:  101,
+			wantGroupSet:   true,
+			wantGroupValue: 82,
+		},
+		{
+			name:         "negative IDs leave the fields unset so a custom image's USER is honored",
+			runAsUser:    -1,
+			runAsGroup:   -1,
+			wantUserSet:  false,
+			wantGroupSet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := buildInitContainer("repo/image:tag", "/modules_mount", tt.runAsUser, tt.runAsGroup)
+			require.NotNil(t, c.SecurityContext)
+			assert.True(t, *c.SecurityContext.RunAsNonRoot, "RunAsNonRoot must always be enforced")
+
+			if tt.wantUserSet {
+				require.NotNil(t, c.SecurityContext.RunAsUser)
+				assert.Equal(t, tt.wantUserValue, *c.SecurityContext.RunAsUser)
+			} else {
+				assert.Nil(t, c.SecurityContext.RunAsUser)
+			}
+
+			if tt.wantGroupSet {
+				require.NotNil(t, c.SecurityContext.RunAsGroup)
+				assert.Equal(t, tt.wantGroupValue, *c.SecurityContext.RunAsGroup)
+			} else {
+				assert.Nil(t, c.SecurityContext.RunAsGroup)
+			}
+		})
+	}
 }

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -371,6 +371,12 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	// ingress-nginx injection configuration
 	config.BindEnvAndSetDefault("admission_controller.appsec.nginx.init_image", "datadog/ingress-nginx-injection")
 	config.BindEnvAndSetDefault("admission_controller.appsec.nginx.module_mount_path", "/modules_mount")
+	// Non-root UID/GID for the injected init container. Defaults match the
+	// stock datadog/ingress-nginx-injection image, which declares no USER and
+	// would otherwise be rejected under runAsNonRoot. Set to a negative value
+	// to leave the security context unset and honor a custom init_image's own USER.
+	config.BindEnvAndSetDefault("admission_controller.appsec.nginx.init_run_as_user", 101)
+	config.BindEnvAndSetDefault("admission_controller.appsec.nginx.init_run_as_group", 82)
 
 	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.enabled", false)
 	// list of kubernetes resources for which we collect metadata

--- a/releasenotes/notes/fix-appsec-nginx-init-container-runasuser-1739de176dcfe114.yaml
+++ b/releasenotes/notes/fix-appsec-nginx-init-container-runasuser-1739de176dcfe114.yaml
@@ -7,4 +7,7 @@ fixes:
     and the injection image runs as root, so the kubelet rejected it with
     "container has runAsNonRoot and image will run as root", leaving the
     ingress-nginx controller pod stuck in ``CreateContainerConfigError``. The
-    init container now runs with an explicit non-root UID/GID.
+    init container now runs with an explicit non-root UID/GID, configurable via
+    ``admission_controller.appsec.nginx.init_run_as_user`` and
+    ``admission_controller.appsec.nginx.init_run_as_group`` (defaults 101/82;
+    set a negative value to honor a custom init image's own user).

--- a/releasenotes/notes/fix-appsec-nginx-init-container-runasuser-1739de176dcfe114.yaml
+++ b/releasenotes/notes/fix-appsec-nginx-init-container-runasuser-1739de176dcfe114.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed the Cluster Agent AppSec ingress-nginx injector so the injected
+    init container starts on clusters that enforce ``runAsNonRoot``. The init
+    container set ``runAsNonRoot: true`` without an explicit ``runAsUser``,
+    and the injection image runs as root, so the kubelet rejected it with
+    "container has runAsNonRoot and image will run as root", leaving the
+    ingress-nginx controller pod stuck in ``CreateContainerConfigError``. The
+    init container now runs with an explicit non-root UID/GID.


### PR DESCRIPTION
### What does this PR do?

Pins the AppSec ingress-nginx injected init container to a non-root UID/GID (101/82) so it can actually start.

`buildInitContainer` set `RunAsNonRoot: true` but never set `RunAsUser`. The `datadog/ingress-nginx-injection` image declares no `USER` (runs as root), so the kubelet rejects the container with *"container has runAsNonRoot and image will run as root"*, leaving the ingress-nginx controller pod stuck in `CreateContainerConfigError`. AppSec injection never worked on clusters that enforce the `runAsNonRoot` check.

### Motivation

Discovered while end-to-end testing the (now merged) confused-deputy mitigation #51635 on a local k3s cluster: the controller pod never reached Running because the injected init container was rejected by the kubelet.

### Describe how you validated your changes

Verified end-to-end on k3s (Rancher Desktop) with ingress-nginx controller `v1.15.1` and a cluster-agent built from this change:

- Init container reaches `Completed (exitCode 0)`; controller pod is `1/1 Running` (previously `CreateContainerConfigError`).
- `nginx-datadog` module loads; DD-owned ConfigMap is created with the `load_module` + `datadog_appsec_enabled on` snippets.
- Request through the ingress with a normal `User-Agent` → **HTTP 200**.
- Request with `User-Agent: dd-test-scanner-log-block` → **HTTP 403** WAF block ("You've been blocked ... Security provided by Datadog.").

Unit test updated to assert the init container has a non-root `RunAsUser`/`RunAsGroup`, guarding against regression. `dda inv test` (62 passed) and `dda inv linter.go` (0 issues) on `./pkg/clusteragent/appsec/nginx`.

### Additional Notes

UID 101 / GID 82 is ingress-nginx's own `www-data` identity, so the copied module file ownership matches the controller container that consumes it. The module `.so` is world-readable and the shared `emptyDir` is world-writable, so any non-zero ID would function; matching the controller is for consistency.