### PR TITLE
[host-profiler] Fix ensureMetricsPipeline not to materialize empty pipeline for profiles-only configs

### DIFF
--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -138,9 +138,12 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 }
 
 func (c *converterWithoutAgent) ensureMetricsPipeline(conf confMap) error {
-	metrics, err := confmaputils.Ensure[confMap](conf, "service::pipelines::metrics")
-	if err != nil {
-		return err
+	// Only operate on a metrics pipeline the user actually declared. Using Ensure here would
+	// materialize an empty service::pipelines::metrics for profiles-only configs, which then
+	// fails validation with "service::pipelines::metrics: must have at least one receiver".
+	metrics, ok := confmaputils.Get[confMap](conf, "service::pipelines::metrics")
+	if !ok {
+		return nil
 	}
 
 	processors, err := confmaputils.Ensure[[]any](metrics, "processors")

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-missing/out.yaml
@@ -33,8 +33,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-to-pipe/out.yaml
@@ -33,8 +33,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-apikey/out.yaml
@@ -35,8 +35,6 @@ receivers:
                   app_key: test-app-key
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-appkey/out.yaml
@@ -35,8 +35,6 @@ receivers:
                   app_key: "67890"
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-key-exp/out.yaml
@@ -32,8 +32,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/create-default-prof/out.yaml
@@ -32,8 +32,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/deprecated-otlphttp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/deprecated-otlphttp/out.yaml
@@ -56,8 +56,6 @@ receivers:
                         - 127.0.0.1:8889
 service:
     pipelines:
-        metrics:
-            processors: []
         metrics/profiler-internal-health:
             exporters:
                 - otlphttp/prod

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/ensures-headers/out.yaml
@@ -32,8 +32,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/global-procs-notmap/out.yaml
@@ -32,8 +32,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/headers-wrong-type/out.yaml
@@ -32,8 +32,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/ignore-non-otlp/out.yaml
@@ -34,8 +34,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - logging

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-bare-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-bare-ep/out.yaml
@@ -55,8 +55,6 @@ receivers:
                         - 127.0.0.1:8889
 service:
     pipelines:
-        metrics:
-            processors: []
         metrics/profiler-internal-health:
             exporters:
                 - otlphttp

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-existing-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-existing-ep/out.yaml
@@ -56,8 +56,6 @@ receivers:
                         - 127.0.0.1:8889
 service:
     pipelines:
-        metrics:
-            processors: []
         metrics/profiler-internal-health:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-infer-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-infer-ep/out.yaml
@@ -56,8 +56,6 @@ receivers:
                         - 127.0.0.1:8889
 service:
     pipelines:
-        metrics:
-            processors: []
         metrics/profiler-internal-health:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-level-none/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-level-none/out.yaml
@@ -33,8 +33,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-mixed/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-mixed/out.yaml
@@ -62,8 +62,6 @@ receivers:
                         - 127.0.0.1:8889
 service:
     pipelines:
-        metrics:
-            processors: []
         metrics/profiler-internal-health:
             exporters:
                 - otlp_http/with-ep

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-prefer-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-prefer-ep/out.yaml
@@ -56,8 +56,6 @@ receivers:
                         - 127.0.0.1:8889
 service:
     pipelines:
-        metrics:
-            processors: []
         metrics/profiler-internal-health:
             exporters:
                 - otlphttp

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-otlp-exp/out.yaml
@@ -39,8 +39,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http/prod

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-profiling-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-profiling-recv/out.yaml
@@ -41,8 +41,6 @@ receivers:
                   app_key: string-app
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-symbol-ep/out.yaml
@@ -37,8 +37,6 @@ receivers:
                   app_key: "456"
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-all-res-attrs/out.yaml
@@ -32,8 +32,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-evp-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-evp-headers/out.yaml
@@ -32,8 +32,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-arch/out.yaml
@@ -28,8 +28,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-name/out.yaml
@@ -30,8 +30,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-os-type/out.yaml
@@ -30,8 +30,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-otlp-proto/out.yaml
@@ -36,8 +36,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-res-no-sys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-res-no-sys/out.yaml
@@ -33,8 +33,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/proc-name-similar/out.yaml
@@ -38,8 +38,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/out.yaml
@@ -68,8 +68,6 @@ service:
         - custom
         - other
     pipelines:
-        metrics:
-            processors: []
         metrics/profiler-internal-health:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/str-key-exporter/out.yaml
@@ -32,8 +32,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-disabled/out.yaml
@@ -32,8 +32,6 @@ receivers:
             enabled: false
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-str-keys/out.yaml
@@ -35,8 +35,6 @@ receivers:
                   app_key: test-app-key
 service:
     pipelines:
-        metrics:
-            processors: []
         profiles:
             exporters:
                 - otlp_http


### PR DESCRIPTION
## Summary

- `ensureMetricsPipeline` was using `Ensure[confMap]` which **materializes** `service::pipelines::metrics` as an empty map even when the user never declared a metrics pipeline. This caused OTel validation to fail with `"service::pipelines::metrics: must have at least one receiver"` for profiles-only configs.
- Switched to `Get[confMap]` so the function is a no-op when no user-declared metrics pipeline exists.
- Updated 32 golden test files to remove the spuriously generated `metrics: processors: []` entry.

## Test plan

- [ ] `dda inv test --targets=./comp/host-profiler/collector/impl/converters/...` — all 32 previously failing golden-file tests now pass
- [ ] Manually verify a profiles-only config (no `service::pipelines::metrics`) no longer produces an empty metrics pipeline entry after conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)