### PR TITLE
[CWS] Don't log TC detach failures when the manager is already stopped

### DIFF
--- a/pkg/security/resolvers/tc/resolver.go
+++ b/pkg/security/resolvers/tc/resolver.go
@@ -167,15 +167,17 @@ func (tcr *Resolver) SetupNewTCClassifierWithNetNSHandle(device model.NetDevice,
 // detachHook detaches and deletes a TC hook from the resolver, needs to be called with the lock held
 func (tcr *Resolver) detachHook(tcKey ProgramKey, entry programEntry, m *manager.Manager) {
 	if err := m.DetachHook(entry.probe.ProbeIdentificationPair); err != nil {
-		seclog.Errorf("couldn't detach TC classifier %s: %v", entry.probe.ProbeIdentificationPair, err)
-		return
+		// fall through and clean up our local state below if the ebpf-manager has already stopped
+		if !errors.Is(err, manager.ErrManagerNotInitialized) {
+			seclog.Errorf("couldn't detach TC classifier %s: %v", entry.probe.ProbeIdentificationPair, err)
+			return
+		}
 	}
 
-	// only remove the program mapping if the ebpf-manager successfully detached the eBPF programs
+	// only remove the program mapping if the ebpf-manager successfully detached the eBPF program
 	// otherwise SetupNewTCClassifierWithNetNSHandle might try to recreate the probe when it already exists
 	// from the ebpf-manager PoV.
 	// TODO(yoanngh): fix this ebpf-manager/tc resolver desync
-
 	ddebpf.RemoveProgramID(entry.programID, "cws")
 	delete(tcr.programs, tcKey)
 }


### PR DESCRIPTION
### What does this PR do?

Treats the ebpf-manager "not initialized" error as benign when detaching a TC classifier.

### Motivation

On shutdown the manager is stopped first (which already unloads every TC program), and only then does the netns resolver flush those same programs. Those detach calls therefore always fail with the following error:

```
couldn't detach TC classifier {UID:security_classifier_egress_6_4026531840 EBPFFuncName:classifier_egress}: the manager must be initialized first
```

### Describe how you validated your changes

### Additional Notes

Follow up of #51715
