### PR TITLE
Increase memory limit for generate_config_schema-windows CI job

### DIFF
--- a/.gitlab/build/binary_build/schema_generation.yml
+++ b/.gitlab/build/binary_build/schema_generation.yml
@@ -83,7 +83,7 @@ generate_config_schema-windows:
     - $ErrorActionPreference = "Stop"
     - >
       .\tools\ci\docker-run-with-bazel-cache.ps1
-      -m 8192M
+      -m 24576M
       -v "$(Get-Location):c:\mnt"
       -e GITLAB_CI
       -e CI_JOB_ID


### PR DESCRIPTION
### What does this PR do?

Bumps the Docker memory limit for the `generate_config_schema-windows` CI job from 8192M to 24576M.

### Motivation

The job was hitting OOM errors while running `dda inv agent.build` on Windows. The Linux and macOS variants of the same job use 16 GiB; other Windows CI jobs that perform a full agent build consistently use 24576M, so this aligns the schema generation job with that convention.

### Describe how you validated your changes

CI

### Additional Notes

Example failing job https://mosaic.us1.ddbuild.io/change-request/repository/datadog/datadog-agent/pull/51559/request/14856036506318525035?owner=datadog&repository=datadog-agent&taskId=gitlab&taskExecutionId=1741943079