### PR TITLE
fix(ci): restore Windows Go module cache from .tar.zst artifacts

### DIFF
--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -118,6 +118,10 @@ function Expand-ModCache() {
         }
         Write-Host "Modcache extracted"
     } else {
+        if ($env:CI) {
+            Write-Error "Modcache zst file $MODCACHE_ZST_FILE not found in CI"
+            exit 1
+        }
         Write-Host "Modcache zst file $MODCACHE_ZST_FILE not found, dependencies will be downloaded"
     }
 

--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -90,7 +90,7 @@ function Expand-ModCache() {
 
     $MODCACHE_ROOT = $root
     $MODCACHE_FILE_ROOT = $modcache
-    $MODCACHE_XZ_FILE = Join-Path $MODCACHE_ROOT "$MODCACHE_FILE_ROOT.tar.xz"
+    $MODCACHE_ZST_FILE = Join-Path $MODCACHE_ROOT "$MODCACHE_FILE_ROOT.tar.zst"
     $MODCACHE_TAR_FILE = Join-Path $MODCACHE_ROOT "$MODCACHE_FILE_ROOT.tar"
 
     if (-not $env:GOMODCACHE) {
@@ -98,12 +98,12 @@ function Expand-ModCache() {
         return
     }
 
-    Write-Host "MODCACHE_XZ_FILE $MODCACHE_XZ_FILE MODCACHE_TAR_FILE $MODCACHE_TAR_FILE GOMODCACHE $env:GOMODCACHE"
-    if (Test-Path $MODCACHE_XZ_FILE) {
-        Write-Host "Extracting modcache file $MODCACHE_XZ_FILE"
-        & 7z.exe x $MODCACHE_XZ_FILE -o"$MODCACHE_ROOT" -bt
+    Write-Host "MODCACHE_ZST_FILE $MODCACHE_ZST_FILE MODCACHE_TAR_FILE $MODCACHE_TAR_FILE GOMODCACHE $env:GOMODCACHE"
+    if (Test-Path $MODCACHE_ZST_FILE) {
+        Write-Host "Extracting modcache file $MODCACHE_ZST_FILE"
+        & 7z.exe x $MODCACHE_ZST_FILE -o"$MODCACHE_ROOT" -bt
         if ($LASTEXITCODE -ne 0) {
-            Write-Error "Failed to extract $MODCACHE_XZ_FILE"
+            Write-Error "Failed to extract $MODCACHE_ZST_FILE"
             exit 1
         }
         Get-ChildItem $MODCACHE_TAR_FILE
@@ -113,17 +113,17 @@ function Expand-ModCache() {
         # get replaced by the same files
         & 7z.exe x $MODCACHE_TAR_FILE -o"$env:GOMODCACHE\cache" -aoa -bt
         if ($LASTEXITCODE -ne 0) {
-            Write-Error "Failed to extract $MODCACHE_XZ_FILE"
+            Write-Error "Failed to extract $MODCACHE_ZST_FILE"
             exit 1
         }
         Write-Host "Modcache extracted"
     } else {
-        Write-Host "Modcache XZ file $MODCACHE_XZ_FILE not found, dependencies will be downloaded"
+        Write-Host "Modcache zst file $MODCACHE_ZST_FILE not found, dependencies will be downloaded"
     }
 
-    if (Test-Path $MODCACHE_XZ_FILE) {
-        Write-Host "Deleting modcache tar.xz $MODCACHE_XZ_FILE"
-        Remove-Item -Force $MODCACHE_XZ_FILE
+    if (Test-Path $MODCACHE_ZST_FILE) {
+        Write-Host "Deleting modcache tar.zst $MODCACHE_ZST_FILE"
+        Remove-Item -Force $MODCACHE_ZST_FILE
     }
     if (Test-Path $MODCACHE_TAR_FILE) {
         Write-Host "Deleting modcache tar $MODCACHE_TAR_FILE"

--- a/tasks/winbuildscripts/extract-modcache.bat
+++ b/tasks/winbuildscripts/extract-modcache.bat
@@ -36,6 +36,10 @@ if exist %MODCACHE_ZST_FILE% (
     Powershell -C "7z x %MODCACHE_TAR_FILE% -o%GOMODCACHE%\cache -aoa -bt"
     @echo Modcache extracted
 ) else (
+    if defined CI (
+        @echo ERROR: %MODCACHE_ZST_FILE% not found in CI
+        exit /b 1
+    )
     @echo %MODCACHE_ZST_FILE% not found, dependencies will be downloaded
 )
 goto :endofscript

--- a/tasks/winbuildscripts/extract-modcache.bat
+++ b/tasks/winbuildscripts/extract-modcache.bat
@@ -16,7 +16,7 @@ if "%2" == "" (
 
 set MODCACHE_ROOT=%1
 set MODCACHE_FILE_ROOT=%2
-set MODCACHE_XZ_FILE=%MODCACHE_ROOT%\%MODCACHE_FILE_ROOT%.tar.xz
+set MODCACHE_ZST_FILE=%MODCACHE_ROOT%\%MODCACHE_FILE_ROOT%.tar.zst
 set MODCACHE_TAR_FILE=%MODCACHE_ROOT%\%MODCACHE_FILE_ROOT%.tar
 
 if "%GOMODCACHE%" == "" (
@@ -24,10 +24,10 @@ if "%GOMODCACHE%" == "" (
     goto :endofscript
 )
 
-@echo MODCACHE_XZ_FILE %MODCACHE_XZ_FILE% MODCACHE_TAR_FILE %MODCACHE_TAR_FILE% GOMODCACHE %GOMODCACHE%
-if exist %MODCACHE_XZ_FILE% (
-    @echo Extracting modcache file %MODCACHE_XZ_FILE%
-    Powershell -C "7z x %MODCACHE_XZ_FILE% -o%MODCACHE_ROOT% -bt"
+@echo MODCACHE_ZST_FILE %MODCACHE_ZST_FILE% MODCACHE_TAR_FILE %MODCACHE_TAR_FILE% GOMODCACHE %GOMODCACHE%
+if exist %MODCACHE_ZST_FILE% (
+    @echo Extracting modcache file %MODCACHE_ZST_FILE%
+    Powershell -C "7z x %MODCACHE_ZST_FILE% -o%MODCACHE_ROOT% -bt"
     dir %MODCACHE_TAR_FILE%
     REM Use -aoa to allow overwriting existing files
     REM This shouldn't have any negative impact: since modules are
@@ -36,7 +36,7 @@ if exist %MODCACHE_XZ_FILE% (
     Powershell -C "7z x %MODCACHE_TAR_FILE% -o%GOMODCACHE%\cache -aoa -bt"
     @echo Modcache extracted
 ) else (
-    @echo %MODCACHE_XZ_FILE% not found, dependencies will be downloaded
+    @echo %MODCACHE_ZST_FILE% not found, dependencies will be downloaded
 )
 goto :endofscript
 
@@ -46,9 +46,9 @@ goto :endofscript
 goto :eof
 
 :endofscript
-if exist %MODCACHE_XZ_FILE% (
-    @echo deleting modcache tar.xz %MODCACHE_XZ_FILE%
-    del /f %MODCACHE_XZ_FILE%
+if exist %MODCACHE_ZST_FILE% (
+    @echo deleting modcache tar.zst %MODCACHE_ZST_FILE%
+    del /f %MODCACHE_ZST_FILE%
 )
 if exist %MODCACHE_TAR_FILE% (
     @echo deleting modcache tar %MODCACHE_TAR_FILE%


### PR DESCRIPTION
### What does this PR do?

Fixes `Expand-ModCache` in `tasks/winbuildscripts/common.ps1` and `extract-modcache.bat` to look for `modcache.tar.zst` instead of `modcache.tar.xz`.

### Motivation

Commit c14ccc3856d switched `go_deps` / `go_tools_deps` artifacts from xz to zstd compression but didn't update the Windows extraction helpers. Both files were silently skipping extraction ("not found, dependencies will be downloaded") on every Windows CI job, causing all of them to re-download Go module dependencies from scratch:

- `common.ps1` (`Expand-ModCache`) — used by jobs that go through `Invoke-BuildScript` (schema generation, unit tests, linters, package builds, integration tests)
- `extract-modcache.bat` — used by `sysprobe.bat` / `secagent.bat` for the sysprobe and secagent source-test jobs

### Describe how you validated your changes

The extraction logic (7-Zip two-step: decompress → extract tar) is identical in both files; only the file extension changes. 7-Zip 22.01+ supports zstd natively and is available in the Windows build images.

### Additional Notes

N/A