### PR TITLE
Revert "[procmgr] Register process_manager.enabled in agent config schema and template"

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -192,21 +192,6 @@ api_key:
 #
 # remote_updates: true
 
-## @param process_manager - custom object - optional
-## When true (see `enabled` below), the Datadog process manager daemon (dd-procmgrd) is enabled for this host install.
-## On Windows, the core Agent starts the Windows service `dd-procmgr-service` when this option is true.
-## On Linux, dd-procmgrd is started by systemd (`datadog-agent-procmgr.service` linked to the main Agent unit);
-## this setting is ignored on Linux and does not enable or disable the systemd unit.
-#
-# process_manager:
-
-#   # @param enabled - boolean - optional - default: true
-#   # @env DD_PROCESS_MANAGER_ENABLED - boolean - optional - default: true
-#   # When true (Windows only), the core Agent starts the dd-procmgr-service Windows service.
-#   # On Linux, the process manager daemon is started by systemd; this option is ignored.
-#
-#   enabled: true
-
 ## @param tag_value_split_separator - object - optional - default: {}
 ## @env DD_TAG_VALUE_SPLIT_SEPARATOR - JSON object of string to string - optional - default: {}
 ## Split tag values according to a given separator. Only applies to host tags,

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -312,30 +312,6 @@ properties:
     - template_section:Common
     - full-agent-only:true
     comment: Installer configuration
-  process_manager:
-    node_type: section
-    type: object
-    visibility: public
-    description: |-
-      When true (see `enabled` below), the Datadog process manager daemon (dd-procmgrd) is enabled for this host install.
-      On Windows, the core Agent starts the Windows service `dd-procmgr-service` when this option is true.
-      On Linux, dd-procmgrd is started by systemd (`datadog-agent-procmgr.service` linked to the main Agent unit);
-      this setting is ignored on Linux and does not enable or disable the systemd unit.
-    tags:
-    - template_section:Common
-    - full-agent-only:true
-    properties:
-      enabled:
-        node_type: setting
-        type: boolean
-        default: true
-        visibility: public
-        description: |-
-          When true (Windows only), the core Agent starts the dd-procmgr-service Windows service.
-          On Linux, the process manager daemon is started by systemd; this option is ignored.
-        tags:
-        - template_section:Common
-        comment: Process manager
   tag_value_split_separator:
     node_type: setting
     type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -868,10 +868,6 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	// Network
 	config.BindEnv("network.id") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 
-	// Process manager (dd-procmgrd): on Windows the core agent starts dd-procmgr-service when enabled.
-	// On Linux, dd-procmgrd is managed by systemd (datadog-agent-procmgr.service); this setting is ignored there.
-	config.BindEnvAndSetDefault("process_manager.enabled", true)
-
 	// OTel Collector
 	config.BindEnvAndSetDefault("otelcollector.enabled", false)
 	config.BindEnvAndSetDefault("otelcollector.extension_url", "https://localhost:7777")

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -72,19 +72,6 @@ func TestDefaults(t *testing.T) {
 
 	assert.True(t, config.GetBool("logs_config.tag_multi_line_logs"))
 	assert.True(t, config.GetBool("logs_config.tag_truncated_logs"))
-
-	assert.True(t, config.GetBool("process_manager.enabled"))
-}
-
-func TestProcessManagerEnabledEnvOverride(t *testing.T) {
-	t.Setenv("DD_PROCESS_MANAGER_ENABLED", "false")
-	cfg := newTestConf(t)
-	assert.False(t, cfg.GetBool("process_manager.enabled"))
-}
-
-func TestProcessManagerEnabledYAML(t *testing.T) {
-	cfg := confFromYAML(t, "process_manager:\n  enabled: false\n")
-	assert.False(t, cfg.GetBool("process_manager.enabled"))
 }
 
 func TestUnexpectedUnicode(t *testing.T) {

--- a/releasenotes/notes/register-process-manager-enabled-b4e8f0a1c9d2e7f3.yaml
+++ b/releasenotes/notes/register-process-manager-enabled-b4e8f0a1c9d2e7f3.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    Register ``process_manager.enabled`` in the Agent configuration schema (``pkg/config/schema/core_schema.yaml``),
-    set its default in ``pkg/config/setup``, and document it in ``config_template.yaml``.
-    On Windows, this option controls whether the core Agent starts ``dd-procmgr-service``. On Linux, ``dd-procmgrd``
-    is started by systemd; this setting is ignored there.


### PR DESCRIPTION
Reverts DataDog/datadog-agent#51647

#incident-55687