### PR TITLE
refactor(slog): replace custom discard handler with slog.DiscardHandler

### DIFF
--- a/pkg/util/log/slog/handlers/disabled.go
+++ b/pkg/util/log/slog/handlers/disabled.go
@@ -6,38 +6,10 @@
 package handlers
 
 import (
-	"context"
 	"log/slog"
 )
 
-var _ slog.Handler = disabled{}
-
-// disabled is a slog handler which never writes anything.
-//
-// This can be replaced by slog.DiscardHandler once we update to Go 1.25
-type disabled struct{}
-
 // NewDisabled returns a handler which never writes anything.
 func NewDisabled() slog.Handler {
-	return disabled{}
-}
-
-// Enabled returns false
-func (disabled) Enabled(context.Context, slog.Level) bool {
-	return false
-}
-
-// Handle does nothing
-func (disabled) Handle(context.Context, slog.Record) error {
-	return nil
-}
-
-// WithAttrs does nothing
-func (d disabled) WithAttrs([]slog.Attr) slog.Handler {
-	return d
-}
-
-// WithGroup does nothing
-func (d disabled) WithGroup(string) slog.Handler {
-	return d
+	return slog.DiscardHandler
 }


### PR DESCRIPTION
### What does this PR do?

Replaces the custom `disabled` slog handler in `pkg/util/log/slog/handlers` with the stdlib `slog.DiscardHandler` introduced in Go 1.24. The public `NewDisabled()` API is unchanged.

### Motivation
Code simplification.

### Describe how you validated your changes

CI

### Additional Notes
