### PR TITLE
[PROF-15041] Enrich metrics attributes

### DIFF
--- a/comp/host-profiler/collector/impl/agentprovider/BUILD.bazel
+++ b/comp/host-profiler/collector/impl/agentprovider/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//comp/core/config",
         "//comp/host-profiler/collector/impl/extensions/hpflareextension",
         "//comp/host-profiler/collector/impl/params",
+        "//comp/host-profiler/symboluploader/cgroup",
         "//comp/host-profiler/version",
         "//pkg/config/utils",
         "//pkg/util/confmaputils",

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/extensions/hpflareextension"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/params"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/cgroup"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
 	"github.com/DataDog/datadog-agent/pkg/util/confmaputils"
 )
@@ -66,6 +67,7 @@ func buildExporters(conf confMap, agent configManager) []any {
 		headers["dd-api-key"] = key
 		headers["dd-evp-origin"] = version.BundledProfilerName
 		headers["dd-evp-origin-version"] = version.ProfilerVersion
+		headers["dd-otel-metric-config"] = `{"resource_attributes_as_tags": true}`
 		return confMap{
 			"endpoint":    fmt.Sprintf(endpointFormat, site),
 			"compression": "zstd",
@@ -166,6 +168,18 @@ func buildMetricsPipeline(conf confMap, enableGoRuntimeMetrics bool, healthMetri
 	if enableGoRuntimeMetrics {
 		receivers["otlp"] = confMap{"protocols": confMap{"grpc": nil, "http": nil}}
 		metricsReceivers = append(metricsReceivers, "otlp")
+	}
+
+	if containerID, err := cgroup.GetSelfContainerID(); err == nil {
+		const containerIDProcessorName = "resource/dd-profiler-metrics-containerid"
+		processors[containerIDProcessorName] = confMap{
+			"attributes": []any{confMap{
+				"key":    version.OTelContainerIDKey,
+				"value":  containerID,
+				"action": "insert",
+			}},
+		}
+		metricsProcessors = append([]any{containerIDProcessorName}, metricsProcessors...)
 	}
 
 	metricsPipeline["receivers"] = metricsReceivers

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
@@ -62,7 +62,7 @@ func TestBuildExportersNoAdditionalHTTPHeaders(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Equal(t, "test_key", headers["dd-api-key"])
-	assert.Len(t, headers, 3) // dd-api-key, dd-evp-origin, dd-evp-origin-version
+	assert.Len(t, headers, 4) // dd-api-key, dd-evp-origin, dd-evp-origin-version, resource_as_attributes
 }
 
 func TestBuildConfigDDProfilingEnabled(t *testing.T) {

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/add-headers-debug/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/add-headers-debug/otel.yaml
@@ -8,6 +8,7 @@ exporters:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
             x-datadog-profiling-metadata: workspace:peterg17
 extensions:
     hpflare:

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/add-headers/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/add-headers/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
             x-custom-routing: some-value
             x-datadog-profiling-metadata: workspace:peterg17,env:staging
 extensions:

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/additional-ep-only/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/additional-ep-only/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: eu_key_1
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/basic-config/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/basic-config/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/ddprofiling-enabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/ddprofiling-enabled/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     ddprofiling: {}
     hpflare:

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/ddprofiling-period/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/ddprofiling-period/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     ddprofiling:
         profiler_options:

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/debug-disabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/debug-disabled/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/debug-enabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/debug-enabled/otel.yaml
@@ -8,6 +8,7 @@ exporters:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/duplicate-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/duplicate-site/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: additional_api_key
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
     otlp_http/datadoghq.com_1:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
@@ -13,6 +14,7 @@ exporters:
             dd-api-key: main_api_key
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/health-metrics-cust/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/health-metrics-cust/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/health-metrics-dis/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/health-metrics-dis/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/hpflare-custom-port/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/hpflare-custom-port/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:9999

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/infer-dc-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/infer-dc-add-ep/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
     otlp_http/us3.datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.us3.datadoghq.com
@@ -13,6 +14,7 @@ exporters:
             dd-api-key: us3_api_key
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/infer-dc-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/infer-dc-url/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/invalid-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/invalid-add-ep/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: main_key
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
     otlp_http/datadoghq.eu_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.eu
@@ -13,6 +14,7 @@ exporters:
             dd-api-key: eu_key_1
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/multi-keys-per-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/multi-keys-per-ep/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: main_key
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
     otlp_http/datadoghq.eu_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.eu
@@ -13,6 +14,7 @@ exporters:
             dd-api-key: eu_key_1
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
     otlp_http/datadoghq.eu_1:
         compression: zstd
         endpoint: https://otlp.datadoghq.eu
@@ -20,6 +22,7 @@ exporters:
             dd-api-key: eu_key_2
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
     otlp_http/datadoghq.eu_2:
         compression: zstd
         endpoint: https://otlp.datadoghq.eu
@@ -27,6 +30,7 @@ exporters:
             dd-api-key: eu_key_3
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/no-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/no-site/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_api_key
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/prof-dd-url-prec/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/prof-dd-url-prec/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/agentprovider/testdata/provider/profiling-dd-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/testdata/provider/profiling-dd-url/otel.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test_api_key_456
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     hpflare:
         endpoint: localhost:7778

--- a/comp/host-profiler/collector/impl/converters/BUILD.bazel
+++ b/comp/host-profiler/collector/impl/converters/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/converters",
     visibility = ["//visibility:public"],
     deps = [
+        "//comp/host-profiler/symboluploader/cgroup",
         "//comp/host-profiler/version",
         "//pkg/config/utils",
         "//pkg/util/confmaputils",

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -299,6 +299,11 @@ func TestConverterWithoutAgent(t *testing.T) {
 			expected: "no_agent/metrics-reserved-pipe/out.yaml",
 		},
 		{
+			name:     "internal-metrics-skipped-on-reserved-container-id-processor-conflict",
+			provided: "no_agent/reserved-cid-proc/in.yaml",
+			expected: "no_agent/reserved-cid-proc/out.yaml",
+		},
+		{
 			name:     "internal-metrics-uses-explicit-prometheus-reader",
 			provided: "no_agent/metrics-explicit-reader/in.yaml",
 			expected: "no_agent/metrics-explicit-reader/out.yaml",

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -474,7 +474,7 @@ func hasInternalHealthMetricsPipelineConflicts(conf confMap) bool {
 		}
 	}
 	if processors, ok := confmaputils.Get[confMap](conf, "processors"); ok {
-		for _, reserved := range []string{reservedFilterProcessor, reservedCumulativeToDeltaProcessor} {
+		for _, reserved := range []string{reservedFilterProcessor, reservedCumulativeToDeltaProcessor, reservedContainerIDProcessor} {
 			if _, exists := processors[reserved]; exists {
 				slog.Warn("skipping internal health metrics pipeline",
 					slog.String("reason", "processor name conflicts with reserved name"),
@@ -595,17 +595,16 @@ func (c *converterWithoutAgent) addInternalHealthMetricsPipeline(conf confMap, p
 	metricsProcessors := []any{reservedFilterProcessor, reservedCumulativeToDeltaProcessor}
 
 	if containerID, err := cgroup.GetSelfContainerID(); err == nil {
-		const containerIDProcessorName = "resource/" + confmaputils.AutoConfiguredSuffix + "-container-attribute"
 		containerIDProcessor := confMap{
 			"attributes": []any{confMap{
 				"key":    version.OTelContainerIDKey,
 				"value":  containerID,
 				"action": "insert",
 			}}}
-		if err := confmaputils.Set(conf, pathPrefixProcessors+containerIDProcessorName, containerIDProcessor); err != nil {
+		if err := confmaputils.Set(conf, pathPrefixProcessors+reservedContainerIDProcessor, containerIDProcessor); err != nil {
 			return fmt.Errorf("failed to add container ID processor: %w", err)
 		}
-		metricsProcessors = append(metricsProcessors, containerIDProcessorName)
+		metricsProcessors = append(metricsProcessors, reservedContainerIDProcessor)
 	}
 
 	metricsProcessors = append(metricsProcessors, profilesProcessors...)

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/cgroup"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
 	"github.com/DataDog/datadog-agent/pkg/util/confmaputils"
 	"go.opentelemetry.io/collector/confmap"
@@ -384,6 +385,9 @@ func (c *converterWithoutAgent) ensureOtlpHTTPExporterConfig(conf confMap, expor
 			if _, err := confmaputils.SetDefault(headers, fieldDDEVPOriginVersion, version.ProfilerVersion); err != nil {
 				return err
 			}
+			if _, err := confmaputils.SetDefault(headers, fieldDDOtelMetricConfig, fieldDDOtelMetricConfigValue); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -564,45 +568,61 @@ func (c *converterWithoutAgent) addInternalHealthMetricsPipeline(conf confMap, p
 		return nil
 	}
 
-	if len(resolution.uncoveredExporters) > 0 {
-		if err := confmaputils.Set(conf, pathPrefixReceivers+reservedPrometheusReceiver, confmaputils.PrometheusReceiverConfig("host-profiler-internal", resolution.defaultTarget)); err != nil {
-			return fmt.Errorf("failed to add prometheus receiver: %w", err)
-		}
-
-		if err := confmaputils.Set(conf, pathPrefixProcessors+reservedFilterProcessor, confmaputils.FilterProcessorConfig()); err != nil {
-			return fmt.Errorf("failed to add filter processor: %w", err)
-		}
-		if err := confmaputils.Set(conf, pathPrefixProcessors+reservedCumulativeToDeltaProcessor, confMap{}); err != nil {
-			return fmt.Errorf("failed to add cumulativetodelta processor: %w", err)
-		}
-
-		metricsProcessors := []any{reservedFilterProcessor, reservedCumulativeToDeltaProcessor}
-		metricsProcessors = append(metricsProcessors, profilesProcessors...)
-
-		metricsPipeline := confMap{
-			"receivers":  []any{reservedPrometheusReceiver},
-			"processors": metricsProcessors,
-			"exporters":  resolution.uncoveredExporters,
-		}
-
-		if err := confmaputils.Set(conf, "service::pipelines::"+internalHealthMetricsPipelineName, metricsPipeline); err != nil {
-			return fmt.Errorf("failed to create pipeline: %w", err)
-		}
-
-		slog.Info("created internal health metrics pipeline",
-			slog.Int("exporters", len(resolution.uncoveredExporters)),
-			slog.String("pipeline", internalHealthMetricsPipelineName))
-	} else {
-		slog.Info("skipping internal health metrics pipeline",
-			slog.String("reason", "no exporters configured"))
-	}
-
 	for exporterName, metricsEndpoint := range resolution.inferredMetricsEndpoints {
 		if err := confmaputils.Set(conf, pathPrefixExporters+exporterName+"::metrics_endpoint", metricsEndpoint); err != nil {
 			return fmt.Errorf("failed to set metrics_endpoint for %s: %w", exporterName, err)
 		}
 		slog.Info("inferred metrics endpoint for exporter", slog.String("exporter", exporterName), slog.String("metrics_endpoint", metricsEndpoint))
 	}
+
+	if len(resolution.uncoveredExporters) == 0 {
+		slog.Info("skipping internal health metrics pipeline",
+			slog.String("reason", "no uncovered exporters"))
+		return nil
+	}
+
+	if err := confmaputils.Set(conf, pathPrefixReceivers+reservedPrometheusReceiver, confmaputils.PrometheusReceiverConfig("host-profiler-internal", resolution.defaultTarget)); err != nil {
+		return fmt.Errorf("failed to add prometheus receiver: %w", err)
+	}
+
+	if err := confmaputils.Set(conf, pathPrefixProcessors+reservedFilterProcessor, confmaputils.FilterProcessorConfig()); err != nil {
+		return fmt.Errorf("failed to add filter processor: %w", err)
+	}
+	if err := confmaputils.Set(conf, pathPrefixProcessors+reservedCumulativeToDeltaProcessor, confMap{}); err != nil {
+		return fmt.Errorf("failed to add cumulativetodelta processor: %w", err)
+	}
+
+	metricsProcessors := []any{reservedFilterProcessor, reservedCumulativeToDeltaProcessor}
+
+	if containerID, err := cgroup.GetSelfContainerID(); err == nil {
+		const containerIDProcessorName = "resource/" + confmaputils.AutoConfiguredSuffix + "-container-attribute"
+		containerIDProcessor := confMap{
+			"attributes": []any{confMap{
+				"key":    version.OTelContainerIDKey,
+				"value":  containerID,
+				"action": "insert",
+			}}}
+		if err := confmaputils.Set(conf, pathPrefixProcessors+containerIDProcessorName, containerIDProcessor); err != nil {
+			return fmt.Errorf("failed to add container ID processor: %w", err)
+		}
+		metricsProcessors = append(metricsProcessors, containerIDProcessorName)
+	}
+
+	metricsProcessors = append(metricsProcessors, profilesProcessors...)
+
+	metricsPipeline := confMap{
+		"receivers":  []any{reservedPrometheusReceiver},
+		"processors": metricsProcessors,
+		"exporters":  resolution.uncoveredExporters,
+	}
+
+	if err := confmaputils.Set(conf, "service::pipelines::"+internalHealthMetricsPipelineName, metricsPipeline); err != nil {
+		return fmt.Errorf("failed to create pipeline: %w", err)
+	}
+
+	slog.Info("created internal health metrics pipeline",
+		slog.Int("exporters", len(resolution.uncoveredExporters)),
+		slog.String("pipeline", internalHealthMetricsPipelineName))
 
 	return nil
 }

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -56,6 +56,7 @@ const (
 	reservedPrometheusReceiver         = "prometheus/dd-hp-internal"
 	reservedFilterProcessor            = "filter/dd-hp-drop-internal"
 	reservedCumulativeToDeltaProcessor = "cumulativetodelta/dd-hp-internal"
+	reservedContainerIDProcessor       = "resource/" + confmaputils.AutoConfiguredSuffix + "-container-attribute"
 	internalHealthMetricsPipelineName  = "metrics/profiler-internal-health"
 )
 

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -67,11 +67,13 @@ const (
 
 // Configuration field names used multiple times
 const (
-	fieldDDAPIKey           = "dd-api-key"
-	fieldDDEVPOrigin        = "dd-evp-origin"
-	fieldDDEVPOriginVersion = "dd-evp-origin-version"
-	fieldAPIKey             = "api_key"
-	fieldAppKey             = "app_key"
+	fieldDDAPIKey                = "dd-api-key"
+	fieldDDEVPOrigin             = "dd-evp-origin"
+	fieldDDEVPOriginVersion      = "dd-evp-origin-version"
+	fieldDDOtelMetricConfig      = "dd-otel-metric-config"
+	fieldDDOtelMetricConfigValue = `{"resource_attributes_as_tags": true}`
+	fieldAPIKey                  = "api_key"
+	fieldAppKey                  = "app_key"
 )
 
 // OTEL config path prefixes

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-missing/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-to-pipe/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-apikey/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-appkey/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-key-exp/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: "12345"
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/create-default-prof/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/deprecated-otlphttp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/deprecated-otlphttp/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 processors:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/ensures-headers/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/global-procs-notmap/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/headers-wrong-type/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/ignore-non-otlp/out.yaml
@@ -7,6 +7,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-absent-reader/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-absent-reader/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-bad-reader/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-bad-reader/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
     ddhostname/dd-autoconfigured: {}

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-bare-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-bare-ep/out.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     cumulativetodelta/dd-hp-internal: {}
     ddhostname/dd-autoconfigured: {}

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-covered-path/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-covered-path/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://custom.metrics.example.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-covered-user/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-covered-user/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://custom.metrics.example.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-empty-readers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-empty-readers/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 processors:
     ddhostname/dd-autoconfigured: {}

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-existing-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-existing-ep/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://custom.metrics.example.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-explicit-reader/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-explicit-reader/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-infer-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-infer-ep/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 processors:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-level-none/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-level-none/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
     ddhostname/dd-autoconfigured: {}

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-mixed-reader/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-mixed-reader/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
     ddhostname/dd-autoconfigured: {}

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-mixed/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-mixed/out.yaml
@@ -5,12 +5,14 @@ exporters:
             dd-api-key: test-api-key-2
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
     otlp_http/with-ep:
         compression: zstd
         headers:
             dd-api-key: test-api-key-1
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-multi-readers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-multi-readers/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-null-readers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-null-readers/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
     ddhostname/dd-autoconfigured: {}

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-partial-coverage/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-partial-coverage/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key-covered
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://custom.metrics.example.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlp_http/uncovered:
@@ -13,6 +14,7 @@ exporters:
             dd-api-key: test-api-key-uncovered
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 processors:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-periodic-reader/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-periodic-reader/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
     ddhostname/dd-autoconfigured: {}

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-prefer-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-prefer-ep/out.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         profiles_endpoint: https://otlp.datadoghq.com/v1development/profiles
 processors:
     cumulativetodelta/dd-hp-internal: {}

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-reserved-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-reserved-pipe/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
     ddhostname/dd-autoconfigured: {}

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-reserved-proc/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-reserved-proc/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
     ddhostname/dd-autoconfigured: {}

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-reserved-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-reserved-recv/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
     ddhostname/dd-autoconfigured: {}

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-uncovered-path/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-uncovered-path/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://custom.metrics.example.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-uncovered-scheme/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-uncovered-scheme/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
         metrics_endpoint: https://custom.metrics.example.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-otlp-exp/out.yaml
@@ -6,12 +6,14 @@ exporters:
             dd-api-key: "11111"
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
     otlp_http/staging:
         compression: zstd
         headers:
             dd-api-key: staging-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-profiling-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-profiling-recv/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-symbol-ep/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-all-res-attrs/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-evp-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-evp-headers/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: custom-origin
             dd-evp-origin-version: custom-version
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-arch/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-name/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-os-type/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-otlp-proto/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-res-no-sys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-res-no-sys/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/proc-name-similar/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     batch:
         timeout: 10s

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/reserved-cid-proc/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/reserved-cid-proc/in.yaml
@@ -1,0 +1,23 @@
+receivers:
+  profiling:
+    symbol_uploader:
+      enabled: false
+processors:
+  resource/dd-autoconfigured-container-attribute:
+    attributes:
+      - key: container.id
+        value: user-defined-value
+        action: insert
+service:
+  pipelines:
+    profiles:
+      processors: []
+      receivers:
+      - profiling
+      exporters:
+      - otlp_http
+exporters:
+  otlp_http:
+    headers:
+      dd-api-key: test-api-key
+    profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/reserved-cid-proc/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/reserved-cid-proc/out.yaml
@@ -1,0 +1,50 @@
+exporters:
+    otlp_http:
+        compression: zstd
+        headers:
+            dd-api-key: test-api-key
+            dd-evp-origin: host-profiler-standalone
+            dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
+        profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+processors:
+    ddhostname/dd-autoconfigured: {}
+    resource/dd-autoconfigured-container-attribute:
+        attributes:
+            - action: insert
+              key: container.id
+              value: user-defined-value
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: telemetry.distro.name
+              value: host-profiler-standalone
+            - action: upsert
+              key: telemetry.distro.version
+              value: 7.0.0-test
+    resourcedetection/dd-autoconfigured:
+        detectors:
+            - system
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: true
+                host.name:
+                    enabled: false
+                os.type:
+                    enabled: false
+receivers:
+    profiling:
+        symbol_uploader:
+            enabled: false
+service:
+    pipelines:
+        profiles:
+            exporters:
+                - otlp_http
+            processors:
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/out.yaml
@@ -6,6 +6,7 @@ exporters:
             dd-api-key: test-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 extensions:
     custom:
         config: value

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-infraattr-metrics/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     batch:
         timeout: 10s

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/str-key-exporter/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-disabled/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-str-keys/out.yaml
@@ -5,6 +5,7 @@ exporters:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 processors:
     ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/symboluploader/cgroup/BUILD.bazel
+++ b/comp/host-profiler/symboluploader/cgroup/BUILD.bazel
@@ -4,15 +4,21 @@ go_library(
     name = "cgroup",
     srcs = [
         "cgroup.go",
+        "containerid.go",
+        "containerid_other.go",
         "helpers.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/cgroup",
     visibility = ["//visibility:public"],
     deps = select({
         "@rules_go//go/platform:android": [
+            "@io_opentelemetry_go_ebpf_profiler//libpf",
+            "@io_opentelemetry_go_ebpf_profiler//process",
             "@org_golang_x_sys//unix",
         ],
         "@rules_go//go/platform:linux": [
+            "@io_opentelemetry_go_ebpf_profiler//libpf",
+            "@io_opentelemetry_go_ebpf_profiler//process",
             "@org_golang_x_sys//unix",
         ],
         "//conditions:default": [],

--- a/comp/host-profiler/symboluploader/cgroup/containerid.go
+++ b/comp/host-profiler/symboluploader/cgroup/containerid.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package cgroup
+
+import (
+	"errors"
+	"os"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/process"
+)
+
+// GetSelfContainerID returns the container ID of the current process by reading cgroup.
+func GetSelfContainerID() (string, error) {
+	pid := libpf.PID(os.Getpid())
+	id := process.New(pid, pid).GetProcessMeta(process.MetaConfig{}).ContainerID.String()
+	if id == "" {
+		return "", errors.New("not running in a container")
+	}
+	return id, nil
+}

--- a/comp/host-profiler/symboluploader/cgroup/containerid_other.go
+++ b/comp/host-profiler/symboluploader/cgroup/containerid_other.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !linux
+
+// Package cgroup provides utilities for returning usable memory from cgroups.
+// Unavailable on a non-linux OS
+package cgroup
+
+import "errors"
+
+// GetSelfContainerID is not supported on non-linux platforms.
+func GetSelfContainerID() (string, error) {
+	return "", errors.New("not supported on this platform")
+}

--- a/comp/host-profiler/version/version.go
+++ b/comp/host-profiler/version/version.go
@@ -20,6 +20,7 @@ const (
 	StandaloneProfilerName = "host-profiler-standalone"
 	OTelProfilerNameKey    = "telemetry.distro.name"
 	OTelProfilerVersionKey = "telemetry.distro.version"
+	OTelContainerIDKey     = "container.id"
 )
 
 var ProfilerVersion = version.AgentVersion


### PR DESCRIPTION
### What does this PR do?

- adds a newly autogenerated resource processor for metrics that adds `container.id`.

### Motivation

Allows metrics to benefit from the same infraattributes/k8sattributes enrichment as profiles

### Describe how you validated your changes

Deployed on rel-env, picked a profiler metric and checked if that metric was tagged with `container.id`
[link](https://ddstaging.datadoghq.com/metric/explorer?fromUser=false&graph_layout=stacked&start=1782220465158&end=1782224065158&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyABG8oJOkRIAbnAu2lGawPLaOMJoOg0dyABUAAQA8gBKowhw-flxAHRQEBoFOIuR6iM8o9VYo8CZUggYojqL0DyLGBpOx3giCAAUAJQgPAC6VK7ueJihcK-VT-DAxUrxD7fEBrLD9GQgeQYfoIWbKKA4GD3AEaCCZRJuATaJz7ZRNZFmYogNDnJxyRTlHA0qCJGkiVr0JjKERuDxoD78VbyTBYOkKHLU85Qnh8GHC8QAYSkwhgKBE-zQPCAA)

### Additional Notes
