### PR TITLE
test(logs/status): close mutation-testing gaps in status builder & info

### DIFF
--- a/pkg/logs/status/builder_test.go
+++ b/pkg/logs/status/builder_test.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-present Datadog, Inc.
+
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/util/procfilestats"
+)
+
+// TestToDictionaryNetwork exercises the TCP and UDP branches of toDictionary, asserting that each
+// optional key is present (with the right value) when its field is set and absent when it is not.
+// This pins down the conditionals that decide whether TLS, Format, AllowedIPs and DeniedIPs appear.
+func TestToDictionaryNetwork(t *testing.T) {
+	b := &Builder{}
+
+	for _, networkType := range []string{config.TCPType, config.UDPType} {
+		t.Run(networkType+"/all fields set", func(t *testing.T) {
+			c := &config.LogsConfig{
+				Type:       networkType,
+				Service:    "svc",
+				Source:     "src",
+				Port:       8080,
+				Format:     config.SyslogFormat,
+				AllowedIPs: config.StringSliceField{"10.0.0.1", "10.0.0.2"},
+				DeniedIPs:  config.StringSliceField{"192.168.0.1"},
+			}
+			if networkType == config.TCPType {
+				c.TLS = &config.TLSListenerConfig{}
+			}
+			d := b.toDictionary(c)
+
+			assert.Equal(t, "svc", d["Service"])
+			assert.Equal(t, "src", d["Source"])
+			assert.Equal(t, 8080, d["Port"])
+			assert.Equal(t, config.SyslogFormat, d["Format"])
+			assert.Equal(t, "10.0.0.1, 10.0.0.2", d["AllowedIPs"])
+			assert.Equal(t, "192.168.0.1", d["DeniedIPs"])
+			if networkType == config.TCPType {
+				assert.Equal(t, "true", d["TLS"])
+			}
+		})
+
+		t.Run(networkType+"/optional fields empty", func(t *testing.T) {
+			c := &config.LogsConfig{
+				Type:    networkType,
+				Service: "svc",
+				Source:  "src",
+				Port:    8080,
+				// Format empty, no AllowedIPs/DeniedIPs, no TLS.
+			}
+			d := b.toDictionary(c)
+
+			assert.Equal(t, 8080, d["Port"])
+			assert.NotContains(t, d, "TLS")
+			assert.NotContains(t, d, "Format")
+			assert.NotContains(t, d, "AllowedIPs")
+			assert.NotContains(t, d, "DeniedIPs")
+		})
+	}
+}
+
+// TestToDictionaryTCPTLSOnly asserts TLS appears only when the TLS config is non-nil — the TCP-only
+// conditional that the UDP case does not have.
+func TestToDictionaryTCPTLSOnly(t *testing.T) {
+	b := &Builder{}
+
+	withTLS := b.toDictionary(&config.LogsConfig{Type: config.TCPType, Service: "s", Port: 1, TLS: &config.TLSListenerConfig{}})
+	assert.Equal(t, "true", withTLS["TLS"])
+
+	withoutTLS := b.toDictionary(&config.LogsConfig{Type: config.TCPType, Service: "s", Port: 1})
+	assert.NotContains(t, withoutTLS, "TLS")
+}
+
+// TestToDictionaryDropsEmptyStrings asserts the final pass removes keys whose value is an empty
+// string (and keeps non-empty ones), without removing non-string values like Port.
+func TestToDictionaryDropsEmptyStrings(t *testing.T) {
+	b := &Builder{}
+
+	d := b.toDictionary(&config.LogsConfig{Type: config.TCPType, Service: "", Source: "src", Port: 0})
+	assert.NotContains(t, d, "Service", "empty Service should be dropped")
+	assert.Equal(t, "src", d["Source"], "non-empty Source should be kept")
+	assert.Contains(t, d, "Port", "Port is an int and must not be dropped even when 0")
+	assert.Equal(t, 0, d["Port"])
+}
+
+// TestGetProcessFileStatsPopulatedOnSuccess asserts that when process file stats are available,
+// getProcessFileStats returns them (not an empty map) — pinning the err==nil fall-through path.
+// Skips on platforms where the underlying call is unavailable so the test never flakes.
+func TestGetProcessFileStatsPopulatedOnSuccess(t *testing.T) {
+	if _, err := procfilestats.GetProcessFileStats(); err != nil {
+		t.Skipf("process file stats unavailable on this platform: %v", err)
+	}
+
+	stats := (&Builder{}).getProcessFileStats()
+	assert.Contains(t, stats, "CoreAgentProcessOpenFiles")
+	assert.Contains(t, stats, "OSFileLimit")
+}

--- a/pkg/logs/status/utils/info_test.go
+++ b/pkg/logs/status/utils/info_test.go
@@ -33,3 +33,26 @@ func TestInfoRegistryReplace(t *testing.T) {
 	assert.Equal(t, "1", all[0].InfoKey())
 	assert.Equal(t, "10", all[0].Info()[0])
 }
+
+// emptyInfoProvider is an InfoProvider that reports no messages.
+type emptyInfoProvider struct{ key string }
+
+func (e emptyInfoProvider) InfoKey() string { return e.key }
+func (e emptyInfoProvider) Info() []string  { return []string{} }
+
+// TestInfoRegistryRenderedSkipsEmpty asserts Rendered() includes providers that have info and
+// omits providers whose Info() is empty.
+func TestInfoRegistryRenderedSkipsEmpty(t *testing.T) {
+	reg := NewInfoRegistry()
+
+	populated := NewCountInfo("populated")
+	populated.Add(1)
+	reg.Register(populated)
+	reg.Register(emptyInfoProvider{key: "empty"})
+
+	rendered := reg.Rendered()
+
+	assert.Contains(t, rendered, "populated")
+	assert.Equal(t, []string{"1"}, rendered["populated"])
+	assert.NotContains(t, rendered, "empty")
+}


### PR DESCRIPTION
### What does this PR do?

Adds unit tests to `pkg/logs/status` that close concrete test gaps surfaced by a mutation-testing run. Test-only change, no production code touched.

- **`builder.go` `toDictionary()`** — `builder_test.go` exercises the TCP and UDP branches, asserting each optional key (`TLS`, `Format`, `AllowedIPs`, `DeniedIPs`) is present-with-value when set and absent when unset, the TLS-only TCP case, and that the empty-string cleanup drops empty values while keeping non-strings like `Port`.
- **`builder.go` `getProcessFileStats()`** — asserts stats are populated on success (skips where the platform call is unavailable, so it never flakes).
- **`utils/info.go` `Rendered()`** — asserts providers with empty `Info()` are omitted and populated ones included.

### Motivation

`pkg/logs/status` scored **29.6%** on a mutation-testing pass (status builder was effectively untested — `builder.go` at 7.1%). Each surviving mutant is a line whose behavior no test asserted. These tests kill every *killable* surviving mutant in the package.

Result after this PR (re-run on the same harness): `pkg/logs/status/utils` → **100%**; `builder.go` → all conditional-negation and the file-stats mutants killed.

**Four surviving mutants in `builder.go` are intentionally left** — they are **equivalent mutants**: the `len(c.AllowedIPs) > 0` / `len(c.DeniedIPs) > 0` guards (lines 177, 180, 188, 191) mutate `>` to `>=`. Since `len()` is never negative, `>= 0` is always true, but the resulting `strings.Join` of an empty slice produces `""`, which the subsequent empty-string cleanup deletes — so the output is identical and no test can distinguish them. Not worth a production change to make them killable.

### Describe how you validated your changes

`dda inv test --targets=./pkg/logs/status` and `./pkg/logs/status/utils` pass; re-ran the mutation harness to confirm the targeted mutants are now killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)