### PR TITLE
fix: change issuer and subject according to dd-octo-sts spec for both staging and prod

### DIFF
--- a/.github/chainguard/release-dashboard-api-staging.sts.yaml
+++ b/.github/chainguard/release-dashboard-api-staging.sts.yaml
@@ -1,6 +1,8 @@
 # Issued to: rapid-agent-delivery/release-dashboard-api on us1 staging
-issuer: https://ticino.identity.local-cluster.local-dc.fabric.dog:8443/v1/issuer/sycamore
-subject: rapid-agent-delivery.release-dashboard-api@kubernetes.us1.staging.dog
+issuer: https://vault.us1.staging.dog/v1/identity/oidc
+
+# ddtool auth whois --datacenter us1.staging.dog rapid-agent-delivery-release-dashboard-api --format json | jq -r .id
+subject: baf59598-c4eb-7bb7-e96b-d5557dfe4ed9
 
 permissions:
   contents: read

--- a/.github/chainguard/release-dashboard-api.sts.yaml
+++ b/.github/chainguard/release-dashboard-api.sts.yaml
@@ -1,6 +1,8 @@
 # Issued to: rapid-agent-delivery/release-dashboard-api on us1 prod
-issuer: https://ticino.identity.local-cluster.local-dc.fabric.dog:8443/v1/issuer/sycamore
-subject: rapid-agent-delivery.release-dashboard-api@kubernetes.us1.prod.dog
+issuer: https://vault.us1.prod.dog/v1/identity/oidc
+
+# ddtool auth whois --datacenter us1.prod.dog rapid-agent-delivery-release-dashboard-api --format json | jq -r .id
+subject: ccd54910-9533-855e-e357-49e2d692b508
 
 permissions:
   contents: read


### PR DESCRIPTION
### What does this PR do?
- Changes issuer from Ticino to Vault since our service [has isp: True](https://github.com/DataDog/dd-source/blob/main/domains/agent_delivery/apps/apis/release-dashboard-api/rapid.json) (uses the ISP sidecar to authenticate — that issues Vault OIDC tokens)
- Changes the subject to a UUID for Vault issuer accornding to the [spec](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/6134465533/ID+tokens+reference+for+Datadog+services#%3Ahashicorp-vault-better%3A-Vault)
- Changes applied for both staging and prod

 ## Tests
- Only able to test after merge