### PR TITLE
Fix flaky `TestSCPCommand` (SCP fixture race)

### DIFF
--- a/pkg/networkconfigmanagement/remote/cmd_test.go
+++ b/pkg/networkconfigmanagement/remote/cmd_test.go
@@ -100,8 +100,8 @@ func TestSCPCommand(t *testing.T) {
 		name: "unchecked_command",
 		op: func(shell *ShellContext) uint32 {
 			shell.stdout.Write([]byte{0, 0})
-			// wait for the other end to write some data so we don't close stdin early
-			shell.stdin.ReadByte()
+			// wait for the other end to *finish* writing so we don't close stdin early
+			io.Copy(io.Discard, shell.stdin)
 			return 0
 		},
 		expected: "",
@@ -130,8 +130,8 @@ func TestSCPCommand(t *testing.T) {
 		name: "validate_response",
 		op: func(shell *ShellContext) uint32 {
 			io.WriteString(shell.stdout, "\x00\x00returning feedback")
-			// wait for the other end to write some data so we don't close shell.stdin early
-			shell.stdin.ReadByte()
+			// wait for the other end to *finish* writing so we don't close shell.stdin early
+			io.Copy(io.Discard, shell.stdin)
 			return 0
 		},
 		validator: profile.Validator{
@@ -144,8 +144,8 @@ func TestSCPCommand(t *testing.T) {
 		name: "invalid_response",
 		op: func(shell *ShellContext) uint32 {
 			io.WriteString(shell.stdout, "\x00\x00incorrect response")
-			// wait for the other end to write some data so we don't close shell.stdin early
-			shell.stdin.Read(make([]byte, 100))
+			// wait for the other end to *finish* writing so we don't close shell.stdin early
+			io.Copy(io.Discard, shell.stdin)
 			return 0
 		},
 		validator: profile.Validator{


### PR DESCRIPTION
### What does this PR do?
Drain stdin to EOF in the fake SCP server ops instead of reading a fixed number of bytes.

### Motivation
`TestSCPCommand/unchecked_command` failed intermittently (~7% locally) with `scp command ... failed: unexpected EOF`:
```
==================== Test output for //pkg/networkconfigmanagement/remote:remote_test:
--- FAIL: TestSCPCommand (0.07s)
    --- FAIL: TestSCPCommand/validate_response (0.01s)
        cmd_test.go:170:
            	Error Trace:	pkg/networkconfigmanagement/remote/cmd_test.go:170
            	Error:      	Received unexpected error:
            	            	scp command "scp -t '/mnt/flash/backup.txt'" failed: unexpected EOF
            	Test:       	TestSCPCommand/validate_response
FAIL
================================================================================
```
Example, in CI: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1742575749#L2446.

The SCP client writes stdin in two phases: first the control line, then the data payload.
The fixture op only read a few bytes, which unblocks as soon as the control line arrives, so the op returned and the channel closed while the client was still writing the data.
Losing that race turned the client's data write into an EOF, surfaced as `io.ErrUnexpectedEOF`.

### Describe how you validated your changes
- before: 22 failures over 300 runs of the affected subtest,
- after: 600/600 runs of the full `TestSCPCommand` suite pass, plus a clean `go test -race -count=3` of the package.

### Additional Notes
_A real `scp -t` server would consume both the control line and the data before exiting_, so the fixture now better mimicks the protocol.