### PR TITLE
configfilesdiscovery: add redis collector

### DIFF
--- a/comp/core/configfilesdiscovery/impl/BUILD.bazel
+++ b/comp/core/configfilesdiscovery/impl/BUILD.bazel
@@ -6,6 +6,8 @@ go_library(
         "configfilesdiscovery.go",
         "docker_reader.go",
         "docker_reader_nodocker.go",
+        "helpers.go",
+        "redis_collector.go",
         "scheduler.go",
         "types.go",
     ],
@@ -42,6 +44,7 @@ go_test(
     srcs = [
         "configfilesdiscovery_test.go",
         "docker_reader_test.go",
+        "redis_collector_test.go",
     ],
     embed = [":impl"],
     gotags = ["test"],

--- a/comp/core/configfilesdiscovery/impl/configfilesdiscovery.go
+++ b/comp/core/configfilesdiscovery/impl/configfilesdiscovery.go
@@ -44,10 +44,12 @@ func newComponent(
 	readers := map[RuntimeType]configReaderFactory{
 		RuntimeDocker: newDockerConfigReader,
 	}
-	collectors := map[string]configCollector{}
+	collectors := map[string]configCollector{
+		redisIntegrationName: newRedisConfigCollector(),
+	}
 	return &component{
 		ad:        ad,
-		scheduler: newADScheduler(resolver, readers, collectors),
+		scheduler: newADScheduler(resolver, readers, collectors, noopConfigFileReporter{}),
 	}
 }
 

--- a/comp/core/configfilesdiscovery/impl/configfilesdiscovery_test.go
+++ b/comp/core/configfilesdiscovery/impl/configfilesdiscovery_test.go
@@ -201,6 +201,7 @@ func TestSchedulerDispatchesRegisteredIntegrationsOnly(t *testing.T) {
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeHost: readerFactory.Build},
 		map[string]configCollector{"redis": collector},
+		nil,
 	)
 	defer s.Stop()
 
@@ -225,6 +226,7 @@ func TestSchedulerContinuesAfterInvalidConfigInBatch(t *testing.T) {
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
 		map[string]configCollector{"redis": collector},
+		nil,
 	)
 	defer s.Stop()
 
@@ -246,6 +248,7 @@ func TestSchedulerRunsCollectorOutsideScheduleCallback(t *testing.T) {
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeHost: readerFactory.Build},
 		map[string]configCollector{"redis": collector},
+		nil,
 	)
 	defer s.Stop()
 
@@ -268,6 +271,40 @@ func TestSchedulerRunsCollectorOutsideScheduleCallback(t *testing.T) {
 	collector.waitForRuns(t, 1)
 }
 
+func TestSchedulerReportsCollectedFiles(t *testing.T) {
+	reporter := &recordingConfigFileReporter{}
+	collector := &recordingConfigCollector{
+		files: []ConfigFile{
+			{
+				Path:      "/etc/redis/redis.conf",
+				Content:   []byte("port 6379\n"),
+				Truncated: true,
+			},
+		},
+	}
+	s := newADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]configCollector{redisIntegrationName: collector},
+		reporter,
+	)
+	defer s.Stop()
+
+	s.Schedule([]integration.Config{
+		checkConfig(redisIntegrationName, "docker://abc123"),
+	})
+
+	reports := reporter.waitForReports(t, 1)
+	assert.Equal(t, configFileReportCall{
+		integration: redisIntegrationName,
+		file: ConfigFile{
+			Path:      "/etc/redis/redis.conf",
+			Content:   []byte("port 6379\n"),
+			Truncated: true,
+		},
+	}, reports[0])
+}
+
 func TestComponentRegistersAutodiscoverySchedulerOnStart(t *testing.T) {
 	ac := &fakeAutodiscovery{}
 	lifecycle := &recordingLifecycle{}
@@ -286,6 +323,14 @@ func TestComponentRegistersAutodiscoverySchedulerOnStart(t *testing.T) {
 	require.NotNil(t, lifecycle.hook.OnStop)
 	require.NoError(t, lifecycle.hook.OnStop(context.Background()))
 	assert.Equal(t, schedulerName, ac.removedName)
+}
+
+func TestComponentRegistersRedisCollector(t *testing.T) {
+	c := newComponent(nil, targetResolver{})
+	adScheduler, ok := c.scheduler.(*adScheduler)
+	require.True(t, ok)
+
+	assert.Contains(t, adScheduler.collectors, redisIntegrationName)
 }
 
 func checkConfig(name string, serviceID string) integration.Config {
@@ -310,17 +355,19 @@ type recordingConfigCollector struct {
 	mu      sync.Mutex
 	runs    []runCall
 	unblock chan struct{}
+	files   []ConfigFile
+	err     error
 }
 
 type runCall struct {
 	reader ConfigReader
 }
 
-func (c *recordingConfigCollector) Run(ctx context.Context, reader ConfigReader) error {
+func (c *recordingConfigCollector) Collect(ctx context.Context, reader ConfigReader) ([]ConfigFile, error) {
 	if c.unblock != nil {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil, ctx.Err()
 		case <-c.unblock:
 		}
 	}
@@ -330,7 +377,44 @@ func (c *recordingConfigCollector) Run(ctx context.Context, reader ConfigReader)
 	c.runs = append(c.runs, runCall{
 		reader: reader,
 	})
-	return nil
+	return c.files, c.err
+}
+
+type configFileReportCall struct {
+	integration string
+	file        ConfigFile
+}
+
+type recordingConfigFileReporter struct {
+	mu      sync.Mutex
+	reports []configFileReportCall
+	err     error
+}
+
+func (r *recordingConfigFileReporter) ReportConfigFile(_ context.Context, integration string, file ConfigFile) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reports = append(r.reports, configFileReportCall{
+		integration: integration,
+		file:        file,
+	})
+	return r.err
+}
+
+func (r *recordingConfigFileReporter) waitForReports(t *testing.T, count int) []configFileReportCall {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		return len(r.reports) >= count
+	}, time.Second, 10*time.Millisecond)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	reports := make([]configFileReportCall, len(r.reports))
+	copy(reports, r.reports)
+	return reports
 }
 
 func (c *recordingConfigCollector) waitForRuns(t *testing.T, count int) []runCall {

--- a/comp/core/configfilesdiscovery/impl/helpers.go
+++ b/comp/core/configfilesdiscovery/impl/helpers.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package configfilesdiscoveryimpl
+
+import (
+	"path"
+	"strings"
+)
+
+func commandlineArgs(commandline TargetCommandline) []string {
+	return unwrapShellCommandline(commandline.Args)
+}
+
+func unwrapShellCommandline(args []string) []string {
+	if len(args) < 3 || !isShellExecutable(args[0]) || args[1] != "-c" {
+		return args
+	}
+	return strings.Fields(args[2])
+}
+
+func isShellExecutable(arg string) bool {
+	switch path.Base(arg) {
+	case "sh", "bash", "dash", "ash", "zsh":
+		return true
+	default:
+		return false
+	}
+}

--- a/comp/core/configfilesdiscovery/impl/redis_collector.go
+++ b/comp/core/configfilesdiscovery/impl/redis_collector.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package configfilesdiscoveryimpl
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const redisIntegrationName = "redisdb"
+
+type redisConfigCollector struct{}
+
+func newRedisConfigCollector() configCollector {
+	return redisConfigCollector{}
+}
+
+func (c redisConfigCollector) Collect(ctx context.Context, reader ConfigReader) ([]ConfigFile, error) {
+	commandline, err := reader.ReadCommandline(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read redis command line: %w", err)
+	}
+
+	configPath, ok := redisGetConfigPath(commandline)
+	if !ok {
+		log.Debugf("config files discovery skipped redis config collection: no explicit config file path detected")
+		return nil, nil
+	}
+
+	file, err := reader.ReadFile(ctx, configPath)
+	if err != nil {
+		return nil, fmt.Errorf("read redis config file %q: %w", configPath, err)
+	}
+
+	return []ConfigFile{file}, nil
+}
+
+// redisGetConfigPath returns the explicit config file path passed to
+// redis-server. Redis also accepts command-line options as temporary config,
+// but those options do not identify a file this collector can read.
+func redisGetConfigPath(commandline TargetCommandline) (string, bool) {
+	args := commandlineArgs(commandline)
+	redisArgs, ok := redisGetArgs(args)
+	if !ok {
+		return "", false
+	}
+
+	configPath, ok := redisGetConfigArg(redisArgs)
+	if !ok {
+		return "", false
+	}
+	return redisResolveConfigPath(configPath, commandline.WorkingDir)
+}
+
+func redisGetArgs(args []string) ([]string, bool) {
+	for i, arg := range args {
+		if path.Base(arg) == "redis-server" {
+			return args[i+1:], true
+		}
+	}
+	return nil, false
+}
+
+// redisGetConfigArg returns the positional config path that redis-server
+// accepts before command-line options. A flags-only startup is intentionally
+// skipped because it has no config file to read.
+func redisGetConfigArg(redisArgs []string) (string, bool) {
+	if len(redisArgs) == 0 || redisArgs[0] == "" || strings.HasPrefix(redisArgs[0], "-") {
+		return "", false
+	}
+	return redisArgs[0], true
+}
+
+func redisResolveConfigPath(configPath string, workingDir string) (string, bool) {
+	if configPath == "" || strings.ContainsRune(configPath, 0) {
+		return "", false
+	}
+	if path.IsAbs(configPath) {
+		return path.Clean(configPath), true
+	}
+	if !path.IsAbs(workingDir) {
+		return "", false
+	}
+	return path.Clean(path.Join(workingDir, configPath)), true
+}

--- a/comp/core/configfilesdiscovery/impl/redis_collector_test.go
+++ b/comp/core/configfilesdiscovery/impl/redis_collector_test.go
@@ -1,0 +1,225 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package configfilesdiscoveryimpl
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedisGetConfigPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		commandline TargetCommandline
+		wantPath    string
+		wantOK      bool
+	}{
+		{
+			name: "official docker custom config",
+			commandline: TargetCommandline{
+				Args: []string{
+					"docker-entrypoint.sh",
+					"redis-server",
+					"/usr/local/etc/redis/redis.conf",
+				},
+			},
+			wantPath: "/usr/local/etc/redis/redis.conf",
+			wantOK:   true,
+		},
+		{
+			name: "explicit redis command",
+			commandline: TargetCommandline{
+				Args: []string{"redis-server", "/etc/redis/redis.conf"},
+			},
+			wantPath: "/etc/redis/redis.conf",
+			wantOK:   true,
+		},
+		{
+			name: "redis full config",
+			commandline: TargetCommandline{
+				Args: []string{"redis-server", "/etc/redis/redis-full.conf"},
+			},
+			wantPath: "/etc/redis/redis-full.conf",
+			wantOK:   true,
+		},
+		{
+			name: "relative path",
+			commandline: TargetCommandline{
+				Args:       []string{"redis-server", "redis.conf"},
+				WorkingDir: "/usr/local/etc/redis",
+			},
+			wantPath: "/usr/local/etc/redis/redis.conf",
+			wantOK:   true,
+		},
+		{
+			name: "relative path with docker default working dir",
+			commandline: TargetCommandline{
+				Args:       []string{"redis-server", "redis.conf"},
+				WorkingDir: "/",
+			},
+			wantPath: "/redis.conf",
+			wantOK:   true,
+		},
+		{
+			name: "arbitrary config filename",
+			commandline: TargetCommandline{
+				Args: []string{"redis-server", "/usr/local/etc/redis/foo.bar"},
+			},
+			wantPath: "/usr/local/etc/redis/foo.bar",
+			wantOK:   true,
+		},
+		{
+			name: "direct config path without redis server",
+			commandline: TargetCommandline{
+				Args: []string{"/usr/local/etc/redis/redis.conf"},
+			},
+		},
+		{
+			name: "default startup",
+			commandline: TargetCommandline{
+				Args: []string{"redis-server"},
+			},
+		},
+		{
+			name: "flags only",
+			commandline: TargetCommandline{
+				Args: []string{"redis-server", "--save", "60", "1", "--loglevel", "warning"},
+			},
+		},
+		{
+			name: "shell form",
+			commandline: TargetCommandline{
+				Args: []string{"/bin/sh", "-c", "redis-server /etc/redis/redis.conf"},
+			},
+			wantPath: "/etc/redis/redis.conf",
+			wantOK:   true,
+		},
+		{
+			name: "non redis command",
+			commandline: TargetCommandline{
+				Args: []string{"nginx", "-c", "/etc/nginx/nginx.conf"},
+			},
+		},
+		{
+			name: "relative path without absolute working dir",
+			commandline: TargetCommandline{
+				Args: []string{"redis-server", "redis.conf"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, gotOK := redisGetConfigPath(tt.commandline)
+
+			assert.Equal(t, tt.wantOK, gotOK)
+			assert.Equal(t, tt.wantPath, gotPath)
+		})
+	}
+}
+
+func TestRedisCollectorReadsDetectedConfig(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		commandline: TargetCommandline{
+			Args: []string{"redis-server", "/etc/redis/redis.conf"},
+		},
+		file: ConfigFile{
+			Path:      "/etc/redis/redis.conf",
+			Content:   []byte("port 6379\n"),
+			Truncated: true,
+		},
+	}
+	collector := newRedisConfigCollector()
+
+	files, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
+	require.Len(t, files, 1)
+	assert.Equal(t, ConfigFile{
+		Path:      "/etc/redis/redis.conf",
+		Content:   []byte("port 6379\n"),
+		Truncated: true,
+	}, files[0])
+}
+
+func TestRedisCollectorSkipsWhenNoConfigPathIsDetected(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		commandline: TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+	}
+	collector := newRedisConfigCollector()
+
+	files, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, files)
+}
+
+func TestRedisCollectorReturnsCommandlineErrors(t *testing.T) {
+	expectedErr := errors.New("command line unavailable")
+	reader := &redisCollectorTestReader{commandlineErr: expectedErr}
+	collector := newRedisConfigCollector()
+
+	files, err := collector.Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Nil(t, files)
+}
+
+func TestRedisCollectorReturnsReadFileErrors(t *testing.T) {
+	expectedErr := errors.New("read failed")
+	reader := &redisCollectorTestReader{
+		commandline: TargetCommandline{
+			Args: []string{"redis-server", "/etc/redis/redis.conf"},
+		},
+		readFileErr: expectedErr,
+	}
+	collector := newRedisConfigCollector()
+
+	files, err := collector.Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
+	assert.Nil(t, files)
+}
+
+type redisCollectorTestReader struct {
+	commandline    TargetCommandline
+	commandlineErr error
+	readFileCalls  []string
+	file           ConfigFile
+	readFileErr    error
+}
+
+func (r *redisCollectorTestReader) Runtime() RuntimeType {
+	return RuntimeDocker
+}
+
+func (r *redisCollectorTestReader) ReadFile(_ context.Context, path string) (ConfigFile, error) {
+	r.readFileCalls = append(r.readFileCalls, path)
+	if r.readFileErr != nil {
+		return ConfigFile{}, r.readFileErr
+	}
+	return r.file, nil
+}
+
+func (r *redisCollectorTestReader) ReadEnvVars(context.Context, []string) (map[string]string, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r *redisCollectorTestReader) ReadCommandline(context.Context) (TargetCommandline, error) {
+	if r.commandlineErr != nil {
+		return TargetCommandline{}, r.commandlineErr
+	}
+	return r.commandline, nil
+}

--- a/comp/core/configfilesdiscovery/impl/scheduler.go
+++ b/comp/core/configfilesdiscovery/impl/scheduler.go
@@ -23,6 +23,7 @@ type adScheduler struct {
 	resolver   targetResolver
 	readers    map[RuntimeType]configReaderFactory
 	collectors map[string]configCollector
+	reporter   configFileReporter
 
 	ctx             context.Context
 	cancel          context.CancelFunc
@@ -40,16 +41,31 @@ type configCollectionWork struct {
 	readerFactory configReaderFactory
 }
 
+type configFileReporter interface {
+	ReportConfigFile(context.Context, string, ConfigFile) error
+}
+
+type noopConfigFileReporter struct{}
+
+func (noopConfigFileReporter) ReportConfigFile(context.Context, string, ConfigFile) error {
+	return nil
+}
+
 // newADScheduler builds the object registered with autodiscovery.
 // Autodiscovery calls this scheduler when integration configs appear or
 // disappear; this component only uses the scheduled configs as triggers for
 // one-shot config collection.
-func newADScheduler(resolver targetResolver, readers map[RuntimeType]configReaderFactory, collectors map[string]configCollector) *adScheduler {
+func newADScheduler(resolver targetResolver, readers map[RuntimeType]configReaderFactory, collectors map[string]configCollector, reporter configFileReporter) *adScheduler {
+	if reporter == nil {
+		reporter = noopConfigFileReporter{}
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &adScheduler{
 		resolver:        resolver,
 		readers:         readers,
 		collectors:      collectors,
+		reporter:        reporter,
 		ctx:             ctx,
 		cancel:          cancel,
 		collectionQueue: make(chan configCollectionWork, configCollectionQueueSize),
@@ -119,14 +135,28 @@ func (s *adScheduler) runCollection(work configCollectionWork) {
 		return
 	}
 
-	if err := work.collector.Run(s.ctx, reader); err != nil {
+	files, err := work.collector.Collect(s.ctx, reader)
+	if err != nil {
 		select {
 		case <-s.ctx.Done():
 			return
 		default:
-			log.Warnf("failed to run config files discovery for integration %q service %q: %v", work.config.Name, work.config.ServiceID, err)
+			log.Warnf("failed to collect config files for integration %q service %q: %v", work.config.Name, work.config.ServiceID, err)
 			return
 		}
+	}
+
+	for _, file := range files {
+		if err := s.reporter.ReportConfigFile(s.ctx, work.config.Name, file); err != nil {
+			select {
+			case <-s.ctx.Done():
+				return
+			default:
+				log.Warnf("failed to report config file for integration %q service %q path %q: %v", work.config.Name, work.config.ServiceID, file.Path, err)
+				continue
+			}
+		}
+		log.Debugf("config files discovery collected config file: integration %q path %q size_bytes %d truncated %t", work.config.Name, file.Path, len(file.Content), file.Truncated)
 	}
 }
 

--- a/comp/core/configfilesdiscovery/impl/types.go
+++ b/comp/core/configfilesdiscovery/impl/types.go
@@ -54,7 +54,7 @@ type ConfigReader interface {
 type configReaderFactory func(target) (ConfigReader, error)
 
 type configCollector interface {
-	Run(context.Context, ConfigReader) error
+	Collect(context.Context, ConfigReader) ([]ConfigFile, error)
 }
 
 type targetResolver struct {


### PR DESCRIPTION
### What does this PR do?

This PR adds a Redis config collector for config discovery.

It works by getting the configuration file path from the Redis commandline, reads it using the provided config reader.

### Motivation

DSCVR-458

### Describe how you validated your changes

Covered by unit tests + manual testing with Redis Docker containers (currently, only the docker config reader is implemented)

### Additional Notes
