### PR TITLE
Remove curl from cluster-agent image

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -57,7 +57,7 @@ ENV PATH="/opt/datadog-agent/bin/:$PATH" \
 
 RUN apt-get update \
     && apt full-upgrade -y \
-    && apt-get install --no-install-recommends -y ca-certificates curl libseccomp2 tzdata adduser\
+    && apt-get install --no-install-recommends -y ca-certificates libseccomp2 tzdata adduser\
     && rm -rf \
       /var/cache/debconf/*-old \
       /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary

Remove `curl` from the cluster-agent image runtime package list. Local `dda inv cluster-agent.image-build` comparison showed a smaller image when `curl` is omitted.

Local measurements:
- Flattened filesystem export: 268.02 MiB -> 262.68 MiB (-5.34 MiB)
- Gzipped flattened export: 93.53 MiB -> 91.33 MiB (-2.21 MiB)

CI static quality gates should provide the authoritative comparison.

## Tests

- `dda inv cluster-agent.image-build --arch amd64 --tag datadog/cluster-agent:size-with-curl`
- `dda inv cluster-agent.image-build --arch amd64 --tag datadog/cluster-agent:size-no-curl`
- pre-push hooks passed