### PR TITLE
Fix error.msg not being set when http.response.status_code is an integer

### DIFF
--- a/pkg/trace/transform/transform.go
+++ b/pkg/trace/transform/transform.go
@@ -318,10 +318,7 @@ func OtelSpanToDDSpan(
 	if msg := otelspan.Status().Message(); msg != "" {
 		ddspan.Meta[string(semconv.OtelStatusDescriptionKey)] = msg
 	}
-
-	if !spanMetaHasKey(ddspan, "error.msg") || !spanMetaHasKey(ddspan, "error.type") || !spanMetaHasKey(ddspan, "error.stack") {
-		ddspan.Error = Status2Error(otelspan.Status(), otelspan.Events(), ddspan.Meta)
-	}
+	SetErrorMsg(ddspan, otelspan.Status(), spanAccessor)
 
 	if !spanMetaHasKey(ddspan, "env") {
 		if env := LookupSemanticStringWithAccessor(spanAccessor, semantics.ConceptDeploymentEnv, true); env != "" {
@@ -564,6 +561,30 @@ func SetMetricOTLPIfEmpty(s *pb.Span, k string, v float64) {
 	}
 	if _, ok := s.Metrics[key]; !ok {
 		s.Metrics[key] = v
+	}
+}
+
+// SetErrorMsg checks the given status and sets error.msg when appropriate.
+func SetErrorMsg(s *pb.Span, status ptrace.Status, accessor semantics.Accessor) {
+	if _, ok := s.Meta["error.msg"]; s.Error == 0 || ok {
+		// Not an error span, or error message already set
+		return
+	}
+	if status.Message() != "" {
+		// Use the status message
+		s.Meta["error.msg"] = status.Message()
+		return
+	}
+	httpCode, ok := semantics.LookupInt64(semantics.DefaultRegistry(), accessor, semantics.ConceptHTTPStatusCode)
+	// If the status code is in the 1xx, 2xx, or 3xx range, the error must be unrelated
+	// See https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+	if !ok || (100 <= httpCode && httpCode <= 399) {
+		return
+	}
+	if statusText := http.StatusText(int(httpCode)); int64(int(httpCode)) == httpCode && statusText != "" {
+		s.Meta["error.msg"] = fmt.Sprintf("%d %s", httpCode, statusText)
+	} else {
+		s.Meta["error.msg"] = fmt.Sprintf("%d", httpCode)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

The OTel span conversion code used to have logic in `Status2Error` setting `error.msg` to the HTTP status code when no span status message is provided (optionally with `http.status_text` after it, but that attribute is long deprecated).

I believe #33753 accidentally broke this behavior, by no longer mapping `http.response.status_code` to `span.Meta` (only `span.Metrics`, since it's normally an integer attribute), which `Status2Error` relies on.

In #44025, I later attempted to improve the logic by inferring the status text from the status code instead of `http.status_text`. Ironically, I now believe this may have only modified behavior in the deprecated `receiveResourceSpansV1` code path, which also uses `Status2Error`, and still sets the `span.Meta` key.

In #46222, `Status2Error` was modified again to use the semantics SDK for looking up keys, but was still restricted to using `span.Meta`.

To avoid more breaking changes to the old code path, this PR introduces a new function, `SetErrorMsg`, which now uses the attributes of the original span to get the status code. It also no longer returns the value of `span.Error`, which is set at the very beginning of `otelSpanToDDSpanMinimal` anyway.

### Motivation

I noticed that `error.msg` (or `error.message`? I believe there may be some backend-side renaming) is never set on error spans that don't contain a span status message, even when they have an HTTP status code.

### Describe how you validated your changes

### Additional Notes
