### PR TITLE
CODEOWNERS: Update codeowners for ./pkg/util/filesystem

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -627,7 +627,8 @@
 /pkg/util/docker/                       @DataDog/container-integrations
 /pkg/util/ecs/                          @DataDog/ecs-experiences
 /pkg/util/fargate/                      @DataDog/ecs-experiences
-/pkg/util/filesystem/                   @DataDog/agent-runtimes @DataDog/agent-configuration
+/pkg/util/filesystem/                   @DataDog/agent-runtimes
+/pkg/util/filesystem/rights_*.go        @DataDog/agent-configuration
 /pkg/util/funcs/                        @DataDog/ebpf-platform
 /pkg/util/gpu/                          @DataDog/container-platform
 /pkg/util/installinfo/                  @DataDog/agent-configuration


### PR DESCRIPTION
### What does this PR do?

Before: `@DataDog/agent-runtimes` and `@DataDog/agent-configuration` were co-owners of `/pkg/util/filesystem/`.

Now: `@DataDog/agent-configuration` owns `rights_*.go` files under `/pkg/util/filesystem/`. The rest of the directory remains under `@DataDog/agent-runtimes`.

### Motivation
Better separation of ownership

### Describe how you validated your changes
CODEOWNERS syntax checked.

### Additional Notes