### PR TITLE
Remove adduser from agent image

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -224,7 +224,8 @@ RUN [ "$(getent passwd dd-agent | cut -d: -f 3)" -eq 100 ]
 # cleaning up
 # We remove /etc/ssl because in JMX images, openjdk triggers installation of ca-certificates-java
 # which writes to /etc/ssl. Yet, in the Agent we only rely on certs shipped in the Agent package.
-RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/ssl
+RUN apt-get purge -y adduser \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/ssl
 RUN ln -sf /opt/datadog-agent/embedded/ssl /etc/ssl
 
 # Enable FIPS if needed


### PR DESCRIPTION
## Summary

Purge `adduser` from the Agent image after the Dockerfile has finished creating the `dd-agent` user and `secret-manager` group. This keeps `adduser` available for build-time user/group setup while removing it from the final image filesystem.

This is a small image-size cleanup; CI static quality gates should provide the authoritative size comparison.

## Tests

- pre-commit hooks passed during `git commit`
- pre-push hooks passed during `git push`
- no Docker image builds run, per request