### PR TITLE
test(logs/launchers/file): cover position fingerprint-alignment branches

### DIFF
--- a/pkg/logs/launchers/file/position_test.go
+++ b/pkg/logs/launchers/file/position_test.go
@@ -90,3 +90,55 @@ func TestPosition(t *testing.T) {
 	assert.Equal(t, int64(0), offset)
 	assert.Equal(t, io.SeekEnd, whence)
 }
+
+// TestPositionFingerprintAlignment covers the fingerprint-comparison branches that TestPosition
+// never reaches (its identifiers are too short to yield a non-empty file path). It uses an
+// identifier longer than the 5-char prefix so Position derives a file path and consults the
+// fingerprinter.
+func TestPositionFingerprintAlignment(t *testing.T) {
+	const identifier = "file:abc" // len > 5, so filePath = "abc"
+	cfg := &types.FingerprintConfig{
+		MaxBytes:            2048,
+		Count:               1,
+		CountToSkip:         0,
+		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+	}
+
+	t.Run("fingerprints align: stored offset is used", func(t *testing.T) {
+		registry := auditorMock.NewMockRegistry()
+		fp := file.NewFingerprinterMock()
+		registry.SetOffset(identifier, "555")
+		registry.SetFingerprint(&types.Fingerprint{Value: 12345, Config: cfg})
+		fp.SetFingerprint("abc", &types.Fingerprint{Value: 12345, Config: cfg})
+
+		offset, whence, err := Position(registry, identifier, config.End, fp)
+		assert.Nil(t, err)
+		assert.Equal(t, int64(555), offset)
+		assert.Equal(t, io.SeekStart, whence)
+	})
+
+	t.Run("fingerprints differ: restart from beginning despite stored offset", func(t *testing.T) {
+		registry := auditorMock.NewMockRegistry()
+		fp := file.NewFingerprinterMock()
+		registry.SetOffset(identifier, "555")
+		registry.SetFingerprint(&types.Fingerprint{Value: 12345, Config: cfg})
+		fp.SetFingerprint("abc", &types.Fingerprint{Value: 99999, Config: cfg})
+
+		offset, whence, err := Position(registry, identifier, config.End, fp)
+		assert.Nil(t, err)
+		assert.Equal(t, int64(0), offset)
+		assert.Equal(t, io.SeekStart, whence)
+	})
+
+	t.Run("no previous fingerprint: stored offset is used", func(t *testing.T) {
+		registry := auditorMock.NewMockRegistry()
+		fp := file.NewFingerprinterMock()
+		registry.SetOffset(identifier, "777")
+		// No registry fingerprint set => GetFingerprint returns nil => alignment is assumed.
+
+		offset, whence, err := Position(registry, identifier, config.End, fp)
+		assert.Nil(t, err)
+		assert.Equal(t, int64(777), offset)
+		assert.Equal(t, io.SeekStart, whence)
+	})
+}


### PR DESCRIPTION
### What does this PR do?

Adds tests to `pkg/logs/launchers/file/position.go` closing gaps surfaced by a mutation-testing run. Test-only change.

`Position` consults the fingerprinter to decide whether a stored offset is still valid (rotation detection). The existing `TestPosition` never exercised that path — all its identifiers were ≤5 chars, so the derived file path was always empty and the fingerprint block was skipped. This adds a test with a longer identifier covering:
- previous fingerprint present and **aligns** → the stored offset is used
- fingerprints **differ** (rotation) → restart from the beginning despite a stored offset
- **no** previous fingerprint → alignment assumed, stored offset used

### Motivation

`pkg/logs/launchers/file` scored **64.7%** on a mutation pass. These tests kill the previously-uncovered fingerprint-comparison mutants in `position.go`.

**Scope / follow-ups:** This PR deliberately covers only `position.go`. The bulk of the package's surviving mutants are in `launcher.go` and are predominantly **logging-only conditionals** — branches that only decide whether a warn/debug line is emitted on an error or threshold path. Killing those requires capturing log output to assert on, which is a larger testing-harness change; left as a focused follow-up. A handful (e.g. the `len(identifier) > 5` boundary, where the sliced path is empty on either side) are equivalent mutants.

### Describe how you validated your changes

`dda inv test --targets=./pkg/logs/launchers/file` passes; re-ran the mutation harness to confirm the position.go fingerprint-alignment mutants are killed (64.7% → 66.4%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)