### PR TITLE
workspace(S4): switch to base-compat + adopt post-#1089 image

### DIFF
--- a/.devcontainer/datadog/default/features/datadog-agent/devcontainer-feature.json
+++ b/.devcontainer/datadog/default/features/datadog-agent/devcontainer-feature.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "name": "Datadog Agent Development Environment",
     "description": "Configures the Datadog Agent development environment for the bits user, cleaning the base image for it to work in workspaces.",
-    "installsAfter": ["registry.ddbuild.io/workspaces/features/base"],
+    "installsAfter": ["registry.ddbuild.io/workspaces/features/base-compat"],
     "postCreateCommand": {
         "datadog-agent": "/opt/doghome/devcontainer/features/datadog-agent/lifecycle/postCreate.sh"
     }

--- a/.devcontainer/datadog/default/features/datadog-agent/install.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/install.sh
@@ -5,8 +5,11 @@ featureDir=$(cd "$(dirname "$0")"; pwd)
 # Get claude from the buildimages /root/.local/bin
 cp /root/.local/bin/claude /home/bits/.local/bin/claude
 
-# Add bits user to the docker group. This should probably be handled by the base feature. But not working for now.
-usermod -aG docker bits
+# Ensure bits is in the docker and build-shared groups. Both are pre-baked in the
+# dev-env-workspace image; these guards are a no-op in practice but make the feature
+# safe to apply on other bases where the groups may be absent.
+getent group docker >/dev/null && usermod -aG docker bits
+getent group build-shared >/dev/null && usermod -aG build-shared bits
 
 # Copy lifecycle scripts into the image
 install -d /opt/doghome/devcontainer/features/datadog-agent/lifecycle

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,9 +1,9 @@
 {
-    // Trigger build: 2026-05-04 10:25
+    // Trigger build: 2026-06-04 (S4: switch to base-compat, bump to post-#1089 image)
     "name": "Datadog Agent Development Container",
-    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace:v110159745-8628883e",
+    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace:v116490909-fc35a1a5",
     "features": {
-        "registry.ddbuild.io/workspaces/features/base:0.4.100410934": {},
+        "registry.ddbuild.io/workspaces/features/base-compat:0.1.<BUILD_ID>": {},
         "./features/datadog-agent": {}
     },
     "forwardPorts": [22],


### PR DESCRIPTION
## Summary

Switch the agent workspace prebuild from `workspaces/features/base` to `workspaces/features/base-compat`.

The `base` feature's unconditional `useradd --uid 2000 bits` collides with the pre-baked `bits` user in the post-#1089 `dev-env-workspace` image, breaking workspace provisioning. `base-compat` is a new minimal feature that installs only the provisioner contract (the three scripts the Go provisioner hard-codes: `adduser.sh`, `setup_ide_backends.sh`, `install_dotfiles.sh`) without creating users or running apt — safe for managed images that pre-bake `bits`.

## Changes

- `prebuild-devcontainer.json`: `base:0.4.x` → `base-compat:0.1.<BUILD_ID>` _(fill in after dd-source PR publishes)_; image bumped to `v116490909-fc35a1a5` (post-PR #1089)
- `devcontainer-feature.json`: `installsAfter` → `base-compat`
- `install.sh`: harden `usermod` lines with `getent` guards

## Related PRs

- **`dd-source`** (platform, required first): https://github.com/DataDog/dd-source/pull/458460 — implements `base-compat` and the `useradd` guard. Overlaps with Ofek's `workspace-abi` POC — coordinate with platform team before merging.

## Blockers

1. Platform team alignment on dd-source PR #458460
2. `base-compat` published → fill in `0.1.<BUILD_ID>`
3. Build verifier (`devcontainer.go:66-105`) must accept `base-compat` feature ID

## Test plan

- [ ] `bazel build //domains/devcontainers/features/base-compat` + `tar tf` — 3 sbin scripts at correct paths
- [ ] `base-compat` precondition check fails fast on image without `bits`
- [ ] DinD smoke test: `docker ps` works inside workspace
- [ ] Full E2E: `dda inv install-tools` + `dda inv agent.build` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)