### PR TITLE
windows: build agent through hermetic mingw (ld 2.44) for readable PDBs

### DIFF
--- a/tasks/libs/common/go.py
+++ b/tasks/libs/common/go.py
@@ -97,6 +97,26 @@ def _with_pdb_extldflag(ldflags: str, bin_path: str) -> str:
     return (ldflags + suffix) if ldflags else suffix.lstrip()
 
 
+def _with_hermetic_mingw_path(ctx: Context, env: dict[str, str] | None) -> dict[str, str] | None:
+    """
+    Prepend the Bazel hermetic MinGW (GNU ld >= 2.44) to PATH for a Windows cgo
+    build, so the linker emits PDBs that Microsoft dbghelp/symstore can read. The
+    build image's default mingw is ld 2.43, whose `--pdb` output those tools
+    can't parse (WINA-2770). Returns env unchanged if it can't be resolved.
+
+    TODO: remove once migrated fully to the Bazel MinGW toolchain.
+    """
+    # bazel fetch is idempotent: it extracts @winlibs_mingw64 only if missing.
+    if not ctx.run("bazelisk fetch --repo=@winlibs_mingw64", hide=True, warn=True).ok:
+        return env
+    res = ctx.run("bazelisk info output_base", hide=True, warn=True)
+    if not res.ok:
+        return env
+    mingw_bin = f"{res.stdout.strip()}/external/+winlibs_mingw_repository+winlibs_mingw64/bin"
+    path = (env or {}).get("PATH") or os.environ.get("PATH", "")
+    return {**(env or {}), "PATH": f"{mingw_bin}{os.pathsep}{path}"}
+
+
 def go_build(
     ctx: Context,
     entrypoint: str | Path,
@@ -126,6 +146,8 @@ def go_build(
         os.makedirs(os.path.dirname(os.path.abspath(str(bin_path))) or ".", exist_ok=True)
         if os.environ.get("DD_GO_PDB", "1") != "0":
             ldflags = _with_pdb_extldflag(ldflags or "", str(bin_path))
+            if sys.platform == "win32":
+                env = _with_hermetic_mingw_path(ctx, env)
 
     cmd = "go build"
     if coverage:


### PR DESCRIPTION
### What does this PR do?

On Windows, `go_build` prepends the Bazel hermetic MinGW (GNU `ld` >= 2.44) to `PATH` (materialized via idempotent `bazelisk fetch`) so the agent's PDBs are readable by dbghelp/symstore/cdb/xperf. The build image's default `ld` 2.43 emits PDBs those tools can't read.

### Motivation

Prerequisite for the Windows PDB symbol server: #51662 / [WINA-2770](https://datadoghq.atlassian.net/browse/WINA-2770). Validated by cdb/xperf resolving Go callstacks from the produced PDBs.

Since we're moving toward bazel's mingw this seemed like a better fit than a buildimage bump (https://github.com/DataDog/datadog-agent-buildimages/pull/1185)

[WINA-2770]: https://datadoghq.atlassian.net/browse/WINA-2770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ