### PR TITLE
oracle: fall back to v$lock/gv$lock for blocking_session on enq waits

### DIFF
--- a/pkg/collector/corechecks/oracle/activity.go
+++ b/pkg/collector/corechecks/oracle/activity.go
@@ -122,6 +122,19 @@ func sendRows(c *Check, sessionRows []OracleActivityRow) error {
 	return nil
 }
 
+// getBlockerFromLock fetches the blocking session's instance id and sid from v$lock/gv$lock
+// for the given blocked session id. This is a fallback for deployments where Oracle does not
+// populate blocking_session in v$session even when the session is waiting on an enqueue lock.
+// Returns (0, 0, nil) when no blocker is found.
+func (c *Check) getBlockerFromLock(blockedSID uint64) (blockerInstance uint64, blockerSession uint64, err error) {
+	var row blockerFallbackRow
+	err = getWrapper(c, &row, activityQueryBlockerFromLock, blockedSID)
+	if err != nil {
+		return 0, 0, err
+	}
+	return row.BlockingInstance, row.BlockingSession, nil
+}
+
 //nolint:revive // TODO(DBM) Fix revive linter
 func (c *Check) SampleSession() error {
 	activeSessionHistory := c.config.QuerySamples.ActiveSessionHistory
@@ -183,6 +196,7 @@ AND status = 'ACTIVE'`)
 
 	o := c.LazyInitObfuscator()
 	var payloadSent bool
+	var blockerFallbackErrLogged bool
 	for _, sample := range sessionSamples {
 		var sessionRow OracleActivityRow
 
@@ -289,6 +303,22 @@ AND status = 'ACTIVE'`)
 		if sample.WaitTimeMicro != nil {
 			sessionRow.WaitTimeMicro = *sample.WaitTimeMicro
 		}
+
+		// Fallback: some Oracle releases/deployments do not populate blocking_session in v$session
+		// for sessions waiting on an enqueue lock. When that happens, query v$lock/gv$lock directly.
+		if !activeSessionHistory && c.config.QuerySamples.BlockingSessionFallbackEnabled && sessionRow.BlockingSession == 0 && strings.HasPrefix(sessionRow.WaitEvent, "enq") {
+			blockerInst, blockerSID, errBlk := c.getBlockerFromLock(sessionRow.SessionID)
+			if errBlk != nil {
+				if !blockerFallbackErrLogged {
+					log.Warnf("%s failed to fetch blocker from v$lock for sid %d: %s", c.logPrompt, sessionRow.SessionID, errBlk)
+					blockerFallbackErrLogged = true
+				}
+			} else if blockerSID != 0 {
+				sessionRow.BlockingInstance = blockerInst
+				sessionRow.BlockingSession = blockerSID
+			}
+		}
+
 		sessionRow.OpFlags = sample.OpFlags
 
 		statement := ""

--- a/pkg/collector/corechecks/oracle/activity_blocker_fallback_test.go
+++ b/pkg/collector/corechecks/oracle/activity_blocker_fallback_test.go
@@ -1,0 +1,123 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle_test
+
+package oracle
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/benbjohnson/clock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlockerFallbackFiresForEnqWaiter verifies that when a session is waiting on an
+// enqueue lock (wait event begins with "enq") and blocking_session is not populated
+// by Oracle, the agent queries v$lock/gv$lock and populates BlockingSession/BlockingInstance.
+func TestBlockerFallbackFiresForEnqWaiter(t *testing.T) {
+	db, dbMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	c, _ := newDbDoesNotExistCheck(t, "", "")
+	c.db = sqlx.NewDb(db, "sqlmock")
+	c.clock = clock.New()
+	c.sqlSubstringLength = 4000
+	c.config.QuerySamples.ForceDirectQuery = true
+	c.config.QuerySamples.IncludeAllSessions = true
+
+	// Main activity query: one row waiting on an enqueue lock with no blocking session.
+	activityRows := sqlmock.NewRows([]string{
+		"NOW", "UTC_MS", "SID", "SERIAL#", "STATUS", "OP_FLAGS", "EVENT",
+	}).AddRow(
+		"2024-01-01 00:00:00", 0.0, 100, 1, "ACTIVE", 0,
+		"enq: TX - row lock contention",
+	)
+	dbMock.ExpectQuery("DD_ACTIVITY_SAMPLING").WillReturnRows(activityRows)
+
+	// Fallback query: returns the blocker (instance 2, sid 200).
+	fallbackRows := sqlmock.NewRows([]string{"BLOCKER_INST_ID", "BLOCKER_SID"}).
+		AddRow(2, 200)
+	dbMock.ExpectQuery("blocker_inst_id").WillReturnRows(fallbackRows)
+
+	err = c.SampleSession()
+	require.NoError(t, err)
+	require.Len(t, c.lastOracleActivityRows, 1)
+	assert.Equal(t, uint64(200), c.lastOracleActivityRows[0].BlockingSession)
+	assert.Equal(t, uint64(2), c.lastOracleActivityRows[0].BlockingInstance)
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+}
+
+// TestBlockerFallbackSkippedForNonEnqSession verifies that the v$lock/gv$lock fallback
+// is NOT executed for sessions that are not waiting on an enqueue lock (e.g. CPU sessions
+// or sessions with other wait event classes).
+func TestBlockerFallbackSkippedForNonEnqSession(t *testing.T) {
+	db, dbMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	c, _ := newDbDoesNotExistCheck(t, "", "")
+	c.db = sqlx.NewDb(db, "sqlmock")
+	c.clock = clock.New()
+	c.sqlSubstringLength = 4000
+	c.config.QuerySamples.ForceDirectQuery = true
+	c.config.QuerySamples.IncludeAllSessions = true
+
+	// Main activity query: one row on CPU with no blocking session.
+	// A non-enq wait event should never trigger the v$lock fallback.
+	activityRows := sqlmock.NewRows([]string{
+		"NOW", "UTC_MS", "SID", "SERIAL#", "STATUS", "OP_FLAGS", "EVENT",
+	}).AddRow(
+		"2024-01-01 00:00:00", 0.0, 100, 1, "ACTIVE", 0,
+		"CPU",
+	)
+	dbMock.ExpectQuery("DD_ACTIVITY_SAMPLING").WillReturnRows(activityRows)
+	// No fallback expectation registered; an unexpected query would cause a test error.
+
+	err = c.SampleSession()
+	require.NoError(t, err)
+	require.Len(t, c.lastOracleActivityRows, 1)
+	assert.Equal(t, uint64(0), c.lastOracleActivityRows[0].BlockingSession)
+	// Verify all (and only) the expected queries executed — no surprise fallback query.
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+}
+
+// TestBlockerFallbackDisabledByConfig verifies that setting
+// BlockingSessionFallbackEnabled=false suppresses the v$lock/gv$lock fallback entirely,
+// even for sessions that would otherwise qualify (enq wait, no blocking session).
+func TestBlockerFallbackDisabledByConfig(t *testing.T) {
+	db, dbMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	c, _ := newDbDoesNotExistCheck(t, "", "")
+	c.db = sqlx.NewDb(db, "sqlmock")
+	c.clock = clock.New()
+	c.sqlSubstringLength = 4000
+	c.config.QuerySamples.ForceDirectQuery = true
+	c.config.QuerySamples.IncludeAllSessions = true
+	c.config.QuerySamples.BlockingSessionFallbackEnabled = false
+
+	// Main activity query: enq waiter with no blocking session — would trigger the fallback
+	// if it were enabled.
+	activityRows := sqlmock.NewRows([]string{
+		"NOW", "UTC_MS", "SID", "SERIAL#", "STATUS", "OP_FLAGS", "EVENT",
+	}).AddRow(
+		"2024-01-01 00:00:00", 0.0, 100, 1, "ACTIVE", 0,
+		"enq: TX - row lock contention",
+	)
+	dbMock.ExpectQuery("DD_ACTIVITY_SAMPLING").WillReturnRows(activityRows)
+	// No fallback expectation — the flag disables it.
+
+	err = c.SampleSession()
+	require.NoError(t, err)
+	require.Len(t, c.lastOracleActivityRows, 1)
+	assert.Equal(t, uint64(0), c.lastOracleActivityRows[0].BlockingSession)
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+}

--- a/pkg/collector/corechecks/oracle/activity_queries.go
+++ b/pkg/collector/corechecks/oracle/activity_queries.go
@@ -276,3 +276,21 @@ WHERE
 	AND sess.sid(+) = s.session_id AND sess.serial#(+) = s.session_serial#
 	AND s.sample_id > :last_sample_id
 ORDER BY s.sample_time`
+
+// activityQueryBlockerFromLock is a fallback query used when the blocking_session field is not populated
+// by Oracle for sessions waiting on an enqueue lock (enq: wait events). It fetches the blocker's
+// instance id and sid from v$lock (waiter, local instance) joined to gv$lock (holder, any RAC instance).
+// Requires GRANT SELECT ON v$lock and gv$lock to the agent database user.
+const activityQueryBlockerFromLock = `SELECT /* DD_ACTIVITY_SAMPLING */
+	h.inst_id AS blocker_inst_id,
+	h.sid     AS blocker_sid
+FROM v$lock w, gv$lock h
+WHERE w.sid     = :blocked_sid
+AND   w.request > 0
+AND   h.id1     = w.id1
+AND   h.id2     = w.id2
+AND   h.type    = w.type
+AND   h.con_id  = w.con_id
+AND   h.lmode   > 0
+AND   h.sid    != w.sid
+AND   ROWNUM    = 1`

--- a/pkg/collector/corechecks/oracle/activity_structs.go
+++ b/pkg/collector/corechecks/oracle/activity_structs.go
@@ -9,6 +9,12 @@ package oracle
 
 import "database/sql"
 
+// blockerFallbackRow is the scan target for activityQueryBlockerFromLock.
+type blockerFallbackRow struct {
+	BlockingInstance uint64 `db:"BLOCKER_INST_ID"`
+	BlockingSession  uint64 `db:"BLOCKER_SID"`
+}
+
 // ActivitySnapshot is a payload containing database activity samples. It is parsed from the intake payload.
 // easyjson:json
 type ActivitySnapshot struct {

--- a/pkg/collector/corechecks/oracle/config/config.go
+++ b/pkg/collector/corechecks/oracle/config/config.go
@@ -46,10 +46,11 @@ type DatabaseIdentifierConfig struct {
 
 //nolint:revive // TODO(DBM) Fix revive linter
 type QuerySamplesConfig struct {
-	Enabled              bool `yaml:"enabled"`
-	IncludeAllSessions   bool `yaml:"include_all_sessions"`
-	ForceDirectQuery     bool `yaml:"force_direct_query"`
-	ActiveSessionHistory bool `yaml:"active_session_history"`
+	Enabled                        bool `yaml:"enabled"`
+	IncludeAllSessions             bool `yaml:"include_all_sessions"`
+	ForceDirectQuery               bool `yaml:"force_direct_query"`
+	ActiveSessionHistory           bool `yaml:"active_session_history"`
+	BlockingSessionFallbackEnabled bool `yaml:"blocking_session_fallback_enabled"`
 }
 
 type queryMetricsTrackerConfig struct {
@@ -253,6 +254,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.ObfuscatorOptions = GetDefaultObfuscatorOptions()
 
 	instance.QuerySamples.Enabled = true
+	instance.QuerySamples.BlockingSessionFallbackEnabled = true
 
 	instance.QueryMetrics.Enabled = true
 	instance.QueryMetrics.CollectionInterval = defaultMetricCollectionInterval

--- a/releasenotes/notes/oracle-blocking-session-fallback-7b257dcbcd6a5846.yaml
+++ b/releasenotes/notes/oracle-blocking-session-fallback-7b257dcbcd6a5846.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Oracle: The Database Monitoring agent now derives blocking session and
+    instance information from ``v$lock``/``gv$lock`` for sessions waiting on
+    enqueue locks (``enq:`` wait events) when the database does not
+    auto-populate these fields. This requires granting ``SELECT`` on
+    ``v$lock`` and ``gv$lock`` to the agent database user.


### PR DESCRIPTION
## Summary

- On some Oracle releases and deployment types, `blocking_session`/`blocking_instance` in `v$session` is not populated for sessions waiting on an enqueue lock even when a blocker exists
- Detect this case (wait event begins with `enq:`, `blocking_session` is zero) and fall back to querying `v$lock`/`gv$lock` to derive the immediate blocker's instance id and sid
- The fallback is gated on a hidden config field `query_samples.blocking_session_fallback_enabled` (default `true`) so support can disable it if a customer hits issues
- If the fallback query fails (e.g. missing privilege), a warning is logged at most once per check run and the sample is emitted as-is — non-invasive
- Requires `GRANT SELECT ON v$lock` and `GRANT SELECT ON gv$lock` to the agent DB user

## Test plan

- [x] Unit test: fallback fires for `enq:` waiter without `blocking_session` → `BlockingSession`/`BlockingInstance` populated
- [x] Unit test: fallback skipped for non-enq session (CPU) → no extra query issued
- [x] Unit test: fallback disabled via config → no extra query issued even for `enq:` waiter
- [x] Live validation against `nenadnoveljicoad_low` (OCI Autonomous DB that does not auto-populate `blocking_session`): confirmed `blocking_session` and `blocking_instance` appear in the UI at dd.datad0g.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)