### PR TITLE
[ AGNTLOG-641 ] Reconnect container log tailer on stream close instead of silently stopping

### DIFF
--- a/pkg/logs/tailers/container/tailer.go
+++ b/pkg/logs/tailers/container/tailer.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	dockerclient "github.com/moby/moby/client"
+	"go.uber.org/atomic"
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -91,6 +92,13 @@ type Tailer struct {
 	// stop: writing a value to this channel will cause the readForever component to stop
 	stop chan struct{}
 
+	// stopping is set before Stop() closes/cancels the reader. readForever uses
+	// it to distinguish a deliberate shutdown (where the reader's body is closed
+	// on purpose) from a reader/connection close that happens during normal
+	// operation, so it only terminates on the former and reconnects on the
+	// latter. See readForever for the full rationale (AGENT-16261).
+	stopping *atomic.Bool
+
 	// done: a value is written to this channel when the message-forwarder
 	// component is finished.
 	done chan struct{}
@@ -147,6 +155,7 @@ func NewAPITailer(
 		readTimeout:        readTimeout,
 		sleepDuration:      defaultSleepDuration,
 		stop:               make(chan struct{}, 1),
+		stopping:           atomic.NewBool(false),
 		done:               make(chan struct{}, 1),
 		erroredContainerID: erroredContainerID,
 		reader:             newSafeReader(),
@@ -178,6 +187,7 @@ func NewDockerTailer(
 		readTimeout:        readTimeout,
 		sleepDuration:      defaultSleepDuration,
 		stop:               make(chan struct{}, 1),
+		stopping:           atomic.NewBool(false),
 		done:               make(chan struct{}, 1),
 		erroredContainerID: erroredContainerID,
 		reader:             newSafeReader(),
@@ -199,6 +209,12 @@ func (t *Tailer) Stop() {
 	log.Infof("Stop tailing container: %v", t.ContainerID)
 
 	t.registry.SetTailed(t.Identifier(), false)
+
+	// Mark the tailer as stopping BEFORE closing/cancelling the reader below, so
+	// that the reader-close and context-cancel errors those calls provoke in
+	// readForever are recognized as an intentional shutdown rather than a
+	// stream close to recover from.
+	t.stopping.Store(true)
 
 	// signal the readForever component to stop
 	t.stop <- struct{}{}
@@ -259,6 +275,7 @@ func (t *Tailer) setupReader() error {
 	return err
 }
 
+// tryRestartReader reconnects the reader by setting up a fresh one.
 func (t *Tailer) tryRestartReader(reason string) error {
 	log.Debugf("%s for container %v", reason, t.ContainerID)
 	t.wait()
@@ -313,10 +330,34 @@ func (t *Tailer) readForever() {
 			t.Source.RecordBytes(int64(n))
 			if err != nil { // an error occurred, stop from reading new logs
 				switch {
-				case isReaderClosed(err):
-					// The reader has been closed during the shut down process
-					// of the tailer, stop reading
-					return
+				case isReaderClosed(err), isClosedConnError(err):
+					// These errors mean the underlying log stream was closed:
+					// "http: read on closed response body" (isReaderClosed) or
+					// "use of closed network connection" (isClosedConnError).
+					//
+					// During a deliberate Stop() we close/cancel the reader on
+					// purpose, so these are expected and we must terminate.
+					//
+					// During normal operation, however, the same errors are
+					// produced by the moby client (github.com/moby/moby/client):
+					// it wraps the log stream in a cancelReadCloser that closes
+					// the HTTP body whenever the read context is cancelled. Our
+					// read timeout cancels that context on every idle stream,
+					// and the cancelled read then races between surfacing as
+					// context.Canceled (handled below) and, when the body close
+					// wins, one of these "closed" errors. They also occur when
+					// the daemon simply drops the connection. In all of those
+					// non-stopping cases the tailer must reconnect: returning
+					// here would silently kill the tailer with no restart and no
+					// further "Stop tailing container" log, blacking out the
+					// container's logs until its source is removed (AGENT-16261).
+					if t.stopping.Load() {
+						return
+					}
+					if err := t.tryRestartReader("Restarting reader after the log stream was closed"); err != nil {
+						return
+					}
+					continue
 				case isContextCanceled(err):
 					// Note that it could happen that the docker daemon takes a lot of time gathering timestamps
 					// before starting to send any data when it has stored several large log files.
@@ -325,9 +366,6 @@ func (t *Tailer) readForever() {
 						return
 					}
 					continue
-				case isClosedConnError(err):
-					// This error is raised when the agent is stopping
-					return
 				case isFileAlreadyClosed(err):
 					// This error seems to be returned by Docker for Windows
 					// See: https://github.com/microsoft/go-winio/blob/master/file.go

--- a/pkg/logs/tailers/container/tailer_test.go
+++ b/pkg/logs/tailers/container/tailer_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	dockerclient "github.com/moby/moby/client"
+	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
@@ -93,6 +94,7 @@ func NewTestTailer(reader io.ReadCloser, unsafeReader io.ReadCloser, cancelFunc 
 		readTimeout:        time.Millisecond,
 		sleepDuration:      time.Second,
 		stop:               make(chan struct{}, 1),
+		stopping:           atomic.NewBool(false),
 		done:               make(chan struct{}, 1),
 		erroredContainerID: make(chan string, 1),
 		reader:             newSafeReader(),
@@ -202,6 +204,9 @@ func TestTailer_readForever(t *testing.T) {
 				_, cancelFunc := context.WithCancel(context.Background())
 				reader := NewTestReader("", errors.New("http: read on closed response body"), nil)
 				tailer := NewTestTailer(reader, reader, cancelFunc)
+				// The reader-closed error here is the result of Stop() closing
+				// the reader, so the tailer is already stopping.
+				tailer.stopping.Store(true)
 				return tailer
 			},
 			wantFunc: func(tailer *Tailer) error {
@@ -217,6 +222,7 @@ func TestTailer_readForever(t *testing.T) {
 				_, cancelFunc := context.WithCancel(context.Background())
 				reader := NewTestReader("", errors.New("use of closed network connection"), nil)
 				tailer := NewTestTailer(reader, reader, cancelFunc)
+				tailer.stopping.Store(true)
 				return tailer
 			},
 			wantFunc: func(tailer *Tailer) error {
@@ -235,6 +241,12 @@ func TestTailer_readForever(t *testing.T) {
 				// then the new reader return by the unsafeReader client will return close network connection to simulate stop agent
 				connectionCloseReader := NewTestReader("", errors.New("use of closed network connection"), nil)
 				tailer := NewTestTailer(initialReader, connectionCloseReader, cancelFunc)
+				tailer.sleepDuration = time.Millisecond
+				// The EOF triggers a restart onto connectionCloseReader; the
+				// connection-close that reader then returns represents the agent
+				// stopping mid-restart, so readForever terminates without
+				// flagging the container as errored.
+				tailer.stopping.Store(true)
 				return tailer
 			},
 			wantFunc: func(tailer *Tailer) error {
@@ -267,12 +279,131 @@ func TestTailer_readForever(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tailer := tt.newTailer()
-			tailer.readForever()
+
+			// Run readForever under a watchdog. Every case here is expected to
+			// terminate (either by reconnecting onto a reader that then signals
+			// a stop, or by erroring out), so if readForever does not return
+			// promptly it has regressed into an infinite restart loop
+			// (AGENT-16261). Fail fast with a clear message instead of letting
+			// the whole package hang until the test binary's global timeout.
+			done := make(chan struct{})
+			go func() {
+				tailer.readForever()
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				t.Fatal("readForever did not return; it likely spun in an infinite restart loop")
+			}
+
 			if err := tt.wantFunc(tailer); err != nil {
 				t.Error(err)
 			}
 		})
 	}
+}
+
+// cancelSurfacingReader blocks until its context is cancelled, modeling a read
+// that is in flight when readForever's read timeout fires. When cancelled it
+// returns onCancel, modeling how the moby client (which closes the HTTP body on
+// context cancellation) surfaces a cancelled read as a closed-stream error
+// instead of context.Canceled.
+type cancelSurfacingReader struct {
+	ctx      context.Context
+	onCancel error
+}
+
+func (r *cancelSurfacingReader) Read(_ []byte) (int, error) {
+	<-r.ctx.Done()
+	return 0, r.onCancel
+}
+
+func (r *cancelSurfacingReader) Close() error { return nil }
+
+// TestTailer_readForeverReconnectsOnStreamCloseWhenNotStopping is the
+// regression test for AGENT-16261. The moby client surfaces a read whose
+// context was cancelled by our read timeout as either "http: read on closed
+// response body" or "use of closed network connection". Before the fix,
+// readForever returned on those errors, silently killing the tailer with no
+// restart, no erroredContainerID signal, and no further "Stop tailing
+// container" log. The fix makes it reconnect unless the tailer is stopping.
+func TestTailer_readForeverReconnectsOnStreamCloseWhenNotStopping(t *testing.T) {
+	for _, errStr := range []string{
+		"http: read on closed response body", // isReaderClosed
+		"use of closed network connection",   // isClosedConnError
+	} {
+		t.Run(errStr, func(t *testing.T) {
+			_, cancelFunc := context.WithCancel(context.Background())
+			reader := NewTestReader("", errors.New(errStr), nil)
+			tailer := NewTestTailer(reader, reader, cancelFunc)
+			tailer.sleepDuration = time.Millisecond
+
+			// Count reconnects (tryRestartReader -> setupReader ->
+			// unsafeLogReader). Allow the first reconnect to prove recovery,
+			// then mark the tailer stopping so the next closed-stream error
+			// terminates the loop instead of spinning forever.
+			var restarts atomic.Int64
+			tailer.unsafeLogReader = func(_ context.Context, _ time.Time) (io.ReadCloser, error) {
+				restarts.Add(1)
+				tailer.stopping.Store(true)
+				return reader, nil
+			}
+
+			done := make(chan struct{})
+			go func() {
+				tailer.readForever()
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("readForever did not return; the closed-stream error likely still bare-returns or spins")
+			}
+
+			assert.GreaterOrEqual(t, restarts.Load(), int64(1),
+				"a closed-stream error while not stopping must trigger a reconnect (tryRestartReader), not a silent return")
+			assert.Equal(t, 0, len(tailer.erroredContainerID),
+				"a recoverable stream close must not be reported as a fatally errored container")
+		})
+	}
+}
+
+// TestTailer_readForeverReconnectsAfterReadTimeoutCancel reproduces the
+// AGENT-16261 mechanism end-to-end at the read() boundary: a read that is in
+// flight when the read timeout fires has its context cancelled, and the moby
+// client surfaces that cancelled read as a closed-stream error rather than
+// context.Canceled. readForever must reconnect, not die.
+func TestTailer_readForeverReconnectsAfterReadTimeoutCancel(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	blocked := &cancelSurfacingReader{ctx: ctx, onCancel: errors.New("use of closed network connection")}
+	restartReader := NewTestReader("", errors.New("use of closed network connection"), nil)
+	tailer := NewTestTailer(blocked, restartReader, cancelFunc)
+	tailer.sleepDuration = time.Millisecond
+
+	var restarts atomic.Int64
+	tailer.unsafeLogReader = func(_ context.Context, _ time.Time) (io.ReadCloser, error) {
+		restarts.Add(1)
+		tailer.stopping.Store(true)
+		return restartReader, nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		tailer.readForever()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("readForever did not return after a read-timeout-driven stream close")
+	}
+
+	assert.GreaterOrEqual(t, restarts.Load(), int64(1),
+		"a read cancelled by the read timeout that surfaces as a closed-stream error must trigger a reconnect")
+	assert.Equal(t, 0, len(tailer.erroredContainerID))
 }
 
 func NewTestReader(data string, err, closeErr error) *testIOReadCloser { //nolint:revive

--- a/releasenotes/notes/fix-container-log-tailer-silent-stop-a8bbcba24a0e8496.yaml
+++ b/releasenotes/notes/fix-container-log-tailer-silent-stop-a8bbcba24a0e8496.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fix an issue where container log collection could stop for an individual
+    container without recovering and without any error in the Agent logs. When
+    a container's log stream was idle longer than ``logs_config.docker_client_read_timeout``,
+    the read timeout could cause the underlying Docker connection to close in a
+    way that the tailer treated as a permanent shutdown, silently stopping log
+    collection for that container until it was recreated or the Agent was
+    restarted. The tailer now reconnects in this case, and only stops when the
+    Agent is intentionally shutting down. Low-volume containers (for example,
+    services that log only periodically) were the most affected.


### PR DESCRIPTION
### What does this PR do?

Keeps container log collection alive when a container's Docker log stream is closed during normal operation. Previously, when the read timeout cancelled an idle stream, the tailer could observe the close as a terminal error and stop reading that container's logs entirely, with no restart and no error surfaced. The tailer now reconnects on those stream-close errors and only stops when the Agent is genuinely shutting down.

### Motivation

After the move to the `github.com/moby/moby/client` library, `ContainerLogs` wraps the response body so that cancelling the read context also closes the underlying HTTP body. The tailer cancels that context on every read timeout to bound idle reads, so the cancelled read now races between surfacing as `context.Canceled` (which restarted the reader) and `use of closed network connection` / `http: read on closed response body` (which the tailer treated as shutdown and returned on). When the close won that race, the container's tailer died silently — no restart, no errored-container signal, and no further `Stop tailing container` log — and its logs blacked out until the container was recreated or the Agent restarted.

Because the race is decided by goroutine scheduling, it only loses occasionally and under load, which made the failure intermittent and per-container. Low-volume containers (those that log only periodically) hit the read timeout on every idle gap, so they rolled the race most often and were the most affected.

### Describe how you validated your changes

Added regression tests in `pkg/logs/tailers/container` that drive both stream-close error strings and the read-timeout cancel path, asserting the tailer reconnects when it is not stopping (and still returns cleanly when it is). The existing `readForever` shutdown cases were updated to reflect that these errors are only terminal during an intentional stop. Verified the new tests fail against the previous bare-return behavior and pass with the fix. Run via `dda inv test --targets=./pkg/logs/tailers/container`; package linting is clean.

### Additional Notes

N/A