### PR TITLE
packaging/aix: bake install-path -blibpath into Python binaries and extension modules

### DIFF
--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -10,6 +10,8 @@
 
 <!-- Add entries here for changes not yet in a release. -->
 
+- The embedded `python3.13` binary and all Python extension modules now have the correct install-time library search path baked into their XCOFF loader section. Previously, the staging path was baked in, causing `libpython3.13.so could not be loaded` when running pip or python directly (without `LIBPATH` set). Operators can now run `pip install` without setting `LIBPATH` first.
+
 ---
 
 ## 7.81.0-devel.git.349.9b5ddbe-1 (2026-06-01)

--- a/packaging/aix/stages/02-python.sh
+++ b/packaging/aix/stages/02-python.sh
@@ -392,6 +392,23 @@ log "Configure complete."
 log "Building Python ${PYTHON_VERSION} with make -j$NPROC"
 log "  (This step takes approximately 20 minutes on POWER8 — please be patient.)"
 
+# Create the runtime-path symlink BEFORE make so that the baked-in -blibpath
+# resolves during Python's own build-time module import tests.
+# Python self-tests each extension module by importing it mid-build; those .so
+# files carry -blibpath:$EMBEDDED/lib (from _PYTHON_LDFLAGS), so the symlink
+# must exist for the loader to find libpython3.13.so and other staged libs.
+if [ -L "$EMBEDDED" ] && [ "$(readlink "$EMBEDDED")" = "$EMBEDDED_DESTDIR" ]; then
+    log "INFO: $EMBEDDED symlink already correct."
+else
+    if [ -e "$EMBEDDED" ] && [ ! -L "$EMBEDDED" ]; then
+        log "INFO: $EMBEDDED is a real path — removing to create symlink"
+        rm -rf "$EMBEDDED"
+    fi
+    mkdir -p "$(dirname "$EMBEDDED")"
+    ln -sf "$EMBEDDED_DESTDIR" "$EMBEDDED"
+    log "Created runtime-path symlink: $EMBEDDED -> $EMBEDDED_DESTDIR"
+fi
+
 cd "$PYTHON_SRC"
 make -j"$NPROC"
 
@@ -416,30 +433,6 @@ log "Python executable: $EMBEDDED_DESTDIR/bin/python${PYTHON_MAJ_MIN}"
 if [ ! -f "$EMBEDDED_DESTDIR/bin/python${PYTHON_MAJ_MIN}" ]; then
     log "ERROR: $EMBEDDED_DESTDIR/bin/python${PYTHON_MAJ_MIN} not found after make install — install failed."
     exit 1
-fi
-
-# ─── Step 6b: Create runtime-path symlink ────────────────────────────────────
-#
-# Python's sys.prefix is baked-in as $EMBEDDED (/opt/datadog-agent/embedded).
-# The Python binaries now carry -blibpath:$EMBEDDED/lib in their XCOFF loader
-# section (see _PYTHON_LDFLAGS above). We must create the symlink BEFORE the
-# first invocation of the staged Python (ensurepip below) so that libpython
-# can be found via the baked-in path on a clean build host.
-#
-# The symlink also ensures that C extensions in later stages can resolve
-# ld_so_aix and Python config files at the $EMBEDDED prefix.
-# The 10-assemble stage removes this symlink and replaces it with real files.
-
-if [ -L "$EMBEDDED" ] && [ "$(readlink "$EMBEDDED")" = "$EMBEDDED_DESTDIR" ]; then
-    log "INFO: $EMBEDDED symlink already correct."
-else
-    if [ -e "$EMBEDDED" ] && [ ! -L "$EMBEDDED" ]; then
-        log "INFO: $EMBEDDED is a real path — removing to create symlink"
-        rm -rf "$EMBEDDED"
-    fi
-    mkdir -p "$(dirname "$EMBEDDED")"
-    ln -sf "$EMBEDDED_DESTDIR" "$EMBEDDED"
-    log "Created runtime-path symlink: $EMBEDDED -> $EMBEDDED_DESTDIR"
 fi
 
 # ─── Step 7: Bootstrap pip ───────────────────────────────────────────────────

--- a/packaging/aix/stages/02-python.sh
+++ b/packaging/aix/stages/02-python.sh
@@ -418,14 +418,37 @@ if [ ! -f "$EMBEDDED_DESTDIR/bin/python${PYTHON_MAJ_MIN}" ]; then
     exit 1
 fi
 
+# ─── Step 6b: Create runtime-path symlink ────────────────────────────────────
+#
+# Python's sys.prefix is baked-in as $EMBEDDED (/opt/datadog-agent/embedded).
+# The Python binaries now carry -blibpath:$EMBEDDED/lib in their XCOFF loader
+# section (see _PYTHON_LDFLAGS above). We must create the symlink BEFORE the
+# first invocation of the staged Python (ensurepip below) so that libpython
+# can be found via the baked-in path on a clean build host.
+#
+# The symlink also ensures that C extensions in later stages can resolve
+# ld_so_aix and Python config files at the $EMBEDDED prefix.
+# The 10-assemble stage removes this symlink and replaces it with real files.
+
+if [ -L "$EMBEDDED" ] && [ "$(readlink "$EMBEDDED")" = "$EMBEDDED_DESTDIR" ]; then
+    log "INFO: $EMBEDDED symlink already correct."
+else
+    if [ -e "$EMBEDDED" ] && [ ! -L "$EMBEDDED" ]; then
+        log "INFO: $EMBEDDED is a real path — removing to create symlink"
+        rm -rf "$EMBEDDED"
+    fi
+    mkdir -p "$(dirname "$EMBEDDED")"
+    ln -sf "$EMBEDDED_DESTDIR" "$EMBEDDED"
+    log "Created runtime-path symlink: $EMBEDDED -> $EMBEDDED_DESTDIR"
+fi
+
 # ─── Step 7: Bootstrap pip ───────────────────────────────────────────────────
 #
 # We configured with --without-ensurepip, so we must bootstrap pip manually.
 # We invoke the STAGING executable ($EMBEDDED_DESTDIR/bin/python${PYTHON_MAJ_MIN}).
 # Python discovers sys.prefix from its executable path at runtime, so it finds
 # its stdlib under $EMBEDDED_DESTDIR/lib/python${PYTHON_MAJ_MIN}/ and installs packages into
-# the staging tree — not into $EMBEDDED (which does not exist yet on this host).
-# At runtime on the user's system the files are at $EMBEDDED, which is correct.
+# the staging tree. At runtime on the user's system the files are at $EMBEDDED.
 
 log "Bootstrapping pip using staging Python executable"
 "$EMBEDDED_DESTDIR/bin/python${PYTHON_MAJ_MIN}" -m ensurepip
@@ -455,26 +478,6 @@ log "Created: $EMBEDDED_DESTDIR/lib/libpython${PYTHON_MAJ_MIN}.a (member: shr_64
 # of hardcoding the minor version.
 ln -sf "libpython${PYTHON_MAJ_MIN}.a" "$EMBEDDED_DESTDIR/lib/libpython3.a"
 log "Created symlink: libpython3.a -> libpython${PYTHON_MAJ_MIN}.a"
-
-# ─── Step 7c: Create runtime-path symlink (needed to build C extensions) ─────
-#
-# Python's sys.prefix is baked-in as $EMBEDDED (/opt/datadog-agent/embedded).
-# When building C extensions (cffi, psutil, etc.) in later stages, Python looks
-# for ld_so_aix and config files at that prefix. We create a symlink from the
-# runtime path to the staging path so Python can find these files during the build.
-# The 10-assemble stage will remove this symlink and replace it with the real files.
-
-if [ -L "$EMBEDDED" ] && [ "$(readlink "$EMBEDDED")" = "$EMBEDDED_DESTDIR" ]; then
-    log "INFO: $EMBEDDED symlink already correct."
-else
-    if [ -e "$EMBEDDED" ] && [ ! -L "$EMBEDDED" ]; then
-        log "INFO: $EMBEDDED is a real path — removing to create symlink"
-        rm -rf "$EMBEDDED"
-    fi
-    mkdir -p "$(dirname "$EMBEDDED")"
-    ln -sf "$EMBEDDED_DESTDIR" "$EMBEDDED"
-    log "Created runtime-path symlink: $EMBEDDED -> $EMBEDDED_DESTDIR"
-fi
 
 # ─── Step 8: Convenience symlinks ────────────────────────────────────────────
 

--- a/packaging/aix/stages/02-python.sh
+++ b/packaging/aix/stages/02-python.sh
@@ -346,6 +346,20 @@ log "AIX patching complete."
 log "Configuring Python ${PYTHON_VERSION} (--prefix=$EMBEDDED)"
 log "  (Note: configure can take several minutes on POWER8)"
 
+# Extend LDFLAGS with the final install-time -blibpath for all Python binaries
+# (python3.13, libpython3.13.so, and every C extension .so built in later stages).
+#
+# Without this, the linker bakes the staging path ($EMBEDDED_DESTDIR/lib, i.e.
+# /opt/dd-build/staging/opt/datadog-agent/embedded/lib) into the XCOFF loader
+# section. That path does not exist on the installed system, so any direct
+# invocation of the embedded Python without LIBPATH set (e.g. running pip as the
+# operator) fails with "libpython3.13.so could not be loaded".
+#
+# On AIX, -blibpath replaces the default runtime search path computed by ld, so
+# we must list every directory needed at runtime: our embedded libs, the GCC/
+# freeware libs (libgcc_s, libstdc++, etc.), and the system defaults.
+_PYTHON_LDFLAGS="$LDFLAGS -Wl,-blibpath:$EMBEDDED/lib:/opt/freeware/lib64:/opt/freeware/lib:/usr/lib:/lib"
+
 cd "$PYTHON_SRC"
 ./configure \
     --prefix="$EMBEDDED" \
@@ -358,7 +372,7 @@ cd "$PYTHON_SRC"
     CXX="$CXX" \
     CFLAGS="$CFLAGS -I$EMBEDDED_DESTDIR/include" \
     CPPFLAGS="$CPPFLAGS" \
-    LDFLAGS="$LDFLAGS" \
+    LDFLAGS="$_PYTHON_LDFLAGS" \
     ARFLAGS="$ARFLAGS" \
     NM="$NM" \
     ac_cv_header_libintl_h=no \


### PR DESCRIPTION
### What does this PR do?

Adds `-Wl,-blibpath:/opt/datadog-agent/embedded/lib:/opt/freeware/lib64:/opt/freeware/lib:/usr/lib:/lib` to the `LDFLAGS` passed to Python's `./configure` in stage 02, so the final install path is baked into the XCOFF loader section of `python3.13`, `libpython3.13.so`, and every C extension module compiled during the build.

Also moves the `$EMBEDDED → $EMBEDDED_DESTDIR` symlink creation to before `make`: the baked-in `-blibpath` affects every `.so` Python compiles, and Python self-tests each one by importing it mid-build, so those imports need the symlink to exist so the loader can resolve staged libs via the final path.

### Motivation

The AIX linker bakes the *staging* library path into every binary built during the package build. On the installed system that path does not exist, so any direct invocation of the embedded Python without `LIBPATH` set fails:

```
exec(): 0509-036 Cannot load program /opt/datadog-agent/embedded/bin/python3.13
0509-150  Dependent module libpython3.13.so could not be loaded.
0509-026  System error: A file or directory in the path name does not exist.
```

This affects users running `pip install` to add Python check dependencies (e.g. `ibm_db` for the DB2 check).

### Describe how you validated your changes

Built on an AIX host and ran various python/pip commands, eg. `env -i pip install requests && python3.13 -c "import requests"`.

### Additional Notes
