### PR TITLE
[cluster-agent] Pin Checks to Existing Runner if No Data

### DIFF
--- a/pkg/clusteragent/clusterchecks/checks_distribution.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution.go
@@ -16,10 +16,12 @@ import (
 
 // ConfigStatus is one config's entry in a distribution.
 // WorkersNeeded is summed across the config's instances.
+// Pinned configs are kept on their current runner during rebalancing.
 type ConfigStatus struct {
 	WorkersNeeded float64
 	Runner        string
 	CheckName     string
+	Pinned        bool
 }
 
 // RunnerStatus represents the status of a check runner
@@ -95,16 +97,17 @@ func (distribution *configsDistribution) leastBusyRunner(preferredRunner string,
 	return leastBusyRunner
 }
 
-func (distribution *configsDistribution) addToLeastBusy(digest, checkName string, workersNeeded float64, preferredRunner string, excludeRunner string) {
+func (distribution *configsDistribution) addToLeastBusy(digest, checkName string, workersNeeded float64, preferredRunner string, excludeRunner string, pinned bool) {
 	leastBusy := distribution.leastBusyRunner(preferredRunner, excludeRunner)
 	if leastBusy == "" {
 		return
 	}
 
-	distribution.addConfig(digest, checkName, workersNeeded, leastBusy)
+	distribution.addConfig(digest, checkName, workersNeeded, leastBusy, pinned)
 }
 
-func (distribution *configsDistribution) addConfig(digest, checkName string, workersNeeded float64, runner string) {
+// addConfig records a config instance in the distribution.
+func (distribution *configsDistribution) addConfig(digest, checkName string, workersNeeded float64, runner string, pinned bool) {
 	// Initialize the runner and attribute work
 	runnerInfo, runnerExists := distribution.Runners[runner]
 	if !runnerExists {
@@ -135,6 +138,9 @@ func (distribution *configsDistribution) addConfig(digest, checkName string, wor
 	}
 
 	configInfo.WorkersNeeded += workersNeeded
+
+	// Cumulate Pinned: Pin the entire config if any of its instances are pinned
+	configInfo.Pinned = configInfo.Pinned || pinned
 }
 
 func (distribution *configsDistribution) runnerWorkers() map[string]int {

--- a/pkg/clusteragent/clusterchecks/checks_distribution_test.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution_test.go
@@ -150,10 +150,10 @@ func TestAddToLeastBusy(t *testing.T) {
 			distribution := newConfigsDistribution(test.existingRunners)
 
 			for checkID, checkStatus := range test.existingChecks {
-				distribution.addConfig(checkID, checkStatus.CheckName, checkStatus.WorkersNeeded, checkStatus.Runner)
+				distribution.addConfig(checkID, checkStatus.CheckName, checkStatus.WorkersNeeded, checkStatus.Runner, false)
 			}
 
-			distribution.addToLeastBusy("newCheck", "newCheck", 10, test.preferredRunner, "")
+			distribution.addToLeastBusy("newCheck", "newCheck", 10, test.preferredRunner, "", false)
 
 			assert.Equal(t, test.expectedPlacement, distribution.runnerForConfig("newCheck"))
 		})
@@ -165,7 +165,7 @@ func TestAddCheck(t *testing.T) {
 		"runner1": 4,
 	})
 
-	distribution.addConfig("check1", "check1", 3, "runner1")
+	distribution.addConfig("check1", "check1", 3, "runner1", false)
 	assert.Equal(t, "runner1", distribution.runnerForConfig("check1"))
 	assert.Equal(t, 3.0, distribution.workersNeededForConfig("check1"))
 }
@@ -178,10 +178,10 @@ func TestChecksSortedByWorkersNeeded(t *testing.T) {
 		"runner3": 4,
 	})
 
-	distribution.addConfig("check1", "check1", 3, "runner1")
-	distribution.addConfig("check2", "check2", 1, "runner1")
-	distribution.addConfig("check3", "check3", 4, "runner2")
-	distribution.addConfig("check4", "check4", 2, "runner3")
+	distribution.addConfig("check1", "check1", 3, "runner1", false)
+	distribution.addConfig("check2", "check2", 1, "runner1", false)
+	distribution.addConfig("check3", "check3", 4, "runner2", false)
+	distribution.addConfig("check4", "check4", 2, "runner3", false)
 
 	assert.Equal(t, []string{"check3", "check1", "check4", "check2"}, distribution.configsSortedByWorkersNeeded())
 
@@ -191,10 +191,10 @@ func TestChecksSortedByWorkersNeeded(t *testing.T) {
 		"runner2": 4,
 	})
 
-	distribution.addConfig("check_B", "check_B", 1, "runner1")
-	distribution.addConfig("check_A", "check_A", 1, "runner2")
-	distribution.addConfig("check_C", "check_C", 1, "runner1")
-	distribution.addConfig("check_Z", "check_Z", 2, "runner2")
+	distribution.addConfig("check_B", "check_B", 1, "runner1", false)
+	distribution.addConfig("check_A", "check_A", 1, "runner2", false)
+	distribution.addConfig("check_C", "check_C", 1, "runner1", false)
+	distribution.addConfig("check_Z", "check_Z", 2, "runner2", false)
 
 	assert.Equal(t, []string{"check_Z", "check_A", "check_B", "check_C"}, distribution.configsSortedByWorkersNeeded())
 }
@@ -206,10 +206,10 @@ func TestNumEmptyRunners(t *testing.T) {
 	})
 	assert.Equal(t, 2, distribution.numEmptyRunners())
 
-	distribution.addConfig("check1", "check1", 1, "runner1")
+	distribution.addConfig("check1", "check1", 1, "runner1", false)
 	assert.Equal(t, 1, distribution.numEmptyRunners())
 
-	distribution.addConfig("check2", "check2", 1, "runner2")
+	distribution.addConfig("check2", "check2", 1, "runner2", false)
 	assert.Equal(t, 0, distribution.numEmptyRunners())
 }
 
@@ -220,13 +220,13 @@ func TestNumRunnersWithHighUtilization(t *testing.T) {
 	})
 	assert.Equal(t, 0, distribution.numRunnersWithHighUtilization())
 
-	distribution.addConfig("check1", "check1", 1, "runner1") // runner 1 at 25%
+	distribution.addConfig("check1", "check1", 1, "runner1", false) // runner 1 at 25%
 	assert.Equal(t, 0, distribution.numRunnersWithHighUtilization())
 
-	distribution.addConfig("check2", "check2", 2.5, "runner1") // runner 1 at 3.5/4=0.875, above threshold
+	distribution.addConfig("check2", "check2", 2.5, "runner1", false) // runner 1 at 3.5/4=0.875, above threshold
 	assert.Equal(t, 1, distribution.numRunnersWithHighUtilization())
 
-	distribution.addConfig("check3", "check3", 2, "runner2") // runner 2 at 100%
+	distribution.addConfig("check3", "check3", 2, "runner2", false) // runner 2 at 100%
 	assert.Equal(t, 2, distribution.numRunnersWithHighUtilization())
 }
 
@@ -237,13 +237,13 @@ func TestAddConfigConflictTransfersAccumulatedWeight(t *testing.T) {
 	})
 
 	// Two instances of digestA are processed on runner1 first.
-	distribution.addConfig("digestA", "configA", 2.0, "runner1")
-	distribution.addConfig("digestA", "configA", 1.5, "runner1")
+	distribution.addConfig("digestA", "configA", 2.0, "runner1", false)
+	distribution.addConfig("digestA", "configA", 1.5, "runner1", false)
 	assert.InDelta(t, 3.5, distribution.Runners["runner1"].WorkersUsed, 0.001)
 	assert.InDelta(t, 0.0, distribution.Runners["runner2"].WorkersUsed, 0.001)
 
 	// Conflicting assignment of digestA to runner2
-	distribution.addConfig("digestA", "configA", 3.0, "runner2")
+	distribution.addConfig("digestA", "configA", 3.0, "runner2", false)
 
 	// All accumulated weight for digestA (3.5) must transfer from runner1 to runner2,
 	// plus the new instance weight (3.0).
@@ -260,10 +260,10 @@ func TestUtilizationStdDev(t *testing.T) {
 		"runner2": 4,
 		"runner3": 4,
 	})
-	distribution.addConfig("check1", "check1", 1, "runner1")
-	distribution.addConfig("check2", "check2", 2, "runner1")
-	distribution.addConfig("check3", "check3", 2, "runner2")
-	distribution.addConfig("check4", "check4", 4, "runner3")
+	distribution.addConfig("check1", "check1", 1, "runner1", false)
+	distribution.addConfig("check2", "check2", 2, "runner1", false)
+	distribution.addConfig("check3", "check3", 2, "runner2", false)
+	distribution.addConfig("check4", "check4", 4, "runner3", false)
 
 	// The avg utilization is (0.75 + 0.5 + 1)/3 = 0.75
 	// The variance is ((0.75-0.75)^2 + (0.5-0.75)^2 + (1-0.75)^2)/3 = 0.125/3

--- a/pkg/clusteragent/clusterchecks/dispatcher_isolate.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_isolate.go
@@ -60,6 +60,7 @@ func (d *dispatcher) isolateCheck(isolateCheckID string) types.IsolateResponse {
 			config.WorkersNeeded,
 			config.Runner,
 			isolateNode,
+			false,
 		)
 	}
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -388,21 +388,25 @@ func (d *dispatcher) rebalanceUsingUtilization(force bool) []types.RebalanceResp
 	proposedDistribution := newConfigsDistribution(currentConfigsDistribution.runnerWorkers())
 
 	// Place configs in proposed: pinned ones stay on their current runner,
+	for digest, config := range currentConfigsDistribution.Configs {
+		if config.Pinned {
+			proposedDistribution.addConfig(digest, config.CheckName, config.WorkersNeeded, config.Runner, true)
+		}
+	}
 	// the rest go greedily on the least busy runner (descending workersNeeded).
 	for _, digest := range currentConfigsDistribution.configsSortedByWorkersNeeded() {
 		config := currentConfigsDistribution.Configs[digest]
 		if config.Pinned {
-			proposedDistribution.addConfig(digest, config.CheckName, config.WorkersNeeded, config.Runner, true)
-		} else {
-			proposedDistribution.addToLeastBusy(
-				digest,
-				config.CheckName,
-				config.WorkersNeeded,
-				config.Runner,
-				"",
-				false,
-			)
+			continue
 		}
+		proposedDistribution.addToLeastBusy(
+			digest,
+			config.CheckName,
+			config.WorkersNeeded,
+			config.Runner,
+			"",
+			false,
+		)
 	}
 
 	// We don't calculate the optimal distribution, so it might be worse than

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -385,21 +385,13 @@ func (d *dispatcher) rebalanceUsingUtilization(force bool) []types.RebalanceResp
 	}()
 
 	currentConfigsDistribution := d.currentDistribution()
-
 	proposedDistribution := newConfigsDistribution(currentConfigsDistribution.runnerWorkers())
-
-	// Pin excluded configs to their current runner.
-	for digest, config := range currentConfigsDistribution.Configs {
-		if _, excluded := d.excludedChecksFromDispatching[config.CheckName]; excluded {
-			proposedDistribution.addConfig(digest, config.CheckName, config.WorkersNeeded, config.Runner)
-		}
-	}
 
 	// Place the rest greedily by descending workersNeeded.
 	for _, digest := range currentConfigsDistribution.configsSortedByWorkersNeeded() {
 		config := currentConfigsDistribution.Configs[digest]
-		if _, excluded := d.excludedChecksFromDispatching[config.CheckName]; excluded {
-			continue
+		if config.Pinned {
+			proposedDistribution.addConfig(digest, config.CheckName, config.WorkersNeeded, config.Runner, true)
 		}
 		proposedDistribution.addToLeastBusy(
 			digest,
@@ -407,6 +399,7 @@ func (d *dispatcher) rebalanceUsingUtilization(force bool) []types.RebalanceResp
 			config.WorkersNeeded,
 			config.Runner,
 			"",
+			false,
 		)
 	}
 
@@ -487,7 +480,12 @@ func (d *dispatcher) currentDistribution() configsDistribution {
 				workersNeeded = 1
 			}
 
-			distribution.addConfig(digest, conf.Name, workersNeeded, nodeName)
+			// Pin if the check is explicitly excluded from rebalancing or if
+			// this instance has no usable execution-time signal (AverageExecutionTime == 0).
+			_, excluded := d.excludedChecksFromDispatching[conf.Name]
+			pinned := excluded || workersNeeded == 0
+
+			distribution.addConfig(digest, conf.Name, workersNeeded, nodeName, pinned)
 		}
 		nodeStoreInfo.RUnlock()
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -387,20 +387,22 @@ func (d *dispatcher) rebalanceUsingUtilization(force bool) []types.RebalanceResp
 	currentConfigsDistribution := d.currentDistribution()
 	proposedDistribution := newConfigsDistribution(currentConfigsDistribution.runnerWorkers())
 
-	// Place the rest greedily by descending workersNeeded.
+	// Place configs in proposed: pinned ones stay on their current runner,
+	// the rest go greedily on the least busy runner (descending workersNeeded).
 	for _, digest := range currentConfigsDistribution.configsSortedByWorkersNeeded() {
 		config := currentConfigsDistribution.Configs[digest]
 		if config.Pinned {
 			proposedDistribution.addConfig(digest, config.CheckName, config.WorkersNeeded, config.Runner, true)
+		} else {
+			proposedDistribution.addToLeastBusy(
+				digest,
+				config.CheckName,
+				config.WorkersNeeded,
+				config.Runner,
+				"",
+				false,
+			)
 		}
-		proposedDistribution.addToLeastBusy(
-			digest,
-			config.CheckName,
-			config.WorkersNeeded,
-			config.Runner,
-			"",
-			false,
-		)
 	}
 
 	// We don't calculate the optimal distribution, so it might be worse than

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -1783,6 +1783,81 @@ func TestRebalanceUsingUtilization_GroupsAndSpreadsMultiInstanceConfigs(t *testi
 	assert.Equal(t, "digestLight", checksMoved2[0].Digest)
 }
 
+// Verifies that checks whose AverageExecutionTime is 0 (e.g. long-running checks
+// or checks that haven't completed a meaningful run yet) are pinned to their
+// current runner and excluded from rebalancing, while a sibling check with real
+// execution-time data remains eligible to move.
+func TestRebalanceUsingUtilization_PinsChecksWithoutExecutionTime(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	testDispatcher := newDispatcher(fakeTagger)
+
+	mockClient := &rebalanceTestClcRunnerClient{
+		testStats: make(map[string]types.CLCRunnersStats),
+	}
+	testDispatcher.clcRunnersClient = mockClient
+	testDispatcher.advancedDispatching.Store(true)
+
+	testDispatcher.store.active = true
+	testDispatcher.store.nodes["node1"] = newNodeStore("node1", "10.0.0.1")
+	testDispatcher.store.nodes["node1"].workers = pkgconfigsetup.DefaultNumWorkers
+	testDispatcher.store.nodes["node2"] = newNodeStore("node2", "10.0.0.2")
+	testDispatcher.store.nodes["node2"].workers = pkgconfigsetup.DefaultNumWorkers
+
+	// All three checks start on node1: two with AverageExecutionTime == 0
+	// (pinned) and one with real data (eligible to move).
+	node1Stats := types.CLCRunnersStats{
+		"pinned1": {AverageExecutionTime: 0, IsClusterCheck: true},
+		"pinned2": {AverageExecutionTime: 0, IsClusterCheck: true},
+		"movable": {AverageExecutionTime: 2000, IsClusterCheck: true},
+	}
+	testDispatcher.store.nodes["node1"].clcRunnerStats = node1Stats
+	mockClient.testStats["10.0.0.1"] = node1Stats
+	mockClient.testStats["10.0.0.2"] = types.CLCRunnersStats{}
+
+	testDispatcher.store.idToDigest = map[checkid.ID]string{
+		"pinned1": "digestPinned1",
+		"pinned2": "digestPinned2",
+		"movable": "digestMovable",
+	}
+	testDispatcher.store.digestToConfig = map[string]integration.Config{
+		"digestPinned1": {Name: "pinned1"},
+		"digestPinned2": {Name: "pinned2"},
+		"digestMovable": {Name: "movable"},
+	}
+	testDispatcher.store.digestToNode = map[string]string{
+		"digestPinned1": "node1",
+		"digestPinned2": "node1",
+		"digestMovable": "node1",
+	}
+
+	// currentDistribution should mark the two zero-execution-time checks as
+	// pinned and leave the movable one unpinned.
+	dist := testDispatcher.currentDistribution()
+	require.Contains(t, dist.Configs, "digestPinned1")
+	require.Contains(t, dist.Configs, "digestPinned2")
+	require.Contains(t, dist.Configs, "digestMovable")
+	assert.True(t, dist.Configs["digestPinned1"].Pinned, "pinned1 should be pinned (AverageExecutionTime == 0)")
+	assert.True(t, dist.Configs["digestPinned2"].Pinned, "pinned2 should be pinned (AverageExecutionTime == 0)")
+	assert.False(t, dist.Configs["digestMovable"].Pinned, "movable should not be pinned")
+
+	// Force the rebalance and verify pinned checks are never relocated.
+	checksMoved := testDispatcher.rebalanceUsingUtilization(true)
+
+	requireNotLocked(t, testDispatcher.store)
+
+	for _, move := range checksMoved {
+		assert.NotEqual(t, "digestPinned1", move.Digest, "pinned1 must not move")
+		assert.NotEqual(t, "digestPinned2", move.Digest, "pinned2 must not move")
+	}
+
+	// Final placement: both pinned checks remain on node1 regardless of what
+	// the rebalancer decided to do with the movable check.
+	assert.Contains(t, testDispatcher.store.nodes["node1"].clcRunnerStats, "pinned1")
+	assert.Contains(t, testDispatcher.store.nodes["node1"].clcRunnerStats, "pinned2")
+	assert.NotContains(t, testDispatcher.store.nodes["node2"].clcRunnerStats, "pinned1")
+	assert.NotContains(t, testDispatcher.store.nodes["node2"].clcRunnerStats, "pinned2")
+}
+
 // Verifies that two configs sharing a check name but with different digests
 // (e.g., two postgres configs monitoring different databases) get separate
 // distribution entries and are moved independently.

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -1858,6 +1858,74 @@ func TestRebalanceUsingUtilization_PinsChecksWithoutExecutionTime(t *testing.T) 
 	assert.NotContains(t, testDispatcher.store.nodes["node2"].clcRunnerStats, "pinned2")
 }
 
+// Regression: when a pinned config and a movable config share a runner, the
+// pinned config's load must be accounted for before greedy placement so the
+// movable one is rebalanced off the (already overloaded) runner. Without the
+// two-loop split, sorting by WorkersNeeded places the heavier movable config
+// first while both runners still look empty, which anchors it to its current
+// (overloaded) runner.
+func TestRebalanceUsingUtilization_PinnedLoadAccountedBeforeGreedyPlacement(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	testDispatcher := newDispatcher(fakeTagger)
+
+	mockClient := &rebalanceTestClcRunnerClient{
+		testStats: make(map[string]types.CLCRunnersStats),
+	}
+	testDispatcher.clcRunnersClient = mockClient
+	testDispatcher.advancedDispatching.Store(true)
+
+	// Pin the "pinned" check via the exclusion list so it ends up with
+	// WorkersNeeded > 0 (the AverageExecutionTime == 0 path would give 0).
+	testDispatcher.excludedChecksFromDispatching = map[string]struct{}{
+		"pinned": {},
+	}
+
+	testDispatcher.store.active = true
+	testDispatcher.store.nodes["node1"] = newNodeStore("node1", "10.0.0.1")
+	testDispatcher.store.nodes["node1"].workers = pkgconfigsetup.DefaultNumWorkers
+	testDispatcher.store.nodes["node2"] = newNodeStore("node2", "10.0.0.2")
+	testDispatcher.store.nodes["node2"].workers = pkgconfigsetup.DefaultNumWorkers
+
+	// node1: pinned (0.6 workers) + movable (0.7 workers). node2: empty.
+	// With a default 15s interval, AvgExecTime in ms equals workersNeeded * 15000.
+	node1Stats := types.CLCRunnersStats{
+		"pinned":  {AverageExecutionTime: 9000, IsClusterCheck: true},  // 0.6 workers
+		"movable": {AverageExecutionTime: 10500, IsClusterCheck: true}, // 0.7 workers
+	}
+	testDispatcher.store.nodes["node1"].clcRunnerStats = node1Stats
+	mockClient.testStats["10.0.0.1"] = node1Stats
+	mockClient.testStats["10.0.0.2"] = types.CLCRunnersStats{}
+
+	testDispatcher.store.idToDigest = map[checkid.ID]string{
+		"pinned":  "digestPinned",
+		"movable": "digestMovable",
+	}
+	testDispatcher.store.digestToConfig = map[string]integration.Config{
+		"digestPinned":  {Name: "pinned"},
+		"digestMovable": {Name: "movable"},
+	}
+	testDispatcher.store.digestToNode = map[string]string{
+		"digestPinned":  "node1",
+		"digestMovable": "node1",
+	}
+
+	checksMoved := testDispatcher.rebalanceUsingUtilization(true)
+
+	requireNotLocked(t, testDispatcher.store)
+
+	// The pinned check must stay on node1; the movable one must move to node2
+	// because node1 already carries 0.6 workers of pinned load.
+	require.Len(t, checksMoved, 1)
+	assert.Equal(t, "digestMovable", checksMoved[0].Digest)
+	assert.Equal(t, "node1", checksMoved[0].SourceNodeName)
+	assert.Equal(t, "node2", checksMoved[0].DestNodeName)
+
+	assert.Contains(t, testDispatcher.store.nodes["node1"].clcRunnerStats, "pinned")
+	assert.NotContains(t, testDispatcher.store.nodes["node1"].clcRunnerStats, "movable")
+	assert.Contains(t, testDispatcher.store.nodes["node2"].clcRunnerStats, "movable")
+	assert.NotContains(t, testDispatcher.store.nodes["node2"].clcRunnerStats, "pinned")
+}
+
 // Verifies that two configs sharing a check name but with different digests
 // (e.g., two postgres configs monitoring different databases) get separate
 // distribution entries and are moved independently.

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -1886,25 +1886,25 @@ func TestRebalanceIsWorthIt(t *testing.T) {
 	// The proposed solution is worth it if it leaves less unused runners
 
 	currentDistribution := newConfigsDistribution(workersPerRunner)
-	currentDistribution.addConfig("check1", "check1", 1, "runner1")
-	currentDistribution.addConfig("check2", "check2", 1, "runner1")
+	currentDistribution.addConfig("check1", "check1", 1, "runner1", false)
+	currentDistribution.addConfig("check2", "check2", 1, "runner1", false)
 
 	proposedDistribution := newConfigsDistribution(workersPerRunner)
-	proposedDistribution.addConfig("check1", "check1", 1, "runner1")
-	proposedDistribution.addConfig("check2", "check2", 1, "runner2")
+	proposedDistribution.addConfig("check1", "check1", 1, "runner1", false)
+	proposedDistribution.addConfig("check2", "check2", 1, "runner2", false)
 
 	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10))
 
 	// The proposed	solution is worth it if it has fewer runners with a high utilization
 	currentDistribution = newConfigsDistribution(workersPerRunner)
-	currentDistribution.addConfig("check1", "check1", 1, "runner1")
-	currentDistribution.addConfig("check2", "check2", 1, "runner1")
-	currentDistribution.addConfig("check3", "check3", 1, "runner1")
+	currentDistribution.addConfig("check1", "check1", 1, "runner1", false)
+	currentDistribution.addConfig("check2", "check2", 1, "runner1", false)
+	currentDistribution.addConfig("check3", "check3", 1, "runner1", false)
 
 	proposedDistribution = newConfigsDistribution(workersPerRunner)
-	proposedDistribution.addConfig("check1", "check1", 1, "runner1")
-	proposedDistribution.addConfig("check2", "check2", 1, "runner2")
-	proposedDistribution.addConfig("check3", "check3", 1, "runner3")
+	proposedDistribution.addConfig("check1", "check1", 1, "runner1", false)
+	proposedDistribution.addConfig("check2", "check2", 1, "runner2", false)
+	proposedDistribution.addConfig("check3", "check3", 1, "runner3", false)
 
 	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10))
 }


### PR DESCRIPTION
### What does this PR do?

Whenever a check has an AverageExecutionTime of 0, leave it on it's previously scheduled runner until we can get better data about it's real runtime.

### Motivation

Avoid unscheduling a check which has never completed once. This helps longer running checks avoid being prematurely unscheduled during rebalancing.

[CONTP-1699]

### Describe how you validated your changes

Unit Tests and CI

[CONTP-1699]: https://datadoghq.atlassian.net/browse/CONTP-1699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ