### PR TITLE
Remove RETURN_IF_NOT_IN_SYSPROBE_TASK Fargate filter from fentry tracer

### DIFF
--- a/pkg/network/ebpf/c/co-re/tracer-fentry.c
+++ b/pkg/network/ebpf/c/co-re/tracer-fentry.c
@@ -21,37 +21,6 @@
 BPF_PERCPU_HASH_MAP(udp6_send_skb_args, u64, u64, 1024)
 BPF_PERCPU_HASH_MAP(udp_send_skb_args, u64, conn_tuple_t, 1024)
 
-#define RETURN_IF_NOT_IN_SYSPROBE_TASK(prog_name)           \
-    if (!event_in_task(prog_name)) {                        \
-        return 0;                                           \
-    }
-
-static __always_inline __u32 systemprobe_dev() {
-    __u64 val = 0;
-    LOAD_CONSTANT("systemprobe_device", val);
-    return (__u32)val;
-}
-
-static __always_inline __u32 systemprobe_ino() {
-    __u64 val = 0;
-    LOAD_CONSTANT("systemprobe_ino", val);
-    return (__u32)val;
-}
-
-static __always_inline bool event_in_task(char *prog_name) {
-    __u32 dev = systemprobe_dev();
-    __u32 ino = systemprobe_ino();
-    struct bpf_pidns_info ns = {};
-
-    u64 error = bpf_get_ns_current_pid_tgid(dev, ino, &ns, sizeof(struct bpf_pidns_info));
-
-    if (error) {
-        log_debug("%s: err=event originates from outside current fargate task", prog_name);
-    }
-
-    return !error;
-}
-
 static __always_inline int read_conn_tuple_partial_from_flowi4(conn_tuple_t *t, struct flowi4 *fl4, u64 pid_tgid, metadata_mask_t type) {
     t->pid = GET_USER_MODE_PID(pid_tgid);
     t->metadata = type;
@@ -138,7 +107,6 @@ static __always_inline int read_conn_tuple_partial_from_flowi6(conn_tuple_t *t, 
 
 SEC("fexit/tcp_sendmsg")
 int BPF_PROG(tcp_sendmsg_exit, struct sock *sk, struct msghdr *msg, size_t size, int sent) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/tcp_sendmsg");
     if (sent < 0) {
         log_debug("fexit/tcp_sendmsg: tcp_sendmsg err=%d", sent);
         return 0;
@@ -163,7 +131,6 @@ int BPF_PROG(tcp_sendmsg_exit, struct sock *sk, struct msghdr *msg, size_t size,
 
 SEC("fexit/tcp_sendpage")
 int BPF_PROG(tcp_sendpage_exit, struct sock *sk, struct page *page, int offset, size_t size, int flags, int sent) {
-RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/tcp_sendpage");
     if (sent < 0) {
         log_debug("fexit/tcp_sendpage: err=%d", sent);
         return 0;
@@ -188,7 +155,6 @@ RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/tcp_sendpage");
 
 SEC("fexit/udp_sendpage")
 int BPF_PROG(udp_sendpage_exit, struct sock *sk, struct page *page, int offset, size_t size, int flags, int sent) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/udp_sendpage");
     if (sent < 0) {
         log_debug("fexit/udp_sendpage: err=%d", sent);
         return 0;
@@ -207,7 +173,6 @@ int BPF_PROG(udp_sendpage_exit, struct sock *sk, struct page *page, int offset, 
 
 SEC("fexit/tcp_recvmsg")
 int BPF_PROG(tcp_recvmsg_exit, struct sock *sk, struct msghdr *msg, size_t len, int flags, int *addr_len, int copied) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/tcp_recvmsg");
     if (copied < 0) { // error
         return 0;
     }
@@ -218,7 +183,6 @@ int BPF_PROG(tcp_recvmsg_exit, struct sock *sk, struct msghdr *msg, size_t len, 
 
 SEC("fexit/tcp_recvmsg")
 int BPF_PROG(tcp_recvmsg_exit_pre_5_19_0, struct sock *sk, struct msghdr *msg, size_t len, int nonblock, int flags, int *addr_len, int copied) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/tcp_recvmsg");
     if (copied < 0) { // error
         return 0;
     }
@@ -229,7 +193,6 @@ int BPF_PROG(tcp_recvmsg_exit_pre_5_19_0, struct sock *sk, struct msghdr *msg, s
 
 SEC("fentry/tcp_close")
 int BPF_PROG(tcp_close, struct sock *sk, long timeout) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/tcp_close");
     conn_tuple_t t = {};
     u64 pid_tgid = bpf_get_current_pid_tgid();
 
@@ -267,7 +230,6 @@ static __always_inline int handle_udp_send(struct sock *sk, int sent) {
 
 SEC("kprobe/udp_v6_send_skb")
 int kprobe__udp_v6_send_skb(struct pt_regs *ctx) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("kprobe/udp_v6_send_skb");
     struct sk_buff *skb = (struct sk_buff*) PT_REGS_PARM1(ctx);
     struct flowi6 *fl6 = (struct flowi6*) PT_REGS_PARM2(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -288,13 +250,11 @@ int kprobe__udp_v6_send_skb(struct pt_regs *ctx) {
 
 SEC("fexit/udpv6_sendmsg")
 int BPF_PROG(udpv6_sendmsg_exit, struct sock *sk, struct msghdr *msg, size_t len, int sent) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/udpv6_sendmsg");
     return handle_udp_send(sk, sent);
 }
 
 SEC("kprobe/udp_send_skb")
 int kprobe__udp_send_skb(struct pt_regs *ctx) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("kprobe/udp_send_skb");
     struct sk_buff *skb = (struct sk_buff*) PT_REGS_PARM1(ctx);
     struct flowi4 *fl4 = (struct flowi4*) PT_REGS_PARM2(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -315,7 +275,6 @@ int kprobe__udp_send_skb(struct pt_regs *ctx) {
 
 SEC("fexit/udp_sendmsg")
 int BPF_PROG(udp_sendmsg_exit, struct sock *sk, struct msghdr *msg, size_t len, int sent) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/udp_sendmsg");
     return handle_udp_send(sk, sent);
 }
 
@@ -338,14 +297,12 @@ static __always_inline int handle_udp_recvmsg_ret() {
 
 SEC("fentry/udp_recvmsg")
 int BPF_PROG(udp_recvmsg, struct sock *sk, struct msghdr *msg, size_t len, int noblock, int flags) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/udp_recvmsg");
     log_debug("fentry/udp_recvmsg: flags: %x", flags);
     return handle_udp_recvmsg(sk, flags);
 }
 
 SEC("fentry/udpv6_recvmsg")
 int BPF_PROG(udpv6_recvmsg, struct sock *sk, struct msghdr *msg, size_t len, int noblock, int flags) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/udpv6_recvmsg");
     log_debug("fentry/udpv6_recvmsg: flags: %x", flags);
     return handle_udp_recvmsg(sk, flags);
 }
@@ -354,7 +311,6 @@ SEC("fexit/udp_recvmsg")
 int BPF_PROG(udp_recvmsg_exit, struct sock *sk, struct msghdr *msg, size_t len,
              int flags, int *addr_len,
              int copied) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/udp_recvmsg");
     return handle_udp_recvmsg_ret();
 }
 
@@ -362,7 +318,6 @@ SEC("fexit/udp_recvmsg")
 int BPF_PROG(udp_recvmsg_exit_pre_5_19_0, struct sock *sk, struct msghdr *msg, size_t len, int noblock,
              int flags, int *addr_len,
              int copied) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/udp_recvmsg");
     return handle_udp_recvmsg_ret();
 }
 
@@ -370,7 +325,6 @@ SEC("fexit/udpv6_recvmsg")
 int BPF_PROG(udpv6_recvmsg_exit, struct sock *sk, struct msghdr *msg, size_t len,
              int flags, int *addr_len,
              int copied) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/udpv6_recvmsg");
     return handle_udp_recvmsg_ret();
 }
 
@@ -378,31 +332,26 @@ SEC("fexit/udpv6_recvmsg")
 int BPF_PROG(udpv6_recvmsg_exit_pre_5_19_0, struct sock *sk, struct msghdr *msg, size_t len, int noblock,
              int flags, int *addr_len,
              int copied) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/udpv6_recvmsg");
     return handle_udp_recvmsg_ret();
 }
 
 SEC("fentry/skb_free_datagram_locked")
 int BPF_PROG(skb_free_datagram_locked, struct sock *sk, struct sk_buff *skb) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/skb_free_datagram_locked");
     return handle_skb_consume_udp(sk, skb, 0);
 }
 
 SEC("fentry/__skb_free_datagram_locked")
 int BPF_PROG(__skb_free_datagram_locked, struct sock *sk, struct sk_buff *skb, int len) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/__skb_free_datagram_locked");
     return handle_skb_consume_udp(sk, skb, len);
 }
 
 SEC("fentry/skb_consume_udp")
 int BPF_PROG(skb_consume_udp, struct sock *sk, struct sk_buff *skb, int len) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/skb_consume_udp");
     return handle_skb_consume_udp(sk, skb, len);
 }
 
 SEC("fentry/tcp_retransmit_skb")
 int BPF_PROG(tcp_retransmit_skb, struct sock *sk, struct sk_buff *skb, int segs, int err) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/tcp_retransmit_skb");
     log_debug("fexntry/tcp_retransmit");
     u64 pid_tgid = bpf_get_current_pid_tgid();
     tcp_retransmit_skb_args_t args = {};
@@ -418,7 +367,6 @@ int BPF_PROG(tcp_retransmit_skb, struct sock *sk, struct sk_buff *skb, int segs,
 
 SEC("fexit/tcp_retransmit_skb")
 int BPF_PROG(tcp_retransmit_skb_exit, struct sock *sk, struct sk_buff *skb, int segs, int err) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/tcp_retransmit_skb");
     log_debug("fexit/tcp_retransmit");
     u64 pid_tgid = bpf_get_current_pid_tgid();
     if (err < 0) {
@@ -442,7 +390,6 @@ int BPF_PROG(tcp_retransmit_skb_exit, struct sock *sk, struct sk_buff *skb, int 
 
 SEC("fentry/tcp_connect")
 int BPF_PROG(tcp_connect, struct sock *sk) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/tcp_connect");
     u64 pid_tgid = bpf_get_current_pid_tgid();
     log_debug("fentry/tcp_connect: kernel thread id: %llu, user mode pid: %llu", GET_KERNEL_THREAD_ID(pid_tgid), GET_USER_MODE_PID(pid_tgid));
 
@@ -461,7 +408,6 @@ int BPF_PROG(tcp_connect, struct sock *sk) {
 
 SEC("fentry/tcp_finish_connect")
 int BPF_PROG(tcp_finish_connect, struct sock *sk, struct sk_buff *skb, int rc) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/tcp_finish_connect");
     conn_tuple_t t = {};
     if (!read_conn_tuple(&t, sk, 0, CONN_TYPE_TCP)) {
         increment_telemetry_count(tcp_finish_connect_failed_tuple);
@@ -486,7 +432,6 @@ int BPF_PROG(tcp_finish_connect, struct sock *sk, struct sk_buff *skb, int rc) {
 
 SEC("fexit/inet_csk_accept")
 int BPF_PROG(inet_csk_accept_exit, struct sock *_sk, int flags, int *err, bool kern, struct sock *sk) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/inet_csk_accept");
     if (sk == NULL) {
         return 0;
     }
@@ -515,7 +460,6 @@ int BPF_PROG(inet_csk_accept_exit, struct sock *_sk, int flags, int *err, bool k
 
 SEC("fentry/inet_csk_listen_stop")
 int BPF_PROG(inet_csk_listen_stop_enter, struct sock *sk) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/inet_csk_listen_stop");
     __u16 lport = read_sport(sk);
     if (lport == 0) {
         log_debug("ERR(inet_csk_listen_stop): lport is 0 ");
@@ -561,40 +505,34 @@ static __always_inline int handle_udp_destroy_sock(void *ctx, struct sock *sk) {
 
 SEC("fentry/udp_destroy_sock")
 int BPF_PROG(udp_destroy_sock, struct sock *sk) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/udp_destroy_sock");
     return handle_udp_destroy_sock(ctx, sk);
 }
 
 SEC("fentry/udpv6_destroy_sock")
 int BPF_PROG(udpv6_destroy_sock, struct sock *sk) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/udpv6_destroy_sock");
     return handle_udp_destroy_sock(ctx, sk);
 }
 
 SEC("fentry/inet_bind")
 int BPF_PROG(inet_bind_enter, struct socket *sock, struct sockaddr *uaddr, int addr_len) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/inet_bind");
     log_debug("fentry/inet_bind");
     return sys_enter_bind(sock, uaddr);
 }
 
 SEC("fentry/inet6_bind")
 int BPF_PROG(inet6_bind_enter, struct socket *sock, struct sockaddr *uaddr, int addr_len) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fentry/inet6_bind");
     log_debug("fentry/inet6_bind");
     return sys_enter_bind(sock, uaddr);
 }
 
 SEC("fexit/inet_bind")
 int BPF_PROG(inet_bind_exit, struct socket *sock, struct sockaddr *uaddr, int addr_len, int rc) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/inet_bind");
     log_debug("fexit/inet_bind: rc=%d", rc);
     return sys_exit_bind(rc);
 }
 
 SEC("fexit/inet6_bind")
 int BPF_PROG(inet6_bind_exit, struct socket *sock, struct sockaddr *uaddr, int addr_len, int rc) {
-    RETURN_IF_NOT_IN_SYSPROBE_TASK("fexit/inet6_bind");
     log_debug("fexit/inet6_bind: rc=%d", rc);
     return sys_exit_bind(rc);
 }

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -10,8 +10,6 @@ package fentry
 import (
 	"errors"
 	"fmt"
-	"os"
-	"syscall"
 
 	manager "github.com/DataDog/ebpf-manager"
 
@@ -67,19 +65,6 @@ func initFentryTracer(ar bytecode.AssetReader, o manager.Options, config *config
 	}
 
 	initManager(m)
-
-	file, err := os.Stat("/proc/self/ns/pid")
-	if err != nil {
-		return fmt.Errorf("could not load sysprobe pid: %w", err)
-	}
-	pidStat := file.Sys().(*syscall.Stat_t)
-	o.ConstantEditors = append(o.ConstantEditors, manager.ConstantEditor{
-		Name:  "systemprobe_device",
-		Value: pidStat.Dev,
-	}, manager.ConstantEditor{
-		Name:  "systemprobe_ino",
-		Value: pidStat.Ino,
-	})
 
 	// exclude all non-enabled probes to ensure we don't run into problems with unsupported probe types
 	for _, p := range m.Probes {


### PR DESCRIPTION
This eBPF-side PID-namespace filter was originally added to keep a system-probe sidecar from observing events outside its own Fargate task. It is dead code today: eBPF is not currently supported in Fargate (Datadog's Fargate path is ebpfless).

Removes:
- The RETURN_IF_NOT_IN_SYSPROBE_TASK macro and its 31 call sites in tracer-fentry.c.
- The event_in_task / systemprobe_dev / systemprobe_ino helpers.
- The Go-side ConstantEditor block that read /proc/self/ns/pid and populated systemprobe_device / systemprobe_ino.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
