### PR TITLE
Validate DNS monitoring port range and harden empty-list fallback

### DIFF
--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -334,17 +334,25 @@ func New() *Config {
 		log.Warnf("failed to parse dns_monitoring_ports: %v", err)
 	}
 
+	dnsPortsKey := sysconfig.FullKeyPath(netNS, "dns_monitoring_ports")
+	c.DNSMonitoringPortList = slices.DeleteFunc(c.DNSMonitoringPortList, func(port int) bool {
+		if port < 1 || port > 65535 {
+			log.Warnf("CNM detected and removed invalid port %d from %s (must be 1-65535)", port, dnsPortsKey)
+			return true
+		}
+		if port == 80 || port == 443 {
+			log.Warnf("CNM detected and removed HTTP port %d from %s, which is unsupported due to the large volume of traffic it would capture", port, dnsPortsKey)
+			return true
+		}
+		return false
+	})
+
+	// Fall back to the default only after sanitization: a config containing only
+	// invalid/HTTP/out-of-range ports must not be left empty, which would disable
+	// DNS monitoring on the eBPF path or capture all traffic on the classic-BPF path.
 	if len(c.DNSMonitoringPortList) == 0 {
 		c.DNSMonitoringPortList = []int{53}
 	}
-
-	c.DNSMonitoringPortList = slices.DeleteFunc(c.DNSMonitoringPortList, func(port int) bool {
-		isHTTP := port == 80 || port == 443
-		if isHTTP {
-			log.Warnf("CNM detected and removed HTTP port %d from %s, which is unsupported due to the large volume of traffic it would capture", port, sysconfig.FullKeyPath(netNS, "dns_monitoring_ports"))
-		}
-		return isHTTP
-	})
 
 	if !c.EnableProcessEventMonitoring {
 		log.Info("network process event monitoring disabled")

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -627,4 +627,56 @@ func TestDNSMonitoringPorts(t *testing.T) {
 		cfg := New()
 		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
 	})
+
+	t.Run("via YAML - out-of-range ports should be removed", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.dns_monitoring_ports", []int{53, 0, -1, 65536, 99999, 5353})
+		cfg := New()
+		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via env var - many space-separated ports", func(t *testing.T) {
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "1 2 3 4 5 6 7 53")
+		mock.NewSystemProbe(t)
+		cfg := New()
+		assert.Equal(t, []int{1, 2, 3, 4, 5, 6, 7, 53}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via env var - out-of-range ports should be removed", func(t *testing.T) {
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "53 -1 65536 99999 5353")
+		mock.NewSystemProbe(t)
+		cfg := New()
+		assert.Equal(t, []int{53, 5353}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via env var - empty string falls back to default", func(t *testing.T) {
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "")
+		mock.NewSystemProbe(t)
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via env var - all HTTP ports fall back to default", func(t *testing.T) {
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "80 443")
+		mock.NewSystemProbe(t)
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
+	})
+
+	t.Run("via env var - all out-of-range ports fall back to default", func(t *testing.T) {
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "0 65536")
+		mock.NewSystemProbe(t)
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
+	})
+
+	// With the generic string-to-numeric-slice converter, a single malformed
+	// token fails the whole env-var parse (it is not coerced to 0 per-element),
+	// so the override is ignored and the default is used.
+	t.Run("via env var - a malformed token invalidates the override", func(t *testing.T) {
+		t.Setenv("DD_NETWORK_CONFIG_DNS_MONITORING_PORTS", "53 not-a-port 5353")
+		mock.NewSystemProbe(t)
+		cfg := New()
+		assert.Equal(t, []int{53}, cfg.DNSMonitoringPortList)
+	})
 }


### PR DESCRIPTION
Builds on the generic string-to-numeric-slice env-var parsing (EnableStringUnmarshal) by adding DNS-port-specific sanitization in config.New():

- Reject out-of-range ports (must be 1-65535) in addition to the existing HTTP-port (80/443) removal. Out-of-range values corrupt the eBPF LOAD_CONSTANT slot encoding and silently disable the filter.
- Sanitize first, then fall back to [53]. Previously the fallback ran before HTTP removal, so a config of only invalid/HTTP ports (e.g. "80 443") left the list empty — disabling DNS monitoring on the eBPF path and capturing all traffic on the classic-BPF path.

Expands TestDNSMonitoringPorts with out-of-range, all-invalid, and fallback cases. A single malformed token now fails the whole env-var parse (the generic converter is all-or-nothing, not per-element zero coercion) and falls back to the default.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
