### PR TITLE
Fix Go SDK overriding rules to use the exact `go.work` version

### DIFF
--- a/bazel/rules/go_fast/repo.bzl
+++ b/bazel/rules/go_fast/repo.bzl
@@ -1,6 +1,5 @@
 """Repository rule for building a patched cmd/go binary."""
 
-load("@go_host_compatible_sdk_label//:defs.bzl", "HOST_COMPATIBLE_SDK")
 load("@rules_python//python/private:repo_utils.bzl", "repo_utils")  # buildifier: disable=bzl-visibility
 
 _PATCHED = [
@@ -10,6 +9,7 @@ _PATCHED = [
 
 def _impl(rctx):
     sdk = rctx.path(rctx.attr._go_sdk).dirname
+    rctx.watch(sdk.get_child("VERSION"))  # invalidate on SDK bump, since non-overlaid files can differ across patches
     replace = {}
     for path in _PATCHED:
         src = sdk.get_child(path)
@@ -33,7 +33,7 @@ def _impl(rctx):
 go_fast = repository_rule(
     implementation = _impl,
     attrs = {
-        "_go_sdk": attr.label(default = HOST_COMPATIBLE_SDK),
+        "_go_sdk": attr.label(default = "@go_work_sdk//:ROOT"),
         "patch": attr.label(default = "//bazel/rules/go_fast:avoid-redundant-work-in-go-work-sync.patch"),
     },
 )

--- a/bazel/rules/go_sdk_overrides/repo.bzl
+++ b/bazel/rules/go_sdk_overrides/repo.bzl
@@ -1,6 +1,5 @@
 """Repository rule for patching Go SDK packages into a local repo."""
 
-load("@go_host_compatible_sdk_label//:defs.bzl", "HOST_COMPATIBLE_SDK")
 load("@rules_python//python/private:repo_utils.bzl", "repo_utils")  # buildifier: disable=bzl-visibility
 load("//bazel/rules/go_sdk_overrides:defs.bzl", "OVERRIDES", "PATCHES")
 
@@ -27,7 +26,7 @@ def _impl(rctx):
 go_sdk_overrides = repository_rule(
     implementation = _impl,
     attrs = {
-        "_go_sdk": attr.label(default = HOST_COMPATIBLE_SDK),
+        "_go_sdk": attr.label(default = "@go_work_sdk//:ROOT"),
         "_gopatch": attr.label(default = "@com_github_uber_go_gopatch//:gopatch"),
         "overrides": attr.string_keyed_label_dict(default = OVERRIDES),
         "patches": attr.label_list(default = PATCHES),

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -1,6 +1,9 @@
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.from_file(go_work = "//:go.work")
-use_repo(go_sdk, "go_host_compatible_sdk_label")
+go_sdk.from_file(
+    name = "go_work_sdk",
+    go_work = "//:go.work",
+)
+use_repo(go_sdk, "go_work_sdk")
 # go_sdk.nogo(nogo = "//:nogo")  # TODO(agent-build): assess benefits of the `nogo` static code analyzer
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")


### PR DESCRIPTION
### What does this PR do?
Make `go_fast` and `go_sdk_overrides` rules deterministically reflect the Go SDK pinned by `go.work`, closing two **reproducibility gaps**:
- selection: build from the `go.work`-pinned SDK version (`@go_work_sdk//:ROOT`, now ubiquitously named in `go_sdk.from_file`) instead of `HOST_COMPATIBLE_SDK`, which allows to drop the now-unused `go_host_compatible_sdk_label`,
- invalidation: watch the SDK's `VERSION` in `go_fast` so it re-evaluates when the Go version changes.

`go_sdk_overrides` switches to `@go_work_sdk` but does not need to watch its `VERSION` because it only copies/patches specific files, so identical source yields identical output: its tailored per-file watches are exactly what we want.

### Motivation
@pgimalac [spotted this inconsistency](https://dd.slack.com/archives/C08SK4B0FK8/p1780579008776269?thread_ts=1780492409.028439&cid=C08SK4B0FK8) while we were investigating `go work sync` slowness: the `bazel`-built `go_fast` did not match the `go.work` Go version (that slowness is addressed separately, this change is only about a reproducibility fix).

`go_fast` overlays files onto the SDK's `cmd/go`, so it must match the `go.work`-pinned SDK.
Two ways it could drift, both non-reproducible:
- `HOST_COMPATIBLE_SDK` is `rules_go`'s **first host-compatible** toolchain, not necessarily matching the exact `go.work`-pinned SDK: their patch version may diverge,
- `go_fast` watched only the two files it overlays (`src/cmd/go/internal/modload/[buildlist|load].go`), which are byte-identical across most patch releases (e.g. 1.25.9 to 1.25.10), so a bump invalidated nothing and `go_fast` stayed the cached binary.

### Describe how you validated your changes
Before this change (`HOST_COMPATIBLE_SDK`, no `VERSION` watch):
```
$ bazel run //:go -- version
go version go1.25.10 linux/amd64
$ sed -i '1s/1.25.10/1.25.9/' go.work
$ bazel run //:go -- version
go version go1.25.10 linux/amd64  # stale: did not follow go.work
```
After this change:
```
$ sed -i '1s/1.25.10/1.25.9/' go.work
$ bazel run //:go -- version
go version go1.25.9 linux/amd64  # rebuilt to match go.work
```

### Additional Notes
See `rules_go`'s [Go SDK](https://github.com/bazel-contrib/rules_go/blob/master/go/toolchains.rst#the-sdk).