### PR TITLE
[AGENTRUN-1334] fix(e2e): increase timeout of agent stop eventually in auth artifact e2e test

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/auth_artifact_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/auth_artifact_common_test.go
@@ -119,7 +119,7 @@ func (a *authArtifactBase) checkAuthStack() {
 	a.EventuallyWithT(func(c *assert.CollectT) {
 		_, err = a.svcManager.Status(a.svcName)
 		require.Error(c, err)
-	}, 10*time.Second, 1*time.Second, "datadog Agent should be stopped")
+	}, 15*time.Second, 1*time.Second, "datadog Agent should be stopped")
 
 	// Removing log files and artifacts files
 	a.Env().RemoteHost.MustExecute(fmt.Sprintf(a.removeFilesCmdTmpl, a.logFolder, a.authTokenPath, a.ipcCertPath))


### PR DESCRIPTION
### What does this PR do?

Increases the agent stop eventually timeout from 10 to 15 seconds in `TestServersideIPCCertUsage` to fix flakiness on Windows

### Motivation

`TestServersideIPCCertUsage` started recently to be flaky on Windows

### Describe how you validated your changes

CI

### Additional Notes
