### PR TITLE
packaging/aix: add missing pre-flight checks to build.sh

### DIFF
--- a/packaging/aix/build.sh
+++ b/packaging/aix/build.sh
@@ -70,6 +70,10 @@ check_tool cmake      cmake
 check_tool gcc        gcc
 check_tool python3.12 python3.12
 check_tool go         golang
+check_tool dump       bos.perf.tools
+check_tool mkinstallp bos.adt.insttools
+
+check_tool strip binutils
 
 # Several libraries are taken from AIX Toolbox (source builds fail on AIX).
 # Check that all required -devel packages are installed.
@@ -92,12 +96,20 @@ check_aix_devel /opt/freeware/include/gdbm.h          gdbm-devel
 check_aix_devel /opt/freeware/lib/libgdbm.a           gdbm-devel
 check_aix_devel /opt/freeware/include/libxslt/xslt.h  libxslt-devel
 check_aix_devel /opt/freeware/lib/libxslt.a           libxslt-devel
+# libexslt ships with libxslt-devel; stage 01 copies it silently if present.
+check_aix_devel /opt/freeware/lib/libexslt.a          libxslt-devel
 
 # ── Source shared environment ─────────────────────────────────────────────────
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=/dev/null
 . "$SCRIPT_DIR/lib/env.sh"
+
+# Rust SDK cargo — checked after env.sh so RUST_VERSION is available.
+# Required by stage 05 (cryptography, ~15 min), stage 06 (pydantic-core,
+# ~52 min), and stage 07 (jellyfish). Failing here avoids wasting that time.
+check_tool "/opt/freeware/lib/RustSDK/${RUST_VERSION}/bin/cargo" \
+    "rust${RUST_VERSION}.ppc cargo${RUST_VERSION}.ppc rust${RUST_VERSION}-std-static.ppc"
 
 # ── Bootstrap build directories ───────────────────────────────────────────────
 

--- a/packaging/aix/stages/09-strip-bytecode.sh
+++ b/packaging/aix/stages/09-strip-bytecode.sh
@@ -31,14 +31,18 @@ trap cleanup EXIT
 
 # ─── Step 1: Strip debug info from shared libraries ───────────────────────────
 #
-# /opt/freeware/bin/strip supports -X64 (required for XCOFF64 binaries on AIX).
-# The system /usr/bin/strip is 32-bit only and will refuse or silently corrupt
-# 64-bit XCOFF objects. Use while-read rather than for-f-in-$(find) to avoid
-# command substitution size limits and to handle filenames with spaces safely.
+# strip -X64 selects 64-bit XCOFF object mode; the system /usr/bin/strip
+# handles XCOFF64 correctly on AIX 7.x.
+# -type f skips symlinks so each physical file is processed exactly once
+# (the lib directory contains versioned symlinks like libxml2.so -> libxml2.so.16.0.5).
+# Use while-read rather than for-f-in-$(find) to avoid command substitution
+# size limits and to handle filenames with spaces safely.
 
 log "Stripping debug info from .so files under $EMBEDDED_DESTDIR/lib"
-find "$EMBEDDED_DESTDIR/lib" -name "*.so*" | while IFS= read -r f; do
-    /opt/freeware/bin/strip -X64 "$f" 2>/dev/null || true
+find "$EMBEDDED_DESTDIR/lib" -type f -name "*.so*" | while IFS= read -r f; do
+    # AIX strip exits 255 with "0654-420 already stripped" for files distributed
+    # without debug symbols (e.g. toolbox libs like liblzma, libxml2); ignore it.
+    strip -X64 "$f" 2>/dev/null || true
 done
 log "Strip pass complete"
 


### PR DESCRIPTION
### What does this PR do?

Add missing pre-flight checks to `packaging/aix/build.sh` so the build fails early with a clear error instead of hours into the pipeline.

Also fixes stage 09 to use the bare `strip` command like other steps do.

### Motivation
Fail early if anything is missing.

### Describe how you validated your changes
Manual checking on an AIX host.

### Additional Notes