### PR TITLE
tasks/build_tags: exclude sharedlibrarycheck from AIX builds

### DIFF
--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -9,6 +9,7 @@
 ## Unreleased
 
 <!-- Add entries here for changes not yet in a release. -->
+- Remove `sharedlibrarycheck` from the AIX agent build (the shared-library check loader was included but not validated on AIX)
 
 ---
 

--- a/tasks/build_tags.bzl
+++ b/tasks/build_tags.bzl
@@ -310,6 +310,7 @@ AIX_EXCLUDED_TAGS = set([
     "orchestrator",
     "pcap",
     "podman",
+    "sharedlibrarycheck",
     "systemd",
     "systemprobechecks",
     "trivy",


### PR DESCRIPTION
### What does this PR do?

Add `sharedlibrarycheck` to `AIX_EXCLUDED_TAGS` in `build_tags.bzl`.

### Motivation
Not supported on AIX.

### Describe how you validated your changes

Build tag change only.

### Additional Notes