### PR TITLE
Use registry.datadoghq.com for admission defaults

### DIFF
--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -667,7 +667,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.mutation.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.mutate_unlabelled", false)
 	config.BindEnvAndSetDefault("admission_controller.port", 8000)
-	config.BindEnvAndSetDefault("admission_controller.container_registry", "gcr.io/datadoghq")
+	config.BindEnvAndSetDefault("admission_controller.container_registry", "registry.datadoghq.com")
 	config.BindEnvAndSetDefault("admission_controller.timeout_seconds", 10) // in seconds (see kubernetes/kubernetes#71508)
 	config.BindEnvAndSetDefault("admission_controller.service_name", "datadog-admission-controller")
 	config.BindEnvAndSetDefault("admission_controller.certificate.validity_bound", 365*24)             // validity bound of the certificate created by the controller (in hours, default 1 year)

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -72,6 +72,7 @@ func TestDefaults(t *testing.T) {
 
 	assert.True(t, config.GetBool("logs_config.tag_multi_line_logs"))
 	assert.True(t, config.GetBool("logs_config.tag_truncated_logs"))
+	assert.Equal(t, "registry.datadoghq.com", config.GetString("admission_controller.container_registry"))
 }
 
 func TestUnexpectedUnicode(t *testing.T) {

--- a/releasenotes/notes/admission-controller-registry-default-2e74df9a739bd513.yaml
+++ b/releasenotes/notes/admission-controller-registry-default-2e74df9a739bd513.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The Cluster Agent admission controller now defaults to ``registry.datadoghq.com`` for injected Datadog images.
+    Existing ``admission_controller.container_registry`` overrides continue to be honored.

--- a/test/new-e2e/tests/ssi/ssi_test.go
+++ b/test/new-e2e/tests/ssi/ssi_test.go
@@ -358,9 +358,9 @@ func (v *ssiSuite) TestWorkloadSelection() {
 }
 
 func (v *ssiSuite) TestRegistryAllowList() {
-	// All three apps run in the same cluster with allow list = gcr.io/datadoghq.
-	// The default container registry for injector and library images is gcr.io/datadoghq.
-	// - "allowed": default injector and library, both from gcr.io/datadoghq — injection proceeds.
+	// All three apps run in the same cluster with allow list = registry.datadoghq.com.
+	// The default container registry for injector and library images is registry.datadoghq.com.
+	// - "allowed": default injector and library, both from registry.datadoghq.com — injection proceeds.
 	// - "injector-blocked": injector image overridden to fake.registry.invalid — injection blocked.
 	// - "library-blocked": injector is allowed, but python-lib.custom-image points to
 	//   fake.registry.invalid — injection blocked by library registry check.

--- a/test/new-e2e/tests/ssi/testdata/registry_allow_list.yaml
+++ b/test/new-e2e/tests/ssi/testdata/registry_allow_list.yaml
@@ -4,9 +4,9 @@ clusterAgent:
     configMode: "hostip"
   env:
     - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY_ALLOW_LIST
-      value: "gcr.io/datadoghq"
+      value: "registry.datadoghq.com"
     # Disable gradual rollout so the injector resolves deterministically to
-    # gcr.io/datadoghq (the NoOpResolver). Without this, the rollout
+    # registry.datadoghq.com (the NoOpResolver). Without this, the rollout
     # resolver may return an image from a different registry, causing the
     # allow list check to block the "allowed" pod unexpectedly.
     - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_GRADUAL_ROLLOUT_ENABLED


### PR DESCRIPTION
## What

Update the Cluster Agent admission controller fallback registry from `gcr.io/datadoghq` to `registry.datadoghq.com` for injected Datadog images.

## Why

The public container registry guidance now recommends `registry.datadoghq.com` as the simple/default Datadog registry, while keeping cloud-provider registries available when users explicitly choose them. This aligns the Agent-side default with that guidance without changing existing `admission_controller.container_registry` overrides.

## Validation

- `dda inv test --targets=./pkg/config/setup`
- pre-push hooks (`go-mod-tidy`, `go-mod-replace`, `go-test`, `go-linter`)