### PR TITLE
Fix possible overflows in working_set metric

### DIFF
--- a/pkg/util/containers/metrics/docker/collector_linux.go
+++ b/pkg/util/containers/metrics/docker/collector_linux.go
@@ -54,7 +54,7 @@ func convertMemoryStats(memStats *container.MemoryStats) *provider.ContainerMemS
 	}
 
 	inactiveFile := getFieldFromMap(memStats.Stats, "total_inactive_file", "inactive_file")
-	if inactiveFile != nil {
+	if inactiveFile != nil && *inactiveFile < *containerMemStats.UsageTotal {
 		containerMemStats.WorkingSet = pointer.Ptr(*containerMemStats.UsageTotal - *inactiveFile)
 	}
 

--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -364,7 +364,7 @@ func buildMemoryStats(cgs *cgroups.MemoryStats) *provider.ContainerMemStats {
 	convertFieldAndUnit(cgs.PSISome.Total, &cs.PartialStallTime, float64(time.Microsecond))
 
 	// Compute complex fields
-	if cgs.UsageTotal != nil && cgs.InactiveFile != nil {
+	if cgs.UsageTotal != nil && cgs.InactiveFile != nil && *cgs.InactiveFile < *cgs.UsageTotal {
 		cs.WorkingSet = pointer.Ptr(float64(*cgs.UsageTotal - *cgs.InactiveFile))
 	}
 


### PR DESCRIPTION
### What does this PR do?

Fix possible overflows in working_set metric when collection of two different files happen to bring normally impossible values

### Motivation

Fix aberrant values of `container.memory.working_set` in some scenarios.

### Describe how you validated your changes

Change is difficult to validate because reproduction is hard, seems to be limited to specific conditions.

### Additional Notes

Completing fix from https://github.com/DataDog/datadog-agent/pull/40168 for all scenarios.