### PR TITLE
Theomagellan/preview docs

### DIFF
--- a/cmd/host-profiler/deploy/README.md
+++ b/cmd/host-profiler/deploy/README.md
@@ -1,0 +1,63 @@
+# Deploying Datadog's Host Profiler
+
+The Host Profiler collects CPU and memory profiles at the OS level across all processes, regardless of language or runtime.
+
+All commands in these docs assume you are running from this directory:
+
+```shell
+cd cmd/host-profiler/deploy
+```
+
+**If the Datadog Agent is already deployed on your cluster**, use **[Bundled](bundled/README.md)** mode. The host profiler runs as a sidecar and the Agent enriches profiles.
+
+**Otherwise**, use **[Standalone](standalone/README.md)** mode. The host profiler runs independently with no Agent required.
+
+If something isn't working, see [Troubleshooting](troubleshooting.md).
+
+## Requirements
+
+**OS:** Linux (kernel 5.10+)
+
+**Architecture:** amd64, arm64
+
+## Common usage
+
+### Service naming
+
+The host profiler determines each process's service name from its `OTEL_SERVICE_NAME` environment variable.
+
+If `OTEL_SERVICE_NAME` is not set, the profiler infers the service name from the binary name. For interpreted languages, this is the interpreter name (for example, `java` for a Java process). If multiple services share the same interpreter and none set `OTEL_SERVICE_NAME`, their profiles are grouped under the same inferred name.
+
+Set `OTEL_SERVICE_NAME` on each workload to identify them separately:
+
+```yaml
+env:
+  - name: OTEL_SERVICE_NAME
+    value: my-service
+```
+
+#### Datadog-specific naming
+
+The profiler is also compatible with `DD_SERVICE` as replacement for `OTEL_SERVICE_NAME`.
+
+Set `DD_ENV` and `DD_VERSION` for richer filtering in the Profiler UI.
+
+### Manually uploading debug symbols
+
+For compiled languages (C, C++, Rust, Go), the host profiler uploads debug symbols to Datadog for symbolization. Binaries must include debug symbols (not stripped) for function names to appear in profiles.
+
+To upload symbols from stripped binaries:
+
+1. Install the [datadog-ci CLI](https://github.com/DataDog/datadog-ci).
+2. Set your API key and site:
+
+```shell
+export DD_API_KEY=<DATADOG_API_KEY>
+export DD_SITE=<DATADOG_SITE>
+```
+
+3. Upload symbols:
+
+```shell
+DD_BETA_COMMANDS_ENABLED=1 datadog-ci elf-symbols upload /path/to/build/symbols/
+```

--- a/cmd/host-profiler/deploy/apparmor-profile
+++ b/cmd/host-profiler/deploy/apparmor-profile
@@ -1,0 +1,28 @@
+profile dd-host-profiler flags=(attach_disconnected,mediate_deleted) {
+  # File access — unrestricted (readOnlyRootFilesystem + volume mounts handle this)
+  /       r,
+  /**     rwlkm,
+
+  # Network — unrestricted (NetworkPolicy handles egress)
+  network,
+  unix,
+
+  # Capabilities mirroring securityContext.capabilities.add
+  capability bpf,
+  capability perfmon,
+  capability sys_ptrace,
+  capability sys_resource,
+  capability dac_read_search,
+  capability syslog,
+  capability checkpoint_restore,
+  capability kill,
+  capability ipc_lock,
+
+  # Go runtime and host-wide process tracing
+  signal,
+  ptrace (read, readby, trace) peer=**,
+
+  # Only exec permitted: objcopy for symbol extraction
+  /usr/bin/objcopy ix,
+  /usr/bin/*objcopy ix,
+}

--- a/cmd/host-profiler/deploy/bundled/README.md
+++ b/cmd/host-profiler/deploy/bundled/README.md
@@ -1,0 +1,25 @@
+# Deploying Bundled
+
+The host profiler runs as a sidecar in the Datadog Agent DaemonSet.
+
+- **[Datadog Operator](operator.md)**: add annotations to your existing `DatadogAgent` CR.
+- **[Helm Charts](helm.md)**: add `hostProfiler` values to your existing Datadog Helm release.
+
+
+## Configuring the profiler
+
+The profiler infers [most of its configuration](https://github.com/DataDog/datadog-agent/tree/main/cmd/host-profiler#configuration-inference) from the core agent. The following settings can be overridden in the agent's config file:
+
+| Name | Values | Default | Description |
+| :---- | :---- | :---- | :---- |
+| `hostprofiler.debug.verbosity` | string | _(disabled)_ | Configures a [debug exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/debugexporter/README.md) |
+| `hostprofiler.additional_http_headers` | map[string]string | _(empty)_ | Adds additional headers to payloads |
+| `hostprofiler.ddprofiling.enabled` | bool | `false` | Enables Go Runtime Profiler |
+| `hostprofiler.ddprofiling.period` | int | `0` | Sampling rate |
+| `hostprofiler.health_metrics.enabled` | bool | `true` | Enables collector internal metrics collection |
+| `hostprofiler.health_metrics.target` | string | `127.0.0.1:8889` | Exposed Prometheus address |
+| `hostprofiler.hpflare.port` | int | `7778` | Exposed port to retrieve Host Profiler flares |
+
+## Verification
+
+After deploying the host profiler, profiles appear on the [Datadog Profiler](https://app.datadoghq.com/profiling) page within a few minutes. If profiles do not appear, see the [Troubleshooting](../troubleshooting.md) guide.

--- a/cmd/host-profiler/deploy/bundled/helm.md
+++ b/cmd/host-profiler/deploy/bundled/helm.md
@@ -1,0 +1,43 @@
+# Deploying Bundled: Using Helm Charts
+
+## Prerequisite
+
+Deploy the Datadog Agent using Helm (chart version 3.220.0 or later). See the [installation guide](https://app.datadoghq.com/fleet/install-agent/latest?platform=kubernetes).
+
+## Deploy
+
+1. Add to your `values.yaml` (create the file if you don't have one):
+
+```yaml
+datadog:
+  hostProfiler:
+    enabled: true
+    image: "registry.datadoghq.com/ddot-ebpf:7.81.0-preview-host-profiler-1.0"
+```
+
+2. Upgrade:
+
+```shell
+helm upgrade --install datadog datadog/datadog \
+  -f values.yaml \
+  --reuse-values \
+  -n datadog
+```
+
+The chart automatically configures all required capabilities and seccomp.
+
+Wait for the rollout to complete:
+
+```shell
+kubectl rollout status daemonset/datadog -n datadog
+```
+
+## AppArmor (optional)
+
+To use a custom AppArmor profile instead of `unconfined`, load [`apparmor-profile`](../apparmor-profile) on each node, then set:
+
+```yaml
+datadog:
+  hostProfiler:
+    apparmor: localhost/dd-host-profiler
+```

--- a/cmd/host-profiler/deploy/bundled/operator.md
+++ b/cmd/host-profiler/deploy/bundled/operator.md
@@ -1,0 +1,68 @@
+# Deploying Bundled: Using the Datadog Operator
+
+## Prerequisite
+
+Deploy the Datadog Agent using the Operator. See the [installation guide](https://app.datadoghq.com/fleet/install-agent/latest?platform=kubernetes).
+
+## Deploy
+
+Add the annotations to your existing `DatadogAgent` CR:
+
+```shell
+kubectl annotate datadogagent datadog \
+  agent.datadoghq.com/host-profiler-enabled="true" \
+  'experimental.agent.datadoghq.com/image-override-config={"host-profiler":{"name":"registry.datadoghq.com/ddot-ebpf:7.81.0-preview-host-profiler-1.0"}}' \
+  -n <namespace>
+```
+
+Or add them directly to your manifest and re-apply:
+
+```yaml
+metadata:
+  annotations:
+    agent.datadoghq.com/host-profiler-enabled: "true"
+    experimental.agent.datadoghq.com/image-override-config: |
+      {"host-profiler": {"name": "registry.datadoghq.com/ddot-ebpf:7.81.0-preview-host-profiler-1.0"}}
+```
+
+The Operator rolls out a new DaemonSet revision adding the host-profiler container. Agent pods restart one node at a time.
+
+The profiler will run fully privileged in this configuration as Operator does not yet apply security enforcements. If you wish to reduce privileges, see next section.
+
+## Capabilities and seccomp
+
+### Capabilities
+
+Apply the provided patch to set the required capabilities on the host-profiler container:
+
+```shell
+kubectl patch datadogagent datadog -n <namespace> --patch-file bundled/operator/override.yaml --type merge
+```
+
+### Seccomp (recommended)
+
+Provision the seccomp profile to each node through your cluster's node management tooling before deploying the host-profiler.
+
+The profile is at `/etc/dd-host-profiler/seccomp.json` inside the image. Copy it to `/var/lib/kubelet/seccomp/host-profiler.json` on every node, then add `seccompProfile` to [`operator/override.yaml`](operator/override.yaml):
+
+```yaml
+      containers:
+        host-profiler:
+          securityContext:
+            seccompProfile:
+              type: Localhost
+              localhostProfile: host-profiler.json
+```
+
+## AppArmor (optional)
+
+Load [`apparmor-profile`](../apparmor-profile) on each node using your cluster's AppArmor provisioning mechanism, then set `appArmorProfileName` on the host-profiler container override:
+
+```yaml
+spec:
+  override:
+    nodeAgent:
+      containers:
+        host-profiler:
+          appArmorProfileName: localhost/dd-host-profiler
+```

--- a/cmd/host-profiler/deploy/bundled/operator/override.yaml
+++ b/cmd/host-profiler/deploy/bundled/operator/override.yaml
@@ -1,0 +1,11 @@
+spec:
+  override:
+    nodeAgent:
+      containers:
+        host-profiler:
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+              add: ["BPF", "PERFMON", "SYS_PTRACE", "SYS_RESOURCE", "DAC_READ_SEARCH", "SYSLOG", "CHECKPOINT_RESTORE", "IPC_LOCK"]

--- a/cmd/host-profiler/deploy/prerequisites.yaml
+++ b/cmd/host-profiler/deploy/prerequisites.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dd-host-profiler

--- a/cmd/host-profiler/deploy/standalone/README.md
+++ b/cmd/host-profiler/deploy/standalone/README.md
@@ -1,0 +1,28 @@
+# Deploying Standalone
+
+Standalone mode runs the Host Profiler as a DaemonSet, one pod per node, without the Datadog Agent.
+
+Choose based on what your cluster already uses:
+
+- **[Helm](helm.md)**: uses the `open-telemetry/opentelemetry-collector` Helm chart with a Datadog-provided values override.
+- **[OTel Operator](operator.md)**: uses an `OpenTelemetryCollector` custom resource managed by the OpenTelemetry Operator.
+
+## Prerequisites
+
+1. Apply [`prerequisites.yaml`](../prerequisites.yaml) to create the `dd-host-profiler` namespace:
+
+```shell
+kubectl apply -f prerequisites.yaml
+```
+
+2. Create a Kubernetes secret with your Datadog API key:
+
+```shell
+kubectl create secret generic datadog-secret \
+  --from-literal=api-key="$DD_API_KEY" \
+  --namespace dd-host-profiler
+```
+
+## Verification
+
+After deploying the host profiler, profiles appear on the [Datadog Profiler](https://app.datadoghq.com/profiling) page within a few minutes. If profiles do not appear, see the [Troubleshooting](../troubleshooting.md) guide.

--- a/cmd/host-profiler/deploy/standalone/cilium-network-policy.yaml
+++ b/cmd/host-profiler/deploy/standalone/cilium-network-policy.yaml
@@ -1,0 +1,49 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: dd-host-profiler
+  namespace: dd-host-profiler
+specs:
+- description: Egress DNS
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: dd-host-profiler-collector
+  egress:
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+      rules:
+        dns:
+        - matchPattern: "*"
+- description: Egress to Datadog intake
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: dd-host-profiler-collector
+  egress:
+  - toFQDNs:
+    - matchPattern: "**.datadoghq.com"
+    - matchPattern: "**.datadoghq.eu"
+    - matchPattern: "**.ddog-gov.com"
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: TCP
+- description: Egress to kubelet API
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: dd-host-profiler-collector
+  egress:
+  - toPorts:
+    - ports:
+      - port: "10250"
+        protocol: TCP
+- description: Egress to Kubernetes API server
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: dd-host-profiler-collector
+  egress:
+  - toEntities:
+    - kube-apiserver

--- a/cmd/host-profiler/deploy/standalone/helm.md
+++ b/cmd/host-profiler/deploy/standalone/helm.md
@@ -1,0 +1,56 @@
+# Deploying Standalone: Using Helm Charts
+
+Complete the [prerequisites](README.md#prerequisites) before continuing.
+
+## Setup
+
+Add the OpenTelemetry Helm chart repository:
+
+```shell
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update
+```
+
+## Configure
+
+In [`helm/pod-spec.yaml`](helm/pod-spec.yaml), update `image.tag` if you want a different image version, and set `DD_SITE` under `extraEnvs` to your Datadog site if you are not using `datadoghq.com`.
+
+## Deploy
+
+```shell
+helm upgrade --install dd-host-profiler open-telemetry/opentelemetry-collector \
+  --namespace dd-host-profiler \
+  --values standalone/helm/pod-spec.yaml \
+  --values standalone/helm/otel-config.yaml
+```
+
+On non-Cilium clusters:
+
+```shell
+kubectl apply -f standalone/network-policy.yaml
+```
+
+### Seccomp
+
+The collector is automatically configured to run under a seccomp profile. An init container copies the profile from the collector image to every node at pod startup. No manual steps required.
+
+### AppArmor (optional)
+
+Load [`apparmor-profile`](../apparmor-profile) on each node using your cluster's AppArmor provisioning mechanism, then update `securityContext` in [`helm/pod-spec.yaml`](helm/pod-spec.yaml):
+
+```yaml
+securityContext:
+  # ... existing fields ...
+  appArmorProfile:
+    type: Localhost
+    localhostProfile: dd-host-profiler
+```
+
+### Cilium (optional)
+
+On clusters with Cilium, replace the standard network policy with the Cilium one to get FQDN-scoped egress enforcement:
+
+```shell
+kubectl delete -f standalone/network-policy.yaml
+kubectl apply -f standalone/cilium-network-policy.yaml
+```

--- a/cmd/host-profiler/deploy/standalone/helm/otel-config.yaml
+++ b/cmd/host-profiler/deploy/standalone/helm/otel-config.yaml
@@ -1,0 +1,55 @@
+config:
+  extensions:
+    health_check:
+      endpoint: ${env:MY_POD_IP}:13133
+
+  receivers:
+    jaeger: null
+    zipkin: null
+    prometheus: null
+    otlp:
+      protocols:
+        grpc: {}
+        http: {}
+    profiling:
+      symbol_uploader:
+        enabled: true
+        symbol_endpoints:
+          - site: ${env:DD_SITE}
+            api_key: ${env:DD_API_KEY}
+
+  processors:
+    batch: null
+    memory_limiter: null
+    cumulativetodelta: {}
+    resourcedetection:
+      detectors: ["system"]
+      system:
+        resource_attributes:
+          host.arch:
+            enabled: true
+          host.name:
+            enabled: false
+          os.type:
+            enabled: false
+
+  exporters:
+    otlp_http:
+      endpoint: https://otlp.${env:DD_SITE}
+      headers:
+        dd-api-key: ${env:DD_API_KEY}
+        dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
+
+  service:
+    extensions: [health_check]
+    pipelines:
+      logs: null
+      traces: null
+      metrics:
+        receivers: [otlp]
+        processors: [cumulativetodelta, resourcedetection, k8sattributes]
+        exporters: [otlp_http]
+      profiles:
+        receivers: [profiling]
+        processors: [resourcedetection, k8sattributes]
+        exporters: [otlp_http]

--- a/cmd/host-profiler/deploy/standalone/helm/pod-spec.yaml
+++ b/cmd/host-profiler/deploy/standalone/helm/pod-spec.yaml
@@ -1,0 +1,90 @@
+nameOverride: dd-host-profiler-collector
+fullnameOverride: dd-host-profiler-collector
+
+mode: daemonset
+
+presets:
+  profiling:
+    enabled: true
+  kubernetesAttributes:
+    enabled: true
+    extractAllPodLabels: true
+
+image:
+  repository: registry.datadoghq.com/ddot-ebpf
+  tag: 7.81.0-preview-host-profiler-1.0
+
+command:
+  name: opt/datadog-agent/embedded/bin/host-profiler
+
+clusterRole:
+  rules:
+    - apiGroups: [""]
+      resources: ["nodes", "nodes/proxy", "nodes/spec"]
+      verbs: ["get", "list"]
+
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  appArmorProfile:
+    type: Unconfined
+  capabilities:
+    add:
+      - BPF
+      - PERFMON
+      - SYS_PTRACE
+      - SYS_RESOURCE
+      - DAC_READ_SEARCH
+      - SYSLOG
+      - CHECKPOINT_RESTORE
+      - IPC_LOCK
+    drop:
+      - ALL
+  seccompProfile:
+    type: Localhost
+    localhostProfile: host-profiler.json
+
+
+initContainers:
+  - name: seccomp-installer
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    command:
+      - cp
+      - /etc/dd-host-profiler/seccomp.json
+      - /host/var/lib/kubelet/seccomp/host-profiler.json
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      appArmorProfile:
+        type: Unconfined
+      capabilities:
+        drop:
+          - ALL
+    volumeMounts:
+      - name: host-seccomp
+        mountPath: /host/var/lib/kubelet/seccomp
+
+extraVolumeMounts:
+  - name: tmpdir
+    mountPath: /tmp
+
+extraVolumes:
+  - name: tmpdir
+    emptyDir: {}
+  - name: host-seccomp
+    hostPath:
+      path: /var/lib/kubelet/seccomp
+      type: DirectoryOrCreate
+
+networkPolicy:
+  enabled: false
+
+extraEnvs:
+  - name: DD_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: datadog-secret
+        key: api-key
+  - name: DD_SITE
+    value: "datadoghq.com"

--- a/cmd/host-profiler/deploy/standalone/network-policy.yaml
+++ b/cmd/host-profiler/deploy/standalone/network-policy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dd-host-profiler
+  namespace: dd-host-profiler
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: dd-host-profiler-collector
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - ports:
+        - port: 443
+          protocol: TCP
+    - ports:
+        - port: 10250
+          protocol: TCP

--- a/cmd/host-profiler/deploy/standalone/operator.md
+++ b/cmd/host-profiler/deploy/standalone/operator.md
@@ -1,0 +1,54 @@
+# Deploying Standalone: Using the OTel Operator
+
+Complete the [prerequisites](README.md#prerequisites) before continuing.
+
+If the OpenTelemetry Operator is not installed, follow the [official installation guide](https://opentelemetry.io/docs/kubernetes/operator/).
+
+## Configure
+
+In [`operator/collector.yaml`](operator/collector.yaml), update `spec.image` if you want a different image version, and set `DD_SITE` under `spec.env` to your Datadog site if you are not using `datadoghq.com`.
+
+## Deploy
+
+```shell
+kubectl apply -f standalone/operator/collector.yaml
+```
+
+On non-Cilium clusters:
+
+```shell
+kubectl apply -f standalone/network-policy.yaml
+```
+
+[`operator/collector.yaml`](operator/collector.yaml) contains three resources:
+
+1. A `ClusterRole` granting the collector's service account access to the kubelet APIs needed for hostname resolution.
+2. A `ClusterRoleBinding` attaching that role to the `dd-host-profiler-collector` service account the Operator creates.
+3. The `OpenTelemetryCollector` CR defining the DaemonSet.
+
+The Operator reconciles the CR and creates the DaemonSet.
+
+### Seccomp
+
+The collector is automatically configured to run under a seccomp profile. An init container copies the profile from the collector image to every node at pod startup. No manual steps required.
+
+### AppArmor (optional)
+
+Load [`apparmor-profile`](../apparmor-profile) on each node using your cluster's AppArmor provisioning mechanism, then update `securityContext` in [`operator/collector.yaml`](operator/collector.yaml):
+
+```yaml
+securityContext:
+  # ... existing fields ...
+  appArmorProfile:
+    type: Localhost
+    localhostProfile: dd-host-profiler
+```
+
+### Cilium (optional)
+
+On clusters with Cilium, replace the standard network policy with the Cilium one to get FQDN-scoped egress enforcement:
+
+```shell
+kubectl delete -f standalone/network-policy.yaml
+kubectl apply -f standalone/cilium-network-policy.yaml
+```

--- a/cmd/host-profiler/deploy/standalone/operator/collector.yaml
+++ b/cmd/host-profiler/deploy/standalone/operator/collector.yaml
@@ -1,0 +1,172 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dd-host-profiler-kubelet
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/proxy", "nodes/spec"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dd-host-profiler-kubelet
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dd-host-profiler-kubelet
+subjects:
+  - kind: ServiceAccount
+    name: dd-host-profiler-collector
+    namespace: dd-host-profiler
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: dd-host-profiler
+  namespace: dd-host-profiler
+spec:
+  mode: daemonset
+  image: registry.datadoghq.com/ddot-ebpf:7.81.0-preview-host-profiler-1.0
+  hostPID: true
+
+  securityContext:
+    privileged: false
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    appArmorProfile:
+      type: Unconfined
+    capabilities:
+      add:
+        - BPF
+        - PERFMON
+        - SYS_PTRACE
+        - SYS_RESOURCE
+        - DAC_READ_SEARCH
+        - SYSLOG
+        - CHECKPOINT_RESTORE
+        - IPC_LOCK
+      drop:
+        - ALL
+    seccompProfile:
+      type: Localhost
+      localhostProfile: host-profiler.json
+
+  initContainers:
+    - name: seccomp-installer
+      image: registry.datadoghq.com/ddot-ebpf:7.81.0-preview-host-profiler-1.0
+      command:
+        - cp
+        - /etc/dd-host-profiler/seccomp.json
+        - /host/var/lib/kubelet/seccomp/host-profiler.json
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        appArmorProfile:
+          type: Unconfined
+        capabilities:
+          drop:
+            - ALL
+      volumeMounts:
+        - name: host-seccomp
+          mountPath: /host/var/lib/kubelet/seccomp
+
+  volumes:
+    - name: tmpdir
+      emptyDir: {}
+    - name: tracefs
+      hostPath:
+        path: /sys/kernel/tracing
+        type: Directory
+    - name: host-seccomp
+      hostPath:
+        path: /var/lib/kubelet/seccomp
+        type: DirectoryOrCreate
+
+  volumeMounts:
+    - name: tmpdir
+      mountPath: /tmp
+    - name: tracefs
+      mountPath: /sys/kernel/tracing
+
+  env:
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: DD_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: datadog-secret
+          key: api-key
+    - name: DD_SITE
+      value: "datadoghq.com"
+
+  config:
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+    receivers:
+      profiling:
+        symbol_uploader:
+          enabled: true
+          symbol_endpoints:
+            - site: ${env:DD_SITE}
+              api_key: ${env:DD_API_KEY}
+      otlp:
+        protocols:
+          grpc: {}
+          http: {}
+    processors:
+      cumulativetodelta: {}
+      k8s_attributes:
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: container.id
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+          - sources:
+              - from: resource_attribute
+                name: host.name
+      resourcedetection:
+        detectors: ["system"]
+        system:
+          resource_attributes:
+            host.arch:
+              enabled: true
+            host.name:
+              enabled: false
+            os.type:
+              enabled: false
+    exporters:
+      otlp_http:
+        endpoint: https://otlp.${env:DD_SITE}
+        headers:
+          dd-api-key: ${env:DD_API_KEY}
+          dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [cumulativetodelta, resourcedetection, k8s_attributes]
+          exporters: [otlp_http]
+        profiles:
+          receivers: [profiling]
+          processors: [resourcedetection, k8s_attributes]
+          exporters: [otlp_http]

--- a/cmd/host-profiler/deploy/troubleshooting.md
+++ b/cmd/host-profiler/deploy/troubleshooting.md
@@ -1,0 +1,35 @@
+# Troubleshooting
+
+## Profiles not appearing in the UI
+
+Check the host-profiler container logs:
+
+```shell
+kubectl logs <pod> -c host-profiler
+```
+
+Look for API key errors, endpoint errors, or config validation failures.
+
+Also verify:
+
+- `DD_SITE` matches your Datadog org's site.
+- The API key secret is non-empty: `kubectl get secret datadog-secret -o jsonpath='{.data.api-key}' | base64 -d`
+
+## Container won't start
+
+Check whether the seccomp profile was installed on the node:
+
+```shell
+kubectl debug node/<node> -it --image=busybox -- ls /var/lib/kubelet/seccomp/
+```
+
+The file `host-profiler` or `dd-host-profiler` should be present. If it is missing, check the init container logs:
+
+```shell
+kubectl logs <pod> -c host-profiler-seccomp-setup
+```
+
+## No profiles for a specific process
+
+- If `DD_SERVICE` is not set on a workload, profiles group under the interpreter name (e.g. `java`, `python`). Set `DD_SERVICE` on the workload to separate it.
+- For compiled languages, function names do not resolve in stripped binaries. Upload debug symbols manually — see [Manually uploading debug symbols](README.md#manually-uploading-debug-symbols).


### PR DESCRIPTION
### What does this PR do?

Adds deployment documentation and manifests for the host profiler preview under cmd/host-profiler/deploy/. The docs cover all four supported deployment paths:
- Bundled mode:
  - **Helm** (tested on `datadog-3.220.0`): add `hostProfiler` values to existing Datadog Helm deployments. The chart configures capabilities and seccomp automatically.
  - **Operator** (tested on `v.0.127.0`): annotate existing `DatadogAgent` CR. Capabilities must be applied manually via a patch; seccomp requires manual node provisioning.

- Standalone mode:
  - **Helm**: deploy via the `open-telemetry/opentelemetry-collector` chart
  - **Operator**: deploy via an `OpenTelemetryCollector` CR managed by the OTel Operator
- Both Standalone paths:
  - have provided values overrides to remove privileges and add capabilities through `securityContext` and add an init container to install seccomp profile 
  -  apply a standard NetworkPolicy by default. An optional CiliumNetworkPolicy is provided for Cilium clusters, scoping egress to Datadog FQDNs, the kubelet API, and the Kubernetes API server.

### Motivation

Introduces a deployment guide for the Host Profiler going over each deployment path with every possible configuration depending on path and flavor.

### Describe how you validated your changes

All four paths were deployed end-to-end on an EKS cluster running Cilium, following the docs exactly as a user would:
  - Check profiles on Datadog
  - Symbol uploads were confirmed for fresh Go binaries on each path
  - Standard NetworkPolicy and CiliumNetworkPolicy were both tested for both standalone paths; collector pods were restarted after each policy change to verify connectivity at startup
  - Seccomp and capabilities were verified for both standalone paths (init container copies profile from image; no manual provisioning required) and for the bundled Operator path (manual provisioning documented)
  - AppArmor profile was tested with the bundled Helm path

Each path of each flavor was tested on:
- ubuntu 22.04
- ubuntu 24.04
- ubuntu 26.04

### Additional Notes

- The bundled Operator path requires manual seccomp provisioning (no init container mechanism available) for now as `v.0.127.0` doesn't contain our security efforts. They should be included in `v.0.128.0-rc2` but that version still has to be released.