### PR TITLE
[trace/otlp] Allow _dd.stats_computed=false to override computed-stat…

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -50,6 +50,22 @@ import (
 // computed for the resource spans.
 const keyStatsComputed = "_dd.stats_computed"
 
+// resolveClientComputedStats determines whether APM stats have already been computed for
+// the given resource spans. The _dd.stats_computed resource attribute takes precedence over
+// the HTTP header when explicitly set:
+//   - true / any non-empty, non-"false" value → stats already computed (concentrator skips them)
+//   - false (bool or string "false")           → force stats computation via concentrator
+//
+// When the attribute is absent, fromHeader (derived from Datadog-Client-Computed-Stats) is used.
+func resolveClientComputedStats(attrs pcommon.Map, fromHeader bool) bool {
+	_, ok := attrs.Get(keyStatsComputed)
+	if !ok {
+		return fromHeader
+	}
+	s := transform.GetOTelAttrVal(attrs, true, keyStatsComputed)
+	return s != "" && s != "false"
+}
+
 var _ (ptraceotlp.GRPCServer) = (*OTLPReceiver)(nil)
 
 // OTLPReceiver implements an OpenTelemetry Collector receiver which accepts incoming
@@ -372,7 +388,7 @@ func (o *OTLPReceiver) receiveResourceSpansV2(ctx context.Context, rspans ptrace
 	_ = o.statsd.Count("datadog.trace_agent.otlp.traces", int64(len(tracesByID)), tags, 1)
 	p := Payload{
 		Source:                 tagstats,
-		ClientComputedStats:    transform.GetOTelAttrVal(otelres.Attributes(), true, keyStatsComputed) != "" || clientComputedStats,
+		ClientComputedStats:    resolveClientComputedStats(otelres.Attributes(), clientComputedStats),
 		ClientComputedTopLevel: o.conf.HasFeature("enable_otlp_compute_top_level_by_span_kind"),
 		TracerPayload: &pb.TracerPayload{
 			Hostname:      hostname,

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -1138,6 +1138,43 @@ func testOTLPReceiveResourceSpans(enableReceiveResourceSpansV2 bool, t *testing.
 		t.Run("resource", testAndExpect(testSpans[1], http.Header{}, func(p *Payload) {
 			require.True(p.ClientComputedStats)
 		}))
+
+		if enableReceiveResourceSpansV2 {
+			// _dd.stats_computed = false (bool or string) overrides the header in V2 only.
+			falseAttrSpans := []testutil.OTLPResourceSpan{{
+				LibName:    "libname",
+				LibVersion: "1.2",
+				Attributes: map[string]interface{}{
+					keyStatsComputed: false,
+				},
+				Spans: []*testutil.OTLPSpan{{Attributes: map[string]interface{}{string(semconv.K8SPodUIDKey): "123cid"}}},
+			}}
+
+			t.Run("resource_false_bool_no_header", testAndExpect(falseAttrSpans, http.Header{}, func(p *Payload) {
+				require.False(p.ClientComputedStats)
+			}))
+
+			t.Run("resource_false_bool_overrides_header", testAndExpect(falseAttrSpans, http.Header{
+				header.ComputedStats: []string{"true"},
+			}, func(p *Payload) {
+				require.False(p.ClientComputedStats)
+			}))
+
+			falseStringAttrSpans := []testutil.OTLPResourceSpan{{
+				LibName:    "libname",
+				LibVersion: "1.2",
+				Attributes: map[string]interface{}{
+					keyStatsComputed: "false",
+				},
+				Spans: []*testutil.OTLPSpan{{Attributes: map[string]interface{}{string(semconv.K8SPodUIDKey): "123cid"}}},
+			}}
+
+			t.Run("resource_false_string_overrides_header", testAndExpect(falseStringAttrSpans, http.Header{
+				header.ComputedStats: []string{"true"},
+			}, func(p *Payload) {
+				require.False(p.ClientComputedStats)
+			}))
+		}
 	})
 
 	t.Run("ClientComputedTopLevel", func(t *testing.T) {

--- a/releasenotes/notes/otlp-stats-computed-attr-override-0805991cb1d406be.yaml
+++ b/releasenotes/notes/otlp-stats-computed-attr-override-0805991cb1d406be.yaml
@@ -1,0 +1,7 @@
+fixes:
+  - |
+    OTLP: The ``_dd.stats_computed=false`` resource attribute now overrides the
+    ``Datadog-Client-Computed-Stats: true`` HTTP header. Collectors that cannot
+    compute APM stats out-of-band can set this attribute to ensure APM metrics
+    are computed by the Agent regardless of the header value. When the attribute
+    is absent, the header still governs.


### PR DESCRIPTION
…s header (V2 path)

Implemeted to address https://datadoghq.atlassian.net/browse/OTELS-1032

When the DisableAPMStats feature gate is enabled (Beta default), the Datadog exporter sets Datadog-Client-Computed-Stats: true, causing the trace agent concentrator to skip spans entirely. Collectors without a Datadog connector (e.g. ADOT) have no way to compute stats out-of-band, leaving APM metrics empty.

The _dd.stats_computed resource attribute previously only OR-ed with the header, so setting it to false had no effect when the header was true. This change makes the attribute override the header in the V2 receive path (ReceiveResourceSpans): when the attribute is explicitly present and equals false (bool or string), stats computation is forced on regardless of the header value. When absent, the header still governs.

The V1 receive path (receiveResourceSpansV1) is unchanged.

Assisted-by: Claude Sonnet 4.6

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
