### PR TITLE
[AGNTLOG-628] Fix flaky TestRestartTestSuite TempDir cleanup race

### DIFF
--- a/comp/logs/agent/impl/agent_restart_test.go
+++ b/comp/logs/agent/impl/agent_restart_test.go
@@ -157,6 +157,21 @@ func createTestAgent(suite *RestartTestSuite, endpoints *config.Endpoints) (*log
 	agent.setupAgent()
 	suite.T().Cleanup(func() {
 		_ = agent.stop(context.TODO())
+
+		// Guarantee the auditor's background flush goroutine is stopped before
+		// the test's TempDir is removed. Tests that call partialStop() without a
+		// subsequent restart leave the transient components (launchers, pipeline
+		// provider, destinationsCtx) already stopped; the cleanup stop() above
+		// then stops them a second time. A non-idempotent component Stop() (e.g.
+		// the integration launcher's unbuffered stop channel) blocks the
+		// SerialStopper before it reaches the auditor, so stop() force-closes and
+		// returns with the auditor still running. The auditor's 1s flush ticker
+		// then keeps recreating registry.json under run_path (== t.TempDir()),
+		// racing with the testing package's TempDir RemoveAll and producing flaky
+		// "directory not empty" cleanup failures. Stopping the auditor explicitly
+		// is idempotent (Stop guards its channels) and removes the only writer
+		// that races with TempDir removal.
+		agent.auditor.Stop()
 	})
 
 	return agent, sources, services


### PR DESCRIPTION
## What this does

Fixes the flaky `comp/logs/agent/agentimpl TestRestartTestSuite/TestPartialStop_WithTimeout` (AGNTLOG-628), which intermittently failed on CI with:

```
testing.go:1369: TempDir RemoveAll cleanup: unlinkat /tmp/.../001: directory not empty
```

## Root cause (verified against CI job traces + local goroutine dumps)

The reported failures were **not** the timing assertion they looked like — in every failing run, `partialStop()` logged `Components stopped gracefully` almost instantly, so `elapsed` was well within bounds. The actual failure is a `t.TempDir()` cleanup race:

1. The restart tests that call `partialStop()` without a subsequent restart (e.g. `TestPartialStop_WithTimeout`) leave the transient components (launchers, pipeline provider, destinationsCtx) already stopped.
2. The shared `createTestAgent` cleanup then calls `agent.stop()`, which stops those components **a second time**.
3. `integration.(*Launcher).Stop()` is **not idempotent** — it does a bare send on an unbuffered `stop` channel with no receiver (every sibling launcher already guards `Stop()` with `sync.Once`). The second call blocks forever, so the `SerialStopper` never reaches `auditor.Stop()` and `agent.stop()` force-closes with the auditor still running.
4. The auditor's 1-second flush ticker keeps recreating `registry.json` under `run_path` (which is `suite.T().TempDir()`), racing with the testing package's `RemoveAll` → `directory not empty`.

It is a genuine timing race (small overlap window, hence flaky/slow-CI-only) riding on top of a deterministic double-stop hang. It is **not** a deadlock: `stopComponents` is bounded (grace period + 5s), so the test always completes.

## The fix

Stop the auditor explicitly at the end of the shared test cleanup. `auditor.Stop()` synchronously joins its `run()` goroutine (`closeChannels` waits on `<-done`) and is idempotent (its channel ops are nil-guarded), so after cleanup there is no background writer left to race with `TempDir` removal. Test-only; no production shutdown behavior is changed.

## Verification

- Full `TestRestartTestSuite` passes 2x under `-race` (no data races, no `directory not empty`).
- A temporary diagnostic confirmed the auditor `run()` goroutine is alive before cleanup and provably gone after `stop()` + explicit `auditor.Stop()`.
- `TestPartialStop_WithTimeout` passes 20/20 via `dda inv test`.
- `dda inv linter.go --only-modified-packages`: 0 issues.

## Follow-up (not in this PR)

The underlying non-idempotent double-`Stop()` is a small latent bug shared by `integration.(*Launcher).Stop()` (missing the `sync.Once` its siblings have) and `sender.(*Sender).Stop()` / `pipeline.(*provider).Stop()`. Production never double-stops today (restart rebuilds components between stops), so this is left as a separate hardening follow-up to keep this fix minimal and low-risk.

## Note

Supersedes the approach in #51124, which adjusted the `elapsed` timing assertion — that assertion was never the failing one, so it would not have fixed the flake. Per request, #51124 is left untouched.