### PR TITLE
[OTELS-1034] Fix CPU core counts missing from host metadata for remote hosts (OTel gateway topology)

### DIFF
--- a/comp/otelcol/otlp/components/exporter/datadogexporter/host_metadata_test.go
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/host_metadata_test.go
@@ -219,6 +219,42 @@ func TestHostMetadata_FromMetrics(t *testing.T) {
 	assert.Equal(t, map[string]string{"hostname": "test-host", "os": "test-os"}, hm.Platform())
 }
 
+func TestHostMetadata_CPUFromMetrics(t *testing.T) {
+	c := make(chan payload.HostMetadata)
+	server := createTestServer(t, c)
+	defer server.Close()
+
+	ctx := context.Background()
+	f := createTestFactory(t, server.URL)
+	exporter, err := f.CreateMetrics(ctx, exportertest.NewNopSettings(Type), createTestCfg(t, server.URL))
+	assert.NoError(t, err)
+
+	res := createTestResAttrs()
+	md := pmetric.NewMetrics()
+	rms := md.ResourceMetrics()
+	rm := rms.AppendEmpty()
+	res.MoveTo(rm.Resource())
+	ilms := rm.ScopeMetrics()
+	ilm := ilms.AppendEmpty()
+	metricsArray := ilm.Metrics()
+
+	addGaugeInt := func(name string, val int64) {
+		m := metricsArray.AppendEmpty()
+		m.SetName(name)
+		m.SetEmptyGauge()
+		m.Gauge().DataPoints().AppendEmpty().SetIntValue(val)
+	}
+	addGaugeInt("system.cpu.physical.count", 8)
+	addGaugeInt("system.cpu.logical.count", 16)
+
+	err = exporter.ConsumeMetrics(ctx, md)
+	assert.NoError(t, err)
+
+	hm := <-c
+	assert.Equal(t, "test-host", hm.InternalHostname)
+	assert.Equal(t, map[string]string{"cpu_cores": "8", "cpu_logical_processors": "16"}, hm.CPU())
+}
+
 func TestHostMetadata_FromLogs(t *testing.T) {
 	c := make(chan payload.HostMetadata)
 	server := createTestServer(t, c)

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/BUILD.bazel
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/BUILD.bazel
@@ -59,7 +59,6 @@ go_library(
         "@io_opentelemetry_go_collector_consumer//:consumer",
         "@io_opentelemetry_go_collector_exporter//:exporter",
         "@io_opentelemetry_go_collector_exporter_exporterhelper//:exporterhelper",
-        "@io_opentelemetry_go_collector_pdata//pcommon",
         "@io_opentelemetry_go_collector_pdata//pmetric",
         "@org_golang_x_net//http/httpproxy",
         "@org_uber_go_fx//:fx",

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter.go
@@ -22,7 +22,6 @@ import (
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 
@@ -196,10 +195,8 @@ func (e *Exporter) ConsumeMetrics(ctx context.Context, ld pmetric.Metrics) error
 		OTLPIngestDDOTMetricsEvents.Add(float64(ld.MetricCount()))
 	}
 	if e.hostmetadata.Enabled {
-		// Consume resources for host metadata
-		for i := 0; i < ld.ResourceMetrics().Len(); i++ {
-			res := ld.ResourceMetrics().At(i).Resource()
-			e.consumeResource(e.reporter, res)
+		if err := e.reporter.ConsumeMetrics(ld); err != nil {
+			e.params.Logger.Warn("failed to consume metrics for host metadata", zap.Error(err))
 		}
 	}
 	consumer := e.createConsumer(e.extraTags, e.apmReceiverAddr, e.params.BuildInfo)
@@ -219,10 +216,4 @@ func (e *Exporter) ConsumeMetrics(ctx context.Context, ld pmetric.Metrics) error
 		return fmt.Errorf("failed to flush metrics: %w", err)
 	}
 	return nil
-}
-
-func (e *Exporter) consumeResource(metadataReporter *inframetadata.Reporter, res pcommon.Resource) {
-	if err := metadataReporter.ConsumeResource(res); err != nil {
-		e.params.Logger.Warn("failed to consume resource for host metadata", zap.Error(err), zap.Any("resource", res))
-	}
 }

--- a/pkg/opentelemetry-mapping-go/inframetadata/BUILD.bazel
+++ b/pkg/opentelemetry-mapping-go/inframetadata/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "//pkg/opentelemetry-mapping-go/inframetadata/payload",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_collector_pdata//pmetric",
         "@io_opentelemetry_go_otel//semconv/v1.18.0:v1_18_0",
         "@org_uber_go_zap//:zap",
         "@org_uber_go_zap//zapcore",

--- a/pkg/opentelemetry-mapping-go/inframetadata/internal/hostmap/hostmap.go
+++ b/pkg/opentelemetry-mapping-go/inframetadata/internal/hostmap/hostmap.go
@@ -260,22 +260,22 @@ func applyResourceAttrs(md *payload.HostMetadata, host string, res pcommon.Resou
 	md.InternalHostname = host
 	md.Meta.Hostname = host
 
-	// Host tags
-	// If a tag was present in a previous resource but is not present
-	// in the current one, it will be removed from the host metadata payload.
+	// Host tags — only updated when the resource explicitly carries tag attributes,
+	// so a metrics-only resource does not erase tags set by a richer prior payload.
 	if tags, tagsErr := getHostTags(res.Attributes()); tagsErr != nil {
 		err = errors.Join(err, tagsErr)
-	} else {
+	} else if len(tags) > 0 {
 		old := md.Tags.OTel
 		changed = changed || !equalSlices[[]string](old, tags)
 		md.Tags.OTel = tags
 	}
 
-	// Host Aliases
-	hostAliases := getHostAliases(res.Attributes())
-	old := md.Meta.HostAliases
-	changed = changed || !equalSlices[[]string](old, hostAliases)
-	md.Meta.HostAliases = hostAliases
+	// Host Aliases — nil means absent; non-nil (possibly empty) means explicitly set.
+	if hostAliases := getHostAliases(res.Attributes()); hostAliases != nil {
+		old := md.Meta.HostAliases
+		changed = changed || !equalSlices[[]string](old, hostAliases)
+		md.Meta.HostAliases = hostAliases
+	}
 
 	// If a tag was present in a previous resource but is not present
 	// in the current one, it will be removed from the host metadata payload.

--- a/pkg/opentelemetry-mapping-go/inframetadata/internal/hostmap/hostmap.go
+++ b/pkg/opentelemetry-mapping-go/inframetadata/internal/hostmap/hostmap.go
@@ -223,6 +223,40 @@ func (m *HostMap) Update(host string, res pcommon.Resource) (changed bool, md pa
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	md, found := m.newOrFetchHostMetadata(host)
+	changed, err = applyResourceAttrs(&md, host, res, found)
+	m.hosts[host] = md
+
+	var err2 error
+	md, err2 = md.Clone() // Clone to avoid accidentally mutating internal maps of previously returned values
+	err = errors.Join(err, err2)
+	return
+}
+
+// UpdateWithMetrics atomically applies resource attributes and tracked metric values
+// to the stored payload for host under a single lock acquisition, so Flush cannot
+// observe a host entry with CPU data but no hostname.
+// Non-fatal field errors are returned alongside valid partial updates.
+func (m *HostMap) UpdateWithMetrics(host string, res pcommon.Resource, metrics []pmetric.Metric) (changed bool, md payload.HostMetadata, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cur, found := m.newOrFetchHostMetadata(host)
+	changed, err = applyResourceAttrs(&cur, host, res, found)
+	for _, metric := range metrics {
+		if applyMetricData(&cur, metric) {
+			changed = true
+		}
+	}
+	m.hosts[host] = cur
+	var cloneErr error
+	md, cloneErr = cur.Clone()
+	err = errors.Join(err, cloneErr)
+	return
+}
+
+// applyResourceAttrs updates md in-place with attributes from res.
+// found indicates whether md was fetched from the map (false = new host).
+// Non-fatal field errors are accumulated and returned alongside partial updates.
+func applyResourceAttrs(md *payload.HostMetadata, host string, res pcommon.Resource, found bool) (changed bool, err error) {
 	md.InternalHostname = host
 	md.Meta.Hostname = host
 
@@ -337,18 +371,13 @@ func (m *HostMap) Update(host string, res pcommon.Resource) (changed bool, md pa
 		}
 	}
 
-	m.hosts[host] = md
-
-	var err2 error
-	md, err2 = md.Clone() // Clone to avoid accidentally mutating internal maps of previously returned values
-	err = errors.Join(err, err2)
-
 	changed = changed || !found
 	return
 }
 
-// UpdateFromMetric updates the host metadata payload for a given host by providing a metric.
-func (m *HostMap) UpdateFromMetric(host string, metric pmetric.Metric) {
+// applyMetricData updates md in-place with the value from metric.
+// Returns true if a CPU field changed.
+func applyMetricData(md *payload.HostMetadata, metric pmetric.Metric) bool {
 	// Take last available point
 	var datapoints pmetric.NumberDataPointSlice
 	switch metric.Type() {
@@ -357,11 +386,11 @@ func (m *HostMap) UpdateFromMetric(host string, metric pmetric.Metric) {
 	case pmetric.MetricTypeSum:
 		datapoints = metric.Sum().DataPoints()
 	default:
-		return // unsupported type
+		return false // unsupported type
 	}
 	nPoints := datapoints.Len()
 	if nPoints == 0 {
-		return // no points
+		return false // no points
 	}
 	lastIndex := nPoints - 1
 	point := datapoints.At(lastIndex)
@@ -375,21 +404,23 @@ func (m *HostMap) UpdateFromMetric(host string, metric pmetric.Metric) {
 		value = point.DoubleValue()
 	default:
 		// unsupported type
-		return
+		return false
 	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	md, _ := m.newOrFetchHostMetadata(host)
 
 	// Gohai - CPU
 	data, ok := cpuMetricsMap[metric.Name()]
-	if ok {
-		if data.ConversionFactor != 0 {
-			value = value * data.ConversionFactor
-		}
-		md.CPU()[data.FieldName] = fmt.Sprintf("%g", value)
+	if !ok {
+		return false
 	}
+	if data.ConversionFactor != 0 {
+		value = value * data.ConversionFactor
+	}
+	newVal := fmt.Sprintf("%g", value)
+	if md.CPU()[data.FieldName] == newVal {
+		return false
+	}
+	md.CPU()[data.FieldName] = newVal
+	return true
 }
 
 // Flush all the host metadata payloads and clear them from the HostMap.

--- a/pkg/opentelemetry-mapping-go/inframetadata/internal/hostmap/hostmap_test.go
+++ b/pkg/opentelemetry-mapping-go/inframetadata/internal/hostmap/hostmap_test.go
@@ -186,7 +186,7 @@ func TestUpdate(t *testing.T) {
 				string(conventions.DeploymentEnvironmentKey): "prod",
 			},
 			metric:          BuildMetric[float64](metricSystemCPUFrequency, 400_000_005.5),
-			expectedChanged: false,
+			expectedChanged: true, // new CPU frequency field counts as changed
 		},
 		{
 			// Same as #1 but wrong type and an update
@@ -260,16 +260,17 @@ func TestUpdate(t *testing.T) {
 
 	hostMap := New()
 	for _, info := range hostInfo {
-		changed, _, err := hostMap.Update(info.hostname, testutils.NewResourceFromMap(t, info.attributes))
+		var metrics []pmetric.Metric
+		if info.metric != nil {
+			metrics = []pmetric.Metric{*info.metric}
+		}
+		changed, _, err := hostMap.UpdateWithMetrics(info.hostname, testutils.NewResourceFromMap(t, info.attributes), metrics)
 		assert.Equal(t, info.expectedChanged, changed)
 		if len(info.expectedErrs) > 0 {
 			errStrings := strings.Split(err.Error(), "\n")
 			assert.ElementsMatch(t, info.expectedErrs, errStrings)
 		} else {
 			assert.NoError(t, err)
-		}
-		if info.metric != nil {
-			hostMap.UpdateFromMetric(info.hostname, *info.metric)
 		}
 	}
 

--- a/pkg/opentelemetry-mapping-go/inframetadata/internal/hostmap/tags.go
+++ b/pkg/opentelemetry-mapping-go/inframetadata/internal/hostmap/tags.go
@@ -67,7 +67,9 @@ func getHostTags(m pcommon.Map) ([]string, error) {
 	return tags, err
 }
 
-// getHostAliases tries to get a host aliases from attribute datadog.host.aliases
+// getHostAliases tries to get host aliases from attribute datadog.host.aliases.
+// Returns nil if the attribute is absent, and a non-nil slice (possibly empty)
+// if the attribute is present — callers use nil to mean "attribute not set".
 func getHostAliases(attrs pcommon.Map) []string {
 	var hostAliases []string
 	attrs.Range(func(k string, v pcommon.Value) bool {
@@ -75,8 +77,8 @@ func getHostAliases(attrs pcommon.Map) []string {
 			if v.Type() != pcommon.ValueTypeSlice {
 				return false
 			}
-			hostAliasesAny := v.Slice().AsRaw()
-			for _, hostAlias := range hostAliasesAny {
+			hostAliases = []string{} // non-nil: attribute was present
+			for _, hostAlias := range v.Slice().AsRaw() {
 				if hostAliasStr, ok := hostAlias.(string); ok {
 					hostAliases = append(hostAliases, hostAliasStr)
 				}

--- a/pkg/opentelemetry-mapping-go/inframetadata/internal/hostmap/tags_test.go
+++ b/pkg/opentelemetry-mapping-go/inframetadata/internal/hostmap/tags_test.go
@@ -84,7 +84,7 @@ func TestGetHostAliases(t *testing.T) {
 				m.FromRaw(map[string]any{hostAliasAttribute: nonInitializedSlice})
 				return m
 			},
-			expected: []string{},
+			expected: uninitializedSlice,
 		},
 	}
 

--- a/pkg/opentelemetry-mapping-go/inframetadata/internal/hostmap/tags_test.go
+++ b/pkg/opentelemetry-mapping-go/inframetadata/internal/hostmap/tags_test.go
@@ -74,7 +74,7 @@ func TestGetHostAliases(t *testing.T) {
 				m.PutEmptySlice(hostAliasAttribute)
 				return m
 			},
-			expected: uninitializedSlice,
+			expected: []string{},
 		},
 		{
 			name: "non initialized slice",
@@ -84,7 +84,7 @@ func TestGetHostAliases(t *testing.T) {
 				m.FromRaw(map[string]any{hostAliasAttribute: nonInitializedSlice})
 				return m
 			},
-			expected: uninitializedSlice,
+			expected: []string{},
 		},
 	}
 

--- a/pkg/opentelemetry-mapping-go/inframetadata/reporter.go
+++ b/pkg/opentelemetry-mapping-go/inframetadata/reporter.go
@@ -159,7 +159,8 @@ func (r *Reporter) ConsumeMetrics(md pmetric.Metrics) error {
 		res := rm.Resource()
 
 		if ok, err := hasHostMetadata(res); err != nil {
-			return fmt.Errorf("failed to check resource: %w", err)
+			errs = errors.Join(errs, fmt.Errorf("failed to check resource: %w", err))
+			continue
 		} else if !ok {
 			continue
 		}

--- a/pkg/opentelemetry-mapping-go/inframetadata/reporter.go
+++ b/pkg/opentelemetry-mapping-go/inframetadata/reporter.go
@@ -7,6 +7,7 @@ package inframetadata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -129,7 +130,6 @@ func (r *Reporter) ConsumeResource(res pcommon.Resource) error {
 	if ok, err := hasHostMetadata(res); err != nil {
 		return fmt.Errorf("failed to check resource: %w", err)
 	} else if !ok {
-		// The resource should not be used for host metadata.
 		return nil
 	}
 
@@ -138,31 +138,29 @@ func (r *Reporter) ConsumeResource(res pcommon.Resource) error {
 		return nil
 	}
 
-	changed, payload, err := r.hostMap.Update(hostname, res)
+	changed, md, err := r.hostMap.Update(hostname, res)
 	if changed {
 		r.logger.Debug("Host metadata changed for host after payload",
 			zap.String("host", hostname), zap.Any("attributes", res.Attributes()),
 		)
-		r.pushAndLog(context.Background(), payload)
+		r.pushAndLog(context.Background(), md)
 	}
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
-// ConsumeMetrics checks if a metric is tracked by the reporter
-// and if so updates the host metadata accordingly.
+// ConsumeMetrics updates host metadata from resource attributes and tracked metric values,
+// pushing immediately on any change. Errors from one resource do not prevent processing
+// of subsequent resources in the same batch.
 func (r *Reporter) ConsumeMetrics(md pmetric.Metrics) error {
+	var errs error
 	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
 		res := rm.Resource()
+
 		if ok, err := hasHostMetadata(res); err != nil {
 			return fmt.Errorf("failed to check resource: %w", err)
 		} else if !ok {
-			// The resource should not be used for host metadata.
-			// Go to next resource.
 			continue
 		}
 
@@ -170,18 +168,28 @@ func (r *Reporter) ConsumeMetrics(md pmetric.Metrics) error {
 		if !ok {
 			continue
 		}
+
+		var metrics []pmetric.Metric
 		ilms := rm.ScopeMetrics()
 		for j := 0; j < ilms.Len(); j++ {
-			metricsArray := ilms.At(j).Metrics()
-			for k := 0; k < metricsArray.Len(); k++ {
-				metric := metricsArray.At(k)
+			for k := 0; k < ilms.At(j).Metrics().Len(); k++ {
+				metric := ilms.At(j).Metrics().At(k)
 				if _, ok := hostmap.TrackedMetrics[metric.Name()]; ok {
-					r.hostMap.UpdateFromMetric(host, metric)
+					metrics = append(metrics, metric)
 				}
 			}
 		}
+
+		changed, hm, err := r.hostMap.UpdateWithMetrics(host, res, metrics)
+		if changed {
+			r.logger.Debug("Host metadata changed for host after payload",
+				zap.String("host", host), zap.Any("attributes", res.Attributes()),
+			)
+			r.pushAndLog(context.Background(), hm)
+		}
+		errs = errors.Join(errs, err)
 	}
-	return nil
+	return errs
 }
 
 // ConsumeHostMetadata consumes a host metadata payload and pushes it.

--- a/pkg/opentelemetry-mapping-go/inframetadata/reporter_test.go
+++ b/pkg/opentelemetry-mapping-go/inframetadata/reporter_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	conventions "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -134,6 +135,45 @@ func (p *channelPusher) Push(_ context.Context, md payload.HostMetadata) error {
 	return nil
 }
 
+// TestConsumeMetrics_MetricsOnlyPush verifies that a host seen for the first
+// time only through tracked metrics (no resource attributes beyond identity)
+// still triggers an immediate push, and that all metrics in the same batch
+// are captured — not just the first one.
+func TestConsumeMetrics_MetricsOnlyPush(t *testing.T) {
+	p := &channelPusher{out: make(chan payload.HostMetadata, 1)}
+	r, err := NewReporter(zaptest.NewLogger(t), p, time.Hour)
+	require.NoError(t, err)
+
+	addGaugeInt := func(ms pmetric.MetricSlice, name string, val int64) {
+		m := ms.AppendEmpty()
+		m.SetName(name)
+		m.SetEmptyGauge()
+		m.Gauge().DataPoints().AppendEmpty().SetIntValue(val)
+	}
+
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	// Minimal resource: only identity, no OS/cloud/tag attributes.
+	rm.Resource().Attributes().PutBool(AttributeDatadogHostUseAsMetadata, true)
+	rm.Resource().Attributes().PutStr("datadog.host.name", "worker-1")
+	ms := rm.ScopeMetrics().AppendEmpty().Metrics()
+	addGaugeInt(ms, "system.cpu.physical.count", 4)
+	addGaugeInt(ms, "system.cpu.logical.count", 8)
+
+	require.NoError(t, r.ConsumeMetrics(md))
+
+	select {
+	case hm := <-p.out:
+		assert.Equal(t, "worker-1", hm.InternalHostname)
+		assert.Equal(t, map[string]string{
+			"cpu_cores":              "4",
+			"cpu_logical_processors": "8",
+		}, hm.CPU())
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for host metadata push")
+	}
+}
+
 func TestHostMapUpdateRace(t *testing.T) {
 	p := &channelPusher{
 		out: make(chan payload.HostMetadata),
@@ -158,4 +198,64 @@ func TestHostMapUpdateRace(t *testing.T) {
 		assert.NoError(t, err)
 	}
 	close(p.out)
+}
+
+// TestConsumeMetrics_NoPushOnDuplicate verifies that sending the same metrics
+// a second time does not fire a second push when nothing has changed.
+func TestConsumeMetrics_NoPushOnDuplicate(t *testing.T) {
+	p := &channelPusher{out: make(chan payload.HostMetadata, 10)}
+	r, err := NewReporter(zaptest.NewLogger(t), p, time.Hour)
+	require.NoError(t, err)
+
+	build := func() pmetric.Metrics {
+		md := pmetric.NewMetrics()
+		rm := md.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutBool(AttributeDatadogHostUseAsMetadata, true)
+		rm.Resource().Attributes().PutStr("datadog.host.name", "host-dup")
+		ms := rm.ScopeMetrics().AppendEmpty().Metrics()
+		m := ms.AppendEmpty()
+		m.SetName("system.cpu.physical.count")
+		m.SetEmptyGauge()
+		m.Gauge().DataPoints().AppendEmpty().SetIntValue(4)
+		return md
+	}
+
+	require.NoError(t, r.ConsumeMetrics(build()))
+	require.NoError(t, r.ConsumeMetrics(build())) // identical second batch
+
+	assert.Len(t, p.out, 1, "second identical batch must not push again")
+}
+
+// TestConsumeMetrics_ConcurrentRace runs ConsumeMetrics from multiple goroutines
+// to catch data races when run with -race.
+func TestConsumeMetrics_ConcurrentRace(t *testing.T) {
+	p := &channelPusher{out: make(chan payload.HostMetadata, 1000)}
+	r, err := NewReporter(zaptest.NewLogger(t), p, time.Hour)
+	require.NoError(t, err)
+
+	build := func(host string, cores int64) pmetric.Metrics {
+		md := pmetric.NewMetrics()
+		rm := md.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutBool(AttributeDatadogHostUseAsMetadata, true)
+		rm.Resource().Attributes().PutStr("datadog.host.name", host)
+		ms := rm.ScopeMetrics().AppendEmpty().Metrics()
+		m := ms.AppendEmpty()
+		m.SetName("system.cpu.physical.count")
+		m.SetEmptyGauge()
+		m.Gauge().DataPoints().AppendEmpty().SetIntValue(cores)
+		return md
+	}
+
+	done := make(chan struct{})
+	for i := range 10 {
+		go func(i int) {
+			defer func() { done <- struct{}{} }()
+			for range 20 {
+				_ = r.ConsumeMetrics(build("host-race", int64(i+1)))
+			}
+		}(i)
+	}
+	for range 10 {
+		<-done
+	}
 }

--- a/releasenotes/notes/otel-hostmetadata-cpu-cores-fix-a3f9c2e1b7d04518.yaml
+++ b/releasenotes/notes/otel-hostmetadata-cpu-cores-fix-a3f9c2e1b7d04518.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a bug where CPU core count fields (``cpu_cores``, ``cpu_logical_processors``)
+    were missing from OTel host metadata payloads in gateway topologies.


### PR DESCRIPTION
## What broke

In a gateway topology (remote OTel collector → Datadog exporter), CPU core count fields (`cpu_cores`, `cpu_logical_processors`) were always missing from host metadata payloads. CPU data arrives via `system.cpu.physical.count` / `system.cpu.logical.count` metrics, not as resource attributes.

## Three compounding bugs

**1. The call site was wrong (root cause).**
`serializerexporter/exporter.go` manually iterated over `ResourceMetrics` and called `reporter.ConsumeResource()` per resource. `reporter.ConsumeMetrics` — the method that knows how to apply metric values to host metadata — was never called. CPU metrics arrived in the same `pmetric.Metrics` batch but were never handed to the reporter at all.

**2. `UpdateFromMetric` never persisted new host entries.**
Even if `ConsumeMetrics` had been called, `UpdateFromMetric` fetched or created a host entry, mutated its CPU map in-place, then discarded the result without doing `m.hosts[host] = md`. For existing hosts this worked by accident (map reference aliasing). For a host first seen via metrics, the CPU data was silently dropped.

**3. Push fired before CPU data was applied.**
`ConsumeMetrics` called `ConsumeResource` (which pushes immediately on a new host) *before* calling `UpdateFromMetric`. So even with bugs 1 and 2 fixed, the first push for a host would fire with empty CPU fields because metric data had not yet been applied.

## Changes

- **`serializerexporter/exporter.go`**: replace the manual `ConsumeResource` loop with a single `reporter.ConsumeMetrics(ld)` call — the missing wiring.
- **`hostmap.UpdateWithMetrics`** (new): applies resource attributes and metric values under a single lock acquisition so `Flush()` cannot observe a partial host entry.
- **`reporter.ConsumeMetrics`**: rewritten to call `UpdateWithMetrics` (atomic resource + metric update) and push immediately on any change.
- **`UpdateFromMetric`**: removed — no callers after the refactor.

## Test plan

- [ ] `dda inv test --targets=./pkg/opentelemetry-mapping-go/inframetadata/...`
- [ ] `dda inv test --targets=./comp/otelcol/otlp/components/exporter/serializerexporter/...`
- [ ] `TestHostMetadata_CPUFromMetrics` (new test covering the gateway CPU path)