### PR TITLE
fix(tasks): skip root module in `check_valid_mods`

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -291,9 +291,11 @@ def raise_if_errors(errors_found, suggestion_msg=None):
         raise Exit(message=message)
 
 
-def check_valid_mods(ctx):
+def _check_valid_mods():
     errors_found = []
     for mod in get_default_modules().values():
+        if mod.path == ".":
+            continue
         pattern = os.path.join(mod.full_path(), '*.go')
         if not glob.glob(pattern):
             errors_found.append(f"module {mod.import_path} does not contain *.go source files, so it is not a package")
@@ -303,7 +305,7 @@ def check_valid_mods(ctx):
 
 @task
 def check_mod_tidy(ctx, test_folder="testmodule"):
-    check_valid_mods(ctx)
+    _check_valid_mods()
     with generate_dummy_package(ctx, test_folder) as dummy_folder:
         errors_found = []
         ctx.run("go work sync")
@@ -349,7 +351,7 @@ def tidy_all(ctx):
 
 @task
 def tidy(ctx, verbose: bool = False):
-    check_valid_mods(ctx)
+    _check_valid_mods()
     (_bazel_tidy if shutil.which("bazel") else _go_only_tidy)(ctx, verbose)
 
 


### PR DESCRIPTION
### What does this PR do?
`check_valid_mods` now skips the root module (`.`), **mirroring** the `mod.path != "."` guard already present in `generate_dummy_package`.
The root module is never imported by the dummy package, so requiring a root-level `.go` file there serves no purpose.

While at it, make explicit the function is "module-private" by adding a `_` prefix and drop the unused `ctx` parameter.

### Motivation
`check_valid_mods` was introduced in #31018 to guard `generate_dummy_package`, which imports each non-root module root as a Go package.
The root module was included in that check **despite being excluded** from the dummy imports.

The mismatch blocks consolidating all tool pins into `internal/tools/tools.go`: removing the last `.go` file from the repo root (`generate_tools.go`) causes `dda inv tidy` to fail with:
```
module github.com/DataDog/datadog-agent does not contain *.go source files, so it is not a package
```

### Additional Notes
`pkg/proto/empty.go` and `pkg/config/remote/empty.go` were each added in the commit that made their directory a Go submodule, showing the same workaround was applied there too: those _could_ be renamed to `doc.go` in a follow-up.