### PR TITLE
feat(bazel): make testutil.CurDir() runfiles-aware and migrate parked packages

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -397,7 +397,6 @@ exports_files(glob(
 # gazelle:exclude pkg/gpu/testutil
 # gazelle:exclude pkg/hosttags
 # gazelle:exclude pkg/kubestatemetrics/builder
-# gazelle:exclude pkg/languagedetection/internal/detectors/privileged
 # gazelle:exclude pkg/languagedetection/privileged
 # gazelle:exclude pkg/logs/client/http
 # gazelle:exclude pkg/logs/client/tcp

--- a/pkg/discovery/tracermetadata/BUILD.bazel
+++ b/pkg/discovery/tracermetadata/BUILD.bazel
@@ -1,7 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 
-# gazelle:exclude tracer_memfd_test.go
-
 go_library(
     name = "tracermetadata",
     srcs = ["tracer_memfd.go"],
@@ -22,7 +20,10 @@ go_library(
 
 go_test(
     name = "tracermetadata_test",
-    srcs = ["tracer_java_test.go"],
+    srcs = [
+        "tracer_java_test.go",
+        "tracer_memfd_test.go",
+    ],
     data = glob(["testdata/**"]),
     embed = [":tracermetadata"],
     gotags = ["test"],
@@ -30,5 +31,17 @@ go_test(
         "//pkg/discovery/tracermetadata/model",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-    ],
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "//pkg/network/protocols/http/testutil",
+            "//pkg/util/kernel",
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/network/protocols/http/testutil",
+            "//pkg/util/kernel",
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/languagedetection/internal/detectors/privileged/BUILD.bazel
+++ b/pkg/languagedetection/internal/detectors/privileged/BUILD.bazel
@@ -1,0 +1,67 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+# gazelle:exclude dotnet_detector_test.go
+
+go_library(
+    name = "privileged",
+    srcs = [
+        "dotnet_detector.go",
+        "go_detector.go",
+        "injector.go",
+        "tracer.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/languagedetection/internal/detectors/privileged",
+    visibility = ["//pkg/languagedetection:__subpackages__"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "//pkg/discovery/tracermetadata",
+            "//pkg/discovery/tracermetadata/language",
+            "//pkg/errors",
+            "//pkg/languagedetection/languagemodels",
+            "//pkg/network/go/binversion",
+            "//pkg/util/kernel",
+            "//pkg/util/safeelf",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/discovery/tracermetadata",
+            "//pkg/discovery/tracermetadata/language",
+            "//pkg/errors",
+            "//pkg/languagedetection/languagemodels",
+            "//pkg/network/go/binversion",
+            "//pkg/util/kernel",
+            "//pkg/util/safeelf",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "privileged_test",
+    srcs = [
+        "go_detector_test.go",
+        "injector_test.go",
+        "tracer_test.go",
+    ],
+    data = glob(["testdata/**"]),
+    embed = [":privileged"],
+    gotags = ["test"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "//pkg/languagedetection/languagemodels",
+            "//pkg/network/protocols/http/testutil",
+            "//pkg/proto/pbgo/languagedetection",
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/languagedetection/languagemodels",
+            "//pkg/network/protocols/http/testutil",
+            "//pkg/proto/pbgo/languagedetection",
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/pkg/network/protocols/http/testutil/testutil.go
+++ b/pkg/network/protocols/http/testutil/testutil.go
@@ -204,6 +204,14 @@ func CurDir() (string, error) {
 		return "", err
 	}
 
+	// Under Bazel, the test runs from the sandbox execroot and its data
+	// dependencies live in the runfiles tree, not next to the package sources.
+	// Resolve the package directory relative to the runfiles root so that
+	// `data`-declared testdata is found.
+	if srcDir := os.Getenv("TEST_SRCDIR"); srcDir != "" {
+		return filepath.Join(srcDir, os.Getenv("TEST_WORKSPACE"), relPath), nil
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
### What does this PR do?

Makes `testutil.CurDir()` (in `pkg/network/protocols/http/testutil`) work correctly under Bazel by consulting `TEST_SRCDIR`/`TEST_WORKSPACE` before falling back to the `os.Getwd()` path.

Migrates two packages that were parked specifically because of this gap:

- `pkg/discovery/tracermetadata` — removes the `# gazelle:exclude tracer_memfd_test.go` that was added as a workaround; the test is now in the Bazel target.
- `pkg/languagedetection/internal/detectors/privileged` — removes the root `# gazelle:exclude` and adds a proper `BUILD.bazel`. `dotnet_detector_test.go` is still excluded pending migration of `pkg/network/usm/sharedlibraries/testutil`.

### Motivation

`CurDir()` computes the package source path by truncating the call-stack path at the first `pkg/` segment. Under `go test` that segment is the actual source directory, so the math is correct. Under Bazel the test runs from a sandbox whose first `pkg/` is `bin/pkg/`, so `CurDir()` would resolve to `bin/` and miss the runfiles entirely. Adding the `TEST_SRCDIR`/`TEST_WORKSPACE` check (the standard Bazel test contract) fixes it.

### Describe how you validated your changes

- `bazel build --config=cache //pkg/discovery/tracermetadata/...` passes.
- `bazel build --config=cache //pkg/languagedetection/internal/detectors/privileged/...` passes.