### PR TITLE
[FA] Add spec.yaml for file_handle

### DIFF
--- a/cmd/agent/dist/assets/file_handle/spec.yaml
+++ b/cmd/agent/dist/assets/file_handle/spec.yaml
@@ -1,0 +1,63 @@
+name: file_handle
+fleet_configurable: true
+version: 1.0.0
+files:
+- name: file_handle.yaml
+  options:
+  - template: init_config
+    options:
+    - name: service
+      fleet_configurable: true
+      value:
+        type: string
+        example: "<SERVICE>"
+      description: |
+        Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+
+        Additionally, this sets the default `service` for every log source.
+      required: false
+  - template: instances
+    options:
+    - name: tags
+      fleet_configurable: true
+      required: false
+      value:
+        type: array
+        items:
+          type: string
+        example: ["<KEY_1>:<VALUE_1>", "<KEY_2>:<VALUE_2>"]
+      description: |
+        A list of tags to attach to every metric, event, and service check emitted by this instance.
+
+        Learn more about tagging at https://docs.datadoghq.com/tagging/
+    - name: service
+      fleet_configurable: true
+      value:
+        type: string
+        example: "<SERVICE>"
+      description: |
+        Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+
+        Overrides any `service` defined in the `init_config` section.
+      required: false
+    - name: min_collection_interval
+      fleet_configurable: true
+      value:
+        type: number
+        example: 15
+        default: 15
+      description: |
+        This changes the collection interval of the check. For more information, see:
+        https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+      required: false
+    - name: empty_default_hostname
+      fleet_configurable: true
+      value:
+        type: boolean
+        example: false
+        default: false
+      description: |
+        This forces the check to send metrics with no hostname.
+
+        This is useful for cluster-level checks.
+      required: false


### PR DESCRIPTION
## What does this PR do?

Adds `spec.yaml` for the `file_handle` core check under `cmd/agent/dist/assets/file_handle/spec.yaml`.

The spec formally documents the check's configuration schema for Fleet configuration support and tooling validation.

## Motivation

This check ships with a `conf.yaml.default` but was missing its `spec.yaml` companion file.