### PR TITLE
Fix failing e2e V3 tests

### DIFF
--- a/test/new-e2e/tests/agent-metric-pipelines/dogstatsd-unit/dogstatsd_unit_nix_test.go
+++ b/test/new-e2e/tests/agent-metric-pipelines/dogstatsd-unit/dogstatsd_unit_nix_test.go
@@ -190,8 +190,6 @@ func (s *dogstatsdUnitSuite) TestDogstatsdUnitOnlyOnTimingMetrics() {
 	if s.v3Enabled {
 		assert.Greater(s.T(), routeStats[metricsV3Endpoint], 0,
 			"expected payloads on %s when V3 is enabled", metricsV3Endpoint)
-		assert.Zero(s.T(), routeStats[metricsV2Endpoint],
-			"expected no payloads on %s when V3 is enabled", metricsV2Endpoint)
 	} else {
 		assert.Greater(s.T(), routeStats[metricsV2Endpoint], 0,
 			"expected payloads on %s when V3 is not enabled", metricsV2Endpoint)

--- a/test/new-e2e/tests/otel/otlp-ingest/docker_pipelines_test.go
+++ b/test/new-e2e/tests/otel/otlp-ingest/docker_pipelines_test.go
@@ -106,8 +106,6 @@ func (s *otlpIngestDockerTestSuite) TestOTLPMetrics() {
 	if s.v3Enabled {
 		assert.Greater(s.T(), routeStats[otlpMetricsV3Endpoint], 0,
 			"expected payloads on %s when V3 is enabled", otlpMetricsV3Endpoint)
-		assert.Zero(s.T(), routeStats[otlpMetricsV2Endpoint],
-			"expected no payloads on %s when V3 is enabled", otlpMetricsV2Endpoint)
 	} else {
 		assert.Greater(s.T(), routeStats[otlpMetricsV2Endpoint], 0,
 			"expected payloads on %s when V3 is not enabled", otlpMetricsV2Endpoint)


### PR DESCRIPTION
### What does this PR do?

Remove the requirement to receive no messages via the V2 endpoint when V3 is enabled.

### Motivation

Agent has a mode where it can validate V3 payloads: it also sends additional messages via V2 to cross-check the data. This causes our V3 e2e tests to fail, because they expect strictly no usage of that V2 endpoint. To take this into account we remove the check for zero V2 messages completely.

### Describe how you validated your changes

The failing test shall be green again.

### Additional Notes
