### PR TITLE
chore(slapr): Bump to new version

### DIFF
--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -23,7 +23,7 @@ jobs:
         token: ${{ steps.octo-sts.outputs.token }}
         sparse-checkout: tasks/libs/pipeline/github_slack_map.yaml
         sparse-checkout-cone-mode: false
-    - uses: DataDog/slapr@3c19d2a0971acfc3f5a3524b508ed233f8ce0e23
+    - uses: DataDog/slapr@95312d6b8528460243ba27c7f8167bfe20a68bec # v1.1.0
       with:
         review-map: tasks/libs/pipeline/github_slack_map.yaml
         github-token: ${{ steps.octo-sts.outputs.token }}


### PR DESCRIPTION
### What does this PR do?
Bump slapr to the new version

### Motivation
This version will ignore when a slack channel is not defined in the slack_map (like agent_configuration)

### Describe how you validated your changes
Tested on slapr side

### Additional Notes
