### PR TITLE
fix(procmgr): Windows processes.d from InstallPath, logs from ConfigRoot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,7 @@ dependencies = [
  "tonic-reflection",
  "tower",
  "uuid",
+ "windows-registry",
  "windows-sys 0.61.2",
 ]
 

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -70,6 +70,7 @@ _LIB_DEPS = [
     ],
     "@platforms//os:windows": [
         "//comp/core/log/rust:dd-agent-log",
+        "@crates//:windows-registry",
         "@crates//:windows-sys",
     ],
     "//conditions:default": [],

--- a/pkg/procmgr/rust/Cargo.toml
+++ b/pkg/procmgr/rust/Cargo.toml
@@ -44,6 +44,7 @@ uuid.workspace = true
 nix = { workspace = true, features = ["signal", "process"] }
 
 [target.'cfg(windows)'.dependencies]
+windows-registry.workspace = true
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_System_JobObjects",
@@ -51,6 +52,7 @@ windows-sys = { workspace = true, features = [
     "Win32_System_Threading",
     "Win32_System_Console",
     "Win32_Security",
+    "Win32_System_Registry",
 ] }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -183,31 +183,32 @@ pub fn last_signal(_status: &std::process::ExitStatus) -> Option<i32> {
     None
 }
 
-/// Root directory for agent program data on Windows.
-///
-/// Mirrors `pkg/util/winutil.GetProgramDataDir` in Go: read
-/// `HKLM\SOFTWARE\Datadog\Datadog Agent\ConfigRoot`, else `%ProgramData%\Datadog`.
-pub fn program_data_root() -> PathBuf {
-    program_data_root_from_registry().unwrap_or_else(default_program_data_dir)
-}
-
-fn program_data_root_from_registry() -> Option<PathBuf> {
+fn open_datadog_agent_key() -> Option<windows_registry::Key> {
     use windows_registry::LOCAL_MACHINE;
     use windows_sys::Win32::System::Registry::KEY_WOW64_64KEY;
 
-    let key = LOCAL_MACHINE
+    LOCAL_MACHINE
         .options()
         .read()
         .access(KEY_WOW64_64KEY)
         .open(r"SOFTWARE\Datadog\Datadog Agent")
-        .ok()?;
+        .ok()
+}
 
-    let value: String = key.get_string("ConfigRoot").ok()?;
-    if value.is_empty() {
-        None
-    } else {
-        Some(PathBuf::from(value))
-    }
+fn registry_nonempty_string(key: &windows_registry::Key, name: &str) -> Option<String> {
+    let value: String = key.get_string(name).ok()?;
+    if value.is_empty() { None } else { Some(value) }
+}
+
+/// Root directory for agent program data on Windows (logs, etc.).
+///
+/// Mirrors `pkg/util/winutil.GetProgramDataDir` in Go:
+/// `HKLM\SOFTWARE\Datadog\Datadog Agent\ConfigRoot`, else `%ProgramData%\Datadog`.
+pub fn program_data_root() -> PathBuf {
+    open_datadog_agent_key()
+        .and_then(|k| registry_nonempty_string(&k, "ConfigRoot"))
+        .map(PathBuf::from)
+        .unwrap_or_else(default_program_data_dir)
 }
 
 fn default_program_data_dir() -> PathBuf {
@@ -215,8 +216,30 @@ fn default_program_data_dir() -> PathBuf {
     PathBuf::from(base).join("Datadog")
 }
 
+fn install_root_from_registry() -> Option<PathBuf> {
+    open_datadog_agent_key()
+        .and_then(|k| registry_nonempty_string(&k, "InstallPath"))
+        .map(PathBuf::from)
+}
+
+fn default_install_root() -> PathBuf {
+    let program_files =
+        std::env::var("ProgramFiles").unwrap_or_else(|_| r"C:\Program Files".to_string());
+    PathBuf::from(program_files)
+        .join("Datadog")
+        .join("Datadog Agent")
+}
+
+fn install_root() -> PathBuf {
+    install_root_from_registry().unwrap_or_else(default_install_root)
+}
+
+/// Default directory for process-manager YAML (`*.yaml`), same layout as Linux
+/// (`/opt/datadog-agent/processes.d`) and omnibus. Resolves the install root like
+/// `pkg/util/winutil.GetProgramFilesDirForProduct` in Go (`InstallPath` registry value,
+/// else `%ProgramFiles%\Datadog\Datadog Agent`), then appends `processes.d`.
 pub fn default_config_dir() -> PathBuf {
-    program_data_root().join("dd-procmgr").join("processes.d")
+    install_root().join("processes.d")
 }
 
 /// Wait for a shutdown trigger: either Ctrl+C (console mode) or an SCM

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -183,9 +183,40 @@ pub fn last_signal(_status: &std::process::ExitStatus) -> Option<i32> {
     None
 }
 
-pub fn default_config_dir() -> PathBuf {
+/// Root directory for agent program data on Windows.
+///
+/// Mirrors `pkg/util/winutil.GetProgramDataDir` in Go: read
+/// `HKLM\SOFTWARE\Datadog\Datadog Agent\ConfigRoot`, else `%ProgramData%\Datadog`.
+pub fn program_data_root() -> PathBuf {
+    program_data_root_from_registry().unwrap_or_else(default_program_data_dir)
+}
+
+fn program_data_root_from_registry() -> Option<PathBuf> {
+    use windows_registry::LOCAL_MACHINE;
+    use windows_sys::Win32::System::Registry::KEY_WOW64_64KEY;
+
+    let key = LOCAL_MACHINE
+        .options()
+        .read()
+        .access(KEY_WOW64_64KEY)
+        .open(r"SOFTWARE\Datadog\Datadog Agent")
+        .ok()?;
+
+    let value: String = key.get_string("ConfigRoot").ok()?;
+    if value.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(value))
+    }
+}
+
+fn default_program_data_dir() -> PathBuf {
     let base = std::env::var("ProgramData").unwrap_or_else(|_| r"C:\ProgramData".to_string());
-    PathBuf::from(base).join(r"Datadog\dd-procmgr\processes.d")
+    PathBuf::from(base).join("Datadog")
+}
+
+pub fn default_config_dir() -> PathBuf {
+    program_data_root().join("dd-procmgr").join("processes.d")
 }
 
 /// Wait for a shutdown trigger: either Ctrl+C (console mode) or an SCM

--- a/pkg/procmgr/rust/src/service.rs
+++ b/pkg/procmgr/rust/src/service.rs
@@ -138,11 +138,12 @@ unsafe extern "system" fn service_main(_argc: u32, _argv: *mut *mut u16) {
     set_service_status(SERVICE_STOPPED, 0, NO_ERROR, 0);
 }
 
-/// Default log file path, following the agent convention
-/// (`C:\ProgramData\Datadog\logs\<service>.log`).
+/// Default log file path under the Windows program data root (registry `ConfigRoot` when set,
+/// else `%ProgramData%\Datadog`), matching other agent services.
 fn default_log_file() -> PathBuf {
-    let base = std::env::var("ProgramData").unwrap_or_else(|_| r"C:\ProgramData".to_string());
-    PathBuf::from(base).join(r"Datadog\logs\dd-procmgr.log")
+    crate::platform::program_data_root()
+        .join("logs")
+        .join("dd-procmgr.log")
 }
 
 /// Core service logic: creates the tokio runtime, runs ProcessManager, then


### PR DESCRIPTION
### What does this PR do?

On Windows, `dd-procmgrd` resolves paths from the same registry keys as Go `winutil`:

- **`processes.d` (default):** `{InstallPath}\processes.d` reads **`InstallPath`** under `HKLM\SOFTWARE\Datadog\Datadog Agent` (WOW64 64-bit view), with fallback to `%ProgramFiles%\Datadog\Datadog Agent\processes.d`. Matches Linux (`/opt/datadog-agent/processes.d`) and omnibus (read-only config under the install prefix).
- **Service log file:** `{ConfigRoot}\logs\dd-procmgr.log` uses **`ConfigRoot`** with fallback to `%ProgramData%\Datadog`, same idea as `GetProgramDataDir`.

Override unchanged: **`DD_PM_CONFIG_DIR`** for the process config directory.

### Motivation

- Hardcoded `%ProgramData%\Datadog\...` ignored MSI **ConfigRoot** for logs.
- Packaged **`processes.d`** lives under the **install** tree; defaults should follow **`InstallPath`**, not only program data.

### How to validate

- `cargo check -p dd-procmgrd` (or Windows target build in CI)
- MSI with redirected application data: log under **ConfigRoot**; YAML under **InstallPath** unless overridden by env.