### PR TITLE
Simplify pyc file cleanup in Agent removal

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -107,9 +107,8 @@ build do
             # cleanup clutter
             delete "#{install_dir}/etc"
 
-            # The prerm script of the package should use this list to remove the pyc/pyo files
-            command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.py_compiled_files.txt"
-            command "find #{install_dir}/embedded '(' -name '*.pyc' -o -name '*.pyo' ')' -type f -delete -print | sort >> #{install_dir}/embedded/.py_compiled_files.txt"
+            # Python bytecode caches (pyc files) are generated at runtime and should not be shipped.
+            command "find #{install_dir}/embedded -type d -name __pycache__ -prune -exec rm -rf {} +"
 
             # The prerm and preinst scripts of the package will use this list to detect which files
             # have been setup by the installer, this way, on removal, we'll be able to delete only files

--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -132,11 +132,8 @@ else
     fi
 fi
 
-# Delete all the .pyc/.pyo files in the embedded dir that are part of the old agent's package
-# This MUST be done after using pip or any python, because executing python might generate .pyc files
-if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
-    # (commented lines are filtered out)
-    cat $INSTALL_DIR/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
-fi
+# Delete Python bytecode caches in the embedded dir.
+# This MUST be done after using pip or any python, because executing python might generate .pyc files.
+find "$INSTALL_DIR/embedded" -type d -name __pycache__ -prune -exec rm -rf {} + || true
 
 exit 0

--- a/pkg/fleet/installer/packages/integrations/integrations.go
+++ b/pkg/fleet/installer/packages/integrations/integrations.go
@@ -147,30 +147,12 @@ func RemoveCustomIntegrations(ctx context.Context, installPath string) (err erro
 	return nil
 }
 
-// RemoveCompiledFiles removes compiled Python files (.pyc, .pyo) and __pycache__ directories
+// RemoveCompiledFiles removes compiled Python files (__pycache__ folders)
 func RemoveCompiledFiles(installPath string) error {
-	// Remove files in in "{installPath}/embedded/.py_compiled_files.txt"
-	_, err := os.Stat(filepath.Join(installPath, "embedded/.py_compiled_files.txt"))
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to check if compiled files list exists: %w", err)
-	}
-	if !os.IsNotExist(err) {
-		compiledFiles, err := os.ReadFile(filepath.Join(installPath, "embedded/.py_compiled_files.txt"))
+	// Remove files in {installPath}/embedded
+	err := filepath.WalkDir(filepath.Join(installPath, "embedded"), func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return fmt.Errorf("failed to read compiled files list: %w", err)
-		}
-		for file := range strings.SplitSeq(string(compiledFiles), "\n") {
-			if strings.HasPrefix(file, installPath) {
-				if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
-					return fmt.Errorf("failed to remove compiled file %s: %w", file, err)
-				}
-			}
-		}
-	}
-	// Remove files in {installPath}/bin/agent/dist
-	err = filepath.WalkDir(filepath.Join(installPath, "bin", "agent", "dist"), func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			if !os.IsNotExist(err) {
+			if os.IsNotExist(err) {
 				return nil
 			}
 			return err
@@ -179,10 +161,26 @@ func RemoveCompiledFiles(installPath string) error {
 			if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
 				return err
 			}
-		} else if strings.HasSuffix(d.Name(), ".pyc") || strings.HasSuffix(d.Name(), ".pyo") {
-			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to remove compiled files: %w", err)
+	}
+	// Remove files in {installPath}/bin/agent/dist
+	err = filepath.WalkDir(filepath.Join(installPath, "bin", "agent", "dist"), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() && d.Name() == "__pycache__" {
+			if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
 				return err
 			}
+			return filepath.SkipDir
 		}
 		return nil
 	})
@@ -192,7 +190,7 @@ func RemoveCompiledFiles(installPath string) error {
 	// Remove files in {installPath}/python-scripts
 	err = filepath.WalkDir(filepath.Join(installPath, "python-scripts"), func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			if !os.IsNotExist(err) {
+			if os.IsNotExist(err) {
 				return nil
 			}
 			return err
@@ -201,10 +199,7 @@ func RemoveCompiledFiles(installPath string) error {
 			if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
 				return err
 			}
-		} else if strings.HasSuffix(d.Name(), ".pyc") || strings.HasSuffix(d.Name(), ".pyo") {
-			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-				return err
-			}
+			return filepath.SkipDir
 		}
 		return nil
 	})

--- a/pkg/fleet/installer/packages/integrations/integrations_test.go
+++ b/pkg/fleet/installer/packages/integrations/integrations_test.go
@@ -129,3 +129,48 @@ func TestRemoveCustomIntegrations(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoveCompiledFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	removed := []string{
+		"embedded/lib/python3.12/site-packages/dateutil/__pycache__/parser.cpython-312.pyc",
+		"embedded/lib/python3.12/site-packages/dateutil/__pycache__/tz.cpython-312.opt-1.pyc",
+		"bin/agent/dist/checks/__pycache__/foo.cpython-312.pyc",
+		"python-scripts/__pycache__/pre.cpython-312.pyc",
+	}
+	remaining := []string{
+		"embedded/lib/python3.12/site-packages/dateutil/parser.py",
+		"embedded/lib/python3.12/site-packages/legacy/module.py",
+	}
+
+	for _, relPath := range append(removed, remaining...) {
+		fullPath := filepath.Join(dir, relPath)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+			t.Fatalf("failed to create directory for %s: %v", fullPath, err)
+		}
+		if err := os.WriteFile(fullPath, []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create file %s: %v", fullPath, err)
+		}
+	}
+
+	if err := RemoveCompiledFiles(dir); err != nil {
+		t.Fatalf("RemoveCompiledFiles failed: %v", err)
+	}
+
+	for _, relPath := range removed {
+		fullPath := filepath.Join(dir, relPath)
+		if _, err := os.Stat(fullPath); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed, but it exists", fullPath)
+		}
+	}
+	for _, relPath := range remaining {
+		fullPath := filepath.Join(dir, relPath)
+		if _, err := os.Stat(fullPath); err != nil {
+			t.Errorf("expected %s to exist, but got error: %v", fullPath, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "embedded/lib/python3.12/site-packages/dateutil/__pycache__")); !os.IsNotExist(err) {
+		t.Errorf("expected __pycache__ directory to be removed")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

It replaces the `.py_compiled_files.txt`- based mechanism for cleaning byte-compiled Python files (pyc) files by a simpler, broader cleanup of `__pycache__` folders.

### Motivation

During the installation of agent integrations and their dependencies, we generate pyc files of which we're just using the name for some installation removal logic. As we move to Bazel ([ABLD-260](https://datadoghq.atlassian.net/browse/ABLD-260)), it's preferable to not even generate the pyc files in the first place. This is the main motivation for wanting to revisit this.

An additional good reason to do this is that the `.py_compiled_files.txt` file takes 1.22 MiB, so dropping it helps with package size.

### Describe how you validated your changes

CI.

### Additional Notes

This seems to have introduced very long ago, in https://github.com/DataDog/datadog-agent/pull/3280. There's almost no context for this addition, but one important change is that we no longer support Python 2 on the current Agent main line, which is significant, because:
- All .pyc files now go under `__pycache__` folders (https://peps.python.org/pep-3147).
- pyo files no longer exist (https://peps.python.org/pep-0488/).

The other thing the existing implementation allowed was to keep modified packages' pyc files around on package removal. This provides very little value, as pyc files are just a cache and are automatically regenerated (at a negligible cost).


[ABLD-260]: https://datadoghq.atlassian.net/browse/ABLD-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ