### PR TITLE
fix(e2e): harden Windows service start/stop/restart in new-e2e helpers

### DIFF
--- a/test/new-e2e/tests/windows/common/service.go
+++ b/test/new-e2e/tests/windows/common/service.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
 )
@@ -33,6 +34,12 @@ const (
 	SERVICE_DISABLED     = 4
 
 	//revive:enable:var-naming
+)
+
+// Windows SCM can transiently fail stop/restart while child processes or tooling delay shutdown.
+const (
+	windowsServiceOpMaxAttempts   = 8
+	windowsServiceOpRetryInterval = 2 * time.Second
 )
 
 // ServiceConfig contains information about a Windows service
@@ -103,25 +110,75 @@ func GetServiceStatus(host *components.RemoteHost, service string) (string, erro
 	return strings.TrimSpace(out), err
 }
 
-// StopService stops the service
+// StopService stops the service.
+// It retries on failure because Windows SCM can transiently return CouldNotStopService
+// while child processes or tooling (e.g. debuggers) delay shutdown.
 func StopService(host *components.RemoteHost, service string) error {
-	cmd := fmt.Sprintf("Stop-Service -Force -Name '%s'", service)
-	_, err := host.Execute(cmd)
-	return err
+	var lastErr error
+	for attempt := 1; attempt <= windowsServiceOpMaxAttempts; attempt++ {
+		if status, statusErr := GetServiceStatus(host, service); statusErr == nil && strings.EqualFold(strings.TrimSpace(status), "Stopped") {
+			return nil
+		}
+		cmd := fmt.Sprintf("Stop-Service -Force -Name '%s'", service)
+		_, err := host.Execute(cmd)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if status, statusErr := GetServiceStatus(host, service); statusErr == nil && strings.EqualFold(strings.TrimSpace(status), "Stopped") {
+			return nil
+		}
+		if attempt < windowsServiceOpMaxAttempts {
+			time.Sleep(windowsServiceOpRetryInterval)
+		}
+	}
+	return fmt.Errorf("failed to stop service %s after %d attempts: %w", service, windowsServiceOpMaxAttempts, lastErr)
 }
 
-// StartService starts the service
+// StartService starts the service.
+// It retries on failure because Windows SCM can transiently refuse start while the service
+// is still stopping or dependencies are settling.
 func StartService(host *components.RemoteHost, service string) error {
-	cmd := fmt.Sprintf("Start-Service -Name '%s'", service)
-	_, err := host.Execute(cmd)
-	return err
+	var lastErr error
+	for attempt := 1; attempt <= windowsServiceOpMaxAttempts; attempt++ {
+		if status, statusErr := GetServiceStatus(host, service); statusErr == nil && strings.EqualFold(strings.TrimSpace(status), "Running") {
+			return nil
+		}
+		cmd := fmt.Sprintf("Start-Service -Name '%s'", service)
+		_, err := host.Execute(cmd)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if status, statusErr := GetServiceStatus(host, service); statusErr == nil && strings.EqualFold(strings.TrimSpace(status), "Running") {
+			return nil
+		}
+		if attempt < windowsServiceOpMaxAttempts {
+			time.Sleep(windowsServiceOpRetryInterval)
+		}
+	}
+	return fmt.Errorf("failed to start service %s after %d attempts: %w", service, windowsServiceOpMaxAttempts, lastErr)
 }
 
-// RestartService restarts the service
+// RestartService restarts the service.
+// It retries on failure for the same transient SCM issues as StopService (stop phase or start phase).
 func RestartService(host *components.RemoteHost, service string) error {
-	cmd := fmt.Sprintf("Restart-Service -Force -Name '%s'", service)
-	_, err := host.Execute(cmd)
-	return err
+	var lastErr error
+	for attempt := 1; attempt <= windowsServiceOpMaxAttempts; attempt++ {
+		cmd := fmt.Sprintf("Restart-Service -Force -Name '%s'", service)
+		_, err := host.Execute(cmd)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if status, statusErr := GetServiceStatus(host, service); statusErr == nil && strings.EqualFold(strings.TrimSpace(status), "Running") {
+			return nil
+		}
+		if attempt < windowsServiceOpMaxAttempts {
+			time.Sleep(windowsServiceOpRetryInterval)
+		}
+	}
+	return fmt.Errorf("failed to restart service %s after %d attempts: %w", service, windowsServiceOpMaxAttempts, lastErr)
 }
 
 // GetServiceConfig returns the configuration of the service

--- a/test/new-e2e/tests/windows/common/service.go
+++ b/test/new-e2e/tests/windows/common/service.go
@@ -160,25 +160,20 @@ func StartService(host *components.RemoteHost, service string) error {
 	return fmt.Errorf("failed to start service %s after %d attempts: %w", service, windowsServiceOpMaxAttempts, lastErr)
 }
 
-// RestartService restarts the service.
-// It retries on failure for the same transient SCM issues as StopService (stop phase or start phase).
+// RestartService restarts the service by stopping then starting it.
+//
+// We do not use Restart-Service and treat "still Running" after a failure as success: SCM can
+// return errors such as CouldNotStopService while the previous service instance remains running,
+// so callers that change config and then restart could continue without an actual recycle.
+// StopService and StartService each apply retries for transient SCM failures.
 func RestartService(host *components.RemoteHost, service string) error {
-	var lastErr error
-	for attempt := 1; attempt <= windowsServiceOpMaxAttempts; attempt++ {
-		cmd := fmt.Sprintf("Restart-Service -Force -Name '%s'", service)
-		_, err := host.Execute(cmd)
-		if err == nil {
-			return nil
-		}
-		lastErr = err
-		if status, statusErr := GetServiceStatus(host, service); statusErr == nil && strings.EqualFold(strings.TrimSpace(status), "Running") {
-			return nil
-		}
-		if attempt < windowsServiceOpMaxAttempts {
-			time.Sleep(windowsServiceOpRetryInterval)
-		}
+	if err := StopService(host, service); err != nil {
+		return fmt.Errorf("restart %s (stop phase): %w", service, err)
 	}
-	return fmt.Errorf("failed to restart service %s after %d attempts: %w", service, windowsServiceOpMaxAttempts, lastErr)
+	if err := StartService(host, service); err != nil {
+		return fmt.Errorf("restart %s (start phase): %w", service, err)
+	}
+	return nil
 }
 
 // GetServiceConfig returns the configuration of the service


### PR DESCRIPTION
### What does this PR do?

Updates `test/new-e2e/tests/windows/common/service.go` so Windows service control in new-e2e is more reliable:

- **Retries with backoff** for start/stop/restart when SCM returns transient errors (e.g. `CouldNotStopService`), re-checking service status between attempts.
- **Restart = stop then start** instead of a single `Restart-Service`, so we do not treat “restart failed but service still Running” as success when a real recycle was required (e.g. after config changes). Reuses the same stop/start retry paths.

### Motivation

Windows SCM flakes and ambiguous restart outcomes have caused flaky or misleading new-e2e runs. This aligns helper behavior with how operators typically recycle services and reduces false greens after failed restarts.

### How to validate

- Run targeted Windows new-e2e suites that exercise service lifecycle
- Local: `go test ./test/new-e2e/tests/windows/common/...`

### Scope

- **Go / new-e2e only** — no agent runtime or MSI changes.