### PR TITLE
feat(healthplatform): enable Agent Health by default

### DIFF
--- a/comp/healthplatform/bundle_test.go
+++ b/comp/healthplatform/bundle_test.go
@@ -86,7 +86,7 @@ func TestBundleStartLifecycle(t *testing.T) {
 			cfg := config.NewMock(t)
 			cfg.SetInTest("api_key", "test-api-key")
 			cfg.SetInTest("dd_url", server.URL)
-			cfg.SetInTest("health_platform.enabled", true)
+			// health_platform.enabled defaults to true; no explicit set needed
 			cfg.SetInTest("health_platform.persist_on_kubernetes", true)
 			cfg.SetInTest("health_platform.forwarder.interval", tickInterval)
 			cfg.SetInTest("run_path", t.TempDir())

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8189,7 +8189,7 @@ properties:
       enabled:
         node_type: setting
         type: boolean
-        default: false
+        default: true
       forwarder:
         node_type: section
         type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1201,7 +1201,7 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("auth_init_timeout", 30*time.Second)
 	config.BindEnv("bind_host") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.BindEnvAndSetDefault("health_port", int64(0))
-	config.BindEnvAndSetDefault("health_platform.enabled", false)
+	config.BindEnvAndSetDefault("health_platform.enabled", true)
 	config.BindEnvAndSetDefault("health_platform.persist_on_kubernetes", false)
 	config.BindEnvAndSetDefault("health_platform.forwarder.interval", 0)
 	config.BindEnvAndSetDefault("disable_py3_validation", false)

--- a/releasenotes/notes/enable-agent-health-by-default-cdf14f1ef69a4179.yaml
+++ b/releasenotes/notes/enable-agent-health-by-default-cdf14f1ef69a4179.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    The Agent Health platform is now enabled by default. The agent automatically
+    detects and reports self-health issues (such as check execution failures and
+    misconfigured integrations) to the Datadog platform without requiring any
+    configuration change. To opt out, set ``health_platform.enabled: false`` in
+    ``datadog.yaml``.

--- a/test/new-e2e/tests/agent-health/check_failure_test.go
+++ b/test/new-e2e/tests/agent-health/check_failure_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 const healthPlatformAgentConfig = `health_platform:
-  enabled: true
   forwarder:
     interval: 30s
 `


### PR DESCRIPTION
### What does this PR do?

Sets `health_platform.enabled` default value to `true` in `pkg/config/setup/common_settings.go`, enabling the Agent Health platform out of the box without requiring explicit user configuration.

### Motivation

The health platform is fully implemented and wired into all agent binaries. Keeping it opt-in forces users who want self-health reporting to discover and set the flag manually. Enabling it by default makes the feature available immediately upon upgrade.

Users who want to opt out can still set `health_platform.enabled: false` in `datadog.yaml`.

Note: `health_platform.forwarder.interval` defaults to `0`, which the egress component treats as `defaultEgressInterval` (5 min), so the flush cadence is correct even without explicit configuration.

### Describe how you validated your changes

- Existing unit tests in `comp/healthplatform/bundle_test.go` already exercise the enabled path explicitly (`cfg.SetInTest("health_platform.enabled", true)`) and are unaffected by the default change.
- The internal guard clauses in `egress/impl/egress.go` and `store/impl/store.go` continue to function correctly as opt-out paths.

### Additional Notes

A release note should be added before merge to document this behavioral change.