### PR TITLE
Also pin `GOTOOLCHAIN=local` in Go SDK patching rules and `bazel run`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,9 +27,11 @@ common --repo_env=DEPLOY_AGENT # Keep in sync with env_vars in MODULE.bazel
 common --repo_env=FORCED_PACKAGE_COMPRESSION_LEVEL # Keep in sync with env_vars in MODULE.bazel
 common --repo_env=GOCACHE # https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
 common --repo_env=GOMODCACHE # https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
+common --repo_env=GOTOOLCHAIN=local # Extend https://github.com/bazel-contrib/rules_go/pull/3660 to Go SDK patching rules
 common --repo_env=PACKAGE_VERSION # Keep in sync with env_vars in MODULE.bazel
 common --repo_env=SIGN_MAC # Keep in sync with env_vars in MODULE.bazel
 common --repo_env=XDG_CACHE_HOME # https://wiki.archlinux.org/title/XDG_Base_Directory
+common --run_env=GOTOOLCHAIN=local # Extend https://github.com/bazel-contrib/rules_go/pull/3660 to `bazel run //:go`
 common --skip_incompatible_explicit_targets # Let target_compatible_with skip rather than fail
 common --test_output=errors # Print test errors to console output instead of only capturing them in buried test.log
 common --verbose_failures


### PR DESCRIPTION
### What does this PR do?
Forward `GOTOOLCHAIN=local` to the Go invocations under `bazel` that `rules_go` doesn't already pin:
- Go SDK-patching repository rules, via `--repo_env`,
- `bazel run //:go`, via `--run_env`.

### Motivation
Follow-up to #51855, which made `go_fast` and `go_sdk_overrides` build from the `go.work`-pinned SDK and therefore removed the version skew, this now closes the hole that let a skew degrade silently: with `GOTOOLCHAIN=auto` (Go SDK default), a `go_fast` older than `go.work` silently downloads and runs an _unpatched_ upstream toolchain (the original `go work sync` slowdown investigated earlier).
=> `GOTOOLCHAIN=local` would no longer silently switch to another SDK, preventing any future [surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).

This restores `rules_go`'s own convention (bazel-contrib/rules_go#3660) which pins `GOTOOLCHAIN=local` for build actions (`go_context`) and for the `go_bin_runner`, i.e.:
- https://github.com/bazel-contrib/rules_go/blob/8808bb8c6604f1e7a2badbfcd9a9db4c32ba0a8c/go/private/context.bzl#L610
- https://github.com/bazel-contrib/rules_go/blob/8808bb8c6604f1e7a2badbfcd9a9db4c32ba0a8c/go/tools/go_bin_runner/main.go#L49

But `//:go` is `@go_fast`, a raw `cmd/go` that bypasses the `go_bin_runner`, so neither `bazel run //:go` nor the `go_fast`/`go_sdk_overrides` repo rules inherit it.
=> these two `.bazelrc` lines extend the pin to both.

### Describe how you validated your changes
Before:
```
$ bazel run //:go -- env GOTOOLCHAIN
auto
```
After:
```
$ bazel run //:go -- env GOTOOLCHAIN
local
```

### Additional Notes
Build actions are already pinned by bazel-contrib/rules_go#366, so no `--action_env=GOTOOLCHAIN=local` counterpart is needed.