### PR TITLE
[Host Profiler] bump-workflow: add bazel setup cache step

### DIFF
--- a/.github/workflows/update-ebpf-profiler-branch.yml
+++ b/.github/workflows/update-ebpf-profiler-branch.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Update go.mod replace directive to datadog branch
         run: sed -i "s|go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v[^ ]*|go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler datadog|" go.mod
 
+      - name: Set up Bazel cache
+        uses: ./.github/actions/bazel-cache
+
       - name: Tidy and generate licenses
         run: |
           go mod tidy


### PR DESCRIPTION
### What does this PR do?

adds bazel setup cache step

### Motivation

Without this step, the workflow fails with an error that can be found [here](https://github.com/DataDog/datadog-agent/actions/runs/27126031230/job/80054735916).

### Describe how you validated your changes

Adding this cache setup step fixes it, as can be seen on this [trial run](https://github.com/DataDog/datadog-agent/actions/runs/27129303711/job/80065901897). It's failing because the chainguard only allows PR creation from the main branch whereas this job was triggered on this dev branch; that's expected.

### Additional Notes
