### PR TITLE
Reduce native Windows lint load

### DIFF
--- a/.gitlab/build/lint/cross.yml
+++ b/.gitlab/build/lint/cross.yml
@@ -18,6 +18,8 @@
 
 lint_cross_windows-x64:
   extends: .cross_lint
+  rules:
+    - when: on_success
   script:
     - dda inv -- -e build-messagetable
     - export GOOS=windows GOARCH=amd64

--- a/.gitlab/windows/build/lint/windows.yml
+++ b/.gitlab/windows/build/lint/windows.yml
@@ -34,8 +34,10 @@
 lint_windows-x64:
   extends: .lint_windows_base
   rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
+    - if: $CI_COMMIT_TAG != null
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
+    - if: ($DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null) && $BUCKET_BRANCH =~ /^(nightly|oldnightly|beta|stable)$/
+    - when: never
   variables:
     ARCH: "x64"
   timeout: 1h30m

--- a/.gitlab/windows/deploy/e2e_testing_deploy/windows.yml
+++ b/.gitlab/windows/deploy/e2e_testing_deploy/windows.yml
@@ -11,7 +11,7 @@ deploy_windows_testing-a7:
   tags: ["arch:amd64", "specific:true"]
   retry: 2
   needs:
-    ["lint_windows-x64", "windows_msi_and_bosh_zip_x64-a7"]
+    ["lint_cross_windows-x64", "windows_msi_and_bosh_zip_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID
   script:
@@ -35,7 +35,7 @@ deploy_windows_testing-a7-fips:
   tags: ["arch:amd64", "specific:true"]
   retry: 2
   needs:
-    ["lint_windows-x64", "windows_msi_and_bosh_zip_x64-a7-fips"]
+    ["lint_cross_windows-x64", "windows_msi_and_bosh_zip_x64-a7-fips"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID
   script:

--- a/tasks/winbuildscripts/Invoke-Linters.ps1
+++ b/tasks/winbuildscripts/Invoke-Linters.ps1
@@ -52,7 +52,7 @@ Invoke-BuildScript `
     }
 
     # Lint Go
-    & dda inv -- -e linter.go --debug
+    & dda inv -- -e linter.go --debug --cpus 4
     $err = $LASTEXITCODE
     Write-Host Go linter result is $err
     if($err -ne 0){
@@ -61,7 +61,7 @@ Invoke-BuildScript `
     }
 
     # Lint system-probe Go
-    & dda inv -- -e linter.go --build system-probe-unit-tests --targets .\pkg
+    & dda inv -- -e linter.go --build system-probe-unit-tests --targets .\pkg --cpus 4
     $err = $LASTEXITCODE
     Write-Host system-probe Go linter result is $err
     if($err -ne 0){

--- a/tasks/winbuildscripts/Invoke-Linters.ps1
+++ b/tasks/winbuildscripts/Invoke-Linters.ps1
@@ -52,7 +52,7 @@ Invoke-BuildScript `
     }
 
     # Lint Go
-    & dda inv -- -e linter.go --debug --cpus 4
+    & dda inv -- -e linter.go --debug
     $err = $LASTEXITCODE
     Write-Host Go linter result is $err
     if($err -ne 0){
@@ -61,7 +61,7 @@ Invoke-BuildScript `
     }
 
     # Lint system-probe Go
-    & dda inv -- -e linter.go --build system-probe-unit-tests --targets .\pkg --cpus 4
+    & dda inv -- -e linter.go --build system-probe-unit-tests --targets .\pkg
     $err = $LASTEXITCODE
     Write-Host system-probe Go linter result is $err
     if($err -ne 0){


### PR DESCRIPTION
<!-- dd-meta {"pullId":"dc495997-9d07-48e3-8857-965ca937cae8","source":"chat","resourceId":"3c1333a6-9e08-4e87-bc8f-56112301816e","workflowId":"01a4b778-14d4-4860-bbf2-8f347475efc8","codeChangeId":"01a4b778-14d4-4860-bbf2-8f347475efc8","sourceType":"slack"} -->
### What does this PR do?

- Makes `lint_cross_windows-x64` explicitly run by default.
- Limits native `lint_windows-x64` to tag pipelines, release branches, and nightly/beta/stable deploy builds.
- Updates Windows testing deploy jobs to depend on `lint_cross_windows-x64` so pipelines where native Windows lint is skipped still have a Windows lint gate.

### Motivation

`lint_windows-x64` has been seeing more package-loading timeouts and memory-pressure-style failures on Windows. Telemetry showed the cross Windows lint job already runs alongside the native job on main and normal branch pipelines, succeeds much more reliably, and is significantly faster. Keeping native Windows lint only for release-sensitive contexts reduces Windows runner pressure while preserving broader Windows Go lint coverage through the cross job.

### Describe how you validated your changes

- Ran `git diff --check` on the modified Windows lint and GitLab CI files.
- Parsed the modified YAML files locally with a custom `!reference` loader to catch syntax errors.
- Inspected the updated rules and `needs` references to ensure deploy jobs no longer depend on a native lint job that can be skipped.
- Verified `tasks/winbuildscripts/Invoke-Linters.ps1` no longer contains the earlier `--cpus 4` changes.

### Additional Notes

Native `lint_windows-x64` still runs for tag pipelines, release branches, and deploy builds targeting nightly, oldnightly, beta, or stable buckets.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/3c1333a6-9e08-4e87-bc8f-56112301816e)

Comment @datadog to request changes