### PR TITLE
Remove unused field SketchSeries.ContextKey

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -101,7 +101,7 @@ func (cs *CheckSampler) newSketchSeries(ck ckey.ContextKey, points []metrics.Ske
 		Tags: ctx.Tags(),
 		Host: ctx.Host,
 		// Interval: TODO: investigate
-		Points:     points,
+		Points: points,
 	}
 
 	return ss

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -102,7 +102,6 @@ func (cs *CheckSampler) newSketchSeries(ck ckey.ContextKey, points []metrics.Ske
 		Host: ctx.Host,
 		// Interval: TODO: investigate
 		Points:     points,
-		ContextKey: ck,
 	}
 
 	return ss

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -262,7 +262,6 @@ func testCheckHistogramBucketSampling(t *testing.T, store *tags.Store) {
 		Points: []metrics.SketchPoint{
 			{Ts: 12345.0, Sketch: expSketch},
 		},
-		ContextKey: generateContextKey(bucket1),
 	}, flushed[0], .03)
 
 	bucket2 := &metrics.HistogramBucket{
@@ -295,7 +294,6 @@ func testCheckHistogramBucketSampling(t *testing.T, store *tags.Store) {
 		Points: []metrics.SketchPoint{
 			{Ts: 12400.0, Sketch: expSketch},
 		},
-		ContextKey: generateContextKey(bucket1),
 	}, flushed[0], .03)
 
 	// garbage collection
@@ -359,7 +357,6 @@ func testCheckHistogramBucketDontFlushFirstValue(t *testing.T, store *tags.Store
 		Points: []metrics.SketchPoint{
 			{Ts: 12400.0, Sketch: expSketch},
 		},
-		ContextKey: generateContextKey(bucket1),
 	}, flushed[0], .03)
 }
 
@@ -424,16 +421,14 @@ func testCheckHistogramBucketReset(t *testing.T, store *tags.Store) {
 
 	require.Len(t, flushed, 2)
 	metrics.AssertSketchSeriesApproxEqual(t, &metrics.SketchSeries{
-		Name:       "my.histogram",
-		ContextKey: generateContextKey(&metrics.HistogramBucket{Name: "my.histogram"}),
+		Name: "my.histogram",
 		Points: []metrics.SketchPoint{
 			{Ts: 12410, Sketch: sketchOf(10, 20, 3)},
 		},
 	}, flushed[0], 0.01)
 
 	metrics.AssertSketchSeriesApproxEqual(t, &metrics.SketchSeries{
-		Name:       "my.histogram",
-		ContextKey: generateContextKey(&metrics.HistogramBucket{Name: "my.histogram"}),
+		Name: "my.histogram",
 		Points: []metrics.SketchPoint{
 			{Ts: 12420, Sketch: sketchOf(10, 20, 2)},
 		},
@@ -502,7 +497,6 @@ func testCheckHistogramBucketMultipleBucketsSampling(t *testing.T, store *tags.S
 		Points: []metrics.SketchPoint{
 			{Ts: 12345.0, Sketch: expSketch.Finish()},
 		},
-		ContextKey: ctx,
 	}, flushed[0], .03)
 
 	// Second round: same bounds, larger raw values. Per-bound de-cumulation
@@ -544,7 +538,6 @@ func testCheckHistogramBucketMultipleBucketsSampling(t *testing.T, store *tags.S
 		Points: []metrics.SketchPoint{
 			{Ts: 12400.0, Sketch: expSketch.Finish()},
 		},
-		ContextKey: ctx,
 	}, flushed[0], .03)
 
 	// One more commit without further adds expires the context (sampler was
@@ -594,7 +587,6 @@ func testCheckHistogramBucketInfinityBucket(t *testing.T, store *tags.Store) {
 		Points: []metrics.SketchPoint{
 			{Ts: 12345.0, Sketch: expSketch},
 		},
-		ContextKey: generateContextKey(bucket1),
 	}, flushed[0], .03)
 }
 
@@ -632,7 +624,6 @@ func testCheckDistribution(t *testing.T, store *tags.Store) {
 		Points: []metrics.SketchPoint{
 			{Ts: 12345.0, Sketch: expSketch},
 		},
-		ContextKey: generateContextKey(&mSample1),
 	}, sketches[0])
 }
 

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -123,13 +123,13 @@ func (s *TimeSampler) newSketchSeries(ck ckey.ContextKey, points []metrics.Sketc
 	}
 
 	ss := &metrics.SketchSeries{
-		Name:       ctx.Name,
-		Tags:       ctx.Tags(),
-		Host:       ctx.Host,
-		Interval:   s.interval,
-		Points:     points,
-		Source:     ctx.source,
-		NoIndex:    ctx.noIndex,
+		Name:     ctx.Name,
+		Tags:     ctx.Tags(),
+		Host:     ctx.Host,
+		Interval: s.interval,
+		Points:   points,
+		Source:   ctx.source,
+		NoIndex:  ctx.noIndex,
 	}
 
 	return ss

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -128,7 +128,6 @@ func (s *TimeSampler) newSketchSeries(ck ckey.ContextKey, points []metrics.Sketc
 		Host:       ctx.Host,
 		Interval:   s.interval,
 		Points:     points,
-		ContextKey: ck,
 		Source:     ctx.source,
 		NoIndex:    ctx.noIndex,
 	}

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -314,12 +314,11 @@ func testSketch(t *testing.T, store *tags.Store) {
 
 	t.Run("single bucket", func(t *testing.T) {
 		var (
-			now    float64
-			name   = "m.0"
-			tags   = []string{"a"}
-			host   = "host"
-			exp    = &quantile.Sketch{}
-			keyGen = ckey.NewKeyGenerator()
+			now  float64
+			name = "m.0"
+			tags = []string{"a"}
+			host = "host"
+			exp  = &quantile.Sketch{}
 		)
 
 		for i := 0; i < bucketSize; i++ {
@@ -342,7 +341,6 @@ func testSketch(t *testing.T, store *tags.Store) {
 					Ts:     0,
 				},
 			},
-			ContextKey: keyGen.Generate(name, host, tagset.NewHashingTagsAccumulatorWithTags(tags)),
 		}, flushed[0])
 
 		_, flushed = flushSerie(sampler, now, false)
@@ -391,7 +389,6 @@ func testSketchBucketSampling(t *testing.T, store *tags.Store) {
 			{Ts: 10000, Sketch: expSketch},
 			{Ts: 10010, Sketch: expSketch},
 		},
-		ContextKey: generateContextKey(&mSample1),
 	}, flushed[0])
 
 	// The samples added after the flush time remains in the dist sampler
@@ -438,7 +435,6 @@ func testSketchContextSampling(t *testing.T, store *tags.Store) {
 		Points: []metrics.SketchPoint{
 			{Ts: 10010, Sketch: expSketch},
 		},
-		ContextKey: generateContextKey(&mSample1),
 	}, flushed[0])
 
 	metrics.AssertSketchSeriesEqual(t, &metrics.SketchSeries{
@@ -448,7 +444,6 @@ func testSketchContextSampling(t *testing.T, store *tags.Store) {
 		Points: []metrics.SketchPoint{
 			{Ts: 10010, Sketch: expSketch},
 		},
-		ContextKey: generateContextKey(&mSample2),
 	}, flushed[1])
 }
 func TestSketchContextSampling(t *testing.T) {
@@ -508,7 +503,6 @@ func testBucketSamplingWithSketchAndSeries(t *testing.T, store *tags.Store) {
 			{Ts: 12340.0, Sketch: expSketch},
 			{Ts: 12350.0, Sketch: expSketch},
 		},
-		ContextKey: generateContextKey(&dSample1),
 	}, sketches[0])
 }
 func TestBucketSamplingWithSketchAndSeries(t *testing.T) {
@@ -672,7 +666,6 @@ func TestForcedFlush(t *testing.T) {
 			{Ts: 1010.0, Sketch: expSketch},
 			{Ts: 1020.0, Sketch: expSketch},
 		},
-		ContextKey: generateContextKey(testSketch),
 	}, sSerie[0])
 }
 

--- a/pkg/metrics/sketch_series.go
+++ b/pkg/metrics/sketch_series.go
@@ -14,13 +14,13 @@ import (
 
 // A SketchSeries is a timeseries of quantile sketches.
 type SketchSeries struct {
-	Name       string               `json:"metric"`
-	Tags       tagset.CompositeTags `json:"tags"`
-	Host       string               `json:"host"`
-	Interval   int64                `json:"interval"`
-	Points     []SketchPoint        `json:"points"`
-	NoIndex    bool                 `json:"-"` // This is only used by api V2
-	Source     MetricSource         `json:"-"` // This is only used by api V2
+	Name     string               `json:"metric"`
+	Tags     tagset.CompositeTags `json:"tags"`
+	Host     string               `json:"host"`
+	Interval int64                `json:"interval"`
+	Points   []SketchPoint        `json:"points"`
+	NoIndex  bool                 `json:"-"` // This is only used by api V2
+	Source   MetricSource         `json:"-"` // This is only used by api V2
 }
 
 // GetName returns the name of the SketchSeries

--- a/pkg/metrics/sketch_series.go
+++ b/pkg/metrics/sketch_series.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 )
 
@@ -20,7 +19,6 @@ type SketchSeries struct {
 	Host       string               `json:"host"`
 	Interval   int64                `json:"interval"`
 	Points     []SketchPoint        `json:"points"`
-	ContextKey ckey.ContextKey      `json:"-"`
 	NoIndex    bool                 `json:"-"` // This is only used by api V2
 	Source     MetricSource         `json:"-"` // This is only used by api V2
 }

--- a/pkg/metrics/test_helper.go
+++ b/pkg/metrics/test_helper.go
@@ -190,7 +190,6 @@ func assertSketchSeriesEqualWithComparator(t assert.TestingT, exp, act *SketchSe
 
 	assert.Equal(t, exp.Host, act.Host, "Host")
 	assert.Equal(t, exp.Interval, act.Interval, "Interval")
-	assert.Equal(t, exp.ContextKey, act.ContextKey, "ContextKey")
 
 	switch {
 	case len(exp.Points) != len(act.Points):

--- a/pkg/serializer/go.mod
+++ b/pkg/serializer/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/comp/serializer/metricscompression v0.59.0-rc.6
-	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.59.0-rc.6
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.70.0
 	github.com/DataDog/datadog-agent/pkg/config/model v0.77.2
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.70.0
@@ -47,6 +46,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.60.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.60.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.73.0-rc.5 // indirect
+	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.59.0-rc.6 // indirect
 	github.com/DataDog/datadog-agent/pkg/api v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect

--- a/pkg/serializer/internal/metrics/BUILD.bazel
+++ b/pkg/serializer/internal/metrics/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//comp/forwarder/defaultforwarder/resolver",
         "//comp/forwarder/defaultforwarder/transaction",
         "//comp/serializer/metricscompression/def",
-        "//pkg/aggregator/ckey",
         "//pkg/metrics",
         "//pkg/metrics/event",
         "//pkg/metrics/servicecheck",

--- a/pkg/serializer/internal/metrics/test_helper.go
+++ b/pkg/serializer/internal/metrics/test_helper.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/util/quantile"
@@ -37,9 +36,6 @@ func Makeseries(i int) *metrics.SketchSeries {
 			Sketch: makesketch(j),
 		})
 	}
-
-	gen := ckey.NewKeyGenerator()
-	ss.ContextKey = gen.Generate(ss.Name, ss.Host, tagset.NewHashingTagsAccumulatorWithTags(ss.Tags.UnsafeToReadOnlySliceString()))
 
 	return ss
 }


### PR DESCRIPTION
### What does this PR do?

Remove unused field SketchSeries.ContextKey. 

### Motivation

The field was only ever assigned, but not read by prod code. 

### Describe how you validated your changes

### Additional Notes
