### PR TITLE
fix(tagger): rename impl-optional-remote package to optionalremoteimpl

### DIFF
--- a/comp/core/tagger/fx-optional-remote/fx.go
+++ b/comp/core/tagger/fx-optional-remote/fx.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/fx"
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
-	optionalimpl "github.com/DataDog/datadog-agent/comp/core/tagger/impl-optional-remote"
+	optionalremoteimpl "github.com/DataDog/datadog-agent/comp/core/tagger/impl-optional-remote"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -22,7 +22,7 @@ import (
 func Module(optionalParams tagger.OptionalRemoteParams, remoteParams tagger.RemoteParams) fxutil.Module {
 	return fxutil.Component(
 		fxutil.ProvideComponentConstructor(
-			optionalimpl.NewComponent,
+			optionalremoteimpl.NewComponent,
 		),
 		fx.Supply(remoteParams),
 		fx.Supply(optionalParams),

--- a/comp/core/tagger/impl-optional-remote/optional-remote.go
+++ b/comp/core/tagger/impl-optional-remote/optional-remote.go
@@ -3,13 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package optionalimpl contains the implementation of the optional remote
-// tagger. The optionalimpl allow clients to use either the remote tagger or
-// the noop tagger based on their configuration. This should only be used in
-// the trace-agent in an Azure App Services (AAS) Extension environment where
-// we are confident that the container tagging functionality provided by the
-// remote tagger is not needed.
-package optionalimpl
+// Package optionalremoteimpl contains the implementation of the optional remote
+// tagger. It allows clients to use either the remote tagger or the noop tagger
+// based on their configuration. This should only be used in the trace-agent in
+// an Azure App Services (AAS) Extension environment where we are confident that
+// the container tagging functionality provided by the remote tagger is not needed.
+package optionalremoteimpl
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/config"

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -257,7 +257,7 @@ def check_component_contents_and_file_hiearchy(comp):
             for part in src_file.parts:
                 if "impl-" in part:
                     parts = part.split("-")
-                    expectname = parts[1] + 'impl'
+                    expectname = ''.join(parts[1:]) + 'impl'
 
             if pkgname != expectname:
                 return f"** {src_file} has wrong package name '{pkgname}', must be '{expectname}'"


### PR DESCRIPTION
### What does this PR do?

Renames the Go package in `comp/core/tagger/impl-optional-remote/` from `optionalimpl` to `optionalremoteimpl`, and updates the one caller in `comp/core/tagger/fx-optional-remote/fx.go` to use the new name.

### Motivation

Per v2 component conventions, the package name of an `impl-<suffix>` folder must be `<suffix>impl` (with hyphens stripped). The folder is `impl-optional-remote`, so the required package name is `optionalremoteimpl`. The old name `optionalimpl` was incorrect and flagged by the component linter.

### Describe how you validated your changes

The only importer is `comp/core/tagger/fx-optional-remote/fx.go` — updated in the same commit. No other files reference this package by name.

### Additional Notes

Companion to the linter allowlist cleanup in #51930.