### PR TITLE
fix(healthplatform): fix health_platform.forwarder.interval type to string

### DIFF
--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8196,8 +8196,8 @@ properties:
         properties:
           interval:
             node_type: setting
-            type: integer
-            default: 0
+            type: string
+            default: 0s
       persist_on_kubernetes:
         node_type: setting
         type: boolean

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1203,7 +1203,7 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("health_port", int64(0))
 	config.BindEnvAndSetDefault("health_platform.enabled", false)
 	config.BindEnvAndSetDefault("health_platform.persist_on_kubernetes", false)
-	config.BindEnvAndSetDefault("health_platform.forwarder.interval", 0)
+	config.BindEnvAndSetDefault("health_platform.forwarder.interval", "0s")
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
 	config.BindEnvAndSetDefault("win_skip_com_init", false)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)

--- a/releasenotes/notes/fix-hp-interval-string-type-75030d7bbb18d32d.yaml
+++ b/releasenotes/notes/fix-hp-interval-string-type-75030d7bbb18d32d.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fix the ``health_platform.forwarder.interval`` configuration field type from
+    integer to string. Previously, setting an integer value (e.g. ``900``) would
+    be interpreted as nanoseconds by the agent instead of seconds, resulting in
+    an unexpectedly short flush interval. The field now accepts duration strings
+    such as ``15m`` or ``5m30s``, consistent with other duration configuration
+    fields in the agent.


### PR DESCRIPTION
### What does this PR do?

Fixes `health_platform.forwarder.interval` config field to use a string default (`"0s"`) and `type: string` in the schema, consistent with other duration fields read via `GetDuration` (e.g. `network_path.collector.pathtest_ttl`, `network_path.collector.flush_interval`).

### Motivation

The field was declared as `type: integer` with default `0` in the schema, but consumed via `GetDuration` in the egress component. This creates a subtle foot-gun: viper's `GetDuration` interprets integers as nanoseconds, so a user setting `interval: 900` would get 900ns instead of 900s. The string form (`"15m"`, `"5m"`) is unambiguous and matches how every other duration field in this codebase is typed.

### Describe how you validated your changes

- `GetDuration("0s")` returns `0`, which the egress component correctly treats as "use `defaultEgressInterval` (15min)". Behaviour is identical to before.
- No test changes needed: no existing test asserts the raw default value.

### Additional Notes

Related to #51923 (`health_platform.enabled` enabled by default).