### PR TITLE
[CSPM] Fix nil pointer panic on XCCDF evaluator shutdown

### DIFF
--- a/pkg/compliance/evaluator_xccdf.go
+++ b/pkg/compliance/evaluator_xccdf.go
@@ -19,10 +19,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance/metrics"
 	"github.com/DataDog/datadog-agent/pkg/compliance/scap"
@@ -64,7 +64,7 @@ var (
 )
 
 type oscapIO struct {
-	cmd      atomic.Pointer[exec.Cmd]
+	cmd      *atomic.Pointer[exec.Cmd]
 	File     string
 	RuleCh   chan *oscapIORule
 	ResultCh chan *oscapIOResult
@@ -74,6 +74,7 @@ type oscapIO struct {
 
 func newOSCAPIO(file string) *oscapIO {
 	return &oscapIO{
+		cmd:      atomic.NewPointer[exec.Cmd](nil),
 		File:     file,
 		RuleCh:   make(chan *oscapIORule),
 		ResultCh: make(chan *oscapIOResult),

--- a/pkg/compliance/evaluator_xccdf.go
+++ b/pkg/compliance/evaluator_xccdf.go
@@ -19,14 +19,16 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance/metrics"
 	"github.com/DataDog/datadog-agent/pkg/compliance/scap"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 const (
@@ -62,7 +64,7 @@ var (
 )
 
 type oscapIO struct {
-	cmd      *exec.Cmd
+	cmd      atomic.Pointer[exec.Cmd]
 	File     string
 	RuleCh   chan *oscapIORule
 	ResultCh chan *oscapIOResult
@@ -108,7 +110,6 @@ func (p *oscapIO) Run(ctx context.Context) error {
 	if oscapProbeRoot != "" {
 		cmd.Env = append(cmd.Env, "OSCAP_PROBE_ROOT="+oscapProbeRoot)
 	}
-	p.cmd = cmd
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -133,6 +134,7 @@ func (p *oscapIO) Run(ctx context.Context) error {
 	if err := cmd.Start(); err != nil {
 		return err
 	}
+	p.cmd.Store(cmd)
 
 	r := bufio.NewReader(stdout)
 	go func() {
@@ -240,7 +242,15 @@ func (p *oscapIO) Stop() {
 }
 
 func (p *oscapIO) Kill() error {
-	if err := p.cmd.Process.Kill(); err != nil {
+	// p.cmd is Stored asynchronously by Run only after the oscap-io process has started
+	// successfully. Kill may be called before that happens (for example from
+	// FinishXCCDFBenchmark on context cancellation), in which case cmd is
+	// still nil and there is no process to kill.
+	cmd := p.cmd.Load()
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	if err := cmd.Process.Kill(); err != nil {
 		return err
 	}
 	// Wait for the oscap-io process to terminate.


### PR DESCRIPTION
### What does this PR do?

Fixes a race leading to nil pointer dereference that happens when an XCCDF benchmark is terminated before its oscap-io subprocess has started.

### Motivation

The subprocess is started asynchronously while its handle is already reachable by the termination path. On context cancellation during shutdown, termination could dereference the not-yet-initialized command and panic the agent:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xa0 pc=0x116f3da]
goroutine 2841 [running]:
github.com/DataDog/datadog-agent/pkg/compliance.(*oscapIO).Kill(0xc004de7200)
	github.com/DataDog/datadog-agent/pkg/compliance/evaluator_xccdf.go:243 +0x1a
github.com/DataDog/datadog-agent/pkg/compliance.FinishXCCDFBenchmark({0xc002aadf20?, 0xc002aade78?}, 0xc006278000)
	github.com/DataDog/datadog-agent/pkg/compliance/evaluator_xccdf.go:398 +0x25f
github.com/DataDog/datadog-agent/pkg/compliance.(*Agent).runXCCDFBenchmarks(0xc001c8e140, {0x31f6060, 0xc002ec05f0})
	github.com/DataDog/datadog-agent/pkg/compliance/agent.go:392 +0x5cb
github.com/DataDog/datadog-agent/pkg/compliance.(*Agent).Start.func4()
	github.com/DataDog/datadog-agent/pkg/compliance/agent.go:254 +0x28
created by github.com/DataDog/datadog-agent/pkg/compliance.(*Agent).Start in goroutine 1
	github.com/DataDog/datadog-agent/pkg/compliance/agent.go:253 +0x37e
```

### Describe how you validated your changes

`dda inv test --targets=./pkg/compliance` tests pass.

### Additional Notes
