### PR TITLE
Retrieve go mod contents from cache in macos builds

### DIFF
--- a/.gitlab/build/package_build/build_agent_dmg.sh
+++ b/.gitlab/build/package_build/build_agent_dmg.sh
@@ -93,14 +93,21 @@ echo Launching omnibus build
 rm -rf "$INSTALL_DIR" "$CONFIG_DIR"
 mkdir -p "$INSTALL_DIR" "$CONFIG_DIR"
 rm -rf "$OMNIBUS_DIR" && mkdir -p "$OMNIBUS_DIR"
+OMNIBUS_BUILD_ARGS=(
+    --skip-deps
+    --go-mod-cache="$GOMODCACHE"
+    --config-directory "$CONFIG_DIR"
+    --install-directory "$INSTALL_DIR"
+    --base-dir "$OMNIBUS_DIR"
+)
 if [ "${SIGN:-false}" = true ]; then
     # Unlock the keychain to get access to the signing certificates
     security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_NAME"
-    dda inv -- -e omnibus.build --hardened-runtime --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR" --base-dir "$OMNIBUS_DIR" || exit 1
+    dda inv -- -e omnibus.build --hardened-runtime "${OMNIBUS_BUILD_ARGS[@]}" || exit 1
     # Lock the keychain once we're done
     security lock-keychain "$KEYCHAIN_NAME"
 else
-    dda inv -- -e omnibus.build --skip-sign --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR" --base-dir "$OMNIBUS_DIR" || exit 1
+    dda inv -- -e omnibus.build --skip-sign "${OMNIBUS_BUILD_ARGS[@]}" || exit 1
 fi
 
 #TODO(regis): consider moving the following check to `DataDog/omnibus-ruby` to benefit other OSes

--- a/.gitlab/build/package_build/dmg.yml
+++ b/.gitlab/build/package_build/dmg.yml
@@ -18,13 +18,14 @@
   # Set bundler install path to cached folder
   - !reference [.cache_omnibus_ruby_deps, setup]
   - |
-    export GOMODCACHE=~/gomodcache
-    mkdir -p $GOMODCACHE
+    export GOPATH="$(go env GOPATH)"
+    export GOMODCACHE="$GOPATH/pkg/mod"
+    mkdir -p "$GOMODCACHE"
 
 .agent_dmg:
   extends: .bazel:defs:cache:macos
   stage: package_build
-  needs: ["go_mod_tidy_check"]
+  needs: ["go_deps", "go_mod_tidy_check"]
   rules:
      - if: $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
        variables:
@@ -73,6 +74,7 @@
     # List Python and Go existing environments and their disk space
     - !reference [.macos_runner_maintenance]
     - !reference [.macos_setup_cache]
+    - !reference [.retrieve_linux_go_deps]
     - bash .gitlab/build/package_build/build_agent_dmg.sh
     - !reference [.upload_sbom_artifacts]
 


### PR DESCRIPTION
### What does this PR do?

Use pregenerated go mod cache contents on macos builds.

### Motivation

- Do the same as on other platforms as well as macos test jobs.
- Save some time, as this step can take anywhere from 80 to 400+ seconds ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1751282223#L128)):
```
go mod download && go mod tidy completed in 410.98s
```

### Describe how you validated your changes

CI passes, and the step above is not run on build jobs.

### Additional Notes
