### PR TITLE
[AMCC-196]Ensure filterlist telemetry is consistent between RC and config file

### DIFF
--- a/comp/filterlist/impl/filterlist.go
+++ b/comp/filterlist/impl/filterlist.go
@@ -254,9 +254,6 @@ func (fl *FilterList) setTagFilterList(metricTags tagMatcher) {
 func (fl *FilterList) SetMetricFilterList(metricNames []string, matchPrefix bool) {
 	fl.log.Debugf("SetMetricFilterList with %d metrics", len(metricNames))
 
-	fl.tlmMetricFilterListUpdates.Inc()
-	fl.tlmMetricFilterListSize.Set(float64(len(metricNames)))
-
 	// we will use two different filterlists:
 	// - one with all the metrics names, with all values from `metricNames`
 	// - one with only the metric names ending with histogram aggregates suffixes
@@ -265,6 +262,11 @@ func (fl *FilterList) SetMetricFilterList(metricNames []string, matchPrefix bool
 	histoMetricNames := fl.createHistogramsFilterList(metricNames)
 	filterList := utilstrings.NewMatcher(metricNames, matchPrefix)
 	histoFilterList := utilstrings.NewMatcher(histoMetricNames, matchPrefix)
+
+	// Report the compiled size: with prefix matching, NewMatcher compacts
+	// redundant sub-prefixes, so len(metricNames) can overcount.
+	fl.tlmMetricFilterListUpdates.Inc()
+	fl.tlmMetricFilterListSize.Set(float64(filterList.Len()))
 
 	fl.updateMetricMtx.Lock()
 	fl.filterList = filterList

--- a/comp/filterlist/impl/filterlist.go
+++ b/comp/filterlist/impl/filterlist.go
@@ -114,7 +114,9 @@ func NewFilterList(log log.Component, config config.Component, telemetryComp tel
 		tlmTagFilterListUpdates:    tlmTagFilterListUpdates,
 		tlmTagFilterListSize:       tlmTagFilterListSize,
 	}
-	fl.SetTagFilterListFromEntries(localFilterListConfig.tagFilterList)
+	compiledTag := loadTagFilterList(localFilterListConfig.tagFilterList, log)
+	fl.setTagFilterList(compiledTag)
+
 	fl.SetMetricFilterList(localFilterListConfig.metricNames, localFilterListConfig.matchPrefix)
 
 	return fl
@@ -233,6 +235,9 @@ func (fl *FilterList) SetTagFilterList(metricTags map[string]MetricTagList) {
 func (fl *FilterList) setTagFilterList(metricTags tagMatcher) {
 	fl.log.Debugf("SetTagFilterList with %d metrics", len(metricTags.MetricTags))
 
+	fl.tlmTagFilterListUpdates.Inc()
+	fl.tlmTagFilterListSize.Set(float64(len(metricTags.MetricTags)))
+
 	fl.updateTagMtx.Lock()
 	fl.tagFilterList = metricTags
 	fl.updateTagMtx.Unlock()
@@ -245,16 +250,12 @@ func (fl *FilterList) setTagFilterList(metricTags tagMatcher) {
 	}
 }
 
-// SetTagFilterListFromEntries takes a list of tag filter list objects that
-// were loaded from the config file, converts and hashes the tags in a format
-// used internally. Any registered callbacks are informed of the update.
-func (fl *FilterList) SetTagFilterListFromEntries(entries []MetricTagListEntry) {
-	fl.setTagFilterList(loadTagFilterList(entries, fl.log))
-}
-
 // SetMetricFilterList updates the metric names filter on all running worker.
 func (fl *FilterList) SetMetricFilterList(metricNames []string, matchPrefix bool) {
 	fl.log.Debugf("SetMetricFilterList with %d metrics", len(metricNames))
+
+	fl.tlmMetricFilterListUpdates.Inc()
+	fl.tlmMetricFilterListSize.Set(float64(len(metricNames)))
 
 	// we will use two different filterlists:
 	// - one with all the metrics names, with all values from `metricNames`
@@ -281,9 +282,6 @@ func (fl *FilterList) SetMetricFilterList(metricNames []string, matchPrefix bool
 func (fl *FilterList) restoreMetricFilterListFromLocalConfig() {
 	fl.log.Debug("Restoring metric filterlist with local config.")
 
-	fl.tlmMetricFilterListUpdates.Inc()
-	fl.tlmMetricFilterListSize.Set(float64(len(fl.localFilterListConfig.metricNames)))
-
 	fl.SetMetricFilterList(
 		fl.localFilterListConfig.metricNames,
 		fl.localFilterListConfig.matchPrefix,
@@ -293,10 +291,8 @@ func (fl *FilterList) restoreMetricFilterListFromLocalConfig() {
 func (fl *FilterList) restoreTagFilterListFromLocalConfig() {
 	fl.log.Debug("Restoring tag metric filterlist with local config.")
 
-	fl.tlmTagFilterListUpdates.Inc()
-	fl.tlmTagFilterListSize.Set(float64(len(fl.localFilterListConfig.tagFilterList)))
-
-	fl.SetTagFilterListFromEntries(fl.localFilterListConfig.tagFilterList)
+	compiled := loadTagFilterList(fl.localFilterListConfig.tagFilterList, fl.log)
+	fl.setTagFilterList(compiled)
 }
 
 // OnUpdateMetricFilterList is called to register a callback to be called when the

--- a/comp/filterlist/impl/rc.go
+++ b/comp/filterlist/impl/rc.go
@@ -110,8 +110,6 @@ func (fl *FilterList) onFilterListUpdateCallback(updates map[string]state.RawCon
 		}
 
 		// apply this new blocklist to all the running workers
-		fl.tlmMetricFilterListUpdates.Inc()
-		fl.tlmMetricFilterListSize.Set(float64(len(metricNames)))
 		fl.SetMetricFilterList(metricNames, false)
 	} else {
 		fl.config.UnsetForSource("metric_filterlist", model.SourceRC)
@@ -131,8 +129,6 @@ func (fl *FilterList) onFilterListUpdateCallback(updates map[string]state.RawCon
 		fl.config.Set("metric_tag_filterlist", tagEntries, model.SourceRC)
 
 		// apply this new blocklist to all the running workers
-		fl.tlmTagFilterListUpdates.Inc()
-		fl.tlmTagFilterListSize.Set(float64(len(tags)))
 		fl.setTagFilterList(tagMatcher{
 			MetricTags: tags,
 		})

--- a/pkg/util/strings/matcher.go
+++ b/pkg/util/strings/matcher.go
@@ -47,6 +47,14 @@ func NewMatcher(data []string, matchPrefix bool) Matcher {
 	}
 }
 
+// Len returns the number of entries in the compiled matcher.
+func (m *Matcher) Len() int {
+	if m == nil {
+		return 0
+	}
+	return len(m.data)
+}
+
 // Test returns true if the given string matches one in the matcher list.
 // or is matching by prefix if the matcher has been created with `matchPrefix`.
 func (m *Matcher) Test(name string) bool {


### PR DESCRIPTION
### What does this PR do?

Ensures the following metrics are emitted when initially loading configuration from a file:

- `filterlist.updates`
- `filterlist.size`
- `tag_filterlist.updates`
- `tag_filterlist.size`

### Motivation

These should be emitted. We also need to make sure the values are consistently emitting the size of the filterlists after compilation - if there are duplicates the resulting size would be smaller than the uncompiled.

### Describe how you validated your changes

Tested manually.

### Additional Notes

