### PR TITLE
ci(lint): restrict native OS linters to release/nightly pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
 ---
-
 # Condition mixins for simplification of rules, needed in the include rules so must be defined first
 .if_run_all_e2e_tests: &if_run_all_e2e_tests
   if: $RUN_E2E_TESTS == "on"
@@ -23,7 +22,7 @@
   if: $DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null
 
 # Windows-specific Go source files, pkg/, and cmd/ (27 paths), need to be splitted because Gitlab has a limit to 50 paths in a single rule
-.windows_path: &windows_path
+.windows_path: &windows_path 
   # Windows-specific Go source files (by filename convention)
   - "**/*_windows.go"
 
@@ -65,8 +64,7 @@
   - bazel/**/*
 
 # Windows-specific comp/, tools, omnibus, containers, tasks, and cross-cutting paths
-.windows_path_2: &windows_path_2
-  # Windows-specific comp/ components
+.windows_path_2: &windows_path_2 # Windows-specific comp/ components
   - comp/systray/**/*
   - comp/updater/**/*
   - comp/checks/agentcrashdetect/**/*
@@ -423,7 +421,6 @@ variables:
 .if_installer_tests: &if_installer_tests
   if: ($CI_COMMIT_BRANCH == "main"  || $DEPLOY_AGENT == "true" || $RUN_E2E_TESTS == "on" || $DDR_WORKFLOW_ID != null) && $RUN_E2E_TESTS != "off"
 
-
 # When RUN_E2E_TESTS is set to "auto". We do not enforce a behavior for the tests.
 # The behavior of each test will be defined by its rules.
 # For example for new-e2e tests created by each team, here is an example of such rules: https://github.com/DataDog/datadog-agent/blob/ba7079d92077ab5898378594dcafb9cd88a77e57/.gitlab-ci.yml#L1160-L1167
@@ -694,7 +691,6 @@ workflow:
     when: manual
     allow_failure: true
 
-
 # Rule for native OS linters (macOS, Windows): restrict to release/tag/nightly
 # deploys where the cross-platform lint job is insufficient (e.g. cgo, platform
 # runtime behavior). For normal branch and main pipelines the cross lint job
@@ -703,7 +699,6 @@ workflow:
   - <<: *if_tagged_commit
   - <<: *if_release_branch
   - if: ($DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null) && $BUCKET_BRANCH =~ /^(nightly|oldnightly|beta|stable)$/
-  - when: never
 
 .on_main_or_release_branch_or_deploy_always:
   - <<: *if_deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -695,6 +695,16 @@ workflow:
     allow_failure: true
 
 
+# Rule for native OS linters (macOS, Windows): restrict to release/tag/nightly
+# deploys where the cross-platform lint job is insufficient (e.g. cgo, platform
+# runtime behavior). For normal branch and main pipelines the cross lint job
+# already provides coverage at a fraction of the resource cost.
+.on_native_os_linters:
+  - <<: *if_tagged_commit
+  - <<: *if_release_branch
+  - if: ($DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null) && $BUCKET_BRANCH =~ /^(nightly|oldnightly|beta|stable)$/
+  - when: never
+
 .on_main_or_release_branch_or_deploy_always:
   - <<: *if_deploy
     when: always

--- a/.gitlab/build/lint/cross.yml
+++ b/.gitlab/build/lint/cross.yml
@@ -8,7 +8,7 @@
   extends: .linux_x64
   needs: ["go_deps", "go_tools_deps"]
   variables:
-    FLAVORS: '--flavor base'
+    FLAVORS: "--flavor base"
     KUBERNETES_CPU_REQUEST: 16
     KUBERNETES_MEMORY_REQUEST: 32Gi
     KUBERNETES_MEMORY_LIMIT: 32Gi
@@ -18,8 +18,6 @@
 
 lint_cross_windows-x64:
   extends: .cross_lint
-  rules:
-    - when: on_success
   script:
     - dda inv -- -e build-messagetable
     - export GOOS=windows GOARCH=amd64
@@ -27,16 +25,12 @@ lint_cross_windows-x64:
 
 lint_cross_macos-x64:
   extends: .cross_lint
-  rules:
-    - when: on_success
   script:
     - export GOOS=darwin GOARCH=amd64
     - !reference [.lint_script]
 
 lint_cross_macos-arm64:
   extends: .cross_lint
-  rules:
-    - when: on_success
   script:
     - export GOOS=darwin GOARCH=arm64
     - !reference [.lint_script]

--- a/.gitlab/build/lint/cross.yml
+++ b/.gitlab/build/lint/cross.yml
@@ -27,12 +27,16 @@ lint_cross_windows-x64:
 
 lint_cross_macos-x64:
   extends: .cross_lint
+  rules:
+    - when: on_success
   script:
     - export GOOS=darwin GOARCH=amd64
     - !reference [.lint_script]
 
 lint_cross_macos-arm64:
   extends: .cross_lint
+  rules:
+    - when: on_success
   script:
     - export GOOS=darwin GOARCH=arm64
     - !reference [.lint_script]

--- a/.gitlab/build/lint/macos.yml
+++ b/.gitlab/build/lint/macos.yml
@@ -6,8 +6,7 @@ include:
   stage: lint
   extends: .macos_gitlab
   rules:
-    - !reference [.except_mergequeue]
-    - !reference [.on_main_or_release_branch]
+    - !reference [.on_native_os_linters]
   script:
     - dda inv -- -e linter.go --cpus 12 --debug --timeout 60
   retry: !reference [.retry_only_infra_failure, retry]

--- a/.gitlab/windows/build/lint/windows.yml
+++ b/.gitlab/windows/build/lint/windows.yml
@@ -1,5 +1,3 @@
-
-
 .lint_windows_base:
   stage: lint
   needs: ["go_deps", "go_tools_deps"]
@@ -34,10 +32,7 @@
 lint_windows-x64:
   extends: .lint_windows_base
   rules:
-    - if: $CI_COMMIT_TAG != null
-    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
-    - if: ($DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null) && $BUCKET_BRANCH =~ /^(nightly|oldnightly|beta|stable)$/
-    - when: never
+    - !reference [.on_native_os_linters]
   variables:
     ARCH: "x64"
   timeout: 1h30m


### PR DESCRIPTION
### What does this PR do?

Introduces a new `.on_native_os_linters` rule in `.gitlab-ci.yml` that restricts the native macOS and Windows lint jobs to only run on tagged commits, release branches, and nightly/beta/stable deploys. For all other pipelines (regular branches, main), the cross-compile lint jobs now run unconditionally instead, providing equivalent coverage.

Specific changes:
- **`.gitlab-ci.yml`**: Add `.on_native_os_linters` anchor with tight gating rules.
- **`.gitlab/build/lint/cross.yml`**: Add explicit `when: on_success` to `lint_cross_windows-x64`, `lint_cross_macos-x64`, and `lint_cross_macos-arm64` so they always run on all pipelines.
- **`.gitlab/build/lint/macos.yml`**: Switch macOS native linter from `except_mergequeue + on_main_or_release_branch` to `on_native_os_linters`.
- **`.gitlab/windows/build/lint/windows.yml`**: Switch Windows native linter from `except_mergequeue + on_success` to `on_native_os_linters`.
- **`.gitlab/windows/deploy/e2e_testing_deploy/windows.yml`**: Update `deploy_windows_testing-a7` and `deploy_windows_testing-a7-fips` `needs` from `lint_windows-x64` to `lint_cross_windows-x64` so these deploy jobs remain unblocked on regular branch pipelines where the native lint no longer runs.

### Motivation
https://datadoghq.atlassian.net/browse/ACIX-1658

Native OS lint jobs (macOS runners, Windows runners) are expensive in terms of CI time and infrastructure cost. On regular branch pipelines, the cross-compile lint jobs (`lint_cross_macos-x64`, `lint_cross_windows-x64`, etc.) already catch the vast majority of issues at a fraction of the resource cost. Running native linters on every branch push provides diminishing returns for the extra expense.

Restricting native linters to release, tagged, and nightly contexts preserves their value where it matters (pre-release validation, cgo/platform runtime behavior) while reducing cost on the high-frequency developer branch pipelines.

Follow-up of https://github.com/DataDog/datadog-agent/pull/51927

### Describe how you validated your changes

CI-only change — no agent binary code modified.