### PR TITLE
[AGNTLOG-643] pipeline backpressure / component utilization monitoring

### DIFF
--- a/comp/core/status/render_helpers.go
+++ b/comp/core/status/render_helpers.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"path"
 	"strconv"
 	"strings"
@@ -54,6 +55,7 @@ func HTMLFmap() pkghtmltemplate.FuncMap {
 			"ntpWarning":          ntpWarning,
 			"version":             getVersion,
 			"percent":             func(v float64) string { return fmt.Sprintf("%02.1f", v*100) },
+			"pctInt":              func(v float64) int { return int(math.Round(v * 100)) },
 			"complianceResult":    complianceResult,
 			"lastErrorTraceback":  lastErrorTracebackHTML,
 			"lastErrorMessage":    lastErrorMessageHTML,

--- a/comp/forwarder/eventplatform/impl/epforwarder.go
+++ b/comp/forwarder/eventplatform/impl/epforwarder.go
@@ -655,6 +655,8 @@ func newHTTPPassthroughPipeline(
 		endpoints.BatchMaxConcurrentSend,
 		endpoints.BatchMaxConcurrentSend,
 		secretsComp,
+		// Noop: passthrough pipelines must not write to the logs backpressure registry (their keys would collide).
+		pipelineMonitor,
 	)
 
 	var encoder compressioncommon.Compressor

--- a/comp/logs-library/metrics/BUILD.bazel
+++ b/comp/logs-library/metrics/BUILD.bazel
@@ -6,12 +6,14 @@ go_library(
         "capacity_monitor.go",
         "metrics.go",
         "pipeline_monitor.go",
+        "rolling_history.go",
         "utilization_monitor.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/logs-library/metrics",
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/telemetry/impl",
+        "//pkg/util/log",
         "@com_github_benbjohnson_clock//:clock",
     ],
 )
@@ -22,6 +24,7 @@ go_test(
         "capacity_monitor_test.go",
         "metrics_test.go",
         "pipeline_monitor_test.go",
+        "rolling_history_test.go",
         "utilization_monitor_test.go",
     ],
     embed = [":metrics"],

--- a/comp/logs-library/metrics/capacity_monitor.go
+++ b/comp/logs-library/metrics/capacity_monitor.go
@@ -74,9 +74,12 @@ func (i *CapacityMonitor) sample() {
 	}
 	select {
 	case <-i.tickChan:
-		i.avgItems = ewma(float64(i.ingress-i.egress), i.avgItems)
-		i.avgBytes = ewma(float64(i.ingressBytes-i.egressBytes), i.avgBytes)
+		rawItems := i.ingress - i.egress
+		rawBytes := i.ingressBytes - i.egressBytes
+		i.avgItems = ewma(float64(rawItems), i.avgItems)
+		i.avgBytes = ewma(float64(rawBytes), i.avgBytes)
 		i.report()
+		setComponentCapacity(i.name, i.instance, i.avgItems, i.avgBytes, rawItems, rawBytes)
 	default:
 	}
 }

--- a/comp/logs-library/metrics/metrics.go
+++ b/comp/logs-library/metrics/metrics.go
@@ -88,15 +88,12 @@ var (
 	// TlmAutoMultilineStackTraceAggregatorFlush counts Go stack trace aggregation outcomes.
 	TlmAutoMultilineStackTraceAggregatorFlush = telemetryimpl.GetCompatComponent().NewCounter("logs", "auto_multi_line_go_stack_trace_aggregator_flush", []string{"result"}, "Count of Go stack traces flushed from the stack trace aggregator")
 
-	// TlmUtilizationRatio is the utilization ratio of a component.
-	// Utilization ratio is calculated as the ratio of time spent in use to the total time.
-	// This metric is internally sampled and exposed as an ewma in order to produce a useable value.
-	TlmUtilizationRatio = telemetryimpl.GetCompatComponent().NewGauge("logs_component_utilization", "ratio", []string{"name", "instance"}, "Gauge of the utilization ratio of a component")
-	// TlmUtilizationItems is the capacity of a component by number of elements
-	// Both the number of items and the number of bytes are aggregated and exposed as a ewma.
-	TlmUtilizationItems = telemetryimpl.GetCompatComponent().NewGauge("logs_component_utilization", "items", []string{"name", "instance"}, "Gauge of the number of items currently held in a component and its buffers")
-	// TlmUtilizationBytes is the capacity of a component by number of bytes
-	TlmUtilizationBytes = telemetryimpl.GetCompatComponent().NewGauge("logs_component_utilization", "bytes", []string{"name", "instance"}, "Gauge of the number of bytes currently held in a component and its buffers")
+	// TlmUtilizationRatio is the N=15 EWMA utilization ratio of a component (~15s window).
+	TlmUtilizationRatio = telemetryimpl.GetCompatComponent().NewGauge("logs_component_utilization", "ratio", []string{"name", "instance"}, "Gauge of the utilization ratio of a component (N=15 EWMA, ~15s window)")
+	// TlmUtilizationItems is the EWMA item count held in a component and its buffers.
+	TlmUtilizationItems = telemetryimpl.GetCompatComponent().NewGauge("logs_component_utilization", "items", []string{"name", "instance"}, "Gauge of the number of items currently held in a component and its buffers (N=15 EWMA, ~15s window)")
+	// TlmUtilizationBytes is the EWMA byte count held in a component and its buffers.
+	TlmUtilizationBytes = telemetryimpl.GetCompatComponent().NewGauge("logs_component_utilization", "bytes", []string{"name", "instance"}, "Gauge of the number of bytes currently held in a component and its buffers (N=15 EWMA, ~15s window)")
 	// TlmDestNumWorkers is the number of destination workers in use.
 	TlmDestNumWorkers = telemetryimpl.GetCompatComponent().NewGauge("logs_destination", "destination_workers", []string{"instance"}, "Gauge of the number of destination workers in use")
 	// TlmDestVirtualLatency is a moving average of the destination's latency.

--- a/comp/logs-library/metrics/pipeline_monitor.go
+++ b/comp/logs-library/metrics/pipeline_monitor.go
@@ -7,10 +7,108 @@ package metrics
 
 import (
 	"sync"
+	"time"
+
+	"github.com/benbjohnson/clock"
 )
 
+const ewmaAlpha = 2 / (float64(15) + 1) // ~0.125 — 15-second smoothing window
+
+// ComponentSnapshot is the latest utilization/capacity sample for a component (Avg* are N=15 EWMA, Raw* instantaneous).
+type ComponentSnapshot struct {
+	Name     string
+	Instance string
+	AvgRatio float64
+	RawRatio float64
+	AvgItems float64
+	RawItems int64
+	AvgBytes float64
+	RawBytes int64
+	Windows  WindowStats
+
+	// history is the live rolling history; Windows is recomputed from it at read time, and it is
+	// cleared on returned copies so the pointer never escapes this package.
+	history *rollingHistory
+}
+
+// globalSnapshots keys (name:instance) are unique only per pipeline monitor, so only the logs
+// pipeline owns one; other senders pass a NoopPipelineMonitor to avoid colliding here.
+var (
+	globalSnapshotsMu sync.RWMutex
+	globalSnapshots   = map[string]*ComponentSnapshot{}
+)
+
+// setComponentUtilization stores the utilization fields and live history for name:instance.
+func setComponentUtilization(name, instance string, avgRatio, rawRatio float64, history *rollingHistory) {
+	key := name + ":" + instance
+	globalSnapshotsMu.Lock()
+	defer globalSnapshotsMu.Unlock()
+	s := globalSnapshots[key]
+	if s == nil {
+		s = &ComponentSnapshot{Name: name, Instance: instance}
+		globalSnapshots[key] = s
+	}
+	s.AvgRatio = avgRatio
+	s.RawRatio = rawRatio
+	s.history = history
+}
+
+// setComponentCapacity stores the capacity fields for name:instance.
+func setComponentCapacity(name, instance string, avgItems, avgBytes float64, rawItems, rawBytes int64) {
+	key := name + ":" + instance
+	globalSnapshotsMu.Lock()
+	defer globalSnapshotsMu.Unlock()
+	s := globalSnapshots[key]
+	if s == nil {
+		s = &ComponentSnapshot{Name: name, Instance: instance}
+		globalSnapshots[key] = s
+	}
+	s.AvgItems = avgItems
+	s.AvgBytes = avgBytes
+	s.RawItems = rawItems
+	s.RawBytes = rawBytes
+}
+
+// GlobalComponentSnapshots returns a copy of all snapshots, window stats recomputed against now.
+func GlobalComponentSnapshots() []ComponentSnapshot {
+	return globalComponentSnapshotsAt(time.Now())
+}
+
+// globalComponentSnapshotsAt copies all snapshots, recomputing window stats against now (so idle components decay).
+func globalComponentSnapshotsAt(now time.Time) []ComponentSnapshot {
+	globalSnapshotsMu.RLock()
+	defer globalSnapshotsMu.RUnlock()
+	result := make([]ComponentSnapshot, 0, len(globalSnapshots))
+	for _, s := range globalSnapshots {
+		snap := *s
+		if s.history != nil {
+			snap.Windows = s.history.allStats(now)
+		}
+		snap.history = nil
+		result = append(result, snap)
+	}
+	return result
+}
+
+// lookupComponentSnapshot returns the snapshot for name:instance, or false if none exists.
+func lookupComponentSnapshot(name, instance string) (ComponentSnapshot, bool) {
+	globalSnapshotsMu.RLock()
+	defer globalSnapshotsMu.RUnlock()
+	s := globalSnapshots[name+":"+instance]
+	if s == nil {
+		return ComponentSnapshot{}, false
+	}
+	return *s, true
+}
+
+// ClearComponentSnapshots removes all stored snapshots; called when the logs pipeline stops.
+func ClearComponentSnapshots() {
+	globalSnapshotsMu.Lock()
+	defer globalSnapshotsMu.Unlock()
+	globalSnapshots = map[string]*ComponentSnapshot{}
+}
+
 const (
-	ewmaAlpha = 2 / (float64(30) + 1) // ~ 0.0645 for a 30s window
 
 	// ProcessorTlmName is the telemetry name for processor components
 	ProcessorTlmName = "processor"
@@ -37,6 +135,9 @@ type PipelineMonitor interface {
 	ReportComponentIngress(size MeasurablePayload, name string, instanceID string)
 	ReportComponentEgress(size MeasurablePayload, name string, instanceID string)
 	MakeUtilizationMonitor(name string, instanceID string) UtilizationMonitor
+	// Start/Stop bracket periodic sampling of this monitor's utilization monitors.
+	Start()
+	Stop()
 }
 
 // NoopPipelineMonitor is a no-op implementation of PipelineMonitor.
@@ -70,17 +171,40 @@ func (n *NoopPipelineMonitor) MakeUtilizationMonitor(_ string, _ string) Utiliza
 	return &NoopUtilizationMonitor{}
 }
 
+// Start does nothing.
+func (n *NoopPipelineMonitor) Start() {}
+
+// Stop does nothing.
+func (n *NoopPipelineMonitor) Stop() {}
+
+// utilizationSampleInterval is how often the ticker samples each monitor, so mid-operation blocks are observed.
+const utilizationSampleInterval = 1 * time.Second
+
 // TelemetryPipelineMonitor is a PipelineMonitor that reports capacity metrics to telemetry
 type TelemetryPipelineMonitor struct {
 	monitors map[string]*CapacityMonitor
 	lock     sync.RWMutex
+
+	// utilizationMonitors are ticked by sampleLoop so a component blocked between Start and Stop is still sampled.
+	utilizationMonitors []*TelemetryUtilizationMonitor
+	clock               clock.Clock
+	sampleInterval      time.Duration
+	stopCh              chan struct{}
+	doneCh              chan struct{}
+	started             bool
 }
 
-// NewTelemetryPipelineMonitor creates a new pipeline monitort that reports capacity and utiilization metrics as telemetry
+// NewTelemetryPipelineMonitor creates a new pipeline monitor that reports capacity and utilization metrics as telemetry
 func NewTelemetryPipelineMonitor() *TelemetryPipelineMonitor {
+	return newTelemetryPipelineMonitorWithClock(clock.New(), utilizationSampleInterval)
+}
+
+func newTelemetryPipelineMonitorWithClock(clk clock.Clock, sampleInterval time.Duration) *TelemetryPipelineMonitor {
 	return &TelemetryPipelineMonitor{
-		monitors: make(map[string]*CapacityMonitor),
-		lock:     sync.RWMutex{},
+		monitors:       make(map[string]*CapacityMonitor),
+		lock:           sync.RWMutex{},
+		clock:          clk,
+		sampleInterval: sampleInterval,
 	}
 }
 
@@ -103,9 +227,61 @@ func (c *TelemetryPipelineMonitor) getMonitor(name string, instanceID string) *C
 	return monitor
 }
 
-// MakeUtilizationMonitor creates a new utilization monitor for a component.
+// MakeUtilizationMonitor creates a utilization monitor and registers it for periodic sampling.
 func (c *TelemetryPipelineMonitor) MakeUtilizationMonitor(name string, instanceID string) UtilizationMonitor {
-	return NewTelemetryUtilizationMonitor(name, instanceID)
+	m := newTelemetryUtilizationMonitorWithSampleRateAndClock(name, instanceID, c.sampleInterval, c.clock)
+	c.lock.Lock()
+	c.utilizationMonitors = append(c.utilizationMonitors, m)
+	c.lock.Unlock()
+	return m
+}
+
+// Start launches the periodic sampling loop. Idempotent.
+func (c *TelemetryPipelineMonitor) Start() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.started {
+		return
+	}
+	c.started = true
+	c.stopCh = make(chan struct{})
+	c.doneCh = make(chan struct{})
+	go c.sampleLoop(c.stopCh, c.doneCh)
+}
+
+// Stop ends the sampling loop and blocks until the goroutine has exited. Idempotent.
+func (c *TelemetryPipelineMonitor) Stop() {
+	c.lock.Lock()
+	if !c.started {
+		c.lock.Unlock()
+		return
+	}
+	c.started = false
+	close(c.stopCh)
+	done := c.doneCh
+	c.lock.Unlock()
+	<-done
+}
+
+func (c *TelemetryPipelineMonitor) sampleLoop(stop, done chan struct{}) {
+	defer close(done)
+	ticker := c.clock.Ticker(c.sampleInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			now := c.clock.Now()
+			c.lock.RLock()
+			// MakeUtilizationMonitor only appends, so the captured slice never races registration.
+			monitors := c.utilizationMonitors
+			c.lock.RUnlock()
+			for _, m := range monitors {
+				m.sample(now)
+			}
+		}
+	}
 }
 
 // GetCapacityMonitor returns the capacity monitor for the given name and instance ID.

--- a/comp/logs-library/metrics/pipeline_monitor_test.go
+++ b/comp/logs-library/metrics/pipeline_monitor_test.go
@@ -7,8 +7,11 @@ package metrics
 
 import (
 	"testing"
+	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPipelineMonitorTracksCorrectCapacity(t *testing.T) {
@@ -43,4 +46,120 @@ func TestPipelineMonitorTracksCorrectCapacity(t *testing.T) {
 	assert.Equal(t, pm.getMonitor("1", "test").ingress-pm.getMonitor("1", "test").egress, int64(0))
 	assert.Equal(t, pm.getMonitor("5", "test").ingress-pm.getMonitor("5", "test").egress, int64(0))
 	assert.Equal(t, pm.getMonitor("10", "test").ingress-pm.getMonitor("10", "test").egress, int64(0))
+}
+
+// TestTelemetryPipelineMonitor_StartStopLifecycle checks Stop doesn't hang, is safe without Start, and is idempotent.
+func TestTelemetryPipelineMonitor_StartStopLifecycle(_ *testing.T) {
+	clk := clock.NewMock()
+
+	// Stop without Start must be a no-op, not block on a nil channel.
+	pm := newTelemetryPipelineMonitorWithClock(clk, time.Second)
+	pm.Stop()
+
+	pm = newTelemetryPipelineMonitorWithClock(clk, time.Second)
+	pm.Start()
+	pm.Start() // idempotent: must not spawn a second loop
+	// Stop blocks until the loop goroutine exits; if it leaked, the test would hang here.
+	pm.Stop()
+	pm.Stop() // idempotent
+}
+
+// TestTelemetryPipelineMonitor_TickerSamplesRegisteredMonitor checks the running ticker samples its registered monitors.
+func TestTelemetryPipelineMonitor_TickerSamplesRegisteredMonitor(t *testing.T) {
+	ClearComponentSnapshots()
+	defer ClearComponentSnapshots()
+
+	clk := clock.NewMock()
+	pm := newTelemetryPipelineMonitorWithClock(clk, time.Second)
+	um := pm.MakeUtilizationMonitor("processor", "0").(*TelemetryUtilizationMonitor)
+
+	pm.Start()
+	defer pm.Stop()
+	um.Start() // blocked in-use, never Stop
+
+	require.Eventually(t, func() bool {
+		clk.Add(time.Second)
+		um.mu.Lock()
+		defer um.mu.Unlock()
+		return um.avg > 0
+	}, 2*time.Second, 5*time.Millisecond,
+		"the pipeline monitor's ticker must sample its registered utilization monitor")
+}
+
+// findSnapshot returns the snapshot for name:instance from a slice, or fails the test.
+func findSnapshot(t *testing.T, snaps []ComponentSnapshot, name, instance string) ComponentSnapshot {
+	t.Helper()
+	for _, s := range snaps {
+		if s.Name == name && s.Instance == instance {
+			return s
+		}
+	}
+	t.Fatalf("no snapshot for %s:%s", name, instance)
+	return ComponentSnapshot{}
+}
+
+// TestGlobalSnapshots_SaturationHoldsThenDecaysToWarning checks CurrentlySaturated holds while blocked, then decays to WARNING once idle.
+func TestGlobalSnapshots_SaturationHoldsThenDecaysToWarning(t *testing.T) {
+	ClearComponentSnapshots()
+	defer ClearComponentSnapshots()
+
+	clk := clock.NewMock()
+	pm := newTelemetryPipelineMonitorWithClock(clk, time.Second)
+	um := pm.MakeUtilizationMonitor("processor", "0").(*TelemetryUtilizationMonitor)
+
+	um.Start() // enter in-use and never Stop: models a goroutine blocked on a full output channel
+
+	// Drive periodic samples while blocked: the EWMA must climb to saturation.
+	for i := 0; i < 40; i++ {
+		clk.Add(time.Second)
+		um.sample(clk.Now())
+	}
+	require.True(t, findSnapshot(t, globalComponentSnapshotsAt(clk.Now()), "processor", "0").Windows.CurrentlySaturated,
+		"a component blocked in-use must read as currently saturated")
+
+	// While still blocked, repeated reads (each a status-page render) must stay saturated.
+	for i := 0; i < 10; i++ {
+		clk.Add(time.Second)
+		um.sample(clk.Now())
+		assert.True(t, findSnapshot(t, globalComponentSnapshotsAt(clk.Now()), "processor", "0").Windows.CurrentlySaturated,
+			"CurrentlySaturated must not flap while the component remains saturated (read %d)", i)
+	}
+
+	// Recover: go idle; continued sampling decays the EWMA and ages saturated samples out of the window.
+	um.Stop()
+	for i := 0; i < 20; i++ {
+		clk.Add(time.Second)
+		um.sample(clk.Now())
+	}
+
+	final := findSnapshot(t, globalComponentSnapshotsAt(clk.Now()), "processor", "0")
+	assert.False(t, final.Windows.CurrentlySaturated,
+		"once recovered and idle, CurrentlySaturated must decay to false")
+	assert.Greater(t, final.Windows.Saturated30m, time.Duration(0),
+		"the past saturation must persist as Saturated30m so the state holds at WARNING, not HEALTHY")
+}
+
+// TestGlobalComponentSnapshotsAt_IdleDecay checks that reading against a later clock decays an idle component's CurrentlySaturated.
+func TestGlobalComponentSnapshotsAt_IdleDecay(t *testing.T) {
+	ClearComponentSnapshots()
+	defer ClearComponentSnapshots()
+
+	at := time.Unix(7200, 0)
+	h := newRollingHistory()
+	h.add(at, 0.95) // saturated sample
+	setComponentUtilization("processor", "0", 0.95, 0.95, h)
+
+	// Read at the sample time: still saturated.
+	fresh := globalComponentSnapshotsAt(at)
+	require.Len(t, fresh, 1)
+	assert.True(t, fresh[0].Windows.CurrentlySaturated, "fresh read must report saturation")
+	assert.Nil(t, fresh[0].history, "history pointer must not escape to callers")
+
+	// Read long after, with no new samples: window stats recompute against the live clock.
+	stale := globalComponentSnapshotsAt(at.Add(time.Hour))
+	require.Len(t, stale, 1)
+	assert.False(t, stale[0].Windows.CurrentlySaturated,
+		"an idle component's saturation must decay when read against a later clock")
+	assert.InDelta(t, 0.95, stale[0].AvgRatio, 0.0001,
+		"AvgRatio is the last-known EWMA and is expected to stay frozen; only window stats decay")
 }

--- a/comp/logs-library/metrics/rolling_history.go
+++ b/comp/logs-library/metrics/rolling_history.go
@@ -1,0 +1,330 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	// SaturationThreshold is the EWMA value above which a component is considered saturated.
+	SaturationThreshold = 0.90
+
+	fineTierCapacity     = 300 // 1s samples, 5min
+	mediumBucketDuration = time.Minute
+	mediumTierCapacity   = 25 // 1min buckets, 5m–30m
+	coarseBucketDuration = time.Hour
+	coarseTierCapacity   = 10 // 1h buckets, 30m–10h
+
+	// currentSaturationWindow bounds how recent a saturated sample must be to count as saturated "now".
+	currentSaturationWindow = 15 * time.Second
+)
+
+type fineSample struct {
+	tsNano    int64
+	ewmaValue float64
+}
+
+// aggregateBucket holds pre-aggregated stats for a time-aligned period (medium and coarse tiers).
+type aggregateBucket struct {
+	tsNano            int64 // period-aligned start
+	ewmaSum           float64
+	ewmaMax           float64
+	count             int32
+	saturatedCount    int32
+	lastSaturatedNano int64
+}
+
+// WindowStats holds pre-computed statistics over several time windows. Ratios are fractions in [0,1].
+type WindowStats struct {
+	Avg5m            float64
+	Max5m            float64
+	Avg30m           float64
+	Max30m           float64
+	Max2h            float64
+	Max5h            float64
+	Max10h           float64
+	Saturated1m      time.Duration
+	Saturated30m     time.Duration
+	LastSaturatedAt  time.Time
+	HasLastSaturated bool
+	// CurrentlySaturated is true if any sample within currentSaturationWindow was saturated (debounces flapping).
+	CurrentlySaturated bool
+}
+
+// rollingHistory is a three-tier (1s/1m/1h) EWMA time-series; samples roll up tier to tier, bounding memory to ~6.2 KB.
+type rollingHistory struct {
+	mu sync.Mutex
+
+	fine     [fineTierCapacity]fineSample
+	fineHead int // next write slot; also the oldest slot once full
+	fineSize int
+
+	mediumPending    aggregateBucket
+	hasMediumPending bool
+
+	medium     [mediumTierCapacity]aggregateBucket
+	mediumHead int
+	mediumSize int
+
+	coarse     [coarseTierCapacity]aggregateBucket
+	coarseHead int
+	coarseSize int
+}
+
+func newRollingHistory() *rollingHistory {
+	return &rollingHistory{}
+}
+
+// add records a 1-second EWMA sample, rolling the oldest fine sample up when the ring is full.
+func (h *rollingHistory) add(ts time.Time, ewmaValue float64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.fineSize == fineTierCapacity {
+		h.rollupFineToMedium(h.fine[h.fineHead], ts)
+	}
+
+	h.fine[h.fineHead] = fineSample{tsNano: ts.UnixNano(), ewmaValue: ewmaValue}
+	h.fineHead = (h.fineHead + 1) % fineTierCapacity
+	if h.fineSize < fineTierCapacity {
+		h.fineSize++
+	}
+}
+
+// rollupFineToMedium accumulates a fine sample into the current minute bucket, flushing on a minute boundary. Caller holds h.mu.
+func (h *rollingHistory) rollupFineToMedium(s fineSample, now time.Time) {
+	bucketStart := (s.tsNano / int64(mediumBucketDuration)) * int64(mediumBucketDuration)
+
+	if h.hasMediumPending && h.mediumPending.tsNano == bucketStart {
+		accumulateInto(&h.mediumPending, s)
+		return
+	}
+
+	if h.hasMediumPending {
+		h.pushMediumBucket(h.mediumPending, now)
+	}
+	h.mediumPending = aggregateBucket{tsNano: bucketStart}
+	accumulateInto(&h.mediumPending, s)
+	h.hasMediumPending = true
+}
+
+// pushMediumBucket appends a completed bucket to the medium ring, overflowing into the coarse tier. Caller holds h.mu.
+func (h *rollingHistory) pushMediumBucket(b aggregateBucket, now time.Time) {
+	if h.mediumSize == mediumTierCapacity {
+		h.rollupMediumToCoarse(h.medium[h.mediumHead], now)
+	}
+	h.medium[h.mediumHead] = b
+	h.mediumHead = (h.mediumHead + 1) % mediumTierCapacity
+	if h.mediumSize < mediumTierCapacity {
+		h.mediumSize++
+	}
+}
+
+// rollupMediumToCoarse merges a medium bucket into its hourly coarse bucket. Caller holds h.mu.
+func (h *rollingHistory) rollupMediumToCoarse(b aggregateBucket, _ time.Time) {
+	bucketStart := (b.tsNano / int64(coarseBucketDuration)) * int64(coarseBucketDuration)
+
+	if h.coarseSize > 0 {
+		last := &h.coarse[(h.coarseHead-1+coarseTierCapacity)%coarseTierCapacity]
+		if last.tsNano == bucketStart {
+			mergeInto(last, b)
+			return
+		}
+	}
+
+	h.coarse[h.coarseHead] = aggregateBucket{
+		tsNano:            bucketStart,
+		ewmaSum:           b.ewmaSum,
+		ewmaMax:           b.ewmaMax,
+		count:             b.count,
+		saturatedCount:    b.saturatedCount,
+		lastSaturatedNano: b.lastSaturatedNano,
+	}
+	h.coarseHead = (h.coarseHead + 1) % coarseTierCapacity
+	if h.coarseSize < coarseTierCapacity {
+		h.coarseSize++
+	}
+}
+
+// accumulateInto adds a single fine sample into an aggregate bucket.
+func accumulateInto(b *aggregateBucket, s fineSample) {
+	b.ewmaSum += s.ewmaValue
+	b.count++
+	if s.ewmaValue > b.ewmaMax {
+		b.ewmaMax = s.ewmaValue
+	}
+	if s.ewmaValue >= SaturationThreshold {
+		b.saturatedCount++
+		b.lastSaturatedNano = s.tsNano
+	}
+}
+
+// mergeInto merges a completed medium bucket into an existing coarse bucket.
+func mergeInto(dst *aggregateBucket, src aggregateBucket) {
+	dst.ewmaSum += src.ewmaSum
+	dst.count += src.count
+	if src.ewmaMax > dst.ewmaMax {
+		dst.ewmaMax = src.ewmaMax
+	}
+	dst.saturatedCount += src.saturatedCount
+	if src.lastSaturatedNano > dst.lastSaturatedNano {
+		dst.lastSaturatedNano = src.lastSaturatedNano
+	}
+}
+
+// allStats computes all window statistics in a single pass over all three tiers.
+func (h *rollingHistory) allStats(now time.Time) WindowStats {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	cCurrent := now.Add(-currentSaturationWindow).UnixNano()
+	c1m := now.Add(-1 * time.Minute).UnixNano()
+	c5m := now.Add(-5 * time.Minute).UnixNano()
+	c30m := now.Add(-30 * time.Minute).UnixNano()
+	c2h := now.Add(-2 * time.Hour).UnixNano()
+	c5h := now.Add(-5 * time.Hour).UnixNano()
+	c10h := now.Add(-10 * time.Hour).UnixNano()
+
+	var (
+		sum5m, sum30m      float64
+		cnt5m, cnt30m      int
+		max5m, max30m      float64
+		sat1m, satFine     int
+		lastSat            time.Time
+		hasLastSat         bool
+		currentlySaturated bool
+	)
+
+	// Fine tier. The ring evicts by count, not time, so break at c30m to drop stale idle samples.
+	for i := 0; i < h.fineSize; i++ {
+		idx := (h.fineHead - 1 - i + fineTierCapacity) % fineTierCapacity
+		s := h.fine[idx]
+		v := s.ewmaValue
+
+		if s.tsNano < c30m {
+			break
+		}
+		if s.tsNano >= cCurrent && v >= SaturationThreshold {
+			currentlySaturated = true
+		}
+		if !hasLastSat && v >= SaturationThreshold {
+			lastSat = time.Unix(0, s.tsNano)
+			hasLastSat = true
+		}
+		sum30m += v
+		cnt30m++
+		if v > max30m {
+			max30m = v
+		}
+		if s.tsNano >= c5m {
+			sum5m += v
+			cnt5m++
+			if v > max5m {
+				max5m = v
+			}
+		}
+		if v >= SaturationThreshold {
+			satFine++
+			if s.tsNano >= c1m {
+				sat1m++
+			}
+		}
+	}
+
+	// Medium pending: aged out of fine but not yet in the ring; include it so stats don't jump back ~1 minute.
+	var satMedium int
+	if h.hasMediumPending && h.mediumPending.count > 0 && h.mediumPending.tsNano >= c30m {
+		satMedium += int(h.mediumPending.saturatedCount)
+		sum30m += h.mediumPending.ewmaSum
+		cnt30m += int(h.mediumPending.count)
+		if h.mediumPending.ewmaMax > max30m {
+			max30m = h.mediumPending.ewmaMax
+		}
+		if !hasLastSat && h.mediumPending.lastSaturatedNano > 0 {
+			lastSat = time.Unix(0, h.mediumPending.lastSaturatedNano)
+			hasLastSat = true
+		}
+	}
+
+	// Medium tier (5m–30m, 1-minute buckets).
+	for i := 0; i < h.mediumSize; i++ {
+		idx := (h.mediumHead - 1 - i + mediumTierCapacity) % mediumTierCapacity
+		b := h.medium[idx]
+
+		// Compare against the bucket end so a bucket straddling c30m is still included.
+		bucketEnd := b.tsNano + int64(mediumBucketDuration)
+		if bucketEnd <= c30m {
+			break
+		}
+		if b.count > 0 {
+			sum30m += b.ewmaSum
+			cnt30m += int(b.count)
+			if b.ewmaMax > max30m {
+				max30m = b.ewmaMax
+			}
+			satMedium += int(b.saturatedCount)
+		}
+		if !hasLastSat && b.lastSaturatedNano > 0 {
+			lastSat = time.Unix(0, b.lastSaturatedNano)
+			hasLastSat = true
+		}
+	}
+
+	sat30m := satFine + satMedium
+
+	var avg5m, avg30m float64
+	if cnt5m > 0 {
+		avg5m = sum5m / float64(cnt5m)
+	}
+	if cnt30m > 0 {
+		avg30m = sum30m / float64(cnt30m)
+	}
+
+	// Coarse tier (30m–10h, 1-hour buckets). Seed long-window maxes from fine+medium.
+	max2h, max5h, max10h := max30m, max30m, max30m
+
+	for i := 0; i < h.coarseSize; i++ {
+		idx := (h.coarseHead - 1 - i + coarseTierCapacity) % coarseTierCapacity
+		b := h.coarse[idx]
+
+		// Compare against the bucket end so a bucket straddling a cutoff is included.
+		bucketEnd := b.tsNano + int64(coarseBucketDuration)
+
+		if bucketEnd <= c10h {
+			break
+		}
+		if b.ewmaMax > max10h {
+			max10h = b.ewmaMax
+		}
+		if bucketEnd > c5h && b.ewmaMax > max5h {
+			max5h = b.ewmaMax
+		}
+		if bucketEnd > c2h && b.ewmaMax > max2h {
+			max2h = b.ewmaMax
+		}
+		if !hasLastSat && b.lastSaturatedNano > 0 {
+			lastSat = time.Unix(0, b.lastSaturatedNano)
+			hasLastSat = true
+		}
+	}
+
+	return WindowStats{
+		Avg5m:              avg5m,
+		Max5m:              max5m,
+		Avg30m:             avg30m,
+		Max30m:             max30m,
+		Max2h:              max2h,
+		Max5h:              max5h,
+		Max10h:             max10h,
+		Saturated1m:        time.Duration(sat1m) * time.Second,
+		Saturated30m:       time.Duration(sat30m) * time.Second,
+		LastSaturatedAt:    lastSat,
+		HasLastSaturated:   hasLastSat,
+		CurrentlySaturated: currentlySaturated,
+	}
+}

--- a/comp/logs-library/metrics/rolling_history_test.go
+++ b/comp/logs-library/metrics/rolling_history_test.go
@@ -1,0 +1,149 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// base is a minute-aligned reference time so samples fall into predictable medium-tier buckets.
+var base = time.Unix(3600, 0)
+
+// TestAllStats_StaleFineSamplesExcluded checks that fine samples older than 30m are ignored.
+func TestAllStats_StaleFineSamplesExcluded(t *testing.T) {
+	h := newRollingHistory()
+	stale := base.Add(-31 * time.Minute)
+
+	for i := 0; i < 5; i++ {
+		h.add(stale.Add(time.Duration(i)*time.Second), 1.0)
+	}
+
+	ws := h.allStats(base)
+
+	assert.Equal(t, time.Duration(0), ws.Saturated1m, "stale samples must not count in 1m window")
+	assert.Equal(t, time.Duration(0), ws.Saturated30m, "stale samples must not count in 30m window")
+	assert.False(t, ws.HasLastSaturated, "stale samples must not set LastSaturatedAt")
+}
+
+// TestAllStats_MediumPendingLastSaturatedAt checks a sample evicted into mediumPending still sets LastSaturatedAt.
+func TestAllStats_MediumPendingLastSaturatedAt(t *testing.T) {
+	h := newRollingHistory()
+
+	// The 301st add evicts the saturated sample at base into mediumPending.
+	h.add(base, 1.0)
+	for i := 1; i <= 300; i++ {
+		h.add(base.Add(time.Duration(i)*time.Millisecond), 0.0)
+	}
+
+	ws := h.allStats(base.Add(500 * time.Millisecond))
+
+	require.True(t, ws.HasLastSaturated, "evicted saturated sample in mediumPending must set LastSaturatedAt")
+	assert.Equal(t, base.UnixNano(), ws.LastSaturatedAt.UnixNano(),
+		"LastSaturatedAt must point to the sample in mediumPending, not be absent")
+}
+
+// TestAllStats_MediumPendingSaturated30m checks that mediumPending's saturated count feeds Saturated30m.
+func TestAllStats_MediumPendingSaturated30m(t *testing.T) {
+	h := newRollingHistory()
+
+	h.add(base, 1.0)
+	for i := 1; i <= 300; i++ {
+		h.add(base.Add(time.Duration(i)*time.Millisecond), 0.0)
+	}
+
+	ws := h.allStats(base.Add(500 * time.Millisecond))
+
+	assert.Equal(t, time.Duration(1)*time.Second, ws.Saturated30m,
+		"mediumPending saturated count must be included in Saturated30m")
+}
+
+// TestAllStats_CurrentlySaturatedFresh checks CurrentlySaturated decays once the newest sample ages past the window.
+func TestAllStats_CurrentlySaturatedFresh(t *testing.T) {
+	h := newRollingHistory()
+	h.add(base, 0.95)
+
+	assert.True(t, h.allStats(base).CurrentlySaturated,
+		"a fresh saturated sample must report CurrentlySaturated")
+	assert.True(t, h.allStats(base.Add(currentSaturationWindow)).CurrentlySaturated,
+		"sample at exactly currentSaturationWindow must still count as fresh")
+	assert.False(t, h.allStats(base.Add(currentSaturationWindow+time.Second)).CurrentlySaturated,
+		"a stale saturated sample must not report CurrentlySaturated")
+}
+
+// TestAllStats_CurrentlySaturatedStickyWindow checks a single dip doesn't clear CurrentlySaturated until the window empties.
+func TestAllStats_CurrentlySaturatedStickyWindow(t *testing.T) {
+	h := newRollingHistory()
+	h.add(base, 0.95)
+	h.add(base.Add(time.Second), 0.10)
+
+	assert.True(t, h.allStats(base.Add(time.Second)).CurrentlySaturated,
+		"a single dip must not clear CurrentlySaturated while a saturated sample is still in-window")
+	assert.False(t, h.allStats(base.Add(currentSaturationWindow+time.Second)).CurrentlySaturated,
+		"CurrentlySaturated must clear once the last saturated sample ages out of the window")
+}
+
+// TestAllStats_CurrentlySaturatedNoFlapNearThreshold is the flip-flop regression: an EWMA oscillating around the threshold stays saturated.
+func TestAllStats_CurrentlySaturatedNoFlapNearThreshold(t *testing.T) {
+	h := newRollingHistory()
+
+	for i := 0; i < 30; i++ {
+		v := 0.88
+		if i%2 == 0 {
+			v = 0.92
+		}
+		now := base.Add(time.Duration(i) * time.Second)
+		h.add(now, v)
+		assert.True(t, h.allStats(now).CurrentlySaturated,
+			"CurrentlySaturated must not flap while saturated samples keep landing within the window (i=%d)", i)
+	}
+}
+
+// TestAllStats_IdleFineSamplesIn30mAverages checks fine samples retained past 5m still feed the 30m avg/max.
+func TestAllStats_IdleFineSamplesIn30mAverages(t *testing.T) {
+	h := newRollingHistory()
+
+	for i := 0; i < 10; i++ {
+		h.add(base.Add(time.Duration(i)*time.Second), 1.0)
+	}
+
+	// 6 minutes later every sample is older than 5m but within 30m.
+	ws := h.allStats(base.Add(6 * time.Minute))
+
+	assert.Equal(t, time.Duration(10)*time.Second, ws.Saturated30m, "burst must count as 30m saturation")
+	assert.InDelta(t, 1.0, ws.Max30m, 0.0001, "30m max must reflect the saturated burst, not 0")
+	assert.InDelta(t, 1.0, ws.Avg30m, 0.0001, "30m avg must reflect the saturated burst, not 0")
+	assert.Equal(t, 0.0, ws.Max5m, "nothing occurred in the last 5m")
+	assert.Equal(t, 0.0, ws.Avg5m, "nothing occurred in the last 5m")
+}
+
+// TestAllStats_MediumBucketStraddlesC30m checks a medium bucket straddling the 30m cutoff is still counted.
+func TestAllStats_MediumBucketStraddlesC30m(t *testing.T) {
+	h := newRollingHistory()
+
+	// One fully-saturated 1-minute bucket covering base..base+60s.
+	h.medium[0] = aggregateBucket{
+		tsNano:            base.UnixNano(),
+		ewmaSum:           60.0, // 60 samples at 1.0
+		ewmaMax:           1.0,
+		count:             60,
+		saturatedCount:    60,
+		lastSaturatedNano: base.Add(59 * time.Second).UnixNano(),
+	}
+	h.mediumHead = 1
+	h.mediumSize = 1
+
+	// Read so that c30m (= now-30m = base+30s) falls inside the bucket: start < c30m < end.
+	ws := h.allStats(base.Add(30*time.Minute + 30*time.Second))
+
+	assert.InDelta(t, 1.0, ws.Max30m, 0.0001, "straddling medium bucket must contribute to Max30m")
+	assert.InDelta(t, 1.0, ws.Avg30m, 0.0001, "straddling medium bucket must contribute to Avg30m")
+	assert.Equal(t, time.Duration(60)*time.Second, ws.Saturated30m,
+		"straddling saturated bucket must count toward Saturated30m, not be dropped")
+}

--- a/comp/logs-library/metrics/utilization_monitor.go
+++ b/comp/logs-library/metrics/utilization_monitor.go
@@ -6,9 +6,18 @@
 package metrics
 
 import (
+	"sync"
 	"time"
 
 	"github.com/benbjohnson/clock"
+
+	log "github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	saturationThrottleDuration = 10 * time.Minute
+	// recoveryDebounce is how long the EWMA must stay below threshold before recovery is logged.
+	recoveryDebounce = 10 * time.Second
 )
 
 // UtilizationMonitor is an interface for monitoring the utilization of a component.
@@ -28,17 +37,30 @@ func (n *NoopUtilizationMonitor) Stop() {}
 
 // TelemetryUtilizationMonitor is a UtilizationMonitor that reports utilization metrics as telemetry.
 type TelemetryUtilizationMonitor struct {
+	// mu guards all mutable state: Start/Stop run on the component goroutine, sample on the ticker.
+	mu sync.Mutex
+
 	inUse      time.Duration
 	idle       time.Duration
 	startIdle  time.Time
 	startInUse time.Time
 	lastSample time.Time
 	sampleRate time.Duration
-	avg        float64
+	avg        float64 // EWMA utilization (N=15, α≈0.125)
+	history    *rollingHistory
 	name       string
 	instance   string
 	started    bool
 	clock      clock.Clock
+
+	// Saturation episode tracking for log emission.
+	isSaturated          bool
+	saturatedSince       time.Time
+	lastThrottleLog      time.Time
+	episodeMaxUtil       float64
+	episodeMaxItems      int64
+	episodeMaxBytes      int64
+	pendingRecoverySince time.Time // non-zero while EWMA is below threshold but debounce not yet met
 }
 
 // NewTelemetryUtilizationMonitor creates a new TelemetryUtilizationMonitor.
@@ -55,6 +77,7 @@ func newTelemetryUtilizationMonitorWithSampleRateAndClock(name, instance string,
 		lastSample: clock.Now(),
 		sampleRate: sampleRate,
 		avg:        0,
+		history:    newRollingHistory(),
 		started:    false,
 		clock:      clock,
 	}
@@ -62,32 +85,121 @@ func newTelemetryUtilizationMonitorWithSampleRateAndClock(name, instance string,
 
 // Start tracks a start event in the utilization tracker.
 func (u *TelemetryUtilizationMonitor) Start() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
 	if u.started {
 		return
 	}
 	u.started = true
-	u.idle += u.clock.Since(u.startIdle)
-	u.startInUse = u.clock.Now()
-	u.reportIfNeeded()
+	now := u.clock.Now()
+	u.idle += now.Sub(u.startIdle)
+	u.startInUse = now
+	u.reportIfNeededLocked(now)
 }
 
 // Stop tracks a finish event in the utilization tracker.
 func (u *TelemetryUtilizationMonitor) Stop() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
 	if !u.started {
 		return
 	}
 	u.started = false
-	u.inUse += u.clock.Since(u.startInUse)
-	u.startIdle = u.clock.Now()
-	u.reportIfNeeded()
+	now := u.clock.Now()
+	u.inUse += now.Sub(u.startInUse)
+	u.startIdle = now
+	u.reportIfNeededLocked(now)
 }
 
-func (u *TelemetryUtilizationMonitor) reportIfNeeded() {
-	if u.clock.Since(u.lastSample) >= u.sampleRate {
-		u.avg = ewma(float64(u.inUse)/float64(u.idle+u.inUse), u.avg)
-		TlmUtilizationRatio.Set(u.avg, u.name, u.instance)
-		u.idle = 0
-		u.inUse = 0
-		u.lastSample = u.clock.Now()
+// sample is driven by the ticker so a component blocked mid-operation is observed, not frozen at its last EWMA.
+func (u *TelemetryUtilizationMonitor) sample(now time.Time) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.settleLocked(now)
+	u.reportIfNeededLocked(now)
+}
+
+// settleLocked credits the open interval up to now and advances its start so Start/Stop won't double-count it. Caller holds u.mu.
+func (u *TelemetryUtilizationMonitor) settleLocked(now time.Time) {
+	if u.started {
+		u.inUse += now.Sub(u.startInUse)
+		u.startInUse = now
+	} else {
+		u.idle += now.Sub(u.startIdle)
+		u.startIdle = now
+	}
+}
+
+// reportIfNeededLocked publishes a sample if sampleRate has elapsed; now is passed for a consistent instant. Caller holds u.mu.
+func (u *TelemetryUtilizationMonitor) reportIfNeededLocked(now time.Time) {
+	if now.Sub(u.lastSample) < u.sampleRate {
+		return
+	}
+	rawRatio := 0.0
+	if total := u.idle + u.inUse; total > 0 {
+		rawRatio = float64(u.inUse) / float64(total)
+	}
+	u.avg = ewma(rawRatio, u.avg)
+
+	u.history.add(now, u.avg)
+
+	TlmUtilizationRatio.Set(u.avg, u.name, u.instance)
+	setComponentUtilization(u.name, u.instance, u.avg, rawRatio, u.history)
+	u.idle = 0
+	u.inUse = 0
+	u.lastSample = now
+
+	u.updateSaturationState(now)
+}
+
+// updateSaturationState drives the saturation state machine, emitting transition and throttled logs. Caller holds u.mu.
+func (u *TelemetryUtilizationMonitor) updateSaturationState(now time.Time) {
+	currentlySaturated := u.avg >= SaturationThreshold
+
+	if currentlySaturated {
+		u.pendingRecoverySince = time.Time{}
+
+		snap, _ := lookupComponentSnapshot(u.name, u.instance)
+
+		if !u.isSaturated {
+			u.isSaturated = true
+			u.saturatedSince = now
+			u.lastThrottleLog = now
+			u.episodeMaxUtil = u.avg
+			u.episodeMaxItems = snap.RawItems
+			u.episodeMaxBytes = snap.RawBytes
+			// max_items/max_bytes are omitted at onset (capacity snapshot may not have ticked yet).
+			log.Warnf("Logs Agent pipeline component saturated component=%s instance=%s utilization=%.0f%%",
+				u.name, u.instance, u.avg*100)
+		} else {
+			if u.avg > u.episodeMaxUtil {
+				u.episodeMaxUtil = u.avg
+			}
+			if snap.RawItems > u.episodeMaxItems {
+				u.episodeMaxItems = snap.RawItems
+			}
+			if snap.RawBytes > u.episodeMaxBytes {
+				u.episodeMaxBytes = snap.RawBytes
+			}
+
+			if now.Sub(u.lastThrottleLog) >= saturationThrottleDuration {
+				log.Warnf("Logs Agent pipeline component saturated component=%s instance=%s utilization=%.0f%% duration=%s max_utilization=%.0f%% max_items=%d max_bytes=%d",
+					u.name, u.instance, u.avg*100, now.Sub(u.saturatedSince), u.episodeMaxUtil*100, u.episodeMaxItems, u.episodeMaxBytes)
+				u.lastThrottleLog = now
+			}
+		}
+	} else if u.isSaturated {
+		// Below threshold: start or advance the recovery debounce timer.
+		if u.pendingRecoverySince.IsZero() {
+			u.pendingRecoverySince = now
+		} else if now.Sub(u.pendingRecoverySince) >= recoveryDebounce {
+			log.Infof("Logs Agent pipeline component recovered component=%s instance=%s saturated_duration=%s max_utilization=%.0f%% max_items=%d max_bytes=%d",
+				u.name, u.instance, now.Sub(u.saturatedSince), u.episodeMaxUtil*100, u.episodeMaxItems, u.episodeMaxBytes)
+			u.isSaturated = false
+			u.pendingRecoverySince = time.Time{}
+			u.episodeMaxUtil = 0
+			u.episodeMaxItems = 0
+			u.episodeMaxBytes = 0
+		}
 	}
 }

--- a/comp/logs-library/metrics/utilization_monitor_test.go
+++ b/comp/logs-library/metrics/utilization_monitor_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,4 +51,116 @@ func TestUtilizationMonitorLifecycle(t *testing.T) {
 
 	require.InDelta(t, 0.0, um.avg, 0.01)
 
+}
+
+// runBusyIterations drives the monitor at ~99% utilization for n samples.
+func runBusyIterations(um *TelemetryUtilizationMonitor, clk interface{ Add(time.Duration) }, n int) {
+	for i := 0; i < n; i++ {
+		um.Start()
+		clk.Add(990 * time.Millisecond)
+		um.Stop()
+		clk.Add(10 * time.Millisecond)
+	}
+}
+
+// runIdleIterations drives the monitor at ~0.1% utilization for n samples.
+func runIdleIterations(um *TelemetryUtilizationMonitor, clk interface{ Add(time.Duration) }, n int) {
+	for i := 0; i < n; i++ {
+		um.Start()
+		clk.Add(1 * time.Millisecond)
+		um.Stop()
+		clk.Add(999 * time.Millisecond)
+	}
+}
+
+// TestSample_BlockedComponentObserved checks a component blocked in-use still climbs to saturation via periodic sampling.
+func TestSample_BlockedComponentObserved(t *testing.T) {
+	clk := clock.NewMock()
+	um := newTelemetryUtilizationMonitorWithSampleRateAndClock("comp", "0", time.Second, clk)
+
+	um.Start() // never Stop
+
+	for i := 0; i < 40; i++ {
+		clk.Add(time.Second)
+		um.sample(clk.Now())
+	}
+
+	require.GreaterOrEqual(t, um.avg, SaturationThreshold,
+		"a component blocked in-use must reach saturation via periodic sampling, not freeze at 0")
+	assert.True(t, um.isSaturated, "saturation state must flip while still blocked, before any Stop")
+}
+
+// TestSample_IdleComponentStaysLow checks periodic sampling of a never-in-use component keeps the EWMA at 0.
+func TestSample_IdleComponentStaysLow(t *testing.T) {
+	clk := clock.NewMock()
+	um := newTelemetryUtilizationMonitorWithSampleRateAndClock("comp", "0", time.Second, clk)
+
+	for i := 0; i < 40; i++ {
+		clk.Add(time.Second)
+		um.sample(clk.Now())
+	}
+
+	assert.InDelta(t, 0.0, um.avg, 0.0001, "an idle component sampled periodically must stay at 0 utilization")
+	assert.False(t, um.isSaturated)
+}
+
+// TestSaturationStateOnset checks that the state machine flips to saturated at the threshold.
+func TestSaturationStateOnset(t *testing.T) {
+	clk := clock.NewMock()
+	um := newTelemetryUtilizationMonitorWithSampleRateAndClock("comp", "0", time.Second, clk)
+
+	require.False(t, um.isSaturated, "should start healthy")
+
+	runBusyIterations(um, clk, 40)
+
+	require.GreaterOrEqual(t, um.avg, SaturationThreshold, "EWMA must reach saturation threshold")
+	assert.True(t, um.isSaturated, "isSaturated must flip true at onset")
+	assert.False(t, um.saturatedSince.IsZero(), "saturatedSince must be recorded at onset")
+}
+
+// TestRecoveryDebounce_StaysInSaturatedState checks a dip below threshold doesn't recover until recoveryDebounce elapses.
+func TestRecoveryDebounce_StaysInSaturatedState(t *testing.T) {
+	clk := clock.NewMock()
+	um := newTelemetryUtilizationMonitorWithSampleRateAndClock("comp", "0", time.Second, clk)
+
+	runBusyIterations(um, clk, 40)
+	require.True(t, um.isSaturated)
+
+	runIdleIterations(um, clk, 5)
+
+	require.Less(t, um.avg, SaturationThreshold, "EWMA must have dropped below threshold")
+	assert.True(t, um.isSaturated, "must remain saturated while debounce pending")
+	assert.False(t, um.pendingRecoverySince.IsZero(), "debounce timer must start running")
+}
+
+// TestRecoveryDebounce_FiresAfterWindow checks recovery fires only after the EWMA stays low for recoveryDebounce.
+func TestRecoveryDebounce_FiresAfterWindow(t *testing.T) {
+	clk := clock.NewMock()
+	um := newTelemetryUtilizationMonitorWithSampleRateAndClock("comp", "0", time.Second, clk)
+
+	runBusyIterations(um, clk, 40)
+	require.True(t, um.isSaturated)
+
+	runIdleIterations(um, clk, 20)
+
+	assert.False(t, um.isSaturated, "must have recovered after debounce window")
+	assert.True(t, um.pendingRecoverySince.IsZero(), "debounce timer must be cleared after recovery")
+}
+
+// TestRecoveryDebounce_ResetByReSaturation checks re-saturating before the debounce fires cancels the pending recovery.
+func TestRecoveryDebounce_ResetByReSaturation(t *testing.T) {
+	clk := clock.NewMock()
+	um := newTelemetryUtilizationMonitorWithSampleRateAndClock("comp", "0", time.Second, clk)
+
+	runBusyIterations(um, clk, 40)
+	require.True(t, um.isSaturated)
+
+	runIdleIterations(um, clk, 2)
+	require.Less(t, um.avg, SaturationThreshold)
+	require.False(t, um.pendingRecoverySince.IsZero(), "debounce must be running")
+
+	runBusyIterations(um, clk, 40)
+	require.GreaterOrEqual(t, um.avg, SaturationThreshold)
+
+	assert.True(t, um.pendingRecoverySince.IsZero(), "debounce timer must be cancelled on re-saturation")
 }

--- a/comp/logs-library/pipeline/provider.go
+++ b/comp/logs-library/pipeline/provider.go
@@ -153,6 +153,8 @@ func tcpSender(
 		componentName,
 		queueCount,
 		workersPerQueue,
+		// The logs-agent pipeline is the sole owner of the backpressure snapshot registry.
+		metrics.NewTelemetryPipelineMonitor(),
 	)
 }
 
@@ -210,6 +212,8 @@ func httpSender(
 		minSenderConcurrency,
 		maxSenderConcurrency,
 		secretsComp,
+		// The logs-agent pipeline is the sole owner of the backpressure snapshot registry.
+		metrics.NewTelemetryPipelineMonitor(),
 	)
 }
 

--- a/comp/logs-library/pipeline/provider_test.go
+++ b/comp/logs-library/pipeline/provider_test.go
@@ -14,6 +14,7 @@ import (
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	secretsnoopimpl "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl"
 	"github.com/DataDog/datadog-agent/comp/logs-library/client"
+	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
 	"github.com/DataDog/datadog-agent/comp/logs-library/sender"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	compressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
@@ -50,6 +51,7 @@ func (f *mockSenderFactory) NewTCPSender(
 	_ string,
 	queueCount int,
 	workersPerQueue int,
+	_ metrics.PipelineMonitor,
 ) *sender.Sender {
 	f.queueCount = queueCount
 	f.workersPerQueue = workersPerQueue
@@ -76,6 +78,7 @@ func (f *mockSenderFactory) NewHTTPSender(
 	minWorkerConcurrency int,
 	maxWorkerConcurrency int,
 	_ secrets.Component,
+	_ metrics.PipelineMonitor,
 ) *sender.Sender {
 	f.queueCount = queueCount
 	f.workersPerQueue = workersPerQueue

--- a/comp/logs-library/sender/batch.go
+++ b/comp/logs-library/sender/batch.go
@@ -185,8 +185,9 @@ func (b *batch) sendMessages(messagesMetadata []*message.MessageMetadata, output
 
 	p := message.NewPayload(messagesMetadata, b.encodedPayload.Bytes(), b.compression.ContentEncoding(), unencodedSize)
 
-	b.utilization.Stop()
+	// Stay in-use across the channel write: blocking here is downstream backpressure, not idle.
 	outputChan <- p
+	b.utilization.Stop()
 	b.pipelineMonitor.ReportComponentEgress(p, metrics.StrategyTlmName, b.instanceID)
 	b.pipelineMonitor.ReportComponentIngress(p, metrics.SenderTlmName, metrics.SenderTlmInstanceID)
 }

--- a/comp/logs-library/sender/http/http_sender.go
+++ b/comp/logs-library/sender/http/http_sender.go
@@ -19,7 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// NewHTTPSender returns a new http sender.
+// NewHTTPSender returns a new http sender. pipelineMonitor is caller-supplied so pipelines that
+// shouldn't report component telemetry can pass a NoopPipelineMonitor (see globalSnapshots).
 func NewHTTPSender(
 	config pkgconfigmodel.Reader,
 	sink sender.Sink,
@@ -35,6 +36,7 @@ func NewHTTPSender(
 	minWorkerConcurrency int,
 	maxWorkerConcurrency int,
 	secretsComp secrets.Component,
+	pipelineMonitor metrics.PipelineMonitor,
 ) *sender.Sender {
 	log.Debugf(
 		"Creating a new sender for component %s with %d queues, %d http workers, %d min sender concurrency, and %d max sender concurrency",
@@ -44,7 +46,6 @@ func NewHTTPSender(
 		minWorkerConcurrency,
 		maxWorkerConcurrency,
 	)
-	pipelineMonitor := metrics.NewTelemetryPipelineMonitor()
 
 	destinationFactory := httpDestinationFactory(
 		endpoints,

--- a/comp/logs-library/sender/http/http_sender_test.go
+++ b/comp/logs-library/sender/http/http_sender_test.go
@@ -149,3 +149,37 @@ func TestHttpDestinationFactory(t *testing.T) {
 		})
 	}
 }
+
+// TestNewHTTPSender_UsesCallerPipelineMonitor verifies NewHTTPSender uses the caller's monitor rather than creating its own.
+func TestNewHTTPSender_UsesCallerPipelineMonitor(t *testing.T) {
+	endpoints := config.NewMockEndpoints([]config.Endpoint{
+		config.NewMockEndpointWithOptions(map[string]interface{}{
+			"host":        "localhost:8080",
+			"is_reliable": true,
+		}),
+	})
+	mockConfig := configmock.New(t)
+	noop := metrics.NewNoopPipelineMonitor("test")
+
+	s := NewHTTPSender(
+		mockConfig,
+		&sender.NoopSink{},
+		1,
+		sender.NewServerlessMeta(false),
+		endpoints,
+		client.NewDestinationsContext(),
+		"test-component",
+		"application/json",
+		"",
+		1,
+		1,
+		1,
+		1,
+		secretsnoopimpl.NewComponent().Comp,
+		noop,
+	)
+
+	assert.Same(t, noop, s.PipelineMonitor(),
+		"NewHTTPSender must use the caller-provided pipeline monitor, not fabricate its own — "+
+			"a passthrough pipeline passing a Noop monitor must not register global snapshots")
+}

--- a/comp/logs-library/sender/sender.go
+++ b/comp/logs-library/sender/sender.go
@@ -171,6 +171,7 @@ func (s *Sender) PipelineMonitor() metrics.PipelineMonitor {
 
 // Start starts all sender workers.
 func (s *Sender) Start() {
+	s.pipelineMonitor.Start()
 	for _, worker := range s.workers {
 		worker.start()
 	}
@@ -185,4 +186,5 @@ func (s *Sender) Stop() {
 	for _, q := range s.queues {
 		close(q)
 	}
+	s.pipelineMonitor.Stop()
 }

--- a/comp/logs-library/sender/tcp/tcp_sender.go
+++ b/comp/logs-library/sender/tcp/tcp_sender.go
@@ -17,7 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// NewTCPSender returns a new tcp sender.
+// NewTCPSender returns a new tcp sender. pipelineMonitor is caller-supplied; see NewHTTPSender.
 func NewTCPSender(
 	config pkgconfigmodel.Reader,
 	sink sender.Sink,
@@ -29,9 +29,9 @@ func NewTCPSender(
 	componentName string,
 	queueCount int,
 	workersPerQueue int,
+	pipelineMonitor metrics.PipelineMonitor,
 ) *sender.Sender {
 	log.Debugf("Creating a new sender for component %s with %d queues, %d tcp workers", componentName, queueCount, workersPerQueue)
-	pipelineMonitor := metrics.NewTelemetryPipelineMonitor()
 
 	destinationFactory := tcpDestinationFactory(endpoints, destinationsCtx, serverlessMeta, status)
 

--- a/comp/logs/agent/impl/agent.go
+++ b/comp/logs/agent/impl/agent.go
@@ -329,6 +329,9 @@ func (a *logAgent) stop(context.Context) error {
 		a.destinationsCtx.Stop()
 	})
 
+	// Clear snapshots only after the monitors stop, else an in-flight sample repopulates the map.
+	metrics.ClearComponentSnapshots()
+
 	return nil
 }
 

--- a/comp/logs/agent/impl/agent_restart.go
+++ b/comp/logs/agent/impl/agent_restart.go
@@ -175,6 +175,9 @@ func (a *logAgent) partialStop() error {
 		a.destinationsCtx.Stop()
 	})
 
+	// Clear snapshots only after the monitors stop, else an in-flight sample repopulates the map for the restarted pipeline.
+	logsmetrics.ClearComponentSnapshots()
+
 	// Flush auditor to write current positions to disk
 	a.log.Debug("Flushing auditor registry after pipeline stop")
 	a.auditor.Flush()

--- a/comp/logs/agent/impl/status_templates/logsagent.tmpl
+++ b/comp/logs/agent/impl/status_templates/logsagent.tmpl
@@ -22,6 +22,11 @@
   {{- end }}
 {{- end }}
 
+{{- if .BackpressureTable }}
+
+{{ .BackpressureTable }}
+{{- end }}
+
 {{- if .ProcessFileStats }}
   {{- range $metric_name, $metric_value := .ProcessFileStats }}
     {{$metric_name}}: {{$metric_value}}

--- a/comp/logs/agent/impl/status_templates/logsagentHTML.tmpl
+++ b/comp/logs/agent/impl/status_templates/logsagentHTML.tmpl
@@ -18,6 +18,43 @@
         {{$metric_name}}: {{$metric_value}}<br>
       {{- end }}
     {{- end }}
+    {{- if .ComponentUtilization }}
+      <span class="stat_subtitle">Logs Agent Backpressure</span>
+      <span class="stat_subdata">
+        <strong>Overall state:</strong> {{ .Backpressure.State }}<br>
+        {{- if .Backpressure.Reason }}
+        <strong>Reason:</strong> {{ .Backpressure.Reason }}<br>
+        {{- end }}
+        <table style="border-collapse:collapse;margin-top:6px;font-family:monospace;font-size:12px">
+          <tr style="text-align:left;border-bottom:1px solid #ccc">
+            <th style="padding:2px 8px">Component</th>
+            <th style="padding:2px 8px">Instance</th>
+            <th style="padding:2px 8px">Current</th>
+            <th style="padding:2px 8px">5m avg/max</th>
+            <th style="padding:2px 8px">30m avg/max</th>
+            <th style="padding:2px 8px">2h max</th>
+            <th style="padding:2px 8px">5h max</th>
+            <th style="padding:2px 8px">10h max</th>
+            <th style="padding:2px 8px">30m saturated</th>
+            <th style="padding:2px 8px">Last saturated</th>
+          </tr>
+          {{- range .ComponentUtilization }}
+          <tr>
+            <td style="padding:2px 8px">{{ .Name }}</td>
+            <td style="padding:2px 8px">{{ .Instance }}</td>
+            <td style="padding:2px 8px">{{ printf "%d%%" (pctInt .AvgRatio) }}</td>
+            <td style="padding:2px 8px">{{ printf "%d/%d%%" (pctInt .Avg5m) (pctInt .Max5m) }}</td>
+            <td style="padding:2px 8px">{{ printf "%d/%d%%" (pctInt .Avg30m) (pctInt .Max30m) }}</td>
+            <td style="padding:2px 8px">{{ printf "%d%%" (pctInt .Max2h) }}</td>
+            <td style="padding:2px 8px">{{ printf "%d%%" (pctInt .Max5h) }}</td>
+            <td style="padding:2px 8px">{{ printf "%d%%" (pctInt .Max10h) }}</td>
+            <td style="padding:2px 8px">{{ if .Saturated30mSeconds }}{{ .Saturated30mSeconds }}s{{ else }}0s{{ end }}</td>
+            <td style="padding:2px 8px">{{ if .HasLastSaturated }}{{ .LastSaturatedAt }}{{ else }}-{{ end }}</td>
+          </tr>
+          {{- end }}
+        </table>
+      </span>
+    {{- end }}
     {{- if .Errors }}
       <span class="error stat_subtitle">Errors</span>
       <span class="stat_subdata">

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -8,12 +8,16 @@ package status
 
 import (
 	"expvar"
+	"fmt"
+	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"go.uber.org/atomic"
 
+	logsMetrics "github.com/DataDog/datadog-agent/comp/logs-library/metrics"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
 	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
@@ -51,17 +55,220 @@ func (b *Builder) BuildStatus(verbose bool) Status {
 	if verbose {
 		tailers = b.getTailers()
 	}
+	utils := b.getComponentUtilization()
+	bp := b.getBackpressureStatus(utils)
 	return Status{
-		IsRunning:        b.getIsRunning(),
-		Endpoints:        b.getEndpoints(),
-		Integrations:     b.getIntegrations(),
-		Tailers:          tailers,
-		StatusMetrics:    b.getMetricsStatus(),
-		ProcessFileStats: b.getProcessFileStats(),
-		Warnings:         b.getWarnings(),
-		Errors:           b.getErrors(),
-		UseHTTP:          b.getUseHTTP(),
+		IsRunning:            b.getIsRunning(),
+		Endpoints:            b.getEndpoints(),
+		Integrations:         b.getIntegrations(),
+		Tailers:              tailers,
+		StatusMetrics:        b.getMetricsStatus(),
+		ProcessFileStats:     b.getProcessFileStats(),
+		Warnings:             b.getWarnings(),
+		Errors:               b.getErrors(),
+		UseHTTP:              b.getUseHTTP(),
+		ComponentUtilization: utils,
+		Backpressure:         bp,
+		BackpressureTable:    b.formatBackpressureSection(utils, bp),
 	}
+}
+
+// componentSortOrder defines the canonical display order for pipeline components.
+var componentSortOrder = map[string]int{
+	"processor": 0,
+	"strategy":  1,
+	"sender":    2,
+	"worker":    3,
+}
+
+func componentRank(name string) int {
+	if r, ok := componentSortOrder[name]; ok {
+		return r
+	}
+	return 10 // destination_* and anything else comes last
+}
+
+// getComponentUtilization returns per-component snapshots sorted in pipeline order.
+func (b *Builder) getComponentUtilization() []ComponentUtilization {
+	snaps := logsMetrics.GlobalComponentSnapshots()
+	result := make([]ComponentUtilization, 0, len(snaps))
+	for _, s := range snaps {
+		lastSat := ""
+		if s.Windows.HasLastSaturated {
+			lastSat = s.Windows.LastSaturatedAt.Local().Format("15:04:05")
+		}
+		result = append(result, ComponentUtilization{
+			Name:                s.Name,
+			Instance:            s.Instance,
+			AvgRatio:            s.AvgRatio,
+			RawRatio:            s.RawRatio,
+			AvgItems:            s.AvgItems,
+			RawItems:            s.RawItems,
+			AvgBytes:            s.AvgBytes,
+			RawBytes:            s.RawBytes,
+			Avg5m:               s.Windows.Avg5m,
+			Max5m:               s.Windows.Max5m,
+			Avg30m:              s.Windows.Avg30m,
+			Max30m:              s.Windows.Max30m,
+			Max2h:               s.Windows.Max2h,
+			Max5h:               s.Windows.Max5h,
+			Max10h:              s.Windows.Max10h,
+			Saturated1mSeconds:  int64(s.Windows.Saturated1m.Seconds()),
+			Saturated30mSeconds: int64(s.Windows.Saturated30m.Seconds()),
+			LastSaturatedAt:     lastSat,
+			HasLastSaturated:    s.Windows.HasLastSaturated,
+			CurrentlySaturated:  s.Windows.CurrentlySaturated,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		ri, rj := componentRank(result[i].Name), componentRank(result[j].Name)
+		if ri != rj {
+			return ri < rj
+		}
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return result[i].Instance < result[j].Instance
+	})
+	return result
+}
+
+// getBackpressureStatus returns SATURATED (saturated in last 1m), WARNING (last 30m only), or HEALTHY.
+func (b *Builder) getBackpressureStatus(utils []ComponentUtilization) BackpressureStatus {
+	// SATURATED signal: among currently-saturated components, surface the one with the highest EWMA.
+	var hasCurrSat bool
+	var maxCurrRatio float64
+	var currSatName, currSatInst string
+	var currSat30m int64
+
+	// WARNING signal: the component with the most recent 1m/30m saturation.
+	var maxSat1m, maxSat30m int64
+	var sat30mForMaxSat1m int64
+	var satName1m, satInst1m string
+	var satName30m, satInst30m string
+
+	for _, u := range utils {
+		if u.CurrentlySaturated && u.AvgRatio > maxCurrRatio {
+			hasCurrSat = true
+			maxCurrRatio = u.AvgRatio
+			currSatName = u.Name
+			currSatInst = u.Instance
+			currSat30m = u.Saturated30mSeconds
+		}
+		if u.Saturated1mSeconds > maxSat1m {
+			maxSat1m = u.Saturated1mSeconds
+			sat30mForMaxSat1m = u.Saturated30mSeconds
+			satName1m = u.Name
+			satInst1m = u.Instance
+		}
+		if u.Saturated30mSeconds > maxSat30m {
+			maxSat30m = u.Saturated30mSeconds
+			satName30m = u.Name
+			satInst30m = u.Instance
+		}
+	}
+
+	// SATURATED: a component is at or above threshold right now. Clears within seconds of recovery.
+	if hasCurrSat {
+		dur30m := time.Duration(currSat30m) * time.Second
+		return BackpressureStatus{
+			State:  "SATURATED",
+			Reason: fmt.Sprintf("%s pipeline %s is currently saturated (saturated for %s in the last 30m)", currSatName, currSatInst, fmtDuration(dur30m)),
+		}
+	}
+	// WARNING: saturation occurred in the last 1m or 30m but no component is currently at threshold.
+	if maxSat1m > 0 {
+		dur30m := time.Duration(sat30mForMaxSat1m) * time.Second
+		return BackpressureStatus{
+			State:  "WARNING",
+			Reason: fmt.Sprintf("%s pipeline %s is not currently saturated but was saturated for %s in the last 30m", satName1m, satInst1m, fmtDuration(dur30m)),
+		}
+	}
+	if maxSat30m > 0 {
+		dur30m := time.Duration(maxSat30m) * time.Second
+		return BackpressureStatus{
+			State:  "WARNING",
+			Reason: fmt.Sprintf("%s pipeline %s is not currently saturated but was saturated for %s in the last 30m", satName30m, satInst30m, fmtDuration(dur30m)),
+		}
+	}
+	return BackpressureStatus{State: "HEALTHY"}
+}
+
+// formatBackpressureSection renders the backpressure section as preformatted text (omitted from JSON).
+func (b *Builder) formatBackpressureSection(utils []ComponentUtilization, bp BackpressureStatus) string {
+	if len(utils) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("  Logs Agent Backpressure\n")
+	sb.WriteString("  =======================\n")
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("  Overall state: %s\n", bp.State))
+	if bp.Reason != "" {
+		sb.WriteString(fmt.Sprintf("  Reason: %s\n", bp.Reason))
+	}
+	sb.WriteString("\n")
+
+	// Size columns to the widest name/instance so the table stays aligned.
+	nameW := len("Component")
+	instW := len("Instance")
+	for _, u := range utils {
+		if len(u.Name) > nameW {
+			nameW = len(u.Name)
+		}
+		if len(u.Instance) > instW {
+			instW = len(u.Instance)
+		}
+	}
+	rowFmt := fmt.Sprintf("  %%-%ds %%-%ds %%-9s %%-13s %%-14s %%-9s %%-9s %%-10s %%-16s %%s\n", nameW, instW)
+
+	sb.WriteString(fmt.Sprintf(rowFmt,
+		"Component", "Instance", "Current", "5m avg/max", "30m avg/max",
+		"2h max", "5h max", "10h max", "30m saturated", "Last saturated"))
+
+	for _, u := range utils {
+		lastSat := u.LastSaturatedAt
+		if !u.HasLastSaturated {
+			lastSat = "-"
+		}
+		sb.WriteString(fmt.Sprintf(rowFmt,
+			u.Name,
+			u.Instance,
+			bpPct(u.AvgRatio),
+			bpPctRange(u.Avg5m, u.Max5m),
+			bpPctRange(u.Avg30m, u.Max30m),
+			bpPct(u.Max2h),
+			bpPct(u.Max5h),
+			bpPct(u.Max10h),
+			fmtDuration(time.Duration(u.Saturated30mSeconds)*time.Second),
+			lastSat,
+		))
+	}
+	return sb.String()
+}
+
+func bpPct(v float64) string {
+	return fmt.Sprintf("%d%%", int(math.Round(v*100)))
+}
+
+func bpPctRange(avg, max float64) string {
+	return fmt.Sprintf("%d/%d%%", int(math.Round(avg*100)), int(math.Round(max*100)))
+}
+
+func fmtDuration(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	s := int(d.Seconds()) % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh%dm%ds", h, m, s)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%dm%ds", m, s)
+	}
+	return fmt.Sprintf("%ds", s)
 }
 
 // getIsRunning returns true if the agent is running,

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -71,17 +71,52 @@ type Integration struct {
 	Sources []Source `json:"sources"`
 }
 
+// ComponentUtilization is the per-component utilization/capacity snapshot shown on the status page.
+type ComponentUtilization struct {
+	Name                string  `json:"name"`
+	Instance            string  `json:"instance"`
+	AvgRatio            float64 `json:"avg_ratio"`
+	RawRatio            float64 `json:"raw_ratio"`
+	AvgItems            float64 `json:"avg_items"`
+	RawItems            int64   `json:"raw_items"`
+	AvgBytes            float64 `json:"avg_bytes"`
+	RawBytes            int64   `json:"raw_bytes"`
+	Avg5m               float64 `json:"avg_5m"`
+	Max5m               float64 `json:"max_5m"`
+	Avg30m              float64 `json:"avg_30m"`
+	Max30m              float64 `json:"max_30m"`
+	Max2h               float64 `json:"max_2h"`
+	Max5h               float64 `json:"max_5h"`
+	Max10h              float64 `json:"max_10h"`
+	Saturated1mSeconds  int64   `json:"saturated_1m_s"`
+	Saturated30mSeconds int64   `json:"saturated_30m_s"`
+	LastSaturatedAt     string  `json:"last_saturated_at"`
+	HasLastSaturated    bool    `json:"has_last_saturated"`
+	// CurrentlySaturated decays when the component goes idle (unlike AvgRatio), so it drives the live SATURATED state.
+	CurrentlySaturated bool `json:"currently_saturated"`
+}
+
+// BackpressureStatus is the overall state: SATURATED (saturated in last 1m), WARNING (last 30m only), or HEALTHY.
+type BackpressureStatus struct {
+	State  string `json:"state"`
+	Reason string `json:"reason"`
+}
+
 // Status provides some information about logs-agent.
 type Status struct {
-	IsRunning        bool              `json:"is_running"`
-	Endpoints        []string          `json:"endpoints"`
-	StatusMetrics    map[string]string `json:"metrics"`
-	ProcessFileStats map[string]uint64 `json:"process_file_stats"`
-	Integrations     []Integration     `json:"integrations"`
-	Tailers          []Tailer          `json:"tailers"`
-	Errors           []string          `json:"errors"`
-	Warnings         []string          `json:"warnings"`
-	UseHTTP          bool              `json:"use_http"`
+	IsRunning            bool                   `json:"is_running"`
+	Endpoints            []string               `json:"endpoints"`
+	StatusMetrics        map[string]string      `json:"metrics"`
+	ProcessFileStats     map[string]uint64      `json:"process_file_stats"`
+	Integrations         []Integration          `json:"integrations"`
+	Tailers              []Tailer               `json:"tailers"`
+	Errors               []string               `json:"errors"`
+	Warnings             []string               `json:"warnings"`
+	UseHTTP              bool                   `json:"use_http"`
+	ComponentUtilization []ComponentUtilization `json:"component_utilization"`
+	Backpressure         BackpressureStatus     `json:"backpressure"`
+	// BackpressureTable is the preformatted text table, omitted from JSON; use ComponentUtilization for structured access.
+	BackpressureTable string `json:"-"`
 }
 
 // SetCurrentTransport sets the current transport used by the log agent.
@@ -118,6 +153,7 @@ func Clear() {
 	builder = nil
 	warnings = nil
 	errors = nil
+	// Snapshots are cleared by the agent after stopComponents() (not here, where the still-running monitors would repopulate them).
 }
 
 // Get returns the status of the logs-agent computed on the fly.

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -150,3 +150,92 @@ func TestStatusEndpoints(t *testing.T) {
 	status := Get(false)
 	assert.Equal(t, "Reliable: Sending uncompressed logs in SSL encrypted TCP to agent-intake.logs.datadoghq.com. on port 10516 (API Key: ********)", status.Endpoints[0])
 }
+
+// Tests for getBackpressureStatus, called directly with a crafted utilization slice (no agent infra).
+
+func TestGetBackpressureStatus_Healthy(t *testing.T) {
+	b := &Builder{}
+	utils := []ComponentUtilization{
+		{Name: "processor", Instance: "0", AvgRatio: 0.5},
+	}
+	bp := b.getBackpressureStatus(utils)
+	assert.Equal(t, "HEALTHY", bp.State)
+	assert.Empty(t, bp.Reason)
+}
+
+func TestGetBackpressureStatus_Saturated(t *testing.T) {
+	b := &Builder{}
+	utils := []ComponentUtilization{
+		{Name: "processor", Instance: "0", AvgRatio: 0.95, CurrentlySaturated: true, Saturated30mSeconds: 120},
+	}
+	bp := b.getBackpressureStatus(utils)
+	assert.Equal(t, "SATURATED", bp.State)
+	assert.Contains(t, bp.Reason, "processor")
+	assert.Contains(t, bp.Reason, "2m0s") // 120s formatted
+}
+
+// TestGetBackpressureStatus_FrozenRatioNotSaturated checks a frozen-high AvgRatio with stale saturation reads WARNING, not SATURATED.
+func TestGetBackpressureStatus_FrozenRatioNotSaturated(t *testing.T) {
+	b := &Builder{}
+	utils := []ComponentUtilization{
+		{Name: "processor", Instance: "0", AvgRatio: 0.95, CurrentlySaturated: false, Saturated30mSeconds: 120},
+	}
+	bp := b.getBackpressureStatus(utils)
+	assert.NotEqual(t, "SATURATED", bp.State, "a frozen high AvgRatio must not read as live saturation")
+	assert.Equal(t, "WARNING", bp.State)
+}
+
+// TestGetBackpressureStatus_FrozenRatioFullyIdleHealthy checks a frozen-high EWMA with no recent saturation reads HEALTHY.
+func TestGetBackpressureStatus_FrozenRatioFullyIdleHealthy(t *testing.T) {
+	b := &Builder{}
+	utils := []ComponentUtilization{
+		{Name: "processor", Instance: "0", AvgRatio: 0.95, CurrentlySaturated: false},
+	}
+	bp := b.getBackpressureStatus(utils)
+	assert.Equal(t, "HEALTHY", bp.State)
+	assert.Empty(t, bp.Reason)
+}
+
+func TestGetBackpressureStatus_WarningSat1m(t *testing.T) {
+	b := &Builder{}
+	utils := []ComponentUtilization{
+		{Name: "sender", Instance: "1", AvgRatio: 0.7, Saturated1mSeconds: 30, Saturated30mSeconds: 90},
+	}
+	bp := b.getBackpressureStatus(utils)
+	assert.Equal(t, "WARNING", bp.State)
+	assert.Contains(t, bp.Reason, "sender")
+	assert.Contains(t, bp.Reason, "1m30s") // 90s
+}
+
+func TestGetBackpressureStatus_WarningSat30mOnly(t *testing.T) {
+	b := &Builder{}
+	utils := []ComponentUtilization{
+		{Name: "worker", Instance: "2", AvgRatio: 0.5, Saturated1mSeconds: 0, Saturated30mSeconds: 45},
+	}
+	bp := b.getBackpressureStatus(utils)
+	assert.Equal(t, "WARNING", bp.State)
+	assert.Contains(t, bp.Reason, "worker")
+	assert.Contains(t, bp.Reason, "45s")
+}
+
+func TestGetBackpressureStatus_SaturatedPicksHighestRatio(t *testing.T) {
+	b := &Builder{}
+	utils := []ComponentUtilization{
+		{Name: "processor", Instance: "0", AvgRatio: 0.85, CurrentlySaturated: true, Saturated30mSeconds: 10},
+		{Name: "sender", Instance: "1", AvgRatio: 0.98, CurrentlySaturated: true, Saturated30mSeconds: 60},
+	}
+	bp := b.getBackpressureStatus(utils)
+	assert.Equal(t, "SATURATED", bp.State)
+	assert.Contains(t, bp.Reason, "sender", "highest AvgRatio component must appear in reason")
+}
+
+func TestGetBackpressureStatus_WarningPicksHighestSat1m(t *testing.T) {
+	b := &Builder{}
+	utils := []ComponentUtilization{
+		{Name: "processor", Instance: "0", AvgRatio: 0.3, Saturated1mSeconds: 10, Saturated30mSeconds: 20},
+		{Name: "sender", Instance: "1", AvgRatio: 0.5, Saturated1mSeconds: 55, Saturated30mSeconds: 120},
+	}
+	bp := b.getBackpressureStatus(utils)
+	assert.Equal(t, "WARNING", bp.State)
+	assert.Contains(t, bp.Reason, "sender", "component with highest Saturated1mSeconds must appear in reason")
+}


### PR DESCRIPTION
Cleaned-up reorganization of #51800 (same change set, clearer history split into three commits, trimmed comments). #51800 can be closed in favor of this.

### What this adds
Per-component utilization and backpressure visibility for the logs pipeline:

- **`feat(logs): add pipeline component utilization monitoring`** — the engine. Per-component EWMA over in-use vs idle time and a three-tier rolling history (1s/1m/1h) for windowed saturation stats; a 1Hz sampler so components blocked mid-operation are still observed; a saturation state machine emitting throttled warning logs. The pipeline monitor is now injected into the senders, so only the logs pipeline populates the shared snapshot registry — event-platform passthrough pipelines pass a noop monitor and no longer collide on shared component keys.
- **`feat(logs): show pipeline backpressure on the agent status page`** — a "Logs Agent Backpressure" section (text + HTML) with per-component utilization windows and an overall HEALTHY/WARNING/SATURATED state, plus JSON equivalents.
- **`test(logs): add tests …`** — rolling-history window math, idle decay, saturation state machine, sticky-window debounce, sampler lifecycle, status state logic, and the passthrough-collision regression.

### Testing
- 107 unit tests across `comp/logs-library/{metrics,sender,pipeline}` and `pkg/logs/status` pass; linters clean.
- Verified live: under sustained saturation the status holds steadily at SATURATED (no flip-flop) and decays correctly to WARNING then HEALTHY.
