### PR TITLE
refactor(collector): extract CheckLoader from CheckScheduler

### DIFF
--- a/pkg/collector/loader.go
+++ b/pkg/collector/loader.go
@@ -1,0 +1,137 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package collector
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v2"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+type commonInitConfig struct {
+	LoaderName string `yaml:"loader"`
+}
+
+type commonInstanceConfig struct {
+	LoaderName string `yaml:"loader"`
+}
+
+// CheckLoader manages check loaders and knows how to instantiate check instances
+// from integration configs. It is decoupled from routing concerns — which
+// SenderManager the resulting checks use is passed at load time via LoadChecks,
+// allowing the same loader to serve both the normal pipeline and an alternate
+// destination (e.g. the shadow pipeline) without duplication.
+type CheckLoader struct {
+	loaders       []check.Loader
+	senderManager sender.SenderManager
+}
+
+// newCheckLoader creates a CheckLoader populated with all registered loaders.
+func newCheckLoader(senderManager sender.SenderManager, logReceiver option.Option[integrations.Component], taggerComp tagger.Component, filterStore workloadfilter.Component) *CheckLoader {
+	cl := &CheckLoader{
+		senderManager: senderManager,
+		loaders:       make([]check.Loader, 0),
+	}
+	for _, loader := range loaders.LoaderCatalog(senderManager, logReceiver, taggerComp, filterStore) {
+		cl.addLoader(loader)
+		log.Debugf("Added %s to Check Loader", loader)
+	}
+	return cl
+}
+
+// addLoader adds a Loader, skipping duplicates.
+func (cl *CheckLoader) addLoader(loader check.Loader) {
+	if slices.Contains(cl.loaders, loader) {
+		log.Warnf("Loader %s was already added, skipping...", loader)
+		return
+	}
+	cl.loaders = append(cl.loaders, loader)
+}
+
+// LoadChecks instantiates check instances for a single config using the given
+// SenderManager. Passing a different SenderManager (e.g. for the shadow pipeline)
+// allows routing samples to an alternate destination without touching the config.
+func (cl *CheckLoader) LoadChecks(config integration.Config, sm sender.SenderManager) ([]check.Check, error) {
+	checks := []check.Check{}
+	numLoaders := len(cl.loaders)
+
+	initConfig := commonInitConfig{}
+	err := yaml.Unmarshal(config.InitConfig, &initConfig)
+	if err != nil {
+		return nil, err
+	}
+	selectedLoader := initConfig.LoaderName
+
+	for instanceIndex, instance := range config.Instances {
+		if check.IsJMXInstance(config.Name, instance, config.InitConfig) {
+			log.Debugf("skip loading jmx check '%s', it is handled elsewhere", config.Name)
+			continue
+		}
+
+		selectedInstanceLoader := selectedLoader
+		instanceConfig := commonInstanceConfig{}
+
+		err := yaml.Unmarshal(instance, &instanceConfig)
+		if err != nil {
+			log.Warnf("Unable to parse instance config for check `%s`: %v", config.Name, instance)
+			continue
+		}
+
+		if instanceConfig.LoaderName != "" {
+			selectedInstanceLoader = instanceConfig.LoaderName
+		}
+		if selectedInstanceLoader != "" {
+			log.Debugf("Loading check instance for check '%s' using loader %s (init_config loader: %s, instance loader: %s)", config.Name, selectedInstanceLoader, initConfig.LoaderName, instanceConfig.LoaderName)
+		} else {
+			log.Debugf("Loading check instance for check '%s' using default loaders", config.Name)
+		}
+
+		loaderErrors := make(map[string]error, len(cl.loaders))
+		for _, loader := range cl.loaders {
+			if (selectedInstanceLoader != "") && (selectedInstanceLoader != loader.Name()) {
+				log.Debugf("Loader name %v does not match, skip loader %v for check %v", selectedInstanceLoader, loader.Name(), config.Name)
+				continue
+			}
+			c, err := loader.Load(sm, config, instance, instanceIndex)
+			if err == nil {
+				log.Debugf("%v: successfully loaded check '%s'", loader, config.Name)
+				checks = append(checks, c)
+				break
+			}
+			loaderErrors[fmt.Sprintf("%v", loader)] = err
+		}
+
+		if len(loaderErrors) == numLoaders {
+			var concatErr strings.Builder
+			for loaderName, err := range loaderErrors {
+				errMsg := err.Error()
+				errorStats.setLoaderError(config.Name, loaderName, errMsg)
+
+				concatErr.WriteString(loaderName)
+				concatErr.WriteString(": ")
+				concatErr.WriteString(errMsg)
+				concatErr.WriteString("; ")
+			}
+			log.Errorf("Unable to load a check from instance of config '%s': %s", config.Name, concatErr.String())
+		} else {
+			errorStats.removeLoaderErrors(config.Name)
+		}
+	}
+
+	return checks, nil
+}

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -9,11 +9,8 @@ package collector
 import (
 	"expvar"
 	"fmt"
-	"slices"
-	"strings"
 	"sync"
 
-	yaml "go.yaml.in/yaml/v2"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -25,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
-	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
@@ -36,14 +32,6 @@ var (
 	errorStats     = newCollectorErrors()
 	checkScheduler *CheckScheduler
 )
-
-type commonInitConfig struct {
-	LoaderName string `yaml:"loader"`
-}
-
-type commonInstanceConfig struct {
-	LoaderName string `yaml:"loader"`
-}
 
 func init() {
 	schedulerErrs = expvar.NewMap("CheckScheduler")
@@ -58,26 +46,18 @@ func init() {
 // CheckScheduler is the check scheduler
 type CheckScheduler struct {
 	configToChecks map[string][]checkid.ID // cache the ID of checks we load for each config
-	loaders        []check.Loader
+	loader         *CheckLoader
 	collector      option.Option[collectorcomp.Component]
-	senderManager  sender.SenderManager
 	m              sync.RWMutex
 }
 
 // InitCheckScheduler creates and returns a check scheduler
-func InitCheckScheduler(collector option.Option[collectorcomp.Component], senderManager sender.SenderManager, logReceiver option.Option[integrations.Component], tagger tagger.Component, filterStore filter.Component) *CheckScheduler {
+func InitCheckScheduler(collector option.Option[collectorcomp.Component], senderManager sender.SenderManager, logReceiver option.Option[integrations.Component], taggerComp tagger.Component, filterStore filter.Component) *CheckScheduler {
 	checkScheduler = &CheckScheduler{
 		collector:      collector,
-		senderManager:  senderManager,
+		loader:         newCheckLoader(senderManager, logReceiver, taggerComp, filterStore),
 		configToChecks: make(map[string][]checkid.ID),
-		loaders:        make([]check.Loader, 0, len(loaders.LoaderCatalog(senderManager, logReceiver, tagger, filterStore))),
 	}
-	// add the check loaders
-	for _, loader := range loaders.LoaderCatalog(senderManager, logReceiver, tagger, filterStore) {
-		checkScheduler.addLoader(loader)
-		log.Debugf("Added %s to Check Scheduler", loader)
-	}
-
 	return checkScheduler
 }
 
@@ -153,88 +133,6 @@ func (s *CheckScheduler) Unschedule(configs []integration.Config) {
 // Stop is a stub to satisfy the scheduler interface
 func (s *CheckScheduler) Stop() {}
 
-// addLoader adds a new Loader that AutoConfig can use to load a check.
-func (s *CheckScheduler) addLoader(loader check.Loader) {
-	if slices.Contains(s.loaders, loader) {
-		log.Warnf("Loader %s was already added, skipping...", loader)
-		return
-	}
-	s.loaders = append(s.loaders, loader)
-}
-
-// getChecks takes a check configuration and returns a slice of Check instances
-// along with any error it might happen during the process
-func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, error) {
-	checks := []check.Check{}
-	numLoaders := len(s.loaders)
-
-	initConfig := commonInitConfig{}
-	err := yaml.Unmarshal(config.InitConfig, &initConfig)
-	if err != nil {
-		return nil, err
-	}
-	selectedLoader := initConfig.LoaderName
-
-	for instanceIndex, instance := range config.Instances {
-		if check.IsJMXInstance(config.Name, instance, config.InitConfig) {
-			log.Debugf("skip loading jmx check '%s', it is handled elsewhere", config.Name)
-			continue
-		}
-
-		selectedInstanceLoader := selectedLoader
-		instanceConfig := commonInstanceConfig{}
-
-		err := yaml.Unmarshal(instance, &instanceConfig)
-		if err != nil {
-			log.Warnf("Unable to parse instance config for check `%s`: %v", config.Name, instance)
-			continue
-		}
-
-		if instanceConfig.LoaderName != "" {
-			selectedInstanceLoader = instanceConfig.LoaderName
-		}
-		if selectedInstanceLoader != "" {
-			log.Debugf("Loading check instance for check '%s' using loader %s (init_config loader: %s, instance loader: %s)", config.Name, selectedInstanceLoader, initConfig.LoaderName, instanceConfig.LoaderName)
-		} else {
-			log.Debugf("Loading check instance for check '%s' using default loaders", config.Name)
-		}
-
-		loaderErrors := make(map[string]error, len(s.loaders))
-		for _, loader := range s.loaders {
-			// the loader is skipped if the loader name is set and does not match
-			if (selectedInstanceLoader != "") && (selectedInstanceLoader != loader.Name()) {
-				log.Debugf("Loader name %v does not match, skip loader %v for check %v", selectedInstanceLoader, loader.Name(), config.Name)
-				continue
-			}
-			c, err := loader.Load(s.senderManager, config, instance, instanceIndex)
-			if err == nil {
-				log.Debugf("%v: successfully loaded check '%s'", loader, config.Name)
-				checks = append(checks, c)
-				break
-			}
-			loaderErrors[fmt.Sprintf("%v", loader)] = err
-		}
-
-		if len(loaderErrors) == numLoaders {
-			var concatErr strings.Builder
-			for loaderName, err := range loaderErrors {
-				errMsg := err.Error()
-				errorStats.setLoaderError(config.Name, loaderName, errMsg)
-
-				concatErr.WriteString(loaderName)
-				concatErr.WriteString(": ")
-				concatErr.WriteString(errMsg)
-				concatErr.WriteString("; ")
-			}
-			log.Errorf("Unable to load a check from instance of config '%s': %s", config.Name, concatErr.String())
-		} else {
-			errorStats.removeLoaderErrors(config.Name)
-		}
-	}
-
-	return checks, nil
-}
-
 // GetChecksByNameForConfigs returns checks matching name for passed in configs
 func GetChecksByNameForConfigs(checkName string, configs []integration.Config) []check.Check {
 	var checks []check.Check
@@ -270,7 +168,7 @@ func (s *CheckScheduler) GetChecksFromConfigs(configs []integration.Config, popu
 			continue
 		}
 		configDigest := config.Digest()
-		checks, err := s.getChecks(config)
+		checks, err := s.loader.LoadChecks(config, s.loader.senderManager)
 		if err != nil {
 			log.Errorf("Unable to load the check: %v", err)
 			continue

--- a/pkg/collector/scheduler_test.go
+++ b/pkg/collector/scheduler_test.go
@@ -63,18 +63,23 @@ func (l *MockPythonLoader) Load(_ sender.SenderManager, config integration.Confi
 }
 
 func TestAddLoader(t *testing.T) {
-	s := CheckScheduler{}
-	assert.Len(t, s.loaders, 0)
-	s.addLoader(&MockCoreLoader{})
-	s.addLoader(&MockCoreLoader{}) // noop
-	assert.Len(t, s.loaders, 1)
+	cl := &CheckLoader{}
+	assert.Len(t, cl.loaders, 0)
+	cl.addLoader(&MockCoreLoader{})
+	cl.addLoader(&MockCoreLoader{}) // noop
+	assert.Len(t, cl.loaders, 1)
 }
 
 func TestGetChecksFromConfigs(t *testing.T) {
-	s := CheckScheduler{}
-	assert.Len(t, s.loaders, 0)
-	s.addLoader(&MockCoreLoader{})
-	s.addLoader(&MockPythonLoader{})
+	cl := &CheckLoader{}
+	assert.Len(t, cl.loaders, 0)
+	cl.addLoader(&MockCoreLoader{})
+	cl.addLoader(&MockPythonLoader{})
+
+	s := &CheckScheduler{
+		loader:         cl,
+		configToChecks: make(map[string][]checkid.ID),
+	}
 
 	// test instance level loader selection
 	conf1 := integration.Config{
@@ -109,7 +114,7 @@ func TestGetChecksFromConfigs(t *testing.T) {
 
 	checks := s.GetChecksFromConfigs([]integration.Config{conf1, conf2, conf3, conf4}, false)
 
-	assert.Len(t, s.loaders, 2)
+	assert.Len(t, cl.loaders, 2)
 
 	var actualChecks []string
 
@@ -161,11 +166,13 @@ func (m *MockCollector) AddEventReceiver(_ collectorcomp.EventReceiver) {
 func TestSchedule_AllChecksAllowed(t *testing.T) {
 	// Test that when not in basic mode, all checks are scheduled
 	mockCollector := &MockCollector{}
+	cl := &CheckLoader{}
+	cl.addLoader(&MockCoreLoader{})
 	s := &CheckScheduler{
+		loader:         cl,
 		collector:      option.New[collectorcomp.Component](mockCollector),
 		configToChecks: make(map[string][]checkid.ID),
 	}
-	s.addLoader(&MockCoreLoader{})
 
 	configs := []integration.Config{
 		{


### PR DESCRIPTION
## Summary

- Moves check-loading fields (`loaders`, `senderManager`) and methods (`addLoader`, `getChecks`) out of `CheckScheduler` into a new `CheckLoader` type in `pkg/collector/loader.go`
- `CheckScheduler` now holds a `*CheckLoader` and delegates instantiation to `CheckLoader.LoadChecks(config, sm)` — the explicit `sm` parameter enables callers to pass a different `SenderManager` without touching the config (needed by the shadow pipeline)
- `InitCheckScheduler` signature is **unchanged** — all existing callers continue to compile without modification

## Motivation

This is a prerequisite for PR #51938 (shadow check pipeline). That PR needs `collectorimpl` to configure shadow pipeline parameters on `CheckScheduler` after the shadow runner is started. Making `*CheckLoader` a dedicated type (with no `collector.Component` dependency) breaks the would-be circular fx dependency:

```
CheckScheduler → option.Option[collector.Component] → collectorimpl → *CheckLoader  ✓ (no cycle)
```

`collectorimpl` can safely receive `*CheckLoader` as an optional fx dep and call `ConfigureShadow` on it.

## Test plan

- [ ] `dda inv test --targets=./pkg/collector` passes
- [ ] `dda inv agent.build --build-exclude=systemd` compiles cleanly
- [ ] All three scheduler tests (`TestAddLoader`, `TestGetChecksFromConfigs`, `TestSchedule_AllChecksAllowed`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)