### PR TITLE
(fleet) remove T() from e2e client layer to allow non-test usage

### DIFF
--- a/test/e2e-framework/common/utils/log.go
+++ b/test/e2e-framework/common/utils/log.go
@@ -5,14 +5,21 @@
 
 package utils
 
-import "time"
+import (
+	"testing"
+	"time"
+)
 
-type logger interface {
-	Logf(format string, args ...any)
+// Logf logs a message prepended with the current timestamp + test name, along with the given format and args
+func Logf(t *testing.T, format string, args ...any) {
+	t.Helper()
+	args = append([]any{time.Now().Format("02-01-2006 15:04:05"), t.Name()}, args...)
+	t.Logf("%s - %s - "+format, args...)
 }
 
-// Logf logs a message prepended with the current timestamp, along with the given format and args
-func Logf(l logger, format string, args ...any) {
-	args = append([]any{time.Now().Format("02-01-2006 15:04:05")}, args...)
-	l.Logf("%s - "+format, args...)
+// Errorf logs an error message prepended with the current timestamp + test name, along with the given format and args
+func Errorf(t *testing.T, format string, args ...any) {
+	t.Helper()
+	args = append([]any{time.Now().Format("02-01-2006 15:04:05"), t.Name()}, args...)
+	t.Errorf("%s - %s - "+format, args...)
 }

--- a/test/e2e-framework/common/utils/log.go
+++ b/test/e2e-framework/common/utils/log.go
@@ -11,18 +11,8 @@ type logger interface {
 	Logf(format string, args ...any)
 }
 
-type errLogger interface {
-	Errorf(format string, args ...any)
-}
-
 // Logf logs a message prepended with the current timestamp, along with the given format and args
 func Logf(l logger, format string, args ...any) {
 	args = append([]any{time.Now().Format("02-01-2006 15:04:05")}, args...)
 	l.Logf("%s - "+format, args...)
-}
-
-// Errorf marks the test as failed and logs an error message prepended with the current timestamp, along with the given format and args
-func Errorf(l errLogger, format string, args ...any) {
-	args = append([]any{time.Now().Format("02-01-2006 15:04:05")}, args...)
-	l.Errorf("ERROR: %s - "+format, args...)
 }

--- a/test/e2e-framework/common/utils/log.go
+++ b/test/e2e-framework/common/utils/log.go
@@ -11,14 +11,18 @@ type logger interface {
 	Logf(format string, args ...any)
 }
 
+type errLogger interface {
+	Errorf(format string, args ...any)
+}
+
 // Logf logs a message prepended with the current timestamp, along with the given format and args
 func Logf(l logger, format string, args ...any) {
 	args = append([]any{time.Now().Format("02-01-2006 15:04:05")}, args...)
 	l.Logf("%s - "+format, args...)
 }
 
-// Errorf logs an error message prepended with the current timestamp, along with the given format and args
-func Errorf(l logger, format string, args ...any) {
+// Errorf marks the test as failed and logs an error message prepended with the current timestamp, along with the given format and args
+func Errorf(l errLogger, format string, args ...any) {
 	args = append([]any{time.Now().Format("02-01-2006 15:04:05")}, args...)
-	l.Logf("ERROR: %s - "+format, args...)
+	l.Errorf("ERROR: %s - "+format, args...)
 }

--- a/test/e2e-framework/common/utils/log.go
+++ b/test/e2e-framework/common/utils/log.go
@@ -5,21 +5,20 @@
 
 package utils
 
-import (
-	"testing"
-	"time"
-)
+import "time"
 
-// logf logs a message prepended with the current timestamp + test name, along with the given format and args
-func Logf(t *testing.T, format string, args ...any) {
-	t.Helper()
-	args = append([]any{time.Now().Format("02-01-2006 15:04:05"), t.Name()}, args...)
-	t.Logf("%s - %s - "+format, args...)
+type logger interface {
+	Logf(format string, args ...any)
 }
 
-// errorf logs an error message prepended with the current timestamp + test name, along with the given format and args
-func Errorf(t *testing.T, format string, args ...any) {
-	t.Helper()
-	args = append([]any{time.Now().Format("02-01-2006 15:04:05"), t.Name()}, args...)
-	t.Errorf("%s - %s - "+format, args...)
+// Logf logs a message prepended with the current timestamp, along with the given format and args
+func Logf(l logger, format string, args ...any) {
+	args = append([]any{time.Now().Format("02-01-2006 15:04:05")}, args...)
+	l.Logf("%s - "+format, args...)
+}
+
+// Errorf logs an error message prepended with the current timestamp, along with the given format and args
+func Errorf(l logger, format string, args ...any) {
+	args = append([]any{time.Now().Format("02-01-2006 15:04:05")}, args...)
+	l.Logf("ERROR: %s - "+format, args...)
 }

--- a/test/e2e-framework/common/utils/log.go
+++ b/test/e2e-framework/common/utils/log.go
@@ -10,14 +10,14 @@ import (
 	"time"
 )
 
-// Logf logs a message prepended with the current timestamp + test name, along with the given format and args
+// logf logs a message prepended with the current timestamp + test name, along with the given format and args
 func Logf(t *testing.T, format string, args ...any) {
 	t.Helper()
 	args = append([]any{time.Now().Format("02-01-2006 15:04:05"), t.Name()}, args...)
 	t.Logf("%s - %s - "+format, args...)
 }
 
-// Errorf logs an error message prepended with the current timestamp + test name, along with the given format and args
+// errorf logs an error message prepended with the current timestamp + test name, along with the given format and args
 func Errorf(t *testing.T, format string, args ...any) {
 	t.Helper()
 	args = append([]any{time.Now().Format("02-01-2006 15:04:05"), t.Name()}, args...)

--- a/test/e2e-framework/testing/components/remotehost_docker.go
+++ b/test/e2e-framework/testing/components/remotehost_docker.go
@@ -23,6 +23,6 @@ var _ common.Initializable = (*RemoteHostDocker)(nil)
 
 // Init is called by e2e test Suite after the component is provisioned.
 func (d *RemoteHostDocker) Init(ctx common.Context) (err error) {
-	d.Client, err = client.NewDocker(ctx.T(), d.ManagerOutput)
+	d.Client, err = client.NewDocker(ctx, d.ManagerOutput)
 	return err
 }

--- a/test/e2e-framework/testing/e2e/suite.go
+++ b/test/e2e-framework/testing/e2e/suite.go
@@ -239,6 +239,13 @@ func (bs *BaseSuite[Env]) Logf(format string, args ...any) {
 	bs.T().Logf(format, args...)
 }
 
+// FailNow satisfies the common.Context interface by logging the message and stopping the test.
+func (bs *BaseSuite[Env]) FailNow(format string, args ...any) {
+	bs.T().Helper()
+	bs.T().Logf(format, args...)
+	bs.T().FailNow()
+}
+
 // EventuallyWithT is a wrapper around testify.Suite.EventuallyWithT that catches panics to fail test without skipping TeardownSuite
 func (bs *BaseSuite[Env]) EventuallyWithT(condition func(*assert.CollectT), timeout time.Duration, interval time.Duration, msgAndArgs ...interface{}) bool {
 	return bs.Suite.EventuallyWithT(func(c *assert.CollectT) {

--- a/test/e2e-framework/testing/e2e/suite.go
+++ b/test/e2e-framework/testing/e2e/suite.go
@@ -233,12 +233,18 @@ func (bs *BaseSuite[Env]) Env() *Env {
 	return bs.env
 }
 
+// Logf satisfies the common.Context interface by delegating to the underlying *testing.T
+func (bs *BaseSuite[Env]) Logf(format string, args ...any) {
+	bs.T().Helper()
+	bs.T().Logf(format, args...)
+}
+
 // EventuallyWithT is a wrapper around testify.Suite.EventuallyWithT that catches panics to fail test without skipping TeardownSuite
 func (bs *BaseSuite[Env]) EventuallyWithT(condition func(*assert.CollectT), timeout time.Duration, interval time.Duration, msgAndArgs ...interface{}) bool {
 	return bs.Suite.EventuallyWithT(func(c *assert.CollectT) {
 		defer func() {
 			if r := recover(); r != nil {
-				utils.Errorf(bs.T(), "EventuallyWithT, panic: %v", r)
+				bs.T().Errorf("EventuallyWithT, panic: %v", r)
 			}
 		}()
 		condition(c)
@@ -268,7 +274,7 @@ func (bs *BaseSuite[Env]) EventuallyWithTf(condition func(*assert.CollectT), wai
 	return bs.Suite.EventuallyWithTf(func(c *assert.CollectT) {
 		defer func() {
 			if r := recover(); r != nil {
-				utils.Errorf(bs.T(), "EventuallyWithTf, panic: %v", r)
+				bs.T().Errorf("EventuallyWithTf, panic: %v", r)
 			}
 		}()
 		condition(c)

--- a/test/e2e-framework/testing/e2e/suite.go
+++ b/test/e2e-framework/testing/e2e/suite.go
@@ -244,7 +244,7 @@ func (bs *BaseSuite[Env]) EventuallyWithT(condition func(*assert.CollectT), time
 	return bs.Suite.EventuallyWithT(func(c *assert.CollectT) {
 		defer func() {
 			if r := recover(); r != nil {
-				bs.T().Errorf("EventuallyWithT, panic: %v", r)
+				utils.Errorf(bs.T(), "EventuallyWithT, panic: %v", r)
 			}
 		}()
 		condition(c)
@@ -274,7 +274,7 @@ func (bs *BaseSuite[Env]) EventuallyWithTf(condition func(*assert.CollectT), wai
 	return bs.Suite.EventuallyWithTf(func(c *assert.CollectT) {
 		defer func() {
 			if r := recover(); r != nil {
-				bs.T().Errorf("EventuallyWithTf, panic: %v", r)
+				utils.Errorf(bs.T(), "EventuallyWithTf, panic: %v", r)
 			}
 		}()
 		condition(c)
@@ -659,7 +659,7 @@ func (bs *BaseSuite[Env]) SetupSuite() {
 		if _, isNonFatalError := err.(runner.NonFatalError); isNonFatalError {
 			utils.Logf(bs.T(), "Non-fatal error encountered creating the session output directory: %v", err)
 		} else {
-			bs.T().Errorf("unable to create session output directory: %v", err)
+			utils.Errorf(bs.T(), "unable to create session output directory: %v", err)
 		}
 	}
 	bs.outputDir = sessionDirectory
@@ -781,7 +781,7 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 	if bs.coverage && !bs.params.disableCoverage {
 		err := bs.SaveCoverage(bs.coverageOutDir)
 		if err != nil {
-			bs.T().Errorf("fatal errors were encounterned while computing coverage: %v", err)
+			utils.Errorf(bs.T(), "fatal errors were encounterned while computing coverage: %v", err)
 		}
 
 		bs.attachMetadataToCoverage(bs.coverageOutDir)
@@ -850,7 +850,7 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 		} else {
 			utils.Logf(bs.T(), "Destroying stack %s with provisioner %s", bs.params.stackName, id)
 			if err := provisioner.Destroy(ctx, bs.params.stackName, newTestLogger(bs.T())); err != nil {
-				bs.T().Errorf("unable to delete stack: %s, provisioner %s, err: %v", bs.params.stackName, id, err)
+				utils.Errorf(bs.T(), "unable to delete stack: %s, provisioner %s, err: %v", bs.params.stackName, id, err)
 			}
 		}
 	}

--- a/test/e2e-framework/testing/e2e/suite.go
+++ b/test/e2e-framework/testing/e2e/suite.go
@@ -659,7 +659,7 @@ func (bs *BaseSuite[Env]) SetupSuite() {
 		if _, isNonFatalError := err.(runner.NonFatalError); isNonFatalError {
 			utils.Logf(bs.T(), "Non-fatal error encountered creating the session output directory: %v", err)
 		} else {
-			utils.Errorf(bs.T(), "unable to create session output directory: %v", err)
+			bs.T().Errorf("unable to create session output directory: %v", err)
 		}
 	}
 	bs.outputDir = sessionDirectory
@@ -781,7 +781,7 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 	if bs.coverage && !bs.params.disableCoverage {
 		err := bs.SaveCoverage(bs.coverageOutDir)
 		if err != nil {
-			utils.Errorf(bs.T(), "fatal errors were encounterned while computing coverage: %v", err)
+			bs.T().Errorf("fatal errors were encounterned while computing coverage: %v", err)
 		}
 
 		bs.attachMetadataToCoverage(bs.coverageOutDir)
@@ -850,7 +850,7 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 		} else {
 			utils.Logf(bs.T(), "Destroying stack %s with provisioner %s", bs.params.stackName, id)
 			if err := provisioner.Destroy(ctx, bs.params.stackName, newTestLogger(bs.T())); err != nil {
-				utils.Errorf(bs.T(), "unable to delete stack: %s, provisioner %s, err: %v", bs.params.stackName, id, err)
+				bs.T().Errorf("unable to delete stack: %s, provisioner %s, err: %v", bs.params.stackName, id, err)
 			}
 		}
 	}

--- a/test/e2e-framework/testing/utils/common/types.go
+++ b/test/e2e-framework/testing/utils/common/types.go
@@ -11,6 +11,7 @@ import "testing"
 type Context interface {
 	T() *testing.T
 	Logf(format string, args ...any)
+	FailNow(format string, args ...any)
 	SessionOutputDir() string
 }
 

--- a/test/e2e-framework/testing/utils/common/types.go
+++ b/test/e2e-framework/testing/utils/common/types.go
@@ -10,6 +10,7 @@ import "testing"
 // Context defines an interface that allows to get information about current test context
 type Context interface {
 	T() *testing.T
+	Logf(format string, args ...any)
 	SessionOutputDir() string
 }
 

--- a/test/e2e-framework/testing/utils/e2e/client/agent_client.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_client.go
@@ -9,14 +9,11 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent"
 	osComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/remote"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/common"
@@ -39,7 +36,7 @@ func NewHostAgentClient(context common.Context, hostOutput remote.HostOutput, wa
 	}
 
 	ae := newAgentHostExecutor(hostOutput.OSFamily, host, params)
-	commandRunner := newAgentCommandRunner(context.T(), ae)
+	commandRunner := newAgentCommandRunner(context, ae)
 
 	if params.ShouldWaitForReady {
 		if err := waitForReadyTimeout(commandRunner, agentReadyTimeout); err != nil {
@@ -61,7 +58,7 @@ func NewHostAgentClientWithParams(context common.Context, hostOutput remote.Host
 	}
 
 	ae := newAgentHostExecutor(hostOutput.OSFamily, host, params)
-	commandRunner := newAgentCommandRunner(context.T(), ae)
+	commandRunner := newAgentCommandRunner(context, ae)
 
 	if params.ShouldWaitForReady {
 		if err := waitForReadyTimeout(commandRunner, agentReadyTimeout); err != nil {
@@ -69,7 +66,9 @@ func NewHostAgentClientWithParams(context common.Context, hostOutput remote.Host
 		}
 	}
 
-	waitForAgentsReady(context.T(), host, params)
+	if err := waitForAgentsReady(context, host, params); err != nil {
+		return nil, err
+	}
 
 	return commandRunner, nil
 }
@@ -78,7 +77,7 @@ func NewHostAgentClientWithParams(context common.Context, hostOutput remote.Host
 func NewDockerAgentClient(context common.Context, dockerAgentOutput agent.DockerAgentOutput, options ...agentclientparams.Option) (agentclient.Agent, error) {
 	params := agentclientparams.NewParams(dockerAgentOutput.DockerManager.Host.OSFamily, options...)
 	ae := newAgentDockerExecutor(context, dockerAgentOutput)
-	commandRunner := newAgentCommandRunner(context.T(), ae)
+	commandRunner := newAgentCommandRunner(context, ae)
 
 	if params.ShouldWaitForReady {
 		if err := commandRunner.waitForReadyTimeout(agentReadyTimeout); err != nil {
@@ -99,7 +98,7 @@ func NewK8sAgentClient(context common.Context, podSelector metav1.ListOptions, c
 		return nil, fmt.Errorf("could not create k8s agent executor: %w", err)
 	}
 
-	commandRunner := newAgentCommandRunner(context.T(), ae)
+	commandRunner := newAgentCommandRunner(context, ae)
 
 	if params.ShouldWaitForReady {
 		if err := commandRunner.waitForReadyTimeout(agentReadyTimeout); err != nil {
@@ -118,33 +117,49 @@ func NewK8sAgentClient(context common.Context, podSelector metav1.ListOptions, c
 // If the timeout is reached, an error is returned.
 //
 // As of now this is only implemented for Linux.
-func waitForAgentsReady(tt *testing.T, host *Host, params *agentclientparams.Params) {
-	hostHTTPClient := host.NewHTTPClient()
-	require.EventuallyWithT(tt, func(t *assert.CollectT) {
-		agentReadyCmds := map[string]func(*agentclientparams.Params, *Host) (*http.Request, bool, error){
-			"process-agent":  processAgentRequest,
-			"trace-agent":    traceAgentRequest,
-			"security-agent": securityAgentRequest,
-		}
+func waitForAgentsReady(ctx clientContext, host *Host, params *agentclientparams.Params) error {
+	agentReadyCmds := map[string]func(*agentclientparams.Params, *Host) (*http.Request, bool, error){
+		"process-agent":  processAgentRequest,
+		"trace-agent":    traceAgentRequest,
+		"security-agent": securityAgentRequest,
+	}
 
+	hostHTTPClient := host.NewHTTPClient()
+	deadline := time.Now().Add(params.WaitForDuration)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		allReady := true
 		for name, getReadyRequest := range agentReadyCmds {
 			req, ok, err := getReadyRequest(params, host)
-			if !assert.NoErrorf(t, err, "could not build ready command for %s", name) {
+			if err != nil {
+				allReady = false
+				lastErr = fmt.Errorf("could not build ready command for %s: %w", name, err)
 				continue
 			}
-
 			if !ok {
 				continue
 			}
-
-			tt.Logf("Checking if %s is ready...", name)
+			ctx.Logf("Checking if %s is ready...", name)
 			resp, err := hostHTTPClient.Do(req)
-			if assert.NoErrorf(t, err, "%s did not become ready", name) {
-				assert.Less(t, resp.StatusCode, 400)
-				resp.Body.Close()
+			if err != nil {
+				allReady = false
+				lastErr = fmt.Errorf("%s did not become ready: %w", name, err)
+				continue
+			}
+			resp.Body.Close()
+			if resp.StatusCode >= 400 {
+				allReady = false
+				lastErr = fmt.Errorf("%s returned status %d", name, resp.StatusCode)
 			}
 		}
-	}, params.WaitForDuration, params.WaitForTick)
+		if allReady {
+			return nil
+		}
+		time.Sleep(params.WaitForTick)
+	}
+
+	return fmt.Errorf("agents not ready after %v: %w", params.WaitForDuration, lastErr)
 }
 
 func processAgentRequest(params *agentclientparams.Params, host *Host) (*http.Request, bool, error) {

--- a/test/e2e-framework/testing/utils/e2e/client/agent_client.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/remote"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/common"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client/agentclientparams"
 )
@@ -26,7 +25,7 @@ const (
 )
 
 // NewHostAgentClient creates an Agent client for host install
-func NewHostAgentClient(context common.Context, hostOutput remote.HostOutput, waitForAgentReady bool) (agentclient.Agent, error) {
+func NewHostAgentClient(context Context, hostOutput remote.HostOutput, waitForAgentReady bool) (agentclient.Agent, error) {
 	params := agentclientparams.NewParams(hostOutput.OSFamily)
 	params.ShouldWaitForReady = waitForAgentReady
 
@@ -49,7 +48,7 @@ func NewHostAgentClient(context common.Context, hostOutput remote.HostOutput, wa
 }
 
 // NewHostAgentClientWithParams creates an Agent client for host install with custom parameters
-func NewHostAgentClientWithParams(context common.Context, hostOutput remote.HostOutput, options ...agentclientparams.Option) (agentclient.Agent, error) {
+func NewHostAgentClientWithParams(context Context, hostOutput remote.HostOutput, options ...agentclientparams.Option) (agentclient.Agent, error) {
 	params := agentclientparams.NewParams(hostOutput.OSFamily, options...)
 
 	host, err := NewHost(context, hostOutput)
@@ -74,7 +73,7 @@ func NewHostAgentClientWithParams(context common.Context, hostOutput remote.Host
 }
 
 // NewDockerAgentClient creates an Agent client for a Docker install
-func NewDockerAgentClient(context common.Context, dockerAgentOutput agent.DockerAgentOutput, options ...agentclientparams.Option) (agentclient.Agent, error) {
+func NewDockerAgentClient(context Context, dockerAgentOutput agent.DockerAgentOutput, options ...agentclientparams.Option) (agentclient.Agent, error) {
 	params := agentclientparams.NewParams(dockerAgentOutput.DockerManager.Host.OSFamily, options...)
 	ae := newAgentDockerExecutor(context, dockerAgentOutput)
 	commandRunner := newAgentCommandRunner(context, ae)
@@ -91,7 +90,7 @@ func NewDockerAgentClient(context common.Context, dockerAgentOutput agent.Docker
 // NewK8sAgentClient creates an Agent client for a Kubernetes install, passing the ListOptions
 // to select the pod that runs the agent. There are some helper functions to create common selectors,
 // such as AgentSelectorAnyPod that will select any pod that runs the agent.
-func NewK8sAgentClient(context common.Context, podSelector metav1.ListOptions, clusterClient *KubernetesClient, options ...agentclientparams.Option) (agentclient.Agent, error) {
+func NewK8sAgentClient(context Context, podSelector metav1.ListOptions, clusterClient *KubernetesClient, options ...agentclientparams.Option) (agentclient.Agent, error) {
 	params := agentclientparams.NewParams(osComp.LinuxFamily, options...)
 	ae, err := newAgentK8sExecutor(podSelector, clusterClient)
 	if err != nil {
@@ -117,7 +116,7 @@ func NewK8sAgentClient(context common.Context, podSelector metav1.ListOptions, c
 // If the timeout is reached, an error is returned.
 //
 // As of now this is only implemented for Linux.
-func waitForAgentsReady(ctx clientContext, host *Host, params *agentclientparams.Params) error {
+func waitForAgentsReady(ctx Context, host *Host, params *agentclientparams.Params) error {
 	agentReadyCmds := map[string]func(*agentclientparams.Params, *Host) (*http.Request, bool, error){
 		"process-agent":  processAgentRequest,
 		"trace-agent":    traceAgentRequest,

--- a/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
@@ -42,7 +42,9 @@ func newAgentCommandRunner(ctx Context, executor agentCommandExecutor) *agentCom
 
 func (agent *agentCommandRunner) executeCommand(command string, commandArgs ...agentclient.AgentArgsOption) string {
 	output, err := agent.executeCommandWithError(command, commandArgs...)
-	requireNoErr(err)
+	if err != nil {
+		agent.ctx.FailNow("%v", err)
+	}
 	return output
 }
 

--- a/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/optional"
 
@@ -204,7 +203,7 @@ func (agent *agentCommandRunner) WorkloadList() (*agentclient.Status, error) {
 func (agent *agentCommandRunner) waitForReadyTimeout(timeout time.Duration) error {
 	interval := 100 * time.Millisecond
 	maxRetries := timeout.Milliseconds() / interval.Milliseconds()
-	utils.Logf(agent.ctx, "Waiting for the agent to be ready")
+	agent.ctx.Logf("Waiting for the agent to be ready")
 	_, err := backoff.Retry(context.Background(), func() (any, error) {
 		_, err := agent.executor.execute([]string{"status"})
 		if err != nil {

--- a/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
@@ -25,13 +25,13 @@ type agentCommandExecutor interface {
 // agentCommandRunner is an internal type that provides methods to run Agent commands.
 // It is used by both [VMClient] and [Docker]
 type agentCommandRunner struct {
-	ctx      clientContext
+	ctx      Context
 	executor agentCommandExecutor
 	isReady  bool
 }
 
 // Create a new instance of agentCommandRunner
-func newAgentCommandRunner(ctx clientContext, executor agentCommandExecutor) *agentCommandRunner {
+func newAgentCommandRunner(ctx Context, executor agentCommandExecutor) *agentCommandRunner {
 	agent := &agentCommandRunner{
 		ctx:      ctx,
 		executor: executor,
@@ -85,7 +85,9 @@ func (agent *agentCommandRunner) Check(commandArgs ...agentclient.AgentArgsOptio
 // Check runs check command and returns the runtime Agent check or an error
 func (agent *agentCommandRunner) CheckWithError(commandArgs ...agentclient.AgentArgsOption) (string, error) {
 	args, err := optional.MakeParams(commandArgs...)
-	requireNoErr(err)
+	if err != nil {
+		return "", err
+	}
 	arguments := append([]string{"check"}, args.Args...)
 	return agent.executor.execute(arguments)
 }
@@ -98,7 +100,9 @@ func (agent *agentCommandRunner) Config(commandArgs ...agentclient.AgentArgsOpti
 // ConfigWithError runs config command and returns the runtime agent config or an error
 func (agent *agentCommandRunner) ConfigWithError(commandArgs ...agentclient.AgentArgsOption) (string, error) {
 	args, err := optional.MakeParams(commandArgs...)
-	requireNoErr(err)
+	if err != nil {
+		return "", err
+	}
 	arguments := append([]string{"config"}, args.Args...)
 	return agent.executor.execute(arguments)
 }

--- a/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
@@ -17,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/optional"
 
 	"github.com/cenkalti/backoff/v5"
-	"github.com/stretchr/testify/require"
 )
 
 type agentCommandExecutor interface {
@@ -28,15 +26,15 @@ type agentCommandExecutor interface {
 // agentCommandRunner is an internal type that provides methods to run Agent commands.
 // It is used by both [VMClient] and [Docker]
 type agentCommandRunner struct {
-	t        *testing.T
+	ctx      clientContext
 	executor agentCommandExecutor
 	isReady  bool
 }
 
 // Create a new instance of agentCommandRunner
-func newAgentCommandRunner(t *testing.T, executor agentCommandExecutor) *agentCommandRunner {
+func newAgentCommandRunner(ctx clientContext, executor agentCommandExecutor) *agentCommandRunner {
 	agent := &agentCommandRunner{
-		t:        t,
+		ctx:      ctx,
 		executor: executor,
 		isReady:  false,
 	}
@@ -45,7 +43,7 @@ func newAgentCommandRunner(t *testing.T, executor agentCommandExecutor) *agentCo
 
 func (agent *agentCommandRunner) executeCommand(command string, commandArgs ...agentclient.AgentArgsOption) string {
 	output, err := agent.executeCommandWithError(command, commandArgs...)
-	require.NoError(agent.t, err)
+	requireNoErr(err)
 	return output
 }
 
@@ -88,8 +86,7 @@ func (agent *agentCommandRunner) Check(commandArgs ...agentclient.AgentArgsOptio
 // Check runs check command and returns the runtime Agent check or an error
 func (agent *agentCommandRunner) CheckWithError(commandArgs ...agentclient.AgentArgsOption) (string, error) {
 	args, err := optional.MakeParams(commandArgs...)
-	require.NoError(agent.t, err)
-
+	requireNoErr(err)
 	arguments := append([]string{"check"}, args.Args...)
 	return agent.executor.execute(arguments)
 }
@@ -102,8 +99,7 @@ func (agent *agentCommandRunner) Config(commandArgs ...agentclient.AgentArgsOpti
 // ConfigWithError runs config command and returns the runtime agent config or an error
 func (agent *agentCommandRunner) ConfigWithError(commandArgs ...agentclient.AgentArgsOption) (string, error) {
 	args, err := optional.MakeParams(commandArgs...)
-	require.NoError(agent.t, err)
-
+	requireNoErr(err)
 	arguments := append([]string{"config"}, args.Args...)
 	return agent.executor.execute(arguments)
 }
@@ -208,7 +204,7 @@ func (agent *agentCommandRunner) WorkloadList() (*agentclient.Status, error) {
 func (agent *agentCommandRunner) waitForReadyTimeout(timeout time.Duration) error {
 	interval := 100 * time.Millisecond
 	maxRetries := timeout.Milliseconds() / interval.Milliseconds()
-	utils.Logf(agent.t, "Waiting for the agent to be ready")
+	utils.Logf(agent.ctx, "Waiting for the agent to be ready")
 	_, err := backoff.Retry(context.Background(), func() (any, error) {
 		_, err := agent.executor.execute([]string{"status"})
 		if err != nil {

--- a/test/e2e-framework/testing/utils/e2e/client/agent_docker.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_docker.go
@@ -21,7 +21,7 @@ type agentDockerExecutor struct {
 
 var _ agentCommandExecutor = &agentDockerExecutor{}
 
-func newAgentDockerExecutor(context clientContext, dockerAgentOutput agent.DockerAgentOutput) *agentDockerExecutor {
+func newAgentDockerExecutor(context Context, dockerAgentOutput agent.DockerAgentOutput) *agentDockerExecutor {
 	dockerClient, err := NewDocker(context, dockerAgentOutput.DockerManager)
 	if err != nil {
 		panic(err)

--- a/test/e2e-framework/testing/utils/e2e/client/agent_docker.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_docker.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent"
 
-	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/common"
 )
 
 type agentDockerExecutor struct {
@@ -22,8 +21,8 @@ type agentDockerExecutor struct {
 
 var _ agentCommandExecutor = &agentDockerExecutor{}
 
-func newAgentDockerExecutor(context common.Context, dockerAgentOutput agent.DockerAgentOutput) *agentDockerExecutor {
-	dockerClient, err := NewDocker(context.T(), dockerAgentOutput.DockerManager)
+func newAgentDockerExecutor(context clientContext, dockerAgentOutput agent.DockerAgentOutput) *agentDockerExecutor {
+	dockerClient, err := NewDocker(context, dockerAgentOutput.DockerManager)
 	if err != nil {
 		panic(err)
 	}

--- a/test/e2e-framework/testing/utils/e2e/client/agent_docker.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_docker.go
@@ -24,7 +24,8 @@ var _ agentCommandExecutor = &agentDockerExecutor{}
 func newAgentDockerExecutor(context Context, dockerAgentOutput agent.DockerAgentOutput) *agentDockerExecutor {
 	dockerClient, err := NewDocker(context, dockerAgentOutput.DockerManager)
 	if err != nil {
-		panic(err)
+		context.FailNow("%v", err)
+		return nil
 	}
 	return &agentDockerExecutor{
 		dockerClient:       dockerClient,

--- a/test/e2e-framework/testing/utils/e2e/client/client_context.go
+++ b/test/e2e-framework/testing/utils/e2e/client/client_context.go
@@ -5,9 +5,9 @@
 
 package client
 
-// clientContext is the subset of common.Context needed by the client layer.
+// Context is the subset of common.Context needed by the client layer.
 // It has no dependency on *testing.T, so non-test callers can implement it.
-type clientContext interface {
+type Context interface {
 	Logf(format string, args ...any)
 	SessionOutputDir() string
 }

--- a/test/e2e-framework/testing/utils/e2e/client/client_context.go
+++ b/test/e2e-framework/testing/utils/e2e/client/client_context.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package client
+
+// clientContext is the subset of common.Context needed by the client layer.
+// It has no dependency on *testing.T, so non-test callers can implement it.
+type clientContext interface {
+	Logf(format string, args ...any)
+	SessionOutputDir() string
+}
+
+// requireNoErr panics if err is non-nil. Used in must-style helpers where
+// returning an error would change public API signatures.
+func requireNoErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/test/e2e-framework/testing/utils/e2e/client/client_context.go
+++ b/test/e2e-framework/testing/utils/e2e/client/client_context.go
@@ -9,13 +9,8 @@ package client
 // It has no dependency on *testing.T, so non-test callers can implement it.
 type Context interface {
 	Logf(format string, args ...any)
+	// FailNow logs the formatted message and immediately stops the current goroutine.
+	// In test contexts this calls t.Logf + t.FailNow(); in other contexts it panics.
+	FailNow(format string, args ...any)
 	SessionOutputDir() string
-}
-
-// requireNoErr panics if err is non-nil. Used in must-style helpers where
-// returning an error would change public API signatures.
-func requireNoErr(err error) {
-	if err != nil {
-		panic(err)
-	}
 }

--- a/test/e2e-framework/testing/utils/e2e/client/docker.go
+++ b/test/e2e-framework/testing/utils/e2e/client/docker.go
@@ -14,13 +14,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/docker"
 	"github.com/docker/cli/cli/connhelper"
 	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/client"
-	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
@@ -31,14 +29,14 @@ import (
 //
 // [docker.Deamon]: https://pkg.go.dev/github.com/DataDog/datadog-agent/test/e2e-framework@main/components/datadog/agent/docker#Deamon
 type Docker struct {
-	t        *testing.T
+	ctx      clientContext
 	client   *client.Client
 	scrubber *scrubber.Scrubber
 }
 
 // NewDocker creates a new instance of Docker
 // NOTE: docker+ssh does not support password protected SSH keys.
-func NewDocker(t *testing.T, dockerOutput docker.ManagerOutput) (*Docker, error) {
+func NewDocker(ctx clientContext, dockerOutput docker.ManagerOutput) (*Docker, error) {
 	deamonURL := fmt.Sprintf("ssh://%v@%v", dockerOutput.Host.Username, dockerOutput.Host.Address)
 
 	sshOpts := []string{"-o", "StrictHostKeyChecking no"}
@@ -66,7 +64,7 @@ func NewDocker(t *testing.T, dockerOutput docker.ManagerOutput) (*Docker, error)
 	}
 
 	return &Docker{
-		t:        t,
+		ctx:      ctx,
 		client:   client,
 		scrubber: scrubber.NewWithDefaults(),
 	}, nil
@@ -75,7 +73,9 @@ func NewDocker(t *testing.T, dockerOutput docker.ManagerOutput) (*Docker, error)
 // ExecuteCommand executes a command on containerName and returns the output.
 func (docker *Docker) ExecuteCommand(containerName string, commands ...string) string {
 	output, err := docker.ExecuteCommandWithErr(containerName, commands...)
-	require.NoErrorf(docker.t, err, "%v: %v", output, err)
+	if err != nil {
+		panic(fmt.Errorf("%v: %w", output, err))
+	}
 	return output
 }
 
@@ -92,24 +92,24 @@ func (docker *Docker) ExecuteCommandWithErr(containerName string, commands ...st
 func (docker *Docker) ExecuteCommandStdoutStdErr(containerName string, commands ...string) (stdout string, stderr string, err error) {
 	cmd := strings.Join(commands, " ")
 	scrubbedCommand := docker.scrubber.ScrubLine(cmd) // scrub the command in case it contains secrets
-	docker.t.Logf("Executing command `%s`", scrubbedCommand)
+	docker.ctx.Logf("Executing command `%s`", scrubbedCommand)
 
-	context := context.Background()
-	execCreateResp, err := docker.client.ExecCreate(context, containerName, client.ExecCreateOptions{Cmd: commands, AttachStderr: true, AttachStdout: true})
-	require.NoError(docker.t, err)
+	ctx := context.Background()
+	execCreateResp, err := docker.client.ExecCreate(ctx, containerName, client.ExecCreateOptions{Cmd: commands, AttachStderr: true, AttachStdout: true})
+	requireNoErr(err)
 
-	execAttachResp, err := docker.client.ExecAttach(context, execCreateResp.ID, client.ExecAttachOptions{})
-	require.NoError(docker.t, err)
+	execAttachResp, err := docker.client.ExecAttach(ctx, execCreateResp.ID, client.ExecAttachOptions{})
+	requireNoErr(err)
 	defer execAttachResp.Close()
 
 	var outBuf, errBuf bytes.Buffer
 	// Use stdcopy.StdCopy to remove prefix for stdout and stderr
 	// See https://stackoverflow.com/questions/52774830/docker-exec-command-from-golang-api for additional context
 	_, err = stdcopy.StdCopy(&outBuf, &errBuf, execAttachResp.Reader)
-	require.NoError(docker.t, err)
+	requireNoErr(err)
 
-	execInspectResp, err := docker.client.ExecInspect(context, execCreateResp.ID, client.ExecInspectOptions{})
-	require.NoError(docker.t, err)
+	execInspectResp, err := docker.client.ExecInspect(ctx, execCreateResp.ID, client.ExecInspectOptions{})
+	requireNoErr(err)
 
 	stdout = outBuf.String()
 	stderr = errBuf.String()
@@ -152,7 +152,7 @@ func (docker *Docker) getContainerIDsByName() (map[string]string, error) {
 
 // DownloadFile downloads a file or directory from the container to the local filesystem.
 func (docker *Docker) DownloadFile(containerName, containerPath, localPath string) error {
-	docker.t.Logf("Downloading from container %s:%s to local path %s", containerName, containerPath, localPath)
+	docker.ctx.Logf("Downloading from container %s:%s to local path %s", containerName, containerPath, localPath)
 
 	ctx := context.Background()
 	copyResult, err := docker.client.CopyFromContainer(ctx, containerName, client.CopyFromContainerOptions{SourcePath: containerPath})
@@ -200,7 +200,7 @@ func (docker *Docker) DownloadFile(containerName, containerPath, localPath strin
 			if err := os.MkdirAll(target, 0755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", target, err)
 			}
-			docker.t.Logf("Created directory: %s", target)
+			docker.ctx.Logf("Created directory: %s", target)
 
 		case tar.TypeReg:
 			// Ensure parent directory exists
@@ -223,10 +223,10 @@ func (docker *Docker) DownloadFile(containerName, containerPath, localPath strin
 				return fmt.Errorf("failed to close file %s: %w", target, closeErr)
 			}
 
-			docker.t.Logf("Created file: %s", target)
+			docker.ctx.Logf("Created file: %s", target)
 		}
 	}
 
-	docker.t.Logf("Successfully downloaded to %s", localPath)
+	docker.ctx.Logf("Successfully downloaded to %s", localPath)
 	return nil
 }

--- a/test/e2e-framework/testing/utils/e2e/client/docker.go
+++ b/test/e2e-framework/testing/utils/e2e/client/docker.go
@@ -29,14 +29,14 @@ import (
 //
 // [docker.Deamon]: https://pkg.go.dev/github.com/DataDog/datadog-agent/test/e2e-framework@main/components/datadog/agent/docker#Deamon
 type Docker struct {
-	ctx      clientContext
+	ctx      Context
 	client   *client.Client
 	scrubber *scrubber.Scrubber
 }
 
 // NewDocker creates a new instance of Docker
 // NOTE: docker+ssh does not support password protected SSH keys.
-func NewDocker(ctx clientContext, dockerOutput docker.ManagerOutput) (*Docker, error) {
+func NewDocker(ctx Context, dockerOutput docker.ManagerOutput) (*Docker, error) {
 	deamonURL := fmt.Sprintf("ssh://%v@%v", dockerOutput.Host.Username, dockerOutput.Host.Address)
 
 	sshOpts := []string{"-o", "StrictHostKeyChecking no"}

--- a/test/e2e-framework/testing/utils/e2e/client/docker.go
+++ b/test/e2e-framework/testing/utils/e2e/client/docker.go
@@ -96,20 +96,28 @@ func (docker *Docker) ExecuteCommandStdoutStdErr(containerName string, commands 
 
 	ctx := context.Background()
 	execCreateResp, err := docker.client.ExecCreate(ctx, containerName, client.ExecCreateOptions{Cmd: commands, AttachStderr: true, AttachStdout: true})
-	requireNoErr(err)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create exec on container %s: %w", containerName, err)
+	}
 
 	execAttachResp, err := docker.client.ExecAttach(ctx, execCreateResp.ID, client.ExecAttachOptions{})
-	requireNoErr(err)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to attach to exec on container %s: %w", containerName, err)
+	}
 	defer execAttachResp.Close()
 
 	var outBuf, errBuf bytes.Buffer
 	// Use stdcopy.StdCopy to remove prefix for stdout and stderr
 	// See https://stackoverflow.com/questions/52774830/docker-exec-command-from-golang-api for additional context
 	_, err = stdcopy.StdCopy(&outBuf, &errBuf, execAttachResp.Reader)
-	requireNoErr(err)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read exec output on container %s: %w", containerName, err)
+	}
 
 	execInspectResp, err := docker.client.ExecInspect(ctx, execCreateResp.ID, client.ExecInspectOptions{})
-	requireNoErr(err)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to inspect exec on container %s: %w", containerName, err)
+	}
 
 	stdout = outBuf.String()
 	stderr = errBuf.String()

--- a/test/e2e-framework/testing/utils/e2e/client/docker.go
+++ b/test/e2e-framework/testing/utils/e2e/client/docker.go
@@ -74,7 +74,7 @@ func NewDocker(ctx Context, dockerOutput docker.ManagerOutput) (*Docker, error) 
 func (docker *Docker) ExecuteCommand(containerName string, commands ...string) string {
 	output, err := docker.ExecuteCommandWithErr(containerName, commands...)
 	if err != nil {
-		panic(fmt.Errorf("%v: %w", output, err))
+		docker.ctx.FailNow("%v: %v", output, err)
 	}
 	return output
 }

--- a/test/e2e-framework/testing/utils/e2e/client/host.go
+++ b/test/e2e-framework/testing/utils/e2e/client/host.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cenkalti/backoff/v5"
 	"github.com/pkg/sftp"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
@@ -32,7 +31,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner/parameters"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/common"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/optional"
 )
 
@@ -54,7 +52,7 @@ type HostArtifactClient interface {
 type sshExecutor struct {
 	client     *ssh.Client
 	privileged *ssh.Client
-	context    common.Context
+	context    clientContext
 
 	username             string
 	privilegedUsername   string
@@ -78,7 +76,7 @@ type Host struct {
 
 // NewHost creates a new ssh client to connect to a remote host with
 // reconnect retry logic
-func NewHost(context common.Context, hostOutput remote.HostOutput) (*Host, error) {
+func NewHost(context clientContext, hostOutput remote.HostOutput) (*Host, error) {
 	var privateSSHKey []byte
 
 	privateKeyPath, err := runner.GetProfile().ParamStore().GetWithDefault(parameters.StoreKey(hostOutput.CloudProvider+parameters.PrivateKeyPathSuffix), "")
@@ -132,7 +130,7 @@ func NewHost(context common.Context, hostOutput remote.HostOutput) (*Host, error
 
 // Reconnect closes the current ssh client and creates a new one, with retries.
 func (h *sshExecutor) Reconnect() error {
-	utils.Logf(h.context.T(), "Reconnecting to host")
+	utils.Logf(h.context, "Reconnecting to host")
 	if h.client != nil {
 		_ = h.client.Close()
 	}
@@ -148,7 +146,7 @@ func (h *sshExecutor) Reconnect() error {
 
 		privileged, err := getSSHClient(h.privilegedUsername, h.host, h.privateKey, h.privateKeyPassphrase)
 		if err != nil {
-			utils.Logf(h.context.T(), "Unable to create privileged SSH connection: %v", err)
+			utils.Logf(h.context, "Unable to create privileged SSH connection: %v", err)
 			// Ignore this error for now, since SSH connection as root are not enable on some providers
 		}
 		h.privileged = privileged
@@ -169,7 +167,7 @@ func (h *sshExecutor) Execute(command string, options ...ExecuteOption) (string,
 
 func (h *sshExecutor) executeAndReconnectOnError(command string) (string, error) {
 	scrubbedCommand := h.scrubber.ScrubLine(command) // scrub the command in case it contains secrets
-	utils.Logf(h.context.T(), "Executing command `%s`", scrubbedCommand)
+	utils.Logf(h.context, "Executing command `%s`", scrubbedCommand)
 	stdout, err := execute(h.client, command)
 	if err != nil && strings.Contains(err.Error(), "failed to create session:") {
 		err = h.Reconnect()
@@ -196,7 +194,7 @@ func (h *sshExecutor) Start(command string, options ...ExecuteOption) (*ssh.Sess
 
 func (h *sshExecutor) startAndReconnectOnError(command string) (*ssh.Session, io.WriteCloser, io.Reader, error) {
 	scrubbedCommand := h.scrubber.ScrubLine(command) // scrub the command in case it contains secrets
-	utils.Logf(h.context.T(), "Executing command `%s`", scrubbedCommand)
+	utils.Logf(h.context, "Executing command `%s`", scrubbedCommand)
 	session, stdin, stdout, err := start(h.client, command)
 	if err != nil && strings.Contains(err.Error(), "failed to create session:") {
 		err = h.Reconnect()
@@ -211,36 +209,36 @@ func (h *sshExecutor) startAndReconnectOnError(command string) (*ssh.Session, io
 // MustExecute executes a command and requires no error.
 func (h *sshExecutor) MustExecute(command string, options ...ExecuteOption) string {
 	stdout, err := h.Execute(command, options...)
-	require.NoError(h.context.T(), err)
+	requireNoErr(err)
 	return stdout
 }
 
 // CopyFileFromFS creates a sftp session and copy a single embedded file to the remote host through SSH
 func (h *Host) CopyFileFromFS(fs fs.FS, src, dst string) {
-	utils.Logf(h.context.T(), "Copying file from local %s to remote %s", src, dst)
+	utils.Logf(h.context, "Copying file from local %s to remote %s", src, dst)
 	dst = h.convertPathSeparator(dst)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
 	file, err := fs.Open(src)
-	require.NoError(h.context.T(), err)
+	requireNoErr(err)
 	defer file.Close()
 	err = copyFileFromIoReader(sftpClient, file, dst)
-	require.NoError(h.context.T(), err)
+	requireNoErr(err)
 }
 
 // CopyFile creates a sftp session and copy a single file to the remote host through SSH
 func (h *Host) CopyFile(src string, dst string) {
-	utils.Logf(h.context.T(), "Copying file from local %s to remote %s", src, dst)
+	utils.Logf(h.context, "Copying file from local %s to remote %s", src, dst)
 	dst = h.convertPathSeparator(dst)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
 	err := copyFile(sftpClient, src, dst)
-	require.NoError(h.context.T(), err)
+	requireNoErr(err)
 }
 
 // CopyFolder create a sftp session and copy a folder to remote host through SSH
 func (h *Host) CopyFolder(srcFolder string, dstFolder string) error {
-	utils.Logf(h.context.T(), "Copying folder from local %s to remote %s", srcFolder, dstFolder)
+	utils.Logf(h.context, "Copying folder from local %s to remote %s", srcFolder, dstFolder)
 	dstFolder = h.convertPathSeparator(dstFolder)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -249,7 +247,7 @@ func (h *Host) CopyFolder(srcFolder string, dstFolder string) error {
 
 // FileExists create a sftp session to and returns true if the file exists and is a regular file
 func (h *Host) FileExists(path string) (bool, error) {
-	utils.Logf(h.context.T(), "Checking if file exists: %s", path)
+	utils.Logf(h.context, "Checking if file exists: %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -279,7 +277,7 @@ func (h *Host) EnsureFileIsReadable(path string) error {
 
 // GetFile create a sftp session and copy a single file from the remote host through SSH
 func (h *Host) GetFile(src string, dst string) error {
-	utils.Logf(h.context.T(), "Copying file from remote %s to local %s", src, dst)
+	utils.Logf(h.context, "Copying file from remote %s to local %s", src, dst)
 	dst = h.convertPathSeparator(dst)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -288,7 +286,7 @@ func (h *Host) GetFile(src string, dst string) error {
 
 // GetFolder create a sftp session and copy a folder from the remote host through SSH
 func (h *Host) GetFolder(srcFolder string, dstFolder string) error {
-	utils.Logf(h.context.T(), "Copying folder from remote %s to local %s", srcFolder, dstFolder)
+	utils.Logf(h.context, "Copying folder from remote %s to local %s", srcFolder, dstFolder)
 	srcFolder = h.convertPathSeparator(srcFolder)
 	dstFolder = h.convertPathSeparator(dstFolder)
 	sftpClient := h.getSFTPClient()
@@ -297,7 +295,7 @@ func (h *Host) GetFolder(srcFolder string, dstFolder string) error {
 }
 
 func (h *Host) readFileWithClient(sftpClient *sftp.Client, path string) ([]byte, error) {
-	utils.Logf(h.context.T(), "Reading file with client at %s", path)
+	utils.Logf(h.context, "Reading file with client at %s", path)
 	path = h.convertPathSeparator(path)
 	defer sftpClient.Close()
 
@@ -317,19 +315,19 @@ func (h *Host) readFileWithClient(sftpClient *sftp.Client, path string) ([]byte,
 
 // ReadFile reads the content of the file, return bytes read and error if any
 func (h *Host) ReadFile(path string) ([]byte, error) {
-	utils.Logf(h.context.T(), "Reading file at %s", path)
+	utils.Logf(h.context, "Reading file at %s", path)
 	return h.readFileWithClient(h.getSFTPClient(), path)
 }
 
 // ReadFilePrivileged reads the content of the file with a privileged user, return bytes read and error if any
 func (h *Host) ReadFilePrivileged(path string) ([]byte, error) {
-	utils.Logf(h.context.T(), "Reading file with privileges at %s", path)
+	utils.Logf(h.context, "Reading file with privileges at %s", path)
 	return h.readFileWithClient(h.getSFTPPrivilegedClient(), path)
 }
 
 // WriteFile write content to the file and returns the number of bytes written and error if any
 func (h *Host) WriteFile(path string, content []byte) (int64, error) {
-	utils.Logf(h.context.T(), "Writing to file at %s", path)
+	utils.Logf(h.context, "Writing to file at %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -346,7 +344,7 @@ func (h *Host) WriteFile(path string, content []byte) (int64, error) {
 
 // AppendFile append content to the file and returns the number of bytes appened and error if any
 func (h *Host) AppendFile(os, path string, content []byte) (int64, error) {
-	utils.Logf(h.context.T(), "Appending to file at %s", path)
+	utils.Logf(h.context, "Appending to file at %s", path)
 	path = h.convertPathSeparator(path)
 	if os == "linux" {
 		return h.appendWithSudo(path, content)
@@ -356,7 +354,7 @@ func (h *Host) AppendFile(os, path string, content []byte) (int64, error) {
 
 // ReadDir returns list of directory entries in path
 func (h *Host) ReadDir(path string) ([]fs.DirEntry, error) {
-	utils.Logf(h.context.T(), "Reading filesystem at %s", path)
+	utils.Logf(h.context, "Reading filesystem at %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 
@@ -378,7 +376,7 @@ func (h *Host) ReadDir(path string) ([]fs.DirEntry, error) {
 
 // FindFiles returns a list of files with a given name
 func (h *Host) FindFiles(name string) ([]string, error) {
-	h.context.T().Logf("Finding files with name %s", name)
+	h.context.Logf("Finding files with name %s", name)
 	switch h.osFamily {
 	case oscomp.WindowsFamily:
 		out, err := h.Execute("Get-ChildItem -Path C:\\ -Filter " + name)
@@ -400,7 +398,7 @@ func (h *Host) FindFiles(name string) ([]string, error) {
 // Lstat returns a FileInfo structure describing path.
 // if path is a symbolic link, the FileInfo structure describes the symbolic link.
 func (h *Host) Lstat(path string) (fs.FileInfo, error) {
-	utils.Logf(h.context.T(), "Reading file info of %s", path)
+	utils.Logf(h.context, "Reading file info of %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -412,7 +410,7 @@ func (h *Host) Lstat(path string) (fs.FileInfo, error) {
 // If the path is already a directory, does nothing and returns nil.
 // Otherwise returns an error if any.
 func (h *Host) MkdirAll(path string) error {
-	utils.Logf(h.context.T(), "Creating directory %s", path)
+	utils.Logf(h.context, "Creating directory %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -423,7 +421,7 @@ func (h *Host) MkdirAll(path string) error {
 // Remove removes the specified file or directory.
 // Returns an error if file or directory does not exist, or if the directory is not empty.
 func (h *Host) Remove(path string) error {
-	utils.Logf(h.context.T(), "Removing %s", path)
+	utils.Logf(h.context, "Removing %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -434,7 +432,7 @@ func (h *Host) Remove(path string) error {
 // RemoveAll recursively removes all files/folders in the specified directory.
 // Returns an error if the directory does not exist.
 func (h *Host) RemoveAll(path string) error {
-	utils.Logf(h.context.T(), "Removing all under %s", path)
+	utils.Logf(h.context, "Removing all under %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -444,7 +442,7 @@ func (h *Host) RemoveAll(path string) error {
 
 // DialPort creates a connection from the remote host to its `port`.
 func (h *Host) DialPort(port uint16) (net.Conn, error) {
-	utils.Logf(h.context.T(), "Creating connection to host port %d", port)
+	utils.Logf(h.context, "Creating connection to host port %d", port)
 	address := fmt.Sprintf("127.0.0.1:%d", port)
 	protocol := "tcp"
 	// TODO add context to host
@@ -552,10 +550,9 @@ func (h *Host) appendWithSftp(path string, content []byte) (int64, error) {
 func (h *Host) getSFTPClient() *sftp.Client {
 	sftpClient, err := sftp.NewClient(h.client, sftp.UseConcurrentWrites(true))
 	if err != nil {
-		err = h.Reconnect()
-		require.NoError(h.context.T(), err)
+		requireNoErr(h.Reconnect())
 		sftpClient, err = sftp.NewClient(h.client, sftp.UseConcurrentWrites(true))
-		require.NoError(h.context.T(), err)
+		requireNoErr(err)
 	}
 	return sftpClient
 }
@@ -563,16 +560,13 @@ func (h *Host) getSFTPClient() *sftp.Client {
 func (h *Host) getSFTPPrivilegedClient() *sftp.Client {
 	if h.privileged == nil {
 		// Some cloud provider don't provide SSH connection as root (GCP) required for these file operations
-		utils.Logf(h.context.T(), "Can't SFTP files without a privileged SSH connection")
-		h.context.T().Fail()
-		return nil
+		panic("can't SFTP files without a privileged SSH connection")
 	}
 	sftpClient, err := sftp.NewClient(h.privileged, sftp.UseConcurrentWrites(true))
 	if err != nil {
-		err = h.Reconnect()
-		require.NoError(h.context.T(), err)
+		requireNoErr(h.Reconnect())
 		sftpClient, err = sftp.NewClient(h.privileged, sftp.UseConcurrentWrites(true))
-		require.NoError(h.context.T(), err)
+		requireNoErr(err)
 	}
 	return sftpClient
 }

--- a/test/e2e-framework/testing/utils/e2e/client/host.go
+++ b/test/e2e-framework/testing/utils/e2e/client/host.go
@@ -550,7 +550,8 @@ func (h *Host) appendWithSftp(path string, content []byte) (int64, error) {
 func (h *Host) getSFTPClient() *sftp.Client {
 	sftpClient, err := sftp.NewClient(h.client, sftp.UseConcurrentWrites(true))
 	if err != nil {
-		requireNoErr(h.Reconnect())
+		err = h.Reconnect()
+		requireNoErr(err)
 		sftpClient, err = sftp.NewClient(h.client, sftp.UseConcurrentWrites(true))
 		requireNoErr(err)
 	}
@@ -564,7 +565,8 @@ func (h *Host) getSFTPPrivilegedClient() *sftp.Client {
 	}
 	sftpClient, err := sftp.NewClient(h.privileged, sftp.UseConcurrentWrites(true))
 	if err != nil {
-		requireNoErr(h.Reconnect())
+		err = h.Reconnect()
+		requireNoErr(err)
 		sftpClient, err = sftp.NewClient(h.privileged, sftp.UseConcurrentWrites(true))
 		requireNoErr(err)
 	}

--- a/test/e2e-framework/testing/utils/e2e/client/host.go
+++ b/test/e2e-framework/testing/utils/e2e/client/host.go
@@ -51,7 +51,7 @@ type HostArtifactClient interface {
 type sshExecutor struct {
 	client     *ssh.Client
 	privileged *ssh.Client
-	context    clientContext
+	context    Context
 
 	username             string
 	privilegedUsername   string
@@ -75,7 +75,7 @@ type Host struct {
 
 // NewHost creates a new ssh client to connect to a remote host with
 // reconnect retry logic
-func NewHost(context clientContext, hostOutput remote.HostOutput) (*Host, error) {
+func NewHost(context Context, hostOutput remote.HostOutput) (*Host, error) {
 	var privateSSHKey []byte
 
 	privateKeyPath, err := runner.GetProfile().ParamStore().GetWithDefault(parameters.StoreKey(hostOutput.CloudProvider+parameters.PrivateKeyPathSuffix), "")

--- a/test/e2e-framework/testing/utils/e2e/client/host.go
+++ b/test/e2e-framework/testing/utils/e2e/client/host.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	oscomp "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/remote"
 
@@ -130,7 +129,7 @@ func NewHost(context clientContext, hostOutput remote.HostOutput) (*Host, error)
 
 // Reconnect closes the current ssh client and creates a new one, with retries.
 func (h *sshExecutor) Reconnect() error {
-	utils.Logf(h.context, "Reconnecting to host")
+	h.context.Logf("Reconnecting to host")
 	if h.client != nil {
 		_ = h.client.Close()
 	}
@@ -146,7 +145,7 @@ func (h *sshExecutor) Reconnect() error {
 
 		privileged, err := getSSHClient(h.privilegedUsername, h.host, h.privateKey, h.privateKeyPassphrase)
 		if err != nil {
-			utils.Logf(h.context, "Unable to create privileged SSH connection: %v", err)
+			h.context.Logf("Unable to create privileged SSH connection: %v", err)
 			// Ignore this error for now, since SSH connection as root are not enable on some providers
 		}
 		h.privileged = privileged
@@ -167,7 +166,7 @@ func (h *sshExecutor) Execute(command string, options ...ExecuteOption) (string,
 
 func (h *sshExecutor) executeAndReconnectOnError(command string) (string, error) {
 	scrubbedCommand := h.scrubber.ScrubLine(command) // scrub the command in case it contains secrets
-	utils.Logf(h.context, "Executing command `%s`", scrubbedCommand)
+	h.context.Logf("Executing command `%s`", scrubbedCommand)
 	stdout, err := execute(h.client, command)
 	if err != nil && strings.Contains(err.Error(), "failed to create session:") {
 		err = h.Reconnect()
@@ -194,7 +193,7 @@ func (h *sshExecutor) Start(command string, options ...ExecuteOption) (*ssh.Sess
 
 func (h *sshExecutor) startAndReconnectOnError(command string) (*ssh.Session, io.WriteCloser, io.Reader, error) {
 	scrubbedCommand := h.scrubber.ScrubLine(command) // scrub the command in case it contains secrets
-	utils.Logf(h.context, "Executing command `%s`", scrubbedCommand)
+	h.context.Logf("Executing command `%s`", scrubbedCommand)
 	session, stdin, stdout, err := start(h.client, command)
 	if err != nil && strings.Contains(err.Error(), "failed to create session:") {
 		err = h.Reconnect()
@@ -215,7 +214,7 @@ func (h *sshExecutor) MustExecute(command string, options ...ExecuteOption) stri
 
 // CopyFileFromFS creates a sftp session and copy a single embedded file to the remote host through SSH
 func (h *Host) CopyFileFromFS(fs fs.FS, src, dst string) {
-	utils.Logf(h.context, "Copying file from local %s to remote %s", src, dst)
+	h.context.Logf("Copying file from local %s to remote %s", src, dst)
 	dst = h.convertPathSeparator(dst)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -228,7 +227,7 @@ func (h *Host) CopyFileFromFS(fs fs.FS, src, dst string) {
 
 // CopyFile creates a sftp session and copy a single file to the remote host through SSH
 func (h *Host) CopyFile(src string, dst string) {
-	utils.Logf(h.context, "Copying file from local %s to remote %s", src, dst)
+	h.context.Logf("Copying file from local %s to remote %s", src, dst)
 	dst = h.convertPathSeparator(dst)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -238,7 +237,7 @@ func (h *Host) CopyFile(src string, dst string) {
 
 // CopyFolder create a sftp session and copy a folder to remote host through SSH
 func (h *Host) CopyFolder(srcFolder string, dstFolder string) error {
-	utils.Logf(h.context, "Copying folder from local %s to remote %s", srcFolder, dstFolder)
+	h.context.Logf("Copying folder from local %s to remote %s", srcFolder, dstFolder)
 	dstFolder = h.convertPathSeparator(dstFolder)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -247,7 +246,7 @@ func (h *Host) CopyFolder(srcFolder string, dstFolder string) error {
 
 // FileExists create a sftp session to and returns true if the file exists and is a regular file
 func (h *Host) FileExists(path string) (bool, error) {
-	utils.Logf(h.context, "Checking if file exists: %s", path)
+	h.context.Logf("Checking if file exists: %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -277,7 +276,7 @@ func (h *Host) EnsureFileIsReadable(path string) error {
 
 // GetFile create a sftp session and copy a single file from the remote host through SSH
 func (h *Host) GetFile(src string, dst string) error {
-	utils.Logf(h.context, "Copying file from remote %s to local %s", src, dst)
+	h.context.Logf("Copying file from remote %s to local %s", src, dst)
 	dst = h.convertPathSeparator(dst)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -286,7 +285,7 @@ func (h *Host) GetFile(src string, dst string) error {
 
 // GetFolder create a sftp session and copy a folder from the remote host through SSH
 func (h *Host) GetFolder(srcFolder string, dstFolder string) error {
-	utils.Logf(h.context, "Copying folder from remote %s to local %s", srcFolder, dstFolder)
+	h.context.Logf("Copying folder from remote %s to local %s", srcFolder, dstFolder)
 	srcFolder = h.convertPathSeparator(srcFolder)
 	dstFolder = h.convertPathSeparator(dstFolder)
 	sftpClient := h.getSFTPClient()
@@ -295,7 +294,7 @@ func (h *Host) GetFolder(srcFolder string, dstFolder string) error {
 }
 
 func (h *Host) readFileWithClient(sftpClient *sftp.Client, path string) ([]byte, error) {
-	utils.Logf(h.context, "Reading file with client at %s", path)
+	h.context.Logf("Reading file with client at %s", path)
 	path = h.convertPathSeparator(path)
 	defer sftpClient.Close()
 
@@ -315,19 +314,19 @@ func (h *Host) readFileWithClient(sftpClient *sftp.Client, path string) ([]byte,
 
 // ReadFile reads the content of the file, return bytes read and error if any
 func (h *Host) ReadFile(path string) ([]byte, error) {
-	utils.Logf(h.context, "Reading file at %s", path)
+	h.context.Logf("Reading file at %s", path)
 	return h.readFileWithClient(h.getSFTPClient(), path)
 }
 
 // ReadFilePrivileged reads the content of the file with a privileged user, return bytes read and error if any
 func (h *Host) ReadFilePrivileged(path string) ([]byte, error) {
-	utils.Logf(h.context, "Reading file with privileges at %s", path)
+	h.context.Logf("Reading file with privileges at %s", path)
 	return h.readFileWithClient(h.getSFTPPrivilegedClient(), path)
 }
 
 // WriteFile write content to the file and returns the number of bytes written and error if any
 func (h *Host) WriteFile(path string, content []byte) (int64, error) {
-	utils.Logf(h.context, "Writing to file at %s", path)
+	h.context.Logf("Writing to file at %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -344,7 +343,7 @@ func (h *Host) WriteFile(path string, content []byte) (int64, error) {
 
 // AppendFile append content to the file and returns the number of bytes appened and error if any
 func (h *Host) AppendFile(os, path string, content []byte) (int64, error) {
-	utils.Logf(h.context, "Appending to file at %s", path)
+	h.context.Logf("Appending to file at %s", path)
 	path = h.convertPathSeparator(path)
 	if os == "linux" {
 		return h.appendWithSudo(path, content)
@@ -354,7 +353,7 @@ func (h *Host) AppendFile(os, path string, content []byte) (int64, error) {
 
 // ReadDir returns list of directory entries in path
 func (h *Host) ReadDir(path string) ([]fs.DirEntry, error) {
-	utils.Logf(h.context, "Reading filesystem at %s", path)
+	h.context.Logf("Reading filesystem at %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 
@@ -398,7 +397,7 @@ func (h *Host) FindFiles(name string) ([]string, error) {
 // Lstat returns a FileInfo structure describing path.
 // if path is a symbolic link, the FileInfo structure describes the symbolic link.
 func (h *Host) Lstat(path string) (fs.FileInfo, error) {
-	utils.Logf(h.context, "Reading file info of %s", path)
+	h.context.Logf("Reading file info of %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -410,7 +409,7 @@ func (h *Host) Lstat(path string) (fs.FileInfo, error) {
 // If the path is already a directory, does nothing and returns nil.
 // Otherwise returns an error if any.
 func (h *Host) MkdirAll(path string) error {
-	utils.Logf(h.context, "Creating directory %s", path)
+	h.context.Logf("Creating directory %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -421,7 +420,7 @@ func (h *Host) MkdirAll(path string) error {
 // Remove removes the specified file or directory.
 // Returns an error if file or directory does not exist, or if the directory is not empty.
 func (h *Host) Remove(path string) error {
-	utils.Logf(h.context, "Removing %s", path)
+	h.context.Logf("Removing %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -432,7 +431,7 @@ func (h *Host) Remove(path string) error {
 // RemoveAll recursively removes all files/folders in the specified directory.
 // Returns an error if the directory does not exist.
 func (h *Host) RemoveAll(path string) error {
-	utils.Logf(h.context, "Removing all under %s", path)
+	h.context.Logf("Removing all under %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -442,7 +441,7 @@ func (h *Host) RemoveAll(path string) error {
 
 // DialPort creates a connection from the remote host to its `port`.
 func (h *Host) DialPort(port uint16) (net.Conn, error) {
-	utils.Logf(h.context, "Creating connection to host port %d", port)
+	h.context.Logf("Creating connection to host port %d", port)
 	address := fmt.Sprintf("127.0.0.1:%d", port)
 	protocol := "tcp"
 	// TODO add context to host

--- a/test/e2e-framework/testing/utils/e2e/client/host.go
+++ b/test/e2e-framework/testing/utils/e2e/client/host.go
@@ -208,7 +208,9 @@ func (h *sshExecutor) startAndReconnectOnError(command string) (*ssh.Session, io
 // MustExecute executes a command and requires no error.
 func (h *sshExecutor) MustExecute(command string, options ...ExecuteOption) string {
 	stdout, err := h.Execute(command, options...)
-	requireNoErr(err)
+	if err != nil {
+		h.context.FailNow("%v", err)
+	}
 	return stdout
 }
 
@@ -219,10 +221,13 @@ func (h *Host) CopyFileFromFS(fs fs.FS, src, dst string) {
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
 	file, err := fs.Open(src)
-	requireNoErr(err)
+	if err != nil {
+		h.context.FailNow("%v", err)
+	}
 	defer file.Close()
-	err = copyFileFromIoReader(sftpClient, file, dst)
-	requireNoErr(err)
+	if err = copyFileFromIoReader(sftpClient, file, dst); err != nil {
+		h.context.FailNow("%v", err)
+	}
 }
 
 // CopyFile creates a sftp session and copy a single file to the remote host through SSH
@@ -231,8 +236,9 @@ func (h *Host) CopyFile(src string, dst string) {
 	dst = h.convertPathSeparator(dst)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
-	err := copyFile(sftpClient, src, dst)
-	requireNoErr(err)
+	if err := copyFile(sftpClient, src, dst); err != nil {
+		h.context.FailNow("%v", err)
+	}
 }
 
 // CopyFolder create a sftp session and copy a folder to remote host through SSH
@@ -549,10 +555,15 @@ func (h *Host) appendWithSftp(path string, content []byte) (int64, error) {
 func (h *Host) getSFTPClient() *sftp.Client {
 	sftpClient, err := sftp.NewClient(h.client, sftp.UseConcurrentWrites(true))
 	if err != nil {
-		err = h.Reconnect()
-		requireNoErr(err)
+		if err = h.Reconnect(); err != nil {
+			h.context.FailNow("%v", err)
+			return nil
+		}
 		sftpClient, err = sftp.NewClient(h.client, sftp.UseConcurrentWrites(true))
-		requireNoErr(err)
+		if err != nil {
+			h.context.FailNow("%v", err)
+			return nil
+		}
 	}
 	return sftpClient
 }
@@ -560,14 +571,20 @@ func (h *Host) getSFTPClient() *sftp.Client {
 func (h *Host) getSFTPPrivilegedClient() *sftp.Client {
 	if h.privileged == nil {
 		// Some cloud provider don't provide SSH connection as root (GCP) required for these file operations
-		panic("can't SFTP files without a privileged SSH connection")
+		h.context.FailNow("can't SFTP files without a privileged SSH connection")
+		return nil
 	}
 	sftpClient, err := sftp.NewClient(h.privileged, sftp.UseConcurrentWrites(true))
 	if err != nil {
-		err = h.Reconnect()
-		requireNoErr(err)
+		if err = h.Reconnect(); err != nil {
+			h.context.FailNow("%v", err)
+			return nil
+		}
 		sftpClient, err = sftp.NewClient(h.privileged, sftp.UseConcurrentWrites(true))
-		requireNoErr(err)
+		if err != nil {
+			h.context.FailNow("%v", err)
+			return nil
+		}
 	}
 	return sftpClient
 }

--- a/test/new-e2e/tests/agent-subcommands/run_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/run_nix_test.go
@@ -73,7 +73,7 @@ func (s *linuxRunSuite) TestRunAgentCtrlC() {
 	// run command with timeout it
 	_, _, stdout, err := host.Start(cmd)
 	if err != nil {
-		s.FailNow("failed to start agent run command", err)
+		s.FailNow("failed to start agent run command: %v", err)
 	}
 
 	s.T().Log("Agent run command started")


### PR DESCRIPTION
## Summary

This PR decouples the e2e client layer from `*testing.T` so it can be used outside of `go test`.

## Motivation

`common.Context` exposed `T() *testing.T`, which forced every implementer to hold a test handle. This made it impossible to construct a `*components.RemoteHost` from non-test code (e.g. a CLI tool or a standalone binary).

## Approach

- Add `Logf(format string, args ...any)` to `common.Context` (keeping `T()` so existing test code is unaffected)
- Define a narrow `clientContext` interface in the client package (`Logf` + `SessionOutputDir` — no `T()`)
- Store `clientContext` in `Host`, `Docker`, and `agentCommandRunner` instead of `*testing.T`
- Rewrite `waitForAgentsReady` as a polling loop returning `error` (removes the `require.EventuallyWithT` dependency on `*testing.T`)
- Replace `require.NoError(t, err)` in must-style helpers with `panic(err)` — uniform pattern, no public API changes

`BaseSuite` gets a `Logf()` method delegating to `bs.T().Logf(...)`, so it satisfies both `common.Context` and `clientContext`. A non-test caller only needs to implement `Logf` + `SessionOutputDir`.