### PR TITLE
Strip port from grpc metrics peer tag

### DIFF
--- a/pkg/util/grpc/interceptors.go
+++ b/pkg/util/grpc/interceptors.go
@@ -7,6 +7,7 @@ package grpc
 
 import (
 	"context"
+	"net"
 	"strings"
 	"time"
 
@@ -31,10 +32,17 @@ func extractMethodInfo(fullMethod string) (serviceMethod string) {
 	return service + "/" + method
 }
 
-// extractPeerInfo extracts peer information from the context
+// extractPeerInfo extracts the peer host from the context, stripping the
+// ephemeral source port to keep tag cardinality bounded.
 func extractPeerInfo(ctx context.Context) string {
 	if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
-		return p.Addr.String()
+		addr := p.Addr.String()
+		// Strip the port for TCP/UDP addresses; Unix socket paths have no port
+		// and SplitHostPort will return an error, so we keep the full path.
+		if host, _, err := net.SplitHostPort(addr); err == nil {
+			return host
+		}
+		return addr
 	}
 	return "unknown"
 }


### PR DESCRIPTION
### What does this PR do?

Strips the source port from the `peer` tag on all gRPC metrics (`grpc.request_count`, `grpc.error_count`, `grpc.request_duration_seconds`, `grpc.payload_size_bytes`).

### Motivation

Previously `extractPeerInfo()` returned `p.Addr.String()` which includes the ephemeral OS-assigned source port (e.g. `127.0.0.1:54321`). Since that port changes on every new connection, the `peer` tag had unbounded cardinality, so each CLI invocation, stream, or reconnect created a new timeseries.

After this change the tag contains only the host/IP (e.g. `127.0.0.1`), keeping cardinality bounded while still being useful (e.g. identifying which node agent is calling the cluster-agent). Unix domain socket paths have no port component and are kept as-is.

### Describe how you validated your changes

CI

### Additional Notes
