### PR TITLE
discovery: remove CentOS 7 skip for Rust binary KMT tests on x86_64

### DIFF
--- a/pkg/discovery/module/impl_linux_test.go
+++ b/pkg/discovery/module/impl_linux_test.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -37,6 +39,7 @@ import (
 	spclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 func findService(pid int, services []model.Service) *model.Service {
@@ -77,6 +80,18 @@ func setupRustLibraryDiscoveryModule(t *testing.T) *testDiscoveryModule {
 
 func setupRustDiscoveryModule(t *testing.T) *testDiscoveryModule {
 	t.Helper()
+
+	// CentOS 7 arm64 is not a supported platform (arm64 support starts at CentOS 8)
+	// and the binary requires GLIBC_2.18 which is not available on CentOS 7 (glibc 2.17).
+	if runtime.GOARCH == "arm64" {
+		platform, err := kernel.Platform()
+		require.NoError(t, err)
+		platformVersion, err := kernel.PlatformVersion()
+		require.NoError(t, err)
+		if platform == "centos" && strings.HasPrefix(platformVersion, "7") {
+			t.Skip("system-probe-lite requires GLIBC_2.18 on arm64; CentOS 7 (glibc 2.17) is unsupported on arm64")
+		}
+	}
 
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)

--- a/pkg/discovery/module/impl_linux_test.go
+++ b/pkg/discovery/module/impl_linux_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -38,7 +37,6 @@ import (
 	spclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 func findService(pid int, services []model.Service) *model.Service {
@@ -79,16 +77,6 @@ func setupRustLibraryDiscoveryModule(t *testing.T) *testDiscoveryModule {
 
 func setupRustDiscoveryModule(t *testing.T) *testDiscoveryModule {
 	t.Helper()
-
-	// Skip on CentOS 7 due to Rust binary not being statically linked
-	platform, err := kernel.Platform()
-	require.NoError(t, err)
-	platformVersion, err := kernel.PlatformVersion()
-	require.NoError(t, err)
-
-	if platform == "centos" && strings.HasPrefix(platformVersion, "7") {
-		t.Skip("Skipping Rust binary test on CentOS 7 due to glibc compatibility issues with non-static binary")
-	}
 
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)


### PR DESCRIPTION
## What does this PR do?

Replaces the blanket CentOS 7 skip for Rust binary tests in KMT (added in #44635) with a narrower skip scoped to **arm64 + CentOS 7 only**.

**x86_64 CentOS 7** — the Bazel hermetic GCC 11.4.0 x86\_64 toolchain now produces a binary compatible with CentOS 7's glibc 2.17. The skip is removed for x64.

**arm64 CentOS 7** — the arm64 Bazel toolchain (GCC 12.3.0) links \`system-probe-lite\` against \`__cxa_thread_atexit_impl\` (GLIBC_2.18), which is absent on CentOS 7 (glibc 2.17). However, CentOS 7 arm64 is **not a supported platform** — arm64 support starts at CentOS 8 per https://docs.datadoghq.com/agent/supported_platforms/?tab=linux. The skip is retained for this unsupported combination with an explanatory comment.

Investigation confirmed via [DSCVR-315](https://datadoghq.atlassian.net/browse/DSCVR-315):
- x64 CentOS 7 KMT tests pass in CI
- arm64 CentOS 7 KMT tests fail with relocation error (expected; unsupported platform)
- Docker test on actual CentOS 7 arm64 container reproduces the same failure

## Motivation

https://datadoghq.atlassian.net/browse/DSCVR-315

## Describe how you validated your changes

CI (KMT on CentOS 7 x86\_64 and arm64)

[DSCVR-315]: https://datadoghq.atlassian.net/browse/DSCVR-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ