### PR TITLE
feat(ssi): add APM injection observability annotations

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation/annotation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation/annotation.go
@@ -68,6 +68,48 @@ const (
 	// LibraryCanonicalVersion is set with the actual version of the library as opposed to a resolved digest.
 	// Example value: 3.19.2
 	LibraryCanonicalVersion LibraryAnnotationFormat = "internal.apm.datadoghq.com/%s-canonical-version"
+	// EffectiveInjectionMode is set with the injection mode that was actually used by the webhook,
+	// regardless of the configured or requested mode. For "auto" mode, this reflects the resolved mode.
+	// Example value: csi
+	EffectiveInjectionMode = "internal.apm.datadoghq.com/effective-injection-mode"
+	// CSIDriverStatus is set with the observed state of the Datadog CSI driver at
+	// injection time. It is only present when CSI driver detection is active
+	// (i.e. CSIDriverWatcher is non-nil). See the CSIDriverStatus* constants below.
+	CSIDriverStatus = "internal.apm.datadoghq.com/csi-driver-status"
+	// InjectionStatus is set with the overall outcome of the APM injection attempt.
+	// See the InjectionStatus* constants below for possible values.
+	InjectionStatus = "internal.apm.datadoghq.com/injection-status"
+	// InjectedLibraries is set with a JSON array of components effectively injected into the pod.
+	// Each entry has at minimum "name" (component name or language) and "image" (full OCI image reference).
+	// Example value: [{"name":"injector","image":"gcr.io/datadoghq/apm-inject:0.52.0"},{"name":"java","image":"gcr.io/datadoghq/dd-lib-java-init:1.30.0"}]
+	InjectedLibraries = "internal.apm.datadoghq.com/injected-libraries"
+)
+
+// CSIDriverStatus annotation values.
+const (
+	// CSIDriverStatusAPMEnabled means the Datadog CSI driver is installed and
+	// has advertised APM SSI support (csi.datadoghq.com/apm-enabled="true").
+	CSIDriverStatusAPMEnabled = "apm-enabled"
+	// CSIDriverStatusAPMDisabled means the Datadog CSI driver is installed but
+	// APM SSI support is not advertised — add the annotation to the CSIDriver object to enable it.
+	CSIDriverStatusAPMDisabled = "apm-disabled"
+	// CSIDriverStatusNotInstalled means the Datadog CSI driver object was not
+	// found in the cluster.
+	CSIDriverStatusNotInstalled = "not-installed"
+)
+
+// InjectionStatus annotation values.
+const (
+	// InjectionStatusInjected means the injector and all requested libraries were successfully injected.
+	InjectionStatusInjected = "injected"
+	// InjectionStatusPartial means the injector succeeded but at least one library was skipped
+	// (e.g. unsupported language).
+	InjectionStatusPartial = "partial"
+	// InjectionStatusSkipped means injection was skipped before it started
+	// (e.g. insufficient pod resources, incompatible runtime, or disabled injection mode).
+	InjectionStatusSkipped = "skipped"
+	// InjectionStatusError means a fatal error prevented the injector from running.
+	InjectionStatusError = "error"
 )
 
 // LibraryAnnotationFormat is a helper type to format an annotation with a language.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/auto.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/auto.go
@@ -55,6 +55,12 @@ func pickAutoProvider(cfg LibraryInjectionConfig) LibraryInjectionProvider {
 	return NewInitContainerProvider(cfg)
 }
 
+// GetName returns the effective injection mode of the resolved concrete provider,
+// suffixed with " (auto)" to indicate that the mode was automatically selected.
+func (p *AutoProvider) GetName() string {
+	return p.realProvider.GetName() + " (auto)"
+}
+
 // InjectInjector mutates the pod to add the APM injector.
 func (p *AutoProvider) InjectInjector(pod *corev1.Pod, cfg InjectorConfig) MutationResult {
 	return p.realProvider.InjectInjector(pod, cfg)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/auto_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/auto_test.go
@@ -24,10 +24,12 @@ const datadogCSIDriverName = "k8s.csi.datadoghq.com"
 // used in unit tests so we can drive the AutoProvider decision tree without
 // spinning up a workloadmeta subscription.
 type fakeCSIDriverWatcher struct {
+	registered bool
 	apmEnabled bool
 }
 
-func (f fakeCSIDriverWatcher) IsAPMEnabled() bool { return f.apmEnabled }
+func (f fakeCSIDriverWatcher) IsRegistered() bool { return f.registered }
+func (f fakeCSIDriverWatcher) IsAPMEnabled() bool { return f.registered && f.apmEnabled }
 
 func newPod() *corev1.Pod {
 	return &corev1.Pod{
@@ -61,7 +63,7 @@ func TestAutoProvider_PicksCSIWhenWatcherReportsAPMEnabled(t *testing.T) {
 	pod := newPod()
 
 	provider := libraryinjection.NewAutoProvider(libraryinjection.LibraryInjectionConfig{
-		CSIDriverWatcher: fakeCSIDriverWatcher{apmEnabled: true},
+		CSIDriverWatcher: fakeCSIDriverWatcher{registered: true, apmEnabled: true},
 	})
 
 	result := provider.InjectInjector(pod, injectorConfig())
@@ -83,7 +85,7 @@ func TestAutoProvider_FallsBackToInitContainerWhenWatcherReportsAPMDisabled(t *t
 	pod := newPod()
 
 	provider := libraryinjection.NewAutoProvider(libraryinjection.LibraryInjectionConfig{
-		CSIDriverWatcher: fakeCSIDriverWatcher{apmEnabled: false},
+		CSIDriverWatcher: fakeCSIDriverWatcher{registered: true, apmEnabled: false},
 	})
 
 	result := provider.InjectInjector(pod, injectorConfig())

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/csi.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/csi.go
@@ -50,6 +50,11 @@ func NewCSIProvider(cfg LibraryInjectionConfig) *CSIProvider {
 	}
 }
 
+// GetName returns the injection mode for this provider.
+func (p *CSIProvider) GetName() string {
+	return string(InjectionModeCSI)
+}
+
 // InjectInjector mutates the pod to add the APM injector using CSI volumes.
 func (p *CSIProvider) InjectInjector(pod *corev1.Pod, cfg InjectorConfig) MutationResult {
 	patcher := NewPodPatcher(pod, p.cfg.ContainerFilter)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/csi_watcher.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/csi_watcher.go
@@ -30,9 +30,12 @@ const (
 // admission controller hot path.
 //
 // Implementations must be safe to call from multiple goroutines without
-// additional synchronisation: the admission webhook calls IsAPMEnabled once
+// additional synchronisation: the admission webhook calls these methods once
 // per pod mutation, so the read path must be lock-free.
 type CSIDriverWatcher interface {
+	// IsRegistered returns true when the Datadog CSI driver object exists in
+	// the cluster, regardless of whether APM SSI support is advertised.
+	IsRegistered() bool
 	// IsAPMEnabled returns true when the Datadog CSI driver is registered
 	// in the cluster and has explicitly advertised support for APM SSI
 	// volumes via the csi.datadoghq.com/apm-enabled="true" annotation.
@@ -77,6 +80,11 @@ func NewCSIDriverWatcher(ctx context.Context, wmeta workloadmeta.Component) CSID
 
 	go w.run(ctx, wmeta)
 	return w
+}
+
+// IsRegistered implements CSIDriverWatcher.
+func (w *csiDriverWatcher) IsRegistered() bool {
+	return w.state.Load().registered
 }
 
 // IsAPMEnabled implements CSIDriverWatcher.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/image_volume.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/image_volume.go
@@ -34,6 +34,11 @@ func NewImageVolumeProvider(cfg LibraryInjectionConfig) *ImageVolumeProvider {
 	}
 }
 
+// GetName returns the injection mode for this provider.
+func (p *ImageVolumeProvider) GetName() string {
+	return string(InjectionModeImageVolume)
+}
+
 func (p *ImageVolumeProvider) InjectInjector(pod *corev1.Pod, cfg InjectorConfig) MutationResult {
 	// Validate that the pod has sufficient resources for the micro init container.
 	result, err := ComputeInitContainerResourceRequirementsForInitContainer(pod, p.cfg.DefaultResourceRequirements, InjectLDPreloadInitContainerName)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/init_container.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/init_container.go
@@ -35,6 +35,11 @@ func NewInitContainerProvider(cfg LibraryInjectionConfig) *InitContainerProvider
 	}
 }
 
+// GetName returns the injection mode for this provider.
+func (p *InitContainerProvider) GetName() string {
+	return string(InjectionModeInitContainer)
+}
+
 // InjectInjector mutates the pod to add the APM injector using init containers.
 func (p *InitContainerProvider) InjectInjector(pod *corev1.Pod, cfg InjectorConfig) MutationResult {
 	// First, validate that the pod has sufficient resources

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator.go
@@ -97,10 +97,8 @@ func InjectAPMLibraries(pod *corev1.Pod, cfg LibraryInjectionConfig) error {
 
 	// Inject language-specific libraries and collect entries for the annotation.
 	// All attempted libraries are recorded, regardless of outcome.
-	// partial is set to true as soon as any library ends up with a non-injected status.
+	// injectionErr is non-nil as soon as any library ends up with a non-injected status.
 	injectedEntries := []injectedLibraryEntry{{Name: "injector", Image: cfg.Injector.Package.FullRef(), Status: string(MutationStatusInjected)}}
-	var lastError error
-	var partial bool
 	for _, lib := range cfg.Libraries {
 		injectedEntries = append(injectedEntries, injectedLibraryEntry{Name: lib.Language, Image: lib.Package.FullRef()})
 		entry := &injectedEntries[len(injectedEntries)-1]
@@ -108,9 +106,8 @@ func InjectAPMLibraries(pod *corev1.Pod, cfg LibraryInjectionConfig) error {
 		// Validate language before injection
 		if !IsLanguageSupported(lib.Language) {
 			metrics.LibInjectionErrors.Inc(lib.Language, strconv.FormatBool(cfg.AutoDetected), cfg.InjectionType)
-			lastError = fmt.Errorf("language %s is not supported", lib.Language)
+			injectionErr = fmt.Errorf("language %s is not supported", lib.Language)
 			entry.Status = string(MutationStatusSkipped)
-			partial = true
 			continue
 		}
 
@@ -129,8 +126,7 @@ func InjectAPMLibraries(pod *corev1.Pod, cfg LibraryInjectionConfig) error {
 
 		if libResult.Status == MutationStatusError {
 			metrics.LibInjectionErrors.Inc(lib.Language, strconv.FormatBool(cfg.AutoDetected), cfg.InjectionType)
-			lastError = fmt.Errorf("library injection failed for %s: %w", lib.Language, libResult.Err)
-			partial = true
+			injectionErr = fmt.Errorf("library injection failed for %s: %w", lib.Language, libResult.Err)
 		}
 	}
 
@@ -140,13 +136,13 @@ func InjectAPMLibraries(pod *corev1.Pod, cfg LibraryInjectionConfig) error {
 		log.Errorf("Failed to marshal injected libraries annotation for pod %s: %v", mutatecommon.PodString(pod), err)
 	}
 
-	if partial {
+	if injectionErr != nil {
 		injectionStatus = annotation.InjectionStatusPartial
 	} else {
 		injectionStatus = annotation.InjectionStatusInjected
 	}
 
-	return lastError
+	return injectionErr
 }
 
 // injectAPMEnvVars injects APM environment variables (LD_PRELOAD, etc.) into application containers.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator.go
@@ -8,6 +8,7 @@
 package libraryinjection
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -20,6 +21,17 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// injectedLibraryEntry represents a single component injected into a pod,
+// stored in the InjectedLibraries annotation.
+type injectedLibraryEntry struct {
+	// Name is the component name: "injector" or a language (e.g. "java", "python").
+	Name string `json:"name"`
+	// Image is the full OCI image reference used for injection.
+	Image string `json:"image"`
+	// Status is the outcome of the injection attempt: "injected", "skipped", or "error".
+	Status string `json:"status"`
+}
+
 // InjectAPMLibraries performs the complete APM injection into a pod.
 // This includes:
 // 1. Injecting the APM injector (volumes, mounts, and provider-specific resources)
@@ -28,9 +40,36 @@ import (
 //
 // Returns an error if the injection fails.
 func InjectAPMLibraries(pod *corev1.Pod, cfg LibraryInjectionConfig) error {
+	injectionStatus := annotation.InjectionStatusError
+	var injectionErr error
+	defer func() {
+		if injectionErr != nil {
+			annotation.Set(pod, annotation.InjectionError, injectionErr.Error())
+		}
+		annotation.Set(pod, annotation.InjectionStatus, injectionStatus)
+	}()
+
+	// Record the observed state of the Datadog CSI driver when detection is active.
+	// This is set regardless of the configured injection mode so that an operator
+	// can answer "is the driver installed?" and "is APM support enabled?" from the
+	// pod annotations alone.
+	if w := cfg.CSIDriverWatcher; w != nil {
+		var csiStatus string
+		switch {
+		case w.IsAPMEnabled():
+			csiStatus = annotation.CSIDriverStatusAPMEnabled
+		case w.IsRegistered():
+			csiStatus = annotation.CSIDriverStatusAPMDisabled
+		default:
+			csiStatus = annotation.CSIDriverStatusNotInstalled
+		}
+		annotation.Set(pod, annotation.CSIDriverStatus, csiStatus)
+	}
+
 	// Select the provider based on the injection mode (annotation or default)
 	factory := NewProviderFactory(InjectionMode(cfg.InjectionMode))
 	provider := factory.GetProviderForPod(pod, cfg)
+	annotation.Set(pod, annotation.EffectiveInjectionMode, provider.GetName())
 
 	// Inject the APM injector
 	injectorResult := provider.InjectInjector(pod, cfg.Injector)
@@ -38,11 +77,13 @@ func InjectAPMLibraries(pod *corev1.Pod, cfg LibraryInjectionConfig) error {
 	// Handle injector result
 	switch injectorResult.Status {
 	case MutationStatusSkipped:
-		annotation.Set(pod, annotation.InjectionError, injectorResult.Err.Error())
+		injectionErr = injectorResult.Err
+		injectionStatus = annotation.InjectionStatusSkipped
 		return nil
 	case MutationStatusError:
 		metrics.LibInjectionErrors.Inc("injector", strconv.FormatBool(cfg.AutoDetected), cfg.InjectionType)
 		log.Errorf("Cannot inject library injector into pod %s: %v", mutatecommon.PodString(pod), injectorResult.Err)
+		injectionErr = injectorResult.Err
 		return fmt.Errorf("injector injection failed: %w", injectorResult.Err)
 	}
 
@@ -54,13 +95,22 @@ func InjectAPMLibraries(pod *corev1.Pod, cfg LibraryInjectionConfig) error {
 	// Inject APM environment variables to application containers
 	injectAPMEnvVars(pod, cfg)
 
-	// Inject language-specific libraries
+	// Inject language-specific libraries and collect entries for the annotation.
+	// All attempted libraries are recorded, regardless of outcome.
+	// partial is set to true as soon as any library ends up with a non-injected status.
+	injectedEntries := []injectedLibraryEntry{{Name: "injector", Image: cfg.Injector.Package.FullRef(), Status: string(MutationStatusInjected)}}
 	var lastError error
+	var partial bool
 	for _, lib := range cfg.Libraries {
+		injectedEntries = append(injectedEntries, injectedLibraryEntry{Name: lib.Language, Image: lib.Package.FullRef()})
+		entry := &injectedEntries[len(injectedEntries)-1]
+
 		// Validate language before injection
 		if !IsLanguageSupported(lib.Language) {
 			metrics.LibInjectionErrors.Inc(lib.Language, strconv.FormatBool(cfg.AutoDetected), cfg.InjectionType)
 			lastError = fmt.Errorf("language %s is not supported", lib.Language)
+			entry.Status = string(MutationStatusSkipped)
+			partial = true
 			continue
 		}
 
@@ -69,6 +119,7 @@ func InjectAPMLibraries(pod *corev1.Pod, cfg LibraryInjectionConfig) error {
 
 		libResult := provider.InjectLibrary(pod, lib)
 		injected := libResult.Status == MutationStatusInjected
+		entry.Status = string(libResult.Status)
 
 		metrics.LibInjectionAttempts.Inc(lib.Language, strconv.FormatBool(injected), strconv.FormatBool(cfg.AutoDetected), cfg.InjectionType)
 
@@ -79,7 +130,20 @@ func InjectAPMLibraries(pod *corev1.Pod, cfg LibraryInjectionConfig) error {
 		if libResult.Status == MutationStatusError {
 			metrics.LibInjectionErrors.Inc(lib.Language, strconv.FormatBool(cfg.AutoDetected), cfg.InjectionType)
 			lastError = fmt.Errorf("library injection failed for %s: %w", lib.Language, libResult.Err)
+			partial = true
 		}
+	}
+
+	if entriesJSON, err := json.Marshal(injectedEntries); err == nil {
+		annotation.Set(pod, annotation.InjectedLibraries, string(entriesJSON))
+	} else {
+		log.Errorf("Failed to marshal injected libraries annotation for pod %s: %v", mutatecommon.PodString(pod), err)
+	}
+
+	if partial {
+		injectionStatus = annotation.InjectionStatusPartial
+	} else {
+		injectionStatus = annotation.InjectionStatusInjected
 	}
 
 	return lastError

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator_test.go
@@ -8,8 +8,10 @@
 package libraryinjection_test
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +20,398 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection"
 )
+
+// libraryAnnotationEntry mirrors the unexported injectedLibraryEntry struct
+// for assertion purposes in tests.
+type libraryAnnotationEntry struct {
+	Name   string `json:"name"`
+	Image  string `json:"image"`
+	Status string `json:"status"`
+}
+
+func parseInjectedLibraries(t *testing.T, pod *corev1.Pod) []libraryAnnotationEntry {
+	t.Helper()
+	val, ok := annotation.Get(pod, annotation.InjectedLibraries)
+	require.True(t, ok, "InjectedLibraries annotation should be set")
+	var entries []libraryAnnotationEntry
+	require.NoError(t, json.Unmarshal([]byte(val), &entries))
+	return entries
+}
+
+func javaLib() libraryinjection.LibraryConfig {
+	return libraryinjection.LibraryConfig{
+		Language: "java",
+		Package:  libraryinjection.NewLibraryImageFromFullRef("gcr.io/datadoghq/dd-lib-java-init:1.30.0", "1.30.0"),
+	}
+}
+
+// TestGetName verifies that each provider reports its effective injection mode correctly.
+func TestGetName(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider libraryinjection.LibraryInjectionProvider
+		expected string
+	}{
+		{
+			name:     "InitContainerProvider",
+			provider: libraryinjection.NewInitContainerProvider(libraryinjection.LibraryInjectionConfig{}),
+			expected: "init_container",
+		},
+		{
+			name:     "CSIProvider",
+			provider: libraryinjection.NewCSIProvider(libraryinjection.LibraryInjectionConfig{}),
+			expected: "csi",
+		},
+		{
+			name:     "ImageVolumeProvider",
+			provider: libraryinjection.NewImageVolumeProvider(libraryinjection.LibraryInjectionConfig{}),
+			expected: "image_volume",
+		},
+		{
+			name: "AutoProvider resolves to CSI when driver is available",
+			provider: libraryinjection.NewAutoProvider(libraryinjection.LibraryInjectionConfig{
+				CSIDriverWatcher: fakeCSIDriverWatcher{registered: true, apmEnabled: true},
+			}),
+			expected: "csi (auto)",
+		},
+		{
+			name: "AutoProvider resolves to init_container when driver is unavailable",
+			provider: libraryinjection.NewAutoProvider(libraryinjection.LibraryInjectionConfig{
+				CSIDriverWatcher: fakeCSIDriverWatcher{registered: true, apmEnabled: false},
+			}),
+			expected: "init_container (auto)",
+		},
+		{
+			name: "AutoProvider resolves to init_container when watcher is nil",
+			provider: libraryinjection.NewAutoProvider(libraryinjection.LibraryInjectionConfig{
+				CSIDriverWatcher: nil,
+			}),
+			expected: "init_container (auto)",
+		},
+		{
+			name: "NoopProvider returns disabled",
+			provider: func() libraryinjection.LibraryInjectionProvider {
+				factory := libraryinjection.NewProviderFactory(libraryinjection.InjectionModeAuto)
+				pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					annotation.InjectionMode: "image_volume",
+				}}}
+				return factory.GetProviderForPod(pod, libraryinjection.LibraryInjectionConfig{
+					KubeServerVersion: &version.Info{GitVersion: "v1.30.9"},
+				})
+			}(),
+			expected: "disabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.provider.GetName())
+		})
+	}
+}
+
+// TestInjectAPMLibraries_Annotations_InitContainer verifies the annotations
+// written for a successful init_container injection.
+func TestInjectAPMLibraries_Annotations_InitContainer(t *testing.T) {
+	pod := newPod()
+
+	err := libraryinjection.InjectAPMLibraries(pod, libraryinjection.LibraryInjectionConfig{
+		InjectionMode: string(libraryinjection.InjectionModeInitContainer),
+		Injector:      injectorConfig(),
+		Libraries:     []libraryinjection.LibraryConfig{javaLib()},
+	})
+	require.NoError(t, err)
+
+	mode, ok := annotation.Get(pod, annotation.EffectiveInjectionMode)
+	require.True(t, ok)
+	assert.Equal(t, "init_container", mode)
+
+	status, ok := annotation.Get(pod, annotation.InjectionStatus)
+	require.True(t, ok)
+	assert.Equal(t, annotation.InjectionStatusInjected, status)
+
+	entries := parseInjectedLibraries(t, pod)
+	require.Len(t, entries, 2)
+	assert.Equal(t, libraryAnnotationEntry{Name: "injector", Image: "gcr.io/datadoghq/apm-inject:0.52.0", Status: "injected"}, entries[0])
+	assert.Equal(t, libraryAnnotationEntry{Name: "java", Image: "gcr.io/datadoghq/dd-lib-java-init:1.30.0", Status: "injected"}, entries[1])
+}
+
+// TestInjectAPMLibraries_Annotations_CSI verifies the annotations written
+// for a successful CSI injection.
+func TestInjectAPMLibraries_Annotations_CSI(t *testing.T) {
+	pod := newPod()
+
+	err := libraryinjection.InjectAPMLibraries(pod, libraryinjection.LibraryInjectionConfig{
+		InjectionMode: string(libraryinjection.InjectionModeCSI),
+		Injector:      injectorConfig(),
+		Libraries:     []libraryinjection.LibraryConfig{javaLib()},
+	})
+	require.NoError(t, err)
+
+	mode, ok := annotation.Get(pod, annotation.EffectiveInjectionMode)
+	require.True(t, ok)
+	assert.Equal(t, "csi", mode)
+
+	entries := parseInjectedLibraries(t, pod)
+	require.Len(t, entries, 2)
+	assert.Equal(t, libraryAnnotationEntry{Name: "injector", Image: "gcr.io/datadoghq/apm-inject:0.52.0", Status: "injected"}, entries[0])
+	assert.Equal(t, libraryAnnotationEntry{Name: "java", Image: "gcr.io/datadoghq/dd-lib-java-init:1.30.0", Status: "injected"}, entries[1])
+}
+
+// TestInjectAPMLibraries_Annotations_Auto_CSI verifies that auto mode resolving
+// to CSI reports "csi (auto)" as the effective injection mode.
+func TestInjectAPMLibraries_Annotations_Auto_CSI(t *testing.T) {
+	pod := newPod()
+
+	err := libraryinjection.InjectAPMLibraries(pod, libraryinjection.LibraryInjectionConfig{
+		InjectionMode:    string(libraryinjection.InjectionModeAuto),
+		CSIDriverWatcher: fakeCSIDriverWatcher{registered: true, apmEnabled: true},
+		Injector:         injectorConfig(),
+		Libraries:        []libraryinjection.LibraryConfig{javaLib()},
+	})
+	require.NoError(t, err)
+
+	mode, ok := annotation.Get(pod, annotation.EffectiveInjectionMode)
+	require.True(t, ok)
+	assert.Equal(t, "csi (auto)", mode)
+}
+
+// TestInjectAPMLibraries_Annotations_Auto_InitContainer verifies that auto mode
+// falling back to init_container reports "init_container (auto)".
+func TestInjectAPMLibraries_Annotations_Auto_InitContainer(t *testing.T) {
+	pod := newPod()
+
+	err := libraryinjection.InjectAPMLibraries(pod, libraryinjection.LibraryInjectionConfig{
+		InjectionMode:    string(libraryinjection.InjectionModeAuto),
+		CSIDriverWatcher: fakeCSIDriverWatcher{registered: true, apmEnabled: false},
+		Injector:         injectorConfig(),
+		Libraries:        []libraryinjection.LibraryConfig{javaLib()},
+	})
+	require.NoError(t, err)
+
+	mode, ok := annotation.Get(pod, annotation.EffectiveInjectionMode)
+	require.True(t, ok)
+	assert.Equal(t, "init_container (auto)", mode)
+}
+
+// TestInjectAPMLibraries_Annotations_Skipped verifies that when injection is
+// skipped (e.g. incompatible k8s version), EffectiveInjectionMode is still set
+// but InjectedLibraries is not, and InjectionStatus is "skipped".
+func TestInjectAPMLibraries_Annotations_Skipped(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotation.InjectionMode: "image_volume",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app"}},
+		},
+	}
+
+	err := libraryinjection.InjectAPMLibraries(pod, libraryinjection.LibraryInjectionConfig{
+		InjectionMode:     "auto",
+		KubeServerVersion: &version.Info{GitVersion: "v1.30.9"},
+		Injector:          injectorConfig(),
+	})
+	require.NoError(t, err)
+
+	// EffectiveInjectionMode is set immediately after provider selection, even on skip.
+	_, ok := annotation.Get(pod, annotation.EffectiveInjectionMode)
+	assert.True(t, ok, "EffectiveInjectionMode should be set even when injection is skipped")
+
+	// InjectedLibraries must NOT be set: nothing was actually injected.
+	_, ok = annotation.Get(pod, annotation.InjectedLibraries)
+	assert.False(t, ok, "InjectedLibraries should not be set when injection is skipped")
+
+	// InjectionStatus must be "skipped".
+	status, ok := annotation.Get(pod, annotation.InjectionStatus)
+	require.True(t, ok, "InjectionStatus should be set when injection is skipped")
+	assert.Equal(t, annotation.InjectionStatusSkipped, status)
+
+	// The existing error annotation must still be present.
+	val, ok := annotation.Get(pod, annotation.InjectionError)
+	require.True(t, ok)
+	require.Contains(t, val, "requires kubernetes version")
+}
+
+// TestInjectAPMLibraries_InjectedLibraries_UnsupportedLanguage verifies that
+// an unsupported language gets a "skipped" status in the InjectedLibraries annotation
+// and that the global InjectionStatus is "partial".
+func TestInjectAPMLibraries_InjectedLibraries_UnsupportedLanguage(t *testing.T) {
+	pod := newPod()
+
+	err := libraryinjection.InjectAPMLibraries(pod, libraryinjection.LibraryInjectionConfig{
+		InjectionMode: string(libraryinjection.InjectionModeCSI),
+		Injector:      injectorConfig(),
+		Libraries: []libraryinjection.LibraryConfig{
+			javaLib(),
+			{
+				Language: "cobol",
+				Package:  libraryinjection.NewLibraryImageFromFullRef("gcr.io/datadoghq/dd-lib-cobol-init:1.0.0", "1.0.0"),
+			},
+		},
+	})
+	// InjectAPMLibraries returns a non-nil error for unsupported languages.
+	require.Error(t, err)
+
+	status, ok := annotation.Get(pod, annotation.InjectionStatus)
+	require.True(t, ok)
+	assert.Equal(t, annotation.InjectionStatusPartial, status)
+
+	entries := parseInjectedLibraries(t, pod)
+	require.Len(t, entries, 3)
+	assert.Equal(t, libraryAnnotationEntry{Name: "injector", Image: "gcr.io/datadoghq/apm-inject:0.52.0", Status: "injected"}, entries[0])
+	assert.Equal(t, libraryAnnotationEntry{Name: "java", Image: "gcr.io/datadoghq/dd-lib-java-init:1.30.0", Status: "injected"}, entries[1])
+	assert.Equal(t, libraryAnnotationEntry{Name: "cobol", Image: "gcr.io/datadoghq/dd-lib-cobol-init:1.0.0", Status: "skipped"}, entries[2])
+}
+
+// TestInjectAPMLibraries_InjectionStatus verifies the global InjectionStatus annotation
+// across the full range of outcomes.
+func TestInjectAPMLibraries_InjectionStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            libraryinjection.LibraryInjectionConfig
+		pod            *corev1.Pod
+		wantErr        bool
+		wantStatus     string
+		wantStatusSet  bool
+	}{
+		{
+			name: "all libraries injected → injected",
+			pod:  newPod(),
+			cfg: libraryinjection.LibraryInjectionConfig{
+				InjectionMode: string(libraryinjection.InjectionModeCSI),
+				Injector:      injectorConfig(),
+				Libraries:     []libraryinjection.LibraryConfig{javaLib()},
+			},
+			wantStatus:    annotation.InjectionStatusInjected,
+			wantStatusSet: true,
+		},
+		{
+			name: "no libraries configured → injected (injector OK, nothing else requested)",
+			pod:  newPod(),
+			cfg: libraryinjection.LibraryInjectionConfig{
+				InjectionMode: string(libraryinjection.InjectionModeCSI),
+				Injector:      injectorConfig(),
+				Libraries:     nil,
+			},
+			wantStatus:    annotation.InjectionStatusInjected,
+			wantStatusSet: true,
+		},
+		{
+			name: "only unsupported languages → partial",
+			pod:  newPod(),
+			cfg: libraryinjection.LibraryInjectionConfig{
+				InjectionMode: string(libraryinjection.InjectionModeCSI),
+				Injector:      injectorConfig(),
+				Libraries: []libraryinjection.LibraryConfig{
+					{
+						Language: "cobol",
+						Package:  libraryinjection.NewLibraryImageFromFullRef("gcr.io/datadoghq/dd-lib-cobol-init:1.0.0", "1.0.0"),
+					},
+				},
+			},
+			wantErr:       true,
+			wantStatus:    annotation.InjectionStatusPartial,
+			wantStatusSet: true,
+		},
+		{
+			name: "injector skipped (incompatible k8s version) → skipped",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotation.InjectionMode: string(libraryinjection.InjectionModeImageVolume),
+					},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+			},
+			cfg: libraryinjection.LibraryInjectionConfig{
+				InjectionMode:     string(libraryinjection.InjectionModeAuto),
+				KubeServerVersion: &version.Info{GitVersion: "v1.30.9"},
+				Injector:          injectorConfig(),
+				Libraries:         []libraryinjection.LibraryConfig{javaLib()},
+			},
+			wantStatus:    annotation.InjectionStatusSkipped,
+			wantStatusSet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := libraryinjection.InjectAPMLibraries(tt.pod, tt.cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			status, ok := annotation.Get(tt.pod, annotation.InjectionStatus)
+			require.Equal(t, tt.wantStatusSet, ok, "InjectionStatus annotation presence mismatch")
+			if tt.wantStatusSet {
+				assert.Equal(t, tt.wantStatus, status)
+			}
+		})
+	}
+}
+
+// TestInjectAPMLibraries_CSIDriverStatus verifies that the csi-driver-status annotation
+// reflects the three possible states of the Datadog CSI driver.
+func TestInjectAPMLibraries_CSIDriverStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		watcher        libraryinjection.CSIDriverWatcher
+		wantStatus     string
+		wantAnnotation bool
+	}{
+		{
+			name:           "driver installed and APM enabled → apm-enabled",
+			watcher:        fakeCSIDriverWatcher{registered: true, apmEnabled: true},
+			wantStatus:     annotation.CSIDriverStatusAPMEnabled,
+			wantAnnotation: true,
+		},
+		{
+			name:           "driver installed but APM disabled → apm-disabled",
+			watcher:        fakeCSIDriverWatcher{registered: true, apmEnabled: false},
+			wantStatus:     annotation.CSIDriverStatusAPMDisabled,
+			wantAnnotation: true,
+		},
+		{
+			name:           "driver not installed → not-installed",
+			watcher:        fakeCSIDriverWatcher{registered: false, apmEnabled: false},
+			wantStatus:     annotation.CSIDriverStatusNotInstalled,
+			wantAnnotation: true,
+		},
+		{
+			name:           "watcher nil (CSI detection disabled) → annotation absent",
+			watcher:        nil,
+			wantAnnotation: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := newPod()
+			err := libraryinjection.InjectAPMLibraries(pod, libraryinjection.LibraryInjectionConfig{
+				InjectionMode:    string(libraryinjection.InjectionModeCSI),
+				CSIDriverWatcher: tt.watcher,
+				Injector:         injectorConfig(),
+				Libraries:        []libraryinjection.LibraryConfig{javaLib()},
+			})
+			require.NoError(t, err)
+
+			status, ok := annotation.Get(pod, annotation.CSIDriverStatus)
+			require.Equal(t, tt.wantAnnotation, ok, "CSIDriverStatus annotation presence mismatch")
+			if tt.wantAnnotation {
+				assert.Equal(t, tt.wantStatus, status)
+			}
+		})
+	}
+}
 
 func TestInjectAPMLibraries_StopsGracefullyWhenProviderUnavailable(t *testing.T) {
 	pod := &corev1.Pod{

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator_test.go
@@ -274,12 +274,12 @@ func TestInjectAPMLibraries_InjectedLibraries_UnsupportedLanguage(t *testing.T) 
 // across the full range of outcomes.
 func TestInjectAPMLibraries_InjectionStatus(t *testing.T) {
 	tests := []struct {
-		name           string
-		cfg            libraryinjection.LibraryInjectionConfig
-		pod            *corev1.Pod
-		wantErr        bool
-		wantStatus     string
-		wantStatusSet  bool
+		name          string
+		cfg           libraryinjection.LibraryInjectionConfig
+		pod           *corev1.Pod
+		wantErr       bool
+		wantStatus    string
+		wantStatusSet bool
 	}{
 		{
 			name: "all libraries injected → injected",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator_test.go
@@ -254,7 +254,9 @@ func TestInjectAPMLibraries_InjectedLibraries_UnsupportedLanguage(t *testing.T) 
 			},
 		},
 	})
-	// InjectAPMLibraries returns a non-nil error for unsupported languages.
+	// InjectAPMLibraries still reports per-library failures via the returned error.
+	// It is the caller's responsibility (apmInjectionMutator) to absorb it so the
+	// patch is applied. Here we verify the error is present and the annotations are set.
 	require.Error(t, err)
 
 	status, ok := annotation.Get(pod, annotation.InjectionStatus)
@@ -314,6 +316,8 @@ func TestInjectAPMLibraries_InjectionStatus(t *testing.T) {
 					},
 				},
 			},
+			// InjectAPMLibraries reports the per-library failure via the error return.
+			// The caller (apmInjectionMutator) absorbs it so the patch is still applied.
 			wantErr:       true,
 			wantStatus:    annotation.InjectionStatusPartial,
 			wantStatusSet: true,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator_test.go
@@ -263,6 +263,11 @@ func TestInjectAPMLibraries_InjectedLibraries_UnsupportedLanguage(t *testing.T) 
 	require.True(t, ok)
 	assert.Equal(t, annotation.InjectionStatusPartial, status)
 
+	// The injection-error annotation must carry the human-readable reason.
+	injErr, ok := annotation.Get(pod, annotation.InjectionError)
+	require.True(t, ok, "InjectionError annotation should be set for partial injection")
+	assert.Contains(t, injErr, "cobol")
+
 	entries := parseInjectedLibraries(t, pod)
 	require.Len(t, entries, 3)
 	assert.Equal(t, libraryAnnotationEntry{Name: "injector", Image: "gcr.io/datadoghq/apm-inject:0.52.0", Status: "injected"}, entries[0])

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/noop_provider.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/noop_provider.go
@@ -29,6 +29,11 @@ func newNoopProvider(err error) *NoopProvider {
 // Err returns the skip reason that will be reported in MutationResult.Err.
 func (p *NoopProvider) Err() error { return p.err }
 
+// GetName returns "disabled" since this provider performs no injection.
+func (p *NoopProvider) GetName() string {
+	return "disabled"
+}
+
 func (p *NoopProvider) InjectInjector(_ *corev1.Pod, _ InjectorConfig) MutationResult {
 	return MutationResult{
 		Status: MutationStatusSkipped,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/provider.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/provider.go
@@ -130,6 +130,7 @@ type LibraryInjectionConfig struct {
 // Different implementations can use different mechanisms:
 // - InitContainerProvider: Uses init containers with EmptyDir volumes
 // - CSIProvider: Uses a CSI driver to mount library files
+// - ImageVolumeProvider: Uses Kubernetes image volumes to mount library files
 type LibraryInjectionProvider interface {
 	// InjectInjector mutates the pod to add the APM injector component.
 	// The injector is responsible for the LD_PRELOAD mechanism that enables auto-instrumentation.
@@ -140,4 +141,9 @@ type LibraryInjectionProvider interface {
 	// It adds volumes, volume mounts, and optionally init containers for the library.
 	// Returns MutationStatusError if the language is not supported.
 	InjectLibrary(pod *corev1.Pod, cfg LibraryConfig) MutationResult
+
+	// GetName returns the effective injection mode used by this provider.
+	// For AutoProvider, this reflects the resolved concrete mode suffixed with " (auto)"
+	// (e.g. "csi (auto)" or "init_container (auto)").
+	GetName() string
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -98,6 +98,7 @@ func (m *mutatorCore) apmInjectionMutator(config extractedPodLibInfo, autoDetect
 		if err != nil {
 			log.Warnf("Skipping APM library injection for pod %s: %s", mutatecommon.PodString(pod), err)
 			annotation.Set(pod, annotation.InjectionError, err.Error())
+			annotation.Set(pod, annotation.InjectionStatus, annotation.InjectionStatusSkipped)
 			return nil
 		}
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -101,7 +101,14 @@ func (m *mutatorCore) apmInjectionMutator(config extractedPodLibInfo, autoDetect
 			return nil
 		}
 
-		return libraryinjection.InjectAPMLibraries(pod, injectionCfg)
+		if err := libraryinjection.InjectAPMLibraries(pod, injectionCfg); err != nil {
+			// Per-library failures (unsupported language, injection error) are non-fatal
+			// at the webhook level: the outcome is already recorded in the pod annotations
+			// and returning an error here would cause Mutate to discard the entire patch,
+			// making the annotations and any successful injections unobservable.
+			log.Warnf("APM library injection completed with partial failures for pod %s: %v", mutatecommon.PodString(pod), err)
+		}
+		return nil
 	})
 }
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 	corev1 "k8s.io/api/core/v1"
@@ -22,6 +23,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -170,6 +172,48 @@ func assertEqualLibInjection(actualLibs []libInfo, expectedLibs []libInfo) bool 
 	}
 
 	return reflect.DeepEqual(actualLibsAsSet, expectedLibsAsSet)
+}
+
+// TestAPMInjectionMutatorSetsStatusOnConfigError verifies that when
+// buildLibraryInjectionConfig fails (e.g. registry allow-list rejection),
+// both injection-status and injection-error annotations are set on the pod
+// even though InjectAPMLibraries is never called.
+func TestAPMInjectionMutatorSetsStatusOnConfigError(t *testing.T) {
+	mutator := &mutatorCore{
+		config: &Config{
+			staticConfig: staticConfig{
+				Instrumentation:   &InstrumentationConfig{},
+				containerRegistry: "docker.io/datadog",
+				registryAllowList: []string{"docker.io/datadog"},
+			},
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+
+	config := extractedPodLibInfo{
+		libs: []libInfo{
+			{lang: python, image: "dd-lib-python-init:v3"},
+		},
+		source: libInfoSourceLibInjection,
+	}
+
+	m := mutator.apmInjectionMutator(config, false, localLibraryInstrumentationInstallType)
+	err := m.mutatePod(pod)
+	require.NoError(t, err, "config errors must not propagate to Mutate")
+
+	status, ok := annotation.Get(pod, annotation.InjectionStatus)
+	require.True(t, ok, "injection-status annotation must be set")
+	assert.Equal(t, annotation.InjectionStatusSkipped, status)
+
+	injErr, ok := annotation.Get(pod, annotation.InjectionError)
+	require.True(t, ok, "injection-error annotation must be set")
+	assert.NotEmpty(t, injErr)
 }
 
 func TestBuildLibraryInjectionConfigRejectsImplicitLibraryRegistryWhenAllowListIsSet(t *testing.T) {

--- a/releasenotes-dca/notes/apm-ssi-injection-observability-annotations-312ec4a5da19f355.yaml
+++ b/releasenotes-dca/notes/apm-ssi-injection-observability-annotations-312ec4a5da19f355.yaml
@@ -1,0 +1,30 @@
+---
+features:
+  - |
+    The admission webhook now writes a set of APM Single Step Instrumentation
+    (SSI) observability annotations directly on mutated pods, making the full
+    injection outcome inspectable via ``kubectl get pod -o yaml`` without
+    requiring cluster-level access.
+
+    New annotations written by the webhook:
+
+    - ``internal.apm.datadoghq.com/injection-status``: overall outcome —
+      ``injected``, ``partial``, ``skipped``, or ``error``.
+    - ``internal.apm.datadoghq.com/injected-libraries``: JSON array listing
+      every component the webhook attempted to inject (injector + per-language
+      libraries), each with its name, image, and individual status.
+    - ``internal.apm.datadoghq.com/effective-injection-mode``: the injection
+      mode actually used (e.g. ``csi``, ``init_container``, ``csi (auto)``),
+      set immediately after provider selection so it is present even when
+      injection is subsequently skipped.
+    - ``internal.apm.datadoghq.com/injection-error``: human-readable reason
+      when injection was skipped or errored.
+    - ``internal.apm.datadoghq.com/csi-driver-status``: observed state of the
+      Datadog CSI driver at injection time — ``apm-enabled``, ``apm-disabled``
+      (driver present but APM SSI not advertised), or ``not-installed``. Set
+      independently of the configured injection mode.
+
+    Per-library failures (unsupported language, library injection error) no
+    longer prevent the webhook patch from being applied. The webhook now logs
+    a warning and reflects the partial outcome in the annotations instead of
+    discarding the entire mutation.


### PR DESCRIPTION
### What does this PR do?

Adds a set of pod annotations written by the admission webhook during
Single Step Instrumentation (SSI), so that the full injection outcome
is observable directly on the pod:

| Annotation | Example value |
|---|---|
| `internal.apm.datadoghq.com/injection-status` | `injected`, `partial`, `skipped`, `error` |
| `internal.apm.datadoghq.com/injected-libraries` | `[{"name":"injector","image":"…","status":"injected"},{"name":"java",…}]` |
| `internal.apm.datadoghq.com/effective-injection-mode` | `csi`, `init_container`, `csi (auto)` |
| `internal.apm.datadoghq.com/injection-error` | human-readable reason when skipped or errored |
| `internal.apm.datadoghq.com/csi-driver-status` | `apm-enabled`, `apm-disabled`, `not-installed` |

`injection-status` summarises the overall outcome: `injected` means
everything succeeded, `partial` means the injector ran but at least one
library was skipped (e.g. unsupported language), `skipped` means the
injector did not run at all (insufficient resources, incompatible k8s
version, disabled mode), and `error` means a fatal failure occurred.

`csi-driver-status` is set independently of the configured injection
mode, answering "is the CSI driver installed?" and "is APM SSI support
enabled on it?" from a single annotation, without needing cluster-level
access.

This PR also changes the error-handling behaviour in `apmInjectionMutator`:
per-library failures (unsupported language, injection error) no longer
propagate as errors out of the mutator. Previously, returning an error
caused `Mutate` to discard the entire JSON patch, so neither the
annotations nor any successful injections would reach the pod. The
failure is now logged as a warning and reflected in the annotations;
the patch is always applied.

### Motivation

With the introduction of CSI and image-volume injection modes, the
existing mutation detection heuristic (presence of SSI init containers)
no longer works. These annotations provide a mode-agnostic,
forward-compatible signal that can be consumed by queries, dashboards,
and support tooling to determine whether a pod was instrumented and why,
without requiring access to cluster-level resources or node-level state.

### Describe how you validated your changes

Unit tests cover all annotation values across injection modes (CSI,
init_container, auto resolving to either), injector skip/error paths,
partial injection (unsupported language), and the three CSI driver
states. All existing tests continue to pass.

### Additional Notes

The `csi-driver-status` annotation requires a small extension to the
`CSIDriverWatcher` interface (`IsRegistered() bool`) to distinguish
between "driver not installed" and "driver installed but APM not
advertised". The annotation is absent when the CSI driver watcher is
nil (i.e. CSI auto-detection is disabled via feature flag).