### PR TITLE
enhance(autodiscovery): Enable instrumentation check provider only in k8s envs

### DIFF
--- a/pkg/config/autodiscovery/autodiscovery.go
+++ b/pkg/config/autodiscovery/autodiscovery.go
@@ -38,7 +38,8 @@ func DiscoverComponentsFromConfig() ([]pkgconfigsetup.ConfigurationProviders, []
 	}
 
 	// Add instrumentation checks provider if `instrumentation_crd_controller.enabled` is true
-	if pkgconfigsetup.Datadog().GetBool("instrumentation_crd_controller.enabled") && flavor.GetFlavor() == flavor.DefaultAgent {
+	if pkgconfigsetup.Datadog().GetBool("instrumentation_crd_controller.enabled") &&
+		flavor.GetFlavor() == flavor.DefaultAgent && env.IsKubernetes() {
 		instrumentationChecksProvider := pkgconfigsetup.ConfigurationProviders{Name: "instrumentation_checks", Polling: true}
 		log.Info("Instrumentation controller is enabled: Adding the instrumentation checks config provider")
 		detectedProviders = append(detectedProviders, instrumentationChecksProvider)


### PR DESCRIPTION
### What does this PR do?

Add `env.IsKubernetes` check prior to enabling the `instrumentation_check` provider.

### Motivation

As part of the [DatatadogInstrumentation CRD work](https://datadoghq.atlassian.net/wiki/spaces/CONTP/pages/6564659495/DatadogInstrumentation+CRD+for+Workload-Scoped+Product+Enablement), an `instrumentation_checks` provider was added to the node agent that polls for checks from the cluster agent.

Instrumentation CRD backed checks are only relevant in kubernetes environments so adding an `IsKubernetes` check is an important pre-caution to avoid wasted polling.

### Describe how you validated your changes

CI passes ✅ 

### Additional Notes
