### PR TITLE
Map NCCL check metrics to GPU source

### DIFF
--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -390,6 +390,11 @@ func TestSenderPopulatingMetricSampleSource(t *testing.T) {
 			expectedMetricSource: metrics.MetricSourcePostgres,
 		},
 		{
+			name:                 "checkid nccl:1 should have MetricSourceGPU",
+			checkID:              "nccl:1",
+			expectedMetricSource: metrics.MetricSourceGPU,
+		},
+		{
 			name:                 "checkid tls:1 should have MetricSourceTLS",
 			checkID:              "tls:1",
 			expectedMetricSource: metrics.MetricSourceTLS,

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -1308,7 +1308,7 @@ func CheckNameToMetricSource(name string) MetricSource {
 		return MetricSourceGlusterfs
 	case "go_expvar":
 		return MetricSourceGoExpvar
-	case "gpu":
+	case "gpu", "nccl":
 		return MetricSourceGPU
 	case "gunicorn":
 		return MetricSourceGunicorn


### PR DESCRIPTION
## Summary

NCCL core check metrics are now attributed to the GPU metric source/origin metadata by mapping the `nccl` check name to `MetricSourceGPU`.

## Testing

- `dda inv test --targets=./pkg/aggregator --extra-args='-run TestSenderPopulatingMetricSampleSource'`
