### PR TITLE
[AGNTLOG-644] Disable sampler outcome telemetry in detection-only mode

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/sampler.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler.go
@@ -207,15 +207,21 @@ func (s *AdaptiveSampler) appendPatternHashTagIfEnabled(msg *message.Message, to
 	}
 }
 
+func (s *AdaptiveSampler) recordKeptTlm() {
+	if !s.config.DetectionOnly {
+		tlmAdaptiveSamplerKept.Inc(s.source)
+	}
+}
+
 // Process applies credit-based rate limiting to the message.
 // Returns the message if allowed, nil if dropped.
 func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message.Message {
 	if !s.shouldSample(msg, tokens) {
-		tlmAdaptiveSamplerKept.Inc(s.source)
+		s.recordKeptTlm()
 		return msg
 	}
 	if s.config.ProtectImportantLogs && isImportant(tokens) {
-		tlmAdaptiveSamplerKept.Inc(s.source)
+		s.recordKeptTlm()
 		tlmAdaptiveSamplerProtected.Inc(s.source)
 		return msg
 	}
@@ -268,11 +274,10 @@ func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message
 		}
 
 		if allow {
-			tlmAdaptiveSamplerKept.Inc(s.source)
+			s.recordKeptTlm()
 			return msg
 		}
 		if s.config.DetectionOnly {
-			tlmAdaptiveSamplerKept.Inc(s.source)
 			return msg
 		}
 		tlmAdaptiveSamplerDropped.Inc(s.source)
@@ -294,7 +299,7 @@ func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message
 		matchCount: 1,
 		sampled:    0,
 	})
-	tlmAdaptiveSamplerKept.Inc(s.source)
+	s.recordKeptTlm()
 	return msg
 }
 

--- a/pkg/logs/internal/decoder/preprocessor/sampler.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler.go
@@ -213,6 +213,12 @@ func (s *AdaptiveSampler) recordKeptTlm() {
 	}
 }
 
+func (s *AdaptiveSampler) recordProtectedTlm() {
+	if !s.config.DetectionOnly {
+		tlmAdaptiveSamplerProtected.Inc(s.source)
+	}
+}
+
 // Process applies credit-based rate limiting to the message.
 // Returns the message if allowed, nil if dropped.
 func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message.Message {
@@ -222,7 +228,7 @@ func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message
 	}
 	if s.config.ProtectImportantLogs && isImportant(tokens) {
 		s.recordKeptTlm()
-		tlmAdaptiveSamplerProtected.Inc(s.source)
+		s.recordProtectedTlm()
 		return msg
 	}
 	now := s.now()

--- a/pkg/logs/internal/decoder/preprocessor/sampler_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_test.go
@@ -286,6 +286,41 @@ func TestAdaptiveSampler_RecordsOutcomeTelemetry(t *testing.T) {
 	assert.Equal(t, bytesDroppedBefore+float64(msg.RawDataLen), tlmAdaptiveSamplerBytesDropped.WithValues(source).Get())
 }
 
+func TestAdaptiveSampler_DetectionOnlyDoesNotRecordProtectedTelemetry(t *testing.T) {
+	source := strings.ReplaceAll(t.Name(), "/", "_")
+	s := NewAdaptiveSampler(AdaptiveSamplerConfig{
+		MaxPatterns:          10,
+		RateLimit:            0,
+		BurstSize:            1,
+		MatchThreshold:       0.9,
+		ProtectImportantLogs: true,
+		DetectionOnly:        true,
+	}, source)
+	importantTokens := tokenize("ERROR something went wrong")
+
+	protectedBefore := tlmAdaptiveSamplerProtected.WithValues(source).Get()
+	require.NotNil(t, s.Process(testMsg(), importantTokens), "important logs should still pass through")
+
+	assert.Equal(t, protectedBefore, tlmAdaptiveSamplerProtected.WithValues(source).Get())
+}
+
+func TestAdaptiveSampler_RecordsProtectedTelemetry(t *testing.T) {
+	source := strings.ReplaceAll(t.Name(), "/", "_")
+	s := NewAdaptiveSampler(AdaptiveSamplerConfig{
+		MaxPatterns:          10,
+		RateLimit:            0,
+		BurstSize:            1,
+		MatchThreshold:       0.9,
+		ProtectImportantLogs: true,
+	}, source)
+	importantTokens := tokenize("ERROR something went wrong")
+
+	protectedBefore := tlmAdaptiveSamplerProtected.WithValues(source).Get()
+	require.NotNil(t, s.Process(testMsg(), importantTokens), "important logs should pass through")
+
+	assert.Equal(t, protectedBefore+1, tlmAdaptiveSamplerProtected.WithValues(source).Get())
+}
+
 // Credits are capped at BurstSize even if a long time has passed.
 func TestAdaptiveSampler_CreditsCappedAtBurstSize(t *testing.T) {
 	const burst = 3.0

--- a/pkg/logs/internal/decoder/preprocessor/sampler_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_test.go
@@ -236,6 +236,56 @@ func TestAdaptiveSampler_DetectionOnlyDoesNotEmitSampledCountAfterRefill(t *test
 	assert.Equal(t, int64(0), s.entries[0].sampled)
 }
 
+func TestAdaptiveSampler_DetectionOnlyDoesNotRecordOutcomeTelemetry(t *testing.T) {
+	source := strings.ReplaceAll(t.Name(), "/", "_")
+	s := NewAdaptiveSampler(AdaptiveSamplerConfig{
+		MaxPatterns:    10,
+		RateLimit:      0,
+		BurstSize:      1,
+		MatchThreshold: 0.9,
+		DetectionOnly:  true,
+	}, source)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	keptBefore := tlmAdaptiveSamplerKept.WithValues(source).Get()
+	droppedBefore := tlmAdaptiveSamplerDropped.WithValues(source).Get()
+	bytesDroppedBefore := tlmAdaptiveSamplerBytesDropped.WithValues(source).Get()
+
+	require.NotNil(t, s.Process(testMsg(), patternA), "first message creates the pattern and would be kept")
+	out := s.Process(testMsg(), patternA)
+	require.NotNil(t, out, "detection-only should keep messages that would be dropped")
+	assert.Contains(t, out.ParsingExtra.Tags, adaptiveSamplerNoisyLogTag)
+
+	assert.Equal(t, keptBefore, tlmAdaptiveSamplerKept.WithValues(source).Get())
+	assert.Equal(t, droppedBefore, tlmAdaptiveSamplerDropped.WithValues(source).Get())
+	assert.Equal(t, bytesDroppedBefore, tlmAdaptiveSamplerBytesDropped.WithValues(source).Get())
+}
+
+func TestAdaptiveSampler_RecordsOutcomeTelemetry(t *testing.T) {
+	source := strings.ReplaceAll(t.Name(), "/", "_")
+	s := NewAdaptiveSampler(AdaptiveSamplerConfig{
+		MaxPatterns:    10,
+		RateLimit:      0,
+		BurstSize:      1,
+		MatchThreshold: 0.9,
+	}, source)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	msg := testMsg()
+	keptBefore := tlmAdaptiveSamplerKept.WithValues(source).Get()
+	droppedBefore := tlmAdaptiveSamplerDropped.WithValues(source).Get()
+	bytesDroppedBefore := tlmAdaptiveSamplerBytesDropped.WithValues(source).Get()
+
+	require.NotNil(t, s.Process(msg, patternA), "first message creates the pattern and is kept")
+	require.Nil(t, s.Process(msg, patternA), "second message should be dropped")
+
+	assert.Equal(t, keptBefore+1, tlmAdaptiveSamplerKept.WithValues(source).Get())
+	assert.Equal(t, droppedBefore+1, tlmAdaptiveSamplerDropped.WithValues(source).Get())
+	assert.Equal(t, bytesDroppedBefore+float64(msg.RawDataLen), tlmAdaptiveSamplerBytesDropped.WithValues(source).Get())
+}
+
 // Credits are capped at BurstSize even if a long time has passed.
 func TestAdaptiveSampler_CreditsCappedAtBurstSize(t *testing.T) {
 	const burst = 3.0


### PR DESCRIPTION
### What does this PR do?

Disables outcome telemetry in the adaptive sampler when it's in detection only mode.

### Motivation

The outcome telemetry, if used in detection only mode, has the potential to pollute data needed to evaluate the adaptive sampler.

### Describe how you validated your changes

Local testing

### Additional Notes
