### PR TITLE
fix(logs): prevent silent docker tailer death on read timeout (AGENT-16325)

### DIFF
--- a/pkg/logs/tailers/container/tailer.go
+++ b/pkg/logs/tailers/container/tailer.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	dockerclient "github.com/moby/moby/client"
@@ -112,6 +113,14 @@ type Tailer struct {
 	mutex     sync.Mutex
 
 	messageForwarder messageForwarder
+
+	// shutdownRequested is set by Stop() before cancelling the reader, so that
+	// readForever can distinguish a self-initiated shutdown close from an
+	// unexpected reader close (daemon disconnect, SDK regression, etc.).
+	// Without this, an unexpected close that surfaces as
+	// "http: read on closed response body" or "use of closed network connection"
+	// would silently kill the tailer without notifying the supervisor.
+	shutdownRequested atomic.Bool
 }
 
 type messageForwarder interface {
@@ -197,6 +206,11 @@ func (t *Tailer) Identifier() string {
 // this call blocks until the decoder is completely flushed
 func (t *Tailer) Stop() {
 	log.Infof("Stop tailing container: %v", t.ContainerID)
+
+	// Mark shutdown before any cancellation so that readForever distinguishes
+	// the upcoming reader-close from an unexpected one and does not signal the
+	// supervisor.
+	t.shutdownRequested.Store(true)
 
 	t.registry.SetTailed(t.Identifier(), false)
 
@@ -314,8 +328,16 @@ func (t *Tailer) readForever() {
 			if err != nil { // an error occurred, stop from reading new logs
 				switch {
 				case isReaderClosed(err):
-					// The reader has been closed during the shut down process
-					// of the tailer, stop reading
+					// Normally the reader is only closed during the tailer's
+					// shutdown process. If we got here without a shutdown being
+					// requested, the reader closed unexpectedly (e.g. daemon
+					// disconnect, SDK-side body close). Notify the supervisor
+					// so it can re-create the tailer instead of silently
+					// dropping log collection for this container.
+					if !t.shutdownRequested.Load() {
+						log.Warnf("Docker reader closed unexpectedly for container %v: %v", t.ContainerID, err)
+						t.erroredContainerID <- t.ContainerID
+					}
 					return
 				case isContextCanceled(err):
 					// Note that it could happen that the docker daemon takes a lot of time gathering timestamps
@@ -326,7 +348,14 @@ func (t *Tailer) readForever() {
 					}
 					continue
 				case isClosedConnError(err):
-					// This error is raised when the agent is stopping
+					// This error is normally raised when the agent is stopping.
+					// If shutdown was not requested, the underlying connection
+					// closed unexpectedly; surface it to the supervisor so the
+					// tailer is re-created.
+					if !t.shutdownRequested.Load() {
+						log.Warnf("Docker connection closed unexpectedly for container %v: %v", t.ContainerID, err)
+						t.erroredContainerID <- t.ContainerID
+					}
 					return
 				case isFileAlreadyClosed(err):
 					// This error seems to be returned by Docker for Windows
@@ -375,15 +404,24 @@ func (t *Tailer) read(buffer []byte, timeout time.Duration) (int, error) {
 
 	select {
 	case <-doneReading:
+		return n, err
 	case <-time.After(timeout):
-		// Cancel the docker socket reader context
+		// Cancel the in-flight Docker reader context.
+		//
+		// moby/moby/client v0.4.0+ wraps ContainerLogs' response body in a
+		// cancelReadCloser (utils.go:132-141) that registers
+		// context.AfterFunc(ctx, body.Close). Cancelling the context closes
+		// the body asynchronously, and the blocked Read() returns
+		// "http: read on closed response body" instead of context.Canceled.
+		// readForever would then match isReaderClosed and exit permanently,
+		// killing the tailer without notifying the supervisor.
+		//
+		// Synthesize context.Canceled to preserve the documented contract
+		// regardless of the underlying SDK's cancellation surface.
 		t.readerCancelFunc()
-		// wait for the Read call to return, likely with
-		// context.Canceled
 		<-doneReading
+		return n, context.Canceled
 	}
-
-	return n, err
 }
 
 // buildMessage builds a new log message.Message, enriching it with tags and metadata

--- a/pkg/logs/tailers/container/tailer_test.go
+++ b/pkg/logs/tailers/container/tailer_test.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -75,6 +76,27 @@ func (m *mockReaderSleep) Read(p []byte) (int, error) {
 }
 
 func (m *mockReaderSleep) Close() error {
+	return nil
+}
+
+// mockMobyReader simulates the cancelReadCloser wrapper used by
+// moby/moby/client v0.4.0+: when the context is cancelled, the body is
+// closed asynchronously and the blocked Read() returns
+// "http: read on closed response body" rather than context.Canceled.
+type mockMobyReader struct {
+	ctx context.Context
+}
+
+func newMockMobyReader(ctx context.Context) *mockMobyReader {
+	return &mockMobyReader{ctx: ctx}
+}
+
+func (m *mockMobyReader) Read(_ []byte) (int, error) {
+	<-m.ctx.Done()
+	return 0, errors.New("http: read on closed response body")
+}
+
+func (m *mockMobyReader) Close() error {
 	return nil
 }
 
@@ -177,6 +199,28 @@ func TestReadTimeout(t *testing.T) {
 	assert.Equal(t, 0, n)
 }
 
+// TestReadReturnsCanceledOnTimeout verifies that read() synthesizes
+// context.Canceled on a self-initiated timeout regardless of which error
+// the underlying SDK surfaces.
+//
+// moby/moby/client v0.4.0+ wraps ContainerLogs' response body so that a
+// context cancellation closes the body asynchronously and the blocked
+// Read() returns "http: read on closed response body". Without this
+// guarantee, readForever's isReaderClosed branch would match and the
+// tailer would die silently after every read timeout (AGENT-16325).
+func TestReadReturnsCanceledOnTimeout(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	reader := newMockMobyReader(ctx)
+
+	tailer := NewTestTailer(reader, nil, cancelFunc)
+	inBuf := make([]byte, 4096)
+
+	n, err := tailer.read(inBuf, testReadTimeout)
+
+	assert.Equal(t, 0, n)
+	assert.Equal(t, context.Canceled, err)
+}
+
 func TestTailerCanStopWithNilReader(t *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	tailer := NewTestTailer(newMockReaderSleep(ctx), nil, cancelFunc)
@@ -202,11 +246,34 @@ func TestTailer_readForever(t *testing.T) {
 				_, cancelFunc := context.WithCancel(context.Background())
 				reader := NewTestReader("", errors.New("http: read on closed response body"), nil)
 				tailer := NewTestTailer(reader, reader, cancelFunc)
+				// Stop() would have set this before closing the reader.
+				tailer.shutdownRequested.Store(true)
 				return tailer
 			},
 			wantFunc: func(tailer *Tailer) error {
 				if len(tailer.erroredContainerID) != 0 {
-					return fmt.Errorf("tailer.erroredContainerID should be empty, current len: %d", len(tailer.erroredContainerID))
+					return fmt.Errorf("tailer.erroredContainerID should be empty during shutdown, current len: %d", len(tailer.erroredContainerID))
+				}
+				return nil
+			},
+		},
+		{
+			name: "The reader closes unexpectedly (no shutdown requested)",
+			newTailer: func() *Tailer {
+				_, cancelFunc := context.WithCancel(context.Background())
+				reader := NewTestReader("", errors.New("http: read on closed response body"), nil)
+				tailer := NewTestTailer(reader, reader, cancelFunc)
+				// shutdownRequested defaults to false; this is the AGENT-16325
+				// silent-death path that must now signal the supervisor.
+				return tailer
+			},
+			wantFunc: func(tailer *Tailer) error {
+				if len(tailer.erroredContainerID) != 1 {
+					return fmt.Errorf("tailer.erroredContainerID should contain 1 ID, got len=%d", len(tailer.erroredContainerID))
+				}
+				containerID := <-tailer.erroredContainerID
+				if containerID != "1234567890abcdef" {
+					return fmt.Errorf("wrong containerID: %s", containerID)
 				}
 				return nil
 			},
@@ -217,11 +284,31 @@ func TestTailer_readForever(t *testing.T) {
 				_, cancelFunc := context.WithCancel(context.Background())
 				reader := NewTestReader("", errors.New("use of closed network connection"), nil)
 				tailer := NewTestTailer(reader, reader, cancelFunc)
+				tailer.shutdownRequested.Store(true)
 				return tailer
 			},
 			wantFunc: func(tailer *Tailer) error {
 				if len(tailer.erroredContainerID) != 0 {
-					return fmt.Errorf("tailer.erroredContainerID should be empty, current len: %d", len(tailer.erroredContainerID))
+					return fmt.Errorf("tailer.erroredContainerID should be empty during shutdown, current len: %d", len(tailer.erroredContainerID))
+				}
+				return nil
+			},
+		},
+		{
+			name: "The connection closes unexpectedly (no shutdown requested)",
+			newTailer: func() *Tailer {
+				_, cancelFunc := context.WithCancel(context.Background())
+				reader := NewTestReader("", errors.New("use of closed network connection"), nil)
+				tailer := NewTestTailer(reader, reader, cancelFunc)
+				return tailer
+			},
+			wantFunc: func(tailer *Tailer) error {
+				if len(tailer.erroredContainerID) != 1 {
+					return fmt.Errorf("tailer.erroredContainerID should contain 1 ID, got len=%d", len(tailer.erroredContainerID))
+				}
+				containerID := <-tailer.erroredContainerID
+				if containerID != "1234567890abcdef" {
+					return fmt.Errorf("wrong containerID: %s", containerID)
 				}
 				return nil
 			},
@@ -235,6 +322,9 @@ func TestTailer_readForever(t *testing.T) {
 				// then the new reader return by the unsafeReader client will return close network connection to simulate stop agent
 				connectionCloseReader := NewTestReader("", errors.New("use of closed network connection"), nil)
 				tailer := NewTestTailer(initialReader, connectionCloseReader, cancelFunc)
+				// Model the "agent stopping after EOF restart" path: by the time
+				// the connection-close error surfaces, Stop() has set the flag.
+				tailer.shutdownRequested.Store(true)
 				return tailer
 			},
 			wantFunc: func(tailer *Tailer) error {
@@ -273,6 +363,58 @@ func TestTailer_readForever(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReadForeverRestartsAfterTimeout verifies that a moby v0.4.0-style
+// timeout cycle does not silently kill the tailer: each cycle synthesizes
+// context.Canceled and feeds the reader-timeout branch, which calls
+// tryRestartReader. The tailer keeps running across multiple cycles and
+// no error is signaled to the supervisor.
+func TestReadForeverRestartsAfterTimeout(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	initial := newMockMobyReader(ctx)
+	tailer := NewTestTailer(initial, nil, cancelFunc)
+	tailer.readTimeout = 5 * time.Millisecond
+	tailer.sleepDuration = 1 * time.Millisecond
+
+	var setupCount atomic.Int32
+	tailer.unsafeLogReader = func(ctx context.Context, _ time.Time) (io.ReadCloser, error) {
+		setupCount.Add(1)
+		return newMockMobyReader(ctx), nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		tailer.readForever()
+		close(done)
+	}()
+
+	// Wait for the loop to complete at least two restart cycles.
+	assert.Eventually(t, func() bool {
+		return setupCount.Load() >= 2
+	}, 2*time.Second, 5*time.Millisecond, "expected unsafeLogReader to be called at least twice")
+
+	// Confirm the goroutine is still alive — the bug under fix would have
+	// caused it to return after the first cycle.
+	select {
+	case <-done:
+		t.Fatal("readForever exited unexpectedly during restart cycles")
+	default:
+	}
+
+	// Shut down cleanly.
+	tailer.shutdownRequested.Store(true)
+	tailer.stop <- struct{}{}
+	tailer.readerCancelFunc()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readForever did not exit after stop")
+	}
+
+	assert.Equal(t, 0, len(tailer.erroredContainerID),
+		"erroredContainerID should be empty during normal restart cycles")
 }
 
 func NewTestReader(data string, err, closeErr error) *testIOReadCloser { //nolint:revive

--- a/releasenotes/notes/fix-docker-log-tailer-silent-death-eaf19e640e7e1fe6.yaml
+++ b/releasenotes/notes/fix-docker-log-tailer-silent-death-eaf19e640e7e1fe6.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    Fix a regression introduced in 7.79.0 where the Docker container log
+    tailer could silently stop tailing low-traffic containers (those
+    writing less often than ``docker_client_read_timeout``, default 30s)
+    after several hours of healthy operation. The Docker SDK upgrade in
+    7.79.0 changed how request-context cancellation surfaces in the
+    response body, causing the tailer's self-initiated read timeout to be
+    misclassified as a shutdown signal and exit the read loop without
+    notifying the supervisor. The tailer now restarts the reader on every
+    timeout regardless of which error surface the SDK reports, and any
+    unexpected reader-close signals the supervisor so the tailer can be
+    re-created.


### PR DESCRIPTION
### What does this PR do?

Two changes to `pkg/logs/tailers/container/tailer.go` to fix the AGENT-16325 silent Docker log-tailer death regression introduced in 7.79.0:

- **Patch 1** — `read()` now synthesizes `context.Canceled` on its self-initiated timeout, regardless of which error surface the underlying SDK reports.
- **Patch 2** — adds a `shutdownRequested atomic.Bool` flag set in `Stop()`, and replaces the bare `return`s in `readForever`'s `isReaderClosed` and `isClosedConnError` branches with conditional `erroredContainerID` sends, so any non-shutdown reader close re-creates the tailer via the supervisor.

### Motivation

In 7.79.0, the Docker SDK upgrade swapped `docker/docker v28` for `moby/moby/client v0.4.0`. The new SDK wraps the `ContainerLogs()` response body in a `cancelReadCloser` (`utils.go:132-141`) that registers `context.AfterFunc(ctx, body.Close)`. When the agent's `docker_client_read_timeout` (default 30s) fires for a low-traffic container, the body is closed asynchronously and the blocked `Read()` returns `"http: read on closed response body"` instead of `context.Canceled`.

`readForever`'s `isReaderClosed` branch was a bare `return` — no `erroredContainerID` send, no error log. The supervisor at `pkg/logs/launchers/container/tailerfactory/tailers/tailer.go:118` parks forever in its select, the integration's `Status: OK` stays misleadingly green, and log collection silently stops for the affected container. Cumulative probability of at least one fatal race outcome over ~420 cycles in 7 hours is high — which matches the customer-observed failure timeline.

See AGENT-16325 for the full root-cause writeup with goroutine dumps, registry-freeze evidence, and SDK source pointers.

### Describe how you validated your changes

`dda inv test --targets=./pkg/logs/tailers/container` — 15 tests pass (added 2 new, updated 4 existing).
`dda inv test --targets=./pkg/logs/launchers/container/tailerfactory/tailers` — 5 supervisor tests pass.
`dda inv linter.go --targets=./pkg/logs/tailers/container` — 0 issues.

New tests:
- `TestReadReturnsCanceledOnTimeout` — fakes the moby v0.4.0 `cancelReadCloser` behaviour (`Read()` blocks on `ctx.Done()`, returns the post-close error) and asserts `read()` returns `context.Canceled`. Fails without Patch 1.
- `TestReadForeverRestartsAfterTimeout` — runs `readForever` against a moby-style reader for multiple cycles, asserts the restart loop survives and no error is signaled to the supervisor.

Existing `TestTailer_readForever` cases that modeled shutdown paths were updated to set `shutdownRequested=true`; two new cases cover the AGENT-16325 unexpected-close path with `shutdownRequested=false` and assert the supervisor signal.

### Additional Notes

- **Backport candidate**: 7.79.3 — bug is present in all 7.79.x and current `main`.
- The workaround for users still on 7.79.x is `logs_config.docker_container_force_use_file: true`, which bypasses the registry-override that keeps existing socket-mode entries pinned to the docker socket tailer.