### PR TITLE
Add check metric lookback ringbuffer

### DIFF
--- a/cmd/agent/subcommands/run/command_windows.go
+++ b/cmd/agent/subcommands/run/command_windows.go
@@ -66,6 +66,7 @@ import (
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server/def"
 	defaultforwarder "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/def"
+	haagentdef "github.com/DataDog/datadog-agent/comp/haagent/def"
 	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent/def"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
@@ -148,6 +149,7 @@ func StartAgentWithDefaults(ctxChan <-chan context.Context) (<-chan error, error
 			ipc ipc.Component,
 			snmpScanManager snmpscanmanager.Component,
 			traceroute traceroute.Component,
+			haAgent haagentdef.Component,
 			healthplatformComp healthplatformdef.Component,
 			ncmComp option.Option[networkconfigmanagement.Component],
 
@@ -177,6 +179,7 @@ func StartAgentWithDefaults(ctxChan <-chan context.Context) (<-chan error, error
 				ipc,
 				snmpScanManager,
 				traceroute,
+				haAgent,
 				healthplatformComp,
 				ncmComp,
 			)

--- a/pkg/collector/metriclookback/lookbacksender/sender_test.go
+++ b/pkg/collector/metriclookback/lookbacksender/sender_test.go
@@ -177,7 +177,7 @@ func TestSenderDropsUnsupportedPayloadsAndRejectsInvalidTimestamps(t *testing.T)
 
 func TestSenderTelemetry(t *testing.T) {
 	mockConfig := configmock.New(t)
-	mockConfig.SetWithoutSource("telemetry.metric_lookback", "*")
+	mockConfig.SetInTest("telemetry.metric_lookback", "*")
 
 	writer := &recordingWriter{}
 	manager := NewSenderManager(context.Background(), "default-host", writer, func() float64 { return 42 })

--- a/pkg/collector/metriclookback/ringbuffer/BUILD.bazel
+++ b/pkg/collector/metriclookback/ringbuffer/BUILD.bazel
@@ -16,7 +16,10 @@ go_test(
     name = "ringbuffer_test",
     srcs = ["buffer_test.go"],
     embed = [":ringbuffer"],
+    gotags = ["test"],
     deps = [
+        "//pkg/collector/check/id",
         "//pkg/collector/metriclookback/lookbacksender",
+        "//pkg/metrics",
     ],
 )

--- a/pkg/collector/metriclookback/ringbuffer/BUILD.bazel
+++ b/pkg/collector/metriclookback/ringbuffer/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "ringbuffer",
+    srcs = ["buffer.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/collector/metriclookback/ringbuffer",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/collector/check/id",
+        "//pkg/metrics",
+        "@org_uber_go_atomic//:atomic",
+    ],
+)
+
+go_test(
+    name = "ringbuffer_test",
+    srcs = ["buffer_test.go"],
+    embed = [":ringbuffer"],
+    deps = [
+        "//pkg/collector/metriclookback/lookbacksender",
+    ],
+)

--- a/pkg/collector/metriclookback/ringbuffer/buffer.go
+++ b/pkg/collector/metriclookback/ringbuffer/buffer.go
@@ -1,0 +1,439 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package ringbuffer stores recent scalar check metric samples in a bounded
+// in-memory ring. It is intended to satisfy the metric lookback sender Writer
+// API without exposing a query surface yet.
+package ringbuffer
+
+import (
+	"context"
+	"hash/fnv"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"go.uber.org/atomic"
+)
+
+const (
+	// DefaultCapacity is the total number of samples retained when Options.Capacity
+	// is not set.
+	DefaultCapacity = 262_144
+
+	// DefaultShardCount is the number of independent rings used when
+	// Options.ShardCount is not set.
+	DefaultShardCount = 16
+)
+
+type sampleFlags uint8
+
+const (
+	flagFlushFirstValue sampleFlags = 1 << iota
+)
+
+// Options controls Buffer construction.
+type Options struct {
+	// Capacity is the total number of sample slots allocated across all shards.
+	// Retention is shard-local: samples are assigned to shards by metric context,
+	// so a hot shard can overwrite its oldest samples while other shards still
+	// have unused slots. When zero or negative, DefaultCapacity is used.
+	Capacity int
+
+	// ShardCount is the number of independent rings. When zero or negative,
+	// DefaultShardCount is used. Values larger than Capacity are clamped so every
+	// shard has at least one slot.
+	ShardCount int
+
+	// Now supplies timestamps for samples without an explicit MetricSample
+	// timestamp. When nil, time.Now is used.
+	Now func() time.Time
+}
+
+// Stats describes the current state of a Buffer.
+type Stats struct {
+	Capacity             int
+	ShardCount           int
+	Records              int
+	ActiveContexts       int
+	TotalContextsCreated uint64
+	AppendedSamples      uint64
+	OverwrittenSamples   uint64
+}
+
+// Buffer is a bounded in-memory ring for recent check metric samples.
+type Buffer struct {
+	now func() time.Time
+
+	contexts *contextStore
+	shards   []shard
+
+	nextSequence       *atomic.Uint64
+	appendedSamples    *atomic.Uint64
+	overwrittenSamples *atomic.Uint64
+}
+
+// New creates a bounded in-memory ring buffer.
+func New(options Options) *Buffer {
+	capacity := options.Capacity
+	if capacity <= 0 {
+		capacity = DefaultCapacity
+	}
+
+	shardCount := options.ShardCount
+	if shardCount <= 0 {
+		shardCount = DefaultShardCount
+	}
+	if shardCount > capacity {
+		shardCount = capacity
+	}
+
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	b := &Buffer{
+		now:                now,
+		contexts:           newContextStore(shardCount),
+		shards:             make([]shard, shardCount),
+		nextSequence:       atomic.NewUint64(0),
+		appendedSamples:    atomic.NewUint64(0),
+		overwrittenSamples: atomic.NewUint64(0),
+	}
+
+	baseCapacity := capacity / shardCount
+	extraSlots := capacity % shardCount
+	for i := range b.shards {
+		shardCapacity := baseCapacity
+		if i < extraSlots {
+			shardCapacity++
+		}
+		b.shards[i].records = make([]record, shardCapacity)
+	}
+
+	return b
+}
+
+// Append stores scalar metric samples emitted by a check. It implements the
+// lookbacksender.Writer shape. If the context is cancelled before or during the
+// call, Append returns the context error after retaining any samples already
+// appended.
+func (b *Buffer) Append(ctx context.Context, checkID checkid.ID, samples []metrics.MetricSample) error {
+	if b == nil || len(samples) == 0 {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	nowUnixMicro := int64(0)
+	for i := range samples {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		sample := samples[i]
+		timestampUnixMicro := sampleTimestampUnixMicro(sample.Timestamp)
+		if timestampUnixMicro == 0 {
+			if nowUnixMicro == 0 {
+				nowUnixMicro = b.now().UnixMicro()
+			}
+			timestampUnixMicro = nowUnixMicro
+		}
+
+		contextID, shardID := b.contexts.retain(checkID, sample)
+		sequence := b.nextSequence.Inc()
+		rec := record{
+			contextID:          contextID,
+			timestampUnixMicro: timestampUnixMicro,
+			sequence:           sequence,
+			value:              sample.Value,
+			sampleRate:         sample.SampleRate,
+			flags:              flagsForSample(sample),
+		}
+
+		overwrittenContextID, overwritten := b.shards[shardID].append(rec)
+		b.appendedSamples.Inc()
+		if overwritten {
+			b.overwrittenSamples.Inc()
+			b.contexts.release(overwrittenContextID)
+		}
+	}
+
+	return nil
+}
+
+// Stats returns a point-in-time summary of the buffer.
+func (b *Buffer) Stats() Stats {
+	if b == nil {
+		return Stats{}
+	}
+
+	records := 0
+	capacity := 0
+	for i := range b.shards {
+		recordCount, shardCapacity := b.shards[i].stats()
+		records += recordCount
+		capacity += shardCapacity
+	}
+
+	activeContexts, totalContextsCreated := b.contexts.stats()
+	return Stats{
+		Capacity:             capacity,
+		ShardCount:           len(b.shards),
+		Records:              records,
+		ActiveContexts:       activeContexts,
+		TotalContextsCreated: totalContextsCreated,
+		AppendedSamples:      b.appendedSamples.Load(),
+		OverwrittenSamples:   b.overwrittenSamples.Load(),
+	}
+}
+
+type record struct {
+	contextID          uint64
+	timestampUnixMicro int64
+	sequence           uint64
+	value              float64
+	sampleRate         float64
+	flags              sampleFlags
+}
+
+type shard struct {
+	mu      sync.Mutex
+	records []record
+	start   int
+	length  int
+	next    int
+}
+
+func (s *shard) append(rec record) (uint64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.records) == 0 {
+		return 0, false
+	}
+
+	overwrittenContextID := uint64(0)
+	overwritten := s.length == len(s.records)
+	if overwritten {
+		overwrittenContextID = s.records[s.next].contextID
+	} else {
+		s.length++
+	}
+
+	s.records[s.next] = rec
+	s.next = (s.next + 1) % len(s.records)
+	if overwritten {
+		s.start = s.next
+	}
+
+	return overwrittenContextID, overwritten
+}
+
+func (s *shard) stats() (int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.length, len(s.records)
+}
+
+type metricContext struct {
+	id      uint64
+	checkID checkid.ID
+	name    string
+	host    string
+	tags    []string
+	mtype   metrics.MetricType
+	noIndex bool
+	source  metrics.MetricSource
+	unit    string
+	shardID int
+}
+
+type contextEntry struct {
+	key  string
+	ctx  metricContext
+	refs int
+}
+
+type contextStore struct {
+	mu                   sync.Mutex
+	shardCount           int
+	nextID               uint64
+	byKey                map[string]*contextEntry
+	byID                 map[uint64]*contextEntry
+	totalContextsCreated uint64
+}
+
+func newContextStore(shardCount int) *contextStore {
+	return &contextStore{
+		shardCount: shardCount,
+		nextID:     1,
+		byKey:      make(map[string]*contextEntry),
+		byID:       make(map[uint64]*contextEntry),
+	}
+}
+
+func (s *contextStore) retain(checkID checkid.ID, sample metrics.MetricSample) (uint64, int) {
+	tags := canonicalTags(sample.Tags)
+	key := buildContextKey(checkID, sample, tags)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if entry, found := s.byKey[key]; found {
+		entry.refs++
+		return entry.ctx.id, entry.ctx.shardID
+	}
+
+	contextID := s.nextID
+	s.nextID++
+	shardID := shardIndex(hashString(key), s.shardCount)
+	entry := &contextEntry{
+		key: key,
+		ctx: metricContext{
+			id:      contextID,
+			checkID: checkID,
+			name:    sample.Name,
+			host:    sample.Host,
+			tags:    tags,
+			mtype:   sample.Mtype,
+			noIndex: sample.NoIndex,
+			source:  sample.Source,
+			unit:    sample.Unit,
+			shardID: shardID,
+		},
+		refs: 1,
+	}
+	s.byKey[key] = entry
+	s.byID[contextID] = entry
+	s.totalContextsCreated++
+	return contextID, shardID
+}
+
+func (s *contextStore) release(contextID uint64) {
+	if contextID == 0 {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, found := s.byID[contextID]
+	if !found {
+		return
+	}
+	entry.refs--
+	if entry.refs > 0 {
+		return
+	}
+	delete(s.byID, contextID)
+	delete(s.byKey, entry.key)
+}
+
+func (s *contextStore) stats() (int, uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.byID), s.totalContextsCreated
+}
+
+func sampleTimestampUnixMicro(timestamp float64) int64 {
+	if timestamp <= 0 {
+		return 0
+	}
+	return int64(timestamp * 1e6)
+}
+
+func flagsForSample(sample metrics.MetricSample) sampleFlags {
+	var flags sampleFlags
+	if sample.FlushFirstValue {
+		flags |= flagFlushFirstValue
+	}
+	return flags
+}
+
+func canonicalTags(tags []string) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := append([]string(nil), tags...)
+	sort.Strings(out)
+	return dedupeSortedStrings(out)
+}
+
+func dedupeSortedStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+
+	writeIdx := 0
+	for readIdx := 1; readIdx < len(values); readIdx++ {
+		if values[readIdx] == values[writeIdx] {
+			continue
+		}
+		writeIdx++
+		values[writeIdx] = values[readIdx]
+	}
+	return values[:writeIdx+1]
+}
+
+func buildContextKey(checkID checkid.ID, sample metrics.MetricSample, tags []string) string {
+	var builder strings.Builder
+	appendStringField(&builder, string(checkID))
+	appendStringField(&builder, sample.Name)
+	appendStringField(&builder, sample.Host)
+	appendIntField(&builder, int64(sample.Mtype))
+	appendBoolField(&builder, sample.NoIndex)
+	appendIntField(&builder, int64(sample.Source))
+	appendStringField(&builder, sample.Unit)
+	appendIntField(&builder, int64(len(tags)))
+	for _, tag := range tags {
+		appendStringField(&builder, tag)
+	}
+	return builder.String()
+}
+
+func appendStringField(builder *strings.Builder, value string) {
+	builder.WriteString(strconv.Itoa(len(value)))
+	builder.WriteByte(':')
+	builder.WriteString(value)
+	builder.WriteByte('|')
+}
+
+func appendIntField(builder *strings.Builder, value int64) {
+	builder.WriteString(strconv.FormatInt(value, 10))
+	builder.WriteByte('|')
+}
+
+func appendBoolField(builder *strings.Builder, value bool) {
+	if value {
+		builder.WriteByte('1')
+	} else {
+		builder.WriteByte('0')
+	}
+	builder.WriteByte('|')
+}
+
+func hashString(value string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(value))
+	return h.Sum64()
+}
+
+func shardIndex(hash uint64, shardCount int) int {
+	if shardCount <= 1 {
+		return 0
+	}
+	return int(hash % uint64(shardCount))
+}

--- a/pkg/collector/metriclookback/ringbuffer/buffer_test.go
+++ b/pkg/collector/metriclookback/ringbuffer/buffer_test.go
@@ -1,0 +1,573 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ringbuffer
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	"github.com/DataDog/datadog-agent/pkg/collector/metriclookback/lookbacksender"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+func TestAppendCanonicalizesContextsAndStoresRecords(t *testing.T) {
+	now := time.Unix(123, 456789000)
+	buffer := New(Options{
+		Capacity:   4,
+		ShardCount: 1,
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	samples := []metrics.MetricSample{
+		{
+			Name:            "custom.metric",
+			Value:           1.25,
+			Mtype:           metrics.GaugeType,
+			Tags:            []string{"b:2", "a:1", "a:1"},
+			Host:            "host-a",
+			SampleRate:      0.5,
+			Timestamp:       10.125,
+			FlushFirstValue: true,
+			NoIndex:         true,
+			Source:          metrics.MetricSourceInternal,
+			Unit:            "request",
+		},
+		{
+			Name:       "custom.metric",
+			Value:      2.5,
+			Mtype:      metrics.GaugeType,
+			Tags:       []string{"a:1", "b:2"},
+			Host:       "host-a",
+			SampleRate: 0.75,
+			NoIndex:    true,
+			Source:     metrics.MetricSourceInternal,
+			Unit:       "request",
+		},
+	}
+
+	if err := buffer.Append(context.Background(), checkid.ID("check:abc"), samples); err != nil {
+		t.Fatalf("Append returned error: %v", err)
+	}
+	samples[0].Tags[0] = "mutated:true"
+
+	records := buffer.snapshotRecords()
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+	if records[0].contextID != records[1].contextID {
+		t.Fatalf("expected equal context IDs for canonical tag equivalents, got %d and %d", records[0].contextID, records[1].contextID)
+	}
+	if records[0].timestampUnixMicro != 10_125_000 {
+		t.Fatalf("expected explicit timestamp in microseconds, got %d", records[0].timestampUnixMicro)
+	}
+	if records[1].timestampUnixMicro != now.UnixMicro() {
+		t.Fatalf("expected fallback timestamp %d, got %d", now.UnixMicro(), records[1].timestampUnixMicro)
+	}
+	if records[0].value != 1.25 || records[1].value != 2.5 {
+		t.Fatalf("unexpected record values: %+v", records)
+	}
+	if records[0].sampleRate != 0.5 || records[1].sampleRate != 0.75 {
+		t.Fatalf("unexpected sample rates: %+v", records)
+	}
+	if records[0].flags&flagFlushFirstValue == 0 {
+		t.Fatal("expected first record to retain FlushFirstValue flag")
+	}
+	if records[1].flags != 0 {
+		t.Fatalf("expected second record to have no flags, got %d", records[1].flags)
+	}
+
+	contexts := buffer.snapshotContexts()
+	if len(contexts) != 1 {
+		t.Fatalf("expected 1 active context, got %d", len(contexts))
+	}
+	metricContext := contexts[records[0].contextID]
+	if metricContext.checkID != checkid.ID("check:abc") {
+		t.Fatalf("unexpected check ID: %s", metricContext.checkID)
+	}
+	if metricContext.name != "custom.metric" || metricContext.host != "host-a" || metricContext.mtype != metrics.GaugeType {
+		t.Fatalf("unexpected context: %+v", metricContext)
+	}
+	if !metricContext.noIndex || metricContext.source != metrics.MetricSourceInternal || metricContext.unit != "request" {
+		t.Fatalf("unexpected context metadata: %+v", metricContext)
+	}
+	if !reflect.DeepEqual(metricContext.tags, []string{"a:1", "b:2"}) {
+		t.Fatalf("expected sorted deduped tags, got %#v", metricContext.tags)
+	}
+
+	stats := buffer.Stats()
+	if stats.Capacity != 4 || stats.ShardCount != 1 || stats.Records != 2 || stats.ActiveContexts != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if stats.TotalContextsCreated != 1 || stats.AppendedSamples != 2 || stats.OverwrittenSamples != 0 {
+		t.Fatalf("unexpected counters: %+v", stats)
+	}
+	assertInvariants(t, buffer)
+}
+
+func TestRingOverwritesOldestAndEvictsContexts(t *testing.T) {
+	buffer := New(Options{Capacity: 3, ShardCount: 1})
+	for i := 0; i < 4; i++ {
+		if err := buffer.Append(context.Background(), checkid.ID("check:abc"), []metrics.MetricSample{{
+			Name:  "metric." + string(rune('a'+i)),
+			Value: float64(i + 1),
+			Mtype: metrics.GaugeType,
+		}}); err != nil {
+			t.Fatalf("Append returned error: %v", err)
+		}
+	}
+
+	records := buffer.snapshotRecords()
+	if len(records) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(records))
+	}
+	for i, expectedValue := range []float64{2, 3, 4} {
+		if records[i].value != expectedValue {
+			t.Fatalf("record %d value = %f, want %f (records: %+v)", i, records[i].value, expectedValue, records)
+		}
+	}
+
+	contexts := buffer.snapshotContexts()
+	if len(contexts) != 3 {
+		t.Fatalf("expected 3 active contexts, got %d", len(contexts))
+	}
+	for _, ctx := range contexts {
+		if ctx.name == "metric.a" {
+			t.Fatalf("oldest context was not evicted: %+v", contexts)
+		}
+	}
+
+	stats := buffer.Stats()
+	if stats.Records != 3 || stats.ActiveContexts != 3 || stats.TotalContextsCreated != 4 || stats.AppendedSamples != 4 || stats.OverwrittenSamples != 1 {
+		t.Fatalf("unexpected stats after overwrite: %+v", stats)
+	}
+	assertInvariants(t, buffer)
+}
+
+func TestOverwriteSameContextKeepsContextActive(t *testing.T) {
+	buffer := New(Options{Capacity: 2, ShardCount: 1})
+	for i := 0; i < 3; i++ {
+		if err := buffer.Append(context.Background(), checkid.ID("check:abc"), []metrics.MetricSample{{
+			Name:  "same.metric",
+			Value: float64(i + 1),
+			Mtype: metrics.CountType,
+			Tags:  []string{"env:test"},
+		}}); err != nil {
+			t.Fatalf("Append returned error: %v", err)
+		}
+	}
+
+	records := buffer.snapshotRecords()
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+	if records[0].value != 2 || records[1].value != 3 {
+		t.Fatalf("unexpected records after overwrite: %+v", records)
+	}
+	if records[0].contextID != records[1].contextID {
+		t.Fatalf("expected retained records to share a context: %+v", records)
+	}
+
+	stats := buffer.Stats()
+	if stats.ActiveContexts != 1 || stats.TotalContextsCreated != 1 || stats.OverwrittenSamples != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	assertInvariants(t, buffer)
+}
+
+func TestAppendHonorsCanceledContext(t *testing.T) {
+	buffer := New(Options{Capacity: 2, ShardCount: 1})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := buffer.Append(ctx, checkid.ID("check:abc"), []metrics.MetricSample{{
+		Name:  "metric",
+		Value: 1,
+		Mtype: metrics.GaugeType,
+	}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	stats := buffer.Stats()
+	if stats.Records != 0 || stats.ActiveContexts != 0 || stats.AppendedSamples != 0 || stats.OverwrittenSamples != 0 {
+		t.Fatalf("expected empty buffer after canceled append, got %+v", stats)
+	}
+	assertInvariants(t, buffer)
+}
+
+func TestSingleShardRingMatchesReferenceModel(t *testing.T) {
+	const capacity = 5
+	buffer := New(Options{Capacity: capacity, ShardCount: 1})
+	var reference []float64
+
+	for i := 0; i < 17; i++ {
+		sample := metrics.MetricSample{
+			Name:      "model.metric." + strconv.Itoa(i%3),
+			Value:     float64(i),
+			Mtype:     metrics.MetricType(i % int(metrics.NumMetricTypes)),
+			Tags:      []string{"tag:" + strconv.Itoa(i%2), "stable:true"},
+			Host:      "host-" + strconv.Itoa(i%4),
+			Timestamp: float64(100 + i),
+		}
+		if err := buffer.Append(context.Background(), checkid.ID("check:model"), []metrics.MetricSample{sample}); err != nil {
+			t.Fatalf("Append returned error at step %d: %v", i, err)
+		}
+
+		reference = append(reference, sample.Value)
+		if len(reference) > capacity {
+			reference = reference[len(reference)-capacity:]
+		}
+
+		records := buffer.snapshotRecords()
+		if len(records) != len(reference) {
+			t.Fatalf("step %d: got %d records, want %d", i, len(records), len(reference))
+		}
+		for idx, expected := range reference {
+			if records[idx].value != expected {
+				t.Fatalf("step %d: record %d value = %f, want %f (records: %+v)", i, idx, records[idx].value, expected, records)
+			}
+		}
+	}
+
+	stats := buffer.Stats()
+	if stats.Records != capacity || stats.AppendedSamples != 17 || stats.OverwrittenSamples != 12 {
+		t.Fatalf("unexpected final stats: %+v", stats)
+	}
+	assertInvariants(t, buffer)
+}
+
+func TestConcurrentAppendMaintainsCounts(t *testing.T) {
+	const (
+		workers          = 8
+		samplesPerWorker = 64
+		totalSamples     = workers * samplesPerWorker
+	)
+	buffer := New(Options{Capacity: totalSamples * 4, ShardCount: 4})
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < samplesPerWorker; i++ {
+				if err := buffer.Append(context.Background(), checkid.ID("check:"+strconv.Itoa(worker)), []metrics.MetricSample{{
+					Name:  "concurrent.metric",
+					Value: float64(worker*samplesPerWorker + i),
+					Mtype: metrics.GaugeType,
+					Tags:  []string{"worker:" + strconv.Itoa(worker)},
+				}}); err != nil {
+					t.Errorf("Append returned error: %v", err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	stats := buffer.Stats()
+	if stats.Records != totalSamples || stats.AppendedSamples != totalSamples || stats.OverwrittenSamples != 0 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if stats.ActiveContexts != workers || stats.TotalContextsCreated != workers {
+		t.Fatalf("unexpected context stats: %+v", stats)
+	}
+
+	records := buffer.snapshotRecords()
+	if len(records) != totalSamples {
+		t.Fatalf("expected %d records, got %d", totalSamples, len(records))
+	}
+	for i := 1; i < len(records); i++ {
+		if records[i-1].sequence >= records[i].sequence {
+			t.Fatalf("records are not globally sequence ordered around %d: %+v then %+v", i, records[i-1], records[i])
+		}
+	}
+	assertInvariants(t, buffer)
+}
+
+func TestAppendReturnsContextErrorAfterMidBatchCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	buffer := New(Options{
+		Capacity:   4,
+		ShardCount: 1,
+		Now: func() time.Time {
+			cancel()
+			return time.Unix(100, 0)
+		},
+	})
+
+	err := buffer.Append(ctx, checkid.ID("check:abc"), []metrics.MetricSample{
+		{Name: "first", Value: 1, Mtype: metrics.GaugeType},
+		{Name: "second", Value: 2, Mtype: metrics.GaugeType},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	records := buffer.snapshotRecords()
+	if len(records) != 1 || records[0].value != 1 {
+		t.Fatalf("expected first sample to be retained before cancellation, got %+v", records)
+	}
+	stats := buffer.Stats()
+	if stats.Records != 1 || stats.AppendedSamples != 1 || stats.ActiveContexts != 1 {
+		t.Fatalf("unexpected stats after mid-batch cancellation: %+v", stats)
+	}
+	assertInvariants(t, buffer)
+}
+
+func TestShardLocalCapacityAndInvariantAccounting(t *testing.T) {
+	buffer := New(Options{Capacity: 6, ShardCount: 3})
+
+	for shardID, values := range [][]float64{{1, 2, 3}, {10}, {20, 21}} {
+		for _, value := range values {
+			sample := sampleForShard(t, checkid.ID("check:sharded"), shardID)
+			sample.Value = value
+			if err := buffer.Append(context.Background(), checkid.ID("check:sharded"), []metrics.MetricSample{sample}); err != nil {
+				t.Fatalf("Append returned error: %v", err)
+			}
+		}
+	}
+
+	stats := buffer.Stats()
+	if stats.Capacity != 6 || stats.Records != 5 || stats.AppendedSamples != 6 || stats.OverwrittenSamples != 1 {
+		t.Fatalf("unexpected sharded stats: %+v", stats)
+	}
+
+	contexts := buffer.snapshotContexts()
+	recordsByShard := make(map[int]int)
+	for _, rec := range buffer.snapshotRecords() {
+		ctx, found := contexts[rec.contextID]
+		if !found {
+			t.Fatalf("record references missing context %d", rec.contextID)
+		}
+		recordsByShard[ctx.shardID]++
+		if ctx.shardID == 0 && rec.value == 1 {
+			t.Fatal("expected oldest shard 0 record to be overwritten")
+		}
+	}
+	if !reflect.DeepEqual(recordsByShard, map[int]int{0: 2, 1: 1, 2: 2}) {
+		t.Fatalf("unexpected per-shard record counts: %+v", recordsByShard)
+	}
+	assertInvariants(t, buffer)
+}
+
+func TestLookbackSenderCommitAppendsFormattedSamples(t *testing.T) {
+	const formattedTimestamp = 123.456789
+	buffer := New(Options{Capacity: 8, ShardCount: 1})
+	checkID := checkid.ID("cpu:instance-hash")
+	manager := lookbacksender.NewSenderManager(context.Background(), "default-host", buffer, func() float64 {
+		return formattedTimestamp
+	})
+
+	sender, err := manager.GetSender(checkID)
+	if err != nil {
+		t.Fatalf("GetSender returned error: %v", err)
+	}
+	sender.SetCheckCustomTags([]string{"check_tag:one"})
+	sender.SetCheckService("svc")
+	sender.FinalizeCheckServiceTag()
+	sender.SetNoIndex(true)
+
+	sender.Gauge("lookback.gauge", 1, "", []string{"b:2", "a:1"})
+	if err := sender.CountWithTimestamp("lookback.count_ts", 2, "explicit-host", []string{"z:9"}, 42.25); err != nil {
+		t.Fatalf("CountWithTimestamp returned error: %v", err)
+	}
+	sender.Commit()
+
+	records := buffer.snapshotRecords()
+	if len(records) != 2 {
+		t.Fatalf("expected 2 ringbuffer records, got %d", len(records))
+	}
+	if records[0].value != 1 || records[0].timestampUnixMicro != 123_456_789 {
+		t.Fatalf("unexpected formatted gauge record: %+v", records[0])
+	}
+	if records[1].value != 2 || records[1].timestampUnixMicro != 42_250_000 {
+		t.Fatalf("unexpected timestamped count record: %+v", records[1])
+	}
+
+	contexts := buffer.snapshotContexts()
+	gaugeContext := contexts[records[0].contextID]
+	if gaugeContext.name != "lookback.gauge" || gaugeContext.host != "default-host" || gaugeContext.mtype != metrics.GaugeType {
+		t.Fatalf("unexpected gauge context: %+v", gaugeContext)
+	}
+	if !gaugeContext.noIndex || gaugeContext.source != metrics.CheckNameToMetricSource("cpu") {
+		t.Fatalf("unexpected gauge context metadata: %+v", gaugeContext)
+	}
+	if !reflect.DeepEqual(gaugeContext.tags, []string{"a:1", "b:2", "check_tag:one", "service:svc"}) {
+		t.Fatalf("unexpected gauge tags: %#v", gaugeContext.tags)
+	}
+
+	countContext := contexts[records[1].contextID]
+	if countContext.name != "lookback.count_ts" || countContext.host != "explicit-host" || countContext.mtype != metrics.CountWithTimestampType {
+		t.Fatalf("unexpected count context: %+v", countContext)
+	}
+	if !countContext.noIndex || countContext.source != metrics.CheckNameToMetricSource("cpu") {
+		t.Fatalf("unexpected count context metadata: %+v", countContext)
+	}
+	if !reflect.DeepEqual(countContext.tags, []string{"check_tag:one", "service:svc", "z:9"}) {
+		t.Fatalf("unexpected count tags: %#v", countContext.tags)
+	}
+
+	stats := buffer.Stats()
+	if stats.Records != 2 || stats.ActiveContexts != 2 || stats.AppendedSamples != 2 || stats.OverwrittenSamples != 0 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	assertInvariants(t, buffer)
+}
+
+func BenchmarkAppendStableContext(b *testing.B) {
+	buffer := New(Options{Capacity: 1024, ShardCount: 4})
+	sample := metrics.MetricSample{
+		Name:  "benchmark.metric",
+		Value: 1,
+		Mtype: metrics.GaugeType,
+		Tags:  []string{"env:bench", "region:local"},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := buffer.Append(context.Background(), checkid.ID("check:bench"), []metrics.MetricSample{sample}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAppendHighCardinality(b *testing.B) {
+	buffer := New(Options{Capacity: 1024, ShardCount: 4})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := buffer.Append(context.Background(), checkid.ID("check:bench"), []metrics.MetricSample{{
+			Name:  "benchmark.metric." + strconv.Itoa(i),
+			Value: float64(i),
+			Mtype: metrics.GaugeType,
+			Tags:  []string{"env:bench", "iteration:" + strconv.Itoa(i)},
+		}}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func assertInvariants(t *testing.T, buffer *Buffer) {
+	t.Helper()
+
+	records := buffer.snapshotRecords()
+	refs := buffer.contexts.snapshotContextRefs()
+	counts := make(map[uint64]int)
+	for _, rec := range records {
+		if rec.contextID == 0 {
+			t.Fatalf("record has zero context ID: %+v", rec)
+		}
+		counts[rec.contextID]++
+		if _, found := refs[rec.contextID]; !found {
+			t.Fatalf("record references missing context %d", rec.contextID)
+		}
+	}
+
+	for contextID, count := range counts {
+		if refs[contextID] != count {
+			t.Fatalf("context %d refcount = %d, want retained record count %d", contextID, refs[contextID], count)
+		}
+	}
+	for contextID, refs := range refs {
+		if counts[contextID] != refs {
+			t.Fatalf("context %d has stale refcount %d with retained record count %d", contextID, refs, counts[contextID])
+		}
+	}
+
+	stats := buffer.Stats()
+	if stats.Records != len(records) {
+		t.Fatalf("Stats.Records = %d, want %d", stats.Records, len(records))
+	}
+	if stats.ActiveContexts != len(refs) {
+		t.Fatalf("Stats.ActiveContexts = %d, want %d", stats.ActiveContexts, len(refs))
+	}
+}
+
+func sampleForShard(t *testing.T, checkID checkid.ID, shardID int) metrics.MetricSample {
+	t.Helper()
+	for i := 0; i < 10_000; i++ {
+		sample := metrics.MetricSample{
+			Name:  "sharded.metric." + strconv.Itoa(shardID) + "." + strconv.Itoa(i),
+			Mtype: metrics.GaugeType,
+			Tags:  []string{"target_shard:" + strconv.Itoa(shardID)},
+		}
+		key := buildContextKey(checkID, sample, canonicalTags(sample.Tags))
+		if shardIndex(hashString(key), 3) == shardID {
+			return sample
+		}
+	}
+	t.Fatalf("could not find sample for shard %d", shardID)
+	return metrics.MetricSample{}
+}
+
+func (b *Buffer) snapshotRecords() []record {
+	if b == nil {
+		return nil
+	}
+
+	var out []record
+	for i := range b.shards {
+		out = append(out, b.shards[i].snapshotRecords()...)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].sequence < out[j].sequence
+	})
+	return out
+}
+
+func (s *shard) snapshotRecords() []record {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]record, 0, s.length)
+	for i := 0; i < s.length; i++ {
+		idx := (s.start + i) % len(s.records)
+		out = append(out, s.records[idx])
+	}
+	return out
+}
+
+func (b *Buffer) snapshotContexts() map[uint64]metricContext {
+	if b == nil {
+		return nil
+	}
+	return b.contexts.snapshotContexts()
+}
+
+func (s *contextStore) snapshotContexts() map[uint64]metricContext {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make(map[uint64]metricContext, len(s.byID))
+	for id, entry := range s.byID {
+		ctx := entry.ctx
+		ctx.tags = append([]string(nil), entry.ctx.tags...)
+		out[id] = ctx
+	}
+	return out
+}
+
+func (s *contextStore) snapshotContextRefs() map[uint64]int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make(map[uint64]int, len(s.byID))
+	for id, entry := range s.byID {
+		out[id] = entry.refs
+	}
+	return out
+}


### PR DESCRIPTION
### What does this PR do?

Adds an in-memory bounded ringbuffer for metric lookback samples under:

- `pkg/collector/metriclookback/ringbuffer`

The buffer implements the existing `lookbacksender.Writer` API:

```go
Append(ctx context.Context, checkID checkid.ID, samples []metrics.MetricSample) error
```

Behavior included in this checkpoint:

- bounded in-memory retention
- sharded ring buffers
- overwrite-oldest behavior per shard
- Unix microsecond timestamps
- deterministic timestamp injection via `Options.Now`
- compact sample records stored separately from metric context metadata
- canonical tags: cloned, sorted, and deduped
- context refcounting and eviction when overwritten records no longer reference a context
- basic `Stats()` for future telemetry/config wiring

### Motivation

This is the storage-side checkpoint for high-granularity check metric lookback.

Ella’s merged `lookbacksender` path can already format scalar check samples and commit them through a `Writer`. This PR adds the in-memory writer implementation that can retain those samples in a bounded structure without introducing the full runtime integration or query API yet.

V1 intentionally avoids disk/WAL persistence and keeps the surface area small so we can validate ingestion, retention, and metadata accounting first.

### Describe how you validated your changes

Added unit/integration coverage for:

- canonical tag handling
- timestamp conversion and fallback timestamps
- overwrite-oldest behavior
- context eviction/refcounting
- same-context overwrite behavior
- cancellation before append and mid-batch
- shard-local capacity behavior
- single-shard model behavior
- concurrent appends
- sender integration:
  - `lookbacksender.SenderManager -> Sender -> Commit -> ringbuffer.Buffer`

Validated locally with:

```bash
bazel test //pkg/collector/metriclookback/ringbuffer:ringbuffer_test
```

```bash
bazel test \
  --@rules_go//go/config:race \
  --test_output=errors \
  //pkg/collector/metriclookback/ringbuffer:ringbuffer_test
```

Both passed.

### Additional Notes

This PR does not yet add:

- Agent/component runtime wiring
- config options
- telemetry export
- query/read API
- disk persistence/WAL
