### PR TITLE
fix(e2e): align Windows procmgr smoke test with processes.d

### DIFF
--- a/test/e2e-framework/components/command/windowsOSCommand.go
+++ b/test/e2e-framework/components/command/windowsOSCommand.go
@@ -33,11 +33,11 @@ func (fs windowsOSCommand) CreateDirectory(
 ) (Command, error) {
 	useSudo := false
 	opts = append(opts, pulumi.DeleteBeforeReplace(true))
-	// Quote for PowerShell: paths under "Program Files" contain spaces and break
-	// unquoted -Path (see PR #51990).
-	createCmd := pulumi.Sprintf("New-Item -Force -LiteralPath '%v' -ItemType Directory", remotePath)
+	// Single-quote the path so spaces (e.g. under Program Files) are one argument.
+	// Use -Path not -LiteralPath: older Windows PowerShell on some AMIs rejects -LiteralPath on New-Item (PR #51990).
+	createCmd := pulumi.Sprintf("New-Item -Force -Path '%v' -ItemType Directory", remotePath)
 	deleteCmd := pulumi.Sprintf(
-		"if ((Get-ChildItem -LiteralPath '%v' -Force -ErrorAction SilentlyContinue | Measure-Object).Count -eq 0) { Remove-Item -LiteralPath '%v' -ErrorAction SilentlyContinue }",
+		"if ((Get-ChildItem -Path '%v' -Force -ErrorAction SilentlyContinue | Measure-Object).Count -eq 0) { Remove-Item -Path '%v' -ErrorAction SilentlyContinue }",
 		remotePath, remotePath,
 	)
 	return runner.Command(name,

--- a/test/e2e-framework/components/command/windowsOSCommand.go
+++ b/test/e2e-framework/components/command/windowsOSCommand.go
@@ -32,13 +32,21 @@ func (fs windowsOSCommand) CreateDirectory(
 	opts ...pulumi.ResourceOption,
 ) (Command, error) {
 	useSudo := false
-	return createDirectory(
-		runner,
-		name,
-		fmt.Sprintf("New-Item -Force -Path %v -ItemType Directory", remotePath),
-		fmt.Sprintf("if (-not (Test-Path -Path %v/*)) { Remove-Item -Path %v -ErrorAction SilentlyContinue }", remotePath, remotePath),
-		useSudo,
-		opts...)
+	opts = append(opts, pulumi.DeleteBeforeReplace(true))
+	// Quote for PowerShell: paths under "Program Files" contain spaces and break
+	// unquoted -Path (see PR #51990).
+	createCmd := pulumi.Sprintf("New-Item -Force -LiteralPath '%v' -ItemType Directory", remotePath)
+	deleteCmd := pulumi.Sprintf(
+		"if ((Get-ChildItem -LiteralPath '%v' -Force -ErrorAction SilentlyContinue | Measure-Object).Count -eq 0) { Remove-Item -LiteralPath '%v' -ErrorAction SilentlyContinue }",
+		remotePath, remotePath,
+	)
+	return runner.Command(name,
+		&Args{
+			Create:   createCmd,
+			Delete:   deleteCmd,
+			Sudo:     useSudo,
+			Triggers: pulumi.Array{createCmd, pulumi.BoolPtr(useSudo)},
+		}, opts...)
 }
 
 func (fs windowsOSCommand) GetTemporaryDirectory() string {

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_common_test.go
@@ -93,18 +93,24 @@ func (s *baseProcmgrSuite) TestServiceRunning() {
 
 func (s *baseProcmgrSuite) TestCLIStatus() {
 	s.requireCLI()
-	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("status"))
-		assertHasField(t, out, "Version")
-		assertHasField(t, out, "Uptime")
+	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
+		out, err := s.Env().RemoteHost.Execute(s.platform.cliCmd("status"))
+		if !assert.NoError(ct, err) {
+			return
+		}
+		assertHasField(ct, out, "Version")
+		assertHasField(ct, out, "Uptime")
 	}, 30*time.Second, 2*time.Second)
 }
 
 func (s *baseProcmgrSuite) TestCLIListShowsConfiguredProcess() {
 	s.requireCLI()
-	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("list"))
-		assertTableRow(t, out, "test-sleep", map[string]string{
+	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
+		out, err := s.Env().RemoteHost.Execute(s.platform.cliCmd("list"))
+		if !assert.NoError(ct, err) {
+			return
+		}
+		assertTableRow(ct, out, "test-sleep", map[string]string{
 			"STATE":   "Running",
 			"COMMAND": s.platform.sleepCommand,
 		})
@@ -113,19 +119,25 @@ func (s *baseProcmgrSuite) TestCLIListShowsConfiguredProcess() {
 
 func (s *baseProcmgrSuite) TestCLIDescribe() {
 	s.requireCLI()
-	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("describe test-sleep"))
-		assertField(t, out, "Name", "test-sleep")
-		assertField(t, out, "State", "Running")
-		assertField(t, out, "Command", s.platform.sleepCommand)
+	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
+		out, err := s.Env().RemoteHost.Execute(s.platform.cliCmd("describe test-sleep"))
+		if !assert.NoError(ct, err) {
+			return
+		}
+		assertField(ct, out, "Name", "test-sleep")
+		assertField(ct, out, "State", "Running")
+		assertField(ct, out, "Command", s.platform.sleepCommand)
 	}, 30*time.Second, 2*time.Second)
 }
 
 func (s *baseProcmgrSuite) TestConditionPathExistsSkipsMissingBinary() {
 	s.requireCLI()
-	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("list"))
-		assertTableRow(t, out, "missing-binary", map[string]string{
+	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
+		out, err := s.Env().RemoteHost.Execute(s.platform.cliCmd("list"))
+		if !assert.NoError(ct, err) {
+			return
+		}
+		assertTableRow(ct, out, "missing-binary", map[string]string{
 			"STATE": "Created",
 			"PID":   "-",
 		})

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_common_test.go
@@ -95,9 +95,7 @@ func (s *baseProcmgrSuite) TestCLIStatus() {
 	s.requireCLI()
 	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
 		out, err := s.Env().RemoteHost.Execute(s.platform.cliCmd("status"))
-		if !assert.NoError(ct, err) {
-			return
-		}
+		require.NoError(ct, err)
 		assertHasField(ct, out, "Version")
 		assertHasField(ct, out, "Uptime")
 	}, 30*time.Second, 2*time.Second)
@@ -107,9 +105,7 @@ func (s *baseProcmgrSuite) TestCLIListShowsConfiguredProcess() {
 	s.requireCLI()
 	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
 		out, err := s.Env().RemoteHost.Execute(s.platform.cliCmd("list"))
-		if !assert.NoError(ct, err) {
-			return
-		}
+		require.NoError(ct, err)
 		assertTableRow(ct, out, "test-sleep", map[string]string{
 			"STATE":   "Running",
 			"COMMAND": s.platform.sleepCommand,
@@ -121,9 +117,7 @@ func (s *baseProcmgrSuite) TestCLIDescribe() {
 	s.requireCLI()
 	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
 		out, err := s.Env().RemoteHost.Execute(s.platform.cliCmd("describe test-sleep"))
-		if !assert.NoError(ct, err) {
-			return
-		}
+		require.NoError(ct, err)
 		assertField(ct, out, "Name", "test-sleep")
 		assertField(ct, out, "State", "Running")
 		assertField(ct, out, "Command", s.platform.sleepCommand)
@@ -134,9 +128,7 @@ func (s *baseProcmgrSuite) TestConditionPathExistsSkipsMissingBinary() {
 	s.requireCLI()
 	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
 		out, err := s.Env().RemoteHost.Execute(s.platform.cliCmd("list"))
-		if !assert.NoError(ct, err) {
-			return
-		}
+		require.NoError(ct, err)
 		assertTableRow(ct, out, "missing-binary", map[string]string{
 			"STATE": "Created",
 			"PID":   "-",

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_win_test.go
@@ -24,7 +24,9 @@ import (
 const (
 	winDaemonBin = `C:\Program Files\Datadog\Datadog Agent\bin\agent\dd-procmgrd.exe`
 	winCLIBin    = `C:\Program Files\Datadog\Datadog Agent\bin\agent\dd-procmgr.exe`
-	winConfigDir = `C:/ProgramData/Datadog/dd-procmgr/processes.d`
+	// Must match dd-procmgrd default on Windows: install root + processes.d
+	// (see pkg/procmgr/rust/src/platform/windows.rs default_config_dir).
+	winConfigDir = `C:/Program Files/Datadog/Datadog Agent/processes.d`
 
 	winSleepCommand = `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`
 


### PR DESCRIPTION
### What does this PR do?

- Points the Windows procmgr new-e2e `WithFile` provisioning at the install **`processes.d`** directory (`…\Program Files\Datadog\Datadog Agent\processes.d`) so `dd-procmgrd` loads the smoke YAML the same way production does.
- **e2e-framework:** fixes Windows `CreateDirectory` so Pulumi uses **`New-Item -Force -Path '…'`** (quoted path) instead of an unquoted `-Path`, so directories under **`Program Files`** work. Uses **`-Path`** (not `-LiteralPath`) on **`New-Item`** / **`Get-ChildItem`** / **`Remove-Item`** because some CI Windows PowerShell builds do not support `-LiteralPath` on `New-Item`.
- **procmgr tests:** in shared CLI checks, uses **`Execute`** plus **`require.NoError(ct, err)`** on the **`CollectT`** inside **`require.EventuallyWithT`** so a failed CLI attempt is retried instead of failing the whole test via `MustExecute` / `require` on the suite `T`.

### Motivation

`TestProcmgrSmokeWindowsSuite` failed (e.g. `describe test-sleep` → process not found) when YAML was provisioned under the wrong directory, and would also fail once provisioning targeted **`Program Files\…`** because the remote **`New-Item`** command did not quote paths with spaces. Separately, **`MustExecute`** inside **`EventuallyWithT`** aborted on the first error instead of retrying.

### Describe how you validated your changes

- `go test -c ./test/new-e2e/tests/agent-runtimes/procmgr/...` (compile).
- `dda inv new-e2e-tests.run --targets=./tests/agent-runtimes/procmgr --run=TestProcmgrSmokeWindowsSuite` against a Windows agent build that includes procmgr (when run).

### Additional Notes

- No customer-facing agent behavior change; e2e + e2e-framework only.