### PR TITLE
omnibus: stream bazelisk output to CI logs

### DIFF
--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -16,7 +16,8 @@ dependency 'pympler'
 dependency 'datadog-agent-integrations-py3'
 
 build do
-    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} #{flavor_flag} -- //packages/agent/dependencies:install --destdir=#{install_dir}"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} #{flavor_flag} -- //packages/agent/dependencies:install --destdir=#{install_dir}",
+        :live_stream => Omnibus.logger.live_stream(:info)
 end
 
 build do

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -27,12 +27,15 @@ build do
         # Push all the pieces built with Bazel.
 
         # TODO: flavor can be defaulted and set from the bazel wrapper based on the environment.
-        command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/install_dir:install"
+        command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/install_dir:install",
+            :live_stream => Omnibus.logger.live_stream(:info)
 
         if linux_target?
-            command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/agent/linux:license_files_install --destdir=#{install_dir}"
+            command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/agent/linux:license_files_install --destdir=#{install_dir}",
+                :live_stream => Omnibus.logger.live_stream(:info)
         elsif osx_target?
-            command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/agent/dependencies:license_files_install --destdir=#{install_dir}"
+            command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/agent/dependencies:license_files_install --destdir=#{install_dir}",
+                :live_stream => Omnibus.logger.live_stream(:info)
         end
 
         # Conf files

--- a/omnibus/config/software/datadog-agent-installer-symlinks.rb
+++ b/omnibus/config/software/datadog-agent-installer-symlinks.rb
@@ -10,7 +10,8 @@ build do
 
   block do
     if linux_target? and install_dir == '/opt/datadog-agent'
-      command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //packages/agent/linux:install --destdir='/'"
+      command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //packages/agent/linux:install --destdir='/'",
+        :live_stream => Omnibus.logger.live_stream(:info)
       project.extra_package_file "/opt/datadog-packages/datadog-agent"
       project.extra_package_file "/opt/datadog-packages/run"
       # private action runner: pkg/privateactionrunner/autoconnections/conf

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -77,13 +77,16 @@ build do
     if ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?
       do_windows_sysprobe = "--windows-sysprobe"
     end
-    command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install --destdir=\"#{install_dir}"
+    command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install --destdir=\"#{install_dir}",
+      :live_stream => Omnibus.logger.live_stream(:info)
     # Put the static rtloader library where it gets picked up by the go build linking to it
-    command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install_static --destdir=\"#{project_dir}/rtloader/build/rtloader\""
+    command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install_static --destdir=\"#{project_dir}/rtloader/build/rtloader\"",
+      :live_stream => Omnibus.logger.live_stream(:info)
     command "dda inv -- -e agent.build --exclude-rtloader --no-development --install-path=#{install_dir} --embedded-path=#{install_dir}/embedded #{do_windows_sysprobe} --flavor #{flavor_arg}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     command "dda inv -- -e systray.build", env: env, :live_stream => Omnibus.logger.live_stream(:info)
   else
-    command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install --destdir='#{install_dir}'"
+    command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install --destdir='#{install_dir}'",
+      :live_stream => Omnibus.logger.live_stream(:info)
     command "dda inv -- -e agent.build --exclude-rtloader --no-development --install-path=#{install_dir} --embedded-path=#{install_dir}/embedded --flavor #{flavor_arg}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
   end
 

--- a/omnibus/config/software/init-scripts-agent.rb
+++ b/omnibus/config/software/init-scripts-agent.rb
@@ -14,7 +14,8 @@ build do
     if debian_target?
       # building into / is not acceptable. We'll continue to to that for now,
       # but the replacement has to build to a build output tree.
-      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/debian/etc:install --verbose --destdir=#{destdir}"
+      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/debian/etc:install --verbose --destdir=#{destdir}",
+        :live_stream => Omnibus.logger.live_stream(:info)
 
       # sysvinit support for debian only for now
       mkdir "/etc/init.d"
@@ -26,7 +27,8 @@ build do
       project.extra_package_file '/etc/init.d/datadog-agent-data-plane'
       project.extra_package_file '/etc/init.d/datadog-agent-action'
     elsif redhat_target? || suse_target?
-      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/redhat/etc:install --verbose --destdir=#{destdir}"
+      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/redhat/etc:install --verbose --destdir=#{destdir}",
+        :live_stream => Omnibus.logger.live_stream(:info)
     end
     project.extra_package_file '/etc/init/datadog-agent.conf'
     project.extra_package_file '/etc/init/datadog-agent-process.conf'

--- a/omnibus/config/software/init-scripts-ddot.rb
+++ b/omnibus/config/software/init-scripts-ddot.rb
@@ -10,12 +10,14 @@ build do
   output_config_dir = ENV["OUTPUT_CONFIG_DIR"] || ""
   if linux_target?
     if debian_target?
-      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/ddot/debian:install --verbose --destdir=#{destdir}"
+      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/ddot/debian:install --verbose --destdir=#{destdir}",
+        :live_stream => Omnibus.logger.live_stream(:info)
 
       project.extra_package_file '/etc/init.d/datadog-agent-ddot'
       project.extra_package_file '/etc/init/datadog-agent-ddot.conf'
     elsif redhat_target? || suse_target?
-      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/ddot/redhat:install --verbose --destdir=#{destdir}"
+      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/ddot/redhat:install --verbose --destdir=#{destdir}",
+        :live_stream => Omnibus.logger.live_stream(:info)
 
       project.extra_package_file '/etc/init/datadog-agent-ddot.conf'
     end

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -62,7 +62,8 @@ build do
       omnibus_package_dir = "#{ci_project_dir}/omnibus/pkg"
     end
     if omnibus_package_dir
-      command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=#{omnibus_package_dir}"
+      command_on_repo_root "bazelisk run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=#{omnibus_package_dir}",
+        :live_stream => Omnibus.logger.live_stream(:info)
     end
   elsif windows_target?
     command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -13,14 +13,17 @@ build do
 
   if !windows_target?
     env = with_standard_compiler_flags(with_embedded_path)
-    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @cpython//:install --destdir='#{install_dir}'"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @cpython//:install --destdir='#{install_dir}'",
+      :live_stream => Omnibus.logger.live_stream(:info)
     # Libraries and binaries are rpath-patched by dd_cc_packaged in cpython.BUILD.bazel;
     # this call is now only for the ##PREFIX## text substitution in _sysconfigdata.
     command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-      " #{install_dir}/embedded/lib/python3.*/_sysconfigdata__*.py"
+      " #{install_dir}/embedded/lib/python3.*/_sysconfigdata__*.py",
+      :live_stream => Omnibus.logger.live_stream(:info)
     python = "#{install_dir}/embedded/bin/python3"
   else
-    command_on_repo_root "bazelisk run #{flavor_flag} --//:install_dir=#{install_dir} -- @cpython//:install --destdir=#{install_dir}"
+    command_on_repo_root "bazelisk run #{flavor_flag} --//:install_dir=#{install_dir} -- @cpython//:install --destdir=#{install_dir}",
+      :live_stream => Omnibus.logger.live_stream(:info)
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
   end
 


### PR DESCRIPTION
### What does this PR do?
Add `:live_stream` to all `bazelisk run` calls in omnibus software definitions.

### Motivation
Bazel progress output (invocation ID, "Checking for file changes", cache hit/miss counts) was silently swallowed for most build steps, making it much harder to diagnose performance issues.

### Describe how you validated your changes

### Additional Notes
`bazelisk cquery` in `installer.rb` intentionally left unchanged (stdout is redirected to a file via shell).