### PR TITLE
perf(healthplatform): reduce idle memory and enable by default

### DIFF
--- a/comp/healthplatform/issues/invalidconfig/module.go
+++ b/comp/healthplatform/issues/invalidconfig/module.go
@@ -21,12 +21,13 @@ func init() {
 }
 
 type invalidConfigModule struct {
+	cfg     config.Component
 	checker *checker
 }
 
 // NewModule captures the config so the once-only startup check can read it.
 func NewModule(cfg config.Component) issues.Module {
-	return &invalidConfigModule{checker: newChecker(cfg)}
+	return &invalidConfigModule{cfg: cfg, checker: newChecker(cfg)}
 }
 
 func (m *invalidConfigModule) IssueName() string {
@@ -42,10 +43,24 @@ func (m *invalidConfigModule) BuiltInPeriodicHealthCheck() *runnerdef.BuiltInPer
 	return nil
 }
 
-// BuiltInStartupHealthCheck runs the schema validation once at agent startup.
+// BuiltInStartupHealthCheck runs schema validation once at agent startup.
+// The check is gated inside Fn rather than at registration time so that
+// IssueNames-based stale-issue resolution still fires on restart even when
+// the flag is disabled — returning nil/empty resolves any previously-stored
+// issues rather than leaving them orphaned.
+//
+// The gate exists because schema.ValidateCoreConfig decompresses, parses, and
+// compiles the full core_schema.yaml (~8000 lines) into a *jsonschema.Schema
+// stored in a process-lifetime global — adding ~8 MiB of permanent heap even
+// when the agent config is valid.
 func (m *invalidConfigModule) BuiltInStartupHealthCheck() *runnerdef.BuiltInHealthCheck {
 	return &runnerdef.BuiltInHealthCheck{
 		Source: "agent",
-		Fn:     m.checker.Run,
+		Fn: func() ([]runnerdef.IssueReport, error) {
+			if !m.cfg.GetBool("health_platform.invalidconfig_check.enabled") {
+				return nil, nil
+			}
+			return m.checker.Run()
+		},
 	}
 }

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -51,7 +51,7 @@ type Provides struct {
 	FlareProvider flaretypes.Provider
 }
 
-// healthPlatformImpl implements the health platform component
+// healthPlatformImpl implements the health platform component.
 // It aggregates health issues reported by various agent components and integrations.
 // The component provides methods to report issues, retrieve them, and manage the health monitoring lifecycle.
 type healthPlatformImpl struct {
@@ -62,17 +62,21 @@ type healthPlatformImpl struct {
 	hostnameProvider hostnameinterface.Component // Hostname provider for runtime resolution
 	agentFlavor      string                      // Agent flavor captured at construction time
 
-	// Issue tracking
-	issues       map[string]*healthplatform.Issue // IssueID → active Issue
-	issuesByName map[string]map[string]struct{}   // IssueName → set of active IssueIDs
-	issuesMux    sync.RWMutex                     // Mutex for thread-safe access to issues
+	// Issue tracking: lean protos — Extra and Remediation are stripped before storing
+	// and kept in extraJSON/remediationJSON to avoid retaining structpb heap allocations
+	// for the process lifetime. They are hydrated on demand at read time (egress, HTTP API).
+	issues          map[string]*healthplatform.Issue // IssueID → active Issue (no Extra/Remediation)
+	issuesByName    map[string][]string              // IssueName → active IssueIDs
+	extraJSON       map[string]json.RawMessage       // IssueID → Extra as raw JSON
+	remediationJSON map[string]json.RawMessage       // IssueID → Remediation as raw JSON
+	issuesMux       sync.RWMutex
 
-	// Persistence
-	persistedIssues map[string]*PersistedIssue // Persisted issues with status tracking
-	persistence     issuesPersistence          // Persistence strategy (disk or noop)
+	// Persistence: lifecycle state only — proto payload is not stored here.
+	persistedIssues map[string]*PersistedIssue // IssueID → lifecycle state
+	persistence     issuesPersistence
 
 	// Metrics
-	metrics telemetryMetrics // Telemetry metrics for health platform
+	metrics telemetryMetrics
 }
 
 type telemetryMetrics struct {
@@ -110,49 +114,21 @@ func issueStateFromString(s string) IssueState {
 	return 0
 }
 
-// pruneOldResolvedIssues removes resolved issues older than resolvedIssueTTL from the given map.
-// It modifies the map in place.
-func pruneOldResolvedIssues(issues map[string]*PersistedIssue) {
-	now := time.Now()
-	for checkID, persisted := range issues {
-		if persisted == nil || persisted.State != IssueStateResolved || persisted.ResolvedAt == "" {
-			continue
-		}
-		resolvedAt, err := time.Parse(time.RFC3339, persisted.ResolvedAt)
-		if err != nil {
-			continue
-		}
-		if now.Sub(resolvedAt) > resolvedIssueTTL {
-			delete(issues, checkID)
-		}
-	}
-}
-
-// PersistedIssue tracks issue state for disk persistence.
-// Custom JSON marshaling keeps the on-disk state field as a string.
-// The proto fields (Title through Remediation) are populated on every write so
-// that issues can be fully restored on restart without re-running the template.
+// PersistedIssue tracks the lifecycle state of an issue.
+// It is both the in-memory and on-disk representation; proto payload fields are
+// intentionally omitted because IssueIDs are deterministic — when the agent
+// restarts, health checks re-run and call ReportIssue with the same ID, at which
+// point storeIssue picks up the existing firstSeen/state from this struct.
 type PersistedIssue struct {
+	IssueID    string     `json:"issue_id"`
 	IssueType  string     `json:"issue_type"`
 	State      IssueState `json:"state"`
 	FirstSeen  string     `json:"first_seen"`
 	LastSeen   string     `json:"last_seen"`
 	ResolvedAt string     `json:"resolved_at,omitempty"`
-
-	// Proto fields — mirror of healthplatform.Issue, written on every ReportIssue.
-	IssueName   string          `json:"issue_name,omitempty"`
-	Title       string          `json:"title,omitempty"`
-	Description string          `json:"description,omitempty"`
-	Category    string          `json:"category,omitempty"`
-	Location    string          `json:"location,omitempty"`
-	Severity    string          `json:"severity,omitempty"`
-	Source      string          `json:"source,omitempty"`
-	Tags        []string        `json:"tags,omitempty"`
-	Extra       json.RawMessage `json:"extra,omitempty"`
-	Remediation json.RawMessage `json:"remediation,omitempty"`
 }
 
-// MarshalJSON converts the proto IssueState enum to its string representation for disk.
+// MarshalJSON serialises State as a human-readable string.
 func (p *PersistedIssue) MarshalJSON() ([]byte, error) {
 	type Alias PersistedIssue
 	return json.Marshal(&struct {
@@ -164,7 +140,7 @@ func (p *PersistedIssue) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// UnmarshalJSON parses the string state from disk back to the proto enum.
+// UnmarshalJSON parses the string state back to the proto enum.
 func (p *PersistedIssue) UnmarshalJSON(data []byte) error {
 	type Alias PersistedIssue
 	aux := &struct {
@@ -180,8 +156,8 @@ func (p *PersistedIssue) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// persistedIssueToProto converts a local PersistedIssue to the proto PersistedIssue
-// used in the Issue payload. The proto type uses *string for ResolvedAt.
+// persistedIssueToProto converts a PersistedIssue to the proto PersistedIssue
+// embedded in Issue payloads.
 func persistedIssueToProto(p *PersistedIssue) *healthplatform.PersistedIssue {
 	pi := &healthplatform.PersistedIssue{
 		State:     p.State,
@@ -195,22 +171,58 @@ func persistedIssueToProto(p *PersistedIssue) *healthplatform.PersistedIssue {
 }
 
 // PersistedState is the full state written to disk.
-// Version must equal persistedStateVersion; files with a different version
-// are logged and ignored on load (no migration).
+// Version must equal persistedStateVersion; files with a different version are ignored on load.
 type PersistedState struct {
 	Version   int                        `json:"version"`
 	UpdatedAt string                     `json:"updated_at"`
 	Issues    map[string]*PersistedIssue `json:"issues"`
 }
 
+// pruneOldResolvedIssues removes resolved issues older than resolvedIssueTTL from the given map.
+// It modifies the map in place.
+func pruneOldResolvedIssues(issues map[string]*PersistedIssue) {
+	now := time.Now()
+	for id, p := range issues {
+		if p == nil || p.State != IssueStateResolved || p.ResolvedAt == "" {
+			continue
+		}
+		resolvedAt, err := time.Parse(time.RFC3339, p.ResolvedAt)
+		if err != nil {
+			continue
+		}
+		if now.Sub(resolvedAt) > resolvedIssueTTL {
+			delete(issues, id)
+		}
+	}
+}
+
+// appendUnique appends id to ids only if not already present.
+func appendUnique(ids []string, id string) []string {
+	for _, existing := range ids {
+		if existing == id {
+			return ids
+		}
+	}
+	return append(ids, id)
+}
+
+// removeID removes the first occurrence of id from ids.
+func removeID(ids []string, id string) []string {
+	for i, existing := range ids {
+		if existing == id {
+			return append(ids[:i], ids[i+1:]...)
+		}
+	}
+	return ids
+}
+
 // ============================================================================
 // Constructor
 // ============================================================================
 
-// NewComponent creates a new health-platform component
+// NewComponent creates a new health-platform component.
 // It initializes the component with its dependencies and configures telemetry metrics.
 func NewComponent(reqs Requires) (Provides, error) {
-	// Check if health platform is enabled
 	if !reqs.Config.GetBool("health_platform.enabled") {
 		reqs.Log.Info("Health platform component is disabled")
 		noop := noopimpl.NewNoopHealthPlatform()
@@ -244,19 +256,18 @@ func NewComponent(reqs Requires) (Provides, error) {
 
 	// Initialize the health platform implementation
 	comp := &healthPlatformImpl{
-		// Core dependencies
 		config:           reqs.Config,
 		log:              reqs.Log,
 		telemetry:        reqs.Telemetry,
 		hostnameProvider: reqs.Hostname,
 		agentFlavor:      flavor.GetFlavor(),
 
-		// Issue tracking
-		issues:       make(map[string]*healthplatform.Issue),
-		issuesByName: make(map[string]map[string]struct{}),
-		issuesMux:    sync.RWMutex{},
+		issues:          make(map[string]*healthplatform.Issue),
+		issuesByName:    make(map[string][]string),
+		extraJSON:       make(map[string]json.RawMessage),
+		remediationJSON: make(map[string]json.RawMessage),
+		issuesMux:       sync.RWMutex{},
 
-		// Persistence
 		persistedIssues: make(map[string]*PersistedIssue),
 		persistence:     persistence,
 	}
@@ -301,7 +312,6 @@ func (h *healthPlatformImpl) start(_ context.Context) error {
 	if err := h.loadFromDisk(); err != nil {
 		h.log.Warn("Failed to load persisted issues: " + err.Error())
 	}
-
 	return nil
 }
 
@@ -343,7 +353,7 @@ func (h *healthPlatformImpl) ReportIssue(issue *healthplatform.Issue) error {
 // Query Methods
 // ============================================================================
 
-// GetAllIssues returns the count and all issues from all checks (indexed by check ID)
+// GetAllIssues returns the count and all issues from all checks (indexed by check ID).
 func (h *healthPlatformImpl) GetAllIssues() (int, map[string]*healthplatform.Issue) {
 	h.issuesMux.RLock()
 	defer h.issuesMux.RUnlock()
@@ -353,7 +363,9 @@ func (h *healthPlatformImpl) GetAllIssues() (int, map[string]*healthplatform.Iss
 	result := make(map[string]*healthplatform.Issue)
 	for checkID, issue := range h.issues {
 		if issue != nil {
-			result[checkID] = proto.Clone(issue).(*healthplatform.Issue)
+			clone := proto.Clone(issue).(*healthplatform.Issue)
+			h.hydrateIssue(clone)
+			result[checkID] = clone
 			count++
 		} else {
 			result[checkID] = nil
@@ -362,7 +374,7 @@ func (h *healthPlatformImpl) GetAllIssues() (int, map[string]*healthplatform.Iss
 	return count, result
 }
 
-// GetIssue returns the issue for a specific check (nil if no issue)
+// GetIssue returns the issue for a specific check (nil if no issue).
 func (h *healthPlatformImpl) GetIssue(checkID string) *healthplatform.Issue {
 	h.issuesMux.RLock()
 	defer h.issuesMux.RUnlock()
@@ -371,55 +383,71 @@ func (h *healthPlatformImpl) GetIssue(checkID string) *healthplatform.Issue {
 	if issue == nil {
 		return nil
 	}
-
 	// Return a copy to avoid external modifications
-	return proto.Clone(issue).(*healthplatform.Issue)
+	clone := proto.Clone(issue).(*healthplatform.Issue)
+	h.hydrateIssue(clone)
+	return clone
+}
+
+// hydrateIssue populates Extra and Remediation on a cloned issue from the JSON maps.
+// The hot store keeps issues without these fields; they are reconstructed on demand at read time.
+func (h *healthPlatformImpl) hydrateIssue(issue *healthplatform.Issue) {
+	if raw := h.extraJSON[issue.Id]; len(raw) > 0 {
+		issue.Extra = &structpb.Struct{}
+		if err := json.Unmarshal(raw, issue.Extra); err != nil {
+			h.log.Warnf("health platform: failed to hydrate Extra for issue %s: %v", issue.Id, err)
+			issue.Extra = nil
+		}
+	}
+	if raw := h.remediationJSON[issue.Id]; len(raw) > 0 {
+		issue.Remediation = &healthplatform.Remediation{}
+		if err := json.Unmarshal(raw, issue.Remediation); err != nil {
+			h.log.Warnf("health platform: failed to hydrate Remediation for issue %s: %v", issue.Id, err)
+			issue.Remediation = nil
+		}
+	}
 }
 
 // ============================================================================
 // Clear Methods
 // ============================================================================
 
-// ResolveIssue clears the issue for a specific check (useful when issue is resolved)
+// ResolveIssue marks an issue as resolved and removes it from the active set.
 func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 	h.issuesMux.Lock()
 
-	// Only log and update persistence if there was actually an issue to clear
-	existed := false
+	stateChanged := false
 	if _, ok := h.issues[issueID]; ok {
-		existed = true
 		h.log.Info("Cleared issue: " + issueID)
+		stateChanged = true
 	}
 	delete(h.issues, issueID)
+	delete(h.extraJSON, issueID)
+	delete(h.remediationJSON, issueID)
 
-	// Remove from name index
 	if persisted := h.persistedIssues[issueID]; persisted != nil {
-		delete(h.issuesByName[persisted.IssueType], issueID)
-	}
-
-	// Update persisted issue status to resolved
-	if persisted := h.persistedIssues[issueID]; persisted != nil {
-		persisted.State = IssueStateResolved
-		persisted.ResolvedAt = time.Now().Format(time.RFC3339)
+		h.issuesByName[persisted.IssueType] = removeID(h.issuesByName[persisted.IssueType], issueID)
+		if persisted.State != IssueStateResolved {
+			persisted.State = IssueStateResolved
+			persisted.ResolvedAt = time.Now().Format(time.RFC3339)
+			stateChanged = true
+		}
 	}
 
 	h.issuesMux.Unlock()
 
-	// Persist to disk if there was a change
-	if existed {
+	if stateChanged {
 		if err := h.saveToDisk(); err != nil {
 			h.log.Warn("Failed to persist issues to disk: " + err.Error())
 		}
 	}
 }
 
-// ResolveAllIssues clears all issues (useful for testing or when all issues are resolved)
+// ResolveAllIssues clears all active issues.
 func (h *healthPlatformImpl) ResolveAllIssues() {
 	h.issuesMux.Lock()
 
 	now := time.Now().Format(time.RFC3339)
-
-	// Mark all persisted issues as resolved
 	for _, persisted := range h.persistedIssues {
 		if persisted != nil && persisted.State != IssueStateResolved {
 			persisted.State = IssueStateResolved
@@ -428,12 +456,13 @@ func (h *healthPlatformImpl) ResolveAllIssues() {
 	}
 
 	h.issues = make(map[string]*healthplatform.Issue)
-	h.issuesByName = make(map[string]map[string]struct{})
+	h.issuesByName = make(map[string][]string)
+	h.extraJSON = make(map[string]json.RawMessage)
+	h.remediationJSON = make(map[string]json.RawMessage)
 	h.log.Info("Cleared all issues")
 
 	h.issuesMux.Unlock()
 
-	// Persist to disk
 	if err := h.saveToDisk(); err != nil {
 		h.log.Warn("Failed to persist issues to disk: " + err.Error())
 	}
@@ -446,10 +475,8 @@ func (h *healthPlatformImpl) GetActiveIssueIDsByIssueName(issueName string) []st
 	h.issuesMux.RLock()
 	defer h.issuesMux.RUnlock()
 	ids := h.issuesByName[issueName]
-	result := make([]string, 0, len(ids))
-	for id := range ids {
-		result = append(result, id)
-	}
+	result := make([]string, len(ids))
+	copy(result, ids)
 	return result
 }
 
@@ -463,17 +490,14 @@ func (h *healthPlatformImpl) handleIssueStateChange(source string, oldIssue, new
 	if oldIssue == nil && newIssue == nil {
 		return
 	}
-
 	if newIssue != nil && oldIssue == nil {
 		h.log.Info("Health platform: NEW issue from " + source + ": " + newIssue.Title + " (" + newIssue.Severity.String() + ")")
 		return
 	}
-
 	if newIssue == nil && oldIssue != nil {
 		h.log.Info("Health platform: issue RESOLVED from " + source)
 		return
 	}
-
 	if oldIssue.Title != newIssue.Title ||
 		oldIssue.Severity != newIssue.Severity ||
 		oldIssue.Description != newIssue.Description {
@@ -491,21 +515,22 @@ func (h *healthPlatformImpl) storeIssue(issueType string, issue *healthplatform.
 	issue.DetectedAt = now
 	h.metrics.issuesCounter.Add(1, issueType)
 
-	h.issues[issueID] = issue
-	if h.issuesByName[issueType] == nil {
-		h.issuesByName[issueType] = make(map[string]struct{})
-	}
-	h.issuesByName[issueType][issueID] = struct{}{}
+	// Clone before storing to avoid external mutations (reporters may reuse the same *Issue).
+	stored := proto.Clone(issue).(*healthplatform.Issue)
+	h.issues[issueID] = stored
+	h.issuesByName[issueType] = appendUnique(h.issuesByName[issueType], issueID)
 
 	existing := h.persistedIssues[issueID]
 	if existing == nil {
 		h.persistedIssues[issueID] = &PersistedIssue{
+			IssueID:   issueID,
 			IssueType: issueType,
 			State:     IssueStateNew,
 			FirstSeen: now,
 			LastSeen:  now,
 		}
 	} else if existing.State == IssueStateResolved {
+		existing.IssueID = issueID
 		existing.IssueType = issueType
 		existing.State = IssueStateNew
 		existing.FirstSeen = now
@@ -513,6 +538,7 @@ func (h *healthPlatformImpl) storeIssue(issueType string, issue *healthplatform.
 		existing.ResolvedAt = ""
 	} else if existing.IssueType != issueType {
 		h.log.Warnf("health platform: issue %s changed type from %s to %s; resetting to new", issueID, existing.IssueType, issueType)
+		existing.IssueID = issueID
 		existing.IssueType = issueType
 		existing.State = IssueStateNew
 		existing.FirstSeen = now
@@ -523,31 +549,33 @@ func (h *healthPlatformImpl) storeIssue(issueType string, issue *healthplatform.
 		existing.LastSeen = now
 	}
 
-	if persisted := h.persistedIssues[issueID]; persisted != nil {
-		issue.PersistedIssue = persistedIssueToProto(persisted)
-		persisted.IssueName = issue.IssueName
-		persisted.Title = issue.Title
-		persisted.Description = issue.Description
-		persisted.Category = issue.Category
-		persisted.Location = issue.Location
-		persisted.Severity = issue.Severity.String()
-		persisted.Source = issue.Source
-		persisted.Tags = issue.Tags
-		if issue.Extra != nil {
-			if raw, err := json.Marshal(issue.Extra); err == nil {
-				persisted.Extra = raw
-			} else {
-				h.log.Warnf("health platform: failed to serialize Extra for issue %s: %v", issueID, err)
-			}
+	stored.PersistedIssue = persistedIssueToProto(h.persistedIssues[issueID])
+
+	// Serialize Extra/Remediation to raw JSON and strip from the stored clone.
+	// This avoids retaining structpb heap allocations (one boxed *Value per field)
+	// for the process lifetime; they are reconstructed on demand in hydrateIssue.
+	if issue.Extra != nil {
+		if raw, err := json.Marshal(issue.Extra); err == nil {
+			h.extraJSON[issueID] = raw
+		} else {
+			h.log.Warnf("health platform: failed to serialize Extra for issue %s: %v", issueID, err)
+			delete(h.extraJSON, issueID)
 		}
-		if issue.Remediation != nil {
-			if raw, err := json.Marshal(issue.Remediation); err == nil {
-				persisted.Remediation = raw
-			} else {
-				h.log.Warnf("health platform: failed to serialize Remediation for issue %s: %v", issueID, err)
-			}
-		}
+	} else {
+		delete(h.extraJSON, issueID)
 	}
+	if issue.Remediation != nil {
+		if raw, err := json.Marshal(issue.Remediation); err == nil {
+			h.remediationJSON[issueID] = raw
+		} else {
+			h.log.Warnf("health platform: failed to serialize Remediation for issue %s: %v", issueID, err)
+			delete(h.remediationJSON, issueID)
+		}
+	} else {
+		delete(h.remediationJSON, issueID)
+	}
+	stored.Extra = nil
+	stored.Remediation = nil
 
 	h.issuesMux.Unlock()
 
@@ -560,8 +588,10 @@ func (h *healthPlatformImpl) storeIssue(issueType string, issue *healthplatform.
 // Persistence Methods
 // ============================================================================
 
-// loadFromDisk loads persisted issues via the persistence layer.
-// Files whose version field differs from persistedStateVersion are ignored.
+// loadFromDisk restores lifecycle state from the persistence layer.
+// Proto payload (issue title, description, etc.) is not stored on disk — IssueIDs are
+// deterministic, so health checks re-running after restart will call ReportIssue with the
+// same ID and storeIssue will pick up firstSeen/state from the restored PersistedIssue.
 func (h *healthPlatformImpl) loadFromDisk() error {
 	state, err := h.persistence.load()
 	if err != nil {
@@ -577,64 +607,25 @@ func (h *healthPlatformImpl) loadFromDisk() error {
 		return nil
 	}
 
+	pruneOldResolvedIssues(state.Issues)
+
 	h.issuesMux.Lock()
 	defer h.issuesMux.Unlock()
 
-	h.persistedIssues = state.Issues
-	pruneOldResolvedIssues(h.persistedIssues)
 	activeCount := 0
 	for issueID, persisted := range state.Issues {
+		if persisted == nil {
+			continue
+		}
+		persisted.IssueID = issueID
+		h.persistedIssues[issueID] = persisted
+
 		if persisted.State == IssueStateResolved || persisted.IssueType == "" {
 			continue
 		}
-		var issue *healthplatform.Issue
-		if persisted.Title != "" || persisted.Source != "" {
-			issue = &healthplatform.Issue{
-				Id:          issueID,
-				IssueName:   persisted.IssueName,
-				Title:       persisted.Title,
-				Description: persisted.Description,
-				Category:    persisted.Category,
-				Location:    persisted.Location,
-				Severity:    healthplatform.IssueSeverity(healthplatform.IssueSeverity_value[persisted.Severity]),
-				Source:      persisted.Source,
-				Tags:        persisted.Tags,
-			}
-			if len(persisted.Extra) > 0 {
-				issue.Extra = &structpb.Struct{}
-				if err := json.Unmarshal(persisted.Extra, issue.Extra); err != nil {
-					h.log.Warnf("health platform: failed to restore Extra for issue %s: %v", issueID, err)
-					issue.Extra = nil
-				}
-			}
-			if len(persisted.Remediation) > 0 {
-				issue.Remediation = &healthplatform.Remediation{}
-				if err := json.Unmarshal(persisted.Remediation, issue.Remediation); err != nil {
-					h.log.Warnf("health platform: failed to restore Remediation for issue %s: %v", issueID, err)
-					issue.Remediation = nil
-				}
-			}
-		} else {
-			// Version-2 files always cache proto fields; this handles the edge
-			// case of a file written before caching was introduced.
-			issue = &healthplatform.Issue{
-				Id:        issueID,
-				IssueName: persisted.IssueType,
-				Source:    persisted.Source,
-			}
-		}
-		issue.Id = issueID
-		issue.PersistedIssue = persistedIssueToProto(persisted)
-		h.issues[issueID] = issue
-		// Prefer IssueName (written by current code); fall back to IssueType for old JSON files.
-		nameKey := persisted.IssueName
-		if nameKey == "" {
-			nameKey = persisted.IssueType
-		}
-		if h.issuesByName[nameKey] == nil {
-			h.issuesByName[nameKey] = make(map[string]struct{})
-		}
-		h.issuesByName[nameKey][issueID] = struct{}{}
+
+		nameKey := persisted.IssueType
+		h.issuesByName[nameKey] = append(h.issuesByName[nameKey], issueID)
 		activeCount++
 	}
 
@@ -642,7 +633,9 @@ func (h *healthPlatformImpl) loadFromDisk() error {
 	return nil
 }
 
-// saveToDisk persists the current issue state via the persistence layer
+// saveToDisk persists the current lifecycle state via the persistence layer.
+// Only state metadata is written; proto payload fields are omitted because they are
+// repopulated by health checks on the next agent start.
 func (h *healthPlatformImpl) saveToDisk() error {
 	h.issuesMux.RLock()
 	// Make a deep copy to avoid race conditions during marshaling
@@ -655,7 +648,6 @@ func (h *healthPlatformImpl) saveToDisk() error {
 	}
 	h.issuesMux.RUnlock()
 
-	// Prune resolved issues older than the TTL before saving
 	pruneOldResolvedIssues(issuesCopy)
 
 	state := PersistedState{
@@ -663,7 +655,6 @@ func (h *healthPlatformImpl) saveToDisk() error {
 		UpdatedAt: time.Now().Format(time.RFC3339),
 		Issues:    issuesCopy,
 	}
-
 	return h.persistence.save(&state)
 }
 

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -51,6 +51,15 @@ type Provides struct {
 	FlareProvider flaretypes.Provider
 }
 
+// storedIssue is the in-memory record for an active issue.
+// Extra and Remediation are kept as raw JSON to avoid structpb heap allocations
+// for the process lifetime; they are rehydrated on demand at read time.
+type storedIssue struct {
+	issue           *healthplatform.Issue // lean proto — Extra and Remediation are nil
+	extraJSON       json.RawMessage
+	remediationJSON json.RawMessage
+}
+
 // healthPlatformImpl implements the health platform component.
 // It aggregates health issues reported by various agent components and integrations.
 // The component provides methods to report issues, retrieve them, and manage the health monitoring lifecycle.
@@ -62,14 +71,10 @@ type healthPlatformImpl struct {
 	hostnameProvider hostnameinterface.Component // Hostname provider for runtime resolution
 	agentFlavor      string                      // Agent flavor captured at construction time
 
-	// Issue tracking: lean protos — Extra and Remediation are stripped before storing
-	// and kept in extraJSON/remediationJSON to avoid retaining structpb heap allocations
-	// for the process lifetime. They are hydrated on demand at read time (egress, HTTP API).
-	issues          map[string]*healthplatform.Issue // IssueID → active Issue (no Extra/Remediation)
-	issuesByName    map[string][]string              // IssueName → active IssueIDs
-	extraJSON       map[string]json.RawMessage       // IssueID → Extra as raw JSON
-	remediationJSON map[string]json.RawMessage       // IssueID → Remediation as raw JSON
-	issuesMux       sync.RWMutex
+	// Issue tracking: dehydrated at ReportIssue, rehydrated on GetAllIssues/GetIssue.
+	issues       map[string]*storedIssue // IssueID → active issue (lean proto + raw JSON)
+	issuesByName map[string][]string     // IssueName → active IssueIDs
+	issuesMux    sync.RWMutex
 
 	// Persistence: lifecycle state only — proto payload is not stored here.
 	persistedIssues map[string]*PersistedIssue // IssueID → lifecycle state
@@ -262,11 +267,9 @@ func NewComponent(reqs Requires) (Provides, error) {
 		hostnameProvider: reqs.Hostname,
 		agentFlavor:      flavor.GetFlavor(),
 
-		issues:          make(map[string]*healthplatform.Issue),
-		issuesByName:    make(map[string][]string),
-		extraJSON:       make(map[string]json.RawMessage),
-		remediationJSON: make(map[string]json.RawMessage),
-		issuesMux:       sync.RWMutex{},
+		issues:       make(map[string]*storedIssue),
+		issuesByName: make(map[string][]string),
+		issuesMux:    sync.RWMutex{},
 
 		persistedIssues: make(map[string]*PersistedIssue),
 		persistence:     persistence,
@@ -341,7 +344,10 @@ func (h *healthPlatformImpl) ReportIssue(issue *healthplatform.Issue) error {
 	}
 
 	h.issuesMux.RLock()
-	previousIssue := h.issues[issue.Id]
+	var previousIssue *healthplatform.Issue
+	if prev := h.issues[issue.Id]; prev != nil {
+		previousIssue = prev.issue
+	}
 	h.issuesMux.RUnlock()
 
 	h.handleIssueStateChange(issue.Source, previousIssue, issue)
@@ -358,13 +364,12 @@ func (h *healthPlatformImpl) GetAllIssues() (int, map[string]*healthplatform.Iss
 	h.issuesMux.RLock()
 	defer h.issuesMux.RUnlock()
 
-	// Create a copy to avoid external modifications and count issues
 	count := 0
 	result := make(map[string]*healthplatform.Issue)
-	for checkID, issue := range h.issues {
-		if issue != nil {
-			clone := proto.Clone(issue).(*healthplatform.Issue)
-			h.hydrateIssue(clone)
+	for checkID, stored := range h.issues {
+		if stored != nil {
+			clone := proto.Clone(stored.issue).(*healthplatform.Issue)
+			hydrateIssue(clone, stored)
 			result[checkID] = clone
 			count++
 		} else {
@@ -379,30 +384,27 @@ func (h *healthPlatformImpl) GetIssue(checkID string) *healthplatform.Issue {
 	h.issuesMux.RLock()
 	defer h.issuesMux.RUnlock()
 
-	issue := h.issues[checkID]
-	if issue == nil {
+	stored := h.issues[checkID]
+	if stored == nil {
 		return nil
 	}
-	// Return a copy to avoid external modifications
-	clone := proto.Clone(issue).(*healthplatform.Issue)
-	h.hydrateIssue(clone)
+	clone := proto.Clone(stored.issue).(*healthplatform.Issue)
+	hydrateIssue(clone, stored)
 	return clone
 }
 
-// hydrateIssue populates Extra and Remediation on a cloned issue from the JSON maps.
+// hydrateIssue populates Extra and Remediation on a cloned issue from the storedIssue JSON.
 // The hot store keeps issues without these fields; they are reconstructed on demand at read time.
-func (h *healthPlatformImpl) hydrateIssue(issue *healthplatform.Issue) {
-	if raw := h.extraJSON[issue.Id]; len(raw) > 0 {
+func hydrateIssue(issue *healthplatform.Issue, stored *storedIssue) {
+	if len(stored.extraJSON) > 0 {
 		issue.Extra = &structpb.Struct{}
-		if err := json.Unmarshal(raw, issue.Extra); err != nil {
-			h.log.Warnf("health platform: failed to hydrate Extra for issue %s: %v", issue.Id, err)
+		if err := json.Unmarshal(stored.extraJSON, issue.Extra); err != nil {
 			issue.Extra = nil
 		}
 	}
-	if raw := h.remediationJSON[issue.Id]; len(raw) > 0 {
+	if len(stored.remediationJSON) > 0 {
 		issue.Remediation = &healthplatform.Remediation{}
-		if err := json.Unmarshal(raw, issue.Remediation); err != nil {
-			h.log.Warnf("health platform: failed to hydrate Remediation for issue %s: %v", issue.Id, err)
+		if err := json.Unmarshal(stored.remediationJSON, issue.Remediation); err != nil {
 			issue.Remediation = nil
 		}
 	}
@@ -422,8 +424,6 @@ func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 		stateChanged = true
 	}
 	delete(h.issues, issueID)
-	delete(h.extraJSON, issueID)
-	delete(h.remediationJSON, issueID)
 
 	if persisted := h.persistedIssues[issueID]; persisted != nil {
 		h.issuesByName[persisted.IssueType] = removeID(h.issuesByName[persisted.IssueType], issueID)
@@ -455,10 +455,8 @@ func (h *healthPlatformImpl) ResolveAllIssues() {
 		}
 	}
 
-	h.issues = make(map[string]*healthplatform.Issue)
+	h.issues = make(map[string]*storedIssue)
 	h.issuesByName = make(map[string][]string)
-	h.extraJSON = make(map[string]json.RawMessage)
-	h.remediationJSON = make(map[string]json.RawMessage)
 	h.log.Info("Cleared all issues")
 
 	h.issuesMux.Unlock()
@@ -515,9 +513,6 @@ func (h *healthPlatformImpl) storeIssue(issueType string, issue *healthplatform.
 	issue.DetectedAt = now
 	h.metrics.issuesCounter.Add(1, issueType)
 
-	// Clone before storing to avoid external mutations (reporters may reuse the same *Issue).
-	stored := proto.Clone(issue).(*healthplatform.Issue)
-	h.issues[issueID] = stored
 	h.issuesByName[issueType] = appendUnique(h.issuesByName[issueType], issueID)
 
 	existing := h.persistedIssues[issueID]
@@ -549,33 +544,30 @@ func (h *healthPlatformImpl) storeIssue(issueType string, issue *healthplatform.
 		existing.LastSeen = now
 	}
 
-	stored.PersistedIssue = persistedIssueToProto(h.persistedIssues[issueID])
-
-	// Serialize Extra/Remediation to raw JSON and strip from the stored clone.
-	// This avoids retaining structpb heap allocations (one boxed *Value per field)
-	// for the process lifetime; they are reconstructed on demand in hydrateIssue.
+	// Clone before storing to avoid external mutations (reporters may reuse the same *Issue).
+	// Serialize Extra/Remediation to raw JSON and strip from the lean clone so that
+	// structpb heap allocations are not retained for the process lifetime.
+	si := &storedIssue{}
 	if issue.Extra != nil {
 		if raw, err := json.Marshal(issue.Extra); err == nil {
-			h.extraJSON[issueID] = raw
+			si.extraJSON = raw
 		} else {
 			h.log.Warnf("health platform: failed to serialize Extra for issue %s: %v", issueID, err)
-			delete(h.extraJSON, issueID)
 		}
-	} else {
-		delete(h.extraJSON, issueID)
 	}
 	if issue.Remediation != nil {
 		if raw, err := json.Marshal(issue.Remediation); err == nil {
-			h.remediationJSON[issueID] = raw
+			si.remediationJSON = raw
 		} else {
 			h.log.Warnf("health platform: failed to serialize Remediation for issue %s: %v", issueID, err)
-			delete(h.remediationJSON, issueID)
 		}
-	} else {
-		delete(h.remediationJSON, issueID)
 	}
-	stored.Extra = nil
-	stored.Remediation = nil
+	lean := proto.Clone(issue).(*healthplatform.Issue)
+	lean.Extra = nil
+	lean.Remediation = nil
+	lean.PersistedIssue = persistedIssueToProto(h.persistedIssues[issueID])
+	si.issue = lean
+	h.issues[issueID] = si
 
 	h.issuesMux.Unlock()
 

--- a/comp/healthplatform/store/impl/store_test.go
+++ b/comp/healthplatform/store/impl/store_test.go
@@ -113,13 +113,10 @@ func newTestStore(t *testing.T) *healthPlatformImpl {
 		telemetry:        tel,
 		hostnameProvider: &mockHostname{name: "test-host"},
 		agentFlavor:      "agent",
-		issues:           make(map[string]*healthplatformpayload.Issue),
+		issues:           make(map[string]*storedIssue),
 		issuesByName:     make(map[string][]string),
-		extraJSON:        make(map[string]json.RawMessage),
-		remediationJSON:  make(map[string]json.RawMessage),
 		persistedIssues:  make(map[string]*PersistedIssue),
-
-		persistence: &memPersistence{},
+		persistence:      &memPersistence{},
 		metrics: telemetryMetrics{
 			issuesCounter: tel.NewCounter(
 				"health_platform", "issues_detected", []string{"issue_type"}, ""),
@@ -248,9 +245,9 @@ func TestGetAllIssuesDeepCopy(t *testing.T) {
 	require.NotNil(t, got)
 
 	// Mutating the returned value must not affect the in-store issue.
-	originalSource := h.issues["t:id"].Source
+	originalSource := h.issues["t:id"].issue.Source
 	got.Source = "hacked"
-	assert.Equal(t, originalSource, h.issues["t:id"].Source)
+	assert.Equal(t, originalSource, h.issues["t:id"].issue.Source)
 }
 
 func TestMultiInstanceSameType(t *testing.T) {
@@ -406,14 +403,11 @@ func TestTelemetryCounterIncrements(t *testing.T) {
 		telemetry:        tel,
 		hostnameProvider: &mockHostname{name: "test-host"},
 		agentFlavor:      "agent",
-		issues:           make(map[string]*healthplatformpayload.Issue),
+		issues:           make(map[string]*storedIssue),
 		issuesByName:     make(map[string][]string),
-		extraJSON:        make(map[string]json.RawMessage),
-		remediationJSON:  make(map[string]json.RawMessage),
 		persistedIssues:  make(map[string]*PersistedIssue),
-
-		persistence: &memPersistence{},
-		metrics:     telemetryMetrics{issuesCounter: counter},
+		persistence:      &memPersistence{},
+		metrics:          telemetryMetrics{issuesCounter: counter},
 	}
 
 	require.NoError(t, h.ReportIssue(&healthplatformpayload.Issue{Id: "t:id", IssueName: "t"}))

--- a/comp/healthplatform/store/impl/store_test.go
+++ b/comp/healthplatform/store/impl/store_test.go
@@ -114,9 +114,12 @@ func newTestStore(t *testing.T) *healthPlatformImpl {
 		hostnameProvider: &mockHostname{name: "test-host"},
 		agentFlavor:      "agent",
 		issues:           make(map[string]*healthplatformpayload.Issue),
-		issuesByName:     make(map[string]map[string]struct{}),
+		issuesByName:     make(map[string][]string),
+		extraJSON:        make(map[string]json.RawMessage),
+		remediationJSON:  make(map[string]json.RawMessage),
 		persistedIssues:  make(map[string]*PersistedIssue),
-		persistence:      &memPersistence{},
+
+		persistence: &memPersistence{},
 		metrics: telemetryMetrics{
 			issuesCounter: tel.NewCounter(
 				"health_platform", "issues_detected", []string{"issue_type"}, ""),
@@ -282,15 +285,28 @@ func TestPersistenceRoundTrip(t *testing.T) {
 	require.NoError(t, h1.ReportIssue(&healthplatformpayload.Issue{
 		Id: "t:id", IssueName: "t", Title: "Test Issue", Source: "test-src",
 	}))
+	firstSeen := h1.persistedIssues["t:id"].FirstSeen
 
 	h2 := newTestStore(t)
 	h2.persistence = newDiskPersistence(path, logger)
 	require.NoError(t, h2.loadFromDisk())
 
-	issue := h2.GetIssue("t:id")
-	require.NotNil(t, issue, "issue must survive persistence round-trip")
-	assert.Equal(t, "t:id", issue.Id)
-	assert.Equal(t, "Test Issue", issue.Title)
+	// Proto payload is not persisted — it is repopulated when the check re-runs.
+	// What must survive is the lifecycle state so that storeIssue can correctly
+	// resume firstSeen and state on the next ReportIssue call.
+	persisted := h2.persistedIssues["t:id"]
+	require.NotNil(t, persisted, "lifecycle state must survive persistence round-trip")
+	assert.Equal(t, "t:id", persisted.IssueID)
+	assert.Equal(t, "t", persisted.IssueType)
+	assert.Equal(t, firstSeen, persisted.FirstSeen)
+	assert.Equal(t, IssueStateNew, persisted.State)
+
+	// Re-reporting the same issue picks up the persisted firstSeen.
+	require.NoError(t, h2.ReportIssue(&healthplatformpayload.Issue{
+		Id: "t:id", IssueName: "t", Title: "Test Issue", Source: "test-src",
+	}))
+	assert.Equal(t, firstSeen, h2.persistedIssues["t:id"].FirstSeen, "firstSeen must be preserved across restart")
+	assert.Equal(t, IssueStateOngoing, h2.persistedIssues["t:id"].State)
 }
 
 func TestPersistenceVersionMismatch(t *testing.T) {
@@ -391,10 +407,13 @@ func TestTelemetryCounterIncrements(t *testing.T) {
 		hostnameProvider: &mockHostname{name: "test-host"},
 		agentFlavor:      "agent",
 		issues:           make(map[string]*healthplatformpayload.Issue),
-		issuesByName:     make(map[string]map[string]struct{}),
+		issuesByName:     make(map[string][]string),
+		extraJSON:        make(map[string]json.RawMessage),
+		remediationJSON:  make(map[string]json.RawMessage),
 		persistedIssues:  make(map[string]*PersistedIssue),
-		persistence:      &memPersistence{},
-		metrics:          telemetryMetrics{issuesCounter: counter},
+
+		persistence: &memPersistence{},
+		metrics:     telemetryMetrics{issuesCounter: counter},
 	}
 
 	require.NoError(t, h.ReportIssue(&healthplatformpayload.Issue{Id: "t:id", IssueName: "t"}))

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8218,7 +8218,7 @@ properties:
       enabled:
         node_type: setting
         type: boolean
-        default: false
+        default: true
       forwarder:
         node_type: section
         type: object
@@ -8231,6 +8231,16 @@ properties:
         node_type: setting
         type: boolean
         default: false
+      invalidconfig_check:
+        node_type: section
+        type: object
+        properties:
+          enabled:
+            node_type: setting
+            type: boolean
+            # Disabled by default: loading the compiled core_schema.yaml retains ~8 MiB of heap
+            # permanently (sync.Once global). Enable only if startup schema validation is needed.
+            default: false
   heroku_dyno:
     node_type: setting
     type: boolean

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1200,9 +1200,15 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("auth_init_timeout", 30*time.Second)
 	config.BindEnvAndSetDefault("bind_host", "")
 	config.BindEnvAndSetDefault("health_port", int64(0))
-	config.BindEnvAndSetDefault("health_platform.enabled", false)
+	config.BindEnvAndSetDefault("health_platform.enabled", true)
 	config.BindEnvAndSetDefault("health_platform.persist_on_kubernetes", false)
 	config.BindEnvAndSetDefault("health_platform.forwarder.interval", "0s")
+	// health_platform.invalidconfig_check.enabled is off by default because the check calls
+	// schema.ValidateCoreConfig which decompresses, parses, and compiles the full core_schema.yaml
+	// (~8000 lines) into a *jsonschema.Schema retained globally for the process lifetime.
+	// This adds ~8 MiB of permanent heap even when the agent config is valid.
+	// Enable it deliberately if you need schema validation at startup.
+	config.BindEnvAndSetDefault("health_platform.invalidconfig_check.enabled", false)
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
 	config.BindEnvAndSetDefault("win_skip_com_init", false)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)


### PR DESCRIPTION
### What does this PR do?

1. **Enables health platform by default** (`health_platform.enabled: true`)
2. **Reduces memory footprint** of the health platform store
3. **Simplifies the persistence model** — only lifecycle state is written to disk

### Motivation

Follow-up to the investigation in the #agent-health Slack thread on PR #51923. The goal is to enable agent health by default without a memory regression.

### Changes

**Store (`store.go`)**
- `Extra` and `Remediation` are stripped from the stored issue clone and kept as raw JSON in `extraJSON`/`remediationJSON` maps. This avoids retaining `structpb` heap allocations (one boxed `*structpb.Value` per context field) for the process lifetime. They are hydrated on demand via `hydrateIssue` at read time (egress, HTTP API, flare).
- `PersistedIssue` is now a lean in-memory-and-on-disk struct holding only lifecycle state (`IssueID`, `IssueType`, `State`, `FirstSeen`, `LastSeen`, `ResolvedAt`). Proto payload fields are no longer written to disk: IssueIDs are deterministic, so when the agent restarts and checks re-run with the same ID, `storeIssue` picks up the existing state from the restored `PersistedIssue`.
- `issuesByName` changed from `map[string]map[string]struct{}` to `map[string][]string`.
- Issue clones are stored (not the caller's pointer) to avoid mutating caller-owned protos across repeated `ReportIssue` calls.
- `ResolveIssue` triggers a disk save when a persisted issue transitions to resolved even if it was not yet in `h.issues` (e.g. stale issue from a prior run that was never re-reported after restart).

**Default on (`common_settings.go`, `core_schema.yaml`)**
- `health_platform.enabled` default changed from `false` to `true`.

**`invalidconfig` check**
- Gated inside the `Fn` closure (not at registration time) so IssueNames-based stale-issue resolution still fires on restart when disabled.
- Temporarily disabled, then moved behind a config flag, to confirm it was the source of the ~8 MiB idle memory regression.

### Describe how you validated your changes

`bazel test //comp/healthplatform/store/...` ✓

Regression detector identified a +5.55% idle memory increase from the `invalidconfig` check loading `core_schema.yaml` into a `sync.Once` global — confirmed by temporarily disabling the check.

### Additional Notes

Team: agent-health