### PR TITLE
[bazel] use release config unconditionally

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -104,6 +104,7 @@ import %workspace%/bazel/configs/rust.bazelrc
 # though we will never release that instance of the package to customers.
 common:release --config=rust-release
 common:release --//:release
+common --config=release
 
 # Local development options --------------------------------------------------------------------------------------------
 try-import %workspace%/user.bazelrc

--- a/bazel/configs/rust.bazelrc
+++ b/bazel/configs/rust.bazelrc
@@ -1,5 +1,5 @@
-build:rust-release --@rules_rust//rust/settings:lto=fat # Enable fat LTO
-build:rust-release --@rules_rust//rust/settings:extra_rustc_flag=-Copt-level=z # Optimize for size
-build:rust-release --@rules_rust//rust/settings:extra_rustc_flag=-Ccodegen-units=1 # Single codegen unit for maximum optimization
+common:rust-release --@rules_rust//rust/settings:lto=fat # Enable fat LTO
+common:rust-release --@rules_rust//rust/settings:extra_rustc_flag=-Copt-level=z # Optimize for size
+common:rust-release --@rules_rust//rust/settings:extra_rustc_flag=-Ccodegen-units=1 # Single codegen unit for maximum optimization
 # It was discussed in the Bazel/Rust round if we should drop this flag. Therefore, commenting it out for now.
-# build:rust-release --@rules_rust//rust/settings:extra_rustc_flag=-Cpanic=abort # Remove stack unwinding
+# common:rust-release --@rules_rust//rust/settings:extra_rustc_flag=-Cpanic=abort # Remove stack unwinding

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -17,7 +17,7 @@ if heroku_target?
 elsif fips_mode?
   flavor_flag = "--//packages/agent:flavor=fips"
 end
-bazel_flags = "--config=release #{flavor_flag} --//:install_dir='#{install_dir}'"
+bazel_flags = "#{flavor_flag} --//:install_dir='#{install_dir}'"
 
 # We don't want to build any dependencies in "repackaging mode" so all usual dependencies
 # need to go under this guard.

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -39,7 +39,7 @@ build do
     env["GOMODCACHE"] = gomodcache.to_path
   end
 
-  bazel_flags = "--config=release --//:install_dir=#{install_dir}"
+  bazel_flags = "--//:install_dir=#{install_dir}"
 
   if linux_target?
     command "invoke installer.build --no-cgo --run-path=/opt/datadog-packages/run --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1248,9 +1248,7 @@ def build_rust_binaries(ctx: Context, arch: Arch, output_dir: Path | None = None
             continue
 
         install_dest = output_dir / source_path if output_dir else Path(source_path)
-        bazel(
-            ctx, "run", *platform_flags, "--", f"@//{source_path}:install", f"--destdir={install_dest}"
-        )
+        bazel(ctx, "run", *platform_flags, "--", f"@//{source_path}:install", f"--destdir={install_dest}")
 
     # Install Rust static libraries that cgo needs to find at link time. These
     # always land in the source tree (alongside the Go files) rather than in
@@ -1258,9 +1256,7 @@ def build_rust_binaries(ctx: Context, arch: Arch, output_dir: Path | None = None
     for source_path, lib_dest in RUST_STATIC_LIBS.items():
         if packages and not any(source_path.startswith(package) for package in packages):
             continue
-        bazel(
-            ctx, "run", *platform_flags, "--", f"@//{source_path}:install_libs", f"--destdir={lib_dest}"
-        )
+        bazel(ctx, "run", *platform_flags, "--", f"@//{source_path}:install_libs", f"--destdir={lib_dest}")
 
 
 _BAZEL_CWS_BALOUM_TARGETS = {

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1243,15 +1243,13 @@ def build_rust_binaries(ctx: Context, arch: Arch, output_dir: Path | None = None
     if arch.kmt_arch in platform_map:
         platform_flags.append(f"--platforms={platform_map[arch.kmt_arch]}")
 
-    release_flags = ["--config=release"]
-
     for source_path in RUST_BINARIES:
         if packages and not any(source_path.startswith(package) for package in packages):
             continue
 
         install_dest = output_dir / source_path if output_dir else Path(source_path)
         bazel(
-            ctx, "run", *platform_flags, *release_flags, "--", f"@//{source_path}:install", f"--destdir={install_dest}"
+            ctx, "run", *platform_flags, "--", f"@//{source_path}:install", f"--destdir={install_dest}"
         )
 
     # Install Rust static libraries that cgo needs to find at link time. These
@@ -1261,7 +1259,7 @@ def build_rust_binaries(ctx: Context, arch: Arch, output_dir: Path | None = None
         if packages and not any(source_path.startswith(package) for package in packages):
             continue
         bazel(
-            ctx, "run", *platform_flags, *release_flags, "--", f"@//{source_path}:install_libs", f"--destdir={lib_dest}"
+            ctx, "run", *platform_flags, "--", f"@//{source_path}:install_libs", f"--destdir={lib_dest}"
         )
 
 


### PR DESCRIPTION
### What does this PR do?

We use `--config=release` flag unconditionally almost everywhere, but, for instance, python build doesn't have it. Technically, it is correct since release configuration only contains rust specific flags at this point, however in CI it has a side effect of bazel dropping its analysis cache between commands that use `--config=release` and those that don't. Dropping analysis cache is expensive and costs us several extra minutes added to the overall build duration every time.

This PR enables this configuration flag unconditionally to ensure that all bazel invocations have the same set of flags to ensure that we reuse analysis cache.