### PR TITLE
fix(omnibus): disable git cache on macOS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -261,9 +261,6 @@ variables:
   ## build to succeed with S3 caching disabled.
   S3_OMNIBUS_CACHE_BUCKET: dd-ci-datadog-agent-omnibus-cache-build-stable
   S3_OMNIBUS_GIT_CACHE_BUCKET: dd-ci-datadog-agent-omnibus-git-cache-build-stable
-  # This value is not used on windows, a specific value is provided to
-  # our build containers in the windows build jobs
-  OMNIBUS_GIT_CACHE_DIR: /tmp/omnibus-git-cache
   ## comment out the line below to disable integration wheels cache
   INTEGRATION_WHEELS_CACHE_BUCKET: dd-agent-omnibus
   S3_DD_AGENT_OMNIBUS_LLVM_URI: s3://dd-agent-omnibus/llvm

--- a/.gitlab/build/package_build/dmg.yml
+++ b/.gitlab/build/package_build/dmg.yml
@@ -63,7 +63,6 @@
   before_script:
     # Since there is no virtualization on the macOS runners, we need to unmount the Agent dmg volume to avoid conflicts
     - sudo umount /Volumes/Agent || true
-    - rm -rf "$OMNIBUS_GIT_CACHE_DIR" || true
   after_script:
     - sudo umount /Volumes/Agent || true
   script:

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -681,7 +681,6 @@ def docker_build(
 
     # Build environment variables
     env_args = [
-        "-e OMNIBUS_GIT_CACHE_DIR=/omnibus-state/git-cache",
         f"-e OMNIBUS_WORKERS_OVERRIDE={workers}",
         f"-e DD_CC={cc}",
         f"-e DD_CXX={cxx}",

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -290,6 +290,7 @@ def build(
         and target_project == "agent"
         and host_distribution != "ociru"
         and "OMNIBUS_PACKAGE_ARTIFACT_DIR" not in os.environ
+        and sys.platform != 'darwin'
     )
     remote_cache_name = os.environ.get('CI_JOB_NAME_SLUG')
     use_remote_cache = use_omnibus_git_cache and remote_cache_name is not None

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -1,6 +1,7 @@
 import functools
 import os
 import re
+import sys
 import unittest
 from pprint import pformat
 from unittest import mock
@@ -105,6 +106,8 @@ class TestOmnibusCache(unittest.TestCase):
 
     @_for_each_platform
     def test_successful_cache_hit(self):
+        if sys.platform == 'darwin':
+            return  # cache is disabled on macOS
         self.mock_ctx.set_result_for(
             'run',
             re.compile(r'git (.* )?tag -l'),
@@ -137,6 +140,8 @@ class TestOmnibusCache(unittest.TestCase):
 
     @_for_each_platform
     def test_cache_miss(self):
+        if sys.platform == 'darwin':
+            return  # cache is disabled on macOS
         self.mock_ctx.set_result_for(
             'run',
             re.compile(r'aws(\.exe)? s3 cp (\S* )?s3://omnibus-cache/\S* /\S+/omnibus-git-cache-bundle'),
@@ -176,6 +181,8 @@ class TestOmnibusCache(unittest.TestCase):
 
     @_for_each_platform
     def test_cache_hit_with_corruption(self):
+        if sys.platform == 'darwin':
+            return  # cache is disabled on macOS
         # Case where we get a bundle from S3 but git finds it to be corrupted
 
         # Fail to clone
@@ -206,6 +213,8 @@ class TestOmnibusCache(unittest.TestCase):
 
     @_for_each_platform
     def test_mutated_cache(self):
+        if sys.platform == 'darwin':
+            return  # cache is disabled on macOS
         self.mock_ctx.set_result_for(
             'run',
             re.compile(r'git (.* )?tag -l'),


### PR DESCRIPTION
### What does this PR do?

The omnibus git cache is always a cache miss on macOS CI. In addition, with the introduction of Bazel, there is little benefit in restoring from cache — omnibus would only cache the final results, but anything that depends on Python, OpenSSL, or other targets would still need to build from scratch to resolve dependencies.

### Motivation

### Describe how you validated your changes

### Additional Notes