### PR TITLE
[ABLD-410] Switch `cgo_godefs` to hermetic clang (rules_go 0.61+ prereq)

### DIFF
--- a/bazel/rules/ebpf/cgo_godefs.bzl
+++ b/bazel/rules/ebpf/cgo_godefs.bzl
@@ -73,19 +73,15 @@ def _cgo_godefs_impl(ctx):
         package_name = ctx.label.package.split("/")[-1]
         genpost_args = "$ROOT/{test} {pkg}".format(test = test_path_no_ext, pkg = package_name)
 
-    # TODO(ABLD-410): Linux still shells out to the system clang.
-    # Windows points cgo at the hermetic MinGW gcc from the cc_toolchain.
-    cc_prefix = "CC=clang " if platform == "linux" else "CC=$ROOT/{} ".format(go.cgo_tools.c_compiler_path)
-
     cmd = (
         "set -euo pipefail && ROOT=$PWD && cd {src_dir} && " +
-        "GOROOT=$ROOT/{goroot} {cc_prefix}$ROOT/{go} tool cgo -godefs -- {includes} -fsigned-char {src_file} | " +
+        "GOROOT=$ROOT/{goroot} CC=$ROOT/{cc} $ROOT/{go} tool cgo -godefs -- {includes} -fsigned-char {src_file} | " +
         "$ROOT/{genpost} {genpost_args} > $ROOT/{out}"
     ).format(
-        cc_prefix = cc_prefix,
+        cc = ctx.file.c_compiler.path,
         goroot = go.sdk.root_file.dirname,
         src_dir = src.dirname,
-        go = go.go.path,
+        go = go.sdk.go.path,
         includes = include_flags,
         src_file = src.basename,
         genpost = genpost.path,
@@ -101,8 +97,8 @@ def _cgo_godefs_impl(ctx):
     ctx.actions.run_shell(
         outputs = outputs,
         inputs = depset(
-            [src, go.go],
-            transitive = [headers, go.sdk.tools, go.sdk.srcs, go.sdk.libs, go.cc_toolchain_files],
+            [src, go.sdk.go, ctx.file.c_compiler],
+            transitive = [headers, go.sdk.tools, go.sdk.srcs, go.sdk.libs],
         ),
         tools = [genpost],
         command = cmd,
@@ -135,6 +131,10 @@ _cgo_godefs = rule(
         "hdrs": attr.label_list(
             providers = [CcInfo],
             doc = "cc_library targets whose headers are needed in the sandbox but whose include dirs should not appear as -I flags.",
+        ),
+        "c_compiler": attr.label(
+            allow_single_file = True,
+            cfg = "exec",
         ),
         "_genpost": attr.label(
             default = "//pkg/ebpf/cgo:genpost",
@@ -170,6 +170,10 @@ def _cgo_godefs_macro_impl(name, visibility, src, deps, hdrs, platform):
         src = src,
         deps = all_deps,
         hdrs = hdrs,
+        c_compiler = select({
+            "@platforms//os:windows": "@winlibs_mingw64//:gcc",
+            "//conditions:default": "@llvm_toolchain_llvm//:bin/clang",
+        }),
         target_compatible_with = compat,
     )
 


### PR DESCRIPTION
### What does this PR do?
This brings 2 changes to `cgo_godefs.bzl`:
1. replace the hard-coded `CC=clang` (host/system `clang`) with a hermetic compiler wired through the symbolic macro:
   - Windows uses MinGW `gcc` from `@winlibs_mingw64` as before, but now through an explicit compiler label,
   - default (i.e. Linux for now) use `clang`[^1] from `@llvm_toolchain_llvm` (hermetic),
2. replace the deprecated `go.go` and `go.go.path` context properties with `go.sdk.go` since the former got removed by bazel-contrib/rules_go#4389.

### Motivation
`CC=clang` worked on the _current_ `rules_go` because `go.env` injected `PATH=...:/usr/bin` into the sandbox action environment, making the host's `/usr/bin/clang` reachable.
bazel-contrib/rules_go#4389 (shipped in 0.61.0) no longer injects that `PATH`, so `CC=clang` fails in the sandbox:
```
cgo: C compiler "clang" not found: exec: "clang": executable file not found in $PATH
Target //pkg/network/tracer/offsetguess:offsetguess_types_godefs_test failed to build
```

This PR therefore replaces the `PATH`-dependent lookup with an explicit hermetic compiler dependency, closing ABLD-410 and unblocking the `rules_go` 0.61.x bump.

### Describe how you validated your changes
- `bazel build` and `bazel test` on all 23 Linux `cgo_godefs` targets pass,
- 46/46 `diff_test`s confirm generated files are unchanged (`clang` output is identical to what was committed but `gcc` output would diverge for `offsetguess_types_linux.go`[^1]),
- `bazel test` on Windows: `//pkg/network/driver:types_godefs_test` and `//pkg/windowsdriver/procmon:types_godefs_test` also pass.

### Additional Notes
[^1]: `clang` is **required**: our currently wired `gcc` is rather old and still emits enum constants as decimal floats, producing output that diverges from committed files.