### PR TITLE
feat(e2e-framework): add MustExecuteOn for EventuallyWithT remote SSH

### DIFF
--- a/test/e2e-framework/testing/utils/e2e/client/host.go
+++ b/test/e2e-framework/testing/utils/e2e/client/host.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cenkalti/backoff/v5"
 	"github.com/pkg/sftp"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
 	oscomp "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
@@ -211,6 +212,22 @@ func (h *sshExecutor) MustExecute(command string, options ...ExecuteOption) stri
 	if err != nil {
 		h.context.FailNow("%v", err)
 	}
+	return stdout
+}
+
+// MustExecuteOn runs Execute and requires no error on tb.
+//
+// Use this instead of [sshExecutor.MustExecute] inside require.EventuallyWithT (or similar) when the
+// closure receives a *assert.CollectT: [MustExecute] fails via the suite context and aborts the
+// whole test on the first error instead of letting the poll retry.
+//
+// tb must satisfy [require.TestingT] (e.g. *testing.T or *assert.CollectT).
+func (h *sshExecutor) MustExecuteOn(tb require.TestingT, command string, options ...ExecuteOption) string {
+	if hh, ok := tb.(interface{ Helper() }); ok {
+		hh.Helper()
+	}
+	stdout, err := h.Execute(command, options...)
+	require.NoError(tb, err)
 	return stdout
 }
 

--- a/test/new-e2e/examples/agentenv_logs_test.go
+++ b/test/new-e2e/examples/agentenv_logs_test.go
@@ -50,7 +50,7 @@ func (s *vmLogsExampleSuite) TestLogs() {
 	}, 5*time.Minute, 10*time.Second)
 	s.EventuallyWithT(func(c *assert.CollectT) {
 		// part 2: generate logs
-		s.Env().RemoteHost.MustExecute("echo 'totoro' >> /tmp/test.log")
+		s.Env().RemoteHost.MustExecuteOn(c, "echo 'totoro' >> /tmp/test.log")
 		// part 3: there should be logs
 		names, err := fakeintake.GetLogServiceNames()
 		assert.NoError(c, err)

--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -391,8 +391,8 @@ func (c *MacOSTestClient) Execute(command string) (output string, err error) {
 	return c.host.Execute(command)
 }
 
-// MustExecuteOn runs Execute on the underlying host and asserts no error on tb (e.g. *assert.CollectT).
-func (c *MacOSTestClient) MustExecuteOn(tb assert.TestingT, command string, options ...client.ExecuteOption) string {
+// MustExecuteOn runs Execute on the underlying host and requires no error on tb (e.g. *assert.CollectT).
+func (c *MacOSTestClient) MustExecuteOn(tb require.TestingT, command string, options ...client.ExecuteOption) string {
 	return c.host.MustExecuteOn(tb, command, options...)
 }
 

--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -391,6 +391,11 @@ func (c *MacOSTestClient) Execute(command string) (output string, err error) {
 	return c.host.Execute(command)
 }
 
+// MustExecuteOn runs Execute on the underlying host and asserts no error on tb (e.g. *assert.CollectT).
+func (c *MacOSTestClient) MustExecuteOn(tb assert.TestingT, command string, options ...client.ExecuteOption) string {
+	return c.host.MustExecuteOn(tb, command, options...)
+}
+
 // ExecuteWithRetry execute the command with retry
 func (c *MacOSTestClient) ExecuteWithRetry(cmd string) (output string, err error) {
 	return execWithRetry(c.Execute, cmd)

--- a/test/new-e2e/tests/agent-platform/tests/macos_install_test.go
+++ b/test/new-e2e/tests/agent-platform/tests/macos_install_test.go
@@ -48,8 +48,7 @@ func (m *macosInstallSuite) TestInstallAgent() {
 
 	// The agent should start at some point
 	m.EventuallyWithT(func(c *assert.CollectT) {
-		_, err := macosTestClient.Execute("sudo /usr/local/bin/datadog-agent status")
-		assert.NoError(c, err)
+		macosTestClient.MustExecuteOn(c, "sudo /usr/local/bin/datadog-agent status")
 	}, 20*time.Second, 1*time.Second)
 
 	// check that there is no world-writable files or directories in /opt/datadog-agent

--- a/test/new-e2e/tests/agent-runtimes/forwarder_nss_failover_test.go
+++ b/test/new-e2e/tests/agent-runtimes/forwarder_nss_failover_test.go
@@ -257,7 +257,7 @@ func (v *multiFakeIntakeSuite) requireIntakeIsUsed(intake *fi.Client, intakeMaxW
 		assert.NotEmpty(t, metricNames)
 
 		// check logs
-		v.Env().Host.MustExecute("echo 'totoro' >> " + logFile)
+		v.Env().Host.MustExecuteOn(t, "echo 'totoro' >> "+logFile)
 		logs, err := intake.FilterLogs(logService)
 		require.NoError(t, err)
 		assert.NotEmpty(t, logs)
@@ -290,7 +290,7 @@ func (v *multiFakeIntakeSuite) requireIntakeNotUsed(intake *fi.Client, intakeMax
 		intake.FlushServerAndResetAggregators()
 
 		// write a log
-		v.Env().Host.MustExecute("echo 'totoro' >> " + logFile)
+		v.Env().Host.MustExecuteOn(t, "echo 'totoro' >> "+logFile)
 
 		// send a flare
 		v.Env().Agent.Client.Flare(agentclient.WithArgs([]string{"--email", "e2e@test.com", "--send"}))

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_common_test.go
@@ -84,18 +84,16 @@ func (s *baseProcmgrSuite) TestBinariesExist() {
 }
 
 func (s *baseProcmgrSuite) TestServiceRunning() {
-	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out, err := s.Env().RemoteHost.Execute(s.platform.checkSvcRunning)
-		assert.NoError(t, err)
-		assert.Equal(t, s.platform.svcRunningOutput, strings.TrimSpace(out))
+	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecuteOn(ct, s.platform.checkSvcRunning)
+		assert.Equal(ct, s.platform.svcRunningOutput, strings.TrimSpace(out))
 	}, 30*time.Second, 2*time.Second)
 }
 
 func (s *baseProcmgrSuite) TestCLIStatus() {
 	s.requireCLI()
 	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
-		out, err := s.Env().RemoteHost.Execute(s.platform.cliCmd("status"))
-		require.NoError(ct, err)
+		out := s.Env().RemoteHost.MustExecuteOn(ct, s.platform.cliCmd("status"))
 		assertHasField(ct, out, "Version")
 		assertHasField(ct, out, "Uptime")
 	}, 30*time.Second, 2*time.Second)
@@ -104,8 +102,7 @@ func (s *baseProcmgrSuite) TestCLIStatus() {
 func (s *baseProcmgrSuite) TestCLIListShowsConfiguredProcess() {
 	s.requireCLI()
 	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
-		out, err := s.Env().RemoteHost.Execute(s.platform.cliCmd("list"))
-		require.NoError(ct, err)
+		out := s.Env().RemoteHost.MustExecuteOn(ct, s.platform.cliCmd("list"))
 		assertTableRow(ct, out, "test-sleep", map[string]string{
 			"STATE":   "Running",
 			"COMMAND": s.platform.sleepCommand,
@@ -116,8 +113,7 @@ func (s *baseProcmgrSuite) TestCLIListShowsConfiguredProcess() {
 func (s *baseProcmgrSuite) TestCLIDescribe() {
 	s.requireCLI()
 	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
-		out, err := s.Env().RemoteHost.Execute(s.platform.cliCmd("describe test-sleep"))
-		require.NoError(ct, err)
+		out := s.Env().RemoteHost.MustExecuteOn(ct, s.platform.cliCmd("describe test-sleep"))
 		assertField(ct, out, "Name", "test-sleep")
 		assertField(ct, out, "State", "Running")
 		assertField(ct, out, "Command", s.platform.sleepCommand)
@@ -127,8 +123,7 @@ func (s *baseProcmgrSuite) TestCLIDescribe() {
 func (s *baseProcmgrSuite) TestConditionPathExistsSkipsMissingBinary() {
 	s.requireCLI()
 	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
-		out, err := s.Env().RemoteHost.Execute(s.platform.cliCmd("list"))
-		require.NoError(ct, err)
+		out := s.Env().RemoteHost.MustExecuteOn(ct, s.platform.cliCmd("list"))
 		assertTableRow(ct, out, "missing-binary", map[string]string{
 			"STATE": "Created",
 			"PID":   "-",

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
@@ -91,8 +91,7 @@ func (s *procmgrLinuxSuite) SetupSuite() {
 
 	if s.hasCLI {
 		require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-			_, err := s.Env().RemoteHost.Execute("sudo chmod 0777 " + linuxSocket)
-			assert.NoError(t, err, "socket not yet available")
+			s.Env().RemoteHost.MustExecuteOn(t, "sudo chmod 0777 "+linuxSocket)
 		}, 30*time.Second, 2*time.Second)
 	}
 }
@@ -177,7 +176,7 @@ func (s *procmgrLinuxSuite) TestDDOTRestartAfterKill() {
 func (s *procmgrLinuxSuite) TestDDOTProcessDescribe() {
 	s.requireDDOT()
 	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("describe datadog-agent-ddot"))
+		out := s.Env().RemoteHost.MustExecuteOn(t, s.platform.cliCmd("describe datadog-agent-ddot"))
 		assertField(t, out, "Name", "datadog-agent-ddot")
 		assertField(t, out, "State", "Running")
 		assertField(t, out, "Command", ddotExtBinaryPath)
@@ -195,7 +194,7 @@ func (s *procmgrLinuxSuite) waitForRunningProcess(name, expectedBinary string, t
 	s.T().Helper()
 	var pid string
 	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		out := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("describe " + name))
+		out := s.Env().RemoteHost.MustExecuteOn(t, s.platform.cliCmd("describe "+name))
 		assertField(t, out, "State", "Running")
 		p := fieldValue(out, "PID")
 		if !assert.NotEmpty(t, p, "PID should be present for a Running process") ||

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_win_test.go
@@ -101,9 +101,8 @@ func (s *procmgrWindowsSuite) SetupSuite() {
 
 	if s.hasCLI {
 		require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-			out, err := s.Env().RemoteHost.Execute(
+			out := s.Env().RemoteHost.MustExecuteOn(t,
 				`powershell -Command "(Get-Service dd-procmgr-service).Status"`)
-			assert.NoError(t, err)
 			assert.Equal(t, "Running", strings.TrimSpace(out))
 		}, 60*time.Second, 2*time.Second)
 	}

--- a/test/new-e2e/tests/cws/windows_test.go
+++ b/test/new-e2e/tests/cws/windows_test.go
@@ -164,7 +164,7 @@ func (a *agentSuiteWindows) Test03CreateFileSignal() {
 
 	var policies string
 	require.EventuallyWithT(a.T(), func(c *assert.CollectT) {
-		policies = a.Env().RemoteHost.MustExecute(fmt.Sprintf("$env:DD_APP_KEY='%s'; $env:DD_API_KEY='%s'; & '%s' runtime policy download | Out-File temp.txt; Get-Content temp.txt", appKey, apiKey, systemProbePathWindows))
+		policies = a.Env().RemoteHost.MustExecuteOn(c, fmt.Sprintf("$env:DD_APP_KEY='%s'; $env:DD_API_KEY='%s'; & '%s' runtime policy download | Out-File temp.txt; Get-Content temp.txt", appKey, apiKey, systemProbePathWindows))
 		assert.NotEmpty(c, policies, "should not be empty")
 	}, 1*time.Minute, 1*time.Second)
 

--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -546,7 +546,7 @@ func (s *linuxTestSuite) validateDiscoveryMode(mode discoveryMode) {
 		// In system-probe-lite mode, system-probe execs into system-probe-lite during startup.
 		// Retry because the exec happens after fx initialization completes.
 		require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
-			ps := s.Env().RemoteHost.MustExecute("ps aux | grep 'system-probe' | grep -v grep")
+			ps := s.Env().RemoteHost.MustExecuteOn(c, "ps aux | grep 'system-probe' | grep -v grep")
 			s.T().Logf("Process list:\n%s", ps)
 			assert.Contains(c, ps, "system-probe-lite", "system-probe-lite should be running in system-probe-lite mode")
 		}, 1*time.Minute, 5*time.Second)

--- a/test/new-e2e/tests/discovery/process_autodiscovery_test.go
+++ b/test/new-e2e/tests/discovery/process_autodiscovery_test.go
@@ -85,8 +85,7 @@ http {
 
 	// Verify nginx stub_status is accessible, retrying to allow reload to complete
 	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
-		output, err := s.Env().RemoteHost.Execute("curl -s http://localhost:81/nginx_status")
-		assert.NoError(c, err, "curl failed")
+		output := s.Env().RemoteHost.MustExecuteOn(c, "curl -s http://localhost:81/nginx_status")
 		assert.Contains(c, output, "Active connections", "nginx stub_status should be accessible")
 	}, 30*time.Second, 2*time.Second)
 }
@@ -108,7 +107,7 @@ func (s *processAutodiscoverySuite) verifyRedisCheckScheduledViaProcess(c *asser
 	t := s.T()
 
 	// Verify check configuration via config-check
-	configCheckOutput := s.Env().RemoteHost.MustExecute("sudo datadog-agent configcheck")
+	configCheckOutput := s.Env().RemoteHost.MustExecuteOn(c, "sudo datadog-agent configcheck")
 
 	if !assert.Contains(c, configCheckOutput, "=== redisdb check ===", "redisdb check should be configured") {
 		t.Logf("config-check output: %s", configCheckOutput)
@@ -128,7 +127,7 @@ func (s *processAutodiscoverySuite) verifyRedisCheckScheduledViaProcess(c *asser
 	}
 
 	// Verify the check is running via collector status
-	statusOutput := s.Env().RemoteHost.MustExecute("sudo datadog-agent status collector --json")
+	statusOutput := s.Env().RemoteHost.MustExecuteOn(c, "sudo datadog-agent status collector --json")
 
 	var status collectorStatus
 	err := json.Unmarshal([]byte(statusOutput), &status)
@@ -176,7 +175,7 @@ func (s *processAutodiscoverySuite) verifyNginxCheckScheduledViaProcess(c *asser
 	t.Logf("nginx process count: %s", nginxCount)
 
 	// Verify check configuration via config-check
-	configCheckOutput := s.Env().RemoteHost.MustExecute("sudo datadog-agent configcheck")
+	configCheckOutput := s.Env().RemoteHost.MustExecuteOn(c, "sudo datadog-agent configcheck")
 
 	if !assert.Contains(c, configCheckOutput, "=== nginx check ===", "nginx check should be configured") {
 		t.Logf("config-check output: %s", configCheckOutput)
@@ -190,7 +189,7 @@ func (s *processAutodiscoverySuite) verifyNginxCheckScheduledViaProcess(c *asser
 	}
 
 	// Verify the check is running via collector status
-	statusOutput := s.Env().RemoteHost.MustExecute("sudo datadog-agent status collector --json")
+	statusOutput := s.Env().RemoteHost.MustExecuteOn(c, "sudo datadog-agent status collector --json")
 
 	var status collectorStatus
 	err := json.Unmarshal([]byte(statusOutput), &status)

--- a/test/new-e2e/tests/language-detection/setup_test.go
+++ b/test/new-e2e/tests/language-detection/setup_test.go
@@ -17,10 +17,10 @@ import (
 // will run first.
 func (s *languageDetectionSuite) Test00EnsureSetup() {
 	s.EventuallyWithT(func(collect *assert.CollectT) {
-		status := s.Env().RemoteHost.MustExecute(("sudo datadog-agent status"))
+		status := s.Env().RemoteHost.MustExecuteOn(collect, ("sudo datadog-agent status"))
 		assert.Contains(collect, status, "Agent start", "agent failed to return status")
 
-		wl := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/bin/agent/agent workload-list")
+		wl := s.Env().RemoteHost.MustExecuteOn(collect, "sudo /opt/datadog-agent/bin/agent/agent workload-list")
 		assert.NotEmpty(collect, strings.TrimSpace(wl), "agent workload-list was empty")
 	}, 5*time.Minute, 10*time.Second, "setup never completed")
 }

--- a/test/new-e2e/tests/npm/agentenv_npm_test.go
+++ b/test/new-e2e/tests/npm/agentenv_npm_test.go
@@ -39,7 +39,7 @@ func (v *vmSuiteEx6) Test1_FakeIntakeNPM() {
 	// This loop waits for agent and system-probe to be ready, stated by
 	// checking we eventually receive a payload
 	v.EventuallyWithT(func(c *assert.CollectT) {
-		v.Env().RemoteHost.MustExecute("curl http://www.datadoghq.com")
+		v.Env().RemoteHost.MustExecuteOn(c, "curl http://www.datadoghq.com")
 
 		hostnameNetID, err := v.Env().FakeIntake.Client().GetConnectionsNames()
 		require.NoError(c, err, "fakeintake GetConnectionsNames() error")

--- a/test/new-e2e/tests/npm/ec2_1host_direct_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_direct_test.go
@@ -59,7 +59,7 @@ func (v *ec2VMDirectSuite) BeforeTest(suiteName, testName string) {
 
 	// Verify that the process agent is not running
 	assert.EventuallyWithT(v.T(), func(c *assert.CollectT) {
-		status := v.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent status")
+		status := v.Env().RemoteHost.MustExecuteOn(c, "sudo /opt/datadog-agent/embedded/bin/process-agent status")
 		assert.Contains(c, status, "The Process Agent is not running")
 	}, 1*time.Minute, 5*time.Second)
 

--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
@@ -77,14 +77,12 @@ func (s *linuxPrivateActionRunnerEnabledSuite) TestPrivateActionRunnerStartsWhen
 
 	// Verify the log file exists
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
-		_, logExistsErr := host.Execute("sudo test -f " + privateActionRunnerLogFile)
-		assert.NoError(c, logExistsErr)
+		host.MustExecuteOn(c, "sudo test -f "+privateActionRunnerLogFile)
 	}, 2*time.Minute, 5*time.Second, "private action runner log file should exist")
 
 	// Verify log contains startup message
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
-		_, logContainsErr := host.Execute(fmt.Sprintf("sudo grep -i %q %s", privateActionRunnerStartedLogLine, privateActionRunnerLogFile))
-		assert.NoError(c, logContainsErr)
+		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -i %q %s", privateActionRunnerStartedLogLine, privateActionRunnerLogFile))
 	}, 2*time.Minute, 5*time.Second, "private action runner log should contain the started message")
 }
 

--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_nix_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_nix_test.go
@@ -67,12 +67,10 @@ func (s *linuxPrivateActionRunnerSuite) TestPrivateActionRunnerStopsWhenDisabled
 	}, 2*time.Minute, 5*time.Second, "privateactionrunner process should not be running when disabled")
 
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
-		_, logExistsErr := host.Execute("sudo test -f " + privateActionRunnerLogFile)
-		assert.NoError(c, logExistsErr)
+		host.MustExecuteOn(c, "sudo test -f "+privateActionRunnerLogFile)
 	}, 2*time.Minute, 5*time.Second, "private action runner log file should exist")
 
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
-		_, logContainsErr := host.Execute(fmt.Sprintf("sudo grep -F %q %s", privateActionRunnerDisabledLogLine, privateActionRunnerLogFile))
-		assert.NoError(c, logContainsErr)
+		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", privateActionRunnerDisabledLogLine, privateActionRunnerLogFile))
 	}, 2*time.Minute, 5*time.Second, "private action runner log should contain the disabled message")
 }

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -233,7 +233,7 @@ func (s *linuxTestSuite) TestManualProcessCheck() {
 	s.UpdateEnv(awshost.Provisioner(awshost.WithRunOptions(scenec2.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr)))))
 
 	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
-		check := s.Env().RemoteHost.MustExecute("sudo datadog-agent processchecks process --json")
+		check := s.Env().RemoteHost.MustExecuteOn(c, "sudo datadog-agent processchecks process --json")
 		assertManualProcessCheck(c, check, false, "stress")
 	}, 2*time.Minute, 10*time.Second)
 }
@@ -242,14 +242,14 @@ func (s *linuxTestSuite) TestManualRTProcessCheckCoreAgent() {
 	s.UpdateEnv(awshost.Provisioner(awshost.WithRunOptions(scenec2.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr)))))
 
 	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
-		check := s.Env().RemoteHost.MustExecute("sudo datadog-agent processchecks rtprocess --json")
+		check := s.Env().RemoteHost.MustExecuteOn(c, "sudo datadog-agent processchecks rtprocess --json")
 		assertManualRTProcessCheck(c, check)
 	}, 2*time.Minute, 10*time.Second)
 }
 
 func (s *linuxTestSuite) TestManualProcessDiscoveryCheck() {
 	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
-		check := s.Env().RemoteHost.MustExecute("sudo datadog-agent processchecks process_discovery --json")
+		check := s.Env().RemoteHost.MustExecuteOn(c, "sudo datadog-agent processchecks process_discovery --json")
 		assertManualProcessDiscoveryCheck(c, check, "stress")
 	}, 2*time.Minute, 10*time.Second)
 }
@@ -263,7 +263,7 @@ func (s *linuxTestSuite) TestManualProcessCheckWithIO() {
 		agentparams.WithSystemProbeConfig(systemProbeConfigStr)))))
 
 	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
-		check := s.Env().RemoteHost.MustExecute("sudo datadog-agent processchecks process --json")
+		check := s.Env().RemoteHost.MustExecuteOn(c, "sudo datadog-agent processchecks process --json")
 		assertManualProcessCheck(c, check, true, "stress")
 	}, 2*time.Minute, 10*time.Second)
 }

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -293,7 +293,7 @@ func (s *windowsTestSuite) TestManualUnprotectedProcessCheckWithIO() {
 	// Try multiple times as all the I/O data may not be available in a given instant
 	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
 		check := s.Env().RemoteHost.
-			MustExecute("& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent\\process-agent.exe\" check process --json")
+			MustExecuteOn(c, "& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent\\process-agent.exe\" check process --json")
 		assertManualProcessCheck(c, check, true, process)
 
 		var checkOutput struct {
@@ -348,10 +348,7 @@ func (s *windowsTestSuite) TestLanguageDetectionWindows() {
 
 	var lastOutput string
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		out, err := s.Env().RemoteHost.Execute(`& "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" workload-list --json`)
-		if !assert.NoError(c, err, "workload-list command failed") {
-			return
-		}
+		out := s.Env().RemoteHost.MustExecuteOn(c, `& "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" workload-list --json`)
 		lastOutput = out
 		var resp workloadResponse
 		if !assert.NoError(c, json.Unmarshal([]byte(lastOutput), &resp), "failed to parse workload-list JSON") {

--- a/test/new-e2e/tests/remote-config/utils_test.go
+++ b/test/new-e2e/tests/remote-config/utils_test.go
@@ -65,8 +65,7 @@ func assertCurlAgentRcServiceContainsEventually(t *testing.T, rh *components.Rem
 	copy(missingContents, expectedKeys)
 	foundContents := make(map[string]bool, len(expectedKeys))
 	assert.EventuallyWithTf(t, func(c *assert.CollectT) {
-		curlOutput, err := rh.Execute(fmt.Sprintf("curl -sSL localhost:8126/v0.7/config -d @- <<EOF\n%sEOF", payload))
-		assert.NoError(c, err)
+		curlOutput := rh.MustExecuteOn(c, fmt.Sprintf("curl -sSL localhost:8126/v0.7/config -d @- <<EOF\n%sEOF", payload))
 		for _, content := range missingContents {
 			if strings.Contains(curlOutput, content) {
 				t.Logf("found content: %s", content)

--- a/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go
+++ b/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go
@@ -121,8 +121,7 @@ func (v *multiVMSuite) writeCheckConfigAndRestart(host *components.RemoteHost, c
 func (v *multiVMSuite) waitForAgentCheckRunning(host *components.RemoteHost) {
 	cmd := fmt.Sprintf(`&'%s' status`, agentBinaryPath)
 	v.EventuallyWithT(func(c *assert.CollectT) {
-		output, err := host.Execute(cmd)
-		assert.NoError(c, err)
+		output := host.MustExecuteOn(c, cmd)
 		assert.Contains(c, output, checkName)
 		v.T().Logf("Agent status: %s", output)
 	}, agentStatusTimeout, retryInterval)
@@ -133,9 +132,7 @@ func (v *multiVMSuite) runCheckAndWaitForMetric(host *components.RemoteHost, exp
 	cmdCheck := fmt.Sprintf(`&'%s' check %s`, agentBinaryPath, checkName)
 	var output string
 	v.EventuallyWithT(func(c *assert.CollectT) {
-		var err error
-		output, err = host.Execute(cmdCheck)
-		assert.NoError(c, err)
+		output = host.MustExecuteOn(c, cmdCheck)
 		assert.Contains(c, output, expectedMetric)
 		assert.NotContains(c, output, "Access is denied")
 		v.T().Logf("Check output: %s", output)


### PR DESCRIPTION
### What does this PR do?

- Adds `MustExecuteOn(tb require.TestingT, command string, options ...ExecuteOption) string` on the e2e SSH host client: runs `Execute`, then `require.NoError(tb, err)` (with optional `Helper()` when `tb` supports it).
- Documents that `MustExecute` must not be used inside `require.EventuallyWithT` / `*assert.CollectT` polls, because it `require`s on the suite `T` and aborts the whole test instead of retrying.
- Migrates new-e2e call sites from `MustExecute` or `Execute` + `assert.NoError(<CollectT>, err)` to `MustExecuteOn` where the remote command runs inside a polling callback.
- Adds `MacOSTestClient.MustExecuteOn`, forwarding to the underlying `RemoteHost`.

`tb` is **`require.TestingT`** (not `assert.TestingT`): `require.NoError` needs `FailNow()`. `*assert.CollectT` still implements that interface and is the intended use inside `EventuallyWithT`.

### Motivation

`MustExecute` always calls `require.NoError(h.context.T(), err)`, so the first SSH failure `FailNow`s the suite `testing.T` and `EventuallyWithT` never gets another attempt. Failures from remote commands in a poll must be asserted on the **`CollectT`** so the attempt can be retried until the timeout.

### Describe how you validated your changes

- `go test -c` / `go test` on `test/e2e-framework/testing/utils/e2e/client` (and pre-commit hooks on commit).
- Compile checks with a Go toolchain matching `go.work` (e.g. `GOTOOLCHAIN=go1.26.4`) as needed locally.

### Additional Notes

- No Datadog Agent runtime or customer-facing behavior change; e2e framework + new-e2e tests only.
- Optional follow-up: apply the same pattern anywhere new tests use `MustExecute` inside `CollectT` closures.