### PR TITLE
fix(healthplatform): ValidateCoreConfigNoCache — transient schema compilation

### DIFF
--- a/comp/healthplatform/issues/invalidconfig/check.go
+++ b/comp/healthplatform/issues/invalidconfig/check.go
@@ -43,7 +43,7 @@ func (c *checker) validate() ([]runnerdef.IssueReport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalidconfig: normalize config: %w", err)
 	}
-	errs, schemaErr := schema.ValidateCoreConfig(normalized)
+	errs, schemaErr := schema.ValidateCoreConfigNoCache(normalized)
 	if schemaErr != nil {
 		pkglog.Warnf("invalidconfig: schema validator unavailable; skipping check: %v", schemaErr)
 		return nil, schemaErr

--- a/comp/healthplatform/issues/invalidconfig/module.go
+++ b/comp/healthplatform/issues/invalidconfig/module.go
@@ -49,10 +49,9 @@ func (m *invalidConfigModule) BuiltInPeriodicHealthCheck() *runnerdef.BuiltInPer
 // the flag is disabled — returning nil/empty resolves any previously-stored
 // issues rather than leaving them orphaned.
 //
-// The gate exists because schema.ValidateCoreConfig decompresses, parses, and
-// compiles the full core_schema.yaml (~8000 lines) into a *jsonschema.Schema
-// stored in a process-lifetime global — adding ~8 MiB of permanent heap even
-// when the agent config is valid.
+// The gate exists to allow skipping the ~8 MiB startup compilation spike.
+// The check uses schema.ValidateCoreConfigNoCache so the compiled schema is
+// transient and GC-eligible once this goroutine exits — it is not retained globally.
 func (m *invalidConfigModule) BuiltInStartupHealthCheck() *runnerdef.BuiltInHealthCheck {
 	return &runnerdef.BuiltInHealthCheck{
 		Source: "agent",

--- a/comp/healthplatform/issues/invalidconfig/module.go
+++ b/comp/healthplatform/issues/invalidconfig/module.go
@@ -13,6 +13,7 @@ import (
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 )
 
+
 // IssueID is the stable Agent Health identifier for configuration-schema violations
 const IssueID = "invalid-config"
 
@@ -21,13 +22,12 @@ func init() {
 }
 
 type invalidConfigModule struct {
-	cfg     config.Component
 	checker *checker
 }
 
 // NewModule captures the config so the once-only startup check can read it.
 func NewModule(cfg config.Component) issues.Module {
-	return &invalidConfigModule{cfg: cfg, checker: newChecker(cfg)}
+	return &invalidConfigModule{checker: newChecker(cfg)}
 }
 
 func (m *invalidConfigModule) IssueName() string {
@@ -44,22 +44,11 @@ func (m *invalidConfigModule) BuiltInPeriodicHealthCheck() *runnerdef.BuiltInPer
 }
 
 // BuiltInStartupHealthCheck runs schema validation once at agent startup.
-// The check is gated inside Fn rather than at registration time so that
-// IssueNames-based stale-issue resolution still fires on restart even when
-// the flag is disabled — returning nil/empty resolves any previously-stored
-// issues rather than leaving them orphaned.
-//
-// The gate exists to allow skipping the ~8 MiB startup compilation spike.
-// The check uses schema.ValidateCoreConfigNoCache so the compiled schema is
-// transient and GC-eligible once this goroutine exits — it is not retained globally.
+// schema.ValidateCoreConfigNoCache is used so the compiled schema (~8 MiB) is
+// transient and GC-eligible once this goroutine exits — not retained globally.
 func (m *invalidConfigModule) BuiltInStartupHealthCheck() *runnerdef.BuiltInHealthCheck {
 	return &runnerdef.BuiltInHealthCheck{
 		Source: "agent",
-		Fn: func() ([]runnerdef.IssueReport, error) {
-			if !m.cfg.GetBool("health_platform.invalidconfig_check.enabled") {
-				return nil, nil
-			}
-			return m.checker.Run()
-		},
+		Fn:     m.checker.Run,
 	}
 }

--- a/pkg/config/schema/schema.go
+++ b/pkg/config/schema/schema.go
@@ -124,6 +124,20 @@ func ValidateCoreConfig(config interface{}) ([]string, error) {
 	return validateData(sch, config)
 }
 
+// ValidateCoreConfigNoCache compiles the core schema, validates config against it, then
+// discards the compiled schema so the ~8 MiB of heap it occupies can be reclaimed by the
+// GC. Use this for one-shot validation (e.g. a startup health check) where retaining the
+// compiled schema for the process lifetime is not acceptable.
+// Unlike ValidateCoreConfig, concurrent callers each compile their own copy; prefer
+// ValidateCoreConfig in hot paths.
+func ValidateCoreConfigNoCache(config interface{}) ([]string, error) {
+	sch, err := loadSchema("core_schema")
+	if err != nil {
+		return nil, err
+	}
+	return validateData(sch, config)
+}
+
 // ValidateSystemProbeConfig validates a unmarshal YAML/JSON contents against the system-probe agent schema
 func ValidateSystemProbeConfig(config interface{}) ([]string, error) {
 	sch, err := sysprobeSchemaGetter()

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8238,9 +8238,10 @@ properties:
           enabled:
             node_type: setting
             type: boolean
-            # Disabled by default: loading the compiled core_schema.yaml retains ~8 MiB of heap
-            # permanently (sync.Once global). Enable only if startup schema validation is needed.
-            default: false
+            # The check uses ValidateCoreConfigNoCache so the compiled schema (~8 MiB) is
+            # transient and GC-eligible after the startup goroutine exits. Set to false to
+            # skip the compilation spike entirely.
+            default: true
   heroku_dyno:
     node_type: setting
     type: boolean

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8231,17 +8231,6 @@ properties:
         node_type: setting
         type: boolean
         default: false
-      invalidconfig_check:
-        node_type: section
-        type: object
-        properties:
-          enabled:
-            node_type: setting
-            type: boolean
-            # The check uses ValidateCoreConfigNoCache so the compiled schema (~8 MiB) is
-            # transient and GC-eligible after the startup goroutine exits. Set to false to
-            # skip the compilation spike entirely.
-            default: true
   heroku_dyno:
     node_type: setting
     type: boolean

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1203,11 +1203,6 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("health_platform.enabled", true)
 	config.BindEnvAndSetDefault("health_platform.persist_on_kubernetes", false)
 	config.BindEnvAndSetDefault("health_platform.forwarder.interval", "0s")
-	// health_platform.invalidconfig_check.enabled gates the startup schema-validation check.
-	// The check uses schema.ValidateCoreConfigNoCache which compiles core_schema.yaml (~8000 lines)
-	// without retaining the result globally, so the ~8 MiB compilation is transient and GC-eligible
-	// once the check goroutine completes. Disable it to skip the startup spike entirely.
-	config.BindEnvAndSetDefault("health_platform.invalidconfig_check.enabled", true)
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
 	config.BindEnvAndSetDefault("win_skip_com_init", false)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1203,12 +1203,11 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("health_platform.enabled", true)
 	config.BindEnvAndSetDefault("health_platform.persist_on_kubernetes", false)
 	config.BindEnvAndSetDefault("health_platform.forwarder.interval", "0s")
-	// health_platform.invalidconfig_check.enabled is off by default because the check calls
-	// schema.ValidateCoreConfig which decompresses, parses, and compiles the full core_schema.yaml
-	// (~8000 lines) into a *jsonschema.Schema retained globally for the process lifetime.
-	// This adds ~8 MiB of permanent heap even when the agent config is valid.
-	// Enable it deliberately if you need schema validation at startup.
-	config.BindEnvAndSetDefault("health_platform.invalidconfig_check.enabled", false)
+	// health_platform.invalidconfig_check.enabled gates the startup schema-validation check.
+	// The check uses schema.ValidateCoreConfigNoCache which compiles core_schema.yaml (~8000 lines)
+	// without retaining the result globally, so the ~8 MiB compilation is transient and GC-eligible
+	// once the check goroutine completes. Disable it to skip the startup spike entirely.
+	config.BindEnvAndSetDefault("health_platform.invalidconfig_check.enabled", true)
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
 	config.BindEnvAndSetDefault("win_skip_com_init", false)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)


### PR DESCRIPTION
### What does this PR do?

Eliminates the permanent ~8 MiB heap retention caused by the `invalidconfig` health check loading `core_schema.yaml` at startup.

Targets: #51996

### Motivation

The regression detector on PR #51996 flagged +5.55% idle memory (+8 MiB on `quality_gate_idle`, observed 152.26 MiB vs 147 MiB bound). Investigation traced the root cause to `schema.ValidateCoreConfig`, which decompresses, parses, and compiles `core_schema.yaml` (~8000 lines) into a `*jsonschema.Schema` stored in a `sync.Once` global for the entire process lifetime. The `invalidconfig` startup health check is the only runtime caller of this path in the agent daemon, so the allocation only exists when agent health is enabled — which PR #51996 made the default.

### Changes

**`pkg/config/schema/schema.go`**
- Adds `ValidateCoreConfigNoCache`: same validation as `ValidateCoreConfig` but compiles the schema without caching it globally. The compiled `*jsonschema.Schema` is dropped after validation and becomes GC-eligible once the caller's goroutine exits.

**`comp/healthplatform/issues/invalidconfig/check.go`**
- Switches from `ValidateCoreConfig` to `ValidateCoreConfigNoCache`. The startup check runs once in a short-lived goroutine, so there is no benefit to caching.

**`comp/healthplatform/issues/invalidconfig/module.go`**
- Removes the `health_platform.invalidconfig_check.enabled` gate (added temporarily to confirm the root cause) along with the `cfg` field on `invalidConfigModule`. The check now runs unconditionally on startup.

**`pkg/config/setup/common_settings.go` / `core_schema.yaml`**
- Removes the `health_platform.invalidconfig_check.enabled` config key entirely.

### Describe how you validated your changes

`bazel test //pkg/config/schema/...` ✓

### Additional Notes

The existing `ValidateCoreConfig` (cached) is left unchanged for any future callers that benefit from reuse across multiple validations.

Team: agent-health