### PR TITLE
SBOM: keep layer DiffID and manifest Digest distinct

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -456,10 +456,10 @@ func getLayersWithHistory(ocispecImage ocispec.Image, manifest ocispec.Manifest)
 
 	historyIndex := 0
 	for manifestIndex, manifestLayer := range manifest.Layers {
-		// DiffID is the OCI rootfs diff_id. When the image config is
-		// short of one (off-spec), fall back to the manifest layer
-		// digest -- a wrong-but-best-effort value rather than empty.
-		diffID := manifestLayer.Digest.String()
+		// The diff_id is the layer's uncompressed-content hash from the image
+		// config, not the manifest layer Digest (a compressed-blob hash). Leave
+		// it empty when the config has no entry rather than substitute the digest.
+		var diffID string
 		if manifestIndex < len(ocispecImage.RootFS.DiffIDs) {
 			diffID = ocispecImage.RootFS.DiffIDs[manifestIndex].String()
 		}

--- a/comp/core/workloadmeta/collectors/internal/crio/image.go
+++ b/comp/core/workloadmeta/collectors/internal/crio/image.go
@@ -148,7 +148,7 @@ func parseImageInfo(info map[string]string, layerFilePath string, imgID string) 
 
 			// Match layers with their history entries, including empty layers
 			historyIndex := 0
-			for layerIndex, layerDigest := range parsed.ImageSpec.RootFS.DiffIDs {
+			for layerIndex, diffID := range parsed.ImageSpec.RootFS.DiffIDs {
 				// Append all empty layers encountered before this layer
 				for historyIndex < len(parsed.ImageSpec.History) {
 					history := parsed.ImageSpec.History[historyIndex]
@@ -187,7 +187,7 @@ func parseImageInfo(info map[string]string, layerFilePath string, imgID string) 
 
 				// Create and append the layer with the matched history
 				layer := workloadmeta.ContainerImageLayer{
-					DiffID:  layerDigest,
+					DiffID:  diffID,
 					History: historyEntry,
 				}
 

--- a/pkg/util/trivy/crio.go
+++ b/pkg/util/trivy/crio.go
@@ -10,23 +10,31 @@ package trivy
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/util/crio"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/samber/lo"
 )
 
-// buildCRIOLayerPaths pairs each CRI-O lowerDir with its non-empty
-// imgMeta.Layers entry. GetCRIOImageLayers builds the paths by
-// prepending as it walks imgMeta.Layers in image-config order, so
-// lowerDirs comes out top-to-base while the filtered layers stay
+// buildCRIOLayerPaths pairs each non-empty imgMeta.Layers entry with its CRI-O
+// lowerDir and, when available, its per-layer manifest digest. DiffID is the
+// image-config diff_id. manifestDigests holds the compressed-blob digests from
+// the image manifest in image-config (base-to-top) order; they are paired
+// positionally with the non-empty layers and left empty when their count does
+// not match, mirroring the containerd overlayfs scan rather than risk a wrong
+// pairing. GetCRIOImageLayers prepends each path while walking imgMeta.Layers in
+// image-config order, so lowerDirs is top-to-base while the filtered layers stay
 // base-to-top; walk lowerDirs in reverse to realign them.
-func buildCRIOLayerPaths(imgMeta *workloadmeta.ContainerImageMetadata, lowerDirs []string) ([]ftypes.LayerPath, error) {
+func buildCRIOLayerPaths(imgMeta *workloadmeta.ContainerImageMetadata, lowerDirs, manifestDigests []string) ([]ftypes.LayerPath, error) {
 	nonEmpty := lo.Filter(imgMeta.Layers, func(layer workloadmeta.ContainerImageLayer, _ int) bool {
 		return layer.DiffID != ""
 	})
@@ -35,16 +43,56 @@ func buildCRIOLayerPaths(imgMeta *workloadmeta.ContainerImageMetadata, lowerDirs
 			errLayerCountMismatch, len(lowerDirs), len(nonEmpty))
 	}
 	n := len(lowerDirs)
+	digestsAligned := len(manifestDigests) == n
+	if len(manifestDigests) > 0 && !digestsAligned {
+		log.Warnf("image %s: manifest has %d layer digests but %d non-empty layers; emitting SBOM without LayerDigest",
+			imgMeta.ID, len(manifestDigests), n)
+	}
 	out := make([]ftypes.LayerPath, n)
 	for i := 0; i < n; i++ {
-		dir := lowerDirs[n-1-i]
-		out[i] = ftypes.LayerPath{
-			DiffID: "sha256:" + filepath.Base(filepath.Dir(dir)),
-			Digest: nonEmpty[i].DiffID,
-			Path:   dir,
+		lp := ftypes.LayerPath{
+			DiffID: nonEmpty[i].DiffID,
+			Path:   lowerDirs[n-1-i],
 		}
+		if digestsAligned {
+			lp.Digest = manifestDigests[i]
+		}
+		out[i] = lp
 	}
 	return out, nil
+}
+
+// readCRIOManifestLayerDigests reads the OCI image manifest CRI-O stores at
+// overlay-images/<id>/manifest and returns each layer's compressed-blob digest
+// in manifest (image-config, base-to-top) order. This is the same file the
+// workloadmeta CRI-O collector reads for layer size and media type. It is best
+// effort: it returns nil on any error so the caller emits an SBOM without
+// LayerDigest rather than failing the scan.
+func readCRIOManifestLayerDigests(imgID string) []string {
+	id := strings.TrimPrefix(imgID, "sha256:")
+	path := filepath.Join(crio.GetOverlayImagePath(), id, "manifest")
+	file, err := os.Open(path)
+	if err != nil {
+		log.Debugf("failed to open CRI-O image manifest %s: %v", path, err)
+		return nil
+	}
+	defer file.Close()
+
+	var manifest struct {
+		Layers []struct {
+			Digest string `json:"digest"`
+		} `json:"layers"`
+	}
+	if err := json.NewDecoder(file).Decode(&manifest); err != nil {
+		log.Debugf("failed to decode CRI-O image manifest %s: %v", path, err)
+		return nil
+	}
+
+	digests := make([]string, len(manifest.Layers))
+	for i, layer := range manifest.Layers {
+		digests[i] = layer.Digest
+	}
+	return digests
 }
 
 type fakeCRIOContainer struct {
@@ -110,7 +158,7 @@ func (c *Collector) ScanCRIOImageFromOverlayFS(ctx context.Context, imgMeta *wor
 		return nil, fmt.Errorf("failed to retrieve layer directories: %w", err)
 	}
 
-	layers, err := buildCRIOLayerPaths(imgMeta, lowerDirs)
+	layers, err := buildCRIOLayerPaths(imgMeta, lowerDirs, readCRIOManifestLayerDigests(imgMeta.ID))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/trivy/layers_crio_test.go
+++ b/pkg/util/trivy/layers_crio_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 func TestBuildCRIOLayerPaths(t *testing.T) {
-	// Distinct value namespaces for the path-encoded DiffID and the
-	// imgMeta layer DiffID so a positional swap is detectable -- the
-	// same-name fixtures of the original test let an off-by-one go silently.
+	// The layer DiffIDs (digest_*) and the lowerDir basenames (diff_*) use
+	// distinct value namespaces so a layer paired with the wrong path is
+	// detectable rather than silently masked by same-name fixtures.
 	imgMeta := &workloadmeta.ContainerImageMetadata{
 		Layers: []workloadmeta.ContainerImageLayer{
 			{DiffID: "sha256:digest_base"},
@@ -35,13 +35,19 @@ func TestBuildCRIOLayerPaths(t *testing.T) {
 		"/var/lib/containers/storage/overlay/diff_base/diff",
 	}
 
+	// manifestDigests are the per-layer compressed-blob digests from the image
+	// manifest, in image-config (base-to-top) order, so they pair with the
+	// non-empty layers. A third namespace (mdigest_*) keeps them distinct from
+	// the diff_ids and the lowerDir basenames.
+	manifestDigests := []string{"sha256:mdigest_base", "sha256:mdigest_middle", "sha256:mdigest_top"}
+
 	t.Run("happy_path_pairs_in_image_config_order", func(t *testing.T) {
-		got, err := buildCRIOLayerPaths(imgMeta, lowerDirs)
+		got, err := buildCRIOLayerPaths(imgMeta, lowerDirs, manifestDigests)
 		require.NoError(t, err)
 		want := []struct{ diffID, digest, path string }{
-			{"sha256:diff_base", "sha256:digest_base", "/var/lib/containers/storage/overlay/diff_base/diff"},
-			{"sha256:diff_middle", "sha256:digest_middle", "/var/lib/containers/storage/overlay/diff_middle/diff"},
-			{"sha256:diff_top", "sha256:digest_top", "/var/lib/containers/storage/overlay/diff_top/diff"},
+			{"sha256:digest_base", "sha256:mdigest_base", "/var/lib/containers/storage/overlay/diff_base/diff"},
+			{"sha256:digest_middle", "sha256:mdigest_middle", "/var/lib/containers/storage/overlay/diff_middle/diff"},
+			{"sha256:digest_top", "sha256:mdigest_top", "/var/lib/containers/storage/overlay/diff_top/diff"},
 		}
 		require.Len(t, got, len(want))
 		for i, w := range want {
@@ -51,15 +57,36 @@ func TestBuildCRIOLayerPaths(t *testing.T) {
 		}
 	})
 
+	t.Run("nil_manifest_digests_leave_digest_empty", func(t *testing.T) {
+		got, err := buildCRIOLayerPaths(imgMeta, lowerDirs, nil)
+		require.NoError(t, err)
+		require.Len(t, got, len(lowerDirs))
+		for i := range got {
+			assert.NotEmpty(t, got[i].DiffID)
+			assert.Empty(t, got[i].Digest, "no manifest digests means no LayerDigest")
+		}
+	})
+
+	t.Run("misaligned_manifest_digests_leave_digest_empty", func(t *testing.T) {
+		// Two digests for three layers: the counts disagree, so any positional
+		// pairing would be wrong. Drop the digests rather than mispair them.
+		got, err := buildCRIOLayerPaths(imgMeta, lowerDirs, manifestDigests[:2])
+		require.NoError(t, err)
+		require.Len(t, got, len(lowerDirs))
+		for i := range got {
+			assert.Empty(t, got[i].Digest, "misaligned manifest digests means no LayerDigest")
+		}
+	})
+
 	t.Run("count_mismatch_extra_lower_dir", func(t *testing.T) {
 		extra := append([]string{}, lowerDirs...)
 		extra = append(extra, "/var/lib/containers/storage/overlay/diff_spurious/diff")
-		_, err := buildCRIOLayerPaths(imgMeta, extra)
+		_, err := buildCRIOLayerPaths(imgMeta, extra, manifestDigests)
 		require.ErrorIs(t, err, errLayerCountMismatch)
 	})
 
 	t.Run("count_mismatch_short_lower_dir", func(t *testing.T) {
-		_, err := buildCRIOLayerPaths(imgMeta, lowerDirs[:1])
+		_, err := buildCRIOLayerPaths(imgMeta, lowerDirs[:1], manifestDigests)
 		require.ErrorIs(t, err, errLayerCountMismatch)
 	})
 }

--- a/releasenotes/notes/sbom-layer-digest-not-diffid-7c3f1a9b2e4d6058.yaml
+++ b/releasenotes/notes/sbom-layer-digest-not-diffid-7c3f1a9b2e4d6058.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Container image SBOMs no longer report a layer's diff_id as its
+    ``LayerDigest``. A diff_id is the uncompressed-content hash, while the
+    ``LayerDigest`` is the compressed manifest blob digest; the two are
+    distinct identifiers. The CRI-O ``LayerDigest`` is now read from the image
+    manifest CRI-O stores on disk, and its ``LayerDiffID`` is taken from the
+    image config rather than the containers-storage layer ID. Docker exposes no
+    per-layer manifest digest and leaves ``LayerDigest`` empty instead of
+    substituting the diff_id.


### PR DESCRIPTION
A layer's ftypes.LayerPath was assembled by indexing three unrelated
slices at the same position: the config's diff_ids, the overlay mount
paths, and workloadmeta's layers. Nothing kept those in the same order,
so any drift paired one layer's DiffID with another's path or digest.
Trivy keys its blob cache on DiffID, so a bad pairing poisoned the
on-disk cache and survived agent restarts.

Build each LayerPath from data that is already together, and refuse to
scan when the inputs disagree:

- containerd: read diff_ids and the manifest from the image config,
  then walk the snapshotter's parent chain to confirm it matches the
  chainIDs the diff_ids produce. Digest is the real manifest digest.
  These reads are namespaced: containerd stores content and snapshots
  per namespace, and the incoming context may not carry one.
- docker: take DiffID and Path from the same inspect response; leave
  Digest empty, since the daemon has no reliable per-layer digest.
- crio: pair the path-derived DiffID with the non-empty workloadmeta
  layers, reversing lowerDirs (returned top-to-base) to realign them.

Two sentinels make a mismatch fatal: errLayerCountMismatch (paths vs
diff_ids) and errLayerChainMismatch (snapshotter chain vs config).

The old test reused one value for both DiffID and Digest and could not
catch a swap. The new per-runtime tests give every field a distinct
value and stub the snapshotter with a small fake, so a pairing or
chain-check regression fails loudly.