### PR TITLE
[Backport 7.80.x] Fix AKS selectors on admission probe webhook

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/config.go
+++ b/pkg/clusteragent/admission/controllers/webhook/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	failurePolicy            string
 	reinvocationPolicy       string
 	probeEnabled             bool
+	addAKSSelectors          bool
 }
 
 // NewConfig creates a webhook controller configuration
@@ -52,6 +53,7 @@ func NewConfig(admissionV1Enabled, namespaceSelectorEnabled, matchConditionsSupp
 		failurePolicy:            datadogConfig.GetString("admission_controller.failure_policy"),
 		reinvocationPolicy:       datadogConfig.GetString("admission_controller.reinvocation_policy"),
 		probeEnabled:             datadogConfig.GetBool("admission_controller.probe.enabled"),
+		addAKSSelectors:          datadogConfig.GetBool("admission_controller.add_aks_selectors"),
 	}
 }
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -252,6 +252,22 @@ func (c *controllerBase) triggerReconciliation() {
 	c.queue.Add(c.config.getWebhookName())
 }
 
+func (c *controllerBase) getProbeNamespaceSelector() *metav1.LabelSelector {
+	selector := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      common.NamespaceLabelKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{c.config.getServiceNs()},
+			},
+		},
+	}
+	if c.config.addAKSSelectors {
+		selector.MatchExpressions = append(selector.MatchExpressions, common.AzureAKSLabelSelectorRequirement()...)
+	}
+	return selector
+}
+
 func (c *controllerBase) getSecret() (*corev1.Secret, error) {
 	secret, err := c.secretsLister.Secrets(c.config.getSecretNs()).Get(c.config.getSecretName())
 	if err != nil {

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -394,15 +394,7 @@ func (c *ControllerV1) generateTemplates() {
 			probeEndpoint,
 			[]admiv1.OperationType{admiv1.Create},
 			[]common.WebhookResourceRule{{APIGroup: "", APIVersion: "v1", Resources: []string{"configmaps"}}},
-			&metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      common.NamespaceLabelKey,
-						Operator: metav1.LabelSelectorOpIn,
-						Values:   []string{c.config.getServiceNs()},
-					},
-				},
-			},
+			c.getProbeNamespaceSelector(),
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					common.ProbeLabelKey: "true",

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -232,6 +232,15 @@ func TestGenerateTemplatesV1(t *testing.T) {
 			},
 		},
 	}
+	probeNsSelectorWithAKS := &metav1.LabelSelector{
+		MatchExpressions: append([]metav1.LabelSelectorRequirement{
+			{
+				Key:      common.NamespaceLabelKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"nsfoo"},
+			},
+		}, common.AzureAKSLabelSelectorRequirement()...),
+	}
 
 	webhook := func(name, path string, objSelector, nsSelector *metav1.LabelSelector, matchConditions []admiv1.MatchCondition, operations []admiv1.OperationType, resources []string, to int32) admiv1.MutatingWebhook {
 		return admiv1.MutatingWebhook{
@@ -545,6 +554,63 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					timeout,
 				)
 				return []admiv1.MutatingWebhook{webhook}
+			},
+		},
+		{
+			name: "AKS-specific label selector with probe enabled",
+			setupConfig: func(mockConfig model.Config) {
+				mockConfig.SetWithoutSource("admission_controller.add_aks_selectors", true)
+				mockConfig.SetWithoutSource("admission_controller.probe.enabled", true)
+				mockConfig.SetWithoutSource("admission_controller.namespace_selector_fallback", false)
+				mockConfig.SetWithoutSource("admission_controller.inject_config.enabled", true)
+				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", true)
+				mockConfig.SetWithoutSource("admission_controller.inject_tags.enabled", false)
+				mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.enabled", false)
+				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.enabled", false)
+			},
+			configFunc: func(mockConfig model.Config) Config { return NewConfig(false, false, false, mockConfig) },
+			want: func() []admiv1.MutatingWebhook {
+				configWebhook := webhook(
+					"datadog.webhook.agent.config",
+					"/injectconfig",
+					&metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "admission.datadoghq.com/enabled",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"false"},
+							},
+						},
+					},
+					&metav1.LabelSelector{
+						MatchExpressions: append([]metav1.LabelSelectorRequirement{
+							{
+								Key:      common.NamespaceLabelKey,
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   excludedDefaultNs,
+							},
+						}, common.AzureAKSLabelSelectorRequirement()...),
+					},
+					[]admiv1.MatchCondition{},
+					[]admiv1.OperationType{admiv1.Create},
+					[]string{"pods"},
+					timeout,
+				)
+				probeWebhook := webhook(
+					"datadog.webhook.probe",
+					"/injectconfig",
+					&metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							common.ProbeLabelKey: "true",
+						},
+					},
+					probeNsSelectorWithAKS,
+					nil,
+					[]admiv1.OperationType{admiv1.Create},
+					[]string{"configmaps"},
+					timeout,
+				)
+				return []admiv1.MutatingWebhook{configWebhook, probeWebhook}
 			},
 		},
 		{
@@ -1015,6 +1081,8 @@ func TestGenerateTemplatesV1(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockConfig := configmock.New(t)
 			mockConfig.SetWithoutSource("kube_resources_namespace", "nsfoo")
+			mockConfig.SetWithoutSource("admission_controller.add_aks_selectors", false)
+			mockConfig.SetWithoutSource("admission_controller.probe.enabled", false)
 			tt.setupConfig(mockConfig)
 
 			c := &ControllerV1{}

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -397,15 +397,7 @@ func (c *ControllerV1beta1) generateTemplates() {
 			probeEndpoint,
 			[]admiv1beta1.OperationType{admiv1beta1.Create},
 			[]common.WebhookResourceRule{{APIGroup: "", APIVersion: "v1", Resources: []string{"configmaps"}}},
-			&metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      common.NamespaceLabelKey,
-						Operator: metav1.LabelSelectorOpIn,
-						Values:   []string{c.config.getServiceNs()},
-					},
-				},
-			},
+			c.getProbeNamespaceSelector(),
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					common.ProbeLabelKey: "true",

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -228,6 +228,15 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 			},
 		},
 	}
+	probeNsSelectorWithAKS := &metav1.LabelSelector{
+		MatchExpressions: append([]metav1.LabelSelectorRequirement{
+			{
+				Key:      common.NamespaceLabelKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"nsfoo"},
+			},
+		}, common.AzureAKSLabelSelectorRequirement()...),
+	}
 
 	webhook := func(name, path string, objSelector, nsSelector *metav1.LabelSelector, matchConditions []admiv1beta1.MatchCondition, operations []admiv1beta1.OperationType, resources []string, to int32) admiv1beta1.MutatingWebhook {
 		return admiv1beta1.MutatingWebhook{
@@ -540,6 +549,63 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					timeout,
 				)
 				return []admiv1beta1.MutatingWebhook{webhook}
+			},
+		},
+		{
+			name: "AKS-specific label selector with probe enabled",
+			setupConfig: func(mockConfig model.Config) {
+				mockConfig.SetWithoutSource("admission_controller.add_aks_selectors", true)
+				mockConfig.SetWithoutSource("admission_controller.probe.enabled", true)
+				mockConfig.SetWithoutSource("admission_controller.namespace_selector_fallback", false)
+				mockConfig.SetWithoutSource("admission_controller.inject_config.enabled", true)
+				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", true)
+				mockConfig.SetWithoutSource("admission_controller.inject_tags.enabled", false)
+				mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.enabled", false)
+				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.enabled", false)
+			},
+			configFunc: func(mockConfig model.Config) Config { return NewConfig(false, false, false, mockConfig) },
+			want: func() []admiv1beta1.MutatingWebhook {
+				configWebhook := webhook(
+					"datadog.webhook.agent.config",
+					"/injectconfig",
+					&metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "admission.datadoghq.com/enabled",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"false"},
+							},
+						},
+					},
+					&metav1.LabelSelector{
+						MatchExpressions: append([]metav1.LabelSelectorRequirement{
+							{
+								Key:      common.NamespaceLabelKey,
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   excludedDefaultNs,
+							},
+						}, common.AzureAKSLabelSelectorRequirement()...),
+					},
+					[]admiv1beta1.MatchCondition{},
+					[]admiv1beta1.OperationType{admiv1beta1.Create},
+					[]string{"pods"},
+					timeout,
+				)
+				probeWebhook := webhook(
+					"datadog.webhook.probe",
+					"/injectconfig",
+					&metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							common.ProbeLabelKey: "true",
+						},
+					},
+					probeNsSelectorWithAKS,
+					nil,
+					[]admiv1beta1.OperationType{admiv1beta1.Create},
+					[]string{"configmaps"},
+					timeout,
+				)
+				return []admiv1beta1.MutatingWebhook{configWebhook, probeWebhook}
 			},
 		},
 		{
@@ -1009,6 +1075,8 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockConfig := configmock.New(t)
 			mockConfig.SetWithoutSource("kube_resources_namespace", "nsfoo")
+			mockConfig.SetWithoutSource("admission_controller.add_aks_selectors", false)
+			mockConfig.SetWithoutSource("admission_controller.probe.enabled", false)
 			tt.setupConfig(mockConfig)
 
 			c := &ControllerV1beta1{}

--- a/releasenotes-dca/notes/fix-admission-probe-aks-selectors-e307c388794f1d9a.yaml
+++ b/releasenotes-dca/notes/fix-admission-probe-aks-selectors-e307c388794f1d9a.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue where the admission controller connectivity probe webhook
+    did not include the AKS selector requirements when
+    ``admission_controller.add_aks_selectors`` was enabled, which could cause
+    repeated webhook reconciliation conflicts on AKS.


### PR DESCRIPTION
## Backport

Cherry-pick of dfc5f165d47 onto 7.80.x.

### What does this PR do?

Adds the AKS namespace selector requirements to the admission controller probe webhook when `admission_controller.add_aks_selectors` is enabled. The probe webhook now uses the same AKS opt-out selector handling as the other admission webhooks, while still restricting probes to the Cluster Agent namespace and probe-labeled ConfigMaps.

Adds regression coverage for both `admissionregistration.k8s.io/v1` and `v1beta1`, plus a DCA release note.

### Conflict resolution

The two test files used `SetWithoutSource` on 7.80.x while the original PR introduced calls to `SetInTest` (added on `main` after 7.80.x was cut). All `SetInTest` calls were replaced with `SetWithoutSource` to match the API available on this branch.

### Additional Notes

Backport of #52005