### PR TITLE
fix(gpu): query GPM metrics individually (#51934)

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/gpm.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm.go
@@ -204,19 +204,33 @@ func (c *gpmCollector) calculateGpmMetrics() (*nvml.GpmMetricsGetType, error) {
 	}
 
 	metricIndex := 0
+	var errs []error
 	for metricID := range c.metricsToCollect {
-		metricsGet.Metrics[metricIndex] = nvml.GpmMetric{
-			MetricId: uint32(metricID),
+		// WORKAROUND: go-nvml's GpmMetricsGetType.Metrics array has a memory-layout
+		// mismatch that corrupts elements past index 0 when NumMetrics > 1. Query each
+		// metric in its own call via Metrics[0] until the upstream fix lands.
+		singleMetricGet := &nvml.GpmMetricsGetType{
+			NumMetrics: 1,
+			Version:    nvml.GPM_METRICS_GET_VERSION,
+			Sample1:    secondToLastSample,
+			Sample2:    lastSample,
 		}
+		singleMetricGet.Metrics[0] = nvml.GpmMetric{
+			MetricId:   uint32(metricID),
+			NvmlReturn: uint32(nvml.ERROR_UNKNOWN), // initialize to a sentinel value to ensure NVML has actually modified the value
+		}
+
+		err := c.lib.GpmMetricsGet(singleMetricGet)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to get GPM metric %d: %w", metricID, err))
+			continue
+		}
+
+		metricsGet.Metrics[metricIndex] = singleMetricGet.Metrics[0]
 		metricIndex++
 	}
 
-	err := c.lib.GpmMetricsGet(metricsGet)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get GPM metrics: %w", err)
-	}
-
-	return metricsGet, nil
+	return metricsGet, errors.Join(errs...)
 }
 
 func (c *gpmCollector) DeviceUUID() string {

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -829,8 +829,8 @@ func GetBasicNvmlMockWithOptions(options ...NvmlMockOption) *nvmlmock.Interface 
 			return nvml.SUCCESS
 		},
 		GpmMetricsGetFunc: func(metricsGet *nvml.GpmMetricsGetType) nvml.Return {
-			for _, metric := range metricsGet.Metrics[:metricsGet.NumMetrics] {
-				metric.NvmlReturn = uint32(nvml.SUCCESS)
+			for i := range metricsGet.Metrics[:metricsGet.NumMetrics] {
+				metricsGet.Metrics[i].NvmlReturn = uint32(nvml.SUCCESS)
 			}
 
 			return nvml.SUCCESS

--- a/releasenotes/notes/gpm-fix-5e74ba2a3c542262.yaml
+++ b/releasenotes/notes/gpm-fix-5e74ba2a3c542262.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    gpu: fix an issue where some GPM metrics (gpu.gr_engine_active, gpu.sm_utilization, gpu.sm_occupancy, gpu.integer_active, gpu.fp16_active, gpu.fp32_active, gpu.fp64_active, gpu.tensor_active) were only emitted correctly one out of eight times on average.


### PR DESCRIPTION
Backport 5a6de08b43363b2722f5da937229b684273c0760 from #51934

 ___

### What does this PR do?

Queries GPM metrics one by one to avoid a memory layout issue.

### Motivation

Fix GPM metrics.

### Describe how you validated your changes

Manually run in a H100 instance. Also, checked that GPM collector times were still below 10ms on average.

### Additional Notes
