### PR TITLE
Address `TestMemHigh` flakiness: widen GC slack

### DIFF
--- a/pkg/trace/watchdog/info_test.go
+++ b/pkg/trace/watchdog/info_test.go
@@ -122,8 +122,8 @@ func doTestMemHigh(t *testing.T, n int) {
 
 	t.Logf("Mem (%d bytes): %v %v", n, oldM, m)
 
-	// Checking that Mem is high enough (allow 0.1% slack for GC/alignment jitter)
-	slack := int64(n) / 1000
+	// Checking that Mem is high enough (allow 0.5% slack for GC/alignment jitter)
+	slack := int64(n) / 200
 	assert.GreaterOrEqualf(m.Alloc, uint64(n), "not enough bytes allocated")
 	assert.GreaterOrEqualf(int64(m.Alloc)-int64(oldM.Alloc)+slack, int64(n), "not enough bytes allocated since last call")
 	<-data


### PR DESCRIPTION
### What does this PR do?
Widen the GC jitter slack in `doTestMemHigh` from 0.1% (`n/1000`) to 0.5% (`n/200`).

### Motivation
The delta assertion (`m.Alloc - oldM.Alloc + slack >= n`) fails when GC reclaims more than slack bytes between the two `ReadMemStats` calls.

The CI runtime environment produces a live heap ~5× larger than a local build (~2.3MB vs ~519KB with the full test suite), for reasons that are environmental rather than due to a difference in imported packages (the transitive dependency tree is identical in both cases).
GC overhead scales with the live heap, so the absolute reclamation is larger in CI.
With the earlier 0.1% slack (10'000B for `n`=10MB), the observed reclamation of ~11'300B exceeds the budget and the test fails intermittently ([eg#1](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1754612366#L1577), [eg#2](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1741021528#L1739)):
```
INFO: From Testing //pkg/trace/watchdog:watchdog_test:
==================== Test output for //pkg/trace/watchdog:watchdog_test:
--- FAIL: TestMemHigh (2.01s)
    info_test.go:123: Mem (100000 bytes): {2451328} {2558080}
    info_test.go:123: Mem (10000000 bytes): {2451808} {12440552}
    info_test.go:128:
        	Error Trace:	pkg/trace/watchdog/info_test.go:128
        	            				pkg/trace/watchdog/info_test.go:137
        	Error:      	"9998744" is not greater than or equal to "10000000"
        	Test:       	TestMemHigh
        	Messages:   	not enough bytes allocated since last call
FAIL
================================================================================
```

Widening to 0.5% (50'000B) clears the largest observed gap by ~30%.

### Describe how you validated your changes
Standalone harness reproducing CI-like conditions (2MB live baseline, `GOGC=1`):
- old slack `n/1000` = 10'000: 1/50 failed (gap 38'008 > 10'000)
- new slack `n/200` = 50'000: 0/50 failed (gap 38'008 < 50'000)