### PR TITLE
Skip e2e tests on Windows to limit OOM failures

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -381,6 +381,7 @@ modules:
   tasks/unit_tests/testdata/go_mod_formatter/valid_package: ignored
   test/e2e-framework:
     independent: false
+    should_test_condition: is_linux
   test/fakeintake: default
   test/integration/serverless/recorder-extension: ignored
   test/integration/serverless/src: ignored


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1ab9b1f9-41aa-49f4-a163-ebc89706fb71","source":"chat","resourceId":"174adbe6-4030-4dd2-bb5b-e92175dbce6d","workflowId":"15aca32a-a6e9-457f-a076-a2ee1d13da19","codeChangeId":"15aca32a-a6e9-457f-a076-a2ee1d13da19","sourceType":"slack"} -->
### What does this PR do?

Adds a condition to skip e2e framework tests on Windows platforms to prevent out-of-memory allocation failures during test execution.

### Motivation

The `tests_windows-x64` job has been regularly failing with virtualalloc out-of-memory errors (errno 1455) since commit dc2eacde7c2504913864903755f4287e975bb482. Multiple allocation failures ranging from 8KB to 114KB have been reported, indicating memory pressure on the Windows test runner. By restricting the e2e framework tests to Linux, we can limit these OOM failures and allow the Windows test suite to complete successfully.

### Describe how you validated your changes

The change is a configuration update that conditionally excludes the e2e framework tests from running on Windows while maintaining normal execution on Linux platforms. This follows the existing pattern in modules.yml where platform-specific test conditions are already in use.

### Additional Notes

This is a targeted fix to stabilize the Windows test pipeline. The e2e framework tests can continue to run on Linux where resource constraints are not an issue.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/174adbe6-4030-4dd2-bb5b-e92175dbce6d)

Comment @datadog to request changes