### PR TITLE
fix(healthplatform): serialize Issue.Severity as lowercase string in forwarder JSON

### DIFF
--- a/comp/healthplatform/forwarder/impl/BUILD.bazel
+++ b/comp/healthplatform/forwarder/impl/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "impl",
-    srcs = ["forwarder.go"],
+    srcs = [
+        "forwarder.go",
+        "marshal.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/forwarder/impl",
     visibility = ["//visibility:public"],
     deps = [
@@ -14,12 +17,16 @@ go_library(
         "//pkg/util/http",
         "//pkg/version",
         "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
     ],
 )
 
 go_test(
     name = "impl_test",
-    srcs = ["forwarder_test.go"],
+    srcs = [
+        "forwarder_test.go",
+        "marshal_test.go",
+    ],
     embed = [":impl"],
     gotags = ["test"],
     deps = [
@@ -29,5 +36,6 @@ go_test(
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//types/known/structpb",
     ],
 )

--- a/comp/healthplatform/forwarder/impl/forwarder.go
+++ b/comp/healthplatform/forwarder/impl/forwarder.go
@@ -9,7 +9,6 @@ package forwarderimpl
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -65,7 +64,7 @@ func (f *forwarder) Send(ctx context.Context, report *healthplatform.HealthRepor
 		return errors.New("API key not configured")
 	}
 
-	payload, err := json.Marshal(report)
+	payload, err := marshalHealthReport(report)
 	if err != nil {
 		return fmt.Errorf("marshal report: %w", err)
 	}

--- a/comp/healthplatform/forwarder/impl/forwarder_test.go
+++ b/comp/healthplatform/forwarder/impl/forwarder_test.go
@@ -69,9 +69,17 @@ func TestSend(t *testing.T) {
 	assert.Equal(t, version.AgentVersion, receivedRequest.Header.Get("DD-Agent-Version"))
 	assert.Contains(t, receivedRequest.Header.Get("User-Agent"), "datadog-agent/")
 
-	var decoded healthplatform.HealthReport
+	// Decode into a plain map to verify the JSON shape without proto type constraints.
+	var decoded map[string]any
 	require.NoError(t, json.Unmarshal(receivedBody, &decoded))
-	assert.Equal(t, "test-host", decoded.Host.Hostname)
+	assert.Equal(t, "test-host", decoded["host"].(map[string]any)["hostname"])
+
+	// Severity must be serialized as the lowercase string, not an integer.
+	// The agenthealth-remediation EVP worker maps this JSON field directly onto
+	// recommendations.Issue.Severity (a proto string field); an integer would be
+	// silently dropped, leaving severity empty and breaking all severity-filtered queries.
+	issue := decoded["issues"].(map[string]any)["issue-1"].(map[string]any)
+	assert.Equal(t, "high", issue["severity"])
 }
 
 func TestSendHTTPError(t *testing.T) {

--- a/comp/healthplatform/forwarder/impl/marshal.go
+++ b/comp/healthplatform/forwarder/impl/marshal.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package forwarderimpl
+
+import (
+	"encoding/json"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// issueJSON is a JSON-serializable mirror of healthplatform.Issue that emits
+// severity as a lowercase string ("low", "medium", "high") instead of the
+// integer enum value that encoding/json produces for IssueSeverity (int32).
+//
+// The agenthealth-remediation EVP worker maps this JSON directly onto the
+// recommendations.Issue proto, whose severity field is typed string.
+// Sending an integer caused the field to be silently dropped, so all
+// severity-filtered tile queries returned zero results.
+//
+// PersistedIssue is intentionally omitted: it is internal lifecycle state and
+// has no corresponding field in the downstream recommendations proto.
+type issueJSON struct {
+	ID          string                      `json:"id,omitempty"`
+	IssueName   string                      `json:"issue_name,omitempty"`
+	Title       string                      `json:"title,omitempty"`
+	Description string                      `json:"description,omitempty"`
+	Category    string                      `json:"category,omitempty"`
+	Location    string                      `json:"location,omitempty"`
+	Severity    string                      `json:"severity,omitempty"`
+	DetectedAt  string                      `json:"detected_at,omitempty"`
+	Source      string                      `json:"source,omitempty"`
+	Extra       *structpb.Struct            `json:"extra,omitempty"`
+	Remediation *healthplatform.Remediation `json:"remediation,omitempty"`
+	Tags        []string                    `json:"tags,omitempty"`
+}
+
+type hostInfoJSON struct {
+	Hostname     string   `json:"hostname,omitempty"`
+	AgentVersion *string  `json:"agent_version,omitempty"`
+	ParIds       []string `json:"par_ids,omitempty"`
+}
+
+type healthReportJSON struct {
+	SchemaVersion string                `json:"schema_version,omitempty"`
+	EventType     string                `json:"event_type,omitempty"`
+	EmittedAt     string                `json:"emitted_at,omitempty"`
+	Host          *hostInfoJSON         `json:"host,omitempty"`
+	Issues        map[string]*issueJSON `json:"issues,omitempty"`
+}
+
+// severityString converts an IssueSeverity enum value to the lowercase string
+// expected by the recommendations pipeline ("low", "medium", "high").
+func severityString(s healthplatform.IssueSeverity) string {
+	switch s {
+	case healthplatform.IssueSeverity_ISSUE_SEVERITY_LOW:
+		return "low"
+	case healthplatform.IssueSeverity_ISSUE_SEVERITY_MEDIUM:
+		return "medium"
+	case healthplatform.IssueSeverity_ISSUE_SEVERITY_HIGH:
+		return "high"
+	default:
+		return ""
+	}
+}
+
+// marshalHealthReport serializes a HealthReport to JSON, converting the
+// IssueSeverity integer enum to a lowercase string for each issue so that the
+// downstream agenthealth-remediation service can forward it without loss.
+func marshalHealthReport(report *healthplatform.HealthReport) ([]byte, error) {
+	w := &healthReportJSON{
+		SchemaVersion: report.GetSchemaVersion(),
+		EventType:     report.GetEventType(),
+		EmittedAt:     report.GetEmittedAt(),
+	}
+	if h := report.GetHost(); h != nil {
+		w.Host = &hostInfoJSON{
+			Hostname:     h.GetHostname(),
+			AgentVersion: h.AgentVersion,
+			ParIds:       h.GetParIds(),
+		}
+	}
+	if issues := report.GetIssues(); len(issues) > 0 {
+		w.Issues = make(map[string]*issueJSON, len(issues))
+		for k, issue := range issues {
+			w.Issues[k] = &issueJSON{
+				ID:          issue.GetId(),
+				IssueName:   issue.GetIssueName(),
+				Title:       issue.GetTitle(),
+				Description: issue.GetDescription(),
+				Category:    issue.GetCategory(),
+				Location:    issue.GetLocation(),
+				Severity:    severityString(issue.GetSeverity()),
+				DetectedAt:  issue.GetDetectedAt(),
+				Source:      issue.GetSource(),
+				Extra:       issue.GetExtra(),
+				Remediation: issue.GetRemediation(),
+				Tags:        issue.GetTags(),
+			}
+		}
+	}
+	return json.Marshal(w)
+}

--- a/comp/healthplatform/forwarder/impl/marshal_test.go
+++ b/comp/healthplatform/forwarder/impl/marshal_test.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package forwarderimpl
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestSeverityString(t *testing.T) {
+	tests := []struct {
+		severity healthplatform.IssueSeverity
+		expected string
+	}{
+		{healthplatform.IssueSeverity_ISSUE_SEVERITY_LOW, "low"},
+		{healthplatform.IssueSeverity_ISSUE_SEVERITY_MEDIUM, "medium"},
+		{healthplatform.IssueSeverity_ISSUE_SEVERITY_HIGH, "high"},
+		{healthplatform.IssueSeverity_ISSUE_SEVERITY_UNSPECIFIED, ""},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, severityString(tt.severity))
+	}
+}
+
+func TestMarshalHealthReport_SeverityAsString(t *testing.T) {
+	extra, err := structpb.NewStruct(map[string]any{"key": "value"})
+	require.NoError(t, err)
+
+	report := &healthplatform.HealthReport{
+		SchemaVersion: "1.0.0",
+		EventType:     "agent-health",
+		EmittedAt:     "2026-01-01T00:00:00Z",
+		Host:          &healthplatform.HostInfo{Hostname: "my-host"},
+		Issues: map[string]*healthplatform.Issue{
+			"medium-issue": {
+				Id:        "mid-1",
+				IssueName: "check-failure",
+				Severity:  healthplatform.IssueSeverity_ISSUE_SEVERITY_MEDIUM,
+				Category:  "integration",
+				Extra:     extra,
+			},
+			"high-issue": {
+				Id:       "hid-1",
+				Severity: healthplatform.IssueSeverity_ISSUE_SEVERITY_HIGH,
+			},
+			"low-issue": {
+				Id:       "lid-1",
+				Severity: healthplatform.IssueSeverity_ISSUE_SEVERITY_LOW,
+			},
+		},
+	}
+
+	payload, err := marshalHealthReport(report)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+
+	assert.Equal(t, "1.0.0", decoded["schema_version"])
+	assert.Equal(t, "my-host", decoded["host"].(map[string]any)["hostname"])
+
+	issues := decoded["issues"].(map[string]any)
+	assert.Equal(t, "medium", issues["medium-issue"].(map[string]any)["severity"])
+	assert.Equal(t, "high", issues["high-issue"].(map[string]any)["severity"])
+	assert.Equal(t, "low", issues["low-issue"].(map[string]any)["severity"])
+
+	// Extra must be a JSON object, not double-encoded.
+	extra_ := issues["medium-issue"].(map[string]any)["extra"]
+	assert.IsType(t, map[string]any{}, extra_)
+}
+
+func TestMarshalHealthReport_PersistedIssueOmitted(t *testing.T) {
+	report := &healthplatform.HealthReport{
+		Issues: map[string]*healthplatform.Issue{
+			"issue-1": {
+				Id:       "i1",
+				Severity: healthplatform.IssueSeverity_ISSUE_SEVERITY_MEDIUM,
+				PersistedIssue: &healthplatform.PersistedIssue{
+					State:     healthplatform.IssueState_ISSUE_STATE_ONGOING,
+					FirstSeen: "2026-01-01T00:00:00Z",
+				},
+			},
+		},
+	}
+
+	payload, err := marshalHealthReport(report)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+
+	issue := decoded["issues"].(map[string]any)["issue-1"].(map[string]any)
+	assert.Nil(t, issue["persisted_issue"], "persisted_issue must not be sent to intake")
+}


### PR DESCRIPTION
### What does this PR do?

Changes the `healthplatform` forwarder to serialize `Issue.Severity` as a lowercase string (`"low"`, `"medium"`, `"high"`) in the JSON payload sent to `agenthealth-intake`, instead of the integer enum value that `encoding/json` produces for an `int32`.

### Motivation

The `HealthReport.Issue.Severity` field is typed `IssueSeverity` (proto3 `int32` enum). When marshaled with `encoding/json`, it becomes `"severity": 2` (integer) in the JSON payload.

The downstream `agenthealth-remediation` EVP worker maps this JSON directly onto `recommendations.Issue`, whose `severity` field is a proto `string`. An integer value is silently dropped on unmarshal, leaving `severity: ""` for every agent health issue in the EVP.

This caused **all severity-filtered queries in the agent health tile to return zero results** — the tile showed 0 for broken/warning/recommendations regardless of real issue counts. The unfiltered side-panel query was unaffected (it fetches all issues regardless of severity).

Evidence from a real API call: the `/api/unstable/recommendations` response returns `"severity": ""` for every agent health issue.

### Describe how you validated your changes

- Added `TestSeverityString` covering all four enum values.
- Added `TestMarshalHealthReport_SeverityAsString` asserting `"medium"`, `"high"`, and `"low"` appear as strings in the JSON output.
- Added `TestMarshalHealthReport_PersistedIssueOmitted` confirming internal lifecycle state is not included in the intake payload.
- Updated `TestSend` to assert the severity arrives as the string `"high"` rather than the integer `3`.

### Additional Notes

`PersistedIssue` is intentionally excluded from the marshaled output. It tracks internal lifecycle state (`first_seen`, `last_seen`, `resolved_at`) and has no corresponding field in the downstream `recommendations.Issue` proto. The current `json.Marshal(report)` does include it; this PR removes it from the wire format as a cleanup.