### PR TITLE
refactor(logs): make utilization monitor hot path lock-free

### DIFF
--- a/comp/logs-library/metrics/BUILD.bazel
+++ b/comp/logs-library/metrics/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//comp/core/telemetry/impl",
         "//pkg/util/log",
         "@com_github_benbjohnson_clock//:clock",
+        "@org_uber_go_atomic//:atomic",
     ],
 )
 

--- a/comp/logs-library/metrics/pipeline_monitor_test.go
+++ b/comp/logs-library/metrics/pipeline_monitor_test.go
@@ -76,9 +76,8 @@ func TestTelemetryPipelineMonitor_TickerSamplesRegisteredMonitor(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		clk.Add(time.Second)
-		um.mu.Lock()
-		defer um.mu.Unlock()
-		return um.avg > 0
+		// avg is published atomically, so a subscriber can poll it without locking the hot path.
+		return um.avg.Load() > 0
 	}, 2*time.Second, 5*time.Millisecond,
 		"the pipeline monitor's ticker must sample its registered utilization monitor")
 }

--- a/comp/logs-library/metrics/utilization_monitor.go
+++ b/comp/logs-library/metrics/utilization_monitor.go
@@ -6,10 +6,10 @@
 package metrics
 
 import (
-	"sync"
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"go.uber.org/atomic"
 
 	log "github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -36,22 +36,29 @@ func (n *NoopUtilizationMonitor) Start() {}
 func (n *NoopUtilizationMonitor) Stop() {}
 
 // TelemetryUtilizationMonitor is a UtilizationMonitor that reports utilization metrics as telemetry.
+//
+// Start/Stop run on the component goroutine (a hot path); sample() runs on the pipeline sampler
+// goroutine. They share state only through atomics, so the hot path takes no lock: Start/Stop
+// publish raw accumulators and the sampler owns all derived state.
 type TelemetryUtilizationMonitor struct {
-	// mu guards all mutable state: Start/Stop run on the component goroutine, sample on the ticker.
-	mu sync.Mutex
+	// Accumulators written by the hot path and read by the sampler. cumulativeBusyNanos plus the
+	// open interval (now - startInUseNanos, while started) is the effective busy time at any instant.
+	cumulativeBusyNanos atomic.Int64
+	startInUseNanos     atomic.Int64
+	started             atomic.Bool
 
-	inUse      time.Duration
-	idle       time.Duration
-	startIdle  time.Time
-	startInUse time.Time
-	lastSample time.Time
-	sampleRate time.Duration
-	avg        float64 // EWMA utilization (N=15, α≈0.125)
-	history    *rollingHistory
-	name       string
-	instance   string
-	started    bool
-	clock      clock.Clock
+	// avg is the EWMA utilization (N=15, α≈0.125), written by the sampler and read atomically so
+	// subscribers can poll it without blocking the hot path.
+	avg atomic.Float64
+
+	// Sampler-owned state.
+	name              string
+	instance          string
+	sampleRate        time.Duration
+	clock             clock.Clock
+	history           *rollingHistory
+	lastSample        time.Time
+	lastEffectiveBusy int64
 	// registry, when non-nil, receives utilization snapshots and supplies the capacity figures
 	// used in saturation logs. It is owned by the pipeline monitor; standalone monitors leave it nil.
 	registry *snapshotRegistry
@@ -75,92 +82,84 @@ func newTelemetryUtilizationMonitorWithSampleRateAndClock(name, instance string,
 	return &TelemetryUtilizationMonitor{
 		name:       name,
 		instance:   instance,
-		startIdle:  clock.Now(),
-		startInUse: clock.Now(),
-		lastSample: clock.Now(),
 		sampleRate: sampleRate,
-		avg:        0,
-		history:    newRollingHistory(),
-		started:    false,
 		clock:      clock,
+		history:    newRollingHistory(),
+		lastSample: clock.Now(),
 		registry:   registry,
 	}
 }
 
-// Start tracks a start event in the utilization tracker.
+// Start tracks a start event in the utilization tracker. startInUseNanos is stored before
+// flipping started so the sampler never observes started with a stale start timestamp.
 func (u *TelemetryUtilizationMonitor) Start() {
-	u.mu.Lock()
-	defer u.mu.Unlock()
-	if u.started {
+	if u.started.Load() {
 		return
 	}
-	u.started = true
-	now := u.clock.Now()
-	u.idle += now.Sub(u.startIdle)
-	u.startInUse = now
-	u.reportIfNeededLocked(now)
+	u.startInUseNanos.Store(u.clock.Now().UnixNano())
+	u.started.Store(true)
 }
 
-// Stop tracks a finish event in the utilization tracker.
+// Stop tracks a finish event in the utilization tracker. The closed interval is credited to the
+// cumulative counter before clearing started, so a sampler that observes started=false also
+// observes the credited time.
 func (u *TelemetryUtilizationMonitor) Stop() {
-	u.mu.Lock()
-	defer u.mu.Unlock()
-	if !u.started {
+	if !u.started.Load() {
 		return
 	}
-	u.started = false
-	now := u.clock.Now()
-	u.inUse += now.Sub(u.startInUse)
-	u.startIdle = now
-	u.reportIfNeededLocked(now)
-}
-
-// sample is driven by the ticker so a component blocked mid-operation is observed, not frozen at its last EWMA.
-func (u *TelemetryUtilizationMonitor) sample(now time.Time) {
-	u.mu.Lock()
-	defer u.mu.Unlock()
-	u.settleLocked(now)
-	u.reportIfNeededLocked(now)
-}
-
-// settleLocked credits the open interval up to now and advances its start so Start/Stop won't double-count it. Caller holds u.mu.
-func (u *TelemetryUtilizationMonitor) settleLocked(now time.Time) {
-	if u.started {
-		u.inUse += now.Sub(u.startInUse)
-		u.startInUse = now
-	} else {
-		u.idle += now.Sub(u.startIdle)
-		u.startIdle = now
+	if busy := u.clock.Now().UnixNano() - u.startInUseNanos.Load(); busy > 0 {
+		u.cumulativeBusyNanos.Add(busy)
 	}
+	u.started.Store(false)
 }
 
-// reportIfNeededLocked publishes a sample if sampleRate has elapsed; now is passed for a consistent instant. Caller holds u.mu.
-func (u *TelemetryUtilizationMonitor) reportIfNeededLocked(now time.Time) {
+// sample is driven by the ticker so a component blocked mid-operation is observed, not frozen at
+// its last EWMA.
+func (u *TelemetryUtilizationMonitor) sample(now time.Time) {
 	if now.Sub(u.lastSample) < u.sampleRate {
 		return
 	}
+
+	// Differencing the monotonic effective-busy across the window credits the open interval once;
+	// a torn read against the hot path only shifts time between adjacent windows and self-corrects.
+	effBusy := u.effectiveBusyNanos(now)
+	windowBusy := effBusy - u.lastEffectiveBusy
+	windowElapsed := now.UnixNano() - u.lastSample.UnixNano()
+
 	rawRatio := 0.0
-	if total := u.idle + u.inUse; total > 0 {
-		rawRatio = float64(u.inUse) / float64(total)
+	if windowElapsed > 0 {
+		rawRatio = clamp01(float64(windowBusy) / float64(windowElapsed))
 	}
-	u.avg = ewma(rawRatio, u.avg)
 
-	u.history.add(now, u.avg)
+	avg := ewma(rawRatio, u.avg.Load())
+	u.avg.Store(avg)
+	u.history.add(now, avg)
 
-	TlmUtilizationRatio.Set(u.avg, u.name, u.instance)
+	TlmUtilizationRatio.Set(avg, u.name, u.instance)
 	if u.registry != nil {
-		u.registry.setUtilization(u.name, u.instance, u.avg, rawRatio, u.history)
+		u.registry.setUtilization(u.name, u.instance, avg, rawRatio, u.history)
 	}
-	u.idle = 0
-	u.inUse = 0
+
+	u.lastEffectiveBusy = effBusy
 	u.lastSample = now
 
-	u.updateSaturationState(now)
+	u.updateSaturationState(now, avg)
 }
 
-// updateSaturationState drives the saturation state machine, emitting transition and throttled logs. Caller holds u.mu.
-func (u *TelemetryUtilizationMonitor) updateSaturationState(now time.Time) {
-	currentlySaturated := u.avg >= SaturationThreshold
+// effectiveBusyNanos returns total in-use time as of now: completed intervals plus any open one.
+func (u *TelemetryUtilizationMonitor) effectiveBusyNanos(now time.Time) int64 {
+	busy := u.cumulativeBusyNanos.Load()
+	if u.started.Load() {
+		if open := now.UnixNano() - u.startInUseNanos.Load(); open > 0 {
+			busy += open
+		}
+	}
+	return busy
+}
+
+// updateSaturationState drives the saturation state machine, emitting transition and throttled logs.
+func (u *TelemetryUtilizationMonitor) updateSaturationState(now time.Time, avg float64) {
+	currentlySaturated := avg >= SaturationThreshold
 
 	if currentlySaturated {
 		u.pendingRecoverySince = time.Time{}
@@ -174,15 +173,15 @@ func (u *TelemetryUtilizationMonitor) updateSaturationState(now time.Time) {
 			u.isSaturated = true
 			u.saturatedSince = now
 			u.lastThrottleLog = now
-			u.episodeMaxUtil = u.avg
+			u.episodeMaxUtil = avg
 			u.episodeMaxItems = snap.RawItems
 			u.episodeMaxBytes = snap.RawBytes
 			// max_items/max_bytes are omitted at onset (capacity snapshot may not have ticked yet).
 			log.Warnf("Logs Agent pipeline component saturated component=%s instance=%s utilization=%.0f%%",
-				u.name, u.instance, u.avg*100)
+				u.name, u.instance, avg*100)
 		} else {
-			if u.avg > u.episodeMaxUtil {
-				u.episodeMaxUtil = u.avg
+			if avg > u.episodeMaxUtil {
+				u.episodeMaxUtil = avg
 			}
 			if snap.RawItems > u.episodeMaxItems {
 				u.episodeMaxItems = snap.RawItems
@@ -193,7 +192,7 @@ func (u *TelemetryUtilizationMonitor) updateSaturationState(now time.Time) {
 
 			if now.Sub(u.lastThrottleLog) >= saturationThrottleDuration {
 				log.Warnf("Logs Agent pipeline component saturated component=%s instance=%s utilization=%.0f%% duration=%s max_utilization=%.0f%% max_items=%d max_bytes=%d",
-					u.name, u.instance, u.avg*100, now.Sub(u.saturatedSince), u.episodeMaxUtil*100, u.episodeMaxItems, u.episodeMaxBytes)
+					u.name, u.instance, avg*100, now.Sub(u.saturatedSince), u.episodeMaxUtil*100, u.episodeMaxItems, u.episodeMaxBytes)
 				u.lastThrottleLog = now
 			}
 		}
@@ -211,4 +210,15 @@ func (u *TelemetryUtilizationMonitor) updateSaturationState(now time.Time) {
 			u.episodeMaxBytes = 0
 		}
 	}
+}
+
+// clamp01 bounds a ratio to [0, 1]; timing skew can push the raw ratio slightly outside it.
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
 }

--- a/comp/logs-library/metrics/utilization_monitor.go
+++ b/comp/logs-library/metrics/utilization_monitor.go
@@ -43,6 +43,8 @@ func (n *NoopUtilizationMonitor) Stop() {}
 type TelemetryUtilizationMonitor struct {
 	// Accumulators written by the hot path and read by the sampler. cumulativeBusyNanos plus the
 	// open interval (now - startInUseNanos, while started) is the effective busy time at any instant.
+	// Both are wall-clock UnixNano, so the window math stays self-consistent; NTP steps are absorbed
+	// by the >0 guards and clamp01 rather than corrupting the EWMA.
 	cumulativeBusyNanos atomic.Int64
 	startInUseNanos     atomic.Int64
 	started             atomic.Bool

--- a/comp/logs-library/metrics/utilization_monitor.go
+++ b/comp/logs-library/metrics/utilization_monitor.go
@@ -35,21 +35,17 @@ func (n *NoopUtilizationMonitor) Start() {}
 // Stop does nothing.
 func (n *NoopUtilizationMonitor) Stop() {}
 
-// TelemetryUtilizationMonitor reports component utilization as telemetry.
-//
-// Start/Stop run on the component hot path and touch only atomics; the sampler goroutine owns all
-// derived state, so neither side locks.
+// TelemetryUtilizationMonitor reports component utilization as telemetry. Start/Stop run lock-free
+// on the hot path; the sampler goroutine owns all derived state.
 type TelemetryUtilizationMonitor struct {
-	// Hot-path accumulators (wall-clock UnixNano), read by the sampler. Effective busy time is
-	// cumulativeBusyNanos plus the open interval (now - startInUseNanos) while started.
+	// Hot-path accumulators in ns; effective busy = cumulativeBusyNanos + open interval while started.
 	cumulativeBusyNanos atomic.Int64
 	startInUseNanos     atomic.Int64
 	started             atomic.Bool
 
-	// EWMA utilization (N=15, α≈0.125). Written by the sampler, read atomically by subscribers.
+	// EWMA utilization (N=15, α≈0.125); sampler writes, subscribers read.
 	avg atomic.Float64
 
-	// Sampler-owned state.
 	name              string
 	instance          string
 	sampleRate        time.Duration
@@ -57,18 +53,15 @@ type TelemetryUtilizationMonitor struct {
 	history           *rollingHistory
 	lastSample        time.Time
 	lastEffectiveBusy int64
-	// registry, when non-nil, receives utilization snapshots and supplies the capacity figures
-	// used in saturation logs. It is owned by the pipeline monitor; standalone monitors leave it nil.
-	registry *snapshotRegistry
+	registry          *snapshotRegistry // nil for standalone monitors
 
-	// Saturation episode tracking for log emission.
 	isSaturated          bool
 	saturatedSince       time.Time
 	lastThrottleLog      time.Time
 	episodeMaxUtil       float64
 	episodeMaxItems      int64
 	episodeMaxBytes      int64
-	pendingRecoverySince time.Time // non-zero while EWMA is below threshold but debounce not yet met
+	pendingRecoverySince time.Time
 }
 
 func newTelemetryUtilizationMonitorWithSampleRateAndClock(name, instance string, sampleRate time.Duration, clock clock.Clock, registry *snapshotRegistry) *TelemetryUtilizationMonitor {
@@ -111,8 +104,8 @@ func (u *TelemetryUtilizationMonitor) sample(now time.Time) {
 		return
 	}
 
-	// A torn read against the hot path can over- or under-count one interval; clamp01 bounds the
-	// window and the next tick self-corrects.
+	// A torn read against the hot path can over- or under-count one interval; clamp01 bounds it and
+	// the next tick self-corrects.
 	effBusy := u.effectiveBusyNanos(now)
 	windowBusy := effBusy - u.lastEffectiveBusy
 	windowElapsed := now.UnixNano() - u.lastSample.UnixNano()
@@ -137,7 +130,6 @@ func (u *TelemetryUtilizationMonitor) sample(now time.Time) {
 	u.updateSaturationState(now, avg)
 }
 
-// effectiveBusyNanos returns total in-use time as of now: completed intervals plus any open one.
 func (u *TelemetryUtilizationMonitor) effectiveBusyNanos(now time.Time) int64 {
 	busy := u.cumulativeBusyNanos.Load()
 	if u.started.Load() {
@@ -203,7 +195,6 @@ func (u *TelemetryUtilizationMonitor) updateSaturationState(now time.Time, avg f
 	}
 }
 
-// clamp01 bounds a ratio to [0, 1]; timing skew can push the raw ratio slightly outside it.
 func clamp01(v float64) float64 {
 	if v < 0 {
 		return 0

--- a/comp/logs-library/metrics/utilization_monitor.go
+++ b/comp/logs-library/metrics/utilization_monitor.go
@@ -35,22 +35,18 @@ func (n *NoopUtilizationMonitor) Start() {}
 // Stop does nothing.
 func (n *NoopUtilizationMonitor) Stop() {}
 
-// TelemetryUtilizationMonitor is a UtilizationMonitor that reports utilization metrics as telemetry.
+// TelemetryUtilizationMonitor reports component utilization as telemetry.
 //
-// Start/Stop run on the component goroutine (a hot path); sample() runs on the pipeline sampler
-// goroutine. They share state only through atomics, so the hot path takes no lock: Start/Stop
-// publish raw accumulators and the sampler owns all derived state.
+// Start/Stop run on the component hot path and touch only atomics; the sampler goroutine owns all
+// derived state, so neither side locks.
 type TelemetryUtilizationMonitor struct {
-	// Accumulators written by the hot path and read by the sampler. cumulativeBusyNanos plus the
-	// open interval (now - startInUseNanos, while started) is the effective busy time at any instant.
-	// Both are wall-clock UnixNano, so the window math stays self-consistent; NTP steps are absorbed
-	// by the >0 guards and clamp01 rather than corrupting the EWMA.
+	// Hot-path accumulators (wall-clock UnixNano), read by the sampler. Effective busy time is
+	// cumulativeBusyNanos plus the open interval (now - startInUseNanos) while started.
 	cumulativeBusyNanos atomic.Int64
 	startInUseNanos     atomic.Int64
 	started             atomic.Bool
 
-	// avg is the EWMA utilization (N=15, α≈0.125), written by the sampler and read atomically so
-	// subscribers can poll it without blocking the hot path.
+	// EWMA utilization (N=15, α≈0.125). Written by the sampler, read atomically by subscribers.
 	avg atomic.Float64
 
 	// Sampler-owned state.
@@ -87,39 +83,36 @@ func newTelemetryUtilizationMonitorWithSampleRateAndClock(name, instance string,
 	}
 }
 
-// Start tracks a start event in the utilization tracker. startInUseNanos is stored before
-// flipping started so the sampler never observes started with a stale start timestamp.
+// Start marks the component in-use.
 func (u *TelemetryUtilizationMonitor) Start() {
 	if u.started.Load() {
 		return
 	}
+	// Store the start before flipping started, so the sampler never sees started with a stale start.
 	u.startInUseNanos.Store(u.clock.Now().UnixNano())
 	u.started.Store(true)
 }
 
-// Stop tracks a finish event in the utilization tracker. The closed interval is credited to the
-// cumulative counter before clearing started, so a sampler that observes started=false also
-// observes the credited time.
+// Stop marks the component idle and credits the elapsed in-use interval.
 func (u *TelemetryUtilizationMonitor) Stop() {
 	if !u.started.Load() {
 		return
 	}
+	// Credit the interval before clearing started, so a sampler seeing started=false also sees it.
 	if busy := u.clock.Now().UnixNano() - u.startInUseNanos.Load(); busy > 0 {
 		u.cumulativeBusyNanos.Add(busy)
 	}
 	u.started.Store(false)
 }
 
-// sample is driven by the ticker so a component blocked mid-operation is observed, not frozen at
-// its last EWMA.
+// sample is driven by the ticker so a component blocked mid-operation is still observed.
 func (u *TelemetryUtilizationMonitor) sample(now time.Time) {
 	if now.Sub(u.lastSample) < u.sampleRate {
 		return
 	}
 
-	// effectiveBusyNanos is monotonic, so differencing it across the window normally credits the open
-	// interval exactly once. A torn read mid-Stop can briefly over- or under-count one interval;
-	// clamp01 bounds that window and the next one self-corrects, leaving only EWMA noise.
+	// A torn read against the hot path can over- or under-count one interval; clamp01 bounds the
+	// window and the next tick self-corrects.
 	effBusy := u.effectiveBusyNanos(now)
 	windowBusy := effBusy - u.lastEffectiveBusy
 	windowElapsed := now.UnixNano() - u.lastSample.UnixNano()

--- a/comp/logs-library/metrics/utilization_monitor.go
+++ b/comp/logs-library/metrics/utilization_monitor.go
@@ -73,11 +73,6 @@ type TelemetryUtilizationMonitor struct {
 	pendingRecoverySince time.Time // non-zero while EWMA is below threshold but debounce not yet met
 }
 
-// NewTelemetryUtilizationMonitor creates a new TelemetryUtilizationMonitor that reports to telemetry only.
-func NewTelemetryUtilizationMonitor(name, instance string) *TelemetryUtilizationMonitor {
-	return newTelemetryUtilizationMonitorWithSampleRateAndClock(name, instance, 1*time.Second, clock.New(), nil)
-}
-
 func newTelemetryUtilizationMonitorWithSampleRateAndClock(name, instance string, sampleRate time.Duration, clock clock.Clock, registry *snapshotRegistry) *TelemetryUtilizationMonitor {
 	return &TelemetryUtilizationMonitor{
 		name:       name,

--- a/comp/logs-library/metrics/utilization_monitor.go
+++ b/comp/logs-library/metrics/utilization_monitor.go
@@ -115,8 +115,9 @@ func (u *TelemetryUtilizationMonitor) sample(now time.Time) {
 		return
 	}
 
-	// Differencing the monotonic effective-busy across the window credits the open interval once;
-	// a torn read against the hot path only shifts time between adjacent windows and self-corrects.
+	// effectiveBusyNanos is monotonic, so differencing it across the window normally credits the open
+	// interval exactly once. A torn read mid-Stop can briefly over- or under-count one interval;
+	// clamp01 bounds that window and the next one self-corrects, leaving only EWMA noise.
 	effBusy := u.effectiveBusyNanos(now)
 	windowBusy := effBusy - u.lastEffectiveBusy
 	windowElapsed := now.UnixNano() - u.lastSample.UnixNano()

--- a/comp/logs-library/metrics/utilization_monitor_test.go
+++ b/comp/logs-library/metrics/utilization_monitor_test.go
@@ -15,61 +15,64 @@ import (
 )
 
 func TestUtilizationMonitorLifecycle(t *testing.T) {
-	clock := clock.NewMock()
-	um := newTelemetryUtilizationMonitorWithSampleRateAndClock("name", "instance", 2*time.Second, clock, nil)
+	clk := clock.NewMock()
+	// Reporting is driven by the sampler, so each 1s window is closed with an explicit sample().
+	um := newTelemetryUtilizationMonitorWithSampleRateAndClock("name", "instance", time.Second, clk, nil)
 
-	// Converge on 50% utilization
+	// Converge on 50% utilization: 500ms busy + 500ms idle per window.
 	for i := 0; i < 100; i++ {
 		um.Start()
-		clock.Add(1 * time.Second)
-
+		clk.Add(500 * time.Millisecond)
 		um.Stop()
-		clock.Add(1 * time.Second)
+		clk.Add(500 * time.Millisecond)
+		um.sample(clk.Now())
 	}
 
-	require.InDelta(t, 0.5, um.avg, 0.01)
+	require.InDelta(t, 0.5, um.avg.Load(), 0.01)
 
-	// Converge on 100% utilization
+	// Converge on ~100% utilization: 990ms busy + 10ms idle per window.
 	for i := 0; i < 100; i++ {
 		um.Start()
-		clock.Add(1 * time.Second)
-
+		clk.Add(990 * time.Millisecond)
 		um.Stop()
-		clock.Add(1 * time.Millisecond)
+		clk.Add(10 * time.Millisecond)
+		um.sample(clk.Now())
 	}
 
-	require.InDelta(t, 0.99, um.avg, 0.01)
+	require.InDelta(t, 0.99, um.avg.Load(), 0.01)
 
-	// Converge on 0% utilization
+	// Converge on ~0% utilization: 1ms busy + 999ms idle per window.
 	for i := 0; i < 200; i++ {
 		um.Start()
-		clock.Add(1 * time.Millisecond)
-
+		clk.Add(1 * time.Millisecond)
 		um.Stop()
-		clock.Add(1 * time.Second)
+		clk.Add(999 * time.Millisecond)
+		um.sample(clk.Now())
 	}
 
-	require.InDelta(t, 0.0, um.avg, 0.01)
+	require.InDelta(t, 0.0, um.avg.Load(), 0.01)
 
 }
 
-// runBusyIterations drives the monitor at ~99% utilization for n samples.
-func runBusyIterations(um *TelemetryUtilizationMonitor, clk interface{ Add(time.Duration) }, n int) {
+// runBusyIterations drives the monitor at ~99% utilization for n 1s sample windows.
+func runBusyIterations(um *TelemetryUtilizationMonitor, clk *clock.Mock, n int) {
 	for i := 0; i < n; i++ {
 		um.Start()
 		clk.Add(990 * time.Millisecond)
 		um.Stop()
 		clk.Add(10 * time.Millisecond)
+		um.sample(clk.Now())
 	}
 }
 
-// runIdleIterations drives the monitor at ~0.1% utilization for n samples.
-func runIdleIterations(um *TelemetryUtilizationMonitor, clk interface{ Add(time.Duration) }, n int) {
+// runIdleIterations drives the monitor at ~0.1% utilization for n 1s sample windows.
+func runIdleIterations(um *TelemetryUtilizationMonitor, clk *clock.Mock, n int) {
 	for i := 0; i < n; i++ {
 		um.Start()
 		clk.Add(1 * time.Millisecond)
 		um.Stop()
 		clk.Add(999 * time.Millisecond)
+		um.sample(clk.Now())
 	}
 }
 
@@ -85,7 +88,7 @@ func TestSample_BlockedComponentObserved(t *testing.T) {
 		um.sample(clk.Now())
 	}
 
-	require.GreaterOrEqual(t, um.avg, SaturationThreshold,
+	require.GreaterOrEqual(t, um.avg.Load(), SaturationThreshold,
 		"a component blocked in-use must reach saturation via periodic sampling, not freeze at 0")
 	assert.True(t, um.isSaturated, "saturation state must flip while still blocked, before any Stop")
 }
@@ -100,7 +103,7 @@ func TestSample_IdleComponentStaysLow(t *testing.T) {
 		um.sample(clk.Now())
 	}
 
-	assert.InDelta(t, 0.0, um.avg, 0.0001, "an idle component sampled periodically must stay at 0 utilization")
+	assert.InDelta(t, 0.0, um.avg.Load(), 0.0001, "an idle component sampled periodically must stay at 0 utilization")
 	assert.False(t, um.isSaturated)
 }
 
@@ -113,7 +116,7 @@ func TestSaturationStateOnset(t *testing.T) {
 
 	runBusyIterations(um, clk, 40)
 
-	require.GreaterOrEqual(t, um.avg, SaturationThreshold, "EWMA must reach saturation threshold")
+	require.GreaterOrEqual(t, um.avg.Load(), SaturationThreshold, "EWMA must reach saturation threshold")
 	assert.True(t, um.isSaturated, "isSaturated must flip true at onset")
 	assert.False(t, um.saturatedSince.IsZero(), "saturatedSince must be recorded at onset")
 }
@@ -128,7 +131,7 @@ func TestRecoveryDebounce_StaysInSaturatedState(t *testing.T) {
 
 	runIdleIterations(um, clk, 5)
 
-	require.Less(t, um.avg, SaturationThreshold, "EWMA must have dropped below threshold")
+	require.Less(t, um.avg.Load(), SaturationThreshold, "EWMA must have dropped below threshold")
 	assert.True(t, um.isSaturated, "must remain saturated while debounce pending")
 	assert.False(t, um.pendingRecoverySince.IsZero(), "debounce timer must start running")
 }
@@ -156,11 +159,11 @@ func TestRecoveryDebounce_ResetByReSaturation(t *testing.T) {
 	require.True(t, um.isSaturated)
 
 	runIdleIterations(um, clk, 2)
-	require.Less(t, um.avg, SaturationThreshold)
+	require.Less(t, um.avg.Load(), SaturationThreshold)
 	require.False(t, um.pendingRecoverySince.IsZero(), "debounce must be running")
 
 	runBusyIterations(um, clk, 40)
-	require.GreaterOrEqual(t, um.avg, SaturationThreshold)
+	require.GreaterOrEqual(t, um.avg.Load(), SaturationThreshold)
 
 	assert.True(t, um.pendingRecoverySince.IsZero(), "debounce timer must be cancelled on re-saturation")
 }


### PR DESCRIPTION
### What does this PR do?

Makes the `TelemetryUtilizationMonitor` hot path lock-free. `Start`/`Stop` now touch only atomics: `Start` stores the in-use interval start, `Stop` adds the closed interval to `cumulativeBusyNanos`. The 1 Hz sampler reads those accumulators and owns all derived state (`avg`, history, saturation), so it takes no lock. `avg` is published via `atomic.Float64`.

Also drops the unused exported `NewTelemetryUtilizationMonitor`.


### Motivation

Follow-up to [review feedback](https://github.com/DataDog/datadog-agent/pull/51973#discussion_r3382725398) on #51973. The backpressure PR added a sampling ticker on a separate goroutine, which put a mutex on the `Start`/`Stop` hot path. An atomic accumulator restores the lock-free hot path.

### Describe how you validated your changes

- `dda inv test --targets=./comp/logs-library/metrics/`: 23/23 pass
- `go test -race`: clean
- `bazel test //comp/logs-library/metrics:metrics_test`: pass
- Compared changes in SMP playground, including load testing from `experiment:file_to_blackhole_0ms_latency_ramp_up`, no matieral increase in CPU or memory usage, log throughput remains stable

### Additional Notes

Utilization ratio denominator changes from `inUse/(idle+inUse)` to `windowBusy/wallClockElapsed`.
