### PR TITLE
Add taskmd worktickets directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,7 @@
 /CHANGELOG-INSTALLSCRIPT.rst            @DataDog/agent-delivery
 
 /*.md                                   @DataDog/agent-devx
+/worktickets/                           # do not notify anyone
 /CHANGELOG-AIX.md                       @DataDog/agent-runtimes
 /NOTICE                                 @DataDog/agent-delivery
 

--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,4 @@ AUTO_JIRA.md
 .python-nix-home
 .venv-nix
 flake.lock
+.phoenix/

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -9,6 +9,7 @@ slack_teams_channels_check           @DataDog/agent-devx
 lint*                                @DataDog/agent-devx
 notify*                              @DataDog/agent-devx
 check_modules_replace                @DataDog/agent-devx
+validate_worktickets                  @DataDog/agent-devx
 
 # Deps build
 build_clang_*                        @DataDog/ebpf-platform

--- a/.gitlab/build/lint/technical_linters.yml
+++ b/.gitlab/build/lint/technical_linters.yml
@@ -41,6 +41,17 @@ lint_codeowners:
   script:
     - dda inv -- -e github.lint-codeowner
 
+validate_worktickets:
+  extends: .lint
+  rules:
+    - changes:
+        paths:
+          - worktickets/**/*
+        compare_to: $COMPARE_TO_BRANCH
+      when: on_success
+  script:
+    - uvx 'taskmd>=1.3.0' validate
+
 lint_components:
   extends: .lint
   script:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,15 @@ repos:
       language: system
       pass_filenames: false
       stages: [pre-commit, pre-push]
+    - id: taskmd-validate
+      name: taskmd-validate
+      description: Validate workticket filenames
+      entry: taskmd validate
+      language: python
+      language_version: python3.12
+      additional_dependencies: ["taskmd>=1.3.0"]
+      pass_filenames: false
+      files: ^worktickets/
     - id: copyright
       name: copyright
       description: copyright headers

--- a/worktickets/00001-p2-done--add-taskmd-worktickets.md
+++ b/worktickets/00001-p2-done--add-taskmd-worktickets.md
@@ -1,0 +1,28 @@
+# Add taskmd work tickets to datadog-agent
+
+## Goal
+
+Introduce `taskmd` as a lightweight work-ticket system for the Datadog Agent repository.
+
+The initial repository convention will be:
+
+- use a top-level `worktickets/` directory for taskmd tickets
+- include the standard taskmd `_TEMPLATE.md` in that directory
+- make the setup discoverable enough that contributors can run `taskmd --help` and start using the workflow
+
+## Proposed initial changes
+
+1. Create a top-level `worktickets/` directory.
+2. Add `worktickets/_TEMPLATE.md` using the standard taskmd template.
+3. Optionally add a short `worktickets/README.md` or repository-facing note if needed after reviewing how `taskmd` expects projects to document usage.
+4. Verify the resulting layout with the local `taskmd` CLI, starting with `taskmd --help` and any relevant validation/list commands.
+
+## Open question for follow-up
+
+We will discuss and refine the exact `_TEMPLATE.md` contents before committing the final template.
+
+## Validation
+
+- Confirm `taskmd --help` is available in the workspace.
+- Confirm `taskmd` recognizes or is compatible with the proposed `worktickets/` folder layout.
+- Confirm the template filename and structure match taskmd expectations.

--- a/worktickets/README
+++ b/worktickets/README
@@ -1,0 +1,21 @@
+Work tickets
+============
+
+This directory contains repository-local work tickets. `taskmd` is an optional convenience wrapper for creating, listing, validating, and renaming tickets while preserving the filename conventions for status and priority. Install it with `uv tool install taskmd`, or run it without installing via `uvx taskmd`.
+
+Each ticket is a Markdown file. The filename encodes the task metadata:
+
+    DDNNN-pX-status--short-slug.md
+
+`DD` is a two-digit stem derived from the hostname and worktree path. Its goal is to avoid ID conflicts by splitting ticket IDs across 100 possible stems. `NNN` is the incrementing sequence number within that stem.
+
+Common commands:
+
+    taskmd --help
+    taskmd list
+    taskmd validate
+    echo 'Describe the work to do.' | taskmd new --slug describe-work --priority p2
+    taskmd status 12345 in-progress
+
+Use worktickets/_TEMPLATE.md as the starting point for new ticket bodies.
+The `_TEMPLATE.md` marker allows taskmd to auto-discover this directory.

--- a/worktickets/_TEMPLATE.md
+++ b/worktickets/_TEMPLATE.md
@@ -1,0 +1,19 @@
+# Task Title
+
+## Summary
+
+Brief description of what needs to be done.
+
+## Context
+
+Why this task exists, any relevant background.
+
+## Done When
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Notes
+
+Any additional information, links, or considerations.


### PR DESCRIPTION
## Summary

Introduce `taskmd` work tickets for repository-local task context in `worktickets/`.

This adds:
- a top-level `worktickets/` directory with the standard `_TEMPLATE.md`
- a short `worktickets/README` explaining the filename convention and optional `taskmd` usage
- taskmd validation in pre-commit and GitLab technical linters
- CODEOWNERS/JOBOWNERS entries so workticket files are intentionally free-form while the CI job has an owner

## Validation

- `/home/bits/.local/bin/taskmd validate`
- `/home/bits/.local/bin/taskmd list`
- `pre-commit run taskmd-validate --all-files`
- pre-push hooks, including `gitlab-configuration`
