### PR TITLE
fix(autoscaling): release .spec.replicas ownership when DPA stops scaling

### DIFF
--- a/Dockerfiles/manifests/agent-only/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/agent-only/cluster-agent-rbac.yaml
@@ -223,9 +223,16 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
     verbs: ["get"]
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on the target
+  # when scaling stops, so server-side-apply writers such as Helm do not
+  # conflict with a stale `datadog-cluster-agent` field manager.
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments"]
+    verbs: ["patch"]
   - apiGroups: [""]
     resources: ["replicationcontrollers"]
-    verbs: ["get"]
+    verbs: ["get", "patch"]
   - apiGroups:
       - "security.openshift.io"
     resources:

--- a/Dockerfiles/manifests/all-containers/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/all-containers/cluster-agent-rbac.yaml
@@ -223,9 +223,16 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
     verbs: ["get"]
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on the target
+  # when scaling stops, so server-side-apply writers such as Helm do not
+  # conflict with a stale `datadog-cluster-agent` field manager.
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments"]
+    verbs: ["patch"]
   - apiGroups: [""]
     resources: ["replicationcontrollers"]
-    verbs: ["get"]
+    verbs: ["get", "patch"]
   - apiGroups:
       - ""
     resources:

--- a/Dockerfiles/manifests/cluster-agent-datadogmetrics/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-agent-datadogmetrics/cluster-agent-rbac.yaml
@@ -249,9 +249,16 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
     verbs: ["get"]
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on the target
+  # when scaling stops, so server-side-apply writers such as Helm do not
+  # conflict with a stale `datadog-cluster-agent` field manager.
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments"]
+    verbs: ["patch"]
   - apiGroups: [""]
     resources: ["replicationcontrollers"]
-    verbs: ["get"]
+    verbs: ["get", "patch"]
   - apiGroups:
       - "security.openshift.io"
     resources:

--- a/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml
@@ -234,9 +234,16 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
     verbs: ["get"]
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on the target
+  # when scaling stops, so server-side-apply writers such as Helm do not
+  # conflict with a stale `datadog-cluster-agent` field manager.
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments"]
+    verbs: ["patch"]
   - apiGroups: [""]
     resources: ["replicationcontrollers"]
-    verbs: ["get"]
+    verbs: ["get", "patch"]
   - apiGroups:
       - "security.openshift.io"
     resources:

--- a/Dockerfiles/manifests/cluster-checks-runners/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-checks-runners/cluster-agent-rbac.yaml
@@ -234,9 +234,16 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
     verbs: ["get"]
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on the target
+  # when scaling stops, so server-side-apply writers such as Helm do not
+  # conflict with a stale `datadog-cluster-agent` field manager.
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments"]
+    verbs: ["patch"]
   - apiGroups: [""]
     resources: ["replicationcontrollers"]
-    verbs: ["get"]
+    verbs: ["get", "patch"]
   - apiGroups:
       - "security.openshift.io"
     resources:

--- a/Dockerfiles/manifests/kubernetes_state_core/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/kubernetes_state_core/cluster-agent-rbac.yaml
@@ -223,9 +223,16 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
     verbs: ["get"]
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on the target
+  # when scaling stops, so server-side-apply writers such as Helm do not
+  # conflict with a stale `datadog-cluster-agent` field manager.
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments"]
+    verbs: ["patch"]
   - apiGroups: [""]
     resources: ["replicationcontrollers"]
-    verbs: ["get"]
+    verbs: ["get", "patch"]
   - apiGroups:
       - "security.openshift.io"
     resources:

--- a/Dockerfiles/manifests/orchestrator-explorer/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/orchestrator-explorer/cluster-agent-rbac.yaml
@@ -223,9 +223,16 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
     verbs: ["get"]
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on the target
+  # when scaling stops, so server-side-apply writers such as Helm do not
+  # conflict with a stale `datadog-cluster-agent` field manager.
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments"]
+    verbs: ["patch"]
   - apiGroups: [""]
     resources: ["replicationcontrollers"]
-    verbs: ["get"]
+    verbs: ["get", "patch"]
   - apiGroups:
       - "security.openshift.io"
     resources:

--- a/Dockerfiles/manifests/security-agent/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/security-agent/cluster-agent-rbac.yaml
@@ -223,9 +223,16 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
     verbs: ["get"]
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on the target
+  # when scaling stops, so server-side-apply writers such as Helm do not
+  # conflict with a stale `datadog-cluster-agent` field manager.
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments"]
+    verbs: ["patch"]
   - apiGroups: [""]
     resources: ["replicationcontrollers"]
-    verbs: ["get"]
+    verbs: ["get", "patch"]
   - apiGroups:
       - ""
     resources:

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -243,6 +243,12 @@ func (c *Controller) syncPodAutoscaler(ctx context.Context, key, ns, name string
 		// Also if object was not owned by remote config, we also need to delete it (deleted by user)
 		if podAutoscalerInternal.Deleted() || (!podAutoscalerInternal.IsProfileManaged() && podAutoscalerInternal.Spec().Owner != datadoghqcommon.DatadogPodAutoscalerRemoteOwner) {
 			log.Infof("Object %s not present in Kubernetes and flagged for deletion (remote) or owner == local, clearing internal store", key)
+			// Local-owned DPAs reach this branch when the user deletes the K8s
+			// object directly (the remote-owned and profile-managed paths above
+			// already released ownership before calling deletePodAutoscaler).
+			// Release here too so that a deleted local-owned DPA doesn't leak
+			// a stale `datadog-cluster-agent` scale managedFields entry.
+			c.releaseTargetReplicasOwnership(ctx, podAutoscalerInternal)
 			c.store.UnlockDelete(key, c.ID)
 			return autoscaling.NoRequeue, nil
 		}

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -131,7 +131,7 @@ func NewController(
 	c.limitHeap = limitHeap
 	c.store = store
 	c.podWatcher = podWatcher
-	c.scaler = newScaler(restMapper, scaleClient)
+	c.scaler = newScaler(restMapper, scaleClient, dynamicClient)
 
 	// Initialize metrics store
 	c.metricsStore = metricsstore.NewMetricsStore(metrics.GeneratePodAutoscalerMetrics, localSender, c.IsLeader, globalTagsFunc)
@@ -272,6 +272,7 @@ func (c *Controller) syncPodAutoscaler(ctx context.Context, key, ns, name string
 		// Deletion can only happen if the object is owned by remote config.
 		if podAutoscalerInternal.Deleted() {
 			log.Infof("Remote owned PodAutoscaler with Deleted flag, deleting object: %s", key)
+			c.releaseTargetReplicasOwnership(ctx, podAutoscalerInternal)
 			err := c.deletePodAutoscaler(ns, name)
 			// In case of not found, it means the object is gone but informer cache is not updated yet, we can safely delete it from our store
 			if err != nil && k8serrors.IsNotFound(err) {
@@ -359,6 +360,7 @@ func (c *Controller) syncPodAutoscaler(ctx context.Context, key, ns, name string
 	if podAutoscalerInternal.IsProfileManaged() {
 		if podAutoscalerInternal.Deleted() {
 			log.Infof("Profile-managed PodAutoscaler with Deleted flag, deleting object: %s", key)
+			c.releaseTargetReplicasOwnership(ctx, podAutoscalerInternal)
 			err := c.deletePodAutoscaler(ns, name)
 			if err != nil && k8serrors.IsNotFound(err) {
 				c.store.UnlockDelete(key, c.ID)
@@ -466,7 +468,7 @@ func (c *Controller) handleScaling(ctx context.Context, podAutoscaler *datadoghq
 
 	// TODO: While horizontal scaling is in progress we should not start vertical scaling
 	// While vertical scaling is in progress we should only allow horizontal scale up
-	horizontalRes, err := c.horizontalController.sync(ctx, podAutoscaler, podAutoscalerInternal, scale, gr, scaleErr)
+	horizontalRes, err := c.horizontalController.sync(ctx, podAutoscaler, podAutoscalerInternal, targetGVK, scale, gr, scaleErr)
 	if err != nil {
 		return horizontalRes, err
 	}
@@ -604,6 +606,26 @@ func (c *Controller) deletePodAutoscaler(ns, name string) error {
 		return fmt.Errorf("Unable to delete PodAutoscaler: %s/%s, err: %v", ns, name, err)
 	}
 	return nil
+}
+
+// releaseTargetReplicasOwnership best-effort removes the cluster agent's
+// managed-fields entry for `.spec.replicas` (scale subresource) from the
+// DPA's target workload. Called before deleting a DPA so that subsequent
+// SSA writers (e.g. Helm) do not conflict with a stale field manager.
+// Errors are logged but not returned — cleanup must not block deletion.
+func (c *Controller) releaseTargetReplicasOwnership(ctx context.Context, podAutoscalerInternal model.PodAutoscalerInternal) {
+	spec := podAutoscalerInternal.Spec()
+	if spec == nil || spec.TargetRef.Name == "" {
+		return
+	}
+	targetGVK, err := podAutoscalerInternal.TargetGVK()
+	if err != nil {
+		log.Debugf("Skipping replicas-ownership release for %s/%s: unable to resolve target GVK: %v", podAutoscalerInternal.Namespace(), podAutoscalerInternal.Name(), err)
+		return
+	}
+	if err := c.scaler.releaseReplicasOwnership(ctx, podAutoscalerInternal.Namespace(), spec.TargetRef.Name, targetGVK); err != nil {
+		log.Warnf("Failed to release replicas ownership for %s %s/%s: %v", targetGVK.Kind, podAutoscalerInternal.Namespace(), spec.TargetRef.Name, err)
+	}
 }
 
 func (c *Controller) validateAutoscaler(podAutoscalerInternal model.PodAutoscalerInternal) error {

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
@@ -50,7 +50,7 @@ func newHorizontalReconciler(clock clock.Clock, eventRecorder record.EventRecord
 	}
 }
 
-func (hr *horizontalController) sync(ctx context.Context, podAutoscaler *datadoghq.DatadogPodAutoscaler, autoscalerInternal *model.PodAutoscalerInternal, scale *autoscalingv1.Scale, gr schema.GroupResource, scaleErr error) (autoscaling.ProcessResult, error) {
+func (hr *horizontalController) sync(ctx context.Context, podAutoscaler *datadoghq.DatadogPodAutoscaler, autoscalerInternal *model.PodAutoscalerInternal, targetGVK schema.GroupVersionKind, scale *autoscalingv1.Scale, gr schema.GroupResource, scaleErr error) (autoscaling.ProcessResult, error) {
 	// If we have no Spec, nothing to do
 	if autoscalerInternal.Spec() == nil {
 		return autoscaling.NoRequeue, nil
@@ -58,6 +58,17 @@ func (hr *horizontalController) sync(ctx context.Context, podAutoscaler *datadog
 
 	// If horizontal scaling is disabled, clear horizontal state and exit.
 	if !autoscalerInternal.IsHorizontalScalingEnabled() {
+		// If we previously scaled this target, release ownership of
+		// `.spec.replicas` so SSA writers (e.g. Helm) do not conflict with
+		// a stale field manager once horizontal scaling is off. Gated on
+		// HorizontalLastActions to avoid issuing a GET on every reconcile
+		// while horizontal stays disabled — ClearHorizontalState below
+		// nils out actions so subsequent ticks skip this branch.
+		if len(autoscalerInternal.HorizontalLastActions()) > 0 && autoscalerInternal.Spec().TargetRef.Name != "" {
+			if err := hr.scaler.releaseReplicasOwnership(ctx, autoscalerInternal.Namespace(), autoscalerInternal.Spec().TargetRef.Name, targetGVK); err != nil {
+				log.Warnf("Failed to release replicas ownership for %s %s/%s after disabling horizontal scaling: %v", targetGVK.Kind, autoscalerInternal.Namespace(), autoscalerInternal.Spec().TargetRef.Name, err)
+			}
+		}
 		autoscalerInternal.ClearHorizontalState()
 		return autoscaling.NoRequeue, nil
 	}

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
@@ -64,9 +64,16 @@ func (hr *horizontalController) sync(ctx context.Context, podAutoscaler *datadog
 		// HorizontalLastActions to avoid issuing a GET on every reconcile
 		// while horizontal stays disabled — ClearHorizontalState below
 		// nils out actions so subsequent ticks skip this branch.
+		//
+		// IMPORTANT: only clear horizontal state once the release actually
+		// succeeds. If we cleared on failure (RBAC missing, JSON-patch test
+		// op race, transient API error), the gate above would never fire
+		// again and the stale managedFields entry would leak permanently.
+		// On failure we requeue and retry with a fresh snapshot.
 		if len(autoscalerInternal.HorizontalLastActions()) > 0 && autoscalerInternal.Spec().TargetRef.Name != "" {
 			if err := hr.scaler.releaseReplicasOwnership(ctx, autoscalerInternal.Namespace(), autoscalerInternal.Spec().TargetRef.Name, targetGVK); err != nil {
-				log.Warnf("Failed to release replicas ownership for %s %s/%s after disabling horizontal scaling: %v", targetGVK.Kind, autoscalerInternal.Namespace(), autoscalerInternal.Spec().TargetRef.Name, err)
+				log.Warnf("Failed to release replicas ownership for %s %s/%s after disabling horizontal scaling, will retry: %v", targetGVK.Kind, autoscalerInternal.Namespace(), autoscalerInternal.Spec().TargetRef.Name, err)
+				return autoscaling.Requeue, nil
 			}
 		}
 		autoscalerInternal.ClearHorizontalState()

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
@@ -79,14 +79,16 @@ func (f *horizontalControllerFixture) runSync(fakePai *model.FakePodAutoscalerIn
 	// Pre-fetch scale subresource, mirroring what handleScaling does in the parent controller.
 	var scale *autoscalingv1.Scale
 	var gr schema.GroupResource
+	var targetGVK schema.GroupVersionKind
 	var scaleErr error
 	if autoscalerInternal.Spec() != nil {
 		if gvk, err := autoscalerInternal.TargetGVK(); err == nil {
+			targetGVK = gvk
 			scale, gr, scaleErr = f.scaler.get(context.Background(), fakePai.Namespace, autoscalerInternal.Spec().TargetRef.Name, gvk)
 		}
 	}
 
-	res, err := f.controller.sync(context.Background(), fakeAutoscaler, &autoscalerInternal, scale, gr, scaleErr)
+	res, err := f.controller.sync(context.Background(), fakeAutoscaler, &autoscalerInternal, targetGVK, scale, gr, scaleErr)
 	return autoscalerInternal, res, err
 }
 
@@ -350,6 +352,58 @@ func TestHorizontalControllerSyncPrerequisites(t *testing.T) {
 	// })
 	// assert.Equal(t, autoscaling.NoRequeue, result)
 	// assert.NoError(t, err)
+}
+
+func TestHorizontalControllerReleaseOwnershipOnDisable(t *testing.T) {
+	f := newHorizontalControllerFixture(t, time.Now())
+	autoscalerNamespace := "default"
+	autoscalerName := "test"
+
+	targetGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	disabledStrategy := datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect
+	disabledPolicy := &datadoghq.DatadogPodAutoscalerApplyPolicy{
+		ScaleUp:   &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{Strategy: &disabledStrategy},
+		ScaleDown: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{Strategy: &disabledStrategy},
+	}
+	spec := &datadoghq.DatadogPodAutoscalerSpec{
+		TargetRef: v2.CrossVersionObjectReference{
+			Name:       autoscalerName,
+			Kind:       targetGVK.Kind,
+			APIVersion: targetGVK.Group + "/" + targetGVK.Version,
+		},
+		ApplyPolicy: disabledPolicy,
+	}
+
+	// Case 1: horizontal disabled with prior actions → release exactly once.
+	fakePai := &model.FakePodAutoscalerInternal{
+		Namespace: autoscalerNamespace,
+		Name:      autoscalerName,
+		Spec:      spec,
+		TargetGVK: targetGVK,
+		HorizontalLastActions: []datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
+			{Time: metav1.NewTime(f.clock.Now()), FromReplicas: 3, ToReplicas: 5},
+		},
+	}
+	f.scaler.mockGet(*fakePai, 5, 5, nil)
+	_, result, err := f.runSync(fakePai)
+	assert.Equal(t, autoscaling.NoRequeue, result)
+	assert.NoError(t, err)
+	f.scaler.AssertNumberOfCalls(t, "releaseReplicasOwnership", 1)
+	f.scaler.AssertCalled(t, "releaseReplicasOwnership", mock.Anything, autoscalerNamespace, autoscalerName, targetGVK)
+
+	// Case 2: horizontal disabled with no prior actions → no release.
+	f.resetFakeScaler()
+	fakePaiNoActions := &model.FakePodAutoscalerInternal{
+		Namespace: autoscalerNamespace,
+		Name:      autoscalerName,
+		Spec:      spec,
+		TargetGVK: targetGVK,
+	}
+	f.scaler.mockGet(*fakePaiNoActions, 5, 5, nil)
+	_, result, err = f.runSync(fakePaiNoActions)
+	assert.Equal(t, autoscaling.NoRequeue, result)
+	assert.NoError(t, err)
+	f.scaler.AssertNumberOfCalls(t, "releaseReplicasOwnership", 0)
 }
 
 func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
@@ -9,6 +9,7 @@ package workload
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -451,7 +452,7 @@ func TestHorizontalControllerReleaseOwnershipOnDisable_FailureRetainsState(t *te
 	f.scaler = strictScaler
 	f.scaler.mockGet(*fakePai, 5, 5, nil)
 	strictScaler.On("releaseReplicasOwnership", mock.Anything, autoscalerNamespace, autoscalerName, targetGVK).
-		Return(fmt.Errorf("forbidden: missing patch permission"))
+		Return(errors.New("forbidden: missing patch permission"))
 
 	autoscaler, result, err := f.runSync(fakePai)
 	assert.Equal(t, autoscaling.Requeue, result, "must requeue so the workqueue retries the release")

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
@@ -406,6 +406,65 @@ func TestHorizontalControllerReleaseOwnershipOnDisable(t *testing.T) {
 	f.scaler.AssertNumberOfCalls(t, "releaseReplicasOwnership", 0)
 }
 
+func TestHorizontalControllerReleaseOwnershipOnDisable_FailureRetainsState(t *testing.T) {
+	// When releaseReplicasOwnership fails (e.g. RBAC not yet granted, or
+	// JSON-patch test op detected a managedFields race), the controller
+	// must NOT clear HorizontalLastActions — otherwise the gate
+	// (`len(HorizontalLastActions) > 0`) would never fire again and the
+	// stale managedFields entry would leak permanently. The controller
+	// should also return Requeue so the workqueue retries.
+	f := newHorizontalControllerFixture(t, time.Now())
+	autoscalerNamespace := "default"
+	autoscalerName := "test"
+
+	targetGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	disabledStrategy := datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect
+	disabledPolicy := &datadoghq.DatadogPodAutoscalerApplyPolicy{
+		ScaleUp:   &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{Strategy: &disabledStrategy},
+		ScaleDown: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{Strategy: &disabledStrategy},
+	}
+	spec := &datadoghq.DatadogPodAutoscalerSpec{
+		TargetRef: v2.CrossVersionObjectReference{
+			Name:       autoscalerName,
+			Kind:       targetGVK.Kind,
+			APIVersion: targetGVK.Group + "/" + targetGVK.Version,
+		},
+		ApplyPolicy: disabledPolicy,
+	}
+
+	priorActions := []datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
+		{Time: metav1.NewTime(f.clock.Now()), FromReplicas: 3, ToReplicas: 5},
+	}
+	fakePai := &model.FakePodAutoscalerInternal{
+		Namespace:             autoscalerNamespace,
+		Name:                  autoscalerName,
+		Spec:                  spec,
+		TargetGVK:             targetGVK,
+		HorizontalLastActions: priorActions,
+	}
+
+	// Bypass the Maybe-equipped fakeScaler: install a fresh one with a
+	// strict failing expectation so the controller sees an error from
+	// releaseReplicasOwnership.
+	strictScaler := &fakeScaler{}
+	f.controller.scaler = strictScaler
+	f.scaler = strictScaler
+	f.scaler.mockGet(*fakePai, 5, 5, nil)
+	strictScaler.On("releaseReplicasOwnership", mock.Anything, autoscalerNamespace, autoscalerName, targetGVK).
+		Return(fmt.Errorf("forbidden: missing patch permission"))
+
+	autoscaler, result, err := f.runSync(fakePai)
+	assert.Equal(t, autoscaling.Requeue, result, "must requeue so the workqueue retries the release")
+	assert.NoError(t, err, "best-effort cleanup must not surface an error to the workqueue retry counter")
+	strictScaler.AssertNumberOfCalls(t, "releaseReplicasOwnership", 1)
+
+	// HorizontalLastActions must NOT be cleared — otherwise the gate above
+	// would never fire on the next reconcile and the stale managedFields
+	// entry would leak permanently.
+	assert.Equal(t, priorActions, autoscaler.HorizontalLastActions(),
+		"HorizontalLastActions must be retained on release failure to allow retry")
+}
+
 func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
 	testTime := time.Now()
 	startTime := testTime.Add(-time.Hour)

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -156,6 +156,12 @@ func TestLeaderCreateDeleteLocal(t *testing.T) {
 
 	f.RunControllerSync(true, "default/dpa-0")
 	assert.Len(t, f.store.GetAll(), 0)
+	// Even for local-owned DPAs (deleted directly via kubectl), the
+	// controller must release `.spec.replicas` ownership on the target
+	// workload before clearing the internal store, so SSA writers do not
+	// conflict with a stale `datadog-cluster-agent` field manager.
+	f.scaler.AssertCalled(t, "releaseReplicasOwnership", mock.Anything, "default", "app-0",
+		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
 
 	// Re-create object
 	f.InformerObjects = append(f.InformerObjects, dpa)

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -226,6 +226,12 @@ func TestLeaderCreateDeleteRemote(t *testing.T) {
 	f.ExpectDeleteAction("default", "dpa-0")
 	f.RunControllerSync(true, "default/dpa-0")
 	assert.Len(t, f.store.GetAll(), 1) // Still in store
+	// The controller must release `.spec.replicas` ownership on the target
+	// workload before deleting the DPA, so SSA writers (e.g. Helm) do not
+	// conflict with a stale `datadog-cluster-agent` field manager.
+	f.scaler.AssertNumberOfCalls(t, "releaseReplicasOwnership", 1)
+	f.scaler.AssertCalled(t, "releaseReplicasOwnership", mock.Anything, "default", "app-0",
+		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
 
 	// Next reconcile the controller is going to remove the object from the store
 	f.InformerObjects = nil

--- a/pkg/clusteragent/autoscaling/workload/scaler.go
+++ b/pkg/clusteragent/autoscaling/workload/scaler.go
@@ -137,12 +137,31 @@ func (sg *scalerImpl) releaseReplicasOwnershipForGVR(ctx context.Context, namesp
 		return nil
 	}
 
-	patch := make([]map[string]string, 0, len(indices))
+	// Guard each remove with `test` ops asserting the manager+subresource
+	// at that index still match what we observed in the GET. If a concurrent
+	// writer (Helm SSA, kubectl, another controller) shifted managedFields
+	// between our GET and this PATCH, the test fails, the whole patch is
+	// rejected (422 Invalid) atomically, and no foreign ownership entry is
+	// dropped. We just retry on the next reconcile with a fresh snapshot.
+	patch := make([]map[string]string, 0, 3*len(indices))
 	for j := len(indices) - 1; j >= 0; j-- {
-		patch = append(patch, map[string]string{
-			"op":   "remove",
-			"path": fmt.Sprintf("/metadata/managedFields/%d", indices[j]),
-		})
+		idx := indices[j]
+		patch = append(patch,
+			map[string]string{
+				"op":    "test",
+				"path":  fmt.Sprintf("/metadata/managedFields/%d/manager", idx),
+				"value": datadogClusterAgentFieldManager,
+			},
+			map[string]string{
+				"op":    "test",
+				"path":  fmt.Sprintf("/metadata/managedFields/%d/subresource", idx),
+				"value": "scale",
+			},
+			map[string]string{
+				"op":   "remove",
+				"path": fmt.Sprintf("/metadata/managedFields/%d", idx),
+			},
+		)
 	}
 	body, err := json.Marshal(patch)
 	if err != nil {

--- a/pkg/clusteragent/autoscaling/workload/scaler.go
+++ b/pkg/clusteragent/autoscaling/workload/scaler.go
@@ -23,7 +23,7 @@ import (
 )
 
 // datadogClusterAgentFieldManager is the field-manager name Kubernetes
-// records for writes the cluster agent issues against scaleable workloads.
+// records for writes the cluster agent issues against scalable workloads.
 // It is derived from the binary's user-agent. See the support case context
 // in the PR description for how stale entries with this manager surface as
 // SSA conflicts for users.

--- a/pkg/clusteragent/autoscaling/workload/scaler.go
+++ b/pkg/clusteragent/autoscaling/workload/scaler.go
@@ -9,29 +9,50 @@ package workload
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 	scaleclient "k8s.io/client-go/scale"
 )
+
+// datadogClusterAgentFieldManager is the field-manager name Kubernetes
+// records for writes the cluster agent issues against scaleable workloads.
+// It is derived from the binary's user-agent. See the support case context
+// in the PR description for how stale entries with this manager surface as
+// SSA conflicts for users.
+const datadogClusterAgentFieldManager = "datadog-cluster-agent"
 
 type scaler interface {
 	get(ctx context.Context, namespace, name string, gvk schema.GroupVersionKind) (*autoscalingv1.Scale, schema.GroupResource, error)
 	update(ctx context.Context, gr schema.GroupResource, scale *autoscalingv1.Scale) (*autoscalingv1.Scale, error)
+	// releaseReplicasOwnership removes the cluster agent's managed-fields
+	// entry for the scale subresource on the target workload, so that
+	// server-side appliers (e.g. Helm SSA) can write `.spec.replicas`
+	// without conflicting with a stale entry left behind once the
+	// DatadogPodAutoscaler stops scaling the workload.
+	//
+	// Safe to call when no such entry exists (returns nil).
+	releaseReplicasOwnership(ctx context.Context, namespace, name string, gvk schema.GroupVersionKind) error
 }
 
 type scalerImpl struct {
-	restMapper  apimeta.RESTMapper
-	scaleGetter scaleclient.ScalesGetter
+	restMapper    apimeta.RESTMapper
+	scaleGetter   scaleclient.ScalesGetter
+	dynamicClient dynamic.Interface
 }
 
-func newScaler(restMapper apimeta.RESTMapper, scaleGetter scaleclient.ScalesGetter) scaler {
+func newScaler(restMapper apimeta.RESTMapper, scaleGetter scaleclient.ScalesGetter, dynamicClient dynamic.Interface) scaler {
 	return &scalerImpl{
-		restMapper:  restMapper,
-		scaleGetter: scaleGetter,
+		restMapper:    restMapper,
+		scaleGetter:   scaleGetter,
+		dynamicClient: dynamicClient,
 	}
 }
 
@@ -66,4 +87,68 @@ func (sg *scalerImpl) get(ctx context.Context, namespace, name string, gvk schem
 
 func (sg *scalerImpl) update(ctx context.Context, gr schema.GroupResource, scale *autoscalingv1.Scale) (*autoscalingv1.Scale, error) {
 	return sg.scaleGetter.Scales(scale.Namespace).Update(ctx, gr, scale, metav1.UpdateOptions{})
+}
+
+func (sg *scalerImpl) releaseReplicasOwnership(ctx context.Context, namespace, name string, gvk schema.GroupVersionKind) error {
+	mappings, err := sg.restMapper.RESTMappings(gvk.GroupKind())
+	if err != nil {
+		return fmt.Errorf("failed to get REST mappings for GVK: %s", gvk)
+	}
+
+	var firstErr error
+	for i, mapping := range mappings {
+		gvr := mapping.Resource
+		err := sg.releaseReplicasOwnershipForGVR(ctx, namespace, name, gvr)
+		if err == nil {
+			return nil
+		}
+		if k8serrors.IsNotFound(err) {
+			// Target workload no longer exists — nothing left to release.
+			return nil
+		}
+		if i == 0 {
+			firstErr = err
+		}
+	}
+
+	if firstErr == nil {
+		return fmt.Errorf("unrecognized resource: %s", gvk)
+	}
+	return firstErr
+}
+
+func (sg *scalerImpl) releaseReplicasOwnershipForGVR(ctx context.Context, namespace, name string, gvr schema.GroupVersionResource) error {
+	obj, err := sg.dynamicClient.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Collect indices of managedFields entries owned by the cluster agent
+	// on the scale subresource. Iterate in descending order so each remove
+	// op leaves earlier indices stable.
+	managedFields := obj.GetManagedFields()
+	var indices []int
+	for i, mf := range managedFields {
+		if mf.Manager == datadogClusterAgentFieldManager && mf.Subresource == "scale" {
+			indices = append(indices, i)
+		}
+	}
+	if len(indices) == 0 {
+		return nil
+	}
+
+	patch := make([]map[string]string, 0, len(indices))
+	for j := len(indices) - 1; j >= 0; j-- {
+		patch = append(patch, map[string]string{
+			"op":   "remove",
+			"path": fmt.Sprintf("/metadata/managedFields/%d", indices[j]),
+		})
+	}
+	body, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal managedFields patch: %w", err)
+	}
+
+	_, err = sg.dynamicClient.Resource(gvr).Namespace(namespace).Patch(ctx, name, types.JSONPatchType, body, metav1.PatchOptions{})
+	return err
 }

--- a/pkg/clusteragent/autoscaling/workload/scaler.go
+++ b/pkg/clusteragent/autoscaling/workload/scaler.go
@@ -92,29 +92,23 @@ func (sg *scalerImpl) update(ctx context.Context, gr schema.GroupResource, scale
 func (sg *scalerImpl) releaseReplicasOwnership(ctx context.Context, namespace, name string, gvk schema.GroupVersionKind) error {
 	mappings, err := sg.restMapper.RESTMappings(gvk.GroupKind())
 	if err != nil {
-		return fmt.Errorf("failed to get REST mappings for GVK: %s", gvk)
+		return fmt.Errorf("failed to get REST mappings for GVK %s: %w", gvk, err)
+	}
+	if len(mappings) == 0 {
+		return fmt.Errorf("no REST mappings for GVK %s", gvk)
 	}
 
-	var firstErr error
-	for i, mapping := range mappings {
-		gvr := mapping.Resource
-		err := sg.releaseReplicasOwnershipForGVR(ctx, namespace, name, gvr)
-		if err == nil {
-			return nil
-		}
-		if k8serrors.IsNotFound(err) {
-			// Target workload no longer exists — nothing left to release.
-			return nil
-		}
-		if i == 0 {
-			firstErr = err
-		}
+	// Multi-version mappings (e.g. CRDs served under multiple versions) all
+	// resolve to the same etcd object — patching via the preferred (first)
+	// mapping is sufficient. The previous loop would silently swallow a
+	// Forbidden from an earlier mapping if a later mapping returned NotFound,
+	// causing the release to look successful when it actually never ran.
+	err = sg.releaseReplicasOwnershipForGVR(ctx, namespace, name, mappings[0].Resource)
+	if k8serrors.IsNotFound(err) {
+		// Target workload no longer exists — nothing left to release.
+		return nil
 	}
-
-	if firstErr == nil {
-		return fmt.Errorf("unrecognized resource: %s", gvk)
-	}
-	return firstErr
+	return err
 }
 
 func (sg *scalerImpl) releaseReplicasOwnershipForGVR(ctx context.Context, namespace, name string, gvr schema.GroupVersionResource) error {

--- a/pkg/clusteragent/autoscaling/workload/scaler_fake.go
+++ b/pkg/clusteragent/autoscaling/workload/scaler_fake.go
@@ -23,10 +23,12 @@ type fakeScaler struct {
 
 func newFakeScaler() *fakeScaler {
 	fs := &fakeScaler{}
-	// Default Maybe-expectation: most existing tests don't care about the
-	// best-effort release-ownership cleanup path. Tests that need to assert
-	// on releaseReplicasOwnership can register a stricter expectation via
-	// mockReleaseReplicasOwnership and it will take precedence.
+	// Default Maybe-expectation so existing tests that exercise the
+	// best-effort release-ownership cleanup path don't have to declare
+	// per-test mocks. testify-mock matches expectations FIFO, so a test
+	// that needs to inject an error must NOT use newFakeScaler() — it
+	// should construct its own &fakeScaler{} (no permissive default) and
+	// register a strict expectation that's guaranteed to match first.
 	fs.On("releaseReplicasOwnership", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).Maybe()
 	return fs
@@ -45,11 +47,6 @@ func (fs *fakeScaler) update(ctx context.Context, gr schema.GroupResource, scale
 func (fs *fakeScaler) releaseReplicasOwnership(ctx context.Context, namespace, name string, gvk schema.GroupVersionKind) error {
 	args := fs.Called(ctx, namespace, name, gvk)
 	return args.Error(0)
-}
-
-func (fs *fakeScaler) mockReleaseReplicasOwnership(pai model.FakePodAutoscalerInternal, err error) {
-	fs.On("releaseReplicasOwnership", mock.Anything, pai.Namespace, pai.Spec.TargetRef.Name, pai.TargetGVK).
-		Return(err)
 }
 
 func (fs *fakeScaler) mockGet(pai model.FakePodAutoscalerInternal, specReplicas, statusReplicas int32, err error) {

--- a/pkg/clusteragent/autoscaling/workload/scaler_fake.go
+++ b/pkg/clusteragent/autoscaling/workload/scaler_fake.go
@@ -22,7 +22,14 @@ type fakeScaler struct {
 }
 
 func newFakeScaler() *fakeScaler {
-	return &fakeScaler{}
+	fs := &fakeScaler{}
+	// Default Maybe-expectation: most existing tests don't care about the
+	// best-effort release-ownership cleanup path. Tests that need to assert
+	// on releaseReplicasOwnership can register a stricter expectation via
+	// mockReleaseReplicasOwnership and it will take precedence.
+	fs.On("releaseReplicasOwnership", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Maybe()
+	return fs
 }
 
 func (fs *fakeScaler) get(ctx context.Context, namespace, name string, gvk schema.GroupVersionKind) (*autoscalingv1.Scale, schema.GroupResource, error) {
@@ -33,6 +40,16 @@ func (fs *fakeScaler) get(ctx context.Context, namespace, name string, gvk schem
 func (fs *fakeScaler) update(ctx context.Context, gr schema.GroupResource, scale *autoscalingv1.Scale) (*autoscalingv1.Scale, error) {
 	args := fs.Called(ctx, gr, scale)
 	return args.Get(0).(*autoscalingv1.Scale), args.Error(1)
+}
+
+func (fs *fakeScaler) releaseReplicasOwnership(ctx context.Context, namespace, name string, gvk schema.GroupVersionKind) error {
+	args := fs.Called(ctx, namespace, name, gvk)
+	return args.Error(0)
+}
+
+func (fs *fakeScaler) mockReleaseReplicasOwnership(pai model.FakePodAutoscalerInternal, err error) {
+	fs.On("releaseReplicasOwnership", mock.Anything, pai.Namespace, pai.Spec.TargetRef.Name, pai.TargetGVK).
+		Return(err)
 }
 
 func (fs *fakeScaler) mockGet(pai model.FakePodAutoscalerInternal, specReplicas, statusReplicas int32, err error) {

--- a/pkg/clusteragent/autoscaling/workload/scaler_test.go
+++ b/pkg/clusteragent/autoscaling/workload/scaler_test.go
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && test
+
+package workload
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+var deploymentGVK = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+
+func newScalerForTest(t *testing.T, objs ...runtime.Object) (*scalerImpl, *dynamicfake.FakeDynamicClient) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+
+	dynClient := dynamicfake.NewSimpleDynamicClient(scheme, objs...)
+
+	mapper := apimeta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "apps", Version: "v1"}})
+	mapper.Add(deploymentGVK, apimeta.RESTScopeNamespace)
+
+	return &scalerImpl{
+		restMapper:    mapper,
+		dynamicClient: dynClient,
+	}, dynClient
+}
+
+func newDeploymentWithManagedFields(namespace, name string, managedFields []metav1.ManagedFieldsEntry) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:     namespace,
+			Name:          name,
+			ManagedFields: managedFields,
+		},
+	}
+}
+
+func TestScalerReleaseReplicasOwnership_RemovesClusterAgentEntry(t *testing.T) {
+	otherEntry := metav1.ManagedFieldsEntry{
+		Manager:   "kubectl-edit",
+		Operation: metav1.ManagedFieldsOperationApply,
+	}
+	helmEntry := metav1.ManagedFieldsEntry{
+		Manager:   "helm",
+		Operation: metav1.ManagedFieldsOperationApply,
+	}
+	dcaEntry := metav1.ManagedFieldsEntry{
+		Manager:     datadogClusterAgentFieldManager,
+		Operation:   metav1.ManagedFieldsOperationUpdate,
+		Subresource: "scale",
+	}
+
+	deployment := newDeploymentWithManagedFields("default", "app",
+		[]metav1.ManagedFieldsEntry{otherEntry, dcaEntry, helmEntry})
+
+	sg, dynClient := newScalerForTest(t, deployment)
+
+	require.NoError(t, sg.releaseReplicasOwnership(context.Background(), "default", "app", deploymentGVK))
+
+	got, err := dynClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).
+		Namespace("default").Get(context.Background(), "app", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	managers := []string{}
+	for _, mf := range got.GetManagedFields() {
+		managers = append(managers, mf.Manager)
+	}
+	assert.ElementsMatch(t, []string{"kubectl-edit", "helm"}, managers, "DCA scale entry should be removed; other entries preserved")
+}
+
+func TestScalerReleaseReplicasOwnership_NoEntryIsNoOp(t *testing.T) {
+	// No managedFields entry from the cluster agent — release should be a no-op.
+	deployment := newDeploymentWithManagedFields("default", "app",
+		[]metav1.ManagedFieldsEntry{{Manager: "helm", Operation: metav1.ManagedFieldsOperationApply}})
+
+	sg, dynClient := newScalerForTest(t, deployment)
+
+	// Reset action tracking to ensure we observe only what releaseReplicasOwnership triggers.
+	dynClient.ClearActions()
+	require.NoError(t, sg.releaseReplicasOwnership(context.Background(), "default", "app", deploymentGVK))
+
+	for _, action := range dynClient.Actions() {
+		assert.NotEqual(t, "patch", action.GetVerb(), "no patch should be issued when no DCA entry exists")
+	}
+}
+
+func TestScalerReleaseReplicasOwnership_TargetNotFoundIsNoError(t *testing.T) {
+	// No deployment created; the dynamic client returns NotFound on Get.
+	sg, _ := newScalerForTest(t)
+
+	err := sg.releaseReplicasOwnership(context.Background(), "default", "missing", deploymentGVK)
+	assert.NoError(t, err, "missing target should be treated as already-released")
+}
+
+func TestScalerReleaseReplicasOwnership_IgnoresNonScaleEntries(t *testing.T) {
+	// An entry owned by the cluster agent but NOT on the scale subresource
+	// (e.g. a parent-resource update) must be left untouched. Only the
+	// scale-subresource entry is the one that conflicts with Helm SSA on
+	// `.spec.replicas`.
+	dcaParent := metav1.ManagedFieldsEntry{
+		Manager:   datadogClusterAgentFieldManager,
+		Operation: metav1.ManagedFieldsOperationUpdate,
+	}
+	deployment := newDeploymentWithManagedFields("default", "app",
+		[]metav1.ManagedFieldsEntry{dcaParent})
+
+	sg, dynClient := newScalerForTest(t, deployment)
+
+	require.NoError(t, sg.releaseReplicasOwnership(context.Background(), "default", "app", deploymentGVK))
+
+	got, err := dynClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).
+		Namespace("default").Get(context.Background(), "app", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, got.GetManagedFields(), 1, "non-scale DCA entry must be preserved")
+	assert.Equal(t, datadogClusterAgentFieldManager, got.GetManagedFields()[0].Manager)
+	assert.Empty(t, got.GetManagedFields()[0].Subresource)
+}

--- a/pkg/clusteragent/autoscaling/workload/scaler_test.go
+++ b/pkg/clusteragent/autoscaling/workload/scaler_test.go
@@ -10,11 +10,14 @@ package workload
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -109,6 +112,25 @@ func TestScalerReleaseReplicasOwnership_TargetNotFoundIsNoError(t *testing.T) {
 
 	err := sg.releaseReplicasOwnership(context.Background(), "default", "missing", deploymentGVK)
 	assert.NoError(t, err, "missing target should be treated as already-released")
+}
+
+func TestScalerReleaseReplicasOwnership_ForbiddenSurfacesEvenWithMultipleMappings(t *testing.T) {
+	// RESTMapper iteration was historically prone to silently returning nil
+	// when a later mapping returned NotFound after an earlier mapping had
+	// returned a real error (Forbidden). The fix collapses to a single
+	// (preferred) mapping. Assert that a Forbidden on the first mapping
+	// propagates rather than being swallowed.
+	sg, dynClient := newScalerForTest(t)
+	dynClient.PrependReactor("get", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewForbidden(
+			schema.GroupResource{Group: "apps", Resource: "deployments"},
+			"app", fmt.Errorf("user cannot patch deployments.apps"))
+	})
+
+	err := sg.releaseReplicasOwnership(context.Background(), "default", "app", deploymentGVK)
+	assert.Error(t, err, "Forbidden must propagate so the caller can requeue / surface it")
+	assert.True(t, k8serrors.IsForbidden(err) || strings.Contains(err.Error(), "forbidden"),
+		"underlying Forbidden must be preserved (errors.Is or string contains)")
 }
 
 func TestScalerReleaseReplicasOwnership_PatchIsTestGuarded(t *testing.T) {

--- a/pkg/clusteragent/autoscaling/workload/scaler_test.go
+++ b/pkg/clusteragent/autoscaling/workload/scaler_test.go
@@ -10,7 +10,7 @@ package workload
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"strings"
 	"testing"
 
@@ -124,7 +124,7 @@ func TestScalerReleaseReplicasOwnership_ForbiddenSurfacesEvenWithMultipleMapping
 	dynClient.PrependReactor("get", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, k8serrors.NewForbidden(
 			schema.GroupResource{Group: "apps", Resource: "deployments"},
-			"app", fmt.Errorf("user cannot patch deployments.apps"))
+			"app", errors.New("user cannot patch deployments.apps"))
 	})
 
 	err := sg.releaseReplicasOwnership(context.Background(), "default", "app", deploymentGVK)

--- a/pkg/clusteragent/autoscaling/workload/scaler_test.go
+++ b/pkg/clusteragent/autoscaling/workload/scaler_test.go
@@ -9,6 +9,7 @@ package workload
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,9 +17,11 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 var deploymentGVK = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
@@ -106,6 +109,99 @@ func TestScalerReleaseReplicasOwnership_TargetNotFoundIsNoError(t *testing.T) {
 
 	err := sg.releaseReplicasOwnership(context.Background(), "default", "missing", deploymentGVK)
 	assert.NoError(t, err, "missing target should be treated as already-released")
+}
+
+func TestScalerReleaseReplicasOwnership_PatchIsTestGuarded(t *testing.T) {
+	// Each remove op must be preceded by `test` ops asserting the entry at
+	// that index still has manager=datadog-cluster-agent and
+	// subresource=scale. This is the only thing that keeps a concurrent
+	// writer (Helm SSA, kubectl, another controller) shifting managedFields
+	// between our GET and PATCH from causing us to drop a foreign entry by
+	// stale index. Verify the emitted patch body has the expected shape.
+	dcaEntry := metav1.ManagedFieldsEntry{
+		Manager:     datadogClusterAgentFieldManager,
+		Operation:   metav1.ManagedFieldsOperationUpdate,
+		Subresource: "scale",
+	}
+	helmEntry := metav1.ManagedFieldsEntry{
+		Manager:   "helm",
+		Operation: metav1.ManagedFieldsOperationApply,
+	}
+	deployment := newDeploymentWithManagedFields("default", "app",
+		[]metav1.ManagedFieldsEntry{helmEntry, dcaEntry})
+
+	sg, dynClient := newScalerForTest(t, deployment)
+	dynClient.ClearActions()
+	require.NoError(t, sg.releaseReplicasOwnership(context.Background(), "default", "app", deploymentGVK))
+
+	var patchBody []byte
+	for _, action := range dynClient.Actions() {
+		if action.GetVerb() != "patch" {
+			continue
+		}
+		patchAction, ok := action.(k8stesting.PatchAction)
+		require.True(t, ok, "patch action should implement PatchAction")
+		patchBody = patchAction.GetPatch()
+	}
+	require.NotNil(t, patchBody, "expected one patch action")
+
+	var ops []map[string]any
+	require.NoError(t, json.Unmarshal(patchBody, &ops))
+	require.Len(t, ops, 3, "expected 3 ops (test manager, test subresource, remove) for the single DCA entry")
+	assert.Equal(t, "test", ops[0]["op"])
+	assert.Equal(t, "/metadata/managedFields/1/manager", ops[0]["path"])
+	assert.Equal(t, datadogClusterAgentFieldManager, ops[0]["value"])
+	assert.Equal(t, "test", ops[1]["op"])
+	assert.Equal(t, "/metadata/managedFields/1/subresource", ops[1]["path"])
+	assert.Equal(t, "scale", ops[1]["value"])
+	assert.Equal(t, "remove", ops[2]["op"])
+	assert.Equal(t, "/metadata/managedFields/1", ops[2]["path"])
+}
+
+func TestScalerReleaseReplicasOwnership_TestOpFailureRejectsPatch(t *testing.T) {
+	// Simulate the race the test ops guard against: our GET sees the DCA
+	// entry at index 1, but the underlying store has been mutated so index
+	// 1 now points at a different manager. The `test` op against that
+	// index must fail and the whole patch must be rejected atomically —
+	// returning an error rather than silently dropping a foreign entry by
+	// stale index. The next reconcile retries with a fresh snapshot.
+	dcaEntry := metav1.ManagedFieldsEntry{
+		Manager:     datadogClusterAgentFieldManager,
+		Operation:   metav1.ManagedFieldsOperationUpdate,
+		Subresource: "scale",
+	}
+	helmEntry := metav1.ManagedFieldsEntry{
+		Manager:   "helm",
+		Operation: metav1.ManagedFieldsOperationApply,
+	}
+	other := metav1.ManagedFieldsEntry{
+		Manager:   "kubectl-edit",
+		Operation: metav1.ManagedFieldsOperationUpdate,
+	}
+
+	// What our GET will return: [helm, dca-scale] (DCA at index 1).
+	getView := newDeploymentWithManagedFields("default", "app",
+		[]metav1.ManagedFieldsEntry{helmEntry, dcaEntry})
+	// What the underlying store actually holds: [kubectl-edit, helm, dca-scale]
+	// (a concurrent writer inserted at the front; DCA is now at index 2,
+	// helm is at index 1).
+	storedView := newDeploymentWithManagedFields("default", "app",
+		[]metav1.ManagedFieldsEntry{other, helmEntry, dcaEntry})
+
+	sg, dynClient := newScalerForTest(t, storedView)
+	// Override Get to return the stale snapshot. PATCH still runs against
+	// the underlying store, so the test op asserting manager at index 1
+	// equals "datadog-cluster-agent" will fail (it's now "helm").
+	dynClient.PrependReactor("get", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(getView)
+		if err != nil {
+			return true, nil, err
+		}
+		return true, &unstructured.Unstructured{Object: u}, nil
+	})
+
+	err := sg.releaseReplicasOwnership(context.Background(), "default", "app", deploymentGVK)
+	assert.Error(t, err, "patch must be rejected when managedFields shifted between GET and PATCH")
 }
 
 func TestScalerReleaseReplicasOwnership_IgnoresNonScaleEntries(t *testing.T) {

--- a/releasenotes/notes/fix-dpa-release-replicas-ownership-0aeac59d5f27d543.yaml
+++ b/releasenotes/notes/fix-dpa-release-replicas-ownership-0aeac59d5f27d543.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Fix a bug in the workload autoscaling controller where the
+    ``datadog-cluster-agent`` field-manager entry for ``.spec.replicas`` on
+    the target workload (recorded on the ``scale`` subresource) was never
+    cleaned up after horizontal scaling was disabled or the
+    ``DatadogPodAutoscaler`` was deleted. The stale entry caused
+    server-side-apply writers such as Helm to fail with
+    ``Apply failed with 1 conflict: conflict with "datadog-cluster-agent"``
+    unless the user passed ``--force-conflicts`` indefinitely. The cluster
+    agent now best-effort releases ``.spec.replicas`` ownership on both
+    transitions.

--- a/releasenotes/notes/fix-dpa-release-replicas-ownership-0aeac59d5f27d543.yaml
+++ b/releasenotes/notes/fix-dpa-release-replicas-ownership-0aeac59d5f27d543.yaml
@@ -1,13 +1,27 @@
 ---
+upgrade:
+  - |
+    The cluster agent now requires the ``patch`` verb on the workload
+    resources it targets via ``DatadogPodAutoscaler`` (``apps/deployments``,
+    ``apps/statefulsets``, ``apps/replicasets``, and core
+    ``replicationcontrollers``). This is required for the cluster agent to
+    release its stale ``.spec.replicas`` field-manager entry when a DPA
+    stops scaling a workload (see the ``fixes`` entry below). Users
+    deploying the cluster agent via the in-tree
+    ``Dockerfiles/manifests/.../cluster-agent-rbac.yaml`` manifests get the
+    new permission automatically. Users deploying via the official Helm
+    chart or Datadog Operator must wait for the corresponding bumps in
+    those repositories or grant the verb manually.
 fixes:
   - |
     Fix a bug in the workload autoscaling controller where the
     ``datadog-cluster-agent`` field-manager entry for ``.spec.replicas`` on
     the target workload (recorded on the ``scale`` subresource) was never
-    cleaned up after horizontal scaling was disabled or the
-    ``DatadogPodAutoscaler`` was deleted. The stale entry caused
-    server-side-apply writers such as Helm to fail with
+    cleaned up after horizontal scaling was disabled, the
+    ``DatadogPodAutoscaler`` was deleted (remote-owned, profile-managed,
+    or local-owned), causing server-side-apply writers such as Helm to
+    fail with
     ``Apply failed with 1 conflict: conflict with "datadog-cluster-agent"``
     unless the user passed ``--force-conflicts`` indefinitely. The cluster
-    agent now best-effort releases ``.spec.replicas`` ownership on both
-    transitions.
+    agent now best-effort releases ``.spec.replicas`` ownership on all of
+    those transitions.


### PR DESCRIPTION
## Summary

Resolves a stale-field-manager leak in the workload autoscaler: when the cluster agent scales a target workload via the `scale` subresource, Kubernetes records a `datadog-cluster-agent` managed-fields entry on `.spec.replicas`. The cluster agent never released that entry, so once the DPA stopped scaling (mode switch to vertical-only, or DPA deletion) the stale entry remained forever — causing server-side-apply writers such as Helm to fail with:

```
error: Apply failed with 1 conflict: conflict with "datadog-cluster-agent" with subresource "scale" using apps/v1: .spec.replicas
```

…unless the user passed `--force-conflicts` indefinitely. Plain `helm upgrade --install` (client-side apply) was not affected.

## Changes

- **`scaler.go`** — new `releaseReplicasOwnership(ctx, ns, name, gvk)` method: GETs the parent resource via the dynamic client, finds managed-fields entries where `Manager == "datadog-cluster-agent"` AND `Subresource == "scale"`, and issues a JSON patch to drop them. Idempotent (no-op when no such entry exists). Treats target-NotFound as already-released.
- **`controller_horizontal.go`** — on the `!IsHorizontalScalingEnabled()` branch, call the release before `ClearHorizontalState()`. Gated on `HorizontalLastActions` being non-empty so we don't issue a GET on every reconcile while horizontal stays disabled (clearing horizontal state nils actions, so subsequent ticks skip).
- **`controller.go`** — call the release in both `Deleted()` branches (remote-owned and profile-managed) before `deletePodAutoscaler`.
- Cleanup is **best-effort**: errors are logged (`Warnf`) but never propagated. Deletion and mode-switch logic are never blocked.

## Non-goals / what this PR does NOT do

- Does not switch DCA scale writes from `Scales().Update()` to server-side apply. The release path uses a JSON patch on `metadata.managedFields` directly, keeping blast radius minimal. Migrating to SSA is a separate, larger discussion.
- Does not strip managed-fields entries from non-scale subresources, or from any manager other than `datadog-cluster-agent`.

## Test plan

- [x] New unit tests in `scaler_test.go`:
  - removes the DCA scale entry, preserves other managers
  - no-op when no DCA entry exists (no PATCH issued)
  - target-NotFound returns nil
  - DCA entry without `Subresource: "scale"` is left untouched
- [x] New unit test in `controller_horizontal_test.go`: disabling horizontal scaling with prior actions triggers exactly one release; without prior actions, no release.
- [x] Existing test `TestLeaderCreateDeleteRemote` extended to assert release is called before `deletePodAutoscaler`.
- [x] `go test -tags "kubeapiserver test" ./pkg/clusteragent/autoscaling/workload/...` — all pass.
- [x] `gofmt`, `go vet` clean.

## Reviewer notes

- The field-manager name `"datadog-cluster-agent"` is derived from the binary's user-agent, which matches the manager string seen in customer-reported managedFields entries. Codified as a `const` in `scaler.go`.
- For the disable path, I considered switching scale writes to SSA so that ownership is releasable via an empty Apply, but that touches every scale event for every DPA customer and felt out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)