### PR TITLE
add ubuntu 26.04

### DIFF
--- a/bazel/rules/ebpf/ebpf.bzl
+++ b/bazel/rules/ebpf/ebpf.bzl
@@ -22,6 +22,7 @@ _COMMON_FLAGS = [
     "-Wno-unused-value",
     "-Wno-pointer-sign",
     "-Wno-compare-distinct-pointer-types",
+    "-Wno-microsoft-anon-tag",
     "-Wunused",
     "-Wall",
     "-Werror",
@@ -32,6 +33,7 @@ _COMMON_FLAGS = [
     "-fno-asynchronous-unwind-tables",
     "-fno-jump-tables",
     "-fmerge-all-constants",
+    "-fms-extensions",
 ]
 
 _PREBUILT_FLAGS = [

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -38,6 +38,7 @@ var defaultFlags = []string{
 	"-Wno-unused-value",
 	"-Wno-pointer-sign",
 	"-Wno-compare-distinct-pointer-types",
+	"-Wno-microsoft-anon-tag",
 	"-Wunused",
 	"-Wall",
 	"-Werror",
@@ -48,6 +49,7 @@ var defaultFlags = []string{
 	"-fno-unwind-tables",
 	"-fno-asynchronous-unwind-tables",
 	"-fno-jump-tables",
+	"-fms-extensions",
 	"-nostdinc",
 }
 

--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -295,6 +295,17 @@
       "alt_version_names": [
         "questing"
       ]
+    },
+    "ubuntu_26.04": {
+      "image": "ubuntu-26.04-x86_64.qcow2.xz",
+      "image_version": "bryce.kahle/ubuntu-26-04",
+      "os_name": "Ubuntu",
+      "os_id": "ubuntu",
+      "kernel": "7.0.0-15-generic",
+      "os_version": "26.04",
+      "alt_version_names": [
+        "resolute"
+      ]
     }
   },
   "arm64": {
@@ -553,6 +564,17 @@
       "os_version": "25.10",
       "alt_version_names": [
         "questing"
+      ]
+    },
+    "ubuntu_26.04": {
+      "image": "ubuntu-26.04-arm64.qcow2.xz",
+      "image_version": "bryce.kahle/ubuntu-26-04",
+      "os_name": "Ubuntu",
+      "os_id": "ubuntu",
+      "kernel": "7.0.0-15-generic",
+      "os_version": "26.04",
+      "alt_version_names": [
+        "resolute"
       ]
     }
   }

--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -298,7 +298,7 @@
     },
     "ubuntu_26.04": {
       "image": "ubuntu-26.04-x86_64.qcow2.xz",
-      "image_version": "bryce.kahle/ubuntu-26-04",
+      "image_version": "20260610_1c4a8911",
       "os_name": "Ubuntu",
       "os_id": "ubuntu",
       "kernel": "7.0.0-15-generic",
@@ -568,7 +568,7 @@
     },
     "ubuntu_26.04": {
       "image": "ubuntu-26.04-arm64.qcow2.xz",
-      "image_version": "bryce.kahle/ubuntu-26-04",
+      "image_version": "20260610_1c4a8911",
       "os_name": "Ubuntu",
       "os_id": "ubuntu",
       "kernel": "7.0.0-15-generic",


### PR DESCRIPTION
### What does this PR do?

Adds Ubuntu 26.04 to available KMT images

### Motivation

Allow teams to debug issues before adding to CI

### Describe how you validated your changes

### Additional Notes

- Compiler flags are necessary to build eBPF programs on 7.0 kernel.