### PR TITLE
Fix `bazel run *install*` for non-admin Windows users

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -68,6 +68,7 @@ common:windows --repo_env=SYSTEMDRIVE # needed by vswhere to locate the VS insta
 common:windows --repo_env=SYSTEMROOT # used by COM to load system DLLs, needed by vswhere
 common:windows --repo_env=USERPROFILE # used by MSYS2 bash to emulate HOME, needed by git to fetch repositories
 common:windows --repo_env=VSTUDIO_ROOT # visual_studio(path_variable) in MODULE.bazel
+common:windows --run_env=__COMPAT_LAYER=RunAsInvoker # install*.exe may otherwise fail claiming unneeded admin elevation
 common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
 
 # Force the x86_64-pc-windows-gnu Rust toolchain (compact name for rust_windows_gnu_x86_64)


### PR DESCRIPTION
### What does this PR do?
Add one Windows-only line to `.bazelrc` so `bazel run` starts its target through the "run as invoker" application compatibility shim:
```
common:windows --run_env=__COMPAT_LAYER=RunAsInvoker
```

This keeps `bazel run` of any target whose launcher executable name contains an installer keyword (for example
`//pkg/config/schema:install_compressed`) from failing on Windows with:
> The requested operation requires elevation. (error: 740)

### Motivation
Initially [reported](https://dd.slack.com/archives/C08SK4B0FK8/p1780510248023219) by @clarkb7:
```
PS C:\dd\datadog-agent-main> dda inv schema.compress --output-dir .\tmpschemadest\
[...]
FATAL: ExecuteProgram(C:\users\user\_bazel_user\g5crn47h\execroot\_main\bazel-out\x64_windows-fastbuild\bin\pkg\config\schema\install_compressed.exe) failed: ERROR: src/main/native/windows/process.cc(189): CreateProcessW("C:\users\user\_bazel_user\g5crn47h\execroot\_main\bazel-out\x64_windows-fastbuild\bin\pkg\config\schema\install_compressed.exe"  --destdir=C:\dd\datadog-agent-main\tmpschemadest): The requested operation requires elevation.
 (error: 740)
```
> because the executable name contains `install` Windows assumes that it's a legacy installer that should run elevated, so it forces a UAC request
> 😭😮

According to [Windows User Account Control](https://www.advancedinstaller.com/user-guide/vista-uac.html#), the cause is indeed Windows' "installer detection": before creating a process, Windows **guesses** whether an unmanifested executable is a "legacy installer" and, if so, demands elevation:
> [!WARNING]
> Windows Vista or above _heuristically detects_ installation, updater, uninstallation programs and requests administrator credentials or administrator approval in order to run with access privileges. This heuristic detection checks such attributes like: filenames, keywords, versioning resources, etc. (e.g. keywords like: "install", "setup", "update", etc.).

Confirmed on my VM: `xinstallx` and `my_update` (also `patch`... and probably others) all trip it, while a keyword-free name does not.

The heuristic fires only when the executable carries no execution level in its manifest:
> [!WARNING]
> Note that this detection heuristic applies only if you do not add `requested execution level` information to the application's manifest. Beware, if you do not set an execution level information your application might be easily mistaken as an application that needs administrator privileges.

The launcher here is Bazel's prebuilt, manifest-less stub (`@bazel_tools//tools/launcher`), reused for every `py_binary`, which `rules_pkg` names  after the `pkg_install` target, so the launcher inherits the "install" keyword.
We cannot embed a manifest into it the way a `go_binary` does (a `go_binary` is linked, so it accepts a `.syso`).

The least intrusive fix proposed here simply consists in setting the `__COMPAT_LAYER` environment variable on the launched process: `RunAsInvoker` makes the application compatibility shim run the target with the caller's token instead of requesting elevation as per:
- https://dangough.github.io/packageology/app-v/supressing-uac-prompts-in-appv5-with-compat-layer/
- https://www.nirsoft.net/articles/run_application_without_elevation.html
- etc.

The variable is inherited by the launcher process Bazel creates, so the shim suppresses the spurious+useless elevation attempt.

### Describe how you validated your changes
On a Windows 11 VM, in a standard (medium integrity) session, running `bazel run //pkg/config/schema:install_compressed -- --destdir=...`:
- before:
```
INFO: Running command line: C:/cache/bazel/jgkidtko/execroot/_main/bazel-out/x64_windows-fastbuild/bin/pkg/config/schema/install_compressed.exe <args omitted>
FATAL: ExecuteProgram(C:\cache\bazel\jgkidtko\execroot\_main\bazel-out\x64_windows-fastbuild\bin\pkg\config\schema\install_compressed.exe) failed: ERROR: src/main/native/windows/process.cc(189):
CreateProcessW("C:\cache\bazel\jgkidtko\execroot\_main\bazel-out\x64_windows-fastbuild\bin\pkg\config\schema\install_compressed.exe"  --destdir=C:\temp\schemaout): The requested operation requires elevation.
 (error: 740)
```
- after:
```
INFO: Running command line: C:/cache/bazel/lqvbbwxe/execroot/_main/bazel-out/x64_windows-fastbuild/bin/pkg/config/schema/install_compressed.exe <args omitted>
INFO: Installing to C:\temp\schemaout
```

### Additional Notes
Other solutions considered:
- rename the target to drop the keyword (and alias the old name) works, but per target only: **aliases would proliferate** - and the `install` name is meaningful here,
- set `__COMPAT_LAYER` only around the `bazel run` in `tasks/schema/generate.py` would also imply a **proliferation** of such cases and cover only `dda inv` paths, not direct `bazel run`s,
- mangle the launcher name inside the `pkg_install` macro, a single transparent fix, but forks `rules_pkg` with a carried patch to re-base on every bump, and an upstream PR would feel _adhoc_ with **weird generated names** - not to mention we don't have the exhaustive list of substrings that would have to be mangled that way,
- embed an `asInvoker` manifest in the executable: the correct, name-independent fix, trivial for a `go_binary` via a `.syso`, but the `py_binary` launcher is Bazel's prebuilt stub with no link step, so it would need **fragile post-link PE resource surgery**,
- add the manifest to Bazel's launcher stub upstream, the **proper, universal fix**, but it lives in `@bazel_tools` (not overridable) so we'll need an upstream bazelbuild/bazel change (~I'll try later~ bazelbuild/bazel#29822).

The chosen `.bazelrc` line is the only option that for now fixes each and every `install`/`setup`/`update`/etc.-named `bazel run` target on Windows from a single place, with no renames, aliases, nor forks.