### PR TITLE
Fix local scaling around pod warmup

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 	corev1 "k8s.io/api/core/v1"
@@ -275,13 +276,28 @@ func (p minimalPodParser) Parse(obj interface{}) workloadmeta.Entity {
 	}
 
 	var ready bool
+	var readyTimestamp *time.Time
 	for _, condition := range pod.Status.Conditions {
 		if condition.Type == corev1.PodReady {
 			if condition.Status == corev1.ConditionTrue {
 				ready = true
+				// Leave readyTimestamp nil when the transition time is unknown (omitted/zero),
+				// so the warmup gate treats the readiness time as unknown rather than year 1.
+				if !condition.LastTransitionTime.IsZero() {
+					t := condition.LastTransitionTime.Time
+					readyTimestamp = &t
+				}
 			}
 			break
 		}
+	}
+
+	// DeletionTimestamp is set once the pod is terminating; cluster-agent workload autoscaling
+	// uses it to exclude terminating pods from its replica calculation (matching the HPA).
+	var deletionTimestamp *time.Time
+	if pod.DeletionTimestamp != nil {
+		t := pod.DeletionTimestamp.Time
+		deletionTimestamp = &t
 	}
 
 	var pvcNames []string
@@ -353,6 +369,8 @@ func (p minimalPodParser) Parse(obj interface{}) workloadmeta.Entity {
 		GPUVendorList:              gpuVendorList,
 		Containers:                 containersList,
 		CreationTimestamp:          pod.CreationTimestamp.Time,
+		ReadyTimestamp:             readyTimestamp,
+		DeletionTimestamp:          deletionTimestamp,
 		NodeName:                   pod.Spec.NodeName,
 	}
 }

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod.go
@@ -9,6 +9,7 @@ package kubernetesresourceparsers
 
 import (
 	"regexp"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -61,13 +62,28 @@ func (p podParser) Parse(obj interface{}) workloadmeta.Entity {
 	}
 
 	var ready bool
+	var readyTimestamp *time.Time
 	for _, condition := range pod.Status.Conditions {
 		if condition.Type == corev1.PodReady {
 			if condition.Status == corev1.ConditionTrue {
 				ready = true
+				// Leave readyTimestamp nil when the transition time is unknown (omitted/zero),
+				// so the warmup gate treats the readiness time as unknown rather than year 1.
+				if !condition.LastTransitionTime.IsZero() {
+					t := condition.LastTransitionTime.Time
+					readyTimestamp = &t
+				}
 			}
 			break
 		}
+	}
+
+	// DeletionTimestamp is set once the pod is terminating; cluster-agent workload autoscaling
+	// uses it to exclude terminating pods from its replica calculation (matching the HPA).
+	var deletionTimestamp *time.Time
+	if pod.DeletionTimestamp != nil {
+		t := pod.DeletionTimestamp.Time
+		deletionTimestamp = &t
 	}
 
 	var pvcNames []string
@@ -139,6 +155,8 @@ func (p podParser) Parse(obj interface{}) workloadmeta.Entity {
 		GPUVendorList:              gpuVendorList,
 		Containers:                 containersList,
 		CreationTimestamp:          pod.CreationTimestamp.Time,
+		ReadyTimestamp:             readyTimestamp,
+		DeletionTimestamp:          deletionTimestamp,
 		NodeName:                   pod.Spec.NodeName,
 	}
 }

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -832,12 +832,13 @@ type KubernetesPod struct {
 	FinishedAt                 time.Time           `proto:"ignore"`
 	SecurityContext            *PodSecurityContext `proto:"ignore"`
 	Resources                  ContainerResources  `proto:"ignore"`
+	DeletionTimestamp          *time.Time          `proto:"ignore"`
+	ReadyTimestamp             *time.Time          `proto:"ignore"`
 
 	// The following fields are only needed for the kubelet check or KSM check
 	// when configured to emit pod metrics from the node agent. That means only
 	// the node agent needs them, so for now they're not added to the protobufs.
 	CreationTimestamp          time.Time                   `proto:"ignore"`
-	DeletionTimestamp          *time.Time                  `proto:"ignore"`
 	StartTime                  *time.Time                  `proto:"ignore"`
 	NodeName                   string                      `proto:"ignore"`
 	HostIP                     string                      `proto:"ignore"`

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
@@ -118,8 +118,9 @@ func (hr *horizontalController) performScaling(ctx context.Context, podAutoscale
 		return autoscaling.NoRequeue, nil
 	}
 
-	scale.Spec.Replicas = horizontalAction.ToReplicas
-	_, err = hr.scaler.update(ctx, gr, scale)
+	newScale := scale.DeepCopy()
+	newScale.Spec.Replicas = horizontalAction.ToReplicas
+	_, err = hr.scaler.update(ctx, gr, newScale)
 	if err != nil {
 		err = autoscaling.NewConditionError(autoscaling.ConditionReasonScaleFailed, fmt.Errorf("failed to scale target: %s/%s to %d replicas, err: %w", scale.Namespace, scale.Name, horizontalAction.ToReplicas, err))
 		hr.eventRecorder.Event(podAutoscaler, corev1.EventTypeWarning, model.FailedScaleEventReason, err.Error())

--- a/pkg/clusteragent/autoscaling/workload/local/recommender_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommender_test.go
@@ -17,6 +17,7 @@ import (
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/loadstore"
@@ -30,7 +31,16 @@ func TestProcessScaleUp(t *testing.T) {
 
 	// setup podwatcher
 	pw := workload.NewPodWatcher(nil, nil)
-	pw.HandleEvent(newFakeWLMPodEvent("default", "test-deployment", "pod1", []string{"container-name1", "container-name2"}))
+	pw.HandleEvent(workloadmeta.Event{
+		Type: workloadmeta.EventTypeSet,
+		Entity: newFakePod(fakePodConfig{
+			podName:        "pod1",
+			containerNames: []string{"container-name1", "container-name2"},
+			deployment:     "test-deployment",
+			cpuRequest:     25,
+			readyTimestamp: time.Now().Add(-time.Hour),
+		}),
+	})
 
 	// setup store
 	store := autoscaling.NewStore[model.PodAutoscalerInternal]()
@@ -79,9 +89,36 @@ func TestProcessScaleDown(t *testing.T) {
 
 	// setup podwatcher
 	pw := workload.NewPodWatcher(nil, nil)
-	pw.HandleEvent(newFakeWLMPodEvent("default", "test-deployment", "pod1", []string{"container-name1", "container-name2"}))
-	pw.HandleEvent(newFakeWLMPodEvent("default", "test-deployment", "pod2", []string{"container-name1"}))
-	pw.HandleEvent(newFakeWLMPodEvent("default", "test-deployment", "pod3", []string{"container-name1"}))
+	pw.HandleEvent(workloadmeta.Event{
+		Type: workloadmeta.EventTypeSet,
+		Entity: newFakePod(fakePodConfig{
+			podName:        "pod1",
+			containerNames: []string{"container-name1", "container-name2"},
+			deployment:     "test-deployment",
+			cpuRequest:     25,
+			readyTimestamp: time.Now().Add(-time.Hour),
+		}),
+	})
+	pw.HandleEvent(workloadmeta.Event{
+		Type: workloadmeta.EventTypeSet,
+		Entity: newFakePod(fakePodConfig{
+			podName:        "pod2",
+			containerNames: []string{"container-name1"},
+			deployment:     "test-deployment",
+			cpuRequest:     25,
+			readyTimestamp: time.Now().Add(-time.Hour),
+		}),
+	})
+	pw.HandleEvent(workloadmeta.Event{
+		Type: workloadmeta.EventTypeSet,
+		Entity: newFakePod(fakePodConfig{
+			podName:        "pod3",
+			containerNames: []string{"container-name1"},
+			deployment:     "test-deployment",
+			cpuRequest:     25,
+			readyTimestamp: time.Now().Add(-time.Hour),
+		}),
+	})
 
 	// setup store
 	store := autoscaling.NewStore[model.PodAutoscalerInternal]()

--- a/pkg/clusteragent/autoscaling/workload/local/recommender_testutils.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommender_testutils.go
@@ -9,8 +9,10 @@ package local
 
 import (
 	"sync"
+	"time"
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
@@ -27,15 +29,51 @@ func resetWorkloadMetricStore() {
 	loadstore.WorkloadMetricStoreOnce = sync.Once{}
 }
 
-func newFakeWLMPodEvent(ns, deployment, podName string, containerNames []string) workloadmeta.Event {
-	containers := []workloadmeta.OrchestratorContainer{}
-	for _, c := range containerNames {
+// newFakePod builds a single pod with the given lifecycle/readiness state. CPU and memory
+// requests are set on every container so it can be used as an autoscaling target.
+type fakePodConfig struct {
+	namespace      string
+	deployment     string
+	podName        string
+	containerNames []string
+	cpuRequest     float64
+	phase          string
+	ready          bool
+	readyTimestamp time.Time
+}
+
+func newFakePod(config fakePodConfig) *workloadmeta.KubernetesPod {
+	if config.namespace == "" {
+		config.namespace = "default"
+	}
+	if config.podName == "" {
+		config.podName = "pod"
+	}
+	if len(config.containerNames) == 0 {
+		config.containerNames = []string{"c"}
+	}
+	if config.cpuRequest == 0 {
+		config.cpuRequest = 100.0 // 1 core
+	}
+	if config.phase == "" {
+		config.phase = string(corev1.PodRunning)
+	}
+
+	// A zero readyTimestamp means "readiness time unknown" -> nil pointer.
+	var readyTS *time.Time
+	if !config.readyTimestamp.IsZero() {
+		readyTS = &config.readyTimestamp
+		config.ready = true
+	}
+
+	containers := make([]workloadmeta.OrchestratorContainer, 0, len(config.containerNames))
+	for _, c := range config.containerNames {
 		containers = append(containers, workloadmeta.OrchestratorContainer{
 			ID:   c + "-id",
 			Name: c,
 			Resources: workloadmeta.ContainerResources{
-				CPURequest:    func(f float64) *float64 { return &f }(25), // 250m
-				MemoryRequest: func(f uint64) *uint64 { return &f }(2048),
+				CPURequest:    pointer.Ptr(config.cpuRequest),
+				MemoryRequest: pointer.Ptr[uint64](2048),
 			},
 		})
 	}
@@ -43,19 +81,36 @@ func newFakeWLMPodEvent(ns, deployment, podName string, containerNames []string)
 	pod := &workloadmeta.KubernetesPod{
 		EntityID: workloadmeta.EntityID{
 			Kind: workloadmeta.KindKubernetesPod,
-			ID:   podName,
+			ID:   config.podName,
 		},
 		EntityMeta: workloadmeta.EntityMeta{
-			Name:      podName,
-			Namespace: ns,
+			Name:      config.podName,
+			Namespace: config.namespace,
 		},
-		Owners:     []workloadmeta.KubernetesPodOwner{{Kind: kubernetes.ReplicaSetKind, Name: deployment + "-766dbb7846"}},
-		Containers: containers,
+		Containers:     containers,
+		Phase:          config.phase,
+		Ready:          config.ready,
+		ReadyTimestamp: readyTS,
 	}
+	if config.deployment != "" {
+		pod.Owners = []workloadmeta.KubernetesPodOwner{{Kind: kubernetes.ReplicaSetKind, Name: config.deployment + "-766dbb7846"}}
+	}
+	return pod
+}
 
-	return workloadmeta.Event{
-		Type:   workloadmeta.EventTypeSet,
-		Entity: pod,
+// newCPUUsageResult builds a loadstore PodResult with two CPU usage data points at
+// currentTime-15s and currentTime-30s that yield the requested utilization ratio against
+// a 1-core (1e9 nanocores) request.
+func newCPUUsageResult(podName, containerName string, utilization float64, currentTime time.Time) loadstore.PodResult {
+	usage := utilization * 1e9 // 1 core request == 1e9 nanocores
+	return loadstore.PodResult{
+		PodName: podName,
+		ContainerValues: map[string][]loadstore.EntityValue{
+			containerName: {
+				*newEntityValue(currentTime.Unix()-15, usage),
+				*newEntityValue(currentTime.Unix()-30, usage),
+			},
+		},
 	}
 }
 

--- a/pkg/clusteragent/autoscaling/workload/local/replica_calculator.go
+++ b/pkg/clusteragent/autoscaling/workload/local/replica_calculator.go
@@ -41,9 +41,10 @@ type replicaCalculator struct {
 type utilizationResult struct {
 	// averageUtilization is computed over measured pods only.
 	averageUtilization float64
-	podToUtilization   map[string]float64
-	// missingPods are measurable pods without usable metrics; recommend reserves one slot each.
-	missingPods             []string
+	// measuredPods is the number of pods with usable metrics; it is the average's denominator.
+	measuredPods int
+	// missingPods is the count of measurable pods without usable metrics; recommend reserves one slot each.
+	missingPods             int
 	recommendationTimestamp time.Time
 }
 
@@ -140,9 +141,9 @@ func recommend(currentTime time.Time, recSettings resourceRecommenderSettings, p
 		return 0, utilizationResult{}, err
 	}
 
-	measuredCount := float64(len(utilizationRes.podToUtilization))
+	measuredCount := float64(utilizationRes.measuredPods)
 	recommendedReplicas := calculateReplicas(recSettings, measuredCount, utilizationRes.averageUtilization)
-	recommendedReplicas += int32(len(utilizationRes.missingPods))
+	recommendedReplicas += int32(utilizationRes.missingPods)
 
 	return recommendedReplicas, utilizationRes, nil
 }
@@ -156,9 +157,9 @@ func calculateUtilization(recSettings resourceRecommenderSettings, pods []*workl
 		return utilizationResult{}, errors.New("Issue fetching metrics data")
 	}
 
-	podUtilization := make(map[string]float64)
+	measuredPods := 0
 	totalMeasuredUtilization := 0.0
-	missingPods := []string{}
+	missingPods := 0
 	lastValidTimestamp := time.Time{}
 
 	for _, pod := range pods {
@@ -169,11 +170,11 @@ func calculateUtilization(recSettings resourceRecommenderSettings, pods []*workl
 		minValidTime := pod.ReadyTimestamp.Add(readinessWarmupWindow)
 		utilization, lastTimestamp, ok := calculatePodUtilization(recSettings, pod, queryResult, currentTime, minValidTime)
 		if !ok {
-			missingPods = append(missingPods, pod.Name)
+			missingPods++
 			continue
 		}
 
-		podUtilization[pod.Name] = utilization
+		measuredPods++
 		// Keep the average deterministic by accumulating in pod order.
 		totalMeasuredUtilization += utilization
 		if lastTimestamp.After(lastValidTimestamp) {
@@ -181,13 +182,13 @@ func calculateUtilization(recSettings resourceRecommenderSettings, pods []*workl
 		}
 	}
 
-	if len(podUtilization) == 0 {
+	if measuredPods == 0 {
 		return utilizationResult{}, errors.New("Issue calculating pod utilization")
 	}
 
 	return utilizationResult{
-		averageUtilization:      totalMeasuredUtilization / float64(len(podUtilization)),
-		podToUtilization:        podUtilization,
+		averageUtilization:      totalMeasuredUtilization / float64(measuredPods),
+		measuredPods:            measuredPods,
 		missingPods:             missingPods,
 		recommendationTimestamp: lastValidTimestamp,
 	}, nil
@@ -272,7 +273,8 @@ func processAverageContainerMetricValue(series []loadstore.EntityValue, currentT
 
 		ts := convertTimestampToTime(entity.Timestamp)
 		// Keep samples exactly at the warmup boundary, matching HPA's strict-before check.
-		if !minValidTime.IsZero() && ts.Before(minValidTime) {
+		// minValidTime is always set: isMeasurablePod guarantees a non-nil ReadyTimestamp.
+		if ts.Before(minValidTime) {
 			continue
 		}
 

--- a/pkg/clusteragent/autoscaling/workload/local/replica_calculator.go
+++ b/pkg/clusteragent/autoscaling/workload/local/replica_calculator.go
@@ -14,13 +14,13 @@ import (
 	"math"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/clock"
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/loadstore"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -28,6 +28,9 @@ import (
 
 const (
 	minRequiredMetricDataPoints = 2 // minimum number of data points to consider for a metric
+
+	// Ignore samples from newly-ready pods to avoid scaling on startup bursts.
+	readinessWarmupWindow = 30 * time.Second
 )
 
 type replicaCalculator struct {
@@ -36,8 +39,10 @@ type replicaCalculator struct {
 }
 
 type utilizationResult struct {
-	averageUtilization      float64
-	podToUtilization        map[string]float64
+	// averageUtilization is computed over measured pods only.
+	averageUtilization float64
+	podToUtilization   map[string]float64
+	// missingPods are measurable pods without usable metrics; recommend reserves one slot each.
 	missingPods             []string
 	recommendationTimestamp time.Time
 }
@@ -53,7 +58,6 @@ func newReplicaCalculator(clock clock.Clock, podWatcher workload.PodWatcher) rep
 func (r replicaCalculator) calculateHorizontalRecommendations(dpai model.PodAutoscalerInternal, lStore loadstore.Store) (*model.HorizontalScalingValues, error) {
 	currentTime := r.clock.Now()
 
-	// Get current pods for the target
 	targetRef := dpai.Spec().TargetRef
 	objectives := dpai.Spec().Objectives
 	if dpai.Spec().Fallback != nil && len(dpai.Spec().Fallback.Horizontal.Objectives) > 0 {
@@ -74,7 +78,6 @@ func (r replicaCalculator) calculateHorizontalRecommendations(dpai model.PodAuto
 	}
 	pods := r.podWatcher.GetPodsForOwner(podOwner)
 	if len(pods) == 0 {
-		// If we found nothing, we'll wait just until the next sync
 		return nil, fmt.Errorf("No pods found for autoscaler: %s, gvk: %s, name: %s", dpai.ID(), targetGVK.String(), targetRef.Name)
 	}
 
@@ -100,7 +103,6 @@ func (r replicaCalculator) calculateHorizontalRecommendations(dpai model.PodAuto
 		ts := utilizationRes.recommendationTimestamp
 		lastUtilizationPct = float64(utilizationRes.averageUtilization)
 
-		// Always choose the highest recommendation given
 		if rec > recommendedReplicas.Replicas {
 			recommendedReplicas.Replicas = rec
 			recommendedReplicas.Timestamp = ts
@@ -116,40 +118,36 @@ func (r replicaCalculator) calculateHorizontalRecommendations(dpai model.PodAuto
 	return &recommendedReplicas, nil
 }
 
+// recommend computes a replica recommendation for a single objective from observed pod state
+// only, so the result is stable and independent of the scaling direction.
+//
+// Pods are bucketed in calculateUtilization:
+//
+//   - Measured: Running, Ready, past their warmup window, with usable metrics. They are the
+//     sole metric source and denominator.
+//   - Missing: Running & Ready but without usable (fresh, post-warmup) metrics. Each is
+//     reserved as one replica (neutral fill) — it can neither justify a scale-up (no observed
+//     load) nor be scaled away (we keep its capacity until metrics return).
+//   - Excluded: terminating/terminal pods (never capacity) and Pending/not-Ready/warming pods
+//     (future capacity whose metrics are unreliable). They are left out of both numerator and
+//     denominator until they become measurable, which prevents the warmup-burst runaway.
+//
+// The recommendation is therefore: size for the measured load, then add one slot per missing
+// pod.
 func recommend(currentTime time.Time, recSettings resourceRecommenderSettings, pods []*workloadmeta.KubernetesPod, queryResult loadstore.QueryResult) (int32, utilizationResult, error) {
-	currentReplicas := float64(len(pods))
 	utilizationRes, err := calculateUtilization(recSettings, pods, queryResult, currentTime)
 	if err != nil {
 		return 0, utilizationResult{}, err
 	}
 
-	recommendedReplicas := calculateReplicas(recSettings, currentReplicas, utilizationRes.averageUtilization)
-
-	scaleDirection := common.GetScaleDirection(int32(currentReplicas), recommendedReplicas)
-	if scaleDirection != common.NoScale && len(utilizationRes.missingPods) > 0 {
-		adjustedPodToUtilization := adjustMissingPods(scaleDirection, utilizationRes.podToUtilization, utilizationRes.missingPods)
-		adjustedUtilization := getAveragePodUtilization(adjustedPodToUtilization)
-		newRecommendation := calculateReplicas(recSettings, currentReplicas, adjustedUtilization)
-
-		// If scale direction is reversed, we should not scale
-		if common.GetScaleDirection(int32(currentReplicas), newRecommendation) != scaleDirection {
-			recommendedReplicas = int32(currentReplicas)
-		} else {
-			recommendedReplicas = newRecommendation
-			utilizationRes.averageUtilization = adjustedUtilization
-		}
-	}
+	measuredCount := float64(len(utilizationRes.podToUtilization))
+	recommendedReplicas := calculateReplicas(recSettings, measuredCount, utilizationRes.averageUtilization)
+	recommendedReplicas += int32(len(utilizationRes.missingPods))
 
 	return recommendedReplicas, utilizationRes, nil
 }
 
 func calculateUtilization(recSettings resourceRecommenderSettings, pods []*workloadmeta.KubernetesPod, queryResult loadstore.QueryResult, currentTime time.Time) (utilizationResult, error) {
-	totalPodUtilization := 0.0
-	podCount := 0
-	podUtilization := make(map[string]float64)
-	missingPods := []string{}
-	lastValidTimestamp := time.Time{}
-
 	if len(pods) == 0 {
 		return utilizationResult{}, errors.New("No pods found")
 	}
@@ -158,65 +156,93 @@ func calculateUtilization(recSettings resourceRecommenderSettings, pods []*workl
 		return utilizationResult{}, errors.New("Issue fetching metrics data")
 	}
 
+	podUtilization := make(map[string]float64)
+	totalMeasuredUtilization := 0.0
+	missingPods := []string{}
+	lastValidTimestamp := time.Time{}
+
 	for _, pod := range pods {
-		totalUsage := 0.0
-		totalRequests := 0.0
-
-		for _, container := range pod.Containers {
-			if recSettings.containerName != "" && container.Name != recSettings.containerName {
-				continue
-			}
-
-			if recSettings.metricName == "container.memory.usage" && container.Resources.MemoryRequest != nil {
-				totalRequests += float64(*container.Resources.MemoryRequest)
-			} else if recSettings.metricName == "container.cpu.usage" && container.Resources.CPURequest != nil {
-				totalRequests += convertCPURequestToNanocores(*container.Resources.CPURequest)
-			} else {
-				continue // skip; no request information
-			}
-
-			series := getContainerMetrics(queryResult, pod.Name, container.Name)
-			averageValue, lastTimestamp, err := processAverageContainerMetricValue(series, currentTime, recSettings.fallbackStaleDataThreshold)
-			if err != nil {
-				continue // skip; no usage information
-			}
-			totalUsage += averageValue
-			if lastTimestamp.After(lastValidTimestamp) {
-				lastValidTimestamp = lastTimestamp
-			}
+		if !isMeasurablePod(pod, currentTime) {
+			continue
 		}
 
-		if totalRequests > 0 && totalUsage > 0 {
-			utilization := totalUsage / totalRequests
-			podUtilization[pod.Name] = utilization
-			totalPodUtilization += podUtilization[pod.Name]
-			podCount++
-		} else {
+		minValidTime := pod.ReadyTimestamp.Add(readinessWarmupWindow)
+		utilization, lastTimestamp, ok := calculatePodUtilization(recSettings, pod, queryResult, currentTime, minValidTime)
+		if !ok {
 			missingPods = append(missingPods, pod.Name)
+			continue
+		}
+
+		podUtilization[pod.Name] = utilization
+		// Keep the average deterministic by accumulating in pod order.
+		totalMeasuredUtilization += utilization
+		if lastTimestamp.After(lastValidTimestamp) {
+			lastValidTimestamp = lastTimestamp
 		}
 	}
 
-	if podCount == 0 {
+	if len(podUtilization) == 0 {
 		return utilizationResult{}, errors.New("Issue calculating pod utilization")
 	}
 
 	return utilizationResult{
-		averageUtilization:      totalPodUtilization / float64(podCount),
-		missingPods:             missingPods,
+		averageUtilization:      totalMeasuredUtilization / float64(len(podUtilization)),
 		podToUtilization:        podUtilization,
+		missingPods:             missingPods,
 		recommendationTimestamp: lastValidTimestamp,
 	}, nil
 }
 
-func getAveragePodUtilization(podToUtilization map[string]float64) float64 {
-	totalUtilization := 0.0
-	for _, utilization := range podToUtilization {
-		totalUtilization += utilization
+// isMeasurablePod applies readiness guards used to avoid startup bursts.
+func isMeasurablePod(pod *workloadmeta.KubernetesPod, currentTime time.Time) bool {
+	if pod.DeletionTimestamp != nil || pod.Phase != string(corev1.PodRunning) {
+		return false
 	}
-	return totalUtilization / float64(len(podToUtilization))
+
+	// A nil ReadyTimestamp is treated like HPA's missing ready condition.
+	if !pod.Ready || pod.ReadyTimestamp == nil {
+		return false
+	}
+
+	return !currentTime.Before(pod.ReadyTimestamp.Add(readinessWarmupWindow))
 }
 
-// getContainerMetrics retrieves the metrics for a specific container in a pod
+// calculatePodUtilization returns ok=false when the pod lacks enough fresh post-warmup data.
+func calculatePodUtilization(recSettings resourceRecommenderSettings, pod *workloadmeta.KubernetesPod, queryResult loadstore.QueryResult, currentTime, minValidTime time.Time) (float64, time.Time, bool) {
+	totalUsage := 0.0
+	totalRequests := 0.0
+	latestTimestamp := time.Time{}
+
+	for _, container := range pod.Containers {
+		if recSettings.containerName != "" && container.Name != recSettings.containerName {
+			continue
+		}
+
+		if recSettings.metricName == containerMemoryUsageMetricName && container.Resources.MemoryRequest != nil {
+			totalRequests += float64(*container.Resources.MemoryRequest)
+		} else if recSettings.metricName == containerCPUUsageMetricName && container.Resources.CPURequest != nil {
+			totalRequests += convertCPURequestToNanocores(*container.Resources.CPURequest)
+		} else {
+			continue
+		}
+
+		series := getContainerMetrics(queryResult, pod.Name, container.Name)
+		averageValue, lastTimestamp, err := processAverageContainerMetricValue(series, currentTime, minValidTime, recSettings.fallbackStaleDataThreshold)
+		if err != nil {
+			continue
+		}
+		totalUsage += averageValue
+		if lastTimestamp.After(latestTimestamp) {
+			latestTimestamp = lastTimestamp
+		}
+	}
+
+	if totalRequests > 0 && totalUsage > 0 {
+		return totalUsage / totalRequests, latestTimestamp, true
+	}
+	return 0, time.Time{}, false
+}
+
 func getContainerMetrics(queryResult loadstore.QueryResult, podName, containerName string) []loadstore.EntityValue {
 	for _, result := range queryResult.Results {
 		if result.PodName == podName {
@@ -228,51 +254,39 @@ func getContainerMetrics(queryResult loadstore.QueryResult, podName, containerNa
 	return nil
 }
 
-// processAverageContainerMetricValue takes a series of metrics and processes them to return the final metric value and
-// corresponding timestamp to use to generate a recommendation
-func processAverageContainerMetricValue(series []loadstore.EntityValue, currentTime time.Time, fallbackStaleDataThreshold int64) (float64, time.Time, error) {
-	if len(series) < 2 { // too little metrics data
-		return 0.0, time.Time{}, errors.New("Missing usage metrics")
-	}
-
+// processAverageContainerMetricValue drops stale and pre-warmup samples before averaging.
+// It returns the oldest sample timestamp used in the average.
+func processAverageContainerMetricValue(series []loadstore.EntityValue, currentTime time.Time, minValidTime time.Time, fallbackStaleDataThreshold int64) (float64, time.Time, error) {
 	values := []loadstore.ValueType{}
-	var lastTimestamp time.Time
+	var oldestTimestamp time.Time
 
-	// series is already sorted oldest to newest data point based on insertion
 	for i := len(series) - 1; i >= 0; i-- {
 		entity := series[i]
-		// Invalid data point; data not yet populated
 		if entity.Timestamp == 0 {
 			continue
 		}
 
-		// Discard stale metrics
-		if isStaleMetric(currentTime, entity.Timestamp, fallbackStaleDataThreshold) && len(values) >= minRequiredMetricDataPoints {
+		if isStaleMetric(currentTime, entity.Timestamp, fallbackStaleDataThreshold) {
+			continue
+		}
+
+		ts := convertTimestampToTime(entity.Timestamp)
+		// Keep samples exactly at the warmup boundary, matching HPA's strict-before check.
+		if !minValidTime.IsZero() && ts.Before(minValidTime) {
 			continue
 		}
 
 		values = append(values, entity.Value)
-		ts := convertTimestampToTime(entity.Timestamp)
-		// we want to keep the oldest timestamp used in the average
-		if (lastTimestamp == time.Time{}) || ts.Before(lastTimestamp) {
-			lastTimestamp = ts
-		}
-
-	}
-
-	return average(values), lastTimestamp, nil
-}
-
-func adjustMissingPods(scaleDirection common.ScaleDirection, podToUtilization map[string]float64, missingPods []string) map[string]float64 {
-	for _, pod := range missingPods {
-		// adjust based on scale direction
-		if scaleDirection == common.ScaleUp {
-			podToUtilization[pod] = 0.0 // 0%
-		} else if scaleDirection == common.ScaleDown {
-			podToUtilization[pod] = 1.0 // 100%
+		if oldestTimestamp.IsZero() || ts.Before(oldestTimestamp) {
+			oldestTimestamp = ts
 		}
 	}
-	return podToUtilization
+
+	if len(values) < minRequiredMetricDataPoints {
+		return 0.0, time.Time{}, errors.New("Missing usage metrics")
+	}
+
+	return average(values), oldestTimestamp, nil
 }
 
 func calculateReplicas(recSettings resourceRecommenderSettings, currentReplicas float64, averageUtilization float64) int32 {

--- a/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
@@ -280,11 +280,9 @@ func TestCalculateUtilizationPodResource(t *testing.T) {
 			},
 			currentTime: testTime,
 			want: utilizationResult{
-				averageUtilization: 0.275,
-				missingPods:        []string{},
-				podToUtilization: map[string]float64{
-					"pod-name1": 0.275,
-				},
+				averageUtilization:      0.275,
+				missingPods:             0,
+				measuredPods:            1,
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
 			err: nil,
@@ -340,11 +338,9 @@ func TestCalculateUtilizationPodResource(t *testing.T) {
 			},
 			currentTime: testTime,
 			want: utilizationResult{
-				averageUtilization: 0.275,
-				missingPods:        []string{},
-				podToUtilization: map[string]float64{
-					"pod-name1": .275,
-				},
+				averageUtilization:      0.275,
+				missingPods:             0,
+				measuredPods:            1,
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
 			err: nil,
@@ -417,12 +413,9 @@ func TestCalculateUtilizationPodResource(t *testing.T) {
 			},
 			currentTime: testTime,
 			want: utilizationResult{
-				averageUtilization: 0.275,
-				missingPods:        []string{},
-				podToUtilization: map[string]float64{
-					"pod-name1": 0.25,
-					"pod-name2": 0.30,
-				},
+				averageUtilization:      0.275,
+				missingPods:             0,
+				measuredPods:            2,
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
 			err: nil,
@@ -486,11 +479,9 @@ func TestCalculateUtilizationPodResource(t *testing.T) {
 			},
 			currentTime: testTime,
 			want: utilizationResult{
-				averageUtilization: 0.25,
-				missingPods:        []string{"pod-name2"},
-				podToUtilization: map[string]float64{
-					"pod-name1": 0.25,
-				},
+				averageUtilization:      0.25,
+				missingPods:             1,
+				measuredPods:            1,
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
 			err: nil,
@@ -660,11 +651,9 @@ func TestCalculateUtilizationContainerResource(t *testing.T) {
 			},
 			currentTime: testTime,
 			want: utilizationResult{
-				averageUtilization: 0.25,
-				missingPods:        []string{},
-				podToUtilization: map[string]float64{
-					"pod-name1": 0.25,
-				},
+				averageUtilization:      0.25,
+				missingPods:             0,
+				measuredPods:            1,
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
 			err: nil,
@@ -720,11 +709,9 @@ func TestCalculateUtilizationContainerResource(t *testing.T) {
 			},
 			currentTime: testTime,
 			want: utilizationResult{
-				averageUtilization: 0.25,
-				missingPods:        []string{},
-				podToUtilization: map[string]float64{
-					"pod-name1": 0.25,
-				},
+				averageUtilization:      0.25,
+				missingPods:             0,
+				measuredPods:            1,
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
 			err: nil,
@@ -797,12 +784,9 @@ func TestCalculateUtilizationContainerResource(t *testing.T) {
 			},
 			currentTime: testTime,
 			want: utilizationResult{
-				averageUtilization: 0.275,
-				missingPods:        []string{},
-				podToUtilization: map[string]float64{
-					"pod-name1": 0.25,
-					"pod-name2": 0.30,
-				},
+				averageUtilization:      0.275,
+				missingPods:             0,
+				measuredPods:            2,
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
 			err: nil,
@@ -866,11 +850,9 @@ func TestCalculateUtilizationContainerResource(t *testing.T) {
 			},
 			currentTime: testTime,
 			want: utilizationResult{
-				averageUtilization: 0.25,
-				missingPods:        []string{"pod-name2"},
-				podToUtilization: map[string]float64{
-					"pod-name1": 0.25,
-				},
+				averageUtilization:      0.25,
+				missingPods:             1,
+				measuredPods:            1,
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
 			err: nil,
@@ -1182,14 +1164,9 @@ func TestRecommend(t *testing.T) {
 			currentTime:         testTime,
 			recommendedReplicas: 3,
 			utilizationRes: utilizationResult{
-				averageUtilization: 0.46425,
-				missingPods:        []string{},
-				podToUtilization: map[string]float64{
-					"pod-name1": 0.517,
-					"pod-name2": 0.420,
-					"pod-name3": 0.44,
-					"pod-name4": 0.48,
-				},
+				averageUtilization:      0.46425,
+				missingPods:             0,
+				measuredPods:            4,
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
 			err: nil,
@@ -1333,14 +1310,9 @@ func TestRecommend(t *testing.T) {
 			currentTime:         testTime,
 			recommendedReplicas: 5,
 			utilizationRes: utilizationResult{
-				averageUtilization: 0.941,
-				missingPods:        []string{},
-				podToUtilization: map[string]float64{
-					"pod-name1": 0.944,
-					"pod-name2": 0.92,
-					"pod-name3": 0.94,
-					"pod-name4": 0.96,
-				},
+				averageUtilization:      0.941,
+				missingPods:             0,
+				measuredPods:            4,
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
 			err: nil,
@@ -1457,12 +1429,9 @@ func TestRecommend(t *testing.T) {
 			recommendedReplicas: 5,
 			utilizationRes: utilizationResult{
 				// Only the two pods with usable metrics drive the average.
-				averageUtilization: 0.94,
-				missingPods:        []string{"pod-name2", "pod-name4"},
-				podToUtilization: map[string]float64{
-					"pod-name1": 0.94,
-					"pod-name3": 0.94,
-				},
+				averageUtilization:      0.94,
+				missingPods:             2,
+				measuredPods:            2,
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
 			err: nil,
@@ -1579,12 +1548,9 @@ func TestRecommend(t *testing.T) {
 			recommendedReplicas: 3,
 			utilizationRes: utilizationResult{
 				// Average is over the two ready pods with metrics.
-				averageUtilization: 0.25,
-				missingPods:        []string{"pod-name2", "pod-name3"},
-				podToUtilization: map[string]float64{
-					"pod-name1": 0.24,
-					"pod-name4": 0.26,
-				},
+				averageUtilization:      0.25,
+				missingPods:             2,
+				measuredPods:            2,
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
 			err: nil,
@@ -1870,11 +1836,11 @@ func TestCalculateUtilizationExcludesIneligiblePods(t *testing.T) {
 	require.NoError(t, err)
 
 	// Only the healthy pod contributes to the average.
-	assert.Equal(t, map[string]float64{"healthy": 0.5}, res.podToUtilization)
+	assert.Equal(t, 1, res.measuredPods)
 	assert.InDelta(t, 0.5, res.averageUtilization, 1e-9)
 	// no-data and stale running pods are Ready-but-unmeasured -> missing (reserved as slots).
 	// Pending and still-warming pods are excluded entirely.
-	assert.ElementsMatch(t, []string{"no-data", "stale"}, res.missingPods)
+	assert.Equal(t, 2, res.missingPods)
 }
 
 // TestRecommendDoesNotInfinitelyUpscaleWithWarmupPods reproduces the fallback runaway:
@@ -2023,7 +1989,7 @@ func TestRecommendReservesSlotForMissingMetricsPod(t *testing.T) {
 		}
 		rec, res, err := recommend(currentTime, *recSettings, pods, loadstore.QueryResult{Results: results})
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"missing"}, res.missingPods)
+		assert.Equal(t, 1, res.missingPods)
 		assert.Equalf(t, int32(3), rec, "expected 2 measured + 1 reserved slot = 3, got %d", rec)
 	})
 
@@ -2044,7 +2010,7 @@ func TestRecommendReservesSlotForMissingMetricsPod(t *testing.T) {
 		}
 		rec, res, err := recommend(currentTime, *recSettings, pods, loadstore.QueryResult{Results: results})
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"missing"}, res.missingPods)
+		assert.Equal(t, 1, res.missingPods)
 		assert.Equalf(t, int32(2), rec, "expected 1 (collapsed measured) + 1 reserved slot = 2, got %d", rec)
 	})
 }

--- a/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
@@ -10,12 +10,15 @@ package local
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/clock"
 
@@ -30,6 +33,19 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
+func cpuPodObjective(utilization int32) datadoghqcommon.DatadogPodAutoscalerObjective {
+	return datadoghqcommon.DatadogPodAutoscalerObjective{
+		Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+		PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
+			Name: "cpu",
+			Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+				Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
+				Utilization: pointer.Ptr(utilization),
+			},
+		},
+	}
+}
+
 func TestProcessAverageContainerMetricValue(t *testing.T) {
 	testTime := time.Now()
 
@@ -37,6 +53,7 @@ func TestProcessAverageContainerMetricValue(t *testing.T) {
 		name          string
 		series        []loadstore.EntityValue
 		currentTime   time.Time
+		minValidTime  time.Time
 		averageMetric float64
 		lastTimestamp time.Time
 		err           error
@@ -72,11 +89,61 @@ func TestProcessAverageContainerMetricValue(t *testing.T) {
 			lastTimestamp: time.Unix(testTime.Unix()-30, 0),
 			err:           nil,
 		},
+		{
+			name: "Stale values are dropped, not force-included to reach the minimum",
+			series: []loadstore.EntityValue{
+				*newEntityValue(testTime.Unix()-270, 100), // stale, must be excluded
+				*newEntityValue(testTime.Unix()-15, 2),
+			},
+			currentTime:   testTime,
+			averageMetric: 0.0,
+			lastTimestamp: time.Time{},
+			// Only one fresh point remains after dropping the stale one -> below the minimum.
+			err: errors.New("Missing usage metrics"),
+		},
+		{
+			name: "All samples within the warmup window are excluded",
+			series: []loadstore.EntityValue{
+				*newEntityValue(testTime.Unix()-30, 4),
+				*newEntityValue(testTime.Unix()-15, 2),
+			},
+			currentTime:   testTime,
+			minValidTime:  time.Unix(testTime.Unix()-10, 0), // pod cleared warmup 10s ago
+			averageMetric: 0.0,
+			lastTimestamp: time.Time{},
+			err:           errors.New("Missing usage metrics"),
+		},
+		{
+			name: "Only post-warmup samples are averaged",
+			series: []loadstore.EntityValue{
+				*newEntityValue(testTime.Unix()-30, 100), // within warmup window, excluded
+				*newEntityValue(testTime.Unix()-8, 4),
+				*newEntityValue(testTime.Unix()-4, 2),
+			},
+			currentTime:   testTime,
+			minValidTime:  time.Unix(testTime.Unix()-10, 0),
+			averageMetric: 3.0,
+			lastTimestamp: time.Unix(testTime.Unix()-8, 0),
+			err:           nil,
+		},
+		{
+			name: "Sample exactly at the warmup boundary is kept",
+			series: []loadstore.EntityValue{
+				*newEntityValue(testTime.Unix()-15, 100), // before the boundary, excluded
+				*newEntityValue(testTime.Unix()-10, 4),   // exactly at the boundary, kept
+				*newEntityValue(testTime.Unix()-4, 2),
+			},
+			currentTime:   testTime,
+			minValidTime:  time.Unix(testTime.Unix()-10, 0),
+			averageMetric: 3.0,
+			lastTimestamp: time.Unix(testTime.Unix()-10, 0),
+			err:           nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			averageMetric, lastTimestamp, err := processAverageContainerMetricValue(tt.series, tt.currentTime, defaultStaleDataThresholdSeconds)
+			averageMetric, lastTimestamp, err := processAverageContainerMetricValue(tt.series, tt.currentTime, tt.minValidTime, defaultStaleDataThresholdSeconds)
 			if err != nil {
 				assert.Error(t, err, tt.err.Error())
 				assert.Equal(t, tt.err, err)
@@ -432,6 +499,7 @@ func TestCalculateUtilizationPodResource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			markPodsRunningReady(tt.pods, tt.currentTime)
 			objective := datadoghqcommon.DatadogPodAutoscalerObjective{
 				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
 				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
@@ -452,6 +520,18 @@ func TestCalculateUtilizationPodResource(t *testing.T) {
 				assert.Equal(t, tt.want, utilization)
 			}
 		})
+	}
+}
+
+// markPodsRunningReady marks every pod Running, Ready and past its warmup window so that
+// its metrics are eligible for the utilization calculation. Used by tests that pre-date
+// readiness gating and only care about the utilization math.
+func markPodsRunningReady(pods []*workloadmeta.KubernetesPod, currentTime time.Time) {
+	readyAt := currentTime.Add(-time.Hour)
+	for _, p := range pods {
+		p.Phase = string(corev1.PodRunning)
+		p.Ready = true
+		p.ReadyTimestamp = &readyAt
 	}
 }
 
@@ -810,6 +890,7 @@ func TestCalculateUtilizationContainerResource(t *testing.T) {
 			},
 		}
 		t.Run(tt.name, func(t *testing.T) {
+			markPodsRunningReady(tt.pods, tt.currentTime)
 			recSettings, err := newResourceRecommenderSettings(objective)
 			assert.NoError(t, err)
 			utilization, err := calculateUtilization(*recSettings, tt.pods, tt.queryResult, tt.currentTime)
@@ -1370,16 +1451,17 @@ func TestRecommend(t *testing.T) {
 					},
 				},
 			},
-			currentTime:         testTime,
-			recommendedReplicas: 4,
+			currentTime: testTime,
+			// Two measured pods at 0.94 want 3 replicas; each of the two missing-metrics pods
+			// reserves one more slot (neutral fill) -> 5.
+			recommendedReplicas: 5,
 			utilizationRes: utilizationResult{
+				// Only the two pods with usable metrics drive the average.
 				averageUtilization: 0.94,
 				missingPods:        []string{"pod-name2", "pod-name4"},
 				podToUtilization: map[string]float64{
 					"pod-name1": 0.94,
-					"pod-name2": 0.0,
 					"pod-name3": 0.94,
-					"pod-name4": 0.0,
 				},
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
 			},
@@ -1491,15 +1573,16 @@ func TestRecommend(t *testing.T) {
 					},
 				},
 			},
-			currentTime:         testTime,
-			recommendedReplicas: 3, // original recommendation 1
+			currentTime: testTime,
+			// Two measured pods at 0.25 want 1 replica; each of the two missing-metrics pods
+			// reserves one more slot (neutral fill) -> 3.
+			recommendedReplicas: 3,
 			utilizationRes: utilizationResult{
-				averageUtilization: 0.625,
+				// Average is over the two ready pods with metrics.
+				averageUtilization: 0.25,
 				missingPods:        []string{"pod-name2", "pod-name3"},
 				podToUtilization: map[string]float64{
 					"pod-name1": 0.24,
-					"pod-name2": 1.0,
-					"pod-name3": 1.0,
 					"pod-name4": 0.26,
 				},
 				recommendationTimestamp: time.Unix(testTime.Unix()-30, 0),
@@ -1521,6 +1604,7 @@ func TestRecommend(t *testing.T) {
 				},
 			})
 			assert.NoError(t, err)
+			markPodsRunningReady(tt.pods, tt.currentTime)
 			recommendedReplicas, utilizationRes, err := recommend(tt.currentTime, *recSettings, tt.pods, tt.queryResult)
 			if err != nil {
 				assert.Error(t, err, tt.err.Error())
@@ -1623,7 +1707,17 @@ func TestCalculateHorizontalRecommendations(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// Setup podwatcher
 			pw := workload.NewPodWatcher(nil, nil)
-			pw.HandleEvent(newFakeWLMPodEvent(ns, deploymentName, "pod1", []string{"container-name1"}))
+			pw.HandleEvent(workloadmeta.Event{
+				Type: workloadmeta.EventTypeSet,
+				Entity: newFakePod(fakePodConfig{
+					namespace:      ns,
+					podName:        "pod1",
+					containerNames: []string{"container-name1"},
+					deployment:     deploymentName,
+					cpuRequest:     25,
+					readyTimestamp: time.Now().Add(-time.Hour),
+				}),
+			})
 
 			expectedOwner := workload.NamespacedPodOwner{
 				Namespace: ns,
@@ -1673,4 +1767,284 @@ func TestCalculateHorizontalRecommendations(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsMeasurablePod(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name string
+		pod  *workloadmeta.KubernetesPod
+		want bool
+	}{
+		{
+			name: "running, ready, past warmup",
+			pod:  newFakePod(fakePodConfig{readyTimestamp: now.Add(-time.Hour)}),
+			want: true,
+		},
+		{
+			name: "pending pod is excluded",
+			pod:  newFakePod(fakePodConfig{phase: string(corev1.PodPending)}),
+			want: false,
+		},
+		{
+			name: "running but not ready",
+			pod:  newFakePod(fakePodConfig{}),
+			want: false,
+		},
+		{
+			name: "running, ready, but still within warmup window",
+			pod:  newFakePod(fakePodConfig{readyTimestamp: now.Add(-10 * time.Second)}),
+			want: false,
+		},
+		{
+			name: "running, ready, but readiness time unknown",
+			pod:  newFakePod(fakePodConfig{ready: true}),
+			want: false,
+		},
+		{
+			name: "failed pod is excluded",
+			pod:  newFakePod(fakePodConfig{phase: string(corev1.PodFailed)}),
+			want: false,
+		},
+		{
+			name: "succeeded pod is excluded",
+			pod:  newFakePod(fakePodConfig{phase: string(corev1.PodSucceeded)}),
+			want: false,
+		},
+		{
+			name: "terminating pod is excluded",
+			pod: func() *workloadmeta.KubernetesPod {
+				p := newFakePod(fakePodConfig{readyTimestamp: now.Add(-time.Hour)})
+				deletion := now.Add(-time.Second)
+				p.DeletionTimestamp = &deletion
+				return p
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isMeasurablePod(tt.pod, now))
+		})
+	}
+}
+
+// TestCalculateUtilizationExcludesIneligiblePods verifies that non-running pods, pods
+// without data, pods with only stale data, and pods still in their warmup window are all
+// excluded from the average, while the single healthy pod drives it.
+func TestCalculateUtilizationExcludesIneligiblePods(t *testing.T) {
+	currentTime := time.Now()
+	recSettings, err := newResourceRecommenderSettings(cpuPodObjective(80))
+	require.NoError(t, err)
+
+	pods := []*workloadmeta.KubernetesPod{
+		newFakePod(fakePodConfig{podName: "healthy", readyTimestamp: currentTime.Add(-time.Hour)}),
+		newFakePod(fakePodConfig{podName: "warming", readyTimestamp: currentTime.Add(-5 * time.Second)}),
+		newFakePod(fakePodConfig{podName: "pending", phase: string(corev1.PodPending)}),
+		newFakePod(fakePodConfig{podName: "no-data", readyTimestamp: currentTime.Add(-time.Hour)}),
+		newFakePod(fakePodConfig{podName: "stale", readyTimestamp: currentTime.Add(-time.Hour)}),
+	}
+
+	queryResult := loadstore.QueryResult{
+		Results: []loadstore.PodResult{
+			// Healthy pod: fresh, post-warmup samples at 50% utilization.
+			newCPUUsageResult("healthy", "c", 0.5, currentTime),
+			// Warming pod: high startup burst, but entirely within its warmup window.
+			newCPUUsageResult("warming", "c", 4.0, currentTime),
+			// Stale pod: data points are older than the staleness threshold.
+			{
+				PodName: "stale",
+				ContainerValues: map[string][]loadstore.EntityValue{
+					"c": {
+						*newEntityValue(currentTime.Unix()-300, 4.0e8),
+						*newEntityValue(currentTime.Unix()-280, 4.0e8),
+					},
+				},
+			},
+			// "no-data" and "pending" have no entries at all.
+		},
+	}
+
+	res, err := calculateUtilization(*recSettings, pods, queryResult, currentTime)
+	require.NoError(t, err)
+
+	// Only the healthy pod contributes to the average.
+	assert.Equal(t, map[string]float64{"healthy": 0.5}, res.podToUtilization)
+	assert.InDelta(t, 0.5, res.averageUtilization, 1e-9)
+	// no-data and stale running pods are Ready-but-unmeasured -> missing (reserved as slots).
+	// Pending and still-warming pods are excluded entirely.
+	assert.ElementsMatch(t, []string{"no-data", "stale"}, res.missingPods)
+}
+
+// TestRecommendDoesNotInfinitelyUpscaleWithWarmupPods reproduces the fallback runaway:
+// established pods sit right at target, but every scale-up adds a freshly-created pod whose
+// startup burst reads far above target. Without warmup gating, that burst inflates the average
+// and triggers another scale-up, looping until max replicas. With gating, the warming pod is
+// excluded entirely and the recommendation holds at the established size.
+//
+// This test fails against the pre-fix recommender (replicas climb every iteration) and
+// passes once warming-up pods are excluded.
+func TestRecommendDoesNotInfinitelyUpscaleWithWarmupPods(t *testing.T) {
+	currentTime := time.Now()
+	recSettings, err := newResourceRecommenderSettings(cpuPodObjective(80))
+	require.NoError(t, err)
+
+	// targetUtilization sits within the [0.75, 0.85] dead band so a correct
+	// recommender holds; warmupBurstUtilization is the startup CPU burst of a
+	// freshly-created pod (counted at full weight by the pre-fix recommender).
+	const (
+		targetUtilization      = 0.80
+		warmupBurstUtilization = 3.0
+		initialReplicas        = 3
+		iterations             = 25
+	)
+
+	establishedReplicas := initialReplicas
+	maxObserved := initialReplicas
+
+	for i := 0; i < iterations; i++ {
+		pods := make([]*workloadmeta.KubernetesPod, 0, establishedReplicas+1)
+		results := make([]loadstore.PodResult, 0, establishedReplicas+1)
+
+		// Established pods: long ready, sitting right at the target utilization.
+		for j := 0; j < establishedReplicas; j++ {
+			name := fmt.Sprintf("ready-%d", j)
+			pods = append(pods, newFakePod(fakePodConfig{podName: name, readyTimestamp: currentTime.Add(-time.Hour)}))
+			results = append(results, newCPUUsageResult(name, "c", targetUtilization, currentTime))
+		}
+		// One freshly-created pod still within its warmup window, reporting a startup burst.
+		pods = append(pods, newFakePod(fakePodConfig{podName: "warmup", readyTimestamp: currentTime.Add(-10 * time.Second)}))
+		results = append(results, newCPUUsageResult("warmup", "c", warmupBurstUtilization, currentTime))
+
+		rec, _, err := recommend(currentTime, *recSettings, pods, loadstore.QueryResult{Results: results})
+		require.NoError(t, err)
+
+		// The warming pod is excluded entirely, so the recommendation is sized off the
+		// established pods alone (at target -> no change). A recommender that counted the
+		// warmup pod's burst would climb by one every cycle, up to max replicas.
+		if int(rec) > establishedReplicas {
+			establishedReplicas = int(rec)
+		}
+		if establishedReplicas > maxObserved {
+			maxObserved = establishedReplicas
+		}
+	}
+
+	assert.Equalf(t, initialReplicas, establishedReplicas,
+		"recommender kept scaling up off warm-up pods, reaching %d replicas (expected to hold at %d)", maxObserved, initialReplicas)
+}
+
+// TestRecommendSizesToMeasuredLoadDuringRollout verifies the recommender ignores warming pods
+// and sizes purely to the measured load during an in-flight scale-up. With 3 established pods
+// at target and 2 still-warming pods, it recommends 3 (the measured count) rather than holding
+// at a larger desired count — smoothing that rollout transient is the controller's
+// stabilization window's job, not the recommender's.
+func TestRecommendSizesToMeasuredLoadDuringRollout(t *testing.T) {
+	currentTime := time.Now()
+	recSettings, err := newResourceRecommenderSettings(cpuPodObjective(80))
+	require.NoError(t, err)
+
+	const (
+		establishedReplicas = 3
+		warmingReplicas     = 2
+		targetUtilization   = 0.80
+		warmupBurst         = 3.0
+	)
+
+	pods := []*workloadmeta.KubernetesPod{}
+	results := []loadstore.PodResult{}
+	for j := 0; j < establishedReplicas; j++ {
+		name := fmt.Sprintf("ready-%d", j)
+		pods = append(pods, newFakePod(fakePodConfig{podName: name, readyTimestamp: currentTime.Add(-time.Hour)}))
+		results = append(results, newCPUUsageResult(name, "c", targetUtilization, currentTime))
+	}
+	// The pods the in-flight scale-up added are still within their warmup window.
+	for j := 0; j < warmingReplicas; j++ {
+		name := fmt.Sprintf("warmup-%d", j)
+		pods = append(pods, newFakePod(fakePodConfig{podName: name, readyTimestamp: currentTime.Add(-10 * time.Second)}))
+		results = append(results, newCPUUsageResult(name, "c", warmupBurst, currentTime))
+	}
+
+	rec, _, err := recommend(currentTime, *recSettings, pods, loadstore.QueryResult{Results: results})
+	require.NoError(t, err)
+
+	assert.Equalf(t, int32(establishedReplicas), rec,
+		"expected the recommender to size to the %d measured pods at target, got %d", establishedReplicas, rec)
+}
+
+// TestRecommendScalesUpFromHotMeasuredPods verifies the recommendation is sized off the
+// measured pods only, with no clamp to any desired count. Three measured pods hot at 120% of
+// request want 5 replicas (ceil(1.2/0.85*3)); the warming pod is excluded and does not dampen
+// the result.
+func TestRecommendScalesUpFromHotMeasuredPods(t *testing.T) {
+	currentTime := time.Now()
+	recSettings, err := newResourceRecommenderSettings(cpuPodObjective(80))
+	require.NoError(t, err)
+
+	pods := []*workloadmeta.KubernetesPod{
+		newFakePod(fakePodConfig{podName: "ready-0", readyTimestamp: currentTime.Add(-time.Hour)}),
+		newFakePod(fakePodConfig{podName: "ready-1", readyTimestamp: currentTime.Add(-time.Hour)}),
+		newFakePod(fakePodConfig{podName: "ready-2", readyTimestamp: currentTime.Add(-time.Hour)}),
+		newFakePod(fakePodConfig{podName: "warmup", readyTimestamp: currentTime.Add(-10 * time.Second)}),
+	}
+	results := []loadstore.PodResult{
+		newCPUUsageResult("ready-0", "c", 1.2, currentTime),
+		newCPUUsageResult("ready-1", "c", 1.2, currentTime),
+		newCPUUsageResult("ready-2", "c", 1.2, currentTime),
+		newCPUUsageResult("warmup", "c", 3.0, currentTime),
+	}
+
+	rec, _, err := recommend(currentTime, *recSettings, pods, loadstore.QueryResult{Results: results})
+	require.NoError(t, err)
+
+	assert.Equalf(t, int32(5), rec, "expected scale-up to 5 off the hot measured pods, got %d", rec)
+}
+
+// TestRecommendReservesSlotForMissingMetricsPod verifies the neutral fill: a Running & Ready
+// pod whose metrics are absent is reserved as one capacity slot — it neither drives a scale-up
+// (no observed load) nor is scaled away (its slot is kept until metrics return).
+func TestRecommendReservesSlotForMissingMetricsPod(t *testing.T) {
+	currentTime := time.Now()
+	recSettings, err := newResourceRecommenderSettings(cpuPodObjective(80))
+	require.NoError(t, err)
+
+	// 2 measured pods at target want 2 replicas; the missing pod reserves one more -> 3.
+	t.Run("at target reserves the missing slot", func(t *testing.T) {
+		pods := []*workloadmeta.KubernetesPod{
+			newFakePod(fakePodConfig{podName: "measured-0", readyTimestamp: currentTime.Add(-time.Hour)}),
+			newFakePod(fakePodConfig{podName: "measured-1", readyTimestamp: currentTime.Add(-time.Hour)}),
+			newFakePod(fakePodConfig{podName: "missing", readyTimestamp: currentTime.Add(-time.Hour)}),
+		}
+		results := []loadstore.PodResult{
+			newCPUUsageResult("measured-0", "c", 0.80, currentTime),
+			newCPUUsageResult("measured-1", "c", 0.80, currentTime),
+			// "missing" has no metrics.
+		}
+		rec, res, err := recommend(currentTime, *recSettings, pods, loadstore.QueryResult{Results: results})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"missing"}, res.missingPods)
+		assert.Equalf(t, int32(3), rec, "expected 2 measured + 1 reserved slot = 3, got %d", rec)
+	})
+
+	// 3 idle measured pods collapse to 1; the missing pod keeps its slot -> 2, instead of being
+	// scaled away.
+	t.Run("on scale-down keeps the missing slot", func(t *testing.T) {
+		pods := []*workloadmeta.KubernetesPod{
+			newFakePod(fakePodConfig{podName: "measured-0", readyTimestamp: currentTime.Add(-time.Hour)}),
+			newFakePod(fakePodConfig{podName: "measured-1", readyTimestamp: currentTime.Add(-time.Hour)}),
+			newFakePod(fakePodConfig{podName: "measured-2", readyTimestamp: currentTime.Add(-time.Hour)}),
+			newFakePod(fakePodConfig{podName: "missing", readyTimestamp: currentTime.Add(-time.Hour)}),
+		}
+		results := []loadstore.PodResult{
+			newCPUUsageResult("measured-0", "c", 0.2, currentTime),
+			newCPUUsageResult("measured-1", "c", 0.2, currentTime),
+			newCPUUsageResult("measured-2", "c", 0.2, currentTime),
+			// "missing" has no metrics.
+		}
+		rec, res, err := recommend(currentTime, *recSettings, pods, loadstore.QueryResult{Results: results})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"missing"}, res.missingPods)
+		assert.Equalf(t, int32(2), rec, "expected 1 (collapsed measured) + 1 reserved slot = 2, got %d", rec)
+	})
 }


### PR DESCRIPTION
### What does this PR do?

Prevents local workload autoscaling recommendations from using pods that are not yet Ready or still inside the post-readiness warmup window. The local recommender now sizes from measured pods only, reserves capacity for eligible pods with missing metrics, and propagates pod readiness timestamps through workloadmeta.

### Motivation

Freshly-created pods can report startup bursts before they represent steady-state workload capacity. Counting those samples can repeatedly trigger scale-ups, so the recommender should ignore pods until they are Ready and past the warmup window.

### Describe how you validated your changes

Requires deployment of Autoscaling with local fallback. Need a specific scenario where local fallback is force enabled (or use future integration in fake intake to fake no/stale RC data).
Observe that workloads are not getting their replicas increased constantly when in local fallback mode.

### Additional Notes

Made with [Cursor](https://cursor.com)