### PR TITLE
AGTMETRICS-532 disable v3beta shadowing

### DIFF
--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1513,7 +1513,7 @@ func serializer(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.compression_level", 0)
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.use_beta", false)
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.beta_route", "/api/intake/metrics/v3beta/series")
-	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.shadow_sample_rate", 0.001)
+	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.shadow_sample_rate", 0)
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.shadow_sites", []string{"datadoghq.com"})
 
 	config.BindEnvAndSetDefault("use_v2_api.series", true)

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1513,7 +1513,7 @@ func serializer(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.compression_level", 0)
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.use_beta", false)
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.beta_route", "/api/intake/metrics/v3beta/series")
-	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.shadow_sample_rate", 0)
+	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.shadow_sample_rate", float64(0))
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.shadow_sites", []string{"datadoghq.com"})
 
 	config.BindEnvAndSetDefault("use_v2_api.series", true)

--- a/releasenotes/notes/disable-v3beta-series-shadow-sampling-f633c5f2ef7c72db.yaml
+++ b/releasenotes/notes/disable-v3beta-series-shadow-sampling-f633c5f2ef7c72db.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    The v3beta metrics series shadow sampling introduced in Agent 7.80.0 is
+    now disabled by default.


### PR DESCRIPTION
### What does this PR do?

Disable shadowing series to v3beta endpoint by default.

### Motivation

Series v3 intake is now enabled by default, and shadowing is no longer required.

### Describe how you validated your changes

This configuration is covered by unit tests.

### Additional Notes

Shadowing support will be removed in the following release.