### PR TITLE
fix(autoscaling): grant patch RBAC on argoproj.io/rollouts

### DIFF
--- a/Dockerfiles/manifests/agent-only/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/agent-only/cluster-agent-rbac.yaml
@@ -264,6 +264,15 @@ rules:
       - list
       - watch
       - get
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on Argo
+  # Rollouts (which expose a /scale subresource and can be DPA targets).
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
   - apiGroups:
       - source.toolkit.fluxcd.io
     resources:

--- a/Dockerfiles/manifests/all-containers/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/all-containers/cluster-agent-rbac.yaml
@@ -293,6 +293,15 @@ rules:
       - list
       - watch
       - get
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on Argo
+  # Rollouts (which expose a /scale subresource and can be DPA targets).
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
   - apiGroups:
       - source.toolkit.fluxcd.io
     resources:

--- a/Dockerfiles/manifests/cluster-agent-datadogmetrics/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-agent-datadogmetrics/cluster-agent-rbac.yaml
@@ -290,6 +290,15 @@ rules:
       - list
       - watch
       - get
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on Argo
+  # Rollouts (which expose a /scale subresource and can be DPA targets).
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
   - apiGroups:
       - source.toolkit.fluxcd.io
     resources:

--- a/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml
@@ -275,6 +275,15 @@ rules:
       - list
       - watch
       - get
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on Argo
+  # Rollouts (which expose a /scale subresource and can be DPA targets).
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
   - apiGroups:
       - source.toolkit.fluxcd.io
     resources:

--- a/Dockerfiles/manifests/cluster-checks-runners/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-checks-runners/cluster-agent-rbac.yaml
@@ -275,6 +275,15 @@ rules:
       - list
       - watch
       - get
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on Argo
+  # Rollouts (which expose a /scale subresource and can be DPA targets).
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
   - apiGroups:
       - source.toolkit.fluxcd.io
     resources:

--- a/Dockerfiles/manifests/kubernetes_state_core/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/kubernetes_state_core/cluster-agent-rbac.yaml
@@ -264,6 +264,15 @@ rules:
       - list
       - watch
       - get
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on Argo
+  # Rollouts (which expose a /scale subresource and can be DPA targets).
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
   - apiGroups:
       - source.toolkit.fluxcd.io
     resources:

--- a/Dockerfiles/manifests/orchestrator-explorer/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/orchestrator-explorer/cluster-agent-rbac.yaml
@@ -264,6 +264,15 @@ rules:
       - list
       - watch
       - get
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on Argo
+  # Rollouts (which expose a /scale subresource and can be DPA targets).
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
   - apiGroups:
       - source.toolkit.fluxcd.io
     resources:

--- a/Dockerfiles/manifests/security-agent/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/security-agent/cluster-agent-rbac.yaml
@@ -293,6 +293,15 @@ rules:
       - list
       - watch
       - get
+  # Required by the workload autoscaler (DatadogPodAutoscaler) to release
+  # the cluster agent's `.spec.replicas` managedFields entry on Argo
+  # Rollouts (which expose a /scale subresource and can be DPA targets).
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
   - apiGroups:
       - source.toolkit.fluxcd.io
     resources:

--- a/releasenotes/notes/dpa-argoproj-rollouts-patch-rbac-31c96a0dbaeb8570.yaml
+++ b/releasenotes/notes/dpa-argoproj-rollouts-patch-rbac-31c96a0dbaeb8570.yaml
@@ -1,0 +1,13 @@
+---
+upgrade:
+  - |
+    The in-tree ``Dockerfiles/manifests/.../cluster-agent-rbac.yaml``
+    manifests now grant the cluster agent the ``patch`` verb on
+    ``argoproj.io/rollouts``, in addition to the existing
+    ``list``/``watch``/``get``. This is required for the workload
+    autoscaler (``DatadogPodAutoscaler``) to release its stale
+    ``.spec.replicas`` field-manager entry on Argo Rollouts targets
+    when scaling stops (paired with the ``fixes`` entry in the previous
+    release). Users deploying the cluster agent via the official Helm
+    chart or Datadog Operator must wait for the corresponding RBAC
+    bumps in those repositories or grant the verb manually.


### PR DESCRIPTION
## Summary

Follow-up to #52040 (workload autoscaler `.spec.replicas` ownership release). The in-tree cluster-agent RBAC manifests already grant `list`/`watch`/`get` on `argoproj.io/rollouts`, but the ownership-release path introduced by #52040 also needs `patch` to remove the stale `datadog-cluster-agent` managedFields entry on Rollout targets. Without it the release returns 403 and the stale entry persists — re-introducing the Helm SSA conflict #52040 fixes, just for Argo Rollouts customers.

Scope: a focused `patch` rule on `argoproj.io/rollouts` only (not applications/applicationsets, which are not scaleable) across all eight `Dockerfiles/manifests/*/cluster-agent-rbac.yaml` files, plus a release-note YAML.

## Why not in #52040

Argo Rollouts targeting was a pre-existing capability — DPA scaled Rollouts through the scale subresource without the new patch verb. The ownership-release leak was masked there too. Keeping this separate from #52040 to keep that PR focused on the original Helm SSA conflict fix.

## Test plan

- [x] YAML inserts only; no code changes.
- [ ] Once both PRs land, validate against an Argo Rollouts target: scale, disable scaling, verify the managedFields entry is released.

## Coordination

- Helm chart and Datadog Operator RBAC in their respective repositories need the same `patch` verb on `argoproj.io/rollouts` separately — called out in the release-note upgrade entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)