### PR TITLE
chore(codeowners): fix q-branch entries overriding go.mod no-owner rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -938,6 +938,10 @@
 /internal/third_party/kubernetes        @DataDog/container-integrations
 /internal/third_party/golang/           @DataDog/container-integrations
 
+/q_branch/                               @DataDog/q-branch
+/internal/qbranch/                       @DataDog/q-branch
+/comp/anomalydetection/                  @DataDog/q-branch # Useful for AGENTS.md files etc. at the root of all AD components
+
 # With the introduction of go.work, dependencies bump modify go.mod and go.sum in a lot of file.
 # Which bring a lot of team in the review each time. To make it smoother we no longer consider go.mod and go.sum owned by teams.
 # Each team can individually decide to update CODEOWNERS to be requested for a review on each modification of their go.mod/sum
@@ -948,10 +952,6 @@
 # Add here modules that need explicit review from the team owning them
 /pkg/util/scrubber/go.mod                @DataDog/agent-runtimes
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
-
-/q_branch/                               @DataDog/q-branch
-/internal/qbranch/                       @DataDog/q-branch
-/comp/anomalydetection/                  @DataDog/q-branch # Useful for AGENTS.md files etc. at the root of all AD components
 
 # AI-related files
 /.claude/rules/bazel.md               @DataDog/agent-build


### PR DESCRIPTION
## What does this PR do?

Move q-branch ownership above go.mod no-owner rule.

## Motivation

Remove unnecessary review requests for q-branch when bumping dependencies.
