### PR TITLE
fix(autoscaling): restructure release gating around LastScaledTarget

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -243,12 +243,19 @@ func (c *Controller) syncPodAutoscaler(ctx context.Context, key, ns, name string
 		// Also if object was not owned by remote config, we also need to delete it (deleted by user)
 		if podAutoscalerInternal.Deleted() || (!podAutoscalerInternal.IsProfileManaged() && podAutoscalerInternal.Spec().Owner != datadoghqcommon.DatadogPodAutoscalerRemoteOwner) {
 			log.Infof("Object %s not present in Kubernetes and flagged for deletion (remote) or owner == local, clearing internal store", key)
-			// Local-owned DPAs reach this branch when the user deletes the K8s
-			// object directly (the remote-owned and profile-managed paths above
-			// already released ownership before calling deletePodAutoscaler).
-			// Release here too so that a deleted local-owned DPA doesn't leak
-			// a stale `datadog-cluster-agent` scale managedFields entry.
-			c.releaseTargetReplicasOwnership(ctx, podAutoscalerInternal)
+			// Release the scale-subresource managedFields entry on whatever
+			// workload we last scaled, so a `kubectl delete dpa` does not leak
+			// a stale `datadog-cluster-agent` entry. Retry up to maxRetry times
+			// (workqueue rate-limited) before giving up — after that we log
+			// loudly and clear the store anyway so the queue doesn't grow
+			// unbounded on a permanent failure (e.g. RBAC never granted).
+			if err := c.releaseTargetReplicasOwnership(ctx, podAutoscalerInternal); err != nil {
+				if c.Workqueue.NumRequeues(key) < maxRetry {
+					storeUnlock()
+					return autoscaling.Requeue, err
+				}
+				log.Errorf("Giving up releasing replicas ownership for %s after %d attempts; stale managedFields entry may need manual cleanup: %v", key, maxRetry, err)
+			}
 			c.store.UnlockDelete(key, c.ID)
 			return autoscaling.NoRequeue, nil
 		}
@@ -278,7 +285,19 @@ func (c *Controller) syncPodAutoscaler(ctx context.Context, key, ns, name string
 		// Deletion can only happen if the object is owned by remote config.
 		if podAutoscalerInternal.Deleted() {
 			log.Infof("Remote owned PodAutoscaler with Deleted flag, deleting object: %s", key)
-			c.releaseTargetReplicasOwnership(ctx, podAutoscalerInternal)
+			// Try to release the scale-subresource managedFields entry on the
+			// last-scaled target BEFORE deleting the DPA — once the DPA is
+			// gone we have nothing to retry from. Retry up to maxRetry times
+			// (workqueue rate-limited); after that, give up loudly and
+			// proceed with the delete so the user is never permanently
+			// blocked from removing a DPA on a stuck release.
+			if err := c.releaseTargetReplicasOwnership(ctx, podAutoscalerInternal); err != nil {
+				if c.Workqueue.NumRequeues(key) < maxRetry {
+					storeUnlock()
+					return autoscaling.Requeue, err
+				}
+				log.Errorf("Giving up releasing replicas ownership for %s after %d attempts; stale managedFields entry may need manual cleanup: %v", key, maxRetry, err)
+			}
 			err := c.deletePodAutoscaler(ns, name)
 			// In case of not found, it means the object is gone but informer cache is not updated yet, we can safely delete it from our store
 			if err != nil && k8serrors.IsNotFound(err) {
@@ -366,7 +385,19 @@ func (c *Controller) syncPodAutoscaler(ctx context.Context, key, ns, name string
 	if podAutoscalerInternal.IsProfileManaged() {
 		if podAutoscalerInternal.Deleted() {
 			log.Infof("Profile-managed PodAutoscaler with Deleted flag, deleting object: %s", key)
-			c.releaseTargetReplicasOwnership(ctx, podAutoscalerInternal)
+			// Try to release the scale-subresource managedFields entry on the
+			// last-scaled target BEFORE deleting the DPA — once the DPA is
+			// gone we have nothing to retry from. Retry up to maxRetry times
+			// (workqueue rate-limited); after that, give up loudly and
+			// proceed with the delete so the user is never permanently
+			// blocked from removing a DPA on a stuck release.
+			if err := c.releaseTargetReplicasOwnership(ctx, podAutoscalerInternal); err != nil {
+				if c.Workqueue.NumRequeues(key) < maxRetry {
+					storeUnlock()
+					return autoscaling.Requeue, err
+				}
+				log.Errorf("Giving up releasing replicas ownership for %s after %d attempts; stale managedFields entry may need manual cleanup: %v", key, maxRetry, err)
+			}
 			err := c.deletePodAutoscaler(ns, name)
 			if err != nil && k8serrors.IsNotFound(err) {
 				c.store.UnlockDelete(key, c.ID)
@@ -614,24 +645,25 @@ func (c *Controller) deletePodAutoscaler(ns, name string) error {
 	return nil
 }
 
-// releaseTargetReplicasOwnership best-effort removes the cluster agent's
-// managed-fields entry for `.spec.replicas` (scale subresource) from the
-// DPA's target workload. Called before deleting a DPA so that subsequent
-// SSA writers (e.g. Helm) do not conflict with a stale field manager.
-// Errors are logged but not returned — cleanup must not block deletion.
-func (c *Controller) releaseTargetReplicasOwnership(ctx context.Context, podAutoscalerInternal model.PodAutoscalerInternal) {
-	spec := podAutoscalerInternal.Spec()
-	if spec == nil || spec.TargetRef.Name == "" {
-		return
+// releaseTargetReplicasOwnership removes the cluster agent's managed-fields
+// entry for `.spec.replicas` (scale subresource) from the workload the
+// horizontal controller most recently wrote on. Returns the underlying error
+// so the caller can decide whether to requeue or give up.
+//
+// Reads the target from LastScaledTarget (set after every successful
+// scaler.update) rather than the current spec.TargetRef — that way a DPA
+// retargeted before deletion still releases the correct workload, and a DPA
+// that never successfully scaled (LastScaledTarget == nil) short-circuits as
+// a no-op instead of issuing a needless GET.
+func (c *Controller) releaseTargetReplicasOwnership(ctx context.Context, podAutoscalerInternal model.PodAutoscalerInternal) error {
+	target := podAutoscalerInternal.LastScaledTarget()
+	if target == nil {
+		return nil
 	}
-	targetGVK, err := podAutoscalerInternal.TargetGVK()
-	if err != nil {
-		log.Debugf("Skipping replicas-ownership release for %s/%s: unable to resolve target GVK: %v", podAutoscalerInternal.Namespace(), podAutoscalerInternal.Name(), err)
-		return
+	if err := c.scaler.releaseReplicasOwnership(ctx, target.Namespace, target.Name, target.GVK); err != nil {
+		return fmt.Errorf("failed to release replicas ownership for %s %s/%s: %w", target.GVK.Kind, target.Namespace, target.Name, err)
 	}
-	if err := c.scaler.releaseReplicasOwnership(ctx, podAutoscalerInternal.Namespace(), spec.TargetRef.Name, targetGVK); err != nil {
-		log.Warnf("Failed to release replicas ownership for %s %s/%s: %v", targetGVK.Kind, podAutoscalerInternal.Namespace(), spec.TargetRef.Name, err)
-	}
+	return nil
 }
 
 func (c *Controller) validateAutoscaler(podAutoscalerInternal model.PodAutoscalerInternal) error {

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
@@ -51,31 +51,26 @@ func newHorizontalReconciler(clock clock.Clock, eventRecorder record.EventRecord
 }
 
 func (hr *horizontalController) sync(ctx context.Context, podAutoscaler *datadoghq.DatadogPodAutoscaler, autoscalerInternal *model.PodAutoscalerInternal, targetGVK schema.GroupVersionKind, scale *autoscalingv1.Scale, gr schema.GroupResource, scaleErr error) (autoscaling.ProcessResult, error) {
+	_ = targetGVK // historical signature; release now reads target from LastScaledTarget
+
 	// If we have no Spec, nothing to do
 	if autoscalerInternal.Spec() == nil {
 		return autoscaling.NoRequeue, nil
 	}
 
+	// If we previously wrote `.spec.replicas` and we are now in a state where
+	// we will not write again on the recorded target (horizontal scaling
+	// disabled, Preview mode, or the DPA was retargeted), release the cluster
+	// agent's scale-subresource managedFields entry on the recorded target so
+	// SSA writers (e.g. Helm) do not conflict with a stale field manager.
+	// Surface failures via event/condition/metric and requeue — bounded by
+	// maxRetry — rather than logging silently.
+	if err := hr.maybeReleaseLastScaledTargetOwnership(ctx, podAutoscaler, autoscalerInternal); err != nil {
+		return autoscaling.Requeue, err
+	}
+
 	// If horizontal scaling is disabled, clear horizontal state and exit.
 	if !autoscalerInternal.IsHorizontalScalingEnabled() {
-		// If we previously scaled this target, release ownership of
-		// `.spec.replicas` so SSA writers (e.g. Helm) do not conflict with
-		// a stale field manager once horizontal scaling is off. Gated on
-		// HorizontalLastActions to avoid issuing a GET on every reconcile
-		// while horizontal stays disabled — ClearHorizontalState below
-		// nils out actions so subsequent ticks skip this branch.
-		//
-		// IMPORTANT: only clear horizontal state once the release actually
-		// succeeds. If we cleared on failure (RBAC missing, JSON-patch test
-		// op race, transient API error), the gate above would never fire
-		// again and the stale managedFields entry would leak permanently.
-		// On failure we requeue and retry with a fresh snapshot.
-		if len(autoscalerInternal.HorizontalLastActions()) > 0 && autoscalerInternal.Spec().TargetRef.Name != "" {
-			if err := hr.scaler.releaseReplicasOwnership(ctx, autoscalerInternal.Namespace(), autoscalerInternal.Spec().TargetRef.Name, targetGVK); err != nil {
-				log.Warnf("Failed to release replicas ownership for %s %s/%s after disabling horizontal scaling, will retry: %v", targetGVK.Kind, autoscalerInternal.Namespace(), autoscalerInternal.Spec().TargetRef.Name, err)
-				return autoscaling.Requeue, nil
-			}
-		}
 		autoscalerInternal.ClearHorizontalState()
 		return autoscaling.NoRequeue, nil
 	}
@@ -149,6 +144,17 @@ func (hr *horizontalController) performScaling(ctx context.Context, podAutoscale
 	log.Debugf("Scaled target: %s/%s from %d replicas to %d replicas", scale.Namespace, scale.Name, horizontalAction.FromReplicas, horizontalAction.ToReplicas)
 	autoscalerInternal.UpdateFromHorizontalAction(horizontalAction, nil)
 	autoscalerInternal.HorizontalActionSuccessInc()
+	// Record where we just wrote `.spec.replicas` so a later release path
+	// (disable, Preview, retarget, deletion) knows which workload still holds
+	// our scale-subresource managedFields entry — independent of the current
+	// spec, which may be edited before release runs.
+	if gvk, gvkErr := autoscalerInternal.TargetGVK(); gvkErr == nil {
+		autoscalerInternal.SetLastScaledTarget(&model.LastScaledTarget{
+			Namespace: scale.Namespace,
+			Name:      scale.Name,
+			GVK:       gvk,
+		})
+	}
 	hr.eventRecorder.Eventf(podAutoscaler, corev1.EventTypeNormal, model.SuccessfulScaleEventReason, "Scaled target: %s/%s from %d replicas to %d replicas", scale.Namespace, scale.Name, horizontalAction.FromReplicas, horizontalAction.ToReplicas)
 	if nextEvalAfter > 0 {
 		return autoscaling.Requeue.After(nextEvalAfter), nil
@@ -519,4 +525,55 @@ func accumulateReplicasChange(currentTime time.Time, events []datadoghqcommon.Da
 		expireIn = periodDuration
 	}
 	return
+}
+
+// maybeReleaseLastScaledTargetOwnership releases the cluster agent's
+// scale-subresource managedFields entry on the workload we previously wrote
+// `.spec.replicas` on, if the controller is transitioning away from that
+// target. Triggers:
+//   - horizontal scaling disabled (both ScaleUp and ScaleDown strategies
+//     set to DisabledStrategySelect),
+//   - apply mode is Preview (the controller still computes recommendations
+//     but no longer writes replicas),
+//   - the DPA spec was retargeted to a different workload (different name
+//     or different GVK) since the last successful scale.
+//
+// If the release call returns an error, surface it via event/condition/
+// metric and propagate so the caller can requeue with the err set — the
+// workqueue's maxRetry guard then caps the retry budget rather than
+// silently hot-looping. On success, clears LastScaledTarget so we do not
+// re-issue the release on every subsequent reconcile.
+func (hr *horizontalController) maybeReleaseLastScaledTargetOwnership(
+	ctx context.Context,
+	podAutoscaler *datadoghq.DatadogPodAutoscaler,
+	autoscalerInternal *model.PodAutoscalerInternal,
+) error {
+	target := autoscalerInternal.LastScaledTarget()
+	if target == nil {
+		return nil
+	}
+	spec := autoscalerInternal.Spec()
+	if spec == nil {
+		return nil
+	}
+
+	disabled := !autoscalerInternal.IsHorizontalScalingEnabled()
+	preview := spec.ApplyPolicy != nil && spec.ApplyPolicy.Mode == datadoghq.DatadogPodAutoscalerApplyModePreview
+	targetChanged := target.Name != spec.TargetRef.Name ||
+		target.GVK.Kind != spec.TargetRef.Kind ||
+		target.GVK.GroupVersion().String() != spec.TargetRef.APIVersion
+	if !disabled && !preview && !targetChanged {
+		return nil
+	}
+
+	if err := hr.scaler.releaseReplicasOwnership(ctx, target.Namespace, target.Name, target.GVK); err != nil {
+		wrappedErr := autoscaling.NewConditionError(autoscaling.ConditionReasonScaleFailed,
+			fmt.Errorf("failed to release replicas ownership for %s %s/%s: %w", target.GVK.Kind, target.Namespace, target.Name, err))
+		hr.eventRecorder.Event(podAutoscaler, corev1.EventTypeWarning, model.FailedScaleEventReason, wrappedErr.Error())
+		autoscalerInternal.UpdateFromHorizontalAction(nil, wrappedErr)
+		autoscalerInternal.HorizontalActionErrorInc()
+		return wrappedErr
+	}
+	autoscalerInternal.ClearLastScaledTarget()
+	return nil
 }

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
@@ -146,6 +146,14 @@ func (f *horizontalControllerFixture) testScalingDecision(args horizontalScaling
 		args.fakePai.AddHorizontalAction(action.Time.Time, action)
 		args.fakePai.HorizontalLastActionError = nil
 		args.fakePai.HorizontalActionSuccessCount++
+		// Mirror SetLastScaledTarget that the production code runs after
+		// every successful scaler.update — drives the release-on-disable
+		// gate in subsequent reconciles.
+		args.fakePai.LastScaledTarget = &model.LastScaledTarget{
+			Namespace: args.fakePai.Namespace,
+			Name:      args.fakePai.Spec.TargetRef.Name,
+			GVK:       args.fakePai.TargetGVK,
+		}
 	} else if args.scaleError != nil {
 		args.fakePai.HorizontalLastActionError = args.scaleError
 		// Counter is only incremented when the scale update itself fails (not for internal errors like policy restrictions)
@@ -375,14 +383,17 @@ func TestHorizontalControllerReleaseOwnershipOnDisable(t *testing.T) {
 		ApplyPolicy: disabledPolicy,
 	}
 
-	// Case 1: horizontal disabled with prior actions → release exactly once.
+	// Case 1: horizontal disabled with LastScaledTarget set (previous scale
+	// observed) → release exactly once against the recorded target.
 	fakePai := &model.FakePodAutoscalerInternal{
 		Namespace: autoscalerNamespace,
 		Name:      autoscalerName,
 		Spec:      spec,
 		TargetGVK: targetGVK,
-		HorizontalLastActions: []datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
-			{Time: metav1.NewTime(f.clock.Now()), FromReplicas: 3, ToReplicas: 5},
+		LastScaledTarget: &model.LastScaledTarget{
+			Namespace: autoscalerNamespace,
+			Name:      autoscalerName,
+			GVK:       targetGVK,
 		},
 	}
 	f.scaler.mockGet(*fakePai, 5, 5, nil)
@@ -392,7 +403,8 @@ func TestHorizontalControllerReleaseOwnershipOnDisable(t *testing.T) {
 	f.scaler.AssertNumberOfCalls(t, "releaseReplicasOwnership", 1)
 	f.scaler.AssertCalled(t, "releaseReplicasOwnership", mock.Anything, autoscalerNamespace, autoscalerName, targetGVK)
 
-	// Case 2: horizontal disabled with no prior actions → no release.
+	// Case 2: horizontal disabled with LastScaledTarget unset (DPA never
+	// successfully scaled) → no release.
 	f.resetFakeScaler()
 	fakePaiNoActions := &model.FakePodAutoscalerInternal{
 		Namespace: autoscalerNamespace,
@@ -407,13 +419,84 @@ func TestHorizontalControllerReleaseOwnershipOnDisable(t *testing.T) {
 	f.scaler.AssertNumberOfCalls(t, "releaseReplicasOwnership", 0)
 }
 
+func TestHorizontalControllerReleaseOwnershipOnPreviewTransition(t *testing.T) {
+	// Apply mode == Preview is functionally "stop writing replicas" but
+	// IsHorizontalScalingEnabled() returns true. The release gate must
+	// still fire so the workload's stale managedFields entry is cleaned up.
+	f := newHorizontalControllerFixture(t, time.Now())
+	autoscalerNamespace := "default"
+	autoscalerName := "test"
+
+	targetGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	spec := &datadoghq.DatadogPodAutoscalerSpec{
+		TargetRef: v2.CrossVersionObjectReference{
+			Name:       autoscalerName,
+			Kind:       targetGVK.Kind,
+			APIVersion: targetGVK.Group + "/" + targetGVK.Version,
+		},
+		ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+			Mode: datadoghq.DatadogPodAutoscalerApplyModePreview,
+		},
+	}
+	fakePai := &model.FakePodAutoscalerInternal{
+		Namespace: autoscalerNamespace,
+		Name:      autoscalerName,
+		Spec:      spec,
+		TargetGVK: targetGVK,
+		LastScaledTarget: &model.LastScaledTarget{
+			Namespace: autoscalerNamespace,
+			Name:      autoscalerName,
+			GVK:       targetGVK,
+		},
+	}
+	f.scaler.mockGet(*fakePai, 5, 5, nil)
+	_, _, err := f.runSync(fakePai)
+	assert.NoError(t, err)
+	f.scaler.AssertNumberOfCalls(t, "releaseReplicasOwnership", 1)
+	f.scaler.AssertCalled(t, "releaseReplicasOwnership", mock.Anything, autoscalerNamespace, autoscalerName, targetGVK)
+}
+
+func TestHorizontalControllerReleaseOwnershipOnTargetRefChange(t *testing.T) {
+	// If a DPA scaled workload "old" and is then retargeted to workload
+	// "new", the release must fire against "old" (the workload that
+	// actually holds the stale managedFields entry) — NOT against the
+	// current spec.TargetRef.Name which points at the new target.
+	f := newHorizontalControllerFixture(t, time.Now())
+	autoscalerNamespace := "default"
+
+	targetGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	spec := &datadoghq.DatadogPodAutoscalerSpec{
+		TargetRef: v2.CrossVersionObjectReference{
+			Name:       "new",
+			Kind:       targetGVK.Kind,
+			APIVersion: targetGVK.Group + "/" + targetGVK.Version,
+		},
+	}
+	fakePai := &model.FakePodAutoscalerInternal{
+		Namespace: autoscalerNamespace,
+		Name:      "dpa",
+		Spec:      spec,
+		TargetGVK: targetGVK,
+		LastScaledTarget: &model.LastScaledTarget{
+			Namespace: autoscalerNamespace,
+			Name:      "old",
+			GVK:       targetGVK,
+		},
+	}
+	f.scaler.mockGet(*fakePai, 5, 5, nil)
+	_, _, err := f.runSync(fakePai)
+	assert.NoError(t, err)
+	f.scaler.AssertCalled(t, "releaseReplicasOwnership", mock.Anything, autoscalerNamespace, "old", targetGVK)
+}
+
 func TestHorizontalControllerReleaseOwnershipOnDisable_FailureRetainsState(t *testing.T) {
 	// When releaseReplicasOwnership fails (e.g. RBAC not yet granted, or
 	// JSON-patch test op detected a managedFields race), the controller
-	// must NOT clear HorizontalLastActions — otherwise the gate
-	// (`len(HorizontalLastActions) > 0`) would never fire again and the
-	// stale managedFields entry would leak permanently. The controller
-	// should also return Requeue so the workqueue retries.
+	// must NOT clear LastScaledTarget — otherwise the gate would never
+	// fire again and the stale managedFields entry would leak permanently.
+	// The controller should also return Requeue with the error so the
+	// workqueue's maxRetry caps the retry budget and the error surfaces
+	// via DPA condition / Event / telemetry.
 	f := newHorizontalControllerFixture(t, time.Now())
 	autoscalerNamespace := "default"
 	autoscalerName := "test"
@@ -433,15 +516,17 @@ func TestHorizontalControllerReleaseOwnershipOnDisable_FailureRetainsState(t *te
 		ApplyPolicy: disabledPolicy,
 	}
 
-	priorActions := []datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
-		{Time: metav1.NewTime(f.clock.Now()), FromReplicas: 3, ToReplicas: 5},
+	lastScaled := &model.LastScaledTarget{
+		Namespace: autoscalerNamespace,
+		Name:      autoscalerName,
+		GVK:       targetGVK,
 	}
 	fakePai := &model.FakePodAutoscalerInternal{
-		Namespace:             autoscalerNamespace,
-		Name:                  autoscalerName,
-		Spec:                  spec,
-		TargetGVK:             targetGVK,
-		HorizontalLastActions: priorActions,
+		Namespace:        autoscalerNamespace,
+		Name:             autoscalerName,
+		Spec:             spec,
+		TargetGVK:        targetGVK,
+		LastScaledTarget: lastScaled,
 	}
 
 	// Bypass the Maybe-equipped fakeScaler: install a fresh one with a
@@ -456,14 +541,14 @@ func TestHorizontalControllerReleaseOwnershipOnDisable_FailureRetainsState(t *te
 
 	autoscaler, result, err := f.runSync(fakePai)
 	assert.Equal(t, autoscaling.Requeue, result, "must requeue so the workqueue retries the release")
-	assert.NoError(t, err, "best-effort cleanup must not surface an error to the workqueue retry counter")
+	assert.Error(t, err, "release failures must surface to the workqueue so maxRetry caps the loop")
 	strictScaler.AssertNumberOfCalls(t, "releaseReplicasOwnership", 1)
 
-	// HorizontalLastActions must NOT be cleared — otherwise the gate above
-	// would never fire on the next reconcile and the stale managedFields
-	// entry would leak permanently.
-	assert.Equal(t, priorActions, autoscaler.HorizontalLastActions(),
-		"HorizontalLastActions must be retained on release failure to allow retry")
+	// LastScaledTarget must NOT be cleared — otherwise the gate would never
+	// fire on the next reconcile and the stale managedFields entry would
+	// leak permanently.
+	assert.Equal(t, lastScaled, autoscaler.LastScaledTarget(),
+		"LastScaledTarget must be retained on release failure to allow retry")
 }
 
 func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -150,6 +150,18 @@ func TestLeaderCreateDeleteLocal(t *testing.T) {
 	assert.True(t, found)
 	model.AssertPodAutoscalersEqual(t, expectedDPAInternal, dpaInternal)
 
+	// Simulate that the controller successfully scaled the target before the
+	// K8s object was deleted (the production path records LastScaledTarget
+	// after every successful scaler.update); without this, the release
+	// helper correctly short-circuits because there's nothing to clean up.
+	deploymentGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	dpaInternal.SetLastScaledTarget(&model.LastScaledTarget{
+		Namespace: "default",
+		Name:      "app-0",
+		GVK:       deploymentGVK,
+	})
+	f.store.Set("default/dpa-0", dpaInternal, controllerID)
+
 	// Object deleted from Kubernetes, should be deleted from store
 	f.InformerObjects = nil
 	f.Objects = nil
@@ -160,8 +172,7 @@ func TestLeaderCreateDeleteLocal(t *testing.T) {
 	// controller must release `.spec.replicas` ownership on the target
 	// workload before clearing the internal store, so SSA writers do not
 	// conflict with a stale `datadog-cluster-agent` field manager.
-	f.scaler.AssertCalled(t, "releaseReplicasOwnership", mock.Anything, "default", "app-0",
-		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+	f.scaler.AssertCalled(t, "releaseReplicasOwnership", mock.Anything, "default", "app-0", deploymentGVK)
 
 	// Re-create object
 	f.InformerObjects = append(f.InformerObjects, dpa)
@@ -169,6 +180,9 @@ func TestLeaderCreateDeleteLocal(t *testing.T) {
 
 	f.RunControllerSync(true, "default/dpa-0")
 
+	// Re-fetch the stored DPA: after recreate, the store holds a fresh
+	// instance with no LastScaledTarget — assert it equals expected.
+	dpaInternal, found = f.store.Get("default/dpa-0")
 	assert.True(t, found)
 	model.AssertPodAutoscalersEqual(t, expectedDPAInternal, dpaInternal)
 }
@@ -222,8 +236,15 @@ func TestLeaderCreateDeleteRemote(t *testing.T) {
 	f.ExpectCreateAction(expectedUnstructured)
 	f.RunControllerSync(true, "default/dpa-0")
 
-	// We flag the object as deleted in the store, we expect delete operation in Kubernetes
+	// We flag the object as deleted in the store, we expect delete operation in Kubernetes.
+	// Also seed LastScaledTarget so the release path actually fires — the
+	// production helper short-circuits when no prior scale has been recorded.
 	dpaInternal.Deleted = true
+	dpaInternal.LastScaledTarget = &model.LastScaledTarget{
+		Namespace: "default",
+		Name:      "app-0",
+		GVK:       schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+	}
 	f.store.Set("default/dpa-0", dpaInternal.Build(), controllerID)
 	f.InformerObjects = append(f.InformerObjects, expectedUnstructured)
 	f.Objects = append(f.Objects, expectedDPA)

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
@@ -58,6 +58,17 @@ var resyncAnnotationKeysFromPodAutoscaler = []string{
 	CustomRecommenderAnnotationKey,
 }
 
+// LastScaledTarget records the workload that the horizontal controller most
+// recently wrote `.spec.replicas` on. It is used to release the cluster
+// agent's scale-subresource managedFields entry at the right target when
+// scaling stops (disabled, Preview, retarget, DPA deletion), even if the DPA
+// spec's TargetRef has since changed.
+type LastScaledTarget struct {
+	Namespace string
+	Name      string
+	GVK       schema.GroupVersionKind
+}
+
 // PodAutoscalerInternal holds the necessary data to work with the `DatadogPodAutoscaler` CRD.
 type PodAutoscalerInternal struct {
 	// namespace is the namespace of the PodAutoscaler
@@ -131,6 +142,17 @@ type PodAutoscalerInternal struct {
 
 	// horizontalActionSuccessCount is the number of successful horizontal actions
 	horizontalActionSuccessCount uint
+
+	// lastScaledTarget identifies the workload (ns/name/GVK) the horizontal
+	// controller most recently wrote `.spec.replicas` on, used to decide
+	// where to release the cluster agent's scale-subresource managedFields
+	// entry when the controller stops scaling (disabled, Preview, retarget,
+	// deletion). Nil means "no horizontal write has been observed since this
+	// internal state was constructed." Stored in-memory only — on controller
+	// restart this is rebuilt only after the next successful scale, which is
+	// an acceptable limitation since the next scale would re-establish the
+	// managedFields entry anyway.
+	lastScaledTarget *LastScaledTarget
 
 	// verticalLastAction is the last action taken by the Vertical Pod Autoscaler
 	verticalLastAction *datadoghqcommon.DatadogPodAutoscalerVerticalAction
@@ -803,6 +825,27 @@ func (p *PodAutoscalerInternal) HorizontalActionSuccessCount() uint {
 // HorizontalActionSuccessInc increment the number of horizontal actions that triggered a success
 func (p *PodAutoscalerInternal) HorizontalActionSuccessInc() {
 	p.horizontalActionSuccessCount++
+}
+
+// LastScaledTarget returns the workload the horizontal controller most
+// recently wrote `.spec.replicas` on, or nil if no write has been observed.
+func (p *PodAutoscalerInternal) LastScaledTarget() *LastScaledTarget {
+	return p.lastScaledTarget
+}
+
+// SetLastScaledTarget records the workload the horizontal controller just
+// successfully wrote `.spec.replicas` on. Called after every successful
+// scaler.update so the release path knows where the cluster agent's
+// managedFields entry currently lives.
+func (p *PodAutoscalerInternal) SetLastScaledTarget(target *LastScaledTarget) {
+	p.lastScaledTarget = target
+}
+
+// ClearLastScaledTarget resets the recorded last-scaled target. Called after
+// the cluster agent's managedFields entry on that target has been
+// successfully released.
+func (p *PodAutoscalerInternal) ClearLastScaledTarget() {
+	p.lastScaledTarget = nil
 }
 
 // VerticalLastAction returns the last action taken by the Vertical Pod Autoscaler

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test_utils.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test_utils.go
@@ -46,6 +46,7 @@ type FakePodAutoscalerInternal struct {
 	HorizontalLastActionError          error
 	HorizontalActionErrorCount         uint
 	HorizontalActionSuccessCount       uint
+	LastScaledTarget                   *LastScaledTarget
 	HorizontalEventsRetention          time.Duration
 	HorizontalRecommendationsRetention time.Duration
 	VerticalLastAction                 *datadoghqcommon.DatadogPodAutoscalerVerticalAction
@@ -130,6 +131,7 @@ func (f FakePodAutoscalerInternal) Build() PodAutoscalerInternal {
 		horizontalLastActionError:          f.HorizontalLastActionError,
 		horizontalActionErrorCount:         f.HorizontalActionErrorCount,
 		horizontalActionSuccessCount:       f.HorizontalActionSuccessCount,
+		lastScaledTarget:                   f.LastScaledTarget,
 		horizontalEventsRetention:          f.HorizontalEventsRetention,
 		horizontalRecommendationsRetention: f.HorizontalRecommendationsRetention,
 		verticalLastAction:                 f.VerticalLastAction,

--- a/releasenotes/notes/dpa-lastscaled-target-release-gate-af88caaa4dd7e8e7.yaml
+++ b/releasenotes/notes/dpa-lastscaled-target-release-gate-af88caaa4dd7e8e7.yaml
@@ -1,0 +1,22 @@
+---
+fixes:
+  - |
+    The workload autoscaler (``DatadogPodAutoscaler``) now releases the
+    cluster agent's ``.spec.replicas`` field-manager entry on additional
+    transitions that previously left the entry stale:
+
+    - When ``ApplyPolicy.Mode`` is switched to ``Preview`` (the
+      controller still computes recommendations but no longer writes
+      replicas, so the prior managedFields entry must be cleaned up).
+    - When ``Spec.TargetRef`` is retargeted to a different workload
+      (the release now fires against the *previously scaled* target,
+      not the new spec's target).
+
+    Release-failure handling has also been strengthened: failures now
+    surface via a DPA status condition, a Kubernetes Event, and a
+    telemetry counter; the workqueue's standard retry budget caps the
+    loop instead of hot-looping invisibly. The deletion paths
+    (remote-owned, profile-managed, local-owned) retry release up to
+    ``maxRetry`` attempts before logging an error and proceeding with
+    the delete, so a permanently broken release cannot block a user
+    from removing a DPA.


### PR DESCRIPTION
## Summary

Stacked on top of #52040 (workload autoscaler \`.spec.replicas\` ownership release). Addresses three pre-existing gaps in the autoscaler that #52040 made more visible but didn't cause:

- **Preview-mode transition** doesn't release ownership today — \`IsHorizontalScalingEnabled()\` returns true for \`ApplyPolicy.Mode==Preview\`, so the disable path's release never fires even though the controller stops writing replicas.
- **TargetRef retarget race** — if a DPA scaled deployment A and is then retargeted to deployment B (in any order with the disable), the release fires against B (no DCA entry there) while A keeps the stale entry forever.
- **Release failures are invisible** — the disable path returns \`(Requeue, nil)\` on failure with no event/condition/metric. Workqueue \`maxRetry\` guard only fires on \`err != nil\`, so a permanently broken release hot-loops indefinitely with no signal.

## What changes

- New \`LastScaledTarget\` field on \`PodAutoscalerInternal\` records (ns, name, GVK) on every successful \`scaler.update\`, cleared on successful release. Replaces the brittle \`HorizontalLastActions > 0\` gate.
- Release fires on three triggers: horizontal disabled, ApplyMode==Preview, or TargetRef retargeted (release goes to the OLD target).
- Release failures emit a Warning Event on the DPA, set a \`ConditionError\` (\`ScaleFailed\`), increment \`HorizontalActionErrorCount\`, and return \`(Requeue, err)\` so workqueue \`maxRetry\` caps the loop.
- The three delete branches retry release up to \`maxRetry\` via \`c.Workqueue.NumRequeues(key)\`; on exhaustion they log \`Errorf\` and proceed with the delete so a permanently broken release cannot block a user from removing a DPA.

## Why stacked on #52040

The state restructuring depends on the release path and helper introduced there. Targeted against \`celene/dpa-release-replicas-ownership\` to keep the diff narrow — once #52040 lands, this PR will retarget \`main\` automatically.

## Tradeoff: \`LastScaledTarget\` is in-memory only

Stored on \`PodAutoscalerInternal\` (in-memory store), not persisted in DPA status. Resets on cluster-agent restart — a DPA that's then disabled before its next successful scale won't release. Acceptable in exchange for not needing a CRD schema bump; can revisit if we hear real reports.

## Test plan

- [x] New \`TestHorizontalControllerReleaseOwnershipOnPreviewTransition\` and \`TestHorizontalControllerReleaseOwnershipOnTargetRefChange\`.
- [x] Existing release-on-disable tests rewritten to seed \`LastScaledTarget\`.
- [x] \`TestLeaderCreateDelete{Local,Remote}\` updated to seed \`LastScaledTarget\` so the delete-path release actually fires.
- [x] All workload tests + subpackages pass; \`go vet\` and \`gofmt\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)