### PR TITLE
fix(rtloader): fix wrong field nulled after free in freePyInfo

### DIFF
--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -225,7 +225,7 @@ void Three::freePyInfo(py_info_t *info)
     info->version = NULL;
     if (info->path) {
         _free(info->path);
-        info->version = NULL;
+        info->path = NULL;
     }
     _free(info);
     return;


### PR DESCRIPTION
## What does this PR do?

Fixes a wrong field assignment in `Three::freePyInfo`: changes `info->version = NULL` to `info->path = NULL` after `_free(info->path)`.

## Motivation

`info->version` was already set to NULL unconditionally above; the path pointer was freed but never nulled.

## Describe how you validated your changes

No behavioral change

## Additional Notes