### PR TITLE
[WP] Mark TestProcessExit/exit-signaled as not flaky

### DIFF
--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1884,7 +1884,6 @@ func TestProcessExit(t *testing.T) {
 
 	t.Run("exit-signaled", func(t *testing.T) {
 		SkipIfNotAvailable(t)
-		flake.MarkOnJobName(t, "ubuntu_25.10")
 
 		test.WaitSignalFromRule(t, func() error {
 			args := []string{"--preserve-status", "--signal=SIGTERM", "2", sleepExec, "9"}


### PR DESCRIPTION
### What does this PR do?

Mark TestProcessExit/exit-signaled as not flaky

### Motivation

### Describe how you validated your changes

### Additional Notes
