### PR TITLE
[CWS] Disable capabilities usage monitoring a newer kernel versions

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -390,7 +390,7 @@ func (p *EBPFProbe) sanityChecks() error {
 	}
 
 	if p.config.Probe.CapabilitiesMonitoringEnabled && !p.isCapabilitiesMonitoringSupported() {
-		seclog.Warnf("The capabilities monitoring feature of CWS requires a more recent kernel (at least 5.17), setting event_monitoring_config.capabilities_monitoring.enabled to false")
+		seclog.Warnf("The capabilities monitoring feature of CWS requires a kernel version between 5.17 and 6.13, setting event_monitoring_config.capabilities_monitoring.enabled to false")
 		p.config.Probe.CapabilitiesMonitoringEnabled = false
 	}
 

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -88,8 +88,10 @@ func IsNetworkFlowMonitorNotSupported(kv *kernel.Version) bool {
 }
 
 // IsCapabilitiesMonitoringSupported returns if the capabilities monitoring feature is supported
+// override_creds/restore_creds kernel functions must not be inlined
+// https://github.com/torvalds/linux/commit/6771e004b40962402d0e973fc7d2e0e61364fdfb
 func IsCapabilitiesMonitoringSupported(kv *kernel.Version) bool {
-	return kv.HasBPFForEachMapElemHelper()
+	return kv.HasBPFForEachMapElemHelper() && kv.Code != 0 && kv.Code < kernel.Kernel6_14
 }
 
 // NewAgentContainerContext returns the agent container context

--- a/pkg/security/tests/capabilities_test.go
+++ b/pkg/security/tests/capabilities_test.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
@@ -38,7 +39,7 @@ func TestCapabilitiesEvent(t *testing.T) {
 	})
 
 	checkKernelCompatibility(t, "no override_creds/restore_creds", func(kv *kernel.Version) bool {
-		return kv.Code >= kernel.Kernel6_14
+		return !probe.IsCapabilitiesMonitoringSupported(kv)
 	})
 
 	ruleDefs := []*rules.RuleDefinition{


### PR DESCRIPTION
### What does this PR do?

Automatically disable capabilities usage monitoring (disabled by default) on newer kernel versions.

### Motivation

Starting with kernel version 6.14, the `override_creds`/`revert_creds` kernel functions have been inlined (https://github.com/torvalds/linux/commit/6771e004b40962402d0e973fc7d2e0e61364fdfb#diff-b4ef63fea95927c16e7dede942c51cfdf3d5b6a72e133d967412d7d6588fd3d9). This prevents CWS from starting when this feature is enabled:

```
error registering HTTP endpoints for module event_monitor: failed to init probe: probes activation validation failed: AllOf requirement failed, the following probes are not running [{UID:security EBPFFuncName:hook_override_creds}: symbol 'override_creds' not found: invalid argument | {UID:security EBPFFuncName:hook_revert_creds}: symbol 'revert_creds' not found: invalid argument]
```


### Describe how you validated your changes

### Additional Notes
