### PR TITLE
[CWS] Do not reuse test module for self tests

### DIFF
--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -110,5 +110,5 @@ func withForceReload() optFunc {
 }
 
 func (to testOpts) Equal(opts testOpts) bool {
-	return reflect.DeepEqual(to, opts)
+	return reflect.DeepEqual(to, opts) && !to.enableSelfTests
 }


### PR DESCRIPTION
### What does this PR do?

Do not reuse test module when self tests are enabled

### Motivation

Self tests are executed at the test module instantiation. Reusing the test module means the self tests are not reecuted

### Describe how you validated your changes

### Additional Notes
