### PR TITLE
Add OpenLineage support to EMR init script

### DIFF
--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -284,6 +284,7 @@ type APMConfigurationDefault struct {
 	AppsecEnabled                 *bool   `yaml:"DD_APPSEC_ENABLED,omitempty"`
 	IastEnabled                   *bool   `yaml:"DD_IAST_ENABLED,omitempty"`
 	DataJobsEnabled               *bool   `yaml:"DD_DATA_JOBS_ENABLED,omitempty"`
+	DataJobsOpenLineageEnabled    *bool   `yaml:"DD_DATA_JOBS_OPENLINEAGE_ENABLED,omitempty"`
 	AppsecScaEnabled              *bool   `yaml:"DD_APPSEC_SCA_ENABLED,omitempty"`
 	LogsCollectionEnabled         *bool   `yaml:"DD_APP_LOGS_COLLECTION_ENABLED,omitempty"`
 	RumEnabled                    *bool   `yaml:"DD_RUM_ENABLED,omitempty"`

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/common"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/config"
@@ -23,7 +24,7 @@ const (
 	emrInjectorVersion    = "0.64.0-1"
 	emrJavaTracerVersion  = "1.63.0-1"
 	emrAgentVersion       = "7.79.2-1"
-	emrOpenLineageVersion = "1.24.0"
+	emrOpenLineageVersion = "1.49.0"
 	hadoopDriverFolder    = "/mnt/var/log/hadoop/steps/"
 )
 
@@ -235,11 +236,7 @@ func setupOpenLineage(s *common.Setup) {
 		return
 	}
 
-	// Download from Maven Central — default to Scala 2.12 variant, override via DD_OPENLINEAGE_SPARK_VARIANT
-	variant := os.Getenv("DD_OPENLINEAGE_SPARK_VARIANT")
-	if variant == "" {
-		variant = "_2.12"
-	}
+	variant := detectScalaVariant(s)
 	jarURL := fmt.Sprintf(
 		"https://repo1.maven.org/maven2/io/openlineage/openlineage-spark%s/%s/openlineage-spark%s-%s.jar",
 		variant, emrOpenLineageVersion, variant, emrOpenLineageVersion,
@@ -248,6 +245,28 @@ func setupOpenLineage(s *common.Setup) {
 	if _, err := common.ExecuteCommandWithTimeout(s, "curl", "-sSfL", "-o", jarDest, jarURL); err != nil {
 		log.Warnf("failed to download OpenLineage JAR: %v", err)
 	}
+}
+
+// detectScalaVariant infers the Scala binary version suffix (e.g. "_2.12") by inspecting
+// the scala-library JAR bundled in Spark's jars directory. EMR releases may use either
+// Scala 2.12 or 2.13 depending on the Spark version (e.g. EMR 8.x with Spark 8.x uses 2.13).
+// Falls back to "_2.12" with a warning if detection fails.
+func detectScalaVariant(s *common.Setup) string {
+	matches, _ := filepath.Glob(filepath.Join(openLineageJARDir, "scala-library-*.jar"))
+	if len(matches) == 0 {
+		log.Warn("Could not detect Scala variant from Spark jars directory — no scala-library-*.jar found. Falling back to Scala 2.12 for OpenLineage JAR download; set DD_OPENLINEAGE_SPARK_VARIANT to override.")
+		s.Out.WriteString("WARNING: Could not detect Scala variant, falling back to Scala 2.12 for OpenLineage JAR\n")
+		return "_2.12"
+	}
+	// e.g. "scala-library-2.12.18.jar" → "_2.12"
+	base := strings.TrimSuffix(strings.TrimPrefix(filepath.Base(matches[0]), "scala-library-"), ".jar")
+	parts := strings.SplitN(base, ".", 3)
+	if len(parts) < 2 {
+		log.Warnf("Could not parse Scala version from JAR name %q. Falling back to Scala 2.12 for OpenLineage JAR download; set DD_OPENLINEAGE_SPARK_VARIANT to override.", filepath.Base(matches[0]))
+		s.Out.WriteString("WARNING: Could not parse Scala variant from JAR name, falling back to Scala 2.12 for OpenLineage JAR\n")
+		return "_2.12"
+	}
+	return "_" + parts[0] + "." + parts[1]
 }
 
 func enableEmrLogs(s *common.Setup) {

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -25,11 +25,11 @@ const (
 	emrAgentVersion       = "7.79.2-1"
 	emrOpenLineageVersion = "1.24.0"
 	hadoopDriverFolder    = "/mnt/var/log/hadoop/steps/"
-	openLineageJARDir     = "/usr/lib/spark/jars"
 )
 
 var (
-	emrInfoPath     = "/mnt/var/lib/info"
+	emrInfoPath       = "/mnt/var/lib/info"
+	openLineageJARDir = "/usr/lib/spark/jars"
 	tracerConfigEmr = config.APMConfigurationDefault{
 		DataJobsEnabled:               config.BoolToPtr(true),
 		IntegrationsEnabled:           config.BoolToPtr(false),

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -30,7 +30,7 @@ const (
 var (
 	emrInfoPath       = "/mnt/var/lib/info"
 	openLineageJARDir = "/usr/lib/spark/jars"
-	tracerConfigEmr = config.APMConfigurationDefault{
+	tracerConfigEmr   = config.APMConfigurationDefault{
 		DataJobsEnabled:               config.BoolToPtr(true),
 		IntegrationsEnabled:           config.BoolToPtr(false),
 		DataJobsCommandPattern:        ".*org.apache.spark.deploy.*",

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -247,11 +247,15 @@ func setupOpenLineage(s *common.Setup) {
 	}
 }
 
-// detectScalaVariant infers the Scala binary version suffix (e.g. "_2.12") by inspecting
-// the scala-library JAR bundled in Spark's jars directory. EMR releases may use either
-// Scala 2.12 or 2.13 depending on the Spark version (e.g. EMR 8.x with Spark 8.x uses 2.13).
-// Falls back to "_2.12" with a warning if detection fails.
+// detectScalaVariant returns the Scala binary version suffix (e.g. "_2.12") to use when
+// downloading the OpenLineage JAR. It checks, in order:
+//  1. DD_OPENLINEAGE_SPARK_VARIANT env var — for clusters where auto-detection is unavailable
+//  2. scala-library-*.jar in Spark's jars directory — reliable on most EMR releases
+//  3. Falls back to "_2.12" with a warning (covers EMR 6.x/7.x; EMR 8.x uses 2.13)
 func detectScalaVariant(s *common.Setup) string {
+	if v := os.Getenv("DD_OPENLINEAGE_SPARK_VARIANT"); v != "" {
+		return v
+	}
 	matches, _ := filepath.Glob(filepath.Join(openLineageJARDir, "scala-library-*.jar"))
 	if len(matches) == 0 {
 		log.Warn("Could not detect Scala variant from Spark jars directory — no scala-library-*.jar found. Falling back to Scala 2.12 for OpenLineage JAR download; set DD_OPENLINEAGE_SPARK_VARIANT to override.")

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -225,7 +225,9 @@ func setupOpenLineage(s *common.Setup) {
 		return
 	}
 
-	jarDest := filepath.Join(openLineageJARDir, "openlineage-spark.jar")
+	variant := detectScalaVariant(s)
+	jarName := fmt.Sprintf("openlineage-spark%s-%s.jar", variant, emrOpenLineageVersion)
+	jarDest := filepath.Join(openLineageJARDir, jarName)
 
 	// Allow pre-staged JAR via DD_OPENLINEAGE_JAR_PATH for VPCs without internet
 	if jarPath := os.Getenv("DD_OPENLINEAGE_JAR_PATH"); jarPath != "" {
@@ -236,10 +238,9 @@ func setupOpenLineage(s *common.Setup) {
 		return
 	}
 
-	variant := detectScalaVariant(s)
 	jarURL := fmt.Sprintf(
-		"https://repo1.maven.org/maven2/io/openlineage/openlineage-spark%s/%s/openlineage-spark%s-%s.jar",
-		variant, emrOpenLineageVersion, variant, emrOpenLineageVersion,
+		"https://repo1.maven.org/maven2/io/openlineage/openlineage-spark%s/%s/%s",
+		variant, emrOpenLineageVersion, jarName,
 	)
 	s.Out.WriteString(fmt.Sprintf("Downloading OpenLineage JAR v%s\n", emrOpenLineageVersion))
 	if _, err := common.ExecuteCommandWithTimeout(s, "curl", "-sSfL", "-o", jarDest, jarURL); err != nil {

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -20,10 +20,12 @@ import (
 )
 
 const (
-	emrInjectorVersion   = "0.64.0-1"
-	emrJavaTracerVersion = "1.63.0-1"
-	emrAgentVersion      = "7.79.2-1"
-	hadoopDriverFolder   = "/mnt/var/log/hadoop/steps/"
+	emrInjectorVersion    = "0.64.0-1"
+	emrJavaTracerVersion  = "1.63.0-1"
+	emrAgentVersion       = "7.79.2-1"
+	emrOpenLineageVersion = "1.24.0"
+	hadoopDriverFolder    = "/mnt/var/log/hadoop/steps/"
+	openLineageJARDir     = "/usr/lib/spark/jars"
 )
 
 var (
@@ -80,6 +82,7 @@ func SetupEmr(s *common.Setup) error {
 		s.Out.WriteString("Enabling Datadog Java Tracer DEBUG logs on DD_TRACE_DEBUG=true\n")
 		tracerConfigEmr.TraceDebug = config.BoolToPtr(true)
 	}
+	setupOpenLineage(s)
 	s.Config.ApplicationMonitoringYAML = &config.ApplicationMonitoringConfig{
 		Default: tracerConfigEmr,
 	}
@@ -203,6 +206,47 @@ func setEmrClusterNameSpanTags(span *telemetry.Span, source, reason, errorMessag
 	span.SetTag("cluster_name_resolution_reason", reason)
 	if errorMessage != "" {
 		span.SetTag("cluster_name_resolution_error_message", errorMessage)
+	}
+}
+
+func setupOpenLineage(s *common.Setup) {
+	if os.Getenv("DD_OPENLINEAGE_ENABLED") != "true" {
+		return
+	}
+	s.Out.WriteString("Enabling OpenLineage integration\n")
+	tracerConfigEmr.DataJobsOpenLineageEnabled = config.BoolToPtr(true)
+	s.Span.SetTag("host_tag_set.openlineage_enabled", "true")
+
+	// Check if an OpenLineage JAR is already on the classpath
+	matches, err := filepath.Glob(filepath.Join(openLineageJARDir, "openlineage-spark*.jar"))
+	if err == nil && len(matches) > 0 {
+		s.Out.WriteString(fmt.Sprintf("OpenLineage JAR already present (%s), skipping download\n", matches[0]))
+		return
+	}
+
+	jarDest := filepath.Join(openLineageJARDir, "openlineage-spark.jar")
+
+	// Allow pre-staged JAR via DD_OPENLINEAGE_JAR_PATH for VPCs without internet
+	if jarPath := os.Getenv("DD_OPENLINEAGE_JAR_PATH"); jarPath != "" {
+		s.Out.WriteString(fmt.Sprintf("Copying OpenLineage JAR from %s\n", jarPath))
+		if _, err := common.ExecuteCommandWithTimeout(s, "cp", jarPath, jarDest); err != nil {
+			log.Warnf("failed to copy OpenLineage JAR from %s: %v", jarPath, err)
+		}
+		return
+	}
+
+	// Download from Maven Central — default to Scala 2.12 variant, override via DD_OPENLINEAGE_SPARK_VARIANT
+	variant := os.Getenv("DD_OPENLINEAGE_SPARK_VARIANT")
+	if variant == "" {
+		variant = "_2.12"
+	}
+	jarURL := fmt.Sprintf(
+		"https://repo1.maven.org/maven2/io/openlineage/openlineage-spark%s/%s/openlineage-spark%s-%s.jar",
+		variant, emrOpenLineageVersion, variant, emrOpenLineageVersion,
+	)
+	s.Out.WriteString(fmt.Sprintf("Downloading OpenLineage JAR v%s\n", emrOpenLineageVersion))
+	if _, err := common.ExecuteCommandWithTimeout(s, "curl", "-sSfL", "-o", jarDest, jarURL); err != nil {
+		log.Warnf("failed to download OpenLineage JAR: %v", err)
 	}
 }
 

--- a/pkg/fleet/installer/setup/djm/emr_test.go
+++ b/pkg/fleet/installer/setup/djm/emr_test.go
@@ -127,6 +127,7 @@ func TestSetupOpenLineage_Enabled(t *testing.T) {
 	assert.Equal(t, "curl", capturedCmd)
 	expectedURL := "https://repo1.maven.org/maven2/io/openlineage/openlineage-spark_2.12/1.49.0/openlineage-spark_2.12-1.49.0.jar"
 	assert.Contains(t, capturedArgs, expectedURL)
+	assert.Contains(t, capturedArgs, filepath.Join(openLineageJARDir, "openlineage-spark_2.12-1.49.0.jar"))
 }
 
 func TestSetupOpenLineage_Disabled(t *testing.T) {

--- a/pkg/fleet/installer/setup/djm/emr_test.go
+++ b/pkg/fleet/installer/setup/djm/emr_test.go
@@ -108,7 +108,7 @@ func TestSetupOpenLineage_Enabled(t *testing.T) {
 
 	var capturedCmd string
 	var capturedArgs []string
-	common.ExecuteCommandWithTimeout = func(s *common.Setup, command string, args ...string) ([]byte, error) {
+	common.ExecuteCommandWithTimeout = func(_ *common.Setup, command string, args ...string) ([]byte, error) {
 		capturedCmd = command
 		capturedArgs = args
 		return nil, nil
@@ -152,7 +152,7 @@ func TestSetupOpenLineage_JarAlreadyPresent(t *testing.T) {
 	t.Setenv("DD_OPENLINEAGE_ENABLED", "true")
 
 	commandCalled := false
-	common.ExecuteCommandWithTimeout = func(s *common.Setup, command string, args ...string) ([]byte, error) {
+	common.ExecuteCommandWithTimeout = func(_ *common.Setup, _ string, _ ...string) ([]byte, error) {
 		commandCalled = true
 		return nil, nil
 	}
@@ -186,7 +186,7 @@ func TestSetupOpenLineage_CustomJarPath(t *testing.T) {
 
 	var capturedCmd string
 	var capturedArgs []string
-	common.ExecuteCommandWithTimeout = func(s *common.Setup, command string, args ...string) ([]byte, error) {
+	common.ExecuteCommandWithTimeout = func(_ *common.Setup, command string, args ...string) ([]byte, error) {
 		capturedCmd = command
 		capturedArgs = args
 		return nil, nil

--- a/pkg/fleet/installer/setup/djm/emr_test.go
+++ b/pkg/fleet/installer/setup/djm/emr_test.go
@@ -114,17 +114,19 @@ func TestSetupOpenLineage_Enabled(t *testing.T) {
 		return nil, nil
 	}
 
-	// Use a temp dir so the glob finds no existing JARs
 	origJARDir := openLineageJARDir
 	openLineageJARDir = t.TempDir()
 	defer func() { openLineageJARDir = origJARDir }()
+	// Place a scala-library JAR so variant detection works
+	require.NoError(t, os.WriteFile(filepath.Join(openLineageJARDir, "scala-library-2.12.18.jar"), []byte{}, 0644))
 
 	s := newTestSetup(t)
 	setupOpenLineage(s)
 
 	assert.Equal(t, config.BoolToPtr(true), tracerConfigEmr.DataJobsOpenLineageEnabled)
 	assert.Equal(t, "curl", capturedCmd)
-	assert.Contains(t, capturedArgs, "-sSfL")
+	expectedURL := "https://repo1.maven.org/maven2/io/openlineage/openlineage-spark_2.12/1.49.0/openlineage-spark_2.12-1.49.0.jar"
+	assert.Contains(t, capturedArgs, expectedURL)
 }
 
 func TestSetupOpenLineage_Disabled(t *testing.T) {
@@ -200,4 +202,28 @@ func TestSetupOpenLineage_CustomJarPath(t *testing.T) {
 	assert.Equal(t, config.BoolToPtr(true), tracerConfigEmr.DataJobsOpenLineageEnabled)
 	assert.Equal(t, "cp", capturedCmd)
 	assert.Equal(t, customJar, capturedArgs[0])
+}
+
+func TestDetectScalaVariant(t *testing.T) {
+	origJARDir := openLineageJARDir
+	defer func() { openLineageJARDir = origJARDir }()
+
+	s := newTestSetup(t)
+
+	t.Run("detects 2.12", func(t *testing.T) {
+		openLineageJARDir = t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(openLineageJARDir, "scala-library-2.12.18.jar"), []byte{}, 0644))
+		assert.Equal(t, "_2.12", detectScalaVariant(s))
+	})
+
+	t.Run("detects 2.13", func(t *testing.T) {
+		openLineageJARDir = t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(openLineageJARDir, "scala-library-2.13.12.jar"), []byte{}, 0644))
+		assert.Equal(t, "_2.13", detectScalaVariant(s))
+	})
+
+	t.Run("falls back to 2.12 when no JAR found", func(t *testing.T) {
+		openLineageJARDir = t.TempDir()
+		assert.Equal(t, "_2.12", detectScalaVariant(s))
+	})
 }

--- a/pkg/fleet/installer/setup/djm/emr_test.go
+++ b/pkg/fleet/installer/setup/djm/emr_test.go
@@ -226,4 +226,12 @@ func TestDetectScalaVariant(t *testing.T) {
 		openLineageJARDir = t.TempDir()
 		assert.Equal(t, "_2.12", detectScalaVariant(s))
 	})
+
+	t.Run("env var overrides detection", func(t *testing.T) {
+		openLineageJARDir = t.TempDir()
+		// Place a 2.12 JAR, but override to 2.13 via env var
+		require.NoError(t, os.WriteFile(filepath.Join(openLineageJARDir, "scala-library-2.12.18.jar"), []byte{}, 0644))
+		t.Setenv("DD_OPENLINEAGE_SPARK_VARIANT", "_2.13")
+		assert.Equal(t, "_2.13", detectScalaVariant(s))
+	})
 }

--- a/pkg/fleet/installer/setup/djm/emr_test.go
+++ b/pkg/fleet/installer/setup/djm/emr_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/common"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/config"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 )
 
@@ -84,4 +85,119 @@ func TestSetupEmr(t *testing.T) {
 			assert.ElementsMatch(t, tt.wantTags, s.Config.DatadogYAML.Tags)
 		})
 	}
+}
+
+func newTestSetup(t *testing.T) *common.Setup {
+	t.Helper()
+	span, _ := telemetry.StartSpanFromContext(context.Background(), "test")
+	return &common.Setup{
+		Span: span,
+		Ctx:  context.Background(),
+		Out:  &common.Output{},
+	}
+}
+
+func TestSetupOpenLineage_Enabled(t *testing.T) {
+	// Save and restore global state
+	originalExecuteCommand := common.ExecuteCommandWithTimeout
+	defer func() { common.ExecuteCommandWithTimeout = originalExecuteCommand }()
+	origConfig := tracerConfigEmr
+	defer func() { tracerConfigEmr = origConfig }()
+
+	t.Setenv("DD_OPENLINEAGE_ENABLED", "true")
+
+	var capturedCmd string
+	var capturedArgs []string
+	common.ExecuteCommandWithTimeout = func(s *common.Setup, command string, args ...string) ([]byte, error) {
+		capturedCmd = command
+		capturedArgs = args
+		return nil, nil
+	}
+
+	// Use a temp dir so the glob finds no existing JARs
+	origJARDir := openLineageJARDir
+	openLineageJARDir = t.TempDir()
+	defer func() { openLineageJARDir = origJARDir }()
+
+	s := newTestSetup(t)
+	setupOpenLineage(s)
+
+	assert.Equal(t, config.BoolToPtr(true), tracerConfigEmr.DataJobsOpenLineageEnabled)
+	assert.Equal(t, "curl", capturedCmd)
+	assert.Contains(t, capturedArgs, "-sSfL")
+}
+
+func TestSetupOpenLineage_Disabled(t *testing.T) {
+	origConfig := tracerConfigEmr
+	defer func() { tracerConfigEmr = origConfig }()
+
+	// DD_OPENLINEAGE_ENABLED not set
+	t.Setenv("DD_OPENLINEAGE_ENABLED", "false")
+
+	s := newTestSetup(t)
+	setupOpenLineage(s)
+
+	assert.Nil(t, tracerConfigEmr.DataJobsOpenLineageEnabled)
+}
+
+func TestSetupOpenLineage_JarAlreadyPresent(t *testing.T) {
+	originalExecuteCommand := common.ExecuteCommandWithTimeout
+	defer func() { common.ExecuteCommandWithTimeout = originalExecuteCommand }()
+	origConfig := tracerConfigEmr
+	defer func() { tracerConfigEmr = origConfig }()
+
+	t.Setenv("DD_OPENLINEAGE_ENABLED", "true")
+
+	commandCalled := false
+	common.ExecuteCommandWithTimeout = func(s *common.Setup, command string, args ...string) ([]byte, error) {
+		commandCalled = true
+		return nil, nil
+	}
+
+	// Create a temp dir with a fake existing JAR
+	origJARDir := openLineageJARDir
+	openLineageJARDir = t.TempDir()
+	defer func() { openLineageJARDir = origJARDir }()
+	require.NoError(t, os.WriteFile(filepath.Join(openLineageJARDir, "openlineage-spark_2.12-1.20.0.jar"), []byte{}, 0644))
+
+	s := newTestSetup(t)
+	setupOpenLineage(s)
+
+	// Tracer flag should still be set
+	assert.Equal(t, config.BoolToPtr(true), tracerConfigEmr.DataJobsOpenLineageEnabled)
+	// But no download should have been attempted
+	assert.False(t, commandCalled)
+}
+
+func TestSetupOpenLineage_CustomJarPath(t *testing.T) {
+	originalExecuteCommand := common.ExecuteCommandWithTimeout
+	defer func() { common.ExecuteCommandWithTimeout = originalExecuteCommand }()
+	origConfig := tracerConfigEmr
+	defer func() { tracerConfigEmr = origConfig }()
+
+	t.Setenv("DD_OPENLINEAGE_ENABLED", "true")
+
+	customJar := filepath.Join(t.TempDir(), "custom-ol.jar")
+	require.NoError(t, os.WriteFile(customJar, []byte{}, 0644))
+	t.Setenv("DD_OPENLINEAGE_JAR_PATH", customJar)
+
+	var capturedCmd string
+	var capturedArgs []string
+	common.ExecuteCommandWithTimeout = func(s *common.Setup, command string, args ...string) ([]byte, error) {
+		capturedCmd = command
+		capturedArgs = args
+		return nil, nil
+	}
+
+	// Use a temp dir so the glob finds no existing JARs
+	origJARDir := openLineageJARDir
+	openLineageJARDir = t.TempDir()
+	defer func() { openLineageJARDir = origJARDir }()
+
+	s := newTestSetup(t)
+	setupOpenLineage(s)
+
+	assert.Equal(t, config.BoolToPtr(true), tracerConfigEmr.DataJobsOpenLineageEnabled)
+	assert.Equal(t, "cp", capturedCmd)
+	assert.Equal(t, customJar, capturedArgs[0])
 }


### PR DESCRIPTION
### What does this PR do?

Adds OpenLineage support to the EMR init script. When `DD_OPENLINEAGE_ENABLED=true` is set:

1. Sets the `DD_DATA_JOBS_OPENLINEAGE_ENABLED=true` tracer flag via a new `DataJobsOpenLineageEnabled` field in `APMConfigurationDefault`
2. Downloads the `openlineage-spark` JAR to `/usr/lib/spark/jars/` (auto-discovered by Spark) on **all nodes** (master + workers)
3. Skips download if the JAR is already present on the classpath

To aid in unique customer setups:
1. Supports `DD_OPENLINEAGE_JAR_PATH` for pre-staged JARs in VPCs without internet access
2. Supports `DD_OPENLINEAGE_SPARK_VARIANT` to override the default Scala 2.12 variant in case the autodetection fails

### Motivation

Linear: DOIO-1

Enable OpenLineage lineage tracking for Spark jobs on EMR clusters. This is gated behind the `DD_OPENLINEAGE_ENABLED` env var and follows existing patterns (e.g., `DD_DATA_STREAMS_ENABLED`).

### Describe how you validated your changes

- Added 4 new tests covering: enabled flow with download, disabled flow, JAR already present (skip download), and custom JAR path via `DD_OPENLINEAGE_JAR_PATH`
- All existing DJM tests continue to pass

#### Testing in AWS EMR
- Validated Scala version is detected and used during installation
- Validated the following scripts work as expected in EMR ([results](https://app.datadoghq.com/data-obs/jobs?query=job_name%3Acharles%2A&fromUser=false&job_filter=spark&view=health&start=1780605299848&end=1781210099848&paused=false)):
    - Client mode emits OL events: `spark-submit --deploy-mode client --conf "spark.driver.extraJavaOptions=-Ddd.service=charles-test-emr-job" --conf "spark.executor.extraJavaOptions=-Ddd.service=charles-test-emr-job" s3://charlesyu-test-resources/script_2.12-1.0.jar`
    - Cluster mode emits OL events: `spark-submit --deploy-mode cluster --conf "spark.driver.extraJavaOptions=-Ddd.service=charles-test-emr-job" --conf "spark.executor.extraJavaOptions=-Ddd.service=charles-test-emr-job" s3://charlesyu-test-resources/script_2.12-1.0.jar`
    - OL disabled does _not_ emit OL events: `spark-submit --deploy-mode client --conf "spark.driver.extraJavaOptions=-Ddd.service=charles-test-emr-job -Ddd.data.jobs.openlineage.enabled=false" --conf "spark.executor.extraJavaOptions=-Ddd.service=charles-test-emr-job" s3://charlesyu-test-resources/script_2.12-1.0.jar`

### Additional Notes

- OpenLineage JAR version is pinned at `1.49.0` as a constant (`emrOpenLineageVersion`)
- Downloads from Maven Central; can switch to Datadog-hosted later if needed
- The 10s `ExecuteCommandWithTimeout` may be tight for large JAR downloads on slow connections — a follow-up could add a longer timeout for this specific call