### PR TITLE
enable RC BTF by default

### DIFF
--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -511,7 +511,7 @@ properties:
       remote_config_btf_enabled:
         node_type: setting
         type: boolean
-        default: false
+        default: true
         env_vars:
         - DD_SYSTEM_PROBE_REMOTE_CONFIG_BTF_ENABLED
         tags: []

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -134,7 +134,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("system_probe_config.enable_co_re", true, "DD_ENABLE_CO_RE")
 	cfg.BindEnvAndSetDefault("system_probe_config.btf_path", "", "DD_SYSTEM_PROBE_BTF_PATH")
 	cfg.BindEnvAndSetDefault("system_probe_config.btf_output_dir", defaultBTFOutputDir, "DD_SYSTEM_PROBE_BTF_OUTPUT_DIR")
-	cfg.BindEnvAndSetDefault("system_probe_config.remote_config_btf_enabled", false, "DD_SYSTEM_PROBE_REMOTE_CONFIG_BTF_ENABLED")
+	cfg.BindEnvAndSetDefault("system_probe_config.remote_config_btf_enabled", true, "DD_SYSTEM_PROBE_REMOTE_CONFIG_BTF_ENABLED")
 	cfg.BindEnvAndSetDefault("system_probe_config.enable_runtime_compiler", false, "DD_ENABLE_RUNTIME_COMPILER")
 	// deprecated in favor of allow_prebuilt_fallback below
 	cfg.BindEnvAndSetDefault("system_probe_config.allow_precompiled_fallback", false, "DD_ALLOW_PRECOMPILED_FALLBACK")

--- a/releasenotes/notes/sysprobe-rc-btf-default-652a26ca81ee6bfd.yaml
+++ b/releasenotes/notes/sysprobe-rc-btf-default-652a26ca81ee6bfd.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    System Probe will now download BTF (BPF Type Format) data, if needed, to support eBPF-based features.
+    This behavior will only take effect in environments where the Linux kernel is newer than the Agent release
+    and BTF is not available directly from the kernel.


### PR DESCRIPTION
### What does this PR do?

Enables Remote Config downloading of BTF by default, when necessary.

### Motivation

Supporting eBPF features on bleeding edge kernel updates that do not also expose BTF data directly from the kernel.

### Describe how you validated your changes

### Additional Notes

If for some reason we are not ready on the backend before the release is ready, we will submit a patch during the release candidate process to disable this feature.
