### PR TITLE
test(e2e): mark DDOT installer autorestart as flaky

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -31,5 +31,10 @@ test/new-e2e/tests/containers:
 test/new-e2e/tests/sbom:
   - test: TestSBOMKindSuite/TestSBOM
 
+# TODO: https://app.datadoghq.com/incidents/55979
+test/new-e2e/tests/installer/unix:
+  - test: TestPackages/ddot_debian_12_x86_64_install_script/TestInstallDDOTInstaller
+    on-log: "auto-restart"
+
 on-log:
   - "panic: Expected to find a single pod" # K8s Agent Executor can be flaky with the current implementation


### PR DESCRIPTION
### What does this PR do?

Marks the DDOT installer package E2E case as flaky only when the failure log contains the observed `auto-restart` service state.

### Motivation
[#incident-55979](https://dd.enterprise.slack.com/archives/C0B9DFV88Q3)

The `new-e2e-installer` job has recurring failures tracked in https://app.datadoghq.com/incidents/55979 where `datadog-agent-ddot.service` starts and then exits/restarts, producing an assertion like expected `running` got `auto-restart`.

Datadog MCP pipeline and test-event data confirmed the recurring failure pattern, but the indexed CI data did not retain the DDOT service journal payload needed to confirm the process-level root cause. This keeps CI unblocked while preserving unrelated failures for this test.

### Describe how you validated your changes

- `python3 -c "import yaml; yaml.safe_load(open('flakes.yaml'))"`
- `python3 -m pytest tasks/unit_tests/testwasher_tests.py tasks/unit_tests/flakes_tests.py`
