### PR TITLE
system-probe(-lite): log and graceful exit on unwritable system-probe socket paths

### DIFF
--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -106,6 +106,8 @@ type spLiteExecCmd struct {
 // configPrefix is the system-probe config namespace (avoids importing pkg/system-probe/config and its setup dependency cycle).
 const configPrefix = "system_probe_config."
 
+const socketPathNotWritableMessage = "cannot create system-probe socket at %s: path is not writable; set DD_SYSPROBE_SOCKET or system_probe_config.sysprobe_socket to a writable directory"
+
 // configstreamConsumerEnabledEnvVar is the environment variable that controls whether the configstream consumer is enabled.
 const configstreamConsumerEnabledEnvVar = "DD_REMOTE_AGENT_CONFIGSTREAM_CONSUMER_ENABLED"
 
@@ -354,6 +356,13 @@ func run(
 			time.Sleep(5 * time.Second)
 			return nil
 		}
+		if isSocketPathNotWritable(err) {
+			socketPath := deps.SysprobeConfig.GetString("system_probe_config.sysprobe_socket")
+			_ = deps.Log.Criticalf(socketPathNotWritableMessage+": %v", socketPath, err)
+			deps.Log.Flush()
+			// Exit 0 so supervisors that restart only on failure do not loop on this configuration error.
+			return nil
+		}
 		return err
 	}
 	return <-stopCh
@@ -417,9 +426,17 @@ func startSystemProbe(rcclient rcclient.Component, settings settings.Component, 
 	}
 
 	if err = api.StartServer(cfg, settings, rcclient, deps); err != nil {
-		return deps.Log.Criticalf("error while starting api server, exiting: %v", err)
+		if isSocketPathNotWritable(err) {
+			return err
+		}
+		_ = deps.Log.Criticalf("error while starting api server, exiting: %v", err)
+		return fmt.Errorf("error while starting api server, exiting: %w", err)
 	}
 	return nil
+}
+
+func isSocketPathNotWritable(err error) bool {
+	return errors.Is(err, syscall.EROFS) || errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.EPERM)
 }
 
 // stopSystemProbe Tears down the system-probe process

--- a/cmd/system-probe/subcommands/run/command_test.go
+++ b/cmd/system-probe/subcommands/run/command_test.go
@@ -6,11 +6,15 @@
 package run
 
 import (
+	"fmt"
 	_ "net/http/pprof"
+	"os"
+	"syscall"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRunCommand(t *testing.T) {
@@ -19,4 +23,49 @@ func TestRunCommand(t *testing.T) {
 		[]string{"run"},
 		run,
 		func() {})
+}
+
+func TestSocketPathNotWritableClassification(t *testing.T) {
+	for _, errno := range []syscall.Errno{syscall.EROFS, syscall.EACCES, syscall.EPERM} {
+		t.Run(errno.Error(), func(t *testing.T) {
+			err := fmt.Errorf("uds: listen: %w", &os.PathError{
+				Op:   "bind",
+				Path: "/readonly/sysprobe.sock",
+				Err:  errno,
+			})
+
+			assert.True(t, isSocketPathNotWritable(err))
+			assert.ErrorIs(t, err, errno)
+			assert.True(t, isSocketPathNotWritable(fmt.Errorf("failed to create listener: %w", err)))
+		})
+	}
+}
+
+func TestSocketPathNotWritableClassificationExcludesOtherSocketErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "address in use",
+			err: &os.SyscallError{
+				Syscall: "bind",
+				Err:     syscall.EADDRINUSE,
+			},
+		},
+		{
+			name: "invalid argument",
+			err: &os.SyscallError{
+				Syscall: "bind",
+				Err:     syscall.EINVAL,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := fmt.Errorf("uds: listen: %w", tc.err)
+			assert.False(t, isSocketPathNotWritable(err))
+		})
+	}
 }

--- a/pkg/discovery/module/rust/src/main.rs
+++ b/pkg/discovery/module/rust/src/main.rs
@@ -22,10 +22,11 @@
 use std::env;
 use std::fs::Permissions;
 use std::io::ErrorKind;
+use std::os::unix::fs::FileTypeExt;
 use std::os::unix::fs::{PermissionsExt, chown};
 use std::path::Path;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use dd_discovery::{Params, get_services};
 
 use http_body_util::combinators::BoxBody;
@@ -62,15 +63,20 @@ fn remove_pid_file(path: &Path) {
 }
 
 fn setup_socket(socket_path: &str) -> Result<UnixListener> {
-    std::fs::remove_file(socket_path)
-        .or_else(|error| {
-            if error.kind() == ErrorKind::NotFound {
-                Ok(())
-            } else {
-                Err(error)
+    match std::fs::symlink_metadata(socket_path) {
+        Ok(metadata) => {
+            if !metadata.file_type().is_socket() {
+                bail!("path already exists and it is not a UNIX socket");
             }
-        })
-        .context("failed to remove existing socket")?;
+
+            std::fs::remove_file(socket_path).context("failed to remove existing socket")?;
+        }
+        Err(error) => {
+            if error.kind() != ErrorKind::NotFound {
+                return Err(error).context("failed to stat existing socket");
+            }
+        }
+    }
 
     let sock = UnixListener::bind(socket_path).context("could not create socket")?;
     std::fs::set_permissions(socket_path, Permissions::from_mode(0o720))
@@ -90,6 +96,23 @@ fn setup_socket(socket_path: &str) -> Result<UnixListener> {
     }
 
     Ok(sock)
+}
+
+fn is_socket_setup_path_not_writable(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(is_not_writable_io_error)
+    })
+}
+
+fn is_not_writable_io_error(err: &std::io::Error) -> bool {
+    const EPERM: i32 = 1;
+    const EACCES: i32 = 13;
+    const EROFS: i32 = 30;
+
+    matches!(err.raw_os_error(), Some(EPERM | EACCES | EROFS))
+        || err.kind() == ErrorKind::PermissionDenied
 }
 
 /// Drops all Linux capabilities except CAP_SYS_PTRACE and CAP_DAC_READ_SEARCH
@@ -355,7 +378,17 @@ where
 
 async fn run_system_probe_lite(socket_path: &str) -> Result<()> {
     info!("Using sysprobe socket path: {}", socket_path);
-    let sock = setup_socket(socket_path).context("Failed to setup Unix socket")?;
+    let sock = match setup_socket(socket_path) {
+        Ok(sock) => sock,
+        Err(err) if is_socket_setup_path_not_writable(&err) => {
+            error!(
+                "cannot create system-probe socket at {socket_path}: path is not writable; \
+                 set DD_SYSPROBE_SOCKET or system_probe_config.sysprobe_socket to a writable directory: {err:#}",
+            );
+            return Ok(());
+        }
+        Err(err) => return Err(err.context("Failed to setup Unix socket")),
+    };
 
     drop_capabilities();
 
@@ -548,5 +581,52 @@ mod tests {
             !nonexistent_path.exists(),
             "Nonexistent file should remain nonexistent"
         );
+    }
+
+    #[test]
+    fn test_socket_setup_not_writable_classification() {
+        for errno in [1, 13, 30] {
+            let err = anyhow::Error::new(std::io::Error::from_raw_os_error(errno))
+                .context("could not create socket");
+
+            assert!(
+                is_socket_setup_path_not_writable(&err),
+                "errno {errno} should be classified as not writable"
+            );
+        }
+    }
+
+    #[test]
+    fn test_socket_setup_not_writable_excludes_other_errors() {
+        for errno in [22, 98] {
+            let err = anyhow::Error::new(std::io::Error::from_raw_os_error(errno))
+                .context("could not create socket");
+
+            assert!(
+                !is_socket_setup_path_not_writable(&err),
+                "errno {errno} should not be classified as not writable"
+            );
+        }
+    }
+
+    #[test]
+    fn test_setup_socket_rejects_regular_file_without_not_writable_classification() {
+        let temp_dir =
+            TempDir::new().unwrap_or_else(|e| panic!("Failed to create temp dir: {}", e));
+        let socket_path = temp_dir.path().join("sysprobe.sock");
+        fs::write(&socket_path, "not a socket")
+            .unwrap_or_else(|e| panic!("Failed to create regular file: {}", e));
+
+        let socket_path = socket_path.to_string_lossy().into_owned();
+        let result = setup_socket(&socket_path);
+
+        assert!(result.is_err(), "regular file should not be reused");
+        if let Err(err) = result {
+            let err: anyhow::Error = err.into();
+            assert!(
+                !is_socket_setup_path_not_writable(&err),
+                "regular file at socket path should not be classified as not writable"
+            );
+        }
     }
 }

--- a/pkg/system-probe/api/server/listener_unix.go
+++ b/pkg/system-probe/api/server/listener_unix.go
@@ -32,17 +32,17 @@ func NewListener(socketAddr string) (net.Listener, error) {
 		}
 		// Attempt to remove the pre-existing socket
 		if err = os.Remove(socketAddr); err != nil {
-			return nil, fmt.Errorf("uds: remove stale UNIX socket: %v", err)
+			return nil, fmt.Errorf("uds: remove stale UNIX socket: %w", err)
 		}
 	}
 
 	conn, err := net.Listen("unix", socketAddr)
 	if err != nil {
-		return nil, fmt.Errorf("listen: %s", err)
+		return nil, fmt.Errorf("listen: %w", err)
 	}
 
 	if err := os.Chmod(socketAddr, 0720); err != nil {
-		return nil, fmt.Errorf("socket chmod write-only: %s", err)
+		return nil, fmt.Errorf("socket chmod write-only: %w", err)
 	}
 
 	perms, err := filesystem.NewPermission()
@@ -51,7 +51,7 @@ func NewListener(socketAddr string) (net.Listener, error) {
 	}
 
 	if err := perms.RestrictAccessToUser(socketAddr); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("restrict socket access: %w", err)
 	}
 
 	log.Debugf("uds: %s successfully initialized", conn.Addr())


### PR DESCRIPTION
### What does this PR do?

This PR adds more explicit logging & graceful exit to SP/SPL.

When the socket path is not writable, SP/SPL will now:
- Log the issue explicitly, with suggestion to change the socket path to a writable path.
- Exit with a status 0, to prevent unwanted restart loops.

### Motivation

Part of resolution of AGENT-16332: with the recent default enablement of discovery and SPL, SPL was found crashing on ECS fargate due to the socket path not being writable.

It was suggested to make system-probe(-lite) exit more gracefully in that case, and with a more explicit log message, which this PR adds to both SP & SPL.

### Describe how you validated your changes

Unit tests

### Additional Notes
