### PR TITLE
fix(e2e): align DDOT installer OCI test with procmgr-supervised DDOT

### DIFF
--- a/test/new-e2e/tests/installer/unix/package_ddot_test.go
+++ b/test/new-e2e/tests/installer/unix/package_ddot_test.go
@@ -106,12 +106,13 @@ func (s *packageDDOTSuite) TestInstallDDOTInstaller() {
 	// Check if datadog.yaml exists, if not return an error
 	s.host.Run("sudo test -f /etc/datadog-agent/datadog.yaml || { echo 'Error: datadog.yaml does not exist'; exit 1; }")
 
-	s.host.WaitForUnitActive(s.T(), ddotUnit)
+	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit, procmgrUnit)
 
 	state := s.host.State()
-	// Verify running
 	s.assertCoreUnits(state, true)
-	s.assertDDOTUnits(state, false)
+	// Extension DDOT runs under dd-procmgrd; datadog-agent-ddot.service stays loaded but not the active supervisor.
+	state.AssertUnitsLoaded(ddotUnit)
+	state.AssertUnitsDead(ddotUnit)
 
 	// Verify files exist
 	state.AssertFileExists("/etc/datadog-agent/datadog.yaml", 0640, "dd-agent", "dd-agent")
@@ -121,6 +122,9 @@ func (s *packageDDOTSuite) TestInstallDDOTInstaller() {
 	state.AssertFileExists("/opt/datadog-packages/datadog-agent-ddot/stable/embedded/bin/otel-agent", 0755, "dd-agent", "dd-agent")
 
 	s.host.Run("sudo grep -q 'otelcollector:' /etc/datadog-agent/datadog.yaml")
+
+	ddot.AssertDDOTManagedByProcmgr(s.T(), s.Env().RemoteHost)
+	ddot.AssertProcmgrDDOTTelemetry(s.T(), s.Env().RemoteHost)
 }
 
 func (s *packageDDOTSuite) TestInstallDDOTWithoutDatadogYAML() {
@@ -255,29 +259,4 @@ func (s *packageDDOTSuite) assertCoreUnits(state host.State, oldUnits bool) {
 	for _, unit := range []string{agentUnit, traceUnit, procmgrUnit, processUnit, probeUnit, securityUnit} {
 		s.host.AssertUnitProperty(unit, "FragmentPath", filepath.Join(systemdPath, unit))
 	}
-}
-
-// Verify ddot service running
-func (s *packageDDOTSuite) assertDDOTUnits(state host.State, oldUnits bool) {
-	state.AssertUnitsLoaded(ddotUnit)
-	state.AssertUnitsRunning(ddotUnit)
-
-	systemdPath := "/etc/systemd/system"
-	if oldUnits {
-		pkgManager := s.host.GetPkgManager()
-		switch pkgManager {
-		case "apt":
-			if s.os.Flavor == e2eos.Ubuntu {
-				systemdPath = "/usr/lib/systemd/system"
-			} else {
-				systemdPath = "/lib/systemd/system"
-			}
-		case "yum", "zypper":
-			systemdPath = "/usr/lib/systemd/system"
-		default:
-			s.T().Fatalf("unsupported package manager: %s", pkgManager)
-		}
-	}
-
-	s.host.AssertUnitProperty(ddotUnit, "FragmentPath", filepath.Join(systemdPath, ddotUnit))
 }

--- a/test/new-e2e/tests/installer/unix/package_ddot_test.go
+++ b/test/new-e2e/tests/installer/unix/package_ddot_test.go
@@ -106,13 +106,11 @@ func (s *packageDDOTSuite) TestInstallDDOTInstaller() {
 	// Check if datadog.yaml exists, if not return an error
 	s.host.Run("sudo test -f /etc/datadog-agent/datadog.yaml || { echo 'Error: datadog.yaml does not exist'; exit 1; }")
 
-	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit, procmgrUnit)
+	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit, procmgrUnit, ddotUnit)
 
 	state := s.host.State()
 	s.assertCoreUnits(state, true)
-	// Extension DDOT runs under dd-procmgrd; datadog-agent-ddot.service stays loaded but not the active supervisor.
-	state.AssertUnitsLoaded(ddotUnit)
-	state.AssertUnitsDead(ddotUnit)
+	s.assertDDOTUnits(state, false)
 
 	// Verify files exist
 	state.AssertFileExists("/etc/datadog-agent/datadog.yaml", 0640, "dd-agent", "dd-agent")
@@ -122,9 +120,6 @@ func (s *packageDDOTSuite) TestInstallDDOTInstaller() {
 	state.AssertFileExists("/opt/datadog-packages/datadog-agent-ddot/stable/embedded/bin/otel-agent", 0755, "dd-agent", "dd-agent")
 
 	s.host.Run("sudo grep -q 'otelcollector:' /etc/datadog-agent/datadog.yaml")
-
-	ddot.AssertDDOTManagedByProcmgr(s.T(), s.Env().RemoteHost)
-	ddot.AssertProcmgrDDOTTelemetry(s.T(), s.Env().RemoteHost)
 }
 
 func (s *packageDDOTSuite) TestInstallDDOTWithoutDatadogYAML() {
@@ -259,4 +254,29 @@ func (s *packageDDOTSuite) assertCoreUnits(state host.State, oldUnits bool) {
 	for _, unit := range []string{agentUnit, traceUnit, procmgrUnit, processUnit, probeUnit, securityUnit} {
 		s.host.AssertUnitProperty(unit, "FragmentPath", filepath.Join(systemdPath, unit))
 	}
+}
+
+// Verify ddot service running
+func (s *packageDDOTSuite) assertDDOTUnits(state host.State, oldUnits bool) {
+	state.AssertUnitsLoaded(ddotUnit)
+	state.AssertUnitsRunning(ddotUnit)
+
+	systemdPath := "/etc/systemd/system"
+	if oldUnits {
+		pkgManager := s.host.GetPkgManager()
+		switch pkgManager {
+		case "apt":
+			if s.os.Flavor == e2eos.Ubuntu {
+				systemdPath = "/usr/lib/systemd/system"
+			} else {
+				systemdPath = "/lib/systemd/system"
+			}
+		case "yum", "zypper":
+			systemdPath = "/usr/lib/systemd/system"
+		default:
+			s.T().Fatalf("unsupported package manager: %s", pkgManager)
+		}
+	}
+
+	s.host.AssertUnitProperty(ddotUnit, "FragmentPath", filepath.Join(systemdPath, ddotUnit))
 }


### PR DESCRIPTION
### What does this PR do?

Updates `TestInstallDDOTInstaller` in `test/new-e2e/tests/installer/unix/package_ddot_test.go` so it matches the other DDOT installer tests: DDOT is supervised by **dd-procmgr**, so `datadog-agent-ddot.service` should be **loaded but dead**, not active with SubState `running`. Removes the obsolete `assertDDOTUnits` helper that enforced the old “ddot systemd unit running” model. Adds `AssertDDOTManagedByProcmgr` and `AssertProcmgrDDOTTelemetry` for the same coverage as `TestInstallDDOTSubcommand`.

### Motivation

`TestInstallDDOTInstaller` still waited for `datadog-agent-ddot.service` to be active and asserted `SubState == running`. With DDOT under procmgr, that unit can sit in **`auto-restart`** while the real workload runs under procmgr, which broke CI (e.g. `ddot_debian_12_x86_64_install_script/TestInstallDDOTInstaller`).

### Describe how you validated your changes

- Pre-commit hooks passed on commit (`go-fmt`, etc.).
- E2E `TestPackages/.../TestInstallDDOTInstaller` on the installer unix suite.

### Additional Notes

None.