### PR TITLE
Replace git_override with archive_override rules

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -82,10 +82,11 @@ single_version_override(
 )
 
 # Temporary until rules_pkg > 1.2.0 is in BCR
-git_override(
+archive_override(
     module_name = "rules_pkg",
-    commit = "401969d4367c42dcbb45d33a637eae87788d025e",  # main as of April 22, 2026
-    remote = "https://github.com/bazelbuild/rules_pkg.git",
+    sha256 = "9923c6c8855b153f837a953760159908507f571b4b77cb24ed862dda1de20f90",
+    strip_prefix = "rules_pkg-401969d4367c42dcbb45d33a637eae87788d025e",
+    urls = ["https://github.com/bazelbuild/rules_pkg/archive/401969d4367c42dcbb45d33a637eae87788d025e.tar.gz"],  # main as of April 22, 2026
 )
 
 # Pinned past the 0.69.0 release to pick up the Windows-GNU ABI support from
@@ -93,22 +94,23 @@ git_override(
 # emission split by abi). Required because our Windows cc_toolchain is MinGW
 # (@winlibs_mingw64), and the 0.69.0 stable release still hard-codes MSVC
 # behavior for `target_os == "windows"`.
-git_override(
+archive_override(
     module_name = "rules_rust",
-    commit = "f31db8b6f124dd5eebdd0ed8de4daf20d4d9685f",  # main as of April 27, 2026 (includes #3940 + #3990)
     patch_strip = 1,
     patches = [
         # Derives `-Cdlltool=<linker-dir>/dlltool.exe` automatically
         "//bazel/patches:rules_rust-derive-dlltool-from-linker.patch",
     ],
-    remote = "https://github.com/bazelbuild/rules_rust.git",
+    sha256 = "784ff0ef0334b37d88da8a08a29cd58d5896d88b82643ee3207ef5e8076c27b2",
+    strip_prefix = "rules_rust-f31db8b6f124dd5eebdd0ed8de4daf20d4d9685f",
+    urls = ["https://github.com/bazelbuild/rules_rust/archive/f31db8b6f124dd5eebdd0ed8de4daf20d4d9685f.tar.gz"],  # main as of April 27, 2026 (includes #3940 + #3990)
 )
 
-git_override(
+archive_override(
     module_name = "rules_rust_prost",
-    commit = "f31db8b6f124dd5eebdd0ed8de4daf20d4d9685f",
-    remote = "https://github.com/bazelbuild/rules_rust.git",
-    strip_prefix = "extensions/prost",
+    sha256 = "784ff0ef0334b37d88da8a08a29cd58d5896d88b82643ee3207ef5e8076c27b2",
+    strip_prefix = "rules_rust-f31db8b6f124dd5eebdd0ed8de4daf20d4d9685f/extensions/prost",
+    urls = ["https://github.com/bazelbuild/rules_rust/archive/f31db8b6f124dd5eebdd0ed8de4daf20d4d9685f.tar.gz"],
 )
 
 #########################
@@ -213,9 +215,8 @@ use_repo(linux_headers_ext, "linux_headers", "linux_headers_aarch64", "linux_hea
 ## Compilers and toolchains        ##
 ####################################
 
-git_override(
+archive_override(
     module_name = "gcc_toolchain",
-    commit = "cd3e7ee1027a3ecc8b89dc61eb485299ed833399",
     patch_args = ["-p1"],
     patches = [
         "//bazel/patches:gcc-toolchain/0001-adapt-to-our-ctng-toolchain.patch",
@@ -223,7 +224,9 @@ git_override(
         "//bazel/patches:gcc-toolchain/0003-add-nostdinc-to-asmflags.patch",
         "//bazel/patches:gcc-toolchain/0005-fix-bazel-9-compat.patch",
     ],
-    remote = "https://github.com/f0rmiga/gcc-toolchain.git",
+    sha256 = "c7a6674abbf309d2ed5fb2cf6a03aca1e4f357a6f287de2cf21ace856a08f6c2",
+    strip_prefix = "gcc-toolchain-cd3e7ee1027a3ecc8b89dc61eb485299ed833399",
+    urls = ["https://github.com/f0rmiga/gcc-toolchain/archive/cd3e7ee1027a3ecc8b89dc61eb485299ed833399.tar.gz"],
 )
 
 gcc_toolchains = use_extension("@gcc_toolchain//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -76,9 +76,8 @@ http_archive(
 # - bazel-contrib/rules_foreign_cc#1493: load CcSharedLibraryInfo from rules_cc (Bazel 9)
 # - bazel-contrib/rules_foreign_cc#1492: bump bazel_skylib_gazelle_plugin to 1.9.0 (Bazel 9)
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
-git_override(
+archive_override(
     module_name = "rules_foreign_cc",
-    commit = "7e486222f4899ea22f6f7b689534fc8b9e54b575",
     patch_strip = 1,
     patches = [
         # https://github.com/bazel-contrib/rules_foreign_cc/pull/1452
@@ -90,7 +89,9 @@ git_override(
         # finding a general solution that could be properly upstreamed
         "//bazel/patches:rules_foreign_cc/0004-Pass-cc-flags-as-CPPFLAGS.patch",
     ],
-    remote = "https://github.com/bazel-contrib/rules_foreign_cc",
+    sha256 = "7bdc037346ba96222f53907893329efc0586aaf46703f87e6084e1770a967f41",
+    strip_prefix = "rules_foreign_cc-7e486222f4899ea22f6f7b689534fc8b9e54b575",
+    urls = ["https://github.com/bazel-contrib/rules_foreign_cc/archive/7e486222f4899ea22f6f7b689534fc8b9e54b575.tar.gz"],
 )
 
 register_toolchains(


### PR DESCRIPTION
### What does this PR do?

It replaces all `git_override` repository rules with `archive_override` equivalents.

### Motivation

Git based repository rules are susceptible to line ending differences when checked out via git (CRLF vs LF), which I think may rely on global settings and can't be controled via bazel. This causes unwanted MODULE.bazel.lock changes (for bzlTransitiveDigest on module extensions) while working on Windows, an example being the entry for `"@@rules_pkg+//toolchains/rpm:rpmbuild_configure.bzl%find_system_rpmbuild_bzlmod"`.

### Describe how you validated your changes

Running `bazel mod tidy` from a windows machine, before and after the change, confirms that this solves this specific source of unwanted lockfile changes.

### Additional Notes

This is a bit of a tradeoff in convenience for specifying overrides, but there's no other obvious way to solve this problem.

Running `bazel mod tidy` I also realized that `//bazel/tools:bazelisk_check.bzl%bazelisk_check` also faces this problem, probably because it has `recordedInputs` that are not under this gitattributes setting:
https://github.com/DataDog/datadog-agent/blob/368a38c25318084d7b6a4bb89ba43ea89c07209c/.gitattributes#L31-L34

That would need a separate solution.
