### PR TITLE
[anomalydetection] Add stdout verbosity config for reports

### DIFF
--- a/comp/anomalydetection/reporter/impl/reporter.go
+++ b/comp/anomalydetection/reporter/impl/reporter.go
@@ -66,9 +66,11 @@ func NewComponent(req Requires) (Provides, error) {
 		emittedCounter:  emittedCounter,
 		seenCorrelation: make(map[string]bool),
 		activeBefore:    make(map[string]bool),
+		stdoutEnabled:   req.Config.GetBool("anomaly_detection.reporting.stdout.enabled"),
+		stdoutVerbose:   req.Config.GetBool("anomaly_detection.reporting.stdout.verbose"),
 	}}
 
-	if req.Config.GetBool("anomaly_detection.reporting.enabled") {
+	if req.Config.GetBool("anomaly_detection.reporting.events.enabled") {
 		forwarder, ok := req.EventPlatform.Get()
 		if !ok {
 			req.Log.Warnf("[reporter] event_reporter disabled: event-platform forwarder is not running")
@@ -96,6 +98,12 @@ type stdoutReporter struct {
 	// activeBefore holds patterns that were in ActiveCorrelations last advance,
 	// used to detect when a pattern goes inactive for recurrence cleanup.
 	activeBefore map[string]bool
+	// stdoutEnabled gates all [observer] stdout log lines.
+	// Controlled by anomaly_detection.reporting.stdout.enabled (default: true).
+	stdoutEnabled bool
+	// stdoutVerbose prints individual anomaly series lines after the title.
+	// Controlled by anomaly_detection.reporting.stdout.verbose (default: false).
+	stdoutVerbose bool
 }
 
 func (r *stdoutReporter) Name() string { return "stdout_reporter" }
@@ -110,8 +118,17 @@ func (r *stdoutReporter) Report(output reporterdef.ReportOutput) bool {
 	newlyEmitted := make(map[string]bool)
 	for _, ac := range output.CorrelationHistory {
 		if !r.seenCorrelation[ac.Pattern] {
-			r.logger.Infof("[observer] anomaly detection report: pattern=%s title=%q members=%d",
-				ac.Pattern, ac.Title, len(ac.Members))
+			if r.stdoutEnabled {
+				r.logger.Infof("[observer] anomaly detection report: pattern=%s title=%q members=%d",
+					ac.Pattern, ac.Title, len(ac.Members))
+				if r.stdoutVerbose {
+					for _, a := range ac.Anomalies {
+						ts := time.Unix(a.Timestamp, 0).UTC().Format(time.RFC3339)
+						r.logger.Infof("[observer]   - %s [%s] at %s",
+							a.Source.DisplayName(), a.DetectorName, ts)
+					}
+				}
+			}
 			r.emittedCounter.Add(1)
 			r.seenCorrelation[ac.Pattern] = true
 			newlyEmitted[ac.Pattern] = true
@@ -122,8 +139,10 @@ func (r *stdoutReporter) Report(output reporterdef.ReportOutput) bool {
 	hasOngoing := false
 	for _, ac := range output.ActiveCorrelations {
 		if !newlyEmitted[ac.Pattern] {
-			r.logger.Debugf("[observer] ongoing anomaly correlation: pattern=%s members=%d",
-				ac.Pattern, len(ac.Members))
+			if r.stdoutEnabled {
+				r.logger.Debugf("[observer] ongoing anomaly correlation: pattern=%s members=%d",
+					ac.Pattern, len(ac.Members))
+			}
 			hasOngoing = true
 		}
 	}
@@ -132,10 +151,12 @@ func (r *stdoutReporter) Report(output reporterdef.ReportOutput) bool {
 	}
 
 	// Debug log for raw new anomalies detected this cycle.
-	for _, a := range output.NewAnomalies {
-		ts := time.Unix(a.Timestamp, 0).UTC().Format(time.RFC3339)
-		r.logger.Debugf("[observer] anomaly detected: source=%s detector=%s at=%s",
-			a.Source.DisplayName(), a.DetectorName, ts)
+	if r.stdoutEnabled {
+		for _, a := range output.NewAnomalies {
+			ts := time.Unix(a.Timestamp, 0).UTC().Format(time.RFC3339)
+			r.logger.Debugf("[observer] anomaly detected: source=%s detector=%s at=%s",
+				a.Source.DisplayName(), a.DetectorName, ts)
+		}
 	}
 
 	// Recurrence cleanup: a pattern that was active before and is no longer active

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -6266,12 +6266,29 @@ properties:
         node_type: section
         type: object
         properties:
-          enabled:
-            node_type: setting
-            type: boolean
-            default: false
-            comment: Anomaly event reporting. Keep false during evaluation / shadow
-              mode.
+          events:
+            node_type: section
+            type: object
+            properties:
+              enabled:
+                node_type: setting
+                type: boolean
+                default: false
+                comment: Forward anomaly correlations as Datadog change events. Keep false during evaluation / shadow mode.
+          stdout:
+            node_type: section
+            type: object
+            properties:
+              enabled:
+                node_type: setting
+                type: boolean
+                default: true
+                comment: Set to false to silence all [observer] stdout log lines.
+              verbose:
+                node_type: setting
+                type: boolean
+                default: false
+                comment: Set to true to print individual anomaly series lines after the title (one line per anomaly).
       storage:
         node_type: section
         type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -2107,8 +2107,15 @@ func anomalyDetection(config pkgconfigmodel.Setup) {
 	// Log-derived virtual metrics are unaffected.
 	config.BindEnvAndSetDefault("anomaly_detection.metrics.enabled", true)
 
-	// Anomaly event reporting. Keep false during evaluation / shadow mode.
-	config.BindEnvAndSetDefault("anomaly_detection.reporting.enabled", false)
+	// Stdout reporting verbosity.
+	// stdout.enabled: set to false to silence all [observer] stdout log lines.
+	// stdout.verbose: set to true to print individual anomaly series after the title line.
+	// Default: title-only (stdout.enabled=true, stdout.verbose=false).
+	config.BindEnvAndSetDefault("anomaly_detection.reporting.stdout.enabled", true)
+	config.BindEnvAndSetDefault("anomaly_detection.reporting.stdout.verbose", false)
+
+	// Datadog event reporting. Keep false during evaluation / shadow mode.
+	config.BindEnvAndSetDefault("anomaly_detection.reporting.events.enabled", false)
 
 	// Parquet recording of raw ingested signals for offline analysis and replay.
 	config.BindEnvAndSetDefault("anomaly_detection.recording.enabled", false)


### PR DESCRIPTION
### What does this PR do?

When we have anomaly detection reports, the logs are pretty verbose if multiple series are anomalous.

This updates the configuration to avoid spamming logs:

```
anomaly_detection:
  reporting:
    stdout:
      enabled: true # Print only report title (number of anomalies)
      verbose: false # Print all series
    events:
      enabled: false # Was anomaly_detection.reporting.enabled before
```

### Motivation

### Describe how you validated your changes

### Additional Notes
