### PR TITLE
Don't flag every PR that modifies `MODULE.bazel` in AI reviews

### DIFF
--- a/bazel/codereview_guideline.md
+++ b/bazel/codereview_guideline.md
@@ -53,8 +53,8 @@ runfiles library or `$(rlocationpath :target)` in `genrule`/test `args`.
 
 ## MODULE.bazel lock file
 
-`MODULE.bazel.lock` must be committed. Flag any PR that modifies `MODULE.bazel` or any module extension without a
-corresponding update to `MODULE.bazel.lock`.
+`MODULE.bazel.lock` must be committed. Flag any PR that modifies any module extension (implementation or invocation)
+without a corresponding update to `MODULE.bazel.lock`.
 
 ## No WORKSPACE patterns
 


### PR DESCRIPTION
### What does this PR do?

Removes guideline that every MODULE.bazel modification must carry a MODULE.bazel.lock file update.

### Motivation

I've had repeated codex comments on my PR's where there's been MODULE.bazel modifications that don't affect the MODULE.bazel.lock file (I had a recent example but the reviews got deleted by automation).

My rationale:
- Not all MODULE.bazel changes actually cause a lockfile change. Repository rules instantiations, for example, don't update it. Only changes to the module dependency graph are registered.
- We have checks in CI that check the lockfile. Those are deterministic and more reliable than heuristics applied by a bot.

### Describe how you validated your changes

### Additional Notes
