### PR TITLE
Set GOMEMLIMIT on tests_windows jobs

### DIFF
--- a/.gitlab/windows/build/source_test/windows.yml
+++ b/.gitlab/windows/build/source_test/windows.yml
@@ -40,6 +40,7 @@
       -e GOMODCACHE="c:\modcache"
       -e GOPROXY
       -e GONOSUMDB
+      -e GOMEMLIMIT=2560MiB
       -e JUNIT_TAR="c:\mnt\junit-${CI_JOB_NAME_SLUG}.tgz"
       -e PIP_INDEX_URL
       -e TEST_OUTPUT_FILE="${TEST_OUTPUT_FILE}.json"


### PR DESCRIPTION
### What does this PR do?

We are currently experiencing OOM issues after upgrading Go last week. This PR hints GC to kick in more aggressively. The value is the right one as it is **per process** and not **per job**. If a process (e.g. linker) requires more than `GOMEMLIMIT` it can go beyond this value as it mainly serves as a soft limit.