### PR TITLE
chore(renovate): track go.mod files under test/

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended", "mergeConfidence:all-badges", ":enablePreCommit", "schedule:nonOfficeHours"],
-    "ignorePaths": ["**/node_modules/**", "**/bower_components/**", "**/vendor/**", "**/__tests__/**", "**/spec/**"],
+    "ignorePaths": [],
     "constraints": {
       "go": "1.26.4"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended", "mergeConfidence:all-badges", ":enablePreCommit", "schedule:nonOfficeHours"],
+    "ignorePaths": ["**/node_modules/**", "**/bower_components/**", "**/vendor/**", "**/__tests__/**", "**/spec/**"],
     "constraints": {
       "go": "1.26.4"
     },


### PR DESCRIPTION
## What does this PR do?

The `config:recommended` Renovate preset includes `:ignoreModulesAndTests`, which adds `**/test/**` to `ignorePaths`. This silently prevents Renovate from tracking any `go.mod` files under `test/` — including `test/new-e2e/go.mod` and `test/e2e-framework/go.mod` (which contain Pulumi dependencies).

This PR sets `ignorePaths: []` to fully override the preset, so Renovate tracks all paths without exception.

## Motivation

Enables Renovate to propose bump PRs for packages like `pulumi-gcp` declared in the test infrastructure modules.

Note: if specific packages still need to be excluded (e.g. Pulumi packages that must be synced with `test-infra-definitions`), they can be added as explicit `packageRules` entries.

## Test plan

- [ ] Verify the Renovate dependency dashboard (issue #33469) starts listing `test/new-e2e` and `test/e2e-framework` go.mod dependencies after the next Renovate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)