### PR TITLE
[EBPF] Add GPU PCIe link degradation metrics

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -330,6 +330,54 @@ func pcieLinkBytesPerSecond(gen int, width int) (float64, error) {
 	return bps, nil
 }
 
+func pcieLinkWidthMetrics(device ddnvml.Device) ([]Metric, uint64, error) {
+	currentWidth, err := device.GetCurrPcieLinkWidth()
+	if err != nil {
+		return nil, 0, fmt.Errorf("get current PCIe link width: %w", err)
+	}
+	maxWidth, err := device.GetMaxPcieLinkWidth()
+	if err != nil {
+		return nil, 0, fmt.Errorf("get max PCIe link width: %w", err)
+	}
+	return []Metric{
+		{Name: "pci.link.width.current", Value: float64(currentWidth), Type: metrics.GaugeType},
+		{Name: "pci.link.width.max", Value: float64(maxWidth), Type: metrics.GaugeType},
+		{Name: "pci.link.width.degraded", Value: boolToFloat(currentWidth < maxWidth), Type: metrics.GaugeType},
+	}, 0, nil
+}
+
+func pcieLinkSpeedMetrics(device ddnvml.Device) ([]Metric, uint64, error) {
+	currentGeneration, err := device.GetCurrPcieLinkGeneration()
+	if err != nil {
+		return nil, 0, fmt.Errorf("get current PCIe link generation: %w", err)
+	}
+	currentWidth, err := device.GetCurrPcieLinkWidth()
+	if err != nil {
+		return nil, 0, fmt.Errorf("get current PCIe link width: %w", err)
+	}
+	currentSpeed, err := pcieLinkBytesPerSecond(currentGeneration, currentWidth)
+	if err != nil {
+		return nil, 0, fmt.Errorf("compute current PCIe link speed: %w", err)
+	}
+	maxGeneration, err := device.GetMaxPcieLinkGeneration()
+	if err != nil {
+		return nil, 0, fmt.Errorf("get max PCIe link generation: %w", err)
+	}
+	maxWidth, err := device.GetMaxPcieLinkWidth()
+	if err != nil {
+		return nil, 0, fmt.Errorf("get max PCIe link width: %w", err)
+	}
+	maxSpeed, err := pcieLinkBytesPerSecond(maxGeneration, maxWidth)
+	if err != nil {
+		return nil, 0, fmt.Errorf("compute max PCIe link speed: %w", err)
+	}
+	return []Metric{
+		{Name: "pci.link.speed.current", Value: currentSpeed, Type: metrics.GaugeType},
+		{Name: "pci.link.speed.max", Value: maxSpeed, Type: metrics.GaugeType},
+		{Name: "pci.link.speed.degraded", Value: boolToFloat(currentSpeed < maxSpeed), Type: metrics.GaugeType},
+	}, 0, nil
+}
+
 // createStatelessAPIs creates API call definitions for all stateless metrics on demand
 func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 	apis := []apiCallInfo{
@@ -401,39 +449,15 @@ func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 			},
 		},
 		{
-			Name: "pci_link_speed_current",
+			Name: "pci_link_speed",
 			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				gen, err := device.GetCurrPcieLinkGeneration()
-				if err != nil {
-					return nil, 0, err
-				}
-				width, err := device.GetCurrPcieLinkWidth()
-				if err != nil {
-					return nil, 0, err
-				}
-				speed, err := pcieLinkBytesPerSecond(gen, width)
-				if err != nil {
-					return nil, 0, err
-				}
-				return []Metric{{Name: "pci.link.speed.current", Value: speed, Type: metrics.GaugeType}}, 0, nil
+				return pcieLinkSpeedMetrics(device)
 			},
 		},
 		{
-			Name: "pci_link_speed_max",
+			Name: "pci_link_width",
 			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				gen, err := device.GetMaxPcieLinkGeneration()
-				if err != nil {
-					return nil, 0, err
-				}
-				width, err := device.GetMaxPcieLinkWidth()
-				if err != nil {
-					return nil, 0, err
-				}
-				speed, err := pcieLinkBytesPerSecond(gen, width)
-				if err != nil {
-					return nil, 0, err
-				}
-				return []Metric{{Name: "pci.link.speed.max", Value: speed, Type: metrics.GaugeType}}, 0, nil
+				return pcieLinkWidthMetrics(device)
 			},
 		},
 		{

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -330,22 +330,6 @@ func pcieLinkBytesPerSecond(gen int, width int) (float64, error) {
 	return bps, nil
 }
 
-func pcieLinkWidthMetrics(device ddnvml.Device) ([]Metric, uint64, error) {
-	currentWidth, err := device.GetCurrPcieLinkWidth()
-	if err != nil {
-		return nil, 0, fmt.Errorf("get current PCIe link width: %w", err)
-	}
-	maxWidth, err := device.GetMaxPcieLinkWidth()
-	if err != nil {
-		return nil, 0, fmt.Errorf("get max PCIe link width: %w", err)
-	}
-	return []Metric{
-		{Name: "pci.link.width.current", Value: float64(currentWidth), Type: metrics.GaugeType},
-		{Name: "pci.link.width.max", Value: float64(maxWidth), Type: metrics.GaugeType},
-		{Name: "pci.link.width.degraded", Value: boolToFloat(currentWidth < maxWidth), Type: metrics.GaugeType},
-	}, 0, nil
-}
-
 func pcieLinkMetrics(device ddnvml.Device) ([]Metric, uint64, error) {
 	var metricsOut []Metric
 

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -346,36 +346,43 @@ func pcieLinkWidthMetrics(device ddnvml.Device) ([]Metric, uint64, error) {
 	}, 0, nil
 }
 
-func pcieLinkSpeedMetrics(device ddnvml.Device) ([]Metric, uint64, error) {
-	currentGeneration, err := device.GetCurrPcieLinkGeneration()
-	if err != nil {
-		return nil, 0, fmt.Errorf("get current PCIe link generation: %w", err)
-	}
+func pcieLinkMetrics(device ddnvml.Device) ([]Metric, uint64, error) {
+	var metricsOut []Metric
+
 	currentWidth, err := device.GetCurrPcieLinkWidth()
 	if err != nil {
-		return nil, 0, fmt.Errorf("get current PCIe link width: %w", err)
+		return metricsOut, 0, fmt.Errorf("get current PCIe link width: %w", err)
+	}
+	metricsOut = append(metricsOut, Metric{Name: "pci.link.width.current", Value: float64(currentWidth), Type: metrics.GaugeType})
+
+	maxWidth, err := device.GetMaxPcieLinkWidth()
+	if err != nil {
+		return metricsOut, 0, fmt.Errorf("get max PCIe link width: %w", err)
+	}
+	metricsOut = append(metricsOut, Metric{Name: "pci.link.width.max", Value: float64(maxWidth), Type: metrics.GaugeType})
+	metricsOut = append(metricsOut, Metric{Name: "pci.link.width.degraded", Value: boolToFloat(currentWidth < maxWidth), Type: metrics.GaugeType})
+
+	currentGeneration, err := device.GetCurrPcieLinkGeneration()
+	if err != nil {
+		return metricsOut, 0, fmt.Errorf("get current PCIe link generation: %w", err)
 	}
 	currentSpeed, err := pcieLinkBytesPerSecond(currentGeneration, currentWidth)
 	if err != nil {
-		return nil, 0, fmt.Errorf("compute current PCIe link speed: %w", err)
+		return metricsOut, 0, fmt.Errorf("compute current PCIe link speed: %w", err)
 	}
+	metricsOut = append(metricsOut, Metric{Name: "pci.link.speed.current", Value: currentSpeed, Type: metrics.GaugeType})
+
 	maxGeneration, err := device.GetMaxPcieLinkGeneration()
 	if err != nil {
-		return nil, 0, fmt.Errorf("get max PCIe link generation: %w", err)
-	}
-	maxWidth, err := device.GetMaxPcieLinkWidth()
-	if err != nil {
-		return nil, 0, fmt.Errorf("get max PCIe link width: %w", err)
+		return metricsOut, 0, fmt.Errorf("get max PCIe link generation: %w", err)
 	}
 	maxSpeed, err := pcieLinkBytesPerSecond(maxGeneration, maxWidth)
 	if err != nil {
-		return nil, 0, fmt.Errorf("compute max PCIe link speed: %w", err)
+		return metricsOut, 0, fmt.Errorf("compute max PCIe link speed: %w", err)
 	}
-	return []Metric{
-		{Name: "pci.link.speed.current", Value: currentSpeed, Type: metrics.GaugeType},
-		{Name: "pci.link.speed.max", Value: maxSpeed, Type: metrics.GaugeType},
-		{Name: "pci.link.speed.degraded", Value: boolToFloat(currentSpeed < maxSpeed), Type: metrics.GaugeType},
-	}, 0, nil
+	metricsOut = append(metricsOut, Metric{Name: "pci.link.speed.max", Value: maxSpeed, Type: metrics.GaugeType})
+	metricsOut = append(metricsOut, Metric{Name: "pci.link.speed.degraded", Value: boolToFloat(currentSpeed < maxSpeed), Type: metrics.GaugeType})
+	return metricsOut, 0, nil
 }
 
 // createStatelessAPIs creates API call definitions for all stateless metrics on demand
@@ -449,15 +456,9 @@ func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 			},
 		},
 		{
-			Name: "pci_link_speed",
+			Name: "pci_link",
 			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				return pcieLinkSpeedMetrics(device)
-			},
-		},
-		{
-			Name: "pci_link_width",
-			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				return pcieLinkWidthMetrics(device)
+				return pcieLinkMetrics(device)
 			},
 		},
 		{

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -727,21 +727,84 @@ func TestPCIELinkBytesPerSecond(t *testing.T) {
 	}
 }
 
-func TestPCIELinkWidthMetrics(t *testing.T) {
+func TestPCIELinkMetrics(t *testing.T) {
 	tests := map[string]struct {
-		currentWidth     int
-		maxWidth         int
-		expectedDegraded float64
+		currentWidth       int
+		maxWidth           int
+		currentGeneration  int
+		maxGeneration      int
+		expectedMetricVals map[string]float64
+		expectedErr        string
 	}{
-		"matching width": {
-			currentWidth:     16,
-			maxWidth:         16,
-			expectedDegraded: 0,
+		"matching link": {
+			currentWidth:      16,
+			maxWidth:          16,
+			currentGeneration: 4,
+			maxGeneration:     4,
+			expectedMetricVals: map[string]float64{
+				"pci.link.width.current":  16,
+				"pci.link.width.max":      16,
+				"pci.link.width.degraded": 0,
+				"pci.link.speed.current":  31.50769230769231e9,
+				"pci.link.speed.max":      31.50769230769231e9,
+				"pci.link.speed.degraded": 0,
+			},
 		},
-		"degraded width": {
-			currentWidth:     8,
-			maxWidth:         16,
-			expectedDegraded: 1,
+		"degraded link": {
+			currentWidth:      8,
+			maxWidth:          16,
+			currentGeneration: 4,
+			maxGeneration:     4,
+			expectedMetricVals: map[string]float64{
+				"pci.link.width.current":  8,
+				"pci.link.width.max":      16,
+				"pci.link.width.degraded": 1,
+				"pci.link.speed.current":  15.753846153846155e9,
+				"pci.link.speed.max":      31.50769230769231e9,
+				"pci.link.speed.degraded": 1,
+			},
+		},
+		"current width error": {
+			currentWidth:      -1,
+			maxWidth:          16,
+			currentGeneration: 4,
+			maxGeneration:     4,
+			expectedErr:       "get current PCIe link width",
+		},
+		"max width error emits current width": {
+			currentWidth:      16,
+			maxWidth:          -1,
+			currentGeneration: 4,
+			maxGeneration:     4,
+			expectedMetricVals: map[string]float64{
+				"pci.link.width.current": 16,
+			},
+			expectedErr: "get max PCIe link width",
+		},
+		"current generation error emits width metrics": {
+			currentWidth:      8,
+			maxWidth:          16,
+			currentGeneration: -1,
+			maxGeneration:     4,
+			expectedMetricVals: map[string]float64{
+				"pci.link.width.current":  8,
+				"pci.link.width.max":      16,
+				"pci.link.width.degraded": 1,
+			},
+			expectedErr: "get current PCIe link generation",
+		},
+		"max generation error emits current speed": {
+			currentWidth:      8,
+			maxWidth:          16,
+			currentGeneration: 4,
+			maxGeneration:     -1,
+			expectedMetricVals: map[string]float64{
+				"pci.link.width.current":  8,
+				"pci.link.width.max":      16,
+				"pci.link.width.degraded": 1,
+				"pci.link.speed.current":  15.753846153846155e9,
+			},
+			expectedErr: "get max PCIe link generation",
 		},
 	}
 
@@ -749,82 +812,45 @@ func TestPCIELinkWidthMetrics(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			device := setupMockDevice(t, testutil.WithCustomHook(func(device *mock.Device) {
 				device.GetCurrPcieLinkWidthFunc = func() (int, nvml.Return) {
+					if test.currentWidth == -1 {
+						return 0, nvml.ERROR_UNKNOWN
+					}
 					return test.currentWidth, nvml.SUCCESS
 				}
 				device.GetMaxPcieLinkWidthFunc = func() (int, nvml.Return) {
+					if test.maxWidth == -1 {
+						return 0, nvml.ERROR_UNKNOWN
+					}
 					return test.maxWidth, nvml.SUCCESS
 				}
-			}))
-
-			metricsOut, _, err := pcieLinkWidthMetrics(device)
-			require.NoError(t, err)
-			require.Len(t, metricsOut, 3)
-			metricsByName := metricValuesToPointers(metricsOut)
-			currentWidthMetric := findMetric(metricsByName, "pci.link.width.current")
-			maxWidthMetric := findMetric(metricsByName, "pci.link.width.max")
-			degradedMetric := findMetric(metricsByName, "pci.link.width.degraded")
-			require.NotNil(t, currentWidthMetric)
-			require.NotNil(t, maxWidthMetric)
-			require.NotNil(t, degradedMetric)
-			require.Equal(t, float64(test.currentWidth), currentWidthMetric.Value)
-			require.Equal(t, float64(test.maxWidth), maxWidthMetric.Value)
-			require.Equal(t, test.expectedDegraded, degradedMetric.Value)
-		})
-	}
-}
-
-func TestPCIELinkSpeedMetrics(t *testing.T) {
-	tests := map[string]struct {
-		currentGeneration int
-		maxGeneration     int
-		currentWidth      int
-		maxWidth          int
-		expectedDegraded  float64
-	}{
-		"matching speed": {
-			currentGeneration: 4,
-			maxGeneration:     4,
-			currentWidth:      16,
-			maxWidth:          16,
-			expectedDegraded:  0,
-		},
-		"degraded speed": {
-			currentGeneration: 3,
-			maxGeneration:     4,
-			currentWidth:      16,
-			maxWidth:          16,
-			expectedDegraded:  1,
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			device := setupMockDevice(t, testutil.WithCustomHook(func(device *mock.Device) {
 				device.GetCurrPcieLinkGenerationFunc = func() (int, nvml.Return) {
+					if test.currentGeneration == -1 {
+						return 0, nvml.ERROR_UNKNOWN
+					}
 					return test.currentGeneration, nvml.SUCCESS
 				}
 				device.GetMaxPcieLinkGenerationFunc = func() (int, nvml.Return) {
+					if test.maxGeneration == -1 {
+						return 0, nvml.ERROR_UNKNOWN
+					}
 					return test.maxGeneration, nvml.SUCCESS
-				}
-				device.GetCurrPcieLinkWidthFunc = func() (int, nvml.Return) {
-					return test.currentWidth, nvml.SUCCESS
-				}
-				device.GetMaxPcieLinkWidthFunc = func() (int, nvml.Return) {
-					return test.maxWidth, nvml.SUCCESS
 				}
 			}))
 
-			metricsOut, _, err := pcieLinkSpeedMetrics(device)
-			require.NoError(t, err)
-			require.Len(t, metricsOut, 3)
+			metricsOut, _, err := pcieLinkMetrics(device)
+			if test.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.expectedErr)
+			}
+			require.Len(t, metricsOut, len(test.expectedMetricVals))
 			metricsByName := metricValuesToPointers(metricsOut)
-			currentMetric := findMetric(metricsByName, "pci.link.speed.current")
-			maxMetric := findMetric(metricsByName, "pci.link.speed.max")
-			degradedMetric := findMetric(metricsByName, "pci.link.speed.degraded")
-			require.NotNil(t, currentMetric)
-			require.NotNil(t, maxMetric)
-			require.NotNil(t, degradedMetric)
-			require.Equal(t, test.expectedDegraded, degradedMetric.Value)
+			for metricName, expectedValue := range test.expectedMetricVals {
+				metric := findMetric(metricsByName, metricName)
+				require.NotNil(t, metric, "expected metric %s", metricName)
+				require.InDelta(t, expectedValue, metric.Value, 1e6)
+				require.Equal(t, metrics.GaugeType, metric.Type)
+			}
 		})
 	}
 }

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -727,6 +727,108 @@ func TestPCIELinkBytesPerSecond(t *testing.T) {
 	}
 }
 
+func TestPCIELinkWidthMetrics(t *testing.T) {
+	tests := map[string]struct {
+		currentWidth     int
+		maxWidth         int
+		expectedDegraded float64
+	}{
+		"matching width": {
+			currentWidth:     16,
+			maxWidth:         16,
+			expectedDegraded: 0,
+		},
+		"degraded width": {
+			currentWidth:     8,
+			maxWidth:         16,
+			expectedDegraded: 1,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			device := setupMockDevice(t, testutil.WithCustomHook(func(device *mock.Device) {
+				device.GetCurrPcieLinkWidthFunc = func() (int, nvml.Return) {
+					return test.currentWidth, nvml.SUCCESS
+				}
+				device.GetMaxPcieLinkWidthFunc = func() (int, nvml.Return) {
+					return test.maxWidth, nvml.SUCCESS
+				}
+			}))
+
+			metricsOut, _, err := pcieLinkWidthMetrics(device)
+			require.NoError(t, err)
+			require.Len(t, metricsOut, 3)
+			metricsByName := metricValuesToPointers(metricsOut)
+			currentWidthMetric := findMetric(metricsByName, "pci.link.width.current")
+			maxWidthMetric := findMetric(metricsByName, "pci.link.width.max")
+			degradedMetric := findMetric(metricsByName, "pci.link.width.degraded")
+			require.NotNil(t, currentWidthMetric)
+			require.NotNil(t, maxWidthMetric)
+			require.NotNil(t, degradedMetric)
+			require.Equal(t, float64(test.currentWidth), currentWidthMetric.Value)
+			require.Equal(t, float64(test.maxWidth), maxWidthMetric.Value)
+			require.Equal(t, test.expectedDegraded, degradedMetric.Value)
+		})
+	}
+}
+
+func TestPCIELinkSpeedMetrics(t *testing.T) {
+	tests := map[string]struct {
+		currentGeneration int
+		maxGeneration     int
+		currentWidth      int
+		maxWidth          int
+		expectedDegraded  float64
+	}{
+		"matching speed": {
+			currentGeneration: 4,
+			maxGeneration:     4,
+			currentWidth:      16,
+			maxWidth:          16,
+			expectedDegraded:  0,
+		},
+		"degraded speed": {
+			currentGeneration: 3,
+			maxGeneration:     4,
+			currentWidth:      16,
+			maxWidth:          16,
+			expectedDegraded:  1,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			device := setupMockDevice(t, testutil.WithCustomHook(func(device *mock.Device) {
+				device.GetCurrPcieLinkGenerationFunc = func() (int, nvml.Return) {
+					return test.currentGeneration, nvml.SUCCESS
+				}
+				device.GetMaxPcieLinkGenerationFunc = func() (int, nvml.Return) {
+					return test.maxGeneration, nvml.SUCCESS
+				}
+				device.GetCurrPcieLinkWidthFunc = func() (int, nvml.Return) {
+					return test.currentWidth, nvml.SUCCESS
+				}
+				device.GetMaxPcieLinkWidthFunc = func() (int, nvml.Return) {
+					return test.maxWidth, nvml.SUCCESS
+				}
+			}))
+
+			metricsOut, _, err := pcieLinkSpeedMetrics(device)
+			require.NoError(t, err)
+			require.Len(t, metricsOut, 3)
+			metricsByName := metricValuesToPointers(metricsOut)
+			currentMetric := findMetric(metricsByName, "pci.link.speed.current")
+			maxMetric := findMetric(metricsByName, "pci.link.speed.max")
+			degradedMetric := findMetric(metricsByName, "pci.link.speed.degraded")
+			require.NotNil(t, currentMetric)
+			require.NotNil(t, maxMetric)
+			require.NotNil(t, degradedMetric)
+			require.Equal(t, test.expectedDegraded, degradedMetric.Value)
+		})
+	}
+}
+
 func findAPICallByName(t *testing.T, apis []apiCallInfo, name string) apiCallInfo {
 	t.Helper()
 	for _, api := range apis {

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -1716,7 +1716,7 @@ metrics:
       - device
     validator:
       range:
-        min: 1
+        min: 0
         max: 32
     support:
       device_modes:
@@ -1731,7 +1731,7 @@ metrics:
       - device
     validator:
       range:
-        min: 1
+        min: 0
         max: 32
     support:
       device_modes:

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -1695,6 +1695,62 @@ metrics:
         mig: false
         physical: true
         vgpu: false
+  pci.link.speed.degraded:
+    metadata:
+      metric_type: gauge
+      description: Whether the current PCI link speed is lower than the max PCI link speed
+    tagsets:
+      - device
+    validator:
+      values: [0, 1]
+    support:
+      device_modes:
+        mig: false
+        physical: true
+        vgpu: false
+  pci.link.width.current:
+    metadata:
+      metric_type: gauge
+      description: Current lane width for the PCI link
+    tagsets:
+      - device
+    validator:
+      range:
+        min: 1
+        max: 32
+    support:
+      device_modes:
+        mig: false
+        physical: true
+        vgpu: false
+  pci.link.width.max:
+    metadata:
+      metric_type: gauge
+      description: Max lane width for the PCI link
+    tagsets:
+      - device
+    validator:
+      range:
+        min: 1
+        max: 32
+    support:
+      device_modes:
+        mig: false
+        physical: true
+        vgpu: false
+  pci.link.width.degraded:
+    metadata:
+      metric_type: gauge
+      description: Whether the current PCI link width is lower than the max PCI link width
+    tagsets:
+      - device
+    validator:
+      values: [0, 1]
+    support:
+      device_modes:
+        mig: false
+        physical: true
+        vgpu: false
   performance_state:
     metadata:
       metric_type: gauge

--- a/releasenotes/notes/gpu-pci-19836f335c56c50a.yaml
+++ b/releasenotes/notes/gpu-pci-19836f335c56c50a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    gpu: add new PCI link width metrics ``gpu.pci.link.width.{current,max}`` and add degraded PCI link metrics ``gpu.pci.link.{width,speed}.degraded``.
+    considered a new feature), or remove this section.

--- a/releasenotes/notes/gpu-pci-19836f335c56c50a.yaml
+++ b/releasenotes/notes/gpu-pci-19836f335c56c50a.yaml
@@ -9,4 +9,3 @@
 enhancements:
   - |
     gpu: add new PCI link width metrics ``gpu.pci.link.width.{current,max}`` and add degraded PCI link metrics ``gpu.pci.link.{width,speed}.degraded``.
-    considered a new feature), or remove this section.


### PR DESCRIPTION
### What does this PR do?

Adds GPU PCIe link width metrics and degradation gauges for PCIe link width and computed link speed.

### Motivation

Make downtrained or otherwise degraded GPU PCIe links directly detectable without comparing current and max metrics manually.

### Describe how you validated your changes

Unit tests added. Local execution was not possible on Darwin because the package is gated by `linux && nvml` build tags.

### Additional Notes