### PR TITLE
[macOS installer] Suppress curl progress bar in non-interactive environments

### DIFF
--- a/cmd/agent/macos/install_mac_os.sh
+++ b/cmd/agent/macos/install_mac_os.sh
@@ -23,6 +23,16 @@ else
     BLUE=''
     NC=''
 fi
+# curl progress: show the bar interactively, suppress it in non-interactive
+# environments (CI, MDM/Jamf scripts, piped invocations) where --progress-bar
+# floods logs with hash lines (e.g. "##########  67.5%"). Must be set before
+# the exec redirect below, which makes [ -t ] checks unreliable.
+# --no-progress-meter requires curl 7.67+ (2019); macOS 12+ ships ≥7.79.
+if [ -t 2 ]; then
+    curl_progress_opt="--progress-bar"
+else
+    curl_progress_opt="--no-progress-meter"
+fi
 # Use mktemp so the log path is unpredictable (0600, random suffix). A fixed
 # /tmp path would let a local user pre-create it as a symlink and redirect
 # root-owned `tee` output into a privileged file.
@@ -253,7 +263,7 @@ else
 
     printf "${BLUE}\n* Downloading datadog-agent ${dmg_version}\n${NC}"
     prepare_dmg_file $dmg_file
-    if ! $sudo_cmd curl --fail --progress-bar "$dmg_url" "${curl_retries[@]}" --output $dmg_file; then
+    if ! $sudo_cmd curl --fail $curl_progress_opt "$dmg_url" "${curl_retries[@]}" --output $dmg_file; then
         printf "${RED}Couldn't download the installer for macOS Agent version ${dmg_version}.${NC}\n"
         exit 1;
     fi


### PR DESCRIPTION
## What does this PR do?

`--progress-bar` is hardcoded in the DMG download curl call, which floods logs with hash-bar lines (`##########  67.5%`) whenever the script runs non-interactively — CI pipelines, MDM/Jamf policies, piped invocations, etc. In tools like Jamf the log noise can hit the per-policy truncation limit, hiding all output that follows the download.

Example of the issue (JAMF logs screen)

<img width="1077" height="728" alt="image" src="https://github.com/user-attachments/assets/9de33e16-03e4-4f3d-8bba-60d5585c0503" />

## Changes

- Detect interactivity with `[ -t 2 ]` (stderr is a terminal) **before** the `exec > >(tee ...) 2>&1` redirect — mirroring the existing colour-variable pattern in the same block, since the redirect makes subsequent `[ -t ]` checks unreliable.
- Use `--progress-bar` when stderr is a terminal (interactive, behaviour unchanged).
- Use `--no-progress-meter` otherwise — this flag keeps error messages visible on failure while suppressing the progress noise.

## Motivation

`--no-progress-meter` (curl 7.67, 2019) is safe for this script:
- macOS 12 is the minimum supported version (enforced earlier in the script), and macOS 12+ ships with curl ≥ 7.79.
- Unlike `-s`/`--silent`, `--no-progress-meter` preserves error output, so failures are still clearly visible in logs.

## Testing

- Run `bash install_mac_os.sh` from a terminal → progress bar still shown (interactive).
- Run `bash install_mac_os.sh 2>/tmp/out.log` or pipe through Jamf → no hash-bar lines in the log, errors still visible on failure.

Made with [Cursor](https://cursor.com)