### PR TITLE
fixup pod resource limit metric name

### DIFF
--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
@@ -190,7 +190,7 @@ func (p *Provider) generatePodSpecMetrics(sender sender.Sender, pod *workloadmet
 			continue
 		}
 
-		sender.Gauge(common.KubeletMetricsPrefix+"pod."+r+".limit", quantity.AsApproximateFloat64(), "", tagList)
+		sender.Gauge(common.KubeletMetricsPrefix+"pod."+r+".limits", quantity.AsApproximateFloat64(), "", tagList)
 	}
 }
 

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
@@ -176,7 +176,7 @@ func (p *Provider) generatePodSpecMetrics(sender sender.Sender, pod *workloadmet
 			continue
 		}
 
-		sender.Gauge(common.KubeletMetricsPrefix+"pod."+r+".request", quantity.AsApproximateFloat64(), "", tagList)
+		sender.Gauge(common.KubeletMetricsPrefix+"pod."+r+".requests", quantity.AsApproximateFloat64(), "", tagList)
 	}
 
 	for r, value := range pod.Resources.RawLimits {

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
@@ -243,8 +243,8 @@ func (suite *ProviderTestSuite) TestTransformPodsRequestsLimits() {
 	// pod resource metrics
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.cpu.request", 0.75, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.memory.request", 1610612736.0, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.cpu.limit", 1.0, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.memory.limit", 2147483648.0, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.cpu.limits", 1.0, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.memory.limits", 2147483648.0, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
 }
 
 // TestTransformPodsInPlaceResize verifies that request/limit metrics

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
@@ -241,13 +241,13 @@ func (suite *ProviderTestSuite) TestTransformPodsRequestsLimits() {
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"ephemeral-storage.limits", 2147483648.0, "", append(config.Tags, "pod_name:cassandra-0"))
 
 	// pod resource metrics
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.cpu.request", 0.75, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
-	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.memory.request", 1610612736.0, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.cpu.requests", 0.75, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.memory.requests", 1610612736.0, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.cpu.limits", 1.0, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.memory.limits", 2147483648.0, "", append(config.Tags, "pod_name:cassandra-0", "kube_namespace:default"))
 }
 
-// TestTransformPodsInPlaceResize verifies that request/limit metrics
+// TestTransformPodsInPlaceResize verifies that requests/limits metrics
 // reflect containerStatuses[].resources (in-place vertical scaling) when
 // set, and fall back to the spec for keys status does not report.
 func (suite *ProviderTestSuite) TestTransformPodsInPlaceResize() {

--- a/releasenotes/notes/pod-level-resources-79ac0a28bdbcd7c8.yaml
+++ b/releasenotes/notes/pod-level-resources-79ac0a28bdbcd7c8.yaml
@@ -9,4 +9,4 @@
 features:
   - |
     Parses and collects ``kubernetes.pod.cpu.request``, ``kubernetes.pod.memory.request``,
-    ``kubernetes.pod.cpu.limit``, and ``kubernetes.pod.memory.limit``.
+    ``kubernetes.pod.cpu.limits``, and ``kubernetes.pod.memory.limits``.

--- a/releasenotes/notes/pod-level-resources-79ac0a28bdbcd7c8.yaml
+++ b/releasenotes/notes/pod-level-resources-79ac0a28bdbcd7c8.yaml
@@ -8,5 +8,5 @@
 ---
 features:
   - |
-    Parses and collects ``kubernetes.pod.cpu.request``, ``kubernetes.pod.memory.request``,
+    Parses and collects ``kubernetes.pod.cpu.requests``, ``kubernetes.pod.memory.requests``,
     ``kubernetes.pod.cpu.limits``, and ``kubernetes.pod.memory.limits``.


### PR DESCRIPTION
### What does this PR do?

The metric exposed was named `kubernetes.pod.<resource>.limit`. When it should be named `...limits` with an S in the end.

this is to match the previously used metric
`kubernetes.<resource>.limits` for consistency.

### Motivation

### Describe how you validated your changes

### Additional Notes
