### PR TITLE
fix(windows): make MSI rollback ACL restore resilient to deleted files

### DIFF
--- a/releasenotes/notes/windows-rollback-acl-restore-9638878c241d6662.yaml
+++ b/releasenotes/notes/windows-rollback-acl-restore-9638878c241d6662.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    On Windows, when an Agent upgrade fails and the MSI rolls back, the
+    installer step that restores file permissions no longer aborts when a
+    generated file (such as ``auth_token`` or ``ipc_cert.pem``) was already
+    removed earlier in the rollback. Previously the first missing file would
+    stop the restore, leaving other files (for example ``datadog.yaml``)
+    without their permissions restored, which could prevent the Agent from
+    starting after the rollback.

--- a/releasenotes/notes/windows-rollback-acl-restore-9638878c241d6662.yaml
+++ b/releasenotes/notes/windows-rollback-acl-restore-9638878c241d6662.yaml
@@ -1,10 +1,6 @@
 ---
 fixes:
   - |
-    On Windows, when an Agent upgrade fails and the MSI rolls back, the
-    installer step that restores file permissions no longer aborts when a
-    generated file (such as ``auth_token`` or ``ipc_cert.pem``) was already
-    removed earlier in the rollback. Previously the first missing file would
-    stop the restore, leaving other files (for example ``datadog.yaml``)
-    without their permissions restored, which could prevent the Agent from
-    starting after the rollback.
+    On Windows, fixed an issue where a failed Agent upgrade could leave some
+    files without their permissions restored after the MSI rolled back,
+    which could prevent the Agent from starting.

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/FilePermissionRollbackData.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/FilePermissionRollbackData.cs
@@ -36,6 +36,17 @@ namespace Datadog.CustomActions.Rollback
         /// </remarks>
         public void Restore(ISession session, IFileSystemServices fileSystemServices, IServiceController _)
         {
+            // The file may have been removed earlier in the rollback (e.g. by CleanupFiles, which
+            // deletes generated paths such as auth_token/ipc_cert.pem that also appear here). There
+            // is no ACL to restore on a file that no longer exists, so skip it. Without this guard
+            // GetAccessControl throws and aborts the entire restore loop, leaving later entries
+            // (datadog.yaml, install_info, ...) with their ACLs never restored.
+            if (!fileSystemServices.Exists(_filePath))
+            {
+                session.Log($"{_filePath} no longer exists, skipping ACL rollback");
+                return;
+            }
+
             var fileSystemSecurity = fileSystemServices.GetAccessControl(_filePath);
             session.Log(
                 $"{_filePath} current ACLs: {fileSystemSecurity.GetSecurityDescriptorSddlForm(AccessControlSections.All)}");

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/RollbackDataStore.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/RollbackDataStore.cs
@@ -137,7 +137,17 @@ namespace Datadog.CustomActions.Rollback
             Load();
             for (var i = RollbackActions.Count - 1; i >= 0; i--)
             {
-                RollbackActions[i].Restore(_session, _fileSystemServices, _serviceController);
+                // Restore is best-effort: a failure on one entry must not prevent the remaining
+                // entries from being restored. Log and continue so a single bad item cannot
+                // poison the rest of the rollback.
+                try
+                {
+                    RollbackActions[i].Restore(_session, _fileSystemServices, _serviceController);
+                }
+                catch (Exception e)
+                {
+                    _session.Log($"Error restoring rollback action {RollbackActions[i].GetType().Name}: {e}");
+                }
             }
         }
 


### PR DESCRIPTION
### What does this PR do?

Makes the Windows MSI rollback's permission-restore step resilient to files that were already deleted earlier in the same rollback.

During rollback, `CleanupOnRollback` deletes generated files (`auth_token`, `ipc_cert.pem`, and their `.lock` files) that are *also* tracked in `PathsWithAgentAccess` and snapshotted into the rollback data store. When `RunRollbackDataRestore` iterates those snapshots, `FilePermissionRollbackData.Restore` calls `GetAccessControl` on the now-deleted file, which throws (`System.Exception: <path> is not a file or directory`). `RollbackDataStore.Restore` has no per-item error handling, so the first throw aborts the entire loop, leaving every remaining entry (`datadog.yaml`, `install_info`, `system-probe.yaml`, ...) with its ACLs never restored.

Two complementary changes:

1. **`FilePermissionRollbackData.Restore`** — skip entries whose path no longer exists (there is no ACL to restore on a deleted file). Fixes the root cause.
2. **`RollbackDataStore.Restore`** — wrap each `Restore()` in try/catch so one failing entry cannot poison the rest of the rollback. Defense in depth.

This continues the rollback-resilience work from #49011, which cleaned up stale `.lock` files and the agent-side symptom but left the installer-side throw that aborts the ACL restore loop.

### Motivation

`test/new-e2e/tests/windows/install-test/TestUpgradeRollback` (WINA-2721). The failure surfaces as `Start-Service` failing after rollback with `error while creating or fetching auth token: unable to read the artifact or acquire the lock in the given time`.

### Honest caveat on scope

This PR fixes a real defect (the aborted ACL restore leaves sub-path permissions unrestored) but is **not yet confirmed to make `TestUpgradeRollback` green**. Investigation of the live job artifacts showed: (a) #49011's lock-file fix is already in and working (the stale `.lock` no longer survives), yet the symptom persists; and (b) the root directory ACL the auth-token lock depends on *was* restored before the throw. So the precise cause of the 30s lock timeout remains unproven, and the failure appears environment-sensitive/flaky (the flake wave started after the Windows E2E AMI swap in #48563, 2026-03-30). CI running `TestUpgradeRollback` against this branch is the real validation. See WINA-2721 for the full analysis.

### Describe how you validated your changes

- This is a Windows MSI / WiX change that cannot be built or run locally on non-Windows; relying on CI to exercise `TestUpgradeRollback` and the installer build.

### Possible Drawbacks / Trade-offs

Rollback ACL restore becomes best-effort per item: a genuinely failing restore is now logged and skipped rather than aborting the sequence. This is the intended behavior for rollback (maximize what gets restored) but means a single failure is no longer loudly fatal — it is logged to the MSI log instead.

### Additional Notes

Refs: [WINA-2721](https://datadoghq.atlassian.net/browse/WINA-2721)

[WINA-2721]: https://datadoghq.atlassian.net/browse/WINA-2721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ