### PR TITLE
[automated] Upgrade embedded Python patch version to 3.13.14 (#52085) [backport 7.80.x]

### DIFF
--- a/deps/cpython/cpython.MODULE.bazel
+++ b/deps/cpython/cpython.MODULE.bazel
@@ -1,6 +1,6 @@
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-PYTHON_VERSION = "3.13.13"
+PYTHON_VERSION = "3.13.14"
 
 http_archive(
     name = "cpython",
@@ -15,7 +15,7 @@ http_archive(
         "//deps/cpython:0002-Set-the-install-name-to-use-rpath-instead-of-absolut.patch",
         "//deps/cpython:0003-propagate-pgo-test-exit-code.patch",
     ],
-    sha256 = "f9cde7b0e2ec8165d7326e2a0f59ea2686ce9d0c617dbbb3d66a7e54d31b74b9",
+    sha256 = "5ae535a36af0ebca6fca176ecb8197f5db9c1cb8c8f0cd12cdf1787046db1f41",
     strip_prefix = "Python-{}".format(PYTHON_VERSION),
     url = "https://python.org/ftp/python/{0}/Python-{0}.tgz".format(PYTHON_VERSION),
 )

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -1,6 +1,6 @@
 name "python3"
 
-default_version "3.13.13"
+default_version "3.13.14"
 
 
 relative_path "Python-#{version}"

--- a/releasenotes/notes/Bump-embedded-Python-to-3.13.14-30a6782c0ee1a75c.yaml
+++ b/releasenotes/notes/Bump-embedded-Python-to-3.13.14-30a6782c0ee1a75c.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+- |
+    The Agent's embedded Python has been upgraded from 3.13.13 to 3.13.14

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -228,7 +228,7 @@ const (
 	ExpectedPythonVersion2 = "2.7.18"
 	// ExpectedPythonVersion3 is the expected python 3 version
 	// Bump this version when the version in omnibus/config/software/python3.rb changes
-	ExpectedPythonVersion3 = "3.13.13"
+	ExpectedPythonVersion3 = "3.13.14"
 	// ExpectedUnloadedPython is the status value for uninitialized lazy loaded python runtime
 	ExpectedUnloadedPython = "unused"
 )


### PR DESCRIPTION
Backport of #52085 to `7.80.x`.

The automated backport failed due to a merge conflict in `deps/cpython/cpython.MODULE.bazel`: `main` carries an unrelated `constants_repo` declaration that does not exist on `7.80.x`. Resolved by applying only the version bump (3.13.13 → 3.13.14) and keeping the `7.80.x` file structure. The `sha256` change applied cleanly.

### What does this PR do?
Upgrades the Agent's embedded Python interpreter from **3.13.13** to **3.13.14** (patch version update).

### Changes
- Updated `omnibus/config/software/python3.rb` with new version
- Updated `deps/cpython/cpython.MODULE.bazel` with new version and SHA256
- Updated `test/new-e2e/tests/agent-platform/common/agent_behaviour.go` with expected version
- Created release note documenting the upgrade

See the [official Python release page](https://www.python.org/downloads/release/python-31314/) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)