### PR TITLE
Remove reference to merged upstream buildifier PR

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -134,7 +134,7 @@ http_archive(
     patches = [
         "//bazel/patches:buildifier-build.patch",  # bazelbuild/buildtools#1398
         "//bazel/patches:buildifier-internal-factory.patch",  # bazelbuild/buildtools#1399
-        "//bazel/patches:buildifier-runner-bat-template.patch",  # bazelbuild/buildtools#1400 bazelbuild/buildtools#1404
+        "//bazel/patches:buildifier-runner-bat-template.patch",  # bazelbuild/buildtools#1400
         "//bazel/patches:buildifier-runner-bash-template.patch",  # bazelbuild/buildtools#1454
     ],
     sha256 = "f3b800e9f6ca60bdef3709440f393348f7c18a29f30814288a7326285c80aab9",


### PR DESCRIPTION
### What does this PR do?

Removes obsolete reference to merged upstream buildifier PR.

### Motivation

The second PR mentioned in this comment (https://github.com/bazelbuild/buildtools/pull/1404) was already merged, and our patch no longer include those changes (since https://github.com/DataDog/datadog-agent/pull/47383).

### Describe how you validated your changes

N/A

### Additional Notes
