### PR TITLE
fix(jetson): support GR3D_FREQ without usage percentage on AGX Thor/Orin

### DIFF
--- a/pkg/collector/corechecks/nvidia/jetson/gpuMetricsSender.go
+++ b/pkg/collector/corechecks/nvidia/jetson/gpuMetricsSender.go
@@ -21,7 +21,7 @@ type gpuMetricSender struct {
 }
 
 func (gpuMetricSender *gpuMetricSender) Init() error {
-	regex, err := regexp.Compile(`(?:EMC_FREQ\s*(?P<emcPct>\d+)%(?:@(?P<emcFreq>\d+))?\s*)?GR3D_FREQ\s*(?P<gpuPct>\d+)%(?:@(?P<gpuFreq>\d+)|@(?:\[(?P<gpcFreqs>(?:\d+,?)+)]))?`)
+	regex, err := regexp.Compile(`(?:EMC_FREQ\s*(?P<emcPct>\d+)%(?:@(?P<emcFreq>\d+))?\s*)?GR3D_FREQ\s*(?:(?P<gpuPct>\d+)%)?(?:@(?P<gpuFreq>\d+)|@(?:\[(?P<gpcFreqs>(?:\d+,?)+)]))?`)
 	if err != nil {
 		return err
 	}
@@ -52,11 +52,13 @@ func (gpuMetricSender *gpuMetricSender) SendMetrics(sender sender.Sender, field 
 		sender.Gauge("nvidia.jetson.emc.freq", emcFreq, "", nil)
 	}
 
-	gpuPct, err := strconv.ParseFloat(gpuFields["gpuPct"], 64)
-	if err != nil {
-		return err
+	if len(gpuFields["gpuPct"]) > 0 {
+		gpuPct, err := strconv.ParseFloat(gpuFields["gpuPct"], 64)
+		if err != nil {
+			return err
+		}
+		sender.Gauge("nvidia.jetson.gpu.usage", gpuPct, "", nil)
 	}
-	sender.Gauge("nvidia.jetson.gpu.usage", gpuPct, "", nil)
 
 	if len(gpuFields["gpuFreq"]) > 0 {
 		gpuFreq, err := strconv.ParseFloat(gpuFields["gpuFreq"], 64)

--- a/pkg/collector/corechecks/nvidia/jetson/jetson_test.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson_test.go
@@ -28,6 +28,7 @@ const (
 	voltageUnitSample = "RAM 6334/15388MB (lfb 1770x4MB) SWAP 491/7694MB (cached 0MB) CPU [6%@729,9%@729,5%@729,16%@729,off,off,off,off] EMC_FREQ 0%@2133 GR3D_FREQ 0%@611 VIC_FREQ 729 APE 174 CV0@45.812C CPU@47.937C SOC2@46.093C SOC0@46.968C CV1@46.406C GPU@45.875C tj@48.875C SOC1@48.875C CV2@45.75C VDD_IN 5299mW/5299mW VDD_CPU_GPU_CV 773mW/773mW VDD_SOC 1424mW/1424mW"
 	r36Sample         = "RAM 29114/30697MB (lfb 3x4MB)    SWAP 4915/15348MB (cached 1MB) CPU [3%@729,4%@729,0%@729,1%@729,0%@2201,100%@2201,1%@2201,0%@2201,100%@2201,0%@2201,0%@2201,0%@2201] EMC_FREQ 1%@2133 GR3D_FREQ 0%@[305,305] NVENC      off  NVDEC    off NVJPG off NVJPG1    off         VIC        off          OFA           off          NVDLA0    off       NVDLA1     off          PVA0_FREQ off         APE           174        cpu@53.062C soc2@48.25C soc0@48.843C  gpu@47.812C tj@53.062C soc1@48.968C    VDD_GPU_SOC 3205mW/3205mW VDD_CPU_CV 4405mW/4405mW VIN_SYS_5V0 4767mW/4767mW"
 	orinSample        = `RAM 2448/62840MB (lfb 2x4MB) SWAP 0/31420MB (cached 0MB) CPU [0%@2201,0%@2201,0%@2201,0%@2201,0%@2201,0%@2201,0%@2201,0%@2201,0%@2201,0%@2201,0%@2201,0%@2201] GR3D_FREQ 0% cpu@42C soc2@37.843C soc0@39.187C gpu@37.75C tj@42C soc1@37.937C VDD_GPU_SOC 4940mW/4940mW VDD_CPU_CV 988mW/988mW VIN_SYS_5V0 4442mW/4442mW`
+	thorSample        = `RAM 3429/125773MB (lfb 12x4MB) CPU [0%@2601,100%@2601,0%@972,0%@972,100%@2601,0%@2601,1%@972,0%@972,0%@972,0%@972,0%@972,0%@972,0%@972,0%@972] EMC_FREQ 0%@2750 GR3D_FREQ @[494,494,494] NVENC0_FREQ @665 NVENC1_FREQ @666 NVDEC0_FREQ @665 NVDEC1_FREQ @665 NVJPG0_FREQ @665 VIC off OFA_FREQ @665 PVA0_FREQ off APE 300 cpu@35.875C tj@35.875C soc012@32.562C gpu@34.562C soc345@33.531C VDD_GPU 3132mW/3132mW VDD_CPU_SOC_MSS 9397mW/9397mW VIN_SYS_5V0 5680mW/5680mW`
 )
 
 func TestNano(t *testing.T) {
@@ -539,6 +540,83 @@ func TestOrin(t *testing.T) {
 
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, "Gauge", 46)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestThor(t *testing.T) {
+	tegraCheck := new(JetsonCheck)
+	mock := mocksender.NewMockSender(tegraCheck.ID())
+	tegraCheck.Configure(mock.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test", "provider")
+
+	// RAM 3429/125773MB (lfb 12x4MB)
+	mock.On("Gauge", "nvidia.jetson.mem.used", 3429.0*mb, "", []string(nil)).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.mem.total", 125773.0*mb, "", []string(nil)).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.mem.n_lfb", 12.0, "", []string(nil)).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.mem.lfb", 4.0*mb, "", []string(nil)).Return().Once()
+
+	// CPU [0%@2601,100%@2601,0%@972,0%@972,100%@2601,0%@2601,1%@972,0%@972,0%@972,0%@972,0%@972,0%@972,0%@972,0%@972]
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 0.0, "", []string{"cpu:0"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 2601.0, "", []string{"cpu:0"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 100.0, "", []string{"cpu:1"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 2601.0, "", []string{"cpu:1"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 0.0, "", []string{"cpu:2"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 972.0, "", []string{"cpu:2"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 0.0, "", []string{"cpu:3"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 972.0, "", []string{"cpu:3"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 100.0, "", []string{"cpu:4"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 2601.0, "", []string{"cpu:4"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 0.0, "", []string{"cpu:5"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 2601.0, "", []string{"cpu:5"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 1.0, "", []string{"cpu:6"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 972.0, "", []string{"cpu:6"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 0.0, "", []string{"cpu:7"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 972.0, "", []string{"cpu:7"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 0.0, "", []string{"cpu:8"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 972.0, "", []string{"cpu:8"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 0.0, "", []string{"cpu:9"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 972.0, "", []string{"cpu:9"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 0.0, "", []string{"cpu:10"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 972.0, "", []string{"cpu:10"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 0.0, "", []string{"cpu:11"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 972.0, "", []string{"cpu:11"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 0.0, "", []string{"cpu:12"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 972.0, "", []string{"cpu:12"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.usage", 0.0, "", []string{"cpu:13"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.freq", 972.0, "", []string{"cpu:13"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.inactive_count", 0.0, "", []string(nil)).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.cpu.total_count", 14.0, "", []string(nil)).Return().Once()
+
+	// EMC_FREQ 0%@2750
+	mock.On("Gauge", "nvidia.jetson.emc.usage", 0.0, "", []string(nil)).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.emc.freq", 2750.0, "", []string(nil)).Return().Once()
+
+	// GR3D_FREQ @[494,494,494] — no percentage, only per-GPC frequencies
+	mock.On("Gauge", "nvidia.jetson.gpu.freq", 494.0, "", []string{"gpc:0"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.gpu.freq", 494.0, "", []string{"gpc:1"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.gpu.freq", 494.0, "", []string{"gpc:2"}).Return().Once()
+
+	// cpu@35.875C tj@35.875C soc012@32.562C gpu@34.562C soc345@33.531C
+	mock.On("Gauge", "nvidia.jetson.temp", 35.875, "", []string{"zone:cpu"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.temp", 35.875, "", []string{"zone:tj"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.temp", 32.562, "", []string{"zone:soc012"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.temp", 34.562, "", []string{"zone:gpu"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.temp", 33.531, "", []string{"zone:soc345"}).Return().Once()
+
+	// VDD_GPU 3132mW/3132mW VDD_CPU_SOC_MSS 9397mW/9397mW VIN_SYS_5V0 5680mW/5680mW
+	mock.On("Gauge", "nvidia.jetson.power.instant", 3132.0, "", []string{"probe:VDD_GPU"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.power.average", 3132.0, "", []string{"probe:VDD_GPU"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.power.instant", 9397.0, "", []string{"probe:VDD_CPU_SOC_MSS"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.power.average", 9397.0, "", []string{"probe:VDD_CPU_SOC_MSS"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.power.instant", 5680.0, "", []string{"probe:VIN_SYS_5V0"}).Return().Once()
+	mock.On("Gauge", "nvidia.jetson.power.average", 5680.0, "", []string{"probe:VIN_SYS_5V0"}).Return().Once()
+
+	mock.On("Commit").Return().Once()
+
+	err := tegraCheck.processTegraStatsOutput(thorSample)
+	assert.NoError(t, err)
+
+	mock.AssertExpectations(t)
+	mock.AssertNumberOfCalls(t, "Gauge", 50)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 }
 

--- a/releasenotes/notes/fix-jetson-gr3d-freq-no-pct-a8ad3604842bf646.yaml
+++ b/releasenotes/notes/fix-jetson-gr3d-freq-no-pct-a8ad3604842bf646.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix Jetson check failing to parse ``tegrastats`` output on boards (e.g. Jetson AGX Thor)
+    where ``GR3D_FREQ`` reports only per-GPC frequencies with no usage percentage
+    (e.g. ``GR3D_FREQ @[494,494,494]``). When no percentage is present,
+    ``nvidia.jetson.gpu.usage`` is omitted instead of causing a parse error.


### PR DESCRIPTION
### What does this PR do?

Fix the Jetson check failing on boards (e.g. Jetson AGX Thor) where `tegrastats` emits `GR3D_FREQ @[494,494,494]` — a per-GPC frequency list with no usage percentage. The GPU usage regex required a percentage, causing a parse error for every `tegrastats` line.

Closes #52046

### Motivation

The `GR3D_FREQ` field has three documented formats; the regex only handled the two that include a percentage. The third format (`@[Y,Y,...]`) is used on AGX Thor and reportedly on some Orin configurations.

### Describe how you validated your changes

Added `TestThor` unit test with the exact `tegrastats` output from the bug report. All existing tests continue to pass.

### Additional Notes

When no GPU usage percentage is present, `nvidia.jetson.gpu.usage` is omitted rather than defaulting to zero, consistent with how optional fields are handled elsewhere in this check.