### PR TITLE
feat(healthplatform): structured errors for targeted NPM/USM probe remediation

### DIFF
--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -30,6 +30,13 @@ import (
 // ErrSysprobeUnsupported is the unsupported error prefix, for error-class matching from callers
 var ErrSysprobeUnsupported = errors.New("system-probe unsupported")
 
+// Sentinel errors that categorize probe-init failures for targeted remediation in health issues.
+var (
+	errNetworkProbeKernelUnsupported = errors.New("kernel version not supported by network probe")
+	errNetworkProbeVerifierRejected  = errors.New("eBPF verifier rejected network probe program")
+	errNetworkProbeUSMUnsupported    = errors.New("USM not supported on this kernel")
+)
+
 const inactivityLogDuration = 10 * time.Minute
 const inactivityRestartDuration = 20 * time.Minute
 const maxConntrackDumpSize = 3000
@@ -39,7 +46,7 @@ func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDepe
 
 	// Checking whether the current OS + kernel version is supported by the tracer
 	if supported, err := tracer.IsTracerSupportedByOS(ncfg.ExcludedBPFLinuxVersions); !supported {
-		initErr := fmt.Errorf("%w: %s", ErrSysprobeUnsupported, err)
+		initErr := fmt.Errorf("%w: %w: %s", ErrSysprobeUnsupported, errNetworkProbeKernelUnsupported, err)
 		reportNetworkProbeInitFailure(deps, initErr, ncfg.NPMEnabled, ncfg.ServiceMonitoringEnabled)
 		return nil, initErr
 	}
@@ -53,8 +60,9 @@ func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDepe
 
 	t, err := tracer.NewTracer(ncfg, deps.Telemetry, deps.Statsd)
 	if err != nil {
-		reportNetworkProbeInitFailure(deps, err, ncfg.NPMEnabled, ncfg.ServiceMonitoringEnabled)
-		return nil, err
+		initErr := categorizeTracerError(err)
+		reportNetworkProbeInitFailure(deps, initErr, ncfg.NPMEnabled, ncfg.ServiceMonitoringEnabled)
+		return nil, initErr
 	}
 	resolveNetworkProbeInitFailure(deps)
 

--- a/cmd/system-probe/modules/network_tracer_errcat_linux.go
+++ b/cmd/system-probe/modules/network_tracer_errcat_linux.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && linux_bpf
+
+package modules
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cilium/ebpf"
+
+	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
+)
+
+// categorizeTracerError wraps err with one of the sentinel errors defined in network_tracer.go
+// so that buildNetworkProbeIssue can select targeted remediation steps.
+func categorizeTracerError(err error) error {
+	var ve *ebpf.VerifierError
+	switch {
+	case errors.As(err, &ve):
+		return fmt.Errorf("%w: %w", errNetworkProbeVerifierRejected, err)
+	case errors.Is(err, usmconfig.ErrNotSupported):
+		return fmt.Errorf("%w: %w", errNetworkProbeUSMUnsupported, err)
+	default:
+		return err
+	}
+}

--- a/cmd/system-probe/modules/network_tracer_errcat_other.go
+++ b/cmd/system-probe/modules/network_tracer_errcat_other.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build (windows && npm) || darwin
+
+package modules
+
+// categorizeTracerError returns err unchanged on platforms where eBPF verifier and USM
+// failures cannot occur (Windows, Darwin).
+func categorizeTracerError(err error) error {
+	return err
+}

--- a/cmd/system-probe/modules/network_tracer_health.go
+++ b/cmd/system-probe/modules/network_tracer_health.go
@@ -8,6 +8,7 @@
 package modules
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -70,16 +71,61 @@ func buildNetworkProbeIssue(initErr error, npmEnabled, usmEnabled bool) *healthp
 		Source:      "system-probe",
 		Extra:       extra,
 		Tags:        []string{"system-probe", "npm", "usm", "ebpf", "network-monitoring"},
-		Remediation: &healthplatformpayload.Remediation{
+		Remediation: networkProbeRemediation(initErr),
+	}
+}
+
+func networkProbeRemediation(initErr error) *healthplatformpayload.Remediation {
+	logStep := &healthplatformpayload.RemediationStep{
+		Order: 1, Text: "Check system-probe logs: journalctl -u datadog-agent-sysprobe or /var/log/datadog/system-probe.log",
+	}
+	restartStep := &healthplatformpayload.RemediationStep{
+		Order: 99, Text: "Restart after fixing: systemctl restart datadog-agent-sysprobe",
+	}
+
+	switch {
+	case errors.Is(initErr, errNetworkProbeKernelUnsupported):
+		return &healthplatformpayload.Remediation{
+			Summary: "The running kernel does not meet the minimum version requirements for this feature.",
+			Steps: []*healthplatformpayload.RemediationStep{
+				logStep,
+				{Order: 2, Text: "Check the kernel version: uname -r (NPM requires >= 4.4, USM requires >= 4.14)"},
+				{Order: 3, Text: "Upgrade the host kernel or disable the unsupported feature in datadog.yaml"},
+				restartStep,
+			},
+		}
+	case errors.Is(initErr, errNetworkProbeVerifierRejected):
+		return &healthplatformpayload.Remediation{
+			Summary: "The eBPF verifier rejected a network probe program. The full verifier log is in system-probe logs.",
+			Steps: []*healthplatformpayload.RemediationStep{
+				logStep,
+				{Order: 2, Text: "Search logs for 'verifier' to find the rejected program and the verifier output"},
+				{Order: 3, Text: "Check BTF availability for CO-RE probes: ls /sys/kernel/btf/vmlinux"},
+				{Order: 4, Text: "If in a container, ensure privileged mode or a permissive seccomp profile"},
+				restartStep,
+			},
+		}
+	case errors.Is(initErr, errNetworkProbeUSMUnsupported):
+		return &healthplatformpayload.Remediation{
+			Summary: "Universal Service Monitoring (USM) requires a newer kernel than the one running.",
+			Steps: []*healthplatformpayload.RemediationStep{
+				logStep,
+				{Order: 2, Text: "Check the kernel version: uname -r (USM requires >= 4.14)"},
+				{Order: 3, Text: "Upgrade the host kernel or disable USM (service_monitoring_config.enabled: false) in datadog.yaml"},
+				restartStep,
+			},
+		}
+	default:
+		return &healthplatformpayload.Remediation{
 			Summary: "Check kernel compatibility and system-probe capabilities, then restart system-probe.",
 			Steps: []*healthplatformpayload.RemediationStep{
-				{Order: 1, Text: "Check system-probe logs: journalctl -u datadog-agent-sysprobe or /var/log/datadog/system-probe.log"},
+				logStep,
 				{Order: 2, Text: "Verify kernel version (>= 4.4 for NPM, >= 4.14 for USM): uname -r"},
 				{Order: 3, Text: "Check BTF availability for CO-RE probes: ls /sys/kernel/btf/vmlinux"},
 				{Order: 4, Text: "Verify required capabilities are granted (check system-probe logs for specific capability errors)"},
 				{Order: 5, Text: "If in a container, ensure privileged mode or a permissive seccomp profile"},
-				{Order: 6, Text: "Restart after fixing: systemctl restart datadog-agent-sysprobe"},
+				restartStep,
 			},
-		},
+		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Stacked on #51712. Addresses [brycekahle's review comment](https://github.com/DataDog/datadog-agent/pull/51712#discussion_r2145095038) asking whether we should use structured errors to drive the health issue remediation steps instead of a single generic list.

**Approach:** keep all changes in `cmd/system-probe/modules/` — no need to touch `pkg/network/tracer` or its sub-packages.

Three sentinel errors are added to `network_tracer.go`:
- `errNetworkProbeKernelUnsupported` — wrapped around `IsTracerSupportedByOS` failures
- `errNetworkProbeVerifierRejected` — wrapped when `errors.As(err, &ebpf.VerifierError{})` matches
- `errNetworkProbeUSMUnsupported` — wrapped when `errors.Is(err, usmconfig.ErrNotSupported)` matches

A new `categorizeTracerError(err)` function (Linux-only implementation in `network_tracer_errcat_linux.go`, no-op stub in `network_tracer_errcat_other.go`) categorizes `NewTracer` errors before they reach `reportNetworkProbeInitFailure`.

`buildNetworkProbeIssue` is refactored: the single static remediation block is replaced by a `networkProbeRemediation(initErr)` helper that switches on the sentinel to produce targeted steps:

| Error category | Remediation focus |
|---|---|
| Kernel unsupported | Kernel version requirements, upgrade/disable path |
| Verifier rejection | Verifier log location, BTF/CO-RE check, container seccomp |
| USM unsupported | USM-specific kernel minimum, disable path |
| Generic fallback | Original broad checklist |

### What's not covered

Capability failures (e.g. `EPERM` from the eBPF manager) are still caught by the generic fallback — they're buried inside the cilium/ebpf manager as log lines, not typed errors, so surfacing them cleanly would require upstream changes.

### Validation

```
GOOS=linux GOARCH=amd64 go vet -tags linux_bpf ./cmd/system-probe/modules/
```
No errors introduced by this PR.