### PR TITLE
fix(logs): harden utilization monitor lifecycle

### DIFF
--- a/comp/logs-library/metrics/pipeline_monitor.go
+++ b/comp/logs-library/metrics/pipeline_monitor.go
@@ -192,7 +192,7 @@ type TelemetryPipelineMonitor struct {
 	registry *snapshotRegistry
 
 	// utilizationMonitors are ticked by sampleLoop so a component blocked between Start and Stop is still sampled.
-	utilizationMonitors []*TelemetryUtilizationMonitor
+	utilizationMonitors map[string]*TelemetryUtilizationMonitor
 	clock               clock.Clock
 	sampleInterval      time.Duration
 	stopCh              chan struct{}
@@ -207,11 +207,12 @@ func NewTelemetryPipelineMonitor() *TelemetryPipelineMonitor {
 
 func newTelemetryPipelineMonitorWithClock(clk clock.Clock, sampleInterval time.Duration) *TelemetryPipelineMonitor {
 	return &TelemetryPipelineMonitor{
-		monitors:       make(map[string]*CapacityMonitor),
-		lock:           sync.RWMutex{},
-		registry:       newSnapshotRegistry(),
-		clock:          clk,
-		sampleInterval: sampleInterval,
+		monitors:            make(map[string]*CapacityMonitor),
+		utilizationMonitors: make(map[string]*TelemetryUtilizationMonitor),
+		lock:                sync.RWMutex{},
+		registry:            newSnapshotRegistry(),
+		clock:               clk,
+		sampleInterval:      sampleInterval,
 	}
 }
 
@@ -244,7 +245,7 @@ func (c *TelemetryPipelineMonitor) getMonitor(name string, instanceID string) *C
 func (c *TelemetryPipelineMonitor) MakeUtilizationMonitor(name string, instanceID string) UtilizationMonitor {
 	m := newTelemetryUtilizationMonitorWithSampleRateAndClock(name, instanceID, c.sampleInterval, c.clock, c.registry)
 	c.lock.Lock()
-	c.utilizationMonitors = append(c.utilizationMonitors, m)
+	c.utilizationMonitors[name+":"+instanceID] = m
 	c.lock.Unlock()
 	return m
 }
@@ -287,8 +288,10 @@ func (c *TelemetryPipelineMonitor) sampleLoop(stop, done chan struct{}) {
 		case <-ticker.C:
 			now := c.clock.Now()
 			c.lock.RLock()
-			// MakeUtilizationMonitor only appends, so the captured slice never races registration.
-			monitors := c.utilizationMonitors
+			monitors := make([]*TelemetryUtilizationMonitor, 0, len(c.utilizationMonitors))
+			for _, m := range c.utilizationMonitors {
+				monitors = append(monitors, m)
+			}
 			c.lock.RUnlock()
 			for _, m := range monitors {
 				m.sample(now)

--- a/comp/logs-library/metrics/pipeline_monitor_test.go
+++ b/comp/logs-library/metrics/pipeline_monitor_test.go
@@ -64,6 +64,18 @@ func TestTelemetryPipelineMonitor_StartStopLifecycle(_ *testing.T) {
 	pm.Stop() // idempotent
 }
 
+func TestMakeUtilizationMonitor_ReplacesDuplicateKey(t *testing.T) {
+	clk := clock.NewMock()
+	pm := newTelemetryPipelineMonitorWithClock(clk, time.Second)
+
+	first := pm.MakeUtilizationMonitor("processor", "0").(*TelemetryUtilizationMonitor)
+	second := pm.MakeUtilizationMonitor("processor", "0").(*TelemetryUtilizationMonitor)
+
+	require.Len(t, pm.utilizationMonitors, 1)
+	require.NotSame(t, first, second)
+	require.Same(t, second, pm.utilizationMonitors["processor:0"])
+}
+
 // TestTelemetryPipelineMonitor_TickerSamplesRegisteredMonitor checks the running ticker samples its registered monitors.
 func TestTelemetryPipelineMonitor_TickerSamplesRegisteredMonitor(t *testing.T) {
 	clk := clock.NewMock()

--- a/comp/logs-library/pipeline/provider.go
+++ b/comp/logs-library/pipeline/provider.go
@@ -155,7 +155,6 @@ func tcpSender(
 		componentName,
 		queueCount,
 		workersPerQueue,
-		// A real monitor: this sender owns the snapshot registry surfaced on the status page.
 		metrics.NewTelemetryPipelineMonitor(),
 	)
 }
@@ -214,7 +213,6 @@ func httpSender(
 		minSenderConcurrency,
 		maxSenderConcurrency,
 		secretsComp,
-		// A real monitor: this sender owns the snapshot registry surfaced on the status page.
 		metrics.NewTelemetryPipelineMonitor(),
 	)
 }

--- a/comp/logs-library/pipeline/provider.go
+++ b/comp/logs-library/pipeline/provider.go
@@ -285,6 +285,9 @@ func (p *provider) Start() {
 // If failover is enabled, closes all router channels and waits for forwarder goroutines
 // to finish draining before stopping pipelines.
 func (p *provider) Stop() {
+	// Stop the sampler before pipelines so a flush blocked on a backed-up sender can't leak it.
+	p.sender.PipelineMonitor().Stop()
+
 	stopper := startstop.NewParallelStopper()
 
 	for _, ch := range p.routerChannels {

--- a/comp/logs-library/pipeline/provider_failover_test.go
+++ b/comp/logs-library/pipeline/provider_failover_test.go
@@ -156,3 +156,56 @@ func TestGracefulShutdownDrainsMessages(t *testing.T) {
 		t.Fatal("Stop() did not complete within timeout")
 	}
 }
+
+type recordingMonitor struct {
+	*metrics.NoopPipelineMonitor
+	stopped chan struct{}
+}
+
+func (m *recordingMonitor) Stop() { close(m.stopped) }
+
+func TestProviderStopStopsSamplerBeforePipelines(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("logs_config.message_channel_size", 10)
+
+	endpoints := config.NewMockEndpointsWithOptions([]config.Endpoint{config.NewMockEndpoint()}, map[string]interface{}{
+		"use_http": false,
+	})
+
+	mon := &recordingMonitor{NoopPipelineMonitor: metrics.NewNoopPipelineMonitor(""), stopped: make(chan struct{})}
+	snd := &mockSender{inputChan: make(chan *message.Payload), monitor: mon} // unbuffered, never drained: wedges the strategy
+
+	p := newProvider(
+		1,
+		&diagnostic.BufferedMessageReceiver{},
+		nil,
+		endpoints,
+		nil,
+		cfg,
+		compressionfx.NewMockCompressor(),
+		sender.NewServerlessMeta(false),
+		snd,
+	).(*provider)
+	p.Start()
+
+	p.NextPipelineChan() <- createTestMessage("x", "id")
+
+	stopDone := make(chan struct{})
+	go func() { p.Stop(); close(stopDone) }()
+
+	select {
+	case <-mon.stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider.Stop must stop the sampler before the blocked pipeline stop")
+	}
+
+	for {
+		select {
+		case <-snd.inputChan:
+		case <-stopDone:
+			return
+		case <-time.After(5 * time.Second):
+			t.Fatal("provider.Stop did not complete after draining the sender")
+		}
+	}
+}

--- a/comp/logs-library/sender/sender.go
+++ b/comp/logs-library/sender/sender.go
@@ -180,11 +180,11 @@ func (s *Sender) Start() {
 // Stop stops all sender workers
 func (s *Sender) Stop() {
 	log.Debug("sender mux stopping")
+	s.pipelineMonitor.Stop()
 	for _, s := range s.workers {
 		s.stop()
 	}
 	for _, q := range s.queues {
 		close(q)
 	}
-	s.pipelineMonitor.Stop()
 }

--- a/comp/logs-library/sender/sender_test.go
+++ b/comp/logs-library/sender/sender_test.go
@@ -7,14 +7,58 @@ package sender
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/comp/logs-library/client"
+	"github.com/DataDog/datadog-agent/comp/logs-library/client/http"
 	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
+
+type recordingPipelineMonitor struct {
+	*metrics.NoopPipelineMonitor
+	stopped chan struct{}
+}
+
+func (m *recordingPipelineMonitor) Stop() { close(m.stopped) }
+
+func TestSenderStopHaltsMonitorBeforeWorkerJoin(t *testing.T) {
+	cfg := configmock.New(t)
+	respond := make(chan int)
+	server := http.NewTestServerWithOptions(500, 1, true, respond, cfg)
+	destinationFactory := func(_ string) *client.Destinations {
+		return client.NewDestinations([]client.Destination{server.Destination}, nil)
+	}
+
+	mon := &recordingPipelineMonitor{NoopPipelineMonitor: metrics.NewNoopPipelineMonitor(""), stopped: make(chan struct{})}
+	s := NewSender(cfg, &testAuditor{output: make(chan *message.Payload, 1)}, destinationFactory, 10, NewMockServerlessMeta(false), 1, 1, mon)
+	s.Start()
+
+	s.In() <- &message.Payload{}
+	<-respond
+	<-respond // looping on 500: the worker is wedged, so the worker join would block
+
+	done := make(chan struct{})
+	go func() { s.Stop(); close(done) }()
+
+	select {
+	case <-mon.stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pipeline monitor must be stopped before the wedged worker join")
+	}
+
+	server.ChangeStatus(200)
+	for {
+		if <-respond == 200 {
+			break
+		}
+	}
+	<-done
+	server.Stop()
+}
 
 func TestNewSenderWorkerDistribution(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
### What does this PR do?

Hardens the logs pipeline utilization-monitor lifecycle:

- Registers utilization monitors keyed by `name:instance` (replace on collision) instead of an append-only slice, so a reused `TelemetryPipelineMonitor` can't accumulate duplicate, dead monitors for the same component. 
- Stops the utilization sampler at the start of `provider.Stop()` (and keeps the call in `Sender.Stop()`, which is idempotent). `provider.Stop()` stops pipelines before the sender, and a strategy flush can block on a backed-up sender, so stopping the sampler only in `Sender.Stop()` could leave it running after the stop times out — which is what would emit a spurious "recovered" log. Stopping it first closes that hole.
- Drops two redundant inline comments on the pipeline monitor.

### Motivation

In response to review feedback on the backpressure feature branch (`UTXOnly/backpressure-t4`): https://github.com/DataDog/datadog-agent/pull/51973#discussion_r3397920446 and https://github.com/DataDog/datadog-agent/pull/51973#discussion_r3397883664.

The "dead monitor overwrites live status" path doesn't reproduce on the branch — a transport switch rebuilds the provider/sender/monitor, and the snapshot registry is already instance-owned, so there's no cross-monitor snapshot bleed. These changes implement the suggested lifecycle hardening (keyed registration) and close the residual: a sampler that can leak when the stop times out on a wedged sender.

### Describe how you validated your changes

- `dda inv test` (with `--race`) on `./comp/logs-library/metrics`, `./comp/logs-library/sender`, `./comp/logs-library/pipeline`.
- New tests:
  - `TestMakeUtilizationMonitor_ReplacesDuplicateKey` — keyed replacement leaves one live monitor.
  - `TestSenderStopHaltsMonitorBeforeWorkerJoin` — sampler stops even when a wedged worker would block the join.
  - `TestProviderStopStopsSamplerBeforePipelines` — sampler stops even when a wedged pipeline flush blocks `provider.Stop()`. Verified it fails when the fix is reverted.
- `dda inv linter.go` on the changed packages.

### Additional Notes

