### PR TITLE
fix(fleet/ssi): resolve a supported installer for the systemd unit, d…

### DIFF
--- a/pkg/fleet/installer/packages/apminject/apm_inject.go
+++ b/pkg/fleet/installer/packages/apminject/apm_inject.go
@@ -150,26 +150,16 @@ func (a *InjectorInstaller) Instrument(ctx context.Context) (retErr error) {
 			return err
 		}
 		if systemdRunning {
-			// The service manages /etc/ld.so.preload via ExecStart/ExecStop on
-			// every boot. We also call InstrumentLDPreload directly here so the
-			// current boot is covered: if the service started successfully its
-			// ExecStart already wrote the entry and this becomes a no-op; if the
-			// service failed to start (non-fatal, e.g. during initial install
-			// before the agent is running), this writes the entry directly.
-			mgr := NewSystemdServiceManager()
-			if err := mgr.Setup(ctx); err != nil {
-				return err
-			}
-			a.rollbacks = append(a.rollbacks, func() error {
-				return mgr.Uninstall(ctx)
-			})
-			if err := a.InstrumentLDPreload(ctx); err != nil {
-				return err
-			}
-		} else {
-			if err := a.InstrumentLDPreload(ctx); err != nil {
-				return err
-			}
+			// Best-effort: set up the systemd unit that re-asserts
+			// /etc/ld.so.preload on every boot. This never fails the install — the
+			// unit is a reliability enhancement, and the direct InstrumentLDPreload
+			// below already persists across reboots on its own.
+			a.setupHostPreload(ctx)
+		}
+		// Always write /etc/ld.so.preload directly so the current boot is covered
+		// (and so host injection works even when the systemd unit was skipped).
+		if err := a.InstrumentLDPreload(ctx); err != nil {
+			return err
 		}
 	}
 
@@ -196,6 +186,51 @@ func (a *InjectorInstaller) Instrument(ctx context.Context) (retErr error) {
 	}
 
 	return nil
+}
+
+// setupHostPreload installs (or refreshes) the datadog-apm-inject systemd unit
+// that re-asserts /etc/ld.so.preload on every boot, when a datadog-installer
+// supporting `apm instrument-start` is available. If none is available, or the
+// unit setup fails for any reason, it degrades to direct ld.so.preload management
+// (the InstrumentLDPreload call in Instrument): the unit is a reliability
+// enhancement and must never fail the package install. Any stale unit left by a
+// previous install is removed so a doomed ExecStart is not left enabled.
+func (a *InjectorInstaller) setupHostPreload(ctx context.Context) {
+	span, ctx := telemetry.StartSpanFromContext(ctx, "setup_host_preload")
+	defer func() { span.Finish(nil) }()
+
+	mgr := NewSystemdServiceManager()
+	installerPath := mgr.InstallerPath()
+	span.SetTag("installer_path", installerPath)
+
+	if installerPath == "" {
+		// No installer on disk supports `apm instrument-start` (no candidate at
+		// all, or only older ones — e.g. the pinned agent in the DJM/Databricks
+		// flow, or a stale `stable` symlink on upgrade). Skip the unit and rely on
+		// the direct /etc/ld.so.preload write in Instrument, removing any stale
+		// unit a previous install left behind.
+		span.SetTag("mode", "direct_fallback")
+		if err := mgr.Uninstall(ctx); err != nil {
+			log.Warnf("failed to remove stale apm-inject systemd service: %v", err)
+		}
+		return
+	}
+
+	span.SetTag("mode", "systemd")
+	if err := mgr.Setup(ctx); err != nil {
+		// Degrade rather than abort: clean up any partial unit and rely on the
+		// direct /etc/ld.so.preload write in Instrument.
+		span.SetTag("mode", "direct_fallback_after_setup_error")
+		span.SetTag("setup_error", err.Error())
+		log.Warnf("failed to set up apm-inject systemd service, using direct /etc/ld.so.preload: %v", err)
+		if uErr := mgr.Uninstall(ctx); uErr != nil {
+			log.Warnf("failed to clean up partial apm-inject systemd service: %v", uErr)
+		}
+		return
+	}
+	a.rollbacks = append(a.rollbacks, func() error {
+		return mgr.Uninstall(ctx)
+	})
 }
 
 // Uninstrument uninstruments the APM injector

--- a/pkg/fleet/installer/packages/apminject/systemd.go
+++ b/pkg/fleet/installer/packages/apminject/systemd.go
@@ -13,7 +13,9 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/systemd"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
@@ -46,26 +48,49 @@ type SystemdServiceManager struct {
 	installerPath string
 }
 
-// NewSystemdServiceManager builds a manager pointing at whichever
-// datadog-installer binary is on disk at call time. Every supported install
-// flow leaves at least one candidate present before apm-inject's post-install
-// runs:
-//   - SSI / DD_NO_AGENT_INSTALL: copyInstallerSSI is invoked before the
-//     package install loop in pkg/fleet/installer/setup/common/setup.go,
-//     so /opt/datadog-packages/run/datadog-installer-ssi is in place.
-//   - Regular OCI agent install: datadog-agent is installed before
-//     datadog-apm-inject, so the agent's embedded installer is in place.
-//   - Legacy deb/rpm: /usr/bin/datadog-installer ships with the package.
+// NewSystemdServiceManager builds a manager pointing at the first on-disk
+// datadog-installer that supports the `apm instrument-start`/`instrument-stop`
+// subcommands the unit invokes. The resolved path is baked into the unit's
+// ExecStart/ExecStop. installerPath is "" when no supported installer is found
+// (no candidate on disk, or only older ones); callers must then skip rendering
+// the unit and fall back to direct ld.so.preload management (see
+// setupHostPreload), since the candidate set is not guaranteed in practice.
 func NewSystemdServiceManager() *SystemdServiceManager {
-	installerPath, err := resolveInstallerPath(installerPathCandidates)
+	installerPath, err := resolveInstallerPath(installerPathCandidates, supportsInstrumentSubcommands)
 	if err != nil {
-		log.Warnf("could not resolve datadog-installer path for APM inject service: %v; writeServiceFile will refuse to render the unit", err)
+		log.Warnf("no datadog-installer supporting `apm instrument-start` found for APM inject service: %v", err)
 	}
 	return &SystemdServiceManager{
 		servicePath:   filepath.Join(systemd.UserUnitsPath, systemdServiceName),
 		serviceName:   systemdServiceName,
 		installerPath: installerPath,
 	}
+}
+
+// InstallerPath returns the supported datadog-installer path resolved at
+// construction time, or "" if none was found.
+func (s *SystemdServiceManager) InstallerPath() string {
+	return s.installerPath
+}
+
+// installerVerifier reports whether the datadog-installer at path supports the
+// subcommands the unit invokes. It is a parameter of resolveInstallerPath so
+// tests can exercise pure path resolution without an executable installer.
+type installerVerifier func(path string) bool
+
+// supportsInstrumentSubcommands reports whether the installer at path exposes
+// `apm instrument-start` and `apm instrument-stop`. It inspects the `apm --help`
+// usage text rather than the exit status (which varies by command tree); the
+// subcommands are not Hidden, so a supporting installer lists both.
+func supportsInstrumentSubcommands(path string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, path, "apm", "--help").CombinedOutput()
+	supported := bytes.Contains(out, []byte("instrument-start")) && bytes.Contains(out, []byte("instrument-stop"))
+	if !supported {
+		log.Debugf("installer candidate %s does not expose apm instrument-start/stop (err: %v)", path, err)
+	}
+	return supported
 }
 
 // Setup writes the embedded service file and enables it for future boots.
@@ -76,6 +101,7 @@ func NewSystemdServiceManager() *SystemdServiceManager {
 func (s *SystemdServiceManager) Setup(ctx context.Context) (err error) {
 	span, ctx := telemetry.StartSpanFromContext(ctx, "systemd_service_setup")
 	defer func() { span.Finish(err) }()
+	span.SetTag("installer_path", s.installerPath)
 
 	if err := s.writeServiceFile(); err != nil {
 		return err
@@ -144,7 +170,8 @@ func (s *SystemdServiceManager) writeServiceFile() error {
 	return nil
 }
 
-func resolveInstallerPath(candidates []string) (string, error) {
+func resolveInstallerPath(candidates []string, verify installerVerifier) (string, error) {
+	var skippedUnsupported []string
 	for _, p := range candidates {
 		info, err := os.Stat(p)
 		// Skip if doesn't exist.
@@ -155,7 +182,17 @@ func resolveInstallerPath(candidates []string) (string, error) {
 		if info.IsDir() || info.Mode()&0111 == 0 {
 			continue
 		}
+		// Skip binaries too old to support the subcommands the unit invokes, so we
+		// never bake a doomed ExecStart into the service file and fall through to a
+		// supported candidate if one exists.
+		if verify != nil && !verify(p) {
+			skippedUnsupported = append(skippedUnsupported, p)
+			continue
+		}
 		return p, nil
+	}
+	if len(skippedUnsupported) > 0 {
+		return "", fmt.Errorf("found datadog-installer binaries but none support `apm instrument-start` (too old): %v", skippedUnsupported)
 	}
 	return "", fmt.Errorf("no datadog-installer binary found among %v", candidates)
 }

--- a/pkg/fleet/installer/packages/apminject/systemd_other.go
+++ b/pkg/fleet/installer/packages/apminject/systemd_other.go
@@ -17,6 +17,9 @@ func NewSystemdServiceManager() *SystemdServiceManager {
 	return &SystemdServiceManager{}
 }
 
+// InstallerPath returns "" on non-Linux platforms.
+func (s *SystemdServiceManager) InstallerPath() string { return "" }
+
 // Setup is a no-op on non-Linux platforms.
 func (s *SystemdServiceManager) Setup(_ context.Context) error { return nil }
 

--- a/pkg/fleet/installer/packages/apminject/systemd_test.go
+++ b/pkg/fleet/installer/packages/apminject/systemd_test.go
@@ -126,7 +126,7 @@ func TestResolveInstallerPath(t *testing.T) {
 	executable := filepath.Join(tmpDir, "executable")
 	require.NoError(t, os.WriteFile(executable, []byte("#!/bin/sh\n"), 0755))
 
-	got, err := resolveInstallerPath([]string{missing, nonExec, executable})
+	got, err := resolveInstallerPath([]string{missing, nonExec, executable}, alwaysSupported)
 	require.NoError(t, err)
 	assert.Equal(t, executable, got)
 }
@@ -136,7 +136,7 @@ func TestResolveInstallerPath_AllMissing(t *testing.T) {
 	_, err := resolveInstallerPath([]string{
 		filepath.Join(tmpDir, "a"),
 		filepath.Join(tmpDir, "b"),
-	})
+	}, alwaysSupported)
 	assert.Error(t, err)
 }
 
@@ -147,10 +147,54 @@ func TestResolveInstallerPath_SkipsDirectory(t *testing.T) {
 	exe := filepath.Join(tmpDir, "candidate-exe")
 	require.NoError(t, os.WriteFile(exe, []byte{}, 0755))
 
-	got, err := resolveInstallerPath([]string{dir, exe})
+	got, err := resolveInstallerPath([]string{dir, exe}, alwaysSupported)
 	require.NoError(t, err)
 	assert.Equal(t, exe, got)
 }
+
+// TestResolveInstallerPath_SkipsUnsupportedInstaller guards the upgrade case: a
+// higher-priority candidate that is on disk and executable but too old to support
+// `apm instrument-start` must be skipped in favor of a newer candidate.
+func TestResolveInstallerPath_SkipsUnsupportedInstaller(t *testing.T) {
+	tmpDir := t.TempDir()
+	stale := filepath.Join(tmpDir, "stale-installer")
+	require.NoError(t, os.WriteFile(stale, []byte{}, 0755))
+	fresh := filepath.Join(tmpDir, "fresh-installer")
+	require.NoError(t, os.WriteFile(fresh, []byte{}, 0755))
+
+	got, err := resolveInstallerPath([]string{stale, fresh}, func(p string) bool { return p == fresh })
+	require.NoError(t, err)
+	assert.Equal(t, fresh, got, "stale installer (no instrument-start) must be skipped")
+}
+
+// TestResolveInstallerPath_AllUnsupported asserts we report failure rather than
+// return a stale installer that would produce a unit doomed to fail on boot.
+func TestResolveInstallerPath_AllUnsupported(t *testing.T) {
+	tmpDir := t.TempDir()
+	exe := filepath.Join(tmpDir, "old-installer")
+	require.NoError(t, os.WriteFile(exe, []byte{}, 0755))
+
+	_, err := resolveInstallerPath([]string{exe}, func(string) bool { return false })
+	assert.ErrorContains(t, err, "too old")
+}
+
+// TestSupportsInstrumentSubcommands exercises the real `apm --help` probe against
+// stub binaries standing in for a newer and an older datadog-installer.
+func TestSupportsInstrumentSubcommands(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	newer := filepath.Join(tmpDir, "new-installer")
+	require.NoError(t, os.WriteFile(newer, []byte("#!/bin/sh\necho 'Available Commands:'\necho '  instrument-start ...'\necho '  instrument-stop ...'\n"), 0755))
+	assert.True(t, supportsInstrumentSubcommands(newer))
+
+	older := filepath.Join(tmpDir, "old-installer")
+	require.NoError(t, os.WriteFile(older, []byte("#!/bin/sh\necho 'Available Commands:'\necho '  instrument ...'\necho '  uninstrument ...'\n"), 0755))
+	assert.False(t, supportsInstrumentSubcommands(older))
+
+	assert.False(t, supportsInstrumentSubcommands(filepath.Join(tmpDir, "does-not-exist")))
+}
+
+func alwaysSupported(string) bool { return true }
 
 func TestSystemdServiceManager_Uninstall(t *testing.T) {
 	tmpDir := t.TempDir()


### PR DESCRIPTION
…egrade gracefully otherwise

The datadog-apm-inject systemd unit bakes a resolved datadog-installer path into its ExecStart (`<installer> apm instrument-start host`). Two failure modes were observed in production and CI:

- When no candidate installer path exists, resolution returned an empty path and writeServiceFile refused to render the unit, aborting the whole datadog-apm-inject package install ("could not setup package ... refusing to write ... with empty installer path").
- When only an older installer is present (no `apm instrument-start`, e.g. an upgrade from an older Agent or a flow that pins an older Agent like DJM), the unit was rendered pointing at it and failed its ExecStart on every boot.

Resolution now verifies a candidate actually exposes the instrument subcommands (via `apm --help`) and skips ones that do not. When no supported installer is available, or unit setup fails for any reason, the installer degrades to direct /etc/ld.so.preload management (which persists across reboots) instead of failing the install. A `setup_host_preload` span (mode/installer_path tags) and an `installer_path` tag on `systemd_service_setup` make the decision visible in APM.

Fixes some errors "refusing to write /etc/systemd/system/datadog-apm-inject.service with empty installer path" https://app.datadoghq.com/u/d4735e3a/QDe-3nB-jgB