### PR TITLE
Align allium specs with code implementation

### DIFF
--- a/comp/anomalydetection/reporter/reporter.allium
+++ b/comp/anomalydetection/reporter/reporter.allium
@@ -16,8 +16,8 @@
 --     resources, change_metadata)
 --   - Sub-category classification (spike, drop, new_pattern) recorded in
 --     change_metadata.sub_category
---   - Routing identity for edge-intelligence (integration_id,
---     source_type_id, changed_resource.type), locked by invariant
+--   - Routing identity for edge-intelligence (integration_id and
+--     changed_resource.type), locked by invariant
 --   - Payload size caps imposed by the v2 Events API
 --
 -- Excludes:
@@ -104,7 +104,6 @@ external entity ChangeEvent {
     message: String
     category: EventCategory
     integration_id: String
-    source_type_id: Integer
     tags: Set<String>
     timestamp: Timestamp
     aggregation_key: String
@@ -253,9 +252,12 @@ config {
 -- Routing Identity
 ------------------------------------------------------------
 
--- The Event Management intake routes a change event by the publisher's
--- (integration_id, source_type_id) pair. These values are constants of
--- the `edge-intelligence` integration; they are not configurable and are
+-- The Event Management intake routes a change event by integration_id.
+-- source_type_id is derived intake-side from that integration and is not
+-- emitted by the reporter payload.
+--
+-- integration_id and changed_resource.type are constants of the
+-- `edge-intelligence` integration; they are not configurable and are
 -- enforced on every emitted ChangeEvent by the RoutingIdentityLocked
 -- invariant.
 --
@@ -263,7 +265,7 @@ config {
 -- previously-emitted `configuration` value.
 --
 --   integration_id        = "edge-intelligence"
---   source_type_id        = 78252213
+--   derived source_type_id = 78252213 (from integration_id)
 --   changed_resource_type = "anomaly"
 --   author_name           = "datadog-agent-observer"
 --   author_type           = "automation"
@@ -340,7 +342,6 @@ rule PublishNewCorrelation {
                     message: render_change_message(c),
                     category: change,
                     integration_id: "edge-intelligence",
-                    source_type_id: 78252213,
                     tags: derive_event_tags(c),
                     timestamp: c.first_seen,
                     aggregation_key: "observer:" + c.pattern,
@@ -504,11 +505,12 @@ invariant SubCategoryCoversAll {
 
 invariant RoutingIdentityLocked {
     -- Every emitted ChangeEvent uses the locked routing identity.
+    -- source_type_id is not emitted; Event Management derives it from
+    -- integration_id for the registered publisher.
     -- changed_resource.type is `anomaly`; the previously-emitted
     -- `configuration` value is rejected by the intake.
     for e in ChangeEvents:
         e.integration_id = "edge-intelligence"
-        and e.source_type_id = 78252213
         and e.changed_resource_type = "anomaly"
         and e.author_name = "datadog-agent-observer"
         and e.author_type = "automation"

--- a/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
+++ b/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
@@ -15,6 +15,8 @@
 --   - Message framing, parsing, and raw content handling
 --   - Telemetry counter emissions (dropped, kept, new_patterns, evictions)
 --   - NoopSampler (trivial pass-through when sampling is disabled)
+--   - Include/exclude filter resolution and important-log bypass policy
+--     wiring (modelled as preconditions around ProcessLog entry)
 
 ------------------------------------------------------------
 -- Value Types
@@ -39,12 +41,16 @@
 --   Character runs: consecutive letters [a-zA-Z] and any byte not
 --     classified above produce a single token encoding the run length:
 --     C1 (1 char) through C10 (10+ chars). Capped at C10.
---     Before emitting, short runs (1-4 chars) are checked for special
+--     Before emitting, short runs (1-9 chars) are checked for special
 --     token promotion (see Tokenization contract).
 --
---   Special: character runs of 1-4 chars that match known patterns
---     are promoted to one of: Month, Day, Zone, Apm, T.
---     The regular C1-C4 token is replaced by the special token.
+--   Special: character runs of 1-9 chars that match known patterns
+--     are promoted to one of:
+--       Month, Day, Zone, Apm, T
+--       Warn, Fatal, Error, Panic, Alert, Severe, Critical,
+--       Emergency, Exception, Crash, Failure, Deadlock, Timeout
+--     The corresponding regular Cn token is replaced by the special
+--     token.
 
 value TokenSequence {
     -- Ordered sequence of tokens produced by the tokenizer from
@@ -112,9 +118,9 @@ contract Tokenization {
         -- 15 consecutive digits produce D10, identical to 10 digits.
 
     @invariant SpecialTokenPromotion
-        -- Before emitting a character run of length 1-4, the run's
+        -- Before emitting a character run of length 1-9, the run's
         -- bytes are uppercased and checked against a fixed table.
-        -- If matched, the special token replaces the regular C1-C4:
+        -- If matched, the special token replaces the regular Cn:
         --   Length 1: T → time_separator, Z → zone
         --   Length 2: AM, PM → apm
         --   Length 3:
@@ -123,10 +129,33 @@ contract Tokenization {
         --     UTC GMT EST EDT CST CDT MST MDT PST PDT JST KST
         --       IST MSK CET BST HST HDT NST NDT → zone
         --   Length 4:
+        --     WARN → warn
+        --     CRIT → critical
         --     CEST NZST NZDT ACST ACDT AEST AEDT AWST AWDT
         --       AKST AKDT CHST CHDT → zone
-        -- Character runs of length 5+ are never promoted. Runs of
-        -- length 1-4 that match no pattern emit the regular token.
+        --   Length 5:
+        --     FATAL → fatal
+        --     ERROR → error
+        --     PANIC → panic
+        --     ALERT → alert
+        --     EMERG → emergency
+        --     CRASH → crash
+        --   Length 6:
+        --     SEVERE → severe
+        --     FAILED → failure
+        --   Length 7:
+        --     WARNING → warn
+        --     CRASHED → crash
+        --     FAILURE → failure
+        --     TIMEOUT → timeout
+        --   Length 8:
+        --     CRITICAL → critical
+        --     DEADLOCK → deadlock
+        --   Length 9:
+        --     EMERGENCY → emergency
+        --     EXCEPTION → exception
+        -- Character runs of length 10+ are never promoted. Runs of
+        -- length 1-9 that match no pattern emit the regular token.
         -- Matching is case-insensitive: "jan", "JAN", "Jan" all
         -- match month.
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"2f7d0c8f-9eaa-485c-8d74-e0c1907cb521","source":"chat","resourceId":"5c895448-4a70-4767-a79c-15c72d7d1f0f","workflowId":"cc9edbd1-7feb-4e0e-8b6f-46f8d33d9467","codeChangeId":"cc9edbd1-7feb-4e0e-8b6f-46f8d33d9467","sourceType":"scheduled_task"} -->
### What does this PR do?

Updates `.allium` specification files to align with actual code implementation by removing `source_type_id` field from ChangeEvent and expanding tokenization special token promotion rules.

### Motivation

The `.allium` spec files contained mismatches with the implementation:
1. `reporter.allium` specified `source_type_id` as part of the routing identity, but the code does not emit this field. Event Management derives it intake-side from the `integration_id`.
2. `adaptive_sampler.allium` documented special token promotion for character runs of length 1-4, but the implementation supports lengths 1-9 with additional level/severity keywords.

### Describe how you validated your changes

- Reviewed `comp/anomalydetection/reporter/reporter.allium` against the ChangeEvent structure to confirm `source_type_id` removal
- Updated routing identity documentation to clarify that `source_type_id` is derived intake-side, not emitted
- Removed `source_type_id` assignment from `PublishNewCorrelation` rule
- Updated `RoutingIdentityLocked` invariant to reflect the correct constraints
- Expanded `adaptive_sampler.allium` tokenization contract to document all supported special token patterns up to length 9 (WARN, FATAL, ERROR, PANIC, ALERT, SEVERE, CRITICAL, EMERGENCY, EXCEPTION, CRASH, FAILURE, DEADLOCK, TIMEOUT)

### Additional Notes

These changes ensure the specification documents accurately reflect the production code behavior and serve as authoritative documentation for the systems they describe.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/5c895448-4a70-4767-a79c-15c72d7d1f0f)

Comment @datadog to request changes