### PR TITLE
[noisy_neighbor] Re-introduce per-cgroup PMU + tracepoint signals (dev image)

### DIFF
--- a/cmd/system-probe/modules/noisy_neighbor.go
+++ b/cmd/system-probe/modules/noisy_neighbor.go
@@ -10,10 +10,12 @@ package modules
 import (
 	"fmt"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/noisyneighbor"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
@@ -22,6 +24,28 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// pmuMetricConfigKeys maps each BPF perf-event-array map name to its
+// noisy_neighbor.pmu_metrics.* config key. Kept in one place so adding a
+// new PMU event is a single edit.
+var pmuMetricConfigKeys = map[string]string{
+	"cycles_pmu":           "noisy_neighbor.pmu_metrics.cycles",
+	"instructions_pmu":     "noisy_neighbor.pmu_metrics.instructions",
+	"cache_misses_pmu":     "noisy_neighbor.pmu_metrics.cache_misses",
+	"cache_references_pmu": "noisy_neighbor.pmu_metrics.cache_references",
+	"itlb_misses_pmu":      "noisy_neighbor.pmu_metrics.itlb_misses",
+	"branch_misses_pmu":    "noisy_neighbor.pmu_metrics.branch_misses",
+	"cpu_migrations_pmu":   "noisy_neighbor.pmu_metrics.cpu_migrations",
+}
+
+func readPMUMetricsConfig() map[string]bool {
+	cfg := pkgconfigsetup.SystemProbe()
+	out := make(map[string]bool, len(pmuMetricConfigKeys))
+	for mapName, configKey := range pmuMetricConfigKeys {
+		out[mapName] = cfg.GetBool(configKey)
+	}
+	return out
+}
+
 func init() { registerModule(NoisyNeighbor) }
 
 // NoisyNeighbor Factory
@@ -29,13 +53,15 @@ var NoisyNeighbor = &module.Factory{
 	Name: config.NoisyNeighborModule,
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		log.Infof("Starting the noisy neighbor module")
-		p, err := noisyneighbor.NewProbe(ebpf.NewConfig())
+		pmuMetrics := readPMUMetricsConfig()
+		p, err := noisyneighbor.NewProbe(ebpf.NewConfig(), noisyneighbor.Config{PMUMetrics: pmuMetrics})
 		if err != nil {
 			return nil, fmt.Errorf("unable to start the noisy neighbor probe: %w", err)
 		}
 		return &noisyNeighborModule{
-			Probe:     p,
-			lastCheck: &atomic.Int64{},
+			Probe:      p,
+			lastCheck:  &atomic.Int64{},
+			pmuMetrics: pmuMetrics,
 		}, nil
 	},
 	NeedsEBPF: func() bool {
@@ -47,24 +73,50 @@ var _ module.Module = &noisyNeighborModule{}
 
 type noisyNeighborModule struct {
 	*noisyneighbor.Probe
-	lastCheck *atomic.Int64
+	lastCheck  *atomic.Int64
+	pmuMetrics map[string]bool
+	inflight   sync.WaitGroup
+	closed     atomic.Bool
 }
 
 // GetStats implements module.Module.GetStats
-func (n noisyNeighborModule) GetStats() map[string]interface{} {
+func (n *noisyNeighborModule) GetStats() map[string]interface{} {
 	return map[string]interface{}{
-		"last_check": n.lastCheck.Load(),
+		"last_check":  n.lastCheck.Load(),
+		"pmu_metrics": n.pmuMetrics,
 	}
 }
 
 // Register implements module.Module.Register
-func (n noisyNeighborModule) Register(httpMux *module.Router) error {
+func (n *noisyNeighborModule) Register(httpMux *module.Router) error {
 	// Limit concurrency to one as the probe check is not thread safe (mainly in the entry count buffers)
 	httpMux.HandleFunc("/check", utils.WithConcurrencyLimit(1, func(w http.ResponseWriter, req *http.Request) {
+		if n.closed.Load() {
+			http.Error(w, "module closing", http.StatusServiceUnavailable)
+			return
+		}
+		n.inflight.Add(1)
+		defer n.inflight.Done()
+		// Re-check after Add to close the race where Close() observed inflight==0
+		// before our Add but set closed afterwards.
+		if n.closed.Load() {
+			http.Error(w, "module closing", http.StatusServiceUnavailable)
+			return
+		}
 		n.lastCheck.Store(time.Now().Unix())
 		stats := n.Probe.GetAndFlush()
 		utils.WriteAsJSON(req, w, stats, utils.GetPrettyPrintFromQueryParams(req))
 	}))
 
 	return nil
+}
+
+// Close marks the module as closing, waits for any in-flight /check
+// handlers to complete, and then tears down the underlying eBPF probe.
+// Without this, an in-flight GetAndFlush iterating the BPF map could race
+// with Probe.Close() unloading the manager.
+func (n *noisyNeighborModule) Close() {
+	n.closed.Store(true)
+	n.inflight.Wait()
+	n.Probe.Close()
 }

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
@@ -8,6 +8,39 @@ typedef struct {
     __u64 event_count;
     __u64 preemption_count;
     __u64 pid_count;
+    __u64 sum_cycles;
+    __u64 sum_instructions;
+    __u64 sum_cache_misses;
+    __u64 sum_itlb_misses;
+    __u64 sum_softirq_ns;
+    __u64 block_io_requests;
+    __u64 sum_branch_misses;
+    __u64 sum_cpu_migrations;
+    __u64 wakeup_count;
+    __u64 sum_cache_references;
 } cgroup_agg_stats_t;
+
+// Per-PMU-event stamp: counter value plus enabled/running times.
+// enabled and running are needed to scale counter deltas back up when the
+// kernel time-multiplexes a hardware counter onto fewer physical counters
+// than there are configured events. Without scaling, multiplexed events
+// under-report by a factor of running/enabled. See bpf_perf_event_read_value
+// docs and tools/perf/Documentation/perf-stat.txt for the standard formula
+// scaled = counter * enabled / running.
+typedef struct {
+    __u64 counter;
+    __u64 enabled;
+    __u64 running;
+} pmu_event_stamp_t;
+
+typedef struct {
+    pmu_event_stamp_t cycles;
+    pmu_event_stamp_t instructions;
+    pmu_event_stamp_t cache_misses;
+    pmu_event_stamp_t itlb_misses;
+    pmu_event_stamp_t branch_misses;
+    pmu_event_stamp_t cpu_migrations;
+    pmu_event_stamp_t cache_references;
+} task_pmu_stamp_t;
 
 #endif

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -12,7 +12,24 @@
 
 BPF_TASK_STORAGE_MAP(runq_enqueued, u64)
 
+BPF_TASK_STORAGE_MAP(task_oncpu_pmu, task_pmu_stamp_t)
+
 BPF_PERCPU_HASH_MAP(cgroup_agg_stats, __u64, cgroup_agg_stats_t, MAX_TASK_ENTRIES)
+
+// Per-CPU perf event arrays for hardware counters. Populated from user space
+// at probe init; if a CPU's slot is unset, the read helper returns -ENOENT
+// and the corresponding deltas are skipped.
+BPF_PERF_EVENT_ARRAY_MAP(cycles_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(instructions_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(cache_misses_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(itlb_misses_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(branch_misses_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(cpu_migrations_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(cache_references_pmu, u32)
+
+// Per-CPU softirq entry timestamp. Single-slot percpu array; softirq runs in
+// non-preemptible context so per-CPU storage is sufficient.
+BPF_PERCPU_ARRAY_MAP(softirq_start_ns, __u64, 1)
 
 void bpf_rcu_read_lock(void) __ksym;
 void bpf_rcu_read_unlock(void) __ksym;
@@ -61,6 +78,128 @@ static __always_inline int enqueue_timestamp(struct task_struct *task) {
     return 0;
 }
 
+// scaled_pmu_delta computes (val.counter - stamp.counter) scaled by
+// enabled/running to undo any time-multiplexing the kernel applied to the
+// underlying hardware counter. When enabled == running (no multiplexing),
+// the result equals the raw delta. When the event was paused for the
+// entire window (running_delta == 0), returns 0 — the sample carries no
+// usable information.
+static __always_inline u64 scaled_pmu_delta(struct bpf_perf_event_value *val, pmu_event_stamp_t *stamp) {
+    u64 raw = val->counter - stamp->counter;
+    u64 enabled_delta = val->enabled - stamp->enabled;
+    u64 running_delta = val->running - stamp->running;
+    if (running_delta == 0) {
+        return 0;
+    }
+    if (enabled_delta == running_delta) {
+        return raw;
+    }
+    // Compute as raw + raw*(enabled-running)/running rather than
+    // raw*enabled/running to keep the multiplication operands small in
+    // the common multiplexing case (enabled-running << running). This
+    // reduces — but does not eliminate — u64 overflow risk on very long
+    // sched windows.
+    u64 missing = enabled_delta - running_delta;
+    return raw + (raw * missing) / running_delta;
+}
+
+// pmu_sample_t holds one sample of every PMU event we track, along with
+// per-event ok flags marking which reads succeeded. A failed read leaves
+// the bpf_perf_event_value buffer at zero; the ok flag prevents that zero
+// from being used as a stamp baseline (which would produce a huge bogus
+// delta on the next sched_switch) or as an accumulator input.
+//
+// Every counter is gated independently: cycles can be on while instructions
+// is off, etc. (CPI, if needed, is computed dashboard-side from the raw
+// counters.) When a userspace toggle disables a perf event, that event's
+// perf-event-array map stays empty, the read returns -ENOENT, the ok flag
+// stays false, and accumulation skips that counter only.
+typedef struct {
+    struct bpf_perf_event_value cycles;
+    struct bpf_perf_event_value instructions;
+    struct bpf_perf_event_value cache_misses;
+    struct bpf_perf_event_value itlb_misses;
+    struct bpf_perf_event_value branch_misses;
+    struct bpf_perf_event_value cpu_migrations;
+    struct bpf_perf_event_value cache_references;
+    bool cycles_ok;
+    bool instructions_ok;
+    bool cache_misses_ok;
+    bool itlb_ok;
+    bool branch_misses_ok;
+    bool cpu_migrations_ok;
+    bool cache_references_ok;
+} pmu_sample_t;
+
+static __always_inline void pmu_sample_all(pmu_sample_t *s) {
+    s->cycles_ok = bpf_perf_event_read_value(&cycles_pmu, BPF_F_CURRENT_CPU, &s->cycles, sizeof(s->cycles)) == 0;
+    s->instructions_ok = bpf_perf_event_read_value(&instructions_pmu, BPF_F_CURRENT_CPU, &s->instructions, sizeof(s->instructions)) == 0;
+    s->cache_misses_ok = bpf_perf_event_read_value(&cache_misses_pmu, BPF_F_CURRENT_CPU, &s->cache_misses, sizeof(s->cache_misses)) == 0;
+    s->itlb_ok = bpf_perf_event_read_value(&itlb_misses_pmu, BPF_F_CURRENT_CPU, &s->itlb_misses, sizeof(s->itlb_misses)) == 0;
+    s->branch_misses_ok = bpf_perf_event_read_value(&branch_misses_pmu, BPF_F_CURRENT_CPU, &s->branch_misses, sizeof(s->branch_misses)) == 0;
+    s->cpu_migrations_ok = bpf_perf_event_read_value(&cpu_migrations_pmu, BPF_F_CURRENT_CPU, &s->cpu_migrations, sizeof(s->cpu_migrations)) == 0;
+    s->cache_references_ok = bpf_perf_event_read_value(&cache_references_pmu, BPF_F_CURRENT_CPU, &s->cache_references, sizeof(s->cache_references)) == 0;
+}
+
+static __always_inline bool pmu_any_ok(pmu_sample_t *s) {
+    return s->cycles_ok || s->instructions_ok || s->cache_misses_ok || s->itlb_ok ||
+           s->branch_misses_ok || s->cpu_migrations_ok || s->cache_references_ok;
+}
+
+static __always_inline void pmu_stamp_event(pmu_event_stamp_t *slot, struct bpf_perf_event_value *val) {
+    slot->counter = val->counter;
+    slot->enabled = val->enabled;
+    slot->running = val->running;
+}
+
+static __always_inline void pmu_stamp_from_sample(task_pmu_stamp_t *stamp, pmu_sample_t *s) {
+    if (s->cycles_ok) {
+        pmu_stamp_event(&stamp->cycles, &s->cycles);
+    }
+    if (s->instructions_ok) {
+        pmu_stamp_event(&stamp->instructions, &s->instructions);
+    }
+    if (s->cache_misses_ok) {
+        pmu_stamp_event(&stamp->cache_misses, &s->cache_misses);
+    }
+    if (s->itlb_ok) {
+        pmu_stamp_event(&stamp->itlb_misses, &s->itlb_misses);
+    }
+    if (s->branch_misses_ok) {
+        pmu_stamp_event(&stamp->branch_misses, &s->branch_misses);
+    }
+    if (s->cpu_migrations_ok) {
+        pmu_stamp_event(&stamp->cpu_migrations, &s->cpu_migrations);
+    }
+    if (s->cache_references_ok) {
+        pmu_stamp_event(&stamp->cache_references, &s->cache_references);
+    }
+}
+
+static __always_inline void pmu_accum_to_stats(cgroup_agg_stats_t *stats, task_pmu_stamp_t *stamp, pmu_sample_t *s) {
+    if (s->cycles_ok) {
+        stats->sum_cycles += scaled_pmu_delta(&s->cycles, &stamp->cycles);
+    }
+    if (s->instructions_ok) {
+        stats->sum_instructions += scaled_pmu_delta(&s->instructions, &stamp->instructions);
+    }
+    if (s->cache_misses_ok) {
+        stats->sum_cache_misses += scaled_pmu_delta(&s->cache_misses, &stamp->cache_misses);
+    }
+    if (s->itlb_ok) {
+        stats->sum_itlb_misses += scaled_pmu_delta(&s->itlb_misses, &stamp->itlb_misses);
+    }
+    if (s->branch_misses_ok) {
+        stats->sum_branch_misses += scaled_pmu_delta(&s->branch_misses, &stamp->branch_misses);
+    }
+    if (s->cpu_migrations_ok) {
+        stats->sum_cpu_migrations += scaled_pmu_delta(&s->cpu_migrations, &stamp->cpu_migrations);
+    }
+    if (s->cache_references_ok) {
+        stats->sum_cache_references += scaled_pmu_delta(&s->cache_references, &stamp->cache_references);
+    }
+}
+
 static __always_inline cgroup_agg_stats_t *get_or_create_cgroup_stats(u64 cgroup_id) {
     cgroup_agg_stats_t *stats = bpf_map_lookup_elem(&cgroup_agg_stats, &cgroup_id);
     if (!stats) {
@@ -71,16 +210,50 @@ static __always_inline cgroup_agg_stats_t *get_or_create_cgroup_stats(u64 cgroup
     return stats;
 }
 
+// task_cgroup_stats returns the cgroup aggregate stats entry for the given
+// task, creating it on first observation. Returns NULL if the map insert fails.
+static __always_inline cgroup_agg_stats_t *task_cgroup_stats(struct task_struct *task) {
+    u64 cgroup_id = get_task_cgroup_id(task);
+    return get_or_create_cgroup_stats(cgroup_id);
+}
+
+// current_cgroup_stats returns the cgroup aggregate stats entry for the
+// currently-running task. Returns NULL if the current task pointer can't be
+// resolved or if the map insert fails.
+static __always_inline cgroup_agg_stats_t *current_cgroup_stats(void) {
+    struct task_struct *task = bpf_get_current_task_btf();
+    if (!task) {
+        return NULL;
+    }
+    return task_cgroup_stats(task);
+}
+
+// count_wakeup increments the per-cgroup wakeup counter for the given task.
+// Called only from the genuine wakeup tracepoints — not from the sched_switch
+// re-enqueue path (which is a preemption-driven re-enqueue, not a wakeup).
+static __always_inline void count_wakeup(struct task_struct *task) {
+    cgroup_agg_stats_t *stats = task_cgroup_stats(task);
+    if (stats) {
+        stats->wakeup_count += 1;
+    }
+}
+
+// handle_wakeup is the shared body of tp_sched_wakeup and tp_sched_wakeup_new.
+// Both tracepoints carry the same (task) shape and need the same accounting:
+// count the wakeup, then stamp the enqueue timestamp.
+static __always_inline int handle_wakeup(struct task_struct *task) {
+    count_wakeup(task);
+    return enqueue_timestamp(task);
+}
+
 SEC("tp_btf/sched_wakeup")
 int tp_sched_wakeup(u64 *ctx) {
-    struct task_struct *task = (void *)ctx[0];
-    return enqueue_timestamp(task);
+    return handle_wakeup((struct task_struct *)ctx[0]);
 }
 
 SEC("tp_btf/sched_wakeup_new")
 int tp_sched_wakeup_new(u64 *ctx) {
-    struct task_struct *task = (void *)ctx[0];
-    return enqueue_timestamp(task);
+    return handle_wakeup((struct task_struct *)ctx[0]);
 }
 
 SEC("tp_btf/sched_switch")
@@ -91,13 +264,28 @@ int tp_sched_switch(u64 *ctx) {
     u32 prev_pid = prev->pid;
     u32 next_pid = next->pid;
 
+    // Sample PMU counters once. Each read is independent — if iTLB events
+    // aren't supported but cycles are, only iTLB deltas are skipped.
+    pmu_sample_t pmu = {};
+    pmu_sample_all(&pmu);
+    bool pmu_ok = pmu_any_ok(&pmu);
+
+    if (pmu_ok && prev_pid) {
+        task_pmu_stamp_t *stamp = bpf_task_storage_get(&task_oncpu_pmu, prev, NULL, 0);
+        if (stamp) {
+            cgroup_agg_stats_t *stats = task_cgroup_stats(prev);
+            if (stats) {
+                pmu_accum_to_stats(stats, stamp, &pmu);
+            }
+        }
+    }
+
     if (prev->__state == TASK_RUNNING) {
         enqueue_timestamp(prev);
     }
 
     if (preempted && prev_pid) {
-        u64 prev_cgroup_id = get_task_cgroup_id(prev);
-        cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(prev_cgroup_id);
+        cgroup_agg_stats_t *stats = task_cgroup_stats(prev);
         if (stats) {
             stats->preemption_count += 1;
         }
@@ -105,6 +293,14 @@ int tp_sched_switch(u64 *ctx) {
 
     if (!next_pid) {
         return 0;
+    }
+
+    if (pmu_ok) {
+        task_pmu_stamp_t zero = {};
+        task_pmu_stamp_t *stamp = bpf_task_storage_get(&task_oncpu_pmu, next, &zero, BPF_LOCAL_STORAGE_GET_F_CREATE);
+        if (stamp) {
+            pmu_stamp_from_sample(stamp, &pmu);
+        }
     }
 
     u64 *tsp = bpf_task_storage_get(&runq_enqueued, next, NULL, 0);
@@ -115,14 +311,58 @@ int tp_sched_switch(u64 *ctx) {
     u64 runq_lat = bpf_ktime_get_ns() - *tsp;
     bpf_task_storage_delete(&runq_enqueued, next);
 
-    u64 cgroup_id = get_task_cgroup_id(next);
-    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    cgroup_agg_stats_t *stats = task_cgroup_stats(next);
     if (stats) {
         stats->sum_latencies_ns += runq_lat;
         stats->event_count += 1;
         stats->pid_count = get_cgroup_pids_count(next);
     }
 
+    return 0;
+}
+
+// Softirq accounting: stamp the entry timestamp per CPU; on exit, attribute
+// the elapsed nanoseconds to the cgroup of whatever task was running on this
+// CPU when the softirq fired. For irq-tail softirq processing, this charges
+// time back to the interrupted task's cgroup (the victim — exactly what we
+// want). For ksoftirqd-driven softirqs, it charges to the ksoftirqd cgroup
+// (typically root); a known limitation we accept for the prototype.
+SEC("tp_btf/softirq_entry")
+int tp_softirq_entry(u64 *ctx) {
+    u32 zero = 0;
+    u64 *slot = bpf_map_lookup_elem(&softirq_start_ns, &zero);
+    if (slot) {
+        *slot = bpf_ktime_get_ns();
+    }
+    return 0;
+}
+
+SEC("tp_btf/softirq_exit")
+int tp_softirq_exit(u64 *ctx) {
+    u32 zero = 0;
+    u64 *slot = bpf_map_lookup_elem(&softirq_start_ns, &zero);
+    if (!slot || *slot == 0) {
+        return 0;
+    }
+    u64 delta = bpf_ktime_get_ns() - *slot;
+    *slot = 0;
+
+    cgroup_agg_stats_t *stats = current_cgroup_stats();
+    if (stats) {
+        stats->sum_softirq_ns += delta;
+    }
+    return 0;
+}
+
+// Block I/O issue tracking: count requests issued from each cgroup. Uses the
+// task that issued the I/O (current task), not the bio's owning cgroup —
+// simple and matches what cgroup CPU accounting attributes elsewhere.
+SEC("tp_btf/block_rq_issue")
+int tp_block_rq_issue(u64 *ctx) {
+    cgroup_agg_stats_t *stats = current_cgroup_stats();
+    if (stats) {
+        stats->block_io_requests += 1;
+    }
     return 0;
 }
 

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/common.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/common.go
@@ -3,7 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package noisyneighbor contains the Noisy Neighbor check
+// Package noisyneighbor contains the Noisy Neighbor check.
+//
+// EXPERIMENTAL — this module is unstable and under active development. Metric
+// names, configuration keys, BPF map layout, and on-CPU overhead may all
+// change without notice between releases, and the check may be removed
+// outright. Use at your own risk; do not build production dashboards,
+// monitors, or alerting on top of these metrics yet.
 package noisyneighbor
 
 const (

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -29,16 +29,34 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
+// NoisyNeighborConfig holds the YAML-parseable configuration for the
+// noisy_neighbor check. The check currently has no tunable knobs, but the
+// type is kept so the standard check Configure flow can call Parse.
 type NoisyNeighborConfig struct{}
 
+// NoisyNeighborCheck is the agent-side core check that consumes per-cgroup
+// scheduling and PMU stats from the system-probe noisyneighbor module and
+// emits Datadog metrics tagged by container.
 type NoisyNeighborCheck struct {
 	core.CheckBase
 	config         *NoisyNeighborConfig
 	tagger         tagger.Component
 	sysProbeClient *sysprobeclient.CheckClient
 	cgroupReader   *cgroups.Reader
+	// pmuMetricsEnabled is captured once during Configure to avoid a config
+	// lookup per metric per Run tick. Keys are the agent-side metric short
+	// names ("cycles", "instructions", ...); a missing or false entry means
+	// the metric is not emitted.
+	pmuMetricsEnabled map[string]bool
 }
 
+var pmuMetricConfigKeys = []string{
+	"cycles", "instructions", "cache_misses", "cache_references",
+	"itlb_misses", "branch_misses", "cpu_migrations",
+}
+
+// Factory returns the check.Check constructor used by the collector to
+// instantiate the noisy_neighbor check.
 func Factory(tagger tagger.Component) option.Option[func() check.Check] {
 	return option.New(func() check.Check {
 		return newCheck(tagger)
@@ -53,40 +71,50 @@ func newCheck(tagger tagger.Component) check.Check {
 	}
 }
 
+// Parse unmarshals the check's YAML configuration into c.
 func (c *NoisyNeighborConfig) Parse(data []byte) error {
 	return yaml.Unmarshal(data, c)
 }
 
+// Configure sets up the check by parsing its configuration, building a
+// system-probe client, and initializing the cgroup reader used for tagging.
 func (n *NoisyNeighborCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string, provider string) error {
 	if err := n.CommonConfigure(senderManager, initConfig, config, source, provider); err != nil {
 		return err
 	}
 	if err := n.config.Parse(config); err != nil {
-		return fmt.Errorf("noisy_neighbor check config: %s", err)
+		return fmt.Errorf("noisy_neighbor check config: %w", err)
 	}
-	n.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")))
+	sysCfg := pkgconfigsetup.SystemProbe()
+	n.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(sysCfg.GetString("system_probe_config.sysprobe_socket")))
 	reader, err := cgroups.NewReader(cgroups.WithReaderFilter(cgroups.ContainerFilter))
 	if err != nil {
-		return fmt.Errorf("noisy_neighbor: cgroup reader init failed: %s", err)
+		return fmt.Errorf("noisy_neighbor: cgroup reader init failed: %w", err)
 	}
 	n.cgroupReader = reader
+	n.pmuMetricsEnabled = make(map[string]bool, len(pmuMetricConfigKeys))
+	for _, name := range pmuMetricConfigKeys {
+		n.pmuMetricsEnabled[name] = sysCfg.GetBool("noisy_neighbor.pmu_metrics." + name)
+	}
 	return nil
 }
 
+// Run fetches the latest per-cgroup stats from system-probe, refreshes the
+// cgroup reader, and emits Datadog metrics for each tracked container.
 func (n *NoisyNeighborCheck) Run() error {
 	stats, err := sysprobeclient.GetCheck[[]model.NoisyNeighborStats](n.sysProbeClient, sysconfig.NoisyNeighborModule)
 	if err != nil {
-		return fmt.Errorf("get noisy neighbor check: %s", err)
+		return fmt.Errorf("get noisy neighbor check: %w", err)
 	}
 
 	sender, err := n.GetSender()
 	if err != nil {
-		return fmt.Errorf("get metric sender: %s", err)
+		return fmt.Errorf("get metric sender: %w", err)
 	}
 
 	err = n.cgroupReader.RefreshCgroups(0)
 	if err != nil {
-		return fmt.Errorf("unable to refresh cgroups: %s", err)
+		return fmt.Errorf("unable to refresh cgroups: %w", err)
 	}
 
 	var totalCgroups uint64
@@ -134,6 +162,35 @@ func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat mod
 }
 
 func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
+	// Always-on counters: scheduling and software accounting that don't
+	// consume PMU counter slots.
 	sender.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
 	sender.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
+	sender.Count("noisy_neighbor.softirq_ns", float64(stat.SumSoftirqNs), "", tags)
+	sender.Count("noisy_neighbor.block_io_requests", float64(stat.BlockIORequests), "", tags)
+	sender.Count("noisy_neighbor.wakeups", float64(stat.WakeupCount), "", tags)
+
+	// PMU counters: each is independently gated by noisy_neighbor.pmu_metrics.X.
+	// Disabled events don't emit (no zero-valued noise on dashboards).
+	if n.pmuMetricsEnabled["cycles"] {
+		sender.Count("noisy_neighbor.cycles", float64(stat.SumCycles), "", tags)
+	}
+	if n.pmuMetricsEnabled["instructions"] {
+		sender.Count("noisy_neighbor.instructions", float64(stat.SumInstructions), "", tags)
+	}
+	if n.pmuMetricsEnabled["cache_misses"] {
+		sender.Count("noisy_neighbor.cache_misses", float64(stat.SumCacheMisses), "", tags)
+	}
+	if n.pmuMetricsEnabled["cache_references"] {
+		sender.Count("noisy_neighbor.cache_references", float64(stat.SumCacheReferences), "", tags)
+	}
+	if n.pmuMetricsEnabled["itlb_misses"] {
+		sender.Count("noisy_neighbor.itlb_misses", float64(stat.SumITLBMisses), "", tags)
+	}
+	if n.pmuMetricsEnabled["branch_misses"] {
+		sender.Count("noisy_neighbor.branch_misses", float64(stat.SumBranchMisses), "", tags)
+	}
+	if n.pmuMetricsEnabled["cpu_migrations"] {
+		sender.Count("noisy_neighbor.cpu_migrations", float64(stat.SumCPUMigrations), "", tags)
+	}
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
@@ -4,8 +4,18 @@
 package noisyneighbor
 
 type ebpfCgroupAggStats struct {
-	Sum_latencies_ns uint64
-	Event_count      uint64
-	Preemption_count uint64
-	Pid_count        uint64
+	Sum_latencies_ns     uint64
+	Event_count          uint64
+	Preemption_count     uint64
+	Pid_count            uint64
+	Sum_cycles           uint64
+	Sum_instructions     uint64
+	Sum_cache_misses     uint64
+	Sum_itlb_misses      uint64
+	Sum_softirq_ns       uint64
+	Block_io_requests    uint64
+	Sum_branch_misses    uint64
+	Sum_cpu_migrations   uint64
+	Wakeup_count         uint64
+	Sum_cache_references uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -8,9 +8,19 @@ package model
 
 // NoisyNeighborStats contains the statistics from the noisy neighbor check
 type NoisyNeighborStats struct {
-	CgroupID        uint64
-	SumLatenciesNs  uint64
-	EventCount      uint64
-	PreemptionCount uint64
-	UniquePidCount  uint64 // kernel task_struct->pid (TID) count
+	CgroupID           uint64
+	SumLatenciesNs     uint64
+	EventCount         uint64
+	PreemptionCount    uint64
+	UniquePidCount     uint64 // kernel task_struct->pid (TID) count
+	SumCycles          uint64
+	SumInstructions    uint64
+	SumCacheMisses     uint64
+	SumITLBMisses      uint64
+	SumSoftirqNs       uint64
+	BlockIORequests    uint64
+	SumBranchMisses    uint64
+	SumCPUMigrations   uint64
+	WakeupCount        uint64
+	SumCacheReferences uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -10,8 +10,10 @@ package noisyneighbor
 
 import (
 	"fmt"
+	"unsafe"
 
 	manager "github.com/DataDog/ebpf-manager"
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -24,16 +26,26 @@ import (
 // 5.13 for kfuncs, 6.2 for bpf_rcu_read_lock kfunc
 var minimumKernelVersion = kernel.VersionCode(6, 2, 0)
 
+// Config holds noisy_neighbor-specific runtime knobs read from system-probe
+// config. PMUMetrics keys are the BPF perf-event-array map names (e.g.
+// "cycles_pmu"); a missing key or a false value disables the corresponding
+// counter: no perf fds are opened for it, the eBPF program reads -ENOENT
+// and skips the deltas for that event.
+type Config struct {
+	PMUMetrics map[string]bool
+}
+
 // Probe is the eBPF side of the noisy neighbor check
 type Probe struct {
-	mgr *ddebpf.Manager
+	mgr    *ddebpf.Manager
+	pmuFDs []int
 }
 
 // NewProbe creates a [Probe]
-func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
+func NewProbe(cfg *ddebpf.Config, modCfg Config) (*Probe, error) {
 	kv, err := kernel.HostVersion()
 	if err != nil {
-		return nil, fmt.Errorf("kernel version: %s", err)
+		return nil, fmt.Errorf("kernel version: %w", err)
 	}
 	if kv < minimumKernelVersion {
 		return nil, fmt.Errorf("minimum kernel version %s not met, read %s", minimumKernelVersion, kv)
@@ -52,10 +64,22 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_wakeup", UID: uid}},
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_wakeup_new", UID: uid}},
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_switch", UID: uid}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_softirq_entry", UID: uid}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_softirq_exit", UID: uid}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_block_rq_issue", UID: uid}},
 		}
 		p.mgr.Maps = []*manager.Map{
 			{Name: "runq_enqueued"},
+			{Name: "task_oncpu_pmu"},
 			{Name: "cgroup_agg_stats"},
+			{Name: "cycles_pmu"},
+			{Name: "instructions_pmu"},
+			{Name: "cache_misses_pmu"},
+			{Name: "itlb_misses_pmu"},
+			{Name: "branch_misses_pmu"},
+			{Name: "cpu_migrations_pmu"},
+			{Name: "cache_references_pmu"},
+			{Name: "softirq_start_ns"},
 		}
 		if err := p.mgr.InitWithOptions(buf, &opts); err != nil {
 			return fmt.Errorf("failed to init ebpf manager: %w", err)
@@ -66,16 +90,136 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 		return nil, err
 	}
 
-	err = p.mgr.Start()
-	if err != nil {
+	if err := p.mgr.Start(); err != nil {
 		return nil, err
 	}
 	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
+	p.attachPMU(modCfg.PMUMetrics)
 	return p, nil
+}
+
+// pmuEvent describes one perf event (hardware or software counter) that we
+// open per-CPU and expose to BPF via a perf-event-array map.
+type pmuEvent struct {
+	mapName    string
+	humanLabel string
+	perfType   uint32
+	perfConfig uint64
+}
+
+// iTLB-load-misses encoded for PERF_TYPE_HW_CACHE: cache_id | (op << 8) | (result << 16).
+const itlbLoadMissesConfig = uint64(unix.PERF_COUNT_HW_CACHE_ITLB) |
+	(uint64(unix.PERF_COUNT_HW_CACHE_OP_READ) << 8) |
+	(uint64(unix.PERF_COUNT_HW_CACHE_RESULT_MISS) << 16)
+
+// attachPMU opens per-CPU perf events for every counter enabled via
+// pmuEnabled (keyed by BPF map name) and populates the corresponding BPF
+// perf-event-array maps. Events absent from the map or set to false are
+// skipped — no perf fds are opened, the eBPF read returns -ENOENT, and
+// deltas for that event are dropped. See attachPMUEvent for per-event
+// semantics and failure modes.
+//
+// The CPU list comes from kernel.OnlineCPUs() rather than runtime.NumCPU().
+// runtime.NumCPU() returns the size of the caller's sched_getaffinity mask,
+// so on a cpuset-restricted system-probe (e.g. a Guaranteed-QoS pod under
+// the kubelet static CPU manager) it can be smaller than the host CPU id
+// range. Tracepoints fire on every online CPU regardless of the loader's
+// affinity, so any host CPU missing from the perf-event-array reads -ENOENT
+// on the BPF side and silently undercounts.
+//
+// CPU hotplug is not handled: the online set is snapshotted once here. A
+// CPU brought online after init will have an empty map slot and its PMU
+// samples will be dropped until the probe is reloaded.
+func (p *Probe) attachPMU(pmuEnabled map[string]bool) {
+	cpus, err := kernel.OnlineCPUs()
+	if err != nil {
+		log.Warnf("noisy_neighbor: cannot enumerate online CPUs (%v); PMU counters disabled", err)
+		return
+	}
+	events := []pmuEvent{
+		{mapName: "cycles_pmu", humanLabel: "cycles", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CPU_CYCLES},
+		{mapName: "instructions_pmu", humanLabel: "instructions", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_INSTRUCTIONS},
+		{mapName: "cache_misses_pmu", humanLabel: "cache misses", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CACHE_MISSES},
+		{mapName: "itlb_misses_pmu", humanLabel: "iTLB misses", perfType: unix.PERF_TYPE_HW_CACHE, perfConfig: itlbLoadMissesConfig},
+		{mapName: "branch_misses_pmu", humanLabel: "branch misses", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_BRANCH_MISSES},
+		// CPU migrations is a software counter — doesn't compete for hardware
+		// PMU counters and is always available regardless of µarch.
+		{mapName: "cpu_migrations_pmu", humanLabel: "CPU migrations", perfType: unix.PERF_TYPE_SOFTWARE, perfConfig: unix.PERF_COUNT_SW_CPU_MIGRATIONS},
+		// Cache references pairs with cache_misses to give cache hit-rate: under
+		// cache thrashing the rate moves even when absolute miss count stays
+		// flat for memory-bound workloads already at floor miss rate.
+		{mapName: "cache_references_pmu", humanLabel: "cache references", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CACHE_REFERENCES},
+	}
+	for _, ev := range events {
+		if !pmuEnabled[ev.mapName] {
+			log.Debugf("noisy_neighbor: %s PMU event disabled by config, skipping", ev.humanLabel)
+			continue
+		}
+		p.attachPMUEvent(ev, cpus)
+	}
+}
+
+// attachPMUEvent opens one perf event per online CPU and inserts the fds
+// into the associated BPF perf-event-array map at the host CPU id (matching
+// BPF_F_CURRENT_CPU on the reader side). On hosts where the event isn't
+// supported (virtualized envs, restrictive perf_event_paranoid, missing
+// CAP_PERF_MON, or µarch lacking the event) opens fail and we log once per
+// event type. Other events still attach independently, and the eBPF program
+// checks each read-value return code and skips just that counter's deltas.
+func (p *Probe) attachPMUEvent(ev pmuEvent, cpus []uint) {
+	m, _, err := p.mgr.GetMap(ev.mapName)
+	if err != nil {
+		log.Warnf("noisy_neighbor: %s map (%s) lookup failed: %v", ev.humanLabel, ev.mapName, err)
+		return
+	}
+	if m == nil {
+		log.Warnf("noisy_neighbor: %s map (%s) not registered in manager", ev.humanLabel, ev.mapName)
+		return
+	}
+	var logged bool
+	for _, cpu := range cpus {
+		fd, err := openHardwarePerfEvent(ev.perfType, ev.perfConfig, int(cpu))
+		if err != nil {
+			if !logged {
+				log.Warnf("noisy_neighbor: %s PMU event unavailable on cpu %d, metric will be zero for that CPU: %v", ev.humanLabel, cpu, err)
+				logged = true
+			}
+			continue
+		}
+		if err := m.Put(uint32(cpu), uint32(fd)); err != nil {
+			log.Warnf("noisy_neighbor: failed to register %s fd on cpu %d: %v", ev.humanLabel, cpu, err)
+			_ = unix.Close(fd)
+			continue
+		}
+		p.pmuFDs = append(p.pmuFDs, fd)
+	}
+}
+
+func openHardwarePerfEvent(perfType uint32, config uint64, cpu int) (int, error) {
+	attr := &unix.PerfEventAttr{
+		Type:   perfType,
+		Config: config,
+		Size:   uint32(unsafe.Sizeof(unix.PerfEventAttr{})),
+	}
+	fd, err := unix.PerfEventOpen(attr, -1, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
+	if err != nil {
+		return -1, err
+	}
+	if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
+		_ = unix.Close(fd)
+		return -1, fmt.Errorf("enable perf event: %w", err)
+	}
+	return fd, nil
 }
 
 // Close releases all associated resources
 func (p *Probe) Close() {
+	for _, fd := range p.pmuFDs {
+		if err := unix.Close(fd); err != nil {
+			log.Warnf("noisy_neighbor: failed to close PMU fd %d: %v", fd, err)
+		}
+	}
+	p.pmuFDs = nil
 	if p.mgr != nil {
 		ddebpf.RemoveNameMappings(p.mgr.Manager)
 		if err := p.mgr.Stop(manager.CleanAll); err != nil {
@@ -84,7 +228,10 @@ func (p *Probe) Close() {
 	}
 }
 
-// GetAndFlush gets the stats
+// GetAndFlush returns aggregated per-cgroup stats for the current window
+// and atomically deletes each returned cgroup's entry from the BPF map.
+// Cgroups with zero observable activity (no events, softirq, block-IO,
+// or wakeups) are filtered out of the return slice but still flushed.
 func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 	var nnstats []model.NoisyNeighborStats
 
@@ -104,29 +251,37 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 	var cgroupsToDelete []uint64
 
 	for iter.Next(&cgroupID, &perCPUStats) {
-		var cgroupLatencies, cgroupEvents, cgroupPreemptions, pidCount uint64
+		stat := model.NoisyNeighborStats{CgroupID: cgroupID}
 		for _, cpuStat := range perCPUStats {
-			cgroupLatencies += cpuStat.Sum_latencies_ns
-			cgroupEvents += cpuStat.Event_count
-			cgroupPreemptions += cpuStat.Preemption_count
+			stat.SumLatenciesNs += cpuStat.Sum_latencies_ns
+			stat.EventCount += cpuStat.Event_count
+			stat.PreemptionCount += cpuStat.Preemption_count
+			stat.SumCycles += cpuStat.Sum_cycles
+			stat.SumInstructions += cpuStat.Sum_instructions
+			stat.SumCacheMisses += cpuStat.Sum_cache_misses
+			stat.SumITLBMisses += cpuStat.Sum_itlb_misses
+			stat.SumSoftirqNs += cpuStat.Sum_softirq_ns
+			stat.BlockIORequests += cpuStat.Block_io_requests
+			stat.SumBranchMisses += cpuStat.Sum_branch_misses
+			stat.SumCPUMigrations += cpuStat.Sum_cpu_migrations
+			stat.WakeupCount += cpuStat.Wakeup_count
+			stat.SumCacheReferences += cpuStat.Sum_cache_references
 			// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
-			if cpuStat.Pid_count > pidCount {
-				pidCount = cpuStat.Pid_count
+			if cpuStat.Pid_count > stat.UniquePidCount {
+				stat.UniquePidCount = cpuStat.Pid_count
 			}
 		}
 
 		cgroupsToDelete = append(cgroupsToDelete, cgroupID)
 
-		if cgroupEvents == 0 {
+		// Drop only when there is no observable activity from any source.
+		// PMU sums are included so a task that was already on-CPU at window
+		// start and gets switched out exactly once (PMU stamp delta accrued,
+		// no schedule-on event) isn't silently flushed.
+		if stat.EventCount == 0 && stat.SumSoftirqNs == 0 && stat.BlockIORequests == 0 && stat.WakeupCount == 0 &&
+			stat.SumCycles == 0 && stat.SumInstructions == 0 && stat.SumCacheMisses == 0 && stat.SumCacheReferences == 0 &&
+			stat.SumITLBMisses == 0 && stat.SumBranchMisses == 0 && stat.SumCPUMigrations == 0 {
 			continue
-		}
-
-		stat := model.NoisyNeighborStats{
-			CgroupID:        cgroupID,
-			SumLatenciesNs:  cgroupLatencies,
-			EventCount:      cgroupEvents,
-			PreemptionCount: cgroupPreemptions,
-			UniquePidCount:  pidCount,
 		}
 
 		nnstats = append(nnstats, stat)

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -90,8 +90,15 @@ func NewProbe(cfg *ddebpf.Config, modCfg Config) (*Probe, error) {
 		return nil, err
 	}
 
-	if err := p.mgr.Start(); err != nil {
-		return nil, err
+	// Manually attach probes instead of calling p.mgr.Start().
+	// Start() runs cleanupTraceFS() which tries to remove ALL orphaned kprobe
+	// events (not just ours) and fails fatally if any are pinned by a dead
+	// process. Since this module only uses tracepoints—no kprobes—we skip
+	// Start() and attach directly. Init already loaded programs and created maps.
+	for _, probe := range p.mgr.Probes {
+		if err := probe.Attach(); err != nil {
+			return nil, fmt.Errorf("failed to attach probe %s: %w", probe.EBPFFuncName, err)
+		}
 	}
 	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
 	p.attachPMU(modCfg.PMUMetrics)

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
@@ -36,7 +36,7 @@ func TestNoisyNeighborProbe(t *testing.T) {
 		t.Logf("testing on %s", os.Getenv("CI_JOB_NAME"))
 
 		cfg := testConfig()
-		probe, err := NewProbe(cfg)
+		probe, err := NewProbe(cfg, Config{PMUMetrics: allPMUMetricsEnabled()})
 		require.NoError(t, err)
 		t.Cleanup(probe.Close)
 
@@ -54,4 +54,18 @@ func TestNoisyNeighborProbe(t *testing.T) {
 func testConfig() *ebpf.Config {
 	cfg := ebpf.NewConfig()
 	return cfg
+}
+
+// allPMUMetricsEnabled returns the PMU-metrics map that NewProbe expects,
+// with every counter enabled — the default tested configuration.
+func allPMUMetricsEnabled() map[string]bool {
+	return map[string]bool{
+		"cycles_pmu":           true,
+		"instructions_pmu":     true,
+		"cache_misses_pmu":     true,
+		"cache_references_pmu": true,
+		"itlb_misses_pmu":      true,
+		"branch_misses_pmu":    true,
+		"cpu_migrations_pmu":   true,
+	}
 }


### PR DESCRIPTION
### What does this PR do?

Re-introduces the per-cgroup PMU + tracepoint signal expansion from #50350, which was reverted in #51570 due to a lock contention regression observed during RC rollout.

Also includes the tracefs cleanup workaround from the pre-#50350 branch: instead of calling `mgr.Start()` (which runs `cleanupTraceFS()` and fails fatally when unrelated orphaned kprobes are pinned by a dead process), we attach tracepoint probes directly via `probe.Attach()`. This module uses only `tp_btf` tracepoints — no kprobes — so `cleanupTraceFS` was never needed.

**Commits:**
- `Reapply "[noisy_neighbor] Add Per-cgroup PMU + more tracepoint signals (default off)"` — restores #50350 exactly (reverting the revert from #51570)
- `[noisy_neighbor] Simplify Layer 1 triage; work around tracefs cleanup` — applies the kprobe/tracefs fix on top

### Motivation

The PMU + tracepoint signals (all default-off) are the core of the noisy-neighbor victim detection signal set. The revert was a safety measure pending investigation of the lock contention regression. This PR re-introduces the code for dev image testing to reproduce and narrow down the regression.

**All PMU metrics remain default-off.** The regression was observed in production clusters where all toggles were `false`, so the contention likely comes from the tracepoint side (sched_switch / wakeup / softirq / block_io) rather than from PMU fd opens.

### Describe how you validated your changes

Dev image testing. This PR is intentionally scoped to reproduce the regression environment.

### Additional Notes

- Related open PR: #50866 (PMU any-enabled gate — skips `pmu_sample_all` branch entirely when no PMU toggle is on). That optimization is **not** included here to keep the surface identical to the original reverted code.
- Regression context: #51570 cites lock contention visible in a Datadog dashboard. The contention appeared during RC rollout with all PMU metrics disabled, suggesting the sched_switch tracepoint path or the cgroup_agg_stats BPF map operations are involved.