### PR TITLE
fix(orchestrator): skip all subresources during CRD discovery

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
@@ -177,7 +177,11 @@ func (d *DiscoveryCollector) List(group, version, kind string) []CollectorVersio
 	var result []CollectorVersion
 
 	for cv := range d.cache.CollectorForVersion {
-		if strings.HasSuffix(cv.Kind, "/status") {
+		// Skip subresources (e.g. "nodepools/scale", "pods/status"). Their names
+		// always contain a "/", whereas full resource names never do. Subresources
+		// are not listable/watchable on their own, so collecting them spins up an
+		// informer that can never sync (e.g. karpenter.sh/v1 nodepools/scale).
+		if strings.Contains(cv.Kind, "/") {
 			continue
 		}
 		if !matchesGroupVersion(cv.GroupVersion, group, version) {

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd_test.go
@@ -109,6 +109,27 @@ func TestDiscoveryCollector_List(t *testing.T) {
 			},
 		},
 		{
+			name: "exclude subresources other than status",
+			setup: func() *DiscoveryCollector {
+				return &DiscoveryCollector{
+					cache: DiscoveryCache{
+						CollectorForVersion: map[CollectorVersion]struct{}{
+							{GroupVersion: "karpenter.sh/v1", Kind: "nodepools"}:       {},
+							{GroupVersion: "karpenter.sh/v1", Kind: "nodepools/scale"}: {},
+							{GroupVersion: "karpenter.sh/v1", Kind: "nodeclaims"}:      {},
+						},
+					},
+				}
+			},
+			group:   "karpenter.sh",
+			version: "v1",
+			kind:    "",
+			expected: []CollectorVersion{
+				{GroupVersion: "karpenter.sh/v1", Kind: "nodepools"},
+				{GroupVersion: "karpenter.sh/v1", Kind: "nodeclaims"},
+			},
+		},
+		{
 			name: "match by group only",
 			setup: func() *DiscoveryCollector {
 				return &DiscoveryCollector{

--- a/releasenotes-dca/notes/orchestrator-skip-subresource-discovery-38455c45c93f0040.yaml
+++ b/releasenotes-dca/notes/orchestrator-skip-subresource-discovery-38455c45c93f0040.yaml
@@ -1,9 +1,5 @@
 ---
 fixes:
   - |
-    Fix the orchestrator explorer attempting to collect Kubernetes subresources
-    (such as ``nodepools/scale``) when collecting out-of-the-box custom resources
-    by group. Subresources cannot be listed or watched on their own, which
-    previously produced a continuous stream of ``Failed to watch`` errors and
-    informer sync warnings on clusters running operators like Karpenter. Only
-    full resources are now considered during custom resource discovery.
+    Fix a bug in the orchestrator explorer check that led to trying to collect
+    Kubernetes subresources under certain custom resource API groups.

--- a/releasenotes-dca/notes/orchestrator-skip-subresource-discovery-38455c45c93f0040.yaml
+++ b/releasenotes-dca/notes/orchestrator-skip-subresource-discovery-38455c45c93f0040.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fix the orchestrator explorer attempting to collect Kubernetes subresources
+    (such as ``nodepools/scale``) when collecting out-of-the-box custom resources
+    by group. Subresources cannot be listed or watched on their own, which
+    previously produced a continuous stream of ``Failed to watch`` errors and
+    informer sync warnings on clusters running operators like Karpenter. Only
+    full resources are now considered during custom resource discovery.


### PR DESCRIPTION
### What does this PR do?

The orchestrator explorer collects out-of-the-box custom resources by group (e.g. all of `karpenter.sh/v1`). To enumerate the resources in a group it walks the API discovery cache, which includes subresources such as `nodepools/scale` alongside the real `nodepools` resource.

`List()` only excluded `/status` subresources, so `nodepools/scale` (and any other non-status subresource) was turned into a collector. The orchestrator then started a dynamic informer for it, but subresources are not listable/watchable on their own, so the informer could never sync. This produced a continuous stream of:

  "Failed to watch" err="failed to list karpenter.sh/v1, Resource=nodepools/scale:
  nodepools.karpenter.sh \"scale\" not found" type="karpenter.sh/v1, Resource=nodepools/scale"

plus repeated "couldn't sync informer ... nodepools/scale" warnings, every few seconds on every cluster running Karpenter with the default OOTB custom-resource collection enabled.

Full resource names never contain a "/", whereas subresources always do, so skip any kind containing "/" instead of only the "/status" suffix. This covers `/scale` and any future subresource without needing an explicit deny-list.


### Motivation

avoid log spam

### Describe how you validated your changes

### Additional Notes
