### PR TITLE
[ACTP] Use logger for PAR identity rotation command

### DIFF
--- a/cmd/privateactionrunner/subcommands/rotateidentity/command.go
+++ b/cmd/privateactionrunner/subcommands/rotateidentity/command.go
@@ -50,7 +50,7 @@ Restart the Private Action Runner process to apply the new identity.`,
 	return []*cobra.Command{cmd}
 }
 
-func run(_ log.Component, cfg config.Component, hostnameComp hostname.Component) error {
+func run(logger log.Component, cfg config.Component, hostnameComp hostname.Component) error {
 	ctx := context.Background()
 
 	if !cfg.GetBool(pkgconfigsetup.PAREnabled) {
@@ -74,9 +74,9 @@ func run(_ log.Component, cfg config.Component, hostnameComp hostname.Component)
 
 	parCfg, err := parconfig.FromDDConfig(cfg)
 	if err != nil {
-		fmt.Printf("Identity rotated, but failed to load runner config for auto-connection: %v\n", err)
+		logger.Warnf("Identity rotated, but failed to load runner config for auto-connection: %v", err)
 	} else if urnParts, err := parutil.ParseRunnerURN(result.URN); err != nil {
-		fmt.Printf("Identity rotated, but failed to parse URN for auto-connection: %v\n", err)
+		logger.Warnf("Identity rotated, but failed to parse URN for auto-connection: %v", err)
 	} else {
 		autoconnections.CreateConnectionsIfEnabled(
 			ctx, cfg, parCfg,
@@ -85,7 +85,7 @@ func run(_ log.Component, cfg config.Component, hostnameComp hostname.Component)
 		)
 	}
 
-	fmt.Printf("Identity successfully rotated. New URN: %s\n", result.URN)
-	fmt.Println("Restart the Private Action Runner to apply the new identity.")
+	logger.Infof("Identity successfully rotated. New URN: %s", result.URN)
+	logger.Info("Restart the Private Action Runner to apply the new identity.")
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Replace fmt.Printf by logger in PAR rotate identity command

### Motivation

Was missing partially in https://github.com/DataDog/datadog-agent/pull/52031

### Describe how you validated your changes

Ran locally

### Additional Notes
