### PR TITLE
[anomalydetection] Fix stale comments and documentation

### DIFF
--- a/comp/README.md
+++ b/comp/README.md
@@ -812,8 +812,8 @@ Package updater is the updater component.
 
 *Datadog Team*: q-branch
 
-Package logssource provides a component that feeds container logs into the
-observer without requiring the logs agent to be enabled.
+Package logssource provides a component that feeds container and kubelet
+journald logs into the observer without requiring the logs agent to be enabled.
 
 ### [comp/anomalydetection/observer](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/anomalydetection/observer)
 

--- a/comp/anomalydetection/AGENTS.md
+++ b/comp/anomalydetection/AGENTS.md
@@ -1,0 +1,144 @@
+# comp/anomalydetection — AI Agent Guide
+
+## What This Subsystem Does
+
+Edge anomaly detection inside the Datadog Agent. Data enters through lightweight
+**observer handles**, is stored and analyzed by the **observer engine**, then
+reported via **reporters** (stdout trace and optional Datadog change events).
+
+```
+Handle → Storage → Detect → Correlate → Report
+```
+
+## Component Tree
+
+```
+comp/anomalydetection/
+  internal/logsfilter/     ← shared severity bucketing + rate limiting
+  observer/
+    def/                 ← public interfaces (own go.mod)
+    fx/                  ← production Fx wiring (python build tag)
+    fx/fx_noop.go        ← IoT / !python stub
+    impl/                ← engine, detectors, correlators, extractors
+      patterns/          ← log tokenizer/clusterer subpackage
+    scenarios/           ← replay scenario directories (testbench)
+  logssource/
+    def/ fx/ impl/       ← container + kubelet journald log ingestion
+    fx/fx_noop.go        ← IoT / !python stub
+  reporter/
+    def/
+    fx/                  ← production: stdout + optional event reporter
+    fx-noop/             ← linter stub package only
+    fx-testbench/        ← SSE reporter for testbench
+    impl/                ← live reporter (stdout + event)
+    impl-noop/           ← linter stub package only
+    impl-testbench/      ← SSE hub + testbench reporter
+    mock/
+    reporter.allium      ← behavioral spec for reporter payloads
+  recorder/
+    def/
+    fx-noop/             ← noop wired in production agent
+    impl-noop/           ← noop implementation (full parquet impl planned)
+```
+
+## Agent Wiring
+
+Wired in `cmd/agent/subcommands/run/command.go`:
+
+| Module | Package | Role |
+|--------|---------|------|
+| Observer | `observer/fx` | Analysis pipeline (`python` build tag) |
+| Log source | `logssource/fx` | Container + kubelet logs (`python` tag) |
+| Reporter | `reporter/fx` | Stdout reporter + optional event reporter |
+| Recorder | `recorder/fx-noop` | No-op (parquet middleware not shipped yet) |
+
+**IoT / `!python` builds** use no-op `observer/fx` and `logssource/fx` modules.
+
+**Testbench** (`internal/qbranch/anomalydetection-testbench/`) wires
+`observer/fx`, `recorder/fx-noop`, and `reporter/fx-testbench`. It replays
+scenarios from `observer/scenarios/` and has its own parquet tooling under
+`internal/qbranch/anomalydetection-testbench/bench/`.
+
+```bash
+# Build the testbench binary
+dda inv anomalydetection.build-testbench
+
+# Launch backend + web UI (add --build to rebuild first)
+dda inv anomalydetection.launch-testbench
+```
+
+See `internal/qbranch/anomalydetection-testbench/README.md` for flags and
+headless/eval workflows.
+
+## Data Ingress (Handle Sources)
+
+Production callers of `observer.GetHandle()` use statically-defined source names:
+
+| Source | Wired from |
+|--------|------------|
+| `all-metrics` | `pkg/aggregator/demultiplexer_agent.go` |
+| `logs` | `logssource/impl/logssource.go` |
+| `agent-internal-logs` | `observer/impl/observer.go` (pkg/util/log tap) |
+
+**Log ingestion split:**
+- **Container + kubelet logs** → `logssource` component
+- **Agent-internal logs** → `observer` taps `pkg/util/log` directly
+
+Both paths share filtering primitives from `internal/logsfilter/`.
+
+## Reporter Model
+
+Reporters register through the `anomalydetection_reporters` Fx group
+(`reporter/def`). The observer subscribes each injected `Reporter` after each
+advance cycle.
+
+- **StdoutReporter** — always active in `reporter/fx`; logs correlations at
+  info on first-seen, debug for ongoing
+- **EventReporter** — created when `anomaly_detection.reporting.enabled=true`
+  AND the event-platform forwarder is available; publishes change events via
+  `reporter/impl/notify.go`
+
+See `reporter/reporter.allium` for the payload contract.
+
+## Configuration
+
+Keys are registered in `pkg/config/setup/common_settings.go`.
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `anomaly_detection.enabled` | `false` | Master analysis gate |
+| `anomaly_detection.metrics.enabled` | `true` | External metric ingestion at handles |
+| `anomaly_detection.reporting.enabled` | `false` | Event reporter (change events) |
+| `anomaly_detection.recording.enabled` | `false` | Parquet recording middleware |
+| `anomaly_detection.logs.enabled` | `true` | Parent gate for all log sources |
+| `anomaly_detection.logs.containers.enabled` | `true` | Workloadmeta container logs |
+| `anomaly_detection.logs.kubelet.enabled` | `true` | Kubelet journald source |
+| `anomaly_detection.logs.internal.enabled` | `true` | Agent-internal log tap |
+| `anomaly_detection.detectors.<name>.enabled` | varies | Per detector/correlator/extractor |
+| `anomaly_detection.storage.max_series` | `50000` | Storage series cap |
+| `anomaly_detection.storage.point_retention_secs` | `120` | Per-series point retention |
+
+Per-source log rate limits and min severity live under
+`anomaly_detection.logs.{internal,kubelet,containers}.*`.
+
+## Allium Specifications
+
+| Spec | Scope |
+|------|-------|
+| `reporter/reporter.allium` | Change-event payloads, deduplication, routing identity |
+
+## Testing
+
+```bash
+dda inv test --targets=./comp/anomalydetection/observer/...
+dda inv test --targets=./comp/anomalydetection/reporter/impl/
+dda inv test --targets=./comp/anomalydetection/logssource/impl/
+```
+
+Benchmarks: `dda inv test --targets=./comp/anomalydetection/observer/impl/ -- -bench=.`
+
+## Sub-Guides
+
+| Path | Focus |
+|------|-------|
+| `observer/AGENTS.md` | Engine architecture, key files, design decisions, pitfalls |

--- a/comp/anomalydetection/logssource/def/component.go
+++ b/comp/anomalydetection/logssource/def/component.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package logssource provides a component that feeds container logs into the
-// observer without requiring the logs agent to be enabled.
+// Package logssource provides a component that feeds container and kubelet
+// journald logs into the observer without requiring the logs agent to be enabled.
 package logssource
 
 // team: q-branch

--- a/comp/anomalydetection/logssource/fx/BUILD.bazel
+++ b/comp/anomalydetection/logssource/fx/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_go//go:def.bzl", "go_library")
 
 # Only the noop variant is built here. fx.go imports logssource/impl which
 # depends on pkg/logs/launchers → comp/logs-library/pipeline (not yet in
-# Bazel). See comp/anomalydetection/logssource/impl/BUILD.bazel.
+# Bazel). impl/ has no BUILD.bazel yet.
 go_library(
     name = "fx",
     srcs = ["fx_noop.go"],

--- a/comp/anomalydetection/logssource/impl/logssource.go
+++ b/comp/anomalydetection/logssource/impl/logssource.go
@@ -53,7 +53,8 @@ type Requires struct {
 	FilterStore option.Option[workloadfilter.Component]
 
 	// Autodiscovery is optional: when absent the AD scheduler is simply not started
-	// and the observer falls back to generic container log collection only.
+	// and the observer falls back to generic container and kubelet log collection
+	// without AD-scheduled config overlays.
 	Autodiscovery autodiscovery.Component `fx:"optional"`
 }
 
@@ -68,13 +69,12 @@ type logssourceComponent struct{}
 // NewComponent creates the logssource component.
 //
 // anomaly_detection.logs.enabled is the main toggle for all log ingestion:
-// setting it to false disables container, kubelet, and agent-internal logs
-// (observer's internal log tap).
+// setting it to false disables container and kubelet sources wired here.
 // anomaly_detection.logs.containers.enabled controls workloadmeta generic
 // container sources and AD-scheduled container log configs.
 // anomaly_detection.logs.kubelet.enabled controls the kubelet journald source.
-// anomaly_detection.logs.internal.enabled additionally controls the agent-internal
-// log tap and defaults to true when logs.enabled is true.
+// Agent-internal logs are wired separately by the observer via
+// anomaly_detection.logs.internal.enabled (see observer/impl/observer.go).
 //
 // The component is a no-op when any of these are true:
 //   - the observer is unavailable

--- a/comp/anomalydetection/observer/AGENTS.md
+++ b/comp/anomalydetection/observer/AGENTS.md
@@ -1,9 +1,11 @@
 # comp/anomalydetection/observer — AI Agent Guide
 
+Subsystem overview, wiring, and config: see `../AGENTS.md`.
+
 ## What This Component Does
 
 The observer watches data flowing through the agent and runs anomaly detection
-on it. It is a pipeline:
+on it:
 
 ```
 Handle → Storage → Detect → Correlate → Report
@@ -11,41 +13,7 @@ Handle → Storage → Detect → Correlate → Report
 
 Data enters through lightweight **Handles** (non-blocking, copy-on-send).
 The **engine** stores metrics, runs detectors and correlators, and emits
-events to reporters. See `README.md` for the full pipeline diagram and
-extension guide.
-
-## Component structure
-
-The observer lives inside `comp/anomalydetection/` alongside three sibling
-components it depends on at runtime:
-
-```
-comp/anomalydetection/
-  observer/
-    def/        ← public interfaces (own go.mod)
-    fx/         ← production Fx wiring
-    impl/       ← engine, detectors, correlators, extractors, telemetry
-      patterns/ ← log pattern tokenizer/clusterer subpackage
-  logssource/   ← container and kubelet log sources feeding the observer
-    def/ fx/ impl/
-  reporter/     ← anomaly event reporter
-    def/
-    fx/           ← production (Datadog notify + events API)
-    fx-noop/      ← stub wired in the main agent build
-    fx-testbench/ ← SSE debug reporter wired in the testbench
-    impl/
-    impl-testbench/
-    mock/
-  recorder/     ← parquet recorder for scenario capture
-    def/
-    fx-noop/    ← stub wired in the main agent build
-    impl-noop/  ← no-op implementation
-```
-
-The **production agent** wires `reporter/fx-noop` and `recorder/fx-noop` to
-keep those heavy dependencies out of the agent binary. The
-**testbench** (`internal/qbranch/anomalydetection-testbench/`) wires the full
-`fx` + `impl` variants.
+events to reporters injected via the `anomalydetection_reporters` Fx group.
 
 ## Architecture
 
@@ -53,7 +21,7 @@ keep those heavy dependencies out of the agent binary. The
 
 | Layer | Code | Role |
 |-------|------|------|
-| **Component** (`observerImpl`) | `impl/observer.go` | Fx lifecycle, channel dispatch, Handle factory |
+| **Component** (`observerImpl`) | `impl/observer.go` | Fx lifecycle, channel dispatch, Handle factory, agent-internal log tap |
 | **Engine** (`engine`) | `impl/engine.go` | Storage, detection, correlation, replay — the shared core |
 
 The engine is a plain Go struct, not an Fx component. Both the live observer
@@ -63,29 +31,35 @@ and the testbench use the same engine.
 
 | File | Purpose |
 |------|---------|
-| `def/component.go` | Component interface (GetHandle, GetStorageReader, etc.) |
-| `def/types.go` | Public interfaces: Handle, View types, Detector, Correlator, etc. |
+| `def/component.go` | Component interface (GetHandle, RecordSamplerDropped, DumpMetrics) |
+| `def/types.go` | Handle, View types, Detector, Correlator, StorageReader, Anomaly, etc. |
 | `impl/engine.go` | Pipeline orchestration: ingest, advance, detect, correlate, replay |
 | `impl/storage.go` | In-memory columnar time-series storage (1s buckets, read-time aggregation) |
 | `impl/scheduler.go` | Scheduling policy: when to advance analysis |
-| `impl/observer.go` | Fx component: lifecycle, channel loop, handle creation |
+| `impl/observer.go` | Fx component: lifecycle, channel loop, handle creation, log tap |
 | `impl/component_catalog.go` | Registry of all detectors, correlators, extractors |
+| `impl/agent_logs.go` | Agent-internal log tap (source: `agent-internal-logs`) |
+| `impl/log_pattern_extractor.go` | Log → virtual metrics via pattern clustering |
+| `impl/log_metrics_extractor.go` | Log → virtual metrics via regex extraction |
+| `impl/anomaly_correlator_time_cluster.go` | Default time-proximity correlator |
+| `impl/patterns/` | Tokenizer + clusterer used by log pattern extractor |
 
-## Allium Specification
+### Component catalog (defaults)
 
-`observer-engine.allium` is the **behavioral specification** for the engine,
-written in [Allium](../../.agents/skills/allium/SKILL.md).
+Registered in `impl/component_catalog.go`. Enabled by default unless noted:
 
-The spec is authoritative for behavior. If the code disagrees with the spec,
-one of them is wrong. Open questions in the spec are unresolved design
-ambiguities, not documentation — resolving them requires a decision, not just
-code.
+| Kind | Name | Default |
+|------|------|---------|
+| Extractor | `log_metrics_extractor` | on |
+| Extractor | `log_pattern_extractor` | on |
+| Extractor | `connection_error_extractor` | off |
+| Detector | `bocpd` | on |
+| Detector | `rrcf` | on |
+| Detector | `cusum`, `scanmw`, `scanwelch`, `holt_residual`, `tukey_biweight` | off |
+| Correlator | `time_cluster` | on |
+| Correlator | `cross_signal`, `passthrough` | off |
 
-**Reading order:**
-1. `README.md` — pipeline overview, extension guide, configuration
-2. `observer-engine.allium` — behavioral spec (rules, contracts, invariants)
-3. `def/component.go` and `def/types.go` — public interfaces
-4. `impl/engine.go` — implementation of the spec
+Toggle via `anomaly_detection.detectors.<name>.enabled` in datadog.yaml.
 
 ## Key Design Decisions
 
@@ -105,6 +79,13 @@ writing. Detectors can pick any aggregation without re-ingesting data.
 Handles do non-blocking sends to a buffered channel. If the channel is full,
 observations are silently dropped. Analysis never back-pressures data ingestion.
 
+### Metric ingestion gate
+
+When `anomaly_detection.metrics.enabled=false`, handles wrap with
+`metricDropHandle` so external metrics are dropped at the edge. `ObserveLog`
+still passes through; log-derived virtual metrics produced inside the engine
+are unaffected.
+
 ## Common Pitfalls
 
 1. **Don't call engine methods from multiple goroutines.** The engine assumes
@@ -119,9 +100,22 @@ observations are silently dropped. Analysis never back-pressures data ingestion.
 4. **Extractor names must be unique.** The name is the storage namespace for
    derived metrics. Duplicates cause silent data collision.
 
+5. **Agent-internal logs are not logssource.** The internal tap is wired in
+   `impl/observer.go`, gated by `anomaly_detection.logs.internal.*`.
+
 ## Testing
 
 ```bash
 dda inv test --targets=./comp/anomalydetection/observer/...
 dda inv test --targets=./comp/anomalydetection/observer/impl/ -- -bench=.
 ```
+
+**Testbench** (algorithm iteration + scenario replay):
+
+```bash
+dda inv anomalydetection.build-testbench
+dda inv anomalydetection.launch-testbench
+```
+
+Reads scenarios from `observer/scenarios/`. See
+`internal/qbranch/anomalydetection-testbench/README.md`.

--- a/comp/anomalydetection/observer/AGENTS.md
+++ b/comp/anomalydetection/observer/AGENTS.md
@@ -26,7 +26,7 @@ comp/anomalydetection/
     fx/         ← production Fx wiring
     impl/       ← engine, detectors, correlators, extractors, telemetry
       patterns/ ← log pattern tokenizer/clusterer subpackage
-  logssource/   ← container log source feeding the observer
+  logssource/   ← container and kubelet log sources feeding the observer
     def/ fx/ impl/
   reporter/     ← anomaly event reporter
     def/
@@ -38,10 +38,8 @@ comp/anomalydetection/
     mock/
   recorder/     ← parquet recorder for scenario capture
     def/
-    fx/         ← full implementation (parquet, heavy deps)
     fx-noop/    ← stub wired in the main agent build
-    impl/
-    impl-noop/
+    impl-noop/  ← no-op implementation
 ```
 
 The **production agent** wires `reporter/fx-noop` and `recorder/fx-noop` to
@@ -55,7 +53,7 @@ keep those heavy dependencies out of the agent binary. The
 
 | Layer | Code | Role |
 |-------|------|------|
-| **Component** (`observerImpl`) | `impl/observer.go` | Fx lifecycle, channel dispatch, Handle factory, HF check runners |
+| **Component** (`observerImpl`) | `impl/observer.go` | Fx lifecycle, channel dispatch, Handle factory |
 | **Engine** (`engine`) | `impl/engine.go` | Storage, detection, correlation, replay — the shared core |
 
 The engine is a plain Go struct, not an Fx component. Both the live observer
@@ -65,7 +63,8 @@ and the testbench use the same engine.
 
 | File | Purpose |
 |------|---------|
-| `def/component.go` | Public interfaces: Component, Handle, View types, Detector, Correlator, etc. |
+| `def/component.go` | Component interface (GetHandle, GetStorageReader, etc.) |
+| `def/types.go` | Public interfaces: Handle, View types, Detector, Correlator, etc. |
 | `impl/engine.go` | Pipeline orchestration: ingest, advance, detect, correlate, replay |
 | `impl/storage.go` | In-memory columnar time-series storage (1s buckets, read-time aggregation) |
 | `impl/scheduler.go` | Scheduling policy: when to advance analysis |
@@ -85,7 +84,7 @@ code.
 **Reading order:**
 1. `README.md` — pipeline overview, extension guide, configuration
 2. `observer-engine.allium` — behavioral spec (rules, contracts, invariants)
-3. `def/component.go` — public interfaces
+3. `def/component.go` and `def/types.go` — public interfaces
 4. `impl/engine.go` — implementation of the spec
 
 ## Key Design Decisions

--- a/comp/anomalydetection/observer/impl/anomaly_correlator_passthrough.go
+++ b/comp/anomalydetection/observer/impl/anomaly_correlator_passthrough.go
@@ -13,11 +13,10 @@ import (
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
 
-// DetectorPassthroughCorrelator passes all anomalies straight through, grouped
-// by detector name. It does no time-clustering or filtering — each detector's
-// anomalies become a separate ActiveCorrelation. This is used for Level 1
-// detector-specific evaluation where we want to score each detector's raw
-// output independently.
+// DetectorPassthroughCorrelator passes all anomalies straight through without
+// time-clustering or filtering. Each individual anomaly becomes its own
+// ActiveCorrelation. This is used for Level 1 detector-specific evaluation
+// where we want to score each detector's raw output independently.
 type DetectorPassthroughCorrelator struct {
 	// anomaliesByDetector groups anomalies by DetectorName.
 	anomaliesByDetector map[string][]observer.Anomaly
@@ -62,9 +61,7 @@ func (c *DetectorPassthroughCorrelator) Reset() {
 //   - Anomalies:   single-element slice containing the original anomaly
 //   - FirstSeen/LastUpdated: the anomaly's timestamp
 //
-// When serialized via WriteObserverOutput, each correlation becomes an
-// ObserverCorrelation where period_start == period_end == anomaly.Timestamp.
-// This allows the scorer to evaluate each detection independently
+// This allows the scorer to evaluate each detection independently.
 func (c *DetectorPassthroughCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/comp/anomalydetection/observer/impl/anomaly_correlator_time_cluster.go
+++ b/comp/anomalydetection/observer/impl/anomaly_correlator_time_cluster.go
@@ -21,7 +21,7 @@ type TimeClusterConfig struct {
 	ProximitySeconds int64 `json:"proximity_seconds"`
 
 	// WindowSeconds is how long to keep anomalies before eviction.
-	// Default: 60 seconds.
+	// Default: 120 seconds (see DefaultTimeClusterConfig).
 	WindowSeconds int64 `json:"window_seconds"`
 
 	// MinClusterSize is the minimum number of anomalies a cluster must contain
@@ -73,7 +73,7 @@ func NewTimeClusterCorrelator(config TimeClusterConfig) *TimeClusterCorrelator {
 		config.ProximitySeconds = 10
 	}
 	if config.WindowSeconds == 0 {
-		config.WindowSeconds = 60
+		config.WindowSeconds = DefaultTimeClusterConfig().WindowSeconds
 	}
 	return &TimeClusterCorrelator{
 		config:   config,
@@ -201,7 +201,7 @@ func (c *TimeClusterCorrelator) mergeClusters(clusters []*timeCluster) *timeClus
 	return merged
 }
 
-// Flush evicts old clusters and returns empty (reporters pull state via ActiveCorrelations).
+// Advance evicts old clusters past the retention window (reporters pull state via ActiveCorrelations).
 func (c *TimeClusterCorrelator) Advance(dataTime int64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/comp/anomalydetection/observer/impl/anomaly_processor_correlator.go
+++ b/comp/anomalydetection/observer/impl/anomaly_processor_correlator.go
@@ -93,7 +93,7 @@ func (c *CrossSignalCorrelator) Name() string {
 	return "cross_signal_correlator"
 }
 
-// Process implements Correlator. It adds an anomaly to the buffer
+// ProcessAnomaly implements Correlator. It adds an anomaly to the buffer
 // using its data timestamp and evicts old entries.
 func (c *CrossSignalCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	dataTime := anomaly.Timestamp

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -255,10 +255,8 @@ func (e *engine) registerHandle(h *handle) {
 // passes a statically-defined string constant. As of this writing the full
 // set is:
 //   - "all-metrics"          (pkg/aggregator/demultiplexer_agent.go)
-//   - "dogstatsd"            (comp/dogstatsd/server/server.go)
-//   - "logs"                 (comp/observer/logssource/impl/component.go)
-//   - "agent-internal-logs"  (comp/observer/impl/observer.go)
-//   - "profile-agent"        (comp/observer/impl/observer.go)
+//   - "logs"                 (comp/anomalydetection/logssource/impl/logssource.go)
+//   - "agent-internal-logs"  (comp/anomalydetection/observer/impl/observer.go)
 //
 // If a future caller ever passes a user-controlled or per-container source
 // string, the COW map becomes unbounded and this memoisation strategy is
@@ -368,13 +366,13 @@ func (e *engine) removeEvictedMetricSeries(namespace string, evictedNames []stri
 // SeriesRemover interface that the listed SeriesRefs have been freed by
 // storage. This keeps detector-side per-series state (BOCPD posterior maps,
 // ScanMW/ScanWelch segment trackers, seriesDetectorAdapter visible-count
-// maps) symmetric with storage so the LRU caps placed on extractorsâ
+// maps) symmetric with storage so the LRU caps placed on extractors'
 // contexts actually translate into bounded heap usage end-to-end.
 //
-// The caller (removeContextRefsForEvictedKeys / Reset / future GC paths)
-// is responsible for invoking this with whatever refs storage actually
-// freed. Detectors are expected to ignore unknown refs, so itâs safe to
-// broadcast the same ref list to all of them.
+// The caller (removeEvictedMetricSeries / Reset / future GC paths) is
+// responsible for invoking this with whatever refs storage actually freed.
+// Detectors are expected to ignore unknown refs, so it's safe to broadcast
+// the same ref list to all of them.
 //
 // Concurrency invariant: this method, like every method on engine and
 // every detector RemoveSeries / Detect callback, runs only on the single

--- a/comp/anomalydetection/observer/impl/metrics_detector_cusum.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_cusum.go
@@ -44,17 +44,16 @@ func DefaultCUSUMConfig() CUSUMConfig {
 	}
 }
 
-// CUSUMDetector uses the Cumulative Sum (CUSUM) algorithm to detect when a
+// CUSUMDetector uses a two-sided Cumulative Sum (CUSUM) algorithm to detect when a
 // metric shifts from its baseline. CUSUM is designed for detecting change points.
 //
-// Algorithm:
+// Algorithm (upper and lower recurrences run in parallel):
 //
-//	S[0] = 0
-//	S[t] = max(0, S[t-1] + (x[t] - μ - k))
+//	S_high[t] = max(0, S_high[t-1] + (x[t] - μ - k))
+//	S_low[t]  = max(0, S_low[t-1]  + (μ - x[t] - k))
 //
 // Where μ is the baseline mean and k is the slack parameter (allowance for noise).
-// An anomaly is emitted when S[t] first exceeds threshold h, representing the
-// point of change detection.
+// An anomaly is emitted when either S_high[t] or S_low[t] first exceeds threshold h.
 type CUSUMDetector struct {
 	config CUSUMConfig
 }
@@ -83,7 +82,7 @@ func (c *CUSUMDetector) Name() string {
 	return "cusum"
 }
 
-// Analyze runs CUSUM on the series and returns an anomaly if a shift is detected.
+// Detect runs CUSUM on the series and returns an anomaly if a shift is detected.
 // The anomaly's Timestamp indicates when the shift was first detected (threshold crossing).
 func (c *CUSUMDetector) Detect(series observer.Series) observer.DetectionResult {
 	cfg := c.config

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
@@ -141,7 +141,7 @@ type HoltResidualDetector struct {
 	series map[holtStateKey]*holtSeriesState
 
 	// cache the discovered series list across Detect calls (mirrors the
-	// scanwelch / scanmw / bocpd / kl pattern).
+	// scanwelch / scanmw / bocpd pattern).
 	cachedSeries []observer.SeriesMeta
 	cachedGen    uint64
 }

--- a/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
@@ -380,7 +380,7 @@ func (r *RRCFDetector) alignByTimestamp(pointsByMetric map[string][]observer.Poi
 
 // sortTimestampedVectors sorts vectors by timestamp ascending.
 func sortTimestampedVectors(vecs []timestampedVector) {
-	// Simple insertion sort (vectors are typically small and nearly sorted)
+	// Simple insertion sort (vectors are typically small)
 	for i := 1; i < len(vecs); i++ {
 		for j := i; j > 0 && vecs[j].timestamp < vecs[j-1].timestamp; j-- {
 			vecs[j], vecs[j-1] = vecs[j-1], vecs[j]

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
@@ -129,7 +129,7 @@ func (d *ScanMWDetector) RemoveSeries(refs []observer.SeriesRef) {
 // and scans for changepoints. After finding one, the segment start advances
 // so subsequent calls only examine post-change data.
 //
-// Iteration pattern is the same as BOCPD (metrics_detector_bocpd.go:140-221)
+// Iteration pattern is the same as BOCPD (metrics_detector_bocpd.go Detect loop)
 // and ScanWelch — consider dedup if more scan-based detectors are added.
 func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) observer.DetectionResult {
 	d.ensureDefaults()

--- a/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
@@ -425,22 +425,9 @@ func (d *TukeyBiweightDetector) scoreBiweight(state *tbSeriesState, series *obse
 		return observer.Anomaly{}, false
 	}
 
-	// (f) PLAN DEVIATION: the original plan specified a "biweight-weight"
-	// gate — fire only if |latest - mu| < c·sigma, the same trimming cutoff
-	// used during the IRLS fit. With the plan's defaults (ZThreshold=5,
-	// c=4.685) this gate is mathematically empty: zAbs >= 5 AND |z| < 4.685
-	// have no overlap, so the detector could never fire and tests #3 and #4
-	// (FiresOnLevelShift, RobustToHistoricalOutlier) would be unsatisfiable.
-	//
-	// The candidate description's stated property is "downweights extremes
-	// during baseline estimation, then scores deviation against the
-	// IMMUNIZED baseline" — the biweight protects (mu, sigma), and any
-	// sufficiently anomalous latest point should fire. So the gate's real
-	// purpose is to suppress EXTREME glitches (sensor errors, NaN-converted
-	// 1e308, etc.) without blocking real shifts. We replace the c·sigma
-	// cutoff with a generous glitch cap at glitchZCap·sigma — anything
-	// beyond that is almost certainly an instrumentation artifact rather
-	// than a genuine regime change.
+	// (f) Suppress extreme glitches (sensor errors, NaN-converted 1e308, etc.)
+	// without blocking real shifts. Points with |z| >= glitchZCap are treated
+	// as instrumentation artifacts rather than genuine regime changes.
 	if zAbs >= tbGlitchZCap {
 		return observer.Anomaly{}, false
 	}
@@ -474,9 +461,8 @@ func (d *TukeyBiweightDetector) scoreBiweight(state *tbSeriesState, series *obse
 	return anomaly, true
 }
 
-// ensureDefaults fills in zero-valued config fields with sensible defaults.
-// Mirrors MannKendallDetector.ensureDefaults so a struct-literal construction
-// (&TukeyBiweightDetector{}) still produces a working detector.
+// ensureDefaults fills in zero-valued config fields with sensible defaults so
+// struct-literal construction (&TukeyBiweightDetector{}) still works.
 func (d *TukeyBiweightDetector) ensureDefaults() {
 	if d.WindowSize <= 0 {
 		d.WindowSize = 80

--- a/comp/anomalydetection/observer/impl/metrics_detector_util.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_util.go
@@ -108,7 +108,8 @@ func detectorMedian(vals []float64) float64 {
 // When scaleToSigma is true, the result is scaled by 1.4826 to estimate the
 // standard deviation for normally distributed data. Use scaleToSigma=true when
 // comparing against sigma-based thresholds (e.g. Mann-Whitney's deviation check),
-// and false when using raw MAD as a denominator for relative change scores (e.g. TopK).
+// and false when using raw MAD as a denominator for relative change scores
+// (e.g. ScanMW/ScanWelch preMAD checks).
 func detectorMAD(vals []float64, median float64, scaleToSigma bool) float64 {
 	if len(vals) == 0 {
 		return 0

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -121,7 +121,7 @@ func (l *logObs) GetHostname() string {
 	return l.hostname
 }
 
-// Optionally, for logs that provide timestamp interface (if needed elsewhere)
+// GetTimestampUnixMilli implements observerdef.LogView.
 func (l *logObs) GetTimestampUnixMilli() int64 {
 	return l.timestampMs
 }
@@ -345,10 +345,10 @@ type observerImpl struct {
 	advanceLogCleanup func() // flushes advance log recording file
 
 	// ingestMetricsEnabled gates externally-ingested metrics at the handle
-	// factory. When false, "all-metrics" and HF handles return a wrapper
-	// that drops ObserveMetric calls. Logs and profiles still pass through,
-	// and log-derived virtual metrics produced inside the engine by
-	// LogMetricsExtractors are unaffected because they bypass the handle.
+	// factory. When false, handles return a metricDropHandle wrapper that drops
+	// ObserveMetric calls. ObserveLog still passes through, and log-derived
+	// virtual metrics produced inside the engine by LogMetricsExtractors are
+	// unaffected because they bypass the handle.
 	ingestMetricsEnabled bool
 
 	// replayMu serialises engine access between the run() dispatch loop and
@@ -424,7 +424,7 @@ type seriesDetectorAdapter struct {
 
 	// lastVisibleCount is keyed by the storage's compact SeriesRef so we
 	// avoid rebuilding a string key per series per Detect call. SeriesRefs
-	// are append-only (storage.go:217) so they remain stable for the lifetime
+	// are append-only (storage.go:305) so they remain stable for the lifetime
 	// of a series.
 	lastVisibleCount map[observerdef.SeriesRef]int
 }
@@ -555,10 +555,10 @@ func (o *observerImpl) GetHandle(name string) observerdef.Handle {
 	return o.handleFunc(name)
 }
 
-// innerHandle creates the base handle without any middleware wrapping.
-// When anomaly_detection.metrics.enabled=false, the handle is wrapped with
+// innerHandle creates the base handle for a named source. When
+// anomaly_detection.metrics.enabled=false, the handle is wrapped with
 // metricDropHandle so external metrics are dropped at the edge, while
-// ObserveLog/ObserveProfile pass through.
+// ObserveLog calls still pass through.
 func (o *observerImpl) innerHandle(name string) observerdef.Handle {
 	h := &handle{ch: o.obsCh, source: name, telemetry: o.telemetry}
 	o.engine.registerHandle(h)
@@ -569,8 +569,8 @@ func (o *observerImpl) innerHandle(name string) observerdef.Handle {
 	return out
 }
 
-// metricDropHandle drops every ObserveMetric call but lets logs and
-// profiles through. Used when anomaly_detection.metrics.enabled=false so
+// metricDropHandle drops every ObserveMetric call but lets ObserveLog
+// through. Used when anomaly_detection.metrics.enabled=false so
 // external metric sources (DogStatsD, check samplers) do not feed the engine.
 // Virtual metrics produced by LogMetricsExtractors during engine.IngestLog are
 // unaffected because they bypass this handle path entirely.

--- a/comp/anomalydetection/observer/impl/patterns/cluster.go
+++ b/comp/anomalydetection/observer/impl/patterns/cluster.go
@@ -206,7 +206,8 @@ func (pc *PatternClusterer) Process(message string, unixSec int64) (*Cluster, bo
 	return pc.ProcessTokens(tokens, message, unixSec)
 }
 
-// ProcessTokens records unixSec on new clusters; see ProcessAt.
+// ProcessTokens records unixSec on new clusters and returns the matched or
+// newly created cluster.
 func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string, unixSec int64) (*Cluster, bool) {
 	sig := TokenListSignature(tokens)
 

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -18,7 +18,6 @@ import (
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// timeSeriesStorage is an internal storage for time series data.
 // StorageConfig holds tunable parameters for timeSeriesStorage.
 type StorageConfig struct {
 	// MaxSeries caps live series; when exceeded on Advance, series are evicted
@@ -57,6 +56,7 @@ const (
 	storagePointRetentionSecs = 120
 )
 
+// timeSeriesStorage is an internal storage for time series data.
 type timeSeriesStorage struct {
 	cfg    StorageConfig
 	mu     sync.RWMutex
@@ -966,37 +966,14 @@ func (s *timeSeriesStorage) DataTimestamps() []int64 {
 
 // SeriesGeneration returns a counter that increments whenever the series
 // catalog changes — either when a new series key is created or when an
-// existing key is removed via RemoveSeriesByKeys. Callers can use this to
-// safely cache ListSeries results.
+// existing key is removed via RemoveSeriesByRefs or RemoveSeriesByMetricName.
+// Callers can use this to safely cache ListSeries results.
 func (s *timeSeriesStorage) SeriesGeneration() uint64 {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.seriesGen
 }
 
-// RemoveSeriesByKeys deletes the listed internal series keys (as produced by
-// seriesKey). The compact numeric SeriesRef IDs assigned to each removed
-// series are retired but NEVER reused: the slot in seriesIDStats is set to
-// nil so any stale SeriesRef resolves to nil via resolveByID, and the slot
-// in seriesIDKeys is set to "" — the slice length is preserved so subsequent
-// index lookups remain bounds-safe, but the original key string is no longer
-// referenced and can be garbage-collected. GetSeriesByNumericID's nil-stats
-// guard handles the empty-string lookup safely (s.series[""] is always nil).
-// Returns the SeriesRefs that were actually freed (one per successful removal,
-// in input order; unknown keys are silently skipped). seriesGen is bumped iff
-// at least one series was removed so cached ListSeries results are invalidated.
-//
-// Callers use the returned refs to fan out per-series teardown to detector
-// state that's keyed by SeriesRef (BOCPD, ScanMW, ScanWelch posterior maps,
-// seriesDetectorAdapter.lastVisibleCount, etc.). Without that fan-out, those
-// maps grow with the cumulative number of series ever observed even though
-// storage shrinks â defeating the LRU caps put on the upstream extractors.
-//
-// This is the storage-side counterpart to engine.removeContextRefsForEvictedKeys:
-// the engine's contextRefs index keeps track of which storage key was created
-// for which extractor context key, so when an extractor evicts a context the
-// engine can pass the corresponding storage keys here to free their tags +
-// columnar arrays. Without this path, evicted patterns leak indefinitely.
 // RemoveSeriesByRefs deletes series by their compact numeric refs. Each removed
 // series has its seriesIDStats slot set to nil (ref is never reused) and its
 // hash slot deleted from s.series. Returns the refs actually freed; out-of-range

--- a/comp/anomalydetection/observer/impl/telemetry.go
+++ b/comp/anomalydetection/observer/impl/telemetry.go
@@ -30,13 +30,11 @@ const (
 )
 
 type observerTelemetry struct {
-	// Existing telemetry
 	channelDropped  telemetry.Counter
 	rrcfScore       telemetry.Gauge
 	rrcfThreshold   telemetry.Gauge
 	logPatternCount telemetry.Counter
 
-	// New telemetry
 	logsIngested     telemetry.Counter
 	processedLogSize telemetry.Counter
 	droppedLogs      telemetry.Counter

--- a/comp/anomalydetection/recorder/fx-noop/fx_noop.go
+++ b/comp/anomalydetection/recorder/fx-noop/fx_noop.go
@@ -5,7 +5,7 @@
 
 // Package fx provides the fx module for the recorder component.
 // This no-op variant provides an empty option so the observer starts
-// without recording. Wire recorder/fx instead when recording is needed.
+// without recording. Wire the full recorder implementation when recording is needed.
 package fx
 
 import (

--- a/comp/anomalydetection/recorder/impl-noop/recorder.go
+++ b/comp/anomalydetection/recorder/impl-noop/recorder.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package noopimpl provides a no-op recorder implementation.
-// The full implementation (parquet writer) ships with the testbench in a later PR.
+// Package noopimpl provides a no-op recorder implementation wired in the
+// production agent. The full parquet implementation is planned for recorder/impl.
 package noopimpl
 
 import (

--- a/comp/anomalydetection/reporter/fx-testbench/fx.go
+++ b/comp/anomalydetection/reporter/fx-testbench/fx.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Package fx provides the testbench fx module for the reporter component.
-// Wire this in the testbench binary: it provides the SSE-pushing reporter.Component
+// Wire this in the testbench binary: it provides the SSE-pushing reporter.Reporter
 // and exposes SSEAccess for the HTTP API to register browser clients.
 package fx
 

--- a/comp/anomalydetection/reporter/impl-noop/reporter.go
+++ b/comp/anomalydetection/reporter/impl-noop/reporter.go
@@ -5,5 +5,6 @@
 
 // Package noopimpl provides a no-op reporter implementation.
 // Reporters in production register via the anomalydetection_reporters Fx group.
-// This stub satisfies the component structure linter until the real impl lands.
+// This stub satisfies the component structure linter; the real implementation
+// lives in reporter/impl.
 package noopimpl

--- a/comp/anomalydetection/reporter/impl-testbench/reporter.go
+++ b/comp/anomalydetection/reporter/impl-testbench/reporter.go
@@ -11,7 +11,7 @@ import (
 	reporter "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
 )
 
-// TestbenchReporter implements reporter.Component for the testbench.
+// TestbenchReporter implements reporter.Reporter for the testbench.
 // On each Report call it pushes a lightweight "advance" SSE event so connected
 // browser clients know to refresh their state via the API.
 // It also satisfies SSEAccess so the testbench HTTP API can subscribe clients.

--- a/comp/anomalydetection/reporter/impl-testbench/sse.go
+++ b/comp/anomalydetection/reporter/impl-testbench/sse.go
@@ -12,7 +12,7 @@ import (
 
 // SSEEvent is a message sent to SSE clients.
 type SSEEvent struct {
-	Event string // "status", "progress", "heartbeat"
+	Event string // "advance", "status"
 	Data  []byte // JSON payload
 }
 

--- a/comp/anomalydetection/reporter/impl/notify.go
+++ b/comp/anomalydetection/reporter/impl/notify.go
@@ -40,8 +40,8 @@ const (
 	logPatternExtractorNamespace = "log_pattern_extractor"
 	logMetricsExtractorNamespace = "log_metrics_extractor"
 
-	// changeEventMessageMaxLen caps the rendered change-event message. The v2
-	// Events API rejects messages larger than 4 KiB.
+	// changeEventMessageMaxLen caps the rendered change-event message below the
+	// v2 Events API 4 KiB limit (4096 bytes).
 	changeEventMessageMaxLen = 4000
 	// impactedResourcesMaxItems caps the number of service entries we attach
 	// to a change event. Matches the v2 API server-side limit.

--- a/comp/anomalydetection/reporter/reporter.allium
+++ b/comp/anomalydetection/reporter/reporter.allium
@@ -104,6 +104,7 @@ external entity ChangeEvent {
     message: String
     category: EventCategory
     integration_id: String
+    host: String?
     tags: Set<String>
     timestamp: Timestamp
     aggregation_key: String
@@ -138,6 +139,7 @@ value AnomalyDebugInfo {
     baseline_mean: Decimal
     baseline_median: Decimal
     baseline_stddev: Decimal
+    baseline_mad: Decimal
     threshold: Decimal
     current_value: Decimal
     deviation_sigma: Decimal
@@ -264,9 +266,9 @@ config {
 -- changed_resource.type is `anomaly`. The intake rejects the
 -- previously-emitted `configuration` value.
 --
---   integration_id        = "edge-intelligence"
+--   integration_id         = "edge-intelligence"
 --   derived source_type_id = 78252213 (from integration_id)
---   changed_resource_type = "anomaly"
+--   changed_resource_type  = "anomaly"
 --   author_name           = "datadog-agent-observer"
 --   author_type           = "automation"
 --   category              = change
@@ -316,10 +318,10 @@ rule ReportCorrelationsToStdout {
         )
 
     @guidance
-        -- StdoutReporter never publishes externally and never deduplicates;
-        -- it is a tracing aid for local development and replay. The
-        -- StdoutTraceWritten event is the observable boundary; its textual
-        -- form is unspecified.
+        -- StdoutReporter never publishes externally but deduplicates patterns
+        -- at info level (mirrors EventReporter semantics): first-seen patterns
+        -- log at info, ongoing patterns at debug. The StdoutTraceWritten event
+        -- is the observable boundary; its textual form is unspecified.
 }
 
 -- A correlation that the EventReporter has not yet published is published
@@ -342,6 +344,7 @@ rule PublishNewCorrelation {
                     message: render_change_message(c),
                     category: change,
                     integration_id: "edge-intelligence",
+                    host: derive_host(c),
                     tags: derive_event_tags(c),
                     timestamp: c.first_seen,
                     aggregation_key: "observer:" + c.pattern,
@@ -420,6 +423,12 @@ rule DropExpiredSeenPatterns {
 --      current_value <= baseline_mean, classify as `drop`.
 --   3. Otherwise classify as `spike`.
 --   A Correlation with no anomalies classifies as `spike`.
+
+-- derive_host(c: Correlation) -> String
+--
+-- The agent hostname from the hostname component, attached to the change
+-- event for intake-side host association. Omitted from the wire payload
+-- when the hostname component is unavailable or returns an empty value.
 
 -- derive_event_tags(c: Correlation) -> Set<String>
 --


### PR DESCRIPTION
### What does this PR do?

- Updated comments that were outdated to avoid guiding LLMs incorrectly
- Fixed time cluster default duration
- Fixed other "documentation" files such as AGENTS and allium

### Motivation

### Describe how you validated your changes

### Additional Notes