### PR TITLE
test(healthplatform): assert RESOLVED state and lower forwarder interval in all E2E tests

### DIFF
--- a/test/new-e2e/tests/agent-health/check_failure_test.go
+++ b/test/new-e2e/tests/agent-health/check_failure_test.go
@@ -21,11 +21,11 @@ import (
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
 )
 
-const healthPlatformAgentConfig = `health_platform:
-  enabled: true
-  forwarder:
-    interval: 30s
-`
+// healthPlatformAgentConfig is the shared base agent config for health platform E2E tests.
+// The short forwarder interval reduces detection and resolution latency.
+//
+//go:embed fixtures/agent_config.yaml
+var healthPlatformAgentConfig string
 
 const brokenCheckConf = `init_config:
 instances:
@@ -68,8 +68,7 @@ func TestCheckFailureSuite(t *testing.T) {
 
 // TestCheckFailureIssueLifecycle verifies that a check execution failure is
 // detected in fakeintake as NEW and that replacing the failing check with a
-// working version causes the issue to stop being reported (or be reported as
-// RESOLVED).
+// working version causes the issue to transition to RESOLVED.
 //
 // Cross-restart persistence is tested separately in TestResilienceSuite.
 func (suite *checkFailureSuite) TestCheckFailureIssueLifecycle() {
@@ -122,6 +121,21 @@ func (suite *checkFailureSuite) TestCheckFailureIssueLifecycle() {
 				),
 			),
 		))
+
+		// Wait for the issue to explicitly transition to RESOLVED before flushing.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			payloads, err := fakeIntake.GetAgentHealth()
+			assert.NoError(ct, err)
+			for _, p := range payloads {
+				for _, iss := range findIssuesByPrefix(p, issuePrefix) {
+					if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_RESOLVED {
+						return
+					}
+				}
+			}
+			assert.Fail(ct, "issue not yet RESOLVED")
+		}, defaultIssueTimeout, defaultIssuePollInterval, "issue never transitioned to RESOLVED after fix")
+
 		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
 
 		require.Never(t, func() bool {
@@ -134,6 +148,6 @@ func (suite *checkFailureSuite) TestCheckFailureIssueLifecycle() {
 				}
 			}
 			return false
-		}, defaultIssueAbsenceWindow, defaultIssuePollInterval, "issue still reported as non-resolved after fix")
+		}, defaultIssueAbsenceWindow, defaultIssuePollInterval, "issue reappeared as non-resolved after fix")
 	})
 }

--- a/test/new-e2e/tests/agent-health/docker_permission_test.go
+++ b/test/new-e2e/tests/agent-health/docker_permission_test.go
@@ -188,6 +188,21 @@ func (suite *dockerPermissionSuite) TestDockerPermissionIssueLifecycle() {
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			assert.True(ct, agent.Client.IsReady())
 		}, 2*time.Minute, 10*time.Second, "agent not ready after fix restart")
+
+		// Wait for the issue to explicitly transition to RESOLVED before flushing.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			payloads, err := fakeIntake.GetAgentHealth()
+			assert.NoError(ct, err)
+			for _, p := range payloads {
+				for _, iss := range findIssuesByID(t, p, issueID) {
+					if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_RESOLVED {
+						return
+					}
+				}
+			}
+			assert.Fail(ct, "issue not yet RESOLVED")
+		}, defaultIssueTimeout, defaultIssuePollInterval, "issue never transitioned to RESOLVED after fix")
+
 		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
 
 		require.Never(t, func() bool {
@@ -200,6 +215,6 @@ func (suite *dockerPermissionSuite) TestDockerPermissionIssueLifecycle() {
 				}
 			}
 			return false
-		}, defaultIssueAbsenceWindow, defaultIssuePollInterval, "issue still reported as non-resolved after fix")
+		}, defaultIssueAbsenceWindow, defaultIssuePollInterval, "issue reappeared as non-resolved after fix")
 	})
 }

--- a/test/new-e2e/tests/agent-health/fixtures/agent_config.yaml
+++ b/test/new-e2e/tests/agent-health/fixtures/agent_config.yaml
@@ -1,0 +1,4 @@
+health_platform:
+  enabled: true
+  forwarder:
+    interval: 5s

--- a/test/new-e2e/tests/agent-health/fixtures/docker_permission_agent_config.yaml
+++ b/test/new-e2e/tests/agent-health/fixtures/docker_permission_agent_config.yaml
@@ -1,7 +1,7 @@
 health_platform:
   enabled: true
   forwarder:
-    interval: 30s
+    interval: 5s
 logs_enabled: true
 logs_config:
   container_collect_all: true

--- a/test/new-e2e/tests/agent-health/resilience_test.go
+++ b/test/new-e2e/tests/agent-health/resilience_test.go
@@ -153,9 +153,24 @@ func (suite *resilienceSuite) TestHealthPlatformIssueRecurrence() {
 			),
 		),
 	))
+
+	// Wait for the issue to explicitly transition to RESOLVED before flushing.
+	require.EventuallyWithT(suite.T(), func(ct *assert.CollectT) {
+		payloads, err := fakeIntake.GetAgentHealth()
+		assert.NoError(ct, err)
+		for _, p := range payloads {
+			for _, iss := range findIssuesByPrefix(p, issuePrefix) {
+				if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_RESOLVED {
+					return
+				}
+			}
+		}
+		assert.Fail(ct, "issue not yet RESOLVED")
+	}, defaultIssueTimeout, defaultIssuePollInterval, "issue never transitioned to RESOLVED after fix")
+
 	require.NoError(suite.T(), fakeIntake.FlushServerAndResetAggregators())
 
-	// Verify the issue is resolved or no longer reported.
+	// Verify the issue is no longer reported after flush.
 	require.Never(suite.T(), func() bool {
 		payloads, _ := fakeIntake.GetAgentHealth()
 		for _, p := range payloads {
@@ -166,7 +181,7 @@ func (suite *resilienceSuite) TestHealthPlatformIssueRecurrence() {
 			}
 		}
 		return false
-	}, defaultIssueAbsenceWindow, defaultIssuePollInterval, "issue not resolved after fix")
+	}, defaultIssueAbsenceWindow, defaultIssuePollInterval, "issue reappeared as non-resolved after fix")
 
 	// Re-break: deploy the broken check again.
 	suite.UpdateEnv(awshost.Provisioner(


### PR DESCRIPTION
### What does this PR do?

Brings all health platform E2E lifecycle tests in line with the pattern validated in the `invalidconfig` test (PR #52106):

1. **Lower forwarder interval to 5s** across all tests via a shared `fixtures/agent_config.yaml` fixture (replaces the inline `healthPlatformAgentConfig` const that used `interval: 30s`). This reduces detection and resolution latency in tests from ~30s to ~5s.

2. **Assert `ISSUE_STATE_RESOLVED`** in every Resolution phase, replacing the old pattern of flush → Never with: fix → `EventuallyWithT(RESOLVED)` → flush → Never. This explicitly verifies the state machine transition rather than just checking absence.

### Affected tests

| Test | Change |
|---|---|
| `TestCheckFailureIssueLifecycle/Resolution` | Add `EventuallyWithT(RESOLVED)` before flush |
| `TestDockerPermissionIssueLifecycle/Resolution` | Add `EventuallyWithT(RESOLVED)` before flush |
| `TestHealthPlatformIssueRecurrence` (resilience) | Add `EventuallyWithT(RESOLVED)` before flush |

### Dependencies

Depends on PR #52168 (`fix(healthplatform): reliably forward RESOLVED state after agent restart`) which fixes the production code bugs that prevented `ISSUE_STATE_RESOLVED` from being forwarded to fakeintake.