### PR TITLE
Optimize bazel overhead in unix python build

### DIFF
--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -145,7 +145,25 @@ cc_library(
 
 filegroup(
     name = "all_srcs",
-    srcs = glob(["**"], exclude = ["BUILD.bazel"]),
+    srcs = glob(
+        ["**"],
+        exclude = [
+            "BUILD.bazel",
+            ".devcontainer/**",
+            "Android/**",
+            "Doc/**",
+            "InternalDocs/**",
+            "iOS/**",
+            # Windows related.
+            "PC/**",
+            "PCbuild/**",
+            "Tools/msi/**",
+            "Tools/nuget/**",
+            # Tests that don't need to be shipped with the Agent
+            "Lib/idlelib/idle_test/**",
+            "Lib/test/**",
+        ],
+    ),
 )
 
 UNIX_BINS = [

--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -315,6 +315,8 @@ configure_make(
       --install-prefix "##PREFIX##" \
       --sandbox-prefix "$$BUILD_TMPDIR/$$INSTALL_PREFIX" \
       $$INSTALLDIR/lib/python{version}/_sysconfigdata__*.py
+    rm -f $$INSTALLDIR/lib/python{version}/config-*/Makefile
+    find $$INSTALLDIR/lib/python{version} -name '*.exe' -delete
     """.format(
         version = PYTHON_MAJOR_MINOR,
     ),
@@ -394,19 +396,6 @@ select_file(
     srcs = ":python_unix",
     subpath = "bin/python{}".format(PYTHON_MAJOR_MINOR),
     visibility = ["//visibility:public"],
-)
-
-# Using a copy here is the most convenient way to exclude a bunch of things for the final package
-copy_to_directory(
-    name = "python_lib_dir_unix",
-    srcs = [":python_lib_dir_group_unix"],
-    exclude_srcs_patterns = [
-        "test/**/*",
-        "**/*.exe",
-        "**/Makefile",
-    ],
-    root_paths = ["python_unix/lib/python{}".format(PYTHON_MAJOR_MINOR)],
-    out = "python{}".format(PYTHON_MAJOR_MINOR),
 )
 
 filegroup(
@@ -511,7 +500,7 @@ dd_cc_packaged(
     installed_files = [":_python_pkg_common_files"],
     installed_executables = {
         ":python3_bin": "bin",
-        ":python_lib_dir_unix": "lib/python{}".format(PYTHON_MAJOR_MINOR),
+        ":python_lib_dir_group_unix": "lib/python{}".format(PYTHON_MAJOR_MINOR),
     } | select({
         "@platforms//os:linux": {":python_stable_lib_linux": "lib"},
         "//conditions:default": {},


### PR DESCRIPTION
### What does this PR do?

It applies two optimizations to the Python build on linux/macos:
- It reduces the inputs to the configure_make rule that builds Python. Indirectly, this also removes part of the outputs (the exclusions under Lib), which is acceptable given that they're directories that we're cleaning up one way or another.
- It removes an intermediate copy_to_directory whose only purpose was filtering the output, by using postfix_script to remove the necessary files from the original output.

### Motivation

Reducing Bazel overhead around the parts that don't involve the building itself. This includes reducing the costs of staging and hashing inputs, and the amount of data that potentially gets downloaded and uploaded to the remote cache.

### Describe how you validated your changes

CI passing, and no changes in the file inventory check.

### Additional Notes

Windows optimization will be tackled separately.

Justification for the exclusions under `Lib`:
https://github.com/DataDog/datadog-agent/blob/50c86066b1034a0ecd07aa0db843f5733e8b5f89/omnibus/config/software/datadog-agent-integrations-py3.rb#L232

(we'll get rid of the line on omnibus later)

https://github.com/DataDog/datadog-agent/blob/50c86066b1034a0ecd07aa0db843f5733e8b5f89/deps/cpython.BUILD.bazel#L386