### PR TITLE
[CONTINT-5277] Widen container.cpu.usage e2e assertion to reduce flakiness

### DIFF
--- a/test/new-e2e/tests/containers/base_test.go
+++ b/test/new-e2e/tests/containers/base_test.go
@@ -70,6 +70,21 @@ type testMetricExpectValueArgs struct {
 	Max float64
 }
 
+// cpustressUsageMin / cpustressUsageMax bound the expected `container.cpu.usage`
+// (in nanocores) for the shared stress-ng workload (`--cpu=1 --cpu-load=15`
+// under a 0.2-core allocation: a 200m limit on Kubernetes, Cpu:200 on ECS).
+// The reported usage is noisy: across 220 failures sampled from two independent
+// bursts (2026-05 and 2026-06) the value spanned [0.125, 0.172] core, roughly
+// symmetric around the ~0.15 target. The previous [0.145, 0.155] window (±3%)
+// sat well inside that spread, making it the dominant flake for TestCPU across
+// the Kind/EKS/OpenShift/ECS suites (CONTINT-5277, CONTINT-5146, CONTINT-3928,
+// CONTINT-4153). [0.12, 0.18] covers the observed envelope with a small margin
+// while still catching gross collection errors.
+const (
+	cpustressUsageMin = 120_000_000 // 0.12 core (observed min ~0.125)
+	cpustressUsageMax = 180_000_000 // 0.18 core (observed max ~0.172)
+)
+
 // myCollectT does nothing more than "github.com/stretchr/testify/assert".CollectT
 // It’s used only to get access to `errors` field which is otherwise private.
 type myCollectT struct {

--- a/test/new-e2e/tests/containers/base_test.go
+++ b/test/new-e2e/tests/containers/base_test.go
@@ -70,16 +70,6 @@ type testMetricExpectValueArgs struct {
 	Max float64
 }
 
-// cpustressUsageMin / cpustressUsageMax bound the expected `container.cpu.usage`
-// (in nanocores) for the shared stress-ng workload (`--cpu=1 --cpu-load=15`
-// under a 0.2-core allocation: a 200m limit on Kubernetes, Cpu:200 on ECS).
-// The reported usage is noisy: across 220 failures sampled from two independent
-// bursts (2026-05 and 2026-06) the value spanned [0.125, 0.172] core, roughly
-// symmetric around the ~0.15 target. The previous [0.145, 0.155] window (±3%)
-// sat well inside that spread, making it the dominant flake for TestCPU across
-// the Kind/EKS/OpenShift/ECS suites (CONTINT-5277, CONTINT-5146, CONTINT-3928,
-// CONTINT-4153). [0.12, 0.18] covers the observed envelope with a small margin
-// while still catching gross collection errors.
 const (
 	cpustressUsageMin = 120_000_000 // 0.12 core (observed min ~0.125)
 	cpustressUsageMax = 180_000_000 // 0.18 core (observed max ~0.172)

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -529,8 +529,8 @@ func (suite *ecsSuite) TestCPU() {
 				`^task_version:[[:digit:]]+$`,
 			},
 			Value: &testMetricExpectValueArgs{
-				Max: 155000000,
-				Min: 145000000,
+				Min: cpustressUsageMin,
+				Max: cpustressUsageMax,
 			},
 		},
 	})

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -1044,8 +1044,8 @@ func (suite *k8sSuite) TestCPU() {
 				`^short_image:apps-stress-ng$`,
 			}, sourceCodeIntegrationTags),
 			Value: &testMetricExpectValueArgs{
-				Max: 155000000,
-				Min: 145000000,
+				Min: cpustressUsageMin,
+				Max: cpustressUsageMax,
 			},
 		},
 	})


### PR DESCRIPTION
### What does this PR do?

Replaces the `container.cpu.usage` value-range assertion used by `TestCPU` and factors the bounds into two shared constants (`cpustressUsageMin`/`cpustressUsageMax` in `base_test.go`), used by both the Kubernetes-based suites (Kind/EKS/OpenShift, via the embedded `k8sSuite`) and the ECS suite.

Range: `[145M, 155M]` nanocores (±3% around the workload's ~0.15-core target) → **`[120M, 180M]`** (`[0.12, 0.18]` core).

### Motivation

The shared `stress-ng` workload runs `--cpu=1 --cpu-load=15` (target ~0.15 core) under a 0.2-core allocation, but its reported CPU usage is genuinely noisy. This single assertion was the **dominant flaky-test cause across all four container e2e suites** (Datadog Test Optimization failure rate on `main`: ~18% Kind, ~13% OpenShift, ~4.4% EKS, ~3% ECS).

The window is **empirically derived**, not guessed. I mined the observed `container.cpu.usage` values from the failure messages of **220 failed `TestCPU` occurrences across two independent bursts ~1 month apart**:

| Sample | Occurrences | Observed envelope | Undershoot / Overshoot |
|---|---|---|---|
| 2026-05-22 → 24 | 120 | `[0.1246, 0.1699]` core | 67 / 53 |
| 2026-06-12 | 100 | `[0.1251, 0.1719]` core | 46 / 54 |

The distribution is **stable across both windows**, roughly symmetric around ~0.15 core, with **no near-zero values** (collection is healthy — failures are pure jitter at the tails). Combined observed envelope: **`[0.1246, 0.1719]` core**.

`[0.12, 0.18]` covers that envelope with a small (~4–8M) margin on each side. It is:
- **wide enough** to eliminate the tail flakiness (the smallest window that passes every sampled failure is `[125M, 172M]`);
- **tight enough** to remain a meaningful ±20% plausibility check — it still catches gross errors (zero/near-zero, order-of-magnitude, or an at-allocation `200M` reading, since `180M < 200M`).

### Describe how you validated your changes

- The new range **contains** the old `[145M, 155M]` window, so no previously-passing run can newly fail.
- Empirically covers `[0.1246, 0.1719]` core, the full observed failure envelope across 220 occurrences / two bursts.
- Verified the constants resolve across all three files (same `package containers`) via LSP `findReferences`; confirmed no other `container.cpu.usage` value assertion uses the old literals, and that Kind/EKS/OpenShift inherit the single `k8sSuite.TestCPU`.
- E2E suites were not run locally (they provision real cloud infra and only adjust an assertion threshold); the container e2e jobs on this PR exercise the change.

### Additional Notes

First of a series of flaky-reduction PRs for the container e2e suites (P0). The stable bimodal spread suggests a deeper follow-up worth considering: making the workload itself more deterministic, or asserting relative to the CPU allocation rather than an absolute band. Other follow-ups: hardening the fakeintake client against transient network timeouts, and OpenShift/ECS provisioning-startup robustness.

Refs: CONTINT-5277, CONTINT-5146, CONTINT-3928, CONTINT-4153
