### PR TITLE
Enable OTel by default in the standalone DDOT image

### DIFF
--- a/Dockerfiles/otel-agent/Dockerfile
+++ b/Dockerfiles/otel-agent/Dockerfile
@@ -92,5 +92,7 @@ COPY --from=builder /workspace/datadog-agent/bin/otel-agent/dist/otel-config.yam
 # Find all directories and files in /etc with world-writable permissions and remove write permissions for group and others
 RUN find /etc -type d,f -perm -o+w -print0 | xargs -r -0 chmod g-w,o-w
 
+ENV DD_OTELCOLLECTOR_ENABLED=true
+
 ENTRYPOINT ["/bin/bash"]
 CMD ["/opt/datadog-agent/embedded/bin/otel-agent", "run"]


### PR DESCRIPTION
### What does this PR do?

Set the environment enabling the otel agent by default in the image that only contains the otel agent

### Motivation

Reduce config necessary to use DDOT with upstream helm chart & operator

[OTAGENT-1084](https://datadoghq.atlassian.net/browse/OTAGENT-1084?atlOrigin=eyJpIjoiODVhMGM0YjM0NGI5NGY3MGIxM2I3MjgzYTM1YmIyNzAiLCJwIjoiaiJ9)

[OTAGENT-1084]: https://datadoghq.atlassian.net/browse/OTAGENT-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ