### PR TITLE
fix(package): cross-platform .deb extraction in package.diff

### DIFF
--- a/tasks/libs/package/extract.py
+++ b/tasks/libs/package/extract.py
@@ -1,14 +1,19 @@
 import os
+import sys
 
 from invoke.context import Context
 
 
 def extract_deb(ctx: Context, deb_path: str, extract_path: str):
     os.makedirs(extract_path)
-    # ar x with --output is GNU-only; BSD ar (macOS) requires cd + absolute path
-    abs_deb_path = os.path.abspath(deb_path)
+    if sys.platform == 'darwin':
+        # bsdtar (macOS default tar, via libarchive) supports the ar format used by .deb files;
+        # BSD ar does not support the System V ar format used by .deb files
+        ctx.run(f"tar xf {deb_path} -C {extract_path}")
+    else:
+        # GNU ar supports .deb's System V ar format; --output sets the extract directory
+        ctx.run(f"ar x {deb_path} --output {extract_path}")
     with ctx.cd(extract_path):
-        ctx.run(f"ar x {abs_deb_path}")
         ctx.run("tar xf data.tar.xz")
         ctx.run("rm data.tar.xz")
 

--- a/tasks/libs/package/extract.py
+++ b/tasks/libs/package/extract.py
@@ -5,8 +5,10 @@ from invoke.context import Context
 
 def extract_deb(ctx: Context, deb_path: str, extract_path: str):
     os.makedirs(extract_path)
-    ctx.run(f"ar x {deb_path} --output {extract_path}")
+    # ar x with --output is GNU-only; BSD ar (macOS) requires cd + absolute path
+    abs_deb_path = os.path.abspath(deb_path)
     with ctx.cd(extract_path):
+        ctx.run(f"ar x {abs_deb_path}")
         ctx.run("tar xf data.tar.xz")
         ctx.run("rm data.tar.xz")
 


### PR DESCRIPTION
### What does this PR do?

Use platform-specific tools to extract `.deb` files: `bsdtar` on macOS, GNU `ar` on Linux.

### Motivation

`.deb` files use the System V `ar` format. BSD `ar` on macOS does not support this format, so `ar x` fails. macOS's default `tar` (bsdtar, via libarchive) does support it. GNU `ar` on Linux supports it and also provides `--output` to set the extract directory.

### Describe how you validated your changes

Manual testing on macOS.

### Additional Notes

N/A