### PR TITLE
Use constant fetcher to retrieve inode uid and mode

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -89,11 +89,17 @@ static __attribute__((always_inline)) void fill_file(struct dentry *dentry, stru
       file->metadata.nlink = nlink;
     }
 
+    u64 inode_mode_offset;
+    LOAD_CONSTANT("inode_mode_offset", inode_mode_offset);
+
+    u64 inode_uid_offset;
+    LOAD_CONSTANT("inode_uid_offset", inode_uid_offset);
+
     u64 inode_gid_offset;
     LOAD_CONSTANT("inode_gid_offset", inode_gid_offset);
 
-    bpf_probe_read(&file->metadata.mode, sizeof(file->metadata.mode), &d_inode->i_mode);
-    bpf_probe_read(&file->metadata.uid, sizeof(file->metadata.uid), &d_inode->i_uid);
+    bpf_probe_read(&file->metadata.mode, sizeof(file->metadata.mode), (void *)d_inode + inode_mode_offset);
+    bpf_probe_read(&file->metadata.uid, sizeof(file->metadata.uid), (void *)d_inode + inode_uid_offset);
     bpf_probe_read(&file->metadata.gid, sizeof(file->metadata.gid), (void *)d_inode + inode_gid_offset);
 
     u64 inode_ctime_sec_offset;

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -53,6 +53,8 @@ const (
 	// inode
 	OffsetInodeIno   = "inode_ino_offset"
 	OffsetInodeNlink = "inode_nlink_offset"
+	OffsetInodeMode  = "inode_mode_offset"
+	OffsetInodeUID   = "inode_uid_offset"
 	OffsetInodeGid   = "inode_gid_offset"
 	OffsetInodeMtime = "inode_mtime_offset"
 	OffsetInodeCtime = "inode_ctime_offset"

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -45,6 +45,8 @@ func (f *FallbackConstantFetcher) String() string {
 func computeRawsTable() map[string]uint64 {
 	return map[string]uint64{
 		OffsetInodeIno:                            64,
+		OffsetInodeMode:                           0,
+		OffsetInodeUID:                            4,
 		OffsetInodeGid:                            8,
 		OffsetInodeNlink:                          72,
 		OffsetInodeMtime:                          104,

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3574,6 +3574,8 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 
 	// inode
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeIno, "struct inode", "i_ino")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeMode, "struct inode", "i_mode")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeUID, "struct inode", "i_uid")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeGid, "struct inode", "i_gid")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeNlink, "struct inode", "i_nlink")
 	constantFetcher.AppendOffsetofRequestWithFallbacks(


### PR DESCRIPTION
### What does this PR do?

Use constant fetcher to retrieve inode uid and mode

### Motivation

Layout of the inode struct has changed significantly on Linux 7.0

### Describe how you validated your changes

### Additional Notes
