### PR TITLE
[CONTINT-4153] Harden fakeintake client against transient network timeouts

### DIFF
--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -119,6 +119,27 @@ func WithGetBackoffRetries(retries uint) Option {
 	}
 }
 
+// Default HTTP client timeouts for requests to the fakeintake server.
+const (
+	// defaultHTTPDialTimeout bounds connection establishment so a transient
+	// "dial tcp ...: i/o timeout" fails fast (in seconds) instead of hanging on
+	// the OS-default connect timeout, letting the get() backoff and the caller's
+	// polling loop retry within their budget.
+	defaultHTTPDialTimeout = 10 * time.Second
+	// defaultHTTPResponseHeaderTimeout bounds a server that accepts the
+	// connection but never sends response headers. It does NOT cap body reads,
+	// so large payload dumps are unaffected.
+	defaultHTTPResponseHeaderTimeout = 30 * time.Second
+)
+
+// WithHTTPDialTimeout sets the connection (dial) timeout for HTTP requests to
+// the fakeintake server.
+func WithHTTPDialTimeout(timeout time.Duration) Option {
+	return func(c *Client) {
+		c.httpDialTimeout = timeout
+	}
+}
+
 // Client is a fake intake client
 type Client struct {
 	fakeintakeID            string
@@ -129,6 +150,12 @@ type Client struct {
 	// Get retry parameters
 	getBackoffRetries uint
 	getBackoffDelay   time.Duration
+
+	// HTTP client used for all requests to the fakeintake server, with a bounded
+	// dial timeout so transient network blips surface as retryable errors rather
+	// than hanging on the OS-default connect timeout.
+	httpClient      *http.Client
+	httpDialTimeout time.Duration
 
 	metricAggregator               aggregator.MetricAggregator
 	metricAggregatorV3             aggregator.MetricAggregator
@@ -164,6 +191,7 @@ func NewClient(fakeIntakeURL string, opts ...Option) *Client {
 		fakeintakeIDMutex:              sync.RWMutex{},
 		getBackoffRetries:              4,
 		getBackoffDelay:                5 * time.Second,
+		httpDialTimeout:                defaultHTTPDialTimeout,
 		fakeIntakeURL:                  strings.TrimSuffix(fakeIntakeURL, "/"),
 		metricAggregator:               aggregator.NewMetricAggregator(),
 		metricAggregatorV3:             aggregator.NewMetricAggregatorV3(),
@@ -194,7 +222,24 @@ func NewClient(fakeIntakeURL string, opts ...Option) *Client {
 		opt(client)
 	}
 
+	client.httpClient = newHTTPClient(client.httpDialTimeout)
+
 	return client
+}
+
+// newHTTPClient builds the HTTP client used for all fakeintake requests. It
+// bounds connection establishment (dial) and the response-header wait so a
+// transient network failure surfaces quickly as a retryable error instead of
+// hanging on the OS-default connect timeout. It intentionally sets no overall
+// client Timeout so large payload body reads are not truncated.
+func newHTTPClient(dialTimeout time.Duration) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{
+		Timeout:   dialTimeout,
+		KeepAlive: 30 * time.Second,
+	}).DialContext
+	transport.ResponseHeaderTimeout = defaultHTTPResponseHeaderTimeout
+	return &http.Client{Transport: transport}
 }
 
 // PayloadFilter is used to filter payloads by name and resource type
@@ -482,7 +527,7 @@ func (c *Client) getFakePayloads(endpoint string) (rawPayloads []api.Payload, er
 // GetServerHealth fetches fakeintake health status and returns an error if
 // fakeintake is unhealthy
 func (c *Client) GetServerHealth() error {
-	resp, err := http.Get(c.fakeIntakeURL + "/fakeintake/health")
+	resp, err := c.httpClient.Get(c.fakeIntakeURL + "/fakeintake/health")
 	if err != nil {
 		return err
 	}
@@ -503,7 +548,7 @@ func (c *Client) ConfigureOverride(override api.ResponseOverride) error {
 		return err
 	}
 
-	resp, err := http.Post(route, "application/json", buf)
+	resp, err := c.httpClient.Post(route, "application/json", buf)
 	if err != nil {
 		return err
 	}
@@ -517,7 +562,7 @@ func (c *Client) ConfigureOverride(override api.ResponseOverride) error {
 
 // GetLastAPIKey returns the last apiKey sent with a payload to the intake
 func (c *Client) GetLastAPIKey() (string, error) {
-	resp, err := http.Get(c.fakeIntakeURL + "/debug/lastAPIKey")
+	resp, err := c.httpClient.Get(c.fakeIntakeURL + "/debug/lastAPIKey")
 	if err != nil {
 		return "", err
 	}
@@ -746,7 +791,7 @@ func (c *Client) FlushServerAndResetAggregators() error {
 }
 
 func (c *Client) flushPayloads() error {
-	resp, err := http.Get(c.fakeIntakeURL + "/fakeintake/flushPayloads")
+	resp, err := c.httpClient.Get(c.fakeIntakeURL + "/fakeintake/flushPayloads")
 	if err != nil {
 		return err
 	}
@@ -1019,7 +1064,7 @@ func (c *Client) GetOrchestratorManifests() ([]*aggregator.OrchestratorManifestP
 
 func (c *Client) get(route string) ([]byte, error) {
 	body, err := backoff.Retry(context.Background(), func() ([]byte, error) {
-		tmpResp, err := http.Get(fmt.Sprintf("%s/%s", c.fakeIntakeURL, route))
+		tmpResp, err := c.httpClient.Get(fmt.Sprintf("%s/%s", c.fakeIntakeURL, route))
 		if err != nil {
 			return nil, err
 		}
@@ -1053,8 +1098,12 @@ func (c *Client) get(route string) ([]byte, error) {
 
 		return io.ReadAll(tmpResp.Body)
 	}, backoff.WithBackOff(backoff.NewConstantBackOff(c.getBackoffDelay)), backoff.WithMaxTries(c.getBackoffRetries))
-	if err, ok := err.(net.Error); ok && err.Timeout() {
-		panic(fmt.Sprintf("fakeintake call timed out: %v", err))
+	if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+		// Surface timeouts as a normal (retryable) error instead of panicking:
+		// callers run get() inside polling loops (e.g. EventuallyWithTf), where a
+		// panic fails the whole test on a single transient network blip instead
+		// of letting the next poll iteration retry.
+		return nil, fmt.Errorf("fakeintake call timed out: %w", err)
 	}
 	return body, err
 }

--- a/test/fakeintake/client/client_timeout_test.go
+++ b/test/fakeintake/client/client_timeout_test.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package client
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubTimeoutError is a net.Error that reports a timeout, used to exercise the
+// timeout-handling branch of get() deterministically without real network I/O.
+type stubTimeoutError struct{}
+
+func (stubTimeoutError) Error() string   { return "simulated i/o timeout" }
+func (stubTimeoutError) Timeout() bool   { return true }
+func (stubTimeoutError) Temporary() bool { return true }
+
+// stubRoundTripper lets a test swap the client's transport for one that always
+// fails a given way.
+type stubRoundTripper struct {
+	err error
+}
+
+func (rt stubRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, rt.err
+}
+
+// TestGetReturnsTimeoutErrorWithoutPanicking locks the contract that a network
+// timeout surfaces as a regular (retryable) error rather than a panic. Callers
+// run get() inside polling loops (e.g. EventuallyWithTf); a panic there fails
+// the whole test on a single transient blip instead of letting the next poll
+// iteration retry.
+func TestGetReturnsTimeoutErrorWithoutPanicking(t *testing.T) {
+	client := NewClient("http://fakeintake.invalid",
+		WithGetBackoffRetries(1),
+		WithGetBackoffDelay(time.Millisecond),
+	)
+	client.httpClient = &http.Client{
+		Transport: stubRoundTripper{err: &net.OpError{Op: "dial", Net: "tcp", Err: stubTimeoutError{}}},
+	}
+
+	var (
+		body []byte
+		err  error
+	)
+	require.NotPanics(t, func() {
+		body, err = client.get("fakeintake/routestats")
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "fakeintake call timed out")
+	require.Nil(t, body)
+}
+
+// TestGetReturnsNonTimeoutNetworkErrorWithoutPanicking ensures non-timeout
+// network failures are also returned as errors (not panics), matching the
+// timeout path.
+func TestGetReturnsNonTimeoutNetworkErrorWithoutPanicking(t *testing.T) {
+	client := NewClient("http://fakeintake.invalid",
+		WithGetBackoffRetries(1),
+		WithGetBackoffDelay(time.Millisecond),
+	)
+	client.httpClient = &http.Client{
+		Transport: stubRoundTripper{err: &net.OpError{Op: "dial", Net: "tcp", Err: &net.AddrError{Err: "connection refused"}}},
+	}
+
+	var err error
+	require.NotPanics(t, func() {
+		_, err = client.get("fakeintake/routestats")
+	})
+	require.Error(t, err)
+	// A non-timeout failure must not be mislabeled as a timeout: this guards the
+	// timeout/non-timeout discrimination in get().
+	require.NotContains(t, err.Error(), "fakeintake call timed out")
+}
+
+// TestNewClientHTTPDialTimeout verifies the HTTP dial timeout is wired: a sane
+// default is applied and WithHTTPDialTimeout overrides it.
+func TestNewClientHTTPDialTimeout(t *testing.T) {
+	def := NewClient("http://fakeintake.invalid")
+	require.NotNil(t, def.httpClient)
+	require.Equal(t, defaultHTTPDialTimeout, def.httpDialTimeout)
+
+	custom := NewClient("http://fakeintake.invalid", WithHTTPDialTimeout(2*time.Second))
+	require.NotNil(t, custom.httpClient)
+	require.Equal(t, 2*time.Second, custom.httpDialTimeout)
+}

--- a/test/fakeintake/client/par.go
+++ b/test/fakeintake/client/par.go
@@ -29,7 +29,7 @@ func (c *Client) EnqueuePARTask(taskID, actionFQN string, inputs map[string]inte
 	if err != nil {
 		return fmt.Errorf("marshal enqueue request: %w", err)
 	}
-	resp, err := http.Post(c.fakeIntakeURL+"/fakeintake/par/enqueue", "application/json", bytes.NewReader(body))
+	resp, err := c.httpClient.Post(c.fakeIntakeURL+"/fakeintake/par/enqueue", "application/json", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("enqueue PAR task: %w", err)
 	}
@@ -57,7 +57,7 @@ func (c *Client) GetPARTaskResult(taskID string, timeout time.Duration) (*api.PA
 
 // FlushPAR clears all queued PAR tasks and captured results from fakeintake.
 func (c *Client) FlushPAR() error {
-	resp, err := http.Post(c.fakeIntakeURL+"/fakeintake/par/flush", "", nil)
+	resp, err := c.httpClient.Post(c.fakeIntakeURL+"/fakeintake/par/flush", "", nil)
 	if err != nil {
 		return fmt.Errorf("flush PAR state: %w", err)
 	}
@@ -71,7 +71,7 @@ func (c *Client) FlushPAR() error {
 // GetPARDequeueCount returns how many times PAR has called the dequeue endpoint.
 // A non-zero value confirms PAR is actively polling fakeintake.
 func (c *Client) GetPARDequeueCount() (int, error) {
-	resp, err := http.Get(c.fakeIntakeURL + "/fakeintake/par/stats")
+	resp, err := c.httpClient.Get(c.fakeIntakeURL + "/fakeintake/par/stats")
 	if err != nil {
 		return 0, fmt.Errorf("get PAR stats: %w", err)
 	}
@@ -89,7 +89,7 @@ func (c *Client) GetPARDequeueCount() (int, error) {
 }
 
 func (c *Client) getPARResult(taskID string) (*api.PARTaskResult, error) {
-	resp, err := http.Get(fmt.Sprintf("%s/fakeintake/par/result?taskID=%s", c.fakeIntakeURL, taskID))
+	resp, err := c.httpClient.Get(fmt.Sprintf("%s/fakeintake/par/result?taskID=%s", c.fakeIntakeURL, taskID))
 	if err != nil {
 		return nil, err
 	}

--- a/test/fakeintake/client/rc.go
+++ b/test/fakeintake/client/rc.go
@@ -32,7 +32,7 @@ func (c *Client) RCAddConfig(orgID, product, configID, configName string, data [
 	if err != nil {
 		return err
 	}
-	resp, err := http.Post(c.fakeIntakeURL+"/fakeintake/rc/config", "application/json", bytes.NewReader(body))
+	resp, err := c.httpClient.Post(c.fakeIntakeURL+"/fakeintake/rc/config", "application/json", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (c *Client) RCAddConfig(orgID, product, configID, configName string, data [
 
 // RCListConfigs returns every Remote Config entry stored on fakeintake.
 func (c *Client) RCListConfigs() ([]api.RCConfig, error) {
-	resp, err := http.Get(c.fakeIntakeURL + "/fakeintake/rc/configs")
+	resp, err := c.httpClient.Get(c.fakeIntakeURL + "/fakeintake/rc/configs")
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (c *Client) RCDeleteConfig(key string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (c *Client) RCDeleteConfig(key string) error {
 // Use Polls / LastPoll to assert that the agent has actually reached out.
 func (c *Client) RCStats() (api.RCStats, error) {
 	var stats api.RCStats
-	resp, err := http.Get(c.fakeIntakeURL + "/fakeintake/rc/stats")
+	resp, err := c.httpClient.Get(c.fakeIntakeURL + "/fakeintake/rc/stats")
 	if err != nil {
 		return stats, err
 	}


### PR DESCRIPTION
### What does this PR do?

Hardens the fakeintake test client (`test/fakeintake/client/`) against transient network timeouts:

1. **`Client.get()` no longer panics on a network timeout.** It returns `fmt.Errorf("fakeintake call timed out: %w", err)` so the caller's polling loop can absorb a transient blip.
2. **Introduces a shared `*http.Client`** built in `NewClient` with a bounded dial timeout (`net.Dialer.Timeout`, default 10s, configurable via the new `WithHTTPDialTimeout` option) and a `ResponseHeaderTimeout` (30s). It intentionally sets **no overall `http.Client.Timeout`**, so large payload body reads are not truncated. Every fakeintake HTTP call in `client.go`, `rc.go` and `par.go` now goes through it (previously raw `http.Get`/`http.Post`/`http.DefaultClient`, which have no timeout).
3. **Adds unit tests** locking the no-panic-on-timeout contract and the dial-timeout wiring.

### Motivation

E2E container tests poll fakeintake via this client inside `EventuallyWithTf` loops. Two compounding issues turned a transient network blip into a hard test failure:

- `get()` used `http.Get` (default client, **no timeout**) and **panicked** on a `net.Error` timeout.
- The framework's `EventuallyWithTf` recovers that panic but reports it via `utils.Errorf(bs.T(), …)`, which marks the **outer suite test** as failed — so a single `dial tcp …: i/o timeout` permanently failed the test, defeating both the client's own backoff and the polling loop.

This is a recurring flaky-test cause for the container e2e suites (observed on `TestECSSuite` sub-tests: `TestWindowsFargate`, `TestDogtstatsdUDP/UDS`, `checkRun http.can_connect` — all `fakeintake call timed out: … dial tcp …: i/o timeout`). With this change, a transient timeout returns quickly (bounded dial) as a normal error and the next poll iteration retries instead of failing the test.

### Describe how you validated your changes

- `dda inv test --targets=./test/fakeintake/client/` — **44 tests pass** (including the 3 new ones).
- New tests use a stub `http.RoundTripper` to deterministically exercise the timeout branch (no real network): timeout → wrapped error (no panic), non-timeout net error → error (no panic, not mislabeled as timeout), and the dial-timeout default/override wiring.
- The only construction path is `NewClient` (so `httpClient` is never nil); the fakeintake-ID-mismatch panic is intentionally left intact.

### Additional Notes

P1 of the container e2e flaky-reduction effort (follow-up to the `TestCPU` range PR). `test/fakeintake/` is owned by `@DataDog/agent-devx` — flagging for their review, especially the removal of the timeout `panic` (a deliberate design choice worth confirming together).

A complementary, broader hardening is intentionally **out of scope** here and left for discussion with the framework owners: `EventuallyWithTf` (`test/e2e-framework/testing/e2e/suite.go`) marks the *outer* test failed on any recovered panic in a condition — even after this PR, a panic in a polled condition is fatal rather than retried.

Refs: CONTINT-4153
