### PR TITLE
gpu: add DogStatsD job metadata control events

### DIFF
--- a/comp/core/tagger/tagstore/tagstore.go
+++ b/comp/core/tagger/tagstore/tagstore.go
@@ -145,7 +145,7 @@ func (s *TagStore) ProcessTagInfo(tagInfos []*types.TagInfo) {
 			s.store.Set(info.EntityID, storedTags)
 		}
 
-		completenessChanged := storedTags.getIsComplete() != info.IsComplete
+		completenessChanged := !info.PreserveEntityCompleteness && storedTags.getIsComplete() != info.IsComplete
 
 		// Skip if nothing changed
 		if !tagsChanged && !completenessChanged {
@@ -159,9 +159,10 @@ func (s *TagStore) ProcessTagInfo(tagInfos []*types.TagInfo) {
 		if tagsChanged {
 			storedTags.setTagsForSource(info.Source, newSt)
 		}
-		storedTags.setIsComplete(info.IsComplete)
-
-		s.trackCompletenessDelay(info.EntityID, eventType, info.IsComplete)
+		if !info.PreserveEntityCompleteness {
+			storedTags.setIsComplete(info.IsComplete)
+			s.trackCompletenessDelay(info.EntityID, eventType, info.IsComplete)
+		}
 
 		events = append(events, types.EntityEvent{
 			EventType: eventType,

--- a/comp/core/tagger/tagstore/tagstore_test.go
+++ b/comp/core/tagger/tagstore/tagstore_test.go
@@ -536,6 +536,35 @@ func TestProcessTagInfo_IsComplete(t *testing.T) {
 	}
 }
 
+func TestProcessTagInfo_PreserveEntityCompleteness(t *testing.T) {
+	entityID := types.NewEntityID(types.ContainerID, "test")
+	telemetryComponent := fxutil.Test[telemetry.Component](t, mocktelemetry.Module())
+	telemetryStore := taggerTelemetry.NewStore(telemetryComponent)
+	tagStore := NewTagStore(telemetryStore)
+
+	tagStore.ProcessTagInfo([]*types.TagInfo{
+		{
+			Source:      "source",
+			EntityID:    entityID,
+			LowCardTags: []string{"low"},
+			IsComplete:  true,
+		},
+	})
+	tagStore.ProcessTagInfo([]*types.TagInfo{
+		{
+			Source:                     "preserving-source",
+			EntityID:                   entityID,
+			OrchestratorCardTags:       []string{"job:123"},
+			PreserveEntityCompleteness: true,
+		},
+	})
+
+	entity, err := tagStore.GetEntity(entityID)
+	require.NoError(t, err)
+	assert.True(t, entity.IsComplete)
+	assert.ElementsMatch(t, []string{"job:123"}, entity.OrchestratorCardinalityTags)
+}
+
 func TestProcessTagInfo_CompletenessDelay(t *testing.T) {
 	entityID := types.NewEntityID(types.ContainerID, "test")
 	prefix := string(types.ContainerID)

--- a/comp/core/tagger/types/types.go
+++ b/comp/core/tagger/types/types.go
@@ -31,15 +31,16 @@ type TaggerListEntity struct {
 // TagInfo holds the tag information for a given entity and source. It's meant
 // to be created from collectors and read by the store.
 type TagInfo struct {
-	Source               string    // source collector's name
-	EntityID             EntityID  // entity id for lookup
-	HighCardTags         []string  // high cardinality tags that can create a lot of different timeseries (typically one per container, user request, etc.)
-	OrchestratorCardTags []string  // orchestrator cardinality tags that have as many combination as pods/tasks
-	LowCardTags          []string  // low cardinality tags safe for every pipeline
-	StandardTags         []string  // the discovered standard tags (env, version, service) for the entity
-	DeleteEntity         bool      // true if the entity is to be deleted from the store
-	ExpiryDate           time.Time // keep in cache until expiryDate
-	IsComplete           bool      // whether all expected collectors have reported data for this entity in wmeta
+	Source                     string    // source collector's name
+	EntityID                   EntityID  // entity id for lookup
+	HighCardTags               []string  // high cardinality tags that can create a lot of different timeseries (typically one per container, user request, etc.)
+	OrchestratorCardTags       []string  // orchestrator cardinality tags that have as many combination as pods/tasks
+	LowCardTags                []string  // low cardinality tags safe for every pipeline
+	StandardTags               []string  // the discovered standard tags (env, version, service) for the entity
+	DeleteEntity               bool      // true if the entity is to be deleted from the store
+	ExpiryDate                 time.Time // keep in cache until expiryDate
+	IsComplete                 bool      // whether all expected collectors have reported data for this entity in wmeta
+	PreserveEntityCompleteness bool      // true if this update should not change the entity-level completeness state
 }
 
 // CollectorPriority helps resolving dupe tags from collectors

--- a/comp/dogstatsd/server/impl/filterlist_init_test.go
+++ b/comp/dogstatsd/server/impl/filterlist_init_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	taggerdef "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	mocktelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -77,7 +78,7 @@ func TestWorkerFilterListInitializedFromLocalConfig(t *testing.T) {
 	))
 
 	fl := filterlistimpl.NewFilterList(deps.Log, deps.Config, deps.Telemetry)
-	s := newServerCompat(deps.Config, deps.Log, deps.Hostname, deps.Replay, deps.Debug, false, deps.Demultiplexer, deps.WMeta, deps.PidMap, deps.Telemetry, fl)
+	s := newServerCompat(deps.Config, deps.Log, deps.Hostname, deps.Replay, deps.Debug, false, deps.Demultiplexer, deps.WMeta, deps.PidMap, deps.Telemetry, fl, option.None[taggerdef.Processor]())
 
 	err := s.start(context.TODO())
 	require.NoError(t, err)

--- a/comp/dogstatsd/server/impl/gpu_job_metadata.go
+++ b/comp/dogstatsd/server/impl/gpu_job_metadata.go
@@ -1,0 +1,214 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package serverimpl
+
+import (
+	"strings"
+	"time"
+
+	taggerdef "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	coretaggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/pkg/gpu/jobmetadata"
+	metricsevent "github.com/DataDog/datadog-agent/pkg/metrics/event"
+	pkgtaggertypes "github.com/DataDog/datadog-agent/pkg/tagger/types"
+)
+
+const (
+	gpuJobMetadataEnabledConfig        = "gpu.job_metadata.enabled"
+	gpuJobMetadataTTLConfig            = "gpu.job_metadata.ttl"
+	gpuJobMetadataTaggerSource         = "dogstatsd-gpu-job-metadata"
+	gpuJobMetadataProcessSweepInterval = 15 * time.Second
+	containerIDOriginPrefix            = "container_id://"
+)
+
+type gpuJobMetadataProcessRecord struct {
+	ContainerID string
+	ProcessID   uint32
+	Sequence    uint64
+}
+
+func (s *dsdServer) handleGPUJobMetadataEvent(event *metricsevent.Event) bool {
+	if event == nil || !jobmetadata.IsControlEvent(event.Title, event.SourceTypeName) {
+		return false
+	}
+
+	if !s.config.GetBool(gpuJobMetadataEnabledConfig) {
+		return false
+	}
+
+	containerID := containerIDFromOriginInfo(event.OriginInfo)
+	record, consumed, err := jobmetadata.RecordFromEvent(containerID, event.Title, event.SourceTypeName, event.Text, event.Tags, s.config.GetDuration(gpuJobMetadataTTLConfig))
+	if !consumed {
+		return false
+	}
+	if err != nil {
+		s.log.Warnf("DogStatsD GPU job metadata event ignored: %v", err)
+		return true
+	}
+
+	processor, ok := s.taggerProcessor.Get()
+	if !ok {
+		s.log.Warn("DogStatsD GPU job metadata event ignored: tagger processor is unavailable")
+		return true
+	}
+
+	if record.Action == jobmetadata.ActionEnd {
+		s.forgetGPUJobMetadataProcess(record.ContainerID)
+		s.clearGPUJobMetadataTags(processor, record.ContainerID)
+		return true
+	}
+
+	entityID := coretaggertypes.NewEntityID(coretaggertypes.ContainerID, record.ContainerID)
+	processor.ProcessTagInfo([]*coretaggertypes.TagInfo{
+		{
+			Source:                     gpuJobMetadataTaggerSource,
+			EntityID:                   entityID,
+			OrchestratorCardTags:       record.Tags,
+			ExpiryDate:                 record.ExpiresAt,
+			PreserveEntityCompleteness: true,
+		},
+	})
+	// UDS origin detection provides the sender PID. Track it so a missing
+	// explicit end event can still be cleaned up when the training process exits.
+	s.trackGPUJobMetadataProcess(record.ContainerID, event.OriginInfo.LocalData.ProcessID)
+
+	s.log.Infof(
+		"DogStatsD GPU job metadata published: entity_id=%q job_id=%q tags=%v expires_at=%s",
+		entityID.String(),
+		record.JobID,
+		record.Tags,
+		formatGPUJobMetadataExpiry(record.ExpiresAt),
+	)
+	return true
+}
+
+func (s *dsdServer) startGPUJobMetadataProcessSweeper() {
+	if !s.config.GetBool(gpuJobMetadataEnabledConfig) {
+		return
+	}
+
+	ticker := time.NewTicker(gpuJobMetadataProcessSweepInterval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				s.sweepGPUJobMetadataProcesses()
+			case <-s.stopChan:
+				return
+			}
+		}
+	}()
+}
+
+func (s *dsdServer) trackGPUJobMetadataProcess(containerID string, processID uint32) {
+	s.gpuJobMetadataProcessesLock.Lock()
+	defer s.gpuJobMetadataProcessesLock.Unlock()
+
+	if processID == 0 {
+		delete(s.gpuJobMetadataProcesses, containerID)
+		return
+	}
+	if s.gpuJobMetadataProcesses == nil {
+		s.gpuJobMetadataProcesses = make(map[string]gpuJobMetadataProcessRecord)
+	}
+
+	s.gpuJobMetadataProcessSequence++
+	s.gpuJobMetadataProcesses[containerID] = gpuJobMetadataProcessRecord{
+		ContainerID: containerID,
+		ProcessID:   processID,
+		Sequence:    s.gpuJobMetadataProcessSequence,
+	}
+}
+
+func (s *dsdServer) forgetGPUJobMetadataProcess(containerID string) {
+	s.gpuJobMetadataProcessesLock.Lock()
+	defer s.gpuJobMetadataProcessesLock.Unlock()
+	delete(s.gpuJobMetadataProcesses, containerID)
+}
+
+func (s *dsdServer) gpuJobMetadataProcessRecords() []gpuJobMetadataProcessRecord {
+	s.gpuJobMetadataProcessesLock.Lock()
+	defer s.gpuJobMetadataProcessesLock.Unlock()
+
+	records := make([]gpuJobMetadataProcessRecord, 0, len(s.gpuJobMetadataProcesses))
+	for _, record := range s.gpuJobMetadataProcesses {
+		records = append(records, record)
+	}
+	return records
+}
+
+func (s *dsdServer) removeGPUJobMetadataProcessIfCurrent(record gpuJobMetadataProcessRecord) bool {
+	s.gpuJobMetadataProcessesLock.Lock()
+	defer s.gpuJobMetadataProcessesLock.Unlock()
+
+	current, ok := s.gpuJobMetadataProcesses[record.ContainerID]
+	if !ok || current.ProcessID != record.ProcessID || current.Sequence != record.Sequence {
+		return false
+	}
+	delete(s.gpuJobMetadataProcesses, record.ContainerID)
+	return true
+}
+
+func (s *dsdServer) sweepGPUJobMetadataProcesses() {
+	processor, ok := s.taggerProcessor.Get()
+	if !ok {
+		return
+	}
+
+	processExists := s.gpuJobMetadataProcessExists
+	if processExists == nil {
+		processExists = defaultGPUJobMetadataProcessExists
+	}
+
+	for _, record := range s.gpuJobMetadataProcessRecords() {
+		if record.ProcessID == 0 || processExists(record.ProcessID) {
+			continue
+		}
+		if !s.removeGPUJobMetadataProcessIfCurrent(record) {
+			continue
+		}
+		s.clearGPUJobMetadataTags(processor, record.ContainerID)
+		s.log.Infof("DogStatsD GPU job metadata auto-cleared: entity_id=%q pid=%d", coretaggertypes.NewEntityID(coretaggertypes.ContainerID, record.ContainerID).String(), record.ProcessID)
+	}
+}
+
+func (s *dsdServer) clearGPUJobMetadataTags(processor taggerdef.Processor, containerID string) {
+	entityID := coretaggertypes.NewEntityID(coretaggertypes.ContainerID, containerID)
+	processor.ProcessTagInfo([]*coretaggertypes.TagInfo{
+		{
+			Source:                     gpuJobMetadataTaggerSource,
+			EntityID:                   entityID,
+			PreserveEntityCompleteness: true,
+		},
+	})
+	s.log.Infof("DogStatsD GPU job metadata cleared: entity_id=%q", entityID.String())
+}
+
+func formatGPUJobMetadataExpiry(expiresAt time.Time) string {
+	if expiresAt.IsZero() {
+		return "none"
+	}
+	return expiresAt.Format(time.RFC3339)
+}
+
+func containerIDFromOriginInfo(originInfo pkgtaggertypes.OriginInfo) string {
+	return containerIDFromSocketOrigin(originInfo.ContainerIDFromSocket)
+}
+
+func containerIDFromSocketOrigin(origin string) string {
+	origin = strings.TrimSpace(origin)
+	if origin == "" {
+		return ""
+	}
+	if strings.HasPrefix(origin, containerIDOriginPrefix) {
+		return strings.TrimPrefix(origin, containerIDOriginPrefix)
+	}
+	if strings.Contains(origin, "://") {
+		return ""
+	}
+	return origin
+}

--- a/comp/dogstatsd/server/impl/gpu_job_metadata_process_linux.go
+++ b/comp/dogstatsd/server/impl/gpu_job_metadata_process_linux.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux
+
+package serverimpl
+
+import "github.com/DataDog/datadog-agent/pkg/util/kernel"
+
+func defaultGPUJobMetadataProcessExists(processID uint32) bool {
+	return kernel.ProcessExists(int(processID))
+}

--- a/comp/dogstatsd/server/impl/gpu_job_metadata_process_other.go
+++ b/comp/dogstatsd/server/impl/gpu_job_metadata_process_other.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build !linux
+
+package serverimpl
+
+func defaultGPUJobMetadataProcessExists(_ uint32) bool {
+	// PID cleanup is only meaningful for the Linux UDS SO_PASSCRED path. Keep
+	// records alive elsewhere and rely on explicit end events or TTL fallback.
+	return true
+}

--- a/comp/dogstatsd/server/impl/gpu_job_metadata_test.go
+++ b/comp/dogstatsd/server/impl/gpu_job_metadata_test.go
@@ -1,0 +1,201 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build test
+
+package serverimpl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	taggerdef "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
+	coretaggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/listeners"
+	pkgtaggertypes "github.com/DataDog/datadog-agent/pkg/tagger/types"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+type fakeTaggerProcessor struct {
+	tagInfos []*coretaggertypes.TagInfo
+}
+
+func (p *fakeTaggerProcessor) ProcessTagInfo(tagInfos []*coretaggertypes.TagInfo) {
+	p.tagInfos = append(p.tagInfos, tagInfos...)
+}
+
+func TestGPUJobMetadataEventPublishesOrchestratorTagsFromSocketOrigin(t *testing.T) {
+	deps := fulfillDepsWithConfigOverride(t, map[string]interface{}{
+		"dogstatsd_port":                    listeners.RandomPortName,
+		"dogstatsd_origin_detection_client": true,
+		"gpu.job_metadata.enabled":          true,
+	})
+	s := deps.Server.(*dsdServer)
+	processor := &fakeTaggerProcessor{}
+	s.taggerProcessor = option.New[taggerdef.Processor](processor)
+	requireStart(t, s)
+
+	parser := newParser(deps.Config, s.sharedFloat64List, 1, deps.WMeta, s.stringInternerTelemetry)
+	event, err := s.parseEventMessage(parser, []byte("_e{15,5}:datadog.gpu.job|start|s:datadog_gpu_job|#gpu_job_id:job-123,team:ml"), "container_id://training-container", 0)
+	require.NoError(t, err)
+
+	require.True(t, s.handleGPUJobMetadataEvent(event))
+
+	require.Len(t, processor.tagInfos, 1)
+	info := processor.tagInfos[0]
+	require.Equal(t, gpuJobMetadataTaggerSource, info.Source)
+	require.Equal(t, coretaggertypes.NewEntityID(coretaggertypes.ContainerID, "training-container"), info.EntityID)
+	require.Equal(t, []string{"gpu_job_id:job-123", "team:ml"}, info.OrchestratorCardTags)
+	require.Empty(t, info.LowCardTags)
+	require.Empty(t, info.HighCardTags)
+	require.True(t, info.PreserveEntityCompleteness)
+}
+
+func TestGPUJobMetadataEventOptionalTTL(t *testing.T) {
+	deps := fulfillDepsWithConfigOverride(t, map[string]interface{}{
+		"dogstatsd_port":                    listeners.RandomPortName,
+		"dogstatsd_origin_detection_client": true,
+		"gpu.job_metadata.enabled":          true,
+		"gpu.job_metadata.ttl":              time.Minute,
+	})
+	s := deps.Server.(*dsdServer)
+	processor := &fakeTaggerProcessor{}
+	s.taggerProcessor = option.New[taggerdef.Processor](processor)
+	requireStart(t, s)
+
+	parser := newParser(deps.Config, s.sharedFloat64List, 1, deps.WMeta, s.stringInternerTelemetry)
+	event, err := s.parseEventMessage(parser, []byte("_e{15,9}:datadog.gpu.job|heartbeat|s:datadog_gpu_job|#gpu_job_id:job-123"), "container_id://training-container", 0)
+	require.NoError(t, err)
+
+	start := time.Now()
+	require.True(t, s.handleGPUJobMetadataEvent(event))
+
+	require.Len(t, processor.tagInfos, 1)
+	require.WithinDuration(t, start.Add(time.Minute), processor.tagInfos[0].ExpiryDate, time.Second)
+}
+
+func TestGPUJobMetadataAutoClearsTagsWhenSenderPIDExits(t *testing.T) {
+	deps := fulfillDepsWithConfigOverride(t, map[string]interface{}{
+		"dogstatsd_port":                    listeners.RandomPortName,
+		"dogstatsd_origin_detection_client": true,
+		"gpu.job_metadata.enabled":          true,
+	})
+	s := deps.Server.(*dsdServer)
+	processor := &fakeTaggerProcessor{}
+	s.taggerProcessor = option.New[taggerdef.Processor](processor)
+	s.gpuJobMetadataProcessExists = func(processID uint32) bool {
+		require.Equal(t, uint32(1234), processID)
+		return false
+	}
+	requireStart(t, s)
+
+	parser := newParser(deps.Config, s.sharedFloat64List, 1, deps.WMeta, s.stringInternerTelemetry)
+	event, err := s.parseEventMessage(parser, []byte("_e{15,5}:datadog.gpu.job|start|s:datadog_gpu_job|#gpu_job_id:job-123"), "container_id://training-container", 1234)
+	require.NoError(t, err)
+
+	require.True(t, s.handleGPUJobMetadataEvent(event))
+	s.sweepGPUJobMetadataProcesses()
+
+	require.Len(t, processor.tagInfos, 2)
+	require.Equal(t, []string{"gpu_job_id:job-123"}, processor.tagInfos[0].OrchestratorCardTags)
+	clearInfo := processor.tagInfos[1]
+	require.Equal(t, gpuJobMetadataTaggerSource, clearInfo.Source)
+	require.Equal(t, coretaggertypes.NewEntityID(coretaggertypes.ContainerID, "training-container"), clearInfo.EntityID)
+	require.Empty(t, clearInfo.OrchestratorCardTags)
+	require.True(t, clearInfo.PreserveEntityCompleteness)
+}
+
+func TestGPUJobMetadataEndEventClearsTags(t *testing.T) {
+	deps := fulfillDepsWithConfigOverride(t, map[string]interface{}{
+		"dogstatsd_port":                    listeners.RandomPortName,
+		"dogstatsd_origin_detection_client": true,
+		"gpu.job_metadata.enabled":          true,
+	})
+	s := deps.Server.(*dsdServer)
+	processor := &fakeTaggerProcessor{}
+	s.taggerProcessor = option.New[taggerdef.Processor](processor)
+	requireStart(t, s)
+
+	parser := newParser(deps.Config, s.sharedFloat64List, 1, deps.WMeta, s.stringInternerTelemetry)
+	event, err := s.parseEventMessage(parser, []byte("_e{15,3}:datadog.gpu.job|end|s:datadog_gpu_job"), "container_id://training-container", 0)
+	require.NoError(t, err)
+
+	require.True(t, s.handleGPUJobMetadataEvent(event))
+
+	require.Len(t, processor.tagInfos, 1)
+	info := processor.tagInfos[0]
+	require.Equal(t, gpuJobMetadataTaggerSource, info.Source)
+	require.Equal(t, coretaggertypes.NewEntityID(coretaggertypes.ContainerID, "training-container"), info.EntityID)
+	require.Empty(t, info.OrchestratorCardTags)
+	require.Empty(t, info.LowCardTags)
+	require.Empty(t, info.HighCardTags)
+	require.True(t, info.PreserveEntityCompleteness)
+}
+
+func TestGPUJobMetadataEventUsesSocketOriginFirst(t *testing.T) {
+	originInfo := pkgtaggertypes.OriginInfo{
+		ContainerIDFromSocket: "container_id://socket-container",
+		LocalData:             origindetection.LocalData{ContainerID: "local-container"},
+	}
+
+	require.Equal(t, "socket-container", containerIDFromOriginInfo(originInfo))
+}
+
+func TestGPUJobMetadataEventIgnoresClientOriginContainerID(t *testing.T) {
+	deps := fulfillDepsWithConfigOverride(t, map[string]interface{}{
+		"dogstatsd_port":                    listeners.RandomPortName,
+		"dogstatsd_origin_detection_client": true,
+		"gpu.job_metadata.enabled":          true,
+	})
+	s := deps.Server.(*dsdServer)
+	processor := &fakeTaggerProcessor{}
+	s.taggerProcessor = option.New[taggerdef.Processor](processor)
+	requireStart(t, s)
+
+	parser := newParser(deps.Config, s.sharedFloat64List, 1, deps.WMeta, s.stringInternerTelemetry)
+	event, err := s.parseEventMessage(parser, []byte("_e{15,5}:datadog.gpu.job|start|s:datadog_gpu_job|c:ci-training-container|#gpu_job_id:job-123"), "", 0)
+	require.NoError(t, err)
+
+	require.True(t, s.handleGPUJobMetadataEvent(event))
+	require.Empty(t, processor.tagInfos)
+}
+
+func TestGPUJobMetadataEventNotConsumedWhenDisabled(t *testing.T) {
+	deps := fulfillDepsWithConfigOverride(t, map[string]interface{}{
+		"dogstatsd_port":                    listeners.RandomPortName,
+		"dogstatsd_origin_detection_client": true,
+		"gpu.job_metadata.enabled":          false,
+	})
+	s := deps.Server.(*dsdServer)
+	processor := &fakeTaggerProcessor{}
+	s.taggerProcessor = option.New[taggerdef.Processor](processor)
+	requireStart(t, s)
+
+	parser := newParser(deps.Config, s.sharedFloat64List, 1, deps.WMeta, s.stringInternerTelemetry)
+	event, err := s.parseEventMessage(parser, []byte("_e{15,5}:datadog.gpu.job|start|s:datadog_gpu_job|#gpu_job_id:job-123"), "container_id://training-container", 0)
+	require.NoError(t, err)
+
+	require.False(t, s.handleGPUJobMetadataEvent(event))
+	require.Empty(t, processor.tagInfos)
+}
+
+func TestGPUJobMetadataEventConsumedWhenTaggerProcessorUnavailable(t *testing.T) {
+	deps := fulfillDepsWithConfigOverride(t, map[string]interface{}{
+		"dogstatsd_port":                    listeners.RandomPortName,
+		"dogstatsd_origin_detection_client": true,
+		"gpu.job_metadata.enabled":          true,
+	})
+	s := deps.Server.(*dsdServer)
+	requireStart(t, s)
+
+	parser := newParser(deps.Config, s.sharedFloat64List, 1, deps.WMeta, s.stringInternerTelemetry)
+	event, err := s.parseEventMessage(parser, []byte("_e{15,5}:datadog.gpu.job|start|s:datadog_gpu_job|#gpu_job_id:job-123"), "container_id://training-container", 0)
+	require.NoError(t, err)
+
+	require.True(t, s.handleGPUJobMetadataEvent(event))
+}

--- a/comp/dogstatsd/server/impl/server.go
+++ b/comp/dogstatsd/server/impl/server.go
@@ -21,6 +21,7 @@ import (
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	taggerdef "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
@@ -84,6 +85,7 @@ type dependencies struct {
 	PidMap          pidmap.Component
 	Params          server.Params
 	WMeta           option.Option[workloadmeta.Component]
+	TaggerProcessor option.Option[taggerdef.Processor] `optional:"true"`
 	Telemetry       telemetry.Component
 	Hostname        hostnameinterface.Component
 	FilterList      filterlist.Component
@@ -171,7 +173,13 @@ type dsdServer struct {
 	enrichConfig
 
 	wmeta           option.Option[workloadmeta.Component]
+	taggerProcessor option.Option[taggerdef.Processor]
 	offlineReporter offlinereporter.Component
+
+	gpuJobMetadataProcessesLock   sync.Mutex
+	gpuJobMetadataProcesses       map[string]gpuJobMetadataProcessRecord
+	gpuJobMetadataProcessSequence uint64
+	gpuJobMetadataProcessExists   func(uint32) bool
 
 	// telemetry
 	telemetry               telemetry.Component
@@ -205,7 +213,7 @@ func initTelemetry() {
 // TODO: (components) - merge with newServerCompat once NewServerlessServer is removed
 // NewComponent creates a new dogstatsd server component.
 func NewComponent(deps dependencies) Provides {
-	s := newServerCompat(deps.Config, deps.Log, deps.Hostname, deps.Replay, deps.Debug, deps.Params.Serverless, deps.Demultiplexer, deps.WMeta, deps.PidMap, deps.Telemetry, deps.FilterList)
+	s := newServerCompat(deps.Config, deps.Log, deps.Hostname, deps.Replay, deps.Debug, deps.Params.Serverless, deps.Demultiplexer, deps.WMeta, deps.PidMap, deps.Telemetry, deps.FilterList, deps.TaggerProcessor)
 	s.offlineReporter = deps.OfflineReporter
 
 	dsdConfig := dsdconfig.NewConfig(s.config)
@@ -222,7 +230,7 @@ func NewComponent(deps dependencies) Provides {
 	}
 }
 
-func newServerCompat(cfg model.ReaderWriter, log log.Component, hostname hostnameinterface.Component, capture replay.Component, debug serverdebug.Component, serverless bool, demux aggregator.Demultiplexer, wmeta option.Option[workloadmeta.Component], pidMap pidmap.Component, telemetrycomp telemetry.Component, filterList filterlist.Component) *dsdServer {
+func newServerCompat(cfg model.ReaderWriter, log log.Component, hostname hostnameinterface.Component, capture replay.Component, debug serverdebug.Component, serverless bool, demux aggregator.Demultiplexer, wmeta option.Option[workloadmeta.Component], pidMap pidmap.Component, telemetrycomp telemetry.Component, filterList filterlist.Component, taggerProcessor option.Option[taggerdef.Processor]) *dsdServer {
 	// This needs to be done after the configuration is loaded
 	once.Do(func() { initTelemetry() })
 	var stats *statutil.Stats
@@ -319,13 +327,16 @@ func newServerCompat(cfg model.ReaderWriter, log log.Component, hostname hostnam
 			defaultHostname:           defaultHostname,
 			serverlessMode:            serverless,
 		},
-		wmeta:                   wmeta,
-		telemetry:               telemetrycomp,
-		filterList:              filterList,
-		tlmProcessed:            dogstatsdTelemetryCount,
-		tlmProcessedOk:          dogstatsdTelemetryCount.WithValues("metrics", "ok", ""),
-		tlmProcessedError:       dogstatsdTelemetryCount.WithValues("metrics", "error", ""),
-		stringInternerTelemetry: newSiTelemetry(utils.IsTelemetryEnabled(cfg), telemetrycomp),
+		wmeta:                       wmeta,
+		taggerProcessor:             taggerProcessor,
+		gpuJobMetadataProcesses:     make(map[string]gpuJobMetadataProcessRecord),
+		gpuJobMetadataProcessExists: defaultGPUJobMetadataProcessExists,
+		telemetry:                   telemetrycomp,
+		filterList:                  filterList,
+		tlmProcessed:                dogstatsdTelemetryCount,
+		tlmProcessedOk:              dogstatsdTelemetryCount.WithValues("metrics", "ok", ""),
+		tlmProcessedError:           dogstatsdTelemetryCount.WithValues("metrics", "error", ""),
+		stringInternerTelemetry:     newSiTelemetry(utils.IsTelemetryEnabled(cfg), telemetrycomp),
 	}
 
 	buckets := getBuckets(cfg, log, "telemetry.dogstatsd.aggregator_channel_latency_buckets")
@@ -584,6 +595,7 @@ func (s *dsdServer) handleMessages() {
 	// It is important to set this up after the workers are running so they receive
 	// any updates.
 	s.filterList.OnUpdateMetricFilterList(s.onFilterListUpdate)
+	s.startGPUJobMetadataProcessSweeper()
 }
 
 func (s *dsdServer) UDPLocalAddr() string {
@@ -714,6 +726,9 @@ func (s *dsdServer) parsePackets(batcher dogstatsdBatcher, parser *parser, packe
 				event, err := s.parseEventMessage(parser, message, packet.Origin, packet.ProcessID)
 				if err != nil {
 					s.errLog("Dogstatsd: error parsing event '%q': %s", message, err)
+					continue
+				}
+				if s.handleGPUJobMetadataEvent(event) {
 					continue
 				}
 				batcher.appendEvent(event)

--- a/comp/dogstatsd/server/impl/server_util_test.go
+++ b/comp/dogstatsd/server/impl/server_util_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	taggerdef "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	mocktelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -143,7 +144,7 @@ func fulfillDepsWithInactiveServer(t *testing.T, cfg map[string]interface{}) (de
 		fx.Provide(func() offlinereporter.Component { return offlinereportermock.Mock(t) }),
 	))
 
-	s := newServerCompat(deps.Config, deps.Log, deps.Hostname, deps.Replay, deps.Debug, false, deps.Demultiplexer, deps.WMeta, deps.PidMap, deps.Telemetry, deps.FilterList)
+	s := newServerCompat(deps.Config, deps.Log, deps.Hostname, deps.Replay, deps.Debug, false, deps.Demultiplexer, deps.WMeta, deps.PidMap, deps.Telemetry, deps.FilterList, option.None[taggerdef.Processor]())
 
 	return deps, s
 }

--- a/comp/dogstatsd/server/impl/serverless.go
+++ b/comp/dogstatsd/server/impl/serverless.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	logComponentImpl "github.com/DataDog/datadog-agent/comp/core/log/impl"
+	taggerdef "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pidmapimpl "github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap/impl"
@@ -34,7 +35,7 @@ type ServerlessDogstatsd interface {
 //nolint:revive // TODO(AML) Fix revive linter
 func NewServerlessServer(demux aggregator.Demultiplexer, extraTags []string) (ServerlessDogstatsd, error) {
 	wmeta := option.None[workloadmeta.Component]()
-	s := newServerCompat(pkgconfigsetup.Datadog(), logComponentImpl.NewTemporaryLoggerWithoutInit(), hostnameimpl.NewHostnameService(), replay.NewNoopTrafficCapture(), serverdebugimpl.NewServerlessServerDebug(pkgconfigsetup.Datadog()), true, demux, wmeta, pidmapimpl.NewServerlessPidMap(), telemetry.GetCompatComponent(), filterlistimpl.NewNoopFilterList())
+	s := newServerCompat(pkgconfigsetup.Datadog(), logComponentImpl.NewTemporaryLoggerWithoutInit(), hostnameimpl.NewHostnameService(), replay.NewNoopTrafficCapture(), serverdebugimpl.NewServerlessServerDebug(pkgconfigsetup.Datadog()), true, demux, wmeta, pidmapimpl.NewServerlessPidMap(), telemetry.GetCompatComponent(), filterlistimpl.NewNoopFilterList(), option.None[taggerdef.Processor]())
 
 	s.extraTags = append(s.extraTags, extraTags...)
 	err := s.start(context.TODO())

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -608,6 +608,30 @@ api_key:
 #
 #   enabled: false
 
+#   # @param job_metadata - custom object - optional
+#   # GPU job metadata enrichment. When enabled, the Agent consumes
+#   # reserved DogStatsD events with source_type `datadog_gpu_job` and title
+#   # `datadog.gpu.job`, then publishes the supplied job tags to the tagger for
+#   # the socket-detected container at orchestrator cardinality. Tags remain
+#   # until an `end` control event is received, the sender PID exits, or ttl
+#   # expires.
+#
+#   job_metadata:
+#
+#     # @param enabled - boolean - optional - default: false
+#     # @env DD_GPU_JOB_METADATA_ENABLED - boolean - optional - default: false
+#     # Enable DogStatsD GPU job metadata control events.
+#
+#     enabled: false
+#
+#     # @param ttl - duration - optional - default: 15m
+#     # @env DD_GPU_JOB_METADATA_TTL - duration - optional - default: 15m
+#     # Fallback expiry for published container job tags. When 0s, tags do not
+#     # expire by time and are cleared by an `end` control event or sender PID
+#     # exit.
+#
+#     ttl: 15m
+
 #   # @param nccl - custom object - optional
 #   # NCCL collective communication metrics. When enabled, the Agent listens on a
 #   # Unix domain socket for events emitted by the NCCL profiler plugin in

--- a/pkg/config/schema/yaml/gpu.yaml
+++ b/pkg/config/schema/yaml/gpu.yaml
@@ -21,6 +21,38 @@ properties:
       Must be used together with gpu_monitoring.enabled: true in system-probe.yaml.
     tags:
     - template_section:Common
+  job_metadata:
+    node_type: section
+    type: object
+    visibility: public
+    description: |-
+      GPU job metadata enrichment. When enabled, the Agent consumes
+      reserved DogStatsD events with source_type `datadog_gpu_job` and title
+      `datadog.gpu.job`, then publishes the supplied job tags to the tagger for
+      the socket-detected container at orchestrator cardinality. Tags remain
+      until an `end` control event is received, the sender PID exits, or ttl
+      expires.
+    tags:
+    - template_section:Common
+    properties:
+      enabled:
+        node_type: setting
+        type: boolean
+        default: false
+        visibility: public
+        description: Enable DogStatsD GPU job metadata control events.
+        tags:
+        - template_section:Common
+      ttl:
+        node_type: setting
+        type: number
+        default: 15m
+        format: duration
+        visibility: public
+        description: Fallback expiry for published container job tags. When 0s, tags do not expire by time and are cleared by an `end` control event or sender PID exit.
+        tags:
+        - template_section:Common
+        - golang_type:duration
   nccl:
     node_type: section
     type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -477,6 +477,8 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("gpu.workload_tag_cache_size", 1024)
 	config.BindEnvAndSetDefault("gpu.disabled_collectors", []string{})
 	config.BindEnvAndSetDefault("gpu.nvlink.fec_light_error_threshold", 3)
+	config.BindEnvAndSetDefault("gpu.job_metadata.enabled", false)
+	config.BindEnvAndSetDefault("gpu.job_metadata.ttl", 15*time.Minute)
 
 	// NCCL
 	config.BindEnvAndSetDefault("gpu.nccl.enabled", false)

--- a/pkg/gpu/jobmetadata/event.go
+++ b/pkg/gpu/jobmetadata/event.go
@@ -1,0 +1,182 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package jobmetadata validates DogStatsD GPU job metadata control events.
+package jobmetadata
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	// ControlEventTitle is the reserved DogStatsD event title.
+	ControlEventTitle = "datadog.gpu.job"
+	// ControlEventSourceType is the reserved DogStatsD event source type.
+	ControlEventSourceType = "datadog_gpu_job"
+	// JobIDTagPrefix is the tag prefix carrying the current job ID.
+	JobIDTagPrefix = "gpu_job_id:"
+
+	// DefaultTTL is the fallback expiry used when job metadata updates are not refreshed.
+	DefaultTTL = 15 * time.Minute
+
+	maxTags      = 16
+	maxTagLength = 200
+)
+
+// Action is the lifecycle action carried by a GPU job metadata control event.
+type Action string
+
+const (
+	// ActionUpdate publishes or refreshes job metadata tags for a container.
+	ActionUpdate Action = "update"
+	// ActionEnd clears job metadata tags for a container.
+	ActionEnd Action = "end"
+)
+
+var (
+	// ErrNoContainerID is returned when a control event cannot be mapped to a container.
+	ErrNoContainerID = errors.New("missing container id")
+	// ErrNoJobID is returned when an update control event does not include gpu_job_id.
+	ErrNoJobID = errors.New("missing gpu_job_id tag")
+	// ErrUnsupportedAction is returned when a control event has an unknown lifecycle action.
+	ErrUnsupportedAction = errors.New("unsupported gpu job metadata action")
+)
+
+// Record is job metadata parsed from a control event for one container.
+type Record struct {
+	ContainerID string
+	Action      Action
+	JobID       string
+	Tags        []string
+	UpdatedAt   time.Time
+	ExpiresAt   time.Time
+}
+
+// IsControlEvent returns true when the event is the reserved GPU job metadata event.
+func IsControlEvent(title, sourceType string) bool {
+	return title == ControlEventTitle && sourceType == ControlEventSourceType
+}
+
+// RecordFromEvent validates and normalizes a parsed control event. The returned
+// bool is true when the event matched the reserved control-event shape and was
+// consumed. The DogStatsD event text carries the action: "start", "update", and
+// "heartbeat" publish tags, while "end" clears tags.
+func RecordFromEvent(containerID, title, sourceType, text string, tags []string, ttl time.Duration) (Record, bool, error) {
+	return recordFromEventAt(containerID, title, sourceType, text, tags, ttl, time.Now())
+}
+
+func recordFromEventAt(containerID, title, sourceType, text string, tags []string, ttl time.Duration, now time.Time) (Record, bool, error) {
+	if !IsControlEvent(title, sourceType) {
+		return Record{}, false, nil
+	}
+
+	containerID = strings.TrimSpace(containerID)
+	if containerID == "" {
+		return Record{}, true, ErrNoContainerID
+	}
+
+	action, err := actionFromText(text)
+	if err != nil {
+		return Record{}, true, err
+	}
+
+	record := Record{
+		ContainerID: containerID,
+		Action:      action,
+		UpdatedAt:   now,
+	}
+
+	if action == ActionEnd {
+		return record, true, nil
+	}
+
+	jobID, eventTags, err := parseEventTags(tags)
+	if err != nil {
+		return Record{}, true, err
+	}
+
+	record.JobID = jobID
+	record.Tags = normalizeTags(jobID, eventTags)
+	if ttl > 0 {
+		record.ExpiresAt = now.Add(ttl)
+	}
+	return copyRecord(record), true, nil
+}
+
+func actionFromText(text string) (Action, error) {
+	switch strings.ToLower(strings.TrimSpace(text)) {
+	case "", "start", "update", "heartbeat":
+		return ActionUpdate, nil
+	case "end", "stop", "complete", "completed":
+		return ActionEnd, nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrUnsupportedAction, text)
+	}
+}
+
+func parseEventTags(tags []string) (string, []string, error) {
+	var jobID string
+	eventTags := make([]string, 0, len(tags))
+	for _, rawTag := range tags {
+		tag, ok := sanitizeTag(rawTag)
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(tag, JobIDTagPrefix) {
+			if jobID == "" {
+				jobID = strings.TrimSpace(strings.TrimPrefix(tag, JobIDTagPrefix))
+			}
+			continue
+		}
+		eventTags = append(eventTags, tag)
+	}
+
+	if jobID == "" {
+		return "", nil, ErrNoJobID
+	}
+	return jobID, eventTags, nil
+}
+
+func normalizeTags(jobID string, tags []string) []string {
+	jobTag := JobIDTagPrefix + jobID
+	result := []string{jobTag}
+	seen := map[string]struct{}{jobTag: {}}
+
+	for _, rawTag := range tags {
+		tag, ok := sanitizeTag(rawTag)
+		if !ok || strings.HasPrefix(tag, JobIDTagPrefix) {
+			continue
+		}
+		if _, found := seen[tag]; found {
+			continue
+		}
+		seen[tag] = struct{}{}
+		result = append(result, tag)
+		if len(result) >= maxTags {
+			break
+		}
+	}
+
+	return result
+}
+
+func sanitizeTag(tag string) (string, bool) {
+	tag = strings.TrimSpace(tag)
+	if tag == "" || len(tag) > maxTagLength || !strings.Contains(tag, ":") {
+		return "", false
+	}
+	if strings.HasPrefix(tag, "host:") || strings.HasPrefix(tag, "dd.internal:") || strings.HasPrefix(tag, "dd.internal.") {
+		return "", false
+	}
+	return tag, true
+}
+
+func copyRecord(record Record) Record {
+	record.Tags = append([]string(nil), record.Tags...)
+	return record
+}

--- a/pkg/gpu/jobmetadata/event_test.go
+++ b/pkg/gpu/jobmetadata/event_test.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package jobmetadata
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordFromControlEventUpdate(t *testing.T) {
+	now := time.Unix(100, 0)
+
+	record, consumed, err := recordFromEventAt(" container-a ", ControlEventTitle, ControlEventSourceType, "start", []string{
+		"team:ml",
+		"gpu_job_id:job-a",
+		"team:ml",
+		"host:spoofed",
+		"dd.internal.foo:bar",
+		"missing_colon",
+	}, time.Second, now)
+	require.NoError(t, err)
+	require.True(t, consumed)
+	require.Equal(t, "container-a", record.ContainerID)
+	require.Equal(t, ActionUpdate, record.Action)
+	require.Equal(t, "job-a", record.JobID)
+	require.Equal(t, []string{"gpu_job_id:job-a", "team:ml"}, record.Tags)
+	require.Equal(t, now, record.UpdatedAt)
+	require.Equal(t, now.Add(time.Second), record.ExpiresAt)
+}
+
+func TestRecordFromControlEventUpdateWithDefaultTTLExpires(t *testing.T) {
+	now := time.Unix(200, 0)
+
+	record, consumed, err := recordFromEventAt("container-a", ControlEventTitle, ControlEventSourceType, "heartbeat", []string{"gpu_job_id:job-a"}, DefaultTTL, now)
+	require.NoError(t, err)
+	require.True(t, consumed)
+	require.Equal(t, now.Add(DefaultTTL), record.ExpiresAt)
+}
+
+func TestRecordFromControlEventUpdateWithZeroTTLDoesNotExpire(t *testing.T) {
+	now := time.Unix(250, 0)
+
+	record, consumed, err := recordFromEventAt("container-a", ControlEventTitle, ControlEventSourceType, "heartbeat", []string{"gpu_job_id:job-a"}, 0, now)
+	require.NoError(t, err)
+	require.True(t, consumed)
+	require.True(t, record.ExpiresAt.IsZero())
+}
+
+func TestRecordFromControlEventEnd(t *testing.T) {
+	now := time.Unix(300, 0)
+
+	record, consumed, err := recordFromEventAt("container-a", ControlEventTitle, ControlEventSourceType, "end", nil, time.Minute, now)
+	require.NoError(t, err)
+	require.True(t, consumed)
+	require.Equal(t, "container-a", record.ContainerID)
+	require.Equal(t, ActionEnd, record.Action)
+	require.Empty(t, record.JobID)
+	require.Empty(t, record.Tags)
+	require.Equal(t, now, record.UpdatedAt)
+	require.True(t, record.ExpiresAt.IsZero())
+}
+
+func TestRecordFromControlEventIgnoresRegularEvents(t *testing.T) {
+	record, consumed, err := recordFromEventAt("container-a", "regular event", ControlEventSourceType, "start", []string{"gpu_job_id:job-a"}, time.Minute, time.Now())
+	require.NoError(t, err)
+	require.False(t, consumed)
+	require.Empty(t, record)
+}
+
+func TestRecordFromControlEventValidation(t *testing.T) {
+	_, consumed, err := recordFromEventAt("", ControlEventTitle, ControlEventSourceType, "start", []string{"gpu_job_id:job-a"}, time.Minute, time.Now())
+	require.True(t, consumed)
+	require.True(t, errors.Is(err, ErrNoContainerID))
+
+	_, consumed, err = recordFromEventAt("container-a", ControlEventTitle, ControlEventSourceType, "start", []string{"team:ml"}, time.Minute, time.Now())
+	require.True(t, consumed)
+	require.True(t, errors.Is(err, ErrNoJobID))
+
+	_, consumed, err = recordFromEventAt("container-a", ControlEventTitle, ControlEventSourceType, "unknown", []string{"gpu_job_id:job-a"}, time.Minute, time.Now())
+	require.True(t, consumed)
+	require.True(t, errors.Is(err, ErrUnsupportedAction))
+}


### PR DESCRIPTION
### What does this PR do?

Adds a gated DogStatsD control-event path for GPU job metadata. Reserved events publish `gpu_job_id` and related job tags into the tagger for the socket-detected container, so existing GPU metric tagging can pick them up through normal container tags.

### Motivation

Let training workloads attach job identity to GPU telemetry without adding GPU-check-specific job metadata logic or a new side channel.

### Describe how you validated your changes

`dda inv test --targets=./comp/core/tagger/tagstore,./comp/dogstatsd/server/impl,./pkg/gpu/jobmetadata`

### Additional Notes

Points needing discussion:
- Trust model: this branch only trusts socket-detected container identity and ignores client-origin `c:ci-*` overrides for these control events. We should decide whether any override path is needed and how it would be authenticated.
- Lifecycle: tags clear on `end`, Linux sender PID exit, or the 15m fallback TTL. Container deletion cleanup may still be worth adding explicitly.
- Product shape: confirm final tag spelling (`gpu_job_id` vs `ml_job_id`) and which user-supplied tags should be accepted.