### PR TITLE
Exclude unused inputs from Bazel openssl build

### DIFF
--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -10,7 +10,20 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "all_srcs",
-    srcs = glob(["**"], exclude = ["BUILD.bazel"]),
+    srcs = glob(
+        ["**"],
+        exclude = [
+            "BUILD.bazel",
+            ".ctags.d/**",
+            "doc/**",
+            "test/recipes/**",
+            "VMS/**",
+            "*.md",
+            "funding.json",
+        ],
+    ) + glob([
+        "doc/**/build.info",
+    ]),
 )
 
 config_setting(


### PR DESCRIPTION
### What does this PR do?

Excludes parts of the openssl source from the input to its build. This removes ~2000 files (80 MiB+).

### Motivation

Even when having full cache hits, bazel commands spend a long time in the preparatory stages, such that on macos, a fully cached python build regularly takes more than 60 seconds.

This is an attempt at optimizing the work that bazel needs to do to determine cache hits.

### Describe how you validated your changes

CI passing, and no changes in the file inventory check.

### Additional Notes

See https://github.com/DataDog/datadog-agent/pull/52173 for prior art on a similar optimization.