### PR TITLE
chore(gpum): add metric value integration tests

### DIFF
--- a/pkg/collector/corechecks/gpu/integrationtests/check_test.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/check_test.go
@@ -9,7 +9,9 @@ package integrationtests
 
 import (
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/require"
@@ -31,14 +33,16 @@ import (
 
 type CheckTestSuite struct {
 	suite.Suite
-	devices []safenvml.Device
-	metrics map[string]map[string][]gpuspec.MetricObservation
+	devices    []safenvml.Device
+	metrics    map[string]map[string][]gpuspec.MetricObservation
+	smiSamples map[string]*testutil.SmiSample
 }
 
 func (suite *CheckTestSuite) SetupTest() {
 	t := suite.T()
 
 	testutil.RequireGPU(t)
+	testutil.RequireSmi(t)
 	env.SetFeatures(t, env.KubernetesDevicePlugins, env.NVML)
 
 	lib, err := safenvml.GetSafeNvmlLib()
@@ -71,6 +75,30 @@ func (suite *CheckTestSuite) SetupTest() {
 	require.NoError(t, err)
 	t.Cleanup(func() { checkInstance.Cancel() })
 
+	// Collect an nvidia-smi sample for each device concurrently with the
+	// collector runs below, so both observe the (idle) device over the same
+	// wall-clock window. nvidia-smi dmon takes ~3 seconds (three cycles), which
+	// overlaps the two check runs and the 1s sleep between them.
+	type smiResult struct {
+		uuid   string
+		sample *testutil.SmiSample
+		err    error
+	}
+	smiResults := make([]smiResult, len(devices))
+	var smiWG sync.WaitGroup
+	for i, device := range devices {
+		deviceID, err := device.GetUUID()
+		require.NoError(t, err, "could not get the device ID")
+		uuid := strings.ToLower(device.GetDeviceInfo().UUID)
+
+		smiWG.Add(1)
+		go func(i int, deviceID, uuid string) {
+			defer smiWG.Done()
+			sample, err := testutil.CollectSmiSample(deviceID)
+			smiResults[i] = smiResult{uuid: uuid, sample: sample, err: err}
+		}(i, deviceID, uuid)
+	}
+
 	err = checkInstance.Run()
 	require.NoError(t, err, "Check.Run() should not return an error")
 
@@ -86,9 +114,20 @@ func (suite *CheckTestSuite) SetupTest() {
 
 	// Run the check a second time so rate-derived field metrics such as NVLink
 	// throughput have a previous sample to compare against and can be emitted.
+	// We need a one second interval before the second call to ensure new
+	// metrics are available for the sample.
+	time.Sleep(1 * time.Second)
 	mockSender.ResetCalls()
 	err = checkInstance.Run()
 	require.NoError(t, err, "Second Check.Run() should not return an error")
+
+	// Wait for the concurrent nvidia-smi collection to finish and assert its results on the test goroutine.
+	smiWG.Wait()
+	suite.smiSamples = make(map[string]*testutil.SmiSample, len(smiResults))
+	for _, res := range smiResults {
+		require.NoError(t, res.err, "could not collect nvidia-smi sample for GPU %s", res.uuid)
+		suite.smiSamples[res.uuid] = res.sample
+	}
 
 	metricsByName := gpu.GetEmittedGPUMetrics(mockSender)
 	require.NotEmpty(t, metricsByName)
@@ -150,6 +189,44 @@ func (suite *CheckTestSuite) TestCheckRunMatchesSpecForPhysicalDevices() {
 	}
 }
 
+func (suite *CheckTestSuite) TestCheckMetricValuesMatchSmi() {
+	t := suite.T()
+
+	for _, device := range suite.devices {
+		arch, err := device.GetArchitecture()
+		require.NoError(t, err, "could not get device architecture")
+
+		deviceInfo := device.GetDeviceInfo()
+		deviceUUID := strings.ToLower(deviceInfo.UUID)
+		deviceMetrics := suite.metrics[deviceUUID]
+
+		sample := suite.smiSamples[deviceUUID]
+		require.NotNil(t, sample, "no nvidia-smi sample collected for GPU %s", deviceUUID)
+
+		// Power is recored in watts from nvidia-smi, but milliwatts from our collector. We need to scale it up and also
+		// give a larger margin of error to account for that.
+		requireMetricNearSmi(t, deviceMetrics, "power.usage", sample.PowerWatts, 1000, 500)
+		requireMetricNearSmi(t, deviceMetrics, "temperature", sample.GPUTempC, 1, 5)
+		requireMetricNearSmi(t, deviceMetrics, "encoder_active", sample.EncoderPct, 1, 5)
+		requireMetricNearSmi(t, deviceMetrics, "decoder_active", sample.DecoderPct, 1, 5)
+		requireMetricNearSmi(t, deviceMetrics, "clock.speed.memory", sample.MemClockMHz, 1, 5)
+		requireMetricNearSmi(t, deviceMetrics, "clock.speed.graphics", sample.ProcClockMHz, 1, 5)
+
+		// Not all GPUs have a memory temporature sensors.
+		if sample.MemTempC != nil {
+			requireMetricNearSmi(t, deviceMetrics, "memory.temperature", sample.MemTempC, 1, 5)
+		}
+
+		// Skip gpm metrics on older architectures.
+		if arch < nvml.DEVICE_ARCH_HOPPER {
+			continue
+		}
+
+		// GPM metrics (nvidia-smi --gpm-metrics) are only available on Hopper and newer GPUs.
+		requireMetricNearSmi(t, deviceMetrics, "gr_engine_active", sample.GraphicsActivity, 1, 5)
+	}
+}
+
 func TestCheckTestSuite(t *testing.T) {
 	suite.Run(t, new(CheckTestSuite))
 }
@@ -166,4 +243,36 @@ func linkCount(t *testing.T, device safenvml.Device, name string, countFunc func
 		return 0
 	}
 	return count
+}
+
+func getFloatValue(t *testing.T, in *float64) float64 {
+	t.Helper()
+	require.NotNil(t, in, "float value does not exist")
+	return *in
+}
+
+// requireMetricNearSmi asserts that the first emitted sample of the named
+// metric is within delta of the nvidia-smi reading, after applying scale to
+// convert the nvidia-smi units into the agent's units (e.g. watts to
+// milliwatts).
+//
+// It is a no-op when nvidia-smi did not report the field (dmon prints "-" for
+// counters the device does not support) or when the check did not emit the
+// metric for this device, since metric support varies across architectures.
+// Presence is enforced by TestCheckRunMatchesSpecForPhysicalDevices; this test
+// only validates the values that are actually reported on both sides.
+func requireMetricNearSmi(t *testing.T, deviceMetrics map[string][]gpuspec.MetricObservation, name string, smiValue *float64, scale, delta float64) {
+	t.Helper()
+
+	observations, ok := deviceMetrics[name]
+	require.True(t, ok, "could not find %s for device", name)
+	require.GreaterOrEqual(t, len(observations), 1, "%s was not emitted for this device", name)
+	actual := getFloatValue(t, observations[0].Value)
+
+	require.NotNil(t, smiValue, "nividia-smi value was blank for %s", name)
+	expected := *smiValue * scale
+
+	t.Logf("checking %s with value %f against nividia-smi value %f", name, actual, expected)
+
+	require.InDelta(t, expected, actual, delta, "%s value %v differs from nvidia-smi reading %v", name, actual, expected)
 }

--- a/pkg/collector/corechecks/gpu/integrationtests/check_test.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/check_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
@@ -28,40 +29,17 @@ import (
 	gpuutil "github.com/DataDog/datadog-agent/pkg/util/gpu"
 )
 
-// TestNVMLDeviceEnumeration tests that NVML can enumerate GPU devices on the current system.
-// This validates the check's ability to discover and interact with GPUs.
-func TestNVMLDeviceEnumeration(t *testing.T) {
-	testutil.RequireGPU(t)
-
-	lib, err := safenvml.GetSafeNvmlLib()
-	require.NoError(t, err, "NVML library should be available")
-	require.NotNil(t, lib, "NVML library should not be nil")
-
-	deviceCount, err := lib.DeviceGetCount()
-	require.NoError(t, err, "Should be able to get device count")
-	require.Greater(t, deviceCount, 0, "Should have at least one GPU")
-
-	for i := 0; i < deviceCount; i++ {
-		device, err := lib.DeviceGetHandleByIndex(i)
-		require.NoError(t, err, "Should be able to get device handle for index %d", i)
-		require.NotNil(t, device, "Device handle should not be nil")
-
-		name, err := device.GetName()
-		require.NoError(t, err, "Should be able to get device name")
-		t.Logf("GPU %d: %s", i, name)
-
-		uuid, err := device.GetUUID()
-		require.NoError(t, err, "Should be able to get device UUID")
-		t.Logf("GPU %d UUID: %s", i, uuid)
-	}
+type CheckTestSuite struct {
+	suite.Suite
+	devices []safenvml.Device
+	metrics map[string]map[string][]gpuspec.MetricObservation
 }
 
-func TestCheckRunMatchesSpecForPhysicalDevices(t *testing.T) {
+func (suite *CheckTestSuite) SetupTest() {
+	t := suite.T()
+
 	testutil.RequireGPU(t)
 	env.SetFeatures(t, env.KubernetesDevicePlugins, env.NVML)
-
-	specs, err := gpuspec.LoadSpecs()
-	require.NoError(t, err)
 
 	lib, err := safenvml.GetSafeNvmlLib()
 	require.NoError(t, err)
@@ -72,6 +50,7 @@ func TestCheckRunMatchesSpecForPhysicalDevices(t *testing.T) {
 	devices, err := cache.AllPhysicalDevices()
 	require.NoError(t, err)
 	require.NotEmpty(t, devices)
+	suite.devices = devices
 
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	wmetaMock := testutil.GetWorkloadMetaMock(t)
@@ -129,8 +108,16 @@ func TestCheckRunMatchesSpecForPhysicalDevices(t *testing.T) {
 			metricsByUUID[deviceUUID][metricName] = append(metricsByUUID[deviceUUID][metricName], sample)
 		}
 	}
+	suite.metrics = metricsByUUID
+}
 
-	for _, device := range devices {
+func (suite *CheckTestSuite) TestCheckRunMatchesSpecForPhysicalDevices() {
+	t := suite.T()
+
+	specs, err := gpuspec.LoadSpecs()
+	require.NoError(t, err)
+
+	for _, device := range suite.devices {
 		deviceInfo := device.GetDeviceInfo()
 		deviceUUID := strings.ToLower(deviceInfo.UUID)
 		archName := gpuutil.ArchToString(deviceInfo.Architecture)
@@ -143,7 +130,7 @@ func TestCheckRunMatchesSpecForPhysicalDevices(t *testing.T) {
 		require.True(t, ok, "architecture %s missing from architectures spec", archName)
 		require.True(t, gpuspec.IsModeSupportedByArchitecture(archSpec, gpuspec.DeviceModePhysical), "physical mode should be supported for architecture %s", archName)
 
-		deviceMetrics := metricsByUUID[deviceUUID]
+		deviceMetrics := suite.metrics[deviceUUID]
 		require.NotEmpty(t, deviceMetrics, "expected emitted metrics for GPU %s", deviceUUID)
 
 		capabilities := archSpec.EffectiveCapabilities(gpuspec.DeviceModePhysical)
@@ -161,6 +148,10 @@ func TestCheckRunMatchesSpecForPhysicalDevices(t *testing.T) {
 			gpu.ValidateEmittedMetricsAgainstSpec(t, specs, gpuConfig, deviceMetrics, nil, validationOptions)
 		})
 	}
+}
+
+func TestCheckTestSuite(t *testing.T) {
+	suite.Run(t, new(CheckTestSuite))
 }
 
 func linkCount(t *testing.T, device safenvml.Device, name string, countFunc func(safenvml.Device) (int, error)) int {

--- a/pkg/collector/corechecks/gpu/integrationtests/check_test.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/check_test.go
@@ -205,7 +205,7 @@ func (suite *CheckTestSuite) TestCheckMetricValuesMatchSmi() {
 
 		// Power is recored in watts from nvidia-smi, but milliwatts from our collector. We need to scale it up and also
 		// give a larger margin of error to account for that.
-		requireMetricNearSmi(t, deviceMetrics, "power.usage", sample.PowerWatts, 1000, 500)
+		requireMetricNearSmi(t, deviceMetrics, "power.usage", sample.PowerWatts, 1000, 1000)
 		requireMetricNearSmi(t, deviceMetrics, "temperature", sample.GPUTempC, 1, 5)
 		requireMetricNearSmi(t, deviceMetrics, "encoder_active", sample.EncoderPct, 1, 5)
 		requireMetricNearSmi(t, deviceMetrics, "decoder_active", sample.DecoderPct, 1, 5)
@@ -255,12 +255,6 @@ func getFloatValue(t *testing.T, in *float64) float64 {
 // metric is within delta of the nvidia-smi reading, after applying scale to
 // convert the nvidia-smi units into the agent's units (e.g. watts to
 // milliwatts).
-//
-// It is a no-op when nvidia-smi did not report the field (dmon prints "-" for
-// counters the device does not support) or when the check did not emit the
-// metric for this device, since metric support varies across architectures.
-// Presence is enforced by TestCheckRunMatchesSpecForPhysicalDevices; this test
-// only validates the values that are actually reported on both sides.
 func requireMetricNearSmi(t *testing.T, deviceMetrics map[string][]gpuspec.MetricObservation, name string, smiValue *float64, scale, delta float64) {
 	t.Helper()
 
@@ -273,6 +267,5 @@ func requireMetricNearSmi(t *testing.T, deviceMetrics map[string][]gpuspec.Metri
 	expected := *smiValue * scale
 
 	t.Logf("checking %s with value %f against nividia-smi value %f", name, actual, expected)
-
 	require.InDelta(t, expected, actual, delta, "%s value %v differs from nvidia-smi reading %v", name, actual, expected)
 }

--- a/pkg/collector/corechecks/gpu/integrationtests/nvml_test.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/nvml_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux && nvml
+
+package integrationtests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
+)
+
+// TestNVMLDeviceEnumeration tests that NVML can enumerate GPU devices on the current system.
+// This validates the check's ability to discover and interact with GPUs.
+func TestNVMLDeviceEnumeration(t *testing.T) {
+	testutil.RequireGPU(t)
+
+	lib, err := safenvml.GetSafeNvmlLib()
+	require.NoError(t, err, "NVML library should be available")
+	require.NotNil(t, lib, "NVML library should not be nil")
+
+	deviceCount, err := lib.DeviceGetCount()
+	require.NoError(t, err, "Should be able to get device count")
+	require.Greater(t, deviceCount, 0, "Should have at least one GPU")
+
+	for i := 0; i < deviceCount; i++ {
+		device, err := lib.DeviceGetHandleByIndex(i)
+		require.NoError(t, err, "Should be able to get device handle for index %d", i)
+		require.NotNil(t, device, "Device handle should not be nil")
+
+		name, err := device.GetName()
+		require.NoError(t, err, "Should be able to get device name")
+		t.Logf("GPU %d: %s", i, name)
+
+		uuid, err := device.GetUUID()
+		require.NoError(t, err, "Should be able to get device UUID")
+		t.Logf("GPU %d UUID: %s", i, uuid)
+	}
+}

--- a/pkg/gpu/testutil/smi.go
+++ b/pkg/gpu/testutil/smi.go
@@ -8,6 +8,7 @@
 package testutil
 
 import (
+	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -22,6 +23,8 @@ const (
 	GrEngineActiveID    = "1001"
 )
 
+// SmiSample is a sample of metrics from the dmon subcommand of nividia-smi. The values returned from dmon might not
+// exist 
 type SmiSample struct {
 	Index            int
 	PowerWatts       *float64
@@ -38,12 +41,14 @@ type SmiSample struct {
 	GraphicsActivity *float64
 }
 
+// RequireSmi ensures the nvidia-smi binary exists on the system path.
 func RequireSmi(t *testing.T) {
 	_, err := exec.LookPath(nvidiaSmi)
 	require.NoError(t, err)
 }
 
-func CollectSmiSample(t *testing.T, deviceID string) *SmiSample {
+// CollectSmiSample runs nvidia-smi dmon for the given device and returns the parsed sample.
+func CollectSmiSample(deviceID string) (*SmiSample, error) {
 	gpmMetrics := []string{
 		"1", // Graphics Activity
 	}
@@ -57,27 +62,26 @@ func CollectSmiSample(t *testing.T, deviceID string) *SmiSample {
 	out, err := cmd.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			t.Fatalf("nvidia-smi failed (%v):\nstderr: %s", err, ee.Stderr)
+			return nil, fmt.Errorf("nvidia-smi failed (%w):\nstderr: %s", err, ee.Stderr)
 		}
-		require.NoError(t, err, "could not collect sample")
+		return nil, fmt.Errorf("could not collect sample: %w", err)
 	}
 
 	// One data line per monitoring cycle (single device via --id). Read the
 	// third line so the GPM metrics have two prior samples to diff against.
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	require.GreaterOrEqual(t, len(lines), 3,
-		"expected at least 3 sample lines, got %d:\n%s", len(lines), string(out))
-	values := strings.Split(strings.TrimSpace(lines[2]), ",")
+	if len(lines) < 3 {
+		return nil, fmt.Errorf("expected at least 3 sample lines, got %d:\n%s", len(lines), string(out))
+	}
 
-	require.Equal(t, len(values), standardMetricCount+len(gpmMetrics), "invalid output")
+	values := strings.Split(strings.TrimSpace(lines[2]), ",")
+	if want := standardMetricCount + len(gpmMetrics); len(values) != want {
+		return nil, fmt.Errorf("invalid output: expected %d fields, got %d: %q", want, len(values), lines[2])
+	}
+
 	idx, err := strconv.Atoi(strings.TrimSpace(values[0]))
-	require.NoError(t, err, "bad gpu index")
-	gpmValues := make([]*float64, len(gpmMetrics))
-	if len(gpmMetrics) > 0 {
-		require.Equal(t, standardMetricCount+len(gpmMetrics), len(values), "invalid output")
-		for i := standardMetricCount; i < len(values); i++ {
-			gpmValues[i-standardMetricCount] = parseFloatField(values[i])
-		}
+	if err != nil {
+		return nil, fmt.Errorf("bad gpu index %q: %w", values[0], err)
 	}
 	return &SmiSample{
 		Index:            idx,
@@ -93,7 +97,7 @@ func CollectSmiSample(t *testing.T, deviceID string) *SmiSample {
 		MemClockMHz:      parseFloatField(values[10]),
 		ProcClockMHz:     parseFloatField(values[11]),
 		GraphicsActivity: parseFloatField(values[12]),
-	}
+	}, nil
 }
 
 // parseFloatField returns nil for "-" or unparseable values.

--- a/pkg/gpu/testutil/smi.go
+++ b/pkg/gpu/testutil/smi.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux && test
+
+package testutil
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	nvidiaSmi           = "nvidia-smi"
+	standardMetricCount = 12
+	GrEngineActiveID    = "1001"
+)
+
+type SmiSample struct {
+	Index            int
+	PowerWatts       *float64
+	GPUTempC         *float64
+	MemTempC         *float64
+	SMUtilPct        *float64
+	MemUtilPct       *float64
+	EncoderPct       *float64
+	DecoderPct       *float64
+	JPEGPct          *float64
+	OFAPct           *float64
+	MemClockMHz      *float64
+	ProcClockMHz     *float64
+	GraphicsActivity *float64
+}
+
+func RequireSmi(t *testing.T) {
+	_, err := exec.LookPath(nvidiaSmi)
+	require.NoError(t, err)
+}
+
+func CollectSmiSample(t *testing.T, deviceID string) *SmiSample {
+	gpmMetrics := []string{
+		"1", // Graphics Activity
+	}
+	// GPM metrics are a delta between consecutive samples, so the first dmon
+	// cycle always reports "-". Run multiple cycles and read a later line.
+	args := []string{"dmon", "--id", deviceID, "-c", "3", "--format", "csv,noheader,nounit"}
+	if len(gpmMetrics) > 0 {
+		args = append(args, "--gpm-metrics", strings.Join(gpmMetrics, ","))
+	}
+	cmd := exec.Command(nvidiaSmi, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("nvidia-smi failed (%v):\nstderr: %s", err, ee.Stderr)
+		}
+		require.NoError(t, err, "could not collect sample")
+	}
+
+	// One data line per monitoring cycle (single device via --id). Read the
+	// third line so the GPM metrics have two prior samples to diff against.
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	require.GreaterOrEqual(t, len(lines), 3,
+		"expected at least 3 sample lines, got %d:\n%s", len(lines), string(out))
+	values := strings.Split(strings.TrimSpace(lines[2]), ",")
+
+	require.Equal(t, len(values), standardMetricCount+len(gpmMetrics), "invalid output")
+	idx, err := strconv.Atoi(strings.TrimSpace(values[0]))
+	require.NoError(t, err, "bad gpu index")
+	gpmValues := make([]*float64, len(gpmMetrics))
+	if len(gpmMetrics) > 0 {
+		require.Equal(t, standardMetricCount+len(gpmMetrics), len(values), "invalid output")
+		for i := standardMetricCount; i < len(values); i++ {
+			gpmValues[i-standardMetricCount] = parseFloatField(values[i])
+		}
+	}
+	return &SmiSample{
+		Index:            idx,
+		PowerWatts:       parseFloatField(values[1]),
+		GPUTempC:         parseFloatField(values[2]),
+		MemTempC:         parseFloatField(values[3]),
+		SMUtilPct:        parseFloatField(values[4]),
+		MemUtilPct:       parseFloatField(values[5]),
+		EncoderPct:       parseFloatField(values[6]),
+		DecoderPct:       parseFloatField(values[7]),
+		JPEGPct:          parseFloatField(values[8]),
+		OFAPct:           parseFloatField(values[9]),
+		MemClockMHz:      parseFloatField(values[10]),
+		ProcClockMHz:     parseFloatField(values[11]),
+		GraphicsActivity: parseFloatField(values[12]),
+	}
+}
+
+// parseFloatField returns nil for "-" or unparseable values.
+func parseFloatField(s string) *float64 {
+	s = strings.TrimSpace(s)
+	if s == "-" || s == "" {
+		return nil
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return nil
+	}
+	return &v
+}

--- a/pkg/gpu/testutil/smi.go
+++ b/pkg/gpu/testutil/smi.go
@@ -24,7 +24,7 @@ const (
 )
 
 // SmiSample is a sample of metrics from the dmon subcommand of nividia-smi. The values returned from dmon might not
-// exist 
+// exist
 type SmiSample struct {
 	Index            int
 	PowerWatts       *float64


### PR DESCRIPTION
### What does this PR do?
This change adds an integration test to validate the metric values we get from `nvidia-smi` against what the collector produces.

### Motivation
Changes in the underlying `go-nvml` library have caused issues where metric values we collect are not accurate. We want to provide a safe guard for 

### Changes
* [chore(gpum): refactor check test to suite](https://github.com/DataDog/datadog-agent/commit/243a640396cb41862732e592b49169f555072f01) 
    * This commit refactors the check test to a suite so we can share setup code across tests.
* [chore(gpum): add nvidia-smi test util](https://github.com/DataDog/datadog-agent/commit/fba34606272df9f8207dff6726e30f9eadd14a26) 
    * This commit adds the nvidia-smi harness to testutil so we can call it and collect samples.
* [chore(gpum): add test to validate metric values](https://github.com/DataDog/datadog-agent/commit/fd020c3c1fc43bce30faef4ae0727b1d8e0e0dcc) 
    * This commit adds a check to validate metric values against nvidia-smi output. It takes readings in parallel to our collector to get them as close as possible.
   
### Describe how you validated your changes
I ran this accross an a10 and h100:
```
dda inv test --targets=./pkg/collector/corechecks/gpu/integrationtests
```

### Additional Notes
This change does not run a workload, so this is testing an idle GPU.
