### PR TITLE
[AGNTLOG-647] Add disabled_sources config to bypass adaptive sampling per source

### DIFF
--- a/pkg/config/schema/yaml/logs_config.yaml
+++ b/pkg/config/schema/yaml/logs_config.yaml
@@ -553,6 +553,15 @@ properties:
         tags:
         - golang_type:float64
         comment: Maximum burst allowance per pattern, measured in accumulated credits/logs.
+      disabled_sources:
+        node_type: setting
+        type: array
+        default: []
+        items:
+          type: string
+        comment: Sources listed here will not have adaptive sampling or noisy log
+          detection applied, even if enabled globally. Matches against the configured
+          source tag of each log source.
       enabled:
         node_type: setting
         type: boolean

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1885,6 +1885,9 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.experimental_adaptive_sampling.include", []map[string]interface{}{})
 	// Exclude prevents adaptive sampling from applying to logs matching any rule when configured.
 	config.BindEnvAndSetDefault("logs_config.experimental_adaptive_sampling.exclude", []map[string]interface{}{})
+	// Sources listed here will not have adaptive sampling or noisy log detection applied, even if enabled globally.
+	// Useful for auto-discovered sources that cannot be configured via integration-level YAML.
+	config.BindEnvAndSetDefault("logs_config.experimental_adaptive_sampling.disabled_sources", []string{})
 	// Tag repetitive logs that would be dropped by the adaptive sampler with noisy_log:true
 	// without dropping them. Real adaptive sampling takes precedence when enabled.
 	config.BindEnvAndSetDefault("logs_config.experimental_noisy_log_detection", false)

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -7,7 +7,6 @@ package decoder
 
 import (
 	"regexp"
-	"slices"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -188,6 +187,33 @@ func resolveNoisyLogDetectionEnabled(sourceNoisyLogDetection *bool) bool {
 	return pkgconfigsetup.Datadog().GetBool("logs_config.experimental_noisy_log_detection")
 }
 
+const disabledSourcesConfigKey = "logs_config.experimental_adaptive_sampling.disabled_sources"
+
+func newDisabledSet() map[string]struct{} {
+	entries := pkgconfigsetup.Datadog().GetStringSlice(disabledSourcesConfigKey)
+	m := make(map[string]struct{}, len(entries))
+	for _, s := range entries {
+		m[s] = struct{}{}
+	}
+	return m
+}
+
+// buildIsSourceDisabled builds a closure that checks whether the current source
+// is in the disabled_sources set. The set is built once at init; the source name
+// is read per-message through ReplaceableSource to track source swaps.
+// When Remote Config support is added, the set can be rebuilt via a callback
+// (e.g. using atomic.Pointer for lock-free reads) without changing the caller.
+func buildIsSourceDisabled(source *sources.ReplaceableSource) func() bool {
+	disabledSet := newDisabledSet()
+	if len(disabledSet) == 0 {
+		return nil
+	}
+	return func() bool {
+		_, disabled := disabledSet[source.Config().Source]
+		return disabled
+	}
+}
+
 type samplerMode int
 
 const (
@@ -319,21 +345,11 @@ func buildLineHandler(source *sources.ReplaceableSource, multiLinePattern *regex
 	switch resolveSamplerMode(sourceConfig.ExperimentalAdaptiveSampling, sourceConfig.ExperimentalNoisyLogDetection) {
 	case samplerAdaptiveSampling:
 		cfg := resolveAdaptiveSamplerConfig(sourceConfig.ExperimentalAdaptiveSampling, tok)
-		cfg.IsSourceDisabled = func() bool {
-			return slices.Contains(
-				pkgconfigsetup.Datadog().GetStringSlice("logs_config.experimental_adaptive_sampling.disabled_sources"),
-				source.Config().Source,
-			)
-		}
+		cfg.IsSourceDisabled = buildIsSourceDisabled(source)
 		sampler = preprocessor.NewAdaptiveSampler(cfg, source.UnderlyingSource().Name, baseBytesEstimate)
 	case samplerNoisyLogDetection:
 		cfg := resolveNoisyLogDetectionConfig(sourceConfig.ExperimentalAdaptiveSampling, tok)
-		cfg.IsSourceDisabled = func() bool {
-			return slices.Contains(
-				pkgconfigsetup.Datadog().GetStringSlice("logs_config.experimental_adaptive_sampling.disabled_sources"),
-				source.Config().Source,
-			)
-		}
+		cfg.IsSourceDisabled = buildIsSourceDisabled(source)
 		sampler = preprocessor.NewAdaptiveSampler(cfg, source.UnderlyingSource().Name, baseBytesEstimate)
 	default:
 		sampler = preprocessor.NewNoopSampler()

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -7,6 +7,7 @@ package decoder
 
 import (
 	"regexp"
+	"slices"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -317,9 +318,23 @@ func buildLineHandler(source *sources.ReplaceableSource, multiLinePattern *regex
 	sourceConfig := source.Config()
 	switch resolveSamplerMode(sourceConfig.ExperimentalAdaptiveSampling, sourceConfig.ExperimentalNoisyLogDetection) {
 	case samplerAdaptiveSampling:
-		sampler = preprocessor.NewAdaptiveSampler(resolveAdaptiveSamplerConfig(sourceConfig.ExperimentalAdaptiveSampling, tok), source.UnderlyingSource().Name, baseBytesEstimate)
+		cfg := resolveAdaptiveSamplerConfig(sourceConfig.ExperimentalAdaptiveSampling, tok)
+		cfg.IsSourceDisabled = func() bool {
+			return slices.Contains(
+				pkgconfigsetup.Datadog().GetStringSlice("logs_config.experimental_adaptive_sampling.disabled_sources"),
+				source.Config().Source,
+			)
+		}
+		sampler = preprocessor.NewAdaptiveSampler(cfg, source.UnderlyingSource().Name, baseBytesEstimate)
 	case samplerNoisyLogDetection:
-		sampler = preprocessor.NewAdaptiveSampler(resolveNoisyLogDetectionConfig(sourceConfig.ExperimentalAdaptiveSampling, tok), source.UnderlyingSource().Name, baseBytesEstimate)
+		cfg := resolveNoisyLogDetectionConfig(sourceConfig.ExperimentalAdaptiveSampling, tok)
+		cfg.IsSourceDisabled = func() bool {
+			return slices.Contains(
+				pkgconfigsetup.Datadog().GetStringSlice("logs_config.experimental_adaptive_sampling.disabled_sources"),
+				source.Config().Source,
+			)
+		}
+		sampler = preprocessor.NewAdaptiveSampler(cfg, source.UnderlyingSource().Name, baseBytesEstimate)
 	default:
 		sampler = preprocessor.NewNoopSampler()
 	}

--- a/pkg/logs/internal/decoder/preprocessor/sampler.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler.go
@@ -112,6 +112,11 @@ type AdaptiveSamplerConfig struct {
 	// Exclude makes matching messages bypass adaptive sampling. Exclude takes
 	// precedence over Include.
 	Exclude []AdaptiveSamplerFilter
+	// IsSourceDisabled is called per-message to check whether the current source
+	// is in the disabled_sources list. When it returns true the sampler passes the
+	// message through without rate-limiting. Using a closure lets the check track
+	// ReplaceableSource swaps and future Remote Config updates.
+	IsSourceDisabled func() bool
 }
 
 // AdaptiveSamplerFilter matches messages by raw-content regex, structural sample,
@@ -217,6 +222,9 @@ func (s *AdaptiveSampler) appendPatternHashTagIfEnabled(msg *message.Message, to
 // Process applies credit-based rate limiting to the message.
 // Returns the message if allowed, nil if dropped.
 func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message.Message {
+	if s.config.IsSourceDisabled != nil && s.config.IsSourceDisabled() {
+		return msg
+	}
 	if !s.shouldSample(msg, tokens) {
 		tlmAdaptiveSamplerKept.Inc(s.source)
 		return msg

--- a/pkg/logs/internal/decoder/preprocessor/sampler_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_test.go
@@ -778,7 +778,6 @@ func TestAdaptiveSampler_DetectionOnly_TracksBytesWithoutDropping(t *testing.T) 
 	beforeTagBytes := tlmAdaptiveSamplerTagBytesDropped.WithValues("test_detect", "true").Get()
 
 	msg := testMsg()
-	// In detection-only mode the message is returned (not nil) with the noisy tag
 	result := s.Process(msg, tokens)
 	require.NotNil(t, result, "detection-only must not drop messages")
 	assert.Contains(t, result.ParsingExtra.Tags, adaptiveSamplerNoisyLogTag)
@@ -788,4 +787,77 @@ func TestAdaptiveSampler_DetectionOnly_TracksBytesWithoutDropping(t *testing.T) 
 
 	assert.Greater(t, afterBytes-beforeBytes, float64(0), "bytes_dropped should be tracked in detection-only mode")
 	assert.Equal(t, float64(20), afterTagBytes-beforeTagBytes, "tag_bytes_dropped should reflect baseBytesEstimate")
+}
+
+func TestAdaptiveSampler_IsSourceDisabled(t *testing.T) {
+	t0 := time.Now()
+
+	t.Run("disabled source passes all messages through", func(t *testing.T) {
+		s := NewAdaptiveSampler(AdaptiveSamplerConfig{
+			MaxPatterns:      10,
+			RateLimit:        1.0,
+			BurstSize:        1,
+			MatchThreshold:   0.3,
+			IsSourceDisabled: func() bool { return true },
+		}, "test", 0)
+		s.now = func() time.Time { return t0 }
+
+		tokens := tokenize("connection timeout to host abc")
+		assert.NotNil(t, s.Process(testMsg(), tokens), "first message allowed")
+		assert.NotNil(t, s.Process(testMsg(), tokens), "second message also allowed — source is disabled")
+		assert.NotNil(t, s.Process(testMsg(), tokens), "third message also allowed — no rate limiting")
+	})
+
+	t.Run("enabled source rate-limits normally", func(t *testing.T) {
+		s := NewAdaptiveSampler(AdaptiveSamplerConfig{
+			MaxPatterns:      10,
+			RateLimit:        1.0,
+			BurstSize:        1,
+			MatchThreshold:   0.3,
+			IsSourceDisabled: func() bool { return false },
+		}, "test", 0)
+		s.now = func() time.Time { return t0 }
+
+		tokens := tokenize("connection timeout to host abc")
+		assert.NotNil(t, s.Process(testMsg(), tokens), "first message allowed (new pattern)")
+		assert.Nil(t, s.Process(testMsg(), tokens), "second message dropped — burst exhausted")
+	})
+
+	t.Run("nil IsSourceDisabled behaves as enabled", func(t *testing.T) {
+		s := NewAdaptiveSampler(AdaptiveSamplerConfig{
+			MaxPatterns:      10,
+			RateLimit:        1.0,
+			BurstSize:        1,
+			MatchThreshold:   0.3,
+			IsSourceDisabled: nil,
+		}, "test", 0)
+		s.now = func() time.Time { return t0 }
+
+		tokens := tokenize("connection timeout to host abc")
+		assert.NotNil(t, s.Process(testMsg(), tokens), "first message allowed")
+		assert.Nil(t, s.Process(testMsg(), tokens), "second message dropped — nil means enabled")
+	})
+
+	t.Run("dynamic toggle mid-stream", func(t *testing.T) {
+		disabled := false
+		s := NewAdaptiveSampler(AdaptiveSamplerConfig{
+			MaxPatterns:      10,
+			RateLimit:        1.0,
+			BurstSize:        1,
+			MatchThreshold:   0.3,
+			IsSourceDisabled: func() bool { return disabled },
+		}, "test", 0)
+		s.now = func() time.Time { return t0 }
+
+		tokens := tokenize("connection timeout to host abc")
+		assert.NotNil(t, s.Process(testMsg(), tokens), "first message allowed (new pattern)")
+		assert.Nil(t, s.Process(testMsg(), tokens), "second message dropped — enabled, burst exhausted")
+
+		disabled = true
+		assert.NotNil(t, s.Process(testMsg(), tokens), "third message allowed — source now disabled")
+		assert.NotNil(t, s.Process(testMsg(), tokens), "fourth message allowed — still disabled")
+
+		disabled = false
+		assert.Nil(t, s.Process(testMsg(), tokens), "fifth message dropped — re-enabled, credits still exhausted")
+	})
 }


### PR DESCRIPTION
### What does this PR do?

Adds a new config option `logs_config.experimental_adaptive_sampling.disabled_sources` that lets operators bypass adaptive sampling and noisy log detection for specific log sources, even when those features are globally enabled.

When a source name appears in this list, the decoder skips both the sampler instantiation and the tokenizer window widening that adaptive sampling normally triggers. Matching is done against the configured source: tag (e.g. "nginx"), falling back to the integration/provider name (e.g. "docker") for auto-discovered sources.

### Motivation

Adaptive sampling is enabled globally, but some sources produce logs that should never be sampled — audit logs, compliance sources, low-volume but high-value streams. Today, the only way to opt out is via per-integration YAML (`experimental_adaptive_sampling.enabled: false`), which doesn't work for auto-discovered sources (container AD, Kubernetes annotations) where operators don't control the integration config directly.

`disabled_sources` provides a global-level escape hatch: list the source names and they're excluded from sampling regardless of how they were discovered.

### Describe how you validated your changes

- Added unit tests for `resolveTokenizerAndLabelerMaxInputBytes` verifying disabled sources don't widen the tokenizer window
- Added unit tests for `resolveSamplerMode` verifying disabled sources return `samplerDisabled` (covers exact match, non-match, and multi-entry list)
- Verified config binding follows the same BindEnvAndSetDefault pattern as neighboring adaptive sampling keys
- Schema entry added under `logs_config.experimental_adaptive_sampling`

### Additional Notes

- The config key is `[]string{}` (empty by default) — no behavioral change unless explicitly configured
- `isSourceDisabledForSampling` lives inside the decoder but is called in all adaptiveSampler. We create a sampler even when the exclusion is on for the source however the resource impact is minimal and the accuracy is a lot better. 