### PR TITLE
[CONS-8382] Fix panic for empty container.ID for "Could not collect tags for container" debug log

### DIFF
--- a/pkg/process/util/containers/containers.go
+++ b/pkg/process/util/containers/containers.go
@@ -19,6 +19,7 @@ import (
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmetafilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/util/workloadmeta"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	containerutilPkg "github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -134,7 +135,7 @@ func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousC
 		entityID := types.NewEntityID(types.ContainerID, container.ID)
 		tags, err := p.tagger.Tag(entityID, types.HighCardinality)
 		if err != nil {
-			log.Debugf("Could not collect tags for container %q, err: %v", container.ID[:12], err)
+			log.Debugf("Could not collect tags for container %q, err: %v", containerutilPkg.ShortContainerID(container.ID), err)
 		}
 		tags = append(tags, container.CollectorTags...)
 

--- a/pkg/process/util/containers/containers_test.go
+++ b/pkg/process/util/containers/containers_test.go
@@ -7,6 +7,7 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadfilterfxmock "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-mock"
@@ -851,6 +853,46 @@ func TestGetContainersExcludesFilteredContainers(t *testing.T) {
 		1: "included-id",
 		2: "included-id",
 	}, pidToCid, "PID mapping should only contain PIDs from included container")
+}
+
+// erroringTagger wraps a tagger.Component and forces Tag to return an error,
+// to exercise the error-logging path in GetContainers.
+type erroringTagger struct {
+	tagger.Component
+}
+
+func (erroringTagger) Tag(types.EntityID, types.TagCardinality) ([]string, error) {
+	return nil, errors.New("forced tag error")
+}
+
+// TestGetContainersDoesNotPanicOnShortID ensures GetContainers does not panic
+// when a container has an ID shorter than the short-ID length (here, empty) and
+// the tagger returns an error, which previously triggered a slice-out-of-range
+// panic from container.ID[:12].
+func TestGetContainersDoesNotPanicOnShortID(t *testing.T) {
+	metadataProvider := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		fx.Supply(context.Background()),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+
+	// Force the tagger to error so the error-logging branch runs.
+	errTagger := erroringTagger{Component: taggerfxmock.SetupFakeTagger(t)}
+	filter := workloadfilterfxmock.SetupMockFilter(t).GetContainerSharedMetricFilters()
+	containerProvider := NewContainerProvider(mock.NewMetricsProvider(), metadataProvider, filter, errTagger)
+
+	// A running container with an empty ID is enough: the panic happened while
+	// logging the tagger error, before any metrics were gathered.
+	metadataProvider.Set(&workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainer, ID: ""},
+		Runtime:  workloadmeta.ContainerRuntimeContainerd,
+		State:    workloadmeta.ContainerState{Running: true, Status: workloadmeta.ContainerStatusRunning},
+	})
+
+	assert.NotPanics(t, func() {
+		_, _, _, err := containerProvider.GetContainers(0, nil)
+		assert.NoError(t, err)
+	})
 }
 
 func compareResults(a, b interface{}) string {

--- a/releasenotes/notes/fix-panic-for-empty-container.ID-bba69b30f64f9c14.yaml
+++ b/releasenotes/notes/fix-panic-for-empty-container.ID-bba69b30f64f9c14.yaml
@@ -1,3 +1,4 @@
 fixes:
   - |
     Fixed a rare process-agent panic when collecting metrics for a container with an empty or short (<12 character) ID.
+    

--- a/releasenotes/notes/fix-panic-for-empty-container.ID-bba69b30f64f9c14.yaml
+++ b/releasenotes/notes/fix-panic-for-empty-container.ID-bba69b30f64f9c14.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixed a rare process-agent panic when collecting metrics for a container with an empty or short (<12 character) ID.


### PR DESCRIPTION
### What does this PR do?
Fixes a panic whenever `container.ID[:12]` is either less than 12 characters long or is an empty string.

There is a recent case of this where a user would run very short lived containers and because the container is so short-lived, the ECS introspection endpoint reports it as a running task before it has a DockerId (or after it's gone), so it returns an empty `DockerId`. `workloadmeta` copies that empty ID into the `container.ID` 

Panic shared by a user:
```
  panic: runtime error: slice bounds out of range [:12] with length 0
    pkg/process/util/containers.(*containerProvider).GetContainers
    pkg/process/checks.(*ProcessCheck).run → process.go:279
```

This PR changes the code so that it uses the `ShortContainerID` helper function here as it does the same thing and is panic safe: https://github.com/DataDog/datadog-agent/blob/main/pkg/util/containers/identifier.go

### Motivation
CONS-8382

### Describe how you validated your changes
Write unit test for this. Run:
```
go test -tags test ./pkg/process/util/containers/ -run TestGetContainersDoesNotPanicOnShortID -v
```