### PR TITLE
[serializerexporter] Split Fargate running metric from host running metric

### DIFF
--- a/comp/otelcol/otlp/components/exporter/serializerexporter/BUILD.bazel
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
     srcs = [
         "apm_stats_test.go",
         "config_test.go",
+        "consumer_collector_test.go",
         "consumer_test.go",
         "exporter_test.go",
         "factory_test.go",

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/consumer_collector.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/consumer_collector.go
@@ -7,9 +7,11 @@ package serializerexporter
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes/source"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
@@ -38,13 +40,18 @@ func (c *collectorConsumer) addRuntimeTelemetryMetric(_ string, languageTags []s
 		series = append(series, runningMetric)
 	}
 
-	var tags []string
-	tags = append(tags, buildTags...)
+	var nonFargateTags []string
 	for tag := range c.seenTags {
-		tags = append(tags, tag)
+		if strings.HasPrefix(tag, string(source.AWSECSFargateKind)+":") {
+			series = append(series, exporterFargateMetrics(timestamp, append(buildTags, tag)))
+		} else {
+			nonFargateTags = append(nonFargateTags, tag)
+		}
 	}
-	runningMetrics := exporterDefaultMetrics("metrics", "", timestamp, tags)
-	series = append(series, runningMetrics)
+	if len(c.seenTags) == 0 || len(nonFargateTags) > 0 {
+		tags := append(buildTags, nonFargateTags...)
+		series = append(series, exporterDefaultMetrics("metrics", "", timestamp, tags))
+	}
 
 	for _, lang := range languageTags {
 		tags := append(buildTags, "language:"+lang) //nolint:gocritic
@@ -83,6 +90,23 @@ func exporterDefaultMetrics(exporterType string, hostname string, timestamp uint
 		Source: metrics.MetricSourceOpenTelemetryCollectorUnknown,
 	}
 	return metrics
+}
+
+// exporterFargateMetrics creates a built-in metric to report that a Fargate exporter is running.
+func exporterFargateMetrics(timestamp uint64, tags []string) *metrics.Serie {
+	return &metrics.Serie{
+		Name: "otel.datadog_exporter.metrics.running.fargate",
+		Points: []metrics.Point{
+			{
+				Ts:    float64(timestamp),
+				Value: 1.0,
+			},
+		},
+		Host:   "",
+		MType:  metrics.APIGaugeType,
+		Tags:   tagset.CompositeTagsFromSlice(tags),
+		Source: metrics.MetricSourceOpenTelemetryCollectorUnknown,
+	}
 }
 
 // tagsFromBuildInfo returns a list of tags derived from buildInfo to be used when creating metrics

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/consumer_collector_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/consumer_collector_test.go
@@ -34,20 +34,6 @@ func TestExporterFargateMetrics(t *testing.T) {
 	assert.Equal(t, "", serie.Host)
 }
 
-func TestAddRuntimeTelemetryMetric_FargateTags(t *testing.T) {
-	buildInfo := component.BuildInfo{Version: "1.0", Command: "otelcontribcol"}
-	c := newTestCollectorConsumer(buildInfo)
-	c.ConsumeTag("task_arn:arn:aws:ecs:us-east-1:123:task/cluster/abc")
-
-	c.addRuntimeTelemetryMetric("", nil)
-
-	var names []string
-	for _, s := range c.series {
-		names = append(names, s.Name)
-	}
-	assert.ElementsMatch(t, []string{"otel.datadog_exporter.metrics.running.fargate"}, names)
-}
-
 func TestAddRuntimeTelemetryMetric_NoTags(t *testing.T) {
 	buildInfo := component.BuildInfo{Version: "1.0", Command: "otelcontribcol"}
 	c := newTestCollectorConsumer(buildInfo)
@@ -75,4 +61,35 @@ func TestAddRuntimeTelemetryMetric_HostSource(t *testing.T) {
 	// host path emits metrics.running with hostname, plus the baseline tagless metric
 	assert.Contains(t, names, "otel.datadog_exporter.metrics.running")
 	assert.Contains(t, hosts, "my-hostname")
+}
+
+func TestAddRuntimeTelemetryMetric_FargateTags(t *testing.T) {
+	buildInfo := component.BuildInfo{Version: "1.0", Command: "otelcontribcol"}
+	c := newTestCollectorConsumer(buildInfo)
+	c.ConsumeTag("task_arn:arn:aws:ecs:us-east-1:123:task/cluster/abc")
+
+	c.addRuntimeTelemetryMetric("", nil)
+
+	var names []string
+	for _, s := range c.series {
+		names = append(names, s.Name)
+	}
+	assert.ElementsMatch(t, []string{"otel.datadog_exporter.metrics.running.fargate"}, names)
+}
+
+func TestAddRuntimeTelemetryMetric_HostAndFargate(t *testing.T) {
+	buildInfo := component.BuildInfo{Version: "1.0", Command: "otelcontribcol"}
+	c := newTestCollectorConsumer(buildInfo)
+	c.ConsumeHost("my-hostname")
+	c.ConsumeTag("task_arn:arn:aws:ecs:us-east-1:123:task/cluster/abc")
+
+	c.addRuntimeTelemetryMetric("", nil)
+
+	metricsByName := make(map[string][]string) // name → hosts
+	for _, s := range c.series {
+		metricsByName[s.Name] = append(metricsByName[s.Name], s.Host)
+	}
+	assert.ElementsMatch(t, metricsByName["otel.datadog_exporter.metrics.running"], []string{"my-hostname"})
+	assert.ElementsMatch(t, metricsByName["otel.datadog_exporter.metrics.running.fargate"], []string{""})
+	assert.Len(t, c.series, 2)
 }

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/consumer_collector_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/consumer_collector_test.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package serializerexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
+)
+
+func newTestCollectorConsumer(buildInfo component.BuildInfo) *collectorConsumer {
+	s := &serializerConsumer{ipath: ossCollector}
+	return &collectorConsumer{
+		serializerConsumer: s,
+		seenHosts:          make(map[string]struct{}),
+		seenTags:           make(map[string]struct{}),
+		buildInfo:          buildInfo,
+		getPushTime:        func() uint64 { return uint64(2e9) },
+	}
+}
+
+func TestExporterFargateMetrics(t *testing.T) {
+	tags := []string{"version:1.0", "command:otelcontribcol"}
+	serie := exporterFargateMetrics(uint64(2e9), tags)
+
+	assert.Equal(t, "otel.datadog_exporter.metrics.running.fargate", serie.Name)
+	assert.Equal(t, 1, len(serie.Points))
+	assert.Equal(t, float64(2e9), serie.Points[0].Ts)
+	assert.Equal(t, 1.0, serie.Points[0].Value)
+	assert.Equal(t, "", serie.Host)
+}
+
+func TestAddRuntimeTelemetryMetric_FargateTags(t *testing.T) {
+	buildInfo := component.BuildInfo{Version: "1.0", Command: "otelcontribcol"}
+	c := newTestCollectorConsumer(buildInfo)
+	c.ConsumeTag("task_arn:arn:aws:ecs:us-east-1:123:task/cluster/abc")
+
+	c.addRuntimeTelemetryMetric("", nil)
+
+	var names []string
+	for _, s := range c.series {
+		names = append(names, s.Name)
+	}
+	assert.ElementsMatch(t, []string{"otel.datadog_exporter.metrics.running.fargate"}, names)
+}
+
+func TestAddRuntimeTelemetryMetric_NoTags(t *testing.T) {
+	buildInfo := component.BuildInfo{Version: "1.0", Command: "otelcontribcol"}
+	c := newTestCollectorConsumer(buildInfo)
+
+	c.addRuntimeTelemetryMetric("", nil)
+
+	assert.Len(t, c.series, 1)
+	assert.Equal(t, "otel.datadog_exporter.metrics.running", c.series[0].Name)
+	assert.Equal(t, "", c.series[0].Host)
+}
+
+func TestAddRuntimeTelemetryMetric_HostSource(t *testing.T) {
+	buildInfo := component.BuildInfo{Version: "1.0", Command: "otelcontribcol"}
+	c := newTestCollectorConsumer(buildInfo)
+	c.ConsumeHost("my-hostname")
+
+	c.addRuntimeTelemetryMetric("", nil)
+
+	var names []string
+	var hosts []string
+	for _, s := range c.series {
+		names = append(names, s.Name)
+		hosts = append(hosts, s.Host)
+	}
+	// host path emits metrics.running with hostname, plus the baseline tagless metric
+	assert.Contains(t, names, "otel.datadog_exporter.metrics.running")
+	assert.Contains(t, hosts, "my-hostname")
+}

--- a/releasenotes/notes/split-fargate-running-metric-ac292f8c2dedb0e0.yaml
+++ b/releasenotes/notes/split-fargate-running-metric-ac292f8c2dedb0e0.yaml
@@ -9,4 +9,4 @@
 enhancements:
   - |
     The OTel Datadog exporter will now emit ``otel.datadog_exporter.metrics.running.fargate{task_arn}`` for AWS ECS Fargate workloads so that each workload has its own metric.
-    Host-based workloads continue to use ``otel.datadog_exporter.metrics.running{host} unchanged.``
+    Host-based workloads continue to use ``otel.datadog_exporter.metrics.running{host}`` unchanged.

--- a/releasenotes/notes/split-fargate-running-metric-ac292f8c2dedb0e0.yaml
+++ b/releasenotes/notes/split-fargate-running-metric-ac292f8c2dedb0e0.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The OTel Datadog exporter will now emit ``otel.datadog_exporter.metrics.running.fargate{task_arn}`` for AWS ECS Fargate workloads so that each workload has its own metric.
+    Host-based workloads continue to use ``otel.datadog_exporter.metrics.running{host} unchanged.``


### PR DESCRIPTION
### What does this PR do?
Currently, `otel.datadog_exporter.metrics.running` is emitted for both host-based and Fargate workloads. This PR splits the Fargate case into a separate metric `otel.datadog_exporter.metrics.running.fargate`, tagged with `task_arn`, so that each workload type has its own metric. Host-based workloads continue to use `otel.datadog_exporter.metrics.running{host}` unchanged. [A PR has been made in the Datadog exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49042), but as the `metricexportserializerclient` feature gate is on by default, this updates the `serializeexporterpath`.

### Motivation
https://datadoghq.atlassian.net/browse/SVLS-9246

### Describe how you validated your changes
Unit tests were added to ensure that Fargate emits the new metric name and host sources emit the pre-existing metric with hostname.