### PR TITLE
 nccl: use Distribution instead of Gauge for collective perf metrics

### DIFF
--- a/pkg/collector/corechecks/gpu/nccl/check.go
+++ b/pkg/collector/corechecks/gpu/nccl/check.go
@@ -236,25 +236,29 @@ func (c *Check) processEvent(snd sender.Sender, parsed ParsedEvent) error {
 		tags = append(tags, "timing_source:"+perf.TimingSource)
 	}
 
-	// Emit metrics
-	// Execution time (the key metric for straggler detection)
-	snd.Gauge(ncclMetricsNs+"collective.exec_time_us", perf.ExecTimeUS, "", tags)
+	// Emit metrics as Distribution (DDSketch) so the agent computes
+	// min/max/avg/p50/p95/p99 server-side across all events in the flush window.
+	// Gauge would collapse 570 events/s to a single last-write-wins value, losing
+	// straggler signal. Distribution preserves the tail latency.
+	// Note: hang-detection staleness (seconds_since_last_event) stays as Gauge —
+	// it is a point-in-time rank-health signal, not a distribution of samples.
+	snd.Distribution(ncclMetricsNs+"collective.exec_time_us", perf.ExecTimeUS, "", tags)
 	c.checkTelemetry.metricsSent.Inc("exec_time_us")
 
 	// Bandwidth metrics
 	if perf.AlgoBandwidthGB > 0 {
-		snd.Gauge(ncclMetricsNs+"collective.algo_bandwidth_gbps", perf.AlgoBandwidthGB, "", tags)
+		snd.Distribution(ncclMetricsNs+"collective.algo_bandwidth_gbps", perf.AlgoBandwidthGB, "", tags)
 		c.checkTelemetry.metricsSent.Inc("algo_bandwidth_gbps")
 	}
 
 	if perf.BusBandwidthGB > 0 {
-		snd.Gauge(ncclMetricsNs+"collective.bus_bandwidth_gbps", perf.BusBandwidthGB, "", tags)
+		snd.Distribution(ncclMetricsNs+"collective.bus_bandwidth_gbps", perf.BusBandwidthGB, "", tags)
 		c.checkTelemetry.metricsSent.Inc("bus_bandwidth_gbps")
 	}
 
 	// Message size
 	if perf.MsgSizeBytes > 0 {
-		snd.Gauge(ncclMetricsNs+"collective.msg_size_bytes", float64(perf.MsgSizeBytes), "", tags)
+		snd.Distribution(ncclMetricsNs+"collective.msg_size_bytes", float64(perf.MsgSizeBytes), "", tags)
 		c.checkTelemetry.metricsSent.Inc("msg_size_bytes")
 	}
 

--- a/pkg/collector/corechecks/gpu/nccl/check_test.go
+++ b/pkg/collector/corechecks/gpu/nccl/check_test.go
@@ -249,3 +249,42 @@ func TestParseEventWithoutExtraTags(t *testing.T) {
 	assert.Nil(t, event.ExtraTags)
 	assert.Equal(t, 0, event.Rank)
 }
+
+func TestProcessEventUsesDistribution(t *testing.T) {
+	// Collective perf metrics must be submitted as Distribution (DDSketch), not
+	// Gauge. Gauge collapses 570 events/s to last-write-wins, losing straggler
+	// signal. Distribution preserves min/max/p95/p99 across all events in the
+	// flush window. Hang-detection staleness stays as Gauge (point-in-time).
+	snd := new(mocksender.MockSender)
+	snd.On("Distribution", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+	c := &Check{}
+	parsed := ParsedEvent{
+		Event: NCCLInspectorEvent{
+			Rank:   0,
+			PID:    42,
+			NRanks: 2,
+			CollPerf: &CollectivePerf{
+				Collective:      "AllReduce",
+				ExecTimeUS:      4438.0,
+				AlgoBandwidthGB: 189.2,
+				BusBandwidthGB:  94.6,
+				MsgSizeBytes:    4194304,
+			},
+		},
+	}
+
+	err := c.processEvent(snd, parsed)
+	require.NoError(t, err)
+
+	snd.AssertMetricTaggedWith(t, "Distribution", ncclMetricsNs+"collective.exec_time_us",
+		[]string{"rank:0", "collective:AllReduce"})
+	snd.AssertMetricTaggedWith(t, "Distribution", ncclMetricsNs+"collective.algo_bandwidth_gbps",
+		[]string{"rank:0", "collective:AllReduce"})
+	snd.AssertMetricTaggedWith(t, "Distribution", ncclMetricsNs+"collective.bus_bandwidth_gbps",
+		[]string{"rank:0", "collective:AllReduce"})
+	snd.AssertMetricTaggedWith(t, "Distribution", ncclMetricsNs+"collective.msg_size_bytes",
+		[]string{"rank:0", "collective:AllReduce"})
+	snd.AssertNotCalled(t, "Gauge", ncclMetricsNs+"collective.exec_time_us",
+		mock.Anything, mock.Anything, mock.Anything)
+}

--- a/pkg/collector/corechecks/gpu/nccl/check_test.go
+++ b/pkg/collector/corechecks/gpu/nccl/check_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 )
 
 func TestProcessEventCreatesCorrectTags(t *testing.T) {
@@ -258,7 +260,9 @@ func TestProcessEventUsesDistribution(t *testing.T) {
 	snd := new(mocksender.MockSender)
 	snd.On("Distribution", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 
-	c := &Check{}
+	c := &Check{
+		checkTelemetry: newCheckTelemetry(telemetryimpl.NewMockComponent()),
+	}
 	parsed := ParsedEvent{
 		Event: NCCLInspectorEvent{
 			Rank:   0,


### PR DESCRIPTION
###  What does this PR do?

Switches the four collective performance metrics emitted by the NCCL check (exec_time_us, algo_bandwidth_gbps, bus_bandwidth_gbps, msg_size_bytes) from Gauge to Distribution (DDSketch). 

 ### Motivation
Gauge uses last-write-wins semantics within the agent's flush window (~15s). At typical training rates (~30ms/collective), ~500 events arrive per tagset per flush. A straggler event — a collective that ran 10× slower than normal — can be silently overwritten by subsequent normal events before the flush completes, making straggler detection non-deterministic.

Distribution accumulates all samples in the flush window and computes min/max/avg/p50/p95/p99 server-side via DDSketch, so every straggler event contributes to the reported tail latency. This is the semantic the straggler detection use case requires.

### Describe how you validated your changes

