### PR TITLE
Mark pkg/serverless/trace.TestStartEnabledTrueValidConfigValidPath as flaky

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -18,6 +18,10 @@
 # * Note:
 # If you mute a parent test it will ignore all the subtests as well.
 
+# TODO: https://datadoghq.atlassian.net/browse/SVLS-4500
+"pkg/serverless/trace":
+  - test: TestStartEnabledTrueValidConfigValidPath
+
 # TODO: https://datadoghq.atlassian.net/browse/CONTINT-4143
 test/new-e2e/tests/containers:
   - test: TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}


### PR DESCRIPTION
## Summary
- `TestStartEnabledTrueValidConfigValidPath` starts a real trace agent via `go ta.Run()` which races on arm64: the goroutine can panic before test assertions run, killing the test binary with no stack trace or race detector output surfaced in CI
- Adds the test to `flakes.yaml` to suppress CI noise while the proper fix (a `started` signal on `pkg/trace/agent/Agent`) is tracked under [SVLS-4500](https://datadoghq.atlassian.net/browse/SVLS-4500)

## Test plan
- [ ] CI passes with the flake marker applied

[SVLS-4500]: https://datadoghq.atlassian.net/browse/SVLS-4500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ