### PR TITLE
[CONTP-1744] enhance(worloadfilter): Share CEL env programs to reduce per rule overhead

### DIFF
--- a/comp/core/workloadfilter/def/types.go
+++ b/comp/core/workloadfilter/def/types.go
@@ -71,6 +71,42 @@ func (rt ResourceType) ToSingular() ResourceType {
 	return rt
 }
 
+// ToProtoMessage converts a resource type to its equivalent proto message.
+func (rt ResourceType) ToProtoMessage() proto.Message {
+	switch rt {
+	case ContainerType:
+		return &Container{}
+	case PodType:
+		return &Pod{}
+	case KubeServiceType:
+		return &KubeService{}
+	case KubeEndpointType:
+		return &KubeEndpoint{}
+	case ProcessType:
+		return &Process{}
+	default:
+		return nil
+	}
+}
+
+// ToProtoTypeString converts the resource type to its corresponding proto type string.
+func (rt ResourceType) ToProtoTypeString() string {
+	switch rt {
+	case ContainerType:
+		return "datadog.workloadfilter.FilterContainer"
+	case PodType:
+		return "datadog.workloadfilter.FilterPod"
+	case KubeServiceType:
+		return "datadog.workloadfilter.FilterKubeService"
+	case KubeEndpointType:
+		return "datadog.workloadfilter.FilterKubeEndpoint"
+	case ProcessType:
+		return "datadog.workloadfilter.FilterProcess"
+	default:
+		return ""
+	}
+}
+
 // GetAllResourceTypes returns all defined resource types.
 func GetAllResourceTypes() []ResourceType {
 	return []ResourceType{

--- a/comp/core/workloadfilter/util/celprogram/BUILD.bazel
+++ b/comp/core/workloadfilter/util/celprogram/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/workloadfilter/def",
+        "//pkg/util/cache",
         "@com_github_google_cel_go//cel:go_default_library",
     ],
 )

--- a/comp/core/workloadfilter/util/celprogram/create.go
+++ b/comp/core/workloadfilter/util/celprogram/create.go
@@ -7,10 +7,9 @@
 package celprogram
 
 import (
-	"github.com/google/cel-go/cel"
-
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/google/cel-go/cel"
 )
 
 // getEnv returns a reusable CEL environment for the given object type, building it once and storing
@@ -19,8 +18,8 @@ func getEnv(objectType workloadfilter.ResourceType) (*cel.Env, error) {
 	key := cache.BuildAgentKey("workloadfilter", "celprogram", "env", string(objectType))
 	return cache.Get[*cel.Env](key, func() (*cel.Env, error) {
 		return cel.NewEnv(
-			cel.Types(&workloadfilter.Container{}, &workloadfilter.Pod{}, &workloadfilter.KubeService{}, &workloadfilter.KubeEndpoint{}, &workloadfilter.Process{}),
-			cel.Variable(string(objectType), cel.ObjectType(convertTypeToProtoType(objectType))),
+			cel.Types(objectType.ToProtoMessage()),
+			cel.Variable(string(objectType), cel.ObjectType(objectType.ToProtoTypeString())),
 		)
 	})
 }
@@ -43,22 +42,4 @@ func CreateCELProgram(rules string, objectType workloadfilter.ResourceType) (cel
 		return nil, err
 	}
 	return prg, nil
-}
-
-// convertTypeToProtoType converts a filter.ResourceType to its corresponding proto type string.
-func convertTypeToProtoType(key workloadfilter.ResourceType) string {
-	switch key {
-	case workloadfilter.ContainerType:
-		return "datadog.workloadfilter.FilterContainer"
-	case workloadfilter.PodType:
-		return "datadog.workloadfilter.FilterPod"
-	case workloadfilter.KubeServiceType:
-		return "datadog.workloadfilter.FilterKubeService"
-	case workloadfilter.KubeEndpointType:
-		return "datadog.workloadfilter.FilterKubeEndpoint"
-	case workloadfilter.ProcessType:
-		return "datadog.workloadfilter.FilterProcess"
-	default:
-		return ""
-	}
 }

--- a/comp/core/workloadfilter/util/celprogram/create.go
+++ b/comp/core/workloadfilter/util/celprogram/create.go
@@ -10,17 +10,27 @@ import (
 	"github.com/google/cel-go/cel"
 
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 )
+
+// getEnv returns a reusable CEL environment for the given object type, building it once and storing
+// it in the global in-memory cache (no expiration) so it is shared by every program.
+func getEnv(objectType workloadfilter.ResourceType) (*cel.Env, error) {
+	key := cache.BuildAgentKey("workloadfilter", "celprogram", "env", string(objectType))
+	return cache.Get[*cel.Env](key, func() (*cel.Env, error) {
+		return cel.NewEnv(
+			cel.Types(&workloadfilter.Container{}, &workloadfilter.Pod{}, &workloadfilter.KubeService{}, &workloadfilter.KubeEndpoint{}, &workloadfilter.Process{}),
+			cel.Variable(string(objectType), cel.ObjectType(convertTypeToProtoType(objectType))),
+		)
+	})
+}
 
 // CreateCELProgram creates a CEL program from the given rules and object type.
 func CreateCELProgram(rules string, objectType workloadfilter.ResourceType) (cel.Program, error) {
 	if rules == "" {
 		return nil, nil
 	}
-	env, err := cel.NewEnv(
-		cel.Types(&workloadfilter.Container{}, &workloadfilter.Pod{}, &workloadfilter.KubeService{}, &workloadfilter.KubeEndpoint{}, &workloadfilter.Process{}),
-		cel.Variable(string(objectType), cel.ObjectType(convertTypeToProtoType(objectType))),
-	)
+	env, err := getEnv(objectType)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

Cache and share CEL environments across multiple programs instead of building one for each program.

At 4000 CEL rules, the agent saw **160Mib** of memory to hold all CEL configs. After this change, memory attributed to CEL sat at 30 Mib.

### Motivation

Every `integration.Config` with a CEL selector compiled its program against a freshly built `cel.Env`, and since each compiled program holds the env's type in memory, heap grew linearly with the number of configs. Sharing one env per resource type instead removes that per-config duplication.

### Describe how you validated your changes

- CI passes ✅ 
- Checked memory profile

**Before:** ~2000 CEL programs
<img width="1032" height="504" alt="Screenshot 2026-06-15 at 11 00 27 AM" src="https://github.com/user-attachments/assets/6ab88adf-42d3-426a-ad7c-1f55c3deffb0" />

**After:** ~2000 CEL programs
<img width="1261" height="520" alt="Screenshot 2026-06-15 at 11 01 17 AM" src="https://github.com/user-attachments/assets/a104a5c8-a29a-4ace-bfd3-29e8cff1c21a" />

### Additional Notes
