### PR TITLE
[#incident-56171] Fix serverless trace agent startup race

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -18,10 +18,6 @@
 # * Note:
 # If you mute a parent test it will ignore all the subtests as well.
 
-# TODO: https://datadoghq.atlassian.net/browse/SVLS-4500
-"pkg/serverless/trace":
-  - test: TestStartEnabledTrueValidConfigValidPath
-
 # TODO: https://datadoghq.atlassian.net/browse/CONTINT-4143
 test/new-e2e/tests/containers:
   - test: TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -122,11 +122,11 @@ func StartServerlessTraceAgent(args StartServerlessTraceAgentArgs) ServerlessTra
 		if confErr != nil {
 			log.Errorf("Unable to load trace agent config: %s", confErr)
 		} else {
-			context, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(context.Background())
 			tc.Hostname = ""
 			tc.SynchronousFlushing = true
 			tc.AdditionalProfileTags = args.AdditionalProfileTags
-			ta := agent.NewAgent(context, tc, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, zstd.NewComponent())
+			ta := agent.NewAgent(ctx, tc, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, zstd.NewComponent())
 
 			// Check if trace stats should be disabled for serverless
 			if disabled, _ := strconv.ParseBool(os.Getenv(disableTraceStatsEnvVar)); disabled {
@@ -142,6 +142,11 @@ func StartServerlessTraceAgent(args StartServerlessTraceAgentArgs) ServerlessTra
 			ta.DiscardSpan = filterSpan
 			startTraceAgentConfigEndpoint(args.RCService, tc)
 			go ta.Run()
+			if err := ta.WaitForStarted(ctx); err != nil {
+				log.Errorf("Trace agent failed to start: %v", err)
+				cancel()
+				return noopTraceAgent{}
+			}
 			return &serverlessTraceAgent{
 				ta:     ta,
 				cancel: cancel,

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -8,6 +8,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -162,6 +163,10 @@ type Agent struct {
 	// Used to synchronize on a clean exit
 	ctx context.Context
 
+	// started is closed when Run() has initialized all components, allowing
+	// callers to wait for the agent to be ready to process traces.
+	started chan struct{}
+
 	// stopped is closed when Run() returns, allowing callers to wait for
 	// the agent's full shutdown sequence to complete.
 	stopped chan struct{}
@@ -215,6 +220,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig, telemetryCollector 
 		InV1:                  inV1,
 		conf:                  conf,
 		ctx:                   ctx,
+		started:               make(chan struct{}),
 		stopped:               make(chan struct{}),
 		DebugServer:           api.NewDebugServer(conf),
 		Statsd:                statsd,
@@ -249,6 +255,7 @@ func (a *Agent) Run() {
 		starter.Start()
 	}
 
+	close(a.started)
 	go a.StatsWriter.Run()
 
 	// Having GOMAXPROCS processor threads is
@@ -290,6 +297,20 @@ func (a *Agent) FlushSync() {
 	if err := a.TraceWriterV1.FlushSync(); err != nil {
 		log.Errorf("Error flushing traces v1: %s", err.Error())
 		return
+	}
+}
+
+// WaitForStarted blocks until the agent's Run() method has finished initializing
+// all components and is ready to process traces. It returns an error if the agent
+// stopped before completing startup, or the context's error if ctx is done first.
+func (a *Agent) WaitForStarted(ctx context.Context) error {
+	select {
+	case <-a.started:
+		return nil
+	case <-a.stopped:
+		return errors.New("stopped before completing startup")
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
Add `Agent.started` (a `chan struct{}` closed after all starters complete in `Run()`) and `Agent.WaitForStarted(ctx)` to `pkg/trace/agent`.

`StartServerlessTraceAgent` now waits for that signal before returning.

This allows to remove `TestStartEnabledTrueValidConfigValidPath` from `flakes.yaml`.

### Motivation
`TestStartEnabledTrueValidConfigValidPath` was consistently failing with status `(unknown)` on CI macOS ARM64 (PR #52206 added it to `flakes.yaml` as a workaround), see for instance:
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1769361294#L2339

The root cause is a race: `go ta.Run()` was launched and `StartServerlessTraceAgent` returned immediately, giving the goroutine time to crash the binary (via `killProcess` -> `os.Exit(1)` on a failed TCP bind) before the test could record a result.
Waiting for the `started` signal ensures callers receive a fully initialized agent, and `defer agent.Stop()` then cancels the context before any crash-prone code path is reached.

The `WaitForStarted` select also covers `a.stopped` so that a premature exit (before all starters complete) surfaces as an error rather than a hang.

### Describe how you validated your changes
`dda inv test --targets=./pkg/serverless/trace/...,./pkg/trace/agent/...` passes (374 tests, 3 skipped).

### Additional Notes
Closes [SVLS-4500].

[SVLS-4500]: https://datadoghq.atlassian.net/browse/SVLS-4500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ