### PR TITLE
[#incident-56171] Disable TCP receiver in serverless trace agent tests

### DIFF
--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -10,7 +10,6 @@ package trace
 import (
 	"errors"
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,14 +18,12 @@ import (
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
-	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
 )
 
 func setupTraceAgentTest(t *testing.T) {
-	// ensure a free port is used for starting the trace agent
-	if port, err := testutil.FindTCPPort(); err == nil {
-		t.Setenv("DD_RECEIVER_PORT", strconv.Itoa(port))
-	}
+	// Disable TCP: tests don't submit traces over HTTP, and `FindTCPPort` caused a TOCTOU race.
+	t.Setenv("DD_RECEIVER_PORT", "0")
+	configmock.New(t) // fresh config so BuildSchema picks up DD_RECEIVER_PORT=0
 }
 
 type LoadConfigMocked struct {


### PR DESCRIPTION
### What does this PR do?
Replace `FindTCPPort` + `DD_RECEIVER_PORT=<port>` with `DD_RECEIVER_PORT=0` in `setupTraceAgentTest`, and add `configmock.New(t)` so the environment var is picked up by the config.

### Motivation
`FindTCPPort` opens a TCP listener to obtain a free port then closes it.
Between that close and the moment `Receiver.Start()` binds the same port, another process can grab it (TOCTOU).
When the bind fails, `killProcess` calls `os.Exit(1)`, which kills the test binary and yields the `(unknown)` status seen consistently on fresh macOS ARM64 CI runners.

But **tests in this file do not submit traces over HTTP** and do not need it:
1. set `DD_RECEIVER_PORT=0` to make `Receiver.Start()` return early before any bind attempt,
2. add `configmock.New(t)` to create a fresh config with `allowDynamicSchema=true`, so `BuildSchema` runs after `t.Setenv` and picks up `DD_RECEIVER_PORT=0`.

### Describe how you validated your changes
`dda inv test --targets=./pkg/serverless/trace/`

### Additional Notes
The `strconv` and `pkg/trace/testutil` imports are now unused and were removed.