### PR TITLE
trace: propagate HTTPReceiver.Start errors instead of os.Exit

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -237,7 +237,6 @@ func (a *Agent) Run() {
 	defer a.Timing.Stop()
 	for _, starter := range []interface{ Start() }{
 		a.ContainerTagsBuffer,
-		a.Receiver,
 		a.Concentrator,
 		a.ClientStatsAggregator,
 		a.SamplerMetrics,
@@ -247,6 +246,11 @@ func (a *Agent) Run() {
 		a.DebugServer,
 	} {
 		starter.Start()
+	}
+	a.Receiver.Start()
+	if err := a.Receiver.StartErr(); err != nil {
+		log.Errorf("HTTP receiver failed to start: %v", err)
+		return
 	}
 
 	go a.StatsWriter.Run()

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -153,7 +153,11 @@ type HTTPReceiver struct {
 	timing   timing.Reporter
 	info     *watchdog.CurrentInfo
 	Handlers map[string]http.Handler
+	startErr error
 }
+
+// StartErr returns the error recorded by Start, if any. Safe to call after Start returns.
+func (r *HTTPReceiver) StartErr() error { return r.startErr }
 
 // NewHTTPReceiver returns a pointer to a new HTTPReceiver
 func NewHTTPReceiver(
@@ -354,7 +358,9 @@ func (r *HTTPReceiver) Start() {
 
 		if err != nil {
 			r.telemetryCollector.SendStartupError(telemetry.CantStartHttpServer, err)
-			killProcess("Error creating tcp listener: %v", err)
+			log.Criticalf("Error creating tcp listener: %v", err)
+			r.startErr = err
+			return
 		}
 		go func() {
 			defer watchdog.LogOnPanic(r.statsd)
@@ -415,7 +421,9 @@ func (r *HTTPReceiver) Start() {
 		ln, err := listenPipe(pipepath, secdec, bufferSize, r.conf.MaxConnections, r.statsd)
 		if err != nil {
 			r.telemetryCollector.SendStartupError(telemetry.CantStartWindowsPipeServer, err)
-			killProcess("Error creating %q named pipe: %v", pipepath, err)
+			log.Criticalf("Error creating %q named pipe: %v", pipepath, err)
+			r.startErr = err
+			return
 		}
 		go func() {
 			defer watchdog.LogOnPanic(r.statsd)


### PR DESCRIPTION
### What does this PR do?

`HTTPReceiver.Start` calls `killProcess` (i.e. `os.Exit(1)`) on TCP-listener and Windows-pipe bind failures. `os.Exit` bypasses all deferred functions, including `defer close(a.stopped)` in `Agent.Run()`, crashing the test binary with no stack trace or race detector output in CI.

Replace both `killProcess` calls with `log.Criticalf` + a new `startErr` field. Pull `a.Receiver.Start()` out of the generic starters loop in `Agent.Run()`, check `StartErr()` immediately, and return early on failure so the defer fires and the process exits cleanly.

### Motivation

`pkg/serverless/trace.TestStartEnabledTrueValidConfigValidPath` intermittently crashed the test binary on macOS ARM64 CI (incident #56171) due to a TOCTOU race on the receiver port. The `os.Exit` path suppressed all diagnostics, producing `(unknown)` duration in gotestsum with no actionable output.

### Describe how you validated your changes

`dda inv test` on `./pkg/trace/api/...`, `./pkg/trace/agent/...`, and `./pkg/serverless/trace/...` — 1021 tests, all pass.

### Additional Notes

The third `killProcess` call site (OOM watchdog) is intentionally left unchanged — OOM is not recoverable.