### PR TITLE
[#incident-56171] Ensure `DD_RECEIVER_PORT` is picked up by config

### DIFF
--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -14,9 +14,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
@@ -24,9 +26,11 @@ import (
 
 func setupTraceAgentTest(t *testing.T) {
 	// ensure a free port is used for starting the trace agent
-	if port, err := testutil.FindTCPPort(); err == nil {
-		t.Setenv("DD_RECEIVER_PORT", strconv.Itoa(port))
-	}
+	port, err := testutil.FindTCPPort()
+	require.NoError(t, err)
+	t.Setenv("DD_RECEIVER_PORT", strconv.Itoa(port))
+	configmock.New(t) // fresh config so BuildSchema picks it up
+	require.Equal(t, port, pkgconfigsetup.Datadog().GetInt("apm_config.receiver_port"))
 }
 
 type LoadConfigMocked struct {


### PR DESCRIPTION
### What does this PR do?
Add `configmock.New(t)` to `setupTraceAgentTest`.
This is a targeted fix to unblock CI wrt #[incident-56171](https://dd.enterprise.slack.com/archives/C0BA4MSCZ1D).

### Motivation
The ntm config model freezes its env-var layer when `BuildSchema` is called at `init()` time, before any test runs.
`t.Setenv` therefore has **no effect** on the original global config: `apm_config.receiver_port` stays at its default (8126) regardless of the `DD_RECEIVER_PORT` env var set by the test.

Port 8126 is in use on macOS ARM64 CI runners, causing `Receiver.Start()` to call `killProcess` -> `os.Exit(1)`, which kills the test binary and yields the `(unknown)` status for `TestStartEnabledTrueValidConfigValidPath`.

`configmock.New(t)` replaces the global config with a fresh instance that has `allowDynamicSchema=true`, so `BuildSchema` runs after `t.Setenv` and picks up `DD_RECEIVER_PORT` correctly.

### Describe how you validated your changes
`dda inv test --targets=./pkg/serverless/trace/`