### PR TITLE
do: fix unschedule when unrelated check exists in the same config

### DIFF
--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -16,12 +16,32 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// activeConfigEntry stores the scheduled check config alongside the base postgres config
-// metadata and parsed instance, so that disabling can restore the original config.
+// A "base config" is a postgres integration.Config emitted by another provider (typically the
+// file provider reading conf.d/postgres.d/conf.yaml) that a DO query action matched against via
+// findPostgresConfig — i.e. the config as it exists before DO touches it. A single base config
+// can bundle several postgres instances. Throughout this file, "base config" always refers to
+// this original, provider-emitted config, as distinct from the DO check config or remainder
+// config that this component derives from it.
+
+// activeConfigEntry stores the scheduled DO check config alongside the base postgres config it
+// was derived from and the host it targets, so reconcileBases can rebuild the set of postgres
+// instances that should keep running independently of any single DO config.
 type activeConfigEntry struct {
 	checkConfig integration.Config
-	baseCfg     *integration.Config // the original matched postgres config for restoration
-	instance    map[string]any      // full parsed postgres instance for rebuilding
+	baseCfg     *integration.Config // the original matched postgres config (full, all instances)
+	matchHost   string              // host this DO config targets (DBIdentifier.Host)
+}
+
+// managedBaseEntry tracks a base postgres config that has at least one instance targeted by a
+// DO query action. A DO query action only injects data_observability.queries into the targeted
+// instance — every other field, and every other instance, is unchanged. But autodiscovery
+// schedules whole configs (by digest), not single instances, so we cannot patch one instance in
+// place: we unschedule the base config and schedule the targeted instance (with queries) plus a
+// "remainder" config holding the base config's other instances verbatim. The original base config
+// is retained here so it can be restored once no DO query action targets any of its instances.
+type managedBaseEntry struct {
+	original  integration.Config  // the full original base config, for restoration
+	remainder *integration.Config // remainder config currently scheduled, or nil if none
 }
 
 // isSupportedIntegration reports whether name is a supported DB integration.
@@ -69,7 +89,7 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 
 		// Empty queries list signals all queries for this config should be removed
 		if len(payload.Queries) == 0 {
-			c.collectDisable(configID, &changes)
+			c.removeActiveConfig(configID, &changes)
 			applyStatus(path, state.ApplyStatus{State: state.ApplyStateAcknowledged})
 			continue
 		}
@@ -93,7 +113,7 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 		if err != nil {
 			c.log.Warnf("No matching postgres config for %s: %v", configID, err)
 			applyStatus(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
-			c.collectDisable(configID, &changes)
+			c.removeActiveConfig(configID, &changes)
 			continue
 		}
 
@@ -106,21 +126,18 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 		if err != nil {
 			c.log.Errorf("Failed to build check config for %s: %v", configID, err)
 			applyStatus(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
-			c.collectDisable(configID, &changes)
+			c.removeActiveConfig(configID, &changes)
 			continue
 		}
 
 		// Remove previous DO config version if this config_id was already active.
 		c.removeActiveConfig(configID, &changes)
-		// Unschedule the base file-provider config to prevent duplicate check execution.
-		// No-op in autodiscovery if the base config was already unscheduled by a prior update.
-		changes.Unschedule = append(changes.Unschedule, *baseCfg)
 
 		c.activeConfigsMu.Lock()
 		c.activeConfigs[configID] = activeConfigEntry{
 			checkConfig: checkConfig,
 			baseCfg:     baseCfg,
-			instance:    instance,
+			matchHost:   payload.DBIdentifier.Host,
 		}
 		c.activeConfigsMu.Unlock()
 		changes.Schedule = append(changes.Schedule, checkConfig)
@@ -140,15 +157,20 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 
 	for _, configID := range toUnschedule {
 		c.log.Infof("Config %s absent from RC snapshot, disabling", configID)
-		c.collectDisable(configID, &changes)
+		c.removeActiveConfig(configID, &changes)
 	}
+
+	// Reconcile base postgres configs: schedule remainder configs for partially-managed bases
+	// and restore originals for bases no longer targeted by any DO config.
+	c.reconcileBases(&changes)
 
 	return changes
 }
 
-// removeActiveConfig removes a config from activeConfigs and adds the previous DO check
-// config to changes.Unschedule. Used before scheduling an updated DO config (where the
-// base config should NOT be restored). It is a no-op if configID is not currently active.
+// removeActiveConfig removes a DO config from activeConfigs and adds its check config to
+// changes.Unschedule. It does NOT touch the base config — base-config lifecycle (restoring
+// the original file-provider config or its remainder) is owned by reconcileBases, which runs
+// after all activeConfigs mutations for an update. No-op if configID is not currently active.
 func (c *component) removeActiveConfig(configID string, changes *integration.ConfigChanges) {
 	c.activeConfigsMu.Lock()
 	prev, existed := c.activeConfigs[configID]
@@ -164,24 +186,112 @@ func (c *component) removeActiveConfig(configID string, changes *integration.Con
 	changes.Unschedule = append(changes.Unschedule, prev.checkConfig)
 }
 
-// collectDisable removes a config from activeConfigs, unschedules the DO check config,
-// and re-schedules the original base postgres config to restore normal check behavior.
-// It is a no-op if configID is not currently active.
-func (c *component) collectDisable(configID string, changes *integration.ConfigChanges) {
+// reconcileBases keeps file-provider postgres instances that are NOT targeted by a DO query
+// action scheduled, while preventing the targeted instances from running twice.
+//
+// Autodiscovery schedules whole integration.Configs (keyed by Digest), but a single
+// file-provider postgres config can bundle several instances. When a DO config targets one of
+// them, we cannot simply unschedule the whole base config — that would drop the untargeted
+// sibling instances. Instead, for each base config that currently has at least one active DO
+// config, we unschedule the original and schedule a "remainder" config holding only the
+// instances no DO config targets. Once no DO config targets a base config, the original is
+// restored.
+//
+// The remainder is computed from the full set of active DO configs, so multiple DO configs
+// targeting different instances of the same base config never cause an instance to be both
+// kept in the remainder and run as a DO check (which would duplicate DBM collection).
+func (c *component) reconcileBases(changes *integration.ConfigChanges) {
 	c.activeConfigsMu.Lock()
-	prev, existed := c.activeConfigs[configID]
-	if existed {
-		delete(c.activeConfigs, configID)
-	}
-	c.activeConfigsMu.Unlock()
+	defer c.activeConfigsMu.Unlock()
 
-	if !existed {
-		return
+	// Group the hosts targeted by active DO configs per base config digest.
+	type baseGroup struct {
+		original integration.Config
+		hosts    map[string]bool
+	}
+	desired := make(map[string]*baseGroup)
+	for _, entry := range c.activeConfigs {
+		digest := entry.baseCfg.Digest()
+		g := desired[digest]
+		if g == nil {
+			g = &baseGroup{original: *entry.baseCfg, hosts: make(map[string]bool)}
+			desired[digest] = g
+		}
+		g.hosts[entry.matchHost] = true
 	}
 
-	changes.Unschedule = append(changes.Unschedule, prev.checkConfig)
-	changes.Schedule = append(changes.Schedule, *prev.baseCfg)
-	c.log.Infof("Disabled Data Observability query actions for config: %s", configID)
+	// Newly-managed or changed bases.
+	for digest, g := range desired {
+		remainder := buildRemainder(&g.original, g.hosts)
+		managed, exists := c.managedBases[digest]
+		if !exists {
+			// First DO config to target this base: unschedule the original, schedule the remainder.
+			changes.Unschedule = append(changes.Unschedule, g.original)
+			if remainder != nil {
+				changes.Schedule = append(changes.Schedule, *remainder)
+			}
+			c.managedBases[digest] = &managedBaseEntry{original: g.original, remainder: remainder}
+			continue
+		}
+		// Already managed (original already unscheduled). Only touch the remainder if it changed,
+		// to avoid needlessly restarting the untargeted instances.
+		if sameConfig(managed.remainder, remainder) {
+			continue
+		}
+		if managed.remainder != nil {
+			changes.Unschedule = append(changes.Unschedule, *managed.remainder)
+		}
+		if remainder != nil {
+			changes.Schedule = append(changes.Schedule, *remainder)
+		}
+		managed.remainder = remainder
+	}
+
+	// Bases no longer targeted by any DO config: unschedule the remainder, restore the original.
+	for digest, managed := range c.managedBases {
+		if _, ok := desired[digest]; ok {
+			continue
+		}
+		if managed.remainder != nil {
+			changes.Unschedule = append(changes.Unschedule, *managed.remainder)
+		}
+		changes.Schedule = append(changes.Schedule, managed.original)
+		delete(c.managedBases, digest)
+		c.log.Infof("Restored original postgres config (digest %s); no Data Observability query actions target it", digest)
+	}
+}
+
+// buildRemainder returns a copy of base containing only the instances whose host is NOT in
+// matchedHosts. Returns nil when no instances remain (every instance is DO-managed). Instances
+// whose YAML cannot be parsed are kept, so a config we cannot classify is never silently dropped.
+func buildRemainder(base *integration.Config, matchedHosts map[string]bool) *integration.Config {
+	kept := make([]integration.Data, 0, len(base.Instances))
+	for _, instanceData := range base.Instances {
+		var instance map[string]any
+		if err := yaml.Unmarshal(instanceData, &instance); err != nil {
+			kept = append(kept, instanceData)
+			continue
+		}
+		host, _ := instance["host"].(string)
+		if matchedHosts[host] {
+			continue
+		}
+		kept = append(kept, instanceData)
+	}
+	if len(kept) == 0 {
+		return nil
+	}
+	remainder := *base
+	remainder.Instances = kept
+	return &remainder
+}
+
+// sameConfig reports whether two optional configs are equivalent by autodiscovery digest.
+func sameConfig(a, b *integration.Config) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Digest() == b.Digest()
 }
 
 // findPostgresConfig finds a postgres config that matches the given identifier and has

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -45,6 +45,7 @@ func newTestComponentWithAC(t *testing.T, configs []integration.Config) *compone
 		log:           logmock.New(t),
 		ac:            newMockAutodiscovery(t, configs),
 		activeConfigs: make(map[string]activeConfigEntry),
+		managedBases:  make(map[string]*managedBaseEntry),
 	}
 }
 
@@ -280,6 +281,7 @@ func newTestComponent(t *testing.T) *component {
 	return &component{
 		log:           logmock.New(t),
 		activeConfigs: make(map[string]activeConfigEntry),
+		managedBases:  make(map[string]*managedBaseEntry),
 	}
 }
 
@@ -313,81 +315,66 @@ func TestOnRCUpdate_EmptyConfigID(t *testing.T) {
 }
 
 func TestOnRCUpdate_EmptyQueriesDisables(t *testing.T) {
-	baseCfg := &integration.Config{Name: "postgres", Provider: "file", NodeName: "node1"}
-	pgInstance := map[string]any{"host": "localhost", "dbname": "mydb", "data_observability": map[string]any{"enabled": true}}
-	existing := activeConfigEntry{
-		checkConfig: integration.Config{Name: "postgres"},
-		baseCfg:     baseCfg,
-		instance:    pgInstance,
+	postgresCfg := integration.Config{
+		Name:      "postgres",
+		Provider:  "file",
+		NodeName:  "node1",
+		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\ndata_observability:\n  enabled: true\n")},
 	}
-	c := newTestComponent(t)
-	c.activeConfigs["cfg-1"] = existing
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
 
-	updates := map[string]state.RawConfig{
-		"path/config": {Config: []byte(`{"config_id": "cfg-1", "queries": []}`)},
+	// First: schedule a DO config so the base config becomes managed.
+	enable := DOQueryPayload{
+		ConfigID:     "cfg-1",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
+		Queries:      []QuerySpec{{Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
 	}
-	statuses, changes := collectStatuses(c, updates)
+	enableJSON, err := json.Marshal(enable)
+	require.NoError(t, err)
+	collectStatuses(c, map[string]state.RawConfig{"path/config": {Config: enableJSON}})
+	require.Contains(t, c.activeConfigs, "cfg-1")
+
+	// Now: empty queries disables the DO config and the original base config must be restored.
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/config": {Config: []byte(`{"config_id": "cfg-1", "queries": []}`)},
+	})
 
 	assert.Equal(t, state.ApplyStateAcknowledged, statuses["path/config"].State)
 	assert.Empty(t, c.activeConfigs)
-	require.Len(t, changes.Unschedule, 1, "should unschedule previous DO config")
+	require.Len(t, changes.Unschedule, 1, "should unschedule the DO config")
 	require.Len(t, changes.Schedule, 1, "should re-schedule original base config")
-	assert.Equal(t, *baseCfg, changes.Schedule[0], "scheduled config should be the original base config")
+	assert.Equal(t, postgresCfg, changes.Schedule[0], "scheduled config should be the original base config")
 }
 
 func TestOnRCUpdate_ReconcileDisablesStaleConfigs(t *testing.T) {
-	baseCfg := &integration.Config{Name: "postgres", Provider: "file"}
-	pgInstance := map[string]any{"host": "localhost", "dbname": "mydb", "data_observability": map[string]any{"enabled": true}}
-	existing := activeConfigEntry{
-		checkConfig: integration.Config{Name: "postgres"},
-		baseCfg:     baseCfg,
-		instance:    pgInstance,
+	postgresCfg := integration.Config{
+		Name:      "postgres",
+		Provider:  "file",
+		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\ndata_observability:\n  enabled: true\n")},
 	}
-	c := newTestComponent(t)
-	c.activeConfigs["stale-config"] = existing
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+
+	// First: schedule a DO config so the base config becomes managed.
+	enable := DOQueryPayload{
+		ConfigID:     "stale-config",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
+		Queries:      []QuerySpec{{Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+	}
+	enableJSON, err := json.Marshal(enable)
+	require.NoError(t, err)
+	collectStatuses(c, map[string]state.RawConfig{"path/stale": {Config: enableJSON}})
+	require.Contains(t, c.activeConfigs, "stale-config")
 
 	// Update snapshot contains only a config without config_id — stale-config should be disabled
-	updates := map[string]state.RawConfig{
+	// and the original base config restored.
+	_, changes := collectStatuses(c, map[string]state.RawConfig{
 		"path/other": {Config: []byte(`{"some_field": true}`)},
-	}
-	_, changes := collectStatuses(c, updates)
+	})
 
 	assert.Empty(t, c.activeConfigs)
-	require.Len(t, changes.Unschedule, 1, "should unschedule previous DO config")
+	require.Len(t, changes.Unschedule, 1, "should unschedule the DO config")
 	require.Len(t, changes.Schedule, 1, "should re-schedule original base config")
-	assert.Equal(t, *baseCfg, changes.Schedule[0])
-}
-
-// --- collectDisable tests ---
-
-func TestCollectDisable_NotFound(t *testing.T) {
-	c := newTestComponent(t)
-	changes := integration.ConfigChanges{}
-	c.collectDisable("nonexistent", &changes)
-	assert.Empty(t, changes.Schedule)
-	assert.Empty(t, changes.Unschedule)
-	assert.Empty(t, c.activeConfigs)
-}
-
-func TestCollectDisable_Found(t *testing.T) {
-	baseCfg := &integration.Config{Name: "postgres", Provider: "file"}
-	pgInstance := map[string]any{"host": "localhost", "dbname": "mydb", "data_observability": map[string]any{"enabled": true}}
-	doCheckConfig := integration.Config{Name: "postgres", Provider: "do_query_actions"}
-	c := newTestComponent(t)
-	c.activeConfigs["my-config"] = activeConfigEntry{
-		checkConfig: doCheckConfig,
-		baseCfg:     baseCfg,
-		instance:    pgInstance,
-	}
-	changes := integration.ConfigChanges{}
-
-	c.collectDisable("my-config", &changes)
-
-	assert.Empty(t, c.activeConfigs)
-	require.Len(t, changes.Unschedule, 1, "should unschedule previous DO config")
-	assert.Equal(t, doCheckConfig, changes.Unschedule[0])
-	require.Len(t, changes.Schedule, 1, "should re-schedule original base config")
-	assert.Equal(t, *baseCfg, changes.Schedule[0])
+	assert.Equal(t, postgresCfg, changes.Schedule[0])
 }
 
 // --- removeActiveConfig tests ---
@@ -407,7 +394,7 @@ func TestRemoveActiveConfig_Found(t *testing.T) {
 	c.activeConfigs["my-config"] = activeConfigEntry{
 		checkConfig: doCheckConfig,
 		baseCfg:     baseCfg,
-		instance:    map[string]any{"host": "localhost"},
+		matchHost:   "localhost",
 	}
 	changes := integration.ConfigChanges{}
 
@@ -510,12 +497,13 @@ func TestOnRCUpdate_UpdateReplacesExistingCheck(t *testing.T) {
 	require.Len(t, changes1.Unschedule, 1, "first update should unschedule base config")
 	require.Contains(t, c.activeConfigs, "cfg-update")
 
-	// Second update: same config_id, different query. Unschedules previous DO config + base config,
-	// schedules only the new DO config.
+	// Second update: same config_id, different query. The base config is already managed
+	// (unscheduled on the first update), so only the previous DO config is unscheduled and the
+	// new one scheduled — the base config is not touched again.
 	_, changes2 := collectStatuses(c, map[string]state.RawConfig{
 		"path/cfg": {Config: mkPayload("SELECT 2")},
 	})
-	require.Len(t, changes2.Unschedule, 2, "should unschedule previous DO config + base config")
+	require.Len(t, changes2.Unschedule, 1, "should unschedule only the previous DO config")
 	require.Len(t, changes2.Schedule, 1, "should schedule only the new DO check")
 
 	var instance map[string]any
@@ -526,6 +514,137 @@ func TestOnRCUpdate_UpdateReplacesExistingCheck(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, queries, 1)
 	assert.Equal(t, "SELECT 2", queries[0].(map[string]any)["query"])
+}
+
+// hostsOf parses every instance of a config and returns the set of host values, for asserting
+// which postgres instances a scheduled config covers.
+func hostsOf(t *testing.T, cfg integration.Config) map[string]bool {
+	t.Helper()
+	hosts := make(map[string]bool, len(cfg.Instances))
+	for _, instanceData := range cfg.Instances {
+		var instance map[string]any
+		require.NoError(t, yaml.Unmarshal(instanceData, &instance))
+		host, _ := instance["host"].(string)
+		hosts[host] = true
+	}
+	return hosts
+}
+
+// findScheduledWithHost returns the scheduled config that contains an instance with the given
+// host, failing the test if none is found.
+func findScheduledWithHost(t *testing.T, changes integration.ConfigChanges, host string) integration.Config {
+	t.Helper()
+	for _, cfg := range changes.Schedule {
+		if hostsOf(t, cfg)[host] {
+			return cfg
+		}
+	}
+	t.Fatalf("no scheduled config contains host %q", host)
+	return integration.Config{}
+}
+
+// TestOnRCUpdate_PreservesUnrelatedInstances is the regression test for the bug where a
+// do-query-actions config replaced the whole file-provider postgres config, dropping sibling
+// instances. A base config with two instances (localhost + an RDS endpoint) receives a DO config
+// targeting only localhost; the RDS instance must stay scheduled, and only localhost may carry
+// the DO queries.
+func TestOnRCUpdate_PreservesUnrelatedInstances(t *testing.T) {
+	const rdsHost = "iceberg-test-postgres-demo-rds.c0lma4q6o85w.us-east-1.rds.amazonaws.com"
+	postgresCfg := integration.Config{
+		Name:     "postgres",
+		Provider: "file",
+		Instances: []integration.Data{
+			integration.Data("host: localhost\nport: 5432\ndbname: testdb\ndata_observability:\n  enabled: true\ntags:\n  - env:demo\n"),
+			integration.Data("host: " + rdsHost + "\nport: 5432\ndbname: testdb\ndata_observability:\n  enabled: true\ntags:\n  - env:rds\n"),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-local",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
+		Queries:      []QuerySpec{{Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-local": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-local"].State)
+
+	// The original two-instance base config is unscheduled.
+	require.Len(t, changes.Unschedule, 1)
+	assert.Equal(t, map[string]bool{"localhost": true, rdsHost: true}, hostsOf(t, changes.Unschedule[0]))
+
+	// Two configs scheduled: the DO check for localhost and the remainder holding the RDS instance.
+	require.Len(t, changes.Schedule, 2)
+
+	doCfg := findScheduledWithHost(t, changes, "localhost")
+	require.Len(t, doCfg.Instances, 1, "DO config should carry only the targeted localhost instance")
+	var doInstance map[string]any
+	require.NoError(t, yaml.Unmarshal(doCfg.Instances[0], &doInstance))
+	_, hasDO := doInstance["data_observability"].(map[string]any)["queries"]
+	assert.True(t, hasDO, "localhost instance should carry DO queries")
+
+	remainder := findScheduledWithHost(t, changes, rdsHost)
+	require.Len(t, remainder.Instances, 1, "remainder should hold only the untargeted RDS instance")
+	assert.Equal(t, "file", remainder.Provider, "remainder keeps the base config provider")
+	var rdsInstance map[string]any
+	require.NoError(t, yaml.Unmarshal(remainder.Instances[0], &rdsInstance))
+	assert.Equal(t, rdsHost, rdsInstance["host"])
+	_, rdsHasQueries := rdsInstance["data_observability"].(map[string]any)["queries"]
+	assert.False(t, rdsHasQueries, "RDS instance must remain a plain DBM instance with no DO queries")
+}
+
+// TestOnRCUpdate_MultipleDOConfigsSameBase verifies that two DO configs targeting two different
+// instances of the same base config never leave an instance both in the remainder and as a DO
+// check (which would double-run it). With both instances targeted, no remainder is scheduled.
+func TestOnRCUpdate_MultipleDOConfigsSameBase(t *testing.T) {
+	const rdsHost = "rds.example.com"
+	postgresCfg := integration.Config{
+		Name:     "postgres",
+		Provider: "file",
+		Instances: []integration.Data{
+			integration.Data("host: localhost\ndata_observability:\n  enabled: true\n"),
+			integration.Data("host: " + rdsHost + "\ndata_observability:\n  enabled: true\n"),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+
+	mkPayload := func(configID, host string) []byte {
+		b, err := json.Marshal(DOQueryPayload{
+			ConfigID:     configID,
+			DBIdentifier: DBIdentifier{Type: "self-hosted", Host: host},
+			Queries:      []QuerySpec{{Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+		})
+		require.NoError(t, err)
+		return b
+	}
+
+	_, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/local": {Config: mkPayload("cfg-local", "localhost")},
+		"path/rds":   {Config: mkPayload("cfg-rds", rdsHost)},
+	})
+
+	// Both instances are DO-targeted, so the base config is unscheduled and there is no remainder.
+	require.Len(t, changes.Unschedule, 1, "only the original base config is unscheduled")
+	require.Len(t, changes.Schedule, 2, "two DO checks, no remainder")
+	for _, cfg := range changes.Schedule {
+		require.Len(t, cfg.Instances, 1, "each scheduled config is a single-instance DO check")
+	}
+
+	// Disabling one DO config restores a remainder holding the still-targeted other instance.
+	_, changes2 := collectStatuses(c, map[string]state.RawConfig{
+		"path/local": {Config: mkPayload("cfg-local", "localhost")},
+		"path/rds":   {Config: []byte(`{"config_id": "cfg-rds", "queries": []}`)},
+	})
+	assert.NotContains(t, c.activeConfigs, "cfg-rds")
+	require.Contains(t, c.activeConfigs, "cfg-local")
+	remainder := findScheduledWithHost(t, changes2, rdsHost)
+	require.Len(t, remainder.Instances, 1)
+	assert.Equal(t, map[string]bool{rdsHost: true}, hostsOf(t, remainder))
 }
 
 // TestOnRCUpdate_NoMatchingPostgres_ReportsError verifies that when no postgres instance

--- a/comp/dataobs/queryactions/impl/queryactions.go
+++ b/comp/dataobs/queryactions/impl/queryactions.go
@@ -39,10 +39,16 @@ type Provides struct {
 
 // component implements the Data Observability query actions component
 type component struct {
-	log             log.Component
-	ac              autodiscovery.Component
-	rcclient        rcclient.Component
-	activeConfigs   map[string]activeConfigEntry
+	log      log.Component
+	ac       autodiscovery.Component
+	rcclient rcclient.Component
+	// activeConfigs maps a DO config_id to the DO check config currently scheduled for it.
+	activeConfigs map[string]activeConfigEntry
+	// managedBases maps a base postgres config Digest to the bookkeeping needed to restore it.
+	// A base config has an entry here while at least one DO config targets one of its instances;
+	// the entry records the original config (for restoration) and the remainder config currently
+	// scheduled in its place. See reconcileBases.
+	managedBases    map[string]*managedBaseEntry
 	activeConfigsMu sync.Mutex
 }
 
@@ -53,6 +59,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 		ac:            reqs.Ac,
 		rcclient:      reqs.RcClient,
 		activeConfigs: make(map[string]activeConfigEntry),
+		managedBases:  make(map[string]*managedBaseEntry),
 	}
 
 	reqs.Lc.Append(compdef.Hook{

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -59,6 +59,7 @@ func newStreamComponent(t *testing.T, postgresConfigs []integration.Config) (*co
 		ac:            newMockAutodiscovery(t, postgresConfigs),
 		rcclient:      rc,
 		activeConfigs: make(map[string]activeConfigEntry),
+		managedBases:  make(map[string]*managedBaseEntry),
 	}
 	return c, rc
 }


### PR DESCRIPTION
### What does this PR do?

Stops `do-query-actions` from killing other Postgres check instances on the host, if they don't have DO remote config. 

Today, when a DO query-action config comes in for one database, the provider unschedules the whole file-provider Postgres config, and since autodiscovery only schedules and unschedules whole configs (a single config can hold several instances), that takes down every instance in it, not just the one DO cares about. 

The fix splits things instead of deleting them: for a base config that a DO action targets, we unschedule the original and schedule two things in its place - the targeted instance with the queries injected, and rest of the config holding the rest of the instances untouched. 

When the DO action goes away, the original config comes back. We build the remainder from all active DO configs at once, so if two actions target two instances of the same config, nothing ends up scheduled twice.

### Motivation

If a host has several Postgres databases configured via files for DBM, all but the DO-targeted one would silently stop collecting the moment a DO query-action config showed up. 

The bug was seem when a local Postgres and an RDS instance existed side by side - as soon as a DO action targeting local Postgres arrived, the RDS instance stopped its scheduled `collect_schemas` and DBM collection, even though its config was fine and the check worked when run by hand. Targeting one database shouldn't take down an unrelated one.

### Describe how you validated your changes

Unit tests covering the above scenario, and scenario where we have two DO enabled databases with separate config, to check if nothing gets double scheduled.

I also tried it on a workspace: built the patched agent, added a second untargeted Postgres instance, and confirmed both instances were scheduled by the file provider beforehand.