### PR TITLE
fix(trace-writer): count bytes_uncompressed per sender to match bytes accounting

### DIFF
--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -123,8 +123,10 @@ func (t eventType) String() string { return eventTypeStrings[t] }
 type eventData struct {
 	// host specifies the host which the sender is sending to.
 	host string
-	// bytes represents the number of bytes affected by this event.
+	// bytes represents the number of compressed bytes affected by this event.
 	bytes int
+	// uncompressedBytes represents the number of uncompressed bytes affected by this event.
+	uncompressedBytes int
 	// count specfies the number of payloads that this events refers to.
 	count int
 	// duration specifies the time it took to complete this event. It
@@ -333,10 +335,11 @@ func (s *sender) sendOnce(p *payload) bool {
 	start := time.Now()
 	err = s.do(req)
 	stats := &eventData{
-		bytes:    p.body.Len(),
-		count:    1,
-		duration: time.Since(start),
-		err:      err,
+		bytes:             p.body.Len(),
+		uncompressedBytes: p.uncompressedSize,
+		count:             1,
+		duration:          time.Since(start),
+		err:               err,
 	}
 	if err != nil {
 		log.Tracef("Error submitting payload: %v\n", err)
@@ -491,9 +494,10 @@ func isRetriable(code int) bool {
 
 // payloads specifies a payload to be sent by the sender.
 type payload struct {
-	body    *bytes.Buffer     // request body
-	headers map[string]string // request headers
-	retries *atomic.Int32     // number of retries sending this payload
+	body             *bytes.Buffer     // request body (compressed)
+	headers          map[string]string // request headers
+	retries          *atomic.Int32     // number of retries sending this payload
+	uncompressedSize int               // size of the payload before compression
 }
 
 // ppool is a pool of payloads.
@@ -514,6 +518,7 @@ func newPayload(headers map[string]string) *payload {
 	p.body.Reset()
 	p.headers = headers
 	p.retries.Store(0)
+	p.uncompressedSize = 0
 	return p
 }
 
@@ -524,6 +529,7 @@ func (p *payload) clone() *payload {
 	if _, err := clone.body.ReadFrom(bytes.NewBuffer(p.body.Bytes())); err != nil {
 		log.Errorf("Error cloning writer payload: %v", err)
 	}
+	clone.uncompressedSize = p.uncompressedSize
 	return clone
 }
 

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -127,7 +127,7 @@ type eventData struct {
 	bytes int
 	// uncompressedBytes represents the number of uncompressed bytes affected by this event.
 	uncompressedBytes int
-	// count specfies the number of payloads that this events refers to.
+	// count specifies the number of payloads that this event refers to.
 	count int
 	// duration specifies the time it took to complete this event. It
 	// is set for eventType{Sent,Retry,Rejected}.

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -324,12 +324,12 @@ func (w *TraceWriter) serialize(pl *pb.AgentPayload) {
 		return
 	}
 
-	w.stats.BytesUncompressed.Add(int64(len(b)))
 	p := newPayload(map[string]string{
 		"Content-Type":     "application/x-protobuf",
 		"Content-Encoding": w.compressor.Encoding(),
 		headerLanguages:    strings.Join(info.Languages(), "|"),
 	})
+	p.uncompressedSize = len(b)
 	p.body.Grow(len(b) / 2)
 	writer, err := w.compressor.NewWriter(p.body)
 	if err != nil {
@@ -378,6 +378,7 @@ func (w *TraceWriter) recordEvent(t eventType, data *eventData) {
 		log.Debugf("Flushed traces to the API; time: %s, bytes: %d", data.duration, data.bytes)
 		w.timing.Since("datadog.trace_agent.trace_writer.flush_duration", time.Now().Add(-data.duration))
 		w.stats.Bytes.Add(int64(data.bytes))
+		w.stats.BytesUncompressed.Add(int64(data.uncompressedBytes))
 		w.stats.Payloads.Inc()
 		if !w.telemetryCollector.SentFirstTrace() {
 			go w.telemetryCollector.SendFirstTrace()

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -14,7 +14,6 @@ import (
 	"runtime"
 	"sync"
 	"testing"
-	"time"
 
 	compression "github.com/DataDog/datadog-agent/comp/trace/compression/def"
 	gzip "github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip"
@@ -555,14 +554,11 @@ func TestTraceWriterInfo(t *testing.T) {
 	defer useFlushThreshold(testSpans[0].Size + testSpans[1].Size + 10)()
 	tw := NewTraceWriter(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{}, zstd.NewComponent())
 
-	time.Sleep(200 * time.Millisecond) // allow stats to be initialized
-
 	for _, ss := range testSpans {
 		tw.WriteChunks(ss)
 	}
 	err := tw.FlushSync()
 	assert.NoError(t, err)
-	time.Sleep(200 * time.Millisecond) // allow stats to be propagated in the reporter goroutine
 	// One payload flushes due to overflowing the threshold, and the second one
 	// because of the sync flush
 	assert.Equal(t, 2, srv.Accepted())
@@ -616,11 +612,9 @@ func TestTraceWriterBytesMetricsMultipleSenders(t *testing.T) {
 	}
 	defer useFlushThreshold(1)()
 	tw := NewTraceWriter(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{}, passthroughCompressor{})
-	time.Sleep(200 * time.Millisecond)
 
 	tw.WriteChunks(randomSampledSpans(20, 8))
 	require.NoError(t, tw.FlushSync())
-	time.Sleep(200 * time.Millisecond)
 
 	bytes := tw.statsLastMinute.Bytes.Load()
 	bytesUncompressed := tw.statsLastMinute.BytesUncompressed.Load()

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -574,8 +574,60 @@ func TestTraceWriterInfo(t *testing.T) {
 	assert.Equal(t, int64(2), tw.statsLastMinute.Payloads.Load())
 	assert.NotEmpty(t, tw.statsLastMinute.Bytes.Load())
 	assert.NotEmpty(t, tw.statsLastMinute.BytesUncompressed.Load())
+	assert.Less(t, tw.statsLastMinute.Bytes.Load(), tw.statsLastMinute.BytesUncompressed.Load())
 	assert.Empty(t, tw.statsLastMinute.Errors.Load())
 	assert.Empty(t, tw.statsLastMinute.Retries.Load())
+
+	tw.Stop()
+}
+
+// passthroughCompressor is a no-op compressor that writes/reads data unchanged.
+// It is used in tests to obtain a compression ratio of 1, making bytes and
+// bytes_uncompressed directly comparable.
+type passthroughCompressor struct{}
+
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }
+
+func (passthroughCompressor) NewWriter(w io.Writer) (io.WriteCloser, error) {
+	return nopWriteCloser{w}, nil
+}
+func (passthroughCompressor) NewReader(r io.Reader) (io.ReadCloser, error) {
+	return io.NopCloser(r), nil
+}
+func (passthroughCompressor) Encoding() string { return "identity" }
+
+// TestTraceWriterBytesMetricsMultipleSenders verifies that bytes_uncompressed is
+// counted once per sender (same scope as bytes), so the two metrics remain
+// consistent regardless of the number of configured endpoints.
+func TestTraceWriterBytesMetricsMultipleSenders(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+	cfg := &config.AgentConfig{
+		Hostname:   testHostname,
+		DefaultEnv: testEnv,
+		Endpoints: []*config.Endpoint{
+			{APIKey: "123", Host: srv.URL},
+			{APIKey: "123", Host: srv.URL},
+		},
+		SynchronousFlushing: true,
+		TraceWriter:         &config.WriterConfig{ConnectionLimit: 200, QueueSize: 40, FlushPeriodSeconds: 100},
+	}
+	defer useFlushThreshold(1)()
+	tw := NewTraceWriter(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{}, passthroughCompressor{})
+	time.Sleep(200 * time.Millisecond)
+
+	tw.WriteChunks(randomSampledSpans(20, 8))
+	require.NoError(t, tw.FlushSync())
+	time.Sleep(200 * time.Millisecond)
+
+	bytes := tw.statsLastMinute.Bytes.Load()
+	bytesUncompressed := tw.statsLastMinute.BytesUncompressed.Load()
+	assert.Greater(t, bytes, int64(0))
+	// With a passthrough compressor, compressed == uncompressed per payload.
+	// Both metrics are counted once per sender, so they must be equal.
+	assert.Equal(t, bytes, bytesUncompressed)
 
 	tw.Stop()
 }

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -570,7 +570,6 @@ func TestTraceWriterInfo(t *testing.T) {
 	assert.Equal(t, int64(2), tw.statsLastMinute.Payloads.Load())
 	assert.NotEmpty(t, tw.statsLastMinute.Bytes.Load())
 	assert.NotEmpty(t, tw.statsLastMinute.BytesUncompressed.Load())
-	assert.Less(t, tw.statsLastMinute.Bytes.Load(), tw.statsLastMinute.BytesUncompressed.Load())
 	assert.Empty(t, tw.statsLastMinute.Errors.Load())
 	assert.Empty(t, tw.statsLastMinute.Retries.Load())
 

--- a/pkg/trace/writer/tracev1.go
+++ b/pkg/trace/writer/tracev1.go
@@ -307,12 +307,12 @@ func (w *TraceWriterV1) serializePrepared(pl *pb.AgentPayload, prepared []*pb.Pr
 		return
 	}
 
-	w.stats.BytesUncompressed.Add(int64(len(b)))
 	p := newPayload(map[string]string{
 		"Content-Type":     "application/x-protobuf",
 		"Content-Encoding": w.compressor.Encoding(),
 		headerLanguages:    strings.Join(info.Languages(), "|"),
 	})
+	p.uncompressedSize = len(b)
 	p.body.Grow(len(b) / 2)
 	writer, err := w.compressor.NewWriter(p.body)
 	if err != nil {
@@ -361,6 +361,7 @@ func (w *TraceWriterV1) recordEvent(t eventType, data *eventData) {
 		log.Debugf("Flushed traces to the API; time: %s, bytes: %d", data.duration, data.bytes)
 		w.timing.Since("datadog.trace_agent.trace_writer.flush_duration", time.Now().Add(-data.duration))
 		w.stats.Bytes.Add(int64(data.bytes))
+		w.stats.BytesUncompressed.Add(int64(data.uncompressedBytes))
 		w.stats.Payloads.Inc()
 		if !w.telemetryCollector.SentFirstTrace() {
 			go w.telemetryCollector.SendFirstTrace()

--- a/pkg/trace/writer/tracev1_test.go
+++ b/pkg/trace/writer/tracev1_test.go
@@ -487,6 +487,38 @@ func TestTraceWriterV1AgentPayload(t *testing.T) {
 	})
 }
 
+// TestTraceWriterV1BytesMetricsMultipleSenders verifies that bytes_uncompressed is
+// counted once per sender (same scope as bytes), so the two metrics remain
+// consistent regardless of the number of configured endpoints.
+func TestTraceWriterV1BytesMetricsMultipleSenders(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+	cfg := &config.AgentConfig{
+		Hostname:   testHostname,
+		DefaultEnv: testEnv,
+		Endpoints: []*config.Endpoint{
+			{APIKey: "123", Host: srv.URL},
+			{APIKey: "123", Host: srv.URL},
+		},
+		SynchronousFlushing: true,
+		TraceWriter:         &config.WriterConfig{ConnectionLimit: 200, QueueSize: 40, FlushPeriodSeconds: 100},
+	}
+	defer useFlushThreshold(1)()
+	tw := NewTraceWriterV1(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{}, passthroughCompressor{})
+
+	tw.WriteChunksV1(randomSampledSpansV1(20, 8))
+	require.NoError(t, tw.FlushSync())
+
+	bytes := tw.statsLastMinute.Bytes.Load()
+	bytesUncompressed := tw.statsLastMinute.BytesUncompressed.Load()
+	assert.Greater(t, bytes, int64(0))
+	// With a passthrough compressor, compressed == uncompressed per payload.
+	// Both metrics are counted once per sender, so they must be equal.
+	assert.Equal(t, bytes, bytesUncompressed)
+
+	tw.Stop()
+}
+
 func TestTraceWriterV1UpdateAPIKey(t *testing.T) {
 	assert := assert.New(t)
 	srv := newTestServer()


### PR DESCRIPTION
### What does this PR do?

Fix for https://datadoghq.atlassian.net/browse/APMSP-3498

Fixes `trace_writer.bytes_uncompressed` being counted once per serialization while `trace_writer.bytes` is counted once per sender. With multiple endpoints (`additional_endpoints`, dual-shipping), `bytes` was multiplied by the sender count but `bytes_uncompressed` was not — causing `bytes > bytes_uncompressed` in those deployments.

The fix stores the uncompressed size on the `payload` struct and moves the `bytes_uncompressed` accounting to `recordEvent(eventTypeSent)`, giving both metrics the same scope: per sender, successful sends only.

### Motivation

https://datadoghq.atlassian.net/browse/APMSP-3498

### Describe how you validated your changes

Added regression tests.

### Additional Notes