### PR TITLE
CAP-3713 Retry fakeintake timeout panics

### DIFF
--- a/test/new-e2e/tests/orchestrator/util_test.go
+++ b/test/new-e2e/tests/orchestrator/util_test.go
@@ -6,11 +6,12 @@
 package orchestrator
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
@@ -29,21 +30,29 @@ type expectAtLeastOneResource struct {
 // supplied test function. If no matching resource is found within the timeout, the test fails.
 func (e expectAtLeastOneResource) Assert(t *testing.T, client *fakeintake.Client) {
 	giveup := time.Now().Add(e.timeout)
+	var lastErr error
 	fmt.Println("trying to " + e.message)
 	for {
-		payloads, err := client.GetOrchestratorResources(e.filter)
-		require.NoError(t, err, "failed to get resource payloads from intake")
-		//fmt.Printf("found %d resources\n", len(payloads))
-		for _, p := range payloads {
-			if p != nil && e.test(p) {
-				fmt.Println("success: " + e.message)
-				return
+		payloads, err := getOrchestratorResources(client, e.filter)
+		if err != nil {
+			lastErr = err
+		} else {
+			for _, p := range payloads {
+				if p != nil && e.test(p) {
+					fmt.Println("success: " + e.message)
+					return
+				}
 			}
 		}
+		//fmt.Printf("found %d resources\n", len(payloads))
 		if time.Now().After(giveup) {
 			break
 		}
 		time.Sleep(5 * time.Second)
+	}
+	if lastErr != nil {
+		t.Errorf("failed to %s: last fakeintake error: %v", e.message, lastErr)
+		return
 	}
 	t.Error("failed to " + e.message)
 }
@@ -74,21 +83,25 @@ type expectAtLeastOneManifest struct {
 // supplied test function. If no matching manifest is found within the timeout, the test fails.
 func (e expectAtLeastOneManifest) Assert(suite *k8sSuite) {
 	giveup := time.Now().Add(e.timeout)
+	var lastErr error
 	fmt.Println("trying to " + e.message)
 	for {
-		payloads, err := suite.Env().FakeIntake.Client().GetOrchestratorManifests()
-		suite.NoError(err, "failed to get manifest payloads from intake")
-		//fmt.Printf("found %d manifests\n", len(payloads))
-		for _, p := range payloads {
-			manif := manifest{}
-			err := yaml.Unmarshal(p.Manifest.Content, &manif)
-			if err != nil {
-				continue // unable to parse manifest content
-			}
-			//fmt.Printf("MANIF %d %d - %s %s - %s %s\n", p.Type, p.Manifest.Type, manif.APIVersion, manif.Kind, manif.Metadata.Name, manif.Metadata.Namespace)
-			if p != nil && e.test(p, manif) {
-				fmt.Println("success: " + e.message)
-				return
+		payloads, err := getOrchestratorManifests(suite.Env().FakeIntake.Client())
+		if err != nil {
+			lastErr = err
+		} else {
+			//fmt.Printf("found %d manifests\n", len(payloads))
+			for _, p := range payloads {
+				manif := manifest{}
+				err := yaml.Unmarshal(p.Manifest.Content, &manif)
+				if err != nil {
+					continue // unable to parse manifest content
+				}
+				//fmt.Printf("MANIF %d %d - %s %s - %s %s\n", p.Type, p.Manifest.Type, manif.APIVersion, manif.Kind, manif.Metadata.Name, manif.Metadata.Namespace)
+				if p != nil && e.test(p, manif) {
+					fmt.Println("success: " + e.message)
+					return
+				}
 			}
 		}
 		if time.Now().After(giveup) {
@@ -96,5 +109,40 @@ func (e expectAtLeastOneManifest) Assert(suite *k8sSuite) {
 		}
 		time.Sleep(5 * time.Second)
 	}
+	if lastErr != nil {
+		suite.Failf("failed to "+e.message, "last fakeintake error: %v", lastErr)
+		return
+	}
 	suite.Fail("failed to " + e.message)
+}
+
+func getOrchestratorResources(client *fakeintake.Client, filter *fakeintake.PayloadFilter) (payloads []*aggregator.OrchestratorPayload, err error) {
+	defer func() {
+		panicErr := toFakeintakeTimeoutError(recover())
+		if panicErr != nil {
+			err = panicErr
+		}
+	}()
+	return client.GetOrchestratorResources(filter)
+}
+
+func getOrchestratorManifests(client *fakeintake.Client) (payloads []*aggregator.OrchestratorManifestPayload, err error) {
+	defer func() {
+		panicErr := toFakeintakeTimeoutError(recover())
+		if panicErr != nil {
+			err = panicErr
+		}
+	}()
+	return client.GetOrchestratorManifests()
+}
+
+func toFakeintakeTimeoutError(p any) error {
+	if p == nil {
+		return nil
+	}
+	message := fmt.Sprint(p)
+	if strings.HasPrefix(message, "fakeintake call timed out:") {
+		return errors.New(message)
+	}
+	panic(p)
 }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6094f875-1949-4889-87af-c9d093cc228d","source":"chat","resourceId":"df1d5b5b-33dc-4bc4-878b-8108cab94389","workflowId":"dc44bc0d-4487-440f-992f-3e9aacb382d6","codeChangeId":"dc44bc0d-4487-440f-992f-3e9aacb382d6","sourceType":"action_platform_workflows"} -->
### What does this PR do?

- Makes the orchestrator e2e polling helpers resilient to transient fakeintake timeout panics.
- Converts the panic path into retryable errors during polling instead of aborting the test immediately.
- Applies this behavior to both orchestrator resource and manifest polling paths.

### Motivation
CAP-3713 tracks repeated flakes in `TestKindSuite` where calls to fakeintake occasionally panic with `fakeintake call timed out` before the helper’s timeout window is exhausted. The helpers were intended to poll up to a deadline, but a transient timeout panic short-circuited that behavior and failed multiple subtests at once.

### Describe how you validated your changes
- Ran repository formatter (`Format` tool): no formatting changes required.
- Attempted targeted validation with Bazel:
  - `bazel test //test/new-e2e/tests/orchestrator:go_default_test --test_filter=TestNope`
  - Blocked in this environment because Bazel bootstrap download returned `Bad Gateway`.
- Attempted linter (`Lint` tool): blocked because required Go toolchain `1.26.4` is not installed in this sandbox (`goenv` error).

### Additional Notes
- The panic recovery is intentionally scoped to the known fakeintake timeout panic message. Other panic types are re-panicked to preserve existing failure behavior.
- This is intended as a draft PR.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/df1d5b5b-33dc-4bc4-878b-8108cab94389)

Comment @datadog to request changes