### PR TITLE
Disable v3beta shadow in otel-agent (#52138)

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -194,6 +194,10 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 		pkgconfig.Set("skip_ssl_validation", ddc.ClientConfig.TLS.InsecureSkipVerify, pkgconfigmodel.SourceFile)
 	}
 
+	// The otel-agent forces zlib compression, which is incompatible with the v3
+	// metrics intake.
+	pkgconfig.Set("serializer_experimental_use_v3_api.series.shadow_sample_rate", float64(0), pkgconfigmodel.SourceAgentRuntime)
+
 	// Log configs
 	pkgconfig.Set("logs_enabled", true, pkgconfigmodel.SourceDefault)
 	pkgconfig.Set("logs_config.force_use_http", true, pkgconfigmodel.SourceDefault)

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
@@ -83,6 +83,11 @@ func setupSerializer(config pkgconfigmodel.Config, cfg *ExporterConfig) {
 	config.Set("serializer_zstd_compressor_level", pkgconfigsetup.DefaultZstdCompressionLevel, pkgconfigmodel.SourceDefault)
 
 	config.Set("use_v2_api.series", true, pkgconfigmodel.SourceDefault)
+
+	// The serializer exporter forces zlib compression (metricscompressionfx
+	// fx-otel), which is incompatible with the v3 metrics intake.
+	config.Set("serializer_experimental_use_v3_api.series.shadow_sample_rate", float64(0), pkgconfigmodel.SourceAgentRuntime)
+
 	// Serializer: allow user to blacklist any kind of payload to be sent
 	config.Set("enable_payloads.events", true, pkgconfigmodel.SourceDefault)
 	config.Set("enable_payloads.series", true, pkgconfigmodel.SourceDefault)

--- a/releasenotes/notes/otel-agent-shadow-v3-6b39c3c08b7cf373.yaml
+++ b/releasenotes/notes/otel-agent-shadow-v3-6b39c3c08b7cf373.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    OTel Agent: Disable v3 series API shadow sampling, which is incompatible
+    with the zlib compression the OTel Agent forces for the metrics intake.


### PR DESCRIPTION
### What does this PR do?

Disable v3beta shadow in otel-agent.

### Motivation

otel-agent uses zlib compression, which is incompatible with v3 intake. When a zlib-compressed series v3 payload is sent to the intake, it will be rejected with a 400 error. These errors do not impact real traffic, but create noise and will be confusing.

### Describe how you validated your changes

### Additional Notes

(cherry picked from commit cf55aea8f5b6e3636c495955d8f171febacd238b)
