### PR TITLE
[WINA-2844] logonduration: drop duplicate user_logon timeline milestone

### DIFF
--- a/comp/logonduration/impl/impl_darwin.go
+++ b/comp/logonduration/impl/impl_darwin.go
@@ -248,9 +248,6 @@ func buildTimelineMilestones(bootTime time.Time, ts logonduration.LoginTimestamp
 	}{
 		{"boot_duration", "Boot Duration", bootTime, safeDurationMs(ts.LoginWindowTime, bootTime)},
 		{"login_window_ready", "Login Window Ready", ts.LoginWindowTime, 0},
-		{"user_logon", "User Logon", ts.LoginTime, safeDurationMs(ts.DesktopReadyTime, ts.LoginTime)},
-		// logon_duration mirrors user_logon as a duplicate span, matching the
-		// Windows payload shape (see impl_windows.go).
 		{"logon_duration", "Logon Duration", ts.LoginTime, safeDurationMs(ts.DesktopReadyTime, ts.LoginTime)},
 	}
 

--- a/comp/logonduration/impl/impl_darwin_test.go
+++ b/comp/logonduration/impl/impl_darwin_test.go
@@ -37,7 +37,7 @@ import (
 func TestBuildTimelineMilestones(t *testing.T) {
 	boot := time.Date(2026, 1, 15, 8, 0, 0, 0, time.UTC)
 
-	t.Run("returns four milestones", func(t *testing.T) {
+	t.Run("returns three milestones", func(t *testing.T) {
 		ts := logonduration.LoginTimestamps{
 			LoginWindowTime:  boot.Add(10 * time.Second),
 			LoginTime:        boot.Add(30 * time.Second),
@@ -46,11 +46,10 @@ func TestBuildTimelineMilestones(t *testing.T) {
 
 		milestones := buildTimelineMilestones(boot, ts)
 
-		require.Len(t, milestones, 4)
+		require.Len(t, milestones, 3)
 		assert.Equal(t, "Boot Duration", milestones[0].Name)
 		assert.Equal(t, "Login Window Ready", milestones[1].Name)
-		assert.Equal(t, "User Logon", milestones[2].Name)
-		assert.Equal(t, "Logon Duration", milestones[3].Name)
+		assert.Equal(t, "Logon Duration", milestones[2].Name)
 	})
 
 	t.Run("computes correct offsets from boot start", func(t *testing.T) {
@@ -63,12 +62,11 @@ func TestBuildTimelineMilestones(t *testing.T) {
 		milestones := buildTimelineMilestones(boot, ts)
 
 		// The 20s idle gap (LoginWindowTime -> LoginTime) is collapsed out of the
-		// post-login offsets, so user_logon / logon_duration start where the
+		// post-login offsets, so logon_duration starts where the
 		// login window appeared.
 		assert.InDelta(t, 0.0, milestones[0].OffsetMs, 0.001)
 		assert.InDelta(t, 10000.0, milestones[1].OffsetMs, 0.001)
 		assert.InDelta(t, 10000.0, milestones[2].OffsetMs, 0.001)
-		assert.InDelta(t, 10000.0, milestones[3].OffsetMs, 0.001)
 	})
 
 	t.Run("computes correct durations between milestones", func(t *testing.T) {
@@ -83,7 +81,6 @@ func TestBuildTimelineMilestones(t *testing.T) {
 		assert.InDelta(t, 10000.0, milestones[0].DurationMs, 0.001)
 		assert.InDelta(t, 0.0, milestones[1].DurationMs, 0.001)
 		assert.InDelta(t, 60000.0, milestones[2].DurationMs, 0.001)
-		assert.InDelta(t, 60000.0, milestones[3].DurationMs, 0.001)
 	})
 
 	t.Run("formats timestamps correctly", func(t *testing.T) {
@@ -98,7 +95,6 @@ func TestBuildTimelineMilestones(t *testing.T) {
 		assert.Equal(t, "2026-01-15T08:00:00.000Z", milestones[0].Timestamp)
 		assert.Equal(t, "2026-01-15T08:00:10.000Z", milestones[1].Timestamp)
 		assert.Equal(t, "2026-01-15T08:00:30.000Z", milestones[2].Timestamp)
-		assert.Equal(t, "2026-01-15T08:00:30.000Z", milestones[3].Timestamp)
 	})
 
 	t.Run("handles millisecond precision", func(t *testing.T) {
@@ -113,7 +109,6 @@ func TestBuildTimelineMilestones(t *testing.T) {
 		// gap = 30.25s - 10.5s = 19.75s; collapsed offsets all land at 10500ms.
 		assert.InDelta(t, 10500.0, milestones[1].OffsetMs, 0.001)
 		assert.InDelta(t, 10500.0, milestones[2].OffsetMs, 0.001)
-		assert.InDelta(t, 10500.0, milestones[3].OffsetMs, 0.001)
 	})
 
 	t.Run("zero LoginWindowTime omits the login_window_ready milestone", func(t *testing.T) {
@@ -125,20 +120,19 @@ func TestBuildTimelineMilestones(t *testing.T) {
 		milestones := buildTimelineMilestones(boot, ts)
 
 		// Milestones with a zero timestamp are skipped: login_window_ready drops out.
-		require.Len(t, milestones, 3)
+		require.Len(t, milestones, 2)
 		assert.Equal(t, "boot_duration", milestones[0].ID)
-		assert.Equal(t, "user_logon", milestones[1].ID)
-		assert.Equal(t, "logon_duration", milestones[2].ID)
+		assert.Equal(t, "logon_duration", milestones[1].ID)
 
 		// Boot Duration depends on LoginWindowTime, so its duration is 0.
 		assert.InDelta(t, 0.0, milestones[0].DurationMs, 0.001)
-		// No gap can be computed without LoginWindowTime, so user_logon keeps its
+		// No gap can be computed without LoginWindowTime, so logon_duration keeps its
 		// wall-clock offset.
 		assert.InDelta(t, 30000.0, milestones[1].OffsetMs, 0.001)
 		assert.InDelta(t, 60000.0, milestones[1].DurationMs, 0.001)
 	})
 
-	t.Run("zero LoginTime omits user_logon and logon_duration milestones", func(t *testing.T) {
+	t.Run("zero LoginTime omits the logon_duration milestone", func(t *testing.T) {
 		ts := logonduration.LoginTimestamps{
 			LoginWindowTime:  boot.Add(10 * time.Second),
 			DesktopReadyTime: boot.Add(90 * time.Second),
@@ -162,14 +156,12 @@ func TestBuildTimelineMilestones(t *testing.T) {
 
 		milestones := buildTimelineMilestones(boot, ts)
 
-		require.Len(t, milestones, 4)
-		// user_logon / logon_duration durations depend on DesktopReadyTime.
-		assert.Equal(t, "user_logon", milestones[2].ID)
+		require.Len(t, milestones, 3)
+		// logon_duration's duration depends on DesktopReadyTime.
+		assert.Equal(t, "logon_duration", milestones[2].ID)
 		assert.InDelta(t, 0.0, milestones[2].DurationMs, 0.001)
 		// The idle gap (LoginWindowTime -> LoginTime) is still collapsed.
 		assert.InDelta(t, 10000.0, milestones[2].OffsetMs, 0.001)
-		assert.Equal(t, "logon_duration", milestones[3].ID)
-		assert.InDelta(t, 0.0, milestones[3].DurationMs, 0.001)
 	})
 }
 
@@ -255,7 +247,7 @@ func TestBuildCustomPayload(t *testing.T) {
 
 		timeline, ok := custom["boot_timeline"].([]Milestone)
 		require.True(t, ok)
-		assert.Len(t, timeline, 4)
+		assert.Len(t, timeline, 3)
 	})
 
 	t.Run("zero LoginWindowTime yields 0 boot_duration_ms", func(t *testing.T) {

--- a/comp/logonduration/impl/impl_windows.go
+++ b/comp/logonduration/impl/impl_windows.go
@@ -242,7 +242,6 @@ func buildTimelineMilestones(tl BootTimeline) []Milestone {
 		{"login_ui_start", "Login UI Start", tl.LoginUIStart, durationBetween(tl.LoginUIStart, tl.LoginUIDone)},
 		{"computer_group_policy", "Computer Group Policy", tl.MachineGPStart, durationBetween(tl.MachineGPStart, tl.MachineGPEnd)},
 		{"user_group_policy", "User Group Policy", tl.UserGPStart, durationBetween(tl.UserGPStart, tl.UserGPEnd)},
-		{"user_logon", "User Logon", tl.SessionLogon, durationBetween(tl.SessionLogon, tl.DesktopVisibleStart)},
 		{"logon_duration", "Logon Duration", tl.SessionLogon, durationBetween(tl.SessionLogon, tl.DesktopVisibleStart)},
 		{"profile_loaded", "Profile Loaded", tl.ProfileLoadStart, durationBetween(tl.ProfileLoadStart, tl.ProfileLoadEnd)},
 		{"profile_created", "Profile Created", tl.ProfileCreationStart, durationBetween(tl.ProfileCreationStart, tl.ProfileCreationEnd)},

--- a/comp/logonduration/impl/impl_windows_test.go
+++ b/comp/logonduration/impl/impl_windows_test.go
@@ -123,7 +123,7 @@ func TestBuildTimelineMilestones(t *testing.T) {
 
 		milestones := buildTimelineMilestones(tl)
 
-		require.Len(t, milestones, 12)
+		require.Len(t, milestones, 11)
 
 		// gap = SessionLogon(29s) - LoginUIDone(10s) = 19000ms; milestones
 		// at/after SessionLogon have their offset collapsed by the idle gap.
@@ -135,7 +135,6 @@ func TestBuildTimelineMilestones(t *testing.T) {
 			{"Login UI Start", 8000},
 			{"Computer Group Policy", 12000},
 			{"User Group Policy", 13000},
-			{"User Logon", 10000},
 			{"Logon Duration", 10000},
 			{"Profile Loaded", 12000},
 			{"Profile Created", 14000},


### PR DESCRIPTION
### What does this PR do?

Removes the duplicate `user_logon` milestone from the logon-duration boot timeline, on both macOS and Windows. The emitted payload previously carried both `user_logon` and `logon_duration` as identical spans (same timestamp, offset, and duration), plus a redundant `user_logon` key in the `durations` map. Only `logon_duration` is kept.

- `comp/logonduration/impl/impl_darwin.go` — drop the `user_logon` candidate from `buildTimelineMilestones`
- `comp/logonduration/impl/impl_windows.go` — same
- Tests updated for the shifted milestone indices/counts

### Motivation

`user_logon` and `logon_duration` were emitted as exact duplicates, so the timeline shipped redundant data. `logon_duration` is the authoritative span, so the duplicate is removed. The gap-collapse offset logic is unaffected — it keys off the login/session timestamp directly (not the removed milestone), so `logon_duration` retains identical timestamp/offset/duration.

### Describe how you validated your changes

- `dda inv test --targets=./comp/logonduration/impl/` — 33/33 pass (darwin).
- End-to-end on a macOS arm64 VM: built the agent, deployed it, forced a fresh emit, and inspected the event payload at DEBUG. Confirmed `boot_timeline` now contains `[boot_duration, login_window_ready, logon_duration]` with no `user_logon`, and the `durations` map no longer has a `user_logon` key. `logon_duration`'s timestamp/offset/duration matched the pre-change value.

### Additional Notes

This changes the emitted timeline payload contract: any backend dashboard, monitor, or saved query referencing the `user_logon` span ID will go empty and should migrate to `logon_duration` (a pure duplicate). The Windows path mirrors the macOS change but was not compiled/tested locally (Windows build tag) — it will be validated in CI.
