### PR TITLE
Fix panic in tests: return after `killProcess`

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -355,6 +355,7 @@ func (r *HTTPReceiver) Start() {
 		if err != nil {
 			r.telemetryCollector.SendStartupError(telemetry.CantStartHttpServer, err)
 			killProcess("Error creating tcp listener: %v", err)
+			return
 		}
 		go func() {
 			defer watchdog.LogOnPanic(r.statsd)
@@ -416,6 +417,7 @@ func (r *HTTPReceiver) Start() {
 		if err != nil {
 			r.telemetryCollector.SendStartupError(telemetry.CantStartWindowsPipeServer, err)
 			killProcess("Error creating %q named pipe: %v", pipepath, err)
+			return
 		}
 		go func() {
 			defer watchdog.LogOnPanic(r.statsd)


### PR DESCRIPTION
### What does this PR do?
Add `return` after the two `killProcess` calls in `(*HTTPReceiver).Start()` (TCP listener and Windows named pipe).

### Motivation
`killProcess` calls `os.Exit(1)` in production, so the code after it is dead.
In tests, `TestMain` in `pkg/trace/api` overrides `killProcess` to only log, without exiting.
When the TCP listener bind fails (e.g. port 8126 already in use on macOS ARM64), execution falls through to `r.server.Serve(ln)` with `ln == nil`, causing a `nil` pointer dereference in the `go func()` goroutine and a spurious panic diluting the root cause:
```
Error creating tcp listener: listen tcp 127.0.0.1:8126: bind: address already in use
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x104b80164]
goroutine 190 [running]:
github.com/DataDog/datadog-agent/pkg/trace/watchdog.LogOnPanic({0x105a11678, 0x105af4580})
	pkg/trace/watchdog/logonpanic.go:47 +0x1d8
panic({0x1058b1400?, 0x105a919d0?})
	GOROOT/src/runtime/panic.go:860 +0x12c
net/http.(*onceCloseListener).close(...)
	GOROOT/src/net/http/server.go:3940
sync.(*Once).doSlow(0x13?, 0x11f1fcfe54e88?)
	GOROOT/src/sync/once.go:78 +0xdc
sync.(*Once).Do(...)
	GOROOT/src/sync/once.go:69
net/http.(*onceCloseListener).Close(0x1f1fcfc4a000)
	GOROOT/src/net/http/server.go:3936 +0x44
net/http.(*Server).Serve(0x1f1fcfa3e300, {0x0, 0x0})
	GOROOT/src/net/http/server.go:3418 +0x1f8
github.com/DataDog/datadog-agent/pkg/trace/api.(*HTTPReceiver).Start.func1()
	pkg/trace/api/api.go:361 +0x5c
created by github.com/DataDog/datadog-agent/pkg/trace/api.(*HTTPReceiver).Start in goroutine 19
	pkg/trace/api/api.go:359 +0x6e0
```
([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1771059629#L21))

The `return` is unreachable in production (`os.Exit` terminates first) but prevents the goroutine from being launched with a `nil` listener when `killProcess` is a no-op.