### PR TITLE
Fix trace API test to not bind port 8126

### DIFF
--- a/pkg/trace/api/api_nix_test.go
+++ b/pkg/trace/api/api_nix_test.go
@@ -96,6 +96,7 @@ func TestUDS(t *testing.T) {
 
 		conf := config.New()
 		conf.Endpoints[0].APIKey = "apikey_2"
+		conf.ReceiverPort = 0 // do not bind production port 8126
 		conf.ReceiverSocket = filepath.Join(dir, "apm.socket")
 
 		r := newTestReceiverFromConfig(conf)


### PR DESCRIPTION
### What does this PR do?
Set `ReceiverPort = 0` in the `uds_permission_err` sub-test of `TestUDS`.
The test only exercises UDS socket permission error handling.

### Motivation
Leaving `ReceiverPort` at its default (8126, the production port) causes spurious bind failures.
```
==================== Test output for //pkg/trace/api:api_test:
Error creating tcp listener: listen tcp 127.0.0.1:8126: bind: address already in use
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x104b80164]
goroutine 190 [running]:
github.com/DataDog/datadog-agent/pkg/trace/watchdog.LogOnPanic({0x105a11678, 0x105af4580})
	pkg/trace/watchdog/logonpanic.go:47 +0x1d8
panic({0x1058b1400?, 0x105a919d0?})
	GOROOT/src/runtime/panic.go:860 +0x12c
net/http.(*onceCloseListener).close(...)
	GOROOT/src/net/http/server.go:3940
sync.(*Once).doSlow(0x13?, 0x11f1fcfe54e88?)
	GOROOT/src/sync/once.go:78 +0xdc
sync.(*Once).Do(...)
	GOROOT/src/sync/once.go:69
net/http.(*onceCloseListener).Close(0x1f1fcfc4a000)
	GOROOT/src/net/http/server.go:3936 +0x44
net/http.(*Server).Serve(0x1f1fcfa3e300, {0x0, 0x0})
	GOROOT/src/net/http/server.go:3418 +0x1f8
github.com/DataDog/datadog-agent/pkg/trace/api.(*HTTPReceiver).Start.func1()
	pkg/trace/api/api.go:361 +0x5c
created by github.com/DataDog/datadog-agent/pkg/trace/api.(*HTTPReceiver).Start in goroutine 19
	pkg/trace/api/api.go:359 +0x6e0
================================================================================
```
([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1771059629))

The sibling sub-tests (`off`, `on`) had already been updated with a comment explaining the same concern (resp. hardcoded to 8127 and 8125), whereas `uds_permission_err` was missed.

### Describe how you validated your changes
CI.