### PR TITLE
Add system.wlan.scan.rssi for nearby access points

### DIFF
--- a/cmd/agent/dist/conf.d/wlan.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/wlan.d/conf.yaml.default
@@ -1,5 +1,10 @@
 ad_identifiers:
   - _end_user_device
 init_config:
+  ## @param collect_nearby_aps - boolean - optional - default: true
+  ## Emit system.wlan.scan.rssi for every visible access point (the connected
+  ## one and nearby ones), tagged with ssid, bssid, and connected:1|0.
+  ## Set to false to disable scanning for nearby access points.
+  # collect_nearby_aps: true
 instances:
   - {}

--- a/cmd/agent/dist/conf.d/wlan.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/wlan.d/conf.yaml.default
@@ -1,10 +1,33 @@
 ad_identifiers:
   - _end_user_device
 init_config:
-  ## @param collect_nearby_aps - boolean - optional - default: true
+  ## @param ap_scan - boolean - optional - default: true
   ## Emit system.wlan.scan.rssi for every visible access point (the connected
   ## one and nearby ones), tagged with ssid, bssid, and connected:1|0.
   ## Set to false to disable scanning for nearby access points.
-  # collect_nearby_aps: true
+  # ap_scan: true
+
+  ## @param ap_scan_limit - integer - optional
+  ## Report only the N strongest nearby access points by RSSI. The connected
+  ## access point is always reported and does not count against this limit.
+  # ap_scan_limit: 20
+
+  ## @param ap_scan_rssi_cutoff - integer - optional
+  ## Drop nearby access points whose RSSI (in dBm) is below this value, e.g.
+  ## -80 to ignore weak signals. The connected access point is exempt.
+  # ap_scan_rssi_cutoff: -80
+
+  ## @param ssid_include / ssid_exclude / bssid_include / bssid_exclude - list of strings - optional
+  ## Glob patterns (case-insensitive) gating the connected-AP metrics by the
+  ## currently connected network. ssid_*/bssid_* combine as OR; exclude wins;
+  ## empty lists allow everything.
+  # ssid_include:
+  #   - "Corp-*"
+
+  ## @param scan_ssid_include / scan_ssid_exclude / scan_bssid_include / scan_bssid_exclude - list of strings - optional
+  ## Same glob semantics, gating whether the nearby-AP scan runs at all, matched
+  ## on the connected network. Example: scan only at work.
+  # scan_ssid_include:
+  #   - "Corp-*"
 instances:
   - {}

--- a/cmd/agent/dist/conf.d/wlan.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/wlan.d/conf.yaml.example
@@ -3,6 +3,11 @@
 ## to `conf.yaml` and make your changes on that file.
 
 init_config:
+    ## @param collect_nearby_aps - boolean - optional - default: true
+    ## Emit system.wlan.scan.rssi for every visible access point (the connected
+    ## one and nearby ones), tagged with ssid, bssid, and connected:1|0.
+    ## Set to false to disable scanning for nearby access points.
+    # collect_nearby_aps: true
 
 instances:
   - {}

--- a/cmd/agent/dist/conf.d/wlan.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/wlan.d/conf.yaml.example
@@ -3,11 +3,45 @@
 ## to `conf.yaml` and make your changes on that file.
 
 init_config:
-    ## @param collect_nearby_aps - boolean - optional - default: true
+    ## @param ap_scan - boolean - optional - default: true
     ## Emit system.wlan.scan.rssi for every visible access point (the connected
     ## one and nearby ones), tagged with ssid, bssid, and connected:1|0.
     ## Set to false to disable scanning for nearby access points.
-    # collect_nearby_aps: true
+    # ap_scan: true
+
+    ## @param ap_scan_limit - integer - optional
+    ## Report only the N strongest nearby access points by RSSI. The connected
+    ## access point is always reported and does not count against this limit.
+    # ap_scan_limit: 20
+
+    ## @param ap_scan_rssi_cutoff - integer - optional
+    ## Drop nearby access points whose RSSI (in dBm) is below this value, e.g.
+    ## -80 to ignore weak signals. The connected access point is exempt.
+    # ap_scan_rssi_cutoff: -80
+
+    ## @param ssid_include - list of strings - optional
+    ## @param ssid_exclude - list of strings - optional
+    ## @param bssid_include - list of strings - optional
+    ## @param bssid_exclude - list of strings - optional
+    ## Glob patterns (case-insensitive) gating the connected-AP metrics
+    ## (system.wlan.rssi, .noise, .txrate, .rxrate, .status) by the currently
+    ## connected network. ssid_* and bssid_* combine as OR; exclude wins;
+    ## empty lists allow everything. Example: only collect on corporate Wi-Fi.
+    # ssid_include:
+    #   - "Corp-*"
+    # ssid_exclude:
+    #   - "MyHomeNet"
+
+    ## @param scan_ssid_include - list of strings - optional
+    ## @param scan_ssid_exclude - list of strings - optional
+    ## @param scan_bssid_include - list of strings - optional
+    ## @param scan_bssid_exclude - list of strings - optional
+    ## Same glob semantics as the ssid_*/bssid_* options above, but gating
+    ## whether the nearby-AP scan runs at all, matched on the connected
+    ## network. When the connected network is not allowed, no scan is performed.
+    ## Example: scan only at work.
+    # scan_ssid_include:
+    #   - "Corp-*"
 
 instances:
   - {}

--- a/comp/core/gui/impl/systray/Sources/WiFiDataProvider.swift
+++ b/comp/core/gui/impl/systray/Sources/WiFiDataProvider.swift
@@ -35,6 +35,25 @@ struct WiFiData: Codable {
     }
 }
 
+/// AccessPointData represents a single visible access point from a WiFi scan.
+struct AccessPointData: Codable {
+    let rssi: Int
+    let ssid: String
+    let bssid: String
+}
+
+/// WiFiScanData is the payload returned for a get_wifi_scan command: the list
+/// of all visible access points (connected and nearby).
+struct WiFiScanData: Codable {
+    let accessPoints: [AccessPointData]
+    let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case accessPoints = "access_points"
+        case error
+    }
+}
+
 /// WiFiDataProvider handles CoreLocation permissions and WiFi data collection.
 /// When authorization is `.notDetermined`, the system location prompt is requested via
 /// `requestWhenInUseAuthorization()` (gated by the WLAN check flag on each IPC request).
@@ -183,6 +202,46 @@ class WiFiDataProvider: NSObject, CLLocationManagerDelegate {
 
         Logger.debug("Collected WiFi data: SSID=\(ssid.isEmpty ? "<empty>" : ssid), RSSI=\(wifiData.rssi), locationAuthorized=\(isAuthorized)", context: "WiFiDataProvider")
         return wifiData
+    }
+
+    /// Scan for all visible access points (connected and nearby) and return
+    /// their RSSI. requestLocationPermission behaves the same as getWiFiInfo:
+    /// SSID/BSSID require Location Services on macOS 11+, so without permission
+    /// those fields come back empty while RSSI is still reported.
+    func scanForNetworks(requestLocationPermission: Bool) -> WiFiScanData {
+        let authStatus = getAuthorizationStatus()
+
+        // Mirror getWiFiInfo's permission-prompt behavior.
+        let timeSinceInit = Date().timeIntervalSince(initializationTime)
+        if authStatus == .notDetermined && timeSinceInit >= 10.0 {
+            if requestLocationPermission && isGUIAvailable() {
+                attemptPermissionPrompt(authStatus: authStatus)
+            }
+        }
+
+        let client = CWWiFiClient.shared()
+        guard let interface = client.interface() else {
+            Logger.error("No WiFi interface available for scan", context: "WiFiDataProvider")
+            return WiFiScanData(accessPoints: [], error: "No WiFi interface")
+        }
+
+        do {
+            // Passing nil scans for all networks. This is an active scan and
+            // can take a few seconds to complete.
+            let networks = try interface.scanForNetworks(withName: nil)
+            let accessPoints = networks.map { network in
+                AccessPointData(
+                    rssi: network.rssiValue,
+                    ssid: network.ssid ?? "",
+                    bssid: network.bssid ?? ""
+                )
+            }
+            Logger.debug("WiFi scan found \(accessPoints.count) access point(s)", context: "WiFiDataProvider")
+            return WiFiScanData(accessPoints: accessPoints, error: nil)
+        } catch {
+            Logger.error("WiFi scan failed: \(error)", context: "WiFiDataProvider")
+            return WiFiScanData(accessPoints: [], error: "scan failed: \(error.localizedDescription)")
+        }
     }
 
     // CLLocationManagerDelegate

--- a/comp/core/gui/impl/systray/Sources/WiFiIPCServer.swift
+++ b/comp/core/gui/impl/systray/Sources/WiFiIPCServer.swift
@@ -21,6 +21,13 @@ struct WiFiIPCResponse: Codable {
     let error: String?
 }
 
+/// Response structure for the get_wifi_scan command.
+struct WiFiScanIPCResponse: Codable {
+    let success: Bool
+    let data: WiFiScanData?
+    let error: String?
+}
+
 /// WiFiIPCServer handles Unix socket communication for WiFi data
 class WiFiIPCServer {
     private let wifiDataProvider: WiFiDataProvider
@@ -228,13 +235,20 @@ class WiFiIPCServer {
             let response = WiFiIPCResponse(success: true, data: wifiData, error: nil)
             sendResponse(clientFD, response: response)
 
+        case "get_wifi_scan":
+            let scanData = wifiDataProvider.scanForNetworks(
+                requestLocationPermission: request.requestLocationPermission ?? false
+            )
+            let response = WiFiScanIPCResponse(success: true, data: scanData, error: nil)
+            sendResponse(clientFD, response: response)
+
         default:
             Logger.error("Unknown command: \(request.command)", context: "WiFiIPCServer")
             sendErrorResponse(clientFD, error: "Unknown command: \(request.command)")
         }
     }
 
-    private func sendResponse(_ clientFD: Int32, response: WiFiIPCResponse) {
+    private func sendResponse<T: Encodable>(_ clientFD: Int32, response: T) {
         guard let responseData = try? JSONEncoder().encode(response) else {
             Logger.error("Failed to encode response", context: "WiFiIPCServer")
             return

--- a/pkg/collector/corechecks/net/wlan/wlan.go
+++ b/pkg/collector/corechecks/net/wlan/wlan.go
@@ -41,9 +41,25 @@ type wifiInfo struct {
 	phyMode          string
 }
 
+// accessPointInfo contains the subset of WiFi data we report per visible
+// access point during a scan (connected or not). RSSI is the payload; ssid
+// and bssid are used for tagging. Whether an AP is the connected one is
+// derived at emit time by comparing its BSSID to the connected BSSID, so it
+// is intentionally not stored here.
+type accessPointInfo struct {
+	rssi  int
+	ssid  string
+	bssid string
+}
+
 // wlanInitConfig mirrors the init_config section of wlan.d/conf.yaml.
 type wlanInitConfig struct {
 	RequestLocationPermission bool `yaml:"request_location_permission"`
+
+	// CollectNearbyAPs toggles emission of system.wlan.scan.rssi for every
+	// visible access point (connected and nearby). A nil pointer means the
+	// option was omitted, in which case it defaults to enabled.
+	CollectNearbyAPs *bool `yaml:"collect_nearby_aps"`
 }
 
 // WLANCheck monitors the status of the WLAN interface
@@ -58,6 +74,10 @@ type WLANCheck struct {
 	// Location Services permission. The agent owns the config; the GUI has no
 	// read access to auth_token / ipc_cert.pem and cannot query the agent itself.
 	requestLocationPermission bool
+
+	// When true, emit system.wlan.scan.rssi for every visible access point
+	// (connected and nearby). Defaults to true; disabled via init_config.
+	collectNearbyAPs bool
 }
 
 // Configure reads request_location_permission from init_config so it can be
@@ -80,6 +100,8 @@ func (c *WLANCheck) Configure(senderManager sender.SenderManager, _ uint64, data
 		}
 	}
 	c.requestLocationPermission = ic.RequestLocationPermission
+	// Default to enabled when the option is omitted from init_config.
+	c.collectNearbyAPs = ic.CollectNearbyAPs == nil || *ic.CollectNearbyAPs
 	return nil
 }
 
@@ -224,6 +246,11 @@ func (c *WLANCheck) Run() error {
 		sender.Gauge("system.wlan.rxrate", float64(wi.receiveRate), "", tags)
 	}
 
+	// Emit per-AP RSSI for every visible access point (connected and nearby).
+	if c.collectNearbyAPs {
+		c.emitNearbyAPs(sender, wi.bssid)
+	}
+
 	// Emit event metrics for roaming and channel swaps
 	if c.isRoaming(&wi) {
 		sender.Count("system.wlan.roaming_events", 1.0, "", tags)
@@ -244,6 +271,43 @@ func (c *WLANCheck) Run() error {
 
 	sender.Commit()
 	return nil
+}
+
+// emitNearbyAPs scans for all visible access points and emits one
+// system.wlan.scan.rssi gauge per AP, tagged with ssid, bssid, and
+// connected:1|0 (1 for the AP matching connectedBSSID, 0 otherwise).
+//
+// Failure to scan is non-fatal: the connected-AP metrics have already been
+// emitted in Run(), so we log and return rather than failing the check.
+func (c *WLANCheck) emitNearbyAPs(sender sender.Sender, connectedBSSID string) {
+	aps, err := c.GetNearbyAccessPoints()
+	if err != nil {
+		log.Warnf("Failed to scan for nearby access points: %v", err)
+		return
+	}
+
+	for _, ap := range aps {
+		ssid := ap.ssid
+		if ssid == "" {
+			ssid = "unknown"
+		}
+		bssid := ap.bssid
+		if bssid == "" {
+			bssid = "unknown"
+		}
+
+		connected := "0"
+		if connectedBSSID != "" && strings.EqualFold(ap.bssid, connectedBSSID) {
+			connected = "1"
+		}
+
+		tags := []string{
+			"ssid:" + ssid,
+			"bssid:" + bssid,
+			"connected:" + connected,
+		}
+		sender.Gauge("system.wlan.scan.rssi", float64(ap.rssi), "", tags)
+	}
 }
 
 // Factory creates a new check factory

--- a/pkg/collector/corechecks/net/wlan/wlan.go
+++ b/pkg/collector/corechecks/net/wlan/wlan.go
@@ -8,9 +8,11 @@ package wlan
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/gobwas/glob"
 	yaml "go.yaml.in/yaml/v2"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
@@ -56,10 +58,94 @@ type accessPointInfo struct {
 type wlanInitConfig struct {
 	RequestLocationPermission bool `yaml:"request_location_permission"`
 
-	// CollectNearbyAPs toggles emission of system.wlan.scan.rssi for every
-	// visible access point (connected and nearby). A nil pointer means the
-	// option was omitted, in which case it defaults to enabled.
-	CollectNearbyAPs *bool `yaml:"collect_nearby_aps"`
+	// APScan toggles emission of system.wlan.scan.rssi for every visible
+	// access point (connected and nearby). A nil pointer means the option was
+	// omitted, in which case it defaults to enabled.
+	APScan *bool `yaml:"ap_scan"`
+
+	// APScanLimit, when set and > 0, caps the nearby access points reported to
+	// the N strongest by RSSI. The connected AP is always reported and does
+	// not count against the limit. nil/0 means no limit.
+	APScanLimit *int `yaml:"ap_scan_limit"`
+
+	// APScanRSSICutoff, when set, drops nearby access points whose RSSI is
+	// below this value (in dBm, e.g. -80). The connected AP is exempt.
+	APScanRSSICutoff *int `yaml:"ap_scan_rssi_cutoff"`
+
+	// Metric filter (filter 1): gate the connected-AP metrics by the connected
+	// network's SSID/BSSID. Glob patterns. Empty lists allow everything.
+	SSIDInclude  []string `yaml:"ssid_include"`
+	SSIDExclude  []string `yaml:"ssid_exclude"`
+	BSSIDInclude []string `yaml:"bssid_include"`
+	BSSIDExclude []string `yaml:"bssid_exclude"`
+
+	// Scan filter (filter 2): gate whether the nearby-AP scan runs, by the
+	// connected network's SSID/BSSID (e.g. "scan only at work"). Glob patterns.
+	ScanSSIDInclude  []string `yaml:"scan_ssid_include"`
+	ScanSSIDExclude  []string `yaml:"scan_ssid_exclude"`
+	ScanBSSIDInclude []string `yaml:"scan_bssid_include"`
+	ScanBSSIDExclude []string `yaml:"scan_bssid_exclude"`
+}
+
+// apFilter decides whether an access point identified by (ssid, bssid) should
+// be collected, based on glob include/exclude lists. ssid and bssid lists are
+// OR-combined within the include set and within the exclude set; exclude wins.
+// A filter with no lists allows everything.
+type apFilter struct {
+	ssidInclude  []glob.Glob
+	ssidExclude  []glob.Glob
+	bssidInclude []glob.Glob
+	bssidExclude []glob.Glob
+}
+
+// compileGlobs compiles patterns (lowercased for case-insensitive matching),
+// logging and skipping any that are invalid.
+func compileGlobs(patterns []string) []glob.Glob {
+	var globs []glob.Glob
+	for _, p := range patterns {
+		g, err := glob.Compile(strings.ToLower(p))
+		if err != nil {
+			log.Warnf("Ignoring invalid wlan filter pattern %q: %v", p, err)
+			continue
+		}
+		globs = append(globs, g)
+	}
+	return globs
+}
+
+// newAPFilter builds a filter from include/exclude string lists.
+func newAPFilter(ssidInc, ssidExc, bssidInc, bssidExc []string) apFilter {
+	return apFilter{
+		ssidInclude:  compileGlobs(ssidInc),
+		ssidExclude:  compileGlobs(ssidExc),
+		bssidInclude: compileGlobs(bssidInc),
+		bssidExclude: compileGlobs(bssidExc),
+	}
+}
+
+func matchAny(globs []glob.Glob, s string) bool {
+	for _, g := range globs {
+		if g.Match(s) {
+			return true
+		}
+	}
+	return false
+}
+
+// allowed reports whether an AP with the given ssid/bssid passes the filter.
+func (f apFilter) allowed(ssid, bssid string) bool {
+	ssid = strings.ToLower(ssid)
+	bssid = strings.ToLower(bssid)
+
+	if matchAny(f.ssidExclude, ssid) || matchAny(f.bssidExclude, bssid) {
+		return false
+	}
+
+	hasInclude := len(f.ssidInclude) > 0 || len(f.bssidInclude) > 0
+	if !hasInclude {
+		return true
+	}
+	return matchAny(f.ssidInclude, ssid) || matchAny(f.bssidInclude, bssid)
 }
 
 // WLANCheck monitors the status of the WLAN interface
@@ -77,7 +163,18 @@ type WLANCheck struct {
 
 	// When true, emit system.wlan.scan.rssi for every visible access point
 	// (connected and nearby). Defaults to true; disabled via init_config.
-	collectNearbyAPs bool
+	apScanEnabled bool
+
+	// apScanLimit caps reported nearby APs to the N strongest (0 = unlimited).
+	// apScanRSSICutoff drops nearby APs below this RSSI (nil = no cutoff).
+	// The connected AP is exempt from both.
+	apScanLimit      int
+	apScanRSSICutoff *int
+
+	// metricFilter gates the connected-AP metrics; scanFilter gates whether
+	// the nearby-AP scan runs. Both match the connected network's ssid/bssid.
+	metricFilter apFilter
+	scanFilter   apFilter
 }
 
 // Configure reads request_location_permission from init_config so it can be
@@ -101,7 +198,16 @@ func (c *WLANCheck) Configure(senderManager sender.SenderManager, _ uint64, data
 	}
 	c.requestLocationPermission = ic.RequestLocationPermission
 	// Default to enabled when the option is omitted from init_config.
-	c.collectNearbyAPs = ic.CollectNearbyAPs == nil || *ic.CollectNearbyAPs
+	c.apScanEnabled = ic.APScan == nil || *ic.APScan
+
+	c.apScanLimit = 0
+	if ic.APScanLimit != nil && *ic.APScanLimit > 0 {
+		c.apScanLimit = *ic.APScanLimit
+	}
+	c.apScanRSSICutoff = ic.APScanRSSICutoff
+
+	c.metricFilter = newAPFilter(ic.SSIDInclude, ic.SSIDExclude, ic.BSSIDInclude, ic.BSSIDExclude)
+	c.scanFilter = newAPFilter(ic.ScanSSIDInclude, ic.ScanSSIDExclude, ic.ScanBSSIDInclude, ic.ScanBSSIDExclude)
 	return nil
 }
 
@@ -226,48 +332,58 @@ func (c *WLANCheck) Run() error {
 		macAddress = "unknown"
 	}
 
-	tags := []string{
-		"ssid:" + ssid,
-		"bssid:" + bssid,
-		"mac_address:" + macAddress,
-		"status:ok",
+	// Filter 1: only emit connected-AP metrics for allowed networks. When the
+	// connected network is filtered out we emit nothing for it (so its
+	// ssid/bssid never appear in tags) and skip the state update below so a
+	// later allowed sample does not register a false roam/channel-swap.
+	if c.metricFilter.allowed(wi.ssid, wi.bssid) {
+		tags := []string{
+			"ssid:" + ssid,
+			"bssid:" + bssid,
+			"mac_address:" + macAddress,
+			"status:ok",
+		}
+
+		// WiFi data collected successfully - emit OK status (replaces deprecated service check)
+		sender.Gauge("system.wlan.status", statusOK, "", tags)
+
+		// Emit metrics
+		sender.Gauge("system.wlan.rssi", float64(wi.rssi), "", tags)
+		if wi.noiseValid {
+			sender.Gauge("system.wlan.noise", float64(wi.noise), "", tags)
+		}
+		sender.Gauge("system.wlan.txrate", float64(wi.transmitRate), "", tags)
+		if wi.receiveRateValid {
+			sender.Gauge("system.wlan.rxrate", float64(wi.receiveRate), "", tags)
+		}
+
+		// Emit event metrics for roaming and channel swaps
+		if c.isRoaming(&wi) {
+			sender.Count("system.wlan.roaming_events", 1.0, "", tags)
+			sender.Count("system.wlan.channel_swap_events", 0.0, "", tags)
+		} else if c.isChannelSwap(&wi) {
+			sender.Count("system.wlan.roaming_events", 0.0, "", tags)
+			sender.Count("system.wlan.channel_swap_events", 1.0, "", tags)
+		} else {
+			sender.Count("system.wlan.roaming_events", 0.0, "", tags)
+			sender.Count("system.wlan.channel_swap_events", 0.0, "", tags)
+		}
+
+		// Update last values for next run
+		c.lastChannel = wi.channel
+		c.lastBSSID = wi.bssid
+		c.lastSSID = wi.ssid
+		c.isWarmedUp = true
+	} else {
+		log.Debugf("Connected network filtered out by metric include/exclude; skipping connected WLAN metrics")
 	}
 
-	// WiFi data collected successfully - emit OK status (replaces deprecated service check)
-	sender.Gauge("system.wlan.status", statusOK, "", tags)
-
-	// Emit metrics
-	sender.Gauge("system.wlan.rssi", float64(wi.rssi), "", tags)
-	if wi.noiseValid {
-		sender.Gauge("system.wlan.noise", float64(wi.noise), "", tags)
-	}
-	sender.Gauge("system.wlan.txrate", float64(wi.transmitRate), "", tags)
-	if wi.receiveRateValid {
-		sender.Gauge("system.wlan.rxrate", float64(wi.receiveRate), "", tags)
-	}
-
-	// Emit per-AP RSSI for every visible access point (connected and nearby).
-	if c.collectNearbyAPs {
+	// Filter 2: emit per-AP RSSI only when scanning is enabled and the
+	// connected network is allowed to scan ("scan only at work"). Gating here
+	// avoids triggering the relatively expensive active scan when not wanted.
+	if c.apScanEnabled && c.scanFilter.allowed(wi.ssid, wi.bssid) {
 		c.emitNearbyAPs(sender, wi.bssid)
 	}
-
-	// Emit event metrics for roaming and channel swaps
-	if c.isRoaming(&wi) {
-		sender.Count("system.wlan.roaming_events", 1.0, "", tags)
-		sender.Count("system.wlan.channel_swap_events", 0.0, "", tags)
-	} else if c.isChannelSwap(&wi) {
-		sender.Count("system.wlan.roaming_events", 0.0, "", tags)
-		sender.Count("system.wlan.channel_swap_events", 1.0, "", tags)
-	} else {
-		sender.Count("system.wlan.roaming_events", 0.0, "", tags)
-		sender.Count("system.wlan.channel_swap_events", 0.0, "", tags)
-	}
-
-	// Update last values for next run
-	c.lastChannel = wi.channel
-	c.lastBSSID = wi.bssid
-	c.lastSSID = wi.ssid
-	c.isWarmedUp = true
 
 	sender.Commit()
 	return nil
@@ -276,6 +392,10 @@ func (c *WLANCheck) Run() error {
 // emitNearbyAPs scans for all visible access points and emits one
 // system.wlan.scan.rssi gauge per AP, tagged with ssid, bssid, and
 // connected:1|0 (1 for the AP matching connectedBSSID, 0 otherwise).
+//
+// The connected AP is always reported. Nearby (non-connected) APs are first
+// dropped below apScanRSSICutoff (when set), then the strongest apScanLimit of
+// the remainder are kept (when set). Both limits exempt the connected AP.
 //
 // Failure to scan is non-fatal: the connected-AP metrics have already been
 // emitted in Run(), so we log and return rather than failing the check.
@@ -286,28 +406,65 @@ func (c *WLANCheck) emitNearbyAPs(sender sender.Sender, connectedBSSID string) {
 		return
 	}
 
-	for _, ap := range aps {
-		ssid := ap.ssid
-		if ssid == "" {
-			ssid = "unknown"
+	// Partition into the connected AP (always reported) and the rest.
+	var connectedAP *accessPointInfo
+	others := make([]accessPointInfo, 0, len(aps))
+	for i := range aps {
+		ap := aps[i]
+		if connectedAP == nil && connectedBSSID != "" && strings.EqualFold(ap.bssid, connectedBSSID) {
+			connectedAP = &aps[i]
+			continue
 		}
-		bssid := ap.bssid
-		if bssid == "" {
-			bssid = "unknown"
-		}
-
-		connected := "0"
-		if connectedBSSID != "" && strings.EqualFold(ap.bssid, connectedBSSID) {
-			connected = "1"
-		}
-
-		tags := []string{
-			"ssid:" + ssid,
-			"bssid:" + bssid,
-			"connected:" + connected,
-		}
-		sender.Gauge("system.wlan.scan.rssi", float64(ap.rssi), "", tags)
+		others = append(others, ap)
 	}
+
+	// RSSI cutoff on nearby APs only.
+	if c.apScanRSSICutoff != nil {
+		filtered := others[:0]
+		for _, ap := range others {
+			if ap.rssi >= *c.apScanRSSICutoff {
+				filtered = append(filtered, ap)
+			}
+		}
+		others = filtered
+	}
+
+	// Keep the strongest N nearby APs (connected AP excluded from the cap).
+	if c.apScanLimit > 0 && len(others) > c.apScanLimit {
+		sort.SliceStable(others, func(i, j int) bool { return others[i].rssi > others[j].rssi })
+		others = others[:c.apScanLimit]
+	}
+
+	if connectedAP != nil {
+		c.emitScanRSSI(sender, *connectedAP, connectedBSSID)
+	}
+	for _, ap := range others {
+		c.emitScanRSSI(sender, ap, connectedBSSID)
+	}
+}
+
+// emitScanRSSI emits a single system.wlan.scan.rssi gauge for one access point.
+func (c *WLANCheck) emitScanRSSI(sender sender.Sender, ap accessPointInfo, connectedBSSID string) {
+	ssid := ap.ssid
+	if ssid == "" {
+		ssid = "unknown"
+	}
+	bssid := ap.bssid
+	if bssid == "" {
+		bssid = "unknown"
+	}
+
+	connected := "0"
+	if connectedBSSID != "" && strings.EqualFold(ap.bssid, connectedBSSID) {
+		connected = "1"
+	}
+
+	tags := []string{
+		"ssid:" + ssid,
+		"bssid:" + bssid,
+		"connected:" + connected,
+	}
+	sender.Gauge("system.wlan.scan.rssi", float64(ap.rssi), "", tags)
 }
 
 // Factory creates a new check factory

--- a/pkg/collector/corechecks/net/wlan/wlan_darwin.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_darwin.go
@@ -56,6 +56,16 @@ const (
 
 	// Maximum IPC response size (4KB is sufficient for WiFi metadata)
 	maxIPCResponseSize = 4096
+
+	// Maximum IPC response size for a scan response, which carries one entry
+	// per visible access point and can be substantially larger than the
+	// single connected-AP response.
+	maxScanIPCResponseSize = 65536
+
+	// Timeout for a scan request. An active scan (CWInterface.scanForNetworks)
+	// can take several seconds, so this is much larger than the connected-AP
+	// fetch timeout.
+	scanRequestTimeout = 6 * time.Second
 )
 
 // guiWiFiData represents the WiFi data structure from GUI IPC
@@ -82,9 +92,34 @@ type guiIPCResponse struct {
 	Error   *string      `json:"error"`
 }
 
+// guiAPData represents a single visible access point from the GUI scan IPC
+// command. It carries only the fields needed to emit system.wlan.scan.rssi.
+type guiAPData struct {
+	RSSI  int    `json:"rssi"`
+	SSID  string `json:"ssid"`
+	BSSID string `json:"bssid"`
+}
+
+// guiScanData is the payload of a get_wifi_scan response.
+type guiScanData struct {
+	AccessPoints []guiAPData `json:"access_points"`
+	Error        *string     `json:"error"`
+}
+
+// guiScanResponse represents the IPC response to a get_wifi_scan command.
+type guiScanResponse struct {
+	Success bool         `json:"success" required:"true"`
+	Data    *guiScanData `json:"data"`
+	Error   *string      `json:"error"`
+}
+
 // getWiFiInfo is a package-level function variable for testability
 // Tests can reassign this to mock WiFi data retrieval
 var getWiFiInfo func() (wifiInfo, error)
+
+// getNearbyAPs is a package-level function variable for testability
+// Tests can reassign this to mock nearby access point scanning
+var getNearbyAPs func() ([]accessPointInfo, error)
 
 // GetWiFiInfo retrieves WiFi information via IPC from the GUI/user app
 func (c *WLANCheck) GetWiFiInfo() (wifiInfo, error) {
@@ -551,4 +586,147 @@ func (c *WLANCheck) fetchWiFiFromGUI(socketPath string, timeout time.Duration) (
 		info.ssid, info.rssi, info.phyMode, data.LocationAuthorized)
 
 	return info, nil
+}
+
+// validateAPData performs defensive validation on a single scanned access
+// point received from the GUI. It reuses the same bounds as validateWiFiData.
+func validateAPData(ap *guiAPData) error {
+	if ap.RSSI < minRSSI || ap.RSSI > maxRSSI {
+		return fmt.Errorf("RSSI out of range: %d (expected %d to %d)", ap.RSSI, minRSSI, maxRSSI)
+	}
+	if len(ap.SSID) > maxSSIDLength {
+		return fmt.Errorf("SSID too long: %d bytes (max %d)", len(ap.SSID), maxSSIDLength)
+	}
+	if ap.BSSID != "" && !isValidMACAddress(ap.BSSID) {
+		return fmt.Errorf("invalid BSSID format: %s (expected XX:XX:XX:XX:XX:XX)", ap.BSSID)
+	}
+	return nil
+}
+
+// GetNearbyAccessPoints scans for all visible access points via the GUI IPC
+// server (get_wifi_scan command).
+//
+// Graceful degradation: if no GUI is reachable or it does not support the scan
+// command (e.g. an older GUI build), this returns an empty slice and no error
+// so the check stays healthy — the connected-AP metrics have already been
+// emitted by the time this runs.
+func (c *WLANCheck) GetNearbyAccessPoints() ([]accessPointInfo, error) {
+	if getNearbyAPs != nil {
+		return getNearbyAPs()
+	}
+
+	// Prefer the console user's GUI socket, mirroring GetWiFiInfo.
+	uid, err := getConsoleUserUID()
+	if err == nil {
+		socketPath := filepath.Join(defaultpaths.GetInstallPath(), "run", "ipc", fmt.Sprintf("gui-%s.sock", uid))
+		aps, ferr := c.fetchWiFiScanFromGUI(socketPath, scanRequestTimeout)
+		if ferr == nil {
+			return aps, nil
+		}
+		log.Infof("Console user's GUI scan unavailable: %v, trying any available socket", ferr)
+	} else {
+		log.Debugf("No console user detected: %v, trying any available socket", err)
+	}
+
+	// Fallback: try any available socket (WiFi scan data is system-wide).
+	runPath := filepath.Join(defaultpaths.GetInstallPath(), "run", "ipc")
+	sockets, globErr := filepath.Glob(filepath.Join(runPath, "gui-*.sock"))
+	if globErr == nil {
+		for _, socketPath := range sockets {
+			aps, ferr := c.fetchWiFiScanFromGUI(socketPath, scanRequestTimeout)
+			if ferr == nil {
+				return aps, nil
+			}
+			log.Debugf("Fallback scan socket %s failed: %v", socketPath, ferr)
+		}
+	}
+
+	// No socket produced scan data. Degrade gracefully rather than failing the
+	// check, since the GUI may not yet support get_wifi_scan.
+	log.Info("Nearby AP scan unavailable (GUI may not support get_wifi_scan); skipping system.wlan.scan.rssi")
+	return nil, nil
+}
+
+// fetchWiFiScanFromGUI connects to the GUI Unix socket and fetches the list of
+// visible access points via the get_wifi_scan command.
+func (c *WLANCheck) fetchWiFiScanFromGUI(socketPath string, timeout time.Duration) ([]accessPointInfo, error) {
+	// Validate socket ownership before connecting (security: prevent socket hijacking)
+	if err := validateSocketOwnership(socketPath); err != nil {
+		return nil, fmt.Errorf("socket validation failed: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to GUI socket %s: %w", socketPath, err)
+	}
+	defer conn.Close()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err != nil {
+			return nil, fmt.Errorf("failed to set deadline: %w", err)
+		}
+	}
+
+	// request_location_permission is forwarded the same way as get_wifi_info so
+	// the GUI can prompt for Location Services (BSSID/SSID require it).
+	request := map[string]any{
+		"command":                     "get_wifi_scan",
+		"request_location_permission": c.requestLocationPermission,
+	}
+	requestData, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	if _, err := conn.Write(append(requestData, '\n')); err != nil {
+		return nil, fmt.Errorf("failed to write request: %w", err)
+	}
+
+	// Read response with a larger size limit than the connected-AP path.
+	reader := bufio.NewReaderSize(conn, maxScanIPCResponseSize)
+	responseLine, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if len(responseLine) > maxScanIPCResponseSize {
+		return nil, fmt.Errorf("response too large: %d bytes (max %d)", len(responseLine), maxScanIPCResponseSize)
+	}
+
+	// Strict decoding: reject unknown/extra fields (attack detection).
+	var response guiScanResponse
+	decoder := json.NewDecoder(strings.NewReader(responseLine))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		return nil, fmt.Errorf("invalid IPC scan response structure: %w", err)
+	}
+
+	if !response.Success || response.Data == nil {
+		errMsg := "unknown error"
+		if response.Error != nil {
+			errMsg = *response.Error
+		}
+		return nil, fmt.Errorf("GUI returned error: %s", errMsg)
+	}
+
+	aps := make([]accessPointInfo, 0, len(response.Data.AccessPoints))
+	for i := range response.Data.AccessPoints {
+		ap := &response.Data.AccessPoints[i]
+		// Skip (don't fail) individual malformed entries.
+		if err := validateAPData(ap); err != nil {
+			log.Warnf("Skipping invalid access point from GUI scan: %v", err)
+			continue
+		}
+		aps = append(aps, accessPointInfo{
+			rssi:  ap.RSSI,
+			ssid:  ap.SSID,
+			bssid: ap.BSSID,
+		})
+	}
+
+	log.Debugf("WiFi scan retrieved %d access point(s)", len(aps))
+	return aps, nil
 }

--- a/pkg/collector/corechecks/net/wlan/wlan_nix.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_nix.go
@@ -16,6 +16,10 @@ import (
 // Tests can reassign this to mock WiFi data retrieval
 var getWiFiInfo func() (wifiInfo, error)
 
+// getNearbyAPs is a package-level function variable for testability
+// Tests can reassign this to mock nearby access point scanning
+var getNearbyAPs func() ([]accessPointInfo, error)
+
 // GetWiFiInfo retrieves WiFi information (not supported on this platform)
 func (c *WLANCheck) GetWiFiInfo() (wifiInfo, error) {
 	// Check for test override
@@ -24,4 +28,14 @@ func (c *WLANCheck) GetWiFiInfo() (wifiInfo, error) {
 	}
 
 	return wifiInfo{}, errors.New("wifi info only supported on macOS and Windows")
+}
+
+// GetNearbyAccessPoints scans for nearby access points (not supported on this platform)
+func (c *WLANCheck) GetNearbyAccessPoints() ([]accessPointInfo, error) {
+	// Check for test override
+	if getNearbyAPs != nil {
+		return getNearbyAPs()
+	}
+
+	return nil, errors.New("wifi scan only supported on macOS and Windows")
 }

--- a/pkg/collector/corechecks/net/wlan/wlan_test.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_test.go
@@ -929,3 +929,133 @@ func TestWLANReceiveRateValid(t *testing.T) {
 	wlanCheck.Run()
 	mockSender.AssertMetric(t, "Gauge", "system.wlan.rxrate", 5.0, "", expectedTags)
 }
+
+func TestWLANCollectNearbyAPsDefaultEnabled(t *testing.T) {
+	wlanCheck := new(WLANCheck)
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	// init_config omitted -> collect_nearby_aps defaults to enabled.
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test", "provider")
+
+	assert.True(t, wlanCheck.collectNearbyAPs)
+}
+
+func TestWLANCollectNearbyAPsExplicitTrue(t *testing.T) {
+	wlanCheck := new(WLANCheck)
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, integration.Data("collect_nearby_aps: true"), "test", "provider")
+
+	assert.True(t, wlanCheck.collectNearbyAPs)
+}
+
+func TestWLANCollectNearbyAPsDisabled(t *testing.T) {
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:       10,
+			ssid:       "test-ssid",
+			bssid:      "test-bssid",
+			macAddress: "hardware-address",
+			phyMode:    "802.11ac",
+		}, nil
+	}
+	getNearbyAPs = func() ([]accessPointInfo, error) {
+		t.Fatal("GetNearbyAccessPoints should not be called when collect_nearby_aps is false")
+		return nil, nil
+	}
+	defer func() {
+		getWiFiInfo = nil
+		getNearbyAPs = nil
+	}()
+
+	wlanCheck := new(WLANCheck)
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, integration.Data("collect_nearby_aps: false"), "test", "provider")
+
+	assert.False(t, wlanCheck.collectNearbyAPs)
+
+	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+
+	wlanCheck.Run()
+
+	mockSender.AssertMetricMissing(t, "Gauge", "system.wlan.scan.rssi")
+}
+
+func TestWLANScanRSSIEmission(t *testing.T) {
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "AA:BB:CC:DD:EE:01",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
+		}, nil
+	}
+	getNearbyAPs = func() ([]accessPointInfo, error) {
+		return []accessPointInfo{
+			{rssi: 10, ssid: "test-ssid", bssid: "AA:BB:CC:DD:EE:01"},   // the connected AP
+			{rssi: -60, ssid: "neighbor-1", bssid: "AA:BB:CC:DD:EE:02"}, // nearby
+			{rssi: -70, ssid: "", bssid: ""},                            // nearby, missing ssid/bssid
+		}, nil
+	}
+	defer func() {
+		getWiFiInfo = nil
+		getNearbyAPs = nil
+	}()
+
+	wlanCheck := new(WLANCheck)
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test", "provider")
+
+	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+
+	wlanCheck.Run()
+
+	// The connected AP is tagged connected:1; nearby APs connected:0. Empty
+	// ssid/bssid fall back to "unknown" like the connected-AP path.
+	mockSender.AssertMetric(t, "Gauge", "system.wlan.scan.rssi", 10.0, "", []string{"ssid:test-ssid", "bssid:AA:BB:CC:DD:EE:01", "connected:1"})
+	mockSender.AssertMetric(t, "Gauge", "system.wlan.scan.rssi", -60.0, "", []string{"ssid:neighbor-1", "bssid:AA:BB:CC:DD:EE:02", "connected:0"})
+	mockSender.AssertMetric(t, "Gauge", "system.wlan.scan.rssi", -70.0, "", []string{"ssid:unknown", "bssid:unknown", "connected:0"})
+}
+
+func TestWLANScanErrorDoesNotFailCheck(t *testing.T) {
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "test-bssid",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
+		}, nil
+	}
+	getNearbyAPs = func() ([]accessPointInfo, error) {
+		return nil, errors.New("scan failed")
+	}
+	defer func() {
+		getWiFiInfo = nil
+		getNearbyAPs = nil
+	}()
+
+	expectedTags := []string{"ssid:test-ssid", "bssid:test-bssid", "mac_address:hardware-address", "status:ok"}
+
+	wlanCheck := new(WLANCheck)
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test", "provider")
+
+	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+
+	// A scan failure is non-fatal: connected-AP metrics still emit and Run succeeds.
+	err := wlanCheck.Run()
+	assert.NoError(t, err)
+	mockSender.AssertMetric(t, "Gauge", "system.wlan.rssi", 10.0, "", expectedTags)
+	mockSender.AssertMetricMissing(t, "Gauge", "system.wlan.scan.rssi")
+}

--- a/pkg/collector/corechecks/net/wlan/wlan_test.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_test.go
@@ -930,24 +930,24 @@ func TestWLANReceiveRateValid(t *testing.T) {
 	mockSender.AssertMetric(t, "Gauge", "system.wlan.rxrate", 5.0, "", expectedTags)
 }
 
-func TestWLANCollectNearbyAPsDefaultEnabled(t *testing.T) {
+func TestWLANAPScanDefaultEnabled(t *testing.T) {
 	wlanCheck := new(WLANCheck)
 	senderManager := mocksender.CreateDefaultDemultiplexer()
-	// init_config omitted -> collect_nearby_aps defaults to enabled.
+	// init_config omitted -> ap_scan defaults to enabled.
 	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test", "provider")
 
-	assert.True(t, wlanCheck.collectNearbyAPs)
+	assert.True(t, wlanCheck.apScanEnabled)
 }
 
-func TestWLANCollectNearbyAPsExplicitTrue(t *testing.T) {
+func TestWLANAPScanExplicitTrue(t *testing.T) {
 	wlanCheck := new(WLANCheck)
 	senderManager := mocksender.CreateDefaultDemultiplexer()
-	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, integration.Data("collect_nearby_aps: true"), "test", "provider")
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, integration.Data("ap_scan: true"), "test", "provider")
 
-	assert.True(t, wlanCheck.collectNearbyAPs)
+	assert.True(t, wlanCheck.apScanEnabled)
 }
 
-func TestWLANCollectNearbyAPsDisabled(t *testing.T) {
+func TestWLANAPScanDisabled(t *testing.T) {
 	getWiFiInfo = func() (wifiInfo, error) {
 		return wifiInfo{
 			rssi:       10,
@@ -958,7 +958,7 @@ func TestWLANCollectNearbyAPsDisabled(t *testing.T) {
 		}, nil
 	}
 	getNearbyAPs = func() ([]accessPointInfo, error) {
-		t.Fatal("GetNearbyAccessPoints should not be called when collect_nearby_aps is false")
+		t.Fatal("GetNearbyAccessPoints should not be called when ap_scan is false")
 		return nil, nil
 	}
 	defer func() {
@@ -968,9 +968,9 @@ func TestWLANCollectNearbyAPsDisabled(t *testing.T) {
 
 	wlanCheck := new(WLANCheck)
 	senderManager := mocksender.CreateDefaultDemultiplexer()
-	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, integration.Data("collect_nearby_aps: false"), "test", "provider")
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, integration.Data("ap_scan: false"), "test", "provider")
 
-	assert.False(t, wlanCheck.collectNearbyAPs)
+	assert.False(t, wlanCheck.apScanEnabled)
 
 	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
 	mockSender.SetupAcceptAll()
@@ -1058,4 +1058,169 @@ func TestWLANScanErrorDoesNotFailCheck(t *testing.T) {
 	assert.NoError(t, err)
 	mockSender.AssertMetric(t, "Gauge", "system.wlan.rssi", 10.0, "", expectedTags)
 	mockSender.AssertMetricMissing(t, "Gauge", "system.wlan.scan.rssi")
+}
+
+func TestAPFilterAllowed(t *testing.T) {
+	tests := []struct {
+		name                           string
+		ssidInc, ssidExc, bsInc, bsExc []string
+		ssid, bssid                    string
+		want                           bool
+	}{
+		{name: "default allow all", ssid: "Any", bssid: "aa:bb", want: true},
+		{name: "ssid include match", ssidInc: []string{"Corp-*"}, ssid: "Corp-5G", bssid: "x", want: true},
+		{name: "ssid include no match", ssidInc: []string{"Corp-*"}, ssid: "Home", bssid: "x", want: false},
+		{name: "ssid include case-insensitive", ssidInc: []string{"corp-*"}, ssid: "CORP-5G", bssid: "x", want: true},
+		{name: "ssid exclude wins", ssidInc: []string{"*"}, ssidExc: []string{"Home"}, ssid: "Home", bssid: "x", want: false},
+		{name: "exclude only blocks match", ssidExc: []string{"Home"}, ssid: "Home", bssid: "x", want: false},
+		{name: "exclude only allows non-match", ssidExc: []string{"Home"}, ssid: "Work", bssid: "x", want: true},
+		{name: "bssid include match", bsInc: []string{"00:1a:2b:*"}, ssid: "x", bssid: "00:1A:2B:CC:DD:EE", want: true},
+		{name: "include set but empty inputs", ssidInc: []string{"Corp-*"}, ssid: "", bssid: "", want: false},
+		{name: "ssid or bssid include (bssid matches)", ssidInc: []string{"Corp-*"}, bsInc: []string{"00:*"}, ssid: "Home", bssid: "00:11:22", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newAPFilter(tc.ssidInc, tc.ssidExc, tc.bsInc, tc.bsExc)
+			assert.Equal(t, tc.want, f.allowed(tc.ssid, tc.bssid))
+		})
+	}
+}
+
+func TestWLANMetricFilterExcludesConnected(t *testing.T) {
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi: 10, ssid: "HomeNet", bssid: "AA:BB:CC:DD:EE:01",
+			noise: 20, noiseValid: true, transmitRate: 4.0,
+			macAddress: "hardware-address", phyMode: "802.11ac",
+		}, nil
+	}
+	getNearbyAPs = func() ([]accessPointInfo, error) { return nil, nil }
+	defer func() { getWiFiInfo = nil; getNearbyAPs = nil }()
+
+	wlanCheck := new(WLANCheck)
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, integration.Data("ssid_exclude:\n  - HomeNet\n"), "test", "provider")
+
+	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+
+	err := wlanCheck.Run()
+	assert.NoError(t, err)
+	// Connected network is excluded -> no connected metrics, no status.
+	mockSender.AssertMetricMissing(t, "Gauge", "system.wlan.rssi")
+	mockSender.AssertMetricMissing(t, "Gauge", "system.wlan.status")
+}
+
+func TestWLANScanFilterGatesScan(t *testing.T) {
+	// Connected SSID does not match scan_ssid_include -> scan must not run.
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi: 10, ssid: "HomeNet", bssid: "AA:BB:CC:DD:EE:01",
+			noise: 20, noiseValid: true, transmitRate: 4.0,
+			macAddress: "hardware-address", phyMode: "802.11ac",
+		}, nil
+	}
+	getNearbyAPs = func() ([]accessPointInfo, error) {
+		t.Fatal("scan must not run when connected network is not in scan_ssid_include")
+		return nil, nil
+	}
+	defer func() { getWiFiInfo = nil; getNearbyAPs = nil }()
+
+	wlanCheck := new(WLANCheck)
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, integration.Data("scan_ssid_include:\n  - \"Corp-*\"\n"), "test", "provider")
+
+	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+
+	err := wlanCheck.Run()
+	assert.NoError(t, err)
+	// Connected metrics still emit (metric filter is allow-all); scan does not.
+	mockSender.AssertMetric(t, "Gauge", "system.wlan.rssi", 10.0, "", []string{"ssid:HomeNet", "bssid:AA:BB:CC:DD:EE:01", "mac_address:hardware-address", "status:ok"})
+	mockSender.AssertMetricMissing(t, "Gauge", "system.wlan.scan.rssi")
+}
+
+func TestWLANScanFilterAllowsGlob(t *testing.T) {
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi: 10, ssid: "Corp-5G", bssid: "AA:BB:CC:DD:EE:01",
+			noise: 20, noiseValid: true, transmitRate: 4.0,
+			macAddress: "hardware-address", phyMode: "802.11ac",
+		}, nil
+	}
+	getNearbyAPs = func() ([]accessPointInfo, error) {
+		return []accessPointInfo{{rssi: -60, ssid: "Corp-5G", bssid: "AA:BB:CC:DD:EE:02"}}, nil
+	}
+	defer func() { getWiFiInfo = nil; getNearbyAPs = nil }()
+
+	wlanCheck := new(WLANCheck)
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, integration.Data("scan_ssid_include:\n  - \"Corp-*\"\n"), "test", "provider")
+
+	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+
+	err := wlanCheck.Run()
+	assert.NoError(t, err)
+	mockSender.AssertMetric(t, "Gauge", "system.wlan.scan.rssi", -60.0, "", []string{"ssid:Corp-5G", "bssid:AA:BB:CC:DD:EE:02", "connected:0"})
+}
+
+func TestWLANAPScanRSSICutoffKeepsConnected(t *testing.T) {
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{rssi: -85, ssid: "test-ssid", bssid: "AA:BB:CC:DD:EE:01", macAddress: "m", phyMode: "802.11ac"}, nil
+	}
+	getNearbyAPs = func() ([]accessPointInfo, error) {
+		return []accessPointInfo{
+			{rssi: -85, ssid: "test-ssid", bssid: "AA:BB:CC:DD:EE:01"}, // connected, weak (kept anyway)
+			{rssi: -60, ssid: "near-strong", bssid: "AA:BB:CC:DD:EE:02"},
+			{rssi: -90, ssid: "near-weak", bssid: "AA:BB:CC:DD:EE:03"}, // below cutoff -> dropped
+		}, nil
+	}
+	defer func() { getWiFiInfo = nil; getNearbyAPs = nil }()
+
+	wlanCheck := new(WLANCheck)
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	// Exclude connected metrics so only scan.rssi gauges are emitted (isolates the count).
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, integration.Data("ap_scan_rssi_cutoff: -80\nssid_exclude:\n  - \"*\"\n"), "test", "provider")
+
+	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+
+	err := wlanCheck.Run()
+	assert.NoError(t, err)
+	mockSender.AssertMetric(t, "Gauge", "system.wlan.scan.rssi", -85.0, "", []string{"ssid:test-ssid", "bssid:AA:BB:CC:DD:EE:01", "connected:1"})
+	mockSender.AssertMetric(t, "Gauge", "system.wlan.scan.rssi", -60.0, "", []string{"ssid:near-strong", "bssid:AA:BB:CC:DD:EE:02", "connected:0"})
+	// Only connected(-85) and near-strong(-60) survive; near-weak(-90) dropped.
+	mockSender.AssertNumberOfCalls(t, "Gauge", 2)
+}
+
+func TestWLANAPScanLimitKeepsStrongestPlusConnected(t *testing.T) {
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{rssi: -50, ssid: "test-ssid", bssid: "AA:BB:CC:DD:EE:01", macAddress: "m", phyMode: "802.11ac"}, nil
+	}
+	getNearbyAPs = func() ([]accessPointInfo, error) {
+		return []accessPointInfo{
+			{rssi: -50, ssid: "test-ssid", bssid: "AA:BB:CC:DD:EE:01"}, // connected
+			{rssi: -70, ssid: "n3", bssid: "AA:BB:CC:DD:EE:04"},
+			{rssi: -60, ssid: "n2", bssid: "AA:BB:CC:DD:EE:03"},
+			{rssi: -80, ssid: "n4", bssid: "AA:BB:CC:DD:EE:05"},
+			{rssi: -55, ssid: "n1", bssid: "AA:BB:CC:DD:EE:02"},
+		}, nil
+	}
+	defer func() { getWiFiInfo = nil; getNearbyAPs = nil }()
+
+	wlanCheck := new(WLANCheck)
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, integration.Data("ap_scan_limit: 2\nssid_exclude:\n  - \"*\"\n"), "test", "provider")
+
+	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+
+	err := wlanCheck.Run()
+	assert.NoError(t, err)
+	// connected(-50) always + 2 strongest nearby (-55, -60).
+	mockSender.AssertMetric(t, "Gauge", "system.wlan.scan.rssi", -50.0, "", []string{"ssid:test-ssid", "bssid:AA:BB:CC:DD:EE:01", "connected:1"})
+	mockSender.AssertMetric(t, "Gauge", "system.wlan.scan.rssi", -55.0, "", []string{"ssid:n1", "bssid:AA:BB:CC:DD:EE:02", "connected:0"})
+	mockSender.AssertMetric(t, "Gauge", "system.wlan.scan.rssi", -60.0, "", []string{"ssid:n2", "bssid:AA:BB:CC:DD:EE:03", "connected:0"})
+	mockSender.AssertNumberOfCalls(t, "Gauge", 3)
 }

--- a/pkg/collector/corechecks/net/wlan/wlan_windows.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_windows.go
@@ -26,10 +26,10 @@ var (
 	wlanAPI            = windows.NewLazyDLL("wlanapi.dll")
 	wlanOpenHandle     = wlanAPI.NewProc("WlanOpenHandle")
 	wlanCloseHandle    = wlanAPI.NewProc("WlanCloseHandle")
-	wlanEnumInterfaces = wlanAPI.NewProc("WlanEnumInterfaces")
-	wlanQueryInterface = wlanAPI.NewProc("WlanQueryInterface")
-	// wlanGetNetworkBssList = wlanAPI.NewProc("WlanGetNetworkBssList")
-	wlanFreeMemory = wlanAPI.NewProc("WlanFreeMemory")
+	wlanEnumInterfaces    = wlanAPI.NewProc("WlanEnumInterfaces")
+	wlanQueryInterface    = wlanAPI.NewProc("WlanQueryInterface")
+	wlanGetNetworkBssList = wlanAPI.NewProc("WlanGetNetworkBssList")
+	wlanFreeMemory        = wlanAPI.NewProc("WlanFreeMemory")
 
 	iphlpapi                   = windows.NewLazyDLL("iphlpapi.dll")
 	getIfEntry2                = iphlpapi.NewProc("GetIfEntry2")
@@ -38,6 +38,10 @@ var (
 	// getWiFiInfo is a package-level function variable for testability
 	// Tests can reassign this to mock WiFi data retrieval
 	getWiFiInfo func() (wifiInfo, error)
+
+	// getNearbyAPs is a package-level function variable for testability
+	// Tests can reassign this to mock nearby access point scanning
+	getNearbyAPs func() ([]accessPointInfo, error)
 )
 
 // https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/ne-wlanapi-wlan_interface_state-r1
@@ -211,6 +215,55 @@ type WLAN_CONNECTION_ATTRIBUTES struct {
 	profileName               [256]uint16
 	wlanAssociationAttributes WLAN_ASSOCIATION_ATTRIBUTES
 	wlanSecurityAttributes    WLAN_SECURITY_ATTRIBUTES
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/nativewifi/dot11-bss-type
+type WLAN_BSS_TYPE uint32
+
+const (
+	dot11BssTypeInfrastructure WLAN_BSS_TYPE = 1
+	dot11BssTypeIndependent    WLAN_BSS_TYPE = 2
+	dot11BssTypeAny            WLAN_BSS_TYPE = 3
+)
+
+// DOT11_RATE_SET_MAX_LENGTH from the Native WiFi headers.
+const dot11RateSetMaxLength = 126
+
+// https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/ns-wlanapi-wlan_rate_set
+type WLAN_RATE_SET struct {
+	uRateSetLength uint32
+	usRateSet      [dot11RateSetMaxLength]uint16
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/ns-wlanapi-wlan_bss_entry
+//
+// The field order and types mirror the C struct exactly so the in-memory
+// layout matches; Go's automatic padding aligns with MSVC's for these types
+// on windows/amd64 (the only Windows architecture the Agent ships).
+type WLAN_BSS_ENTRY struct {
+	dot11Ssid               DOT11_SSID
+	uPhyId                  uint32
+	dot11Bssid              [6]byte
+	dot11BssType            uint32 // WLAN_BSS_TYPE
+	dot11BssPhyType         uint32 // DOT11_PHY_TYPE
+	lRssi                   int32  // signal strength in dBm
+	uLinkQuality            uint32
+	bInRegDomain            byte // BOOLEAN
+	usBeaconPeriod          uint16
+	ullTimestamp            uint64
+	ullHostTimestamp        uint64
+	usCapabilityInformation uint16
+	ulChCenterFrequency     uint32
+	wlanRateSet             WLAN_RATE_SET
+	ulIeOffset              uint32
+	ulIeSize                uint32
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/ns-wlanapi-wlan_bss_list
+type WLAN_BSS_LIST struct {
+	TotalSize      uint32
+	NumberOfItems  uint32
+	wlanBssEntries [1]WLAN_BSS_ENTRY
 }
 
 // ------------------------------------------------------
@@ -503,6 +556,91 @@ func getFirstConnectedWlanInfo() (*wifiInfo, error) {
 	}
 
 	log.Tracef("No connected WLAN interfaces are found")
+	return nil, nil
+}
+
+// getNetworkBssList returns one accessPointInfo per visible BSS for the given
+// interface. It uses the cached BSS list (no forced WlanScan), which is
+// lightweight enough for the check's collection interval.
+func getNetworkBssList(wlanClient uintptr, itfGuid windows.GUID) ([]accessPointInfo, error) {
+	// https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/nf-wlanapi-wlangetnetworkbsslist
+	var bssList *WLAN_BSS_LIST
+	ret, _, _ := wlanGetNetworkBssList.Call(
+		wlanClient,
+		uintptr(unsafe.Pointer(&itfGuid)),
+		0, // pDot11Ssid = NULL -> return BSSs for all SSIDs
+		uintptr(dot11BssTypeAny),
+		0, // bSecurityEnabled (ignored when pDot11Ssid is NULL)
+		0, // pReserved
+		uintptr(unsafe.Pointer(&bssList)),
+	)
+	if ret != 0 {
+		return nil, fmt.Errorf("wlanGetNetworkBssList failed: %d", ret)
+	}
+	if bssList == nil {
+		return nil, nil
+	}
+	defer wlanFreeMemory.Call(uintptr(unsafe.Pointer(bssList))) //nolint:errcheck
+
+	n := int(bssList.NumberOfItems)
+	if n == 0 {
+		return nil, nil
+	}
+
+	aps := make([]accessPointInfo, 0, n)
+	entrySize := unsafe.Sizeof(WLAN_BSS_ENTRY{})
+	base := unsafe.Pointer(&bssList.wlanBssEntries[0])
+	for i := 0; i < n; i++ {
+		// unsafe.Add keeps pointer provenance (vet-clean), unlike a
+		// uintptr round-trip. bssList stays live via the defer above.
+		entry := (*WLAN_BSS_ENTRY)(unsafe.Add(base, uintptr(i)*entrySize))
+		bssid, err := formatMacAddress(entry.dot11Bssid[:])
+		if err != nil {
+			log.Warnf("Skipping access point with invalid BSSID: %v", err)
+			continue
+		}
+		aps = append(aps, accessPointInfo{
+			rssi:  int(entry.lRssi),
+			ssid:  formatSSID(entry.dot11Ssid),
+			bssid: bssid,
+		})
+	}
+	return aps, nil
+}
+
+// GetNearbyAccessPoints scans for all visible access points on Windows.
+func (c *WLANCheck) GetNearbyAccessPoints() ([]accessPointInfo, error) {
+	// Check for test override
+	if getNearbyAPs != nil {
+		return getNearbyAPs()
+	}
+
+	wlanClient, err := getWlanHandle()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get WLAN client handle: %v", err)
+	}
+	defer wlanCloseHandle.Call(wlanClient, 0) //nolint:errcheck
+
+	itfs, err := getWlanInterfacesList(wlanClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get WLAN interfaces: %v", err)
+	}
+	defer wlanFreeMemory.Call(uintptr(unsafe.Pointer(itfs))) //nolint:errcheck
+
+	if itfs.NumberOfItems == 0 {
+		return nil, nil
+	}
+
+	// Scan using the first connected interface (consistent with the
+	// connected-AP path in getFirstConnectedWlanInfo).
+	for i := 0; i < int(itfs.NumberOfItems); i++ {
+		itf := &itfs.InterfaceInfo[i]
+		if itf.IsState != uint32(wlanInterfaceStateConnected) {
+			continue
+		}
+		return getNetworkBssList(wlanClient, itf.InterfaceGUID)
+	}
+
 	return nil, nil
 }
 

--- a/releasenotes/notes/wlan-scan-rssi-3f2a9c1b7e4d6a08.yaml
+++ b/releasenotes/notes/wlan-scan-rssi-3f2a9c1b7e4d6a08.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The ``wlan`` integration now emits ``system.wlan.scan.rssi``, a per-access-point
+    signal-strength metric covering every visible access point (the connected one and
+    nearby ones whose RSSI is measurable). Each series is tagged with ``ssid``, ``bssid``,
+    and ``connected`` (``1`` for the currently connected access point, ``0`` otherwise).
+    This is supported on Windows and macOS. Collection is enabled by default and can be
+    disabled by setting ``collect_nearby_aps: false`` in the integration ``init_config``.

--- a/releasenotes/notes/wlan-scan-rssi-3f2a9c1b7e4d6a08.yaml
+++ b/releasenotes/notes/wlan-scan-rssi-3f2a9c1b7e4d6a08.yaml
@@ -13,4 +13,15 @@ features:
     nearby ones whose RSSI is measurable). Each series is tagged with ``ssid``, ``bssid``,
     and ``connected`` (``1`` for the currently connected access point, ``0`` otherwise).
     This is supported on Windows and macOS. Collection is enabled by default and can be
-    disabled by setting ``collect_nearby_aps: false`` in the integration ``init_config``.
+    disabled by setting ``ap_scan: false`` in the integration ``init_config``.
+
+    The nearby access point scan can be bounded with ``ap_scan_limit`` (report only the
+    N strongest nearby access points) and ``ap_scan_rssi_cutoff`` (drop nearby access
+    points weaker than a given RSSI in dBm); the connected access point is always reported.
+
+    Two glob-pattern include/exclude filters, matched against the currently connected
+    network, are also available: ``ssid_include``/``ssid_exclude``/``bssid_include``/
+    ``bssid_exclude`` gate the connected access point metrics, and ``scan_ssid_include``/
+    ``scan_ssid_exclude``/``scan_bssid_include``/``scan_bssid_exclude`` gate whether the
+    nearby access point scan runs at all (for example, to scan only when connected to a
+    work network).


### PR DESCRIPTION
[NO REVIEW NEEDED, if you pinged it was by accident, sorry about it. Moving it to draft]

### What does this PR do?

Adds a new metric, `system.wlan.scan.rssi`, to the `wlan` integration. Unlike the existing connected-only `system.wlan.rssi`, this metric is emitted **once per visible access point** — the connected AP *and* nearby APs whose signal is measurable.

Each series carries the tags:

- `ssid` — the access point's network name (`unknown` if unavailable)
- `bssid` — the access point's MAC address (`unknown` if unavailable)
- `connected` — `1` for the currently connected AP, `0` for every other visible AP

Collection is **enabled by default** and can be disabled with the new `collect_nearby_aps` flag in the integration `init_config`.

### Motivation

`system.wlan.rssi` only reports the connected access point. That hides the surrounding RF environment — e.g. whether a stronger AP is nearby that the device isn't roaming to. Emitting per-AP RSSI with a `connected:1|0` tag gives visibility into coverage and roaming decisions while keeping the connected-only metric intact.

### Implementation

**Shared logic — `pkg/collector/corechecks/net/wlan/wlan.go`**
- New `accessPointInfo` struct (`rssi`, `ssid`, `bssid`) — a pure platform-data carrier. Whether an AP is the connected one is derived at emit time, not stored.
- New `emitNearbyAPs(sender, connectedBSSID)` helper: calls the platform `GetNearbyAccessPoints()`, and for each AP emits `system.wlan.scan.rssi` with `connected:1` when `strings.EqualFold(ap.bssid, connectedBSSID)` else `connected:0`. A scan failure is **non-fatal** — connected-AP metrics have already been emitted, so it logs and returns.
- New `collect_nearby_aps` field on `wlanInitConfig` (a `*bool`, so omission ⇒ enabled). New `collectNearbyAPs` field on `WLANCheck`, set in `Configure`.

**Windows — `wlan_windows.go`**
- Enabled the previously stubbed `WlanGetNetworkBssList` proc and added the `WLAN_BSS_ENTRY` / `WLAN_BSS_LIST` / `WLAN_RATE_SET` structs (layout mirrors the Win32 headers; windows/amd64 only).
- New `getNetworkBssList(...)` reads the **cached** BSS list (no forced `WlanScan` — lightweight for the collection interval) and builds one `accessPointInfo` per entry. New `GetNearbyAccessPoints()` method scans on the first connected interface.

**macOS — `wlan_darwin.go` + in-repo Swift systray GUI**
- The agent does not query CoreWLAN directly; it asks the in-repo Swift GUI over IPC. Added a new `get_wifi_scan` command end-to-end:
  - `comp/core/gui/impl/systray/Sources/WiFiDataProvider.swift`: new `scanForNetworks(requestLocationPermission:)` using CoreWLAN `CWInterface.scanForNetworks(withName: nil)`, returning `WiFiScanData` (`AccessPointData` list).
  - `comp/core/gui/impl/systray/Sources/WiFiIPCServer.swift`: new `case "get_wifi_scan"` dispatch and a `WiFiScanIPCResponse` type; `sendResponse` generalized to any `Encodable`.
  - `wlan_darwin.go`: `GetNearbyAccessPoints()` + `fetchWiFiScanFromGUI(...)` parse the response (strict `DisallowUnknownFields`, per-AP `validateAPData`, larger `maxScanIPCResponseSize`, longer `scanRequestTimeout` since an active scan takes seconds). **Degrades gracefully** (returns empty, no error) if the GUI predates scan support.

**Unsupported platforms — `wlan_nix.go`**
- `GetNearbyAccessPoints()` returns an unsupported-platform error, mirroring `GetWiFiInfo`.

**Config & docs**
- Documented `collect_nearby_aps` in `conf.d/wlan.d/conf.yaml.example` and `conf.yaml.default`.

### Describe how you validated your changes

- Added unit tests in `wlan_test.go`: default-enabled config, explicit `true`/`false`, per-AP emission with correct `connected:1|0` and `unknown` fallbacks, and graceful degradation (scan error ⇒ connected metrics still emit, `Run()` returns `nil`).
- Manual QA to follow: `agent check wlan` on Windows (multiple visible SSIDs) and macOS (with the GUI running) to confirm one `system.wlan.scan.rssi` per BSSID and that `collect_nearby_aps: false` suppresses them.

### Additional Notes

- `system.wlan.rssi` (connected-only) is unchanged. The connected AP also appears in `system.wlan.scan.rssi` with `connected:1`, so the new metric is a complete view.
- Metric metadata/docs for the integration tile live in `integrations-core` (separate repo) and will be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
