### PR TITLE
Change default entry point and args of the DDOT image

### DIFF
--- a/Dockerfiles/otel-agent/Dockerfile
+++ b/Dockerfiles/otel-agent/Dockerfile
@@ -94,5 +94,5 @@ RUN find /etc -type d,f -perm -o+w -print0 | xargs -r -0 chmod g-w,o-w
 
 ENV DD_OTELCOLLECTOR_ENABLED=true
 
-ENTRYPOINT ["/bin/bash"]
-CMD ["/opt/datadog-agent/embedded/bin/otel-agent", "run"]
+ENTRYPOINT ["otel-agent", "run"]
+CMD ["--config", "file:/etc/datadog-agent/otel-config.yaml"]

--- a/Dockerfiles/otel-agent/Dockerfile
+++ b/Dockerfiles/otel-agent/Dockerfile
@@ -94,5 +94,5 @@ RUN find /etc -type d,f -perm -o+w -print0 | xargs -r -0 chmod g-w,o-w
 
 ENV DD_OTELCOLLECTOR_ENABLED=true
 
-ENTRYPOINT ["otel-agent", "run"]
-CMD ["--config", "file:/etc/datadog-agent/otel-config.yaml"]
+ENTRYPOINT ["otel-agent"]
+CMD ["run", "--config", "file:/etc/datadog-agent/otel-config.yaml"]


### PR DESCRIPTION
### What does this PR do?

Fix the default entrypoint of the otel agent image being non-sensical.

We can now run the image with docker without having to override the entrypoint:
```shell
docker run \
  -e DD_API_KEY -e DD_SITE -e DD_HOSTNAME=$(uname -n) \
  -it --rm \
  datadog/ddot-collector:latest
```
will now work and run DDOT using the default bundled config (overridable by mounting another config at `/etc/datadog-agent/otel-config.yaml`, without having to set the args), instead of crashing with a cryptic error like:
```console
/opt/datadog-agent/embedded/bin/otel-agent: /opt/datadog-agent/embedded/bin/otel-agent: cannot execute binary file
2026/06/15 18:08:27 could not run command: exit status 126
```

### Motivation

Reduce steps to deploy DDOT standalone using open source tooling.

I had falsely claimed that this would be a breaking change, but after double-checking our Helm chart and operator, I confirm that we always override the `command` (and not just `args`) field of the `otel-agent` container.

Sources:
- Helm chart
  - [daemonset](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/templates/_container-otel-agent.yaml#L14-L41)
  - [gateway](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/templates/otel-agent-gateway-deployment.yaml#L119-L135)
- Operator
  - [daemonset](https://github.com/DataDog/datadog-operator/blob/main/internal/controller/datadogagent/component/agent/default.go#L500-L504)
  - [gateway](https://github.com/DataDog/datadog-operator/blob/main/internal/controller/datadogagent/component/otelagentgateway/default.go#L82)
