### PR TITLE
fix(renovate): Improve go configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -102,7 +102,6 @@
       {
         "description": "Disable Go directives, toolchain (go update is managed independently) or replace (->fork)",
         "matchManagers": ["gomod"],
-        "matchDepNames": ["go"],
         "matchDepTypes": ["golang", "toolchain", "replace"],
         "enabled": false
       },

--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,6 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended", "mergeConfidence:all-badges", ":enablePreCommit", "schedule:nonOfficeHours"],
     "ignorePaths": [],
-    "constraints": {
-      "go": "1.26.4"
-    },
-    "constraintsFiltering": "strict",
     "minimumReleaseAge": "7 days",
     "prConcurrentLimit": 20,
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
@@ -98,11 +94,20 @@
         "enabled": false
       },
       {
+        "description": "Only propose Go module updates compatible with the module go directive",
         "matchManagers": ["gomod"],
-        "matchDepTypes": ["replace"],
+        "matchDepTypes": ["require", "indirect", "tool"],
+        "constraintsFiltering": "strict"
+      },
+      {
+        "description": "Disable Go directives, toolchain (go update is managed independently) or replace (->fork)",
+        "matchManagers": ["gomod"],
+        "matchDepNames": ["go"],
+        "matchDepTypes": ["golang", "toolchain", "replace"],
         "enabled": false
       },
       {
+        "description": "Disable when pinned on a commit (->forks)",
         "matchManagers": ["gomod"],
         "matchUpdateTypes": ["digest"],
         "enabled": false

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -31,7 +31,6 @@ GO_VERSION_REFERENCES: list[tuple[str, str, str, bool]] = [
     ("./pkg/logs/launchers/windowsevent/README.md", "install go ", "+,", False),
     ("./tools/host-profiler/Dockerfile", "FROM golang:", "-trixie", True),
     ("./.wwhrd.yml", "raw.githubusercontent.com/golang/go/go", "/LICENSE", True),
-    ("./renovate.json", '"go": "', '"', True),
     ("./go.work", "go ", "", True),
     ("./Dockerfiles/agent-ddot/Dockerfile.agent-otel", "ARG GO_VERSION=", "", True),
 ]


### PR DESCRIPTION
Remove the previous constraint on `gomod` that prevented renovate to propose recent updates on libraries. The new version with specific updates on `packageRules` should unleash way more dependencies

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
