### PR TITLE
[Backport 7.80.x] Reapply "Update dependency linux-images to v114075546" (#51125) (#51136)

### DIFF
--- a/.gitlab/.pre/deps_fetch/deps_fetch.yml
+++ b/.gitlab/.pre/deps_fetch/deps_fetch.yml
@@ -8,14 +8,28 @@
   - rm -f modcache.tar.zst
 
 .retrieve_linux_go_tools_deps: 
-  - mkdir -p $GOPATH/bin $GOPATH/pkg/mod/cache && zstd -dc modcache_tools.tar.zst | tar xf - -C $GOPATH
-  - rm -f modcache_tools.tar.zst
-  - export PATH=$PATH:$GOPATH/bin
+  - |
+    go_bin="$(go env GOBIN)"
+    if [ -z "$go_bin" ]; then
+      go_bin="$(go env GOPATH)/bin"
+    fi
+    mkdir -p "$go_bin" "$GOPATH/pkg/mod/cache"
+    zstd -dc go_tools_bin.tar.zst | tar xf - -C "$go_bin"
+    zstd -dc modcache_tools.tar.zst | tar xf - -C "$GOPATH/pkg/mod/cache"
+  - rm -f go_tools_bin.tar.zst modcache_tools.tar.zst
+  - export PATH=$PATH:$go_bin
 
 .retrieve_linux_go_tools_deps_arm64:
-  - mkdir -p $GOPATH/bin $GOPATH/pkg/mod/cache && zstd -dc modcache_tools_arm64.tar.zst | tar xf - -C $GOPATH
-  - rm -f modcache_tools_arm64.tar.zst
-  - export PATH=$PATH:$GOPATH/bin
+  - |
+    go_bin="$(go env GOBIN)"
+    if [ -z "$go_bin" ]; then
+      go_bin="$(go env GOPATH)/bin"
+    fi
+    mkdir -p "$go_bin" "$GOPATH/pkg/mod/cache"
+    zstd -dc go_tools_bin_arm64.tar.zst | tar xf - -C "$go_bin"
+    zstd -dc modcache_tools_arm64.tar.zst | tar xf - -C "$GOPATH/pkg/mod/cache"
+  - rm -f go_tools_bin_arm64.tar.zst modcache_tools_arm64.tar.zst
+  - export PATH=$PATH:$go_bin
 
 .retrieve_linux_go_e2e_deps:
   - mkdir -p $GOPATH/pkg/mod/cache && zstd -dc modcache_e2e.tar.zst | tar xf - -C $GOPATH/pkg/mod/cache
@@ -73,13 +87,20 @@ go_tools_deps:
   extends: .cache
   tags: ["arch:amd64", "specific:true"]
   script:
-    - if [ -f modcache_tools.tar.zst  ]; then exit 0; fi
+    - if [ -f go_tools_bin.tar.zst ] && [ -f modcache_tools.tar.zst ]; then exit 0; fi
     - dda inv -- -e install-tools
     # Exclude datadog-package binary from the cache: it's already installed on all images and they don't have the same glibc version
-    - cd $GOPATH && tar c -I "zstd -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache_tools.tar.zst $(find bin/ -type f ! -name 'datadog-package') pkg/mod/cache/
+    - |
+      go_bin="$(go env GOBIN)"
+      if [ -z "$go_bin" ]; then
+        go_bin="$(go env GOPATH)/bin"
+      fi
+      tar c -C "$go_bin" -I "zstd -T${KUBERNETES_CPU_REQUEST}" -f "$CI_PROJECT_DIR/go_tools_bin.tar.zst" --exclude='./datadog-package' .
+      tar c -C "$GOPATH/pkg/mod/cache" -I "zstd -T${KUBERNETES_CPU_REQUEST}" -f "$CI_PROJECT_DIR/modcache_tools.tar.zst" .
   artifacts:
     expire_in: 1 day
     paths:
+      - $CI_PROJECT_DIR/go_tools_bin.tar.zst
       - $CI_PROJECT_DIR/modcache_tools.tar.zst
   cache:
     - key:
@@ -88,19 +109,27 @@ go_tools_deps:
           - .gitlab/.pre/deps_fetch/deps_fetch.yml
         prefix: "go_tools_deps_modcache_zstd"
       paths:
+        - go_tools_bin.tar.zst
         - modcache_tools.tar.zst
 
 go_tools_deps_arm64:
   extends: .cache
   tags: ["arch:arm64", "specific:true"]
   script:
-    - if [ -f modcache_tools_arm64.tar.zst  ]; then exit 0; fi
+    - if [ -f go_tools_bin_arm64.tar.zst ] && [ -f modcache_tools_arm64.tar.zst ]; then exit 0; fi
     - dda inv -- -e install-tools
     # Exclude datadog-package binary from the cache: it's already installed on all images and they don't have the same glibc version
-    - cd $GOPATH && tar c -I "zstd -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache_tools_arm64.tar.zst $(find bin/ -type f ! -name 'datadog-package') pkg/mod/cache/
+    - |
+      go_bin="$(go env GOBIN)"
+      if [ -z "$go_bin" ]; then
+        go_bin="$(go env GOPATH)/bin"
+      fi
+      tar c -C "$go_bin" -I "zstd -T${KUBERNETES_CPU_REQUEST}" -f "$CI_PROJECT_DIR/go_tools_bin_arm64.tar.zst" --exclude='./datadog-package' .
+      tar c -C "$GOPATH/pkg/mod/cache" -I "zstd -T${KUBERNETES_CPU_REQUEST}" -f "$CI_PROJECT_DIR/modcache_tools_arm64.tar.zst" .
   artifacts:
     expire_in: 1 day
     paths:
+      - $CI_PROJECT_DIR/go_tools_bin_arm64.tar.zst
       - $CI_PROJECT_DIR/modcache_tools_arm64.tar.zst
   cache:
     - key:
@@ -109,6 +138,7 @@ go_tools_deps_arm64:
           - .gitlab/.pre/deps_fetch/deps_fetch.yml
         prefix: "go_tools_deps_modcache_arm64_zstd"
       paths:
+        - go_tools_bin_arm64.tar.zst
         - modcache_tools_arm64.tar.zst
 
 go_e2e_deps:

--- a/docs/public/.hooks/inject_variables.py
+++ b/docs/public/.hooks/inject_variables.py
@@ -70,14 +70,13 @@ def get_dda_tab_complete_docs():
 
 
 def get_vscode_extensions():
-    url = "https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/refs/heads/main/dev-envs/linux/default-vscode-extensions.txt"
+    url = "https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/refs/heads/main/dev-envs/linux/default-vscode-extensions.json"
     response = httpx.get(url)
     response.raise_for_status()
     marketplace_url_base = "https://marketplace.visualstudio.com/items?itemName="
     return "\n".join(
         f"- [{extension}]({marketplace_url_base}{extension})"
-        for extension in response.text.splitlines()
-        if not extension.startswith("#")
+        for extension in response.json()
     )
 
 

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -1,3 +1,6 @@
+require "find"
+require "set"
+
 require "./lib/symbols_inspectors"
 
 module Omnibus
@@ -31,6 +34,7 @@ module Omnibus
 
     # Override the package_me step to sign the binaries just before the packagers run
     def package_me
+      normalize_linux_package_permissions
       if @chmod_before_packaging
         @chmod_before_packaging.each do |file, mode|
           next unless File.exist?(file)
@@ -44,6 +48,76 @@ module Omnibus
         end
       end
       super
+    end
+
+    # Build images may make package output paths group-writable, setgid, and
+    # owned by a shared build group so non-root builders can write to them.
+    # Package managers record file metadata, so restore runtime ownership and
+    # remove those build-only sharing bits before generating deb/rpm payloads.
+    def normalize_linux_package_permissions
+      return unless linux_target?
+
+      normalize_package_path(install_dir)
+      Array(extra_package_files).each do |path|
+        normalize_package_path(path)
+      end
+    end
+
+    def normalize_package_path(path)
+      return unless File.exist?(path)
+
+      normalize_path_tree_permissions(path)
+    end
+
+    def normalize_path_tree_permissions(root)
+      if File.directory?(root)
+        Find.find(root) do |path|
+          normalize_path_permissions(path)
+        end
+      else
+        normalize_path_permissions(root)
+      end
+    end
+
+    def external_package_path?(path)
+      expanded_path = File.expand_path(path)
+      project_root = File.expand_path(Omnibus::Config.project_root)
+      install_root = File.expand_path(install_dir)
+
+      !path_inside?(expanded_path, project_root) && !path_inside?(expanded_path, install_root)
+    end
+
+    def path_inside?(path, root)
+      path == root || path.start_with?("#{root}/")
+    end
+
+    def normalize_path_permissions(path)
+      return unless File.exist?(path)
+
+      # The Linux build image may make files group-writable and directories
+      # group-writable/setgid so non-root builders can update shared build
+      # roots. Those bits are build-environment details, not package metadata.
+      # Normalize only real payload paths; symlink permissions are irrelevant
+      # and chmod/chown would affect their targets.
+      stat = File.lstat(path)
+      return if stat.symlink?
+
+      # Keep all existing permission bits except the shared-build bits:
+      # g+w for files, and g+w/setgid for directories.
+      mode = stat.mode & 0o7777
+      normalized_mode = stat.directory? ? mode & ~0o2020 : mode & ~0o020
+
+      # Non-root dev-env builds may write through group permissions without
+      # owning root-created paths, so chmod must also be best-effort.
+      if normalized_mode != mode && (Process.euid == 0 || stat.uid == Process.euid)
+        File.chmod(normalized_mode, path)
+      end
+
+      # Best-effort filesystem cleanup for root-run Omnibus builds. Package
+      # metadata should be root-owned regardless of the builder user, but
+      # non-root builds cannot chown staged files; packager metadata must cover
+      # that case.
+      File.chown(0, 0, path) if Process.euid == 0 && (stat.uid != 0 || stat.gid != 0)
     end
 
     def ddwcssign(file)
@@ -166,6 +240,54 @@ module Omnibus
   end
 
   Packager::PKG.prepend PackagerPKGNotarizer
+
+  # The legacy Omnibus RPM packager builds its file list by globbing the staging
+  # tree. When Omnibus stages an external extra_package_file, it creates parent
+  # directories in that tree as an implementation detail. Without filtering,
+  # those synthetic parents are emitted as %dir entries, so our RPM starts
+  # owning distro-owned directories like /usr/lib/systemd or /lib/systemd/system.
+  #
+  # Keep explicit extra_package_file entries, but drop only the parent
+  # directories that were created to stage external extra_package_file paths.
+  module PackagerRPMExtraPackageParentFilter
+    def build_filepath(path, debug = false)
+      filepath = "/" + path.gsub("#{build_dir(debug)}/", "")
+      return "" if extra_package_parent_directory?(filepath)
+
+      super
+    end
+
+    private
+
+    def extra_package_parent_directory?(filepath)
+      extra_package_parent_directories.include?(File.expand_path(filepath))
+    end
+
+    def extra_package_parent_directories
+      @extra_package_parent_directories ||= begin
+        dirs = Set.new
+        project_root = File.expand_path(Omnibus::Config.project_root)
+        install_root = File.expand_path(project.install_dir)
+        Array(project.extra_package_files).each do |path|
+          expanded_path = File.expand_path(path)
+          next if path_inside?(expanded_path, project_root) || path_inside?(expanded_path, install_root)
+
+          parent = File.dirname(expanded_path)
+          while parent != "/"
+            dirs.add(parent)
+            parent = File.dirname(parent)
+          end
+        end
+        dirs
+      end
+    end
+
+    def path_inside?(path, root)
+      path == root || path.start_with?("#{root}/")
+    end
+  end
+
+  Packager::RPM.prepend PackagerRPMExtraPackageParentFilter
 
   # Open the Builder class to allow adding custom DSL methods
   class Builder

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -62,7 +62,7 @@ from tasks.libs.ciproviders.gitlab_api import (
 )
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.git import get_current_branch
-from tasks.libs.common.utils import get_build_flags
+from tasks.libs.common.utils import get_build_flags, get_gobin
 from tasks.libs.pipeline.tools import GitlabJobStatus, loop_status
 from tasks.libs.releasing.json import load_release_json
 from tasks.libs.releasing.version import VERSION_RE, check_version
@@ -954,7 +954,7 @@ def _prepare(
         # In CI, these binaries are always present
         llc_path = LLC_PATH_CI
         clang_path = CLANG_PATH_CI
-        gotestsum_path = Path(f"{os.getenv('GOPATH')}/bin/gotestsum")
+        gotestsum_path = Path(get_gobin(ctx)) / "gotestsum"
 
         # Copy the binaries to the target directory, CI will take them from those
         # paths as artifacts


### PR DESCRIPTION
Backport a41685aa901ff233f76de848d732ea8d5bb5dcff from #51136.

 ___

### What does this PR do?

This reverts commit 94363f10626e317a76ab18af0bf879767814234b.

### Motivation

Not all tests ran on the original PR since that requires a `/trigger-ci` comment (which this PR now [applies](https://github.com/DataDog/datadog-agent/pull/51136#issuecomment-4503107900)).