### PR TITLE
[CONTP-1749] Collect non-preferred CRD group version if preferred resource not in use.

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -490,6 +490,77 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.resources": "apps/daemonsets apps/statefulsetsy",
 			},
 		},
+		{
+			// Regression test for CONTP-1749: a CRD served only on a non-preferred
+			// version of its group must still be auto-discovered. Here the preferred
+			// version of datadoghq.com is v2alpha1 (listed first), but datadogslos is
+			// only served on v1alpha1.
+			name: "resource served only on a non-preferred group version is discovered",
+			apiServerResourceList: []*metav1.APIResourceList{
+				{
+					GroupVersion: "datadoghq.com/v2alpha1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "datadogagents",
+							Kind:       "DatadogAgent",
+							Namespaced: true,
+						},
+					},
+				},
+				{
+					GroupVersion: "datadoghq.com/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "datadogslos",
+							Kind:       "DatadogSLO",
+							Namespaced: true,
+						},
+					},
+				},
+			},
+			expectedGVRs: []schema.GroupVersionResource{
+				{Resource: "datadogagents", Group: "datadoghq.com", Version: "v2alpha1"},
+				{Resource: "datadogslos", Group: "datadoghq.com", Version: "v1alpha1"},
+			},
+			cfg: map[string]interface{}{
+				"cluster_agent.kube_metadata_collection.enabled":   true,
+				"cluster_agent.kube_metadata_collection.resources": "datadoghq.com/datadogagents datadoghq.com/datadogslos",
+			},
+		},
+		{
+			// The preferred version always wins when a resource is served on both
+			// the preferred and a non-preferred version, regardless of list ordering.
+			name: "resource served on both preferred and non-preferred versions resolves to preferred",
+			apiServerResourceList: []*metav1.APIResourceList{
+				{
+					GroupVersion: "datadoghq.com/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "datadogmetrics",
+							Kind:       "DatadogMetric",
+							Namespaced: true,
+						},
+					},
+				},
+				{
+					GroupVersion: "datadoghq.com/v2alpha1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "datadogmetrics",
+							Kind:       "DatadogMetric",
+							Namespaced: true,
+						},
+					},
+				},
+			},
+			expectedGVRs: []schema.GroupVersionResource{
+				{Resource: "datadogmetrics", Group: "datadoghq.com", Version: "v1alpha1"},
+			},
+			cfg: map[string]interface{}{
+				"cluster_agent.kube_metadata_collection.enabled":   true,
+				"cluster_agent.kube_metadata_collection.resources": "datadoghq.com/datadogmetrics",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -491,10 +491,6 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			},
 		},
 		{
-			// Regression test for CONTP-1749: a CRD served only on a non-preferred
-			// version of its group must still be auto-discovered. Here the preferred
-			// version of datadoghq.com is v2alpha1 (listed first), but datadogslos is
-			// only served on v1alpha1.
 			name: "resource served only on a non-preferred group version is discovered",
 			apiServerResourceList: []*metav1.APIResourceList{
 				{
@@ -528,37 +524,35 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			},
 		},
 		{
-			// The preferred version always wins when a resource is served on both
-			// the preferred and a non-preferred version, regardless of list ordering.
 			name: "resource served on both preferred and non-preferred versions resolves to preferred",
 			apiServerResourceList: []*metav1.APIResourceList{
 				{
-					GroupVersion: "datadoghq.com/v1alpha1",
+					GroupVersion: "datadoghq.com/v2alpha1",
 					APIResources: []metav1.APIResource{
 						{
-							Name:       "datadogmetrics",
-							Kind:       "DatadogMetric",
+							Name:       "datadogagents",
+							Kind:       "DatadogAgent",
 							Namespaced: true,
 						},
 					},
 				},
 				{
-					GroupVersion: "datadoghq.com/v2alpha1",
+					GroupVersion: "datadoghq.com/v1alpha1",
 					APIResources: []metav1.APIResource{
 						{
-							Name:       "datadogmetrics",
-							Kind:       "DatadogMetric",
+							Name:       "datadogagents",
+							Kind:       "DatadogAgent",
 							Namespaced: true,
 						},
 					},
 				},
 			},
 			expectedGVRs: []schema.GroupVersionResource{
-				{Resource: "datadogmetrics", Group: "datadoghq.com", Version: "v1alpha1"},
+				{Resource: "datadogagents", Group: "datadoghq.com", Version: "v2alpha1"},
 			},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "datadoghq.com/datadogmetrics",
+				"cluster_agent.kube_metadata_collection.resources": "datadoghq.com/datadogagents",
 			},
 		},
 	}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go
@@ -150,8 +150,7 @@ func getGVRsForRequestedResources(discoveryClient discovery.DiscoveryInterface, 
 // discoverGroupResourceVersions discovers groups, resources, and versions in the kubernetes api server and returns a mapping
 // from GroupResource to Version.
 // A group resource is mapped to the preferred version of its group when the resource is served on that version.
-// Otherwise it falls back to a non-preferred version, so that resources served only on a non-preferred version
-// (e.g. a v1alpha1 CRD in a group whose preferred version is v2alpha1) remain discoverable.
+// Otherwise, it falls back to a non-preferred version, so that resources served only on a non-preferred version remain discoverable.
 func discoverGroupResourceVersions(discoveryClient discovery.DiscoveryInterface) (map[schema.GroupResource]string, error) {
 	apiGroups, apiResourceLists, err := discoveryClient.ServerGroupsAndResources()
 	if err != nil {
@@ -170,8 +169,7 @@ func discoverGroupResourceVersions(discoveryClient discovery.DiscoveryInterface)
 	}
 
 	// groupResourceToVersion maps a group resource to a discovered version.
-	// The preferred version of the group always wins; a non-preferred version is only recorded
-	// when no version has been discovered yet for that resource.
+	// The preferred version of the group always wins out over others.
 	groupResourceToVersion := map[schema.GroupResource]string{}
 	for _, resourceList := range apiResourceLists {
 		_, isPreferred := preferredGroupVersions[resourceList.GroupVersion]

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go
@@ -149,7 +149,9 @@ func getGVRsForRequestedResources(discoveryClient discovery.DiscoveryInterface, 
 
 // discoverGroupResourceVersions discovers groups, resources, and versions in the kubernetes api server and returns a mapping
 // from GroupResource to Version.
-// A group resource is mapped to the version that is considered the preferred version by the API Server.
+// A group resource is mapped to the preferred version of its group when the resource is served on that version.
+// Otherwise it falls back to a non-preferred version, so that resources served only on a non-preferred version
+// (e.g. a v1alpha1 CRD in a group whose preferred version is v2alpha1) remain discoverable.
 func discoverGroupResourceVersions(discoveryClient discovery.DiscoveryInterface) (map[schema.GroupResource]string, error) {
 	apiGroups, apiResourceLists, err := discoveryClient.ServerGroupsAndResources()
 	if err != nil {
@@ -167,20 +169,28 @@ func discoverGroupResourceVersions(discoveryClient discovery.DiscoveryInterface)
 		preferredGroupVersions[group.PreferredVersion.GroupVersion] = struct{}{}
 	}
 
-	// groupResourceToVersion maps a group resource to discovered preferred group version
+	// groupResourceToVersion maps a group resource to a discovered version.
+	// The preferred version of the group always wins; a non-preferred version is only recorded
+	// when no version has been discovered yet for that resource.
 	groupResourceToVersion := map[schema.GroupResource]string{}
 	for _, resourceList := range apiResourceLists {
-		_, found := preferredGroupVersions[resourceList.GroupVersion]
-		if found {
-			for _, resource := range resourceList.APIResources {
-				// No need to handle error because we are sure it is correctly formatted
-				gv, _ := schema.ParseGroupVersion(resourceList.GroupVersion)
+		_, isPreferred := preferredGroupVersions[resourceList.GroupVersion]
 
-				groupResourceToVersion[schema.GroupResource{
-					Resource: resource.Name,
-					Group:    gv.Group,
-				}] = gv.Version
+		// No need to handle error because we are sure it is correctly formatted
+		gv, _ := schema.ParseGroupVersion(resourceList.GroupVersion)
+
+		for _, resource := range resourceList.APIResources {
+			groupResource := schema.GroupResource{
+				Resource: resource.Name,
+				Group:    gv.Group,
 			}
+
+			// Keep the already-recorded version unless the current one is preferred.
+			if _, found := groupResourceToVersion[groupResource]; found && !isPreferred {
+				continue
+			}
+
+			groupResourceToVersion[groupResource] = gv.Version
 		}
 	}
 

--- a/releasenotes/notes/fix-kubeapiserver-non-preferred-crd-version-d1f5a7c3b2e9f4a6.yaml
+++ b/releasenotes/notes/fix-kubeapiserver-non-preferred-crd-version-d1f5a7c3b2e9f4a6.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed the Cluster Agent ``kubeapiserver`` workloadmeta collector failing to
+    auto-discover Custom Resource Definitions that are served only on a
+    non-preferred version of their API group (for example a ``v1alpha1`` CRD in
+    a group whose preferred version is ``v2alpha1``). Such resources referenced
+    by ``DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS`` are now correctly
+    resolved instead of causing an auto-discovery error at startup.

--- a/releasenotes/notes/fix-kubeapiserver-non-preferred-crd-version-d1f5a7c3b2e9f4a6.yaml
+++ b/releasenotes/notes/fix-kubeapiserver-non-preferred-crd-version-d1f5a7c3b2e9f4a6.yaml
@@ -1,9 +1,6 @@
 ---
 fixes:
   - |
-    Fixed the Cluster Agent ``kubeapiserver`` workloadmeta collector failing to
-    auto-discover Custom Resource Definitions that are served only on a
-    non-preferred version of their API group (for example a ``v1alpha1`` CRD in
-    a group whose preferred version is ``v2alpha1``). Such resources referenced
-    by ``DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS`` are now correctly
-    resolved instead of causing an auto-discovery error at startup.
+    Fixed the Cluster Agent ``kubeapiserver`` workloadmeta collector so that
+    resources are now discovered on a non-preferred API group version when they
+    are not served on the group's preferred version.


### PR DESCRIPTION
### What does this PR do?

Makes the Cluster Agent `kubeapiserver` workloadmeta collector fall back to a non-preferred API group version when a resource is not served on the group's preferred version, instead of failing to discover it.

### Motivation

The collector errored at startup (`failed to auto-discover version of group resource ...`) for CRDs served only on a non-preferred version of their group (e.g. a `v1alpha1` CRD in the `datadoghq.com` group whose preferred version is `v2alpha1`), because discovery only indexed each group's preferred version.

Fixes [CONTP-1749](https://datadoghq.atlassian.net/browse/CONTP-1749).

### Describe how you validated your changes

Added regression tests covering a resource served only on a non-preferred version (now discovered) and a resource served on both versions (still resolves to the preferred one). All package tests pass via `dda inv test --targets=./comp/core/workloadmeta/collectors/internal/kubeapiserver --build-include=kubeapiserver,test`.

[CONTP-1749]: https://datadoghq.atlassian.net/browse/CONTP-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ