### PR TITLE
fix(ci): allow `test_gitlab_compare_to` to push workflow changes

### DIFF
--- a/.github/chainguard/self.gitlab.compare-to.sts.yaml
+++ b/.github/chainguard/self.gitlab.compare-to.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/datadog-agent:ref_type:branch:ref:.*"
+
+claim_pattern:
+  project_path: "DataDog/datadog-agent"
+  project_id: "4670"
+  ref_type: "branch"
+  ref: ".+"
+
+permissions:
+  contents: write
+  workflows: write

--- a/.gitlab/.pre/ci_configuration.yml
+++ b/.gitlab/.pre/ci_configuration.yml
@@ -19,7 +19,7 @@ test_gitlab_compare_to:
     - !reference [.except_mergequeue]
     - !reference [.on_gitlab_changes]
   before_script:
-    - !reference [.setup_github_token_write]
+    - !reference [.setup_github_token_compare_to]
   script:
     - dda self dep sync -f legacy-tasks
     - dda inv -- pipeline.compare-to-itself

--- a/.gitlab/.pre/common/shared.yml
+++ b/.gitlab/.pre/common/shared.yml
@@ -17,6 +17,9 @@
 .setup_github_token_write:
   - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.write)
 
+.setup_github_token_compare_to:
+  - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.compare-to)
+
 .setup_github_ci_platform_machine_images_token:
   - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/ci-platform-machine-images --policy self.datadog-agent.trigger-agent-bump)
 


### PR DESCRIPTION
### What does this PR do?
Create a dedicated `self.gitlab.compare-to.sts.yaml` octo-sts policy for the `test_gitlab_compare_to` job, granting `contents: write` and `workflows: write`.
Wire it to a new `.setup_github_token_compare_to` anchor and updates the job to use it.

### Motivation
The `test_gitlab_compare_to` job runs on GitLab CI config changes: it pushes a comparison branch to GitHub.
When the PR targets a release branch (e.g. `7.80.x`), that branch diverges from `main` in `.github/workflows`, so GitHub rejects the push without `workflows` scope.
For [instance](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1771994419):
```
> Found a gitlab configuration change on line: +  - !reference [.log_dd_pkg_version]
To https://github.com/DataDog/datadog-agent.git
 ! [remote rejected]       compare/backport-51136-to-7.80.x/1781542912 -> compare/backport-51136-to-7.80.x/1781542912 (Unable to determine if workflow can be created or updated due to timeout; `workflows` scope may be required.)
error: failed to push some refs to 'https://github.com/DataDog/datadog-agent.git'
```

### Additional Notes
Same root cause as #49532, different job.
Rather than widening the shared `self.gitlab.write` policy (which covers all GitLab write jobs), this introduces a purpose-specific policy to limit the blast radius.
GitLab OIDC tokens carry no job-name claim, so job-level scoping is not possible: the policy is additionally constrained to branch pipelines (`ref_type: "branch"`) to exclude tag and trigger pipelines.