### PR TITLE
Update Code Scanning Image for datadog-agent CodeQL Scan

### DIFF
--- a/.gitlab/build/source_test/codeql_scan.yml
+++ b/.gitlab/build/source_test/codeql_scan.yml
@@ -3,7 +3,7 @@
 # Contains CodeQL scan job to perform security static analysis
 
 run_codeql_scan:
-  image: registry.ddbuild.io/code-scanning:v118892930-05618fa-datadog-agent
+  image: registry.ddbuild.io/code-scanning:v118956404-e223d07-datadog-agent
   timeout: 5h
   tags: ["arch:amd64", "specific:true"]
   extends:
@@ -24,7 +24,7 @@ run_codeql_scan:
     KUBERNETES_MEMORY_LIMIT: 128Gi
     CODEQL: /usr/local/codeql/codeql
     CODEQL_DB: /tmp/datadog-agent.codeql
-    DB_CONFIGS: --threads 8 --ram 128000 --db-cluster --language=go,python,cpp
+    DB_CONFIGS: --threads 8 --ram 128000 --db-cluster --language=go,python,javascript,cpp
     SCAN_CONFIGS: --format sarifv2.1.0 --threads 8 --ram 128000 --no-tuple-counting
     UPLOAD_CONFIGS: -upload_sarif=true
   script:
@@ -34,12 +34,14 @@ run_codeql_scan:
     - git config --global url."https://gitlab-ci-token:${token}@gitlab.ddbuild.io/DataDog/codescanning".insteadOf "https://github.com/DataDog/codescanning"
     - git clone https://github.com/DataDog/codescanning.git --depth 1 --single-branch --branch=main /tmp/codescanning
     - $CODEQL database create datadog-agent.codeql $DB_CONFIGS --command="inv -e agent.build --build-exclude=systemd"
+    - $CODEQL database analyze datadog-agent.codeql/javascript codeql/javascript-queries $SCAN_CONFIGS --sarif-category="javascript" --output="/tmp/javascript.sarif" --verbosity=progress+++    
     - $CODEQL database analyze datadog-agent.codeql/go codeql/go-queries $SCAN_CONFIGS --sarif-category="go" --output="/tmp/go.sarif" --verbosity=progress+++
     - $CODEQL database analyze datadog-agent.codeql/python codeql/python-queries $SCAN_CONFIGS --sarif-category="python" --output="/tmp/python.sarif" --verbosity=progress+++
     - $CODEQL database analyze datadog-agent.codeql/cpp codeql/cpp-queries $SCAN_CONFIGS --sarif-category="cpp" --output="/tmp/cpp.sarif" --verbosity=progress+++
     - export GITHUB_TOKEN="$(DD_TRACE_ENABLED=false dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.security-events-write)"
     - GOPRIVATE=github.com/DataDog GOBIN=/usr/local/go/bin go install github.com/DataDog/codescanning@cd95491d100cc08a1baa4bbc35172df444ef12da
     - CODEQL_SARIF="/tmp/go.sarif" codescanning $UPLOAD_CONFIGS -scan_started_time="$CI_JOB_STARTED_AT"
+    - CODEQL_SARIF="/tmp/javascript.sarif" codescanning $UPLOAD_CONFIGS -scan_started_time="$CI_JOB_STARTED_AT"
     - CODEQL_SARIF="/tmp/python.sarif" codescanning $UPLOAD_CONFIGS -scan_started_time="$CI_JOB_STARTED_AT"
     - CODEQL_SARIF="/tmp/cpp.sarif" codescanning $UPLOAD_CONFIGS -scan_started_time="$CI_JOB_STARTED_AT"
   after_script:

--- a/.gitlab/build/source_test/codeql_scan.yml
+++ b/.gitlab/build/source_test/codeql_scan.yml
@@ -24,7 +24,7 @@ run_codeql_scan:
     KUBERNETES_MEMORY_LIMIT: 128Gi
     CODEQL: /usr/local/codeql/codeql
     CODEQL_DB: /tmp/datadog-agent.codeql
-    DB_CONFIGS: --threads 8 --ram 128000 --db-cluster --language=go,python,javascript,cpp
+    DB_CONFIGS: --threads 8 --ram 128000 --db-cluster --language=go,python,cpp
     SCAN_CONFIGS: --format sarifv2.1.0 --threads 8 --ram 128000 --no-tuple-counting
     UPLOAD_CONFIGS: -upload_sarif=true
   script:
@@ -34,14 +34,12 @@ run_codeql_scan:
     - git config --global url."https://gitlab-ci-token:${token}@gitlab.ddbuild.io/DataDog/codescanning".insteadOf "https://github.com/DataDog/codescanning"
     - git clone https://github.com/DataDog/codescanning.git --depth 1 --single-branch --branch=main /tmp/codescanning
     - $CODEQL database create datadog-agent.codeql $DB_CONFIGS --command="inv -e agent.build --build-exclude=systemd"
-    - $CODEQL database analyze datadog-agent.codeql/javascript codeql/javascript-queries $SCAN_CONFIGS --sarif-category="javascript" --output="/tmp/javascript.sarif" --verbosity=progress+++
     - $CODEQL database analyze datadog-agent.codeql/go codeql/go-queries $SCAN_CONFIGS --sarif-category="go" --output="/tmp/go.sarif" --verbosity=progress+++
     - $CODEQL database analyze datadog-agent.codeql/python codeql/python-queries $SCAN_CONFIGS --sarif-category="python" --output="/tmp/python.sarif" --verbosity=progress+++
     - $CODEQL database analyze datadog-agent.codeql/cpp codeql/cpp-queries $SCAN_CONFIGS --sarif-category="cpp" --output="/tmp/cpp.sarif" --verbosity=progress+++
     - export GITHUB_TOKEN="$(DD_TRACE_ENABLED=false dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.security-events-write)"
     - GOPRIVATE=github.com/DataDog GOBIN=/usr/local/go/bin go install github.com/DataDog/codescanning@cd95491d100cc08a1baa4bbc35172df444ef12da
     - CODEQL_SARIF="/tmp/go.sarif" codescanning $UPLOAD_CONFIGS -scan_started_time="$CI_JOB_STARTED_AT"
-    - CODEQL_SARIF="/tmp/javascript.sarif" codescanning $UPLOAD_CONFIGS -scan_started_time="$CI_JOB_STARTED_AT"
     - CODEQL_SARIF="/tmp/python.sarif" codescanning $UPLOAD_CONFIGS -scan_started_time="$CI_JOB_STARTED_AT"
     - CODEQL_SARIF="/tmp/cpp.sarif" codescanning $UPLOAD_CONFIGS -scan_started_time="$CI_JOB_STARTED_AT"
   after_script:

--- a/.gitlab/build/source_test/codeql_scan.yml
+++ b/.gitlab/build/source_test/codeql_scan.yml
@@ -3,7 +3,7 @@
 # Contains CodeQL scan job to perform security static analysis
 
 run_codeql_scan:
-  image: registry.ddbuild.io/code-scanning:v89505840-d7f7832-datadog-agent
+  image: registry.ddbuild.io/code-scanning:v118892930-05618fa-datadog-agent
   timeout: 5h
   tags: ["arch:amd64", "specific:true"]
   extends:

--- a/.gitlab/build/source_test/codeql_scan.yml
+++ b/.gitlab/build/source_test/codeql_scan.yml
@@ -34,7 +34,7 @@ run_codeql_scan:
     - git config --global url."https://gitlab-ci-token:${token}@gitlab.ddbuild.io/DataDog/codescanning".insteadOf "https://github.com/DataDog/codescanning"
     - git clone https://github.com/DataDog/codescanning.git --depth 1 --single-branch --branch=main /tmp/codescanning
     - $CODEQL database create datadog-agent.codeql $DB_CONFIGS --command="inv -e agent.build --build-exclude=systemd"
-    - $CODEQL database analyze datadog-agent.codeql/javascript codeql/javascript-queries $SCAN_CONFIGS --sarif-category="javascript" --output="/tmp/javascript.sarif" --verbosity=progress+++    
+    - $CODEQL database analyze datadog-agent.codeql/javascript codeql/javascript-queries $SCAN_CONFIGS --sarif-category="javascript" --output="/tmp/javascript.sarif" --verbosity=progress+++
     - $CODEQL database analyze datadog-agent.codeql/go codeql/go-queries $SCAN_CONFIGS --sarif-category="go" --output="/tmp/go.sarif" --verbosity=progress+++
     - $CODEQL database analyze datadog-agent.codeql/python codeql/python-queries $SCAN_CONFIGS --sarif-category="python" --output="/tmp/python.sarif" --verbosity=progress+++
     - $CODEQL database analyze datadog-agent.codeql/cpp codeql/cpp-queries $SCAN_CONFIGS --sarif-category="cpp" --output="/tmp/cpp.sarif" --verbosity=progress+++


### PR DESCRIPTION
### What does this PR do?

- Fixes the CodeQL Scan on datadog-agent repo. 
- Updates Code Scanning image by using the latest [datadog-agent build image](https://github.com/DataDog/images/pull/10306) and installing nodejs and npm to the image. 

### Motivation
CodeQL scan at datadog-agent is failing with the error
```
Could not start Node.js. It is required for TypeScript extraction.
[2026-06-12 03:13:10] [build-stderr] Please install Node.js and ensure 'node' is on the PATH.
```
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1764617778
### Describe how you validated your changes

Verified the change successfully using the gitlab job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1773497260

### Additional Notes
