### PR TITLE
refactor(healthplatform): remove PruneResolvedIssues via IssueObserver

### DIFF
--- a/comp/healthplatform/bundle_test.go
+++ b/comp/healthplatform/bundle_test.go
@@ -256,7 +256,8 @@ func TestIssueStateLifecycleForwarded(t *testing.T) {
 		return latestHasIssueState(issueAID, healthplatformpayload.IssueState_ISSUE_STATE_NEW)
 	}, waitTimeout, waitInterval, "issueA never appeared as NEW in the latest forwarded payload")
 
-	// RESOLVED must appear in exactly one payload across the full history (PruneResolvedIssues).
+	// RESOLVED must appear in exactly one payload across the full history: the egress
+	// removes tombstones from its pending map after a successful send.
 	allPayloads, err := fiClient.GetAgentHealth()
 	require.NoError(t, err)
 	resolvedCountA, resolvedCountB := 0, 0

--- a/comp/healthplatform/egress/impl/BUILD.bazel
+++ b/comp/healthplatform/egress/impl/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     deps = [
         "//comp/core/log/mock",
         "//comp/healthplatform/forwarder/def",
+        "//comp/healthplatform/store/def",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/comp/healthplatform/egress/impl/egress.go
+++ b/comp/healthplatform/egress/impl/egress.go
@@ -31,7 +31,7 @@ const (
 	eventType             = "agent-health-issues"
 
 	// channel capacity for active and resolved issue delivery.
-	issueChSize = 1024
+	issueChSize = 2048
 )
 
 // egress drives the periodic outbound POST to the Datadog intake.

--- a/comp/healthplatform/egress/impl/egress.go
+++ b/comp/healthplatform/egress/impl/egress.go
@@ -138,21 +138,8 @@ func (e *egress) run() {
 }
 
 func (e *egress) tick() {
-	// Snapshot both channels. Active issues are always returned to activeCh after
-	// the tick so they persist until explicitly removed by notifyResolved.
-	// Resolved tombstones are only returned on failure; on success they are consumed.
 	active := drainCh(e.activeCh)
 	resolved := drainCh(e.resolvedCh)
-
-	defer func() {
-		for _, i := range active {
-			select {
-			case e.activeCh <- i:
-			default:
-				e.log.Warnf("Health platform egress: active channel full on requeue, %s", i.Id)
-			}
-		}
-	}()
 
 	if len(active) == 0 && len(resolved) == 0 {
 		e.log.Debug("Health platform egress: no issues to report, skipping tick")
@@ -174,30 +161,47 @@ func (e *egress) tick() {
 
 	if err := e.forwarder.Send(ctx, e.buildReport(merged)); err != nil {
 		e.log.Warn(fmt.Sprintf("Health platform egress: failed to send %d issues: %v", len(merged), err))
-		for _, r := range resolved {
-			select {
-			case e.resolvedCh <- r:
-			default:
-				e.log.Warnf("Health platform egress: resolved channel full on retry, %s recoverable from disk", r.Id)
-			}
-		}
-		return
+		return // items are still in both channels; retried next tick
 	}
 
 	e.log.Info(fmt.Sprintf("Health platform egress: sent report with %d issues", len(merged)))
-}
 
-// drainCh non-blockingly drains all available items from ch into a slice.
-func drainCh(ch chan *healthplatform.Issue) []*healthplatform.Issue {
-	var out []*healthplatform.Issue
-	for {
+	// Consume the resolved tombstones we just sent from the front of resolvedCh.
+	// drainCh re-queued them, so they sit at the front; any tombstones that
+	// arrived during the send remain at the back and are retried next tick.
+	for range len(resolved) {
 		select {
-		case i := <-ch:
-			out = append(out, i)
+		case <-e.resolvedCh:
 		default:
-			return out
 		}
 	}
+}
+
+// drainCh returns a snapshot of all items currently in ch.
+// Items are drained and immediately re-queued, leaving the channel intact
+// for the next tick or concurrent writers.
+func drainCh(ch chan *healthplatform.Issue) []*healthplatform.Issue {
+	n := len(ch)
+	if n == 0 {
+		return nil
+	}
+	items := make([]*healthplatform.Issue, 0, n)
+drain:
+	for range n {
+		select {
+		case item := <-ch:
+			items = append(items, item)
+		default:
+			break drain
+		}
+	}
+	for _, item := range items {
+		select {
+		case ch <- item:
+		default:
+		}
+	}
+	return items
 }
 
 func (e *egress) buildReport(issues map[string]*healthplatform.Issue) *healthplatform.HealthReport {

--- a/comp/healthplatform/egress/impl/egress.go
+++ b/comp/healthplatform/egress/impl/egress.go
@@ -30,20 +30,25 @@ const (
 	sendTimeout           = 30 * time.Second
 	eventType             = "agent-health-issues"
 
-	// resolvedChSize is the capacity of the resolved-issue delivery channel.
-	resolvedChSize = 1024
+	// channel capacity for active and resolved issue delivery.
+	issueChSize = 1024
 )
 
 // egress drives the periodic outbound POST to the Datadog intake.
+// Both channels are populated by the registered IssueObserver:
+//   - activeCh:   new/ongoing issues; drained each tick, re-populated by the
+//     next ReportIssue call from the health checks.
+//   - resolvedCh: resolved issues; drained and flushed on a successful send,
+//     returned to the channel on failure for retry next tick.
 type egress struct {
 	log         log.Component
 	interval    time.Duration
 	hostname    string
 	agentFlavor string
-	store       storedef.Component
 	forwarder   forwarderdef.Component
 
-	resolvedCh chan *healthplatform.Issue // resolved issues pending send; drained each tick
+	activeCh   chan *healthplatform.Issue // new/ongoing issues
+	resolvedCh chan *healthplatform.Issue // resolved issues; flushed after successful send
 
 	stopCh chan struct{}
 	doneCh chan struct{}
@@ -81,9 +86,9 @@ func New(reqs Requires) egressdef.Component {
 		interval:    interval,
 		hostname:    hostname,
 		agentFlavor: flavor.GetFlavor(),
-		store:       reqs.Store,
 		forwarder:   reqs.Forwarder,
-		resolvedCh:  make(chan *healthplatform.Issue, resolvedChSize),
+		activeCh:    make(chan *healthplatform.Issue, issueChSize),
+		resolvedCh:  make(chan *healthplatform.Issue, issueChSize),
 		stopCh:      make(chan struct{}),
 		doneCh:      make(chan struct{}),
 	}
@@ -91,6 +96,13 @@ func New(reqs Requires) egressdef.Component {
 	// Register before OnStart: loadFromDisk fires first and calls OnIssueResolved
 	// for any resolved issues found on disk.
 	reqs.Store.RegisterObserver(storedef.IssueObserver{
+		OnIssueReported: func(issue *healthplatform.Issue) {
+			select {
+			case e.activeCh <- issue:
+			default:
+				e.log.Warnf("Health platform egress: active channel full, %s will resend on next check run", issue.Id)
+			}
+		},
 		OnIssueResolved: func(resolved *healthplatform.Issue) {
 			select {
 			case e.resolvedCh <- resolved:
@@ -138,20 +150,8 @@ func (e *egress) run() {
 }
 
 func (e *egress) tick() {
-	_, active := e.store.GetAllIssues()
-
-	// Drain resolved issues into a tick-local slice; room to return them on failure
-	// is guaranteed since we just freed N slots.
-	var resolved []*healthplatform.Issue
-drain:
-	for {
-		select {
-		case r := <-e.resolvedCh:
-			resolved = append(resolved, r)
-		default:
-			break drain
-		}
-	}
+	active := drainCh(e.activeCh)
+	resolved := drainCh(e.resolvedCh)
 
 	if len(active) == 0 && len(resolved) == 0 {
 		e.log.Debug("Health platform egress: no issues to report, skipping tick")
@@ -159,9 +159,10 @@ drain:
 	}
 
 	merged := make(map[string]*healthplatform.Issue, len(active)+len(resolved))
-	for k, v := range active {
-		merged[k] = v
+	for _, i := range active {
+		merged[i.Id] = i
 	}
+	// resolved overwrites active for the same ID (most recent state wins)
 	for _, r := range resolved {
 		merged[r.Id] = r
 	}
@@ -172,6 +173,7 @@ drain:
 
 	if err := e.forwarder.Send(ctx, e.buildReport(merged)); err != nil {
 		e.log.Warn(fmt.Sprintf("Health platform egress: failed to send %d issues: %v", len(merged), err))
+		// Return resolved issues for retry; active issues are re-populated by the next check run.
 		for _, r := range resolved {
 			select {
 			case e.resolvedCh <- r:
@@ -183,6 +185,20 @@ drain:
 	}
 
 	e.log.Info(fmt.Sprintf("Health platform egress: sent report with %d issues", len(merged)))
+	// resolvedCh was already drained above; nothing to flush explicitly.
+}
+
+// drainCh non-blockingly drains all available items from ch into a slice.
+func drainCh(ch chan *healthplatform.Issue) []*healthplatform.Issue {
+	var out []*healthplatform.Issue
+	for {
+		select {
+		case i := <-ch:
+			out = append(out, i)
+		default:
+			return out
+		}
+	}
 }
 
 func (e *egress) buildReport(issues map[string]*healthplatform.Issue) *healthplatform.HealthReport {

--- a/comp/healthplatform/egress/impl/egress.go
+++ b/comp/healthplatform/egress/impl/egress.go
@@ -138,8 +138,8 @@ func (e *egress) run() {
 }
 
 func (e *egress) tick() {
-	active := drainCh(e.activeCh)
-	resolved := drainCh(e.resolvedCh)
+	active := snapshotIssues(e.activeCh)
+	resolved := snapshotIssues(e.resolvedCh)
 
 	if len(active) == 0 && len(resolved) == 0 {
 		e.log.Debug("Health platform egress: no issues to report, skipping tick")
@@ -177,22 +177,22 @@ func (e *egress) tick() {
 	}
 }
 
-// drainCh returns a snapshot of all items currently in ch.
-// Items are drained and immediately re-queued, leaving the channel intact
-// for the next tick or concurrent writers.
-func drainCh(ch chan *healthplatform.Issue) []*healthplatform.Issue {
+// snapshotIssues returns a copy of all items currently in ch.
+// Items are drained then immediately re-queued so the channel is left intact.
+// The requeue always runs regardless of early exit from the drain, ensuring
+// no items are lost if concurrent writers consumed slots between len(ch) and reads.
+func snapshotIssues(ch chan *healthplatform.Issue) []*healthplatform.Issue {
 	n := len(ch)
 	if n == 0 {
 		return nil
 	}
 	items := make([]*healthplatform.Issue, 0, n)
-drain:
-	for range n {
+	for i := 0; i < n; i++ {
 		select {
 		case item := <-ch:
 			items = append(items, item)
 		default:
-			break drain
+			n = i // channel drained early; stop without iterating further
 		}
 	}
 	for _, item := range items {

--- a/comp/healthplatform/egress/impl/egress.go
+++ b/comp/healthplatform/egress/impl/egress.go
@@ -31,16 +31,10 @@ const (
 	eventType             = "agent-health-issues"
 
 	// resolvedChSize is the capacity of the resolved-issue delivery channel.
-	// Sized to comfortably hold all pending resolved issues; overflow is logged
-	// as a warning (items are recoverable from disk on restart).
 	resolvedChSize = 1024
 )
 
 // egress drives the periodic outbound POST to the Datadog intake.
-// Active issues are queried from the store on every tick. Resolved issues are
-// delivered via a channel owned by the egress; observers write to it via the
-// registered IssueObserver. On send failure drained items are returned so they
-// are retried on the next tick.
 type egress struct {
 	log         log.Component
 	interval    time.Duration
@@ -146,8 +140,8 @@ func (e *egress) run() {
 func (e *egress) tick() {
 	_, active := e.store.GetAllIssues()
 
-	// Drain the resolved-issue channel into a tick-local slice.
-	// We just pulled N items out, so on failure there is always room to return them.
+	// Drain resolved issues into a tick-local slice; room to return them on failure
+	// is guaranteed since we just freed N slots.
 	var resolved []*healthplatform.Issue
 drain:
 	for {

--- a/comp/healthplatform/egress/impl/egress.go
+++ b/comp/healthplatform/egress/impl/egress.go
@@ -35,7 +35,7 @@ const (
 )
 
 // egress drives the periodic outbound POST to the Datadog intake.
-// Both channels are populated by the registered IssueObserver:
+// Both channels are populated by the registered EgressAggregator:
 //   - activeCh:   new/ongoing issues; drained each tick, re-populated by the
 //     next ReportIssue call from the health checks.
 //   - resolvedCh: resolved issues; drained and flushed on a successful send,
@@ -95,7 +95,7 @@ func New(reqs Requires) egressdef.Component {
 
 	// Register before OnStart: loadFromDisk fires first and writes any resolved
 	// issues found on disk into ResolvedCh.
-	reqs.Store.RegisterObserver(storedef.IssueObserver{
+	reqs.Store.RegisterEgressAggregator(storedef.EgressAggregator{
 		ActiveCh:   e.activeCh,
 		ResolvedCh: e.resolvedCh,
 	})

--- a/comp/healthplatform/egress/impl/egress.go
+++ b/comp/healthplatform/egress/impl/egress.go
@@ -36,10 +36,10 @@ const (
 
 // egress drives the periodic outbound POST to the Datadog intake.
 // Both channels are populated by the registered EgressAggregator:
-//   - activeCh:   new/ongoing issues; drained each tick, re-populated by the
-//     next ReportIssue call from the health checks.
-//   - resolvedCh: resolved issues; drained and flushed on a successful send,
-//     returned to the channel on failure for retry next tick.
+//   - activeCh:   new/ongoing issues; snapshotted each tick and always returned
+//     so they persist until notifyResolved removes them via removeFromCh.
+//   - resolvedCh: resolved tombstones; consumed on a successful send,
+//     returned on failure for retry next tick.
 type egress struct {
 	log         log.Component
 	interval    time.Duration
@@ -138,8 +138,21 @@ func (e *egress) run() {
 }
 
 func (e *egress) tick() {
+	// Snapshot both channels. Active issues are always returned to activeCh after
+	// the tick so they persist until explicitly removed by notifyResolved.
+	// Resolved tombstones are only returned on failure; on success they are consumed.
 	active := drainCh(e.activeCh)
 	resolved := drainCh(e.resolvedCh)
+
+	defer func() {
+		for _, i := range active {
+			select {
+			case e.activeCh <- i:
+			default:
+				e.log.Warnf("Health platform egress: active channel full on requeue, %s", i.Id)
+			}
+		}
+	}()
 
 	if len(active) == 0 && len(resolved) == 0 {
 		e.log.Debug("Health platform egress: no issues to report, skipping tick")
@@ -161,7 +174,6 @@ func (e *egress) tick() {
 
 	if err := e.forwarder.Send(ctx, e.buildReport(merged)); err != nil {
 		e.log.Warn(fmt.Sprintf("Health platform egress: failed to send %d issues: %v", len(merged), err))
-		// Return resolved issues for retry; active issues are re-populated by the next check run.
 		for _, r := range resolved {
 			select {
 			case e.resolvedCh <- r:
@@ -173,7 +185,6 @@ func (e *egress) tick() {
 	}
 
 	e.log.Info(fmt.Sprintf("Health platform egress: sent report with %d issues", len(merged)))
-	// resolvedCh was already drained above; nothing to flush explicitly.
 }
 
 // drainCh non-blockingly drains all available items from ch into a slice.

--- a/comp/healthplatform/egress/impl/egress.go
+++ b/comp/healthplatform/egress/impl/egress.go
@@ -9,7 +9,6 @@ package egressimpl
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/DataDog/agent-payload/v5/healthplatform"
@@ -27,31 +26,30 @@ import (
 )
 
 const (
-	// defaultEgressInterval is the default interval between health report submissions.
-	// Matches the previous forwarder default for backward compatibility.
 	defaultEgressInterval = 15 * time.Minute
+	sendTimeout           = 30 * time.Second
+	eventType             = "agent-health-issues"
 
-	// sendTimeout is the HTTP timeout for a single forwarder.Send call.
-	sendTimeout = 30 * time.Second
-
-	// eventType is the health report event type consumed by the intake.
-	eventType = "agent-health-issues"
+	// resolvedChSize is the capacity of the resolved-issue delivery channel.
+	// Sized to comfortably hold all pending resolved issues; overflow is logged
+	// as a warning (items are recoverable from disk on restart).
+	resolvedChSize = 1024
 )
 
 // egress drives the periodic outbound POST to the Datadog intake.
-// active issues are re-sent every tick; resolved tombstones (toSendOnce) are
-// trimmed by a slice-length operation after a successful send, so exactly-once
-// forwarding is structural rather than conditional.
+// Active issues are queried from the store on every tick. Resolved issues are
+// delivered via a channel owned by the egress; observers write to it via the
+// registered IssueObserver. On send failure drained items are returned so they
+// are retried on the next tick.
 type egress struct {
 	log         log.Component
 	interval    time.Duration
 	hostname    string
 	agentFlavor string
+	store       storedef.Component
 	forwarder   forwarderdef.Component
 
-	pendingMu  sync.Mutex
-	active     map[string]*healthplatform.Issue // re-sent every tick until resolved
-	toSendOnce []*healthplatform.Issue          // tombstones; trimmed after a successful send
+	resolvedCh chan *healthplatform.Issue // resolved issues pending send; drained each tick
 
 	stopCh chan struct{}
 	doneCh chan struct{}
@@ -89,17 +87,23 @@ func New(reqs Requires) egressdef.Component {
 		interval:    interval,
 		hostname:    hostname,
 		agentFlavor: flavor.GetFlavor(),
+		store:       reqs.Store,
 		forwarder:   reqs.Forwarder,
-		active:      make(map[string]*healthplatform.Issue),
+		resolvedCh:  make(chan *healthplatform.Issue, resolvedChSize),
 		stopCh:      make(chan struct{}),
 		doneCh:      make(chan struct{}),
 	}
 
-	// Callbacks must be registered before OnStart: the store's loadFromDisk fires
-	// first and calls onResolveIssue for any RESOLVED issues found on disk.
-	reqs.Store.SetEgressCallbacks(storedef.EgressCallbacks{
-		OnReportIssue:  e.onReportIssue,
-		OnResolveIssue: e.onResolveIssue,
+	// Register before OnStart: loadFromDisk fires first and calls OnIssueResolved
+	// for any resolved issues found on disk.
+	reqs.Store.RegisterObserver(storedef.IssueObserver{
+		OnIssueResolved: func(resolved *healthplatform.Issue) {
+			select {
+			case e.resolvedCh <- resolved:
+			default:
+				e.log.Warnf("Health platform egress: resolved channel full, %s recoverable from disk", resolved.Id)
+			}
+		},
 	})
 
 	reqs.Lifecycle.Append(compdef.Hook{
@@ -139,63 +143,52 @@ func (e *egress) run() {
 	}
 }
 
-func (e *egress) onReportIssue(issue *healthplatform.Issue) {
-	e.pendingMu.Lock()
-	e.active[issue.Id] = issue
-	e.pendingMu.Unlock()
-}
-
-// onResolveIssue removes the issue from active and queues the tombstone for one send.
-func (e *egress) onResolveIssue(tombstone *healthplatform.Issue) {
-	e.pendingMu.Lock()
-	delete(e.active, tombstone.Id)
-	e.toSendOnce = append(e.toSendOnce, tombstone)
-	e.pendingMu.Unlock()
-}
-
 func (e *egress) tick() {
-	e.pendingMu.Lock()
-	if len(e.active) == 0 && len(e.toSendOnce) == 0 {
-		e.pendingMu.Unlock()
+	_, active := e.store.GetAllIssues()
+
+	// Drain the resolved-issue channel into a tick-local slice.
+	// We just pulled N items out, so on failure there is always room to return them.
+	var resolved []*healthplatform.Issue
+drain:
+	for {
+		select {
+		case r := <-e.resolvedCh:
+			resolved = append(resolved, r)
+		default:
+			break drain
+		}
+	}
+
+	if len(active) == 0 && len(resolved) == 0 {
 		e.log.Debug("Health platform egress: no issues to report, skipping tick")
 		return
 	}
 
-	activeSnap := make(map[string]*healthplatform.Issue, len(e.active))
-	for k, v := range e.active {
-		activeSnap[k] = v
-	}
-	// Take a reference without clearing: we trim by length after a successful
-	// send, so tombstones appended by onResolveIssue during the send are kept.
-	resolvedSnap := e.toSendOnce
-	e.pendingMu.Unlock()
-
-	merged := make(map[string]*healthplatform.Issue, len(activeSnap)+len(resolvedSnap))
-	for k, v := range activeSnap {
+	merged := make(map[string]*healthplatform.Issue, len(active)+len(resolved))
+	for k, v := range active {
 		merged[k] = v
 	}
-	for _, t := range resolvedSnap {
-		merged[t.Id] = t
+	for _, r := range resolved {
+		merged[r.Id] = r
 	}
-
-	report := e.buildReport(merged)
 
 	// Derive from Background: the run loop has no parent context to cancel.
 	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
 	defer cancel()
 
-	if err := e.forwarder.Send(ctx, report); err != nil {
+	if err := e.forwarder.Send(ctx, e.buildReport(merged)); err != nil {
 		e.log.Warn(fmt.Sprintf("Health platform egress: failed to send %d issues: %v", len(merged), err))
+		for _, r := range resolved {
+			select {
+			case e.resolvedCh <- r:
+			default:
+				e.log.Warnf("Health platform egress: resolved channel full on retry, %s recoverable from disk", r.Id)
+			}
+		}
 		return
 	}
 
 	e.log.Info(fmt.Sprintf("Health platform egress: sent report with %d issues", len(merged)))
-
-	if len(resolvedSnap) > 0 {
-		e.pendingMu.Lock()
-		e.toSendOnce = e.toSendOnce[len(resolvedSnap):]
-		e.pendingMu.Unlock()
-	}
 }
 
 func (e *egress) buildReport(issues map[string]*healthplatform.Issue) *healthplatform.HealthReport {

--- a/comp/healthplatform/egress/impl/egress.go
+++ b/comp/healthplatform/egress/impl/egress.go
@@ -9,12 +9,13 @@ package egressimpl
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/DataDog/agent-payload/v5/healthplatform"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	egressdef "github.com/DataDog/datadog-agent/comp/healthplatform/egress/def"
@@ -38,16 +39,19 @@ const (
 )
 
 // egress drives the periodic outbound POST to the Datadog intake.
-// On each tick it calls store.GetAllIssues(), builds a HealthReport, and
-// forwards it via forwarder.Send. When health_platform is disabled, lifecycle
-// hooks are never registered so the goroutine is never launched.
+// active issues are re-sent every tick; resolved tombstones (toSendOnce) are
+// trimmed by a slice-length operation after a successful send, so exactly-once
+// forwarding is structural rather than conditional.
 type egress struct {
 	log         log.Component
 	interval    time.Duration
 	hostname    string
 	agentFlavor string
-	store       storedef.Component
 	forwarder   forwarderdef.Component
+
+	pendingMu  sync.Mutex
+	active     map[string]*healthplatform.Issue // re-sent every tick until resolved
+	toSendOnce []*healthplatform.Issue          // tombstones; trimmed after a successful send
 
 	stopCh chan struct{}
 	doneCh chan struct{}
@@ -64,8 +68,6 @@ type Requires struct {
 }
 
 // New creates the egress component and registers its lifecycle hooks.
-// When health_platform.enabled is false, it returns a zero-value struct without
-// registering any lifecycle hooks.
 func New(reqs Requires) egressdef.Component {
 	if !reqs.Config.GetBool("health_platform.enabled") {
 		return &egress{}
@@ -87,11 +89,18 @@ func New(reqs Requires) egressdef.Component {
 		interval:    interval,
 		hostname:    hostname,
 		agentFlavor: flavor.GetFlavor(),
-		store:       reqs.Store,
 		forwarder:   reqs.Forwarder,
+		active:      make(map[string]*healthplatform.Issue),
 		stopCh:      make(chan struct{}),
 		doneCh:      make(chan struct{}),
 	}
+
+	// Callbacks must be registered before OnStart: the store's loadFromDisk fires
+	// first and calls onResolveIssue for any RESOLVED issues found on disk.
+	reqs.Store.SetEgressCallbacks(storedef.EgressCallbacks{
+		OnReportIssue:  e.onReportIssue,
+		OnResolveIssue: e.onResolveIssue,
+	})
 
 	reqs.Lifecycle.Append(compdef.Hook{
 		OnStart: e.start,
@@ -130,28 +139,63 @@ func (e *egress) run() {
 	}
 }
 
+func (e *egress) onReportIssue(issue *healthplatform.Issue) {
+	e.pendingMu.Lock()
+	e.active[issue.Id] = issue
+	e.pendingMu.Unlock()
+}
+
+// onResolveIssue removes the issue from active and queues the tombstone for one send.
+func (e *egress) onResolveIssue(tombstone *healthplatform.Issue) {
+	e.pendingMu.Lock()
+	delete(e.active, tombstone.Id)
+	e.toSendOnce = append(e.toSendOnce, tombstone)
+	e.pendingMu.Unlock()
+}
+
 func (e *egress) tick() {
-	count, issues := e.store.GetAllIssues()
-	if count == 0 {
+	e.pendingMu.Lock()
+	if len(e.active) == 0 && len(e.toSendOnce) == 0 {
+		e.pendingMu.Unlock()
 		e.log.Debug("Health platform egress: no issues to report, skipping tick")
 		return
 	}
 
-	report := e.buildReport(issues)
+	activeSnap := make(map[string]*healthplatform.Issue, len(e.active))
+	for k, v := range e.active {
+		activeSnap[k] = v
+	}
+	// Take a reference without clearing: we trim by length after a successful
+	// send, so tombstones appended by onResolveIssue during the send are kept.
+	resolvedSnap := e.toSendOnce
+	e.pendingMu.Unlock()
 
-	// Fresh context with a fixed timeout per send: the run loop does not carry
-	// a cancellable context, so we derive from Background rather than from an
-	// ancestor that may have already expired or been cancelled.
+	merged := make(map[string]*healthplatform.Issue, len(activeSnap)+len(resolvedSnap))
+	for k, v := range activeSnap {
+		merged[k] = v
+	}
+	for _, t := range resolvedSnap {
+		merged[t.Id] = t
+	}
+
+	report := e.buildReport(merged)
+
+	// Derive from Background: the run loop has no parent context to cancel.
 	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
 	defer cancel()
 
 	if err := e.forwarder.Send(ctx, report); err != nil {
-		e.log.Warn(fmt.Sprintf("Health platform egress: failed to send %d issues: %v", count, err))
+		e.log.Warn(fmt.Sprintf("Health platform egress: failed to send %d issues: %v", len(merged), err))
 		return
 	}
 
-	e.log.Info(fmt.Sprintf("Health platform egress: sent report with %d issues", count))
-	e.store.PruneResolvedIssues()
+	e.log.Info(fmt.Sprintf("Health platform egress: sent report with %d issues", len(merged)))
+
+	if len(resolvedSnap) > 0 {
+		e.pendingMu.Lock()
+		e.toSendOnce = e.toSendOnce[len(resolvedSnap):]
+		e.pendingMu.Unlock()
+	}
 }
 
 func (e *egress) buildReport(issues map[string]*healthplatform.Issue) *healthplatform.HealthReport {

--- a/comp/healthplatform/egress/impl/egress.go
+++ b/comp/healthplatform/egress/impl/egress.go
@@ -93,23 +93,11 @@ func New(reqs Requires) egressdef.Component {
 		doneCh:      make(chan struct{}),
 	}
 
-	// Register before OnStart: loadFromDisk fires first and calls OnIssueResolved
-	// for any resolved issues found on disk.
+	// Register before OnStart: loadFromDisk fires first and writes any resolved
+	// issues found on disk into ResolvedCh.
 	reqs.Store.RegisterObserver(storedef.IssueObserver{
-		OnIssueReported: func(issue *healthplatform.Issue) {
-			select {
-			case e.activeCh <- issue:
-			default:
-				e.log.Warnf("Health platform egress: active channel full, %s will resend on next check run", issue.Id)
-			}
-		},
-		OnIssueResolved: func(resolved *healthplatform.Issue) {
-			select {
-			case e.resolvedCh <- resolved:
-			default:
-				e.log.Warnf("Health platform egress: resolved channel full, %s recoverable from disk", resolved.Id)
-			}
-		},
+		ActiveCh:   e.activeCh,
+		ResolvedCh: e.resolvedCh,
 	})
 
 	reqs.Lifecycle.Append(compdef.Hook{

--- a/comp/healthplatform/egress/impl/egress_test.go
+++ b/comp/healthplatform/egress/impl/egress_test.go
@@ -242,31 +242,21 @@ func TestActiveDrainedNotReturned(t *testing.T) {
 	assert.Empty(t, e.activeCh, "active issues are not returned on failure — next check run repopulates")
 }
 
-// TestObserverWiresChannels verifies that the observer registered in New routes
-// reported and resolved issues into the correct channels.
+// TestObserverWiresChannels verifies that registering with ActiveCh/ResolvedCh
+// routes issues written by the store directly into the egress channels.
 func TestObserverWiresChannels(t *testing.T) {
 	store := &mockStore{}
 	fwd := &mockForwarder{}
 	e := newTestEgress(t, time.Minute, fwd)
 
 	store.RegisterObserver(storedef.IssueObserver{
-		OnIssueReported: func(issue *healthplatformpayload.Issue) {
-			select {
-			case e.activeCh <- issue:
-			default:
-			}
-		},
-		OnIssueResolved: func(resolved *healthplatformpayload.Issue) {
-			select {
-			case e.resolvedCh <- resolved:
-			default:
-			}
-		},
+		ActiveCh:   e.activeCh,
+		ResolvedCh: e.resolvedCh,
 	})
 
 	store.mu.Lock()
-	store.observer.OnIssueReported(&healthplatformpayload.Issue{Id: "active"})
-	store.observer.OnIssueResolved(&healthplatformpayload.Issue{Id: "resolved"})
+	store.observer.ActiveCh <- &healthplatformpayload.Issue{Id: "active"}
+	store.observer.ResolvedCh <- &healthplatformpayload.Issue{Id: "resolved"}
 	store.mu.Unlock()
 
 	assert.Len(t, e.activeCh, 1)

--- a/comp/healthplatform/egress/impl/egress_test.go
+++ b/comp/healthplatform/egress/impl/egress_test.go
@@ -23,21 +23,32 @@ import (
 	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 )
 
-// mockStore satisfies storedef.Component for egress unit tests.
+// mockStore satisfies storedef.Component; captures the registered observer for assertions.
 type mockStore struct {
-	mu  sync.Mutex
-	cbs storedef.EgressCallbacks
+	mu       sync.Mutex
+	issues   map[string]*healthplatformpayload.Issue
+	observer storedef.IssueObserver
 }
 
-func (m *mockStore) SetEgressCallbacks(cbs storedef.EgressCallbacks) {
+func (m *mockStore) RegisterObserver(obs storedef.IssueObserver) {
 	m.mu.Lock()
-	m.cbs = cbs
+	m.observer = obs
 	m.mu.Unlock()
 }
 
 func (m *mockStore) GetAllIssues() (int, map[string]*healthplatformpayload.Issue) {
-	return 0, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.issues) == 0 {
+		return 0, nil
+	}
+	cp := make(map[string]*healthplatformpayload.Issue, len(m.issues))
+	for k, v := range m.issues {
+		cp[k] = v
+	}
+	return len(cp), cp
 }
+
 func (m *mockStore) ReportIssue(_ *healthplatformpayload.Issue) error { return nil }
 func (m *mockStore) ResolveIssue(_ string)                            {}
 func (m *mockStore) ResolveAllIssues()                                {}
@@ -65,24 +76,33 @@ func (m *mockForwarder) Send(_ context.Context, report *healthplatformpayload.He
 
 var _ forwarderdef.Component = (*mockForwarder)(nil)
 
-func newTestEgress(t *testing.T, interval time.Duration, fwd *mockForwarder) *egress {
+func newTestEgress(t *testing.T, interval time.Duration, store *mockStore, fwd *mockForwarder) *egress {
 	t.Helper()
-	return &egress{
+	e := &egress{
 		log:         logmock.New(t),
 		interval:    interval,
 		hostname:    "test-host",
 		agentFlavor: "agent",
+		store:       store,
 		forwarder:   fwd,
-		active:      make(map[string]*healthplatformpayload.Issue),
+		resolvedCh:  make(chan *healthplatformpayload.Issue, resolvedChSize),
 		stopCh:      make(chan struct{}),
 		doneCh:      make(chan struct{}),
 	}
+	store.RegisterObserver(storedef.IssueObserver{
+		OnIssueResolved: func(resolved *healthplatformpayload.Issue) {
+			e.resolvedCh <- resolved
+		},
+	})
+	return e
 }
 
-func TestTickSendsReport(t *testing.T) {
+func TestTickSendsActiveIssues(t *testing.T) {
+	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
+		"issue-1": {Id: "issue-1", Title: "Test", Severity: healthplatformpayload.IssueSeverity_ISSUE_SEVERITY_HIGH},
+	}}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, fwd)
-	e.active["issue-1"] = &healthplatformpayload.Issue{Id: "issue-1", Title: "Test", Severity: healthplatformpayload.IssueSeverity_ISSUE_SEVERITY_HIGH}
+	e := newTestEgress(t, time.Minute, store, fwd)
 
 	e.tick()
 
@@ -95,9 +115,10 @@ func TestTickSendsReport(t *testing.T) {
 	assert.Equal(t, eventType, fwd.reports[0].EventType)
 }
 
-func TestTickSkipsEmptyQueues(t *testing.T) {
+func TestTickSkipsWhenEmpty(t *testing.T) {
+	store := &mockStore{}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, fwd)
+	e := newTestEgress(t, time.Minute, store, fwd)
 
 	e.tick()
 
@@ -105,9 +126,11 @@ func TestTickSkipsEmptyQueues(t *testing.T) {
 }
 
 func TestTickLogsOnForwarderError(t *testing.T) {
+	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
+		"issue-1": {Id: "issue-1"},
+	}}
 	fwd := &mockForwarder{sendErr: assert.AnError}
-	e := newTestEgress(t, time.Minute, fwd)
-	e.active["issue-1"] = &healthplatformpayload.Issue{Id: "issue-1"}
+	e := newTestEgress(t, time.Minute, store, fwd)
 
 	e.tick()
 
@@ -115,8 +138,9 @@ func TestTickLogsOnForwarderError(t *testing.T) {
 }
 
 func TestLifecycleStartStop(t *testing.T) {
+	store := &mockStore{}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, 50*time.Millisecond, fwd)
+	e := newTestEgress(t, 50*time.Millisecond, store, fwd)
 
 	require.NoError(t, e.start(context.Background()))
 	time.Sleep(30 * time.Millisecond)
@@ -124,29 +148,28 @@ func TestLifecycleStartStop(t *testing.T) {
 }
 
 func TestTickFiresOnInterval(t *testing.T) {
+	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
+		"issue-1": {Id: "issue-1"},
+	}}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, 30*time.Millisecond, fwd)
-	e.active["issue-1"] = &healthplatformpayload.Issue{Id: "issue-1"}
+	e := newTestEgress(t, 30*time.Millisecond, store, fwd)
 
 	require.NoError(t, e.start(context.Background()))
-
 	require.Eventually(t, func() bool {
 		return fwd.sendCount.Load() >= 2
 	}, 2*time.Second, 10*time.Millisecond, "expected at least 2 ticks")
-
 	require.NoError(t, e.stop(context.Background()))
 }
 
 func TestErrorThenRecovery(t *testing.T) {
+	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
+		"issue-1": {Id: "issue-1"},
+	}}
 	fwd := &mockForwarder{sendErr: assert.AnError}
-	e := newTestEgress(t, 20*time.Millisecond, fwd)
-	e.active["issue-1"] = &healthplatformpayload.Issue{Id: "issue-1"}
+	e := newTestEgress(t, 20*time.Millisecond, store, fwd)
 
 	require.NoError(t, e.start(context.Background()))
-
-	require.Eventually(t, func() bool {
-		return fwd.sendCount.Load() >= 1
-	}, 2*time.Second, 5*time.Millisecond)
+	require.Eventually(t, func() bool { return fwd.sendCount.Load() >= 1 }, 2*time.Second, 5*time.Millisecond)
 
 	fwd.mu.Lock()
 	fwd.sendErr = nil
@@ -162,14 +185,11 @@ func TestErrorThenRecovery(t *testing.T) {
 }
 
 func TestBuildReport(t *testing.T) {
+	store := &mockStore{}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, fwd)
+	e := newTestEgress(t, time.Minute, store, fwd)
 
-	issues := map[string]*healthplatformpayload.Issue{
-		"a": {Id: "a"},
-		"b": {Id: "b"},
-	}
-	report := e.buildReport(issues)
+	report := e.buildReport(map[string]*healthplatformpayload.Issue{"a": {Id: "a"}, "b": {Id: "b"}})
 
 	assert.Equal(t, eventType, report.EventType)
 	assert.Equal(t, "test-host", report.Host.Hostname)
@@ -179,106 +199,61 @@ func TestBuildReport(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestOnReportIssueFeedsTickPayload(t *testing.T) {
+// TestTombstoneChannelForwardedOnce verifies that a tombstone written to the
+// channel is sent once and consumed; the channel is empty after success.
+func TestTombstoneChannelForwardedOnce(t *testing.T) {
+	store := &mockStore{}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, fwd)
+	e := newTestEgress(t, time.Minute, store, fwd)
 
-	e.onReportIssue(&healthplatformpayload.Issue{Id: "cb-issue"})
-
-	e.tick()
-
-	fwd.mu.Lock()
-	defer fwd.mu.Unlock()
-	require.Len(t, fwd.reports, 1)
-	assert.Contains(t, fwd.reports[0].Issues, "cb-issue")
-}
-
-func TestOnResolveIssueForwardedOnce(t *testing.T) {
-	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, fwd)
-
-	e.onReportIssue(&healthplatformpayload.Issue{Id: "r-issue", IssueName: "t"})
-	e.onResolveIssue(&healthplatformpayload.Issue{
-		Id:        "r-issue",
-		IssueName: "t",
+	// Simulate the store writing a tombstone.
+	e.resolvedCh <- &healthplatformpayload.Issue{
+		Id: "r-issue",
 		PersistedIssue: &healthplatformpayload.PersistedIssue{
 			State: healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED,
 		},
-	})
+	}
 
-	// First tick: tombstone forwarded.
 	e.tick()
+
 	assert.Equal(t, int32(1), fwd.sendCount.Load())
 	fwd.mu.Lock()
 	require.Len(t, fwd.reports, 1)
-	iss := fwd.reports[0].Issues["r-issue"]
-	require.NotNil(t, iss)
-	assert.Equal(t, healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED, iss.PersistedIssue.GetState())
+	assert.Contains(t, fwd.reports[0].Issues, "r-issue")
 	fwd.mu.Unlock()
 
-	e.pendingMu.Lock()
-	assert.Empty(t, e.toSendOnce, "toSendOnce must be trimmed after a successful send")
-	e.pendingMu.Unlock()
+	// channel must be empty after a successful send
+	assert.Empty(t, e.resolvedCh)
 
-	// second tick: active is empty and toSendOnce was trimmed — nothing to send
+	// second tick: no active issues, no tombstones — nothing to send
 	e.tick()
-	assert.Equal(t, int32(1), fwd.sendCount.Load(), "tombstone must not be re-sent")
+	assert.Equal(t, int32(1), fwd.sendCount.Load())
 }
 
-func TestResolvedTombstoneKeptOnSendFailure(t *testing.T) {
+// TestTombstoneReturnedOnSendFailure verifies that tombstones are put back into
+// the channel when the send fails, so they are retried on the next tick.
+func TestTombstoneReturnedOnSendFailure(t *testing.T) {
+	store := &mockStore{}
 	fwd := &mockForwarder{sendErr: assert.AnError}
-	e := newTestEgress(t, time.Minute, fwd)
+	e := newTestEgress(t, time.Minute, store, fwd)
 
-	e.onResolveIssue(&healthplatformpayload.Issue{
-		Id: "fail-issue",
-		PersistedIssue: &healthplatformpayload.PersistedIssue{
-			State: healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED,
-		},
-	})
-
+	e.resolvedCh <- &healthplatformpayload.Issue{Id: "fail-issue"}
 	e.tick() // send fails
 
-	e.pendingMu.Lock()
-	assert.Len(t, e.toSendOnce, 1, "toSendOnce must not be trimmed after a failed send")
-	e.pendingMu.Unlock()
+	assert.Len(t, e.resolvedCh, 1, "tombstone must be returned to channel after failed send")
 }
 
-// TestTombstoneAddedDuringSendIsRetained verifies the slice-trim invariant:
-// tombstones appended to toSendOnce after the snapshot but before the trim survive.
-func TestTombstoneAddedDuringSendIsRetained(t *testing.T) {
-	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, fwd)
-
-	e.onResolveIssue(&healthplatformpayload.Issue{Id: "first"})
-	e.tick() // snapshots len=1, trims 1
-
-	e.onResolveIssue(&healthplatformpayload.Issue{Id: "second"})
-
-	e.pendingMu.Lock()
-	assert.Len(t, e.toSendOnce, 1, "second tombstone must survive the trim")
-	assert.Equal(t, "second", e.toSendOnce[0].Id)
-	e.pendingMu.Unlock()
-}
-
-func TestCallbacksRegisteredWithStore(t *testing.T) {
+// TestObserverWiredToTombstoneChannel verifies that the observer registered by
+// the egress routes resolved issues into the tombstone channel.
+func TestObserverWiredToTombstoneChannel(t *testing.T) {
 	store := &mockStore{}
 	fwd := &mockForwarder{}
-
-	e := newTestEgress(t, time.Minute, fwd)
-	store.SetEgressCallbacks(storedef.EgressCallbacks{
-		OnReportIssue:  e.onReportIssue,
-		OnResolveIssue: e.onResolveIssue,
-	})
+	e := newTestEgress(t, time.Minute, store, fwd)
 
 	store.mu.Lock()
-	require.NotNil(t, store.cbs.OnReportIssue)
-	require.NotNil(t, store.cbs.OnResolveIssue)
+	require.NotNil(t, store.observer.OnIssueResolved)
+	store.observer.OnIssueResolved(&healthplatformpayload.Issue{Id: "from-store"})
 	store.mu.Unlock()
 
-	store.cbs.OnReportIssue(&healthplatformpayload.Issue{Id: "wired-issue"})
-
-	e.pendingMu.Lock()
-	_, ok := e.active["wired-issue"]
-	e.pendingMu.Unlock()
-	assert.True(t, ok)
+	assert.Len(t, e.resolvedCh, 1)
 }

--- a/comp/healthplatform/egress/impl/egress_test.go
+++ b/comp/healthplatform/egress/impl/egress_test.go
@@ -230,16 +230,28 @@ func TestResolvedReturnedOnSendFailure(t *testing.T) {
 	assert.Len(t, e.resolvedCh, 1, "resolved issue must be returned after failed send")
 }
 
-// TestActiveDrainedNotReturned verifies active issues are drained each tick and
-// not put back (re-populated by the next check run).
-func TestActiveDrainedNotReturned(t *testing.T) {
+// TestActiveReturnedAfterTick verifies active issues are always returned to
+// activeCh after a tick so they persist between sends.
+func TestActiveReturnedAfterTick(t *testing.T) {
+	fwd := &mockForwarder{}
+	e := newTestEgress(t, time.Minute, fwd)
+
+	e.activeCh <- &healthplatformpayload.Issue{Id: "active-issue"}
+	e.tick()
+
+	assert.Len(t, e.activeCh, 1, "active issues must be returned to the channel after a successful send")
+}
+
+// TestActiveReturnedOnSendFailure verifies active issues are also returned when
+// the send fails.
+func TestActiveReturnedOnSendFailure(t *testing.T) {
 	fwd := &mockForwarder{sendErr: assert.AnError}
 	e := newTestEgress(t, time.Minute, fwd)
 
 	e.activeCh <- &healthplatformpayload.Issue{Id: "active-issue"}
 	e.tick()
 
-	assert.Empty(t, e.activeCh, "active issues are not returned on failure — next check run repopulates")
+	assert.Len(t, e.activeCh, 1, "active issues must be returned to the channel after a failed send")
 }
 
 // TestObserverWiresChannels verifies that registering with ActiveCh/ResolvedCh

--- a/comp/healthplatform/egress/impl/egress_test.go
+++ b/comp/healthplatform/egress/impl/egress_test.go
@@ -26,7 +26,6 @@ import (
 // mockStore satisfies storedef.Component; captures the registered observer for assertions.
 type mockStore struct {
 	mu       sync.Mutex
-	issues   map[string]*healthplatformpayload.Issue
 	observer storedef.IssueObserver
 }
 
@@ -36,24 +35,12 @@ func (m *mockStore) RegisterObserver(obs storedef.IssueObserver) {
 	m.mu.Unlock()
 }
 
-func (m *mockStore) GetAllIssues() (int, map[string]*healthplatformpayload.Issue) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if len(m.issues) == 0 {
-		return 0, nil
-	}
-	cp := make(map[string]*healthplatformpayload.Issue, len(m.issues))
-	for k, v := range m.issues {
-		cp[k] = v
-	}
-	return len(cp), cp
-}
-
-func (m *mockStore) ReportIssue(_ *healthplatformpayload.Issue) error { return nil }
-func (m *mockStore) ResolveIssue(_ string)                            {}
-func (m *mockStore) ResolveAllIssues()                                {}
-func (m *mockStore) GetIssue(_ string) *healthplatformpayload.Issue   { return nil }
-func (m *mockStore) GetActiveIssueIDsByIssueName(_ string) []string   { return nil }
+func (m *mockStore) GetAllIssues() (int, map[string]*healthplatformpayload.Issue) { return 0, nil }
+func (m *mockStore) ReportIssue(_ *healthplatformpayload.Issue) error             { return nil }
+func (m *mockStore) ResolveIssue(_ string)                                        {}
+func (m *mockStore) ResolveAllIssues()                                            {}
+func (m *mockStore) GetIssue(_ string) *healthplatformpayload.Issue               { return nil }
+func (m *mockStore) GetActiveIssueIDsByIssueName(_ string) []string               { return nil }
 
 // mockForwarder records Send calls.
 type mockForwarder struct {
@@ -76,33 +63,25 @@ func (m *mockForwarder) Send(_ context.Context, report *healthplatformpayload.He
 
 var _ forwarderdef.Component = (*mockForwarder)(nil)
 
-func newTestEgress(t *testing.T, interval time.Duration, store *mockStore, fwd *mockForwarder) *egress {
+func newTestEgress(t *testing.T, interval time.Duration, fwd *mockForwarder) *egress {
 	t.Helper()
-	e := &egress{
+	return &egress{
 		log:         logmock.New(t),
 		interval:    interval,
 		hostname:    "test-host",
 		agentFlavor: "agent",
-		store:       store,
 		forwarder:   fwd,
-		resolvedCh:  make(chan *healthplatformpayload.Issue, resolvedChSize),
+		activeCh:    make(chan *healthplatformpayload.Issue, issueChSize),
+		resolvedCh:  make(chan *healthplatformpayload.Issue, issueChSize),
 		stopCh:      make(chan struct{}),
 		doneCh:      make(chan struct{}),
 	}
-	store.RegisterObserver(storedef.IssueObserver{
-		OnIssueResolved: func(resolved *healthplatformpayload.Issue) {
-			e.resolvedCh <- resolved
-		},
-	})
-	return e
 }
 
 func TestTickSendsActiveIssues(t *testing.T) {
-	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
-		"issue-1": {Id: "issue-1", Title: "Test", Severity: healthplatformpayload.IssueSeverity_ISSUE_SEVERITY_HIGH},
-	}}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, fwd)
+	e.activeCh <- &healthplatformpayload.Issue{Id: "issue-1", Title: "Test"}
 
 	e.tick()
 
@@ -116,9 +95,8 @@ func TestTickSendsActiveIssues(t *testing.T) {
 }
 
 func TestTickSkipsWhenEmpty(t *testing.T) {
-	store := &mockStore{}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, fwd)
 
 	e.tick()
 
@@ -126,11 +104,9 @@ func TestTickSkipsWhenEmpty(t *testing.T) {
 }
 
 func TestTickLogsOnForwarderError(t *testing.T) {
-	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
-		"issue-1": {Id: "issue-1"},
-	}}
 	fwd := &mockForwarder{sendErr: assert.AnError}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, fwd)
+	e.activeCh <- &healthplatformpayload.Issue{Id: "issue-1"}
 
 	e.tick()
 
@@ -138,9 +114,8 @@ func TestTickLogsOnForwarderError(t *testing.T) {
 }
 
 func TestLifecycleStartStop(t *testing.T) {
-	store := &mockStore{}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, 50*time.Millisecond, store, fwd)
+	e := newTestEgress(t, 50*time.Millisecond, fwd)
 
 	require.NoError(t, e.start(context.Background()))
 	time.Sleep(30 * time.Millisecond)
@@ -148,13 +123,23 @@ func TestLifecycleStartStop(t *testing.T) {
 }
 
 func TestTickFiresOnInterval(t *testing.T) {
-	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
-		"issue-1": {Id: "issue-1"},
-	}}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, 30*time.Millisecond, store, fwd)
+	e := newTestEgress(t, 30*time.Millisecond, fwd)
 
 	require.NoError(t, e.start(context.Background()))
+
+	// Keep activeCh populated so ticks don't skip.
+	go func() {
+		issue := &healthplatformpayload.Issue{Id: "issue-1"}
+		for {
+			select {
+			case e.activeCh <- issue:
+			case <-e.stopCh:
+				return
+			}
+		}
+	}()
+
 	require.Eventually(t, func() bool {
 		return fwd.sendCount.Load() >= 2
 	}, 2*time.Second, 10*time.Millisecond, "expected at least 2 ticks")
@@ -162,13 +147,22 @@ func TestTickFiresOnInterval(t *testing.T) {
 }
 
 func TestErrorThenRecovery(t *testing.T) {
-	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
-		"issue-1": {Id: "issue-1"},
-	}}
 	fwd := &mockForwarder{sendErr: assert.AnError}
-	e := newTestEgress(t, 20*time.Millisecond, store, fwd)
+	e := newTestEgress(t, 20*time.Millisecond, fwd)
 
 	require.NoError(t, e.start(context.Background()))
+
+	go func() {
+		issue := &healthplatformpayload.Issue{Id: "issue-1"}
+		for {
+			select {
+			case e.activeCh <- issue:
+			case <-e.stopCh:
+				return
+			}
+		}
+	}()
+
 	require.Eventually(t, func() bool { return fwd.sendCount.Load() >= 1 }, 2*time.Second, 5*time.Millisecond)
 
 	fwd.mu.Lock()
@@ -185,9 +179,8 @@ func TestErrorThenRecovery(t *testing.T) {
 }
 
 func TestBuildReport(t *testing.T) {
-	store := &mockStore{}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, fwd)
 
 	report := e.buildReport(map[string]*healthplatformpayload.Issue{"a": {Id: "a"}, "b": {Id: "b"}})
 
@@ -199,14 +192,12 @@ func TestBuildReport(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestTombstoneChannelForwardedOnce verifies that a tombstone written to the
-// channel is sent once and consumed; the channel is empty after success.
-func TestTombstoneChannelForwardedOnce(t *testing.T) {
-	store := &mockStore{}
+// TestResolvedIssueSentOnce verifies that a resolved issue is sent and removed
+// from resolvedCh; activeCh is also drained each tick.
+func TestResolvedIssueSentOnce(t *testing.T) {
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, fwd)
 
-	// Simulate the store writing a tombstone.
 	e.resolvedCh <- &healthplatformpayload.Issue{
 		Id: "r-issue",
 		PersistedIssue: &healthplatformpayload.PersistedIssue{
@@ -218,42 +209,66 @@ func TestTombstoneChannelForwardedOnce(t *testing.T) {
 
 	assert.Equal(t, int32(1), fwd.sendCount.Load())
 	fwd.mu.Lock()
-	require.Len(t, fwd.reports, 1)
 	assert.Contains(t, fwd.reports[0].Issues, "r-issue")
 	fwd.mu.Unlock()
 
-	// channel must be empty after a successful send
-	assert.Empty(t, e.resolvedCh)
+	assert.Empty(t, e.resolvedCh, "resolvedCh must be empty after successful send")
 
-	// second tick: no active issues, no tombstones — nothing to send
+	// second tick: both channels empty — skip
 	e.tick()
 	assert.Equal(t, int32(1), fwd.sendCount.Load())
 }
 
-// TestTombstoneReturnedOnSendFailure verifies that tombstones are put back into
-// the channel when the send fails, so they are retried on the next tick.
-func TestTombstoneReturnedOnSendFailure(t *testing.T) {
-	store := &mockStore{}
+// TestResolvedReturnedOnSendFailure verifies resolvedCh items are put back on failure.
+func TestResolvedReturnedOnSendFailure(t *testing.T) {
 	fwd := &mockForwarder{sendErr: assert.AnError}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, fwd)
 
 	e.resolvedCh <- &healthplatformpayload.Issue{Id: "fail-issue"}
-	e.tick() // send fails
+	e.tick()
 
-	assert.Len(t, e.resolvedCh, 1, "tombstone must be returned to channel after failed send")
+	assert.Len(t, e.resolvedCh, 1, "resolved issue must be returned after failed send")
 }
 
-// TestObserverWiredToTombstoneChannel verifies that the observer registered by
-// the egress routes resolved issues into the tombstone channel.
-func TestObserverWiredToTombstoneChannel(t *testing.T) {
+// TestActiveDrainedNotReturned verifies active issues are drained each tick and
+// not put back (re-populated by the next check run).
+func TestActiveDrainedNotReturned(t *testing.T) {
+	fwd := &mockForwarder{sendErr: assert.AnError}
+	e := newTestEgress(t, time.Minute, fwd)
+
+	e.activeCh <- &healthplatformpayload.Issue{Id: "active-issue"}
+	e.tick()
+
+	assert.Empty(t, e.activeCh, "active issues are not returned on failure — next check run repopulates")
+}
+
+// TestObserverWiresChannels verifies that the observer registered in New routes
+// reported and resolved issues into the correct channels.
+func TestObserverWiresChannels(t *testing.T) {
 	store := &mockStore{}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, fwd)
+
+	store.RegisterObserver(storedef.IssueObserver{
+		OnIssueReported: func(issue *healthplatformpayload.Issue) {
+			select {
+			case e.activeCh <- issue:
+			default:
+			}
+		},
+		OnIssueResolved: func(resolved *healthplatformpayload.Issue) {
+			select {
+			case e.resolvedCh <- resolved:
+			default:
+			}
+		},
+	})
 
 	store.mu.Lock()
-	require.NotNil(t, store.observer.OnIssueResolved)
-	store.observer.OnIssueResolved(&healthplatformpayload.Issue{Id: "from-store"})
+	store.observer.OnIssueReported(&healthplatformpayload.Issue{Id: "active"})
+	store.observer.OnIssueResolved(&healthplatformpayload.Issue{Id: "resolved"})
 	store.mu.Unlock()
 
+	assert.Len(t, e.activeCh, 1)
 	assert.Len(t, e.resolvedCh, 1)
 }

--- a/comp/healthplatform/egress/impl/egress_test.go
+++ b/comp/healthplatform/egress/impl/egress_test.go
@@ -20,33 +20,27 @@ import (
 	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	forwarderdef "github.com/DataDog/datadog-agent/comp/healthplatform/forwarder/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 )
 
-// mockStore records GetAllIssues calls and returns preset data.
+// mockStore satisfies storedef.Component for egress unit tests.
 type mockStore struct {
-	mu        sync.Mutex
-	issues    map[string]*healthplatformpayload.Issue
-	callCount atomic.Int32
+	mu  sync.Mutex
+	cbs storedef.EgressCallbacks
+}
+
+func (m *mockStore) SetEgressCallbacks(cbs storedef.EgressCallbacks) {
+	m.mu.Lock()
+	m.cbs = cbs
+	m.mu.Unlock()
 }
 
 func (m *mockStore) GetAllIssues() (int, map[string]*healthplatformpayload.Issue) {
-	m.callCount.Add(1)
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if len(m.issues) == 0 {
-		return 0, nil
-	}
-	cp := make(map[string]*healthplatformpayload.Issue, len(m.issues))
-	for k, v := range m.issues {
-		cp[k] = v
-	}
-	return len(cp), cp
+	return 0, nil
 }
-
 func (m *mockStore) ReportIssue(_ *healthplatformpayload.Issue) error { return nil }
 func (m *mockStore) ResolveIssue(_ string)                            {}
 func (m *mockStore) ResolveAllIssues()                                {}
-func (m *mockStore) PruneResolvedIssues()                             {}
 func (m *mockStore) GetIssue(_ string) *healthplatformpayload.Issue   { return nil }
 func (m *mockStore) GetActiveIssueIDsByIssueName(_ string) []string   { return nil }
 
@@ -71,28 +65,24 @@ func (m *mockForwarder) Send(_ context.Context, report *healthplatformpayload.He
 
 var _ forwarderdef.Component = (*mockForwarder)(nil)
 
-func newTestEgress(t *testing.T, interval time.Duration, store *mockStore, fwd *mockForwarder) *egress {
+func newTestEgress(t *testing.T, interval time.Duration, fwd *mockForwarder) *egress {
 	t.Helper()
 	return &egress{
 		log:         logmock.New(t),
 		interval:    interval,
 		hostname:    "test-host",
 		agentFlavor: "agent",
-		store:       store,
 		forwarder:   fwd,
+		active:      make(map[string]*healthplatformpayload.Issue),
 		stopCh:      make(chan struct{}),
 		doneCh:      make(chan struct{}),
 	}
 }
 
 func TestTickSendsReport(t *testing.T) {
-	store := &mockStore{
-		issues: map[string]*healthplatformpayload.Issue{
-			"issue-1": {Id: "issue-1", Title: "Test", Severity: healthplatformpayload.IssueSeverity_ISSUE_SEVERITY_HIGH},
-		},
-	}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, fwd)
+	e.active["issue-1"] = &healthplatformpayload.Issue{Id: "issue-1", Title: "Test", Severity: healthplatformpayload.IssueSeverity_ISSUE_SEVERITY_HIGH}
 
 	e.tick()
 
@@ -105,10 +95,9 @@ func TestTickSendsReport(t *testing.T) {
 	assert.Equal(t, eventType, fwd.reports[0].EventType)
 }
 
-func TestTickSkipsEmptyStore(t *testing.T) {
-	store := &mockStore{}
+func TestTickSkipsEmptyQueues(t *testing.T) {
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, fwd)
 
 	e.tick()
 
@@ -116,24 +105,18 @@ func TestTickSkipsEmptyStore(t *testing.T) {
 }
 
 func TestTickLogsOnForwarderError(t *testing.T) {
-	store := &mockStore{
-		issues: map[string]*healthplatformpayload.Issue{
-			"issue-1": {Id: "issue-1"},
-		},
-	}
 	fwd := &mockForwarder{sendErr: assert.AnError}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, fwd)
+	e.active["issue-1"] = &healthplatformpayload.Issue{Id: "issue-1"}
 
-	// Should not panic; error is logged internally.
 	e.tick()
 
 	assert.Equal(t, int32(1), fwd.sendCount.Load())
 }
 
 func TestLifecycleStartStop(t *testing.T) {
-	store := &mockStore{}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, 50*time.Millisecond, store, fwd)
+	e := newTestEgress(t, 50*time.Millisecond, fwd)
 
 	require.NoError(t, e.start(context.Background()))
 	time.Sleep(30 * time.Millisecond)
@@ -141,13 +124,9 @@ func TestLifecycleStartStop(t *testing.T) {
 }
 
 func TestTickFiresOnInterval(t *testing.T) {
-	store := &mockStore{
-		issues: map[string]*healthplatformpayload.Issue{
-			"issue-1": {Id: "issue-1"},
-		},
-	}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, 30*time.Millisecond, store, fwd)
+	e := newTestEgress(t, 30*time.Millisecond, fwd)
+	e.active["issue-1"] = &healthplatformpayload.Issue{Id: "issue-1"}
 
 	require.NoError(t, e.start(context.Background()))
 
@@ -159,22 +138,16 @@ func TestTickFiresOnInterval(t *testing.T) {
 }
 
 func TestErrorThenRecovery(t *testing.T) {
-	store := &mockStore{
-		issues: map[string]*healthplatformpayload.Issue{
-			"issue-1": {Id: "issue-1"},
-		},
-	}
 	fwd := &mockForwarder{sendErr: assert.AnError}
-	e := newTestEgress(t, 20*time.Millisecond, store, fwd)
+	e := newTestEgress(t, 20*time.Millisecond, fwd)
+	e.active["issue-1"] = &healthplatformpayload.Issue{Id: "issue-1"}
 
 	require.NoError(t, e.start(context.Background()))
 
-	// Wait for at least one failed tick.
 	require.Eventually(t, func() bool {
 		return fwd.sendCount.Load() >= 1
 	}, 2*time.Second, 5*time.Millisecond)
 
-	// Clear the error; next tick should succeed.
 	fwd.mu.Lock()
 	fwd.sendErr = nil
 	fwd.mu.Unlock()
@@ -189,9 +162,8 @@ func TestErrorThenRecovery(t *testing.T) {
 }
 
 func TestBuildReport(t *testing.T) {
-	store := &mockStore{}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, fwd)
 
 	issues := map[string]*healthplatformpayload.Issue{
 		"a": {Id: "a"},
@@ -205,4 +177,108 @@ func TestBuildReport(t *testing.T) {
 	assert.Len(t, report.Issues, 2)
 	_, err := time.Parse(time.RFC3339, report.EmittedAt)
 	assert.NoError(t, err)
+}
+
+func TestOnReportIssueFeedsTickPayload(t *testing.T) {
+	fwd := &mockForwarder{}
+	e := newTestEgress(t, time.Minute, fwd)
+
+	e.onReportIssue(&healthplatformpayload.Issue{Id: "cb-issue"})
+
+	e.tick()
+
+	fwd.mu.Lock()
+	defer fwd.mu.Unlock()
+	require.Len(t, fwd.reports, 1)
+	assert.Contains(t, fwd.reports[0].Issues, "cb-issue")
+}
+
+func TestOnResolveIssueForwardedOnce(t *testing.T) {
+	fwd := &mockForwarder{}
+	e := newTestEgress(t, time.Minute, fwd)
+
+	e.onReportIssue(&healthplatformpayload.Issue{Id: "r-issue", IssueName: "t"})
+	e.onResolveIssue(&healthplatformpayload.Issue{
+		Id:        "r-issue",
+		IssueName: "t",
+		PersistedIssue: &healthplatformpayload.PersistedIssue{
+			State: healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED,
+		},
+	})
+
+	// First tick: tombstone forwarded.
+	e.tick()
+	assert.Equal(t, int32(1), fwd.sendCount.Load())
+	fwd.mu.Lock()
+	require.Len(t, fwd.reports, 1)
+	iss := fwd.reports[0].Issues["r-issue"]
+	require.NotNil(t, iss)
+	assert.Equal(t, healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED, iss.PersistedIssue.GetState())
+	fwd.mu.Unlock()
+
+	e.pendingMu.Lock()
+	assert.Empty(t, e.toSendOnce, "toSendOnce must be trimmed after a successful send")
+	e.pendingMu.Unlock()
+
+	// second tick: active is empty and toSendOnce was trimmed — nothing to send
+	e.tick()
+	assert.Equal(t, int32(1), fwd.sendCount.Load(), "tombstone must not be re-sent")
+}
+
+func TestResolvedTombstoneKeptOnSendFailure(t *testing.T) {
+	fwd := &mockForwarder{sendErr: assert.AnError}
+	e := newTestEgress(t, time.Minute, fwd)
+
+	e.onResolveIssue(&healthplatformpayload.Issue{
+		Id: "fail-issue",
+		PersistedIssue: &healthplatformpayload.PersistedIssue{
+			State: healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED,
+		},
+	})
+
+	e.tick() // send fails
+
+	e.pendingMu.Lock()
+	assert.Len(t, e.toSendOnce, 1, "toSendOnce must not be trimmed after a failed send")
+	e.pendingMu.Unlock()
+}
+
+// TestTombstoneAddedDuringSendIsRetained verifies the slice-trim invariant:
+// tombstones appended to toSendOnce after the snapshot but before the trim survive.
+func TestTombstoneAddedDuringSendIsRetained(t *testing.T) {
+	fwd := &mockForwarder{}
+	e := newTestEgress(t, time.Minute, fwd)
+
+	e.onResolveIssue(&healthplatformpayload.Issue{Id: "first"})
+	e.tick() // snapshots len=1, trims 1
+
+	e.onResolveIssue(&healthplatformpayload.Issue{Id: "second"})
+
+	e.pendingMu.Lock()
+	assert.Len(t, e.toSendOnce, 1, "second tombstone must survive the trim")
+	assert.Equal(t, "second", e.toSendOnce[0].Id)
+	e.pendingMu.Unlock()
+}
+
+func TestCallbacksRegisteredWithStore(t *testing.T) {
+	store := &mockStore{}
+	fwd := &mockForwarder{}
+
+	e := newTestEgress(t, time.Minute, fwd)
+	store.SetEgressCallbacks(storedef.EgressCallbacks{
+		OnReportIssue:  e.onReportIssue,
+		OnResolveIssue: e.onResolveIssue,
+	})
+
+	store.mu.Lock()
+	require.NotNil(t, store.cbs.OnReportIssue)
+	require.NotNil(t, store.cbs.OnResolveIssue)
+	store.mu.Unlock()
+
+	store.cbs.OnReportIssue(&healthplatformpayload.Issue{Id: "wired-issue"})
+
+	e.pendingMu.Lock()
+	_, ok := e.active["wired-issue"]
+	e.pendingMu.Unlock()
+	assert.True(t, ok)
 }

--- a/comp/healthplatform/egress/impl/egress_test.go
+++ b/comp/healthplatform/egress/impl/egress_test.go
@@ -26,10 +26,10 @@ import (
 // mockStore satisfies storedef.Component; captures the registered observer for assertions.
 type mockStore struct {
 	mu       sync.Mutex
-	observer storedef.IssueObserver
+	observer storedef.EgressAggregator
 }
 
-func (m *mockStore) RegisterObserver(obs storedef.IssueObserver) {
+func (m *mockStore) RegisterEgressAggregator(obs storedef.EgressAggregator) {
 	m.mu.Lock()
 	m.observer = obs
 	m.mu.Unlock()
@@ -249,7 +249,7 @@ func TestObserverWiresChannels(t *testing.T) {
 	fwd := &mockForwarder{}
 	e := newTestEgress(t, time.Minute, fwd)
 
-	store.RegisterObserver(storedef.IssueObserver{
+	store.RegisterEgressAggregator(storedef.EgressAggregator{
 		ActiveCh:   e.activeCh,
 		ResolvedCh: e.resolvedCh,
 	})

--- a/comp/healthplatform/egress/impl/egress_test.go
+++ b/comp/healthplatform/egress/impl/egress_test.go
@@ -125,7 +125,7 @@ func TestLifecycleStartStop(t *testing.T) {
 func TestTickFiresOnInterval(t *testing.T) {
 	fwd := &mockForwarder{}
 	e := newTestEgress(t, 30*time.Millisecond, fwd)
-	// Active issues persist across ticks via drainCh re-queue; no goroutine needed.
+	// Active issues persist across ticks via snapshotIssues re-queue; no goroutine needed.
 	e.activeCh <- &healthplatformpayload.Issue{Id: "issue-1"}
 
 	require.NoError(t, e.start(context.Background()))

--- a/comp/healthplatform/egress/impl/egress_test.go
+++ b/comp/healthplatform/egress/impl/egress_test.go
@@ -125,21 +125,10 @@ func TestLifecycleStartStop(t *testing.T) {
 func TestTickFiresOnInterval(t *testing.T) {
 	fwd := &mockForwarder{}
 	e := newTestEgress(t, 30*time.Millisecond, fwd)
+	// Active issues persist across ticks via drainCh re-queue; no goroutine needed.
+	e.activeCh <- &healthplatformpayload.Issue{Id: "issue-1"}
 
 	require.NoError(t, e.start(context.Background()))
-
-	// Keep activeCh populated so ticks don't skip.
-	go func() {
-		issue := &healthplatformpayload.Issue{Id: "issue-1"}
-		for {
-			select {
-			case e.activeCh <- issue:
-			case <-e.stopCh:
-				return
-			}
-		}
-	}()
-
 	require.Eventually(t, func() bool {
 		return fwd.sendCount.Load() >= 2
 	}, 2*time.Second, 10*time.Millisecond, "expected at least 2 ticks")
@@ -149,20 +138,9 @@ func TestTickFiresOnInterval(t *testing.T) {
 func TestErrorThenRecovery(t *testing.T) {
 	fwd := &mockForwarder{sendErr: assert.AnError}
 	e := newTestEgress(t, 20*time.Millisecond, fwd)
+	e.activeCh <- &healthplatformpayload.Issue{Id: "issue-1"}
 
 	require.NoError(t, e.start(context.Background()))
-
-	go func() {
-		issue := &healthplatformpayload.Issue{Id: "issue-1"}
-		for {
-			select {
-			case e.activeCh <- issue:
-			case <-e.stopCh:
-				return
-			}
-		}
-	}()
-
 	require.Eventually(t, func() bool { return fwd.sendCount.Load() >= 1 }, 2*time.Second, 5*time.Millisecond)
 
 	fwd.mu.Lock()

--- a/comp/healthplatform/noop-impl/health_platform_noop.go
+++ b/comp/healthplatform/noop-impl/health_platform_noop.go
@@ -53,8 +53,7 @@ func (n *noopHealthPlatform) GetIssue(_ string) *healthplatformpayload.Issue {
 	return nil
 }
 
-func (n *noopHealthPlatform) SetEgressCallbacks(_ healthplatformdef.EgressCallbacks) {
-}
+func (n *noopHealthPlatform) RegisterObserver(_ healthplatformdef.IssueObserver) {}
 
 func (n *noopHealthPlatform) ResolveIssue(_ string) {
 }

--- a/comp/healthplatform/noop-impl/health_platform_noop.go
+++ b/comp/healthplatform/noop-impl/health_platform_noop.go
@@ -53,7 +53,7 @@ func (n *noopHealthPlatform) GetIssue(_ string) *healthplatformpayload.Issue {
 	return nil
 }
 
-func (n *noopHealthPlatform) RegisterObserver(_ healthplatformdef.IssueObserver) {}
+func (n *noopHealthPlatform) RegisterEgressAggregator(_ healthplatformdef.EgressAggregator) {}
 
 func (n *noopHealthPlatform) ResolveIssue(_ string) {
 }

--- a/comp/healthplatform/noop-impl/health_platform_noop.go
+++ b/comp/healthplatform/noop-impl/health_platform_noop.go
@@ -53,13 +53,13 @@ func (n *noopHealthPlatform) GetIssue(_ string) *healthplatformpayload.Issue {
 	return nil
 }
 
+func (n *noopHealthPlatform) SetEgressCallbacks(_ healthplatformdef.EgressCallbacks) {
+}
+
 func (n *noopHealthPlatform) ResolveIssue(_ string) {
 }
 
 func (n *noopHealthPlatform) ResolveAllIssues() {
-}
-
-func (n *noopHealthPlatform) PruneResolvedIssues() {
 }
 
 func (n *noopHealthPlatform) GetActiveIssueIDsByIssueName(_ string) []string {

--- a/comp/healthplatform/runner/impl/runner_test.go
+++ b/comp/healthplatform/runner/impl/runner_test.go
@@ -42,9 +42,9 @@ func (m *mockStore) ReportIssue(issue *healthplatformpayload.Issue) error {
 	return nil
 }
 
+func (m *mockStore) SetEgressCallbacks(_ storedef.EgressCallbacks)                {}
 func (m *mockStore) ResolveIssue(_ string)                                        {}
 func (m *mockStore) ResolveAllIssues()                                            {}
-func (m *mockStore) PruneResolvedIssues()                                         {}
 func (m *mockStore) GetIssue(_ string) *healthplatformpayload.Issue               { return nil }
 func (m *mockStore) GetAllIssues() (int, map[string]*healthplatformpayload.Issue) { return 0, nil }
 func (m *mockStore) GetActiveIssueIDsByIssueName(_ string) []string               { return nil }

--- a/comp/healthplatform/runner/impl/runner_test.go
+++ b/comp/healthplatform/runner/impl/runner_test.go
@@ -42,7 +42,7 @@ func (m *mockStore) ReportIssue(issue *healthplatformpayload.Issue) error {
 	return nil
 }
 
-func (m *mockStore) SetEgressCallbacks(_ storedef.EgressCallbacks)                {}
+func (m *mockStore) RegisterObserver(_ storedef.IssueObserver)                    {}
 func (m *mockStore) ResolveIssue(_ string)                                        {}
 func (m *mockStore) ResolveAllIssues()                                            {}
 func (m *mockStore) GetIssue(_ string) *healthplatformpayload.Issue               { return nil }

--- a/comp/healthplatform/runner/impl/runner_test.go
+++ b/comp/healthplatform/runner/impl/runner_test.go
@@ -42,7 +42,7 @@ func (m *mockStore) ReportIssue(issue *healthplatformpayload.Issue) error {
 	return nil
 }
 
-func (m *mockStore) RegisterObserver(_ storedef.IssueObserver)                    {}
+func (m *mockStore) RegisterEgressAggregator(_ storedef.EgressAggregator)         {}
 func (m *mockStore) ResolveIssue(_ string)                                        {}
 func (m *mockStore) ResolveAllIssues()                                            {}
 func (m *mockStore) GetIssue(_ string) *healthplatformpayload.Issue               { return nil }

--- a/comp/healthplatform/scheduler/impl/scheduler_test.go
+++ b/comp/healthplatform/scheduler/impl/scheduler_test.go
@@ -53,7 +53,7 @@ func (m *mockStore) ResolveIssue(id string) {
 	defer m.mu.Unlock()
 	m.resolvedIDs = append(m.resolvedIDs, id)
 }
-func (m *mockStore) SetEgressCallbacks(_ storedef.EgressCallbacks)                {}
+func (m *mockStore) RegisterObserver(_ storedef.IssueObserver)                    {}
 func (m *mockStore) ReportIssue(_ *healthplatformpayload.Issue) error             { return nil }
 func (m *mockStore) ResolveAllIssues()                                            {}
 func (m *mockStore) GetIssue(_ string) *healthplatformpayload.Issue               { return nil }

--- a/comp/healthplatform/scheduler/impl/scheduler_test.go
+++ b/comp/healthplatform/scheduler/impl/scheduler_test.go
@@ -53,7 +53,7 @@ func (m *mockStore) ResolveIssue(id string) {
 	defer m.mu.Unlock()
 	m.resolvedIDs = append(m.resolvedIDs, id)
 }
-func (m *mockStore) RegisterObserver(_ storedef.IssueObserver)                    {}
+func (m *mockStore) RegisterEgressAggregator(_ storedef.EgressAggregator)         {}
 func (m *mockStore) ReportIssue(_ *healthplatformpayload.Issue) error             { return nil }
 func (m *mockStore) ResolveAllIssues()                                            {}
 func (m *mockStore) GetIssue(_ string) *healthplatformpayload.Issue               { return nil }

--- a/comp/healthplatform/scheduler/impl/scheduler_test.go
+++ b/comp/healthplatform/scheduler/impl/scheduler_test.go
@@ -53,9 +53,9 @@ func (m *mockStore) ResolveIssue(id string) {
 	defer m.mu.Unlock()
 	m.resolvedIDs = append(m.resolvedIDs, id)
 }
+func (m *mockStore) SetEgressCallbacks(_ storedef.EgressCallbacks)                {}
 func (m *mockStore) ReportIssue(_ *healthplatformpayload.Issue) error             { return nil }
 func (m *mockStore) ResolveAllIssues()                                            {}
-func (m *mockStore) PruneResolvedIssues()                                         {}
 func (m *mockStore) GetIssue(_ string) *healthplatformpayload.Issue               { return nil }
 func (m *mockStore) GetAllIssues() (int, map[string]*healthplatformpayload.Issue) { return 0, nil }
 func (m *mockStore) GetActiveIssueIDsByIssueName(_ string) []string               { return nil }

--- a/comp/healthplatform/store/def/component.go
+++ b/comp/healthplatform/store/def/component.go
@@ -15,24 +15,31 @@ import (
 	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
 )
 
-// EgressCallbacks groups the functions the egress registers with the store.
-// The store calls these on state transitions; either field may be nil (no-op).
-type EgressCallbacks struct {
-	// OnReportIssue is called after a new or updated issue is stored.
-	// The issue is a fully-hydrated clone safe for the egress to retain.
-	OnReportIssue func(issue *healthplatformpayload.Issue)
+// IssueObserver is an optional listener that receives notifications when issues
+// change state. It is the single extension point for reactive integrations —
+// the egress uses it to receive resolved issues for delivery, and future
+// consumers such as an MCP server can use it to expose issues to AI agents for
+// proactive remediation.
+//
+// Callbacks are invoked synchronously by the store outside its internal lock.
+// Implementations must not block; use a goroutine if the work is non-trivial.
+type IssueObserver struct {
+	// OnIssueReported is called after a new or updated issue is stored.
+	// The issue is a fully-hydrated clone; PersistedIssue.State distinguishes
+	// NEW from ONGOING so observers can choose to act only on first occurrence.
+	OnIssueReported func(issue *healthplatformpayload.Issue)
 
-	// OnResolveIssue is called when an issue transitions to RESOLVED.
-	// The tombstone is a minimal proto (ID, IssueName, PersistedIssue only).
-	OnResolveIssue func(tombstone *healthplatformpayload.Issue)
+	// OnIssueResolved is called when an issue transitions to RESOLVED.
+	// The resolved issue contains the ID, name, and PersistedIssue state.
+	OnIssueResolved func(resolved *healthplatformpayload.Issue)
 }
 
 // Component is the health platform store component interface.
 type Component interface {
-	// SetEgressCallbacks registers the egress callbacks invoked on state changes.
-	// Must be called before the component's OnStart lifecycle hook fires (i.e.
-	// from the egress constructor, before App.Start).
-	SetEgressCallbacks(cbs EgressCallbacks)
+	// RegisterObserver registers a listener for issue state-change notifications.
+	// Multiple observers may be registered; each receives all events. Observers
+	// registered before OnStart also receive resolved issues re-queued from disk.
+	RegisterObserver(obs IssueObserver)
 
 	// ReportIssue records a new or ongoing issue keyed by issue.Id. Two calls
 	// with the same issue.Id update the same instance (state machine: new →

--- a/comp/healthplatform/store/def/component.go
+++ b/comp/healthplatform/store/def/component.go
@@ -15,21 +15,18 @@ import (
 	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
 )
 
-// IssueObserver listens for issue state changes. It is the extension point for
-// reactive integrations — e.g. an MCP server exposing issues to AI agents for
-// proactive remediation.
-//
-// Callbacks run synchronously outside the store's lock. Implementations must
-// not block; use a goroutine for non-trivial work.
+// IssueObserver holds the channels the store writes issue events into.
+// It is the extension point for reactive integrations — e.g. an MCP server
+// exposing issues to AI agents for proactive remediation.
 type IssueObserver struct {
-	// OnIssueReported is called after a new or updated issue is stored.
+	// ActiveCh receives new and ongoing issues as they are stored.
 	// The issue is a fully-hydrated clone; check PersistedIssue.State to
 	// distinguish NEW from ONGOING.
-	OnIssueReported func(issue *healthplatformpayload.Issue)
+	ActiveCh chan<- *healthplatformpayload.Issue
 
-	// OnIssueResolved is called when an issue transitions to RESOLVED.
-	// Contains the issue ID, name, and PersistedIssue state.
-	OnIssueResolved func(resolved *healthplatformpayload.Issue)
+	// ResolvedCh receives issues when they transition to RESOLVED, including
+	// resolved issues recovered from disk on startup.
+	ResolvedCh chan<- *healthplatformpayload.Issue
 }
 
 // Component is the health platform store component interface.

--- a/comp/healthplatform/store/def/component.go
+++ b/comp/healthplatform/store/def/component.go
@@ -15,30 +15,28 @@ import (
 	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
 )
 
-// IssueObserver is an optional listener that receives notifications when issues
-// change state. It is the single extension point for reactive integrations —
-// the egress uses it to receive resolved issues for delivery, and future
-// consumers such as an MCP server can use it to expose issues to AI agents for
+// IssueObserver listens for issue state changes. It is the extension point for
+// reactive integrations — e.g. an MCP server exposing issues to AI agents for
 // proactive remediation.
 //
-// Callbacks are invoked synchronously by the store outside its internal lock.
-// Implementations must not block; use a goroutine if the work is non-trivial.
+// Callbacks run synchronously outside the store's lock. Implementations must
+// not block; use a goroutine for non-trivial work.
 type IssueObserver struct {
 	// OnIssueReported is called after a new or updated issue is stored.
-	// The issue is a fully-hydrated clone; PersistedIssue.State distinguishes
-	// NEW from ONGOING so observers can choose to act only on first occurrence.
+	// The issue is a fully-hydrated clone; check PersistedIssue.State to
+	// distinguish NEW from ONGOING.
 	OnIssueReported func(issue *healthplatformpayload.Issue)
 
 	// OnIssueResolved is called when an issue transitions to RESOLVED.
-	// The resolved issue contains the ID, name, and PersistedIssue state.
+	// Contains the issue ID, name, and PersistedIssue state.
 	OnIssueResolved func(resolved *healthplatformpayload.Issue)
 }
 
 // Component is the health platform store component interface.
 type Component interface {
-	// RegisterObserver registers a listener for issue state-change notifications.
-	// Multiple observers may be registered; each receives all events. Observers
-	// registered before OnStart also receive resolved issues re-queued from disk.
+	// RegisterObserver registers a state-change listener. Multiple observers
+	// may be registered. Observers registered before OnStart also receive
+	// resolved issues recovered from disk on startup.
 	RegisterObserver(obs IssueObserver)
 
 	// ReportIssue records a new or ongoing issue keyed by issue.Id. Two calls

--- a/comp/healthplatform/store/def/component.go
+++ b/comp/healthplatform/store/def/component.go
@@ -22,11 +22,11 @@ type EgressAggregator struct {
 	// ActiveCh receives new and ongoing issues as they are stored.
 	// The issue is a fully-hydrated clone; check PersistedIssue.State to
 	// distinguish NEW from ONGOING.
-	ActiveCh chan<- *healthplatformpayload.Issue
+	ActiveCh chan *healthplatformpayload.Issue
 
 	// ResolvedCh receives issues when they transition to RESOLVED, including
 	// resolved issues recovered from disk on startup.
-	ResolvedCh chan<- *healthplatformpayload.Issue
+	ResolvedCh chan *healthplatformpayload.Issue
 }
 
 // Component is the health platform store component interface.

--- a/comp/healthplatform/store/def/component.go
+++ b/comp/healthplatform/store/def/component.go
@@ -15,10 +15,10 @@ import (
 	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
 )
 
-// IssueObserver holds the channels the store writes issue events into.
+// EgressAggregator holds the channels the store writes issue events into.
 // It is the extension point for reactive integrations — e.g. an MCP server
 // exposing issues to AI agents for proactive remediation.
-type IssueObserver struct {
+type EgressAggregator struct {
 	// ActiveCh receives new and ongoing issues as they are stored.
 	// The issue is a fully-hydrated clone; check PersistedIssue.State to
 	// distinguish NEW from ONGOING.
@@ -31,10 +31,10 @@ type IssueObserver struct {
 
 // Component is the health platform store component interface.
 type Component interface {
-	// RegisterObserver registers a state-change listener. Multiple observers
+	// RegisterEgressAggregator registers a state-change listener. Multiple observers
 	// may be registered. Observers registered before OnStart also receive
 	// resolved issues recovered from disk on startup.
-	RegisterObserver(obs IssueObserver)
+	RegisterEgressAggregator(obs EgressAggregator)
 
 	// ReportIssue records a new or ongoing issue keyed by issue.Id. Two calls
 	// with the same issue.Id update the same instance (state machine: new →

--- a/comp/healthplatform/store/def/component.go
+++ b/comp/healthplatform/store/def/component.go
@@ -15,8 +15,25 @@ import (
 	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
 )
 
+// EgressCallbacks groups the functions the egress registers with the store.
+// The store calls these on state transitions; either field may be nil (no-op).
+type EgressCallbacks struct {
+	// OnReportIssue is called after a new or updated issue is stored.
+	// The issue is a fully-hydrated clone safe for the egress to retain.
+	OnReportIssue func(issue *healthplatformpayload.Issue)
+
+	// OnResolveIssue is called when an issue transitions to RESOLVED.
+	// The tombstone is a minimal proto (ID, IssueName, PersistedIssue only).
+	OnResolveIssue func(tombstone *healthplatformpayload.Issue)
+}
+
 // Component is the health platform store component interface.
 type Component interface {
+	// SetEgressCallbacks registers the egress callbacks invoked on state changes.
+	// Must be called before the component's OnStart lifecycle hook fires (i.e.
+	// from the egress constructor, before App.Start).
+	SetEgressCallbacks(cbs EgressCallbacks)
+
 	// ReportIssue records a new or ongoing issue keyed by issue.Id. Two calls
 	// with the same issue.Id update the same instance (state machine: new →
 	// ongoing). issue.IssueName is used as the issue-type key for telemetry
@@ -44,11 +61,6 @@ type Component interface {
 
 	// ResolveAllIssues marks every active issue as resolved.
 	ResolveAllIssues()
-
-	// PruneResolvedIssues removes RESOLVED tombstones from the active set.
-	// Called by the egress after a successful send so that resolved issues are
-	// not re-forwarded on every subsequent tick.
-	PruneResolvedIssues()
 
 	// GetActiveIssueIDsByIssueName returns the IDs of all currently active issues
 	// with the given IssueName (e.g. "docker_file_tailing_disabled").

--- a/comp/healthplatform/store/impl/BUILD.bazel
+++ b/comp/healthplatform/store/impl/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//comp/core/hostname/hostnameinterface/def",
         "//comp/core/log/mock",
         "//comp/core/telemetry/mock",
+        "//comp/healthplatform/store/def",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -370,8 +370,8 @@ drain:
 // re-report after resolve does not lose to an older RESOLVED entry.
 func (h *healthPlatformImpl) notifyReported(lean *healthplatform.Issue, si *storedIssue) {
 	h.aggregatorsMu.RLock()
+	defer h.aggregatorsMu.RUnlock()
 	agg := h.aggregators
-	h.aggregatorsMu.RUnlock()
 	if len(agg) == 0 {
 		return
 	}
@@ -394,8 +394,8 @@ func (h *healthPlatformImpl) notifyReported(lean *healthplatform.Issue, si *stor
 // resolve does not race with a lingering ONGOING entry.
 func (h *healthPlatformImpl) notifyResolved(resolved *healthplatform.Issue) {
 	h.aggregatorsMu.RLock()
+	defer h.aggregatorsMu.RUnlock()
 	agg := h.aggregators
-	h.aggregatorsMu.RUnlock()
 	for _, o := range agg {
 		if o.ResolvedCh != nil {
 			removeFromCh(o.ActiveCh, resolved.Id)

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -80,8 +80,9 @@ type healthPlatformImpl struct {
 	persistedIssues map[string]*PersistedIssue // IssueID → lifecycle state
 	persistence     issuesPersistence
 
-	// Egress callbacks: registered before OnStart fires; called outside issuesMux.
-	egressCbs healthplatformdef.EgressCallbacks
+	// Issue observers: notified on every state transition outside issuesMux.
+	observersMu sync.RWMutex
+	observers   []healthplatformdef.IssueObserver
 
 	// Metrics
 	metrics telemetryMetrics
@@ -331,10 +332,43 @@ func (h *healthPlatformImpl) stop(_ context.Context) error {
 // Egress Callback Registration
 // ============================================================================
 
-// SetEgressCallbacks registers the callbacks the egress wants to receive on
-// state transitions. Must be called before the component's OnStart hook fires.
-func (h *healthPlatformImpl) SetEgressCallbacks(cbs healthplatformdef.EgressCallbacks) {
-	h.egressCbs = cbs
+// RegisterObserver appends an observer that will be notified on every issue
+// state transition. Safe to call at any time; observers registered after
+// OnStart will miss events that occurred before registration.
+func (h *healthPlatformImpl) RegisterObserver(obs healthplatformdef.IssueObserver) {
+	h.observersMu.Lock()
+	h.observers = append(h.observers, obs)
+	h.observersMu.Unlock()
+}
+
+// notifyReported fires OnIssueReported on all registered observers.
+// Must be called outside issuesMux; lean and si must remain valid for the call.
+func (h *healthPlatformImpl) notifyReported(lean *healthplatform.Issue, si *storedIssue) {
+	h.observersMu.RLock()
+	obs := h.observers
+	h.observersMu.RUnlock()
+	if len(obs) == 0 {
+		return
+	}
+	hydrated := proto.Clone(lean).(*healthplatform.Issue)
+	hydrateIssue(hydrated, si)
+	for _, o := range obs {
+		if o.OnIssueReported != nil {
+			o.OnIssueReported(hydrated)
+		}
+	}
+}
+
+// notifyResolved fires OnIssueResolved on all registered observers.
+func (h *healthPlatformImpl) notifyResolved(resolved *healthplatform.Issue) {
+	h.observersMu.RLock()
+	obs := h.observers
+	h.observersMu.RUnlock()
+	for _, o := range obs {
+		if o.OnIssueResolved != nil {
+			o.OnIssueResolved(resolved)
+		}
+	}
 }
 
 // ============================================================================
@@ -428,12 +462,11 @@ func hydrateIssue(issue *healthplatform.Issue, stored *storedIssue) {
 // ============================================================================
 
 // ResolveIssue marks an issue as resolved and removes it from the active set.
-// It fires OnResolveIssue so the egress can forward the tombstone exactly once.
 func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 	h.issuesMux.Lock()
 
 	stateChanged := false
-	var tombstone *healthplatform.Issue
+	var resolved *healthplatform.Issue
 
 	if _, ok := h.issues[issueID]; ok {
 		h.log.Info("Cleared issue: " + issueID)
@@ -449,9 +482,7 @@ func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 			stateChanged = true
 		}
 
-		// Build tombstone for the egress; issued regardless of whether the
-		// issue was in the active set (covers the post-restart re-resolve case).
-		tombstone = &healthplatform.Issue{
+		resolved = &healthplatform.Issue{
 			Id:             issueID,
 			IssueName:      persisted.IssueType,
 			PersistedIssue: persistedIssueToProto(persisted),
@@ -460,8 +491,8 @@ func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 
 	h.issuesMux.Unlock()
 
-	if tombstone != nil && h.egressCbs.OnResolveIssue != nil {
-		h.egressCbs.OnResolveIssue(tombstone)
+	if resolved != nil {
+		h.notifyResolved(resolved)
 	}
 
 	if stateChanged {
@@ -472,18 +503,18 @@ func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 }
 
 // ResolveAllIssues marks every active issue as resolved.
-// Fires OnResolveIssue for each so the egress forwards them as tombstones.
+// Fires OnResolveIssue for each so the egress forwards them as resolved.
 func (h *healthPlatformImpl) ResolveAllIssues() {
 	h.issuesMux.Lock()
 
 	now := time.Now().Format(time.RFC3339)
-	var tombstones []*healthplatform.Issue
+	var resolved []*healthplatform.Issue
 
 	for _, persisted := range h.persistedIssues {
 		if persisted != nil && persisted.State != IssueStateResolved {
 			persisted.State = IssueStateResolved
 			persisted.ResolvedAt = now
-			tombstones = append(tombstones, &healthplatform.Issue{
+			resolved = append(resolved, &healthplatform.Issue{
 				Id:             persisted.IssueID,
 				IssueName:      persisted.IssueType,
 				PersistedIssue: persistedIssueToProto(persisted),
@@ -497,10 +528,8 @@ func (h *healthPlatformImpl) ResolveAllIssues() {
 
 	h.issuesMux.Unlock()
 
-	if h.egressCbs.OnResolveIssue != nil {
-		for _, t := range tombstones {
-			h.egressCbs.OnResolveIssue(t)
-		}
+	for _, t := range resolved {
+		h.notifyResolved(t)
 	}
 
 	if err := h.saveToDisk(); err != nil {
@@ -613,12 +642,7 @@ func (h *healthPlatformImpl) storeIssue(issueType string, issue *healthplatform.
 
 	h.issuesMux.Unlock()
 
-	if h.egressCbs.OnReportIssue != nil {
-		// Rehydrate Extra/Remediation for the egress copy outside the lock.
-		hydrated := proto.Clone(lean).(*healthplatform.Issue)
-		hydrateIssue(hydrated, si)
-		h.egressCbs.OnReportIssue(hydrated)
-	}
+	h.notifyReported(lean, si)
 
 	if err := h.saveToDisk(); err != nil {
 		h.log.Warn("Failed to persist issues to disk: " + err.Error())
@@ -653,7 +677,7 @@ func (h *healthPlatformImpl) loadFromDisk() error {
 	h.issuesMux.Lock()
 
 	activeCount := 0
-	var resolvedTombstones []*healthplatform.Issue
+	var resolvedIssues []*healthplatform.Issue
 
 	for issueID, persisted := range state.Issues {
 		if persisted == nil {
@@ -667,7 +691,7 @@ func (h *healthPlatformImpl) loadFromDisk() error {
 		}
 
 		if persisted.State == IssueStateResolved {
-			resolvedTombstones = append(resolvedTombstones, &healthplatform.Issue{
+			resolvedIssues = append(resolvedIssues, &healthplatform.Issue{
 				Id:             issueID,
 				IssueName:      persisted.IssueType,
 				PersistedIssue: persistedIssueToProto(persisted),
@@ -682,12 +706,10 @@ func (h *healthPlatformImpl) loadFromDisk() error {
 	h.issuesMux.Unlock()
 
 	h.log.Info(fmt.Sprintf("Loaded %d persisted issues (%d active, %d resolved pending send)",
-		len(state.Issues), activeCount, len(resolvedTombstones)))
+		len(state.Issues), activeCount, len(resolvedIssues)))
 
-	if h.egressCbs.OnResolveIssue != nil {
-		for _, t := range resolvedTombstones {
-			h.egressCbs.OnResolveIssue(t)
-		}
+	for _, t := range resolvedIssues {
+		h.notifyResolved(t)
 	}
 
 	return nil

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -329,20 +329,18 @@ func (h *healthPlatformImpl) stop(_ context.Context) error {
 }
 
 // ============================================================================
-// Egress Callback Registration
+// Observer Registration
 // ============================================================================
 
-// RegisterObserver appends an observer that will be notified on every issue
-// state transition. Safe to call at any time; observers registered after
-// OnStart will miss events that occurred before registration.
+// RegisterObserver appends an observer. Observers registered after OnStart
+// will miss events that occurred before registration.
 func (h *healthPlatformImpl) RegisterObserver(obs healthplatformdef.IssueObserver) {
 	h.observersMu.Lock()
 	h.observers = append(h.observers, obs)
 	h.observersMu.Unlock()
 }
 
-// notifyReported fires OnIssueReported on all registered observers.
-// Must be called outside issuesMux; lean and si must remain valid for the call.
+// notifyReported fires OnIssueReported; must be called outside issuesMux.
 func (h *healthPlatformImpl) notifyReported(lean *healthplatform.Issue, si *storedIssue) {
 	h.observersMu.RLock()
 	obs := h.observers
@@ -359,7 +357,6 @@ func (h *healthPlatformImpl) notifyReported(lean *healthplatform.Issue, si *stor
 	}
 }
 
-// notifyResolved fires OnIssueResolved on all registered observers.
 func (h *healthPlatformImpl) notifyResolved(resolved *healthplatform.Issue) {
 	h.observersMu.RLock()
 	obs := h.observers
@@ -503,7 +500,6 @@ func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 }
 
 // ResolveAllIssues marks every active issue as resolved.
-// Fires OnResolveIssue for each so the egress forwards them as resolved.
 func (h *healthPlatformImpl) ResolveAllIssues() {
 	h.issuesMux.Lock()
 

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -328,10 +328,6 @@ func (h *healthPlatformImpl) stop(_ context.Context) error {
 	return nil
 }
 
-// ============================================================================
-// Observer Registration
-// ============================================================================
-
 // RegisterObserver appends an observer. Observers registered after OnStart
 // will miss events that occurred before registration.
 func (h *healthPlatformImpl) RegisterObserver(obs healthplatformdef.IssueObserver) {

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -80,6 +80,9 @@ type healthPlatformImpl struct {
 	persistedIssues map[string]*PersistedIssue // IssueID → lifecycle state
 	persistence     issuesPersistence
 
+	// Egress callbacks: registered before OnStart fires; called outside issuesMux.
+	egressCbs healthplatformdef.EgressCallbacks
+
 	// Metrics
 	metrics telemetryMetrics
 }
@@ -325,6 +328,16 @@ func (h *healthPlatformImpl) stop(_ context.Context) error {
 }
 
 // ============================================================================
+// Egress Callback Registration
+// ============================================================================
+
+// SetEgressCallbacks registers the callbacks the egress wants to receive on
+// state transitions. Must be called before the component's OnStart hook fires.
+func (h *healthPlatformImpl) SetEgressCallbacks(cbs healthplatformdef.EgressCallbacks) {
+	h.egressCbs = cbs
+}
+
+// ============================================================================
 // Core Public API
 // ============================================================================
 
@@ -415,19 +428,17 @@ func hydrateIssue(issue *healthplatform.Issue, stored *storedIssue) {
 // ============================================================================
 
 // ResolveIssue marks an issue as resolved and removes it from the active set.
+// It fires OnResolveIssue so the egress can forward the tombstone exactly once.
 func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 	h.issuesMux.Lock()
 
 	stateChanged := false
-	if stored, ok := h.issues[issueID]; ok {
+	var tombstone *healthplatform.Issue
+
+	if _, ok := h.issues[issueID]; ok {
 		h.log.Info("Cleared issue: " + issueID)
+		delete(h.issues, issueID)
 		stateChanged = true
-		if stored != nil && stored.issue != nil {
-			if stored.issue.PersistedIssue == nil {
-				stored.issue.PersistedIssue = &healthplatform.PersistedIssue{}
-			}
-			stored.issue.PersistedIssue.State = healthplatform.IssueState_ISSUE_STATE_RESOLVED
-		}
 	}
 
 	if persisted := h.persistedIssues[issueID]; persisted != nil {
@@ -438,18 +449,20 @@ func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 			stateChanged = true
 		}
 
-		if _, ok := h.issues[issueID]; !ok {
-			tombstone := &healthplatform.Issue{
-				Id:             issueID,
-				IssueName:      persisted.IssueType,
-				PersistedIssue: persistedIssueToProto(persisted),
-			}
-			h.issues[issueID] = &storedIssue{issue: tombstone}
-			stateChanged = true
+		// Build tombstone for the egress; issued regardless of whether the
+		// issue was in the active set (covers the post-restart re-resolve case).
+		tombstone = &healthplatform.Issue{
+			Id:             issueID,
+			IssueName:      persisted.IssueType,
+			PersistedIssue: persistedIssueToProto(persisted),
 		}
 	}
 
 	h.issuesMux.Unlock()
+
+	if tombstone != nil && h.egressCbs.OnResolveIssue != nil {
+		h.egressCbs.OnResolveIssue(tombstone)
+	}
 
 	if stateChanged {
 		if err := h.saveToDisk(); err != nil {
@@ -458,30 +471,23 @@ func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 	}
 }
 
-// PruneResolvedIssues removes RESOLVED tombstones from h.issues.
-// Called by the egress after a successful send so that resolved issues are
-// not re-forwarded on every subsequent tick.
-func (h *healthPlatformImpl) PruneResolvedIssues() {
-	h.issuesMux.Lock()
-	defer h.issuesMux.Unlock()
-	for id, stored := range h.issues {
-		if stored != nil && stored.issue != nil &&
-			stored.issue.PersistedIssue != nil &&
-			stored.issue.PersistedIssue.State == IssueStateResolved {
-			delete(h.issues, id)
-		}
-	}
-}
-
-// ResolveAllIssues clears all active issues.
+// ResolveAllIssues marks every active issue as resolved.
+// Fires OnResolveIssue for each so the egress forwards them as tombstones.
 func (h *healthPlatformImpl) ResolveAllIssues() {
 	h.issuesMux.Lock()
 
 	now := time.Now().Format(time.RFC3339)
+	var tombstones []*healthplatform.Issue
+
 	for _, persisted := range h.persistedIssues {
 		if persisted != nil && persisted.State != IssueStateResolved {
 			persisted.State = IssueStateResolved
 			persisted.ResolvedAt = now
+			tombstones = append(tombstones, &healthplatform.Issue{
+				Id:             persisted.IssueID,
+				IssueName:      persisted.IssueType,
+				PersistedIssue: persistedIssueToProto(persisted),
+			})
 		}
 	}
 
@@ -490,6 +496,12 @@ func (h *healthPlatformImpl) ResolveAllIssues() {
 	h.log.Info("Cleared all issues")
 
 	h.issuesMux.Unlock()
+
+	if h.egressCbs.OnResolveIssue != nil {
+		for _, t := range tombstones {
+			h.egressCbs.OnResolveIssue(t)
+		}
+	}
 
 	if err := h.saveToDisk(); err != nil {
 		h.log.Warn("Failed to persist issues to disk: " + err.Error())
@@ -601,6 +613,13 @@ func (h *healthPlatformImpl) storeIssue(issueType string, issue *healthplatform.
 
 	h.issuesMux.Unlock()
 
+	if h.egressCbs.OnReportIssue != nil {
+		// Rehydrate Extra/Remediation for the egress copy outside the lock.
+		hydrated := proto.Clone(lean).(*healthplatform.Issue)
+		hydrateIssue(hydrated, si)
+		h.egressCbs.OnReportIssue(hydrated)
+	}
+
 	if err := h.saveToDisk(); err != nil {
 		h.log.Warn("Failed to persist issues to disk: " + err.Error())
 	}
@@ -632,9 +651,10 @@ func (h *healthPlatformImpl) loadFromDisk() error {
 	pruneOldResolvedIssues(state.Issues)
 
 	h.issuesMux.Lock()
-	defer h.issuesMux.Unlock()
 
 	activeCount := 0
+	var resolvedTombstones []*healthplatform.Issue
+
 	for issueID, persisted := range state.Issues {
 		if persisted == nil {
 			continue
@@ -642,16 +662,34 @@ func (h *healthPlatformImpl) loadFromDisk() error {
 		persisted.IssueID = issueID
 		h.persistedIssues[issueID] = persisted
 
-		if persisted.State == IssueStateResolved || persisted.IssueType == "" {
+		if persisted.IssueType == "" {
 			continue
 		}
 
-		nameKey := persisted.IssueType
-		h.issuesByName[nameKey] = append(h.issuesByName[nameKey], issueID)
+		if persisted.State == IssueStateResolved {
+			resolvedTombstones = append(resolvedTombstones, &healthplatform.Issue{
+				Id:             issueID,
+				IssueName:      persisted.IssueType,
+				PersistedIssue: persistedIssueToProto(persisted),
+			})
+			continue
+		}
+
+		h.issuesByName[persisted.IssueType] = append(h.issuesByName[persisted.IssueType], issueID)
 		activeCount++
 	}
 
-	h.log.Info(fmt.Sprintf("Loaded %d persisted issues (%d active)", len(state.Issues), activeCount))
+	h.issuesMux.Unlock()
+
+	h.log.Info(fmt.Sprintf("Loaded %d persisted issues (%d active, %d resolved pending send)",
+		len(state.Issues), activeCount, len(resolvedTombstones)))
+
+	if h.egressCbs.OnResolveIssue != nil {
+		for _, t := range resolvedTombstones {
+			h.egressCbs.OnResolveIssue(t)
+		}
+	}
+
 	return nil
 }
 

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -336,7 +336,8 @@ func (h *healthPlatformImpl) RegisterObserver(obs healthplatformdef.IssueObserve
 	h.observersMu.Unlock()
 }
 
-// notifyReported fires OnIssueReported; must be called outside issuesMux.
+// notifyReported writes a hydrated clone to each observer's ActiveCh.
+// Must be called outside issuesMux.
 func (h *healthPlatformImpl) notifyReported(lean *healthplatform.Issue, si *storedIssue) {
 	h.observersMu.RLock()
 	obs := h.observers
@@ -347,8 +348,12 @@ func (h *healthPlatformImpl) notifyReported(lean *healthplatform.Issue, si *stor
 	hydrated := proto.Clone(lean).(*healthplatform.Issue)
 	hydrateIssue(hydrated, si)
 	for _, o := range obs {
-		if o.OnIssueReported != nil {
-			o.OnIssueReported(hydrated)
+		if o.ActiveCh != nil {
+			select {
+			case o.ActiveCh <- hydrated:
+			default:
+				h.log.Warnf("health platform: active channel full, %s will resend on next check run", lean.Id)
+			}
 		}
 	}
 }
@@ -358,8 +363,12 @@ func (h *healthPlatformImpl) notifyResolved(resolved *healthplatform.Issue) {
 	obs := h.observers
 	h.observersMu.RUnlock()
 	for _, o := range obs {
-		if o.OnIssueResolved != nil {
-			o.OnIssueResolved(resolved)
+		if o.ResolvedCh != nil {
+			select {
+			case o.ResolvedCh <- resolved:
+			default:
+				h.log.Warnf("health platform: resolved channel full, %s recoverable from disk", resolved.Id)
+			}
 		}
 	}
 }

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -80,9 +80,9 @@ type healthPlatformImpl struct {
 	persistedIssues map[string]*PersistedIssue // IssueID → lifecycle state
 	persistence     issuesPersistence
 
-	// Issue observers: notified on every state transition outside issuesMux.
-	observersMu sync.RWMutex
-	observers   []healthplatformdef.IssueObserver
+	// Egress aggregators: receive issue events outside issuesMux.
+	aggregatorsMu sync.RWMutex
+	aggregators   []healthplatformdef.EgressAggregator
 
 	// Metrics
 	metrics telemetryMetrics
@@ -328,26 +328,26 @@ func (h *healthPlatformImpl) stop(_ context.Context) error {
 	return nil
 }
 
-// RegisterObserver appends an observer. Observers registered after OnStart
-// will miss events that occurred before registration.
-func (h *healthPlatformImpl) RegisterObserver(obs healthplatformdef.IssueObserver) {
-	h.observersMu.Lock()
-	h.observers = append(h.observers, obs)
-	h.observersMu.Unlock()
+// RegisterEgressAggregator appends an aggregator. Aggregators registered after
+// OnStart will miss events that occurred before registration.
+func (h *healthPlatformImpl) RegisterEgressAggregator(agg healthplatformdef.EgressAggregator) {
+	h.aggregatorsMu.Lock()
+	h.aggregators = append(h.aggregators, agg)
+	h.aggregatorsMu.Unlock()
 }
 
 // notifyReported writes a hydrated clone to each observer's ActiveCh.
 // Must be called outside issuesMux.
 func (h *healthPlatformImpl) notifyReported(lean *healthplatform.Issue, si *storedIssue) {
-	h.observersMu.RLock()
-	obs := h.observers
-	h.observersMu.RUnlock()
-	if len(obs) == 0 {
+	h.aggregatorsMu.RLock()
+	agg := h.aggregators
+	h.aggregatorsMu.RUnlock()
+	if len(agg) == 0 {
 		return
 	}
 	hydrated := proto.Clone(lean).(*healthplatform.Issue)
 	hydrateIssue(hydrated, si)
-	for _, o := range obs {
+	for _, o := range agg {
 		if o.ActiveCh != nil {
 			select {
 			case o.ActiveCh <- hydrated:
@@ -359,10 +359,10 @@ func (h *healthPlatformImpl) notifyReported(lean *healthplatform.Issue, si *stor
 }
 
 func (h *healthPlatformImpl) notifyResolved(resolved *healthplatform.Issue) {
-	h.observersMu.RLock()
-	obs := h.observers
-	h.observersMu.RUnlock()
-	for _, o := range obs {
+	h.aggregatorsMu.RLock()
+	agg := h.aggregators
+	h.aggregatorsMu.RUnlock()
+	for _, o := range agg {
 		if o.ResolvedCh != nil {
 			select {
 			case o.ResolvedCh <- resolved:

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -336,8 +336,38 @@ func (h *healthPlatformImpl) RegisterEgressAggregator(agg healthplatformdef.Egre
 	h.aggregatorsMu.Unlock()
 }
 
-// notifyReported writes a hydrated clone to each observer's ActiveCh.
+// removeFromCh drains up to len(ch) items from ch, discards entries whose ID
+// matches excludeID, and returns the rest. Bounded by len(ch) so concurrent
+// writers that arrive after the call starts are not affected.
+func removeFromCh(ch chan *healthplatform.Issue, excludeID string) {
+	n := len(ch)
+	if n == 0 {
+		return
+	}
+	var keep []*healthplatform.Issue
+drain:
+	for range n {
+		select {
+		case item := <-ch:
+			if item.Id != excludeID {
+				keep = append(keep, item)
+			}
+		default:
+			break drain
+		}
+	}
+	for _, item := range keep {
+		select {
+		case ch <- item:
+		default:
+		}
+	}
+}
+
+// notifyReported writes a hydrated clone to each aggregator's ActiveCh.
 // Must be called outside issuesMux.
+// Cancels any stale tombstone in ResolvedCh for the same ID first, so a
+// re-report after resolve does not lose to an older RESOLVED entry.
 func (h *healthPlatformImpl) notifyReported(lean *healthplatform.Issue, si *storedIssue) {
 	h.aggregatorsMu.RLock()
 	agg := h.aggregators
@@ -349,6 +379,7 @@ func (h *healthPlatformImpl) notifyReported(lean *healthplatform.Issue, si *stor
 	hydrateIssue(hydrated, si)
 	for _, o := range agg {
 		if o.ActiveCh != nil {
+			removeFromCh(o.ResolvedCh, lean.Id)
 			select {
 			case o.ActiveCh <- hydrated:
 			default:
@@ -358,12 +389,16 @@ func (h *healthPlatformImpl) notifyReported(lean *healthplatform.Issue, si *stor
 	}
 }
 
+// notifyResolved writes a resolved snapshot to each aggregator's ResolvedCh.
+// Cancels any stale active entry in ActiveCh for the same ID first, so a
+// resolve does not race with a lingering ONGOING entry.
 func (h *healthPlatformImpl) notifyResolved(resolved *healthplatform.Issue) {
 	h.aggregatorsMu.RLock()
 	agg := h.aggregators
 	h.aggregatorsMu.RUnlock()
 	for _, o := range agg {
 		if o.ResolvedCh != nil {
+			removeFromCh(o.ActiveCh, resolved.Id)
 			select {
 			case o.ResolvedCh <- resolved:
 			default:

--- a/comp/healthplatform/store/impl/store_test.go
+++ b/comp/healthplatform/store/impl/store_test.go
@@ -26,6 +26,7 @@ import (
 	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	telemetrymock "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
+	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 )
 
 // memPersistence stores state in memory, replacing disk I/O in unit tests.
@@ -203,13 +204,20 @@ func TestResolveIssueRemovesFromActive(t *testing.T) {
 	h := newTestStore(t)
 	require.NoError(t, h.ReportIssue(&healthplatformpayload.Issue{Id: "t:id", IssueName: "t"}))
 
-	// ResolveIssue keeps the issue active with RESOLVED state so the egress keeps
-	// forwarding it. Cleanup happens on the next restart via loadFromDisk.
+	var cbTombstone *healthplatformpayload.Issue
+	h.SetEgressCallbacks(healthplatformdef.EgressCallbacks{
+		OnResolveIssue: func(tombstone *healthplatformpayload.Issue) {
+			cbTombstone = tombstone
+		},
+	})
+
 	h.ResolveIssue("t:id")
-	issue := h.GetIssue("t:id")
-	require.NotNil(t, issue, "issue must stay in active set after ResolveIssue")
-	require.NotNil(t, issue.PersistedIssue)
-	assert.Equal(t, IssueStateResolved, issue.PersistedIssue.State)
+
+	// Issue must be removed from the active set; the egress gets a tombstone via callback.
+	assert.Nil(t, h.GetIssue("t:id"), "issue must be removed from active set after ResolveIssue")
+	require.NotNil(t, cbTombstone, "OnResolveIssue callback must be called")
+	require.NotNil(t, cbTombstone.PersistedIssue)
+	assert.Equal(t, IssueStateResolved, cbTombstone.PersistedIssue.State)
 
 	require.NotNil(t, h.persistedIssues["t:id"])
 	assert.Equal(t, IssueStateResolved, h.persistedIssues["t:id"].State)

--- a/comp/healthplatform/store/impl/store_test.go
+++ b/comp/healthplatform/store/impl/store_test.go
@@ -26,7 +26,7 @@ import (
 	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	telemetrymock "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
-	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 )
 
 // memPersistence stores state in memory, replacing disk I/O in unit tests.
@@ -204,20 +204,18 @@ func TestResolveIssueRemovesFromActive(t *testing.T) {
 	h := newTestStore(t)
 	require.NoError(t, h.ReportIssue(&healthplatformpayload.Issue{Id: "t:id", IssueName: "t"}))
 
-	var cbTombstone *healthplatformpayload.Issue
-	h.SetEgressCallbacks(healthplatformdef.EgressCallbacks{
-		OnResolveIssue: func(tombstone *healthplatformpayload.Issue) {
-			cbTombstone = tombstone
-		},
+	var gotResolved *healthplatformpayload.Issue
+	h.RegisterObserver(storedef.IssueObserver{
+		OnIssueResolved: func(resolved *healthplatformpayload.Issue) { gotResolved = resolved },
 	})
 
 	h.ResolveIssue("t:id")
 
-	// Issue must be removed from the active set; the egress gets a tombstone via callback.
+	// Issue must be removed from the active set; observer receives the resolved issue.
 	assert.Nil(t, h.GetIssue("t:id"), "issue must be removed from active set after ResolveIssue")
-	require.NotNil(t, cbTombstone, "OnResolveIssue callback must be called")
-	require.NotNil(t, cbTombstone.PersistedIssue)
-	assert.Equal(t, IssueStateResolved, cbTombstone.PersistedIssue.State)
+	require.NotNil(t, gotResolved, "OnIssueResolved must be called")
+	require.NotNil(t, gotResolved.PersistedIssue)
+	assert.Equal(t, IssueStateResolved, gotResolved.PersistedIssue.State)
 
 	require.NotNil(t, h.persistedIssues["t:id"])
 	assert.Equal(t, IssueStateResolved, h.persistedIssues["t:id"].State)

--- a/comp/healthplatform/store/impl/store_test.go
+++ b/comp/healthplatform/store/impl/store_test.go
@@ -437,3 +437,114 @@ func TestGetActiveIssueIDsByIssueName(t *testing.T) {
 	ids = h.GetActiveIssueIDsByIssueName("t")
 	assert.ElementsMatch(t, []string{"t:2"}, ids)
 }
+
+// ============================================================================
+// EgressAggregator channel integration tests
+//
+// These tests cover the state-transition cases where both ActiveCh and
+// ResolvedCh can hold an entry for the same issue ID, and verify that
+// notifyReported/notifyResolved cancel the stale cross-channel entry.
+// ============================================================================
+
+func newTestAggregator(activeSz, resolvedSz int) storedef.EgressAggregator {
+	return storedef.EgressAggregator{
+		ActiveCh:   make(chan *healthplatformpayload.Issue, activeSz),
+		ResolvedCh: make(chan *healthplatformpayload.Issue, resolvedSz),
+	}
+}
+
+// TestEgressAggregatorNewIssue: first report → activeCh receives NEW.
+func TestEgressAggregatorNewIssue(t *testing.T) {
+	h := newTestStore(t)
+	agg := newTestAggregator(4, 4)
+	h.RegisterEgressAggregator(agg)
+
+	require.NoError(t, h.ReportIssue(&healthplatformpayload.Issue{Id: "i:1", IssueName: "t"}))
+
+	require.Len(t, agg.ActiveCh, 1)
+	assert.Empty(t, agg.ResolvedCh)
+	got := <-agg.ActiveCh
+	assert.Equal(t, IssueStateNew, got.PersistedIssue.GetState())
+}
+
+// TestEgressAggregatorOngoingIssue: second report → activeCh receives ONGOING.
+func TestEgressAggregatorOngoingIssue(t *testing.T) {
+	h := newTestStore(t)
+	agg := newTestAggregator(4, 4)
+	h.RegisterEgressAggregator(agg)
+
+	issue := &healthplatformpayload.Issue{Id: "i:1", IssueName: "t"}
+	require.NoError(t, h.ReportIssue(issue))
+	require.NoError(t, h.ReportIssue(issue))
+
+	// Drain both entries; the second one must be ONGOING.
+	assert.Len(t, agg.ActiveCh, 2)
+	<-agg.ActiveCh
+	got := <-agg.ActiveCh
+	assert.Equal(t, IssueStateOngoing, got.PersistedIssue.GetState())
+}
+
+// TestEgressAggregatorResolveAfterActive: resolve while an unread active entry
+// sits in ActiveCh → stale entry cancelled, ResolvedCh gets the tombstone.
+func TestEgressAggregatorResolveAfterActive(t *testing.T) {
+	h := newTestStore(t)
+	agg := newTestAggregator(4, 4)
+	h.RegisterEgressAggregator(agg)
+
+	require.NoError(t, h.ReportIssue(&healthplatformpayload.Issue{Id: "i:1", IssueName: "t"}))
+	require.Len(t, agg.ActiveCh, 1)
+
+	h.ResolveIssue("i:1")
+
+	// notifyResolved must have cancelled the stale active entry.
+	assert.Empty(t, agg.ActiveCh, "stale active entry must be removed when issue is resolved")
+	require.Len(t, agg.ResolvedCh, 1)
+	got := <-agg.ResolvedCh
+	assert.Equal(t, IssueStateResolved, got.PersistedIssue.GetState())
+}
+
+// TestEgressAggregatorReReportCancelsResolved: resolve (tombstone queued),
+// then re-report before the egress ticks → tombstone cancelled, ActiveCh
+// gets NEW so the issue is not incorrectly forwarded as RESOLVED.
+func TestEgressAggregatorReReportCancelsResolved(t *testing.T) {
+	h := newTestStore(t)
+	agg := newTestAggregator(4, 4)
+	h.RegisterEgressAggregator(agg)
+
+	issue := &healthplatformpayload.Issue{Id: "i:1", IssueName: "t"}
+	require.NoError(t, h.ReportIssue(issue))
+	<-agg.ActiveCh // simulate egress draining activeCh
+
+	h.ResolveIssue("i:1")
+	require.Len(t, agg.ResolvedCh, 1, "tombstone must be queued after resolve")
+
+	// Re-report before the egress ticks.
+	require.NoError(t, h.ReportIssue(issue))
+
+	// notifyReported must have cancelled the tombstone.
+	assert.Empty(t, agg.ResolvedCh, "stale tombstone must be removed on re-report")
+	require.Len(t, agg.ActiveCh, 1)
+	got := <-agg.ActiveCh
+	assert.Equal(t, IssueStateNew, got.PersistedIssue.GetState())
+}
+
+// TestEgressAggregatorResolveAfterOngoing: ongoing report queued in ActiveCh,
+// then resolved → stale ongoing entry cancelled, ResolvedCh gets tombstone.
+func TestEgressAggregatorResolveAfterOngoing(t *testing.T) {
+	h := newTestStore(t)
+	agg := newTestAggregator(4, 4)
+	h.RegisterEgressAggregator(agg)
+
+	issue := &healthplatformpayload.Issue{Id: "i:1", IssueName: "t"}
+	require.NoError(t, h.ReportIssue(issue))
+	require.NoError(t, h.ReportIssue(issue)) // ONGOING in activeCh
+	<-agg.ActiveCh                           // drain NEW, leave ONGOING unread
+	require.Len(t, agg.ActiveCh, 1)
+
+	h.ResolveIssue("i:1")
+
+	assert.Empty(t, agg.ActiveCh, "stale ongoing entry must be cancelled on resolve")
+	require.Len(t, agg.ResolvedCh, 1)
+	got := <-agg.ResolvedCh
+	assert.Equal(t, IssueStateResolved, got.PersistedIssue.GetState())
+}

--- a/comp/healthplatform/store/impl/store_test.go
+++ b/comp/healthplatform/store/impl/store_test.go
@@ -204,18 +204,17 @@ func TestResolveIssueRemovesFromActive(t *testing.T) {
 	h := newTestStore(t)
 	require.NoError(t, h.ReportIssue(&healthplatformpayload.Issue{Id: "t:id", IssueName: "t"}))
 
-	var gotResolved *healthplatformpayload.Issue
-	h.RegisterObserver(storedef.IssueObserver{
-		OnIssueResolved: func(resolved *healthplatformpayload.Issue) { gotResolved = resolved },
-	})
+	ch := make(chan *healthplatformpayload.Issue, 1)
+	h.RegisterObserver(storedef.IssueObserver{ResolvedCh: ch})
 
 	h.ResolveIssue("t:id")
 
-	// Issue must be removed from the active set; observer receives the resolved issue.
+	// Issue must be removed from the active set; resolved snapshot written to ResolvedCh.
 	assert.Nil(t, h.GetIssue("t:id"), "issue must be removed from active set after ResolveIssue")
-	require.NotNil(t, gotResolved, "OnIssueResolved must be called")
-	require.NotNil(t, gotResolved.PersistedIssue)
-	assert.Equal(t, IssueStateResolved, gotResolved.PersistedIssue.State)
+	require.Len(t, ch, 1, "resolved issue must be written to ResolvedCh")
+	got := <-ch
+	require.NotNil(t, got.PersistedIssue)
+	assert.Equal(t, IssueStateResolved, got.PersistedIssue.State)
 
 	require.NotNil(t, h.persistedIssues["t:id"])
 	assert.Equal(t, IssueStateResolved, h.persistedIssues["t:id"].State)

--- a/comp/healthplatform/store/impl/store_test.go
+++ b/comp/healthplatform/store/impl/store_test.go
@@ -205,7 +205,7 @@ func TestResolveIssueRemovesFromActive(t *testing.T) {
 	require.NoError(t, h.ReportIssue(&healthplatformpayload.Issue{Id: "t:id", IssueName: "t"}))
 
 	ch := make(chan *healthplatformpayload.Issue, 1)
-	h.RegisterObserver(storedef.IssueObserver{ResolvedCh: ch})
+	h.RegisterEgressAggregator(storedef.EgressAggregator{ResolvedCh: ch})
 
 	h.ResolveIssue("t:id")
 

--- a/comp/healthplatform/store/mock/mock.go
+++ b/comp/healthplatform/store/mock/mock.go
@@ -59,6 +59,10 @@ func (m *mockHealthPlatform) GetIssue(checkID string) *healthplatformpayload.Iss
 	return proto.Clone(issue).(*healthplatformpayload.Issue)
 }
 
+// SetEgressCallbacks is a no-op in the mock.
+func (m *mockHealthPlatform) SetEgressCallbacks(_ healthplatform.EgressCallbacks) {
+}
+
 // ResolveIssue clears issues for a specific check
 func (m *mockHealthPlatform) ResolveIssue(checkID string) {
 	delete(m.issues, checkID)
@@ -72,14 +76,4 @@ func (m *mockHealthPlatform) ResolveAllIssues() {
 // GetActiveIssueIDsByIssueName returns nil in the mock.
 func (m *mockHealthPlatform) GetActiveIssueIDsByIssueName(_ string) []string {
 	return nil
-}
-
-// PruneResolvedIssues removes resolved issues from the mock store.
-func (m *mockHealthPlatform) PruneResolvedIssues() {
-	for id, issue := range m.issues {
-		if issue != nil && issue.PersistedIssue != nil &&
-			issue.PersistedIssue.State == healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED {
-			delete(m.issues, id)
-		}
-	}
 }

--- a/comp/healthplatform/store/mock/mock.go
+++ b/comp/healthplatform/store/mock/mock.go
@@ -59,8 +59,8 @@ func (m *mockHealthPlatform) GetIssue(checkID string) *healthplatformpayload.Iss
 	return proto.Clone(issue).(*healthplatformpayload.Issue)
 }
 
-// RegisterObserver is a no-op in the mock.
-func (m *mockHealthPlatform) RegisterObserver(_ healthplatform.IssueObserver) {}
+// RegisterEgressAggregator is a no-op in the mock.
+func (m *mockHealthPlatform) RegisterEgressAggregator(_ healthplatform.EgressAggregator) {}
 
 // ResolveIssue clears issues for a specific check
 func (m *mockHealthPlatform) ResolveIssue(checkID string) {

--- a/comp/healthplatform/store/mock/mock.go
+++ b/comp/healthplatform/store/mock/mock.go
@@ -59,9 +59,8 @@ func (m *mockHealthPlatform) GetIssue(checkID string) *healthplatformpayload.Iss
 	return proto.Clone(issue).(*healthplatformpayload.Issue)
 }
 
-// SetEgressCallbacks is a no-op in the mock.
-func (m *mockHealthPlatform) SetEgressCallbacks(_ healthplatform.EgressCallbacks) {
-}
+// RegisterObserver is a no-op in the mock.
+func (m *mockHealthPlatform) RegisterObserver(_ healthplatform.IssueObserver) {}
 
 // ResolveIssue clears issues for a specific check
 func (m *mockHealthPlatform) ResolveIssue(checkID string) {

--- a/comp/healthplatform/store/noop-impl/noop.go
+++ b/comp/healthplatform/store/noop-impl/noop.go
@@ -35,8 +35,8 @@ func NewNoopHealthPlatform() *NoopHealthPlatform {
 	return &NoopHealthPlatform{}
 }
 
-// RegisterObserver does nothing when the health platform is disabled.
-func (n *NoopHealthPlatform) RegisterObserver(_ healthplatform.IssueObserver) {}
+// RegisterEgressAggregator does nothing when the health platform is disabled.
+func (n *NoopHealthPlatform) RegisterEgressAggregator(_ healthplatform.EgressAggregator) {}
 
 // ReportIssue does nothing when the health platform is disabled.
 func (n *NoopHealthPlatform) ReportIssue(_ *healthplatformpayload.Issue) error {

--- a/comp/healthplatform/store/noop-impl/noop.go
+++ b/comp/healthplatform/store/noop-impl/noop.go
@@ -50,16 +50,16 @@ func (n *NoopHealthPlatform) GetIssue(_ string) *healthplatformpayload.Issue {
 	return nil
 }
 
+// SetEgressCallbacks does nothing when the health platform is disabled.
+func (n *NoopHealthPlatform) SetEgressCallbacks(_ healthplatform.EgressCallbacks) {
+}
+
 // ResolveIssue does nothing when the health platform is disabled.
 func (n *NoopHealthPlatform) ResolveIssue(_ string) {
 }
 
 // ResolveAllIssues does nothing when the health platform is disabled.
 func (n *NoopHealthPlatform) ResolveAllIssues() {
-}
-
-// PruneResolvedIssues does nothing when the health platform is disabled.
-func (n *NoopHealthPlatform) PruneResolvedIssues() {
 }
 
 // GetActiveIssueIDsByIssueName returns nil when the health platform is disabled.

--- a/comp/healthplatform/store/noop-impl/noop.go
+++ b/comp/healthplatform/store/noop-impl/noop.go
@@ -35,6 +35,9 @@ func NewNoopHealthPlatform() *NoopHealthPlatform {
 	return &NoopHealthPlatform{}
 }
 
+// RegisterObserver does nothing when the health platform is disabled.
+func (n *NoopHealthPlatform) RegisterObserver(_ healthplatform.IssueObserver) {}
+
 // ReportIssue does nothing when the health platform is disabled.
 func (n *NoopHealthPlatform) ReportIssue(_ *healthplatformpayload.Issue) error {
 	return nil
@@ -48,10 +51,6 @@ func (n *NoopHealthPlatform) GetAllIssues() (int, map[string]*healthplatformpayl
 // GetIssue returns nil when the health platform is disabled.
 func (n *NoopHealthPlatform) GetIssue(_ string) *healthplatformpayload.Issue {
 	return nil
-}
-
-// SetEgressCallbacks does nothing when the health platform is disabled.
-func (n *NoopHealthPlatform) SetEgressCallbacks(_ healthplatform.EgressCallbacks) {
 }
 
 // ResolveIssue does nothing when the health platform is disabled.


### PR DESCRIPTION
### What does this PR do?

Removes `PruneResolvedIssues` from the store interface and introduces `RegisterObserver(IssueObserver)` as the store's single extension point for consumers.

`IssueObserver` has two callbacks:
- `OnIssueReported(issue)` — fired after any issue is stored (NEW or ONGOING), full proto with all fields
- `OnIssueResolved(resolved)` — fired when an issue resolves, contains ID/name/state. Also fired by `loadFromDisk` for resolved issues recovered from disk

The egress registers as an observer and writes resolved issues into its own `resolvedCh` channel, which it drains on each tick. On send failure items are returned to the channel and retried. The store's `issues` map now only contains active issues; the egress has no state of its own.

`IssueObserver` is also designed as the hook for a future MCP integration where an AI agent can subscribe to `OnIssueReported` and proactively act on issues.

### Motivation

Follow-up to #52168. Staff reviewer suggested the state logic belong in the store via callbacks.

### Describe how you validated your changes

Existing tests pass. New tests cover: `OnIssueResolved` fires on `ResolveIssue`, resolved issues forwarded once and consumed from channel, returned to channel on send failure.

### Additional Notes

Builds on `louis-cqrl/healthplatform-persistence-resolved-forwarding`.