### PR TITLE
[CONTP-1744] chore(ddi): Use XOR for config hashing in AD instrumentation handler

### DIFF
--- a/pkg/clusteragent/instrumentation/handlers/BUILD.bazel
+++ b/pkg/clusteragent/instrumentation/handlers/BUILD.bazel
@@ -38,5 +38,6 @@ go_test(
         "@io_k8s_api//autoscaling/v2:autoscaling",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_apimachinery//pkg/types",
     ],
 )

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -18,6 +18,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
@@ -563,4 +564,59 @@ func TestBuildCELSelector(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCheckStoreIncrementalHash verifies the incremental configHash maintained by
+// writeConfigs/deleteConfigs.
+func TestCheckStoreIncrementalHash(t *testing.T) {
+	cfg := []integration.Config{{Name: "check"}}
+	write := func(cs *CheckStore, key, uid string, gen int64) {
+		cr := newCR(key, "ns", "Deployment", "app", nil)
+		cr.UID = types.UID(uid)
+		cr.Generation = gen
+		cs.writeConfigs(key, cr, cfg)
+	}
+
+	t.Run("empty store hashes to zero", func(t *testing.T) {
+		require.Equal(t, uint64(0), NewCheckStore().Hash())
+	})
+
+	t.Run("add then delete restores empty hash", func(t *testing.T) {
+		cs := NewCheckStore()
+		write(cs, "a", "uid-a", 1)
+		require.NotEqual(t, uint64(0), cs.Hash())
+		cs.deleteConfigs("a")
+		require.Equal(t, uint64(0), cs.Hash())
+	})
+
+	t.Run("update changes hash and revert restores it", func(t *testing.T) {
+		cs := NewCheckStore()
+		write(cs, "a", "uid-a", 1)
+		write(cs, "b", "uid-b", 1)
+		full := cs.Hash()
+		write(cs, "b", "uid-b", 2) // generation bump
+		require.NotEqual(t, full, cs.Hash())
+		write(cs, "b", "uid-b", 1) // revert
+		require.Equal(t, full, cs.Hash())
+	})
+
+	t.Run("hash is independent of apply order", func(t *testing.T) {
+		cs := NewCheckStore()
+		write(cs, "a", "uid-a", 1)
+		write(cs, "b", "uid-b", 1)
+
+		other := NewCheckStore()
+		write(other, "b", "uid-b", 1)
+		write(other, "a", "uid-a", 1)
+
+		require.Equal(t, cs.Hash(), other.Hash())
+	})
+
+	t.Run("hash is different when same cr has new uid", func(t *testing.T) {
+		cs := NewCheckStore()
+		write(cs, "a", "uid-a", 1)
+		prevHash := cs.Hash()
+		write(cs, "a", "uid-b", 1)
+		require.NotEqual(t, prevHash, cs.Hash())
+	})
 }

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_utils.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_utils.go
@@ -10,7 +10,6 @@ package handlers
 import (
 	"fmt"
 	"hash/fnv"
-	"sort"
 	"sync"
 
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
@@ -142,9 +141,10 @@ type CheckStore struct {
 // NewCheckStore creates a new CheckStore.
 func NewCheckStore() *CheckStore {
 	return &CheckStore{
-		configs:    make(map[string][]integration.Config),
-		states:     make(map[string]string),
-		configHash: fnv.New64a().Sum64(),
+		configs: make(map[string][]integration.Config),
+		states:  make(map[string]string),
+		// configHash is the XOR of all per-entry hashes; the empty set hashes to 0.
+		configHash: 0,
 	}
 }
 
@@ -171,38 +171,42 @@ func (c *CheckStore) Hash() uint64 {
 func (c *CheckStore) writeConfigs(key string, cr *datadoghq.DatadogInstrumentation, configs []integration.Config) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// Remove the previous entry's contribution before applying the change, then add the
+	// new one.
+	if old, ok := c.states[key]; ok {
+		c.configHash ^= entryHash(key, old)
+	}
 	if len(configs) == 0 {
 		delete(c.configs, key)
 		delete(c.states, key)
 	} else {
 		c.configs[key] = configs
-		c.states[key] = fmt.Sprintf("%s:%d", cr.UID, cr.Generation)
+		state := fmt.Sprintf("%s:%d", cr.UID, cr.Generation)
+		c.states[key] = state
+		c.configHash ^= entryHash(key, state)
 	}
-	c.configHash = c.hashStates()
 }
 
 func (c *CheckStore) deleteConfigs(key string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if old, ok := c.states[key]; ok {
+		c.configHash ^= entryHash(key, old)
+	}
 	delete(c.configs, key)
 	delete(c.states, key)
-	c.configHash = c.hashStates()
 }
 
-// hashStates computes a deterministic hash from the sorted set of
-// "key:uid:generation" entries in the store. Including the UID ensures that a
-// recreation of a CR with the same namespace/name is detected even when
-// the new CR starts at generation 1.
-func (c *CheckStore) hashStates() uint64 {
-	keys := make([]string, 0, len(c.states))
-	for k := range c.states {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+// entryHash returns the hash contribution of a single "key/state" entry. writeConfigs and
+// deleteConfigs maintain CheckStore.configHash by XOR-combining these per-entry hashes; XOR is
+// commutative, so the result is independent of the order entries are applied and identical across
+// cluster agent replicas with the same CR state.
+func entryHash(key, state string) uint64 {
 	h := fnv.New64a()
-	for _, k := range keys {
-		fmt.Fprintf(h, "%s:%s\n", k, c.states[k]) //nolint:errcheck
-	}
+	_, _ = h.Write([]byte(key))
+	// The 0 separator keeps ("ab", "c") distinct from ("a", "bc").
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(state))
 	return h.Sum64()
 }
 


### PR DESCRIPTION
### What does this PR do?

Replaces the config-state hashing in the AD instrumentation handler `CheckStore` with an incremental XOR computation instead of a full re-hashing. Going from an O(N) memory allocation & iteration, with N being the number of check CRs down to O(1) XOR.

### Motivation

While performance testing DDI controller with up to 4000 CRs, we saw high volumes of memory allocation because each CR reconciliation requires a complete rehash of the store's state. While it's not expected for hundreds or thousands of CRs to reconcile at once, there's still room for optimization with the use of XOR hashing. 

### Describe how you validated your changes

 Deployed the cluster agent on a local kind cluster with 4000 fake CRs, capturing the heap profile before and after the change.

Metric (alloc_space) | Before | After
-- | -- | --
CheckStore.hashStates | 364 MB (~47% of all DCA allocations) | N/A
instrumentation.(*Controller) subtree | 410 MB (~52%) | 48 MB (~7%)
Largest allocator in the cluster agent | hashStates | generic client-go watch/JSON decode
Controller live heap (inuse_space) | ~13 MB | ~14 MB (unchanged)

### Additional Notes
