### PR TITLE
ci: add self.gitlab.compare-to octo-sts policy

### DIFF
--- a/.github/chainguard/self.gitlab.compare-to.sts.yaml
+++ b/.github/chainguard/self.gitlab.compare-to.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/datadog-agent:ref_type:branch:ref:.*"
+
+claim_pattern:
+  project_path: "DataDog/datadog-agent"
+  project_id: "4670"
+  ref_type: "branch"
+  ref: ".+"
+
+permissions:
+  contents: write
+  workflows: write


### PR DESCRIPTION
### What does this PR do?
Add `.github/chainguard/self.gitlab.compare-to.sts.yaml`, a dedicated octo-sts policy granting `contents: write` and `workflows: write`, restricted to branch pipelines (`ref_type: "branch"`).

### Motivation
Prerequisite for #52265: `dd-octo-sts` reads policies from `main`, so the policy must land here before the job wiring in #52265 can be tested in CI.