### PR TITLE
Fix runtime SBOM enrichment dropped for kubelet-reported images

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -178,13 +178,17 @@ func workloadmetaEventFromSBOMEventSet(store workloadmeta.Component, event *sbom
 		return workloadmeta.Event{}, fmt.Errorf("failed to compress SBOM for image %s: %w", imageID, err)
 	}
 
-	// Return event to update the ContainerImageMetadata entity
+	// Emit the enriched SBOM under the resolved image's own EntityID, so it lands
+	// on the same ContainerImageMetadata the runtime collector populates and
+	// workloadmeta merges the two sources. existingImage is looked up by
+	// container.Image.ID, or by matching RepoDigest when the kubelet reports that
+	// ID as a manifest/repo digest, so its ID can differ from imageID.
 	return workloadmeta.Event{
 		Type: workloadmeta.EventTypeSet,
 		Entity: &workloadmeta.ContainerImageMetadata{
 			EntityID: workloadmeta.EntityID{
 				Kind: workloadmeta.KindContainerImageMetadata,
-				ID:   imageID,
+				ID:   existingImage.EntityID.ID,
 			},
 			SBOM: finalCompressedSBOM,
 		},

--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector_test.go
@@ -693,8 +693,13 @@ func TestWorkloadmetaEventFromSBOMEventSet_FallsBackToRepoDigest(t *testing.T) {
 
 	got, ok := event.Entity.(*workloadmeta.ContainerImageMetadata)
 	require.True(t, ok)
-	// The event ID is the original (kubelet) image ID, not the config digest.
-	assert.Equal(t, repoDigest, got.ID)
+	// The enriched SBOM must be keyed by the resolved image entity's own
+	// (config-digest) ID, not the kubelet repo digest. Keying it by the repo
+	// digest would create a separate, metadata-less image entity that the SBOM
+	// check cannot ship; using the config digest lands it on the same entity the
+	// runtime collector populates so the two sources merge and the enriched SBOM
+	// is published.
+	assert.Equal(t, configDigest, got.ID)
 }
 
 func TestWorkloadmetaEventFromSBOMEventSet_PendingSBOMSkipped(t *testing.T) {

--- a/releasenotes/notes/fix-sbom-package-in-use-kubelet-b7e2f4a9c1d8035e.yaml
+++ b/releasenotes/notes/fix-sbom-package-in-use-kubelet-b7e2f4a9c1d8035e.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue where the SBOM runtime usage enrichment (the "package in use"
+    indicators such as ``LastSeenRunning``) was never reported for containers
+    managed by the kubelet. The enriched SBOM was keyed by the container image's
+    manifest digest instead of its config digest, so it landed on a separate
+    image entity that was never shipped to the backend.


### PR DESCRIPTION
The remote SBOM collector keyed the runtime-enriched image SBOM by
container.Image.ID. Under the kubelet that is the manifest/repo digest,
which differs from the config digest the image entity is stored under, so
the enriched SBOM landed on a separate image entity with no repo
digests/tags. The SBOM check skips such entities, so the runtime usage
properties (LastSeenRunning, ...) never reached the backend even though the
merge ran every cycle.

Key the entity by the resolved image's own ID instead, so the enriched
SBOM merges onto the entity the runtime collector populates (the
remote_sbom_collector source sorts ahead of runtime, so it wins) and is
shipped by the SBOM check.

