### PR TITLE
Gate workloadmeta process collector behind systemprobechecks build tag

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && systemprobechecks
 
 // Package process implements the process collector for Workloadmeta.
 package process

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_nop.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_nop.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux
+//go:build !linux || !systemprobechecks
 
 // Package process implements the process collector for Workloadmeta.
 package process

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && test
+//go:build linux && systemprobechecks && test
 
 // Package process implements the process collector for Workloadmeta.
 package process

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && test
+//go:build linux && systemprobechecks && test
 
 package process
 

--- a/pkg/process/checks/process_clock_test_helpers_test.go
+++ b/pkg/process/checks/process_clock_test_helpers_test.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux || systemprobechecks
+
+package checks
+
+import (
+	"time"
+
+	"github.com/benbjohnson/clock"
+)
+
+func constantMockClock(t time.Time) *clock.Mock {
+	c := clock.NewMock()
+	c.Set(t)
+	return c
+}

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -387,10 +386,4 @@ func yieldConnections(count int) []*model.Connection {
 		result[i] = &model.Connection{LastBytesReceived: 10, LastBytesSent: 20}
 	}
 	return result
-}
-
-func constantMockClock(time time.Time) *clock.Mock {
-	c := clock.NewMock()
-	c.Set(time)
-	return c
 }

--- a/pkg/process/checks/process_fallback.go
+++ b/pkg/process/checks/process_fallback.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux
+//go:build !linux || !systemprobechecks
 
 package checks
 

--- a/pkg/process/checks/process_linux.go
+++ b/pkg/process/checks/process_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && systemprobechecks
 
 package checks
 

--- a/pkg/process/checks/process_linux_test.go
+++ b/pkg/process/checks/process_linux_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && systemprobechecks
 
 package checks
 

--- a/releasenotes/notes/iot-agent-process-collector-build-tag-fac62d4022fba58e.yaml
+++ b/releasenotes/notes/iot-agent-process-collector-build-tag-fac62d4022fba58e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Exclude the workloadmeta process collector from the IoT Agent binary using the ``systemprobechecks`` build tag, reducing binary size.


### PR DESCRIPTION
## What does this PR do?

Fixes [AGENT-16334](https://datadoghq.atlassian.net/browse/AGENT-16334). Customers running the IoT Agent on Linux see repeated ERROR-level log spam:

```
CORE | ERROR | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:509 in updateServices) | failed to get services: Get "http://sysprobe/debug/stats": dial unix /opt/datadog-agent/run/sysprobe.sock: connect: no such file or directory
```

Gates the workloadmeta process collector and the process check's WLM path behind the `systemprobechecks` build tag, excluding them from the IoT Agent binary at compile time. Also gates `WLMProcessCollectionEnabled()` and `processesByPID()` in the process check so that non-`systemprobechecks` Linux builds fall back to procfs instead of silently returning an empty payload.

**Supersedes #52048.** That PR added a runtime `GetFlavor() == IotAgent` guard to handle the same bug. On Linux, IoT deployments always use the IoT binary (built without `systemprobechecks`), so the compile-time gate is sufficient. The `iot_host: true` case on a default Linux binary is a Windows-only billing scenario; on Windows `process_collector.go` is already excluded by `//go:build linux`, so no runtime check is needed there either.

## Motivation

- [AGENT-16334](https://datadoghq.atlassian.net/browse/AGENT-16334) — IoT Agent on Linux generating repeated ERROR logs from the workloadmeta process collector trying to connect to a non-existent system-probe socket.
- IoT Agent has no system-probe; process collection is not expected to work.
- Excluding the collector and WLM process check path at compile time reduces binary size and eliminates the error logs at the root.
- The `systemprobechecks` tag is already absent from `IOT_AGENT_TAGS` in `tasks/build_tags.bzl`, making it the natural gate.

## Test plan

- [x] `dda inv agent.build --flavor iot --build-exclude=systemd` — builds successfully; process collector excluded
- [x] `dda inv agent.build --build-exclude=systemd` — builds successfully; process collector still included in default agent
- Linux CI will verify tests still pass under `linux && systemprobechecks && test`

## QA

`qa/done` — compile-time exclusion only; no runtime behavior change. Covered by build verification for both IoT and default flavors and the CI linter/test runs.

[AGENT-16334]: https://datadoghq.atlassian.net/browse/AGENT-16334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AGENT-16334]: https://datadoghq.atlassian.net/browse/AGENT-16334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ