### PR TITLE
test(trace): reduce allocations in trace-agent unit tests

### DIFF
--- a/pkg/trace/agent/obfuscate_test.go
+++ b/pkg/trace/agent/obfuscate_test.go
@@ -41,6 +41,8 @@ func TestObfuscateStatsGroup(t *testing.T) {
 			Resource: resource,
 		}
 	}
+	agnt, stop := agentWithDefaults()
+	defer stop()
 	for _, tt := range []struct {
 		in  *pb.ClientGroupedStats // input stats
 		out string                 // output obfuscated resource
@@ -51,8 +53,6 @@ func TestObfuscateStatsGroup(t *testing.T) {
 		{statsGroup("valkey", "ADD 1, 2"), "ADD"},
 		{statsGroup("other", "ADD 1, 2"), "ADD 1, 2"},
 	} {
-		agnt, stop := agentWithDefaults()
-		defer stop()
 		agnt.obfuscateStatsGroup(tt.in)
 		assert.Equal(t, tt.in.Resource, tt.out)
 	}

--- a/pkg/trace/filters/blacklister_test.go
+++ b/pkg/trace/filters/blacklister_test.go
@@ -58,9 +58,9 @@ func TestBlacklisterDenyingRule(t *testing.T) {
 func TestCompileRules(t *testing.T) {
 	filter := NewBlacklister([]string{"[123", "]123", "{6}"})
 	for i := 0; i < 100; i++ {
-		span := testutil.RandomSpan()
-		stat := pb.ClientGroupedStats{Resource: span.Resource}
-		result, _ := filter.AllowsString(span.Resource)
+		resource := testutil.RandomSpanResource()
+		stat := pb.ClientGroupedStats{Resource: resource}
+		result, _ := filter.AllowsString(resource)
 		assert.True(t, result)
 		assert.True(t, filter.AllowsStat(&stat))
 	}

--- a/pkg/trace/semantics/lookup_dd_test.go
+++ b/pkg/trace/semantics/lookup_dd_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDDSpanAccessor(t *testing.T) {
@@ -70,8 +69,7 @@ func TestDDSpanAccessor(t *testing.T) {
 	})
 
 	t.Run("http.status_code in metrics resolves via int64 registry entry", func(t *testing.T) {
-		r, err := NewEmbeddedRegistry()
-		require.NoError(t, err)
+		r := testRegistry
 
 		// Newer agents store http.status_code in Metrics as float64(200).
 		a := NewDDSpanAccessor(
@@ -87,8 +85,7 @@ func TestDDSpanAccessor(t *testing.T) {
 	})
 
 	t.Run("http.status_code in meta resolves via string registry entry", func(t *testing.T) {
-		r, err := NewEmbeddedRegistry()
-		require.NoError(t, err)
+		r := testRegistry
 
 		// Older agents store http.status_code in Meta as a string.
 		a := NewDDSpanAccessor(
@@ -232,8 +229,7 @@ func TestDDSpanAccessorV1(t *testing.T) {
 	})
 
 	t.Run("integration: LookupInt64 with IntValue storage", func(t *testing.T) {
-		r, err := NewEmbeddedRegistry()
-		require.NoError(t, err)
+		r := testRegistry
 
 		s := newTestSpanV1()
 		s.SetAttributeFromString("http.status_code", "404") // stored as IntValue
@@ -244,8 +240,7 @@ func TestDDSpanAccessorV1(t *testing.T) {
 	})
 
 	t.Run("integration: LookupInt64 with DoubleValue storage", func(t *testing.T) {
-		r, err := NewEmbeddedRegistry()
-		require.NoError(t, err)
+		r := testRegistry
 
 		s := newTestSpanV1()
 		s.SetFloat64Attribute("http.status_code", 503.0)

--- a/pkg/trace/semantics/lookup_pdata_test.go
+++ b/pkg/trace/semantics/lookup_pdata_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
@@ -100,8 +99,7 @@ func TestNewOTelSpanAccessor(t *testing.T) {
 }
 
 func TestPDataAccessorWithRegistry(t *testing.T) {
-	r, err := NewEmbeddedRegistry()
-	require.NoError(t, err)
+	r := testRegistry
 
 	spanAttrs := pcommon.NewMap()
 	spanAttrs.PutStr("db.statement", "SELECT * FROM users")
@@ -114,8 +112,7 @@ func TestPDataAccessorWithRegistry(t *testing.T) {
 }
 
 func TestPDataAccessorTypedLookup(t *testing.T) {
-	r, err := NewEmbeddedRegistry()
-	require.NoError(t, err)
+	r := testRegistry
 
 	spanAttrs := pcommon.NewMap()
 	spanAttrs.PutInt("http.status_code", 404)

--- a/pkg/trace/semantics/lookup_test.go
+++ b/pkg/trace/semantics/lookup_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
@@ -22,8 +21,7 @@ func newTestAccessor(raw map[string]any) PDataMapAccessor {
 }
 
 func TestLookupString(t *testing.T) {
-	r, err := NewEmbeddedRegistry()
-	require.NoError(t, err)
+	r := testRegistry
 
 	t.Run("finds string value", func(t *testing.T) {
 		accessor := newTestAccessor(map[string]any{"db.statement": "SELECT 1"})
@@ -37,8 +35,7 @@ func TestLookupString(t *testing.T) {
 }
 
 func TestLookupInt64(t *testing.T) {
-	r, err := NewEmbeddedRegistry()
-	require.NoError(t, err)
+	r := testRegistry
 
 	t.Run("finds int64 value via typed accessor", func(t *testing.T) {
 		accessor := newTestAccessor(map[string]any{"http.status_code": int64(200)})
@@ -62,8 +59,7 @@ func TestLookupInt64(t *testing.T) {
 }
 
 func TestLookupFloat64(t *testing.T) {
-	r, err := NewEmbeddedRegistry()
-	require.NoError(t, err)
+	r := testRegistry
 
 	t.Run("converts int64 to float64 via typed accessor", func(t *testing.T) {
 		accessor := newTestAccessor(map[string]any{"http.status_code": int64(200)})
@@ -81,8 +77,7 @@ func TestLookupFloat64(t *testing.T) {
 }
 
 func TestLookup(t *testing.T) {
-	r, err := NewEmbeddedRegistry()
-	require.NoError(t, err)
+	r := testRegistry
 
 	t.Run("returns result with metadata", func(t *testing.T) {
 		accessor := newTestAccessor(map[string]any{"db.statement": "SELECT 1"})
@@ -104,8 +99,7 @@ func TestLookup(t *testing.T) {
 // a legacy fallback when rpc.system=grpc and rpc.system.name is absent. The legacy
 // row's two-condition AND also gives ANDing implicit coverage.
 func TestGRPCStatusCodeConditionalFallback(t *testing.T) {
-	r, err := NewEmbeddedRegistry()
-	require.NoError(t, err)
+	r := testRegistry
 
 	for _, tt := range []struct {
 		name  string
@@ -212,8 +206,7 @@ func TestStringMapAccessor(t *testing.T) {
 	})
 
 	t.Run("with semantic lookup", func(t *testing.T) {
-		r, err := NewEmbeddedRegistry()
-		require.NoError(t, err)
+		r := testRegistry
 
 		accessor := NewStringMapAccessor(map[string]string{"http.status_code": "404"})
 		v, ok := LookupInt64(r, accessor, ConceptHTTPStatusCode)

--- a/pkg/trace/semantics/semantics_test.go
+++ b/pkg/trace/semantics/semantics_test.go
@@ -19,7 +19,7 @@ import (
 // internal fields. Tests that mutate the registry must build their own instance.
 var testRegistry Registry = mustEmbeddedRegistry()
 
-func mustEmbeddedRegistry() Registry {
+func mustEmbeddedRegistry() *EmbeddedRegistry {
 	r, err := NewEmbeddedRegistry()
 	if err != nil {
 		panic(err)

--- a/pkg/trace/semantics/semantics_test.go
+++ b/pkg/trace/semantics/semantics_test.go
@@ -15,10 +15,11 @@ import (
 // testRegistry is a shared, read-only embedded registry for lookup tests.
 // NewEmbeddedRegistry parses the embedded mappings JSON on every call, so tests
 // that only read from the registry reuse this single instance instead of
-// re-parsing. Tests that mutate the registry must build their own instance.
-var testRegistry = mustEmbeddedRegistry()
+// re-parsing. It is typed as the Registry interface so callers cannot reach the
+// internal fields. Tests that mutate the registry must build their own instance.
+var testRegistry Registry = mustEmbeddedRegistry()
 
-func mustEmbeddedRegistry() *EmbeddedRegistry {
+func mustEmbeddedRegistry() Registry {
 	r, err := NewEmbeddedRegistry()
 	if err != nil {
 		panic(err)

--- a/pkg/trace/semantics/semantics_test.go
+++ b/pkg/trace/semantics/semantics_test.go
@@ -12,6 +12,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testRegistry is a shared, read-only embedded registry for lookup tests.
+// NewEmbeddedRegistry parses the embedded mappings JSON on every call, so tests
+// that only read from the registry reuse this single instance instead of
+// re-parsing. Tests that mutate the registry must build their own instance.
+var testRegistry = mustEmbeddedRegistry()
+
+func mustEmbeddedRegistry() *EmbeddedRegistry {
+	r, err := NewEmbeddedRegistry()
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
 func TestEmbeddedRegistry(t *testing.T) {
 	r, err := NewEmbeddedRegistry()
 	require.NoError(t, err)
@@ -19,8 +33,7 @@ func TestEmbeddedRegistry(t *testing.T) {
 }
 
 func TestGetAttributePrecedence(t *testing.T) {
-	r, err := NewEmbeddedRegistry()
-	require.NoError(t, err)
+	r := testRegistry
 
 	t.Run("known concept returns tags", func(t *testing.T) {
 		tags := r.GetAttributePrecedence(ConceptDBStatement)
@@ -41,16 +54,14 @@ func TestDefaultRegistry(t *testing.T) {
 }
 
 func TestPartialVersionRegistryType(t *testing.T) {
-	r, err := NewEmbeddedRegistry()
-	require.NoError(t, err)
+	r := testRegistry
 	tags := r.GetAttributePrecedence(ConceptDDPartialVersion)
 	require.Len(t, tags, 1, "ConceptDDPartialVersion should have exactly one fallback")
 	assert.Equal(t, ValueTypeFloat64, tags[0].Type, "_dd.partial_version must be float64 to match the Metrics map storage type")
 }
 
 func TestDDTagConceptsRegistered(t *testing.T) {
-	r, err := NewEmbeddedRegistry()
-	require.NoError(t, err)
+	r := testRegistry
 
 	concepts := []struct {
 		concept Concept
@@ -76,8 +87,7 @@ func TestDDTagConceptsRegistered(t *testing.T) {
 }
 
 func TestDDTagConceptLookup(t *testing.T) {
-	r, err := NewEmbeddedRegistry()
-	require.NoError(t, err)
+	r := testRegistry
 
 	meta := map[string]string{
 		"env":                "production",


### PR DESCRIPTION
### What does this PR do?


Three small, independent optimizations to trace-agent unit tests:
- `TestCompileRules`: use `RandomSpanResource()` instead of the much heavier `RandomSpan()` (it only needs a resource string).
- `semantics` lookup tests: share one read-only embedded registry instead of re-parsing the embedded mappings JSON ~16 times.
- `TestObfuscateStatsGroup`: build the agent once instead of per table row, and drop a `defer` that accumulated inside the loop.

### Motivation
I had Claude review Trace Agent unit tests and find any simple, low-risk optimizations (this initiative was sparked by [this commit](https://github.com/DataDog/datadog-agent/pull/52238/changes/104a305b5ea43dfa3228c4e42e9e1d2da5eacdef), following up on feedback provided by Codex).

### Describe how you validated your changes

`go test` on the affected packages (`filters`, `semantics`, `agent`) passes; measured before/after with `-count`/`-benchmem`.

### Additional Notes
