### PR TITLE
Remove extra `go_deps` extension from MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -50,17 +50,6 @@ bazel_dep(name = "bazel_lib", version = "3.3.1")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "gawk", version = "5.3.2.bcr.7")
 bazel_dep(name = "gazelle", version = "0.51.3")
-
-go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
-
-# Needed by //bazel/rules/go to construct Starlark AST nodes.
-go_deps.module(
-    path = "github.com/bazelbuild/buildtools",
-    sum = "h1:njQAmjTv/YHRm/0Lfv9DXHFZ4MdT2IA/RKHTnqZkgDw=",
-    version = "v0.0.0-20250930140053-2eb4fccefb52",
-)
-use_repo(go_deps, buildtools = "com_github_bazelbuild_buildtools")
-
 bazel_dep(name = "gcc_toolchain", version = "0.9.2")
 bazel_dep(name = "libarchive", version = "3.8.1.bcr.2")
 bazel_dep(name = "package_metadata", version = "0.0.10")

--- a/bazel/rules/go/BUILD.bazel
+++ b/bazel/rules/go/BUILD.bazel
@@ -63,7 +63,7 @@ go_test(
     srcs = [":gazelle_extension_test_src"],
     embed = [":gazelle_extension"],
     deps = [
-        "@buildtools//build",
+        "@@gazelle++go_deps+com_github_bazelbuild_buildtools//build",
         "@gazelle//config",
         "@gazelle//language",
         "@gazelle//rule",


### PR DESCRIPTION
### What does this PR do?
Remove the standalone `go_deps` Gazelle module extension instance from `MODULE.bazel` that existed solely to expose
`github.com/bazelbuild/buildtools` as `@buildtools` for test purposes.

`bazel/rules/go/BUILD.bazel` now references the necessary buildtools `build` package via its _canonical label_:
`@@gazelle++go_deps+com_github_bazelbuild_buildtools//build`[^1].

### Motivation
Two instantiations of `@gazelle//:extensions.bzl%go_deps` (the original one in `deps/go.MODULE.bazel` and an extra one in `MODULE.bazel`) had unintended side effects:

`bazel mod tidy` would indeed sometimes write `use_repo` entries into `MODULE.bazel` instead of `deps/go.MODULE.bazel`, because the `go_deps` extension **aggregates tags from all instances** and infers repo ownership via Go maps whose iteration order is purposely randomized (golang/go#6719), so the target file varies per run (`reproducible = True` only guarantees the repo set, not placement).

Renovate CI jobs, each starting with fresh entropy, triggered this more often (e.g., #51839), so version bumps generated by Renovate for Go dependencies were incomplete and required manual fixups.

Additionally, the canonical-label approach enforces that the test in `bazel/rules/go` links against Gazelle's exact `buildtools` version, guaranteeing no API/ABI mismatch and avoiding fetching/compiling it twice.

### Describe how you validated your changes
`bazel mod tidy` no longer modifies `MODULE.bazel`.

### Additional Notes
[^1]: Module extensions' [Repository names and visibility](https://bazel.build/external/extension#repository_names_and_visibility):
    > Repos generated by extensions have canonical names in the form of _`module_repo_canonical_name`_+_`extension_name`_+_`repo_name`_. 