### PR TITLE
[autoscaling] Fix burstable CPU-limit removal under HA cluster-agent

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/pod_patcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher.go
@@ -89,10 +89,18 @@ func (pa podPatcher) ApplyRecommendations(pod *corev1.Pod) (bool, error) {
 		return patched, nil
 	}
 
-	// Patching the pod with the recommendations.
-	// In burstable mode, applyVerticalConstraints has already stamped the CPU-limit remove
-	// sentinel (-1) on each container recommendation, so ResourcesHash naturally encodes the
-	// burstable state — no extra suffix is needed here.
+	// Re-derive the burstable/constraint transformations here so they are applied consistently on
+	// every replica. The controller stamps the removeLimitSentinel only on the leader (and it is
+	// stripped from the DPA status), so a follower webhook would otherwise leave the CPU limit in
+	// place. Inputs come from the spec/annotations, available on all replicas; idempotent on the leader.
+	constrainedVertical := autoscaler.ScalingValues().Vertical.DeepCopy()
+	if _, err := applyVerticalConstraints(constrainedVertical, autoscaler.Spec().Constraints, autoscaler.IsBurstable()); err != nil {
+		log.Warnf("Autoscaler %s: failed to apply vertical constraints for POD %s/%s, not patching resources: %v", autoscaler.ID(), pod.Namespace, pod.Name, err)
+		return patched, nil
+	}
+
+	// Use the active scaling values hash (mirrored to the DPA status) so the annotation stays
+	// identical across replicas; not the recomputed constrained hash.
 	effectiveRecommendationID := autoscaler.ScalingValues().Vertical.ResourcesHash
 	if pod.Annotations[model.RecommendationIDAnnotation] != effectiveRecommendationID {
 		pod.Annotations[model.RecommendationIDAnnotation] = effectiveRecommendationID
@@ -100,7 +108,7 @@ func (pa podPatcher) ApplyRecommendations(pod *corev1.Pod) (bool, error) {
 	}
 
 	// Even if annotation matches, we still verify the resources are correct, in case the POD was modified.
-	for _, reco := range autoscaler.ScalingValues().Vertical.ContainerResources {
+	for _, reco := range constrainedVertical.ContainerResources {
 		patched = patchPod(reco, pod) || patched
 	}
 

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
@@ -203,6 +203,37 @@ func patcherTestStoreWithData() *store {
 		},
 	}.Build(), "")
 
+	// ns1/autoscaler-burstable-follower simulates a FOLLOWER replica: the stored recommendation has
+	// NO removeLimitSentinel (it never ran the leader sync and the status strips negatives), yet
+	// ApplyRecommendations must still remove the CPU limit by re-deriving burstable from the spec.
+	store.Set("ns1/autoscaler-burstable-follower", model.FakePodAutoscalerInternal{
+		Namespace:            "ns1",
+		Name:                 "autoscaler-burstable-follower",
+		PreviewAnnotationKey: `{"burstable":true}`,
+		Spec: &datadoghq.DatadogPodAutoscalerSpec{
+			TargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "burstable-follower-deployment",
+			},
+			Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+				Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+					{Name: "*", Enabled: pointer.Ptr(true)},
+				},
+			},
+		},
+		ScalingValues: model.ScalingValues{
+			Vertical: &model.VerticalScalingValues{
+				Source:        datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+				ResourcesHash: "version1-burstable-follower",
+				ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+					// No CPU limit entry: the status strips the sentinel, so the follower never sees it.
+					{Name: "app", Limits: corev1.ResourceList{"memory": resource.MustParse("512Mi")}, Requests: corev1.ResourceList{"cpu": resource.MustParse("250m")}},
+				},
+			},
+		},
+	}.Build(), "")
+
 	return store
 }
 
@@ -843,6 +874,108 @@ func TestPatcherApplyRecommendations(t *testing.T) {
 							// CPU limit is restored from the recommendation
 							Limits:   corev1.ResourceList{"cpu": resource.MustParse("500m")},
 							Requests: corev1.ResourceList{"memory": resource.MustParse("256Mi")},
+						},
+					}},
+				},
+			},
+		},
+		// Follower replica: stored reco has no sentinel; the CPU limit must still be removed.
+		{
+			name: "burstable follower: CPU limit removed even though stored reco has no sentinel",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+					Name:      "burstable-follower-pod",
+					OwnerReferences: []metav1.OwnerReference{{
+						Kind:       "ReplicaSet",
+						Name:       "burstable-follower-deployment-968f49d86",
+						APIVersion: "apps/v1",
+					}},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"cpu": resource.MustParse("1"), "memory": resource.MustParse("1Gi")},
+							Requests: corev1.ResourceList{"cpu": resource.MustParse("100m")},
+						},
+					}},
+				},
+			},
+			wantInjected: true,
+			wantPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+					Name:      "burstable-follower-pod",
+					OwnerReferences: []metav1.OwnerReference{{
+						Kind:       "ReplicaSet",
+						Name:       "burstable-follower-deployment-968f49d86",
+						APIVersion: "apps/v1",
+					}},
+					Annotations: map[string]string{
+						model.RecommendationIDAnnotation: "version1-burstable-follower",
+						model.AutoscalerIDAnnotation:     "ns1/autoscaler-burstable-follower",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							// CPU limit removed; memory limit and CPU request still applied.
+							Limits:   corev1.ResourceList{"memory": resource.MustParse("512Mi")},
+							Requests: corev1.ResourceList{"cpu": resource.MustParse("250m")},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "burstable follower: idempotent when CPU limit already absent",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+					Name:      "burstable-follower-pod",
+					OwnerReferences: []metav1.OwnerReference{{
+						Kind:       "ReplicaSet",
+						Name:       "burstable-follower-deployment-968f49d86",
+						APIVersion: "apps/v1",
+					}},
+					Annotations: map[string]string{
+						model.RecommendationIDAnnotation: "version1-burstable-follower",
+						model.AutoscalerIDAnnotation:     "ns1/autoscaler-burstable-follower",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"memory": resource.MustParse("512Mi")},
+							Requests: corev1.ResourceList{"cpu": resource.MustParse("250m")},
+						},
+					}},
+				},
+			},
+			wantInjected: false,
+			wantPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+					Name:      "burstable-follower-pod",
+					OwnerReferences: []metav1.OwnerReference{{
+						Kind:       "ReplicaSet",
+						Name:       "burstable-follower-deployment-968f49d86",
+						APIVersion: "apps/v1",
+					}},
+					Annotations: map[string]string{
+						model.RecommendationIDAnnotation: "version1-burstable-follower",
+						model.AutoscalerIDAnnotation:     "ns1/autoscaler-burstable-follower",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Limits:   corev1.ResourceList{"memory": resource.MustParse("512Mi")},
+							Requests: corev1.ResourceList{"cpu": resource.MustParse("250m")},
 						},
 					}},
 				},

--- a/releasenotes/notes/fix-autoscaling-burstable-ha-e8d3f673f150f686.yaml
+++ b/releasenotes/notes/fix-autoscaling-burstable-ha-e8d3f673f150f686.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Workload autoscaling: fixed a bug where, when running the Cluster Agent in
+    high-availability mode (multiple replicas), the burstable mode of a
+    ``DatadogPodAutoscaler`` could leave the CPU limit in place on a random
+    subset of pods. The CPU-limit removal is now re-derived from the autoscaler
+    spec in the admission controller, so every replica applies it consistently
+    regardless of which one handles the admission request.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where, with multiple Cluster Agent replicas (HA), the burstable mode of a `DatadogPodAutoscaler` left the CPU limit in place on a random subset of pods.

The mutating admission webhook (`ApplyRecommendations`) relied on the `removeLimitSentinel` already being present in the recommendation. That sentinel is stamped only during the controller sync, which runs on the leader, and it is stripped from the DPA status. Follower replicas rebuild their state from the K8s object/status, so their webhook never removed the CPU limit. Since the webhook is served by every replica, the limit survived on whichever pods the API server routed to a follower.

The fix re-derives the burstable/constraint transformation from the DPA spec (available on every replica) in `ApplyRecommendations`, so the CPU-limit removal is applied consistently regardless of which replica handles the admission request. The recommendation-id annotation keeps using the status hash so it stays identical across replicas.

### Motivation

Customer report: running 2 Cluster Agent replicas (recommended HA setup), the CPU limit was added back on pods at random even though the rest of the recommendation was applied.

### Describe how you validated your changes

- New follower-shaped unit tests in `pod_patcher_test.go` (recommendation without the sentinel + burstable) asserting the CPU limit is removed, plus idempotency.
- `dda inv test --targets=./pkg/clusteragent/autoscaling/workload` — all pass.
- `dda inv linter.go --targets=./pkg/clusteragent/autoscaling/workload` — 0 issues.
- Live A/B on a 2-replica kind cluster: buggy build left 29/75 pods with a CPU limit; fixed build removed it on 36/36 across multiple pod-churn rounds.

### Additional Notes

🤖 PR description and code assisted by Claude:claude-opus-4-8