### PR TITLE
fix(ci): stop retrying and skip MQ for `tests_linux-x64-py3_hybrid`

### DIFF
--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -81,6 +81,11 @@ tests_linux-x64-py3_hybrid:
     CONDA_ENV: ddpy3
     EXPERIMENTAL_USE_BAZEL_TESTS: "1"
   allow_failure: true  # This is for measurement during migration. It is not the actual test job.
+  retry: 0  # allowed to fail, ~35 min exec time
+  rules:
+    - !reference [.except_mergequeue]  # allowed to fail, not a gate at this stage
+    - !reference [.except_disable_unit_tests]
+    - !reference [.fast_on_dev_branch_only]
 
 tests_nodetreemodel:
   extends:


### PR DESCRIPTION
### What does this PR do?
- set `retry: 0` on `tests_linux-x64-py3_hybrid` so GitLab's default `retry: max: 1` does not trigger a re-run since the job always fails,
- add `.except_mergequeue` so the job is skipped in merge-queue pipelines, which it shouldn't delay.

### Motivation
The job has `allow_failure: true` (measurement only, not a gate), so retrying and running it in MQ pipelines adds a delay of about ~35 min.

### Additional Notes
`rules:` is set as per sibling jobs not applicable to MQ pipelines.