### PR TITLE
POC: Network Path scheduled tests via RC DEBUG

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -672,6 +672,10 @@ func startAgent(
 		actionsController := datastreams.NewActionsController(ac, rcclient)
 		ac.AddConfigProvider(actionsController, false, 0)
 
+		networkPathRCProvider := providers.NewNetworkPathRemoteConfigProvider()
+		rcclient.Subscribe(providers.NetworkPathRemoteConfigProduct, networkPathRCProvider.ScheduleCallback)
+		ac.AddConfigProvider(networkPathRCProvider, true, 10*time.Second)
+
 		if cfg.GetBool("remote_configuration.agent_integrations.enabled") {
 			// Spin up the config provider to schedule integrations through remote-config
 			rcProvider := providers.NewRemoteConfigProvider()

--- a/comp/core/autodiscovery/providers/names/provider_names.go
+++ b/comp/core/autodiscovery/providers/names/provider_names.go
@@ -53,6 +53,8 @@ const (
 	PrometheusServicesEndpointSlices = "prometheus-services-endpointslices"
 	// RemoteConfig delivers check configurations pushed from the Datadog backend via Remote Configuration.
 	RemoteConfig = "remote-config"
+	// NetworkPathRemoteConfig delivers Network Path check configurations pushed from Remote Configuration.
+	NetworkPathRemoteConfig = "network-path-remote-config"
 	// SNMP autodiscovers SNMP devices on configured subnets.
 	SNMP = "snmp"
 	// Zookeeper discovers check configurations stored in a Zookeeper ZNode tree.

--- a/comp/core/autodiscovery/providers/remote_config_network_path.go
+++ b/comp/core/autodiscovery/providers/remote_config_network_path.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -199,7 +200,7 @@ func parseNetworkPathDebugConfig(cfgPath string, rawConfig state.RawConfig) (int
 		return integration.Config{}, fmt.Errorf("invalid Network Path DEBUG config: %w", err)
 	}
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
-		return integration.Config{}, fmt.Errorf("invalid Network Path DEBUG config: trailing JSON tokens")
+		return integration.Config{}, errors.New("invalid Network Path DEBUG config: trailing JSON tokens")
 	}
 
 	if scheduled.POC != networkPathDebugPOCMarker {
@@ -209,7 +210,7 @@ func parseNetworkPathDebugConfig(cfgPath string, rawConfig state.RawConfig) (int
 		return integration.Config{}, fmt.Errorf("unsupported Network Path DEBUG config type %q", scheduled.Type)
 	}
 	if scheduled.Configs == nil {
-		return integration.Config{}, fmt.Errorf("invalid Network Path DEBUG config: configs must be provided")
+		return integration.Config{}, errors.New("invalid Network Path DEBUG config: configs must be provided")
 	}
 
 	provenanceTags := networkPathRCProvenanceTags(cfgPath, rawConfig.Metadata)
@@ -235,25 +236,25 @@ func parseNetworkPathDebugConfig(cfgPath string, rawConfig state.RawConfig) (int
 
 func translateNetworkPathDebugTestConfig(cfg networkPathDebugTestConfig, provenanceTags []string) (networkPathInstanceConfig, error) {
 	if strings.TrimSpace(cfg.Hostname) == "" {
-		return networkPathInstanceConfig{}, fmt.Errorf("hostname is required")
+		return networkPathInstanceConfig{}, errors.New("hostname is required")
 	}
 	if cfg.Port != nil && (*cfg.Port < 1 || *cfg.Port > 65535) {
-		return networkPathInstanceConfig{}, fmt.Errorf("port must be between 1 and 65535")
+		return networkPathInstanceConfig{}, errors.New("port must be between 1 and 65535")
 	}
 	if cfg.MaxTTL != nil && (*cfg.MaxTTL < 1 || *cfg.MaxTTL > 255) {
-		return networkPathInstanceConfig{}, fmt.Errorf("max_ttl must be between 1 and 255")
+		return networkPathInstanceConfig{}, errors.New("max_ttl must be between 1 and 255")
 	}
 	if cfg.TimeoutMS != nil && *cfg.TimeoutMS <= 0 {
-		return networkPathInstanceConfig{}, fmt.Errorf("timeout_ms must be > 0")
+		return networkPathInstanceConfig{}, errors.New("timeout_ms must be > 0")
 	}
 	if cfg.IntervalSec != nil && *cfg.IntervalSec <= 0 {
-		return networkPathInstanceConfig{}, fmt.Errorf("interval_sec must be > 0")
+		return networkPathInstanceConfig{}, errors.New("interval_sec must be > 0")
 	}
 	if cfg.TracerouteQueries != nil && *cfg.TracerouteQueries <= 0 {
-		return networkPathInstanceConfig{}, fmt.Errorf("traceroute_queries must be > 0")
+		return networkPathInstanceConfig{}, errors.New("traceroute_queries must be > 0")
 	}
 	if cfg.E2eQueries != nil && *cfg.E2eQueries <= 0 {
-		return networkPathInstanceConfig{}, fmt.Errorf("e2e_queries must be > 0")
+		return networkPathInstanceConfig{}, errors.New("e2e_queries must be > 0")
 	}
 
 	var protocol string
@@ -262,7 +263,7 @@ func translateNetworkPathDebugTestConfig(cfg networkPathDebugTestConfig, provena
 		switch payload.Protocol(protocol) {
 		case payload.ProtocolTCP, payload.ProtocolUDP, payload.ProtocolICMP:
 		default:
-			return networkPathInstanceConfig{}, fmt.Errorf("protocol must be one of TCP, UDP, or ICMP")
+			return networkPathInstanceConfig{}, errors.New("protocol must be one of TCP, UDP, or ICMP")
 		}
 	}
 
@@ -272,7 +273,7 @@ func translateNetworkPathDebugTestConfig(cfg networkPathDebugTestConfig, provena
 		switch payload.TCPMethod(tcpMethod) {
 		case payload.TCPConfigSYN, payload.TCPConfigSACK, payload.TCPConfigPreferSACK, payload.TCPConfigSYNSocket:
 		default:
-			return networkPathInstanceConfig{}, fmt.Errorf("tcp_method must be one of syn, sack, prefer_sack, or syn_socket")
+			return networkPathInstanceConfig{}, errors.New("tcp_method must be one of syn, sack, prefer_sack, or syn_socket")
 		}
 	}
 
@@ -285,10 +286,10 @@ func translateNetworkPathDebugTestConfig(cfg networkPathDebugTestConfig, provena
 	if cfg.TestID != nil {
 		testID := strings.TrimSpace(*cfg.TestID)
 		if testID == "" {
-			return networkPathInstanceConfig{}, fmt.Errorf("test_id must not be empty")
+			return networkPathInstanceConfig{}, errors.New("test_id must not be empty")
 		}
 		if strings.ContainsAny(testID, ",\n\r") {
-			return networkPathInstanceConfig{}, fmt.Errorf("test_id must not contain commas or newlines")
+			return networkPathInstanceConfig{}, errors.New("test_id must not contain commas or newlines")
 		}
 		tags = append(tags, "network_path.test_id:"+testID)
 	}

--- a/comp/core/autodiscovery/providers/remote_config_network_path.go
+++ b/comp/core/autodiscovery/providers/remote_config_network_path.go
@@ -1,0 +1,380 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package providers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+
+	"go.yaml.in/yaml/v2"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/networkpath"
+	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
+	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+)
+
+const (
+	networkPathDebugPOCMarker = "network_path_scheduled_tests"
+	networkPathScheduledType  = "scheduled"
+)
+
+var reservedNetworkPathRCTagPrefixes = []string{
+	"network_path.test_id:",
+	"network_path.config_source:",
+	"network_path.rc_product:",
+	"network_path.rc_config_id:",
+	"network_path.rc_config_version:",
+}
+
+// NetworkPathRemoteConfigProvider receives scheduled Network Path test
+// configurations from the Remote Config DEBUG product.
+type NetworkPathRemoteConfigProvider struct {
+	configErrors map[string]types.ErrorMsgSet
+	configCache  map[string]integration.Config
+	mu           sync.RWMutex
+	upToDate     bool
+}
+
+type networkPathDebugConfigMarker struct {
+	POC string `json:"poc"`
+}
+
+type networkPathDebugScheduledConfig struct {
+	POC     string                       `json:"poc"`
+	Type    string                       `json:"type"`
+	Configs []networkPathDebugTestConfig `json:"configs"`
+}
+
+type networkPathDebugTestConfig struct {
+	TestID             *string  `json:"test_id,omitempty"`
+	Hostname           string   `json:"hostname"`
+	Port               *int     `json:"port,omitempty"`
+	Protocol           *string  `json:"protocol,omitempty"`
+	MaxTTL             *int     `json:"max_ttl,omitempty"`
+	TimeoutMS          *int     `json:"timeout_ms,omitempty"`
+	IntervalSec        *int     `json:"interval_sec,omitempty"`
+	SourceService      string   `json:"source_service,omitempty"`
+	DestinationService string   `json:"destination_service,omitempty"`
+	TCPMethod          *string  `json:"tcp_method,omitempty"`
+	TracerouteQueries  *int     `json:"traceroute_queries,omitempty"`
+	E2eQueries         *int     `json:"e2e_queries,omitempty"`
+	Tags               []string `json:"tags,omitempty"`
+}
+
+type networkPathInstanceConfig struct {
+	Hostname              string   `yaml:"hostname"`
+	Port                  *int     `yaml:"port,omitempty"`
+	Protocol              string   `yaml:"protocol,omitempty"`
+	MaxTTL                *int     `yaml:"max_ttl,omitempty"`
+	Timeout               *int     `yaml:"timeout,omitempty"`
+	MinCollectionInterval *int     `yaml:"min_collection_interval,omitempty"`
+	SourceService         string   `yaml:"source_service,omitempty"`
+	DestinationService    string   `yaml:"destination_service,omitempty"`
+	TCPMethod             string   `yaml:"tcp_method,omitempty"`
+	TracerouteQueries     *int     `yaml:"traceroute_queries,omitempty"`
+	E2eQueries            *int     `yaml:"e2e_queries,omitempty"`
+	Tags                  []string `yaml:"tags,omitempty"`
+}
+
+// NewNetworkPathRemoteConfigProvider creates a new
+// NetworkPathRemoteConfigProvider.
+func NewNetworkPathRemoteConfigProvider() *NetworkPathRemoteConfigProvider {
+	return &NetworkPathRemoteConfigProvider{
+		configErrors: make(map[string]types.ErrorMsgSet),
+		configCache:  make(map[string]integration.Config),
+		upToDate:     false,
+	}
+}
+
+// Collect retrieves Network Path integrations from remote-config.
+func (rc *NetworkPathRemoteConfigProvider) Collect(_ context.Context) ([]integration.Config, error) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	rc.upToDate = true
+
+	integrationList := []integration.Config{}
+	for _, intg := range rc.configCache {
+		integrationList = append(integrationList, intg)
+	}
+
+	return integrationList, nil
+}
+
+// IsUpToDate allows autodiscovery to cache configs as long as no changes are
+// detected in remote-config.
+func (rc *NetworkPathRemoteConfigProvider) IsUpToDate(_ context.Context) (bool, error) {
+	rc.mu.RLock()
+	defer rc.mu.RUnlock()
+
+	return rc.upToDate, nil
+}
+
+// String returns a string representation of the provider.
+func (rc *NetworkPathRemoteConfigProvider) String() string {
+	return names.NetworkPathRemoteConfig
+}
+
+// GetConfigErrors returns a map of configuration errors for each configuration path.
+func (rc *NetworkPathRemoteConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	rc.mu.RLock()
+	defer rc.mu.RUnlock()
+
+	errors := make(map[string]types.ErrorMsgSet, len(rc.configErrors))
+	maps.Copy(errors, rc.configErrors)
+
+	return errors
+}
+
+// ScheduleCallback handles DEBUG remote-config updates for the Network Path
+// scheduled tests POC.
+func (rc *NetworkPathRemoteConfigProvider) ScheduleCallback(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	newCache := make(map[string]integration.Config, len(updates))
+	newErrors := make(map[string]types.ErrorMsgSet)
+
+	for cfgPath, rawConfig := range updates {
+		isMarked, markerErr := isNetworkPathDebugConfig(rawConfig.Config)
+		if markerErr != nil {
+			if existing, found := rc.configCache[cfgPath]; found {
+				newCache[cfgPath] = existing
+				recordNetworkPathRCError(newErrors, cfgPath, markerErr, applyStateCallback)
+			}
+			continue
+		}
+		if !isMarked {
+			continue
+		}
+
+		config, err := parseNetworkPathDebugConfig(cfgPath, rawConfig)
+		if err != nil {
+			if existing, found := rc.configCache[cfgPath]; found {
+				newCache[cfgPath] = existing
+			}
+			recordNetworkPathRCError(newErrors, cfgPath, err, applyStateCallback)
+			continue
+		}
+
+		if len(config.Instances) > 0 {
+			newCache[cfgPath] = config
+		}
+		applyStateCallback(cfgPath, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+	}
+
+	rc.configCache = newCache
+	rc.configErrors = newErrors
+	rc.upToDate = false
+}
+
+func isNetworkPathDebugConfig(raw []byte) (bool, error) {
+	var marker networkPathDebugConfigMarker
+	if err := json.Unmarshal(raw, &marker); err != nil {
+		return false, err
+	}
+
+	return marker.POC == networkPathDebugPOCMarker, nil
+}
+
+func parseNetworkPathDebugConfig(cfgPath string, rawConfig state.RawConfig) (integration.Config, error) {
+	var scheduled networkPathDebugScheduledConfig
+	decoder := json.NewDecoder(bytes.NewReader(rawConfig.Config))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&scheduled); err != nil {
+		return integration.Config{}, fmt.Errorf("invalid Network Path DEBUG config: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return integration.Config{}, fmt.Errorf("invalid Network Path DEBUG config: trailing JSON tokens")
+	}
+
+	if scheduled.POC != networkPathDebugPOCMarker {
+		return integration.Config{}, fmt.Errorf("invalid Network Path DEBUG config: unexpected poc %q", scheduled.POC)
+	}
+	if scheduled.Type != networkPathScheduledType {
+		return integration.Config{}, fmt.Errorf("unsupported Network Path DEBUG config type %q", scheduled.Type)
+	}
+	if scheduled.Configs == nil {
+		return integration.Config{}, fmt.Errorf("invalid Network Path DEBUG config: configs must be provided")
+	}
+
+	provenanceTags := networkPathRCProvenanceTags(cfgPath, rawConfig.Metadata)
+	instances := make([]integration.Data, 0, len(scheduled.Configs))
+	for i, cfg := range scheduled.Configs {
+		instance, err := translateNetworkPathDebugTestConfig(cfg, provenanceTags)
+		if err != nil {
+			return integration.Config{}, fmt.Errorf("invalid Network Path DEBUG config at configs[%d]: %w", i, err)
+		}
+		instanceYAML, err := yaml.Marshal(instance)
+		if err != nil {
+			return integration.Config{}, fmt.Errorf("invalid Network Path DEBUG config at configs[%d]: %w", i, err)
+		}
+		instances = append(instances, integration.Data(instanceYAML))
+	}
+
+	return integration.Config{
+		Name:      networkpath.CheckName,
+		Instances: instances,
+		Source:    networkPathRCSource(cfgPath, rawConfig.Metadata),
+	}, nil
+}
+
+func translateNetworkPathDebugTestConfig(cfg networkPathDebugTestConfig, provenanceTags []string) (networkPathInstanceConfig, error) {
+	if strings.TrimSpace(cfg.Hostname) == "" {
+		return networkPathInstanceConfig{}, fmt.Errorf("hostname is required")
+	}
+	if cfg.Port != nil && (*cfg.Port < 1 || *cfg.Port > 65535) {
+		return networkPathInstanceConfig{}, fmt.Errorf("port must be between 1 and 65535")
+	}
+	if cfg.MaxTTL != nil && (*cfg.MaxTTL < 1 || *cfg.MaxTTL > 255) {
+		return networkPathInstanceConfig{}, fmt.Errorf("max_ttl must be between 1 and 255")
+	}
+	if cfg.TimeoutMS != nil && *cfg.TimeoutMS <= 0 {
+		return networkPathInstanceConfig{}, fmt.Errorf("timeout_ms must be > 0")
+	}
+	if cfg.IntervalSec != nil && *cfg.IntervalSec <= 0 {
+		return networkPathInstanceConfig{}, fmt.Errorf("interval_sec must be > 0")
+	}
+	if cfg.TracerouteQueries != nil && *cfg.TracerouteQueries <= 0 {
+		return networkPathInstanceConfig{}, fmt.Errorf("traceroute_queries must be > 0")
+	}
+	if cfg.E2eQueries != nil && *cfg.E2eQueries <= 0 {
+		return networkPathInstanceConfig{}, fmt.Errorf("e2e_queries must be > 0")
+	}
+
+	var protocol string
+	if cfg.Protocol != nil {
+		protocol = strings.ToUpper(*cfg.Protocol)
+		switch payload.Protocol(protocol) {
+		case payload.ProtocolTCP, payload.ProtocolUDP, payload.ProtocolICMP:
+		default:
+			return networkPathInstanceConfig{}, fmt.Errorf("protocol must be one of TCP, UDP, or ICMP")
+		}
+	}
+
+	var tcpMethod string
+	if cfg.TCPMethod != nil {
+		tcpMethod = strings.ToLower(*cfg.TCPMethod)
+		switch payload.TCPMethod(tcpMethod) {
+		case payload.TCPConfigSYN, payload.TCPConfigSACK, payload.TCPConfigPreferSACK, payload.TCPConfigSYNSocket:
+		default:
+			return networkPathInstanceConfig{}, fmt.Errorf("tcp_method must be one of syn, sack, prefer_sack, or syn_socket")
+		}
+	}
+
+	tags := slices.Clone(cfg.Tags)
+	for _, tag := range tags {
+		if hasReservedNetworkPathRCTagPrefix(tag) {
+			return networkPathInstanceConfig{}, fmt.Errorf("tag %q uses a reserved Network Path RC prefix", tag)
+		}
+	}
+	if cfg.TestID != nil {
+		testID := strings.TrimSpace(*cfg.TestID)
+		if testID == "" {
+			return networkPathInstanceConfig{}, fmt.Errorf("test_id must not be empty")
+		}
+		if strings.ContainsAny(testID, ",\n\r") {
+			return networkPathInstanceConfig{}, fmt.Errorf("test_id must not contain commas or newlines")
+		}
+		tags = append(tags, "network_path.test_id:"+testID)
+	}
+	tags = append(tags, provenanceTags...)
+
+	return networkPathInstanceConfig{
+		Hostname:              cfg.Hostname,
+		Port:                  cfg.Port,
+		Protocol:              protocol,
+		MaxTTL:                cfg.MaxTTL,
+		Timeout:               cfg.TimeoutMS,
+		MinCollectionInterval: cfg.IntervalSec,
+		SourceService:         cfg.SourceService,
+		DestinationService:    cfg.DestinationService,
+		TCPMethod:             tcpMethod,
+		TracerouteQueries:     cfg.TracerouteQueries,
+		E2eQueries:            cfg.E2eQueries,
+		Tags:                  tags,
+	}, nil
+}
+
+func networkPathRCProvenanceTags(cfgPath string, metadata state.Metadata) []string {
+	configID := networkPathRCConfigID(cfgPath, metadata)
+	tags := []string{
+		"network_path.config_source:remote_config",
+		"network_path.rc_product:debug",
+		"network_path.rc_config_id:" + sanitizeNetworkPathRCTagValue(configID),
+	}
+	if metadata.Version > 0 {
+		tags = append(tags, fmt.Sprintf("network_path.rc_config_version:%d", metadata.Version))
+	}
+
+	return tags
+}
+
+func networkPathRCSource(cfgPath string, metadata state.Metadata) string {
+	configName := metadata.Name
+	if configName == "" {
+		configName = "unnamed"
+	}
+
+	return fmt.Sprintf("remote_config_debug/network_path/%s/%s",
+		sanitizeNetworkPathRCSourceSegment(networkPathRCConfigID(cfgPath, metadata)),
+		sanitizeNetworkPathRCSourceSegment(configName),
+	)
+}
+
+func networkPathRCConfigID(cfgPath string, metadata state.Metadata) string {
+	if metadata.ID != "" {
+		return metadata.ID
+	}
+
+	return cfgPath
+}
+
+func hasReservedNetworkPathRCTagPrefix(tag string) bool {
+	for _, prefix := range reservedNetworkPathRCTagPrefixes {
+		if strings.HasPrefix(tag, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func sanitizeNetworkPathRCTagValue(value string) string {
+	value = strings.TrimSpace(value)
+	replacer := strings.NewReplacer(",", "_", "\n", "_", "\r", "_", " ", "_")
+	return replacer.Replace(value)
+}
+
+func sanitizeNetworkPathRCSourceSegment(value string) string {
+	value = sanitizeNetworkPathRCTagValue(value)
+	replacer := strings.NewReplacer("/", "_")
+	return replacer.Replace(value)
+}
+
+func recordNetworkPathRCError(errors map[string]types.ErrorMsgSet, cfgPath string, err error, applyStateCallback func(string, state.ApplyStatus)) {
+	errors[cfgPath] = types.ErrorMsgSet{err.Error(): struct{}{}}
+	applyStateCallback(cfgPath, state.ApplyStatus{
+		State: state.ApplyStateError,
+		Error: err.Error(),
+	})
+}
+
+var _ types.CollectingConfigProvider = (*NetworkPathRemoteConfigProvider)(nil)
+var _ types.ConfigProvider = (*NetworkPathRemoteConfigProvider)(nil)
+
+// NetworkPathRemoteConfigProduct is the RC product consumed by this provider.
+const NetworkPathRemoteConfigProduct = data.ProductDebug

--- a/comp/core/autodiscovery/providers/remote_config_network_path_test.go
+++ b/comp/core/autodiscovery/providers/remote_config_network_path_test.go
@@ -1,0 +1,239 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package providers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+)
+
+func TestNetworkPathRemoteConfigProviderIgnoresUnmarkedConfigs(t *testing.T) {
+	provider := NewNetworkPathRemoteConfigProvider()
+	statuses := map[string]state.ApplyStatus{}
+
+	provider.ScheduleCallback(map[string]state.RawConfig{
+		"datadog/2/DEBUG/other/config": {
+			Config: []byte(`{"hello":"world"}`),
+		},
+	}, recordApplyStatuses(statuses))
+
+	require.Empty(t, statuses)
+	configs, err := provider.Collect(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, configs)
+}
+
+func TestNetworkPathRemoteConfigProviderSchedulesMarkedConfigs(t *testing.T) {
+	provider := NewNetworkPathRemoteConfigProvider()
+	statuses := map[string]state.ApplyStatus{}
+	configPath := "datadog/2/DEBUG/abc/network_path.json"
+
+	provider.ScheduleCallback(map[string]state.RawConfig{
+		configPath: {
+			Config: []byte(`{
+				"poc": "network_path_scheduled_tests",
+				"type": "scheduled",
+				"configs": [{
+					"test_id": "test-123",
+					"hostname": "api.example.com",
+					"port": 443,
+					"protocol": "tcp",
+					"max_ttl": 30,
+					"timeout_ms": 1000,
+					"interval_sec": 60,
+					"source_service": "frontend",
+					"destination_service": "api",
+					"tcp_method": "SYN",
+					"traceroute_queries": 3,
+					"e2e_queries": 50,
+					"tags": ["env:prod"]
+				}]
+			}`),
+			Metadata: state.Metadata{
+				ID:      "abc",
+				Name:    "network_path.json",
+				Version: 7,
+			},
+		},
+	}, recordApplyStatuses(statuses))
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses[configPath].State)
+
+	configs, err := provider.Collect(context.Background())
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+
+	cfg := configs[0]
+	require.Equal(t, "network_path", cfg.Name)
+	require.Equal(t, "remote_config_debug/network_path/abc/network_path.json", cfg.Source)
+	require.Len(t, cfg.Instances, 1)
+
+	instance := unmarshalNetworkPathInstance(t, cfg.Instances[0])
+	require.Equal(t, "api.example.com", instance["hostname"])
+	require.Equal(t, 443, instance["port"])
+	require.Equal(t, "TCP", instance["protocol"])
+	require.Equal(t, 30, instance["max_ttl"])
+	require.Equal(t, 1000, instance["timeout"])
+	require.Equal(t, 60, instance["min_collection_interval"])
+	require.Equal(t, "frontend", instance["source_service"])
+	require.Equal(t, "api", instance["destination_service"])
+	require.Equal(t, "syn", instance["tcp_method"])
+	require.Equal(t, 3, instance["traceroute_queries"])
+	require.Equal(t, 50, instance["e2e_queries"])
+	require.ElementsMatch(t, []interface{}{
+		"env:prod",
+		"network_path.test_id:test-123",
+		"network_path.config_source:remote_config",
+		"network_path.rc_product:debug",
+		"network_path.rc_config_id:abc",
+		"network_path.rc_config_version:7",
+	}, instance["tags"])
+}
+
+func TestNetworkPathRemoteConfigProviderEmptyConfigsUnschedules(t *testing.T) {
+	provider := NewNetworkPathRemoteConfigProvider()
+	statuses := map[string]state.ApplyStatus{}
+	configPath := "datadog/2/DEBUG/abc/network_path.json"
+
+	provider.ScheduleCallback(map[string]state.RawConfig{
+		configPath: {
+			Config: []byte(`{
+				"poc": "network_path_scheduled_tests",
+				"type": "scheduled",
+				"configs": [{"hostname": "api.example.com"}]
+			}`),
+			Metadata: state.Metadata{ID: "abc"},
+		},
+	}, recordApplyStatuses(statuses))
+
+	configs, err := provider.Collect(context.Background())
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+
+	provider.ScheduleCallback(map[string]state.RawConfig{
+		configPath: {
+			Config: []byte(`{
+				"poc": "network_path_scheduled_tests",
+				"type": "scheduled",
+				"configs": []
+			}`),
+			Metadata: state.Metadata{ID: "abc"},
+		},
+	}, recordApplyStatuses(statuses))
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses[configPath].State)
+	configs, err = provider.Collect(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, configs)
+}
+
+func TestNetworkPathRemoteConfigProviderRejectsInvalidConfigAndKeepsLastValid(t *testing.T) {
+	provider := NewNetworkPathRemoteConfigProvider()
+	statuses := map[string]state.ApplyStatus{}
+	configPath := "datadog/2/DEBUG/abc/network_path.json"
+
+	provider.ScheduleCallback(map[string]state.RawConfig{
+		configPath: {
+			Config: []byte(`{
+				"poc": "network_path_scheduled_tests",
+				"type": "scheduled",
+				"configs": [{"hostname": "api.example.com", "port": 443}]
+			}`),
+			Metadata: state.Metadata{ID: "abc"},
+		},
+	}, recordApplyStatuses(statuses))
+
+	configs, err := provider.Collect(context.Background())
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	previous := configs[0]
+
+	provider.ScheduleCallback(map[string]state.RawConfig{
+		configPath: {
+			Config: []byte(`{
+				"poc": "network_path_scheduled_tests",
+				"type": "scheduled",
+				"configs": [{"hostname": "api.example.com", "port": 70000}]
+			}`),
+			Metadata: state.Metadata{ID: "abc"},
+		},
+	}, recordApplyStatuses(statuses))
+
+	require.Equal(t, state.ApplyStateError, statuses[configPath].State)
+	require.Contains(t, statuses[configPath].Error, "port must be between 1 and 65535")
+
+	configs, err = provider.Collect(context.Background())
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	require.Equal(t, previous.FastDigest(), configs[0].FastDigest())
+	require.NotEmpty(t, provider.GetConfigErrors()[configPath])
+}
+
+func TestNetworkPathRemoteConfigProviderRejectsUnsupportedType(t *testing.T) {
+	provider := NewNetworkPathRemoteConfigProvider()
+	statuses := map[string]state.ApplyStatus{}
+	configPath := "datadog/2/DEBUG/abc/network_path.json"
+
+	provider.ScheduleCallback(map[string]state.RawConfig{
+		configPath: {
+			Config: []byte(`{
+				"poc": "network_path_scheduled_tests",
+				"type": "dynamic",
+				"configs": []
+			}`),
+			Metadata: state.Metadata{ID: "abc"},
+		},
+	}, recordApplyStatuses(statuses))
+
+	require.Equal(t, state.ApplyStateError, statuses[configPath].State)
+	require.Contains(t, statuses[configPath].Error, `unsupported Network Path DEBUG config type "dynamic"`)
+	configs, err := provider.Collect(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, configs)
+}
+
+func TestNetworkPathRemoteConfigProviderRejectsReservedTags(t *testing.T) {
+	provider := NewNetworkPathRemoteConfigProvider()
+	statuses := map[string]state.ApplyStatus{}
+	configPath := "datadog/2/DEBUG/abc/network_path.json"
+
+	provider.ScheduleCallback(map[string]state.RawConfig{
+		configPath: {
+			Config: []byte(`{
+				"poc": "network_path_scheduled_tests",
+				"type": "scheduled",
+				"configs": [{
+					"hostname": "api.example.com",
+					"tags": ["network_path.rc_product:debug"]
+				}]
+			}`),
+			Metadata: state.Metadata{ID: "abc"},
+		},
+	}, recordApplyStatuses(statuses))
+
+	require.Equal(t, state.ApplyStateError, statuses[configPath].State)
+	require.Contains(t, statuses[configPath].Error, "reserved Network Path RC prefix")
+}
+
+func recordApplyStatuses(statuses map[string]state.ApplyStatus) func(string, state.ApplyStatus) {
+	return func(path string, status state.ApplyStatus) {
+		statuses[path] = status
+	}
+}
+
+func unmarshalNetworkPathInstance(t *testing.T, data integration.Data) map[string]interface{} {
+	t.Helper()
+
+	var instance map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(data, &instance))
+	return instance
+}

--- a/netpath-rc-poc.md
+++ b/netpath-rc-poc.md
@@ -1,0 +1,164 @@
+# Network Path Scheduled Tests via Remote Config DEBUG POC
+
+## Goal
+
+This POC proves that the Agent can receive Network Path Scheduled Test definitions through Remote Config and run them as ordinary `network_path` integration instances, without an Agent restart and without adding a dedicated scheduler.
+
+The POC uses the staging-only Remote Config `DEBUG` product. Production follow-up work can move the same listener contract to a real Network Path RC product.
+
+## Design
+
+The Agent subscribes to the `DEBUG` RC product whenever Remote Config is enabled. Because `DEBUG` is shared by internal POCs, the Network Path listener only processes configs with this top-level marker:
+
+```json
+{
+  "poc": "network_path_scheduled_tests"
+}
+```
+
+All other `DEBUG` configs are ignored by this listener and do not receive an apply status from it.
+
+Marked configs must use `type: "scheduled"`. Each RC config contributes one `network_path` integration config with one instance per entry in `configs`. Autodiscovery then reconciles the generated integration configs and the existing `network_path` check performs the scheduled traceroute runs.
+
+YAML-configured `network_path` checks continue to run. The POC does not implement custom duplicate detection; any de-duplication is whatever the existing autodiscovery scheduler already provides.
+
+## Payload
+
+Canonical DEBUG payload:
+
+```json
+{
+  "poc": "network_path_scheduled_tests",
+  "type": "scheduled",
+  "configs": [
+    {
+      "test_id": "np-test-001",
+      "hostname": "api.example.com",
+      "port": 443,
+      "protocol": "TCP",
+      "max_ttl": 30,
+      "timeout_ms": 1000,
+      "interval_sec": 60,
+      "source_service": "frontend",
+      "destination_service": "api",
+      "tcp_method": "syn",
+      "traceroute_queries": 3,
+      "e2e_queries": 50,
+      "tags": ["env:prod", "team:network"]
+    }
+  ]
+}
+```
+
+Field mapping into the existing `network_path` integration schema:
+
+| RC field | Integration field |
+|---|---|
+| `hostname` | `hostname` |
+| `port` | `port` |
+| `protocol` | `protocol` |
+| `max_ttl` | `max_ttl` |
+| `timeout_ms` | `timeout` |
+| `interval_sec` | `min_collection_interval` |
+| `source_service` | `source_service` |
+| `destination_service` | `destination_service` |
+| `tcp_method` | `tcp_method` |
+| `traceroute_queries` | `traceroute_queries` |
+| `e2e_queries` | `e2e_queries` |
+| `tags` | `tags` |
+
+`test_id` is optional and is added as `network_path.test_id:<test_id>`.
+
+The listener also adds these provenance tags:
+
+```text
+network_path.config_source:remote_config
+network_path.rc_product:debug
+network_path.rc_config_id:<rc config id or path>
+network_path.rc_config_version:<rc config version>
+```
+
+The `network_path.*` tag prefixes above are reserved for the listener. If users provide those tags directly, the config is rejected.
+
+`configs: []` is valid and schedules no tests. This is useful to remove all tests contributed by a config while keeping the RC object.
+
+## Validation And Apply Semantics
+
+The listener validates marked configs before scheduling them:
+
+- `type` must be `scheduled`
+- `configs` must be present
+- each test must include `hostname`
+- numeric values must be in valid ranges
+- `protocol` must be `TCP`, `UDP`, or `ICMP` when set
+- `tcp_method` must be `syn`, `sack`, `prefer_sack`, or `syn_socket` when set
+- reserved listener tags are rejected
+
+If a marked config is invalid, the listener reports `ApplyStateError` for that RC config. If a previous valid version of the same RC config was already scheduled, it remains active. Deleting the RC config removes its scheduled tests.
+
+## Manual Validation Against Staging RC
+
+Build and run the Agent from this branch:
+
+```bash
+dda inv agent.build --build-exclude=systemd
+./bin/agent/agent run -c bin/agent/dist/datadog.yaml
+```
+
+The Agent must run with Remote Config enabled and a staging API key that can receive RC configs. No Network Path-specific local flag is required.
+
+Create a DEBUG config targeted to the Agent hostname:
+
+```bash
+export TARGET_HOSTNAME="$(hostname)"
+export CONFIG_CONTENT="$(jq -nc '{
+  poc: "network_path_scheduled_tests",
+  type: "scheduled",
+  configs: [{
+    test_id: "np-poc-001",
+    hostname: "api.datadoghq.com",
+    port: 443,
+    protocol: "TCP",
+    timeout_ms: 1000,
+    interval_sec: 60,
+    tags: ["env:poc"]
+  }]
+}')"
+
+export BODY="$(jq -n \
+  --arg contents "$CONFIG_CONTENT" \
+  --arg hostname "$TARGET_HOSTNAME" \
+  '{"data":{"type":"configs","id":"network-path-scheduled-poc","attributes":{"contents":$contents,"version":1,"target":{"hostname":$hostname}}}}')"
+
+http --ignore-stdin \
+  https://rc-debug-api.us1.staging.dog/internal/remote_config/products/debug/datadog/configs \
+  "$(ddtool auth token rapid-remote-config --datacenter us1.staging.dog --http-header)" \
+  --raw="$BODY"
+```
+
+Expected result:
+
+- RC admin shows the DEBUG config as acknowledged by the Agent.
+- Agent logs show the `network-path-remote-config` provider collecting a new config.
+- Agent status shows a `network_path` check sourced from `remote_config_debug/network_path/...`.
+- Emitted Network Path payloads are scheduled test runs and include the POC provenance tags.
+
+To update the config, increment `attributes.version` by one and use the RC debug API `PATCH` endpoint for the returned config ID. To remove the test, either patch the contents to `{"poc":"network_path_scheduled_tests","type":"scheduled","configs":[]}` or delete the RC config.
+
+## POC Scope
+
+Included:
+
+- DEBUG product listener
+- scheduled Network Path tests
+- unit tests for parsing, validation, translation, cache behavior, and apply status
+- manual staging RC validation steps
+
+Out of scope:
+
+- Dynamic Tests
+- production `NETWORK_PATH` RC product registration and schema
+- UI or RC API changes
+- custom scheduler or custom duplicate detection
+- secret resolution
+- automated staging RC E2E tests

--- a/netpath-rc-poc.md
+++ b/netpath-rc-poc.md
@@ -98,19 +98,85 @@ If a marked config is invalid, the listener reports `ApplyStateError` for that R
 
 ## Manual Validation Against Staging RC
 
-Build and run the Agent from this branch:
+The staging validation exercised the full local path:
 
-```bash
-dda inv agent.build --build-exclude=systemd
-./bin/agent/agent run -c bin/agent/dist/datadog.yaml
+```text
+RC DEBUG -> core Agent RC client -> network-path RC provider -> Autodiscovery scheduler -> network_path check -> system-probe traceroute
 ```
 
-The Agent must run with Remote Config enabled and a staging API key that can receive RC configs. No Network Path-specific local flag is required.
+### Local Configuration
+
+Use the same dev config directory for the Agent and system-probe:
+
+```bash
+export CONFIG_DIR=/Users/alexandre.yang/go/src/github.com/DataDog/datadog-agent/dev/dist
+export AGENT_CONFIG="$CONFIG_DIR/datadog.yaml"
+```
+
+`datadog.yaml` must include:
+
+- a staging RC-enabled API key
+- staging site configuration, for example `site: datad0g.com`
+- `remote_configuration.enabled: true`
+- a hostname matching the RC DEBUG target
+
+The successful staging run used hostname `alex-test02`.
+
+`system-probe.yaml` must enable traceroute support. The session used:
+
+```yaml
+traceroute:
+  enabled: true
+
+network_config:
+  enabled: true
+
+log_level: debug
+```
+
+### Build
+
+Build both binaries from this branch:
+
+```bash
+GOPROXY=https://proxy.golang.org,direct GOSUMDB=sum.golang.org \
+  dda inv agent.build --build-exclude=systemd --skip-assets
+
+GOPROXY=https://proxy.golang.org,direct GOSUMDB=sum.golang.org \
+  dda inv system-probe.build
+```
+
+### Run System-Probe
+
+Start system-probe first. It owns the traceroute endpoint used by the `network_path` check:
+
+```bash
+mkdir -p run run/ipc
+
+sudo ./bin/system-probe/system-probe run \
+  -c "$CONFIG_DIR" \
+  --datadogcfgpath "$CONFIG_DIR"
+```
+
+`sudo` is required for the traceroute raw socket path on macOS. Without it, the Agent can receive and schedule the RC config, but the check fails with a permission error from system-probe.
+
+### Run The Agent
+
+In another terminal, run the Agent against the same config:
+
+```bash
+./bin/agent/agent run \
+  -c "$AGENT_CONFIG"
+```
+
+No Network Path-specific local Agent flag is required. The listener is active whenever Remote Config is enabled; this matches the RFC decision for the POC.
+
+### Create A DEBUG Config
 
 Create a DEBUG config targeted to the Agent hostname:
 
 ```bash
-export TARGET_HOSTNAME="$(hostname)"
+export TARGET_HOSTNAME="alex-test02"
 export CONFIG_CONTENT="$(jq -nc '{
   poc: "network_path_scheduled_tests",
   type: "scheduled",
@@ -136,14 +202,131 @@ http --ignore-stdin \
   --raw="$BODY"
 ```
 
-Expected result:
+The RC API returns the concrete config ID. In the staging session, it was `network-path-scheduled-poc-1781637194`.
+
+### Update The DEBUG Config
+
+To update an existing DEBUG config, read the current config first and send its current `attributes.version` in the `PATCH` request. The RC API treats that version as a precondition and increments it on success.
+
+This example updates the POC config to monitor several well-known domains:
+
+```bash
+export CONFIG_ID="network-path-scheduled-poc-1781637194"
+export BASE_URL="https://rc-debug-api.us1.staging.dog/internal/remote_config/products/debug/datadog/configs"
+export RC_AUTH_HEADER="$(ddtool auth token rapid-remote-config --datacenter us1.staging.dog --http-header)"
+
+export CURRENT="$(http --ignore-stdin GET "$BASE_URL/$CONFIG_ID" "$RC_AUTH_HEADER")"
+export CURRENT_VERSION="$(printf '%s' "$CURRENT" | jq -r '.data.attributes.version')"
+export TARGET_HOSTNAME="$(printf '%s' "$CURRENT" | jq -r '.data.attributes.target.hostname')"
+
+export CONFIG_CONTENT="$(jq -nc '{
+  poc: "network_path_scheduled_tests",
+  type: "scheduled",
+  configs: [
+    {
+      test_id: "np-poc-001",
+      hostname: "api.datadoghq.com",
+      port: 443,
+      protocol: "TCP",
+      timeout_ms: 1000,
+      interval_sec: 60,
+      tags: ["env:poc", "source:rc-debug"]
+    },
+    {
+      test_id: "np-poc-google",
+      hostname: "www.google.com",
+      port: 443,
+      protocol: "TCP",
+      timeout_ms: 1000,
+      interval_sec: 60,
+      tags: ["env:poc", "source:rc-debug", "endpoint:google"]
+    },
+    {
+      test_id: "np-poc-cloudflare",
+      hostname: "www.cloudflare.com",
+      port: 443,
+      protocol: "TCP",
+      timeout_ms: 1000,
+      interval_sec: 60,
+      tags: ["env:poc", "source:rc-debug", "endpoint:cloudflare"]
+    },
+    {
+      test_id: "np-poc-github",
+      hostname: "github.com",
+      port: 443,
+      protocol: "TCP",
+      timeout_ms: 1000,
+      interval_sec: 60,
+      tags: ["env:poc", "source:rc-debug", "endpoint:github"]
+    },
+    {
+      test_id: "np-poc-wikipedia",
+      hostname: "www.wikipedia.org",
+      port: 443,
+      protocol: "TCP",
+      timeout_ms: 1000,
+      interval_sec: 60,
+      tags: ["env:poc", "source:rc-debug", "endpoint:wikipedia"]
+    }
+  ]
+}')"
+
+export BODY="$(jq -n \
+  --arg id "$CONFIG_ID" \
+  --arg contents "$CONFIG_CONTENT" \
+  --arg hostname "$TARGET_HOSTNAME" \
+  --argjson version "$CURRENT_VERSION" \
+  '{"data":{"type":"configs","id":$id,"attributes":{"contents":$contents,"version":$version,"target":{"hostname":$hostname}}}}')"
+
+http --ignore-stdin PATCH "$BASE_URL/$CONFIG_ID" "$RC_AUTH_HEADER" --raw="$BODY"
+```
+
+Verify the applied version and endpoints:
+
+```bash
+http --ignore-stdin GET "$BASE_URL/$CONFIG_ID" "$RC_AUTH_HEADER" |
+  jq '{
+    id: .data.id,
+    version: .data.attributes.version,
+    target: .data.attributes.target,
+    configs: (
+      .data.attributes.contents |
+      fromjson |
+      .configs |
+      map({test_id, hostname, port, protocol, interval_sec})
+    )
+  }'
+```
+
+The staging config was updated to version `3` with the five endpoints above.
+
+### Expected Result
 
 - RC admin shows the DEBUG config as acknowledged by the Agent.
 - Agent logs show the `network-path-remote-config` provider collecting a new config.
 - Agent status shows a `network_path` check sourced from `remote_config_debug/network_path/...`.
 - Emitted Network Path payloads are scheduled test runs and include the POC provenance tags.
 
-To update the config, increment `attributes.version` by one and use the RC debug API `PATCH` endpoint for the returned config ID. To remove the test, either patch the contents to `{"poc":"network_path_scheduled_tests","type":"scheduled","configs":[]}` or delete the RC config.
+The successful local Agent status included:
+
+```text
+Instance ID: network_path:ee77807503a2bae1 [OK]
+Configuration Source: remote_config_debug/network_path/network-path-scheduled-poc-1781637194/ef1454580708448bf6cdd91f73ff903ab58618a67240d81c846ab6802ee8cd42[0]
+Total Runs: 1
+Metric Samples: Last Run: 2, Total: 2
+Network Path: Last Run: 1, Total: 1
+Last Successful Execution Date: 2026-06-16 21:28:35 CEST
+```
+
+This validates the RC DEBUG to scheduled Network Path execution path locally. It does not by itself prove product UI visibility in staging; that requires checking the backend/UI after payload ingestion.
+
+### Troubleshooting Notes
+
+- `dial unix .../run/sysprobe.sock: connect: no such file or directory`: system-probe is not running or did not create the socket.
+- `listen unix .../run/sysprobe.sock: bind: no such file or directory`: create the local runtime directory with `mkdir -p run run/ipc` before starting system-probe.
+- `Permission denied` or `failed to create raw socket: operation not permitted`: restart system-probe with `sudo`.
+- Initial system-probe `Registering with Core Agent ... connection refused` messages are expected if system-probe starts before the Agent. It registers once the Agent gRPC server is available.
+- To remove all tests from a DEBUG config without deleting the RC object, patch contents to `{"poc":"network_path_scheduled_tests","type":"scheduled","configs":[]}`.
 
 ## POC Scope
 

--- a/pkg/config/remote/data/product.go
+++ b/pkg/config/remote/data/product.go
@@ -9,6 +9,8 @@ package data
 type Product string
 
 const (
+	// ProductDebug is the staging-only debug product used for internal POCs.
+	ProductDebug Product = "DEBUG"
 	// ProductAPMSampling is the apm sampling product
 	ProductAPMSampling Product = "APM_SAMPLING"
 	// ProductCWSDD is the cloud workload security product

--- a/pkg/remoteconfig/state/products.go
+++ b/pkg/remoteconfig/state/products.go
@@ -6,6 +6,7 @@
 package state
 
 var validProducts = map[string]struct{}{
+	ProductDebug:                        {},
 	ProductInstallerConfig:              {},
 	ProductUpdaterCatalogDD:             {},
 	ProductUpdaterAgent:                 {},
@@ -50,6 +51,8 @@ var validProducts = map[string]struct{}{
 }
 
 const (
+	// ProductDebug is the staging-only debug product used for internal POCs
+	ProductDebug = "DEBUG"
 	// ProductInstallerConfig is the product used to receive the installer configuration
 	ProductInstallerConfig = "INSTALLER_CONFIG"
 	// ProductUpdaterCatalogDD is the product used to receive the package catalog from datadog


### PR DESCRIPTION
### What does this PR do?

Adds a Network Path Remote Config DEBUG POC listener/provider in the Agent. Marked DEBUG configs with `poc: "network_path_scheduled_tests"` and `type: "scheduled"` are validated, translated into ordinary `network_path` integration instances, and reconciled through autodiscovery.

The POC also adds DEBUG as a known RC product, wires the provider into Agent startup whenever Remote Config is enabled, adds unit coverage for parsing/validation/cache/apply-status behavior, and documents the staging validation flow in `netpath-rc-poc.md`.

### Motivation

Prove the Scheduled Tests part of the Network Path RC RFC without building a new scheduler or production RC product yet. The Agent should be able to receive scheduled test definitions through RC, schedule them without restart, and emit normal Network Path scheduled-test payloads.

### Describe how you validated your changes

- `GOPROXY=https://proxy.golang.org,direct GOSUMDB=sum.golang.org dda inv test --targets=./comp/core/autodiscovery/providers`
- `GOPROXY=https://proxy.golang.org,direct GOSUMDB=sum.golang.org dda inv test --targets=./pkg/remoteconfig/state`
- `GOPROXY=https://proxy.golang.org,direct GOSUMDB=sum.golang.org dda inv test --targets=./cmd/agent/subcommands/run`

### Additional Notes

This is intentionally scoped to Scheduled Tests on the staging-only `DEBUG` product. Dynamic Tests, production `NETWORK_PATH` product registration/schema, UI/API work, custom duplicate detection, and automated staging RC E2E tests are out of scope for this POC. Invalid marked updates report apply errors and keep the last valid scheduled config for that RC path active.