### PR TITLE
fix(cws-btfhub-sync): add workflows:write for non-main target branches

### DIFF
--- a/.github/chainguard/self.cws-btfhub-sync.create-pr.sts.yaml
+++ b/.github/chainguard/self.cws-btfhub-sync.create-pr.sts.yaml
@@ -12,3 +12,6 @@ claim_pattern:
 permissions:
   contents: write
   pull_requests: write
+  # Required when targeting a non-main branch: the new PR branch lags main under
+  # .github/workflows, which GitHub refuses to create without this (see #49532).
+  workflows: write


### PR DESCRIPTION
### What does this PR do?
Adds `workflows: write` to the `cws-btfhub-sync` create-pr trust policy.

### Motivation
When the workflow targets a non-main branch, the generated PR branch can lag behind `main` under `.github/workflows`, and GitHub refuses to create the ref without `workflows: write` (example: https://github.com/DataDog/datadog-agent/actions/runs/27552374474/job/81465028766)

Same problem and fix as #49532 for the `backport-pr` workflow.

### Describe how you validated your changes

### Additional Notes

Folllow up of #49245