### PR TITLE
chore(tidy): run write_agent_payload_version in dda inv tidy

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -393,6 +393,8 @@ def _bazel_tidy(ctx, verbose: bool):
     bazel(ctx, "mod", "tidy")
     # 5. deps/go.MODULE.bazel + /BUILD.bazel + **/*.go + **/go.mod -> **/BUILD.bazel (infer build rules from Go source)
     bazel(ctx, "run", "//:gazelle")
+    # 6. regenerate agent payload version file from go.mod
+    bazel(ctx, "run", "//tasks:write_agent_payload_version")
 
 
 @task(autoprint=True)


### PR DESCRIPTION
### What does this PR do?
Adds `bazel run //tasks:write_agent_payload_version` as a final step in `_bazel_tidy`, so that `dda inv tidy` regenerates the agent payload version file automatically.

### Motivation
After running `dda inv tidy`, the agent payload version file could be left out of sync with `go.mod`. Running the bazel target as part of tidy keeps it up to date without a separate manual step.

### Describe how you validated your changes
Verified the function reads correctly and the new step is appended after gazelle.

### Additional Notes
This change only affects the `_bazel_tidy` path (when `bazel` is available on `PATH`). The `_go_only_tidy` fallback is unchanged.