### PR TITLE
kmt: add Amazon Linux 2023 w/ kernel 6.12

### DIFF
--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -49,6 +49,14 @@
       "image": "amzn2023-amd64-2023.qcow2.xz",
       "image_version": "20251015_301103a6"
     },
+    "amazon_2023_6.12": {
+      "os_name": "Amazon Linux",
+      "os_id": "amzn",
+      "kernel": "6.12.30-1.amzn2023",
+      "os_version": "2023",
+      "image": "amzn2023-amd64-6.12.qcow2.xz",
+      "image_version": "20251015_301103a6"
+    },
     "centos_7.9": {
       "os_name": "CentOS Linux",
       "os_id": "centos",
@@ -436,6 +444,14 @@
       "kernel": "6.1.119-129.201.amzn2023",
       "os_version": "2023",
       "image": "amzn2023-arm64-2023.qcow2.xz",
+      "image_version": "20251015_301103a6"
+    },
+    "amazon_2023_6.12": {
+      "os_name": "Amazon Linux",
+      "os_id": "amzn",
+      "kernel": "6.12.30-1.amzn2023",
+      "os_version": "2023",
+      "image": "amzn2023-arm64-6.12.qcow2.xz",
       "image_version": "20251015_301103a6"
     },
     "ubuntu_18.04": {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"29131c5c-6267-40ce-a5cd-0b108291c232","source":"chat","resourceId":"1802843f-e34d-4636-83b9-24b82685bc42","workflowId":"9f89ce17-fd85-421d-84f5-6a04e3598be8","codeChangeId":"9f89ce17-fd85-421d-84f5-6a04e3598be8","sourceType":"chat"} -->
### What does this PR do?

Adds an Amazon Linux 2023 image entry running the `kernel-6.12` package (`amazon_2023_6.12`) to the available KMT platforms for both `x86_64` and `arm64`. The existing `amazon_2023` entry continues to track AL2023 with the default 6.1 kernel.

### Motivation

AL2023 ships with kernel 6.1 by default, but also offers an LTS `kernel-6.12` package. Adding it to KMT lets teams debug AL2023-on-6.12 specific behavior locally before wiring it into the CI matrix, mirroring the pattern used for recent additions like Ubuntu 26.04 (#52044).

### Describe how you validated your changes

- Validated `test/new-e2e/system-probe/config/platforms.json` is still valid JSON and that both architectures expose the new `amazon_2023_6.12` entry alongside `amazon_2023`.
- Followed the existing AL2 multi-kernel naming convention (kernel version suffix in image filename: `amzn2023-{amd64,arm64}-6.12.qcow2.xz`).

### Additional Notes

- This change only adds the platform definition — it is intentionally not yet referenced from `.gitlab/test/kernel_matrix_testing/{system_probe,security_agent}.yml` so teams can debug first before CI adoption (same pattern as #52044).
- The `kernel` and `image_version` fields use placeholder values reflecting the AL2023 kernel-6.12 package and the most recent rootfs version; these should be updated once the matching `amzn2023-{amd64,arm64}-6.12.qcow2.xz` rootfs is built and uploaded to the KMT S3 bucket.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/1802843f-e34d-4636-83b9-24b82685bc42)

Comment @datadog to request changes