### PR TITLE
fix(network/encoding): use builder API in TestKafkaSerializationWithLocalhostTraffic

### DIFF
--- a/pkg/network/encoding/encoding_linux_test.go
+++ b/pkg/network/encoding/encoding_linux_test.go
@@ -8,6 +8,7 @@
 package encoding
 
 import (
+	"bytes"
 	"fmt"
 	"slices"
 	"testing"
@@ -257,23 +258,23 @@ func TestKafkaSerializationWithLocalhostTraffic(t *testing.T) {
 		},
 	}
 
-	kafkaOut := &model.DataStreamsAggregations{
-		KafkaAggregations: []*model.KafkaAggregation{
-			{
-				Header: &model.KafkaRequestHeader{
-					RequestType:    kafka.FetchAPIKey,
-					RequestVersion: apiVersion2,
-				},
-				Topic: topicName,
-				StatsByErrorCode: map[int32]*model.KafkaStats{
-					0: {Count: 10, FirstLatencySample: 5},
-				},
-			},
-		},
-	}
-
-	kafkaOutBlob, err := proto.Marshal(kafkaOut)
-	require.NoError(t, err)
+	var kafkaOutBuf bytes.Buffer
+	kafkaAggBuilder := model.NewDataStreamsAggregationsBuilder(&kafkaOutBuf)
+	kafkaAggBuilder.AddKafkaAggregations(func(agg *model.KafkaAggregationBuilder) {
+		agg.SetHeader(func(h *model.KafkaRequestHeaderBuilder) {
+			h.SetRequest_type(uint32(kafka.FetchAPIKey))
+			h.SetRequest_version(uint32(apiVersion2))
+		})
+		agg.SetTopic(topicName)
+		agg.AddStatsByErrorCode(func(e *model.KafkaAggregation_StatsByErrorCodeEntryBuilder) {
+			e.SetKey(0)
+			e.SetValue(func(v *model.KafkaStatsBuilder) {
+				v.SetCount(10)
+				v.SetFirstLatencySample(5)
+			})
+		})
+	})
+	kafkaOutBlob := kafkaOutBuf.Bytes()
 
 	out := &model.Connections{
 		Conns: []*model.Connection{


### PR DESCRIPTION
### What does this PR do?

Fixes `TestKafkaSerializationWithLocalhostTraffic` failing on KMT (#incident-56277):
```
    encoding_linux_test.go:311: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/pkg/network/encoding/encoding_linux_test.go:311
        	Error:      	Not equal: 
        	            	expected: &process.Connections{Conns:[]*process.Connection{(*process.Connection)(0x41f6ed65ba0), (*process.Connection)(0x41f6ed65d40)}, Dns:map[string]*process.DNSEntry(nil), ConnTelemetry:(*process.ConnectionsTelemetry)(nil), Domains:[]string(nil), Routes:[]*process.Route(nil), CompilationTelemetryByAsset:map[string]*process.RuntimeCompilationTelemetry(nil), AgentConfiguration:(*process.AgentConfiguration)(0x41f6edcb538), Tags:[]string(nil), ConnTelemetryMap:map[string]int64(nil), KernelHeaderFetchResult:0, CORETelemetryByAsset:map[string]process.COREResult(nil), PrebuiltEBPFAssets:[]string(nil), ResolvConfs:[]string(nil)}
        	            	actual  : &process.Connections{Conns:[]*process.Connection{(*process.Connection)(0x41f6ed6e340), (*process.Connection)(0x41f6ed6e4e0)}, Dns:map[string]*process.DNSEntry(nil), ConnTelemetry:(*process.ConnectionsTelemetry)(nil), Domains:[]string(nil), Routes:[]*process.Route(nil), CompilationTelemetryByAsset:map[string]*process.RuntimeCompilationTelemetry(nil), AgentConfiguration:(*process.AgentConfiguration)(0x41f6edcb609), Tags:[]string(nil), ConnTelemetryMap:map[string]int64(nil), KernelHeaderFetchResult:0, CORETelemetryByAsset:map[string]process.COREResult(nil), PrebuiltEBPFAssets:[]string(nil), ResolvConfs:[]string(nil)}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -52,6 +52,6 @@
        	            	    StateIndex: (uint32) 0,
        	            	-   DataStreamsAggregations: ([]uint8) (len=36) {
        	            	-    00000000  1a 22 0a 04 08 01 10 01  12 09 54 6f 70 69 63 4e  |."........TopicN|
        	            	-    00000010  61 6d 65 22 0f 08 00 12  0b 08 0a 19 00 00 00 00  |ame"............|
        	            	-    00000020  00 00 14 40                                       |...@|
        	            	+   DataStreamsAggregations: ([]uint8) (len=34) {
        	            	+    00000000  1a 20 0a 04 08 01 10 01  12 09 54 6f 70 69 63 4e  |. ........TopicN|
        	            	+    00000010  61 6d 65 22 0d 12 0b 08  0a 19 00 00 00 00 00 00  |ame"............|
        	            	+    00000020  14 40                                             |.@|
        	            	    },
        	            	@@ -123,6 +123,6 @@
        	            	    StateIndex: (uint32) 0,
        	            	-   DataStreamsAggregations: ([]uint8) (len=36) {
        	            	-    00000000  1a 22 0a 04 08 01 10 01  12 09 54 6f 70 69 63 4e  |."........TopicN|
        	            	-    00000010  61 6d 65 22 0f 08 00 12  0b 08 0a 19 00 00 00 00  |ame"............|
        	            	-    00000020  00 00 14 40                                       |...@|
        	            	+   DataStreamsAggregations: ([]uint8) (len=34) {
        	            	+    00000000  1a 20 0a 04 08 01 10 01  12 09 54 6f 70 69 63 4e  |. ........TopicN|
        	            	+    00000010  61 6d 65 22 0d 12 0b 08  0a 19 00 00 00 00 00 00  |ame"............|
        	            	+    00000020  14 40                                             |.@|
        	            	    },
        	Test:       	TestKafkaSerializationWithLocalhostTraffic
```
([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1775483594#L2339))

=> Replace the `proto.Marshal` approach for building the expected `DataStreamsAggregations` blob with the protoc-generated `DataStreamsAggregationsBuilder` API.

### Motivation

`agent-payload` v5.0.201 added an early-return in `SetKey` when the value is 0, honoring proto3's default behavior (omit zero-value fields). The test was constructing the expected blob via `proto.Marshal` which always emits zero keys regardless — so the raw-byte comparison failed even though both blobs decode identically.

Using `proto.Marshal` directly on a manually-constructed struct is fragile ("garbage in → garbage out"). The builder is protoc-generated and knows the correct serialization semantics, matching what the production code produces.

### Describe how you validated your changes

Pre-push hooks: go-mod-tidy, go-test, go-linter all passed locally.

The fix aligns the expected blob generation with the same builder path used by production serialization, so the raw-byte comparison is now consistent.

### Additional Notes

Related [#incident-56277](https://dd.enterprise.slack.com/archives/C0BB26X2WTW) — `kmt_run_sysprobe_tests_x64` broken on main.
There is a remaining `proto.Marshal` call in the same file for the HTTP/2 test (line 109) which is out of scope for this fix:
- #52343.