### PR TITLE
Stream partial SNMP device scan results

### DIFF
--- a/comp/snmpscan/impl/BUILD.bazel
+++ b/comp/snmpscan/impl/BUILD.bazel
@@ -45,6 +45,7 @@ dd_agent_go_test(
         "//comp/forwarder/eventplatform/def",
         "//comp/forwarder/eventplatform/mock",
         "//comp/serializer/logscompression/fx-mock",
+        "//pkg/networkdevice/metadata",
         "//pkg/snmp/gosnmplib",
         "//pkg/util/fxutil",
         "@com_github_gosnmp_gosnmp//:gosnmp",

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -25,6 +25,10 @@ import (
 // during a device scan when none is configured.
 const defaultBulkMaxRepetitions = 20
 
+// defaultFlushInterval reports partial scan results at least this often, so
+// slow or large devices surface data before the whole scan completes.
+const defaultFlushInterval = 15 * time.Second
+
 func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *snmpparse.SNMPConfig, namespace string, scanParams snmpscan.ScanParams) error {
 	// Establish connection
 	snmp, err := snmpparse.NewSNMP(connParams, s.log)
@@ -74,9 +78,10 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 	if !useBulk {
 		s.log.Infof("device %s is SNMPv1, using GetNext for the scan (GetBulk unsupported)", deviceID)
 	}
-
+	scanStart := time.Now()
 	err = s.runDeviceScan(ctx, snmp, namespace, deviceID, useBulk,
-		scanParams.CallInterval, scanParams.MaxCallCount, defaultBulkMaxRepetitions)
+		scanParams.CallInterval, scanParams.MaxCallCount, defaultBulkMaxRepetitions,
+		metadata.PayloadMetadataBatchSize, defaultFlushInterval)
 	if err != nil {
 		errs := []error{err}
 
@@ -95,6 +100,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 		}
 		return fmt.Errorf("unable to perform device scan: %w", errors.Join(errs...))
 	}
+	s.log.Infof("device scan for %s completed in %s", deviceID, time.Since(scanStart))
 	// Send a completed status if the scan was successful
 	completedStatusPayload := metadata.NetworkDevicesMetadata{
 		DeviceScanStatus: &metadata.ScanStatusMetadata{
@@ -120,39 +126,110 @@ func (s snmpScannerImpl) runDeviceScan(
 	callInterval time.Duration,
 	maxCallCount int,
 	bulkMaxRep int,
+	flushEveryNOIDs int,
+	flushInterval time.Duration,
 ) error {
-	// execute the scan
-	var (
-		pdus []*gosnmp.SnmpPDU
-		err  error
-	)
-	if useBulk {
-		pdus, err = gatherPDUsWithBulk(ctx, snmpConnection, deviceID, callInterval, maxCallCount, bulkMaxRep)
-	} else {
-		pdus, err = gatherPDUs(ctx, snmpConnection, callInterval, maxCallCount)
-	}
-	if err != nil {
-		return err
-	}
+	flusher := newOIDFlusher(deviceNamespace, flushEveryNOIDs, flushInterval, s.sendPayload)
 
-	var deviceOids []*metadata.DeviceOID
-	for _, pdu := range pdus {
+	// Always report whatever has been buffered, even when the walk errors out
+	// partway through, so partial results collected before the failure are not
+	// lost.
+	defer func() {
+		if err := flusher.flush(); err != nil {
+			s.log.Warnf("unable to flush remaining scan results for device %s: %v", deviceID, err)
+		}
+	}()
+
+	// emit is called for every OID the walk keeps, and reports partial results
+	// as thresholds are reached so results stream out before the scan finishes.
+	emit := func(pdu *gosnmp.SnmpPDU) error {
 		record, err := metadata.DeviceOIDFromPDU(deviceID, pdu)
 		if err != nil {
 			s.log.Warnf("PDU parsing error: %v", err)
-			continue
+			return nil
 		}
-		deviceOids = append(deviceOids, record)
+		// A failed partial-result send should not abort an otherwise healthy
+		// scan; log it and keep walking so the rest of the device is still
+		// collected.
+		if err := flusher.add(record); err != nil {
+			s.log.Warnf("unable to send partial scan results for device %s: %v", deviceID, err)
+		}
+		return nil
 	}
 
-	metadataPayloads := metadata.BatchDeviceScan(deviceNamespace, time.Now(), metadata.PayloadMetadataBatchSize, deviceOids)
-	for _, payload := range metadataPayloads {
-		err := s.sendPayload(payload)
-		if err != nil {
+	// tick is called once per GetBulk round-trip so the flush interval is
+	// checked even when a batch yields no new column to emit. A failed send
+	// is logged and swallowed, same as emit, so it doesn't abort the walk.
+	tick := func() error {
+		if err := flusher.checkInterval(); err != nil {
+			s.log.Warnf("unable to send partial scan results for device %s: %v", deviceID, err)
+		}
+		return nil
+	}
+
+	if useBulk {
+		return gatherPDUsWithBulk(ctx, snmpConnection, deviceID, emit, tick, callInterval, maxCallCount, bulkMaxRep)
+	}
+	return gatherPDUs(ctx, snmpConnection, emit, callInterval, maxCallCount)
+}
+
+// oidFlusher accumulates scanned OIDs and reports them as partial scan results
+// once a threshold (count or elapsed time) is reached, so large devices surface
+// results before the whole scan completes.
+type oidFlusher struct {
+	namespace       string
+	flushEveryNOIDs int
+	flushInterval   time.Duration
+	send            func(metadata.NetworkDevicesMetadata) error
+
+	oids      []*metadata.DeviceOID
+	lastFlush time.Time
+}
+
+func newOIDFlusher(namespace string, flushEveryNOIDs int, flushInterval time.Duration, send func(metadata.NetworkDevicesMetadata) error) *oidFlusher {
+	return &oidFlusher{
+		namespace:       namespace,
+		flushEveryNOIDs: flushEveryNOIDs,
+		flushInterval:   flushInterval,
+		send:            send,
+		lastFlush:       time.Now(),
+	}
+}
+
+// add buffers a record and flushes when a threshold is reached.
+func (f *oidFlusher) add(record *metadata.DeviceOID) error {
+	f.oids = append(f.oids, record)
+	if len(f.oids) >= f.flushEveryNOIDs ||
+		(f.flushInterval > 0 && time.Since(f.lastFlush) >= f.flushInterval) {
+		return f.flush()
+	}
+	return nil
+}
+
+// checkInterval flushes any buffered OIDs once the flush interval has
+// elapsed, independent of add being called. Column filtering during a bulk
+// walk can otherwise go minutes between add calls on large tables with few
+// unique columns, which would defeat time-based streaming.
+func (f *oidFlusher) checkInterval() error {
+	if f.flushInterval > 0 && time.Since(f.lastFlush) >= f.flushInterval {
+		return f.flush()
+	}
+	return nil
+}
+
+// flush reports the buffered OIDs and resets the buffer.
+func (f *oidFlusher) flush() error {
+	if len(f.oids) == 0 {
+		return nil
+	}
+	payloads := metadata.BatchDeviceScan(f.namespace, time.Now(), metadata.PayloadMetadataBatchSize, f.oids)
+	for _, payload := range payloads {
+		if err := f.send(payload); err != nil {
 			return err
 		}
 	}
-
+	f.oids = nil
+	f.lastFlush = time.Now()
 	return nil
 }
 
@@ -163,22 +240,19 @@ func (s snmpScannerImpl) runDeviceScan(
 // OIDs that may not exist on the device and can cause infinite loops or crash
 // some devices. It is kept only as the SNMPv1 fallback, since v1 has no
 // GetBulk. Everything else uses gatherPDUsWithBulk.
-func gatherPDUs(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval time.Duration, maxCallCount int) ([]*gosnmp.SnmpPDU, error) {
-	var pdus []*gosnmp.SnmpPDU
-	err := gosnmplib.ConditionalWalk(
+func gatherPDUs(ctx context.Context, snmp *gosnmp.GoSNMP, emit func(*gosnmp.SnmpPDU) error, callInterval time.Duration, maxCallCount int) error {
+	return gosnmplib.ConditionalWalk(
 		ctx,
 		snmp,
 		"",
 		callInterval,
 		maxCallCount,
 		func(dataUnit gosnmp.SnmpPDU) (string, error) {
-			pdus = append(pdus, &dataUnit)
+			if err := emit(&dataUnit); err != nil {
+				return "", err
+			}
 			return gosnmplib.SkipOIDRowsNaive(dataUnit.Name), nil
 		})
-	if err != nil {
-		return nil, err
-	}
-	return pdus, nil
 }
 
 // bulkGetter is the GetBulk surface gatherPDUsWithBulk needs. Wrapping it in an
@@ -187,8 +261,8 @@ type bulkGetter interface {
 	GetBulk(oids []string, nonRepeaters uint8, maxRepetitions uint32) (*gosnmp.SnmpPacket, error)
 }
 
-// gatherPDUsWithBulk returns PDUs from the given SNMP device using GetBulk operations.
-// It walks the entire MIB tree but filters results to keep only one row per column.
+// gatherPDUsWithBulk walks the given SNMP device using GetBulk operations,
+// calling emit for each OID it keeps (one row per column).
 //
 // Key safety properties:
 //   - Never sends fabricated OIDs to the device - only OIDs the device has returned
@@ -202,8 +276,8 @@ type bulkGetter interface {
 //
 // Trade-off: May be slower than gatherPDUs for devices with large tables (1000+ rows)
 // because it retrieves all rows before filtering.
-func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, deviceID string, callInterval time.Duration, maxCallCount int, bulkMaxRep int) ([]*gosnmp.SnmpPDU, error) {
-	var result []*gosnmp.SnmpPDU
+func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, deviceID string, emit func(*gosnmp.SnmpPDU) error, tick func() error, callInterval time.Duration, maxCallCount int, bulkMaxRep int) error {
+	emitted := 0
 	seenColumns := make(map[string]bool)
 
 	// Start from the beginning of the MIB tree.
@@ -214,7 +288,7 @@ func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, deviceID string, c
 	// every OID we have seen.
 	prevInts, err := gosnmplib.OIDToInts(oid)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	requests := 0
 	// Name the optimizer after the device so its Debug logs are attributable
@@ -224,7 +298,7 @@ func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, deviceID string, c
 	for {
 		select {
 		case <-ctx.Done():
-			return result, ctx.Err()
+			return ctx.Err()
 		default:
 		}
 
@@ -234,7 +308,7 @@ func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, deviceID string, c
 
 		requests++
 		if maxCallCount > 0 && requests >= maxCallCount {
-			return result, fmt.Errorf("exceeded maximum request limit (%d)", maxCallCount)
+			return fmt.Errorf("exceeded maximum request limit (%d)", maxCallCount)
 		}
 
 		// Use GetBulk with REAL OIDs only (never fabricated).
@@ -247,17 +321,17 @@ func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, deviceID string, c
 				continue
 			}
 			if err != nil {
-				return result, gosnmplib.NewConnectionError(
+				return gosnmplib.NewConnectionError(
 					fmt.Errorf("GetBulk error at OID %s (max-rep=%d): %w", oid, maxRep, err),
 				)
 			}
-			return result, fmt.Errorf("GetBulk returned SNMP error %s at OID %s (max-rep=%d)", response.Error, oid, maxRep)
+			return fmt.Errorf("GetBulk returned SNMP error %s at OID %s (max-rep=%d)", response.Error, oid, maxRep)
 		}
 		maxRepOpt.OnSuccess()
 
 		if len(response.Variables) == 0 {
 			// No more data.
-			log.Debugf("SNMP scan for device %s completed after %d requests, %d OIDs collected", deviceID, requests, len(result))
+			log.Debugf("SNMP scan for device %s completed after %d requests, %d OIDs collected", deviceID, requests, emitted)
 			break
 		}
 
@@ -268,8 +342,8 @@ func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, deviceID string, c
 			if pdu.Type == gosnmp.EndOfMibView ||
 				pdu.Type == gosnmp.NoSuchObject ||
 				pdu.Type == gosnmp.NoSuchInstance {
-				log.Debugf("SNMP scan for device %s reached end of MIB view at OID %s after %d requests, %d OIDs collected", deviceID, lastOID, requests, len(result))
-				return result, nil
+				log.Debugf("SNMP scan for device %s reached end of MIB view at OID %s after %d requests, %d OIDs collected", deviceID, lastOID, requests, emitted)
+				return nil
 			}
 
 			// Loop/stuck detection: each returned OID must be strictly after
@@ -277,11 +351,11 @@ func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, deviceID string, c
 			// advancing, so stop.
 			cur, err := gosnmplib.OIDToInts(pdu.Name)
 			if err != nil {
-				return result, err
+				return err
 			}
 			if !gosnmplib.CmpOIDs(cur, prevInts).IsAfter() {
-				log.Debugf("SNMP scan for device %s stopped: OID %s did not advance past %s (after %d requests, %d OIDs collected)", deviceID, pdu.Name, lastOID, requests, len(result))
-				return result, fmt.Errorf("walk stuck: OID %s did not advance past %s", pdu.Name, lastOID)
+				log.Debugf("SNMP scan for device %s stopped: OID %s did not advance past %s (after %d requests, %d OIDs collected)", deviceID, pdu.Name, lastOID, requests, emitted)
+				return fmt.Errorf("walk stuck: OID %s did not advance past %s", pdu.Name, lastOID)
 			}
 			prevInts = cur
 			lastOID = pdu.Name
@@ -291,8 +365,18 @@ func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, deviceID string, c
 			if !seenColumns[columnSig] {
 				seenColumns[columnSig] = true
 				pduCopy := pdu // Copy to avoid aliasing issues.
-				result = append(result, &pduCopy)
+				if err := emit(&pduCopy); err != nil {
+					return err
+				}
+				emitted++
 			}
+		}
+
+		// Check the flush interval once per GetBulk round-trip, independent of
+		// whether this batch yielded a new column, so large tables with few
+		// unique columns still stream on schedule.
+		if err := tick(); err != nil {
+			return err
 		}
 
 		// Use the last OID from the batch as the starting point for the next request.
@@ -300,5 +384,5 @@ func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, deviceID string, c
 		oid = lastOID
 	}
 
-	return result, nil
+	return nil
 }

--- a/comp/snmpscan/impl/devicescan_test.go
+++ b/comp/snmpscan/impl/devicescan_test.go
@@ -12,12 +12,20 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// discardPDU is an emit callback that drops PDUs, for walk tests that only
+// care about request behavior rather than collected results.
+func discardPDU(*gosnmp.SnmpPDU) error { return nil }
+
+// noopTick is a tick callback for walk tests that don't exercise interval flushing.
+func noopTick() error { return nil }
 
 func TestExtractColumnSignatureIntegration(t *testing.T) {
 	// Test that ExtractColumnSignature works correctly for filtering purposes
@@ -81,7 +89,7 @@ func TestGatherPDUsWithBulk_ContextCancellation(t *testing.T) {
 		Version:   gosnmp.Version2c,
 	}
 
-	_, err := gatherPDUsWithBulk(ctx, snmp, "test-device", 0, 0, defaultBulkMaxRepetitions)
+	err := gatherPDUsWithBulk(ctx, snmp, "test-device", discardPDU, noopTick, 0, 0, defaultBulkMaxRepetitions)
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
@@ -130,7 +138,7 @@ func TestGatherPDUsWithBulk_AdaptsMaxRepOnFailure(t *testing.T) {
 		},
 	}
 
-	_, err := gatherPDUsWithBulk(context.Background(), fake, "test-device", 0, 0, 10)
+	err := gatherPDUsWithBulk(context.Background(), fake, "test-device", discardPDU, noopTick, 0, 0, 10)
 	require.NoError(t, err)
 
 	require.Len(t, fake.calls, 2)
@@ -155,7 +163,7 @@ func TestGatherPDUsWithBulk_GivesUpWhenMaxRepCannotShrink(t *testing.T) {
 		},
 	}
 
-	_, err := gatherPDUsWithBulk(context.Background(), fake, "test-device", 0, 0, 4)
+	err := gatherPDUsWithBulk(context.Background(), fake, "test-device", discardPDU, noopTick, 0, 0, 4)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "request timeout")
 	// 4 → 2 → 1 → still 1 (OnFailure returns false): 3 calls.
@@ -205,6 +213,65 @@ func TestColumnFilteringLogic(t *testing.T) {
 	assert.False(t, keptOIDs["1.3.6.1.2.1.2.2.1.3.3"], "Second ifType row should be filtered")
 }
 
+// collectOIDs sums the DeviceOIDs across the payloads a flusher sent.
+func collectOIDs(payloads []metadata.NetworkDevicesMetadata) int {
+	total := 0
+	for _, p := range payloads {
+		total += len(p.DeviceOIDs)
+	}
+	return total
+}
+
+func TestOIDFlusherCountBased(t *testing.T) {
+	var sent []metadata.NetworkDevicesMetadata
+	send := func(p metadata.NetworkDevicesMetadata) error {
+		sent = append(sent, p)
+		return nil
+	}
+
+	// flushInterval 0 so only the count threshold fires.
+	flusher := newOIDFlusher("default", 100, 0, send)
+	for i := 0; i < 250; i++ {
+		assert.NoError(t, flusher.add(&metadata.DeviceOID{OID: "1.2.3"}))
+	}
+	// Two flushes happened mid-walk (at 100 and 200), so results stream out
+	// before the scan finishes.
+	assert.Len(t, sent, 2)
+	assert.NoError(t, flusher.flush())
+	// The final flush reports the remaining 50 OIDs; nothing is dropped.
+	assert.Len(t, sent, 3)
+	assert.Equal(t, 250, collectOIDs(sent))
+}
+
+func TestOIDFlusherEndOnly(t *testing.T) {
+	var sent []metadata.NetworkDevicesMetadata
+	send := func(p metadata.NetworkDevicesMetadata) error {
+		sent = append(sent, p)
+		return nil
+	}
+
+	// A count threshold larger than the OID count and no time threshold means
+	// no mid-walk flush.
+	flusher := newOIDFlusher("default", 1000, 0, send)
+	for i := 0; i < 50; i++ {
+		assert.NoError(t, flusher.add(&metadata.DeviceOID{OID: "1.2.3"}))
+	}
+	assert.Empty(t, sent)
+	assert.NoError(t, flusher.flush())
+	assert.Len(t, sent, 1)
+	assert.Equal(t, 50, collectOIDs(sent))
+}
+
+func TestOIDFlusherEmptyFlushNoOp(t *testing.T) {
+	called := false
+	flusher := newOIDFlusher("default", 100, 0, func(metadata.NetworkDevicesMetadata) error {
+		called = true
+		return nil
+	})
+	assert.NoError(t, flusher.flush())
+	assert.False(t, called)
+}
+
 // dataPacket returns a successful packet carrying the given OIDs as octet strings.
 func dataPacket(oids ...string) *gosnmp.SnmpPacket {
 	vars := make([]gosnmp.SnmpPDU, 0, len(oids))
@@ -226,9 +293,34 @@ func TestGatherPDUsWithBulk_StopsOnNonAdvancingOID(t *testing.T) {
 		},
 	}
 
-	_, err := gatherPDUsWithBulk(context.Background(), fake, "test-device", 0, 0, defaultBulkMaxRepetitions)
+	err := gatherPDUsWithBulk(context.Background(), fake, "test-device", discardPDU, noopTick, 0, 0, defaultBulkMaxRepetitions)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "did not advance")
+}
+
+func TestGatherPDUsWithBulk_TicksOncePerRoundTrip(t *testing.T) {
+	// tick must fire once per GetBulk round-trip regardless of whether emit
+	// was called, so time-based flushing keeps working on tables where a
+	// batch yields no new column (e.g. repeated column filtering).
+	fake := &fakeBulkGetter{
+		responses: []bulkResponse{
+			{packet: dataPacket("1.3.6.1.2.1.1.1.0")},
+			{packet: dataPacket("1.3.6.1.2.1.1.2.0")},
+			{packet: endOfMibPacket()},
+		},
+	}
+
+	ticks := 0
+	tick := func() error {
+		ticks++
+		return nil
+	}
+
+	err := gatherPDUsWithBulk(context.Background(), fake, "test-device", discardPDU, tick, 0, 0, defaultBulkMaxRepetitions)
+	require.NoError(t, err)
+	// The end-of-MIB response returns immediately, before reaching tick, so
+	// only the two data-yielding round-trips tick.
+	assert.Equal(t, 2, ticks)
 }
 
 func TestGatherPDUsWithBulk_TreatsSNMPErrorAsFailure(t *testing.T) {
@@ -241,7 +333,7 @@ func TestGatherPDUsWithBulk_TreatsSNMPErrorAsFailure(t *testing.T) {
 		},
 	}
 
-	_, err := gatherPDUsWithBulk(context.Background(), fake, "test-device", 0, 0, 10)
+	err := gatherPDUsWithBulk(context.Background(), fake, "test-device", discardPDU, noopTick, 0, 0, 10)
 	require.NoError(t, err)
 	require.Len(t, fake.calls, 2)
 	assert.Equal(t, uint32(10), fake.calls[0].maxRep)

--- a/releasenotes/notes/snmp-scan-partial-results-8b2d4e1f6a9c3e7d.yaml
+++ b/releasenotes/notes/snmp-scan-partial-results-8b2d4e1f6a9c3e7d.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    SNMP device scans now report results incrementally while the scan is running
+    instead of only after it completes, so large devices surface OIDs sooner.


### PR DESCRIPTION
Reports device scan results incrementally during the walk instead of only at the end, so large devices surface results before the scan completes.

- Both walk paths (GetBulk and the legacy v1 GetNext) now emit each kept OID through a callback into an oidFlusher, rather than accumulating and sending at the end.
- Flushes every 100 OIDs or every 15s, whichever comes first.
- Adds FlushEveryNOIDs and FlushInterval to ScanParams (0 = use the defaults).

Stacked on #52318.