### PR TITLE
[cluster-agent] Log Leadership Warmup State of Nodes Reporting

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -318,6 +318,24 @@ func (d *dispatcher) scanUnscheduledChecks() {
 	}
 }
 
+// logWarmupSummary logs the nodes seen by the leader at the end of the warmup phase.
+func (d *dispatcher) logWarmupSummary() {
+	d.store.RLock()
+	defer d.store.RUnlock()
+
+	clcCount, nodeAgentCount := 0, 0
+	for _, node := range d.store.nodes {
+		switch node.nodetype {
+		case cctypes.NodeTypeCLCRunner:
+			clcCount++
+		case cctypes.NodeTypeNodeAgent:
+			nodeAgentCount++
+		}
+	}
+	log.Infof("Warmup summary: %d nodes registered (%d CLC runners, %d node agents)",
+		len(d.store.nodes), clcCount, nodeAgentCount)
+}
+
 // UpdateAdvancedDispatchingMode checks if any node agents are in the pool
 // and disables advanced dispatching if found
 func (d *dispatcher) UpdateAdvancedDispatchingMode() {

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -325,7 +325,10 @@ func (d *dispatcher) logWarmupSummary() {
 
 	clcCount, nodeAgentCount := 0, 0
 	for _, node := range d.store.nodes {
-		switch node.nodetype {
+		node.RLock()
+		nodetype := node.nodetype
+		node.RUnlock()
+		switch nodetype {
 		case cctypes.NodeTypeCLCRunner:
 			clcCount++
 		case cctypes.NodeTypeNodeAgent:
@@ -349,7 +352,10 @@ func (d *dispatcher) UpdateAdvancedDispatchingMode() {
 	// Check if any node agents are in the pool
 	hasNodeAgent := false
 	for _, node := range d.store.nodes {
-		if node.nodetype == cctypes.NodeTypeNodeAgent {
+		node.RLock()
+		nodetype := node.nodetype
+		node.RUnlock()
+		if nodetype == cctypes.NodeTypeNodeAgent {
 			hasNodeAgent = true
 			break
 		}

--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -142,6 +142,7 @@ func (h *Handler) Run(ctx context.Context) {
 
 		// Run discovery and dispatching
 		log.Info("Warmup phase finished, starting to serve configurations")
+		h.dispatcher.logWarmupSummary()
 
 		// Initial mode determination after warmup
 		h.dispatcher.UpdateAdvancedDispatchingMode()

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -67,7 +67,10 @@ func (s *clusterStore) CountNodeTypes() (clcRunnerCount, nodeAgentCount int) {
 		if node == nil {
 			continue
 		}
-		switch node.nodetype {
+		node.RLock()
+		nodetype := node.nodetype
+		node.RUnlock()
+		switch nodetype {
 		case types.NodeTypeCLCRunner:
 			clcRunnerCount++
 		case types.NodeTypeNodeAgent:


### PR DESCRIPTION
### What does this PR do?

Logs leader state of the cluster before dispatching runs.

### Motivation

While we do have the `nodes_reporting` telemetry, this is only reported every 15 seconds. I want to know the exact number of cluster-check-runners the cluster-agent agent leader has detected for check re-scheduling when it finishes the warmup

### Describe how you validated your changes

Unit tests and CI
