### PR TITLE
fix(etwtracer): forward only DotNETRuntime events matching enabled keywords

### DIFF
--- a/comp/trace/etwtracer/impl/etwtracer.go
+++ b/comp/trace/etwtracer/impl/etwtracer.go
@@ -114,6 +114,11 @@ const (
 	//revive:enable:var-naming
 )
 
+// dotNetRuntimeKeywords is the set of Microsoft-Windows-DotNETRuntime keywords we
+// enable and forward: GCKeyword (0x1) | ContentionKeyword (0x4000) | StackKeyword
+// (0x40000000). These match the keywords the dd-trace-dotnet profiler consumes.
+const dotNetRuntimeKeywords uint64 = 0x40004001
+
 type win32MessageBytePipe interface {
 	CloseWrite() error
 }
@@ -355,6 +360,14 @@ func (a *etwtracerimpl) doTrace() {
 			return
 		}
 
+		// ETW delivers events whose keyword is 0 even when a MatchAnyKeyword mask
+		// is set, so the realtime session receives some events outside the
+		// keywords we requested. The profiler only consumes events matching those
+		// keywords, so forward only matching events.
+		if e.EventHeader.EventDescriptor.Keyword&dotNetRuntimeKeywords == 0 {
+			return
+		}
+
 		payloadBuffer.Reset()
 
 		/*
@@ -487,7 +500,7 @@ func (a *etwtracerimpl) reconfigureProvider() error {
 
 	a.session.ConfigureProvider(a.dotNetRuntimeProviderGUID, func(cfg *etw.ProviderConfiguration) {
 		cfg.TraceLevel = etw.TRACE_LEVEL_VERBOSE
-		cfg.MatchAnyKeyword = 0x40004001
+		cfg.MatchAnyKeyword = dotNetRuntimeKeywords
 		cfg.PIDs = pidsList
 	})
 

--- a/releasenotes/notes/apm-etwtracer-keyword-scoping-48be5b3b0ca3d316.yaml
+++ b/releasenotes/notes/apm-etwtracer-keyword-scoping-48be5b3b0ca3d316.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    APM : On Windows, the .NET ETW tracer now forwards only the .NET runtime
+    events that match its configured keywords, instead of all events delivered
+    by the tracing session.


### PR DESCRIPTION
### What does this PR do?

On Windows, the APM .NET ETW tracer (`comp/trace/etwtracer`) subscribes to the `Microsoft-Windows-DotNETRuntime` provider with a `MatchAnyKeyword` mask and forwards the received events to the registered profiler over its named pipe. ETW additionally delivers events whose own keyword is `0` even when a `MatchAnyKeyword` mask is set, so the realtime session receives some events outside the keyword set the tracer requested.

This change adds a check in the event-forwarding callback so that only events whose keyword intersects the configured mask are forwarded.

### Motivation

The profiler only consumes the events matching the keywords the tracer enables (GC, contention, stack). Forwarding events outside that set is unnecessary, so the tracer now forwards only matching events.

https://datadoghq.atlassian.net/browse/WINA-2836

### Describe how you validated your changes

- Built the trace-agent (`dda inv trace-agent.build`).
- Verified on a Windows host, using a small harness that reproduces the tracer's exact provider configuration, that the events the profiler consumes (GC / contention / stack) are still delivered unchanged while events outside the configured keyword set are dropped.