### PR TITLE
[Backport 7.80.x] Fix trace API test to not bind port 8126 

### DIFF
--- a/pkg/trace/api/api_nix_test.go
+++ b/pkg/trace/api/api_nix_test.go
@@ -96,6 +96,7 @@ func TestUDS(t *testing.T) {
 
 		conf := config.New()
 		conf.Endpoints[0].APIKey = "apikey_2"
+		conf.ReceiverPort = 0 // do not bind production port 8126
 		conf.ReceiverSocket = filepath.Join(dir, "apm.socket")
 
 		r := newTestReceiverFromConfig(conf)


### PR DESCRIPTION
## What does this PR do?
Backport of #52255 to fix CI for DataDog/datadog-agent#51868

## Motivation

## Describe how you validated your changes

## Additional Notes