### PR TITLE
SVLS-8857: dogstatsd/server: flush worker batchers on stop

### DIFF
--- a/comp/dogstatsd/server/impl/BUILD.bazel
+++ b/comp/dogstatsd/server/impl/BUILD.bazel
@@ -96,6 +96,7 @@ dd_agent_go_test(
         "parse_test.go",
         "server_bench_test.go",
         "server_integration_test.go",
+        "server_serverless_flush_test.go",
         "server_test.go",
         "server_util_test.go",
         "server_worker_test.go",

--- a/comp/dogstatsd/server/impl/server.go
+++ b/comp/dogstatsd/server/impl/server.go
@@ -126,6 +126,11 @@ type dsdServer struct {
 	// and pushing them to the aggregator
 	workers []*worker
 
+	// workerWg tracks the worker run loops. stop() waits on it so that every
+	// worker has finished its run loop — including any flush-on-stop of its
+	// batcher — before stop() returns and the demultiplexer is torn down.
+	workerWg sync.WaitGroup
+
 	packetsIn               chan packets.Packets
 	captureChan             chan packets.Packets
 	serverlessFlushChan     chan bool
@@ -518,7 +523,16 @@ func (s *dsdServer) stop(context.Context) error {
 	for _, l := range s.listeners {
 		l.Stop()
 	}
+
 	close(s.stopChan)
+
+	// Wait for every worker run loop to exit before tearing down the
+	// demultiplexer. When dogstatsd_flush_incomplete_buckets is set, each worker
+	// flushes its batcher into the time sampler as it exits (see worker.run), so
+	// waiting here guarantees those samples have reached the sampler before the
+	// demultiplexer's own stop drains and flushes them out. Without the flag the
+	// workers simply return, and this wait is a cheap barrier.
+	s.workerWg.Wait()
 
 	if s.Statistics != nil {
 		s.Statistics.Stop()
@@ -582,6 +596,7 @@ func (s *dsdServer) handleMessages() {
 
 	for i := 0; i < workersCount; i++ {
 		worker := newWorker(s, i, s.wmeta, s.packetsTelemetry, s.stringInternerTelemetry, s.filterList.GetMetricFilterList())
+		s.workerWg.Add(1)
 		go worker.run()
 		s.workers = append(s.workers, worker)
 	}

--- a/comp/dogstatsd/server/impl/server_integration_test.go
+++ b/comp/dogstatsd/server/impl/server_integration_test.go
@@ -144,7 +144,7 @@ func TestUDSConn(t *testing.T) {
 	runConnTest(t, conn, deps)
 
 	s := deps.Server.(*dsdServer)
-	s.Stop()
+	require.NoError(t, s.stop(context.Background()))
 	_, err = net.Dial("unixgram", socketPath)
 	require.Error(t, err, "UDS listener should be closed")
 }

--- a/comp/dogstatsd/server/impl/server_serverless_flush_test.go
+++ b/comp/dogstatsd/server/impl/server_serverless_flush_test.go
@@ -74,6 +74,40 @@ func TestStopFlushesAllWorkersWhenEnabled(t *testing.T) {
 	}
 }
 
+// TestStopDrainsQueuedPacketsWhenEnabled verifies that flush-on-stop also
+// rescues packets still queued in packetsIn but not yet parsed. Stopping the
+// listeners can leave assembled packets in packetsIn, and the random select in
+// worker.run could otherwise let a worker exit on stopChan before parsing them,
+// dropping the metrics. drainAndFlush parses the remaining queue before flushing.
+func TestStopDrainsQueuedPacketsWhenEnabled(t *testing.T) {
+	cfg := make(map[string]interface{})
+	cfg["dogstatsd_port"] = listeners.RandomPortName
+	cfg["dogstatsd_workers_count"] = 1
+	cfg["dogstatsd_flush_incomplete_buckets"] = true
+
+	deps := fulfillDepsWithServerlessConfigOverride(t, cfg)
+	s := deps.Server.(*dsdServer)
+	requireStart(t, s)
+	require.Len(t, s.workers, 1)
+
+	// Stop the run loop first so this goroutine can own packetsIn without racing
+	// the worker, then drive drainAndFlush directly — the exact code path the
+	// stopChan case takes when packets are still queued at stop. stop() leaves
+	// packetsIn open, so we can enqueue afterwards.
+	require.NoError(t, s.stop(context.Background()))
+	requireStopped(t, s)
+
+	w := s.workers[0]
+	s.packetsIn <- genTestPackets([]byte("drain.test.metric:42|g"))
+	w.drainAndFlush()
+
+	assert.Empty(t, s.packetsIn, "drainAndFlush must consume every queued packet before returning")
+
+	samples, _ := deps.Demultiplexer.WaitForNumberOfSamples(1, 0, 2*time.Second)
+	require.Len(t, samples, 1, "the queued packet must be parsed and flushed to the sampler")
+	assert.Equal(t, "drain.test.metric", samples[0].Name)
+}
+
 // TestStopDoesNotFlushWhenDisabled verifies the gate is honored: with
 // dogstatsd_flush_incomplete_buckets unset (the long-running-agent default),
 // stop() must NOT drain worker batchers — workers just exit on stopChan. The

--- a/comp/dogstatsd/server/impl/server_serverless_flush_test.go
+++ b/comp/dogstatsd/server/impl/server_serverless_flush_test.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package serverimpl
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/listeners"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+// TestStopFlushesAllWorkersWhenEnabled verifies the flush-on-stop behavior:
+// when dogstatsd_flush_incomplete_buckets is set, stop() must drain every
+// worker's batched samples into the time sampler before returning. Each worker
+// gets a uniquely-named sample so the assertion verifies EVERY worker drained,
+// not just a total count — a regression where one fast worker double-fires
+// while a busy peer never flushes would match the total but miss one of the
+// unique names. This is the serverless-init production path
+// (newServerlessBatcher) the deleted ServerlessFlush method used to cover.
+func TestStopFlushesAllWorkersWhenEnabled(t *testing.T) {
+	const workerCount = 2
+
+	cfg := make(map[string]interface{})
+	cfg["dogstatsd_port"] = listeners.RandomPortName
+	cfg["dogstatsd_workers_count"] = workerCount
+	cfg["dogstatsd_flush_incomplete_buckets"] = true
+
+	// Serverless-mode helper so workers run newServerlessBatcher — the exact
+	// production code path exercised by serverless-init.
+	deps := fulfillDepsWithServerlessConfigOverride(t, cfg)
+	s := deps.Server.(*dsdServer)
+	requireStart(t, s)
+	require.Len(t, s.workers, workerCount, "expected the configured number of workers")
+
+	// Workers are parked on select with no packetsIn traffic, so direct batcher
+	// writes from this test goroutine are safe. stop() closes stopChan and then
+	// waits on workerWg, so each worker's batcher.flush() (run in its stopChan
+	// case) has completed by the time stop() returns.
+	expectedNames := make(map[string]struct{}, workerCount)
+	for i, w := range s.workers {
+		name := "serverless.flush.test.worker." + strconv.Itoa(i)
+		expectedNames[name] = struct{}{}
+		w.batcher.appendSample(metrics.MetricSample{
+			Name:       name,
+			Value:      float64(i + 1),
+			Mtype:      metrics.GaugeType,
+			SampleRate: 1,
+		})
+	}
+
+	require.NoError(t, s.stop(context.Background()))
+	requireStopped(t, s)
+
+	// Wait for at least workerCount samples, then verify each unique per-worker
+	// name appears — proves every worker's batcher.flush() actually ran.
+	samples, _ := deps.Demultiplexer.WaitForNumberOfSamples(workerCount, 0, 2*time.Second)
+	gotNames := make(map[string]struct{}, len(samples))
+	for _, sample := range samples {
+		gotNames[sample.Name] = struct{}{}
+	}
+	for name := range expectedNames {
+		assert.Contains(t, gotNames, name, "expected sample from each worker — fan-out regression: missing %s", name)
+	}
+}
+
+// TestStopDoesNotFlushWhenDisabled verifies the gate is honored: with
+// dogstatsd_flush_incomplete_buckets unset (the long-running-agent default),
+// stop() must NOT drain worker batchers — workers just exit on stopChan. The
+// batched sample must therefore never reach the sampler.
+func TestStopDoesNotFlushWhenDisabled(t *testing.T) {
+	cfg := make(map[string]interface{})
+	cfg["dogstatsd_port"] = listeners.RandomPortName
+	cfg["dogstatsd_workers_count"] = 1
+	// dogstatsd_flush_incomplete_buckets intentionally left unset (defaults to false).
+
+	deps := fulfillDepsWithServerlessConfigOverride(t, cfg)
+	s := deps.Server.(*dsdServer)
+	requireStart(t, s)
+	require.Len(t, s.workers, 1)
+
+	s.workers[0].batcher.appendSample(metrics.MetricSample{
+		Name:       "serverless.noflush.test",
+		Value:      1,
+		Mtype:      metrics.GaugeType,
+		SampleRate: 1,
+	})
+
+	require.NoError(t, s.stop(context.Background()))
+	requireStopped(t, s)
+
+	// No flush was triggered, so no sample should ever arrive. WaitForNumberOfSamples
+	// returns whatever it collected within the timeout; with the gate off it must
+	// stay empty.
+	samples, _ := deps.Demultiplexer.WaitForNumberOfSamples(1, 0, 500*time.Millisecond)
+	assert.Empty(t, samples, "no samples should reach the sampler when dogstatsd_flush_incomplete_buckets is unset")
+}

--- a/comp/dogstatsd/server/impl/server_util_test.go
+++ b/comp/dogstatsd/server/impl/server_util_test.go
@@ -82,6 +82,17 @@ func fulfillDeps(t testing.TB) serverDeps {
 }
 
 func fulfillDepsWithConfigOverride(t testing.TB, overrides map[string]interface{}) serverDeps {
+	return fulfillDepsWithParamsAndConfigOverride(t, server.Params{Serverless: false}, overrides)
+}
+
+// fulfillDepsWithServerlessConfigOverride builds a serverDeps with the server
+// running in serverless mode (Params{Serverless: true}). This exercises the
+// newServerlessBatcher code path used by serverless-init in production.
+func fulfillDepsWithServerlessConfigOverride(t testing.TB, overrides map[string]interface{}) serverDeps {
+	return fulfillDepsWithParamsAndConfigOverride(t, server.Params{Serverless: true}, overrides)
+}
+
+func fulfillDepsWithParamsAndConfigOverride(t testing.TB, params server.Params, overrides map[string]interface{}) serverDeps {
 	return fxutil.Test[serverDeps](t, fx.Options(
 		fx.Provide(func() log.Component { return logmock.New(t) }),
 		fx.Provide(func() configComponent.Component { return configComponent.NewMockWithOverrides(t, overrides) }),
@@ -98,7 +109,7 @@ func fulfillDepsWithConfigOverride(t testing.TB, overrides map[string]interface{
 		fx.Provide(func() offlinereporter.Component { return offlinereportermock.Mock(t) }),
 
 		fxutil.ProvideComponentConstructor(NewComponent),
-		fx.Supply(server.Params{Serverless: false}),
+		fx.Supply(params),
 	))
 }
 
@@ -126,13 +137,17 @@ func fulfillDepsWithConfigYaml(t testing.TB, yaml string) serverDeps {
 // Returns a server that is not started along with associated dependencies
 // Be careful when using this functionality, as server start instantiates many internal components to non-nil values
 func fulfillDepsWithInactiveServer(t *testing.T, cfg map[string]interface{}) (depsWithoutServer, *dsdServer) {
+	return fulfillDepsWithInactiveServerAndParams(t, cfg, false)
+}
+
+func fulfillDepsWithInactiveServerAndParams(t *testing.T, cfg map[string]interface{}, serverless bool) (depsWithoutServer, *dsdServer) {
 	deps := fxutil.Test[depsWithoutServer](t, fx.Options(
 		fx.Provide(func() log.Component { return logmock.New(t) }),
 		fx.Provide(func() configComponent.Component { return configComponent.NewMockWithOverrides(t, cfg) }),
 		mocktelemetry.Module(),
 		hostnameimpl.MockModule(),
 		serverdebugmock.MockModule(),
-		fx.Supply(server.Params{Serverless: false}),
+		fx.Supply(server.Params{Serverless: serverless}),
 		replaymock.MockModule(),
 		pidmapfx.Module(),
 		demultiplexerimpl.FakeSamplerMockModule(),
@@ -143,7 +158,7 @@ func fulfillDepsWithInactiveServer(t *testing.T, cfg map[string]interface{}) (de
 		fx.Provide(func() offlinereporter.Component { return offlinereportermock.Mock(t) }),
 	))
 
-	s := newServerCompat(deps.Config, deps.Log, deps.Hostname, deps.Replay, deps.Debug, false, deps.Demultiplexer, deps.WMeta, deps.PidMap, deps.Telemetry, deps.FilterList)
+	s := newServerCompat(deps.Config, deps.Log, deps.Hostname, deps.Replay, deps.Debug, serverless, deps.Demultiplexer, deps.WMeta, deps.PidMap, deps.Telemetry, deps.FilterList)
 
 	return deps, s
 }

--- a/comp/dogstatsd/server/impl/server_worker.go
+++ b/comp/dogstatsd/server/impl/server_worker.go
@@ -64,15 +64,15 @@ func (w *worker) run() {
 	for {
 		select {
 		case <-w.server.stopChan:
-			// On stop, optionally flush the batcher's pending samples into the
-			// time sampler before exiting. Gated by
-			// dogstatsd_flush_incomplete_buckets so that short-lived processes
-			// (serverless-init) report everything they have; long-running agents
-			// leave it off and simply exit. stop() waits on workerWg, so the
-			// flush is guaranteed to complete before the demultiplexer is torn
-			// down.
+			// On stop, optionally drain any still-queued packets and flush the
+			// batcher's pending samples into the time sampler before exiting.
+			// Gated by dogstatsd_flush_incomplete_buckets so that short-lived
+			// processes (serverless-init) report everything they have;
+			// long-running agents leave it off and simply exit. stop() waits on
+			// workerWg, so the drain and flush are guaranteed to complete before
+			// the demultiplexer is torn down.
 			if w.server.config.GetBool("dogstatsd_flush_incomplete_buckets") {
-				w.batcher.flush()
+				w.drainAndFlush()
 			}
 			return
 		case <-w.server.health.C:
@@ -81,12 +81,35 @@ func (w *worker) run() {
 		case filterList := <-w.FilterListUpdate:
 			w.filterList = filterList
 		case ps := <-w.server.packetsIn:
-			w.packetsTelemetry.TelemetryUntrackPackets(ps)
-			w.samples = w.samples[0:0]
-			// we return the samples in case the slice was extended
-			// when parsing the packets
-			w.samples = w.server.parsePackets(w.batcher, w.parser, ps, w.samples, &w.filterList)
+			w.handlePackets(ps)
 		}
 
+	}
+}
+
+// handlePackets parses one batch of packets into the worker's batcher.
+func (w *worker) handlePackets(ps packets.Packets) {
+	w.packetsTelemetry.TelemetryUntrackPackets(ps)
+	w.samples = w.samples[0:0]
+	// we return the samples in case the slice was extended
+	// when parsing the packets
+	w.samples = w.server.parsePackets(w.batcher, w.parser, ps, w.samples, &w.filterList)
+}
+
+// drainAndFlush parses any packets still queued in packetsIn, then flushes the
+// batcher into the time sampler. Used on stop: stopping the listeners can leave
+// assembled packets in packetsIn, and the random select in run could otherwise
+// exit before they are parsed, dropping them. The listeners are already stopped
+// by the time stopChan is closed, so no new packets are produced and the
+// non-blocking drain terminates once the queue is empty.
+func (w *worker) drainAndFlush() {
+	for {
+		select {
+		case ps := <-w.server.packetsIn:
+			w.handlePackets(ps)
+		default:
+			w.batcher.flush()
+			return
+		}
 	}
 }

--- a/comp/dogstatsd/server/impl/server_worker.go
+++ b/comp/dogstatsd/server/impl/server_worker.go
@@ -60,9 +60,20 @@ func newWorker(s *dsdServer, workerNum int, wmeta option.Option[workloadmeta.Com
 }
 
 func (w *worker) run() {
+	defer w.server.workerWg.Done()
 	for {
 		select {
 		case <-w.server.stopChan:
+			// On stop, optionally flush the batcher's pending samples into the
+			// time sampler before exiting. Gated by
+			// dogstatsd_flush_incomplete_buckets so that short-lived processes
+			// (serverless-init) report everything they have; long-running agents
+			// leave it off and simply exit. stop() waits on workerWg, so the
+			// flush is guaranteed to complete before the demultiplexer is torn
+			// down.
+			if w.server.config.GetBool("dogstatsd_flush_incomplete_buckets") {
+				w.batcher.flush()
+			}
 			return
 		case <-w.server.health.C:
 		case <-w.server.serverlessFlushChan:

--- a/comp/dogstatsd/server/impl/server_worker.go
+++ b/comp/dogstatsd/server/impl/server_worker.go
@@ -64,13 +64,10 @@ func (w *worker) run() {
 	for {
 		select {
 		case <-w.server.stopChan:
-			// On stop, optionally drain any still-queued packets and flush the
-			// batcher's pending samples into the time sampler before exiting.
-			// Gated by dogstatsd_flush_incomplete_buckets so that short-lived
-			// processes (serverless-init) report everything they have;
-			// long-running agents leave it off and simply exit. stop() waits on
-			// workerWg, so the drain and flush are guaranteed to complete before
-			// the demultiplexer is torn down.
+			// On stop, optionally drain still-queued packets and flush the
+			// batcher into the time sampler before exiting. Gated by
+			// dogstatsd_flush_incomplete_buckets; stop() waits on workerWg so
+			// the flush completes before the demultiplexer is torn down.
 			if w.server.config.GetBool("dogstatsd_flush_incomplete_buckets") {
 				w.drainAndFlush()
 			}
@@ -97,11 +94,7 @@ func (w *worker) handlePackets(ps packets.Packets) {
 }
 
 // drainAndFlush parses any packets still queued in packetsIn, then flushes the
-// batcher into the time sampler. Used on stop: stopping the listeners can leave
-// assembled packets in packetsIn, and the random select in run could otherwise
-// exit before they are parsed, dropping them. The listeners are already stopped
-// by the time stopChan is closed, so no new packets are produced and the
-// non-blocking drain terminates once the queue is empty.
+// batcher into the time sampler.
 func (w *worker) drainAndFlush() {
 	for {
 		select {

--- a/comp/dogstatsd/server/impl/server_worker_test.go
+++ b/comp/dogstatsd/server/impl/server_worker_test.go
@@ -7,6 +7,7 @@
 package serverimpl
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -456,7 +457,9 @@ func TestProcessedMetricsOrigin(t *testing.T) {
 		s := deps.Server.(*dsdServer)
 		assert := assert.New(t)
 
-		s.Stop()
+		// Stop the server so the parser-only assertions below can't race with
+		// the worker goroutines started by fulfillDepsWithConfigOverride.
+		require.NoError(t, s.stop(context.Background()))
 
 		assert.Len(s.cachedOriginCounters, 0, "this cache must be empty")
 		assert.Len(s.cachedOrder, 0, "this cache list must be empty")

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -7851,7 +7851,6 @@ properties:
     node_type: setting
     type: boolean
     default: false
-    comment: Control dogstatsd shutdown behaviors
   dogstatsd_host_socket_path:
     node_type: setting
     type: string

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1704,7 +1704,12 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("dogstatsd_log_file_max_size", "10Mb")
 	// Control for how long counter would be sampled to 0 if not received
 	config.BindEnvAndSetDefault("dogstatsd_expiry_seconds", 300)
-	// Control dogstatsd shutdown behaviors
+	// On stop, flush everything still held in memory instead of dropping it.
+	// This drains the dogstatsd server's per-worker batchers into the time
+	// sampler as the workers exit, and then flushes the sampler's final
+	// (incomplete) bucket out to the serializer. Intended for short-lived
+	// processes (e.g. serverless-init) that want their last metrics reported on
+	// shutdown; long-running agents leave it off.
 	config.BindEnvAndSetDefault("dogstatsd_flush_incomplete_buckets", false)
 	// Control how long we keep dogstatsd contexts in memory.
 	config.BindEnvAndSetDefault("dogstatsd_context_expiry_seconds", 20)

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1704,12 +1704,6 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("dogstatsd_log_file_max_size", "10Mb")
 	// Control for how long counter would be sampled to 0 if not received
 	config.BindEnvAndSetDefault("dogstatsd_expiry_seconds", 300)
-	// On stop, flush everything still held in memory instead of dropping it.
-	// This drains the dogstatsd server's per-worker batchers into the time
-	// sampler as the workers exit, and then flushes the sampler's final
-	// (incomplete) bucket out to the serializer. Intended for short-lived
-	// processes (e.g. serverless-init) that want their last metrics reported on
-	// shutdown; long-running agents leave it off.
 	config.BindEnvAndSetDefault("dogstatsd_flush_incomplete_buckets", false)
 	// Control how long we keep dogstatsd contexts in memory.
 	config.BindEnvAndSetDefault("dogstatsd_context_expiry_seconds", 20)

--- a/releasenotes/notes/dogstatsd-flush-incomplete-buckets-on-stop-e031aed9b321ce01.yaml
+++ b/releasenotes/notes/dogstatsd-flush-incomplete-buckets-on-stop-e031aed9b321ce01.yaml
@@ -9,8 +9,5 @@
 enhancements:
   - |
     When ``dogstatsd_flush_incomplete_buckets`` is enabled, the DogStatsD server
-    now also drains its per-worker batchers into the time sampler on stop before
-    the sampler flushes its final bucket. This ensures metrics buffered in the
-    server at shutdown are reported rather than dropped, which is useful for
-    short-lived processes. The setting remains ``false`` by default, so
-    long-running agents are unaffected.
+    now also finishes processing in-flight packets before sending metrics in the
+    current (incomplete) aggregation window.

--- a/releasenotes/notes/dogstatsd-flush-incomplete-buckets-on-stop-e031aed9b321ce01.yaml
+++ b/releasenotes/notes/dogstatsd-flush-incomplete-buckets-on-stop-e031aed9b321ce01.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    When ``dogstatsd_flush_incomplete_buckets`` is enabled, the DogStatsD server
+    now also drains its per-worker batchers into the time sampler on stop before
+    the sampler flushes its final bucket. This ensures metrics buffered in the
+    server at shutdown are reported rather than dropped, which is useful for
+    short-lived processes. The setting remains ``false`` by default, so
+    long-running agents are unaffected.


### PR DESCRIPTION
When dogstatsd_flush_incomplete_buckets is enabled, each worker flushes its batcher into the time sampler as it exits its run loop on stop. stop() closes stopChan and then waits on a workerWg so every worker's flush completes before the demultiplexer is torn down — guaranteeing the batched samples reach the sampler before its own final flush, with no dropped metrics on the shutdown of a short-lived process (serverless-init).

The flush is gated by the existing dogstatsd_flush_incomplete_buckets setting rather than a new key: that setting already flushes the sampler's final bucket, and draining the server batchers one layer upstream is the same "report everything we have on stop" intent. Long-running agents leave it off and are unaffected.

The legacy ServerlessFlush mechanism is left in place for now; it is removed once serverless-init stops using it.

### Motivation
We're migrating to use as much of the existing metrics agent functionality in serverless-init as possible, but need some short-lived-agent features to make that work.

### Describe how you validated your changes
Unit tests, as well as testing in a real serverelss-init short-lived test rig deployed to cloud run jobs.
