### PR TITLE
[CONTP-1749] feat: Support versions pinning for resources as tags

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -88,12 +88,23 @@ func (c *WorkloadMetaCollector) initK8sResourcesMetaAsTags(resourcesLabelsAsTags
 	c.globK8sResourcesLabels = map[string]map[string]glob.Glob{}
 
 	for resource, labelsAsTags := range resourcesLabelsAsTags {
-		c.k8sResourcesLabelsAsTags[resource], c.globK8sResourcesLabels[resource] = k8smetadata.InitMetadataAsTags(labelsAsTags)
+		normalizedResource := groupResourceWithoutVersion(resource)
+		c.k8sResourcesLabelsAsTags[normalizedResource], c.globK8sResourcesLabels[normalizedResource] = k8smetadata.InitMetadataAsTags(labelsAsTags)
 	}
 
 	for resource, annotationsAsTags := range resourcesAnnotationsAsTags {
-		c.k8sResourcesAnnotationsAsTags[resource], c.globK8sResourcesAnnotations[resource] = k8smetadata.InitMetadataAsTags(annotationsAsTags)
+		normalizedResource := groupResourceWithoutVersion(resource)
+		c.k8sResourcesAnnotationsAsTags[normalizedResource], c.globK8sResourcesAnnotations[normalizedResource] = k8smetadata.InitMetadataAsTags(annotationsAsTags)
 	}
+}
+
+// groupResourceWithoutVersion strips the optional /{version} suffix from a group resource key.
+func groupResourceWithoutVersion(groupResource string) string {
+	normalized, _, hasVersion := strings.Cut(groupResource, "/")
+	if hasVersion {
+		return normalized
+	}
+	return groupResource
 }
 
 // Run runs the continuous event watching loop and sends new tags to the

--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -98,15 +98,6 @@ func (c *WorkloadMetaCollector) initK8sResourcesMetaAsTags(resourcesLabelsAsTags
 	}
 }
 
-// groupResourceWithoutVersion strips the optional /{version} suffix from a group resource key.
-func groupResourceWithoutVersion(groupResource string) string {
-	normalized, _, hasVersion := strings.Cut(groupResource, "/")
-	if hasVersion {
-		return normalized
-	}
-	return groupResource
-}
-
 // Run runs the continuous event watching loop and sends new tags to the
 // tagger based on the events sent by the workloadmeta.
 func (c *WorkloadMetaCollector) Run(ctx context.Context) {
@@ -234,6 +225,16 @@ func retrieveMappingFromConfig(cfg config.Component, configKey string) map[strin
 		labelsList[strings.ToLower(label)] = value
 	}
 	return labelsList
+}
+
+// groupResourceWithoutVersion strips the optional /{version} suffix from a group resource key
+// so that "datadogdashboards.datadoghq.com/v1alpha1" normalizes to "datadogdashboards.datadoghq.com",
+// matching the format returned by GroupResource().String() used during tag lookup.
+// strings.Cut returns the original string as "before" when the separator is absent, so no
+// special case is needed for keys that have no version suffix.
+func groupResourceWithoutVersion(groupResource string) string {
+	normalized, _, _ := strings.Cut(groupResource, "/")
+	return normalized
 }
 
 // mergeMaps merges two maps, in case of conflict the first argument is prioritized

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -1668,6 +1668,40 @@ func TestHandleKubeDeployment(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "version-pinned key maps annotations correctly",
+			k8sResourcesAnnotationsAsTags: map[string]map[string]string{
+				// The /{version} suffix is stripped at init time; lookup uses "deployments.apps"
+				"deployments.apps/v1": {
+					"depl_tier": "depl_tier",
+				},
+			},
+			k8sResourcesLabelsAsTags: map[string]map[string]string{},
+			kubeMetadata: workloadmeta.KubernetesMetadata{
+				EntityID: kubeMetadataEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: deploymentName,
+					Annotations: map[string]string{
+						"depl_tier": "critical",
+					},
+				},
+				GVR: &schema.GroupVersionResource{
+					Version:  "v1",
+					Group:    "apps",
+					Resource: "deployments",
+				},
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:               kubeMetadataSource,
+					EntityID:             taggerEntityID,
+					HighCardTags:         []string{},
+					OrchestratorCardTags: []string{},
+					LowCardTags:          []string{"depl_tier:critical"},
+					StandardTags:         []string{},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -1702,6 +1702,39 @@ func TestHandleKubeDeployment(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "version-pinned key with mismatched version still maps annotations",
+			k8sResourcesAnnotationsAsTags: map[string]map[string]string{
+				"deployments.apps/v1beta1": {
+					"depl_tier": "depl_tier",
+				},
+			},
+			k8sResourcesLabelsAsTags: map[string]map[string]string{},
+			kubeMetadata: workloadmeta.KubernetesMetadata{
+				EntityID: kubeMetadataEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: deploymentName,
+					Annotations: map[string]string{
+						"depl_tier": "critical",
+					},
+				},
+				GVR: &schema.GroupVersionResource{
+					Version:  "v1",
+					Group:    "apps",
+					Resource: "deployments",
+				},
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:               kubeMetadataSource,
+					EntityID:             taggerEntityID,
+					HighCardTags:         []string{},
+					OrchestratorCardTags: []string{},
+					LowCardTags:          []string{"depl_tier:critical"},
+					StandardTags:         []string{},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -545,6 +545,17 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 			expectedResources: []string{"//nodes", "//namespaces", "example.com//custom"},
 		},
 		{
+			name: "version-pinned resource in annotations as tags uses explicit version",
+			cfg: map[string]interface{}{
+				"language_detection.enabled":                       false,
+				"language_detection.reporting.enabled":             false,
+				"cluster_agent.kube_metadata_collection.enabled":   false,
+				"cluster_agent.kube_metadata_collection.resources": "",
+				"kubernetes_resources_annotations_as_tags":         `{"datadogdashboards.datadoghq.com/v1alpha1": {"my-annotation": "my-tag"}}`,
+			},
+			expectedResources: []string{"//nodes", "datadoghq.com/v1alpha1/datadogdashboards"},
+		},
+		{
 			name: "generic resources tagging should be exclude invalid resources",
 			cfg: map[string]interface{}{
 				"language_detection.enabled":                       false,

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go
@@ -22,7 +22,7 @@ import (
 
 // groupResourceToGVRString is a helper function that converts a group resource string to
 // a group-version-resource string
-// a group resource string is in the form `{resource}.{group}` or `{resource}` (example: deployments.apps, pods)
+// a group resource string is in the form `{resource}.{group}`, `{resource}.{group}/{version}`, or `{resource}` (example: deployments.apps, datadogdashboards.datadoghq.com/v1alpha1, pods)
 // a group version resource string is in the form `{group}/{version}/{resource}` (example: apps/v1/deployments)
 // if the groupResource argument is not in the correct format, an empty string is returned
 func groupResourceToGVRString(groupResource string) string {
@@ -31,12 +31,18 @@ func groupResourceToGVRString(groupResource string) string {
 		return groupResource
 	} else if len(validation.IsDNS1123Subdomain(groupResource)) == 0 {
 		resource, group, _ := strings.Cut(groupResource, ".")
-		// format is `{group}/{version}/{resource}`
+		// format is `{group}//{resource}` (version auto-discovered)
 		return fmt.Sprintf("%s//%s", group, resource)
+	} else if resourceGroup, version, found := strings.Cut(groupResource, "/"); found &&
+		strings.Contains(resourceGroup, ".") &&
+		len(validation.IsDNS1123Subdomain(resourceGroup)) == 0 {
+		// format is `{resource}.{group}/{version}` (explicit version pinning)
+		resource, group, _ := strings.Cut(resourceGroup, ".")
+		return fmt.Sprintf("%s/%s/%s", group, version, resource)
 	}
 
 	// invalid group resource format
-	log.Errorf("invalid group resource %q. must be a valid RFC1123 subdomain in the format `{resource}.{group}` or `{resource}`", groupResource)
+	log.Errorf("invalid group resource %q. must be a valid RFC1123 subdomain in the format `{resource}.{group}`, `{resource}.{group}/{version}`, or `{resource}`", groupResource)
 	return ""
 }
 


### PR DESCRIPTION
### What does this PR do?

### Motivation

The collector errores at startup (`failed to auto-discover version of group resource ...`) for CRDs served only on a non-preferred version of their group (e.g. a `v1alpha1` CRD in the `datadoghq.com` group whose preferred version is `v2alpha1`), because discovery only indexed each group's preferred version.

Customers need an option to specify a non-preferred version for resource annotation to tag collection.

### Describe how you validated your changes

- Added unit tests

#### Manually QA'd

> TODO: steps
