### PR TITLE
[incident-55877] [anomalydetection] skip observer build when disabled

### DIFF
--- a/comp/anomalydetection/observer/impl/BUILD.bazel
+++ b/comp/anomalydetection/observer/impl/BUILD.bazel
@@ -92,6 +92,7 @@ go_test(
         "metrics_detector_scanwelch_test.go",
         "metrics_detector_tukey_biweight_test.go",
         "metrics_detector_util_test.go",
+        "observer_disabled_test.go",
         "observer_test.go",
         "profile_test.go",
         "rrcf_test.go",
@@ -106,6 +107,7 @@ go_test(
     gotags = ["test"],
     deps = [
         "//comp/anomalydetection/observer/def",
+        "//comp/anomalydetection/recorder/def",
         "//comp/anomalydetection/reporter/def",
         "//comp/core/log/def",
         "//comp/core/telemetry/def",
@@ -114,6 +116,7 @@ go_test(
         "//comp/def",
         "//pkg/config/mock",
         "//pkg/util/log",
+        "//pkg/util/option",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -192,6 +192,17 @@ func NewComponent(deps Requires) (Provides, error) {
 		return Provides{Comp: &disabledObserver{}}, nil
 	}
 
+	// Off-by-default fast path: when neither analysis nor recording is active the
+	// live observer noops every handle (see handleFunc below) and installs no log
+	// tap, so skip building the catalog, engine, storage, 1000-cap channel, and
+	// dispatch goroutine — return the zero-allocation stub instead. The predicate
+	// mirrors the analysisEnabled/recorderEnabled gates used further down.
+	if !cfg.GetBool("anomaly_detection.enabled") {
+		if _, recorderEnabled := deps.Recorder.Get(); !recorderEnabled {
+			return Provides{Comp: &disabledObserver{}}, nil
+		}
+	}
+
 	catalog := defaultCatalog()
 	settings := settingsFromAgentConfig(catalog, cfg)
 	detectors, correlators, rawScorer, extractors, _ := catalog.Instantiate(settings)

--- a/comp/anomalydetection/observer/impl/observer_disabled_test.go
+++ b/comp/anomalydetection/observer/impl/observer_disabled_test.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+// TestNewComponentReturnsDisabledStubWhenOff verifies the off-by-default fast
+// path: with anomaly_detection.enabled=false and no recorder, NewComponent must
+// return the zero-allocation disabledObserver stub rather than building the
+// engine, storage, catalog, 1000-cap channel, and dispatch goroutine.
+func TestNewComponentReturnsDisabledStubWhenOff(t *testing.T) {
+	// anomaly_detection.enabled defaults to false; the mock carries that default.
+	cfg := configmock.New(t)
+
+	provides, err := NewComponent(Requires{
+		Config:   cfg,
+		Recorder: option.None[recorderdef.Component](),
+	})
+	require.NoError(t, err)
+
+	_, ok := provides.Comp.(*disabledObserver)
+	require.Truef(t, ok, "expected *disabledObserver when anomaly detection is disabled, got %T", provides.Comp)
+}

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -254,7 +254,7 @@ func (tb *Bench) ListScenarios() ([]ScenarioInfo, error) {
 		return nil, fmt.Errorf("failed to read scenarios directory: %w", err)
 	}
 
-	var scenarios []ScenarioInfo
+	scenarios := []ScenarioInfo{}
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue

--- a/internal/qbranch/anomalydetection-testbench/go.mod
+++ b/internal/qbranch/anomalydetection-testbench/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.82.0-devel.0.20260624113434-509b872045c2
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.80.2
 	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.80.2
+	github.com/DataDog/datadog-agent/pkg/config/model v0.81.0-devel.0.20260603133502-a41610237dba
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.81.0-devel.0.20260603133502-a41610237dba
 	github.com/DataDog/datadog-agent/pkg/util/log v0.81.0-devel.0.20260603133502-a41610237dba
 	github.com/DataDog/datadog-agent/pkg/util/option v0.81.0-devel.0.20260603133502-a41610237dba
@@ -53,7 +54,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/env v0.80.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/helper v0.80.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.82.0-devel.0.20260624113434-509b872045c2 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/model v0.80.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.80.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/remote v0.59.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.82.0-devel.0.20260624113434-509b872045c2 // indirect

--- a/internal/qbranch/anomalydetection-testbench/main.go
+++ b/internal/qbranch/anomalydetection-testbench/main.go
@@ -32,6 +32,7 @@ import (
 	workloadfilterdef "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmetadef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/internal/qbranch/anomalydetection-testbench/bench"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
@@ -141,6 +142,18 @@ func main() {
 		fx.Supply(option.None[workloadfilterdef.Component]()),
 		fx.Supply(option.None[taggerdef.Component]()),
 		core.Bundle(),
+		// The testbench drives the engine directly via DebugView, so it needs the
+		// full observerImpl, not the disabled stub that NewComponent returns when
+		// anomaly detection is off. Force the feature on; replay is driven by
+		// DebugView.Reset with the testbench's own ComponentSettings, so this does
+		// not change scenario results. Keep the agent-internal log tap off so
+		// pkg/util/log messages (e.g. from parquet loading) are never ingested as
+		// scenario data — the testbench feeds the engine exclusively via DebugView.
+		fx.Decorate(func(c config.Component) config.Component {
+			c.Set("anomaly_detection.enabled", true, pkgconfigmodel.SourceAgentRuntime)
+			c.Set("anomaly_detection.logs.internal.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+			return c
+		}),
 		fx.Supply(core.BundleParams{
 			ConfigParams: config.NewAgentParams(""),
 			LogParams:    log.ForOneShot("", "off", true),

--- a/internal/qbranch/anomalydetection-testbench/main_test.go
+++ b/internal/qbranch/anomalydetection-testbench/main_test.go
@@ -19,6 +19,7 @@ import (
 	taggerdef "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadfilterdef "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmetadef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/stretchr/testify/require"
@@ -34,6 +35,14 @@ func TestFxApp(t *testing.T) {
 			fx.Supply(option.None[workloadfilterdef.Component]()),
 			fx.Supply(option.None[taggerdef.Component]()),
 			core.Bundle(),
+			// Mirror main(): force anomaly detection on so NewComponent yields the
+			// full observerImpl (with DebugView) instead of the disabled stub, and
+			// keep the agent-internal log tap off so it never ingests scenario data.
+			fx.Decorate(func(c config.Component) config.Component {
+				c.Set("anomaly_detection.enabled", true, pkgconfigmodel.SourceAgentRuntime)
+				c.Set("anomaly_detection.logs.internal.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+				return c
+			}),
 			fx.Supply(core.BundleParams{
 				ConfigParams: config.NewAgentParams(""),
 				LogParams:    log.ForOneShot("", "off", true),

--- a/releasenotes/notes/skip-anomalydetection-observer-build-if-config-disabled-8fc350c1cf500059.yaml
+++ b/releasenotes/notes/skip-anomalydetection-observer-build-if-config-disabled-8fc350c1cf500059.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    The anomaly detection observer component no longer allocates memory or starts
+    background goroutines when anomaly detection is disabled (the default). This
+    reduces idle Agent PSS.


### PR DESCRIPTION
### What does this PR do?

Returns the existing zero-allocation `disabledObserver` stub early from the
observer component's constructor when neither anomaly-detection analysis nor
recording is active, instead of building the full detector catalog, the
time-series storage engine, a 1000-cap observation channel, and a dispatch
goroutine.

### Motivation

Part of `incident-55877` — reducing core-agent idle PSS so the SMP
`quality_gate_idle` benchmark stays under its 147 MiB gate.

The observer (`comp/anomalydetection/observer`) is wired unconditionally into
the agent fx graph and eagerly instantiated, but `anomaly_detection.enabled`
defaults to `false`. The constructor allocated the catalog/engine/storage/
channel and started `go obs.run()` *before* checking the flag, so every idle
agent paid that cost (memory + a parked goroutine) for a feature that was off.

The new guard mirrors the constructor's existing runtime gates
(`analysisEnabled` from `anomaly_detection.enabled`, and `recorderEnabled` from
the Recorder component — not the raw `recording.enabled` config key, which can
diverge under the default noop recorder). In that state the live observer
already noops every handle and installs no log tap, so the stub is
behavior-preserving for the idle case. One benign nuance: the debug
metric-dump goroutine no longer starts when fully disabled, but with analysis
off it would only ever dump an empty engine.

### Describe how you validated your changes

- `dda inv test --targets=./comp/anomalydetection/observer/impl` — passes,
  including the new `TestNewComponentReturnsDisabledStubWhenOff`.
- `dda inv linter.go --targets=./comp/anomalydetection/observer/impl` — 0 issues.
- `dda inv anomalydetection.launch-testbench --build` -- revealed what looks like a pre-existing backend bug in the benchmark. This PR also fixes the benchmark to confirm that the function of the anomaly detector is preserved in its tests.
- in `internal/qbranch/anomalydetection-testbench`, `go test -tags "test python" ./...` passes.
- `bazel test //comp/anomalydetection/observer/impl:impl_test` passes.

### Additional Notes

Expected idle savings are modest (~hundreds of KB + one goroutine); this is one
of a small set of "off-by-default feature constructs heavy state before
checking its flag" cleanups for `incident-55877`.