### PR TITLE
[incident-55877] [netflow] build flow aggregator only when enabled

### DIFF
--- a/comp/netflow/server/impl/server.go
+++ b/comp/netflow/server/impl/server.go
@@ -51,60 +51,63 @@ type Provides struct {
 	StatusProvider status.InformationProvider
 }
 
+// disabledServer is the zero-overhead stub returned when netflow is disabled.
+type disabledServer struct{}
+
 // NewComponent configures a netflow server.
 func NewComponent(deps Requires) (Provides, error) {
 	conf := deps.Config.Get()
 
+	if !conf.Enabled {
+		return Provides{
+			Comp:           &disabledServer{},
+			StatusProvider: status.NewInformationProvider(nil),
+		}, nil
+	}
+
+	sender, err := deps.Demultiplexer.GetDefaultSender()
+	if err != nil {
+		return Provides{}, err
+	}
+
+	// Note that multiple components can share the same rdnsQuerier instance.  If any of them have
+	// reverse DNS enrichment enabled then the deps.RDNSQuerier component passed here will be an
+	// active instance.  However, we also need to check here whether the netflow component has
+	// reverse DNS enrichment enabled to decide whether to use the passed instance or to override
+	// it with a noop implementation.
+	rdnsQuerier := deps.RDNSQuerier
+	if conf.ReverseDNSEnrichmentEnabled {
+		deps.Logger.Infof("Reverse DNS Enrichment is enabled for NDM NetFlow")
+	} else {
+		rdnsQuerier = rdnsquerierimplnone.NewNone().Comp
+		deps.Logger.Infof("Reverse DNS Enrichment is disabled for NDM NetFlow")
+	}
+	networkPathEnabled := deps.AgentConfig.GetBool("network_path.netflow_monitoring.enabled")
+
+	flowAgg := flowaggregator.NewFlowAggregator(sender, deps.Forwarder, conf, deps.Hostname.GetSafe(context.Background()), deps.Logger, rdnsQuerier, networkPathEnabled, deps.NPCollector)
+
 	srv := &Server{
-		config: conf,
-		logger: deps.Logger,
+		config:  conf,
+		FlowAgg: flowAgg,
+		logger:  deps.Logger,
 	}
 
-	var statusProvider status.Provider
-
-	// When netflow is disabled (the default), skip building the flow aggregator
-	// entirely: its 10k-cap input channel, accumulator, and filter would sit
-	// resident for a feature that never starts. FlowAgg is only dereferenced from
-	// Start/Stop/startFlowListener, which run solely via the enabled-only
-	// lifecycle hook below, so leaving it nil here is safe.
-	if conf.Enabled {
-		sender, err := deps.Demultiplexer.GetDefaultSender()
-		if err != nil {
-			return Provides{}, err
-		}
-
-		// Note that multiple components can share the same rdnsQuerier instance.  If any of them have
-		// reverse DNS enrichment enabled then the deps.RDNSQuerier component passed here will be an
-		// active instance.  However, we also need to check here whether the netflow component has
-		// reverse DNS enrichment enabled to decide whether to use the passed instance or to override
-		// it with a noop implementation.
-		rdnsQuerier := deps.RDNSQuerier
-		if conf.ReverseDNSEnrichmentEnabled {
-			deps.Logger.Infof("Reverse DNS Enrichment is enabled for NDM NetFlow")
-		} else {
-			rdnsQuerier = rdnsquerierimplnone.NewNone().Comp
-			deps.Logger.Infof("Reverse DNS Enrichment is disabled for NDM NetFlow")
-		}
-		networkPathEnabled := deps.AgentConfig.GetBool("network_path.netflow_monitoring.enabled")
-
-		srv.FlowAgg = flowaggregator.NewFlowAggregator(sender, deps.Forwarder, conf, deps.Hostname.GetSafe(context.Background()), deps.Logger, rdnsQuerier, networkPathEnabled, deps.NPCollector)
-
-		statusProvider = Provider{
-			server: srv,
-		}
-
-		// netflow is enabled, so start the server
-		deps.Lc.Append(compdef.Hook{
-			OnStart: func(_ context.Context) error {
-				err := srv.Start()
-				return err
-			},
-			OnStop: func(context.Context) error {
-				srv.Stop()
-				return nil
-			},
-		})
+	statusProvider := Provider{
+		server: srv,
 	}
+
+	// netflow is enabled, so start the server
+	deps.Lc.Append(compdef.Hook{
+		OnStart: func(_ context.Context) error {
+			err := srv.Start()
+			return err
+		},
+		OnStop: func(context.Context) error {
+			srv.Stop()
+			return nil
+		},
+	})
+
 	return Provides{
 		Comp:           srv,
 		StatusProvider: status.NewInformationProvider(statusProvider),

--- a/comp/netflow/server/impl/server.go
+++ b/comp/netflow/server/impl/server.go
@@ -54,36 +54,41 @@ type Provides struct {
 // NewComponent configures a netflow server.
 func NewComponent(deps Requires) (Provides, error) {
 	conf := deps.Config.Get()
-	sender, err := deps.Demultiplexer.GetDefaultSender()
-	if err != nil {
-		return Provides{}, err
-	}
-
-	// Note that multiple components can share the same rdnsQuerier instance.  If any of them have
-	// reverse DNS enrichment enabled then the deps.RDNSQuerier component passed here will be an
-	// active instance.  However, we also need to check here whether the netflow component has
-	// reverse DNS enrichment enabled to decide whether to use the passed instance or to override
-	// it with a noop implementation.
-	rdnsQuerier := deps.RDNSQuerier
-	if conf.ReverseDNSEnrichmentEnabled {
-		deps.Logger.Infof("Reverse DNS Enrichment is enabled for NDM NetFlow")
-	} else {
-		rdnsQuerier = rdnsquerierimplnone.NewNone().Comp
-		deps.Logger.Infof("Reverse DNS Enrichment is disabled for NDM NetFlow")
-	}
-	networkPathEnabled := deps.AgentConfig.GetBool("network_path.netflow_monitoring.enabled")
-
-	flowAgg := flowaggregator.NewFlowAggregator(sender, deps.Forwarder, conf, deps.Hostname.GetSafe(context.Background()), deps.Logger, rdnsQuerier, networkPathEnabled, deps.NPCollector)
 
 	srv := &Server{
-		config:  conf,
-		FlowAgg: flowAgg,
-		logger:  deps.Logger,
+		config: conf,
+		logger: deps.Logger,
 	}
 
 	var statusProvider status.Provider
 
+	// When netflow is disabled (the default), skip building the flow aggregator
+	// entirely: its 10k-cap input channel, accumulator, and filter would sit
+	// resident for a feature that never starts. FlowAgg is only dereferenced from
+	// Start/Stop/startFlowListener, which run solely via the enabled-only
+	// lifecycle hook below, so leaving it nil here is safe.
 	if conf.Enabled {
+		sender, err := deps.Demultiplexer.GetDefaultSender()
+		if err != nil {
+			return Provides{}, err
+		}
+
+		// Note that multiple components can share the same rdnsQuerier instance.  If any of them have
+		// reverse DNS enrichment enabled then the deps.RDNSQuerier component passed here will be an
+		// active instance.  However, we also need to check here whether the netflow component has
+		// reverse DNS enrichment enabled to decide whether to use the passed instance or to override
+		// it with a noop implementation.
+		rdnsQuerier := deps.RDNSQuerier
+		if conf.ReverseDNSEnrichmentEnabled {
+			deps.Logger.Infof("Reverse DNS Enrichment is enabled for NDM NetFlow")
+		} else {
+			rdnsQuerier = rdnsquerierimplnone.NewNone().Comp
+			deps.Logger.Infof("Reverse DNS Enrichment is disabled for NDM NetFlow")
+		}
+		networkPathEnabled := deps.AgentConfig.GetBool("network_path.netflow_monitoring.enabled")
+
+		srv.FlowAgg = flowaggregator.NewFlowAggregator(sender, deps.Forwarder, conf, deps.Hostname.GetSafe(context.Background()), deps.Logger, rdnsQuerier, networkPathEnabled, deps.NPCollector)
+
 		statusProvider = Provider{
 			server: srv,
 		}

--- a/comp/netflow/server/impl/server_test.go
+++ b/comp/netflow/server/impl/server_test.go
@@ -115,9 +115,9 @@ func TestStartServerAndStopServer(t *testing.T) {
 }
 
 // TestNewComponentSkipsAggregatorWhenDisabled verifies that with netflow
-// disabled (the default), NewComponent does not allocate the flow aggregator
-// (10k-cap input channel + accumulator + filter) and leaves FlowAgg nil. The
-// server must still be constructed and safe to expose.
+// disabled (the default), NewComponent returns the zero-allocation
+// disabledServer stub rather than building the flow aggregator (10k-cap
+// input channel + accumulator + filter).
 func TestNewComponentSkipsAggregatorWhenDisabled(t *testing.T) {
 	var component server.Component
 	fxtest.New(t, fx.Options(
@@ -133,8 +133,6 @@ func TestNewComponentSkipsAggregatorWhenDisabled(t *testing.T) {
 		fx.Supply(fx.Annotate(t, fx.As(new(testing.TB)))),
 		fx.Populate(&component),
 	))
-	srv := component.(*Server)
-	require.NotNil(t, srv)
-	require.False(t, srv.config.Enabled, "precondition: default mock config must be disabled")
-	assert.Nil(t, srv.FlowAgg, "FlowAgg must be nil when netflow is disabled, avoiding the 10k-cap channel allocation")
+	_, ok := component.(*disabledServer)
+	require.Truef(t, ok, "expected *disabledServer when netflow is disabled, got %T", component)
 }

--- a/comp/netflow/server/impl/server_test.go
+++ b/comp/netflow/server/impl/server_test.go
@@ -113,3 +113,28 @@ func TestStartServerAndStopServer(t *testing.T) {
 	app.RequireStop()
 	assert.False(t, srv.running)
 }
+
+// TestNewComponentSkipsAggregatorWhenDisabled verifies that with netflow
+// disabled (the default), NewComponent does not allocate the flow aggregator
+// (10k-cap input channel + accumulator + filter) and leaves FlowAgg nil. The
+// server must still be constructed and safe to expose.
+func TestNewComponentSkipsAggregatorWhenDisabled(t *testing.T) {
+	var component server.Component
+	fxtest.New(t, fx.Options(
+		fxutil.FxAgentBase(),
+		fxutil.Component(fxutil.ProvideComponentConstructor(NewComponent)),
+		nfconfigmock.MockModule(),
+		forwardermock.MockModule(),
+		demultiplexerimpl.MockModule(),
+		defaultforwardermock.MockModule(),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		rdnsquerierfxmock.MockModule(),
+		fx.Supply(fx.Annotate(t, fx.As(new(testing.TB)))),
+		fx.Populate(&component),
+	))
+	srv := component.(*Server)
+	require.NotNil(t, srv)
+	require.False(t, srv.config.Enabled, "precondition: default mock config must be disabled")
+	assert.Nil(t, srv.FlowAgg, "FlowAgg must be nil when netflow is disabled, avoiding the 10k-cap channel allocation")
+}

--- a/releasenotes/notes/netflow-lazy-flow-aggregator-24285ce27142af80.yaml
+++ b/releasenotes/notes/netflow-lazy-flow-aggregator-24285ce27142af80.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Reduce idle agent memory usage when Network Device Monitoring NetFlow is
+    disabled (the default). The NetFlow flow aggregator is no longer allocated
+    when the feature is off.


### PR DESCRIPTION
### What does this PR do?

Constructs the netflow `FlowAggregator` only when `network_devices.netflow.enabled`
is true. When disabled (the default), `FlowAgg` is left nil and the 10k-cap
input channel, accumulator, and filter are never allocated.

### Motivation

Part of `incident-55877` — reducing core-agent idle PSS so the SMP
`quality_gate_idle` benchmark stays under its 147 MiB gate.

`NewComponent` built the aggregator unconditionally even though the feature
defaults off and the aggregator goroutine only starts via the enabled-only
lifecycle hook, so the allocation sat resident in every idle agent. Sender
acquisition, rdns selection, and aggregator construction now move inside the
`conf.Enabled` block. `FlowAgg` is only dereferenced from
`Start`/`Stop`/`startFlowListener`, all reachable solely through that hook, so
nil is safe when disabled. A disabled netflow also no longer fails agent
startup if `GetDefaultSender` errors, since the sender is only needed when the
feature runs.

### Describe how you validated your changes

- `dda inv test --targets=./comp/netflow/server/impl` — passes, including the
  new `TestNewComponentSkipsAggregatorWhenDisabled`.
- `dda inv linter.go --targets=./comp/netflow/server/impl` — 0 issues.

### Additional Notes

One of a small set of "off-by-default feature constructs heavy state before
checking its flag" cleanups for `incident-55877`. Draft for early team review.
