### PR TITLE
[ADP] Register data_plane.stop_timeout config setting

### DIFF
--- a/comp/core/config/setup.go
+++ b/comp/core/config/setup.go
@@ -100,8 +100,9 @@ func setupConfig(config pkgconfigmodel.BuildableConfig, secretComp secrets.Compo
 			}
 		}
 		// Fleet policies are merged after LoadDatadog's override pass, so re-run
-		// suppression logic that depends on values fleet policies may set.
+		// ADP overrides that depend on values fleet policies may set.
 		pkgconfigsetup.ApplyUseDogstatsdSuppression(config)
+		pkgconfigsetup.ComputeDataPlaneStopTimeout(config)
 	}
 
 	for k, v := range p.cliOverride {

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1069,9 +1069,10 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("data_plane.telemetry_enabled", false)
 	config.BindEnvAndSetDefault("data_plane.telemetry_listen_addr", "tcp://0.0.0.0:5102")
 	config.BindEnvAndSetDefault("data_plane.log_file", defaultpaths.GetDefaultDataPlaneLogFile())
-	// No default: when unset, ADP derives the topology shutdown timeout from
-	// aggregator_stop_timeout + forwarder_stop_timeout. Setting this key overrides that sum.
-	config.BindEnv("data_plane.stop_timeout") //nolint:forbidigo // intentional: no static default, derived in ADP
+	// 4 matches aggregator_stop_timeout + forwarder_stop_timeout (each defaults to 2 in seconds).
+	// ComputeDataPlaneStopTimeout (post-load override) recomputes this at runtime so it tracks
+	// any user-set values for aggregator_stop_timeout / forwarder_stop_timeout.
+	config.BindEnvAndSetDefault("data_plane.stop_timeout", 4)
 	config.BindEnvAndSetDefault("data_plane.dogstatsd.enabled", true)
 	config.BindEnvAndSetDefault("data_plane.otlp.enabled", false)
 	config.BindEnvAndSetDefault("data_plane.otlp.proxy.enabled", false)

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1069,6 +1069,9 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("data_plane.telemetry_enabled", false)
 	config.BindEnvAndSetDefault("data_plane.telemetry_listen_addr", "tcp://0.0.0.0:5102")
 	config.BindEnvAndSetDefault("data_plane.log_file", defaultpaths.GetDefaultDataPlaneLogFile())
+	// No default: when unset, ADP derives the topology shutdown timeout from
+	// aggregator_stop_timeout + forwarder_stop_timeout. Setting this key overrides that sum.
+	config.BindEnv("data_plane.stop_timeout") //nolint:forbidigo // intentional: no static default, derived in ADP
 	config.BindEnvAndSetDefault("data_plane.dogstatsd.enabled", true)
 	config.BindEnvAndSetDefault("data_plane.otlp.enabled", false)
 	config.BindEnvAndSetDefault("data_plane.otlp.proxy.enabled", false)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1522,6 +1522,24 @@ func ApplyUseDogstatsdSuppression(config pkgconfigmodel.Config) {
 	}
 }
 
+// ComputeDataPlaneStopTimeout is a post-load override that, when the user has
+// not explicitly set data_plane.stop_timeout, recomputes it from
+// aggregator_stop_timeout + forwarder_stop_timeout. The Agent Data Plane reads
+// this value via the config stream to size its topology graceful-shutdown
+// budget; computing the sum here keeps that budget aligned with the documented
+// core-agent shutdown window even when operators customize the component
+// timeouts.
+func ComputeDataPlaneStopTimeout(config pkgconfigmodel.Config) {
+	if config.GetSource("data_plane.stop_timeout") != pkgconfigmodel.SourceDefault {
+		return
+	}
+	sum := config.GetInt("aggregator_stop_timeout") + config.GetInt("forwarder_stop_timeout")
+	// Keep the source as default: the value is a derived default, not an
+	// agent runtime decision, so it should be filtered out by views that
+	// strip defaults (e.g. config dumps for diagnostics).
+	config.Set("data_plane.stop_timeout", sum, pkgconfigmodel.SourceDefault)
+}
+
 func bindEnvAndSetLogsConfigKeys(config pkgconfigmodel.Setup, prefix string) {
 	config.BindEnvAndSetDefault(prefix+"logs_dd_url", "") // Send the logs to a proxy. Must respect format '<HOST>:<PORT>' and '<PORT>' to be an integer
 	config.BindEnvAndSetDefault(prefix+"dd_url", "")

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1527,8 +1527,12 @@ func ApplyUseDogstatsdSuppression(config pkgconfigmodel.Config) {
 // aggregator_stop_timeout + forwarder_stop_timeout. The Agent Data Plane reads
 // this value via the config stream to size its topology graceful-shutdown
 // budget; computing the sum here keeps that budget aligned with the documented
-// core-agent shutdown window even when operators customize the component
+// core-agent shutdown window even when users customize the component
 // timeouts.
+//
+// It is registered as an override func (runs after datadog.yaml loads) and
+// also called explicitly after fleet policy merging, because fleet policies
+// are applied after the initial override pass.
 func ComputeDataPlaneStopTimeout(config pkgconfigmodel.Config) {
 	if config.GetSource("data_plane.stop_timeout") != pkgconfigmodel.SourceDefault {
 		return

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -856,6 +856,40 @@ data_plane:
 	})
 }
 
+func TestComputeDataPlaneStopTimeout(t *testing.T) {
+	t.Run("unset stop timeout derives from component timeouts", func(t *testing.T) {
+		cfg := confFromYAML(t, "")
+
+		ComputeDataPlaneStopTimeout(cfg)
+
+		assert.Equal(t, 4, cfg.GetInt("data_plane.stop_timeout"))
+		assert.Equal(t, pkgconfigmodel.SourceDefault, cfg.GetSource("data_plane.stop_timeout"))
+	})
+
+	t.Run("explicit stop timeout is preserved", func(t *testing.T) {
+		cfg := confFromYAML(t, `
+data_plane:
+  stop_timeout: 11
+`)
+
+		ComputeDataPlaneStopTimeout(cfg)
+
+		assert.Equal(t, 11, cfg.GetInt("data_plane.stop_timeout"))
+		assert.Equal(t, pkgconfigmodel.SourceFile, cfg.GetSource("data_plane.stop_timeout"))
+	})
+
+	t.Run("recomputes default after component timeout changes", func(t *testing.T) {
+		cfg := confFromYAML(t, "")
+		cfg.Set("aggregator_stop_timeout", 3, pkgconfigmodel.SourceFleetPolicies)
+		cfg.Set("forwarder_stop_timeout", 7, pkgconfigmodel.SourceFleetPolicies)
+
+		ComputeDataPlaneStopTimeout(cfg)
+
+		assert.Equal(t, 10, cfg.GetInt("data_plane.stop_timeout"))
+		assert.Equal(t, pkgconfigmodel.SourceDefault, cfg.GetSource("data_plane.stop_timeout"))
+	})
+}
+
 func TestDataPlaneDefaults(t *testing.T) {
 	cfg := confFromYAML(t, "")
 

--- a/pkg/config/setup/fixup_init.go
+++ b/pkg/config/setup/fixup_init.go
@@ -72,6 +72,7 @@ func fixupInitCommonConfigComponents(config pkgconfigmodel.Config) {
 	pkgconfigmodel.AddOverrideFunc(toggleDefaultPayloads)
 	pkgconfigmodel.AddOverrideFunc(applyInfrastructureModeOverrides)
 	pkgconfigmodel.AddOverrideFunc(ApplyUseDogstatsdSuppression)
+	pkgconfigmodel.AddOverrideFunc(ComputeDataPlaneStopTimeout)
 }
 
 // called only for full-agent, NOT serverless-init, after declaring settings

--- a/releasenotes/notes/adp-data-plane-stop-timeout-2421f91a4d4851b1.yaml
+++ b/releasenotes/notes/adp-data-plane-stop-timeout-2421f91a4d4851b1.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Added the ``data_plane.stop_timeout`` configuration setting, which controls the
+    graceful shutdown budget for the Agent Data Plane (ADP). When unset, it derives
+    its value from ``aggregator_stop_timeout + forwarder_stop_timeout``, so customizing
+    either of those component timeouts now extends ADP's shutdown window in lockstep
+    with the core Agent.


### PR DESCRIPTION
### What does this PR do?

Adds the core Agent config key `data_plane.stop_timeout` so users can set ADP's graceful shutdown timeout from `datadog.yaml` or `DD_DATA_PLANE_STOP_TIMEOUT`.

When `data_plane.stop_timeout` is not set explicitly, the Agent sends ADP the existing default shutdown budget: `aggregator_stop_timeout + forwarder_stop_timeout`. Explicit user values still take precedence.

### Motivation

ADP just added `data_plane.stop_timeout` as the topology-wide graceful shutdown override (DataDog/saluki#1876). For Agent users to set it from `datadog.yaml`, the key must be registered on the core Agent side too. 

### Describe how you validated your changes

- Built the PR Agent locally:

```sh
cd /Users/andrew.qian/Documents/Code/agent-related/datadog-agent
dda inv agent.build --build-exclude=systemd
```

- Ran the PR Agent with an explicit non-default value and local IPC artifacts:

```sh
cd /Users/andrew.qian/Documents/Code/agent-related/datadog-agent
env \
  DD_DATA_PLANE_FORCE_ENABLE=true \
  DD_DATA_PLANE_STOP_TIMEOUT=20 \
  DD_AUTH_TOKEN_FILE_PATH=/Users/andrew.qian/Documents/Code/agent-related/datadog-agent/dev/dist/auth_token \
  DD_IPC_CERT_FILE_PATH=/Users/andrew.qian/Documents/Code/agent-related/datadog-agent/dev/dist/ipc_cert.pem \
  ./bin/agent/agent run -c dev/dist/datadog.yaml
```

- In a second terminal, ran ADP with `DD_API_KEY` set locally in the shell and without passing `DD_DATA_PLANE_STOP_TIMEOUT` to ADP:

```sh
cd /Users/andrew.qian/Documents/Code/agent-related/saluki
env \
  DD_DATA_PLANE_ENABLED=true \
  DD_ADP_OTLP_ENABLED=true \
  DD_DATA_PLANE_OTLP_ENABLED=true \
  DD_OTLP_CONFIG='{}' \
  RUST_LOG=info \
  ADP_RUN_AGENT_CONFIG_DIR=/Users/andrew.qian/Documents/Code/agent-related/datadog-agent/dev/dist \
  make run-adp
```

- Confirmed ADP registered with the Agent and received the initial config over IPC/config stream. ADP logged `Successfully registered with the Datadog Agent`, `Waiting for initial configuration from Datadog Agent...`, and `Initial configuration received.`
- Confirmed the Agent saw the ADP remote agent via `./bin/agent/agent status -c dev/dist/datadog.yaml`, which reported `1 remote agent(s) registered` with name `Agent Data Plane`.
- Confirmed ADP received the Agent-sourced value by querying ADP config:

```sh
cd /Users/andrew.qian/Documents/Code/agent-related/saluki
env \
  DD_AUTH_TOKEN_FILE_PATH=/Users/andrew.qian/Documents/Code/agent-related/datadog-agent/dev/dist/auth_token \
  DD_IPC_CERT_FILE_PATH=/Users/andrew.qian/Documents/Code/agent-related/datadog-agent/dev/dist/ipc_cert.pem \
  target/devel/agent-data-plane \
    -c /Users/andrew.qian/Documents/Code/agent-related/datadog-agent/dev/dist/datadog.yaml \
    config 2>&1 | rg -n -C 4 'data_plane|stop_timeout'
```

The ADP config dump showed `data_plane.stop_timeout: 20` while `aggregator_stop_timeout` and `forwarder_stop_timeout` remained `2`, proving ADP received the explicit Agent-side setting instead of falling back to the `2 + 2` sum.
