### PR TITLE
[NDM Schema Migration] add static 'test' to device config - Step 4/5 (datadog-agent)

### DIFF
--- a/pkg/networkconfigmanagement/report/payload.go
+++ b/pkg/networkconfigmanagement/report/payload.go
@@ -33,6 +33,7 @@ type NetworkDeviceConfig struct {
 	Content      string             `json:"content"`
 	ID           string             `json:"id,omitempty"`
 	ConfigHash   string             `json:"config_hash,omitempty"`
+	Test         string             `json:"test"` // [NDM migration] static test value emitted on every config object
 }
 
 // InventoryEntry contains the metadata about the configs stored locally on the agent
@@ -79,5 +80,6 @@ func ToNetworkDeviceConfig(deviceID, deviceIP string, configType types.ConfigTyp
 		Content:      string(content),
 		ID:           uuid,
 		ConfigHash:   configHash,
+		Test:         "test", // [NDM migration] static value emitted on every config object
 	}
 }


### PR DESCRIPTION
## Schema Migration: add static `test` value to device config (additive)

**Why:** Practice migration — propagate a new static string `test` end-to-end from the agent's NCM config payload to network-device-api.
**Pipeline:** ndm-data-pipeline · **Kind:** additive
**Step:** 4 of 5 — datadog-agent (origin)

### This step
Adds `Test` to `NetworkDeviceConfig` and sets it to the static `"test"` in `ToNetworkDeviceConfig`, so every emitted config object carries the value on the `ndm` EVP track.

### Full migration sequence (merge in order)
- Step 1: orgstore-ndm — k8s-resources#162557
- Step 2: ndm-config-writer — dd-source#470702
- Step 3: event-workers-ndmconfig — dd-source#470710
- **Step 4: datadog-agent** — datadog-agent (this PR) — emit `test:"test"`
- Step 5: network-device-api — dd-source — expose in response

### Safe merge order
⛔ Do not merge until **Step 3 (dd-source#470710)** is merged (the worker must accept the field before the agent emits it). Step 5 merges after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)