### PR TITLE
fix(renovate): Disable the strict mode for go

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -94,12 +94,6 @@
         "enabled": false
       },
       {
-        "description": "Only propose Go module updates compatible with the module go directive",
-        "matchManagers": ["gomod"],
-        "matchDepTypes": ["require", "indirect", "tool"],
-        "constraintsFiltering": "strict"
-      },
-      {
         "description": "Disable Go directives, toolchain (go update is managed independently) or replace (->fork)",
         "matchManagers": ["gomod"],
         "matchDepTypes": ["golang", "toolchain", "replace"],


### PR DESCRIPTION
This constraint still prevent updates from being done. Let's remove it completely, we will dismiss the libraries that force a gomod update.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
Stop the tentatives from:
- https://github.com/DataDog/datadog-agent/pull/52260
- https://github.com/DataDog/datadog-agent/pull/49631
