### PR TITLE
chore(network/encoding): use builder API in other HTTP2 tests

### DIFF
--- a/pkg/network/encoding/encoding_linux_test.go
+++ b/pkg/network/encoding/encoding_linux_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/golang/protobuf/proto" //nolint:staticcheck // SA1019: agent-payload/v5/process types are gogo-generated and do not implement protoreflect.ProtoMessage
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -46,8 +45,8 @@ func assertConnsEqualHTTP2(t *testing.T, expected, actual *model.Connections) {
 		// the workaround is to check for protobuf equality, and then set actual.Conns[i] == expected.Conns[i]
 		// so actual.Conns and expected.Conns can be compared.
 		var expectedHTTP2, actualHTTP2 model.HTTP2Aggregations
-		require.NoError(t, proto.Unmarshal(expectedRawHTTP2, &expectedHTTP2))
-		require.NoError(t, proto.Unmarshal(actualRawHTTP2, &actualHTTP2))
+		require.NoError(t, expectedHTTP2.Unmarshal(expectedRawHTTP2))
+		require.NoError(t, actualHTTP2.Unmarshal(actualRawHTTP2))
 		require.Equalf(t, expectedHTTP2, actualHTTP2, "HTTP2 connection %d was not equal", i)
 		actual.Conns[i].Http2Aggregations = expected.Conns[i].Http2Aggregations
 	}
@@ -96,19 +95,14 @@ func TestHTTP2SerializationWithLocalhostTraffic(t *testing.T) {
 		},
 	}
 
-	http2Out := &model.HTTP2Aggregations{
-		EndpointAggregations: []*model.HTTPStats{
-			{
-				Path:              "/testpath",
-				Method:            model.HTTPMethod_Post,
-				FullPath:          true,
-				StatsByStatusCode: make(map[int32]*model.HTTPStats_Data),
-			},
-		},
-	}
-
-	http2OutBlob, err := proto.Marshal(http2Out)
-	require.NoError(t, err)
+	var http2OutBuf bytes.Buffer
+	http2OutBuilder := model.NewHTTP2AggregationsBuilder(&http2OutBuf)
+	http2OutBuilder.AddEndpointAggregations(func(s *model.HTTPStatsBuilder) {
+		s.SetPath("/testpath")
+		s.SetMethod(uint64(model.HTTPMethod_Post))
+		s.SetFullPath(true)
+	})
+	http2OutBlob := http2OutBuf.Bytes()
 
 	out := &model.Connections{
 		Conns: []*model.Connection{
@@ -182,7 +176,7 @@ func TestPooledHTTP2ObjectGarbageRegression(t *testing.T) {
 		}
 
 		http2Out := new(model.HTTP2Aggregations)
-		err = proto.Unmarshal(http2Blob, http2Out)
+		err = http2Out.Unmarshal(http2Blob)
 		require.NoError(t, err)
 		return http2Out
 	}


### PR DESCRIPTION
### What does this PR do?
Replace `proto.Marshal`/`proto.Unmarshal` with the `protoc-*`-generated builders and `Unmarshal` methods in:
- `TestHTTP2SerializationWithLocalhostTraffic`,
- `TestPooledHTTP2ObjectGarbageRegression`.

### Motivation
This is a follow-up to #52316, which noted the remaining `proto.Marshal` call as out of scope (incident).
The generated builder API is indeed suitable for constructing expected blobs, and the `gogo`-generated `Unmarshal` method is its natural inverse.

### Describe how you validated your changes
CI.