### PR TITLE
Add a claude guideline to not create bazel config_settings without asking

### DIFF
--- a/.claude/rules/bazel.md
+++ b/.claude/rules/bazel.md
@@ -12,3 +12,9 @@ Ingest bazel/AGENTS.md prior to any Bazel-related activity:
 - reading or editing Bazel files,
 - running `bazel` commands,
 - inspecting Bazel-managed directories.
+
+## config_setting — design review required
+
+If a solution requires a new `config_setting`, **stop before implementing it**.
+Explain the proposed design to the user and wait for explicit approval.
+`config_setting` additions affect the build graph globally and require design review before being added to the project.


### PR DESCRIPTION
### What does this PR do?

Adds a recommendation that it must ask for human approval and design review before implementing solutions that create a bazel config_setting.

### Motivation

I just saw claude to something that was technically correct, but would have terrible performance and complexity.

### Describe how you validated your changes

How does one prove anything about an AI guideline.

### Additional Notes
