### PR TITLE
fix(pkg/config/setup): revert `invalidconfig` flag to `false`

### DIFF
--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8456,7 +8456,7 @@ properties:
           enabled:
             node_type: setting
             type: boolean
-            default: true
+            default: false
             comment: |-
               health_platform.invalidconfig_check.enabled is off by default because the check calls
               schema.ValidateCoreConfig which decompresses, parses, and compiles the full core_schema.yaml

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1217,7 +1217,7 @@ func agent(config pkgconfigmodel.Setup) {
 	// (~8000 lines) into a *jsonschema.Schema retained globally for the process lifetime.
 	// This adds ~8 MiB of permanent heap even when the agent config is valid.
 	// Enable it deliberately if you need schema validation at startup.
-	config.BindEnvAndSetDefault("health_platform.invalidconfig_check.enabled", true)
+	config.BindEnvAndSetDefault("health_platform.invalidconfig_check.enabled", false)
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
 	config.BindEnvAndSetDefault("win_skip_com_init", false)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)


### PR DESCRIPTION
### What does this PR do?
**Flip a default back** to false until the schema type mismatch is fixed.

### Motivation
#52226 accidentally enabled `health_platform.invalidconfig_check.enabled` by default.

The existing comment actually explains the original reason why it should have remained disabled:
https://github.com/DataDog/datadog-agent/blob/bad6782aac0424636210de5ed5eef59bdb7b2953/pkg/config/setup/common_settings.go#L1215-L1220

More importantly, the schema has a pre-existing bug where `golang_type:duration` fields are declared as `type: number` but real configs supply duration `strings` (e.g. "5s"), causing spurious schema violations that broke `new-e2e-agent-subcommands` on `main`:
- [Linux](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1778359743/viewer#L2231):
  ```
  Diagnosis: Found 1 schema violation in /etc/datadog-agent/datadog.yaml: at '/remote_configuration/refresh_interval': got string, want number
  ```
- [Windows](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1778378943/viewer#L10982):
  ```
  Diagnosis: Found 1 schema violation in C:\ProgramData\Datadog\datadog.yaml: at '/remote_configuration/refresh_interval': got string, want number
  ```

### Additional Notes
Analysis:
- https://app.datadoghq.com/actions/agents/3796fd1f-0993-4df7-9d0c-ca045e959671?ap-custom-agents__conversationId=286e611f-e988-4db6-9580-e87f6fc8a047

Follow-up:
- #52366

Closes #52357