### PR TITLE
Remove unused inputs from cpython builds on windows

### DIFF
--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -13,6 +13,20 @@ load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mklink")
 
+COMMON_GLOB_EXCLUSIONS = [
+    "BUILD.bazel",
+    ".devcontainer/**",
+    "Android/**",
+    "Doc/**",
+    "InternalDocs/**",
+    "iOS/**",
+    "Tools/msi/**",
+    "Tools/nuget/**",
+    # Tests that don't need to be shipped with the Agent
+    "Lib/idlelib/idle_test/**",
+    "Lib/test/**",
+]
+
 # Keep in sync with the ones on repos.MODULE.bazel
 python_externals = {
     "bzip2": "1.0.8",
@@ -56,7 +70,7 @@ run_binary(
     srcs = (
         glob(
             ["**"],
-            exclude = ["**/*.pyc", "BUILD.bazel"],
+            exclude = COMMON_GLOB_EXCLUSIONS + ["**/*.pyc", "BUILD.bazel"],
         ) + [
             "bzip2_win_dir",
             "mpdecimal_win_dir",
@@ -147,21 +161,10 @@ filegroup(
     name = "all_srcs",
     srcs = glob(
         ["**"],
-        exclude = [
-            "BUILD.bazel",
-            ".devcontainer/**",
-            "Android/**",
-            "Doc/**",
-            "InternalDocs/**",
-            "iOS/**",
-            # Windows related.
+        exclude = COMMON_GLOB_EXCLUSIONS + [
+            # Windows-only tooling.
             "PC/**",
             "PCbuild/**",
-            "Tools/msi/**",
-            "Tools/nuget/**",
-            # Tests that don't need to be shipped with the Agent
-            "Lib/idlelib/idle_test/**",
-            "Lib/test/**",
         ],
     ),
 )

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -227,10 +227,6 @@ build do
   # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
   command "#{python} -m pip check"
 
-  # Removing tests that don't need to be shipped in the embedded folder
-  # This dependency doesn't come from the integrations-core lockfiles, so its tests need to be removed here
-  delete "#{site_packages_path}/../idlelib/idle_test/"
-
   unless windows_target?
     block "Remove .exe files" do
       # setuptools come from supervisor and ddtrace


### PR DESCRIPTION
### What does this PR do?

It removes unused inputs to the bazel-driven cpython build on Windows, reducing Bazel overhead.

### Motivation

Windows version of #52173.

### Describe how you validated your changes

Green CI.

### Additional Notes
