### PR TITLE
ci: add build_tags.bzl file to CI bazel_paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,8 +22,8 @@
   if: $DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null
 
 # Windows-specific Go source files, pkg/, and cmd/ (27 paths), need to be splitted because Gitlab has a limit to 50 paths in a single rule
-.windows_path: &windows_path
-  # Windows-specific Go source files (by filename convention)
+.windows_path:
+  &windows_path # Windows-specific Go source files (by filename convention)
   - "**/*_windows.go"
 
   # Windows-specific packages in pkg/
@@ -62,6 +62,7 @@
   - "*.bazel*"
   - deps/**/*
   - bazel/**/*
+  - tasks/build_tags.bzl
 
 # Windows-specific comp/, tools, omnibus, containers, tasks, and cross-cutting paths
 .windows_path_2: &windows_path_2 # Windows-specific comp/ components


### PR DESCRIPTION
### What does this PR do?

Adds the `tasks/build_tags.bzl` file to the `bazel_paths` list of Bazel files that trigger CI jobs.

### Motivation

The `static_quality_gates` job doesn't trigger if there are only changes to the list of build tags. However, changes in that file affect the size of binaries, so we could unknowingly merge regressions if the job does not run.

### Describe how you validated your changes

CI running.

### Additional Notes
