### PR TITLE
fix(ci): run subcommands tests on `pkg/config/schema` changes

### DIFF
--- a/.gitlab/windows/test/e2e/windows.yml
+++ b/.gitlab/windows/test/e2e/windows.yml
@@ -40,6 +40,7 @@ new-e2e-agent-subcommands-windows:
     - !reference [.on_e2e_main_release_or_rc]
     - changes:
         paths:
+          - pkg/config/schema/**/* # DataDog/datadog-agent#52358
           - test/new-e2e/tests/agent-subcommands/**/*
         compare_to: $COMPARE_TO_BRANCH
     - !reference [.manual]

--- a/tasks/dyntest.py
+++ b/tasks/dyntest.py
@@ -30,6 +30,7 @@ def compute_and_upload_job_index(ctx: Context, bucket_uri: str, coverage_folder:
         "test/e2e-framework/**/*",  # Modification to the framework should trigger all tests
         "test/new-e2e/go.mod",
         "go.mod",  # incident-47421
+        "pkg/config/schema/*",  # DataDog/datadog-agent#52358
         "flakes.yaml",
         "release.json",
         ".gitlab/test/e2e/e2e.yml",


### PR DESCRIPTION
### What does this PR do?
Add `pkg/config/schema/**/*` to `dyntest`'s `run_all_paths` and to `new-e2e-agent-subcommands-windows` triggering conditions.

### Motivation
The diffed-coverage `dyntest` index excludes `pkg/config/schema` because agent startup always covers it via the baseline suite, so changes there are not associated with any test suite and slip through undetected.

#52226 exposed this gap: only `TestLinuxFlareSuite` ran in the PR pipeline because `dyntest` skipped the suites that would have caught the regression, and the Windows job did not run at all because schema paths were absent from its trigger.

### Describe how you validated your changes
CI.

### Additional Notes
- short-term countermeasure: #52358
- analysis: https://app.datadoghq.com/actions/agents/3796fd1f-0993-4df7-9d0c-ca045e959671?ap-custom-agents__conversationId=286e611f-e988-4db6-9580-e87f6fc8a047