### PR TITLE
fix: APM replace tags must not be able to change the env tag

### DIFF
--- a/pkg/trace/filters/replacer.go
+++ b/pkg/trace/filters/replacer.go
@@ -29,6 +29,11 @@ func NewReplacer(rules []*config.ReplaceRule) *Replacer {
 
 const hiddenTagPrefix = "_"
 
+// envKey is the Meta tag the trace agent derives the env from (see
+// pkg/trace/traceutil.GetEnv). Replace rules must never rewrite it, otherwise
+// they can silently change the env used for sampling-bucket signatures.
+const envKey = "env"
+
 // Replace replaces all tags matching the Replacer's rules.
 func (f Replacer) Replace(trace pb.Trace) {
 	for _, rule := range f.rules {
@@ -37,11 +42,20 @@ func (f Replacer) Replace(trace pb.Trace) {
 			switch key {
 			case "*":
 				for k := range s.Meta {
+					if k == envKey {
+						// env must stay immutable to replace rules.
+						continue
+					}
 					if !strings.HasPrefix(k, hiddenTagPrefix) {
 						s.Meta[k] = re.ReplaceAllString(s.Meta[k], str)
 					}
 				}
 				for k := range s.Metrics {
+					if k == envKey {
+						// env must stay immutable to replace rules: replaceNumericTag
+						// can move a non-numeric result into Meta["env"].
+						continue
+					}
 					if !strings.HasPrefix(k, hiddenTagPrefix) {
 						f.replaceNumericTag(re, s, k, str)
 					}
@@ -58,6 +72,20 @@ func (f Replacer) Replace(trace pb.Trace) {
 				}
 			case "resource.name":
 				s.Resource = re.ReplaceAllString(s.Resource, str)
+			case envKey:
+				// The env tag must stay immutable to replace rules: the trace
+				// agent derives the sampling env from it (traceutil.GetEnv), so
+				// rewriting it could silently change sampling. This covers both
+				// the Meta path and the numeric-metrics path (replaceNumericTag
+				// can move a metric into Meta["env"]). Span-event attributes
+				// named env are not the sampling env, so they are still replaced.
+				for _, spanEvent := range s.SpanEvents {
+					if spanEvent != nil {
+						if val, ok := spanEvent.Attributes[key]; ok {
+							spanEvent.Attributes[key] = f.replaceAttributeAnyValue(re, val, str)
+						}
+					}
+				}
 			default:
 				if s.Meta != nil {
 					if _, ok := s.Meta[key]; ok {
@@ -90,6 +118,10 @@ func (f Replacer) ReplaceV1(trace *idx.InternalTraceChunk) {
 			case "*":
 				for k, v := range s.Attributes() {
 					kString := trace.Strings.Get(k)
+					if kString == envKey {
+						// env must stay immutable to replace rules.
+						continue
+					}
 					if strings.HasPrefix(kString, hiddenTagPrefix) {
 						continue
 					}
@@ -114,6 +146,15 @@ func (f Replacer) ReplaceV1(trace *idx.InternalTraceChunk) {
 				}
 			case "resource.name":
 				s.SetResource(re.ReplaceAllString(s.Resource(), str))
+			case envKey:
+				// The env tag must stay immutable to replace rules (see the V0
+				// path above); span-event attributes named env are not the
+				// sampling env, so they are still replaced.
+				for _, spanEvent := range s.Events() {
+					if val, ok := spanEvent.GetAttributeAsString(key); ok {
+						spanEvent.SetAttributeFromString(key, re.ReplaceAllString(val, str))
+					}
+				}
 			default:
 				if val, ok := s.GetAttributeAsString(key); ok {
 					s.SetAttributeFromString(key, re.ReplaceAllString(val, str))

--- a/pkg/trace/filters/replacer_test.go
+++ b/pkg/trace/filters/replacer_test.go
@@ -224,6 +224,133 @@ func TestReplacer(t *testing.T) {
 	})
 }
 
+// TestReplacerEnvImmutable verifies that replace rules can never change the
+// "env" tag, which the trace agent uses to derive the sampling env (see
+// pkg/trace/traceutil.GetEnv). Both an explicit "env" rule and a "*" wildcard
+// rule must leave Meta["env"] untouched while still rewriting other tags.
+func TestReplacerEnvImmutable(t *testing.T) {
+	t.Run("v0 named env rule leaves the env Meta tag untouched", func(tt *testing.T) {
+		rules := parseRulesFromString([][3]string{
+			{"env", "prod", "myenv"},
+		})
+		span := &pb.Span{
+			Meta: map[string]string{"env": "prod", "http.url": "/foo"},
+			SpanEvents: []*pb.SpanEvent{
+				{Attributes: map[string]*pb.AttributeAnyValue{
+					"env": {Type: pb.AttributeAnyValue_STRING_VALUE, StringValue: "prod"},
+				}},
+			},
+		}
+		NewReplacer(rules).Replace(pb.Trace{span})
+		// The env Meta tag (used by traceutil.GetEnv for sampling) is immutable.
+		assert.Equal(tt, "prod", span.Meta["env"])
+		assert.Equal(tt, "/foo", span.Meta["http.url"])
+		// A span-event attribute named env is not the sampling env, so an
+		// explicit env rule still applies to it (matching wildcard behavior).
+		assert.Equal(tt, "myenv", span.SpanEvents[0].Attributes["env"].StringValue)
+	})
+
+	t.Run("v0 named env rule does not leak a numeric env metric into Meta", func(tt *testing.T) {
+		// replaceNumericTag can move a non-numeric replacement result from
+		// Metrics into Meta; an env rule must not be able to create or change
+		// Meta["env"] that way.
+		rules := parseRulesFromString([][3]string{
+			{"env", "1", "prod"},
+		})
+		span := &pb.Span{
+			Meta:    map[string]string{},
+			Metrics: map[string]float64{"env": 1},
+		}
+		NewReplacer(rules).Replace(pb.Trace{span})
+		_, ok := span.Meta["env"]
+		assert.False(tt, ok, "env metric must not be written into Meta[\"env\"]")
+		assert.Equal(tt, float64(1), span.Metrics["env"], "env metric is unchanged")
+	})
+
+	t.Run("v0 wildcard rule does not touch env", func(tt *testing.T) {
+		rules := parseRulesFromString([][3]string{
+			{"*", "prod", "stage"},
+		})
+		span := &pb.Span{
+			Meta:     map[string]string{"env": "prod", "custom.tag": "prod-value"},
+			Resource: "prod-resource",
+		}
+		NewReplacer(rules).Replace(pb.Trace{span})
+		assert.Equal(tt, "prod", span.Meta["env"], "env must be immutable")
+		assert.Equal(tt, "stage-value", span.Meta["custom.tag"], "other tags still replaced")
+		assert.Equal(tt, "stage-resource", span.Resource, "resource still replaced")
+	})
+
+	t.Run("v0 wildcard rule does not leak a numeric env metric into Meta", func(tt *testing.T) {
+		rules := parseRulesFromString([][3]string{
+			{"*", "1", "prod"},
+		})
+		span := &pb.Span{
+			Meta:    map[string]string{},
+			Metrics: map[string]float64{"env": 1, "latency": 1},
+		}
+		NewReplacer(rules).Replace(pb.Trace{span})
+		_, ok := span.Meta["env"]
+		assert.False(tt, ok, "wildcard rule must not write env into Meta")
+		assert.Equal(tt, float64(1), span.Metrics["env"], "env metric is unchanged")
+		// A non-env numeric metric is still subject to the wildcard rule.
+		assert.Equal(tt, "prod", span.Meta["latency"], "non-env metric still replaced")
+	})
+
+	t.Run("v1 named env rule leaves the env attribute untouched", func(tt *testing.T) {
+		rules := parseRulesFromString([][3]string{
+			{"env", "prod", "myenv"},
+		})
+		chunk := &idx.InternalTraceChunk{
+			Spans:   make([]*idx.InternalSpan, 1),
+			Strings: idx.NewStringTable(),
+		}
+		span := idx.NewInternalSpan(chunk.Strings, &idx.Span{
+			SpanID:      rand.Uint64(),
+			ParentID:    1111,
+			ServiceRef:  chunk.Strings.Add("django"),
+			NameRef:     chunk.Strings.Add("django.controller"),
+			ResourceRef: chunk.Strings.Add("GET /some/raclette"),
+			Start:       1448466874000000000,
+			Duration:    10000000,
+			Attributes:  map[uint32]*idx.AnyValue{},
+			Events: []*idx.SpanEvent{
+				{NameRef: chunk.Strings.Add("foo"), Attributes: map[uint32]*idx.AnyValue{}},
+			},
+		})
+		span.SetAttributeFromString("env", "prod")
+		span.SetAttributeFromString("http.url", "/foo")
+		span.Events()[0].SetAttributeFromString("env", "prod")
+		chunk.Spans[0] = span
+		NewReplacer(rules).ReplaceV1(chunk)
+		env, _ := chunk.Spans[0].GetAttributeAsString("env")
+		url, _ := chunk.Spans[0].GetAttributeAsString("http.url")
+		eventEnv, _ := chunk.Spans[0].Events()[0].GetAttributeAsString("env")
+		assert.Equal(tt, "prod", env, "env tag must be immutable")
+		assert.Equal(tt, "/foo", url)
+		assert.Equal(tt, "myenv", eventEnv, "span-event env attribute is still replaced")
+	})
+
+	t.Run("v1 wildcard rule does not touch env", func(tt *testing.T) {
+		rules := parseRulesFromString([][3]string{
+			{"*", "prod", "stage"},
+		})
+		chunk := &idx.InternalTraceChunk{
+			Spans:   make([]*idx.InternalSpan, 1),
+			Strings: idx.NewStringTable(),
+		}
+		span := newTestSpanV1EmptyAttributes(chunk.Strings)
+		span.SetAttributeFromString("env", "prod")
+		span.SetAttributeFromString("custom.tag", "prod-value")
+		chunk.Spans[0] = span
+		NewReplacer(rules).ReplaceV1(chunk)
+		env, _ := chunk.Spans[0].GetAttributeAsString("env")
+		custom, _ := chunk.Spans[0].GetAttributeAsString("custom.tag")
+		assert.Equal(tt, "prod", env, "env must be immutable")
+		assert.Equal(tt, "stage-value", custom, "other tags still replaced")
+	})
+}
+
 // GetTestSpan returns a Span with different fields set
 func newTestSpanV1EmptyAttributes(strings *idx.StringTable) *idx.InternalSpan {
 	return idx.NewInternalSpan(strings, &idx.Span{

--- a/releasenotes/notes/apm-replace-tags-env-immutable-c17a446714d5697f.yaml
+++ b/releasenotes/notes/apm-replace-tags-env-immutable-c17a446714d5697f.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    APM: ``DD_APM_REPLACE_TAGS`` rules can no longer change a span's ``env`` tag.
+    A rule targeting ``env`` or a ``*`` wildcard rule previously rewrote the
+    ``env`` Meta tag, which the trace agent uses to derive the sampling env. This
+    could silently change the env used for sampling-bucket signatures and cause
+    the tracer to fall back to 100% ingestion. The ``env`` tag is now immutable
+    to replace rules.


### PR DESCRIPTION
### What does this PR do?

Makes the `env` tag immutable to `DD_APM_REPLACE_TAGS` (replace tags) rules. A rule that targets `env` directly (e.g. `{"name":"env","pattern":".*","repl":"myenv"}`) or a `*` wildcard rule can no longer rewrite a span's `env`.

The exclusion is applied consistently across every path that could reach the env tag:

- `Replacer.Replace` (V0): the `*` wildcard `Meta` loop, the `*` wildcard `Metrics` loop, and a named `env` rule (a dedicated `case "env"` that skips both `Meta` and the numeric-metrics path).
- `Replacer.ReplaceV1` (V1, used by `ProcessV1`): the `*` wildcard attribute loop and a named `env` rule.

`resource.name` rules and `ReplaceStatsGroup` are unchanged. Span-event attributes named `env` are intentionally still replaced (both by `*` and by a named rule): they are not the sampling env and are documented as subject to replace rules, so excluding them would be a redaction regression.

The numeric-metrics paths matter because `replaceNumericTag` can move a non-numeric replacement result from `Metrics["env"]` into `Meta["env"]`, which would otherwise re-introduce the very mutation this change prevents.

### Motivation

Fixes #21253.

The trace agent derives the env used for sampling-bucket signatures from the span `Meta` via `traceutil.GetEnv` (`Meta["env"]`). When a replace rule rewrites `env`, the env used for sampling silently changes. With no env configured on the Agent and a tracer sending spans under a different env, the rewritten env makes the Agent's returned sample rates never match the tracer's env, so the tracer falls back to 100% ingestion. As the issue states, replace tags should not be able to alter the Agent env in any way.

### Describe how you validated your changes

Added `TestReplacerEnvImmutable` in `pkg/trace/filters/replacer_test.go` covering both V0 and V1:

- A named `env` rule leaves `Meta["env"]` / the env attribute untouched, while still rewriting a span-event attribute named `env`.
- A `*` wildcard rule leaves `env` untouched while still rewriting other `Meta` tags, the resource, and non-env numeric metrics.
- A numeric `env` metric is not leaked into `Meta["env"]` under either a named `env` rule or a `*` rule.

Existing `TestReplacer` cases (stats, span events, traces v1) continue to pass, confirming non-env tags, resources, and metrics are still replaced as before.

```
go test ./pkg/trace/filters/...   # ok
gofmt -l / go vet ./pkg/trace/filters/...  # clean
```

### Additional Notes

A `releasenotes/notes/` reno fragment is included documenting the fix.
