### PR TITLE
[DOIO-36] Extend queryactions component to support SQL Server

### DIFF
--- a/comp/dataobs/queryactions/def/component.go
+++ b/comp/dataobs/queryactions/def/component.go
@@ -11,6 +11,6 @@ package queryactions
 // Component is the Data Observability query actions component interface.
 // This component subscribes to RC DO_QUERY_ACTIONS product to receive declarative query configs,
 // each containing the full set of active monitor queries for a DB instance.
-// It injects data_observability config into matching postgres check instances.
-// Activates when a postgres instance with data_observability.enabled: true is detected.
+// It injects data_observability config into matching supported database check instances.
+// Activates when a supported integration instance with data_observability.enabled: true is detected.
 type Component interface{}

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -8,6 +8,7 @@ package queryactionsimpl
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"net"
@@ -26,19 +27,17 @@ var databaseIdentifierVariablePattern = regexp.MustCompile(`\$\$|\$\{[A-Za-z_][A
 
 const defaultPostgresPort = 5432
 
-// A "base config" is a postgres integration.Config emitted by another provider (typically the
-// file provider reading conf.d/postgres.d/conf.yaml) that a DO query action matched against via
-// findPostgresConfig — i.e. the config as it exists before DO touches it. A single base config
-// can bundle several postgres instances. Throughout this file, "base config" always refers to
-// this original, provider-emitted config, as distinct from the DO check config or remainder
-// config that this component derives from it.
+// A "base config" is a supported DB integration.Config emitted by another provider that a DO
+// query action matched against. A single base config can bundle several instances. Throughout
+// this file, "base config" always refers to this original, provider-emitted config, as distinct
+// from the DO check config or remainder config that this component derives from it.
 
-// activeConfigEntry stores the scheduled DO check config alongside the base postgres config it
+// activeConfigEntry stores the scheduled DO check config alongside the base integration config it
 // was derived from and the instance identity it targets, so reconcileBases can rebuild the set of
-// postgres instances that should keep running independently of any single DO config.
+// integration instances that should keep running independently of any single DO config.
 type activeConfigEntry struct {
 	checkConfig   integration.Config
-	baseCfg       *integration.Config    // the original matched postgres config (full, all instances)
+	baseCfg       *integration.Config    // the original matched integration config (full, all instances)
 	matchInstance instanceConfigIdentity // exact source instance this DO config targets
 }
 
@@ -47,7 +46,7 @@ type activeConfigEntry struct {
 // while using different database_identifier templates or tags.
 type instanceConfigIdentity [sha256.Size]byte
 
-// managedBaseEntry tracks a base postgres config that has at least one instance targeted by a
+// managedBaseEntry tracks a base integration config that has at least one instance targeted by a
 // DO query action. A DO query action only injects data_observability.queries into the targeted
 // instance — every other field, and every other instance, is unchanged. But autodiscovery
 // schedules whole configs (by digest), not single instances, so we cannot patch one instance in
@@ -59,14 +58,33 @@ type managedBaseEntry struct {
 	remainder *integration.Config // remainder config currently scheduled, or nil if none
 }
 
+// isSupportedIntegration reports whether name is a supported DB integration.
+func isSupportedIntegration(name string) bool {
+	return name == "postgres" || name == "sap_hana" || name == "sqlserver"
+}
+
 // instanceHost returns the host/server field for an integration instance,
-// handling the fact that sap_hana uses "server" while postgres uses "host".
+// handling the fact that SAP HANA uses "server" while other integrations use "host".
 func instanceHost(instance map[string]any) string {
 	if host, ok := instance["host"].(string); ok && host != "" {
 		return host
 	}
 	server, _ := instance["server"].(string)
 	return server
+}
+
+// azureSQLDatabase returns the database when the instance uses Azure SQL Database.
+func azureSQLDatabase(instance map[string]any) (string, bool) {
+	azure, ok := instance["azure"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	deploymentType, _ := azure["deployment_type"].(string)
+	if deploymentType != "sql_database" {
+		return "", false
+	}
+	database, _ := instance["database"].(string)
+	return database, true
 }
 
 // instanceHasDOEnabled checks whether a parsed instance map has data_observability.enabled: true.
@@ -113,7 +131,7 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 			continue
 		}
 
-		// Validate each query spec before paying the cost of finding the postgres config.
+		// Validate each query spec before paying the cost of finding the integration config.
 		// On the first invalid query, reject the entire config — no partial scheduling.
 		var validationErr error
 		for _, q := range payload.Queries {
@@ -128,9 +146,9 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 			continue
 		}
 
-		baseCfg, instance, matchInstance, err := c.resolveBaseConfig(configID, &payload.DBIdentifier)
+		baseCfg, instance, matchInstance, err := c.resolveBaseConfig(configID, &payload.DBIdentifier, payload.Queries)
 		if err != nil {
-			c.log.Warnf("No matching postgres config for %s: %v", configID, err)
+			c.log.Warnf("No matching integration config for %s: %v", configID, err)
 			applyStatus(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
 			c.removeActiveConfig(configID, &changes)
 			continue
@@ -179,7 +197,7 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 		c.removeActiveConfig(configID, &changes)
 	}
 
-	// Reconcile base postgres configs: schedule remainder configs for partially-managed bases
+	// Reconcile base integration configs: schedule remainder configs for partially-managed bases
 	// and restore originals for bases no longer targeted by any DO config.
 	c.reconcileBases(&changes)
 
@@ -205,20 +223,19 @@ func (c *component) removeActiveConfig(configID string, changes *integration.Con
 	changes.Unschedule = append(changes.Unschedule, prev.checkConfig)
 }
 
-// reconcileBases keeps file-provider postgres instances that are NOT targeted by a DO query
+// reconcileBases keeps file-provider integration instances that are NOT targeted by a DO query
 // action scheduled, while preventing the targeted instances from running twice.
 //
 // Autodiscovery schedules whole integration.Configs (keyed by Digest), but a single
-// file-provider postgres config can bundle several instances. When a DO config targets one of
-// them, we cannot simply unschedule the whole base config — that would drop the untargeted
-// sibling instances. Instead, for each base config that currently has at least one active DO
-// config, we unschedule the original and schedule a "remainder" config holding only the
-// instances no DO config targets. Once no DO config targets a base config, the original is
-// restored.
+// file-provider config can bundle several instances. When a DO config targets one of them, we
+// cannot simply unschedule the whole base config — that would drop the untargeted sibling
+// instances. Instead, for each base config that currently has at least one active DO config, we
+// unschedule the original and schedule a "remainder" config holding only the instances no DO
+// config targets. Once no DO config targets a base config, the original is restored.
 //
 // The remainder is computed from the full set of active DO configs, so multiple DO configs
-// targeting different instances of the same base config never cause an instance to be both
-// kept in the remainder and run as a DO check (which would duplicate DBM collection).
+// targeting different instances of the same base config never cause an instance to be both kept
+// in the remainder and run as a DO check (which would duplicate DBM collection).
 func (c *component) reconcileBases(changes *integration.ConfigChanges) {
 	c.activeConfigsMu.Lock()
 	defer c.activeConfigsMu.Unlock()
@@ -276,7 +293,7 @@ func (c *component) reconcileBases(changes *integration.ConfigChanges) {
 		}
 		changes.Schedule = append(changes.Schedule, managed.original)
 		delete(c.managedBases, digest)
-		c.log.Infof("Restored original postgres config (digest %s); no Data Observability query actions target it", digest)
+		c.log.Infof("Restored original integration config (digest %s); no Data Observability query actions target it", digest)
 	}
 }
 
@@ -311,6 +328,11 @@ func sameConfig(a, b *integration.Config) bool {
 	return a.Digest() == b.Digest()
 }
 
+var (
+	errAmbiguousSQLServerInstanceMatch = errors.New("ambiguous SQL Server instance match")
+	errEmptyIdentifierHost             = errors.New("empty db_identifier.host")
+)
+
 // resolveBaseConfig returns the base config a DO check for configID should be derived from.
 //
 // If configID is already active, its previously-resolved base is reused as-is rather than
@@ -325,67 +347,78 @@ func sameConfig(a, b *integration.Config) bool {
 //
 // Falls back to a fresh search if the stored base no longer has an instance matching dbID (e.g.
 // its host genuinely changed between updates).
-func (c *component) resolveBaseConfig(configID string, dbID *DBIdentifier) (*integration.Config, map[string]any, instanceConfigIdentity, error) {
+func (c *component) resolveBaseConfig(configID string, dbID *DBIdentifier, queries []QuerySpec) (*integration.Config, map[string]any, instanceConfigIdentity, error) {
+	if dbID.Host == "" {
+		return nil, nil, instanceConfigIdentity{}, errEmptyIdentifierHost
+	}
+
 	c.activeConfigsMu.Lock()
 	existing, alreadyActive := c.activeConfigs[configID]
 	c.activeConfigsMu.Unlock()
 
 	if alreadyActive {
-		instance, identity, err := c.findMatchingInstance(existing.baseCfg, dbID)
+		instance, identity, err := c.findMatchingInstance(existing.baseCfg, dbID, queries)
 		if instance != nil {
 			return existing.baseCfg, instance, identity, nil
+		}
+		if errors.Is(err, errAmbiguousSQLServerInstanceMatch) {
+			return nil, nil, instanceConfigIdentity{}, err
 		}
 		if err != nil {
 			c.log.Warnf("Stored base config for %s no longer parses cleanly, re-resolving: %v", configID, err)
 		}
 	}
-	return c.findMatchingConfig(dbID)
+	return c.findMatchingConfig(dbID, queries)
 }
 
-// findMatchingConfig finds a supported DB integration config that matches the given identifier
-// and has data_observability.enabled: true. Returns the matching config and the already-parsed
-// instance map to avoid re-parsing YAML in callers.
-func (c *component) findMatchingConfig(dbID *DBIdentifier) (*integration.Config, map[string]any, instanceConfigIdentity, error) {
-	cfgs := c.ac.GetUnresolvedConfigs()
+// findMatchingConfig finds an enabled supported integration instance matching the identifier and
+// queries.
+func (c *component) findMatchingConfig(dbID *DBIdentifier, queries []QuerySpec) (*integration.Config, map[string]any, instanceConfigIdentity, error) {
+	if dbID.Host == "" {
+		return nil, nil, instanceConfigIdentity{}, errEmptyIdentifierHost
+	}
 
+	cfgs := c.ac.GetUnresolvedConfigs()
 	var lastParseErr error
+
 	for cfgIdx := range cfgs {
-		cfg := cfgs[cfgIdx]
-		instance, identity, err := c.findMatchingInstance(&cfg, dbID)
+		cfg := &cfgs[cfgIdx]
+		if !isSupportedIntegration(cfg.Name) {
+			continue
+		}
+		instance, identity, err := c.findMatchingInstance(cfg, dbID, queries)
+		if errors.Is(err, errAmbiguousSQLServerInstanceMatch) {
+			return nil, nil, instanceConfigIdentity{}, err
+		}
 		if err != nil {
 			lastParseErr = err
 		}
 		if instance != nil {
-			return &cfg, instance, identity, nil
+			return cfg, instance, identity, nil
 		}
 	}
-
 	if lastParseErr != nil {
-		return nil, nil, instanceConfigIdentity{}, fmt.Errorf("no supported DB config found for identifier: type=%s, host=%s; at least one instance had a YAML parse error: %w",
-			dbID.Type, dbID.Host, lastParseErr)
+		return nil, nil, instanceConfigIdentity{}, fmt.Errorf("no supported integration config found for identifier: type=%s, host=%s; at least one instance had a YAML parse error: %w", dbID.Type, dbID.Host, lastParseErr)
 	}
-	return nil, nil, instanceConfigIdentity{}, fmt.Errorf("no supported DB config found for identifier: type=%s, host=%s",
-		dbID.Type, dbID.Host)
+	return nil, nil, instanceConfigIdentity{}, fmt.Errorf("no supported integration config found for identifier: type=%s, host=%s", dbID.Type, dbID.Host)
 }
 
-// findMatchingInstance searches cfg's instances for one matching dbID with data_observability
-// enabled, returning the first match. Instances whose YAML fails to parse are skipped (logged and
-// recorded as lastErr) rather than aborting the search — a later instance may still match.
-func (c *component) findMatchingInstance(cfg *integration.Config, dbID *DBIdentifier) (map[string]any, instanceConfigIdentity, error) {
-	if cfg.Name != "postgres" && cfg.Name != "sap_hana" {
-		c.log.Warnf("DO query action: config %s is not a known DO-supported integration", cfg.Name)
-	}
-
-	var lastErr error
+// findMatchingInstance returns the first enabled match for PostgreSQL and SAP HANA. It rejects
+// multiple SQL Server matches because a host-only identifier could otherwise select an arbitrary
+// local SQL Server instance.
+func (c *component) findMatchingInstance(cfg *integration.Config, dbID *DBIdentifier, queries []QuerySpec) (map[string]any, instanceConfigIdentity, error) {
+	var lastParseErr error
+	var matchedInstance map[string]any
+	var matchedIdentity instanceConfigIdentity
 	for _, instanceData := range cfg.Instances {
 		var instance map[string]any
 		if err := yaml.Unmarshal(instanceData, &instance); err != nil {
 			c.log.Warnf("Failed to unmarshal %s instance data for config %s, skipping: %v", cfg.Name, cfg.Name, err)
-			lastErr = err
+			lastParseErr = err
 			continue
 		}
 
-		match := evaluateInstanceIdentifier(instance, *dbID, cfg.Name)
+		match := evaluateInstanceIdentifier(instance, *dbID, cfg.Name, queries)
 		c.log.Debugf(
 			"Evaluated DO query action database identifier: integration=%s instance_host=%q target=%q strategy=%s rendered_database_identifier=%q renderable=%t matched=%t",
 			cfg.Name,
@@ -396,11 +429,19 @@ func (c *component) findMatchingInstance(cfg *integration.Config, dbID *DBIdenti
 			match.renderable,
 			match.matched,
 		)
-		if match.matched && instanceHasDOEnabled(instance) {
+		if !match.matched || !instanceHasDOEnabled(instance) {
+			continue
+		}
+		if cfg.Name != "sqlserver" {
 			return instance, identifyInstanceConfig(instanceData), nil
 		}
+		if matchedInstance != nil {
+			return nil, instanceConfigIdentity{}, fmt.Errorf("%w for identifier: type=%s, host=%s", errAmbiguousSQLServerInstanceMatch, dbID.Type, dbID.Host)
+		}
+		matchedInstance = instance
+		matchedIdentity = identifyInstanceConfig(instanceData)
 	}
-	return nil, instanceConfigIdentity{}, lastErr
+	return matchedInstance, matchedIdentity, lastParseErr
 }
 
 // matchesIdentifier checks if a Postgres instance matches the given DB identifier. It uses the
@@ -410,16 +451,8 @@ func matchesIdentifier(instance map[string]any, dbID *DBIdentifier) bool {
 	return instanceMatchesIdentifier(instance, *dbID, "postgres")
 }
 
-// instanceMatchesIdentifier reports whether an integration instance targets the given identifier.
-// sap_hana uses "server" as the host key; postgres uses "host". The target host may be
-// "host:port" (as sent by sap_hana backends) or bare "host", so we match against both the
-// bare host and the "host:port" form built from the instance. Postgres also derives its
-// database_instance from a configurable template. Render the same connection and tag values as
-// the Python check and compare the resulting value.
-//
-// This is the single source of truth for selecting the instance to schedule.
 func instanceMatchesIdentifier(instance map[string]any, identifier DBIdentifier, integrationName string) bool {
-	return evaluateInstanceIdentifier(instance, identifier, integrationName).matched
+	return evaluateInstanceIdentifier(instance, identifier, integrationName, nil).matched
 }
 
 type identifierMatchEvaluation struct {
@@ -429,15 +462,43 @@ type identifierMatchEvaluation struct {
 	renderable         bool
 }
 
-func evaluateInstanceIdentifier(instance map[string]any, identifier DBIdentifier, integrationName string) identifierMatchEvaluation {
+// evaluateInstanceIdentifier keeps each integration's identifier contract independent.
+func evaluateInstanceIdentifier(instance map[string]any, identifier DBIdentifier, integrationName string, queries []QuerySpec) identifierMatchEvaluation {
+	if identifier.Host == "" {
+		return identifierMatchEvaluation{strategy: "empty_identifier"}
+	}
 	switch integrationName {
 	case "postgres":
 		return evaluatePostgresIdentifier(instance, identifier)
 	case "sap_hana":
 		return evaluateSapHanaIdentifier(instance, identifier.Host)
+	case "sqlserver":
+		return evaluateSQLServerIdentifier(instance, identifier.Host, queries)
 	default:
 		return identifierMatchEvaluation{strategy: "unsupported_integration"}
 	}
+}
+
+func evaluateSQLServerIdentifier(instance map[string]any, targetHost string, queries []QuerySpec) identifierMatchEvaluation {
+	match := evaluateSapHanaIdentifier(instance, targetHost)
+	if !match.matched {
+		match.strategy = "sqlserver_endpoint"
+		return match
+	}
+	database, isAzureSQLDatabase := azureSQLDatabase(instance)
+	if !isAzureSQLDatabase {
+		return match
+	}
+	if len(queries) == 0 {
+		return identifierMatchEvaluation{strategy: "azure_sql_database"}
+	}
+	for _, query := range queries {
+		if !strings.EqualFold(query.DBName, database) {
+			return identifierMatchEvaluation{strategy: "azure_sql_database"}
+		}
+	}
+	match.strategy = "azure_sql_database"
+	return match
 }
 
 func evaluatePostgresIdentifier(instance map[string]any, identifier DBIdentifier) identifierMatchEvaluation {

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -779,7 +779,7 @@ func TestFindMatchingConfig_TemplatedIdentifiersDistinguishPorts(t *testing.T) {
 				Type:          "self-hosted",
 				Host:          fmt.Sprintf("do-test-postgres-staging:%d", port),
 				AgentHostname: "do-test-postgres-staging",
-			})
+			}, nil)
 			require.NoError(t, err)
 			assert.Equal(t, port, instance["port"])
 		})
@@ -1041,6 +1041,67 @@ func TestOnRCUpdate_PortlessMatchedInstance_KeepsPortedSiblingInRemainder(t *tes
 	assert.Equal(t, siblingPort, remainderInstance["port"], "remainder must keep the ported sibling, not drop it via the portless matched identity")
 }
 
+// TestOnRCUpdate_SameHostDifferentPorts_RejectsAmbiguousMatch verifies that a literal SQL Server
+// host cannot silently select the first of two enabled local instances that differ only by port.
+func TestOnRCUpdate_SameHostDifferentPorts_RejectsAmbiguousMatch(t *testing.T) {
+	const sharedHost = "sqlserver.internal"
+	sqlserverCfg := integration.Config{
+		Name:     "sqlserver",
+		Provider: "file",
+		Instances: []integration.Data{
+			integration.Data("host: " + sharedHost + "\nport: 1433\ndata_observability:\n  enabled: true\n"),
+			integration.Data("host: " + sharedHost + "\nport: 1434\ndata_observability:\n  enabled: true\n"),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{sqlserverCfg})
+
+	payloadJSON, err := json.Marshal(DOQueryPayload{
+		ConfigID:     "cfg-same-host",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: sharedHost},
+		Queries:      []QuerySpec{{DBName: "master", Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+	})
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-same-host": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateError, statuses["path/cfg-same-host"].State)
+	assert.Contains(t, statuses["path/cfg-same-host"].Error, "ambiguous SQL Server instance match")
+	assert.Empty(t, changes.Schedule)
+	assert.Empty(t, changes.Unschedule)
+	assert.Empty(t, c.activeConfigs)
+}
+
+// TestOnRCUpdate_DuplicateLocalInstances_RejectsAmbiguousMatch verifies that duplicate enabled
+// local instances are rejected instead of resolving to whichever one appears first.
+func TestOnRCUpdate_DuplicateLocalInstances_RejectsAmbiguousMatch(t *testing.T) {
+	const instanceYAML = "host: duplicate.example.com\nport: 1433\ndata_observability:\n  enabled: true\n"
+	sqlserverCfg := integration.Config{
+		Name:      "sqlserver",
+		Provider:  "file",
+		Instances: []integration.Data{integration.Data(instanceYAML), integration.Data(instanceYAML)},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{sqlserverCfg})
+
+	payloadJSON, err := json.Marshal(DOQueryPayload{
+		ConfigID:     "cfg-duplicate",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "duplicate.example.com"},
+		Queries:      []QuerySpec{{DBName: "master", Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+	})
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-duplicate": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateError, statuses["path/cfg-duplicate"].State)
+	assert.Contains(t, statuses["path/cfg-duplicate"].Error, "ambiguous SQL Server instance match")
+	assert.Empty(t, changes.Schedule)
+	assert.Empty(t, changes.Unschedule)
+	assert.Empty(t, c.activeConfigs)
+}
+
 // TestOnRCUpdate_MultipleDOConfigsSameBase verifies that two DO configs targeting two different
 // instances of the same base config never leave an instance both in the remainder and as a DO
 // check (which would double-run it). With both instances targeted, no remainder is scheduled.
@@ -1203,8 +1264,8 @@ func TestBuildCheckConfig_PerQueryDBName(t *testing.T) {
 }
 
 // TestOnRCUpdate_MalformedPostgresYAML_SurfacesParseError verifies that when a postgres
-// instance's YAML is malformed, the error message from findPostgresConfig mentions the
-// parse failure, not just "identifier not found".
+// instance's YAML is malformed, the error message from findPostgresConfig mentions
+// the parse failure, not just "identifier not found".
 func TestOnRCUpdate_MalformedPostgresYAML_SurfacesParseError(t *testing.T) {
 	postgresCfg := integration.Config{
 		Name:      "postgres",
@@ -1515,4 +1576,259 @@ func TestOnRCUpdate_SecondUpdateReusesStoredBase(t *testing.T) {
 		queries, _ := doSection["queries"].([]any)
 		assert.NotEmpty(t, queries, "scheduled config has no DO queries — looks like the wrongly-restored original")
 	}
+}
+
+// --- SQL Server tests ---
+
+// TestOnRCUpdate_SQLServer_SchedulesCheck verifies that a sqlserver integration config
+// is matched and scheduled using the correct integration name (not "postgres").
+func TestOnRCUpdate_SQLServer_SchedulesCheck(t *testing.T) {
+	sqlserverCfg := integration.Config{
+		Name:     "sqlserver",
+		Provider: "file",
+		NodeName: "node1",
+		Instances: []integration.Data{
+			integration.Data("host: sqlserver.example.com\nport: 1433\nusername: datadog\ndata_observability:\n  enabled: true\n"),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{sqlserverCfg})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-sqlserver",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "sqlserver.example.com"},
+		Queries: []QuerySpec{
+			{
+				MonitorID:       10,
+				Type:            "run_query",
+				Query:           "SELECT count(*) FROM sys.tables",
+				IntervalSeconds: 60,
+				TimeoutSeconds:  10,
+				Entity:          EntityMetadata{Platform: "sqlserver", Database: "master", Table: "sys.tables"},
+			},
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-sqlserver": {Config: payloadJSON, Metadata: state.Metadata{ID: "rc-sqlserver"}},
+	})
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-sqlserver"].State)
+	require.Len(t, changes.Schedule, 1)
+	assert.Equal(t, "sqlserver", changes.Schedule[0].Name, "scheduled check must use sqlserver integration name")
+	assert.Equal(t, "file", changes.Schedule[0].Provider)
+	assert.Equal(t, "node1", changes.Schedule[0].NodeName)
+	require.Contains(t, c.activeConfigs, "cfg-sqlserver")
+}
+
+// TestMatchesIdentifier_SQLServer_HostOnly verifies that a self-hosted or Azure VM SQL Server
+// instance matches by host only (no Azure SQL DB deployment_type present).
+func TestMatchesIdentifier_SQLServer_HostOnly(t *testing.T) {
+	instance := map[string]any{
+		"host": "sqlserver.internal",
+		"port": 1433,
+	}
+
+	t.Run("matching host with different query databases", func(t *testing.T) {
+		dbID := &DBIdentifier{Type: "self-hosted", Host: "sqlserver.internal"}
+		queries := []QuerySpec{{DBName: "master"}, {DBName: "msdb"}}
+		assert.True(t, evaluateInstanceIdentifier(instance, *dbID, "sqlserver", queries).matched)
+	})
+
+	t.Run("mismatching host", func(t *testing.T) {
+		dbID := &DBIdentifier{Type: "self-hosted", Host: "other.internal"}
+		assert.False(t, evaluateInstanceIdentifier(instance, *dbID, "sqlserver", nil).matched)
+	})
+}
+
+// TestMatchesIdentifier_AzureSQLDB_HostAndDatabase verifies that Azure SQL Database instances
+// require host equality and case-insensitive database equality for every query.
+func TestMatchesIdentifier_AzureSQLDB_HostAndDatabase(t *testing.T) {
+	instance := map[string]any{
+		"host":     "myserver.database.windows.net",
+		"database": "MyDB",
+		"azure": map[string]any{
+			"deployment_type": "sql_database",
+		},
+	}
+	dbID := &DBIdentifier{Type: "self-hosted", Host: "myserver.database.windows.net"}
+
+	t.Run("host and same-case query databases match", func(t *testing.T) {
+		queries := []QuerySpec{{DBName: "MyDB"}, {DBName: "MyDB"}}
+		assert.True(t, evaluateInstanceIdentifier(instance, *dbID, "sqlserver", queries).matched)
+	})
+
+	t.Run("host matches but query database does not", func(t *testing.T) {
+		queries := []QuerySpec{{DBName: "OtherDB"}}
+		assert.False(t, evaluateInstanceIdentifier(instance, *dbID, "sqlserver", queries).matched)
+	})
+
+	t.Run("database matching is case-insensitive", func(t *testing.T) {
+		queries := []QuerySpec{{DBName: "mydb"}}
+		assert.True(t, evaluateInstanceIdentifier(instance, *dbID, "sqlserver", queries).matched, "MyDB must match mydb")
+	})
+
+	t.Run("mixed query databases do not match", func(t *testing.T) {
+		queries := []QuerySpec{{DBName: "MyDB"}, {DBName: "OtherDB"}}
+		assert.False(t, evaluateInstanceIdentifier(instance, *dbID, "sqlserver", queries).matched)
+
+		otherInstance := map[string]any{
+			"host":     "myserver.database.windows.net",
+			"database": "OtherDB",
+			"azure": map[string]any{
+				"deployment_type": "sql_database",
+			},
+		}
+		assert.False(t, evaluateInstanceIdentifier(otherInstance, *dbID, "sqlserver", queries).matched)
+	})
+
+	t.Run("empty queries do not match", func(t *testing.T) {
+		assert.False(t, evaluateInstanceIdentifier(instance, *dbID, "sqlserver", nil).matched)
+	})
+
+	t.Run("host does not match", func(t *testing.T) {
+		otherDBID := &DBIdentifier{Type: "self-hosted", Host: "otherserver.database.windows.net"}
+		assert.False(t, evaluateInstanceIdentifier(instance, *otherDBID, "sqlserver", []QuerySpec{{DBName: "MyDB"}}).matched)
+	})
+}
+
+// TestOnRCUpdate_EmptyIdentifierHost verifies that an empty db_identifier.host is rejected before
+// any local instance can be selected.
+func TestOnRCUpdate_EmptyIdentifierHost(t *testing.T) {
+	sqlserverCfg := integration.Config{
+		Name:      "sqlserver",
+		Provider:  "file",
+		Instances: []integration.Data{integration.Data("host: sqlserver.example.com\ndata_observability:\n  enabled: true\n")},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{sqlserverCfg})
+
+	payloadJSON, err := json.Marshal(DOQueryPayload{
+		ConfigID:     "cfg-empty-host",
+		DBIdentifier: DBIdentifier{Type: "self-hosted"},
+		Queries:      []QuerySpec{{DBName: "master", Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+	})
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-empty-host": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateError, statuses["path/cfg-empty-host"].State)
+	assert.Equal(t, "empty db_identifier.host", statuses["path/cfg-empty-host"].Error)
+	assert.Empty(t, changes.Schedule)
+	assert.Empty(t, changes.Unschedule)
+}
+
+// TestOnRCUpdate_AzureSQLDB_RejectsCrossDBPayload verifies that an RC payload targeting
+// another database cannot be injected into a MyDB instance sharing the same Azure SQL Server host.
+func TestOnRCUpdate_AzureSQLDB_RejectsCrossDBPayload(t *testing.T) {
+	sqlserverCfg := integration.Config{
+		Name:     "sqlserver",
+		Provider: "file",
+		Instances: []integration.Data{
+			integration.Data("host: myserver.database.windows.net\ndatabase: MyDB\nazure:\n  deployment_type: sql_database\ndata_observability:\n  enabled: true\n"),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{sqlserverCfg})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-wrongdb",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "myserver.database.windows.net"},
+		Queries:      []QuerySpec{{DBName: "OtherDB", Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-wrongdb": {Config: payloadJSON},
+	})
+
+	assert.Equal(t, state.ApplyStateError, statuses["path/cfg-wrongdb"].State)
+	assert.Empty(t, changes.Schedule)
+	assert.Empty(t, c.activeConfigs)
+}
+
+// TestOnRCUpdate_AzureSQLDB_PreservesSiblingDatabase checks that targeting one Azure SQL
+// database does not remove another database that shares the server host.
+func TestOnRCUpdate_AzureSQLDB_PreservesSiblingDatabase(t *testing.T) {
+	const host = "myserver.database.windows.net"
+	sqlserverCfg := integration.Config{
+		Name:     "sqlserver",
+		Provider: "file",
+		Instances: []integration.Data{
+			integration.Data("host: " + host + "\ndatabase: MyDB\nazure:\n  deployment_type: sql_database\ndata_observability:\n  enabled: true\n"),
+			integration.Data("host: " + host + "\ndatabase: OtherDB\nazure:\n  deployment_type: sql_database\ndata_observability:\n  enabled: true\n"),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{sqlserverCfg})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-my-db",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: host},
+		Queries:      []QuerySpec{{DBName: "mydb", Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-my-db": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-my-db"].State)
+	require.Len(t, changes.Unschedule, 1, "should unschedule the original two-instance config")
+	require.Len(t, changes.Schedule, 2, "should schedule the targeted check and the sibling remainder")
+
+	databasesWithQueries := make(map[string]bool)
+	for _, cfg := range changes.Schedule {
+		for _, instanceData := range cfg.Instances {
+			var instance map[string]any
+			require.NoError(t, yaml.Unmarshal(instanceData, &instance))
+			database, _ := instance["database"].(string)
+			dataObservability, ok := instance["data_observability"].(map[string]any)
+			require.True(t, ok)
+			_, hasQueries := dataObservability["queries"]
+			databasesWithQueries[database] = hasQueries
+		}
+	}
+
+	assert.True(t, databasesWithQueries["MyDB"], "the targeted database must receive queries")
+	assert.False(t, databasesWithQueries["OtherDB"], "the sibling must remain unchanged")
+}
+
+// TestOnRCUpdate_SQLServer_DisableRestoresOriginalConfig verifies that sending an empty
+// queries list for a previously active SQL Server config re-schedules the original config.
+func TestOnRCUpdate_SQLServer_DisableRestoresOriginalConfig(t *testing.T) {
+	sqlserverCfg := integration.Config{
+		Name:     "sqlserver",
+		Provider: "file",
+		NodeName: "node1",
+		Instances: []integration.Data{
+			integration.Data("host: sqlserver.example.com\nport: 1433\ndata_observability:\n  enabled: true\n"),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{sqlserverCfg})
+
+	// First: schedule a DO config so the base config becomes managed.
+	enable := DOQueryPayload{
+		ConfigID:     "cfg-sqlserver-disable",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "sqlserver.example.com"},
+		Queries:      []QuerySpec{{Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+	}
+	enableJSON, err := json.Marshal(enable)
+	require.NoError(t, err)
+	collectStatuses(c, map[string]state.RawConfig{"path/config": {Config: enableJSON}})
+	require.Contains(t, c.activeConfigs, "cfg-sqlserver-disable")
+
+	// Now: empty queries disables the DO config and restores the original sqlserver config.
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/config": {Config: []byte(`{"config_id": "cfg-sqlserver-disable", "queries": []}`)},
+	})
+
+	assert.Equal(t, state.ApplyStateAcknowledged, statuses["path/config"].State)
+	assert.Empty(t, c.activeConfigs)
+	require.Len(t, changes.Unschedule, 1, "should unschedule the DO sqlserver check")
+	require.Len(t, changes.Schedule, 1, "should re-schedule the original base sqlserver config")
+	assert.Equal(t, sqlserverCfg, changes.Schedule[0])
+	assert.Equal(t, "sqlserver", changes.Schedule[0].Name)
 }

--- a/comp/dataobs/queryactions/impl/queryactions.go
+++ b/comp/dataobs/queryactions/impl/queryactions.go
@@ -44,7 +44,7 @@ type component struct {
 	rcclient rcclient.Component
 	// activeConfigs maps a DO config_id to the DO check config currently scheduled for it.
 	activeConfigs map[string]activeConfigEntry
-	// managedBases maps a base postgres config Digest to the bookkeeping needed to restore it.
+	// managedBases maps a base integration config Digest to the bookkeeping needed to restore it.
 	// A base config has an entry here while at least one DO config targets one of its instances;
 	// the entry records the original config (for restoration) and the remainder config currently
 	// scheduled in its place. See reconcileBases.
@@ -184,6 +184,9 @@ func (c *component) Stream(ctx context.Context) <-chan integration.ConfigChanges
 // data_observability.enabled: true is configured in autodiscovery.
 func (c *component) hasSupportedIntegration() bool {
 	for _, cfg := range c.ac.GetUnresolvedConfigs() {
+		if !isSupportedIntegration(cfg.Name) {
+			continue
+		}
 		for _, instanceData := range cfg.Instances {
 			var instance map[string]any
 			if err := yaml.Unmarshal(instanceData, &instance); err != nil {

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -79,6 +79,30 @@ func buildPayloadJSON(t *testing.T, configID, host string, queries []QuerySpec) 
 
 var singleQuery = []QuerySpec{{Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}}
 
+func TestHasSupportedIntegration(t *testing.T) {
+	tests := []struct {
+		name            string
+		integrationName string
+		want            bool
+	}{
+		{name: "PostgreSQL", integrationName: "postgres", want: true},
+		{name: "SAP HANA", integrationName: "sap_hana", want: true},
+		{name: "SQL Server", integrationName: "sqlserver", want: true},
+		{name: "unsupported integration", integrationName: "mysql", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := integration.Config{
+				Name:      test.integrationName,
+				Instances: []integration.Data{integration.Data("data_observability:\n  enabled: true\n")},
+			}
+			c, _ := newStreamComponent(t, []integration.Config{cfg})
+			assert.Equal(t, test.want, c.hasSupportedIntegration())
+		})
+	}
+}
+
 // --- Stream() lifecycle tests ---
 
 func TestStream_InitialEmptyChangesSentImmediately(t *testing.T) {

--- a/comp/dataobs/queryactions/impl/types.go
+++ b/comp/dataobs/queryactions/impl/types.go
@@ -5,17 +5,20 @@
 
 package queryactionsimpl
 
-// DOQueryPayload represents the RC config payload for a database cluster.
-// Each config groups all active monitor queries for a single host, with per-query dbname routing.
+// DOQueryPayload represents the RC config payload for a database integration instance.
+// QuerySpec.DBName is authoritative for execution routing and also selects the local Azure SQL
+// Database instance when several databases share a server hostname.
 type DOQueryPayload struct {
 	ConfigID     string       `json:"config_id"`
 	DBIdentifier DBIdentifier `json:"db_identifier"`
 	Queries      []QuerySpec  `json:"queries"`
 }
 
-// DBIdentifier identifies a database cluster to target.
-// Type describes the hosting kind (e.g. "self-hosted", "rds"). Host contains the resolved
-// database_instance identifier. Per-query dbname fields handle database routing.
+// DBIdentifier identifies the integration host to target.
+// PostgreSQL compares Host with its rendered database identifier. SQL Server compares Host with
+// its configured endpoint, and Azure SQL Database additionally compares every query's DBName with
+// the top-level integration database. Type describes the producer's hosting kind and is
+// informational.
 type DBIdentifier struct {
 	Type          string `json:"type"`
 	Host          string `json:"host"`

--- a/releasenotes/notes/queryactions-sqlserver-support-50c170c3a653c595.yaml
+++ b/releasenotes/notes/queryactions-sqlserver-support-50c170c3a653c595.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Data Observability: Extended the ``queryactions`` component to support
+    SQL Server in addition to PostgreSQL. The component now schedules
+    ``data_observability.queries`` for ``sqlserver`` check instances and
+    correctly resolves Azure SQL Database instances by requiring both host
+    and database equality, preventing cross-database payload injection.


### PR DESCRIPTION
## Summary

This PR adds SQL Server support to the Data Observability queryactions component. It schedules RC query payloads on the matching `sqlserver` check without changing the `DO_QUERY_ACTIONS` payload schema.

It also makes shared instance selection and remainder reconciliation safer:

- finds PostgreSQL, SAP HANA and SQL Server configs through one supported-integration path
- keeps the matched integration name when it builds the scheduled check
- rejects an empty `db_identifier.host`
- rejects payloads that match more than one enabled local instance instead of selecting the first
- stores the matched base-config instance ordinal, so reconciliation removes only that exact instance and keeps bundled siblings

## SQL Server matching

Non-Azure SQL Server instances continue to match by host.

Azure SQL Database instances match when:

- `azure.deployment_type` is `sql_database`
- the top-level instance `database` matches every query `dbname`, case-insensitively

This prevents a host-shared payload from being scheduled against another Azure database. It also rejects payloads that contain mixed databases.

## Test plan

- [x] `bazel test //comp/dataobs/queryactions/impl:impl_test_base`
- [x] SQL Server check scheduling and disable or restore
- [x] non-Azure host matching
- [x] Azure shared-host database selection, case-insensitive matching and cross-database rejection
- [x] same-host different-port and duplicate-instance ambiguity rejection
- [x] exact ordinal remainder handling
- [x] PostgreSQL and SAP HANA remainder regression coverage

Closes https://linear.app/datadog/issue/DOIO-36