### PR TITLE
Suppress misleading `No sum for … found` from 1st `mod tidy` output

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -384,7 +384,7 @@ def _go_only_tidy(ctx, verbose: bool):
 
 def _bazel_tidy(ctx, verbose: bool):
     # 1. deps/go.MODULE.bazel ↺ (prune stale use_repo declarations to not hinder next `bazel` commands)
-    bazel(ctx, "mod", "tidy")
+    bazel(ctx, "mod", "--ui_event_filters=-DEBUG", "tidy")  # inhibit `No sum for … found` (go_mod_tidy_all will fix it)
     # 2. go.work + **/go.mod -> **/go.mod (sync each workspace module's deps to the workspace build list)
     bazel(ctx, "run", "//:go", "work", "sync")
     # 3. **/*.go + **/go.mod -> **/go.mod, **/go.sum (reconcile each module's requirements with its actual imports)


### PR DESCRIPTION
### What does this PR do?
Pass `--ui_event_filters=-DEBUG` to the first `bazel mod tidy` call in `dda inv tidy`.

### Motivation
Developers running `dda inv tidy` after changing Go dependencies have been facing an equal number of lines like:
```sh
$ dda inv tidy
bazel mod tidy
DEBUG: .../external/gazelle+/internal/bzlmod/go_deps.bzl:869:18: No sum for github.com/x/y@1.2.3 found, run bazel run @rules_go//go -- mod tidy to generate it
DEBUG: ...
```

#47918 indeed added an early `bazel mod tidy` to prune stale `use_repo` entries from `deps/go.MODULE.bazel` before any `bazel run` command, but that call may run before `go.sum` is fully populated so, when a dependency version is introduced, Gazelle's `go_deps` extension has no checksum to verify and logically emits a message (`DEBUG` line) per affected module.

However, it's more a problem of user experience because the early call does not need `go.sum` to be complete (it is only there to _clear_ stale entries) and next `go_mod_tidy_all`[^1] step is what then (re)populates `go.sum`.

In short, the sequence is not broken _per se_, it's just that these messages are not actionable and they are even [misleading](https://dd.slack.com/archives/C06PBHLD4DQ/p1781690322228809) at this stage.

Bazel is precisely equipped with user experience flags, of which `--ui_event_filters` controls what messages reach the terminal, so `-DEBUG` silences the noise at the call site without affecting any other step or suppressing genuine errors.

### Describe how you validated your changes
1. stripped `go.sum` entries,
2. ran `dda inv tidy`:
   - no noisy `DEBUG` output,
   - missing entries restored by `go_mod_tidy_all`.

### Additional Notes
[^1]: `bazel run //:go_mod_tidy_all` is a superset of the `bazel run @rules_go//go` advised in each issued `DEBUG` line.