### PR TITLE
fix(autodiscovery): Update AD endpoint services on Prometheus service annotation change

### DIFF
--- a/comp/core/autodiscovery/listeners/kube_endpoints.go
+++ b/comp/core/autodiscovery/listeners/kube_endpoints.go
@@ -214,6 +214,11 @@ func (l *KubeEndpointsListener) serviceUpdated(old, obj interface{}) {
 		l.createService(l.endpointsForService(castedObj), false)
 	}
 
+	// Detect if prometheus annotations changed
+	if l.promInclAnnot.AnnotationsDiffer(castedObj.GetAnnotations(), castedOld.GetAnnotations()) {
+		l.createService(l.endpointsForService(castedObj), false)
+	}
+
 	// Detect changes of AD labels for standard tags if the Service is annotated
 	if isServiceAnnotated(castedObj, kubeEndpointsID) && (standardTagsDigest(castedOld.GetLabels()) != standardTagsDigest(castedObj.GetLabels())) {
 		kep := l.endpointsForService(castedObj)

--- a/comp/core/autodiscovery/listeners/kube_endpoints_test.go
+++ b/comp/core/autodiscovery/listeners/kube_endpoints_test.go
@@ -13,9 +13,12 @@ import (
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	listv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	adtypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
@@ -754,4 +757,60 @@ func TestKubeEndpointsFiltering(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newEndpointsTestListener(t *testing.T, svc *v1.Service, kep *v1.Endpoints) (*KubeEndpointsListener, cache.Indexer, chan Service, chan Service) {
+	svcIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	require.NoError(t, svcIndexer.Add(svc))
+	epIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	require.NoError(t, epIndexer.Add(kep))
+
+	newCh := make(chan Service, 10)
+	delCh := make(chan Service, 10)
+	l := &KubeEndpointsListener{
+		endpoints:       make(map[types.UID][]*KubeEndpointService),
+		endpointsLister: listv1.NewEndpointsLister(epIndexer),
+		serviceLister:   listv1.NewServiceLister(svcIndexer),
+		promInclAnnot:   getPrometheusIncludeAnnotations(),
+		filterStore:     workloadfilterfxmock.SetupMockFilter(t),
+		newService:      newCh,
+		delService:      delCh,
+	}
+	return l, svcIndexer, newCh, delCh
+}
+
+// TestEndpointsServiceUpdatedPrometheusAnnotations verifies that changes to prometheus
+// scrape annotations trigger endpoint service emission.
+func TestEndpointsServiceUpdatedPrometheusAnnotations(t *testing.T) {
+	kep := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-svc", Namespace: "default", UID: types.UID("ep-uid")},
+		Subsets: []v1.EndpointSubset{{
+			Addresses: []v1.EndpointAddress{{IP: "10.0.0.1"}, {IP: "10.0.0.2"}},
+			Ports:     []v1.EndpointPort{{Name: "metrics", Port: 9113}},
+		}},
+	}
+
+	t.Run("annotation added", func(t *testing.T) {
+		svcOld := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "nginx-svc", Namespace: "default", UID: "svc-uid"}}
+		l, svcIndexer, newCh, _ := newEndpointsTestListener(t, svcOld, kep)
+
+		svcNew := svcOld.DeepCopy()
+		svcNew.Annotations = map[string]string{"prometheus.io/scrape": "true"}
+		require.NoError(t, svcIndexer.Update(svcNew))
+		l.serviceUpdated(svcOld, svcNew)
+
+		require.Len(t, newCh, 2, "endpoint services should be emitted when prometheus annotation is added")
+	})
+
+	t.Run("scrape annotation value changed", func(t *testing.T) {
+		svcOld := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "nginx-svc", Namespace: "default", UID: "svc-uid", Annotations: map[string]string{"prometheus.io/scrape": "false"}}}
+		l, svcIndexer, newCh, _ := newEndpointsTestListener(t, svcOld, kep)
+
+		svcNew := svcOld.DeepCopy()
+		svcNew.Annotations["prometheus.io/scrape"] = "true"
+		require.NoError(t, svcIndexer.Update(svcNew))
+		l.serviceUpdated(svcOld, svcNew)
+
+		require.Len(t, newCh, 2, "endpoint services should be emitted when scrape annotation value changes")
+	})
 }

--- a/comp/core/autodiscovery/listeners/kube_endpointslices.go
+++ b/comp/core/autodiscovery/listeners/kube_endpointslices.go
@@ -201,6 +201,12 @@ func (l *KubeEndpointSlicesListener) serviceUpdated(old, obj interface{}) {
 		return
 	}
 
+	// Detect if prometheus annotations changed
+	if l.promInclAnnot.AnnotationsDiffer(svc.GetAnnotations(), oldSvc.GetAnnotations()) {
+		l.processServiceUpdate(svc.Namespace, svc.Name)
+		return
+	}
+
 	// Detect changes of AD labels for standard tags if the Service is annotated or tracked
 	tracked := l.serviceTracker != nil && l.serviceTracker.HasService(svc.Namespace, svc.Name)
 	if (isServiceAnnotated(svc, kubeEndpointSlicesID) || tracked) &&

--- a/comp/core/autodiscovery/listeners/kube_endpointslices_test.go
+++ b/comp/core/autodiscovery/listeners/kube_endpointslices_test.go
@@ -776,3 +776,44 @@ func TestReconcilesServiceOnUpdatedTags(t *testing.T) {
 	assert.Contains(t, newTags, "env:staging")
 	assert.NotContains(t, newTags, "env:prod")
 }
+
+// TestEndpointSlicesServiceUpdatedPrometheusAnnotations verifies that changes to prometheus
+// scrape annotations trigger endpoint service emission.
+func TestEndpointSlicesServiceUpdatedPrometheusAnnotations(t *testing.T) {
+	slice := &discv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-svc-abc",
+			Namespace: "default",
+			UID:       types.UID("slice-1"),
+			Labels:    map[string]string{"kubernetes.io/service-name": "nginx-svc"},
+		},
+		Endpoints: []discv1.Endpoint{
+			{Addresses: []string{"10.0.0.1"}},
+			{Addresses: []string{"10.0.0.2"}},
+		},
+	}
+
+	t.Run("annotation added", func(t *testing.T) {
+		svcOld := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "nginx-svc", Namespace: "default"}}
+		l, svcIndexer, newCh, _ := newTrackerTestListener(t, nil, svcOld, slice)
+
+		svcNew := svcOld.DeepCopy()
+		svcNew.Annotations = map[string]string{"prometheus.io/scrape": "true"}
+		require.NoError(t, svcIndexer.Update(svcNew))
+		l.serviceUpdated(svcOld, svcNew)
+
+		require.Len(t, newCh, 2, "endpoint services should be emitted when prometheus annotation is added")
+	})
+
+	t.Run("scrape annotation value changed", func(t *testing.T) {
+		svcOld := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "nginx-svc", Namespace: "default", Annotations: map[string]string{"prometheus.io/scrape": "false"}}}
+		l, svcIndexer, newCh, _ := newTrackerTestListener(t, nil, svcOld, slice)
+
+		svcNew := svcOld.DeepCopy()
+		svcNew.Annotations["prometheus.io/scrape"] = "true"
+		require.NoError(t, svcIndexer.Update(svcNew))
+		l.serviceUpdated(svcOld, svcNew)
+
+		require.Len(t, newCh, 2, "endpoint services should be emitted when scrape annotation value changes")
+	})
+}

--- a/comp/core/autodiscovery/providers/prometheus_services.go
+++ b/comp/core/autodiscovery/providers/prometheus_services.go
@@ -290,7 +290,9 @@ func (p *PrometheusServicesConfigProvider) invalidateIfChangedEndpoints(old, obj
 	defer p.Unlock()
 	if found := p.monitoredEndpoints[endpointsID]; found {
 		// Invalidate only when subsets change
-		p.upToDate = equality.Semantic.DeepEqual(castedObj.Subsets, castedOld.Subsets)
+		if !equality.Semantic.DeepEqual(castedObj.Subsets, castedOld.Subsets) {
+			p.upToDate = false
+		}
 	}
 }
 

--- a/comp/core/autodiscovery/providers/prometheus_services_eps.go
+++ b/comp/core/autodiscovery/providers/prometheus_services_eps.go
@@ -302,7 +302,9 @@ func (p *PrometheusServicesEndpointSlicesConfigProvider) invalidateIfChangedEndp
 	defer p.Unlock()
 	if found := p.monitoredEndpoints[endpointsID]; found {
 		// Invalidate only when endpoints change
-		p.upToDate = equality.Semantic.DeepEqual(castedObj.Endpoints, castedOld.Endpoints)
+		if !equality.Semantic.DeepEqual(castedObj.Endpoints, castedOld.Endpoints) {
+			p.upToDate = false
+		}
 	}
 }
 

--- a/comp/core/autodiscovery/providers/prometheus_services_eps_test.go
+++ b/comp/core/autodiscovery/providers/prometheus_services_eps_test.go
@@ -354,10 +354,12 @@ func TestPrometheusServicesEPS_InvalidateIfChangedEndpointSlices(t *testing.T) {
 		old                *discv1.EndpointSlice
 		new                *discv1.EndpointSlice
 		monitoredEndpoints []string
+		initialUpToDate    bool
 		expectUpToDate     bool
 	}{
 		{
-			name: "no change",
+			name:            "no change",
+			initialUpToDate: true,
 			old: &discv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
 					ResourceVersion: "v1",
@@ -445,7 +447,8 @@ func TestPrometheusServicesEPS_InvalidateIfChangedEndpointSlices(t *testing.T) {
 			monitoredEndpoints: []string{
 				"kube_endpoint_uid://ns/svc/",
 			},
-			expectUpToDate: true,
+			initialUpToDate: true,
+			expectUpToDate:  true,
 		},
 		{
 			name: "new address added to endpoint slice",
@@ -500,7 +503,56 @@ func TestPrometheusServicesEPS_InvalidateIfChangedEndpointSlices(t *testing.T) {
 			monitoredEndpoints: []string{
 				"kube_endpoint_uid://ns/svc/",
 			},
-			expectUpToDate: false,
+			initialUpToDate: true,
+			expectUpToDate:  false,
+		},
+		{
+			name: "unchanged endpoints must not re-validate a pending invalidation",
+			old: &discv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "v1",
+					Name:            "svc-abc123",
+					Namespace:       "ns",
+					Labels: map[string]string{
+						"kubernetes.io/service-name": "svc",
+					},
+				},
+				Endpoints: []discv1.Endpoint{
+					{
+						Addresses: []string{"10.0.0.1"},
+						TargetRef: &v1.ObjectReference{
+							Kind: "Pod",
+							UID:  "svc-pod-1",
+						},
+						NodeName: &node,
+					},
+				},
+			},
+			new: &discv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "v2",
+					Name:            "svc-abc123",
+					Namespace:       "ns",
+					Labels: map[string]string{
+						"kubernetes.io/service-name": "svc",
+					},
+				},
+				Endpoints: []discv1.Endpoint{
+					{
+						Addresses: []string{"10.0.0.1"},
+						TargetRef: &v1.ObjectReference{
+							Kind: "Pod",
+							UID:  "svc-pod-1",
+						},
+						NodeName: &node,
+					},
+				},
+			},
+			monitoredEndpoints: []string{
+				"kube_endpoint_uid://ns/svc/",
+			},
+			initialUpToDate: false,
+			expectUpToDate:  false,
 		},
 	}
 
@@ -508,7 +560,7 @@ func TestPrometheusServicesEPS_InvalidateIfChangedEndpointSlices(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			p := newPromServicesEndpointSlicesProvider(checks, api, true)
-			p.setUpToDate(true)
+			p.setUpToDate(test.initialUpToDate)
 			for _, monitored := range test.monitoredEndpoints {
 				p.monitoredEndpoints[monitored] = true
 			}

--- a/comp/core/autodiscovery/providers/prometheus_services_test.go
+++ b/comp/core/autodiscovery/providers/prometheus_services_test.go
@@ -353,10 +353,12 @@ func TestPrometheusServicesInvalidateIfChangedEndpoints(t *testing.T) {
 		old                *v1.Endpoints
 		new                *v1.Endpoints
 		monitoredEndpoints []string
+		initialUpToDate    bool
 		expectUpToDate     bool
 	}{
 		{
-			name: "no change",
+			name:            "no change",
+			initialUpToDate: true,
 			old: &v1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					ResourceVersion: "v1",
@@ -448,7 +450,8 @@ func TestPrometheusServicesInvalidateIfChangedEndpoints(t *testing.T) {
 			monitoredEndpoints: []string{
 				"kube_endpoint_uid://ns/svc/",
 			},
-			expectUpToDate: true,
+			initialUpToDate: true,
+			expectUpToDate:  true,
 		},
 		{
 			name: "subsets change",
@@ -505,7 +508,58 @@ func TestPrometheusServicesInvalidateIfChangedEndpoints(t *testing.T) {
 			monitoredEndpoints: []string{
 				"kube_endpoint_uid://ns/svc/",
 			},
-			expectUpToDate: false,
+			initialUpToDate: true,
+			expectUpToDate:  false,
+		},
+		{
+			name: "unchanged subsets must not re-validate a pending invalidation",
+			old: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "v1",
+					Name:            "svc",
+					Namespace:       "ns",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+								TargetRef: &v1.ObjectReference{
+									Kind: "Pod",
+									UID:  "svc-pod-1",
+								},
+								NodeName: &node,
+							},
+						},
+					},
+				},
+			},
+			new: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "v2",
+					Name:            "svc",
+					Namespace:       "ns",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+								TargetRef: &v1.ObjectReference{
+									Kind: "Pod",
+									UID:  "svc-pod-1",
+								},
+								NodeName: &node,
+							},
+						},
+					},
+				},
+			},
+			monitoredEndpoints: []string{
+				"kube_endpoint_uid://ns/svc/",
+			},
+			initialUpToDate: false,
+			expectUpToDate:  false,
 		},
 	}
 
@@ -513,7 +567,7 @@ func TestPrometheusServicesInvalidateIfChangedEndpoints(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			p := newPromServicesProvider(checks, api, true)
-			p.setUpToDate(true)
+			p.setUpToDate(test.initialUpToDate)
 			for _, monitored := range test.monitoredEndpoints {
 				p.monitoredEndpoints[monitored] = true
 			}

--- a/releasenotes/notes/fix-prometheus-services-annotation-pickup-2da1087ac2c24176.yaml
+++ b/releasenotes/notes/fix-prometheus-services-annotation-pickup-2da1087ac2c24176.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue where the Cluster Agent could fail to schedule Prometheus
+    checks for Kubernetes Services newly annotated with ``prometheus.io/scrape``
+    until the Cluster Agent was restarted or the backing workload was scaled.


### PR DESCRIPTION
### What does this PR do?

Fixes two related bugs that prevented Prometheus checks from being scheduled when a prometheus annotation is added or update on a kubernetes service. 

Primarily, added an annotation diff check in the endpointslices and endpoints AD service listeners to trigger a re-creation of endpoint services when a prometheus annotation is changed. Previously, this check only looked at AD-template annotations, so prometheus annotated services never triggered a refresh.

Second is the prometheus services config provider switches `upToDate` back to `true` when multiple endpointslice updates are processed and the last one processed hasn't change. 

### Motivation

When a Kubernetes Service is annotated with `prometheus.io/scrape: "true"` after the Cluster Agent starts, the expected Prometheus checks are never scheduled unless the DCA is restarted or the backing deployment is scaled. 

### Describe how you validated your changes

- Added unit tests for both bugs ✅ 

#### Manual QA

1. Deploy agent with prometheus scraping enabled.
```yaml
datadog:
  clusterName: mathewe-eps-dev
  operator:
    enabled: false
  csi:
    enabled: false
  clusterChecks:
    enabled: true
  kubelet:
    tlsVerify: false
  logs:
    enabled: true
    containerCollectAll: true
  prometheusScrape:
    enabled: true
    serviceEndpoints: true
clusterAgent:
  enabled: true
```
3. Deploy service with no prom annotation
```yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-prometheus
  labels:
    app: nginx-prometheus
spec:
  replicas: 2  # Multiple replicas to generate multiple endpoints
  selector:
    matchLabels:
      app: nginx-prometheus
  template:
    metadata:
      labels:
        app: nginx-prometheus
    spec:
      containers:
      - name: nginx
        image: nginx:latest
        ports:
        - containerPort: 80
          name: http
      - name: nginx-prometheus-exporter
        image: nginx/nginx-prometheus-exporter:latest
        args:
        - -nginx.scrape-uri=http://localhost/stub_status
        ports:
        - containerPort: 9113
          name: metrics

---
apiVersion: v1
kind: Service
metadata:
  name: nginx-prometheus-svc
# annotation commented out
#  annotations:
#    prometheus.io/scrape: "true"
#    prometheus.io/port: "9113"
  labels:
    app: nginx-prometheus
spec:
  selector:
    app: nginx-prometheus
  ports:
  - name: http
    port: 80
    targetPort: 80
  - name: metrics
    port: 9113
    targetPort: 9113
  type: ClusterIP

```
5. Uncomment annotation on service to add it.
6. Validate DCA dispatches prom endpoint checks `agent clusterchecks`.

<img width="811" height="428" alt="image" src="https://github.com/user-attachments/assets/1df6b0ca-e0c9-40fd-bc5d-91456ee34b45" />

7. Change the annotation again. like setting the scrape annotation to false.
8. Confirm both configs and services are removed from `agent configcheck -v`