### PR TITLE
Fix logs status file stats ordering

### DIFF
--- a/comp/logs/agent/impl/agent_test.go
+++ b/comp/logs/agent/impl/agent_test.go
@@ -385,11 +385,12 @@ func (suite *AgentTestSuite) TestStatusOut() {
 			"CoreAgentProcessOpenFiles": 27,
 			"OSFileLimit":               1048576,
 		},
-		Integrations: []logsStatus.Integration{},
-		Tailers:      []logsStatus.Tailer{},
-		Errors:       []string{},
-		Warnings:     []string{},
-		UseHTTP:      true,
+		BackpressureTable: "  Logs Agent Backpressure\n  =======================\n",
+		Integrations:      []logsStatus.Integration{},
+		Tailers:           []logsStatus.Tailer{},
+		Errors:            []string{},
+		Warnings:          []string{},
+		UseHTTP:           true,
 	}
 
 	logsProvider = func(_ bool) logsStatus.Status {
@@ -430,6 +431,10 @@ func (suite *AgentTestSuite) TestStatusOut() {
     world: 13
     CoreAgentProcessOpenFiles: 27
     OSFileLimit: 1048576
+
+  Logs Agent Backpressure
+  =======================
+
 `
 			// We replace windows line break by linux so the tests pass on every OS
 			expectedResult := strings.ReplaceAll(result, "\r\n", "\n")

--- a/comp/logs/agent/impl/status_templates/logsagent.tmpl
+++ b/comp/logs/agent/impl/status_templates/logsagent.tmpl
@@ -22,16 +22,16 @@
   {{- end }}
 {{- end }}
 
-{{- if .BackpressureTable }}
-
-{{ .BackpressureTable }}
-{{- end }}
-
 {{- if .ProcessFileStats }}
   {{- range $metric_name, $metric_value := .ProcessFileStats }}
     {{$metric_name}}: {{$metric_value}}
   {{- end}}
 {{- end}}
+
+{{- if .BackpressureTable }}
+
+{{ .BackpressureTable }}
+{{- end }}
 
 {{- if .Errors }}
 


### PR DESCRIPTION
### What does this PR do?

Keeps the logs agent process file stats grouped with the rest of the logs status metrics in text status output.

`CoreAgentProcessOpenFiles` and `OSFileLimit` now render before the logs agent backpressure section instead of after it. The status output test also covers the case where a backpressure table is present.

### Motivation

The backpressure section was rendered before `ProcessFileStats`. On agents with component utilization data, that made the file-limit metrics appear separated from the rest of the logs metrics, which looked like the status output was being interleaved incorrectly.

### Describe how you validated your changes

* `dda inv test --targets=./comp/logs/agent/impl`
* Local testing with `dda inv agent.exec -- status` to confirm backpressure status renders correctly.

### Additional Notes

This only changes text status output ordering. JSON status output is unchanged.