### PR TITLE
[Backport 7.81.x] fix(healthplatform): reliably forward RESOLVED state after agent restart

### DIFF
--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -51,6 +51,8 @@ go_test(
         "//comp/healthplatform/scheduler/def",
         "//comp/healthplatform/store/def",
         "//pkg/util/fxutil",
+        "//test/fakeintake/client",
+        "//test/fakeintake/server",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/comp/healthplatform/bundle_test.go
+++ b/comp/healthplatform/bundle_test.go
@@ -27,6 +27,9 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	telemetrymock "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
+	fakeintakeclient "github.com/DataDog/datadog-agent/test/fakeintake/client"
+	fakeintakeserver "github.com/DataDog/datadog-agent/test/fakeintake/server"
+
 	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 	schedulerdef "github.com/DataDog/datadog-agent/comp/healthplatform/scheduler/def"
@@ -143,6 +146,129 @@ func TestBundleStartLifecycle(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "no received report contained the test issue (id=%s)", testIssueID)
+}
+
+// TestIssueStateLifecycleForwarded exercises the full issue state machine end-to-end.
+func TestIssueStateLifecycleForwarded(t *testing.T) {
+	ready := make(chan bool, 1)
+	fi := fakeintakeserver.NewServer(
+		fakeintakeserver.WithAddress("127.0.0.1:0"),
+		fakeintakeserver.WithReadyChannel(ready),
+	)
+	fi.Start()
+	require.True(t, <-ready, "fakeintake server did not become ready")
+	t.Cleanup(func() { _ = fi.Stop() })
+
+	fiClient := fakeintakeclient.NewClient(fi.URL())
+
+	type appDeps struct {
+		fx.In
+		HP storedef.Component
+	}
+
+	const tickInterval = 50 * time.Millisecond
+
+	deps := fxutil.Test[appDeps](t,
+		Bundle(),
+		fx.Provide(func(t testing.TB) log.Component { return logmock.New(t) }),
+		fx.Provide(func(t testing.TB) config.Component {
+			cfg := config.NewMock(t)
+			cfg.SetInTest("api_key", "test-api-key")
+			cfg.SetInTest("dd_url", fi.URL())
+			cfg.SetInTest("health_platform.enabled", true)
+			cfg.SetInTest("health_platform.persist_on_kubernetes", true)
+			cfg.SetInTest("health_platform.forwarder.interval", tickInterval)
+			cfg.SetInTest("run_path", t.TempDir())
+			return cfg
+		}),
+		telemetrymock.Module(),
+		hostnameinterface.MockModule(),
+	)
+
+	const (
+		issueAID      = "test-lifecycle-A"
+		issueBID      = "test-lifecycle-B"
+		testIssueName = "docker_file_tailing_disabled"
+		testSource    = "test-lifecycle"
+	)
+
+	const (
+		waitTimeout  = 2 * time.Second
+		waitInterval = 10 * time.Millisecond
+	)
+
+	// latestHasIssueState uses collectedTime (ns precision) rather than EmittedAt (RFC3339, s precision).
+	latestHasIssueState := func(issueID string, state healthplatformpayload.IssueState) bool {
+		payloads, err := fiClient.GetAgentHealth()
+		if err != nil || len(payloads) == 0 {
+			return false
+		}
+		latest := payloads[0]
+		for _, p := range payloads[1:] {
+			if p.GetCollectedTime().After(latest.GetCollectedTime()) {
+				latest = p
+			}
+		}
+		iss, ok := latest.Issues[issueID]
+		return ok && iss != nil && iss.PersistedIssue != nil && iss.PersistedIssue.State == state
+	}
+
+	issueA := &healthplatformpayload.Issue{
+		Id:        issueAID,
+		IssueName: testIssueName,
+		Source:    testSource,
+	}
+
+	issueB := &healthplatformpayload.Issue{
+		Id:        issueBID,
+		IssueName: testIssueName,
+		Source:    testSource,
+	}
+
+	deps.HP.ReportIssue(issueA)
+	deps.HP.ReportIssue(issueB)
+	require.Eventually(t, func() bool {
+		return latestHasIssueState(issueAID, healthplatformpayload.IssueState_ISSUE_STATE_NEW) &&
+			latestHasIssueState(issueBID, healthplatformpayload.IssueState_ISSUE_STATE_NEW)
+	}, waitTimeout, waitInterval, "issueA and issueB never appeared as NEW in forwarded reports")
+
+	deps.HP.ReportIssue(issueA)
+	require.Eventually(t, func() bool {
+		return latestHasIssueState(issueAID, healthplatformpayload.IssueState_ISSUE_STATE_ONGOING)
+	}, waitTimeout, waitInterval, "issueA never transitioned to ONGOING in forwarded reports")
+
+	deps.HP.ResolveIssue(issueAID)
+	deps.HP.ResolveIssue(issueBID)
+
+	require.Eventually(t, func() bool {
+		return latestHasIssueState(issueAID, healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED) &&
+			latestHasIssueState(issueBID, healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED)
+	}, waitTimeout, waitInterval, "expected a forwarded payload with issueA=RESOLVED and issueB=RESOLVED")
+
+	deps.HP.ReportIssue(issueA)
+	require.Eventually(t, func() bool {
+		return latestHasIssueState(issueAID, healthplatformpayload.IssueState_ISSUE_STATE_NEW)
+	}, waitTimeout, waitInterval, "issueA never appeared as NEW in the latest forwarded payload")
+
+	// RESOLVED must appear exactly once: tombstones are removed after a successful send.
+	allPayloads, err := fiClient.GetAgentHealth()
+	require.NoError(t, err)
+	resolvedCountA, resolvedCountB := 0, 0
+	for _, p := range allPayloads {
+		if p == nil || p.HealthReport == nil {
+			continue
+		}
+		if iss, ok := p.Issues[issueAID]; ok && iss != nil && iss.PersistedIssue != nil &&
+			iss.PersistedIssue.State == healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED {
+			resolvedCountA++
+		}
+		if iss, ok := p.Issues[issueBID]; ok && iss != nil && iss.PersistedIssue != nil &&
+			iss.PersistedIssue.State == healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED {
+			resolvedCountB++
+		}
+	}
+	require.Equal(t, 1, resolvedCountA, "issueA RESOLVED forwarded more than once")
+	require.Equal(t, 1, resolvedCountB, "issueB RESOLVED forwarded more than once")
 }
 
 // TestAllModulesIssueNameMatchesBuiltIssueName guards the invariant that

--- a/comp/healthplatform/egress/impl/BUILD.bazel
+++ b/comp/healthplatform/egress/impl/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     deps = [
         "//comp/core/log/mock",
         "//comp/healthplatform/forwarder/def",
+        "//comp/healthplatform/store/def",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/comp/healthplatform/egress/impl/egress.go
+++ b/comp/healthplatform/egress/impl/egress.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/agent-payload/v5/healthplatform"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	egressdef "github.com/DataDog/datadog-agent/comp/healthplatform/egress/def"
@@ -26,21 +26,17 @@ import (
 )
 
 const (
-	// defaultEgressInterval is the default interval between health report submissions.
-	// Matches the previous forwarder default for backward compatibility.
 	defaultEgressInterval = 15 * time.Minute
+	sendTimeout           = 30 * time.Second
+	eventType             = "agent-health-issues"
 
-	// sendTimeout is the HTTP timeout for a single forwarder.Send call.
-	sendTimeout = 30 * time.Second
-
-	// eventType is the health report event type consumed by the intake.
-	eventType = "agent-health-issues"
+	resolvedChBuf = 64
 )
 
 // egress drives the periodic outbound POST to the Datadog intake.
-// On each tick it calls store.GetAllIssues(), builds a HealthReport, and
-// forwards it via forwarder.Send. When health_platform is disabled, lifecycle
-// hooks are never registered so the goroutine is never launched.
+// Active issues are fetched via store.GetAllIssues on each tick.
+// Resolved tombstones are pushed by the store through resolvedCh and held in
+// the resolved map until they are successfully sent.
 type egress struct {
 	log         log.Component
 	interval    time.Duration
@@ -48,6 +44,9 @@ type egress struct {
 	agentFlavor string
 	store       storedef.Component
 	forwarder   forwarderdef.Component
+
+	resolvedCh chan *healthplatform.Issue       // transit: store → run()
+	resolved   map[string]*healthplatform.Issue // dedup store for tombstones; owned by run()
 
 	stopCh chan struct{}
 	doneCh chan struct{}
@@ -64,8 +63,6 @@ type Requires struct {
 }
 
 // New creates the egress component and registers its lifecycle hooks.
-// When health_platform.enabled is false, it returns a zero-value struct without
-// registering any lifecycle hooks.
 func New(reqs Requires) egressdef.Component {
 	if !reqs.Config.GetBool("health_platform.enabled") {
 		return &egress{}
@@ -89,9 +86,16 @@ func New(reqs Requires) egressdef.Component {
 		agentFlavor: flavor.GetFlavor(),
 		store:       reqs.Store,
 		forwarder:   reqs.Forwarder,
+		resolvedCh:  make(chan *healthplatform.Issue, resolvedChBuf),
+		resolved:    make(map[string]*healthplatform.Issue),
 		stopCh:      make(chan struct{}),
 		doneCh:      make(chan struct{}),
 	}
+
+	// Register before OnStart so loadFromDisk can pre-populate resolvedCh.
+	reqs.Store.RegisterIssuesObserver(storedef.IssuesObserver{
+		ResolvedCh: e.resolvedCh,
+	})
 
 	reqs.Lifecycle.Append(compdef.Hook{
 		OnStart: e.start,
@@ -124,6 +128,8 @@ func (e *egress) run() {
 		select {
 		case <-ticker.C:
 			e.tick()
+		case issue := <-e.resolvedCh:
+			e.resolved[issue.Id] = issue
 		case <-e.stopCh:
 			return
 		}
@@ -131,26 +137,35 @@ func (e *egress) run() {
 }
 
 func (e *egress) tick() {
-	count, issues := e.store.GetAllIssues()
-	if count == 0 {
+	count, active := e.store.GetAllIssues()
+	if count == 0 && len(e.resolved) == 0 {
 		e.log.Debug("Health platform egress: no issues to report, skipping tick")
 		return
 	}
 
-	report := e.buildReport(issues)
+	// Merge: active entries win over resolved tombstones for the same ID
+	// (a recurrence after a resolve is more recent than the tombstone).
+	merged := make(map[string]*healthplatform.Issue, count+len(e.resolved))
+	for id, issue := range e.resolved {
+		merged[id] = issue
+	}
+	for id, issue := range active {
+		merged[id] = issue
+	}
 
-	// Fresh context with a fixed timeout per send: the run loop does not carry
-	// a cancellable context, so we derive from Background rather than from an
-	// ancestor that may have already expired or been cancelled.
 	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
 	defer cancel()
 
-	if err := e.forwarder.Send(ctx, report); err != nil {
-		e.log.Warn(fmt.Sprintf("Health platform egress: failed to send %d issues: %v", count, err))
+	if err := e.forwarder.Send(ctx, e.buildReport(merged)); err != nil {
+		e.log.Warn(fmt.Sprintf("Health platform egress: failed to send %d issues: %v", len(merged), err))
 		return
 	}
 
-	e.log.Info(fmt.Sprintf("Health platform egress: sent report with %d issues", count))
+	e.log.Info(fmt.Sprintf("Health platform egress: sent report with %d issues", len(merged)))
+
+	// Resolved tombstones are consumed after a successful send; active issues
+	// are always re-fetched fresh from the store on the next tick.
+	e.resolved = make(map[string]*healthplatform.Issue)
 }
 
 func (e *egress) buildReport(issues map[string]*healthplatform.Issue) *healthplatform.HealthReport {

--- a/comp/healthplatform/egress/impl/egress_test.go
+++ b/comp/healthplatform/egress/impl/egress_test.go
@@ -20,27 +20,27 @@ import (
 	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	forwarderdef "github.com/DataDog/datadog-agent/comp/healthplatform/forwarder/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 )
 
-// mockStore records GetAllIssues calls and returns preset data.
+// mockStore satisfies storedef.Component; captures the registered observer and
+// returns configurable active issues from GetAllIssues.
 type mockStore struct {
-	mu        sync.Mutex
-	issues    map[string]*healthplatformpayload.Issue
-	callCount atomic.Int32
+	mu       sync.Mutex
+	observer storedef.IssuesObserver
+	issues   map[string]*healthplatformpayload.Issue
+}
+
+func (m *mockStore) RegisterIssuesObserver(obs storedef.IssuesObserver) {
+	m.mu.Lock()
+	m.observer = obs
+	m.mu.Unlock()
 }
 
 func (m *mockStore) GetAllIssues() (int, map[string]*healthplatformpayload.Issue) {
-	m.callCount.Add(1)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(m.issues) == 0 {
-		return 0, nil
-	}
-	cp := make(map[string]*healthplatformpayload.Issue, len(m.issues))
-	for k, v := range m.issues {
-		cp[k] = v
-	}
-	return len(cp), cp
+	return len(m.issues), m.issues
 }
 
 func (m *mockStore) ReportIssue(_ *healthplatformpayload.Issue) error { return nil }
@@ -79,17 +79,21 @@ func newTestEgress(t *testing.T, interval time.Duration, store *mockStore, fwd *
 		agentFlavor: "agent",
 		store:       store,
 		forwarder:   fwd,
+		resolvedCh:  make(chan *healthplatformpayload.Issue, resolvedChBuf),
+		resolved:    make(map[string]*healthplatformpayload.Issue),
 		stopCh:      make(chan struct{}),
 		doneCh:      make(chan struct{}),
 	}
 }
 
-func TestTickSendsReport(t *testing.T) {
-	store := &mockStore{
-		issues: map[string]*healthplatformpayload.Issue{
-			"issue-1": {Id: "issue-1", Title: "Test", Severity: healthplatformpayload.IssueSeverity_ISSUE_SEVERITY_HIGH},
-		},
-	}
+func newEmptyStore() *mockStore {
+	return &mockStore{issues: make(map[string]*healthplatformpayload.Issue)}
+}
+
+func TestTickSendsActiveIssues(t *testing.T) {
+	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
+		"issue-1": {Id: "issue-1", Title: "Test"},
+	}}
 	fwd := &mockForwarder{}
 	e := newTestEgress(t, time.Minute, store, fwd)
 
@@ -104,10 +108,9 @@ func TestTickSendsReport(t *testing.T) {
 	assert.Equal(t, eventType, fwd.reports[0].EventType)
 }
 
-func TestTickSkipsEmptyStore(t *testing.T) {
-	store := &mockStore{}
+func TestTickSkipsWhenEmpty(t *testing.T) {
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, newEmptyStore(), fwd)
 
 	e.tick()
 
@@ -115,24 +118,20 @@ func TestTickSkipsEmptyStore(t *testing.T) {
 }
 
 func TestTickLogsOnForwarderError(t *testing.T) {
-	store := &mockStore{
-		issues: map[string]*healthplatformpayload.Issue{
-			"issue-1": {Id: "issue-1"},
-		},
-	}
+	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
+		"issue-1": {Id: "issue-1"},
+	}}
 	fwd := &mockForwarder{sendErr: assert.AnError}
 	e := newTestEgress(t, time.Minute, store, fwd)
 
-	// Should not panic; error is logged internally.
 	e.tick()
 
 	assert.Equal(t, int32(1), fwd.sendCount.Load())
 }
 
 func TestLifecycleStartStop(t *testing.T) {
-	store := &mockStore{}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, 50*time.Millisecond, store, fwd)
+	e := newTestEgress(t, 50*time.Millisecond, newEmptyStore(), fwd)
 
 	require.NoError(t, e.start(context.Background()))
 	time.Sleep(30 * time.Millisecond)
@@ -140,40 +139,29 @@ func TestLifecycleStartStop(t *testing.T) {
 }
 
 func TestTickFiresOnInterval(t *testing.T) {
-	store := &mockStore{
-		issues: map[string]*healthplatformpayload.Issue{
-			"issue-1": {Id: "issue-1"},
-		},
-	}
+	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
+		"issue-1": {Id: "issue-1"},
+	}}
 	fwd := &mockForwarder{}
 	e := newTestEgress(t, 30*time.Millisecond, store, fwd)
 
 	require.NoError(t, e.start(context.Background()))
-
 	require.Eventually(t, func() bool {
 		return fwd.sendCount.Load() >= 2
 	}, 2*time.Second, 10*time.Millisecond, "expected at least 2 ticks")
-
 	require.NoError(t, e.stop(context.Background()))
 }
 
 func TestErrorThenRecovery(t *testing.T) {
-	store := &mockStore{
-		issues: map[string]*healthplatformpayload.Issue{
-			"issue-1": {Id: "issue-1"},
-		},
-	}
+	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
+		"issue-1": {Id: "issue-1"},
+	}}
 	fwd := &mockForwarder{sendErr: assert.AnError}
 	e := newTestEgress(t, 20*time.Millisecond, store, fwd)
 
 	require.NoError(t, e.start(context.Background()))
+	require.Eventually(t, func() bool { return fwd.sendCount.Load() >= 1 }, 2*time.Second, 5*time.Millisecond)
 
-	// Wait for at least one failed tick.
-	require.Eventually(t, func() bool {
-		return fwd.sendCount.Load() >= 1
-	}, 2*time.Second, 5*time.Millisecond)
-
-	// Clear the error; next tick should succeed.
 	fwd.mu.Lock()
 	fwd.sendErr = nil
 	fwd.mu.Unlock()
@@ -188,15 +176,10 @@ func TestErrorThenRecovery(t *testing.T) {
 }
 
 func TestBuildReport(t *testing.T) {
-	store := &mockStore{}
 	fwd := &mockForwarder{}
-	e := newTestEgress(t, time.Minute, store, fwd)
+	e := newTestEgress(t, time.Minute, newEmptyStore(), fwd)
 
-	issues := map[string]*healthplatformpayload.Issue{
-		"a": {Id: "a"},
-		"b": {Id: "b"},
-	}
-	report := e.buildReport(issues)
+	report := e.buildReport(map[string]*healthplatformpayload.Issue{"a": {Id: "a"}, "b": {Id: "b"}})
 
 	assert.Equal(t, eventType, report.EventType)
 	assert.Equal(t, "test-host", report.Host.Hostname)
@@ -204,4 +187,83 @@ func TestBuildReport(t *testing.T) {
 	assert.Len(t, report.Issues, 2)
 	_, err := time.Parse(time.RFC3339, report.EmittedAt)
 	assert.NoError(t, err)
+}
+
+// TestResolvedIssueSentOnce verifies that resolved tombstones are cleared after a successful send.
+func TestResolvedIssueSentOnce(t *testing.T) {
+	fwd := &mockForwarder{}
+	e := newTestEgress(t, time.Minute, newEmptyStore(), fwd)
+	e.resolved["r-issue"] = &healthplatformpayload.Issue{
+		Id: "r-issue",
+		PersistedIssue: &healthplatformpayload.PersistedIssue{
+			State: healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED,
+		},
+	}
+
+	e.tick()
+
+	assert.Equal(t, int32(1), fwd.sendCount.Load())
+	fwd.mu.Lock()
+	assert.Contains(t, fwd.reports[0].Issues, "r-issue")
+	fwd.mu.Unlock()
+	assert.Empty(t, e.resolved, "resolved map must be cleared after successful send")
+
+	e.tick()
+	assert.Equal(t, int32(1), fwd.sendCount.Load(), "second tick must skip: no active or resolved issues")
+}
+
+// TestResolvedStaysOnSendFailure verifies resolved tombstones are retained when send fails.
+func TestResolvedStaysOnSendFailure(t *testing.T) {
+	fwd := &mockForwarder{sendErr: assert.AnError}
+	e := newTestEgress(t, time.Minute, newEmptyStore(), fwd)
+	e.resolved["fail-issue"] = &healthplatformpayload.Issue{Id: "fail-issue"}
+
+	e.tick()
+
+	assert.Contains(t, e.resolved, "fail-issue", "resolved map must be retained after failed send")
+}
+
+// TestActiveWinsOverResolvedOnRecurrence verifies that a NEW active entry takes precedence over
+// a stale resolved tombstone for the same ID (issue recurred after being resolved).
+func TestActiveWinsOverResolvedOnRecurrence(t *testing.T) {
+	store := &mockStore{issues: map[string]*healthplatformpayload.Issue{
+		"i:1": {Id: "i:1", PersistedIssue: &healthplatformpayload.PersistedIssue{
+			State: healthplatformpayload.IssueState_ISSUE_STATE_NEW,
+		}},
+	}}
+	fwd := &mockForwarder{}
+	e := newTestEgress(t, time.Minute, store, fwd)
+	e.resolved["i:1"] = &healthplatformpayload.Issue{
+		Id: "i:1",
+		PersistedIssue: &healthplatformpayload.PersistedIssue{
+			State: healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED,
+		},
+	}
+
+	e.tick()
+
+	fwd.mu.Lock()
+	defer fwd.mu.Unlock()
+	require.Len(t, fwd.reports, 1)
+	sent := fwd.reports[0].Issues["i:1"]
+	require.NotNil(t, sent)
+	assert.Equal(t, healthplatformpayload.IssueState_ISSUE_STATE_NEW, sent.PersistedIssue.GetState(),
+		"active NEW entry must win over stale resolved tombstone on recurrence")
+}
+
+// TestObserverWiresResolvedCh verifies that RegisterIssuesObserver wires resolvedCh into egress.
+func TestObserverWiresResolvedCh(t *testing.T) {
+	store := newEmptyStore()
+	fwd := &mockForwarder{}
+	e := newTestEgress(t, time.Minute, store, fwd)
+
+	store.RegisterIssuesObserver(storedef.IssuesObserver{
+		ResolvedCh: e.resolvedCh,
+	})
+
+	store.mu.Lock()
+	store.observer.ResolvedCh <- &healthplatformpayload.Issue{Id: "resolved"}
+	store.mu.Unlock()
+
+	assert.Len(t, e.resolvedCh, 1)
 }

--- a/comp/healthplatform/noop-impl/health_platform_noop.go
+++ b/comp/healthplatform/noop-impl/health_platform_noop.go
@@ -53,6 +53,8 @@ func (n *noopHealthPlatform) GetIssue(_ string) *healthplatformpayload.Issue {
 	return nil
 }
 
+func (n *noopHealthPlatform) RegisterIssuesObserver(_ healthplatformdef.IssuesObserver) {}
+
 func (n *noopHealthPlatform) ResolveIssue(_ string) {
 }
 

--- a/comp/healthplatform/runner/impl/runner_test.go
+++ b/comp/healthplatform/runner/impl/runner_test.go
@@ -42,6 +42,7 @@ func (m *mockStore) ReportIssue(issue *healthplatformpayload.Issue) error {
 	return nil
 }
 
+func (m *mockStore) RegisterIssuesObserver(_ storedef.IssuesObserver)             {}
 func (m *mockStore) ResolveIssue(_ string)                                        {}
 func (m *mockStore) ResolveAllIssues()                                            {}
 func (m *mockStore) GetIssue(_ string) *healthplatformpayload.Issue               { return nil }

--- a/comp/healthplatform/scheduler/impl/scheduler_test.go
+++ b/comp/healthplatform/scheduler/impl/scheduler_test.go
@@ -53,6 +53,7 @@ func (m *mockStore) ResolveIssue(id string) {
 	defer m.mu.Unlock()
 	m.resolvedIDs = append(m.resolvedIDs, id)
 }
+func (m *mockStore) RegisterIssuesObserver(_ storedef.IssuesObserver)             {}
 func (m *mockStore) ReportIssue(_ *healthplatformpayload.Issue) error             { return nil }
 func (m *mockStore) ResolveAllIssues()                                            {}
 func (m *mockStore) GetIssue(_ string) *healthplatformpayload.Issue               { return nil }

--- a/comp/healthplatform/store/def/component.go
+++ b/comp/healthplatform/store/def/component.go
@@ -15,8 +15,22 @@ import (
 	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
 )
 
+// IssuesObserver holds the channels the store writes issue events into.
+// It is the extension point for reactive integrations — e.g. an MCP server
+// exposing issues to AI agents for proactive remediation.
+type IssuesObserver struct {
+	// ResolvedCh receives issues when they transition to RESOLVED, including
+	// resolved issues recovered from disk on startup.
+	ResolvedCh chan *healthplatformpayload.Issue
+}
+
 // Component is the health platform store component interface.
 type Component interface {
+	// RegisterIssuesObserver registers a state-change listener. Multiple observers
+	// may be registered. Observers registered before OnStart also receive
+	// resolved issues recovered from disk on startup.
+	RegisterIssuesObserver(obs IssuesObserver)
+
 	// ReportIssue records a new or ongoing issue keyed by issue.Id. Two calls
 	// with the same issue.Id update the same instance (state machine: new →
 	// ongoing). issue.IssueName is used as the issue-type key for telemetry

--- a/comp/healthplatform/store/impl/BUILD.bazel
+++ b/comp/healthplatform/store/impl/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//comp/core/hostname/hostnameinterface/def",
         "//comp/core/log/mock",
         "//comp/core/telemetry/mock",
+        "//comp/healthplatform/store/def",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -23,7 +23,7 @@ import (
 	api "github.com/DataDog/datadog-agent/comp/api/api/def"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
@@ -79,6 +79,10 @@ type healthPlatformImpl struct {
 	// Persistence: lifecycle state only — proto payload is not stored here.
 	persistedIssues map[string]*PersistedIssue // IssueID → lifecycle state
 	persistence     issuesPersistence
+
+	// Issue observers: receive issue events outside issuesMux.
+	observersMu sync.RWMutex
+	observers   []healthplatformdef.IssuesObserver
 
 	// Metrics
 	metrics telemetryMetrics
@@ -310,8 +314,6 @@ func NewComponent(reqs Requires) (Provides, error) {
 // start starts the health platform component
 func (h *healthPlatformImpl) start(_ context.Context) error {
 	h.log.Info("Starting health platform component")
-
-	// Load persisted issues from disk
 	if err := h.loadFromDisk(); err != nil {
 		h.log.Warn("Failed to load persisted issues: " + err.Error())
 	}
@@ -322,6 +324,31 @@ func (h *healthPlatformImpl) start(_ context.Context) error {
 func (h *healthPlatformImpl) stop(_ context.Context) error {
 	h.log.Info("Stopping health platform component")
 	return nil
+}
+
+// RegisterIssuesObserver appends an observer. Observers registered after
+// OnStart will miss events that occurred before registration.
+func (h *healthPlatformImpl) RegisterIssuesObserver(obs healthplatformdef.IssuesObserver) {
+	h.observersMu.Lock()
+	h.observers = append(h.observers, obs)
+	h.observersMu.Unlock()
+}
+
+// notifyResolved writes a resolved tombstone to each observer's ResolvedCh.
+// Must be called outside issuesMux.
+func (h *healthPlatformImpl) notifyResolved(resolved *healthplatform.Issue) {
+	h.observersMu.RLock()
+	obs := h.observers
+	h.observersMu.RUnlock()
+	for _, o := range obs {
+		if o.ResolvedCh != nil {
+			select {
+			case o.ResolvedCh <- resolved:
+			default:
+				h.log.Warnf("health platform: resolved channel full, %s recoverable from disk", resolved.Id)
+			}
+		}
+	}
 }
 
 // ============================================================================
@@ -419,11 +446,13 @@ func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 	h.issuesMux.Lock()
 
 	stateChanged := false
+	var resolved *healthplatform.Issue
+
 	if _, ok := h.issues[issueID]; ok {
 		h.log.Info("Cleared issue: " + issueID)
+		delete(h.issues, issueID)
 		stateChanged = true
 	}
-	delete(h.issues, issueID)
 
 	if persisted := h.persistedIssues[issueID]; persisted != nil {
 		h.issuesByName[persisted.IssueType] = removeID(h.issuesByName[persisted.IssueType], issueID)
@@ -432,9 +461,19 @@ func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 			persisted.ResolvedAt = time.Now().Format(time.RFC3339)
 			stateChanged = true
 		}
+
+		resolved = &healthplatform.Issue{
+			Id:             issueID,
+			IssueName:      persisted.IssueType,
+			PersistedIssue: persistedIssueToProto(persisted),
+		}
 	}
 
 	h.issuesMux.Unlock()
+
+	if resolved != nil {
+		h.notifyResolved(resolved)
+	}
 
 	if stateChanged {
 		if err := h.saveToDisk(); err != nil {
@@ -443,15 +482,22 @@ func (h *healthPlatformImpl) ResolveIssue(issueID string) {
 	}
 }
 
-// ResolveAllIssues clears all active issues.
+// ResolveAllIssues marks every active issue as resolved.
 func (h *healthPlatformImpl) ResolveAllIssues() {
 	h.issuesMux.Lock()
 
 	now := time.Now().Format(time.RFC3339)
+	var resolved []*healthplatform.Issue
+
 	for _, persisted := range h.persistedIssues {
 		if persisted != nil && persisted.State != IssueStateResolved {
 			persisted.State = IssueStateResolved
 			persisted.ResolvedAt = now
+			resolved = append(resolved, &healthplatform.Issue{
+				Id:             persisted.IssueID,
+				IssueName:      persisted.IssueType,
+				PersistedIssue: persistedIssueToProto(persisted),
+			})
 		}
 	}
 
@@ -460,6 +506,10 @@ func (h *healthPlatformImpl) ResolveAllIssues() {
 	h.log.Info("Cleared all issues")
 
 	h.issuesMux.Unlock()
+
+	for _, t := range resolved {
+		h.notifyResolved(t)
+	}
 
 	if err := h.saveToDisk(); err != nil {
 		h.log.Warn("Failed to persist issues to disk: " + err.Error())
@@ -602,9 +652,10 @@ func (h *healthPlatformImpl) loadFromDisk() error {
 	pruneOldResolvedIssues(state.Issues)
 
 	h.issuesMux.Lock()
-	defer h.issuesMux.Unlock()
 
 	activeCount := 0
+	var resolvedIssues []*healthplatform.Issue
+
 	for issueID, persisted := range state.Issues {
 		if persisted == nil {
 			continue
@@ -612,16 +663,32 @@ func (h *healthPlatformImpl) loadFromDisk() error {
 		persisted.IssueID = issueID
 		h.persistedIssues[issueID] = persisted
 
-		if persisted.State == IssueStateResolved || persisted.IssueType == "" {
+		if persisted.IssueType == "" {
 			continue
 		}
 
-		nameKey := persisted.IssueType
-		h.issuesByName[nameKey] = append(h.issuesByName[nameKey], issueID)
+		if persisted.State == IssueStateResolved {
+			resolvedIssues = append(resolvedIssues, &healthplatform.Issue{
+				Id:             issueID,
+				IssueName:      persisted.IssueType,
+				PersistedIssue: persistedIssueToProto(persisted),
+			})
+			continue
+		}
+
+		h.issuesByName[persisted.IssueType] = append(h.issuesByName[persisted.IssueType], issueID)
 		activeCount++
 	}
 
-	h.log.Info(fmt.Sprintf("Loaded %d persisted issues (%d active)", len(state.Issues), activeCount))
+	h.issuesMux.Unlock()
+
+	h.log.Info(fmt.Sprintf("Loaded %d persisted issues (%d active, %d resolved pending send)",
+		len(state.Issues), activeCount, len(resolvedIssues)))
+
+	for _, t := range resolvedIssues {
+		h.notifyResolved(t)
+	}
+
 	return nil
 }
 

--- a/comp/healthplatform/store/impl/store_test.go
+++ b/comp/healthplatform/store/impl/store_test.go
@@ -26,6 +26,7 @@ import (
 	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	telemetrymock "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 )
 
 // memPersistence stores state in memory, replacing disk I/O in unit tests.
@@ -203,9 +204,18 @@ func TestResolveIssueRemovesFromActive(t *testing.T) {
 	h := newTestStore(t)
 	require.NoError(t, h.ReportIssue(&healthplatformpayload.Issue{Id: "t:id", IssueName: "t"}))
 
+	ch := make(chan *healthplatformpayload.Issue, 1)
+	h.RegisterIssuesObserver(storedef.IssuesObserver{ResolvedCh: ch})
+
 	h.ResolveIssue("t:id")
 
-	assert.Nil(t, h.GetIssue("t:id"))
+	// Issue must be removed from the active set; resolved snapshot written to ResolvedCh.
+	assert.Nil(t, h.GetIssue("t:id"), "issue must be removed from active set after ResolveIssue")
+	require.Len(t, ch, 1, "resolved issue must be written to ResolvedCh")
+	got := <-ch
+	require.NotNil(t, got.PersistedIssue)
+	assert.Equal(t, IssueStateResolved, got.PersistedIssue.State)
+
 	require.NotNil(t, h.persistedIssues["t:id"])
 	assert.Equal(t, IssueStateResolved, h.persistedIssues["t:id"].State)
 	assert.NotEmpty(t, h.persistedIssues["t:id"].ResolvedAt)
@@ -426,4 +436,24 @@ func TestGetActiveIssueIDsByIssueName(t *testing.T) {
 	h.ResolveIssue("t:1")
 	ids = h.GetActiveIssueIDsByIssueName("t")
 	assert.ElementsMatch(t, []string{"t:2"}, ids)
+}
+
+func newTestObserver(resolvedSz int) storedef.IssuesObserver {
+	return storedef.IssuesObserver{
+		ResolvedCh: make(chan *healthplatformpayload.Issue, resolvedSz),
+	}
+}
+
+// TestIssuesObserverResolvedNotification verifies that ResolvedCh receives a tombstone on ResolveIssue.
+func TestIssuesObserverResolvedNotification(t *testing.T) {
+	h := newTestStore(t)
+	obs := newTestObserver(4)
+	h.RegisterIssuesObserver(obs)
+
+	require.NoError(t, h.ReportIssue(&healthplatformpayload.Issue{Id: "i:1", IssueName: "t"}))
+	h.ResolveIssue("i:1")
+
+	require.Len(t, obs.ResolvedCh, 1)
+	got := <-obs.ResolvedCh
+	assert.Equal(t, IssueStateResolved, got.PersistedIssue.GetState())
 }

--- a/comp/healthplatform/store/mock/mock.go
+++ b/comp/healthplatform/store/mock/mock.go
@@ -59,6 +59,9 @@ func (m *mockHealthPlatform) GetIssue(checkID string) *healthplatformpayload.Iss
 	return proto.Clone(issue).(*healthplatformpayload.Issue)
 }
 
+// RegisterIssuesObserver is a no-op in the mock.
+func (m *mockHealthPlatform) RegisterIssuesObserver(_ healthplatform.IssuesObserver) {}
+
 // ResolveIssue clears issues for a specific check
 func (m *mockHealthPlatform) ResolveIssue(checkID string) {
 	delete(m.issues, checkID)

--- a/comp/healthplatform/store/noop-impl/noop.go
+++ b/comp/healthplatform/store/noop-impl/noop.go
@@ -35,6 +35,9 @@ func NewNoopHealthPlatform() *NoopHealthPlatform {
 	return &NoopHealthPlatform{}
 }
 
+// RegisterIssuesObserver does nothing when the health platform is disabled.
+func (n *NoopHealthPlatform) RegisterIssuesObserver(_ healthplatform.IssuesObserver) {}
+
 // ReportIssue does nothing when the health platform is disabled.
 func (n *NoopHealthPlatform) ReportIssue(_ *healthplatformpayload.Issue) error {
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -949,6 +949,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/confmaputils v0.81.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/util/hostport v0.81.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace v0.81.0-rc.2
+	github.com/DataDog/datadog-agent/test/fakeintake v0.0.0-00010101000000-000000000000
 	github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5
 	github.com/DataDog/rshell v0.0.20
 	github.com/aptly-dev/aptly v1.6.3-0.20260504093056-0d31298f3709

--- a/test/new-e2e/tests/agent-health/admission_probe_test.go
+++ b/test/new-e2e/tests/agent-health/admission_probe_test.go
@@ -74,54 +74,48 @@ func (suite *admissionProbeSuite) TestAdmissionProbeIssueLifecycle() {
 	// =========================================================================
 	// Phase 1: Verify probe is healthy
 	// =========================================================================
-	suite.T().Run("ProbeHealthy", func(t *testing.T) {
-		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			stdout, _, err := suite.Env().KubernetesCluster.KubernetesClient.PodExec(
-				clusterAgentNamespace, clusterAgentPod.Name, "cluster-agent",
-				[]string{"env", "DD_LOG_LEVEL=off", "datadog-cluster-agent", "status", "--json"},
-			)
-			assert.NoError(ct, err)
+	require.EventuallyWithT(suite.T(), func(ct *assert.CollectT) {
+		stdout, _, err := suite.Env().KubernetesCluster.KubernetesClient.PodExec(
+			clusterAgentNamespace, clusterAgentPod.Name, "cluster-agent",
+			[]string{"env", "DD_LOG_LEVEL=off", "datadog-cluster-agent", "status", "--json"},
+		)
+		assert.NoError(ct, err)
 
-			var status map[string]interface{}
-			assert.NoError(ct, json.Unmarshal([]byte(stdout), &status))
+		var status map[string]any
+		assert.NoError(ct, json.Unmarshal([]byte(stdout), &status))
 
-			webhook, ok := status["admissionWebhook"].(map[string]interface{})
-			if !assert.True(ct, ok, "admissionWebhook section not found in status") {
-				return
-			}
-			probeSection, ok := webhook["Probe"].(map[string]interface{})
-			if !assert.True(ct, ok, "Probe section not found in admissionWebhook status") {
-				return
-			}
-			assert.Equal(ct, true, probeSection["LastExecutionSuccess"])
-		}, 3*time.Minute, 15*time.Second, "Probe has not completed a successful execution")
-	})
+		webhook, ok := status["admissionWebhook"].(map[string]any)
+		if !assert.True(ct, ok, "admissionWebhook section not found in status") {
+			return
+		}
+		probeSection, ok := webhook["Probe"].(map[string]any)
+		if !assert.True(ct, ok, "Probe section not found in admissionWebhook status") {
+			return
+		}
+		assert.Equal(ct, true, probeSection["LastExecutionSuccess"])
+	}, 3*time.Minute, 15*time.Second, "Probe has not completed a successful execution")
 
-	// =========================================================================
-	// Phase 2: Block connectivity and verify issue detection
-	// =========================================================================
 	suite.T().Run("IssueDetection", func(t *testing.T) {
 		suite.blockWebhookFromAPIServer(t)
 
 		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
 
-		// Wait for the health report containing the admission probe issue to arrive in fakeintake.
-		// This is the authoritative assertion: it verifies the full pipeline
-		// (probe detection → health platform → forwarder → fakeintake).
 		var detectedIssue *healthplatform.Issue
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			payloads, err := fakeIntake.GetAgentHealth()
 			assert.NoError(ct, err)
-			assert.NotEmpty(ct, payloads, "No health report received in fakeintake")
-			if len(payloads) == 0 {
-				return
+			for _, p := range payloads {
+				for _, iss := range findIssuesByID(t, p, admissionProbeIssueID) {
+					if iss.PersistedIssue != nil &&
+						(iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_NEW ||
+							iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_ONGOING) {
+						detectedIssue = iss
+						return
+					}
+				}
 			}
-			latest := payloads[len(payloads)-1]
-			if issues := findIssuesByID(t, latest, admissionProbeIssueID); len(issues) > 0 {
-				detectedIssue = issues[0]
-			}
-			assert.NotNil(ct, detectedIssue, "Admission probe issue not in fakeintake report")
-		}, 4*time.Minute, 15*time.Second, "Health report with admission probe issue not received in fakeintake")
+			assert.Fail(ct, "admission probe issue not found as NEW or ONGOING in fakeintake")
+		}, defaultIssueTimeout, defaultIssuePollInterval, "admission probe issue not detected in fakeintake")
 
 		require.NotNil(t, detectedIssue)
 		assert.Equal(t, admissionProbeIssueID, detectedIssue.Id)
@@ -130,7 +124,6 @@ func (suite *admissionProbeSuite) TestAdmissionProbeIssueLifecycle() {
 		assert.Equal(t, "cluster-agent", detectedIssue.Source)
 		assert.NotNil(t, detectedIssue.Remediation)
 		assert.NotEmpty(t, detectedIssue.Remediation.Steps)
-
 		require.NotNil(t, detectedIssue.PersistedIssue)
 		assert.Contains(t,
 			[]healthplatform.IssueState{
@@ -138,36 +131,25 @@ func (suite *admissionProbeSuite) TestAdmissionProbeIssueLifecycle() {
 				healthplatform.IssueState_ISSUE_STATE_ONGOING,
 			},
 			detectedIssue.PersistedIssue.State)
-
-		t.Logf("Phase 2 passed: admission probe issue detected (state=%v)", detectedIssue.PersistedIssue.State)
 	})
 
-	// =========================================================================
-	// Phase 3: Restore connectivity and verify resolution
-	// =========================================================================
+	suite.unblockWebhookFromAPIServer(suite.T())
+
 	suite.T().Run("Resolution", func(t *testing.T) {
-		suite.unblockWebhookFromAPIServer(t)
-
-		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
-
-		// Once resolved, the issue should be absent from all subsequent health reports.
-		require.Never(t, func() bool {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			payloads, err := fakeIntake.GetAgentHealth()
-			if err != nil {
-				return false
-			}
-			for _, payload := range payloads {
-				if len(findIssuesByID(t, payload, admissionProbeIssueID)) > 0 {
-					return true
+			assert.NoError(ct, err)
+			for _, p := range payloads {
+				for _, iss := range findIssuesByID(t, p, admissionProbeIssueID) {
+					if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_RESOLVED {
+						return
+					}
 				}
 			}
-			return false
-		}, 3*time.Minute, 15*time.Second, "Admission probe issue still present after restoring connectivity")
-
-		t.Log("Phase 3 passed: admission probe issue resolved")
+			assert.Fail(ct, "no payload found with the issue in RESOLVED state")
+		}, defaultIssueTimeout, defaultIssuePollInterval, "admission probe issue never transitioned to RESOLVED")
 	})
 
-	suite.T().Log("=== Full admission probe lifecycle test passed ===")
 }
 
 // ============================================================================

--- a/test/new-e2e/tests/agent-health/check_failure_test.go
+++ b/test/new-e2e/tests/agent-health/check_failure_test.go
@@ -8,6 +8,7 @@ package agenthealth
 import (
 	_ "embed"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,11 +22,10 @@ import (
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
 )
 
-const healthPlatformAgentConfig = `health_platform:
-  enabled: true
-  forwarder:
-    interval: 30s
-`
+// healthPlatformAgentConfig is the shared base agent config; short forwarder interval reduces test latency.
+//
+//go:embed fixtures/agent_config.yaml
+var healthPlatformAgentConfig string
 
 const brokenCheckConf = `init_config:
 instances:
@@ -37,10 +37,6 @@ var brokenCheckPy string
 
 //go:embed fixtures/fixed_check.py
 var fixedCheckPy string
-
-// ============================================================================
-// Test suite
-// ============================================================================
 
 type checkFailureSuite struct {
 	e2e.BaseSuite[environments.Host]
@@ -66,21 +62,15 @@ func TestCheckFailureSuite(t *testing.T) {
 	)
 }
 
-// TestCheckFailureIssueLifecycle verifies that a check execution failure is
-// detected in fakeintake as NEW and that replacing the failing check with a
-// working version causes the issue to stop being reported (or be reported as
-// RESOLVED).
-//
-// Cross-restart persistence is tested separately in TestResilienceSuite.
+// TestCheckFailureIssueLifecycle verifies that a check execution failure is detected as NEW
+// and transitions to RESOLVED after the check is fixed. Cross-restart persistence is in TestResilienceSuite.
 func (suite *checkFailureSuite) TestCheckFailureIssueLifecycle() {
 	fakeIntake := suite.Env().FakeIntake.Client()
 
 	const issuePrefix = "check-execution-failure:broken_check"
 
 	suite.T().Run("IssueDetection", func(t *testing.T) {
-		// broken_check.py is deployed by the provisioner; agent is ready at suite start.
-		// Accept NEW or ONGOING: the check may fail multiple times before the first egress
-		// tick fires, so the state could already be ONGOING by the time it reaches fakeintake.
+		// Accept NEW or ONGOING: check may fail multiple times before the first egress tick.
 		var issues []*healthplatform.Issue
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			payloads, err := fakeIntake.GetAgentHealth()
@@ -108,32 +98,39 @@ func (suite *checkFailureSuite) TestCheckFailureIssueLifecycle() {
 		assert.NotEmpty(t, issue.Remediation.Summary)
 	})
 
-	suite.T().Run("Resolution", func(t *testing.T) {
-		suite.UpdateEnv(awshost.Provisioner(
-			awshost.WithRunOptions(
-				ec2.WithAgentOptions(
-					agentparams.WithAgentConfig(healthPlatformAgentConfig),
-					agentparams.WithIntegration("broken_check.d", brokenCheckConf),
-					agentparams.WithFile(
-						"/etc/datadog-agent/checks.d/broken_check.py",
-						fixedCheckPy,
-						true,
-					),
+	suite.UpdateEnv(awshost.Provisioner(
+		awshost.WithRunOptions(
+			ec2.WithAgentOptions(
+				agentparams.WithAgentConfig(healthPlatformAgentConfig),
+				agentparams.WithIntegration("broken_check.d", brokenCheckConf),
+				agentparams.WithFile(
+					"/etc/datadog-agent/checks.d/broken_check.py",
+					fixedCheckPy,
+					true,
 				),
 			),
-		))
-		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
+		),
+	))
+	// Restart so the agent re-imports fixed_check.py (WithFile doesn't reload cached Python modules).
+	agent := suite.Env().Agent
+	require.NoError(suite.T(), agent.Client.Restart())
+	require.EventuallyWithT(suite.T(), func(ct *assert.CollectT) {
+		assert.True(ct, agent.Client.IsReady())
+	}, 2*time.Minute, 10*time.Second, "agent not ready after fix")
+	require.NoError(suite.T(), fakeIntake.FlushServerAndResetAggregators())
 
-		require.Never(t, func() bool {
-			payloads, _ := fakeIntake.GetAgentHealth()
+	suite.T().Run("Resolution", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			payloads, err := fakeIntake.GetAgentHealth()
+			assert.NoError(ct, err)
 			for _, p := range payloads {
 				for _, iss := range findIssuesByPrefix(p, issuePrefix) {
-					if iss.PersistedIssue == nil || iss.PersistedIssue.State != healthplatform.IssueState_ISSUE_STATE_RESOLVED {
-						return true
+					if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_RESOLVED {
+						return
 					}
 				}
 			}
-			return false
-		}, defaultIssueAbsenceWindow, defaultIssuePollInterval, "issue still reported as non-resolved after fix")
+			assert.Fail(ct, "no payload found with the issue in RESOLVED state")
+		}, defaultIssueTimeout, defaultIssuePollInterval, "issue never transitioned to RESOLVED after fix")
 	})
 }

--- a/test/new-e2e/tests/agent-health/docker_permission_test.go
+++ b/test/new-e2e/tests/agent-health/docker_permission_test.go
@@ -128,18 +128,16 @@ func (suite *dockerPermissionSuite) TestDockerPermissionIssueLifecycle() {
 
 	const issueID = "docker-socket-permissions"
 
-	suite.T().Run("PreCondition", func(t *testing.T) {
-		containers, err := suite.Env().Docker.Client.ListContainers()
-		require.NoError(t, err)
-		found := false
-		for _, name := range containers {
-			if strings.Contains(name, "spam") {
-				found = true
-				break
-			}
+	containers, err := suite.Env().Docker.Client.ListContainers()
+	require.NoError(suite.T(), err)
+	found := false
+	for _, name := range containers {
+		if strings.Contains(name, "spam") {
+			found = true
+			break
 		}
-		assert.True(t, found, "busybox spam containers should be running")
-	})
+	}
+	assert.True(suite.T(), found, "busybox spam containers should be running")
 
 	suite.T().Run("IssueDetection", func(t *testing.T) {
 		host.MustExecute("sudo chmod 660 /var/run/docker.sock")
@@ -173,6 +171,14 @@ func (suite *dockerPermissionSuite) TestDockerPermissionIssueLifecycle() {
 		assert.NotEmpty(t, issue.Remediation.Steps)
 	})
 
+	host.MustExecute("sudo chmod 666 /var/run/docker.sock")
+	perm := host.MustExecute("stat -c '%a' /var/run/docker.sock")
+	assert.Contains(suite.T(), strings.TrimSpace(perm), "666", "docker socket should be world-accessible")
+	require.NoError(suite.T(), agent.Client.Restart())
+	require.EventuallyWithT(suite.T(), func(ct *assert.CollectT) {
+		assert.True(ct, agent.Client.IsReady())
+	}, 2*time.Minute, 10*time.Second, "agent not ready after fix restart")
+
 	suite.T().Run("Resolution", func(t *testing.T) {
 		// Restore broken state on cleanup so infra can be re-used for re-runs.
 		t.Cleanup(func() {
@@ -180,26 +186,17 @@ func (suite *dockerPermissionSuite) TestDockerPermissionIssueLifecycle() {
 			_ = agent.Client.Restart()
 		})
 
-		host.MustExecute("sudo chmod 666 /var/run/docker.sock")
-		perm := host.MustExecute("stat -c '%a' /var/run/docker.sock")
-		assert.Contains(t, strings.TrimSpace(perm), "666", "docker socket should be world-accessible")
-
-		require.NoError(t, agent.Client.Restart())
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			assert.True(ct, agent.Client.IsReady())
-		}, 2*time.Minute, 10*time.Second, "agent not ready after fix restart")
-		require.NoError(t, fakeIntake.FlushServerAndResetAggregators())
-
-		require.Never(t, func() bool {
-			payloads, _ := fakeIntake.GetAgentHealth()
+			payloads, err := fakeIntake.GetAgentHealth()
+			assert.NoError(ct, err)
 			for _, p := range payloads {
 				for _, iss := range findIssuesByID(t, p, issueID) {
-					if iss.PersistedIssue == nil || iss.PersistedIssue.State != healthplatform.IssueState_ISSUE_STATE_RESOLVED {
-						return true
+					if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_RESOLVED {
+						return
 					}
 				}
 			}
-			return false
-		}, defaultIssueAbsenceWindow, defaultIssuePollInterval, "issue still reported as non-resolved after fix")
+			assert.Fail(ct, "no payload found with the issue in RESOLVED state")
+		}, defaultIssueTimeout, defaultIssuePollInterval, "issue never transitioned to RESOLVED after fix")
 	})
 }

--- a/test/new-e2e/tests/agent-health/fixtures/agent_config.yaml
+++ b/test/new-e2e/tests/agent-health/fixtures/agent_config.yaml
@@ -1,0 +1,4 @@
+health_platform:
+  enabled: true
+  forwarder:
+    interval: 5s

--- a/test/new-e2e/tests/agent-health/fixtures/docker_permission_agent_config.yaml
+++ b/test/new-e2e/tests/agent-health/fixtures/docker_permission_agent_config.yaml
@@ -1,7 +1,7 @@
 health_platform:
   enabled: true
   forwarder:
-    interval: 30s
+    interval: 5s
 logs_enabled: true
 logs_config:
   container_collect_all: true

--- a/test/new-e2e/tests/agent-health/helpers_test.go
+++ b/test/new-e2e/tests/agent-health/helpers_test.go
@@ -17,12 +17,10 @@ import (
 )
 
 const (
-	// defaultIssueTimeout is the default timeout for issue detection.
+	// defaultIssueTimeout is the default timeout for issue detection and resolution.
 	defaultIssueTimeout = 2 * time.Minute
-	// defaultIssuePollInterval is the poll cadence for EventuallyWithT / Never.
+	// defaultIssuePollInterval is the poll cadence for EventuallyWithT.
 	defaultIssuePollInterval = 10 * time.Second
-	// defaultIssueAbsenceWindow is how long we verify an issue stays absent/resolved.
-	defaultIssueAbsenceWindow = 45 * time.Second
 )
 
 // findIssuesByID returns all issues with the given exact ID from a fakeintake payload.

--- a/test/new-e2e/tests/agent-health/resilience_test.go
+++ b/test/new-e2e/tests/agent-health/resilience_test.go
@@ -21,15 +21,12 @@ import (
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
 )
 
-// resilienceSuite tests the health platform's cross-restart persistence and
-// recurrence behaviours. These are framework-level concerns (not issue-specific),
-// so they are covered once here rather than duplicated in every lifecycle test.
+// resilienceSuite tests cross-restart persistence and issue recurrence (framework-level, not issue-specific).
 type resilienceSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
 
-// TestResilienceSuite runs the health platform resilience tests.
-// It reuses the broken_check fixtures from check_failure_test.go (same package).
+// TestResilienceSuite runs the health platform resilience tests (reuses broken_check fixtures).
 func TestResilienceSuite(t *testing.T) {
 	t.Parallel()
 	e2e.Run(t, &resilienceSuite{},
@@ -49,18 +46,15 @@ func TestResilienceSuite(t *testing.T) {
 	)
 }
 
-// TestHealthPlatformResilience verifies that a health issue persists across a
-// graceful agent restart: after restart the issue must be re-reported to
-// fakeintake as ONGOING with the same first_seen timestamp as before.
+// TestHealthPlatformResilience verifies that a health issue persists across a graceful restart,
+// re-reported as ONGOING with the same first_seen timestamp.
 func (suite *resilienceSuite) TestHealthPlatformResilience() {
 	agent := suite.Env().Agent
 	fakeIntake := suite.Env().FakeIntake.Client()
 
 	const issuePrefix = "check-execution-failure:broken_check"
 
-	// Wait for the initial detection (NEW or ONGOING) so we have a first_seen to compare.
-	// The check may fail multiple times before the first egress tick, so the state may
-	// already be ONGOING by the time the report arrives in fakeintake.
+	// Accept NEW or ONGOING: check may fail multiple times before the first egress tick.
 	var initialIssues []*healthplatform.Issue
 	require.EventuallyWithT(suite.T(), func(ct *assert.CollectT) {
 		payloads, err := fakeIntake.GetAgentHealth()
@@ -116,12 +110,8 @@ func (suite *resilienceSuite) TestHealthPlatformResilience() {
 	}
 }
 
-// TestHealthPlatformIssueRecurrence verifies that a previously resolved issue
-// re-appears as NEW (not ONGOING) when the underlying problem recurs, and that
-// first_seen is reset to the new detection time.
-//
-// This tests store.go's state-transition logic: a resolved issue ID that is
-// re-reported reverts to NEW and clears its original first_seen/last_seen.
+// TestHealthPlatformIssueRecurrence verifies that a resolved issue re-appears as NEW (not ONGOING)
+// when the problem recurs, with first_seen reset to the new detection time.
 func (suite *resilienceSuite) TestHealthPlatformIssueRecurrence() {
 	fakeIntake := suite.Env().FakeIntake.Client()
 
@@ -153,20 +143,26 @@ func (suite *resilienceSuite) TestHealthPlatformIssueRecurrence() {
 			),
 		),
 	))
-	require.NoError(suite.T(), fakeIntake.FlushServerAndResetAggregators())
+	// Restart so the Python module cache is cleared and fixed_check.py is loaded.
+	agent := suite.Env().Agent
+	require.NoError(suite.T(), agent.Client.Restart())
+	require.EventuallyWithT(suite.T(), func(ct *assert.CollectT) {
+		assert.True(ct, agent.Client.IsReady())
+	}, 2*time.Minute, 10*time.Second, "agent not ready after fix")
 
-	// Verify the issue is resolved or no longer reported.
-	require.Never(suite.T(), func() bool {
-		payloads, _ := fakeIntake.GetAgentHealth()
+	// Wait for the RESOLVED state to appear in fakeintake before re-breaking.
+	require.EventuallyWithT(suite.T(), func(ct *assert.CollectT) {
+		payloads, err := fakeIntake.GetAgentHealth()
+		assert.NoError(ct, err)
 		for _, p := range payloads {
 			for _, iss := range findIssuesByPrefix(p, issuePrefix) {
-				if iss.PersistedIssue == nil || iss.PersistedIssue.State != healthplatform.IssueState_ISSUE_STATE_RESOLVED {
-					return true
+				if iss.PersistedIssue != nil && iss.PersistedIssue.State == healthplatform.IssueState_ISSUE_STATE_RESOLVED {
+					return
 				}
 			}
 		}
-		return false
-	}, defaultIssueAbsenceWindow, defaultIssuePollInterval, "issue not resolved after fix")
+		assert.Fail(ct, "no payload found with the issue in RESOLVED state")
+	}, defaultIssueTimeout, defaultIssuePollInterval, "issue never transitioned to RESOLVED after fix")
 
 	// Re-break: deploy the broken check again.
 	suite.UpdateEnv(awshost.Provisioner(


### PR DESCRIPTION
### What does this PR do?
Backport of #52168 to `7.81.x`.

### Motivation
Manual backport — automated cherry-pick failed due to `go.mod` version drift (internal packages at different versions on `7.81.x`). Conflict resolved by keeping `7.81.x` package versions and adding the one new `test/fakeintake` require entry introduced by the original PR.

### Describe how you validated your changes
Cherry-pick of `2581e4c402ff` onto `7.81.x` with conflict resolved in `go.mod`.

### Additional Notes
Backport of #52168.