### PR TITLE
In autodiscovery, use config.Component instead of global accessor

### DIFF
--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	confad "github.com/DataDog/datadog-agent/pkg/config/autodiscovery"
 	pkgconfigenv "github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -41,9 +42,9 @@ var (
 	legacyProviders = []string{"kubelet", "container", "docker"}
 )
 
-func setupAutoDiscovery(confSearchPaths []string, ac autodiscovery.Component) {
-	if pkgconfigsetup.Datadog().GetString("fleet_policies_dir") != "" {
-		confSearchPaths = append(confSearchPaths, filepath.Join(pkgconfigsetup.Datadog().GetString("fleet_policies_dir"), "conf.d"))
+func setupAutoDiscovery(confSearchPaths []string, ac autodiscovery.Component, cfg config.Component) {
+	if cfg.GetString("fleet_policies_dir") != "" {
+		confSearchPaths = append(confSearchPaths, filepath.Join(cfg.GetString("fleet_policies_dir"), "conf.d"))
 	}
 
 	providers.InitConfigFilesReader(confSearchPaths)
@@ -52,23 +53,23 @@ func setupAutoDiscovery(confSearchPaths []string, ac autodiscovery.Component) {
 
 	ac.AddConfigProvider(
 		providers.NewFileConfigProvider(acTelemetryStore),
-		pkgconfigsetup.Datadog().GetBool("autoconf_config_files_poll"),
-		time.Duration(pkgconfigsetup.Datadog().GetInt("autoconf_config_files_poll_interval"))*time.Second,
+		cfg.GetBool("autoconf_config_files_poll"),
+		time.Duration(cfg.GetInt("autoconf_config_files_poll_interval"))*time.Second,
 	)
 
 	// Autodiscovery cannot easily use config.RegisterOverrideFunc() due to Unmarshalling
-	extraConfigProviders, extraConfigListeners := confad.DiscoverComponentsFromConfig()
+	extraConfigProviders, extraConfigListeners := confad.DiscoverComponentsFromConfig(cfg)
 
 	var extraEnvProviders []pkgconfigsetup.ConfigurationProviders
 	var extraEnvListeners []pkgconfigsetup.Listeners
-	if pkgconfigenv.IsAutoconfigEnabled(pkgconfigsetup.Datadog()) && !pkgconfigsetup.IsCLCRunner(pkgconfigsetup.Datadog()) {
-		extraEnvProviders, extraEnvListeners = confad.DiscoverComponentsFromEnv()
+	if pkgconfigenv.IsAutoconfigEnabled(cfg) && !pkgconfigsetup.IsCLCRunner(cfg) {
+		extraEnvProviders, extraEnvListeners = confad.DiscoverComponentsFromEnv(cfg)
 	}
 
 	// Register additional configuration providers
 	var configProviders []pkgconfigsetup.ConfigurationProviders
 	var uniqueConfigProviders map[string]pkgconfigsetup.ConfigurationProviders
-	err := structure.UnmarshalKey(pkgconfigsetup.Datadog(), "config_providers", &configProviders)
+	err := structure.UnmarshalKey(cfg, "config_providers", &configProviders)
 
 	if err == nil {
 		uniqueConfigProviders = make(map[string]pkgconfigsetup.ConfigurationProviders, len(configProviders)+len(extraEnvProviders)+len(configProviders))
@@ -77,7 +78,7 @@ func setupAutoDiscovery(confSearchPaths []string, ac autodiscovery.Component) {
 		}
 
 		// Add extra config providers
-		for _, name := range pkgconfigsetup.Datadog().GetStringSlice("extra_config_providers") {
+		for _, name := range cfg.GetStringSlice("extra_config_providers") {
 			if _, found := uniqueConfigProviders[name]; !found {
 				uniqueConfigProviders[name] = pkgconfigsetup.ConfigurationProviders{Name: name, Polling: true}
 			} else {
@@ -121,10 +122,10 @@ func setupAutoDiscovery(confSearchPaths []string, ac autodiscovery.Component) {
 	}
 
 	var listeners []pkgconfigsetup.Listeners
-	err = structure.UnmarshalKey(pkgconfigsetup.Datadog(), "listeners", &listeners)
+	err = structure.UnmarshalKey(cfg, "listeners", &listeners)
 	if err == nil {
 		// Add extra listeners
-		for _, name := range pkgconfigsetup.Datadog().GetStringSlice("extra_listeners") {
+		for _, name := range cfg.GetStringSlice("extra_listeners") {
 			listeners = append(listeners, pkgconfigsetup.Listeners{Name: name})
 		}
 

--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -9,17 +9,20 @@ import (
 	"path/filepath"
 
 	autodiscovery "github.com/DataDog/datadog-agent/comp/core/autodiscovery/def"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 )
 
 // LoadComponents configures several common Agent components:
 // tagger, collector, scheduler and autodiscovery
-func LoadComponents(ac autodiscovery.Component, confdPath string) {
+func LoadComponents(ac autodiscovery.Component, config config.Component) {
+	confdPath := config.GetString("confd_path")
+
 	confSearchPaths := []string{
 		confdPath,
 		filepath.Join(defaultpaths.GetDistPath(), "conf.d"),
 		"",
 	}
 
-	setupAutoDiscovery(confSearchPaths, ac)
+	setupAutoDiscovery(confSearchPaths, ac, config)
 }

--- a/cmd/agent/subcommands/analyzelogs/command.go
+++ b/cmd/agent/subcommands/analyzelogs/command.go
@@ -194,7 +194,9 @@ func resolveCheckConfig(ac autodiscovery.Component, cliParams *CliParams) ([]*so
 	waitTime := time.Duration(1) * time.Second
 	waitCtx, cancelTimeout := context.WithTimeout(
 		context.Background(), waitTime)
-	common.LoadComponents(ac, pkgconfigsetup.Datadog().GetString("confd_path"))
+
+	config := pkgconfigsetup.Datadog()
+	common.LoadComponents(ac, config)
 	ac.LoadAndRun(context.Background())
 	allConfigs, err := common.WaitForConfigsFromAD(waitCtx, []string{cliParams.LogConfigPath}, 1, "", ac)
 	cancelTimeout()

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -281,7 +281,7 @@ func runJmxCommandConsole(config config.Component,
 
 	// The Autoconfig instance setup happens in the workloadmeta start hook
 	// create and setup the Collector and others.
-	common.LoadComponents(ac, config.GetString("confd_path"))
+	common.LoadComponents(ac, config)
 	ac.LoadAndRun(context.Background())
 
 	// if cliSelectedChecks is empty, then we want to fetch all check configs;

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -510,7 +510,7 @@ func getSharedFxOption() fx.Option {
 			lc.Append(fx.Hook{
 				OnStart: func(_ context.Context) error {
 					//  setup the AutoConfig instance
-					common.LoadComponents(ac, cfg.GetString("confd_path"))
+					common.LoadComponents(ac, cfg)
 					return nil
 				},
 			})

--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -79,7 +79,6 @@ import (
 	clusterchecksHandler "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
 	pkgcollector "github.com/DataDog/datadog-agent/pkg/collector"
 
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -222,13 +221,13 @@ func run(
 
 	// initialize CC Cache
 	var ccCache cloudfoundry.CCCacheI
-	ccCache, err = initializeCCCache(mainCtx)
+	ccCache, err = initializeCCCache(mainCtx, config)
 	if err != nil {
 		_ = pkglog.Errorf("Error initializing Cloud Foundry CCAPI cache, some advanced tagging features may be missing: %v", err)
 	}
 
 	// initialize BBS Cache before starting provider/listener, passing the CC cache for enrichment
-	if err = initializeBBSCache(mainCtx, ccCache); err != nil {
+	if err = initializeBBSCache(mainCtx, config, ccCache); err != nil {
 		return err
 	}
 

--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -200,7 +200,7 @@ func run(
 	mainCtx, mainCtxCancel := context.WithCancel(context.Background())
 	defer mainCtxCancel() // Calling cancel twice is safe
 
-	if !pkgconfigsetup.Datadog().IsConfigured("api_key") {
+	if !config.IsConfigured("api_key") {
 		pkglog.Critical("no API key configured, exiting")
 		return nil
 	}
@@ -232,7 +232,7 @@ func run(
 		return err
 	}
 
-	common.LoadComponents(ac, pkgconfigsetup.Datadog().GetString("confd_path"))
+	common.LoadComponents(ac, config)
 
 	// Set up check collector
 	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(option.New(collector), demultiplexer, logReceiver, taggerComp, filterStore), true)
@@ -277,15 +277,15 @@ func run(
 	return nil
 }
 
-func initializeCCCache(ctx context.Context) (cloudfoundry.CCCacheI, error) {
-	pollInterval := time.Second * time.Duration(pkgconfigsetup.Datadog().GetInt("cloud_foundry_cc.poll_interval"))
+func initializeCCCache(ctx context.Context, config config.Component) (cloudfoundry.CCCacheI, error) {
+	pollInterval := time.Second * time.Duration(config.GetInt("cloud_foundry_cc.poll_interval"))
 
 	// Create the CF client
 	ccClient, err := cloudfoundry.NewCFClient(&cfclient.Config{
-		ApiAddress:        pkgconfigsetup.Datadog().GetString("cloud_foundry_cc.url"),
-		ClientID:          pkgconfigsetup.Datadog().GetString("cloud_foundry_cc.client_id"),
-		ClientSecret:      pkgconfigsetup.Datadog().GetString("cloud_foundry_cc.client_secret"),
-		SkipSslValidation: pkgconfigsetup.Datadog().GetBool("cloud_foundry_cc.skip_ssl_validation"),
+		ApiAddress:        config.GetString("cloud_foundry_cc.url"),
+		ClientID:          config.GetString("cloud_foundry_cc.client_id"),
+		ClientSecret:      config.GetString("cloud_foundry_cc.client_secret"),
+		SkipSslValidation: config.GetBool("cloud_foundry_cc.skip_ssl_validation"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CC client: %v", err)
@@ -294,11 +294,11 @@ func initializeCCCache(ctx context.Context) (cloudfoundry.CCCacheI, error) {
 	ccCache, err := cloudfoundry.ConfigureGlobalCCCache(ctx, cloudfoundry.CCCacheConfig{
 		CCAPIClient:        ccClient,
 		PollInterval:       pollInterval,
-		AppsBatchSize:      pkgconfigsetup.Datadog().GetInt("cloud_foundry_cc.apps_batch_size"),
-		RefreshCacheOnMiss: pkgconfigsetup.Datadog().GetBool("cluster_agent.refresh_on_cache_miss"),
-		ServeNozzleData:    pkgconfigsetup.Datadog().GetBool("cluster_agent.serve_nozzle_data"),
-		SidecarsTags:       pkgconfigsetup.Datadog().GetBool("cluster_agent.sidecars_tags"),
-		SegmentsTags:       pkgconfigsetup.Datadog().GetBool("cluster_agent.isolation_segments_tags"),
+		AppsBatchSize:      config.GetInt("cloud_foundry_cc.apps_batch_size"),
+		RefreshCacheOnMiss: config.GetBool("cluster_agent.refresh_on_cache_miss"),
+		ServeNozzleData:    config.GetBool("cluster_agent.serve_nozzle_data"),
+		SidecarsTags:       config.GetBool("cluster_agent.sidecars_tags"),
+		SegmentsTags:       config.GetBool("cluster_agent.isolation_segments_tags"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize CC Cache: %v", err)
@@ -306,12 +306,12 @@ func initializeCCCache(ctx context.Context) (cloudfoundry.CCCacheI, error) {
 	return ccCache, nil
 }
 
-func initializeBBSCache(ctx context.Context, ccCache cloudfoundry.CCCacheI) error {
-	pollInterval := time.Second * time.Duration(pkgconfigsetup.Datadog().GetInt("cloud_foundry_bbs.poll_interval"))
+func initializeBBSCache(ctx context.Context, config config.Component, ccCache cloudfoundry.CCCacheI) error {
+	pollInterval := time.Second * time.Duration(config.GetInt("cloud_foundry_bbs.poll_interval"))
 	// NOTE: we can't use GetPollInterval in ConfigureGlobalBBSCache, as that causes import cycle
 
-	includeListString := pkgconfigsetup.Datadog().GetStringSlice("cloud_foundry_bbs.env_include")
-	excludeListString := pkgconfigsetup.Datadog().GetStringSlice("cloud_foundry_bbs.env_exclude")
+	includeListString := config.GetStringSlice("cloud_foundry_bbs.env_include")
+	excludeListString := config.GetStringSlice("cloud_foundry_bbs.env_exclude")
 
 	includeList := make([]*regexp.Regexp, len(includeListString))
 	excludeList := make([]*regexp.Regexp, len(excludeListString))
@@ -334,10 +334,10 @@ func initializeBBSCache(ctx context.Context, ccCache cloudfoundry.CCCacheI) erro
 
 	// Create the BBS client
 	bbsClient, err := bbs.NewClient(
-		pkgconfigsetup.Datadog().GetString("cloud_foundry_bbs.url"),
-		pkgconfigsetup.Datadog().GetString("cloud_foundry_bbs.ca_file"),
-		pkgconfigsetup.Datadog().GetString("cloud_foundry_bbs.cert_file"),
-		pkgconfigsetup.Datadog().GetString("cloud_foundry_bbs.key_file"),
+		config.GetString("cloud_foundry_bbs.url"),
+		config.GetString("cloud_foundry_bbs.ca_file"),
+		config.GetString("cloud_foundry_bbs.cert_file"),
+		config.GetString("cloud_foundry_bbs.key_file"),
 		0, // clientSessionCacheSize
 		0, // maxIdleConnsPerHost
 	)

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -515,7 +515,7 @@ func start(log log.Component,
 	// create and setup the autoconfig instance
 	// The autoconfig instance setup happens in the workloadmeta start hook
 	// create and setup the Collector and others.
-	common.LoadComponents(ac, config.GetString("confd_path"))
+	common.LoadComponents(ac, config)
 
 	// Set up check collector
 	registerChecks(wmeta, taggerComp, config)

--- a/comp/core/diagnose/local/local.go
+++ b/comp/core/diagnose/local/local.go
@@ -97,7 +97,7 @@ func getLocalIntegrationConfigs(
 	ac autodiscovery.Component,
 	tagger tagger.Component,
 	config config.Component) ([]integration.Config, error) {
-	common.LoadComponents(ac, config.GetString("confd_path"))
+	common.LoadComponents(ac, config)
 	ac.LoadAndRun(context.Background())
 
 	// Create the CheckScheduler, but do not attach it to AutoDiscovery.

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -85,7 +85,6 @@ import (
 	sharedlibrarycheck "github.com/DataDog/datadog-agent/pkg/collector/sharedlibrary/sharedlibraryimpl"
 	"github.com/DataDog/datadog-agent/pkg/commonchecks"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	statuscollector "github.com/DataDog/datadog-agent/pkg/status/collector"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
@@ -283,15 +282,15 @@ func run(
 	previousIntegrationTracing := false
 	previousIntegrationTracingExhaustive := false
 	if cliParams.generateIntegrationTraces {
-		if pkgconfigsetup.Datadog().IsSet("integration_tracing") {
-			previousIntegrationTracing = pkgconfigsetup.Datadog().GetBool("integration_tracing")
+		if config.IsSet("integration_tracing") {
+			previousIntegrationTracing = config.GetBool("integration_tracing")
 
 		}
-		if pkgconfigsetup.Datadog().IsSet("integration_tracing_exhaustive") {
-			previousIntegrationTracingExhaustive = pkgconfigsetup.Datadog().GetBool("integration_tracing_exhaustive")
+		if config.IsSet("integration_tracing_exhaustive") {
+			previousIntegrationTracingExhaustive = config.GetBool("integration_tracing_exhaustive")
 		}
-		pkgconfigsetup.Datadog().Set("integration_tracing", true, model.SourceAgentRuntime)
-		pkgconfigsetup.Datadog().Set("integration_tracing_exhaustive", true, model.SourceAgentRuntime)
+		config.Set("integration_tracing", true, model.SourceAgentRuntime)
+		config.Set("integration_tracing_exhaustive", true, model.SourceAgentRuntime)
 	}
 
 	if len(cliParams.args) != 0 {
@@ -302,7 +301,7 @@ func run(
 	}
 
 	// Check if the check is allowed in infrastructure basic mode
-	if !pkgcollector.IsCheckAllowed(cliParams.checkName, pkgconfigsetup.Datadog()) {
+	if !pkgcollector.IsCheckAllowed(cliParams.checkName, config) {
 		return fmt.Errorf("check '%s' is not allowed in infrastructure basic mode", cliParams.checkName)
 	}
 
@@ -321,7 +320,7 @@ func run(
 	//  so the subcommand can't read the RC database if the agent is also running.
 	commonchecks.RegisterChecks(wmeta, filterStore, tagger, config, telemetry, nil, nil, nil, traceroute, option.None[networkconfigmanagement.Component]())
 
-	common.LoadComponents(ac, pkgconfigsetup.Datadog().GetString("confd_path"))
+	common.LoadComponents(ac, config)
 	ac.LoadAndRun(context.Background())
 
 	// Create the CheckScheduler, but do not attach it to
@@ -654,8 +653,8 @@ func run(
 	}
 
 	if cliParams.generateIntegrationTraces {
-		pkgconfigsetup.Datadog().Set("integration_tracing", previousIntegrationTracing, model.SourceAgentRuntime)
-		pkgconfigsetup.Datadog().Set("integration_tracing_exhaustive", previousIntegrationTracingExhaustive, model.SourceAgentRuntime)
+		config.Set("integration_tracing", previousIntegrationTracing, model.SourceAgentRuntime)
+		config.Set("integration_tracing_exhaustive", previousIntegrationTracingExhaustive, model.SourceAgentRuntime)
 	}
 
 	return nil

--- a/pkg/config/autodiscovery/autodiscovery.go
+++ b/pkg/config/autodiscovery/autodiscovery.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	snmplistener "github.com/DataDog/datadog-agent/pkg/snmp"
@@ -21,12 +22,12 @@ import (
 )
 
 // DiscoverComponentsFromConfig returns a list of AD Providers and Listeners based on the agent configuration
-func DiscoverComponentsFromConfig() ([]pkgconfigsetup.ConfigurationProviders, []pkgconfigsetup.Listeners) {
+func DiscoverComponentsFromConfig(cfg config.Component) ([]pkgconfigsetup.ConfigurationProviders, []pkgconfigsetup.Listeners) {
 	detectedProviders := []pkgconfigsetup.ConfigurationProviders{}
 	detectedListeners := []pkgconfigsetup.Listeners{}
 
 	// Auto-add Prometheus config provider based on `prometheus_scrape.enabled`
-	if pkgconfigsetup.Datadog().GetBool("prometheus_scrape.enabled") {
+	if cfg.GetBool("prometheus_scrape.enabled") {
 		var prometheusProvider pkgconfigsetup.ConfigurationProviders
 		if flavor.GetFlavor() == flavor.ClusterAgent {
 			prometheusProvider = pkgconfigsetup.ConfigurationProviders{Name: "prometheus_services", Polling: true}
@@ -38,7 +39,7 @@ func DiscoverComponentsFromConfig() ([]pkgconfigsetup.ConfigurationProviders, []
 	}
 
 	// Add instrumentation checks provider if `instrumentation_crd_controller.enabled` is true
-	if pkgconfigsetup.Datadog().GetBool("instrumentation_crd_controller.enabled") &&
+	if cfg.GetBool("instrumentation_crd_controller.enabled") &&
 		flavor.GetFlavor() == flavor.DefaultAgent && env.IsKubernetes() {
 		instrumentationChecksProvider := pkgconfigsetup.ConfigurationProviders{Name: "instrumentation_checks", Polling: true}
 		log.Info("Instrumentation controller is enabled: Adding the instrumentation checks config provider")
@@ -46,12 +47,12 @@ func DiscoverComponentsFromConfig() ([]pkgconfigsetup.ConfigurationProviders, []
 	}
 
 	// Add database-monitoring aurora listener if the feature is enabled
-	if pkgconfigsetup.Datadog().GetBool("database_monitoring.autodiscovery.aurora.enabled") {
+	if cfg.GetBool("database_monitoring.autodiscovery.aurora.enabled") {
 		detectedListeners = append(detectedListeners, pkgconfigsetup.Listeners{Name: "database-monitoring-aurora"})
 		log.Info("Database monitoring aurora discovery is enabled: Adding the aurora listener")
 	}
 	// Add database-monitoring rds listener if the feature is enabled
-	if pkgconfigsetup.Datadog().GetBool("database_monitoring.autodiscovery.rds.enabled") {
+	if cfg.GetBool("database_monitoring.autodiscovery.rds.enabled") {
 		detectedListeners = append(detectedListeners, pkgconfigsetup.Listeners{Name: "database-monitoring-rds"})
 		log.Info("Database monitoring rds discovery is enabled: Adding the rds listener")
 	}
@@ -60,7 +61,6 @@ func DiscoverComponentsFromConfig() ([]pkgconfigsetup.ConfigurationProviders, []
 	// 2) Auto-add file-based kube service and endpoints config providers based on check config files.
 	if flavor.GetFlavor() == flavor.ClusterAgent {
 
-		cfg := pkgconfigsetup.Datadog()
 		if cfg.IsConfigured("prometheus_http_sd.url") || cfg.IsConfigured("prometheus_http_sd.configs") {
 			log.Info("Prometheus HTTP SD is configured: Adding the prometheus_http_sd config provider")
 			detectedProviders = append(detectedProviders, pkgconfigsetup.ConfigurationProviders{Name: "prometheus_http_sd", Polling: true})
@@ -124,7 +124,7 @@ func DiscoverComponentsFromConfig() ([]pkgconfigsetup.ConfigurationProviders, []
 }
 
 // DiscoverComponentsFromEnv returns a list of AD Providers and Listeners based on environment characteristics
-func DiscoverComponentsFromEnv() ([]pkgconfigsetup.ConfigurationProviders, []pkgconfigsetup.Listeners) {
+func DiscoverComponentsFromEnv(cfg config.Component) ([]pkgconfigsetup.ConfigurationProviders, []pkgconfigsetup.Listeners) {
 	detectedProviders := []pkgconfigsetup.ConfigurationProviders{}
 	detectedListeners := []pkgconfigsetup.Listeners{}
 
@@ -145,7 +145,7 @@ func DiscoverComponentsFromEnv() ([]pkgconfigsetup.ConfigurationProviders, []pkg
 	isContainerEnv := env.IsFeaturePresent(env.Docker) ||
 		env.IsFeaturePresent(env.Containerd) ||
 		env.IsFeaturePresent(env.Podman) ||
-		env.IsECSSidecarMode(pkgconfigsetup.Datadog())
+		env.IsECSSidecarMode(cfg)
 	isKubeEnv := env.IsFeaturePresent(env.Kubernetes)
 
 	if isContainerEnv || isKubeEnv {

--- a/pkg/config/autodiscovery/autodiscovery_test.go
+++ b/pkg/config/autodiscovery/autodiscovery_test.go
@@ -22,29 +22,29 @@ func TestDiscoverComponentsFromConfigForHTTPSD(t *testing.T) {
 	flavor.SetTestFlavor(t, flavor.ClusterAgent)
 
 	t.Run("legacy single url triggers provider", func(t *testing.T) {
-		configmock.NewFromYAML(t, `
+		cfg := configmock.NewFromYAML(t, `
 prometheus_http_sd:
   url: http://legacy/sd
   check_template: '{"name":"openmetrics","init_config":{},"instances":[{}]}'
 `)
-		providers, _ := DiscoverComponentsFromConfig()
+		providers, _ := DiscoverComponentsFromConfig(cfg)
 		require.True(t, containsProvider(providers, "prometheus_http_sd"))
 	})
 
 	t.Run("configs list triggers provider", func(t *testing.T) {
-		configmock.NewFromYAML(t, `
+		cfg := configmock.NewFromYAML(t, `
 prometheus_http_sd:
   configs:
     - url: http://a/sd
       check_template: '{"name":"openmetrics","init_config":{},"instances":[{}]}'
 `)
-		providers, _ := DiscoverComponentsFromConfig()
+		providers, _ := DiscoverComponentsFromConfig(cfg)
 		require.True(t, containsProvider(providers, "prometheus_http_sd"))
 	})
 
 	t.Run("no http_sd config means no provider", func(t *testing.T) {
-		configmock.NewFromYAML(t, ``)
-		providers, _ := DiscoverComponentsFromConfig()
+		cfg := configmock.NewFromYAML(t, ``)
+		providers, _ := DiscoverComponentsFromConfig(cfg)
 		require.False(t, containsProvider(providers, "prometheus_http_sd"))
 	})
 }
@@ -69,13 +69,13 @@ func containsListener(listeners []pkgconfigsetup.Listeners, name string) bool {
 
 func TestDiscoverComponentsFromEnvForProcess(t *testing.T) {
 	configmock.SetDefaultConfigType(t, "yaml")
-	configmock.NewFromYAML(t, ``)
+	cfg := configmock.NewFromYAML(t, ``)
 
 	t.Run("process feature adds process listener", func(t *testing.T) {
 		flavor.SetTestFlavor(t, flavor.DefaultAgent)
 		env.SetFeatures(t, env.Process)
 
-		_, listeners := DiscoverComponentsFromEnv()
+		_, listeners := DiscoverComponentsFromEnv(cfg)
 		assert.True(t, containsListener(listeners, "process"))
 	})
 
@@ -83,7 +83,7 @@ func TestDiscoverComponentsFromEnvForProcess(t *testing.T) {
 		flavor.SetTestFlavor(t, flavor.DefaultAgent)
 		env.SetFeatures(t)
 
-		_, listeners := DiscoverComponentsFromEnv()
+		_, listeners := DiscoverComponentsFromEnv(cfg)
 		assert.False(t, containsListener(listeners, "process"))
 	})
 
@@ -91,7 +91,7 @@ func TestDiscoverComponentsFromEnvForProcess(t *testing.T) {
 		flavor.SetTestFlavor(t, flavor.DefaultAgent)
 		env.SetFeatures(t, env.Process, env.Docker)
 
-		providers, listeners := DiscoverComponentsFromEnv()
+		providers, listeners := DiscoverComponentsFromEnv(cfg)
 		assert.True(t, containsProvider(providers, "kubernetes-container-allinone"))
 		assert.True(t, containsListener(listeners, "container"))
 		assert.True(t, containsListener(listeners, "process"))
@@ -101,7 +101,7 @@ func TestDiscoverComponentsFromEnvForProcess(t *testing.T) {
 		flavor.SetTestFlavor(t, flavor.ClusterAgent)
 		env.SetFeatures(t, env.Process)
 
-		_, listeners := DiscoverComponentsFromEnv()
+		_, listeners := DiscoverComponentsFromEnv(cfg)
 		assert.False(t, containsListener(listeners, "process"))
 	})
 }
@@ -109,13 +109,13 @@ func TestDiscoverComponentsFromEnvForProcess(t *testing.T) {
 func TestDiscoverComponentsFromConfigForSnmp(t *testing.T) {
 	configmock.SetDefaultConfigType(t, "yaml")
 
-	configmock.NewFromYAML(t, `
+	cfg := configmock.NewFromYAML(t, `
 network_devices:
   autodiscovery:
     configs:
       - network: 127.0.0.1/30
 `)
-	_, configListeners := DiscoverComponentsFromConfig()
+	_, configListeners := DiscoverComponentsFromConfig(cfg)
 	require.Len(t, configListeners, 1)
 	assert.Equal(t, "snmp", configListeners[0].Name)
 
@@ -124,7 +124,7 @@ network_devices:
   autodiscovery:
     configs:
 `)
-	_, configListeners = DiscoverComponentsFromConfig()
+	_, configListeners = DiscoverComponentsFromConfig(cfg)
 	assert.Empty(t, len(configListeners))
 
 	configmock.NewFromYAML(t, `
@@ -132,7 +132,7 @@ snmp_listener:
   configs:
     - network: 127.0.0.1/30
 `)
-	_, configListeners = DiscoverComponentsFromConfig()
+	_, configListeners = DiscoverComponentsFromConfig(cfg)
 	require.Len(t, configListeners, 1)
 	assert.Equal(t, "snmp", configListeners[0].Name)
 
@@ -144,7 +144,7 @@ network_devices:
         ignored_ip_addresses:
           - 127.0.0.3
 `)
-	_, configListeners = DiscoverComponentsFromConfig()
+	_, configListeners = DiscoverComponentsFromConfig(cfg)
 	require.Len(t, configListeners, 1)
 	assert.Equal(t, "snmp", configListeners[0].Name)
 }


### PR DESCRIPTION
### What does this PR do?

Replace calls to `pkgconfigmodel.Datadog()` with using the `config.Component` interface instead.

### Motivation

This code already has the desired interface, it just needs to be passed along. Better than calling global functions.

### Describe how you validated your changes

Refacting only, relying on tests in the CI

### Additional Notes
