### PR TITLE
[incident-55877] quality_gate_idle: limit=154 MiB

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -38,7 +38,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher
-      upper_bound: "147 MiB"
+      upper_bound: "154 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."


### PR DESCRIPTION
### What does this PR do?

In response to adding new Agent Health and Agent Telemetry features to the Agent, we're bumping the `quality_gate_idle` experiment's PSS bytes limit from 147 MiB to 154 MiB with Sarang Wardadkar's approval.

### Motivation

See above.

### Describe how you validated your changes

Examining previous `quality_gate_idle` data over the past 6 weeks on nightly quality gate runes.

### Additional Notes

Aim is to attempt to land optimizations to enable us to reduce the memory limit again.