### PR TITLE
[NCM] Add `finished_at` timestamp to execution output for notifier

### DIFF
--- a/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/BUILD.bazel
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/BUILD.bazel
@@ -13,5 +13,6 @@ go_library(
         "//pkg/config/setup",
         "//pkg/privateactionrunner/libs/privateconnection",
         "//pkg/privateactionrunner/types",
+        "@com_github_benbjohnson_clock//:clock",
     ],
 )

--- a/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/rollback_config.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/rollback_config.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/benbjohnson/clock"
+
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
@@ -25,14 +27,14 @@ import (
 // RollbackConfigHandler handles the rollbackConfig action for network config management
 type RollbackConfigHandler struct {
 	ipcClient ipc.HTTPClient
-	now       func() time.Time
+	clock     clock.Clock
 }
 
 // NewRollbackConfigHandler creates a new RollbackConfigHandler
 func NewRollbackConfigHandler(client ipc.HTTPClient) *RollbackConfigHandler {
 	return &RollbackConfigHandler{
 		ipcClient: client,
-		now:       time.Now,
+		clock:     clock.New(),
 	}
 }
 
@@ -49,9 +51,9 @@ type RollbackConfigInputs struct {
 
 // RollbackConfigOutputs is the output of a rollbackConfig action.
 type RollbackConfigOutputs struct {
-	Success    bool   `json:"success,omitempty"`
-	Error      string `json:"error,omitempty"`
-	FinishedAt int64  `json:"finished_at,omitempty"` // unix seconds
+	Success    bool       `json:"success,omitempty"`
+	Error      string     `json:"error,omitempty"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
 }
 
 // Run executes the rollbackConfig action
@@ -97,5 +99,6 @@ func (h *RollbackConfigHandler) Run(
 		return RollbackConfigOutputs{Error: errMsg}, err
 	}
 
-	return RollbackConfigOutputs{Success: true, FinishedAt: h.now().UTC().Unix()}, nil
+	t := h.clock.Now()
+	return RollbackConfigOutputs{Success: true, FinishedAt: &t}, nil
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/rollback_config.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/rollback_config.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -24,11 +25,15 @@ import (
 // RollbackConfigHandler handles the rollbackConfig action for network config management
 type RollbackConfigHandler struct {
 	ipcClient ipc.HTTPClient
+	now       func() time.Time
 }
 
 // NewRollbackConfigHandler creates a new RollbackConfigHandler
 func NewRollbackConfigHandler(client ipc.HTTPClient) *RollbackConfigHandler {
-	return &RollbackConfigHandler{ipcClient: client}
+	return &RollbackConfigHandler{
+		ipcClient: client,
+		now:       time.Now,
+	}
 }
 
 // RollbackConfigInputs defines the inputs for the rollbackConfig action
@@ -44,8 +49,9 @@ type RollbackConfigInputs struct {
 
 // RollbackConfigOutputs is the output of a rollbackConfig action.
 type RollbackConfigOutputs struct {
-	Success bool   `json:"success,omitempty"`
-	Error   string `json:"error,omitempty"`
+	Success    bool   `json:"success,omitempty"`
+	Error      string `json:"error,omitempty"`
+	FinishedAt int64  `json:"finished_at,omitempty"` // unix seconds
 }
 
 // Run executes the rollbackConfig action
@@ -91,5 +97,5 @@ func (h *RollbackConfigHandler) Run(
 		return RollbackConfigOutputs{Error: errMsg}, err
 	}
 
-	return RollbackConfigOutputs{Success: true}, nil
+	return RollbackConfigOutputs{Success: true, FinishedAt: h.now().UTC().Unix()}, nil
 }


### PR DESCRIPTION
### What does this PR do?
add `finished_at` timestamp to execution output of NCM rollbacks PAR task

### Motivation
to update the timestamp for the completion of the rollback using time as close to the agent application as possible

### Describe how you validated your changes
to QA soon on CML/boston lab

### Additional Notes
