### PR TITLE
[autoscaling] Re-sync local DPA on ad.datadoghq.com/tags change

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/model/BUILD.bazel
+++ b/pkg/clusteragent/autoscaling/workload/model/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusteragent/autoscaling",
+        "//pkg/util/kubernetes",
         "//pkg/util/pointer",
         "@com_github_datadog_agent_payload_v5//autoscaling/kubernetes",
         "@com_github_datadog_datadog_operator_api//datadoghq/common",

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
@@ -18,6 +18,7 @@ import (
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 
 	"github.com/twmb/murmur3"
@@ -51,11 +52,14 @@ var resyncLabelKeysFromPodAutoscaler = []string{
 	ProfileLabelKey,
 }
 
-// resyncAnnotationKeysFromPodAutoscaler lists the annotation keys read by UpdateFromPodAutoscaler.
+// resyncAnnotationKeysFromPodAutoscaler lists annotation keys whose value must trigger a re-sync
+// when changed. Edits to these don't bump .metadata.generation, so they're part of the metadata
+// fingerprint. Includes annotations consumed downstream, e.g. ad.datadoghq.com/tags (metric tags).
 var resyncAnnotationKeysFromPodAutoscaler = []string{
 	PreviewAnnotationKey,
 	ProfileTemplateHashAnnotation,
 	CustomRecommenderAnnotationKey,
+	kubernetes.ADTagsAnnotation,
 }
 
 // PodAutoscalerInternal holds the necessary data to work with the `DatadogPodAutoscaler` CRD.

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test.go
@@ -962,6 +962,12 @@ func TestUpdateFromPodAutoscalerResyncsOnWatchedMetadata(t *testing.T) {
 	dpa.Annotations["unrelated"] = "x"
 	pai.UpdateFromPodAutoscaler(dpa)
 	assert.True(t, pai.IsBurstable())
+
+	// A tags annotation-only edit (no generation bump) must refresh the cached upstream CR.
+	dpa.Annotations["ad.datadoghq.com/tags"] = `{"team":"foo"}`
+	pai.UpdateFromPodAutoscaler(dpa)
+	assert.Equal(t, `{"team":"foo"}`, pai.UpstreamCR().Annotations["ad.datadoghq.com/tags"],
+		"ad.datadoghq.com/tags edit must be picked up without a generation bump")
 }
 
 // TestSetActiveScalingValues_NilSource_ClearsVertical verifies that a nil verticalActiveSource

--- a/releasenotes/notes/fix-autoscaling-dpa-tags-refresh-9c4f1a2b3d5e6f70.yaml
+++ b/releasenotes/notes/fix-autoscaling-dpa-tags-refresh-9c4f1a2b3d5e6f70.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Workload autoscaling: fixed a bug where custom tags added through the
+    ``ad.datadoghq.com/tags`` annotation on a local-owner ``DatadogPodAutoscaler``
+    were not applied to the ``datadog.cluster-agent.autoscaling.workload.*``
+    metrics until the Cluster Agent was restarted (or the autoscaler spec was
+    otherwise modified). The annotation is now part of the metadata fingerprint
+    used to detect changes, so edits are picked up on the next reconcile.


### PR DESCRIPTION
## What does this PR do?
Tags set via the `ad.datadoghq.com/tags` annotation on a local-owner `DatadogPodAutoscaler` now reach the `datadog.cluster-agent.autoscaling.workload.*` metrics on the next reconcile, instead of only after a Cluster Agent restart or spec edit.

## Motivation
For local-owner DPAs, `UpdateFromPodAutoscaler` short-circuits when the metadata fingerprint is unchanged. The fingerprint didn't include `ad.datadoghq.com/tags`, and annotation edits don't bump `.metadata.generation`, so the cached upstream CR (read at metric-generation time) stayed stale. The annotation is now part of the watched key list.

## Describe how you validated your changes
Extended `TestUpdateFromPodAutoscalerResyncsOnWatchedMetadata` to assert a tags-annotation-only edit refreshes the cached CR. `dda inv test` + `dda inv linter.go` pass on the package.

🤖 Assisted by Claude:claude-opus-4-8