### PR TITLE
[#incident-56371] Harden Windows Docker CI downloads

### DIFF
--- a/.gitlab/windows/deploy/container_build/windows.yml
+++ b/.gitlab/windows/deploy/container_build/windows.yml
@@ -33,7 +33,6 @@
       --build-arg CI
       --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL}
       ${BUILD_ARG}
-      --pull
       --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile
       --tag ${TARGET_TAG}
       --label 'org.opencontainers.image.created=${BUILD_DATE}'

--- a/.gitlab/windows/deploy/container_build/windows.yml
+++ b/.gitlab/windows/deploy/container_build/windows.yml
@@ -33,6 +33,7 @@
       --build-arg CI
       --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL}
       ${BUILD_ARG}
+      --pull
       --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile
       --tag ${TARGET_TAG}
       --label 'org.opencontainers.image.created=${BUILD_DATE}'

--- a/Dockerfiles/agent/install-fips.ps1
+++ b/Dockerfiles/agent/install-fips.ps1
@@ -14,9 +14,23 @@ if ("$env:WITH_FIPS" -ne "true") {
 $maven_sha512 = '03e2d65d4483a3396980629f260e25cac0d8b6f7f2791e4dc20bc83f9514db8d0f05b0479e699a5f34679250c49c8e52e961262ded468a20de0be254d8207076'
 $maven_version = '3.9.11'
 
+function Invoke-WebRequestWithRetry {
+    $MaxAttempts = 5
+    for ($i = 1; $i -le $MaxAttempts; $i++) {
+        try {
+            Invoke-WebRequest @args
+            return
+        } catch {
+            if ($i -ge $MaxAttempts) { throw }
+            Write-Host ("Attempt #{0} failed: {1}" -f $i, $_)
+            Start-Sleep -Seconds ($i * $i)
+        }
+    }
+}
+
 if ("$env:WITH_JMX" -ne "false") {
     cd \fips-build
-    Invoke-WebRequest -Outfile maven.zip https://repo1.maven.org/maven2/org/apache/maven/apache-maven/${maven_version}/apache-maven-${maven_version}-bin.zip
+    Invoke-WebRequestWithRetry -Outfile maven.zip https://repo1.maven.org/maven2/org/apache/maven/apache-maven/${maven_version}/apache-maven-${maven_version}-bin.zip
     if ((Get-FileHash -Algorithm SHA512 maven.zip).Hash -eq $maven_sha512) {
         Write-Host "Maven checksum match"
     } else {

--- a/Dockerfiles/agent/install-fips.ps1
+++ b/Dockerfiles/agent/install-fips.ps1
@@ -14,21 +14,8 @@ if ("$env:WITH_FIPS" -ne "true") {
 $maven_sha512 = '03e2d65d4483a3396980629f260e25cac0d8b6f7f2791e4dc20bc83f9514db8d0f05b0479e699a5f34679250c49c8e52e961262ded468a20de0be254d8207076'
 $maven_version = '3.9.11'
 
-function Invoke-WebRequestWithRetry {
-    $MaxAttempts = 5
-    for ($i = 1; $i -le $MaxAttempts; $i++) {
-        try {
-            Invoke-WebRequest @args
-            return
-        } catch {
-            if ($i -ge $MaxAttempts) { throw }
-            Write-Host ("Attempt #{0} failed: {1}" -f $i, $_)
-            Start-Sleep -Seconds ($i * $i)
-        }
-    }
-}
-
 if ("$env:WITH_JMX" -ne "false") {
+    . ./install-utils.ps1
     cd \fips-build
     Invoke-WebRequestWithRetry -Outfile maven.zip https://repo1.maven.org/maven2/org/apache/maven/apache-maven/${maven_version}/apache-maven-${maven_version}-bin.zip
     if ((Get-FileHash -Algorithm SHA512 maven.zip).Hash -eq $maven_sha512) {

--- a/Dockerfiles/agent/install-utils.ps1
+++ b/Dockerfiles/agent/install-utils.ps1
@@ -1,0 +1,15 @@
+function Invoke-WebRequestWithRetry {
+    $MaxAttempts = 5
+    for ($i = 1; $i -le $MaxAttempts; $i++) {
+        try {
+            Invoke-WebRequest @args
+            return
+        } catch {
+            if ($i -ge $MaxAttempts) {
+                throw
+            }
+            Write-Host ("Attempt #{0} failed: {1}" -f $i, $_)
+            Start-Sleep -Seconds ($i * $i)
+        }
+    }
+}

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -1,5 +1,5 @@
 $ErrorActionPreference = "Stop"
-Trap { Write-Host "Error in install.ps1: $_" }
+Trap { Write-Host "Error in install.ps1: $_"; break }
 
 function Install-Service {
   param(

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -31,7 +31,11 @@ if ("$env:WITH_JMX" -ne "false") {
 
     $JDK_DOWNLOAD_URL = if ($env:GENERAL_ARTIFACTS_CACHE_BUCKET_URL) {"${env:GENERAL_ARTIFACTS_CACHE_BUCKET_URL}/openjdk"} else {$JDK_UPSTREAM}
     Invoke-WebRequestWithRetry -OutFile jre.zip "${JDK_DOWNLOAD_URL}/${JDK_FILENAME}"
-    (Get-FileHash -Algorithm SHA256 jre.zip).Hash -eq "$JDK_SHA256"
+    if ((Get-FileHash -Algorithm SHA256 jre.zip).Hash -eq "$JDK_SHA256") {
+        Write-Host "JDK checksum match"
+    } else {
+        Write-Error "JDK checksum mismatch"
+    }
     Expand-Archive -Path jre.zip -DestinationPath C:/
     Remove-Item jre.zip
     Move-Item "C:/$JDK_DIR/" C:/java

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -12,14 +12,28 @@ function Install-Service {
   } else {
       New-Service -Name $SvcName -StartupType Manual -BinaryPathName $BinPath
   }
-  $eventSourceData = new-object System.Diagnostics.EventSourceCreationData("$SvcName", "Application")  
+  $eventSourceData = new-object System.Diagnostics.EventSourceCreationData("$SvcName", "Application")
   $eventSourceData.CategoryResourceFile = $BinPath
   $eventSourceData.MessageResourceFile = $BinPath
 
   If (![System.Diagnostics.EventLog]::SourceExists($eventSourceData.Source))
-  {      
-  [System.Diagnostics.EventLog]::CreateEventSource($eventSourceData)  
-  } 
+  {
+  [System.Diagnostics.EventLog]::CreateEventSource($eventSourceData)
+  }
+}
+
+function Invoke-WebRequestWithRetry {
+  $MaxAttempts = 5
+  for ($i = 1; $i -le $MaxAttempts; $i++) {
+    try {
+      Invoke-WebRequest @args
+      return
+    } catch {
+      if ($i -ge $MaxAttempts) { throw }
+      Write-Host ("Attempt #{0} failed: {1}" -f $i, $_)
+      Start-Sleep -Seconds ($i * $i)
+    }
+  }
 }
 
 if ("$env:WITH_JMX" -ne "false") {
@@ -29,7 +43,7 @@ if ("$env:WITH_JMX" -ne "false") {
     $JDK_SHA256 = "052f09448d5b8d9afb7a8e5049d40d7fafa8f5884afe6043bb2359787fd41e84"
 
     $JDK_DOWNLOAD_URL = if ($env:GENERAL_ARTIFACTS_CACHE_BUCKET_URL) {"${env:GENERAL_ARTIFACTS_CACHE_BUCKET_URL}/openjdk"} else {$JDK_UPSTREAM}
-    Invoke-WebRequest -OutFile jre.zip "${JDK_DOWNLOAD_URL}/${JDK_FILENAME}"
+    Invoke-WebRequestWithRetry -OutFile jre.zip "${JDK_DOWNLOAD_URL}/${JDK_FILENAME}"
     (Get-FileHash -Algorithm SHA256 jre.zip).Hash -eq "$JDK_SHA256"
     Expand-Archive -Path jre.zip -DestinationPath C:/
     Remove-Item jre.zip

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -22,21 +22,8 @@ function Install-Service {
   }
 }
 
-function Invoke-WebRequestWithRetry {
-  $MaxAttempts = 5
-  for ($i = 1; $i -le $MaxAttempts; $i++) {
-    try {
-      Invoke-WebRequest @args
-      return
-    } catch {
-      if ($i -ge $MaxAttempts) { throw }
-      Write-Host ("Attempt #{0} failed: {1}" -f $i, $_)
-      Start-Sleep -Seconds ($i * $i)
-    }
-  }
-}
-
 if ("$env:WITH_JMX" -ne "false") {
+    . ./install-utils.ps1
     $JDK_UPSTREAM = "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.25%2B9"
     $JDK_FILENAME = "OpenJDK11U-jre_x64_windows_hotspot_11.0.25_9.zip"
     $JDK_DIR = "jdk-11.0.25+9-jre"

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -25,7 +25,7 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 COPY ["Datadog Agent", "C:/Program Files/Datadog/Datadog Agent"]
 
-COPY install.ps1 ./
+COPY install.ps1 install-utils.ps1 ./
 RUN . ./install.ps1
 
 COPY bouncycastle-fips /fips-build


### PR DESCRIPTION
<!-- dd-meta {"pullId":"7c9e12ed-14e4-47ee-9009-82865985409a","source":"chat","resourceId":"7885e6b8-425c-455d-b93d-85932bce6acb","workflowId":"8970b5ba-f784-42b5-8153-1652c551a9c2","codeChangeId":"8970b5ba-f784-42b5-8153-1652c551a9c2","sourceType":"bits_ai_sre"} -->
### What does this PR do?

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/35544e4a-697f-4af3-b2ba-fe0849b88d45)

~~Removes the forced base-image pull from the shared Windows Agent container build and~~
**Adds retry handling around the JMX JDK download and Maven download performed during the Windows Docker image build.**

### Motivation

The `docker_build_agent7_windows` job has been failing with intermittent DNS resolution errors from inside Windows Docker NAT-networked build containers. 
~~The build was forcing a fresh MCR lookup with `--pull`, and JMX~~ **JMX** builds made a single `Invoke-WebRequest` attempt for the JDK download from the artifact cache/upstream URL. That made every affected build sensitive to transient DNS failures observed in CI.

~~Removing `--pull` eliminates the MCR DNS dependency since base images are pre-pulled during AMI creation.~~

**Per reviewer feedback, the `--pull` removal was reverted: `docker build` is already wrapped in `retry.ps1`, runner recycling frequency makes base image staleness a non-issue, and removing `--pull` only here would be inconsistent with all other Windows CI docker commands.**

### Describe how you validated your changes

- ~~Ran `git diff --check` for `.gitlab/windows/deploy/container_build/windows.yml`.~~
- Reviewed the shared Windows container-build call path from `docker_build_agent7_windows` through `.docker_build_agent_windows_common` to `Dockerfiles/agent/windows/amd64/Dockerfile` and `Dockerfiles/agent/install.ps1`.
- Confirmed `Dockerfiles/agent/install.ps1` still uses CRLF line endings after editing.
- Could not run PowerShell syntax validation because `pwsh` is not installed in this Linux workspace.

### Additional Notes

`git diff --check` on `Dockerfiles/agent/install.ps1` reports CRLF-added-line whitespace noise for this existing Windows CRLF script, so validation was limited to line-ending preservation and diff review for that file.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/7885e6b8-425c-455d-b93d-85932bce6acb)

Comment @datadog to request changes