### PR TITLE
[CNM-5355] Improve protocol_classifier_entrypoint performance

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/defs.h
+++ b/pkg/network/ebpf/c/protocols/classification/defs.h
@@ -29,13 +29,14 @@
 #define LAYER_APPLICATION_MAX (LAYER_APPLICATION_BIT + MAX_ENTRIES_PER_LAYER)
 #define LAYER_ENCRYPTION_MAX  (LAYER_ENCRYPTION_BIT + MAX_ENTRIES_PER_LAYER)
 
-#define FLAG_FULLY_CLASSIFIED       1 << 0
-#define FLAG_USM_ENABLED            1 << 1
-#define FLAG_NPM_ENABLED            1 << 2
-#define FLAG_TCP_CLOSE_DELETION     1 << 3
-#define FLAG_SOCKET_FILTER_DELETION 1 << 4
-#define FLAG_SERVER_SIDE            1 << 5
-#define FLAG_CLIENT_SIDE            1 << 6
+#define FLAG_FULLY_CLASSIFIED        1 << 0
+#define FLAG_USM_ENABLED             1 << 1
+#define FLAG_NPM_ENABLED             1 << 2
+#define FLAG_TCP_CLOSE_DELETION      1 << 3
+#define FLAG_SOCKET_FILTER_DELETION  1 << 4
+#define FLAG_SERVER_SIDE             1 << 5
+#define FLAG_CLIENT_SIDE             1 << 6
+#define FLAG_TLS_CLASSIFICATION_DONE 1 << 7
 
 // The enum below represents all different protocols we're able to
 // classify. Entries are segmented such that it is possible to infer the

--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -142,18 +142,24 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint(struct
         return;
     }
 
-    classification_context_t *classification_ctx = classification_context_init(skb, &skb_tup, &skb_info);
-    if (!classification_ctx) {
-        return;
-    }
-
-    protocol_stack_t *protocol_stack = get_protocol_stack_if_exists(&classification_ctx->tuple);
+    protocol_stack_t *protocol_stack = get_protocol_stack_if_exists(&skb_tup);
 
     if (is_fully_classified(protocol_stack)) {
         return;
     }
 
     bool encryption_layer_known = is_protocol_layer_known(protocol_stack, LAYER_ENCRYPTION);
+
+    if (encryption_layer_known && protocol_stack && (protocol_stack->flags & FLAG_TLS_CLASSIFICATION_DONE)) {
+        // All cleartext TLS metadata has been captured and the rest of the flow is encrypted, so there's nothing
+        // more we can classify here. USM's uprobes classify the inner protocol on decrypted data in a separate program.
+        return;
+    }
+
+    classification_context_t *classification_ctx = classification_context_init(skb, &skb_tup, &skb_info);
+    if (!classification_ctx) {
+        return;
+    }
 
     // Load information that will be later on used to route tail-calls
     init_routing_cache(classification_ctx, protocol_stack);
@@ -188,6 +194,10 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint(struct
                 return;
             }
             if (is_tls_handshake_server_hello(skb, offset, data_end)) {
+                // ServerHello seen: the tail call captures the last cleartext TLS metadata.
+                // Set here, not on the first non-handshake record, so TLS 1.3 0-RTT early data,
+                // which can arrive before ServerHello, won't early-exit and skip ServerHello.
+                set_protocol_flag(protocol_stack, FLAG_TLS_CLASSIFICATION_DONE);
                 bpf_tail_call_compat(skb, &classification_progs, CLASSIFICATION_TLS_SERVER_PROG);
                 return;
             }


### PR DESCRIPTION
Early exit once TLS is known and the TLS handshake has finished, and move the early exits ahead of classification_context_init().

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
