### PR TITLE
[ABLD-430] Fix junit xml upload failure at the end of the hybrid test job

### DIFF
--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -35,6 +35,9 @@
     - if [[ "$FAST_TESTS" == "true" ]]; then FAST_TESTS_FLAG="--only-impacted-packages"; fi
     - dda inv -- -e agent.build
     - dda inv -- -e test $FLAVORS --race --profile --rerun-fails=2 --coverage --cpus $KUBERNETES_CPU_REQUEST $EXTRA_OPTS --result-json ${TEST_OUTPUT_FILE}.json --junit-tar "junit-${CI_JOB_NAME}.tgz" --build-stdlib $FAST_TESTS_FLAG --test-washer
+    - if [[ "$FAST_TESTS" == "true" ]]; then FAST_TESTS_FLAG="--only-impacted-packages"; fi
+    - # In the hybrid test, bazel gets run, and that leaves a symlink to junit-out-base.xml. The uploader chokes on symlinks.
+    - if [[ "$EXPERIMENTAL_USE_BAZEL_TESTS" == "1" ]] ; then find $(bazel info execution_root) -type l -name 'junit-*.xml' -delete ; fi
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -36,7 +36,7 @@
     - dda inv -- -e agent.build
     - dda inv -- -e test $FLAVORS --race --profile --rerun-fails=2 --coverage --cpus $KUBERNETES_CPU_REQUEST $EXTRA_OPTS --result-json ${TEST_OUTPUT_FILE}.json --junit-tar "junit-${CI_JOB_NAME}.tgz" --build-stdlib $FAST_TESTS_FLAG --test-washer
     - if [[ "$FAST_TESTS" == "true" ]]; then FAST_TESTS_FLAG="--only-impacted-packages"; fi
-    - # In the hybrid test, bazel gets run, and that leaves a symlink to junit-out-base.xml. The uploader chokes on symlinks.
+    # In the hybrid test, bazel gets run, and that leaves a symlink to junit-out-base.xml. The uploader chokes on symlinks.
     - if [[ "$EXPERIMENTAL_USE_BAZEL_TESTS" == "1" ]] ; then find $(bazel info execution_root) -type l -name 'junit-*.xml' -delete ; fi
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -35,9 +35,6 @@
     - if [[ "$FAST_TESTS" == "true" ]]; then FAST_TESTS_FLAG="--only-impacted-packages"; fi
     - dda inv -- -e agent.build
     - dda inv -- -e test $FLAVORS --race --profile --rerun-fails=2 --coverage --cpus $KUBERNETES_CPU_REQUEST $EXTRA_OPTS --result-json ${TEST_OUTPUT_FILE}.json --junit-tar "junit-${CI_JOB_NAME}.tgz" --build-stdlib $FAST_TESTS_FLAG --test-washer
-    - if [[ "$FAST_TESTS" == "true" ]]; then FAST_TESTS_FLAG="--only-impacted-packages"; fi
-    # In the hybrid test, bazel gets run, and that leaves a symlink to junit-out-base.xml. The uploader chokes on symlinks.
-    - if [[ "$EXPERIMENTAL_USE_BAZEL_TESTS" == "1" ]] ; then find $(bazel info execution_root) -type l -name 'junit-*.xml' -delete ; fi
   artifacts:
     expire_in: 2 weeks
     when: always
@@ -72,6 +69,8 @@ tests_linux-x64-py3_hybrid:
     - .linux_tests
     - .linux_x64
   after_script:
+    # In the hybrid test, bazel gets run, and that leaves a symlink to junit-out-base.xml. The uploader chokes on symlinks.
+    - find $(bazel info execution_root) -type l -name 'junit-*.xml' -delete
     - !reference [.upload_junit_source]
     # skip coverage upload for several reasons
     # 1. It would conflate with coverate from the regular job

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -263,7 +263,7 @@ def get_bazel_test_targets(
                 return True
         return False
 
-    result = {}
+    targets = {}
     for line in output.splitlines():
         line = line.strip()
         if not line or not line.startswith('//'):
@@ -275,8 +275,8 @@ def get_bazel_test_targets(
         # Keep map of bazel target to Go package name: //pkg/util/log:log_test -> pkg/util/log
         package = label.split(':')[0]
         dir_path = package[2:]  # strip //
-        result[label] = f'{MODULE_PREFIX}/{dir_path}'
-    return result
+        targets[label] = f'{MODULE_PREFIX}/{dir_path}'
+    return targets
 
 
 def _parse_bazel_test_line(line: str) -> tuple[str, str, str | None, bool] | None:


### PR DESCRIPTION
### What does this PR do?

Fixes a failure to upload junit xml files in the go/bazel hybrid test job.

### Motivation

The job currently fails while uploading test artifacts at the end.
```
2026-06-17T20:22:18.116777Z 01O **/junit-out-*.xml: found 82 matching artifact files and directories
2026-06-17T20:22:18.116814Z 01O ERROR: Uploading artifacts as "junit" to coordinator... error
  error=couldn't execute POST against https://gitlab.ddbuild.io/api/v4/jobs/1781938458/artifacts?artifact_format=gzip&artifact_type=junit&expire_in=2+weeks:
  Post "https://gitlab.ddbuild.io/api/v4/jobs/1781938458/artifacts?artifact_format=gzip&artifact_type=junit&expire_in=2+weeks":
   failed to copy content to form: the ".cache/bazel/_bazel_root/8595a61ca643e2561dc364b98a410786/execroot/_main/junit-out-base.xml" is not a regular file
```

The problem is that:
- the Go tests run first, creating <TOP>/junit-out-base.xml
- then bazel runs, which symlinks to everything in the top folder
- then the uploader finds the files, but chokes on the symlinks

The fix is easy, remove the symlinks to the junit xml files.
