### PR TITLE
Reload masked AppArmor with parser

### DIFF
--- a/pkg/fleet/installer/packages/apminject/app_armor.go
+++ b/pkg/fleet/installer/packages/apminject/app_armor.go
@@ -9,6 +9,7 @@ package apminject
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -30,6 +31,11 @@ const (
 	appArmorProfile              = `/opt/datadog-packages/** rix,
 /proc/@{pid}/** rix,
 /run/datadog/apm.socket rw,`
+)
+
+var (
+	appArmorEnabledPath = "/sys/module/apparmor/parameters/enabled"
+	systemdIsRunning    = systemd.IsRunning
 )
 
 func findAndReplaceAllInFile(filename string, needle string, replaceWith string) error {
@@ -168,16 +174,46 @@ func reloadAppArmor(ctx context.Context) error {
 	if !isAppArmorRunning() {
 		return nil
 	}
-	if running, err := systemd.IsRunning(); err != nil {
+	if running, err := systemdIsRunning(); err != nil {
 		return err
 	} else if running {
+		masked, err := isSystemdUnitMasked(ctx, "apparmor")
+		if err != nil {
+			return err
+		}
+		if masked {
+			log.Infof("Installer: apparmor.service is masked, skipping reload")
+			return nil
+		}
 		return telemetry.CommandContext(ctx, "systemctl", "reload", "apparmor").Run()
 	}
 	return telemetry.CommandContext(ctx, "service", "apparmor", "reload").Run()
 }
 
+func isSystemdUnitMasked(ctx context.Context, unit string) (bool, error) {
+	var stdout bytes.Buffer
+	cmd := telemetry.CommandContext(ctx, "systemctl", "is-enabled", unit).
+		WithExpectedExitCodes(
+			1, // disabled, masked, static, indirect, generated, transient — https://man7.org/linux/man-pages/man1/systemctl.1.html
+			4, // no such unit file — https://man7.org/linux/man-pages/man1/systemctl.1.html
+		)
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	if strings.TrimSpace(stdout.String()) == "masked" {
+		return true, nil
+	}
+	if err != nil {
+		exitErr := &exec.ExitError{}
+		if errors.As(err, &exitErr) {
+			return false, nil
+		}
+		return false, err
+	}
+	return false, nil
+}
+
 func isAppArmorRunning() bool {
-	data, err := os.ReadFile("/sys/module/apparmor/parameters/enabled")
+	data, err := os.ReadFile(appArmorEnabledPath)
 	if err != nil {
 		return false
 	}

--- a/pkg/fleet/installer/packages/apminject/app_armor.go
+++ b/pkg/fleet/installer/packages/apminject/app_armor.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/systemd"
@@ -35,6 +36,7 @@ const (
 
 var (
 	appArmorEnabledPath = "/sys/module/apparmor/parameters/enabled"
+	appArmorProfileDir  = "/etc/apparmor.d"
 	systemdIsRunning    = systemd.IsRunning
 )
 
@@ -182,12 +184,48 @@ func reloadAppArmor(ctx context.Context) error {
 			return err
 		}
 		if masked {
-			log.Infof("Installer: apparmor.service is masked, skipping reload")
-			return nil
+			log.Infof("Installer: apparmor.service is masked, reloading profiles with apparmor_parser")
+			return reloadAppArmorWithParser(ctx)
 		}
 		return telemetry.CommandContext(ctx, "systemctl", "reload", "apparmor").Run()
 	}
 	return telemetry.CommandContext(ctx, "service", "apparmor", "reload").Run()
+}
+
+func reloadAppArmorWithParser(ctx context.Context) error {
+	if _, err := exec.LookPath("apparmor_parser"); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			log.Warnf("apparmor_parser not found, skipping AppArmor reload")
+			return nil
+		}
+		return err
+	}
+	profiles, err := appArmorProfiles()
+	if err != nil {
+		return err
+	}
+	if len(profiles) == 0 {
+		return nil
+	}
+	return telemetry.CommandContext(ctx, "apparmor_parser", append([]string{"-r"}, profiles...)...).Run()
+}
+
+func appArmorProfiles() ([]string, error) {
+	paths, err := filepath.Glob(filepath.Join(appArmorProfileDir, "*"))
+	if err != nil {
+		return nil, err
+	}
+	var profiles []string
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, err
+		}
+		if info.Mode().IsRegular() {
+			profiles = append(profiles, path)
+		}
+	}
+	return profiles, nil
 }
 
 func isSystemdUnitMasked(ctx context.Context, unit string) (bool, error) {

--- a/pkg/fleet/installer/packages/apminject/app_armor.go
+++ b/pkg/fleet/installer/packages/apminject/app_armor.go
@@ -200,32 +200,50 @@ func reloadAppArmorWithParser(ctx context.Context) error {
 		}
 		return err
 	}
-	profiles, err := appArmorProfiles()
+	enforceProfiles, complainProfiles, err := appArmorProfiles()
 	if err != nil {
 		return err
 	}
-	if len(profiles) == 0 {
-		return nil
+	if len(enforceProfiles) > 0 {
+		if err := telemetry.CommandContext(ctx, "apparmor_parser", append([]string{"-r"}, enforceProfiles...)...).Run(); err != nil {
+			return err
+		}
 	}
-	return telemetry.CommandContext(ctx, "apparmor_parser", append([]string{"-r"}, profiles...)...).Run()
+	if len(complainProfiles) > 0 {
+		return telemetry.CommandContext(ctx, "apparmor_parser", append([]string{"-r", "-C"}, complainProfiles...)...).Run()
+	}
+	return nil
 }
 
-func appArmorProfiles() ([]string, error) {
+func appArmorProfiles() (enforceProfiles []string, complainProfiles []string, err error) {
 	paths, err := filepath.Glob(filepath.Join(appArmorProfileDir, "*"))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	var profiles []string
 	for _, path := range paths {
 		info, err := os.Stat(path)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		if info.Mode().IsRegular() {
-			profiles = append(profiles, path)
+		if !info.Mode().IsRegular() {
+			continue
 		}
+		name := filepath.Base(path)
+		if pathExists(filepath.Join(appArmorProfileDir, "disable", name)) {
+			continue
+		}
+		if pathExists(filepath.Join(appArmorProfileDir, "force-complain", name)) {
+			complainProfiles = append(complainProfiles, path)
+			continue
+		}
+		enforceProfiles = append(enforceProfiles, path)
 	}
-	return profiles, nil
+	return enforceProfiles, complainProfiles, nil
+}
+
+func pathExists(path string) bool {
+	_, err := os.Lstat(path)
+	return err == nil
 }
 
 func isSystemdUnitMasked(ctx context.Context, unit string) (bool, error) {

--- a/pkg/fleet/installer/packages/apminject/app_armor_test.go
+++ b/pkg/fleet/installer/packages/apminject/app_armor_test.go
@@ -8,8 +8,10 @@
 package apminject
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -195,4 +197,77 @@ func TestAppArmorBaseProfileUpdates(t *testing.T) {
 			assert.Equal(t, tt.expectedBaseProfile, string(content))
 		})
 	}
+}
+
+func TestReloadAppArmorSkipsMaskedSystemdUnit(t *testing.T) {
+	callsFile := setupAppArmorReloadTest(t, `#!/bin/sh
+echo "$*" >> "$CALLS_FILE"
+if [ "$1" = "is-enabled" ]; then
+	echo masked
+	exit 1
+fi
+if [ "$1" = "reload" ]; then
+	exit 9
+fi
+`)
+
+	err := reloadAppArmor(context.Background())
+	require.NoError(t, err)
+
+	calls, err := os.ReadFile(callsFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(calls), "is-enabled apparmor")
+	assert.NotContains(t, string(calls), "reload apparmor")
+}
+
+func TestReloadAppArmorReloadsWhenSystemdUnitIsNotMasked(t *testing.T) {
+	callsFile := setupAppArmorReloadTest(t, `#!/bin/sh
+echo "$*" >> "$CALLS_FILE"
+if [ "$1" = "is-enabled" ]; then
+	echo disabled
+	exit 1
+fi
+if [ "$1" = "reload" ]; then
+	exit 7
+fi
+`)
+
+	err := reloadAppArmor(context.Background())
+	require.Error(t, err)
+
+	calls, err := os.ReadFile(callsFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(calls), "is-enabled apparmor")
+	assert.Contains(t, string(calls), "reload apparmor")
+}
+
+func setupAppArmorReloadTest(t *testing.T, systemctlScript string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	enabledPath := filepath.Join(dir, "apparmor-enabled")
+	require.NoError(t, os.WriteFile(enabledPath, []byte("Y\n"), 0640))
+
+	previousAppArmorEnabledPath := appArmorEnabledPath
+	appArmorEnabledPath = enabledPath
+	t.Cleanup(func() {
+		appArmorEnabledPath = previousAppArmorEnabledPath
+	})
+
+	previousSystemdIsRunning := systemdIsRunning
+	systemdIsRunning = func() (bool, error) {
+		return true, nil
+	}
+	t.Cleanup(func() {
+		systemdIsRunning = previousSystemdIsRunning
+	})
+
+	binDir := filepath.Join(dir, "bin")
+	require.NoError(t, os.Mkdir(binDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "systemctl"), []byte(strings.TrimSpace(systemctlScript)+"\n"), 0755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	callsFile := filepath.Join(dir, "calls")
+	t.Setenv("CALLS_FILE", callsFile)
+	return callsFile
 }

--- a/pkg/fleet/installer/packages/apminject/app_armor_test.go
+++ b/pkg/fleet/installer/packages/apminject/app_armor_test.go
@@ -199,9 +199,9 @@ func TestAppArmorBaseProfileUpdates(t *testing.T) {
 	}
 }
 
-func TestReloadAppArmorSkipsMaskedSystemdUnit(t *testing.T) {
+func TestReloadAppArmorUsesParserForMaskedSystemdUnit(t *testing.T) {
 	callsFile := setupAppArmorReloadTest(t, `#!/bin/sh
-echo "$*" >> "$CALLS_FILE"
+echo "systemctl $*" >> "$CALLS_FILE"
 if [ "$1" = "is-enabled" ]; then
 	echo masked
 	exit 1
@@ -216,13 +216,15 @@ fi
 
 	calls, err := os.ReadFile(callsFile)
 	require.NoError(t, err)
-	assert.Contains(t, string(calls), "is-enabled apparmor")
-	assert.NotContains(t, string(calls), "reload apparmor")
+	assert.Contains(t, string(calls), "systemctl is-enabled apparmor")
+	assert.NotContains(t, string(calls), "systemctl reload apparmor")
+	assert.Contains(t, string(calls), "apparmor_parser -r ")
+	assert.Contains(t, string(calls), "usr.bin.foo")
 }
 
 func TestReloadAppArmorReloadsWhenSystemdUnitIsNotMasked(t *testing.T) {
 	callsFile := setupAppArmorReloadTest(t, `#!/bin/sh
-echo "$*" >> "$CALLS_FILE"
+echo "systemctl $*" >> "$CALLS_FILE"
 if [ "$1" = "is-enabled" ]; then
 	echo disabled
 	exit 1
@@ -237,8 +239,9 @@ fi
 
 	calls, err := os.ReadFile(callsFile)
 	require.NoError(t, err)
-	assert.Contains(t, string(calls), "is-enabled apparmor")
-	assert.Contains(t, string(calls), "reload apparmor")
+	assert.Contains(t, string(calls), "systemctl is-enabled apparmor")
+	assert.Contains(t, string(calls), "systemctl reload apparmor")
+	assert.NotContains(t, string(calls), "apparmor_parser")
 }
 
 func setupAppArmorReloadTest(t *testing.T, systemctlScript string) string {
@@ -254,6 +257,17 @@ func setupAppArmorReloadTest(t *testing.T, systemctlScript string) string {
 		appArmorEnabledPath = previousAppArmorEnabledPath
 	})
 
+	profilesDir := filepath.Join(dir, "apparmor.d")
+	require.NoError(t, os.Mkdir(profilesDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "usr.bin.foo"), []byte("profile usr.bin.foo {}\n"), 0640))
+	require.NoError(t, os.Mkdir(filepath.Join(profilesDir, "abstractions"), 0755))
+
+	previousAppArmorProfileDir := appArmorProfileDir
+	appArmorProfileDir = profilesDir
+	t.Cleanup(func() {
+		appArmorProfileDir = previousAppArmorProfileDir
+	})
+
 	previousSystemdIsRunning := systemdIsRunning
 	systemdIsRunning = func() (bool, error) {
 		return true, nil
@@ -265,6 +279,7 @@ func setupAppArmorReloadTest(t *testing.T, systemctlScript string) string {
 	binDir := filepath.Join(dir, "bin")
 	require.NoError(t, os.Mkdir(binDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(binDir, "systemctl"), []byte(strings.TrimSpace(systemctlScript)+"\n"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "apparmor_parser"), []byte("#!/bin/sh\necho \"apparmor_parser $*\" >> \"$CALLS_FILE\"\n"), 0755))
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	callsFile := filepath.Join(dir, "calls")

--- a/pkg/fleet/installer/packages/apminject/app_armor_test.go
+++ b/pkg/fleet/installer/packages/apminject/app_armor_test.go
@@ -220,6 +220,9 @@ fi
 	assert.NotContains(t, string(calls), "systemctl reload apparmor")
 	assert.Contains(t, string(calls), "apparmor_parser -r ")
 	assert.Contains(t, string(calls), "usr.bin.foo")
+	assert.Contains(t, string(calls), "apparmor_parser -r -C ")
+	assert.Contains(t, string(calls), "usr.bin.complain")
+	assert.NotContains(t, string(calls), "usr.bin.disabled")
 }
 
 func TestReloadAppArmorReloadsWhenSystemdUnitIsNotMasked(t *testing.T) {
@@ -260,7 +263,13 @@ func setupAppArmorReloadTest(t *testing.T, systemctlScript string) string {
 	profilesDir := filepath.Join(dir, "apparmor.d")
 	require.NoError(t, os.Mkdir(profilesDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "usr.bin.foo"), []byte("profile usr.bin.foo {}\n"), 0640))
+	require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "usr.bin.disabled"), []byte("profile usr.bin.disabled {}\n"), 0640))
+	require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "usr.bin.complain"), []byte("profile usr.bin.complain {}\n"), 0640))
 	require.NoError(t, os.Mkdir(filepath.Join(profilesDir, "abstractions"), 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(profilesDir, "disable"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "disable", "usr.bin.disabled"), nil, 0640))
+	require.NoError(t, os.Mkdir(filepath.Join(profilesDir, "force-complain"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "force-complain", "usr.bin.complain"), nil, 0640))
 
 	previousAppArmorProfileDir := appArmorProfileDir
 	appArmorProfileDir = profilesDir


### PR DESCRIPTION
<!-- dd-meta {"pullId":"c983e519-e001-4bca-9c09-d5ee9797bdd6","source":"chat","resourceId":"7f45d046-5663-4d7e-92fe-722f27627be0","workflowId":"558eabca-1b20-43a9-9482-a733593da063","codeChangeId":"558eabca-1b20-43a9-9482-a733593da063","sourceType":"error_tracking_investigator"} -->
### What does this PR do?

Fixing `apparmor.service masked causes APM SSI install failure` • [View in Error Tracking](https://app.datadoghq.com/error-tracking/issue/e47e9d5c-6ae0-11f1-82e9-da7ad0900002)

Prevents APM SSI installation from failing when the host has AppArmor enabled in the kernel but apparmor.service is masked. The installer now detects that masked systemd unit state and reloads AppArmor profiles directly with apparmor_parser instead of calling the masked systemd unit. Non-masked units keep the existing systemctl reload behavior.

### Motivation

On some hosts, such as Ubuntu 24.04 GCP configurations, AppArmor can be active while apparmor.service is masked. In that state, systemctl reload apparmor exits with "Unit apparmor.service is masked", which was propagated from the apm-inject-package post-install hook and aborted the entire APM SSI setup.

A masked unit can still correspond to active AppArmor enforcement because masking prevents future systemd starts/reloads but does not necessarily unload AppArmor policy that is already active in the kernel. To make the Datadog abstraction changes effective in that case, the installer needs a non-systemd reload path.

### Changes

- Added a systemd unit masked-state check before reloading AppArmor.
- For masked apparmor.service, reloads regular profiles under /etc/apparmor.d with apparmor_parser -r.
- Keeps the previous reload behavior for disabled/non-masked units and non-systemd service managers.
- Added targeted unit coverage for masked parser fallback and non-masked systemd reload behavior.

### Describe how you validated your changes

- GOENV_VERSION=system go test -tags test ./pkg/fleet/installer/packages/apminject -run TestReloadAppArmor -count=1
- GOENV_VERSION=system go test -tags test ./pkg/fleet/installer/packages/apminject -count=1
- GOENV_VERSION=system go build -tags test ./pkg/fleet/installer/packages/apminject
- GOENV_VERSION=system golangci-lint run ./pkg/fleet/installer/packages/apminject
- git diff --check

Note: bazel test //pkg/fleet/installer/packages/apminject:apminject_test --test_filter=TestReloadAppArmor could not run because Bazel attempted to download bazel-9.1.1 from releases.bazel.build and the sandbox proxy returned Bad Gateway.