### PR TITLE
Disable v3beta shadowing when zlib is used

### DIFF
--- a/pkg/serializer/metrics.go
+++ b/pkg/serializer/metrics.go
@@ -195,6 +195,9 @@ func (s *Serializer) buildPipelinesRng(kind metricsKind, rng prng) metrics.Pipel
 	shadowSites := metricsShadowSites(s.config)
 
 	zlib := s.zlibForcesV2()
+	if zlib {
+		shadowRate = 0
+	}
 
 	for _, resolver := range s.Forwarder.GetDomainResolvers() {
 		useV3 := metricsUseV3(resolver, s.config, s.logger, kind)

--- a/pkg/serializer/metrics_test.go
+++ b/pkg/serializer/metrics_test.go
@@ -993,6 +993,36 @@ func TestSeriesV3ForcedToV2WhenCompressorImplIsZlib(t *testing.T) {
 	}
 }
 
+// TestSeriesV3BetaShadowSuppressedWhenCompressorImplIsZlib covers the shadow analogue of
+// TestSeriesV3ForcedToV2WhenCompressorImplIsZlib: the v3beta shadow sends a v3-format
+// payload, so a zlib compressor must suppress it even when shadow sampling would otherwise
+// fire (rate=1, US1 site, fixedRand below the rate).
+func TestSeriesV3BetaShadowSuppressedWhenCompressorImplIsZlib(t *testing.T) {
+	logger := logmock.New(t)
+	config := configmock.New(t)
+	config.SetInTest("dd_url", "https://app.datadoghq.com")
+	config.SetInTest("api_key", "test_key")
+	config.SetInTest("serializer_experimental_use_v3_api.series.shadow_sample_rate", 1)
+	config.SetInTest("use_v3_api.series.enabled", "false")
+	// Config says zstd, but the injected compressor is zlib, as a zlib-only build would resolve.
+	config.SetInTest("serializer_compressor_kind", "zstd")
+
+	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
+	require.NoError(t, err)
+	s := NewSerializer(f, nil, implzlib.New(), config, logger, "")
+	require.Equal(t, compression.ZlibEncoding, s.Strategy.ContentEncoding(), "test precondition: compressor must be zlib")
+
+	pipelines := s.buildPipelinesRng(metricsKindSeries, fixedRand{v: 0})
+	require.Len(t, pipelines, 1, "a zlib compressor must suppress the v3beta shadow pipeline")
+	for conf, ctx := range pipelines {
+		require.Len(t, ctx.Destinations, 1)
+		dest := ctx.Destinations[0]
+		assert.False(t, conf.V3)
+		assert.Equal(t, endpoints.SeriesEndpoint, dest.Endpoint)
+		assert.Empty(t, dest.ValidationBatchID)
+	}
+}
+
 // TestEvalSeriesV3 exercises the full string-acceptance surface of
 // use_v3_api.series.enabled / endpoints[url] in one place. The Datadog and
 // non-Datadog resolvers exist so the "datadog_only" branch is observable from

--- a/releasenotes/notes/v3shadow-zlib-541f7d6e1c8a3fe4.yaml
+++ b/releasenotes/notes/v3shadow-zlib-541f7d6e1c8a3fe4.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Disable v3beta metrics intake shadow payloads when zlib compression is used.


### PR DESCRIPTION
### What does this PR do?

Disable v3beta metrics intake shadow payloads when zlib compression is used.

### Motivation

Avoid producing incorrect payloads that trigger errors from the intake.

### Describe how you validated your changes

Unit test.

Run agent with 
```
DD_USE_V3_API_SERIES_ENABLED=false
DD_SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_SHADOW_SAMPLE_RATE=1
DD_SERIALIZER_COMPRESSOR_KIND=zlib
```

Ensure that telemetry contains transactions__success with `endpoint="series_v2"`, but no entries with `endpoint="series_v3beta"`

### Additional Notes
