### PR TITLE
bazel: turn ci-edge-cache into a superset of ci

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -95,6 +95,7 @@ common:ci --config=cache
 common:ci --config=lint
 # Opt-in override: only Linux CI runs in k8s and can reach the in-cluster edge cache.
 # tools/bazel adds `--config=ci-edge-cache` when `uname -s = Linux`.
+common:ci-edge-cache --config=ci
 common:ci-edge-cache --remote_cache=grpc://buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog:443
 common:ci --noexperimental_convenience_symlinks # not CI-suitable: "These symlinks are only for the user's convenience"
 

--- a/tools/bazel
+++ b/tools/bazel
@@ -32,9 +32,10 @@ if [ -n "${XDG_CACHE_HOME-}" ]; then
   extra_args+=(--disk_cache="$XDG_CACHE_HOME/bazel/disk-cache")
   # https://github.com/bazelbuild/bazel/issues/26384
   [ "$XDG_CACHE_HOME" = "$(dirname "$(dirname "$0")")/.cache" ] && extra_args+=(--repo_contents_cache=)
-  [ -n "${CI-}" ] && [ -z "${GITHUB_ACTIONS-}" ] && extra_args+=(--config=ci)
   # Edge cache is only reachable from inside the k8s cluster (Linux CI runners).
-  [ -n "${CI-}" ] && [ -z "${GITHUB_ACTIONS-}" ] && [ "$(uname -s)" = Linux ] && extra_args+=(--config=ci-edge-cache)
+  if [ -n "${CI-}" ] && [ -z "${GITHUB_ACTIONS-}" ]; then
+    [ "$(uname -s)" = Linux ] && extra_args+=(--config=ci-edge-cache) || extra_args+=(--config=ci)
+  fi
 else
   # Without `XDG_CACHE_HOME`, fall back Go caches to official defaults so Go repo rules work under strict repo_env
   [ -z "${GOCACHE-}" ] && export GOCACHE=~/.cache/go-build


### PR DESCRIPTION
### What does this PR do?

This makes config=ci-edge-cache the same as config=ci, except for the remote cache target.
It also adjusts the `tools/bazel` option accordingly to only pass the required option based on the OS.

### Motivation

Fixing a systematic warning for our linux jobs: 
```
WARNING: option '--remote_cache' was expanded from both option '--config=ci' (source command line options) and option '--config=ci-edge-cache' (source command line options)
```

### Describe how you validated your changes

CI

### Additional Notes
