### PR TITLE
Fix orchestrator skipped informer recovery

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -329,6 +329,7 @@ func (cb *CollectorBundle) Initialize() {
 
 func (cb *CollectorBundle) initialize() {
 	informersToSync := make(map[apiserver.InformerName]cache.SharedInformer)
+	informersByName := make(map[apiserver.InformerName]cache.SharedInformer)
 	// informerSynced is a helper map which makes sure that we don't initialize the same informer twice.
 	// i.e. the cluster and nodes resources share the same informer and using both can lead to a race condition activating both concurrently.
 	informerSynced := map[cache.SharedInformer]struct{}{}
@@ -350,7 +351,9 @@ func (cb *CollectorBundle) initialize() {
 		}
 
 		if _, found := informerSynced[informer]; !found {
-			informersToSync[apiserver.InformerName(collectorFullName)] = informer
+			informerName := apiserver.InformerName(collectorFullName)
+			informersToSync[informerName] = informer
+			informersByName[informerName] = informer
 			informerSynced[informer] = struct{}{}
 
 			// add event handlers for terminated resources
@@ -374,23 +377,51 @@ func (cb *CollectorBundle) initialize() {
 
 	for informerName, err := range errors {
 		if err != nil {
-			cb.skipCollector(informerName, err)
+			cb.skipCollectorsForInformer(informersByName[informerName], err)
 		}
 	}
 }
 
-func (cb *CollectorBundle) skipCollector(informerName apiserver.InformerName, err error) {
-	for _, collector := range cb.collectors {
-		collectorFullName := collector.Metadata().FullName()
-		if apiserver.InformerName(collectorFullName) == informerName {
-			collector.Metadata().IsSkipped = true
-			collector.Metadata().SkippedReason = err.Error()
+func (cb *CollectorBundle) skipCollectorsForInformer(informer cache.SharedInformer, err error) {
+	if informer == nil {
+		return
+	}
 
-			// emit metrics
-			skippedResources[collectorFullName].Set(err.Error())
-			tlmSkippedResources.Inc(collectorFullName)
+	for _, collector := range cb.collectors {
+		if collector.Informer() == informer {
+			cb.skipCollector(collector, err)
 		}
 	}
+}
+
+func (*CollectorBundle) skipCollector(collector collectors.K8sCollector, err error) {
+	collectorFullName := collector.Metadata().FullName()
+	collector.Metadata().IsSkipped = true
+	collector.Metadata().SkippedReason = err.Error()
+
+	// emit metrics
+	if _, ok := skippedResources[collectorFullName]; ok {
+		skippedResources[collectorFullName].Set(err.Error())
+	}
+	tlmSkippedResources.Inc(collectorFullName)
+}
+
+func (*CollectorBundle) recoverSkippedCollector(collector collectors.K8sCollector) bool {
+	informer := collector.Informer()
+	if informer == nil || !informer.HasSynced() {
+		return false
+	}
+
+	collectorFullName := collector.Metadata().FullName()
+	collector.Metadata().IsSkipped = false
+	collector.Metadata().SkippedReason = ""
+
+	if _, ok := skippedResources[collectorFullName]; ok {
+		skippedResources[collectorFullName].Set("")
+	}
+
+	log.Infof("Collector %s recovered after informer cache sync completed", collectorFullName)
+	return true
 }
 
 // Run is used to sequentially run all collectors in the bundle.
@@ -403,8 +434,10 @@ func (cb *CollectorBundle) Run(sender sender.Sender) {
 
 	for _, collector := range cb.collectors {
 		if collector.Metadata().IsSkipped {
-			_ = cb.check.Warnf("Collector %s is skipped: %s", collector.Metadata().FullName(), collector.Metadata().SkippedReason)
-			continue
+			if !cb.recoverSkippedCollector(collector) {
+				_ = cb.check.Warnf("Collector %s is skipped: %s", collector.Metadata().FullName(), collector.Metadata().SkippedReason)
+				continue
+			}
 		}
 
 		runStartTime := time.Now()

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle_retry_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle_retry_test.go
@@ -1,0 +1,158 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator && test
+
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+)
+
+func TestSkipCollectorsForInformerSkipsAllCollectorsSharingInformer(t *testing.T) {
+	informer := &fakeSharedInformer{}
+	otherInformer := &fakeSharedInformer{}
+
+	clusterCollector := newFakeInformerCollector("cluster", informer)
+	nodeCollector := newFakeInformerCollector("nodes", informer)
+	namespaceCollector := newFakeInformerCollector("namespaces", otherInformer)
+
+	cb := &CollectorBundle{
+		collectors: []collectors.K8sCollector{
+			clusterCollector,
+			nodeCollector,
+			namespaceCollector,
+		},
+	}
+
+	err := errors.New("cache sync timed out")
+	cb.skipCollectorsForInformer(informer, err)
+
+	require.True(t, clusterCollector.Metadata().IsSkipped)
+	require.Equal(t, err.Error(), clusterCollector.Metadata().SkippedReason)
+	require.True(t, nodeCollector.Metadata().IsSkipped)
+	require.Equal(t, err.Error(), nodeCollector.Metadata().SkippedReason)
+	require.False(t, namespaceCollector.Metadata().IsSkipped)
+}
+
+func TestRecoverSkippedCollectorWaitsForInformerSync(t *testing.T) {
+	informer := &fakeSharedInformer{}
+	collector := newFakeInformerCollector("namespaces", informer)
+	collector.Metadata().IsSkipped = true
+	collector.Metadata().SkippedReason = "cache sync timed out"
+
+	cb := &CollectorBundle{}
+
+	require.False(t, cb.recoverSkippedCollector(collector))
+	require.True(t, collector.Metadata().IsSkipped)
+	require.Equal(t, "cache sync timed out", collector.Metadata().SkippedReason)
+
+	informer.synced = true
+
+	require.True(t, cb.recoverSkippedCollector(collector))
+	require.False(t, collector.Metadata().IsSkipped)
+	require.Empty(t, collector.Metadata().SkippedReason)
+}
+
+type fakeInformerCollector struct {
+	metadata *collectors.CollectorMetadata
+	informer cache.SharedInformer
+}
+
+func newFakeInformerCollector(name string, informer cache.SharedInformer) *fakeInformerCollector {
+	return &fakeInformerCollector{
+		metadata: &collectors.CollectorMetadata{Name: name},
+		informer: informer,
+	}
+}
+
+func (c *fakeInformerCollector) Init(*collectors.CollectorRunConfig) {}
+
+func (c *fakeInformerCollector) Metadata() *collectors.CollectorMetadata {
+	return c.metadata
+}
+
+func (c *fakeInformerCollector) Run(*collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
+	return &collectors.CollectorRunResult{
+		Result: processors.ProcessResult{
+			MetadataMessages: []model.MessageBody{},
+			ManifestMessages: []model.MessageBody{},
+		},
+	}, nil
+}
+
+func (c *fakeInformerCollector) Process(*collectors.CollectorRunConfig, interface{}) (*collectors.CollectorRunResult, error) {
+	return c.Run(nil)
+}
+
+func (c *fakeInformerCollector) Informer() cache.SharedInformer {
+	return c.informer
+}
+
+type fakeSharedInformer struct {
+	synced bool
+}
+
+func (i *fakeSharedInformer) AddEventHandler(cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func (i *fakeSharedInformer) AddEventHandlerWithResyncPeriod(cache.ResourceEventHandler, time.Duration) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func (i *fakeSharedInformer) AddEventHandlerWithOptions(cache.ResourceEventHandler, cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func (i *fakeSharedInformer) RemoveEventHandler(cache.ResourceEventHandlerRegistration) error {
+	return nil
+}
+
+func (i *fakeSharedInformer) GetStore() cache.Store {
+	return nil
+}
+
+func (i *fakeSharedInformer) GetController() cache.Controller {
+	return nil
+}
+
+func (i *fakeSharedInformer) Run(<-chan struct{}) {}
+
+func (i *fakeSharedInformer) RunWithContext(context.Context) {}
+
+func (i *fakeSharedInformer) HasSynced() bool {
+	return i.synced
+}
+
+func (i *fakeSharedInformer) LastSyncResourceVersion() string {
+	return ""
+}
+
+func (i *fakeSharedInformer) SetWatchErrorHandler(cache.WatchErrorHandler) error {
+	return nil
+}
+
+func (i *fakeSharedInformer) SetWatchErrorHandlerWithContext(cache.WatchErrorHandlerWithContext) error {
+	return nil
+}
+
+func (i *fakeSharedInformer) SetTransform(cache.TransformFunc) error {
+	return nil
+}
+
+func (i *fakeSharedInformer) IsStopped() bool {
+	return false
+}

--- a/releasenotes-dca/notes/orchestrator-retry-skipped-informers-3f4a2d6b7e8c9a10.yaml
+++ b/releasenotes-dca/notes/orchestrator-retry-skipped-informers-3f4a2d6b7e8c9a10.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix an orchestrator check issue where collectors whose informer cache
+    failed to sync during startup stayed skipped until the check was restarted,
+    even if the informer later recovered.


### PR DESCRIPTION
### What does this PR do?

Fixes orchestrator collectors that get skipped after an informer cache sync timeout so they can recover automatically once the informer eventually syncs. When one informer is shared by multiple collectors, all collectors using that informer are now skipped together instead of only the collector name used for the sync wait.

### Motivation

A transient informer sync failure could set `CollectorMetadata.IsSkipped` during initialization. Because initialization is guarded by `sync.Once`, the collector stayed skipped until the orchestrator check was restarted, which can stop collection for resources such as namespaces, nodes, or cluster while other resources continue collecting.

### Describe how you validated your changes

- `dda inv test --targets=./pkg/collector/corechecks/cluster/orchestrator`

### Additional Notes

Added a DCA release note.