### PR TITLE
rtloader: guard against NULL c_stdout before strlen in subprocess_output

### DIFF
--- a/rtloader/common/builtins/_util.c
+++ b/rtloader/common/builtins/_util.c
@@ -234,13 +234,13 @@ PyObject *subprocess_output(PyObject *self, PyObject *args, PyObject *kw)
     PyEval_RestoreThread(Tstate);
     gstate = PyGILState_Ensure();
 
-    if (raise && strlen(c_stdout) == 0) {
-        raiseEmptyOutputError();
+    if (exception) {
+        PyErr_SetString(PyExc_Exception, exception);
         goto cleanup;
     }
 
-    if (exception) {
-        PyErr_SetString(PyExc_Exception, exception);
+    if (raise && (c_stdout == NULL || strlen(c_stdout) == 0)) {
+        raiseEmptyOutputError();
         goto cleanup;
     }
 


### PR DESCRIPTION
## What does this PR do?
Guards `strlen(c_stdout)` with an explicit NULL check in `subprocess_output` and moves the callback exception check ahead of the empty-output check.

## Motivation
`GetSubprocessOutput` (`pkg/collector/python/util.go`) has two early-return paths that set `*exception` but never set `*cStdout`:
  - [cmd.StdoutPipe()](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/python/util.go#L50) failure
  - [cmd.StderrPipe()](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/python/util.go#L64) failure

In both cases `c_stdout` remains NULL on the C side. The existing code calls `strlen(c_stdout)` unconditionally, leading to segfault.

When `raise_on_empty=True`, the original check ordering caused the NULL guard to fire before the exception check, raising `SubprocessOutputEmptyError` and masking the actual callback error. Moving the exception
  check first ensures the real error is surfaced

## Describe how you validated your changes
CI

## Additional Notes
[glibc strlen source code](https://sourceware.org/git/?p=glibc.git;a=blob;f=string/strlen.c;h=3aebeff9ea6d5b1fe0a37e704601ad3ff4eec3e5;hb=HEAD)