### PR TITLE
Skip static quality gates on mq pipelines targeting release branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,9 @@
 .if_mergequeue: &if_mergequeue
   if: $CI_COMMIT_BRANCH =~ /^mq-working-branch-/
 
+.if_mergequeue_targeting_release_branch: &if_mergequeue_targeting_release_branch
+  if: $CI_COMMIT_BRANCH =~ /^mq-working-branch-[0-9]+\.[0-9]+\.x-/
+
 .if_deploy: &if_deploy
   if: $DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null
 
@@ -548,6 +551,10 @@ workflow:
 
 .except_mergequeue:
   - <<: *if_mergequeue
+    when: never
+
+.except_mergequeue_targeting_release_branch:
+  - <<: *if_mergequeue_targeting_release_branch
     when: never
 
 .on_mergequeue:

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -5,6 +5,7 @@ static_quality_gates:
   rules:
     - !reference [.except_release_branch]
     - !reference [.except_pr_targeting_release_branch]
+    - !reference [.except_mergequeue_targeting_release_branch]
     - !reference [.except_coverage_pipeline] # Coverage pipeline creates a special artifact that will not pass the quality gate
     - !reference [.on_main]
     - !reference [.on_mergequeue]


### PR DESCRIPTION
### What does this PR do?

Skips static quality gates on MQ pipelines targeting release branches.

### Motivation

Release branch MQ running into static_quality_gates failure (like [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1783915926)).

https://github.com/DataDog/datadog-agent/pull/51369 already meant to disable static quality gates from release branches, but left this case unhandled.

### Describe how you validated your changes

Merging this PR into 7.81.x should confirm that it works.

### Additional Notes
