### PR TITLE
Do not run the manual_gate_threshold_update job on release branches

### DIFF
--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -90,6 +90,8 @@ static_quality_gates:
 manual_gate_threshold_update:
   stage: functional_test
   rules:
+    - !reference [.except_release_branch]
+    - !reference [.except_pr_targeting_release_branch]
     - !reference [.except_coverage_pipeline] # Coverage pipeline creates a special artifact that will not pass the quality gate
     - !reference [.on_main_manual]
     - !reference [.on_dev_branches_with_artifact_changes_manual]


### PR DESCRIPTION
### What does this PR do?

Do not run the manual_gate_threshold_update job on release branches

### Motivation

I missed it in https://github.com/DataDog/datadog-agent/pull/51369

### Describe how you validated your changes

### Additional Notes
