### PR TITLE
ci(collector-workflow): free disk space before update script

### DIFF
--- a/.github/workflows/collector-generate-and-update.yml
+++ b/.github/workflows/collector-generate-and-update.yml
@@ -13,6 +13,15 @@ jobs:
     permissions:
       id-token: write # This is required for getting the required OIDC token from GitHub
     steps:
+      - name: Cleanup runner
+        run: |
+          sudo rm -rf /usr/local/lib/android >/dev/null 2>&1 || true
+          docker rmi $(docker image ls -aq) >/dev/null 2>&1 || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf "/usr/local/share/boost" || true
+          df -h
+
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 


### PR DESCRIPTION
## Summary

- Add a `Cleanup runner` step (first step in the job) to free ~10 GB of disk space before the collector update script runs
- The `collector.generate` step (OCB `go mod tidy`) downloads enough packages to exhaust the ~14 GB `ubuntu-latest` runner disk — confirmed from run [27767151363](https://github.com/DataDog/datadog-agent/actions/runs/27767151363): `No space left on device`
- Uses the same pattern already present in `.github/workflows/cws-btfhub-sync.yml`: removes Android SDK, .NET, GHC, and Boost pre-installed tools that this job doesn't need

## Test plan
- [ ] Trigger workflow manually: `gh workflow run collector-generate-and-update.yml --ref yang.song/OTAGENT-1111-disk-cleanup`
- [ ] Confirm `Run Collector Update Script` completes without disk space error
- [ ] Confirm draft PR is created with correct OCB version

🤖 Generated with [Claude Code](https://claude.com/claude-code)