### PR TITLE
(rc) Delay gRPC connection until component start

### DIFF
--- a/comp/remote-config/rcclient/impl/rcclient.go
+++ b/comp/remote-config/rcclient/impl/rcclient.go
@@ -79,11 +79,6 @@ type Dependencies struct {
 // components that are instantiated last).  Remote configuration client is a good candidate for this since it must be
 // able to interact with any other components (i.e. be at the end of the dependency graph).
 func NewComponent(deps Dependencies) (rcclient.Component, error) {
-	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
-	if err != nil {
-		return nil, err
-	}
-
 	if deps.Params.AgentName == "" || deps.Params.AgentVersion == "" {
 		return nil, errors.New("Remote config client is missing agent name or version parameter")
 	}

--- a/comp/remote-config/rcclient/impl/rcclient.go
+++ b/comp/remote-config/rcclient/impl/rcclient.go
@@ -53,6 +53,9 @@ type rcClient struct {
 	config            configcomp.Component
 	sysprobeConfig    option.Option[sysprobeconfig.Component]
 	isSystemProbe     bool
+	agentName         string
+	agentVersion      string
+	IPC               ipc.Component
 }
 
 // Dependencies defines the dependencies for the rcclient component.
@@ -85,62 +88,32 @@ func NewComponent(deps Dependencies) (rcclient.Component, error) {
 		return nil, errors.New("Remote config client is missing agent name or version parameter")
 	}
 
-	// Append client options
-	optsWithDefault := []func(*client.Options){
-		client.WithPollInterval(5 * time.Second),
-		client.WithAgent(deps.Params.AgentName, deps.Params.AgentVersion),
-	}
-
-	// We have to create the client in the constructor and set its name later
-	c, err := client.NewUnverifiedGRPCClient(
-		ipcAddress,
-		pkgconfigsetup.GetIPCPort(),
-		deps.IPC.GetAuthToken(),
-		deps.IPC.GetTLSClientConfig(),
-		optsWithDefault...,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	var clientMRF *client.Client
-	if pkgconfigsetup.Datadog().GetBool("multi_region_failover.enabled") {
-		clientMRF, err = client.NewUnverifiedMRFGRPCClient(
-			ipcAddress,
-			pkgconfigsetup.GetIPCPort(),
-			deps.IPC.GetAuthToken(),
-			deps.IPC.GetTLSClientConfig(),
-			optsWithDefault...,
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	rc := &rcClient{
 		listeners:         types.FilterListeners(deps.Listeners),
 		taskListeners:     types.FilterTaskListeners(deps.TaskListeners),
 		m:                 &sync.Mutex{},
-		client:            c,
-		clientMRF:         clientMRF,
 		settingsComponent: deps.SettingsComponent,
 		config:            deps.Config,
 		sysprobeConfig:    deps.SysprobeConfig,
 		isSystemProbe:     deps.Params.IsSystemProbe,
+		agentName:         deps.Params.AgentName,
+		agentVersion:      deps.Params.AgentVersion,
+		IPC:               deps.IPC,
 	}
 
 	if configUtils.IsRemoteConfigEnabled(deps.Config) {
 		deps.Lc.Append(compdef.Hook{
 			OnStart: func(context.Context) error {
-				rc.start()
-				return nil
+				return rc.start()
 			},
 		})
 	}
 
 	deps.Lc.Append(compdef.Hook{
 		OnStop: func(context.Context) error {
-			rc.client.Close()
+			if rc.client != nil {
+				rc.client.Close()
+			}
 			return nil
 		},
 	})
@@ -148,8 +121,52 @@ func NewComponent(deps Dependencies) (rcclient.Component, error) {
 	return rc, nil
 }
 
+func (rc *rcClient) createGRPCClient() error {
+	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
+	if err != nil {
+		return err
+	}
+
+	// Append client options
+	optsWithDefault := []func(*client.Options){
+		client.WithPollInterval(5 * time.Second),
+		client.WithAgent(rc.agentName, rc.agentVersion),
+	}
+
+	// We have to create the client in the constructor and set its name later
+	rc.client, err = client.NewUnverifiedGRPCClient(
+		ipcAddress,
+		pkgconfigsetup.GetIPCPort(),
+		rc.IPC.GetAuthToken(),
+		rc.IPC.GetTLSClientConfig(),
+		optsWithDefault...,
+	)
+	if err != nil {
+		return err
+	}
+
+	if pkgconfigsetup.Datadog().GetBool("multi_region_failover.enabled") {
+		rc.clientMRF, err = client.NewUnverifiedMRFGRPCClient(
+			ipcAddress,
+			pkgconfigsetup.GetIPCPort(),
+			rc.IPC.GetAuthToken(),
+			rc.IPC.GetTLSClientConfig(),
+			optsWithDefault...,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // start subscribes to AGENT_CONFIG configurations and starts the remote config client
-func (rc *rcClient) start() {
+func (rc *rcClient) start() error {
+	if err := rc.createGRPCClient(); err != nil {
+		return err
+
+	}
 	rc.client.Subscribe(state.ProductAgentConfig, rc.agentConfigUpdateCallback)
 
 	// Register every product for every listener
@@ -165,6 +182,8 @@ func (rc *rcClient) start() {
 		rc.clientMRF.Subscribe(state.ProductAgentFailover, rc.mrfUpdateCallback)
 		rc.clientMRF.Start()
 	}
+
+	return nil
 }
 
 // mrfUpdateCallback is the callback function for the AGENT_FAILOVER configs.

--- a/comp/remote-config/rcclient/impl/rcclient.go
+++ b/comp/remote-config/rcclient/impl/rcclient.go
@@ -364,6 +364,10 @@ func (rc *rcClient) SubscribeAgentTask() {
 
 // Subscribe is the generic way to start listening to a specific product update
 func (rc *rcClient) Subscribe(product data.Product, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus))) {
+	if rc.client == nil {
+		pkglog.Errorf("No remote-config client")
+		return
+	}
 	rc.client.Subscribe(string(product), fn)
 }
 

--- a/comp/remote-config/rcclient/impl/rcclient.go
+++ b/comp/remote-config/rcclient/impl/rcclient.go
@@ -133,7 +133,6 @@ func (rc *rcClient) createGRPCClient() error {
 		client.WithAgent(rc.agentName, rc.agentVersion),
 	}
 
-	// We have to create the client in the constructor and set its name later
 	rc.client, err = client.NewUnverifiedGRPCClient(
 		ipcAddress,
 		pkgconfigsetup.GetIPCPort(),


### PR DESCRIPTION
### What does this PR do?

Do not create gRPC connection at component creation

### Motivation

When remote configuration is explicitly disables, system-probe still
tries to connect the core agent over gRPC.

### Describe how you validated your changes

### Additional Notes
