### PR TITLE
Add shadow mode for core check construction

### DIFF
--- a/cmd/agent/subcommands/run/metriclookback.go
+++ b/cmd/agent/subcommands/run/metriclookback.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/collector/checkloader"
+	corechecks "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/DataDog/datadog-agent/pkg/collector/metriclookback"
 	"github.com/DataDog/datadog-agent/pkg/collector/metriclookback/lookbacksender"
@@ -86,7 +87,8 @@ func registerMetricLookbackScheduler(
 	healthplatform healthplatform.Component,
 	hostname hostnameinterface.Component,
 ) {
-	loader := checkloader.New(loaders.LoaderCatalog(demux, logReceiver, tagger, filterStore), demux, noopShadowLoaderErrorRecorder{})
+	shadowLoaders := newMetricLookbackShadowLoaders(demux, logReceiver, tagger, filterStore)
+	loader := checkloader.New(shadowLoaders, demux, noopShadowLoaderErrorRecorder{})
 	shadowScheduler := metriclookback.NewShadowScheduler(metriclookback.ShadowSchedulerOptions{
 		Loader: loader,
 		NewSenderManager: func(ctx context.Context) sender.SenderManager {
@@ -113,6 +115,15 @@ func registerMetricLookbackScheduler(
 		ShadowChecksEnabled: cfg.GetBool("metric_lookback.enabled"),
 		ChecksToShadow:      cfg.GetStringSlice("metric_lookback.enabled_checks"),
 	}, shadowScheduler), true)
+}
+
+func newMetricLookbackShadowLoaders(demux demultiplexer.Component, logReceiver option.Option[integrations.Component], tagger tagger.Component, filterStore workloadfilter.Component) []check.Loader {
+	return append([]check.Loader{newMetricLookbackShadowCoreLoader()}, loaders.LoaderCatalog(demux, logReceiver, tagger, filterStore)...)
+}
+
+func newMetricLookbackShadowCoreLoader() check.Loader {
+	shadowCoreLoader, _ := corechecks.NewGoCheckLoader(corechecks.WithLoadMode(corechecks.ShadowLoadMode))
+	return shadowCoreLoader
 }
 
 type noopLookbackWriter struct{}

--- a/cmd/agent/subcommands/run/metriclookback.go
+++ b/cmd/agent/subcommands/run/metriclookback.go
@@ -118,7 +118,24 @@ func registerMetricLookbackScheduler(
 }
 
 func newMetricLookbackShadowLoaders(demux demultiplexer.Component, logReceiver option.Option[integrations.Component], tagger tagger.Component, filterStore workloadfilter.Component) []check.Loader {
-	return append([]check.Loader{newMetricLookbackShadowCoreLoader()}, loaders.LoaderCatalog(demux, logReceiver, tagger, filterStore)...)
+	return newMetricLookbackShadowLoadersFromCatalog(loaders.LoaderCatalog(demux, logReceiver, tagger, filterStore))
+}
+
+func newMetricLookbackShadowLoadersFromCatalog(catalog []check.Loader) []check.Loader {
+	shadowLoaders := make([]check.Loader, 0, len(catalog)+1)
+	replacedCoreLoader := false
+	for _, loader := range catalog {
+		if _, ok := loader.(*corechecks.GoCheckLoader); ok {
+			shadowLoaders = append(shadowLoaders, newMetricLookbackShadowCoreLoader())
+			replacedCoreLoader = true
+			continue
+		}
+		shadowLoaders = append(shadowLoaders, loader)
+	}
+	if !replacedCoreLoader {
+		shadowLoaders = append(shadowLoaders, newMetricLookbackShadowCoreLoader())
+	}
+	return shadowLoaders
 }
 
 func newMetricLookbackShadowCoreLoader() check.Loader {

--- a/cmd/agent/subcommands/run/metriclookback_test.go
+++ b/cmd/agent/subcommands/run/metriclookback_test.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package run
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corechecks "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+)
+
+func TestMetricLookbackShadowCoreLoaderUsesShadowMode(t *testing.T) {
+	loader := newMetricLookbackShadowCoreLoader()
+
+	coreLoader, ok := loader.(*corechecks.GoCheckLoader)
+	require.True(t, ok)
+	require.Equal(t, corechecks.GoCheckLoaderName, coreLoader.Name())
+	require.Equal(t, corechecks.ShadowLoadMode, coreLoader.LoadMode())
+}

--- a/cmd/agent/subcommands/run/metriclookback_test.go
+++ b/cmd/agent/subcommands/run/metriclookback_test.go
@@ -8,10 +8,14 @@
 package run
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	corechecks "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 )
 
@@ -22,4 +26,62 @@ func TestMetricLookbackShadowCoreLoaderUsesShadowMode(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, corechecks.GoCheckLoaderName, coreLoader.Name())
 	require.Equal(t, corechecks.ShadowLoadMode, coreLoader.LoadMode())
+}
+
+func TestMetricLookbackShadowLoadersReplaceCoreLoaderInPlace(t *testing.T) {
+	normalCoreLoader, err := corechecks.NewGoCheckLoader()
+	require.NoError(t, err)
+	catalog := []check.Loader{
+		metricLookbackTestLoader{name: "python"},
+		normalCoreLoader,
+		metricLookbackTestLoader{name: "jmx"},
+	}
+
+	shadowLoaders := newMetricLookbackShadowLoadersFromCatalog(catalog)
+
+	require.Len(t, shadowLoaders, len(catalog))
+	require.Equal(t, "python", shadowLoaders[0].Name())
+	require.Equal(t, "jmx", shadowLoaders[2].Name())
+
+	coreLoader, ok := shadowLoaders[1].(*corechecks.GoCheckLoader)
+	require.True(t, ok)
+	require.NotSame(t, normalCoreLoader, coreLoader)
+	require.Equal(t, corechecks.ShadowLoadMode, coreLoader.LoadMode())
+
+	coreLoaderCount := 0
+	for _, loader := range shadowLoaders {
+		if _, ok := loader.(*corechecks.GoCheckLoader); ok {
+			coreLoaderCount++
+		}
+	}
+	require.Equal(t, 1, coreLoaderCount)
+}
+
+func TestMetricLookbackShadowLoadersAppendShadowCoreLoaderWhenCatalogHasNoCoreLoader(t *testing.T) {
+	catalog := []check.Loader{
+		metricLookbackTestLoader{name: "python"},
+		metricLookbackTestLoader{name: "jmx"},
+	}
+
+	shadowLoaders := newMetricLookbackShadowLoadersFromCatalog(catalog)
+
+	require.Len(t, shadowLoaders, len(catalog)+1)
+	require.Equal(t, "python", shadowLoaders[0].Name())
+	require.Equal(t, "jmx", shadowLoaders[1].Name())
+
+	coreLoader, ok := shadowLoaders[2].(*corechecks.GoCheckLoader)
+	require.True(t, ok)
+	require.Equal(t, corechecks.ShadowLoadMode, coreLoader.LoadMode())
+}
+
+type metricLookbackTestLoader struct {
+	name string
+}
+
+func (l metricLookbackTestLoader) Name() string {
+	return l.name
+}
+
+func (metricLookbackTestLoader) Load(sender.SenderManager, integration.Config, integration.Data, int) (check.Check, error) {
+	return nil, errors.New("not implemented")
 }

--- a/comp/aggregator/demultiplexerendpoint/impl/BUILD.bazel
+++ b/comp/aggregator/demultiplexerendpoint/impl/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "impl",
@@ -12,5 +12,18 @@ go_library(
         "//comp/core/log/def",
         "//pkg/util/http",
         "@com_github_datadog_zstd//:zstd",
+    ],
+)
+
+go_test(
+    name = "impl_test",
+    srcs = ["endpoint_test.go"],
+    embed = [":impl"],
+    gotags = ["test"],
+    deps = [
+        "//comp/aggregator/demultiplexer/def",
+        "//comp/core/log/mock",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -24,14 +24,42 @@ import (
 // CheckFactory factory function type to instantiate checks
 type CheckFactory func() check.Check
 
+// LoadMode describes why a core check is being constructed.
+type LoadMode string
+
+const (
+	// NormalLoadMode constructs a normal collector check.
+	NormalLoadMode LoadMode = "normal"
+	// ShadowLoadMode constructs a metric-lookback shadow check.
+	ShadowLoadMode LoadMode = "shadow"
+)
+
+// ConstructionContext is passed to factories that need mode-specific
+// dependencies while constructing a check instance.
+type ConstructionContext struct {
+	Mode LoadMode
+}
+
+// ContextualCheckFactory instantiates checks with construction context.
+type ContextualCheckFactory func(ConstructionContext) check.Check
+
 // Catalog keeps track of Go checks by name
-var catalog = make(map[string]CheckFactory)
+var catalog = make(map[string]ContextualCheckFactory)
 
 // GoCheckLoaderName is the name of the Go loader
 const GoCheckLoaderName string = "core"
 
 // RegisterCheck adds a check to the catalog
 func RegisterCheck(name string, checkFactory option.Option[func() check.Check]) {
+	if v, ok := checkFactory.Get(); ok {
+		catalog[name] = func(ConstructionContext) check.Check {
+			return v()
+		}
+	}
+}
+
+// RegisterContextualCheck adds a context-aware check factory to the catalog.
+func RegisterContextualCheck(name string, checkFactory option.Option[func(ConstructionContext) check.Check]) {
 	if v, ok := checkFactory.Get(); ok {
 		catalog[name] = v
 	}
@@ -48,11 +76,32 @@ func GetRegisteredFactoryKeys() []string {
 }
 
 // GoCheckLoader is a specific loader for checks living in this package
-type GoCheckLoader struct{}
+type GoCheckLoader struct {
+	mode LoadMode
+}
+
+// GoCheckLoaderOption configures a GoCheckLoader.
+type GoCheckLoaderOption func(*GoCheckLoader)
+
+// WithLoadMode configures the construction mode for loaded checks.
+func WithLoadMode(mode LoadMode) GoCheckLoaderOption {
+	return func(gl *GoCheckLoader) {
+		gl.mode = mode
+	}
+}
+
+// LoadMode returns the loader's check construction mode.
+func (gl *GoCheckLoader) LoadMode() LoadMode {
+	return gl.mode
+}
 
 // NewGoCheckLoader creates a loader for go checks
-func NewGoCheckLoader() (*GoCheckLoader, error) {
-	return &GoCheckLoader{}, nil
+func NewGoCheckLoader(opts ...GoCheckLoaderOption) (*GoCheckLoader, error) {
+	loader := &GoCheckLoader{mode: NormalLoadMode}
+	for _, opt := range opts {
+		opt(loader)
+	}
+	return loader, nil
 }
 
 // Name return returns Go loader name
@@ -70,7 +119,11 @@ func (gl *GoCheckLoader) Load(senderManger sender.SenderManager, config integrat
 		return c, errors.New(msg)
 	}
 
-	c = factory()
+	c = factory(ConstructionContext{Mode: gl.mode})
+	if c == nil {
+		msg := fmt.Sprintf("Check %s factory returned nil", config.Name)
+		return c, errors.New(msg)
+	}
 
 	configSource := config.Source
 	if instanceIndex >= 0 {

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -30,7 +30,7 @@ type LoadMode string
 const (
 	// NormalLoadMode constructs a normal collector check.
 	NormalLoadMode LoadMode = "normal"
-	// ShadowLoadMode constructs a metric-lookback shadow check.
+	// ShadowLoadMode constructs a shadow collector check.
 	ShadowLoadMode LoadMode = "shadow"
 )
 

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -20,9 +20,20 @@ import (
 // FIXTURE
 type TestCheck struct {
 	stub.StubCheck
+
+	configured     bool
+	configDigest   uint64
+	configData     integration.Data
+	configSource   string
+	configProvider string
 }
 
-func (c *TestCheck) Configure(_ sender.SenderManager, _ uint64, data integration.Data, _ integration.Data, _ string, _ string) error {
+func (c *TestCheck) Configure(_ sender.SenderManager, digest uint64, data integration.Data, _ integration.Data, source string, provider string) error {
+	c.configured = true
+	c.configDigest = digest
+	c.configData = data
+	c.configSource = source
+	c.configProvider = provider
 	if string(data) == "err" {
 		return errors.New("testError")
 	}
@@ -30,6 +41,15 @@ func (c *TestCheck) Configure(_ sender.SenderManager, _ uint64, data integration
 		return check.ErrSkipCheckInstance
 	}
 	return nil
+}
+
+func withTestCatalog(t *testing.T) {
+	t.Helper()
+	originalCatalog := catalog
+	catalog = make(map[string]ContextualCheckFactory)
+	t.Cleanup(func() {
+		catalog = originalCatalog
+	})
 }
 
 func TestNewGoCheckLoader(t *testing.T) {
@@ -45,6 +65,7 @@ func testCheckNew() option.Option[func() check.Check] {
 }
 
 func TestRegisterCheck(t *testing.T) {
+	withTestCatalog(t)
 	RegisterCheck("foo", testCheckNew())
 	_, found := catalog["foo"]
 	if !found {
@@ -52,19 +73,93 @@ func TestRegisterCheck(t *testing.T) {
 	}
 }
 
+func TestGoCheckLoaderPassesDefaultNormalMode(t *testing.T) {
+	withTestCatalog(t)
+
+	var gotMode LoadMode
+	RegisterContextualCheck("foo", option.New(func(ctx ConstructionContext) check.Check {
+		gotMode = ctx.Mode
+		return &TestCheck{}
+	}))
+
+	l, _ := NewGoCheckLoader()
+	_, err := l.Load(aggregator.NewNoOpSenderManager(), integration.Config{Name: "foo"}, integration.Data("foo: bar"), 0)
+	if err != nil {
+		t.Fatalf("Expected nil error, found: %v", err)
+	}
+	if gotMode != NormalLoadMode {
+		t.Fatalf("Expected mode %q, found %q", NormalLoadMode, gotMode)
+	}
+}
+
+func TestGoCheckLoaderPassesShadowMode(t *testing.T) {
+	withTestCatalog(t)
+
+	var gotMode LoadMode
+	RegisterContextualCheck("foo", option.New(func(ctx ConstructionContext) check.Check {
+		gotMode = ctx.Mode
+		return &TestCheck{}
+	}))
+
+	l, _ := NewGoCheckLoader(WithLoadMode(ShadowLoadMode))
+	_, err := l.Load(aggregator.NewNoOpSenderManager(), integration.Config{Name: "foo"}, integration.Data("foo: bar"), 0)
+	if err != nil {
+		t.Fatalf("Expected nil error, found: %v", err)
+	}
+	if gotMode != ShadowLoadMode {
+		t.Fatalf("Expected mode %q, found %q", ShadowLoadMode, gotMode)
+	}
+}
+
+func TestRegisterCheckWrapsLegacyFactory(t *testing.T) {
+	withTestCatalog(t)
+
+	called := false
+	RegisterCheck("foo", option.New(func() check.Check {
+		called = true
+		return &TestCheck{}
+	}))
+
+	l, _ := NewGoCheckLoader(WithLoadMode(ShadowLoadMode))
+	_, err := l.Load(aggregator.NewNoOpSenderManager(), integration.Config{Name: "foo"}, integration.Data("foo: bar"), 0)
+	if err != nil {
+		t.Fatalf("Expected nil error, found: %v", err)
+	}
+	if !called {
+		t.Fatal("Expected legacy factory to be called")
+	}
+}
+
 func TestLoad(t *testing.T) {
+	withTestCatalog(t)
 	RegisterCheck("foo", testCheckNew())
 
 	// check is in catalog, pass 1 good instance
 	i := []integration.Data{
 		integration.Data("foo: bar"),
 	}
-	cc := integration.Config{Name: "foo", Instances: i}
+	cc := integration.Config{Name: "foo", Instances: i, Source: "file:foo.yaml", Provider: "file"}
 	l, _ := NewGoCheckLoader()
 
-	_, err := l.Load(aggregator.NewNoOpSenderManager(), cc, i[0], 0)
+	loadedCheck, err := l.Load(aggregator.NewNoOpSenderManager(), cc, i[0], 0)
 	if err != nil {
 		t.Fatalf("Expected nil error, found: %v", err)
+	}
+	tc := loadedCheck.(*TestCheck)
+	if !tc.configured {
+		t.Fatal("Expected check to be configured")
+	}
+	if tc.configDigest != cc.FastDigest() {
+		t.Fatalf("Expected digest %d, found %d", cc.FastDigest(), tc.configDigest)
+	}
+	if string(tc.configData) != string(i[0]) {
+		t.Fatalf("Expected instance data %q, found %q", i[0], tc.configData)
+	}
+	if tc.configSource != "file:foo.yaml[0]" {
+		t.Fatalf("Expected source %q, found %q", "file:foo.yaml[0]", tc.configSource)
+	}
+	if tc.configProvider != "file" {
+		t.Fatalf("Expected provider %q, found %q", "file", tc.configProvider)
 	}
 
 	// check is in catalog, pass 1 bad instance

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -87,8 +87,10 @@ func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Com
 	corecheckLoader.RegisterCheck(memory.CheckName, memory.Factory())
 	corecheckLoader.RegisterCheck(uptime.CheckName, uptime.Factory())
 	corecheckLoader.RegisterCheck(hostinfo.CheckName, hostinfo.Factory())
-	corecheckLoader.RegisterContextualCheck(telemetryCheck.CheckName, contextualCoreFactory(func(ctx corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
-		return telemetryCheck.Factory(telemetryForMode(ctx))
+	corecheckLoader.RegisterContextualCheck(telemetryCheck.CheckName, contextualCoreFactory(func(corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
+		// The telemetry check scrapes the telemetry registry, so shadow instances
+		// must keep the real registry instead of the shadow noop telemetry.
+		return telemetryCheck.Factory(telemetry)
 	}))
 	corecheckLoader.RegisterCheck(ntp.CheckName, ntp.Factory())
 	corecheckLoader.RegisterCheck(wlan.CheckName, wlan.Factory())

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -20,6 +20,7 @@ import (
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
 	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/agentprofiling"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cloud/hostinfo"
@@ -79,16 +80,22 @@ func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Com
 	telemetry telemetry.Component, rcClient rcclient.Component, flare flare.Component, snmpScanManager snmpscanmanager.Component,
 	traceroute traceroute.Component, ncmComp option.Option[networkconfigmanagement.Component],
 ) {
+	telemetryForMode := telemetryProviderForLoadMode(telemetry)
+
 	// Required checks
 	corecheckLoader.RegisterCheck(cpu.CheckName, cpu.Factory())
 	corecheckLoader.RegisterCheck(memory.CheckName, memory.Factory())
 	corecheckLoader.RegisterCheck(uptime.CheckName, uptime.Factory())
 	corecheckLoader.RegisterCheck(hostinfo.CheckName, hostinfo.Factory())
-	corecheckLoader.RegisterCheck(telemetryCheck.CheckName, telemetryCheck.Factory(telemetry))
+	corecheckLoader.RegisterContextualCheck(telemetryCheck.CheckName, contextualCoreFactory(func(ctx corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
+		return telemetryCheck.Factory(telemetryForMode(ctx))
+	}))
 	corecheckLoader.RegisterCheck(ntp.CheckName, ntp.Factory())
 	corecheckLoader.RegisterCheck(wlan.CheckName, wlan.Factory())
 	corecheckLoader.RegisterCheck(snmp.CheckName, snmp.Factory(cfg, rcClient, snmpScanManager))
-	corecheckLoader.RegisterCheck(networkpath.CheckName, networkpath.Factory(telemetry, traceroute))
+	corecheckLoader.RegisterContextualCheck(networkpath.CheckName, contextualCoreFactory(func(ctx corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
+		return networkpath.Factory(telemetryForMode(ctx), traceroute)
+	}))
 	corecheckLoader.RegisterCheck(io.CheckName, io.Factory())
 	corecheckLoader.RegisterCheck(filehandles.CheckName, filehandles.Factory())
 	corecheckLoader.RegisterCheck(containerimage.CheckName, containerimage.Factory(store, tagger))
@@ -103,8 +110,12 @@ func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Com
 	corecheckLoader.RegisterCheck(helm.CheckName, helm.Factory())
 	corecheckLoader.RegisterCheck(pod.CheckName, pod.Factory(store, cfg, tagger))
 	corecheckLoader.RegisterCheck(kubeletconfig.CheckName, kubeletconfig.Factory(store, cfg, tagger))
-	corecheckLoader.RegisterCheck(gpu.CheckName, gpu.Factory(tagger, telemetry, store))
-	corecheckLoader.RegisterCheck(nccl.CheckName, nccl.Factory(tagger, telemetry, store))
+	corecheckLoader.RegisterContextualCheck(gpu.CheckName, contextualCoreFactory(func(ctx corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
+		return gpu.Factory(tagger, telemetryForMode(ctx), store)
+	}))
+	corecheckLoader.RegisterContextualCheck(nccl.CheckName, contextualCoreFactory(func(ctx corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
+		return nccl.Factory(tagger, telemetryForMode(ctx), store)
+	}))
 	corecheckLoader.RegisterCheck(ecs.CheckName, ecs.Factory(store, tagger))
 	corecheckLoader.RegisterCheck(apm.CheckName, apm.Factory())
 	corecheckLoader.RegisterCheck(process.CheckName, process.Factory())

--- a/pkg/commonchecks/corechecks_context.go
+++ b/pkg/commonchecks/corechecks_context.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package commonchecks
+
+import (
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	noopsimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+func telemetryProviderForLoadMode(normalTelemetry telemetry.Component) func(corecheckLoader.ConstructionContext) telemetry.Component {
+	shadowTelemetry := noopsimpl.NewComponent()
+	return func(ctx corecheckLoader.ConstructionContext) telemetry.Component {
+		if ctx.Mode == corecheckLoader.ShadowLoadMode {
+			return shadowTelemetry
+		}
+		return normalTelemetry
+	}
+}
+
+func contextualCoreFactory(factoryForContext func(corecheckLoader.ConstructionContext) option.Option[func() check.Check]) option.Option[func(corecheckLoader.ConstructionContext) check.Check] {
+	normalFactory := factoryForContext(corecheckLoader.ConstructionContext{Mode: corecheckLoader.NormalLoadMode})
+	_, ok := normalFactory.Get()
+	if !ok {
+		return option.None[func(corecheckLoader.ConstructionContext) check.Check]()
+	}
+
+	return option.New(func(ctx corecheckLoader.ConstructionContext) check.Check {
+		factoryForMode := factoryForContext(ctx)
+		factory, ok := factoryForMode.Get()
+		if !ok {
+			return nil
+		}
+		return factory()
+	})
+}

--- a/pkg/commonchecks/corechecks_test.go
+++ b/pkg/commonchecks/corechecks_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package commonchecks
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/stub"
+	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+func TestTelemetryProviderForLoadMode(t *testing.T) {
+	normalTelemetry := telemetryimpl.NewMockComponent()
+	provider := telemetryProviderForLoadMode(normalTelemetry)
+
+	require.Equal(t, componentPointer(normalTelemetry), componentPointer(provider(corecheckLoader.ConstructionContext{Mode: corecheckLoader.NormalLoadMode})))
+
+	shadowTelemetry := provider(corecheckLoader.ConstructionContext{Mode: corecheckLoader.ShadowLoadMode})
+	require.NotEqual(t, componentPointer(normalTelemetry), componentPointer(shadowTelemetry))
+	require.Equal(t, componentPointer(shadowTelemetry), componentPointer(provider(corecheckLoader.ConstructionContext{Mode: corecheckLoader.ShadowLoadMode})))
+}
+
+func componentPointer(component any) uintptr {
+	return reflect.ValueOf(component).Pointer()
+}
+
+func TestContextualCoreFactoryEvaluatesContextAtConstructionTime(t *testing.T) {
+	var modes []corecheckLoader.LoadMode
+	contextualFactory := contextualCoreFactory(func(ctx corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
+		modes = append(modes, ctx.Mode)
+		return option.New(func() check.Check {
+			return &stub.StubCheck{}
+		})
+	})
+
+	factory, ok := contextualFactory.Get()
+	require.True(t, ok)
+
+	loadedCheck := factory(corecheckLoader.ConstructionContext{Mode: corecheckLoader.ShadowLoadMode})
+
+	require.NotNil(t, loadedCheck)
+	require.Equal(t, []corecheckLoader.LoadMode{corecheckLoader.NormalLoadMode, corecheckLoader.ShadowLoadMode}, modes)
+}


### PR DESCRIPTION
### What does this PR do?

Adds a generic shadow construction mode for Go/core checks and wires metric lookback to use a shadow-mode core loader.

This keeps normal checks on normal telemetry while giving metric-lookback shadow checks noop check-internal telemetry through mode-aware core-check factory construction. The PR also removes the need for metric lookback to hardcode GPU-specific shadow check construction.

Metric-lookback builds from the normal loader catalog and replaces the normal Go/core loader in place with a shadow-mode Go/core loader. That preserves the existing loader order and avoids creating a second `core` loader that could fall through to normal-mode construction.

### Motivation

The venomoth GPU demo showed that running a normal GPU check and a shadow GPU check in the same Agent can duplicate check-internal telemetry collector registration and crash the Agent.

The production fix should not be GPU-specific. Metric lookback owns shadow lifecycle, but core check construction is the layer that has access to check factory dependencies. This PR makes that construction path mode-aware so shadow runs can use shadow-safe dependencies without changing the scheduler API or adding a second check catalog.

### Describe how you validated your changes

- `dda inv test --targets=./cmd/agent/subcommands/run`
- `dda inv test --targets=./pkg/collector/corechecks,./pkg/commonchecks,./cmd/agent/subcommands/run`
- `dda inv agent.build --build-exclude=systemd`

### Additional Notes

Shadow check-internal telemetry is noop by default here. Metric-lookback feature telemetry remains real and unchanged.
