### PR TITLE
Validate adaptive sampler match threshold

### DIFF
--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -195,6 +195,8 @@ const (
 	samplerNoisyLogDetection
 )
 
+const defaultAdaptiveSamplerMatchThreshold = 0.9
+
 func resolveSamplerMode(sourceAdaptiveSampling *config.SourceAdaptiveSamplingOptions, sourceNoisyLogDetection *bool) samplerMode {
 	if resolveAdaptiveSamplerEnabled(sourceAdaptiveSampling) {
 		return samplerAdaptiveSampling
@@ -232,7 +234,11 @@ func resolveAdaptiveSamplerConfig(sourceAdaptiveSampling *config.SourceAdaptiveS
 			c.BurstSize = *sourceAdaptiveSampling.BurstSize
 		}
 		if sourceAdaptiveSampling.MatchThreshold != nil {
-			c.MatchThreshold = *sourceAdaptiveSampling.MatchThreshold
+			if *sourceAdaptiveSampling.MatchThreshold <= 0 || *sourceAdaptiveSampling.MatchThreshold > 1 {
+				log.Warnf("Invalid adaptive sampler source match_threshold %f, keeping %f", *sourceAdaptiveSampling.MatchThreshold, c.MatchThreshold)
+			} else {
+				c.MatchThreshold = *sourceAdaptiveSampling.MatchThreshold
+			}
 		}
 		if sourceAdaptiveSampling.ProtectImportantLogs != nil {
 			c.ProtectImportantLogs = *sourceAdaptiveSampling.ProtectImportantLogs
@@ -396,6 +402,11 @@ func validateAdaptiveSamplerConfig(c preprocessor.AdaptiveSamplerConfig) preproc
 
 	if c.BurstSize <= 0 {
 		c.BurstSize = 1
+	}
+
+	if c.MatchThreshold <= 0 || c.MatchThreshold > 1 {
+		log.Warnf("Invalid adaptive sampler match_threshold %f, using default %f", c.MatchThreshold, defaultAdaptiveSamplerMatchThreshold)
+		c.MatchThreshold = defaultAdaptiveSamplerMatchThreshold
 	}
 
 	return c

--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -676,6 +676,23 @@ func TestResolveAdaptiveSamplerConfig(t *testing.T) {
 		assert.False(t, got.TagPatternHash)
 	})
 
+	t.Run("invalid global match threshold falls back to default", func(t *testing.T) {
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.match_threshold", -1.0, pkgconfigmodel.SourceAgentRuntime)
+		defer mockConfig.Set("logs_config.experimental_adaptive_sampling.match_threshold", 0.8, pkgconfigmodel.SourceAgentRuntime)
+
+		got := resolveAdaptiveSamplerConfig(nil, preprocessor.NewTokenizer(0))
+		assert.Equal(t, defaultAdaptiveSamplerMatchThreshold, got.MatchThreshold)
+	})
+
+	t.Run("invalid source match threshold keeps global value", func(t *testing.T) {
+		sourceInvalidThreshold := 1.5
+		got := resolveAdaptiveSamplerConfig(&config.SourceAdaptiveSamplingOptions{
+			MatchThreshold: &sourceInvalidThreshold,
+		}, preprocessor.NewTokenizer(0))
+
+		assert.Equal(t, 0.8, got.MatchThreshold)
+	})
+
 	t.Run("source filters are resolved", func(t *testing.T) {
 		got := resolveAdaptiveSamplerConfig(&config.SourceAdaptiveSamplingOptions{
 			Include: []*config.AdaptiveSamplingRule{

--- a/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
+++ b/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
@@ -447,6 +447,11 @@ invariant SampledCountNonNegative {
         entry.sampled_count >= 0
 }
 
+invariant MatchThresholdInRange {
+    config.match_threshold > 0.0
+    and config.match_threshold <= 1.0
+}
+
 -- Behavioural properties not expressible as state predicates
 -- but guaranteed by the rules above:
 --
@@ -466,16 +471,3 @@ invariant SampledCountNonNegative {
 --   at most burst_size + rate_limit * T logs of one pattern are
 --   emitted (burst_size for the initial allowance, then rate_limit
 --   per second in steady state).
-
-------------------------------------------------------------
--- Deferred Specifications
-------------------------------------------------------------
-
-deferred "ValidateMatchThreshold"
-    -- The adaptive sampler must reject match_threshold values
-    -- outside (0, 1] at construction time. A threshold of 0 would
-    -- match everything regardless of token content, defeating
-    -- pattern discrimination. The UserSamples path already enforces
-    -- this range (user_samples.go); the same validation needs to be
-    -- added when match_threshold is wired up as user-configurable
-    -- for the adaptive sampler.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a822da39-56b9-4685-bb54-58fb320cbd95","source":"chat","resourceId":"f6472eca-7359-41d9-82a5-1ac1789ab991","workflowId":"464375af-3f75-40f9-a03f-e5f8581ee957","codeChangeId":"464375af-3f75-40f9-a03f-e5f8581ee957","sourceType":"scheduled_task"} -->
### What does this PR do?
- Audits the adaptive sampler `match_threshold` config path against `adaptive_sampler.allium`.
- Enforces `(0, 1]` validation for adaptive sampler `match_threshold` during config resolution.
- Rejects invalid per-source `match_threshold` overrides and keeps the current resolved value.
- Falls back invalid resolved global thresholds to the default `0.9`.
- Updates `adaptive_sampler.allium` to codify `MatchThresholdInRange` and removes the now-resolved deferred spec item.
- Adds decoder config tests for invalid global and invalid source `match_threshold` inputs.

### Motivation
The Allium spec requires rejecting invalid adaptive sampler match thresholds. The runtime config path had no validation after this field became user-configurable, which could allow `0`/out-of-range values and unintentionally collapse pattern discrimination.

### Describe how you validated your changes
- `GOENV_VERSION=1.26.3 go test -tags test ./pkg/logs/internal/decoder ./pkg/logs/internal/decoder/preprocessor`
- `GOENV_VERSION=1.26.3 go build ./pkg/logs/internal/decoder && GOENV_VERSION=1.26.3 golangci-lint run ./pkg/logs/internal/decoder`

### Additional Notes
- No behavior change for valid configs.
- Invalid source overrides now log a warning and are ignored.
- Invalid resolved global values now log a warning and fall back to the safe default `0.9`.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/f6472eca-7359-41d9-82a5-1ac1789ab991)

Comment @datadog to request changes