### PR TITLE
do not stringify IPs in portlist poller

### DIFF
--- a/pkg/diagnose/ports/ports_test.go
+++ b/pkg/diagnose/ports/ports_test.go
@@ -6,6 +6,7 @@
 package ports
 
 import (
+	"net/netip"
 	"os"
 	"testing"
 
@@ -13,6 +14,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/port"
 )
+
+var ipv4Loopback = netip.MustParseAddr("127.0.0.1")
 
 // realProcess returns this test binary's PID and its OS-reported process
 // name. Tests use this so isAgentProcess can succeed on both Windows (where
@@ -57,8 +60,8 @@ func TestWorstBind(t *testing.T) {
 
 	// Agent bind + unknown-owner bind (Pid=0): unknown (1) beats agent (0).
 	binds := []port.Port{
-		{Proto: "tcp", Port: 8126, IP: "0.0.0.0", Pid: pid, Process: name},
-		{Proto: "tcp", Port: 8126, IP: "127.0.0.1", Pid: 0},
+		{Proto: "tcp", Port: 8126, IP: netip.IPv4Unspecified(), Pid: pid, Process: name},
+		{Proto: "tcp", Port: 8126, IP: ipv4Loopback, Pid: 0},
 	}
 	worst, sev, _ := worstBind(binds)
 	require.Equal(t, severityUnknown, sev)
@@ -72,8 +75,8 @@ func TestWorstBind_ForeignOverAgent(t *testing.T) {
 	// Pid=1 resolves to a non-agent process (Linux echoes Process="nginx";
 	// Windows resolves PID 1 to something like "System Idle Process").
 	binds := []port.Port{
-		{Proto: "tcp", Port: 8126, IP: "0.0.0.0", Pid: pid, Process: name},
-		{Proto: "tcp", Port: 8126, IP: "127.0.0.1", Pid: 1, Process: "nginx"},
+		{Proto: "tcp", Port: 8126, IP: netip.IPv4Unspecified(), Pid: pid, Process: name},
+		{Proto: "tcp", Port: 8126, IP: ipv4Loopback, Pid: 1, Process: "nginx"},
 	}
 	worst, sev, _ := worstBind(binds)
 	require.Equal(t, severityForeign, sev)
@@ -86,8 +89,8 @@ func TestWorstBind_OrderIndependent(t *testing.T) {
 	swapAgentNames(t, map[string]struct{}{name: {}})
 
 	binds := []port.Port{
-		{Proto: "tcp", Port: 8126, IP: "127.0.0.1", Pid: 0},
-		{Proto: "tcp", Port: 8126, IP: "0.0.0.0", Pid: pid, Process: name},
+		{Proto: "tcp", Port: 8126, IP: ipv4Loopback, Pid: 0},
+		{Proto: "tcp", Port: 8126, IP: netip.IPv4Unspecified(), Pid: pid, Process: name},
 	}
 	worst, sev, _ := worstBind(binds)
 	require.Equal(t, severityUnknown, sev)

--- a/pkg/process/checks/net_portmap.go
+++ b/pkg/process/checks/net_portmap.go
@@ -51,7 +51,7 @@ func getListeningPortToPIDMap() map[remoteservice.ListenKey]int32 {
 	for _, p := range ports {
 		// USM supports TCP only; skip UDP ports.
 		if p.Pid > 0 && p.Proto == "tcp" {
-			result[remoteservice.ListenKey{IP: p.IP, Port: int32(p.Port)}] = int32(p.Pid)
+			result[remoteservice.ListenKey{IP: p.IP.String(), Port: int32(p.Port)}] = int32(p.Pid)
 		}
 	}
 	cachedPortMap = result

--- a/pkg/util/port/portlist/BUILD.bazel
+++ b/pkg/util/port/portlist/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
     deps = select({
         "@rules_go//go/platform:android": [
             "@com_github_google_go_cmp//cmp",
+            "@com_github_google_go_cmp//cmp/cmpopts",
             "@org_go4_mem//:mem",
         ],
         "@rules_go//go/platform:darwin": [
@@ -71,6 +72,7 @@ go_test(
         ],
         "@rules_go//go/platform:linux": [
             "@com_github_google_go_cmp//cmp",
+            "@com_github_google_go_cmp//cmp/cmpopts",
             "@org_go4_mem//:mem",
         ],
         "//conditions:default": [],

--- a/pkg/util/port/portlist/poller.go
+++ b/pkg/util/port/portlist/poller.go
@@ -89,7 +89,7 @@ func (a *Port) lessThan(b *Port) bool {
 		return a.Proto < b.Proto
 	}
 	if a.IP != b.IP {
-		return a.IP < b.IP
+		return a.IP.Compare(b.IP) == -1
 	}
 	return a.Process < b.Process
 }

--- a/pkg/util/port/portlist/poller_linux.go
+++ b/pkg/util/port/portlist/poller_linux.go
@@ -122,39 +122,39 @@ func (li *linuxImpl) AppendListeningPorts(base []Port) ([]Port, error) {
 // parseHexIPv4 parses an 8-character hex string from /proc/net/tcp
 // representing an IPv4 address in host byte order and returns the
 // canonical IP string (e.g. "0.0.0.0", "127.0.0.1").
-func parseHexIPv4(hexStr string) string {
+func parseHexIPv4(hexStr string) netip.Addr {
 	if len(hexStr) != 8 {
-		return ""
+		return netip.Addr{}
 	}
 	v, err := strconv.ParseUint(hexStr, 16, 32)
 	if err != nil {
-		return ""
+		return netip.Addr{}
 	}
 	addr := netip.AddrFrom4([4]byte{
 		byte(v), byte(v >> 8), byte(v >> 16), byte(v >> 24),
 	})
-	return addr.String()
+	return addr
 }
 
 // parseHexIPv6 parses a 32-character hex string from /proc/net/tcp6
 // representing an IPv6 address as four 32-bit words in host byte order
 // and returns the canonical IP string (e.g. "::", "::1").
-func parseHexIPv6(hexStr string) string {
+func parseHexIPv6(hexStr string) netip.Addr {
 	if len(hexStr) != 32 {
-		return ""
+		return netip.Addr{}
 	}
 	var b [16]byte
 	for i := 0; i < 4; i++ {
 		v, err := strconv.ParseUint(hexStr[i*8:(i+1)*8], 16, 32)
 		if err != nil {
-			return ""
+			return netip.Addr{}
 		}
 		b[i*4] = byte(v)
 		b[i*4+1] = byte(v >> 8)
 		b[i*4+2] = byte(v >> 16)
 		b[i*4+3] = byte(v >> 24)
 	}
-	return netip.AddrFrom16(b).Unmap().String()
+	return netip.AddrFrom16(b).Unmap()
 }
 
 func (li *linuxImpl) parseProcNetFile(r *bufio.Reader, fileBase string) error {
@@ -256,11 +256,11 @@ func (li *linuxImpl) parseProcNetFile(r *bufio.Reader, fileBase string) error {
 			// Rest should be unchanged.
 		} else {
 			ipHex := local.SliceTo(i).StringCopy()
-			var ipStr string
+			var ip netip.Addr
 			if isIPv6 {
-				ipStr = parseHexIPv6(ipHex)
+				ip = parseHexIPv6(ipHex)
 			} else {
-				ipStr = parseHexIPv4(ipHex)
+				ip = parseHexIPv4(ipHex)
 			}
 			li.known[string(inoBuf)] = &portMeta{
 				needsProcName: true,
@@ -268,7 +268,7 @@ func (li *linuxImpl) parseProcNetFile(r *bufio.Reader, fileBase string) error {
 				port: Port{
 					Proto: proto,
 					Port:  uint16(portv),
-					IP:    ipStr,
+					IP:    ip,
 				},
 			}
 		}

--- a/pkg/util/port/portlist/poller_linux_test.go
+++ b/pkg/util/port/portlist/poller_linux_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -66,7 +67,7 @@ func TestParsePorts(t *testing.T) {
 `,
 			want: map[string]*portMeta{
 				"socket:[34062]": {
-					port: Port{Proto: "tcp", Port: 22, IP: "0.0.0.0"},
+					port: Port{Proto: "tcp", Port: 22, IP: netip.IPv4Unspecified()},
 				},
 			},
 		},
@@ -81,10 +82,10 @@ func TestParsePorts(t *testing.T) {
 `,
 			want: map[string]*portMeta{
 				"socket:[142240557]": {
-					port: Port{Proto: "tcp", Port: 8081, IP: "::"},
+					port: Port{Proto: "tcp", Port: 8081, IP: netip.IPv6Unspecified()},
 				},
 				"socket:[34064]": {
-					port: Port{Proto: "tcp", Port: 22, IP: "::"},
+					port: Port{Proto: "tcp", Port: 22, IP: netip.IPv6Unspecified()},
 				},
 			},
 		},
@@ -104,7 +105,7 @@ func TestParsePorts(t *testing.T) {
 `,
 			want: map[string]*portMeta{
 				"socket:[99999]": {
-					port: Port{Proto: "tcp", Port: 443, IP: "192.168.1.1"},
+					port: Port{Proto: "tcp", Port: 443, IP: netip.MustParseAddr("192.168.1.1")},
 				},
 			},
 		},
@@ -137,15 +138,15 @@ func TestParsePorts(t *testing.T) {
 func TestParseHexIPv4(t *testing.T) {
 	tests := []struct {
 		in   string
-		want string
+		want netip.Addr
 	}{
-		{"00000000", "0.0.0.0"},
-		{"0100007F", "127.0.0.1"},
-		{"0101A8C0", "192.168.1.1"},
-		{"0200000A", "10.0.0.2"},
-		{"invalid", ""},
-		{"0100007", ""},   // too short: 7 valid hex chars
-		{"0100007F0", ""}, // too long: 9 valid hex chars
+		{"00000000", netip.IPv4Unspecified()},
+		{"0100007F", netip.MustParseAddr("127.0.0.1")},
+		{"0101A8C0", netip.MustParseAddr("192.168.1.1")},
+		{"0200000A", netip.MustParseAddr("10.0.0.2")},
+		{"invalid", netip.Addr{}},
+		{"0100007", netip.Addr{}},   // too short: 7 valid hex chars
+		{"0100007F0", netip.Addr{}}, // too long: 9 valid hex chars
 	}
 	for _, tt := range tests {
 		got := parseHexIPv4(tt.in)
@@ -158,13 +159,13 @@ func TestParseHexIPv4(t *testing.T) {
 func TestParseHexIPv6(t *testing.T) {
 	tests := []struct {
 		in   string
-		want string
+		want netip.Addr
 	}{
-		{"00000000000000000000000000000000", "::"},
-		{"00000000000000000000000001000000", "::1"},
-		{"0000000000000000FFFF00000100007F", "127.0.0.1"},
-		{"0000000000000000FFFF0000010120AC", "172.32.1.1"},
-		{"short", ""},
+		{"00000000000000000000000000000000", netip.IPv6Unspecified()},
+		{"00000000000000000000000001000000", netip.IPv6Loopback()},
+		{"0000000000000000FFFF00000100007F", netip.MustParseAddr("127.0.0.1")},
+		{"0000000000000000FFFF0000010120AC", netip.MustParseAddr("172.32.1.1")},
+		{"short", netip.Addr{}},
 	}
 	for _, tt := range tests {
 		got := parseHexIPv6(tt.in)
@@ -320,15 +321,15 @@ func TestArgvSubject(t *testing.T) {
 func TestPollerUDPIPPopulated(t *testing.T) {
 	tests := []struct {
 		addr   string
-		wantIP string
+		wantIP netip.Addr
 	}{
-		{"127.0.0.1:0", "127.0.0.1"},
-		{"[::1]:0", "::1"},
+		{"127.0.0.1:0", netip.MustParseAddr("127.0.0.1")},
+		{"[::1]:0", netip.IPv6Loopback()},
 	}
 
 	type bound struct {
 		port   uint16
-		wantIP string
+		wantIP netip.Addr
 		conn   net.PacketConn
 	}
 	var bounds []bound

--- a/pkg/util/port/portlist/poller_linux_test.go
+++ b/pkg/util/port/portlist/poller_linux_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"go4.org/mem"
 )
 
@@ -128,7 +129,7 @@ func TestParsePorts(t *testing.T) {
 				pm.keep = true
 				pm.needsProcName = true
 			}
-			if diff := cmp.Diff(li.known, tt.want, cmp.AllowUnexported(Port{}), cmp.AllowUnexported(portMeta{})); diff != "" {
+			if diff := cmp.Diff(li.known, tt.want, cmp.AllowUnexported(Port{}), cmp.AllowUnexported(portMeta{}), cmpopts.EquateComparable(netip.Addr{})); diff != "" {
 				t.Errorf("unexpected parsed ports (-got+want):\n%s", diff)
 			}
 		})

--- a/pkg/util/port/portlist/poller_test.go
+++ b/pkg/util/port/portlist/poller_test.go
@@ -7,10 +7,13 @@ package portlist
 
 import (
 	"net"
+	"net/netip"
 	"reflect"
 	"runtime"
 	"testing"
 )
+
+var ipv4Loopback = netip.MustParseAddr("127.0.0.1")
 
 func TestEqualLessThan(t *testing.T) {
 	tests := []struct {
@@ -80,26 +83,26 @@ func TestEqualLessThan(t *testing.T) {
 		},
 		{
 			"IP a < b",
-			Port{Proto: "tcp", Port: 100, IP: "0.0.0.0", Process: "proc1"},
-			Port{Proto: "tcp", Port: 100, IP: "127.0.0.1", Process: "proc1"},
+			Port{Proto: "tcp", Port: 100, IP: netip.IPv4Unspecified(), Process: "proc1"},
+			Port{Proto: "tcp", Port: 100, IP: ipv4Loopback, Process: "proc1"},
 			true,
 		},
 		{
 			"IP a > b",
-			Port{Proto: "tcp", Port: 100, IP: "127.0.0.1", Process: "proc1"},
-			Port{Proto: "tcp", Port: 100, IP: "0.0.0.0", Process: "proc1"},
+			Port{Proto: "tcp", Port: 100, IP: ipv4Loopback, Process: "proc1"},
+			Port{Proto: "tcp", Port: 100, IP: netip.IPv4Unspecified(), Process: "proc1"},
 			false,
 		},
 		{
 			"IP evaluated third",
-			Port{Proto: "tcp", Port: 100, IP: "0.0.0.0", Process: "proc2"},
-			Port{Proto: "tcp", Port: 100, IP: "127.0.0.1", Process: "proc1"},
+			Port{Proto: "tcp", Port: 100, IP: netip.IPv4Unspecified(), Process: "proc2"},
+			Port{Proto: "tcp", Port: 100, IP: ipv4Loopback, Process: "proc1"},
 			true,
 		},
 		{
 			"equal with IP",
-			Port{Proto: "tcp", Port: 100, IP: "0.0.0.0", Process: "proc1"},
-			Port{Proto: "tcp", Port: 100, IP: "0.0.0.0", Process: "proc1"},
+			Port{Proto: "tcp", Port: 100, IP: netip.IPv4Unspecified(), Process: "proc1"},
+			Port{Proto: "tcp", Port: 100, IP: netip.IPv4Unspecified(), Process: "proc1"},
 			false,
 		},
 	}
@@ -169,12 +172,12 @@ func TestSortAndDedup(t *testing.T) {
 		{
 			"Same port different IPs preserved",
 			List{
-				{Port: 80, Proto: "tcp", IP: "127.0.0.1", Process: "nginx"},
-				{Port: 80, Proto: "tcp", IP: "0.0.0.0", Process: "nginx"},
+				{Port: 80, Proto: "tcp", IP: ipv4Loopback, Process: "nginx"},
+				{Port: 80, Proto: "tcp", IP: netip.IPv4Unspecified(), Process: "nginx"},
 			},
 			List{
-				{Port: 80, Proto: "tcp", IP: "0.0.0.0", Process: "nginx"},
-				{Port: 80, Proto: "tcp", IP: "127.0.0.1", Process: "nginx"},
+				{Port: 80, Proto: "tcp", IP: netip.IPv4Unspecified(), Process: "nginx"},
+				{Port: 80, Proto: "tcp", IP: ipv4Loopback, Process: "nginx"},
 			},
 		},
 	}
@@ -276,16 +279,16 @@ func TestPollerIPPopulated(t *testing.T) {
 	}
 	tests := []struct {
 		addr   string
-		wantIP string
+		wantIP netip.Addr
 	}{
-		{"127.0.0.1:0", "127.0.0.1"},
-		{"[::1]:0", "::1"},
-		{"[::]:0", "::"},
+		{"127.0.0.1:0", ipv4Loopback},
+		{"[::1]:0", netip.IPv6Loopback()},
+		{"[::]:0", netip.IPv6Unspecified()},
 	}
 
 	type bound struct {
 		port   uint16
-		wantIP string
+		wantIP netip.Addr
 		ln     net.Listener
 	}
 	var bounds []bound

--- a/pkg/util/port/portlist/poller_windows.go
+++ b/pkg/util/port/portlist/poller_windows.go
@@ -7,6 +7,7 @@ package portlist
 
 import (
 	"errors"
+	"net/netip"
 )
 
 // ErrNotImplemented is the "not implemented" error given by `gopsutil` when an
@@ -27,7 +28,7 @@ type windowsImpl struct {
 type famPort struct {
 	proto string
 	port  uint16
-	ip    string
+	ip    netip.Addr
 	pid   uint32
 }
 
@@ -64,7 +65,7 @@ func (im *windowsImpl) AppendListeningPorts(base []Port) ([]Port, error) {
 		fp := famPort{
 			proto: "tcp",
 			port:  e.Local.Port(),
-			ip:    e.Local.Addr().Unmap().String(),
+			ip:    e.Local.Addr().Unmap(),
 			pid:   uint32(e.Pid),
 		}
 		pm, ok := im.known[fp]
@@ -83,7 +84,7 @@ func (im *windowsImpl) AppendListeningPorts(base []Port) ([]Port, error) {
 			port: Port{
 				Proto:   "tcp",
 				Port:    e.Local.Port(),
-				IP:      e.Local.Addr().Unmap().String(),
+				IP:      e.Local.Addr().Unmap(),
 				Process: process,
 				Pid:     e.Pid,
 			},

--- a/pkg/util/port/portlist/portlist.go
+++ b/pkg/util/port/portlist/portlist.go
@@ -9,13 +9,15 @@
 // listening on the current machine.
 package portlist
 
+import "net/netip"
+
 // Port is a listening port on the machine.
 type Port struct {
-	Proto   string // "tcp" or "udp"
-	Port    uint16 // port number
-	IP      string // listening IP address (e.g. "0.0.0.0", "127.0.0.1", "::")
-	Process string // optional process name, if found (requires suitable permissions)
-	Pid     int    // process ID, if known (requires suitable permissions)
+	Proto   string     // "tcp" or "udp"
+	Port    uint16     // port number
+	IP      netip.Addr // listening IP address (e.g. "0.0.0.0", "127.0.0.1", "::")
+	Process string     // optional process name, if found (requires suitable permissions)
+	Pid     int        // process ID, if known (requires suitable permissions)
 }
 
 // List is a list of Ports.


### PR DESCRIPTION
### What does this PR do?

Use `netip.Addr` for IP addresses rather than strings in the portlist poller.

### Motivation

Reduce memory allocations and be more compatible with related code.

### Describe how you validated your changes

### Additional Notes
