### PR TITLE
[Backport] [ACTP][FIX] Route enrollment and OPMS requests through agent proxy config

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -222,13 +222,13 @@ func (p *PrivateActionRunner) start(ctx context.Context) error {
 
 	keysManager := taskverifier.NewKeyManager(p.rcClient)
 	taskVerifier := taskverifier.NewTaskVerifier(keysManager, cfg)
-	opmsClient := opms.NewClient(cfg)
+	opmsClient := opms.NewClient(p.coreConfig, cfg)
 
 	p.workflowRunner, err = runners.NewWorkflowRunner(cfg, keysManager, taskVerifier, opmsClient, p.traceroute, p.eventPlatform)
 	if err != nil {
 		return err
 	}
-	p.commonRunner = runners.NewCommonRunner(cfg)
+	p.commonRunner = runners.NewCommonRunner(p.coreConfig, cfg)
 	err = p.workflowRunner.Start(ctx)
 	if err != nil {
 		return err
@@ -324,9 +324,9 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 		err              error
 	)
 	if apiKeyOnlyEnrollment {
-		enrollmentResult, err = enrollment.SelfEnrollApiKeyOnly(ctx, ddSite, runnerNamePrefix, apiKey, agentIdentifier, cfg.OpmsExtraHeaders)
+		enrollmentResult, err = enrollment.SelfEnrollApiKeyOnly(ctx, p.coreConfig, ddSite, runnerNamePrefix, apiKey, agentIdentifier, cfg.OpmsExtraHeaders)
 	} else {
-		enrollmentResult, err = enrollment.SelfEnroll(ctx, ddSite, runnerNamePrefix, apiKey, appKey, agentIdentifier, cfg.OpmsExtraHeaders)
+		enrollmentResult, err = enrollment.SelfEnroll(ctx, p.coreConfig, ddSite, runnerNamePrefix, apiKey, appKey, agentIdentifier, cfg.OpmsExtraHeaders)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("enrollment API call failed: %w", err)

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/regions"
@@ -78,6 +79,7 @@ func ShouldReenroll(agentIdentifier *AgentIdentifier, identity *PersistedIdentit
 // SelfEnroll performs self-registration using API key + application key.
 func SelfEnroll(
 	ctx context.Context,
+	cfg model.Reader,
 	ddSite,
 	runnerNamePrefix,
 	apiKey,
@@ -97,7 +99,7 @@ func SelfEnroll(
 	}
 
 	ddBaseURL := "https://api." + ddSite
-	publicClient := opms.NewPublicClient(ddBaseURL, extraHeaders)
+	publicClient := opms.NewPublicClient(cfg, ddBaseURL, extraHeaders)
 
 	runnerModes := []modes.Mode{modes.ModePull}
 
@@ -137,6 +139,7 @@ func SelfEnroll(
 // SelfEnrollApiKeyOnly performs self-registration using only an API key (no application key).
 func SelfEnrollApiKeyOnly(
 	ctx context.Context,
+	cfg model.Reader,
 	ddSite,
 	runnerNamePrefix,
 	apiKey string,
@@ -155,7 +158,7 @@ func SelfEnrollApiKeyOnly(
 	}
 
 	ddBaseURL := "https://api." + ddSite
-	publicClient := opms.NewPublicClient(ddBaseURL, extraHeaders)
+	publicClient := opms.NewPublicClient(cfg, ddBaseURL, extraHeaders)
 
 	runnerModes := []modes.Mode{modes.ModePull}
 

--- a/pkg/privateactionrunner/opms/BUILD.bazel
+++ b/pkg/privateactionrunner/opms/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/env",
+        "//pkg/config/model",
         "//pkg/privateactionrunner/adapters/config",
         "//pkg/privateactionrunner/adapters/constants",
         "//pkg/privateactionrunner/adapters/logging",
@@ -21,6 +22,7 @@ go_library(
         "//pkg/proto/pbgo/privateactionrunner/actionsclient",
         "//pkg/proto/pbgo/privateactionrunner/errorcode",
         "//pkg/util/flavor",
+        "//pkg/util/http",
         "@com_github_datadog_jsonapi//:jsonapi",
         "@com_github_go_jose_go_jose_v4//:go-jose",
     ],
@@ -32,6 +34,7 @@ go_test(
     embed = [":opms"],
     gotags = ["test"],
     deps = [
+        "//pkg/config/mock",
         "//pkg/privateactionrunner/adapters/config",
         "//pkg/privateactionrunner/adapters/constants",
         "@com_github_datadog_jsonapi//:jsonapi",

--- a/pkg/privateactionrunner/opms/opms.go
+++ b/pkg/privateactionrunner/opms/opms.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config/env"
-
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	app "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
@@ -32,6 +32,7 @@ import (
 	actionsclientpb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/actionsclient"
 	aperrorpb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/errorcode"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/jsonapi"
 )
 
@@ -144,10 +145,11 @@ type client struct {
 	lastTaskReceivedAt atomic.Pointer[time.Time]
 }
 
-func NewClient(cfg *config.Config) Client {
+func NewClient(coreCfg model.Reader, cfg *config.Config) Client {
 	return &client{
 		httpClient: &http.Client{
-			Timeout: time.Millisecond * time.Duration(cfg.OpmsRequestTimeout),
+			Timeout:   time.Duration(cfg.OpmsRequestTimeout) * time.Millisecond,
+			Transport: httputils.CreateHTTPTransport(coreCfg),
 		},
 		config:          cfg,
 		runnerStartedAt: time.Now().UTC(),

--- a/pkg/privateactionrunner/opms/opms_test.go
+++ b/pkg/privateactionrunner/opms/opms_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,9 +21,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	app "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 // newTestKey generates a throwaway ECDSA key for unit tests.
 func newTestKey(t *testing.T) *ecdsa.PrivateKey {
@@ -253,4 +259,59 @@ func TestHealthCheck_RetryAfterMs_PopulatedOnError(t *testing.T) {
 	require.Error(t, err)
 	require.NotNil(t, data)
 	assert.Equal(t, 3000*time.Millisecond, data.RetryAfter)
+}
+
+// ---------- proxy transport wiring ----------
+
+func TestNewClientHonorsProxyConfig(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("proxy.https", "https://proxy.example.com:3128")
+	parCfg := &config.Config{OpmsRequestTimeout: 5000}
+
+	c := NewClient(cfg, parCfg).(*client)
+
+	transport, ok := c.httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.Proxy)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.datadoghq.com/api/v2/on-prem-management-service/workflow-tasks/dequeue", nil)
+	proxyURL, err := transport.Proxy(req)
+	require.NoError(t, err)
+	assert.Equal(t, "https://proxy.example.com:3128", proxyURL.String())
+}
+
+func TestNewPublicClientHonorsProxyConfig(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("proxy.https", "https://proxy.example.com:3128")
+
+	pc := NewPublicClient(cfg, "https://api.datadoghq.com", nil).(*publicClient)
+
+	transport, ok := pc.httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.Proxy)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.datadoghq.com/api/unstable/on_prem_runners", nil)
+	proxyURL, err := transport.Proxy(req)
+	require.NoError(t, err)
+	assert.Equal(t, "https://proxy.example.com:3128", proxyURL.String())
+}
+
+func TestDoEnrollRequestUsesOwnHttpClient(t *testing.T) {
+	var transportCalled bool
+	p := &publicClient{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				transportCalled = true
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{}")),
+				}, nil
+			}),
+		},
+	}
+
+	_, _, err := p.doEnrollRequest(context.Background(), "https://app.datadoghq.com/enroll", []byte("{}"), "apikey", "")
+
+	require.NoError(t, err)
+	assert.True(t, transportCalled, "doEnrollRequest must use p.httpClient, not http.DefaultClient")
 }

--- a/pkg/privateactionrunner/opms/opms_test.go
+++ b/pkg/privateactionrunner/opms/opms_test.go
@@ -265,7 +265,7 @@ func TestHealthCheck_RetryAfterMs_PopulatedOnError(t *testing.T) {
 
 func TestNewClientHonorsProxyConfig(t *testing.T) {
 	cfg := configmock.New(t)
-	cfg.SetInTest("proxy.https", "https://proxy.example.com:3128")
+	cfg.SetWithoutSource("proxy.https", "https://proxy.example.com:3128")
 	parCfg := &config.Config{OpmsRequestTimeout: 5000}
 
 	c := NewClient(cfg, parCfg).(*client)
@@ -282,7 +282,7 @@ func TestNewClientHonorsProxyConfig(t *testing.T) {
 
 func TestNewPublicClientHonorsProxyConfig(t *testing.T) {
 	cfg := configmock.New(t)
-	cfg.SetInTest("proxy.https", "https://proxy.example.com:3128")
+	cfg.SetWithoutSource("proxy.https", "https://proxy.example.com:3128")
 
 	pc := NewPublicClient(cfg, "https://api.datadoghq.com", nil).(*publicClient)
 

--- a/pkg/privateactionrunner/opms/public_opms.go
+++ b/pkg/privateactionrunner/opms/public_opms.go
@@ -6,6 +6,7 @@
 package opms
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -14,12 +15,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	app "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/parversion"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/par"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/jsonapi"
 	"github.com/go-jose/go-jose/v4"
 )
@@ -64,12 +67,13 @@ type publicClient struct {
 	extraHeaders map[string]string
 }
 
-func NewPublicClient(ddBaseURL string, extraHeaders map[string]string) PublicClient {
+func NewPublicClient(cfg model.Reader, ddBaseURL string, extraHeaders map[string]string) PublicClient {
 	apiHost := strings.Replace(ddBaseURL, "https://", "", 1)
 	return &publicClient{
 		ddApiHost: apiHost,
 		httpClient: &http.Client{
-			Timeout: time.Millisecond * time.Duration(30_000),
+			Timeout:   30 * time.Second,
+			Transport: httputils.CreateHTTPTransport(cfg),
 		},
 		extraHeaders: extraHeaders,
 	}
@@ -172,7 +176,7 @@ func (p *publicClient) doEnrollRequestWithRetry(ctx context.Context, url string,
 // success. On non-2xx responses, returns the status code so the caller can
 // decide whether to retry.
 func (p *publicClient) doEnrollRequest(ctx context.Context, url string, body []byte, apiKey, appKey string) ([]byte, int, error) {
-	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(body)))
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to build runner creation request: %w", err)
 	}
@@ -188,7 +192,7 @@ func (p *publicClient) doEnrollRequest(ctx context.Context, url string, body []b
 		req.Header.Set(k, v)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to send runner creation request: %w", err)
 	}

--- a/pkg/privateactionrunner/runners/common_runner.go
+++ b/pkg/privateactionrunner/runners/common_runner.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/opms"
@@ -22,10 +23,11 @@ type CommonRunner struct {
 }
 
 func NewCommonRunner(
+	coreCfg model.Reader,
 	configuration *config.Config,
 ) *CommonRunner {
 	return &CommonRunner{
-		opmsClient: opms.NewClient(configuration),
+		opmsClient: opms.NewClient(coreCfg, configuration),
 		config:     configuration,
 	}
 }

--- a/releasenotes/notes/fix-par-enrollment-proxy-1ee08674f419430f.yaml
+++ b/releasenotes/notes/fix-par-enrollment-proxy-1ee08674f419430f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix Private Action Runner self-enrollment failing silently on hosts with no
+    direct internet access when a proxy is configured in ``datadog.yaml``.
+    Enrollment requests now respect the agent proxy settings
+    (``proxy.https``, ``proxy.http``, and ``no_proxy``).


### PR DESCRIPTION
Backport of https://github.com/DataDog/datadog-agent/pull/51843 into 7.80.x

## Summary

PAR self-enrollment and OPMS task requests now use the agent's proxy configuration from `datadog.yaml` (`proxy.https`, `proxy.http`, `no_proxy`). All PAR HTTP clients use `httputils.CreateHTTPTransport(cfg)`, matching the existing pattern in `autoconnections/client.go`.

## Motivation

Customers with no direct internet access and a proxy configured in `datadog.yaml` were stuck in an infinite enrollment crash loop. `doEnrollRequest` called `http.DefaultClient.Do` instead of the struct's own `p.httpClient`, bypassing the proxy entirely. The OPMS task client had the same gap (bare `http.Client` with no `Transport`). Both caused silent transport-level failures with no actionable error message.

## Changes

- `public_opms.go`: `NewPublicClient` now accepts `model.Reader` and builds its transport via `httputils.CreateHTTPTransport`. `doEnrollRequest` uses `p.httpClient` (was `http.DefaultClient`). Added `log.Errorf` on transport failures with a proxy config hint.
- `opms.go`: `NewClient` now accepts `model.Reader` and installs a proxy-aware transport.
- `enrollment.go`: `SelfEnroll` and `SelfEnrollApiKeyOnly` accept and thread `model.Reader` to `NewPublicClient`.
- `common_runner.go`: `NewCommonRunner` accepts `model.Reader` and threads it to `NewClient`.
- `privateactionrunner.go`: all call sites updated to pass `p.coreConfig`.
- `opms_test.go`: three new tests verify `NewClient` and `NewPublicClient` install a non-default transport, and that `doEnrollRequest` uses `p.httpClient`.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
