### PR TITLE
Dockerfiles: don't install recommended packages when upgrading

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -85,7 +85,7 @@ ENV DOCKER_DD_AGENT=true \
 
 # make sure we have recent dependencies -- CVE-fixing time!
 RUN apt update \
-  && apt full-upgrade -y \
+  && apt full-upgrade --no-install-recommends -y \
   # Install iproute2 package for the ss utility that is used by the network check.
   # When the network check will have switched from using ss to directly parsing /proc/net/tcp,
   # this can be removed

--- a/Dockerfiles/base-image/Dockerfile
+++ b/Dockerfiles/base-image/Dockerfile
@@ -48,8 +48,8 @@ LABEL maintainer="Datadog <package@datadoghq.com>"
 ENV DEBIAN_FRONTEND=noninteractive
 # make sure we have recent dependencies -- CVE-fixing time!
 RUN apt update && \
-    apt full-upgrade -y && \
-    apt install -y tzdata ca-certificates adduser && \
+    apt full-upgrade --no-install-recommends -y && \
+    apt install --no-install-recommends -y tzdata ca-certificates adduser && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### What does this PR do?

Don't install recommended packages when upgrading the default installed ones

### Motivation

Strip down our container images and reduce the amount of packages installed by default.

### Describe how you validated your changes

CI

### Additional Notes
