### PR TITLE
Handle truncated loclist fixed-size reads

### DIFF
--- a/pkg/dyninst/dwarf/loclist/BUILD.bazel
+++ b/pkg/dyninst/dwarf/loclist/BUILD.bazel
@@ -18,7 +18,10 @@ go_library(
 
 go_test(
     name = "loclist_test",
-    srcs = ["fuzz_test.go"],
+    srcs = [
+        "fuzz_test.go",
+        "parse_test.go",
+    ],
     embed = [":loclist"],
     gotags = ["test"],
 )

--- a/pkg/dyninst/dwarf/loclist/parse.go
+++ b/pkg/dyninst/dwarf/loclist/parse.go
@@ -13,6 +13,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
@@ -191,6 +192,10 @@ func ParseInstructions(data []byte, ptrSize uint8, totalByteSize uint32) ([]ir.P
 }
 
 func readFixedSize(reader *bytes.Buffer, size uint8) (uint64, error) {
+	if reader.Len() < int(size) {
+		return 0, io.ErrUnexpectedEOF
+	}
+
 	switch size {
 	case 1:
 		val, err := reader.ReadByte()

--- a/pkg/dyninst/dwarf/loclist/parse_test.go
+++ b/pkg/dyninst/dwarf/loclist/parse_test.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package loclist
+
+import "testing"
+
+func TestParseInstructionsAddrTruncated(t *testing.T) {
+	_, err := ParseInstructions([]byte{0x03}, 4, 12)
+	if err == nil {
+		t.Fatal("expected error for truncated DW_OP_addr payload")
+	}
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"61946876-a969-466a-8ece-01b2edd0f0d8","source":"chat","resourceId":"5ec849aa-2b02-4462-8dcd-e3f3273c00c7","workflowId":"e5412eb5-c656-4c81-ac6d-d80f0046a96a","codeChangeId":"e5412eb5-c656-4c81-ac6d-d80f0046a96a","sourceType":"action_platform_workflows"} -->
### What does this PR do?

Workflow Automation • [View in Workflow Automation](https://app.datadoghq.com/workflow/6c444a5c-2025-4f04-9d80-27cd665246c5)

- add a deterministic regression test for the fuzz input `[]byte{0x03}, ptrSize=4, totalByteSize=12` in `pkg/dyninst/dwarf/loclist`
- fix `readFixedSize` to return an error when the buffer does not contain enough bytes, instead of panicking
- include the new test file in the Bazel `loclist_test` target

### Motivation
The fuzz input exposed a panic in `ParseInstructions` when handling `DW_OP_addr` with a truncated payload. `readFixedSize` called `binary.LittleEndian.Uint32(reader.Next(4))` even when fewer than 4 bytes were available, causing an out-of-range panic. The parser should fail safely with an error for malformed DWARF data.

### Describe how you validated your changes
- reproduction before fix:
  - `GOENV_VERSION=1.26.3 go test -tags linux_bpf ./pkg/dyninst/dwarf/loclist -run TestParseInstructionsAddrTruncated -count=1`
  - observed panic: `index out of range [3] with length 0`
- verification after fix:
  - `GOENV_VERSION=1.26.3 go test -tags linux_bpf ./pkg/dyninst/dwarf/loclist -count=1`
  - result: all tests pass

### Additional Notes
- no behavior changes for valid inputs; only malformed/truncated fixed-size reads now return `io.ErrUnexpectedEOF`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/5ec849aa-2b02-4462-8dcd-e3f3273c00c7)

Comment @datadog to request changes