### PR TITLE
Add nydus-by-default image variant in internal image deploy

### DIFF
--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -10,22 +10,26 @@
   tags: ["arch:amd64", "specific:true"]
   timeout: 1h
   parallel:
-    matrix: # See https://github.com/DataDog/datadog-agent/pull/45778
-      - COMPRESSION: "zstd"
+    matrix:
+      - COMPRESSION: "-zstd"
         RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd"
-      - COMPRESSION: "nydus"
+      - COMPRESSION: "-nydus"
         RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
+      # We use nydus by default without adding the info in the tag
+      - COMPRESSION: ""
+        RELEASE_TAG_COMPRESSION_SUFFIX: ""
+        IMAGE_VERSION: tmpl-v25
   script:
     # Constant variables
     - export RELEASE_STAGING=""
     - export DYNAMIC_BUILD_RENDER_RULES="agent-build-only"
-    - export IMAGES_GIT_REF="master"
+    - export IMAGES_GIT_REF="florent.clarret/agent-test-new-nydus"
     # Job specific variables
     - export BASE_RELEASE_TAG="${CI_COMMIT_REF_NAME//\//-}"
     - export RELEASE_TAG="${BASE_RELEASE_TAG}${RELEASE_TAG_SUFFIX}${RELEASE_TAG_COMPRESSION_SUFFIX}"
     - export TMPL_SRC_IMAGE="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TMPL_SRC_IMAGE_SUFFIX}"
     # Specify the compression
-    - export IMAGE_VERSION="${IMAGE_VERSION}-${COMPRESSION}"
+    - export IMAGE_VERSION="${IMAGE_VERSION}${COMPRESSION}"
     # BUILD_TAG is always RELEASE_TAG
     - export BUILD_TAG="${RELEASE_TAG}"
     # Fetch Gitlab token


### PR DESCRIPTION
### What does this PR do?

Adds a new matrix entry in the internal image deploy job that builds an image using nydus by default, without adding it to the release tag. This relies on the new image template being added in [DataDog/images#10361](https://github.com/DataDog/images/pull/10361) (`tmpl-v25`).

Also fixes the compression suffix handling: `-zstd` and `-nydus` now include the dash in the `COMPRESSION` variable, so the `IMAGE_VERSION` export no longer needs to add a separator.

### Motivation

Part of [BARX-1184](https://datadoghq.atlassian.net/browse/BARX-1184). Using nydus by default (without exposing it in the tag) is a prerequisite to eventually removing the explicit nydus variant.

### Describe how you validated your changes

The pipeline will exercise the new matrix entry alongside the existing `-zstd` and `-nydus` variants.

### Additional Notes

- `IMAGES_GIT_REF` is temporarily pointing to `florent.clarret/agent-test-new-nydus` (the branch backing [DataDog/images#10361](https://github.com/DataDog/images/pull/10361)); it will be switched back to `master` once that images PR merges.

[BARX-1184]: https://datadoghq.atlassian.net/browse/BARX-1184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ