### PR TITLE
Minor bazel tests fixups

### DIFF
--- a/cmd/serverless-init/exitcode/BUILD.bazel
+++ b/cmd/serverless-init/exitcode/BUILD.bazel
@@ -15,5 +15,9 @@ dd_agent_go_test(
     name = "exitcode_test",
     srcs = ["exitcode_test.go"],
     embed = [":exitcode"],
-    target_compatible_with = ["@platforms//os:linux"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )

--- a/comp/core/autodiscovery/impl/BUILD.bazel
+++ b/comp/core/autodiscovery/impl/BUILD.bazel
@@ -1,7 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
-
-# gazelle:dd_agent_go_test on
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "impl",
@@ -62,7 +59,7 @@ go_library(
     ],
 )
 
-dd_agent_go_test(
+go_test(
     name = "impl_test",
     srcs = [
         "autoconfig_cel_test.go",
@@ -76,6 +73,7 @@ dd_agent_go_test(
         "store_test.go",
     ],
     embed = [":impl"],
+    gotags = ["test"],
     tags = ["manual"],  # keep
     deps = [
         "//comp/core",


### PR DESCRIPTION
### What does this PR do?

Apply 2 fixups prior to checking for test parity:
* Don't convert an unbuildable test to dd_agent_go_test (the go_library it depends on depends on the un-migrated `//pkg/flare` package)
* Ensure serverless-init/exitcode tests can run on macOS, as is the case with `dda`

### Motivation

* Test parity checking will only probe for `dd_agent_go_test`, but if a test is migrated to it, it must run & pass.
* `serverless-init/exitcode` currently runs and pass on macOS when executed through `dda inv test` 

### Describe how you validated your changes

Extracted from https://github.com/DataDog/datadog-agent/pull/50957 where it was tested and the parity checks pass

### Additional Notes
