### PR TITLE
feat(autoinstrumentation): compile SSI targets to policies and wire the mutator to the policy engine

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -147,6 +147,7 @@ core,github.com/DataDog/datadog-traceroute/tcp,Apache-2.0,"Copyright 2016-presen
 core,github.com/DataDog/datadog-traceroute/traceroute,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/datadog-traceroute/udp,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/datadog-traceroute/winconn,Apache-2.0,"Copyright 2016-present Datadog, Inc"
+core,github.com/DataDog/dd-policy-engine/go/policies,Apache-2.0,Copyright 2022 Datadog Inc
 core,github.com/DataDog/dd-trace-go/v2/appsec/events,Apache-2.0,"Copyright (c) 2016-Present, Datadog <info@datadoghq.com> | Copyright 2016 Datadog, Inc | Copyright 2016-Present Datadog, Inc"
 core,github.com/DataDog/dd-trace-go/v2/datastreams/options,Apache-2.0,"Copyright (c) 2016-Present, Datadog <info@datadoghq.com> | Copyright 2016 Datadog, Inc | Copyright 2016-Present Datadog, Inc"
 core,github.com/DataDog/dd-trace-go/v2/ddtrace,Apache-2.0,"Copyright (c) 2016-Present, Datadog <info@datadoghq.com> | Copyright 2016 Datadog, Inc | Copyright 2016-Present Datadog, Inc"

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -161,6 +161,7 @@ use_repo(
     "com_github_datadog_datadog_go_v5",
     "com_github_datadog_datadog_operator_api",
     "com_github_datadog_datadog_traceroute",
+    "com_github_datadog_dd_policy_engine_go",
     "com_github_datadog_dd_trace_go_v2",
     "com_github_datadog_ddtrivy",
     "com_github_datadog_ebpf_manager",

--- a/go.mod
+++ b/go.mod
@@ -166,6 +166,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.8.3
 	github.com/DataDog/datadog-operator/api v0.0.0-20260515125012-8e158b708444
 	github.com/DataDog/datadog-traceroute v1.0.17
+	github.com/DataDog/dd-policy-engine/go v0.0.0-20260619124759-08b73482a87e
 	github.com/DataDog/dd-trace-go/v2 v2.8.2
 	github.com/DataDog/ebpf-manager v0.7.18
 	github.com/DataDog/go-acl v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -2559,6 +2559,8 @@ github.com/DataDog/datadog-operator/api v0.0.0-20260515125012-8e158b708444 h1:ew
 github.com/DataDog/datadog-operator/api v0.0.0-20260515125012-8e158b708444/go.mod h1:zR/MNYiw871evAtspmVn/QpLlPlaakes4YZtQpRFQfU=
 github.com/DataDog/datadog-traceroute v1.0.17 h1:MyBJCb+pFLjN3tt0boZprYmyj4iegHmKzst5iWil/Dw=
 github.com/DataDog/datadog-traceroute v1.0.17/go.mod h1:gtDOEd1qCVGULNYdHULzFBbdDLJwpP+nJMKSXiuVi78=
+github.com/DataDog/dd-policy-engine/go v0.0.0-20260619124759-08b73482a87e h1:CxzF9fSzIjC8KM4mZAYmROk0Lbjn1g2mnSddWQObYIo=
+github.com/DataDog/dd-policy-engine/go v0.0.0-20260619124759-08b73482a87e/go.mod h1:nnthv5h9ibOnhF2U/8laUmHwYpM8rvVLzLYBklt8ytY=
 github.com/DataDog/dd-trace-go/v2 v2.8.2 h1:ZqF2M7j5DPG7PxkJpLIjF4L62LU/QnI86oOSAZjQC/U=
 github.com/DataDog/dd-trace-go/v2 v2.8.2/go.mod h1:o+fhXzd1mPT4Ji5YYcqIjORnNKWcS6m2eW4xqdJplRA=
 github.com/DataDog/ddtrivy v0.0.0-20260519164847-bf6bcaf2f9b7 h1:N9Ufc+tRU6BaVpxw0D60bvhqwsJ90r5ygXNIbx/kucg=

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/policy_matcher.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/policy_matcher.go
@@ -38,38 +38,42 @@ func newPolicyMatcher(ps []policies.Policy, wmeta workloadmeta.Component) *polic
 // Match returns the outcome of the first policy that matches the pod, mirroring
 // the "first match wins" semantics of the target mutator.
 func (m *policyMatcher) Match(pod *corev1.Pod) (policies.Outcome, bool) {
-	if m == nil || pod == nil {
+	idx := m.matchIndex(pod)
+	if idx < 0 {
 		return policies.Outcome{}, false
 	}
-	facts, err := m.factsForPod(pod)
-	if err != nil {
-		log.Debugf("policy matcher: could not build facts for pod in %q: %v", pod.Namespace, err)
-		return policies.Outcome{}, false
-	}
-	return policies.Decide(m.policies, facts)
+	return m.policies[idx].Outcome, true
 }
 
 // matchIndex returns the index of the first policy that matches the pod, or -1
-// if none match. It returns an error when a required fact (e.g. namespace
-// labels) could not be resolved, so the caller can abort matching rather than
-// risk an inaccurate decision.
-func (m *policyMatcher) matchIndex(pod *corev1.Pod) (int, error) {
+// if none match. Policies are evaluated in order (first match wins).
+//
+// A policy that reads namespace labels which could not be resolved (e.g. the
+// pod's namespace is absent from the workloadmeta store) is skipped rather than
+// fatal: it cannot be evaluated, so it is ignored, and the remaining policies
+// are still evaluated in order. This guarantees that an unrelated unresolvable
+// namespace rule never prevents an otherwise-matching rule from injecting.
+func (m *policyMatcher) matchIndex(pod *corev1.Pod) int {
 	if m == nil || pod == nil {
-		return -1, nil
+		return -1
 	}
-	facts, err := m.factsForPod(pod)
-	if err != nil {
-		return -1, err
-	}
+	facts, namespaceLabelsResolved := m.factsForPod(pod)
 	for i := range m.policies {
+		if !namespaceLabelsResolved && nodeUsesNamespaceLabels(m.policies[i].Rules) {
+			// Cannot evaluate this rule without namespace labels; ignore it.
+			continue
+		}
 		if policies.Evaluate(m.policies[i].Rules, facts) == policies.ResultTrue {
-			return i, nil
+			return i
 		}
 	}
-	return -1, nil
+	return -1
 }
 
-func (m *policyMatcher) factsForPod(pod *corev1.Pod) (policies.Facts, error) {
+// factsForPod builds the evaluation facts for a pod. The boolean reports whether
+// namespace labels were resolved: when a policy needs them but they cannot be
+// fetched, it is false and namespace-label rules are skipped by matchIndex.
+func (m *policyMatcher) factsForPod(pod *corev1.Pod) (policies.Facts, bool) {
 	facts := policies.Facts{
 		NamespaceName: pod.Namespace,
 		PodLabels:     pod.Labels,
@@ -77,11 +81,12 @@ func (m *policyMatcher) factsForPod(pod *corev1.Pod) (policies.Facts, error) {
 	if m.needsNamespaceLabels && m.wmeta != nil {
 		nsLabels, err := getNamespaceLabels(m.wmeta, pod.Namespace)
 		if err != nil {
-			return facts, err
+			log.Debugf("policy matcher: namespace labels unavailable for namespace %q, namespace-label rules will be skipped: %v", pod.Namespace, err)
+			return facts, false
 		}
 		facts.NamespaceLabels = nsLabels
 	}
-	return facts, nil
+	return facts, true
 }
 
 // usesNamespaceLabels reports whether any policy rule reads a namespace label,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/policy_matcher.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/policy_matcher.go
@@ -1,0 +1,111 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/dd-policy-engine/go/policies"
+)
+
+// policyMatcher evaluates SSI policies against pods using the pure Go policy
+// engine. It holds the effective ordered policy set (configuration policies,
+// optionally augmented with remote-config ones) and resolves the first match.
+type policyMatcher struct {
+	policies             []policies.Policy
+	wmeta                workloadmeta.Component
+	needsNamespaceLabels bool
+}
+
+// newPolicyMatcher builds a matcher over the given policies and records whether
+// any rule reads namespace labels, so we only pay the workloadmeta lookup when a
+// policy actually needs it.
+func newPolicyMatcher(ps []policies.Policy, wmeta workloadmeta.Component) *policyMatcher {
+	return &policyMatcher{
+		policies:             ps,
+		wmeta:                wmeta,
+		needsNamespaceLabels: usesNamespaceLabels(ps),
+	}
+}
+
+// Match returns the outcome of the first policy that matches the pod, mirroring
+// the "first match wins" semantics of the target mutator.
+func (m *policyMatcher) Match(pod *corev1.Pod) (policies.Outcome, bool) {
+	if m == nil || pod == nil {
+		return policies.Outcome{}, false
+	}
+	facts, err := m.factsForPod(pod)
+	if err != nil {
+		log.Debugf("policy matcher: could not build facts for pod in %q: %v", pod.Namespace, err)
+		return policies.Outcome{}, false
+	}
+	return policies.Decide(m.policies, facts)
+}
+
+// matchIndex returns the index of the first policy that matches the pod, or -1
+// if none match. It returns an error when a required fact (e.g. namespace
+// labels) could not be resolved, so the caller can abort matching rather than
+// risk an inaccurate decision.
+func (m *policyMatcher) matchIndex(pod *corev1.Pod) (int, error) {
+	if m == nil || pod == nil {
+		return -1, nil
+	}
+	facts, err := m.factsForPod(pod)
+	if err != nil {
+		return -1, err
+	}
+	for i := range m.policies {
+		if policies.Evaluate(m.policies[i].Rules, facts) == policies.ResultTrue {
+			return i, nil
+		}
+	}
+	return -1, nil
+}
+
+func (m *policyMatcher) factsForPod(pod *corev1.Pod) (policies.Facts, error) {
+	facts := policies.Facts{
+		NamespaceName: pod.Namespace,
+		PodLabels:     pod.Labels,
+	}
+	if m.needsNamespaceLabels && m.wmeta != nil {
+		nsLabels, err := getNamespaceLabels(m.wmeta, pod.Namespace)
+		if err != nil {
+			return facts, err
+		}
+		facts.NamespaceLabels = nsLabels
+	}
+	return facts, nil
+}
+
+// usesNamespaceLabels reports whether any policy rule reads a namespace label,
+// so the matcher can skip the workloadmeta lookup otherwise.
+func usesNamespaceLabels(ps []policies.Policy) bool {
+	for i := range ps {
+		if nodeUsesNamespaceLabels(ps[i].Rules) {
+			return true
+		}
+	}
+	return false
+}
+
+func nodeUsesNamespaceLabels(n *policies.Node) bool {
+	if n == nil {
+		return false
+	}
+	if n.Eval != nil {
+		return n.Eval.Source == policies.SourceNamespaceLabel
+	}
+	for _, c := range n.Children {
+		if nodeUsesNamespaceLabels(c) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/policy_matcher_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/policy_matcher_test.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func podWith(ns string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Labels:    labels,
+		},
+	}
+}
+
+func TestPolicyMatcherPodLabels(t *testing.T) {
+	targets := []Target{
+		{
+			Name:           "java",
+			PodSelector:    &PodSelector{MatchLabels: map[string]string{"app": "db"}},
+			TracerVersions: map[string]string{"java": "latest"},
+		},
+		{
+			Name:           "catch-all",
+			TracerVersions: map[string]string{"php": "latest"},
+		},
+	}
+
+	m := newPolicyMatcher(policiesFromTargets(targets), nil)
+	if m.needsNamespaceLabels {
+		t.Errorf("matcher should not require namespace labels for pod-label targets")
+	}
+
+	out, ok := m.Match(podWith("any", map[string]string{"app": "db"}))
+	if !ok || out.TracerVersions["java"] != "latest" {
+		t.Fatalf("db pod: got %+v ok=%v", out, ok)
+	}
+
+	out, ok = m.Match(podWith("any", map[string]string{"app": "web"}))
+	if !ok || out.TracerVersions["php"] != "latest" {
+		t.Fatalf("web pod should hit catch-all: got %+v ok=%v", out, ok)
+	}
+}
+
+func TestPolicyMatcherDetectsNamespaceLabels(t *testing.T) {
+	targets := []Target{{
+		Name:              "by-ns-label",
+		NamespaceSelector: &NamespaceSelector{MatchLabels: map[string]string{"instrument": "true"}},
+	}}
+	m := newPolicyMatcher(policiesFromTargets(targets), nil)
+	if !m.needsNamespaceLabels {
+		t.Errorf("matcher should require namespace labels when a policy reads them")
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_matching_change_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_matching_change_test.go
@@ -9,22 +9,23 @@ package autoinstrumentation
 
 import "testing"
 
-// TestMatching_NamespaceMissingFromStore documents an intentional behavior change
-// introduced by the policy-engine matcher.
+// TestMatching_UnresolvableNamespaceRuleIsSkipped documents an intentional
+// behavior change introduced by the policy-engine matcher.
 //
-// When a pod's namespace is absent from the workloadmeta store and at least one
-// target reads namespace labels, the matcher cannot resolve the facts it needs
-// and declines to inject (fail-safe: no injection on an unresolved namespace).
+// When a pod's namespace is absent from the workloadmeta store, a rule that
+// reads namespace labels cannot be evaluated. The matcher now ignores only that
+// rule and keeps evaluating the remaining rules in order, so an unresolvable
+// namespace rule never blocks an otherwise-matching rule from injecting.
 //
-// The legacy label-selector matcher was order-dependent here: a pod-only target
-// placed before the namespace-label target would match without ever resolving
-// namespace labels, so the same pod would be injected. The policy matcher
-// resolves namespace labels once, up front, which removes that order dependence
-// at the cost of not matching the earlier pod-only target in this case. This is
-// considered an improvement (consistent, order-independent fail-safe) and is
-// pinned here so the behavior is explicit and intentional rather than accidental.
-func TestMatching_NamespaceMissingFromStore(t *testing.T) {
-	const cfg = `
+// The legacy label-selector matcher instead aborted all matching as soon as it
+// reached a rule whose namespace could not be resolved (returning "no match").
+// It only injected in this situation by accident of ordering: if a matching
+// pod-only rule happened to come first, it short-circuited before the
+// unresolvable rule was reached. These cases pin the new, order-independent
+// behavior; the "rule first" case is the one that changes versus the legacy
+// matcher (it would previously have aborted).
+func TestMatching_UnresolvableNamespaceRuleIsSkipped(t *testing.T) {
+	const podRuleFirst = `
 apm_config:
   instrumentation:
     enabled: true
@@ -42,9 +43,30 @@ apm_config:
         ddTraceVersions:
           python: "default"
 `
-	// No namespace is registered in the store, so namespace-label resolution
-	// fails for the "ghost" namespace and matching is aborted.
-	runMatchCases(t, cfg, []matchCase{
-		{name: "unresolved namespace declines injection even for an earlier pod-only target", ns: "ghost", podLabels: map[string]string{"app": "web"}, want: ""},
+	const nsRuleFirst = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "ns-label"
+        namespaceSelector:
+          matchLabels:
+            instrument: "true"
+        ddTraceVersions:
+          python: "default"
+      - name: "pod-only"
+        podSelector:
+          matchLabels:
+            app: "web"
+        ddTraceVersions:
+          java: "default"
+`
+	// No namespace is registered in the store, so the namespace-label rule
+	// cannot be evaluated for the "ghost" namespace and is skipped.
+	runMatchCases(t, podRuleFirst, []matchCase{
+		{name: "pod-only rule before the unresolvable rule still matches", ns: "ghost", podLabels: map[string]string{"app": "web"}, want: "pod-only"},
+	})
+	runMatchCases(t, nsRuleFirst, []matchCase{
+		{name: "unresolvable rule first does not block the pod-only rule", ns: "ghost", podLabels: map[string]string{"app": "web"}, want: "pod-only"},
 	})
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_matching_change_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_matching_change_test.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import "testing"
+
+// TestMatching_NamespaceMissingFromStore documents an intentional behavior change
+// introduced by the policy-engine matcher.
+//
+// When a pod's namespace is absent from the workloadmeta store and at least one
+// target reads namespace labels, the matcher cannot resolve the facts it needs
+// and declines to inject (fail-safe: no injection on an unresolved namespace).
+//
+// The legacy label-selector matcher was order-dependent here: a pod-only target
+// placed before the namespace-label target would match without ever resolving
+// namespace labels, so the same pod would be injected. The policy matcher
+// resolves namespace labels once, up front, which removes that order dependence
+// at the cost of not matching the earlier pod-only target in this case. This is
+// considered an improvement (consistent, order-independent fail-safe) and is
+// pinned here so the behavior is explicit and intentional rather than accidental.
+func TestMatching_NamespaceMissingFromStore(t *testing.T) {
+	const cfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "pod-only"
+        podSelector:
+          matchLabels:
+            app: "web"
+        ddTraceVersions:
+          java: "default"
+      - name: "ns-label"
+        namespaceSelector:
+          matchLabels:
+            instrument: "true"
+        ddTraceVersions:
+          python: "default"
+`
+	// No namespace is registered in the store, so namespace-label resolution
+	// fails for the "ghost" namespace and matching is aborted.
+	runMatchCases(t, cfg, []matchCase{
+		{name: "unresolved namespace declines injection even for an earlier pod-only target", ns: "ghost", podLabels: map[string]string{"app": "web"}, want: ""},
+	})
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_matching_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_matching_test.go
@@ -1,0 +1,357 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+// This file is a behavioral characterization (golden master) of the target
+// matcher: which target a pod resolves to for every supported selector shape
+// and for the "first match wins" ordering rule. It exercises the matcher
+// exclusively through the public TargetMutator API (NewTargetMutator +
+// getMatchingTarget), so the exact same suite runs against the legacy
+// label-selector implementation and the policy-engine implementation and proves
+// they agree.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// matchCase is a single (pod -> matched target name) expectation.
+type matchCase struct {
+	name      string
+	ns        string
+	podLabels map[string]string
+	want      string // matched target name, "" when no target matches
+}
+
+func newMatchTestWmeta(t *testing.T, namespaces ...workloadmeta.KubernetesMetadata) workloadmetamock.Mock {
+	t.Helper()
+	wmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		fx.Supply(coreconfig.Params{}),
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		fx.Provide(func() coreconfig.Component { return coreconfig.NewMock(t) }),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+	for i := range namespaces {
+		wmeta.Set(&namespaces[i])
+	}
+	return wmeta
+}
+
+func newMatchMutator(t *testing.T, yamlCfg string, wmeta workloadmeta.Component) *TargetMutator {
+	t.Helper()
+	mockConfig := configmock.NewFromYAML(t, yamlCfg)
+	mockConfig.SetInTest("admission_controller.auto_instrumentation.container_registry", "registry")
+	config, err := NewConfig(mockConfig)
+	require.NoError(t, err)
+	m, err := NewTargetMutator(config, wmeta, imageResolver, nil)
+	require.NoError(t, err)
+	return m
+}
+
+// runMatchCases builds one mutator per case from the shared config so that the
+// workloadmeta store can carry per-case namespace labels.
+func runMatchCases(t *testing.T, yamlCfg string, cases []matchCase, namespaces ...workloadmeta.KubernetesMetadata) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wmeta := newMatchTestWmeta(t, namespaces...)
+			m := newMatchMutator(t, yamlCfg, wmeta)
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: tc.ns, Labels: tc.podLabels}}
+			got := ""
+			if target := m.getMatchingTarget(pod); target != nil {
+				got = target.name
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestMatching_Precedence verifies the "first match wins" ordering rule when a
+// pod satisfies more than one target.
+func TestMatching_Precedence(t *testing.T) {
+	const cfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "db"
+        podSelector:
+          matchLabels:
+            app: "db"
+        ddTraceVersions:
+          java: "default"
+      - name: "router"
+        podSelector:
+          matchLabels:
+            webserver: "user"
+        ddTraceVersions:
+          php: "default"
+      - name: "catch-all"
+        ddTraceVersions:
+          js: "default"
+`
+	runMatchCases(t, cfg, []matchCase{
+		{name: "db pod hits db", podLabels: map[string]string{"app": "db"}, want: "db"},
+		{name: "router pod hits router", podLabels: map[string]string{"webserver": "user"}, want: "router"},
+		{name: "pod matching db and router resolves to the first", podLabels: map[string]string{"app": "db", "webserver": "user"}, want: "db"},
+		{name: "pod matching router and catch-all resolves to router", podLabels: map[string]string{"webserver": "user", "x": "y"}, want: "router"},
+		{name: "unrelated pod falls through to catch-all", podLabels: map[string]string{"other": "x"}, want: "catch-all"},
+		{name: "empty pod falls through to catch-all", podLabels: map[string]string{}, want: "catch-all"},
+	})
+}
+
+// TestMatching_PodMatchLabels verifies that pod matchLabels are ANDed and that
+// extra labels on the pod do not prevent a match.
+func TestMatching_PodMatchLabels(t *testing.T) {
+	const cfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "multi"
+        podSelector:
+          matchLabels:
+            app: "web"
+            tier: "frontend"
+        ddTraceVersions:
+          java: "default"
+`
+	runMatchCases(t, cfg, []matchCase{
+		{name: "all labels present matches", podLabels: map[string]string{"app": "web", "tier": "frontend"}, want: "multi"},
+		{name: "extra labels still match", podLabels: map[string]string{"app": "web", "tier": "frontend", "extra": "x"}, want: "multi"},
+		{name: "missing one label does not match", podLabels: map[string]string{"app": "web"}, want: ""},
+		{name: "wrong value does not match", podLabels: map[string]string{"app": "web", "tier": "backend"}, want: ""},
+	})
+}
+
+// TestMatching_PodExpressionIn covers the In operator on a pod selector.
+func TestMatching_PodExpressionIn(t *testing.T) {
+	const cfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "in"
+        podSelector:
+          matchExpressions:
+            - key: "lang"
+              operator: "In"
+              values: ["java", "go"]
+`
+	runMatchCases(t, cfg, []matchCase{
+		{name: "value in set matches", podLabels: map[string]string{"lang": "go"}, want: "in"},
+		{name: "value not in set does not match", podLabels: map[string]string{"lang": "ruby"}, want: ""},
+		{name: "absent key does not match", podLabels: map[string]string{}, want: ""},
+	})
+}
+
+// TestMatching_PodExpressionNotIn covers the NotIn operator, including the
+// Kubernetes rule that an absent key matches NotIn.
+func TestMatching_PodExpressionNotIn(t *testing.T) {
+	const cfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "notin"
+        podSelector:
+          matchExpressions:
+            - key: "app"
+              operator: "NotIn"
+              values: ["app1", "app2"]
+`
+	runMatchCases(t, cfg, []matchCase{
+		{name: "value outside set matches", podLabels: map[string]string{"app": "app3"}, want: "notin"},
+		{name: "value in set does not match", podLabels: map[string]string{"app": "app1"}, want: ""},
+		{name: "absent key matches notin", podLabels: map[string]string{}, want: "notin"},
+	})
+}
+
+// TestMatching_PodExpressionExists covers Exists and DoesNotExist.
+func TestMatching_PodExpressionExists(t *testing.T) {
+	const existsCfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "exists"
+        podSelector:
+          matchExpressions:
+            - key: "tier"
+              operator: "Exists"
+`
+	runMatchCases(t, existsCfg, []matchCase{
+		{name: "key present matches", podLabels: map[string]string{"tier": "frontend"}, want: "exists"},
+		{name: "key absent does not match", podLabels: map[string]string{"other": "x"}, want: ""},
+	})
+
+	const doesNotExistCfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "dne"
+        podSelector:
+          matchExpressions:
+            - key: "deprecated"
+              operator: "DoesNotExist"
+`
+	runMatchCases(t, doesNotExistCfg, []matchCase{
+		{name: "key absent matches", podLabels: map[string]string{"other": "x"}, want: "dne"},
+		{name: "key present does not match", podLabels: map[string]string{"deprecated": "true"}, want: ""},
+	})
+}
+
+// TestMatching_NamespaceMatchNames covers namespace selection by name. matchNames
+// does not require namespace labels, so no workloadmeta entry is needed.
+func TestMatching_NamespaceMatchNames(t *testing.T) {
+	const cfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "by-name"
+        namespaceSelector:
+          matchNames: ["payments", "billing"]
+        ddTraceVersions:
+          java: "default"
+`
+	runMatchCases(t, cfg, []matchCase{
+		{name: "listed namespace matches", ns: "billing", want: "by-name"},
+		{name: "other listed namespace matches", ns: "payments", want: "by-name"},
+		{name: "unlisted namespace does not match", ns: "default", want: ""},
+	})
+}
+
+// TestMatching_NamespaceMatchLabels covers namespace selection by label, which
+// requires the namespace metadata to be present in the workloadmeta store.
+func TestMatching_NamespaceMatchLabels(t *testing.T) {
+	const cfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "by-ns-label"
+        namespaceSelector:
+          matchLabels:
+            instrument: "true"
+        ddTraceVersions:
+          java: "default"
+`
+	runMatchCases(t, cfg, []matchCase{
+		{name: "labeled namespace matches", ns: "labeled", want: "by-ns-label"},
+		{name: "unlabeled namespace does not match", ns: "plain", want: ""},
+	},
+		newTestNamespace("labeled", map[string]string{"instrument": "true"}),
+		newTestNamespace("plain", map[string]string{"other": "x"}),
+	)
+}
+
+// TestMatching_NamespaceExpressions covers namespace matchExpressions (In and
+// Exists ANDed together).
+func TestMatching_NamespaceExpressions(t *testing.T) {
+	const cfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "ns-expr"
+        namespaceSelector:
+          matchExpressions:
+            - key: "team"
+              operator: "In"
+              values: ["payments"]
+            - key: "instrument"
+              operator: "Exists"
+        ddTraceVersions:
+          java: "default"
+`
+	runMatchCases(t, cfg, []matchCase{
+		{name: "both expressions satisfied matches", ns: "good", want: "ns-expr"},
+		{name: "in fails does not match", ns: "wrong-team", want: ""},
+		{name: "exists fails does not match", ns: "no-instrument", want: ""},
+	},
+		newTestNamespace("good", map[string]string{"team": "payments", "instrument": "yes"}),
+		newTestNamespace("wrong-team", map[string]string{"team": "other", "instrument": "yes"}),
+		newTestNamespace("no-instrument", map[string]string{"team": "payments"}),
+	)
+}
+
+// TestMatching_CombinedNamespaceAndPod verifies that namespace and pod selectors
+// on the same target are ANDed.
+func TestMatching_CombinedNamespaceAndPod(t *testing.T) {
+	const cfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "combined"
+        namespaceSelector:
+          matchNames: ["login"]
+        podSelector:
+          matchLabels:
+            app: "resolver"
+        ddTraceVersions:
+          java: "default"
+`
+	runMatchCases(t, cfg, []matchCase{
+		{name: "namespace and pod both match", ns: "login", podLabels: map[string]string{"app": "resolver"}, want: "combined"},
+		{name: "pod mismatch in matching namespace", ns: "login", podLabels: map[string]string{"app": "other"}, want: ""},
+		{name: "matching pod in wrong namespace", ns: "other", podLabels: map[string]string{"app": "resolver"}, want: ""},
+	})
+}
+
+// TestMatching_EmptyTargetMatchesEverything verifies that a target without any
+// selector matches every pod in every namespace.
+func TestMatching_EmptyTargetMatchesEverything(t *testing.T) {
+	const cfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "default"
+        ddTraceVersions:
+          java: "default"
+`
+	runMatchCases(t, cfg, []matchCase{
+		{name: "labeled pod matches", ns: "whatever", podLabels: map[string]string{"any": "thing"}, want: "default"},
+		{name: "empty pod matches", ns: "elsewhere", want: "default"},
+	})
+}
+
+// TestMatching_DisabledNamespace verifies that a disabled namespace short-circuits
+// matching even when a target would otherwise apply.
+func TestMatching_DisabledNamespace(t *testing.T) {
+	const cfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    disabled_namespaces: ["infra"]
+    targets:
+      - name: "all"
+        ddTraceVersions:
+          java: "default"
+`
+	runMatchCases(t, cfg, []matchCase{
+		{name: "disabled namespace never matches", ns: "infra", want: ""},
+		{name: "other namespace matches", ns: "app", want: "all"},
+	})
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -406,11 +406,7 @@ func (m *TargetMutator) getMatchingTarget(pod *corev1.Pod) *targetInternal {
 
 	// The matcher and targets are aligned by index, so the first matching
 	// policy resolves directly to its injection config (first match wins).
-	idx, err := m.matcher.matchIndex(pod)
-	if err != nil {
-		log.Errorf("error encountered matching targets, aborting all together to avoid inaccurate match: %v", err)
-		return nil
-	}
+	idx := m.matcher.matchIndex(pod)
 	if idx < 0 || idx >= len(m.targets) {
 		return nil
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/dd-policy-engine/go/policies"
 )
 
 const (
@@ -35,9 +36,13 @@ const (
 
 // TargetMutator is an autoinstrumentation mutator that filters pods based on the target based workload selection.
 type TargetMutator struct {
-	enabled                       bool
-	core                          *mutatorCore
-	targets                       []targetInternal
+	enabled bool
+	core    *mutatorCore
+	targets []targetInternal
+	// matcher evaluates the policies derived from the configuration targets.
+	// matcher.policies and targets are aligned by index, so a match resolves
+	// directly to its injection config.
+	matcher                       *policyMatcher
 	disabledNamespaces            map[string]bool
 	securityClientLibraryMutator  containerMutator
 	profilingClientLibraryMutator containerMutator
@@ -63,11 +68,19 @@ func NewTargetMutator(config *Config, wmeta workloadmeta.Component, imageResolve
 	// If there are no targets, we should fall back to enabledNamespace/libVersions. If those are also not defined, the
 	// expected behavior is to inject all pods into all namespaces.
 	var internalTargets []targetInternal
+	// configPolicies is the policy form of the configuration targets, aligned
+	// by index with internalTargets. Pod matching is delegated to the native
+	// policy engine; an empty set (disabled mutator) naturally matches nothing.
+	var configPolicies []policies.Policy
 	if config.Instrumentation.Enabled {
 		targets := config.Instrumentation.Targets
 		if len(targets) == 0 {
 			targets = append(targets, createDefaultTarget(config.Instrumentation.EnabledNamespaces, config.Instrumentation.LibVersions))
 		}
+
+		// Lower the configuration targets into policies once, at the config
+		// boundary. Everything past this point matches on policies only.
+		configPolicies = policiesFromTargets(targets)
 
 		// Convert the targets to internal format.
 		internalTargets = make([]targetInternal, len(targets))
@@ -146,6 +159,7 @@ func NewTargetMutator(config *Config, wmeta workloadmeta.Component, imageResolve
 	m := &TargetMutator{
 		enabled:                       config.Instrumentation.Enabled,
 		targets:                       internalTargets,
+		matcher:                       newPolicyMatcher(configPolicies, wmeta),
 		disabledNamespaces:            disabledNamespacesMap,
 		securityClientLibraryMutator:  config.securityClientLibraryMutator,
 		profilingClientLibraryMutator: config.profilingClientLibraryMutator,
@@ -374,6 +388,11 @@ func (m *TargetMutator) getTargetFromAnnotation(pod *corev1.Pod) *annotationResu
 }
 
 // getMatchingTarget filters a pod based on the targets. It returns the target to inject.
+//
+// Matching is delegated to the native policy engine: each target is compiled
+// into an equivalent policy (namespace and pod selectors ANDed together) and
+// the first policy that evaluates to true wins, preserving the previous
+// first-match semantics without relying on CGO or k8s label selectors.
 func (m *TargetMutator) getMatchingTarget(pod *corev1.Pod) *targetInternal {
 	// If instrumentation is disabled, we don't need to check the targets.
 	if !m.enabled {
@@ -385,32 +404,19 @@ func (m *TargetMutator) getMatchingTarget(pod *corev1.Pod) *targetInternal {
 		return nil
 	}
 
-	// Check if the pod matches any of the targets. The first match wins.
-	for _, target := range m.targets {
-		// Check the pod namespace against the namespace selector.
-		matches, err := target.matchesNamespaceSelector(pod.Namespace)
-		if err != nil {
-			log.Errorf("error encountered matching targets, aborting all together to avoid inaccurate match: %v", err)
-			return nil
-
-		}
-		if !matches {
-			continue
-		}
-
-		// Check the pod labels against the pod selector.
-		if !target.matchesPodSelector(pod.Labels) {
-			continue
-		}
-
-		log.Debugf("Pod %q matched target %q", mutatecommon.PodString(pod), target.name)
-
-		// If the namespace and pod selector match, return the libraries to inject.
-		return &target
+	// The matcher and targets are aligned by index, so the first matching
+	// policy resolves directly to its injection config (first match wins).
+	idx, err := m.matcher.matchIndex(pod)
+	if err != nil {
+		log.Errorf("error encountered matching targets, aborting all together to avoid inaccurate match: %v", err)
+		return nil
+	}
+	if idx < 0 || idx >= len(m.targets) {
+		return nil
 	}
 
-	// No target matched.
-	return nil
+	log.Debugf("Pod %q matched target %q", mutatecommon.PodString(pod), m.targets[idx].name)
+	return &m.targets[idx]
 }
 
 func (t targetInternal) matchesNamespaceSelector(namespace string) (bool, error) {
@@ -433,10 +439,6 @@ func (t targetInternal) matchesNamespaceSelector(namespace string) (bool, error)
 	// Check if the pod namespace is in the match names.
 	_, ok := t.enabledNamespaces[namespace]
 	return ok, nil
-}
-
-func (t targetInternal) matchesPodSelector(podLabels map[string]string) bool {
-	return t.podSelector.Matches(labels.Set(podLabels))
 }
 
 // createDefaultTarget is used when there are no targets. If a user configures enabledNamespaces and libVersions, which

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -664,7 +664,11 @@ func TestGetTargetLibraries(t *testing.T) {
 			},
 			expected: nil,
 		},
-		"missing namespace in store gets no tracers": {
+		// When the namespace is absent from the store, the namespace-label rule
+		// ("Enabled Prod Namespaces") cannot be evaluated and is skipped, so the
+		// pod falls through to the selector-less "Default" target rather than
+		// aborting all matching.
+		"missing namespace in store falls through to the default target": {
 			configPath: "testdata/filter.yaml",
 			in: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -672,7 +676,11 @@ func TestGetTargetLibraries(t *testing.T) {
 					Labels:    map[string]string{},
 				},
 			},
-			expected: nil,
+			expected: &targetInternal{
+				libVersions: []libInfo{
+					defaultLibInfoWithVersion(js, "v5"),
+				},
+			},
 		},
 		"unset tracer versions applies all tracers": {
 			configPath: "testdata/filter.yaml",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/targets.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/targets.go
@@ -1,0 +1,123 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/dd-policy-engine/go/policies"
+)
+
+// policiesFromTargets lowers an ordered list of SSI configuration targets into
+// an equivalent ordered list of policies. Evaluating the result reproduces the
+// native target matcher: namespace and pod selectors are ANDed, match-expressions
+// and match-labels are ANDed within a selector, and a target with no selectors
+// matches every workload.
+//
+// This is the static-configuration counterpart of the remote-config dd-wls
+// parser: both produce policies.Policy, which is the single shape the matcher
+// understands. The targets configuration is an autoinstrumentation concept, so
+// the lowering lives here rather than in the policies engine package.
+func policiesFromTargets(ts []Target) []policies.Policy {
+	out := make([]policies.Policy, 0, len(ts))
+	for _, t := range ts {
+		var conds []*policies.Node
+		if t.NamespaceSelector != nil {
+			conds = append(conds, namespacePolicyConds(t.NamespaceSelector)...)
+		}
+		if t.PodSelector != nil {
+			conds = append(conds, podPolicyConds(t.PodSelector)...)
+		}
+		out = append(out, policies.Policy{
+			Name:  t.Name,
+			Rules: policies.And(conds),
+			Outcome: policies.Outcome{
+				Inject:         true,
+				TracerVersions: t.TracerVersions,
+				TracerConfigs:  tracerConfigsToEnvVars(t.TracerConfigs),
+			},
+		})
+	}
+	return out
+}
+
+func namespacePolicyConds(ns *NamespaceSelector) []*policies.Node {
+	var conds []*policies.Node
+	if len(ns.MatchNames) > 0 {
+		names := make([]*policies.Node, 0, len(ns.MatchNames))
+		for _, n := range ns.MatchNames {
+			names = append(names, policies.Leaf(policies.SourceNamespaceName, "", policies.CmpExact, n))
+		}
+		conds = append(conds, policies.Or(names))
+	}
+	conds = append(conds, matchLabelPolicyConds(policies.SourceNamespaceLabel, ns.MatchLabels)...)
+	for _, req := range ns.MatchExpressions {
+		conds = append(conds, exprPolicyCond(policies.SourceNamespaceLabel, req))
+	}
+	return conds
+}
+
+func podPolicyConds(ps *PodSelector) []*policies.Node {
+	conds := matchLabelPolicyConds(policies.SourcePodLabel, ps.MatchLabels)
+	for _, req := range ps.MatchExpressions {
+		conds = append(conds, exprPolicyCond(policies.SourcePodLabel, req))
+	}
+	return conds
+}
+
+func matchLabelPolicyConds(src policies.Source, m map[string]string) []*policies.Node {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	conds := make([]*policies.Node, 0, len(keys))
+	for _, k := range keys {
+		conds = append(conds, policies.Leaf(src, k, policies.CmpExact, m[k]))
+	}
+	return conds
+}
+
+func exprPolicyCond(src policies.Source, req SelectorMatchExpression) *policies.Node {
+	switch req.Operator {
+	case metav1.LabelSelectorOpIn:
+		return policies.Or(eqPolicyNodes(src, req.Key, req.Values))
+	case metav1.LabelSelectorOpNotIn:
+		return policies.Not(policies.Or(eqPolicyNodes(src, req.Key, req.Values)))
+	case metav1.LabelSelectorOpExists:
+		return policies.Leaf(src, req.Key, policies.CmpExists, "")
+	case metav1.LabelSelectorOpDoesNotExist:
+		return policies.Not(policies.Leaf(src, req.Key, policies.CmpExists, ""))
+	default:
+		return policies.AlwaysAbstain()
+	}
+}
+
+func eqPolicyNodes(src policies.Source, key string, values []string) []*policies.Node {
+	nodes := make([]*policies.Node, 0, len(values))
+	for _, v := range values {
+		nodes = append(nodes, policies.Leaf(src, key, policies.CmpExact, v))
+	}
+	return nodes
+}
+
+func tracerConfigsToEnvVars(configs []TracerConfig) []policies.EnvVar {
+	if len(configs) == 0 {
+		return nil
+	}
+	out := make([]policies.EnvVar, len(configs))
+	for i, c := range configs {
+		out[i] = policies.EnvVar{Name: c.Name, Value: c.Value}
+	}
+	return out
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/targets_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/targets_test.go
@@ -1,0 +1,329 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/dd-policy-engine/go/policies"
+)
+
+func decideName(ps []policies.Policy, f policies.Facts) string {
+	for i := range ps {
+		if policies.Evaluate(ps[i].Rules, f) == policies.ResultTrue {
+			return ps[i].Name
+		}
+	}
+	return ""
+}
+
+func TestPoliciesFromTargetsOutcome(t *testing.T) {
+	targets := []Target{{
+		Name:        "java",
+		PodSelector: &PodSelector{MatchLabels: map[string]string{"app": "db"}},
+		NamespaceSelector: &NamespaceSelector{
+			MatchExpressions: []SelectorMatchExpression{{
+				Key:      "team",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"payments"},
+			}},
+		},
+		TracerVersions: map[string]string{"java": "latest"},
+		TracerConfigs:  []TracerConfig{{Name: "DD_PROFILING_ENABLED", Value: "true"}},
+	}}
+
+	got := policiesFromTargets(targets)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(got))
+	}
+	p := got[0]
+	if p.Name != "java" || !p.Outcome.Inject {
+		t.Errorf("unexpected policy identity/outcome: %+v", p)
+	}
+	if p.Outcome.TracerVersions["java"] != "latest" {
+		t.Errorf("tracer versions not mapped: %+v", p.Outcome.TracerVersions)
+	}
+	if len(p.Outcome.TracerConfigs) != 1 || p.Outcome.TracerConfigs[0] != (policies.EnvVar{Name: "DD_PROFILING_ENABLED", Value: "true"}) {
+		t.Errorf("tracer config not mapped: %+v", p.Outcome.TracerConfigs)
+	}
+}
+
+// TestConvertPodLabelTargets reproduces the canonical SSI example: one target
+// for the "db-user" app (java) and one for the "user-request-router" with a
+// webserver=user pod label (php), in order.
+func TestConvertPodLabelTargets(t *testing.T) {
+	ts := []Target{
+		{
+			Name:           "db-user",
+			PodSelector:    &PodSelector{MatchLabels: map[string]string{"app": "db-user"}},
+			TracerVersions: map[string]string{"java": "latest"},
+		},
+		{
+			Name: "user-request-router",
+			PodSelector: &PodSelector{MatchLabels: map[string]string{
+				"app":       "user-request-router",
+				"webserver": "user",
+			}},
+			TracerVersions: map[string]string{"php": "latest"},
+		},
+	}
+	ps := policiesFromTargets(ts)
+
+	if got := decideName(ps, policies.Facts{PodLabels: map[string]string{"app": "db-user"}}); got != "db-user" {
+		t.Errorf("db-user pod matched %q", got)
+	}
+	if got := decideName(ps, policies.Facts{PodLabels: map[string]string{"app": "user-request-router", "webserver": "user"}}); got != "user-request-router" {
+		t.Errorf("router pod matched %q", got)
+	}
+	// matchLabels are ANDed: missing webserver label must not match the router.
+	if got := decideName(ps, policies.Facts{PodLabels: map[string]string{"app": "user-request-router"}}); got != "" {
+		t.Errorf("partial router pod matched %q want none", got)
+	}
+	if got := decideName(ps, policies.Facts{PodLabels: map[string]string{"app": "other"}}); got != "" {
+		t.Errorf("unrelated pod matched %q want none", got)
+	}
+}
+
+func TestConvertNotIn(t *testing.T) {
+	ts := []Target{{
+		Name: "all-but",
+		PodSelector: &PodSelector{MatchExpressions: []SelectorMatchExpression{{
+			Key:      "app",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   []string{"app1", "app2"},
+		}}},
+	}}
+	ps := policiesFromTargets(ts)
+
+	if got := decideName(ps, policies.Facts{PodLabels: map[string]string{"app": "app3"}}); got != "all-but" {
+		t.Errorf("app3 matched %q want all-but", got)
+	}
+	if got := decideName(ps, policies.Facts{PodLabels: map[string]string{"app": "app1"}}); got != "" {
+		t.Errorf("app1 matched %q want none", got)
+	}
+	// NotIn matches absent keys (Kubernetes semantics).
+	if got := decideName(ps, policies.Facts{PodLabels: map[string]string{}}); got != "all-but" {
+		t.Errorf("absent label matched %q want all-but", got)
+	}
+}
+
+func TestConvertInAndExists(t *testing.T) {
+	ts := []Target{{
+		Name: "expr",
+		PodSelector: &PodSelector{MatchExpressions: []SelectorMatchExpression{
+			{Key: "lang", Operator: metav1.LabelSelectorOpIn, Values: []string{"java", "go"}},
+			{Key: "tier", Operator: metav1.LabelSelectorOpExists},
+			{Key: "deprecated", Operator: metav1.LabelSelectorOpDoesNotExist},
+		}},
+	}}
+	ps := policiesFromTargets(ts)
+
+	match := policies.Facts{PodLabels: map[string]string{"lang": "go", "tier": "frontend"}}
+	if got := decideName(ps, match); got != "expr" {
+		t.Errorf("expected match, got %q", got)
+	}
+	// lang not in set
+	if got := decideName(ps, policies.Facts{PodLabels: map[string]string{"lang": "ruby", "tier": "x"}}); got != "" {
+		t.Errorf("ruby matched %q want none", got)
+	}
+	// tier missing
+	if got := decideName(ps, policies.Facts{PodLabels: map[string]string{"lang": "go"}}); got != "" {
+		t.Errorf("missing tier matched %q want none", got)
+	}
+	// deprecated present -> DoesNotExist fails
+	if got := decideName(ps, policies.Facts{PodLabels: map[string]string{"lang": "go", "tier": "x", "deprecated": "true"}}); got != "" {
+		t.Errorf("deprecated matched %q want none", got)
+	}
+}
+
+func TestConvertNamespaceSelectors(t *testing.T) {
+	ts := []Target{
+		{
+			Name:              "by-name",
+			NamespaceSelector: &NamespaceSelector{MatchNames: []string{"payments", "billing"}},
+			TracerVersions:    map[string]string{"java": "latest"},
+		},
+		{
+			Name:              "by-label",
+			NamespaceSelector: &NamespaceSelector{MatchLabels: map[string]string{"instrument": "true"}},
+			PodSelector:       &PodSelector{MatchLabels: map[string]string{"app": "web"}},
+		},
+	}
+	ps := policiesFromTargets(ts)
+
+	if got := decideName(ps, policies.Facts{NamespaceName: "billing"}); got != "by-name" {
+		t.Errorf("billing ns matched %q want by-name", got)
+	}
+	if got := decideName(ps, policies.Facts{NamespaceName: "default"}); got != "" {
+		t.Errorf("default ns matched %q want none", got)
+	}
+	matched := policies.Facts{
+		NamespaceName:   "default",
+		NamespaceLabels: map[string]string{"instrument": "true"},
+		PodLabels:       map[string]string{"app": "web"},
+	}
+	if got := decideName(ps, matched); got != "by-label" {
+		t.Errorf("labeled ns pod matched %q want by-label", got)
+	}
+}
+
+func TestConvertEmptyTargetMatchesEverything(t *testing.T) {
+	ps := policiesFromTargets([]Target{{Name: "default", TracerVersions: map[string]string{"java": "latest"}}})
+	out, ok := policies.Decide(ps, policies.Facts{NamespaceName: "anything", PodLabels: map[string]string{"x": "y"}})
+	if !ok || out.TracerVersions["java"] != "latest" {
+		t.Fatalf("empty target should match everything, got %+v ok=%v", out, ok)
+	}
+}
+
+// TestTargetMatchingDocExamples is a behavioral guardrail for the targets path:
+// it mirrors every example from the public "Target specific workloads"
+// documentation plus the selector building blocks that the examples do not
+// cover (namespace matchExpressions, combined namespace+pod selectors, and the
+// "first match wins" ordering rule). It exercises the same targets -> policies
+// lowering and evaluation that drives the cluster-agent at runtime, so any
+// regression in matching behavior is caught here.
+func TestTargetMatchingDocExamples(t *testing.T) {
+	// Example 2: namespace by name, then namespace by label.
+	doc2 := []Target{
+		{
+			Name:              "login-service_namespace",
+			NamespaceSelector: &NamespaceSelector{MatchNames: []string{"login-service"}},
+			TracerVersions:    map[string]string{"java": "default"},
+			TracerConfigs:     []TracerConfig{{Name: "DD_PROFILING_ENABLED", Value: "auto"}},
+		},
+		{
+			Name:              "billing-service_apps",
+			NamespaceSelector: &NamespaceSelector{MatchLabels: map[string]string{"app": "billing-service"}},
+			TracerVersions:    map[string]string{"python": "3.1.0"},
+		},
+	}
+	// Example 3: two pod-label targets (also exercises first-match-wins).
+	doc3 := []Target{
+		{
+			Name:           "db-user",
+			PodSelector:    &PodSelector{MatchLabels: map[string]string{"app": "db-user"}},
+			TracerVersions: map[string]string{"java": "default"},
+		},
+		{
+			Name:           "user-request-router",
+			PodSelector:    &PodSelector{MatchLabels: map[string]string{"webserver": "user"}},
+			TracerVersions: map[string]string{"php": "default"},
+		},
+	}
+	// Example 4: a pod within a namespace (namespace matchNames AND pod matchLabels).
+	doc4 := []Target{{
+		Name:              "login-service-namespace",
+		NamespaceSelector: &NamespaceSelector{MatchNames: []string{"login-service"}},
+		PodSelector:       &PodSelector{MatchLabels: map[string]string{"app": "password-resolver"}},
+		TracerVersions:    map[string]string{"java": "default"},
+	}}
+	// Example 5: a subset of pods using matchExpressions (NotIn).
+	doc5 := []Target{{
+		Name: "default-target",
+		PodSelector: &PodSelector{MatchExpressions: []SelectorMatchExpression{{
+			Key:      "app",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   []string{"app1", "app2"},
+		}}},
+	}}
+	// Namespace matchExpressions: not shown in the doc examples but a supported
+	// building block, mirrored for both In and Exists.
+	nsExpr := []Target{{
+		Name: "ns-expr",
+		NamespaceSelector: &NamespaceSelector{MatchExpressions: []SelectorMatchExpression{
+			{Key: "team", Operator: metav1.LabelSelectorOpIn, Values: []string{"payments", "billing"}},
+			{Key: "instrument", Operator: metav1.LabelSelectorOpExists},
+		}},
+	}}
+
+	cases := []struct {
+		name    string
+		targets []Target
+		facts   policies.Facts
+		want    string // matched target name, "" for no match
+	}{
+		// Example 1: no selectors instruments everything.
+		{
+			name:    "ex1 no-selector matches any pod",
+			targets: []Target{{Name: "all-remaining-services", TracerVersions: map[string]string{"java": "default"}}},
+			facts:   policies.Facts{NamespaceName: "whatever", PodLabels: map[string]string{"any": "thing"}},
+			want:    "all-remaining-services",
+		},
+		// Example 2.
+		{name: "ex2 namespace matchNames", targets: doc2, facts: policies.Facts{NamespaceName: "login-service"}, want: "login-service_namespace"},
+		{name: "ex2 namespace matchLabels", targets: doc2, facts: policies.Facts{NamespaceName: "x", NamespaceLabels: map[string]string{"app": "billing-service"}}, want: "billing-service_apps"},
+		{name: "ex2 no match", targets: doc2, facts: policies.Facts{NamespaceName: "other"}, want: ""},
+		// Example 3.
+		{name: "ex3 db-user", targets: doc3, facts: policies.Facts{PodLabels: map[string]string{"app": "db-user"}}, want: "db-user"},
+		{name: "ex3 router", targets: doc3, facts: policies.Facts{PodLabels: map[string]string{"webserver": "user"}}, want: "user-request-router"},
+		{name: "ex3 first match wins when both labels present", targets: doc3, facts: policies.Facts{PodLabels: map[string]string{"app": "db-user", "webserver": "user"}}, want: "db-user"},
+		{name: "ex3 no match", targets: doc3, facts: policies.Facts{PodLabels: map[string]string{"app": "other"}}, want: ""},
+		// Example 4: namespace AND pod selectors are ANDed.
+		{name: "ex4 namespace and pod match", targets: doc4, facts: policies.Facts{NamespaceName: "login-service", PodLabels: map[string]string{"app": "password-resolver"}}, want: "login-service-namespace"},
+		{name: "ex4 pod mismatch in matching namespace", targets: doc4, facts: policies.Facts{NamespaceName: "login-service", PodLabels: map[string]string{"app": "other"}}, want: ""},
+		{name: "ex4 matching pod in wrong namespace", targets: doc4, facts: policies.Facts{NamespaceName: "other", PodLabels: map[string]string{"app": "password-resolver"}}, want: ""},
+		// Example 5: NotIn, including the Kubernetes "absent key matches" rule.
+		{name: "ex5 notin allows other", targets: doc5, facts: policies.Facts{PodLabels: map[string]string{"app": "app3"}}, want: "default-target"},
+		{name: "ex5 notin excludes listed", targets: doc5, facts: policies.Facts{PodLabels: map[string]string{"app": "app1"}}, want: ""},
+		{name: "ex5 notin matches absent key", targets: doc5, facts: policies.Facts{PodLabels: map[string]string{}}, want: "default-target"},
+		// Namespace matchExpressions (In + Exists ANDed).
+		{name: "ns-expr in and exists match", targets: nsExpr, facts: policies.Facts{NamespaceName: "x", NamespaceLabels: map[string]string{"team": "payments", "instrument": "yes"}}, want: "ns-expr"},
+		{name: "ns-expr in fails", targets: nsExpr, facts: policies.Facts{NamespaceName: "x", NamespaceLabels: map[string]string{"team": "other", "instrument": "yes"}}, want: ""},
+		{name: "ns-expr exists fails", targets: nsExpr, facts: policies.Facts{NamespaceName: "x", NamespaceLabels: map[string]string{"team": "payments"}}, want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ps := policiesFromTargets(tc.targets)
+			if got := decideName(ps, tc.facts); got != tc.want {
+				t.Errorf("matched %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTargetMatchingDocExample6Outcome verifies that a matched target returns
+// its full injection outcome (tracer versions and ddTraceConfigs), mirroring
+// documentation Example 6 (enable AAP + profiler via ddTraceConfigs).
+func TestTargetMatchingDocExample6Outcome(t *testing.T) {
+	targets := []Target{{
+		Name:              "web-apps-with-security",
+		NamespaceSelector: &NamespaceSelector{MatchNames: []string{"web-apps"}},
+		TracerVersions:    map[string]string{"java": "default", "python": "default"},
+		TracerConfigs: []TracerConfig{
+			{Name: "DD_APPSEC_ENABLED", Value: "true"},
+			{Name: "DD_PROFILING_ENABLED", Value: "auto"},
+		},
+	}}
+	ps := policiesFromTargets(targets)
+
+	out, ok := policies.Decide(ps, policies.Facts{NamespaceName: "web-apps"})
+	if !ok {
+		t.Fatal("web-apps namespace should match")
+	}
+	if out.TracerVersions["java"] != "default" || out.TracerVersions["python"] != "default" {
+		t.Errorf("unexpected tracer versions: %+v", out.TracerVersions)
+	}
+	wantEnv := map[string]string{"DD_APPSEC_ENABLED": "true", "DD_PROFILING_ENABLED": "auto"}
+	got := make(map[string]string, len(out.TracerConfigs))
+	for _, e := range out.TracerConfigs {
+		got[e.Name] = e.Value
+	}
+	for k, v := range wantEnv {
+		if got[k] != v {
+			t.Errorf("env %q = %q, want %q", k, got[k], v)
+		}
+	}
+
+	// A pod outside the targeted namespace is not instrumented.
+	if _, ok := policies.Decide(ps, policies.Facts{NamespaceName: "other"}); ok {
+		t.Error("other namespace should not match")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Evolves Kubernetes SSI **targets** matching from k8s label selectors to the
shared Go policy engine (`github.com/DataDog/dd-policy-engine/go`), so the
cluster-agent shares one rule semantics with the host injector.

Three commits, in order:

1. **test** — a behavioral characterization (golden master) of the target
   matcher, exercised only through the public `TargetMutator` API
   (`NewTargetMutator` + `getMatchingTarget`). Added *before* the refactor so it
   runs unchanged against the current label-selector implementation.
2. **compiler** — adds the `dd-policy-engine/go` dependency and lowers the
   static `targets` config into policies (`policiesFromTargets`).
3. **wiring** — the `TargetMutator` matches pods via the policy engine
   (`policyMatcher`) instead of label selectors; targets and policies stay
   aligned by index, preserving first-match-wins.

Scope is intentionally minimal: **no remote-config path** is wired here (that
follows in a separate PR). `NewTargetMutator` keeps its signature, so callers
and existing tests are unchanged.

### Matching coverage (characterization)

first-match-wins precedence · pod `matchLabels` (ANDed) · pod `matchExpressions`
In/NotIn/Exists/DoesNotExist (incl. "absent key matches NotIn") · namespace
`matchNames`/`matchLabels`/`matchExpressions` · combined namespace+pod (ANDed) ·
empty-target-matches-all · disabled-namespace short-circuit.

The suite passes against **both** the legacy label-selector implementation
(verified on `main`) and the policy-engine implementation, proving behavior is
preserved.

### Intentional behavior change

`target_matching_change_test.go` pins one deliberate change: when a pod's
namespace is absent from the workloadmeta store and a target reads namespace
labels, the matcher now declines injection **consistently** (the legacy matcher
was order-dependent and could still match an earlier pod-only target). This test
is red on the legacy impl and green on the new one, documenting the change.

### Describe how you validated your changes

```
go build -tags kubeapiserver ./pkg/clusteragent/admission/mutate/autoinstrumentation/...
go test -tags "test kubeapiserver" ./pkg/clusteragent/admission/mutate/autoinstrumentation/
```

Characterization tests were additionally run against `main` (legacy impl) via a
git worktree to confirm equivalence.

### Additional Notes

- The dependency is pinned to a **pseudo-version of the dd-policy-engine PR
  branch** (DataDog/dd-policy-engine#71, draft). Repin to the released version
  once that PR merges — this PR is stacked on it and stays in draft until then.
- `golang.org/x/sys` is bumped `0.45.0 -> 0.46.0` as required by the
  dependency's `go.mod` (MVS).