### PR TITLE
Fail `bazel.bat` early if 8.3 short names are disabled in Windows

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -405,7 +405,7 @@
         "recordedInputs": [
           "FILE:@@//.bazelversion 7b6188c072705b1c51d6ccdedea92238feb4199b75c58b321c5b632d981b0aba",
           "FILE:@@//tools/bazel 8cd8e05bc6563f0ec312c10447f63c0d984f3bee34418ee07490e007f3ebfc3f",
-          "FILE:@@//tools/bazel.bat f13ecb6de386829a4d6fea1e81c6f1cdac0d38e28b52c969eb7da833934a37da",
+          "FILE:@@//tools/bazel.bat 44c2cabd3fb22bd06abf1eb64f11b8eacd046190b221edb1d2cd9aa9922df319",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
         ],
         "generatedRepoSpecs": {}

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -64,6 +64,17 @@ if not exist "!more_than_260_chars!" (
   )
 )
 
+:: Check 8.3 short names are enabled, or fail with instructions
+:: TODO(agent-build): remove once https://github.com/bazelbuild/bazel/pull/29921 (or equivalent) is in effect
+set "more_than_8dot3_chars=%TEMP%\123456789.1234"
+2>nul del /f /q "!more_than_8dot3_chars!"
+>"!more_than_8dot3_chars!" type nul
+for %%i in ("!more_than_8dot3_chars!") do if "%%~nxi"=="%%~snxi" (
+  >&2 echo 🔴 For `bazel` to work properly, please enable 8.3 short names on %%~di:
+  >&2 echo     fsutil 8dot3name set %%~di 0
+  exit /b 2
+)
+
 set "args=%*"
 if defined args if defined extra_args call :insert_extra_args
 "%BAZEL_REAL%" !startup_options! !args!


### PR DESCRIPTION
### What does this PR do?
Add a preflight check that creates a temp file whose name exceeds 8.3 limits and compare its long name (`%%~nxi`) against its short name (`%%~snxi`).

When they are equal, `GetShortPathNameW` is a no-op, meaning 8.3 short names are disabled and the hook exits with actionable instructions.

### Motivation
`GetShortPathNameW` is a no-op when 8.3 short names are disabled, causing Bazel to fail with an internal path-length error (bazelbuild/bazel#19710), even with the 260-character OS limit lifted.

GitLab runners had the volume state enabled, but Docker containers did not, root cause of [#incident-56436](https://dd.enterprise.slack.com/archives/C0BBPAV0J20).
The latter is now fixed by the combo:
- DataDog/datadog-agent-buildimages#1215
- #52561.

The present change makes it fail fast with actionable instructions rather than a cryptic Bazel error.

### Describe how you validated your changes
Before #52561 was merged: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1788332180#L48

### Additional Notes
To be reverted once following upstream fix (or equivalent) is available:
- bazelbuild/bazel#29921.