### PR TITLE
Fix rare flakiness in `TestRegistrationRefreshContention`

### DIFF
--- a/comp/core/remoteagent/helper/BUILD.bazel
+++ b/comp/core/remoteagent/helper/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "@org_golang_google_grpc//credentials",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_grpc//test/bufconn",
         "@org_golang_google_grpc_examples//features/proto/echo",
     ],
 )

--- a/comp/core/remoteagent/helper/serverhelper_test.go
+++ b/comp/core/remoteagent/helper/serverhelper_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -24,6 +25,7 @@ import (
 	"google.golang.org/grpc/examples/features/proto/echo"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
@@ -402,52 +404,49 @@ func TestRegistrationRefreshContention(t *testing.T) {
 	ipcComp := ipcmock.New(t)
 	logComp := logmock.New(t)
 	configComp := configmock.New(t)
-
-	// Set a short query timeout for faster test
-	configComp.SetInTest("remote_agent.registry.query_timeout", 50*time.Millisecond)
-
-	registerCallCount := 0
-	refreshCallCount := 0
-	var mu sync.Mutex
-
-	// Create a mock core agent server where registration hangs the 2 first calls
-	mockCoreAgent := newMockCoreAgentServer(t, ipcComp,
-		func(ctx context.Context, _ *pbcore.RegisterRemoteAgentRequest) (*pbcore.RegisterRemoteAgentResponse, error) {
-			mu.Lock()
-			registerCallCount++
-			if registerCallCount > 2 {
-				defer mu.Unlock()
-				return &pbcore.RegisterRemoteAgentResponse{
-					SessionId:                      "uuid_session_id",
-					RecommendedRefreshIntervalSecs: 1,
-				}, nil
-			}
-			mu.Unlock()
-
-			// Block forever to prevent registration from completing
-			<-ctx.Done()
-			return nil, ctx.Err()
-		},
-		func(_ context.Context, _ *pbcore.RefreshRemoteAgentRequest) (*pbcore.RefreshRemoteAgentResponse, error) {
-			mu.Lock()
-			refreshCallCount++
-			mu.Unlock()
-			return &pbcore.RefreshRemoteAgentResponse{}, nil
-		},
-	)
-	defer mockCoreAgent.stop()
-
-	// Create the remote agent server
 	server, err := NewUnimplementedRemoteAgentServer(
 		ipcComp,
 		logComp,
 		configComp,
 		lc,
-		mockCoreAgent.address,
+		"test.invalid",
 		"test-agent",
 		"Test Agent",
 	)
 	require.NoError(t, err)
+
+	synctest.Test(t, func(t *testing.T) {
+		syncTestRegistrationRefreshContention(t, lc, server)
+	})
+}
+
+func syncTestRegistrationRefreshContention(t *testing.T, lc *compdef.TestLifecycle, server *UnimplementedRemoteAgentServer) {
+	registerCallCount := 0
+	refreshCallCount := 0
+	registered := make(chan struct{})
+	require.NoError(t, server.listener.Close())
+	server.listener = bufconn.Listen(1 << 20)
+
+	// Create a fake agent client where registration hangs the 2 first calls
+	server.agentClient = &fakeRemoteAgentClient{
+		func(ctx context.Context, _ *pbcore.RegisterRemoteAgentRequest) (*pbcore.RegisterRemoteAgentResponse, error) {
+			registerCallCount++
+			if registerCallCount > 2 {
+				close(registered)
+				return &pbcore.RegisterRemoteAgentResponse{
+					SessionId:                      "uuid_session_id",
+					RecommendedRefreshIntervalSecs: 1,
+				}, nil
+			}
+			// Block forever to prevent registration from completing
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		func(_ context.Context, _ *pbcore.RefreshRemoteAgentRequest) (*pbcore.RefreshRemoteAgentResponse, error) {
+			refreshCallCount++
+			return &pbcore.RefreshRemoteAgentResponse{}, nil
+		},
+	}
 
 	// Start the server (impls call this explicitly after registering services).
 	server.Start()
@@ -455,22 +454,16 @@ func TestRegistrationRefreshContention(t *testing.T) {
 
 	// Wait for registration to be retried after the first two timeouts.
 	// The third attempt should succeed and bring the counter to 3.
-	require.Eventually(t, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return registerCallCount == 3
-	}, 3*time.Second, 50*time.Millisecond, "Registration should have been retried after timeout")
+	<-registered
+	assert.Equal(t, 3, registerCallCount, "Registration should have been retried after timeout")
 
 	// Now test refresh contention - the server should be registered by now
 	// Wait a bit more to ensure refresh is called
-	time.Sleep(2 * time.Second)
+	time.Sleep(1500 * time.Millisecond) // at midpoint between 1st and 2nd tick
+	synctest.Wait()                     // for the bubble to quiesce
 
-	mu.Lock()
-	refCount := refreshCallCount
-	mu.Unlock()
-
-	// We should have at least one refresh call by now
-	assert.Greater(t, refCount, 0, "Refresh should have been called")
+	// We should have exactly one refresh call by now
+	assert.Equal(t, 1, refreshCallCount, "Refresh should have been called exactly once")
 }
 
 // TestSessionIDInResponseMetadata tests that the session ID is properly
@@ -536,6 +529,25 @@ func TestSessionIDInResponseMetadata(t *testing.T) {
 }
 
 // Helper types and functions
+
+// fakeRemoteAgentClient implements pbcore.RemoteAgentClient via callbacks, with no gRPC transport
+// goroutines nor timers, safe to use inside a synctest bubble.
+type fakeRemoteAgentClient struct {
+	registerFunc func(context.Context, *pbcore.RegisterRemoteAgentRequest) (*pbcore.RegisterRemoteAgentResponse, error)
+	refreshFunc  func(context.Context, *pbcore.RefreshRemoteAgentRequest) (*pbcore.RefreshRemoteAgentResponse, error)
+}
+
+func (f *fakeRemoteAgentClient) RegisterRemoteAgent(ctx context.Context, req *pbcore.RegisterRemoteAgentRequest, _ ...grpc.CallOption) (*pbcore.RegisterRemoteAgentResponse, error) {
+	return f.registerFunc(ctx, req)
+}
+
+func (f *fakeRemoteAgentClient) RefreshRemoteAgent(ctx context.Context, req *pbcore.RefreshRemoteAgentRequest, _ ...grpc.CallOption) (*pbcore.RefreshRemoteAgentResponse, error) {
+	return f.refreshFunc(ctx, req)
+}
+
+func (f *fakeRemoteAgentClient) ReportRemoteAgentEvent(_ context.Context, _ *pbcore.ReportRemoteAgentEventRequest, _ ...grpc.CallOption) (*pbcore.ReportRemoteAgentEventResponse, error) {
+	return &pbcore.ReportRemoteAgentEventResponse{}, nil
+}
 
 // mockStatusProvider implements a mock status provider
 type mockStatusProvider struct {


### PR DESCRIPTION
### What does this PR do?
Replace the wallclock-based mock gRPC server with `testing/synctest` and a pure-Go `fakeRemoteAgentClient`.
The synthetic clock eliminates real TLS/transport latency that was consuming the RPC timeout budget and causing non-deterministic retry counts.

Key constraints:
- `NewUnimplementedRemoteAgentServer` (and its `grpc.NewServer` call) runs before `synctest.Test` so its internal goroutines stay outside the bubble,
- `bufconn.Listen` and the `registered` channel are created inside the bubble so blocking on them is durable and the clock advances,
- sleep duration is `3 * time.Second / 2`, the midpoint between the 1st and 2nd refresh tick: sleeping for an exact multiple of the interval causes a timer tie that makes the count non-deterministic.

### Motivation
I've been experiencing such failures at times (about every 700 times or so) on my machine:
```
==================== Test output for //comp/core/remoteagent/helper:helper_test:
1781712770379508087 [Info] config lib used: nodetreemodel
1781712770680472740 [Info] config lib used: nodetreemodel
1781712774578812528 [Warn] Cross-node client TLS configuration is already set, ignoring the new configuration
1781712775005697259 [Warn] Cross-node client TLS configuration is already set, ignoring the new configuration
1781712775547117528 [Warn] Cross-node client TLS configuration is already set, ignoring the new configuration
1781712776818495685 [Warn] Cross-node client TLS configuration is already set, ignoring the new configuration
--- FAIL: TestRegistrationRefreshContention (3.69s)
    mock.go:28: 2026-06-17 16:12:56 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:205 in func2) | Session ID is empty, entering registration loop
    mock.go:28: 2026-06-17 16:12:56 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:397 in registerWithAgent) | Registering with Core Agent at 127.0.0.1:44387...
    mock.go:28: 2026-06-17 16:12:56 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:404 in registerWithAgent) | failed to register remote agent: rpc error: code = DeadlineExceeded desc = context deadline exceeded while waiting for connections to become ready
    mock.go:28: 2026-06-17 16:12:56 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:210 in func2) | Registration failed, retrying in 366.799361ms
    mock.go:28: 2026-06-17 16:12:57 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:205 in func2) | Session ID is empty, entering registration loop
    mock.go:28: 2026-06-17 16:12:57 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:397 in registerWithAgent) | Registering with Core Agent at 127.0.0.1:44387...
    mock.go:28: 2026-06-17 16:12:57 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:404 in registerWithAgent) | failed to register remote agent: rpc error: code = DeadlineExceeded desc = context deadline exceeded
    mock.go:28: 2026-06-17 16:12:57 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:210 in func2) | Registration failed, retrying in 985.756936ms
    mock.go:28: 2026-06-17 16:12:58 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:205 in func2) | Session ID is empty, entering registration loop
    mock.go:28: 2026-06-17 16:12:57 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:397 in registerWithAgent) | Registering with Core Agent at 127.0.0.1:44387...
    mock.go:28: 2026-06-17 16:12:58 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:404 in registerWithAgent) | failed to register remote agent: rpc error: code = DeadlineExceeded desc = context deadline exceeded
    mock.go:28: 2026-06-17 16:12:58 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:210 in func2) | Registration failed, retrying in 1.675086037s
    serverhelper_test.go:458:
            Error Trace:    comp/core/remoteagent/helper/serverhelper_test.go:458
            Error:          Condition never satisfied
            Test:           TestRegistrationRefreshContention
            Messages:       Registration should have been retried after timeout
    mock.go:28: 2026-06-17 16:12:59 UTC | DEBUG | (comp/core/remoteagent/helper/serverhelper.go:250 in stop) | remoteAgentServer stopped
1781712780615361020 [Warn] Cross-node client TLS configuration is already set, ignoring the new configuration
FAIL
================================================================================
```

### Additional Notes
The short query timeout (`SetInTest("remote_agent.registry.query_timeout", 50ms)`) is dropped since the synthetic clock advances through any timeout value at zero wall-clock cost, so the configured duration no longer affects test speed.

The mutex guarding the counters is dropped: `close(registered)` / `<-registered` and the timer expiry establish the _happens-before_ ordering that `synctest`'s clock mechanics guarantee.

### Describe how you validated your changes
Measured with:
```
bazel test --nocache_test_results --runs_per_test=200 \
  --test_filter=TestRegistrationRefreshContention \
  //comp/core/remoteagent/helper:helper_test
```
Results:
|        | avg  | min  | max  | dev  |
|--------|------|------|------|------|
| before | 3.7s | 3.0s | 5.5s | 0.4s |
| after  | 1.5s | 0.4s | 2.6s | 0.5s |
- before was flaky (TLS handshakes could consume the 50 ms RPC budget),
- after: 0 failures across 200 runs.

### Additional Notes
Référence: https://go.dev/blog/synctest.