### PR TITLE
(fleet) remove ensurepip from embedded Python

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -144,6 +144,9 @@ build do
             # removing the local folder to reduce package size by ~0.5MB
             delete "#{install_dir}/embedded/share/locale"
 
+            # removing ensurepip from the embedded Python to reduce package size by ~1.8MB
+            delete "#{install_dir}/embedded/lib/python*/ensurepip"
+
             # Drop bundled unit-test directories from embedded Python wheels/deps (not used at agent runtime).
             # Deepest paths first so nested tests/ trees are removed safely.
             command "find #{install_dir}/embedded/lib -path '*/site-packages/*' -depth -type d -name tests -exec rm -rf {} +"


### PR DESCRIPTION
## Summary

This PR removes the `ensurepip` module from the embedded Python during the omnibus finalize step.

`ensurepip` is the module Python uses to bootstrap `pip` into an environment that doesn't have it. The shipped package already includes a fully installed `pip`, so `ensurepip` is unused at runtime and can be dropped from the artifact.

## Size impact

Reduces the on-disk package size by **~1.8 MB**.

It is removed in `omnibus/config/software/datadog-agent-finalize.rb` alongside the other embedded-Python size reductions, using a version-independent glob so it keeps working across Python upgrades.