### PR TITLE
Default to Bazel usage for `agent.build` tasks

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -83,33 +83,30 @@ def build(
     agent_bin=None,
     run_on=None,  # noqa: U100, F841. Used by the run_on_devcontainer decorator
     glibc=True,
-    no_bazel=False,
-    enable_bazel=False,
+    enable_bazel=True,
 ):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
 
     Bazel-backed build steps are enabled by default.
-    Use `--no-bazel` to keep the legacy build paths.
+    Use `--no-enable-bazel` to keep the legacy build paths.
 
     Example invokation:
         dda inv agent.build --build-exclude=systemd
     """
     flavor = AgentFlavor[flavor]
-    if enable_bazel:
-        print("`--enable-bazel` is now the default and will be ignored.")
 
     if not exclude_rtloader and not flavor.is_iot() and sys.platform != "aix":
         # On AIX, rtloader is built natively in advance as a prerequisite.
         with gitlab_section("Install embedded rtloader", collapsed=True):
-            if no_bazel:
-                rtloader_make(ctx, install_prefix=embedded_path, cmake_options=cmake_options)
-                rtloader_install(ctx)
-            else:
+            if enable_bazel:
                 bazel_embedded = rtloader_install_with_bazel(ctx)
                 embedded_path = bazel_embedded
                 python_home_3 = bazel_embedded
+            else:
+                rtloader_make(ctx, install_prefix=embedded_path, cmake_options=cmake_options)
+                rtloader_install(ctx)
 
     ldflags, gcflags, env = get_build_flags(
         ctx,
@@ -301,7 +298,7 @@ def run(
     flavor=AgentFlavor.base.name,
     skip_build=False,
     config_path=None,
-    no_bazel=False,
+    enable_bazel=True,
 ):
     """
     Execute the agent binary.
@@ -310,7 +307,7 @@ def run(
     passed. It accepts the same set of options as agent.build.
     """
     if not skip_build:
-        build(ctx, rebuild, race, build_include, build_exclude, flavor, no_bazel=no_bazel)
+        build(ctx, rebuild, race, build_include, build_exclude, flavor, enable_bazel=enable_bazel)
 
     agent_bin = os.path.join(BIN_PATH, bin_name("agent"))
     config_path = os.path.join(BIN_PATH, "dist", "datadog.yaml") if not config_path else config_path
@@ -456,7 +453,7 @@ def hacky_dev_image_build(
             development=development,
             build_exclude=build_exclude,
             cmake_options=f'-DPython3_ROOT_DIR={extracted_python_dir}/opt/datadog-agent/embedded -DPython3_FIND_STRATEGY=LOCATION',
-            no_bazel=True,
+            enable_bazel=False,
         )
         ctx.run(
             f'perl -0777 -pe \'s|{extracted_python_dir}(/opt/datadog-agent/embedded/lib/python\\d+\\.\\d+/../..)|substr $1."\\0"x length$&,0,length$&|e or die "pattern not found"\' -i dev/lib/libdatadog-agent-three.so'

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -83,27 +83,33 @@ def build(
     agent_bin=None,
     run_on=None,  # noqa: U100, F841. Used by the run_on_devcontainer decorator
     glibc=True,
+    no_bazel=False,
     enable_bazel=False,
 ):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
 
+    Bazel-backed build steps are enabled by default.
+    Use `--no-bazel` to keep the legacy build paths.
+
     Example invokation:
         dda inv agent.build --build-exclude=systemd
     """
     flavor = AgentFlavor[flavor]
+    if enable_bazel:
+        print("`--enable-bazel` is now the default and will be ignored.")
 
     if not exclude_rtloader and not flavor.is_iot() and sys.platform != "aix":
         # On AIX, rtloader is built natively in advance as a prerequisite.
         with gitlab_section("Install embedded rtloader", collapsed=True):
-            if enable_bazel:
+            if no_bazel:
+                rtloader_make(ctx, install_prefix=embedded_path, cmake_options=cmake_options)
+                rtloader_install(ctx)
+            else:
                 bazel_embedded = rtloader_install_with_bazel(ctx)
                 embedded_path = bazel_embedded
                 python_home_3 = bazel_embedded
-            else:
-                rtloader_make(ctx, install_prefix=embedded_path, cmake_options=cmake_options)
-                rtloader_install(ctx)
 
     ldflags, gcflags, env = get_build_flags(
         ctx,
@@ -449,6 +455,7 @@ def hacky_dev_image_build(
             development=development,
             build_exclude=build_exclude,
             cmake_options=f'-DPython3_ROOT_DIR={extracted_python_dir}/opt/datadog-agent/embedded -DPython3_FIND_STRATEGY=LOCATION',
+            no_bazel=True,
         )
         ctx.run(
             f'perl -0777 -pe \'s|{extracted_python_dir}(/opt/datadog-agent/embedded/lib/python\\d+\\.\\d+/../..)|substr $1."\\0"x length$&,0,length$&|e or die "pattern not found"\' -i dev/lib/libdatadog-agent-three.so'

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -301,6 +301,7 @@ def run(
     flavor=AgentFlavor.base.name,
     skip_build=False,
     config_path=None,
+    no_bazel=False,
 ):
     """
     Execute the agent binary.
@@ -309,7 +310,7 @@ def run(
     passed. It accepts the same set of options as agent.build.
     """
     if not skip_build:
-        build(ctx, rebuild, race, build_include, build_exclude, flavor)
+        build(ctx, rebuild, race, build_include, build_exclude, flavor, no_bazel=no_bazel)
 
     agent_bin = os.path.join(BIN_PATH, bin_name("agent"))
     config_path = os.path.join(BIN_PATH, "dist", "datadog.yaml") if not config_path else config_path

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -166,24 +166,40 @@ def get_rtloader_paths(embedded_path=None, rtloader_root=None):
 
         rtloader_lib_found = False
         for candidate_path in [base_path, os.path.join(base_path, "embedded")]:
-            for libdir in ["lib", "lib64", "build/rtloader"]:
-                if os.path.exists(os.path.join(candidate_path, libdir, RTLOADER_LIB_NAME)):
-                    rtloader_lib.append(os.path.join(candidate_path, libdir))
-                    rtloader_lib_found = True
-                    break
+            # Keep only the first libdir that holds the lib for a given base_path, but still
+            # look for headers under every candidate: a legacy lib install can be paired with
+            # headers that only exist under the embedded directory.
+            if not rtloader_lib_found:
+                for libdir in ["lib", "lib64", "build/rtloader"]:
+                    if os.path.exists(os.path.join(candidate_path, libdir, RTLOADER_LIB_NAME)):
+                        rtloader_lib.append(os.path.join(candidate_path, libdir))
+                        rtloader_lib_found = True
+                        break
 
-            header_path = os.path.join(candidate_path, "include")
-            if not rtloader_headers and os.path.exists(os.path.join(header_path, RTLOADER_HEADER_NAME)):
-                rtloader_headers = header_path
+            if not rtloader_headers:
+                header_path = os.path.join(candidate_path, "include")
+                if os.path.exists(os.path.join(header_path, RTLOADER_HEADER_NAME)):
+                    rtloader_headers = header_path
 
-            common_path = os.path.join(candidate_path, "common")
-            if not rtloader_common_headers and os.path.exists(common_path):
-                rtloader_common_headers = common_path
-
-            if rtloader_lib_found:
-                break
+            if not rtloader_common_headers:
+                common_path = os.path.join(candidate_path, "common")
+                if os.path.exists(common_path):
+                    rtloader_common_headers = common_path
 
     return rtloader_lib, rtloader_headers, rtloader_common_headers
+
+
+def get_bazel_python_home(rtloader_lib):
+    # The first entry is the rtloader that actually gets linked (it takes -L / rpath
+    # precedence), so only infer the Python home from it.
+    if not rtloader_lib:
+        return None
+
+    embedded_dir = Path(os.path.abspath(rtloader_lib[0])).parent
+    if embedded_dir.name == "embedded":
+        return str(embedded_dir)
+
+    return None
 
 
 def get_embedded_path(ctx):
@@ -267,6 +283,9 @@ def get_build_flags(
             raise Exit("unable to locate embedded path please check your setup or set --embedded-path")
 
     rtloader_lib, rtloader_headers, rtloader_common_headers = get_rtloader_paths(embedded_path, rtloader_root)
+    if not python_home_3:
+        python_home_3 = get_bazel_python_home(rtloader_lib)
+
     # setting the install path, allowing the agent to be installed in a custom location
     if sys.platform.startswith('linux') and install_path:
         ldflags += f"-X {REPO_PATH}/pkg/util/defaultpaths.defaultInstallPath={install_path} "

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -164,17 +164,18 @@ def get_rtloader_paths(embedded_path=None, rtloader_root=None):
         if not base_path:
             continue
 
-        for libdir in ["lib", "lib64", "build/rtloader"]:
-            if os.path.exists(os.path.join(base_path, libdir, RTLOADER_LIB_NAME)):
-                rtloader_lib.append(os.path.join(base_path, libdir))
+        for candidate_path in [base_path, os.path.join(base_path, "embedded")]:
+            for libdir in ["lib", "lib64", "build/rtloader"]:
+                if os.path.exists(os.path.join(candidate_path, libdir, RTLOADER_LIB_NAME)):
+                    rtloader_lib.append(os.path.join(candidate_path, libdir))
 
-        header_path = os.path.join(base_path, "include")
-        if not rtloader_headers and os.path.exists(os.path.join(header_path, RTLOADER_HEADER_NAME)):
-            rtloader_headers = header_path
+            header_path = os.path.join(candidate_path, "include")
+            if not rtloader_headers and os.path.exists(os.path.join(header_path, RTLOADER_HEADER_NAME)):
+                rtloader_headers = header_path
 
-        common_path = os.path.join(base_path, "common")
-        if not rtloader_common_headers and os.path.exists(common_path):
-            rtloader_common_headers = common_path
+            common_path = os.path.join(candidate_path, "common")
+            if not rtloader_common_headers and os.path.exists(common_path):
+                rtloader_common_headers = common_path
 
     return rtloader_lib, rtloader_headers, rtloader_common_headers
 

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -164,10 +164,13 @@ def get_rtloader_paths(embedded_path=None, rtloader_root=None):
         if not base_path:
             continue
 
+        rtloader_lib_found = False
         for candidate_path in [base_path, os.path.join(base_path, "embedded")]:
             for libdir in ["lib", "lib64", "build/rtloader"]:
                 if os.path.exists(os.path.join(candidate_path, libdir, RTLOADER_LIB_NAME)):
                     rtloader_lib.append(os.path.join(candidate_path, libdir))
+                    rtloader_lib_found = True
+                    break
 
             header_path = os.path.join(candidate_path, "include")
             if not rtloader_headers and os.path.exists(os.path.join(header_path, RTLOADER_HEADER_NAME)):
@@ -176,6 +179,9 @@ def get_rtloader_paths(embedded_path=None, rtloader_root=None):
             common_path = os.path.join(candidate_path, "common")
             if not rtloader_common_headers and os.path.exists(common_path):
                 rtloader_common_headers = common_path
+
+            if rtloader_lib_found:
+                break
 
     return rtloader_lib, rtloader_headers, rtloader_common_headers
 
@@ -322,7 +328,9 @@ def get_build_flags(
         ldflags += "-s -w -linkmode=external "
         extldflags += "-static "
     elif rtloader_lib:
-        if sys.platform != "aix":  # -r sets ELF RPATH; not valid for AIX XCOFF
+        if sys.platform == "darwin":
+            extldflags += " ".join(f"-Wl,-rpath,{lib_path}" for lib_path in rtloader_lib) + " "
+        elif sys.platform != "aix":  # -r sets ELF RPATH; not valid for AIX XCOFF
             ldflags += f"-r {':'.join(rtloader_lib)} "
 
     if os.environ.get("DELVE"):

--- a/tasks/unit_tests/libs/common/utils_tests.py
+++ b/tasks/unit_tests/libs/common/utils_tests.py
@@ -122,8 +122,55 @@ class TestGetRtloaderPaths(unittest.TestCase):
 
         self.assertEqual(rtloader_lib, [str(legacy_lib_dir)])
 
+    def test_finds_headers_under_embedded_dir_when_lib_is_in_legacy_dir(self):
+        lib_dir = self._tmpdir / "dev" / "lib"
+        include_dir = self._tmpdir / "dev" / "embedded" / "include"
+        lib_dir.mkdir(parents=True)
+        include_dir.mkdir(parents=True)
+        (lib_dir / RTLOADER_LIB_NAME).touch()
+        (include_dir / RTLOADER_HEADER_NAME).touch()
+
+        rtloader_lib, rtloader_headers, _ = get_rtloader_paths(embedded_path=self._tmpdir / "dev")
+
+        self.assertEqual(rtloader_lib, [str(lib_dir)])
+        self.assertEqual(rtloader_headers, str(include_dir))
+
 
 class TestGetBuildFlags(unittest.TestCase):
+    @mock.patch("tasks.libs.common.utils.get_version_ldflags", return_value="")
+    @mock.patch("tasks.libs.common.utils.get_rtloader_paths", return_value=(["/dev/embedded/lib"], "", ""))
+    def test_infers_python_home_from_bazel_rtloader_path(self, _get_rtloader_paths, _get_version_ldflags):
+        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev")
+
+        self.assertIn("python.pythonHome3=/dev/embedded", ldflags.replace("\\", "/"))
+
+    @mock.patch("tasks.libs.common.utils.get_version_ldflags", return_value="")
+    @mock.patch("tasks.libs.common.utils.get_rtloader_paths", return_value=(["/external/embedded/lib"], "", ""))
+    def test_infers_python_home_from_selected_rtloader_root_path(self, _get_rtloader_paths, _get_version_ldflags):
+        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev", rtloader_root="/external")
+
+        self.assertIn("python.pythonHome3=/external/embedded", ldflags.replace("\\", "/"))
+
+    @mock.patch("tasks.libs.common.utils.get_version_ldflags", return_value="")
+    @mock.patch("tasks.libs.common.utils.get_rtloader_paths", return_value=(["/dev/lib"], "", ""))
+    def test_does_not_infer_python_home_from_legacy_rtloader_path(self, _get_rtloader_paths, _get_version_ldflags):
+        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev")
+
+        self.assertNotIn("python.pythonHome3", ldflags)
+
+    @mock.patch("tasks.libs.common.utils.get_version_ldflags", return_value="")
+    @mock.patch(
+        "tasks.libs.common.utils.get_rtloader_paths", return_value=(["/external/lib", "/dev/embedded/lib"], "", "")
+    )
+    def test_does_not_infer_python_home_when_selected_rtloader_is_legacy(
+        self, _get_rtloader_paths, _get_version_ldflags
+    ):
+        # The selected (first) rtloader is a legacy root; a stale embedded lib from a prior
+        # Bazel build must not override the Python home for the rtloader actually linked.
+        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev", rtloader_root="/external")
+
+        self.assertNotIn("python.pythonHome3", ldflags)
+
     @mock.patch("tasks.libs.common.utils.get_version_ldflags", return_value="")
     @mock.patch("tasks.libs.common.utils.get_rtloader_paths", return_value=(["/dev/lib", "/dev/embedded/lib"], "", ""))
     @mock.patch("tasks.libs.common.utils.sys.platform", "darwin")

--- a/tasks/unit_tests/libs/common/utils_tests.py
+++ b/tasks/unit_tests/libs/common/utils_tests.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from unittest import mock
 
 from tasks.libs.common.utils import (
+    RTLOADER_HEADER_NAME,
+    RTLOADER_LIB_NAME,
+    get_rtloader_paths,
     link_or_copy,
     running_in_ci,
     running_in_github_actions,
@@ -83,3 +86,25 @@ class TestLinkOrCopy(unittest.TestCase):
     def test_propagates_last_error(self, symlink_to, hardlink_to, copy2):
         with self.assertRaises(OSError):
             link_or_copy(self.src, self.dst)
+
+
+class TestGetRtloaderPaths(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = Path(tempfile.mkdtemp(prefix="test-rtloader-paths"))
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir)
+
+    def test_finds_bazel_install_under_embedded_dir(self):
+        lib_dir = self._tmpdir / "dev" / "embedded" / "lib"
+        include_dir = self._tmpdir / "dev" / "embedded" / "include"
+        lib_dir.mkdir(parents=True)
+        include_dir.mkdir(parents=True)
+        (lib_dir / RTLOADER_LIB_NAME).touch()
+        (include_dir / RTLOADER_HEADER_NAME).touch()
+
+        rtloader_lib, rtloader_headers, rtloader_common_headers = get_rtloader_paths(embedded_path=self._tmpdir / "dev")
+
+        self.assertEqual(rtloader_lib, [str(lib_dir)])
+        self.assertEqual(rtloader_headers, str(include_dir))
+        self.assertEqual(rtloader_common_headers, "")

--- a/tasks/unit_tests/libs/common/utils_tests.py
+++ b/tasks/unit_tests/libs/common/utils_tests.py
@@ -8,6 +8,7 @@ from unittest import mock
 from tasks.libs.common.utils import (
     RTLOADER_HEADER_NAME,
     RTLOADER_LIB_NAME,
+    get_build_flags,
     get_rtloader_paths,
     link_or_copy,
     running_in_ci,
@@ -108,3 +109,29 @@ class TestGetRtloaderPaths(unittest.TestCase):
         self.assertEqual(rtloader_lib, [str(lib_dir)])
         self.assertEqual(rtloader_headers, str(include_dir))
         self.assertEqual(rtloader_common_headers, "")
+
+    def test_prefers_legacy_install_over_embedded_dir(self):
+        legacy_lib_dir = self._tmpdir / "dev" / "lib"
+        embedded_lib_dir = self._tmpdir / "dev" / "embedded" / "lib"
+        legacy_lib_dir.mkdir(parents=True)
+        embedded_lib_dir.mkdir(parents=True)
+        (legacy_lib_dir / RTLOADER_LIB_NAME).touch()
+        (embedded_lib_dir / RTLOADER_LIB_NAME).touch()
+
+        rtloader_lib, _, _ = get_rtloader_paths(embedded_path=self._tmpdir / "dev")
+
+        self.assertEqual(rtloader_lib, [str(legacy_lib_dir)])
+
+
+class TestGetBuildFlags(unittest.TestCase):
+    @mock.patch("tasks.libs.common.utils.get_version_ldflags", return_value="")
+    @mock.patch("tasks.libs.common.utils.get_rtloader_paths", return_value=(["/dev/lib", "/dev/embedded/lib"], "", ""))
+    @mock.patch("tasks.libs.common.utils.sys.platform", "darwin")
+    @mock.patch("tasks.libs.common.utils.get_xcode_version", return_value="15.0")
+    def test_uses_external_linker_for_multiple_rtloader_rpaths_on_macos(
+        self, _get_xcode_version, _get_rtloader_paths, _get_version_ldflags
+    ):
+        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev")
+
+        self.assertIn("-Wl,-rpath,/dev/lib", ldflags)
+        self.assertIn("-Wl,-rpath,/dev/embedded/lib", ldflags)


### PR DESCRIPTION
### Motivation

The legacy local build path depends on whichever Python happens to be active in the shell, which can diverge from the embedded Python used in packaged Agent builds. The Bazel path installs rtloader together with its intended embedded Python environment, making local builds independent of shell activation state.