### PR TITLE
feat(autoinstrumentation): wire remote-config SSI policies (APM_POLICIES)

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -490,7 +490,7 @@ func start(log log.Component,
 			products = append(products, state.ProductK8SActions)
 		}
 		if config.GetBool("admission_controller.auto_instrumentation.enabled") || config.GetBool("apm_config.instrumentation.enabled") {
-			products = append(products, state.ProductGradualRollout)
+			products = append(products, state.ProductGradualRollout, state.ProductApmPolicies)
 		}
 		if config.GetBool("private_action_runner.enabled") {
 			products = append(products, state.ProductActionPlatformRunnerKeys)
@@ -679,6 +679,7 @@ func start(log log.Component,
 			FilterStore:                  filterStore,
 			InstrumentationHandlers:      instrHandlers,
 			CSIDriverWatcher:             csiDriverWatcher,
+			RcClient:                     rcClient,
 		}
 
 		webhooks, err := admissionpkg.StartControllers(admissionCtx, datadogConfig, wmeta, pp, sh, healthPlatform)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -46,6 +46,7 @@ import (
 	clusterspot "github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/cluster/spot"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
+	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	kubecommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -57,11 +58,11 @@ type Controller interface {
 }
 
 // NewController returns the adequate implementation of the Controller interface.
-func NewController(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, validatingInformers admissionregistration.Interface, mutatingInformers admissionregistration.Interface, isLeaderFunc func() bool, leadershipStateNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pp workload.PodPatcher, sh clusterspot.PodHandler, datadogConfig config.Component, demultiplexer demultiplexer.Component, filterStore workloadfilter.Component, handlers []instrumentation.Handler, informerFactory dynamicinformer.DynamicSharedInformerFactory, csiDriverWatcher libraryinjection.CSIDriverWatcher) Controller {
+func NewController(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, validatingInformers admissionregistration.Interface, mutatingInformers admissionregistration.Interface, isLeaderFunc func() bool, leadershipStateNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pp workload.PodPatcher, sh clusterspot.PodHandler, datadogConfig config.Component, rcClient *rcclient.Client, demultiplexer demultiplexer.Component, filterStore workloadfilter.Component, handlers []instrumentation.Handler, informerFactory dynamicinformer.DynamicSharedInformerFactory, csiDriverWatcher libraryinjection.CSIDriverWatcher) Controller {
 	if config.useAdmissionV1() {
-		return NewControllerV1(client, secretInformer, validatingInformers.V1().ValidatingWebhookConfigurations(), mutatingInformers.V1().MutatingWebhookConfigurations(), isLeaderFunc, leadershipStateNotif, config, wmeta, pp, sh, datadogConfig, demultiplexer, filterStore, handlers, informerFactory, csiDriverWatcher)
+		return NewControllerV1(client, secretInformer, validatingInformers.V1().ValidatingWebhookConfigurations(), mutatingInformers.V1().MutatingWebhookConfigurations(), isLeaderFunc, leadershipStateNotif, config, wmeta, pp, sh, datadogConfig, rcClient, demultiplexer, filterStore, handlers, informerFactory, csiDriverWatcher)
 	}
-	return NewControllerV1beta1(client, secretInformer, validatingInformers.V1beta1().ValidatingWebhookConfigurations(), mutatingInformers.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, leadershipStateNotif, config, wmeta, pp, sh, datadogConfig, demultiplexer, filterStore, handlers, informerFactory, csiDriverWatcher)
+	return NewControllerV1beta1(client, secretInformer, validatingInformers.V1beta1().ValidatingWebhookConfigurations(), mutatingInformers.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, leadershipStateNotif, config, wmeta, pp, sh, datadogConfig, rcClient, demultiplexer, filterStore, handlers, informerFactory, csiDriverWatcher)
 }
 
 // Webhook represents an admission webhook
@@ -97,7 +98,7 @@ type Webhook interface {
 // The reason is that the volume mount for the APM socket added by the configWebhook webhook
 // doesn't always work on Fargate (one of the envs where we use an agent sidecar), and
 // the agent sidecar webhook needs to remove it.
-func (c *controllerBase) generateWebhooks(datadogConfig config.Component, wmeta workloadmeta.Component, demultiplexer demultiplexer.Component, pp workload.PodPatcher, sh clusterspot.PodHandler, filterStore workloadfilter.Component, handlers []instrumentation.Handler, informerFactory dynamicinformer.DynamicSharedInformerFactory, csiDriverWatcher libraryinjection.CSIDriverWatcher) []Webhook {
+func (c *controllerBase) generateWebhooks(datadogConfig config.Component, wmeta workloadmeta.Component, rcClient *rcclient.Client, demultiplexer demultiplexer.Component, pp workload.PodPatcher, sh clusterspot.PodHandler, filterStore workloadfilter.Component, handlers []instrumentation.Handler, informerFactory dynamicinformer.DynamicSharedInformerFactory, csiDriverWatcher libraryinjection.CSIDriverWatcher) []Webhook {
 	var webhooks []Webhook
 	var validatingWebhooks []Webhook
 
@@ -158,7 +159,7 @@ func (c *controllerBase) generateWebhooks(datadogConfig config.Component, wmeta 
 	}
 
 	// Setup APM Instrumentation webhook. APM Instrumentation webhook needs to be registered after the config webhook.
-	apmWebhook, err := autoinstrumentation.NewAutoInstrumentation(datadogConfig, wmeta, serverVersion, csiDriverWatcher)
+	apmWebhook, err := autoinstrumentation.NewAutoInstrumentation(datadogConfig, wmeta, serverVersion, csiDriverWatcher, rcClient)
 	if err != nil {
 		log.Errorf("failed to register APM Instrumentation webhook: %v", err)
 	} else {

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
@@ -66,6 +66,7 @@ func TestNewController(t *testing.T) {
 		nil,
 		datadogConfig,
 		nil,
+		nil,
 		newFilterStoreFromConfig(t, datadogConfig),
 		nil,
 		nil,
@@ -87,6 +88,7 @@ func TestNewController(t *testing.T) {
 		nil,
 		nil,
 		datadogConfig,
+		nil,
 		nil,
 		newFilterStoreFromConfig(t, datadogConfig),
 		nil,
@@ -162,7 +164,7 @@ func TestAutoInstrumentation(t *testing.T) {
 				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 			))
 
-			apm, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, wmeta, nil, nil)
+			apm, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, wmeta, nil, nil, nil)
 			assert.NoError(t, err)
 
 			// Create request.

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -34,6 +34,7 @@ import (
 	clusterspot "github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/cluster/spot"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
+	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -52,7 +53,7 @@ type ControllerV1 struct {
 }
 
 // NewControllerV1 returns a new Webhook Controller using admissionregistration/v1.
-func NewControllerV1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, validatingWebhookInformer admissioninformers.ValidatingWebhookConfigurationInformer, mutatingWebhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, leadershipStateNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pp workload.PodPatcher, sh clusterspot.PodHandler, datadogConfig config.Component, demultiplexer demultiplexer.Component, filterStore workloadfilter.Component, handlers []instrumentation.Handler, informerFactory dynamicinformer.DynamicSharedInformerFactory, csiDriverWatcher libraryinjection.CSIDriverWatcher) *ControllerV1 {
+func NewControllerV1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, validatingWebhookInformer admissioninformers.ValidatingWebhookConfigurationInformer, mutatingWebhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, leadershipStateNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pp workload.PodPatcher, sh clusterspot.PodHandler, datadogConfig config.Component, rcClient *rcclient.Client, demultiplexer demultiplexer.Component, filterStore workloadfilter.Component, handlers []instrumentation.Handler, informerFactory dynamicinformer.DynamicSharedInformerFactory, csiDriverWatcher libraryinjection.CSIDriverWatcher) *ControllerV1 {
 	controller := &ControllerV1{}
 	controller.clientSet = client
 	controller.config = config
@@ -69,7 +70,7 @@ func NewControllerV1(client kubernetes.Interface, secretInformer coreinformers.S
 	)
 	controller.isLeaderFunc = isLeaderFunc
 	controller.leadershipStateNotif = leadershipStateNotif
-	controller.webhooks = controller.generateWebhooks(datadogConfig, wmeta, demultiplexer, pp, sh, filterStore, handlers, informerFactory, csiDriverWatcher)
+	controller.webhooks = controller.generateWebhooks(datadogConfig, wmeta, rcClient, demultiplexer, pp, sh, filterStore, handlers, informerFactory, csiDriverWatcher)
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -1088,7 +1088,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 			c := &ControllerV1{}
 			c.config = tt.configFunc(mockConfig)
 			filterStore := newFilterStoreFromConfig(t, mockConfig)
-			c.webhooks = c.generateWebhooks(mockConfig, wmeta, nil, nil, nil, filterStore, nil, nil, nil)
+			c.webhooks = c.generateWebhooks(mockConfig, wmeta, nil, nil, nil, nil, filterStore, nil, nil, nil)
 			c.generateTemplates()
 
 			assert.EqualValues(t, tt.want(), c.mutatingWebhookTemplates)
@@ -1333,6 +1333,7 @@ func (f *fixtureV1) createController() (*ControllerV1, informers.SharedInformerF
 		nil,
 		nil,
 		datadogConfig,
+		nil,
 		nil,
 		newFilterStoreFromConfig(f.t, datadogConfig),
 		nil,

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -35,6 +35,7 @@ import (
 	clusterspot "github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/cluster/spot"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
+	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -53,7 +54,7 @@ type ControllerV1beta1 struct {
 }
 
 // NewControllerV1beta1 returns a new Webhook Controller using admissionregistration/v1beta1.
-func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, validatingWebhookInformer admissioninformers.ValidatingWebhookConfigurationInformer, mutatingWebhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, leadershipStateNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pp workload.PodPatcher, sh clusterspot.PodHandler, datadogConfig config.Component, demultiplexer demultiplexer.Component, filterStore workloadfilter.Component, handlers []instrumentation.Handler, informerFactory dynamicinformer.DynamicSharedInformerFactory, csiDriverWatcher libraryinjection.CSIDriverWatcher) *ControllerV1beta1 {
+func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, validatingWebhookInformer admissioninformers.ValidatingWebhookConfigurationInformer, mutatingWebhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, leadershipStateNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pp workload.PodPatcher, sh clusterspot.PodHandler, datadogConfig config.Component, rcClient *rcclient.Client, demultiplexer demultiplexer.Component, filterStore workloadfilter.Component, handlers []instrumentation.Handler, informerFactory dynamicinformer.DynamicSharedInformerFactory, csiDriverWatcher libraryinjection.CSIDriverWatcher) *ControllerV1beta1 {
 	controller := &ControllerV1beta1{}
 	controller.clientSet = client
 	controller.config = config
@@ -70,7 +71,7 @@ func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinform
 	)
 	controller.isLeaderFunc = isLeaderFunc
 	controller.leadershipStateNotif = leadershipStateNotif
-	controller.webhooks = controller.generateWebhooks(datadogConfig, wmeta, demultiplexer, pp, sh, filterStore, handlers, informerFactory, csiDriverWatcher)
+	controller.webhooks = controller.generateWebhooks(datadogConfig, wmeta, rcClient, demultiplexer, pp, sh, filterStore, handlers, informerFactory, csiDriverWatcher)
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -1082,7 +1082,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 			c := &ControllerV1beta1{}
 			c.config = tt.configFunc(mockConfig)
 			filterStore := newFilterStoreFromConfig(t, mockConfig)
-			c.webhooks = c.generateWebhooks(mockConfig, wmeta, nil, nil, nil, filterStore, nil, nil, nil)
+			c.webhooks = c.generateWebhooks(mockConfig, wmeta, nil, nil, nil, nil, filterStore, nil, nil, nil)
 			c.generateTemplates()
 
 			assert.EqualValues(t, tt.want(), c.mutatingWebhookTemplates)
@@ -1327,6 +1327,7 @@ func (f *fixtureV1beta1) createController() (*ControllerV1beta1, informers.Share
 		nil,
 		nil,
 		datadogConfig,
+		nil,
 		nil,
 		newFilterStoreFromConfig(f.t, datadogConfig),
 		nil,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation/annotation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation/annotation.go
@@ -59,6 +59,9 @@ const (
 	// AppliedTarget is the JSON of the target that was applied to the pod.
 	// Example value: {"name":"python","podSelector":{"matchLabels":{"language":"python"}},"ddTraceVersions":{"python ":"3"}}
 	AppliedTarget = "internal.apm.datadoghq.com/applied-target"
+	// AppliedPolicy is the compact JSON of the remote-config policy that was applied to the pod.
+	// Example value: {"name":"python","version":3,"ddTraceVersions":{"python":"3"}}
+	AppliedPolicy = "internal.apm.datadoghq.com/applied-policy"
 	// InjectionError is set by the webhook when there was an error during mutation.
 	// Example value: The overall pod's containers limit is too low, cpu pod_limit=5m needed=50m, memory pod_limit=4Mi needed=100Mi
 	InjectionError = "internal.apm.datadoghq.com/injection-error"

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -19,13 +19,16 @@ import (
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	configWebhook "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/config"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/tagsfromlabels"
+	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 
 	"k8s.io/apimachinery/pkg/version"
 )
 
 // NewAutoInstrumentation is a helper function to create a fully initialized webhook for SSI. Our webhook is made up of
 // several components, but consumers of this webhook should not need to care about how the webhook is wired together.
-func NewAutoInstrumentation(datadogConfig config.Component, wmeta workloadmeta.Component, serverVersion *version.Info, csiDriverWatcher libraryinjection.CSIDriverWatcher) (*Webhook, error) {
+// When rcClient is non-nil, the mutator also subscribes to remote-config SSI policies (APM_POLICIES), which are layered
+// on top of the configuration baseline at runtime.
+func NewAutoInstrumentation(datadogConfig config.Component, wmeta workloadmeta.Component, serverVersion *version.Info, csiDriverWatcher libraryinjection.CSIDriverWatcher, rcClient *rcclient.Client) (*Webhook, error) {
 	config, err := NewConfig(datadogConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create auto instrumentation config: %v", err)
@@ -34,7 +37,7 @@ func NewAutoInstrumentation(datadogConfig config.Component, wmeta workloadmeta.C
 	// Populate Kubernetes server version for feature gating.
 	config.kubeServerVersion = serverVersion
 	imageResolver := imageresolver.New(imageresolver.NewConfig(datadogConfig))
-	apm, err := NewTargetMutator(config, wmeta, imageResolver, csiDriverWatcher)
+	apm, err := NewTargetMutator(config, wmeta, imageResolver, csiDriverWatcher, rcClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create auto instrumentation namespace mutator: %v", err)
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -2715,7 +2715,7 @@ func TestAutoinstrumentation(t *testing.T) {
 				mockMeta.(workloadmetamock.Mock).Set(&ns)
 			}
 
-			webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta, nil, nil)
+			webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta, nil, nil, nil)
 			require.NoError(t, err)
 
 			// Mutate pod.
@@ -2783,7 +2783,7 @@ func TestAutoinstrumentation_LocalLibInjectionPerContainerOnlyMountsLibraryOnTar
 		mockMeta.(workloadmetamock.Mock).Set(&ns)
 	}
 
-	webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta, nil, nil)
+	webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta, nil, nil, nil)
 	require.NoError(t, err)
 
 	pod := common.FakePodSpec{
@@ -2946,7 +2946,7 @@ func TestEnvVarsAlreadySet(t *testing.T) {
 			}
 
 			// Setup webhook.
-			webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta, nil, nil)
+			webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta, nil, nil, nil)
 			require.NoError(t, err)
 
 			// Mutate pod.
@@ -3145,7 +3145,7 @@ func TestSkippedDueToResources(t *testing.T) {
 			}
 
 			// Setup webhook.
-			webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta, nil, nil)
+			webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta, nil, nil, nil)
 			require.NoError(t, err)
 
 			// Mutate pod.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/rc_policies.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/rc_policies.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"sort"
+
+	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/dd-policy-engine/go/policies"
+)
+
+// subscribeRemoteConfig wires the remote-config client to the mutator so that
+// SSI policies delivered over remote config are layered on top of the
+// configuration baseline. It is a no-op when remote config is not available,
+// in which case the mutator keeps matching against its configuration baseline
+// only. The wire format is the dd-wls policies document; targets do not appear
+// on this path.
+func (m *TargetMutator) subscribeRemoteConfig(client *rcclient.Client) {
+	if client == nil {
+		return
+	}
+
+	log.Infof("auto-instrumentation: subscribing to remote config product %q for SSI policies", state.ProductApmPolicies)
+	client.Subscribe(state.ProductApmPolicies, m.onRemoteConfigUpdate)
+	// Apply whatever the client already has, so we don't wait for the next
+	// update to reflect the current state.
+	m.onRemoteConfigUpdate(client.GetConfigs(state.ProductApmPolicies), client.UpdateApplyStatus)
+}
+
+func (m *TargetMutator) onRemoteConfigUpdate(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
+	log.Debugf("auto-instrumentation: remote config update for SSI policies: %d config(s)", len(updates))
+
+	if len(updates) == 0 {
+		m.ClearRemotePolicies()
+		return
+	}
+
+	// Sort paths so that policy precedence is deterministic across updates and
+	// Cluster Agent instances: the matcher is first-match-wins, so an
+	// inconsistent iteration order over the map would flip allow/deny decisions
+	// whenever two policy files have overlapping rules.
+	paths := make([]string, 0, len(updates))
+	for path := range updates {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	var allPolicies []policies.Policy
+	for _, path := range paths {
+		parsed, err := policies.ParsePolicies(updates[path].Config)
+		if err != nil {
+			applyStateCallback(path, state.ApplyStatus{
+				State: state.ApplyStateError,
+				Error: err.Error(),
+			})
+			log.Errorf("failed to parse SSI policies from remote config %q: %v", path, err)
+			return
+		}
+		allPolicies = append(allPolicies, parsed...)
+	}
+
+	if err := m.SetRemotePolicies(allPolicies); err != nil {
+		for path := range updates {
+			applyStateCallback(path, state.ApplyStatus{
+				State: state.ApplyStateError,
+				Error: err.Error(),
+			})
+		}
+		log.Errorf("failed to apply SSI remote policies: %v", err)
+		return
+	}
+
+	log.Infof("auto-instrumentation: applied %d SSI policies from %d remote config(s)", len(allPolicies), len(updates))
+	for path := range updates {
+		applyStateCallback(path, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/rc_policies_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/rc_policies_test.go
@@ -1,0 +1,226 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/dd-policy-engine/go/policies"
+)
+
+const rcDisabledCfg = `
+apm_config:
+  instrumentation:
+    enabled: false
+`
+
+const rcCatchAllCfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "config-default"
+        ddTraceVersions:
+          java: "default"
+`
+
+func rcPod(ns string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Labels: labels}}
+}
+
+// podLabelPolicy builds a policy matching a single pod label with exact equality.
+func podLabelPolicy(name, key, val string, inject bool, versions map[string]string) policies.Policy {
+	return policies.Policy{
+		Name:    name,
+		Rules:   policies.Leaf(policies.SourcePodLabel, key, policies.CmpExact, val),
+		Outcome: policies.Outcome{Inject: inject, TracerVersions: versions},
+	}
+}
+
+// matchedTarget returns the matched target name and whether it came from a
+// remote-config policy.
+func matchedTarget(t *testing.T, m *TargetMutator, pod *corev1.Pod) (string, bool) {
+	t.Helper()
+	target := m.getMatchingTarget(pod)
+	if target == nil {
+		return "", false
+	}
+	return target.name, target.fromPolicy
+}
+
+// TestRemotePolicies_AppliedOnEmptyBaseline verifies that remote policies match
+// even when instrumentation is disabled in the configuration (empty baseline).
+func TestRemotePolicies_AppliedOnEmptyBaseline(t *testing.T) {
+	wmeta := newMatchTestWmeta(t)
+	m := newMatchMutator(t, rcDisabledCfg, wmeta)
+
+	// No remote policies yet: nothing matches.
+	require.Nil(t, m.getMatchingTarget(rcPod("ns", map[string]string{"app": "db"})))
+
+	require.NoError(t, m.SetRemotePolicies([]policies.Policy{
+		podLabelPolicy("remote-java", "app", "db", true, map[string]string{"java": "default"}),
+	}))
+
+	name, fromPolicy := matchedTarget(t, m, rcPod("ns", map[string]string{"app": "db"}))
+	require.Equal(t, "remote-java", name)
+	require.True(t, fromPolicy)
+
+	require.Nil(t, m.getMatchingTarget(rcPod("ns", map[string]string{"app": "other"})))
+}
+
+// TestRemotePolicies_PrecedenceOverConfig verifies that remote policies are
+// evaluated before the configuration baseline (first match wins), while
+// non-matching pods still fall through to the configuration.
+func TestRemotePolicies_PrecedenceOverConfig(t *testing.T) {
+	wmeta := newMatchTestWmeta(t)
+	m := newMatchMutator(t, rcCatchAllCfg, wmeta)
+
+	// Baseline: the catch-all config target matches everything.
+	name, fromPolicy := matchedTarget(t, m, rcPod("ns", map[string]string{"app": "db"}))
+	require.Equal(t, "config-default", name)
+	require.False(t, fromPolicy)
+
+	require.NoError(t, m.SetRemotePolicies([]policies.Policy{
+		podLabelPolicy("remote", "app", "db", true, map[string]string{"python": "default"}),
+	}))
+
+	// Remote wins for the matching pod...
+	name, fromPolicy = matchedTarget(t, m, rcPod("ns", map[string]string{"app": "db"}))
+	require.Equal(t, "remote", name)
+	require.True(t, fromPolicy)
+
+	// ...but unrelated pods still fall through to the config baseline.
+	name, fromPolicy = matchedTarget(t, m, rcPod("ns", map[string]string{"app": "other"}))
+	require.Equal(t, "config-default", name)
+	require.False(t, fromPolicy)
+}
+
+// TestRemotePolicies_DenyStopsInjection verifies that a matched deny policy
+// prevents injection even when a later policy (or the config baseline) would
+// otherwise match.
+func TestRemotePolicies_DenyStopsInjection(t *testing.T) {
+	wmeta := newMatchTestWmeta(t)
+	m := newMatchMutator(t, rcCatchAllCfg, wmeta)
+
+	require.NoError(t, m.SetRemotePolicies([]policies.Policy{
+		podLabelPolicy("remote-deny", "app", "legacy", false, nil),
+	}))
+
+	// The deny policy matches first, so no target is returned even though the
+	// config catch-all would otherwise apply.
+	require.Nil(t, m.getMatchingTarget(rcPod("ns", map[string]string{"app": "legacy"})))
+
+	// A non-matching pod still hits the config baseline.
+	name, fromPolicy := matchedTarget(t, m, rcPod("ns", map[string]string{"app": "ok"}))
+	require.Equal(t, "config-default", name)
+	require.False(t, fromPolicy)
+}
+
+// TestRemotePolicies_ClearRevertsToBaseline verifies that clearing the remote
+// policies reverts the mutator to its configuration baseline.
+func TestRemotePolicies_ClearRevertsToBaseline(t *testing.T) {
+	wmeta := newMatchTestWmeta(t)
+	m := newMatchMutator(t, rcCatchAllCfg, wmeta)
+
+	require.NoError(t, m.SetRemotePolicies([]policies.Policy{
+		podLabelPolicy("remote", "app", "db", true, map[string]string{"python": "default"}),
+	}))
+	name, _ := matchedTarget(t, m, rcPod("ns", map[string]string{"app": "db"}))
+	require.Equal(t, "remote", name)
+
+	m.ClearRemotePolicies()
+	name, fromPolicy := matchedTarget(t, m, rcPod("ns", map[string]string{"app": "db"}))
+	require.Equal(t, "config-default", name)
+	require.False(t, fromPolicy)
+}
+
+// TestRemotePolicies_FirstMatchWins verifies the ordering among remote policies.
+func TestRemotePolicies_FirstMatchWins(t *testing.T) {
+	wmeta := newMatchTestWmeta(t)
+	m := newMatchMutator(t, rcDisabledCfg, wmeta)
+
+	require.NoError(t, m.SetRemotePolicies([]policies.Policy{
+		podLabelPolicy("first", "app", "db", true, map[string]string{"java": "default"}),
+		podLabelPolicy("second", "app", "db", true, map[string]string{"python": "default"}),
+	}))
+
+	name, _ := matchedTarget(t, m, rcPod("ns", map[string]string{"app": "db"}))
+	require.Equal(t, "first", name)
+}
+
+// TestOnRemoteConfigUpdate_ParsesAndApplies exercises the remote-config callback
+// end to end with a dd-wls policies document, then verifies that an empty update
+// reverts the mutator to the configuration baseline.
+func TestOnRemoteConfigUpdate_ParsesAndApplies(t *testing.T) {
+	wmeta := newMatchTestWmeta(t)
+	m := newMatchMutator(t, rcCatchAllCfg, wmeta)
+
+	const raw = `{
+      "policies": [{
+        "description": "java for db-user",
+        "rules": {
+          "node_type": "EvaluatorNode",
+          "node": {
+            "eval_type": "StrEvaluator",
+            "eval": {"id": "POD_LABEL", "cmp": "CMP_EXACT", "value": "app=db-user"}
+          }
+        },
+        "actions": [
+          {"action": "INJECT_ALLOW"},
+          {"action": "ENABLE_SDK", "values": ["java=latest"]}
+        ]
+      }]
+    }`
+
+	var applied []state.ApplyStatus
+	apply := func(_ string, s state.ApplyStatus) { applied = append(applied, s) }
+
+	m.onRemoteConfigUpdate(map[string]state.RawConfig{
+		"datadog/2/APM_POLICIES/policy-1/config": {Config: []byte(raw)},
+	}, apply)
+
+	require.Len(t, applied, 1)
+	require.Equal(t, state.ApplyStateAcknowledged, applied[0].State)
+
+	name, fromPolicy := matchedTarget(t, m, rcPod("ns", map[string]string{"app": "db-user"}))
+	require.Equal(t, "java for db-user", name)
+	require.True(t, fromPolicy)
+
+	// An empty update reverts to the config baseline.
+	m.onRemoteConfigUpdate(map[string]state.RawConfig{}, apply)
+	name, fromPolicy = matchedTarget(t, m, rcPod("ns", map[string]string{"app": "db-user"}))
+	require.Equal(t, "config-default", name)
+	require.False(t, fromPolicy)
+}
+
+// TestOnRemoteConfigUpdate_InvalidPayloadKeepsBaseline verifies that a malformed
+// policies document is reported as an error and does not disturb the baseline.
+func TestOnRemoteConfigUpdate_InvalidPayloadKeepsBaseline(t *testing.T) {
+	wmeta := newMatchTestWmeta(t)
+	m := newMatchMutator(t, rcCatchAllCfg, wmeta)
+
+	var applied []state.ApplyStatus
+	apply := func(_ string, s state.ApplyStatus) { applied = append(applied, s) }
+
+	m.onRemoteConfigUpdate(map[string]state.RawConfig{
+		"datadog/2/APM_POLICIES/bad/config": {Config: []byte("{")},
+	}, apply)
+
+	require.Len(t, applied, 1)
+	require.Equal(t, state.ApplyStateError, applied[0].State)
+
+	// Baseline is untouched.
+	name, fromPolicy := matchedTarget(t, m, rcPod("ns", map[string]string{"app": "db"}))
+	require.Equal(t, "config-default", name)
+	require.False(t, fromPolicy)
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_matching_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_matching_test.go
@@ -61,7 +61,7 @@ func newMatchMutator(t *testing.T, yamlCfg string, wmeta workloadmeta.Component)
 	mockConfig.SetInTest("admission_controller.auto_instrumentation.container_registry", "registry")
 	config, err := NewConfig(mockConfig)
 	require.NoError(t, err)
-	m, err := NewTargetMutator(config, wmeta, imageResolver, nil)
+	m, err := NewTargetMutator(config, wmeta, imageResolver, nil, nil)
 	require.NoError(t, err)
 	return m
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.uber.org/atomic"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
@@ -25,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/dd-policy-engine/go/policies"
 )
@@ -32,28 +34,43 @@ import (
 const (
 	// AppliedTargetEnvVar is the environment variable that contains the JSON of the target that was applied to the pod.
 	AppliedTargetEnvVar = "DD_INSTRUMENTATION_APPLIED_TARGET"
+	// AppliedPolicyEnvVar is the environment variable that contains the compact JSON of the policy that was applied to the pod.
+	AppliedPolicyEnvVar = "DD_INSTRUMENTATION_APPLIED_POLICY"
 )
+
+// policySet is an immutable, atomically swappable view of the policies a
+// TargetMutator matches against. matcher.policies and targets are aligned by
+// index, so a match resolves directly to its injection config. A disabled
+// mutator is simply represented by an empty set (no targets, no policies),
+// which naturally matches nothing.
+type policySet struct {
+	targets []targetInternal
+	matcher *policyMatcher
+}
 
 // TargetMutator is an autoinstrumentation mutator that filters pods based on the target based workload selection.
 type TargetMutator struct {
-	enabled bool
-	core    *mutatorCore
-	targets []targetInternal
-	// matcher evaluates the policies derived from the configuration targets.
-	// matcher.policies and targets are aligned by index, so a match resolves
-	// directly to its injection config.
-	matcher                       *policyMatcher
+	core                          *mutatorCore
 	disabledNamespaces            map[string]bool
 	securityClientLibraryMutator  containerMutator
 	profilingClientLibraryMutator containerMutator
 	containerRegistry             string
 	mutateUnlabelled              bool
 	defaultLibVersions            []libInfo
+
+	// base is the policy set derived from the agent configuration file. It is
+	// the baseline that remote-config policies are layered on top of.
+	base policySet
+	// active is the effective policy set: base when no remote policies are
+	// present, or remote policies (taking precedence) layered on top of base
+	// otherwise. It is swapped atomically on remote-config updates.
+	active atomic.Pointer[policySet]
 }
 
 // NewTargetMutator creates a new mutator for target based workload selection. We convert the targets to a more
-// efficient internal format for quick lookups.
-func NewTargetMutator(config *Config, wmeta workloadmeta.Component, imageResolver imageresolver.Resolver, csiDriverWatcher libraryinjection.CSIDriverWatcher) (*TargetMutator, error) {
+// efficient internal format for quick lookups. When rcClient is non-nil, the mutator also subscribes to remote-config
+// SSI policies, which are layered on top of the configuration baseline at runtime.
+func NewTargetMutator(config *Config, wmeta workloadmeta.Component, imageResolver imageresolver.Resolver, csiDriverWatcher libraryinjection.CSIDriverWatcher, rcClient *rcclient.Client) (*TargetMutator, error) {
 	// Create a map of user-configured disabled namespaces for quick lookups.
 	// Default namespaces (kube-system, datadog agent namespace) are excluded at
 	// the webhook layer via namespace selectors and not duplicated here.
@@ -66,114 +83,202 @@ func NewTargetMutator(config *Config, wmeta workloadmeta.Component, imageResolve
 	defaultLibVersions := getAllLatestDefaultLibraries(config.containerRegistry)
 
 	// If there are no targets, we should fall back to enabledNamespace/libVersions. If those are also not defined, the
-	// expected behavior is to inject all pods into all namespaces.
-	var internalTargets []targetInternal
-	// configPolicies is the policy form of the configuration targets, aligned
-	// by index with internalTargets. Pod matching is delegated to the native
-	// policy engine; an empty set (disabled mutator) naturally matches nothing.
-	var configPolicies []policies.Policy
+	// expected behavior is to inject all pods into all namespaces. A disabled mutator keeps an empty baseline so it
+	// matches nothing unless remote-config policies are layered on.
+	var targets []Target
 	if config.Instrumentation.Enabled {
-		targets := config.Instrumentation.Targets
+		targets = config.Instrumentation.Targets
 		if len(targets) == 0 {
 			targets = append(targets, createDefaultTarget(config.Instrumentation.EnabledNamespaces, config.Instrumentation.LibVersions))
 		}
-
-		// Lower the configuration targets into policies once, at the config
-		// boundary. Everything past this point matches on policies only.
-		configPolicies = policiesFromTargets(targets)
-
-		// Convert the targets to internal format.
-		internalTargets = make([]targetInternal, len(targets))
-		for i, t := range targets {
-			// Convert the pod selector to a label selector.
-			podSelector := labels.Everything()
-			var err error
-			if t.PodSelector != nil {
-				podSelector, err = t.PodSelector.AsLabelSelector()
-				if err != nil {
-					return nil, fmt.Errorf("could not convert selector to label selector: %w", err)
-				}
-			}
-
-			// Determine if we should use the namespace selector or if we should use enabledNamespaces.
-			useNamespaceSelector := t.NamespaceSelector != nil && len(t.NamespaceSelector.MatchLabels)+len(t.NamespaceSelector.MatchExpressions) > 0
-
-			// Convert the namespace selector to a label selector.
-			namespaceSelector := labels.Everything()
-			if useNamespaceSelector && t.NamespaceSelector != nil {
-				namespaceSelector, err = t.NamespaceSelector.AsLabelSelector()
-				if err != nil {
-					return nil, fmt.Errorf("could not convert selector to label selector: %w", err)
-				}
-			}
-
-			// Create a map of enabled namespaces for quick lookups.
-			var enabledNamespaces map[string]bool
-			if !useNamespaceSelector && t.NamespaceSelector != nil {
-				enabledNamespaces = make(map[string]bool, len(t.NamespaceSelector.MatchNames))
-				for _, ns := range t.NamespaceSelector.MatchNames {
-					enabledNamespaces[ns] = true
-				}
-			}
-
-			// We build the libVersions based on if they are specified in `tracerVersions` else ask the higher-level configuration from `libVersions`
-			// and/or defer to language detection.
-			var libVersions []libInfo
-			usesDefaultLibs := false
-			if len(t.TracerVersions) == 0 {
-				libVersions = defaultLibVersions
-				usesDefaultLibs = true
-			} else {
-				pinnedLibraries := getPinnedLibraries(t.TracerVersions, config.containerRegistry, true)
-				usesDefaultLibs = pinnedLibraries.areSetToDefaults
-				libVersions = pinnedLibraries.libs
-			}
-
-			// Convert the tracer configs to env vars. We check that the env var names start with the DD_ prefix to avoid
-			// this from being used as a generic env var injector. If there is a product requirement to allow arbitrary env
-			// vars in the future, we could relax this requirement.
-			envVars := make([]corev1.EnvVar, len(t.TracerConfigs))
-			for i, tc := range t.TracerConfigs {
-				if !strings.HasPrefix(tc.Name, "DD_") {
-					return nil, fmt.Errorf("tracer config %q does not start with DD_", tc.Name)
-				}
-				envVars[i] = tc.AsEnvVar()
-			}
-
-			// Store the target in the internal format.
-			internalTargets[i] = targetInternal{
-				name:                 t.Name,
-				podSelector:          podSelector,
-				useNamespaceSelector: useNamespaceSelector,
-				nameSpaceSelector:    namespaceSelector,
-				wmeta:                wmeta,
-				enabledNamespaces:    enabledNamespaces,
-				libVersions:          libVersions,
-				envVars:              envVars,
-				json:                 createJSON(t),
-				usesDefaultLibs:      usesDefaultLibs,
-			}
-		}
 	}
 
+	internalTargets, err := buildInternalTargets(config, wmeta, targets, defaultLibVersions)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lower the configuration targets into policies once, at the config
+	// boundary. Everything past this point matches on policies only, aligned
+	// by index with the internal targets above.
+	configPolicies := policiesFromTargets(targets)
+
 	m := &TargetMutator{
-		enabled:                       config.Instrumentation.Enabled,
-		targets:                       internalTargets,
-		matcher:                       newPolicyMatcher(configPolicies, wmeta),
 		disabledNamespaces:            disabledNamespacesMap,
 		securityClientLibraryMutator:  config.securityClientLibraryMutator,
 		profilingClientLibraryMutator: config.profilingClientLibraryMutator,
 		containerRegistry:             config.containerRegistry,
 		mutateUnlabelled:              config.mutateUnlabelled,
 		defaultLibVersions:            defaultLibVersions,
+		base: policySet{
+			targets: internalTargets,
+			matcher: newPolicyMatcher(configPolicies, wmeta),
+		},
 	}
+	m.active.Store(&m.base)
 
 	// Create the core mutator. This is a bit gross.
 	// The target mutator is also the filter which we are passing in.
 	core := newMutatorCore(config, wmeta, m, imageResolver, csiDriverWatcher)
 	m.core = core
 
+	// Subscribe to remote-config SSI policies, if available. This is a no-op
+	// when rcClient is nil (e.g. in tests or when remote config is disabled).
+	m.subscribeRemoteConfig(rcClient)
+
 	return m, nil
+}
+
+// buildInternalTargets converts configuration targets into the internal format used for matching and injection.
+func buildInternalTargets(config *Config, wmeta workloadmeta.Component, targets []Target, defaultLibVersions []libInfo) ([]targetInternal, error) {
+	internalTargets := make([]targetInternal, len(targets))
+	for i, t := range targets {
+		// Convert the pod selector to a label selector.
+		podSelector := labels.Everything()
+		var err error
+		if t.PodSelector != nil {
+			podSelector, err = t.PodSelector.AsLabelSelector()
+			if err != nil {
+				return nil, fmt.Errorf("could not convert selector to label selector: %w", err)
+			}
+		}
+
+		// Determine if we should use the namespace selector or if we should use enabledNamespaces.
+		useNamespaceSelector := t.NamespaceSelector != nil && len(t.NamespaceSelector.MatchLabels)+len(t.NamespaceSelector.MatchExpressions) > 0
+
+		// Convert the namespace selector to a label selector.
+		namespaceSelector := labels.Everything()
+		if useNamespaceSelector && t.NamespaceSelector != nil {
+			namespaceSelector, err = t.NamespaceSelector.AsLabelSelector()
+			if err != nil {
+				return nil, fmt.Errorf("could not convert selector to label selector: %w", err)
+			}
+		}
+
+		// Create a map of enabled namespaces for quick lookups.
+		var enabledNamespaces map[string]bool
+		if !useNamespaceSelector && t.NamespaceSelector != nil {
+			enabledNamespaces = make(map[string]bool, len(t.NamespaceSelector.MatchNames))
+			for _, ns := range t.NamespaceSelector.MatchNames {
+				enabledNamespaces[ns] = true
+			}
+		}
+
+		// We build the libVersions based on if they are specified in `tracerVersions` else ask the higher-level configuration from `libVersions`
+		// and/or defer to language detection.
+		var libVersions []libInfo
+		usesDefaultLibs := false
+		if len(t.TracerVersions) == 0 {
+			libVersions = defaultLibVersions
+			usesDefaultLibs = true
+		} else {
+			pinnedLibraries := getPinnedLibraries(t.TracerVersions, config.containerRegistry, true)
+			usesDefaultLibs = pinnedLibraries.areSetToDefaults
+			libVersions = pinnedLibraries.libs
+		}
+
+		// Convert the tracer configs to env vars. We check that the env var names start with the DD_ prefix to avoid
+		// this from being used as a generic env var injector. If there is a product requirement to allow arbitrary env
+		// vars in the future, we could relax this requirement.
+		envVars := make([]corev1.EnvVar, len(t.TracerConfigs))
+		for j, tc := range t.TracerConfigs {
+			if !strings.HasPrefix(tc.Name, "DD_") {
+				return nil, fmt.Errorf("tracer config %q does not start with DD_", tc.Name)
+			}
+			envVars[j] = tc.AsEnvVar()
+		}
+
+		// Store the target in the internal format.
+		internalTargets[i] = targetInternal{
+			name:                 t.Name,
+			podSelector:          podSelector,
+			useNamespaceSelector: useNamespaceSelector,
+			nameSpaceSelector:    namespaceSelector,
+			wmeta:                wmeta,
+			enabledNamespaces:    enabledNamespaces,
+			libVersions:          libVersions,
+			envVars:              envVars,
+			json:                 createJSON(t),
+			usesDefaultLibs:      usesDefaultLibs,
+		}
+	}
+
+	return internalTargets, nil
+}
+
+// activeSet returns the effective policy set. It is never nil after the
+// mutator has been constructed.
+func (m *TargetMutator) activeSet() *policySet {
+	return m.active.Load()
+}
+
+// SetRemotePolicies layers remote-config policies on top of the configuration
+// baseline and swaps in the result atomically. Remote policies are evaluated
+// first (they take precedence), then the configuration policies, preserving
+// first-match-wins semantics.
+func (m *TargetMutator) SetRemotePolicies(ps []policies.Policy) error {
+	remoteTargets, err := buildInternalTargetsFromPolicies(m.core.config, m.core.wmeta, ps, m.defaultLibVersions)
+	if err != nil {
+		return err
+	}
+
+	combinedPolicies := make([]policies.Policy, 0, len(ps)+len(m.base.matcher.policies))
+	combinedPolicies = append(combinedPolicies, ps...)
+	combinedPolicies = append(combinedPolicies, m.base.matcher.policies...)
+
+	combinedTargets := make([]targetInternal, 0, len(remoteTargets)+len(m.base.targets))
+	combinedTargets = append(combinedTargets, remoteTargets...)
+	combinedTargets = append(combinedTargets, m.base.targets...)
+
+	m.active.Store(&policySet{
+		targets: combinedTargets,
+		matcher: newPolicyMatcher(combinedPolicies, m.core.wmeta),
+	})
+	return nil
+}
+
+// ClearRemotePolicies reverts the mutator to the configuration baseline.
+func (m *TargetMutator) ClearRemotePolicies() {
+	m.active.Store(&m.base)
+}
+
+// buildInternalTargetsFromPolicies resolves each policy's outcome (tracer
+// versions and configs) into the internal injection format, mirroring
+// buildInternalTargets but sourced from policies rather than Targets.
+func buildInternalTargetsFromPolicies(config *Config, wmeta workloadmeta.Component, ps []policies.Policy, defaultLibVersions []libInfo) ([]targetInternal, error) {
+	internalTargets := make([]targetInternal, len(ps))
+	for i, p := range ps {
+		var libVersions []libInfo
+		usesDefaultLibs := false
+		if len(p.Outcome.TracerVersions) == 0 {
+			libVersions = defaultLibVersions
+			usesDefaultLibs = true
+		} else {
+			pinnedLibraries := getPinnedLibraries(p.Outcome.TracerVersions, config.containerRegistry, true)
+			usesDefaultLibs = pinnedLibraries.areSetToDefaults
+			libVersions = pinnedLibraries.libs
+		}
+
+		envVars := make([]corev1.EnvVar, len(p.Outcome.TracerConfigs))
+		for j, tc := range p.Outcome.TracerConfigs {
+			if !strings.HasPrefix(tc.Name, "DD_") {
+				return nil, fmt.Errorf("tracer config %q does not start with DD_", tc.Name)
+			}
+			envVars[j] = corev1.EnvVar{Name: tc.Name, Value: tc.Value}
+		}
+
+		internalTargets[i] = targetInternal{
+			name:            p.Name,
+			wmeta:           wmeta,
+			libVersions:     libVersions,
+			envVars:         envVars,
+			json:            createPolicyJSON(p),
+			usesDefaultLibs: usesDefaultLibs,
+			fromPolicy:      true,
+		}
+	}
+
+	return internalTargets, nil
 }
 
 // MutatePod mutates the pod if it matches the target based workload selection or has the appropriate annotations.
@@ -255,14 +360,23 @@ func (m *TargetMutator) MutatePod(pod *corev1.Pod, ns string, _ dynamic.Interfac
 }
 
 func (m *TargetMutator) addTargetJSONInfo(pod *corev1.Pod, target *targetInternal) {
+	// A policy-driven match (remote config) carries its information on a
+	// dedicated env var / annotation, distinct from configuration targets.
+	envVarName := AppliedTargetEnvVar
+	annotationKey := annotation.AppliedTarget
+	if target.fromPolicy {
+		envVarName = AppliedPolicyEnvVar
+		annotationKey = annotation.AppliedPolicy
+	}
+
 	// Inject the target json. The is added so that the injector can make use of the target information.
 	_ = m.core.mutatePodContainers(pod, envVarMutator(corev1.EnvVar{
-		Name:  AppliedTargetEnvVar,
+		Name:  envVarName,
 		Value: target.json,
 	}), true)
 
 	// Add the annotations to the pod.
-	annotation.Set(pod, annotation.AppliedTarget, target.json)
+	annotation.Set(pod, annotationKey, target.json)
 }
 
 // ShouldMutatePod determines if a pod would be mutated by the target mutator. It is used by other webhook mutators as
@@ -285,18 +399,16 @@ func (m *TargetMutator) ShouldMutatePod(pod *corev1.Pod) bool {
 
 // IsNamespaceEligible returns true if a namespace is eligible for injection/mutation.
 func (m *TargetMutator) IsNamespaceEligible(namespace string) bool {
-	// Return if the mutator is disabled.
-	if !m.enabled {
-		return false
-	}
+	set := m.activeSet()
 
 	// If the namespace is disabled, we don't need to check the targets.
 	if _, ok := m.disabledNamespaces[namespace]; ok {
 		return false
 	}
 
-	// Check if the namespace matches any of the targets.
-	for _, target := range m.targets {
+	// Check if the namespace matches any of the targets. A disabled mutator has
+	// no targets, so this naturally returns false.
+	for _, target := range set.targets {
 		matches, err := target.matchesNamespaceSelector(namespace)
 		if err != nil {
 			log.Errorf("error encountered matching targets, aborting all together to avoid inaccurate match: %v", err)
@@ -325,6 +437,10 @@ type targetInternal struct {
 	wmeta                workloadmeta.Component
 	json                 string
 	usesDefaultLibs      bool
+	// fromPolicy is true when this internal target was derived from a policy
+	// (remote config) rather than a configuration target. It selects which
+	// annotation/env var carries the applied information.
+	fromPolicy bool
 }
 
 // getTarget determines which target to use for a given a pod, which includes the set of tracing libraries to inject.
@@ -394,10 +510,7 @@ func (m *TargetMutator) getTargetFromAnnotation(pod *corev1.Pod) *annotationResu
 // the first policy that evaluates to true wins, preserving the previous
 // first-match semantics without relying on CGO or k8s label selectors.
 func (m *TargetMutator) getMatchingTarget(pod *corev1.Pod) *targetInternal {
-	// If instrumentation is disabled, we don't need to check the targets.
-	if !m.enabled {
-		return nil
-	}
+	set := m.activeSet()
 
 	// If the namespace is disabled, we don't need to check the targets.
 	if _, ok := m.disabledNamespaces[pod.Namespace]; ok {
@@ -405,14 +518,21 @@ func (m *TargetMutator) getMatchingTarget(pod *corev1.Pod) *targetInternal {
 	}
 
 	// The matcher and targets are aligned by index, so the first matching
-	// policy resolves directly to its injection config (first match wins).
-	idx := m.matcher.matchIndex(pod)
-	if idx < 0 || idx >= len(m.targets) {
+	// policy resolves directly to its injection config (first match wins). A
+	// disabled mutator has an empty set, so matchIndex returns -1 below.
+	idx := set.matcher.matchIndex(pod)
+	if idx < 0 || idx >= len(set.targets) {
 		return nil
 	}
 
-	log.Debugf("Pod %q matched target %q", mutatecommon.PodString(pod), m.targets[idx].name)
-	return &m.targets[idx]
+	// A matched policy may explicitly deny injection (first match wins).
+	if !set.matcher.policies[idx].Outcome.Inject {
+		log.Debugf("Pod %q matched policy %q which denies injection", mutatecommon.PodString(pod), set.targets[idx].name)
+		return nil
+	}
+
+	log.Debugf("Pod %q matched target %q", mutatecommon.PodString(pod), set.targets[idx].name)
+	return &set.targets[idx]
 }
 
 func (t targetInternal) matchesNamespaceSelector(namespace string) (bool, error) {
@@ -468,6 +588,29 @@ func createJSON(t Target) string {
 	if err != nil {
 		log.Errorf("error marshalling target %q: %v", t.Name, err)
 		return fmt.Sprintf("error marshalling target %q: %v", t.Name, err)
+	}
+	return string(data)
+}
+
+// createPolicyJSON creates the compact annotation payload for a policy-driven
+// match. It intentionally omits the rule tree and keeps only the policy
+// identity (name, version) and the tracer versions that were injected.
+func createPolicyJSON(p policies.Policy) string {
+	payload := struct {
+		Name           string            `json:"name,omitempty"`
+		ID             string            `json:"id,omitempty"`
+		Version        int64             `json:"version,omitempty"`
+		TracerVersions map[string]string `json:"ddTraceVersions,omitempty"`
+	}{
+		Name:           p.Name,
+		ID:             p.ID,
+		Version:        p.Version,
+		TracerVersions: p.Outcome.TracerVersions,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		log.Errorf("error marshalling policy %q: %v", p.Name, err)
+		return ""
 	}
 	return string(data)
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -88,7 +88,7 @@ func TestNewTargetMutator(t *testing.T) {
 			))
 
 			// Create the mutator.
-			_, err = NewTargetMutator(config, wmeta, imageResolver, nil)
+			_, err = NewTargetMutator(config, wmeta, imageResolver, nil, nil)
 
 			// Validate the output.
 			if test.shouldErr {
@@ -244,7 +244,7 @@ func TestMutatePod(t *testing.T) {
 			}
 
 			// Create the mutator.
-			f, err := NewTargetMutator(config, wmeta, imageresolver.NewNoOpResolver(), nil)
+			f, err := NewTargetMutator(config, wmeta, imageresolver.NewNoOpResolver(), nil, nil)
 			require.NoError(t, err)
 
 			input := test.in.DeepCopy()
@@ -349,7 +349,7 @@ func TestShouldMutatePod(t *testing.T) {
 			}
 
 			// Create the mutator.
-			f, err := NewTargetMutator(config, wmeta, imageresolver.NewNoOpResolver(), nil)
+			f, err := NewTargetMutator(config, wmeta, imageresolver.NewNoOpResolver(), nil, nil)
 			require.NoError(t, err)
 
 			// Determine if the pod should be mutated.
@@ -435,7 +435,7 @@ func TestIsNamespaceEligible(t *testing.T) {
 			}
 
 			// Create the mutator.
-			f, err := NewTargetMutator(config, wmeta, imageresolver.NewNoOpResolver(), nil)
+			f, err := NewTargetMutator(config, wmeta, imageresolver.NewNoOpResolver(), nil, nil)
 			require.NoError(t, err)
 
 			// Determine if the namespace is eligible.
@@ -515,7 +515,7 @@ func TestGetTargetFromAnnotation(t *testing.T) {
 			))
 
 			// Create the mutator.
-			f, err := NewTargetMutator(config, wmeta, imageresolver.NewNoOpResolver(), nil)
+			f, err := NewTargetMutator(config, wmeta, imageresolver.NewNoOpResolver(), nil, nil)
 			require.NoError(t, err)
 
 			// Get the target from the annotation.
@@ -786,7 +786,7 @@ func TestGetTargetLibraries(t *testing.T) {
 			}
 
 			// Create the mutator.
-			f, err := NewTargetMutator(config, wmeta, imageResolver, nil)
+			f, err := NewTargetMutator(config, wmeta, imageResolver, nil, nil)
 			require.NoError(t, err)
 
 			// Filter the pod.
@@ -904,7 +904,7 @@ func TestLanguageDetection(t *testing.T) {
 			wmeta := mutatecommon.FakeStoreWithDeployment(t, test.deployments)
 
 			// Create the mutator.
-			m, err := NewTargetMutator(config, wmeta, imageResolver, nil)
+			m, err := NewTargetMutator(config, wmeta, imageResolver, nil, nil)
 			require.NoError(t, err)
 
 			// Mutate the pod.

--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -24,6 +24,7 @@ import (
 	clusterspot "github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/cluster/spot"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
+	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -49,6 +50,7 @@ type ControllerContext struct {
 	FilterStore                  workloadfilter.Component
 	InstrumentationHandlers      []instrumentation.Handler
 	CSIDriverWatcher             libraryinjection.CSIDriverWatcher
+	RcClient                     *rcclient.Client
 }
 
 // StartControllers starts the secret and webhook controllers
@@ -109,6 +111,7 @@ func StartControllers(ctx ControllerContext, datadogConfig config.Component, wme
 		pp,
 		sh,
 		datadogConfig,
+		ctx.RcClient,
 		ctx.Demultiplexer,
 		ctx.FilterStore,
 		ctx.InstrumentationHandlers,


### PR DESCRIPTION
## Description

Stacked on top of #(previous PR: `luc/wls-target-policy-compiler`, using native Go policies).

This PR wires **Remote Config** for Single Step Instrumentation on the Cluster Agent: the auto-instrumentation webhook subscribes to the `APM_POLICIES` product and layers the SSI policies delivered by RC on top of the configuration baseline at runtime.

- `TargetMutator` now holds a base `policySet` (config) plus an atomically swapped `active atomic.Pointer[policySet]` → hot-reload of RC policies without locking.
- RC policies are evaluated **before** config targets (first-match-wins) and support explicit **deny** (`Outcome.Inject == false`).
- `rc_policies.go`: subscribe to `state.ProductApmPolicies`, parse the dd-wls document via `dd-policy-engine` (`ParsePolicies`), apply/clear on each update (deterministic path sorting).
- `rcClient` is wired from `cmd/cluster-agent` through the webhook controllers down to `NewTargetMutator`.

## Type of Change

- [x] New feature

## Checklist

- [x] Tests added or updated
- [x] No unintended breaking changes

## How Has This Been Tested?

- Unit tests for the `autoinstrumentation` package (including `rc_policies_test.go`: apply on empty baseline, RC precedence over config, deny, clear, first-match-wins, `onRemoteConfigUpdate` parsing/reset/invalid payload): PASS.
- Webhook controller tests: PASS.
- `go build`/`go vet` (`kubeapiserver`) OK on all touched packages + `cmd/cluster-agent`.

## Additional Notes

PR #2 of the PoC split. The base PR (`luc/wls-target-policy-compiler`) must be merged first. No changes to `pkg/config/remote/service/service.go` (debug logging was removed).