### PR TITLE
[ACTP] fetch existing RC configuration on PAR startup

### DIFF
--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
@@ -31,6 +31,8 @@ func (m *mockedRcClient) Subscribe(data.Product, func(map[string]state.RawConfig
 
 func (m *mockedRcClient) GetConfigs(data.Product) map[string]state.RawConfig { return nil }
 
+func (m *mockedRcClient) UpdateApplyStatus(_ string, _ state.ApplyStatus) {}
+
 type mockedAutodiscoveryActions struct {
 	autodiscovery.Component
 	configs []integration.Config

--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
@@ -29,6 +29,8 @@ func (m *mockedRcClient) SubscribeAgentTask() {}
 func (m *mockedRcClient) Subscribe(data.Product, func(map[string]state.RawConfig, func(string, state.ApplyStatus))) {
 }
 
+func (m *mockedRcClient) GetConfigs(data.Product) map[string]state.RawConfig { return nil }
+
 type mockedAutodiscoveryActions struct {
 	autodiscovery.Component
 	configs []integration.Config

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -34,6 +34,8 @@ func (m *mockRCClient) Subscribe(_ data.Product, fn func(map[string]state.RawCon
 
 func (m *mockRCClient) GetConfigs(_ data.Product) map[string]state.RawConfig { return nil }
 
+func (m *mockRCClient) UpdateApplyStatus(_ string, _ state.ApplyStatus) {}
+
 func newMockRCClient() *mockRCClient {
 	return &mockRCClient{
 		subscribedCh: make(chan func(map[string]state.RawConfig, func(string, state.ApplyStatus)), 1),

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -32,6 +32,8 @@ func (m *mockRCClient) Subscribe(_ data.Product, fn func(map[string]state.RawCon
 	m.subscribedCh <- fn
 }
 
+func (m *mockRCClient) GetConfigs(_ data.Product) map[string]state.RawConfig { return nil }
+
 func newMockRCClient() *mockRCClient {
 	return &mockRCClient{
 		subscribedCh: make(chan func(map[string]state.RawConfig, func(string, state.ApplyStatus)), 1),

--- a/comp/remote-config/rcclient/def/component.go
+++ b/comp/remote-config/rcclient/def/component.go
@@ -21,6 +21,8 @@ type Component interface {
 	// Subscribe is the generic way to start listening to a specific product update
 	// Component can also automatically subscribe to updates by returning a `ListenerProvider` struct
 	Subscribe(product data.Product, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)))
+	// GetConfigs returns the current configs applied for a product.
+	GetConfigs(product data.Product) map[string]state.RawConfig
 }
 
 // Params is the input parameter struct for the RC client Component.

--- a/comp/remote-config/rcclient/def/component.go
+++ b/comp/remote-config/rcclient/def/component.go
@@ -23,6 +23,9 @@ type Component interface {
 	Subscribe(product data.Product, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)))
 	// GetConfigs returns the current configs applied for a product.
 	GetConfigs(product data.Product) map[string]state.RawConfig
+	// UpdateApplyStatus updates the apply status of a config in the RC repository.
+	// Use this to report acknowledgement or errors for configs obtained via GetConfigs.
+	UpdateApplyStatus(cfgPath string, status state.ApplyStatus)
 }
 
 // Params is the input parameter struct for the RC client Component.

--- a/comp/remote-config/rcclient/impl/rcclient.go
+++ b/comp/remote-config/rcclient/impl/rcclient.go
@@ -348,6 +348,14 @@ func (rc *rcClient) Subscribe(product data.Product, fn func(update map[string]st
 	rc.client.Subscribe(string(product), fn)
 }
 
+// GetConfigs returns the current configs applied for a product.
+func (rc *rcClient) GetConfigs(product data.Product) map[string]state.RawConfig {
+	if rc.client == nil {
+		return nil
+	}
+	return rc.client.GetConfigs(string(product))
+}
+
 func (rc *rcClient) agentConfigUpdateCallback(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
 	mergedConfig, err := state.MergeRCAgentConfig(rc.client.UpdateApplyStatus, updates)
 	if err != nil {

--- a/comp/remote-config/rcclient/impl/rcclient.go
+++ b/comp/remote-config/rcclient/impl/rcclient.go
@@ -356,6 +356,14 @@ func (rc *rcClient) GetConfigs(product data.Product) map[string]state.RawConfig 
 	return rc.client.GetConfigs(string(product))
 }
 
+// UpdateApplyStatus updates the apply status of a config in the RC repository.
+func (rc *rcClient) UpdateApplyStatus(cfgPath string, status state.ApplyStatus) {
+	if rc.client == nil {
+		return
+	}
+	rc.client.UpdateApplyStatus(cfgPath, status)
+}
+
 func (rc *rcClient) agentConfigUpdateCallback(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
 	mergedConfig, err := state.MergeRCAgentConfig(rc.client.UpdateApplyStatus, updates)
 	if err != nil {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -2173,6 +2173,8 @@ func (m *mockRCClient) Subscribe(product data.Product, fn func(update map[string
 	fn(m.profiles, m.applyStateCallback)
 }
 
+func (m *mockRCClient) GetConfigs(_ data.Product) map[string]state.RawConfig { return nil }
+
 func TestExplicitRCConfig(t *testing.T) {
 	// language=yaml
 	rawInstanceConfig := []byte(`

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -2175,6 +2175,8 @@ func (m *mockRCClient) Subscribe(product data.Product, fn func(update map[string
 
 func (m *mockRCClient) GetConfigs(_ data.Product) map[string]state.RawConfig { return nil }
 
+func (m *mockRCClient) UpdateApplyStatus(_ string, _ state.ApplyStatus) {}
+
 func TestExplicitRCConfig(t *testing.T) {
 	// language=yaml
 	rawInstanceConfig := []byte(`

--- a/pkg/ebpf/rc_btf_test.go
+++ b/pkg/ebpf/rc_btf_test.go
@@ -51,6 +51,8 @@ func (rc *mockRCClient) SubscribeAgentTask() {}
 
 func (rc *mockRCClient) GetConfigs(_ data.Product) map[string]state.RawConfig { return nil }
 
+func (rc *mockRCClient) UpdateApplyStatus(_ string, _ state.ApplyStatus) {}
+
 func TestRemoteConfigBTFTimeout(t *testing.T) {
 	skipIfUnsupported(t)
 	cfg := &Config{

--- a/pkg/ebpf/rc_btf_test.go
+++ b/pkg/ebpf/rc_btf_test.go
@@ -49,6 +49,8 @@ func (rc *mockRCClient) Subscribe(product data.Product, fn func(update map[strin
 
 func (rc *mockRCClient) SubscribeAgentTask() {}
 
+func (rc *mockRCClient) GetConfigs(_ data.Product) map[string]state.RawConfig { return nil }
+
 func TestRemoteConfigBTFTimeout(t *testing.T) {
 	skipIfUnsupported(t)
 	cfg := &Config{

--- a/pkg/privateactionrunner/adapters/rcclient/rc_client_adapter.go
+++ b/pkg/privateactionrunner/adapters/rcclient/rc_client_adapter.go
@@ -13,6 +13,7 @@ import (
 
 type Client interface {
 	Subscribe(product string, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)))
+	GetConfigs(product string) map[string]state.RawConfig
 }
 
 type adapter struct {
@@ -27,4 +28,8 @@ func NewAdapter(comp rcclient.Component) Client {
 
 func (a *adapter) Subscribe(product string, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus))) {
 	a.comp.Subscribe(data.Product(product), fn)
+}
+
+func (a *adapter) GetConfigs(product string) map[string]state.RawConfig {
+	return a.comp.GetConfigs(data.Product(product))
 }

--- a/pkg/privateactionrunner/adapters/rcclient/rc_client_adapter.go
+++ b/pkg/privateactionrunner/adapters/rcclient/rc_client_adapter.go
@@ -14,6 +14,7 @@ import (
 type Client interface {
 	Subscribe(product string, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)))
 	GetConfigs(product string) map[string]state.RawConfig
+	UpdateApplyStatus(cfgPath string, status state.ApplyStatus)
 }
 
 type adapter struct {
@@ -32,4 +33,8 @@ func (a *adapter) Subscribe(product string, fn func(update map[string]state.RawC
 
 func (a *adapter) GetConfigs(product string) map[string]state.RawConfig {
 	return a.comp.GetConfigs(data.Product(product))
+}
+
+func (a *adapter) UpdateApplyStatus(cfgPath string, status state.ApplyStatus) {
+	a.comp.UpdateApplyStatus(cfgPath, status)
 }

--- a/pkg/privateactionrunner/task-verifier/keys_manager.go
+++ b/pkg/privateactionrunner/task-verifier/keys_manager.go
@@ -58,6 +58,12 @@ func NewKeyManager(rcClient rcclient.Client) KeysManager {
 func (k *keysManager) Start(ctx context.Context) {
 	log.FromContext(ctx).Info("Subscribing to remote config updates")
 	k.rcClient.Subscribe(state.ProductActionPlatformRunnerKeys, k.AgentConfigUpdateCallback)
+
+	// Seed from any configs already fetched before this subscription was registered.
+	if existing := k.rcClient.GetConfigs(state.ProductActionPlatformRunnerKeys); len(existing) > 0 {
+		log.FromContext(ctx).Info("Seeding keys from previously fetched remote config")
+		k.AgentConfigUpdateCallback(existing, func(_ string, _ state.ApplyStatus) {})
+	}
 }
 
 func (k *keysManager) GetKey(keyId string) types.DecodedKey {

--- a/pkg/privateactionrunner/task-verifier/keys_manager.go
+++ b/pkg/privateactionrunner/task-verifier/keys_manager.go
@@ -62,7 +62,7 @@ func (k *keysManager) Start(ctx context.Context) {
 	// Seed from any configs already fetched before this subscription was registered.
 	if existing := k.rcClient.GetConfigs(state.ProductActionPlatformRunnerKeys); len(existing) > 0 {
 		log.FromContext(ctx).Info("Seeding keys from previously fetched remote config")
-		k.AgentConfigUpdateCallback(existing, func(_ string, _ state.ApplyStatus) {})
+		k.AgentConfigUpdateCallback(existing, k.rcClient.UpdateApplyStatus)
 	}
 }
 

--- a/releasenotes/notes/par-seed-rc-keys-on-startup-2e874646ea2a5b8c.yaml
+++ b/releasenotes/notes/par-seed-rc-keys-on-startup-2e874646ea2a5b8c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix Private Action Runner startup behavior where task verification keys were unavailable
+    until the first Remote Config poll cycle completed. The keys manager now seeds from any
+    previously fetched Remote Config state immediately on startup.

--- a/releasenotes/notes/par-seed-rc-keys-on-startup-2e874646ea2a5b8c.yaml
+++ b/releasenotes/notes/par-seed-rc-keys-on-startup-2e874646ea2a5b8c.yaml
@@ -1,6 +1,7 @@
 ---
 fixes:
   - |
-    Fix Private Action Runner startup behavior where task verification keys were unavailable
-    until the first Remote Config poll cycle completed. The keys manager now seeds from any
-    previously fetched Remote Config state immediately on startup.
+    Fix Private Action Runner instances running in the Cluster Agent failing to receive
+    Remote Config keys for several hours after startup, causing actions to fail execution.
+    The keys manager now seeds from already-cached Remote Config state immediately on startup
+    instead of waiting for the next poll cycle.


### PR DESCRIPTION
### What does this PR do?

Seed the PAR keys manager from already-cached Remote Config state on startup, so keys are available immediately without waiting for the next RC poll cycle.

### Motivation

If the RC client has already polled before the keys manager subscribes, the subscription callback won't fire until the next cycle, leaving task verification broken in the interim.
This cause issues mostly in the DCA where we observed some PAR not getting their keys for several hours and not being able to execute actions

### Describe how you validated your changes

### Additional Notes

Will backport
