### PR TITLE
Add optional runtime gating mode for python-enabled builds

### DIFF
--- a/pkg/collector/python/embed_python.go
+++ b/pkg/collector/python/embed_python.go
@@ -16,14 +16,16 @@ import (
 func InitPython(paths ...string) {
 	pyVer, pyHome, pyPath := pySetup(paths...)
 
-	// print the Python info if the interpreter was embedded
 	if pyVer != "" {
 		log.Infof("Embedding Python %s", pyVer)
 		log.Debugf("Python Home: %s", pyHome)
 		log.Debugf("Python path: %s", pyPath)
 	}
 
-	// Prepare python environment if necessary
+	if !IsPythonRuntimeAvailable() {
+		return
+	}
+
 	if err := pyPrepareEnv(); err != nil {
 		log.Errorf("Unable to perform additional configuration of the python environment: %v", err)
 	}
@@ -31,8 +33,16 @@ func InitPython(paths ...string) {
 
 func pySetup(paths ...string) (pythonVersion, pythonHome, pythonPath string) {
 	if err := Initialize(paths...); err != nil {
+		setPythonRuntimeAvailable(false)
+		if pythonRuntimeOptional() {
+			log.Warnf("Python runtime is unavailable, disabling Python features: %s", err)
+			return "", "", ""
+		}
 		log.Errorf("Could not initialize Python: %s", err)
+		return PythonVersion, PythonHome, PythonPath
 	}
+
+	setPythonRuntimeAvailable(true)
 	return PythonVersion, PythonHome, PythonPath
 }
 

--- a/pkg/collector/python/runtime_mode_optional.go
+++ b/pkg/collector/python/runtime_mode_optional.go
@@ -3,17 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build python
+//go:build python && python_runtime_optional
 
-package runner
+package python
 
-import (
-	"github.com/DataDog/datadog-agent/pkg/collector/python"
-)
-
-func terminateChecksRunningProcesses() {
-	if !python.IsPythonRuntimeAvailable() {
-		return
-	}
-	python.TerminateRunningProcesses()
+func pythonRuntimeOptional() bool {
+	return true
 }

--- a/pkg/collector/python/runtime_mode_strict.go
+++ b/pkg/collector/python/runtime_mode_strict.go
@@ -3,17 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build python
+//go:build python && !python_runtime_optional
 
-package runner
+package python
 
-import (
-	"github.com/DataDog/datadog-agent/pkg/collector/python"
-)
-
-func terminateChecksRunningProcesses() {
-	if !python.IsPythonRuntimeAvailable() {
-		return
-	}
-	python.TerminateRunningProcesses()
+func pythonRuntimeOptional() bool {
+	return false
 }

--- a/pkg/collector/python/runtime_state.go
+++ b/pkg/collector/python/runtime_state.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build python
+
+package python
+
+import "sync"
+
+var (
+	pythonRuntimeAvailable = true
+	pythonRuntimeMu        sync.RWMutex
+)
+
+func setPythonRuntimeAvailable(v bool) {
+	pythonRuntimeMu.Lock()
+	pythonRuntimeAvailable = v
+	pythonRuntimeMu.Unlock()
+}
+
+func IsPythonRuntimeAvailable() bool {
+	pythonRuntimeMu.RLock()
+	available := pythonRuntimeAvailable
+	pythonRuntimeMu.RUnlock()
+	return available
+}

--- a/tasks/build_tags.bzl
+++ b/tasks/build_tags.bzl
@@ -61,6 +61,7 @@ ALL_TAGS = set([
     "pcap",  # used by system-probe to compile packet filters using google/gopacket/pcap, which requires cgo to link libpcap
     "podman",
     "python",
+    "python_runtime_optional",
     "requirefips",  # used for Linux FIPS mode to avoid having to set GOFIPS
     "seclmax",  # used for security agent/system-probe to compile the full feature set of secl
     "serverless",


### PR DESCRIPTION
### What does this PR do?

Adds a new `python_runtime_optional` build tag to support a third build mode:

- `!python`: no Python expected (IoT-style)
- `python && !python_runtime_optional`: Python required (current strict behavior)
- `python && python_runtime_optional`: Python compiled in but optional at runtime

Changes in this PR:

- add `python_runtime_optional` to `tasks/build_tags.bzl`
- add compile-time mode helpers:
  - `pkg/collector/python/runtime_mode_optional.go`
  - `pkg/collector/python/runtime_mode_strict.go`
- add Python runtime availability state:
  - `pkg/collector/python/runtime_state.go`
- make Python init degradable in optional mode (`embed_python.go`)
- guard runner Python subprocess termination on runtime availability (`runner_python.go`)

### Motivation

We just want to see what it would look like to add this, it's a POC.
