### PR TITLE
feat(renovate): Enable update of import path

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     "stopUpdatingLabel": "stop-updating",
     "gitIgnoredAuthors": ["200755185+dd-octo-sts[bot]@users.noreply.github.com"],
     "platformCommit": "enabled",
-    "postUpdateOptions": ["gomodUpdateImportPaths", "gomodTidy"],
+    "postUpdateOptions": ["gomodUpdateImportPaths"],
     "packageRules": [
       {
         "matchDepNames": ["*"],

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     "stopUpdatingLabel": "stop-updating",
     "gitIgnoredAuthors": ["200755185+dd-octo-sts[bot]@users.noreply.github.com"],
     "platformCommit": "enabled",
+    "postUpdateOptions": ["gomodUpdateImportPaths", "gomodTidy"],
     "packageRules": [
       {
         "matchDepNames": ["*"],


### PR DESCRIPTION
### What does this PR do?

Enable postUpdateOptions to change import path on golang major updates.

### Motivation

Current PR don't change the imports, and the `go mod tidy` we run afterwards wipes the major changes leading to [unexpected](https://github.com/DataDog/datadog-agent/pull/52425#discussion_r3436230248) updates.

### Describe how you validated your changes

N/a, renovate configuration

### Additional Notes
