### PR TITLE
[CASCL-1493] change built-in autoscaling profile values

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/profile/builtin.go
+++ b/pkg/clusteragent/autoscaling/workload/profile/builtin.go
@@ -48,7 +48,7 @@ var (
 					ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
 						Mode: datadoghq.DatadogPodAutoscalerApplyModeApply,
 						ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
-							StabilizationWindowSeconds: 300,
+							StabilizationWindowSeconds: 190,
 							Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
 								{Type: datadoghqcommon.DatadogPodAutoscalerPercentScalingRuleType, Value: 50, PeriodSeconds: 120},
 							},
@@ -101,7 +101,7 @@ var (
 						Mode: datadoghq.DatadogPodAutoscalerApplyModeApply,
 						ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 							Strategy:                   &strategyMax,
-							StabilizationWindowSeconds: 600,
+							StabilizationWindowSeconds: 130,
 							Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
 								{Type: datadoghqcommon.DatadogPodAutoscalerPercentScalingRuleType, Value: 50, PeriodSeconds: 120},
 							},
@@ -154,7 +154,7 @@ var (
 						Mode: datadoghq.DatadogPodAutoscalerApplyModeApply,
 						ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 							Strategy:                   &strategyMax,
-							StabilizationWindowSeconds: 900,
+							StabilizationWindowSeconds: 70,
 							Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
 								{Type: datadoghqcommon.DatadogPodAutoscalerPercentScalingRuleType, Value: 50, PeriodSeconds: 120},
 							},

--- a/releasenotes-dca/notes/dpa-preset-scaleup-stabilization-window-369d31fae395ecd8.yaml
+++ b/releasenotes-dca/notes/dpa-preset-scaleup-stabilization-window-369d31fae395ecd8.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Reduce scale-up stabilization windows for built-in DPA presets:
+    Optimize Cost from 300s to 190s, Optimize Balance from 600s to 130s,
+    and Optimize Performance from 900s to 70s. This allows faster
+    scale-up response for workloads using autoscaling profiles.


### PR DESCRIPTION
### What does this PR do?

Updates the scale-up stabilization window for all three built-in DPA presets in the cluster agent:

| Preset | Before | After |
|--------|--------|-------|
| Optimize Cost | 300s (5 min) | 190s (~3 min) |
| Optimize Balance | 600s (10 min) | 130s (~2 min) |
| Optimize Performance | 900s (15 min) | 70s (~1 min) |

Scale-down values, rate limits, CPU targets, and all other settings remain unchanged.

### Motivation

Per the [stabilization window change proposal](https://datadoghq.atlassian.net/wiki/spaces/CAUT/pages/6858016173), the current scale-up windows are too conservative. The new values allow faster scale-up response while including a 10s buffer to compensate for recommendation propagation latency (BE → RC → agent).

### Describe how you validated your changes

Deployed to a local minikube cluster via skaffold and verified the cluster profiles were created with the correct new values:
```
kubectl label deployment %deploymentName% autoscaling.datadoghq.com/profile=datadog-optimize-cost
kubectl get datadogpodautoscalers -A // check that DPA was created
kubectl get datadogpodautoscaler %dpaName% -o yaml // check scale-up stabilization window value
```
