### PR TITLE
[omnibus] Don't force root ownership on external shared dirs, fixing RPM datadog-fips-proxy co-install conflict

### DIFF
--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -59,23 +59,23 @@ module Omnibus
 
       normalize_package_path(install_dir)
       Array(extra_package_files).each do |path|
-        normalize_package_path(path)
+        normalize_package_path(path, external: external_package_path?(path))
       end
     end
 
-    def normalize_package_path(path)
+    def normalize_package_path(path, external: false)
       return unless File.exist?(path)
 
-      normalize_path_tree_permissions(path)
+      normalize_path_tree_permissions(path, external: external)
     end
 
-    def normalize_path_tree_permissions(root)
+    def normalize_path_tree_permissions(root, external: false)
       if File.directory?(root)
         Find.find(root) do |path|
-          normalize_path_permissions(path)
+          normalize_path_permissions(path, external: external)
         end
       else
-        normalize_path_permissions(root)
+        normalize_path_permissions(root, external: external)
       end
     end
 
@@ -91,7 +91,7 @@ module Omnibus
       path == root || path.start_with?("#{root}/")
     end
 
-    def normalize_path_permissions(path)
+    def normalize_path_permissions(path, external: false)
       return unless File.exist?(path)
 
       # The Linux build image may make files group-writable and directories
@@ -112,6 +112,15 @@ module Omnibus
       if normalized_mode != mode && (Process.euid == 0 || stat.uid == Process.euid)
         File.chmod(normalized_mode, path)
       end
+
+      # Do not force root:root on external shared OS directories such as
+      # /var/log/datadog or /usr/bin/dd-agent. These are co-owned with other
+      # Datadog packages (datadog-fips-proxy, datadog-dogstatsd, datadog-iot-agent)
+      # built outside this project, so recording root ownership here makes RPM's
+      # transaction test reject co-installation ("file ... conflicts between
+      # attempted installs"). Their runtime ownership is set by the postinst
+      # scripts anyway, so the package metadata owner is not load-bearing.
+      return if external
 
       # Best-effort filesystem cleanup for root-run Omnibus builds. Package
       # metadata should be root-owned regardless of the builder user, but


### PR DESCRIPTION
### What does this PR do?

Scopes the `normalize_linux_package_permissions` Omnibus step (in `omnibus/lib/project_extension.rb`) so it no longer forces `root:root` ownership on **external** shared OS directories declared via `extra_package_file` (e.g. `/var/log/datadog`, `/usr/bin/dd-agent`).

The build-only setgid/group-write bit stripping still runs on every path, and `install_dir` payload is still recorded as root-owned. Only the `File.chown(0, 0, path)` call is now skipped for external co-owned paths, gated by the existing (previously unused) `external_package_path?` helper.

### Motivation

`normalize_linux_package_permissions` was added in 7.80.2 (backport `6b12f2edc06`). Because it iterates over `extra_package_files`, it started recording `/var/log/datadog` as `root:root` in the `datadog-agent` RPM. That directory is co-owned by the separately-built `datadog-fips-proxy` package, which keeps the conventional `dd-agent` ownership, so RPM's transaction test now rejects co-installation:

```
file /var/log/datadog conflicts between attempted installs of
datadog-agent-1:7.80.2-1.x86_64 and datadog-fips-proxy-1:1.1.24-1.x86_64
```

This breaks `DD_FIPS_MODE=true` installs on RPM-based distros (Amazon Linux 2023, RHEL 8, CentOS 7) and the `TestInstallFipsSuite` e2e test in `agent-linux-install-script`. dpkg tolerates differing directory ownership across packages, so Debian/Ubuntu were unaffected. The directory's runtime owner is set by the postinst scripts regardless, so the `root:root` package metadata was both incorrect and unnecessary.

### Describe how you validated your changes

- `ruby -c` passes on the edited file.
- Verified `external_package_path?` classifies `/var/log/datadog` and `/usr/bin/dd-agent` as external (outside `project_root` and `install_dir`), so the chown is skipped only for the co-owned dirs; `install_dir` payload is unaffected.
- End-to-end validation lands in CI: after building the agent RPM, `rpm -qlvp datadog-agent*.rpm | grep ' /var/log/datadog$'` should no longer report `root root` and must match the `datadog-fips-proxy` RPM's entry; `rpm -i --test datadog-agent*.rpm datadog-fips-proxy*.rpm` should pass; and `TestInstallFipsSuite` on an RPM OS should go green.

### Additional Notes

- `datadog-dogstatsd` and `datadog-iot-agent` also declare `/var/log/datadog/` and share this file, so they benefit from the same fix.
- Should be backported to `7.80.x`, since the regression shipped in 7.80.2.
- No release note (minor packaging bug fix) — labeled `changelog/no-changelog`.
