### PR TITLE
ci: include Windows jobs for changes under `pkg/security`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@
 .if_deploy: &if_deploy
   if: $DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null
 
-# Windows-specific Go source files, pkg/, and cmd/ (27 paths), need to be splitted because Gitlab has a limit to 50 paths in a single rule
+# Windows-specific Go source files, pkg/, and cmd/ (26 paths), need to be splitted because Gitlab has a limit to 50 paths in a single rule
 .windows_path:
   &windows_path # Windows-specific Go source files (by filename convention)
   - "**/*_windows.go"
@@ -44,6 +44,8 @@
 
   # Global packages likely to impact windows
   - pkg/config/**/*
+  # pkg/security: changes in platform-agnostic Go files can affect Windows behavior.
+  - pkg/security/**/*
 
   # cmd/
   - cmd/agent/**/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@
 .if_deploy: &if_deploy
   if: $DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null
 
-# Windows-specific Go source files, pkg/, and cmd/ (26 paths), need to be splitted because Gitlab has a limit to 50 paths in a single rule
+# Windows-specific Go source files, pkg/, and cmd/ (26 paths), need to be split because Gitlab has a limit to 50 paths in a single rule
 .windows_path:
   &windows_path # Windows-specific Go source files (by filename convention)
   - "**/*_windows.go"


### PR DESCRIPTION
### What does this PR do?

Adds `pkg/security/**/*` to the Windows CI change-path filter so any change under `pkg/security` runs the Windows test jobs.

### Motivation

Windows jobs only run when a PR's diff matches a Windows or Bazel-specific path, but some Go code under `pkg/security/` is OS-agnostic: changes to this code can cause tests to fail on a specific OS (such as Windows).
Because the Windows jobs aren't included in PR pipelines, this means that a change can pass the CI on a PR but fail Windows jobs on `main` such as it was the case with https://github.com/DataDog/datadog-agent/pull/52457

### Describe how you validated your changes

### Additional Notes

#incident-56493
