### PR TITLE
[AGENTCFG-840][AGENTCFG-841][AGENTCFG-842] fix: correct break-in-select bug and goroutine leak in configstream tests

### DIFF
--- a/comp/core/configstream/impl/configstream_test.go
+++ b/comp/core/configstream/impl/configstream_test.go
@@ -103,6 +103,7 @@ func TestClientConnectsAndReceivesStream(t *testing.T) {
 		updates := make([]*pb.ConfigUpdate, 0)
 		timeout := time.After(2 * time.Second)
 
+	loop:
 		for i := 0; i < 3; i++ {
 			select {
 			case event := <-eventChan:
@@ -111,7 +112,7 @@ func TestClientConnectsAndReceivesStream(t *testing.T) {
 					updates = append(updates, update)
 				}
 			case <-timeout:
-				break
+				break loop
 			}
 		}
 
@@ -309,6 +310,7 @@ func newConfigStreamForTest(t *testing.T, cfg config.Component, logger log.Compo
 
 	cs := provides.Comp.(*configStream)
 	go cs.run()
+	t.Cleanup(func() { close(cs.stopChan) })
 
 	return cs
 }


### PR DESCRIPTION
### What does this PR do?

Fixes two bugs in `comp/core/configstream/impl` tests that caused flaky failures on `tests_linux-arm64-py3`:

1. **`break` inside `select` inside `for` in `TestClientConnectsAndReceivesStream`** — in Go, `break` within a `select` only exits the `select`, not the enclosing `for` loop. When the 2-second timeout fired on a loaded arm64 machine before all expected events arrived, the loop continued running and blocked indefinitely on the event channel (since the `time.After` channel is drained after its first receive). This caused the test binary to hang until its overall timeout, marking all subsequent tests in the package as failed. Fixed by using a labeled `break loop`.

2. **Goroutine leak in `newConfigStreamForTest`** — the helper starts `cs.run()` in a goroutine but never signals it to stop. Because `compdef.NewTestLifecycle(t)` does not execute lifecycle hooks, the `OnStop` hook (which closes `stopChan`) never runs. The `run()` goroutine and its registered `OnUpdate` callback outlive the test. Fixed by adding a `t.Cleanup` that closes `stopChan`.

### Motivation

All three Jira cards ([AGENTCFG-840](https://datadoghq.atlassian.net/browse/AGENTCFG-840), [AGENTCFG-841](https://datadoghq.atlassian.net/browse/AGENTCFG-841), [AGENTCFG-842](https://datadoghq.atlassian.net/browse/AGENTCFG-842)) trace back to the same CI job (`tests_linux-arm64-py3`, job 1788933369). The hang from `TestClientConnectsAndReceivesStream` cascaded to `TestConfigStream` and `TestMultipleSubscribers` via test binary timeout.

### Describe how you validated your changes

Ran the full test suite for the package locally:

```
dda inv test --targets=./comp/core/configstream/impl
```

All 13 tests pass.

### Additional Notes

The `break`-in-`select` pitfall is a common Go gotcha — `break` and `continue` inside `select` apply to the `select`, not any enclosing loop. A labeled break is the idiomatic fix.