### PR TITLE
feat(ssi): add SDK config via annotations

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation/annotation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation/annotation.go
@@ -30,6 +30,12 @@ const (
 	// InjectionMode specifies the injection mode (e.g. init_container, csi).
 	// Example value: csi
 	InjectionMode = "admission.datadoghq.com/apm-inject.injection-mode"
+	// TracerConfigs sets tracer configuration options (injected as environment variables) during
+	// Local SDK Injection. It is the annotation-based equivalent of the targets[].ddTraceConfigs
+	// config option. The value is a JSON array of objects matching the ddTraceConfigs schema, and
+	// every entry's name must start with the DD_ prefix.
+	// Example value: [{"name":"DD_PROFILING_ENABLED","value":"true"}]
+	TracerConfigs = "admission.datadoghq.com/apm-inject.tracer-configs"
 	// LibraryVersion sets the library to use during Local SDK Injection.
 	// Example annotation: admission.datadoghq.com/python-lib.version
 	// Example value: v3

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1311,6 +1311,67 @@ func TestAutoinstrumentation(t *testing.T) {
 				containerNames: defaultContainerNames,
 			},
 		},
+		"local sdk injection with tracer-configs annotation injects env vars": {
+			config: map[string]any{
+				"apm_config.instrumentation.enabled": true,
+			},
+			pod: common.FakePodSpec{
+				Name:       defaultTestContainer,
+				NS:         "application",
+				ParentKind: "replicaset",
+				ParentName: "deployment-123",
+				Annotations: map[string]string{
+					"admission.datadoghq.com/ruby-lib.version":          "v3",
+					"admission.datadoghq.com/apm-inject.tracer-configs": `[{"name":"DD_PROFILING_ENABLED","value":"true"},{"name":"DD_DATA_JOBS_ENABLED","value":"true"}]`,
+				},
+				Labels: map[string]string{
+					admissioncommon.EnabledLabelKey: "true",
+				},
+			}.Create(),
+			deployments:  defaultDeployments,
+			namespaces:   defaultNamespaces,
+			shouldMutate: true,
+			expected: &expected{
+				injectorVersion: defaultInjectorVersion,
+				libraryVersions: map[string]string{
+					"ruby": "v3",
+				},
+				requiredEnvs: map[string]string{
+					"DD_PROFILING_ENABLED": "true",
+					"DD_DATA_JOBS_ENABLED": "true",
+				},
+				containerNames: defaultContainerNames,
+			},
+		},
+		"inject-all annotation with tracer-configs annotation injects env vars": {
+			config: map[string]any{
+				"apm_config.instrumentation.enabled": true,
+			},
+			pod: common.FakePodSpec{
+				Name:       defaultTestContainer,
+				NS:         "application",
+				ParentKind: "replicaset",
+				ParentName: "deployment-123",
+				Annotations: map[string]string{
+					"admission.datadoghq.com/all-lib.version":           "latest",
+					"admission.datadoghq.com/apm-inject.tracer-configs": `[{"name":"DD_PROFILING_ENABLED","value":"true"}]`,
+				},
+				Labels: map[string]string{
+					admissioncommon.EnabledLabelKey: "true",
+				},
+			}.Create(),
+			deployments:  defaultDeployments,
+			namespaces:   defaultNamespaces,
+			shouldMutate: true,
+			expected: &expected{
+				injectorVersion: defaultInjectorVersion,
+				libraryVersions: defaultLibraries,
+				requiredEnvs: map[string]string{
+					"DD_PROFILING_ENABLED": "true",
+				},
+				containerNames: defaultContainerNames,
+			},
+		},
 		"targets with matching rule and local sdk injection but no label favors target": {
 			config: map[string]any{
 				"apm_config.instrumentation.enabled": true,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -353,6 +353,7 @@ func (m *TargetMutator) getTargetFromAnnotation(pod *corev1.Pod) *annotationResu
 			shouldContinue: false,
 			target: &targetInternal{
 				libVersions: extractedLibraries,
+				envVars:     extractTracerConfigsFromAnnotations(pod),
 			},
 		}
 	}
@@ -363,6 +364,7 @@ func (m *TargetMutator) getTargetFromAnnotation(pod *corev1.Pod) *annotationResu
 			shouldContinue: false,
 			target: &targetInternal{
 				libVersions: m.defaultLibVersions,
+				envVars:     extractTracerConfigsFromAnnotations(pod),
 			},
 		}
 	}
@@ -517,6 +519,37 @@ func containsInitContainer(pod *corev1.Pod, initContainerName string) bool {
 	}
 
 	return false
+}
+
+// extractTracerConfigsFromAnnotations parses the tracer-configs annotation into env vars to inject
+// alongside the locally injected libraries. It is the annotation-based equivalent of a target's
+// ddTraceConfigs. Invalid input (malformed JSON or a non DD_ prefixed name) is logged and skipped
+// rather than failing the mutation, mirroring the lenient handling of the other local SDK
+// injection annotations.
+func extractTracerConfigsFromAnnotations(pod *corev1.Pod) []corev1.EnvVar {
+	value, found := annotation.Get(pod, annotation.TracerConfigs)
+	if !found {
+		return nil
+	}
+
+	var tracerConfigs []TracerConfig
+	if err := json.Unmarshal([]byte(value), &tracerConfigs); err != nil {
+		log.Errorf("could not parse %q annotation for Single Step Instrumentation: %v", annotation.TracerConfigs, err)
+		return nil
+	}
+
+	envVars := make([]corev1.EnvVar, 0, len(tracerConfigs))
+	for _, tc := range tracerConfigs {
+		// Match the validation applied to config-based ddTraceConfigs: only allow DD_ prefixed names
+		// so this cannot be used as a generic env var injector.
+		if !strings.HasPrefix(tc.Name, "DD_") {
+			log.Errorf("tracer config %q from %q annotation does not start with DD_, skipping", tc.Name, annotation.TracerConfigs)
+			continue
+		}
+		envVars = append(envVars, tc.AsEnvVar())
+	}
+
+	return envVars
 }
 
 func extractLibrariesFromAnnotations(pod *corev1.Pod, registry string) []libInfo {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -496,6 +496,93 @@ func TestGetTargetFromAnnotation(t *testing.T) {
 			},
 			expected: nil,
 		},
+		"a pod with a lib annotation and tracer-configs gets env vars": {
+			configPath: "testdata/filter_limited.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Labels: map[string]string{
+						common.EnabledLabelKey: "true",
+					},
+					Annotations: map[string]string{
+						"admission.datadoghq.com/python-lib.version":        "v3",
+						"admission.datadoghq.com/apm-inject.tracer-configs": `[{"name":"DD_PROFILING_ENABLED","value":"true"},{"name":"DD_DATA_JOBS_ENABLED","value":"true"}]`,
+					},
+				},
+			},
+			expected: &targetInternal{
+				libVersions: []libInfo{
+					defaultLibInfoWithVersion(python, "v3"),
+				},
+				envVars: []corev1.EnvVar{
+					{Name: "DD_PROFILING_ENABLED", Value: "true"},
+					{Name: "DD_DATA_JOBS_ENABLED", Value: "true"},
+				},
+			},
+		},
+		"a pod with the inject-all annotation and tracer-configs gets env vars": {
+			configPath: "testdata/filter_limited.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Labels: map[string]string{
+						common.EnabledLabelKey: "true",
+					},
+					Annotations: map[string]string{
+						"admission.datadoghq.com/all-lib.version":           "latest",
+						"admission.datadoghq.com/apm-inject.tracer-configs": `[{"name":"DD_PROFILING_ENABLED","value":"true"}]`,
+					},
+				},
+			},
+			expected: &targetInternal{
+				envVars: []corev1.EnvVar{
+					{Name: "DD_PROFILING_ENABLED", Value: "true"},
+				},
+			},
+		},
+		"tracer-configs entries without a DD_ prefix are skipped": {
+			configPath: "testdata/filter_limited.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Labels: map[string]string{
+						common.EnabledLabelKey: "true",
+					},
+					Annotations: map[string]string{
+						"admission.datadoghq.com/python-lib.version":        "v3",
+						"admission.datadoghq.com/apm-inject.tracer-configs": `[{"name":"NOT_DD","value":"true"},{"name":"DD_PROFILING_ENABLED","value":"true"}]`,
+					},
+				},
+			},
+			expected: &targetInternal{
+				libVersions: []libInfo{
+					defaultLibInfoWithVersion(python, "v3"),
+				},
+				envVars: []corev1.EnvVar{
+					{Name: "DD_PROFILING_ENABLED", Value: "true"},
+				},
+			},
+		},
+		"malformed tracer-configs json is ignored": {
+			configPath: "testdata/filter_limited.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Labels: map[string]string{
+						common.EnabledLabelKey: "true",
+					},
+					Annotations: map[string]string{
+						"admission.datadoghq.com/python-lib.version":        "v3",
+						"admission.datadoghq.com/apm-inject.tracer-configs": `not json`,
+					},
+				},
+			},
+			expected: &targetInternal{
+				libVersions: []libInfo{
+					defaultLibInfoWithVersion(python, "v3"),
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -526,7 +613,13 @@ func TestGetTargetFromAnnotation(t *testing.T) {
 				require.Nil(t, actual.target)
 			} else {
 				require.NotNil(t, actual)
-				require.Equal(t, test.expected.libVersions, actual.target.libVersions)
+				require.NotNil(t, actual.target)
+				// Some cases (e.g. inject-all) populate libVersions with the default
+				// libraries, which we don't assert on here; only check when set.
+				if test.expected.libVersions != nil {
+					require.Equal(t, test.expected.libVersions, actual.target.libVersions)
+				}
+				require.Equal(t, test.expected.envVars, actual.target.envVars)
 			}
 		})
 	}

--- a/releasenotes/notes/ssi-tracer-configs-annotation-3f6a1b2c4d5e6f70.yaml
+++ b/releasenotes/notes/ssi-tracer-configs-annotation-3f6a1b2c4d5e6f70.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not differ between releases and is easy to read regardless
+# of the order the notes are displayed.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM Single Step Instrumentation now supports setting tracer configuration
+    options via the ``admission.datadoghq.com/apm-inject.tracer-configs`` pod
+    annotation, the annotation-based equivalent of the
+    ``apm_config.instrumentation.targets[].ddTraceConfigs`` option. The value is
+    a JSON array of objects (for example
+    ``[{"name":"DD_PROFILING_ENABLED","value":"true"}]``) and each entry's name
+    must start with the ``DD_`` prefix.


### PR DESCRIPTION
### What does this PR do?
This commit adds the ability to set SDK configurations via an annotation to bring it into feature parity with targets.

### Motivation
When customers are using Local SDK Injection, they should have the ability to configure an SDK in addition to selecting the library version.

### Describe how you validated your changes
The additional tests.

### Additional Notes
