### PR TITLE
discovery: send service discovery requests in batches

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -334,13 +334,10 @@ func (c *collector) detectLanguages(processes []*procutil.Process) []*languagemo
 }
 
 // filterPidsToRequest filters PIDs to categorize them as new or needing heartbeat refresh.
-// It returns separate slices for new PIDs and heartbeat PIDs, along with a map of pids to *model.Service
-// to be filled up with the response received from system-probe.
-func (c *collector) filterPidsToRequest(alivePids core.PidSet, procs map[int32]*procutil.Process) ([]int32, []int32, map[int32]*model.Service) {
+func (c *collector) filterPidsToRequest(alivePids core.PidSet, procs map[int32]*procutil.Process) ([]int32, []int32) {
 	now := c.clock.Now().UTC()
 	newPids := make([]int32, 0, len(alivePids))
 	heartbeatPids := make([]int32, 0, len(alivePids))
-	pidsToService := make(map[int32]*model.Service, len(alivePids))
 
 	for pid := range alivePids {
 		if c.ignoredPids.Has(pid) {
@@ -360,16 +357,14 @@ func (c *collector) filterPidsToRequest(alivePids core.PidSet, procs map[int32]*
 		if !exists {
 			// Never seen this process before, need full service info
 			newPids = append(newPids, pid)
-			pidsToService[pid] = nil
 		} else if now.Sub(lastHeartbeat) > core.HeartbeatTime {
 			// Service data is stale, need heartbeat refresh
 			// Since we have a pidHeartbeats entry, we know service data exists
 			heartbeatPids = append(heartbeatPids, pid)
-			pidsToService[pid] = nil
 		}
 	}
 
-	return newPids, heartbeatPids, pidsToService
+	return newPids, heartbeatPids
 }
 
 // getDiscoveryServices calls the system-probe /discovery/services endpoint
@@ -589,7 +584,7 @@ func (c *collector) getProcessEntitiesFromServices(newPids []int32, heartbeatPid
 
 // updateServices retrieves service discovery data for alive processes and returns workloadmeta entities
 func (c *collector) updateServices(alivePids core.PidSet, procs map[int32]*procutil.Process) ([]*workloadmeta.Process, core.PidSet) {
-	newPids, heartbeatPids, _ := c.filterPidsToRequest(alivePids, procs)
+	newPids, heartbeatPids := c.filterPidsToRequest(alivePids, procs)
 	if len(newPids) == 0 && len(heartbeatPids) == 0 {
 		return nil, nil
 	}

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -68,12 +68,13 @@ type collector struct {
 	containerProvider      proccontainers.ContainerProvider
 
 	// Service discovery fields
-	sysProbeClient           *sysprobeclient.CheckClient
-	serviceRetries           map[int32]uint
-	ignoredPids              core.PidSet
-	pidHeartbeats            map[int32]time.Time
-	knownInjectionStatusPids core.PidSet // Track PIDs whose injection status we've already reported (but have no service data yet)
-	metricDiscoveredServices telemetry.Gauge
+	sysProbeClient             *sysprobeclient.CheckClient
+	serviceCollectionBatchSize int
+	serviceRetries             map[int32]uint
+	ignoredPids                core.PidSet
+	pidHeartbeats              map[int32]time.Time
+	knownInjectionStatusPids   core.PidSet // Track PIDs whose injection status we've already reported (but have no service data yet)
+	metricDiscoveredServices   telemetry.Gauge
 }
 
 // EventType represents the type of collector event
@@ -115,12 +116,13 @@ func newProcessCollector(id string, catalog workloadmeta.AgentType, clock clock.
 		lastCollectedProcesses: make(map[int32]*procutil.Process),
 
 		// Initialize service discovery fields
-		sysProbeClient:           sysprobeclient.GetCheckClient(),
-		serviceRetries:           make(map[int32]uint),
-		ignoredPids:              make(core.PidSet),
-		pidHeartbeats:            make(map[int32]time.Time),
-		knownInjectionStatusPids: make(core.PidSet),
-		metricDiscoveredServices: discoveredServicesGauge,
+		sysProbeClient:             sysprobeclient.GetCheckClient(),
+		serviceCollectionBatchSize: systemProbeConfig.GetInt(serviceCollectionBatchSizeConfigKey),
+		serviceRetries:             make(map[int32]uint),
+		ignoredPids:                make(core.PidSet),
+		pidHeartbeats:              make(map[int32]time.Time),
+		knownInjectionStatusPids:   make(core.PidSet),
+		metricDiscoveredServices:   discoveredServicesGauge,
 	}
 }
 
@@ -393,7 +395,7 @@ func buildServiceDiscoveryPIDBatches(newPids []int32, heartbeatPids []int32, bat
 		return nil
 	}
 
-	if batchSize == 0 {
+	if batchSize <= 0 {
 		return []serviceDiscoveryPIDBatch{
 			{
 				newPids:       newPids,
@@ -448,13 +450,20 @@ func mergeServiceDiscoveryResponses(dst *model.ServicesResponse, src *model.Serv
 	dst.GPUPIDs = append(dst.GPUPIDs, src.GPUPIDs...)
 }
 
-func (c *collector) getDiscoveryServicesBatched(newPids []int32, heartbeatPids []int32) (*model.ServicesResponse, []int32, []int32) {
-	batches := buildServiceDiscoveryPIDBatches(newPids, heartbeatPids, c.systemProbeConfig.GetInt(serviceCollectionBatchSizeConfigKey))
+func (c *collector) getDiscoveryServicesBatched(ctx context.Context, newPids []int32, heartbeatPids []int32) (*model.ServicesResponse, []int32, []int32) {
+	batches := buildServiceDiscoveryPIDBatches(newPids, heartbeatPids, c.serviceCollectionBatchSize)
 	mergedResponse := &model.ServicesResponse{}
 	successfulNewPids := make([]int32, 0, len(newPids))
 	successfulHeartbeatPids := make([]int32, 0, len(heartbeatPids))
 
 	for batchIndex, batch := range batches {
+		select {
+		case <-ctx.Done():
+			log.Debugf("stopping service discovery batching after %d/%d batches: %s", batchIndex, len(batches), ctx.Err())
+			return mergedResponse, successfulNewPids, successfulHeartbeatPids
+		default:
+		}
+
 		log.Debugf("Requesting service discovery batch %d/%d with %d new PIDs and %d heartbeat PIDs",
 			batchIndex+1, len(batches), len(batch.newPids), len(batch.heartbeatPids))
 
@@ -583,13 +592,13 @@ func (c *collector) getProcessEntitiesFromServices(newPids []int32, heartbeatPid
 }
 
 // updateServices retrieves service discovery data for alive processes and returns workloadmeta entities
-func (c *collector) updateServices(alivePids core.PidSet, procs map[int32]*procutil.Process) ([]*workloadmeta.Process, core.PidSet) {
+func (c *collector) updateServices(ctx context.Context, alivePids core.PidSet, procs map[int32]*procutil.Process) ([]*workloadmeta.Process, core.PidSet) {
 	newPids, heartbeatPids := c.filterPidsToRequest(alivePids, procs)
 	if len(newPids) == 0 && len(heartbeatPids) == 0 {
 		return nil, nil
 	}
 
-	resp, successfulNewPids, successfulHeartbeatPids := c.getDiscoveryServicesBatched(newPids, heartbeatPids)
+	resp, successfulNewPids, successfulHeartbeatPids := c.getDiscoveryServicesBatched(ctx, newPids, heartbeatPids)
 	if len(successfulNewPids) == 0 && len(successfulHeartbeatPids) == 0 {
 		return nil, nil
 	}
@@ -619,8 +628,8 @@ func (c *collector) updateServices(alivePids core.PidSet, procs map[int32]*procu
 	return c.getProcessEntitiesFromServices(successfulNewPids, successfulHeartbeatPids, pidsToService, injectedPids, gpuPids), injectedPids
 }
 
-func (c *collector) updateServicesNoCache(alivePids core.PidSet, procs map[int32]*procutil.Process) []*workloadmeta.Process {
-	entities, _ := c.updateServices(alivePids, procs)
+func (c *collector) updateServicesNoCache(ctx context.Context, alivePids core.PidSet, procs map[int32]*procutil.Process) []*workloadmeta.Process {
+	entities, _ := c.updateServices(ctx, alivePids, procs)
 	if len(entities) == 0 {
 		return nil
 	}
@@ -808,7 +817,7 @@ func (c *collector) collectServicesNoCache(ctx context.Context, collectionTicker
 				continue // no processes to check
 			}
 
-			wlmServiceEntities := c.updateServicesNoCache(alivePids, procs)
+			wlmServiceEntities := c.updateServicesNoCache(ctx, alivePids, procs)
 			deletedProcesses := c.findDeletedProcesses(procs)
 
 			if len(wlmServiceEntities) > 0 || len(deletedProcesses) > 0 {
@@ -874,7 +883,7 @@ func (c *collector) collectServicesCached(ctx context.Context, collectionTicker 
 				})
 			}
 
-			wlmServiceEntities, _ := c.updateServices(alivePids, procs)
+			wlmServiceEntities, _ := c.updateServices(ctx, alivePids, procs)
 
 			if len(wlmServiceEntities) > 0 || len(wlmDeletedProcs) > 0 {
 				c.processEventsCh <- &Event{

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -50,7 +50,8 @@ const (
 	cacheValidityNoRT = 2 * time.Second
 
 	// Service discovery constants
-	maxPortCheckTries = 10
+	maxPortCheckTries                   = 10
+	serviceCollectionBatchSizeConfigKey = "discovery.service_collection_batch_size"
 )
 
 type collector struct {
@@ -387,6 +388,99 @@ func (c *collector) getDiscoveryServices(newPids []int32, heartbeatPids []int32)
 	return &response, nil
 }
 
+type serviceDiscoveryPIDBatch struct {
+	newPids       []int32
+	heartbeatPids []int32
+}
+
+func buildServiceDiscoveryPIDBatches(newPids []int32, heartbeatPids []int32, batchSize int) []serviceDiscoveryPIDBatch {
+	if len(newPids) == 0 && len(heartbeatPids) == 0 {
+		return nil
+	}
+
+	if batchSize == 0 {
+		return []serviceDiscoveryPIDBatch{
+			{
+				newPids:       newPids,
+				heartbeatPids: heartbeatPids,
+			},
+		}
+	}
+
+	batches := make([]serviceDiscoveryPIDBatch, 0, (len(newPids)+len(heartbeatPids)+batchSize-1)/batchSize)
+	current := serviceDiscoveryPIDBatch{
+		newPids:       make([]int32, 0, min(len(newPids), batchSize)),
+		heartbeatPids: make([]int32, 0, min(len(heartbeatPids), batchSize)),
+	}
+
+	addPID := func(pid int32, isHeartbeat bool) {
+		if len(current.newPids)+len(current.heartbeatPids) == batchSize {
+			batches = append(batches, current)
+			current = serviceDiscoveryPIDBatch{
+				newPids:       make([]int32, 0, min(len(newPids), batchSize)),
+				heartbeatPids: make([]int32, 0, min(len(heartbeatPids), batchSize)),
+			}
+		}
+
+		if isHeartbeat {
+			current.heartbeatPids = append(current.heartbeatPids, pid)
+			return
+		}
+		current.newPids = append(current.newPids, pid)
+	}
+
+	for _, pid := range newPids {
+		addPID(pid, false)
+	}
+	for _, pid := range heartbeatPids {
+		addPID(pid, true)
+	}
+
+	if len(current.newPids) > 0 || len(current.heartbeatPids) > 0 {
+		batches = append(batches, current)
+	}
+
+	return batches
+}
+
+func mergeServiceDiscoveryResponses(dst *model.ServicesResponse, src *model.ServicesResponse) {
+	if src == nil {
+		return
+	}
+
+	dst.Services = append(dst.Services, src.Services...)
+	dst.InjectedPIDs = append(dst.InjectedPIDs, src.InjectedPIDs...)
+	dst.GPUPIDs = append(dst.GPUPIDs, src.GPUPIDs...)
+}
+
+func (c *collector) getDiscoveryServicesBatched(newPids []int32, heartbeatPids []int32) (*model.ServicesResponse, []int32, []int32) {
+	batches := buildServiceDiscoveryPIDBatches(newPids, heartbeatPids, c.systemProbeConfig.GetInt(serviceCollectionBatchSizeConfigKey))
+	mergedResponse := &model.ServicesResponse{}
+	successfulNewPids := make([]int32, 0, len(newPids))
+	successfulHeartbeatPids := make([]int32, 0, len(heartbeatPids))
+
+	for batchIndex, batch := range batches {
+		log.Debugf("Requesting service discovery batch %d/%d with %d new PIDs and %d heartbeat PIDs",
+			batchIndex+1, len(batches), len(batch.newPids), len(batch.heartbeatPids))
+
+		resp, err := c.getDiscoveryServices(batch.newPids, batch.heartbeatPids)
+		if err != nil {
+			// CheckClient handles startup warnings internally, but we still need to suppress
+			// the error if system-probe hasn't started yet.
+			if sysprobeclient.IgnoreStartupError(err) != nil {
+				log.Errorf("failed to get services: %s", err)
+			}
+			return mergedResponse, successfulNewPids, successfulHeartbeatPids
+		}
+
+		mergeServiceDiscoveryResponses(mergedResponse, resp)
+		successfulNewPids = append(successfulNewPids, batch.newPids...)
+		successfulHeartbeatPids = append(successfulHeartbeatPids, batch.heartbeatPids...)
+	}
+
+	return mergedResponse, successfulNewPids, successfulHeartbeatPids
+}
+
 func (c *collector) handleServiceRetries(pid int32) {
 	tries := c.serviceRetries[pid]
 	tries++
@@ -495,20 +589,22 @@ func (c *collector) getProcessEntitiesFromServices(newPids []int32, heartbeatPid
 
 // updateServices retrieves service discovery data for alive processes and returns workloadmeta entities
 func (c *collector) updateServices(alivePids core.PidSet, procs map[int32]*procutil.Process) ([]*workloadmeta.Process, core.PidSet) {
-	newPids, heartbeatPids, pidsToService := c.filterPidsToRequest(alivePids, procs)
+	newPids, heartbeatPids, _ := c.filterPidsToRequest(alivePids, procs)
 	if len(newPids) == 0 && len(heartbeatPids) == 0 {
 		return nil, nil
 	}
 
-	resp, err := c.getDiscoveryServices(newPids, heartbeatPids)
-	if err != nil {
-		// CheckClient handles startup warnings internally, but we still need to suppress
-		// the error if system-probe hasn't started yet
-		if sysprobeclient.IgnoreStartupError(err) == nil {
-			return nil, nil
-		}
-		log.Errorf("failed to get services: %s", err)
+	resp, successfulNewPids, successfulHeartbeatPids := c.getDiscoveryServicesBatched(newPids, heartbeatPids)
+	if len(successfulNewPids) == 0 && len(successfulHeartbeatPids) == 0 {
 		return nil, nil
+	}
+
+	pidsToService := make(map[int32]*model.Service, len(successfulNewPids)+len(successfulHeartbeatPids))
+	for _, pid := range successfulNewPids {
+		pidsToService[pid] = nil
+	}
+	for _, pid := range successfulHeartbeatPids {
+		pidsToService[pid] = nil
 	}
 
 	for i, service := range resp.Services {
@@ -525,7 +621,7 @@ func (c *collector) updateServices(alivePids core.PidSet, procs map[int32]*procu
 		gpuPids.Add(int32(pid))
 	}
 
-	return c.getProcessEntitiesFromServices(newPids, heartbeatPids, pidsToService, injectedPids, gpuPids), injectedPids
+	return c.getProcessEntitiesFromServices(successfulNewPids, successfulHeartbeatPids, pidsToService, injectedPids, gpuPids), injectedPids
 }
 
 func (c *collector) updateServicesNoCache(alivePids core.PidSet, procs map[int32]*procutil.Process) []*workloadmeta.Process {
@@ -579,21 +675,23 @@ func (c *collector) getProcessDataForServices() (core.PidSet, map[int32]*procuti
 	return alivePids, procs, nil
 }
 
-func (c *collector) getCachedProcessData() (core.PidSet, error) {
+func (c *collector) getCachedProcessData() (core.PidSet, map[int32]*procutil.Process, error) {
 	// Get alive PIDs from last collected processes (populated by collectProcesses)
 	c.mux.RLock()
 	defer c.mux.RUnlock()
 
 	if len(c.lastCollectedProcesses) == 0 {
-		return nil, nil // no processes to check
+		return nil, nil, nil // no processes to check
 	}
 
 	alivePids := make(core.PidSet, len(c.lastCollectedProcesses))
-	for pid := range c.lastCollectedProcesses {
+	procs := make(map[int32]*procutil.Process, len(c.lastCollectedProcesses))
+	for pid, proc := range c.lastCollectedProcesses {
 		alivePids.Add(pid)
+		procs[pid] = proc
 	}
 
-	return alivePids, nil
+	return alivePids, procs, nil
 }
 
 // cleanPidMaps deletes dead PIDs from the provided maps.
@@ -747,7 +845,7 @@ func (c *collector) collectServicesCached(ctx context.Context, collectionTicker 
 	for {
 		select {
 		case <-collectionTicker.C:
-			alivePids, err := c.getCachedProcessData()
+			alivePids, procs, err := c.getCachedProcessData()
 			if err != nil {
 				log.Errorf("Error getting processes for service discovery: %v", err)
 				continue
@@ -781,9 +879,7 @@ func (c *collector) collectServicesCached(ctx context.Context, collectionTicker 
 				})
 			}
 
-			c.mux.RLock()
-			wlmServiceEntities, _ := c.updateServices(alivePids, c.lastCollectedProcesses)
-			c.mux.RUnlock()
+			wlmServiceEntities, _ := c.updateServices(alivePids, procs)
 
 			if len(wlmServiceEntities) > 0 || len(wlmDeletedProcs) > 0 {
 				c.processEventsCh <- &Event{

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -136,6 +136,71 @@ func TestBuildServiceDiscoveryPIDBatchesDisabledSendsSingleBatch(t *testing.T) {
 	assert.Equal(t, heartbeatPids, batches[0].heartbeatPids)
 }
 
+func TestBuildServiceDiscoveryPIDBatchesNonPositiveSizeSendsSingleBatch(t *testing.T) {
+	newPids := []int32{101, 102, 103}
+	heartbeatPids := []int32{201, 202}
+	batches := buildServiceDiscoveryPIDBatches(newPids, heartbeatPids, -1)
+
+	require.Len(t, batches, 1)
+	assert.Equal(t, newPids, batches[0].newPids)
+	assert.Equal(t, heartbeatPids, batches[0].heartbeatPids)
+}
+
+func TestBuildServiceDiscoveryPIDBatchesEdgeCases(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		newPids       []int32
+		heartbeatPids []int32
+		batchSize     int
+		want          []serviceDiscoveryPIDBatch
+	}{
+		{
+			name:      "empty inputs",
+			batchSize: 500,
+		},
+		{
+			name:      "single new pid",
+			newPids:   []int32{101},
+			batchSize: 500,
+			want: []serviceDiscoveryPIDBatch{
+				{newPids: []int32{101}, heartbeatPids: []int32{}},
+			},
+		},
+		{
+			name:          "single heartbeat pid",
+			heartbeatPids: []int32{201},
+			batchSize:     500,
+			want: []serviceDiscoveryPIDBatch{
+				{newPids: []int32{}, heartbeatPids: []int32{201}},
+			},
+		},
+		{
+			name:          "batch size one",
+			newPids:       []int32{101, 102},
+			heartbeatPids: []int32{201},
+			batchSize:     1,
+			want: []serviceDiscoveryPIDBatch{
+				{newPids: []int32{101}, heartbeatPids: []int32{}},
+				{newPids: []int32{102}, heartbeatPids: []int32{}},
+				{newPids: []int32{}, heartbeatPids: []int32{201}},
+			},
+		},
+		{
+			name:          "exact boundary",
+			newPids:       []int32{101, 102},
+			heartbeatPids: []int32{201},
+			batchSize:     3,
+			want: []serviceDiscoveryPIDBatch{
+				{newPids: []int32{101, 102}, heartbeatPids: []int32{201}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, buildServiceDiscoveryPIDBatches(tc.newPids, tc.heartbeatPids, tc.batchSize))
+		})
+	}
+}
+
 func TestBuildServiceDiscoveryPIDBatchesPreservesPIDCategories(t *testing.T) {
 	newPids := []int32{101, 102, 103}
 	heartbeatPids := []int32{201, 202, 203, 204}
@@ -191,7 +256,7 @@ func TestServiceDiscoveryBatchingSuccessfulRequestsMergeResponses(t *testing.T) 
 	})
 	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
-	resp, successfulNewPids, successfulHeartbeatPids := c.collector.getDiscoveryServicesBatched([]int32{101, 102}, nil)
+	resp, successfulNewPids, successfulHeartbeatPids := c.collector.getDiscoveryServicesBatched(context.Background(), []int32{101, 102}, nil)
 
 	require.Equal(t, []int32{101, 102}, successfulNewPids)
 	require.Empty(t, successfulHeartbeatPids)
@@ -202,6 +267,38 @@ func TestServiceDiscoveryBatchingSuccessfulRequestsMergeResponses(t *testing.T) 
 	assert.Equal(t, []int{101, 102}, resp.InjectedPIDs)
 	assert.Equal(t, []int{101, 102}, resp.GPUPIDs)
 	assert.Equal(t, 2, requests())
+}
+
+func TestServiceDiscoveryBatchingStopsWhenContextCanceled(t *testing.T) {
+	sysConfigOverrides := map[string]interface{}{
+		serviceCollectionBatchSizeConfigKey: 1,
+	}
+	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	socketPath, requests := startScriptedServiceDiscoveryServer(t, func(call int, _ core.Params) serviceDiscoveryTestResponse {
+		if call == 0 {
+			cancel()
+			return serviceDiscoveryTestResponse{response: &model.ServicesResponse{
+				Services: []model.Service{makeModelService(101, "first-service")},
+			}}
+		}
+
+		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{
+			Services: []model.Service{makeModelService(102, "second-service")},
+		}}
+	})
+	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
+
+	resp, successfulNewPids, successfulHeartbeatPids := c.collector.getDiscoveryServicesBatched(ctx, []int32{101, 102, 103}, nil)
+
+	require.Equal(t, []int32{101}, successfulNewPids)
+	require.Empty(t, successfulHeartbeatPids)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Services, 1)
+	assert.Equal(t, 101, resp.Services[0].PID)
+	assert.Equal(t, 1, requests())
 }
 
 func TestServiceDiscoveryPartialBatchFailurePreservesRetries(t *testing.T) {
@@ -236,7 +333,7 @@ func TestServiceDiscoveryPartialBatchFailurePreservesRetries(t *testing.T) {
 	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101, 102, 103, 104, 105})
-	entities, _ := c.collector.updateServices(alivePids, procs)
+	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 
 	assert.Equal(t, 2, requests())
 	requestMux.Lock()
@@ -282,7 +379,7 @@ func TestServiceDiscoverySuccessfulNoServiceIncrementsRetries(t *testing.T) {
 	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101})
-	entities, _ := c.collector.updateServices(alivePids, procs)
+	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 
 	require.Len(t, entities, 1)
 	assert.Equal(t, int32(101), entities[0].Pid)

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -95,7 +95,7 @@ func TestFilterPidsToRequest(t *testing.T) {
 	// Add ignored PID (simulating a PID that exceeded max retry attempts)
 	c.collector.ignoredPids.Add(pidIgnoredService)
 
-	newPids, heartbeatPids, pidsToService := c.collector.filterPidsToRequest(alivePids, procs)
+	newPids, heartbeatPids := c.collector.filterPidsToRequest(alivePids, procs)
 	pids := append(newPids, heartbeatPids...)
 
 	// Verify categorization
@@ -111,15 +111,6 @@ func TestFilterPidsToRequest(t *testing.T) {
 	require.NotContains(t, pids, int32(pidFreshService))   // Fresh, should not be requested
 	require.NotContains(t, pids, int32(pidIgnoredService)) // Ignored, should not be requested
 	require.NotContains(t, pids, int32(pidRecentService))  // too recent (< 1 minute)
-
-	// The pidsToService map should have entries for all requested PIDs
-	require.Len(t, pidsToService, 2)
-	require.Contains(t, pidsToService, int32(pidNewService))
-	require.Contains(t, pidsToService, int32(pidStaleService))
-
-	// Initially nil, will be filled by service discovery
-	require.Nil(t, pidsToService[pidNewService])
-	require.Nil(t, pidsToService[pidStaleService])
 }
 
 func TestBuildServiceDiscoveryPIDBatchesRequestSizes(t *testing.T) {
@@ -276,7 +267,7 @@ func TestServiceDiscoveryPartialBatchFailurePreservesRetries(t *testing.T) {
 	}
 
 	c.mockClock.Add(3 * time.Minute)
-	nextNewPids, _, _ := c.collector.filterPidsToRequest(alivePids, procs)
+	nextNewPids, _ := c.collector.filterPidsToRequest(alivePids, procs)
 	assert.Subset(t, nextNewPids, unsuccessfulPids)
 }
 

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -8,11 +8,13 @@
 package process
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -118,6 +120,242 @@ func TestFilterPidsToRequest(t *testing.T) {
 	// Initially nil, will be filled by service discovery
 	require.Nil(t, pidsToService[pidNewService])
 	require.Nil(t, pidsToService[pidStaleService])
+}
+
+func TestBuildServiceDiscoveryPIDBatchesRequestSizes(t *testing.T) {
+	newPids := makeSequentialPIDs(1200, 1000)
+	batches := buildServiceDiscoveryPIDBatches(newPids, nil, 500)
+
+	require.Len(t, batches, 3)
+	assert.Len(t, batches[0].newPids, 500)
+	assert.Len(t, batches[1].newPids, 500)
+	assert.Len(t, batches[2].newPids, 200)
+	assert.Empty(t, batches[0].heartbeatPids)
+	assert.Empty(t, batches[1].heartbeatPids)
+	assert.Empty(t, batches[2].heartbeatPids)
+}
+
+func TestBuildServiceDiscoveryPIDBatchesDisabledSendsSingleBatch(t *testing.T) {
+	newPids := []int32{101, 102, 103}
+	heartbeatPids := []int32{201, 202}
+	batches := buildServiceDiscoveryPIDBatches(newPids, heartbeatPids, 0)
+
+	require.Len(t, batches, 1)
+	assert.Equal(t, newPids, batches[0].newPids)
+	assert.Equal(t, heartbeatPids, batches[0].heartbeatPids)
+}
+
+func TestBuildServiceDiscoveryPIDBatchesPreservesPIDCategories(t *testing.T) {
+	newPids := []int32{101, 102, 103}
+	heartbeatPids := []int32{201, 202, 203, 204}
+	batches := buildServiceDiscoveryPIDBatches(newPids, heartbeatPids, 5)
+
+	require.Len(t, batches, 2)
+	assert.Equal(t, []int32{101, 102, 103}, batches[0].newPids)
+	assert.Equal(t, []int32{201, 202}, batches[0].heartbeatPids)
+	assert.Empty(t, batches[1].newPids)
+	assert.Equal(t, []int32{203, 204}, batches[1].heartbeatPids)
+}
+
+func TestMergeServiceDiscoveryResponses(t *testing.T) {
+	merged := &model.ServicesResponse{}
+	mergeServiceDiscoveryResponses(merged, &model.ServicesResponse{
+		Services:     []model.Service{makeModelService(101, "first-service")},
+		InjectedPIDs: []int{101},
+		GPUPIDs:      []int{101},
+	})
+	mergeServiceDiscoveryResponses(merged, &model.ServicesResponse{
+		Services:     []model.Service{makeModelService(102, "second-service")},
+		InjectedPIDs: []int{102},
+		GPUPIDs:      []int{102},
+	})
+
+	require.Len(t, merged.Services, 2)
+	assert.Equal(t, 101, merged.Services[0].PID)
+	assert.Equal(t, 102, merged.Services[1].PID)
+	assert.Equal(t, []int{101, 102}, merged.InjectedPIDs)
+	assert.Equal(t, []int{101, 102}, merged.GPUPIDs)
+}
+
+func TestServiceDiscoveryBatchingSuccessfulRequestsMergeResponses(t *testing.T) {
+	sysConfigOverrides := map[string]interface{}{
+		serviceCollectionBatchSizeConfigKey: 1,
+	}
+	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
+	socketPath, requests := startScriptedServiceDiscoveryServer(t, func(call int, _ core.Params) serviceDiscoveryTestResponse {
+		switch call {
+		case 0:
+			return serviceDiscoveryTestResponse{response: &model.ServicesResponse{
+				Services:     []model.Service{makeModelService(101, "first-service")},
+				InjectedPIDs: []int{101},
+				GPUPIDs:      []int{101},
+			}}
+		default:
+			return serviceDiscoveryTestResponse{response: &model.ServicesResponse{
+				Services:     []model.Service{makeModelService(102, "second-service")},
+				InjectedPIDs: []int{102},
+				GPUPIDs:      []int{102},
+			}}
+		}
+	})
+	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
+
+	resp, successfulNewPids, successfulHeartbeatPids := c.collector.getDiscoveryServicesBatched([]int32{101, 102}, nil)
+
+	require.Equal(t, []int32{101, 102}, successfulNewPids)
+	require.Empty(t, successfulHeartbeatPids)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Services, 2)
+	assert.Equal(t, 101, resp.Services[0].PID)
+	assert.Equal(t, 102, resp.Services[1].PID)
+	assert.Equal(t, []int{101, 102}, resp.InjectedPIDs)
+	assert.Equal(t, []int{101, 102}, resp.GPUPIDs)
+	assert.Equal(t, 2, requests())
+}
+
+func TestServiceDiscoveryPartialBatchFailurePreservesRetries(t *testing.T) {
+	sysConfigOverrides := map[string]interface{}{
+		serviceCollectionBatchSizeConfigKey: 2,
+	}
+	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
+	c.mockClock.Set(baseTime)
+	c.collector.store = c.mockStore
+
+	var requestMux sync.Mutex
+	var successfulRequestPIDs []int32
+	socketPath, requests := startScriptedServiceDiscoveryServer(t, func(call int, params core.Params) serviceDiscoveryTestResponse {
+		if call == 1 {
+			return serviceDiscoveryTestResponse{
+				response: &model.ServicesResponse{},
+				status:   http.StatusInternalServerError,
+			}
+		}
+		requestMux.Lock()
+		successfulRequestPIDs = append([]int32(nil), params.NewPids...)
+		requestMux.Unlock()
+
+		services := make([]model.Service, 0, len(params.NewPids))
+		for _, pid := range params.NewPids {
+			services = append(services, makeModelService(pid, "first-batch-"+strconv.Itoa(int(pid))))
+		}
+		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{
+			Services: services,
+		}}
+	})
+	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
+
+	alivePids, procs := makeAlivePidsAndProcesses([]int32{101, 102, 103, 104, 105})
+	entities, _ := c.collector.updateServices(alivePids, procs)
+
+	assert.Equal(t, 2, requests())
+	requestMux.Lock()
+	successfulPidsSlice := append([]int32(nil), successfulRequestPIDs...)
+	requestMux.Unlock()
+	require.Len(t, successfulPidsSlice, 2)
+
+	require.Len(t, entities, len(successfulPidsSlice))
+	entityPids := make([]int32, 0, len(entities))
+	for _, entity := range entities {
+		entityPids = append(entityPids, entity.Pid)
+	}
+	assert.ElementsMatch(t, successfulPidsSlice, entityPids)
+
+	successfulPids := make(core.PidSet, len(successfulPidsSlice))
+	for _, pid := range successfulPidsSlice {
+		successfulPids.Add(pid)
+	}
+	var unsuccessfulPids []int32
+	for _, pid := range []int32{101, 102, 103, 104, 105} {
+		if successfulPids.Has(pid) {
+			continue
+		}
+		unsuccessfulPids = append(unsuccessfulPids, pid)
+		assert.NotContains(t, c.collector.serviceRetries, pid)
+		assert.NotContains(t, c.collector.pidHeartbeats, pid)
+		assert.NotContains(t, c.collector.knownInjectionStatusPids, pid)
+	}
+
+	c.mockClock.Add(3 * time.Minute)
+	nextNewPids, _, _ := c.collector.filterPidsToRequest(alivePids, procs)
+	assert.Subset(t, nextNewPids, unsuccessfulPids)
+}
+
+func TestServiceDiscoverySuccessfulNoServiceIncrementsRetries(t *testing.T) {
+	c := setUpCollectorTest(t, nil, nil, nil)
+	c.mockClock.Set(baseTime)
+	c.collector.store = c.mockStore
+
+	socketPath, _ := startScriptedServiceDiscoveryServer(t, func(_ int, _ core.Params) serviceDiscoveryTestResponse {
+		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{}}
+	})
+	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
+
+	alivePids, procs := makeAlivePidsAndProcesses([]int32{101})
+	entities, _ := c.collector.updateServices(alivePids, procs)
+
+	require.Len(t, entities, 1)
+	assert.Equal(t, int32(101), entities[0].Pid)
+	assert.Equal(t, uint(1), c.collector.serviceRetries[101])
+}
+
+func TestCollectServicesCachedReleasesProcessCacheLockBeforeServiceRequests(t *testing.T) {
+	sysConfigOverrides := map[string]interface{}{
+		serviceCollectionBatchSizeConfigKey: 1,
+	}
+	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
+	c.mockClock.Set(baseTime)
+	c.collector.store = c.mockStore
+	c.collector.processEventsCh = make(chan *Event, 1)
+	c.collector.lastCollectedProcesses = map[int32]*procutil.Process{
+		101: makeProcess(101, baseTime.Add(-2*time.Minute).UnixMilli(), nil),
+	}
+
+	lockAvailable := make(chan bool, 1)
+	socketPath, _ := startScriptedServiceDiscoveryServer(t, func(_ int, _ core.Params) serviceDiscoveryTestResponse {
+		locked := c.collector.mux.TryLock()
+		if locked {
+			c.collector.mux.Unlock()
+		}
+		lockAvailable <- locked
+
+		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{
+			Services: []model.Service{makeModelService(101, "cached-service")},
+		}}
+	})
+	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ticker := c.mockClock.Ticker(time.Minute)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.collector.collectServicesCached(ctx, ticker)
+	}()
+
+	c.mockClock.Add(time.Minute)
+
+	select {
+	case locked := <-lockAvailable:
+		require.True(t, locked, "service discovery request should not hold the process cache read lock")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for service discovery request")
+	}
+
+	select {
+	case event := <-c.collector.processEventsCh:
+		require.Len(t, event.Created, 1)
+		assert.Equal(t, int32(101), event.Created[0].Pid)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for service discovery event")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cached service collection to stop")
+	}
 }
 
 // TestServiceStoreLifetimeProcessCollectionDisabled tests service discovery collection when process collection and language detection are disabled
@@ -777,6 +1015,101 @@ func TestServiceLanguageToWLMLanguageMapping(t *testing.T) {
 	} {
 		assert.Equal(t, tc.expected, convertServiceLanguageToWLMLanguage(tc.serviceLanguage))
 	}
+}
+
+type serviceDiscoveryTestResponse struct {
+	response *model.ServicesResponse
+	status   int
+}
+
+func startScriptedServiceDiscoveryServer(t *testing.T, handler func(call int, params core.Params) serviceDiscoveryTestResponse) (string, func() int) {
+	t.Helper()
+
+	var mux sync.Mutex
+	requests := 0
+	requestCount := func() int {
+		mux.Lock()
+		defer mux.Unlock()
+		return requests
+	}
+
+	httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handle CheckClient's startup check.
+		if r.URL.Path == "/debug/stats" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("{}"))
+			return
+		}
+
+		if r.URL.Path != "/discovery/services" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		var params core.Params
+		if r.Body != nil {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("failed to read request body: %v", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if len(body) > 0 {
+				if err := json.Unmarshal(body, &params); err != nil {
+					t.Errorf("failed to unmarshal request body: %v", err)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+			}
+		}
+
+		mux.Lock()
+		call := requests
+		requests++
+		mux.Unlock()
+
+		result := handler(call, params)
+
+		status := result.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		if result.response == nil {
+			result.response = &model.ServicesResponse{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		responseBytes, _ := json.Marshal(result.response)
+		w.Write(responseBytes)
+	})
+
+	socketPath := testutil.SystemProbeSocketPath(t, "")
+	server, err := testutil.NewSystemProbeTestServer(httpHandler, socketPath)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	server.Start()
+	t.Cleanup(server.Close)
+
+	return socketPath, requestCount
+}
+
+func makeSequentialPIDs(count int, start int32) []int32 {
+	pids := make([]int32, count)
+	for i := range pids {
+		pids[i] = start + int32(i)
+	}
+	return pids
+}
+
+func makeAlivePidsAndProcesses(pids []int32) (core.PidSet, map[int32]*procutil.Process) {
+	alivePids := make(core.PidSet, len(pids))
+	procs := make(map[int32]*procutil.Process, len(pids))
+	for _, pid := range pids {
+		alivePids.Add(pid)
+		procs[pid] = makeProcess(pid, baseTime.Add(-2*time.Minute).UnixMilli(), nil)
+	}
+	return alivePids, procs
 }
 
 // startTestServer creates a system-probe test server that returns the specified response or error

--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -2702,6 +2702,11 @@ properties:
         node_type: setting
         type: string
         default: 60s
+      service_collection_batch_size:
+        node_type: setting
+        type: integer
+        default: 500
+        minimum: 0
       service_map:
         node_type: section
         type: object

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -370,6 +370,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("discovery.use_system_probe_lite", runtime.GOOS == "linux")
 	cfg.BindEnvAndSetDefault("discovery.cpu_usage_update_delay", "60s")
 	cfg.BindEnvAndSetDefault("discovery.service_collection_interval", "60s")
+	cfg.BindEnvAndSetDefault("discovery.service_collection_batch_size", 500)
 	cfg.BindEnvAndSetDefault("discovery.service_map.enabled", false)
 
 	// Privileged Logs config

--- a/pkg/config/setup/system_probe_test.go
+++ b/pkg/config/setup/system_probe_test.go
@@ -53,6 +53,7 @@ func TestSystemProbeDefaultConfig(t *testing.T) {
 		{key: "system_probe_config.closed_channel_size", defaultValue: 0},
 		{key: "network_config.closed_channel_size", defaultValue: 500},
 		{key: "gpu_monitoring.nvml_lib_path", defaultValue: ""},
+		{key: "discovery.service_collection_batch_size", defaultValue: 500},
 	} {
 		t.Run(tc.key, func(t *testing.T) {
 			switch expected := tc.defaultValue.(type) {

--- a/pkg/system-probe/config/adjust_discovery.go
+++ b/pkg/system-probe/config/adjust_discovery.go
@@ -29,7 +29,11 @@ var discoveryForceDisabledProtocols = []string{
 	smNS("redis", "enabled"),
 }
 
+const defaultDiscoveryServiceCollectionBatchSize = 500
+
 func adjustDiscovery(cfg model.Config) {
+	adjustDiscoveryServiceCollectionBatchSize(cfg)
+
 	if !cfg.GetBool(discoveryNS("service_map", "enabled")) {
 		return
 	}
@@ -94,4 +98,15 @@ func adjustDiscovery(cfg model.Config) {
 	for _, key := range discoveryForceDisabledProtocols {
 		disableConfig(cfg, key, "not needed for discovery service map")
 	}
+}
+
+func adjustDiscoveryServiceCollectionBatchSize(cfg model.Config) {
+	key := discoveryNS("service_collection_batch_size")
+	batchSize := cfg.GetInt(key)
+	if batchSize >= 0 {
+		return
+	}
+
+	log.Warnf("%s cannot be negative: %d, using default value %d", key, batchSize, defaultDiscoveryServiceCollectionBatchSize)
+	cfg.Set(key, defaultDiscoveryServiceCollectionBatchSize, model.SourceAgentRuntime)
 }

--- a/pkg/system-probe/config/adjust_discovery_test.go
+++ b/pkg/system-probe/config/adjust_discovery_test.go
@@ -24,6 +24,34 @@ func setBool(cfg model.Config, key string, value bool) {
 	cfg.Set(key, value, model.SourceUnknown)
 }
 
+func setInt(cfg model.Config, key string, value int) {
+	cfg.Set(key, value, model.SourceUnknown)
+}
+
+func TestAdjustDiscoveryServiceCollectionBatchSize(t *testing.T) {
+	key := discoveryNS("service_collection_batch_size")
+	tests := []struct {
+		name  string
+		input int
+		want  int
+	}{
+		{"positive value preserved", 123, 123},
+		{"zero disables batching", 0, 0},
+		{"negative value falls back to default", -1, defaultDiscoveryServiceCollectionBatchSize},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := mock.NewSystemProbe(t)
+			setInt(cfg, key, tc.input)
+
+			adjustDiscovery(cfg)
+
+			assert.Equal(t, tc.want, cfg.GetInt(key))
+		})
+	}
+}
+
 func TestAdjustDiscovery_Coexistence(t *testing.T) {
 	tests := []struct {
 		name                     string


### PR DESCRIPTION
### What does this PR do?

This PR makes service discovery handle unknown PIDs in batches (default 500) instead of all at once.

### Motivation

DSCVR-567
On machines with very high processes count, service discovery can timeout, causing high kernel CPU usage due to repeating requests.

### Describe how you validated your changes

Covered by unit tests + manual testing with 6000 processes.

### Additional Notes

- Lock/Unlock change around the call to `updateServices` has been removed. Given `updateServices` will go through the batches, it may take a large amount of time (could be in minutes in the case of multi-thousands processes hosts). In order to not block the whole collector, `getCachedProcessData` now returns a snapshot of the `lastCollectedProcesses` field to build the batches, and allow the early release of the lock.
