### PR TITLE
refactor(healthplatform): remove option.Option wrapper from healthplatformdef.Component

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -297,7 +297,7 @@ func start(log log.Component,
 	_ metadatarunner.Component,
 	tracerouteComp traceroute.Component,
 	eventPlatform eventplatform.Component,
-	healthPlatform option.Option[healthplatformdef.Component],
+	healthPlatform healthplatformdef.Component,
 	autoscalingGate *autoscalinggate.Gate,
 	serviceTemplateStore *instrumentationhandlers.ServiceCheckTemplateStore,
 ) error {

--- a/comp/core/autodiscovery/impl/BUILD.bazel
+++ b/comp/core/autodiscovery/impl/BUILD.bazel
@@ -97,6 +97,7 @@ go_test(
         "//comp/core/workloadmeta/mock",
         "//comp/healthplatform/store/def",
         "//comp/healthplatform/store/mock",
+        "//comp/healthplatform/store/noop-impl",
         "//pkg/collector/check/id",
         "//pkg/config/mock",
         "//pkg/config/setup",

--- a/comp/core/autodiscovery/impl/autoconfig.go
+++ b/comp/core/autodiscovery/impl/autoconfig.go
@@ -71,7 +71,7 @@ type Requires struct {
 	WMeta          option.Option[workloadmeta.Component]
 	FilterStore    workloadfilter.Component
 	Telemetry      telemetry.Component
-	HealthPlatform option.Option[healthplatformdef.Component]
+	HealthPlatform healthplatformdef.Component
 	ServiceTracker adtypes.ServiceTracker `optional:"true"`
 }
 
@@ -100,7 +100,7 @@ type AutoConfig struct {
 	logs                     logComp.Component
 	filterStore              workloadfilter.Component
 	telemetryStore           *acTelemetry.Store
-	healthPlatform           option.Option[healthplatformdef.Component]
+	healthPlatform           healthplatformdef.Component
 	staticConfigIndex        *listeners.StaticConfigIndex
 	serviceTracker           adtypes.ServiceTracker
 
@@ -196,20 +196,14 @@ func newAutoConfig(deps Requires) autodiscoverydef.Component {
 
 // NewAutoConfigFromDeps creates an AutoConfig instance from explicit dependencies (without starting).
 // Exported for use by the mock package.
-func NewAutoConfigFromDeps(schedulerController *scheduler.Controller, secretResolver secrets.Component, wmeta option.Option[workloadmeta.Component], taggerComp tagger.Component, logs logComp.Component, telemetryComp telemetry.Component, filterStore workloadfilter.Component, hp option.Option[healthplatformdef.Component]) *AutoConfig {
+func NewAutoConfigFromDeps(schedulerController *scheduler.Controller, secretResolver secrets.Component, wmeta option.Option[workloadmeta.Component], taggerComp tagger.Component, logs logComp.Component, telemetryComp telemetry.Component, filterStore workloadfilter.Component, hp healthplatformdef.Component) *AutoConfig {
 	return createNewAutoConfig(schedulerController, secretResolver, wmeta, taggerComp, logs, telemetryComp, filterStore, hp, nil)
 }
 
 // createNewAutoConfig creates an AutoConfig instance (without starting).
-func createNewAutoConfig(schedulerController *scheduler.Controller, secretResolver secrets.Component, wmeta option.Option[workloadmeta.Component], taggerComp tagger.Component, logs logComp.Component, telemetryComp telemetry.Component, filterStore workloadfilter.Component, hp option.Option[healthplatformdef.Component], tracker adtypes.ServiceTracker) *AutoConfig {
-	var hpComp healthplatformdef.Component
-	if h, ok := hp.Get(); ok {
-		hpComp = h
-	} else {
-		log.Infof("Health platform component not available. Issue reporting disabled for config providers.")
-	}
+func createNewAutoConfig(schedulerController *scheduler.Controller, secretResolver secrets.Component, wmeta option.Option[workloadmeta.Component], taggerComp tagger.Component, logs logComp.Component, telemetryComp telemetry.Component, filterStore workloadfilter.Component, hp healthplatformdef.Component, tracker adtypes.ServiceTracker) *AutoConfig {
 	staticConfigIndex := listeners.NewStaticConfigIndex()
-	cfgMgr := newReconcilingConfigManager(secretResolver, hpComp, staticConfigIndex, discovererPkg.NewPythonBridge())
+	cfgMgr := newReconcilingConfigManager(secretResolver, hp, staticConfigIndex, discovererPkg.NewPythonBridge())
 	ac := &AutoConfig{
 		configPollers:            make([]*configPoller, 0, 9),
 		listenerCandidates:       make(map[string]*listenerCandidate),
@@ -504,10 +498,9 @@ func (ac *AutoConfig) AddConfigProviderFromCatalog(cp pkgconfigsetup.Configurati
 		return fmt.Errorf("unable to find this provider in the catalog: %v", cp.Name)
 	}
 
-	hp, _ := ac.healthPlatform.Get()
 	wmeta, _ := ac.wmeta.Get()
 
-	configProvider, err := factory(&cp, wmeta, ac.taggerComp, ac.filterStore, hp, ac.telemetryStore)
+	configProvider, err := factory(&cp, wmeta, ac.taggerComp, ac.filterStore, ac.healthPlatform, ac.telemetryStore)
 	if err != nil {
 		return fmt.Errorf("error while adding config provider %v: %w", cp.Name, err)
 	}

--- a/comp/core/autodiscovery/impl/autoconfig_test.go
+++ b/comp/core/autodiscovery/impl/autoconfig_test.go
@@ -39,7 +39,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
-	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+	hpnoopimpl "github.com/DataDog/datadog-agent/comp/healthplatform/store/noop-impl"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -203,7 +203,7 @@ func (suite *AutoConfigTestSuite) SetupTest() {
 }
 
 func getAutoConfig(schedulerController *scheduler.Controller, secretResolver secrets.Component, wmeta option.Option[workloadmeta.Component], taggerComp tagger.Component, logsComp log.Component, telemetryComp telemetry.Component, filterComp workloadfilter.Component) *AutoConfig {
-	ac := createNewAutoConfig(schedulerController, secretResolver, wmeta, taggerComp, logsComp, telemetryComp, filterComp, option.None[healthplatformdef.Component](), nil)
+	ac := createNewAutoConfig(schedulerController, secretResolver, wmeta, taggerComp, logsComp, telemetryComp, filterComp, hpnoopimpl.NewNoopComponent(), nil)
 	go ac.serviceListening()
 	return ac
 }

--- a/comp/core/autodiscovery/mock/BUILD.bazel
+++ b/comp/core/autodiscovery/mock/BUILD.bazel
@@ -20,7 +20,7 @@ go_library(
         "//comp/core/workloadfilter/def",
         "//comp/core/workloadmeta/def",
         "//comp/def",
-        "//comp/healthplatform/store/def",
+        "//comp/healthplatform/store/noop-impl",
         "//pkg/util/fxutil",
         "//pkg/util/option",
     ],

--- a/comp/core/autodiscovery/mock/autoconfig_mock.go
+++ b/comp/core/autodiscovery/mock/autoconfig_mock.go
@@ -19,7 +19,7 @@ import (
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
-	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+	hpnoopimpl "github.com/DataDog/datadog-agent/comp/healthplatform/store/noop-impl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
@@ -61,7 +61,7 @@ func NewMockComponent(deps MockRequires) MockProvides {
 	ac := autodiscoveryimpl.NewAutoConfigFromDeps(
 		deps.Params.Scheduler, deps.Secrets, deps.WMeta, deps.TaggerComp,
 		deps.LogsComp, deps.Telemetry, deps.FilterComp,
-		option.None[healthplatformdef.Component](),
+		hpnoopimpl.NewNoopComponent(),
 	)
 	return MockProvides{Comp: ac}
 }

--- a/comp/healthplatform/store/fx/BUILD.bazel
+++ b/comp/healthplatform/store/fx/BUILD.bazel
@@ -6,10 +6,7 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/store/fx",
     visibility = ["//visibility:public"],
     deps = [
-        "//comp/healthplatform/store/def",
         "//comp/healthplatform/store/impl",
         "//pkg/util/fxutil",
-        "//pkg/util/option",
-        "@org_uber_go_fx//:fx",
     ],
 )

--- a/comp/healthplatform/store/fx/fx.go
+++ b/comp/healthplatform/store/fx/fx.go
@@ -7,12 +7,8 @@
 package fx
 
 import (
-	"go.uber.org/fx"
-
-	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	coreimpl "github.com/DataDog/datadog-agent/comp/healthplatform/store/impl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 // Module defines the fx options for this component
@@ -21,8 +17,5 @@ func Module() fxutil.Module {
 		fxutil.ProvideComponentConstructor(
 			coreimpl.NewComponent,
 		),
-		fx.Provide(func(hp healthplatformdef.Component) option.Option[healthplatformdef.Component] {
-			return option.New(hp)
-		}),
 	)
 }

--- a/pkg/clusteragent/admission/probe/probe.go
+++ b/pkg/clusteragent/admission/probe/probe.go
@@ -28,7 +28,6 @@ import (
 	admcommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/cloudprovider"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 var errProbeNotReceived = errors.New("dry-run probe configmap was not annotated by the webhook")
@@ -44,7 +43,7 @@ type Probe struct {
 	logLimiter     *log.Limit
 	diagnosticHint string
 
-	healthPlatform option.Option[healthplatformdef.Component]
+	healthPlatform healthplatformdef.Component
 
 	stats Stats
 }
@@ -85,7 +84,7 @@ const (
 // New creates a new admission controller connectivity probe.
 // The namespace parameter specifies where dry-run ConfigMaps are created; this
 // should be the namespace the cluster agent is deployed in.
-func New(k8sClient kubernetes.Interface, isLeaderFunc func() bool, namespace string, datadogConfig config.Component, healthPlatform option.Option[healthplatformdef.Component]) *Probe {
+func New(k8sClient kubernetes.Interface, isLeaderFunc func() bool, namespace string, datadogConfig config.Component, healthPlatform healthplatformdef.Component) *Probe {
 	interval := time.Duration(datadogConfig.GetInt("admission_controller.probe.interval")) * time.Second
 	if interval <= 0 {
 		log.Warnf("admission_controller.probe.interval is invalid (%s), falling back to %s", interval, defaultInterval)
@@ -252,11 +251,6 @@ func (p *Probe) handleError(err error) {
 }
 
 func (p *Probe) reportHealthIssue() {
-	hp, ok := p.healthPlatform.Get()
-	if !ok {
-		return
-	}
-
 	issue, buildErr := (&admissionprobe.AdmissionProbeIssue{}).BuildIssue(map[string]string{
 		"remediation": p.diagnosticHint,
 	})
@@ -271,17 +265,13 @@ func (p *Probe) reportHealthIssue() {
 		issue.Id = healthIssueID
 	}
 
-	if reportErr := hp.ReportIssue(issue); reportErr != nil {
+	if reportErr := p.healthPlatform.ReportIssue(issue); reportErr != nil {
 		log.Warnf("Failed to report admission probe health issue: %v", reportErr)
 	}
 }
 
 func (p *Probe) clearHealthIssue() {
-	hp, ok := p.healthPlatform.Get()
-	if !ok {
-		return
-	}
-	hp.ResolveIssue(healthIssueID)
+	p.healthPlatform.ResolveIssue(healthIssueID)
 }
 
 func (p *Probe) execute(ctx context.Context) error {

--- a/pkg/clusteragent/admission/probe/probe_test.go
+++ b/pkg/clusteragent/admission/probe/probe_test.go
@@ -25,9 +25,9 @@ import (
 
 	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	healthplatformmock "github.com/DataDog/datadog-agent/comp/healthplatform/store/mock"
+	hpnoopimpl "github.com/DataDog/datadog-agent/comp/healthplatform/store/noop-impl"
 	admcommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 const testNamespace = "test-probe-ns"
@@ -38,7 +38,7 @@ func newTestProbe(client *fakeclientset.Clientset) *Probe {
 		namespace:      testNamespace,
 		isLeaderFunc:   func() bool { return true },
 		logLimiter:     log.NewLogLimit(10, time.Minute),
-		healthPlatform: option.None[healthplatformdef.Component](),
+		healthPlatform: hpnoopimpl.NewNoopComponent(),
 	}
 }
 
@@ -49,7 +49,7 @@ func newTestProbeWithHP(t *testing.T, client *fakeclientset.Clientset) (*Probe, 
 		namespace:      testNamespace,
 		isLeaderFunc:   func() bool { return true },
 		logLimiter:     log.NewLogLimit(10, time.Minute),
-		healthPlatform: option.New[healthplatformdef.Component](hp),
+		healthPlatform: hp,
 	}, hp
 }
 

--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -27,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
@@ -52,7 +51,7 @@ type ControllerContext struct {
 }
 
 // StartControllers starts the secret and webhook controllers
-func StartControllers(ctx ControllerContext, datadogConfig config.Component, wmeta workloadmeta.Component, pp workload.PodPatcher, sh clusterspot.PodHandler, healthPlatform option.Option[healthplatformdef.Component]) ([]webhook.Webhook, error) {
+func StartControllers(ctx ControllerContext, datadogConfig config.Component, wmeta workloadmeta.Component, pp workload.PodPatcher, sh clusterspot.PodHandler, healthPlatform healthplatformdef.Component) ([]webhook.Webhook, error) {
 	var webhooks []webhook.Webhook
 
 	if !datadogConfig.GetBool("admission_controller.enabled") {


### PR DESCRIPTION
### What does this PR do?

Removes `option.Option[healthplatformdef.Component]` from every call site and replaces it with the direct `healthplatformdef.Component` interface.

The `option.Option` wrapper was introduced when the health platform was conditionally present. Now that a noop implementation (`comp/healthplatform/store/noop-impl`) is always available, the optionality is unnecessary indirection.

### Motivation

Simplify the codebase now that the health platform always has a fallback noop implementation. Removes 25 lines of boilerplate unwrapping and makes the dependency explicit and non-optional everywhere.

### Describe how you validated your changes

Pre-push hooks ran the full test suite for all affected packages — 75 tests passed.

### Additional Notes

/