### PR TITLE
fix(procmgr): avoid invalid stdio handles and fix spawn failure states on Windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,9 +41,6 @@
   - pkg/logs/tailers/windowsevent/**/*
   - pkg/logs/util/windowsevent/**/*
   - pkg/network/driver/**/*
-  - pkg/procmgr/**/*
-  - pkg/proto/datadog/procmgr/**/*
-  - pkg/proto/pbgo/procmgr/**/*
 
   # Global packages likely to impact windows
   - pkg/config/**/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,8 @@
   - pkg/logs/util/windowsevent/**/*
   - pkg/network/driver/**/*
   - pkg/procmgr/**/*
+  - pkg/proto/datadog/procmgr/**/*
+  - pkg/proto/pbgo/procmgr/**/*
 
   # Global packages likely to impact windows
   - pkg/config/**/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,7 @@
   - pkg/logs/tailers/windowsevent/**/*
   - pkg/logs/util/windowsevent/**/*
   - pkg/network/driver/**/*
+  - pkg/procmgr/**/*
 
   # Global packages likely to impact windows
   - pkg/config/**/*

--- a/pkg/procmgr/rust/Cargo.toml
+++ b/pkg/procmgr/rust/Cargo.toml
@@ -54,6 +54,7 @@ windows-sys = { workspace = true, features = [
     "Win32_System_Environment",
     "Win32_Security",
     "Win32_System_Registry",
+    "Win32_Storage_FileSystem",
 ] }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/pkg/procmgr/rust/src/platform/unix.rs
+++ b/pkg/procmgr/rust/src/platform/unix.rs
@@ -46,6 +46,14 @@ pub fn default_config_dir() -> PathBuf {
     PathBuf::from("/opt/datadog-agent/processes.d")
 }
 
+pub fn stdout_inheritable() -> bool {
+    true
+}
+
+pub fn stderr_inheritable() -> bool {
+    true
+}
+
 /// Wait for a shutdown trigger (SIGTERM or SIGINT).
 pub async fn shutdown_signal() {
     use tokio::signal::unix::{SignalKind, signal};

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -11,7 +11,8 @@ use std::sync::{Mutex, OnceLock};
 use tokio::sync::Notify;
 use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, TRUE};
 use windows_sys::Win32::System::Console::{
-    AttachConsole, CTRL_BREAK_EVENT, FreeConsole, GenerateConsoleCtrlEvent, SetConsoleCtrlHandler,
+    AttachConsole, CTRL_BREAK_EVENT, FreeConsole, GenerateConsoleCtrlEvent, GetConsoleWindow,
+    SetConsoleCtrlHandler,
 };
 use windows_sys::Win32::System::JobObjects::{
     AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
@@ -138,6 +139,15 @@ impl Drop for JobObject {
 // ---------------------------------------------------------------------------
 // Platform functions
 // ---------------------------------------------------------------------------
+
+/// True when this process has no attached console (typical for Windows services).
+///
+/// In that mode, inheriting stdin/stdout/stderr from the parent for `CreateProcess`
+/// often yields invalid handles; the first spawn may succeed while a later one
+/// fails with Windows error `ERROR_INVALID_HANDLE` (6).
+pub fn lacks_console() -> bool {
+    unsafe { GetConsoleWindow().is_null() }
+}
 
 /// Give the child its own hidden console plus a new process group so
 /// `GenerateConsoleCtrlEvent` / `AttachConsole` graceful shutdown can work (null stdio alone

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -23,6 +23,9 @@ use windows_sys::Win32::System::Threading::{
     CREATE_NEW_CONSOLE, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, OpenProcess, PROCESS_SET_QUOTA,
     PROCESS_TERMINATE, TerminateProcess,
 };
+use windows_sys::Win32::Storage::FileSystem::{
+    GetFileType, FILE_TYPE_CHAR, FILE_TYPE_DISK, FILE_TYPE_PIPE,
+};
 
 static SHUTDOWN_NOTIFY: OnceLock<Notify> = OnceLock::new();
 
@@ -140,12 +143,18 @@ impl Drop for JobObject {
 // Platform functions
 // ---------------------------------------------------------------------------
 
-/// True when the parent's standard handle is valid for child inheritance.
+/// True when the parent's standard handle is a usable console, pipe, or file.
 fn std_handle_inheritable(handle: u32) -> bool {
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     unsafe {
         let h = GetStdHandle(handle);
-        !h.is_null() && h != INVALID_HANDLE_VALUE
+        if h.is_null() || h == INVALID_HANDLE_VALUE {
+            return false;
+        }
+        matches!(
+            GetFileType(h),
+            FILE_TYPE_CHAR | FILE_TYPE_PIPE | FILE_TYPE_DISK
+        )
     }
 }
 

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -140,14 +140,21 @@ impl Drop for JobObject {
 // Platform functions
 // ---------------------------------------------------------------------------
 
-/// True when stdout and stderr are both null or `INVALID_HANDLE_VALUE`.
-/// Used to avoid inheriting unusable handles on spawn (services, post-`FreeConsole`).
-pub fn lacks_inheritable_stdio() -> bool {
+/// True when the parent's standard handle is valid for child inheritance.
+fn std_handle_inheritable(handle: u32) -> bool {
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     unsafe {
-        let is_bad = |h: HANDLE| h.is_null() || h == INVALID_HANDLE_VALUE;
-        is_bad(GetStdHandle(STD_OUTPUT_HANDLE)) && is_bad(GetStdHandle(STD_ERROR_HANDLE))
+        let h = GetStdHandle(handle);
+        !h.is_null() && h != INVALID_HANDLE_VALUE
     }
+}
+
+pub fn stdout_inheritable() -> bool {
+    std_handle_inheritable(STD_OUTPUT_HANDLE)
+}
+
+pub fn stderr_inheritable() -> bool {
+    std_handle_inheritable(STD_ERROR_HANDLE)
 }
 
 /// Give the child its own hidden console plus a new process group so

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -9,13 +9,10 @@ use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 use tokio::sync::Notify;
-use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, TRUE};
-use windows_sys::Win32::Storage::FileSystem::{
-    FILE_TYPE_CHAR, FILE_TYPE_DISK, FILE_TYPE_PIPE, GetFileType,
-};
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE, TRUE};
 use windows_sys::Win32::System::Console::{
     AttachConsole, CTRL_BREAK_EVENT, FreeConsole, GenerateConsoleCtrlEvent, GetStdHandle,
-    STD_ERROR_HANDLE, STD_OUTPUT_HANDLE, SetConsoleCtrlHandler,
+    SetConsoleCtrlHandler, SetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
 };
 use windows_sys::Win32::System::JobObjects::{
     AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
@@ -29,8 +26,15 @@ use windows_sys::Win32::System::Threading::{
 
 static SHUTDOWN_NOTIFY: OnceLock<Notify> = OnceLock::new();
 
-/// Serialize console attach / ctrl-event / detach: these APIs are process-global.
-static GRACEFUL_CONSOLE_LOCK: Mutex<()> = Mutex::new(());
+/// Serialize process-global console state: attach/detach, std-handle reads for inherit, and spawn.
+static CONSOLE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Hold while touching std handles or the attached console (graceful stop, inherit checks, spawn).
+pub(crate) fn console_lock() -> std::sync::MutexGuard<'static, ()> {
+    CONSOLE_LOCK
+        .lock()
+        .expect("console lock poisoned")
+}
 
 /// Returns the global shutdown notifier. The SCM control handler calls
 /// `notify_one()` on this from its OS thread to trigger graceful shutdown
@@ -139,22 +143,12 @@ impl Drop for JobObject {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Platform functions
-// ---------------------------------------------------------------------------
-
-/// True when the parent's standard handle is a usable console, pipe, or file.
+/// True when this process has a non-null stdout/stderr handle (safe to honor `inherit` in YAML).
+/// Caller must hold [`console_lock`]; cleared by [`reset_std_handles`] after [`detach_console`].
 fn std_handle_inheritable(handle: u32) -> bool {
-    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     unsafe {
         let h = GetStdHandle(handle);
-        if h.is_null() || h == INVALID_HANDLE_VALUE {
-            return false;
-        }
-        matches!(
-            GetFileType(h),
-            FILE_TYPE_CHAR | FILE_TYPE_PIPE | FILE_TYPE_DISK
-        )
+        !h.is_null() && h != INVALID_HANDLE_VALUE
     }
 }
 
@@ -164,6 +158,23 @@ pub fn stdout_inheritable() -> bool {
 
 pub fn stderr_inheritable() -> bool {
     std_handle_inheritable(STD_ERROR_HANDLE)
+}
+
+/// `FreeConsole` leaves stale values in the process std-handle table; clear them so a
+/// recycled handle is not mistaken for a valid inherit target.
+fn reset_std_handles() {
+    unsafe {
+        for std_handle in [STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
+            let _ = SetStdHandle(std_handle, std::ptr::null_mut());
+        }
+    }
+}
+
+fn detach_console() {
+    unsafe {
+        let _ = FreeConsole();
+    }
+    reset_std_handles();
 }
 
 /// Give the child its own hidden console plus a new process group so
@@ -182,12 +193,10 @@ unsafe extern "system" fn ignore_console_ctrl_events(_: u32) -> i32 {
 /// Send CTRL_BREAK to the child's process group (`pid` is the group root from `CREATE_NEW_PROCESS_GROUP`).
 /// Services have no console, so we `AttachConsole(pid)` before `GenerateConsoleCtrlEvent`; then detach.
 pub fn send_graceful_stop(pid: u32) -> Result<()> {
-    let _guard = GRACEFUL_CONSOLE_LOCK
-        .lock()
-        .expect("graceful console lock poisoned");
+    let _guard = console_lock();
 
     unsafe {
-        let _ = FreeConsole();
+        detach_console();
         if AttachConsole(pid) == 0 {
             anyhow::bail!(
                 "AttachConsole({pid}) failed: {}",
@@ -197,9 +206,7 @@ pub fn send_graceful_stop(pid: u32) -> Result<()> {
         struct DetachOnDrop;
         impl Drop for DetachOnDrop {
             fn drop(&mut self) {
-                unsafe {
-                    let _ = FreeConsole();
-                }
+                detach_console();
             }
         }
         let _detach = DetachOnDrop;

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -10,6 +10,9 @@ use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 use tokio::sync::Notify;
 use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, TRUE};
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_TYPE_CHAR, FILE_TYPE_DISK, FILE_TYPE_PIPE, GetFileType,
+};
 use windows_sys::Win32::System::Console::{
     AttachConsole, CTRL_BREAK_EVENT, FreeConsole, GenerateConsoleCtrlEvent, GetStdHandle,
     STD_ERROR_HANDLE, STD_OUTPUT_HANDLE, SetConsoleCtrlHandler,
@@ -22,9 +25,6 @@ use windows_sys::Win32::System::JobObjects::{
 use windows_sys::Win32::System::Threading::{
     CREATE_NEW_CONSOLE, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, OpenProcess, PROCESS_SET_QUOTA,
     PROCESS_TERMINATE, TerminateProcess,
-};
-use windows_sys::Win32::Storage::FileSystem::{
-    GetFileType, FILE_TYPE_CHAR, FILE_TYPE_DISK, FILE_TYPE_PIPE,
 };
 
 static SHUTDOWN_NOTIFY: OnceLock<Notify> = OnceLock::new();

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -12,7 +12,7 @@ use tokio::sync::Notify;
 use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE, TRUE};
 use windows_sys::Win32::System::Console::{
     AttachConsole, CTRL_BREAK_EVENT, FreeConsole, GenerateConsoleCtrlEvent, GetStdHandle,
-    SetConsoleCtrlHandler, SetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+    STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, SetConsoleCtrlHandler, SetStdHandle,
 };
 use windows_sys::Win32::System::JobObjects::{
     AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
@@ -31,9 +31,7 @@ static CONSOLE_LOCK: Mutex<()> = Mutex::new(());
 
 /// Hold while touching std handles or the attached console (graceful stop, inherit checks, spawn).
 pub(crate) fn console_lock() -> std::sync::MutexGuard<'static, ()> {
-    CONSOLE_LOCK
-        .lock()
-        .expect("console lock poisoned")
+    CONSOLE_LOCK.lock().expect("console lock poisoned")
 }
 
 /// Returns the global shutdown notifier. The SCM control handler calls

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -11,8 +11,8 @@ use std::sync::{Mutex, OnceLock};
 use tokio::sync::Notify;
 use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, TRUE};
 use windows_sys::Win32::System::Console::{
-    AttachConsole, CTRL_BREAK_EVENT, FreeConsole, GenerateConsoleCtrlEvent, GetConsoleWindow,
-    SetConsoleCtrlHandler,
+    AttachConsole, CTRL_BREAK_EVENT, FreeConsole, GenerateConsoleCtrlEvent, GetStdHandle,
+    STD_ERROR_HANDLE, STD_OUTPUT_HANDLE, SetConsoleCtrlHandler,
 };
 use windows_sys::Win32::System::JobObjects::{
     AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
@@ -140,13 +140,14 @@ impl Drop for JobObject {
 // Platform functions
 // ---------------------------------------------------------------------------
 
-/// True when this process has no attached console (typical for Windows services).
-///
-/// In that mode, inheriting stdin/stdout/stderr from the parent for `CreateProcess`
-/// often yields invalid handles; the first spawn may succeed while a later one
-/// fails with Windows error `ERROR_INVALID_HANDLE` (6).
-pub fn lacks_console() -> bool {
-    unsafe { GetConsoleWindow().is_null() }
+/// True when stdout and stderr are both null or `INVALID_HANDLE_VALUE`.
+/// Used to avoid inheriting unusable handles on spawn (services, post-`FreeConsole`).
+pub fn lacks_inheritable_stdio() -> bool {
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    unsafe {
+        let is_bad = |h: HANDLE| h.is_null() || h == INVALID_HANDLE_VALUE;
+        is_bad(GetStdHandle(STD_OUTPUT_HANDLE)) && is_bad(GetStdHandle(STD_ERROR_HANDLE))
+    }
 }
 
 /// Give the child its own hidden console plus a new process group so

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -273,15 +273,14 @@ impl ManagedProcess {
             platform::apply_child_baseline_env(&mut cmd);
             // Don't inherit stdin: invalid after AttachConsole/FreeConsole on stop.
             cmd.stdin(Stdio::null());
-            // Fall back to null stdout/stderr when parent handles are unusable.
-            let null_instead_of_inherit = platform::lacks_inheritable_stdio();
+            // Fall back to null stdout/stderr when that parent handle is unusable.
             cmd.stdout(stdio_for_windows(
                 &self.config.stdout,
-                null_instead_of_inherit,
+                !platform::stdout_inheritable(),
             ));
             cmd.stderr(stdio_for_windows(
                 &self.config.stderr,
-                null_instead_of_inherit,
+                !platform::stderr_inheritable(),
             ));
         }
         if let Some(ref raw_path) = self.config.environment_file {

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -506,11 +506,7 @@ impl ManagedProcess {
     }
 }
 
-fn apply_child_environment(
-    cmd: &mut Command,
-    name: &str,
-    config: &ProcessConfig,
-) -> Result<()> {
+fn apply_child_environment(cmd: &mut Command, name: &str, config: &ProcessConfig) -> Result<()> {
     cmd.env_clear();
     #[cfg(windows)]
     platform::apply_child_baseline_env(cmd);
@@ -522,13 +518,10 @@ fn apply_child_environment(
             (false, raw_path.as_str())
         };
         if optional && !std::path::Path::new(path).exists() {
-            info!(
-                "[{name}] optional environment file not found, skipping: {path}"
-            );
+            info!("[{name}] optional environment file not found, skipping: {path}");
         } else {
-            let vars = parse_environment_file(path).with_context(|| {
-                format!("[{name}] failed to read environment file: {path}")
-            })?;
+            let vars = parse_environment_file(path)
+                .with_context(|| format!("[{name}] failed to read environment file: {path}"))?;
             for (k, v) in &vars {
                 cmd.env(k, v);
             }

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -7,7 +7,7 @@ use crate::config::{ProcessConfig, RestartPolicy};
 use crate::env::parse_environment_file;
 use crate::platform;
 use crate::state::ProcessState;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use log::{info, warn};
 use std::collections::VecDeque;
 use std::process::Stdio;
@@ -206,6 +206,14 @@ impl ManagedProcess {
     }
 
     pub fn spawn(&mut self) -> Result<()> {
+        if !self.state.can_transition_to(ProcessState::Starting) {
+            bail!(
+                "[{}] cannot spawn: invalid state {}",
+                self.name,
+                self.state
+            );
+        }
+        self.transition_to(ProcessState::Starting);
         let result = self.try_spawn();
         if result.is_err() {
             self.transition_to(ProcessState::Failed);
@@ -271,6 +279,17 @@ impl ManagedProcess {
             // service may no longer have a valid console. Inheriting stdin then fails CreateProcess
             // with ERROR_INVALID_HANDLE (6). Children are non-interactive daemons — discard stdin.
             cmd.stdin(Stdio::null());
+            // Without an interactive console, inheriting stdout/stderr from the parent is unsafe
+            // for repeated spawns (same os error 6 as stdin).
+            let null_instead_of_inherit = platform::lacks_console();
+            cmd.stdout(stdio_for_windows(
+                &self.config.stdout,
+                null_instead_of_inherit,
+            ));
+            cmd.stderr(stdio_for_windows(
+                &self.config.stderr,
+                null_instead_of_inherit,
+            ));
         }
         if let Some(ref raw_path) = self.config.environment_file {
             let (optional, path) = if let Some(stripped) = raw_path.strip_prefix('-') {
@@ -300,8 +319,11 @@ impl ManagedProcess {
             cmd.current_dir(dir);
         }
 
-        cmd.stdout(stdio_from_str(&self.config.stdout));
-        cmd.stderr(stdio_from_str(&self.config.stderr));
+        #[cfg(not(windows))]
+        {
+            cmd.stdout(stdio_from_str(&self.config.stdout));
+            cmd.stderr(stdio_from_str(&self.config.stderr));
+        }
 
         platform::setup_process_group(&mut cmd);
 
@@ -548,6 +570,15 @@ fn stdio_from_str(s: &str) -> Stdio {
     }
 }
 
+#[cfg(windows)]
+fn stdio_for_windows(yaml_value: &str, null_instead_of_inherit: bool) -> Stdio {
+    if null_instead_of_inherit && (yaml_value == "inherit" || yaml_value.is_empty()) {
+        Stdio::null()
+    } else {
+        stdio_from_str(yaml_value)
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -724,6 +755,32 @@ pub mod tests {
         assert!(proc.spawn().is_err());
         assert!(!proc.is_running());
         assert_eq!(proc.state(), ProcessState::Failed);
+    }
+
+    #[tokio::test]
+    async fn test_spawn_failure_after_stop_goes_through_starting_to_failed() {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
+        let mut proc = ManagedProcess::new_config(
+            "svc".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
+        proc.spawn().unwrap();
+        proc.request_stop();
+        let mut child = proc.take_child().unwrap();
+        let status = child.wait().await.unwrap();
+        proc.set_last_status(status);
+        assert_eq!(proc.state(), ProcessState::Stopped);
+
+        let mut bad_cfg = proc.config().clone();
+        bad_cfg.command = "/nonexistent/binary".to_string();
+        proc.set_config(bad_cfg);
+        assert!(proc.spawn().is_err());
+        assert_eq!(
+            proc.state(),
+            ProcessState::Failed,
+            "Stopped -> Starting -> Failed is the spawn-failure path"
+        );
     }
 
     #[tokio::test]

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -1251,7 +1251,7 @@ runtime_success_sec: 5
         let path_str = path.to_str().unwrap();
         let (sh, flag) = test_helpers::shell_cmd();
         for msg in ["first", "second"] {
-            let status = std::process::Command::new(&sh)
+            let status = std::process::Command::new(sh)
                 .arg(flag)
                 .arg(format!("echo {msg}"))
                 .stdout(super::stdio_from_str(path_str))

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -218,6 +218,11 @@ impl ManagedProcess {
     }
 
     fn try_spawn(&mut self) -> Result<()> {
+        // Through CreateProcess: std-handle reads for inherit and handle inheritance
+        // must not race with AttachConsole/FreeConsole on another thread.
+        #[cfg(windows)]
+        let _console_guard = platform::console_lock();
+
         let mut cmd = self.build_command()?;
 
         let child = cmd
@@ -549,21 +554,25 @@ fn apply_child_stdio(cmd: &mut Command, config: &ProcessConfig) {
     ));
 }
 
+fn stdio_from_path(path: &str) -> Stdio {
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        Ok(f) => f.into(),
+        Err(e) => {
+            warn!("failed to open stdio file {path}: {e}, falling back to inherit");
+            Stdio::inherit()
+        }
+    }
+}
+
 fn stdio_from_str(s: &str) -> Stdio {
     match s {
         "null" => Stdio::null(),
         "inherit" | "" => Stdio::inherit(),
-        path => match std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-        {
-            Ok(f) => f.into(),
-            Err(e) => {
-                warn!("failed to open stdio file {path}: {e}, falling back to inherit");
-                Stdio::inherit()
-            }
-        },
+        path => stdio_from_path(path),
     }
 }
 

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -553,7 +553,11 @@ fn stdio_from_str(s: &str) -> Stdio {
     match s {
         "null" => Stdio::null(),
         "inherit" | "" => Stdio::inherit(),
-        path => match std::fs::File::create(path) {
+        path => match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
             Ok(f) => f.into(),
             Err(e) => {
                 warn!("failed to open stdio file {path}: {e}, falling back to inherit");
@@ -1229,6 +1233,26 @@ runtime_success_sec: 5
             contents.contains("fileline"),
             "expected fileline in log, got {contents:?}"
         );
+    }
+
+    #[test]
+    fn test_stdio_from_str_path_appends_on_respawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pmgr_stdio_append.log");
+        let path_str = path.to_str().unwrap();
+        let (sh, flag) = test_helpers::shell_cmd();
+        for msg in ["first", "second"] {
+            let status = std::process::Command::new(&sh)
+                .arg(flag)
+                .arg(format!("echo {msg}"))
+                .stdout(super::stdio_from_str(path_str))
+                .status()
+                .unwrap();
+            assert!(status.success());
+        }
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("first"), "got {contents:?}");
+        assert!(contents.contains("second"), "got {contents:?}");
     }
 
     #[test]

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -267,58 +267,13 @@ impl ManagedProcess {
         let mut cmd = Command::new(&self.config.command);
         cmd.args(&self.config.args);
 
-        cmd.env_clear();
-        #[cfg(windows)]
-        {
-            platform::apply_child_baseline_env(&mut cmd);
-            // Don't inherit stdin: invalid after AttachConsole/FreeConsole on stop.
-            cmd.stdin(Stdio::null());
-        }
-        if let Some(ref raw_path) = self.config.environment_file {
-            let (optional, path) = if let Some(stripped) = raw_path.strip_prefix('-') {
-                (true, stripped)
-            } else {
-                (false, raw_path.as_str())
-            };
-            if optional && !std::path::Path::new(path).exists() {
-                info!(
-                    "[{}] optional environment file not found, skipping: {path}",
-                    self.name
-                );
-            } else {
-                let vars = parse_environment_file(path).with_context(|| {
-                    format!("[{}] failed to read environment file: {path}", self.name)
-                })?;
-                for (k, v) in &vars {
-                    cmd.env(k, v);
-                }
-            }
-        }
-        for (k, v) in &self.config.env {
-            cmd.env(k, v);
-        }
+        apply_child_environment(&mut cmd, self.name(), &self.config)?;
 
         if let Some(ref dir) = self.config.working_dir {
             cmd.current_dir(dir);
         }
 
-        #[cfg(windows)]
-        {
-            // After env validation: path-valued stdout/stderr use File::create.
-            cmd.stdout(stdio_for_windows(
-                &self.config.stdout,
-                !platform::stdout_inheritable(),
-            ));
-            cmd.stderr(stdio_for_windows(
-                &self.config.stderr,
-                !platform::stderr_inheritable(),
-            ));
-        }
-        #[cfg(not(windows))]
-        {
-            cmd.stdout(stdio_from_str(&self.config.stdout));
-            cmd.stderr(stdio_from_str(&self.config.stderr));
-        }
+        apply_child_stdio(&mut cmd, &self.config);
 
         platform::setup_process_group(&mut cmd);
 
@@ -551,6 +506,56 @@ impl ManagedProcess {
     }
 }
 
+fn apply_child_environment(
+    cmd: &mut Command,
+    name: &str,
+    config: &ProcessConfig,
+) -> Result<()> {
+    cmd.env_clear();
+    #[cfg(windows)]
+    platform::apply_child_baseline_env(cmd);
+
+    if let Some(ref raw_path) = config.environment_file {
+        let (optional, path) = if let Some(stripped) = raw_path.strip_prefix('-') {
+            (true, stripped)
+        } else {
+            (false, raw_path.as_str())
+        };
+        if optional && !std::path::Path::new(path).exists() {
+            info!(
+                "[{name}] optional environment file not found, skipping: {path}"
+            );
+        } else {
+            let vars = parse_environment_file(path).with_context(|| {
+                format!("[{name}] failed to read environment file: {path}")
+            })?;
+            for (k, v) in &vars {
+                cmd.env(k, v);
+            }
+        }
+    }
+    for (k, v) in &config.env {
+        cmd.env(k, v);
+    }
+    Ok(())
+}
+
+fn apply_child_stdio(cmd: &mut Command, config: &ProcessConfig) {
+    #[cfg(windows)]
+    {
+        // Don't inherit stdin: invalid after AttachConsole/FreeConsole on stop.
+        cmd.stdin(Stdio::null());
+    }
+    cmd.stdout(stdio_from_config(
+        &config.stdout,
+        platform::stdout_inheritable(),
+    ));
+    cmd.stderr(stdio_from_config(
+        &config.stderr,
+        platform::stderr_inheritable(),
+    ));
+}
+
 fn stdio_from_str(s: &str) -> Stdio {
     match s {
         "null" => Stdio::null(),
@@ -565,13 +570,14 @@ fn stdio_from_str(s: &str) -> Stdio {
     }
 }
 
-#[cfg(windows)]
-fn stdio_for_windows(yaml_value: &str, null_instead_of_inherit: bool) -> Stdio {
-    if null_instead_of_inherit && (yaml_value == "inherit" || yaml_value.is_empty()) {
-        Stdio::null()
-    } else {
-        stdio_from_str(yaml_value)
+fn stdio_from_config(yaml_value: &str, inheritable: bool) -> Stdio {
+    #[cfg(not(windows))]
+    let _ = inheritable;
+    #[cfg(windows)]
+    if !inheritable && (yaml_value == "inherit" || yaml_value.is_empty()) {
+        return Stdio::null();
     }
+    stdio_from_str(yaml_value)
 }
 
 #[cfg(test)]

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -207,11 +207,7 @@ impl ManagedProcess {
 
     pub fn spawn(&mut self) -> Result<()> {
         if !self.state.can_transition_to(ProcessState::Starting) {
-            bail!(
-                "[{}] cannot spawn: invalid state {}",
-                self.name,
-                self.state
-            );
+            bail!("[{}] cannot spawn: invalid state {}", self.name, self.state);
         }
         self.transition_to(ProcessState::Starting);
         let result = self.try_spawn();
@@ -275,13 +271,10 @@ impl ManagedProcess {
         #[cfg(windows)]
         {
             platform::apply_child_baseline_env(&mut cmd);
-            // After graceful stop we call `AttachConsole` / `FreeConsole` on this process; the
-            // service may no longer have a valid console. Inheriting stdin then fails CreateProcess
-            // with ERROR_INVALID_HANDLE (6). Children are non-interactive daemons — discard stdin.
+            // Don't inherit stdin: invalid after AttachConsole/FreeConsole on stop.
             cmd.stdin(Stdio::null());
-            // Without an interactive console, inheriting stdout/stderr from the parent is unsafe
-            // for repeated spawns (same os error 6 as stdin).
-            let null_instead_of_inherit = platform::lacks_console();
+            // Fall back to null stdout/stderr when parent handles are unusable.
+            let null_instead_of_inherit = platform::lacks_inheritable_stdio();
             cmd.stdout(stdio_for_windows(
                 &self.config.stdout,
                 null_instead_of_inherit,

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -273,15 +273,6 @@ impl ManagedProcess {
             platform::apply_child_baseline_env(&mut cmd);
             // Don't inherit stdin: invalid after AttachConsole/FreeConsole on stop.
             cmd.stdin(Stdio::null());
-            // Fall back to null stdout/stderr when that parent handle is unusable.
-            cmd.stdout(stdio_for_windows(
-                &self.config.stdout,
-                !platform::stdout_inheritable(),
-            ));
-            cmd.stderr(stdio_for_windows(
-                &self.config.stderr,
-                !platform::stderr_inheritable(),
-            ));
         }
         if let Some(ref raw_path) = self.config.environment_file {
             let (optional, path) = if let Some(stripped) = raw_path.strip_prefix('-') {
@@ -311,6 +302,18 @@ impl ManagedProcess {
             cmd.current_dir(dir);
         }
 
+        #[cfg(windows)]
+        {
+            // After env validation: path-valued stdout/stderr use File::create.
+            cmd.stdout(stdio_for_windows(
+                &self.config.stdout,
+                !platform::stdout_inheritable(),
+            ));
+            cmd.stderr(stdio_for_windows(
+                &self.config.stderr,
+                !platform::stderr_inheritable(),
+            ));
+        }
         #[cfg(not(windows))]
         {
             cmd.stdout(stdio_from_str(&self.config.stdout));


### PR DESCRIPTION
### What does this PR do?

Two fixes for Windows procmgr when running as a service (no console):

1. **Invalid handle on respawn**: when `stdout`/`stderr` are set to `inherit`
   and the daemon has no console, repeated spawns fail with `ERROR_INVALID_HANDLE`
   (os error 6). We now detect the no-console case via `GetConsoleWindow()` and
   fall back to `null` instead of inheriting.

2. **Bogus state transition log**: `spawn()` from `Stopped` tried the invalid
   `Stopped -> Failed` edge on failure and logged a confusing warning. `spawn()`
   now enters `Starting` first, so failures always take the valid
   `Starting -> Failed` path.

### Motivation

Reproduced with `dd-procmgr stop datadog-agent-ddot` followed by
`dd-procmgr start datadog-agent-ddot` on a Windows install. The second start
fails and the logs show:
`failed to spawn: …/otel-agent.exe: The handle is invalid. (os error 6) invalid state transition: stopped -> failed, ignoring
`

### Describe how you validated your changes

`cargo test process::tests` and `cargo test manager::tests` pass. Manual
stop/start of `datadog-agent-ddot` on Windows no longer errors.

### Additional Notes