### PR TITLE
Replace `nil` testing.T in oracle's TestMain with a minimal stand-in

### DIFF
--- a/pkg/collector/corechecks/oracle/init_test.go
+++ b/pkg/collector/corechecks/oracle/init_test.go
@@ -35,9 +35,37 @@ func TestNoop(t *testing.T) {
 	assert.True(t, true)
 }
 
+// minimalT is a stand-in testing.TB for TestMain, which has no *testing.T.
+// Embedding satisfies the interface, with overrides for methods called by test
+// helpers (Helper/Name/Errorf/FailNow) plus Cleanup, replayed by runCleanups.
+type minimalT struct {
+	testing.TB
+	cleanups []func()
+}
+
+func (*minimalT) Helper() {}
+
+func (*minimalT) Name() string { return "TestMain" }
+
+func (*minimalT) Errorf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+}
+
+func (*minimalT) FailNow() { os.Exit(1) }
+
+func (c *minimalT) Cleanup(f func()) { c.cleanups = append(c.cleanups, f) }
+
+func (c *minimalT) runCleanups() {
+	for i := len(c.cleanups) - 1; i >= 0; i-- {
+		c.cleanups[i]()
+	}
+}
+
 func TestMain(m *testing.M) {
+	t := &minimalT{}
 	defer func() {
 		code := m.Run()
+		t.runCleanups()
 		os.Exit(code)
 	}()
 
@@ -54,7 +82,8 @@ func TestMain(m *testing.M) {
 	// This is a bit of a hack to get a db connection without a testing.T
 	// Ideally we should pull the connection logic out
 	// to make it more accessible for testing
-	sysCheck, _ := newSysCheck(nil, "", "")
+	sysCheck, _ := newSysCheck(t, "", "")
+	t.Cleanup(sysCheck.Teardown)
 	sysCheck.Run()
 	_, err := sysCheck.db.Exec("SELECT 1 FROM dual")
 	if err != nil {

--- a/pkg/collector/corechecks/oracle/oracle_integration_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_integration_test.go
@@ -116,9 +116,9 @@ END;`
 	}
 }
 
-func connectToDB(driver string) (*sqlx.DB, error) {
+func connectToDB(t *testing.T, driver string) (*sqlx.DB, error) {
 	var connStr string
-	connectionConfig := getConnectData(nil, useDefaultUser)
+	connectionConfig := getConnectData(t, useDefaultUser)
 	if driver == common.Godror {
 		godrorConnectionConfig := connectionConfig
 		godrorConnectionConfig.OracleClient = true
@@ -282,7 +282,7 @@ func TestBindingSimple(t *testing.T) {
 	result := 3
 
 	driver := "oracle"
-	db, err := connectToDB(driver)
+	db, err := connectToDB(t, driver)
 	require.NoError(t, err)
 	stmt, err := db.Prepare(fmt.Sprintf("SELECT %d FROM dual WHERE rownum = :1", result))
 	if err != nil {
@@ -305,7 +305,7 @@ func TestSQLXIn(t *testing.T) {
 	slice := []any{1}
 	result := 7
 	driver := common.GoOra
-	db, err := connectToDB(driver)
+	db, err := connectToDB(t, driver)
 	require.NoError(t, err, "failed to connect to DB")
 
 	var rows *sql.Rows

--- a/pkg/collector/corechecks/oracle/testutil.go
+++ b/pkg/collector/corechecks/oracle/testutil.go
@@ -40,7 +40,7 @@ const (
 	expectedSessionsWithCustomQueries = 6
 )
 
-func getConnectData(t *testing.T, userType int) config.ConnectionConfig {
+func getConnectData(t testing.TB, userType int) config.ConnectionConfig {
 	handleRealConnection := func(userType int) config.ConnectionConfig {
 		var userEnvVariable string
 		var passwordEnvVariable string
@@ -88,13 +88,11 @@ func getConnectData(t *testing.T, userType int) config.ConnectionConfig {
 			port = 1521
 		}
 
-		if t != nil {
-			require.NotEqualf(t, "", username, "Please set the %s environment variable", userEnvVariable)
-			require.NotEqualf(t, "", password, "Please set the %s environment variable", passwordEnvVariable)
-			require.NotEqualf(t, "", server, "Please set the %s environment variable", serverEnvVariable)
-			require.NotEqualf(t, "", serviceName, "Please set the %s environment variable", serviceNameEnvVariable)
-			require.NotEqualf(t, 0, port, "Please set the %s environment variable", portEnvVariable)
-		}
+		require.NotEqualf(t, "", username, "Please set the %s environment variable", userEnvVariable)
+		require.NotEqualf(t, "", password, "Please set the %s environment variable", passwordEnvVariable)
+		require.NotEqualf(t, "", server, "Please set the %s environment variable", serverEnvVariable)
+		require.NotEqualf(t, "", serviceName, "Please set the %s environment variable", serviceNameEnvVariable)
+		require.NotEqualf(t, 0, port, "Please set the %s environment variable", portEnvVariable)
 
 		return config.ConnectionConfig{
 			Username:    username,
@@ -131,14 +129,12 @@ func getSysConnection(t *testing.T) (*sql.DB, error) {
 	return conn, err
 }
 
-func newTestCheck(t *testing.T, connectConfig config.ConnectionConfig, instanceConfigAddition string, initConfig string) (Check, *mocksender.MockSender) {
+func newTestCheck(t testing.TB, connectConfig config.ConnectionConfig, instanceConfigAddition string, initConfig string) (Check, *mocksender.MockSender) {
 	var err error
 	c := Check{}
 
 	connectYaml, err := yaml.Marshal(connectConfig)
-	if t != nil {
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
 	instanceConfig := string(connectYaml)
 	if instanceConfigAddition != "" {
 		instanceConfig = fmt.Sprintf("%s\n%s", instanceConfig, instanceConfigAddition)
@@ -147,20 +143,16 @@ func newTestCheck(t *testing.T, connectConfig config.ConnectionConfig, instanceC
 	rawInitConfig := []byte(initConfig)
 	senderManager := mocksender.CreateDefaultDemultiplexer()
 	err = c.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, rawInitConfig, "oracle_test", "")
-	if t != nil {
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
 
 	sender := mocksender.NewMockSenderWithSenderManager(c.ID(), senderManager)
 	sender.SetupAcceptAll()
-	if t != nil {
-		assert.Equal(t, c.config.InstanceConfig.Server, connectConfig.Server)
-		assert.Equal(t, c.config.InstanceConfig.Port, connectConfig.Port)
-		assert.Equal(t, c.config.InstanceConfig.Username, connectConfig.Username)
-		assert.Equal(t, c.config.InstanceConfig.Password, connectConfig.Password)
-		assert.Equal(t, c.config.InstanceConfig.ServiceName, connectConfig.ServiceName)
-		assert.Contains(t, c.configTags, dbmsTag, "c.configTags doesn't contain static tags")
-	}
+	assert.Equal(t, c.config.InstanceConfig.Server, connectConfig.Server)
+	assert.Equal(t, c.config.InstanceConfig.Port, connectConfig.Port)
+	assert.Equal(t, c.config.InstanceConfig.Username, connectConfig.Username)
+	assert.Equal(t, c.config.InstanceConfig.Password, connectConfig.Password)
+	assert.Equal(t, c.config.InstanceConfig.ServiceName, connectConfig.ServiceName)
+	assert.Contains(t, c.configTags, dbmsTag, "c.configTags doesn't contain static tags")
 
 	if oracleLibDir := os.Getenv("ORACLE_TEST_ORACLE_CLIENT_LIB_DIR"); oracleLibDir != "" {
 		c.config.InstanceConfig.OracleClientLibDir = oracleLibDir
@@ -186,7 +178,7 @@ func newDefaultCheck(t *testing.T, instanceConfigAddition string, initConfig str
 	return c, m
 }
 
-func newSysCheck(t *testing.T, instanceConfigAddition string, initConfig string) (Check, *mocksender.MockSender) {
+func newSysCheck(t testing.TB, instanceConfigAddition string, initConfig string) (Check, *mocksender.MockSender) {
 	return newTestCheck(t, getConnectData(t, useSysUser), instanceConfigAddition, initConfig)
 }
 


### PR DESCRIPTION
### What does this PR do?
- add `minimalT`, a `testing.TB` stand-in that `TestMain` passes to test helpers in place of a `*testing.T` set to `nil`,
- drop the `if t != nil` guards from `getConnectData`, `newTestCheck` and `newSysCheck`, which now always receive a valid `TB`,
- threads the real `t` into `connectToDB` (its callers have one),
- registers `t.Cleanup(sysCheck.Teardown)` to close the sys check's database handles when the suite ends.

### Motivation
The primary goal is to unblock #52559, aimed at fixing a massive demultiplexer goroutine leak in the Agent's test suite.
For that, `CreateDefaultDemultiplexer` would register `tb.Cleanup(demux.Stop)` so every test or benchmark stops its demultiplexer, but `TestMain` has been bootstrapping the test database with no `*testing.T`, threading a typed-`nil` down the test helper chain.
With `tb` being `nil` in that one case, #52559 had to fall back to a [reflection guard that reviewers rejected](https://github.com/DataDog/datadog-agent/pull/52559#discussion_r3452098933).
Therefore, removing the `nil` here lets it call `tb.Cleanup` unconditionally and drop that guard altogether.

`TestMain` got away with the `nil` because the helpers wrapped every assertion in `if t != nil`, silently skipping them under `TestMain`: a misconfigured connection (e.g. an unset `ORACLE_TEST_*` variable) would slip through instead of aborting setup.
`minimalT`, a `testing.TB` stand-in `TestMain` can pass, removes the `nil` and lets those guards go.

It is **still a hack**, but a contained one, and two wins fall out of it:
1. **fail-fast is restored** because the assertions now run under `TestMain` too: a bad config reports (through `Errorf`) and aborts (through `FailNow`) instead of being ignored,
2. a **connection leak is fixed**: with a `TB` at hand, `TestMain` registers `t.Cleanup(sysCheck.Teardown)` and executes `t.runCleanups` after `m.Run`, which closes the sys check's `db`, `dbCustomQueries` and go-ora connection.

### Describe how you validated your changes
The oracle functional test job exercises `TestMain` and the helpers.

### Additional Notes
One :green_circle: [job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1815708430) after 2 :orange_circle:, the latter seemingly hitting infrastructure limits **unrelated to the present change**.
