### PR TITLE
sbom: fix package attribution on usr-merged layouts

### DIFF
--- a/pkg/security/resolvers/sbom/file_querier.go
+++ b/pkg/security/resolvers/sbom/file_querier.go
@@ -21,6 +21,8 @@ type fileQuerier struct {
 	files []uint64
 	pkgs  []*sbomtypes.Package
 
+	usrMerged bool
+
 	lastNegativeCache *fixedSizeQueue[uint64]
 }
 
@@ -34,7 +36,7 @@ and each part group is at the index of the given package
 for example here hash5 would match pkgs[2]
 */
 
-func newFileQuerier(report []sbomtypes.PackageWithInstalledFiles) fileQuerier {
+func newFileQuerier(report []sbomtypes.PackageWithInstalledFiles, usrMerged bool) fileQuerier {
 	fileCount := 0
 	pkgCount := 0
 	for _, pkg := range report {
@@ -60,7 +62,7 @@ func newFileQuerier(report []sbomtypes.PackageWithInstalledFiles) fileQuerier {
 		}
 	}
 
-	return fileQuerier{files: files, pkgs: pkgs, lastNegativeCache: newFixedSizeQueue[uint64](2)}
+	return fileQuerier{files: files, pkgs: pkgs, usrMerged: usrMerged, lastNegativeCache: newFixedSizeQueue[uint64](2)}
 }
 
 func (fq *fileQuerier) queryHash(hash uint64) *sbomtypes.Package {
@@ -107,9 +109,19 @@ func (fq *fileQuerier) queryFile(path string) *sbomtypes.Package {
 		return pkg
 	}
 
-	if !strings.HasPrefix(path, "/usr") && (strings.HasPrefix(path, "/bin") || strings.HasPrefix(path, "/sbin") || strings.HasPrefix(path, "/lib")) {
-		if result := fq.queryHashWithNegativeCache(murmur3.StringSum64("/usr/" + path)); result != nil {
-			return result
+	// On usr-merged layouts /bin and /usr/bin are the same tree, so the package
+	// database and the resolved exec path may use either prefix for one file.
+	if fq.usrMerged {
+		if !strings.HasPrefix(path, "/usr") && (strings.HasPrefix(path, "/bin") || strings.HasPrefix(path, "/sbin") || strings.HasPrefix(path, "/lib")) {
+			if result := fq.queryHashWithNegativeCache(murmur3.StringSum64("/usr" + path)); result != nil {
+				return result
+			}
+		}
+
+		if after, ok := strings.CutPrefix(path, "/usr"); ok && (strings.HasPrefix(after, "/bin") || strings.HasPrefix(after, "/sbin") || strings.HasPrefix(after, "/lib")) {
+			if result := fq.queryHashWithNegativeCache(murmur3.StringSum64(after)); result != nil {
+				return result
+			}
 		}
 	}
 

--- a/pkg/security/resolvers/sbom/file_querier_test.go
+++ b/pkg/security/resolvers/sbom/file_querier_test.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package sbom
+
+import (
+	"testing"
+
+	sbomtypes "github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/types"
+)
+
+// TestQueryFileUsrMerge checks that /bin and /usr/bin are treated as one tree on
+// usr-merged layouts (where dpkg may record /bin/mount while execs resolve to
+// /usr/bin/mount) and kept distinct otherwise.
+func TestQueryFileUsrMerge(t *testing.T) {
+	report := []sbomtypes.PackageWithInstalledFiles{
+		{Package: sbomtypes.Package{Name: "mount"}, InstalledFiles: []string{"/bin/mount"}},
+		{Package: sbomtypes.Package{Name: "util-linux"}, InstalledFiles: []string{"/bin/su"}},
+		{Package: sbomtypes.Package{Name: "passwd"}, InstalledFiles: []string{"/usr/bin/passwd"}},
+		{Package: sbomtypes.Package{Name: "coreutils"}, InstalledFiles: []string{"/usr/bin/cat"}},
+	}
+
+	merged := newFileQuerier(report, true)
+	for _, tc := range []struct {
+		name    string
+		query   string
+		wantPkg string
+	}{
+		{"/bin recorded, exec'd as /usr/bin", "/usr/bin/mount", "mount"},
+		{"su resolves to util-linux", "/usr/bin/su", "util-linux"},
+		{"/usr/bin recorded, queried as /bin", "/bin/cat", "coreutils"},
+		{"direct hit", "/usr/bin/passwd", "passwd"},
+		{"unknown file", "/usr/bin/does-not-exist", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ""
+			if pkg := merged.queryFile(tc.query); pkg != nil {
+				got = pkg.Name
+			}
+			if got != tc.wantPkg {
+				t.Errorf("queryFile(%q) = %q, want %q", tc.query, got, tc.wantPkg)
+			}
+		})
+	}
+
+	// Without usr-merge, /bin and /usr/bin are distinct trees: an unmatched
+	// /usr/bin/mount must not be cross-attributed to the /bin/mount package.
+	plain := newFileQuerier(report, false)
+	if pkg := plain.queryFile("/usr/bin/mount"); pkg != nil {
+		t.Errorf("queryFile(/usr/bin/mount) attributed to %q on a non-usr-merged layout, want no match", pkg.Name)
+	}
+}

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -100,6 +100,8 @@ type SBOM struct {
 	forwardRetryCount int
 
 	invalidated bool
+
+	usrMerged bool
 }
 
 type workloadKey string
@@ -116,7 +118,7 @@ func (s *SBOM) IsComputed() bool {
 // SetReport sets the SBOM report
 func (s *SBOM) setReport(pkgs []sbomtypes.PackageWithInstalledFiles) {
 	// build file cache
-	s.data.files = newFileQuerier(pkgs)
+	s.data.files = newFileQuerier(pkgs, s.usrMerged)
 }
 
 func (s *SBOM) stop() {
@@ -251,6 +253,7 @@ func (r *Resolver) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		r.hostSBOM.usrMerged = isUsrMerged(hostRoot)
 		r.hostSBOM.setReport(report)
 		r.hostSBOM.state.Store(computedState)
 	}
@@ -434,6 +437,14 @@ func (r *Resolver) generateSBOM(root string) ([]sbomtypes.PackageWithInstalledFi
 	return report, nil
 }
 
+// isUsrMerged reports whether root uses the merged-/usr layout, where /bin is a
+// symlink into /usr/bin. There the package database and a resolved exec path may
+// disagree on the /bin vs /usr/bin prefix for the same file.
+func isUsrMerged(root string) bool {
+	fi, err := os.Lstat(root + "/bin")
+	return err == nil && fi.Mode()&fs.ModeSymlink != 0
+}
+
 // escapeFilePathForRule escapes special characters in file paths for use in rule expressions
 // This prevents filenames with quotes, backslashes, or other special characters from breaking the syntax
 func escapeFilePathForRule(path string) string {
@@ -535,6 +546,7 @@ func (r *Resolver) doScan(sbom *SBOM) ([]sbomtypes.PackageWithInstalledFiles, er
 		}
 
 		if report, lastErr = r.generateSBOM(containerProcRootPath); lastErr == nil {
+			sbom.usrMerged = isUsrMerged(containerProcRootPath)
 			sbom.setReport(report)
 			scanned = true
 			break
@@ -674,7 +686,7 @@ func (r *Resolver) analyzeWorkload(sb *SBOM) error {
 	}
 
 	data := &Data{
-		files:    newFileQuerier(report),
+		files:    newFileQuerier(report, sb.usrMerged),
 		packages: report, // Store original packages for forwarding with LastAccess
 	}
 	sb.data = data

--- a/releasenotes/notes/fix-sbom-usrmerge-attribution-3c7f1a9e0b6d28f4.yaml
+++ b/releasenotes/notes/fix-sbom-usrmerge-attribution-3c7f1a9e0b6d28f4.yaml
@@ -1,0 +1,17 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed the SBOM runtime usage enrichment ("package in use") not being reported
+    for some binaries on usr-merged Linux distributions (for example ``mount`` and
+    ``su`` on Debian/Ubuntu). The package database records these under their
+    pre-merge path such as ``/bin/mount`` while the kernel resolves the executed
+    path to ``/usr/bin/mount``. The resolver now normalizes both the ``/bin`` and
+    ``/usr/bin`` layouts, so the affected packages' ``HasSetSuidBit`` and
+    ``LastSeenRunning`` properties are populated correctly.


### PR DESCRIPTION
On usr-merged distributions the package database and the resolved exec path
disagree on the /bin versus /usr/bin prefix for the same file. dpkg records
some binaries under their pre-merge path such as /bin/mount and /bin/su while
execs resolve to /usr/bin, so those binaries were never attributed to their
package and their HasSetSuidBit and LastSeenRunning properties stayed unset.
rpm-based images, which record /usr/bin directly, were unaffected.

queryFile now normalizes both prefixes, gated on whether the scanned root is
actually usr-merged so that distinct /bin and /usr/bin trees are never
cross-attributed. The earlier forward-only attempt also built a /usr//bin
double-slash path that never matched.

