### PR TITLE
[EXP-554] Emit daemon-specific task definition tag for ECS daemon tasks

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -562,7 +562,11 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 	taskTags.AddLow(tags.EcsServiceARN, task.ServiceARN)
 	taskTags.AddLow(tags.EcsDaemonARN, task.DaemonARN)
 	taskTags.AddOrchestrator(tags.TaskARN, task.ID)
-	taskTags.AddOrchestrator(tags.TaskDefinitionARN, task.TaskDefinitionARN)
+	if task.DaemonName != "" {
+		taskTags.AddOrchestrator(tags.DaemonTaskDefinitionARN, task.TaskDefinitionARN)
+	} else {
+		taskTags.AddOrchestrator(tags.TaskDefinitionARN, task.TaskDefinitionARN)
+	}
 
 	clusterTags := taglist.NewTagList()
 	if task.ClusterName != "" {

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -2138,7 +2138,7 @@ func TestHandleECSTask(t *testing.T) {
 					HighCardTags: []string{},
 					OrchestratorCardTags: []string{
 						"task_arn:foobar",
-						"task_definition_arn:arn:aws:ecs:us-east-1:1234567891234:daemon-task-definition/datadog-agent-daemon:1",
+						"daemon_task_definition_arn:arn:aws:ecs:us-east-1:1234567891234:daemon-task-definition/datadog-agent-daemon:1",
 					},
 					LowCardTags: []string{
 						"cluster_name:ecs-cluster",

--- a/comp/core/tagger/tags/tags.go
+++ b/comp/core/tagger/tags/tags.go
@@ -237,6 +237,8 @@ const (
 	MesosTask = "mesos_task"
 	// TaskDefinitionARN is the tag for the task definition ARN (Amazon Resource Name)
 	TaskDefinitionARN = "task_definition_arn"
+	// DaemonTaskDefinitionARN is the tag for the daemon task definition ARN (Amazon Resource Name)
+	DaemonTaskDefinitionARN = "daemon_task_definition_arn"
 
 	// HIGH CARDINALITY
 

--- a/comp/core/workloadmeta/collectors/util/ecs_util.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util.go
@@ -52,8 +52,8 @@ func ParseV4Task(task v3or4.Task, seen map[workloadmeta.EntityID]struct{}) []wor
 	clusterName := parseClusterName(task.ClusterName)
 	clusterARN := BuildClusterARN(clusterName, awsAccountID, region)
 	serviceARN := BuildServiceARN(clusterName, task.ServiceName, awsAccountID, region)
-	taskDefinitionARN := BuildTaskDefinitionARN(awsAccountID, task.Family, region, task.Version)
 	daemonName := parseDaemonNameFromGroup(task.Group)
+	taskDefinitionARN := BuildTaskDefinitionARN(awsAccountID, task.Family, region, task.Version, daemonName != "")
 	daemonARN := BuildDaemonARN(clusterName, daemonName, awsAccountID, region)
 
 	entity := &workloadmeta.ECSTask{
@@ -329,12 +329,18 @@ func parseDaemonNameFromGroup(group string) string {
 	return ""
 }
 
-// BuildTaskDefinitionARN builds the task definition ARN from the AWS account ID, family, region, and version
-func BuildTaskDefinitionARN(awsAccountID, family, region, version string) string {
+// BuildTaskDefinitionARN builds the task definition ARN from the AWS account ID, family, region, and version.
+// When isDaemon is true it builds a daemon task definition ARN (daemon-task-definition/) instead of the regular
+// task definition ARN (task-definition/), matching the ARN form AWS uses for daemon-scheduled tasks.
+func BuildTaskDefinitionARN(awsAccountID, family, region, version string, isDaemon bool) string {
 	if awsAccountID == "" || family == "" || region == "" || version == "" {
 		return ""
 	}
-	return fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/%s:%s", region, awsAccountID, family, version)
+	resourceType := "task-definition"
+	if isDaemon {
+		resourceType = "daemon-task-definition"
+	}
+	return fmt.Sprintf("arn:aws:ecs:%s:%s:%s/%s:%s", region, awsAccountID, resourceType, family, version)
 }
 
 // ecsAgentRegexp is a regular expression to match ECS agent versions

--- a/comp/core/workloadmeta/collectors/util/ecs_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util_test.go
@@ -93,8 +93,11 @@ func TestParseDaemonNameFromGroup(t *testing.T) {
 }
 
 func TestBuildTaskDefinitionARN(t *testing.T) {
-	arn := BuildTaskDefinitionARN("123456789012", "family-name", "us-east-1", "1")
+	arn := BuildTaskDefinitionARN("123456789012", "family-name", "us-east-1", "1", false)
 	require.Equal(t, "arn:aws:ecs:us-east-1:123456789012:task-definition/family-name:1", arn)
+
+	daemonARN := BuildTaskDefinitionARN("123456789012", "family-name", "us-east-1", "1", true)
+	require.Equal(t, "arn:aws:ecs:us-east-1:123456789012:daemon-task-definition/family-name:1", daemonARN)
 }
 
 func newMinimalTask(launchType string) v3or4.Task {
@@ -151,6 +154,7 @@ func TestParseV4TaskDaemonGroup(t *testing.T) {
 	task := getECSTaskEntity(t, events)
 	assert.Equal(t, "my-daemon", task.DaemonName)
 	assert.Equal(t, "arn:aws:ecs:us-east-1:123456789012:daemon/cluster/my-daemon", task.DaemonARN)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:123456789012:daemon-task-definition/test-family:1", task.TaskDefinitionARN)
 	assert.Empty(t, task.ServiceName)
 	assert.Empty(t, task.ServiceARN)
 }
@@ -164,6 +168,7 @@ func TestParseV4TaskServiceGroup(t *testing.T) {
 	task := getECSTaskEntity(t, events)
 	assert.Equal(t, "my-service", task.ServiceName)
 	assert.Equal(t, "arn:aws:ecs:us-east-1:123456789012:service/cluster/my-service", task.ServiceARN)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:123456789012:task-definition/test-family:1", task.TaskDefinitionARN)
 	assert.Empty(t, task.DaemonName)
 	assert.Empty(t, task.DaemonARN)
 }

--- a/releasenotes/notes/ecs-daemon-task-definition-tags-a1b2c3d4e5f6a7b8.yaml
+++ b/releasenotes/notes/ecs-daemon-task-definition-tags-a1b2c3d4e5f6a7b8.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ECS daemon-scheduled tasks now emit the ``daemon_task_definition_arn`` tag instead
+    of ``task_definition_arn``, enabling correct entity resolution in the ECS Explorer.


### PR DESCRIPTION
### What does this PR do?

For ECS daemon-scheduled tasks,

- Emits the **`daemon_task_definition_arn`** tag key instead of `task_definition_arn`.
- Builds the task definition ARN value using the **`daemon-task-definition/`** resource form that AWS uses for daemon task definitions (instead of the regular `task-definition/` form).

Non-daemon tasks are unchanged — they continue to emit `task_definition_arn` with the `task-definition/` ARN form.

Concretely:
- `comp/core/tagger/tags/tags.go`: add `DaemonTaskDefinitionARN = "daemon_task_definition_arn"`.
- `comp/core/tagger/collectors/workloadmeta_extract.go`: conditionally emit the daemon key when the task is daemon-scheduled.
- `comp/core/workloadmeta/collectors/util/ecs_util.go`: `BuildTaskDefinitionARN` now takes an `isDaemon` flag and produces the `daemon-task-definition/` ARN for daemon tasks; the daemon-name parse already drives this.

### Motivation

The daemon task definition entity (`aws:ecs:daemon-task-definition`) in the ECS Explorer keys on `daemon_task_definition_arn` with a `daemon-task-definition/` ARN. Previously the agent emitted `task_definition_arn` with a `task-definition/` ARN for all tasks, so the Explorer could not resolve the bidirectional relationship for daemon-scheduled tasks. This change aligns the agent's tagging with the entity's keys and ARN form.

### Describe how you validated your changes

- Unit tests updated/added:
  - `comp/core/workloadmeta/collectors/util/ecs_util_test.go`: `TestBuildTaskDefinitionARN` (daemon + non-daemon), `TestParseV4TaskDaemonGroup` / `TestParseV4TaskServiceGroup` assert the correct ARN form.
  - `comp/core/tagger/collectors/workloadmeta_test.go`: the daemon task case asserts `daemon_task_definition_arn`.
- Built a dev image from this branch and deployed it to a live ECS Managed Instances daemon (`af-south-1`). Confirmed via `agent tagger-list` that the daemon task emits `daemon_task_definition_arn:...:daemon-task-definition/...` while the co-located non-daemon service task still emits `task_definition_arn:...:task-definition/...`.

### Additional Notes

The `daemon_task_definition_arn` tag is only emitted when `task.DaemonName` is populated, which on ECS Managed Instances comes from the v4 `/tasks` endpoint's `Group` field (`daemon:` prefix). Verified that endpoint returns the expected `Group` value in the target environment.

It's worth noting that this change on the agent only impacts anyone deploying the agent as a daemon on ECS managed instances. This tag change can cause monitors to fire upon agent upgrade, but an internal investigation shows that no one will be impacted in terms of alerting.
