### PR TITLE
usm/windows: parse HTTP method/status in agent from raw driver fragments [experiment]

### DIFF
--- a/pkg/config/setup/system_probe_usm.go
+++ b/pkg/config/setup/system_probe_usm.go
@@ -63,6 +63,11 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("service_monitoring_config.http_max_request_fragment", 512)
 	cfg.BindEnvAndSetDefault("network_config.http_max_request_fragment", 512)
 
+	// Windows-only: size of the raw HTTP response fragment shipped from the driver for
+	// agent-side status parsing, and the toggle that moves HTTP field parsing into the agent.
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http.max_response_fragment", 256) // capped at the NPM driver hard limit (512)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http.parse_in_agent", false)
+
 	cfg.BindEnvAndSetDefault("service_monitoring_config.http.map_cleaner_interval_seconds", 300)
 	// Deprecated flat keys for backward compatibility
 	cfg.BindEnvAndSetDefault("service_monitoring_config.http_map_cleaner_interval_in_s", 300)

--- a/pkg/network/config/usm_config.go
+++ b/pkg/network/config/usm_config.go
@@ -105,6 +105,15 @@ type USMConfig struct {
 	// HTTPMaxRequestFragment is the size of the HTTP path buffer to be retrieved (Windows only)
 	HTTPMaxRequestFragment int64
 
+	// HTTPMaxResponseFragment is the size of the raw HTTP response buffer shipped from the driver
+	// for agent-side status parsing (Windows only)
+	HTTPMaxResponseFragment int64
+
+	// HTTPParseInAgent toggles where HTTP fields are parsed (Windows only):
+	// false = the ddnpm driver extracts method/status (legacy), true = the driver ships raw
+	// request/response fragments and the agent parses them.
+	HTTPParseInAgent bool
+
 	// ========================================
 	// HTTP2 Protocol Configuration
 	// ========================================
@@ -214,6 +223,8 @@ func NewUSMConfig(cfg model.Config) *USMConfig {
 		MaxTrackedHTTPConnections: cfg.GetInt64(sysconfig.FullKeyPath(smNS, "http", "max_tracked_connections")),
 		HTTPNotificationThreshold: cfg.GetInt64(sysconfig.FullKeyPath(smNS, "http", "notification_threshold")),
 		HTTPMaxRequestFragment:    cfg.GetInt64(sysconfig.FullKeyPath(smNS, "http", "max_request_fragment")),
+		HTTPMaxResponseFragment:   cfg.GetInt64(sysconfig.FullKeyPath(smNS, "http", "max_response_fragment")),
+		HTTPParseInAgent:          cfg.GetBool(sysconfig.FullKeyPath(smNS, "http", "parse_in_agent")),
 
 		// HTTP2 Protocol Configuration
 		EnableHTTP2Monitoring:               cfg.GetBool(sysconfig.FullKeyPath(smNS, "http2", "enabled")),

--- a/pkg/network/driver/ddnpmapi.h
+++ b/pkg/network/driver/ddnpmapi.h
@@ -16,7 +16,8 @@ typedef __int64 LONG64;
 typedef unsigned char       uint8_t;
 
 // define a version signature so that the driver won't load out of date structures, etc.
-#define DD_NPMDRIVER_VERSION       0x18
+// 0x19: HTTP transaction carries a raw response fragment + parseInAgent toggle (agent-side parsing experiment)
+#define DD_NPMDRIVER_VERSION       0x19
 #define DD_NPMDRIVER_SIGNATURE     ((uint64_t)0xDDFD << 32 | DD_NPMDRIVER_VERSION)
 
 // for more information on defining control codes, see
@@ -420,12 +421,15 @@ typedef struct _HttpTransactionType {
     uint64_t         requestStarted;      // in ns
     uint64_t         responseLastSeen;    // in ns
     CONN_TUPLE_TYPE  tup;
-    HTTP_METHOD_TYPE requestMethod;
-    uint16_t         responseStatusCode;
+    HTTP_METHOD_TYPE requestMethod;       // only populated when parseInAgent == 0 (driver parses)
+    uint16_t         responseStatusCode;  // only populated when parseInAgent == 0 (driver parses)
     uint16_t         maxRequestFragment;
     uint16_t         szRequestFragment;
+    uint16_t         maxResponseFragment;     // capacity of the trailing response fragment buffer
+    uint16_t         szResponseFragment;      // bytes actually captured into the response fragment
     uint8_t          pad[6];                  // make struct 64 bit byte aligned
-    unsigned char* requestFragment;
+    unsigned char* requestFragment;       // trailing buffer: [requestFragment][responseFragment]
+    unsigned char* responseFragment;
 
 } HTTP_TRANSACTION_TYPE, * PHTTP_TRANSACTION_TYPE;
 
@@ -435,6 +439,8 @@ typedef struct _HttpConfigurationSettings {
     uint64_t    notificationThreshold; // when to signal to retrieve transactions
     uint16_t    maxRequestFragment;     // max length of request fragment
     uint16_t    enableAutoETWExclusion; // turns on automatic ETW exclusion if enabled.
+    uint16_t    maxResponseFragment;    // max length of response fragment captured for agent-side parsing
+    uint16_t    parseInAgent;           // 0 = driver extracts method/status (legacy), 1 = ship raw fragments only
 } HTTP_CONFIGURATION_SETTINGS;
 
 typedef struct _ClassificationConfigurationSettings {

--- a/pkg/network/driver/types_windows.go
+++ b/pkg/network/driver/types_windows.go
@@ -3,7 +3,7 @@
 
 package driver
 
-const Signature = 0xddfd00000018
+const Signature = 0xddfd00000019
 
 const (
 	GetStatsIOCTL             = 0x122004
@@ -184,21 +184,25 @@ const (
 )
 
 type HttpTransactionType struct {
-	RequestStarted     uint64
-	ResponseLastSeen   uint64
-	Tup                ConnTupleType
-	RequestMethod      uint32
-	ResponseStatusCode uint16
-	MaxRequestFragment uint16
-	SzRequestFragment  uint16
-	Pad                [6]uint8
-	RequestFragment    *uint8
+	RequestStarted      uint64
+	ResponseLastSeen    uint64
+	Tup                 ConnTupleType
+	RequestMethod       uint32
+	ResponseStatusCode  uint16
+	MaxRequestFragment  uint16
+	SzRequestFragment   uint16
+	MaxResponseFragment uint16
+	SzResponseFragment  uint16
+	Pad                 [6]uint8
+	Pad_cgo_0           [16]byte
 }
 type HttpConfigurationSettings struct {
 	MaxTransactions        uint64
 	NotificationThreshold  uint64
 	MaxRequestFragment     uint16
 	EnableAutoETWExclusion uint16
+	MaxResponseFragment    uint16
+	ParseInAgent           uint16
 }
 type ConnTupleType struct {
 	LocalAddr  [16]byte
@@ -219,8 +223,8 @@ const (
 	TcpStatusEstablished = 0x2
 )
 const (
-	HttpTransactionTypeSize        = 0x50
-	HttpSettingsTypeSize           = 0x14
+	HttpTransactionTypeSize        = 0x5c
+	HttpSettingsTypeSize           = 0x18
 	ClassificationSettingsTypeSize = 0x8
 )
 

--- a/pkg/network/protocols/http/driver_interface.go
+++ b/pkg/network/protocols/http/driver_interface.go
@@ -30,8 +30,13 @@ import (
 
 //nolint:revive // TODO(WKIT) Fix revive linter
 type WinHttpTransaction struct {
-	Txn             driver.HttpTransactionType
-	RequestFragment []byte
+	Txn              driver.HttpTransactionType
+	RequestFragment  []byte
+	ResponseFragment []byte
+	// ParseInAgent records which mode produced this transaction: when true the driver shipped
+	// raw fragments and Method()/StatusCode() parse them; when false the driver-populated fields
+	// (Txn.RequestMethod / Txn.ResponseStatusCode) are trusted.
+	ParseInAgent bool
 
 	// ... plus some extra that's only valid when it's an ETW transactoin
 	AppPool string
@@ -66,22 +71,43 @@ type HttpDriverInterface struct {
 	maxTransactions       uint64
 	notificationThreshold uint64
 	maxRequestFragment    uint64
+	maxResponseFragment   uint64
+	parseInAgent          bool
 }
+
+// driverMaxFragmentLimit mirrors MAX_INSPECTION_BUFFER_LENGTH in the ddnpm driver. The driver
+// caps each fragment at this size, so the agent must size its read buffer with the same cap to
+// keep the flush layout consistent.
+const driverMaxFragmentLimit = 512
 
 //nolint:revive // TODO(WKIT) Fix revive linter
 func NewDriverInterface(c *config.Config, dh driver.Handle) (*HttpDriverInterface, error) {
 	maxRequestFragment := uint64(c.HTTPMaxRequestFragment)
+	maxResponseFragment := uint64(c.HTTPMaxResponseFragment)
 	if c.DiscoveryServiceMapEnabled {
 		// Discovery mode drops path from the aggregation key, so we only
 		// need enough bytes for the driver to identify the request as HTTP.
 		// 16 bytes covers the method + minimal path (e.g., "GET / HTTP/1.1").
 		maxRequestFragment = 16
+		// Discovery mode does not use the response status code either, so keep the
+		// response fragment minimal.
+		maxResponseFragment = 16
+	}
+	// Defensive clamp to the driver's hard limit so the agent's read buffer stride matches the
+	// driver's per-entry copy size (the driver caps fragments at driverMaxFragmentLimit).
+	if maxRequestFragment > driverMaxFragmentLimit {
+		maxRequestFragment = driverMaxFragmentLimit
+	}
+	if maxResponseFragment > driverMaxFragmentLimit {
+		maxResponseFragment = driverMaxFragmentLimit
 	}
 
 	d := &HttpDriverInterface{
 		maxTransactions:       uint64(c.MaxTrackedHTTPConnections),
 		notificationThreshold: uint64(c.HTTPNotificationThreshold),
 		maxRequestFragment:    maxRequestFragment,
+		maxResponseFragment:   maxResponseFragment,
+		parseInAgent:          c.HTTPParseInAgent,
 	}
 	err := d.setupHTTPHandle(dh)
 	if err != nil {
@@ -101,6 +127,8 @@ func (di *HttpDriverInterface) setupHTTPHandle(dh driver.Handle) error {
 		NotificationThreshold:  di.notificationThreshold,
 		MaxRequestFragment:     uint16(di.maxRequestFragment),
 		EnableAutoETWExclusion: uint16(1),
+		MaxResponseFragment:    uint16(di.maxResponseFragment),
+		ParseInAgent:           boolToUint16(di.parseInAgent),
 	}
 
 	_, err := dh.SynchronousDeviceIoControl(
@@ -165,8 +193,15 @@ func (di *HttpDriverInterface) StartReadingBuffers() {
 }
 
 // func (di *httpDriverInterface) flushPendingTransactions() ([]driver.HttpTransactionType, error) {
+func boolToUint16(b bool) uint16 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 func (di *HttpDriverInterface) readPendingTransactions() ([]WinHttpTransaction, error) {
-	buf := make([]byte, (driver.HttpTransactionTypeSize+di.maxRequestFragment)*di.maxTransactions)
+	buf := make([]byte, (driver.HttpTransactionTypeSize+di.maxRequestFragment+di.maxResponseFragment)*di.maxTransactions)
 
 	bytesRead, err := di.driverHTTPHandle.SynchronousDeviceIoControl(
 		driver.FlushPendingHttpTxnsIOCTL,
@@ -185,10 +220,17 @@ func (di *HttpDriverInterface) readPendingTransactions() ([]WinHttpTransaction, 
 	for i := uint32(0); i < bytesRead; {
 		var tx WinHttpTransaction
 		tx.Txn = *(*driver.HttpTransactionType)(unsafe.Pointer(&buf[i]))
-		tx.RequestFragment = make([]byte, tx.Txn.MaxRequestFragment)
+		tx.ParseInAgent = di.parseInAgent
 		i += driver.HttpTransactionTypeSize
+		// The driver lays the trailing buffers out contiguously: [requestFragment][responseFragment].
+		// Stride by the per-transaction sizes the driver reported, not the agent's config, so we
+		// stay aligned even if the driver capped a fragment size.
+		tx.RequestFragment = make([]byte, tx.Txn.MaxRequestFragment)
 		copy(tx.RequestFragment, buf[i:i+uint32(tx.Txn.MaxRequestFragment)])
 		i += uint32(tx.Txn.MaxRequestFragment)
+		tx.ResponseFragment = make([]byte, tx.Txn.MaxResponseFragment)
+		copy(tx.ResponseFragment, buf[i:i+uint32(tx.Txn.MaxResponseFragment)])
+		i += uint32(tx.Txn.MaxResponseFragment)
 		transactionBatch = append(transactionBatch, tx)
 	}
 

--- a/pkg/network/protocols/http/model_windows.go
+++ b/pkg/network/protocols/http/model_windows.go
@@ -85,13 +85,62 @@ func (tx *WinHttpTransaction) ConnTuple() types.ConnectionKey {
 	}
 }
 
+// parseMethodFromFragment extracts the HTTP method from the start of a raw request fragment.
+// It mirrors the driver's HttpParseData prefix matching so agent-parse mode produces the same
+// result the driver would have. Returns MethodUnknown if no known method prefix is present.
+func parseMethodFromFragment(b []byte) Method {
+	switch {
+	case len(b) >= 4 && b[0] == 'P' && b[1] == 'O' && b[2] == 'S' && b[3] == 'T':
+		return MethodPost
+	case len(b) >= 3 && b[0] == 'P' && b[1] == 'U' && b[2] == 'T':
+		return MethodPut
+	case len(b) >= 5 && b[0] == 'P' && b[1] == 'A' && b[2] == 'T' && b[3] == 'C' && b[4] == 'H':
+		return MethodPatch
+	case len(b) >= 3 && b[0] == 'G' && b[1] == 'E' && b[2] == 'T':
+		return MethodGet
+	case len(b) >= 4 && b[0] == 'H' && b[1] == 'E' && b[2] == 'A' && b[3] == 'D':
+		return MethodHead
+	case len(b) >= 7 && b[0] == 'O' && b[1] == 'P' && b[2] == 'T' && b[3] == 'I' && b[4] == 'O' && b[5] == 'N' && b[6] == 'S':
+		return MethodOptions
+	case len(b) >= 6 && b[0] == 'D' && b[1] == 'E' && b[2] == 'L' && b[3] == 'E' && b[4] == 'T' && b[5] == 'E':
+		return MethodDelete
+	default:
+		return MethodUnknown
+	}
+}
+
+// parseStatusFromFragment extracts the status code from the start of a raw response fragment.
+// It mirrors the driver's GetHttpStatusCode: the second whitespace-delimited token of
+// "HTTP-Version SP Status-Code SP Reason-Phrase". Returns 0 for anything outside [100,600).
+func parseStatusFromFragment(b []byte) uint16 {
+	var code uint16
+	spaces := 0
+	for i := 0; i < len(b) && spaces < 2; i++ {
+		if b[i] == ' ' {
+			spaces++
+		} else if spaces == 1 {
+			code = code*10 + uint16(b[i]-'0')
+		}
+	}
+	if code < 100 || code >= 600 {
+		return 0
+	}
+	return code
+}
+
 //nolint:revive // TODO(WKIT) Fix revive linter
 func (tx *WinHttpTransaction) Method() Method {
+	if tx.ParseInAgent {
+		return parseMethodFromFragment(tx.RequestFragment)
+	}
 	return Method(tx.Txn.RequestMethod)
 }
 
 //nolint:revive // TODO(WKIT) Fix revive linter
 func (tx *WinHttpTransaction) StatusCode() uint16 {
+	if tx.ParseInAgent {
+		return parseStatusFromFragment(tx.ResponseFragment)
+	}
 	return tx.Txn.ResponseStatusCode
 }
 

--- a/pkg/network/protocols/http/model_windows_test.go
+++ b/pkg/network/protocols/http/model_windows_test.go
@@ -8,6 +8,10 @@
 package http
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/driver"
 )
@@ -37,4 +41,60 @@ func makeTxnFromLatency(lastSeen, started uint64) WinHttpTransaction {
 			RequestStarted:   started,
 		},
 	}
+}
+
+func TestParseMethodFromFragment(t *testing.T) {
+	cases := map[string]Method{
+		"GET / HTTP/1.1\r\n":          MethodGet,
+		"POST /api/data HTTP/1.1\r\n": MethodPost,
+		"PUT /x HTTP/1.1\r\n":         MethodPut,
+		"DELETE /x HTTP/1.1\r\n":      MethodDelete,
+		"HEAD / HTTP/1.1\r\n":         MethodHead,
+		"OPTIONS * HTTP/1.1\r\n":      MethodOptions,
+		"PATCH /x HTTP/1.1\r\n":       MethodPatch,
+		"NOTAMETHOD /x HTTP/1.1\r\n":  MethodUnknown,
+		"":                            MethodUnknown,
+	}
+	for frag, want := range cases {
+		assert.Equalf(t, want, parseMethodFromFragment([]byte(frag)), "fragment %q", frag)
+	}
+}
+
+func TestParseStatusFromFragment(t *testing.T) {
+	cases := map[string]uint16{
+		"HTTP/1.1 200 OK\r\n":                    200,
+		"HTTP/1.1 404 Not Found\r\n":             404,
+		"HTTP/1.1 500 Internal Server Error\r\n": 500,
+		"HTTP/2 301 Moved\r\n":                   301,
+		"HTTP/1.1 99 Invalid\r\n":                0,
+		"HTTP/1.1 600 Invalid\r\n":               0,
+		"HTTP/1.1 ABC\r\n":                       0,
+		"garbage":                                0,
+		"":                                       0,
+	}
+	for frag, want := range cases {
+		assert.Equalf(t, want, parseStatusFromFragment([]byte(frag)), "fragment %q", frag)
+	}
+}
+
+// TestModeSwitch verifies Method()/StatusCode() honor the ParseInAgent toggle: in agent-parse
+// mode they read the raw fragments; in legacy mode they trust the driver-populated fields.
+func TestModeSwitch(t *testing.T) {
+	agentMode := WinHttpTransaction{
+		ParseInAgent:     true,
+		RequestFragment:  []byte("POST /v1/x HTTP/1.1\r\n"),
+		ResponseFragment: []byte("HTTP/1.1 201 Created\r\n"),
+		Txn:              driver.HttpTransactionType{RequestMethod: 0, ResponseStatusCode: 0},
+	}
+	assert.Equal(t, MethodPost, agentMode.Method())
+	assert.Equal(t, uint16(201), agentMode.StatusCode())
+
+	legacyMode := WinHttpTransaction{
+		ParseInAgent:     false,
+		RequestFragment:  []byte("POST /v1/x HTTP/1.1\r\n"),
+		ResponseFragment: []byte("HTTP/1.1 201 Created\r\n"),
+		Txn:              driver.HttpTransactionType{RequestMethod: uint32(MethodGet), ResponseStatusCode: 200},
+	}
+	assert.Equal(t, MethodGet, legacyMode.Method())
+	assert.Equal(t, uint16(200), legacyMode.StatusCode())
 }


### PR DESCRIPTION
Experiment (do not merge). Moves Windows USM HTTP field parsing out of the ddnpm driver into the agent.

The driver keeps its cheap HTTP classification/filter but, behind a runtime `service_monitoring_config.http.parse_in_agent` toggle, stops extracting method/status and instead ships raw request + response fragments (256B each). The agent parses method/status/path. ABI bumped 0x18->0x19. Paired with windows-drivers branch of the same name.

Purpose: measure the perf impact (transport volume) of agent-side parsing via the Windows load-test compare harness. Draft to trigger CI.