### PR TITLE
[AGENTCFG-839] Fix flaky TestConfigRefresh suites: retry initial config check

### DIFF
--- a/test/new-e2e/tests/agent-configuration/configrefresh_nix_test.go
+++ b/test/new-e2e/tests/agent-configuration/configrefresh_nix_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
@@ -85,7 +84,7 @@ func (v *configRefreshLinuxSuite) TestConfigRefresh() {
 
 	// check that the agents are using the first key
 	// initially they all resolve it using the secret resolver
-	assertAgentsUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey1)
+	assertAgentsEventuallyUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey1)
 
 	// update api_key
 	v.T().Log("Updating the api key")
@@ -98,9 +97,7 @@ func (v *configRefreshLinuxSuite) TestConfigRefresh() {
 	require.Contains(v.T(), secretRefreshOutput, "api_key")
 
 	// and check that the agents are using the new key
-	require.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		assertAgentsUseKey(t, v.Env().RemoteHost, authtoken, apiKey2)
-	}, 2*configRefreshIntervalSec*time.Second, 1*time.Second)
+	assertAgentsEventuallyUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey2)
 }
 
 func (v *configRefreshLinuxSuite) TestConfigRefreshOverSocket() {
@@ -155,7 +152,7 @@ func (v *configRefreshLinuxSuite) TestConfigRefreshOverSocket() {
 
 	// check that the agents are using the first key
 	// initially they all resolve it using the secret resolver
-	assertAgentsUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey1)
+	assertAgentsEventuallyUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey1)
 
 	// update api_key
 	v.T().Log("Updating the api key")
@@ -168,7 +165,5 @@ func (v *configRefreshLinuxSuite) TestConfigRefreshOverSocket() {
 	require.Contains(v.T(), secretRefreshOutput, "api_key")
 
 	// and check that the agents are using the new key
-	require.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		assertAgentsUseKey(t, v.Env().RemoteHost, authtoken, apiKey2)
-	}, 2*configRefreshIntervalSec*time.Second, 1*time.Second)
+	assertAgentsEventuallyUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey2)
 }

--- a/test/new-e2e/tests/agent-configuration/configrefresh_non_core_agents_sync_common.go
+++ b/test/new-e2e/tests/agent-configuration/configrefresh_non_core_agents_sync_common.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,15 @@ var (
 	apiKey1 = strings.Repeat("1", 32)
 	apiKey2 = strings.Repeat("2", 32)
 )
+
+// assertAgentsEventuallyUseKey retries assertAgentsUseKey until every agent reports the
+// expected key, tolerating transient errors while the non-core agents finish starting up.
+func assertAgentsEventuallyUseKey(t *testing.T, host *components.RemoteHost, authtoken, key string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assertAgentsUseKey(c, host, authtoken, key)
+	}, 2*configRefreshIntervalSec*time.Second, 1*time.Second)
+}
 
 // assertAgentsUseKey checks that all agents are using the given key.
 func assertAgentsUseKey(t assert.TestingT, host *components.RemoteHost, authtoken, key string) {

--- a/test/new-e2e/tests/agent-configuration/configrefresh_win_test.go
+++ b/test/new-e2e/tests/agent-configuration/configrefresh_win_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
@@ -92,7 +91,7 @@ func (v *configRefreshWindowsSuite) TestConfigRefresh() {
 
 	// check that the agents are using the first key
 	// initially they all resolve it using the secret resolver
-	assertAgentsUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey1)
+	assertAgentsEventuallyUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey1)
 
 	// update api_key
 	v.T().Log("Updating the api key")
@@ -105,7 +104,5 @@ func (v *configRefreshWindowsSuite) TestConfigRefresh() {
 	require.Contains(v.T(), secretRefreshOutput, "api_key")
 
 	// and check that the agents are using the new key
-	require.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		assertAgentsUseKey(t, v.Env().RemoteHost, authtoken, apiKey2)
-	}, 2*configRefreshIntervalSec*time.Second, 1*time.Second)
+	assertAgentsEventuallyUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey2)
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the flaky E2E test [AGENTCFG-839](https://datadoghq.atlassian.net/browse/AGENTCFG-839) (`TestConfigRefreshLinuxSuite/TestConfigRefresh`).

The initial `assertAgentsUseKey(..., apiKey1)` check ran immediately after agent startup with **no retry**. When the non-core agents (trace/process/security) had not yet finished binding their IPC config ports, the check failed with a transient error and brought down the whole test:

```
configrefresh_non_core_agents_sync_common.go:63 / configrefresh_nix_test.go:88
Get "https://localhost:5012/config": ssh: rejected: connect failed (Connection refused)
failed to fetch config from trace-agent
```

The final `apiKey2` check already tolerated this via `require.EventuallyWithT`; the initial check did not.

### Motivation

Recurring flaky failures on `main` (CI Visibility shows multiple `connection refused` failures around June 18–19) reported via the failed-agent-test workflow.

### Describe how you validated your changes

Introduced a shared `assertAgentsEventuallyUseKey` helper wrapping `assertAgentsUseKey` in `require.EventuallyWithT`, and applied it to both the initial and final checks across the nix (`TestConfigRefresh`, `TestConfigRefreshOverSocket`) and Windows (`TestConfigRefresh`) config-refresh suites. This removes the inline retry duplication and makes the initial check tolerate transient startup errors.

### Possible Drawbacks / Trade-offs

The initial check now waits up to `2 * configRefreshIntervalSec` (20s) for the non-core agents to come up instead of failing immediately. This only affects the slow path; the common case still passes on the first tick.

[AGENTCFG-839]: https://datadoghq.atlassian.net/browse/AGENTCFG-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ