### PR TITLE
Add CNM team as co-owner of /pkg/network/ebpf/c/protocols/classification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -709,6 +709,7 @@
 /pkg/network/ebpf/c/runtime/shared-libraries*   @DataDog/universal-service-monitoring
 /pkg/network/ebpf/c/shared-libraries/           @DataDog/universal-service-monitoring
 /pkg/network/ebpf/c/protocols/          @DataDog/universal-service-monitoring
+/pkg/network/ebpf/c/protocols/classification    @DataDog/cloud-network-monitoring @DataDog/universal-service-monitoring
 /pkg/network/ebpf/c/protocols/tls       @DataDog/cloud-network-monitoring @DataDog/universal-service-monitoring
 /pkg/network/encoding/marshal/*usm*     @DataDog/universal-service-monitoring
 /pkg/network/encoding/marshal/*_windows*.go  @DataDog/windows-products


### PR DESCRIPTION
### What does this PR do?
Add CNM team as co-owner of /pkg/network/ebpf/c/protocols/classification

### Motivation
Similar to /pkg/network/ebpf/c/protocols/tls, the CNM team sometimes works on code in /pkg/network/ebpf/c/protocols/classification. 

### Describe how you validated your changes

### Additional Notes
