### PR TITLE
Make number of no aggregation workers configurable

### DIFF
--- a/comp/aggregator/demultiplexer/impl/BUILD.bazel
+++ b/comp/aggregator/demultiplexer/impl/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
     name = "impl_test",
     srcs = [
         "demultiplexer_mock_test.go",
+        "demultiplexer_options_test.go",
         "status_test.go",
     ],
     embed = [":impl"],
@@ -64,6 +65,7 @@ go_test(
     deps = [
         "//comp/aggregator/demultiplexer/def",
         "//comp/core",
+        "//comp/core/config",
         "//comp/core/hostname/hostnameimpl",
         "//comp/core/secrets/def",
         "//comp/core/secrets/mock",

--- a/comp/aggregator/demultiplexer/impl/demultiplexer.go
+++ b/comp/aggregator/demultiplexer/impl/demultiplexer.go
@@ -112,7 +112,12 @@ func newDemultiplexer(deps dependencies) (provides, error) {
 func createAgentDemultiplexerOptions(config config.Component, params Params) aggregator.AgentDemultiplexerOptions {
 	options := aggregator.DefaultAgentDemultiplexerOptions()
 	if params.useDogstatsdNoAggregationPipelineConfig {
-		options.EnableNoAggregationPipeline = config.GetBool("dogstatsd_no_aggregation_pipeline")
+		if config.GetBool("dogstatsd_no_aggregation_pipeline") {
+			options.NoAggregationPipelineWorkersCount = config.GetInt("dogstatsd_no_aggregation_pipeline_workers_count")
+			if options.NoAggregationPipelineWorkersCount <= 0 {
+				options.NoAggregationPipelineWorkersCount = 1
+			}
+		}
 	}
 
 	// Override FlushInterval only if flushInterval is set by the user

--- a/comp/aggregator/demultiplexer/impl/demultiplexer_options_test.go
+++ b/comp/aggregator/demultiplexer/impl/demultiplexer_options_test.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package demultiplexerimpl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	configmock "github.com/DataDog/datadog-agent/comp/core/config"
+)
+
+func TestCreateAgentDemultiplexerOptionsNoAggWorkerCountNotReadWithoutConfigOption(t *testing.T) {
+	cfg := configmock.NewMockWithOverrides(t, map[string]interface{}{
+		"dogstatsd_no_aggregation_pipeline":               true,
+		"dogstatsd_no_aggregation_pipeline_workers_count": 4,
+	})
+
+	options := createAgentDemultiplexerOptions(cfg, NewDefaultParams())
+
+	require.Equal(t, 0, options.NoAggregationPipelineWorkersCount)
+}
+
+func TestCreateAgentDemultiplexerOptionsNoAggWorkerCountFromConfig(t *testing.T) {
+	cfg := configmock.NewMockWithOverrides(t, map[string]interface{}{
+		"dogstatsd_no_aggregation_pipeline":               true,
+		"dogstatsd_no_aggregation_pipeline_workers_count": 4,
+	})
+
+	options := createAgentDemultiplexerOptions(cfg, NewDefaultParams(WithDogstatsdNoAggregationPipelineConfig()))
+
+	require.Equal(t, 4, options.NoAggregationPipelineWorkersCount)
+}
+
+func TestCreateAgentDemultiplexerOptionsNoAggWorkerCountDefaultsToOneWhenEnabled(t *testing.T) {
+	cfg := configmock.NewMockWithOverrides(t, map[string]interface{}{
+		"dogstatsd_no_aggregation_pipeline": true,
+	})
+
+	options := createAgentDemultiplexerOptions(cfg, NewDefaultParams(WithDogstatsdNoAggregationPipelineConfig()))
+
+	require.Equal(t, 1, options.NoAggregationPipelineWorkersCount)
+}
+
+func TestCreateAgentDemultiplexerOptionsNoAggWorkerCountDisabled(t *testing.T) {
+	cfg := configmock.NewMockWithOverrides(t, map[string]interface{}{
+		"dogstatsd_no_aggregation_pipeline":               false,
+		"dogstatsd_no_aggregation_pipeline_workers_count": 4,
+	})
+
+	options := createAgentDemultiplexerOptions(cfg, NewDefaultParams(WithDogstatsdNoAggregationPipelineConfig()))
+
+	require.Equal(t, 0, options.NoAggregationPipelineWorkersCount)
+}
+
+func TestCreateAgentDemultiplexerOptionsNoAggWorkerCountFallsBackToOne(t *testing.T) {
+	for _, configured := range []int{0, -2} {
+		t.Run(fmt.Sprintf("configured_%d", configured), func(t *testing.T) {
+			cfg := configmock.NewMockWithOverrides(t, map[string]interface{}{
+				"dogstatsd_no_aggregation_pipeline":               true,
+				"dogstatsd_no_aggregation_pipeline_workers_count": configured,
+			})
+
+			options := createAgentDemultiplexerOptions(cfg, NewDefaultParams(WithDogstatsdNoAggregationPipelineConfig()))
+
+			require.Equal(t, 1, options.NoAggregationPipelineWorkersCount)
+		})
+	}
+}

--- a/comp/aggregator/demultiplexer/impl/test_agent_demultiplexer.go
+++ b/comp/aggregator/demultiplexer/impl/test_agent_demultiplexer.go
@@ -182,7 +182,7 @@ func initTestAgentDemultiplexerWithFlushInterval(log log.Component, hostname hos
 	opts := aggregator.DefaultAgentDemultiplexerOptions()
 	opts.FlushInterval = flushInterval
 	opts.DontStartForwarders = true
-	opts.EnableNoAggregationPipeline = true
+	opts.NoAggregationPipelineWorkersCount = 1
 
 	sharedForwarder := defaultforwardernoop.NewComponent()
 	filterList := filterlist.NewNoopFilterList()

--- a/comp/dogstatsd/server/impl/batch.go
+++ b/comp/dogstatsd/server/impl/batch.go
@@ -40,8 +40,9 @@ type batcher struct {
 	samplesCount []int
 
 	// MetricSampleBatch used for metrics with timestamp
-	// no multi-pipelines use for metrics with timestamp since we don't process them and we directly
-	// send them to the serializer
+	// metrics with timestamp are not context-sharded since we don't aggregate them.
+	// When the no-aggregation pipeline is enabled, these batches are sent to a shared
+	// queue consumed by the no-aggregation workers.
 	samplesWithTs metrics.MetricSampleBatch
 	// offset while writing into the sample with timestampe slice (i.e. count of samples
 	// with timestamp currently stored)
@@ -138,7 +139,7 @@ func newBatcher(demux aggregator.DemultiplexerWithAggregator, tlmChannel telemet
 		pipelineCount:  pipelineCount,
 		shardGenerator: newShardGenerator(),
 
-		noAggPipelineEnabled: demux.Options().EnableNoAggregationPipeline,
+		noAggPipelineEnabled: demux.Options().NoAggregationPipelineWorkersCount > 0,
 		tlmChannel:           tlmChannel,
 	}
 }

--- a/docs/public/architecture/dogstatsd/internals.md
+++ b/docs/public/architecture/dogstatsd/internals.md
@@ -105,3 +105,5 @@ The NoAggregationStreamWorker runs an infinite loop in a goroutine. It receives 
 It runs only when `dogstatsd_no_aggregation_pipeline` is set to `true`.
 
 The payload being sent to the intake (through the normal `Serializer`/`Forwarder` pieces) contains, at maximum, `dogstatsd_no_aggregation_pipeline_batch_size` metrics. This value defaults to `2048`.
+
+By default, DogStatsD runs one no-aggregation pipeline worker. Set `dogstatsd_no_aggregation_pipeline_workers_count` to a value greater than `1` to let multiple independent workers pull batches from the shared no-aggregation queue.

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -85,7 +85,7 @@ type AgentDemultiplexer struct {
 type AgentDemultiplexerOptions struct {
 	FlushInterval time.Duration
 
-	EnableNoAggregationPipeline bool
+	NoAggregationPipelineWorkersCount int
 
 	DontStartForwarders bool // unit tests don't need the forwarders to be instanciated
 
@@ -98,7 +98,7 @@ func DefaultAgentDemultiplexerOptions() AgentDemultiplexerOptions {
 	return AgentDemultiplexerOptions{
 		FlushInterval: DefaultFlushInterval,
 		// the different agents/binaries enable it on a per-need basis
-		EnableNoAggregationPipeline: false,
+		NoAggregationPipelineWorkersCount: 0,
 	}
 }
 
@@ -112,9 +112,10 @@ type statsd struct {
 	// shared metric sample pool between the dogstatsd server & the time sampler
 	metricSamplePool *metrics.MetricSamplePool
 
-	// the noAggregationStreamWorker is the one dealing with metrics that don't need to
-	// be aggregated/sampled.
-	noAggStreamWorker *noAggregationStreamWorker
+	// noAggStreamWorkers deal with metrics that don't need to be aggregated/sampled.
+	// They all pull from a shared noAggSamplesChan.
+	noAggStreamWorkers []*noAggregationStreamWorker
+	noAggSamplesChan   chan metrics.MetricSampleBatch
 }
 
 type forwarders struct {
@@ -124,7 +125,7 @@ type forwarders struct {
 type dataOutputs struct {
 	forwarders       forwarders
 	sharedSerializer serializer.MetricSerializer
-	noAggSerializer  serializer.MetricSerializer
+	noAggSerializers []serializer.MetricSerializer
 }
 
 // InitAndStartAgentDemultiplexer creates a new Demultiplexer and runs what's necessary
@@ -196,17 +197,24 @@ func initAgentDemultiplexer(log log.Component,
 			filterList.GetHistoFilterList(), filterList.GetTagFilterList())
 	}
 
-	var noAggWorker *noAggregationStreamWorker
-	var noAggSerializer serializer.MetricSerializer
-	if options.EnableNoAggregationPipeline {
-		noAggSerializer = serializer.NewSerializer(sharedForwarder, orchestratorForwarder, compressor, pkgconfigsetup.Datadog(), log, hostname)
-		noAggWorker = newNoAggregationStreamWorker(
-			pkgconfigsetup.Datadog().GetInt("dogstatsd_no_aggregation_pipeline_batch_size"),
-			metricSamplePool,
-			noAggSerializer,
-			agg.flushAndSerializeInParallel,
-			tagger,
-		)
+	var noAggWorkers []*noAggregationStreamWorker
+	var noAggSerializers []serializer.MetricSerializer
+	var noAggSamplesChan chan metrics.MetricSampleBatch
+	if workersCount := options.NoAggregationPipelineWorkersCount; workersCount > 0 {
+		noAggWorkers = make([]*noAggregationStreamWorker, workersCount)
+		noAggSerializers = make([]serializer.MetricSerializer, workersCount)
+		noAggSamplesChan = make(chan metrics.MetricSampleBatch, pkgconfigsetup.Datadog().GetInt("dogstatsd_queue_size"))
+		for i := 0; i < workersCount; i++ {
+			noAggSerializers[i] = serializer.NewSerializer(sharedForwarder, orchestratorForwarder, compressor, pkgconfigsetup.Datadog(), log, hostname)
+			noAggWorkers[i] = newNoAggregationStreamWorker(
+				pkgconfigsetup.Datadog().GetInt("dogstatsd_no_aggregation_pipeline_batch_size"),
+				metricSamplePool,
+				noAggSamplesChan,
+				noAggSerializers[i],
+				agg.flushAndSerializeInParallel,
+				tagger,
+			)
+		}
 	}
 
 	// --
@@ -224,7 +232,7 @@ func initAgentDemultiplexer(log log.Component,
 			forwarders: forwarders{},
 
 			sharedSerializer: sharedSerializer,
-			noAggSerializer:  noAggSerializer,
+			noAggSerializers: noAggSerializers,
 		},
 
 		hostTagProvider: hosttags.NewHostTagProvider(),
@@ -234,10 +242,11 @@ func initAgentDemultiplexer(log log.Component,
 
 		// statsd time samplers
 		statsd: statsd{
-			pipelinesCount:    statsdPipelinesCount,
-			workers:           statsdWorkers,
-			metricSamplePool:  metricSamplePool,
-			noAggStreamWorker: noAggWorker,
+			pipelinesCount:     statsdPipelinesCount,
+			workers:            statsdWorkers,
+			metricSamplePool:   metricSamplePool,
+			noAggStreamWorkers: noAggWorkers,
+			noAggSamplesChan:   noAggSamplesChan,
 		},
 	}
 
@@ -277,8 +286,8 @@ func (d *AgentDemultiplexer) SetObserver(obs observer.Component) {
 	for _, worker := range d.statsd.workers {
 		worker.sampler.observerHandle = metricsHandle
 	}
-	if d.statsd.noAggStreamWorker != nil {
-		d.statsd.noAggStreamWorker.observerHandle = metricsHandle
+	for _, worker := range d.statsd.noAggStreamWorkers {
+		worker.observerHandle = metricsHandle
 	}
 
 	// Go core check path (BufferedAggregator → CheckSampler)
@@ -374,8 +383,8 @@ func (d *AgentDemultiplexer) run() {
 
 	go d.aggregator.run()
 
-	if d.noAggStreamWorker != nil {
-		go d.noAggStreamWorker.run()
+	for _, w := range d.noAggStreamWorkers {
+		go w.run()
 	}
 
 	// It is important to register callbacks after the statsd workers have been started
@@ -427,8 +436,8 @@ func (d *AgentDemultiplexer) Stop() {
 	timeout := pkgconfigsetup.Datadog().GetDuration("aggregator_stop_timeout") * time.Second
 	forceFlushAll := pkgconfigsetup.Datadog().GetBool("dogstatsd_flush_incomplete_buckets")
 
-	if d.noAggStreamWorker != nil {
-		d.noAggStreamWorker.stop()
+	for _, worker := range d.noAggStreamWorkers {
+		worker.stop()
 	}
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -642,13 +651,16 @@ func (d *AgentDemultiplexer) SendSamplesWithoutAggregation(samples metrics.Metri
 	// safe-guard: if for some reasons we are receiving some metrics here despite
 	// having the no-aggregation pipeline disabled, they are redirected to the first
 	// time sampler.
-	if !d.options.EnableNoAggregationPipeline {
+	if d.options.NoAggregationPipelineWorkersCount <= 0 || d.statsd.noAggSamplesChan == nil {
 		d.AggregateSamples(TimeSamplerID(0), samples)
 		return
 	}
 
 	tlmProcessed.Add(float64(len(samples)), "", "late_metrics")
-	d.statsd.noAggStreamWorker.addSamples(samples)
+	if len(samples) == 0 {
+		return
+	}
+	d.statsd.noAggSamplesChan <- samples
 }
 
 // AggregateSamples adds a batch of MetricSample into the given DogStatsD time sampler shard.

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -100,10 +100,10 @@ func TestDemuxNoAggOptionEnabled(t *testing.T) {
 	mockSerializer := &MockSerializerIterableSerie{}
 	mockSerializer.On("AreSeriesEnabled").Return(true)
 	mockSerializer.On("AreSketchesEnabled").Return(true)
-	opts.EnableNoAggregationPipeline = true
+	opts.NoAggregationPipelineWorkersCount = 1
 	deps := createDemultiplexerAgentTestDeps(t)
 	demux := initAgentDemultiplexer(deps.Log, NewForwarderTest(deps.Log), deps.OrchestratorFwd, opts, deps.EventPlatform, deps.HaAgent, deps.Compressor, deps.Tagger, deps.FilterList, "")
-	demux.statsd.noAggStreamWorker.serializer = mockSerializer // the no agg pipeline will use our mocked serializer
+	demux.statsd.noAggStreamWorkers[0].serializer = mockSerializer // the no agg pipeline will use our mocked serializer
 
 	go demux.run()
 
@@ -139,8 +139,92 @@ func TestDemuxNoAggOptionIsDisabledByDefault(t *testing.T) {
 	)
 	demux := InitAndStartAgentDemultiplexerForTest(deps, opts, "")
 
-	require.False(t, demux.Options().EnableNoAggregationPipeline, "the no aggregation pipeline should be disabled by default")
+	require.Equal(t, 0, demux.Options().NoAggregationPipelineWorkersCount, "the no aggregation pipeline should be disabled by default")
 	demux.Stop()
+}
+
+func TestDemuxNoAggWorkersCount(t *testing.T) {
+	tests := []struct {
+		name          string
+		configured    int
+		expectedCount int
+	}{
+		{
+			name:          "configured count",
+			configured:    3,
+			expectedCount: 3,
+		},
+		{
+			name:          "zero disables no aggregation workers",
+			configured:    0,
+			expectedCount: 0,
+		},
+		{
+			name:          "negative disables no aggregation workers",
+			configured:    -2,
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := demuxTestOptions()
+			opts.NoAggregationPipelineWorkersCount = tt.configured
+			deps := createDemultiplexerAgentTestDeps(t)
+
+			demux := initAgentDemultiplexer(deps.Log, NewForwarderTest(deps.Log), deps.OrchestratorFwd, opts, deps.EventPlatform, deps.HaAgent, deps.Compressor, deps.Tagger, deps.FilterList, "")
+
+			require.Len(t, demux.statsd.noAggStreamWorkers, tt.expectedCount)
+			require.Len(t, demux.noAggSerializers, tt.expectedCount)
+			if tt.expectedCount == 0 {
+				require.Nil(t, demux.statsd.noAggSamplesChan)
+				return
+			}
+			require.NotNil(t, demux.statsd.noAggSamplesChan)
+			for _, worker := range demux.statsd.noAggStreamWorkers {
+				require.Equal(t, demux.statsd.noAggSamplesChan, worker.samplesChan)
+			}
+		})
+	}
+}
+
+func TestDemuxNoAggWorkersUseSharedQueue(t *testing.T) {
+	opts := demuxTestOptions()
+	opts.NoAggregationPipelineWorkersCount = 3
+	deps := createDemultiplexerAgentTestDeps(t)
+
+	demux := initAgentDemultiplexer(deps.Log, NewForwarderTest(deps.Log), deps.OrchestratorFwd, opts, deps.EventPlatform, deps.HaAgent, deps.Compressor, deps.Tagger, deps.FilterList, "")
+
+	for i := 0; i < 5; i++ {
+		demux.SendSamplesWithoutAggregation(metrics.MetricSampleBatch{
+			{
+				Name:      fmt.Sprintf("metric.%d", i),
+				Value:     float64(i),
+				Mtype:     metrics.GaugeType,
+				Timestamp: 1657099120.0,
+			},
+		})
+	}
+
+	require.Len(t, demux.statsd.noAggSamplesChan, 5)
+
+	for i := 0; i < 5; i++ {
+		batch := <-demux.statsd.noAggSamplesChan
+		require.Len(t, batch, 1)
+		require.Equal(t, fmt.Sprintf("metric.%d", i), batch[0].Name)
+	}
+}
+
+func TestSendSamplesWithoutAggregationDropsEmptyBatch(t *testing.T) {
+	opts := demuxTestOptions()
+	opts.NoAggregationPipelineWorkersCount = 1
+	deps := createDemultiplexerAgentTestDeps(t)
+
+	demux := initAgentDemultiplexer(deps.Log, NewForwarderTest(deps.Log), deps.OrchestratorFwd, opts, deps.EventPlatform, deps.HaAgent, deps.Compressor, deps.Tagger, deps.FilterList, "")
+
+	demux.SendSamplesWithoutAggregation(metrics.MetricSampleBatch{})
+
+	require.Len(t, demux.statsd.noAggSamplesChan, 0)
 }
 
 func TestAddAgentStartupTelemetrySendsShutdownEventOnFinalStop(t *testing.T) {

--- a/pkg/aggregator/no_aggregation_stream_worker.go
+++ b/pkg/aggregator/no_aggregation_stream_worker.go
@@ -39,7 +39,8 @@ type noAggregationStreamWorker struct {
 	flushConfig          FlushAndSerializeInParallel
 	maxMetricsPerPayload int
 
-	// pointer to the shared MetricSamplePool stored in the Demultiplexer.
+	// Shared MetricSamplePool stored in the Demultiplexer. The worker that pulls
+	// a batch from samplesChan owns it until it returns the batch to this pool.
 	metricSamplePool *metrics.MetricSamplePool
 
 	seriesSink   *metrics.IterableSeries
@@ -48,6 +49,8 @@ type noAggregationStreamWorker struct {
 	taggerBuffer *tagset.HashlessTagsAccumulator
 	metricBuffer *tagset.HashlessTagsAccumulator
 
+	// Shared no-aggregation input queue. Multiple workers receive from the same
+	// channel so available workers pull work instead of being selected by demux.
 	samplesChan chan metrics.MetricSampleBatch
 	stopChan    chan trigger
 
@@ -86,8 +89,14 @@ func init() {
 	noaggExpvars.Set("Flush", &expvarNoAggFlush)
 }
 
+// newNoAggregationStreamWorker creates one consumer of the shared no-aggregation
+// queue. Each worker has its own serializer, but all workers share samplesChan
+// and metricSamplePool so batches are assigned by channel receive and returned
+// to the common pool after processing.
+//
 //nolint:revive // TODO(AML) Fix revive linter
-func newNoAggregationStreamWorker(maxMetricsPerPayload int, _ *metrics.MetricSamplePool,
+func newNoAggregationStreamWorker(maxMetricsPerPayload int, metricSamplePool *metrics.MetricSamplePool,
+	samplesChan chan metrics.MetricSampleBatch,
 	serializer serializer.MetricSerializer, flushConfig FlushAndSerializeInParallel,
 	tagger tagger.Component,
 ) *noAggregationStreamWorker {
@@ -99,11 +108,13 @@ func newNoAggregationStreamWorker(maxMetricsPerPayload int, _ *metrics.MetricSam
 		seriesSink:   nil,
 		sketchesSink: nil,
 
+		metricSamplePool: metricSamplePool,
+
 		taggerBuffer: tagset.NewHashlessTagsAccumulator(),
 		metricBuffer: tagset.NewHashlessTagsAccumulator(),
 
 		stopChan:    make(chan trigger),
-		samplesChan: make(chan metrics.MetricSampleBatch, pkgconfigsetup.Datadog().GetInt("dogstatsd_queue_size")),
+		samplesChan: samplesChan,
 
 		hostTagProvider: hosttags.NewHostTagProvider(),
 		// warning for the unsupported metric types should appear maximum 200 times
@@ -112,14 +123,6 @@ func newNoAggregationStreamWorker(maxMetricsPerPayload int, _ *metrics.MetricSam
 
 		tagger: tagger,
 	}
-}
-
-func (w *noAggregationStreamWorker) addSamples(samples metrics.MetricSampleBatch) {
-	if len(samples) == 0 {
-		return
-	}
-	// FIXME: instrument
-	w.samplesChan <- samples
 }
 
 func (w *noAggregationStreamWorker) stop() {

--- a/pkg/aggregator/no_aggregation_stream_worker_test.go
+++ b/pkg/aggregator/no_aggregation_stream_worker_test.go
@@ -21,7 +21,7 @@ func TestNoAggStreamWorkerSeriesDisabled(t *testing.T) {
 	noAggWorkerStreamCheckFrequency = 100 * time.Millisecond
 
 	opts := demuxTestOptions()
-	opts.EnableNoAggregationPipeline = true
+	opts.NoAggregationPipelineWorkersCount = 1
 
 	mockSerializer := &MockSerializerIterableSerie{}
 	mockSerializer.On("AreSeriesEnabled").Return(false)
@@ -29,7 +29,7 @@ func TestNoAggStreamWorkerSeriesDisabled(t *testing.T) {
 
 	deps := createDemultiplexerAgentTestDeps(t)
 	demux := initAgentDemultiplexer(deps.Log, NewForwarderTest(deps.Log), deps.OrchestratorFwd, opts, deps.EventPlatform, deps.HaAgent, deps.Compressor, deps.Tagger, deps.FilterList, "")
-	demux.statsd.noAggStreamWorker.serializer = mockSerializer
+	demux.statsd.noAggStreamWorkers[0].serializer = mockSerializer
 
 	go demux.run()
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2656,6 +2656,12 @@ api_key:
 #
 # dogstatsd_no_aggregation_pipeline_batch_size: 2048
 
+## @param dogstatsd_no_aggregation_pipeline_workers_count - integer - optional - default: 1
+## @env DD_DOGSTATSD_NO_AGGREGATION_PIPELINE_WORKERS_COUNT - integer - optional - default: 1
+## How many workers are used by the no-aggregation pipeline.
+#
+# dogstatsd_no_aggregation_pipeline_workers_count: 1
+
 ## @param statsd_forward_host - string - optional - default: ""
 ## @env DD_STATSD_FORWARD_HOST - string - optional - default: ""
 ## Forward every packet received by the DogStatsD server to another statsd server.

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -2508,6 +2508,16 @@ properties:
     - template_section:Dogstatsd
     comment: How many metrics maximum in payloads sent by the no-aggregation pipeline
       to the intake.
+  dogstatsd_no_aggregation_pipeline_workers_count:
+    node_type: setting
+    type: integer
+    default: 1
+    visibility: public
+    description: How many workers are used by the no-aggregation pipeline.
+    tags:
+    - template_section:Dogstatsd
+    comment: How many workers are used by the no-aggregation pipeline. Default of
+      1 applies when the pipeline is enabled via dogstatsd_no_aggregation_pipeline.
   statsd_forward_host:
     node_type: setting
     type: string

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1696,6 +1696,8 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("dogstatsd_no_aggregation_pipeline", true)
 	// How many metrics maximum in payloads sent by the no-aggregation pipeline to the intake.
 	config.BindEnvAndSetDefault("dogstatsd_no_aggregation_pipeline_batch_size", 2048)
+	// How many workers are used by the no-aggregation pipeline.
+	config.BindEnvAndSetDefault("dogstatsd_no_aggregation_pipeline_workers_count", 1)
 	// Force the amount of dogstatsd workers (mainly used for benchmarks or some very specific use-case)
 	config.BindEnvAndSetDefault("dogstatsd_workers_count", 0)
 	config.BindEnvAndSetDefault("dogstatsd_experimental_http.enabled", false)

--- a/pkg/metrics/metric_sample_pool.go
+++ b/pkg/metrics/metric_sample_pool.go
@@ -28,7 +28,8 @@ type MetricSampleBatch []MetricSample
 
 // MetricSamplePool is a pool of metrics sample
 type MetricSamplePool struct {
-	pool *sync.Pool
+	pool      *sync.Pool
+	batchSize int
 	// telemetry
 	tlmEnabled bool
 }
@@ -41,6 +42,7 @@ func NewMetricSamplePool(batchSize int, isTelemetryEnabled bool) *MetricSamplePo
 				return make(MetricSampleBatch, batchSize)
 			},
 		},
+		batchSize: batchSize,
 		// telemetry
 		tlmEnabled: isTelemetryEnabled,
 	}
@@ -58,9 +60,14 @@ func (m *MetricSamplePool) GetBatch() MetricSampleBatch {
 	return m.pool.Get().(MetricSampleBatch)
 }
 
-// PutBatch puts a batch back into the pool
+// PutBatch puts a batch back into the pool.
+// Batches not originating from the pool (wrong capacity) are silently dropped
+// to prevent poisoning GetBatch callers with undersized slices.
 func (m *MetricSamplePool) PutBatch(batch MetricSampleBatch) {
 	if m == nil {
+		return
+	}
+	if cap(batch) != m.batchSize {
 		return
 	}
 	if m.tlmEnabled {

--- a/releasenotes/notes/configure-noagg-pipeline-workers-46ec99aa8f4dd999.yaml
+++ b/releasenotes/notes/configure-noagg-pipeline-workers-46ec99aa8f4dd999.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add a new ``dogstatsd_no_aggregation_pipeline_workers_count`` configuration option
+    to control the number of parallel workers processing messages in the no-aggregation
+    pipeline. Defaults to ``1`` to preserve existing behavior.


### PR DESCRIPTION
### What does this PR do?

Allow to set the number of parallel workers to process messages in the no aggregation pipeline.

### Motivation

We want to allow users to tune the number of workers processing data in the no aggregation pipeline in case their specific workload uses it extensively. We add a new configuration option which allows to set this number explicitly, with the default of 1 to keep the old behavior.

### Describe how you validated your changes

Added new unit tests.

### Additional Notes
