### PR TITLE
refactor(comp/process): rename impl constructors to NewComponent

### DIFF
--- a/comp/process/connectionscheck/fx/fx.go
+++ b/comp/process/connectionscheck/fx/fx.go
@@ -14,6 +14,6 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(connectionscheckimpl.NewCheck),
+		fxutil.ProvideComponentConstructor(connectionscheckimpl.NewComponent),
 	)
 }

--- a/comp/process/connectionscheck/impl/check.go
+++ b/comp/process/connectionscheck/impl/check.go
@@ -43,8 +43,8 @@ type Provides struct {
 	Component connectionscheck.Component
 }
 
-// NewCheck creates a new connectionscheck component.
-func NewCheck(deps dependencies) Provides {
+// NewComponent creates a new connectionscheck component.
+func NewComponent(deps dependencies) Provides {
 	c := &check{
 		connectionsCheck: checks.NewConnectionsCheck(deps.Config, deps.Sysconfig, deps.Sysconfig.SysProbeObject(), deps.WMeta, deps.NpCollector, deps.Tagger),
 	}

--- a/comp/process/connectionscheck/impl/check_darwin_test.go
+++ b/comp/process/connectionscheck/impl/check_darwin_test.go
@@ -36,7 +36,7 @@ func TestConnectionsCheckDisabledOnDarwin(t *testing.T) {
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 		npcollectormock.MockModule(),
 		fx.Provide(func(t testing.TB) tagger.Component { return taggerfxmock.SetupFakeTagger(t) }),
-		fxutil.ProvideComponentConstructor(NewCheck),
+		fxutil.ProvideComponentConstructor(NewComponent),
 	))
 
 	assert.False(t, c.Object().IsEnabled())

--- a/comp/process/connectionscheck/impl/check_test.go
+++ b/comp/process/connectionscheck/impl/check_test.go
@@ -84,7 +84,7 @@ func TestConnectionsCheckIsEnabled(t *testing.T) {
 				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 				npcollectormock.MockModule(),
 				fx.Provide(func(t testing.TB) tagger.Component { return taggerfxmock.SetupFakeTagger(t) }),
-				fxutil.ProvideComponentConstructor(NewCheck),
+				fxutil.ProvideComponentConstructor(NewComponent),
 			))
 
 			flavor.SetFlavor(tc.flavor)

--- a/comp/process/containercheck/fx/fx.go
+++ b/comp/process/containercheck/fx/fx.go
@@ -14,6 +14,6 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(containercheckimpl.NewCheck),
+		fxutil.ProvideComponentConstructor(containercheckimpl.NewComponent),
 	)
 }

--- a/comp/process/containercheck/impl/check.go
+++ b/comp/process/containercheck/impl/check.go
@@ -40,8 +40,8 @@ type Provides struct {
 	Component containercheck.Component
 }
 
-// NewCheck creates a new containercheck component.
-func NewCheck(deps dependencies) Provides {
+// NewComponent creates a new containercheck component.
+func NewComponent(deps dependencies) Provides {
 	c := &check{
 		containerCheck: checks.NewContainerCheck(deps.Config, deps.Sysconfig, deps.WMmeta, deps.Statsd),
 	}

--- a/comp/process/containercheck/impl/check_test.go
+++ b/comp/process/containercheck/impl/check_test.go
@@ -162,7 +162,7 @@ func TestContainerCheckIsEnabled(t *testing.T) {
 				fx.Provide(func() statsd.ClientInterface {
 					return &statsd.NoOpClient{}
 				}),
-				fxutil.ProvideComponentConstructor(NewCheck),
+				fxutil.ProvideComponentConstructor(NewComponent),
 			))
 
 			assert.Equal(t, tc.enabled, c.Object().IsEnabled())

--- a/comp/process/processcheck/fx/fx.go
+++ b/comp/process/processcheck/fx/fx.go
@@ -14,6 +14,6 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(processcheckimpl.NewCheck),
+		fxutil.ProvideComponentConstructor(processcheckimpl.NewComponent),
 	)
 }

--- a/comp/process/processcheck/impl/check.go
+++ b/comp/process/processcheck/impl/check.go
@@ -46,8 +46,8 @@ type Provides struct {
 	Component processcheck.Component
 }
 
-// NewCheck creates a new processcheck component.
-func NewCheck(deps dependencies) Provides {
+// NewComponent creates a new processcheck component.
+func NewComponent(deps dependencies) Provides {
 	c := &check{
 		processCheck: checks.NewProcessCheck(deps.Config, deps.Sysconfig, deps.WMmeta, deps.GpuSubscriber, deps.Statsd, deps.IPC.GetTLSServerConfig(), deps.Tagger),
 	}

--- a/comp/process/processcheck/impl/check_linux_test.go
+++ b/comp/process/processcheck/impl/check_linux_test.go
@@ -69,7 +69,7 @@ func TestProcessCheckEnablementOnCoreAgent(t *testing.T) {
 				fx.Provide(func() statsd.ClientInterface {
 					return &statsd.NoOpClient{}
 				}),
-				fxutil.ProvideComponentConstructor(NewCheck),
+				fxutil.ProvideComponentConstructor(NewComponent),
 				fx.Provide(func() ipc.Component { return ipcmock.New(t) }),
 			))
 			assert.Equal(t, tc.enabled, c.Object().IsEnabled())

--- a/comp/process/processcheck/impl/check_test.go
+++ b/comp/process/processcheck/impl/check_test.go
@@ -94,7 +94,7 @@ func TestProcessChecksIsEnabled(t *testing.T) {
 					return &statsd.NoOpClient{}
 				}),
 				fx.Provide(func() ipc.Component { return ipcmock.New(t) }),
-				fxutil.ProvideComponentConstructor(NewCheck),
+				fxutil.ProvideComponentConstructor(NewComponent),
 			))
 			assert.Equal(t, tc.enabled, c.Object().IsEnabled())
 		})

--- a/comp/process/processdiscoverycheck/fx/fx.go
+++ b/comp/process/processdiscoverycheck/fx/fx.go
@@ -14,6 +14,6 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(processdiscoverycheckimpl.NewCheck),
+		fxutil.ProvideComponentConstructor(processdiscoverycheckimpl.NewComponent),
 	)
 }

--- a/comp/process/processdiscoverycheck/impl/check.go
+++ b/comp/process/processdiscoverycheck/impl/check.go
@@ -36,8 +36,8 @@ type Provides struct {
 	Component processdiscoverycheck.Component
 }
 
-// NewCheck creates a new processdiscoverycheck component.
-func NewCheck(deps dependencies) Provides {
+// NewComponent creates a new processdiscoverycheck component.
+func NewComponent(deps dependencies) Provides {
 	c := &check{
 		processDiscoveryCheck: checks.NewProcessDiscoveryCheck(deps.Config, deps.Sysconfig),
 	}

--- a/comp/process/processdiscoverycheck/impl/check_test.go
+++ b/comp/process/processdiscoverycheck/impl/check_test.go
@@ -73,7 +73,7 @@ func TestProcessDiscoveryIsEnabled(t *testing.T) {
 			c := fxutil.Test[processdiscoverycheck.Component](t, fx.Options(
 				fx.Provide(func(t testing.TB) config.Component { return config.NewMockWithOverrides(t, tc.configs) }),
 				fx.Provide(func() sysprobeconfigdef.Component { return sysprobeConf }),
-				fxutil.ProvideComponentConstructor(NewCheck),
+				fxutil.ProvideComponentConstructor(NewComponent),
 			))
 			assert.Equal(t, tc.enabled, c.Object().IsEnabled())
 		})

--- a/comp/process/rtcontainercheck/fx/fx.go
+++ b/comp/process/rtcontainercheck/fx/fx.go
@@ -14,6 +14,6 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(rtcontainercheckimpl.NewCheck),
+		fxutil.ProvideComponentConstructor(rtcontainercheckimpl.NewComponent),
 	)
 }

--- a/comp/process/rtcontainercheck/impl/check.go
+++ b/comp/process/rtcontainercheck/impl/check.go
@@ -38,8 +38,8 @@ type Provides struct {
 	Component rtcontainercheck.Component
 }
 
-// NewCheck creates a new rtcontainercheck component.
-func NewCheck(deps dependencies) Provides {
+// NewComponent creates a new rtcontainercheck component.
+func NewComponent(deps dependencies) Provides {
 	c := &check{
 		rtContainerCheck: checks.NewRTContainerCheck(deps.Config, deps.Sysconfig, deps.WMmeta),
 	}

--- a/comp/process/rtcontainercheck/impl/check_test.go
+++ b/comp/process/rtcontainercheck/impl/check_test.go
@@ -159,7 +159,7 @@ func TestRTContainerCheckIsEnabled(t *testing.T) {
 				fx.Provide(func() statsd.ClientInterface {
 					return &statsd.NoOpClient{}
 				}),
-				fxutil.ProvideComponentConstructor(NewCheck),
+				fxutil.ProvideComponentConstructor(NewComponent),
 			))
 
 			assert.Equal(t, tc.enabled, c.Object().IsEnabled())


### PR DESCRIPTION
### What does this PR do?
Rename impl constructor functions to `NewComponent` in comp/process/{connectionscheck,containercheck,processcheck,processdiscoverycheck,rtcontainercheck}.

### Motivation
The [component creation docs](https://datadoghq.dev/datadog-agent/components/creating-components/) explicitly require every `impl/` folder to expose a public `NewComponent` function:

> "Must expose a public `NewComponent` function. Dependencies use `Requires`; outputs use `Provides`."

These components correctly used `ProvideComponentConstructor` in their `fx/fx.go` but had domain-specific constructor names. This PR aligns naming with the documented convention.

### Describe how you validated your changes
- Renamed constructor(s) in each `impl/` folder
- Updated the `ProvideComponentConstructor` reference in each `fx/fx.go`
- Verified no other callers of the old name exist outside fx/
- Verified `git diff --name-only` shows only impl/ and fx/ files; no go.mod/go.sum changes
- No behaviour change: `ProvideComponentConstructor` is name-agnostic at runtime

### Additional Notes
Affected: comp/process/{connectionscheck,containercheck,processcheck,processdiscoverycheck,rtcontainercheck}
Part of a series of 20 PRs bringing all v2 components into compliance with the documented naming convention.