### PR TITLE
refactor(comp/forwarder,comp/serializer): rename impl constructors to NewComponent

### DIFF
--- a/comp/forwarder/defaultforwarder/fx/fx.go
+++ b/comp/forwarder/defaultforwarder/fx/fx.go
@@ -17,7 +17,7 @@ import (
 // Module defines the fx options for this component.
 func Module(params defaultforwarderdef.Params) fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(defaultforwarderimpl.NewForwarderFromDeps),
+		fxutil.ProvideComponentConstructor(defaultforwarderimpl.NewComponent),
 		fx.Supply(params),
 	)
 }
@@ -26,7 +26,7 @@ func Module(params defaultforwarderdef.Params) fxutil.Module {
 // Deprecated: will be removed once configsync cleanup is done.
 func ModuleWithOptionTMP(option fx.Option) fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(defaultforwarderimpl.NewForwarderFromDeps),
+		fxutil.ProvideComponentConstructor(defaultforwarderimpl.NewComponent),
 		option,
 	)
 }

--- a/comp/forwarder/defaultforwarder/impl/forwarder.go
+++ b/comp/forwarder/defaultforwarder/impl/forwarder.go
@@ -116,10 +116,10 @@ func newMockForwarder(config config.Component, log log.Component, secrets secret
 	}
 }
 
-// NewForwarderFromDeps is an exported wrapper around newForwarder for use with fx.
+// NewComponent is an exported wrapper around newForwarder for use with fx.
 //
 //nolint:revive
-func NewForwarderFromDeps(dep dependencies) (provides, error) {
+func NewComponent(dep dependencies) (provides, error) {
 	return newForwarder(dep)
 }
 

--- a/comp/serializer/metricscompression/fx/fx.go
+++ b/comp/serializer/metricscompression/fx/fx.go
@@ -15,7 +15,7 @@ import (
 func Module() fxutil.Module {
 	return fxutil.Component(
 		fxutil.ProvideComponentConstructor(
-			metricscompressionimpl.NewCompressorReq,
+			metricscompressionimpl.NewComponent,
 		),
 	)
 }

--- a/comp/serializer/metricscompression/impl/metricscompression.go
+++ b/comp/serializer/metricscompression/impl/metricscompression.go
@@ -18,8 +18,8 @@ type Requires struct {
 	Cfg config.Component
 }
 
-// NewCompressorReq returns the compression component
-func NewCompressorReq(req Requires) Provides {
+// NewComponent returns the compression component
+func NewComponent(req Requires) Provides {
 	return Provides{
 		selector.FromConfig(req.Cfg),
 	}

--- a/pkg/serializer/internal/metrics/events_test.go
+++ b/pkg/serializer/internal/metrics/events_test.go
@@ -143,7 +143,7 @@ func TestEventsMarshaler2(t *testing.T) {
 				"",
 				mockConfig,
 				logmock.New(t),
-				metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp,
+				metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp,
 			)
 			assert.NoError(t, err)
 			payloads := decodePayload(t, mockConfig, bytePayloads)
@@ -175,7 +175,7 @@ func TestEventsMarshaler2Split(t *testing.T) {
 				"",
 				mockConfig,
 				logmock.New(t),
-				metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp,
+				metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp,
 			)
 			assert.NoError(t, err)
 			payloads := decodePayload(t, mockConfig, bytePayloads)
@@ -211,7 +211,7 @@ func TestEventsMarshaler2Drop(t *testing.T) {
 				"",
 				mockConfig,
 				logmock.New(t),
-				metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp,
+				metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp,
 			)
 
 			// assert positions of big events in the sorted array to make sure we're testing the expected states
@@ -234,7 +234,7 @@ func BenchmarkMarshaler2(b *testing.B) {
 	runBenchmark(b, func(b *testing.B, numberOfItem int) {
 		cfg := configmock.New(b)
 		logger := logmock.New(b)
-		compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: cfg}).Comp
+		compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: cfg}).Comp
 		events := createBenchmarkEvents(numberOfItem)
 
 		b.ResetTimer()

--- a/pkg/serializer/internal/metrics/service_checks_test.go
+++ b/pkg/serializer/internal/metrics/service_checks_test.go
@@ -37,7 +37,7 @@ func createServiceCheck(checkName string) *servicecheck.ServiceCheck {
 }
 
 func buildPayload(t *testing.T, m marshaler.StreamJSONMarshaler, cfg pkgconfigmodel.Config) [][]byte {
-	compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: cfg}).Comp
+	compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: cfg}).Comp
 	builder := stream.NewJSONPayloadBuilder(true, cfg, compressor, logmock.New(t))
 	payloads, err := stream.BuildJSONPayload(builder, m)
 	assert.NoError(t, err)
@@ -46,7 +46,7 @@ func buildPayload(t *testing.T, m marshaler.StreamJSONMarshaler, cfg pkgconfigmo
 
 func decodePayload(t *testing.T, cfg pkgconfigmodel.Config, payloads []*transaction.BytesPayload) [][]byte {
 	var uncompressedPayloads [][]byte
-	compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: cfg}).Comp
+	compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: cfg}).Comp
 	for _, compressedPayload := range payloads {
 		payload, err := compressor.Decompress(compressedPayload.GetContent())
 		assert.NoError(t, err)
@@ -125,7 +125,7 @@ func createServiceChecks(numberOfItem int) ServiceChecks {
 
 func benchmarkJSONPayloadBuilderServiceCheck(b *testing.B, numberOfItem int) {
 	mockConfig := mock.New(b)
-	compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+	compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 	payloadBuilder := stream.NewJSONPayloadBuilder(true, mockConfig, compressor, logmock.New(b))
 	serviceChecks := createServiceChecks(numberOfItem)
 

--- a/pkg/serializer/internal/metrics/sketch_benchmark_test.go
+++ b/pkg/serializer/internal/metrics/sketch_benchmark_test.go
@@ -27,7 +27,7 @@ func benchmarkSplitPayloadsSketchesNew(b *testing.B, numPoints int) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	mockConfig := mock.New(b)
-	compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+	compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 	logger := logmock.New(b)
 
 	for n := 0; n < b.N; n++ {

--- a/pkg/serializer/internal/metrics/sketch_series_test.go
+++ b/pkg/serializer/internal/metrics/sketch_series_test.go
@@ -57,7 +57,7 @@ func TestSketchSeriesMarshalSplitCompressEmpty(t *testing.T) {
 			sl := SketchSeriesList{SketchesSource: metrics.NewSketchesSourceTest()}
 
 			pipelines := testPipelines()
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 			err := sl.MarshalSplitCompressPipelines(mockConfig, compressor, pipelines, logger)
 			assert.Nil(t, err)
 			payloads := pipelines.GetPayloads()
@@ -101,7 +101,7 @@ func TestSketchSeriesMarshalSplitCompressItemTooBigIsDropped(t *testing.T) {
 
 			pipelines := testPipelines()
 			serializer := SketchSeriesList{SketchesSource: sl}
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 			err := serializer.MarshalSplitCompressPipelines(mockConfig, compressor, pipelines, logger)
 			payloads := pipelines.GetPayloads()
 
@@ -145,7 +145,7 @@ func TestSketchSeriesMarshalSplitCompress(t *testing.T) {
 
 			pipelines := testPipelines()
 			serializer2 := SketchSeriesList{SketchesSource: sl}
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 			err := serializer2.MarshalSplitCompressPipelines(mockConfig, compressor, pipelines, logger)
 			require.NoError(t, err)
 			payloads := pipelines.GetPayloads()
@@ -207,7 +207,7 @@ func TestSketchSeriesMarshalSplitCompressSplit(t *testing.T) {
 
 			pipelines := testPipelines()
 			serializer := SketchSeriesList{SketchesSource: sl}
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 			err := serializer.MarshalSplitCompressPipelines(mockConfig, compressor, pipelines, logger)
 			assert.Nil(t, err)
 			payloads := pipelines.GetPayloads()
@@ -272,7 +272,7 @@ func TestSketchSeriesMarshalSplitCompressMultiple(t *testing.T) {
 
 			sl.Reset()
 			serializer2 := SketchSeriesList{SketchesSource: sl}
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 
 			primaryConf := PipelineConfig{
 				Filter: AllowAllFilter{},

--- a/pkg/serializer/internal/stream/compressor_test.go
+++ b/pkg/serializer/internal/stream/compressor_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func payloadToString(payload []byte, cfg config.Component) string {
-	compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: cfg}).Comp
+	compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: cfg}).Comp
 	p, err := compressor.Decompress(payload)
 	if err != nil {
 		return err.Error()
@@ -46,7 +46,7 @@ func TestCompressorSimple(t *testing.T) {
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 			maxPayloadSize := mockConfig.GetInt("serializer_max_payload_size")
 			maxUncompressedSize := mockConfig.GetInt("serializer_max_uncompressed_payload_size")
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 			c, err := NewCompressor(
 				&bytes.Buffer{}, &bytes.Buffer{},
 				maxPayloadSize, maxUncompressedSize,
@@ -70,7 +70,7 @@ func TestCompressorLimits(t *testing.T) {
 	maxPayloadSize := mockConfig.GetInt("serializer_max_payload_size")
 	maxUncompressedSize := mockConfig.GetInt("serializer_max_uncompressed_payload_size")
 
-	compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+	compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 	c, err := NewCompressor(
 		&bytes.Buffer{}, &bytes.Buffer{},
 		maxPayloadSize, maxUncompressedSize,
@@ -106,7 +106,7 @@ func TestCompressorAddItemErrCodeWithEmptyCompressor(t *testing.T) {
 			mockConfig := mock.New(t)
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 			checkAddItemErrCode := func(maxPayloadSize, maxUncompressedSize, dataLen int) {
 				c, err := NewCompressor(
 					&bytes.Buffer{}, &bytes.Buffer{},
@@ -160,7 +160,7 @@ func TestOnePayloadSimple(t *testing.T) {
 			mockConfig := mock.New(t)
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 			builder := NewJSONPayloadBuilder(true, mockConfig, compressor, logger)
 			payloads, err := BuildJSONPayload(builder, m)
 			require.NoError(t, err)
@@ -190,7 +190,7 @@ func TestMaxCompressedSizePayload(t *testing.T) {
 			mockConfig := mock.New(t)
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 			mockConfig.SetDefault("serializer_max_payload_size", tc.maxPayloadSize)
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 			builder := NewJSONPayloadBuilder(true, mockConfig, compressor, logger)
 			payloads, err := BuildJSONPayload(builder, m)
 			require.NoError(t, err)
@@ -216,7 +216,7 @@ func TestZstdCompressionLevel(t *testing.T) {
 			mockConfig.SetInTest("serializer_compressor_kind", "zstd")
 			mockConfig.SetDefault("serializer_zstd_compressor_level", level)
 
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 			builder := NewJSONPayloadBuilder(true, mockConfig, compressor, logger)
 			payloads, err := BuildJSONPayload(builder, m)
 			require.NoError(t, err)
@@ -247,7 +247,7 @@ func TestTwoPayload(t *testing.T) {
 			mockConfig.SetDefault("serializer_max_payload_size", tc.maxPayloadSize)
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 			builder := NewJSONPayloadBuilder(true, mockConfig, compressor, logger)
 			payloads, err := BuildJSONPayload(builder, m)
 			require.NoError(t, err)
@@ -277,7 +277,7 @@ func TestLockedCompressorProducesSamePayloads(t *testing.T) {
 			mockConfig := mock.New(t)
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 			builderLocked := NewJSONPayloadBuilder(true, mockConfig, compressor, logger)
 			builderUnLocked := NewJSONPayloadBuilder(false, mockConfig, compressor, logger)
 			payloads1, err := BuildJSONPayload(builderLocked, m)
@@ -305,7 +305,7 @@ func TestBuildWithOnErrItemTooBigPolicyMetadata(t *testing.T) {
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 			mockConfig.SetInTest("serializer_max_uncompressed_payload_size", tc.maxUncompressedPayloadSize)
 
-			compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 			marshaler := &IterableStreamJSONMarshalerMock{index: 0, maxIndex: 100}
 			builder := NewJSONPayloadBuilder(false, mockConfig, compressor, logger)
 			payloads, err := builder.BuildWithOnErrItemTooBigPolicy(

--- a/pkg/serializer/metrics_test.go
+++ b/pkg/serializer/metrics_test.go
@@ -39,7 +39,7 @@ func TestBuildPipelines(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSeries)
@@ -69,7 +69,7 @@ func TestBuildPipelinesWithAdditionalEndpoints(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSeries)
@@ -102,7 +102,7 @@ func TestBuildPipelinesWithAutoscalingFailover(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSeries)
@@ -145,7 +145,7 @@ func TestBuildPipelinesWithAutoscalingFailoverEmptyList(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSeries)
@@ -173,7 +173,7 @@ func TestBuildPipelinesWithMRFInactive(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSeries)
@@ -207,7 +207,7 @@ func TestBuildPipelinesWithMRFActive(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSeries)
@@ -245,7 +245,7 @@ func TestBuildPipelinesWithMRFActiveFilter(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSeries)
@@ -284,7 +284,7 @@ func TestBuildPipelinesSketches(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSketches)
@@ -318,7 +318,7 @@ func TestPipelinesWithV3AndAdditionalEndpoints(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSeries)
@@ -362,7 +362,7 @@ func TestPipelinesWithAdditionalEndpointsV3(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSeries)
@@ -403,7 +403,7 @@ func TestPipelinesWithV3Validate(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSeries)
@@ -468,7 +468,7 @@ func TestBuildPipelinesWithV3Beta(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSeries)
@@ -497,7 +497,7 @@ func TestBuildPipelinesWithV3BetaCustomRoute(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelines(metricsKindSeries)
@@ -530,7 +530,7 @@ func TestBuildPipelinesShadowSampleRateZero(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelinesRng(metricsKindSeries, fixedRand{v: 0})
@@ -556,7 +556,7 @@ func TestBuildPipelinesShadowFires(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelinesRng(metricsKindSeries, fixedRand{v: 0.4})
@@ -609,7 +609,7 @@ func TestBuildPipelinesShadowSkippedAboveRate(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelinesRng(metricsKindSeries, fixedRand{v: 0.6})
@@ -636,7 +636,7 @@ func TestBuildPipelinesShadowSkippedWhenV3Authoritative(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelinesRng(metricsKindSeries, fixedRand{v: 0})
@@ -662,7 +662,7 @@ func TestBuildPipelinesShadowSkippedForSketches(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelinesRng(metricsKindSketches, fixedRand{v: 0})
@@ -691,7 +691,7 @@ func TestBuildPipelinesShadowSkippedForNonShadowSite(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelinesRng(metricsKindSeries, fixedRand{v: 0})
@@ -721,7 +721,7 @@ func TestBuildPipelinesShadowSitesKnobOptsInNonUS1(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelinesRng(metricsKindSeries, fixedRand{v: 0})
@@ -784,7 +784,7 @@ func TestBuildPipelinesShadowSkippedWhenVectorConfigured(t *testing.T) {
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
 	pipelines := s.buildPipelinesRng(metricsKindSeries, fixedRand{v: 0})
@@ -808,7 +808,7 @@ func newSeriesV3Serializer(t *testing.T, config model.BuildableConfig) *Serializ
 	config.SetInTest("serializer_experimental_use_v3_api.series.shadow_sample_rate", 0)
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	return NewSerializer(f, nil, compressor, config, logger, "")
 }
 

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -44,7 +44,7 @@ func TestInitExtraHeadersNoopCompression(t *testing.T) {
 	mockConfig := configmock.New(t)
 	mockConfig.SetInTest("serializer_compressor_kind", "blah")
 
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
 	s := NewSerializer(nil, nil, compressor, mockConfig, logmock.New(t), "testhost")
 	initExtraHeaders(s)
 
@@ -82,7 +82,7 @@ func TestInitExtraHeadersWithCompression(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			mockConfig := configmock.New(t)
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
-			compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
 			s := NewSerializer(nil, nil, compressor, mockConfig, logmock.New(t), "testhost")
 			initExtraHeaders(s)
 
@@ -262,7 +262,7 @@ func TestSendV1EventsNew(t *testing.T) {
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 			f := &forwarder.MockedForwarder{}
 
-			compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
 			s := NewSerializer(f, nil, compressor, mockConfig, logmock.New(t), "testhost")
 			matcher := createJSONPayloadMatcher(`{"apiKey":"","events":{"api":[{"msg_title":"","msg_text":"","timestamp":0,"host":""}]},"internalHostname"`, s)
 			f.On("SubmitV1Intake", matcher, s.jsonExtraHeadersWithCompression).Return(nil).Times(1)
@@ -279,7 +279,7 @@ func TestSendAgentShutdownEvent(t *testing.T) {
 	mockConfig.SetInTest("serializer_compressor_kind", compression.ZlibKind)
 	f := &forwarder.MockedForwarder{}
 
-	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
 	s := NewSerializer(f, nil, compressor, mockConfig, logmock.New(t), "testhost")
 	matcher := createJSONPayloadMatcher(`{"apiKey":"","events":{"System":[{"msg_title":"","msg_text":"Version 7.0.0","timestamp":0,"host":"testhost","source_type_name":"System","event_type":"Agent Shutdown"}]},"internalHostname"`, s)
 	f.On("SubmitV1IntakeDirect", mock.Anything, matcher, mock.MatchedBy(func(kind transaction.Kind) bool {
@@ -309,7 +309,7 @@ func TestSendV1EventsNewNoEmpty(t *testing.T) {
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 			f := &forwarder.MockedForwarder{}
 
-			compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
 			s := NewSerializer(f, nil, compressor, mockConfig, logmock.New(t), "testhost")
 			err := s.SendEvents([]*event.Event{})
 			require.Nil(t, err)
@@ -332,7 +332,7 @@ func TestSendV1ServiceChecks(t *testing.T) {
 			mockConfig := configmock.New(t)
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 
-			compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
 			s := NewSerializer(f, nil, compressor, mockConfig, logmock.New(t), "testhost")
 			matcher := createJSONPayloadMatcher(`[{"check":"","host_name":"","timestamp":0,"status":0,"message":"","tags":null}]`, s)
 			f.On("SubmitV1CheckRuns", matcher, s.jsonExtraHeadersWithCompression).Return(nil).Times(1)
@@ -359,7 +359,7 @@ func TestSendV1Series(t *testing.T) {
 			mockConfig.SetInTest("use_v2_api.series", false)
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 
-			compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
 			s := NewSerializer(f, nil, compressor, mockConfig, logmock.New(t), "testhost")
 			matcher := createJSONPayloadMatcher(
 				`{"series":[{"metric":"foo","points":[[1759241515,3.14],[1759241525,2.71]],`+
@@ -417,7 +417,7 @@ func TestSendSeries(t *testing.T) {
 			mockConfig.SetInTest("use_v3_api.series.enabled", "false")
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 
-			compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
 			s := NewSerializer(f, nil, compressor, mockConfig, logmock.New(t), "testhost")
 			matcher := createProtoscopeMatcher(t, `1: {
 		1: { 1: {"host"} 2: {"localhost"} }
@@ -471,7 +471,7 @@ func TestSendSketch(t *testing.T) {
 			mockConfig.SetInTest("use_v2_api.series", true) // default value, but just to be sure
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 
-			compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
 			s := NewSerializer(f, nil, compressor, mockConfig, logmock.New(t), "testhost")
 			matcher := createProtoscopeMatcher(t, `
 		1: { 1: {"fakename"} 2: {"fakehost"} 8: { 1: { 4: 10 }}}
@@ -502,7 +502,7 @@ func TestSendMetadata(t *testing.T) {
 			mockConfig := configmock.New(t)
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 
-			compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
 			s := NewSerializer(f, nil, compressor, mockConfig, logmock.New(t), "testhost")
 			jsonPayloads, _ := mkPayloads(jsonString, true, s)
 			f.On("SubmitMetadata", jsonPayloads, s.jsonExtraHeadersWithCompression).Return(nil).Times(1)
@@ -539,7 +539,7 @@ func TestSendProcessesMetadata(t *testing.T) {
 			mockConfig := configmock.New(t)
 			mockConfig.SetInTest("serializer_compressor_kind", tc.kind)
 
-			compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
 			s := NewSerializer(f, nil, compressor, mockConfig, logmock.New(t), "testhost")
 			payloads, _ := mkPayloads(payload, true, s)
 			f.On("SubmitV1Intake", payloads, s.jsonExtraHeadersWithCompression).Return(nil).Times(1)
@@ -581,7 +581,7 @@ func TestSendWithDisabledKind(t *testing.T) {
 
 			f := &forwarder.MockedForwarder{}
 
-			compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
+			compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
 			s := NewSerializer(f, nil, compressor, mockConfig, logmock.New(t), "testhost")
 
 			jsonPayloads, _ := mkPayloads(jsonString, true, s)

--- a/pkg/serializer/series_benchmark_test.go
+++ b/pkg/serializer/series_benchmark_test.go
@@ -76,7 +76,7 @@ func BenchmarkSeries(b *testing.B) {
 		}
 	}
 	mockConfig := mock.New(b)
-	compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
+	compressor := metricscompression.NewComponent(metricscompression.Requires{Cfg: mockConfig}).Comp
 	pb := func(series metrics.Series) (transaction.BytesPayloads, error) {
 		iterableSeries := metricsserializer.CreateIterableSeries(metricsserializer.CreateSerieSource(series))
 		pipelineConfig := metricsserializer.PipelineConfig{


### PR DESCRIPTION
### What does this PR do?
Rename impl constructor functions to `NewComponent` in comp/forwarder/defaultforwarder, comp/serializer/metricscompression.

### Motivation
The [component creation docs](https://datadoghq.dev/datadog-agent/components/creating-components/) explicitly require every `impl/` folder to expose a public `NewComponent` function:

> "Must expose a public `NewComponent` function. Dependencies use `Requires`; outputs use `Provides`."

These components correctly used `ProvideComponentConstructor` in their `fx/fx.go` but had domain-specific constructor names. This PR aligns naming with the documented convention.

### Describe how you validated your changes
- Renamed constructor(s) in each `impl/` folder
- Updated the `ProvideComponentConstructor` reference in each `fx/fx.go`
- Verified no other callers of the old name exist outside fx/
- Verified `git diff --name-only` shows only impl/ and fx/ files; no go.mod/go.sum changes
- No behaviour change: `ProvideComponentConstructor` is name-agnostic at runtime

### Additional Notes
Affected: comp/forwarder/defaultforwarder, comp/serializer/metricscompression
Part of a series of 20 PRs bringing all v2 components into compliance with the documented naming convention.