### PR TITLE
refactor(comp/softwareinventory): rename impl constructor to NewComponent

### DIFF
--- a/comp/softwareinventory/fx/fx.go
+++ b/comp/softwareinventory/fx/fx.go
@@ -17,7 +17,7 @@ import (
 func Module() fxutil.Module {
 	return fxutil.Component(
 		fxutil.ProvideComponentConstructor(
-			softwareinventoryimpl.New,
+			softwareinventoryimpl.NewComponent,
 		),
 		fxutil.ProvideOptional[softwareinventory.Component](),
 

--- a/comp/softwareinventory/impl/inventorysoftware.go
+++ b/comp/softwareinventory/impl/inventorysoftware.go
@@ -138,8 +138,8 @@ type Provides struct {
 	Endpoint api.AgentEndpointProvider
 }
 
-// New creates a new inventory software component with the default sysprobeclient
-func New(reqs Requires) (Provides, error) {
+// NewComponent creates a new inventory software component with the default sysprobeclient
+func NewComponent(reqs Requires) (Provides, error) {
 	return newWithClient(reqs, &sysProbeClientWrapper{
 		clientFn: func() *sysprobeclient.CheckClient {
 			return sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(reqs.SysprobeConfig.GetString("system_probe_config.sysprobe_socket")))


### PR DESCRIPTION
### What does this PR do?
Rename impl constructor functions to `NewComponent` in comp/softwareinventory.

### Motivation
The [component creation docs](https://datadoghq.dev/datadog-agent/components/creating-components/) explicitly require every `impl/` folder to expose a public `NewComponent` function:

> "Must expose a public `NewComponent` function. Dependencies use `Requires`; outputs use `Provides`."

These components correctly used `ProvideComponentConstructor` in their `fx/fx.go` but had domain-specific constructor names. This PR aligns naming with the documented convention.

### Describe how you validated your changes
- Renamed constructor(s) in each `impl/` folder
- Updated the `ProvideComponentConstructor` reference in each `fx/fx.go`
- Verified no other callers of the old name exist outside fx/
- Verified `git diff --name-only` shows only impl/ and fx/ files; no go.mod/go.sum changes
- No behaviour change: `ProvideComponentConstructor` is name-agnostic at runtime

### Additional Notes
Affected: comp/softwareinventory
Part of a series of 20 PRs bringing all v2 components into compliance with the documented naming convention.