### PR TITLE
ci: trigger Windows builds on procmgr changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,8 @@
   - pkg/logs/util/windowsevent/**/*
   - pkg/network/driver/**/*
   - pkg/procmgr/**/*
+  - pkg/proto/datadog/procmgr/**/*
+  - pkg/proto/pbgo/procmgr/**/*
 
   # Global packages likely to impact windows
   - pkg/config/**/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,9 +41,6 @@
   - pkg/logs/tailers/windowsevent/**/*
   - pkg/logs/util/windowsevent/**/*
   - pkg/network/driver/**/*
-  - pkg/procmgr/**/*
-  - pkg/proto/datadog/procmgr/**/*
-  - pkg/proto/pbgo/procmgr/**/*
 
   # Global packages likely to impact windows
   - pkg/config/**/*
@@ -119,6 +116,14 @@
   - test/new-e2e/tests/process/**/*
   - test/new-e2e/tests/agent-runtimes/**/*
 
+# Process manager
+.windows_path_4: &windows_path_4
+  - pkg/procmgr/**/*
+  - pkg/proto/datadog/procmgr/**/*
+  - pkg/proto/pbgo/procmgr/**/*
+  - Cargo.toml
+  - Cargo.lock
+
 include:
   - local: .adms/**/*.yaml
   - local: .gitlab/.pre/**.yml
@@ -146,6 +151,9 @@ include:
           compare_to: main
       - changes:
           paths: *windows_path_3
+          compare_to: main
+      - changes:
+          paths: *windows_path_4
           compare_to: main
       - changes:
           paths: *bazel_paths
@@ -534,6 +542,11 @@ workflow:
         SKIP_WINDOWS: "false"
     - changes:
         paths: *windows_path_3
+        compare_to: main
+      variables:
+        SKIP_WINDOWS: "false"
+    - changes:
+        paths: *windows_path_4
         compare_to: main
       variables:
         SKIP_WINDOWS: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,7 @@
   - pkg/logs/tailers/windowsevent/**/*
   - pkg/logs/util/windowsevent/**/*
   - pkg/network/driver/**/*
+  - pkg/procmgr/**/*
 
   # Global packages likely to impact windows
   - pkg/config/**/*


### PR DESCRIPTION
### What does this PR do?

Adds procmgr source files to the Windows CI path globs so branch pipelines include Windows MSI build and deploy jobs when procmgr sources change.

### Motivation

Procmgr-only PRs currently skip the Windows job set, so there are no Windows MSI artifacts in S3 and `aws.create-vm` cannot use those pipeline IDs. This unblocks Windows testing for procmgr work without running a full `--e2e-tests` pipeline.

### Describe how you validated your changes

CI config only. After merge, a procmgr change on a branch pipeline should show `windows_msi_and_bosh_zip_x64-a7` and `deploy_windows_testing-a7`.

### Additional Notes

Linux jobs are unchanged