### PR TITLE
refactor(comp/ndmtmp,comp/networkpath): rename impl constructors to NewComponent

### DIFF
--- a/comp/ndmtmp/forwarder/fx/fx.go
+++ b/comp/ndmtmp/forwarder/fx/fx.go
@@ -14,6 +14,6 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(forwarderimpl.GetForwarder),
+		fxutil.ProvideComponentConstructor(forwarderimpl.NewComponent),
 	)
 }

--- a/comp/ndmtmp/forwarder/impl/forwarder.go
+++ b/comp/ndmtmp/forwarder/impl/forwarder.go
@@ -19,7 +19,7 @@ type Dependencies struct {
 	Demultiplexer demultiplexer.Component
 }
 
-// GetForwarder returns the event platform forwarder from the demultiplexer.
-func GetForwarder(deps Dependencies) (forwarder.Component, error) {
+// NewComponent returns the event platform forwarder from the demultiplexer.
+func NewComponent(deps Dependencies) (forwarder.Component, error) {
 	return deps.Demultiplexer.GetEventPlatformForwarder()
 }

--- a/comp/networkpath/npcollector/fx/fx.go
+++ b/comp/networkpath/npcollector/fx/fx.go
@@ -14,6 +14,6 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(npcollectorimpl.NewNpCollector),
+		fxutil.ProvideComponentConstructor(npcollectorimpl.NewComponent),
 	)
 }

--- a/comp/networkpath/npcollector/impl/module_test.go
+++ b/comp/networkpath/npcollector/impl/module_test.go
@@ -12,6 +12,6 @@ import (
 // Module defines the fx options for the npcollector component for use in tests.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(NewNpCollector),
+		fxutil.ProvideComponentConstructor(NewComponent),
 	)
 }

--- a/comp/networkpath/npcollector/impl/npcollectorcomp.go
+++ b/comp/networkpath/npcollector/impl/npcollectorcomp.go
@@ -38,8 +38,8 @@ type Provides struct {
 	Comp npcollector.Component
 }
 
-// NewNpCollector creates a new npcollector component.
-func NewNpCollector(deps dependencies) Provides {
+// NewComponent creates a new npcollector component.
+func NewComponent(deps dependencies) Provides {
 	var collector *npCollectorImpl
 
 	configs := newConfig(deps.AgentConfig, deps.Logger)


### PR DESCRIPTION
### What does this PR do?
Rename impl constructor functions to `NewComponent` in comp/ndmtmp/forwarder, comp/networkpath/npcollector.

### Motivation
The [component creation docs](https://datadoghq.dev/datadog-agent/components/creating-components/) explicitly require every `impl/` folder to expose a public `NewComponent` function:

> "Must expose a public `NewComponent` function. Dependencies use `Requires`; outputs use `Provides`."

These components correctly used `ProvideComponentConstructor` in their `fx/fx.go` but had domain-specific constructor names. This PR aligns naming with the documented convention.

### Describe how you validated your changes
- Renamed constructor(s) in each `impl/` folder
- Updated the `ProvideComponentConstructor` reference in each `fx/fx.go`
- Verified no other callers of the old name exist outside fx/
- Verified `git diff --name-only` shows only impl/ and fx/ files; no go.mod/go.sum changes
- No behaviour change: `ProvideComponentConstructor` is name-agnostic at runtime

### Additional Notes
Affected: comp/ndmtmp/forwarder, comp/networkpath/npcollector
Part of a series of 20 PRs bringing all v2 components into compliance with the documented naming convention.