### PR TITLE
refactor(comp/anomalydetection/recorder): rename impl constructor to NewComponent

### DIFF
--- a/comp/anomalydetection/recorder/impl-noop/recorder.go
+++ b/comp/anomalydetection/recorder/impl-noop/recorder.go
@@ -12,8 +12,8 @@ import (
 	recorder "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
 )
 
-// NewNoopComponent returns a recorder Component that does nothing.
-func NewNoopComponent() recorder.Component {
+// NewComponent returns a recorder Component that does nothing.
+func NewComponent() recorder.Component {
 	return &noopRecorder{}
 }
 


### PR DESCRIPTION
### What does this PR do?
Rename impl constructor functions to `NewComponent` in comp/anomalydetection/recorder.

### Motivation
The [component creation docs](https://datadoghq.dev/datadog-agent/components/creating-components/) explicitly require every `impl/` folder to expose a public `NewComponent` function:

> "Must expose a public `NewComponent` function. Dependencies use `Requires`; outputs use `Provides`."

These components correctly used `ProvideComponentConstructor` in their `fx/fx.go` but had domain-specific constructor names. This PR aligns naming with the documented convention.

### Describe how you validated your changes
- Renamed constructor(s) in each `impl/` folder
- Updated the `ProvideComponentConstructor` reference in each `fx/fx.go`
- Verified no other callers of the old name exist outside fx/
- Verified `git diff --name-only` shows only impl/ and fx/ files; no go.mod/go.sum changes
- No behaviour change: `ProvideComponentConstructor` is name-agnostic at runtime

### Additional Notes
Affected: comp/anomalydetection/recorder
Part of a series of 20 PRs bringing all v2 components into compliance with the documented naming convention.