### PR TITLE
refactor(comp/otelcol): rename impl constructors to NewComponent

### DIFF
--- a/comp/otelcol/converter/fx/fx.go
+++ b/comp/otelcol/converter/fx/fx.go
@@ -15,7 +15,7 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(converterimpl.NewConverterForAgent),
+		fxutil.ProvideComponentConstructor(converterimpl.NewComponent),
 		fxutil.ProvideOptional[converter.Component](),
 	)
 }

--- a/comp/otelcol/converter/impl/converter.go
+++ b/comp/otelcol/converter/impl/converter.go
@@ -56,8 +56,8 @@ func newConverter(set confmap.ConverterSettings) confmap.Converter {
 	}
 }
 
-// NewConverterForAgent currently only supports a single URI in the uris slice, and this URI needs to be a file path.
-func NewConverterForAgent(reqs Requires) (converter.Component, error) {
+// NewComponent currently only supports a single URI in the uris slice, and this URI needs to be a file path.
+func NewComponent(reqs Requires) (converter.Component, error) {
 	return &ddConverter{
 		coreConfig: reqs.Conf,
 		hostname:   reqs.Hostname,

--- a/comp/otelcol/converter/impl/converter_test.go
+++ b/comp/otelcol/converter/impl/converter_test.go
@@ -66,8 +66,8 @@ func newResolver(uris []string) (*confmap.Resolver, error) {
 	})
 }
 
-func TestNewConverterForAgent(t *testing.T) {
-	_, err := NewConverterForAgent(Requires{})
+func TestNewComponent(t *testing.T) {
+	_, err := NewComponent(Requires{})
 	assert.NoError(t, err)
 }
 
@@ -472,7 +472,7 @@ func TestConvert(t *testing.T) {
 					r.Hostname = &mockHostname{hostname: "test-host"}
 				}
 			}
-			converter, err := NewConverterForAgent(r)
+			converter, err := NewComponent(r)
 			assert.NoError(t, err)
 
 			resolver, err := newResolver(uriFromFile(tc.provided))
@@ -520,7 +520,7 @@ func TestConvert(t *testing.T) {
 func TestConvert_APIKeyFromEnvVar(t *testing.T) {
 	t.Setenv("DD_API_KEY", "123456")
 	t.Setenv("DD_SITE", "")
-	converter, err := NewConverterForAgent(Requires{Conf: config.NewMock(t), Hostname: &mockHostname{hostname: "test-host"}})
+	converter, err := NewComponent(Requires{Conf: config.NewMock(t), Hostname: &mockHostname{hostname: "test-host"}})
 	assert.NoError(t, err)
 
 	resolver, err := newResolver(uriFromFile("dd-core-cfg/apikey/unset-number/config.yaml"))

--- a/comp/otelcol/ddflareextension/fx/fx.go
+++ b/comp/otelcol/ddflareextension/fx/fx.go
@@ -16,7 +16,7 @@ import (
 func Module() fxutil.Module {
 	return fxutil.Component(
 		fxutil.ProvideComponentConstructor(
-			extensionimpl.NewExtension,
+			extensionimpl.NewComponent,
 		),
 		fxutil.ProvideOptional[extension.Component](),
 	)

--- a/comp/otelcol/ddflareextension/impl/configstore_test.go
+++ b/comp/otelcol/ddflareextension/impl/configstore_test.go
@@ -77,7 +77,7 @@ func TestGetConfDump(t *testing.T) {
 		factories:              &factories,
 		configProviderSettings: newConfigProviderSettings(uriFromFile("simple-dd/config.yaml"), false),
 	}
-	extension, err := NewExtension(context.TODO(), &config, componenttest.NewNopTelemetrySettings(), component.BuildInfo{}, option.None[ipc.Component](), true, false)
+	extension, err := NewComponent(context.TODO(), &config, componenttest.NewNopTelemetrySettings(), component.BuildInfo{}, option.None[ipc.Component](), true, false)
 	assert.NoError(t, err)
 
 	ext, ok := extension.(*ddExtension)
@@ -212,7 +212,7 @@ func newResolverSettings(uris []string, enhanced bool) confmap.ResolverSettings 
 func newConverterFactory(enhanced bool) []confmap.ConverterFactory {
 	converterFactories := []confmap.ConverterFactory{}
 
-	converter, err := converterimpl.NewConverterForAgent(converterimpl.Requires{})
+	converter, err := converterimpl.NewComponent(converterimpl.Requires{})
 	if err != nil {
 		return []confmap.ConverterFactory{}
 	}

--- a/comp/otelcol/ddflareextension/impl/extension.go
+++ b/comp/otelcol/ddflareextension/impl/extension.go
@@ -143,8 +143,8 @@ func (ext *ddExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) erro
 	return nil
 }
 
-// NewExtension creates a new instance of the extension.
-func NewExtension(ctx context.Context, cfg *Config, telemetry component.TelemetrySettings, info component.BuildInfo, ipcComp option.Option[ipc.Component], providedConfigSupported bool, byoc bool) (extensionDef.Component, error) {
+// NewComponent creates a new instance of the extension.
+func NewComponent(ctx context.Context, cfg *Config, telemetry component.TelemetrySettings, info component.BuildInfo, ipcComp option.Option[ipc.Component], providedConfigSupported bool, byoc bool) (extensionDef.Component, error) {
 	ext := &ddExtension{
 		cfg:         cfg,
 		telemetry:   telemetry,

--- a/comp/otelcol/ddflareextension/impl/extension_test.go
+++ b/comp/otelcol/ddflareextension/impl/extension_test.go
@@ -69,7 +69,7 @@ func getTestExtension(t *testing.T, optIpc option.Option[ipc.Component]) (ddflar
 	info := component.NewDefaultBuildInfo()
 	cfg := getExtensionTestConfig(t)
 
-	return NewExtension(c, cfg, telemetry, info, optIpc, true, false)
+	return NewComponent(c, cfg, telemetry, info, optIpc, true, false)
 }
 
 func getResponseToHandlerRequest(t *testing.T, ipc ipc.Component, tokenOverride string) *httptest.ResponseRecorder {
@@ -117,7 +117,7 @@ func getResponseToHandlerRequest(t *testing.T, ipc ipc.Component, tokenOverride 
 	return rr
 }
 
-func TestNewExtension(t *testing.T) {
+func TestNewComponent(t *testing.T) {
 	ext, err := getTestExtension(t, option.None[ipc.Component]())
 	assert.NoError(t, err)
 	assert.NotNil(t, ext)

--- a/comp/otelcol/ddflareextension/impl/factory.go
+++ b/comp/otelcol/ddflareextension/impl/factory.go
@@ -51,7 +51,7 @@ func (f *ddExtensionFactory) CreateExtension(ctx context.Context, set extension.
 		configProviderSettings: f.configProviderSettings,
 	}
 	config.HTTPConfig = cfg.(*Config).HTTPConfig
-	return NewExtension(ctx, config, set.TelemetrySettings, set.BuildInfo, f.ipcComp, true, f.byoc)
+	return NewComponent(ctx, config, set.TelemetrySettings, set.BuildInfo, f.ipcComp, true, f.byoc)
 }
 
 // Create creates a new instance of the Datadog Flare Extension, as of v0.112.0 or later
@@ -61,7 +61,7 @@ func (f *ddExtensionFactory) Create(ctx context.Context, set extension.Settings,
 		configProviderSettings: f.configProviderSettings,
 	}
 	config.HTTPConfig = cfg.(*Config).HTTPConfig
-	return NewExtension(ctx, config, set.TelemetrySettings, set.BuildInfo, f.ipcComp, true, f.byoc)
+	return NewComponent(ctx, config, set.TelemetrySettings, set.BuildInfo, f.ipcComp, true, f.byoc)
 }
 
 func (f *ddExtensionFactory) CreateDefaultConfig() component.Config {

--- a/comp/otelcol/ddprofilingextension/fx/fx.go
+++ b/comp/otelcol/ddprofilingextension/fx/fx.go
@@ -17,7 +17,7 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(ddprofilingextensionimpl.NewExtension),
+		fxutil.ProvideComponentConstructor(ddprofilingextensionimpl.NewComponent),
 		fxutil.ProvideOptional[ddprofilingextension.Component](),
 	)
 }

--- a/comp/otelcol/ddprofilingextension/impl/extension.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension.go
@@ -46,8 +46,8 @@ type ddExtension struct {
 	agentMode  bool
 }
 
-// NewExtension creates a new instance of the extension.
-func NewExtension(cfg *Config, info component.BuildInfo, traceAgent traceagent.Component, log corelog.Component) (ddprofilingextensiondef.Component, error) {
+// NewComponent creates a new instance of the extension.
+func NewComponent(cfg *Config, info component.BuildInfo, traceAgent traceagent.Component, log corelog.Component) (ddprofilingextensiondef.Component, error) {
 	return &ddExtension{
 		cfg:        cfg,
 		info:       info,

--- a/comp/otelcol/ddprofilingextension/impl/extension_test.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension_test.go
@@ -71,8 +71,8 @@ func (h *hostWithExtensions) GetExtensions() map[component.ID]component.Componen
 	return h.exts
 }
 
-func TestNewExtension(t *testing.T) {
-	ext, err := NewExtension(&Config{}, component.BuildInfo{}, testComponent{}, log.NewTemporaryLoggerWithoutInit())
+func TestNewComponent(t *testing.T) {
+	ext, err := NewComponent(&Config{}, component.BuildInfo{}, testComponent{}, log.NewTemporaryLoggerWithoutInit())
 	assert.NoError(t, err)
 
 	_, ok := ext.(*ddExtension)
@@ -105,7 +105,7 @@ func TestAgentExtension(t *testing.T) {
 	traceagent := pkgagent.NewAgent(ctx, tcfg, telemetry.NewNoopCollector(), &ddgostatsd.NoOpClient{}, gzip.NewComponent())
 
 	// create extension
-	ext, err := NewExtension(&Config{
+	ext, err := NewComponent(&Config{
 		ProfilerOptions: ProfilerOptions{
 			Period: 1,
 		},
@@ -144,7 +144,7 @@ func TestStandaloneExtension(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ext, err := NewExtension(&Config{
+	ext, err := NewComponent(&Config{
 		AgentAddr: server.Listener.Addr().String(),
 		ProfilerOptions: ProfilerOptions{
 			Period: 1,

--- a/comp/otelcol/ddprofilingextension/impl/factory.go
+++ b/comp/otelcol/ddprofilingextension/impl/factory.go
@@ -45,7 +45,7 @@ func (f *ddExtensionFactory) Create(_ context.Context, set extension.Settings, c
 	if !ok {
 		return nil, errors.New("invalid ddprofiling extension config")
 	}
-	return NewExtension(config, set.BuildInfo, f.traceAgent, f.log)
+	return NewComponent(config, set.BuildInfo, f.traceAgent, f.log)
 }
 
 // Stability returns the stability level of the component

--- a/comp/otelcol/dogtelextension/fx/fx.go
+++ b/comp/otelcol/dogtelextension/fx/fx.go
@@ -22,7 +22,7 @@ import (
 // This module is provided for potential future use if the architecture changes.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(dogtelextensionimpl.NewExtension),
+		fxutil.ProvideComponentConstructor(dogtelextensionimpl.NewComponent),
 		fxutil.ProvideOptional[dogtelextension.Component](),
 	)
 }

--- a/comp/otelcol/dogtelextension/impl/factory.go
+++ b/comp/otelcol/dogtelextension/impl/factory.go
@@ -107,8 +107,8 @@ type Requires struct {
 	Secrets      secrets.Component
 }
 
-// NewExtension creates a new dogtelextension instance for use with FX.
-func NewExtension(reqs Requires) (dogtelextension.Component, error) {
+// NewComponent creates a new dogtelextension instance for use with FX.
+func NewComponent(reqs Requires) (dogtelextension.Component, error) {
 	cfg := createDefaultConfig().(*Config)
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)

--- a/comp/otelcol/dogtelextension/impl/factory_test.go
+++ b/comp/otelcol/dogtelextension/impl/factory_test.go
@@ -92,11 +92,11 @@ func TestNewFactoryForAgent_InvalidConfigErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid configuration")
 }
 
-// TestNewExtension_FX_InvalidConfig verifies the FX constructor (NewExtension)
+// TestNewComponent_FX_InvalidConfig verifies the FX constructor (NewComponent)
 // rejects an invalid default config.
-func TestNewExtension_FX_DefaultSucceeds(t *testing.T) {
+func TestNewComponent_FX_DefaultSucceeds(t *testing.T) {
 	hostname, _ := hostnameinterface.NewMock("test-host")
-	ext, err := NewExtension(Requires{
+	ext, err := NewComponent(Requires{
 		Config:     configmock.NewMockWithOverrides(t, nil),
 		Log:        logmock.New(t),
 		Serializer: serializermock.NewMetricSerializer(t),


### PR DESCRIPTION
### What does this PR do?
Rename impl constructor functions to `NewComponent` in comp/otelcol/{converter,ddflareextension,ddprofilingextension,dogtelextension}.

### Motivation
The [component creation docs](https://datadoghq.dev/datadog-agent/components/creating-components/) explicitly require every `impl/` folder to expose a public `NewComponent` function:

> "Must expose a public `NewComponent` function. Dependencies use `Requires`; outputs use `Provides`."

These components correctly used `ProvideComponentConstructor` in their `fx/fx.go` but had domain-specific constructor names. This PR aligns naming with the documented convention.

### Describe how you validated your changes
- Renamed constructor(s) in each `impl/` folder
- Updated the `ProvideComponentConstructor` reference in each `fx/fx.go`
- Verified no other callers of the old name exist outside fx/
- Verified `git diff --name-only` shows only impl/ and fx/ files; no go.mod/go.sum changes
- No behaviour change: `ProvideComponentConstructor` is name-agnostic at runtime

### Additional Notes
Affected: comp/otelcol/{converter,ddflareextension,ddprofilingextension,dogtelextension}
Part of a series of 20 PRs bringing all v2 components into compliance with the documented naming convention.