### PR TITLE
refactor(comp/remote-config): rename impl constructors to NewComponent

### DIFF
--- a/comp/remote-config/rcclient/fx/fx.go
+++ b/comp/remote-config/rcclient/fx/fx.go
@@ -18,7 +18,7 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(rcclientimpl.NewRemoteConfigClient),
+		fxutil.ProvideComponentConstructor(rcclientimpl.NewComponent),
 		fxutil.ProvideOptional[rcclient.Component](),
 	)
 }

--- a/comp/remote-config/rcclient/impl/rcclient.go
+++ b/comp/remote-config/rcclient/impl/rcclient.go
@@ -71,11 +71,11 @@ type Dependencies struct {
 	IPC               ipc.Component
 }
 
-// NewRemoteConfigClient must not populate any Fx groups or return any types that would be consumed as dependencies by
+// NewComponent must not populate any Fx groups or return any types that would be consumed as dependencies by
 // other components. To avoid dependency cycles between our components we need to have "pure leaf" components (i.e.
 // components that are instantiated last).  Remote configuration client is a good candidate for this since it must be
 // able to interact with any other components (i.e. be at the end of the dependency graph).
-func NewRemoteConfigClient(deps Dependencies) (rcclient.Component, error) {
+func NewComponent(deps Dependencies) (rcclient.Component, error) {
 	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return nil, err

--- a/comp/remote-config/rcclient/impl/rcclient_test.go
+++ b/comp/remote-config/rcclient/impl/rcclient_test.go
@@ -75,7 +75,7 @@ type testDeps struct {
 func TestRCClientCreate(t *testing.T) {
 	// Test missing params — expect the fx app to fail to build
 	_, _, err := fxutil.TestApp[testDeps](
-		fxutil.ProvideComponentConstructor(NewRemoteConfigClient),
+		fxutil.ProvideComponentConstructor(NewComponent),
 		fxutil.ProvideOptional[rcclient.Component](),
 		fx.Provide(func() log.Component { return logmock.New(t) }),
 		fx.Provide(func() config.Component { return configmock.New(t) }),
@@ -88,7 +88,7 @@ func TestRCClientCreate(t *testing.T) {
 
 	// Test success case
 	app, deps, err := fxutil.TestApp[testDeps](
-		fxutil.ProvideComponentConstructor(NewRemoteConfigClient),
+		fxutil.ProvideComponentConstructor(NewComponent),
 		fxutil.ProvideOptional[rcclient.Component](),
 		fx.Provide(func() log.Component { return logmock.New(t) }),
 		fx.Provide(func() config.Component { return configmock.New(t) }),
@@ -117,7 +117,7 @@ func TestAgentConfigCallback(t *testing.T) {
 	rcComponent := fxutil.Test[rcclient.Component](t,
 		fx.Options(
 			fxutil.Component(
-				fxutil.ProvideComponentConstructor(NewRemoteConfigClient),
+				fxutil.ProvideComponentConstructor(NewComponent),
 				fxutil.ProvideOptional[rcclient.Component](),
 			),
 			fx.Provide(func() log.Component { return logmock.New(t) }),
@@ -224,7 +224,7 @@ func TestAgentMRFConfigCallback(t *testing.T) {
 	rcComponent := fxutil.Test[rcclient.Component](t,
 		fx.Options(
 			fxutil.Component(
-				fxutil.ProvideComponentConstructor(NewRemoteConfigClient),
+				fxutil.ProvideComponentConstructor(NewComponent),
 				fxutil.ProvideOptional[rcclient.Component](),
 			),
 			fx.Provide(func() log.Component { return logmock.New(t) }),

--- a/comp/remote-config/rcservice/fx/fx.go
+++ b/comp/remote-config/rcservice/fx/fx.go
@@ -14,6 +14,6 @@ import (
 // Module conditionally provides the remote config service.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(rcserviceimpl.NewRemoteConfigServiceOptional),
+		fxutil.ProvideComponentConstructor(rcserviceimpl.NewComponent),
 	)
 }

--- a/comp/remote-config/rcservice/impl/rcservice.go
+++ b/comp/remote-config/rcservice/impl/rcservice.go
@@ -64,8 +64,8 @@ type Provides struct {
 	FlareProvider flaretypes.Provider
 }
 
-// NewRemoteConfigServiceOptional conditionally creates and configures a new remote config service, based on whether RC is enabled.
-func NewRemoteConfigServiceOptional(deps Dependencies) Provides {
+// NewComponent conditionally creates and configures a new remote config service, based on whether RC is enabled.
+func NewComponent(deps Dependencies) Provides {
 	none := option.None[rcservice.Component]()
 	if !configUtils.IsRemoteConfigEnabled(deps.Cfg) {
 		return Provides{Comp: none}

--- a/comp/remote-config/rcservicemrf/fx/fx.go
+++ b/comp/remote-config/rcservicemrf/fx/fx.go
@@ -14,6 +14,6 @@ import (
 // Module conditionally provides the HA DC remote config service.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(rcservicemrfimpl.NewMrfRemoteConfigServiceOptional),
+		fxutil.ProvideComponentConstructor(rcservicemrfimpl.NewComponent),
 	)
 }

--- a/comp/remote-config/rcservicemrf/impl/rcservicemrf.go
+++ b/comp/remote-config/rcservicemrf/impl/rcservicemrf.go
@@ -48,8 +48,8 @@ type Provides struct {
 	FlareProvider flaretypes.Provider
 }
 
-// NewMrfRemoteConfigServiceOptional conditionally creates and configures a new MRF remote config service, based on whether RC is enabled.
-func NewMrfRemoteConfigServiceOptional(deps Dependencies) Provides {
+// NewComponent conditionally creates and configures a new MRF remote config service, based on whether RC is enabled.
+func NewComponent(deps Dependencies) Provides {
 	none := option.None[rcservicemrf.Component]()
 	if !configUtils.IsRemoteConfigEnabled(deps.Cfg) || !deps.Cfg.GetBool("multi_region_failover.enabled") {
 		return Provides{Comp: none}

--- a/comp/remote-config/rcstatus/fx/fx.go
+++ b/comp/remote-config/rcstatus/fx/fx.go
@@ -14,6 +14,6 @@ import (
 // Module defines the fx options for the rcstatus component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(rcstatusimpl.NewStatus),
+		fxutil.ProvideComponentConstructor(rcstatusimpl.NewComponent),
 	)
 }

--- a/comp/remote-config/rcstatus/impl/status.go
+++ b/comp/remote-config/rcstatus/impl/status.go
@@ -39,8 +39,8 @@ type statusProvider struct {
 	Config config.Component
 }
 
-// NewStatus creates a new rcstatus component.
-func NewStatus(deps Requires) Provides {
+// NewComponent creates a new rcstatus component.
+func NewComponent(deps Requires) Provides {
 	return Provides{
 		StatusProvider: status.NewInformationProvider(statusProvider{
 			Config: deps.Config,

--- a/comp/remote-config/rcstatus/impl/status_test.go
+++ b/comp/remote-config/rcstatus/impl/status_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestStatusOuput(t *testing.T) {
-	provides := NewStatus(Requires{
+	provides := NewComponent(Requires{
 		Config: config.NewMock(t),
 	})
 

--- a/comp/remote-config/rctelemetryreporter/fx/fx.go
+++ b/comp/remote-config/rctelemetryreporter/fx/fx.go
@@ -14,6 +14,6 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(rctelemetryreporterimpl.NewDdRcTelemetryReporter),
+		fxutil.ProvideComponentConstructor(rctelemetryreporterimpl.NewComponent),
 	)
 }

--- a/comp/remote-config/rctelemetryreporter/impl/rctelemetryreporter.go
+++ b/comp/remote-config/rctelemetryreporter/impl/rctelemetryreporter.go
@@ -76,8 +76,8 @@ func (r *DdRcTelemetryReporter) SetConfigSubscriptionClientsTracked(value int) {
 	}
 }
 
-// NewDdRcTelemetryReporter creates a new Remote Config telemetry reporter for sending RC metrics to Datadog
-func NewDdRcTelemetryReporter(deps Dependencies) rctelemetryreporter.Component {
+// NewComponent creates a new Remote Config telemetry reporter for sending RC metrics to Datadog
+func NewComponent(deps Dependencies) rctelemetryreporter.Component {
 	commonOpts := telemetry.Options{NoDoubleUnderscoreSep: true}
 	return &DdRcTelemetryReporter{
 		BypassRateLimitCounter: deps.Telemetry.NewCounterWithOpts(


### PR DESCRIPTION
### What does this PR do?
Rename impl constructor functions to `NewComponent` in comp/remote-config/{rcclient,rcservice,rcservicemrf,rcstatus,rctelemetryreporter}.

### Motivation
The [component creation docs](https://datadoghq.dev/datadog-agent/components/creating-components/) explicitly require every `impl/` folder to expose a public `NewComponent` function:

> "Must expose a public `NewComponent` function. Dependencies use `Requires`; outputs use `Provides`."

These components correctly used `ProvideComponentConstructor` in their `fx/fx.go` but had domain-specific constructor names. This PR aligns naming with the documented convention.

### Describe how you validated your changes
- Renamed constructor(s) in each `impl/` folder
- Updated the `ProvideComponentConstructor` reference in each `fx/fx.go`
- Verified no other callers of the old name exist outside fx/
- Verified `git diff --name-only` shows only impl/ and fx/ files; no go.mod/go.sum changes
- No behaviour change: `ProvideComponentConstructor` is name-agnostic at runtime

### Additional Notes
Affected: comp/remote-config/{rcclient,rcservice,rcservicemrf,rcstatus,rctelemetryreporter}
Part of a series of 20 PRs bringing all v2 components into compliance with the documented naming convention.