### PR TITLE
refactor(comp/logs): rename impl constructors to NewComponent

### DIFF
--- a/comp/logs-library/kubehealth/fx/fx.go
+++ b/comp/logs-library/kubehealth/fx/fx.go
@@ -15,7 +15,7 @@ import (
 func Module() fxutil.Module {
 	return fxutil.Component(
 		fxutil.ProvideComponentConstructor(
-			registrarimpl.NewProvides,
+			registrarimpl.NewComponent,
 		),
 	)
 }

--- a/comp/logs-library/kubehealth/impl/kubehealth.go
+++ b/comp/logs-library/kubehealth/impl/kubehealth.go
@@ -24,8 +24,8 @@ func newRegistrar() *RegistrarImpl {
 	return &RegistrarImpl{}
 }
 
-// NewProvides provides a new Registrar
-func NewProvides() Provides {
+// NewComponent provides a new Registrar
+func NewComponent() Provides {
 	return Provides{
 		Comp: newRegistrar(),
 	}

--- a/comp/logs/auditor/fx/fx.go
+++ b/comp/logs/auditor/fx/fx.go
@@ -15,7 +15,7 @@ import (
 func Module() fxutil.Module {
 	return fxutil.Component(
 		fxutil.ProvideComponentConstructor(
-			auditorimpl.NewProvides,
+			auditorimpl.NewComponent,
 		),
 	)
 }

--- a/comp/logs/auditor/impl/auditor.go
+++ b/comp/logs/auditor/impl/auditor.go
@@ -111,8 +111,8 @@ func newAuditor(deps Dependencies) *registryAuditor {
 	return registryAuditor
 }
 
-// NewProvides creates a new auditor component
-func NewProvides(deps Dependencies) Provides {
+// NewComponent creates a new auditor component
+func NewComponent(deps Dependencies) Provides {
 	auditorImpl := newAuditor(deps)
 	return Provides{
 		Comp: auditorImpl,


### PR DESCRIPTION
### What does this PR do?

Renames `NewProvides` to `NewComponent` in the impl packages of two components:

- `comp/logs/auditor/impl`: `NewProvides` → `NewComponent`
- `comp/logs-library/kubehealth/impl`: `NewProvides` → `NewComponent`

Updates the corresponding `fx/fx.go` files to reference `NewComponent`.

### Motivation

Align constructor naming with the convention described in the [component creation guide](https://datadoghq.dev/datadog-agent/components/creating-components/). The standard name for the fx-wired constructor is `NewComponent`.

### Describe how you validated your changes

- Grepped for all callers of `NewProvides` in both packages — only `fx/fx.go` referenced it in each case.
- Verified with `git diff --name-only` that only the four expected files were modified: `impl/auditor.go`, `fx/fx.go` (auditor), `impl/kubehealth.go`, `fx/fx.go` (kubehealth).
- No mock files were touched.

### Additional Notes

No behavioral changes; this is a pure rename.