### PR TITLE
refactor(comp/collector/collector): export constructor as NewComponent

### DIFF
--- a/comp/collector/collector/impl/collector.go
+++ b/comp/collector/collector/impl/collector.go
@@ -88,7 +88,8 @@ type collectorImpl struct {
 	createdAt time.Time
 }
 
-type provides struct {
+// Provides defines the output types of the collector component.
+type Provides struct {
 	compdef.Out
 
 	Comp             collector.Component
@@ -99,12 +100,13 @@ type provides struct {
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(newProvides),
+		fxutil.ProvideComponentConstructor(NewComponent),
 		fxutil.ProvideOptional[collector.Component](),
 	)
 }
 
-func newProvides(deps dependencies) provides {
+// NewComponent creates a new collector component.
+func NewComponent(deps dependencies) Provides {
 	c := newCollector(deps)
 
 	var agentCheckMetadata metadata.Provider
@@ -112,7 +114,7 @@ func newProvides(deps dependencies) provides {
 		agentCheckMetadata = metadata.NewProvider(c.collectMetadata)
 	}
 
-	return provides{
+	return Provides{
 		Comp:             c,
 		StatusProvider:   status.NewInformationProvider(collectorStatus.NewProvider(c)),
 		MetadataProvider: agentCheckMetadata,


### PR DESCRIPTION
### What does this PR do?

Exports the constructor function in `comp/collector/collector/impl` from `newProvides` to `NewComponent`, and exports the `provides` struct as `Provides`.

Per the component creation guidelines at https://datadoghq.dev/datadog-agent/components/creating-components/, the constructor must be exported as `NewComponent` so it can be referenced directly by fx wiring files (e.g. `collectorimpl.NewComponent`).

### Motivation

The constructor `newProvides` was unexported, which prevents direct use by external fx files. Several consumers (`comp/otelcol/collector/fx`, `comp/otelcol/collector/fx-pipeline`, `comp/host-profiler/collector/fx`) already referenced `collectorimpl.NewComponent`, so this change aligns the implementation with both the doc convention and what callers expect.

Additionally, `revive` lint requires that an exported function does not return an unexported type, so `provides` is exported as `Provides`.

### Describe how you validated your changes

- Verified no other callers reference `collectorimpl.newProvides`
- Ran `go-fmt` and `update-go` hooks — both passed
- Only `comp/collector/collector/impl/collector.go` is changed

### Additional Notes

The `go-test` and `go-linter` pre-push hooks fail in this environment due to a missing `rtloader` build artifact and a broken `dda`/`uv` tooling installation, both unrelated to this change.