### PR TITLE
refactor(comp/core/workloadmeta): rename constructor to NewComponent

### DIFF
--- a/comp/core/workloadmeta/fx/fx.go
+++ b/comp/core/workloadmeta/fx/fx.go
@@ -31,7 +31,7 @@ func ModuleWithProvider[T any](paramsProvider func(T) wmdef.Params) fxutil.Modul
 func module(options ...fx.Option) fxutil.Module {
 	return fxutil.Component(
 		fxutil.ProvideComponentConstructor(
-			workloadmeta.NewWorkloadMeta,
+			workloadmeta.NewComponent,
 		),
 		fx.Provide(func(wmeta wmdef.Component) option.Option[wmdef.Component] {
 			return option.New(wmeta)

--- a/comp/core/workloadmeta/impl/store_test.go
+++ b/comp/core/workloadmeta/impl/store_test.go
@@ -38,7 +38,7 @@ func newWorkloadmetaObject(t *testing.T) *workloadmeta {
 		Params: wmdef.NewParams(),
 	}
 
-	return NewWorkloadMeta(deps).Comp.(*workloadmeta)
+	return NewComponent(deps).Comp.(*workloadmeta)
 }
 
 func TestHandleEvents(t *testing.T) {

--- a/comp/core/workloadmeta/impl/workloadmeta.go
+++ b/comp/core/workloadmeta/impl/workloadmeta.go
@@ -83,8 +83,8 @@ type Provider struct {
 	Endpoint      api.AgentEndpointProvider
 }
 
-// NewWorkloadMeta creates a new workloadmeta component.
-func NewWorkloadMeta(deps Dependencies) Provider {
+// NewComponent creates a new workloadmeta component.
+func NewComponent(deps Dependencies) Provider {
 	candidates := make(map[string]wmdef.Collector)
 	for _, c := range fxutil.GetAndFilterGroup(deps.Catalog) {
 		if (c.GetTargetCatalog() & deps.Params.AgentType) > 0 {

--- a/comp/core/workloadmeta/impl/workloadmeta_mock.go
+++ b/comp/core/workloadmeta/impl/workloadmeta_mock.go
@@ -25,7 +25,7 @@ type workloadMetaMock struct {
 // NewWorkloadMetaMock returns a Mock
 func NewWorkloadMetaMock(deps Dependencies) wmmock.Mock {
 	w := &workloadMetaMock{
-		workloadmeta: NewWorkloadMeta(deps).Comp.(*workloadmeta),
+		workloadmeta: NewComponent(deps).Comp.(*workloadmeta),
 	}
 	return w
 }


### PR DESCRIPTION
### What does this PR do?

Renames the constructor function in `comp/core/workloadmeta/impl` from `NewWorkloadMeta` to `NewComponent`, following the standard naming convention for Datadog Agent components described in the [component creation guide](https://datadoghq.dev/datadog-agent/components/creating-components/).

### Motivation

Standardize the workloadmeta component constructor name to `NewComponent` as required by the component V2 conventions. All component constructors should be named `NewComponent` so that the fx wiring layer (`ProvideComponentConstructor`) can reference them consistently.

### Describe how you validated your changes

- Renamed `NewWorkloadMeta` → `NewComponent` in `impl/workloadmeta.go`
- Updated the internal call in `impl/workloadmeta_mock.go`
- Updated the internal call in `impl/store_test.go`
- Updated the reference in `fx/fx.go`
- Pre-push hooks: `go-test` and `go-linter` both passed

### Additional Notes

No behavior change — this is a pure rename refactor.