### PR TITLE
Enable race instrumentation for Go tests in Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -116,6 +116,7 @@ common:release --//:release
 common --config=release
 
 test --@rules_go//go/config:race
+test --test_env=GORACE=atexit_sleep_ms=50
 
 # Local development options --------------------------------------------------------------------------------------------
 try-import %workspace%/user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -115,5 +115,7 @@ common:release --config=rust-release
 common:release --//:release
 common --config=release
 
+test --@rules_go//go/config:race
+
 # Local development options --------------------------------------------------------------------------------------------
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
### What does this PR do?

Enables equivalent of `--race` parameter for `go test` invoked unit tests in Bazel. It is set unconditionally for all `test` commands that are flowing through Bazel to ensure good cache hit rate and sharing between local dev environments and CI, the price is slightly longer build time but we do use it in CI unconditionally so it's a virtual downside. 

We do not enable it for build commands because, since it's an additional instrumentation, final binaries will be bigger with zero added value for the customers. Therefore, enabled by default for tests only.

### Motivation

We need to maintain the parity of UX and software quality between the current (legacy) build system and Bazel.