### PR TITLE
Small bounds adjustments for new CWS gates

### DIFF
--- a/test/regression/cases/quality_gate_security_mean_fs_load/experiment.yaml
+++ b/test/regression/cases/quality_gate_security_mean_fs_load/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 380 MiB
+  memory_allotment: 370 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -48,13 +48,13 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher.
-      upper_bound: "320 MiB"
+      upper_bound: "310 MiB"
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."
     bounds:
       series: avg(total_cpu_usage_millicores)
-      upper_bound: 70
+      upper_bound: 80
 
 report_links:
   - text: "bounds checks dashboard"


### PR DESCRIPTION
### What does this PR do?

- adjusts the bounds for the `security_mean_fs_load` quality gate

### Motivation

The CWS Quality Gates were introduced yesterday and bounds adjustments were expected; the source of truth is when our nightlies run. 

This adjusts the bounds according to last night's results.

### Describe how you validated your changes

Nightly results came in.

And now, CI is going to run to confirm.

### Additional Notes

Once SMP has gotten https://github.com/DataDog/datadog-agent/pull/50375 and a few nightly runs complete, we'll be passing over the quality gate ownership to CWS.
