### PR TITLE
[observer] Rename / split metric namespaces

### DIFF
--- a/comp/anomalydetection/AGENTS.md
+++ b/comp/anomalydetection/AGENTS.md
@@ -76,13 +76,15 @@ Production callers of `observer.GetHandle()` use statically-defined source names
 
 | Source | Wired from |
 |--------|------------|
-| `all-metrics` | `pkg/aggregator/demultiplexer_agent.go` |
+| `dogstatsd` | `pkg/aggregator/demultiplexer_agent.go` (DogStatsD workers) |
+| `check` | `pkg/aggregator/demultiplexer_agent.go` (core check aggregator) |
+| `agent` | internal agent telemetry namespace for `datadog.*` metrics |
 | `logs` | `logssource/impl/logssource.go` |
-| `agent-internal-logs` | `observer/impl/observer.go` (pkg/util/log tap) |
+| `agent_logs` | `observer/impl/observer.go` (pkg/util/log tap) |
 
 **Log ingestion split:**
 - **Container + kubelet logs** → `logssource` component
-- **Agent-internal logs** → `observer` taps `pkg/util/log` directly
+- **Agent internal logs** → `observer` taps `pkg/util/log` directly via `agent_logs`
 
 Both paths share filtering primitives from `internal/logsfilter/`.
 

--- a/comp/anomalydetection/AGENTS.md
+++ b/comp/anomalydetection/AGENTS.md
@@ -78,7 +78,6 @@ Production callers of `observer.GetHandle()` use statically-defined source names
 |--------|------------|
 | `dogstatsd` | `pkg/aggregator/demultiplexer_agent.go` (DogStatsD workers) |
 | `check` | `pkg/aggregator/demultiplexer_agent.go` (core check aggregator) |
-| `agent` | internal agent telemetry namespace for `datadog.*` metrics |
 | `logs` | `logssource/impl/logssource.go` |
 | `agent_logs` | `observer/impl/observer.go` (pkg/util/log tap) |
 
@@ -87,6 +86,9 @@ Production callers of `observer.GetHandle()` use statically-defined source names
 - **Agent internal logs** → `observer` taps `pkg/util/log` directly via `agent_logs`
 
 Both paths share filtering primitives from `internal/logsfilter/`.
+
+Metrics with the `datadog.*` prefix are normalized as internal agent telemetry
+and dropped before they reach observer storage.
 
 ## Reporter Model
 

--- a/comp/anomalydetection/observer/AGENTS.md
+++ b/comp/anomalydetection/observer/AGENTS.md
@@ -21,7 +21,7 @@ events to reporters injected via the `anomalydetection_reporters` Fx group.
 
 | Layer | Code | Role |
 |-------|------|------|
-| **Component** (`observerImpl`) | `impl/observer.go` | Fx lifecycle, channel dispatch, Handle factory, agent-internal log tap |
+| **Component** (`observerImpl`) | `impl/observer.go` | Fx lifecycle, channel dispatch, Handle factory, `agent_logs` tap |
 | **Engine** (`engine`) | `impl/engine.go` | Storage, detection, correlation, replay — the shared core |
 
 The engine is a plain Go struct, not an Fx component. Both the live observer
@@ -38,7 +38,7 @@ and the testbench use the same engine.
 | `impl/scheduler.go` | Scheduling policy: when to advance analysis |
 | `impl/observer.go` | Fx component: lifecycle, channel loop, handle creation, log tap |
 | `impl/component_catalog.go` | Registry of all detectors, correlators, extractors |
-| `impl/agent_logs.go` | Agent-internal log tap (source: `agent-internal-logs`) |
+| `impl/agent_logs.go` | Agent internal log tap (source: `agent_logs`) |
 | `impl/log_pattern_extractor.go` | Log → virtual metrics via pattern clustering |
 | `impl/log_metrics_extractor.go` | Log → virtual metrics via regex extraction |
 | `impl/anomaly_correlator_time_cluster.go` | Default time-proximity correlator |
@@ -100,7 +100,7 @@ are unaffected.
 4. **Extractor names must be unique.** The name is the storage namespace for
    derived metrics. Duplicates cause silent data collision.
 
-5. **Agent-internal logs are not logssource.** The internal tap is wired in
+5. **Agent internal logs are not logssource.** The internal tap is wired in
    `impl/observer.go`, gated by `anomaly_detection.logs.internal.*`.
 
 ## Testing

--- a/comp/anomalydetection/observer/def/types.go
+++ b/comp/anomalydetection/observer/def/types.go
@@ -478,7 +478,7 @@ type RawAnomalyState interface {
 const TelemetryNamespace = "telemetry"
 
 // AgentNamespace is the storage namespace used for internal agent telemetry
-// with the datadog.* metric prefix.
+// while normalizing datadog.* metrics before they are dropped.
 const AgentNamespace = "agent"
 
 // SeriesFilter specifies criteria for selecting series.
@@ -493,9 +493,9 @@ type SeriesFilter struct {
 }
 
 // WorkloadSeriesFilter returns a filter for anomaly detectors: all namespaces
-// except TelemetryNamespace and AgentNamespace.
+// except TelemetryNamespace.
 func WorkloadSeriesFilter() SeriesFilter {
-	return SeriesFilter{ExcludeNamespaces: []string{TelemetryNamespace, AgentNamespace}}
+	return SeriesFilter{ExcludeNamespaces: []string{TelemetryNamespace}}
 }
 
 // SeriesMeta describes a series discovered via ListSeries.

--- a/comp/anomalydetection/observer/def/types.go
+++ b/comp/anomalydetection/observer/def/types.go
@@ -477,6 +477,10 @@ type RawAnomalyState interface {
 // metrics (e.g. testbench UI charts). Detectors must not treat it as workload data.
 const TelemetryNamespace = "telemetry"
 
+// AgentNamespace is the storage namespace used for internal agent telemetry
+// with the datadog.* metric prefix.
+const AgentNamespace = "agent"
+
 // SeriesFilter specifies criteria for selecting series.
 type SeriesFilter struct {
 	Namespace   string            // exact match (empty = any)
@@ -489,9 +493,9 @@ type SeriesFilter struct {
 }
 
 // WorkloadSeriesFilter returns a filter for anomaly detectors: all namespaces
-// except TelemetryNamespace.
+// except TelemetryNamespace and AgentNamespace.
 func WorkloadSeriesFilter() SeriesFilter {
-	return SeriesFilter{ExcludeNamespaces: []string{TelemetryNamespace}}
+	return SeriesFilter{ExcludeNamespaces: []string{TelemetryNamespace, AgentNamespace}}
 }
 
 // SeriesMeta describes a series discovered via ListSeries.

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -256,7 +256,6 @@ func (e *engine) registerHandle(h *handle) {
 // set is:
 //   - "dogstatsd"                  (pkg/aggregator/demultiplexer_agent.go, DogStatsD workers)
 //   - "check"                      (pkg/aggregator/demultiplexer_agent.go, core check aggregator)
-//   - "agent"                      (internal agent telemetry, datadog.* prefix)
 //   - "log_metrics_extractor"      (virtual metrics from logs)
 //   - "connection_error_extractor" (connection error extractor)
 //   - "log_pattern_extractor"      (log pattern extractor)

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -254,9 +254,15 @@ func (e *engine) registerHandle(h *handle) {
 // The bounded-source assumption: every production caller of obs.GetHandle()
 // passes a statically-defined string constant. As of this writing the full
 // set is:
-//   - "all-metrics"          (pkg/aggregator/demultiplexer_agent.go)
-//   - "logs"                 (comp/anomalydetection/logssource/impl/logssource.go)
-//   - "agent-internal-logs"  (comp/anomalydetection/observer/impl/observer.go)
+//   - "dogstatsd"                  (pkg/aggregator/demultiplexer_agent.go, DogStatsD workers)
+//   - "check"                      (pkg/aggregator/demultiplexer_agent.go, core check aggregator)
+//   - "agent"                      (internal agent telemetry, datadog.* prefix)
+//   - "log_metrics_extractor"      (virtual metrics from logs)
+//   - "connection_error_extractor" (connection error extractor)
+//   - "log_pattern_extractor"      (log pattern extractor)
+//   - "logs"                       (comp/anomalydetection/logssource/impl/logssource.go)
+//   - "agent_logs"                 (comp/anomalydetection/observer/impl/observer.go)
+//   - "telemetry"                  (observer-internal debug metrics)
 //
 // If a future caller ever passes a user-controlled or per-container source
 // string, the COW map becomes unbounded and this memoisation strategy is

--- a/comp/anomalydetection/observer/impl/ingest_metrics_disabled_test.go
+++ b/comp/anomalydetection/observer/impl/ingest_metrics_disabled_test.go
@@ -88,7 +88,7 @@ func TestObserverDropsMetricsWhenIngestMetricsDisabled(t *testing.T) {
 		"log-extractor virtual metrics must keep flowing into storage even when observer.ingest_metrics.enabled=false")
 }
 
-func TestAgentMetricsUseDedicatedNamespace(t *testing.T) {
+func TestAgentMetricsAreDropped(t *testing.T) {
 	storage := newTimeSeriesStorage()
 	eng := newEngine(engineConfig{storage: storage})
 
@@ -133,8 +133,7 @@ func TestAgentMetricsUseDedicatedNamespace(t *testing.T) {
 	assert.Equal(t, "system.cpu.user", dogstatsdSeries[0].Name)
 
 	agentSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: observerdef.AgentNamespace})
-	require.Len(t, agentSeries, 1)
-	assert.Equal(t, "datadog.agent.running", agentSeries[0].Name)
+	assert.Empty(t, agentSeries)
 
 	workloadSeries := storage.ListSeries(observerdef.WorkloadSeriesFilter())
 	require.Len(t, workloadSeries, 1)

--- a/comp/anomalydetection/observer/impl/ingest_metrics_disabled_test.go
+++ b/comp/anomalydetection/observer/impl/ingest_metrics_disabled_test.go
@@ -51,10 +51,10 @@ func TestObserverDropsMetricsWhenIngestMetricsDisabled(t *testing.T) {
 	// Guarantee cleanup even if an assertion calls t.Fatal before stopFn().
 	t.Cleanup(stopFn)
 
-	h := obs.GetHandle("all-metrics")
+	h := obs.GetHandle("dogstatsd")
 
 	drop, ok := h.(*metricDropHandle)
-	require.Truef(t, ok, `GetHandle("all-metrics") returned %T, want *metricDropHandle`, h)
+	require.Truef(t, ok, `GetHandle("dogstatsd") returned %T, want *metricDropHandle`, h)
 
 	assert.True(t, drop.ObserveMetricAndReportDrop(&metricObs{
 		name:      "system.cpu.user",
@@ -79,13 +79,66 @@ func TestObserverDropsMetricsWhenIngestMetricsDisabled(t *testing.T) {
 	// so the ObserveLog above is guaranteed to be processed before we assert storage.
 	stopFn()
 
-	allMetricsSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: "all-metrics"})
-	assert.Empty(t, allMetricsSeries,
+	dogstatsdSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: "dogstatsd"})
+	assert.Empty(t, dogstatsdSeries,
 		"external metrics must not be stored when observer.ingest_metrics.enabled=false")
 
 	extractorSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: extractor.Name()})
 	require.NotEmpty(t, extractorSeries,
 		"log-extractor virtual metrics must keep flowing into storage even when observer.ingest_metrics.enabled=false")
+}
+
+func TestAgentMetricsUseDedicatedNamespace(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	eng := newEngine(engineConfig{storage: storage})
+
+	obs := &observerImpl{
+		engine:               eng,
+		obsCh:                make(chan observation, 16),
+		ingestMetricsEnabled: true,
+	}
+	obs.handleFunc = obs.innerHandle
+
+	var (
+		wg        sync.WaitGroup
+		closeOnce sync.Once
+	)
+	stopFn := func() {
+		closeOnce.Do(func() { close(obs.obsCh) })
+		wg.Wait()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		obs.run()
+	}()
+	t.Cleanup(stopFn)
+
+	h := obs.GetHandle("dogstatsd")
+	h.ObserveMetric(&metricObs{
+		name:      "system.cpu.user",
+		value:     50,
+		timestamp: 1000,
+	})
+	h.ObserveMetric(&metricObs{
+		name:      "datadog.agent.running",
+		value:     1,
+		timestamp: 1000,
+	})
+
+	stopFn()
+
+	dogstatsdSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: "dogstatsd"})
+	require.Len(t, dogstatsdSeries, 1)
+	assert.Equal(t, "system.cpu.user", dogstatsdSeries[0].Name)
+
+	agentSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: observerdef.AgentNamespace})
+	require.Len(t, agentSeries, 1)
+	assert.Equal(t, "datadog.agent.running", agentSeries[0].Name)
+
+	workloadSeries := storage.ListSeries(observerdef.WorkloadSeriesFilter())
+	require.Len(t, workloadSeries, 1)
+	assert.Equal(t, "dogstatsd", workloadSeries[0].Namespace)
 }
 
 // TestMetricDropHandle covers the metricDropHandle wrapper in isolation.

--- a/comp/anomalydetection/observer/impl/ingest_metrics_disabled_test.go
+++ b/comp/anomalydetection/observer/impl/ingest_metrics_disabled_test.go
@@ -140,6 +140,31 @@ func TestAgentMetricsAreDropped(t *testing.T) {
 	assert.Equal(t, "dogstatsd", workloadSeries[0].Namespace)
 }
 
+func TestIngestMetricSyncDropsNormalizedAgentMetrics(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	obs := &observerImpl{
+		engine: newEngine(engineConfig{storage: storage}),
+	}
+
+	obs.IngestMetricSync("dogstatsd", &metricObs{
+		name:      "system.cpu.user",
+		value:     50,
+		timestamp: 1000,
+	})
+	obs.IngestMetricSync("dogstatsd", &metricObs{
+		name:      "datadog.agent.running",
+		value:     1,
+		timestamp: 1000,
+	})
+
+	dogstatsdSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: "dogstatsd"})
+	require.Len(t, dogstatsdSeries, 1)
+	assert.Equal(t, "system.cpu.user", dogstatsdSeries[0].Name)
+
+	agentSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: observerdef.AgentNamespace})
+	assert.Empty(t, agentSeries)
+}
+
 // TestMetricDropHandle covers the metricDropHandle wrapper in isolation.
 func TestMetricDropHandle(t *testing.T) {
 	inner := &countingHandle{}

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -61,10 +61,9 @@ type Provides struct {
 
 // observation is a message sent from handles to the observer.
 type observation struct {
-	source    string
-	namespace string
-	metric    *metricObs
-	log       *logObs
+	source string
+	metric *metricObs
+	log    *logObs
 	// flush, when non-nil, is closed by the dispatch loop once this observation
 	// is reached, signalling that all prior observations have been processed.
 	flush chan struct{}
@@ -428,11 +427,7 @@ func (o *observerImpl) run() {
 		o.replayMu.Lock()
 		var requests []advanceRequest
 		if obs.metric != nil {
-			namespace := obs.namespace
-			if namespace == "" {
-				namespace = obs.source
-			}
-			requests = o.engine.IngestMetric(namespace, obs.metric)
+			requests = o.engine.IngestMetric(obs.source, obs.metric)
 		}
 		if obs.log != nil {
 			logRequests := o.engine.IngestLog(obs.source, obs.log)
@@ -829,13 +824,15 @@ func (o *observerImpl) IngestLogNoAdvance(source string, msg observerdef.LogView
 // the non-blocking channel send. Implements DebugView.
 func (o *observerImpl) IngestMetricSync(source string, sample observerdef.MetricView) {
 	name := sample.GetName()
+	if strings.HasPrefix(name, "datadog.") {
+		source = observerdef.AgentNamespace
+	}
+	if source == observerdef.AgentNamespace {
+		return
+	}
 	timestamp := sample.GetTimestampUnix()
 	if timestamp == 0 {
 		timestamp = time.Now().Unix()
-	}
-	namespace := source
-	if strings.HasPrefix(name, "datadog.") {
-		namespace = observerdef.AgentNamespace
 	}
 	mo := &metricObs{
 		name:      name,
@@ -844,7 +841,7 @@ func (o *observerImpl) IngestMetricSync(source string, sample observerdef.Metric
 		timestamp: timestamp,
 	}
 	o.replayMu.Lock()
-	requests := o.engine.IngestMetric(namespace, mo)
+	requests := o.engine.IngestMetric(source, mo)
 	for _, req := range requests {
 		_ = o.engine.advanceWithReason(req.upToSec, req.reason)
 	}
@@ -877,14 +874,16 @@ func (h *handle) ObserveMetricAndReportDrop(sample observerdef.MetricView) bool 
 	}
 
 	name := sample.GetName()
-	namespace := ""
+	source := h.source
 	if strings.HasPrefix(name, "datadog.") {
-		namespace = observerdef.AgentNamespace
+		source = observerdef.AgentNamespace
+	}
+	if source == observerdef.AgentNamespace {
+		return false
 	}
 
 	obs := observation{
-		source:    h.source,
-		namespace: namespace,
+		source: source,
 		metric: &metricObs{
 			name:      name,
 			value:     sample.GetValue(),

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -819,14 +819,19 @@ func (o *observerImpl) IngestLogNoAdvance(source string, msg observerdef.LogView
 	o.replayMu.Unlock()
 }
 
+func normalizeMetricSource(name, source string) string {
+	if strings.HasPrefix(name, "datadog.") {
+		return observerdef.AgentNamespace
+	}
+	return source
+}
+
 // IngestMetricSync feeds a metric directly into the engine, bypassing the
 // dispatch channel. Mirrors the handle.ObserveMetricAndReportDrop path without
 // the non-blocking channel send. Implements DebugView.
 func (o *observerImpl) IngestMetricSync(source string, sample observerdef.MetricView) {
 	name := sample.GetName()
-	if strings.HasPrefix(name, "datadog.") {
-		source = observerdef.AgentNamespace
-	}
+	source = normalizeMetricSource(name, source)
 	if source == observerdef.AgentNamespace {
 		return
 	}
@@ -874,10 +879,7 @@ func (h *handle) ObserveMetricAndReportDrop(sample observerdef.MetricView) bool 
 	}
 
 	name := sample.GetName()
-	source := h.source
-	if strings.HasPrefix(name, "datadog.") {
-		source = observerdef.AgentNamespace
-	}
+	source := normalizeMetricSource(name, h.source)
 	if source == observerdef.AgentNamespace {
 		return false
 	}

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -61,9 +61,10 @@ type Provides struct {
 
 // observation is a message sent from handles to the observer.
 type observation struct {
-	source string
-	metric *metricObs
-	log    *logObs
+	source    string
+	namespace string
+	metric    *metricObs
+	log       *logObs
 	// flush, when non-nil, is closed by the dispatch loop once this observation
 	// is reached, signalling that all prior observations have been processed.
 	flush chan struct{}
@@ -339,7 +340,7 @@ func NewComponent(deps Requires) Provides {
 
 	go obs.run()
 
-	// Wire agent-internal logs into the observer via the pkg/util/log tap.
+	// Wire agent_logs into the observer via the pkg/util/log tap.
 	// anomaly_detection.logs.enabled is the parent gate; without it,
 	// internal logs are also disabled. anomaly_detection.logs.internal.enabled
 	// defaults to true when unset (explicit false disables it).
@@ -350,7 +351,7 @@ func NewComponent(deps Requires) Provides {
 		maxRateHigh := cfg.GetFloat64("anomaly_detection.logs.internal.max_rate_high_priority")
 		maxRateMedium := cfg.GetFloat64("anomaly_detection.logs.internal.max_rate_medium_priority")
 		maxRateLow := cfg.GetFloat64("anomaly_detection.logs.internal.max_rate_low_priority")
-		agentLogsHandle := obs.GetHandle("agent-internal-logs")
+		agentLogsHandle := obs.GetHandle("agent_logs")
 		installAgentLogTap(agentLogsHandle, minSeverity, maxRateHigh, maxRateMedium, maxRateLow, func(priority string) {
 			obsTelemetry.recordSamplerDropped("internal", priority)
 		})
@@ -427,7 +428,11 @@ func (o *observerImpl) run() {
 		o.replayMu.Lock()
 		var requests []advanceRequest
 		if obs.metric != nil {
-			requests = o.engine.IngestMetric(obs.source, obs.metric)
+			namespace := obs.namespace
+			if namespace == "" {
+				namespace = obs.source
+			}
+			requests = o.engine.IngestMetric(namespace, obs.metric)
 		}
 		if obs.log != nil {
 			logRequests := o.engine.IngestLog(obs.source, obs.log)
@@ -824,12 +829,13 @@ func (o *observerImpl) IngestLogNoAdvance(source string, msg observerdef.LogView
 // the non-blocking channel send. Implements DebugView.
 func (o *observerImpl) IngestMetricSync(source string, sample observerdef.MetricView) {
 	name := sample.GetName()
-	if strings.HasPrefix(name, "datadog.") {
-		return
-	}
 	timestamp := sample.GetTimestampUnix()
 	if timestamp == 0 {
 		timestamp = time.Now().Unix()
+	}
+	namespace := source
+	if strings.HasPrefix(name, "datadog.") {
+		namespace = observerdef.AgentNamespace
 	}
 	mo := &metricObs{
 		name:      name,
@@ -838,7 +844,7 @@ func (o *observerImpl) IngestMetricSync(source string, sample observerdef.Metric
 		timestamp: timestamp,
 	}
 	o.replayMu.Lock()
-	requests := o.engine.IngestMetric(source, mo)
+	requests := o.engine.IngestMetric(namespace, mo)
 	for _, req := range requests {
 		_ = o.engine.advanceWithReason(req.upToSec, req.reason)
 	}
@@ -871,14 +877,14 @@ func (h *handle) ObserveMetricAndReportDrop(sample observerdef.MetricView) bool 
 	}
 
 	name := sample.GetName()
-
-	// filter internal Datadog Agent telemetry
+	namespace := ""
 	if strings.HasPrefix(name, "datadog.") {
-		return false
+		namespace = observerdef.AgentNamespace
 	}
 
 	obs := observation{
-		source: h.source,
+		source:    h.source,
+		namespace: namespace,
 		metric: &metricObs{
 			name:      name,
 			value:     sample.GetValue(),

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -1060,10 +1060,6 @@ func (s *timeSeriesStorage) RemoveSeriesByMetricName(namespace, name string) []o
 	return removed
 }
 
-func isCapacityExemptNamespace(namespace string) bool {
-	return namespace == observer.TelemetryNamespace || namespace == observer.AgentNamespace
-}
-
 // EvictToCapacity evicts the oldest series (by last written timestamp) when
 // the live series count exceeds seriesLimit, draining down to target. The band
 // between the two thresholds prevents a fan-out on every Advance when the
@@ -1078,7 +1074,7 @@ func (s *timeSeriesStorage) EvictToCapacity(seriesLimit, target int) []observer.
 	// Count first — common case is under the limit, skip allocation entirely.
 	count := 0
 	for _, st := range s.seriesIDStats {
-		if st != nil && !isCapacityExemptNamespace(st.Namespace) {
+		if st != nil {
 			count++
 		}
 	}
@@ -1092,7 +1088,7 @@ func (s *timeSeriesStorage) EvictToCapacity(seriesLimit, target int) []observer.
 	}
 	candidates := make([]entry, 0, count)
 	for _, st := range s.seriesIDStats {
-		if st == nil || isCapacityExemptNamespace(st.Namespace) {
+		if st == nil {
 			continue
 		}
 		lastTs := int64(0)

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -1060,6 +1060,10 @@ func (s *timeSeriesStorage) RemoveSeriesByMetricName(namespace, name string) []o
 	return removed
 }
 
+func isCapacityExemptNamespace(namespace string) bool {
+	return namespace == observer.TelemetryNamespace || namespace == observer.AgentNamespace
+}
+
 // EvictToCapacity evicts the oldest series (by last written timestamp) when
 // the live series count exceeds seriesLimit, draining down to target. The band
 // between the two thresholds prevents a fan-out on every Advance when the
@@ -1074,7 +1078,7 @@ func (s *timeSeriesStorage) EvictToCapacity(seriesLimit, target int) []observer.
 	// Count first — common case is under the limit, skip allocation entirely.
 	count := 0
 	for _, st := range s.seriesIDStats {
-		if st != nil {
+		if st != nil && !isCapacityExemptNamespace(st.Namespace) {
 			count++
 		}
 	}
@@ -1088,7 +1092,7 @@ func (s *timeSeriesStorage) EvictToCapacity(seriesLimit, target int) []observer.
 	}
 	candidates := make([]entry, 0, count)
 	for _, st := range s.seriesIDStats {
-		if st == nil {
+		if st == nil || isCapacityExemptNamespace(st.Namespace) {
 			continue
 		}
 		lastTs := int64(0)

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -654,6 +654,30 @@ func TestTimeSeriesStorage_RemoveSeriesByRefsEmptyOrUnknown(t *testing.T) {
 	require.Empty(t, s.RemoveSeriesByRefs([]observer.SeriesRef{-1, 999}))
 	require.Equal(t, genBefore, s.SeriesGeneration(), "no removal → no gen bump")
 }
+
+func TestTimeSeriesStorage_EvictToCapacity_SkipsInternalNamespaces(t *testing.T) {
+	s := newTimeSeriesStorageWith(StorageConfig{
+		MaxSeries:          1,
+		EvictionFloorRatio: 0,
+		PointRetentionSecs: storagePointRetentionSecs,
+	})
+
+	workA := s.Add("dogstatsd", "system.cpu.user", 1.0, 1000, []string{"host:a"})
+	s.Add(observer.AgentNamespace, "datadog.agent.running", 1.0, 1000, []string{"host:a"})
+	workB := s.Add("check", "system.mem.used", 2.0, 2000, []string{"host:a"})
+
+	freed := s.EvictDefault()
+	require.Len(t, freed, 1)
+	require.Equal(t, workA.Ref, freed[0], "oldest workload series should be evicted first")
+
+	require.Nil(t, s.GetSeriesMeta(workA.Ref))
+	require.NotNil(t, s.GetSeriesMeta(workB.Ref))
+
+	agentSeries := s.ListSeries(observer.SeriesFilter{Namespace: observer.AgentNamespace})
+	require.Len(t, agentSeries, 1, "agent namespace should not be counted toward storage eviction capacity")
+	require.Equal(t, "datadog.agent.running", agentSeries[0].Name)
+}
+
 func TestTimeSeriesStorage_AddReturnsRef(t *testing.T) {
 	// Add returns a valid Ref (>= 0) for accepted points, and the same Ref
 	// on subsequent writes. Each distinct series gets a unique Ref.

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -655,29 +655,6 @@ func TestTimeSeriesStorage_RemoveSeriesByRefsEmptyOrUnknown(t *testing.T) {
 	require.Equal(t, genBefore, s.SeriesGeneration(), "no removal → no gen bump")
 }
 
-func TestTimeSeriesStorage_EvictToCapacity_SkipsInternalNamespaces(t *testing.T) {
-	s := newTimeSeriesStorageWith(StorageConfig{
-		MaxSeries:          1,
-		EvictionFloorRatio: 0,
-		PointRetentionSecs: storagePointRetentionSecs,
-	})
-
-	workA := s.Add("dogstatsd", "system.cpu.user", 1.0, 1000, []string{"host:a"})
-	s.Add(observer.AgentNamespace, "datadog.agent.running", 1.0, 1000, []string{"host:a"})
-	workB := s.Add("check", "system.mem.used", 2.0, 2000, []string{"host:a"})
-
-	freed := s.EvictDefault()
-	require.Len(t, freed, 1)
-	require.Equal(t, workA.Ref, freed[0], "oldest workload series should be evicted first")
-
-	require.Nil(t, s.GetSeriesMeta(workA.Ref))
-	require.NotNil(t, s.GetSeriesMeta(workB.Ref))
-
-	agentSeries := s.ListSeries(observer.SeriesFilter{Namespace: observer.AgentNamespace})
-	require.Len(t, agentSeries, 1, "agent namespace should not be counted toward storage eviction capacity")
-	require.Equal(t, "datadog.agent.running", agentSeries[0].Name)
-}
-
 func TestTimeSeriesStorage_AddReturnsRef(t *testing.T) {
 	// Add returns a valid Ref (>= 0) for accepted points, and the same Ref
 	// on subsequent writes. Each distinct series gets a unique Ref.

--- a/comp/anomalydetection/observer/impl/telemetry.go
+++ b/comp/anomalydetection/observer/impl/telemetry.go
@@ -237,7 +237,7 @@ func (t *observerTelemetry) inFlightCounter(logSource string) *atomic.Int64 {
 }
 
 func classifyLogSource(source string, tags []string) string {
-	if source == "agent-internal-logs" {
+	if source == "agent_logs" {
 		return "internal"
 	}
 	for _, tag := range tags {

--- a/comp/anomalydetection/observer/impl/telemetry_test.go
+++ b/comp/anomalydetection/observer/impl/telemetry_test.go
@@ -30,7 +30,7 @@ func TestObserverTelemetry_NoopsDoNotPanic(_ *testing.T) {
 }
 
 func TestClassifyLogSource(t *testing.T) {
-	require.Equal(t, "internal", classifyLogSource("agent-internal-logs", nil))
+	require.Equal(t, "internal", classifyLogSource("agent_logs", nil))
 	require.Equal(t, "kubelet", classifyLogSource("logs", []string{"source:kubelet", "service:kubelet"}))
 	require.Equal(t, "containers", classifyLogSource("logs", []string{"source:docker"}))
 }

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -280,18 +280,18 @@ func (d *AgentDemultiplexer) SetObserver(obs observer.Component) {
 		return
 	}
 
-	metricsHandle := obs.GetHandle("all-metrics")
+	dogstatsdHandle := obs.GetHandle("dogstatsd")
 
 	// DogStatsD paths
 	for _, worker := range d.statsd.workers {
-		worker.sampler.observerHandle = metricsHandle
+		worker.sampler.observerHandle = dogstatsdHandle
 	}
 	for _, worker := range d.statsd.noAggStreamWorkers {
-		worker.observerHandle = metricsHandle
+		worker.observerHandle = dogstatsdHandle
 	}
 
 	// Go core check path (BufferedAggregator → CheckSampler)
-	d.aggregator.SetObserverHandle(metricsHandle)
+	d.aggregator.SetObserverHandle(obs.GetHandle("check"))
 }
 
 // AddAgentStartupTelemetry adds a startup event and count (in a DSD time sampler)


### PR DESCRIPTION
### What does this PR do?

> [!NOTE]
> [Context](https://datadoghq.atlassian.net/wiki/x/XAACmwE).

Refactors the namespaces we use when we ingest logs / metrics.

This replaces the old shared metric namespaces, we now have:
- `dogstatsd` -> custom metrics
- `check` -> checks
- `agent` -> internal agent metrics
- `agent_logs` -> internal agent logs

### Motivation

### Describe how you validated your changes

### Additional Notes
