### PR TITLE
[CONTINT-5411] Collect all Helm releases from ConfigMaps in the cluster

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/collect.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/collect.go
@@ -8,38 +8,30 @@
 package helm
 
 import (
-	"context"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// helmStorageLabelSelector matches the ConfigMaps that Helm uses to store its
-// release records. Helm labels every storage object (ConfigMap or Secret) with
+// Helm labels every storage object (ConfigMap or Secret) with
 // "owner=helm".
-const helmStorageLabelSelector = "owner=helm"
+const StorageLabelSelector = "owner=helm"
 
-// CollectReleases lists every Helm-managed ConfigMap across all namespaces and
-// decodes each into a Release.
+// ReleasesFromConfigMaps decodes the given Helm-managed ConfigMaps into Releases.
+// The ConfigMaps are expected to already be filtered to Helm's storage objects
+// (see StorageLabelSelector), for example by an informer's list options.
 //
 // A ConfigMap whose release data cannot be decoded is logged and skipped, so a
 // single malformed object never prevents the rest from being collected.
 //
 // Only the ConfigMap storage backend is supported for now; Helm 3 defaults to
 // Secrets, which use the same blob format and can be added later.
-func CollectReleases(ctx context.Context, client kubernetes.Interface) ([]*Release, error) {
-	configMaps, err := client.CoreV1().ConfigMaps(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
-		LabelSelector: helmStorageLabelSelector,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	releases := make([]*Release, 0, len(configMaps.Items))
-	for i := range configMaps.Items {
-		cm := &configMaps.Items[i]
+func ReleasesFromConfigMaps(configMaps []*corev1.ConfigMap) []*Release {
+	releases := make([]*Release, 0, len(configMaps))
+	for _, cm := range configMaps {
+		if cm == nil {
+			continue
+		}
 		release, err := ParseRelease(cm.Data["release"])
 		if err != nil {
 			log.Debugf("Skipping Helm ConfigMap %s/%s: %v", cm.Namespace, cm.Name, err)
@@ -47,6 +39,5 @@ func CollectReleases(ctx context.Context, client kubernetes.Interface) ([]*Relea
 		}
 		releases = append(releases, release)
 	}
-
-	return releases, nil
+	return releases
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/collect.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/collect.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+
+package helm
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// helmStorageLabelSelector matches the ConfigMaps that Helm uses to store its
+// release records. Helm labels every storage object (ConfigMap or Secret) with
+// "owner=helm".
+const helmStorageLabelSelector = "owner=helm"
+
+// CollectReleases lists every Helm-managed ConfigMap across all namespaces and
+// decodes each into a Release.
+//
+// A ConfigMap whose release data cannot be decoded is logged and skipped, so a
+// single malformed object never prevents the rest from being collected.
+//
+// Only the ConfigMap storage backend is supported for now; Helm 3 defaults to
+// Secrets, which use the same blob format and can be added later.
+func CollectReleases(ctx context.Context, client kubernetes.Interface) ([]*Release, error) {
+	configMaps, err := client.CoreV1().ConfigMaps(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+		LabelSelector: helmStorageLabelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	releases := make([]*Release, 0, len(configMaps.Items))
+	for i := range configMaps.Items {
+		cm := &configMaps.Items[i]
+		release, err := ParseRelease(cm.Data["release"])
+		if err != nil {
+			log.Debugf("Skipping Helm ConfigMap %s/%s: %v", cm.Namespace, cm.Name, err)
+			continue
+		}
+		releases = append(releases, release)
+	}
+
+	return releases, nil
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/decode.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/decode.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+
+package helm
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Ref: https://github.com/helm/helm/blob/v3.8.0/pkg/storage/driver/util.go#L56
+
+var b64 = base64.StdEncoding
+var magicGzip = []byte{0x1f, 0x8b, 0x08}
+
+// ParseRelease decodes the "release" data of a Helm-managed ConfigMap or Secret
+// into a Release. The data must be a base64-encoded, gzipped string of a valid
+// release, otherwise an error is returned.
+//
+// For backwards-compatibility with releases stored before Helm introduced
+// compression, decompression is skipped when the gzip magic header is absent.
+func ParseRelease(data string) (*Release, error) {
+	// base64 decode string
+	b, err := b64.DecodeString(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) < 4 {
+		// Avoid a panic if b[0:3] cannot be accessed.
+		return nil, fmt.Errorf("the byte array is too short (expected at least 4 bytes, got %d instead): it cannot contain a Helm release", len(b))
+	}
+
+	// For backwards compatibility with releases that were stored before
+	// compression was introduced we skip decompression if the gzip magic header
+	// is not found.
+	if bytes.Equal(b[0:3], magicGzip) {
+		r, err := gzip.NewReader(bytes.NewReader(b))
+		if err != nil {
+			return nil, err
+		}
+		defer r.Close()
+		b2, err := io.ReadAll(r)
+		if err != nil {
+			return nil, err
+		}
+		b = b2
+	}
+
+	var rls Release
+	// unmarshal release object bytes
+	if err := json.Unmarshal(b, &rls); err != nil {
+		return nil, err
+	}
+	return &rls, nil
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+
+// Package helm decodes Helm 3 releases stored in the cluster into structured Go
+// objects so the orchestrator can collect Helm release and chart information.
+package helm
+
+// The Release struct and the related ones below are a simplified version of the
+// ones found in the Helm library. Ref:
+// https://github.com/helm/helm/blob/v3.8.0/pkg/release/release.go#L22
+//
+// Defining the structs here lets us avoid importing Helm as a dependency. Unlike
+// the existing customer-facing Helm check (pkg/collector/corechecks/cluster/helm),
+// we intentionally keep the chart values, user-supplied config, templates and
+// rendered manifest, because the orchestrator surfaces them in the UI.
+
+// Release represents a single Helm release revision, as stored in the
+// "release" data key of a Helm-managed ConfigMap or Secret.
+type Release struct {
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	// Version is the release revision number. It is incremented on every
+	// "helm upgrade", and together with Namespace and Name uniquely identifies
+	// a storage object.
+	Version int    `json:"version,omitempty"`
+	Info    *Info  `json:"info,omitempty"`
+	Chart   *Chart `json:"chart,omitempty"`
+	// Config holds the user-supplied values that override the chart defaults.
+	Config map[string]interface{} `json:"config,omitempty"`
+	// Manifest is the fully rendered Kubernetes YAML applied to the cluster.
+	Manifest string `json:"manifest,omitempty"`
+}
+
+// Info describes the deployment state of a release.
+type Info struct {
+	FirstDeployed string `json:"first_deployed,omitempty"`
+	LastDeployed  string `json:"last_deployed,omitempty"`
+	Deleted       string `json:"deleted,omitempty"`
+	Description   string `json:"description,omitempty"`
+	// Status is the release status, for example "deployed", "superseded" or
+	// "failed".
+	Status string `json:"status,omitempty"`
+	Notes  string `json:"notes,omitempty"`
+}
+
+// Chart holds the chart packaged with a release.
+type Chart struct {
+	Metadata *Metadata `json:"metadata,omitempty"`
+	// Values are the default configuration values for the chart.
+	Values map[string]interface{} `json:"values,omitempty"`
+	// Templates are the chart's template files, before rendering.
+	Templates []*Template `json:"templates,omitempty"`
+}
+
+// Metadata holds the chart's identifying information.
+type Metadata struct {
+	Name         string        `json:"name,omitempty"`
+	Version      string        `json:"version,omitempty"`
+	AppVersion   string        `json:"appVersion,omitempty"`
+	Description  string        `json:"description,omitempty"`
+	APIVersion   string        `json:"apiVersion,omitempty"`
+	Dependencies []*Dependency `json:"dependencies,omitempty"`
+}
+
+// Dependency describes a chart that the parent chart depends on (a subchart).
+type Dependency struct {
+	Name       string `json:"name,omitempty"`
+	Version    string `json:"version,omitempty"`
+	Repository string `json:"repository,omitempty"`
+	// Condition is a values path (for example "datadog.operator.enabled") that
+	// toggles whether the dependency is included.
+	Condition string `json:"condition,omitempty"`
+	Enabled   bool   `json:"enabled,omitempty"`
+	Alias     string `json:"alias,omitempty"`
+}
+
+// Template is a single chart template file. Data holds the raw file contents;
+// encoding/json transparently base64-decodes it during unmarshalling.
+type Template struct {
+	Name string `json:"name,omitempty"`
+	Data []byte `json:"data,omitempty"`
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8scollector.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8scollector.go
@@ -55,6 +55,7 @@ type OrchestratorInformerFactory struct {
 	InformerFactory              informers.SharedInformerFactory
 	UnassignedPodInformerFactory informers.SharedInformerFactory
 	TerminatedPodInformerFactory informers.SharedInformerFactory
+	HelmConfigMapInformerFactory informers.SharedInformerFactory
 	DynamicInformerFactory       dynamicinformer.DynamicSharedInformerFactory
 	CRDInformerFactory           externalversions.SharedInformerFactory
 	VPAInformerFactory           vpai.SharedInformerFactory

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -256,7 +256,6 @@ func (o *OrchestratorCheck) collectAndLogHelmReleases() {
 		return
 	}
 
-	
 	o.helmInformerOnce.Do(func() {
 		cmInformer := o.orchestratorInformerFactory.HelmConfigMapInformerFactory.Core().V1().ConfigMaps()
 		go cmInformer.Informer().Run(o.stopCh)

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"sync"
 	"time"
 
 	"go.uber.org/atomic"
@@ -20,9 +21,12 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	vpai "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 
@@ -93,6 +97,8 @@ type OrchestratorCheck struct {
 	apiClient                   *apiserver.APIClient
 	orchestratorInformerFactory *collectors.OrchestratorInformerFactory
 	agentVersion                *model.AgentVersion
+	helmConfigMapLister         corev1listers.ConfigMapLister
+	helmInformerOnce            sync.Once
 }
 
 func newOrchestratorCheck(base core.CheckBase, instance *OrchestratorInstance, cfg configcomp.Component, wlmStore workloadmeta.Component, tagger tagger.Component) *OrchestratorCheck {
@@ -250,12 +256,35 @@ func (o *OrchestratorCheck) collectAndLogHelmReleases() {
 		return
 	}
 
-	releases, err := helmcollector.CollectReleases(context.TODO(), o.apiClient.Cl)
-	if err != nil {
-		_ = log.Warnc(fmt.Sprintf("helm: failed to collect releases: %v", err), orchestrator.ExtraLogContext...)
+	
+	o.helmInformerOnce.Do(func() {
+		cmInformer := o.orchestratorInformerFactory.HelmConfigMapInformerFactory.Core().V1().ConfigMaps()
+		go cmInformer.Informer().Run(o.stopCh)
+
+		informerName := apiserver.InformerName("helm-configmaps")
+		syncErrors := apiserver.SyncInformersReturnErrors(
+			map[apiserver.InformerName]cache.SharedInformer{informerName: cmInformer.Informer()},
+			o.collectorBundle.extraSyncTimeout,
+		)
+		if err := syncErrors[informerName]; err != nil {
+			_ = log.Warnc(fmt.Sprintf("helm: %v", err), orchestrator.ExtraLogContext...)
+			return
+		}
+		o.helmConfigMapLister = cmInformer.Lister()
+	})
+
+	// Skip Helm collection if the informer never synced.
+	if o.helmConfigMapLister == nil {
 		return
 	}
 
+	configMaps, err := o.helmConfigMapLister.List(labels.Everything())
+	if err != nil {
+		_ = log.Warnc(fmt.Sprintf("helm: failed to list releases: %v", err), orchestrator.ExtraLogContext...)
+		return
+	}
+
+	releases := helmcollector.ReleasesFromConfigMaps(configMaps)
 	log.Debugc(fmt.Sprintf("helm: collected %d release(s)", len(releases)), orchestrator.ExtraLogContext...)
 	for _, r := range releases {
 		var chart string
@@ -295,6 +324,11 @@ func getOrchestratorInformerFactory(apiClient *apiserver.APIClient) *collectors.
 		).String()
 	}
 
+	// Only collect the ConfigMaps that Helm uses to store its release records.
+	helmConfigMapsTweakListOptions := func(options *metav1.ListOptions) {
+		options.LabelSelector = helmcollector.StorageLabelSelector
+	}
+
 	of := &collectors.OrchestratorInformerFactory{
 		InformerFactory:              informers.NewSharedInformerFactoryWithOptions(apiClient.InformerCl, defaultResyncInterval),
 		CRDInformerFactory:           externalversions.NewSharedInformerFactory(apiClient.CRDInformerClient, defaultResyncInterval),
@@ -302,6 +336,7 @@ func getOrchestratorInformerFactory(apiClient *apiserver.APIClient) *collectors.
 		VPAInformerFactory:           vpai.NewSharedInformerFactory(apiClient.VPAInformerClient, defaultResyncInterval),
 		UnassignedPodInformerFactory: informers.NewSharedInformerFactoryWithOptions(apiClient.InformerCl, defaultResyncInterval, informers.WithTweakListOptions(unassignedPodsTweakListOptions)),
 		TerminatedPodInformerFactory: informers.NewSharedInformerFactoryWithOptions(apiClient.InformerCl, defaultResyncInterval, informers.WithTweakListOptions(terminatedPodsTweakListOptions)),
+		HelmConfigMapInformerFactory: informers.NewSharedInformerFactoryWithOptions(apiClient.InformerCl, defaultResyncInterval, informers.WithTweakListOptions(helmConfigMapsTweakListOptions)),
 	}
 
 	return of

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"os"
 	"time"
 
 	"go.uber.org/atomic"
@@ -35,6 +36,7 @@ import (
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
+	helmcollector "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 	orchcfg "github.com/DataDog/datadog-agent/pkg/orchestrator/config"
@@ -232,7 +234,41 @@ func (o *OrchestratorCheck) Run() error {
 	// Run all collectors.
 	o.collectorBundle.Run(sender)
 
+	// Helm release collection (proof-of-concept, env-gated and log-only).
+	o.collectAndLogHelmReleases()
+
 	return nil
+}
+
+// collectAndLogHelmReleases is a temporary, env-gated proof-of-concept that
+// collects every Helm release stored as a ConfigMap and logs a summary of each.
+// It is a no-op unless DD_ORCHESTRATOR_EXPLORER_HELM_RELEASES_ENABLED is "true",
+// and is intended to be replaced by a proper collector that ships the data
+// through the orchestrator pipeline.
+func (o *OrchestratorCheck) collectAndLogHelmReleases() {
+	if os.Getenv("DD_ORCHESTRATOR_EXPLORER_HELM_RELEASES_ENABLED") != "true" {
+		return
+	}
+
+	releases, err := helmcollector.CollectReleases(context.TODO(), o.apiClient.Cl)
+	if err != nil {
+		_ = log.Warnc(fmt.Sprintf("helm: failed to collect releases: %v", err), orchestrator.ExtraLogContext...)
+		return
+	}
+
+	log.Infoc(fmt.Sprintf("helm: collected %d release(s)", len(releases)), orchestrator.ExtraLogContext...)
+	for _, r := range releases {
+		var chart string
+		var templates int
+		if r.Chart != nil {
+			templates = len(r.Chart.Templates)
+			if r.Chart.Metadata != nil {
+				chart = fmt.Sprintf("%s-%s", r.Chart.Metadata.Name, r.Chart.Metadata.Version)
+			}
+		}
+		log.Infoc(fmt.Sprintf("helm: release=%s/%s revision=%d chart=%s templates=%d manifestBytes=%d",
+			r.Namespace, r.Name, r.Version, chart, templates, len(r.Manifest)), orchestrator.ExtraLogContext...)
+	}
 }
 
 // Cancel cancels the orchestrator check

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -256,7 +256,7 @@ func (o *OrchestratorCheck) collectAndLogHelmReleases() {
 		return
 	}
 
-	log.Infoc(fmt.Sprintf("helm: collected %d release(s)", len(releases)), orchestrator.ExtraLogContext...)
+	log.Debugc(fmt.Sprintf("helm: collected %d release(s)", len(releases)), orchestrator.ExtraLogContext...)
 	for _, r := range releases {
 		var chart string
 		var templates int
@@ -266,7 +266,7 @@ func (o *OrchestratorCheck) collectAndLogHelmReleases() {
 				chart = fmt.Sprintf("%s-%s", r.Chart.Metadata.Name, r.Chart.Metadata.Version)
 			}
 		}
-		log.Infoc(fmt.Sprintf("helm: release=%s/%s revision=%d chart=%s templates=%d manifestBytes=%d",
+		log.Debugc(fmt.Sprintf("helm: release=%s/%s revision=%d chart=%s templates=%d manifestBytes=%d",
 			r.Namespace, r.Name, r.Version, chart, templates, len(r.Manifest)), orchestrator.ExtraLogContext...)
 	}
 }


### PR DESCRIPTION
### What does this PR do?
- Added a data model and decoder that parse Helm releases from their stored format (base64 → gzip → JSON).
- Collect Helm releases from owner=helm ConfigMaps across all namespaces, skipping any that fail to decode.
- Gated the whole thing behind an env var and debug-log a summary per release — a POC, not yet shipping through the orchestrator pipeline.

### Motivation

https://datadoghq.atlassian.net/browse/CONTINT-5411


https://datadoghq.atlassian.net/browse/CONTINT-5410


### Describe how you validated your changes

I spun up a local Kubernetes cluster using Minikube and built the Datadog Cluster Agent image locally with my change and loaded it into the cluster.

Deployed the agent via the Datadog Helm chart, overriding the cluster-agent image with my local build and enabling the new env-gated helm release collection plus debug logging:

```
datadog:
  apiKey: "00000000000000000000000000000000"  
  clusterName: minikube-helm-test              # cluster name for orchestrator
  logLevel: debug                            
  orchestratorExplorer:
    enabled: true                              

agents:
  enabled: false                               # skip the node-agent daemonset; only the DCA is needed

clusterAgent:
  image:
    repository: datadog-test/cluster-agent     
    tag: helm
    pullPolicy: Never                          
    doNotCheckTag: true                        
  env:
    - name: DD_ORCHESTRATOR_EXPLORER_HELM_RELEASES_ENABLED
      value: "true"                            # turns on collection code
```

```
helm upgrade --install datadog-agent datadog/datadog -f dd-helm-test-values.yaml
```

Verified the collector output in the cluster-agent logs (at debug level), confirming each owner=helm ConfigMap across all namespaces was listed, decoded, and summarized with its chart name/version, template count, and rendered-manifest size:
```
kubectl logs -f deploy/datadog-agent-cluster-agent | grep -i helm
```

```
2026-06-23 14:03:39 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/orchestrator.go:259 in collectAndLogHelmReleases) | check:orchestrator | helm: collected 1 release(s)
2026-06-23 14:03:39 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/orchestrator.go:269 in collectAndLogHelmReleases) | check:orchestrator | helm: release=default/datadog-agent revision=1 chart=datadog-3.226.0 templates=86 manifestBytes=77500
```



### Additional Notes
