### PR TITLE
chore(ci): auto-publish agent-dev:master-py3-full on main

### DIFF
--- a/.gitlab/deploy/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/deploy/dev_container_deploy/docker_linux.yml
@@ -73,6 +73,8 @@ dev_master-a7:
     - docker_build_agent7_arm64
     - docker_build_agent7_jmx
     - docker_build_agent7_jmx_arm64
+    - docker_build_agent7_full
+    - docker_build_agent7_full_arm64
   variables:
     IMG_REGISTRIES: dev
   parallel:
@@ -81,18 +83,8 @@ dev_master-a7:
         IMG_DESTINATIONS: agent-dev:master-py3
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64
         IMG_DESTINATIONS: agent-dev:master-py3-jmx
-
-dev_master-a7-full:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules: !reference [.on_main]
-  needs:
-    - docker_build_agent7_full
-    - docker_build_agent7_full_arm64
-  variables:
-    IMG_REGISTRIES: dev
-    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-arm64
-    IMG_DESTINATIONS: agent-dev:main-full
+      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-arm64
+        IMG_DESTINATIONS: agent-dev:master-py3-full
 
 dev_master-fips:
   extends: .docker_publish_job_definition

--- a/.gitlab/deploy/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/deploy/dev_container_deploy/docker_linux.yml
@@ -82,6 +82,18 @@ dev_master-a7:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64
         IMG_DESTINATIONS: agent-dev:master-py3-jmx
 
+dev_master-a7-full:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules: !reference [.on_main]
+  needs:
+    - docker_build_agent7_full
+    - docker_build_agent7_full_arm64
+  variables:
+    IMG_REGISTRIES: dev
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-arm64
+    IMG_DESTINATIONS: agent-dev:main-full
+
 dev_master-fips:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy


### PR DESCRIPTION
## Summary

The `agent-dev:main-full` Docker tag was only published when manually triggered. This adds `master-py3-full` as a matrix entry in the existing `dev_master-a7` job so it publishes automatically on every main pipeline alongside `master-py3` and `master-py3-jmx`. This is needed to support ADP CI testing against the latest Agent+DDOT image.

## Test plan

- [ ] Verify `agent-dev:master-py3-full` is published on the next main pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)