### PR TITLE
[CONTP-1701] fix(tests): Remove parallel execution of deployment test suite

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
@@ -125,7 +125,6 @@ func Test_DeploymentsFakeKubernetesClient(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			testCollectEvent(t, tt.createResource, newDeploymentStore, tt.expected)
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Removes `t.Parallel()` from the deployments collector test to avoid flaky behavior from shared test setup.

### Motivation

`Test_DeploymentsFakeKubernetesClient` has [flaked](https://app.datadoghq.com/ci/test/AwAAAZ6Eum6oqiC-RAAAABhBWjZFdW02b0FBQkxxc0pwZ1FyYm1INnQAAAAkZjE5ZTg0YmEtOTE3OC00NDhmLWI2NmItMDk1Y2NmOGE5NjU5AAG4RA?colorByAttr=service&currentTab=trace&env=prod&spanID=12501443774533247836) a few times the past few months with a race error.

Also addresses [CONTP-1700](https://datadoghq.atlassian.net/browse/CONTP-1700)

### Describe how you validated your changes

- ran dda inv tests with race flag confirming tests pass.

[CONTP-1700]: https://datadoghq.atlassian.net/browse/CONTP-1700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ