### PR TITLE
chore(skills): warn against placeholder reno hashes in create-release-note

### DIFF
--- a/.claude/skills/create-release-note/SKILL.md
+++ b/.claude/skills/create-release-note/SKILL.md
@@ -50,6 +50,10 @@ reno --rel-notes-dir <directory> new <topic> --no-edit
 
 This creates a file at `<directory>/notes/<topic>-<hash>.yaml` with a template.
 
+> **Always create the file with `reno`. The `<hash>` suffix is reno's unique note ID** — it must be a real, unique 16-character hex string that `reno` generates for you. Never hand-write a placeholder like `a1b2c3d4e5f6a7b8` or any sequential/guessed value: reno treats the suffix as the note's UID and fails `release-note-check` with a "UID collision" when two notes share one (this placeholder has broken `main` more than once).
+>
+> If `reno` is not installed, install it rather than creating the file by hand: `pip install reno` (see the [contributing guide](https://datadoghq.dev/datadog-agent/guidelines/contributing/#reno)). Only if you genuinely cannot install it, generate a real random suffix with `openssl rand -hex 8` and name the file `<topic>-<hash>.yaml` — never a placeholder.
+
 Then **replace the template content** with only the relevant section. Remove all unused sections (don't leave them commented out — reno template comments are noisy).
 
 **Final file format:**


### PR DESCRIPTION
### What does this PR do?

Adds a warning and clearer guidance to the `create-release-note` skill (`.claude/skills/create-release-note/SKILL.md`) about the reno note hash:
- Never hand-write a placeholder/guessed suffix (e.g. `a1b2c3d4e5f6a7b8`) — reno uses the filename suffix as the note's unique ID.
- If `reno` isn't installed, install it (`pip install reno`) instead of creating the file by hand; `openssl rand -hex 8` is documented only as a last-resort fallback.

### Motivation

The skill told users/agents to run `reno new` but had no guidance for when `reno` is unavailable and no warning against placeholder hashes. When reno was missing, the note got created by hand with the placeholder suffix `a1b2c3d4e5f6a7b8`. Reno treats the suffix as the note's UID, so this placeholder collides with other notes using the same value and fails `release-note-check` on `main`. This has happened more than once (e.g. #52024, and again recently), so fixing the skill prevents recurrence.

### Describe how you validated your changes

Documentation-only change to a skill file; no code impact.
