### PR TITLE
perf(rtloader): avoid redundant allocation in as_string for Python str conversion

### DIFF
--- a/releasenotes/notes/optimize-rtloader-string-conversion-5e69952973fb8814.yaml
+++ b/releasenotes/notes/optimize-rtloader-string-conversion-5e69952973fb8814.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Reduced memory allocations when converting Python strings to C strings
+    across the RTLoader boundary.

--- a/rtloader/common/stringutils.c
+++ b/rtloader/common/stringutils.c
@@ -31,31 +31,23 @@ char *as_string(PyObject *object)
         return NULL;
     }
 
-    char *retval = NULL;
-
-    PyObject *temp_bytes = NULL;
-
     if (PyBytes_Check(object)) {
-        // We already have an encoded string, we suppose it has the correct encoding (UTF-8)
-        temp_bytes = object;
-        Py_INCREF(temp_bytes);
+        // Already encoded; we assume the correct encoding (UTF-8). PyBytes_AS_STRING borrows the
+        // internal buffer, which stays valid while the caller holds a reference to `object`.
+        return strdupe(PyBytes_AS_STRING(object));
     } else if (PyUnicode_Check(object)) {
-        // Encode the Unicode string that was given
-        temp_bytes = PyUnicode_AsEncodedString(object, "UTF-8", "strict");
-        if (temp_bytes == NULL) {
-            // PyUnicode_AsEncodedString might raise an error if the codec raised an
-            // exception
+        // PyUnicode_AsUTF8 returns a borrowed, NUL-terminated UTF-8 buffer cached on the unicode
+        // object. It uses strict error handling, so strings that cannot be encoded as UTF-8
+        // (e.g. lone surrogates) return NULL.
+        const char *utf8 = PyUnicode_AsUTF8(object);
+        if (utf8 == NULL) {
             PyErr_Clear();
             return NULL;
         }
-    } else {
-        return NULL;
+        return strdupe(utf8);
     }
 
-    retval = strdupe(PyBytes_AS_STRING(temp_bytes));
-    Py_XDECREF(temp_bytes);
-
-    return retval;
+    return NULL;
 }
 
 int init_stringutils(void) {


### PR DESCRIPTION
### What does this PR do?

Optimizes the Python `str` → C string conversion in RTLoader's `as_string`
(`rtloader/common/stringutils.c`) to avoid a redundant per-call allocation.

The unicode branch previously called `PyUnicode_AsEncodedString(object, "UTF-8", "strict")`,
which builds and immediately frees a transient `bytes` object on every call, and then copied
that buffer into the owned `char*` returned to callers (two allocations). It now uses
`PyUnicode_AsUTF8`, which returns a borrowed, NUL-terminated UTF-8 buffer cached on the
unicode object, so only the single owned copy is allocated.

The `bytes` branch is also slightly simplified: the unnecessary `Py_INCREF`/`Py_XDECREF`
pair is removed, since the borrowed buffer stays valid while the caller holds the object.

There is no API or behavior change: `as_string` still returns an owned `char*` that callers
free, encoding/error semantics are identical (strict UTF-8; non-encodable strings such as
lone surrogates return `NULL`), and embedded-NUL truncation is unchanged.

### Motivation

`as_string` is on a hot path — it is invoked for every metric/event/service-check tag,
event-dict field, subprocess arg/env, external tag, and every check result/warning/attr
string crossing the Python/C boundary. Halving the per-call allocation count for the common
`str` case reduces allocation churn for every Python integration.

### Describe how you validated your changes

**Regression tests** — built and ran the full RTLoader test suite in the
`datadog-agent-devenv` container (Linux arm64, CPython 3.12.13). All packages pass,
including the `aggregator` suite that exercises tag/event conversion and the
`helpers.AssertMemoryUsage` leak checks:

```
ok  rtloader/test/init          ok  rtloader/test/util
ok  rtloader/test/rtloader      ok  rtloader/test/uutil
ok  rtloader/test/aggregator    ok  rtloader/test/common
ok  rtloader/test/datadog_agent ok  rtloader/test/tagger
ok  rtloader/test/kubeutil      ok  rtloader/test/containers
```

**Microbenchmark** — a standalone harness embeds CPython, implements both the old and new
functions, installs a counting allocator hooking the pymalloc OBJ domain, and verifies
byte-identical output and refcount stability. It sweeps realistic tag sizes and runs 30
interleaved OLD/NEW trials of 300,000 iterations each (Linux arm64, gcc 11.4, CPython
3.12.13), reporting mean ± stddev and a Welch t-statistic.

The **per-call allocation count is deterministic**: the unicode path drops from exactly
1 pymalloc (OBJ-domain) allocation per call to 0 for ASCII strings, independent of length.
Timing differences are large and highly significant (|t| ≫ 2 at every size):

| String size | same object (cache reused) | fresh object (convert once) | allocs/call (old→new) |
|---|---|---|---|
| 8 chars   | 59→13 ns (−79%, t=67)  | 83→60 ns (−28%, t=28) | 1 → 0 |
| 28 chars  | 59→14 ns (−77%, t=108) | 91→66 ns (−28%, t=35) | 1 → 0 |
| 64 chars  | 59→13 ns (−77%, t=118) | 86→62 ns (−28%, t=56) | 1 → 0 |
| 200 chars | 60→15 ns (−75%, t=108) | 91→67 ns (−27%, t=50) | 1 → 0 |

The improvement is consistent across the realistic tag-size range because, for ASCII, the
borrowed UTF-8 buffer is the string's existing internal buffer and the surviving owned-copy
allocation is identical in both implementations. (Timings were measured in a virtualized
Linux environment without CPU pinning, so absolute ns figures carry some jitter; the
deterministic allocation counts and the very large t-statistics are the primary evidence.)

<details>
<summary>Microbenchmark source (<code>bench_stats.c</code>)</summary>

Build and run with:

```bash
cc -O2 -I/usr/include/python3.12 bench_stats.c -o bench_stats -L/usr/lib/aarch64-linux-gnu -lpython3.12 -lm
./bench_stats
```

```c
// Statistical microbenchmark for rtloader's as_string unicode path.
// Sweeps realistic tag string sizes and runs many interleaved trials,
// reporting mean +/- stddev, min, deterministic allocation counts, and a
// Welch t-statistic for the OLD-vs-NEW timing difference.

#include <Python.h>
#include <math.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <time.h>

static long g_obj_allocs = 0;
static PyMemAllocatorEx g_obj_orig;

static void *obj_malloc(void *ctx, size_t size)
{
    g_obj_allocs++;
    return g_obj_orig.malloc(g_obj_orig.ctx, size);
}
static void *obj_calloc(void *ctx, size_t n, size_t size)
{
    g_obj_allocs++;
    return g_obj_orig.calloc(g_obj_orig.ctx, n, size);
}
static void *obj_realloc(void *ctx, void *ptr, size_t size)
{
    g_obj_allocs++;
    return g_obj_orig.realloc(g_obj_orig.ctx, ptr, size);
}
static void obj_free(void *ctx, void *ptr)
{
    g_obj_orig.free(g_obj_orig.ctx, ptr);
}

static void install_counter(void)
{
    PyMem_GetAllocator(PYMEM_DOMAIN_OBJ, &g_obj_orig);
    PyMemAllocatorEx obj = { NULL, obj_malloc, obj_calloc, obj_realloc, obj_free };
    PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &obj);
}

static char *strdupe(const char *s1)
{
    char *s2 = (char *)malloc(strlen(s1) + 1);
    if (!s2) {
        return NULL;
    }
    return strcpy(s2, s1);
}

static char *as_string_old(PyObject *object)
{
    PyObject *temp_bytes = PyUnicode_AsEncodedString(object, "UTF-8", "strict");
    if (temp_bytes == NULL) {
        PyErr_Clear();
        return NULL;
    }
    char *retval = strdupe(PyBytes_AS_STRING(temp_bytes));
    Py_XDECREF(temp_bytes);
    return retval;
}

static char *as_string_new(PyObject *object)
{
    const char *utf8 = PyUnicode_AsUTF8(object);
    if (utf8 == NULL) {
        PyErr_Clear();
        return NULL;
    }
    return strdupe(utf8);
}

static double now_ns(void)
{
    struct timespec ts;
    clock_gettime(CLOCK_MONOTONIC, &ts);
    return (double)ts.tv_sec * 1e9 + (double)ts.tv_nsec;
}

typedef char *(*as_string_fn)(PyObject *);

// one trial = iters conversions of the SAME live object; returns ns/op
static double trial_same(as_string_fn fn, PyObject *obj, long iters)
{
    double t0 = now_ns();
    for (long i = 0; i < iters; i++) {
        free(fn(obj));
    }
    return (now_ns() - t0) / (double)iters;
}

// one trial = iters (create fresh str -> convert -> free); returns ns/op
static double trial_fresh(as_string_fn fn, const char *src, long iters)
{
    double t0 = now_ns();
    for (long i = 0; i < iters; i++) {
        PyObject *obj = PyUnicode_FromString(src);
        free(fn(obj));
        Py_DECREF(obj);
    }
    return (now_ns() - t0) / (double)iters;
}

static void stats(const double *x, int n, double *mean, double *sd, double *mn)
{
    double s = 0, m = 1e30;
    for (int i = 0; i < n; i++) {
        s += x[i];
        if (x[i] < m) {
            m = x[i];
        }
    }
    *mean = s / n;
    double v = 0;
    for (int i = 0; i < n; i++) {
        v += (x[i] - *mean) * (x[i] - *mean);
    }
    *sd = sqrt(v / (n - 1));  // sample stddev
    *mn = m;
}

#define TRIALS 30
#define ITERS 300000

// Welch t-statistic for difference of means (unequal variance)
static double welch_t(double m1, double s1, double m2, double s2, int n)
{
    return (m1 - m2) / sqrt((s1 * s1) / n + (s2 * s2) / n);
}

static void run_size(int nchars)
{
    char *src = (char *)malloc(nchars + 1);
    // realistic tag-like content: "key:" then filler, ASCII
    const char *seed = "kube_namespace:datadog-agent.pod-7f9c8d6b5a-xyz12";
    for (int i = 0; i < nchars; i++) {
        src[i] = seed[i % (int)strlen(seed)];
    }
    src[nchars] = '\0';

    PyObject *obj = PyUnicode_FromString(src);

    double old_s[TRIALS], new_s[TRIALS], old_f[TRIALS], new_f[TRIALS];

    // warmup (also populates utf8 cache for the same-object case)
    for (int i = 0; i < 3; i++) {
        free(as_string_old(obj));
        free(as_string_new(obj));
    }

    // interleave OLD/NEW per trial to cancel thermal/scheduling drift
    for (int t = 0; t < TRIALS; t++) {
        old_s[t] = trial_same(as_string_old, obj, ITERS);
        new_s[t] = trial_same(as_string_new, obj, ITERS);
        old_f[t] = trial_fresh(as_string_old, src, ITERS);
        new_f[t] = trial_fresh(as_string_new, src, ITERS);
    }

    // deterministic allocation counts (one representative measured loop each)
    g_obj_allocs = 0;
    for (long i = 0; i < ITERS; i++)
        free(as_string_old(obj));
    long old_alloc = g_obj_allocs;
    g_obj_allocs = 0;
    for (long i = 0; i < ITERS; i++)
        free(as_string_new(obj));
    long new_alloc = g_obj_allocs;

    double om, os, omn, nm, ns, nmn;
    printf("\n=== string size: %d chars ===\n", nchars);

    stats(old_s, TRIALS, &om, &os, &omn);
    stats(new_s, TRIALS, &nm, &ns, &nmn);
    printf("  [same object]  OLD %6.2f +/- %4.2f (min %6.2f) | NEW %6.2f +/- %4.2f (min %6.2f) ns/op"
           "  -> %+.0f%%  t=%.1f\n",
           om, os, omn, nm, ns, nmn, 100.0 * (nm - om) / om, welch_t(om, os, nm, ns, TRIALS));
    printf("                 pymalloc(OBJ)/call: OLD %.2f  NEW %.2f\n",
           (double)old_alloc / ITERS, (double)new_alloc / ITERS);

    stats(old_f, TRIALS, &om, &os, &omn);
    stats(new_f, TRIALS, &nm, &ns, &nmn);
    printf("  [fresh object] OLD %6.2f +/- %4.2f (min %6.2f) | NEW %6.2f +/- %4.2f (min %6.2f) ns/op"
           "  -> %+.0f%%  t=%.1f\n",
           om, os, omn, nm, ns, nmn, 100.0 * (nm - om) / om, welch_t(om, os, nm, ns, TRIALS));

    Py_DECREF(obj);
    free(src);
}

int main(void)
{
    Py_Initialize();
    install_counter();

    printf("trials=%d, iters/trial=%d, interleaved OLD/NEW\n", TRIALS, ITERS);
    printf("(|t| > ~2.0 => difference significant at ~95%%; allocation counts are exact/deterministic)\n");

    int sizes[] = { 8, 28, 64, 200 };
    for (int i = 0; i < (int)(sizeof(sizes) / sizeof(sizes[0])); i++) {
        run_size(sizes[i]);
    }

    Py_Finalize();
    return 0;
}
```

Raw output:

```
trials=30, iters/trial=300000, interleaved OLD/NEW
(|t| > ~2.0 => difference significant at ~95%; allocation counts are exact/deterministic)

=== string size: 8 chars ===
  [same object]  OLD  60.61 +/- 3.89 (min  55.62) | NEW  13.03 +/- 0.36 (min  12.16) ns/op  -> -79%  t=66.6
                 pymalloc(OBJ)/call: OLD 1.00  NEW 0.00
  [fresh object] OLD  83.20 +/- 2.68 (min  79.24) | NEW  59.69 +/- 3.70 (min  55.08) ns/op  -> -28%  t=28.2

=== string size: 28 chars ===
  [same object]  OLD  59.20 +/- 2.21 (min  54.62) | NEW  13.90 +/- 0.63 (min  13.06) ns/op  -> -77%  t=107.8
                 pymalloc(OBJ)/call: OLD 1.00  NEW 0.00
  [fresh object] OLD  90.95 +/- 2.73 (min  85.75) | NEW  65.75 +/- 2.83 (min  60.36) ns/op  -> -28%  t=35.1

=== string size: 64 chars ===
  [same object]  OLD  59.20 +/- 2.06 (min  55.34) | NEW  13.48 +/- 0.48 (min  12.82) ns/op  -> -77%  t=118.3
                 pymalloc(OBJ)/call: OLD 1.00  NEW 0.00
  [fresh object] OLD  85.56 +/- 1.52 (min  83.27) | NEW  61.50 +/- 1.81 (min  58.08) ns/op  -> -28%  t=55.8

=== string size: 200 chars ===
  [same object]  OLD  59.68 +/- 2.25 (min  56.93) | NEW  15.00 +/- 0.29 (min  14.64) ns/op  -> -75%  t=107.7
                 pymalloc(OBJ)/call: OLD 1.00  NEW 0.00
  [fresh object] OLD  91.49 +/- 2.37 (min  88.15) | NEW  66.88 +/- 1.24 (min  65.06) ns/op  -> -27%  t=50.4
```

</details>

### Additional Notes

`PyUnicode_AsUTF8` has been available since Python 3.3, and Python 2 support has already
been removed from RTLoader, so there is no version concern. The conversion runs under the
GIL, so the borrowed-buffer lifetime introduces no new locking or aliasing concerns.