### PR TITLE
Migrate `cmd/agent/subcommands/snmp` and its dependencies

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -181,7 +181,6 @@ exports_files(["go.mod"])
 # gazelle:exclude comp/process/types
 # gazelle:exclude comp/remote-config/rcservicemrf/fx
 # gazelle:exclude comp/snmpscanmanager/fx
-# gazelle:exclude comp/snmpscanmanager/impl
 # gazelle:exclude comp/softwareinventory/fx
 # gazelle:exclude comp/softwareinventory/impl
 # gazelle:exclude comp/systray/systray/fx

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -184,7 +184,6 @@ exports_files(["go.mod"])
 # gazelle:exclude comp/snmpscanmanager/fx
 # gazelle:exclude comp/snmpscanmanager/impl
 # gazelle:exclude comp/snmptraps/formatter/fx
-# gazelle:exclude comp/snmptraps/formatter/impl
 # gazelle:exclude comp/snmptraps/forwarder/fx
 # gazelle:exclude comp/snmptraps/forwarder/impl
 # gazelle:exclude comp/snmptraps/listener/fx

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -57,7 +57,6 @@ exports_files(["go.mod"])
 # gazelle:exclude cmd/agent/subcommands/jmx
 # gazelle:exclude cmd/agent/subcommands/processchecks
 # gazelle:exclude cmd/agent/subcommands/run
-# gazelle:exclude cmd/agent/subcommands/snmp
 # gazelle:exclude cmd/agent/windows
 # gazelle:exclude cmd/cluster-agent
 # gazelle:exclude cmd/cluster-agent-cloudfoundry

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -189,7 +189,6 @@ exports_files(["go.mod"])
 # gazelle:exclude comp/snmptraps/forwarder/impl
 # gazelle:exclude comp/snmptraps/listener/fx
 # gazelle:exclude comp/snmptraps/listener/impl
-# gazelle:exclude comp/snmptraps/senderhelper
 # gazelle:exclude comp/snmptraps/server/fx
 # gazelle:exclude comp/snmptraps/server/impl
 # gazelle:exclude comp/snmptraps/status/fx

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -180,7 +180,6 @@ exports_files(["go.mod"])
 # gazelle:exclude comp/process/submitter
 # gazelle:exclude comp/process/types
 # gazelle:exclude comp/remote-config/rcservicemrf/fx
-# gazelle:exclude comp/snmpscanmanager/fx
 # gazelle:exclude comp/softwareinventory/fx
 # gazelle:exclude comp/softwareinventory/impl
 # gazelle:exclude comp/systray/systray/fx

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -185,8 +185,6 @@ exports_files(["go.mod"])
 # gazelle:exclude comp/snmpscanmanager/impl
 # gazelle:exclude comp/snmptraps/forwarder/fx
 # gazelle:exclude comp/snmptraps/forwarder/impl
-# gazelle:exclude comp/snmptraps/listener/fx
-# gazelle:exclude comp/snmptraps/listener/impl
 # gazelle:exclude comp/snmptraps/server/fx
 # gazelle:exclude comp/snmptraps/server/impl
 # gazelle:exclude comp/softwareinventory/fx

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -180,7 +180,6 @@ exports_files(["go.mod"])
 # gazelle:exclude comp/process/submitter
 # gazelle:exclude comp/process/types
 # gazelle:exclude comp/remote-config/rcservicemrf/fx
-# gazelle:exclude comp/snmpscan/fx
 # gazelle:exclude comp/snmpscanmanager/fx
 # gazelle:exclude comp/snmpscanmanager/impl
 # gazelle:exclude comp/softwareinventory/fx

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -183,8 +183,6 @@ exports_files(["go.mod"])
 # gazelle:exclude comp/snmpscan/fx
 # gazelle:exclude comp/snmpscanmanager/fx
 # gazelle:exclude comp/snmpscanmanager/impl
-# gazelle:exclude comp/snmptraps/server/fx
-# gazelle:exclude comp/snmptraps/server/impl
 # gazelle:exclude comp/softwareinventory/fx
 # gazelle:exclude comp/softwareinventory/impl
 # gazelle:exclude comp/systray/systray/fx

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -183,7 +183,6 @@ exports_files(["go.mod"])
 # gazelle:exclude comp/snmpscan/fx
 # gazelle:exclude comp/snmpscanmanager/fx
 # gazelle:exclude comp/snmpscanmanager/impl
-# gazelle:exclude comp/snmptraps/formatter/fx
 # gazelle:exclude comp/snmptraps/forwarder/fx
 # gazelle:exclude comp/snmptraps/forwarder/impl
 # gazelle:exclude comp/snmptraps/listener/fx

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -189,8 +189,6 @@ exports_files(["go.mod"])
 # gazelle:exclude comp/snmptraps/listener/impl
 # gazelle:exclude comp/snmptraps/server/fx
 # gazelle:exclude comp/snmptraps/server/impl
-# gazelle:exclude comp/snmptraps/status/fx
-# gazelle:exclude comp/snmptraps/status/impl
 # gazelle:exclude comp/softwareinventory/fx
 # gazelle:exclude comp/softwareinventory/impl
 # gazelle:exclude comp/systray/systray/fx

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -183,8 +183,6 @@ exports_files(["go.mod"])
 # gazelle:exclude comp/snmpscan/fx
 # gazelle:exclude comp/snmpscanmanager/fx
 # gazelle:exclude comp/snmpscanmanager/impl
-# gazelle:exclude comp/snmptraps/forwarder/fx
-# gazelle:exclude comp/snmptraps/forwarder/impl
 # gazelle:exclude comp/snmptraps/server/fx
 # gazelle:exclude comp/snmptraps/server/impl
 # gazelle:exclude comp/softwareinventory/fx

--- a/cmd/agent/subcommands/snmp/BUILD.bazel
+++ b/cmd/agent/subcommands/snmp/BUILD.bazel
@@ -1,0 +1,56 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "snmp",
+    srcs = [
+        "command.go",
+        "optionsflag.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/cmd/agent/subcommands/snmp",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/agent/command",
+        "//comp/core",
+        "//comp/core/config",
+        "//comp/core/hostname/hostnameimpl",
+        "//comp/core/ipc/def",
+        "//comp/core/ipc/fx",
+        "//comp/core/log/def",
+        "//comp/core/tagger/fx-noop",
+        "//comp/forwarder/eventplatform/def",
+        "//comp/forwarder/eventplatform/fx",
+        "//comp/forwarder/eventplatformreceiver/impl",
+        "//comp/forwarder/orchestrator/def",
+        "//comp/forwarder/orchestrator/impl",
+        "//comp/haagent/fx",
+        "//comp/serializer/logscompression/fx",
+        "//comp/serializer/metricscompression/fx",
+        "//comp/snmpscan/def",
+        "//comp/snmpscan/fx",
+        "//pkg/networkdevice/metadata",
+        "//pkg/snmp/analyzer",
+        "//pkg/snmp/snmpparse",
+        "//pkg/util/fxutil",
+        "@com_github_gosnmp_gosnmp//:gosnmp",
+        "@com_github_spf13_cobra//:cobra",
+        "@org_golang_x_term//:term",
+        "@org_uber_go_fx//:fx",
+    ],
+)
+
+go_test(
+    name = "snmp_test",
+    srcs = [
+        "command_test.go",
+        "optionsflag_test.go",
+    ],
+    embed = [":snmp"],
+    gotags = ["test"],
+    deps = [
+        "//cmd/agent/command",
+        "//pkg/snmp/snmpparse",
+        "//pkg/util/fxutil",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/comp/forwarder/orchestrator/impl/BUILD.bazel
+++ b/comp/forwarder/orchestrator/impl/BUILD.bazel
@@ -1,21 +1,28 @@
-# gazelle:ignore
-# This BUILD.bazel is maintained manually because forwarder_orchestrator.go
-# requires //go:build orchestrator and depends on pkg/orchestrator/config which
-# has no Bazel support. Only the !orchestrator variant is Bazel-buildable.
 load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "impl",
     srcs = [
         "forwarder_no_orchestrator.go",
+        "forwarder_orchestrator.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/impl",
     visibility = ["//visibility:public"],
     deps = [
+        "//comp/core/config",
+        "//comp/core/log/def",
+        "//comp/core/secrets/def",
+        "//comp/core/tagger/def",
+        "//comp/core/tagger/types",
         "//comp/def",
         "//comp/forwarder/defaultforwarder/def",
+        "//comp/forwarder/defaultforwarder/impl",
         "//comp/forwarder/defaultforwarder/noop-impl",
+        "//comp/forwarder/defaultforwarder/resolver",
         "//comp/forwarder/orchestrator/def",
+        "//pkg/config/env",
+        "//pkg/orchestrator/config",
+        "//pkg/process/util/api/config",
         "//pkg/util/fxutil",
         "//pkg/util/option",
         "@org_uber_go_fx//:fx",

--- a/comp/snmpscan/fx/BUILD.bazel
+++ b/comp/snmpscan/fx/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmpscan/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/snmpscan/def",
+        "//comp/snmpscan/impl",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/snmpscanmanager/fx/BUILD.bazel
+++ b/comp/snmpscanmanager/fx/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmpscanmanager/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/snmpscanmanager/def",
+        "//comp/snmpscanmanager/impl",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/snmpscanmanager/impl/BUILD.bazel
+++ b/comp/snmpscanmanager/impl/BUILD.bazel
@@ -1,0 +1,62 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "impl",
+    srcs = [
+        "devicescan.go",
+        "flare.go",
+        "mocks.go",
+        "scanscheduler.go",
+        "snmpconfigprovider.go",
+        "snmpscanmanager.go",
+        "status.go",
+    ],
+    embedsrcs = [
+        "status_templates/snmpscanmanager.tmpl",
+        "status_templates/snmpscanmanagerHTML.tmpl",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmpscanmanager/impl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/core/flare/types",
+        "//comp/core/ipc/def",
+        "//comp/core/log/def",
+        "//comp/core/status",
+        "//comp/def",
+        "//comp/snmpscan/def",
+        "//comp/snmpscanmanager/def",
+        "//pkg/networkdevice/metadata",
+        "//pkg/persistentcache",
+        "//pkg/snmp/gosnmplib",
+        "//pkg/snmp/snmpparse",
+        "@com_github_stretchr_testify//mock",
+    ],
+)
+
+go_test(
+    name = "impl_test",
+    srcs = [
+        "devicescan_test.go",
+        "flare_test.go",
+        "scanscheduler_test.go",
+        "snmpscanmanager_test.go",
+        "status_test.go",
+    ],
+    embed = [":impl"],
+    gotags = ["test"],
+    deps = [
+        "//comp/core/flare/helpers",
+        "//comp/core/ipc/mock",
+        "//comp/core/log/mock",
+        "//comp/def",
+        "//comp/snmpscan/mock",
+        "//comp/snmpscanmanager/def",
+        "//pkg/config/mock",
+        "//pkg/persistentcache",
+        "//pkg/snmp/gosnmplib",
+        "//pkg/snmp/snmpparse",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//mock",
+    ],
+)

--- a/comp/snmptraps/BUILD.bazel
+++ b/comp/snmptraps/BUILD.bazel
@@ -1,1 +1,29 @@
-# gazelle:ignore
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "snmptraps",
+    srcs = ["bundle.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmptraps",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/snmptraps/server/fx",
+        "//pkg/util/fxutil",
+    ],
+)
+
+go_test(
+    name = "snmptraps_test",
+    srcs = ["bundle_test.go"],
+    embed = [":snmptraps"],
+    gotags = ["test"],
+    deps = [
+        "//comp/aggregator/demultiplexer/impl",
+        "//comp/core/config",
+        "//comp/core/hostname/hostnameimpl",
+        "//comp/core/log/def",
+        "//comp/core/log/mock",
+        "//comp/forwarder/defaultforwarder/mock",
+        "//pkg/util/fxutil",
+        "@org_uber_go_fx//:fx",
+    ],
+)

--- a/comp/snmptraps/formatter/fx/BUILD.bazel
+++ b/comp/snmptraps/formatter/fx/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = [
+        "fx.go",
+        "fx_mock.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/formatter/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/snmptraps/formatter/def",
+        "//comp/snmptraps/formatter/impl",
+        "//pkg/util/fxutil",
+        "@org_uber_go_fx//:fx",
+    ],
+)

--- a/comp/snmptraps/formatter/impl/BUILD.bazel
+++ b/comp/snmptraps/formatter/impl/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "impl",
+    srcs = [
+        "formatter.go",
+        "mock.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/formatter/impl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/aggregator/demultiplexer/def",
+        "//comp/core/log/def",
+        "//comp/def",
+        "//comp/snmptraps/formatter/def",
+        "//comp/snmptraps/oidresolver/def",
+        "//comp/snmptraps/packet",
+        "//pkg/aggregator/sender",
+        "@com_github_gosnmp_gosnmp//:gosnmp",
+    ],
+)
+
+go_test(
+    name = "impl_test",
+    srcs = [
+        "formatter_test.go",
+        "mock_test.go",
+    ],
+    embed = [":impl"],
+    gotags = ["test"],
+    deps = [
+        "//comp/core/log/mock",
+        "//comp/snmptraps/formatter/def",
+        "//comp/snmptraps/oidresolver/def",
+        "//comp/snmptraps/oidresolver/fx",
+        "//comp/snmptraps/packet",
+        "//comp/snmptraps/senderhelper",
+        "//pkg/aggregator/mocksender",
+        "//pkg/util/fxutil",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_gosnmp_gosnmp//:gosnmp",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_uber_go_fx//:fx",
+    ],
+)

--- a/comp/snmptraps/forwarder/fx/BUILD.bazel
+++ b/comp/snmptraps/forwarder/fx/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/forwarder/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/snmptraps/forwarder/impl",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/snmptraps/forwarder/impl/BUILD.bazel
+++ b/comp/snmptraps/forwarder/impl/BUILD.bazel
@@ -1,0 +1,43 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "impl",
+    srcs = ["forwarder.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/forwarder/impl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/aggregator/demultiplexer/def",
+        "//comp/core/log/def",
+        "//comp/def",
+        "//comp/forwarder/eventplatform/def",
+        "//comp/snmptraps/config/def",
+        "//comp/snmptraps/formatter/def",
+        "//comp/snmptraps/forwarder/def",
+        "//comp/snmptraps/listener/def",
+        "//comp/snmptraps/packet",
+        "//pkg/aggregator/sender",
+    ],
+)
+
+go_test(
+    name = "impl_test",
+    srcs = ["forwarder_test.go"],
+    embed = [":impl"],
+    gotags = ["test"],
+    deps = [
+        "//comp/forwarder/eventplatform/def",
+        "//comp/snmptraps/config/fx",
+        "//comp/snmptraps/formatter/def",
+        "//comp/snmptraps/formatter/fx",
+        "//comp/snmptraps/forwarder/def",
+        "//comp/snmptraps/listener/def",
+        "//comp/snmptraps/listener/fx",
+        "//comp/snmptraps/packet",
+        "//comp/snmptraps/senderhelper",
+        "//pkg/aggregator/mocksender",
+        "//pkg/util/fxutil",
+        "@com_github_gosnmp_gosnmp//:gosnmp",
+        "@com_github_stretchr_testify//require",
+        "@org_uber_go_fx//:fx",
+    ],
+)

--- a/comp/snmptraps/listener/fx/BUILD.bazel
+++ b/comp/snmptraps/listener/fx/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/listener/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/snmptraps/listener/def",
+        "//comp/snmptraps/listener/impl",
+        "//pkg/util/fxutil",
+        "@org_uber_go_fx//:fx",
+    ],
+)

--- a/comp/snmptraps/listener/impl/BUILD.bazel
+++ b/comp/snmptraps/listener/impl/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "impl",
+    srcs = [
+        "listener.go",
+        "mock_listener.go",
+        "test_helpers.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/listener/impl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/aggregator/demultiplexer/def",
+        "//comp/core/log/def",
+        "//comp/def",
+        "//comp/snmptraps/config/def",
+        "//comp/snmptraps/listener/def",
+        "//comp/snmptraps/packet",
+        "//comp/snmptraps/status/def",
+        "//pkg/aggregator/sender",
+        "@com_github_gosnmp_gosnmp//:gosnmp",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)
+
+go_test(
+    name = "impl_test",
+    srcs = ["listener_test.go"],
+    embed = [":impl"],
+    gotags = ["test"],
+    deps = [
+        "//comp/core/log/def",
+        "//comp/snmptraps/config/def",
+        "//comp/snmptraps/config/fx",
+        "//comp/snmptraps/listener/def",
+        "//comp/snmptraps/packet",
+        "//comp/snmptraps/senderhelper",
+        "//comp/snmptraps/status/def",
+        "//comp/snmptraps/status/fx",
+        "//pkg/aggregator/mocksender",
+        "//pkg/networkdevice/testutils",
+        "//pkg/util/fxutil",
+        "@com_github_gosnmp_gosnmp//:gosnmp",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_uber_go_fx//:fx",
+    ],
+)

--- a/comp/snmptraps/senderhelper/BUILD.bazel
+++ b/comp/snmptraps/senderhelper/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "senderhelper",
+    srcs = ["senderhelper.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/senderhelper",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/aggregator/demultiplexer/def",
+        "//comp/aggregator/demultiplexer/impl",
+        "//comp/core/hostname/hostnameimpl",
+        "//comp/core/log/def",
+        "//comp/core/log/mock",
+        "//comp/forwarder/defaultforwarder/mock",
+        "//pkg/aggregator/mocksender",
+        "//pkg/aggregator/sender",
+        "@org_uber_go_fx//:fx",
+    ],
+)

--- a/comp/snmptraps/server/fx/BUILD.bazel
+++ b/comp/snmptraps/server/fx/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/server/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/snmptraps/server/impl",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/snmptraps/server/impl/BUILD.bazel
+++ b/comp/snmptraps/server/impl/BUILD.bazel
@@ -1,0 +1,48 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "impl",
+    srcs = ["server.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/server/impl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/aggregator/demultiplexer/def",
+        "//comp/core/config",
+        "//comp/core/hostname",
+        "//comp/core/log/def",
+        "//comp/core/status",
+        "//comp/def",
+        "//comp/snmptraps/config/def",
+        "//comp/snmptraps/config/fx",
+        "//comp/snmptraps/formatter/def",
+        "//comp/snmptraps/formatter/impl",
+        "//comp/snmptraps/forwarder/def",
+        "//comp/snmptraps/forwarder/fx",
+        "//comp/snmptraps/listener/def",
+        "//comp/snmptraps/listener/fx",
+        "//comp/snmptraps/oidresolver/fx",
+        "//comp/snmptraps/server/def",
+        "//comp/snmptraps/status/def",
+        "//comp/snmptraps/status/impl",
+        "//pkg/util/fxutil",
+        "//pkg/util/fxutil/logging",
+        "@org_uber_go_fx//:fx",
+    ],
+)
+
+go_test(
+    name = "impl_test",
+    srcs = ["server_test.go"],
+    embed = [":impl"],
+    gotags = ["test"],
+    deps = [
+        "//comp/core/config",
+        "//comp/snmptraps/senderhelper",
+        "//comp/snmptraps/server/def",
+        "//pkg/networkdevice/testutils",
+        "//pkg/util/fxutil",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_uber_go_fx//:fx",
+    ],
+)

--- a/comp/snmptraps/status/fx/BUILD.bazel
+++ b/comp/snmptraps/status/fx/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/status/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/snmptraps/status/def",
+        "//comp/snmptraps/status/impl",
+        "//pkg/util/fxutil",
+        "@org_uber_go_fx//:fx",
+    ],
+)

--- a/comp/snmptraps/status/impl/BUILD.bazel
+++ b/comp/snmptraps/status/impl/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "impl",
+    srcs = [
+        "mock.go",
+        "status.go",
+    ],
+    embedsrcs = [
+        "status_templates/snmp.tmpl",
+        "status_templates/snmpHTML.tmpl",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/status/impl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/status",
+        "//comp/forwarder/eventplatform/def",
+        "//comp/snmptraps/status/def",
+    ],
+)
+
+go_test(
+    name = "impl_test",
+    srcs = ["status_test.go"],
+    embed = [":impl"],
+    gotags = ["test"],
+    deps = [
+        "//comp/forwarder/eventplatform/def",
+        "//pkg/aggregator",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)


### PR DESCRIPTION
### What does this PR do?

Migrate `cmd/agent/subcommands/snmp` to Bazel

- `comp/forwarder/orchestrator/impl`
- `cmd/agent/subcommands/snmp`
- `comp/snmpscan/fx`
- `comp/snmpscanmanager/{fx,impl}`
- `comp/snmptraps/senderhelper`
- `comp/snmptraps/formatter/{fx,impl}`
- `comp/snmptraps/status/{fx,impl}`
- `comp/snmptraps/listener/{fx,impl}`
- `comp/snmptraps/forwarder/{fx,impl}`
- `comp/snmptraps/server/{fx,impl}`

### Motivation

### Describe how you validated your changes

`bazel run //:gazelle && bazelisk test --config=cache //...`  for each migrated packages

### Additional Notes

Technically, `comp/forwarder/orchestrator/impl/` is not required in this PR and could be extracted in a more self contained PR