### PR TITLE
[SYNTH-27637] Fix Network Path tests timing out after 10s when timeout not set in test config

### DIFF
--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -240,16 +240,14 @@ func fillNetworkConfig(cfg *config.Config, ncr common.NetworkConfigRequest) {
 	}
 	if ncr.MaxTTL != nil {
 		cfg.MaxTTL = uint8(*ncr.MaxTTL)
+	} else {
+		cfg.MaxTTL = defaultMaxTTL
 	}
 	timeoutSec := defaultTestTimeoutSeconds
 	if ncr.Timeout != nil {
 		timeoutSec = *ncr.Timeout
 	}
-	maxTTL := cfg.MaxTTL
-	if maxTTL == 0 {
-		maxTTL = defaultMaxTTL
-	}
-	cfg.Timeout = time.Duration(float64(timeoutSec) * 0.9 / float64(maxTTL) * float64(time.Second))
+	cfg.Timeout = time.Duration(float64(timeoutSec) * 0.9 / float64(cfg.MaxTTL) * float64(time.Second))
 	if ncr.TracerouteCount != nil {
 		cfg.TracerouteQueries = *ncr.TracerouteCount
 	}

--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -26,6 +26,13 @@ import (
 
 const (
 	syntheticsMetricPrefix = "datadog.synthetics.agent."
+
+	// defaultTestTimeoutSeconds is the total test timeout applied when the test
+	// config does not specify one, matching the default added on the RC path.
+	defaultTestTimeoutSeconds = 60
+	// defaultMaxTTL is the fallback max-TTL used only when computing the
+	// per-hop timeout and neither the test config nor cfg.MaxTTL is set.
+	defaultMaxTTL = 30
 )
 
 // runWorkers starts the configured number of worker goroutines and waits for them.
@@ -234,9 +241,15 @@ func fillNetworkConfig(cfg *config.Config, ncr common.NetworkConfigRequest) {
 	if ncr.MaxTTL != nil {
 		cfg.MaxTTL = uint8(*ncr.MaxTTL)
 	}
+	timeoutSec := defaultTestTimeoutSeconds
 	if ncr.Timeout != nil {
-		cfg.Timeout = time.Duration(float64(*ncr.Timeout) * 0.9 / float64(cfg.MaxTTL) * float64(time.Second))
+		timeoutSec = *ncr.Timeout
 	}
+	maxTTL := cfg.MaxTTL
+	if maxTTL == 0 {
+		maxTTL = defaultMaxTTL
+	}
+	cfg.Timeout = time.Duration(float64(timeoutSec) * 0.9 / float64(maxTTL) * float64(time.Second))
 	if ncr.TracerouteCount != nil {
 		cfg.TracerouteQueries = *ncr.TracerouteCount
 	}

--- a/comp/syntheticstestscheduler/impl/worker_test.go
+++ b/comp/syntheticstestscheduler/impl/worker_test.go
@@ -191,6 +191,7 @@ func TestToNetpathConfig(t *testing.T) {
 			expect: config.Config{
 				Protocol:     payload.ProtocolUDP,
 				DestHostname: "dns.example.com",
+				MaxTTL:       defaultMaxTTL,
 				Timeout:      time.Duration(float64(defaultTestTimeoutSeconds) * 0.9 / float64(defaultMaxTTL) * float64(time.Second)),
 				ReverseDNS:   true,
 			},

--- a/comp/syntheticstestscheduler/impl/worker_test.go
+++ b/comp/syntheticstestscheduler/impl/worker_test.go
@@ -150,6 +150,53 @@ func TestToNetpathConfig(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "UDP request without timeout falls back to 60s default",
+			input: common.SyntheticsTestConfig{
+				Config: struct {
+					Assertions []common.Assertion   `json:"assertions"`
+					Request    common.ConfigRequest `json:"request"`
+				}{
+					Request: common.UDPConfigRequest{
+						Host: "dns.example.com",
+						Port: &udpPort,
+						NetworkConfigRequest: common.NetworkConfigRequest{
+							MaxTTL: &udpTTL,
+							// Timeout intentionally absent — API may omit it
+						},
+					},
+				},
+			},
+			expect: config.Config{
+				Protocol:     payload.ProtocolUDP,
+				DestHostname: "dns.example.com",
+				DestPort:     uint16(udpPort),
+				MaxTTL:       uint8(udpTTL),
+				Timeout:      time.Duration(float64(defaultTestTimeoutSeconds) * 0.9 / float64(udpTTL) * float64(time.Second)),
+				ReverseDNS:   true,
+			},
+			expectError: false,
+		},
+		{
+			name: "UDP request without timeout or maxTTL falls back to defaults",
+			input: common.SyntheticsTestConfig{
+				Config: struct {
+					Assertions []common.Assertion   `json:"assertions"`
+					Request    common.ConfigRequest `json:"request"`
+				}{
+					Request: common.UDPConfigRequest{
+						Host: "dns.example.com",
+					},
+				},
+			},
+			expect: config.Config{
+				Protocol:     payload.ProtocolUDP,
+				DestHostname: "dns.example.com",
+				Timeout:      time.Duration(float64(defaultTestTimeoutSeconds) * 0.9 / float64(defaultMaxTTL) * float64(time.Second)),
+				ReverseDNS:   true,
+			},
+			expectError: false,
+		},
+		{
 			name: "Unsupported subtype",
 			input: common.SyntheticsTestConfig{
 				Config: struct {


### PR DESCRIPTION
### What does this PR do?

Fixes Network Path tests being hard-cut at 10s on Agent 7.80+ when a test has no timeout configured.

When `fillNetworkConfig` receives a `NetworkConfigRequest` with `Timeout == nil`, `cfg.Timeout` stays 0. This flows into `impl-remote/traceroute.go`:

```go
httpTimeout := timeout*time.Duration(maxTTL) + 10*time.Second
// With timeout=0: httpTimeout = 0*maxTTL + 10s = 10s
```

The RC path avoided this because a 60s default was added server-side. The new TestPoller path (added in 7.80 via SYNTH-26786) reads test config directly from the DB, which stores no default, exposing the bug.

**Fix:** always compute `cfg.Timeout` in `fillNetworkConfig`, defaulting to 60s total when the API omits it — matching RC behavior. Also guards the `maxTTL=0` division edge case.

JIRA: https://datadoghq.atlassian.net/browse/SYNTH-27637

### Motivation

Customer reported Synthetics Network Path tests timing out on Agent v7.80. Tests were working on v7.66 (before TestPoller was introduced). Root cause: no default timeout applied on the agent side when the API response omits the timeout field.

### Describe how you validated your changes

- Added two new unit test cases to `TestToNetpathConfig`:
  - UDP request with no timeout falls back to 60s default (with explicit MaxTTL)
  - UDP request with neither timeout nor MaxTTL falls back to both defaults
- All 36 tests in `comp/syntheticstestscheduler/impl/` pass.

### Additional Notes

`defaultTestTimeoutSeconds = 60` matches the RC default. `defaultMaxTTL = 30` matches `setup.DefaultNetworkPathMaxTTL` and is only used as a divisor when computing the per-hop timeout if MaxTTL is also absent from the config.