### PR TITLE
fix(bazel): exclude .worktrees from bazel ignore_directories

### DIFF
--- a/REPO.bazel
+++ b/REPO.bazel
@@ -7,6 +7,7 @@ ignore_directories([
     ".g*",  # .git, .github, .gitlab
     ".i*",  # .idea, .ijwb
     ".v*",  # .venv, .vscode
+    ".worktrees",  # git worktrees checked out under .worktrees/
     "bazel-*",  # bazel convenience symlinks: suddenly caused issues inside arm64 Linux containers
     "target",  # cargo build creates it where Cargo.toml lives
 ])


### PR DESCRIPTION
## Summary

- Adds `.worktrees` to the `ignore_directories()` list in `REPO.bazel`
- Git worktrees checked out under `.worktrees/` were visible to Bazel/Gazelle, causing it to find duplicate Go package targets and generate incorrect `BUILD.bazel` files when run locally

## Test plan

- [ ] Run `bazel run //:gazelle` locally with a worktree present under `.worktrees/` — should produce no spurious changes