### PR TITLE
Fix spurious `MODULE.bazel.lock` changes w/ some `bazel` commands

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,6 +29,7 @@ common --repo_env=GOCACHE # https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
 common --repo_env=GOMODCACHE # https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
 common --repo_env=GOTOOLCHAIN=local # Extend https://github.com/bazel-contrib/rules_go/pull/3660 to Go SDK patching rules
 common --repo_env=PACKAGE_VERSION # Keep in sync with env_vars in MODULE.bazel
+common --repo_env=REPIN=1 # Reduce MODULE.bazel.lock churn when --lockfile_mode=[update|refresh] trigger
 common --repo_env=SIGN_MAC # Keep in sync with env_vars in MODULE.bazel
 common --repo_env=XDG_CACHE_HOME # https://wiki.archlinux.org/title/XDG_Base_Directory
 # Variables to override release.json values

--- a/.github/workflows/deps-tidy.yml
+++ b/.github/workflows/deps-tidy.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Repin Bazel Rust lockfile
         run: |
           bazel mod tidy
-          bazel mod deps --repo_env=REPIN=1
+          bazel mod deps
       - name: Generate Rust licenses
         run: |
           cargo install dd-rust-license-tool@1.0.6 --locked
@@ -135,7 +135,7 @@ jobs:
       - name: Repin Bazel module lockfile
         run: |
           bazel mod tidy
-          bazel mod deps --repo_env=REPIN=1
+          bazel mod deps
       - uses: ./.github/actions/deps-tidy-push
         with:
           token: ${{ steps.setup.outputs.token }}

--- a/.gitlab/build/bazel/lint.yml
+++ b/.gitlab/build/bazel/lint.yml
@@ -16,14 +16,11 @@ bazel:mod-deps:
     #
     # Instead:
     # 1. use `--lockfile_mode=refresh` to forcibly re-evaluate non-local repository rules,
-    # 2. use `--repo_env=REPIN=1` to regenerate rules_* lock files:
-    #    - rules_jvm_external: implies RULES_JVM_EXTERNAL_REPIN=1 for maven_install.json,
-    #    - rules_rust: implies CARGO_BAZEL_REPIN=1 for Cargo.Bazel.lock,
-    # 3. use `git diff --exit-code` to still fail on any discrepancies while printing them exhaustively.
-    - bazel mod deps --lockfile_mode=refresh --repo_env=REPIN=1
+    # 2. use `git diff --exit-code` to still fail on any discrepancies while printing them exhaustively.
+    - bazel mod deps --lockfile_mode=refresh
     - git diff --exit-code
   variables:
-    FIX_COMMAND: "bazel mod deps --repo_env=REPIN=1"
+    FIX_COMMAND: "bazel mod deps"
 
 bazel:mod-tidy:
   extends: [ .bazel:lint, .bazel:runner:linux-amd64 ]


### PR DESCRIPTION
### What does this PR do?
Add `common --repo_env=REPIN=1` to `.bazelrc`, then remove the (now) redundant `--repo_env=REPIN=1` from the `bazel:mod-deps` lint job and the `deps-tidy` GitHub workflows.

### Motivation
As of today, some legacy[^1] rules still propagate re-pinning through environment variables.
This is a pre-`bzlmod` holdover, for instance:
- `rules_rust`'s `crate_universe` reads `CARGO_BAZEL_REPIN`,
- `rules_jvm_external` reads `RULES_JVM_EXTERNAL_REPIN`,
... both aliased by `REPIN`.

Under `bzlmod`, `MODULE.bazel.lock` is instead maintained incrementally by `--lockfile_mode=update` (the default).

`--repo_env=REPIN=1` **re-pins nothing by itself**: it's `--lockfile_mode=update` that does, whenever a module extension's recorded inputs change (incrementally, unlike the _costly_ `--lockfile_mode=refresh`).
The problem is that an update firing without `REPIN=1` unset does not **forward** re-pinning to those legacy[^1] rules, so it completes only partially and leaves `MODULE.bazel.lock` inconsistent: a plain `bazel build`/`test`/`mod` command may producee **unrelated** lock changes in the working tree that the developer has to revert (guarded by the `bazel:mod-deps` job).

Forwarding `REPIN=1` makes that update complete and consistent across developers, CI, and the re-pinning bots, a necessary evil until those rules stop gating re-pinning on env vars.

### Describe how you validated your changes
`bazel mod deps --lockfile_mode=refresh` (the CI command, `REPIN=1` now the default) leaves `MODULE.bazel.lock` byte-identical, `ENV:REPIN 1` preserved (without the flag the same command rewrites the entry to `ENV:REPIN \0`).

### Additional Notes
[^1]: pardon my French, I mean "rules exhibiting a pre-bzlmod behavior".