### PR TITLE
[EBPF] attacher: classify expected uprobe attach failures

### DIFF
--- a/pkg/ebpf/bytecode/runtime/BUILD.bazel
+++ b/pkg/ebpf/bytecode/runtime/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
     srcs = [
         "all_helpers.go",
         "asset.go",
+        "discovery-net.go",
         "helpers.go",
         "offsetguess.go",
         "protected_file.go",

--- a/pkg/ebpf/bytecode/runtime/BUILD.bazel
+++ b/pkg/ebpf/bytecode/runtime/BUILD.bazel
@@ -53,7 +53,6 @@ go_library(
     srcs = [
         "all_helpers.go",
         "asset.go",
-        "discovery-net.go",
         "helpers.go",
         "offsetguess.go",
         "protected_file.go",

--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -1114,10 +1114,22 @@ func (ua *UprobeAttacher) attachToLibrariesOfPID(pid uint32) error {
 		if len(registerErrors) == 0 {
 			return nil // No libraries found to attach
 		}
-		return utils.NewUnknownAttachmentError(fmt.Errorf("no rules matched for pid %d, errors: %v", pid, registerErrors))
+		err := errors.Join(registerErrors...)
+		if hasUnknownAttachmentError(err) {
+			return utils.NewUnknownAttachmentError(fmt.Errorf("no rules matched for pid %d: %w", pid, err))
+		}
+		return err
 	}
 	if len(registerErrors) > 0 {
-		return utils.NewUnknownAttachmentError(fmt.Errorf("partially hooked (%v), errors while attaching pid %d: %v", successfulMatches, pid, registerErrors))
+		err := errors.Join(registerErrors...)
+		if hasUnknownAttachmentError(err) {
+			return utils.NewUnknownAttachmentError(fmt.Errorf("partially hooked (%v), errors while attaching pid %d: %w", successfulMatches, pid, err))
+		}
 	}
 	return nil
+}
+
+func hasUnknownAttachmentError(err error) bool {
+	var unknownErr *utils.UnknownAttachmentError
+	return errors.As(err, &unknownErr)
 }

--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -654,10 +654,6 @@ func (ua *UprobeAttacher) shouldLogRegistryError(err error) bool {
 		return ua.attachLimiter.ShouldLog()
 	}
 
-	if errors.Is(err, utils.ErrProcessDoesNotExist) {
-		return false
-	}
-
 	return false
 }
 

--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -791,7 +792,9 @@ func (ua *UprobeAttacher) AttachPIDWithOptions(pid uint32, attachToLibs bool) (e
 	if ua.handlesExecutables() || (ua.config.ExcludeTargets&ExcludeInternal) != 0 {
 		binPath, err = procInfo.Exe()
 		if err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
+			// procfs can return ESRCH if the process exits while the kernel is
+			// resolving /proc/<pid>/exe, even after path lookup has found it.
+			if !errors.Is(err, os.ErrNotExist) && !errors.Is(err, syscall.ESRCH) {
 				return utils.NewUnknownAttachmentError(err)
 			}
 			return err

--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -644,10 +644,6 @@ func (ua *UprobeAttacher) shouldLogRegistryError(err error) bool {
 		return false
 	}
 
-	if errors.Is(err, utils.ErrProcessDoesNotExist) {
-		return false
-	}
-
 	// Always log all errors if detailed logging is enabled
 	if ua.config.EnableDetailedLogging {
 		return true
@@ -657,6 +653,11 @@ func (ua *UprobeAttacher) shouldLogRegistryError(err error) bool {
 	if errors.As(err, &unknownErr) {
 		return ua.attachLimiter.ShouldLog()
 	}
+
+	if errors.Is(err, utils.ErrProcessDoesNotExist) {
+		return false
+	}
+
 	return false
 }
 

--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -643,6 +643,10 @@ func (ua *UprobeAttacher) shouldLogRegistryError(err error) bool {
 		return false
 	}
 
+	if errors.Is(err, utils.ErrProcessDoesNotExist) {
+		return false
+	}
+
 	// Always log all errors if detailed logging is enabled
 	if ua.config.EnableDetailedLogging {
 		return true

--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -1104,6 +1104,7 @@ func (ua *UprobeAttacher) attachToLibrariesOfPID(pid uint32) error {
 	if err != nil {
 		return utils.NewUnknownAttachmentError(err)
 	}
+
 	for _, libpath := range libs {
 		err := ua.AttachLibrary(libpath, pid)
 
@@ -1118,22 +1119,10 @@ func (ua *UprobeAttacher) attachToLibrariesOfPID(pid uint32) error {
 		if len(registerErrors) == 0 {
 			return nil // No libraries found to attach
 		}
-		err := errors.Join(registerErrors...)
-		if hasUnknownAttachmentError(err) {
-			return utils.NewUnknownAttachmentError(fmt.Errorf("no rules matched for pid %d: %w", pid, err))
-		}
-		return err
+		return fmt.Errorf("no rules matched for pid %d: %w", pid, errors.Join(registerErrors...))
 	}
 	if len(registerErrors) > 0 {
-		err := errors.Join(registerErrors...)
-		if hasUnknownAttachmentError(err) {
-			return utils.NewUnknownAttachmentError(fmt.Errorf("partially hooked (%v), errors while attaching pid %d: %w", successfulMatches, pid, err))
-		}
+		return fmt.Errorf("partially hooked (%v), errors while attaching pid %d: %w", successfulMatches, pid, errors.Join(registerErrors...))
 	}
 	return nil
-}
-
-func hasUnknownAttachmentError(err error) bool {
-	var unknownErr *utils.UnknownAttachmentError
-	return errors.As(err, &unknownErr)
 }

--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	manager "github.com/DataDog/ebpf-manager"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -178,6 +179,60 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 			mockFileRegistryExecuteCallbacks: false,
 		},
 		{
+			name: "registry returns os.ErrNotExist",
+			pid:  1,
+			setup: func(t *testing.T, pid uint32) (AttacherConfig, *MockBinaryInspector) {
+				procRoot := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{{Pid: pid, Cmdline: "foobar", Command: "foobar", Exe: "/bin/foobar"}})
+				return AttacherConfig{
+					ProcRoot: procRoot,
+					Rules: []*AttachRule{
+						{Targets: AttachToExecutable},
+					},
+				}, nil
+			},
+			expectedError:                    os.ErrNotExist,
+			registryReturnError:              os.ErrNotExist,
+			isExpected:                       true,
+			shouldLog:                        false,
+			mockFileRegistry:                 true,
+			mockFileRegistryExecuteCallbacks: false,
+		},
+		{
+			name: "registry returns os.ErrNotExist, with libraries",
+			pid:  1,
+			setup: func(t *testing.T, pid uint32) (AttacherConfig, *MockBinaryInspector) {
+				exe := "foobar"
+				libname := "/target/libssl.so"
+				maps := "08048000-08049000 r-xp 00000000 03:00 8312       " + libname
+				procRoot := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{{Pid: pid, Cmdline: exe, Command: exe, Exe: exe, Maps: maps}})
+				config := AttacherConfig{
+					ProcRoot: procRoot,
+					Rules: []*AttachRule{
+						{
+							LibraryNameRegex: regexp.MustCompile(`libssl\.so`),
+							ProbesSelector: []manager.ProbesSelector{
+								&manager.ProbeSelector{
+									ProbeIdentificationPair: manager.ProbeIdentificationPair{
+										EBPFFuncName: "uprobe__SSL_connect",
+									},
+								},
+							},
+							Targets: AttachToSharedLibraries,
+						},
+					},
+					SharedLibsLibsets: []sharedlibraries.Libset{sharedlibraries.LibsetCrypto},
+				}
+				return config, nil
+			},
+			expectedError:                    os.ErrNotExist,
+			registryReturnError:              os.ErrNotExist,
+			isExpected:                       true,
+			shouldLog:                        false,
+			mockFileRegistry:                 true,
+			mockFileRegistryExecuteCallbacks: false,
+			attachToLibs:                     true,
+		},
+		{
 			name:         "library has no symbols",
 			pid:          1,
 			attachToLibs: true,
@@ -253,12 +308,19 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 			}
 
 			err = ua.AttachPIDWithOptions(tt.pid, tt.attachToLibs)
-			require.ErrorIs(t, err, tt.expectedError)
+			assert.ErrorIs(t, err, tt.expectedError, "AttachPIDWithOptions returned unexpected error")
 
-			var unknownErr *utils.UnknownAttachmentError
-			isUnexpected := errors.As(err, &unknownErr)
-			require.Equal(t, !tt.isExpected, isUnexpected)
-			require.Equal(t, tt.shouldLog, ua.shouldLogRegistryError(err))
+			notStr := " not"
+			if tt.isExpected {
+				notStr = ""
+			}
+			assert.Equal(t, tt.isExpected, !utils.IsUnknownAttachmentError(err), "Returned error (%v) should%s be expected", err, notStr)
+
+			notLogStr := " not"
+			if tt.shouldLog {
+				notLogStr = ""
+			}
+			assert.Equal(t, tt.shouldLog, ua.shouldLogRegistryError(err), "Returned error (%v) should%s be logged", err, notLogStr)
 		})
 	}
 }

--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -657,6 +657,44 @@ func TestAttachToBinaryAndDetach(t *testing.T) {
 	mockMan.AssertExpectations(t)
 }
 
+func TestAttachToBinaryReturnsInspectionResultErrorUnwrapped(t *testing.T) {
+	proc := kernel.FakeProcFSEntry{
+		Pid:     1,
+		Cmdline: "/bin/bash",
+		Exe:     "/bin/bash",
+	}
+	procFS := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{proc})
+
+	config := AttacherConfig{
+		ProcRoot: procFS,
+		Rules: []*AttachRule{
+			{
+				Targets: AttachToExecutable,
+				ProbesSelector: []manager.ProbesSelector{
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "uprobe__SSL_connect"}},
+				},
+			},
+		},
+	}
+
+	inspector := &MockBinaryInspector{}
+	ua, err := NewUprobeAttacher(testModuleName, testAttacherName, config, &MockManager{}, nil, AttacherDependencies{Inspector: inspector, ProcessMonitor: newMockProcessMonitor()})
+	require.NoError(t, err)
+
+	target := utils.FilePath{HostPath: proc.Exe, PID: proc.Pid}
+	expectedErr := errors.New("symbols SSL_connect not found")
+	inspector.On("Inspect", target, mock.Anything).Return(map[int]*InspectionResult{
+		0: {Error: expectedErr},
+	}, nil)
+
+	err = ua.attachToBinary(target, config.Rules, NewProcInfo(procFS, proc.Pid))
+	require.ErrorIs(t, err, expectedErr)
+
+	var unknownErr *utils.UnknownAttachmentError
+	require.False(t, errors.As(err, &unknownErr))
+	inspector.AssertExpectations(t)
+}
+
 func TestAttachToBinaryAtReturnLocation(t *testing.T) {
 	proc := kernel.FakeProcFSEntry{
 		Pid:     1,

--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -33,8 +33,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
-// === Tests
-
 const (
 	testModuleName   = "mock-module"
 	testAttacherName = "mock"
@@ -70,8 +68,14 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 		expectedError error
 		// isExpected indicates whether the error should avoid UnknownAttachmentError classification.
 		isExpected bool
-		// mockFileRegistry makes the mock registry execute the activation callback instead of returning directly.
+		// shouldLog indicates whether the error should be logged by the default logging gate.
+		shouldLog bool
+		// registryReturnError is the error returned by the mock registry.
+		registryReturnError error
+		// mockFileRegistry uses a mock registry so the test can control registration behavior.
 		mockFileRegistry bool
+		// mockFileRegistryExecuteCallbacks indicates whether the mock registry should execute the activation and deactivation callbacks or return early
+		mockFileRegistryExecuteCallbacks bool
 	}{
 		{
 			name: "internal process",
@@ -86,6 +90,7 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 			},
 			expectedError: ErrInternalDDogProcessRejected,
 			isExpected:    true,
+			shouldLog:     false,
 		},
 		{
 			name: "containerd temporary mount",
@@ -116,9 +121,12 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 
 				return config, inspector
 			},
-			expectedError:    utils.ErrEnvironment,
-			isExpected:       true,
-			mockFileRegistry: true,
+			expectedError:                    utils.ErrEnvironment,
+			isExpected:                       true,
+			shouldLog:                        true, // because EnableDetailedLogging is true
+			registryReturnError:              utils.ErrEnvironment,
+			mockFileRegistry:                 true,
+			mockFileRegistryExecuteCallbacks: true,
 		},
 		{
 			name: "self excluded",
@@ -130,6 +138,44 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 			},
 			expectedError: ErrSelfExcluded,
 			isExpected:    true,
+			shouldLog:     false,
+		},
+		{
+			name: "process does not exist",
+			pid:  1,
+			setup: func(t *testing.T, pid uint32) (AttacherConfig, *MockBinaryInspector) {
+				// No process entry setup, so we will fail when we try to get the executable path
+				procRoot := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{})
+
+				return AttacherConfig{
+					ProcRoot: procRoot,
+					Rules: []*AttachRule{
+						{Targets: AttachToExecutable},
+					},
+				}, nil
+			},
+			expectedError: os.ErrNotExist,
+			isExpected:    true,
+			shouldLog:     false,
+		},
+		{
+			name: "process disappears before registry can inspect",
+			pid:  1,
+			setup: func(t *testing.T, pid uint32) (AttacherConfig, *MockBinaryInspector) {
+				procRoot := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{{Pid: pid, Cmdline: "foobar", Command: "foobar", Exe: "/bin/foobar"}})
+				return AttacherConfig{
+					ProcRoot: procRoot,
+					Rules: []*AttachRule{
+						{Targets: AttachToExecutable},
+					},
+				}, nil
+			},
+			expectedError:                    utils.ErrProcessDoesNotExist,
+			registryReturnError:              utils.ErrProcessDoesNotExist,
+			isExpected:                       true,
+			shouldLog:                        false,
+			mockFileRegistry:                 true,
+			mockFileRegistryExecuteCallbacks: false,
 		},
 		{
 			name:         "library has no symbols",
@@ -166,9 +212,12 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 
 				return config, inspector
 			},
-			expectedError:    safeelf.ErrNoSymbols,
-			isExpected:       true,
-			mockFileRegistry: true,
+			expectedError:                    safeelf.ErrNoSymbols,
+			isExpected:                       true,
+			shouldLog:                        false,
+			registryReturnError:              safeelf.ErrNoSymbols,
+			mockFileRegistry:                 true,
+			mockFileRegistryExecuteCallbacks: true,
 		},
 	}
 
@@ -187,6 +236,10 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 			if tt.mockFileRegistry {
 				registry := &MockFileRegistry{}
 				registry.On("Register", mock.Anything, tt.pid, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+					if !tt.mockFileRegistryExecuteCallbacks {
+						return
+					}
+
 					namespacedPath := args.String(0)
 					activationCB := args.Get(2).(utils.Callback)
 					deactivationCB := args.Get(3).(utils.Callback)
@@ -194,7 +247,7 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 					if activationCB(path) != nil {
 						_ = deactivationCB(utils.FilePath{ID: path.ID})
 					}
-				}).Return(tt.expectedError)
+				}).Return(tt.registryReturnError)
 				ua.fileRegistry = registry
 				defer registry.AssertExpectations(t)
 			}
@@ -205,6 +258,7 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 			var unknownErr *utils.UnknownAttachmentError
 			isUnexpected := errors.As(err, &unknownErr)
 			require.Equal(t, !tt.isExpected, isUnexpected)
+			require.Equal(t, tt.shouldLog, ua.shouldLogRegistryError(err))
 		})
 	}
 }

--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -53,53 +53,120 @@ func TestInternalProcessesRegex(t *testing.T) {
 	require.True(t, internalProcessRegex.MatchString("datadog-agent/bin/otel-agent"))
 }
 
-func TestAttachPidExcludesInternal(t *testing.T) {
-	exe := "datadog-agent/bin/system-probe"
-	procRoot := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{{Pid: 1, Cmdline: exe, Command: exe, Exe: exe}})
-	config := AttacherConfig{
-		ExcludeTargets: ExcludeInternal,
-		ProcRoot:       procRoot,
-	}
-	ua, err := NewUprobeAttacher(testModuleName, testAttacherName, config, &MockManager{}, nil, AttacherDependencies{ProcessMonitor: newMockProcessMonitor()})
-	require.NoError(t, err)
-	require.NotNil(t, ua)
+func TestAttachPidReturnsCorrectErrors(t *testing.T) {
+	type setupFunc func(t *testing.T, pid uint32) (AttacherConfig, *MockBinaryInspector)
 
-	err = ua.AttachPIDWithOptions(1, false)
-	require.ErrorIs(t, err, ErrInternalDDogProcessRejected)
-}
+	tests := []struct {
+		// name identifies the subtest scenario.
+		name string
+		// pid is the process ID passed to AttachPIDWithOptions and to setup.
+		pid uint32
+		// attachToLibs controls whether AttachPIDWithOptions should also scan mapped libraries.
+		attachToLibs bool
+		// setup creates the attacher configuration and optional inspector mock for the scenario.
+		setup setupFunc
+		// expectedError is the exact error that AttachPIDWithOptions should return or wrap.
+		expectedError error
+		// isExpected indicates whether the error should avoid UnknownAttachmentError classification.
+		isExpected bool
+		// mockFileRegistry makes the mock registry execute the activation callback instead of returning directly.
+		mockFileRegistry bool
+	}{
+		{
+			name: "internal process",
+			pid:  1,
+			setup: func(t *testing.T, pid uint32) (AttacherConfig, *MockBinaryInspector) {
+				exe := "datadog-agent/bin/system-probe"
+				procRoot := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{{Pid: pid, Cmdline: exe, Command: exe, Exe: exe}})
+				return AttacherConfig{
+					ExcludeTargets: ExcludeInternal,
+					ProcRoot:       procRoot,
+				}, nil
+			},
+			expectedError: ErrInternalDDogProcessRejected,
+			isExpected:    true,
+		},
+		{
+			name: "containerd temporary mount",
+			pid:  1,
+			setup: func(t *testing.T, pid uint32) (AttacherConfig, *MockBinaryInspector) {
+				tmpdir := t.TempDir()
 
-func TestAttachPidExcludesContainerdTmp(t *testing.T) {
-	tmpdir := t.TempDir()
+				// Create a tmpdir/tmpmounts/containerd-mount/bar directory with a file in
+				// it to simulate a containerd tmp mount. It needs to exist so that the code
+				// will be able to read that file.
+				exe := filepath.Join(tmpdir, "tmpmounts/containerd-mount/bar")
+				require.NoError(t, os.MkdirAll(filepath.Dir(exe), 0755))
+				require.NoError(t, os.WriteFile(exe, []byte{}, 0644))
 
-	// Create a tmpdir/tmpmounts/containerd-mount/bar directory with a file in
-	// it to simulate a containerd tmp mount. It needs to exist so that the code
-	// will be able to read that file
-	exe := filepath.Join(tmpdir, "tmpmounts/containerd-mount/bar")
-	require.NoError(t, os.MkdirAll(filepath.Dir(exe), 0755))
-	require.NoError(t, os.WriteFile(exe, []byte{}, 0644))
+				procRoot := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{{Pid: pid, Cmdline: exe, Command: exe, Exe: exe}})
+				config := AttacherConfig{
+					ExcludeTargets:        ExcludeContainerdTmp,
+					ProcRoot:              procRoot,
+					EnableDetailedLogging: true,
+					Rules: []*AttachRule{
+						{Targets: AttachToExecutable},
+					},
+				}
 
-	procRoot := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{{Pid: 1, Cmdline: exe, Command: exe, Exe: exe}})
-	config := AttacherConfig{
-		ExcludeTargets:        ExcludeContainerdTmp,
-		ProcRoot:              procRoot,
-		EnableDetailedLogging: true,
-		Rules: []*AttachRule{
-			{Targets: AttachToExecutable},
+				// Cleanup should be called anyways, even if the attach fails.
+				inspector := &MockBinaryInspector{}
+				inspector.On("Cleanup", mock.Anything).Return(nil)
+
+				return config, inspector
+			},
+			expectedError:    utils.ErrEnvironment,
+			isExpected:       true,
+			mockFileRegistry: true,
+		},
+		{
+			name: "self excluded",
+			pid:  uint32(os.Getpid()),
+			setup: func(t *testing.T, _ uint32) (AttacherConfig, *MockBinaryInspector) {
+				return AttacherConfig{
+					ExcludeTargets: ExcludeSelf,
+				}, nil
+			},
+			expectedError: ErrSelfExcluded,
+			isExpected:    true,
 		},
 	}
 
-	// Cleanup should be called anyways, even if the attach fails
-	inspector := &MockBinaryInspector{}
-	inspector.On("Cleanup", mock.Anything).Return(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, inspector := tt.setup(t, tt.pid)
+			deps := AttacherDependencies{ProcessMonitor: newMockProcessMonitor()}
+			if inspector != nil {
+				deps.Inspector = inspector
+				defer inspector.AssertExpectations(t)
+			}
 
-	ua, err := NewUprobeAttacher(testModuleName, testAttacherName, config, &MockManager{}, nil, AttacherDependencies{Inspector: inspector, ProcessMonitor: newMockProcessMonitor()})
-	require.NoError(t, err)
-	require.NotNil(t, ua)
+			ua, err := NewUprobeAttacher(testModuleName, testAttacherName, config, &MockManager{}, nil, deps)
+			require.NoError(t, err)
+			require.NotNil(t, ua)
+			if tt.mockFileRegistry {
+				registry := &MockFileRegistry{}
+				registry.On("Register", mock.Anything, tt.pid, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+					namespacedPath := args.String(0)
+					activationCB := args.Get(2).(utils.Callback)
+					deactivationCB := args.Get(3).(utils.Callback)
+					path := utils.FilePath{HostPath: namespacedPath, PID: tt.pid}
+					if activationCB(path) != nil {
+						_ = deactivationCB(utils.FilePath{ID: path.ID})
+					}
+				}).Return(tt.expectedError)
+				ua.fileRegistry = registry
+				defer registry.AssertExpectations(t)
+			}
 
-	err = ua.AttachPIDWithOptions(1, false)
-	require.ErrorIs(t, err, utils.ErrEnvironment)
+			err = ua.AttachPIDWithOptions(tt.pid, tt.attachToLibs)
+			require.ErrorIs(t, err, tt.expectedError)
 
-	inspector.AssertExpectations(t)
+			var unknownErr *utils.UnknownAttachmentError
+			isUnexpected := errors.As(err, &unknownErr)
+			require.Equal(t, !tt.isExpected, isUnexpected)
+		})
+	}
 }
 
 func TestAttachPidReadsSharedLibraries(t *testing.T) {
@@ -139,18 +206,6 @@ func TestAttachPidReadsSharedLibraries(t *testing.T) {
 	// We should get calls to Register both with the executable and the library
 	// name, even though the executable returns an error
 	registry.AssertExpectations(t)
-}
-
-func TestAttachPidExcludesSelf(t *testing.T) {
-	config := AttacherConfig{
-		ExcludeTargets: ExcludeSelf,
-	}
-	ua, err := NewUprobeAttacher(testModuleName, testAttacherName, config, &MockManager{}, nil, AttacherDependencies{ProcessMonitor: newMockProcessMonitor()})
-	require.NoError(t, err)
-	require.NotNil(t, ua)
-
-	err = ua.AttachPIDWithOptions(uint32(os.Getpid()), false)
-	require.ErrorIs(t, err, ErrSelfExcluded)
 }
 
 func TestAttachToBinaryContainerdTmpReturnsErrEnvironment(t *testing.T) {

--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -274,6 +274,43 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 			mockFileRegistry:                 true,
 			mockFileRegistryExecuteCallbacks: true,
 		},
+		{
+			name: "executable inspection result error",
+			pid:  1,
+			setup: func(t *testing.T, pid uint32) (AttacherConfig, *MockBinaryInspector) {
+				exe := "/bin/bash"
+				procRoot := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{{Pid: pid, Cmdline: exe, Command: exe, Exe: exe}})
+				config := AttacherConfig{
+					ProcRoot: procRoot,
+					Rules: []*AttachRule{
+						{
+							Targets: AttachToExecutable,
+							ProbesSelector: []manager.ProbesSelector{
+								&manager.ProbeSelector{
+									ProbeIdentificationPair: manager.ProbeIdentificationPair{
+										EBPFFuncName: "uprobe__SSL_connect",
+									},
+								},
+							},
+						},
+					},
+				}
+
+				inspector := &MockBinaryInspector{}
+				inspector.On("Inspect", mock.Anything, mock.Anything).Return(map[int]*InspectionResult{
+					0: {Error: safeelf.ErrNoSymbols},
+				}, nil)
+				inspector.On("Cleanup", mock.Anything).Return(nil)
+
+				return config, inspector
+			},
+			expectedError:                    safeelf.ErrNoSymbols,
+			isExpected:                       true,
+			shouldLog:                        false,
+			registryReturnError:              safeelf.ErrNoSymbols,
+			mockFileRegistry:                 true,
+			mockFileRegistryExecuteCallbacks: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -866,44 +903,6 @@ func TestAttachToBinaryAndDetach(t *testing.T) {
 	require.NoError(t, err)
 	inspector.AssertExpectations(t)
 	mockMan.AssertExpectations(t)
-}
-
-func TestAttachToBinaryReturnsInspectionResultErrorUnwrapped(t *testing.T) {
-	proc := kernel.FakeProcFSEntry{
-		Pid:     1,
-		Cmdline: "/bin/bash",
-		Exe:     "/bin/bash",
-	}
-	procFS := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{proc})
-
-	config := AttacherConfig{
-		ProcRoot: procFS,
-		Rules: []*AttachRule{
-			{
-				Targets: AttachToExecutable,
-				ProbesSelector: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "uprobe__SSL_connect"}},
-				},
-			},
-		},
-	}
-
-	inspector := &MockBinaryInspector{}
-	ua, err := NewUprobeAttacher(testModuleName, testAttacherName, config, &MockManager{}, nil, AttacherDependencies{Inspector: inspector, ProcessMonitor: newMockProcessMonitor()})
-	require.NoError(t, err)
-
-	target := utils.FilePath{HostPath: proc.Exe, PID: proc.Pid}
-	expectedErr := errors.New("symbols SSL_connect not found")
-	inspector.On("Inspect", target, mock.Anything).Return(map[int]*InspectionResult{
-		0: {Error: expectedErr},
-	}, nil)
-
-	err = ua.attachToBinary(target, config.Rules, NewProcInfo(procFS, proc.Pid))
-	require.ErrorIs(t, err, expectedErr)
-
-	var unknownErr *utils.UnknownAttachmentError
-	require.False(t, errors.As(err, &unknownErr))
-	inspector.AssertExpectations(t)
 }
 
 func TestAttachToBinaryAtReturnLocation(t *testing.T) {

--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -30,6 +30,7 @@ import (
 	fileopener "github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 // === Tests
@@ -129,6 +130,45 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 			},
 			expectedError: ErrSelfExcluded,
 			isExpected:    true,
+		},
+		{
+			name:         "library has no symbols",
+			pid:          1,
+			attachToLibs: true,
+			setup: func(t *testing.T, pid uint32) (AttacherConfig, *MockBinaryInspector) {
+				exe := "foobar"
+				libname := "/target/libssl.so"
+				maps := "08048000-08049000 r-xp 00000000 03:00 8312       " + libname
+				procRoot := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{{Pid: pid, Cmdline: exe, Command: exe, Exe: exe, Maps: maps}})
+				config := AttacherConfig{
+					ProcRoot: procRoot,
+					Rules: []*AttachRule{
+						{
+							LibraryNameRegex: regexp.MustCompile(`libssl\.so`),
+							ProbesSelector: []manager.ProbesSelector{
+								&manager.ProbeSelector{
+									ProbeIdentificationPair: manager.ProbeIdentificationPair{
+										EBPFFuncName: "uprobe__SSL_connect",
+									},
+								},
+							},
+							Targets: AttachToSharedLibraries,
+						},
+					},
+					SharedLibsLibsets: []sharedlibraries.Libset{sharedlibraries.LibsetCrypto},
+				}
+
+				inspector := &MockBinaryInspector{}
+				inspector.On("Inspect", mock.Anything, mock.Anything).Return(map[int]*InspectionResult{
+					0: {Error: safeelf.ErrNoSymbols},
+				}, nil)
+				inspector.On("Cleanup", mock.Anything).Return(nil)
+
+				return config, inspector
+			},
+			expectedError:    safeelf.ErrNoSymbols,
+			isExpected:       true,
+			mockFileRegistry: true,
 		},
 	}
 

--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -132,7 +132,7 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 		{
 			name: "self excluded",
 			pid:  uint32(os.Getpid()),
-			setup: func(t *testing.T, _ uint32) (AttacherConfig, *MockBinaryInspector) {
+			setup: func(_ *testing.T, _ uint32) (AttacherConfig, *MockBinaryInspector) {
 				return AttacherConfig{
 					ExcludeTargets: ExcludeSelf,
 				}, nil
@@ -144,7 +144,7 @@ func TestAttachPidReturnsCorrectErrors(t *testing.T) {
 		{
 			name: "process does not exist",
 			pid:  1,
-			setup: func(t *testing.T, pid uint32) (AttacherConfig, *MockBinaryInspector) {
+			setup: func(t *testing.T, _ uint32) (AttacherConfig, *MockBinaryInspector) {
 				// No process entry setup, so we will fail when we try to get the executable path
 				procRoot := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{})
 

--- a/pkg/network/go/bininspect/symbols.go
+++ b/pkg/network/go/bininspect/symbols.go
@@ -24,6 +24,10 @@ const (
 	symbolNameAddressSize = 4
 )
 
+// ErrSymbolsNotFound is returned when the ELF symbol sections are readable, but
+// one or more requested symbols are missing.
+var ErrSymbolsNotFound = errors.New("failed to find symbols")
+
 // getSymbolNameByEntry extracts from the string data section the string in the given position.
 // If the symbol name is shorter or longer than the given min and max (==len(preAllocatedBuf)) then we return false.
 // preAllocatedBuf is a pre allocated buffer with a constant length (== max length among all given symbols) to spare
@@ -254,7 +258,7 @@ func GetAllSymbolsByName(elfFile *safeelf.File, filter symbolFilter) (map[string
 
 	if len(symbolByName) != numWanted {
 		missingSymbols := filter.findMissing(symbolByName)
-		return symbolByName, fmt.Errorf("failed to find symbols %#v", missingSymbols)
+		return symbolByName, fmt.Errorf("%w %#v", ErrSymbolsNotFound, missingSymbols)
 	}
 
 	return symbolByName, nil

--- a/pkg/network/go/bininspect/symbols_test.go
+++ b/pkg/network/go/bininspect/symbols_test.go
@@ -62,6 +62,7 @@ func TestAllMissing(t *testing.T) {
 
 	_, err := GetAllSymbolsInSetByName(elfFile, symbolSet)
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSymbolsNotFound)
 	msg := err.Error()
 	assert.Contains(t, msg, "SSL_connect_not")
 	assert.Contains(t, msg, "foo")
@@ -78,6 +79,7 @@ func TestSomeMissing(t *testing.T) {
 
 	_, err := GetAllSymbolsInSetByName(elfFile, symbolSet)
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSymbolsNotFound)
 	msg := err.Error()
 	assert.Contains(t, msg, "SSL_invalid")
 	assert.Contains(t, msg, "SSL_notthere")

--- a/pkg/network/usm/ebpf_gotls_helpers.go
+++ b/pkg/network/usm/ebpf_gotls_helpers.go
@@ -108,7 +108,7 @@ func (p *goTLSBinaryInspector) Inspect(fpath utils.FilePath, requestSets map[int
 		if errors.Is(err, safeelf.ErrNoSymbols) {
 			p.binNoSymbolsMetric.Add(1)
 		}
-		if errors.Is(err, binversion.ErrNotGoExe) {
+		if isExpectedGoTLSInspectionError(err) {
 			return map[int]*uprobes.InspectionResult{0: {Error: err}}, nil
 		}
 		return nil, fmt.Errorf("error extracting inspection data from %s: %w", path, err)
@@ -122,6 +122,12 @@ func (p *goTLSBinaryInspector) Inspect(fpath utils.FilePath, requestSets map[int
 	p.binAnalysisMetric.Add(elapsed.Milliseconds())
 
 	return map[int]*uprobes.InspectionResult{0: {SymbolMap: inspectionResult.Functions}}, nil
+}
+
+func isExpectedGoTLSInspectionError(err error) bool {
+	return errors.Is(err, binversion.ErrNotGoExe) ||
+		errors.Is(err, safeelf.ErrNoSymbols) ||
+		errors.Is(err, bininspect.ErrSymbolsNotFound)
 }
 
 // Cleanup removes the inspection result for the binary at the given path from the map.

--- a/pkg/network/usm/ebpf_gotls_helpers_test.go
+++ b/pkg/network/usm/ebpf_gotls_helpers_test.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package usm
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
+	"github.com/DataDog/datadog-agent/pkg/network/go/binversion"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
+)
+
+func TestExpectedGoTLSInspectionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "not go executable",
+			err:      fmt.Errorf("could not get Go toolchain version from ELF binary file: %w", binversion.ErrNotGoExe),
+			expected: true,
+		},
+		{
+			name:     "no symbol section",
+			err:      fmt.Errorf("read symbols: %w", safeelf.ErrNoSymbols),
+			expected: true,
+		},
+		{
+			name:     "requested symbols not found",
+			err:      fmt.Errorf("inspect symbols: %w", bininspect.ErrSymbolsNotFound),
+			expected: true,
+		},
+		{
+			name:     "unexpected inspection failure",
+			err:      errors.New("malformed pclntab"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isExpectedGoTLSInspectionError(tt.err))
+		})
+	}
+}

--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -148,6 +148,12 @@ func (e *UnknownAttachmentError) Unwrap() error {
 	return e.Err
 }
 
+// IsUnknownAttachmentError returns true if the error is an UnknownAttachmentError
+func IsUnknownAttachmentError(err error) bool {
+	var unknownErr *UnknownAttachmentError
+	return errors.As(err, &unknownErr)
+}
+
 // NewUnknownAttachmentError creates a new `UnknownAttachmentError` instance wrapping
 // the given error.
 func NewUnknownAttachmentError(err error) *UnknownAttachmentError {
@@ -233,8 +239,8 @@ func (r *FileRegistry) Register(namespacedPath string, pid uint32, activationCB,
 			return err
 		}
 
-		// short living process would be hard to catch and will failed when we try to open the library
-		// so let's failed silently
+		// short living process would be hard to catch and will fail when we try to open the library
+		// so let's fail silently
 		if errors.Is(err, os.ErrNotExist) {
 			return err
 		}


### PR DESCRIPTION
### What does this PR do?

Classifies expected uprobe attach failures as non-unexpected errors so short-lived processes and non-attachable binaries do not produce noisy `unexpected error` logs.

### Motivation

GoTLS inspection and procfs races can fail during normal process discovery. These cases should be treated as expected attachment misses instead of operator-visible unexpected failures.

### Describe how you validated your changes

Unit tests added and targeted uprobe/bininspect/GoTLS tests run. We should validate during RC that logs have decreased

### Additional Notes