### PR TITLE
Drop python final constraints file

### DIFF
--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -9,6 +9,7 @@
 ## Unreleased
 
 <!-- Add entries here for changes not yet in a release. -->
+- Remove the obsolete packaged integration constraints artifact from the AIX BFF package
 - Remove `sharedlibrarycheck` from the AIX agent build (the shared-library check loader was included but not validated on AIX)
 
 - The embedded `python3.13` binary and all Python extension modules now have the correct install-time library search path baked into their XCOFF loader section. Previously, the staging path was baked in, causing `libpython3.13.so could not be loaded` when running pip or python directly (without `LIBPATH` set). Operators can now run `pip install` without setting `LIBPATH` first.

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -60,7 +60,6 @@ var (
 
 	rootDir             string
 	reqAgentReleasePath string
-	constraintsPath     string
 )
 
 // cliParams are the command-line arguments for the sub-subcommands.
@@ -193,11 +192,6 @@ func loadPythonInfo() error {
 		}
 
 		rootDir = parentDir
-	}
-
-	constraintsPath = filepath.Join(rootDir, "final_constraints-py3.txt")
-	if _, err := os.Lstat(constraintsPath); err != nil {
-		return err
 	}
 
 	return nil
@@ -377,7 +371,6 @@ func install(cliParams *cliParams, _ log.Component) error {
 
 	pipArgs := []string{
 		"install",
-		"--constraint", constraintsPath,
 		// We don't use pip to download wheels, so we don't need a cache
 		"--no-cache-dir",
 		// Specify to not use any index since we won't/shouldn't download anything with pip anyway

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -50,7 +50,6 @@ if arm_target?
   excluded_folders.push('ibm_mq')
 end
 
-final_constraints_file = 'final_constraints-py3.txt'
 agent_requirements_file = 'agent_requirements-py3.txt'
 filtered_agent_requirements_in = 'agent_requirements-py3.in'
 agent_requirements_in = 'agent_requirements.in'
@@ -87,10 +86,6 @@ build do
                        "--//packages/agent:flavor=#{ENV.fetch('AGENT_FLAVOR', 'base')} " \
                        "--//:install_dir=#{install_dir} " \
                        "-- //deps/agent_integrations:install --destdir=#{install_dir}"
-
-  # Create a constraint file after installing all the core dependencies and before any integration
-  # This is then used as a constraint file by the integration command to avoid messing with the agent's python environment
-  command "#{python} -m pip freeze > #{install_dir}/#{final_constraints_file}"
 
   # Prepare build env for integrations
   wheel_build_dir = windows_safe_path(project_dir, ".wheels")

--- a/packaging/aix/stages/07-checks-base.sh
+++ b/packaging/aix/stages/07-checks-base.sh
@@ -121,11 +121,6 @@ log "Freezing installed packages to $STAGING/constraints.txt"
 $PIP freeze > "$STAGING/constraints.txt"
 log "Constraints written to $STAGING/constraints.txt ($(wc -l < "$STAGING/constraints.txt") packages)"
 
-# Also write to the package root so the file is included in the BFF package
-# at /opt/datadog-agent/final_constraints-py3.txt, matching other platforms.
-cp "$STAGING/constraints.txt" "$STAGING/opt/datadog-agent/final_constraints-py3.txt"
-log "Copied constraints to $STAGING/opt/datadog-agent/final_constraints-py3.txt"
-
 # --- Mark complete ---
 mkdir -p "$(dirname "$SENTINEL")"
 touch "$SENTINEL"


### PR DESCRIPTION
### What does this PR do?

It drops the final_constraints-py3.txt from the Agent, stopping its generation and its only point of use.

### Motivation

Simplification as we migrate these bits to Bazel ([ABLD-260](https://datadoghq.atlassian.net/browse/ABLD-260)).

### Describe how you validated your changes

CI.

### Additional Notes

This is an alternative to https://github.com/DataDog/datadog-agent/pull/52476, which would migrate the generation of this file to Bazel. If this is an acceptable alternative, it's obviously better than that other PR, as it means removing code (rather than adding quite a bit) and simplifying.

The reason why this looks safe to do is that the only known use of this file is in a fully managed `pip` command that includes [`--no-deps`](https://pip.pypa.io/en/latest/cli/pip_install/#cmdoption-no-deps). `--no-deps` already avoids installing package dependencies, which seems to make the constraints – which prevent specified packages from straying away from their specified version – redundant.


[ABLD-260]: https://datadoghq.atlassian.net/browse/ABLD-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ