### PR TITLE
ci(internal-image-deploy): add image variant without suffix to internal deploy pipeline 

### DIFF
--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -9,12 +9,6 @@
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   timeout: 1h
-  parallel:
-    matrix: # See https://github.com/DataDog/datadog-agent/pull/45778
-      - COMPRESSION: "zstd"
-        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd"
-      - COMPRESSION: "nydus"
-        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
   script:
     # Constant variables
     - export RELEASE_STAGING=""
@@ -25,7 +19,7 @@
     - export RELEASE_TAG="${BASE_RELEASE_TAG}${RELEASE_TAG_SUFFIX}${RELEASE_TAG_COMPRESSION_SUFFIX}"
     - export TMPL_SRC_IMAGE="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TMPL_SRC_IMAGE_SUFFIX}"
     # Specify the compression
-    - export IMAGE_VERSION="${IMAGE_VERSION}-${COMPRESSION}"
+    - export IMAGE_VERSION="${IMAGE_VERSION}${COMPRESSION}"
     # BUILD_TAG is always RELEASE_TAG
     - export BUILD_TAG="${RELEASE_TAG}"
     # Fetch Gitlab token
@@ -50,23 +44,19 @@
 
 # -- binary specific variables --
 .agent_variables: &agent_variables
-  IMAGE_VERSION: tmpl-v24
   IMAGE_NAME: datadog-agent
   TMPL_SRC_REPO: ci/datadog-agent/agent
 
 .cluster_agent_variables: &cluster_agent_variables
-  IMAGE_VERSION: tmpl-v12
   IMAGE_NAME: datadog-cluster-agent
   TMPL_SRC_REPO: ci/datadog-agent/cluster-agent
   RELEASE_PROD: "true"
 
 .ot_standalone_variables: &ot_standalone_variables
-  IMAGE_VERSION: tmpl-v7
   IMAGE_NAME: otel-agent
   TMPL_SRC_REPO: ci/datadog-agent/otel-agent
 
 .host_profiler_standalone_variables: &host_profiler_standalone_variables
-  IMAGE_VERSION: tmpl-v1
   IMAGE_NAME: ddot-ebpf
   TMPL_SRC_REPO: ci/datadog-agent/ddot-ebpf
   RELEASE_PROD_OVERRIDE: "true"
@@ -74,6 +64,17 @@
 # -- publish jobs --
 publish_internal_container_image-jmx:
   extends: .docker_trigger_base
+  parallel:
+    matrix:
+      - COMPRESSION: "-zstd"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd"
+        IMAGE_VERSION: tmpl-v24
+      - COMPRESSION: "-nydus"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
+        IMAGE_VERSION: tmpl-v24
+      - COMPRESSION: ""
+        RELEASE_TAG_COMPRESSION_SUFFIX: ""
+        IMAGE_VERSION: tmpl-v25
   needs:
     - job: docker_build_agent7_jmx
       artifacts: false
@@ -87,6 +88,17 @@ publish_internal_container_image-jmx:
 
 publish_internal_container_image-fips:
   extends: .docker_trigger_base
+  parallel:
+    matrix:
+      - COMPRESSION: "-zstd"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd"
+        IMAGE_VERSION: tmpl-v24
+      - COMPRESSION: "-nydus"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
+        IMAGE_VERSION: tmpl-v24
+      - COMPRESSION: ""
+        RELEASE_TAG_COMPRESSION_SUFFIX: ""
+        IMAGE_VERSION: tmpl-v25
   needs:
     - job: docker_build_fips_agent7_jmx
       artifacts: false
@@ -99,6 +111,17 @@ publish_internal_container_image-fips:
 
 publish_internal_container_image-ot_standalone:
   extends: .docker_trigger_base
+  parallel:
+    matrix:
+      - COMPRESSION: "-zstd"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd"
+        IMAGE_VERSION: tmpl-v7
+      - COMPRESSION: "-nydus"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
+        IMAGE_VERSION: tmpl-v7
+      - COMPRESSION: ""
+        RELEASE_TAG_COMPRESSION_SUFFIX: ""
+        IMAGE_VERSION: tmpl-v8
   needs:
     - job: docker_build_ot_agent_standalone_amd64
       artifacts: false
@@ -110,6 +133,17 @@ publish_internal_container_image-ot_standalone:
 
 publish_internal_container_image-ot_standalone-fips:
   extends: .docker_trigger_base
+  parallel:
+    matrix:
+      - COMPRESSION: "-zstd"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd"
+        IMAGE_VERSION: tmpl-v7
+      - COMPRESSION: "-nydus"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
+        IMAGE_VERSION: tmpl-v7
+      - COMPRESSION: ""
+        RELEASE_TAG_COMPRESSION_SUFFIX: ""
+        IMAGE_VERSION: tmpl-v8
   needs:
     - job: docker_build_ot_agent_standalone_fips_amd64
       artifacts: false
@@ -122,6 +156,17 @@ publish_internal_container_image-ot_standalone-fips:
 
 publish_internal_container_image-host_profiler_standalone:
   extends: .docker_trigger_base
+  parallel:
+    matrix:
+      - COMPRESSION: "-zstd"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd"
+        IMAGE_VERSION: tmpl-v1
+      - COMPRESSION: "-nydus"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
+        IMAGE_VERSION: tmpl-v1
+      - COMPRESSION: ""
+        RELEASE_TAG_COMPRESSION_SUFFIX: ""
+        IMAGE_VERSION: tmpl-v2
   needs:
     - job: docker_build_host_profiler_standalone_amd64
       artifacts: false
@@ -134,6 +179,17 @@ publish_internal_container_image-host_profiler_standalone:
 # DCA publish jobs
 publish_internal_dca_container_image:
   extends: .docker_trigger_base
+  parallel:
+    matrix:
+      - COMPRESSION: "-zstd"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd"
+        IMAGE_VERSION: tmpl-v12
+      - COMPRESSION: "-nydus"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
+        IMAGE_VERSION: tmpl-v12
+      - COMPRESSION: ""
+        RELEASE_TAG_COMPRESSION_SUFFIX: ""
+        IMAGE_VERSION: tmpl-v13
   needs:
     - job: docker_build_cluster_agent_amd64
       artifacts: false
@@ -144,6 +200,17 @@ publish_internal_dca_container_image:
 
 publish_internal_dca_container_image-fips:
   extends: .docker_trigger_base
+  parallel:
+    matrix:
+      - COMPRESSION: "-zstd"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd"
+        IMAGE_VERSION: tmpl-v12
+      - COMPRESSION: "-nydus"
+        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
+        IMAGE_VERSION: tmpl-v12
+      - COMPRESSION: ""
+        RELEASE_TAG_COMPRESSION_SUFFIX: ""
+        IMAGE_VERSION: tmpl-v13
   needs:
     - job: docker_build_cluster_agent_fips_amd64
       artifacts: false


### PR DESCRIPTION
### What does this PR do?

Adds a third matrix entry (no explicit compression, empty `COMPRESSION` suffix, the compression is carried by the template itself https://github.com/DataDog/images/pull/10366) with a bumped template version to each internal image deploy job, alongside the existing `-zstd` and `-zstd-nydus` variants. this new variant is producing the exact same image as `-zstd-nydus` but without the suffix.

Also refactors how the matrix is structured:
- Removes `parallel.matrix` from the shared `.docker_trigger_base` template (it prevented per-job `IMAGE_VERSION` control)
- Each job now owns its full 3-entry matrix because we can't do it with different `IMAGE_VERSION`
- `COMPRESSION` values now include the leading dash (e.g. `-zstd` instead of `zstd`), and the script concatenates directly without a separator — functionally identical for existing entries

### Motivation

Part of [BARX-1184](https://datadoghq.atlassian.net/browse/BARX-1184). Introduces image publishing as a new variant. The existing zstd and zstd-nydus entries are left unchanged. Wd do this to simplify the tag management internally.

A follow-up PR (in a couple of weeks) will remove the zstd and zstd-nydus variants entirely to simplify the pipeline once the new variant is deployed.

### Describe how you validated your changes

CI-only change. The matrix structure is validated by the GitLab pipeline.

### Additional Notes

The template version bumps per job are:
- `agent` (jmx, fips): `tmpl-v24` → `tmpl-v25`
- `otel-agent` (standalone, fips): `tmpl-v7` → `tmpl-v8`
- `ddot-ebpf` (host profiler): `tmpl-v1` → `tmpl-v2`
- `datadog-cluster-agent` (dca, dca-fips): `tmpl-v12` → `tmpl-v13`

[BARX-1184]: https://datadoghq.atlassian.net/browse/BARX-1184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Tested on [this pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/120754096) which produced: 

No suffix:
```
❯ crane manifest --platform linux/amd64 registry.ddbuild.io/images/datadog-agent:dev-florent.clarret-agent-barx-1184-add-uncompressed-image-variant-29d577bf-fips-jmx | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "digest": "sha256:9deffcef6745d47bb13f0c28ef12d15a608d7c31d761d6a7473e236cc390a4b2",
    "size": 25766
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.nydus.blob.v1",
      "digest": "sha256:a9c567c9e1524c96564ab6bda72430527377b1399cda16eb07fdfb046f866dc3",
      "size": 362667628,
      "annotations": {
        "containerd.io/snapshot/nydus-blob": "true"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "digest": "sha256:19881451fb3d475ce5ff5d9c8b9fa01dec18962dd59d77a3bccef9cc18207c7d",
      "size": 1589267,
      "annotations": {
        "containerd.io/snapshot/nydus-bootstrap": "true",
        "containerd.io/snapshot/nydus-fs-version": "6"
      }
    }
  ],
  "annotations": {
    "ci.build_time": "2026-06-24T13:59:58Z",
    "com.datadoghq.image.source_path": "datadog-agent/tmpl-v25/Dockerfile.j2",
    "containerd.io/snapshot/nydus-builder-version": "v2.3.7",
    "containerd.io/snapshot/nydus-fs-version": "6",
    "containerd.io/snapshot/nydus-source-digest": "sha256:fed3de75e1e979c481a88ffe916c3662bb33e422fa23710e46ad358e5e4f1708",
    "containerd.io/snapshot/nydus-source-reference": "registry.ddbuild.io/datadog-agent:v120768689-fe5acf3-tmpl-v25-base",
    "org.opencontainers.image.source": "https://github.com/DataDog/images",
    "target": "staging"
  }
}
```

With suffix: 
```
❯ crane manifest --platform linux/amd64 registry.ddbuild.io/images/datadog-agent:dev-florent.clarret-agent-barx-1184-add-uncompressed-image-variant-29d577bf-fips-jmx-zstd-nydus | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "digest": "sha256:ed1e0df13382446566a6bc866c582ffb02c9890a180dc05920e90bb21704d995",
    "size": 25764
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.nydus.blob.v1",
      "digest": "sha256:d9ce894d6170231680020ee32fa6714530d057cfacef0a990bc866d7c3e2fa04",
      "size": 362667766,
      "annotations": {
        "containerd.io/snapshot/nydus-blob": "true"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "digest": "sha256:375bd8e5afec1a408ae142b3f93656012d2e482556630fbcfcdb5bb71b76dcf9",
      "size": 1589190,
      "annotations": {
        "containerd.io/snapshot/nydus-bootstrap": "true",
        "containerd.io/snapshot/nydus-fs-version": "6"
      }
    }
  ],
  "annotations": {
    "ci.build_time": "2026-06-24T13:59:57Z",
    "com.datadoghq.image.source_path": "datadog-agent/tmpl-v24/Dockerfile.j2",
    "containerd.io/snapshot/nydus-builder-version": "v2.3.7",
    "containerd.io/snapshot/nydus-fs-version": "6",
    "containerd.io/snapshot/nydus-source-digest": "sha256:08d88176c7eb0d793cbc6ce79e97309dbdbc91f0d88744ec1d98daa998ccde92",
    "containerd.io/snapshot/nydus-source-reference": "registry.ddbuild.io/datadog-agent:v120768680-fe5acf3-tmpl-v24-nydus-base",
    "org.opencontainers.image.source": "https://github.com/DataDog/images",
    "target": "staging"
  }
}
```
