### PR TITLE
[synthetics][SYNTH-26326] Classify SACK errors as SACK_NOT_SUPPORTED

### DIFF
--- a/cmd/system-probe/modules/traceroute.go
+++ b/cmd/system-probe/modules/traceroute.go
@@ -122,15 +122,16 @@ func handleTracerouteReqError(w http.ResponseWriter, statusCode int, errString s
 // with synthetics-worker so the UI shows the same text regardless of the
 // source. Messages may contain a %s placeholder for the destination hostname.
 var userFacingMessages = map[traceroutelib.ErrorCode]string{
-	traceroutelib.ErrCodeDNS:            "Failed to resolve the host name %s.",
-	traceroutelib.ErrCodeTimeout:        "The request timed out.",
-	traceroutelib.ErrCodeConnRefused:    "The connection to %s was refused by the remote host.",
-	traceroutelib.ErrCodeHostUnreach:    "The remote host %s is unreachable.",
-	traceroutelib.ErrCodeNetUnreach:     "The remote network for %s is unreachable.",
-	traceroutelib.ErrCodeDenied:         "Permission denied.",
-	traceroutelib.ErrCodeInvalidRequest: "Invalid request parameters.",
-	traceroutelib.ErrCodeFailedEncoding: "Failed to encode the response.",
-	traceroutelib.ErrCodeUnknown:        "An unknown error occurred.",
+	traceroutelib.ErrCodeDNS:                      "Failed to resolve the host name %s.",
+	traceroutelib.ErrCodeTimeout:                  "The request timed out.",
+	traceroutelib.ErrCodeConnRefused:              "The connection to %s was refused by the remote host.",
+	traceroutelib.ErrCodeHostUnreach:              "The remote host %s is unreachable.",
+	traceroutelib.ErrCodeNetUnreach:               "The remote network for %s is unreachable.",
+	traceroutelib.ErrCodeDenied:                   "Permission denied.",
+	traceroutelib.ErrCodeInvalidRequest:           "Invalid request parameters.",
+	traceroutelib.ErrCodeFailedEncoding:           "Failed to encode the response.",
+	traceroutelib.ErrCodeUnknown:                  "An unknown error occurred.",
+	traceroutelib.ErrorCode("SACK_NOT_SUPPORTED"): "SACK is not supported for this target/source.",
 }
 
 func userFacingMessage(code traceroutelib.ErrorCode, host string, fallback string) string {

--- a/comp/networkpath/traceroute/impl-remote/traceroute.go
+++ b/comp/networkpath/traceroute/impl-remote/traceroute.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
@@ -86,6 +87,11 @@ var getSysProbeClient = funcs.MemoizeArgNoError(func(socket string) *http.Client
 	}
 })
 
+func isSACKNotSupportedMessage(message string) bool {
+	return strings.Contains(message, "SACK not supported for this target/source") ||
+		strings.Contains(message, "found no SACK options")
+}
+
 func (t *remoteTraceroute) getTracerouteFromSysProbe(ctx context.Context, clientID string, host string, port uint16, protocol payload.Protocol, tcpMethod payload.TCPMethod, tcpSynParisTracerouteMode bool, disableWindowsDriver bool, reverseDNS bool, maxTTL uint8, timeout time.Duration, tracerouteQueries int, e2eQueries int) ([]byte, error) {
 	httpTimeout := timeout*time.Duration(maxTTL) + 10*time.Second // allow extra time for the system probe communication overhead, calculate full timeout for TCP traceroute
 	t.log.Tracef("Network Path traceroute HTTP request timeout: %s", httpTimeout)
@@ -120,6 +126,16 @@ func (t *remoteTraceroute) getTracerouteFromSysProbe(ctx context.Context, client
 		// Try to parse structured error response
 		var errResp payload.TracerouteErrorResponse
 		if json.Unmarshal(body, &errResp) == nil && errResp.Code != "" {
+			// Remap SACK_NOT_SUPPORTED directly, and detect SACK patterns in UNKNOWN.
+			// Compatibility: datadog-traceroute versions without a dedicated SACK_NOT_SUPPORTED
+			// code classify sack.NotSupportedError as UNKNOWN; detect it by message content.
+			if errResp.Code == payload.TracerouteErrCodeSACKNotSupported ||
+				(errResp.Code == payload.TracerouteErrCodeUnknown && isSACKNotSupportedMessage(errResp.Message)) {
+				return nil, &payload.TracerouteError{
+					Code:    payload.TracerouteErrCodeSACKNotSupported,
+					Message: "SACK is not supported for this target/source.",
+				}
+			}
 			return nil, &payload.TracerouteError{
 				Code:    errResp.Code,
 				Message: errResp.Message,

--- a/comp/networkpath/traceroute/impl-remote/traceroute_test.go
+++ b/comp/networkpath/traceroute/impl-remote/traceroute_test.go
@@ -204,6 +204,85 @@ func TestGetTracerouteStructuredError(t *testing.T) {
 	}
 }
 
+func TestGetTracerouteSACKNotSupported(t *testing.T) {
+	const sackMessage = "sack traceroute failed: ReceiveProbe() failed: SACK not supported for this target/source: endpoint returned SACK-permitted but found no SACK options: sackDriver found no SACK options"
+	const standardMessage = "SACK is not supported for this target/source."
+
+	tests := []struct {
+		name         string
+		errorCode    payload.TracerouteErrorCode
+		errorMessage string
+		expectedCode payload.TracerouteErrorCode
+		expectedMsg  string
+	}{
+		{
+			name:         "SACK_NOT_SUPPORTED code is remapped with standard message",
+			errorCode:    payload.TracerouteErrCodeSACKNotSupported,
+			errorMessage: sackMessage,
+			expectedCode: payload.TracerouteErrCodeSACKNotSupported,
+			expectedMsg:  standardMessage,
+		},
+		{
+			name:         "UNKNOWN code with SACK not supported message is remapped",
+			errorCode:    payload.TracerouteErrCodeUnknown,
+			errorMessage: sackMessage,
+			expectedCode: payload.TracerouteErrCodeSACKNotSupported,
+			expectedMsg:  standardMessage,
+		},
+		{
+			name:         "UNKNOWN code with found no SACK options message is remapped",
+			errorCode:    payload.TracerouteErrCodeUnknown,
+			errorMessage: "endpoint returned SACK-permitted but found no SACK options",
+			expectedCode: payload.TracerouteErrCodeSACKNotSupported,
+			expectedMsg:  standardMessage,
+		},
+		{
+			name:         "UNKNOWN code with unrelated message is not remapped",
+			errorCode:    payload.TracerouteErrCodeUnknown,
+			errorMessage: "some other unknown error",
+			expectedCode: payload.TracerouteErrCodeUnknown,
+			expectedMsg:  "some other unknown error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostnameComponent, _ := hostnameinterface.NewMock("test-agent-hostname")
+
+			errResp := payload.TracerouteErrorResponse{Code: tt.errorCode, Message: tt.errorMessage}
+			jsonBytes, err := json.Marshal(errResp)
+			require.NoError(t, err)
+
+			client := &http.Client{
+				Transport: &mockTransport{
+					RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       io.NopCloser(bytes.NewReader(jsonBytes)),
+							Header:     make(http.Header),
+						}, nil
+					},
+				},
+			}
+
+			cfg := config.Config{
+				DestHostname: "example.com",
+				DestPort:     80,
+				Protocol:     payload.ProtocolTCP,
+			}
+
+			rt := &remoteTraceroute{sysprobeClient: client, log: logmock.New(t), hostname: hostnameComponent}
+			_, err = rt.Run(context.Background(), cfg)
+			require.Error(t, err)
+
+			var trErr *payload.TracerouteError
+			require.ErrorAs(t, err, &trErr)
+			assert.Equal(t, tt.expectedCode, trErr.Code)
+			assert.Equal(t, tt.expectedMsg, trErr.Message)
+		})
+	}
+}
+
 func TestGetTraceroutePlainTextErrorFallback(t *testing.T) {
 	hostnameComponent, _ := hostnameinterface.NewMock("test-agent-hostname")
 

--- a/pkg/networkpath/payload/traceroute_errors.go
+++ b/pkg/networkpath/payload/traceroute_errors.go
@@ -31,6 +31,8 @@ const (
 	TracerouteErrCodeFailedEncoding TracerouteErrorCode = "FAILED_ENCODING"
 	// TracerouteErrCodeUnknown is the catch-all for unclassified errors.
 	TracerouteErrCodeUnknown TracerouteErrorCode = "UNKNOWN"
+	// TracerouteErrCodeSACKNotSupported indicates that SACK is not supported for the target/source.
+	TracerouteErrCodeSACKNotSupported TracerouteErrorCode = "SACK_NOT_SUPPORTED"
 )
 
 // TracerouteError is a classified error returned from the system-probe


### PR DESCRIPTION
### What does this PR do?

Classifies SACK not-supported errors from the datadog-traceroute sidecar as `SACK_NOT_SUPPORTED` instead of the generic `UNKNOWN` failure code.

Fixes [SYNTH-26326](https://datadoghq.atlassian.net/browse/SYNTH-26326). Agent-side equivalent of synthetics-worker [#10408](https://github.com/DataDog/synthetics-worker/pull/10408).

### Motivation

The `datadog-traceroute` library (≤1.0.15) classifies `sack.NotSupportedError` as `UNKNOWN` in `ClassifyError` — no dedicated code exists yet. When the agent's system-probe runs a TCP traceroute against a target that doesn't support SACK, the agent reports a generic `UNKNOWN` failure instead of a meaningful `SACK_NOT_SUPPORTED` one.

The fix lives in `impl-remote` (the agent-side HTTP client that calls system-probe): it detects the SACK message pattern in `UNKNOWN` responses and remaps to `SACK_NOT_SUPPORTED` with a standard user-facing message. The `syntheticstestscheduler` worker already passes error codes through generically, so it picks up the new code with no change.

### Describe how you validated your changes

- Added `TestGetTracerouteSACKNotSupported` covering:
  - `SACK_NOT_SUPPORTED` code passed directly → remapped with standard message
  - `UNKNOWN` + SACK message → remapped to `SACK_NOT_SUPPORTED`
  - `UNKNOWN` + `found no SACK options` message → remapped to `SACK_NOT_SUPPORTED`
  - `UNKNOWN` + unrelated message → stays `UNKNOWN`

### Additional Notes

- `cmd/system-probe/modules/traceroute.go`: forward-compat `userFacingMessages` entry added for when the library eventually emits `SACK_NOT_SUPPORTED` natively.
- `pkg/networkpath/payload/traceroute_errors.go`: new `TracerouteErrCodeSACKNotSupported = "SACK_NOT_SUPPORTED"` constant, mirroring the wire value used by the worker.


[SYNTH-26326]: https://datadoghq.atlassian.net/browse/SYNTH-26326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ