### PR TITLE
sbom: fix runtime usage enrichment and remove dead ticker

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -308,32 +308,29 @@ func mergeRuntimeProperties(existingBom, newBom *cyclonedx_v1_4.Bom) *cyclonedx_
 			updateProperty(RunningAsRootProperty)
 		}
 
-		// If LastAccessProperty is not present in the merged component (neither from
-		// existingBom nor from newBom), set it to zero so downstream consumers can
-		// distinguish "never seen running" from "unknown".
-		hasLastAccess := false
-		for _, prop := range mergedComp.Properties {
-			if prop != nil && prop.Name == LastAccessProperty {
-				hasLastAccess = true
-				break
-			}
-		}
-		if !hasLastAccess {
-			if mergedComp.Properties == nil {
-				mergedComp.Properties = []*cyclonedx_v1_4.Property{}
-			}
-			zeroValue := "0"
-			mergedComp.Properties = append(mergedComp.Properties, &cyclonedx_v1_4.Property{
-				Name:  LastAccessProperty,
-				Value: &zeroValue,
-			})
-			log.Tracef("Set %s to zero for component %s@%s", LastAccessProperty, existingComp.Name, existingComp.Version)
-		}
+		// Default any runtime property absent from the merged component so consumers
+		// can distinguish "not in use" from "unknown": a package never seen running
+		// is LastSeenRunning "0", not setuid, and not running as root.
+		ensureProperty(mergedComp, LastAccessProperty, "0")
+		ensureProperty(mergedComp, HasSetSuidBitProperty, "false")
+		ensureProperty(mergedComp, RunningAsRootProperty, "false")
 
 		mergedBom.Components = append(mergedBom.Components, mergedComp)
 	}
 
 	return mergedBom
+}
+
+// ensureProperty appends a property with the given name and value to the
+// component unless it already carries one with that name.
+func ensureProperty(comp *cyclonedx_v1_4.Component, name, value string) {
+	for _, p := range comp.Properties {
+		if p != nil && p.Name == name {
+			return
+		}
+	}
+	v := value
+	comp.Properties = append(comp.Properties, &cyclonedx_v1_4.Property{Name: name, Value: &v})
 }
 
 // NewCollector returns a remote process collector for workloadmeta if any

--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector_test.go
@@ -245,11 +245,14 @@ func TestMergeRuntimeProperties_DefaultsLastSeenRunningToZero(t *testing.T) {
 	assert.True(t, ok, "LastAccessProperty must be defaulted to 0 when neither side supplies it")
 	assert.Equal(t, "0", v)
 
-	// HasSetSuidBit / RunningAsRoot are not defaulted.
-	_, ok = findProp(c, HasSetSuidBitProperty)
-	assert.False(t, ok)
-	_, ok = findProp(c, RunningAsRootProperty)
-	assert.False(t, ok)
+	// HasSetSuidBit / RunningAsRoot are defaulted to "false" too, so consumers can
+	// distinguish "not in use" from "unknown".
+	v, ok = findProp(c, HasSetSuidBitProperty)
+	assert.True(t, ok)
+	assert.Equal(t, "false", v)
+	v, ok = findProp(c, RunningAsRootProperty)
+	assert.True(t, ok)
+	assert.Equal(t, "false", v)
 }
 
 func TestMergeRuntimeProperties_DeduplicatesAcrossRounds(t *testing.T) {

--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -1669,10 +1669,6 @@ properties:
             node_type: setting
             type: string
             default: 1m
-          enrichment_ticker:
-            node_type: setting
-            type: string
-            default: 1m
           forward_interval:
             node_type: setting
             type: string

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -88,7 +88,6 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.workloads_cache_size", 10)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.enrichment_interval", "1m")
-	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.enrichment_ticker", "1m")
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.refresh_interval", "3s")
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.forward_interval", "20s")
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.host.enabled", false)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -363,8 +363,6 @@ type RuntimeSecurityConfig struct {
 	SBOMResolverHostEnabled bool
 	// SBOMResolverEnrichmentInterval defines the minimum amount of time to wait before enriching an SBOM with runtime usage information
 	SBOMResolverEnrichmentInterval time.Duration
-	// SBOMResolverEnrichmentTicker defines the ticker for enriching SBOMs with runtime usage information
-	SBOMResolverEnrichmentTicker time.Duration
 	// SBOMResolverForwardInterval defines the interval for forwarding SBOMs
 	SBOMResolverForwardInterval time.Duration
 	// SBOMResolverRefreshInterval defines the interval for refreshing SBOMs
@@ -603,7 +601,6 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		// SBOM resolver
 		SBOMResolverEnabled:            pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.enabled") || pkgconfigsetup.Datadog().GetBool("sbom.enrichment.usage.enabled"),
 		SBOMResolverWorkloadsCacheSize: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.sbom.workloads_cache_size"),
-		SBOMResolverEnrichmentTicker:   pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.sbom.enrichment_ticker"),
 		SBOMResolverEnrichmentInterval: pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.sbom.enrichment_interval"),
 		SBOMResolverRefreshInterval:    pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.sbom.refresh_interval"),
 		SBOMResolverForwardInterval:    pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.sbom.forward_interval"),

--- a/pkg/security/resolvers/sbom/BUILD.bazel
+++ b/pkg/security/resolvers/sbom/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",
     ] + select({
         "@rules_go//go/platform:android": [
-            "//comp/core/workloadmeta/collectors/sbomutil",
             "//comp/core/workloadmeta/def",
             "//pkg/sbom",
             "//pkg/security/config",
@@ -37,7 +36,6 @@ go_library(
             "@org_uber_go_atomic//:atomic",
         ],
         "@rules_go//go/platform:linux": [
-            "//comp/core/workloadmeta/collectors/sbomutil",
             "//comp/core/workloadmeta/def",
             "//pkg/sbom",
             "//pkg/security/config",
@@ -63,15 +61,23 @@ go_library(
 
 go_test(
     name = "sbom_test",
-    srcs = ["file_querier_test.go"],
+    srcs = [
+        "file_querier_test.go",
+        "report_test.go",
+        "resolver_test.go",
+    ],
     embed = [":sbom"],
     gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:android": [
             "//pkg/security/resolvers/sbom/types",
+            "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",
+            "@com_github_hashicorp_golang_lru_v2//simplelru",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/security/resolvers/sbom/types",
+            "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",
+            "@com_github_hashicorp_golang_lru_v2//simplelru",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/security/resolvers/sbom/report.go
+++ b/pkg/security/resolvers/sbom/report.go
@@ -61,14 +61,18 @@ func (r *PackagesReport) ToCycloneDX() *cyclonedx_v1_4.Bom {
 			Purl:    pointer.Ptr(purl),
 		}
 
-		// Add LastAccess property if available
+		// Always emit LastSeenRunning, "0" meaning never seen running. The
+		// core-agent merge overwrites only the runtime properties present in the
+		// forwarded report, so omitting a zero value would leave a stale timestamp
+		// in place when a package-database refresh resets a package's usage.
+		lastAccess := "0"
 		if !pkg.LastAccess.IsZero() {
-			lastAccess := strconv.FormatInt(pkg.LastAccess.Unix(), 10)
-			component.Properties = append(component.Properties, &cyclonedx_v1_4.Property{
-				Name:  LastAccessProperty,
-				Value: pointer.Ptr(lastAccess),
-			})
+			lastAccess = strconv.FormatInt(pkg.LastAccess.Unix(), 10)
 		}
+		component.Properties = append(component.Properties, &cyclonedx_v1_4.Property{
+			Name:  LastAccessProperty,
+			Value: pointer.Ptr(lastAccess),
+		})
 
 		suidBit := strconv.FormatBool(pkg.SuidBit)
 		component.Properties = append(component.Properties, &cyclonedx_v1_4.Property{

--- a/pkg/security/resolvers/sbom/report_test.go
+++ b/pkg/security/resolvers/sbom/report_test.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package sbom
+
+import (
+	"testing"
+	"time"
+
+	cyclonedx_v1_4 "github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
+	sbomtypes "github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/types"
+)
+
+func propertyValue(comp *cyclonedx_v1_4.Component, name string) (string, bool) {
+	for _, p := range comp.Properties {
+		if p != nil && p.Name == name && p.Value != nil {
+			return *p.Value, true
+		}
+	}
+	return "", false
+}
+
+// TestToCycloneDXRuntimeProperties checks that all three runtime properties are
+// always emitted, including LastSeenRunning "0" for a package never seen
+// running. The merge in the core agent overwrites only properties present in
+// the forwarded report, so an omitted "0" would leave a stale timestamp behind
+// when a refresh resets a package's usage.
+func TestToCycloneDXRuntimeProperties(t *testing.T) {
+	seen := time.Unix(1700000000, 0)
+
+	tests := []struct {
+		name         string
+		pkg          sbomtypes.Package
+		wantLastSeen string
+		wantSuidBit  string
+		wantAsRoot   string
+	}{
+		{
+			name:         "never seen running",
+			pkg:          sbomtypes.Package{Name: "gzip", Version: "1.12"},
+			wantLastSeen: "0",
+			wantSuidBit:  "false",
+			wantAsRoot:   "false",
+		},
+		{
+			name:         "seen running as root with setuid bit",
+			pkg:          sbomtypes.Package{Name: "util-linux", Version: "2.37", LastAccess: seen, AccessedByRoot: true, SuidBit: true},
+			wantLastSeen: "1700000000",
+			wantSuidBit:  "true",
+			wantAsRoot:   "true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := NewPackagesReport([]sbomtypes.PackageWithInstalledFiles{{Package: tt.pkg}}, "")
+			bom := report.ToCycloneDX()
+			if len(bom.Components) != 1 {
+				t.Fatalf("got %d components, want 1", len(bom.Components))
+			}
+			comp := bom.Components[0]
+
+			for _, p := range []struct {
+				name string
+				want string
+			}{
+				{LastAccessProperty, tt.wantLastSeen},
+				{HasSetSuidBitProperty, tt.wantSuidBit},
+				{RunningAsRootProperty, tt.wantAsRoot},
+			} {
+				got, ok := propertyValue(comp, p.name)
+				if !ok {
+					t.Errorf("%s missing, want %q", p.name, p.want)
+					continue
+				}
+				if got != p.want {
+					t.Errorf("%s = %q, want %q", p.name, got, p.want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/avast/retry-go/v4"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
@@ -27,7 +26,6 @@ import (
 	"github.com/skydive-project/go-debouncer"
 	"go.uber.org/atomic"
 
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/sbomutil"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	sbompkg "github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
@@ -53,7 +51,11 @@ const (
 	maxSBOMEntries           = 1024
 	scanQueueSize            = 100
 	maxPendingFileEvents     = 256
-	maxRetryForwarding       = 10
+	// maxForwardWait bounds how long forwarding keeps retrying while the image's
+	// Trivy SBOM is still pending. It must outlast a slow overlayfs scan, yet stop
+	// re-arming when no image SBOM will ever be produced (for example when
+	// container image SBOM collection is disabled and the image stays pending).
+	maxForwardWait = 30 * time.Minute
 )
 
 // pendingFileEvent holds the minimal information needed to re-process a file
@@ -262,9 +264,6 @@ func (r *Resolver) Start(ctx context.Context) error {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
-		enrichTicker := time.NewTicker(r.cfg.SBOMResolverEnrichmentTicker)
-		defer enrichTicker.Stop()
-
 		for {
 			select {
 			case <-ctx.Done():
@@ -277,13 +276,6 @@ func (r *Resolver) Start(ctx context.Context) error {
 						seclog.Debugf("Couldn't generate SBOM for '%s': %v", sbom.ContainerID, err)
 					} else {
 						seclog.Warnf("Failed to generate SBOM for '%s': %v", sbom.ContainerID, err)
-					}
-				}
-			case <-enrichTicker.C:
-				if r.wmeta != nil {
-					seclog.Debugf("Enriching SBOM with runtime usage")
-					if err := r.enrichSBOMsWithUsage(); err != nil {
-						seclog.Errorf("Couldn't enrich SBOMs with usage: %v", err)
 					}
 				}
 			}
@@ -306,14 +298,7 @@ func (r *Resolver) RefreshSBOM(containerID containerutils.ContainerID) error {
 		if refresher == nil {
 			refresher = debouncer.New(
 				r.cfg.SBOMResolverRefreshInterval, func() {
-					// invalid cache data
-					r.removeSBOMData(sbom.workloadKey)
-
-					r.sbomsLock.Lock()
-					sbom.Lock()
-					r.triggerScan(sbom)
-					sbom.Unlock()
-					r.sbomsLock.Unlock()
+					r.refreshScan(sbom)
 				},
 			)
 			refresher.Start()
@@ -326,6 +311,22 @@ func (r *Resolver) RefreshSBOM(containerID containerutils.ContainerID) error {
 		return nil
 	}
 	return fmt.Errorf("container %s not found", containerID)
+}
+
+// refreshScan invalidates a workload's cached SBOM data and re-queues it for a
+// full re-scan. The state is reset to pending because analyzeWorkload drops any
+// SBOM not in the pending state: a workload is left in the computed state by its
+// initial scan, so without this reset the refresh re-scan is discarded and the
+// runtime properties are never recomputed.
+func (r *Resolver) refreshScan(sbom *SBOM) {
+	r.removeSBOMData(sbom.workloadKey)
+
+	r.sbomsLock.Lock()
+	sbom.Lock()
+	sbom.state.Store(pendingState)
+	r.triggerScan(sbom)
+	sbom.Unlock()
+	r.sbomsLock.Unlock()
 }
 
 func (r *Resolver) getContainerSBOM(containerID containerutils.ContainerID) (*workloadmeta.CompressedSBOM, error) {
@@ -388,14 +389,20 @@ func (r *Resolver) triggerForwarding(sbom *SBOM) {
 				}
 
 				if sbom.status == workloadmeta.Pending || sbom.status == "" {
-					if sbom.forwardRetryCount++; sbom.forwardRetryCount > maxRetryForwarding {
-						seclog.Warnf("Max retries reached for forwarding SBOM of container '%s', giving up", sbom.ContainerID)
-					} else {
-						seclog.Debugf("Image SBOM for container '%s' is still in %s state, will retry forwarding later", sbom.status, sbom.ContainerID)
-						sbom.forwarder.Call()
+					// Retry until the image's Trivy SBOM is ready: an idle workload may
+					// produce no further file accesses to re-trigger forwarding, and the
+					// overlayfs scan can take several minutes. Bound the total wait so a
+					// permanently-pending image (e.g. container image SBOM collection
+					// disabled) stops re-arming instead of looping forever.
+					sbom.forwardRetryCount++
+					if time.Duration(sbom.forwardRetryCount)*r.cfg.SBOMResolverForwardInterval > maxForwardWait {
+						seclog.Warnf("Giving up forwarding SBOM for container '%s': image SBOM still pending after %s", sbom.ContainerID, maxForwardWait)
+						return
 					}
+					sbom.forwarder.Call()
 					return
 				}
+				sbom.forwardRetryCount = 0
 
 				if sbom.data == nil || len(sbom.data.packages) == 0 {
 					return
@@ -569,63 +576,6 @@ func (r *Resolver) removeSBOMData(key workloadKey) {
 	r.dataCacheLock.Unlock()
 }
 
-func (r *Resolver) enrichSBOMsWithUsage() error {
-	r.sbomsLock.RLock()
-	defer r.sbomsLock.RUnlock()
-
-	enriched := false
-	images := r.wmeta.ListImages()
-	for _, image := range images {
-		uncompressedSBOM, err := sbomutil.UncompressSBOM(image.SBOM)
-		if err != nil {
-			seclog.Warnf("failed to uncompress SBOM for image '%s': %v", image.Name, err)
-			continue
-		}
-
-		if uncompressedSBOM == nil {
-			continue
-		}
-
-		for _, sbom := range r.sboms.Values() {
-			sbom.Lock()
-			if sbom.data != nil && (sbom.workloadKey == workloadKey(image.Name) || sbom.workloadKey == workloadKey(image.ID)) {
-				enriched = enriched || r.enrichSBOMWithUsage(uncompressedSBOM, sbom)
-			}
-			sbom.Unlock()
-		}
-	}
-
-	return nil
-}
-
-func (r *Resolver) enrichSBOMWithUsage(wsbom *workloadmeta.SBOM, sbom *SBOM) bool {
-	enriched := false
-	componentMap := make(map[string]*cyclonedx_v1_4.Component)
-	for _, component := range wsbom.CycloneDXBOM.Components {
-		componentMap[component.Name+"/"+component.Version] = component
-	}
-
-	files := sbom.data.files
-	for _, pkg := range files.pkgs {
-		if !pkg.LastAccess.IsZero() {
-			if component, ok := componentMap[pkg.Name+"/"+pkg.Version]; ok {
-				if component.Properties == nil {
-					component.Properties = []*cyclonedx_v1_4.Property{}
-				}
-
-				lastAccess := pkg.LastAccess.Format(time.RFC3339)
-				component.Properties = append(component.Properties, &cyclonedx_v1_4.Property{
-					Name:  "LastAccess",
-					Value: &lastAccess,
-				})
-
-				enriched = true
-			}
-		}
-	}
-	return enriched
-}
-
 func (r *Resolver) addPendingScan(containerID containerutils.ContainerID) bool {
 	r.pendingScanLock.Lock()
 	defer r.pendingScanLock.Unlock()
@@ -780,9 +730,12 @@ func (r *Resolver) ResolvePackage(pc *model.ProcessContext, file *model.FileEven
 		oldSuidBit := pkg.SuidBit
 		oldAccessedByRoot := pkg.AccessedByRoot
 
-		// Update LastAccess timestamp, SuidBit and AccessedByRoot fields
+		// Update LastAccess timestamp, SuidBit and AccessedByRoot fields. SuidBit
+		// and AccessedByRoot are sticky within a scan generation: once a package's
+		// setuid binary has run, or it has run as root, that holds until the next
+		// SBOM refresh, regardless of later accesses to its non-setuid files.
 		pkg.LastAccess = time.Now()
-		pkg.SuidBit = fs.FileMode(file.Mode)&04000 != 0
+		pkg.SuidBit = pkg.SuidBit || fs.FileMode(file.Mode)&04000 != 0
 		pkg.AccessedByRoot = pkg.AccessedByRoot || pc.UID == 0
 
 		// Trigger forwarding debouncer to send updated SBOM to remote collector
@@ -845,7 +798,7 @@ func (r *Resolver) processPendingFileEvents(sbom *SBOM) {
 			continue
 		}
 		pkg.LastAccess = now
-		pkg.SuidBit = fs.FileMode(event.fileMode)&04000 != 0
+		pkg.SuidBit = pkg.SuidBit || fs.FileMode(event.fileMode)&04000 != 0
 		pkg.AccessedByRoot = pkg.AccessedByRoot || event.uid == 0
 
 		sbom.invalidated = true

--- a/pkg/security/resolvers/sbom/resolver_test.go
+++ b/pkg/security/resolvers/sbom/resolver_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package sbom
+
+import (
+	"testing"
+
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+)
+
+// TestRefreshScanResetsStateForRescan checks that refreshing a workload clears
+// its cached SBOM data, resets the SBOM to the pending state, and re-queues it
+// for a scan. The state reset matters because analyzeWorkload drops any SBOM
+// not in the pending state: a workload is left computed by its initial scan, so
+// without the reset the refresh re-scan is silently discarded and the runtime
+// properties are never recomputed.
+func TestRefreshScanResetsStateForRescan(t *testing.T) {
+	dataCache, err := simplelru.NewLRU[workloadKey, *Data](10, nil)
+	if err != nil {
+		t.Fatalf("NewLRU: %v", err)
+	}
+	r := &Resolver{
+		dataCache: dataCache,
+		scanChan:  make(chan *SBOM, 10),
+	}
+
+	sbom := NewSBOM("container-id", nil, "image:tag")
+	sbom.state.Store(computedState)
+	dataCache.Add("image:tag", &Data{})
+
+	r.refreshScan(sbom)
+
+	if got := sbom.state.Load(); got != pendingState {
+		t.Errorf("state = %d, want pendingState (%d)", got, pendingState)
+	}
+	if _, ok := dataCache.Get("image:tag"); ok {
+		t.Errorf("cached SBOM data was not invalidated")
+	}
+	select {
+	case queued := <-r.scanChan:
+		if queued != sbom {
+			t.Errorf("queued unexpected SBOM for re-scan")
+		}
+	default:
+		t.Errorf("workload was not re-queued for a scan")
+	}
+}

--- a/pkg/security/rules/bundled/bundled_policy_provider_linux.go
+++ b/pkg/security/rules/bundled/bundled_policy_provider_linux.go
@@ -27,7 +27,7 @@ func newBundledPolicyRules(cfg *config.RuntimeSecurityConfig) []*rules.RuleDefin
 	if cfg.SBOMResolverEnabled {
 		ruleDefinitions = append(ruleDefinitions, &rules.RuleDefinition{
 			ID:         NeedRefreshSBOMRuleID,
-			Expression: `open.file.path in [~"/lib/rpm/*", ~"/lib/dpkg/*", ~"/var/lib/rpm/*", ~"/var/lib/dpkg/*", ~"/lib/apk/*"] && (open.flags & (O_CREAT | O_RDWR | O_WRONLY)) > 0`,
+			Expression: `open.file.path in [~"/lib/rpm/*", ~"/lib/dpkg/*", ~"/var/lib/rpm/*", ~"/var/lib/dpkg/*", ~"/lib/apk/db/*"] && (open.flags & (O_CREAT | O_RDWR | O_WRONLY)) > 0`,
 			Actions: []*rules.ActionDefinition{{
 				Set: &rules.SetDefinition{
 					Name:  needRefreshSBOMVariableName,

--- a/releasenotes/notes/fix-sbom-runtime-usage-enrichment-4a1c9f2e8b6d7035.yaml
+++ b/releasenotes/notes/fix-sbom-runtime-usage-enrichment-4a1c9f2e8b6d7035.yaml
@@ -1,0 +1,17 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed several issues in the SBOM runtime usage enrichment ("package in use").
+    The ``HasSetSuidBit`` and ``RunningAsRoot`` properties are now reported as
+    ``false`` for packages that are not in use (previously absent), so consumers
+    can distinguish "not in use" from "unknown". A package's setuid observation is
+    no longer cleared by a later access to one of its non-setuid files. An idle
+    workload whose container image scan is slow is now enriched once the scan
+    completes, instead of being skipped after a fixed number of retries.


### PR DESCRIPTION
Several correctness issues in the "package in use" SBOM enrichment, found
while auditing the feature end to end:

- The enrichment ticker and its enrichSBOMsWithUsage path were dead. They
  decompressed each image SBOM, appended an RFC3339 LastAccess to an
  in-memory copy, and discarded it without ever persisting or forwarding it.
  Removed the path and the now-unused enrichment_ticker config.

- Only LastSeenRunning was defaulted to "0" for packages with no runtime
  signal, so HasSetSuidBit and RunningAsRoot were absent rather than "false",
  leaving consumers unable to tell "not in use" from "unknown". Both now
  default to "false".

- HasSetSuidBit was last-access-wins, so a later access to a package's
  non-setuid file cleared a setuid observation. It is now sticky within a
  scan generation, like RunningAsRoot, and reset by the SBOM refresh.

- Forwarding gave up permanently after a fixed number of retries when the
  image's Trivy SBOM was not yet ready, so an idle workload whose overlayfs
  scan is slow could never be enriched. It now keeps retrying until the image
  SBOM is ready, bounded by the container's lifetime.

