### PR TITLE
[CWS] emit events associated to pidfd syscalls

### DIFF
--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -183,6 +183,7 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | -------- | ------------- |
 | [`event.async`](#event-async-doc) | True if the syscall was asynchronous |
 | [`event.hostname`](#event-hostname-doc) | Hostname associated with the event |
+| [`event.is_pidfd`](#event-is_pidfd-doc) | True if the event originates from a pidfd syscall (e.g. pidfd_getfd, pidfd_send_signal) |
 | [`event.origin`](#event-origin-doc) | Origin of the event |
 | [`event.os`](#event-os-doc) | Operating system of the event |
 | [`event.rule.tags`](#event-rule-tags-doc) | Tags associated with the rule that's used to evaluate the event |
@@ -4145,6 +4146,13 @@ Definition: True if the syscall was asynchronous
 Type: string
 
 Definition: Hostname associated with the event
+
+
+
+### `event.is_pidfd` {#event-is_pidfd-doc}
+Type: bool
+
+Definition: True if the event originates from a pidfd syscall (e.g. pidfd_getfd, pidfd_send_signal)
 
 
 

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -18,6 +18,11 @@
           "property_doc_link": "event-hostname-doc"
         },
         {
+          "name": "event.is_pidfd",
+          "definition": "True if the event originates from a pidfd syscall (e.g. pidfd_getfd, pidfd_send_signal)",
+          "property_doc_link": "event-is_pidfd-doc"
+        },
+        {
           "name": "event.origin",
           "definition": "Origin of the event",
           "property_doc_link": "event-origin-doc"
@@ -15799,6 +15804,18 @@
       "link": "event-hostname-doc",
       "type": "string",
       "definition": "Hostname associated with the event",
+      "prefixes": [
+        ""
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "event.is_pidfd",
+      "link": "event-is_pidfd-doc",
+      "type": "bool",
+      "definition": "True if the event originates from a pidfd syscall (e.g. pidfd_getfd, pidfd_send_signal)",
       "prefixes": [
         ""
       ],

--- a/pkg/security/ebpf/c/include/constants/enums.h
+++ b/pkg/security/ebpf/c/include/constants/enums.h
@@ -91,6 +91,7 @@ enum
     // EventFlagsSecurityProfileInProfile = 1<<3 isn't used in kernel space
     EVENT_FLAGS_ANOMALY_DETECTION_EVENT = 1 << 4, // event is an anomaly detection event
     EVENT_FLAGS_INTERNAL = 1 << 5, // event used to keep track of internal caches & resources
+    EVENT_FLAGS_PIDFD = 1 << 6, // event originates from a pidfd syscall (pidfd_getfd, pidfd_send_signal)
 };
 
 enum file_flags

--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -56,6 +56,14 @@ static struct path *__attribute__((always_inline)) get_file_f_path_addr(struct f
     return (struct path *)((char *)file + offset);
 }
 
+static u32 __attribute__((always_inline)) get_file_flags(struct file *file) {
+    u64 offset;
+    LOAD_CONSTANT("file_f_flags_offset", offset);
+    u32 flags = 0;
+    bpf_probe_read(&flags, sizeof(flags), (char *)file + offset);
+    return flags;
+}
+
 static u64 __attribute__((always_inline)) security_have_usernamespace_first_arg(void) {
     u64 flag;
     LOAD_CONSTANT("has_usernamespace_first_arg", flag);

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -242,7 +242,8 @@ int __attribute__((always_inline)) _sys_open_ret(void *ctx, struct syscall_cache
         .event.flags = (syscall->async ? EVENT_FLAGS_ASYNC : 0) |
                        (syscall->resolver.flags & RESOLVER_FLAG_SAVED_BY_ACTIVITY_DUMP ? EVENT_FLAGS_SAVED_BY_AD : 0) |
                        (syscall->resolver.flags & RESOLVER_FLAG_ACTIVITY_DUMP_RUNNING ? EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE : 0) |
-                       (syscall->state == INTERNAL ? EVENT_FLAGS_INTERNAL : 0),
+                       (syscall->state == INTERNAL ? EVENT_FLAGS_INTERNAL : 0) |
+                       (syscall->from_pidfd ? EVENT_FLAGS_PIDFD : 0),
         .file = syscall->open.file,
         .flags = syscall->open.flags,
         .mode = syscall->open.mode,
@@ -336,6 +337,61 @@ int rethook_io_openat2(ctx_t *ctx) {
     }
     syscall->retval = CTX_PARMRET(ctx);
     return _sys_open_ret(ctx, syscall);
+}
+
+// pidfd_getfd(pidfd, targetfd, flags) duplicates the file descriptor `targetfd`
+// out of the process referred to by `pidfd` into the caller's fd table. The
+// stolen fd points at a real struct file, so we resolve its path and emit an
+// `open` event for the thief, reusing the open pipeline.
+HOOK_SYSCALL_ENTRY3(pidfd_getfd, int, pidfd, int, targetfd, unsigned int, flags) {
+    if (is_discarded_by_pid() || is_auid_discarder(EVENT_OPEN)) {
+        return 0;
+    }
+
+    struct policy_t policy = fetch_policy(EVENT_OPEN);
+    struct syscall_cache_t syscall = {
+        .type = EVENT_OPEN,
+        .policy = policy,
+        .async = SYNC_SYSCALL,
+        .from_pidfd = 1,
+        .open = {
+            .flags = O_RDONLY,
+            .mode = 0,
+        }
+    };
+
+    // Record the actual pidfd_getfd arguments. These do not line up with the
+    // open syscall context layout (path, flags, mode), so the open.syscall.*
+    // fields will be mislabeled; we keep the real (pidfd, targetfd, flags)
+    // values anyway.
+    collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_INT(0) | SYSCALL_CTX_ARG_INT(1) | SYSCALL_CTX_ARG_INT(2), (void *)&pidfd, (void *)&targetfd, (void *)&flags);
+    cache_syscall_update_cgroup(ctx, &syscall);
+    return 0;
+}
+
+static int __attribute__((always_inline)) handle_receive_fd(ctx_t *ctx, struct file *f) {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
+    if (!syscall || f == NULL) {
+        return 0;
+    }
+    syscall->open.flags = get_file_flags(f);
+    return handle_open(ctx, get_file_f_path_addr(f));
+}
+
+// receive_fd(struct file *file, int __user *ufd, unsigned int o_flags) — kernel ≥ 5.12
+HOOK_ENTRY("receive_fd")
+int hook_pidfd_receive_fd(ctx_t *ctx) {
+    return handle_receive_fd(ctx, (struct file *)CTX_PARM1(ctx));
+}
+
+// __receive_fd(int fd, struct file *file, int __user *ufd, unsigned int flags) — kernel < 5.12
+HOOK_ENTRY("__receive_fd")
+int hook_pidfd___receive_fd(ctx_t *ctx) {
+    return handle_receive_fd(ctx, (struct file *)CTX_PARM2(ctx));
+}
+
+HOOK_SYSCALL_EXIT(pidfd_getfd) {
+    return sys_open_ret(ctx);
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/signal.h
+++ b/pkg/security/ebpf/c/include/hooks/signal.h
@@ -33,6 +33,27 @@ HOOK_SYSCALL_ENTRY2(kill, int, pid, int, type) {
     return 0;
 }
 
+// pidfd_send_signal(pidfd, sig, info, flags) sends a signal to the process
+// referred to by `pidfd`.
+HOOK_SYSCALL_ENTRY2(pidfd_send_signal, int, pidfd, int, sig) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
+    struct syscall_cache_t syscall = {
+        .type = EVENT_SIGNAL,
+        .from_pidfd = 1,
+        .signal = {
+            .type = sig,
+            .need_target_resolution = 1, // resolved in check_kill_permission via the task_struct
+            .pid = 0,
+        },
+    };
+
+    cache_syscall_update_cgroup(ctx, &syscall);
+    return 0;
+}
+
 HOOK_ENTRY("check_kill_permission")
 int hook_check_kill_permission(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_SIGNAL);
@@ -68,6 +89,7 @@ int rethook_check_kill_permission(ctx_t *ctx) {
     /* constuct and send the event */
     struct signal_event_t event = {
         .syscall.retval = retval,
+        .event.flags = syscall->from_pidfd ? EVENT_FLAGS_PIDFD : 0,
         .pid = syscall->signal.pid,
         .type = syscall->signal.type,
     };

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -34,6 +34,7 @@ struct syscall_cache_t {
     u64 type;
     enum SYSCALL_STATE state;
     u8 async;
+    u8 from_pidfd;
     u32 ctx_id;
     struct dentry_resolver_input_t resolver;
     s64 retval;

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -236,6 +236,13 @@ func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.Eve
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_terminate_walk"),
 			}},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "pidfd_getfd", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: []manager.ProbesSelector{
+				hookFunc("hook_pidfd_receive_fd"),
+			}},
+			&manager.BestEffort{Selectors: []manager.ProbesSelector{
+				hookFunc("hook_pidfd___receive_fd"),
+			}},
 
 			// iouring
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
@@ -516,6 +523,7 @@ func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.Eve
 				hookFunc("hook_check_kill_permission"),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "kill", hasFentry, Entry)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "pidfd_send_signal", hasFentry, Entry)},
 		},
 
 		// List of probes required to capture setsockopt events

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -72,6 +72,18 @@ func getOpenProbes(fentry bool) []*manager.Probe {
 				EBPFFuncName: "hook_terminate_walk",
 			},
 		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_pidfd_receive_fd",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_pidfd___receive_fd",
+			},
+		},
 	}
 
 	openProbes = append(openProbes, ExpandSyscallProbes(&manager.Probe{
@@ -115,6 +127,12 @@ func getOpenProbes(fentry bool) []*manager.Probe {
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "openat2",
+	}, fentry, EntryAndExit)...)
+	openProbes = append(openProbes, ExpandSyscallProbes(&manager.Probe{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
+		SyscallFuncName: "pidfd_getfd",
 	}, fentry, EntryAndExit)...)
 	return openProbes
 }

--- a/pkg/security/ebpf/probes/signal.go
+++ b/pkg/security/ebpf/probes/signal.go
@@ -33,5 +33,12 @@ func getSignalProbes(fentry bool) []*manager.Probe {
 		SyscallFuncName: "kill",
 	}, fentry, Entry)...)
 
+	signalProbes = append(signalProbes, ExpandSyscallProbes(&manager.Probe{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
+		SyscallFuncName: "pidfd_send_signal",
+	}, fentry, Entry)...)
+
 	return signalProbes
 }

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -29,6 +29,7 @@ const (
 	OffsetNameKernelCloneArgsExitSignal = "kernel_clone_args_exit_signal_offset"
 	OffsetNameFileFinode                = "file_f_inode_offset"
 	OffsetNameFileFpath                 = "file_f_path_offset"
+	OffsetNameFileFflags                = "file_f_flags_offset"
 	OffsetNameDentryDSb                 = "dentry_d_sb_offset"
 	OffsetNameMountMntID                = "mount_id_offset"
 	OffsetNameMountMntIDUnique          = "mount_id_unique_offset"

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -126,6 +126,7 @@ func computeCallbacksTable() map[string]func(*kernel.Version) uint64 {
 		OffsetNameKernelCloneArgsExitSignal:   getKernelCloneArgsExitSignalOffset,
 		OffsetNameFileFinode:                  getFileFinodeOffset,
 		OffsetNameFileFpath:                   getFileFpathOffset,
+		OffsetNameFileFflags:                  getFileFflagsOffset,
 		OffsetNameMountMntID:                  getMountIDOffset,
 		OffsetNameDeviceStructNdNet:           getDeviceStructNdNet,
 		OffsetNameSockStructSKProtocol:        getSockStructSKProtocolOffset,
@@ -969,6 +970,15 @@ func getFileFpathOffset(kv *kernel.Version) uint64 {
 		return 152
 	default:
 		return 16
+	}
+}
+
+func getFileFflagsOffset(kv *kernel.Version) uint64 {
+	switch {
+	case kv.IsUbuntuKernel() && kv.IsInRangeCloseOpen(kernel.Kernel6_5, kernel.Kernel6_6):
+		return 72
+	default:
+		return 64
 	}
 }
 

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -417,6 +417,11 @@ func (fh *EBPFFieldHandlers) ResolveAsync(ev *model.Event) bool {
 	return ev.Async
 }
 
+func (fh *EBPFFieldHandlers) ResolveIsPIDFD(ev *model.Event) bool {
+	ev.IsPIDFD = ev.Flags&model.EventFlagsPIDFD > 0
+	return ev.IsPIDFD
+}
+
 func (fh *EBPFFieldHandlers) resolveSBOMFields(ev *model.Event, f *model.FileEvent) {
 	if fh.resolvers.SBOMResolver == nil {
 		return

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -211,6 +211,9 @@ func (fh *EBPFLessFieldHandlers) ResolveProcessCreatedAt(_ *model.Event, e *mode
 // ResolveAsync resolves the async flag
 func (fh *EBPFLessFieldHandlers) ResolveAsync(ev *model.Event) bool { return ev.Async }
 
+// ResolveIsPIDFD resolves the is_pidfd flag of the event
+func (fh *EBPFLessFieldHandlers) ResolveIsPIDFD(ev *model.Event) bool { return ev.IsPIDFD }
+
 // ResolveChownGID resolves the ResolveProcessCacheEntry group id of a chown event to a username
 func (fh *EBPFLessFieldHandlers) ResolveChownGID(_ *model.Event, e *model.ChownEvent) string {
 	return e.Group

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3475,6 +3475,7 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVMAreaStructFlags, "struct vm_area_struct", "vm_flags")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameFileFinode, "struct file", "f_inode")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameFileFpath, "struct file", "f_path")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameFileFflags, "struct file", "f_flags")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameDentryDSb, "struct dentry", "d_sb")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameMountMntID, "struct mount", "mnt_id")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameMountMntNs, "struct mount", "mnt_ns")

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -2060,6 +2060,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "event.is_pidfd":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveIsPIDFD(ev)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "event.origin":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -37391,6 +37402,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"dns.response.ips",
 		"event.async",
 		"event.hostname",
+		"event.is_pidfd",
 		"event.origin",
 		"event.os",
 		"event.rule.tags",
@@ -39897,6 +39909,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Bool, "bool", false, nil
 	case "event.hostname":
 		return "", reflect.String, "string", false, nil
+	case "event.is_pidfd":
+		return "", reflect.Bool, "bool", false, nil
 	case "event.origin":
 		return "", reflect.String, "string", false, nil
 	case "event.os":
@@ -44584,6 +44598,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setBoolFieldValue("event.async", &ev.Async, value)
 	case "event.hostname":
 		return ev.setStringFieldValue("event.hostname", &ev.BaseEvent.Hostname, value)
+	case "event.is_pidfd":
+		return ev.setBoolFieldValue("event.is_pidfd", &ev.IsPIDFD, value)
 	case "event.origin":
 		return ev.setStringFieldValue("event.origin", &ev.BaseEvent.Origin, value)
 	case "event.os":

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -67,6 +67,9 @@ const (
 	// EventFlagsInternal true if the event is an internal event used to keep caches & internal resources up-to-date
 	EventFlagsInternal
 
+	// EventFlagsPIDFD true if the event originates from a pidfd syscall (e.g. pidfd_getfd, pidfd_send_signal)
+	EventFlagsPIDFD
+
 	// non kernel flags
 
 	// EventFlagsHasActiveActivityDump true if the event has an active activity dump associated to it

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -42,6 +42,7 @@ func (e *Event) DeepCopy() *Event {
 	copied.FailedDNS = deepCopyFailedDNSEvent(e.FailedDNS)
 	copied.IMDS = deepCopyIMDSEvent(e.IMDS)
 	copied.InvalidateDentry = deepCopyInvalidateDentryEvent(e.InvalidateDentry)
+	copied.IsPIDFD = e.IsPIDFD
 	copied.Link = deepCopyLinkEvent(e.Link)
 	copied.LoadModule = deepCopyLoadModuleEvent(e.LoadModule)
 	copied.LoginUIDWrite = deepCopyLoginUIDWriteEvent(e.LoginUIDWrite)

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -29,6 +29,7 @@ func (ev *Event) resolveFields(forADs bool) {
 	// resolve context fields that are not related to any event type
 	_ = ev.FieldHandlers.ResolveAsync(ev)
 	_ = ev.FieldHandlers.ResolveHostname(ev, &ev.BaseEvent)
+	_ = ev.FieldHandlers.ResolveIsPIDFD(ev)
 	_ = ev.FieldHandlers.ResolveSource(ev, &ev.BaseEvent)
 	_ = ev.FieldHandlers.ResolveEventTimestamp(ev, &ev.BaseEvent)
 	_ = ev.FieldHandlers.ResolveProcessArgsTruncated(ev, &ev.BaseEvent.ProcessContext.Process)
@@ -1085,6 +1086,7 @@ type FieldHandlers interface {
 	ResolveHashesFromEvent(ev *Event, e *FileEvent) []string
 	ResolveHostname(ev *Event, e *BaseEvent) string
 	ResolveIsIPPublic(ev *Event, e *IPPortContext) bool
+	ResolveIsPIDFD(ev *Event) bool
 	ResolveK8SGroups(ev *Event, e *K8SSessionContext) []string
 	ResolveK8SUID(ev *Event, e *K8SSessionContext) string
 	ResolveK8SUsername(ev *Event, e *K8SSessionContext) string
@@ -1243,6 +1245,7 @@ func (dfh *FakeFieldHandlers) ResolveHostname(ev *Event, e *BaseEvent) string {
 func (dfh *FakeFieldHandlers) ResolveIsIPPublic(ev *Event, e *IPPortContext) bool {
 	return bool(e.IsPublic)
 }
+func (dfh *FakeFieldHandlers) ResolveIsPIDFD(ev *Event) bool { return bool(ev.IsPIDFD) }
 func (dfh *FakeFieldHandlers) ResolveK8SGroups(ev *Event, e *K8SSessionContext) []string {
 	return []string(e.K8SGroups)
 }

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -85,7 +85,8 @@ type Event struct {
 	Signature string `field:"event.signature,handler:ResolveSignature,weight:500,opts:skip_ad"` // SECLDoc[event.signature] Definition:`Signature of the process pid and its cgroup with agent secret key`
 
 	// globals
-	Async bool `field:"event.async,handler:ResolveAsync"` // SECLDoc[event.async] Definition:`True if the syscall was asynchronous`
+	Async   bool `field:"event.async,handler:ResolveAsync"`      // SECLDoc[event.async] Definition:`True if the syscall was asynchronous`
+	IsPIDFD bool `field:"event.is_pidfd,handler:ResolveIsPIDFD"` // SECLDoc[event.is_pidfd] Definition:`True if the event originates from a pidfd syscall (e.g. pidfd_getfd, pidfd_send_signal)`
 
 	// context
 	SpanContext    SpanContext    `field:"-"`

--- a/pkg/security/seclwin/model/consts_common.go
+++ b/pkg/security/seclwin/model/consts_common.go
@@ -67,6 +67,9 @@ const (
 	// EventFlagsInternal true if the event is an internal event used to keep caches & internal resources up-to-date
 	EventFlagsInternal
 
+	// EventFlagsPIDFD true if the event originates from a pidfd syscall (e.g. pidfd_getfd, pidfd_send_signal)
+	EventFlagsPIDFD
+
 	// non kernel flags
 
 	// EventFlagsHasActiveActivityDump true if the event has an active activity dump associated to it

--- a/pkg/security/tests/pidfd_test.go
+++ b/pkg/security/tests/pidfd_test.go
@@ -1,0 +1,173 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && functionaltests
+
+// Package tests holds tests related files
+package tests
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
+
+// TestPIDFDGetfd checks that stealing a file descriptor out of another process
+// with pidfd_getfd(2) is reported as an `open` event on the resolved path,
+// attributed to the thief (the process that called pidfd_getfd).
+//
+// We spawn a small shell command as the victim: it opens our target file
+// read-write on a known fd and holds it open. The test process is the thief, so
+// it knows the victim's pid (the command's pid) and the fd to steal (the one we
+// told the shell to use). The rule is scoped to our own pid, so the victim's
+// setup open is excluded and the only event that can match is the synthetic
+// `open` we expect the pidfd_getfd hook to emit for the thief.
+func TestPIDFDGetfd(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	// pidfd_getfd(2) was introduced in Linux 5.6.
+	checkKernelCompatibility(t, "pidfd_getfd requires kernel 5.6+", func(kv *kernel.Version) bool {
+		return kv.Code < kernel.Kernel5_6
+	})
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_pidfd_getfd",
+			Expression: fmt.Sprintf(`open.file.path == "{{.Root}}/test-pidfd-getfd" && process.pid == %d && event.is_pidfd`, os.Getpid()),
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	testFile, _, err := test.Path("test-pidfd-getfd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(testFile)
+
+	const victimFd = 3
+
+	test.WaitSignalFromRule(t, func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		victim := exec.CommandContext(ctx, "/bin/sh", "-c",
+			fmt.Sprintf("exec %d<>'%s'; echo ready; exec sleep 30", victimFd, testFile))
+		stdout, err := victim.StdoutPipe()
+		if err != nil {
+			return err
+		}
+		if err := victim.Start(); err != nil {
+			return err
+		}
+		defer func() {
+			_ = victim.Process.Kill()
+			_ = victim.Wait()
+		}()
+
+		buf := make([]byte, len("ready\n"))
+		if _, err := io.ReadFull(stdout, buf); err != nil {
+			return fmt.Errorf("victim did not become ready: %w", err)
+		}
+
+		pidfd, err := unix.PidfdOpen(victim.Process.Pid, 0)
+		if err != nil {
+			return fmt.Errorf("pidfd_open(%d): %w", victim.Process.Pid, err)
+		}
+		defer unix.Close(pidfd)
+
+		stolenFd, err := unix.PidfdGetfd(pidfd, victimFd, 0)
+		if err != nil {
+			return fmt.Errorf("pidfd_getfd(%d): %w", victimFd, err)
+		}
+		unix.Close(stolenFd)
+		return nil
+	}, func(event *model.Event, _ *rules.Rule) {
+		assert.Equal(t, "open", event.GetType(), "wrong event type")
+		assert.Equal(t, unix.O_RDWR, int(event.Open.Flags)&unix.O_ACCMODE, "wrong flags")
+		assertInode(t, event.Open.File.Inode, getInode(t, testFile))
+		assert.NotZero(t, event.Flags&model.EventFlagsPIDFD, "event should be flagged as pidfd-originated")
+
+		// The syscall context holds the actual pidfd_getfd arguments
+		// (pidfd, targetfd, flags), not the open layout (path, flags, mode),
+		// so they are surfaced through the int1/int2/int3 slots.
+		sc := &event.Open.SyscallContext
+		assert.Positive(t, event.FieldHandlers.ResolveSyscallCtxArgsInt1(event, sc), "pidfd should be a valid fd")
+		assert.Equal(t, victimFd, event.FieldHandlers.ResolveSyscallCtxArgsInt2(event, sc), "wrong targetfd")
+		assert.Equal(t, 0, event.FieldHandlers.ResolveSyscallCtxArgsInt3(event, sc), "wrong pidfd_getfd flags")
+	}, "test_pidfd_getfd")
+}
+
+// TestPIDFDSendSignal checks whether sending a signal through pidfd_send_signal(2)
+// is reported as a `signal` event.
+func TestPIDFDSendSignal(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	// pidfd_open(2), used to obtain the pidfd, was introduced in Linux 5.3.
+	checkKernelCompatibility(t, "pidfd_send_signal requires kernel 5.3+", func(kv *kernel.Version) bool {
+		return kv.Code < kernel.Kernel5_3
+	})
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			// scope to the sender (this test process); signal.target is the victim.
+			ID:         "test_pidfd_send_signal",
+			Expression: fmt.Sprintf(`signal.type == SIGUSR1 && process.pid == %d && event.is_pidfd`, os.Getpid()),
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// The target: a sleep process we signal through its pidfd.
+	victim := exec.CommandContext(ctx, "/bin/sleep", "30")
+	if err := victim.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = victim.Process.Kill()
+		_ = victim.Wait()
+	}()
+	victimPid := victim.Process.Pid
+
+	test.WaitSignalFromRule(t, func() error {
+		pidfd, err := unix.PidfdOpen(victimPid, 0)
+		if err != nil {
+			return fmt.Errorf("pidfd_open(%d): %w", victimPid, err)
+		}
+		defer unix.Close(pidfd)
+
+		if err := unix.PidfdSendSignal(pidfd, unix.SIGUSR1, nil, 0); err != nil {
+			return fmt.Errorf("pidfd_send_signal: %w", err)
+		}
+		return nil
+	}, func(event *model.Event, _ *rules.Rule) {
+		assert.Equal(t, "signal", event.GetType(), "wrong event type")
+		assert.Equal(t, uint32(unix.SIGUSR1), event.Signal.Type, "wrong signal")
+		assert.Equal(t, uint32(victimPid), event.Signal.PID, "wrong target pid")
+		assert.NotZero(t, event.Flags&model.EventFlagsPIDFD, "event should be flagged as pidfd-originated")
+	}, "test_pidfd_send_signal")
+}

--- a/releasenotes/notes/cws-pidfd-coverage-94b2850c70481451.yaml
+++ b/releasenotes/notes/cws-pidfd-coverage-94b2850c70481451.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Improved syscall coverage in Workload Protection (CWS) to better track
+    activity that operates on processes through process file descriptors (``pidfd``).
+    Added the ``event.is_pidfd`` field, which is set to ``true`` when an event
+    originates from a ``pidfd``-based syscall.


### PR DESCRIPTION
### What does this PR do?

Extends Workload Protection (CWS) syscall coverage to events that operate on processes through process file descriptors (`pidfd`):

- **`pidfd_getfd(pidfd, targetfd, flags)`** — duplicates a file descriptor out of another process into the caller's fd table. The stolen `struct file` is resolved to its path and emitted as an `EVENT_OPEN`.
- **`pidfd_send_signal(pidfd, sig, info, flags)`** — sends a signal to the process referred to by `pidfd`. The target process is resolved via its `task_struct` and emitted as an `EVENT_SIGNAL`.
- Adds a new SECL field **`event.is_pidfd`**, set to `true` when an event originates from a `pidfd`-based syscall.

### Motivation

Cover previously-uncovered syscalls that can manipulate files or send signals.

### Describe how you validated your changes

Added a functional test (`pkg/security/tests/pidfd_test.go`) covering both `pidfd_getfd` → `EVENT_OPEN` and `pidfd_send_signal` → `EVENT_SIGNAL`, asserting the `is_pidfd` flag.

### Additional Notes
