### PR TITLE
Adding cli helpers to locate a setting in the schema

### DIFF
--- a/.claude/skills/locate-config-setting/SKILL.md
+++ b/.claude/skills/locate-config-setting/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: locate-config-setting
+description: Find where an Agent config setting or section is defined in the YAML schemas, and print its schema node, using `dda inv schema.locate`
+allowed-tools: Bash, Read
+argument-hint: "[setting.path]"
+model: sonnet
+---
+
+Locate a Datadog Agent configuration setting or section in the schema source and
+print its definition plus the exact file and line where it lives.
+
+Use this whenever you need to answer "where/how is config key `X` defined?" — its
+type, default, env vars, description, or which schema file to edit. It is much
+faster and more reliable than grepping the ~20k lines of schema YAML by hand,
+because the schema is **split across files** (`core_schema.yaml` plus per-section
+sub-files referenced via `$ref`), so a naive grep often points at the wrong file.
+
+## Command
+
+```bash
+dda inv -- schema.locate <setting.path>
+```
+
+`<setting.path>` is the **dotted logical path** exactly as a user writes it in
+`datadog.yaml` / `system-probe.yaml` — e.g. `api_key`, `proxy.https`,
+`apm_config.enabled`. (Use `--` so invoke treats the path as a positional arg.)
+
+### Flags
+
+| Flag | Effect |
+|---|---|
+| `--target core` / `--target system-probe` | Restrict to one schema (default: search **both**). |
+| `--json` | Emit a JSON array of `{schema, path, file, line, node}` instead of human text. Use this when you want to parse the result programmatically. |
+
+## What it prints
+
+- **Setting (leaf):** the full schema node — `node_type`, `type`, `default`,
+  `env_vars`, `visibility`, `description`, `tags`.
+- **Section:** the section's own metadata, with `properties` collapsed to the
+  **sorted list of immediate child key names** (so a big section like `apm_config`
+  doesn't dump thousands of lines). Drill into a child to see its full node.
+- A clickable location header per match: `[<schema>] <file>:<line>`.
+- If a key exists in **both** schemas (e.g. `log_level`), it prints one block per
+  schema, labeled `[core]` and `[system-probe]`.
+
+## Location semantics (important)
+
+- A **top-level split section** (e.g. `apm_config`, `logs_config`) is reported at
+  its `$ref:` line in `pkg/config/schema/yaml/core_schema.yaml` — that's where it's
+  wired in.
+- A setting **inside** a split section (e.g. `apm_config.enabled`) is reported in
+  the **sub-file** (`pkg/config/schema/yaml/apm_config.yaml:<line>`) — that's where
+  its real definition is, and the file you'd edit.
+- A setting/section that lives inline in the top file (e.g. `api_key`,
+  `proxy.https`) is reported directly in `core_schema.yaml`.
+
+## Behavior notes
+
+- Reads the YAML **source** under `pkg/config/schema/yaml/` — no build step or
+  agent binary needed; works straight from a checkout. Line numbers are real.
+- Only traverses named settings and sections (`properties`). Array `items` and
+  `patternProperties` internals are out of scope.
+- Not found → prints an error and exits non-zero (no fuzzy suggestions).
+
+## Examples
+
+```bash
+# Top-level setting → core_schema.yaml + full node
+dda inv -- schema.locate api_key
+
+# Setting inside a split section → resolves into the sub-file
+dda inv -- schema.locate apm_config.enabled
+
+# Bare split section → $ref site in core_schema.yaml, child names only
+dda inv -- schema.locate apm_config
+
+# Restrict to one schema and get machine-readable output
+dda inv -- schema.locate process_config.enabled --target core --json
+```
+
+## Related
+
+- The task lives in `tasks/schema/locate.py` (registered in `tasks/schema/__init__.py`).
+- Schema source: `pkg/config/schema/yaml/`. To regenerate it, see `dda inv schema.generate`.
+- To **add** a new config field (not just locate one), use the `create-config-field` skill.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,7 @@
 /.claude/skills/update-3rd-party-libs            @DataDog/agent-build
 /.claude/skills/update-otel-deps/                @DataDog/opentelemetry-agent
 /.claude/skills/write-e2e/                       @DataDog/agent-devx
+/.claude/skills/locate-config-setting/SKILL.md   @DataDog/agent-configuration
 # changing the config of mockery will regenerate the mocks, so owners will have to review anyway
 /.mockery.yaml                          # do not notify anyone
 /.go-version                            @DataDog/agent-runtimes @DataDog/agent-build

--- a/tasks/schema/__init__.py
+++ b/tasks/schema/__init__.py
@@ -2,6 +2,7 @@ from invoke.collection import Collection
 
 from tasks.schema.generate import compress, generate, hints
 from tasks.schema.lint import lint as lint_task
+from tasks.schema.locate import locate as locate_task
 from tasks.schema.template import template, template_all
 
 collection = Collection()
@@ -11,3 +12,4 @@ collection.add_task(lint_task)
 collection.add_task(compress)
 collection.add_task(template)
 collection.add_task(template_all)
+collection.add_task(locate_task)

--- a/tasks/schema/locate.py
+++ b/tasks/schema/locate.py
@@ -1,0 +1,255 @@
+"""
+Locate a setting or section in the Agent configuration schemas.
+
+Given a dotted config path (e.g. ``api_key``, ``proxy.https``,
+``apm_config.enabled``), find where it is defined in the YAML schema source
+files under ``pkg/config/schema/yaml`` and print the matching schema node.
+
+Run with:
+
+    dda inv -- schema.locate <setting>
+
+The core schema is split across a top file (``core_schema.yaml``) and
+per-section sub-files referenced via ``$ref``. This module reads the YAML
+*source* files directly (PyYAML ``compose()`` for line numbers) so reported
+locations point at editable source, and reuses ``resolve_schema`` to inline
+``$ref``s when extracting the node content.
+"""
+
+import json as _json
+import os
+
+import yaml
+from invoke import task
+from invoke.exceptions import Exit
+
+from tasks.schema.merge_schema import resolve_schema
+
+SCHEMA_DIR = os.path.join("pkg", "config", "schema", "yaml")
+CORE_SCHEMA = os.path.join(SCHEMA_DIR, "core_schema.yaml")
+SYSPROBE_SCHEMA = os.path.join(SCHEMA_DIR, "system-probe_schema.yaml")
+
+# (label, top file) pairs searched by default. The label is what gets reported
+# to the user so they know which schema a match came from.
+SCHEMAS = [
+    ("core", CORE_SCHEMA),
+    ("system-probe", SYSPROBE_SCHEMA),
+]
+
+
+# ---------------------------------------------------------------------------
+# Composed-node helpers (line numbers + $ref following)
+# ---------------------------------------------------------------------------
+
+
+def _compose(path):
+    """Return the root composed node of a YAML file (carries ``start_mark``)."""
+    with open(path) as f:
+        return yaml.compose(f)
+
+
+def _mapping_entry(node, key):
+    """Return the ``(key_node, value_node)`` pair for *key* in a MappingNode, or None."""
+    if not isinstance(node, yaml.MappingNode):
+        return None
+    for key_node, value_node in node.value:
+        if isinstance(key_node, yaml.ScalarNode) and key_node.value == key:
+            return key_node, value_node
+    return None
+
+
+def _mapping_get(node, key):
+    """Return the value node for *key* in a MappingNode, or None."""
+    entry = _mapping_entry(node, key)
+    return entry[1] if entry else None
+
+
+def _ref_target(value_node):
+    """If *value_node* is a single-key ``{$ref: <file>}`` mapping, return <file>; else None."""
+    if isinstance(value_node, yaml.MappingNode) and len(value_node.value) == 1:
+        key_node, ref_node = value_node.value[0]
+        if isinstance(key_node, yaml.ScalarNode) and key_node.value == "$ref":
+            return ref_node.value
+    return None
+
+
+def _locate_physical(top_file, parts):
+    """Return ``(physical_file, line_1based)`` for the dotted *parts*, or None.
+
+    Walks the composed node tree under each level's ``properties``. When a
+    matched value is a ``$ref`` node and there are more parts to consume, the
+    walk follows the ref into the sibling sub-file. When the ``$ref`` node is
+    itself the final part (a bare split section), the reported line is the
+    ``$ref:`` entry line in the current file (per Q4).
+    """
+    node = _compose(top_file)
+    current_file = top_file
+    line = None
+
+    for i, part in enumerate(parts):
+        props = _mapping_get(node, "properties")
+        entry = _mapping_entry(props, part)
+        if entry is None:
+            return None
+        key_node, value_node = entry
+        line = key_node.start_mark.line + 1
+
+        ref = _ref_target(value_node)
+        if ref is not None and i < len(parts) - 1:
+            # Cross into the referenced sub-file; its root is the section node.
+            current_file = os.path.join(os.path.dirname(current_file), ref)
+            node = _compose(current_file)
+        elif ref is not None:
+            # Bare split section: report the $ref entry line, not the key line.
+            ref_key_node = value_node.value[0][0]
+            line = ref_key_node.start_mark.line + 1
+            node = value_node
+        else:
+            node = value_node
+
+    return current_file, line
+
+
+# ---------------------------------------------------------------------------
+# Content extraction (from the merged schema) + display shaping
+# ---------------------------------------------------------------------------
+
+
+def _navigate_merged(merged, parts):
+    """Return the resolved node dict for the dotted *parts* in a merged schema, or None.
+
+    Only traverses named ``properties`` children (settings + sections); any
+    extra part under a leaf, or a missing key, yields None.
+    """
+    node = merged
+    for part in parts:
+        if not isinstance(node, dict):
+            return None
+        props = node.get("properties")
+        if not isinstance(props, dict) or part not in props:
+            return None
+        node = props[part]
+    return node
+
+
+def _is_section(node):
+    """A node is a section if it says so or carries child ``properties``."""
+    return node.get("node_type") == "section" or "properties" in node
+
+
+def _display_node(node):
+    """Shape *node* for display.
+
+    Settings are returned in full. Sections are returned with their own metadata
+    but with ``properties`` reduced to the sorted list of immediate child key
+    names, so locating a large section does not dump thousands of lines.
+    """
+    if not isinstance(node, dict) or not _is_section(node):
+        return node
+    shaped = {key: value for key, value in node.items() if key != "properties"}
+    props = node.get("properties")
+    if isinstance(props, dict):
+        shaped["properties"] = sorted(props.keys())
+    return shaped
+
+
+# ---------------------------------------------------------------------------
+# Cross-schema aggregation
+# ---------------------------------------------------------------------------
+
+
+def locate_setting(setting, schemas=SCHEMAS):
+    """Locate *setting* (a dotted path) across *schemas*.
+
+    Returns a list of match dicts ``{schema, path, file, line, node}``, one per
+    schema in which the path resolves. A schema contributes a match only when
+    BOTH the physical location and the merged-content lookup succeed (they read
+    the same source, so they agree); otherwise that schema is skipped.
+    """
+    parts = setting.split(".")
+    matches = []
+    for label, top_file in schemas:
+        physical = _locate_physical(top_file, parts)
+        if physical is None:
+            continue
+        node = _navigate_merged(resolve_schema(top_file), parts)
+        if node is None:
+            continue
+        file_path, line = physical
+        matches.append(
+            {
+                "schema": label,
+                "path": setting,
+                "file": file_path,
+                "line": line,
+                "node": _display_node(node),
+            }
+        )
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# Rendering + task entry point
+# ---------------------------------------------------------------------------
+
+
+def _str_presenter(dumper, data):
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+def _render(matches, as_json):
+    """Render *matches* as a string: a JSON array if *as_json*, else human text."""
+    if as_json:
+        return _json.dumps(matches, indent=2, sort_keys=False)
+
+    yaml.add_representer(str, _str_presenter)
+    blocks = []
+    for match in matches:
+        header = f"[{match['schema']}] {match['file']}:{match['line']}"
+        body = yaml.dump({match["path"]: match["node"]}, sort_keys=False).rstrip()
+        blocks.append(f"{header}\n{body}")
+    return "\n\n".join(blocks)
+
+
+def _select_schemas(schemas, target):
+    """Return the subset of *schemas* selected by *target* (a label or None for all)."""
+    if target is None:
+        return schemas
+    selected = [(label, path) for label, path in schemas if label == target]
+    if not selected:
+        valid = ", ".join(label for label, _ in schemas)
+        raise Exit(f"Invalid target '{target}'. Must be one of: {valid}.", code=1)
+    return selected
+
+
+def run_locate(setting, target=None, as_json=False, schemas=SCHEMAS):
+    """Locate *setting* and return the rendered output string.
+
+    Raises ``Exit(code=1)`` if *target* is invalid or the path is not found.
+    """
+    selected = _select_schemas(schemas, target)
+    matches = locate_setting(setting, selected)
+    if not matches:
+        scope = f" in schema '{target}'" if target else ""
+        raise Exit(f"Setting or section '{setting}' not found{scope}.", code=1)
+    return _render(matches, as_json)
+
+
+@task(
+    help={
+        "setting": "Dotted config path to locate, e.g. 'api_key', 'proxy.https', 'apm_config.enabled'.",
+        "target": "Restrict the search to a single schema: 'core' or 'system-probe' (default: both).",
+        "json": "Emit a JSON array of matches instead of human-readable text.",
+    },
+    positional=["setting"],
+)
+def locate(_ctx, setting, target=None, json=False):
+    """
+    Locate a setting or section in the Agent configuration schemas.
+
+    Prints the schema node and the source file + line where it is defined,
+    searching both the core and system-probe schemas.
+    """
+    print(run_locate(setting, target=target, as_json=json))

--- a/tasks/unit_tests/schema_locate_tests.py
+++ b/tasks/unit_tests/schema_locate_tests.py
@@ -1,0 +1,286 @@
+import os
+import tempfile
+import textwrap
+import unittest
+
+import tasks.schema.locate as locate
+
+
+def _write(path, content):
+    with open(path, "w") as f:
+        f.write(textwrap.dedent(content))
+
+
+class _SchemaFixture(unittest.TestCase):
+    """Builds a synthetic split schema in a tempdir.
+
+    Mirrors the real layout: a top file (``core.yaml``) with an inline section
+    (``proxy``) and a ``$ref`` split section (``apm_config``) whose body lives in
+    a sibling file (``apm_config.yaml``). A second standalone schema
+    (``sysprobe.yaml``) shares the ``log_level`` setting so cross-schema matching
+    can be exercised.
+    """
+
+    def setUp(self):
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.dir = self._tempdir.name
+
+        # core top file: api_key (setting), log_level (setting), proxy (inline
+        # section), apm_config (split section via $ref).
+        _write(
+            self._path("core.yaml"),
+            """\
+            properties:
+              api_key:
+                node_type: setting
+                type: string
+                default: ''
+                description: The API key.
+              log_level:
+                node_type: setting
+                type: string
+                default: info
+                description: Core log level.
+              proxy:
+                node_type: section
+                type: object
+                description: Proxy settings.
+                properties:
+                  https:
+                    node_type: setting
+                    type: string
+                    default: ''
+                    description: HTTPS proxy.
+              apm_config:
+                $ref: apm_config.yaml
+            """,
+        )
+        _write(
+            self._path("apm_config.yaml"),
+            """\
+            node_type: section
+            type: object
+            description: APM settings.
+            properties:
+              enabled:
+                node_type: setting
+                type: boolean
+                default: false
+                description: Enable APM.
+              env:
+                node_type: setting
+                type: string
+                default: ''
+                description: APM env.
+            """,
+        )
+        _write(
+            self._path("sysprobe.yaml"),
+            """\
+            properties:
+              log_level:
+                node_type: setting
+                type: string
+                default: info
+                description: System-probe log level.
+            """,
+        )
+
+    def tearDown(self):
+        self._tempdir.cleanup()
+
+    def _path(self, name):
+        return os.path.join(self.dir, name)
+
+
+class TestLocatePhysical(_SchemaFixture):
+    def _line_of(self, filename, needle):
+        """Return the 1-based line number of the first line containing *needle*."""
+        with open(self._path(filename)) as f:
+            for i, line in enumerate(f, start=1):
+                if needle in line:
+                    return i
+        raise AssertionError(f"{needle!r} not found in {filename}")
+
+    def test_top_level_setting(self):
+        result = locate._locate_physical(self._path("core.yaml"), ["api_key"])
+        self.assertEqual(result, (self._path("core.yaml"), self._line_of("core.yaml", "api_key:")))
+
+    def test_nested_setting_in_inline_section(self):
+        result = locate._locate_physical(self._path("core.yaml"), ["proxy", "https"])
+        self.assertEqual(result, (self._path("core.yaml"), self._line_of("core.yaml", "https:")))
+
+    def test_bare_split_section_reports_ref_line_in_top_file(self):
+        # apm_config's value is a $ref node; per Q4 we report the $ref line in the top file.
+        result = locate._locate_physical(self._path("core.yaml"), ["apm_config"])
+        self.assertEqual(result, (self._path("core.yaml"), self._line_of("core.yaml", "$ref:")))
+
+    def test_setting_inside_split_section_reports_subfile(self):
+        result = locate._locate_physical(self._path("core.yaml"), ["apm_config", "enabled"])
+        self.assertEqual(result, (self._path("apm_config.yaml"), self._line_of("apm_config.yaml", "enabled:")))
+
+    def test_unknown_top_level_returns_none(self):
+        self.assertIsNone(locate._locate_physical(self._path("core.yaml"), ["nope"]))
+
+    def test_extra_part_under_leaf_returns_none(self):
+        self.assertIsNone(locate._locate_physical(self._path("core.yaml"), ["api_key", "sub"]))
+
+
+class TestNavigateMerged(_SchemaFixture):
+    def _merged(self):
+        from tasks.schema.merge_schema import resolve_schema
+
+        return resolve_schema(self._path("core.yaml"))
+
+    def test_finds_top_level_setting(self):
+        node = locate._navigate_merged(self._merged(), ["api_key"])
+        self.assertEqual(node["type"], "string")
+        self.assertEqual(node["description"], "The API key.")
+
+    def test_finds_setting_inside_split_section(self):
+        # $ref must be resolved for the content to be reachable.
+        node = locate._navigate_merged(self._merged(), ["apm_config", "enabled"])
+        self.assertEqual(node["type"], "boolean")
+        self.assertEqual(node["default"], False)
+
+    def test_finds_split_section_itself(self):
+        node = locate._navigate_merged(self._merged(), ["apm_config"])
+        self.assertEqual(node["node_type"], "section")
+        self.assertIn("enabled", node["properties"])
+
+    def test_missing_returns_none(self):
+        self.assertIsNone(locate._navigate_merged(self._merged(), ["nope"]))
+
+    def test_extra_part_under_leaf_returns_none(self):
+        self.assertIsNone(locate._navigate_merged(self._merged(), ["api_key", "sub"]))
+
+
+class TestDisplayNode(unittest.TestCase):
+    def test_setting_is_returned_in_full(self):
+        node = {"node_type": "setting", "type": "string", "default": "", "description": "x"}
+        self.assertEqual(locate._display_node(node), node)
+
+    def test_section_drops_property_bodies_to_sorted_key_list(self):
+        node = {
+            "node_type": "section",
+            "type": "object",
+            "description": "APM settings.",
+            "properties": {
+                "env": {"node_type": "setting", "type": "string"},
+                "enabled": {"node_type": "setting", "type": "boolean"},
+            },
+        }
+        result = locate._display_node(node)
+        self.assertEqual(result["description"], "APM settings.")
+        self.assertEqual(result["properties"], ["enabled", "env"])
+
+    def test_node_with_properties_but_no_node_type_treated_as_section(self):
+        node = {"properties": {"b": {"type": "string"}, "a": {"type": "string"}}}
+        self.assertEqual(locate._display_node(node)["properties"], ["a", "b"])
+
+
+class TestLocateSetting(_SchemaFixture):
+    def _schemas(self):
+        return [("core", self._path("core.yaml")), ("system-probe", self._path("sysprobe.yaml"))]
+
+    def test_match_only_in_core(self):
+        matches = locate.locate_setting("api_key", self._schemas())
+        self.assertEqual(len(matches), 1)
+        m = matches[0]
+        self.assertEqual(m["schema"], "core")
+        self.assertEqual(m["path"], "api_key")
+        self.assertEqual(m["file"], self._path("core.yaml"))
+        self.assertEqual(m["node"]["description"], "The API key.")
+        self.assertIsInstance(m["line"], int)
+
+    def test_match_in_both_schemas(self):
+        matches = locate.locate_setting("log_level", self._schemas())
+        self.assertEqual([m["schema"] for m in matches], ["core", "system-probe"])
+        self.assertEqual(matches[0]["file"], self._path("core.yaml"))
+        self.assertEqual(matches[1]["file"], self._path("sysprobe.yaml"))
+        self.assertEqual(matches[1]["node"]["description"], "System-probe log level.")
+
+    def test_split_section_match_shapes_node(self):
+        matches = locate.locate_setting("apm_config", self._schemas())
+        self.assertEqual(len(matches), 1)
+        # Section node: properties reduced to a sorted key list, located at the $ref site.
+        self.assertEqual(matches[0]["node"]["properties"], ["enabled", "env"])
+        self.assertEqual(matches[0]["file"], self._path("core.yaml"))
+
+    def test_missing_returns_empty(self):
+        self.assertEqual(locate.locate_setting("does.not.exist", self._schemas()), [])
+
+
+class TestRender(unittest.TestCase):
+    MATCHES = [
+        {
+            "schema": "core",
+            "path": "log_level",
+            "file": "pkg/config/schema/yaml/core_schema.yaml",
+            "line": 42,
+            "node": {"node_type": "setting", "type": "string", "default": "info"},
+        },
+        {
+            "schema": "system-probe",
+            "path": "log_level",
+            "file": "pkg/config/schema/yaml/system-probe_schema.yaml",
+            "line": 7,
+            "node": {"node_type": "setting", "type": "string", "default": "info"},
+        },
+    ]
+
+    def test_text_render_includes_clickable_location_per_match(self):
+        out = locate._render(self.MATCHES, as_json=False)
+        self.assertIn("[core] pkg/config/schema/yaml/core_schema.yaml:42", out)
+        self.assertIn("[system-probe] pkg/config/schema/yaml/system-probe_schema.yaml:7", out)
+        # The node body is dumped too.
+        self.assertIn("node_type: setting", out)
+
+    def test_json_render_is_always_an_array(self):
+        import json
+
+        single = locate._render(self.MATCHES[:1], as_json=True)
+        parsed = json.loads(single)
+        self.assertIsInstance(parsed, list)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["schema"], "core")
+        self.assertEqual(parsed[0]["line"], 42)
+        self.assertEqual(parsed[0]["node"]["type"], "string")
+
+
+class TestLocateTask(_SchemaFixture):
+    def _schemas(self):
+        return [("core", self._path("core.yaml")), ("system-probe", self._path("sysprobe.yaml"))]
+
+    def test_not_found_raises_exit(self):
+        from invoke.exceptions import Exit
+
+        with self.assertRaises(Exit):
+            locate.run_locate("does.not.exist", schemas=self._schemas())
+
+    def test_run_locate_returns_text_with_location(self):
+        out = locate.run_locate("api_key", schemas=self._schemas())
+        self.assertIn("[core] " + self._path("core.yaml"), out)
+
+    def test_target_filters_to_one_schema(self):
+        matches = locate.locate_setting("log_level", self._schemas())
+        self.assertEqual(len(matches), 2)
+        filtered = locate._select_schemas(self._schemas(), "system-probe")
+        self.assertEqual([label for label, _ in filtered], ["system-probe"])
+
+    def test_run_locate_target_filters(self):
+        import json
+
+        out = locate.run_locate("log_level", target="system-probe", as_json=True, schemas=self._schemas())
+        parsed = json.loads(out)
+        self.assertEqual([m["schema"] for m in parsed], ["system-probe"])
+
+    def test_invalid_target_raises_exit(self):
+        from invoke.exceptions import Exit
+
+        with self.assertRaises(Exit):
+            locate._select_schemas(self._schemas(), "nope")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What does this PR do?

`dda inv schema.locate` allows devs to search and locate a setting or section within the schema.

Example:
```
❯ dda inv schema.locate network_devices.autodiscovery.use_deduplication           
[core] pkg/config/schema/yaml/core_schema.yaml:4320
network_devices.autodiscovery.use_deduplication:
  node_type: setting
  type: boolean
  default: false
  visibility: public
  description: |-
    Deduplicate IP addresses corresponding to the same device.
    The deduplication logic is based on the sysName, sysDesc, sysObjectID and sysUptime
  tags:
```

```
❯ dda inv schema.locate apm_config.enabled --json                                       
[
  {
    "schema": "core",
    "path": "apm_config.enabled",
    "file": "pkg/config/schema/yaml/apm_config.yaml",
    "line": 14,
    "node": {
      "node_type": "setting",
      "type": "boolean",
      "default": true,
      "env_vars": [
        "DD_APM_ENABLED"
      ],
      "visibility": "public",
      "description": "Set to true to enable the APM Agent.",
      "tags": [
        "template_section:TraceAgent"
      ]
    }
  }
]
```