### PR TITLE
[PROF-15208] Fail the ci preview job if the preview number is not set

### DIFF
--- a/.gitlab/distribute/deploy_containers_a7.yml
+++ b/.gitlab/distribute/deploy_containers_a7.yml
@@ -174,6 +174,11 @@ deploy_containers-a7-fips_internal:
   stage: deploy_containers
   dependencies: []
   before_script:
+    - |
+      if [[ -z "${PREVIEW_NUMBER}" ]]; then
+        echo "PREVIEW_NUMBER must be set before running deploy_containers-host-profiler-preview" >&2
+        exit 1
+      fi
     - if [[ "$VERSION" == "" ]]; then VERSION=$(jq -r '.current_milestone' release.json); fi
     - export IMG_SOURCES="${SRC_DDOT_EBPF}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_DDOT_EBPF}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64"
     - export IMG_DESTINATIONS="ddot-ebpf:${VERSION}-preview-host-profiler-${PREVIEW_NUMBER}"


### PR DESCRIPTION
### What does this PR do?
Adds a safeguard to fail the `deploy_containers-host-profiler-preview` job if the preview number is empty.

### Motivation
A preview job was recently triggered without a version number. We want the pipeline to fail in this scenario to ensure that the user intentionally intended to trigger it.

### Describe how you validated your changes

### Additional Notes
