### PR TITLE
add a new ShadowCheck type, wrap normal checks in it when configured

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -87,7 +87,7 @@ import (
 	healthprobe "github.com/DataDog/datadog-agent/comp/core/healthprobe/def"
 	healthprobefx "github.com/DataDog/datadog-agent/comp/core/healthprobe/fx"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -709,7 +709,7 @@ func startAgent(
 
 	// Set up check collector
 	commonchecks.RegisterChecks(wmeta, filterStore, tagger, cfg, tlm, rcclient, flare, snmpScanManager, traceroute, ncmComp)
-	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(option.New(collectorComponent), demultiplexer, logReceiver, tagger, filterStore), true)
+	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(option.New(collectorComponent), demultiplexer, logReceiver, tagger, filterStore, cfg), true)
 
 	demultiplexer.AddAgentStartupTelemetry(version.AgentVersion)
 

--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -235,7 +235,7 @@ func run(
 	common.LoadComponents(ac, pkgconfigsetup.Datadog().GetString("confd_path"))
 
 	// Set up check collector
-	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(option.New(collector), demultiplexer, logReceiver, taggerComp, filterStore), true)
+	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(option.New(collector), demultiplexer, logReceiver, taggerComp, filterStore, config), true)
 
 	// start the autoconfig, this will immediately run any configured check
 	ac.LoadAndRun(mainCtx)

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -41,7 +41,7 @@ import (
 	healthprobe "github.com/DataDog/datadog-agent/comp/core/healthprobe/def"
 	healthprobefx "github.com/DataDog/datadog-agent/comp/core/healthprobe/fx"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -74,6 +74,13 @@ import (
 	remotetraceroutefx "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-remote"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/appsec"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/mcp"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	metadatarunner "github.com/DataDog/datadog-agent/comp/metadata/runner/def"
@@ -123,12 +130,6 @@ import (
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"github.com/spf13/cobra"
-	"go.uber.org/fx"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/tools/record"
 
 	dcametadata "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
 	dcametadatafx "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/fx"
@@ -512,7 +513,7 @@ func start(log log.Component,
 
 	// Set up check collector
 	registerChecks(wmeta, taggerComp, config)
-	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(option.New(collector), demultiplexer, logReceiver, taggerComp, filterStore), true)
+	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(option.New(collector), demultiplexer, logReceiver, taggerComp, filterStore, config), true)
 
 	// start the autoconfig, this will immediately run any configured check
 	ac.LoadAndRun(mainCtx)

--- a/comp/collector/collector/impl/collector.go
+++ b/comp/collector/collector/impl/collector.go
@@ -21,7 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/collector/collector/impl/internal/middleware"
 	agenttelemetry "github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
@@ -35,7 +35,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/collector/runner/expvars"
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
-	"github.com/DataDog/datadog-agent/pkg/collector/sharedlibrary/sharedlibraryimpl"
+	sharedlibrarycheck "github.com/DataDog/datadog-agent/pkg/collector/sharedlibrary/sharedlibraryimpl"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	collectorStatus "github.com/DataDog/datadog-agent/pkg/status/collector"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -176,7 +176,7 @@ func (c *collectorImpl) start(_ context.Context) error {
 	defer c.m.Unlock()
 
 	run := runner.NewRunner(c.senderManager, c.haAgent, c.healthPlatform)
-	sched := scheduler.NewScheduler(run.GetChan())
+	sched := scheduler.NewScheduler(run.GetChan(), run.GetShadowChan())
 
 	// let the runner some visibility into the scheduler
 	run.SetScheduler(sched)
@@ -237,6 +237,10 @@ func (c *collectorImpl) RunCheck(inner check.Check) (checkid.ID, error) {
 		// checks.
 		c.log.Infof("Adding an extra runner for the '%s' long running check", ch)
 		c.runner.AddWorker()
+	} else if _, ok := inner.(*check.ShadowCheck); ok {
+		// Adding a temporary runner for shadow check
+		c.log.Infof("Adding an extra runner for the '%s' shadow check", ch)
+		c.runner.AddShadowWorker()
 	} else {
 		c.runner.UpdateNumWorkers(c.checkInstances)
 	}

--- a/comp/core/diagnose/local/local.go
+++ b/comp/core/diagnose/local/local.go
@@ -101,7 +101,7 @@ func getLocalIntegrationConfigs(
 	ac.LoadAndRun(context.Background())
 
 	// Create the CheckScheduler, but do not attach it to AutoDiscovery.
-	pkgcollector.InitCheckScheduler(option.None[collector.Component](), aggregator.NewNoOpSenderManager(), option.None[integrations.Component](), tagger, filterStore)
+	pkgcollector.InitCheckScheduler(option.None[collector.Component](), aggregator.NewNoOpSenderManager(), option.None[integrations.Component](), tagger, filterStore, config)
 
 	// Load matching configurations (should we use common.AC.GetAllConfigs())
 	waitCtx, cancelTimeout := context.WithTimeout(context.Background(), time.Duration(5*time.Second))

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -37,7 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	autodiscovery "github.com/DataDog/datadog-agent/comp/core/autodiscovery/def"
 	adfx "github.com/DataDog/datadog-agent/comp/core/autodiscovery/fx"
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/impl"
+	autodiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/autodiscovery/impl"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -323,7 +323,7 @@ func run(
 
 	// Create the CheckScheduler, but do not attach it to
 	// AutoDiscovery.
-	pkgcollector.InitCheckScheduler(collector, demultiplexer, logReceiver, tagger, filterStore)
+	pkgcollector.InitCheckScheduler(collector, demultiplexer, logReceiver, tagger, filterStore, config)
 
 	allConfigs, err := getAllCheckConfigs(ac, *cliParams)
 	if err != nil {

--- a/pkg/collector/check/shadowcheck.go
+++ b/pkg/collector/check/shadowcheck.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package check contains the interface for the check.
+package check
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	diagnose "github.com/DataDog/datadog-agent/comp/core/diagnose/def"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/stats"
+)
+
+// ShadowableCheck is implemented by checks that can create a shadow copy of themselves.
+type ShadowableCheck interface {
+	ShadowCheck() (Check, error)
+}
+
+// ShadowCheck wraps an inner Check and delegates all method calls to it.
+type ShadowCheck struct {
+	inner  Check
+	config ShadowConfig
+}
+
+type ShadowConfig struct {
+	Interval time.Duration
+}
+
+// NewShadowCheck creates a new ShadowCheck wrapping the given inner check.
+func NewShadowCheck[T Check](inner T, config ShadowConfig) Check {
+	return &ShadowCheck{inner: inner, config: config}
+}
+
+func (s *ShadowCheck) Run() error {
+	return s.inner.Run()
+}
+
+func (s *ShadowCheck) Stop() {
+	s.inner.Stop()
+}
+
+func (s *ShadowCheck) Cancel() {
+	s.inner.Cancel()
+}
+
+func (s *ShadowCheck) String() string {
+	return s.inner.String()
+}
+
+func (s *ShadowCheck) Loader() string {
+	return s.inner.Loader()
+}
+
+func (s *ShadowCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, config, initConfig integration.Data, source string, provider string) error {
+	return s.inner.Configure(senderManager, integrationConfigDigest, config, initConfig, source, provider)
+}
+
+func (s *ShadowCheck) Interval() time.Duration {
+	return s.config.Interval
+}
+
+func (s *ShadowCheck) ID() checkid.ID {
+	return s.inner.ID() + ":shadow"
+}
+
+func (s *ShadowCheck) GetWarnings() []error {
+	return s.inner.GetWarnings()
+}
+
+func (s *ShadowCheck) GetSenderStats() (stats.SenderStats, error) {
+	return s.inner.GetSenderStats()
+}
+
+func (s *ShadowCheck) Version() string {
+	return s.inner.Version()
+}
+
+func (s *ShadowCheck) ConfigSource() string {
+	return s.inner.ConfigSource()
+}
+
+func (s *ShadowCheck) ConfigProvider() string {
+	return s.inner.ConfigProvider()
+}
+
+func (s *ShadowCheck) IsTelemetryEnabled() bool {
+	return s.inner.IsTelemetryEnabled()
+}
+
+func (s *ShadowCheck) InitConfig() string {
+	return s.inner.InitConfig()
+}
+
+func (s *ShadowCheck) InstanceConfig() string {
+	return s.inner.InstanceConfig()
+}
+
+func (s *ShadowCheck) GetDiagnoses() ([]diagnose.Diagnosis, error) {
+	return s.inner.GetDiagnoses()
+}
+
+func (s *ShadowCheck) IsHASupported() bool {
+	return s.inner.IsHASupported()
+}

--- a/pkg/collector/check/shadowcheck.go
+++ b/pkg/collector/check/shadowcheck.go
@@ -16,11 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check/stats"
 )
 
-// ShadowableCheck is implemented by checks that can create a shadow copy of themselves.
-type ShadowableCheck interface {
-	ShadowCheck() (Check, error)
-}
-
 // ShadowCheck wraps an inner Check and delegates all method calls to it.
 type ShadowCheck struct {
 	inner  Check

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -277,7 +277,7 @@ func (r *Runner) GetChan() chan<- check.Check {
 	return r.pendingChecksChan
 }
 
-// GetChan returns a write-only version of the pending channel
+// GetShadowChan returns a write-only version of the pending shadow check channel
 func (r *Runner) GetShadowChan() chan<- check.Check {
 	return r.pendingShadowChecksChan
 }

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -42,20 +42,21 @@ var (
 
 // Runner is the object in charge of running all the checks
 type Runner struct {
-	senderManager       sender.SenderManager
-	haAgent             haagent.Component
-	healthPlatform      healthplatform.Component // Health platform component for reporting issues
-	isRunning           *atomic.Bool
-	id                  int                           // Globally unique identifier for the Runner
-	workers             map[int]*worker.Worker        // Workers currrently under this Runner's management
-	workersLock         sync.Mutex                    // Lock to prevent concurrent worker changes
-	isStaticWorkerCount bool                          // Flag indicating if numWorkers is dynamically updated
-	pendingChecksChan   chan check.Check              // The channel where checks come from
-	checksTracker       *tracker.RunningChecksTracker // Tracker in charge of maintaining the running check list
-	scheduler           *scheduler.Scheduler          // Scheduler runner operates on
-	schedulerLock       sync.RWMutex                  // Lock around operations on the scheduler
-	utilizationMonitor  *worker.UtilizationMonitor    // Monitor in charge of checking the worker utilization
-	utilizationLogLimit *log.Limit                    // Log limiter for utilization warnings
+	senderManager           sender.SenderManager
+	haAgent                 haagent.Component
+	healthPlatform          healthplatform.Component // Health platform component for reporting issues
+	isRunning               *atomic.Bool
+	id                      int                           // Globally unique identifier for the Runner
+	workers                 map[int]*worker.Worker        // Workers currrently under this Runner's management
+	workersLock             sync.Mutex                    // Lock to prevent concurrent worker changes
+	isStaticWorkerCount     bool                          // Flag indicating if numWorkers is dynamically updated
+	pendingChecksChan       chan check.Check              // The channel where checks come from
+	pendingShadowChecksChan chan check.Check              // The channel where checks come from
+	checksTracker           *tracker.RunningChecksTracker // Tracker in charge of maintaining the running check list
+	scheduler               *scheduler.Scheduler          // Scheduler runner operates on
+	schedulerLock           sync.RWMutex                  // Lock around operations on the scheduler
+	utilizationMonitor      *worker.UtilizationMonitor    // Monitor in charge of checking the worker utilization
+	utilizationLogLimit     *log.Limit                    // Log limiter for utilization warnings
 	// ctx is cancelled when the runner stops, providing a cancellation signal
 	// to any context-aware operation inside workers (e.g. hostname resolution).
 	ctx    context.Context
@@ -69,19 +70,20 @@ func NewRunner(senderManager sender.SenderManager, haAgent haagent.Component, he
 	ctx, cancel := context.WithCancel(context.Background())
 
 	r := &Runner{
-		senderManager:       senderManager,
-		haAgent:             haAgent,
-		healthPlatform:      healthPlatform,
-		id:                  int(runnerIDGenerator.Inc()),
-		isRunning:           atomic.NewBool(true),
-		workers:             make(map[int]*worker.Worker),
-		isStaticWorkerCount: numWorkers != 0,
-		pendingChecksChan:   make(chan check.Check),
-		checksTracker:       tracker.NewRunningChecksTracker(),
-		utilizationMonitor:  worker.NewUtilizationMonitor(pkgconfigsetup.Datadog().GetFloat64("check_runner_utilization_threshold")),
-		utilizationLogLimit: log.NewLogLimit(1, pkgconfigsetup.Datadog().GetDuration("check_runner_utilization_warning_cooldown")),
-		ctx:                 ctx,
-		cancel:              cancel,
+		senderManager:           senderManager,
+		haAgent:                 haAgent,
+		healthPlatform:          healthPlatform,
+		id:                      int(runnerIDGenerator.Inc()),
+		isRunning:               atomic.NewBool(true),
+		workers:                 make(map[int]*worker.Worker),
+		isStaticWorkerCount:     numWorkers != 0,
+		pendingChecksChan:       make(chan check.Check),
+		pendingShadowChecksChan: make(chan check.Check),
+		checksTracker:           tracker.NewRunningChecksTracker(),
+		utilizationMonitor:      worker.NewUtilizationMonitor(pkgconfigsetup.Datadog().GetFloat64("check_runner_utilization_threshold")),
+		utilizationLogLimit:     log.NewLogLimit(1, pkgconfigsetup.Datadog().GetDuration("check_runner_utilization_warning_cooldown")),
+		ctx:                     ctx,
+		cancel:                  cancel,
 	}
 
 	if !r.isStaticWorkerCount {
@@ -110,7 +112,7 @@ func (r *Runner) ensureMinWorkers(desiredNumWorkers int) {
 
 	workersToAdd := desiredNumWorkers - currentWorkers
 	for idx := 0; idx < workersToAdd; idx++ {
-		worker, err := r.newWorker()
+		worker, err := r.newWorker(false)
 		if err == nil {
 			r.workers[worker.ID] = worker
 		}
@@ -129,15 +131,31 @@ func (r *Runner) AddWorker() {
 	r.workersLock.Lock()
 	defer r.workersLock.Unlock()
 
-	worker, err := r.newWorker()
+	worker, err := r.newWorker(false)
+	if err == nil {
+		r.workers[worker.ID] = worker
+	}
+}
+
+// AddShadowWorker adds a single shadow worker to the runner.
+func (r *Runner) AddShadowWorker() {
+	r.workersLock.Lock()
+	defer r.workersLock.Unlock()
+
+	worker, err := r.newWorker(true)
 	if err == nil {
 		r.workers[worker.ID] = worker
 	}
 }
 
 // newWorker adds a new worker running in a separate goroutine
-func (r *Runner) newWorker() (*worker.Worker, error) {
+func (r *Runner) newWorker(isShadowWorker bool) (*worker.Worker, error) {
 	watchdogWarningTimeout := pkgconfigsetup.Datadog().GetDuration("check_watchdog_warning_timeout")
+
+	pendingChecksChan := r.pendingChecksChan
+	if isShadowWorker {
+		pendingChecksChan = r.pendingShadowChecksChan
+	}
 
 	worker, err := worker.NewWorker(
 		r.senderManager,
@@ -145,10 +163,11 @@ func (r *Runner) newWorker() (*worker.Worker, error) {
 		r.healthPlatform,
 		r.id,
 		int(workerIDGenerator.Inc()),
-		r.pendingChecksChan,
+		pendingChecksChan,
 		r.checksTracker,
 		r.ShouldAddCheckStats,
 		watchdogWarningTimeout,
+		isShadowWorker,
 	)
 	if err != nil {
 		log.Errorf("Runner %d was unable to instantiate a worker: %s", r.id, err)
@@ -256,6 +275,11 @@ func (r *Runner) Stop() {
 // GetChan returns a write-only version of the pending channel
 func (r *Runner) GetChan() chan<- check.Check {
 	return r.pendingChecksChan
+}
+
+// GetChan returns a write-only version of the pending channel
+func (r *Runner) GetShadowChan() chan<- check.Check {
+	return r.pendingShadowChecksChan
 }
 
 // SetScheduler sets the scheduler for the runner

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	yaml "go.yaml.in/yaml/v2"
 	"golang.org/x/text/cases"
@@ -19,6 +20,7 @@ import (
 
 	collectorcomp "github.com/DataDog/datadog-agent/comp/collector/collector/def"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	filter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
@@ -57,20 +59,23 @@ func init() {
 
 // CheckScheduler is the check scheduler
 type CheckScheduler struct {
-	configToChecks map[string][]checkid.ID // cache the ID of checks we load for each config
-	loaders        []check.Loader
-	collector      option.Option[collectorcomp.Component]
-	senderManager  sender.SenderManager
-	m              sync.RWMutex
+	config              config.Component
+	configToChecks      map[string][]checkid.ID // cache the ID of checks we load for each config
+	loaders             []check.Loader
+	collector           option.Option[collectorcomp.Component]
+	senderManager       sender.SenderManager
+	shadowSenderManager sender.SenderManager
+	m                   sync.RWMutex
 }
 
 // InitCheckScheduler creates and returns a check scheduler
-func InitCheckScheduler(collector option.Option[collectorcomp.Component], senderManager sender.SenderManager, logReceiver option.Option[integrations.Component], tagger tagger.Component, filterStore filter.Component) *CheckScheduler {
+func InitCheckScheduler(collector option.Option[collectorcomp.Component], senderManager sender.SenderManager, logReceiver option.Option[integrations.Component], tagger tagger.Component, filterStore filter.Component, config config.Component) *CheckScheduler {
 	checkScheduler = &CheckScheduler{
-		collector:      collector,
-		senderManager:  senderManager,
-		configToChecks: make(map[string][]checkid.ID),
-		loaders:        make([]check.Loader, 0, len(loaders.LoaderCatalog(senderManager, logReceiver, tagger, filterStore))),
+		collector:           collector,
+		senderManager:       senderManager,
+		shadowSenderManager: &noopRingBuffer{},
+		configToChecks:      make(map[string][]checkid.ID),
+		loaders:             make([]check.Loader, 0, len(loaders.LoaderCatalog(senderManager, logReceiver, tagger, filterStore))),
 	}
 	// add the check loaders
 	for _, loader := range loaders.LoaderCatalog(senderManager, logReceiver, tagger, filterStore) {
@@ -207,12 +212,24 @@ func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, er
 				continue
 			}
 			c, err := loader.Load(s.senderManager, config, instance, instanceIndex)
-			if err == nil {
-				log.Debugf("%v: successfully loaded check '%s'", loader, config.Name)
-				checks = append(checks, c)
-				break
+
+			if err != nil {
+				loaderErrors[fmt.Sprintf("%v", loader)] = err
+				continue
 			}
-			loaderErrors[fmt.Sprintf("%v", loader)] = err
+			log.Debugf("%v: successfully loaded check '%s'", loader, config.Name)
+			checks = append(checks, c)
+
+			if yes, shadowConfig := s.mustBeShadowed(config); yes {
+				shadowCheck, err := loader.Load(s.shadowSenderManager, config, instance, instanceIndex)
+				if err != nil {
+					log.Errorf("failing to schedule shadow check while succeeding scheduling normal check")
+				}
+				// wrap the check in order to override some methods and route it to dedicated runner
+				shadowCheck = check.NewShadowCheck(shadowCheck, shadowConfig)
+				checks = append(checks, shadowCheck)
+			}
+			break
 		}
 
 		if len(loaderErrors) == numLoaders {
@@ -290,4 +307,10 @@ func (s *CheckScheduler) GetChecksFromConfigs(configs []integration.Config, popu
 // GetLoaderErrors returns the check loader errors
 func GetLoaderErrors() map[string]map[string]string {
 	return errorStats.getLoaderErrors()
+}
+
+func (s *CheckScheduler) mustBeShadowed(_ integration.Config) (bool, check.ShadowConfig) {
+	return true, check.ShadowConfig{
+		Interval: time.Second,
+	}
 }

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -197,14 +197,19 @@ func (jq *jobQueue) process(s *Scheduler) bool {
 
 		log.Tracef("Jobs in bucket: %v", jobs)
 
-		for _, check := range jobs {
-			if !s.IsCheckScheduled(check.ID()) {
+		for _, ch := range jobs {
+			if !s.IsCheckScheduled(ch.ID()) {
 				continue
+			}
+
+			checksPipe := s.checksPipe
+			if _, isShadowCheck := ch.(*check.ShadowCheck); isShadowCheck {
+				checksPipe = s.shadowChecksPipe
 			}
 
 			select {
 			// blocking, we'll be here as long as it takes
-			case s.checksPipe <- check:
+			case checksPipe <- ch:
 			case <-jq.stop:
 				_ = jq.health.Deregister()
 				return false

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -43,6 +43,7 @@ func init() {
 type Scheduler struct {
 	running          *atomic.Bool                // Flag to see if the scheduler is running
 	checksPipe       chan<- check.Check          // The pipe the Runner pops the checks from, initially set to nil
+	shadowChecksPipe chan<- check.Check          // The pipe the Runner pops the checks from, initially set to nil
 	done             chan bool                   // Guard for the main loop
 	halted           chan bool                   // Used to internally communicate all queues are done
 	started          chan bool                   // Used to internally communicate the queues are up
@@ -62,9 +63,10 @@ type Scheduler struct {
 }
 
 // NewScheduler create a Scheduler and returns a pointer to it.
-func NewScheduler(checksPipe chan<- check.Check) *Scheduler {
+func NewScheduler(checksPipe chan<- check.Check, shadowChecksPipe chan<- check.Check) *Scheduler {
 	return &Scheduler{
 		checksPipe:       checksPipe,
+		shadowChecksPipe: shadowChecksPipe,
 		done:             make(chan bool),
 		halted:           make(chan bool),
 		started:          make(chan bool),

--- a/pkg/collector/shadowsender.go
+++ b/pkg/collector/shadowsender.go
@@ -1,0 +1,128 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package collector
+
+import (
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/stats"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/metrics/event"
+	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
+	"github.com/DataDog/datadog-agent/pkg/serializer/types"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// noopRingBuffer is a SenderManager that returns shadowSenders and discards all other operations.
+type noopRingBuffer struct{}
+
+func (n *noopRingBuffer) GetSender(_ checkid.ID) (sender.Sender, error) {
+	return &shadowSender{}, nil
+}
+
+func (n *noopRingBuffer) SetSender(sender.Sender, checkid.ID) error {
+	return nil
+}
+
+func (n *noopRingBuffer) DestroySender(_ checkid.ID) {}
+
+func (n *noopRingBuffer) GetDefaultSender() (sender.Sender, error) {
+	return &shadowSender{}, nil
+}
+
+// shadowSender implements sender.Sender and logs every data point instead of forwarding it.
+type shadowSender struct{}
+
+func (s *shadowSender) Commit() {
+	log.Debugf("shadow sender: Commit")
+}
+
+func (s *shadowSender) Gauge(metric string, value float64, hostname string, tags []string) {
+	log.Debugf("shadow sender: Gauge metric=%s value=%v hostname=%s tags=%v", metric, value, hostname, tags)
+}
+
+func (s *shadowSender) GaugeNoIndex(metric string, value float64, hostname string, tags []string) {
+	log.Debugf("shadow sender: GaugeNoIndex metric=%s value=%v hostname=%s tags=%v", metric, value, hostname, tags)
+}
+
+func (s *shadowSender) Rate(metric string, value float64, hostname string, tags []string) {
+	log.Debugf("shadow sender: Rate metric=%s value=%v hostname=%s tags=%v", metric, value, hostname, tags)
+}
+
+func (s *shadowSender) Count(metric string, value float64, hostname string, tags []string) {
+	log.Debugf("shadow sender: Count metric=%s value=%v hostname=%s tags=%v", metric, value, hostname, tags)
+}
+
+func (s *shadowSender) MonotonicCount(metric string, value float64, hostname string, tags []string) {
+	log.Debugf("shadow sender: MonotonicCount metric=%s value=%v hostname=%s tags=%v", metric, value, hostname, tags)
+}
+
+func (s *shadowSender) MonotonicCountWithFlushFirstValue(metric string, value float64, hostname string, tags []string, flushFirstValue bool) {
+	log.Debugf("shadow sender: MonotonicCountWithFlushFirstValue metric=%s value=%v hostname=%s tags=%v flushFirstValue=%v", metric, value, hostname, tags, flushFirstValue)
+}
+
+func (s *shadowSender) Counter(metric string, value float64, hostname string, tags []string) {
+	log.Debugf("shadow sender: Counter metric=%s value=%v hostname=%s tags=%v", metric, value, hostname, tags)
+}
+
+func (s *shadowSender) Histogram(metric string, value float64, hostname string, tags []string) {
+	log.Debugf("shadow sender: Histogram metric=%s value=%v hostname=%s tags=%v", metric, value, hostname, tags)
+}
+
+func (s *shadowSender) Historate(metric string, value float64, hostname string, tags []string) {
+	log.Debugf("shadow sender: Historate metric=%s value=%v hostname=%s tags=%v", metric, value, hostname, tags)
+}
+
+func (s *shadowSender) Distribution(metric string, value float64, hostname string, tags []string) {
+	log.Debugf("shadow sender: Distribution metric=%s value=%v hostname=%s tags=%v", metric, value, hostname, tags)
+}
+
+func (s *shadowSender) ServiceCheck(checkName string, status servicecheck.ServiceCheckStatus, hostname string, tags []string, message string) {
+	log.Debugf("shadow sender: ServiceCheck checkName=%s status=%v hostname=%s tags=%v message=%s", checkName, status, hostname, tags, message)
+}
+
+func (s *shadowSender) OpenmetricsBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
+	log.Debugf("shadow sender: OpenmetricsBucket metric=%s value=%v [%v,%v) monotonic=%v hostname=%s tags=%v flushFirstValue=%v", metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue)
+}
+
+func (s *shadowSender) HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
+	log.Debugf("shadow sender: HistogramBucket metric=%s value=%v [%v,%v) monotonic=%v hostname=%s tags=%v flushFirstValue=%v", metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue)
+}
+
+func (s *shadowSender) GaugeWithTimestamp(metric string, value float64, hostname string, tags []string, timestamp float64) error {
+	log.Debugf("shadow sender: GaugeWithTimestamp metric=%s value=%v hostname=%s tags=%v timestamp=%v", metric, value, hostname, tags, timestamp)
+	return nil
+}
+
+func (s *shadowSender) CountWithTimestamp(metric string, value float64, hostname string, tags []string, timestamp float64) error {
+	log.Debugf("shadow sender: CountWithTimestamp metric=%s value=%v hostname=%s tags=%v timestamp=%v", metric, value, hostname, tags, timestamp)
+	return nil
+}
+
+func (s *shadowSender) Event(e event.Event) {
+	log.Debugf("shadow sender: Event title=%s host=%s", e.Title, e.Host)
+}
+
+func (s *shadowSender) EventPlatformEvent(rawEvent []byte, eventType string) {
+	log.Debugf("shadow sender: EventPlatformEvent eventType=%s len=%d", eventType, len(rawEvent))
+}
+
+func (s *shadowSender) GetSenderStats() stats.SenderStats {
+	return stats.SenderStats{}
+}
+
+func (s *shadowSender) DisableDefaultHostname(_ bool)   {}
+func (s *shadowSender) SetCheckCustomTags(_ []string)   {}
+func (s *shadowSender) SetCheckService(_ string)        {}
+func (s *shadowSender) SetNoIndex(_ bool)               {}
+func (s *shadowSender) FinalizeCheckServiceTag()        {}
+
+func (s *shadowSender) OrchestratorMetadata(msgs []types.ProcessMessageBody, clusterID string, nodeType int) {
+	log.Debugf("shadow sender: OrchestratorMetadata clusterID=%s nodeType=%d msgs=%d", clusterID, nodeType, len(msgs))
+}
+
+func (s *shadowSender) OrchestratorManifest(msgs []types.ProcessMessageBody, clusterID string) {
+	log.Debugf("shadow sender: OrchestratorManifest clusterID=%s msgs=%d", clusterID, len(msgs))
+}

--- a/pkg/collector/worker/worker.go
+++ b/pkg/collector/worker/worker.go
@@ -60,6 +60,7 @@ type Worker struct {
 	haAgent                 haagent.Component
 	healthPlatform          healthplatform.Component
 	watchdogWarningTimeout  time.Duration
+	isShadowWorker          bool
 }
 
 // NewWorker returns an instance of a `Worker` after parameter sanity checks are passed
@@ -73,6 +74,7 @@ func NewWorker(
 	checksTracker *tracker.RunningChecksTracker,
 	shouldAddCheckStatsFunc func(id checkid.ID) bool,
 	watchdogWarningTimeout time.Duration,
+	isShadowWorker bool,
 ) (*Worker, error) {
 
 	if checksTracker == nil {
@@ -98,6 +100,7 @@ func NewWorker(
 		healthPlatform,
 		pollingInterval,
 		watchdogWarningTimeout,
+		isShadowWorker,
 	)
 }
 
@@ -115,6 +118,7 @@ func newWorkerWithOptions(
 	healthPlatform healthplatform.Component,
 	utilizationTickInterval time.Duration,
 	watchdogWarningTimeout time.Duration,
+	isShadowWorker bool,
 ) (*Worker, error) {
 
 	if getDefaultSenderFunc == nil {
@@ -122,6 +126,10 @@ func newWorkerWithOptions(
 	}
 
 	workerName := fmt.Sprintf("worker_%d", ID)
+
+	if isShadowWorker {
+		workerName = workerName + " (shadow)"
+	}
 
 	return &Worker{
 		ID:                      ID,
@@ -135,6 +143,7 @@ func newWorkerWithOptions(
 		healthPlatform:          healthPlatform,
 		utilizationTickInterval: utilizationTickInterval,
 		watchdogWarningTimeout:  watchdogWarningTimeout,
+		isShadowWorker:          isShadowWorker,
 	}, nil
 }
 
@@ -142,7 +151,7 @@ func newWorkerWithOptions(
 // The provided ctx is used for cancellable operations such as hostname resolution;
 // it should be cancelled when the agent shuts down.
 func (w *Worker) Run(ctx context.Context) {
-	log.Debugf("Runner %d, worker %d: Ready to process checks...", w.runnerID, w.ID)
+	log.Debugf("Runner %d, worker %d, shadow: %t: Ready to process checks...", w.runnerID, w.ID, w.isShadowWorker)
 
 	alpha := 0.25 // converges to 99.98% of constant input in 30 iterations.
 	utilizationTracker := utilizationtracker.NewUtilizationTracker(w.utilizationTickInterval, alpha)
@@ -231,7 +240,7 @@ func (w *Worker) Run(ctx context.Context) {
 			serviceCheckStatus = servicecheck.ServiceCheckCritical
 		}
 
-		if sender != nil && !longRunning {
+		if sender != nil && !longRunning && !w.isShadowWorker {
 			if pkgconfigsetup.Datadog().GetBool("integration_check_status_enabled") {
 				sender.ServiceCheck(serviceCheckStatusKey, serviceCheckStatus, hname, serviceCheckTags, "")
 			}


### PR DESCRIPTION
### What does this PR do?

Key decisions:
- ShadowCheck wrapper lives in `pkg/collector/check/` as a public type. It overrides `ID()` (appends `:shadow`) and `Interval()` to distinguish shadow instances from their normal counterparts without modifying the `Check` interface.
- Dedicated shadow channel and workers in the runner provide isolation: shadow checks never compete with normal checks for worker slots, and shadow workers skip service check status emission.
- Routing via type assertion `(*check.ShadowCheck)` in scheduler/job.go keeps the dispatch logic local to the scheduler without leaking shadow concerns into the runner or the `Check` interface.
- Shadow checks are loaded inline in `getChecks()`, immediately after the normal instance, sharing the same loader loop. This avoids a second scheduling pass.