### PR TITLE
Finish consolidating Bazel invocations in `invoke` tasks

### DIFF
--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -96,9 +96,10 @@ def bazel(
     ctx: Context,
     *args: str,
     capture_output: bool = False,
-    sudo: bool = False,
     capture_stderr: bool = False,
-) -> None | str:
+    ignore_errors: bool = False,
+    sudo: bool = False,
+) -> str:
     """Execute a bazel command.
 
     capture_output: capture stdout.
@@ -107,26 +108,28 @@ def bazel(
         and the caller needs to process it.
     """
 
-    if not (resolved_bazel := shutil.which("bazel")):
+    if not (bazelisk := shutil.which("bazelisk")):  # `/usr/bin/bazel` may otherwise take precedence in DD Workspaces
         raise Exit(bazel_not_found_message("red"))
-    cmd = ("sudo", resolved_bazel) if sudo else ("bazel",)
+    cmd = (("sudo",) if sudo else ()) + (bazelisk,) + args
+    cmdline = (subprocess.list2cmdline if sys.platform == "win32" else shlex.join)(cmd)
+    print(color_message(cmdline.replace(bazelisk, "bazel", 1), "bold"), file=sys.stderr)  # brevity: abspath -> bazel
     kwargs = {}
     # Invoke terminolgy is subtle. "hide" means hide from the user.
     # In every other libray, that would be called capture, and the
     # act of capturing it would hide it from the user.
     # https://docs.pyinvoke.org/en/stable/api/runners.html#invoke.runners.Runner.run
-    if capture_output:
-        kwargs["hide"] = "both" if capture_stderr else "out"
+    if capture_output and capture_stderr:
+        kwargs["hide"] = "both"
+    elif capture_output:
+        kwargs["hide"] = "out"
+    elif capture_stderr:
+        kwargs["hide"] = "err"
     elif not sudo and sys.stdout.isatty() and sys.platform != "win32":
         kwargs["pty"] = True
-    result = ctx.run(
-        (subprocess.list2cmdline if sys.platform == "win32" else shlex.join)(cmd + args),
-        echo=True,
-        in_stream=False,
-        **kwargs,
-    )
-    if not capture_output:
-        return None
+    result = ctx.run(cmdline, in_stream=False, warn=ignore_errors, **kwargs)
+    captured = []
+    if capture_output and result.ok:
+        captured.append(result.stdout)
     if capture_stderr:
-        return (result.stdout or "") + (result.stderr or "")
-    return result.stdout
+        captured.append(result.stderr)
+    return "".join(captured)

--- a/tasks/libs/common/go.py
+++ b/tasks/libs/common/go.py
@@ -15,6 +15,7 @@ from invoke.context import Context, MockContext
 from invoke.exceptions import Exit
 from invoke.runners import Local, Result
 
+from tasks.libs.build.bazel import bazel
 from tasks.libs.common.retry import run_command_with_retry
 from tasks.libs.common.utils import timed
 
@@ -106,13 +107,14 @@ def _with_hermetic_mingw_path(ctx: Context, env: dict[str, str] | None) -> dict[
 
     TODO: remove once migrated fully to the Bazel MinGW toolchain.
     """
-    # bazel fetch is idempotent: it extracts @winlibs_mingw64 only if missing.
-    if not ctx.run("bazelisk fetch --repo=@winlibs_mingw64", hide=True, warn=True).ok:
+    # bazel cquery is idempotent: it fetches/extracts @winlibs_mingw64 only if missing.
+    if not (
+        gcc := bazel(ctx, "cquery", "@winlibs_mingw64//:gcc", "--output=files", capture_output=True, ignore_errors=True)
+    ):
         return env
-    res = ctx.run("bazelisk info output_base", hide=True, warn=True)
-    if not res.ok:
+    if not (output_base := bazel(ctx, "info", "output_base", capture_output=True, ignore_errors=True)):
         return env
-    mingw_bin = f"{res.stdout.strip()}/external/+winlibs_mingw_repository+winlibs_mingw64/bin"
+    mingw_bin = Path(output_base.strip(), gcc.strip()).parent
     path = (env or {}).get("PATH") or os.environ.get("PATH", "")
     return {**(env or {}), "PATH": f"{mingw_bin}{os.pathsep}{path}"}
 

--- a/tasks/unit_tests/libs/build/bazel_tests.py
+++ b/tasks/unit_tests/libs/build/bazel_tests.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from invoke import Context, Exit, MockContext
 
@@ -10,7 +10,7 @@ from tasks.libs.common.utils import get_repo_root
 
 class TestBazel(unittest.TestCase):
     def test_bazel_call(self):
-        self.assertIsNone(bazel(Context(), "info", "release"))
+        self.assertEqual(bazel(Context(), "info", "release"), "")
 
     def test_bazel_output(self):
         expected_version = (get_repo_root() / ".bazelversion").read_text().strip()
@@ -22,6 +22,37 @@ class TestBazel(unittest.TestCase):
         with self.assertRaises(Exit) as cm:
             bazel(MockContext(), "info")
         self.assertIn("Please run `inv install-tools` for `bazel` support!", cm.exception.message)
+
+    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
+    def test_capture_output(self, _):
+        self.assertEqual(bazel(self._ctx(), "info", capture_output=True), "out\n")
+
+    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
+    def test_capture_stderr(self, _):
+        self.assertEqual(bazel(self._ctx(), "info", capture_stderr=True), "err\n")
+
+    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
+    def test_capture_both(self, _):
+        self.assertEqual(bazel(self._ctx(), "info", capture_output=True, capture_stderr=True), "out\nerr\n")
+
+    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
+    def test_ignore_errors_captures_output_on_success(self, _):
+        self.assertEqual(bazel(self._ctx(), "info", ignore_errors=True, capture_output=True), "out\n")
+
+    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
+    def test_ignore_errors_only_captures_stderr_on_failure(self, _):
+        self.assertEqual(
+            bazel(self._ctx(exit=1), "info", ignore_errors=True, capture_output=True, capture_stderr=True), "err\n"
+        )
+
+    def _ctx(self, *, exit=0, stdout="out\n", stderr="err\n"):
+        result = MagicMock()
+        result.ok = exit == 0
+        result.stdout = stdout
+        result.stderr = stderr
+        ctx = MagicMock()
+        ctx.run.return_value = result
+        return ctx
 
 
 class TestSplitLabel(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?
Complete the centralization of #47952 by routing the two remaining direct `bazelisk` calls in `common/go.py` through `bazel()`, resolving the MinGW path via `cquery --output=files` instead of a hardcoded subpath.

To cover error-tolerant and capture-only invocations, `bazel()` gains `ignore_errors`, requiring a rethink of the hide/return logic.

The helper's echo is normalized to show `bazel` rather than the full resolved `bazelisk` path for brevity.

### Motivation
While reviewing #52237, @alopezz [noticed](https://dd.slack.com/archives/C08SC2EG5RD/p1782284369506109?thread_ts=1782131416.867569&cid=C08SC2EG5RD) surviving Bazel server restarts in CI.

It then took us time to realize these traced back to two direct `bazelisk` calls in `common/go.py`: run from Omnibus's `project_dir`, a repo copy, Bazel restarts itself to serve that workspace.

#47952 had established `bazel()` as the single dispatch point for all Bazel invocations, but those two calls predated or bypassed it.

Switching to `bazelisk` also closes a broader class of breakage documented in #48666: system-wide `bazel` binaries (from `apt` or `brew`) silently taking precedence over `bazelisk`-managed symlinks, causing wrong Bazel versions to be used without any obvious error.

### Describe how you validated your changes
On Windows (VM):
1. shut down the Bazel server,
2. deleted the cached repo (`+winlibs_mingw_repository+winlibs_mingw64`) and its `.marker` file,
3. ran `bazel cquery @winlibs_mingw64//:gcc --output=files`.

Bazel re-fetched and extracted the repo: `gcc.exe` was present at the path combining the `cquery` output with `bazel info output_base`.