### PR TITLE
validate ownership and permissions of tmp dir

### DIFF
--- a/pkg/util/kernel/headers/find_headers.go
+++ b/pkg/util/kernel/headers/find_headers.go
@@ -411,7 +411,7 @@ func checkTempDirPermissions(dir string) error {
 		return fmt.Errorf("unable to verify permissions of %s", dir)
 	}
 	if stat.Uid != 0 || stat.Gid != 0 || sfi.Mode().Perm()&os.FileMode(0022) != 0 {
-		return fmt.Errorf("%w: %s has incorrect permissions: user=%d, group=%d, permissions=%s", errInvalidTempDirectory, dir, stat.Uid, stat.Gid, sfi.Mode().Perm())
+		return fmt.Errorf("%w: %s must be owned by user=0, group=0, and no group/world write permissions: found user=%d, group=%d, permissions=%s", errInvalidTempDirectory, dir, stat.Uid, stat.Gid, sfi.Mode().Perm())
 	}
 	return nil
 }

--- a/pkg/util/kernel/headers/find_headers.go
+++ b/pkg/util/kernel/headers/find_headers.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"syscall"
 
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
@@ -200,7 +201,7 @@ func (h *headerProvider) getKernelHeaders(hv kernel.Version) ([]string, headerFe
 		// The `kheaders` module will be automatically added and removed if present and needed.
 		var err error
 		var dirs []string
-		if dirs, err = getSysfsHeaderDirs(hv); err == nil {
+		if dirs, err = getSysfsHeaderDirs(os.TempDir(), hv); err == nil {
 			return dirs, sysfsHeadersFound, nil
 		}
 		log.Debugf("unable to find system kernel headers: %v", err)
@@ -390,23 +391,50 @@ func getDownloadedHeaderDirs(headerDownloadDir string) []string {
 	return dirs
 }
 
-func getSysfsHeaderDirs(v kernel.Version) ([]string, error) {
-	tmpPath := filepath.Join(os.TempDir(), fmt.Sprintf("linux-headers-%s", v))
-	fi, err := os.Stat(tmpPath)
-	if err == nil && fi.IsDir() {
-		hv, err := getHeaderVersion(tmpPath)
-		if err != nil {
-			// remove tmp dir if it errors
-			_ = os.RemoveAll(tmpPath)
-			return nil, fmt.Errorf("unable to verify headers version: %w", err)
+var errInvalidTempDirectory = errors.New("invalid system-probe temp directory")
+
+func getSysfsHeaderDirs(tmpDir string, v kernel.Version) ([]string, error) {
+	sysprobeTmpPath := filepath.Join(tmpDir, "system-probe")
+	tmpPath := filepath.Join(sysprobeTmpPath, fmt.Sprintf("linux-headers-%s", v))
+
+	sfi, statErr := os.Stat(sysprobeTmpPath)
+	if statErr != nil {
+		if errors.Is(statErr, fs.ErrNotExist) {
+			if err := os.MkdirAll(sysprobeTmpPath, 0755); err != nil {
+				return nil, fmt.Errorf("create system-probe temp directory: %s", err)
+			}
+		} else {
+			return nil, fmt.Errorf("stat %s: %s", sysprobeTmpPath, statErr)
 		}
-		if hv != v {
-			// remove tmp dir if it fails to validate
-			_ = os.RemoveAll(tmpPath)
-			return nil, fmt.Errorf("header version %s does not match expected host version %s", v, hv)
+	} else {
+		if !sfi.IsDir() {
+			return nil, fmt.Errorf("%w: %s is not a directory", errInvalidTempDirectory, sysprobeTmpPath)
 		}
-		log.Debugf("found valid kernel headers at %s", tmpPath)
-		return []string{tmpPath}, nil
+
+		stat, ok := sfi.Sys().(*syscall.Stat_t)
+		if !ok {
+			return nil, fmt.Errorf("unable to verify permissions of %s", sysprobeTmpPath)
+		}
+		if stat.Uid != 0 || stat.Gid != 0 || sfi.Mode().Perm()&os.FileMode(0022) != 0 {
+			return nil, fmt.Errorf("%w: %s has incorrect permissions: user=%d, group=%d, permissions=%s", errInvalidTempDirectory, sysprobeTmpPath, stat.Uid, stat.Gid, sfi.Mode().Perm())
+		}
+
+		fi, err := os.Stat(tmpPath)
+		if err == nil && fi.IsDir() {
+			hv, err := getHeaderVersion(tmpPath)
+			if err != nil {
+				// remove tmp dir if it errors
+				_ = os.RemoveAll(tmpPath)
+				return nil, fmt.Errorf("unable to verify headers version: %w", err)
+			}
+			if hv != v {
+				// remove tmp dir if it fails to validate
+				_ = os.RemoveAll(tmpPath)
+				return nil, fmt.Errorf("header version %s does not match expected host version %s", v, hv)
+			}
+			log.Debugf("found valid kernel headers at %s", tmpPath)
+			return []string{tmpPath}, nil
+		}
 	}
 
 	if !sysfsHeadersExist() {
@@ -419,7 +447,7 @@ func getSysfsHeaderDirs(v kernel.Version) ([]string, error) {
 		}
 	}
 
-	if err = archive.TarXZExtractAll(sysfsHeadersPath, tmpPath); err != nil {
+	if err := archive.TarXZExtractAll(sysfsHeadersPath, tmpPath); err != nil {
 		return nil, fmt.Errorf("unable to extract kernel headers: %w", err)
 	}
 	log.Debugf("found valid kernel headers at %s", tmpPath)

--- a/pkg/util/kernel/headers/find_headers.go
+++ b/pkg/util/kernel/headers/find_headers.go
@@ -393,51 +393,50 @@ func getDownloadedHeaderDirs(headerDownloadDir string) []string {
 
 var errInvalidTempDirectory = errors.New("invalid system-probe temp directory")
 
+func checkTempDirPermissions(dir string) error {
+	sfi, statErr := os.Lstat(dir)
+	if statErr != nil {
+		return statErr
+	}
+
+	if !sfi.IsDir() {
+		return fmt.Errorf("%w: %s is not a directory", errInvalidTempDirectory, dir)
+	}
+	if sfi.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf("%w: %s is not allowed to be a symlink", errInvalidTempDirectory, dir)
+	}
+
+	stat, ok := sfi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("unable to verify permissions of %s", dir)
+	}
+	if stat.Uid != 0 || stat.Gid != 0 || sfi.Mode().Perm()&os.FileMode(0022) != 0 {
+		return fmt.Errorf("%w: %s has incorrect permissions: user=%d, group=%d, permissions=%s", errInvalidTempDirectory, dir, stat.Uid, stat.Gid, sfi.Mode().Perm())
+	}
+	return nil
+}
+
 func getSysfsHeaderDirs(tmpDir string, v kernel.Version) ([]string, error) {
 	sysprobeTmpPath := filepath.Join(tmpDir, "system-probe")
 	tmpPath := filepath.Join(sysprobeTmpPath, fmt.Sprintf("linux-headers-%s", v))
 
-	sfi, statErr := os.Lstat(sysprobeTmpPath)
-	if statErr != nil {
-		if errors.Is(statErr, fs.ErrNotExist) {
-			if err := os.MkdirAll(sysprobeTmpPath, 0755); err != nil {
-				return nil, fmt.Errorf("create system-probe temp directory: %s", err)
-			}
-		} else {
-			return nil, fmt.Errorf("stat %s: %s", sysprobeTmpPath, statErr)
+	if fi, err := os.Stat(tmpPath); err == nil && fi.IsDir() {
+		if err := checkTempDirPermissions(sysprobeTmpPath); err != nil {
+			return nil, err
 		}
-	} else {
-		if !sfi.IsDir() {
-			return nil, fmt.Errorf("%w: %s is not a directory", errInvalidTempDirectory, sysprobeTmpPath)
+		hv, err := getHeaderVersion(tmpPath)
+		if err != nil {
+			// remove tmp dir if it errors
+			_ = os.RemoveAll(tmpPath)
+			return nil, fmt.Errorf("unable to verify headers version: %w", err)
 		}
-		if sfi.Mode()&fs.ModeSymlink != 0 {
-			return nil, fmt.Errorf("%w: %s is not allowed to be a symlink", errInvalidTempDirectory, sysprobeTmpPath)
+		if hv != v {
+			// remove tmp dir if it fails to validate
+			_ = os.RemoveAll(tmpPath)
+			return nil, fmt.Errorf("header version %s does not match expected host version %s", v, hv)
 		}
-
-		stat, ok := sfi.Sys().(*syscall.Stat_t)
-		if !ok {
-			return nil, fmt.Errorf("unable to verify permissions of %s", sysprobeTmpPath)
-		}
-		if stat.Uid != 0 || stat.Gid != 0 || sfi.Mode().Perm()&os.FileMode(0022) != 0 {
-			return nil, fmt.Errorf("%w: %s has incorrect permissions: user=%d, group=%d, permissions=%s", errInvalidTempDirectory, sysprobeTmpPath, stat.Uid, stat.Gid, sfi.Mode().Perm())
-		}
-
-		fi, err := os.Stat(tmpPath)
-		if err == nil && fi.IsDir() {
-			hv, err := getHeaderVersion(tmpPath)
-			if err != nil {
-				// remove tmp dir if it errors
-				_ = os.RemoveAll(tmpPath)
-				return nil, fmt.Errorf("unable to verify headers version: %w", err)
-			}
-			if hv != v {
-				// remove tmp dir if it fails to validate
-				_ = os.RemoveAll(tmpPath)
-				return nil, fmt.Errorf("header version %s does not match expected host version %s", v, hv)
-			}
-			log.Debugf("found valid kernel headers at %s", tmpPath)
-			return []string{tmpPath}, nil
-		}
+		log.Debugf("found valid kernel headers at %s", tmpPath)
+		return []string{tmpPath}, nil
 	}
 
 	if !sysfsHeadersExist() {
@@ -450,6 +449,15 @@ func getSysfsHeaderDirs(tmpDir string, v kernel.Version) ([]string, error) {
 		}
 	}
 
+	if _, err := os.Lstat(sysprobeTmpPath); errors.Is(err, fs.ErrNotExist) {
+		if err := os.MkdirAll(sysprobeTmpPath, 0755); err != nil {
+			return nil, fmt.Errorf("create system-probe temp directory: %s", err)
+		}
+	}
+
+	if err := checkTempDirPermissions(sysprobeTmpPath); err != nil {
+		return nil, err
+	}
 	if err := archive.TarXZExtractAll(sysfsHeadersPath, tmpPath); err != nil {
 		return nil, fmt.Errorf("unable to extract kernel headers: %w", err)
 	}

--- a/pkg/util/kernel/headers/find_headers.go
+++ b/pkg/util/kernel/headers/find_headers.go
@@ -397,7 +397,7 @@ func getSysfsHeaderDirs(tmpDir string, v kernel.Version) ([]string, error) {
 	sysprobeTmpPath := filepath.Join(tmpDir, "system-probe")
 	tmpPath := filepath.Join(sysprobeTmpPath, fmt.Sprintf("linux-headers-%s", v))
 
-	sfi, statErr := os.Stat(sysprobeTmpPath)
+	sfi, statErr := os.Lstat(sysprobeTmpPath)
 	if statErr != nil {
 		if errors.Is(statErr, fs.ErrNotExist) {
 			if err := os.MkdirAll(sysprobeTmpPath, 0755); err != nil {
@@ -409,6 +409,9 @@ func getSysfsHeaderDirs(tmpDir string, v kernel.Version) ([]string, error) {
 	} else {
 		if !sfi.IsDir() {
 			return nil, fmt.Errorf("%w: %s is not a directory", errInvalidTempDirectory, sysprobeTmpPath)
+		}
+		if sfi.Mode()&fs.ModeSymlink != 0 {
+			return nil, fmt.Errorf("%w: %s is not allowed to be a symlink", errInvalidTempDirectory, sysprobeTmpPath)
 		}
 
 		stat, ok := sfi.Sys().(*syscall.Stat_t)

--- a/pkg/util/kernel/headers/find_headers_test.go
+++ b/pkg/util/kernel/headers/find_headers_test.go
@@ -85,6 +85,10 @@ func TestInvalidExistingKernelHeaders(t *testing.T) {
 		require.ErrorIs(t, err, errInvalidTempDirectory)
 	})
 	t.Run("user", func(t *testing.T) {
+		if os.Geteuid() != 0 {
+			t.Skip("skipping test because not root")
+		}
+
 		tmpDir := t.TempDir()
 		sp := filepath.Join(tmpDir, "system-probe")
 		err := os.MkdirAll(sp, 0777)
@@ -97,6 +101,10 @@ func TestInvalidExistingKernelHeaders(t *testing.T) {
 		require.ErrorIs(t, err, errInvalidTempDirectory)
 	})
 	t.Run("group", func(t *testing.T) {
+		if os.Geteuid() != 0 {
+			t.Skip("skipping test because not root")
+		}
+
 		tmpDir := t.TempDir()
 		sp := filepath.Join(tmpDir, "system-probe")
 		err := os.MkdirAll(sp, 0777)

--- a/pkg/util/kernel/headers/find_headers_test.go
+++ b/pkg/util/kernel/headers/find_headers_test.go
@@ -9,6 +9,7 @@ package headers
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -70,11 +71,12 @@ func TestParseHeaderVersion(t *testing.T) {
 
 func TestInvalidExistingKernelHeaders(t *testing.T) {
 	kv := kernel.VersionCode(4, 14, 200)
+	headerDirName := fmt.Sprintf("linux-headers-%s", kv)
 
 	t.Run("write perms", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		sp := filepath.Join(tmpDir, "system-probe")
-		err := os.MkdirAll(sp, 0777)
+		err := os.MkdirAll(filepath.Join(sp, headerDirName), 0777)
 		require.NoError(t, err)
 
 		// must chmod because umask affects mkdir
@@ -91,7 +93,7 @@ func TestInvalidExistingKernelHeaders(t *testing.T) {
 
 		tmpDir := t.TempDir()
 		sp := filepath.Join(tmpDir, "system-probe")
-		err := os.MkdirAll(sp, 0777)
+		err := os.MkdirAll(filepath.Join(sp, headerDirName), 0777)
 		require.NoError(t, err)
 
 		err = os.Chown(sp, 1, 0)
@@ -107,7 +109,7 @@ func TestInvalidExistingKernelHeaders(t *testing.T) {
 
 		tmpDir := t.TempDir()
 		sp := filepath.Join(tmpDir, "system-probe")
-		err := os.MkdirAll(sp, 0777)
+		err := os.MkdirAll(filepath.Join(sp, headerDirName), 0777)
 		require.NoError(t, err)
 
 		err = os.Chown(sp, 0, 1)
@@ -119,7 +121,7 @@ func TestInvalidExistingKernelHeaders(t *testing.T) {
 	t.Run("symlink", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		dst := filepath.Join(tmpDir, "symdst")
-		err := os.MkdirAll(dst, 0777)
+		err := os.MkdirAll(filepath.Join(dst, headerDirName), 0777)
 		require.NoError(t, err)
 
 		sp := filepath.Join(tmpDir, "system-probe")

--- a/pkg/util/kernel/headers/find_headers_test.go
+++ b/pkg/util/kernel/headers/find_headers_test.go
@@ -116,16 +116,6 @@ func TestInvalidExistingKernelHeaders(t *testing.T) {
 		_, err = getSysfsHeaderDirs(tmpDir, kv)
 		require.ErrorIs(t, err, errInvalidTempDirectory)
 	})
-	t.Run("file", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		sp := filepath.Join(tmpDir, "system-probe")
-		err := os.WriteFile(sp, nil, 0777)
-		require.NoError(t, err)
-
-		_, err = getSysfsHeaderDirs(tmpDir, kv)
-		require.ErrorIs(t, err, errInvalidTempDirectory)
-	})
-
 	t.Run("symlink", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		dst := filepath.Join(tmpDir, "symdst")

--- a/pkg/util/kernel/headers/find_headers_test.go
+++ b/pkg/util/kernel/headers/find_headers_test.go
@@ -117,4 +117,18 @@ func TestInvalidExistingKernelHeaders(t *testing.T) {
 		_, err = getSysfsHeaderDirs(tmpDir, kv)
 		require.ErrorIs(t, err, errInvalidTempDirectory)
 	})
+
+	t.Run("symlink", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dst := filepath.Join(tmpDir, "symdst")
+		err := os.MkdirAll(dst, 0777)
+		require.NoError(t, err)
+
+		sp := filepath.Join(tmpDir, "system-probe")
+		err = os.Symlink(dst, sp)
+		require.NoError(t, err)
+
+		_, err = getSysfsHeaderDirs(tmpDir, kv)
+		require.ErrorIs(t, err, errInvalidTempDirectory)
+	})
 }

--- a/pkg/util/kernel/headers/find_headers_test.go
+++ b/pkg/util/kernel/headers/find_headers_test.go
@@ -9,9 +9,12 @@ package headers
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -63,4 +66,55 @@ func TestParseHeaderVersion(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestInvalidExistingKernelHeaders(t *testing.T) {
+	kv := kernel.VersionCode(4, 14, 200)
+
+	t.Run("write perms", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		sp := filepath.Join(tmpDir, "system-probe")
+		err := os.MkdirAll(sp, 0777)
+		require.NoError(t, err)
+
+		// must chmod because umask affects mkdir
+		err = os.Chmod(sp, 0777)
+		require.NoError(t, err)
+
+		_, err = getSysfsHeaderDirs(tmpDir, kv)
+		require.ErrorIs(t, err, errInvalidTempDirectory)
+	})
+	t.Run("user", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		sp := filepath.Join(tmpDir, "system-probe")
+		err := os.MkdirAll(sp, 0777)
+		require.NoError(t, err)
+
+		err = os.Chown(sp, 1, 0)
+		require.NoError(t, err)
+
+		_, err = getSysfsHeaderDirs(tmpDir, kv)
+		require.ErrorIs(t, err, errInvalidTempDirectory)
+	})
+	t.Run("group", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		sp := filepath.Join(tmpDir, "system-probe")
+		err := os.MkdirAll(sp, 0777)
+		require.NoError(t, err)
+
+		err = os.Chown(sp, 0, 1)
+		require.NoError(t, err)
+
+		_, err = getSysfsHeaderDirs(tmpDir, kv)
+		require.ErrorIs(t, err, errInvalidTempDirectory)
+	})
+	t.Run("file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		sp := filepath.Join(tmpDir, "system-probe")
+		err := os.WriteFile(sp, nil, 0777)
+		require.NoError(t, err)
+
+		_, err = getSysfsHeaderDirs(tmpDir, kv)
+		require.ErrorIs(t, err, errInvalidTempDirectory)
+	})
 }


### PR DESCRIPTION
### What does this PR do?

Validates the temp directory we read for Linux kernel headers during runtime compilation is owned by root/root and no other user/group has write permissions.

### Motivation

Fix [EBPF-1183](https://datadoghq.atlassian.net/browse/EBPF-1183)

### Describe how you validated your changes

Added tests.

### Additional Notes


[EBPF-1183]: https://datadoghq.atlassian.net/browse/EBPF-1183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ