### PR TITLE
feat(serverless-init): tag forwarded logs with lambda_microvm_id on /launch

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -42,6 +42,8 @@ type LifecycleContext struct {
 	SampleDrainer lifecycle.SampleDrainer
 	FlushTimeout  time.Duration
 	SidecarMode   bool
+	LogsTagSetter lifecycle.LogsTagSetter // nil-safe; applied via server.SetLogsTagSetter after /launch
+	BaseTags      []string                // startup log tag snapshot passed alongside LogsTagSetter
 }
 
 // MicroVM implements CloudService for AWS Lambda MicroVMs.
@@ -142,6 +144,9 @@ func (m *MicroVM) Init(ctx *TracingContext) error {
 		components.Forwarder,
 		heartbeat,
 	)
+	if lc.LogsTagSetter != nil {
+		m.server.SetLogsTagSetter(lc.LogsTagSetter, lc.BaseTags)
+	}
 	l, err := m.server.Listen()
 	if err != nil {
 		log.Fatalf("MicroVM lifecycle server failed to bind: %v", err)

--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -7,6 +7,9 @@ package cloudservice
 
 import (
 	"context"
+	"net/http"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -96,6 +99,73 @@ func TestMicroVMOrigin(t *testing.T) {
 
 func TestMicroVMMetricPrefix(t *testing.T) {
 	assert.Equal(t, microVMPrefix, (&MicroVM{}).GetMetricPrefix())
+}
+
+// TestLifecycleContext_NilLogsTagSetter_IsAccepted verifies that
+// LifecycleContext.LogsTagSetter is nil-safe: passing nil must not cause any
+// compile or runtime issue. This pins the nil-check added to MicroVM.Init so
+// callers that don't need log-tag forwarding are not required to supply a setter.
+func TestLifecycleContext_NilLogsTagSetter_IsAccepted(t *testing.T) {
+	lc := &LifecycleContext{LogsTagSetter: nil, BaseTags: nil}
+	assert.Nil(t, lc.LogsTagSetter, "nil LogsTagSetter must be accepted by LifecycleContext")
+}
+
+// TestMicroVM_LogsTagSetter_InvokedOnLaunch verifies the behaviour that
+// MicroVM.Init wires when LogsTagSetter is non-nil: SetLogsTagSetter is called
+// on the server, and the server then invokes the setter on /launch with the
+// base tags plus the microvm_id from the request body.
+//
+// The test constructs the server directly with port 0 (random free port) to
+// avoid the log.Fatalf that Init emits when port 9000 is already bound.
+func TestMicroVM_LogsTagSetter_InvokedOnLaunch(t *testing.T) {
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+
+	var mu sync.Mutex
+	var receivedTags []string
+	setter := lifecycle.LogsTagSetterFunc(func(tags []string) {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedTags = tags
+	})
+	baseTags := []string{"env:test", "service:myapp"}
+
+	// Construct the server directly with port 0 — same path Init takes, minus
+	// the port-9000 binding that would log.Fatalf in a shared test environment.
+	srv := lifecycle.NewServer(
+		0, // random free port
+		metricAgent, &noopTraceAgent{}, &noopLogsFlusher{},
+		metricAgent, metricAgent,
+		(&MicroVM{}).GetSource(),
+		time.Second,
+		lifecycle.NewNoopChildHandle(),
+		nil, // no forwarder
+		nil, // no heartbeat
+	)
+	// This is the call Init makes when lc.LogsTagSetter != nil.
+	srv.SetLogsTagSetter(setter, baseTags)
+
+	l, err := srv.Listen()
+	require.NoError(t, err)
+	go srv.Serve(l)
+	t.Cleanup(func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Stop(shutCtx)
+	})
+
+	launchPath := "/aws/lambda-microvms/runtime/beta/v1/launch"
+	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
+	resp, err := http.Post("http://"+l.Addr().String()+launchPath, "application/json", body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	mu.Lock()
+	got := receivedTags
+	mu.Unlock()
+
+	assert.Contains(t, got, "env:test", "base tags must be forwarded to LogsTagSetter on /launch")
+	assert.Contains(t, got, "service:myapp", "base tags must be forwarded to LogsTagSetter on /launch")
+	assert.Contains(t, got, "lambda_microvm_id:vm-abc123", "microvm_id from /launch body must be appended to tags")
 }
 
 func TestMicroVMInit_NilTracingCtx_DoesNotStartServer(t *testing.T) {

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -71,7 +71,7 @@ const (
 	resumeMetricName    = "aws.lambda.microvm.enhanced.resume"
 	terminateMetricName = "aws.lambda.microvm.enhanced.terminate"
 
-	instanceIDTagPrefix = "instance_id:"
+	lambdaMicroVMID = "lambda_microvm_id:"
 )
 
 // Flusher is satisfied by serverless.FlushableAgent.
@@ -98,6 +98,18 @@ type SampleDrainer interface {
 	WaitForPendingSamples()
 }
 
+// LogsTagSetter can replace the full tag slice on the live log pipeline.
+// Satisfied by serverlessLogs.SetLogsTags (wrapped via LogsTagSetterFunc).
+type LogsTagSetter interface {
+	SetLogsTags(tags []string)
+}
+
+// LogsTagSetterFunc wraps a bare function so it satisfies LogsTagSetter.
+type LogsTagSetterFunc func([]string)
+
+// SetLogsTags implements LogsTagSetter.
+func (f LogsTagSetterFunc) SetLogsTags(tags []string) { f(tags) }
+
 // launchBody is the JSON payload sent by the MicroVM platform on /launch.
 type launchBody struct {
 	MicroVMID string `json:"microVmId"`
@@ -118,6 +130,9 @@ type Server struct {
 	child       *Child      // non-nil only in init-container mode; nil in sidecar and unit tests. Derived from childHandle when it is a *Child.
 	fwd         *Forwarder  // nil = no opt-in; today's behavior preserved
 	heartbeat   *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
+
+	logsTagSetter LogsTagSetter // nil-safe; set via SetLogsTagSetter after construction
+	baseTags      []string      // startup tag snapshot; lambda_microvm_id is appended at /launch
 
 	httpServer *http.Server
 }
@@ -174,6 +189,14 @@ func NewServer(
 		WriteTimeout: writeTimeout,
 	}
 	return s
+}
+
+// SetLogsTagSetter wires a LogsTagSetter and a baseline tag slice into the server.
+// Must be called before the first /launch request. baseTags is the startup tag
+// snapshot; lambda_microvm_id is appended to it when /launch fires.
+func (s *Server) SetLogsTagSetter(setter LogsTagSetter, baseTags []string) {
+	s.logsTagSetter = setter
+	s.baseTags = baseTags
 }
 
 // Listen binds the TCP port synchronously. Call before Serve so the socket is
@@ -391,7 +414,6 @@ func (s *Server) aliveCheckReady(w http.ResponseWriter) {
 // collapsed into dispatchHook directly. The ID is captured before Start
 // so the first heartbeat emission already carries the correct microvm_id tag.
 func (s *Server) handleLaunch(w http.ResponseWriter, r *http.Request) {
-	log.Info("MicroVM lifecycle: launch")
 	// Read the body once so we can parse the instance ID AND still forward the
 	// original payload to the user app. Without this, the forwarder path would
 	// consume r.Body before the decode, losing the instance_id tag on all
@@ -403,8 +425,14 @@ func (s *Server) handleLaunch(w http.ResponseWriter, r *http.Request) {
 		log.Debugf("MicroVM lifecycle: could not parse launch body: %v", err)
 	}
 	if body.MicroVMID != "" {
+		log.Infof("MicroVM lifecycle: launch (microvm_id=%s)", body.MicroVMID)
 		s.instanceID.Store(body.MicroVMID)
 		s.heartbeat.SetMicroVMID(body.MicroVMID)
+		if s.logsTagSetter != nil {
+			s.logsTagSetter.SetLogsTags(append(append([]string{}, s.baseTags...), lambdaMicroVMID+body.MicroVMID))
+		}
+	} else {
+		log.Info("MicroVM lifecycle: launch")
 	}
 	s.heartbeat.Start()
 	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
@@ -477,7 +505,7 @@ func (s *Server) dispatchHook(metricName, path string, withFlush bool, w http.Re
 func (s *Server) emitLifecycleMetric(name string) {
 	var extraTags []string
 	if id := s.instanceID.Load(); id != "" {
-		extraTags = []string{instanceIDTagPrefix + id}
+		extraTags = []string{lambdaMicroVMID + id}
 	}
 	emitMetric(s.metricEmitter, s.metricSource, name, extraTags...)
 }

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -827,8 +827,8 @@ func TestNewServerWithForwarderWriteTimeoutCoversForwardBudget(t *testing.T) {
 }
 
 // TestInstanceIDTagAppearsInMetricsAfterLaunch verifies that once /launch stores a
-// MicroVM instance ID, subsequent lifecycle metrics include instance_id:<id> as an
-// extra tag. This is the primary tagging path for identifying individual MicroVM
+// MicroVM instance ID, subsequent lifecycle metrics include lambda_microvm_id:<id> as
+// an extra tag. This is the primary tagging path for identifying individual MicroVM
 // instances in lifecycle metrics.
 func TestInstanceIDTagAppearsInMetricsAfterLaunch(t *testing.T) {
 	srv, _, _, _, emitter, _ := newTestServer()
@@ -848,7 +848,7 @@ func TestInstanceIDTagAppearsInMetricsAfterLaunch(t *testing.T) {
 		}
 	}
 	require.NotNil(t, found, "suspend metric must be emitted")
-	assert.Contains(t, found.extraTags, instanceIDTagPrefix+"vm-abc123")
+	assert.Contains(t, found.extraTags, lambdaMicroVMID+"vm-abc123")
 }
 
 // errorReader is a helper io.Reader that always returns the provided error.
@@ -1032,6 +1032,24 @@ func TestHandleLaunch_MissingBodyIDUsesUnknown(t *testing.T) {
 	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:unknown")
 }
 
+// traced_invocations is emitted by the Heartbeat on each tick, not directly by
+// handleLaunch. This test verifies the separation of concerns: the server's own
+// emitter must never receive traced_invocations. Billing tag correctness is
+// covered in heartbeat_test.go.
+func TestHandleLaunch_ServerDoesNotDirectlyEmitTracedInvocations(t *testing.T) {
+	srv, _, _, _, emitter, _ := newTestServer()
+	_, teardown := withFakeHeartbeat(t, srv)
+	defer teardown()
+
+	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
+	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+
+	for _, m := range emitter.getEmittedMetrics() {
+		assert.NotEqual(t, activeInstancesMetricName, m.name,
+			"server must not directly emit traced_invocations; that is the heartbeat's responsibility")
+	}
+}
+
 func TestHandleSuspend_StopsHeartbeat(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	started, teardown := withFakeHeartbeat(t, srv)
@@ -1089,4 +1107,172 @@ func TestServerStop_AlsoStopsHeartbeat(t *testing.T) {
 	require.NoError(t, srv.Stop(ctx))
 
 	assert.False(t, started(), "Server.Stop must also stop the heartbeat")
+}
+
+// ---------------------------------------------------------------------------
+// Log tag setter tests
+// ---------------------------------------------------------------------------
+
+// mockLogsTagSetter records every SetLogsTags call for assertions.
+type mockLogsTagSetter struct {
+	mu    sync.Mutex
+	calls [][]string
+}
+
+func (m *mockLogsTagSetter) SetLogsTags(tags []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, slices.Clone(tags))
+}
+
+func (m *mockLogsTagSetter) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.calls)
+}
+
+func (m *mockLogsTagSetter) lastCall() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.calls) == 0 {
+		return nil
+	}
+	return slices.Clone(m.calls[len(m.calls)-1])
+}
+
+func (m *mockLogsTagSetter) allCalls() [][]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([][]string, len(m.calls))
+	for i, c := range m.calls {
+		out[i] = slices.Clone(c)
+	}
+	return out
+}
+
+// TestLogsTagSetterFunc_CallsWrappedFunction verifies that LogsTagSetterFunc
+// delegates to the underlying function when SetLogsTags is called.
+func TestLogsTagSetterFunc_CallsWrappedFunction(t *testing.T) {
+	var received []string
+	fn := LogsTagSetterFunc(func(tags []string) { received = tags })
+	fn.SetLogsTags([]string{"env:prod", "region:us-east-1"})
+	assert.Equal(t, []string{"env:prod", "region:us-east-1"}, received)
+}
+
+// TestSetLogsTagSetter_WiresFields verifies that SetLogsTagSetter stores both
+// the setter and the base-tag snapshot on the server.
+func TestSetLogsTagSetter_WiresFields(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	setter := &mockLogsTagSetter{}
+	baseTags := []string{"region:us-east-1"}
+	srv.SetLogsTagSetter(setter, baseTags)
+	assert.Equal(t, setter, srv.logsTagSetter)
+	assert.Equal(t, baseTags, srv.baseTags)
+}
+
+// TestHandleLaunch_UpdatesLogTagsWithMicroVMID is the primary feature test:
+// /launch with a microVmId body calls SetLogsTags with baseTags + lambdaMicroVMID + id.
+func TestHandleLaunch_UpdatesLogTagsWithMicroVMID(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	setter := &mockLogsTagSetter{}
+	srv.SetLogsTagSetter(setter, []string{"env:prod", "region:us-east-1"})
+
+	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
+	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+
+	require.Equal(t, 1, setter.callCount(), "SetLogsTags must be called exactly once on /launch")
+	assert.Equal(t, []string{"env:prod", "region:us-east-1", lambdaMicroVMID + "vm-abc123"}, setter.lastCall())
+}
+
+// TestHandleLaunch_NoMicroVmID_DoesNotUpdateLogTags verifies that when the platform
+// sends /launch with no microVmId, SetLogsTags is not called — the tag pipeline
+// should not be updated with an unknown value.
+func TestHandleLaunch_NoMicroVmID_DoesNotUpdateLogTags(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	setter := &mockLogsTagSetter{}
+	srv.SetLogsTagSetter(setter, []string{"env:prod"})
+
+	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, nil))
+
+	assert.Equal(t, 0, setter.callCount(), "SetLogsTags must not be called when microVmId is absent")
+}
+
+// TestHandleLaunch_NilLogsTagSetter_DoesNotPanic verifies nil-safety: a server
+// constructed without SetLogsTagSetter must not panic when /launch fires.
+func TestHandleLaunch_NilLogsTagSetter_DoesNotPanic(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	// logsTagSetter is nil by default
+
+	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
+	assert.NotPanics(t, func() {
+		srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+	})
+}
+
+// TestHandleLaunch_BaseTagsNotMutated verifies the safe-append contract: each
+// call to handleLaunch produces an independent slice and does not modify the
+// baseTags stored on the server. This guards against the naive
+// append(s.baseTags, ...) pattern which can corrupt baseTags when the slice
+// has spare capacity.
+func TestHandleLaunch_BaseTagsNotMutated(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	setter := &mockLogsTagSetter{}
+	baseTags := []string{"env:prod", "service:foo"}
+	originalBase := slices.Clone(baseTags)
+	srv.SetLogsTagSetter(setter, baseTags)
+
+	body1 := strings.NewReader(`{"microVmId":"vm-first"}`)
+	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body1))
+	assert.Equal(t, originalBase, baseTags, "handleLaunch must not mutate the baseTags slice")
+
+	// Simulate a second /launch (e.g. resumed from snapshot with a new ID) to
+	// confirm each call produces an independent result.
+	body2 := strings.NewReader(`{"microVmId":"vm-second"}`)
+	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body2))
+
+	calls := setter.allCalls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, []string{"env:prod", "service:foo", lambdaMicroVMID + "vm-first"}, calls[0])
+	assert.Equal(t, []string{"env:prod", "service:foo", lambdaMicroVMID + "vm-second"}, calls[1])
+}
+
+// TestHandleLaunch_EmptyBaseTags_AppendsMicroVMIDOnly verifies that when the
+// server is started with no base tags, the resulting tag slice contains only
+// the microvm_id tag (not an empty leading element).
+func TestHandleLaunch_EmptyBaseTags_AppendsMicroVMIDOnly(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	setter := &mockLogsTagSetter{}
+	srv.SetLogsTagSetter(setter, nil)
+
+	body := strings.NewReader(`{"microVmId":"vm-solo"}`)
+	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+
+	require.Equal(t, 1, setter.callCount())
+	assert.Equal(t, []string{lambdaMicroVMID + "vm-solo"}, setter.lastCall())
+}
+
+// TestHandleLaunch_WithForwarder_UpdatesLogTags verifies that the log tag update
+// fires even when a user-app forwarder is configured. handleLaunch parses the
+// body and calls the setter before delegating to handleParallel.
+func TestHandleLaunch_WithForwarder_UpdatesLogTags(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	setter := &mockLogsTagSetter{}
+	srv.SetLogsTagSetter(setter, []string{"env:staging"})
+
+	body := strings.NewReader(`{"microVmId":"vm-fwd456"}`)
+	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+
+	require.Equal(t, 1, setter.callCount(), "SetLogsTags must be called even when forwarder is configured")
+	assert.Equal(t, []string{"env:staging", lambdaMicroVMID + "vm-fwd456"}, setter.lastCall())
 }

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"context"
+	"github.com/DataDog/datadog-agent/comp/logs-library/processor"
 	"os"
 	"strings"
 	"sync"
@@ -50,6 +51,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
+	serverlessLogs "github.com/DataDog/datadog-agent/pkg/serverless/logs"
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serverless/otlp"
 	serverlessTag "github.com/DataDog/datadog-agent/pkg/serverless/tags"
@@ -151,6 +153,10 @@ func setup(secretComp secrets.Component, delegatedAuthComp delegatedauth.Compone
 	origin := cloudService.GetOrigin()
 	// Note: we do not modify tags for the LogsAgent.
 	logsAgent := serverlessInitLog.SetupLogAgent(agentLogConfig, tagConfig.Tags, tagger, compression, hostname, origin)
+	// Snapshot the startup log tags so the lifecycle server can append lambda_microvm_id
+	// at /launch without losing the base set. Must be computed after SetupLogAgent
+	// since MapToArray normalises the same map that SetupLogAgent passes to SetLogsTags.
+	logTagsBase := serverlessTag.MapToArray(tagConfig.Tags)
 
 	// When no API key is configured, skip trace and metric agent initialization
 	// to avoid noisy error logs. The process wrapper and logs agent still function normally.
@@ -170,6 +176,11 @@ func setup(secretComp secrets.Component, delegatedAuthComp delegatedauth.Compone
 				SampleDrainer: metricAgent,
 				FlushTimeout:  agentLogConfig.FlushTimeout,
 				SidecarMode:   modeConf.SidecarMode,
+				LogsTagSetter: lifecycle.LogsTagSetterFunc(func(tags []string) {
+					serverlessLogs.SetLogsTags(tags)
+					processor.SetServerlessInitTagCache(tags)
+				}),
+				BaseTags: logTagsBase,
 			},
 		}
 		// Only MicroVM needs initialization without an API key: its Init starts the
@@ -202,6 +213,11 @@ func setup(secretComp secrets.Component, delegatedAuthComp delegatedauth.Compone
 			SampleDrainer: metricAgent,
 			FlushTimeout:  agentLogConfig.FlushTimeout,
 			SidecarMode:   modeConf.SidecarMode,
+			LogsTagSetter: lifecycle.LogsTagSetterFunc(func(tags []string) {
+				serverlessLogs.SetLogsTags(tags)
+				processor.SetServerlessInitTagCache(tags)
+			}),
+			BaseTags: logTagsBase,
 		},
 	}
 

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -146,6 +146,26 @@ func TestSetupWithoutAPIKey(t *testing.T) {
 	})
 }
 
+// TestLogTagsBaseComputedFromTagConfigTags verifies that the logTagsBase variable
+// computed in setup() — as serverlessTag.MapToArray(tagConfig.Tags) — contains all
+// tags configured via DD_TAGS. This documents the contract: BaseTags passed to
+// LifecycleContext must be the full startup tag slice so the lifecycle server can
+// append microvm_id to it without losing any base tags.
+func TestLogTagsBaseComputedFromTagConfigTags(t *testing.T) {
+	configmock.New(t)
+	modeConf = mode.DetectMode()
+	t.Setenv("DD_TAGS", "env:prod region:us-east-1")
+
+	cloudService := &cloudservice.LocalService{}
+	tagConfig := configureTags(cloudService)
+	logTagsBase := serverlessTag.MapToArray(tagConfig.Tags)
+
+	assert.Contains(t, logTagsBase, "env:prod",
+		"logTagsBase must include all DD_TAGS entries (used as BaseTags on the lifecycle server)")
+	assert.Contains(t, logTagsBase, "region:us-east-1")
+	assert.NotEmpty(t, logTagsBase)
+}
+
 // TestSetupOtlpAgentNoPanic ensures setupOtlpAgent does not panic when OTLP is enabled.
 func TestSetupOtlpAgentNoPanic(t *testing.T) {
 	t.Setenv("DD_OTLP_CONFIG_LOGS_ENABLED", "true")

--- a/comp/logs-library/processor/encoder_test.go
+++ b/comp/logs-library/processor/encoder_test.go
@@ -437,6 +437,264 @@ func TestPassthroughEncoder(t *testing.T) {
 	assert.Equal(t, "hello world", string(msg.GetContent()))
 }
 
+func TestJSONServerlessInitEncoder(t *testing.T) {
+	t.Cleanup(func() { SetServerlessInitTagCache(nil) }) // reset singleton cache after test
+
+	logsConfig := &config.LogsConfig{
+		Service: "my-service",
+		Source:  "my-source",
+	}
+	source := sources.NewLogSource("", logsConfig)
+
+	type payload struct {
+		Message   string `json:"message"`
+		Status    string `json:"status"`
+		Timestamp int64  `json:"timestamp"`
+		Hostname  string `json:"hostname"`
+		Service   string `json:"service,omitempty"`
+		Source    string `json:"ddsource"`
+		Tags      string `json:"ddtags"`
+	}
+
+	msg := newMessage([]byte("hello world"), source, message.StatusInfo)
+	msg.State = message.StateRendered
+	msg.Origin.LogSource = source
+	msg.Origin.SetTags([]string{"env:prod", "region:us-east-1"})
+
+	err := JSONServerlessInitEncoder.Encode(msg, "myhost")
+	assert.NoError(t, err)
+
+	var log payload
+	assert.NoError(t, json.Unmarshal(msg.GetContent(), &log))
+	assert.Equal(t, "hello world", log.Message)
+	assert.Equal(t, "myhost", log.Hostname)
+	assert.Equal(t, "my-service", log.Service)
+	assert.Equal(t, "my-source", log.Source)
+	assert.Equal(t, message.StatusInfo, log.Status)
+	assert.NotEmpty(t, log.Timestamp)
+	assert.Equal(t, "env:prod,region:us-east-1", log.Tags)
+}
+
+// TestJSONServerlessInitEncoder_CachesTagsOnFirstUse pins the cache behavior:
+// the second message's ddtags uses the cached string from the first message,
+// not its own (different) origin tags. This documents the intentional trade-off
+// between performance and the need for cache updates on tag changes.
+func TestJSONServerlessInitEncoder_CachesTagsOnFirstUse(t *testing.T) {
+	t.Cleanup(func() { SetServerlessInitTagCache(nil) })
+
+	source := sources.NewLogSource("", &config.LogsConfig{Source: "src"})
+
+	msg1 := newMessage([]byte("first"), source, message.StatusInfo)
+	msg1.State = message.StateRendered
+	msg1.Origin.LogSource = source
+	msg1.Origin.SetTags([]string{"env:prod"})
+	assert.NoError(t, JSONServerlessInitEncoder.Encode(msg1, "host"))
+
+	// Second message has different origin tags — without invalidation the
+	// encoder reuses the cached string from the first message.
+	msg2 := newMessage([]byte("second"), source, message.StatusInfo)
+	msg2.State = message.StateRendered
+	msg2.Origin.LogSource = source
+	msg2.Origin.SetTags([]string{"env:prod", "microvm_id:vm-abc"})
+	assert.NoError(t, JSONServerlessInitEncoder.Encode(msg2, "host"))
+
+	type payload struct {
+		Tags string `json:"ddtags"`
+	}
+	var p1, p2 payload
+	assert.NoError(t, json.Unmarshal(msg1.GetContent(), &p1))
+	assert.NoError(t, json.Unmarshal(msg2.GetContent(), &p2))
+
+	assert.Equal(t, "env:prod", p1.Tags)
+	// Cache was NOT invalidated — second message still carries the startup tags.
+	assert.Equal(t, "env:prod", p2.Tags,
+		"without invalidation, encoder reuses the first message's cached tags")
+}
+
+// TestSetServerlessInitTagCache_UpdatesTagsImmediately is the primary feature
+// test for the MicroVM /launch fix. It simulates the pre-launch → post-launch
+// tag transition:
+//
+//  1. Encode a pre-launch message — encoder caches the startup tags.
+//  2. Call SetServerlessInitTagCache with the new tags (what the /launch callback
+//     now does instead of clearing the cache).
+//  3. Encode a post-launch message — even one with old origin.tags — and assert
+//     that ddtags carries the new (correct) tag string.
+func TestSetServerlessInitTagCache_UpdatesTagsImmediately(t *testing.T) {
+	t.Cleanup(func() { SetServerlessInitTagCache(nil) })
+
+	source := sources.NewLogSource("", &config.LogsConfig{Source: "lambda-microvm"})
+
+	// Pre-launch: startup tags, no lambda_microvm_id.
+	preLaunch := newMessage([]byte("app started"), source, message.StatusInfo)
+	preLaunch.State = message.StateRendered
+	preLaunch.Origin.LogSource = source
+	preLaunch.Origin.SetTags([]string{"env:prod", "account_id:123"})
+	assert.NoError(t, JSONServerlessInitEncoder.Encode(preLaunch, "host"))
+
+	// /launch fires: SetLogsTags updates ChannelTags, then sets the cache to
+	// the new tag string (the fix: set instead of clear).
+	newTags := []string{"env:prod", "account_id:123", "lambda_microvm_id:vm-local"}
+	SetServerlessInitTagCache(newTags)
+
+	// Post-launch message whose origin.tags carries the new tags.
+	postLaunch := newMessage([]byte("launch hook called"), source, message.StatusInfo)
+	postLaunch.State = message.StateRendered
+	postLaunch.Origin.LogSource = source
+	postLaunch.Origin.SetTags(newTags)
+	assert.NoError(t, JSONServerlessInitEncoder.Encode(postLaunch, "host"))
+
+	type payload struct {
+		Tags string `json:"ddtags"`
+	}
+	var pre, post payload
+	assert.NoError(t, json.Unmarshal(preLaunch.GetContent(), &pre))
+	assert.NoError(t, json.Unmarshal(postLaunch.GetContent(), &post))
+
+	assert.Equal(t, "env:prod,account_id:123", pre.Tags,
+		"pre-launch entry must not carry lambda_microvm_id")
+	assert.Equal(t, "env:prod,account_id:123,lambda_microvm_id:vm-local", post.Tags,
+		"post-launch entry must carry lambda_microvm_id")
+}
+
+// TestSetServerlessInitTagCache_StalePreLaunchMessageCannotReprime is the
+// regression test for the race condition fixed by this change.
+//
+// Scenario: at /launch time, messages that the channel tailer already processed
+// (and tagged with pre-launch ChannelTags) are still in the processor pipeline.
+// With the old invalidation approach (clear to ""), the first of those stale
+// messages to reach the encoder re-primes the cache with old tags, causing
+// every subsequent log to lose lambda_microvm_id.
+//
+// With SetServerlessInitTagCache(newTags), the cache is already set to the
+// correct value before any stale message arrives, so they cannot overwrite it.
+func TestSetServerlessInitTagCache_StalePreLaunchMessageCannotReprime(t *testing.T) {
+	t.Cleanup(func() { SetServerlessInitTagCache(nil) })
+
+	source := sources.NewLogSource("", &config.LogsConfig{Source: "lambda-microvm"})
+
+	// Pre-launch: startup tags, no lambda_microvm_id.
+	preLaunch := newMessage([]byte("startup log"), source, message.StatusInfo)
+	preLaunch.State = message.StateRendered
+	preLaunch.Origin.LogSource = source
+	preLaunch.Origin.SetTags([]string{"env:prod", "account_id:123"})
+	assert.NoError(t, JSONServerlessInitEncoder.Encode(preLaunch, "host"))
+
+	// /launch fires: cache is set to the new tag string.
+	newTags := []string{"env:prod", "account_id:123", "lambda_microvm_id:vm-xyz"}
+	SetServerlessInitTagCache(newTags)
+
+	// A stale in-flight message that was already tagged by the tailer with the
+	// OLD ChannelTags (no lambda_microvm_id) reaches the encoder first.
+	stale := newMessage([]byte("stale pipeline message"), source, message.StatusInfo)
+	stale.State = message.StateRendered
+	stale.Origin.LogSource = source
+	stale.Origin.SetTags([]string{"env:prod", "account_id:123"}) // old tags, no microvm_id
+	assert.NoError(t, JSONServerlessInitEncoder.Encode(stale, "host"))
+
+	// A fresh post-launch message follows.
+	fresh := newMessage([]byte("user app log"), source, message.StatusInfo)
+	fresh.State = message.StateRendered
+	fresh.Origin.LogSource = source
+	fresh.Origin.SetTags(newTags)
+	assert.NoError(t, JSONServerlessInitEncoder.Encode(fresh, "host"))
+
+	type payload struct {
+		Tags string `json:"ddtags"`
+	}
+	var staleP, freshP payload
+	assert.NoError(t, json.Unmarshal(stale.GetContent(), &staleP))
+	assert.NoError(t, json.Unmarshal(fresh.GetContent(), &freshP))
+
+	// The stale message uses the already-set cache (new tags), not its own old origin.tags.
+	assert.Equal(t, "env:prod,account_id:123,lambda_microvm_id:vm-xyz", staleP.Tags,
+		"stale in-flight message must use the new cached tags, not re-prime with old ones")
+	assert.Equal(t, "env:prod,account_id:123,lambda_microvm_id:vm-xyz", freshP.Tags,
+		"fresh post-launch message must carry lambda_microvm_id")
+}
+
+// TestSetServerlessInitTagCache_NilResetsCache verifies that passing nil
+// (or an empty slice) resets the cache so the next Encode call re-reads
+// tags from the live message.
+func TestSetServerlessInitTagCache_NilResetsCache(t *testing.T) {
+	t.Cleanup(func() { SetServerlessInitTagCache(nil) })
+	assert.NotPanics(t, func() { SetServerlessInitTagCache(nil) })
+}
+
+// TestSetServerlessInitTagCache_IdempotentOnRepeat verifies that calling
+// SetServerlessInitTagCache multiple times with the same tags does not
+// corrupt state and the last call wins.
+func TestSetServerlessInitTagCache_IdempotentOnRepeat(t *testing.T) {
+	t.Cleanup(func() { SetServerlessInitTagCache(nil) })
+
+	source := sources.NewLogSource("", &config.LogsConfig{Source: "src"})
+	msg := newMessage([]byte("msg"), source, message.StatusInfo)
+	msg.State = message.StateRendered
+	msg.Origin.LogSource = source
+	msg.Origin.SetTags([]string{"k:v"})
+	assert.NoError(t, JSONServerlessInitEncoder.Encode(msg, "host"))
+
+	// Multiple successive calls with new tags — last call wins.
+	SetServerlessInitTagCache([]string{"k:v", "new:tag"})
+	SetServerlessInitTagCache([]string{"k:v", "new:tag"})
+
+	msg2 := newMessage([]byte("msg2"), source, message.StatusInfo)
+	msg2.State = message.StateRendered
+	msg2.Origin.LogSource = source
+	msg2.Origin.SetTags([]string{"k:v", "new:tag"})
+	assert.NoError(t, JSONServerlessInitEncoder.Encode(msg2, "host"))
+
+	type payload struct {
+		Tags string `json:"ddtags"`
+	}
+	var p payload
+	assert.NoError(t, json.Unmarshal(msg2.GetContent(), &p))
+	assert.Equal(t, "k:v,new:tag", p.Tags)
+}
+
+// TestJSONServerlessInitEncoder_ReturnsErrorForUnrenderedMessage verifies that
+// Encode rejects messages that have not yet been rendered. Only StateRendered
+// messages carry a final content representation; encoding earlier states would
+// silently emit incomplete data.
+func TestJSONServerlessInitEncoder_ReturnsErrorForUnrenderedMessage(t *testing.T) {
+	t.Cleanup(func() { SetServerlessInitTagCache(nil) })
+
+	source := sources.NewLogSource("", &config.LogsConfig{Source: "src"})
+	msg := newMessage([]byte("raw"), source, message.StatusInfo)
+	// msg.State is StateUnstructured by default — not rendered.
+
+	err := JSONServerlessInitEncoder.Encode(msg, "host")
+	assert.Error(t, err, "encoding an unrendered message must return an error")
+}
+
+// TestJSONServerlessInitEncoder_UsesServerlessTimestampWhenSet verifies that when
+// msg.ServerlessExtra.Timestamp is non-zero the encoder uses it instead of
+// time.Now(). This matters for forwarded log entries whose original timestamp
+// must be preserved.
+func TestJSONServerlessInitEncoder_UsesServerlessTimestampWhenSet(t *testing.T) {
+	t.Cleanup(func() { SetServerlessInitTagCache(nil) })
+
+	source := sources.NewLogSource("", &config.LogsConfig{Source: "src"})
+	msg := newMessage([]byte("timed"), source, message.StatusInfo)
+	msg.State = message.StateRendered
+	msg.Origin.LogSource = source
+	msg.Origin.SetTags([]string{"k:v"})
+
+	fixedTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	msg.ServerlessExtra.Timestamp = fixedTime
+
+	assert.NoError(t, JSONServerlessInitEncoder.Encode(msg, "host"))
+
+	type payload struct {
+		Timestamp int64 `json:"timestamp"`
+	}
+	var p payload
+	assert.NoError(t, json.Unmarshal(msg.GetContent(), &p))
+	// The encoder stores milliseconds (nanoToMillis = 1_000_000).
+	assert.Equal(t, fixedTime.UnixNano()/1_000_000, p.Timestamp,
+		"encoder must use ServerlessExtra.Timestamp, not time.Now()")
+}
+
 func BenchmarkJSONEncoder_Encode(b *testing.B) {
 	logsConfig := &config.LogsConfig{
 		Service:        "Service",

--- a/comp/logs-library/processor/json_serverless_init.go
+++ b/comp/logs-library/processor/json_serverless_init.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -20,8 +21,26 @@ var JSONServerlessInitEncoder Encoder = &jsonServerlessInitEncoder{}
 
 // jsonServerlessInitEncoder transforms a message into a JSON byte array.
 // It caches the tags string since tags are constant in serverless-init environments.
+// Call SetServerlessInitTagCache when tags change at runtime (e.g. after
+// a MicroVM /launch hook adds lambda_microvm_id).
 type jsonServerlessInitEncoder struct {
 	cachedTags string
+}
+
+// SetServerlessInitTagCache pre-populates the JSONServerlessInitEncoder's cache
+// with the provided tags. This must be called (instead of clearing the cache)
+// whenever the log tag set changes at runtime (e.g. after /launch appends
+// lambda_microvm_id). Setting the cache directly prevents in-flight pre-launch
+// messages — whose origin.tags were snapshotted before the update — from being
+// encoded first and re-priming the cache with stale tags.
+//
+// Pass nil or an empty slice to reset the cache (equivalent to the old
+// InvalidateServerlessInitTagCache behaviour; the next Encode call will
+// re-populate from the message).
+func SetServerlessInitTagCache(tags []string) {
+	if enc, ok := JSONServerlessInitEncoder.(*jsonServerlessInitEncoder); ok {
+		enc.cachedTags = strings.Join(tags, ",")
+	}
 }
 
 // JSON representation of a message for serverless-init.


### PR DESCRIPTION
## What does this PR do?

On \`/launch\`, the MicroVM platform delivers the instance's \`microVmId\` in the request body. This PR propagates that ID into the live log-pipeline tag slice so all subsequently forwarded log messages carry \`lambda_microvm_id:<id>\` — making them filterable by instance in the Datadog backend.

Before this change, only lifecycle metrics and heartbeat ticks received the per-instance tag; forwarded log entries had no way to be correlated to a specific MicroVM clone.

Changes:

- **\`lifecycle/server.go\`**: Add \`LogsTagSetter\` interface and \`LogsTagSetterFunc\` adapter. Add \`logsTagSetter\`/\`baseTags\` fields to \`Server\` and a \`SetLogsTagSetter\` wiring method. In \`handleLaunch\`, after capturing \`microVmId\`, call \`logsTagSetter.SetLogsTags(baseTags + lambda_microvm_id:<id>)\` (nil-safe; skipped when \`microVmId\` is absent). Rename tag-key constant to \`lambdaMicroVmId = "lambda_microvm_id:"\`.
- **\`cloudservice/microvm.go\`**: Add \`LogsTagSetter\` and \`BaseTags\` to \`LifecycleContext\`; wire them onto the server in \`Init\`.
- **\`main.go\`**: Snapshot \`logTagsBase\` from the resolved tag config after \`SetupLogAgent\` and pass a \`LogsTagSetterFunc\` closure — calling both \`serverlessLogs.SetLogsTags\` and \`processor.SetServerlessInitTagCache(tags)\` — into both \`LifecycleContext\` constructions (normal and no-API-key paths).
- **\`comp/logs-library/processor/json_serverless_init.go\`**: Replace \`InvalidateServerlessInitTagCache()\` with \`SetServerlessInitTagCache(tags []string)\`. Instead of clearing the cache (which allowed in-flight pre-launch messages to re-prime it with stale tags), the new function sets it to the correct new value immediately. Passing \`nil\` resets to \`""\` for test isolation.
- **Tests**: \`server_test.go\` covers \`SetLogsTagSetter\` wiring, the primary \`/launch\`→tag-update path, nil-setter safety, base-tag immutability, and the forwarder-path variant. \`encoder_test.go\` covers basic encoding, cache-pinning behavior, the pre→post-launch update sequence, nil-reset safety, and idempotent updates — plus a new regression test (\`TestSetServerlessInitTagCache_StalePreLaunchMessageCannotReprime\`) that directly reproduces the race: a stale in-flight message with old \`origin.tags\` arrives at the encoder first but cannot overwrite the already-set new cache.

Jira: [SVLS-9178](https://datadoghq.atlassian.net/browse/SVLS-9178)

## Motivation

Forwarded log messages lacked the \`lambda_microvm_id\` tag that lifecycle metrics and heartbeat ticks already carried, making it impossible to filter logs by instance in the Datadog backend. This is the final piece of per-instance observability for MicroVM.

### Race condition addressed

The original design called \`InvalidateServerlessInitTagCache()\` (clearing \`cachedTags\` to \`""\`) at \`/launch\` time. This created a window where pre-launch messages still in the processor pipeline — whose \`origin.tags\` were snapshotted by the channel tailer before the \`ChannelTags\` update — could be encoded first after the clear and re-prime the cache with stale tags (no \`lambda_microvm_id\`), causing all subsequent user logs to also miss the tag.

The fix: \`SetServerlessInitTagCache(tags)\` sets the cache to the correct new value atomically. Since \`cachedTags != ""\` after the call, stale messages hit the \`if j.cachedTags == ""` branch as false and use the new cached string instead of calling \`msg.TagsToString()\` on their stale origin.

## Describe how you validated your changes

- \`dda inv test --targets=./cmd/serverless-init/lifecycle/...\` — 120 tests pass
- \`dda inv test --targets=./comp/logs-library/processor/...\` — 40 tests pass (up from 24)
- Docker-based tests show the new tag \`lambda_microvm_id\` present in [the log](https://ddserverless.datadoghq.com/logs/livetail?query=lambda_microvm_id%3Avm-local&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=driveline&stream_sort=desc&viz=stream&from_ts=1779825238434&to_ts=1779825243565&live=false)
<img width="1209" height="844" alt="image" src="https://github.com/user-attachments/assets/170a5025-a896-4ebd-b87d-b153664daca8" />


## Additional Notes

- \`baseTags\` is captured as a snapshot at startup; \`handleLaunch\` builds a new slice each call via safe-append (\`append(append([]string{}, baseTags...), ...)\`) to avoid mutating the stored slice.
- \`SetServerlessInitTagCache\` uses a type assertion against the global \`JSONServerlessInitEncoder\` singleton and is a no-op if the encoder has been replaced — defensive by design.
- Pre-launch agent startup messages will now carry \`lambda_microvm_id\` (they use the new cached value). This is intentionally correct: all logs from a given MicroVM instance should be tagged with its ID.

[SVLS-9178]: https://datadoghq.atlassian.net/browse/SVLS-9178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
🔁 **Mirror of internal PR:** https://github.com/DataDog/datadog-agent-internal/pull/20