### PR TITLE
feat(serverless-init): tag outgoing traces on /launch

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -42,8 +42,10 @@ type LifecycleContext struct {
 	SampleDrainer lifecycle.SampleDrainer
 	FlushTimeout  time.Duration
 	SidecarMode   bool
-	LogsTagSetter lifecycle.LogsTagSetter // nil-safe; applied via server.SetLogsTagSetter after /launch
-	BaseTags      []string                // startup log tag snapshot passed alongside LogsTagSetter
+	LogsTagSetter  lifecycle.LogsTagSetter  // nil-safe; applied via server.SetLogsTagSetter after /launch
+	BaseTags       []string                 // startup log tag snapshot passed alongside LogsTagSetter
+	TraceTagSetter lifecycle.TraceTagSetter // nil-safe; applied via server.SetTraceTagSetter after /launch
+	BaseTraceTags  map[string]string        // startup trace tag snapshot passed alongside TraceTagSetter
 }
 
 // MicroVM implements CloudService for AWS Lambda MicroVMs.
@@ -146,6 +148,9 @@ func (m *MicroVM) Init(ctx *TracingContext) error {
 	)
 	if lc.LogsTagSetter != nil {
 		m.server.SetLogsTagSetter(lc.LogsTagSetter, lc.BaseTags)
+	}
+	if lc.TraceTagSetter != nil {
+		m.server.SetTraceTagSetter(lc.TraceTagSetter, lc.BaseTraceTags)
 	}
 	l, err := m.server.Listen()
 	if err != nil {

--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -168,6 +168,68 @@ func TestMicroVM_LogsTagSetter_InvokedOnLaunch(t *testing.T) {
 	assert.Contains(t, got, "lambda_microvm_id:vm-abc123", "microvm_id from /launch body must be appended to tags")
 }
 
+// TestLifecycleContext_NilTraceTagSetter_IsAccepted verifies that
+// LifecycleContext.TraceTagSetter is nil-safe: passing nil must not cause any
+// compile or runtime issue. Mirrors TestLifecycleContext_NilLogsTagSetter_IsAccepted.
+func TestLifecycleContext_NilTraceTagSetter_IsAccepted(t *testing.T) {
+	lc := &LifecycleContext{TraceTagSetter: nil, BaseTraceTags: nil}
+	assert.Nil(t, lc.TraceTagSetter, "nil TraceTagSetter must be accepted by LifecycleContext")
+}
+
+// TestMicroVM_TraceTagSetter_InvokedOnLaunch verifies the end-to-end wiring of
+// TraceTagSetter: MicroVM.Init passes it to the server, and the server calls it
+// on /launch with base trace tags extended by lambda_microvm_id from the body.
+//
+// Mirrors TestMicroVM_LogsTagSetter_InvokedOnLaunch.
+func TestMicroVM_TraceTagSetter_InvokedOnLaunch(t *testing.T) {
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+
+	var mu sync.Mutex
+	var receivedTags map[string]string
+	setter := lifecycle.TraceTagSetterFunc(func(tags map[string]string) {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedTags = tags
+	})
+	baseTraceTags := map[string]string{"env": "test", "service": "myapp"}
+
+	srv := lifecycle.NewServer(
+		0,
+		metricAgent, &noopTraceAgent{}, &noopLogsFlusher{},
+		metricAgent, metricAgent,
+		(&MicroVM{}).GetSource(),
+		time.Second,
+		lifecycle.NewNoopChildHandle(),
+		nil, // no forwarder
+		nil, // no heartbeat
+	)
+	// This is the call Init makes when lc.TraceTagSetter != nil.
+	srv.SetTraceTagSetter(setter, baseTraceTags)
+
+	l, err := srv.Listen()
+	require.NoError(t, err)
+	go srv.Serve(l)
+	t.Cleanup(func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Stop(shutCtx)
+	})
+
+	launchPath := "/aws/lambda-microvms/runtime/beta/v1/launch"
+	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
+	resp, err := http.Post("http://"+l.Addr().String()+launchPath, "application/json", body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	mu.Lock()
+	got := receivedTags
+	mu.Unlock()
+
+	assert.Equal(t, "test", got["env"], "base trace tags must be forwarded to TraceTagSetter on /launch")
+	assert.Equal(t, "myapp", got["service"], "base trace tags must be forwarded to TraceTagSetter on /launch")
+	assert.Equal(t, "vm-abc123", got["lambda_microvm_id"], "microvm_id from /launch body must appear in trace tags")
+}
+
 func TestMicroVMInit_NilTracingCtx_DoesNotStartServer(t *testing.T) {
 	m := &MicroVM{}
 	err := m.Init(nil)

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -44,6 +44,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"strconv"
@@ -71,7 +72,8 @@ const (
 	resumeMetricName    = "aws.lambda.microvm.enhanced.resume"
 	terminateMetricName = "aws.lambda.microvm.enhanced.terminate"
 
-	lambdaMicroVMID = "lambda_microvm_id:"
+	lambdaMicroVMIDKey = "lambda_microvm_id"      // for map[string]string trace tags: key only
+	lambdaMicroVMID    = lambdaMicroVMIDKey + ":" // for []string log/metric tags: key:value concatenated
 )
 
 // Flusher is satisfied by serverless.FlushableAgent.
@@ -110,6 +112,18 @@ type LogsTagSetterFunc func([]string)
 // SetLogsTags implements LogsTagSetter.
 func (f LogsTagSetterFunc) SetLogsTags(tags []string) { f(tags) }
 
+// TraceTagSetter can replace the full tag map on the live trace pipeline.
+// Satisfied by trace.ServerlessTraceAgent.SetTags (wrapped via TraceTagSetterFunc).
+type TraceTagSetter interface {
+	SetTraceTags(tags map[string]string)
+}
+
+// TraceTagSetterFunc wraps a bare function so it satisfies TraceTagSetter.
+type TraceTagSetterFunc func(map[string]string)
+
+// SetTraceTags implements TraceTagSetter.
+func (f TraceTagSetterFunc) SetTraceTags(tags map[string]string) { f(tags) }
+
 // launchBody is the JSON payload sent by the MicroVM platform on /launch.
 type launchBody struct {
 	MicroVMID string `json:"microVmId"`
@@ -131,8 +145,10 @@ type Server struct {
 	fwd         *Forwarder  // nil = no opt-in; today's behavior preserved
 	heartbeat   *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
 
-	logsTagSetter LogsTagSetter // nil-safe; set via SetLogsTagSetter after construction
-	baseTags      []string      // startup tag snapshot; lambda_microvm_id is appended at /launch
+	logsTagSetter  LogsTagSetter     // nil-safe; set via SetLogsTagSetter after construction
+	baseTags       []string          // startup tag snapshot; lambda_microvm_id is appended at /launch
+	traceTagSetter TraceTagSetter    // nil-safe; set via SetTraceTagSetter after construction
+	baseTraceTags  map[string]string // startup trace tag snapshot; lambda_microvm_id is added at /launch
 
 	httpServer *http.Server
 }
@@ -197,6 +213,14 @@ func NewServer(
 func (s *Server) SetLogsTagSetter(setter LogsTagSetter, baseTags []string) {
 	s.logsTagSetter = setter
 	s.baseTags = baseTags
+}
+
+// SetTraceTagSetter wires a TraceTagSetter and a baseline trace tag map into the
+// server. Must be called before the first /launch request. baseTraceTags is the
+// startup trace tag snapshot; lambda_microvm_id is added to it when /launch fires.
+func (s *Server) SetTraceTagSetter(setter TraceTagSetter, baseTraceTags map[string]string) {
+	s.traceTagSetter = setter
+	s.baseTraceTags = baseTraceTags
 }
 
 // Listen binds the TCP port synchronously. Call before Serve so the socket is
@@ -430,6 +454,11 @@ func (s *Server) handleLaunch(w http.ResponseWriter, r *http.Request) {
 		s.heartbeat.SetMicroVMID(body.MicroVMID)
 		if s.logsTagSetter != nil {
 			s.logsTagSetter.SetLogsTags(append(append([]string{}, s.baseTags...), lambdaMicroVMID+body.MicroVMID))
+		}
+		if s.traceTagSetter != nil {
+			tags := maps.Clone(s.baseTraceTags)
+			tags[lambdaMicroVMIDKey] = body.MicroVMID
+			s.traceTagSetter.SetTraceTags(tags)
 		}
 	} else {
 		log.Info("MicroVM lifecycle: launch")

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -1276,3 +1276,146 @@ func TestHandleLaunch_WithForwarder_UpdatesLogTags(t *testing.T) {
 	require.Equal(t, 1, setter.callCount(), "SetLogsTags must be called even when forwarder is configured")
 	assert.Equal(t, []string{"env:staging", lambdaMicroVMID + "vm-fwd456"}, setter.lastCall())
 }
+
+// ---------------------------------------------------------------------------
+// Trace tag setter tests
+// ---------------------------------------------------------------------------
+
+// mockTraceTagSetter records every SetTraceTags call for assertions.
+type mockTraceTagSetter struct {
+	mu    sync.Mutex
+	calls []map[string]string
+}
+
+func (m *mockTraceTagSetter) SetTraceTags(tags map[string]string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make(map[string]string, len(tags))
+	for k, v := range tags {
+		cp[k] = v
+	}
+	m.calls = append(m.calls, cp)
+}
+
+func (m *mockTraceTagSetter) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.calls)
+}
+
+func (m *mockTraceTagSetter) lastCall() map[string]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.calls) == 0 {
+		return nil
+	}
+	return m.calls[len(m.calls)-1]
+}
+
+// TestTraceTagSetterFunc_CallsWrappedFunction verifies that TraceTagSetterFunc
+// delegates to the underlying function when SetTraceTags is called.
+func TestTraceTagSetterFunc_CallsWrappedFunction(t *testing.T) {
+	var received map[string]string
+	fn := TraceTagSetterFunc(func(tags map[string]string) { received = tags })
+	fn.SetTraceTags(map[string]string{"env": "prod"})
+	assert.Equal(t, map[string]string{"env": "prod"}, received)
+}
+
+// TestSetTraceTagSetter_WiresFields verifies that SetTraceTagSetter stores both
+// the setter and the base trace tag snapshot on the server.
+func TestSetTraceTagSetter_WiresFields(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	setter := &mockTraceTagSetter{}
+	base := map[string]string{"env": "prod", "region": "us-east-1"}
+	srv.SetTraceTagSetter(setter, base)
+	assert.Equal(t, setter, srv.traceTagSetter)
+	assert.Equal(t, base, srv.baseTraceTags)
+}
+
+// TestHandleLaunch_UpdatesTraceTagsWithMicroVMID is the primary feature test:
+// /launch with a microVmId body calls SetTraceTags with baseTraceTags + lambda_microvm_id.
+func TestHandleLaunch_UpdatesTraceTagsWithMicroVMID(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	setter := &mockTraceTagSetter{}
+	srv.SetTraceTagSetter(setter, map[string]string{"env": "prod", "region": "us-east-1"})
+
+	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
+	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+
+	require.Equal(t, 1, setter.callCount(), "SetTraceTags must be called exactly once on /launch")
+	got := setter.lastCall()
+	assert.Equal(t, "vm-abc123", got["lambda_microvm_id"])
+	assert.Equal(t, "prod", got["env"])
+	assert.Equal(t, "us-east-1", got["region"])
+}
+
+// TestHandleLaunch_NoMicroVmID_DoesNotUpdateTraceTags verifies that when the
+// platform sends /launch with no microVmId, SetTraceTags is not called.
+func TestHandleLaunch_NoMicroVmID_DoesNotUpdateTraceTags(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	setter := &mockTraceTagSetter{}
+	srv.SetTraceTagSetter(setter, map[string]string{"env": "prod"})
+
+	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, nil))
+
+	assert.Equal(t, 0, setter.callCount(), "SetTraceTags must not be called when microVmId is absent")
+}
+
+// TestHandleLaunch_NilTraceTagSetter_DoesNotPanic verifies nil-safety: a server
+// constructed without SetTraceTagSetter must not panic when /launch fires.
+func TestHandleLaunch_NilTraceTagSetter_DoesNotPanic(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+
+	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
+	assert.NotPanics(t, func() {
+		srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+	})
+}
+
+// TestHandleLaunch_BaseTraceTagsNotMutated verifies the safe-copy contract: each
+// /launch call produces an independent map and does not modify baseTraceTags.
+func TestHandleLaunch_BaseTraceTagsNotMutated(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	setter := &mockTraceTagSetter{}
+	base := map[string]string{"env": "prod"}
+	srv.SetTraceTagSetter(setter, base)
+
+	body1 := strings.NewReader(`{"microVmId":"vm-first"}`)
+	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body1))
+
+	assert.Equal(t, map[string]string{"env": "prod"}, base, "handleLaunch must not mutate baseTraceTags")
+	assert.Equal(t, "vm-first", setter.lastCall()["lambda_microvm_id"])
+
+	// A second /launch (e.g. resume from snapshot with new ID) must produce an
+	// independent result without leaking the first ID into baseTraceTags.
+	body2 := strings.NewReader(`{"microVmId":"vm-second"}`)
+	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body2))
+
+	assert.Equal(t, map[string]string{"env": "prod"}, base, "baseTraceTags must still be unmodified after second /launch")
+	assert.Equal(t, "vm-second", setter.lastCall()["lambda_microvm_id"])
+}
+
+// TestHandleLaunch_WithForwarder_UpdatesTraceTags verifies that the trace tag
+// update fires even when a user-app forwarder is configured.
+func TestHandleLaunch_WithForwarder_UpdatesTraceTags(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	setter := &mockTraceTagSetter{}
+	srv.SetTraceTagSetter(setter, map[string]string{"env": "staging"})
+
+	body := strings.NewReader(`{"microVmId":"vm-fwd789"}`)
+	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+
+	require.Equal(t, 1, setter.callCount(), "SetTraceTags must be called even when forwarder is configured")
+	assert.Equal(t, "vm-fwd789", setter.lastCall()["lambda_microvm_id"])
+}

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -181,6 +181,10 @@ func setup(secretComp secrets.Component, delegatedAuthComp delegatedauth.Compone
 					processor.SetServerlessInitTagCache(tags)
 				}),
 				BaseTags: logTagsBase,
+				TraceTagSetter: lifecycle.TraceTagSetterFunc(func(tags map[string]string) {
+					traceAgent.SetTags(tags)
+				}),
+				BaseTraceTags: serverlessInitTag.MakeTraceAgentTags(tagConfig.Tags),
 			},
 		}
 		// Only MicroVM needs initialization without an API key: its Init starts the
@@ -218,6 +222,10 @@ func setup(secretComp secrets.Component, delegatedAuthComp delegatedauth.Compone
 				processor.SetServerlessInitTagCache(tags)
 			}),
 			BaseTags: logTagsBase,
+			TraceTagSetter: lifecycle.TraceTagSetterFunc(func(tags map[string]string) {
+				traceAgent.SetTags(tags)
+			}),
+			BaseTraceTags: serverlessInitTag.MakeTraceAgentTags(tagConfig.Tags),
 		},
 	}
 

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -166,6 +166,26 @@ func TestLogTagsBaseComputedFromTagConfigTags(t *testing.T) {
 	assert.NotEmpty(t, logTagsBase)
 }
 
+// TestBaseTraceTagsComputedFromTagConfigTags verifies that traceTags —
+// passed as BaseTraceTags to LifecycleContext — contains all tags from DD_TAGS
+// so that the lifecycle server can extend the map with lambda_microvm_id at /launch
+// without losing any startup tags.
+func TestBaseTraceTagsComputedFromTagConfigTags(t *testing.T) {
+	configmock.New(t)
+	modeConf = mode.DetectMode()
+	t.Setenv("DD_TAGS", "env:prod region:us-east-1")
+
+	cloudService := &cloudservice.LocalService{}
+	tagConfig := configureTags(cloudService)
+	baseTraceTags := serverlessInitTag.MakeTraceAgentTags(tagConfig.Tags)
+
+	assert.Equal(t, "prod", baseTraceTags["env"],
+		"BaseTraceTags must include all DD_TAGS entries (used as BaseTraceTags on the lifecycle server)")
+	assert.Equal(t, "us-east-1", baseTraceTags["region"])
+	assert.NotEmpty(t, baseTraceTags)
+}
+
+
 // TestSetupOtlpAgentNoPanic ensures setupOtlpAgent does not panic when OTLP is enabled.
 func TestSetupOtlpAgentNoPanic(t *testing.T) {
 	t.Setenv("DD_OTLP_CONFIG_LOGS_ENABLED", "true")


### PR DESCRIPTION
## What does this PR do?

On `/launch`, the MicroVM platform delivers the instance's `microVmId` in the request body. This PR propagates that ID into the live trace-pipeline tag map via `traceAgent.SetTags` so all subsequent outgoing spans carry `lambda_microvm_id:<id>` — making them filterable by instance in the Datadog backend.

Before this change, only lifecycle metrics, heartbeat ticks, and forwarded logs (added in the previous PR) carried the per-instance tag; traces had no way to be correlated to a specific MicroVM clone.

### Changes

**`lifecycle/server.go`**
- Add `TraceTagSetter` interface and `TraceTagSetterFunc` adapter (mirrors `LogsTagSetter`)
- Add `traceTagSetter`/`baseTraceTags` fields to `Server` and a `SetTraceTagSetter` wiring method
- In `handleLaunch`, after capturing `microVmId`, call `traceTagSetter.SetTraceTags(maps.Clone(baseTraceTags) + {"lambda_microvm_id": id})` (nil-safe; skipped when ID absent)
- Add `lambdaMicroVmIdKey = "lambda_microvm_id"` (no colon) for `map[string]string` trace tags; derive `lambdaMicroVmId` from it to keep both formats in sync

**`cloudservice/microvm.go`**
- Add `TraceTagSetter` and `BaseTraceTags` to `LifecycleContext`; wire them onto the server in `Init`
- Add `resource_type: "lambda_microvm"` and `resource_provider: "aws"` to `GetTags()` unconditionally
- Add `resource_id` tag: full ARN when available, `"unknown"` otherwise

**`main.go`**
- Pass `TraceTagSetterFunc(traceAgent.SetTags)` and `traceTags` as `BaseTraceTags` into `LifecycleContext`

**`cloudservice/microvm_test.go`**
- `parseMicroVMARN` edge-case coverage: empty string, short ARNs, missing fields
- `GetTags` coverage: `resource_id`, `resource_type`, `resource_provider` fields
- Simple accessor pins: `GetDefaultLogsSource`, `GetUsageMetricSuffix`, `GetSource`, `ShouldForceFlushAllOnForceFlushToSerializer`, `AddStartMetric`
- `GetEnhancedMetricTags`: origin key, clone independence, empty-tag fallback
- `TraceTagSetter` integration test: boots lifecycle server, fires `/launch`, asserts `SetTraceTags` wired correctly

Jira: [SVLS-9181](https://datadoghq.atlassian.net/browse/SVLS-9181)

## Motivation

Traces lacked the `lambda_microvm_id` tag that lifecycle metrics, heartbeat ticks, and forwarded logs already carried. This is the final piece: all three telemetry signals now carry the per-instance identifier.

The `resource_type`/`resource_provider`/`resource_id` tags follow the convention used by other cloud-service backends and enable downstream filtering by exact image version.

## Describe how you validated your changes

- `dda inv test --targets=./cmd/serverless-init/...` — 276 tests pass (4 skipped for platform/port constraints)
- [Docker-based test](https://ddserverless.datadoghq.com/apm/trace/6a18a8260000000058f10d9e40b5063a?graphType=flamegraph&shouldShowLegend=true&spanID=8036529467454192729&timeHint=1780000806923&traceQuery=) shows `lambda_microvm_id`, `resource_type`, `resource_id` and `resource_provider` present in trace tags

<img width="838" height="689" alt="image" src="https://github.com/user-attachments/assets/89f494c9-0df9-415a-abe6-062467c97655" />


[SVLS-9181]: https://datadoghq.atlassian.net/browse/SVLS-9181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
🔁 **Mirror of internal PR:** https://github.com/DataDog/datadog-agent-internal/pull/22
