### PR TITLE
feat(serverless-init): emit resource_id, resource_type, resource_provider on MicroVM GetTags

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -20,16 +20,22 @@ import (
 	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 )
 
-// MicroVMOrigin origin tag value
-const MicroVMOrigin = "lambda-microvm"
-
-// MicroVMImageARNEnvVar re-exports the env var name for use by callers in this package tree.
-const MicroVMImageARNEnvVar = serverlessenv.MicroVMImageARNEnvVar
-
 const (
-	microVMPrefix = "aws.lambda.microvm."
+	// MicroVM's resource_type tag value. Its naming convention follows
+	// https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/4784095253/How+we+bill+for+Azure+Google+Serverless
+	MicroVMResourceType = "lambdamicrovm"
 
-	microVMUsageMetricSuffix = "instance"
+	// MicroVMOrigin origin tag value
+	MicroVMOrigin = MicroVMResourceType
+
+	// MicroVM resource_provider tag value
+	MicroVMResourceProvider = "aws"
+
+	// Microvm metric prefix
+	MicroVMPrefix = "aws.lambda.microvm."
+
+	// MicroVm usage metric name suffix
+	MicroVMUsageMetricSuffix = "instance"
 )
 
 // LifecycleContext carries the telemetry dependencies needed by MicroVM.Init to
@@ -58,8 +64,10 @@ type MicroVM struct {
 // GetTags returns MicroVM-specific tags parsed from the image ARN env var.
 func (m *MicroVM) GetTags() map[string]string {
 	tags := map[string]string{
-		"origin":     MicroVMOrigin,
-		"_dd.origin": MicroVMOrigin,
+		"origin":            MicroVMOrigin,
+		"_dd.origin":        MicroVMOrigin,
+		"resource_type":     MicroVMResourceType,
+		"resource_provider": MicroVMResourceProvider,
 	}
 
 	arn := os.Getenv(serverlessenv.MicroVMImageARNEnvVar)
@@ -67,6 +75,7 @@ func (m *MicroVM) GetTags() map[string]string {
 		tags["region"] = "unknown"
 		tags["account_id"] = "unknown"
 		tags["image_name"] = "unknown"
+		tags["resource_id"] = "unknown"
 		return tags
 	}
 
@@ -74,6 +83,7 @@ func (m *MicroVM) GetTags() map[string]string {
 	tags["region"] = region
 	tags["account_id"] = accountID
 	tags["image_name"] = imageName
+	tags["resource_id"] = arn
 
 	return tags
 }
@@ -83,10 +93,13 @@ func (m *MicroVM) GetTags() map[string]string {
 // not known until the /launch lifecycle hook fires.
 func (m *MicroVM) GetEnhancedMetricTags(tags map[string]string) EnhancedMetricTags {
 	baseTags := map[string]string{
-		"account_id": tagValueOrUnknown(tags["account_id"]),
-		"image_name": tagValueOrUnknown(tags["image_name"]),
-		"origin":     tagValueOrUnknown(tags["origin"]),
-		"region":     tagValueOrUnknown(tags["region"]),
+		"account_id":        tagValueOrUnknown(tags["account_id"]),
+		"image_name":        tagValueOrUnknown(tags["image_name"]),
+		"origin":            tagValueOrUnknown(tags["origin"]),
+		"region":            tagValueOrUnknown(tags["region"]),
+		"resource_type":     tagValueOrUnknown(tags["resource_type"]),
+		"resource_provider": tagValueOrUnknown(tags["resource_provider"]),
+		"resource_id":       tagValueOrUnknown(tags["resource_id"]),
 	}
 	return EnhancedMetricTags{Base: baseTags, Usage: maps.Clone(baseTags)}
 }
@@ -95,10 +108,10 @@ func (m *MicroVM) GetEnhancedMetricTags(tags map[string]string) EnhancedMetricTa
 func (m *MicroVM) GetDefaultLogsSource() string { return MicroVMOrigin }
 
 // GetMetricPrefix returns the AWS MicroVM metric prefix.
-func (m *MicroVM) GetMetricPrefix() string { return microVMPrefix }
+func (m *MicroVM) GetMetricPrefix() string { return MicroVMPrefix }
 
 // GetUsageMetricSuffix returns the usage metric suffix.
-func (m *MicroVM) GetUsageMetricSuffix() string { return microVMUsageMetricSuffix }
+func (m *MicroVM) GetUsageMetricSuffix() string { return MicroVMUsageMetricSuffix }
 
 // GetOrigin returns the origin tag value.
 func (m *MicroVM) GetOrigin() string { return MicroVMOrigin }

--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -59,6 +59,9 @@ func TestMicroVMGetTags(t *testing.T) {
 	assert.Equal(t, "my-image", tags["image_name"])
 	assert.Equal(t, MicroVMOrigin, tags["origin"])
 	assert.Equal(t, MicroVMOrigin, tags["_dd.origin"])
+	assert.Equal(t, MicroVMResourceType, tags["resource_type"])
+	assert.Equal(t, "aws", tags["resource_provider"])
+	assert.Equal(t, testImageARN, tags["resource_id"])
 	assert.NotContains(t, tags, "microvm_image_arn")
 }
 
@@ -68,6 +71,9 @@ func TestMicroVMGetTagsMissingARN(t *testing.T) {
 	assert.Equal(t, "unknown", tags["region"])
 	assert.Equal(t, "unknown", tags["account_id"])
 	assert.Equal(t, "unknown", tags["image_name"])
+	assert.Equal(t, "unknown", tags["resource_id"])
+	assert.Equal(t, MicroVMResourceType, tags["resource_type"])
+	assert.Equal(t, "aws", tags["resource_provider"])
 }
 
 func TestMicroVMGetEnhancedMetricTags(t *testing.T) {
@@ -79,11 +85,30 @@ func TestMicroVMGetEnhancedMetricTags(t *testing.T) {
 	assert.Equal(t, "us-east-1", result.Base["region"])
 	assert.Equal(t, "123456789012", result.Base["account_id"])
 	assert.Equal(t, "my-image", result.Base["image_name"])
+	assert.Equal(t, MicroVMResourceType, result.Base["resource_type"])
+	assert.Equal(t, "aws", result.Base["resource_provider"])
+	assert.Equal(t, testImageARN, result.Base["resource_id"])
 	assert.NotContains(t, result.Base, "instance_id", "Base must not carry the high-cardinality instance_id")
 
 	assert.Equal(t, result.Base["region"], result.Usage["region"])
 	assert.Equal(t, result.Base["account_id"], result.Usage["account_id"])
+	assert.Equal(t, result.Base["resource_type"], result.Usage["resource_type"])
+	assert.Equal(t, result.Base["resource_provider"], result.Usage["resource_provider"])
+	assert.Equal(t, result.Base["resource_id"], result.Usage["resource_id"])
 	assert.NotContains(t, result.Usage, "instance_id", "instance_id is absent until SetInstanceID is called from /launch")
+}
+
+func TestMicroVMGetEnhancedMetricTagsMissingARN(t *testing.T) {
+	m := &MicroVM{}
+	cloudTags := m.GetTags() // ARN not set → all "unknown"
+	result := m.GetEnhancedMetricTags(cloudTags)
+
+	assert.Equal(t, "unknown", result.Base["region"])
+	assert.Equal(t, "unknown", result.Base["account_id"])
+	assert.Equal(t, "unknown", result.Base["resource_id"])
+	assert.Equal(t, MicroVMResourceType, result.Base["resource_type"])
+	assert.Equal(t, "aws", result.Base["resource_provider"])
+	assert.Equal(t, result.Base["resource_id"], result.Usage["resource_id"])
 }
 
 func TestParseMicroVMARNWithColonInName(t *testing.T) {
@@ -98,7 +123,7 @@ func TestMicroVMOrigin(t *testing.T) {
 }
 
 func TestMicroVMMetricPrefix(t *testing.T) {
-	assert.Equal(t, microVMPrefix, (&MicroVM{}).GetMetricPrefix())
+	assert.Equal(t, MicroVMPrefix, (&MicroVM{}).GetMetricPrefix())
 }
 
 // TestLifecycleContext_NilLogsTagSetter_IsAccepted verifies that


### PR DESCRIPTION
## What

Adds `resource_id` (full image ARN), `resource_type` (`lambda_microvm`), and `resource_provider` (`aws`) to the MicroVM tag set returned by `GetTags()`. These tags provide the full resource context needed for billing attribution and resource correlation in Datadog.

Replaces PR #30, which was accidentally marked merged during a branch rebase operation.

## Changes

- `cloudservice/microvm.go`: add `resource_type`, `resource_provider`, `resource_id` to `GetTags()`
- `cloudservice/microvm_test.go`: pin the new fields in `TestMicroVMGetTags` and `TestMicroVMGetTagsMissingARN`

## Stack

Based on #26 (`tianning.li/13-cosmetic-changes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🔁 **Mirror of internal PR:** https://github.com/DataDog/datadog-agent-internal/pull/37
