### PR TITLE
refactor(cloudservice): move arch check into MicroVM, out of GetCloudServiceType

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"maps"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -121,8 +122,17 @@ func (m *MicroVM) GetSource() metrics.MetricSource {
 	return metrics.MetricSourceAWSMicroVMEnhanced
 }
 
+// isSupportedArch reports whether arch is supported by MicroVM.
+// MicroVM supports both amd64 and arm64; all other cloud services are amd64-only.
+func isSupportedArch(arch string) bool {
+	return arch == archAMD64 || arch == archARM64
+}
+
 // Init starts the MicroVM lifecycle hook server.
 func (m *MicroVM) Init(ctx *TracingContext) error {
+	if arch := runtime.GOARCH; !isSupportedArch(arch) {
+		log.Fatalf(unsupportedArchMsg, arch)
+	}
 	if ctx == nil || ctx.LifecycleCtx == nil {
 		return nil
 	}

--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -382,3 +382,14 @@ func TestMicroVMInit_InitMode_ExposesChild(t *testing.T) {
 type noopLogsFlusher struct{}
 
 func (n *noopLogsFlusher) Flush(_ context.Context) {}
+
+// TestIsSupportedArch pins the MicroVM arch allowlist — lives here because
+// isSupportedArch is defined in microvm.go.
+func TestIsSupportedArch(t *testing.T) {
+	for _, arch := range []string{archAMD64, archARM64} {
+		assert.True(t, isSupportedArch(arch), "%s must be supported for MicroVM", arch)
+	}
+	for _, arch := range []string{"386", "mips", "mips64", "riscv64", "s390x", ""} {
+		assert.False(t, isSupportedArch(arch), "%s must be unsupported", arch)
+	}
+}

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -185,21 +185,13 @@ func (l *LocalService) ShouldForceFlushAllOnForceFlushToSerializer() bool {
 	return false
 }
 
-func isSupportedArch(arch string) bool {
-	return arch == archAMD64 || arch == archARM64
-}
-
 // GetCloudServiceType TODO: Refactor to avoid leaking individual service implementation details into the interface layer
 //
 //nolint:revive // TODO(SERV) Fix revive lin
 func GetCloudServiceType() CloudService {
 	arch := runtime.GOARCH
 
-	// MicroVM supports both amd64 and arm64; all other services are amd64-only.
 	if isMicroVM() {
-		if !isSupportedArch(arch) {
-			log.Errorf(unsupportedArchMsg, arch)
-		}
 		return &MicroVM{}
 	}
 

--- a/cmd/serverless-init/cloudservice/service_test.go
+++ b/cmd/serverless-init/cloudservice/service_test.go
@@ -14,24 +14,6 @@ import (
 	serverlessenv "github.com/DataDog/datadog-agent/pkg/serverless/env"
 )
 
-// TestIsSupportedArch pins the MicroVM arch allowlist: amd64 and arm64 must
-// return true; everything else must return false.
-func TestIsSupportedArch(t *testing.T) {
-	for _, arch := range []string{archAMD64, archARM64} {
-		assert.True(t, isSupportedArch(arch), "%s must be considered supported for MicroVM", arch)
-	}
-	for _, arch := range []string{"386", "mips", "mips64", "riscv64", "s390x", ""} {
-		assert.False(t, isSupportedArch(arch), "%s must be considered unsupported", arch)
-	}
-}
-
-// TestGetCloudServiceType_MicroVM_AllowsArm64 verifies that MicroVM is returned
-// on arm64 without triggering the unsupported-arch error path.
-func TestGetCloudServiceType_MicroVM_AllowsArm64(t *testing.T) {
-	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, testImageARN)
-	assert.Equal(t, MicroVMOrigin, GetCloudServiceType().GetOrigin())
-}
-
 func TestGetCloudServiceType(t *testing.T) {
 	assert.Equal(t, "local", GetCloudServiceType().GetOrigin())
 


### PR DESCRIPTION
## Summary
This PR is to track the followup changes of https://github.com/DataDog/datadog-agent-internal/pull/1

- Moves `isSupportedArch` and the arm64 arch check out of the generic `GetCloudServiceType` into `MicroVM.Init`, where it belongs — arm64 support is MicroVM-specific and has no meaning for Lambda, Cloud Run, Azure Container Apps, or App Service
- `GetCloudServiceType` becomes fully generic; the MicroVM block is now a simple `return &MicroVM{}`
- Changes `log.Printf` → `log.Fatalf` for the unsupported-arch path so a misconfigured deployment fails loudly rather than continuing silently

Addresses apiarian-datadog review comment on https://github.com/DataDog/datadog-agent-internal/pull/1

## Test plan

- [x] `TestIsSupportedArch` moved from `service_test.go` to `microvm_test.go` to follow the function
- [x] `TestGetCloudServiceType_MicroVM_AllowsArm64` removed — it was covering the arch check in `GetCloudServiceType` which no longer exists there; `TestIsMicroVM` in `microvm_test.go` covers the detection logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🔁 **Mirror of internal PR:** https://github.com/DataDog/datadog-agent-internal/pull/25
