### PR TITLE
fix(serverless-init): restrict lifecycle hook routes to POST method

### DIFF
--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -68,6 +68,13 @@ const (
 	pathResume    = basePath + "resume"
 	pathTerminate = basePath + "terminate"
 
+	postReady     = "POST " + pathReady
+	postValidate  = "POST " + pathValidate
+	postLaunch    = "POST " + pathLaunch
+	postSuspend   = "POST " + pathSuspend
+	postResume    = "POST " + pathResume
+	postTerminate = "POST " + pathTerminate
+
 	// flushWorkerCount is the number of goroutines launched by flushAll:
 	// one each for the metric, trace, and logs flushers.
 	flushWorkerCount = 3
@@ -276,12 +283,12 @@ func (s *Server) Heartbeat() *Heartbeat { return s.heartbeat }
 
 func (s *Server) handler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc(pathReady, s.handleReady)
-	mux.HandleFunc(pathValidate, s.handleValidate)
-	mux.HandleFunc(pathLaunch, s.handleLaunch)
-	mux.HandleFunc(pathSuspend, s.handleSuspend)
-	mux.HandleFunc(pathResume, s.handleResume)
-	mux.HandleFunc(pathTerminate, s.handleTerminate)
+	mux.HandleFunc(postReady, s.handleReady)
+	mux.HandleFunc(postValidate, s.handleValidate)
+	mux.HandleFunc(postLaunch, s.handleLaunch)
+	mux.HandleFunc(postSuspend, s.handleSuspend)
+	mux.HandleFunc(postResume, s.handleResume)
+	mux.HandleFunc(postTerminate, s.handleTerminate)
 	return mux
 }
 

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -334,6 +334,21 @@ func TestRoutes(t *testing.T) {
 	}
 }
 
+// TestRoutes_NonPost_Returns405 verifies that the mux rejects non-POST requests
+// with 405 Method Not Allowed. All lifecycle hooks are POST-only; the platform
+// never sends GET/PUT/DELETE to these paths.
+func TestRoutes_NonPost_Returns405(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	handler := srv.handler()
+	routes := []string{pathReady, pathValidate, pathLaunch, pathSuspend, pathResume, pathTerminate}
+	for _, route := range routes {
+		req := httptest.NewRequest(http.MethodGet, route, nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusMethodNotAllowed, rec.Code, "route %s must reject GET with 405", route)
+	}
+}
+
 // fakeChildHandle drives /ready behavior in tests.
 type fakeChildHandle struct {
 	alive atomic.Bool


### PR DESCRIPTION
## Summary

- Registers all MicroVM lifecycle hook paths with \`"POST "\` prefix so \`ServeMux\` returns \`405 Method Not Allowed\` for non-POST requests (previously accepted any HTTP method)
- Introduces named \`post*\` constants (\`postReady\`, \`postLaunch\`, etc.) following the existing \`path*\` constant pattern — no runtime string concatenation
- Removes MicroVM-specific inline comments from \`main.go\` per reviewer feedback ("no need to include this commentary here")
- Adds \`TestRoutes_NonPost_Returns405\` to pin the 405 contract

Addresses reviewer feedback on PR #2.

## Test plan

- [x] \`TestRoutes\` (existing) — POST requests to all routes still return 200
- [x] \`TestRoutes_NonPost_Returns405\` (new) — GET requests to all routes return 405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🔁 **Mirror of internal PR:** https://github.com/DataDog/datadog-agent-internal/pull/27
