### PR TITLE
refactor(serverless-init): rename env var prefix DD_SERVERLESS_MICROVM → DD_AWS_MICROVM

### DIFF
--- a/cmd/serverless-init/lifecycle/config.go
+++ b/cmd/serverless-init/lifecycle/config.go
@@ -12,19 +12,19 @@ import (
 )
 
 // UserAppPortEnvVar opts in to forwarding lifecycle hooks to the user app.
-const UserAppPortEnvVar = "DD_SERVERLESS_MICROVM_USER_APP_PORT"
+const UserAppPortEnvVar = "DD_AWS_MICROVM_USER_APP_PORT"
 
 // LifecyclePortEnvVar overrides the port the lifecycle hook server listens on (default 9000).
-const LifecyclePortEnvVar = "DD_SERVERLESS_MICROVM_LIFECYCLE_PORT"
+const LifecyclePortEnvVar = "DD_AWS_MICROVM_LIFECYCLE_PORT"
 
 // ForwardTimeoutMsEnvVar overrides the timeout (ms) for /launch, /resume, /suspend, /terminate.
-const ForwardTimeoutMsEnvVar = "DD_SERVERLESS_MICROVM_FORWARD_TIMEOUT_MS"
+const ForwardTimeoutMsEnvVar = "DD_AWS_MICROVM_FORWARD_TIMEOUT_MS"
 
 // ReadyTimeoutMsEnvVar overrides the timeout (ms) for /ready.
-const ReadyTimeoutMsEnvVar = "DD_SERVERLESS_MICROVM_READY_TIMEOUT_MS"
+const ReadyTimeoutMsEnvVar = "DD_AWS_MICROVM_READY_TIMEOUT_MS"
 
 // ValidateTimeoutMsEnvVar overrides the timeout (ms) for /validate.
-const ValidateTimeoutMsEnvVar = "DD_SERVERLESS_MICROVM_VALIDATE_TIMEOUT_MS"
+const ValidateTimeoutMsEnvVar = "DD_AWS_MICROVM_VALIDATE_TIMEOUT_MS"
 
 // parsePort parses a port number from a raw env-var string.
 // Returns defaultVal when raw is empty. Parsed port must not equal any value in forbidden.

--- a/cmd/serverless-init/lifecycle/forwarder.go
+++ b/cmd/serverless-init/lifecycle/forwarder.go
@@ -25,7 +25,7 @@ import (
 const defaultMaxResponseBodyBytes int64 = 1 << 20
 
 // Forwarder POSTs lifecycle hooks to the user app. It is constructed only
-// when DD_SERVERLESS_MICROVM_USER_APP_PORT is set and we're in init-container
+// when DD_AWS_MICROVM_USER_APP_PORT is set and we're in init-container
 // mode + MicroVM origin.
 type Forwarder struct {
 	target               string        // e.g. "http://127.0.0.1:8080"
@@ -39,7 +39,7 @@ type Forwarder struct {
 // NewForwarder constructs a Forwarder targeting 127.0.0.1:<port>. The forwardTimeout
 // is used for /launch, /resume, /suspend, and /terminate; readyTimeout for /ready;
 // validateTimeout for /validate. Callers should pass the wire.go default constants
-// or values parsed from the DD_SERVERLESS_MICROVM_*_TIMEOUT_MS env vars.
+// or values parsed from the DD_AWS_MICROVM_*_TIMEOUT_MS env vars.
 func NewForwarder(port int, forwardTimeout, readyTimeout, validateTimeout time.Duration) *Forwarder {
 	return &Forwarder{
 		target: fmt.Sprintf("http://127.0.0.1:%d", port),

--- a/cmd/serverless-init/lifecycle/heartbeat.go
+++ b/cmd/serverless-init/lifecycle/heartbeat.go
@@ -17,7 +17,7 @@ import (
 
 // DefaultHeartbeatInterval is the period between heartbeat metrics. The
 // interval is hardcoded for now; if the platform team needs to tune it,
-// promote to a config value (see DD_SERVERLESS_MICROVM_* convention used by
+// promote to a config value (see DD_AWS_MICROVM_* convention used by
 // the forwarder port env var).
 const DefaultHeartbeatInterval = 5 * time.Minute
 


### PR DESCRIPTION
## Summary

- Renames all five lifecycle env var constants from `DD_SERVERLESS_MICROVM_*` to `DD_AWS_MICROVM_*` in `config.go`
- Updates comment references in `forwarder.go` and `heartbeat.go`

The old prefix was inherited from the generic serverless-init context. `DD_AWS_MICROVM_*` is precise: it scopes these variables to the AWS Firecracker MicroVM deployment specifically, disambiguating from other cloud service modes.

## Test plan

- [ ] Existing unit tests pass (`dda inv test --targets=./cmd/serverless-init/lifecycle/`)
- [ ] Update any deployment configs / Dockerfiles using the old env var names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🔁 **Mirror of internal PR:** https://github.com/DataDog/datadog-agent-internal/pull/35
