### PR TITLE
fix(e2e/windows): Retry installers_v2.json fetch to handle S3/network flakes

### DIFF
--- a/test/new-e2e/tests/windows/common/agent/installers/v2/BUILD.bazel
+++ b/test/new-e2e/tests/windows/common/agent/installers/v2/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["installers.go"],
     importpath = "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent/installers/v2",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_cenkalti_backoff_v6//:backoff"],
 )

--- a/test/new-e2e/tests/windows/common/agent/installers/v2/installers.go
+++ b/test/new-e2e/tests/windows/common/agent/installers/v2/installers.go
@@ -7,11 +7,14 @@
 package installers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/cenkalti/backoff/v5"
 )
 
 // Arch is the architecture-specific URL for an installer
@@ -59,6 +62,9 @@ func readURL(url string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, url)
+	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
@@ -66,21 +72,21 @@ func readURL(url string) ([]byte, error) {
 	return body, nil
 }
 
-// ListVersions returns a list of available product versions from a installers_v2.json URL
+// ListVersions returns a list of available product versions from a installers_v2.json URL.
+// It retries on network errors, non-2xx responses, and JSON parse failures (e.g. truncated body).
 func ListVersions(url string) (*Installers, error) {
-	body, err := readURL(url)
-	if err != nil {
-		return nil, err
-	}
-
-	var installers Installers
-	installers.URL = url
-	err = json.Unmarshal(body, &installers)
-	if err != nil {
-		return nil, err
-	}
-
-	return &installers, nil
+	return backoff.Retry(context.Background(), func() (*Installers, error) {
+		body, err := readURL(url)
+		if err != nil {
+			return nil, err
+		}
+		var installers Installers
+		installers.URL = url
+		if err := json.Unmarshal(body, &installers); err != nil {
+			return nil, err
+		}
+		return &installers, nil
+	}, backoff.WithBackOff(backoff.NewExponentialBackOff()), backoff.WithMaxTries(3))
 }
 
 // GetProductURL returns the URL for a product/version/arch pair from a installers_v2.json URL.

--- a/test/new-e2e/tests/windows/common/agent/installers/v2/installers.go
+++ b/test/new-e2e/tests/windows/common/agent/installers/v2/installers.go
@@ -14,7 +14,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/cenkalti/backoff/v5"
+	"github.com/cenkalti/backoff/v6"
 )
 
 // Arch is the architecture-specific URL for an installer


### PR DESCRIPTION
### What does this PR do?

Wraps the `installers_v2.json` HTTP fetch and JSON parse in a single exponential-backoff retry loop (up to 3 attempts) in `test/new-e2e/tests/windows/common/agent/installers/v2/installers.go`.

Also checks `HTTP 200 OK` before reading the response body, so a non-2xx response is surfaced as an error immediately rather than being parsed as JSON.

### Motivation

E2E tests were intermittently failing with `unexpected end of JSON input` when downloading `installers_v2.json` from S3. Transient network errors or truncated responses caused a hard failure with no retry. Since this is test infrastructure fetching a small metadata file, retrying is safe and cheap.

Tracked in [WINA-2831](https://datadoghq.atlassian.net/browse/WINA-2831).

### Describe how you validated your changes

Existing E2E tests exercise this path on every run.

[WINA-2831]: https://datadoghq.atlassian.net/browse/WINA-2831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ