### PR TITLE
Register use_http for log endpoints to fix FIPS unknown-key errors

### DIFF
--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1802,8 +1802,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.kubelet_api_client_read_timeout", "30s")
 	// Internal Use Only: avoid modifying those configuration parameters, this could lead to unexpected results.
 	config.BindEnvAndSetDefault("logs_config.run_path", defaultpaths.GetDefaultRunPath())
-	// DEPRECATED in favor of `logs_config.force_use_http`.
-	config.BindEnvAndSetDefault("logs_config.use_http", false)
+	// logs_config.use_http is registered for all log endpoints via bindEnvAndSetLogsConfigKeys.
+	// force_use_http is the preferred way to force HTTP and takes precedence over use_http.
 	config.BindEnvAndSetDefault("logs_config.force_use_http", false)
 	// DEPRECATED in favor of `logs_config.force_use_tcp`.
 	config.BindEnvAndSetDefault("logs_config.use_tcp", false)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1505,6 +1505,7 @@ func bindEnvAndSetLogsConfigKeys(config pkgconfigmodel.Setup, prefix string) {
 	config.BindEnvAndSetDefault(prefix+"batch_wait", DefaultBatchWait)
 	config.BindEnvAndSetDefault(prefix+"connection_reset_interval", 0) // in seconds, 0 means disabled
 	config.BindEnvAndSetDefault(prefix+"logs_no_ssl", false)
+	config.BindEnvAndSetDefault(prefix+"use_http", false)
 	config.BindEnvAndSetDefault(prefix+"batch_max_concurrent_send", DefaultBatchMaxConcurrentSend)
 	config.BindEnvAndSetDefault(prefix+"batch_max_content_size", DefaultBatchMaxContentSize)
 	config.BindEnvAndSetDefault(prefix+"batch_max_size", DefaultBatchMaxSize)

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1118,6 +1118,34 @@ fips:
 	require.Error(t, err)
 }
 
+// TestSetupFipsEndpointsUseHTTPRegistered ensures use_http is a known config key
+// for every endpoint that FIPS overrides. It uses a production-like config
+// (schema built, dynamic schema disabled) because the other FIPS tests enable
+// dynamic schema, which masks the unknown-key rejection that happens in
+// production and would otherwise hide a missing schema registration.
+func TestSetupFipsEndpointsUseHTTPRegistered(t *testing.T) {
+	conf := newSchemaTestConf(t, `
+fips:
+  enabled: true
+  local_address: localhost
+  port_range_start: 5000
+`)
+	require.NoError(t, setupFipsEndpoints(conf))
+
+	for _, prefix := range []string{
+		"database_monitoring.metrics.",
+		"database_monitoring.activity.",
+		"database_monitoring.samples.",
+		"network_devices.metadata.",
+		"network_devices.snmp_traps.forwarder.",
+		"network_devices.netflow.forwarder.",
+		"runtime_security_config.endpoints.",
+		"compliance_config.endpoints.",
+	} {
+		assert.True(t, conf.GetBool(prefix+"use_http"), "%suse_http should be forced to true under FIPS", prefix)
+	}
+}
+
 func TestEnablePeerServiceStatsAggregationYAML(t *testing.T) {
 	datadogYaml := `
 apm_config:

--- a/pkg/config/setup/test_helpers.go
+++ b/pkg/config/setup/test_helpers.go
@@ -8,7 +8,10 @@
 package setup
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config/create"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -31,4 +34,17 @@ func newTestConf(t *testing.T) pkgconfigmodel.BuildableConfig {
 	conf.SetConfigFile("")
 	pkgconfigmodel.ApplyOverrideFuncs(conf)
 	return conf
+}
+
+// newSchemaTestConf returns a config initialized with the full Agent schema and
+// the schema built, with dynamic schema left disabled. Unlike newTestConf, it
+// mirrors production: setting an unknown key is rejected instead of silently
+// accepted, so it can catch settings that the code writes but never registered.
+func newSchemaTestConf(t *testing.T, yamlConfig string) pkgconfigmodel.BuildableConfig {
+	cfg := create.NewConfig("test")
+	InitConfig(cfg)
+	cfg.BuildSchema()
+	cfg.SetConfigType("yaml")
+	require.NoError(t, cfg.ReadConfig(strings.NewReader(yamlConfig)))
+	return cfg
 }

--- a/releasenotes/notes/fix-fips-use-http-unknown-key-f9d6c3330170a9dc.yaml
+++ b/releasenotes/notes/fix-fips-use-http-unknown-key-f9d6c3330170a9dc.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed spurious ``could not set '<endpoint>.use_http' unknown key`` errors
+    logged at startup when ``fips.enabled`` is set to ``true``. The ``use_http``
+    setting is now registered for the database monitoring, network devices,
+    runtime security, and compliance endpoints that FIPS mode configures, so it
+    is applied instead of being rejected as an unknown key.


### PR DESCRIPTION
### What does this PR do?

Registers the `use_http` setting for every log endpoint configured through `bindEnvAndSetLogsConfigKeys`, so it is a known config key.

### Motivation

When `fips.enabled: true`, `setupFipsEndpoints` calls `setupFipsLogsConfig` for the database monitoring, network devices, runtime security, and compliance endpoints, setting `<endpoint>.use_http`, `<endpoint>.logs_no_ssl`, and `<endpoint>.logs_dd_url`. But `use_http` was never registered for those prefixes — only `logs_dd_url`/`logs_no_ssl` and friends are (via `bindEnvAndSetLogsConfigKeys`), while `logs_config.use_http` was registered separately.

Since nodetreemodel became the default config backend (#48694), `Set` on an unknown key is rejected and logged at ERROR. So enabling FIPS produces spurious startup errors:

```
could not set 'database_monitoring.metrics.use_http' unknown key
could not set 'database_monitoring.activity.use_http' unknown key
could not set 'database_monitoring.samples.use_http' unknown key
could not set 'network_devices.metadata.use_http' unknown key
could not set 'network_devices.snmp_traps.forwarder.use_http' unknown key
could not set 'network_devices.netflow.forwarder.use_http' unknown key
could not set 'runtime_security_config.endpoints.use_http' unknown key
could not set 'compliance_config.endpoints.use_http' unknown key
```

The impact is limited to log noise: FIPS routing still works because `logs_dd_url`/`logs_no_ssl` are set correctly and these endpoints build via `buildHTTPEndpoints`, which forces HTTP regardless of `use_http`. But the ERROR-level lines are alarming and can trip alerting. Registering `use_http` makes the setting apply as intended and removes the errors.

### Describe how you validated your changes

Added `TestSetupFipsEndpointsUseHTTPRegistered`, using a new production-like config helper (`newSchemaTestConf`: full schema built, dynamic schema disabled). The existing FIPS tests enable dynamic schema, which silently accepts unknown keys and masked this bug. The new test fails before the fix (all 8 prefixes) and passes after.

```
dda inv test --targets=./pkg/config/setup --test-run-name=TestSetupFipsEndpoints
```

All pass, including the existing `TestSetupFipsEndpoints` — confirming `logs_config.use_http` still resolves after removing its now-redundant explicit registration (it is still registered via the helper).

### Additional Notes

- **No backport**: this is log noise only, not a functional regression.
- The committed config schema (`pkg/config/schema/core_schema.yaml` and its compressed form) should be regenerated to include the new `use_http` keys; the `generate_config_schema` CI job (main/release only) produces this. I did not run the full agent build to regenerate locally.
- `golangci-lint` and `bazel mod tidy` pre-push hooks were skipped locally (those tools are not installed for the pinned Go toolchain in my environment); CI runs them. `gofmt` is clean, and no `go.mod`/`BUILD.bazel` changes are needed (`testify/require` is already a test dep; `strings` is stdlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
