### PR TITLE
Filter logon-duration AutoLogger to the ETW data it consumes

### DIFF
--- a/test/new-e2e/tests/windows/install-test/autologger_test.go
+++ b/test/new-e2e/tests/windows/install-test/autologger_test.go
@@ -8,6 +8,7 @@ package installtest
 import (
 	"io/fs"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -73,6 +74,33 @@ func (s *testInstallWithAutologgerSuite) TestInstallWithAutologger() {
 			)
 			windows.AssertContainsEqualable(s.T(), out.Access, agentUserRule,
 				"%s should have access rule for %s", autologgerPath, ddAgentUserIdentity)
+		}
+	})
+
+	s.Run("autologger providers are filtered (EnableLevel=4 + MatchAnyKeyword)", func() {
+		// Provider GUID -> MatchAnyKeyword mask. Must mirror ProviderKeywords in
+		// tools/windows/DatadogAgentInstaller/CustomActions/AutoLoggerCustomAction.cs.
+		// Pins the exact filter so an accidental change to the installer is caught here.
+		expected := map[string]uint64{
+			"{22FB2CD6-0E7B-422B-A0C7-2FAD1FD0E716}": 0x10,               // Kernel-Process
+			"{A68CA8B7-004F-D7B6-A698-07E2DE0F1F5D}": 0x80,               // Kernel-General
+			"{DBE9B383-7CF3-4331-91CC-A3CB16A3B538}": 0x200000030000,     // Winlogon
+			"{89B1E9F0-5AFF-44A6-9B44-0A07A7CE5845}": 0x6001000000000000, // User Profiles Service
+			"{AEA1B4FA-97D1-45F2-A64C-4D69FFFD92C9}": 0x4000000000000000, // GroupPolicy
+			"{30336ED4-E327-447C-9DE0-51B652C86108}": 0x4010000,          // Shell-Core
+		}
+		for guid, kw := range expected {
+			providerPath := autologgerPath + `\` + guid
+
+			lvl, err := windows.GetRegistryValue(vm, providerPath, "EnableLevel")
+			require.NoError(s.T(), err)
+			assert.Equal(s.T(), "4", lvl,
+				"provider %s should be enabled at Informational level (4), not Verbose", guid)
+
+			mask, err := windows.GetRegistryValue(vm, providerPath, "MatchAnyKeyword")
+			require.NoError(s.T(), err)
+			assert.Equal(s.T(), strconv.FormatUint(kw, 10), mask,
+				"provider %s MatchAnyKeyword should match the analyzer's consumed keywords", guid)
 		}
 	})
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions/AutoLoggerCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/AutoLoggerCustomAction.cs
@@ -4,6 +4,7 @@ using Datadog.CustomActions.Rollback;
 using Microsoft.Win32;
 using WixToolset.Dtf.WindowsInstaller;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Security.AccessControl;
 using System.Security.Principal;
@@ -20,14 +21,29 @@ namespace Datadog.CustomActions
         private static readonly string SessionKeyPath = $@"{AutoLoggerBasePath}\{SessionName}";
         private const string RollbackDataName = "ConfigureAutoLogger";
 
-        private static readonly string[] ProviderGuids =
+        // Provider GUID -> MatchAnyKeyword mask. The session is enabled at EnableLevel=4
+        // (Informational), and each mask is the OR of the keyword bits carried by the event
+        // IDs that comp/logonduration/impl/analyzer.go actually consumes. The masks were read
+        // from each provider's manifest (Get-WinEvent -ListProvider); every consumed event ID
+        // is emitted at Level 4, so filtering this way is loss-less for the phases we report
+        // while dropping the verbose, all-keyword firehose we never read.
+        private static readonly Dictionary<string, long> ProviderKeywords = new Dictionary<string, long>
         {
-            "{22FB2CD6-0E7B-422B-A0C7-2FAD1FD0E716}", // Microsoft-Windows-Kernel-Process
-            "{A68CA8B7-004F-D7B6-A698-07E2DE0F1F5D}", // Microsoft-Windows-Kernel-General
-            "{DBE9B383-7CF3-4331-91CC-A3CB16A3B538}", // Microsoft-Windows-Winlogon
-            "{89B1E9F0-5AFF-44A6-9B44-0A07A7CE5845}", // Microsoft-Windows-User Profiles Service
-            "{AEA1B4FA-97D1-45F2-A64C-4D69FFFD92C9}", // Microsoft-Windows-GroupPolicy
-            "{30336ED4-E327-447C-9DE0-51B652C86108}"   // Microsoft-Windows-Shell-Core
+            // Kernel-Process: WINEVENT_KEYWORD_PROCESS -> process start (evt 1).
+            { "{22FB2CD6-0E7B-422B-A0C7-2FAD1FD0E716}", 0x10L },
+            // Kernel-General: BootPerformance -> boot timestamp (evt 12).
+            { "{A68CA8B7-004F-D7B6-A698-07E2DE0F1F5D}", 0x80L },
+            // Winlogon: PerfInstrumentation | PerfDiagnostics | ms:Telemetry -> shell-cmd (9,10),
+            // login-UI (103,104), session-logon (7001).
+            { "{DBE9B383-7CF3-4331-91CC-A3CB16A3B538}", 0x200000030000L },
+            // User Profiles Service: Operational/Diagnostic channel keywords | win:ResponseTime ->
+            // profile load (1,2) and create (1001,1002).
+            { "{89B1E9F0-5AFF-44A6-9B44-0A07A7CE5845}", 0x6001000000000000L },
+            // GroupPolicy: Operational channel keyword -> machine GP (4000,8000), user GP (4001,8001).
+            { "{AEA1B4FA-97D1-45F2-A64C-4D69FFFD92C9}", 0x4000000000000000L },
+            // Shell-Core: StartupPerf | Shell -> explorer init (9601,9602), desktop create
+            // (9611,9612), desktop steps (9648,9649).
+            { "{30336ED4-E327-447C-9DE0-51B652C86108}", 0x4010000L }
         };
 
         /// <summary>
@@ -150,9 +166,9 @@ namespace Datadog.CustomActions
                 session.Log("AutoLogger session values configured");
             }
 
-            foreach (var providerGuid in ProviderGuids)
+            foreach (var provider in ProviderKeywords)
             {
-                var providerKeyPath = $@"{SessionKeyPath}\{providerGuid}";
+                var providerKeyPath = $@"{SessionKeyPath}\{provider.Key}";
                 session.Log($"Creating provider sub-key: {providerKeyPath}");
 
                 using (var providerKey = Registry.LocalMachine.CreateSubKey(providerKeyPath))
@@ -163,7 +179,11 @@ namespace Datadog.CustomActions
                     }
 
                     providerKey.SetValue("Enabled", 1, RegistryValueKind.DWord);
-                    providerKey.SetValue("EnableLevel", 5, RegistryValueKind.DWord);
+                    // Informational level (4), not Verbose (5): every consumed event ID is
+                    // emitted at level 4, so this drops only noise.
+                    providerKey.SetValue("EnableLevel", 4, RegistryValueKind.DWord);
+                    // Keyword filter: collect only the event categories the analyzer reads.
+                    providerKey.SetValue("MatchAnyKeyword", provider.Value, RegistryValueKind.QWord);
                 }
             }
 


### PR DESCRIPTION
### What does this PR do?

Slims the Windows logon-duration ETW AutoLogger so it collects only what the analyzer reads, instead of the full Verbose firehose. In `CreateAutoLoggerRegistryKeys` (`AutoLoggerCustomAction.cs`), each of the 6 providers is now configured with:

- `EnableLevel = 4` (Informational), down from `5` (Verbose), and
- a per-provider `MatchAnyKeyword` (REG_QWORD) mask = the OR of the keyword bits carried by the event IDs `comp/logonduration/impl/analyzer.go` actually consumes.

Session buffers (`BufferSize`/`MaximumBuffers`/`MaxFileSize`) are intentionally **unchanged**. Adds an e2e assertion in `autologger_test.go` pinning `EnableLevel=4` + the exact `MatchAnyKeyword` for every provider subkey.

| Provider | MatchAnyKeyword | Keywords |
| --- | --- | --- |
| Kernel-Process | `0x10` | PROCESS |
| Kernel-General | `0x80` | BootPerformance |
| Winlogon | `0x200000030000` | PerfInstrumentation \| PerfDiagnostics \| ms:Telemetry |
| User Profiles Service | `0x6001000000000000` | Operational/Diagnostic channels \| ResponseTime |
| GroupPolicy | `0x4000000000000000` | Operational channel |
| Shell-Core | `0x4010000` | StartupPerf \| Shell |

### Motivation

The AutoLogger subscribed 6 providers at Verbose with no keyword filter — the widest possible config — yet only ~25 event IDs are consumed. This captured ~99% data we never read and could overflow its buffers and **drop events** during boot. Jira: WINA-2664.

### Describe how you validated your changes

- **Manual QA (behavioral):** ran filtered (lvl4 + masks) vs baseline (lvl5/all) boot AutoLoggers over the same real boot + interactive logon on a Win11 VM. All 22 consumed event IDs across all 6 providers were captured **identically** by the filtered session, at the same timestamps — including the user-logon sequence and the Shell-Core desktop events that have no Event Log equivalent. Volume dropped from ~61k events / 31 MB (baseline) to ~700 events (filtered). In a separate run the Verbose baseline overflowed and lost 23,847 events.
- **e2e:** `go vet ./tests/windows/install-test/` passes; the new subtest asserts the filtered registry config (runs in CI against a built MSI).
- C# compiles in the installer pipeline (local SDK can't restore the legacy `packages.config` refs; verified no new errors are introduced by this change).

### Additional Notes

- No analyzer changes — same providers, same event IDs, just filtered at the source.
- The Event Log backup (fallback for genuinely missing phases) is tracked separately as Part 2 of WINA-2664.
