### PR TITLE
Trigger deployment rollout when SSI enabled with DDI CRD

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -130,6 +130,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -400,7 +401,7 @@ func start(log log.Component,
 	apmStore := crstore.New()
 	var instrHandlers []instrumentation.Handler
 	if config.GetBool("instrumentation_crd_controller.enabled") {
-		instrHandlers = setupInstrumentationCRDHandler(le, ac, serviceTemplateStore, apmStore)
+		instrHandlers = setupInstrumentationCRDHandler(le, ac, serviceTemplateStore, apmStore, apiCl.DynamicCl)
 	} else {
 		pkglog.Debug("DatadogInstrumentation CRD controller is disabled")
 	}
@@ -760,13 +761,14 @@ func start(log log.Component,
 	return nil
 }
 
-func setupInstrumentationCRDHandler(le *leaderelection.LeaderEngine, ac autodiscovery.Component, serviceTemplateStore *instrumentationhandlers.ServiceCheckTemplateStore, apmStore *crstore.Store) []instrumentation.Handler {
+func setupInstrumentationCRDHandler(le *leaderelection.LeaderEngine, ac autodiscovery.Component, serviceTemplateStore *instrumentationhandlers.ServiceCheckTemplateStore, apmStore *crstore.Store, updateClient dynamic.Interface) []instrumentation.Handler {
 	checkStore := instrumentationhandlers.NewCheckStore()
 	instrHandlers := instrumentationhandlers.DefaultHandlers(&instrumentationhandlers.Deps{
 		IsLeader:                  le.IsLeader,
 		CheckStore:                checkStore,
 		ServiceCheckTemplateStore: serviceTemplateStore,
 		APMStore:                  apmStore,
+		UpdateClient:              updateClient,
 	})
 
 	api.ModifyAPIRouter(func(r *http.ServeMux) {

--- a/pkg/clusteragent/instrumentation/handlers/apm.go
+++ b/pkg/clusteragent/instrumentation/handlers/apm.go
@@ -9,7 +9,11 @@ package handlers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
@@ -30,6 +34,11 @@ const (
 	reasonAPMDeleted         = "Deleted"
 	reasonAPMUnsupportedLang = "UnsupportedLanguage"
 	reasonAPMInvalidConfig   = "InvalidTracerConfig"
+
+	reasonAPMRolloutTriggered  = "RolloutTriggered"
+	reasonAPMRolloutCurrent    = "RolloutCurrent"
+	reasonAPMRolloutSkipped    = "RolloutSkipped"
+	reasonAPMRolloutFailed     = "RolloutFailed"
 )
 
 var supportedAPMLanguages = map[string]struct{}{
@@ -45,12 +54,21 @@ var supportedAPMLanguages = map[string]struct{}{
 // APMHandler translates DatadogInstrumentation APM sections into SSI admission
 // webhook configuration.
 type APMHandler struct {
-	apmStore *crstore.Store
+	apmStore       *crstore.Store
+	rolloutPatcher APMRolloutPatcher
 }
 
 // NewAPMHandler returns the APM DatadogInstrumentation handler.
 func NewAPMHandler(deps *Deps) *APMHandler {
-	return &APMHandler{apmStore: deps.APMStore}
+	var rolloutPatcher APMRolloutPatcher
+	if deps.UpdateClient != nil {
+		rolloutPatcher = NewAPMDeploymentRolloutPatcher(deps.UpdateClient, deps.IsLeader)
+	}
+
+	return &APMHandler{
+		apmStore:       deps.APMStore,
+		rolloutPatcher: rolloutPatcher,
+	}
 }
 
 // Name returns the unique handler name.
@@ -108,7 +126,7 @@ func (h *APMHandler) Validate(cr *datadoghq.DatadogInstrumentation) []instrument
 }
 
 // Handle applies or removes APM configuration in the shared CR store.
-func (h *APMHandler) Handle(_ context.Context, event instrumentation.EventType, cr *datadoghq.DatadogInstrumentation) (instrumentation.HandlerStatus, error) {
+func (h *APMHandler) Handle(ctx context.Context, event instrumentation.EventType, cr *datadoghq.DatadogInstrumentation) (instrumentation.HandlerStatus, error) {
 	if cr == nil {
 		return instrumentation.HandlerStatus{
 			Type:    apmReadyConditionType,
@@ -134,7 +152,69 @@ func (h *APMHandler) Handle(_ context.Context, event instrumentation.EventType, 
 		Namespace: cr.Namespace,
 		Name:      cr.Spec.TargetRef.Name,
 	}
-	h.apmStore.UpsertAPM(target, apmConfigFromCR(crRef, cr.Spec.Config.APM))
+	apmConfig := apmConfigFromCR(crRef, cr.Spec.Config.APM)
+	h.apmStore.UpsertAPM(target, apmConfig)
+
+	if cr.Spec.TargetRef.Kind != kubernetes.DeploymentKind {
+		return instrumentation.HandlerStatus{
+			Type:    apmReadyConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  reasonAPMConfigured,
+			Message: fmt.Sprintf("APM settings configured for %s/%s", cr.Spec.TargetRef.Kind, cr.Spec.TargetRef.Name),
+		}, nil
+	}
+
+	if !apmConfig.Enabled {
+		return instrumentation.HandlerStatus{
+			Type:    apmReadyConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  reasonAPMConfigured,
+			Message: fmt.Sprintf("APM settings configured for %s/%s; rollout not triggered because APM is disabled", cr.Spec.TargetRef.Kind, cr.Spec.TargetRef.Name),
+		}, nil
+	}
+
+	if h.rolloutPatcher == nil {
+		return instrumentation.HandlerStatus{
+			Type:    apmReadyConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  reasonAPMConfigured,
+			Message: fmt.Sprintf("APM settings configured for %s/%s; awaiting pod restart", cr.Spec.TargetRef.Kind, cr.Spec.TargetRef.Name),
+		}, nil
+	}
+
+	result, err := h.rolloutPatcher.RolloutDeployment(ctx, target.Namespace, target.Name, apmRolloutConfigHash(target, apmConfig))
+	if err != nil {
+		return instrumentation.HandlerStatus{
+			Type:    apmReadyConditionType,
+			Status:  metav1.ConditionFalse,
+			Reason:  reasonAPMRolloutFailed,
+			Message: fmt.Sprintf("APM settings configured for %s/%s; failed to trigger rollout: %v", cr.Spec.TargetRef.Kind, cr.Spec.TargetRef.Name, err),
+		}, err
+	}
+
+	switch result.State {
+	case APMRolloutTriggered:
+		return instrumentation.HandlerStatus{
+			Type:    apmReadyConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  reasonAPMRolloutTriggered,
+			Message: fmt.Sprintf("APM settings configured for %s/%s; rollout triggered", cr.Spec.TargetRef.Kind, cr.Spec.TargetRef.Name),
+		}, nil
+	case APMRolloutAlreadyCurrent:
+		return instrumentation.HandlerStatus{
+			Type:    apmReadyConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  reasonAPMRolloutCurrent,
+			Message: fmt.Sprintf("APM settings configured for %s/%s; rollout already reflects current configuration", cr.Spec.TargetRef.Kind, cr.Spec.TargetRef.Name),
+		}, nil
+	case APMRolloutSkipped:
+		return instrumentation.HandlerStatus{
+			Type:    apmReadyConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  reasonAPMRolloutSkipped,
+			Message: fmt.Sprintf("APM settings configured for %s/%s; rollout skipped because this Cluster Agent is not the leader", cr.Spec.TargetRef.Kind, cr.Spec.TargetRef.Name),
+		}, nil
+	}
 
 	return instrumentation.HandlerStatus{
 		Type:    apmReadyConditionType,
@@ -159,4 +239,42 @@ func apmConfigFromCR(crRef types.NamespacedName, apm *datadoghq.DatadogInstrumen
 		config.TracerConfigs = append([]corev1.EnvVar(nil), apm.TracerConfigs...)
 	}
 	return config
+}
+
+func apmRolloutConfigHash(target crstore.WorkloadTarget, config crstore.APMConfig) string {
+	h := sha256.New()
+
+	writeHashField := func(value string) {
+		h.Write([]byte(value))
+		h.Write([]byte{0})
+	}
+
+	writeHashField(config.CR.Namespace)
+	writeHashField(config.CR.Name)
+	writeHashField(target.Kind)
+	writeHashField(target.Namespace)
+	writeHashField(target.Name)
+	writeHashField(fmt.Sprintf("%t", config.Enabled))
+
+	langs := make([]string, 0, len(config.TracerVersions))
+	for lang := range config.TracerVersions {
+		langs = append(langs, lang)
+	}
+	sort.Strings(langs)
+	for _, lang := range langs {
+		writeHashField(lang)
+		writeHashField(config.TracerVersions[lang])
+	}
+
+	for _, envVar := range config.TracerConfigs {
+		payload, err := json.Marshal(envVar)
+		if err != nil {
+			writeHashField(envVar.Name)
+			writeHashField(envVar.Value)
+			continue
+		}
+		writeHashField(string(payload))
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/pkg/clusteragent/instrumentation/handlers/apm_rollout.go
+++ b/pkg/clusteragent/instrumentation/handlers/apm_rollout.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package handlers
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+
+	workloadpatcher "github.com/DataDog/datadog-agent/pkg/clusteragent/patcher"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	apmRestartedAtAnnotation = "kubectl.kubernetes.io/restartedAt"
+	apmConfigHashAnnotation  = "internal.apm.datadoghq.com/datadoginstrumentation-config-hash"
+)
+
+// APMRolloutState describes what happened when the APM handler requested a rollout.
+type APMRolloutState string
+
+const (
+	// APMRolloutTriggered means the target Deployment pod template was patched.
+	APMRolloutTriggered APMRolloutState = "triggered"
+	// APMRolloutAlreadyCurrent means the target Deployment already has the requested APM config hash.
+	APMRolloutAlreadyCurrent APMRolloutState = "already_current"
+	// APMRolloutSkipped means rollout was intentionally skipped, usually because this DCA is not leader.
+	APMRolloutSkipped APMRolloutState = "skipped"
+)
+
+// APMRolloutResult is returned after trying to trigger an APM rollout.
+type APMRolloutResult struct {
+	State APMRolloutState
+}
+
+// APMRolloutPatcher triggers Deployment rollouts for APM DatadogInstrumentation targets.
+type APMRolloutPatcher interface {
+	RolloutDeployment(ctx context.Context, namespace, name, configHash string) (APMRolloutResult, error)
+}
+
+type deploymentRolloutPatcher struct {
+	client      dynamic.Interface
+	patchClient *workloadpatcher.Patcher
+	isLeader    func() bool
+	now         func() time.Time
+}
+
+// NewAPMDeploymentRolloutPatcher returns an APM rollout patcher backed by the Kubernetes dynamic client.
+func NewAPMDeploymentRolloutPatcher(client dynamic.Interface, isLeader func() bool) APMRolloutPatcher {
+	return &deploymentRolloutPatcher{
+		client:      client,
+		patchClient: workloadpatcher.NewPatcher(client, nil),
+		isLeader:    isLeader,
+		now:         time.Now,
+	}
+}
+
+func (p *deploymentRolloutPatcher) RolloutDeployment(ctx context.Context, namespace, name, configHash string) (APMRolloutResult, error) {
+	if p.isLeader != nil && !p.isLeader() {
+		return APMRolloutResult{State: APMRolloutSkipped}, nil
+	}
+
+	target := workloadpatcher.DeploymentTarget(namespace, name)
+	deployment, err := p.client.Resource(target.GVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return APMRolloutResult{}, err
+	}
+
+	existingHash, _, err := unstructured.NestedString(deployment.Object, "spec", "template", "metadata", "annotations", apmConfigHashAnnotation)
+	if err != nil {
+		log.Debugf("Failed to read APM DatadogInstrumentation rollout annotation from deployment %s/%s: %v", namespace, name, err)
+	}
+	if existingHash == configHash {
+		return APMRolloutResult{State: APMRolloutAlreadyCurrent}, nil
+	}
+
+	intent := workloadpatcher.NewPatchIntent(target).With(workloadpatcher.SetPodTemplateAnnotations(map[string]interface{}{
+		apmRestartedAtAnnotation: p.now().Format(time.RFC3339),
+		apmConfigHashAnnotation:  configHash,
+	}))
+
+	_, err = p.patchClient.Apply(ctx, intent, workloadpatcher.PatchOptions{
+		Caller:          "datadoginstrumentation_apm",
+		RetryOnConflict: true,
+	})
+	if err != nil {
+		return APMRolloutResult{}, err
+	}
+
+	return APMRolloutResult{State: APMRolloutTriggered}, nil
+}

--- a/pkg/clusteragent/instrumentation/handlers/registry.go
+++ b/pkg/clusteragent/instrumentation/handlers/registry.go
@@ -11,6 +11,7 @@ package handlers
 import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
 	"github.com/DataDog/datadog-agent/pkg/ssi/crstore"
+	"k8s.io/client-go/dynamic"
 )
 
 // Deps contains dependencies used to construct DatadogInstrumentation product handlers.
@@ -31,6 +32,9 @@ type Deps struct {
 	// APMStore is used as a shared store for APM SSI configuration between the
 	// DDI handler and the auto-instrumentation admission webhook.
 	APMStore *crstore.Store
+
+	// UpdateClient is used by handlers that need to mutate Kubernetes resources.
+	UpdateClient dynamic.Interface
 }
 
 // DefaultHandlers returns the product handlers registered for the shared controller.


### PR DESCRIPTION
Continuation of https://github.com/DataDog/datadog-agent/pull/52722

## Summary
- Gate APM auto-instrumentation rollout on SSI-enabled clusters
- Route admission and handler logic through the shared SSI crstore path
- Update webhook and target mutator tests for the new rollout flow
- Refresh build inputs and dependency metadata for the new instrumentation path

## Testing
- Added and updated unit coverage for webhook, target mutation, label selector, and rollout behavior
- Not run (not requested)