### PR TITLE
fix(metadata): downgrade network metadata failure log from INFO to DEBUG

### DIFF
--- a/comp/metadata/host/impl/utils/host.go
+++ b/comp/metadata/host/impl/utils/host.go
@@ -105,7 +105,7 @@ type Payload struct {
 func getNetworkMeta(ctx context.Context) *NetworkMeta {
 	nid, err := network.GetNetworkID(ctx)
 	if err != nil {
-		log.Infof("could not get network metadata: %s", err)
+		log.Debugf("could not get network metadata: %s", err)
 		return nil
 	}
 

--- a/releasenotes/notes/suppress-cloud-metadata-info-log-71d283af7ea43107.yaml
+++ b/releasenotes/notes/suppress-cloud-metadata-info-log-71d283af7ea43107.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Reduce log noise in on-premises environments by changing the ``could not get network metadata``
+    message from INFO to DEBUG level. In environments where cloud provider metadata is disabled by
+    configuration, this message was emitted at every metadata collection cycle (every 5-30 minutes),
+    causing unnecessary log volume. The message is still available at DEBUG level for diagnostic purposes.


### PR DESCRIPTION
### What does this PR do?

Changes `log.Infof` to `log.Debugf` for the "could not get network metadata" message in `comp/metadata/host/impl/utils/host.go` (line 108).

### Motivation

In on-premises environments where `cloud_provider_metadata` is disabled by configuration, the host metadata collector runs every 5–30 minutes and emits this INFO-level log on every cycle:

```
could not get network metadata: could not detect network ID: EC2: GetNetworkID failed to get mac addresses: cloud provider is disabled by configuration
```

The failure is expected and not actionable — the cloud provider is intentionally disabled. Emitting it at INFO causes log noise and may trigger unnecessary investigation. DEBUG is the appropriate level for expected, non-actionable diagnostic output.

Closes FRAGENT-3620 / AGENT-16402.

### Describe how you validated your changes

- Ran `dda inv test --targets=./comp/metadata/host/...` — all 38 tests pass (1 skipped, platform-specific).

### Additional Notes