### PR TITLE
feat(codex review): Less occurrence of review on draft PR

### DIFF
--- a/.github/workflows/codex-review-draft.yml
+++ b/.github/workflows/codex-review-draft.yml
@@ -3,7 +3,7 @@ name: "Codex review on draft PR"
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
     branches:
       - main
       - "[0-9]+.[0-9]+.x"
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   codex-review:
-    if: github.event.pull_request.draft == true && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.pull_request.labels.*.name, 'no-review')
+    if: github.event.pull_request.draft == true && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.pull_request.labels.*.name, 'no-draft-review')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
### What does this PR do?
- Trigger the codex review only when PR is opened in draft
- Use a new label to discard review on draft PR

### Motivation
https://datadoghq.atlassian.net/browse/ACIX-1675
The review on all commits was creating noise for users. With #50432 we introduce an on-demand process for review which brings more flexibility

### Describe how you validated your changes
Tested on this PR: I pushed an empty commit to see there was no trigger on second round.
The label change does not deserve a test.

### Additional Notes
