### PR TITLE
[ACTP] Fix PAR startup in DCA

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -476,6 +476,9 @@ func start(log log.Component,
 	rcserv, isSet := rcService.Get()
 	rcEnabled := configUtils.IsRemoteConfigEnabled(config)
 	if rcEnabled && isSet {
+		// We explicitly don't add the `ProductActionPlatformRunnerKeys` here as it will be added automatically from the subscribe call.
+		// Adding it here will create a race condition where the notification can be fired before the subscription
+		// preventing the PAR component to finish its startup.
 		var products []string
 		if config.GetBool("admission_controller.auto_instrumentation.patcher.enabled") {
 			products = append(products, state.ProductAPMTracing)
@@ -491,9 +494,6 @@ func start(log log.Component,
 		}
 		if config.GetBool("admission_controller.auto_instrumentation.enabled") || config.GetBool("apm_config.instrumentation.enabled") {
 			products = append(products, state.ProductGradualRollout)
-		}
-		if config.GetBool("private_action_runner.enabled") {
-			products = append(products, state.ProductActionPlatformRunnerKeys)
 		}
 
 		var err error

--- a/releasenotes/notes/par-dca-fix-startup-8a5e2c17459b0a12.yaml
+++ b/releasenotes/notes/par-dca-fix-startup-8a5e2c17459b0a12.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue where the Private Action Runner (PAR) would fail to start up properly, causing it to not execute any tasks.
+    This was caused by a race condition where the Remote Configuration notification could be fired
+    before the PAR component had finished subscribing, causing it to miss the initial configuration.


### PR DESCRIPTION
### What does this PR do?

Removes ProductActionPlatformRunnerKeys from the RC client's initial product list in the DCA. The product is now registered automatically when the PAR key manager calls Subscribe during its startup.

### Motivation

The PAR was silently failing to execute any tasks when running in the Cluster Agent. The RC backend could fire the initial AP_RUNNER_KEYS notification between rcClient.Start() and the PAR's keysManager.Subscribe(...) call. The PAR key manager would miss this notification, causing WaitForReady() to block indefinitely / until the new key rotation.

Subscribe in the RC client both registers the callback and appends the product to the polled product list, so the backend is correctly asked for AP_RUNNER_KEYS on the next poll

### Describe how you validated your changes

Reproduced the race by adding a deliberate delay before startPrivateActionRunner and confirmed PAR failed to execute tasks. 
Deployed the docker image to a local cluster

### Additional Notes

There was another attempt but it required a larger change and could cause other concurrency issues on RC https://github.com/DataDog/datadog-agent/pull/52557#discussion_r3450837133

Will backport

