### PR TITLE
Use hatchling directly for wheel-building from Bazel

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1665,10 +1665,6 @@
             "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz": "d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991",
             "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl": "77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34"
           },
-          "build": {
-            "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl": "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f",
-            "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz": "302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647"
-          },
           "certifi": {
             "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz": "47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43",
             "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl": "0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de"
@@ -1840,10 +1836,6 @@
             "https://files.pythonhosted.org/packages/f6/42/6f45efee8697b89fda4d50580f292b8f7f9306cb2971d4b53f8914e4d890/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_s390x.whl": "bd28b817ea8c70215401f657edef3a8aa83c29d447fb0b622c35403780ba11d5",
             "https://files.pythonhosted.org/packages/fc/eb/a2ffb08547f4e1e5415fb69eb7db25932c52a52bed371429648db4d84fb1/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl": "c6fd51128a41297f5409deab284fecbe5305ebd7e5a1f959bee1c054622b7018"
           },
-          "colorama": {
-            "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
-            "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
-          },
           "cryptography": {
             "https://files.pythonhosted.org/packages/01/41/3a578f7fd5c70611c0aacba52cd13cb364a5dee895a5c1d467208a9380b0/cryptography-46.0.6-cp314-cp314t-macosx_10_9_universal2.whl": "2ef9e69886cbb137c2aef9772c2e7138dc581fad4fcbcf13cc181eb5a3ab6275",
             "https://files.pythonhosted.org/packages/01/59/562be1e653accee4fdad92c7a2e88fced26b3fdfce144047519bbebc299e/cryptography-46.0.6-cp311-abi3-manylinux_2_31_armv7l.whl": "760997a4b950ff00d418398ad73fbc91aa2894b5c1db7ccb45b4f68b42a63b3c",
@@ -2010,10 +2002,6 @@
           "pygments": {
             "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz": "636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
             "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl": "86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
-          },
-          "pyproject-hooks": {
-            "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl": "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913",
-            "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz": "1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8"
           },
           "pywin32-ctypes": {
             "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz": "d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755",

--- a/deps/agent_integrations/BUILD.bazel
+++ b/deps/agent_integrations/BUILD.bazel
@@ -16,7 +16,6 @@ py_binary(
     srcs = ["build_wheel.py"],
     main = "build_wheel.py",
     deps = [
-        requirement("build"),
         requirement("hatchling"),
     ],
 )

--- a/deps/agent_integrations/build_wheel.py
+++ b/deps/agent_integrations/build_wheel.py
@@ -1,25 +1,43 @@
 #!/usr/bin/env python3
-"""Build a wheel from source using `build`.
+"""Build a wheel from source using `hatchling` directly.
 
-The choice of `build` as the build frontend is based on it being the most minimalist
-officially supported PEP-517-compliant build frontend, with a very minimal set of dependencies
-and with reduced risk of side effects. Using `pip` would potentially require more care
-around controlling the environment to ensure the right build dependencies (like a predefined build backend)
-are present and we don't break hermeticity.
+`hatchling` is the PEP-517-compliant build backend used by all Python packages in integrations-core
+The main reason to invoke it directly, instead of going through a build frontend, is that
+we need control over its behavior that can only achieved by direct calls.
 """
 
 import argparse
+from pathlib import Path
 
-from build import ProjectBuilder
+from hatchling.builders.wheel import WheelBuilder
+from hatchling.metadata.core import load_toml
+
+HATCHLING_BUILD_BACKEND = "hatchling.build"
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--src", required=True)
+    parser.add_argument("--src", required=True, type=Path)
     parser.add_argument("--output-dir", required=True)
     args = parser.parse_args()
 
-    ProjectBuilder(args.src).build("wheel", args.output_dir)
+    config = load_toml(args.src / "pyproject.toml")
+
+    # Validate that the project defines hatchling as its build backend
+    build_backend = config.get("build-system", {}).get("build-backend")
+    if build_backend != HATCHLING_BUILD_BACKEND:
+        raise ValueError(
+            f"Unsupported build backend {build_backend!r} in {args.src / 'pyproject.toml'}; "
+            f"expected {HATCHLING_BUILD_BACKEND!r}"
+        )
+
+    # Disable the default non-hermetic behaviour which walks up the filesystem in search of
+    # .gitignore / .hgignore files as a way to potentially exclude files based on them.
+    # https://hatch.pypa.io/1.16/config/build/#vcs
+    config.setdefault("tool", {}).setdefault("hatch", {}).setdefault("build", {})["ignore-vcs"] = True
+
+    # This is essentially equivalent to to hatchling's `build_wheel` PEP-517 hook
+    next(WheelBuilder(str(args.src), config=config).build(args.output_dir, ["standard"]))
 
 
 if __name__ == "__main__":

--- a/deps/agent_integrations/defs.bzl
+++ b/deps/agent_integrations/defs.bzl
@@ -85,7 +85,7 @@ pyproject_wheel = rule(
             doc = "Executable target for the wheel build frontend.",
         ),
     },
-    doc = "Builds a wheel from a pyproject.toml-based Python source package.",
+    doc = "Builds a wheel from a pyproject.toml-based, hatchling-built Python source package.",
 )
 
 install_wheels = rule(

--- a/deps/py_agent_integrations_tool_requirements.txt
+++ b/deps/py_agent_integrations_tool_requirements.txt
@@ -1,4 +1,2 @@
-build==1.5.0  # PEP 517 compatible build frontend
 hatchling==0.25.1  # Build backend used by integration packages
 installer==1.0.1  # Wheel installer
-colorama  # Transitive dependency for `build` on Windows; direct reference keeps the lock platform-independent

--- a/deps/py_agent_integrations_tool_requirements_lock.txt
+++ b/deps/py_agent_integrations_tool_requirements_lock.txt
@@ -4,12 +4,6 @@
 #
 #    bazel run //deps:py_agent_integrations_tool_requirements.update
 #
-build==1.5.0 \
-    --hash=sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f \
-    --hash=sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647
-colorama==0.4.6 \
-    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
-    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
 editables==0.6 \
     --hash=sha256:1163834902381c4613787951c5914800fdf155ae08848a373b8ea5006780977c \
     --hash=sha256:d70e4698078a1d033e7786d9c64e5be070d058a67c21417024d38a58ac20aa43
@@ -28,6 +22,3 @@ pathspec==1.1.1 \
 pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
-pyproject-hooks==1.2.0 \
-    --hash=sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8 \
-    --hash=sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913


### PR DESCRIPTION
### What does this PR do?

It switches building of integrations-core wheels from being driven by the [build](https://build.pypa.io/) frontend to calling the backend hatchling hooks directly. Along with this change, the [ignore-vcs](https://hatch.pypa.io/1.16/config/build/#vcs) is enabled to remove a source of non-hermeticity – and being able to control this setting is what motivates skipping a frontend.

### Motivation

The as of now WIP PR https://github.com/DataDog/datadog-agent/pull/52657 switches the installation of all integration packages from integrations-core to the bazel mechanisms established by https://github.com/DataDog/datadog-agent/pull/52060 and https://github.com/DataDog/datadog-agent/pull/52369. Unexpectedly, this dropped all files under `datadog_checks/php_fpm/vendor/`, as reported by the inventory check (for example [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1795880761#L135)). Puzzlingly enough, it did so only on CI, not locally.

The culprit turned out to be hatchling's default behaviour, which attempts to find a .gitignore file by walking upwards on the filesystem tree, and apply exclusion based on its contents. This allows the action to read files not included in the inputs, and out of the sandbox. The reason why this manifested the way it did in CI comes from two places.

- First, the XDG_CACHE_HOME in CI is set to under CI_PROJECT_DIR (i.e. the datadog-agent checkout itself), [here](https://github.com/DataDog/datadog-agent/blob/1fae86a0b245dffa98338603324c2de6e8e85a26/.gitlab/build/bazel/defs.yml#L36). This means that inputs will be materialized here, and walking up from them can eventually hit datadog-agent's `.gitignore` file.
- Second, there's an entry for `vendor/` in datadog-agent's .gitignore ([here](https://github.com/DataDog/datadog-agent/blob/c6f732daa1f06f2177f5723fb6048fff1bfcc97b/.gitignore#L5)). This is the reason why that folder in particular was dropped – it happened to be the only match that triggered an accidental exclusion.

### Describe how you validated your changes

- Green CI and clean files inventory check for regressions.
- This same commit was first applied on top of https://github.com/DataDog/datadog-agent/pull/52657, where it was confirmed that the CI build stopped dropping those files.

### Additional Notes

I don't foresee any short-term need, within datadog-agent, to have to build python projects based on other build backends, making the tradeoff of constraining the current rule to use `hatchling` specifically look acceptable.

Other alternatives considered were:
- Adding an empty .gitignore file to the rule's input, such that hatchling will stop searching beyond that point. This has the drawback of requiring setting up a staging directory to put the .gitignore file on the same directory as the input source, which seems a heavier handed approach. Note that modifying the inputs directly is out of bounds.
- Trying to influence hatchling's behavior via [PEP-517 config settings](https://peps.python.org/pep-0517/#config-settings) didn't work because hatchling doesn't read from them in any way.
- Ideas like adding the empty .gitignore files to the build targets' `srcs` or setting ignore-vcs=True in the integrations-core files directly only solve the problem on the surface, as the rule would remain fundamentally non-hermetic.
- Sidestepping hatchling altogether and using rules_python's [py_wheel](https://rules-python.readthedocs.io/en/0.28.0/api/packaging.html#py-wheel). This would require, at the very least, implementing code to extract the version of each integration (from `__about__.py`), and generally risks more problems in terms of reproducing the existing behavior, despite probably being the most hermetic solution.
