### PR TITLE
refactor(comp/core/fxinstrumentation): add NewComponent to impl/

### DIFF
--- a/comp/core/fxinstrumentation/impl/BUILD.bazel
+++ b/comp/core/fxinstrumentation/impl/BUILD.bazel
@@ -2,7 +2,13 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "impl",
-    srcs = ["doc.go"],
+    srcs = [
+        "doc.go",
+        "fxinstrumentation.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/comp/core/fxinstrumentation/impl",
     visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/fxinstrumentation/def",
+    ],
 )

--- a/comp/core/fxinstrumentation/impl/fxinstrumentation.go
+++ b/comp/core/fxinstrumentation/impl/fxinstrumentation.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package fxinstrumentationimpl
+
+import fxinstrumentation "github.com/DataDog/datadog-agent/comp/core/fxinstrumentation/def"
+
+// Provides defines the output of the fxinstrumentation component.
+type Provides struct {
+	Comp fxinstrumentation.Component
+}
+
+// NewComponent creates a new fxinstrumentation component.
+func NewComponent() Provides {
+	return Provides{Comp: struct{}{}}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a `NewComponent` constructor function and a `Provides` struct to `comp/core/fxinstrumentation/impl/`, satisfying the v2 component structural contract.

Also updates `BUILD.bazel` to include the new file and its dependency on the `def` package.

### Motivation

The component linter requires every v2 component's `impl/` to export a `NewComponent` function. `comp/core/fxinstrumentation/impl/` only contained a `doc.go` package stub, making it the only v2 component with no open PR to address the gap.

The `Component` interface is empty (same pattern as `comp/core/pid`), so `NewComponent` returns a `Provides{Comp: struct{}{}}`.

### Describe how you validated your changes

Re-ran the component analysis script — `comp/core/fxinstrumentation` is no longer flagged as non-compliant. Non-compliant count dropped from 12 → 11.

### Additional Notes

The `fx/fx.go` for this component uses `fx.Invoke` instead of `ProvideComponentConstructor` (by design, as noted in the existing comment). This PR only adds the missing `NewComponent` to satisfy the linter; it does not change the fx wiring.