### PR TITLE
bazel: generate, aggregate & upload junit test report for bazel driven tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -100,6 +100,7 @@ common:cache --noremote_upload_local_results
 common:ci --config=adms
 common:ci --config=lint
 common:ci --noexperimental_convenience_symlinks # not CI-suitable: "These symlinks are only for the user's convenience"
+common:ci --remote_download_regex=.*/test\.xml$ # force-download test.xml even under --remote_download_outputs=toplevel, so junit collection can read it locally
 
 # Project/Language configs --------------------------------------------------------------------------------------
 import %workspace%/bazel/configs/flavors.bazelrc

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -13,14 +13,16 @@ include:
   variables:
     EXTERNAL_LINKS_PATH: external_links_$CI_JOB_ID.json
     FLAVOR: base
+    BEP_FILE: $CI_PROJECT_DIR/bazel-bep-$FLAVOR.json
   after_script:
-    - dda inv -- -e bazel.collect-junit --flavor=$FLAVOR --output-tgz=junit-${CI_JOB_NAME}.tgz || true
+    - dda inv -- -e bazel.collect-junit --flavor=$FLAVOR --output-tgz=junit-${CI_JOB_NAME}.tgz --bep-file=$BEP_FILE || true
     - !reference [.upload_junit_source]
   artifacts:
     expire_in: 2 weeks
     when: always
     paths:
       - junit-*.tgz
+      - bazel-bep-*.json
     reports:
       annotations:
         - $EXTERNAL_LINKS_PATH
@@ -32,20 +34,20 @@ bazel:test:linux-amd64:
   extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:linux-amd64 ]
   script:
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --keep_going --remote_download_outputs=toplevel --config=no-dd-agent-go-tests //...
+    - bazel test --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --config=no-dd-agent-go-tests //...
 
 bazel:test:linux-arm64:
   extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:linux-arm64 ]
   script:
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --keep_going --remote_download_outputs=toplevel --config=no-dd-agent-go-tests //...
+    - bazel test --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --config=no-dd-agent-go-tests //...
 
 bazel:test:macos-amd64:
   extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:macos-amd64 ]
   script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --keep_going --remote_download_outputs=toplevel --config=no-dd-agent-go-tests //...
+    - bazel test --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --config=no-dd-agent-go-tests //...
   after_script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting, after_script]
@@ -55,7 +57,7 @@ bazel:test:macos-arm64:
   script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --keep_going --remote_download_outputs=toplevel --config=no-dd-agent-go-tests //...
+    - bazel test --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --config=no-dd-agent-go-tests //...
   after_script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting, after_script]
@@ -76,7 +78,7 @@ bazel:test:windows-amd64:
   extends: [ .bazel:test, .bazel:test:reporting ]
   script:
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v=test2json --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
+    - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v=test2json --build_event_json_file=$BEP_FILE --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
 
 # macOS flavor variant: re-installs dda in both script and after_script since
 # macOS shell executors run each phase in a fresh shell.
@@ -85,7 +87,7 @@ bazel:test:windows-amd64:
   script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v=test2json --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
+    - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v=test2json --build_event_json_file=$BEP_FILE --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
   after_script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting, after_script]

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -1,27 +1,64 @@
+include:
+  - .gitlab/.pre/common/macos.yml
+
 .bazel:test:
   stage: source_test
   rules:
     - when: on_success
 
+.bazel:test:reporting:
+  id_tokens:
+    CI_IDENTITIES_GITLAB_ID_TOKEN:
+      aud: ci-identities
+  variables:
+    EXTERNAL_LINKS_PATH: external_links_$CI_JOB_ID.json
+    FLAVOR: base
+  after_script:
+    - dda inv -- -e bazel.collect-junit --flavor=$FLAVOR --output-tgz=junit-${CI_JOB_NAME}.tgz || true
+    - !reference [.upload_junit_source]
+  artifacts:
+    expire_in: 2 weeks
+    when: always
+    paths:
+      - junit-*.tgz
+    reports:
+      annotations:
+        - $EXTERNAL_LINKS_PATH
+
+.bazel:test:reporting:ci_links:
+  - dda inv -- -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
+
 bazel:test:linux-amd64:
-  extends: [ .bazel:test, .bazel:runner:linux-amd64 ]
+  extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:linux-amd64 ]
   script:
-    - bazel test --keep_going --config=no-dd-agent-go-tests //...
+    - !reference [.bazel:test:reporting:ci_links]
+    - bazel test --keep_going --remote_download_outputs=toplevel --config=no-dd-agent-go-tests //...
 
 bazel:test:linux-arm64:
-  extends: [ .bazel:test, .bazel:runner:linux-arm64 ]
+  extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:linux-arm64 ]
   script:
-    - bazel test --keep_going --config=no-dd-agent-go-tests //...
+    - !reference [.bazel:test:reporting:ci_links]
+    - bazel test --keep_going --remote_download_outputs=toplevel --config=no-dd-agent-go-tests //...
 
 bazel:test:macos-amd64:
-  extends: [ .bazel:test, .bazel:runner:macos-amd64 ]
+  extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:macos-amd64 ]
   script:
-    - bazel test --keep_going --config=no-dd-agent-go-tests //...
+    - !reference [.install_python_dependencies]
+    - !reference [.bazel:test:reporting:ci_links]
+    - bazel test --keep_going --remote_download_outputs=toplevel --config=no-dd-agent-go-tests //...
+  after_script:
+    - !reference [.install_python_dependencies]
+    - !reference [.bazel:test:reporting, after_script]
 
 bazel:test:macos-arm64:
-  extends: [ .bazel:test, .bazel:runner:macos-arm64 ]
+  extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:macos-arm64 ]
   script:
-    - bazel test --keep_going --config=no-dd-agent-go-tests //...
+    - !reference [.install_python_dependencies]
+    - !reference [.bazel:test:reporting:ci_links]
+    - bazel test --keep_going --remote_download_outputs=toplevel --config=no-dd-agent-go-tests //...
+  after_script:
+    - !reference [.install_python_dependencies]
+    - !reference [.bazel:test:reporting, after_script]
 
 bazel:test:windows-amd64:
   extends: [ .bazel:test, .bazel:runner:windows-amd64 ]
@@ -36,9 +73,22 @@ bazel:test:windows-amd64:
 # dda inv test --flavor=<f> topology. --config=<flavor> sets
 # --test_tag_filters=flavor_<flavor>, selecting only the matching go_test variants.
 .bazel:test:flavor:
-  extends: .bazel:test
+  extends: [ .bazel:test, .bazel:test:reporting ]
   script:
-    - bazel test --keep_going --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
+    - !reference [.bazel:test:reporting:ci_links]
+    - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v=test2json --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
+
+# macOS flavor variant: re-installs dda in both script and after_script since
+# macOS shell executors run each phase in a fresh shell.
+.bazel:test:flavor:macos:
+  extends: .bazel:test:flavor
+  script:
+    - !reference [.install_python_dependencies]
+    - !reference [.bazel:test:reporting:ci_links]
+    - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v=test2json --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
+  after_script:
+    - !reference [.install_python_dependencies]
+    - !reference [.bazel:test:reporting, after_script]
 
 bazel:test:linux-amd64:base:
   extends: [ .bazel:test:flavor, .bazel:runner:linux-amd64 ]
@@ -81,22 +131,22 @@ bazel:test:linux-arm64:iot:
     FLAVOR: iot
 
 bazel:test:macos-amd64:base:
-  extends: [ .bazel:test:flavor, .bazel:runner:macos-amd64 ]
+  extends: [ .bazel:test:flavor:macos, .bazel:runner:macos-amd64 ]
   variables:
     FLAVOR: base
 
 bazel:test:macos-amd64:dogstatsd:
-  extends: [ .bazel:test:flavor, .bazel:runner:macos-amd64 ]
+  extends: [ .bazel:test:flavor:macos, .bazel:runner:macos-amd64 ]
   variables:
     FLAVOR: dogstatsd
 
 bazel:test:macos-arm64:base:
-  extends: [ .bazel:test:flavor, .bazel:runner:macos-arm64 ]
+  extends: [ .bazel:test:flavor:macos, .bazel:runner:macos-arm64 ]
   variables:
     FLAVOR: base
 
 bazel:test:macos-arm64:dogstatsd:
-  extends: [ .bazel:test:flavor, .bazel:runner:macos-arm64 ]
+  extends: [ .bazel:test:flavor:macos, .bazel:runner:macos-arm64 ]
   variables:
     FLAVOR: dogstatsd
 
@@ -109,4 +159,3 @@ bazel:test:windows-amd64:base:
     POWERSHELL_SCRIPT: >-
       bazel test --keep_going --build_tests_only --config=base
       //pkg/... //comp/... //cmd/...
-

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -14,6 +14,7 @@ from tasks import (
     ami,
     anomalydetection,
     auth,
+    bazel,
     bench,
     buildimages,
     claude,
@@ -200,6 +201,7 @@ ns.add_task(lint_go)
 # add namespaced tasks to the root
 ns.add_collection(anomalydetection)
 ns.add_collection(auth)
+ns.add_collection(bazel)
 ns.add_collection(agent)
 ns.add_collection(ami)
 ns.add_collection(agent_ci_api)

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 import xml.etree.ElementTree as ET
@@ -12,6 +13,62 @@ from tasks.libs.common.color import color_message
 from tasks.libs.common.gomodules import AGENT_MODULE_PATH_PREFIX
 
 _IMPORT_PREFIX = AGENT_MODULE_PATH_PREFIX.rstrip("/")
+
+
+def _label_to_import_path(label: str) -> str:
+    pkg_part = label.lstrip("/").split(":", 1)[0]
+    return _IMPORT_PREFIX if not pkg_part else f"{_IMPORT_PREFIX}/{pkg_part}"
+
+
+def _parse_bep_cache_status(bep_path: Path) -> dict[str, bool]:
+    """Return a map of import_path → was_cached parsed from a BEP JSON file."""
+    status: dict[str, bool] = {}
+    with bep_path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            tr = event.get("testResult")
+            if not tr:
+                continue
+            label = event.get("id", {}).get("testResult", {}).get("label", "")
+            if not label:
+                continue
+            import_path = _label_to_import_path(label)
+            cached = bool(tr.get("cachedLocally") or tr.get("executionInfo", {}).get("cachedRemotely"))
+            status[import_path] = cached
+    return status
+
+
+def _annotate_junit_cache_status(xml_path: Path, cache_status: dict[str, bool]) -> None:
+    """Add a bazel.cached <property> to each <testsuite> whose import path is known.
+
+    gotestsum emits one <testsuite> per test function with name "{import_path}.{TestFunc}",
+    so the import path is recovered by stripping the final ".FunctionName" component.
+    """
+    if not cache_status:
+        return
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    for ts in root.findall(".//testsuite"):
+        ts_name = ts.get("name", "")
+        cached = cache_status.get(ts_name)
+        if cached is None:
+            dot = ts_name.rfind(".")
+            if dot > 0:
+                cached = cache_status.get(ts_name[:dot])
+        if cached is None:
+            continue
+        props = ts.find("properties")
+        if props is None:
+            props = ET.Element("properties")
+            ts.insert(0, props)
+        ET.SubElement(props, "property", name="bazel.cached", value=str(cached).lower())
+    tree.write(str(xml_path))
 
 
 def _get_testlogs_dir(ctx) -> Path:
@@ -41,9 +98,10 @@ def testlogs_dir(ctx):
     help={
         "flavor": f"Agent flavor ({', '.join(f.name for f in AgentFlavor)}). Embedded in each JUnit XML.",
         "output_tgz": "Destination path for the output tgz (e.g. junit-bazel-base.tgz).",
+        "bep_file": "Path to a Bazel BEP JSON file; when provided, annotates each testsuite with bazel.cached.",
     },
 )
-def collect_junit(ctx, flavor, output_tgz):
+def collect_junit(ctx, flavor, output_tgz, bep_file=None):
     """Collect Bazel test results and package them for junit_upload.
 
     Merges the test.xml files produced by the rules_go test runner (one per
@@ -94,6 +152,14 @@ def collect_junit(ctx, flavor, output_tgz):
         ET.ElementTree(merged).write(str(merged_path), encoding="unicode")
 
         enrich_junitxml(str(merged_path), agent_flavor)
+
+        if bep_file:
+            bep_path = Path(bep_file)
+            if bep_path.is_file():
+                _annotate_junit_cache_status(merged_path, _parse_bep_cache_status(bep_path))
+            else:
+                print(f"warning: BEP file not found: {bep_file}", file=sys.stderr)
+
         produce_junit_tar([str(merged_path)], output_tgz)
 
     print(f"Packaged {collected} test suites → {output_tgz}")

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from invoke import task
 
 from tasks.flavor import AgentFlavor
-from tasks.libs.common.color import color_message
 from tasks.libs.common.gomodules import AGENT_MODULE_PATH_PREFIX
 
 _IMPORT_PREFIX = AGENT_MODULE_PATH_PREFIX.rstrip("/")
@@ -20,9 +19,15 @@ def _label_to_import_path(label: str) -> str:
     return _IMPORT_PREFIX if not pkg_part else f"{_IMPORT_PREFIX}/{pkg_part}"
 
 
-def _parse_bep_cache_status(bep_path: Path) -> dict[str, bool]:
-    """Return a map of import_path → was_cached parsed from a BEP JSON file."""
-    status: dict[str, bool] = {}
+def _parse_bep(bep_path: Path) -> tuple[list[Path], dict[str, bool]]:
+    """Parse a BEP JSON file in one pass.
+
+    Returns (xml_paths, cache_status) where xml_paths are the test.xml files
+    produced by this specific invocation, and cache_status maps import_path →
+    was_cached.
+    """
+    xml_paths: list[Path] = []
+    cache_status: dict[str, bool] = {}
     with bep_path.open() as f:
         for line in f:
             line = line.strip()
@@ -40,8 +45,13 @@ def _parse_bep_cache_status(bep_path: Path) -> dict[str, bool]:
                 continue
             import_path = _label_to_import_path(label)
             cached = bool(tr.get("cachedLocally") or tr.get("executionInfo", {}).get("cachedRemotely"))
-            status[import_path] = cached
-    return status
+            cache_status[import_path] = cached
+            for output in tr.get("testActionOutput", []):
+                if output.get("name") == "test.xml":
+                    uri = output.get("uri", "")
+                    if uri.startswith("file://"):
+                        xml_paths.append(Path(uri[len("file://") :]))
+    return xml_paths, cache_status
 
 
 def _annotate_junit_cache_status(xml_path: Path, cache_status: dict[str, bool]) -> None:
@@ -71,37 +81,14 @@ def _annotate_junit_cache_status(xml_path: Path, cache_status: dict[str, bool]) 
     tree.write(str(xml_path))
 
 
-def _get_testlogs_dir(ctx) -> Path:
-    # `bazel info bazel-testlogs` does not account for configuration transitions,
-    # so locate the directory from output_path instead.
-    output_path = Path(ctx.run("bazel info output_path", hide=True).stdout.strip())
-    candidates = sorted(output_path.glob("*/testlogs"), key=lambda p: p.stat().st_mtime, reverse=True)
-    if not candidates:
-        raise RuntimeError(f"no testlogs directory found under {output_path}")
-    if len(candidates) > 1:
-        others = [str(c) for c in candidates[1:]]
-        print(
-            color_message("warning", "yellow")
-            + f": multiple testlogs directories found, using most recent: {candidates[0]}\n  others: {others}",
-            file=sys.stderr,
-        )
-    return candidates[0]
-
-
-@task
-def testlogs_dir(ctx):
-    """Print the absolute path to Bazel's testlogs directory."""
-    print(_get_testlogs_dir(ctx))
-
-
 @task(
     help={
         "flavor": f"Agent flavor ({', '.join(f.name for f in AgentFlavor)}). Embedded in each JUnit XML.",
         "output_tgz": "Destination path for the output tgz (e.g. junit-bazel-base.tgz).",
-        "bep_file": "Path to a Bazel BEP JSON file; when provided, annotates each testsuite with bazel.cached.",
+        "bep_file": "Path to a Bazel BEP JSON file (--build_event_json_file); drives test.xml discovery and annotates each testsuite with bazel.cached.",
     },
 )
-def collect_junit(ctx, flavor, output_tgz, bep_file=None):
+def collect_junit(ctx, flavor, output_tgz, bep_file):
     """Collect Bazel test results and package them for junit_upload.
 
     Merges the test.xml files produced by the rules_go test runner (one per
@@ -111,11 +98,13 @@ def collect_junit(ctx, flavor, output_tgz, bep_file=None):
     """
     from tasks.libs.common.junit_upload_core import enrich_junitxml, produce_junit_tar
 
-    tl_dir = _get_testlogs_dir(ctx)
-
-    xml_files = [p for p in tl_dir.rglob("test.xml") if p.is_file()]
+    # BEP is the authoritative source: it lists exactly the test.xml files
+    # produced by this invocation, avoiding stale results from previous runs
+    # with a different Bazel configuration.
+    xml_paths, cache_status = _parse_bep(Path(bep_file))
+    xml_files = [p for p in xml_paths if p.is_file()]
     if not xml_files:
-        print(f"error: no test.xml files found under {tl_dir}", file=sys.stderr)
+        print("error: no test.xml files found in BEP output", file=sys.stderr)
         sys.exit(1)
 
     agent_flavor = AgentFlavor[flavor]
@@ -153,12 +142,8 @@ def collect_junit(ctx, flavor, output_tgz, bep_file=None):
 
         enrich_junitxml(str(merged_path), agent_flavor)
 
-        if bep_file:
-            bep_path = Path(bep_file)
-            if bep_path.is_file():
-                _annotate_junit_cache_status(merged_path, _parse_bep_cache_status(bep_path))
-            else:
-                print(f"warning: BEP file not found: {bep_file}", file=sys.stderr)
+        if cache_status:
+            _annotate_junit_cache_status(merged_path, cache_status)
 
         produce_junit_tar([str(merged_path)], output_tgz)
 

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from invoke import task
+
+from tasks.flavor import AgentFlavor
+from tasks.libs.common.color import color_message
+from tasks.libs.common.gomodules import AGENT_MODULE_PATH_PREFIX
+
+_IMPORT_PREFIX = AGENT_MODULE_PATH_PREFIX.rstrip("/")
+
+
+def _get_testlogs_dir(ctx) -> Path:
+    # `bazel info bazel-testlogs` does not account for configuration transitions,
+    # so locate the directory from output_path instead.
+    output_path = Path(ctx.run("bazel info output_path", hide=True).stdout.strip())
+    candidates = sorted(output_path.glob("*/testlogs"), key=lambda p: p.stat().st_mtime, reverse=True)
+    if not candidates:
+        raise RuntimeError(f"no testlogs directory found under {output_path}")
+    if len(candidates) > 1:
+        others = [str(c) for c in candidates[1:]]
+        print(
+            color_message("warning", "yellow")
+            + f": multiple testlogs directories found, using most recent: {candidates[0]}\n  others: {others}",
+            file=sys.stderr,
+        )
+    return candidates[0]
+
+
+@task
+def testlogs_dir(ctx):
+    """Print the absolute path to Bazel's testlogs directory."""
+    print(_get_testlogs_dir(ctx))
+
+
+@task(
+    help={
+        "flavor": f"Agent flavor ({', '.join(f.name for f in AgentFlavor)}). Embedded in each JUnit XML.",
+        "output_tgz": "Destination path for the output tgz (e.g. junit-bazel-base.tgz).",
+    },
+)
+def collect_junit(ctx, flavor, output_tgz):
+    """Collect Bazel test results and package them for junit_upload.
+
+    Merges the test.xml files produced by the rules_go test runner (one per
+    test target) into a single JUnit XML, then packages it into a tgz compatible
+    with the existing junit_upload machinery (same format as --junit-tar from
+    dda inv test).
+    """
+    from tasks.libs.common.junit_upload_core import enrich_junitxml, produce_junit_tar
+
+    tl_dir = _get_testlogs_dir(ctx)
+
+    xml_files = [p for p in tl_dir.rglob("test.xml") if p.is_file()]
+    if not xml_files:
+        print(f"error: no test.xml files found under {tl_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    agent_flavor = AgentFlavor[flavor]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        merged = ET.Element("testsuites")
+        collected = 0
+        for xml_path in xml_files:
+            try:
+                file_root = ET.parse(xml_path).getroot()
+            except ET.ParseError:
+                continue
+            suites = (
+                list(file_root)
+                if file_root.tag == "testsuites"
+                else [file_root]
+                if file_root.tag == "testsuite"
+                else []
+            )
+            for ts in suites:
+                if int(ts.get("tests", "0")) == 0:
+                    continue
+                merged.append(ts)
+                collected += 1
+
+        if collected == 0:
+            print(
+                f"error: no test suites found (all {len(xml_files)} test.xml files had 0 tests)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        merged_path = Path(tmpdir) / f"junit-bazel-{flavor}.xml"
+        ET.ElementTree(merged).write(str(merged_path), encoding="unicode")
+
+        enrich_junitxml(str(merged_path), agent_flavor)
+        produce_junit_tar([str(merged_path)], output_tgz)
+
+    print(f"Packaged {collected} test suites → {output_tgz}")

--- a/tasks/libs/common/junit_upload_core.py
+++ b/tasks/libs/common/junit_upload_core.py
@@ -167,6 +167,14 @@ def split_junitxml(root_dir: Path, xml_path: Path, codeowners, flaky_failures, m
     for suite in tree.iter("testsuite"):
         path = suite.attrib["name"].replace(REPO_NAME_PREFIX, "", 1)
 
+        bazel_cached = None
+        suite_props = suite.find("properties")
+        if suite_props is not None:
+            for prop in suite_props.findall("property"):
+                if prop.get("name") == "bazel.cached":
+                    bazel_cached = prop.get("value")
+                    break
+
         # Dirs in CODEOWNERS might end with "/", but testsuite names in JUnit XML
         # don't, so for determining ownership we append "/" temporarily.
         owners = codeowners.of(path + "/")
@@ -202,6 +210,8 @@ def split_junitxml(root_dir: Path, xml_path: Path, codeowners, flaky_failures, m
                 test_case.attrib["agent_is_marked_flaky"] = "true"
             else:
                 test_case.attrib["agent_is_marked_flaky"] = "false"
+            if bazel_cached:
+                test_case.attrib["bazel_cached"] = bazel_cached
 
         xml.getroot().append(suite)
 
@@ -311,6 +321,8 @@ def set_tags(owner, flavor, flag: str, additional_tags, file_name):
         "test.agent_is_flaky_failure=/testcase/@agent_is_flaky_failure",
         "--xpath-tag",
         "test.agent_is_marked_flaky=/testcase/@agent_is_marked_flaky",
+        "--xpath-tag",
+        "bazel.cached=/testcase/@bazel_cached",
     ]
     if 'e2e' in flag:
         tags.extend(["--tags", "e2e_internal_error:true"])

--- a/tasks/unit_tests/junit_tests.py
+++ b/tasks/unit_tests/junit_tests.py
@@ -76,7 +76,7 @@ class TestSetTag(unittest.TestCase):
     @patch.dict("os.environ", {"CI_PIPELINE_SOURCE": "putsch"})
     def test_default(self):
         tags = junit.set_tags("agent-devx", "base", "", {}, "")
-        self.assertEqual(len(tags), 18)
+        self.assertEqual(len(tags), 20)
         self.assertIn("slack_channel:agent-devx-ops", tags)
 
     @patch.dict("os.environ", {"CI_PIPELINE_ID": "1664"})
@@ -89,7 +89,7 @@ class TestSetTag(unittest.TestCase):
             ["upload_option.os_version_from_name"],
             "kitchen-rspec-win2016-azure-x86_64.xml",
         )
-        self.assertEqual(len(tags), 22)
+        self.assertEqual(len(tags), 24)
         self.assertIn("e2e_internal_error:true", tags)
         self.assertIn("version:win2016", tags)
         self.assertNotIn("upload_option.os_version_from_name", tags)
@@ -98,7 +98,7 @@ class TestSetTag(unittest.TestCase):
     @patch.dict("os.environ", {"CI_PIPELINE_SOURCE": "revolution"})
     def test_additional_tags(self):
         tags = junit.set_tags("agent-devx", "base", "", ["--tags", "simple:basique"], "")
-        self.assertEqual(len(tags), 20)
+        self.assertEqual(len(tags), 22)
         self.assertIn("simple:basique", tags)
 
     @patch.dict("os.environ", {"CI_PIPELINE_ID": "1789"})
@@ -107,7 +107,7 @@ class TestSetTag(unittest.TestCase):
         tags = junit.set_tags(
             "agent-devx", "base", "", junit.read_additional_tags(Path("tasks/unit_tests/testdata")), ""
         )
-        self.assertEqual(len(tags), 18)
+        self.assertEqual(len(tags), 20)
 
 
 class TestJUnitUploadFromTGZ(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?

Add junit tests results artifacts & upload it to CI Visibility from our bazel driven test jobs

### Motivation

Parity with existing go test jobs

https://datadoghq.atlassian.net/browse/ABLD-494

### Describe how you validated your changes

CI

### Additional Notes

Cache tests logs are fetched from the cache and sent to the DD app (so they are essentially duplicated) which might be considered unneeded noise/data waste
Cached tests are also flagged as such with a custom tag
