### PR TITLE
fix(bazel): isolate Python runs from ambient user env

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,8 +35,8 @@ common --repo_env=XDG_CACHE_HOME # https://wiki.archlinux.org/title/XDG_Base_Dir
 # Variables to override release.json values
 common --repo_env=INTEGRATIONS_CORE_VERSION
 common --repo_env=INTEGRATIONS_WHEELS_STORAGE
-
-common --run_env=GOTOOLCHAIN=local # Extend https://github.com/bazel-contrib/rules_go/pull/3660 to `bazel run //:go
+common --run_env=GOTOOLCHAIN=local # Extend https://github.com/bazel-contrib/rules_go/pull/3660 to `bazel run //:go`
+common --run_env=RULES_PYTHON_ADDITIONAL_INTERPRETER_ARGS=-I # Prevent user env, path, and site from shadowing runfiles
 common --skip_incompatible_explicit_targets # Let target_compatible_with skip rather than fail
 common --test_output=errors # Print test errors to console output instead of only capturing them in buried test.log
 common --verbose_failures


### PR DESCRIPTION
### What does this PR do?
Pass `-I`[^1] to the interpreter of every bazel-run `py_binary` through the [RULES_PYTHON_ADDITIONAL_INTERPRETER_ARGS](https://rules-python.readthedocs.io/en/latest/environment-variables.html#envvar-RULES_PYTHON_ADDITIONAL_INTERPRETER_ARGS) environment variable, set via `--run_env` in `.bazelrc`.

### Motivation
A developer's ambient `PYTHONPATH` broke `dda inv agent.build` at `bazel run //pkg/config/schema:install_compressed` [with](https://dd.slack.com/archives/C06PBHLD4DQ/p1782287160445529):
```
$ dda inv -e agent.build
[...]
bazel run //pkg/config/schema:install_compressed -- --destdir=/some/path
[...]
Target //pkg/config/schema:install_compressed up-to-date:
  bazel-bin/pkg/config/schema/install_compressed
  bazel-bin/pkg/config/schema/install_compressed_install_script.py
INFO: Running command line: bazel-bin/pkg/config/schema/install_compressed <args omitted>
Traceback (most recent call last):
  [...]
  File "/some/path/install_compressed.runfiles/_main/pkg/config/schema/install_compressed_install_script.py", line 29, in <module>
    from pkg.private import manifest
ModuleNotFoundError: No module named 'pkg.private'
```

Investigation revealed a leading `":"` in `PYTHONPATH` was injecting the current working directory (the repo root in that case), whose `pkg/` directory is then picked up as a [namespace package](https://peps.python.org/pep-0420/) and **shadows the runfiles** under `pkg/`, so `rules_pkg` could not import its own `pkg.private`.

`rules_python`'s script launcher only sets `PYTHONSAFEPATH`, which strips `sys.path[0]` but **still honors PYTHONPATH**, so the build was not hermetic with respect to the client environment:
https://github.com/bazel-contrib/rules_python/blob/2.0.3/python/private/stage1_bootstrap_template.sh#L263-L273

The fix therefore consists in leveraging `rules_python`'s own environment variable to bridge the gap:
https://github.com/bazel-contrib/rules_python/blob/2.0.3/python/private/stage1_bootstrap_template.sh#L280-L282

I filed the following issue to upstream:
- bazel-contrib/rules_python#3847.

### Describe how you validated your changes
Reproduced on Linux:
`PYTHONPATH=:/tmp bazel run //pkg/config/schema:install_compressed` used to fail on `ModuleNotFoundError` and it now exits 0.

### Additional Notes
[^1]: `-I` means [isolated mode](https://docs.python.org/3/using/cmdline.html#cmdoption-I) and implies `-E`, `-P` and `-s`, so user env, path and site can no longer shadow runfiles.
