### PR TITLE
[codex] Cache dda install dependencies

### DIFF
--- a/.github/actions/install-dda/action.yml
+++ b/.github/actions/install-dda/action.yml
@@ -21,8 +21,48 @@ runs:
       echo "version=${version}" >> $GITHUB_OUTPUT
     shell: bash
 
+  - name: Set cache key
+    id: cache-key
+    run: |-
+      version="${DDA_INPUT_VERSION:-${DDA_DEFAULT_VERSION}}"
+      features="${DDA_FEATURES:-base}"
+
+      features_key="$(printf '%s' "$features" | tr -cs '[:alnum:]._-+' '-')"
+      features_key="${features_key#-}"
+      features_key="${features_key%-}"
+
+      echo "version=${version}" >> "$GITHUB_OUTPUT"
+      echo "features=${features_key:-base}" >> "$GITHUB_OUTPUT"
+    shell: bash
+    env:
+      DDA_INPUT_VERSION: ${{ inputs.version }}
+      DDA_DEFAULT_VERSION: ${{ steps.set-version.outputs.version }}
+      DDA_FEATURES: ${{ inputs.features }}
+
+  - name: Restore dda cache
+    id: dda-cache
+    uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    with:
+      key: dda-${{ runner.os }}-${{ runner.arch }}-${{ steps.cache-key.outputs.version }}-${{ steps.cache-key.outputs.features }}
+      path: |
+        ~/.local/share/pyapp/dda
+        ~/.cache/dda
+        ~/.cache/pip
+        ~/.cache/uv
+        ${{ runner.tool_cache }}/.dda
+
+  - name: Install dda from cache
+    if: steps.dda-cache.outputs.cache-hit == 'true'
+    uses: DataDog/datadog-agent-dev@00e4a423088309efce1d5ba6b8c5366eef648710 # install
+    env:
+      UV_OFFLINE: "1"
+    with:
+      version: ${{ steps.cache-key.outputs.version }}
+      features: ${{ inputs.features }}
+
   - name: Install dda
+    if: steps.dda-cache.outputs.cache-hit != 'true'
     uses: DataDog/datadog-agent-dev@00e4a423088309efce1d5ba6b8c5366eef648710 # install
     with:
-      version: ${{ inputs.version || steps.set-version.outputs.version }}
+      version: ${{ steps.cache-key.outputs.version }}
       features: ${{ inputs.features }}

--- a/.github/actions/install-dda/action.yml
+++ b/.github/actions/install-dda/action.yml
@@ -52,7 +52,9 @@ runs:
         ${{ runner.tool_cache }}/.dda
 
   - name: Install dda from cache
+    id: install-from-cache
     if: steps.dda-cache.outputs.cache-hit == 'true'
+    continue-on-error: true
     uses: DataDog/datadog-agent-dev@00e4a423088309efce1d5ba6b8c5366eef648710 # install
     env:
       UV_OFFLINE: "1"
@@ -61,7 +63,7 @@ runs:
       features: ${{ inputs.features }}
 
   - name: Install dda
-    if: steps.dda-cache.outputs.cache-hit != 'true'
+    if: steps.dda-cache.outputs.cache-hit != 'true' || steps.install-from-cache.outcome != 'success'
     uses: DataDog/datadog-agent-dev@00e4a423088309efce1d5ba6b8c5366eef648710 # install
     with:
       version: ${{ steps.cache-key.outputs.version }}

--- a/.github/actions/install-dda/action.yml
+++ b/.github/actions/install-dda/action.yml
@@ -62,6 +62,15 @@ runs:
       version: ${{ steps.cache-key.outputs.version }}
       features: ${{ inputs.features }}
 
+  - name: Reset cached dda install
+    if: steps.dda-cache.outputs.cache-hit == 'true' && steps.install-from-cache.outcome != 'success'
+    run: |-
+      rm -rf "${HOME}/.local/share/pyapp/dda"
+      if [[ -n "${RUNNER_TOOL_CACHE:-}" ]]; then
+        rm -rf "${RUNNER_TOOL_CACHE}/.dda"
+      fi
+    shell: bash
+
   - name: Install dda
     if: steps.dda-cache.outputs.cache-hit != 'true' || steps.install-from-cache.outcome != 'success'
     uses: DataDog/datadog-agent-dev@00e4a423088309efce1d5ba6b8c5366eef648710 # install

--- a/.github/actions/install-dda/action.yml
+++ b/.github/actions/install-dda/action.yml
@@ -27,7 +27,7 @@ runs:
       version="${DDA_INPUT_VERSION:-${DDA_DEFAULT_VERSION}}"
       features="${DDA_FEATURES:-base}"
 
-      features_key="$(printf '%s' "$features" | tr -cs '[:alnum:]._-+' '-')"
+      features_key="$(printf '%s' "$features" | tr -cs '[:alnum:]._+-' '-')"
       features_key="${features_key#-}"
       features_key="${features_key%-}"
 


### PR DESCRIPTION
## What changed

This updates the shared `.github/actions/install-dda` composite action to restore a GitHub Actions cache before installing `dda`.

The cache is keyed by runner OS, runner architecture, resolved `dda` version, and requested feature set. It stores the hydrated PyApp runtime and Python dependency caches used during `dda self dep sync`:

- `~/.local/share/pyapp/dda`
- `~/.cache/dda`
- `~/.cache/pip`
- `~/.cache/uv`
- `${{ runner.tool_cache }}/.dda`

On an exact cache hit, the action runs the pinned `DataDog/datadog-agent-dev` installer with `UV_OFFLINE=1`. On a miss, it keeps the existing online install behavior and lets `actions/cache` save the warmed state after a successful job.

## Why

A recent `Install dda` failure hit repeated PyPI `503 Service Unavailable` responses while resolving `msgspec-click` during `dda self dep sync`. Retrying the installer helped only when PyPI recovered quickly; it did not protect jobs during a sustained package-index outage.

This makes warmed PR/scheduled jobs resilient to transient PyPI availability issues for the same `dda` version and feature set.

## Validation

- Parsed `.github/actions/install-dda/action.yml` with Ruby YAML loading.
- Checked the cache-key normalization shell snippet locally with `legacy-tasks legacy-github`.
- Ran `git diff --check`.

`actionlint` was not installed locally, so GitHub Actions syntax still needs CI validation.