### PR TITLE
fix(fleet/installer): correctly select and build the FIPS package variant

### DIFF
--- a/.gitlab/.ci-linters.yml
+++ b/.gitlab/.ci-linters.yml
@@ -86,6 +86,8 @@ job-owners:
     - installer-amd64-oci
     - installer-arm64
     - installer-arm64-oci
+    - installer-fips-amd64-oci
+    - installer-fips-arm64-oci
     - installer-install-scripts
     - integration_tests_otel
     - invoke_unit_tests

--- a/.gitlab/build/package_build/installer.yml
+++ b/.gitlab/build/package_build/installer.yml
@@ -162,7 +162,7 @@ installer-install-scripts:
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --target-project="installer" ${INSTALL_DIR_PARAM}
+    - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --target-project="installer" --flavor "${FLAVOR:-base}" ${INSTALL_DIR_PARAM}
     - ls -la $OMNIBUS_PACKAGE_DIR
     - !reference [.upload_sbom_artifacts]
   variables:
@@ -220,6 +220,56 @@ installer-arm64-oci:
   extends: installer-arm64
   variables:
     DESTINATION_FILE: "datadog-updater_7-arm64-oci.tar.xz"
+  before_script:
+    - AGENT_VERSION="$(dda inv agent.version -u)-1" || exit $?
+    - export INSTALL_DIR=/opt/datadog-packages/datadog-installer/"$AGENT_VERSION"
+    - export INSTALL_DIR_PARAM="--install-directory=$INSTALL_DIR"
+
+# FIPS flavor of the installer. Built with AGENT_FLAVOR=fips so the binary is
+# FIPS-built (BuiltForFIPS() == true); packaged as the "fips" variant of the
+# datadog-installer OCI image in .gitlab/build/packaging/oci.yml.
+
+.installer-fips-amd64:
+  extends: [.installer_build_common, .agent_fips_flavor]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
+  stage: package_build
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  tags: ["arch:amd64", "specific:true"]
+  needs: ["go_deps"]
+  variables:
+    PACKAGE_ARCH: amd64
+    DD_CC: "x86_64-unknown-linux-gnu-gcc"
+    DD_CXX: "x86_64-unknown-linux-gnu-g++"
+
+.installer-fips-arm64:
+  extends: [.installer_build_common, .agent_fips_flavor]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
+  stage: package_build
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  tags: ["arch:arm64", "specific:true"]
+  needs: ["go_deps"]
+  variables:
+    PACKAGE_ARCH: arm64
+    DD_CC: "aarch64-unknown-linux-gnu-gcc"
+    DD_CXX: "aarch64-unknown-linux-gnu-g++"
+
+installer-fips-amd64-oci:
+  extends: .installer-fips-amd64
+  variables:
+    DESTINATION_FILE: "datadog-fips-installer_7-amd64-oci.tar.xz"
+  before_script:
+    - AGENT_VERSION="$(dda inv agent.version -u)-1" || exit $?
+    - export INSTALL_DIR=/opt/datadog-packages/datadog-installer/"$AGENT_VERSION"
+    - export INSTALL_DIR_PARAM="--install-directory=$INSTALL_DIR"
+
+installer-fips-arm64-oci:
+  extends: .installer-fips-arm64
+  variables:
+    DESTINATION_FILE: "datadog-fips-installer_7-arm64-oci.tar.xz"
   before_script:
     - AGENT_VERSION="$(dda inv agent.version -u)-1" || exit $?
     - export INSTALL_DIR=/opt/datadog-packages/datadog-installer/"$AGENT_VERSION"

--- a/.gitlab/build/package_build/installer.yml
+++ b/.gitlab/build/package_build/installer.yml
@@ -177,15 +177,23 @@ installer-install-scripts:
 # We build a "regular" installer, meant to be packaged as deb/rpm, without a custom install path
 # and an artifact intended for OCI packaging, which has a custom install path
 
-installer-amd64:
-  extends: .installer_build_common
+.installer_linux_common:
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
   stage: package_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
+
+.installer_oci_common:
+  before_script:
+    - AGENT_VERSION="$(dda inv agent.version -u)-1" || exit $?
+    - export INSTALL_DIR=/opt/datadog-packages/datadog-installer/"$AGENT_VERSION"
+    - export INSTALL_DIR_PARAM="--install-directory=$INSTALL_DIR"
+
+installer-amd64:
+  extends: [.installer_build_common, .installer_linux_common]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     PACKAGE_ARCH: amd64
     DESTINATION_FILE: "datadog-installer_7-amd64.tar.xz"
@@ -193,25 +201,13 @@ installer-amd64:
     DD_CXX: "x86_64-unknown-linux-gnu-g++"
 
 installer-arm64:
-  extends: .installer_build_common
-  rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
-  stage: package_build
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  extends: [.installer_build_common, .installer_linux_common]
   tags: ["arch:arm64", "specific:true"]
-  needs: ["go_deps"]
   variables:
     PACKAGE_ARCH: arm64
     DESTINATION_FILE: "datadog-installer_7-arm64.tar.xz"
     DD_CC: "aarch64-unknown-linux-gnu-gcc"
     DD_CXX: "aarch64-unknown-linux-gnu-g++"
-
-.installer_oci_common:
-  before_script:
-    - AGENT_VERSION="$(dda inv agent.version -u)-1" || exit $?
-    - export INSTALL_DIR=/opt/datadog-packages/datadog-installer/"$AGENT_VERSION"
-    - export INSTALL_DIR_PARAM="--install-directory=$INSTALL_DIR"
 
 installer-amd64-oci:
   extends: [installer-amd64, .installer_oci_common]
@@ -228,28 +224,16 @@ installer-arm64-oci:
 # datadog-installer OCI image in .gitlab/build/packaging/oci.yml.
 
 .installer-fips-amd64:
-  extends: [.installer_build_common, .agent_fips_flavor]
-  rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
-  stage: package_build
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  extends: [.installer_build_common, .installer_linux_common, .agent_fips_flavor]
   tags: ["arch:amd64", "specific:true"]
-  needs: ["go_deps"]
   variables:
     PACKAGE_ARCH: amd64
     DD_CC: "x86_64-unknown-linux-gnu-gcc"
     DD_CXX: "x86_64-unknown-linux-gnu-g++"
 
 .installer-fips-arm64:
-  extends: [.installer_build_common, .agent_fips_flavor]
-  rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
-  stage: package_build
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  extends: [.installer_build_common, .installer_linux_common, .agent_fips_flavor]
   tags: ["arch:arm64", "specific:true"]
-  needs: ["go_deps"]
   variables:
     PACKAGE_ARCH: arm64
     DD_CC: "aarch64-unknown-linux-gnu-gcc"

--- a/.gitlab/build/package_build/installer.yml
+++ b/.gitlab/build/package_build/installer.yml
@@ -207,23 +207,21 @@ installer-arm64:
     DD_CC: "aarch64-unknown-linux-gnu-gcc"
     DD_CXX: "aarch64-unknown-linux-gnu-g++"
 
-installer-amd64-oci:
-  extends: installer-amd64
-  variables:
-    DESTINATION_FILE: "datadog-updater_7-amd64-oci.tar.xz"
+.installer_oci_common:
   before_script:
     - AGENT_VERSION="$(dda inv agent.version -u)-1" || exit $?
     - export INSTALL_DIR=/opt/datadog-packages/datadog-installer/"$AGENT_VERSION"
     - export INSTALL_DIR_PARAM="--install-directory=$INSTALL_DIR"
 
+installer-amd64-oci:
+  extends: [installer-amd64, .installer_oci_common]
+  variables:
+    DESTINATION_FILE: "datadog-updater_7-amd64-oci.tar.xz"
+
 installer-arm64-oci:
-  extends: installer-arm64
+  extends: [installer-arm64, .installer_oci_common]
   variables:
     DESTINATION_FILE: "datadog-updater_7-arm64-oci.tar.xz"
-  before_script:
-    - AGENT_VERSION="$(dda inv agent.version -u)-1" || exit $?
-    - export INSTALL_DIR=/opt/datadog-packages/datadog-installer/"$AGENT_VERSION"
-    - export INSTALL_DIR_PARAM="--install-directory=$INSTALL_DIR"
 
 # FIPS flavor of the installer. Built with AGENT_FLAVOR=fips so the binary is
 # FIPS-built (BuiltForFIPS() == true); packaged as the "fips" variant of the
@@ -258,19 +256,11 @@ installer-arm64-oci:
     DD_CXX: "aarch64-unknown-linux-gnu-g++"
 
 installer-fips-amd64-oci:
-  extends: .installer-fips-amd64
+  extends: [.installer-fips-amd64, .installer_oci_common]
   variables:
     DESTINATION_FILE: "datadog-fips-installer_7-amd64-oci.tar.xz"
-  before_script:
-    - AGENT_VERSION="$(dda inv agent.version -u)-1" || exit $?
-    - export INSTALL_DIR=/opt/datadog-packages/datadog-installer/"$AGENT_VERSION"
-    - export INSTALL_DIR_PARAM="--install-directory=$INSTALL_DIR"
 
 installer-fips-arm64-oci:
-  extends: .installer-fips-arm64
+  extends: [.installer-fips-arm64, .installer_oci_common]
   variables:
     DESTINATION_FILE: "datadog-fips-installer_7-arm64-oci.tar.xz"
-  before_script:
-    - AGENT_VERSION="$(dda inv agent.version -u)-1" || exit $?
-    - export INSTALL_DIR=/opt/datadog-packages/datadog-installer/"$AGENT_VERSION"
-    - export INSTALL_DIR_PARAM="--install-directory=$INSTALL_DIR"

--- a/.gitlab/build/packaging/oci.yml
+++ b/.gitlab/build/packaging/oci.yml
@@ -64,7 +64,10 @@
           INPUT_FILE=$(resolve_artifact "${OCI_PRODUCT}" "${OMNIBUS_PACKAGE_DIR}${OCI_PRODUCT}-*${ARCH}.tar.xz") || exit 1
         fi
         OUTPUT_FILE="$(basename -a -s .xz ${INPUT_FILE})"
-        MERGED_FILE=$(basename -a $OMNIBUS_PACKAGE_DIR/*.tar.xz | head -n 1 | sed "s/-${ARCH}.tar.xz//").oci.tar
+        # Derive the merged name from the resolved base artifact (INPUT_FILE) rather than the
+        # first *.tar.xz in the dir: the FIPS variant (e.g. datadog-fips-installer-*) sorts before
+        # the base product (datadog-installer-*) and would otherwise mislabel the merged image.
+        MERGED_FILE=$(basename "${INPUT_FILE}" | sed "s/-${ARCH}.tar.xz//").oci.tar
         export MERGED_FILE
         INPUT_DIR="/tmp/input_${ARCH}"
         mkdir -p ${INPUT_DIR}
@@ -122,7 +125,11 @@
           mkdir -p ${FIPS_INPUT_DIR}
           echo "Extracting FIPS agent ${FIPS_INPUT_FILE} -> ${FIPS_INPUT_DIR}"
           tar xJf ${FIPS_INPUT_FILE} -C ${FIPS_INPUT_DIR}
-          FIPS_EXTRA_FLAGS="--configs ${FIPS_INPUT_DIR}/etc/datadog-agent --installer ${INSTALLER_INPUT_DIR}/opt/datadog-packages/datadog-installer/${PACKAGE_VERSION}/bin/installer/installer --extension ddot=${DDOT_FIPS_EXTENSION_DIR}"
+          # Use the FIPS-built installer shipped inside the FIPS agent tarball (omnibus builds it with
+          # --fips-mode and places it at embedded/bin/installer), not the non-FIPS datadog-installer
+          # package. Otherwise the FIPS index would embed a non-FIPS installer and bootstrap would not
+          # self-detect FIPS mode.
+          FIPS_EXTRA_FLAGS="--configs ${FIPS_INPUT_DIR}/etc/datadog-agent --installer ${FIPS_INPUT_DIR}/${INSTALL_DIR}/embedded/bin/installer --extension ddot=${DDOT_FIPS_EXTENSION_DIR}"
           echo "Creating FIPS OCI layer -> ${OUTPUT_DIR}/${FIPS_OUTPUT_FILE}"
           datadog-package create \
             --version ${PACKAGE_VERSION} \
@@ -134,6 +141,31 @@
             ${FIPS_EXTRA_FLAGS} \
             ${FIPS_INPUT_DIR}/${INSTALL_DIR}/
           rm -f ${FIPS_INPUT_FILE}
+        fi
+
+        # Build the FIPS-flavored variant of the standalone installer into the
+        # same OCI index. Selected by Platform.Variant="fips" when the daemon
+        # bootstraps the installer in FIPS mode. See downloadIndex() in
+        # pkg/fleet/installer/oci/download.go.
+        if [ "${OCI_PRODUCT}" = "datadog-installer" ]; then
+          FIPS_INSTALLER_INPUT_FILE=$(resolve_artifact "FIPS installer" "${OMNIBUS_PACKAGE_DIR}datadog-fips-installer-*${ARCH}.tar.xz") || exit 1
+          FIPS_INSTALLER_OUTPUT_FILE="$(basename -a -s .xz ${FIPS_INSTALLER_INPUT_FILE})"
+          FIPS_INSTALLER_INPUT_DIR="/tmp/input_fips_installer_${ARCH}"
+          mkdir -p ${FIPS_INSTALLER_INPUT_DIR}
+          echo "Extracting FIPS installer ${FIPS_INSTALLER_INPUT_FILE} -> ${FIPS_INSTALLER_INPUT_DIR}"
+          tar xJf ${FIPS_INSTALLER_INPUT_FILE} -C ${FIPS_INSTALLER_INPUT_DIR}
+          FIPS_EXTRA_FLAGS="--installer ${FIPS_INSTALLER_INPUT_DIR}/${INSTALL_DIR}/bin/installer/installer"
+          echo "Creating FIPS OCI layer -> ${OUTPUT_DIR}/${FIPS_INSTALLER_OUTPUT_FILE}"
+          datadog-package create \
+            --version ${PACKAGE_VERSION} \
+            --package ${OCI_PRODUCT} \
+            --os linux \
+            --arch ${ARCH} \
+            --variant fips \
+            --archive --archive-path "${OUTPUT_DIR}/${FIPS_INSTALLER_OUTPUT_FILE}" \
+            ${FIPS_EXTRA_FLAGS} \
+            ${FIPS_INSTALLER_INPUT_DIR}/${INSTALL_DIR}/
+          rm -f ${FIPS_INSTALLER_INPUT_FILE}
         fi
 
         rm -f ${INPUT_FILE}
@@ -175,6 +207,8 @@ installer_oci:
     [
       "installer-arm64-oci",
       "installer-amd64-oci",
+      "installer-fips-arm64-oci",
+      "installer-fips-amd64-oci",
       "go_tools_deps",
     ]
   variables:

--- a/.gitlab/build/packaging/oci.yml
+++ b/.gitlab/build/packaging/oci.yml
@@ -64,9 +64,6 @@
           INPUT_FILE=$(resolve_artifact "${OCI_PRODUCT}" "${OMNIBUS_PACKAGE_DIR}${OCI_PRODUCT}-*${ARCH}.tar.xz") || exit 1
         fi
         OUTPUT_FILE="$(basename -a -s .xz ${INPUT_FILE})"
-        # Derive the merged name from the resolved base artifact (INPUT_FILE) rather than the
-        # first *.tar.xz in the dir: the FIPS variant (e.g. datadog-fips-installer-*) sorts before
-        # the base product (datadog-installer-*) and would otherwise mislabel the merged image.
         MERGED_FILE=$(basename "${INPUT_FILE}" | sed "s/-${ARCH}.tar.xz//").oci.tar
         export MERGED_FILE
         INPUT_DIR="/tmp/input_${ARCH}"
@@ -114,22 +111,23 @@
           ${EXTRA_FLAGS} \
           ${INPUT_DIR}/${INSTALL_DIR}/
 
-        # Build the FIPS-flavored variant of the agent into the same OCI index.
-        # Distinguished from the base manifest by Platform.Variant="fips" — the
-        # installer requests this variant when DD_FIPS_MODE=true. See
-        # downloadIndex() in pkg/fleet/installer/oci/download.go.
+        # Build the FIPS-flavored variant (Platform.Variant="fips") into the same OCI index.
+        # The installer selects this variant when DD_FIPS_MODE=true.
         if [ "${OCI_PRODUCT}" = "datadog-agent" ]; then
           FIPS_INPUT_FILE=$(resolve_artifact "FIPS agent" "${OMNIBUS_PACKAGE_DIR}datadog-fips-agent-*${ARCH}.tar.xz" "ddot") || exit 1
-          FIPS_OUTPUT_FILE="$(basename -a -s .xz ${FIPS_INPUT_FILE})"
           FIPS_INPUT_DIR="/tmp/input_fips_${ARCH}"
-          mkdir -p ${FIPS_INPUT_DIR}
-          echo "Extracting FIPS agent ${FIPS_INPUT_FILE} -> ${FIPS_INPUT_DIR}"
-          tar xJf ${FIPS_INPUT_FILE} -C ${FIPS_INPUT_DIR}
-          # Use the FIPS-built installer shipped inside the FIPS agent tarball (omnibus builds it with
-          # --fips-mode and places it at embedded/bin/installer), not the non-FIPS datadog-installer
-          # package. Otherwise the FIPS index would embed a non-FIPS installer and bootstrap would not
-          # self-detect FIPS mode.
           FIPS_EXTRA_FLAGS="--configs ${FIPS_INPUT_DIR}/etc/datadog-agent --installer ${FIPS_INPUT_DIR}/${INSTALL_DIR}/embedded/bin/installer --extension ddot=${DDOT_FIPS_EXTENSION_DIR}"
+        fi
+        if [ "${OCI_PRODUCT}" = "datadog-installer" ]; then
+          FIPS_INPUT_FILE=$(resolve_artifact "FIPS installer" "${OMNIBUS_PACKAGE_DIR}datadog-fips-installer-*${ARCH}.tar.xz") || exit 1
+          FIPS_INPUT_DIR="/tmp/input_fips_installer_${ARCH}"
+          FIPS_EXTRA_FLAGS="--installer ${FIPS_INPUT_DIR}/${INSTALL_DIR}/bin/installer/installer"
+        fi
+        if [ -n "${FIPS_INPUT_FILE:-}" ]; then
+          FIPS_OUTPUT_FILE="$(basename -a -s .xz ${FIPS_INPUT_FILE})"
+          mkdir -p ${FIPS_INPUT_DIR}
+          echo "Extracting FIPS ${FIPS_INPUT_FILE} -> ${FIPS_INPUT_DIR}"
+          tar xJf ${FIPS_INPUT_FILE} -C ${FIPS_INPUT_DIR}
           echo "Creating FIPS OCI layer -> ${OUTPUT_DIR}/${FIPS_OUTPUT_FILE}"
           datadog-package create \
             --version ${PACKAGE_VERSION} \
@@ -141,31 +139,6 @@
             ${FIPS_EXTRA_FLAGS} \
             ${FIPS_INPUT_DIR}/${INSTALL_DIR}/
           rm -f ${FIPS_INPUT_FILE}
-        fi
-
-        # Build the FIPS-flavored variant of the standalone installer into the
-        # same OCI index. Selected by Platform.Variant="fips" when the daemon
-        # bootstraps the installer in FIPS mode. See downloadIndex() in
-        # pkg/fleet/installer/oci/download.go.
-        if [ "${OCI_PRODUCT}" = "datadog-installer" ]; then
-          FIPS_INSTALLER_INPUT_FILE=$(resolve_artifact "FIPS installer" "${OMNIBUS_PACKAGE_DIR}datadog-fips-installer-*${ARCH}.tar.xz") || exit 1
-          FIPS_INSTALLER_OUTPUT_FILE="$(basename -a -s .xz ${FIPS_INSTALLER_INPUT_FILE})"
-          FIPS_INSTALLER_INPUT_DIR="/tmp/input_fips_installer_${ARCH}"
-          mkdir -p ${FIPS_INSTALLER_INPUT_DIR}
-          echo "Extracting FIPS installer ${FIPS_INSTALLER_INPUT_FILE} -> ${FIPS_INSTALLER_INPUT_DIR}"
-          tar xJf ${FIPS_INSTALLER_INPUT_FILE} -C ${FIPS_INSTALLER_INPUT_DIR}
-          FIPS_EXTRA_FLAGS="--installer ${FIPS_INSTALLER_INPUT_DIR}/${INSTALL_DIR}/bin/installer/installer"
-          echo "Creating FIPS OCI layer -> ${OUTPUT_DIR}/${FIPS_INSTALLER_OUTPUT_FILE}"
-          datadog-package create \
-            --version ${PACKAGE_VERSION} \
-            --package ${OCI_PRODUCT} \
-            --os linux \
-            --arch ${ARCH} \
-            --variant fips \
-            --archive --archive-path "${OUTPUT_DIR}/${FIPS_INSTALLER_OUTPUT_FILE}" \
-            ${FIPS_EXTRA_FLAGS} \
-            ${FIPS_INSTALLER_INPUT_DIR}/${INSTALL_DIR}/
-          rm -f ${FIPS_INSTALLER_INPUT_FILE}
         fi
 
         rm -f ${INPUT_FILE}

--- a/deps/openssl_fips/fipsinstall.sh
+++ b/deps/openssl_fips/fipsinstall.sh
@@ -4,28 +4,37 @@
 # "The Module shall have the self-tests run, and the Module config file output generated on each
 # platform where it is intended to be used. The Module config file output data shall not be copied from
 # one machine to another."
-# This script aims to run self-tests and generate `fipsmodule.cnf.`
-# Because the provided `openssl.cnf` references to `fipsmodule.cnf` which is not yet created, we first create it
-# as `openssl.cnf.tmp` and then move it to its final name `openssl.cnf` when `fipsmodule.cnf` has been created
+# This script aims to run self-tests and generate `fipsmodule.cnf`.
+# Because the provided `openssl.cnf` references `fipsmodule.cnf` which is not yet created, we first create it
+# then move `openssl.cnf.tmp` to its final name `openssl.cnf`. The .include path is also rewritten to the
+# physical on-disk location so it remains valid if the tree is relocated (OCI installs place the tree at a
+# per-version path that differs from the build-time path).
 
 set -euo pipefail
 
-INSTALL_DIR="{{install_dir}}"
+# Resolve the physical path so .include in openssl.cnf points at the actual
+# directory, not a symlink that may be retargeted later (e.g. experiment/ → stable/).
+INSTALL_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")"
 
 FIPS_MODULE_PATH="${INSTALL_DIR}/ssl/fipsmodule.cnf"
 OPENSSL_CONF_PATH="${INSTALL_DIR}/ssl/openssl.cnf"
-
 FIPS_SO_PATH="${INSTALL_DIR}/lib/ossl-modules/fips.so"
 OPENSSL_BIN="${INSTALL_DIR}/bin/openssl"
-
 
 if [ -f "${FIPS_MODULE_PATH}" ]; then
     rm "${FIPS_MODULE_PATH}"
 fi
-
 "${OPENSSL_BIN}" fipsinstall -module "${FIPS_SO_PATH}" -out "${FIPS_MODULE_PATH}"
+
+# Activate openssl.cnf and fix its .include to the physical fipsmodule.cnf path.
 mv "${OPENSSL_CONF_PATH}.tmp" "${OPENSSL_CONF_PATH}"
+sed -i "s#^\.include .*/fipsmodule\.cnf#.include ${FIPS_MODULE_PATH}#" "${OPENSSL_CONF_PATH}"
+if ! grep -qF ".include ${FIPS_MODULE_PATH}" "${OPENSSL_CONF_PATH}"; then
+    echo "fipsinstall: failed to update .include path in ${OPENSSL_CONF_PATH}"
+    exit 1
+fi
 
 if ! "${OPENSSL_BIN}" fipsinstall -module "${FIPS_SO_PATH}" -in "${FIPS_MODULE_PATH}" -verify; then
     echo "openssl fipsinstall: verification of FIPS compliance failed. $INSTALL_DIR/fipsmodule.cnf was corrupted or the installation failed."
+    exit 1
 fi

--- a/omnibus/config/projects/installer.rb
+++ b/omnibus/config/projects/installer.rb
@@ -4,8 +4,15 @@
 # Copyright 2016-present Datadog, Inc.
 require "./lib/ostools.rb"
 
-name 'installer'
-package_name 'datadog-installer'
+flavor = ENV['AGENT_FLAVOR']
+
+if flavor.nil? || flavor == 'base'
+  name 'installer'
+  package_name 'datadog-installer'
+else
+  name "installer-#{flavor}"
+  package_name "datadog-#{flavor}-installer"
+end
 license "Apache-2.0"
 license_file "../LICENSE"
 

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -170,6 +170,25 @@ build do
             if install_dir.include?("/opt/datadog-packages")
               # The healthcheck will fail as the rpath doesn't contain install_dir
               command "inv omnibus.rpath-edit #{install_dir} #{install_dir}", cwd: Dir.pwd
+
+              # The FIPS daemon has CapabilityBoundingSet=all in its systemd unit. This causes
+              # the kernel to set AT_SECURE when it exec's the installer.layer bootstrap binary,
+              # which makes the dynamic linker drop all $ORIGIN-based RPATH entries. Since
+              # rpath-edit above just converted every RPATH to $ORIGIN-relative, the binary
+              # would fall through to the system libcrypto (wrong version) and panic.
+              #
+              # Fix: add an absolute RPATH entry after rpath-edit. Absolute entries are always
+              # honoured under AT_SECURE. /opt/datadog-agent/embedded/lib is version-independent:
+              # it is the deb install path on deb hosts and a symlink to the current stable OCI
+              # tree on OCI-managed hosts.
+              if fips_mode?
+                installer_bin = "#{install_dir}/embedded/bin/installer"
+                if File.exist?(installer_bin)
+                  embedded_lib = "/opt/datadog-agent/embedded/lib"
+                  command "patchelf --add-rpath #{embedded_lib} #{installer_bin}"
+                  command "patchelf --print-rpath #{installer_bin} | grep -qF '#{embedded_lib}' || (echo 'ERROR: patchelf --add-rpath did not add #{embedded_lib} to #{installer_bin}' && exit 1)"
+                end
+              end
             end
         end
 

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -4,6 +4,7 @@
 # Copyright 2016-present Datadog, Inc.
 
 require './lib/ostools.rb'
+require './lib/fips.rb'
 require 'pathname'
 
 name 'installer'
@@ -39,12 +40,24 @@ build do
     env["GOMODCACHE"] = gomodcache.to_path
   end
 
+  fips_args = fips_mode? ? "--fips-mode" : ""
+  if fips_mode?
+    add_msgo_to_env(env)
+  end
+
   bazel_flags = "--//:install_dir=#{install_dir}"
 
   if linux_target?
-    command "invoke installer.build --no-cgo --run-path=/opt/datadog-packages/run --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
+    command "invoke installer.build #{fips_args} --no-cgo --run-path=/opt/datadog-packages/run --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     mkdir "#{install_dir}/bin"
     copy 'bin/installer', "#{install_dir}/bin/"
+
+    if fips_mode?
+      # Verify FIPS build tags took effect (build succeeding is not sufficient). See lib/fips.rb.
+      block do
+        fips_check_binary_for_expected_symbol(File.join(install_dir, "bin", "installer", "installer"))
+      end
+    end
 
     # Build both packages and dump them where gitlab will upload them.
     command "bazel build #{bazel_flags} //packages/installer/linux:whole_distro_tar_deb", env: env, :live_stream => Omnibus.logger.live_stream(:info)
@@ -66,7 +79,7 @@ build do
         :live_stream => Omnibus.logger.live_stream(:info)
     end
   elsif windows_target?
-    command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
+    command "dda inv -- -e installer.build #{fips_args} --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     copy 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"
     copy 'bin/installer/installer.exe.pdb', "#{install_dir}/datadog-installer.exe.pdb"
   end

--- a/pkg/fips/BUILD.bazel
+++ b/pkg/fips/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "fips.go",
         "fips_buildinfo.go",
+        "fips_buildinfo_disabled.go",
         "fips_disabled.go",
         "fips_goboring.go",
     ],

--- a/pkg/fips/BUILD.bazel
+++ b/pkg/fips/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "fips",
     srcs = [
         "fips.go",
+        "fips_buildinfo.go",
         "fips_disabled.go",
         "fips_goboring.go",
     ],

--- a/pkg/fips/fips_buildinfo.go
+++ b/pkg/fips/fips_buildinfo.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package fips
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// BuiltForFIPS reports whether this binary was built as the FIPS flavor.
+// It reads the embedded build info to detect requirefips or goexperiment.systemcrypto
+// build tags, which is authoritative regardless of how the Go toolchain was invoked.
+// This replaces the previous build-tag-constrained approach which was unreliable on
+// some deb builds where goexperiment.systemcrypto was not recognized as a build tag
+// even though requirefips was set.
+func BuiltForFIPS() bool {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return false
+	}
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "-tags":
+			for _, tag := range strings.Split(s.Value, ",") {
+				tag = strings.TrimSpace(tag)
+				if tag == "requirefips" || tag == "goexperiment.systemcrypto" {
+					return true
+				}
+			}
+		case "GOEXPERIMENT":
+			for _, exp := range strings.Split(s.Value, ",") {
+				if strings.TrimSpace(exp) == "systemcrypto" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/pkg/fips/fips_buildinfo.go
+++ b/pkg/fips/fips_buildinfo.go
@@ -3,40 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build goexperiment.systemcrypto || goexperiment.boringcrypto || requirefips
+
 package fips
 
-import (
-	"runtime/debug"
-	"strings"
-)
-
 // BuiltForFIPS reports whether this binary was built as the FIPS flavor.
-// It reads the embedded build info to detect requirefips or goexperiment.systemcrypto
-// build tags, which is authoritative regardless of how the Go toolchain was invoked.
-// This replaces the previous build-tag-constrained approach which was unreliable on
-// some deb builds where goexperiment.systemcrypto was not recognized as a build tag
-// even though requirefips was set.
-func BuiltForFIPS() bool {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return false
-	}
-	for _, s := range info.Settings {
-		switch s.Key {
-		case "-tags":
-			for _, tag := range strings.Split(s.Value, ",") {
-				tag = strings.TrimSpace(tag)
-				if tag == "requirefips" || tag == "goexperiment.systemcrypto" {
-					return true
-				}
-			}
-		case "GOEXPERIMENT":
-			for _, exp := range strings.Split(s.Value, ",") {
-				if strings.TrimSpace(exp) == "systemcrypto" {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
+func BuiltForFIPS() bool { return true }

--- a/pkg/fips/fips_buildinfo_disabled.go
+++ b/pkg/fips/fips_buildinfo_disabled.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !goexperiment.systemcrypto && !goexperiment.boringcrypto && !requirefips
+
+package fips
+
+// BuiltForFIPS reports whether this binary was built as the FIPS flavor.
+func BuiltForFIPS() bool { return false }

--- a/pkg/fleet/daemon/BUILD.bazel
+++ b/pkg/fleet/daemon/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/api/middleware",
         "//pkg/config/remote/client",
         "//pkg/config/utils",
+        "//pkg/fips",
         "//pkg/fleet/installer",
         "//pkg/fleet/installer/bootstrap",
         "//pkg/fleet/installer/config",

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	agentconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	pkgfips "github.com/DataDog/datadog-agent/pkg/fips"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/bootstrap"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/config"
@@ -151,6 +153,9 @@ func NewDaemon(hostname string, rcFetcher client.ConfigFetcher, config agentconf
 		IsCentos6:            env.DetectCentos6(),
 		IsFromDaemon:         true,
 		ConfigID:             configID,
+		// The daemon builds its env by hand rather than via env.FromEnv, so mirror
+		// the same FIPS detection: FIPS build flavor or explicit DD_FIPS_MODE=true.
+		FIPSMode: pkgfips.BuiltForFIPS() || strings.ToLower(os.Getenv("DD_FIPS_MODE")) == "true",
 	}
 	installer := newInstaller(installerBin)
 	refreshInterval := config.GetDuration("installer.refresh_interval")

--- a/pkg/fleet/installer/env/env.go
+++ b/pkg/fleet/installer/env/env.go
@@ -285,12 +285,6 @@ func FromEnv() *Env {
 	splitFunc := func(c rune) bool {
 		return c == ','
 	}
-	// thisBinaryIsFips is true when the installer is running as the FIPS-compiled agent binary
-	// (embedded/bin/installer is a symlink to the agent binary in DEB/RPM packages).
-	thisBinaryIsFips, _ := pkgfips.Enabled()
-	// fipsIsRequested is true when the caller explicitly sets DD_FIPS_MODE=true,
-	// which is the signal used by the fleet OCI install path.
-	fipsIsRequested := strings.ToLower(os.Getenv(envFIPSMode)) == "true"
 
 	return &Env{
 		APIKey:                getEnvOrDefault(envAPIKey, defaultEnv.APIKey),
@@ -362,7 +356,7 @@ func FromEnv() *Env {
 
 		IsCentos6:    DetectCentos6(),
 		IsFromDaemon: os.Getenv(envIsFromDaemon) == "true",
-		FIPSMode:     fipsIsRequested || thisBinaryIsFips,
+		FIPSMode:     pkgfips.BuiltForFIPS() || strings.ToLower(os.Getenv(envFIPSMode)) == "true",
 	}
 }
 

--- a/pkg/fleet/installer/env/env_test.go
+++ b/pkg/fleet/installer/env/env_test.go
@@ -344,8 +344,7 @@ func TestToEnv(t *testing.T) {
 }
 
 func TestFromEnvFIPSMode(t *testing.T) {
-	thisBinaryIsFips, _ := pkgfips.Enabled()
-	if thisBinaryIsFips {
+	if pkgfips.BuiltForFIPS() {
 		t.Skip("DD_FIPS_MODE env var is irrelevant when the binary itself is FIPS-compiled")
 	}
 	tests := []struct {

--- a/pkg/fleet/installer/packages/packages.go
+++ b/pkg/fleet/installer/packages/packages.go
@@ -231,6 +231,46 @@ func (h *hooksCLI) extensionPackageType(pkg string) PackageType {
 	return PackageTypeDEB
 }
 
+// ensureAgentFIPSProvider runs fipsinstall.sh for the package tree at pkgPath so that
+// requirefips binaries can start. The deb/rpm postinst handles this; the OCI flow does not,
+// so we do it here before re-exec'ing into the tree's installer.
+// No-op for non-FIPS packages (no fipsinstall.sh) and for already-configured trees
+// (openssl.cnf.tmp consumed). Returns an error if the tree looks partially configured.
+func ensureAgentFIPSProvider(ctx context.Context, pkgPath string) (err error) {
+	span, ctx := telemetry.StartSpanFromContext(ctx, "ensure_fips_provider")
+	defer func() { span.Finish(err) }()
+
+	scriptPath := filepath.Join(pkgPath, "embedded", "bin", "fipsinstall.sh")
+	if info, statErr := os.Stat(scriptPath); statErr != nil || info.Mode()&0o111 == 0 {
+		return nil // not a FIPS package, or the script is not executable
+	}
+	if _, statErr := os.Stat(filepath.Join(pkgPath, "embedded", "ssl", "openssl.cnf.tmp")); statErr != nil {
+		// .tmp already consumed; verify fipsmodule.cnf also exists
+		if _, modErr := os.Stat(filepath.Join(pkgPath, "embedded", "ssl", "fipsmodule.cnf")); modErr == nil {
+			return nil // fully configured
+		}
+		return fmt.Errorf("fipsinstall incomplete: openssl.cnf.tmp consumed but fipsmodule.cnf missing at %s; re-installation required", pkgPath)
+	}
+
+	cmd := telemetry.CommandContext(ctx, scriptPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// Clear inherited OPENSSL env so fipsinstall uses the target tree's binaries
+	// without contamination from the running process's embedded FIPS provider.
+	cleanEnv := make([]string, 0, len(os.Environ()))
+	for _, e := range os.Environ() {
+		k, _, _ := strings.Cut(e, "=")
+		if k != "OPENSSL_CONF" && k != "OPENSSL_MODULES" && k != "LD_LIBRARY_PATH" {
+			cleanEnv = append(cleanEnv, e)
+		}
+	}
+	cmd.Env = cleanEnv
+	if err = cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run fipsinstall.sh: %w", err)
+	}
+	return nil
+}
+
 func (h *hooksCLI) callHook(ctx context.Context, experiment bool, pkg string, name string, packageType PackageType, upgrade bool, windowsArgs []string, extension string) error {
 	hooksCLIPath, err := exec.GetExecutable()
 	if err != nil {
@@ -253,6 +293,10 @@ func (h *hooksCLI) callHook(ctx context.Context, experiment bool, pkg string, na
 		}
 		if !os.IsNotExist(err) {
 			hooksCLIPath = agentInstallerPath
+			// Run fipsinstall.sh before re-exec so requirefips binaries can start.
+			if err := ensureAgentFIPSProvider(ctx, pkgPath); err != nil {
+				return fmt.Errorf("failed to configure FIPS provider for %s: %w", pkgPath, err)
+			}
 		}
 	}
 	hookCtx := HookContext{

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -265,8 +265,8 @@ def build(
     if not target_project:
         target_project = "agent"
 
-    if flavor != AgentFlavor.base and target_project not in ["agent", "ddot"]:
-        print("flavors only make sense when building the agent or ddot")
+    if flavor != AgentFlavor.base and target_project not in ["agent", "ddot", "installer"]:
+        print("flavors only make sense when building the agent, ddot or installer")
         raise Exit(code=1)
     if flavor.is_iot():
         target_project = "iot-agent"


### PR DESCRIPTION
## Intent

A `datadog-fips-agent` host running `start-experiment` would silently pull and run a **non-FIPS** package unless `DD_FIPS_MODE=true` was set by hand. Investigation found several independent breakages in the FIPS package-selection path:

| # | Component | Root cause | Example failure | Fix |
|---|-----------|-----------|----------------|-----|
| 1 | **Build-flavor detection** (`env.FromEnv`) | The code asked "is FIPS crypto currently active in this process?" (`pkg/fips.Enabled()`) instead of "was this binary *compiled* as a FIPS build?" — two different questions. The installer spawns short-lived child processes that haven't initialized the crypto backend yet, so they always answer "no" and pull non-FIPS packages. | `start-experiment` on a `datadog-fips-agent` host downloads the non-FIPS agent variant unless `DD_FIPS_MODE=true` is set manually. | New `pkg/fips.BuiltForFIPS()` reads the binary's embedded build metadata to check for the `requirefips`/`goexperiment.systemcrypto` compile-time flags — a reliable answer regardless of runtime state. |
| 2 | **Daemon env** (`NewDaemon`) | The long-running installer daemon builds its own configuration object from scratch rather than going through the shared `env.FromEnv()` path, so `FIPSMode` was simply never set — even if the binary was a FIPS build. | Even with fix #1 applied, the daemon's OCI download still picked the non-FIPS agent variant because its internal config always had `FIPSMode=false`. | `NewDaemon` now sets `FIPSMode: pkgfips.BuiltForFIPS() || DD_FIPS_MODE=="true"`, matching `FromEnv` exactly. A FIPS-flavor daemon now automatically operates in FIPS mode without any env override. |
| 3 | **FIPS provider setup** (OCI flow) | FIPS-compiled binaries require a one-time per-machine self-test of the OpenSSL FIPS module (`fipsinstall.sh`) before they can run. DEB/RPM packages run this in their post-install script; the OCI code path skipped it entirely. | After downloading the experiment via OCI, the new agent binary panics immediately on startup: `panic: opensslcrypto: FIPS mode requested but not available`. | New `ensureAgentFIPSProvider()` runs `fipsinstall.sh` before re-exec'ing into the agent. Also hardened: clears inherited `OPENSSL_*` env before running the script to prevent cross-tree contamination, and fails explicitly when the previous run left the tree in a partial state. |
| 4 | **Library loading under privilege restriction** (installer.layer bootstrap) | The daemon's systemd unit has `CapabilityBoundingSet=all`. When it exec's the bootstrap installer binary, the kernel sets `AT_SECURE`, causing the dynamic linker to silently drop all `\$ORIGIN`-relative RPATH entries. The build system had just converted every RPATH to `\$ORIGIN`-relative, so the binary loaded the host's system libcrypto (wrong version) and panicked. | `start-experiment` fails with `panic: opensslcrypto: FIPS mode requested… OpenSSL 3.5.6` — the system OpenSSL (3.5.6) is loaded instead of the bundled one (3.5.7), and the FIPS module refuses to run. | `patchelf --add-rpath /opt/datadog-agent/embedded/lib` is applied to the FIPS installer binary in `datadog-agent-finalize.rb` **after** `rpath-edit` (which would otherwise overwrite it). Absolute RPATH entries are always honoured under `AT_SECURE`. The path is version-independent: it is the deb install location directly, and a symlink to the current stable OCI tree on OCI-managed hosts. |
| 5 | **Standalone installer FIPS build** | No FIPS variant of the standalone `datadog-installer` binary existed. Its `BuiltForFIPS()` was always `false`, so it always selected the non-FIPS package variant when used to bootstrap OCI installs. | FIPS OCI-managed installs downloaded the wrong variant even after other fixes were in place. | New `installer-fips-amd64/arm64-oci` CI jobs build a FIPS-flavor standalone installer and publish it as the `Platform.Variant="fips"` layer of the `datadog-installer` OCI image index. |

Additional hardening: `fipsinstall.sh` now derives `INSTALL_DIR` via `realpath` (fixes OCI relocation), rewrites the `.include` path in `openssl.cnf` to the physical directory and verifies the substitution succeeded, and exits non-zero on verify failure. `tasks/omnibus.py`'s `_patch_binary_rpath` is unchanged; the existing unit test is updated.

## Package changes

- New `pkg/fips/fips_buildinfo.go` + `fips_buildinfo_test.go`: runtime `BuiltForFIPS()` via `debug.ReadBuildInfo()`, replacing three build-tag-constrained stubs that were unreliable on some deb builds.
- New `datadog-fips-installer` OCI variant: FIPS-flavor standalone installer published as `Platform.Variant="fips"` in the `datadog-installer` OCI image index.

## Surface changes

- `start-experiment` on a `datadog-fips-agent` host now selects and configures the FIPS package end-to-end without any env override.
- New CI jobs: `installer-fips-amd64-oci` and `installer-fips-arm64-oci` (the non-oci variants are hidden templates).
- `fipsinstall.sh`: stricter — exits non-zero on verify failure or broken intermediate state.
- No CLI, config, or proto changes.

## Automated review results

| Agent | Findings | Fixed | Remaining |
|-------|----------|-------|-----------|
| Go best practices | 1 | 0 | 1 (pre-existing comment typo, out of scope) |
| Go code reviewer (7 sub-reviewers) | 17 | 17 | 0 |

## QA guidelines

Install from pipeline A's deb, then run `start-experiment` from pipeline B's OCI. Both should report `FIPS Mode: enabled`.

```bash
# Pipeline A — install deb
sudo env \
  DD_API_KEY=<key> DD_SITE=datadoghq.com DD_AGENT_MAJOR_VERSION=7 \
  DD_AGENT_FLAVOR=datadog-fips-agent DD_REMOTE_UPDATES=true \
  TESTING_KEYS_URL=apttesting.datad0g.com/test-keys \
  TESTING_APT_URL=s3.amazonaws.com/apttesting.datad0g.com/datadog-agent/pipeline-<A>-a7 \
  TESTING_APT_REPO_VERSION="stable-x86_64 7" \
  DD_INSTALLER_REGISTRY_URL=installtesting.datad0g.com \
  DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE=installtesting.datad0g.com \
  DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT=pipeline-<A> \
  bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"

sudo tee /etc/datadog-agent/datadog.yaml <<EOF
api_key: <key>
site: datadoghq.com
remote_updates: true
remote_configuration:
  enabled: true
installer:
  registry:
    url: installtesting.datad0g.com
EOF
sudo chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
sudo systemctl restart datadog-agent
sleep 10
sudo datadog-agent status | grep "FIPS Mode"   # → FIPS Mode: enabled

# Pipeline B — start-experiment from a different OCI
BIN=/opt/datadog-agent/embedded/bin/installer
V=<version-from-pipeline-B>
sudo \$BIN daemon set-catalog '{"packages":[{"package":"datadog-agent","version":"'"$V"'","url":"oci://installtesting.datad0g.com/agent-package:pipeline-<B>"}]}'
sudo \$BIN daemon start-experiment datadog-agent "\$V"
sudo /opt/datadog-packages/datadog-agent/experiment/bin/agent/agent status | grep "FIPS Mode"   # → FIPS Mode: enabled
```