### PR TITLE
aix: drop final_constraints-py3.txt from BFF package

### DIFF
--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -9,6 +9,7 @@
 ## Unreleased
 
 <!-- Add entries here for changes not yet in a release. -->
+- Drop `final_constraints-py3.txt` from the BFF package (aligns with #52711 which drops it from all other platforms)
 - Remove `sharedlibrarycheck` from the AIX agent build (the shared-library check loader was included but not validated on AIX)
 
 - The embedded `python3.13` binary and all Python extension modules now have the correct install-time library search path baked into their XCOFF loader section. Previously, the staging path was baked in, causing `libpython3.13.so could not be loaded` when running pip or python directly (without `LIBPATH` set). Operators can now run `pip install` without setting `LIBPATH` first.

--- a/packaging/aix/stages/07-checks-base.sh
+++ b/packaging/aix/stages/07-checks-base.sh
@@ -121,11 +121,6 @@ log "Freezing installed packages to $STAGING/constraints.txt"
 $PIP freeze > "$STAGING/constraints.txt"
 log "Constraints written to $STAGING/constraints.txt ($(wc -l < "$STAGING/constraints.txt") packages)"
 
-# Also write to the package root so the file is included in the BFF package
-# at /opt/datadog-agent/final_constraints-py3.txt, matching other platforms.
-cp "$STAGING/constraints.txt" "$STAGING/opt/datadog-agent/final_constraints-py3.txt"
-log "Copied constraints to $STAGING/opt/datadog-agent/final_constraints-py3.txt"
-
 # --- Mark complete ---
 mkdir -p "$(dirname "$SENTINEL")"
 touch "$SENTINEL"


### PR DESCRIPTION
### What does this PR do?

Removes `final_constraints-py3.txt` from the AIX BFF package.

### Motivation

Aligns AIX with #52711, which drops this file from all other platforms.

### Describe how you validated your changes

### Additional Notes

The intermediate `constraints.txt` used by stage 08 during the build is unchanged.