### PR TITLE
feat(autodiscovery): set specific config.provider for config discovery

### DIFF
--- a/comp/core/autodiscovery/impl/configmgr_discovery.go
+++ b/comp/core/autodiscovery/impl/configmgr_discovery.go
@@ -9,10 +9,13 @@ package autodiscoveryimpl
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/configresolver"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/discoverer"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/listeners"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -133,6 +136,7 @@ func (cm *reconcilingConfigManager) applyDiscoveredConfigsLocked(svcID, tplDiges
 		errorStats.setResolveWarning(tpl.Name, err.Error())
 		return changes
 	}
+	resolved.Source = rewriteSource(resolved.Source, svcAndADIDs.svc)
 	decrypted, err := decryptConfig(resolved, cm.secretResolver, tplDigest)
 	if err != nil {
 		log.Errorf("error decrypting discovered config %s for service %s: %v", resolved.Name, svcID, err)
@@ -155,4 +159,24 @@ func (cm *reconcilingConfigManager) applyDiscoveredConfigsLocked(svcID, tplDiges
 	changes.ScheduleConfig(decrypted)
 	errorStats.removeResolveWarnings(tpl.Name)
 	return cm.applyChanges(changes)
+}
+
+// rewriteSource rewrites a resolved config's file-based Source to encode that
+// it was applied via a configuration-discovery probe result, and whether the
+// target service is a process or a container. Only the "file" provider is
+// rewritten since that's where we expect discovery configs to come from.
+//
+// This rewritten source is included in the configuration metadata sent to the
+// backend.
+//
+// Config.Provider is intentionally left unchanged — it is used by the secret
+// resolver security mechanism and must not vary with the service type.
+func rewriteSource(source string, svc listeners.Service) string {
+	if !strings.HasPrefix(source, names.File+":") {
+		return source
+	}
+	if strings.HasPrefix(svc.GetServiceID(), "process://") {
+		return names.ADProcessDiscovery + source[len(names.File):]
+	}
+	return names.ADContainerDiscovery + source[len(names.File):]
 }

--- a/comp/core/autodiscovery/impl/configmgr_discovery_test.go
+++ b/comp/core/autodiscovery/impl/configmgr_discovery_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/discoverer"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
@@ -88,50 +89,77 @@ func TestConfigMgr_DiscoveryTemplate_NoPythonNeverSchedules(t *testing.T) {
 // TestConfigMgr_DiscoveryTemplate_RoutesThroughDiscoverer verifies the full
 // end-to-end path: the configmgr enqueues a probe instead of resolving the
 // template, the worker calls the stub, and the resolved config is delivered
-// via discoveredChanges() to be applied by AutoConfig.
+// via discoveredChanges() to be applied by AutoConfig. It covers both a
+// container and a process service, which should get distinct
+// discovery-specific Source prefixes.
 func TestConfigMgr_DiscoveryTemplate_RoutesThroughDiscoverer(t *testing.T) {
-	mockResolver := MockSecretResolver{}
-	disco := newStubDiscoverer(func(_, _ string) (string, error) {
-		return `[{"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics"}]}]`, nil
-	})
-	cm := newReconcilingConfigManager(&mockResolver, nil, nil, disco, nil).(*reconcilingConfigManager)
-	cm.start()
-	defer cm.stop()
-
-	tpl := integration.Config{
-		Name:          "krakend",
-		ADIdentifiers: []string{"krakend"},
-		Discovery:     &integration.DiscoveryConfig{},
-	}
-	svc := &dummyService{
-		ID:            "docker://k1",
-		ADIdentifiers: []string{"krakend"},
-		Hosts:         map[string]string{"main": "10.0.0.1"},
+	tests := []struct {
+		name       string
+		svcID      string
+		wantSource string
+	}{
+		{
+			name:       "container service",
+			svcID:      "docker://k1",
+			wantSource: names.ADContainerDiscovery + ":/etc/datadog-agent/conf.d/krakend.d/auto_conf.yaml",
+		},
+		{
+			name:       "process service",
+			svcID:      "process://1234",
+			wantSource: names.ADProcessDiscovery + ":/etc/datadog-agent/conf.d/krakend.d/auto_conf.yaml",
+		},
 	}
 
-	// processNewConfig + processNewService should NOT schedule synchronously
-	// — the template goes through the discovery path instead.
-	_, _ = cm.processNewConfig(tpl)
-	changes := cm.processNewService(svc)
-	assertConfigsMatch(t, changes.Schedule)
-	assertConfigsMatch(t, changes.Unschedule)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockResolver := MockSecretResolver{}
+			disco := newStubDiscoverer(func(_, _ string) (string, error) {
+				return `[{"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics"}]}]`, nil
+			})
+			cm := newReconcilingConfigManager(&mockResolver, nil, nil, disco, nil).(*reconcilingConfigManager)
+			cm.start()
+			defer cm.stop()
 
-	// Drain the discovered-changes channel for up to one second.
-	ch := cm.discoveredChanges()
-	require.NotNil(t, ch)
-	select {
-	case discovered := <-ch:
-		assertConfigsMatch(t, discovered.Schedule, matchName("krakend"))
-		require.Len(t, discovered.Schedule, 1)
-		// %%host%% in the discovered config should have been resolved
-		// through the normal configresolver path against the live service.
-		assert.Contains(t, string(discovered.Schedule[0].Instances[0]), "10.0.0.1",
-			"discovered instance config should have %%host%% resolved via the configresolver path")
-	case <-time.After(2 * time.Second):
-		t.Fatalf("timed out waiting for discovered changes")
+			tpl := integration.Config{
+				Name:          "krakend",
+				ADIdentifiers: []string{"krakend"},
+				Discovery:     &integration.DiscoveryConfig{},
+				Source:        "file:/etc/datadog-agent/conf.d/krakend.d/auto_conf.yaml",
+				Provider:      names.File,
+			}
+			svc := &dummyService{
+				ID:            tc.svcID,
+				ADIdentifiers: []string{"krakend"},
+				Hosts:         map[string]string{"main": "10.0.0.1"},
+			}
+
+			// processNewConfig + processNewService should NOT schedule synchronously
+			// — the template goes through the discovery path instead.
+			_, _ = cm.processNewConfig(tpl)
+			changes := cm.processNewService(svc)
+			assertConfigsMatch(t, changes.Schedule)
+			assertConfigsMatch(t, changes.Unschedule)
+
+			// Drain the discovered-changes channel for up to one second.
+			ch := cm.discoveredChanges()
+			require.NotNil(t, ch)
+			select {
+			case discovered := <-ch:
+				assertConfigsMatch(t, discovered.Schedule, matchName("krakend"))
+				require.Len(t, discovered.Schedule, 1)
+				// %%host%% in the discovered config should have been resolved
+				// through the normal configresolver path against the live service.
+				assert.Contains(t, string(discovered.Schedule[0].Instances[0]), "10.0.0.1",
+					"discovered instance config should have %%host%% resolved via the configresolver path")
+				assert.Equal(t, tc.wantSource, discovered.Schedule[0].Source,
+					"discovered config's Source should be tagged with the discovery provider")
+			case <-time.After(2 * time.Second):
+				t.Fatalf("timed out waiting for discovered changes")
+			}
+
+			assert.GreaterOrEqual(t, int(disco.called.Load()), 1, "stub discoverer should have been called")
+		})
 	}
-
-	assert.GreaterOrEqual(t, int(disco.called.Load()), 1, "stub discoverer should have been called")
 }
 
 // TestConfigMgr_DiscoveryTemplate_ServiceDeletionCancels confirms that

--- a/comp/core/autodiscovery/providers/names/provider_names.go
+++ b/comp/core/autodiscovery/providers/names/provider_names.go
@@ -67,6 +67,12 @@ const (
 	PrometheusHTTPSD = "prometheus-http-sd"
 	// InstrumentationChecks pulls AD configurations derived from DatadogInstrumentation CRs via the cluster-agent.
 	InstrumentationChecks = "instrumentation-checks"
+	// ADContainerDiscovery is the source prefix for configuration discovery file templates resolved
+	// against non-process services (containers, k8s pods, etc.).
+	ADContainerDiscovery = "ad-container-discovery+file"
+	// ADProcessDiscovery is the source prefix for configuration discovery file templates resolved
+	// against process services.
+	ADProcessDiscovery = "ad-process-discovery+file"
 )
 
 // Internal Autodiscovery names for the config providers


### PR DESCRIPTION
### What does this PR do?

Make Autodiscovery change the config source in the final instance configuration when the configruation comes from configuration discovery. The `config.provider` field in inventory metadata is derived from the prefix of `Config.Source` (split on `:`). Until now it was always `file` or `container`, making it impossible to tell whether configuration discovery was involved. This will be useful to track adoption of configuration discovery.

`Config.Provider` is intentionally left unchanged — it's used by the secret resolver security mechanism.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-573
https://datadoghq.atlassian.net/wiki/spaces/DSCVR/pages/6895337633/

### Describe how you validated your changes

CI.

### Additional Notes

**Required follow-up (backend):** the EPRW decoder (`agentmetadata_decoder.go`) has a check `provider == file` that creates the `datadog_agent_integrations_configurations` resource. It needs to be updated to also handle the new provider strings.