### PR TITLE
fix(aix): disable Bazel in agent.build for AIX packaging

### DIFF
--- a/packaging/aix/stages/04-agent.sh
+++ b/packaging/aix/stages/04-agent.sh
@@ -114,6 +114,7 @@ rm -f "$STAGING/opt/datadog-agent/bin/agent/agent-bin"
 # needed globally (env.sh) for tools like ar that don't respect AIX_OBJECT_MODE.
 unset OBJECT_MODE
 python3.12 -m invoke agent.build \
+    --no-enable-bazel \
     --exclude-rtloader \
     --rtloader-root=/opt/datadog-agent/rtloader \
     --embedded-path="$EMBEDDED_DESTDIR" \


### PR DESCRIPTION
### What does this PR do?

Adds `--no-enable-bazel` to the `agent.build` invocation in `packaging/aix/stages/04-agent.sh`.

### Motivation

#52546 flipped the `enable_bazel` default to `True` in `agent.build`. Bazel cannot run on AIX, so the AIX packaging pipeline must explicitly opt out.

### Describe how you validated your changes

### Additional Notes
