### PR TITLE
Revert agent-rpm preinst to original state

### DIFF
--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -132,8 +132,11 @@ else
     fi
 fi
 
-# Delete Python bytecode caches in the embedded dir.
-# This MUST be done after using pip or any python, because executing python might generate .pyc files.
-find "$INSTALL_DIR/embedded" -type d -name __pycache__ -prune -exec rm -rf {} + || true
+# Delete all the .pyc/.pyo files in the embedded dir that are part of the old agent's package
+# This MUST be done after using pip or any python, because executing python might generate .pyc files
+if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
+    # (commented lines are filtered out)
+    cat $INSTALL_DIR/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
+fi
 
 exit 0


### PR DESCRIPTION
### What does this PR do?

Restores the agent-rpm preinst to the state before https://github.com/DataDog/datadog-agent/pull/51919 (https://github.com/DataDog/datadog-agent/commit/91b747883b3369eaa9ce751201bcc3a0eafbdd29).

### Motivation

https://github.com/DataDog/datadog-agent/pull/51919 made a change ignoring a banner which explicitly instructed against changes:

https://github.com/DataDog/datadog-agent/blob/1a566214d95360e1b2afb38cf507af4a4820edf0/omnibus/package-scripts/agent-rpm/preinst#L37-L40

This causes .pyc files to remain when updating from Agent 6 (which has pyc files but no `__pycache__` folders), which was caught by tests during release pipelines ([here](https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/1804045890)).

### Describe how you validated your changes

The failing tests become green: https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/pipelines/121106555

### Additional Notes
