### PR TITLE
bump github.com/DataDog/rshell v0.0.21 -> v0.0.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -942,7 +942,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/datadog-agent/test/fakeintake v0.0.0-00010101000000-000000000000
 	github.com/DataDog/ddtrivy v0.0.0-20260519164847-bf6bcaf2f9b7
-	github.com/DataDog/rshell v0.0.21
+	github.com/DataDog/rshell v0.0.22
 	github.com/aptly-dev/aptly v1.6.3-0.20260504093056-0d31298f3709
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.3
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.69.3

--- a/go.sum
+++ b/go.sum
@@ -2597,6 +2597,8 @@ github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260615120033-4edb1d33d27
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260615120033-4edb1d33d277/go.mod h1:DqHEtu1S8fTmyvvrSSum1lssLKwYM7aExPNZ/+vWZ6U=
 github.com/DataDog/rshell v0.0.21 h1:irXLFSaCti9AxI1UpLx3GD/JYBgJFdNlRE63QyYRgXc=
 github.com/DataDog/rshell v0.0.21/go.mod h1:jZm0YIxCKYEyHJeSSH5rxqmlI1oUi+mXQF6Zf102q+k=
+github.com/DataDog/rshell v0.0.22 h1:SO+CbjmL7iL2kHS0RJODcInaerZNEdQq6QeISqjRIO0=
+github.com/DataDog/rshell v0.0.22/go.mod h1:jZm0YIxCKYEyHJeSSH5rxqmlI1oUi+mXQF6Zf102q+k=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=
 github.com/DataDog/sketches-go v1.4.8/go.mod h1:a/wjRUqzqtGS8qRHRPDCs4EAQfmvPDZGDlMIF5mxXOE=
 github.com/DataDog/trivy v0.0.0-20260519102929-2926d6041e57 h1:NjLZ7nbzMN1MsTotfQ6/W5a9WpHTREEB2acJOauyoQE=


### PR DESCRIPTION
## Summary
- Bumps `github.com/DataDog/rshell` from v0.0.21 to v0.0.22
- Release notes: https://github.com/DataDog/rshell/releases/tag/v0.0.22

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)