### PR TITLE
feat(adms): Disable the updater

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -34,3 +34,9 @@ excludes:
   - ^gh-pages$
   - ^.*DO-NOT-DELETE$
   - ^agent-v5$
+---
+schema-version: v2
+kind: adms
+auto-version-updates:
+  disabled:
+    reason: Version updates are managed fully by renovate


### PR DESCRIPTION
### What does this PR do?

ADMS updater can create unexpected pressure on the datadog-agent repository CI infrastructure. Until possibility to fully use the updater on open source repository the dependency updates are managed by renovate

### Motivation
CI reliability

### Describe how you validated your changes
n/a

### Additional Notes
