### PR TITLE
CAP-3775 route batched logs per-ResourceLogs scope

### DIFF
--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter.go
@@ -196,17 +196,33 @@ type ScopeName string
 // K8sObjectsReceiver is the scope name for the k8sobjectsreceiver
 var K8sObjectsReceiver ScopeName = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver"
 
-// splitLogsByScope partitions ld into k8sobjects-receiver logs and everything else
+// splitLogsByScope partitions ld by ScopeLogs into k8sobjects logs and everything else.
 func splitLogsByScope(ld plog.Logs) (plog.Logs, plog.Logs) {
 	k8sLogs := plog.NewLogs()
 	regularLogs := plog.NewLogs()
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
-		rl := ld.ResourceLogs().At(i)
-		dst := regularLogs
-		if rl.ScopeLogs().Len() > 0 && ScopeName(rl.ScopeLogs().At(0).Scope().Name()) == K8sObjectsReceiver {
-			dst = k8sLogs
-		}
-		rl.CopyTo(dst.ResourceLogs().AppendEmpty())
+		srcRL := ld.ResourceLogs().At(i)
+		copyMatchingScopes(srcRL, k8sLogs, func(name string) bool { return ScopeName(name) == K8sObjectsReceiver })
+		copyMatchingScopes(srcRL, regularLogs, func(name string) bool { return ScopeName(name) != K8sObjectsReceiver })
 	}
 	return k8sLogs, regularLogs
+}
+
+// copyMatchingScopes copies ScopeLogs from src to dst whose scope name passes match.
+func copyMatchingScopes(src plog.ResourceLogs, dst plog.Logs, match func(scopeName string) bool) {
+	var rl plog.ResourceLogs
+	initialized := false
+	for j := 0; j < src.ScopeLogs().Len(); j++ {
+		sl := src.ScopeLogs().At(j)
+		if !match(sl.Scope().Name()) {
+			continue
+		}
+		if !initialized {
+			rl = dst.ResourceLogs().AppendEmpty()
+			src.Resource().CopyTo(rl.Resource())
+			rl.SetSchemaUrl(src.SchemaUrl())
+			initialized = true
+		}
+		sl.CopyTo(rl.ScopeLogs().AppendEmpty())
+	}
 }

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter.go
@@ -81,17 +81,25 @@ func NewExporterWithGatewayUsage(
 }
 
 // ConsumeLogs checks the scope of the logs and routes them to the appropriate consumer
-func (e *Exporter) ConsumeLogs(ctx context.Context, ld plog.Logs) (err error) {
-	scope := getLogsScope(ld)
-	switch scope {
-	case K8sObjectsReceiver:
-		if e.orchestratorExporter.config.Enabled {
-			return e.consumeK8sObjects(ctx, ld)
-		}
-		fallthrough
-	default:
+func (e *Exporter) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	if !e.orchestratorExporter.config.Enabled {
 		return e.consumeRegularLogs(ctx, ld)
 	}
+
+	k8sLogs, regularLogs := splitLogsByScope(ld)
+
+	var errs []error
+	if k8sLogs.ResourceLogs().Len() > 0 {
+		if err := e.consumeK8sObjects(ctx, k8sLogs); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if regularLogs.ResourceLogs().Len() > 0 {
+		if err := e.consumeRegularLogs(ctx, regularLogs); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // consumeRegularLogs maps logs from OTLP to DD format and ingests them through the exporter channel
@@ -188,14 +196,17 @@ type ScopeName string
 // K8sObjectsReceiver is the scope name for the k8sobjectsreceiver
 var K8sObjectsReceiver ScopeName = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver"
 
-// getLogsScope extracts the scope name from the logs data
-func getLogsScope(ld plog.Logs) ScopeName {
+// splitLogsByScope partitions ld into k8sobjects-receiver logs and everything else
+func splitLogsByScope(ld plog.Logs) (plog.Logs, plog.Logs) {
+	k8sLogs := plog.NewLogs()
+	regularLogs := plog.NewLogs()
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
-		resourceLogs := ld.ResourceLogs().At(i)
-		if resourceLogs.ScopeLogs().Len() > 0 {
-			scopeLogs := resourceLogs.ScopeLogs().At(0)
-			return ScopeName(scopeLogs.Scope().Name())
+		rl := ld.ResourceLogs().At(i)
+		dst := regularLogs
+		if rl.ScopeLogs().Len() > 0 && ScopeName(rl.ScopeLogs().At(0).Scope().Name()) == K8sObjectsReceiver {
+			dst = k8sLogs
 		}
+		rl.CopyTo(dst.ResourceLogs().AppendEmpty())
 	}
-	return ""
+	return k8sLogs, regularLogs
 }

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter.go
@@ -89,13 +89,13 @@ func (e *Exporter) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	k8sLogs, regularLogs := splitLogsByScope(ld)
 
 	var errs []error
-	if k8sLogs.ResourceLogs().Len() > 0 {
-		if err := e.consumeK8sObjects(ctx, k8sLogs); err != nil {
+	if regularLogs.ResourceLogs().Len() > 0 {
+		if err := e.consumeRegularLogs(ctx, regularLogs); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	if regularLogs.ResourceLogs().Len() > 0 {
-		if err := e.consumeRegularLogs(ctx, regularLogs); err != nil {
+	if k8sLogs.ResourceLogs().Len() > 0 {
+		if err := e.consumeK8sObjects(ctx, k8sLogs); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter.go
@@ -220,8 +220,6 @@ func splitLogsByScope(ld plog.Logs) (plog.Logs, plog.Logs) {
 		return ld, plog.NewLogs()
 	}
 
-	isK8s := func(name string) bool { return ScopeName(name) == K8sObjectsReceiver }
-	isRegular := func(name string) bool { return ScopeName(name) != K8sObjectsReceiver }
 	k8sLogs := plog.NewLogs()
 	regularLogs := plog.NewLogs()
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
@@ -232,27 +230,28 @@ func splitLogsByScope(ld plog.Logs) (plog.Logs, plog.Logs) {
 			rl.SetSchemaUrl(srcRL.SchemaUrl())
 			continue
 		}
-		copyMatchingScopes(srcRL, k8sLogs, isK8s)
-		copyMatchingScopes(srcRL, regularLogs, isRegular)
+		var k8sRL, regularRL plog.ResourceLogs
+		var k8sInit, regularInit bool
+		for j := 0; j < srcRL.ScopeLogs().Len(); j++ {
+			sl := srcRL.ScopeLogs().At(j)
+			if ScopeName(sl.Scope().Name()) == K8sObjectsReceiver {
+				if !k8sInit {
+					k8sRL = k8sLogs.ResourceLogs().AppendEmpty()
+					srcRL.Resource().CopyTo(k8sRL.Resource())
+					k8sRL.SetSchemaUrl(srcRL.SchemaUrl())
+					k8sInit = true
+				}
+				sl.CopyTo(k8sRL.ScopeLogs().AppendEmpty())
+			} else {
+				if !regularInit {
+					regularRL = regularLogs.ResourceLogs().AppendEmpty()
+					srcRL.Resource().CopyTo(regularRL.Resource())
+					regularRL.SetSchemaUrl(srcRL.SchemaUrl())
+					regularInit = true
+				}
+				sl.CopyTo(regularRL.ScopeLogs().AppendEmpty())
+			}
+		}
 	}
 	return k8sLogs, regularLogs
-}
-
-// copyMatchingScopes copies ScopeLogs from src to dst whose scope name passes match.
-func copyMatchingScopes(src plog.ResourceLogs, dst plog.Logs, match func(scopeName string) bool) {
-	var rl plog.ResourceLogs
-	initialized := false
-	for j := 0; j < src.ScopeLogs().Len(); j++ {
-		sl := src.ScopeLogs().At(j)
-		if !match(sl.Scope().Name()) {
-			continue
-		}
-		if !initialized {
-			rl = dst.ResourceLogs().AppendEmpty()
-			src.Resource().CopyTo(rl.Resource())
-			rl.SetSchemaUrl(src.SchemaUrl())
-			initialized = true
-		}
-		sl.CopyTo(rl.ScopeLogs().AppendEmpty())
-	}
 }

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter.go
@@ -198,12 +198,42 @@ var K8sObjectsReceiver ScopeName = "github.com/open-telemetry/opentelemetry-coll
 
 // splitLogsByScope partitions ld by ScopeLogs into k8sobjects logs and everything else.
 func splitLogsByScope(ld plog.Logs) (plog.Logs, plog.Logs) {
+	hasK8s, hasRegular := false, false
+	for i := 0; i < ld.ResourceLogs().Len() && !(hasK8s && hasRegular); i++ {
+		srcRL := ld.ResourceLogs().At(i)
+		if srcRL.ScopeLogs().Len() == 0 {
+			hasRegular = true
+			continue
+		}
+		for j := 0; j < srcRL.ScopeLogs().Len() && !(hasK8s && hasRegular); j++ {
+			if ScopeName(srcRL.ScopeLogs().At(j).Scope().Name()) == K8sObjectsReceiver {
+				hasK8s = true
+			} else {
+				hasRegular = true
+			}
+		}
+	}
+	if !hasK8s {
+		return plog.NewLogs(), ld
+	}
+	if !hasRegular {
+		return ld, plog.NewLogs()
+	}
+
+	isK8s := func(name string) bool { return ScopeName(name) == K8sObjectsReceiver }
+	isRegular := func(name string) bool { return ScopeName(name) != K8sObjectsReceiver }
 	k8sLogs := plog.NewLogs()
 	regularLogs := plog.NewLogs()
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		srcRL := ld.ResourceLogs().At(i)
-		copyMatchingScopes(srcRL, k8sLogs, func(name string) bool { return ScopeName(name) == K8sObjectsReceiver })
-		copyMatchingScopes(srcRL, regularLogs, func(name string) bool { return ScopeName(name) != K8sObjectsReceiver })
+		if srcRL.ScopeLogs().Len() == 0 {
+			rl := regularLogs.ResourceLogs().AppendEmpty()
+			srcRL.Resource().CopyTo(rl.Resource())
+			rl.SetSchemaUrl(srcRL.SchemaUrl())
+			continue
+		}
+		copyMatchingScopes(srcRL, k8sLogs, isK8s)
+		copyMatchingScopes(srcRL, regularLogs, isRegular)
 	}
 	return k8sLogs, regularLogs
 }

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter_test.go
@@ -410,14 +410,51 @@ func traceIDToHexOrEmptyString(id pcommon.TraceID) string {
 }
 
 func TestSplitLogsByScope(t *testing.T) {
-	ld := plog.NewLogs()
-	for _, scope := range []string{"filelog", string(K8sObjectsReceiver), "filelog", string(K8sObjectsReceiver)} {
-		ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().Scope().SetName(scope)
-	}
+	t.Run("single-scope ResourceLogs", func(t *testing.T) {
+		ld := plog.NewLogs()
+		for _, scope := range []string{"filelog", string(K8sObjectsReceiver), "filelog", string(K8sObjectsReceiver)} {
+			ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().Scope().SetName(scope)
+		}
 
-	k8s, regular := splitLogsByScope(ld)
-	assert.Equal(t, 2, k8s.ResourceLogs().Len())
-	assert.Equal(t, 2, regular.ResourceLogs().Len())
-	assert.Equal(t, string(K8sObjectsReceiver), k8s.ResourceLogs().At(0).ScopeLogs().At(0).Scope().Name())
-	assert.Equal(t, "filelog", regular.ResourceLogs().At(0).ScopeLogs().At(0).Scope().Name())
+		k8s, regular := splitLogsByScope(ld)
+		assert.Equal(t, 2, k8s.ResourceLogs().Len())
+		assert.Equal(t, 2, regular.ResourceLogs().Len())
+		assert.Equal(t, string(K8sObjectsReceiver), k8s.ResourceLogs().At(0).ScopeLogs().At(0).Scope().Name())
+		assert.Equal(t, "filelog", regular.ResourceLogs().At(0).ScopeLogs().At(0).Scope().Name())
+	})
+
+	t.Run("mixed-scope ResourceLogs", func(t *testing.T) {
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.SetSchemaUrl("https://example.com/schema")
+		rl.Resource().Attributes().PutStr("k8s.cluster.name", "test-cluster")
+		rl.ScopeLogs().AppendEmpty().Scope().SetName("filelog")
+		rl.ScopeLogs().AppendEmpty().Scope().SetName(string(K8sObjectsReceiver))
+		rl.ScopeLogs().AppendEmpty().Scope().SetName("filelog")
+
+		k8s, regular := splitLogsByScope(ld)
+
+		assert.Equal(t, 1, k8s.ResourceLogs().Len())
+		assert.Equal(t, 1, k8s.ResourceLogs().At(0).ScopeLogs().Len())
+		assert.Equal(t, string(K8sObjectsReceiver), k8s.ResourceLogs().At(0).ScopeLogs().At(0).Scope().Name())
+		assert.Equal(t, "https://example.com/schema", k8s.ResourceLogs().At(0).SchemaUrl())
+		clusterName, ok := k8s.ResourceLogs().At(0).Resource().Attributes().Get("k8s.cluster.name")
+		assert.True(t, ok)
+		assert.Equal(t, "test-cluster", clusterName.AsString())
+
+		assert.Equal(t, 1, regular.ResourceLogs().Len())
+		assert.Equal(t, 2, regular.ResourceLogs().At(0).ScopeLogs().Len())
+		assert.Equal(t, "filelog", regular.ResourceLogs().At(0).ScopeLogs().At(0).Scope().Name())
+		assert.Equal(t, "filelog", regular.ResourceLogs().At(0).ScopeLogs().At(1).Scope().Name())
+		assert.Equal(t, "https://example.com/schema", regular.ResourceLogs().At(0).SchemaUrl())
+	})
+
+	t.Run("only k8sobjects scope", func(t *testing.T) {
+		ld := plog.NewLogs()
+		ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().Scope().SetName(string(K8sObjectsReceiver))
+
+		k8s, regular := splitLogsByScope(ld)
+		assert.Equal(t, 1, k8s.ResourceLogs().Len())
+		assert.Equal(t, 0, regular.ResourceLogs().Len())
+	})
 }

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter_test.go
@@ -408,3 +408,16 @@ func traceIDToHexOrEmptyString(id pcommon.TraceID) string {
 	}
 	return hex.EncodeToString(id[:])
 }
+
+func TestSplitLogsByScope(t *testing.T) {
+	ld := plog.NewLogs()
+	for _, scope := range []string{"filelog", string(K8sObjectsReceiver), "filelog", string(K8sObjectsReceiver)} {
+		ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().Scope().SetName(scope)
+	}
+
+	k8s, regular := splitLogsByScope(ld)
+	assert.Equal(t, 2, k8s.ResourceLogs().Len())
+	assert.Equal(t, 2, regular.ResourceLogs().Len())
+	assert.Equal(t, string(K8sObjectsReceiver), k8s.ResourceLogs().At(0).ScopeLogs().At(0).Scope().Name())
+	assert.Equal(t, "filelog", regular.ResourceLogs().At(0).ScopeLogs().At(0).Scope().Name())
+}

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter_test.go
@@ -10,19 +10,32 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
+	"sync/atomic"
 	"testing"
 
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/util/otel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	exp "go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 )
+
+type stubHostname struct{ name string }
+
+func (s stubHostname) Get(context.Context) (string, error) { return s.name, nil }
+func (s stubHostname) GetWithProvider(context.Context) (hostnameinterface.Data, error) {
+	return hostnameinterface.Data{Hostname: s.name, Provider: "stub"}, nil
+}
+func (s stubHostname) GetSafe(context.Context) string { return s.name }
 
 func TestLogsExporter(t *testing.T) {
 	lr := testutil.GenerateLogsOneLogRecord()
@@ -495,5 +508,133 @@ func TestSplitLogsByScope(t *testing.T) {
 		assert.Equal(t, 0, k8s.ResourceLogs().Len())
 		assert.Equal(t, 1, regular.ResourceLogs().Len())
 		assert.Equal(t, ld, regular)
+	})
+}
+
+func TestConsumeLogs_OrchestratorBranching(t *testing.T) {
+	regularLog := func() plog.Logs {
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		sl := rl.ScopeLogs().AppendEmpty()
+		sl.Scope().SetName("filelog")
+		sl.LogRecords().AppendEmpty().Body().SetStr("hello")
+		return ld
+	}
+	mixedLogs := func() plog.Logs {
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("k8s.cluster.uid", "cluster-1")
+		rl.Resource().Attributes().PutStr("k8s.cluster.name", "my-cluster")
+		regular := rl.ScopeLogs().AppendEmpty()
+		regular.Scope().SetName("filelog")
+		regular.LogRecords().AppendEmpty().Body().SetStr("hello")
+		k8sScope := rl.ScopeLogs().AppendEmpty()
+		k8sScope.Scope().SetName(string(K8sObjectsReceiver))
+		k8sScope.LogRecords().AppendEmpty().Body().SetStr(
+			`{"apiVersion":"v1","kind":"Pod","metadata":{"uid":"pod-uid","resourceVersion":"v1","name":"p"}}`)
+		return ld
+	}
+
+	newExp := func(t *testing.T, ch chan *message.Message, cfg *Config) exp.Logs {
+		t.Helper()
+		params := exportertest.NewNopSettings(component.MustNewType(TypeStr))
+		f := NewFactory(ch, otel.NewDisabledGatewayUsage())
+		e, err := f.CreateLogs(context.Background(), params, cfg)
+		require.NoError(t, err)
+		return e
+	}
+
+	t.Run("orchestrator disabled routes everything to regular path", func(t *testing.T) {
+		ch := make(chan *message.Message, 4)
+		e := newExp(t, ch, &Config{OtelSource: otelSource, LogSourceName: LogSourceName})
+		require.NoError(t, e.ConsumeLogs(context.Background(), regularLog()))
+		select {
+		case <-ch:
+		default:
+			t.Fatal("expected regular log to reach channel")
+		}
+	})
+
+	t.Run("orchestrator enabled, only regular logs: no HTTP call", func(t *testing.T) {
+		var posts atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			posts.Add(1)
+		}))
+		defer server.Close()
+
+		ch := make(chan *message.Message, 4)
+		e := newExp(t, ch, &Config{
+			OtelSource:    otelSource,
+			LogSourceName: LogSourceName,
+			OrchestratorConfig: OrchestratorConfig{
+				Enabled: true, Endpoint: server.URL, Key: "k", Hostname: stubHostname{name: "h"},
+			},
+		})
+		require.NoError(t, e.ConsumeLogs(context.Background(), regularLog()))
+		assert.Equal(t, int32(0), posts.Load(), "k8s consumer should not be invoked")
+		select {
+		case <-ch:
+		default:
+			t.Fatal("expected regular log to reach channel")
+		}
+	})
+
+	t.Run("orchestrator enabled, only k8s logs: no channel send", func(t *testing.T) {
+		var posts atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			posts.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("k8s.cluster.uid", "cluster-1")
+		rl.Resource().Attributes().PutStr("k8s.cluster.name", "my-cluster")
+		sl := rl.ScopeLogs().AppendEmpty()
+		sl.Scope().SetName(string(K8sObjectsReceiver))
+		sl.LogRecords().AppendEmpty().Body().SetStr(
+			`{"apiVersion":"v1","kind":"Pod","metadata":{"uid":"pod-uid","resourceVersion":"v1","name":"p"}}`)
+
+		ch := make(chan *message.Message, 4)
+		e := newExp(t, ch, &Config{
+			OtelSource:    otelSource,
+			LogSourceName: LogSourceName,
+			OrchestratorConfig: OrchestratorConfig{
+				Enabled: true, Endpoint: server.URL, Key: "k", Hostname: stubHostname{name: "h"},
+			},
+		})
+		require.NoError(t, e.ConsumeLogs(context.Background(), ld))
+		assert.Equal(t, int32(1), posts.Load(), "k8s consumer should be invoked once")
+		select {
+		case <-ch:
+			t.Fatal("regular channel should not receive anything")
+		default:
+		}
+	})
+
+	t.Run("orchestrator enabled, mixed batch: both consumers invoked", func(t *testing.T) {
+		var posts atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			posts.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		ch := make(chan *message.Message, 4)
+		e := newExp(t, ch, &Config{
+			OtelSource:    otelSource,
+			LogSourceName: LogSourceName,
+			OrchestratorConfig: OrchestratorConfig{
+				Enabled: true, Endpoint: server.URL, Key: "k", Hostname: stubHostname{name: "h"},
+			},
+		})
+		require.NoError(t, e.ConsumeLogs(context.Background(), mixedLogs()))
+		assert.Equal(t, int32(1), posts.Load(), "k8s consumer should be invoked once")
+		select {
+		case <-ch:
+		default:
+			t.Fatal("expected regular log to reach channel")
+		}
 	})
 }

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter_test.go
@@ -457,4 +457,43 @@ func TestSplitLogsByScope(t *testing.T) {
 		assert.Equal(t, 1, k8s.ResourceLogs().Len())
 		assert.Equal(t, 0, regular.ResourceLogs().Len())
 	})
+
+	t.Run("all-regular fast path returns ld unchanged", func(t *testing.T) {
+		ld := plog.NewLogs()
+		ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().Scope().SetName("filelog")
+		ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().Scope().SetName("otherreceiver")
+
+		k8s, regular := splitLogsByScope(ld)
+		assert.Equal(t, 0, k8s.ResourceLogs().Len())
+		assert.Equal(t, 2, regular.ResourceLogs().Len())
+		// fast path returns the same backing plog.Logs (no copy)
+		assert.Equal(t, ld, regular)
+	})
+
+	t.Run("scopeless ResourceLogs routed to regular side", func(t *testing.T) {
+		ld := plog.NewLogs()
+		scopeless := ld.ResourceLogs().AppendEmpty()
+		scopeless.SetSchemaUrl("https://example.com/schema")
+		scopeless.Resource().Attributes().PutStr("host.name", "host-a")
+		ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().Scope().SetName(string(K8sObjectsReceiver))
+
+		k8s, regular := splitLogsByScope(ld)
+		assert.Equal(t, 1, k8s.ResourceLogs().Len())
+		assert.Equal(t, 1, regular.ResourceLogs().Len())
+		assert.Equal(t, 0, regular.ResourceLogs().At(0).ScopeLogs().Len())
+		assert.Equal(t, "https://example.com/schema", regular.ResourceLogs().At(0).SchemaUrl())
+		hostName, ok := regular.ResourceLogs().At(0).Resource().Attributes().Get("host.name")
+		assert.True(t, ok)
+		assert.Equal(t, "host-a", hostName.AsString())
+	})
+
+	t.Run("scopeless ResourceLogs only takes fast path as regular", func(t *testing.T) {
+		ld := plog.NewLogs()
+		ld.ResourceLogs().AppendEmpty().Resource().Attributes().PutStr("host.name", "host-a")
+
+		k8s, regular := splitLogsByScope(ld)
+		assert.Equal(t, 0, k8s.ResourceLogs().Len())
+		assert.Equal(t, 1, regular.ResourceLogs().Len())
+		assert.Equal(t, ld, regular)
+	})
 }

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
@@ -42,6 +42,9 @@ func newOrchestratorExporter(config OrchestratorConfig) orchestratorExporter {
 }
 
 func (e *Exporter) consumeK8sObjects(ctx context.Context, ld plog.Logs) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	result := logsmapping.TranslateK8sObjects(ld, e.orchestratorExporter.manifestCache, e.set.Logger)
 
 	hostname, err := e.orchestratorExporter.config.Hostname.Get(ctx)


### PR DESCRIPTION
### What does this PR do?

`ConsumeLogs` decides where to send a batch by looking at the scope of the first ResourceLogs only, then sends the whole batch to one consumer.

That breaks when a batch contains records from multiple receivers, which happens whenever the OTel `batch` processor merges requests upstream. 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49322

#### Fix

Split the input per ResourceLogs based on its scope, then send each subset to the right consumer:

- k8sobjects → consumeK8sObjects
- everything else → consumeRegularLogs
