### PR TITLE
[CONTP-1785] chore(instrumentation): Replace container image with name in DDI autodiscovery handler

### DIFF
--- a/comp/core/autodiscovery/common/types/consts.go
+++ b/comp/core/autodiscovery/common/types/consts.go
@@ -19,6 +19,8 @@ const (
 	CheckCmdName = "check-cmd"
 	// CelIdentifierPrefix is the prefix used to identify CEL-based AD identifiers.
 	CelIdentifierPrefix = "cel://"
+	// KubeContainerNameIdentifierPrefix is the prefix used to identify Kubernetes containers by container name.
+	KubeContainerNameIdentifierPrefix = "kube_container_name://"
 )
 
 // CelIdentifier represents a CEL-based AD identifier.
@@ -40,3 +42,8 @@ const (
 	// CelEndpointIdentifier is the CEL identifier for endpoint resources.
 	CelEndpointIdentifier CelIdentifier = CelIdentifierPrefix + "kube_endpoint"
 )
+
+// KubeContainerNameIdentifier returns the AD identifier for a Kubernetes container name.
+func KubeContainerNameIdentifier(containerName string) string {
+	return KubeContainerNameIdentifierPrefix + containerName
+}

--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"time"
 
+	adtypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -204,7 +205,7 @@ func (l *KubeletListener) createContainerService(
 		svc.adIdentifiers = append(svc.adIdentifiers, customADID)
 	}
 
-	svc.adIdentifiers = append(svc.adIdentifiers, entity, containerImg.RawName)
+	svc.adIdentifiers = append(svc.adIdentifiers, adtypes.KubeContainerNameIdentifier(containerName), entity, containerImg.RawName)
 
 	if len(containerImg.ShortName) > 0 && containerImg.ShortName != containerImg.RawName {
 		svc.adIdentifiers = append(svc.adIdentifiers, containerImg.ShortName)

--- a/comp/core/autodiscovery/listeners/kubelet_test.go
+++ b/comp/core/autodiscovery/listeners/kubelet_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	adtypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -258,6 +259,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 					service: &WorkloadService{
 						entity: basicContainer,
 						adIdentifiers: []string{
+							adtypes.KubeContainerNameIdentifier(containerName),
 							"docker://foobarquux",
 							"gcr.io/foobar:latest",
 							"foobar",
@@ -292,6 +294,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 					service: &WorkloadService{
 						entity: recentlyStoppedContainer,
 						adIdentifiers: []string{
+							adtypes.KubeContainerNameIdentifier(containerName),
 							"docker://foobarquux",
 							"foobar",
 						},
@@ -349,6 +352,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 					service: &WorkloadService{
 						entity: runningContainerWithFinishedAtTime,
 						adIdentifiers: []string{
+							adtypes.KubeContainerNameIdentifier(containerName),
 							"docker://foobarquux",
 							"foobar",
 						},
@@ -382,6 +386,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 					service: &WorkloadService{
 						entity: multiplePortsContainer,
 						adIdentifiers: []string{
+							adtypes.KubeContainerNameIdentifier(containerName),
 							"docker://foobarquux",
 							"foobar",
 						},
@@ -425,6 +430,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 						entity: customIDsContainer,
 						adIdentifiers: []string{
 							"customid",
+							adtypes.KubeContainerNameIdentifier(containerName),
 							"docker://foobarquux",
 							"foobar",
 						},
@@ -471,6 +477,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 						entity: customIDsContainer,
 						adIdentifiers: []string{
 							"customid",
+							adtypes.KubeContainerNameIdentifier(containerName),
 							"docker://foobarquux",
 							"foobar",
 						},
@@ -507,6 +514,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 						entity: customIDsContainer,
 						adIdentifiers: []string{
 							"customid",
+							adtypes.KubeContainerNameIdentifier(containerName),
 							"docker://foobarquux",
 							"foobar",
 						},
@@ -543,6 +551,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 						entity: customIDsContainer,
 						adIdentifiers: []string{
 							"customid",
+							adtypes.KubeContainerNameIdentifier(containerName),
 							"docker://foobarquux",
 							"foobar",
 						},
@@ -633,6 +642,7 @@ func TestProcessPodWithEphemeralContainer(t *testing.T) {
 			service: &WorkloadService{
 				entity: container,
 				adIdentifiers: []string{
+					adtypes.KubeContainerNameIdentifier(ephemeralContainerName),
 					"docker://ephemeral-container-id",
 					"debug-image",
 				},

--- a/go.mod
+++ b/go.mod
@@ -163,7 +163,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.82.0-devel.0.20260624113434-509b872045c2
 	github.com/DataDog/datadog-agent/pkg/version v0.81.0-devel.0.20260603133502-a41610237dba
 	github.com/DataDog/datadog-go/v5 v5.8.3
-	github.com/DataDog/datadog-operator/api v0.0.0-20260625145238-9a1cc9ae2675
+	github.com/DataDog/datadog-operator/api v0.0.0-20260626143205-3481300263ec
 	github.com/DataDog/datadog-traceroute v1.0.17
 	github.com/DataDog/dd-trace-go/v2 v2.8.2
 	github.com/DataDog/ebpf-manager v0.7.18

--- a/go.mod
+++ b/go.mod
@@ -163,7 +163,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.82.0-devel.0.20260624113434-509b872045c2
 	github.com/DataDog/datadog-agent/pkg/version v0.81.0-devel.0.20260603133502-a41610237dba
 	github.com/DataDog/datadog-go/v5 v5.8.3
-	github.com/DataDog/datadog-operator/api v0.0.0-20260515125012-8e158b708444
+	github.com/DataDog/datadog-operator/api v0.0.0-20260625145238-9a1cc9ae2675
 	github.com/DataDog/datadog-traceroute v1.0.17
 	github.com/DataDog/dd-trace-go/v2 v2.8.2
 	github.com/DataDog/ebpf-manager v0.7.18

--- a/go.sum
+++ b/go.sum
@@ -2545,8 +2545,8 @@ github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dX
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSqGF5n0s=
 github.com/DataDog/datadog-go/v5 v5.8.3/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
-github.com/DataDog/datadog-operator/api v0.0.0-20260515125012-8e158b708444 h1:ewuSNgxVuGWBB7fFHzKjDNdkxxLPkbf72fhj7ptRP74=
-github.com/DataDog/datadog-operator/api v0.0.0-20260515125012-8e158b708444/go.mod h1:zR/MNYiw871evAtspmVn/QpLlPlaakes4YZtQpRFQfU=
+github.com/DataDog/datadog-operator/api v0.0.0-20260626143205-3481300263ec h1:CerkrVwSfyqPnTr7tn3udEkavki+xSvjFCGA1XTGkYg=
+github.com/DataDog/datadog-operator/api v0.0.0-20260626143205-3481300263ec/go.mod h1:uBJ12iaiqhAc0NExRYjhD9X8YnZckba80Ypz8HTFLuI=
 github.com/DataDog/datadog-traceroute v1.0.17 h1:MyBJCb+pFLjN3tt0boZprYmyj4iegHmKzst5iWil/Dw=
 github.com/DataDog/datadog-traceroute v1.0.17/go.mod h1:gtDOEd1qCVGULNYdHULzFBbdDLJwpP+nJMKSXiuVi78=
 github.com/DataDog/dd-trace-go/v2 v2.8.2 h1:ZqF2M7j5DPG7PxkJpLIjF4L62LU/QnI86oOSAZjQC/U=

--- a/pkg/clusteragent/instrumentation/handlers/BUILD.bazel
+++ b/pkg/clusteragent/instrumentation/handlers/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation/handlers",
     visibility = ["//visibility:public"],
     deps = [
+        "//comp/core/autodiscovery/common/types",
         "//comp/core/autodiscovery/integration",
         "//comp/core/workloadfilter/def",
         "//pkg/clusteragent/instrumentation",
@@ -30,6 +31,7 @@ go_test(
         "test",
     ],
     deps = [
+        "//comp/core/autodiscovery/common/types",
         "//comp/core/autodiscovery/integration",
         "//pkg/clusteragent/instrumentation",
         "@com_github_datadog_datadog_operator_api//datadoghq/v1alpha1",

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -86,13 +86,8 @@ func (h *AutodiscoveryHandler) Validate(cr *datadoghq.DatadogInstrumentation) []
 			errs = append(errs, h.checkValidationError(i, "instances", "InvalidInstances", "at least one instance or log config is required"))
 		}
 
-		if !isService(cr) {
-			if !hasContainerTarget(check) {
-				errs = append(errs, h.checkValidationError(i, "", "InvalidContainerTarget", "at least one container image or container name is required"))
-			}
-			if hasContainerName(check) && hasContainerImage(check) {
-				errs = append(errs, h.checkValidationError(i, "", "InvalidContainerTarget", "container image and container name cannot both be set"))
-			}
+		if !isService(cr) && !hasContainerName(check) {
+			errs = append(errs, h.checkValidationError(i, "containerName", "InvalidContainerTarget", "container name is required"))
 		}
 	}
 	return errs
@@ -245,7 +240,7 @@ func rawExtensionToData(raw runtime.RawExtension) (integration.Data, error) {
 	return b, nil
 }
 
-func marshalLogs(logs []datadoghq.DatadogInstrumentationLogFields) (integration.Data, error) {
+func marshalLogs(logs []datadoghq.DatadogInstrumentationLogConfig) (integration.Data, error) {
 	if len(logs) == 0 {
 		return nil, nil
 	}
@@ -266,21 +261,13 @@ func buildCELSelector(ref autoscalingv2.CrossVersionObjectReference, namespace s
 	}
 }
 
-func hasContainerTarget(check datadoghq.DatadogInstrumentationCheckConfig) bool {
-	return hasContainerName(check) || hasContainerImage(check)
-}
-
 func hasContainerName(check datadoghq.DatadogInstrumentationCheckConfig) bool {
 	return strings.TrimSpace(check.ContainerName) != ""
-}
-
-func hasContainerImage(check datadoghq.DatadogInstrumentationCheckConfig) bool {
-	return len(check.ContainerImage) > 0
 }
 
 func adIdentifiers(check datadoghq.DatadogInstrumentationCheckConfig) []string {
 	if hasContainerName(check) {
 		return []string{adtypes.KubeContainerNameIdentifier(strings.TrimSpace(check.ContainerName))}
 	}
-	return check.ContainerImage
+	return nil
 }

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -79,35 +79,36 @@ func (h *AutodiscoveryHandler) Validate(cr *datadoghq.DatadogInstrumentation) []
 	var errs []instrumentation.ValidationError
 	for i, check := range cr.Spec.Config.Checks {
 		if strings.TrimSpace(check.Integration) == "" {
-			errs = append(errs, instrumentation.ValidationError{
-				Type:        checksReadyConditionType,
-				Reason:      "InvalidIntegration",
-				Message:     "integration name must not be empty",
-				Field:       fmt.Sprintf("spec.config.checks[%d].integration", i),
-				HandlerName: h.Name(),
-			})
+			errs = append(errs, h.checkValidationError(i, "integration", "InvalidIntegration", "integration name must not be empty"))
 		}
 		if len(check.Instances) == 0 && len(check.Logs) == 0 {
-			errs = append(errs, instrumentation.ValidationError{
-				Type:        checksReadyConditionType,
-				Reason:      "InvalidInstances",
-				Message:     "at least one instance or log config is required",
-				Field:       fmt.Sprintf("spec.config.checks[%d].instances", i),
-				HandlerName: h.Name(),
-			})
+			errs = append(errs, h.checkValidationError(i, "instances", "InvalidInstances", "at least one instance or log config is required"))
 		}
 
-		if !hasContainerTarget(check) && !isService(cr) {
-			errs = append(errs, instrumentation.ValidationError{
-				Type:        checksReadyConditionType,
-				Reason:      "InvalidContainerTarget",
-				Message:     "at least one container image or container name is required",
-				Field:       fmt.Sprintf("spec.config.checks[%d]", i),
-				HandlerName: h.Name(),
-			})
+		if !isService(cr) {
+			if !hasContainerTarget(check) {
+				errs = append(errs, h.checkValidationError(i, "", "InvalidContainerTarget", "at least one container image or container name is required"))
+			}
+			if hasContainerName(check) && hasContainerImage(check) {
+				errs = append(errs, h.checkValidationError(i, "", "InvalidContainerTarget", "container image and container name cannot both be set"))
+			}
 		}
 	}
 	return errs
+}
+
+func (h *AutodiscoveryHandler) checkValidationError(index int, field, reason, message string) instrumentation.ValidationError {
+	fieldPath := fmt.Sprintf("spec.config.checks[%d]", index)
+	if field != "" {
+		fieldPath += "." + field
+	}
+	return instrumentation.ValidationError{
+		Type:        checksReadyConditionType,
+		Reason:      reason,
+		Message:     message,
+		Field:       fieldPath,
+		HandlerName: h.Name(),
+	}
 }
 
 // Handle translates check configs on Create/Update, removes them on Delete,
@@ -268,11 +269,19 @@ func buildCELSelector(ref autoscalingv2.CrossVersionObjectReference, namespace s
 }
 
 func hasContainerTarget(check datadoghq.DatadogInstrumentationCheckConfig) bool {
-	return strings.TrimSpace(check.ContainerName) != "" || len(check.ContainerImage) > 0
+	return hasContainerName(check) || hasContainerImage(check)
+}
+
+func hasContainerName(check datadoghq.DatadogInstrumentationCheckConfig) bool {
+	return strings.TrimSpace(check.ContainerName) != ""
+}
+
+func hasContainerImage(check datadoghq.DatadogInstrumentationCheckConfig) bool {
+	return len(check.ContainerImage) > 0
 }
 
 func adIdentifiers(check datadoghq.DatadogInstrumentationCheckConfig) []string {
-	if strings.TrimSpace(check.ContainerName) != "" {
+	if hasContainerName(check) {
 		return nil
 	}
 	return check.ContainerImage

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	adtypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
@@ -186,7 +187,7 @@ func translateWorkloadCheck(cr *datadoghq.DatadogInstrumentation, check datadogh
 		InitConfig:    initConfig,
 		Instances:     instances,
 		LogsConfig:    logsConfig,
-		CELSelector:   buildCELSelector(cr.Spec.TargetRef, cr.Namespace, strings.TrimSpace(check.ContainerName)),
+		CELSelector:   buildCELSelector(cr.Spec.TargetRef, cr.Namespace),
 		Source:        fmt.Sprintf("%s:%s/%s", autodiscoveryProvider, cr.Namespace, cr.Name),
 	}, nil
 }
@@ -255,14 +256,11 @@ func marshalLogs(logs []datadoghq.DatadogInstrumentationLogFields) (integration.
 	return b, nil
 }
 
-func buildCELSelector(ref autoscalingv2.CrossVersionObjectReference, namespace string, containerName string) workloadfilter.Rules {
+func buildCELSelector(ref autoscalingv2.CrossVersionObjectReference, namespace string) workloadfilter.Rules {
 	expr := fmt.Sprintf(
 		`container.pod.rootowner.kind == %q && container.pod.rootowner.name == %q && container.pod.namespace == %q && container.image.reference != ""`,
 		ref.Kind, ref.Name, namespace,
 	)
-	if containerName != "" {
-		expr = fmt.Sprintf("%s && container.name == %q", expr, containerName)
-	}
 	return workloadfilter.Rules{
 		Containers: []string{expr},
 	}
@@ -282,7 +280,7 @@ func hasContainerImage(check datadoghq.DatadogInstrumentationCheckConfig) bool {
 
 func adIdentifiers(check datadoghq.DatadogInstrumentationCheckConfig) []string {
 	if hasContainerName(check) {
-		return nil
+		return []string{adtypes.KubeContainerNameIdentifier(strings.TrimSpace(check.ContainerName))}
 	}
 	return check.ContainerImage
 }

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -97,12 +97,12 @@ func (h *AutodiscoveryHandler) Validate(cr *datadoghq.DatadogInstrumentation) []
 			})
 		}
 
-		if len(check.ContainerImage) == 0 && !isService(cr) {
+		if !hasContainerTarget(check) && !isService(cr) {
 			errs = append(errs, instrumentation.ValidationError{
 				Type:        checksReadyConditionType,
-				Reason:      "InvalidContainerImage",
-				Message:     "at least one container image is required",
-				Field:       fmt.Sprintf("spec.config.checks[%d].containerImage", i),
+				Reason:      "InvalidContainerTarget",
+				Message:     "at least one container image or container name is required",
+				Field:       fmt.Sprintf("spec.config.checks[%d]", i),
 				HandlerName: h.Name(),
 			})
 		}
@@ -181,11 +181,11 @@ func translateWorkloadCheck(cr *datadoghq.DatadogInstrumentation, check datadogh
 	}
 	return integration.Config{
 		Name:          check.Integration,
-		ADIdentifiers: check.ContainerImage,
+		ADIdentifiers: adIdentifiers(check),
 		InitConfig:    initConfig,
 		Instances:     instances,
 		LogsConfig:    logsConfig,
-		CELSelector:   buildCELSelector(cr.Spec.TargetRef, cr.Namespace),
+		CELSelector:   buildCELSelector(cr.Spec.TargetRef, cr.Namespace, strings.TrimSpace(check.ContainerName)),
 		Source:        fmt.Sprintf("%s:%s/%s", autodiscoveryProvider, cr.Namespace, cr.Name),
 	}, nil
 }
@@ -243,7 +243,7 @@ func rawExtensionToData(raw runtime.RawExtension) (integration.Data, error) {
 	return b, nil
 }
 
-func marshalLogs(logs []datadoghq.DatadogInstrumentationLogConfig) (integration.Data, error) {
+func marshalLogs(logs []datadoghq.DatadogInstrumentationLogFields) (integration.Data, error) {
 	if len(logs) == 0 {
 		return nil, nil
 	}
@@ -254,12 +254,26 @@ func marshalLogs(logs []datadoghq.DatadogInstrumentationLogConfig) (integration.
 	return b, nil
 }
 
-func buildCELSelector(ref autoscalingv2.CrossVersionObjectReference, namespace string) workloadfilter.Rules {
+func buildCELSelector(ref autoscalingv2.CrossVersionObjectReference, namespace string, containerName string) workloadfilter.Rules {
 	expr := fmt.Sprintf(
-		`container.pod.rootowner.kind == %q && container.pod.rootowner.name == %q && container.pod.namespace == %q`,
+		`container.pod.rootowner.kind == %q && container.pod.rootowner.name == %q && container.pod.namespace == %q && container.image.reference != ""`,
 		ref.Kind, ref.Name, namespace,
 	)
+	if containerName != "" {
+		expr = fmt.Sprintf("%s && container.name == %q", expr, containerName)
+	}
 	return workloadfilter.Rules{
 		Containers: []string{expr},
 	}
+}
+
+func hasContainerTarget(check datadoghq.DatadogInstrumentationCheckConfig) bool {
+	return strings.TrimSpace(check.ContainerName) != "" || len(check.ContainerImage) > 0
+}
+
+func adIdentifiers(check datadoghq.DatadogInstrumentationCheckConfig) []string {
+	if strings.TrimSpace(check.ContainerName) != "" {
+		return nil
+	}
+	return check.ContainerImage
 }

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -176,9 +176,15 @@ func translateWorkloadCheck(cr *datadoghq.DatadogInstrumentation, check datadogh
 	if err != nil {
 		return integration.Config{}, err
 	}
+
+	var adIdentifiers []string
+	if hasContainerName(check) {
+		adIdentifiers = []string{adtypes.KubeContainerNameIdentifier(strings.TrimSpace(check.ContainerName))}
+	}
+
 	return integration.Config{
 		Name:          check.Integration,
-		ADIdentifiers: adIdentifiers(check),
+		ADIdentifiers: adIdentifiers,
 		InitConfig:    initConfig,
 		Instances:     instances,
 		LogsConfig:    logsConfig,
@@ -263,11 +269,4 @@ func buildCELSelector(ref autoscalingv2.CrossVersionObjectReference, namespace s
 
 func hasContainerName(check datadoghq.DatadogInstrumentationCheckConfig) bool {
 	return strings.TrimSpace(check.ContainerName) != ""
-}
-
-func adIdentifiers(check datadoghq.DatadogInstrumentationCheckConfig) []string {
-	if hasContainerName(check) {
-		return []string{adtypes.KubeContainerNameIdentifier(strings.TrimSpace(check.ContainerName))}
-	}
-	return nil
 }

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -159,7 +159,7 @@ func TestValidate(t *testing.T) {
 			expectErrCount: 0,
 		},
 		{
-			name: "valid check with container image fallback",
+			name: "valid check with container image",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
 					Integration:    "redisdb",

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
+	adtypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
 )
@@ -445,6 +446,7 @@ func TestTranslateCheck(t *testing.T) {
 		expectedInstLen  int
 		expectedADIDs    []string
 		expectedCEL      []string
+		unexpectedCEL    []string
 		instanceContains []string
 		logsNil          bool
 		logsContains     string
@@ -458,7 +460,9 @@ func TestTranslateCheck(t *testing.T) {
 			},
 			expectedInit:    "{}",
 			expectedInstLen: 1,
-			expectedCEL:     []string{`container.name == "app"`},
+			expectedADIDs:   []string{adtypes.KubeContainerNameIdentifier("app")},
+			expectedCEL:     []string{`container.pod.rootowner.name == "app"`},
+			unexpectedCEL:   []string{`container.name == "app"`},
 			logsNil:         true,
 		},
 		{
@@ -471,7 +475,9 @@ func TestTranslateCheck(t *testing.T) {
 			},
 			expectedInit:    `{"service":"myservice"}`,
 			expectedInstLen: 1,
-			expectedCEL:     []string{`container.name == "app"`},
+			expectedADIDs:   []string{adtypes.KubeContainerNameIdentifier("app")},
+			expectedCEL:     []string{`container.pod.rootowner.name == "app"`},
+			unexpectedCEL:   []string{`container.name == "app"`},
 			logsNil:         true,
 		},
 		{
@@ -500,7 +506,9 @@ func TestTranslateCheck(t *testing.T) {
 			},
 			expectedInit:    "{}",
 			expectedInstLen: 1,
-			expectedCEL:     []string{`container.name == "app"`},
+			expectedADIDs:   []string{adtypes.KubeContainerNameIdentifier("app")},
+			expectedCEL:     []string{`container.pod.rootowner.name == "app"`},
+			unexpectedCEL:   []string{`container.name == "app"`},
 			logsNil:         true,
 		},
 		{
@@ -544,6 +552,10 @@ func TestTranslateCheck(t *testing.T) {
 					assert.Contains(t, configs[0].CELSelector.Containers[0], expr)
 				}
 			}
+			for _, expr := range tt.unexpectedCEL {
+				require.Len(t, configs[0].CELSelector.Containers, 1)
+				assert.NotContains(t, configs[0].CELSelector.Containers[0], expr)
+			}
 
 			for i, substr := range tt.instanceContains {
 				assert.Contains(t, string(configs[0].Instances[i]), substr)
@@ -563,11 +575,10 @@ func TestBuildCELSelector(t *testing.T) {
 		kind      string
 		target    string
 		namespace string
-		container string
 		contains  []string
 	}{
 		{
-			name:      "basic selector without container names",
+			name:      "basic selector",
 			kind:      "Deployment",
 			target:    "my-app",
 			namespace: "default",
@@ -579,37 +590,35 @@ func TestBuildCELSelector(t *testing.T) {
 			},
 		},
 		{
-			name:      "selector with single container name",
+			name:      "selector with statefulset target",
 			kind:      "StatefulSet",
 			target:    "redis",
 			namespace: "data",
-			container: "redis",
 			contains: []string{
 				`container.pod.rootowner.kind == "StatefulSet"`,
-				`container.name == "redis"`,
+				`container.pod.rootowner.name == "redis"`,
 			},
 		},
 		{
-			name:      "selector with different container name",
+			name:      "selector with deployment target",
 			kind:      "Deployment",
 			target:    "multi",
 			namespace: "default",
-			container: "sidecar",
 			contains: []string{
 				`container.pod.rootowner.kind == "Deployment"`,
 				`container.pod.rootowner.name == "multi"`,
-				`container.name == "sidecar"`,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ref := autoscalingv2.CrossVersionObjectReference{Kind: tt.kind, Name: tt.target}
-			rules := buildCELSelector(ref, tt.namespace, tt.container)
+			rules := buildCELSelector(ref, tt.namespace)
 			require.Len(t, rules.Containers, 1)
 			for _, substr := range tt.contains {
 				assert.Contains(t, rules.Containers[0], substr)
 			}
+			assert.NotContains(t, rules.Containers[0], `container.name ==`)
 		})
 	}
 }

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -421,8 +421,6 @@ func TestTranslateCheck(t *testing.T) {
 		expectedInit     string
 		expectedInstLen  int
 		expectedADIDs    []string
-		expectedCEL      []string
-		unexpectedCEL    []string
 		instanceContains []string
 		logsNil          bool
 		logsContains     string
@@ -437,8 +435,6 @@ func TestTranslateCheck(t *testing.T) {
 			expectedInit:    "{}",
 			expectedInstLen: 1,
 			expectedADIDs:   []string{adtypes.KubeContainerNameIdentifier("app")},
-			expectedCEL:     []string{`container.pod.rootowner.name == "app"`},
-			unexpectedCEL:   []string{`container.name == "app"`},
 			logsNil:         true,
 		},
 		{
@@ -452,8 +448,6 @@ func TestTranslateCheck(t *testing.T) {
 			expectedInit:    `{"service":"myservice"}`,
 			expectedInstLen: 1,
 			expectedADIDs:   []string{adtypes.KubeContainerNameIdentifier("app")},
-			expectedCEL:     []string{`container.pod.rootowner.name == "app"`},
-			unexpectedCEL:   []string{`container.name == "app"`},
 			logsNil:         true,
 		},
 		{
@@ -467,8 +461,6 @@ func TestTranslateCheck(t *testing.T) {
 			expectedInit:    "{}",
 			expectedInstLen: 1,
 			expectedADIDs:   []string{adtypes.KubeContainerNameIdentifier("app")},
-			expectedCEL:     []string{`container.pod.rootowner.name == "app"`},
-			unexpectedCEL:   []string{`container.name == "app"`},
 			logsContains:    `"type":"tcp"`,
 		},
 		{
@@ -494,17 +486,6 @@ func TestTranslateCheck(t *testing.T) {
 			assert.Equal(t, tt.expectedInit, string(configs[0].InitConfig))
 			require.Len(t, configs[0].Instances, tt.expectedInstLen)
 			require.ElementsMatch(t, tt.expectedADIDs, configs[0].ADIdentifiers)
-
-			if len(tt.expectedCEL) > 0 {
-				require.Len(t, configs[0].CELSelector.Containers, 1)
-				for _, expr := range tt.expectedCEL {
-					assert.Contains(t, configs[0].CELSelector.Containers[0], expr)
-				}
-			}
-			for _, expr := range tt.unexpectedCEL {
-				require.Len(t, configs[0].CELSelector.Containers, 1)
-				assert.NotContains(t, configs[0].CELSelector.Containers[0], expr)
-			}
 
 			for i, substr := range tt.instanceContains {
 				assert.Contains(t, string(configs[0].Instances[i]), substr)

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -181,6 +181,19 @@ func TestValidate(t *testing.T) {
 			expectErrCount: 0,
 		},
 		{
+			name: "container image and container name are mutually exclusive",
+			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
+				{
+					Integration:    "redisdb",
+					ContainerImage: []string{"redis"},
+					ContainerName:  "redis",
+					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+				},
+			}),
+			expectErrCount: 1,
+			expectField:    "spec.config.checks[0]",
+		},
+		{
 			name: "empty integration name",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -160,17 +160,6 @@ func TestValidate(t *testing.T) {
 			expectErrCount: 0,
 		},
 		{
-			name: "valid check with container image",
-			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
-				{
-					Integration:    "redisdb",
-					ContainerImage: []string{"redis"},
-					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
-				},
-			}),
-			expectErrCount: 0,
-		},
-		{
 			name: "valid check with container name",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
@@ -182,25 +171,12 @@ func TestValidate(t *testing.T) {
 			expectErrCount: 0,
 		},
 		{
-			name: "container image and container name are mutually exclusive",
-			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
-				{
-					Integration:    "redisdb",
-					ContainerImage: []string{"redis"},
-					ContainerName:  "redis",
-					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
-				},
-			}),
-			expectErrCount: 1,
-			expectField:    "spec.config.checks[0]",
-		},
-		{
 			name: "empty integration name",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
-					Integration:    "",
-					ContainerImage: []string{"redis"},
-					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+					Integration:   "",
+					ContainerName: "redis",
+					Instances:     []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
 				},
 			}),
 			expectErrCount: 1,
@@ -210,9 +186,9 @@ func TestValidate(t *testing.T) {
 			name: "whitespace-only integration name",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
-					Integration:    "   ",
-					ContainerImage: []string{"redis"},
-					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+					Integration:   "   ",
+					ContainerName: "redis",
+					Instances:     []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
 				},
 			}),
 			expectErrCount: 1,
@@ -222,9 +198,9 @@ func TestValidate(t *testing.T) {
 			name: "no instances or logs",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
-					Integration:    "redisdb",
-					ContainerImage: []string{"redis"},
-					Instances:      nil,
+					Integration:   "redisdb",
+					ContainerName: "redis",
+					Instances:     nil,
 				},
 			}),
 			expectErrCount: 1,
@@ -234,9 +210,9 @@ func TestValidate(t *testing.T) {
 			name: "logs only is valid",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
-					Integration:    "custom",
-					ContainerImage: []string{"app"},
-					Logs:           []datadoghq.DatadogInstrumentationLogFields{{Type: "tcp"}},
+					Integration:   "custom",
+					ContainerName: "app",
+					Logs:          []datadoghq.DatadogInstrumentationLogConfig{{Type: "tcp"}},
 				},
 			}),
 			expectErrCount: 0,
@@ -250,7 +226,7 @@ func TestValidate(t *testing.T) {
 				},
 			}),
 			expectErrCount: 1,
-			expectField:    "spec.config.checks[0]",
+			expectField:    "spec.config.checks[0].containerName",
 		},
 		{
 			name: "all validations fail for workload",
@@ -263,14 +239,14 @@ func TestValidate(t *testing.T) {
 			name: "multiple checks with mixed errors",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
-					Integration:    "redisdb",
-					ContainerImage: []string{"redis"},
-					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+					Integration:   "redisdb",
+					ContainerName: "redis",
+					Instances:     []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
 				},
 				{
-					Integration:    "",
-					ContainerImage: []string{"app"},
-					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+					Integration:   "",
+					ContainerName: "app",
+					Instances:     []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
 				},
 			}),
 			expectErrCount: 1,
@@ -481,45 +457,18 @@ func TestTranslateCheck(t *testing.T) {
 			logsNil:         true,
 		},
 		{
-			name: "container image fallback uses AD identifiers",
+			name: "logs config is translated",
 			check: datadoghq.DatadogInstrumentationCheckConfig{
-				Integration:    "http_check",
-				ContainerImage: []string{"app-image", "sidecar-image"},
-				Instances: []runtime.RawExtension{
-					{Raw: []byte(`{"url":"http://host1"}`)},
-					{Raw: []byte(`{"url":"http://host2"}`)},
-				},
-			},
-			expectedInit:     "{}",
-			expectedInstLen:  2,
-			expectedADIDs:    []string{"app-image", "sidecar-image"},
-			instanceContains: []string{"host1", "host2"},
-			logsNil:          true,
-		},
-		{
-			name: "container name takes precedence over container image",
-			check: datadoghq.DatadogInstrumentationCheckConfig{
-				Integration:    "http_check",
-				ContainerName:  "app",
-				ContainerImage: []string{"app-image"},
-				Instances:      []runtime.RawExtension{{Raw: []byte(`{"url":"http://localhost"}`)}},
+				Integration:   "custom",
+				ContainerName: "app",
+				Instances:     []runtime.RawExtension{{Raw: []byte(`{"key":"val"}`)}},
+				Logs:          []datadoghq.DatadogInstrumentationLogConfig{{Type: "tcp", Port: &port}},
 			},
 			expectedInit:    "{}",
 			expectedInstLen: 1,
 			expectedADIDs:   []string{adtypes.KubeContainerNameIdentifier("app")},
 			expectedCEL:     []string{`container.pod.rootowner.name == "app"`},
 			unexpectedCEL:   []string{`container.name == "app"`},
-			logsNil:         true,
-		},
-		{
-			name: "logs config is translated",
-			check: datadoghq.DatadogInstrumentationCheckConfig{
-				Integration: "custom",
-				Instances:   []runtime.RawExtension{{Raw: []byte(`{"key":"val"}`)}},
-				Logs:        []datadoghq.DatadogInstrumentationLogFields{{Type: "tcp", Port: &port}},
-			},
-			expectedInit:    "{}",
-			expectedInstLen: 1,
 			logsContains:    `"type":"tcp"`,
 		},
 		{

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -159,12 +159,23 @@ func TestValidate(t *testing.T) {
 			expectErrCount: 0,
 		},
 		{
-			name: "valid check",
+			name: "valid check with container image fallback",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
 					Integration:    "redisdb",
 					ContainerImage: []string{"redis"},
 					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+				},
+			}),
+			expectErrCount: 0,
+		},
+		{
+			name: "valid check with container name",
+			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
+				{
+					Integration:   "redisdb",
+					ContainerName: "redis",
+					Instances:     []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
 				},
 			}),
 			expectErrCount: 0,
@@ -211,13 +222,13 @@ func TestValidate(t *testing.T) {
 				{
 					Integration:    "custom",
 					ContainerImage: []string{"app"},
-					Logs:           []datadoghq.DatadogInstrumentationLogConfig{{Type: "tcp"}},
+					Logs:           []datadoghq.DatadogInstrumentationLogFields{{Type: "tcp"}},
 				},
 			}),
 			expectErrCount: 0,
 		},
 		{
-			name: "no container image for workload",
+			name: "no container name for workload",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
 					Integration: "redisdb",
@@ -225,7 +236,7 @@ func TestValidate(t *testing.T) {
 				},
 			}),
 			expectErrCount: 1,
-			expectField:    "spec.config.checks[0].containerImage",
+			expectField:    "spec.config.checks[0]",
 		},
 		{
 			name: "all validations fail for workload",
@@ -420,6 +431,7 @@ func TestTranslateCheck(t *testing.T) {
 		expectedInit     string
 		expectedInstLen  int
 		expectedADIDs    []string
+		expectedCEL      []string
 		instanceContains []string
 		logsNil          bool
 		logsContains     string
@@ -427,33 +439,33 @@ func TestTranslateCheck(t *testing.T) {
 		{
 			name: "empty init config defaults to {}",
 			check: datadoghq.DatadogInstrumentationCheckConfig{
-				Integration:    "http_check",
-				ContainerImage: []string{"container-image"},
-				Instances:      []runtime.RawExtension{{Raw: []byte(`{"url":"http://localhost"}`)}},
+				Integration:   "http_check",
+				ContainerName: "app",
+				Instances:     []runtime.RawExtension{{Raw: []byte(`{"url":"http://localhost"}`)}},
 			},
 			expectedInit:    "{}",
 			expectedInstLen: 1,
-			expectedADIDs:   []string{"container-image"},
+			expectedCEL:     []string{`container.name == "app"`},
 			logsNil:         true,
 		},
 		{
 			name: "provided init config is preserved",
 			check: datadoghq.DatadogInstrumentationCheckConfig{
-				Integration:    "http_check",
-				ContainerImage: []string{"container-image"},
-				InitConfig:     runtime.RawExtension{Raw: []byte(`{"service":"myservice"}`)},
-				Instances:      []runtime.RawExtension{{Raw: []byte(`{"url":"http://localhost"}`)}},
+				Integration:   "http_check",
+				ContainerName: "app",
+				InitConfig:    runtime.RawExtension{Raw: []byte(`{"service":"myservice"}`)},
+				Instances:     []runtime.RawExtension{{Raw: []byte(`{"url":"http://localhost"}`)}},
 			},
 			expectedInit:    `{"service":"myservice"}`,
 			expectedInstLen: 1,
-			expectedADIDs:   []string{"container-image"},
+			expectedCEL:     []string{`container.name == "app"`},
 			logsNil:         true,
 		},
 		{
-			name: "multiple instances are translated",
+			name: "container image fallback uses AD identifiers",
 			check: datadoghq.DatadogInstrumentationCheckConfig{
 				Integration:    "http_check",
-				ContainerImage: []string{"container-image", "other-container"},
+				ContainerImage: []string{"app-image", "sidecar-image"},
 				Instances: []runtime.RawExtension{
 					{Raw: []byte(`{"url":"http://host1"}`)},
 					{Raw: []byte(`{"url":"http://host2"}`)},
@@ -461,16 +473,29 @@ func TestTranslateCheck(t *testing.T) {
 			},
 			expectedInit:     "{}",
 			expectedInstLen:  2,
-			expectedADIDs:    []string{"container-image", "other-container"},
+			expectedADIDs:    []string{"app-image", "sidecar-image"},
 			instanceContains: []string{"host1", "host2"},
 			logsNil:          true,
+		},
+		{
+			name: "container name takes precedence over container image",
+			check: datadoghq.DatadogInstrumentationCheckConfig{
+				Integration:    "http_check",
+				ContainerName:  "app",
+				ContainerImage: []string{"app-image"},
+				Instances:      []runtime.RawExtension{{Raw: []byte(`{"url":"http://localhost"}`)}},
+			},
+			expectedInit:    "{}",
+			expectedInstLen: 1,
+			expectedCEL:     []string{`container.name == "app"`},
+			logsNil:         true,
 		},
 		{
 			name: "logs config is translated",
 			check: datadoghq.DatadogInstrumentationCheckConfig{
 				Integration: "custom",
 				Instances:   []runtime.RawExtension{{Raw: []byte(`{"key":"val"}`)}},
-				Logs:        []datadoghq.DatadogInstrumentationLogConfig{{Type: "tcp", Port: &port}},
+				Logs:        []datadoghq.DatadogInstrumentationLogFields{{Type: "tcp", Port: &port}},
 			},
 			expectedInit:    "{}",
 			expectedInstLen: 1,
@@ -498,9 +523,13 @@ func TestTranslateCheck(t *testing.T) {
 			require.Len(t, configs, 1)
 			assert.Equal(t, tt.expectedInit, string(configs[0].InitConfig))
 			require.Len(t, configs[0].Instances, tt.expectedInstLen)
+			require.ElementsMatch(t, tt.expectedADIDs, configs[0].ADIdentifiers)
 
-			if tt.expectedADIDs != nil {
-				require.ElementsMatch(t, tt.expectedADIDs, configs[0].ADIdentifiers)
+			if len(tt.expectedCEL) > 0 {
+				require.Len(t, configs[0].CELSelector.Containers, 1)
+				for _, expr := range tt.expectedCEL {
+					assert.Contains(t, configs[0].CELSelector.Containers[0], expr)
+				}
 			}
 
 			for i, substr := range tt.instanceContains {
@@ -521,10 +550,11 @@ func TestBuildCELSelector(t *testing.T) {
 		kind      string
 		target    string
 		namespace string
+		container string
 		contains  []string
 	}{
 		{
-			name:      "basic selector without images",
+			name:      "basic selector without container names",
 			kind:      "Deployment",
 			target:    "my-app",
 			namespace: "default",
@@ -532,32 +562,37 @@ func TestBuildCELSelector(t *testing.T) {
 				`container.pod.rootowner.kind == "Deployment"`,
 				`container.pod.rootowner.name == "my-app"`,
 				`container.pod.namespace == "default"`,
+				`container.image.reference != ""`,
 			},
 		},
 		{
-			name:      "selector with single image",
+			name:      "selector with single container name",
 			kind:      "StatefulSet",
 			target:    "redis",
 			namespace: "data",
+			container: "redis",
 			contains: []string{
 				`container.pod.rootowner.kind == "StatefulSet"`,
+				`container.name == "redis"`,
 			},
 		},
 		{
-			name:      "selector with multiple images",
+			name:      "selector with different container name",
 			kind:      "Deployment",
 			target:    "multi",
 			namespace: "default",
+			container: "sidecar",
 			contains: []string{
 				`container.pod.rootowner.kind == "Deployment"`,
 				`container.pod.rootowner.name == "multi"`,
+				`container.name == "sidecar"`,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ref := autoscalingv2.CrossVersionObjectReference{Kind: tt.kind, Name: tt.target}
-			rules := buildCELSelector(ref, tt.namespace)
+			rules := buildCELSelector(ref, tt.namespace, tt.container)
 			require.Len(t, rules.Containers, 1)
 			for _, substr := range tt.contains {
 				assert.Contains(t, rules.Containers[0], substr)


### PR DESCRIPTION
### What does this PR do?

Updates DDI autodiscovery checks to target Kubernetes containers by `containerName` instead of `containerImage`. The AD Identifier is set with `kube_container_name://<containerName>` instead of the image name to avoid pure CEL config matching.

Added container name to the AD Identifier list in `listeners/kubelet.go` but not the docker runtime listener because DDI CR is purely a kubernetes feature so adding container name to the AD ID in `containers.go` would be futile.

### Motivation

`containerName` matches how users configure Kubernetes pod specs better than requiring an exact container image. 

### Describe how you validated your changes

- Updated unit tests and they pass ✅ 
- QA'd matching by container name

#### DDI CRD spec

```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogInstrumentation
metadata:
  name: redis-instrumentation
  namespace: cache
spec:
  targetRef:
    apiVersion: apps/v1
    kind: StatefulSet
    name: redis
  config:
    checks:
      - integration: "redisdb"
        containerName: redis
        instances:
          - host: "%%host%%"
            port: "%%port%%"
            password: "ENC[k8s_secret@%%kube_namespace%%/redis-secret/password]"
            tags:
              - service:redis
```

#### Validated check is scheduled

<img width="699" height="534" alt="image" src="https://github.com/user-attachments/assets/f79ef0c8-6bee-4137-92ed-18adf5d59be6" />

#### Service has container name in AD ID

<img width="660" height="230" alt="image" src="https://github.com/user-attachments/assets/ca1e5f79-d08f-468e-ac1b-90591536d040" />

#### Config created in instrumentation check source

<img width="753" height="247" alt="image" src="https://github.com/user-attachments/assets/17962069-90e2-45ab-a220-de179fc9169f" />
