### PR TITLE
[orchestrator] Avoid recompiling regex and redundant work in K8s command-line scrubbing

### DIFF
--- a/pkg/redact/data_scrubber.go
+++ b/pkg/redact/data_scrubber.go
@@ -34,6 +34,10 @@ var (
 	knownSafeEnvVars = map[string]struct{}{
 		"DD_AUTH_TOKEN_FILE_PATH": {},
 	}
+
+	// cmdlineTokenizer tokenizes by capturing non-whitespace terms as tokens EX: "agent --secret" > ["agent", "--secret"]
+	// and non-whitespace terms followed by quotation enclosed subcomponents as tokens EX: "agent --pass="secret house"" > ["agent", "--pass="secret house""]
+	cmdlineTokenizer = regexp.MustCompile(`([^\s"']+("([^"]*)")*('([^']*)')*)`)
 )
 
 // DataScrubber allows the agent to block cmdline arguments that match
@@ -45,7 +49,6 @@ type DataScrubber struct {
 	// LiteralSensitivePatterns are custom words which use to match against
 	LiteralSensitivePatterns         []string
 	regexSensitiveWordsInAnnotations []*regexp.Regexp
-	scrubbedCmdLines                 map[string][]string
 }
 
 // NewDefaultDataScrubber creates a DataScrubber with the default behavior: enabled
@@ -54,7 +57,6 @@ func NewDefaultDataScrubber() *DataScrubber {
 	newDataScrubber := &DataScrubber{
 		Enabled:                  true,
 		LiteralSensitivePatterns: defaultSensitiveWords,
-		scrubbedCmdLines:         make(map[string][]string),
 	}
 
 	newDataScrubber.setupAnnotationRegexps(defaultSensitiveWords)
@@ -118,10 +120,7 @@ func (ds *DataScrubber) ScrubSimpleCommand(cmd, args []string) ([]string, []stri
 		}
 	}
 
-	// Regex tokenizes by capturing non-whitespace terms as tokens EX: "agent --secret" > ["agent", "--secret"]
-	// and non-whitespace terms followed by quotation enclosed subcomponents as tokens EX: "agent --pass="secret house"" > ["agent", "--pass="secret house""]
-	r := regexp.MustCompile(`([^\s"']+("([^"]*)")*('([^']*)')*)`)
-	newCmdline := r.FindAllString(rawCmdline, -1)
+	newCmdline := cmdlineTokenizer.FindAllString(rawCmdline, -1)
 
 	// remove the separator from the cmdline
 	cmIndex := 0
@@ -141,13 +140,14 @@ func (ds *DataScrubber) ScrubSimpleCommand(cmd, args []string) ([]string, []stri
 	// the first index can be skipped because it should be the program name.
 	for index := 1; index < len(newCmdline); index++ {
 		cmd := newCmdline[index]
+		lowerCmd := strings.ToLower(cmd)
 		for _, pattern := range ds.LiteralSensitivePatterns {
 			// if we found a word from the list,
 			// it means either:
 			// - the current after a delimiter should be a password we want to replace e.g. "agent --secret=<replace-me>" (1)
 			// - the next word should be replaced.  e.g. "agent --secret <replace-me>" (1)
 			// - the word is part of a special list of words, contains multiple supportedEnds and can be ignored e.g. "agent > /secret/secret" should not match (3)
-			matchIndex := strings.Index(strings.ToLower(cmd), pattern)
+			matchIndex := strings.Index(lowerCmd, pattern)
 			// password<delimiter>1234 || password || (ignore<delimiter>me<delimiter>password e.g ignore:me:password ignore/me/password)
 			// agent --password======test
 			// agent > /password/secret ==> agent > /password/secret

--- a/releasenotes/notes/optimize-k8s-cmdline-scrubbing-23c3356bc0b5adaa.yaml
+++ b/releasenotes/notes/optimize-k8s-cmdline-scrubbing-23c3356bc0b5adaa.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Reduced the CPU and memory overhead of sensitive-data scrubbing when
+    collecting Kubernetes resources for the Orchestrator Explorer. The
+    command-line tokenizer regular expression is now compiled once instead of on
+    every scrubbing call, and redundant per-token work was removed.


### PR DESCRIPTION
### What does this PR do?

Optimizes `DataScrubber.ScrubSimpleCommand` in `pkg/redact` to avoid repeated work on a hot path:

- Hoist the command-line tokenizer regex to a package-level variable so it is compiled once at init instead of on every call (`regexp.MustCompile` was being invoked per scrubbed command line).
- Compute `strings.ToLower(cmd)` once per token instead of once per sensitive pattern in the inner loop.
- Remove the unused `scrubbedCmdLines` map field and its per-scrubber allocation (dead code — never read or written; not to be confused with the actively-used cache of the same name in `pkg/process/procutil`).

### Motivation

`pkg/redact.ScrubSimpleCommand` runs while scrubbing Kubernetes pod/container
command lines and probe commands during Orchestrator Explorer resource
collection (Cluster Agent), and is also exercised by the Kubernetes flare.
Recompiling a static regex and re-lowercasing the same token for every sensitive
word is wasted CPU and allocations that scale with the number of resources
collected.

While digging into sources of heavy allocations a memory churn these areas stood out as a low hanging source of frequent small allocations within the cluster-agent / cluster-check-runners
<img width="1740" height="766" alt="Screenshot 2026-06-25 at 1 10 36 PM" src="https://github.com/user-attachments/assets/ec4a8788-ba50-4efa-8302-d86867067600" />


### Describe how you validated your changes

- `go build ./pkg/redact/` and `go test ./pkg/redact/` pass.
- No functional change: the regex pattern and tokenization logic are identical;
  `regexp.Regexp` is safe for concurrent use, so the shared package-level value
  is fine across goroutines.

### Additional Notes