### PR TITLE
pkg/clusteragent/autoscaling/cluster/spot: add Kubernetes events

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/doc.go
+++ b/pkg/clusteragent/autoscaling/cluster/doc.go
@@ -5,3 +5,7 @@
 
 // Package cluster contains the controller for cluster autoscaling.
 package cluster
+
+// EventSourceComponent is the Kubernetes event source component name for the cluster autoscaler,
+// shared by all sub-components (cluster autoscaling, spot scheduling).
+const EventSourceComponent = "datadog-cluster-autoscaler"

--- a/pkg/clusteragent/autoscaling/cluster/provider.go
+++ b/pkg/clusteragent/autoscaling/cluster/provider.go
@@ -38,7 +38,7 @@ func StartClusterAutoscaling(
 
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: apiCl.Cl.CoreV1().Events("")})
-	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "datadog-cluster-autoscaler"})
+	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: EventSourceComponent})
 
 	store := autoscaling.NewStore[model.NodePoolInternal]()
 	f := false

--- a/pkg/clusteragent/autoscaling/cluster/spot/README.md
+++ b/pkg/clusteragent/autoscaling/cluster/spot/README.md
@@ -97,7 +97,6 @@ Rebalancing handles the following cases:
 
 - [ ] Implement Argo Rollout support
 - [ ] Implement CronJob support (needs patch permission)
-- [ ] Emit Kubernetes events
 - [ ] Add spot-related labels to the agent's out-of-the-box Kubernetes tag extraction so they are automatically collected as tags on all telemetry.
   See [out-of-the-box tags documentation](https://docs.datadoghq.com/containers/kubernetes/tag/?tab=datadogoperator#out-of-the-box-tags)
   and the corresponding configuration in this repository.

--- a/pkg/clusteragent/autoscaling/cluster/spot/const.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/const.go
@@ -37,6 +37,16 @@ const (
 	spotNodeTaintValue = "interruptible"
 )
 
+// Spot scheduling Kubernetes event reasons.
+const (
+	// EventReasonSpotRebalancingEviction is the event reason for a pod evicted by the rebalancer.
+	EventReasonSpotRebalancingEviction = "SpotRebalancingEviction"
+	// EventReasonSpotFallbackEviction is the event reason for a pending spot pod evicted during on-demand fallback.
+	EventReasonSpotFallbackEviction = "SpotFallbackEviction"
+	// EventReasonSpotSchedulingDisabled is the event reason when spot scheduling is disabled for a workload.
+	EventReasonSpotSchedulingDisabled = "SpotSchedulingDisabled"
+)
+
 // Spot scheduling metrics.
 const (
 	metricPrefix = "datadog.cluster_agent.autoscaling.cluster.spot."

--- a/pkg/clusteragent/autoscaling/cluster/spot/events.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/events.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package spot
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// spotEventRecorder wraps record.EventRecorder with typed methods for spot scheduler events.
+type spotEventRecorder struct {
+	recorder record.EventRecorder
+}
+
+func newSpotEventRecorder(r record.EventRecorder) *spotEventRecorder {
+	return &spotEventRecorder{recorder: r}
+}
+
+// rebalancingEviction emits a SpotRebalancingEviction event on the evicted pod.
+func (e *spotEventRecorder) rebalancingEviction(namespace, name string, isSpot bool) {
+	capacityType := "on-demand"
+	if isSpot {
+		capacityType = "spot"
+	}
+	e.recorder.Eventf(podRef(namespace, name), corev1.EventTypeWarning,
+		EventReasonSpotRebalancingEviction,
+		"Evicted %s pod for rebalancing", capacityType)
+}
+
+// fallbackEviction emits a SpotFallbackEviction event on the evicted pending spot pod.
+func (e *spotEventRecorder) fallbackEviction(namespace, name string) {
+	e.recorder.Event(podRef(namespace, name), corev1.EventTypeWarning,
+		EventReasonSpotFallbackEviction,
+		"Evicted timed-out pending spot pod for on-demand fallback")
+}
+
+// schedulingDisabled emits a SpotSchedulingDisabled event on the workload.
+func (e *spotEventRecorder) schedulingDisabled(ref objectRef, disabledUntil time.Time) {
+	obj, err := workloadRef(ref)
+	if err != nil {
+		log.Warnf("Cannot emit %s event: %v", EventReasonSpotSchedulingDisabled, err)
+		return
+	}
+	e.recorder.Eventf(obj, corev1.EventTypeWarning,
+		EventReasonSpotSchedulingDisabled,
+		"Disabled spot scheduling until %s", disabledUntil.UTC().Format(time.RFC3339))
+}
+
+func podRef(namespace, name string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+}
+
+func workloadRef(ref objectRef) (runtime.Object, error) {
+	for i := range spotWorkloadResources {
+		if spotWorkloadResources[i].kind == ref.Kind {
+			return spotWorkloadResources[i].newObject(ref.Namespace, ref.Name), nil
+		}
+	}
+	return nil, fmt.Errorf("unknown workload kind %q", ref.Kind)
+}

--- a/pkg/clusteragent/autoscaling/cluster/spot/provider.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/provider.go
@@ -12,11 +12,17 @@ import (
 	"errors"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/cluster"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -46,6 +52,10 @@ func StartSpotScheduling(ctx context.Context, clusterID string, wlm workloadmeta
 		return tags
 	}
 
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: apiCl.Cl.CoreV1().Events("")})
+	eventRecorder := newSpotEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: cluster.EventSourceComponent}))
+
 	cfg := ReadConfig(pkgconfigsetup.Datadog())
 	tel := newTelemetry(localSender, isLeaderFunc, globalTagsFunc)
 	s := newScheduler(cfg, wlm,
@@ -54,7 +64,8 @@ func StartSpotScheduling(ctx context.Context, clusterID string, wlm workloadmeta
 		apiCl.DynamicInformerCl,
 		newWLMPodLister(wlm),
 		isLeaderFunc,
-		tel)
+		tel,
+		eventRecorder)
 	s.Start(ctx)
 
 	return s, nil

--- a/pkg/clusteragent/autoscaling/cluster/spot/scheduler.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/scheduler.go
@@ -34,10 +34,11 @@ type scheduler struct {
 	tracker     *podTracker
 	controller  *workloadController
 	telemetry   *telemetry
+	events      *spotEventRecorder
 	synced      chan struct{}
 }
 
-func newScheduler(cfg Config, wlm workloadmeta.Component, evictor podEvictor, patcher workloadPatcher, dynamicClient dynamic.Interface, lister podLister, isLeader func() bool, tel *telemetry) *scheduler {
+func newScheduler(cfg Config, wlm workloadmeta.Component, evictor podEvictor, patcher workloadPatcher, dynamicClient dynamic.Interface, lister podLister, isLeader func() bool, tel *telemetry, events *spotEventRecorder) *scheduler {
 	s := &scheduler{
 		config:    cfg,
 		wlm:       wlm,
@@ -45,6 +46,7 @@ func newScheduler(cfg Config, wlm workloadmeta.Component, evictor podEvictor, pa
 		patcher:   patcher,
 		isLeader:  isLeader,
 		telemetry: tel,
+		events:    events,
 		synced:    make(chan struct{}),
 	}
 	defaultConfig := workloadSpotConfig{percentage: cfg.Percentage, minOnDemand: cfg.MinOnDemandReplicas}
@@ -146,6 +148,7 @@ func (s *scheduler) rebalance(ctx context.Context) {
 			}
 			log.Infof("Evicted pod %s/%s (%s) for rebalancing", owner.Namespace, name, uid)
 			s.telemetry.observeRebalanceEviction(owner, isSpot)
+			s.events.rebalancingEviction(owner.Namespace, name, isSpot)
 		}
 	}
 }
@@ -258,6 +261,7 @@ func (s *scheduler) checkOnDemandFallbackOnce(ctx context.Context, now time.Time
 			}
 			log.Infof("Evicted timed-out pending spot pod %s (%s) of %s for on-demand fallback", pod.name, uid, pod.topLevelOwner)
 			s.tracker.deletePendingSpotPod(uid)
+			s.events.fallbackEviction(pod.topLevelOwner.Namespace, pod.name)
 		}
 	}
 }
@@ -286,6 +290,7 @@ func (s *scheduler) disableSpotScheduling(ctx context.Context, topLevelOwner obj
 	err := s.patcher.setDisabledUntil(ctx, topLevelOwner, disabledUntil)
 	if err == nil {
 		s.telemetry.observeFallback(topLevelOwner)
+		s.events.schedulingDisabled(topLevelOwner, disabledUntil)
 	}
 	return err
 }

--- a/pkg/clusteragent/autoscaling/cluster/spot/scheduler_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/scheduler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
@@ -37,21 +38,23 @@ var defaultTestConfig = spot.Config{
 }
 
 // runTestScheduler creates and starts a Scheduler for testing.
-func runTestScheduler(ctx context.Context, cluster *fakeCluster) (*spot.TestScheduler, *mocksender.MockSender) {
+// It returns the scheduler, the metric sender, and a FakeRecorder that captures Kubernetes events emitted by the scheduler.
+func runTestScheduler(ctx context.Context, cluster *fakeCluster) (*spot.TestScheduler, *mocksender.MockSender, *record.FakeRecorder) {
 	// Use a bare MockSender without a demultiplexer: the demultiplexer starts
 	// background goroutines that get trapped in the synctest bubble and cause
 	// a deadlock when the test exits. All assertion methods only use mock.Mock.
 	m := new(mocksender.MockSender)
 	m.SetupAcceptAll()
 
-	scheduler := spot.NewTestScheduler(defaultTestConfig, m, cluster.WLM(), cluster.EvictPodByName, cluster.DynamicClient())
+	r := record.NewFakeRecorder(100)
+	scheduler := spot.NewTestScheduler(defaultTestConfig, m, r, cluster.WLM(), cluster.EvictPodByName, cluster.DynamicClient())
 	scheduler.Start(ctx)
 	scheduler.WaitSynced()
 
 	cluster.OnPodCreated(scheduler.PodCreated)
 	cluster.OnPodDeleted(scheduler.PodDeleted)
 
-	return scheduler, m
+	return scheduler, m, r
 }
 
 // spotEnabledLabels returns the labels required to opt a workload into spot scheduling.
@@ -110,7 +113,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		_, m := runTestScheduler(t.Context(), cluster)
+		_, m, _ := runTestScheduler(t.Context(), cluster)
 
 		// When
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(100, 2), 1)
@@ -132,7 +135,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddSpotNode("spot")
 
 		const replicas = 10
-		_, m := runTestScheduler(t.Context(), cluster)
+		_, m, _ := runTestScheduler(t.Context(), cluster)
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 2), replicas)
 
 		// When
@@ -155,7 +158,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		_, m := runTestScheduler(t.Context(), cluster)
+		_, m, _ := runTestScheduler(t.Context(), cluster)
 
 		// When: initial deployment with 5 replicas at 60%
 		labels := spotEnabledLabels()
@@ -188,7 +191,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		_, m := runTestScheduler(t.Context(), cluster)
+		_, m, _ := runTestScheduler(t.Context(), cluster)
 
 		// When
 		const replicas = 10
@@ -241,7 +244,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		// No spot node: spot-assigned pods stay Pending.
 
-		s, m := runTestScheduler(t.Context(), cluster)
+		s, m, r := runTestScheduler(t.Context(), cluster)
 
 		// When
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 2), 10)
@@ -265,6 +268,11 @@ func TestScenarios(t *testing.T) {
 		expectRunningOnDemand(t, pods, 4)
 		// Pending pods evicted
 		expectPending(t, pods, 0)
+		// SpotSchedulingDisabled on the workload, then one SpotFallbackEviction per evicted pending pod
+		assertEvent(t, r, spot.EventReasonSpotSchedulingDisabled)
+		for range 6 {
+			assertEvent(t, r, spot.EventReasonSpotFallbackEviction)
+		}
 
 		// When
 		// ReplicaSet recreates pods
@@ -298,6 +306,7 @@ func TestScenarios(t *testing.T) {
 			// ReplicaSet recreates pod
 			d.Reconcile()
 			waitSchedulerTickAfter(s.Config().RebalanceStabilizationPeriod)
+			assertEvent(t, r, spot.EventReasonSpotRebalancingEviction)
 		}
 
 		// Then
@@ -317,7 +326,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		_, m := runTestScheduler(t.Context(), cluster)
+		_, m, _ := runTestScheduler(t.Context(), cluster)
 
 		const replicas = 10
 		const minOnDemand = 2
@@ -372,7 +381,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		s, m := runTestScheduler(t.Context(), cluster)
+		s, m, r := runTestScheduler(t.Context(), cluster)
 
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 2), 10)
 		rs := d.ReplicaSet()
@@ -395,6 +404,7 @@ func TestScenarios(t *testing.T) {
 		// Then: excess on-demand pod evicted
 		pods = cluster.ListOwnerPods(kubernetes.ReplicaSetKind, "default", rs)
 		expectRunningOnDemand(t, pods, 2)
+		assertEvent(t, r, spot.EventReasonSpotRebalancingEviction)
 
 		// ReplicaSet recreates the evicted pod as spot
 		d.Reconcile()
@@ -404,7 +414,6 @@ func TestScenarios(t *testing.T) {
 		pods = cluster.ListOwnerPods(kubernetes.ReplicaSetKind, "default", rs)
 		expectRunningSpot(t, pods, 3)
 		expectRunningOnDemand(t, pods, 2)
-
 		wait(spot.MetricsFlushInterval)
 		expectWorkloadMetrics(t, m, kubernetes.DeploymentKind, "default", "nginx", workloadMetricValues{spot: 3, onDemand: 2, evictedOnDemand: 1})
 		expectWorkloadKindMetrics(t, m, workloadKindMetricsValues{deployments: 1})
@@ -416,7 +425,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		s, m := runTestScheduler(t.Context(), cluster)
+		s, m, r := runTestScheduler(t.Context(), cluster)
 
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 2), 10)
 		rs := d.ReplicaSet()
@@ -444,6 +453,7 @@ func TestScenarios(t *testing.T) {
 			// Then: excess spot pod evicted
 			pods = cluster.ListOwnerPods(kubernetes.ReplicaSetKind, "default", rs)
 			expectRunningSpot(t, pods, 4-i)
+			assertEvent(t, r, spot.EventReasonSpotRebalancingEviction)
 
 			// ReplicaSet recreates the evicted pod as on-demand (on-demand count still below minOnDemand)
 			d.Reconcile()
@@ -467,7 +477,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		s, m := runTestScheduler(t.Context(), cluster)
+		s, m, r := runTestScheduler(t.Context(), cluster)
 
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 1), 10)
 		rs := d.ReplicaSet()
@@ -491,6 +501,7 @@ func TestScenarios(t *testing.T) {
 		// Then: excess spot pod evicted
 		pods = cluster.ListOwnerPods(kubernetes.ReplicaSetKind, "default", rs)
 		expectRunningSpot(t, pods, 3)
+		assertEvent(t, r, spot.EventReasonSpotRebalancingEviction)
 
 		// ReplicaSet recreates the evicted pod as on-demand
 		d.Reconcile()
@@ -500,7 +511,6 @@ func TestScenarios(t *testing.T) {
 		pods = cluster.ListOwnerPods(kubernetes.ReplicaSetKind, "default", rs)
 		expectRunningSpot(t, pods, 3)
 		expectRunningOnDemand(t, pods, 2)
-
 		wait(spot.MetricsFlushInterval)
 		expectWorkloadMetrics(t, m, kubernetes.DeploymentKind, "default", "nginx", workloadMetricValues{spot: 3, onDemand: 2, evictedSpot: 1})
 		expectWorkloadKindMetrics(t, m, workloadKindMetricsValues{deployments: 1})
@@ -512,7 +522,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		s, m := runTestScheduler(t.Context(), cluster)
+		s, m, _ := runTestScheduler(t.Context(), cluster)
 
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 2), 10)
 		rs := d.ReplicaSet()
@@ -548,7 +558,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		_, m := runTestScheduler(t.Context(), cluster)
+		_, m, _ := runTestScheduler(t.Context(), cluster)
 
 		// When
 		d := cluster.CreateDeployment("default", "nginx", nil, nil, 5)
@@ -569,7 +579,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		s, m := runTestScheduler(t.Context(), cluster)
+		s, m, _ := runTestScheduler(t.Context(), cluster)
 
 		const replicas = 10
 		const spotPercentage = 60
@@ -622,7 +632,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		s, m := runTestScheduler(t.Context(), cluster)
+		s, m, _ := runTestScheduler(t.Context(), cluster)
 
 		const replicas = 5
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 1), replicas)
@@ -658,7 +668,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		s, m := runTestScheduler(t.Context(), cluster)
+		s, m, _ := runTestScheduler(t.Context(), cluster)
 
 		const replicas = 5
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 1), replicas)
@@ -694,7 +704,7 @@ func TestScenarios(t *testing.T) {
 		cluster.AddOnDemandNode("on-demand")
 		cluster.AddSpotNode("spot")
 
-		s, m := runTestScheduler(t.Context(), cluster)
+		s, m, _ := runTestScheduler(t.Context(), cluster)
 
 		// When
 		d := cluster.CreateDeployment("default", "nginx", nil, nil, 5)
@@ -735,7 +745,7 @@ func TestScenarios(t *testing.T) {
 		// When
 		stopScheduler()
 
-		s2, m := runTestScheduler(t.Context(), cluster)
+		s2, m, _ := runTestScheduler(t.Context(), cluster)
 
 		// Then
 		waitABit()
@@ -834,6 +844,17 @@ type workloadMetricValues struct {
 type workloadKindMetricsValues struct {
 	deployments               int
 	activeDeploymentFallbacks int
+}
+
+// assertEvent asserts that the next event in the recorder contains the given reason.
+func assertEvent(t *testing.T, recorder *record.FakeRecorder, reason string) {
+	t.Helper()
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, reason)
+	default:
+		t.Errorf("expected %s event, got none", reason)
+	}
 }
 
 // expectWorkloadMetrics verifies per-workload metrics for the given kind/namespace/name.

--- a/pkg/clusteragent/autoscaling/cluster/spot/testing_helpers.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/testing_helpers.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/record"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -22,7 +23,7 @@ import (
 type TestScheduler = scheduler
 
 // NewTestScheduler creates a scheduler for testing.
-func NewTestScheduler(config Config, s sender.Sender, wlm workloadmeta.Component, evictPod func(namespace, name string) error, dynamicClient dynamic.Interface) *TestScheduler {
+func NewTestScheduler(config Config, s sender.Sender, recorder *record.FakeRecorder, wlm workloadmeta.Component, evictPod func(namespace, name string) error, dynamicClient dynamic.Interface) *TestScheduler {
 	isLeader := func() bool {
 		return true
 	}
@@ -33,7 +34,8 @@ func NewTestScheduler(config Config, s sender.Sender, wlm workloadmeta.Component
 		return nil
 	})
 	tel := newTelemetry(s, isLeader, testGlobalTagsFunc)
-	return newScheduler(config, wlm, evictorFunc, patcherFunc, dynamicClient, newWLMPodLister(wlm), isLeader, tel)
+	events := newSpotEventRecorder(recorder)
+	return newScheduler(config, wlm, evictorFunc, patcherFunc, dynamicClient, newWLMPodLister(wlm), isLeader, tel, events)
 }
 
 // HasAdmissionsOrPending reports whether the pod tracker has any in-flight admissions or pending pods

--- a/pkg/clusteragent/autoscaling/cluster/spot/workload_controller.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/workload_controller.go
@@ -11,10 +11,12 @@ import (
 	"context"
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -26,13 +28,26 @@ import (
 )
 
 type workloadResource struct {
-	gvr  schema.GroupVersionResource
-	kind string
+	kind      string
+	gvr       schema.GroupVersionResource
+	newObject func(namespace, name string) runtime.Object
 }
 
 var spotWorkloadResources = []workloadResource{
-	{schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}, kubernetes.DeploymentKind},
-	{schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}, kubernetes.StatefulSetKind},
+	{
+		kind: kubernetes.DeploymentKind,
+		gvr:  schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+		newObject: func(namespace, name string) runtime.Object {
+			return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+		},
+	},
+	{
+		kind: kubernetes.StatefulSetKind,
+		gvr:  schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"},
+		newObject: func(namespace, name string) runtime.Object {
+			return &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+		},
+	},
 }
 
 // workloadController watches spot-enabled workloads and keeps the podTracker and

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -196,7 +196,6 @@ func (k *KubeASCheck) Configure(senderManager sender.SenderManager, _ uint64, co
 			Source: "datadog-cluster-autoscaler",
 		})
 	}
-
 	// When we use both bundled and unbundled transformers, we apply two filters: filtered_event_types and collected_event_types.
 	// When we use only the bundled transformer, we apply filtered_event_types.
 	// When we use only the unbundled transformer, we apply collected_event_types.


### PR DESCRIPTION
### What does this PR do?

### Motivation

Emit Kubernetes events for scheduler actions so operators can observe spot scheduling decisions via `kubectl get events`.

Three events are emitted by the Spot Scheduler:

- `SpotRebalancingEviction` (Warning) on the evicted Pod — emitted each time the rebalancer evicts a pod to converge toward the desired spot/on-demand ratio. Complements the rebalance_evictions metric with a per-pod record that is immediately visible via kubectl, linking the eviction to its cause (excess spot or excess on-demand).

- `SpotFallbackEviction` (Warning) on the evicted Pod — emitted when a pending spot pod is evicted as part of the on-demand fallback trigger. Without this event, pods evicted during fallback look identical to any other eviction; this event makes the reason explicit and visible per pod, paired with SpotSchedulingDisabled on the workload.

- `SpotSchedulingDisabled` (Warning) on the Deployment/StatefulSet — emitted once per fallback trigger on the workload object, with the disabled-until timestamp in the message. Allows operators immediately answer "why is this workload running on-demand?" and "when will spot resume?" using only kubectl, without inspecting annotations or logs.

Updates https://datadoghq.atlassian.net/browse/CASCL-1220



### Describe how you validated your changes

Tested cluster agent build in the cluster.

### Additional Notes
