### PR TITLE
[CONTINT-5412] Ship Helm releases through the fusion pipeline as custom resources

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -474,6 +474,11 @@ func (cb *CollectorBundle) importBuiltinCollectors() {
 		builtinCollectors = append(builtinCollectors, terminatedPodCollector)
 	}
 
+	// add Helm release and chart collectors when their synthetic CRDs can be shipped.
+	if pkgconfigsetup.Datadog().GetBool("orchestrator_explorer.helm_releases.enabled") && cb.hasCRDCollector() {
+		builtinCollectors = append(builtinCollectors, k8s.NewHelmReleaseCollector(), k8s.NewHelmChartCollector())
+	}
+
 	// add builtin collectors and check if they are already activated
 	for _, collector := range builtinCollectors {
 		if _, ok := cb.activatedCollectors[collector.Metadata().FullName()]; ok {

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/builtin_crd.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/builtin_crd.go
@@ -1,0 +1,142 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+
+package k8s
+
+import (
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm"
+)
+
+// syntheticHelmReleaseCRDs describes the synthetic HelmRelease resource.
+func syntheticHelmReleaseCRDs() []runtime.Object {
+	str := v1.JSONSchemaProps{Type: "string"}
+
+	specSchema := v1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]v1.JSONSchemaProps{
+			"spec": {
+				Type: "object",
+				Properties: map[string]v1.JSONSchemaProps{
+					"releaseName":   str,
+					"revision":      {Type: "integer"},
+					"chart":         str,
+					"chartVersion":  str,
+					"appVersion":    str,
+					"status":        str,
+					"firstDeployed": str,
+					"lastDeployed":  str,
+					"chartRef": {
+						Type: "object",
+						Properties: map[string]v1.JSONSchemaProps{
+							"name":    str,
+							"version": str,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	crd := &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "helmreleases." + helm.HelmReleaseGroup,
+			UID:             types.UID("00000000-0000-0000-0000-0000000000a1"),
+			ResourceVersion: "1",
+		},
+		Spec: v1.CustomResourceDefinitionSpec{
+			Group: helm.HelmReleaseGroup,
+			Names: v1.CustomResourceDefinitionNames{
+				Kind:   helm.HelmReleaseKind,
+				Plural: "helmreleases",
+			},
+			Scope: v1.NamespaceScoped,
+			Versions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name:    helm.HelmReleaseVersion,
+					Served:  true,
+					Storage: true,
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &specSchema,
+					},
+				},
+			},
+		},
+	}
+
+	return []runtime.Object{crd}
+}
+
+// syntheticHelmChartCRDs describes the synthetic HelmChart resource.
+func syntheticHelmChartCRDs() []runtime.Object {
+	str := v1.JSONSchemaProps{Type: "string"}
+	preserve := boolPtr(true)
+
+	specSchema := v1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]v1.JSONSchemaProps{
+			"spec": {
+				Type: "object",
+				Properties: map[string]v1.JSONSchemaProps{
+					"name":        str,
+					"version":     str,
+					"appVersion":  str,
+					"apiVersion":  str,
+					"description": str,
+					// Arbitrary-shaped content: preserve so it is not pruned.
+					"defaultValues": {Type: "object", XPreserveUnknownFields: preserve},
+					"templates": {
+						Type: "array",
+						Items: &v1.JSONSchemaPropsOrArray{
+							Schema: &v1.JSONSchemaProps{Type: "object", XPreserveUnknownFields: preserve},
+						},
+					},
+					"dependencies": {
+						Type: "array",
+						Items: &v1.JSONSchemaPropsOrArray{
+							Schema: &v1.JSONSchemaProps{Type: "object", XPreserveUnknownFields: preserve},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	crd := &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "helmcharts." + helm.HelmReleaseGroup,
+			UID:             types.UID("00000000-0000-0000-0000-0000000000a2"),
+			ResourceVersion: "1",
+		},
+		Spec: v1.CustomResourceDefinitionSpec{
+			Group: helm.HelmReleaseGroup,
+			Names: v1.CustomResourceDefinitionNames{
+				Kind:   helm.HelmChartKind,
+				Plural: "helmcharts",
+			},
+			Scope: v1.ClusterScoped,
+			Versions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name:    helm.HelmReleaseVersion,
+					Served:  true,
+					Storage: true,
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &specSchema,
+					},
+				},
+			},
+		},
+	}
+
+	return []runtime.Object{crd}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/crd.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/crd.go
@@ -12,12 +12,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
 	utilTypes "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/util"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
@@ -31,10 +33,11 @@ func NewCRDCollectorVersions() collectors.CollectorVersions {
 
 // CRDCollector is a collector for Kubernetes CRDs.
 type CRDCollector struct {
-	informer  informers.GenericInformer
-	lister    cache.GenericLister
-	metadata  *collectors.CollectorMetadata
-	processor *processors.Processor
+	informer      informers.GenericInformer
+	lister        cache.GenericLister
+	metadata      *collectors.CollectorMetadata
+	processor     *processors.Processor
+	syntheticCRDs []runtime.Object
 }
 
 // NewCRDCollector creates a new collector for the Kubernetes CRD
@@ -72,6 +75,11 @@ func (c *CRDCollector) Init(rcfg *collectors.CollectorRunConfig) {
 		log.Errorc(err.Error(), orchestrator.ExtraLogContext...)
 	}
 	c.lister = c.informer.Lister() // return that Lister
+
+	// Ship schemas for the synthetic Helm custom resources.
+	if pkgconfigsetup.Datadog().GetBool("orchestrator_explorer.helm_releases.enabled") {
+		c.syntheticCRDs = append(syntheticHelmReleaseCRDs(), syntheticHelmChartCRDs()...)
+	}
 }
 
 // Metadata is used to access information about the collector.
@@ -85,6 +93,8 @@ func (c *CRDCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Col
 	if err != nil {
 		return nil, collectors.NewListingError(err)
 	}
+
+	list = append(list, c.syntheticCRDs...)
 
 	return c.Process(rcfg, list)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/collect.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/collect.go
@@ -17,6 +17,11 @@ import (
 const StorageLabelSelector = "owner=helm"
 
 // ReleasesFromConfigMaps decodes the given Helm-managed ConfigMaps into Releases.
+//
+// NOTE: this is currently called independently by both the Helm release and Helm
+// chart collectors, so every ConfigMap is decoded twice
+// per collection cycle. Future optimization: decode releases once and share the
+// result between the two collectors.
 func ReleasesFromConfigMaps(configMaps []*corev1.ConfigMap) []*Release {
 	releases := make([]*Release, 0, len(configMaps))
 	for _, cm := range configMaps {
@@ -28,6 +33,7 @@ func ReleasesFromConfigMaps(configMaps []*corev1.ConfigMap) []*Release {
 			log.Debugf("Skipping Helm ConfigMap %s/%s: %v", cm.Namespace, cm.Name, err)
 			continue
 		}
+		release.ResourceVersion = cm.ResourceVersion
 		releases = append(releases, release)
 	}
 	return releases

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/collect.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/collect.go
@@ -13,19 +13,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// Helm labels every storage object (ConfigMap or Secret) with
-// "owner=helm".
+// Helm labels storage objects with "owner=helm".
 const StorageLabelSelector = "owner=helm"
 
 // ReleasesFromConfigMaps decodes the given Helm-managed ConfigMaps into Releases.
-// The ConfigMaps are expected to already be filtered to Helm's storage objects
-// (see StorageLabelSelector), for example by an informer's list options.
-//
-// A ConfigMap whose release data cannot be decoded is logged and skipped, so a
-// single malformed object never prevents the rest from being collected.
-//
-// Only the ConfigMap storage backend is supported for now; Helm 3 defaults to
-// Secrets, which use the same blob format and can be added later.
 func ReleasesFromConfigMaps(configMaps []*corev1.ConfigMap) []*Release {
 	releases := make([]*Release, 0, len(configMaps))
 	for _, cm := range configMaps {

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/decode.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/decode.go
@@ -21,14 +21,8 @@ import (
 var b64 = base64.StdEncoding
 var magicGzip = []byte{0x1f, 0x8b, 0x08}
 
-// ParseRelease decodes the "release" data of a Helm-managed ConfigMap or Secret
-// into a Release. The data must be a base64-encoded, gzipped string of a valid
-// release, otherwise an error is returned.
-//
-// For backwards-compatibility with releases stored before Helm introduced
-// compression, decompression is skipped when the gzip magic header is absent.
+// ParseRelease decodes Helm's stored "release" data.
 func ParseRelease(data string) (*Release, error) {
-	// base64 decode string
 	b, err := b64.DecodeString(data)
 	if err != nil {
 		return nil, err
@@ -38,9 +32,6 @@ func ParseRelease(data string) (*Release, error) {
 		return nil, fmt.Errorf("the byte array is too short (expected at least 4 bytes, got %d instead): it cannot contain a Helm release", len(b))
 	}
 
-	// For backwards compatibility with releases that were stored before
-	// compression was introduced we skip decompression if the gzip magic header
-	// is not found.
 	if bytes.Equal(b[0:3], magicGzip) {
 		r, err := gzip.NewReader(bytes.NewReader(b))
 		if err != nil {
@@ -55,7 +46,6 @@ func ParseRelease(data string) (*Release, error) {
 	}
 
 	var rls Release
-	// unmarshal release object bytes
 	if err := json.Unmarshal(b, &rls); err != nil {
 		return nil, err
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
@@ -9,17 +9,10 @@
 // objects so the orchestrator can collect Helm release and chart information.
 package helm
 
-// The Release struct and the related ones below are a simplified version of the
-// ones found in the Helm library. Ref:
-// https://github.com/helm/helm/blob/v3.8.0/pkg/release/release.go#L22
-//
-// Defining the structs here lets us avoid importing Helm as a dependency. Unlike
-// the existing customer-facing Helm check (pkg/collector/corechecks/cluster/helm),
-// we intentionally keep the chart values, user-supplied config, templates and
-// rendered manifest, because the orchestrator surfaces them in the UI.
+// These structs mirror the Helm release payload without importing Helm.
+// Ref: https://github.com/helm/helm/blob/v3.8.0/pkg/release/release.go#L22
 
-// Release represents a single Helm release revision, as stored in the
-// "release" data key of a Helm-managed ConfigMap or Secret.
+// Release represents a single Helm release revision.
 type Release struct {
 	Name      string `json:"name,omitempty"`
 	Namespace string `json:"namespace,omitempty"`

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
@@ -26,6 +26,8 @@ type Release struct {
 	Config map[string]interface{} `json:"config,omitempty"`
 	// Manifest is the fully rendered Kubernetes YAML applied to the cluster.
 	Manifest string `json:"manifest,omitempty"`
+	// ResourceVersion is the backing storage object's resourceVersion. 
+	ResourceVersion string `json:"-"`
 }
 
 // Info describes the deployment state of a release.

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
@@ -1,0 +1,231 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+
+package helm
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// HelmReleaseGroup is the synthetic API group used to surface Helm releases as
+// custom resources in the orchestrator.
+const HelmReleaseGroup = "helm.datadoghq.com"
+
+// HelmReleaseVersion is the synthetic API version for the HelmRelease resource.
+const HelmReleaseVersion = "v1"
+
+// HelmReleaseKind is the synthetic Kind for the HelmRelease resource.
+const HelmReleaseKind = "HelmRelease"
+
+// HelmChartKind is the synthetic Kind for packaged Helm charts.
+const HelmChartKind = "HelmChart"
+
+const helmReleaseAPIVersion = HelmReleaseGroup + "/" + HelmReleaseVersion
+
+// ReleaseToUnstructured converts a parsed Helm release revision into a
+// synthetic custom resource.
+func ReleaseToUnstructured(r *Release) *unstructured.Unstructured {
+	var chart, chartVersion, appVersion string
+	if r.Chart != nil && r.Chart.Metadata != nil {
+		chart = r.Chart.Metadata.Name
+		chartVersion = r.Chart.Metadata.Version
+		appVersion = r.Chart.Metadata.AppVersion
+	}
+
+	var status, firstDeployed, lastDeployed string
+	if r.Info != nil {
+		status = r.Info.Status
+		firstDeployed = r.Info.FirstDeployed
+		lastDeployed = r.Info.LastDeployed
+	}
+
+	spec := map[string]interface{}{
+		"releaseName":   r.Name,
+		"revision":      int64(r.Version),
+		"chart":         chart,
+		"chartVersion":  chartVersion,
+		"appVersion":    appVersion,
+		"status":        status,
+		"firstDeployed": firstDeployed,
+		"lastDeployed":  lastDeployed,
+		// Link to the chart object so chart data is not duplicated per release.
+		"chartRef": map[string]interface{}{
+			"name":    chart,
+			"version": chartVersion,
+		},
+	}
+
+	if len(r.Config) > 0 {
+		spec["config"] = r.Config
+	}
+
+	// Keep manifests structured so the scrubber can inspect nested fields.
+	if resources := parseManifest(r.Manifest); len(resources) > 0 {
+		spec["resources"] = resources
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": helmReleaseAPIVersion,
+			"kind":       HelmReleaseKind,
+			"metadata": map[string]interface{}{
+				"name":            fmt.Sprintf("%s.v%d", r.Name, r.Version),
+				"namespace":       r.Namespace,
+				"uid":             releaseUID(r),
+				"resourceVersion": "1", // a given revision is immutable once stored
+				"labels": map[string]interface{}{
+					"helm_release":  r.Name,
+					"helm_revision": strconv.Itoa(r.Version),
+					"helm_status":   status,
+				},
+			},
+			"spec": spec,
+		},
+	}
+}
+
+// templatesToInterface converts chart templates into JSON-compatible maps.
+func templatesToInterface(templates []*Template) []interface{} {
+	out := make([]interface{}, 0, len(templates))
+	for _, t := range templates {
+		if t == nil {
+			continue
+		}
+		out = append(out, map[string]interface{}{
+			"name": t.Name,
+			"data": string(t.Data),
+		})
+	}
+	return out
+}
+
+// parseManifest splits a rendered multi-document YAML manifest.
+func parseManifest(manifest string) []interface{} {
+	if strings.TrimSpace(manifest) == "" {
+		return nil
+	}
+
+	var resources []interface{}
+	decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(manifest), 4096)
+	for {
+		obj := map[string]interface{}{}
+		if err := decoder.Decode(&obj); err != nil {
+			if !errors.Is(err, io.EOF) {
+				log.Debugf("helm: stopping manifest parse after a malformed document: %v", err)
+			}
+			break
+		}
+		if len(obj) == 0 {
+			continue
+		}
+		resources = append(resources, obj)
+	}
+	return resources
+}
+
+// releaseUID returns a deterministic UUID for a release revision.
+func releaseUID(r *Release) string {
+	key := fmt.Sprintf("%s/%s/%d", r.Namespace, r.Name, r.Version)
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(key)).String()
+}
+
+// ChartToUnstructured converts a packaged chart into a synthetic custom resource.
+func ChartToUnstructured(c *Chart) *unstructured.Unstructured {
+	if c == nil || c.Metadata == nil || c.Metadata.Name == "" {
+		return nil
+	}
+
+	name := c.Metadata.Name
+	version := c.Metadata.Version
+
+	spec := map[string]interface{}{
+		"name":        name,
+		"version":     version,
+		"appVersion":  c.Metadata.AppVersion,
+		"apiVersion":  c.Metadata.APIVersion,
+		"description": c.Metadata.Description,
+	}
+
+	if len(c.Values) > 0 {
+		spec["defaultValues"] = c.Values
+	}
+	if len(c.Templates) > 0 {
+		spec["templates"] = templatesToInterface(c.Templates)
+	}
+	if deps := dependenciesToInterface(c.Metadata.Dependencies); len(deps) > 0 {
+		spec["dependencies"] = deps
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": helmReleaseAPIVersion,
+			"kind":       HelmChartKind,
+			"metadata": map[string]interface{}{
+				"name":            fmt.Sprintf("%s.%s", name, version),
+				"uid":             chartUID(name, version),
+				"resourceVersion": "1", // chart content for a version is immutable
+				"labels": map[string]interface{}{
+					"helm_chart":         name,
+					"helm_chart_version": version,
+				},
+			},
+			"spec": spec,
+		},
+	}
+}
+
+// dependenciesToInterface converts chart dependencies into JSON-compatible maps.
+func dependenciesToInterface(deps []*Dependency) []interface{} {
+	out := make([]interface{}, 0, len(deps))
+	for _, d := range deps {
+		if d == nil {
+			continue
+		}
+		out = append(out, map[string]interface{}{
+			"name":       d.Name,
+			"version":    d.Version,
+			"repository": d.Repository,
+			"condition":  d.Condition,
+			"enabled":    d.Enabled,
+			"alias":      d.Alias,
+		})
+	}
+	return out
+}
+
+func chartUID(name, version string) string {
+	key := fmt.Sprintf("%s/%s", name, version)
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(key)).String()
+}
+
+// UniqueCharts returns one chart per distinct (name, version).
+func UniqueCharts(releases []*Release) []*Chart {
+	seen := make(map[string]struct{})
+	charts := make([]*Chart, 0)
+	for _, r := range releases {
+		if r == nil || r.Chart == nil || r.Chart.Metadata == nil || r.Chart.Metadata.Name == "" {
+			continue
+		}
+		key := r.Chart.Metadata.Name + "\x00" + r.Chart.Metadata.Version
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		charts = append(charts, r.Chart)
+	}
+	return charts
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
@@ -86,7 +86,7 @@ func ReleaseToUnstructured(r *Release) *unstructured.Unstructured {
 				"name":            fmt.Sprintf("%s.v%d", r.Name, r.Version),
 				"namespace":       r.Namespace,
 				"uid":             releaseUID(r),
-				"resourceVersion": "1", // a given revision is immutable once stored
+				"resourceVersion": r.ResourceVersion,
 				"labels": map[string]interface{}{
 					"helm_release":  r.Name,
 					"helm_revision": strconv.Itoa(r.Version),

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helmchart.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helmchart.go
@@ -1,0 +1,114 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+
+package k8s
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	corev1Informers "k8s.io/client-go/informers/core/v1"
+	corev1Listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator"
+)
+
+// helmChartCollectorName is the collector/resource name for Helm charts.
+const helmChartCollectorName = "helmcharts"
+
+// NewHelmChartCollectorVersions builds the group of collector versions.
+func NewHelmChartCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewHelmChartCollector(),
+	)
+}
+
+// HelmChartCollector collects charts packaged with Helm releases.
+type HelmChartCollector struct {
+	informer  corev1Informers.ConfigMapInformer
+	lister    corev1Listers.ConfigMapLister
+	metadata  *collectors.CollectorMetadata
+	processor *processors.Processor
+}
+
+// NewHelmChartCollector creates a new collector for Helm charts.
+func NewHelmChartCollector() *HelmChartCollector {
+	return &HelmChartCollector{
+		metadata: &collectors.CollectorMetadata{
+			IsDefaultVersion:                     true,
+			IsStable:                             true,
+			IsManifestProducer:                   true,
+			IsMetadataProducer:                   false,
+			SupportsManifestBuffering:            false,
+			Group:                                helm.HelmReleaseGroup,
+			Name:                                 helmChartCollectorName,
+			Kind:                                 helm.HelmChartKind,
+			NodeType:                             orchestrator.K8sCR,
+			Version:                              helm.HelmReleaseVersion,
+			SupportsTerminatedResourceCollection: false,
+		},
+		processor: processors.NewProcessor(new(k8sProcessors.HelmReleaseHandlers)),
+	}
+}
+
+// Informer returns the shared informer.
+func (c *HelmChartCollector) Informer() cache.SharedInformer {
+	return c.informer.Informer()
+}
+
+// Init is used to initialize the collector.
+func (c *HelmChartCollector) Init(rcfg *collectors.CollectorRunConfig) {
+	c.informer = rcfg.OrchestratorInformerFactory.HelmConfigMapInformerFactory.Core().V1().ConfigMaps()
+	c.lister = c.informer.Lister()
+}
+
+// Metadata is used to access information about the collector.
+func (c *HelmChartCollector) Metadata() *collectors.CollectorMetadata {
+	return c.metadata
+}
+
+// Run triggers the collection process.
+func (c *HelmChartCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
+	configMaps, err := c.lister.List(labels.Everything())
+	if err != nil {
+		return nil, collectors.NewListingError(err)
+	}
+
+	releases := helm.ReleasesFromConfigMaps(configMaps)
+	charts := helm.UniqueCharts(releases)
+	list := make([]runtime.Object, 0, len(charts))
+	for _, chart := range charts {
+		if u := helm.ChartToUnstructured(chart); u != nil {
+			list = append(list, u)
+		}
+	}
+
+	return c.Process(rcfg, list)
+}
+
+// Process is used to process the list of resources and return the result.
+func (c *HelmChartCollector) Process(rcfg *collectors.CollectorRunConfig, list interface{}) (*collectors.CollectorRunResult, error) {
+	ctx := collectors.NewK8sProcessorContext(rcfg, c.metadata)
+
+	processResult, listed, processed := c.processor.Process(ctx, list)
+
+	if processed == -1 {
+		return nil, collectors.ErrProcessingPanic
+	}
+
+	result := &collectors.CollectorRunResult{
+		Result:             processResult,
+		ResourcesListed:    listed,
+		ResourcesProcessed: processed,
+	}
+
+	return result, nil
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helmrelease.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helmrelease.go
@@ -1,0 +1,111 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+
+package k8s
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	corev1Informers "k8s.io/client-go/informers/core/v1"
+	corev1Listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator"
+)
+
+// helmReleaseCollectorName is the collector/resource name for Helm releases.
+const helmReleaseCollectorName = "helmreleases"
+
+// NewHelmReleaseCollectorVersions builds the group of collector versions.
+func NewHelmReleaseCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewHelmReleaseCollector(),
+	)
+}
+
+// HelmReleaseCollector collects Helm releases stored as ConfigMaps.
+type HelmReleaseCollector struct {
+	informer  corev1Informers.ConfigMapInformer
+	lister    corev1Listers.ConfigMapLister
+	metadata  *collectors.CollectorMetadata
+	processor *processors.Processor
+}
+
+// NewHelmReleaseCollector creates a new collector for Helm releases.
+func NewHelmReleaseCollector() *HelmReleaseCollector {
+	return &HelmReleaseCollector{
+		metadata: &collectors.CollectorMetadata{
+			IsDefaultVersion:                     true,
+			IsStable:                             true,
+			IsManifestProducer:                   true,
+			IsMetadataProducer:                   false,
+			SupportsManifestBuffering:            false,
+			Group:                                helm.HelmReleaseGroup,
+			Name:                                 helmReleaseCollectorName,
+			Kind:                                 helm.HelmReleaseKind,
+			NodeType:                             orchestrator.K8sCR,
+			Version:                              helm.HelmReleaseVersion,
+			SupportsTerminatedResourceCollection: false,
+		},
+		processor: processors.NewProcessor(new(k8sProcessors.HelmReleaseHandlers)),
+	}
+}
+
+// Informer returns the shared informer.
+func (c *HelmReleaseCollector) Informer() cache.SharedInformer {
+	return c.informer.Informer()
+}
+
+// Init is used to initialize the collector.
+func (c *HelmReleaseCollector) Init(rcfg *collectors.CollectorRunConfig) {
+	c.informer = rcfg.OrchestratorInformerFactory.HelmConfigMapInformerFactory.Core().V1().ConfigMaps()
+	c.lister = c.informer.Lister()
+}
+
+// Metadata is used to access information about the collector.
+func (c *HelmReleaseCollector) Metadata() *collectors.CollectorMetadata {
+	return c.metadata
+}
+
+// Run triggers the collection process.
+func (c *HelmReleaseCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
+	configMaps, err := c.lister.List(labels.Everything())
+	if err != nil {
+		return nil, collectors.NewListingError(err)
+	}
+
+	releases := helm.ReleasesFromConfigMaps(configMaps)
+	list := make([]runtime.Object, 0, len(releases))
+	for _, r := range releases {
+		list = append(list, helm.ReleaseToUnstructured(r))
+	}
+
+	return c.Process(rcfg, list)
+}
+
+// Process is used to process the list of resources and return the result.
+func (c *HelmReleaseCollector) Process(rcfg *collectors.CollectorRunConfig, list interface{}) (*collectors.CollectorRunResult, error) {
+	ctx := collectors.NewK8sProcessorContext(rcfg, c.metadata)
+
+	processResult, listed, processed := c.processor.Process(ctx, list)
+
+	if processed == -1 {
+		return nil, collectors.ErrProcessingPanic
+	}
+
+	result := &collectors.CollectorRunResult{
+		Result:             processResult,
+		ResourcesListed:    listed,
+		ResourcesProcessed: processed,
+	}
+
+	return result, nil
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -12,8 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"os"
-	"sync"
 	"time"
 
 	"go.uber.org/atomic"
@@ -21,12 +19,9 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	vpai "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
-	corev1listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 
@@ -97,8 +92,6 @@ type OrchestratorCheck struct {
 	apiClient                   *apiserver.APIClient
 	orchestratorInformerFactory *collectors.OrchestratorInformerFactory
 	agentVersion                *model.AgentVersion
-	helmConfigMapLister         corev1listers.ConfigMapLister
-	helmInformerOnce            sync.Once
 }
 
 func newOrchestratorCheck(base core.CheckBase, instance *OrchestratorInstance, cfg configcomp.Component, wlmStore workloadmeta.Component, tagger tagger.Component) *OrchestratorCheck {
@@ -240,63 +233,7 @@ func (o *OrchestratorCheck) Run() error {
 	// Run all collectors.
 	o.collectorBundle.Run(sender)
 
-	// Helm release collection (proof-of-concept, env-gated and log-only).
-	o.collectAndLogHelmReleases()
-
 	return nil
-}
-
-// collectAndLogHelmReleases is a temporary, env-gated proof-of-concept that
-// collects every Helm release stored as a ConfigMap and logs a summary of each.
-// It is a no-op unless DD_ORCHESTRATOR_EXPLORER_HELM_RELEASES_ENABLED is "true",
-// and is intended to be replaced by a proper collector that ships the data
-// through the orchestrator pipeline.
-func (o *OrchestratorCheck) collectAndLogHelmReleases() {
-	if os.Getenv("DD_ORCHESTRATOR_EXPLORER_HELM_RELEASES_ENABLED") != "true" {
-		return
-	}
-
-	o.helmInformerOnce.Do(func() {
-		cmInformer := o.orchestratorInformerFactory.HelmConfigMapInformerFactory.Core().V1().ConfigMaps()
-		go cmInformer.Informer().Run(o.stopCh)
-
-		informerName := apiserver.InformerName("helm-configmaps")
-		syncErrors := apiserver.SyncInformersReturnErrors(
-			map[apiserver.InformerName]cache.SharedInformer{informerName: cmInformer.Informer()},
-			o.collectorBundle.extraSyncTimeout,
-		)
-		if err := syncErrors[informerName]; err != nil {
-			_ = log.Warnc(fmt.Sprintf("helm: %v", err), orchestrator.ExtraLogContext...)
-			return
-		}
-		o.helmConfigMapLister = cmInformer.Lister()
-	})
-
-	// Skip Helm collection if the informer never synced.
-	if o.helmConfigMapLister == nil {
-		return
-	}
-
-	configMaps, err := o.helmConfigMapLister.List(labels.Everything())
-	if err != nil {
-		_ = log.Warnc(fmt.Sprintf("helm: failed to list releases: %v", err), orchestrator.ExtraLogContext...)
-		return
-	}
-
-	releases := helmcollector.ReleasesFromConfigMaps(configMaps)
-	log.Debugc(fmt.Sprintf("helm: collected %d release(s)", len(releases)), orchestrator.ExtraLogContext...)
-	for _, r := range releases {
-		var chart string
-		var templates int
-		if r.Chart != nil {
-			templates = len(r.Chart.Templates)
-			if r.Chart.Metadata != nil {
-				chart = fmt.Sprintf("%s-%s", r.Chart.Metadata.Name, r.Chart.Metadata.Version)
-			}
-		}
-		log.Debugc(fmt.Sprintf("helm: release=%s/%s revision=%d chart=%s templates=%d manifestBytes=%d",
-			r.Namespace, r.Name, r.Version, chart, templates, len(r.Manifest)), orchestrator.ExtraLogContext...)
-	}
 }
 
 // Cancel cancels the orchestrator check

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/helmrelease.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/helmrelease.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+
+package k8s
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+	"github.com/DataDog/datadog-agent/pkg/redact"
+)
+
+const redactedValue = "********"
+
+// HelmReleaseHandlers handles synthetic Helm custom resources.
+type HelmReleaseHandlers struct {
+	CRHandlers
+}
+
+// ScrubBeforeExtraction always scrubs Helm release content before marshalling.
+func (h *HelmReleaseHandlers) ScrubBeforeExtraction(ctx processors.ProcessorContext, resource interface{}) {
+	pctx := ctx.(*processors.K8sProcessorContext)
+	r := resource.(*unstructured.Unstructured)
+
+	redact.ScrubCRManifest(r, pctx.Cfg.Scrubber)
+
+	// Secret data keys are intentionally redacted regardless of key names.
+	redactSecretData(r)
+}
+
+// redactSecretData wipes Secret payloads embedded in spec.resources.
+func redactSecretData(r *unstructured.Unstructured) {
+	spec, ok := r.Object["spec"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	resources, ok := spec["resources"].([]interface{})
+	if !ok {
+		return
+	}
+	for _, res := range resources {
+		m, ok := res.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if kind, _ := m["kind"].(string); kind != "Secret" {
+			continue
+		}
+		if _, ok := m["data"]; ok {
+			m["data"] = redactedValue
+		}
+		if _, ok := m["stringData"]; ok {
+			m["stringData"] = redactedValue
+		}
+	}
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/helmrelease.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/helmrelease.go
@@ -43,18 +43,32 @@ func redactSecretData(r *unstructured.Unstructured) {
 		return
 	}
 	for _, res := range resources {
-		m, ok := res.(map[string]interface{})
-		if !ok {
-			continue
+		if m, ok := res.(map[string]interface{}); ok {
+			redactResourceSecrets(m)
 		}
-		if kind, _ := m["kind"].(string); kind != "Secret" {
-			continue
-		}
+	}
+}
+
+// redactResourceSecrets redacts a Secret manifest's payload, recursing into the
+// items of a Kubernetes List so nested Secrets are not shipped in the clear.
+func redactResourceSecrets(m map[string]interface{}) {
+	switch kind, _ := m["kind"].(string); kind {
+	case "Secret":
 		if _, ok := m["data"]; ok {
 			m["data"] = redactedValue
 		}
 		if _, ok := m["stringData"]; ok {
 			m["stringData"] = redactedValue
+		}
+	case "List":
+		items, ok := m["items"].([]interface{})
+		if !ok {
+			return
+		}
+		for _, item := range items {
+			if im, ok := item.(map[string]interface{}); ok {
+				redactResourceSecrets(im)
+			}
 		}
 	}
 }

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -802,6 +802,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("orchestrator_explorer.terminated_resources.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.terminated_pods.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.terminated_pods_improved.enabled", true)
+	config.BindEnvAndSetDefault("orchestrator_explorer.helm_releases.enabled", false)
 	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.gateway_api", false)
 	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.service_mesh", false)


### PR DESCRIPTION
### What does this PR do?
- Collects Helm releases and charts as custom resources — reads Helm's owner=helm ConfigMaps via an informer/lister and emits two synthetic CRs through the pipeline: HelmRelease (per revision) and HelmChart (per version).
- Scrubs sensitive data before it leaves the agent — scrubs the whole spec and redacts Secret data in rendered resources.
- Ships synthetic CRDs with indexed fields, so releases and chart versions are browsable and filterable in the Kubernetes Explorer.

### Motivation

https://datadoghq.atlassian.net/browse/CONTINT-5412


### Describe how you validated your changes
I spun up a local Kubernetes cluster using Minikube and built the Datadog Cluster Agent image locally with my change and loaded it into the cluster.

Deployed the agent via the Datadog Helm chart pointed towards staging, overriding the cluster-agent image with my local build and enabling the new env-gated helm release collection:

```
datadog:
  site: datad0g.com
  apiKeyExistingSecret: datadog-agent
  clusterName: minikube-helm-test
  logLevel: DEBUG
  kubelet:
    tlsVerify: false
  orchestratorExplorer:
    enabled: true
  processAgent:
    enabled: true
  apm:
    portEnabled: true

clusterAgent:
  enabled: true
  image:
    repository: arnavsehgal97182/cluster-agent
    tag: helm3
    pullPolicy: Never
    doNotCheckTag: true
  env:
    - name: DD_ORCHESTRATOR_EXPLORER_HELM_RELEASES_ENABLED
      value: "true"
```

```
helm upgrade --install datadog-agent datadog/datadog -f dd-helm-test-values.yaml
```

To verify in staging:
1. Go to the Kubernetes Explorer.
2. Switch to the Custom Resources tab on the left.
3. Filter by the cluster name.
4. You should see two synthetic CRDs reporting data:
  - helmreleases.helm.datadoghq.com — one CR per release revision, with chart/version, status, supplied values, and rendered resources.
  - helmcharts.helm.datadoghq.com — one CR per chart version, with templates, default values, and metadata.
5. Open a CR's YAML to confirm the fields are populated and that sensitive data is redacted.

View my custom resource `helmreleases` and `helmcharts` by click on this [link](https://dd.datad0g.com/orchestration/explorer/crd?query=kube_cluster_name%3Aminikube-helm-test&crd-sort=name%3Adesc&explorer-na-groups=false&highlight=%5B%5B%22spec%22%2C%22version%22%5D%5D&ptfu=false) (kube_cluster_name: `minikube-helm-test`)

### Additional Notes
