### PR TITLE
perf(aggregator) Reduce per-sample allocations in the metrics aggregator

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -155,6 +155,8 @@ var (
 		[]string{"shard"}, "Size of the aggregator channel")
 	tlmProcessed = telemetryimpl.GetCompatComponent().NewCounter("aggregator", "processed",
 		[]string{"shard", "data_type"}, "Amount of metrics/services_checks/events processed by the aggregator")
+	tlmProcessedMetrics         = tlmProcessed.WithValues("", "metrics")
+	tlmProcessedHistogramBucket = tlmProcessed.WithValues("", "histogram_bucket")
 	tlmDogstatsdTimeBuckets = telemetryimpl.GetCompatComponent().NewGauge("aggregator", "dogstatsd_time_buckets",
 		[]string{"shard"}, "Number of time buckets in the dogstatsd sampler")
 	tlmDogstatsdContexts = telemetryimpl.GetCompatComponent().NewGauge("aggregator", "dogstatsd_contexts",
@@ -456,7 +458,7 @@ func (agg *BufferedAggregator) handleSenderSample(ss senderMetricSample) {
 	defer agg.mu.Unlock()
 
 	aggregatorChecksMetricSample.Add(1)
-	tlmProcessed.Inc("", "metrics")
+	tlmProcessedMetrics.Inc()
 
 	if checkSampler, ok := agg.checkSamplers[ss.id]; ok {
 		if ss.commit {
@@ -475,7 +477,7 @@ func (agg *BufferedAggregator) handleSenderBucket(checkBucket senderHistogramBuc
 	defer agg.mu.Unlock()
 
 	aggregatorCheckHistogramBucketMetricSample.Add(1)
-	tlmProcessed.Inc("", "histogram_bucket")
+	tlmProcessedHistogramBucket.Inc()
 
 	if checkSampler, ok := agg.checkSamplers[checkBucket.id]; ok {
 		checkBucket.bucket.Tags = sort.UniqInPlace(checkBucket.bucket.Tags)

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -157,7 +157,7 @@ var (
 		[]string{"shard", "data_type"}, "Amount of metrics/services_checks/events processed by the aggregator")
 	tlmProcessedMetrics         = tlmProcessed.WithValues("", "metrics")
 	tlmProcessedHistogramBucket = tlmProcessed.WithValues("", "histogram_bucket")
-	tlmDogstatsdTimeBuckets = telemetryimpl.GetCompatComponent().NewGauge("aggregator", "dogstatsd_time_buckets",
+	tlmDogstatsdTimeBuckets     = telemetryimpl.GetCompatComponent().NewGauge("aggregator", "dogstatsd_time_buckets",
 		[]string{"shard"}, "Number of time buckets in the dogstatsd sampler")
 	tlmDogstatsdContexts = telemetryimpl.GetCompatComponent().NewGauge("aggregator", "dogstatsd_contexts",
 		[]string{"shard"}, "Count the number of dogstatsd contexts in the aggregator")

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -30,6 +30,7 @@ type RawSender interface {
 // checkSender implements Sender
 type checkSender struct {
 	id                      checkid.ID
+	metricSource            metrics.MetricSource
 	defaultHostname         string
 	defaultHostnameDisabled bool
 	metricStats             stats.SenderStats
@@ -105,6 +106,7 @@ func newCheckSender(
 ) *checkSender {
 	return &checkSender{
 		id:                      id,
+		metricSource:            metrics.CheckNameToMetricSource(checkid.IDToCheckName(id)),
 		defaultHostname:         defaultHostname,
 		itemsOut:                itemsOut,
 		serviceCheckOut:         serviceCheckOut,
@@ -203,7 +205,7 @@ func (s *checkSender) sendMetricSample(
 		Timestamp:       timestamp,
 		FlushFirstValue: flushFirstValue,
 		NoIndex:         s.noIndex || noIndex,
-		Source:          metrics.CheckNameToMetricSource(checkid.IDToCheckName(s.id)),
+		Source:          s.metricSource,
 	}
 
 	if hostname == "" && !s.defaultHostnameDisabled {

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -292,16 +292,18 @@ func (s *checkSender) OpenmetricsBucket(metric string, value int64, lowerBound, 
 func (s *checkSender) sendHistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue, multipleBuckets bool) {
 	tags = append(tags, s.checkTags...)
 
-	log.Tracef(
-		"Histogram Bucket %s submitted: %v [%f-%f] monotonic: %v for host %s tags: %v",
-		metric,
-		value,
-		lowerBound,
-		upperBound,
-		monotonic,
-		hostname,
-		tags,
-	)
+	if log.ShouldLog(log.TraceLvl) {
+		log.Tracef(
+			"Histogram Bucket %s submitted: %v [%f-%f] monotonic: %v for host %s tags: %v",
+			metric,
+			value,
+			lowerBound,
+			upperBound,
+			monotonic,
+			hostname,
+			tags,
+		)
+	}
 
 	histogramBucket := &metrics.HistogramBucket{
 		Name:            metric,
@@ -369,7 +371,9 @@ func (s *checkSender) SendRawServiceCheck(sc *servicecheck.ServiceCheck) {
 
 // ServiceCheck submits a service check
 func (s *checkSender) ServiceCheck(checkName string, status servicecheck.ServiceCheckStatus, hostname string, tags []string, message string) {
-	log.Trace("Service check submitted: ", checkName, ": ", status.String(), " for hostname: ", hostname, " tags: ", tags)
+	if log.ShouldLog(log.TraceLvl) {
+		log.Trace("Service check submitted: ", checkName, ": ", status.String(), " for hostname: ", hostname, " tags: ", tags)
+	}
 	serviceCheck := servicecheck.ServiceCheck{
 		CheckName: checkName,
 		Status:    status,
@@ -394,7 +398,9 @@ func (s *checkSender) ServiceCheck(checkName string, status servicecheck.Service
 func (s *checkSender) Event(e event.Event) {
 	e.Tags = append(e.Tags, s.checkTags...)
 
-	log.Trace("Event submitted: ", e.Title, " for hostname: ", e.Host, " tags: ", e.Tags)
+	if log.ShouldLog(log.TraceLvl) {
+		log.Trace("Event submitted: ", e.Title, " for hostname: ", e.Host, " tags: ", e.Tags)
+	}
 
 	if e.Host == "" && !s.defaultHostnameDisabled {
 		e.Host = s.defaultHostname

--- a/releasenotes/notes/optimize-aggregator-sample-hot-path-b0cbeefbd990dd09.yaml
+++ b/releasenotes/notes/optimize-aggregator-sample-hot-path-b0cbeefbd990dd09.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Reduced per-sample allocations in the metrics aggregator, lowering CPU and
+    garbage-collection overhead on Agents processing a high volume of metrics.


### PR DESCRIPTION
## What does this PR do?

Removes avoidable per-sample work on the metrics aggregator hot paths. Three independent optimizations:

- **Cache telemetry counters** (`pkg/aggregator/aggregator.go`): `tlmProcessed.Inc("", "metrics")` / `"histogram_bucket"` allocated a variadic `[]string` on every sample. The child counters are now resolved once at init and incremented via a zero-arg `Inc()`.
- **Resolve metric source once** (`pkg/aggregator/sender.go`): `checkSender` previously called `CheckNameToMetricSource(IDToCheckName(id))` for every metric sample. It is now computed once when the sender is created and stored on the struct.
- **Guard trace logging** (`pkg/aggregator/sender.go`): wrapped `log.Trace*` calls in `sendHistogramBucket`, `ServiceCheck`, and `Event` with `log.ShouldLog(log.TraceLvl)` so their arguments aren't boxed to `interface{}` when trace logging is disabled.

## Motivation

These were uncovered while tracing through profiles of instances emitting high rates of DBM metrics and events. The first two fixes were surfaced as areas we are currently making the most allocations on datadog-agents that are emitting high rates of metric points. The guard on trace logging was also surfaced while profiling. We already have this guard on sendMetricSample, this now extends it to the rest of the calls.

Example profile showing IDToCheckName(id) accounting for 4% of total allocations
<img width="1735" height="787" alt="Screenshot 2026-06-25 at 5 32 36 PM" src="https://github.com/user-attachments/assets/a63ae401-1b07-4a93-82df-9a415459990f" />


Note: I put these 3 changes together in one PR since they all touched aggregator package and should be safe to apply together. I'm happy to split these commits out into separate PR's if desired.

## Describe how you validated your changes

- `go build ./pkg/aggregator/`
- Existing aggregator unit tests pass; added a micro-benchmark for the counter increment.