### PR TITLE
[Backport 7.81.x] gpu: add gpu.collection_interval_override to override check cadence 

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -240,6 +240,18 @@ func (c *Check) Cancel() {
 	c.CheckBase.Cancel()
 }
 
+// Interval returns the scheduling interval for the check. When
+// gpu.collection_interval_override (DD_GPU_COLLECTION_INTERVAL_OVERRIDE) is set to
+// a positive number of seconds it overrides the cadence, taking precedence over
+// the instance's min_collection_interval. Otherwise the check falls back to the
+// instance's min_collection_interval / default.
+func (c *Check) Interval() time.Duration {
+	if iv := pkgconfigsetup.Datadog().GetInt("gpu.collection_interval_override"); iv > 0 {
+		return time.Duration(iv) * time.Second
+	}
+	return c.CheckBase.Interval()
+}
+
 // Run executes the check. Configure must have been called before and returned no errors, otherwise
 // we will panic here as we assume certain components have been initialized.
 func (c *Check) Run() error {

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -477,6 +477,10 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("gpu.workload_tag_cache_size", 1024)
 	config.BindEnvAndSetDefault("gpu.disabled_collectors", []string{})
 	config.BindEnvAndSetDefault("gpu.nvlink.fec_light_error_threshold", 3)
+	// gpu.collection_interval_override (seconds) overrides the gpu check scheduling
+	// cadence when > 0, taking precedence over the instance's min_collection_interval.
+	// Binds DD_GPU_COLLECTION_INTERVAL_OVERRIDE.
+	config.BindEnvAndSetDefault("gpu.collection_interval_override", 0)
 
 	// NCCL
 	config.BindEnvAndSetDefault("gpu.nccl.enabled", false)


### PR DESCRIPTION
Backport https://github.com/DataDog/datadog-agent/commit/bf93a5afd164763158d5ca93bb7f9315ca076ef5 from https://github.com/DataDog/datadog-agent/pull/52787.

___

Adding a config setting bound to `DD_GPU_COLLECTION_INTERVAL_OVERRIDE`, when set to a positive number of seconds, overrides the GPU corecheck's scheduling interval via a Check.Interval() override.

This lets you run the gpu check at customized frequency (e.g. 1Hz). Especially it can work on a subset of nodes through a DatadogAgentProfile env override,  no conf.d/extraConfd change needed, see a two gpu nodes cluster example below.

```

apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgentProfile
metadata:
  name: gpu-1hz
  namespace: datadog
spec:
  profileAffinity:
    profileNodeAffinity:
      - key: gpu-collection-rate
        operator: In
        values: ["gpu-check-1hz"]
  config:
    override:
      nodeAgent:
        containers:
          agent:
            env:
              - {name: DD_GPU_COLLECTION_INTERVAL_OVERRIDE, value: "1"}
```


(cherry picked from commit bf93a5afd164763158d5ca93bb7f9315ca076ef5)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
