### PR TITLE
fix(metadata): skip network ID probes when cloud_provider_metadata is empty

### DIFF
--- a/pkg/util/cloudproviders/network/BUILD.bazel
+++ b/pkg/util/cloudproviders/network/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     embed = [":network"],
     gotags = ["test"],
     deps = [
+        "//pkg/config/mock",
         "//pkg/util/cache",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/util/cloudproviders/network/BUILD.bazel
+++ b/pkg/util/cloudproviders/network/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/setup",
+        "//pkg/config/utils",
         "//pkg/util/cache",
         "//pkg/util/cloudproviders/gce",
         "//pkg/util/ec2",

--- a/pkg/util/cloudproviders/network/network.go
+++ b/pkg/util/cloudproviders/network/network.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/gce"
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
@@ -25,6 +26,12 @@ const (
 	vpcSubnetsForHostCacheKey = "vpcSubnetsForHost"
 )
 
+// for testing
+var (
+	getGCENetworkID = gce.GetNetworkID
+	getEC2NetworkID = ec2.GetNetworkID
+)
+
 // GetNetworkID retrieves the network_id which can be used to improve network
 // connection resolution. This can be configured or detected.  The
 // following sources will be queried:
@@ -32,7 +39,6 @@ const (
 // * GCE
 // * EC2
 func GetNetworkID(ctx context.Context) (string, error) {
-	var err error
 	return cache.Get[string](
 		networkIDCacheKey,
 		func() (string, error) {
@@ -43,23 +49,33 @@ func GetNetworkID(ctx context.Context) (string, error) {
 				return networkID, nil
 			}
 
-			if len(pkgconfigsetup.Datadog().GetStringSlice("cloud_provider_metadata")) == 0 {
+			cfg := pkgconfigsetup.Datadog()
+			var errs []error
+
+			if configutils.IsCloudProviderEnabled(gce.CloudProviderName, cfg) {
+				log.Debugf("GetNetworkID trying GCE")
+				networkID, err := getGCENetworkID(ctx)
+				if err == nil {
+					log.Debugf("GetNetworkID: using network ID from GCE metadata: %s", networkID)
+					return networkID, nil
+				}
+				errs = append(errs, err)
+			}
+
+			if configutils.IsCloudProviderEnabled(ec2.CloudProviderName, cfg) {
+				log.Debugf("GetNetworkID trying EC2")
+				networkID, err := getEC2NetworkID(ctx)
+				if err == nil {
+					log.Debugf("GetNetworkID: using network ID from EC2 metadata: %s", networkID)
+					return networkID, nil
+				}
+				errs = append(errs, err)
+			}
+
+			if len(errs) == 0 {
 				return "", errors.New("cloud provider metadata is disabled by configuration")
 			}
-
-			log.Debugf("GetNetworkID trying GCE")
-			if networkID, err = gce.GetNetworkID(ctx); err == nil {
-				log.Debugf("GetNetworkID: using network ID from GCE metadata: %s", networkID)
-				return networkID, nil
-			}
-
-			log.Debugf("GetNetworkID trying EC2")
-			if networkID, err = ec2.GetNetworkID(ctx); err == nil {
-				log.Debugf("GetNetworkID: using network ID from EC2 metadata: %s", networkID)
-				return networkID, nil
-			}
-
-			return "", fmt.Errorf("could not detect network ID: %w", err)
+			return "", fmt.Errorf("could not detect network ID: %w", errors.Join(errs...))
 		})
 }
 

--- a/pkg/util/cloudproviders/network/network.go
+++ b/pkg/util/cloudproviders/network/network.go
@@ -43,6 +43,10 @@ func GetNetworkID(ctx context.Context) (string, error) {
 				return networkID, nil
 			}
 
+			if len(pkgconfigsetup.Datadog().GetStringSlice("cloud_provider_metadata")) == 0 {
+				return "", errors.New("cloud provider metadata is disabled by configuration")
+			}
+
 			log.Debugf("GetNetworkID trying GCE")
 			if networkID, err = gce.GetNetworkID(ctx); err == nil {
 				log.Debugf("GetNetworkID: using network ID from GCE metadata: %s", networkID)

--- a/pkg/util/cloudproviders/network/network_test.go
+++ b/pkg/util/cloudproviders/network/network_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 )
 
@@ -27,6 +28,15 @@ func addCleanupForSubnets(t *testing.T) {
 func mockGetVPCSubnetsForHostImpl(t *testing.T, mock func(context.Context) ([]string, error)) {
 	t.Cleanup(func() { getVPCSubnetsForHost = getVPCSubnetsForHostImpl })
 	getVPCSubnetsForHost = mock
+}
+
+func TestGetNetworkIDCloudProviderDisabled(t *testing.T) {
+	t.Cleanup(func() { cache.Cache.Delete(networkIDCacheKey) })
+	cfg := configmock.New(t)
+	cfg.SetInTest("cloud_provider_metadata", []string{})
+
+	_, err := GetNetworkID(context.Background())
+	require.ErrorContains(t, err, "cloud provider metadata is disabled by configuration")
 }
 
 func TestGetVPCSubnetsForHost(t *testing.T) {

--- a/pkg/util/cloudproviders/network/network_test.go
+++ b/pkg/util/cloudproviders/network/network_test.go
@@ -30,13 +30,67 @@ func mockGetVPCSubnetsForHostImpl(t *testing.T, mock func(context.Context) ([]st
 	getVPCSubnetsForHost = mock
 }
 
-func TestGetNetworkIDCloudProviderDisabled(t *testing.T) {
-	t.Cleanup(func() { cache.Cache.Delete(networkIDCacheKey) })
-	cfg := configmock.New(t)
-	cfg.SetInTest("cloud_provider_metadata", []string{})
+func TestGetNetworkIDProviderGating(t *testing.T) {
+	gceErr := errors.New("gce error")
+	ec2Err := errors.New("ec2 error")
 
-	_, err := GetNetworkID(context.Background())
-	require.ErrorContains(t, err, "cloud provider metadata is disabled by configuration")
+	tests := []struct {
+		name           string
+		providers      []string
+		gceCallCount   int
+		ec2CallCount   int
+		wantErrContain string
+	}{
+		{
+			name:           "both providers enabled, both fail",
+			providers:      []string{"gcp", "aws"},
+			gceCallCount:   1,
+			ec2CallCount:   1,
+			wantErrContain: "could not detect network ID",
+		},
+		{
+			name:           "only gcp enabled",
+			providers:      []string{"gcp"},
+			gceCallCount:   1,
+			ec2CallCount:   0,
+			wantErrContain: "could not detect network ID",
+		},
+		{
+			name:           "only aws enabled",
+			providers:      []string{"aws"},
+			gceCallCount:   0,
+			ec2CallCount:   1,
+			wantErrContain: "could not detect network ID",
+		},
+		{
+			name:           "no providers enabled",
+			providers:      []string{},
+			gceCallCount:   0,
+			ec2CallCount:   0,
+			wantErrContain: "cloud provider metadata is disabled by configuration",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(func() { cache.Cache.Delete(networkIDCacheKey) })
+
+			cfg := configmock.New(t)
+			cfg.SetInTest("cloud_provider_metadata", tc.providers)
+
+			gceCalls, ec2Calls := 0, 0
+			origGCE, origEC2 := getGCENetworkID, getEC2NetworkID
+			t.Cleanup(func() { getGCENetworkID = origGCE })
+			t.Cleanup(func() { getEC2NetworkID = origEC2 })
+			getGCENetworkID = func(_ context.Context) (string, error) { gceCalls++; return "", gceErr }
+			getEC2NetworkID = func(_ context.Context) (string, error) { ec2Calls++; return "", ec2Err }
+
+			_, err := GetNetworkID(context.Background())
+			require.ErrorContains(t, err, tc.wantErrContain)
+			require.Equal(t, tc.gceCallCount, gceCalls)
+			require.Equal(t, tc.ec2CallCount, ec2Calls)
+		})
+	}
 }
 
 func TestGetVPCSubnetsForHost(t *testing.T) {

--- a/releasenotes/notes/skip-network-id-probes-when-cloud-disabled-e5088699be7bb550.yaml
+++ b/releasenotes/notes/skip-network-id-probes-when-cloud-disabled-e5088699be7bb550.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Skip cloud provider network ID probes when ``cloud_provider_metadata`` is empty. Previously,
+    ``GetNetworkID`` would probe GCE and EC2 metadata endpoints on every host metadata collection
+    cycle (every 5-30 minutes) even when all cloud providers were disabled by configuration.
+    The probes now short-circuit immediately, avoiding unnecessary work in on-premises environments.


### PR DESCRIPTION
### What does this PR do?

Adds an early-return guard in `GetNetworkID` ([pkg/util/cloudproviders/network/network.go](https://github.com/DataDog/datadog-agent/blob/main/pkg/util/cloudproviders/network/network.go)) that short-circuits the GCE and EC2 probe loop when `cloud_provider_metadata` is an empty list.

### Motivation

- AGENT-16458: This is a follow-up to #52762, which reduced the log noise from these failed probes. This PR stops the probes from running at all.

When `cloud_provider_metadata` is intentionally blank (common in on-premises environments), `GetNetworkID` was still probing GCE and EC2 metadata endpoints on every host metadata collection cycle (every 5–30 minutes). Each probe returned immediately once the individual provider checked `IsCloudProviderEnabled`, but the redundant call overhead accumulated every cycle with no possibility of caching the result (the cache only stores successes).

### Describe how you validated your changes

- Ran `dda inv test --targets=./pkg/util/cloudproviders/network/...` — all 4 tests pass, including a new test that asserts `GetNetworkID` returns an error immediately when `cloud_provider_metadata` is empty.

### Additional Notes

The guard is placed after the `network.id` config check so that an explicit static network ID still works regardless of `cloud_provider_metadata`.