### PR TITLE
Use param file in gather_licenses to avoid running into command length limits

### DIFF
--- a/compliance/gather_licenses.py
+++ b/compliance/gather_licenses.py
@@ -197,7 +197,10 @@ class AttrUsage:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Helper for gathering third party license information.")
+    parser = argparse.ArgumentParser(
+        description="Helper for gathering third party license information.",
+        fromfile_prefix_chars="@",
+    )
     parser.add_argument("--target", help="The target we are processing.")
     parser.add_argument("--csv_out", help="The CSV style output file.")
     parser.add_argument("--licenses_dir", help="Directory to copy license texts to.")

--- a/compliance/license_csv.bzl
+++ b/compliance/license_csv.bzl
@@ -255,7 +255,7 @@ def _license_csv_impl(ctx):
     args.add("--kinds", kinds_map_file.path)
 
     args.use_param_file("@%s", use_always = True)
-    args.set_param_file_format("multiline")
+    args.set_param_file_format("flag_per_line")
 
     ctx.actions.run(
         mnemonic = "GatherLicenseMetadata",

--- a/compliance/license_csv.bzl
+++ b/compliance/license_csv.bzl
@@ -254,6 +254,9 @@ def _license_csv_impl(ctx):
     inputs.append(kinds_map_file)
     args.add("--kinds", kinds_map_file.path)
 
+    args.use_param_file("@%s", use_always = True)
+    args.set_param_file_format("multiline")
+
     ctx.actions.run(
         mnemonic = "GatherLicenseMetadata",
         progress_message = "Writing license info for: %s" % str(ctx.attr.target.label),


### PR DESCRIPTION
### What does this PR do?

Adds param files for the license csv script and rule such that arguments are passed via a file.

### Motivation

Avoiding running into

```
Action failed to execute: java.io.IOException: ERROR: src/main/native/windows/process.cc(152): CreateProcessWithExplicitHandles("C:\bob\execroot\_main\bazel-out\x64_windows-opt-exec\bin\compliance\gather_licenses.exe" --csv_out bazel-out/x64_windows-fastbuild/bin/deps/agent_integrations/license_files_licenses.csv --licenses_dir bazel-out/x64_windows-fastbuild/bin/deps/agent_integrations/license_files_licenses_dir_ --offers_dir bazel-out/x64_windows-fastbuild/bin/deps/agent_integrations/license_files_sources_dir_ --metadata bazel-out/fastbuild-noconfig/bin/external/+integration_source_packages+integration_source_pack(...)): command is longer than CreateProcessW's limit (32767 characters)
```

on Windows.

(https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1807625040#L3450)

Also, see https://github.com/DataDog/datadog-agent/pull/52066#pullrequestreview-4476653964.

In particular, `--metadata` becomes large as the dependency graph grows:
https://github.com/DataDog/datadog-agent/blob/619220b218af22b8b2b4ef5517c15568aaee39e7/compliance/license_csv.bzl#L143-L152

### Describe how you validated your changes

As long as CI is green and we see no suspicious changes in file inventory / static quality gates, we're good.

### Additional Notes
