### PR TITLE
CAP-3777 downgrade noisy error logs for unsupported k8s object records to debug for k8s events

### DIFF
--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	logsmapping "github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/logs"
@@ -83,6 +84,28 @@ func TestTranslateK8sObjects_Deduplication(t *testing.T) {
 		require.Len(t, first.Chunks, 1)
 		require.Len(t, second.Chunks, 1, "nil cache should not deduplicate")
 	})
+}
+
+func TestTranslateK8sObjects_SkipsNonJSONBody(t *testing.T) {
+	core, logs := observer.New(zap.DebugLevel)
+	logger := zap.New(core)
+
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("k8s.cluster.uid", "test-cluster-uid")
+	rl.Resource().Attributes().PutStr("k8s.cluster.name", "test-cluster")
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr := sl.LogRecords().AppendEmpty()
+	lr.Body().SetStr("not valid json at all")
+	lr.Attributes().PutStr("k8s.resource.name", "events")
+
+	result := logsmapping.TranslateK8sObjects(ld, nil, logger)
+
+	assert.Empty(t, result.Chunks, "non-JSON record should be skipped, producing no manifests")
+
+	debugLogs := logs.FilterMessage("Skipping log record: body is not a supported k8s manifest")
+	require.Len(t, debugLogs.All(), 1, "expected exactly one debug log for the skipped record")
+	assert.Equal(t, "events", debugLogs.All()[0].ContextMap()["k8s.resource.name"])
 }
 
 // TestShouldSkipResourceKind tests that secrets and configmaps are rejected.
@@ -452,7 +475,7 @@ func TestToManifest(t *testing.T) {
 			name:          "invalid json",
 			bodyJSON:      `{invalid json`,
 			expectError:   true,
-			errorContains: "failed to unmarshal",
+			errorContains: "unsupported log record",
 		},
 		{
 			name: "watch mode - object field not a map",

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter_test.go
@@ -16,7 +16,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
 
 	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	logsmapping "github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/logs"
@@ -87,9 +86,6 @@ func TestTranslateK8sObjects_Deduplication(t *testing.T) {
 }
 
 func TestTranslateK8sObjects_SkipsNonJSONBody(t *testing.T) {
-	core, logs := observer.New(zap.DebugLevel)
-	logger := zap.New(core)
-
 	ld := plog.NewLogs()
 	rl := ld.ResourceLogs().AppendEmpty()
 	rl.Resource().Attributes().PutStr("k8s.cluster.uid", "test-cluster-uid")
@@ -99,13 +95,9 @@ func TestTranslateK8sObjects_SkipsNonJSONBody(t *testing.T) {
 	lr.Body().SetStr("not valid json at all")
 	lr.Attributes().PutStr("k8s.resource.name", "events")
 
-	result := logsmapping.TranslateK8sObjects(ld, nil, logger)
+	result := logsmapping.TranslateK8sObjects(ld, nil, zap.NewNop())
 
 	assert.Empty(t, result.Chunks, "non-JSON record should be skipped, producing no manifests")
-
-	debugLogs := logs.FilterMessage("Skipping log record: body is not a supported k8s manifest")
-	require.Len(t, debugLogs.All(), 1, "expected exactly one debug log for the skipped record")
-	assert.Equal(t, "events", debugLogs.All()[0].ContextMap()["k8s.resource.name"])
 }
 
 // TestShouldSkipResourceKind tests that secrets and configmaps are rejected.

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter_test.go
@@ -371,6 +371,7 @@ func TestToManifest(t *testing.T) {
 	tests := []struct {
 		name            string
 		bodyJSON        string
+		attributes      map[string]string
 		expectError     bool
 		errorContains   string
 		expectWatchMode bool
@@ -464,10 +465,17 @@ func TestToManifest(t *testing.T) {
 			},
 		},
 		{
-			name:          "invalid json",
-			bodyJSON:      `{invalid json`,
+			name:          "k8s Event with non-JSON body (expected skip)",
+			bodyJSON:      `some raw event string`,
+			attributes:    map[string]string{"k8s.resource.name": "events"},
 			expectError:   true,
 			errorContains: "unsupported log record",
+		},
+		{
+			name:          "non-Event resource with invalid JSON body",
+			bodyJSON:      `{invalid json`,
+			expectError:   true,
+			errorContains: "failed to unmarshal log body",
 		},
 		{
 			name: "watch mode - object field not a map",
@@ -484,6 +492,9 @@ func TestToManifest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logRecord := plog.NewLogRecord()
 			logRecord.Body().SetStr(tt.bodyJSON)
+			for k, v := range tt.attributes {
+				logRecord.Attributes().PutStr(k, v)
+			}
 
 			manifest, isWatchMode, err := logsmapping.ToManifest(logRecord)
 

--- a/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
@@ -51,10 +51,13 @@ func init() {
 //
 // Returns the manifest and a boolean indicating if it's from a watch event.
 func ToManifest(logRecord plog.LogRecord) (*agentmodel.Manifest, bool, error) {
-	// Try to parse the body to detect the mode; non-JSON bodies (e.g. k8s Events) are a routine skip.
+	// Try to parse the body to detect the mode; non-JSON bodies (k8s Events) are a routine skip.
 	var bodyMap map[string]interface{}
 	if err := json.Unmarshal([]byte(logRecord.Body().AsString()), &bodyMap); err != nil {
-		return nil, false, errSkipUnsupportedRecord
+		if v, ok := logRecord.Attributes().Get("k8s.resource.name"); ok && v.AsString() == "events" {
+			return nil, false, errSkipUnsupportedRecord
+		}
+		return nil, false, fmt.Errorf("failed to unmarshal log body: %w", err)
 	}
 
 	// Check if this is a watch log (body contains "object" field)

--- a/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
@@ -32,6 +32,8 @@ const (
 
 var (
 	k8sTypeMap map[string]int
+
+	errSkipUnsupportedRecord = errors.New("unsupported log record")
 )
 
 func init() {
@@ -49,10 +51,10 @@ func init() {
 //
 // Returns the manifest and a boolean indicating if it's from a watch event.
 func ToManifest(logRecord plog.LogRecord) (*agentmodel.Manifest, bool, error) {
-	// Try to parse the body to detect the mode
+	// Try to parse the body to detect the mode; non-JSON bodies (e.g. k8s Events) are a routine skip.
 	var bodyMap map[string]interface{}
 	if err := json.Unmarshal([]byte(logRecord.Body().AsString()), &bodyMap); err != nil {
-		return nil, false, fmt.Errorf("failed to unmarshal log body: %w", err)
+		return nil, false, errSkipUnsupportedRecord
 	}
 
 	// Check if this is a watch log (body contains "object" field)
@@ -475,7 +477,17 @@ func TranslateK8sObjects(ld plog.Logs, cache *gocache.Cache, logger *zap.Logger)
 				lr := sl.LogRecords().At(k)
 				manifest, isWatch, err := ToManifest(lr)
 				if err != nil {
-					logger.Error("Failed to convert to manifest: "+err.Error(), zap.Error(err))
+					if errors.Is(err, errSkipUnsupportedRecord) {
+						resourceName := "unknown"
+						if v, ok := lr.Attributes().Get("k8s.resource.name"); ok {
+							resourceName = v.AsString()
+						}
+						logger.Debug("Skipping log record: body is not a supported k8s manifest",
+							zap.String("k8s.resource.name", resourceName),
+						)
+					} else {
+						logger.Error("Failed to convert to manifest: "+err.Error(), zap.Error(err))
+					}
 					continue
 				}
 				isWatchEvent = isWatch


### PR DESCRIPTION
### What does this PR do?

The kube-stack Helm chart enables the Kubernetes events preset by default, which configures the kubernetesObjects receiver to collect Kubernetes Events. Unlike other resources watched by this receiver, Event bodies  are raw strings rather than JSON-encoded k8s resource manifests, so the Datadog exporter fails to parse them and was logging an Error for every record causing alert noise in any cluster using this preset.          
                                                                                                                                                                                                                          
Kubernetes Events are not orchestrator resources and don't need to be forwarded as manifests, so it's completely safe to ignore them. We now log at Debug instead of Error to make it clear this is an expected skip, not a failure. 

### Motivation

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49322

### Describe how you validated your changes

### Additional Notes
