### PR TITLE
 Remove unnecessary deletion of idlelib/idle_test from omnibus

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -209,10 +209,6 @@ build do
   # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
   command "#{python} -m pip check"
 
-  # Removing tests that don't need to be shipped in the embedded folder
-  # This dependency doesn't come from the integrations-core lockfiles, so its tests need to be removed here
-  delete "#{site_packages_path}/../idlelib/idle_test/"
-
   unless windows_target?
     block "Remove .exe files" do
       # setuptools come from supervisor and ddtrace


### PR DESCRIPTION
### What does this PR do?

Removes deletion from omnibus for a folder that is no longer created.

### Motivation

Cleanup.

After https://github.com/DataDog/datadog-agent/pull/52173, idlelib/idle_test is already not present in the Python installation produced by Bazel on linux and macos.

For Windows, it turns out we were already not using these files either:
- I realized that no `idlelib` is present in our windows agent packages.
- `idlelib` seems to only be included [if `--include-idle` is passed](https://github.com/python/cpython/blob/d4cf1fafafc673e6147ff9d28f66ac1b50637605/PC/layout/main.py#L90-L91) to the layout creation script.
- Which is already not the case:
https://github.com/DataDog/datadog-agent/blob/eeaa4809f25bf1a760a404c65a43f93314ce08de/deps/cpython/build_python.bat#L80

### Describe how you validated your changes

Green CI, files inventory check, static quality gates, etc.

### Additional Notes
