### PR TITLE
perf(rtloader): use PyObject_GetAttr in _findSubclassOf to avoid as_string

### DIFF
--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -95,6 +95,31 @@ func runString(code string) (string, error) {
 	return string(output), err
 }
 
+// getClassBench calls get_class for the given module, exercising _findSubclassOf.
+// It discards the result and clears any error. Intended for BenchmarkXxx functions.
+func getClassBench(moduleName string) {
+	var pyModule *C.rtloader_pyobject_t
+	var pyClass *C.rtloader_pyobject_t
+
+	cModule := (*C.char)(helpers.TrackedCString(moduleName))
+	defer C.call_free(unsafe.Pointer(cModule))
+
+	runtime.LockOSThread()
+	state := C.ensure_gil(rtloader)
+
+	C.get_class(rtloader, cModule, &pyModule, &pyClass)
+	if pyModule != nil {
+		C.rtloader_decref(rtloader, pyModule)
+	}
+	if pyClass != nil {
+		C.rtloader_decref(rtloader, pyClass)
+	}
+	C.clear_error(rtloader)
+
+	C.release_gil(rtloader, state)
+	runtime.UnlockOSThread()
+}
+
 func fetchError() error {
 	if C.has_error(rtloader) == 1 {
 		return errors.New(C.GoString(C.get_error(rtloader)))

--- a/rtloader/test/rtloader/rtloader_test.go
+++ b/rtloader/test/rtloader/rtloader_test.go
@@ -15,6 +15,19 @@ import (
 	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
+// BenchmarkGetClass measures the cost of get_class / _findSubclassOf for a
+// realistic check module containing ~50 symbols in its dir() output.
+// Run with:
+//
+//	go test -bench=BenchmarkGetClass -benchtime=5s ./rtloader/test/rtloader/
+func BenchmarkGetClass(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		getClassBench("fake_check")
+	}
+}
+
 func TestMain(m *testing.M) {
 	err := setUp()
 	if err != nil {

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -705,19 +705,15 @@ PyObject *Three::_findSubclassOf(PyObject *base, PyObject *module)
             goto done;
         }
 
-        // get symbol name, as_string returns a new object that we have to free
-        char *symbol_name = as_string(symbol);
-        if (symbol_name == NULL) {
-            // as_string returns NULL if `symbol` is not a string object
-            // and raises TypeError. Let's clear the error and keep going.
-            PyErr_Clear();
+        // PyObject_GetAttr accepts the name as a PyObject directly, so we can
+        // skip the as_string() conversion (strdupe malloc + free) entirely.
+        if (!PyUnicode_Check(symbol)) {
             continue;
         }
 
         // get symbol instance. It's a new ref but in case of success we don't
         // DecRef since we return it and the caller will be owner
-        klass = PyObject_GetAttrString(module, symbol_name);
-        ::_free(symbol_name);
+        klass = PyObject_GetAttr(module, symbol);
         if (klass == NULL) {
             PyErr_Clear();
             continue;


### PR DESCRIPTION
### What does this PR do?

`_findSubclassOf` iterates `dir(module)` to find the check class. For each symbol it called `as_string(symbol)` to produce a `char*`, passed that to `PyObject_GetAttrString`, then freed the string. `PyObject_GetAttrString` internally converts the C string back to a Python str — converting Python str → C str → Python str for no reason.

`PyObject_GetAttr(module, symbol)` accepts the name PyObject directly, eliminating the round-trip entirely.

### Motivation

Each check module load iterates ~50–100 symbols. The old path called `as_string` (one `malloc` + `strcpy` + `free`) for every symbol. This eliminates all of them with no semantic change.

### Describe how you validated your changes

The existing rtloader tests (`TestGetClass` in `rtloader/test/rtloader/`) exercise `_findSubclassOf` through the full stack and end with `helpers.AssertMemoryUsage(t)`. All pass.

<details>
<summary>Allocation analysis</summary>

For a module with N symbols in its `dir()` output (typically 50–100 for a check module):

| | old | new |
|---|---|---|
| `malloc`/`free` pairs | N | 0 |
| Python OBJ allocs (via `as_string` → `PyUnicode_AsEncodedString`) | N | 0 |

The improvement is proportional to the number of symbols in the module. For a typical integration check module with 80 dir() entries, this eliminates 80 `malloc`+`free` pairs and up to 80 Python heap allocs per check load.
</details>