### PR TITLE
fix: -Wsign-compare warning in rtloader signalHandler

### DIFF
--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -351,7 +351,7 @@ void signalHandler(int sig, siginfo_t *info, void *context)
         std::cerr << "Error getting backtrace symbols" << std::endl;
     } else {
         std::cerr << "C-LAND STACKTRACE: " << std::endl;
-        for (int i = 0; i < nptrs; i++) {
+        for (size_t i = 0; i < nptrs; i++) {
             std::cerr << symbols[i] << std::endl;
         }
 


### PR DESCRIPTION
## What does this PR do?

Fix a `-Wsign-compare` compiler warning in `rtloader/rtloader/api.cpp`.

## Motivation

Fix a `-Wsign-compare` compiler warning in `rtloader/rtloader/api.cpp`.