### PR TITLE
fix(test): use errors.As for json unmarshal type assertion in cisco-sdwan client test

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request_test.go
@@ -6,6 +6,7 @@
 package client
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -250,7 +251,10 @@ func TestGetRequestUnmarshallingError(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := get[Device](client, "/test", nil)
-	require.ErrorContains(t, err, "cannot unmarshal string into Go struct field Device.data.lastupdated of type float64")
+	var typeErr *json.UnmarshalTypeError
+	require.ErrorAs(t, err, &typeErr)
+	require.Equal(t, "string", typeErr.Value)
+	require.Contains(t, typeErr.Field, "lastupdated")
 
 	var empty *Response[Device]
 	require.Equal(t, empty, resp)


### PR DESCRIPTION
### What does this PR do?

Replace a hardcoded json error message string in `TestGetRequestUnmarshallingError` with `errors.As` on `*json.UnmarshalTypeError`.

### Motivation

The old assertion matched the exact error string produced by `encoding/json`, which changed format in Go 1.27 (the field path now includes the full generic type, e.g. `Response[...Device].data.0.lastupdated` instead of `Device.data.lastupdated`). Using `errors.As` checks the error type and its typed fields directly, which is stable across Go versions.

### Describe how you validated your changes

Caught by CI on the Go 1.27rc1 testing branch.

### Additional Notes