### PR TITLE
[macOS installer] Bump install script version to 2.1.0

### DIFF
--- a/cmd/agent/macos/install_mac_os.sh
+++ b/cmd/agent/macos/install_mac_os.sh
@@ -6,7 +6,7 @@
 
 # Datadog Agent install script for macOS.
 set -e
-install_script_version=2.0.0
+install_script_version=2.1.0
 
 # Terminal color detection
 # Colors are enabled only when outputting to a terminal (not when piped/redirected)


### PR DESCRIPTION
### What does this PR do?

Bumps `install_script_version` in `install_mac_os.sh` from `2.0.0` to `2.1.0`.

### Motivation

Reflects the changes introduced in #52133 ([macOS installer] Suppress curl progress bar in non-interactive environments):

- Detects interactivity with `[ -t 2 ]` (stderr is a terminal) before the `exec > >(tee ...) 2>&1` redirect.
- Uses `--progress-bar` when stderr is a terminal (interactive, behavior unchanged).
- Uses `--no-progress-meter` otherwise — keeps error messages visible on failure while suppressing progress noise in CI pipelines, MDM/Jamf policies, and piped invocations.

### Describe how you validated your changes

N/A — version string bump only.

### Additional Notes

Changelog entry for 2.1.0:
- Suppress curl progress bar in non-interactive environments (#52133)