### PR TITLE
feat(otel-agent): default sync-delay to 30s

### DIFF
--- a/cmd/otel-agent/command/command.go
+++ b/cmd/otel-agent/command/command.go
@@ -103,7 +103,7 @@ func makeCommands(globalParams *subcommands.GlobalParams) *cobra.Command {
 const (
 	configFlag      = "config"
 	coreConfigFlag  = "core-config"
-	syncDelayFlag   = "sync-delay" // TODO: Change this to sync-on-init-timeout
+	syncDelayFlag   = "sync-delay"
 	syncTimeoutFlag = "sync-to"
 )
 
@@ -155,7 +155,7 @@ func flags(reg *featuregate.Registry, cfgs *subcommands.GlobalParams) *flag.Flag
 	flagSet.Var(cfgs, configFlag, "Locations to the config file(s), note that only a"+
 		" single location can be set per flag entry e.g. `--config=file:/path/to/first --config=file:path/to/second`.")
 	flagSet.StringVar(&cfgs.CoreConfPath, coreConfigFlag, "", "Location to the Datadog Agent config file.")
-	flagSet.DurationVar(&cfgs.SyncOnInitTimeout, syncDelayFlag, 0, "How long should config sync retry at initialization before failing.")
+	flagSet.DurationVar(&cfgs.SyncOnInitTimeout, syncDelayFlag, 30*time.Second, "How long should config sync retry at initialization before failing.")
 	flagSet.DurationVar(&cfgs.SyncTimeout, syncTimeoutFlag, 3*time.Second, "Timeout for config sync requests.")
 
 	flagSet.Func("set",

--- a/releasenotes/notes/otel-agent-sync-delay-default-30s-3f1a2b9c4d5e6f70.yaml
+++ b/releasenotes/notes/otel-agent-sync-delay-default-30s-3f1a2b9c4d5e6f70.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    The OTel Agent ``--sync-delay`` flag (env ``DD_SYNC_DELAY``) now defaults to
+    ``30s`` instead of ``0``. The OTel Agent will retry synchronizing its
+    configuration from the core Agent for up to 30 seconds at startup before
+    failing, which makes startup more resilient when the core Agent is not yet
+    ready. This default can still be overridden via the flag or environment
+    variable.


### PR DESCRIPTION
### What does this PR do?

Changes the otel-agent `--sync-delay` flag (`DD_SYNC_DELAY`) default from `0` to `30s`. With this default, the otel-agent retries synchronizing its configuration from the core Agent for up to 30 seconds at startup before failing, instead of giving up after a single attempt.

### Motivation

A `0` default means "do not retry": configsync makes one attempt and fails if the core Agent is not yet listening. This was masked because helm/operator pass `--sync-delay=30s` as an override. However, the Linux DDOT systemd unit launches otel-agent without the flag, so on Linux it effectively had no startup retry. Making `30s` the default fixes Linux DDOT startup resilience and matches what host-profiler already does (`sync-on-init-timeout` defaults to `30s`).
The flag name and env var are intentionally unchanged, so existing helm/operator overrides keep working. They can drop their `--sync-delay=30s` override in a follow-up.

### Describe how you validated your changes
unti tests

### Possible Drawbacks / Trade-offs

The otel-agent now waits up to 30s for the core Agent at startup rather than failing immediately. For normal deployments this is an improvement, but it can delay a restart by up to 30s in cases of genuine misconfiguration.

https://datadoghq.atlassian.net/browse/OTAGENT-1030