### PR TITLE
(fleet) add per-job build-trace fragments for deb/x86 build timing

### DIFF
--- a/.gitlab/.pre/deps_fetch/deps_fetch.yml
+++ b/.gitlab/.pre/deps_fetch/deps_fetch.yml
@@ -61,6 +61,7 @@ go_deps:
   variables:
     KUBERNETES_MEMORY_REQUEST: 12Gi
     KUBERNETES_MEMORY_LIMIT: 16Gi
+    BUILD_TRACE_SEGMENT: preamble
   script:
     # If the cache already contains the dependencies, don't redownload them
     # but still provide the artifact that's expected for the other jobs to run
@@ -71,6 +72,7 @@ go_deps:
     expire_in: 1 day
     paths:
       - $CI_PROJECT_DIR/modcache.tar.zst
+      - $CI_PROJECT_DIR/build-trace/
   cache:
     # The `cache:key:files` only accepts up to two paths ([docs](https://docs.gitlab.com/ee/ci/yaml/#cachekeyfiles)).
     # We should also include the file this job is defined in to invalicate the cache when this job is modified.

--- a/.gitlab/build/binary_build/system_probe.yml
+++ b/.gitlab/build/binary_build/system_probe.yml
@@ -14,11 +14,13 @@
     KUBERNETES_MEMORY_REQUEST: "6Gi"
     KUBERNETES_MEMORY_LIMIT: "12Gi"
     KUBERNETES_CPU_REQUEST: 6
+    BUILD_TRACE_SEGMENT: preamble
   artifacts:
     expire_in: 2 weeks
     paths:
       - $CI_PROJECT_DIR/sysprobe-build-outputs.tar.xz
       - $CI_PROJECT_DIR/sysprobe-build-outputs.tar.xz.sum
+      - $CI_PROJECT_DIR/build-trace/
 
 build_system-probe-x64:
   stage: binary_build

--- a/.gitlab/build/package_build/linux.yml
+++ b/.gitlab/build/package_build/linux.yml
@@ -29,10 +29,12 @@
     KUBERNETES_CPU_REQUEST: 16
     KUBERNETES_MEMORY_REQUEST: "32Gi"
     KUBERNETES_MEMORY_LIMIT: "32Gi"
+    BUILD_TRACE_SEGMENT: omnibus
   artifacts:
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
+      - $CI_PROJECT_DIR/build-trace/
 
 .agent_build_x86:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX

--- a/.gitlab/build/package_deps_build/package_deps_build.yml
+++ b/.gitlab/build/package_deps_build/package_deps_build.yml
@@ -34,10 +34,12 @@
     KUBERNETES_MEMORY_REQUEST: "64Gi"
     KUBERNETES_MEMORY_LIMIT: "64Gi"
     KUBERNETES_CPU_REQUEST: 24
+    BUILD_TRACE_SEGMENT: preamble
   artifacts:
     expire_in: 2 weeks
     paths:
     - $CI_PROJECT_DIR/minimized-btfs.tar.xz
+    - $CI_PROJECT_DIR/build-trace/
 
 generate_minimized_btfs_x64:
   needs: ["build_system-probe-x64"]

--- a/.gitlab/build/packaging/deb.yml
+++ b/.gitlab/build/packaging/deb.yml
@@ -15,6 +15,7 @@ include:
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
+      - $CI_PROJECT_DIR/build-trace/
       - !reference [.static_quality_gate_report_path]
   variables:
     OMNIBUS_PACKAGE_ARTIFACT_DIR: $OMNIBUS_PACKAGE_DIR
@@ -22,6 +23,7 @@ include:
     KUBERNETES_MEMORY_REQUEST: "32Gi"
     KUBERNETES_MEMORY_LIMIT: "32Gi"
     PACKAGE_REQUIRED_FILES_LIST: "test/required_files/agent-deb.txt"
+    BUILD_TRACE_SEGMENT: deb_packaging
 
 .package_deb_x86:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -21,6 +21,7 @@ from invoke.exceptions import Exit
 
 from tasks.build_tags import ALL_TAGS, UNIT_TEST_TAGS, get_default_build_tags
 from tasks.libs.build.bazel import bazel, bazel_not_found_message
+from tasks.libs.common.build_trace import trace_span
 from tasks.libs.common.color import color_message
 from tasks.libs.common.git import check_uncommitted_changes
 from tasks.libs.common.go import download_go_dependencies
@@ -153,7 +154,8 @@ def deps(ctx, verbose=False):
     Setup Go dependencies
     """
     paths = [mod.full_path() for mod in get_default_modules().values()]
-    download_go_dependencies(ctx, paths, verbose=verbose)
+    with trace_span("go-deps-download", meta={"modules": len(paths)}):
+        download_go_dependencies(ctx, paths, verbose=verbose)
 
 
 @task

--- a/tasks/libs/common/build_trace.py
+++ b/tasks/libs/common/build_trace.py
@@ -1,0 +1,89 @@
+"""
+Build-trace fragments: per-CI-job, machine-readable timing spans.
+
+Each instrumented build job appends spans to a fragment at
+``$CI_PROJECT_DIR/build-trace/<job-slug>.json``. A workstream-side harvester
+later stitches these fragments together with GitLab job timings and the omnibus
+``build-summary.json`` into a unified ``deb``/``x86`` build trace
+(segment -> component -> duration).
+
+This is additive instrumentation layered on top of ``timed``; it does not
+replace ``timed``, ``gitlab_section`` or ``send_build_metrics``. Recording is
+best-effort: it must never raise into the build it is measuring.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from contextlib import contextmanager
+
+SCHEMA_VERSION = "1"
+
+
+def _trace_dir() -> str:
+    base = os.environ.get("CI_PROJECT_DIR") or os.getcwd()
+    return os.path.join(base, "build-trace")
+
+
+def _job_slug() -> str:
+    # GitLab provides CI_JOB_NAME_SLUG; fall back to the name, then to "local".
+    return os.environ.get("CI_JOB_NAME_SLUG") or os.environ.get("CI_JOB_NAME") or "local"
+
+
+def _fragment_path() -> str:
+    return os.path.join(_trace_dir(), f"{_job_slug()}.json")
+
+
+def record_span(name: str, duration_s: float, cached: bool | None = None, meta: dict | None = None) -> None:
+    """Append one timing span to this job's build-trace fragment.
+
+    Safe to call from successive ``dda inv`` invocations within the same CI job:
+    the fragment is read-modify-written so spans accumulate. CI job steps run
+    sequentially, so no locking is needed. Never raises -- a tracing failure must
+    not break a build.
+    """
+    try:
+        path = _fragment_path()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+
+        fragment = {"schema_version": SCHEMA_VERSION, "job": _job_slug(), "spans": []}
+        if os.path.exists(path):
+            try:
+                with open(path) as f:
+                    fragment = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                # Corrupt/partial fragment: start fresh rather than fail the build.
+                fragment = {"schema_version": SCHEMA_VERSION, "job": _job_slug(), "spans": []}
+
+        # Segment is a property of the job, not the span; the harvester maps
+        # job -> segment. We record it here only when CI sets it, for readability.
+        segment = os.environ.get("BUILD_TRACE_SEGMENT")
+        if segment:
+            fragment["segment"] = segment
+        arch = os.environ.get("PACKAGE_ARCH") or os.environ.get("ARCH")
+        if arch:
+            fragment["arch"] = arch
+
+        span: dict = {"name": name, "duration_s": round(float(duration_s), 3)}
+        if cached is not None:
+            span["cached"] = bool(cached)
+        if meta:
+            span["meta"] = meta
+        fragment.setdefault("spans", []).append(span)
+
+        with open(path, "w") as f:
+            json.dump(fragment, f, indent=2)
+    except Exception as e:
+        print(f"build-trace: failed to record span {name!r}: {e}")
+
+
+@contextmanager
+def trace_span(name: str, cached: bool | None = None, meta: dict | None = None):
+    """Time a block and record it as a build-trace span (mirrors ``timed``)."""
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        record_span(name, time.perf_counter() - start, cached=cached, meta=meta)

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -15,6 +15,7 @@ from invoke.exceptions import Exit, UnexpectedExit
 
 from tasks.flavor import AgentFlavor
 from tasks.go import deps
+from tasks.libs.common.build_trace import record_span
 from tasks.libs.common.check_tools_version import expected_go_repo_v
 from tasks.libs.common.omnibus import (
     ENV_PASSHTROUGH,
@@ -379,6 +380,20 @@ def build(
     for name in durations_to_print:
         if name in durations:
             print(f"{name}: {durations[name].duration}")
+
+    # Record the coarse omnibus buckets into this job's build-trace fragment.
+    # Per-software / per-packager detail already lives in build-summary.json
+    # (read by send_build_metrics); these buckets are otherwise stdout-only.
+    build_trace_span_names = {
+        "Deps": "deps",
+        "Bundle": "bundle-install",
+        "Omnibus": "omnibus-total",
+        "Restoring omnibus cache": "omnibus-cache-restore",
+        "Updating omnibus cache": "omnibus-cache-update",
+    }
+    for name, span_name in build_trace_span_names.items():
+        if name in durations:
+            record_span(span_name, durations[name].duration)
 
     try:
         send_build_metrics(ctx, durations['Omnibus'].duration)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -11,6 +11,7 @@ import shutil
 import string
 import sys
 import tempfile
+import time
 from pathlib import Path
 from subprocess import check_output
 
@@ -25,6 +26,7 @@ from tasks.flavor import AgentFlavor
 from tasks.libs.build.bazel import bazel
 from tasks.libs.build.ninja import NinjaWriter
 from tasks.libs.ciproviders.gitlab_api import ReferenceTag
+from tasks.libs.common.build_trace import record_span, trace_span
 from tasks.libs.common.color import color_message
 from tasks.libs.common.git import get_commit_sha
 from tasks.libs.common.go import go_build
@@ -1166,6 +1168,7 @@ def build_object_files(
     ctx,
     arch: str = CURRENT_ARCH,
 ) -> None:
+    _object_files_start = time.perf_counter()
     arch_obj = Arch.from_str(arch)
     build_dir = get_ebpf_build_dir(arch_obj)
     runtime_dir = get_ebpf_runtime_dir()
@@ -1228,6 +1231,8 @@ def build_object_files(
             with ctx.cd(runtime_dir):
                 ctx.run(f"{sudo} mkdir -p {EMBEDDED_SHARE_DIR}/runtime")
                 ctx.run(f"{sudo} find ./ -maxdepth 1 -type f -name '*.c' {cp_cmd('runtime')}")
+
+    record_span("build-object-files", time.perf_counter() - _object_files_start)
 
 
 def build_rust_binaries(ctx: Context, arch: Arch, output_dir: Path | None = None, packages: list[str] | None = None):
@@ -1417,7 +1422,8 @@ def generate_minimized_btfs(ctx, source_dir, output_dir, bpf_programs):
                     },
                 )
 
-    ctx.run(f"ninja -f {ninja_file_path}", env={"NINJA_STATUS": "(%r running) (%c/s) (%es) [%f/%t] "})
+    with trace_span("minimize-btfs", meta={"programs": len(bpf_programs)}):
+        ctx.run(f"ninja -f {ninja_file_path}", env={"NINJA_STATUS": "(%r running) (%c/s) (%es) [%f/%t] "})
 
 
 def compute_go_parallelism(debug: bool = False, ci: bool | None = None) -> int:

--- a/tasks/unit_tests/libs/common/build_trace_tests.py
+++ b/tasks/unit_tests/libs/common/build_trace_tests.py
@@ -1,0 +1,78 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from tasks.libs.common import build_trace
+
+
+class TestBuildTrace(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.env = patch.dict(
+            os.environ,
+            {
+                "CI_PROJECT_DIR": self.tmp.name,
+                "CI_JOB_NAME_SLUG": "datadog-agent-7-x64",
+                "BUILD_TRACE_SEGMENT": "omnibus",
+                "PACKAGE_ARCH": "amd64",
+            },
+            clear=False,
+        )
+        self.env.start()
+        self.addCleanup(self.env.stop)
+
+    def _fragment(self):
+        with open(build_trace._fragment_path()) as f:
+            return json.load(f)
+
+    def test_records_spans_with_metadata(self):
+        build_trace.record_span("bundle-install", 28.0)
+        build_trace.record_span("python", 210.345678, cached=False)
+        build_trace.record_span("openssl", 35.1, cached=True, meta={"size": 10})
+
+        frag = self._fragment()
+        self.assertEqual(frag["schema_version"], build_trace.SCHEMA_VERSION)
+        self.assertEqual(frag["job"], "datadog-agent-7-x64")
+        self.assertEqual(frag["segment"], "omnibus")
+        self.assertEqual(frag["arch"], "amd64")
+        self.assertEqual([s["name"] for s in frag["spans"]], ["bundle-install", "python", "openssl"])
+        # duration is rounded to ms precision
+        self.assertEqual(frag["spans"][1]["duration_s"], 210.346)
+        # cached only emitted when set
+        self.assertNotIn("cached", frag["spans"][0])
+        self.assertIs(frag["spans"][1]["cached"], False)
+        self.assertIs(frag["spans"][2]["cached"], True)
+        self.assertEqual(frag["spans"][2]["meta"], {"size": 10})
+
+    def test_spans_accumulate_across_calls(self):
+        """Successive `dda inv` invocations in the same job append, not overwrite."""
+        build_trace.record_span("a", 1.0)
+        build_trace.record_span("b", 2.0)
+        self.assertEqual([s["name"] for s in self._fragment()["spans"]], ["a", "b"])
+
+    def test_trace_span_context_manager(self):
+        with build_trace.trace_span("work"):
+            pass
+        spans = self._fragment()["spans"]
+        self.assertEqual(spans[0]["name"], "work")
+        self.assertGreaterEqual(spans[0]["duration_s"], 0.0)
+
+    def test_recovers_from_corrupt_fragment(self):
+        os.makedirs(os.path.dirname(build_trace._fragment_path()), exist_ok=True)
+        with open(build_trace._fragment_path(), "w") as f:
+            f.write("{not valid json")
+        build_trace.record_span("recovered", 1.0)
+        self.assertEqual([s["name"] for s in self._fragment()["spans"]], ["recovered"])
+
+    def test_never_raises(self):
+        """A tracing failure must not break the build it measures."""
+        with patch("tasks.libs.common.build_trace._fragment_path", side_effect=OSError("boom")):
+            # Should swallow the error rather than propagate.
+            build_trace.record_span("x", 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds fine-grained, machine-readable build-timing **fragments** to the `deb`/`x86` (`linux/amd64`) cold build path. Each instrumented CI job writes spans to `$CI_PROJECT_DIR/build-trace/<job-slug>.json` (collected as a job artifact), so a per-build breakdown of `segment → component → duration` can be assembled post-hoc instead of guessed at.

The new `tasks/libs/common/build_trace.py` recorder is layered on top of the existing `timed` primitive, accumulates spans across successive `dda inv` invocations in the same job, and is best-effort: a tracing failure never raises into the build it measures.

Instrumentation added:
- **Preamble** in-task spans: go dependency download (`tasks/go.py::deps`), system-probe object-file build (`tasks/system_probe.py::build_object_files`), and BTF minimization (`generate_minimized_btfs`).
- **Omnibus** (`tasks/omnibus.py::build`): folds the coarse buckets (`bundle-install`, omnibus cache restore/update, `deps`, `omnibus-total`) — previously stdout-only — into the job fragment.
- **CI**: `build-trace/` added to the artifacts of `go_deps`, `build_system-probe-x64`, `generate_minimized_btfs`, the omnibus build, and the deb packaging jobs; each job tagged with its `BUILD_TRACE_SEGMENT`.

## Motivation

The build already times coarse buckets and emits per-software durations via omnibus `build-summary.json` + `send_build_metrics`, but the preamble (~13 min) is invisible below GitLab job level and the omnibus sub-buckets are stdout-only, so a whole cold build can't be reconstructed into one attributable trace. This fills those gaps to enable targeted build-speed work.

## Notes / tradeoffs

- Additive only: per-software / per-packager detail still comes from `build-summary.json`; `send_build_metrics` is untouched.
- Deb packaging extras (`dd-pkg` sign/lint, static quality gate) are shell-only steps and are intentionally **not** instrumented here; they surface as per-segment "unattributed" time in the assembled trace. Follow-up if material.
- The post-hoc harvester that stitches fragments + `build-summary.json` + GitLab job timings into the unified trace lives outside this repo.

Unit tests: `tasks/unit_tests/libs/common/build_trace_tests.py` (5 tests).
