### PR TITLE
[AGENTCFG-844][AGENTCFG-845][AGENTCFG-846][AGENTCFG-847] fix: Subscribe() now blocks until initial snapshot is in the channel

### DIFF
--- a/comp/core/configstream/impl/configstream.go
+++ b/comp/core/configstream/impl/configstream.go
@@ -46,7 +46,7 @@ type configStream struct {
 	m           sync.Mutex
 	subscribers map[string]*subscription
 
-	subscribeChan   chan *subscription
+	subscribeChan   chan pendingSubscription
 	unsubscribeChan chan string
 	stopChan        chan struct{}
 
@@ -66,6 +66,13 @@ type subscription struct {
 	lastSequenceID uint64
 }
 
+// pendingSubscription is a short-lived handshake value sent through subscribeChan.
+// ready is closed by addSubscriber once the snapshot is in sub.ch, unblocking Subscribe().
+type pendingSubscription struct {
+	sub   *subscription
+	ready chan struct{}
+}
+
 // NewComponent creates a new configstream component.
 func NewComponent(reqs Requires) (Provides, error) {
 	cs := &configStream{
@@ -73,7 +80,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 		log:             reqs.Log,
 		telemetry:       reqs.Telemetry,
 		subscribers:     make(map[string]*subscription),
-		subscribeChan:   make(chan *subscription),
+		subscribeChan:   make(chan pendingSubscription),
 		unsubscribeChan: make(chan string),
 		stopChan:        make(chan struct{}),
 	}
@@ -109,10 +116,10 @@ func (cs *configStream) Subscribe(req *pb.ConfigStreamRequest) (<-chan *pb.Confi
 	subID := fmt.Sprintf("%s-%s", req.Name, uuid.New().String())
 	subChan := make(chan *pb.ConfigEvent, 100) // Buffered channel to avoid blocking
 
-	cs.subscribeChan <- &subscription{
-		id: subID,
-		ch: subChan,
-	}
+	sub := &subscription{id: subID, ch: subChan}
+	ready := make(chan struct{})
+	cs.subscribeChan <- pendingSubscription{sub: sub, ready: ready}
+	<-ready // wait until the initial snapshot has been sent
 
 	unsubscribeFunc := func() {
 		cs.unsubscribeChan <- subID
@@ -159,8 +166,8 @@ func (cs *configStream) run() {
 
 	for {
 		select {
-		case sub := <-cs.subscribeChan:
-			cs.addSubscriber(sub)
+		case pending := <-cs.subscribeChan:
+			cs.addSubscriber(pending.sub, pending.ready)
 		case id := <-cs.unsubscribeChan:
 			cs.removeSubscriber(id)
 		case update := <-updatesChan:
@@ -177,7 +184,9 @@ func (cs *configStream) run() {
 	}
 }
 
-func (cs *configStream) addSubscriber(sub *subscription) {
+func (cs *configStream) addSubscriber(sub *subscription, ready chan struct{}) {
+	defer close(ready)
+
 	cs.log.Infof("New subscriber '%s' joining the config stream", sub.id)
 	snapshot, seqID, err := cs.createConfigSnapshot()
 	if err != nil {
@@ -196,7 +205,6 @@ func (cs *configStream) addSubscriber(sub *subscription) {
 	cs.subscribersGauge.Set(float64(len(cs.subscribers)))
 	cs.snapshotsSent.Inc()
 
-	// Send snapshot to the new subscriber
 	sub.ch <- snapshot
 }
 

--- a/comp/core/configstream/impl/configstream_test.go
+++ b/comp/core/configstream/impl/configstream_test.go
@@ -147,6 +147,7 @@ func TestClientConnectsAndReceivesStream(t *testing.T) {
 		timeout := time.After(2 * time.Second)
 		typedValues := make(map[string]interface{})
 
+	loop:
 		for len(typedValues) < 4 {
 			select {
 			case event := <-eventChan:
@@ -166,7 +167,7 @@ func TestClientConnectsAndReceivesStream(t *testing.T) {
 					}
 				}
 			case <-timeout:
-				break
+				break loop
 			}
 		}
 

--- a/comp/core/configstream/impl/configstream_test.go
+++ b/comp/core/configstream/impl/configstream_test.go
@@ -282,6 +282,24 @@ done:
 	}
 }
 
+// TestSubscribeBlocksUntilSnapshotReady guards against Subscribe() returning before
+// the initial snapshot is buffered in the channel.
+func TestSubscribeBlocksUntilSnapshotReady(t *testing.T) {
+	cfg := configmock.New(t)
+	mockLog := logmock.New(t)
+	cs := newConfigStreamForTest(t, cfg, mockLog)
+
+	eventChan, unsubscribe := cs.Subscribe(&pb.ConfigStreamRequest{Name: "test-client"})
+	defer unsubscribe()
+
+	select {
+	case event := <-eventChan:
+		require.NotNil(t, event.GetSnapshot(), "first event after Subscribe() must be a snapshot")
+	default:
+		t.Fatal("snapshot not in channel immediately after Subscribe() returned")
+	}
+}
+
 func TestNewComponentNoError(t *testing.T) {
 	mockLog := logmock.New(t)
 	telemetryComp := telemetrynoops.GetCompatComponent()


### PR DESCRIPTION
### What does this PR do?

Fixes two bugs in `comp/core/configstream/impl` that caused flaky failures on `tests_linux-arm64-py3`.

**1. `Subscribe()` race: snapshot not guaranteed in channel on return**

`Subscribe()` sends a subscription to the `run()` goroutine via an unbuffered channel. The channel send unblocks as soon as `run()` reads the value — before `addSubscriber()` has built and sent the initial snapshot. On a heavily loaded arm64 CI runner, `createConfigSnapshot()` took longer than the tests' 2-second timeout, so every test in the package failed with "timeout waiting for snapshot" on the first attempt and passed on retry.

Fixed by introducing a `pendingSubscription` handshake type (carrying both the subscription and a `ready` channel) through `subscribeChan`. `addSubscriber()` closes `ready` via `defer` after the snapshot is in the subscriber's channel, and `Subscribe()` blocks on `<-ready` before returning. Callers are now guaranteed the snapshot is already buffered when `Subscribe()` returns.

A regression test (`TestSubscribeBlocksUntilSnapshotReady`) verifies this guarantee with a non-blocking `select`/`default`: if the snapshot isn't immediately available after `Subscribe()` returns, the test fails instantly — no timers needed.

**2. `break` inside `select` inside `for` in `TestClientConnectsAndReceivesStream` subtest 3**

In Go, `break` within a `select` only exits the `select`, not the enclosing `for` loop. In subtest 3, when the 2-second timeout fired before all 4 typed-value updates arrived, the loop continued spinning — but `time.After` is drained after its first receive, so subsequent iterations blocked indefinitely on the event channel. Fixed with a labeled `break loop`, matching the pattern already used in subtest 2 (introduced in #52570).

### Motivation

All four Jira cards ([AGENTCFG-844](https://datadoghq.atlassian.net/browse/AGENTCFG-844), [AGENTCFG-845](https://datadoghq.atlassian.net/browse/AGENTCFG-845), [AGENTCFG-846](https://datadoghq.atlassian.net/browse/AGENTCFG-846), [AGENTCFG-847](https://datadoghq.atlassian.net/browse/AGENTCFG-847)) trace back to the same CI job (`tests_linux-arm64-py3`, job 1804108345).

### Describe how you validated your changes

added a unit test

[AGENTCFG-844]: https://datadoghq.atlassian.net/browse/AGENTCFG-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ