### PR TITLE
Fix low priority queue drops on Agent shutdown

### DIFF
--- a/comp/forwarder/defaultforwarder/impl/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/impl/default_forwarder.go
@@ -330,8 +330,7 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 	}
 
 	flushToDiskMemRatio := config.GetFloat64("forwarder_flush_to_disk_mem_ratio")
-	domainForwarderSort := transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}
-	transactionContainerSort := transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: false}
+	transactionSorter := transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}
 
 	for domain, resolver := range options.DomainResolvers {
 		domain, _ := utils.AddAgentVersionToDomain(domain, "app")
@@ -356,7 +355,7 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 				flushToDiskMemRatio,
 				domainFolderPath,
 				diskUsageLimit,
-				transactionContainerSort,
+				transactionSorter,
 				resolver,
 				pointCountTelemetry)
 			f.domainResolvers[domain] = resolver
@@ -374,7 +373,7 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 				transactionContainer,
 				numberOfWorkers,
 				options.ConnectionResetInterval,
-				domainForwarderSort,
+				transactionSorter,
 				pointCountTelemetry,
 				options.transport)
 			f.domainForwarders[domain] = fwd

--- a/comp/forwarder/defaultforwarder/impl/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/impl/domain_forwarder.go
@@ -296,7 +296,8 @@ func NewHTTPTransport(config config.Component, numberOfWorkers int, log log.Comp
 	return transport
 }
 
-// Stop stops a domainForwarder, all transactions not yet flushed will be lost.
+// Stop stops a domainForwarder and persists retryable queued transactions when
+// disk storage is enabled.
 func (f *domainForwarder) Stop(purgeHighPrio bool) {
 	// Lock so we can't start a Forwarder while is stopping
 	f.m.Lock()
@@ -320,6 +321,9 @@ func (f *domainForwarder) Stop(purgeHighPrio bool) {
 	close(f.requeuedTransaction)
 
 	for t := range f.requeuedTransaction {
+		f.requeueTransaction(t)
+	}
+	for t := range f.lowPrio {
 		f.requeueTransaction(t)
 	}
 	if err := f.retryQueue.FlushToDisk(); err != nil {

--- a/comp/forwarder/defaultforwarder/impl/domain_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/impl/domain_forwarder_test.go
@@ -341,7 +341,7 @@ func TestForwarderRetryLimitQueue(t *testing.T) {
 	forwarder.blockedList.errorPerEndpoint["blocked"].until = time.Now().Add(1 * time.Minute)
 
 	var transactions []*testTransaction
-	for _, v := range []time.Time{time.Now(), time.Now().Add(1 * time.Minute), time.Now().Add(1 * time.Minute)} {
+	for _, v := range []time.Time{time.Now(), time.Now().Add(1 * time.Minute), time.Now().Add(2 * time.Minute)} {
 		transaction := newTestTransactionDomainForwarder()
 
 		forwarder.requeueTransaction(transaction)
@@ -361,9 +361,9 @@ func TestForwarderRetryLimitQueue(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, trs, 2)
 
-	// assert that the oldest transaction was dropped
+	// assert that the oldest transaction was dropped (transactions[0] has time=Now)
 	assert.Equal(t, transactions[2], trs[0])
-	assert.Equal(t, transactions[0], trs[1])
+	assert.Equal(t, transactions[1], trs[1])
 }
 
 func TestDomainForwarderRetryQueueAllPayloadsMaxSize(t *testing.T) {
@@ -429,6 +429,98 @@ forwarder_requeue_buffer_size: 1300
 	assert.Equal(t, 1100, cap(forwarder.highPrio))
 	assert.Equal(t, 1200, cap(forwarder.lowPrio))
 	assert.Equal(t, 1300, cap(forwarder.requeuedTransaction))
+}
+
+// mockDiskStorage is a TransactionDiskStorage implementation used in tests that
+// captures every transaction passed to Store without performing any I/O.
+type mockDiskStorage struct {
+	allStored []transaction.Transaction
+}
+
+func (m *mockDiskStorage) Store(ts []transaction.Transaction) error {
+	m.allStored = append(m.allStored, ts...)
+	return nil
+}
+
+func (m *mockDiskStorage) ExtractLast() ([]transaction.Transaction, error) { return nil, nil }
+
+func (m *mockDiskStorage) GetDiskSpaceUsed() int64 { return 0 }
+
+// TestDomainForwarderStopPreservesLowPrioTransactions verifies that transactions
+// present in the lowPrio channel at shutdown time are transferred to the retry
+// queue rather than silently dropped.
+func TestDomainForwarderStopPreservesLowPrioTransactions(t *testing.T) {
+	oldFlushInterval := flushInterval
+	defer func() { flushInterval = oldFlushInterval }()
+	flushInterval = time.Hour
+
+	mockConfig := mock.New(t)
+	log := logmock.New(t)
+	forwarder := newDomainForwarderForTest(t, mockConfig, log, 0, false)
+	forwarder.Start()
+
+	// Stop the single worker so it cannot consume from lowPrio before Stop drains it.
+	forwarder.workers[0].Stop(false)
+	forwarder.workers = nil // Prevent Stop from re-stopping the already-stopped worker.
+
+	tr := newTestTransactionDomainForwarder()
+	forwarder.lowPrio <- tr
+
+	forwarder.Stop(false)
+
+	requireLenForwarderRetryQueue(t, forwarder, 1)
+}
+
+// TestDomainForwarderStopFlushesRetryQueueAndLowPrioToDisk verifies that at
+// shutdown, transactions held in both the in-memory retry queue and the lowPrio
+// channel are all written to disk via FlushToDisk.
+func TestDomainForwarderStopFlushesRetryQueueAndLowPrioToDisk(t *testing.T) {
+	oldFlushInterval := flushInterval
+	defer func() { flushInterval = oldFlushInterval }()
+	flushInterval = time.Hour
+
+	storage := &mockDiskStorage{}
+	sorter := transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}
+	telemetry := retry.NewTransactionRetryQueueTelemetry("domain")
+	retryQueue := retry.NewTransactionRetryQueue(
+		sorter,
+		storage,
+		100,
+		0,
+		telemetry,
+		retry.NewPointCountTelemetryMock())
+
+	mockConfig := mock.New(t)
+	mockConfig.SetInTest("forwarder_max_concurrent_requests", 1)
+	log := logmock.New(t)
+	secrets := secretsmock.New(t)
+	forwarder := newDomainForwarder(mockConfig, log, secrets, "test", false, false, retryQueue, 1, 0, sorter, retry.NewPointCountTelemetry("domain"), nil)
+	forwarder.Start()
+
+	forwarder.workers[0].Stop(false)
+	forwarder.workers = nil
+
+	tr1 := newTestTransactionDomainForwarder()
+	tr1.On("GetCreatedAt").Return(time.Now()).Maybe()
+	forwarder.requeueTransaction(tr1)
+
+	tr2 := newTestTransactionDomainForwarder()
+	tr2.On("GetCreatedAt").Return(time.Now()).Maybe()
+	forwarder.lowPrio <- tr2
+
+	forwarder.Stop(false)
+
+	hasTx := func(target transaction.Transaction) bool {
+		for _, tx := range storage.allStored {
+			if tx == target {
+				return true
+			}
+		}
+		return false
+	}
+	require.Len(t, storage.allStored, 2)
+	assert.True(t, hasTx(tr1), "transaction from retry queue should be flushed to disk")
+	assert.True(t, hasTx(tr2), "transaction from lowPrio should be flushed to disk")
 }
 
 func newDomainForwarderForTest(t *testing.T, config config.Component, log log.Component, connectionResetInterval time.Duration, ha bool) *domainForwarder {

--- a/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
@@ -227,7 +227,7 @@ func (tc *TransactionRetryQueue) extractTransactionsForDisk(payloadSize int) [][
 	sizeInBytesToFlush := int(float64(tc.maxMemSizeInBytes) * tc.flushToStorageRatio)
 	var payloadsGroupToFlush [][]transaction.Transaction
 	for tc.currentMemSizeInBytes+payloadSize > tc.maxMemSizeInBytes && len(tc.transactions) > 0 {
-		// Flush the N first transactions whose payload size sum is greater than `sizeInBytesToFlush`
+		// Flush the N last (lowest-priority/oldest) transactions whose payload size sum is greater than `sizeInBytesToFlush`
 		transactions := tc.extractTransactionsFromMemory(sizeInBytesToFlush)
 
 		if len(transactions) == 0 {
@@ -241,19 +241,26 @@ func (tc *TransactionRetryQueue) extractTransactionsForDisk(payloadSize int) [][
 	return payloadsGroupToFlush
 }
 
+// Extracts transactions whose combined payload size is not less than `payloadSizeInBytesToExtract`.
 func (tc *TransactionRetryQueue) extractTransactionsFromMemory(payloadSizeInBytesToExtract int) []transaction.Transaction {
-	i := 0
+	i := len(tc.transactions) - 1
 	sizeInBytesExtracted := 0
 	var transactionsExtracted []transaction.Transaction
 
+	// dropPrioritySorter places high-priority/newest transactions at the front
+	// (index 0) and low-priority/oldest at the tail. Extracting from the tail
+	// evicts the least-valuable transactions first and lets us shrink the slice
+	// with a simple reslice instead of cutting from the front, so this way we
+	// preserve the capacity.
 	tc.dropPrioritySorter.Sort(tc.transactions)
-	for ; i < len(tc.transactions) && sizeInBytesExtracted < payloadSizeInBytesToExtract; i++ {
+	for ; i >= 0 && sizeInBytesExtracted < payloadSizeInBytesToExtract; i-- {
 		transaction := tc.transactions[i]
 		sizeInBytesExtracted += transaction.GetPayloadSize()
 		transactionsExtracted = append(transactionsExtracted, transaction)
+		tc.transactions[i] = nil
 	}
 
-	tc.transactions = tc.transactions[i:]
+	tc.transactions = tc.transactions[:i+1]
 	tc.currentMemSizeInBytes -= sizeInBytesExtracted
 	return transactionsExtracted
 }

--- a/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue_test.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue_test.go
@@ -9,6 +9,7 @@ package retry
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -146,8 +147,82 @@ func TestTransactionRetryQueueZeroMaxMemSizeInBytes(t *testing.T) {
 	a.Equal(pointDropped+1, transactionContainerPointDroppedCountTelemetry.expvar.Value())
 }
 
+// Verifies that when memory is tight, normal-priority transactions are dropped
+// before high-priority ones regardless of insertion order.
+//
+// Setup: max=15, queue has high(5)+normal(5)=10. Adding new(10) needs 5 bytes freed.
+// The drop sorter extracts from the low-priority tail, so normal(5) is dropped, high(5) survives.
+func TestTransactionRetryQueueDropsNormalPriorityBeforeHigh(t *testing.T) {
+	a := assert.New(t)
+	r := require.New(t)
+	container := NewTransactionRetryQueue(createDropPrioritySorter(), nil, 15, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
+
+	high := createTransactionWithPayloadSize(5)
+	high.Priority = transaction.TransactionPriorityHigh
+	_, err := container.Add(high)
+	a.NoError(err)
+
+	normal := createTransactionWithPayloadSize(5)
+	normal.Priority = transaction.TransactionPriorityNormal
+	_, err = container.Add(normal)
+	a.NoError(err)
+
+	// Adding a 10-byte item overflows by 5: (5+5+10)-15=5. The normal-priority transaction
+	// (5 bytes) should be dropped; the high-priority one should survive.
+	newTx := createTransactionWithPayloadSize(10)
+	newTx.Priority = transaction.TransactionPriorityNormal
+	dropCount, err := container.Add(newTx)
+	a.NoError(err)
+	a.Equal(1, dropCount)
+
+	transactions, err := container.ExtractTransactions()
+	a.NoError(err)
+	r.Len(transactions, 2)
+	priorities := []transaction.Priority{transactions[0].GetPriority(), transactions[1].GetPriority()}
+	a.Contains(priorities, transaction.TransactionPriorityHigh)
+}
+
+// Verifies that among same-priority transactions, the oldest are dropped first
+// when the memory limit is reached.
+//
+// Setup: max=25, add old(10)+middle(10)=20. Adding recent(10) overflows by 5,
+// so one transaction must be dropped. The oldest (`old`) should be chosen.
+func TestTransactionRetryQueueDropsOldestFirst(t *testing.T) {
+	a := assert.New(t)
+	r := require.New(t)
+	container := NewTransactionRetryQueue(createDropPrioritySorter(), nil, 25, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
+
+	old := createTransactionWithPayloadSize(10)
+	old.Priority = transaction.TransactionPriorityNormal
+	middle := createTransactionWithPayloadSize(10)
+	middle.Priority = transaction.TransactionPriorityNormal
+	recent := createTransactionWithPayloadSize(10)
+	recent.Priority = transaction.TransactionPriorityNormal
+	// Ensure deterministic creation-time ordering by explicit assignment.
+	old.CreatedAt = old.CreatedAt.Add(-2 * time.Second)
+	middle.CreatedAt = middle.CreatedAt.Add(-1 * time.Second)
+
+	_, _ = container.Add(middle)
+	_, _ = container.Add(old)
+
+	// Adding `recent` overflows by 5: (20+10)-25=5. Should drop `old` (oldest, 10 bytes >= 5).
+	dropCount, err := container.Add(recent)
+	a.NoError(err)
+	a.Equal(1, dropCount)
+
+	transactions, err := container.ExtractTransactions()
+	a.NoError(err)
+	r.Len(transactions, 2)
+	// middle and recent survive; old was dropped.
+	survivingTimes := []time.Time{transactions[0].GetCreatedAt(), transactions[1].GetCreatedAt()}
+	a.Contains(survivingTimes, middle.CreatedAt)
+	a.Contains(survivingTimes, recent.CreatedAt)
+	a.NotContains(survivingTimes, old.CreatedAt)
+}
+
 func createTransactionWithPayloadSize(payloadSize int) *transaction.HTTPTransaction {
 	tr := transaction.NewHTTPTransaction()
+	tr.CreatedAt = time.Unix(int64(payloadSize), 0)
 	payload := make([]byte, payloadSize)
 	tr.Payload = transaction.NewBytesPayload(payload, 1)
 	return tr
@@ -170,7 +245,7 @@ func assertPayloadSizeFromExtractTransactions(
 }
 
 func createDropPrioritySorter() transaction.SortByCreatedTimeAndPriority {
-	return transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: false}
+	return transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}
 }
 
 func newOnDiskRetryQueueTest(t *testing.T, a *assert.Assertions) *onDiskRetryQueue {

--- a/releasenotes/notes/persist-low-prio-on-shutdown-8d36ff35fbb80872.yaml
+++ b/releasenotes/notes/persist-low-prio-on-shutdown-8d36ff35fbb80872.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Persist low-priority transactions (such as retried metrics) to disk
+    during a graceful Agent shutdown instead of dropping them.


### PR DESCRIPTION
### What does this PR do?

Write transactions from the low priority queue to disk on Agent
shutdown.

### Motivation

We want to stop dropping data from the low priority queue if Agent
performs a graceful shutdown (e.g. on update). When we do so, we also
flip the drop sorting priority, so during shutdown we serialize to disk
the items with the highest possible priority first.

### Describe how you validated your changes

New unit tests.

### Additional Notes

As a side effect, we improve the way we handle the retry queue.

Earlier, when we sorted transactions with the goal to evict the oldest
or the ones with the lower priority, we sorted the transactions in
ascending order (less important ones were moved to the beginning of the
list). Then, we removed the first elements until we get all of them or
reach the required limit. However, this code had two problems:
1. We didn't release the old references. The processed array cells still
   referenced the extracted transactions.
2. We resized our slice with the transactions by cutting the front part
   of it. This means that we held the underlying array, and GC couldn't
   free it until we do `tc.transactions = nil`.

This change solves this problem by reversing the sort order - now the
elements to take first (low-prio during normal operation, high prio on
shutdown) are located in the end of the slice - so we extract them from
there and cut the slice's length instead, also nullifying the unneeded
references - this way we don't waste memory.