### PR TITLE
[CONTINT-5401] Event collection via reflector

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -50,12 +50,8 @@ const (
 	defaultResyncPeriodInSecond        = 300
 	defaultTimeoutEventCollection      = 2000
 	defaultMaxEstimatedEventTextLength = 3750
-	// defaultEventCollectionBufferSize bounds the informer event buffer between
-	// check runs. At a 15s interval this sustains ~666 events/s, comfortably
-	// above the highest observed cluster churn; raise event_collection_buffer_size
-	// for clusters that exceed it.
-	defaultEventCollectionBufferSize = 10000
-	maximumWaitForAPIServer          = 10 * time.Second
+	defaultEventCollectionBufferSize   = 10000
+	maximumWaitForAPIServer            = 10 * time.Second
 )
 
 var (
@@ -85,18 +81,14 @@ type KubeASConfig struct {
 	UseComponentStatus  bool `yaml:"use_component_status"`
 
 	// Event collection configuration
-	CollectEvent             bool `yaml:"collect_events"`
-	MaxEventCollection       int  `yaml:"max_events_per_run"`
-	EventCollectionTimeoutMs int  `yaml:"kubernetes_event_read_timeout_ms"`
-	ResyncPeriodEvents       int  `yaml:"kubernetes_event_resync_period_s"`
-	UnbundleEvents           bool `yaml:"unbundle_events"`
-	BundleUnspecifiedEvents  bool `yaml:"bundle_unspecified_events"`
-	UseNewEventCollection    bool `yaml:"use_new_event_collection"`
-
-	// EventCollectionBufferSize bounds how many events the informer-based
-	// collector buffers between check runs. Only used when UseNewEventCollection
-	// is true. Size it to at least the event rate times the check interval.
-	EventCollectionBufferSize int `yaml:"event_collection_buffer_size"`
+	CollectEvent              bool `yaml:"collect_events"`
+	MaxEventCollection        int  `yaml:"max_events_per_run"`
+	EventCollectionTimeoutMs  int  `yaml:"kubernetes_event_read_timeout_ms"`
+	ResyncPeriodEvents        int  `yaml:"kubernetes_event_resync_period_s"`
+	UnbundleEvents            bool `yaml:"unbundle_events"`
+	BundleUnspecifiedEvents   bool `yaml:"bundle_unspecified_events"`
+	UseNewEventCollection     bool `yaml:"use_new_event_collection"`
+	EventCollectionBufferSize int  `yaml:"event_collection_buffer_size"`
 
 	// FilteredEventTypes is a slice of kubernetes field selectors that
 	// works as a deny list of events to filter out.
@@ -141,8 +133,6 @@ type KubeASCheck struct {
 	oshiftAPILevel  apiserver.OpenShiftAPILevel
 	tagger          tagger.Component
 
-	// eventCollectorRunning tracks whether the event informers are currently
-	// running, so they are started and stopped only on leadership transitions.
 	eventCollectorRunning bool
 	informersStopCh       chan struct{}
 }
@@ -375,11 +365,7 @@ func (k *KubeASCheck) Cancel() {
 func (k *KubeASCheck) newEventCollectionCheck(sender sender.Sender) ([]event.Event, error) {
 	events := k.eventCollection.EventCollector.Drain()
 
-	// Surface events shed because the buffer was full, so churn-induced loss is
-	// visible rather than silent. Cumulative across the collector's lifetime; it
-	// resets to zero when the informer is restarted on a leadership change.
-	sender.MonotonicCount("kubernetes_apiserver.events_dropped", float64(k.eventCollection.EventCollector.Dropped()), "", nil)
-
+	sender.Gauge("kubernetes_apiserver.events_dropped", float64(k.eventCollection.EventCollector.Dropped()), "", nil)
 	ddevents, errs := k.eventCollection.Transformer.Transform(events)
 
 	for _, err := range errs {

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -403,9 +403,7 @@ func (k *KubeASCheck) newEventCollectionCheck(sender sender.Sender) ([]event.Eve
 
 	sender.Gauge("kubernetes_apiserver.events_dropped", float64(ec.DrainDropped()), "", nil)
 
-	// Persist the max RV of the events we actually drained, not ec.ResourceVersion().
-	// The reflector can advance lastRV between Drain() and ResourceVersion(), so using
-	// lastRV could skip buffered events on restart.
+	// Persist the max RV of the drained batch; lastRV can be ahead if new events arrived during the drain.
 	if len(events) > 0 {
 		var maxRV uint64
 		for _, ev := range events {

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -86,6 +86,7 @@ type KubeASConfig struct {
 	ResyncPeriodEvents       int  `yaml:"kubernetes_event_resync_period_s"`
 	UnbundleEvents           bool `yaml:"unbundle_events"`
 	BundleUnspecifiedEvents  bool `yaml:"bundle_unspecified_events"`
+	UseNewEventCollection    bool `yaml:"use_new_event_collection"`
 
 	// FilteredEventTypes is a slice of kubernetes field selectors that
 	// works as a deny list of events to filter out.
@@ -129,7 +130,6 @@ type KubeASCheck struct {
 	ac              *apiserver.APIClient
 	oshiftAPILevel  apiserver.OpenShiftAPILevel
 	tagger          tagger.Component
-	useNewEventCollection bool
 
 	// eventCollectorRunning tracks whether the event informers are currently
 	// running, so they are started and stopped only on leadership transitions.
@@ -271,7 +271,7 @@ func (k *KubeASCheck) Run() error {
 		}
 	}
 
-	if k.useNewEventCollection {
+	if k.instance.UseNewEventCollection {
 		// If we are not the current leader, we might need to stop the event collection.
 		if !isCurrentLeader {
 			k.stopEventCollection()
@@ -303,7 +303,7 @@ func (k *KubeASCheck) Run() error {
 	if k.instance.CollectEvent {
 		var events []event.Event
 		var err error
-		if k.useNewEventCollection {
+		if k.instance.UseNewEventCollection {
 			events, err = k.newEventCollectionCheck()
 		} else {
 			events, err = k.legacyEventCollectionCheck()

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -51,7 +51,6 @@ const (
 	defaultTimeoutEventCollection      = 2000
 	defaultMaxEstimatedEventTextLength = 3750
 	defaultEventCollectionBufferSize   = 10000
-	maximumWaitForAPIServer            = 10 * time.Second
 )
 
 var (
@@ -222,23 +221,6 @@ func (k *KubeASCheck) Configure(senderManager sender.SenderManager, _ uint64, co
 		k.eventCollection.Transformer = newBundledTransformer(clusterName, k.tagger, k.instance.CollectedEventTypes, k.instance.FilteringEnabled)
 	}
 
-	// Initialize the API Server client once at configuration time
-	apiCtx, apiCancel := context.WithTimeout(context.Background(), maximumWaitForAPIServer)
-	defer apiCancel()
-	k.ac, err = apiserver.WaitForAPIClient(apiCtx)
-	if err != nil {
-		return err
-	}
-
-	if err := apiserver.InitializeGlobalResourceTypeCache(k.ac.Cl.Discovery()); err != nil {
-		log.Errorf("Could not initialize the global resource type cache: %s", err)
-	}
-
-	// We detect OpenShift presence for quota collection
-	if k.instance.CollectOShiftQuotas {
-		k.oshiftAPILevel = k.ac.DetectOpenShiftAPILevel()
-	}
-
 	return nil
 }
 
@@ -275,18 +257,35 @@ func (k *KubeASCheck) Run() error {
 		}
 	}
 
-	if k.instance.UseNewEventCollection {
-		// If we are not the current leader, we might need to stop the event collection.
-		if !isCurrentLeader {
+	if !isCurrentLeader {
+		if k.instance.UseNewEventCollection {
 			k.stopEventCollection()
-			return nil
 		}
-		// ... or start it if we are the current leader
+		return nil
+	}
+
+	// API Server client init on first run as leader.
+	if k.ac == nil {
+		// Using GetAPIClient (no wait) so the check retries naturally on each run.
+		k.ac, err = apiserver.GetAPIClient()
+		if err != nil {
+			k.Warnf("Could not connect to apiserver: %s", err) //nolint:errcheck
+			return err
+		}
+
+		if err = apiserver.InitializeGlobalResourceTypeCache(k.ac.Cl.Discovery()); err != nil {
+			log.Errorf("Could not initialize the global resource type cache: %s", err)
+		}
+
+		if k.instance.CollectOShiftQuotas {
+			k.oshiftAPILevel = k.ac.DetectOpenShiftAPILevel()
+		}
+	}
+
+	if k.instance.CollectEvent && k.instance.UseNewEventCollection {
 		if err := k.startEventCollection(); err != nil {
 			return err
 		}
-	} else if !isCurrentLeader {
-		return nil
 	}
 
 	// Running the Control Plane status check.

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -50,6 +50,7 @@ const (
 	defaultResyncPeriodInSecond        = 300
 	defaultTimeoutEventCollection      = 2000
 	defaultMaxEstimatedEventTextLength = 3750
+	maximumWaitForAPIServer            = 10 * time.Second
 )
 
 var (
@@ -113,10 +114,11 @@ func (noopEventTransformer) Transform(_ []*v1.Event) ([]event.Event, []error) {
 }
 
 type eventCollection struct {
-	LastResVer  string
-	LastTime    time.Time
-	Filter      string
-	Transformer eventTransformer
+	LastResVer      string
+	LastTime        time.Time
+	Filter          string
+	Transformer     eventTransformer
+	EventCollector *apiserver.EventCollector
 }
 
 // KubeASCheck grabs metrics and events from the API server.
@@ -127,6 +129,12 @@ type KubeASCheck struct {
 	ac              *apiserver.APIClient
 	oshiftAPILevel  apiserver.OpenShiftAPILevel
 	tagger          tagger.Component
+	useNewEventCollection bool
+
+	// eventCollectorRunning tracks whether the event informers are currently
+	// running, so they are started and stopped only on leadership transitions.
+	eventCollectorRunning bool
+	informersStopCh       chan struct{}
 }
 
 func (c *KubeASConfig) parse(data []byte) error {
@@ -210,6 +218,23 @@ func (k *KubeASCheck) Configure(senderManager sender.SenderManager, _ uint64, co
 		k.eventCollection.Transformer = newBundledTransformer(clusterName, k.tagger, k.instance.CollectedEventTypes, k.instance.FilteringEnabled)
 	}
 
+	// Initialize the API Server client once at configuration time
+	apiCtx, apiCancel := context.WithTimeout(context.Background(), maximumWaitForAPIServer)
+	defer apiCancel()
+	k.ac, err = apiserver.WaitForAPIClient(apiCtx)
+	if err != nil {
+		return err
+	}
+
+	if err := apiserver.InitializeGlobalResourceTypeCache(k.ac.Cl.Discovery()); err != nil {
+		log.Errorf("Could not initialize the global resource type cache: %s", err)
+	}
+
+	// We detect OpenShift presence for quota collection
+	if k.instance.CollectOShiftQuotas {
+		k.oshiftAPILevel = k.ac.DetectOpenShiftAPILevel()
+	}
+
 	return nil
 }
 
@@ -225,45 +250,39 @@ func (k *KubeASCheck) Run() error {
 		log.Debug("Cluster agent is enabled. Not running Kubernetes API Server check or collecting Kubernetes Events.")
 		return nil
 	}
-	// If the check is configured as a cluster check, the cluster check worker needs to skip the leader election section.
-	// The Cluster Agent will passed in the `skip_leader_election` bool.
+
+	// Determine current leadership (unless the check is configured as a cluster check)
+	isCurrentLeader := k.instance.LeaderSkip
 	if !k.instance.LeaderSkip {
-		// Only run if Leader Election is enabled.
 		if !pkgconfigsetup.Datadog().GetBool("leader_election") {
 			return log.Error("Leader Election not enabled. Not running Kubernetes API Server check or collecting Kubernetes Events.")
 		}
 		leader, errLeader := cluster.RunLeaderElection()
 		if errLeader != nil {
-			if errLeader == apiserver.ErrNotLeader {
-				// Only the leader can instantiate the apiserver client.
-				log.Debugf("Not leader (leader is %q). Skipping the Kubernetes API Server check", leader)
-				return nil
+			if errLeader != apiserver.ErrNotLeader {
+				_ = k.Warn("Leader Election error. Not running the Kubernetes API Server check.")
+				return errLeader
 			}
-
-			_ = k.Warn("Leader Election error. Not running the Kubernetes API Server check.")
-			return err
+			log.Debugf("Not leader (leader is %q). Skipping the Kubernetes API Server check", leader)
+			isCurrentLeader = false
+		} else {
+			log.Tracef("Current leader: %q, running the Kubernetes API Server check", leader)
+			isCurrentLeader = true
 		}
-
-		log.Tracef("Current leader: %q, running the Kubernetes API Server check", leader)
 	}
-	// API Server client initialisation on first run
-	if k.ac == nil {
-		// Using GetAPIClient (no wait) as check we'll naturally retry with each check run
-		k.ac, err = apiserver.GetAPIClient()
-		if err != nil {
-			k.Warnf("Could not connect to apiserver: %s", err) //nolint:errcheck
+
+	if k.useNewEventCollection {
+		// If we are not the current leader, we might need to stop the event collection.
+		if !isCurrentLeader {
+			k.stopEventCollection()
+			return nil
+		}
+		// ... or start it if we are the current leader
+		if err := k.startEventCollection(); err != nil {
 			return err
 		}
-
-		err = apiserver.InitializeGlobalResourceTypeCache(k.ac.Cl.Discovery())
-		if err != nil {
-			log.Errorf("Could not initialize the global resource type cache: %s", err)
-		}
-
-		// We detect OpenShift presence for quota collection
-		if k.instance.CollectOShiftQuotas {
-			k.oshiftAPILevel = k.ac.DetectOpenShiftAPILevel()
-		}
+	} else if !isCurrentLeader {
+		return nil
 	}
 
 	// Running the Control Plane status check.
@@ -282,10 +301,18 @@ func (k *KubeASCheck) Run() error {
 	}
 
 	if k.instance.CollectEvent {
-		events, err := k.eventCollectionCheck()
+		var events []event.Event
+		var err error
+		if k.useNewEventCollection {
+			events, err = k.newEventCollectionCheck()
+		} else {
+			events, err = k.legacyEventCollectionCheck()
+		}
+
 		if err != nil {
 			return err
 		}
+
 
 		for _, event := range events {
 			sender.Event(event)
@@ -302,7 +329,49 @@ func (k *KubeASCheck) Run() error {
 	return nil
 }
 
-func (k *KubeASCheck) eventCollectionCheck() ([]event.Event, error) {
+// startEventCollection builds a fresh informer factory and starts the event
+// informers. It is idempotent. 
+func (k *KubeASCheck) startEventCollection() error {
+	if k.eventCollectorRunning {
+		return nil
+	}
+
+	k.informersStopCh = make(chan struct{})
+	k.eventCollection.EventCollector = k.ac.NewEventCollector(k.eventCollection.Filter)
+	k.eventCollectorRunning = true
+	return k.eventCollection.EventCollector.Start(k.informersStopCh)
+}
+
+// stopEventCollection stops the running event informers by closing their stop
+// channel. It is idempotent. 
+func (k *KubeASCheck) stopEventCollection() {
+	if !k.eventCollectorRunning {
+		return
+	}
+
+	close(k.informersStopCh)
+	k.eventCollection.EventCollector = nil
+	k.eventCollectorRunning = false
+}
+
+// Cancel stops the event informers when the check is unscheduled.
+func (k *KubeASCheck) Cancel() {
+	k.stopEventCollection()
+}
+
+func (k *KubeASCheck) newEventCollectionCheck() ([]event.Event, error) {
+	events := k.eventCollection.EventCollector.Drain()
+	ddevents, errs := k.eventCollection.Transformer.Transform(events)
+
+	for _, err := range errs {
+		k.Warnf("Error transforming events: %s", err.Error())
+	}
+
+	return ddevents, nil
+}
+
+
+func (k *KubeASCheck) legacyEventCollectionCheck() ([]event.Event, error) {
 	resVer, lastTime, err := k.ac.GetTokenFromConfigmap(eventTokenKey)
 	if err != nil {
 		return nil, err

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -12,7 +12,6 @@ package kubernetesapiserver
 import (
 	"context"
 	"errors"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -358,12 +357,8 @@ func (k *KubeASCheck) startEventCollection() error {
 
 	// ConfigMap I/O outside the lock: resume from the last persisted resourceVersion
 	// so events created while we were not the leader are recovered rather than skipped.
-	if resVer, _, err := k.ac.GetTokenFromConfigmap(eventTokenKey); err != nil {
-		log.Warnf("Could not read persisted event resourceVersion, starting fresh: %s", err)
-	} else {
-		ec.SetResourceVersion(resVer)
-	}
-
+	// Re-list the full backlog on (re)start (no persisted checkpoint) and let the
+	// bundling transformer dedup by UID; the in-memory watermark dedups relists.
 	return ec.Start(stopCh)
 }
 
@@ -402,19 +397,6 @@ func (k *KubeASCheck) newEventCollectionCheck(sender sender.Sender) ([]event.Eve
 	events := ec.Drain()
 
 	sender.Gauge("kubernetes_apiserver.events_dropped", float64(ec.DrainDropped()), "", nil)
-
-	// Persist the max RV of the drained batch; lastRV can be ahead if new events arrived during the drain.
-	if len(events) > 0 {
-		var maxRV uint64
-		for _, ev := range events {
-			if rv, err := strconv.ParseUint(ev.ResourceVersion, 10, 64); err == nil && rv > maxRV {
-				maxRV = rv
-			}
-		}
-		if err := k.ac.UpdateTokenInConfigmap(eventTokenKey, strconv.FormatUint(maxRV, 10), time.Now()); err != nil {
-			k.Warnf("Could not persist event resourceVersion: %s", err.Error())
-		}
-	}
 
 	ddevents, errs := k.eventCollection.Transformer.Transform(events)
 

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -249,9 +249,6 @@ func (k *KubeASCheck) Run() error {
 		leader, errLeader := cluster.RunLeaderElection()
 		if errLeader != nil {
 			if errLeader != apiserver.ErrNotLeader {
-				// Transient error: we don't know whether we lost leadership, so we do
-				// not stop a running EventCollector — stopping on every blip would be
-				// unnecessarily disruptive and we have no evidence another node took over.
 				_ = k.Warn("Leader Election error. Not running the Kubernetes API Server check.")
 				return errLeader
 			}
@@ -355,8 +352,6 @@ func (k *KubeASCheck) startEventCollection() error {
 	k.eventCollectorRunning = true
 	k.mu.Unlock()
 
-	// ConfigMap I/O outside the lock: resume from the last persisted resourceVersion
-	// so events created while we were not the leader are recovered rather than skipped.
 	// Re-list the full backlog on (re)start (no persisted checkpoint) and let the
 	// bundling transformer dedup by UID; the in-memory watermark dedups relists.
 	return ec.Start(stopCh)

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"time"
 
 	"go.yaml.in/yaml/v2"
@@ -132,6 +133,7 @@ type KubeASCheck struct {
 	oshiftAPILevel  apiserver.OpenShiftAPILevel
 	tagger          tagger.Component
 
+	mu                    sync.Mutex
 	eventCollectorRunning bool
 	informersStopCh       chan struct{}
 }
@@ -189,7 +191,7 @@ func (k *KubeASCheck) Configure(senderManager sender.SenderManager, _ uint64, co
 		k.instance.MaxEventCollection = maxEventCardinality
 	}
 
-	if k.instance.EventCollectionBufferSize == 0 {
+	if k.instance.EventCollectionBufferSize < 1 {
 		k.instance.EventCollectionBufferSize = defaultEventCollectionBufferSize
 	}
 
@@ -333,28 +335,38 @@ func (k *KubeASCheck) Run() error {
 
 // startEventCollection builds a new EventCollector and starts it. It is idempotent.
 func (k *KubeASCheck) startEventCollection() error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
 	if k.eventCollectorRunning {
 		return nil
 	}
 
-	k.informersStopCh = make(chan struct{})
-	k.eventCollection.EventCollector = k.ac.NewEventCollector(k.eventCollection.Filter, k.instance.EventCollectionBufferSize)
+	ec := k.ac.NewEventCollector(k.eventCollection.Filter, k.instance.EventCollectionBufferSize)
+	if ec == nil {
+		return errors.New("could not create EventCollector: invalid buffer size")
+	}
+	k.eventCollection.EventCollector = ec
 
 	// Resume from the last persisted resourceVersion so events created while we
 	// were not the leader (or were restarting) are recovered rather than skipped.
 	if resVer, _, err := k.ac.GetTokenFromConfigmap(eventTokenKey); err != nil {
 		log.Warnf("Could not read persisted event resourceVersion, starting fresh: %s", err)
 	} else {
-		k.eventCollection.EventCollector.SetResourceVersion(resVer)
+		ec.SetResourceVersion(resVer)
 	}
 
+	k.informersStopCh = make(chan struct{})
 	k.eventCollectorRunning = true
-	return k.eventCollection.EventCollector.Start(k.informersStopCh)
+	return ec.Start(k.informersStopCh)
 }
 
 // stopEventCollection stops the running EventCollector by closing its stop
 // channel. It is idempotent.
 func (k *KubeASCheck) stopEventCollection() {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
 	if !k.eventCollectorRunning {
 		return
 	}
@@ -370,12 +382,20 @@ func (k *KubeASCheck) Cancel() {
 }
 
 func (k *KubeASCheck) newEventCollectionCheck(sender sender.Sender) ([]event.Event, error) {
-	events := k.eventCollection.EventCollector.Drain()
+	k.mu.Lock()
+	ec := k.eventCollection.EventCollector
+	k.mu.Unlock()
 
-	sender.Gauge("kubernetes_apiserver.events_dropped", float64(k.eventCollection.EventCollector.Dropped()), "", nil)
+	if ec == nil {
+		return nil, nil
+	}
+
+	events := ec.Drain()
+
+	sender.Gauge("kubernetes_apiserver.events_dropped", float64(ec.DrainDropped()), "", nil)
 
 	// Persist the high-water mark so a restart or leader failover resumes here.
-	if err := k.ac.UpdateTokenInConfigmap(eventTokenKey, k.eventCollection.EventCollector.ResourceVersion(), time.Now()); err != nil {
+	if err := k.ac.UpdateTokenInConfigmap(eventTokenKey, ec.ResourceVersion(), time.Now()); err != nil {
 		k.Warnf("Could not persist event resourceVersion: %s", err.Error())
 	}
 

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -50,7 +50,12 @@ const (
 	defaultResyncPeriodInSecond        = 300
 	defaultTimeoutEventCollection      = 2000
 	defaultMaxEstimatedEventTextLength = 3750
-	maximumWaitForAPIServer            = 10 * time.Second
+	// defaultEventCollectionBufferSize bounds the informer event buffer between
+	// check runs. At a 15s interval this sustains ~666 events/s, comfortably
+	// above the highest observed cluster churn; raise event_collection_buffer_size
+	// for clusters that exceed it.
+	defaultEventCollectionBufferSize = 10000
+	maximumWaitForAPIServer          = 10 * time.Second
 )
 
 var (
@@ -88,6 +93,11 @@ type KubeASConfig struct {
 	BundleUnspecifiedEvents  bool `yaml:"bundle_unspecified_events"`
 	UseNewEventCollection    bool `yaml:"use_new_event_collection"`
 
+	// EventCollectionBufferSize bounds how many events the informer-based
+	// collector buffers between check runs. Only used when UseNewEventCollection
+	// is true. Size it to at least the event rate times the check interval.
+	EventCollectionBufferSize int `yaml:"event_collection_buffer_size"`
+
 	// FilteredEventTypes is a slice of kubernetes field selectors that
 	// works as a deny list of events to filter out.
 	FilteredEventTypes []string `yaml:"filtered_event_types"`
@@ -115,10 +125,10 @@ func (noopEventTransformer) Transform(_ []*v1.Event) ([]event.Event, []error) {
 }
 
 type eventCollection struct {
-	LastResVer      string
-	LastTime        time.Time
-	Filter          string
-	Transformer     eventTransformer
+	LastResVer     string
+	LastTime       time.Time
+	Filter         string
+	Transformer    eventTransformer
 	EventCollector *apiserver.EventCollector
 }
 
@@ -188,6 +198,10 @@ func (k *KubeASCheck) Configure(senderManager sender.SenderManager, _ uint64, co
 
 	if k.instance.MaxEventCollection == 0 {
 		k.instance.MaxEventCollection = maxEventCardinality
+	}
+
+	if k.instance.EventCollectionBufferSize == 0 {
+		k.instance.EventCollectionBufferSize = defaultEventCollectionBufferSize
 	}
 
 	hostnameDetected, _ := hostname.Get(context.TODO())
@@ -304,7 +318,7 @@ func (k *KubeASCheck) Run() error {
 		var events []event.Event
 		var err error
 		if k.instance.UseNewEventCollection {
-			events, err = k.newEventCollectionCheck()
+			events, err = k.newEventCollectionCheck(sender)
 		} else {
 			events, err = k.legacyEventCollectionCheck()
 		}
@@ -312,7 +326,6 @@ func (k *KubeASCheck) Run() error {
 		if err != nil {
 			return err
 		}
-
 
 		for _, event := range events {
 			sender.Event(event)
@@ -330,20 +343,20 @@ func (k *KubeASCheck) Run() error {
 }
 
 // startEventCollection builds a fresh informer factory and starts the event
-// informers. It is idempotent. 
+// informers. It is idempotent.
 func (k *KubeASCheck) startEventCollection() error {
 	if k.eventCollectorRunning {
 		return nil
 	}
 
 	k.informersStopCh = make(chan struct{})
-	k.eventCollection.EventCollector = k.ac.NewEventCollector(k.eventCollection.Filter)
+	k.eventCollection.EventCollector = k.ac.NewEventCollector(k.eventCollection.Filter, k.instance.EventCollectionBufferSize)
 	k.eventCollectorRunning = true
 	return k.eventCollection.EventCollector.Start(k.informersStopCh)
 }
 
 // stopEventCollection stops the running event informers by closing their stop
-// channel. It is idempotent. 
+// channel. It is idempotent.
 func (k *KubeASCheck) stopEventCollection() {
 	if !k.eventCollectorRunning {
 		return
@@ -359,8 +372,14 @@ func (k *KubeASCheck) Cancel() {
 	k.stopEventCollection()
 }
 
-func (k *KubeASCheck) newEventCollectionCheck() ([]event.Event, error) {
+func (k *KubeASCheck) newEventCollectionCheck(sender sender.Sender) ([]event.Event, error) {
 	events := k.eventCollection.EventCollector.Drain()
+
+	// Surface events shed because the buffer was full, so churn-induced loss is
+	// visible rather than silent. Cumulative across the collector's lifetime; it
+	// resets to zero when the informer is restarted on a leadership change.
+	sender.MonotonicCount("kubernetes_apiserver.events_dropped", float64(k.eventCollection.EventCollector.Dropped()), "", nil)
+
 	ddevents, errs := k.eventCollection.Transformer.Transform(events)
 
 	for _, err := range errs {
@@ -369,7 +388,6 @@ func (k *KubeASCheck) newEventCollectionCheck() ([]event.Event, error) {
 
 	return ddevents, nil
 }
-
 
 func (k *KubeASCheck) legacyEventCollectionCheck() ([]event.Event, error) {
 	resVer, lastTime, err := k.ac.GetTokenFromConfigmap(eventTokenKey)

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -12,6 +12,7 @@ package kubernetesapiserver
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -402,9 +403,19 @@ func (k *KubeASCheck) newEventCollectionCheck(sender sender.Sender) ([]event.Eve
 
 	sender.Gauge("kubernetes_apiserver.events_dropped", float64(ec.DrainDropped()), "", nil)
 
-	// Persist the high-water mark so a restart or leader failover resumes here.
-	if err := k.ac.UpdateTokenInConfigmap(eventTokenKey, ec.ResourceVersion(), time.Now()); err != nil {
-		k.Warnf("Could not persist event resourceVersion: %s", err.Error())
+	// Persist the max RV of the events we actually drained, not ec.ResourceVersion().
+	// The reflector can advance lastRV between Drain() and ResourceVersion(), so using
+	// lastRV could skip buffered events on restart.
+	if len(events) > 0 {
+		var maxRV uint64
+		for _, ev := range events {
+			if rv, err := strconv.ParseUint(ev.ResourceVersion, 10, 64); err == nil && rv > maxRV {
+				maxRV = rv
+			}
+		}
+		if err := k.ac.UpdateTokenInConfigmap(eventTokenKey, strconv.FormatUint(maxRV, 10), time.Now()); err != nil {
+			k.Warnf("Could not persist event resourceVersion: %s", err.Error())
+		}
 	}
 
 	ddevents, errs := k.eventCollection.Transformer.Transform(events)

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -396,7 +396,7 @@ func (k *KubeASCheck) newEventCollectionCheck(sender sender.Sender) ([]event.Eve
 
 	events := ec.Drain()
 
-	sender.Gauge("kubernetes_apiserver.events_dropped", float64(ec.DrainDropped()), "", nil)
+	sender.Gauge("datadog.cluster_agent.kubernetes_apiserver.events_dropped", float64(ec.DrainDropped()), "", nil)
 
 	ddevents, errs := k.eventCollection.Transformer.Transform(events)
 

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -82,7 +82,7 @@ type KubeASConfig struct {
 
 	// Event collection configuration
 	CollectEvent              bool `yaml:"collect_events"`
-	MaxEventCollection        int  `yaml:"max_events_per_run"`
+	MaxEventCollection        int  `yaml:"max_events_per_run"` // legacy path only; new path drains the full buffer each run
 	EventCollectionTimeoutMs  int  `yaml:"kubernetes_event_read_timeout_ms"`
 	ResyncPeriodEvents        int  `yaml:"kubernetes_event_resync_period_s"`
 	UnbundleEvents            bool `yaml:"unbundle_events"`
@@ -133,9 +133,10 @@ type KubeASCheck struct {
 	oshiftAPILevel  apiserver.OpenShiftAPILevel
 	tagger          tagger.Component
 
-	mu                    sync.Mutex
-	eventCollectorRunning bool
-	informersStopCh       chan struct{}
+	mu                     sync.Mutex
+	eventCollectorRunning  bool
+	eventCollectorCanceled bool // set by Cancel; prevents startEventCollection after teardown
+	informersStopCh        chan struct{}
 }
 
 func (c *KubeASConfig) parse(data []byte) error {
@@ -248,6 +249,9 @@ func (k *KubeASCheck) Run() error {
 		leader, errLeader := cluster.RunLeaderElection()
 		if errLeader != nil {
 			if errLeader != apiserver.ErrNotLeader {
+				// Transient error: we don't know whether we lost leadership, so we do
+				// not stop a running EventCollector — stopping on every blip would be
+				// unnecessarily disruptive and we have no evidence another node took over.
 				_ = k.Warn("Leader Election error. Not running the Kubernetes API Server check.")
 				return errLeader
 			}
@@ -336,29 +340,30 @@ func (k *KubeASCheck) Run() error {
 // startEventCollection builds a new EventCollector and starts it. It is idempotent.
 func (k *KubeASCheck) startEventCollection() error {
 	k.mu.Lock()
-	defer k.mu.Unlock()
-
-	if k.eventCollectorRunning {
+	if k.eventCollectorCanceled || k.eventCollectorRunning {
+		k.mu.Unlock()
 		return nil
 	}
-
 	ec := k.ac.NewEventCollector(k.eventCollection.Filter, k.instance.EventCollectionBufferSize)
 	if ec == nil {
+		k.mu.Unlock()
 		return errors.New("could not create EventCollector: invalid buffer size")
 	}
 	k.eventCollection.EventCollector = ec
+	k.informersStopCh = make(chan struct{})
+	stopCh := k.informersStopCh
+	k.eventCollectorRunning = true
+	k.mu.Unlock()
 
-	// Resume from the last persisted resourceVersion so events created while we
-	// were not the leader (or were restarting) are recovered rather than skipped.
+	// ConfigMap I/O outside the lock: resume from the last persisted resourceVersion
+	// so events created while we were not the leader are recovered rather than skipped.
 	if resVer, _, err := k.ac.GetTokenFromConfigmap(eventTokenKey); err != nil {
 		log.Warnf("Could not read persisted event resourceVersion, starting fresh: %s", err)
 	} else {
 		ec.SetResourceVersion(resVer)
 	}
 
-	k.informersStopCh = make(chan struct{})
-	k.eventCollectorRunning = true
-	return ec.Start(k.informersStopCh)
+	return ec.Start(stopCh)
 }
 
 // stopEventCollection stops the running EventCollector by closing its stop
@@ -378,6 +383,9 @@ func (k *KubeASCheck) stopEventCollection() {
 
 // Cancel stops the EventCollector when the check is unscheduled.
 func (k *KubeASCheck) Cancel() {
+	k.mu.Lock()
+	k.eventCollectorCanceled = true
+	k.mu.Unlock()
 	k.stopEventCollection()
 }
 

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -331,8 +331,7 @@ func (k *KubeASCheck) Run() error {
 	return nil
 }
 
-// startEventCollection builds a fresh informer factory and starts the event
-// informers. It is idempotent.
+// startEventCollection builds a new EventCollector and starts it. It is idempotent.
 func (k *KubeASCheck) startEventCollection() error {
 	if k.eventCollectorRunning {
 		return nil
@@ -340,11 +339,20 @@ func (k *KubeASCheck) startEventCollection() error {
 
 	k.informersStopCh = make(chan struct{})
 	k.eventCollection.EventCollector = k.ac.NewEventCollector(k.eventCollection.Filter, k.instance.EventCollectionBufferSize)
+
+	// Resume from the last persisted resourceVersion so events created while we
+	// were not the leader (or were restarting) are recovered rather than skipped.
+	if resVer, _, err := k.ac.GetTokenFromConfigmap(eventTokenKey); err != nil {
+		log.Warnf("Could not read persisted event resourceVersion, starting fresh: %s", err)
+	} else {
+		k.eventCollection.EventCollector.SetResourceVersion(resVer)
+	}
+
 	k.eventCollectorRunning = true
 	return k.eventCollection.EventCollector.Start(k.informersStopCh)
 }
 
-// stopEventCollection stops the running event informers by closing their stop
+// stopEventCollection stops the running EventCollector by closing its stop
 // channel. It is idempotent.
 func (k *KubeASCheck) stopEventCollection() {
 	if !k.eventCollectorRunning {
@@ -356,7 +364,7 @@ func (k *KubeASCheck) stopEventCollection() {
 	k.eventCollectorRunning = false
 }
 
-// Cancel stops the event informers when the check is unscheduled.
+// Cancel stops the EventCollector when the check is unscheduled.
 func (k *KubeASCheck) Cancel() {
 	k.stopEventCollection()
 }
@@ -365,6 +373,12 @@ func (k *KubeASCheck) newEventCollectionCheck(sender sender.Sender) ([]event.Eve
 	events := k.eventCollection.EventCollector.Drain()
 
 	sender.Gauge("kubernetes_apiserver.events_dropped", float64(k.eventCollection.EventCollector.Dropped()), "", nil)
+
+	// Persist the high-water mark so a restart or leader failover resumes here.
+	if err := k.ac.UpdateTokenInConfigmap(eventTokenKey, k.eventCollection.EventCollector.ResourceVersion(), time.Now()); err != nil {
+		k.Warnf("Could not persist event resourceVersion: %s", err.Error())
+	}
+
 	ddevents, errs := k.eventCollection.Transformer.Transform(events)
 
 	for _, err := range errs {

--- a/pkg/util/kubernetes/apiserver/BUILD.bazel
+++ b/pkg/util/kubernetes/apiserver/BUILD.bazel
@@ -83,6 +83,8 @@ dd_agent_go_test(
     srcs = [
         "endpoints_test.go",
         "endpointslices_test.go",
+        "event_collector_test.go",
+        "event_reflector_store_test.go",
         "events_test.go",
         "resourcetypes_test.go",
         "services_kubelet_test.go",
@@ -110,5 +112,6 @@ dd_agent_go_test(
         "@io_k8s_apimachinery//pkg/version",
         "@io_k8s_client_go//discovery/fake",
         "@io_k8s_client_go//kubernetes/fake",
+        "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/pkg/util/kubernetes/apiserver/BUILD.bazel
+++ b/pkg/util/kubernetes/apiserver/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "endpoints.go",
         "endpointslices.go",
         "event_collector.go",
+        "event_reflector_store.go",
         "events.go",
         "hostname.go",
         "openshift.go",

--- a/pkg/util/kubernetes/apiserver/BUILD.bazel
+++ b/pkg/util/kubernetes/apiserver/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "diagnosis.go",
         "endpoints.go",
         "endpointslices.go",
+        "event_collector.go",
         "events.go",
         "hostname.go",
         "openshift.go",
@@ -72,6 +73,7 @@ go_library(
         "@io_k8s_kube_aggregator//pkg/client/clientset_generated/clientset/typed/apiregistration/v1:apiregistration",
         "@org_golang_x_mod//semver",
         "@org_golang_x_sync//errgroup",
+        "@org_uber_go_atomic//:atomic",
     ],
 )
 

--- a/pkg/util/kubernetes/apiserver/event_collector.go
+++ b/pkg/util/kubernetes/apiserver/event_collector.go
@@ -65,14 +65,20 @@ func (ec *EventCollector) ResourceVersion() string {
 // Reflector lists then watches events matching the field selector, forwarding
 // them to the buffer through eventReflectorStore.
 func (ec *EventCollector) Start(stopCh <-chan struct{}) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
 	lw := &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = ec.filter
-			return ec.client.CoreV1().Events(metav1.NamespaceAll).List(context.TODO(), opts)
+			return ec.client.CoreV1().Events(metav1.NamespaceAll).List(ctx, opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = ec.filter
-			return ec.client.CoreV1().Events(metav1.NamespaceAll).Watch(context.TODO(), opts)
+			return ec.client.CoreV1().Events(metav1.NamespaceAll).Watch(ctx, opts)
 		},
 	}
 
@@ -96,9 +102,9 @@ func (ec *EventCollector) Drain() []*v1.Event {
 	}
 }
 
-// Dropped returns the number of events dropped due to the buffer being full.
-func (ec *EventCollector) Dropped() uint64 {
-	return ec.dropped.Load()
+// DrainDropped returns the number of events dropped since the last call, resetting the counter.
+func (ec *EventCollector) DrainDropped() uint64 {
+	return ec.dropped.Swap(0)
 }
 
 // enqueue buffers an event, dropping it (and counting the drop) if the buffer is full.

--- a/pkg/util/kubernetes/apiserver/event_collector.go
+++ b/pkg/util/kubernetes/apiserver/event_collector.go
@@ -19,10 +19,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// eventChanCapacity bounds how many events may queue between drains. A full
-// channel drops new events rather than blocking the informer's delivery
-// goroutine; see enqueue.
-const eventChanCapacity = 1000
+// defaultEventChanCapacity is a defensive floor used when the caller passes a
+// non-positive buffer size. The kubernetes_apiserver check normally supplies
+// event_collection_buffer_size. The buffer bounds how many events may queue
+// between drains: a full channel drops new events rather than blocking the
+// informer's delivery goroutine (see enqueue), so the size divided by the
+// check interval is the sustainable event rate.
+const defaultEventChanCapacity = 1000
 
 // EventCollector watches Kubernetes events through a shared informer and
 // buffers them for a periodic consumer to drain. The informer's reflector owns
@@ -46,13 +49,18 @@ type EventCollector struct {
 // NewEventCollector returns an EventCollector whose informer lists/watches
 // events matching filter (a field selector, e.g. the value built from
 // filtered_event_types).
-func (c *APIClient) NewEventCollector(filter string) *EventCollector {
+// bufferSize bounds how many events may queue between drains; a non-positive
+// value falls back to defaultEventChanCapacity.
+func (c *APIClient) NewEventCollector(filter string, bufferSize int) *EventCollector {
+	if bufferSize <= 0 {
+		bufferSize = defaultEventChanCapacity
+	}
 	factory := c.GetInformerWithOptions(nil, informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
 		opts.FieldSelector = filter
 	}))
 	return &EventCollector{
 		factory: factory,
-		events:  make(chan *v1.Event, eventChanCapacity),
+		events:  make(chan *v1.Event, bufferSize),
 	}
 }
 

--- a/pkg/util/kubernetes/apiserver/event_collector.go
+++ b/pkg/util/kubernetes/apiserver/event_collector.go
@@ -9,7 +9,6 @@ package apiserver
 
 import (
 	"context"
-	"strconv"
 
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
@@ -51,16 +50,6 @@ func (c *APIClient) NewEventCollector(filter string, bufferSize int) *EventColle
 	}
 }
 
-// SetResourceVersion sets the highest forwarded resourceVersion.
-func (ec *EventCollector) SetResourceVersion(rv string) {
-	ec.lastRV.Store(parseResourceVersion(rv))
-}
-
-// ResourceVersion returns the highest forwarded resourceVersion.
-func (ec *EventCollector) ResourceVersion() string {
-	return strconv.FormatUint(ec.lastRV.Load(), 10)
-}
-
 // Start builds the events Reflector and runs it until stopCh is closed. The
 // Reflector lists then watches events matching the field selector, forwarding
 // them to the buffer through eventReflectorStore.
@@ -83,7 +72,7 @@ func (ec *EventCollector) Start(stopCh <-chan struct{}) error {
 	}
 
 	store := &eventReflectorStore{enqueue: ec.enqueue, watermark: ec.lastRV}
-	reflector := cache.NewReflector(lw, &v1.Event{}, store, 0)
+	reflector := cache.NewReflector(noWatchListLW{lw}, &v1.Event{}, store, 0)
 	go reflector.Run(stopCh)
 
 	return nil
@@ -106,6 +95,15 @@ func (ec *EventCollector) Drain() []*v1.Event {
 func (ec *EventCollector) DrainDropped() uint64 {
 	return ec.dropped.Swap(0)
 }
+
+// noWatchListLW opts the events Reflector out of WatchList, forcing a
+// deterministic List+Watch initial sync instead of a bookmark-terminated stream.
+type noWatchListLW struct {
+	*cache.ListWatch
+}
+
+// IsWatchListSemanticsUnSupported is read structurally by client-go's reflector.
+func (noWatchListLW) IsWatchListSemanticsUnSupported() bool { return true }
 
 // enqueue buffers an event, dropping it (and counting the drop) if the buffer is full.
 func (ec *EventCollector) enqueue(ev *v1.Event) {

--- a/pkg/util/kubernetes/apiserver/event_collector.go
+++ b/pkg/util/kubernetes/apiserver/event_collector.go
@@ -8,9 +8,9 @@
 package apiserver
 
 import (
-	"sync/atomic"
 	"time"
 
+	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -26,7 +26,7 @@ type EventCollector struct {
 	startTS time.Time
 
 	events  chan *v1.Event
-	dropped atomic.Uint64
+	dropped *atomic.Uint64
 }
 
 // NewEventCollector returns an EventCollector whose informer lists/watches
@@ -42,6 +42,7 @@ func (c *APIClient) NewEventCollector(filter string, bufferSize int) *EventColle
 	return &EventCollector{
 		factory: factory,
 		events:  make(chan *v1.Event, bufferSize),
+		dropped: atomic.NewUint64(0),
 	}
 }
 

--- a/pkg/util/kubernetes/apiserver/event_collector.go
+++ b/pkg/util/kubernetes/apiserver/event_collector.go
@@ -9,7 +9,7 @@ package apiserver
 
 import (
 	"context"
-	"time"
+	"strconv"
 
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
@@ -22,12 +22,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// EventCollector watches Kubernetes events through a client-go Reflector and
+// EventCollector watches Kubernetes events through a Reflector and
 // buffers them for a periodic consumer to drain.
 type EventCollector struct {
-	client  kubernetes.Interface
-	filter  string
-	startTS time.Time
+	client kubernetes.Interface
+	filter string
+
+	// lastRV is the highest resourceVersion forwarded so far
+	lastRV *atomic.Uint64
 
 	events  chan *v1.Event
 	dropped *atomic.Uint64
@@ -43,17 +45,26 @@ func (c *APIClient) NewEventCollector(filter string, bufferSize int) *EventColle
 	return &EventCollector{
 		client:  c.InformerCl,
 		filter:  filter,
+		lastRV:  atomic.NewUint64(0),
 		events:  make(chan *v1.Event, bufferSize),
 		dropped: atomic.NewUint64(0),
 	}
+}
+
+// SetResourceVersion sets the highest forwarded resourceVersion.
+func (ec *EventCollector) SetResourceVersion(rv string) {
+	ec.lastRV.Store(parseResourceVersion(rv))
+}
+
+// ResourceVersion returns the highest forwarded resourceVersion.
+func (ec *EventCollector) ResourceVersion() string {
+	return strconv.FormatUint(ec.lastRV.Load(), 10)
 }
 
 // Start builds the events Reflector and runs it until stopCh is closed. The
 // Reflector lists then watches events matching the field selector, forwarding
 // them to the buffer through eventReflectorStore.
 func (ec *EventCollector) Start(stopCh <-chan struct{}) error {
-	ec.startTS = time.Now()
-
 	lw := &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = ec.filter
@@ -65,7 +76,8 @@ func (ec *EventCollector) Start(stopCh <-chan struct{}) error {
 		},
 	}
 
-	reflector := cache.NewReflector(lw, &v1.Event{}, &eventReflectorStore{enqueue: ec.enqueue}, 0)
+	store := &eventReflectorStore{enqueue: ec.enqueue, watermark: ec.lastRV}
+	reflector := cache.NewReflector(lw, &v1.Event{}, store, 0)
 	go reflector.Run(stopCh)
 
 	return nil
@@ -89,27 +101,11 @@ func (ec *EventCollector) Dropped() uint64 {
 	return ec.dropped.Load()
 }
 
-// enqueue adds an event to the buffer. If the event's lastTimestamp and EventTime are before the startTS, it is not collected.
-// If the buffer is full, the event is dropped.
-func (ec *EventCollector) enqueue(obj interface{}) {
-	ev, ok := obj.(*v1.Event)
-	if !ok {
-		log.Errorf("Expected *v1.Event, got %T; skipping", obj)
-		return
-	}
-
-	if !ec.shouldCollect(ev) {
-		return
-	}
-
+// enqueue buffers an event, dropping it (and counting the drop) if the buffer is full.
+func (ec *EventCollector) enqueue(ev *v1.Event) {
 	select {
 	case ec.events <- ev:
 	default:
 		ec.dropped.Add(1)
 	}
-}
-
-// shouldCollect reports whether an event should be collected.
-func (ec *EventCollector) shouldCollect(ev *v1.Event) bool {
-	return ev.LastTimestamp.After(ec.startTS) || ev.EventTime.Time.After(ec.startTS)
 }

--- a/pkg/util/kubernetes/apiserver/event_collector.go
+++ b/pkg/util/kubernetes/apiserver/event_collector.go
@@ -8,62 +8,67 @@
 package apiserver
 
 import (
+	"context"
 	"time"
 
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/informers"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// EventCollector watches Kubernetes events through a shared informer and
+// EventCollector watches Kubernetes events through a client-go Reflector and
 // buffers them for a periodic consumer to drain.
 type EventCollector struct {
-	factory informers.SharedInformerFactory
+	client  kubernetes.Interface
+	filter  string
 	startTS time.Time
 
 	events  chan *v1.Event
 	dropped *atomic.Uint64
 }
 
-// NewEventCollector returns an EventCollector whose informer lists/watches
+// NewEventCollector returns an EventCollector whose Reflector lists/watches
 // events matching filter (a field selector). Requires that the bufferSize be greater than 0.
 func (c *APIClient) NewEventCollector(filter string, bufferSize int) *EventCollector {
 	if bufferSize <= 0 {
 		log.Errorf("Event collection buffer size must be greater than 0, got %d", bufferSize)
 		return nil
 	}
-	factory := c.GetInformerWithOptions(nil, informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
-		opts.FieldSelector = filter
-	}))
 	return &EventCollector{
-		factory: factory,
+		client:  c.InformerCl,
+		filter:  filter,
 		events:  make(chan *v1.Event, bufferSize),
 		dropped: atomic.NewUint64(0),
 	}
 }
 
-// Start registers the events informer and its handlers, starts it, and blocks
-// until its cache has synced. The informer runs until stopCh is closed.
+// Start builds the events Reflector and runs it until stopCh is closed. The
+// Reflector lists then watches events matching the field selector, forwarding
+// them to the buffer through eventReflectorStore.
 func (ec *EventCollector) Start(stopCh <-chan struct{}) error {
 	ec.startTS = time.Now()
 
-	eventsInformer := ec.factory.Core().V1().Events()
-	if _, err := eventsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    ec.enqueue,
-		UpdateFunc: func(_, newObj interface{}) { ec.enqueue(newObj) },
-	}); err != nil {
-		return err
+	lw := &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = ec.filter
+			return ec.client.CoreV1().Events(metav1.NamespaceAll).List(context.TODO(), opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = ec.filter
+			return ec.client.CoreV1().Events(metav1.NamespaceAll).Watch(context.TODO(), opts)
+		},
 	}
 
-	go eventsInformer.Informer().Run(stopCh)
+	reflector := cache.NewReflector(lw, &v1.Event{}, &eventReflectorStore{enqueue: ec.enqueue}, 0)
+	go reflector.Run(stopCh)
 
-	return SyncInformers(map[InformerName]cache.SharedInformer{
-		"kubernetes-events": eventsInformer.Informer(),
-	}, 0)
+	return nil
 }
 
 // Drain returns the events buffered since the last call.

--- a/pkg/util/kubernetes/apiserver/event_collector.go
+++ b/pkg/util/kubernetes/apiserver/event_collector.go
@@ -1,0 +1,124 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package apiserver
+
+import (
+	"sync/atomic"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// eventChanCapacity bounds how many events may queue between drains. A full
+// channel drops new events rather than blocking the informer's delivery
+// goroutine; see enqueue.
+const eventChanCapacity = 1000
+
+// EventCollector watches Kubernetes events through a shared informer and
+// buffers them for a periodic consumer to drain. The informer's reflector owns
+// resource-version tracking and resync, so this type holds none of the manual
+// watermarking that RunEventCollection required.
+//
+// An EventCollector is single-use: create a new one each time the informer is
+// (re)started, because a SharedInformerFactory cannot be restarted once its
+// stop channel is closed.
+type EventCollector struct {
+	factory informers.SharedInformerFactory
+	startTS time.Time
+
+	// events buffers collected events between drains. The informer's single
+	// delivery goroutine sends; Drain receives. dropped counts events shed when
+	// the channel was full, for the check to surface as telemetry.
+	events  chan *v1.Event
+	dropped atomic.Uint64
+}
+
+// NewEventCollector returns an EventCollector whose informer lists/watches
+// events matching filter (a field selector, e.g. the value built from
+// filtered_event_types).
+func (c *APIClient) NewEventCollector(filter string) *EventCollector {
+	factory := c.GetInformerWithOptions(nil, informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+		opts.FieldSelector = filter
+	}))
+	return &EventCollector{
+		factory: factory,
+		events:  make(chan *v1.Event, eventChanCapacity),
+	}
+}
+
+// Start registers the events informer and its handlers, starts it, and blocks
+// until its cache has synced. The informer runs until stopCh is closed.
+func (ec *EventCollector) Start(stopCh <-chan struct{}) error {
+	ec.startTS = time.Now()
+
+	eventsInformer := ec.factory.Core().V1().Events()
+	if _, err := eventsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    ec.enqueue,
+		UpdateFunc: func(_, newObj interface{}) { ec.enqueue(newObj) },
+	}); err != nil {
+		return err
+	}
+
+	go eventsInformer.Informer().Run(stopCh)
+
+	return SyncInformers(map[InformerName]cache.SharedInformer{
+		"kubernetes-events": eventsInformer.Informer(),
+	}, 0)
+}
+
+// Drain returns the events buffered since the last call, leaving the channel
+// empty. It never blocks: it pulls only what is currently queued.
+func (ec *EventCollector) Drain() []*v1.Event {
+	var drained []*v1.Event
+	for {
+		select {
+		case ev := <-ec.events:
+			drained = append(drained, ev)
+		default:
+			return drained
+		}
+	}
+}
+
+// Dropped returns the cumulative count of events shed because the buffer was
+// full, so the check can surface it as telemetry.
+func (ec *EventCollector) Dropped() uint64 {
+	return ec.dropped.Load()
+}
+
+// enqueue buffers an event surfaced by the informer, dropping anything
+// shouldCollect rejects. The send is non-blocking: a full buffer drops the
+// event rather than stalling the informer's delivery goroutine.
+func (ec *EventCollector) enqueue(obj interface{}) {
+	ev, ok := obj.(*v1.Event)
+	if !ok {
+		log.Errorf("Expected *v1.Event, got %T; skipping", obj)
+		return
+	}
+
+	if !ec.shouldCollect(ev) {
+		return
+	}
+
+	select {
+	case ec.events <- ev:
+	default:
+		ec.dropped.Add(1)
+	}
+}
+
+// shouldCollect reports whether an event the informer surfaced should be
+// buffered for emission.
+func (ec *EventCollector) shouldCollect(ev *v1.Event) bool {
+	return ev.LastTimestamp.After(ec.startTS) || ev.EventTime.Time.After(ec.startTS)
+}

--- a/pkg/util/kubernetes/apiserver/event_collector.go
+++ b/pkg/util/kubernetes/apiserver/event_collector.go
@@ -19,41 +19,22 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// defaultEventChanCapacity is a defensive floor used when the caller passes a
-// non-positive buffer size. The kubernetes_apiserver check normally supplies
-// event_collection_buffer_size. The buffer bounds how many events may queue
-// between drains: a full channel drops new events rather than blocking the
-// informer's delivery goroutine (see enqueue), so the size divided by the
-// check interval is the sustainable event rate.
-const defaultEventChanCapacity = 1000
-
 // EventCollector watches Kubernetes events through a shared informer and
-// buffers them for a periodic consumer to drain. The informer's reflector owns
-// resource-version tracking and resync, so this type holds none of the manual
-// watermarking that RunEventCollection required.
-//
-// An EventCollector is single-use: create a new one each time the informer is
-// (re)started, because a SharedInformerFactory cannot be restarted once its
-// stop channel is closed.
+// buffers them for a periodic consumer to drain.
 type EventCollector struct {
 	factory informers.SharedInformerFactory
 	startTS time.Time
 
-	// events buffers collected events between drains. The informer's single
-	// delivery goroutine sends; Drain receives. dropped counts events shed when
-	// the channel was full, for the check to surface as telemetry.
 	events  chan *v1.Event
 	dropped atomic.Uint64
 }
 
 // NewEventCollector returns an EventCollector whose informer lists/watches
-// events matching filter (a field selector, e.g. the value built from
-// filtered_event_types).
-// bufferSize bounds how many events may queue between drains; a non-positive
-// value falls back to defaultEventChanCapacity.
+// events matching filter (a field selector). Requires that the bufferSize be greater than 0.
 func (c *APIClient) NewEventCollector(filter string, bufferSize int) *EventCollector {
 	if bufferSize <= 0 {
-		bufferSize = defaultEventChanCapacity
+		log.Errorf("Event collection buffer size must be greater than 0, got %d", bufferSize)
+		return nil
 	}
 	factory := c.GetInformerWithOptions(nil, informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
 		opts.FieldSelector = filter
@@ -84,8 +65,7 @@ func (ec *EventCollector) Start(stopCh <-chan struct{}) error {
 	}, 0)
 }
 
-// Drain returns the events buffered since the last call, leaving the channel
-// empty. It never blocks: it pulls only what is currently queued.
+// Drain returns the events buffered since the last call.
 func (ec *EventCollector) Drain() []*v1.Event {
 	var drained []*v1.Event
 	for {
@@ -98,15 +78,13 @@ func (ec *EventCollector) Drain() []*v1.Event {
 	}
 }
 
-// Dropped returns the cumulative count of events shed because the buffer was
-// full, so the check can surface it as telemetry.
+// Dropped returns the number of events dropped due to the buffer being full.
 func (ec *EventCollector) Dropped() uint64 {
 	return ec.dropped.Load()
 }
 
-// enqueue buffers an event surfaced by the informer, dropping anything
-// shouldCollect rejects. The send is non-blocking: a full buffer drops the
-// event rather than stalling the informer's delivery goroutine.
+// enqueue adds an event to the buffer. If the event's lastTimestamp and EventTime are before the startTS, it is not collected.
+// If the buffer is full, the event is dropped.
 func (ec *EventCollector) enqueue(obj interface{}) {
 	ev, ok := obj.(*v1.Event)
 	if !ok {
@@ -125,8 +103,7 @@ func (ec *EventCollector) enqueue(obj interface{}) {
 	}
 }
 
-// shouldCollect reports whether an event the informer surfaced should be
-// buffered for emission.
+// shouldCollect reports whether an event should be collected.
 func (ec *EventCollector) shouldCollect(ev *v1.Event) bool {
 	return ev.LastTimestamp.After(ec.startTS) || ev.EventTime.Time.After(ec.startTS)
 }

--- a/pkg/util/kubernetes/apiserver/event_collector_test.go
+++ b/pkg/util/kubernetes/apiserver/event_collector_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,6 +21,7 @@ func makeCollector(bufferSize int, startTS time.Time) *EventCollector {
 	return &EventCollector{
 		events:  make(chan *v1.Event, bufferSize),
 		startTS: startTS,
+		dropped: atomic.NewUint64(0),
 	}
 }
 
@@ -42,12 +44,12 @@ func TestShouldCollect(t *testing.T) {
 		},
 		{
 			name: "EventTime after startTS, LastTimestamp zero: collect",
-			ev:   &v1.Event{EventTime: metav1.MicroTime{Time: future.Time}},
+			ev:   &v1.Event{EventTime: metav1.MicroTime(future)},
 			want: true,
 		},
 		{
 			name: "both timestamps before startTS: drop",
-			ev:   &v1.Event{LastTimestamp: past, EventTime: metav1.MicroTime{Time: past.Time}},
+			ev:   &v1.Event{LastTimestamp: past, EventTime: metav1.MicroTime(past)},
 			want: false,
 		},
 	} {

--- a/pkg/util/kubernetes/apiserver/event_collector_test.go
+++ b/pkg/util/kubernetes/apiserver/event_collector_test.go
@@ -9,67 +9,28 @@ package apiserver
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func makeCollector(bufferSize int, startTS time.Time) *EventCollector {
+func makeCollector(bufferSize int) *EventCollector {
 	return &EventCollector{
 		events:  make(chan *v1.Event, bufferSize),
-		startTS: startTS,
 		dropped: atomic.NewUint64(0),
-	}
-}
-
-// TestShouldCollect verifies collection is gated on at least one timestamp being after startTS.
-func TestShouldCollect(t *testing.T) {
-	now := time.Now()
-	future := metav1.NewTime(now.Add(time.Second))
-	past := metav1.NewTime(now.Add(-time.Second))
-	ec := makeCollector(1, now)
-
-	for _, tc := range []struct {
-		name string
-		ev   *v1.Event
-		want bool
-	}{
-		{
-			name: "LastTimestamp after startTS, EventTime zero: collect",
-			ev:   &v1.Event{LastTimestamp: future},
-			want: true,
-		},
-		{
-			name: "EventTime after startTS, LastTimestamp zero: collect",
-			ev:   &v1.Event{EventTime: metav1.MicroTime(future)},
-			want: true,
-		},
-		{
-			name: "both timestamps before startTS: drop",
-			ev:   &v1.Event{LastTimestamp: past, EventTime: metav1.MicroTime(past)},
-			want: false,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, ec.shouldCollect(tc.ev))
-		})
 	}
 }
 
 // TestDrain verifies Drain returns all buffered events and leaves the channel empty.
 func TestDrain(t *testing.T) {
-	startTS := time.Now().Add(-time.Second)
-
 	t.Run("empty channel: nil", func(t *testing.T) {
-		ec := makeCollector(10, startTS)
+		ec := makeCollector(10)
 		assert.Nil(t, ec.Drain())
 	})
 
 	t.Run("one event: returns slice of length one", func(t *testing.T) {
-		ec := makeCollector(10, startTS)
+		ec := makeCollector(10)
 		ev := &v1.Event{Reason: "OOM"}
 		ec.events <- ev
 		assert.Equal(t, []*v1.Event{ev}, ec.Drain())
@@ -77,7 +38,7 @@ func TestDrain(t *testing.T) {
 	})
 
 	t.Run("multiple events: returns all and clears", func(t *testing.T) {
-		ec := makeCollector(10, startTS)
+		ec := makeCollector(10)
 		ev1 := &v1.Event{Reason: "OOM"}
 		ev2 := &v1.Event{Reason: "Evicted"}
 		ec.events <- ev1
@@ -88,36 +49,19 @@ func TestDrain(t *testing.T) {
 	})
 }
 
-// TestEnqueue verifies enqueue filters by type and timestamp, buffers qualifying events, and counts drops.
+// TestEnqueue verifies enqueue buffers events and counts drops when the buffer is full.
 func TestEnqueue(t *testing.T) {
-	startTS := time.Now().Add(-time.Second)
-	recent := metav1.NewTime(time.Now())
-	ev := &v1.Event{Reason: "OOM", LastTimestamp: recent}
-
-	t.Run("non-Event obj: skipped, no drop counted", func(t *testing.T) {
-		ec := makeCollector(10, startTS)
-		ec.enqueue("not an event")
-		assert.Equal(t, uint64(0), ec.Dropped())
-		assert.Nil(t, ec.Drain())
-	})
-
-	t.Run("shouldCollect false: skipped, no drop counted", func(t *testing.T) {
-		ec := makeCollector(10, startTS)
-		stale := &v1.Event{Reason: "OOM", LastTimestamp: metav1.NewTime(startTS.Add(-time.Minute))}
-		ec.enqueue(stale)
-		assert.Equal(t, uint64(0), ec.Dropped())
-		assert.Nil(t, ec.Drain())
-	})
+	ev := &v1.Event{Reason: "OOM"}
 
 	t.Run("buffer not full: event buffered, Dropped stays zero", func(t *testing.T) {
-		ec := makeCollector(1, startTS)
+		ec := makeCollector(1)
 		ec.enqueue(ev)
 		assert.Equal(t, uint64(0), ec.Dropped())
 		assert.Len(t, ec.Drain(), 1)
 	})
 
 	t.Run("buffer full: event dropped, Dropped incremented", func(t *testing.T) {
-		ec := makeCollector(1, startTS)
+		ec := makeCollector(1)
 		ec.events <- ev // fill the buffer
 		ec.enqueue(ev)
 		assert.Equal(t, uint64(1), ec.Dropped())

--- a/pkg/util/kubernetes/apiserver/event_collector_test.go
+++ b/pkg/util/kubernetes/apiserver/event_collector_test.go
@@ -1,0 +1,123 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package apiserver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func makeCollector(bufferSize int, startTS time.Time) *EventCollector {
+	return &EventCollector{
+		events:  make(chan *v1.Event, bufferSize),
+		startTS: startTS,
+	}
+}
+
+// TestShouldCollect verifies collection is gated on at least one timestamp being after startTS.
+func TestShouldCollect(t *testing.T) {
+	now := time.Now()
+	future := metav1.NewTime(now.Add(time.Second))
+	past := metav1.NewTime(now.Add(-time.Second))
+	ec := makeCollector(1, now)
+
+	for _, tc := range []struct {
+		name string
+		ev   *v1.Event
+		want bool
+	}{
+		{
+			name: "LastTimestamp after startTS, EventTime zero: collect",
+			ev:   &v1.Event{LastTimestamp: future},
+			want: true,
+		},
+		{
+			name: "EventTime after startTS, LastTimestamp zero: collect",
+			ev:   &v1.Event{EventTime: metav1.MicroTime{Time: future.Time}},
+			want: true,
+		},
+		{
+			name: "both timestamps before startTS: drop",
+			ev:   &v1.Event{LastTimestamp: past, EventTime: metav1.MicroTime{Time: past.Time}},
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ec.shouldCollect(tc.ev))
+		})
+	}
+}
+
+// TestDrain verifies Drain returns all buffered events and leaves the channel empty.
+func TestDrain(t *testing.T) {
+	startTS := time.Now().Add(-time.Second)
+
+	t.Run("empty channel: nil", func(t *testing.T) {
+		ec := makeCollector(10, startTS)
+		assert.Nil(t, ec.Drain())
+	})
+
+	t.Run("one event: returns slice of length one", func(t *testing.T) {
+		ec := makeCollector(10, startTS)
+		ev := &v1.Event{Reason: "OOM"}
+		ec.events <- ev
+		assert.Equal(t, []*v1.Event{ev}, ec.Drain())
+		assert.Nil(t, ec.Drain())
+	})
+
+	t.Run("multiple events: returns all and clears", func(t *testing.T) {
+		ec := makeCollector(10, startTS)
+		ev1 := &v1.Event{Reason: "OOM"}
+		ev2 := &v1.Event{Reason: "Evicted"}
+		ec.events <- ev1
+		ec.events <- ev2
+
+		assert.Equal(t, []*v1.Event{ev1, ev2}, ec.Drain())
+		assert.Nil(t, ec.Drain())
+	})
+}
+
+// TestEnqueue verifies enqueue filters by type and timestamp, buffers qualifying events, and counts drops.
+func TestEnqueue(t *testing.T) {
+	startTS := time.Now().Add(-time.Second)
+	recent := metav1.NewTime(time.Now())
+	ev := &v1.Event{Reason: "OOM", LastTimestamp: recent}
+
+	t.Run("non-Event obj: skipped, no drop counted", func(t *testing.T) {
+		ec := makeCollector(10, startTS)
+		ec.enqueue("not an event")
+		assert.Equal(t, uint64(0), ec.Dropped())
+		assert.Nil(t, ec.Drain())
+	})
+
+	t.Run("shouldCollect false: skipped, no drop counted", func(t *testing.T) {
+		ec := makeCollector(10, startTS)
+		stale := &v1.Event{Reason: "OOM", LastTimestamp: metav1.NewTime(startTS.Add(-time.Minute))}
+		ec.enqueue(stale)
+		assert.Equal(t, uint64(0), ec.Dropped())
+		assert.Nil(t, ec.Drain())
+	})
+
+	t.Run("buffer not full: event buffered, Dropped stays zero", func(t *testing.T) {
+		ec := makeCollector(1, startTS)
+		ec.enqueue(ev)
+		assert.Equal(t, uint64(0), ec.Dropped())
+		assert.Len(t, ec.Drain(), 1)
+	})
+
+	t.Run("buffer full: event dropped, Dropped incremented", func(t *testing.T) {
+		ec := makeCollector(1, startTS)
+		ec.events <- ev // fill the buffer
+		ec.enqueue(ev)
+		assert.Equal(t, uint64(1), ec.Dropped())
+	})
+}

--- a/pkg/util/kubernetes/apiserver/event_collector_test.go
+++ b/pkg/util/kubernetes/apiserver/event_collector_test.go
@@ -56,7 +56,7 @@ func TestEnqueue(t *testing.T) {
 	t.Run("buffer not full: event buffered, Dropped stays zero", func(t *testing.T) {
 		ec := makeCollector(1)
 		ec.enqueue(ev)
-		assert.Equal(t, uint64(0), ec.Dropped())
+		assert.Equal(t, uint64(0), ec.DrainDropped())
 		assert.Len(t, ec.Drain(), 1)
 	})
 
@@ -64,6 +64,6 @@ func TestEnqueue(t *testing.T) {
 		ec := makeCollector(1)
 		ec.events <- ev // fill the buffer
 		ec.enqueue(ev)
-		assert.Equal(t, uint64(1), ec.Dropped())
+		assert.Equal(t, uint64(1), ec.DrainDropped())
 	})
 }

--- a/pkg/util/kubernetes/apiserver/event_reflector_store.go
+++ b/pkg/util/kubernetes/apiserver/event_reflector_store.go
@@ -14,19 +14,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// eventReflectorStore is the cache.Store the events Reflector writes into. It
-// keeps no objects: Add/Update/Replace forward events through enqueue and the
-// read methods are inert. The watermark, shared with the owning EventCollector,
-// is the highest resourceVersion forwarded; it dedups relists (where Replace
-// re-delivers the full live set) and is persisted for restart recovery.
+// eventReflectorStore is a cache.Store that retains nothing: it forwards events
+// through enqueue. The watermark (highest resourceVersion forwarded) dedups
+// relists within the collector's lifetime.
 type eventReflectorStore struct {
 	enqueue   func(*v1.Event)
 	watermark *atomic.Uint64
 }
 
-// forwardIfNew forwards an object if it is an *v1.Event whose resourceVersion
-// exceeds the watermark, advancing the mark. The Reflector serializes all store
-// calls (resync is disabled), so the Load-then-Store needs no lock: one writer.
+// forwardIfNew forwards an *v1.Event whose resourceVersion exceeds the watermark,
+// advancing it. The Reflector serializes store calls, so no lock is needed.
 func (s *eventReflectorStore) forwardIfNew(obj interface{}) {
 	ev, ok := obj.(*v1.Event)
 	if !ok {
@@ -49,9 +46,8 @@ func (s *eventReflectorStore) Update(obj interface{}) error { s.forwardIfNew(obj
 // Delete drops a removed event. Removals are never forwarded to Datadog.
 func (s *eventReflectorStore) Delete(_ interface{}) error { return nil }
 
-// Replace handles the initial list and every relist. Lists come in unordered,
-// so we forward against a fixed threshold and advance the watermark only after
-// the loop. On cold start the threshold is 0, so all events are forwarded.
+// Replace handles the initial list and every relist. Lists are unordered, so we
+// forward against a fixed threshold and advance the watermark after the loop.
 func (s *eventReflectorStore) Replace(list []interface{}, resourceVersion string) error {
 	threshold := s.watermark.Load()
 	for _, obj := range list {

--- a/pkg/util/kubernetes/apiserver/event_reflector_store.go
+++ b/pkg/util/kubernetes/apiserver/event_reflector_store.go
@@ -22,7 +22,6 @@ import (
 type eventReflectorStore struct {
 	enqueue   func(*v1.Event)
 	watermark *atomic.Uint64
-	seeded    bool
 }
 
 // forwardIfNew forwards an object if it is an *v1.Event whose resourceVersion
@@ -50,24 +49,20 @@ func (s *eventReflectorStore) Update(obj interface{}) error { s.forwardIfNew(obj
 // Delete drops a removed event. Removals are never forwarded to Datadog.
 func (s *eventReflectorStore) Delete(_ interface{}) error { return nil }
 
-// Replace handles the initial list and every relist. On a cold start, we set the watermark to the list's resourceVersion.
-// Otherwise on a relist, or the first list after a restart, we only forward events past the watermark.
+// Replace handles the initial list and every relist. Lists come in unordered,
+// so we forward against a fixed threshold and advance the watermark only after
+// the loop. On cold start the threshold is 0, so all events are forwarded.
 func (s *eventReflectorStore) Replace(list []interface{}, resourceVersion string) error {
-	if s.seeded || s.watermark.Load() > 0 {
-		// Lists come in unordered, so we forward against a fixed threshold and
-		// update the high watermark only after the loop.
-		threshold := s.watermark.Load()
-		for _, obj := range list {
-			ev, ok := obj.(*v1.Event)
-			if !ok {
-				continue
-			}
-			if parseResourceVersion(ev.ResourceVersion) > threshold {
-				s.enqueue(ev)
-			}
+	threshold := s.watermark.Load()
+	for _, obj := range list {
+		ev, ok := obj.(*v1.Event)
+		if !ok {
+			continue
+		}
+		if parseResourceVersion(ev.ResourceVersion) > threshold {
+			s.enqueue(ev)
 		}
 	}
-	s.seeded = true
 	if listRV := parseResourceVersion(resourceVersion); listRV > s.watermark.Load() {
 		s.watermark.Store(listRV)
 	}

--- a/pkg/util/kubernetes/apiserver/event_reflector_store.go
+++ b/pkg/util/kubernetes/apiserver/event_reflector_store.go
@@ -10,49 +10,57 @@ package apiserver
 import (
 	"strconv"
 
+	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
 )
 
-// eventReflectorStore is a fake cache.Store that forwards events via a callback.
+// eventReflectorStore is the cache.Store the events Reflector writes into. It
+// keeps no objects: Add/Update/Replace forward events through enqueue and the
+// read methods are inert. The watermark, shared with the owning EventCollector,
+// is the highest resourceVersion forwarded; it dedups relists (where Replace
+// re-delivers the full live set) and is persisted for restart recovery.
 type eventReflectorStore struct {
-	enqueue   func(interface{})
-	highestRV uint64
+	enqueue   func(*v1.Event)
+	watermark *atomic.Uint64
 	seeded    bool
 }
 
-// forwardIfNew forwards an object if it is castable as an *v1.Event, and only if its resourceVersion > s.highestRV.
+// forwardIfNew forwards an object if it is an *v1.Event whose resourceVersion
+// exceeds the watermark, advancing the mark. The Reflector serializes all store
+// calls (resync is disabled), so the Load-then-Store needs no lock: one writer.
 func (s *eventReflectorStore) forwardIfNew(obj interface{}) {
 	ev, ok := obj.(*v1.Event)
 	if !ok {
 		return
 	}
 	rv := parseResourceVersion(ev.ResourceVersion)
-	if rv <= s.highestRV {
+	if rv <= s.watermark.Load() {
 		return
 	}
-	s.highestRV = rv
+	s.watermark.Store(rv)
 	s.enqueue(ev)
 }
 
 // Add forwards a newly watched event.
 func (s *eventReflectorStore) Add(obj interface{}) error { s.forwardIfNew(obj); return nil }
 
-// Update forwards a modified event.
+// Update forwards a modified event; handled like Add.
 func (s *eventReflectorStore) Update(obj interface{}) error { s.forwardIfNew(obj); return nil }
 
-// Delete does nothing.
+// Delete drops a removed event. Removals are never forwarded to Datadog.
 func (s *eventReflectorStore) Delete(_ interface{}) error { return nil }
 
-// Replace seeds the highestRV from the list's resourceVersion and forwards all events.
+// Replace handles the initial list and every relist. On a cold start, we set the watermark to the list's resourceVersion.
+// Otherwise on a relist, or the first list after a restart, we only forward events past the watermark.
 func (s *eventReflectorStore) Replace(list []interface{}, resourceVersion string) error {
-	if s.seeded {
+	if s.seeded || s.watermark.Load() > 0 {
 		for _, obj := range list {
 			s.forwardIfNew(obj)
 		}
 	}
 	s.seeded = true
-	if listRV := parseResourceVersion(resourceVersion); listRV > s.highestRV {
-		s.highestRV = listRV
+	if listRV := parseResourceVersion(resourceVersion); listRV > s.watermark.Load() {
+		s.watermark.Store(listRV)
 	}
 	return nil
 }

--- a/pkg/util/kubernetes/apiserver/event_reflector_store.go
+++ b/pkg/util/kubernetes/apiserver/event_reflector_store.go
@@ -54,8 +54,17 @@ func (s *eventReflectorStore) Delete(_ interface{}) error { return nil }
 // Otherwise on a relist, or the first list after a restart, we only forward events past the watermark.
 func (s *eventReflectorStore) Replace(list []interface{}, resourceVersion string) error {
 	if s.seeded || s.watermark.Load() > 0 {
+		// Lists come in unordered, so we forward against a fixed threshold and
+		// update the high watermark only after the loop.
+		threshold := s.watermark.Load()
 		for _, obj := range list {
-			s.forwardIfNew(obj)
+			ev, ok := obj.(*v1.Event)
+			if !ok {
+				continue
+			}
+			if parseResourceVersion(ev.ResourceVersion) > threshold {
+				s.enqueue(ev)
+			}
 		}
 	}
 	s.seeded = true

--- a/pkg/util/kubernetes/apiserver/event_reflector_store.go
+++ b/pkg/util/kubernetes/apiserver/event_reflector_store.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package apiserver
+
+import (
+	"strconv"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// eventReflectorStore is a fake cache.Store that forwards events via a callback.
+type eventReflectorStore struct {
+	enqueue   func(interface{})
+	highestRV uint64
+	seeded    bool
+}
+
+// forwardIfNew forwards an object if it is castable as an *v1.Event, and only if its resourceVersion > s.highestRV.
+func (s *eventReflectorStore) forwardIfNew(obj interface{}) {
+	ev, ok := obj.(*v1.Event)
+	if !ok {
+		return
+	}
+	rv := parseResourceVersion(ev.ResourceVersion)
+	if rv <= s.highestRV {
+		return
+	}
+	s.highestRV = rv
+	s.enqueue(ev)
+}
+
+// Add forwards a newly watched event.
+func (s *eventReflectorStore) Add(obj interface{}) error { s.forwardIfNew(obj); return nil }
+
+// Update forwards a modified event.
+func (s *eventReflectorStore) Update(obj interface{}) error { s.forwardIfNew(obj); return nil }
+
+// Delete does nothing.
+func (s *eventReflectorStore) Delete(_ interface{}) error { return nil }
+
+// Replace seeds the highestRV from the list's resourceVersion and forwards all events.
+func (s *eventReflectorStore) Replace(list []interface{}, resourceVersion string) error {
+	if s.seeded {
+		for _, obj := range list {
+			s.forwardIfNew(obj)
+		}
+	}
+	s.seeded = true
+	if listRV := parseResourceVersion(resourceVersion); listRV > s.highestRV {
+		s.highestRV = listRV
+	}
+	return nil
+}
+
+// eventReflectorStore.List is not implemented.
+func (s *eventReflectorStore) List() []interface{} { return nil }
+
+// eventReflectorStore.ListKeys is not implemented.
+func (s *eventReflectorStore) ListKeys() []string { return nil }
+
+// eventReflectorStore.Get is not implemented.
+func (s *eventReflectorStore) Get(_ interface{}) (interface{}, bool, error) { return nil, false, nil }
+
+// eventReflectorStore.GetByKey is not implemented.
+func (s *eventReflectorStore) GetByKey(_ string) (interface{}, bool, error) { return nil, false, nil }
+
+// eventReflectorStore.Resync is not implemented.
+func (s *eventReflectorStore) Resync() error { return nil }
+
+// parseResourceVersion parses a Kubernetes resourceVersion. Unparseable values (e.g. empty) are 0.
+func parseResourceVersion(rv string) uint64 {
+	n, err := strconv.ParseUint(rv, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/pkg/util/kubernetes/apiserver/event_reflector_store_test.go
+++ b/pkg/util/kubernetes/apiserver/event_reflector_store_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,11 +20,8 @@ import (
 func makeStore() (*eventReflectorStore, *[]*v1.Event) {
 	var captured []*v1.Event
 	s := &eventReflectorStore{
-		enqueue: func(obj interface{}) {
-			if ev, ok := obj.(*v1.Event); ok {
-				captured = append(captured, ev)
-			}
-		},
+		enqueue:   func(ev *v1.Event) { captured = append(captured, ev) },
+		watermark: atomic.NewUint64(0),
 	}
 	return s, &captured
 }
@@ -57,22 +55,22 @@ func TestForwardIfNew(t *testing.T) {
 		assert.Empty(t, *captured)
 	})
 
-	t.Run("RV at or below highestRV is not forwarded", func(t *testing.T) {
+	t.Run("RV at or below watermark is not forwarded", func(t *testing.T) {
 		s, captured := makeStore()
-		s.highestRV = 10
+		s.watermark.Store(10)
 		s.forwardIfNew(eventWithRV("10")) // boundary: equal
 		assert.Empty(t, *captured)
-		assert.Equal(t, uint64(10), s.highestRV)
+		assert.Equal(t, uint64(10), s.watermark.Load())
 	})
 
-	t.Run("RV above highestRV is forwarded and highestRV advances", func(t *testing.T) {
+	t.Run("RV above watermark is forwarded and watermark advances", func(t *testing.T) {
 		s, captured := makeStore()
-		s.highestRV = 10
+		s.watermark.Store(10)
 		ev := eventWithRV("20")
 		s.forwardIfNew(ev)
 		require.Len(t, *captured, 1)
 		assert.Same(t, ev, (*captured)[0])
-		assert.Equal(t, uint64(20), s.highestRV)
+		assert.Equal(t, uint64(20), s.watermark.Load())
 	})
 }
 
@@ -99,7 +97,7 @@ func TestAddUpdate(t *testing.T) {
 	t.Run("stale RV: event skipped", func(t *testing.T) {
 		for _, m := range methods {
 			s, captured := makeStore()
-			s.highestRV = 5
+			s.watermark.Store(5)
 			require.NoError(t, m.call(s, eventWithRV("3")))
 			assert.Empty(t, *captured, m.name)
 		}
@@ -113,25 +111,34 @@ func TestDelete(t *testing.T) {
 	assert.Empty(t, *captured)
 }
 
-// TestReplace verifies first-call seeding suppresses forwarding, and subsequent calls forward qualifying events without lowering highestRV.
+// TestReplace verifies cold-start seeding suppresses forwarding, a seeded watermark
+// (restart) forwards the backlog past it, and relists forward without lowering the watermark.
 func TestReplace(t *testing.T) {
-	t.Run("first call seeds highestRV from listRV and skips all events", func(t *testing.T) {
+	t.Run("cold start seeds watermark from listRV and skips all events", func(t *testing.T) {
 		s, captured := makeStore()
 		require.NoError(t, s.Replace([]interface{}{eventWithRV("5")}, "10"))
 		assert.Empty(t, *captured)
 		assert.True(t, s.seeded)
-		assert.Equal(t, uint64(10), s.highestRV)
+		assert.Equal(t, uint64(10), s.watermark.Load())
 	})
 
-	t.Run("subsequent call forwards new events and does not lower highestRV below its current value", func(t *testing.T) {
+	t.Run("restart from persisted watermark forwards events past it", func(t *testing.T) {
 		s, captured := makeStore()
-		require.NoError(t, s.Replace([]interface{}{}, "5")) // seed; highestRV=5
+		s.watermark.Store(4) // seeded from a persisted resourceVersion
+		require.NoError(t, s.Replace([]interface{}{eventWithRV("3"), eventWithRV("6")}, "6"))
+		require.Len(t, *captured, 1)
+		assert.Equal(t, uint64(6), s.watermark.Load())
+	})
+
+	t.Run("relist forwards new events and does not lower the watermark", func(t *testing.T) {
+		s, captured := makeStore()
+		require.NoError(t, s.Replace([]interface{}{}, "5")) // cold seed; watermark=5
 		ev := eventWithRV("10")
-		// listRV "3" is below highestRV after forwarding ev; highestRV must not drop.
+		// listRV "3" is below the watermark after forwarding ev; it must not drop.
 		require.NoError(t, s.Replace([]interface{}{ev, eventWithRV("3")}, "3"))
 		require.Len(t, *captured, 1)
 		assert.Same(t, ev, (*captured)[0])
-		assert.Equal(t, uint64(10), s.highestRV)
+		assert.Equal(t, uint64(10), s.watermark.Load())
 	})
 }
 

--- a/pkg/util/kubernetes/apiserver/event_reflector_store_test.go
+++ b/pkg/util/kubernetes/apiserver/event_reflector_store_test.go
@@ -1,0 +1,152 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package apiserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func makeStore() (*eventReflectorStore, *[]*v1.Event) {
+	var captured []*v1.Event
+	s := &eventReflectorStore{
+		enqueue: func(obj interface{}) {
+			if ev, ok := obj.(*v1.Event); ok {
+				captured = append(captured, ev)
+			}
+		},
+	}
+	return s, &captured
+}
+
+func eventWithRV(rv string) *v1.Event {
+	return &v1.Event{ObjectMeta: metav1.ObjectMeta{ResourceVersion: rv}}
+}
+
+// TestParseResourceVersion verifies valid, empty, and non-numeric inputs.
+func TestParseResourceVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rv   string
+		want uint64
+	}{
+		{"empty string returns zero", "", 0},
+		{"valid uint is parsed", "42", 42},
+		{"non-numeric returns zero", "abc", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseResourceVersion(tc.rv))
+		})
+	}
+}
+
+// TestForwardIfNew verifies the monotonic-RV gate: non-Events and stale RVs are dropped; new RVs are forwarded.
+func TestForwardIfNew(t *testing.T) {
+	t.Run("non-Event object is dropped", func(t *testing.T) {
+		s, captured := makeStore()
+		s.forwardIfNew("not an event")
+		assert.Empty(t, *captured)
+	})
+
+	t.Run("RV at or below highestRV is not forwarded", func(t *testing.T) {
+		s, captured := makeStore()
+		s.highestRV = 10
+		s.forwardIfNew(eventWithRV("10")) // boundary: equal
+		assert.Empty(t, *captured)
+		assert.Equal(t, uint64(10), s.highestRV)
+	})
+
+	t.Run("RV above highestRV is forwarded and highestRV advances", func(t *testing.T) {
+		s, captured := makeStore()
+		s.highestRV = 10
+		ev := eventWithRV("20")
+		s.forwardIfNew(ev)
+		require.Len(t, *captured, 1)
+		assert.Same(t, ev, (*captured)[0])
+		assert.Equal(t, uint64(20), s.highestRV)
+	})
+}
+
+// TestAddUpdate verifies Add and Update both delegate to forwardIfNew.
+func TestAddUpdate(t *testing.T) {
+	methods := []struct {
+		name string
+		call func(*eventReflectorStore, interface{}) error
+	}{
+		{"Add", (*eventReflectorStore).Add},
+		{"Update", (*eventReflectorStore).Update},
+	}
+
+	t.Run("new RV: event forwarded", func(t *testing.T) {
+		for _, m := range methods {
+			s, captured := makeStore()
+			ev := eventWithRV("1")
+			require.NoError(t, m.call(s, ev))
+			require.Len(t, *captured, 1, m.name)
+			assert.Same(t, ev, (*captured)[0], m.name)
+		}
+	})
+
+	t.Run("stale RV: event skipped", func(t *testing.T) {
+		for _, m := range methods {
+			s, captured := makeStore()
+			s.highestRV = 5
+			require.NoError(t, m.call(s, eventWithRV("3")))
+			assert.Empty(t, *captured, m.name)
+		}
+	})
+}
+
+// TestDelete verifies Delete is a no-op.
+func TestDelete(t *testing.T) {
+	s, captured := makeStore()
+	require.NoError(t, s.Delete(eventWithRV("99")))
+	assert.Empty(t, *captured)
+}
+
+// TestReplace verifies first-call seeding suppresses forwarding, and subsequent calls forward qualifying events without lowering highestRV.
+func TestReplace(t *testing.T) {
+	t.Run("first call seeds highestRV from listRV and skips all events", func(t *testing.T) {
+		s, captured := makeStore()
+		require.NoError(t, s.Replace([]interface{}{eventWithRV("5")}, "10"))
+		assert.Empty(t, *captured)
+		assert.True(t, s.seeded)
+		assert.Equal(t, uint64(10), s.highestRV)
+	})
+
+	t.Run("subsequent call forwards new events and does not lower highestRV below its current value", func(t *testing.T) {
+		s, captured := makeStore()
+		require.NoError(t, s.Replace([]interface{}{}, "5")) // seed; highestRV=5
+		ev := eventWithRV("10")
+		// listRV "3" is below highestRV after forwarding ev; highestRV must not drop.
+		require.NoError(t, s.Replace([]interface{}{ev, eventWithRV("3")}, "3"))
+		require.Len(t, *captured, 1)
+		assert.Same(t, ev, (*captured)[0])
+		assert.Equal(t, uint64(10), s.highestRV)
+	})
+}
+
+// TestNoOpMethods verifies unimplemented cache.Store methods return zero values.
+func TestNoOpMethods(t *testing.T) {
+	s, _ := makeStore()
+	assert.Nil(t, s.List())
+	assert.Nil(t, s.ListKeys())
+	item, exists, err := s.Get(nil)
+	assert.Nil(t, item)
+	assert.False(t, exists)
+	assert.NoError(t, err)
+	item, exists, err = s.GetByKey("")
+	assert.Nil(t, item)
+	assert.False(t, exists)
+	assert.NoError(t, err)
+	assert.NoError(t, s.Resync())
+}

--- a/pkg/util/kubernetes/apiserver/event_reflector_store_test.go
+++ b/pkg/util/kubernetes/apiserver/event_reflector_store_test.go
@@ -112,7 +112,8 @@ func TestDelete(t *testing.T) {
 }
 
 // TestReplace verifies cold-start seeding suppresses forwarding, a seeded watermark
-// (restart) forwards the backlog past it, and relists forward without lowering the watermark.
+// (restart) forwards the backlog past it regardless of list order, and relists
+// advance the watermark to the collection resourceVersion.
 func TestReplace(t *testing.T) {
 	t.Run("cold start seeds watermark from listRV and skips all events", func(t *testing.T) {
 		s, captured := makeStore()
@@ -130,15 +131,23 @@ func TestReplace(t *testing.T) {
 		assert.Equal(t, uint64(6), s.watermark.Load())
 	})
 
-	t.Run("relist forwards new events and does not lower the watermark", func(t *testing.T) {
+	t.Run("unordered list forwards every event past the threshold", func(t *testing.T) {
+		// Regression: unordered list [9, 6, 3] with watermark 4 — both 9 and 6 must forward.
+		s, captured := makeStore()
+		s.watermark.Store(4)
+		_ = s.Replace([]interface{}{eventWithRV("9"), eventWithRV("6"), eventWithRV("3")}, "9")
+		require.Len(t, *captured, 2)
+		assert.ElementsMatch(t, []string{"9", "6"}, []string{(*captured)[0].ResourceVersion, (*captured)[1].ResourceVersion})
+	})
+
+	t.Run("relist forwards only events past the watermark and advances to listRV", func(t *testing.T) {
 		s, captured := makeStore()
 		require.NoError(t, s.Replace([]interface{}{}, "5")) // cold seed; watermark=5
-		ev := eventWithRV("10")
-		// listRV "3" is below the watermark after forwarding ev; it must not drop.
-		require.NoError(t, s.Replace([]interface{}{ev, eventWithRV("3")}, "3"))
+		// Relist at RV 10 with an already-seen event (5) and a new one (8).
+		require.NoError(t, s.Replace([]interface{}{eventWithRV("5"), eventWithRV("8")}, "10"))
 		require.Len(t, *captured, 1)
-		assert.Same(t, ev, (*captured)[0])
-		assert.Equal(t, uint64(10), s.watermark.Load())
+		assert.Equal(t, "8", (*captured)[0].ResourceVersion) // 5 <= threshold skipped, 8 forwarded
+		assert.Equal(t, uint64(10), s.watermark.Load())      // advanced once to listRV
 	})
 }
 

--- a/pkg/util/kubernetes/apiserver/event_reflector_store_test.go
+++ b/pkg/util/kubernetes/apiserver/event_reflector_store_test.go
@@ -111,15 +111,14 @@ func TestDelete(t *testing.T) {
 	assert.Empty(t, *captured)
 }
 
-// TestReplace verifies cold-start seeding suppresses forwarding, a seeded watermark
-// (restart) forwards the backlog past it regardless of list order, and relists
-// advance the watermark to the collection resourceVersion.
+// TestReplace verifies the store forwards events past a fixed threshold and advances the watermark to the collection resourceVersion.
 func TestReplace(t *testing.T) {
-	t.Run("cold start seeds watermark from listRV and skips all events", func(t *testing.T) {
+	t.Run("cold start forwards all events and seeds watermark from listRV", func(t *testing.T) {
 		s, captured := makeStore()
-		require.NoError(t, s.Replace([]interface{}{eventWithRV("5")}, "10"))
-		assert.Empty(t, *captured)
-		assert.True(t, s.seeded)
+		ev := eventWithRV("5")
+		require.NoError(t, s.Replace([]interface{}{ev}, "10"))
+		require.Len(t, *captured, 1)
+		assert.Same(t, ev, (*captured)[0])
 		assert.Equal(t, uint64(10), s.watermark.Load())
 	})
 
@@ -132,10 +131,9 @@ func TestReplace(t *testing.T) {
 	})
 
 	t.Run("unordered list forwards every event past the threshold", func(t *testing.T) {
-		// Regression: unordered list [9, 6, 3] with watermark 4 — both 9 and 6 must forward.
 		s, captured := makeStore()
 		s.watermark.Store(4)
-		_ = s.Replace([]interface{}{eventWithRV("9"), eventWithRV("6"), eventWithRV("3")}, "9")
+		require.NoError(t, s.Replace([]interface{}{eventWithRV("9"), eventWithRV("6"), eventWithRV("3")}, "9"))
 		require.Len(t, *captured, 2)
 		assert.ElementsMatch(t, []string{"9", "6"}, []string{(*captured)[0].ResourceVersion, (*captured)[1].ResourceVersion})
 	})

--- a/releasenotes/notes/kubernetes-reflector-event-collection-419bc420400e18b2.yaml
+++ b/releasenotes/notes/kubernetes-reflector-event-collection-419bc420400e18b2.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add a new reflector-based Kubernetes event collection path, enabled via ``use_new_event_collection``.


### PR DESCRIPTION
### What does this PR do?
This PR adds a new method of Kubernetes event collection (`event_collector.go`) to the agent, alongside the existing one (`events.go`). The new approach to event collection is:
- On the first successful connection to the API server in the `kubernetes_apiserver` check, we start an event reflector which lists then watches events from the API server
- We use the reflector abstraction directly rather than informers because we use a custom cache layer (`event_reflector_store.go`) which does not actually reflect Events into local memory, but instead buffers them in a Go channel (size set by check config `event_collection_buffer_size` or defaults to 10,000 events) until the `kubernetes_apiserver` check drains the channel (i.e., gets the raw K8s events to process them into Datadog events)
- We apply the same watermarking technique from `events.go` to de-duplicate events
- The new event collection method is disabled by default, can be turned on with the check config `use_new_event_collection`
 
### Motivation
https://datadoghq.atlassian.net/browse/CONTINT-5401

### Describe how you validated your changes
Setup a differential test harness to run both collection methods at the same time against the same event stream and saw that the new collector never dropped events, while the old collector occasionally could be missing ~100-150. In detail:
- two kind clusters run the same agent image + fakeintake to capture Datadog events from the cluster agent. only difference is `use_new_event_collection: true/false`
- a generator creates events against both API servers simultaneously 
- the checker checks both fakeintakes to compare delivers events against the input stream to flag to flag any missing/duplicate events

Also added united tests.

### Additional Notes
