### PR TITLE
fix(procmgr): move C++ lib from `deps` to `link_deps`

### DIFF
--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -38,7 +38,6 @@ _LIB_SRCS = glob(
 )
 
 _LIB_DEPS = [
-    ":cpp_stdlib",
     "//pkg/proto/datadog/procmgr:procmgr_rust_proto",
     "@crates//:anyhow",
     "@crates//:hyper-util",
@@ -70,6 +69,7 @@ rust_library(
     srcs = _LIB_SRCS,
     crate_name = "dd_procmgrd",
     edition = "2024",
+    link_deps = [":cpp_stdlib"],
     rustc_flags = ["--cfg=bazel"],
     target_compatible_with = _LINUX_OR_WINDOWS,
     visibility = ["//visibility:public"],
@@ -83,6 +83,7 @@ rust_library(
     crate_features = ["test-helpers"],
     crate_name = "dd_procmgrd",
     edition = "2024",
+    link_deps = [":cpp_stdlib"],
     rustc_flags = ["--cfg=bazel"],
     target_compatible_with = _LINUX_OR_WINDOWS,
     deps = _LIB_DEPS,


### PR DESCRIPTION
### What does this PR do?
Move `:cpp_stdlib` out of the shared `_LIB_DEPS` and into `link_deps` on the `dd-procmgrd-lib` and `dd-procmgrd-lib-testhelpers` targets.

### Motivation
`rules_rust` 0.71.0 deprecates C++ libraries in a Rust target's `deps` and adds `link_deps` for manual FFI linkage:
- bazelbuild/rules_rust#4024.

Left in `deps`, `:cpp_stdlib` makes the build emit a deprecation warning per target:
```
WARNING: Target @@//pkg/procmgr/rust:cpp_stdlib in 'deps' of @@//pkg/procmgr/rust:dd-procmgrd-lib-testhelpers is a C++ library. Only Rust targets are allowed in 'deps'. Please use 'link_deps' for manual FFI linkage. Support for C++ libraries in 'deps' is deprecated and will be removed in a future release.
WARNING: Target @@//pkg/procmgr/rust:cpp_stdlib in 'deps' of @@//pkg/procmgr/rust:dd-procmgrd-lib is a C++ library. Only Rust targets are allowed in 'deps'. Please use 'link_deps' for manual FFI linkage. Support for C++ libraries in 'deps' is deprecated and will be removed in a future release.
```

### Describe how you validated your changes
`bazel build //pkg/procmgr/rust:dd-procmgrd` links cleanly with no `cpp_stdlib` deprecation warning, confirming the `-lstdc++` linkage still propagates to the binary through `link_deps`.

### Additional Notes
Will anyway ease the transition to `rules_rs`, backed by `rules_rust`.