### PR TITLE
[CWS] Report rule expression syntax errors as syntax_error

### DIFF
--- a/pkg/security/rules/monitor/policy_monitor_test.go
+++ b/pkg/security/rules/monitor/policy_monitor_test.go
@@ -33,6 +33,7 @@ type testCase struct {
 	name                 string
 	policies             []*testPolicy
 	expectedPolicyStates []*PolicyState
+	model                *model.Model
 }
 
 func TestPolicyMonitorPolicyState(t *testing.T) {
@@ -1534,6 +1535,54 @@ func TestPolicyMonitorPolicyState(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "rule with disabled event type",
+			model: &model.Model{
+				ExtraValidateFieldFnc: func(field eval.Field, _ eval.FieldValue) error {
+					if field == "exec.file.path" {
+						return rules.ErrEventTypeNotEnabled
+					}
+					return nil
+				},
+			},
+			policies: []*testPolicy{
+				{
+					info: rules.PolicyInfo{
+						Name:         "Policy A",
+						Source:       "test",
+						InternalType: rules.CustomPolicyType,
+						Version:      "0.0.1",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:         "rule_a",
+								Expression: `exec.file.path == "/etc/foo/bar"`,
+							},
+						},
+					},
+				},
+			},
+			expectedPolicyStates: []*PolicyState{
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:    "Policy A",
+						Version: "0.0.1",
+						Source:  "test",
+					},
+					Status: PolicyStatusFullyRejected,
+					Rules: []*RuleState{
+						{
+							ID:         "rule_a",
+							Expression: `exec.file.path == "/etc/foo/bar"`,
+							Status:     "event_type_disabled",
+							Message:    "rule compilation error: event type not enabled",
+							Version:    "0.0.1",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	if runtime.GOOS == "linux" {
@@ -1678,7 +1727,11 @@ func TestPolicyMonitorPolicyState(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			rs := rules.NewRuleSet(&model.Model{}, eventCtor, ruleOpts, evalOpts)
+			m := tc.model
+			if m == nil {
+				m = &model.Model{}
+			}
+			rs := rules.NewRuleSet(m, eventCtor, ruleOpts, evalOpts)
 			loader := rules.NewPolicyLoader(newTestPolicyProvider(tc.policies...))
 			filteredRules, errs := rs.LoadPolicies(loader, rules.PolicyLoaderOpts{MacroFilters: macroFilters, RuleFilters: ruleFilters})
 			policyStates := NewPoliciesState(rs, filteredRules, errs, false)

--- a/pkg/security/rules/monitor/policy_monitor_test.go
+++ b/pkg/security/rules/monitor/policy_monitor_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	gocmp "github.com/google/go-cmp/cmp"
@@ -1466,6 +1467,68 @@ func TestPolicyMonitorPolicyState(t *testing.T) {
 							ID:         "rule_a",
 							Expression: `exec.file.path == "/etc/foo/bar"`,
 							Status:     "loaded",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rule with variable type error",
+			policies: []*testPolicy{
+				{
+					info: rules.PolicyInfo{
+						Name:         "Policy A",
+						Source:       "test",
+						InternalType: rules.CustomPolicyType,
+						Version:      "0.0.1",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:         "rule_a",
+								Expression: `exec.file.path == "/etc/foo/bar" && exec.file.path != ${ratelimiter_var}`,
+								Actions: []*rules.ActionDefinition{
+									{
+										Set: &rules.SetDefinition{
+											Name:         "ratelimiter_var",
+											Field:        "exec.file.path",
+											DefaultValue: "",
+											TTL:          &rules.HumanReadableDuration{Duration: 10 * time.Minute},
+											Append:       true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPolicyStates: []*PolicyState{
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:    "Policy A",
+						Version: "0.0.1",
+						Source:  "test",
+					},
+					Status: PolicyStatusFullyRejected,
+					Rules: []*RuleState{
+						{
+							ID:         "rule_a",
+							Expression: `exec.file.path == "/etc/foo/bar" && exec.file.path != ${ratelimiter_var}`,
+							Status:     "syntax_error",
+							Message:    "rule syntax error: string expected: 1:55: exec.file.path == \"/etc/foo/bar\" && exec.file.path != ${ratelimiter_var}\n                                                      ^",
+							Version:    "0.0.1",
+							Actions: []RuleAction{
+								{
+									Set: &RuleSetAction{
+										Name:         "ratelimiter_var",
+										Field:        "exec.file.path",
+										DefaultValue: "",
+										TTL:          "10m0s",
+										Append:       true,
+									},
+								},
+							},
 						},
 					},
 				},

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -120,6 +120,9 @@ const (
 
 // Type return the type of the error
 func (e *ErrRuleLoad) Type() RuleLoadErrType {
+	// use errors.Is/errors.As so that the type is correctly resolved even when
+	// the underlying error is wrapped (e.g. errors raised during the
+	// AST-to-evaluator conversion are returned wrapped by fmt.Errorf).
 	switch {
 	case errors.Is(e.Err, ErrRuleAgentVersion), errors.Is(e.Err, ErrRuleAgentFilter):
 		return AgentVersionErrType

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -120,17 +120,20 @@ const (
 
 // Type return the type of the error
 func (e *ErrRuleLoad) Type() RuleLoadErrType {
-	switch e.Err {
-	case ErrRuleAgentVersion:
+	switch {
+	case errors.Is(e.Err, ErrRuleAgentVersion), errors.Is(e.Err, ErrRuleAgentFilter):
 		return AgentVersionErrType
-	case ErrRuleAgentFilter:
-		return AgentVersionErrType
-	case ErrEventTypeNotEnabled:
+	case errors.Is(e.Err, ErrEventTypeNotEnabled):
 		return EventTypeNotEnabledErrType
 	}
 
-	switch e.Err.(type) {
-	case *ErrRuleSyntax, *ErrFieldNotAvailable:
+	var (
+		errRuleSyntax        *ErrRuleSyntax
+		errFieldNotAvailable *ErrFieldNotAvailable
+		errRuleParse         *eval.ErrRuleParse
+	)
+	switch {
+	case errors.As(e.Err, &errRuleSyntax), errors.As(e.Err, &errFieldNotAvailable), errors.As(e.Err, &errRuleParse):
 		return SyntaxErrType
 	}
 


### PR DESCRIPTION
### What does this PR do?

- Classifies rule expression syntax errors as `syntax_error` in `ruleset_loaded` events, instead of a generic `error`
- Classifies disabled event type rule errors as `event_type_disabled` in `ruleset_loaded` events, instead of a generic `error`

### Motivation

Syntax and Disabled event type errors raised while compiling a rule expression are returned wrapped, but the policy-state classifier matched error types directly and missed them, falling back to a generic `error`. This misreported the error type in ruleset_loaded/heartbeat events

### Describe how you validated your changes

- Added a unit test for a rule with a variable type error
- Added a unit test for a rule with disabled event type error

### Additional Notes
