### PR TITLE
fix(shared-library-check): append the instance index at the end of the config source

### DIFF
--- a/pkg/collector/sharedlibrary/sharedlibraryimpl/loader.go
+++ b/pkg/collector/sharedlibrary/sharedlibraryimpl/loader.go
@@ -44,7 +44,7 @@ func (*CheckLoader) String() string {
 }
 
 // Load returns a Shared Library check
-func (sl *CheckLoader) Load(senderManager sender.SenderManager, config integration.Config, instance integration.Data, _ int) (check.Check, error) {
+func (sl *CheckLoader) Load(senderManager sender.SenderManager, config integration.Config, instance integration.Data, instanceIndex int) (check.Check, error) {
 	// we need to dynamically compute the shared libraries path because their extensions are platform dependent
 	// we could also have collisions with existing shared libraries
 	libPath, err := sl.loader.ComputeLibraryPath(config.Name)
@@ -67,7 +67,11 @@ func (sl *CheckLoader) Load(senderManager sender.SenderManager, config integrati
 	configDigest := config.FastDigest()
 
 	// pass the configuration to the check
-	if err := c.Configure(senderManager, configDigest, instance, config.InitConfig, config.Source, config.Provider); err != nil {
+	configSource := config.Source
+	if instanceIndex >= 0 {
+		configSource = fmt.Sprintf("%s[%d]", configSource, instanceIndex)
+	}
+	if err := c.Configure(senderManager, configDigest, instance, config.InitConfig, configSource, config.Provider); err != nil {
 		return c, err
 	}
 

--- a/pkg/collector/sharedlibrary/sharedlibraryimpl/loader_test.go
+++ b/pkg/collector/sharedlibrary/sharedlibraryimpl/loader_test.go
@@ -45,7 +45,7 @@ func TestLoad_FakeCheck(t *testing.T) {
 
 	assert.Equal(t, "fake_check", check.(*Check).name)
 	assert.Equal(t, "noop_version", check.(*Check).version)
-	assert.Equal(t, "fake_check:/path/to/conf/fake_check.yaml", check.(*Check).source)
+	assert.Equal(t, "fake_check:/path/to/conf/fake_check.yaml[1]", check.(*Check).source)
 
 	// Remove check finalizer that may trigger race condition while testing
 	runtime.SetFinalizer(check, nil)


### PR DESCRIPTION
### What does this PR do?

Adds the instance index at the end of the check config source.

Config sources like:

```fake_check:/path/to/conf/fake_check.yaml```

Will now look like:

```fake_check:/path/to/conf/fake_check.yaml[1]```

### Motivation

Keep the same behavior as the other loaders

### Describe how you validated your changes

Unit tests

### Additional Notes
