### PR TITLE
[CONTP-1787] feat(instrumentation): Support dedicated logs handler independent from the checks section

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -209,7 +209,7 @@ require (
 	github.com/coreos/go-semver v0.3.1
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/cri-o/ocicni v0.5.0
-	github.com/cyphar/filepath-securejoin v0.7.0
+	github.com/cyphar/filepath-securejoin v0.6.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.6.0
 	github.com/docker/docker v28.5.2+incompatible // indirect
@@ -294,14 +294,14 @@ require (
 	github.com/prometheus/common v0.69.0
 	github.com/prometheus/procfs v0.20.1
 	github.com/redis/go-redis/v9 v9.21.0
-	github.com/rickar/props v1.1.0
+	github.com/rickar/props v1.0.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/safchain/baloum v0.0.0-20260120132056-b70fa9c29846
 	github.com/safchain/ethtool v0.7.0
 	github.com/samber/lo v1.53.0
 	github.com/shirou/gopsutil/v4 v4.26.5
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
-	github.com/sijms/go-ora/v2 v2.9.0
+	github.com/sijms/go-ora/v2 v2.8.24
 	github.com/sirupsen/logrus v1.9.4
 	github.com/skydive-project/go-debouncer v1.0.1
 	github.com/smira/go-xz v0.1.0
@@ -333,7 +333,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4
 	go.etcd.io/bbolt v1.5.0
 	go.etcd.io/etcd/client/v3 v3.6.11 // indirect
-	go.mongodb.org/mongo-driver/v2 v2.7.0
+	go.mongodb.org/mongo-driver/v2 v2.5.0
 	go.opentelemetry.io/collector/component v1.61.0
 	go.opentelemetry.io/collector/component/componenttest v0.155.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.155.0
@@ -391,8 +391,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 	gopkg.in/zorkian/go-datadog-api.v2 v2.30.0
-	istio.io/api v1.30.2
-	istio.io/client-go v1.30.2
+	istio.io/api v1.30.1
+	istio.io/client-go v1.30.1
 	k8s.io/api v0.35.5
 	k8s.io/apiextensions-apiserver v0.35.5
 	k8s.io/apimachinery v0.35.6
@@ -424,7 +424,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	code.cloudfoundry.org/cfhttp/v2 v2.82.0 // indirect
 	code.cloudfoundry.org/tlsconfig v0.60.0 // indirect
-	cyphar.com/go-pathrs v0.2.5 // indirect
+	cyphar.com/go-pathrs v0.2.1 // indirect
 	dario.cat/mergo v1.0.2
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/AlekSi/pointer v1.2.0 // indirect
@@ -895,7 +895,6 @@ require (
 require (
 	code.cloudfoundry.org/bbs/models v0.0.0-20260618205254-dc4b9f8d5bc9
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
-	github.com/DataDog/datadog-agent/comp/core/configstreamconsumer/def v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.80.2
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def v0.61.0
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/mock v0.0.0-00010101000000-000000000000
@@ -931,7 +930,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.69.3
 	github.com/aymerick/raymond v2.0.2+incompatible
 	github.com/bazelbuild/rules_go v0.61.1
-	github.com/cenkalti/backoff/v6 v6.0.1
 	github.com/creack/pty v1.1.24
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/hashicorp/consul/api v1.34.3
@@ -946,7 +944,7 @@ require (
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.0
 	github.com/qri-io/jsonpointer v0.1.1
-	github.com/rabbitmq/amqp091-go v1.12.0
+	github.com/rabbitmq/amqp091-go v1.11.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	gitlab.com/gitlab-org/api/client-go v1.46.0
 	go.etcd.io/etcd/client/v2 v2.305.31
@@ -1239,7 +1237,6 @@ replace (
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/fx => ./comp/core/agenttelemetry/fx
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/impl => ./comp/core/agenttelemetry/impl
 	github.com/DataDog/datadog-agent/comp/core/config => ./comp/core/config
-	github.com/DataDog/datadog-agent/comp/core/configstreamconsumer/def => ./comp/core/configstreamconsumer/def
 	github.com/DataDog/datadog-agent/comp/core/configsync => ./comp/core/configsync
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth => ./comp/core/delegatedauth
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth/api/cloudauth/aws => ./comp/core/delegatedauth/api/cloudauth/aws

--- a/go.mod
+++ b/go.mod
@@ -163,7 +163,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.82.0-devel.0.20260624113434-509b872045c2
 	github.com/DataDog/datadog-agent/pkg/version v0.81.0-devel.0.20260603133502-a41610237dba
 	github.com/DataDog/datadog-go/v5 v5.8.3
-	github.com/DataDog/datadog-operator/api v0.0.0-20260626172128-45c4b00ac27b
+	github.com/DataDog/datadog-operator/api v0.0.0-20260626205451-dfafc0810597
 	github.com/DataDog/datadog-traceroute v1.0.17
 	github.com/DataDog/dd-trace-go/v2 v2.9.0
 	github.com/DataDog/ebpf-manager v0.7.18
@@ -209,7 +209,7 @@ require (
 	github.com/coreos/go-semver v0.3.1
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/cri-o/ocicni v0.5.0
-	github.com/cyphar/filepath-securejoin v0.6.1
+	github.com/cyphar/filepath-securejoin v0.7.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.6.0
 	github.com/docker/docker v28.5.2+incompatible // indirect
@@ -294,14 +294,14 @@ require (
 	github.com/prometheus/common v0.69.0
 	github.com/prometheus/procfs v0.20.1
 	github.com/redis/go-redis/v9 v9.21.0
-	github.com/rickar/props v1.0.0
+	github.com/rickar/props v1.1.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/safchain/baloum v0.0.0-20260120132056-b70fa9c29846
 	github.com/safchain/ethtool v0.7.0
 	github.com/samber/lo v1.53.0
 	github.com/shirou/gopsutil/v4 v4.26.5
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
-	github.com/sijms/go-ora/v2 v2.8.24
+	github.com/sijms/go-ora/v2 v2.9.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/skydive-project/go-debouncer v1.0.1
 	github.com/smira/go-xz v0.1.0
@@ -333,7 +333,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4
 	go.etcd.io/bbolt v1.5.0
 	go.etcd.io/etcd/client/v3 v3.6.11 // indirect
-	go.mongodb.org/mongo-driver/v2 v2.5.0
+	go.mongodb.org/mongo-driver/v2 v2.7.0
 	go.opentelemetry.io/collector/component v1.61.0
 	go.opentelemetry.io/collector/component/componenttest v0.155.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.155.0
@@ -391,8 +391,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 	gopkg.in/zorkian/go-datadog-api.v2 v2.30.0
-	istio.io/api v1.30.1
-	istio.io/client-go v1.30.1
+	istio.io/api v1.30.2
+	istio.io/client-go v1.30.2
 	k8s.io/api v0.35.5
 	k8s.io/apiextensions-apiserver v0.35.5
 	k8s.io/apimachinery v0.35.6
@@ -424,7 +424,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	code.cloudfoundry.org/cfhttp/v2 v2.82.0 // indirect
 	code.cloudfoundry.org/tlsconfig v0.60.0 // indirect
-	cyphar.com/go-pathrs v0.2.1 // indirect
+	cyphar.com/go-pathrs v0.2.5 // indirect
 	dario.cat/mergo v1.0.2
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/AlekSi/pointer v1.2.0 // indirect
@@ -895,6 +895,7 @@ require (
 require (
 	code.cloudfoundry.org/bbs/models v0.0.0-20260618205254-dc4b9f8d5bc9
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
+	github.com/DataDog/datadog-agent/comp/core/configstreamconsumer/def v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.80.2
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def v0.61.0
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/mock v0.0.0-00010101000000-000000000000
@@ -930,6 +931,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.69.3
 	github.com/aymerick/raymond v2.0.2+incompatible
 	github.com/bazelbuild/rules_go v0.61.1
+	github.com/cenkalti/backoff/v6 v6.0.1
 	github.com/creack/pty v1.1.24
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/hashicorp/consul/api v1.34.3
@@ -944,7 +946,7 @@ require (
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.0
 	github.com/qri-io/jsonpointer v0.1.1
-	github.com/rabbitmq/amqp091-go v1.11.0
+	github.com/rabbitmq/amqp091-go v1.12.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	gitlab.com/gitlab-org/api/client-go v1.46.0
 	go.etcd.io/etcd/client/v2 v2.305.31
@@ -1237,6 +1239,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/fx => ./comp/core/agenttelemetry/fx
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/impl => ./comp/core/agenttelemetry/impl
 	github.com/DataDog/datadog-agent/comp/core/config => ./comp/core/config
+	github.com/DataDog/datadog-agent/comp/core/configstreamconsumer/def => ./comp/core/configstreamconsumer/def
 	github.com/DataDog/datadog-agent/comp/core/configsync => ./comp/core/configsync
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth => ./comp/core/delegatedauth
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth/api/cloudauth/aws => ./comp/core/delegatedauth/api/cloudauth/aws

--- a/go.sum
+++ b/go.sum
@@ -2543,8 +2543,8 @@ github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dX
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSqGF5n0s=
 github.com/DataDog/datadog-go/v5 v5.8.3/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
-github.com/DataDog/datadog-operator/api v0.0.0-20260626172128-45c4b00ac27b h1:KDZ/qTEB7wjMDJe831bgglyTi4+kOzVAqWxdnQ6WN3Q=
-github.com/DataDog/datadog-operator/api v0.0.0-20260626172128-45c4b00ac27b/go.mod h1:sFOkv8MUOOjgCmbunaHsUlPzD0RVaQpGuzBAPOPCSmY=
+github.com/DataDog/datadog-operator/api v0.0.0-20260626205451-dfafc0810597 h1:ljwK4rFC1hW2DWC/kJBLnFIpTQmuXcda5zfVLhQSmew=
+github.com/DataDog/datadog-operator/api v0.0.0-20260626205451-dfafc0810597/go.mod h1:sFOkv8MUOOjgCmbunaHsUlPzD0RVaQpGuzBAPOPCSmY=
 github.com/DataDog/datadog-traceroute v1.0.17 h1:MyBJCb+pFLjN3tt0boZprYmyj4iegHmKzst5iWil/Dw=
 github.com/DataDog/datadog-traceroute v1.0.17/go.mod h1:gtDOEd1qCVGULNYdHULzFBbdDLJwpP+nJMKSXiuVi78=
 github.com/DataDog/dd-trace-go/v2 v2.9.0 h1:J/EsZ7nPqkf3Pa56AAre306ylYMhtzz6oylmchqc6JA=

--- a/pkg/clusteragent/instrumentation/handlers/BUILD.bazel
+++ b/pkg/clusteragent/instrumentation/handlers/BUILD.bazel
@@ -3,8 +3,9 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "handlers",
     srcs = [
-        "autodiscovery.go",
         "autodiscovery_utils.go",
+        "checks.go",
+        "logs.go",
         "registry.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation/handlers",
@@ -14,6 +15,7 @@ go_library(
         "//comp/core/autodiscovery/integration",
         "//comp/core/workloadfilter/def",
         "//pkg/clusteragent/instrumentation",
+        "//pkg/util/kubernetes",
         "//pkg/util/kubernetes/apiserver",
         "@com_github_datadog_datadog_operator_api//datadoghq/v1alpha1",
         "@io_k8s_api//autoscaling/v2:autoscaling",
@@ -24,7 +26,10 @@ go_library(
 
 go_test(
     name = "handlers_test",
-    srcs = ["autodiscovery_test.go"],
+    srcs = [
+        "checks_test.go",
+        "logs_test.go",
+    ],
     embed = [":handlers"],
     gotags = [
         "kubeapiserver",

--- a/pkg/clusteragent/instrumentation/handlers/checks.go
+++ b/pkg/clusteragent/instrumentation/handlers/checks.go
@@ -30,18 +30,18 @@ const (
 	autodiscoveryProvider    = "datadoginstrumentation"
 )
 
-// AutodiscoveryHandler translates DatadogInstrumentation check sections into
+// ChecksHandler translates DatadogInstrumentation check sections into
 // integration.Config entries. It supports both workload targets (Deployment,
 // DaemonSet, etc.) and Service targets, branching internally on the target kind.
-type AutodiscoveryHandler struct {
+type ChecksHandler struct {
 	checkStore           *CheckStore
 	templateStore        *ServiceCheckTemplateStore
 	serviceTargetEnabled bool
 }
 
-// NewAutodiscoveryHandler returns the Autodiscovery DatadogInstrumentation handler.
-func NewAutodiscoveryHandler(dep *Deps) *AutodiscoveryHandler {
-	return &AutodiscoveryHandler{
+// NewChecksHandler returns the checks DatadogInstrumentation handler.
+func NewChecksHandler(dep *Deps) *ChecksHandler {
+	return &ChecksHandler{
 		checkStore:           dep.CheckStore,
 		templateStore:        dep.ServiceCheckTemplateStore,
 		serviceTargetEnabled: apiserver.UseEndpointSlices(),
@@ -49,17 +49,17 @@ func NewAutodiscoveryHandler(dep *Deps) *AutodiscoveryHandler {
 }
 
 // Name returns the unique handler name.
-func (h *AutodiscoveryHandler) Name() string {
-	return "autodiscovery"
+func (h *ChecksHandler) Name() string {
+	return "checks"
 }
 
 // HasSection reports whether the CR contains Autodiscovery check configuration.
-func (h *AutodiscoveryHandler) HasSection(cr *datadoghq.DatadogInstrumentation) bool {
+func (h *ChecksHandler) HasSection(cr *datadoghq.DatadogInstrumentation) bool {
 	return cr != nil && len(cr.Spec.Config.Checks) > 0
 }
 
 // SupportsTarget returns whether Autodiscovery check delivery supports the target kind.
-func (h *AutodiscoveryHandler) SupportsTarget(ref autoscalingv2.CrossVersionObjectReference) bool {
+func (h *ChecksHandler) SupportsTarget(ref autoscalingv2.CrossVersionObjectReference) bool {
 	switch ref.Kind {
 	case "Deployment", "DaemonSet", "StatefulSet", "CronJob", "Job":
 		return true
@@ -73,7 +73,7 @@ func (h *AutodiscoveryHandler) SupportsTarget(ref autoscalingv2.CrossVersionObje
 }
 
 // Validate reports per-check validation errors against spec.config.checks.
-func (h *AutodiscoveryHandler) Validate(cr *datadoghq.DatadogInstrumentation) []instrumentation.ValidationError {
+func (h *ChecksHandler) Validate(cr *datadoghq.DatadogInstrumentation) []instrumentation.ValidationError {
 	if cr == nil {
 		return nil
 	}
@@ -82,8 +82,8 @@ func (h *AutodiscoveryHandler) Validate(cr *datadoghq.DatadogInstrumentation) []
 		if strings.TrimSpace(check.Integration) == "" {
 			errs = append(errs, h.checkValidationError(i, "integration", "InvalidIntegration", "integration name must not be empty"))
 		}
-		if len(check.Instances) == 0 && len(check.Logs) == 0 {
-			errs = append(errs, h.checkValidationError(i, "instances", "InvalidInstances", "at least one instance or log config is required"))
+		if len(check.Instances) == 0 {
+			errs = append(errs, h.checkValidationError(i, "instances", "InvalidInstances", "at least one instance is required"))
 		}
 
 		if !isService(cr) && !hasContainerName(check) {
@@ -93,7 +93,7 @@ func (h *AutodiscoveryHandler) Validate(cr *datadoghq.DatadogInstrumentation) []
 	return errs
 }
 
-func (h *AutodiscoveryHandler) checkValidationError(index int, field, reason, message string) instrumentation.ValidationError {
+func (h *ChecksHandler) checkValidationError(index int, field, reason, message string) instrumentation.ValidationError {
 	fieldPath := fmt.Sprintf("spec.config.checks[%d]", index)
 	if field != "" {
 		fieldPath += "." + field
@@ -110,7 +110,7 @@ func (h *AutodiscoveryHandler) checkValidationError(index int, field, reason, me
 // Handle translates check configs on Create/Update, removes them on Delete,
 // and reports a ChecksReady status. For Service targets the configs are stored
 // as templates; for workload targets they are stored directly.
-func (h *AutodiscoveryHandler) Handle(_ context.Context, event instrumentation.EventType, cr *datadoghq.DatadogInstrumentation) (instrumentation.HandlerStatus, error) {
+func (h *ChecksHandler) Handle(_ context.Context, event instrumentation.EventType, cr *datadoghq.DatadogInstrumentation) (instrumentation.HandlerStatus, error) {
 	if cr == nil {
 		return instrumentation.HandlerStatus{
 			Type:    checksReadyConditionType,
@@ -225,11 +225,7 @@ func translateCheckFields(check datadoghq.DatadogInstrumentationCheckConfig) (in
 		instances = append(instances, data)
 	}
 
-	logsConfig, err := marshalLogs(check.Logs)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("logs: %w", err)
-	}
-	return initConfig, instances, logsConfig, nil
+	return initConfig, instances, nil, nil
 }
 
 func rawExtensionToData(raw runtime.RawExtension) (integration.Data, error) {

--- a/pkg/clusteragent/instrumentation/handlers/checks.go
+++ b/pkg/clusteragent/instrumentation/handlers/checks.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -61,9 +62,9 @@ func (h *ChecksHandler) HasSection(cr *datadoghq.DatadogInstrumentation) bool {
 // SupportsTarget returns whether Autodiscovery check delivery supports the target kind.
 func (h *ChecksHandler) SupportsTarget(ref autoscalingv2.CrossVersionObjectReference) bool {
 	switch ref.Kind {
-	case "Deployment", "DaemonSet", "StatefulSet", "CronJob", "Job":
+	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind, kubernetes.CronJobKind, kubernetes.JobKind:
 		return true
-	case "Service":
+	case kubernetes.ServiceKind:
 		// Service target support is backed by endpoint slices CR provider. If Endpointslice collection
 		// is disabled then service targets can't be supported.
 		return h.serviceTargetEnabled
@@ -172,7 +173,7 @@ func (h *ChecksHandler) Handle(_ context.Context, event instrumentation.EventTyp
 }
 
 func translateWorkloadCheck(cr *datadoghq.DatadogInstrumentation, check datadoghq.DatadogInstrumentationCheckConfig) (integration.Config, error) {
-	initConfig, instances, logsConfig, err := translateCheckFields(check)
+	initConfig, instances, err := translateCheckFields(check)
 	if err != nil {
 		return integration.Config{}, err
 	}
@@ -187,14 +188,13 @@ func translateWorkloadCheck(cr *datadoghq.DatadogInstrumentation, check datadogh
 		ADIdentifiers: adIdentifiers,
 		InitConfig:    initConfig,
 		Instances:     instances,
-		LogsConfig:    logsConfig,
-		CELSelector:   buildCELSelector(cr.Spec.TargetRef, cr.Namespace),
+		CELSelector:   rootOwnerCELFilter(cr.Spec.TargetRef, cr.Namespace),
 		Source:        fmt.Sprintf("%s:%s/%s", autodiscoveryProvider, cr.Namespace, cr.Name),
 	}, nil
 }
 
 func translateServiceCheck(cr *datadoghq.DatadogInstrumentation, check datadoghq.DatadogInstrumentationCheckConfig) (integration.Config, error) {
-	initConfig, instances, logsConfig, err := translateCheckFields(check)
+	initConfig, instances, err := translateCheckFields(check)
 	if err != nil {
 		return integration.Config{}, err
 	}
@@ -202,15 +202,14 @@ func translateServiceCheck(cr *datadoghq.DatadogInstrumentation, check datadoghq
 		Name:       check.Integration,
 		InitConfig: initConfig,
 		Instances:  instances,
-		LogsConfig: logsConfig,
 		Source:     fmt.Sprintf("%s:%s/%s", autodiscoveryProvider, cr.Namespace, cr.Name),
 	}, nil
 }
 
-func translateCheckFields(check datadoghq.DatadogInstrumentationCheckConfig) (integration.Data, []integration.Data, integration.Data, error) {
+func translateCheckFields(check datadoghq.DatadogInstrumentationCheckConfig) (integration.Data, []integration.Data, error) {
 	initConfig, err := rawExtensionToData(check.InitConfig)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("init_config: %w", err)
+		return nil, nil, fmt.Errorf("init_config: %w", err)
 	}
 	if len(initConfig) == 0 {
 		initConfig = integration.Data("{}")
@@ -220,12 +219,12 @@ func translateCheckFields(check datadoghq.DatadogInstrumentationCheckConfig) (in
 	for j, raw := range check.Instances {
 		data, err := rawExtensionToData(raw)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("instances[%d]: %w", j, err)
+			return nil, nil, fmt.Errorf("instances[%d]: %w", j, err)
 		}
 		instances = append(instances, data)
 	}
 
-	return initConfig, instances, nil, nil
+	return initConfig, instances, nil
 }
 
 func rawExtensionToData(raw runtime.RawExtension) (integration.Data, error) {
@@ -242,18 +241,7 @@ func rawExtensionToData(raw runtime.RawExtension) (integration.Data, error) {
 	return b, nil
 }
 
-func marshalLogs(logs []datadoghq.DatadogInstrumentationLogConfig) (integration.Data, error) {
-	if len(logs) == 0 {
-		return nil, nil
-	}
-	b, err := json.Marshal(logs)
-	if err != nil {
-		return nil, err
-	}
-	return b, nil
-}
-
-func buildCELSelector(ref autoscalingv2.CrossVersionObjectReference, namespace string) workloadfilter.Rules {
+func rootOwnerCELFilter(ref autoscalingv2.CrossVersionObjectReference, namespace string) workloadfilter.Rules {
 	expr := fmt.Sprintf(
 		`container.pod.rootowner.kind == %q && container.pod.rootowner.name == %q && container.pod.namespace == %q && container.image.reference != ""`,
 		ref.Kind, ref.Name, namespace,

--- a/pkg/clusteragent/instrumentation/handlers/checks_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/checks_test.go
@@ -466,12 +466,11 @@ func TestTranslateCheck(t *testing.T) {
 			for i, substr := range tt.instanceContains {
 				assert.Contains(t, string(configs[0].Instances[i]), substr)
 			}
-			assert.Nil(t, configs[0].LogsConfig)
 		})
 	}
 }
 
-func TestBuildCELSelector(t *testing.T) {
+func TestRootOwnerCELFilter(t *testing.T) {
 	tests := []struct {
 		name      string
 		kind      string
@@ -515,7 +514,7 @@ func TestBuildCELSelector(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ref := autoscalingv2.CrossVersionObjectReference{Kind: tt.kind, Name: tt.target}
-			rules := buildCELSelector(ref, tt.namespace)
+			rules := rootOwnerCELFilter(ref, tt.namespace)
 			require.Len(t, rules.Containers, 1)
 			for _, substr := range tt.contains {
 				assert.Contains(t, rules.Containers[0], substr)

--- a/pkg/clusteragent/instrumentation/handlers/checks_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/checks_test.go
@@ -38,10 +38,10 @@ func (s *ServiceCheckTemplateStore) templatesForService(namespace, name string) 
 	return out
 }
 
-func newHandler() (*AutodiscoveryHandler, *CheckStore, *ServiceCheckTemplateStore) {
+func newHandler() (*ChecksHandler, *CheckStore, *ServiceCheckTemplateStore) {
 	cs := NewCheckStore()
 	ts := NewServiceCheckTemplateStore()
-	h := &AutodiscoveryHandler{
+	h := &ChecksHandler{
 		checkStore:           cs,
 		templateStore:        ts,
 		serviceTargetEnabled: true,
@@ -195,7 +195,7 @@ func TestValidate(t *testing.T) {
 			expectField:    "spec.config.checks[0].integration",
 		},
 		{
-			name: "no instances or logs",
+			name: "no instances",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
 					Integration:   "redisdb",
@@ -205,17 +205,6 @@ func TestValidate(t *testing.T) {
 			}),
 			expectErrCount: 1,
 			expectField:    "spec.config.checks[0].instances",
-		},
-		{
-			name: "logs only is valid",
-			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
-				{
-					Integration:   "custom",
-					ContainerName: "app",
-					Logs:          []datadoghq.DatadogInstrumentationLogConfig{{Type: "tcp"}},
-				},
-			}),
-			expectErrCount: 0,
 		},
 		{
 			name: "no container name for workload",
@@ -414,7 +403,6 @@ func TestServiceCheckTemplateStore_NotifyOnChange(t *testing.T) {
 }
 
 func TestTranslateCheck(t *testing.T) {
-	port := int32(10514)
 	tests := []struct {
 		name             string
 		check            datadoghq.DatadogInstrumentationCheckConfig
@@ -422,8 +410,6 @@ func TestTranslateCheck(t *testing.T) {
 		expectedInstLen  int
 		expectedADIDs    []string
 		instanceContains []string
-		logsNil          bool
-		logsContains     string
 	}{
 		{
 			name: "empty init config defaults to {}",
@@ -435,7 +421,6 @@ func TestTranslateCheck(t *testing.T) {
 			expectedInit:    "{}",
 			expectedInstLen: 1,
 			expectedADIDs:   []string{adtypes.KubeContainerNameIdentifier("app")},
-			logsNil:         true,
 		},
 		{
 			name: "provided init config is preserved",
@@ -448,30 +433,21 @@ func TestTranslateCheck(t *testing.T) {
 			expectedInit:    `{"service":"myservice"}`,
 			expectedInstLen: 1,
 			expectedADIDs:   []string{adtypes.KubeContainerNameIdentifier("app")},
-			logsNil:         true,
 		},
 		{
-			name: "logs config is translated",
+			name: "multiple instances are preserved",
 			check: datadoghq.DatadogInstrumentationCheckConfig{
-				Integration:   "custom",
+				Integration:   "http_check",
 				ContainerName: "app",
-				Instances:     []runtime.RawExtension{{Raw: []byte(`{"key":"val"}`)}},
-				Logs:          []datadoghq.DatadogInstrumentationLogConfig{{Type: "tcp", Port: &port}},
+				Instances: []runtime.RawExtension{
+					{Raw: []byte(`{"url":"http://host1"}`)},
+					{Raw: []byte(`{"url":"http://host2"}`)},
+				},
 			},
-			expectedInit:    "{}",
-			expectedInstLen: 1,
-			expectedADIDs:   []string{adtypes.KubeContainerNameIdentifier("app")},
-			logsContains:    `"type":"tcp"`,
-		},
-		{
-			name: "no logs returns nil logs config",
-			check: datadoghq.DatadogInstrumentationCheckConfig{
-				Integration: "redisdb",
-				Instances:   []runtime.RawExtension{{Raw: []byte(`{"host":"localhost"}`)}},
-			},
-			expectedInit:    "{}",
-			expectedInstLen: 1,
-			logsNil:         true,
+			expectedInit:     "{}",
+			expectedInstLen:  2,
+			expectedADIDs:    []string{adtypes.KubeContainerNameIdentifier("app")},
+			instanceContains: []string{"host1", "host2"},
 		},
 	}
 	for _, tt := range tests {
@@ -490,11 +466,7 @@ func TestTranslateCheck(t *testing.T) {
 			for i, substr := range tt.instanceContains {
 				assert.Contains(t, string(configs[0].Instances[i]), substr)
 			}
-			if tt.logsNil {
-				assert.Nil(t, configs[0].LogsConfig)
-			} else {
-				assert.Contains(t, string(configs[0].LogsConfig), tt.logsContains)
-			}
+			assert.Nil(t, configs[0].LogsConfig)
 		})
 	}
 }

--- a/pkg/clusteragent/instrumentation/handlers/logs.go
+++ b/pkg/clusteragent/instrumentation/handlers/logs.go
@@ -9,6 +9,8 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -139,17 +141,19 @@ func (h *LogsHandler) Handle(_ context.Context, event instrumentation.EventType,
 func translateWorkloadLog(cr *datadoghq.DatadogInstrumentation, logConfig datadoghq.DatadogInstrumentationLogConfig) (integration.Config, error) {
 	containerName := strings.TrimSpace(logConfig.ContainerName)
 	if containerName == "" {
-		return integration.Config{}, fmt.Errorf("container name must not be empty")
+		return integration.Config{}, errors.New("container name must not be empty")
 	}
-	logsConfig, err := marshalLogs([]datadoghq.DatadogInstrumentationLogFields{logConfig.DatadogInstrumentationLogFields})
+
+	config, err := json.Marshal([]datadoghq.DatadogInstrumentationLogFields{logConfig.DatadogInstrumentationLogFields})
 	if err != nil {
 		return integration.Config{}, err
 	}
+
 	return integration.Config{
 		Name:          logsCheckName,
 		ADIdentifiers: []string{adtypes.KubeContainerNameIdentifier(containerName)},
-		LogsConfig:    logsConfig,
-		CELSelector:   buildCELSelector(cr.Spec.TargetRef, cr.Namespace),
+		LogsConfig:    config,
+		CELSelector:   rootOwnerCELFilter(cr.Spec.TargetRef, cr.Namespace),
 		Source:        fmt.Sprintf("%s:%s/%s", autodiscoveryProvider, cr.Namespace, cr.Name),
 	}, nil
 }

--- a/pkg/clusteragent/instrumentation/handlers/logs.go
+++ b/pkg/clusteragent/instrumentation/handlers/logs.go
@@ -1,0 +1,159 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	adtypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+)
+
+const (
+	logsReadyConditionType = "LogsReady"
+	logsCheckName          = "logs"
+)
+
+// LogsHandler translates DatadogInstrumentation log sections into logs-only
+// integration.Config entries stored in the shared check store.
+type LogsHandler struct {
+	checkStore *CheckStore
+}
+
+// NewLogsHandler returns the logs DatadogInstrumentation handler.
+func NewLogsHandler(dep *Deps) *LogsHandler {
+	return &LogsHandler{
+		checkStore: dep.CheckStore,
+	}
+}
+
+// Name returns the unique handler name.
+func (h *LogsHandler) Name() string {
+	return "logs"
+}
+
+// HasSection reports whether the CR contains log configuration.
+func (h *LogsHandler) HasSection(cr *datadoghq.DatadogInstrumentation) bool {
+	return cr != nil && len(cr.Spec.Config.Logs) > 0
+}
+
+// SupportsTarget returns whether log delivery supports the target kind.
+func (h *LogsHandler) SupportsTarget(ref autoscalingv2.CrossVersionObjectReference) bool {
+	switch ref.Kind {
+	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind, kubernetes.CronJobKind, kubernetes.JobKind:
+		return true
+	default:
+		return false
+	}
+}
+
+// Validate reports per-log validation errors against spec.config.logs.
+func (h *LogsHandler) Validate(cr *datadoghq.DatadogInstrumentation) []instrumentation.ValidationError {
+	if cr == nil {
+		return nil
+	}
+	var errs []instrumentation.ValidationError
+	for i, logConfig := range cr.Spec.Config.Logs {
+		if strings.TrimSpace(logConfig.ContainerName) == "" {
+			errs = append(errs, h.logValidationError(i, "containerName", "InvalidContainerName", "container name must not be empty"))
+		}
+	}
+	return errs
+}
+
+func (h *LogsHandler) logValidationError(index int, field, reason, message string) instrumentation.ValidationError {
+	fieldPath := fmt.Sprintf("spec.config.logs[%d]", index)
+	if field != "" {
+		fieldPath += "." + field
+	}
+	return instrumentation.ValidationError{
+		Type:        logsReadyConditionType,
+		Reason:      reason,
+		Message:     message,
+		Field:       fieldPath,
+		HandlerName: h.Name(),
+	}
+}
+
+// Handle translates log configs on Create/Update, removes them on Delete,
+// and reports a LogsReady status.
+func (h *LogsHandler) Handle(_ context.Context, event instrumentation.EventType, cr *datadoghq.DatadogInstrumentation) (instrumentation.HandlerStatus, error) {
+	if cr == nil {
+		return instrumentation.HandlerStatus{
+			Type:    logsReadyConditionType,
+			Status:  metav1.ConditionUnknown,
+			Reason:  "MissingResource",
+			Message: "DatadogInstrumentation resource is nil",
+		}, nil
+	}
+
+	key := logsStoreKey(cr.Namespace + "/" + cr.Name)
+
+	if event == instrumentation.EventDelete {
+		h.checkStore.deleteConfigs(key)
+		return instrumentation.HandlerStatus{
+			Type:    logsReadyConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Deleted",
+			Message: fmt.Sprintf("logs removed for %s/%s", cr.Spec.TargetRef.Kind, cr.Spec.TargetRef.Name),
+		}, nil
+	}
+
+	configs := make([]integration.Config, 0, len(cr.Spec.Config.Logs))
+	for i, logConfig := range cr.Spec.Config.Logs {
+		cfg, err := translateWorkloadLog(cr, logConfig)
+		if err != nil {
+			return instrumentation.HandlerStatus{
+				Type:    logsReadyConditionType,
+				Status:  metav1.ConditionFalse,
+				Reason:  "TranslationFailed",
+				Message: fmt.Sprintf("logs[%d]: %s", i, err),
+			}, nil
+		}
+		configs = append(configs, cfg)
+	}
+
+	h.checkStore.writeConfigs(key, cr, configs)
+
+	return instrumentation.HandlerStatus{
+		Type:    logsReadyConditionType,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Configured",
+		Message: fmt.Sprintf("%d log config(s) configured for %s/%s", len(configs), cr.Spec.TargetRef.Kind, cr.Spec.TargetRef.Name),
+	}, nil
+}
+
+func translateWorkloadLog(cr *datadoghq.DatadogInstrumentation, logConfig datadoghq.DatadogInstrumentationLogConfig) (integration.Config, error) {
+	containerName := strings.TrimSpace(logConfig.ContainerName)
+	if containerName == "" {
+		return integration.Config{}, fmt.Errorf("container name must not be empty")
+	}
+	logsConfig, err := marshalLogs([]datadoghq.DatadogInstrumentationLogFields{logConfig.DatadogInstrumentationLogFields})
+	if err != nil {
+		return integration.Config{}, err
+	}
+	return integration.Config{
+		Name:          logsCheckName,
+		ADIdentifiers: []string{adtypes.KubeContainerNameIdentifier(containerName)},
+		LogsConfig:    logsConfig,
+		CELSelector:   buildCELSelector(cr.Spec.TargetRef, cr.Namespace),
+		Source:        fmt.Sprintf("%s:%s/%s", autodiscoveryProvider, cr.Namespace, cr.Name),
+	}, nil
+}
+
+func logsStoreKey(crKey string) string {
+	return crKey + "/logs"
+}

--- a/pkg/clusteragent/instrumentation/handlers/logs_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/logs_test.go
@@ -1,0 +1,327 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	adtypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
+)
+
+func newLogsHandler() (*LogsHandler, *CheckStore) {
+	cs := NewCheckStore()
+	h := &LogsHandler{
+		checkStore: cs,
+	}
+	return h, cs
+}
+
+func newLogsCR(name, namespace string, targetKind, targetName string, logs []datadoghq.DatadogInstrumentationLogConfig) *datadoghq.DatadogInstrumentation {
+	cr := newCR(name, namespace, targetKind, targetName, nil)
+	cr.Spec.Config.Logs = logs
+	return cr
+}
+
+func TestLogsHasSection(t *testing.T) {
+	tests := []struct {
+		name     string
+		cr       *datadoghq.DatadogInstrumentation
+		expected bool
+	}{
+		{
+			name:     "nil CR",
+			cr:       nil,
+			expected: false,
+		},
+		{
+			name:     "no logs",
+			cr:       newLogsCR("test", "default", "Deployment", "app", nil),
+			expected: false,
+		},
+		{
+			name: "with logs",
+			cr: newLogsCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationLogConfig{
+				{ContainerName: "app"},
+			}),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, _ := newLogsHandler()
+			assert.Equal(t, tt.expected, h.HasSection(tt.cr))
+		})
+	}
+}
+
+func TestLogsSupportsTarget(t *testing.T) {
+	tests := []struct {
+		kind     string
+		expected bool
+	}{
+		{"Deployment", true},
+		{"DaemonSet", true},
+		{"StatefulSet", true},
+		{"CronJob", true},
+		{"Job", true},
+		{"Service", false},
+		{"ReplicaSet", false},
+		{"Pod", false},
+	}
+
+	h, _ := newLogsHandler()
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			ref := autoscalingv2.CrossVersionObjectReference{Kind: tt.kind, Name: "test"}
+			assert.Equal(t, tt.expected, h.SupportsTarget(ref))
+		})
+	}
+}
+
+func TestLogsValidate(t *testing.T) {
+	tests := []struct {
+		name           string
+		cr             *datadoghq.DatadogInstrumentation
+		expectErrCount int
+		expectField    string
+	}{
+		{
+			name:           "nil CR returns nil",
+			cr:             nil,
+			expectErrCount: 0,
+		},
+		{
+			name: "valid log with container name",
+			cr: newLogsCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationLogConfig{
+				{ContainerName: "app", DatadogInstrumentationLogFields: datadoghq.DatadogInstrumentationLogFields{Source: "nginx"}},
+			}),
+			expectErrCount: 0,
+		},
+		{
+			name: "missing container name",
+			cr: newLogsCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationLogConfig{
+				{DatadogInstrumentationLogFields: datadoghq.DatadogInstrumentationLogFields{Source: "nginx"}},
+			}),
+			expectErrCount: 1,
+			expectField:    "spec.config.logs[0].containerName",
+		},
+		{
+			name: "whitespace container name",
+			cr: newLogsCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationLogConfig{
+				{ContainerName: "   "},
+			}),
+			expectErrCount: 1,
+			expectField:    "spec.config.logs[0].containerName",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, _ := newLogsHandler()
+			errs := h.Validate(tt.cr)
+			assert.Len(t, errs, tt.expectErrCount)
+			if tt.expectField != "" && len(errs) > 0 {
+				assert.Equal(t, tt.expectField, errs[0].Field)
+			}
+		})
+	}
+}
+
+func TestLogsHandle_CreateAndDelete(t *testing.T) {
+	port := int32(10514)
+	tests := []struct {
+		name       string
+		targetKind string
+		targetName string
+	}{
+		{"deployment", "Deployment", "app"},
+		{"job", "Job", "worker"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, cs := newLogsHandler()
+			cr := newLogsCR("test", "default", tt.targetKind, tt.targetName, []datadoghq.DatadogInstrumentationLogConfig{
+				{
+					ContainerName: "app",
+					DatadogInstrumentationLogFields: datadoghq.DatadogInstrumentationLogFields{
+						Type:    "tcp",
+						Port:    &port,
+						Service: "web",
+						Source:  "nginx",
+					},
+				},
+			})
+
+			status, err := h.Handle(context.Background(), instrumentation.EventCreate, cr)
+			require.NoError(t, err)
+			assert.Equal(t, metav1.ConditionTrue, status.Status)
+			assert.Equal(t, "Configured", status.Reason)
+			assert.Contains(t, status.Message, "1 log config(s) configured")
+
+			configs, _ := cs.ListConfigs()
+			require.Len(t, configs, 1)
+			assert.Equal(t, logsCheckName, configs[0].Name)
+			assert.Equal(t, []string{adtypes.KubeContainerNameIdentifier("app")}, configs[0].ADIdentifiers)
+			assert.Equal(t, "datadoginstrumentation:default/test", configs[0].Source)
+			assert.Contains(t, string(configs[0].LogsConfig), `"type":"tcp"`)
+			assert.Contains(t, string(configs[0].LogsConfig), `"service":"web"`)
+			assert.NotContains(t, string(configs[0].LogsConfig), "containerName")
+			require.Len(t, configs[0].CELSelector.Containers, 1)
+			assert.Contains(t, configs[0].CELSelector.Containers[0], `container.pod.rootowner.name == "`+tt.targetName+`"`)
+
+			status, err = h.Handle(context.Background(), instrumentation.EventDelete, cr)
+			require.NoError(t, err)
+			assert.Equal(t, metav1.ConditionTrue, status.Status)
+			assert.Equal(t, "Deleted", status.Reason)
+			configs, _ = cs.ListConfigs()
+			assert.Empty(t, configs)
+		})
+	}
+}
+
+func TestLogsHandle_Update(t *testing.T) {
+	h, cs := newLogsHandler()
+	cr := newLogsCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationLogConfig{
+		{
+			ContainerName: "app",
+			DatadogInstrumentationLogFields: datadoghq.DatadogInstrumentationLogFields{
+				Source: "nginx",
+			},
+		},
+	})
+
+	_, err := h.Handle(context.Background(), instrumentation.EventCreate, cr)
+	require.NoError(t, err)
+	configs, _ := cs.ListConfigs()
+	require.Len(t, configs, 1)
+
+	cr.Spec.Config.Logs = append(cr.Spec.Config.Logs, datadoghq.DatadogInstrumentationLogConfig{
+		ContainerName: "sidecar",
+		DatadogInstrumentationLogFields: datadoghq.DatadogInstrumentationLogFields{
+			Source: "envoy",
+		},
+	})
+	status, err := h.Handle(context.Background(), instrumentation.EventUpdate, cr)
+	require.NoError(t, err)
+	assert.Equal(t, metav1.ConditionTrue, status.Status)
+	assert.Contains(t, status.Message, "2 log config(s) configured")
+
+	configs, _ = cs.ListConfigs()
+	require.Len(t, configs, 2)
+	assert.ElementsMatch(t, []string{
+		adtypes.KubeContainerNameIdentifier("app"),
+		adtypes.KubeContainerNameIdentifier("sidecar"),
+	}, []string{configs[0].ADIdentifiers[0], configs[1].ADIdentifiers[0]})
+}
+
+func TestLogsHandle_MultipleCRs(t *testing.T) {
+	h, cs := newLogsHandler()
+	cr1 := newLogsCR("nginx-logs", "ns1", "Deployment", "nginx", []datadoghq.DatadogInstrumentationLogConfig{
+		{
+			ContainerName: "nginx",
+			DatadogInstrumentationLogFields: datadoghq.DatadogInstrumentationLogFields{
+				Source: "nginx",
+			},
+		},
+	})
+	cr2 := newLogsCR("envoy-logs", "ns2", "Deployment", "envoy", []datadoghq.DatadogInstrumentationLogConfig{
+		{
+			ContainerName: "envoy",
+			DatadogInstrumentationLogFields: datadoghq.DatadogInstrumentationLogFields{
+				Source: "envoy",
+			},
+		},
+	})
+
+	_, err := h.Handle(context.Background(), instrumentation.EventCreate, cr1)
+	require.NoError(t, err)
+	_, err = h.Handle(context.Background(), instrumentation.EventCreate, cr2)
+	require.NoError(t, err)
+
+	configs, _ := cs.ListConfigs()
+	require.Len(t, configs, 2)
+
+	_, err = h.Handle(context.Background(), instrumentation.EventDelete, cr1)
+	require.NoError(t, err)
+
+	configs, _ = cs.ListConfigs()
+	require.Len(t, configs, 1)
+	assert.Equal(t, "datadoginstrumentation:ns2/envoy-logs", configs[0].Source)
+	assert.Equal(t, []string{adtypes.KubeContainerNameIdentifier("envoy")}, configs[0].ADIdentifiers)
+}
+
+func TestLogsHandler_NilCR(t *testing.T) {
+	h, _ := newLogsHandler()
+	status, err := h.Handle(context.Background(), instrumentation.EventCreate, nil)
+	require.NoError(t, err)
+	assert.Equal(t, metav1.ConditionUnknown, status.Status)
+	assert.Equal(t, "MissingResource", status.Reason)
+}
+
+func TestLogsHandlerSharesCheckStoreWithoutOverwritingChecks(t *testing.T) {
+	cs := NewCheckStore()
+	ts := NewServiceCheckTemplateStore()
+	checksHandler := &ChecksHandler{
+		checkStore:           cs,
+		templateStore:        ts,
+		serviceTargetEnabled: true,
+	}
+	logsHandler := &LogsHandler{checkStore: cs}
+
+	cr := newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
+		{
+			Integration:   "redisdb",
+			ContainerName: "app",
+			Instances:     []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+		},
+	})
+	cr.Spec.Config.Logs = []datadoghq.DatadogInstrumentationLogConfig{
+		{
+			ContainerName: "app",
+			DatadogInstrumentationLogFields: datadoghq.DatadogInstrumentationLogFields{
+				Source: "redis",
+			},
+		},
+	}
+
+	_, err := checksHandler.Handle(context.Background(), instrumentation.EventCreate, cr)
+	require.NoError(t, err)
+	_, err = logsHandler.Handle(context.Background(), instrumentation.EventCreate, cr)
+	require.NoError(t, err)
+
+	configs, _ := cs.ListConfigs()
+	require.Len(t, configs, 2)
+
+	byName := map[string]integration.Config{}
+	for _, cfg := range configs {
+		byName[cfg.Name] = cfg
+	}
+	assert.Contains(t, byName, "redisdb")
+	assert.Contains(t, byName, logsCheckName)
+	assert.NotNil(t, byName[logsCheckName].LogsConfig)
+	assert.Len(t, byName["redisdb"].Instances, 1)
+
+	_, err = logsHandler.Handle(context.Background(), instrumentation.EventDelete, cr)
+	require.NoError(t, err)
+
+	configs, _ = cs.ListConfigs()
+	require.Len(t, configs, 1)
+	assert.Equal(t, "redisdb", configs[0].Name)
+}

--- a/pkg/clusteragent/instrumentation/handlers/registry.go
+++ b/pkg/clusteragent/instrumentation/handlers/registry.go
@@ -31,6 +31,7 @@ type Deps struct {
 // DefaultHandlers returns the product handlers registered for the shared controller.
 func DefaultHandlers(deps *Deps) []instrumentation.Handler {
 	return []instrumentation.Handler{
-		NewAutodiscoveryHandler(deps),
+		NewChecksHandler(deps),
+		NewLogsHandler(deps),
 	}
 }

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -266,8 +266,8 @@ func CreateSources(config integration.Config) ([]*sourcesPkg.LogSource, error) {
 		if service != nil {
 			// a config defined in a container label or a pod annotation does not always contain a type,
 			// override it here to ensure that the config won't be dropped at validation.
-			if (cfg.Type == logsConfig.FileType || cfg.Type == logsConfig.TCPType || cfg.Type == logsConfig.UDPType || cfg.Type == logsConfig.IntegrationType) && (config.Provider == names.Kubernetes || config.Provider == names.Container || config.Provider == names.KubeContainer || config.Provider == logsConfig.FileType || config.Provider == names.ProcessLog) {
-				// cfg.Type is not overwritten as tailing a file from a Docker or Kubernetes AD configuration
+			if preservesExplicitLogType(config.Provider, cfg.Type) {
+				// cfg.Type is not overwritten as tailing a file from a Docker, Kubernetes, or DDI AD configuration
 				// is explicitly supported (other combinations may be supported later)
 				cfg.Identifier = service.Identifier
 			} else {
@@ -293,6 +293,21 @@ func CreateSources(config integration.Config) ([]*sourcesPkg.LogSource, error) {
 	}
 
 	return sources, nil
+}
+
+func preservesExplicitLogType(provider, logType string) bool {
+	switch logType {
+	case logsConfig.FileType, logsConfig.TCPType, logsConfig.UDPType, logsConfig.IntegrationType:
+	default:
+		return false
+	}
+
+	switch provider {
+	case names.Kubernetes, names.Container, names.KubeContainer, logsConfig.FileType, names.ProcessLog, names.InstrumentationChecks:
+		return true
+	default:
+		return false
+	}
 }
 
 // toService creates a new service for an integrationConfig.

--- a/pkg/logs/schedulers/ad/scheduler_test.go
+++ b/pkg/logs/schedulers/ad/scheduler_test.go
@@ -126,6 +126,53 @@ func TestScheduleIntegrationConfig(t *testing.T) {
 	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
 }
 
+func TestScheduleInstrumentationChecksPreservesExplicitLogType(t *testing.T) {
+	scheduler, spy := setup()
+	configSource := integration.Config{
+		LogsConfig:    []byte(`[{"service":"foo","source":"bar","type":"tcp","port":10514}]`),
+		ADIdentifiers: []string{"kube_container_name://app"},
+		Provider:      names.InstrumentationChecks,
+		TaggerEntity:  "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		ServiceID:     "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		ClusterCheck:  false,
+	}
+
+	scheduler.Schedule([]integration.Config{configSource})
+
+	require.Equal(t, 1, len(spy.Events))
+	require.True(t, spy.Events[0].Add)
+	logSource := spy.Events[0].Source
+	assert.Equal(t, config.DockerType, logSource.Name)
+	assert.Equal(t, "foo", logSource.Config.Service)
+	assert.Equal(t, "bar", logSource.Config.Source)
+	assert.Equal(t, config.TCPType, logSource.Config.Type)
+	assert.Equal(t, 10514, logSource.Config.Port)
+	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
+}
+
+func TestScheduleInstrumentationChecksUsesServiceTypeByDefault(t *testing.T) {
+	scheduler, spy := setup()
+	configSource := integration.Config{
+		LogsConfig:    []byte(`[{"service":"foo","source":"bar"}]`),
+		ADIdentifiers: []string{"kube_container_name://app"},
+		Provider:      names.InstrumentationChecks,
+		TaggerEntity:  "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		ServiceID:     "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		ClusterCheck:  false,
+	}
+
+	scheduler.Schedule([]integration.Config{configSource})
+
+	require.Equal(t, 1, len(spy.Events))
+	require.True(t, spy.Events[0].Add)
+	logSource := spy.Events[0].Source
+	assert.Equal(t, config.DockerType, logSource.Name)
+	assert.Equal(t, "foo", logSource.Config.Service)
+	assert.Equal(t, "bar", logSource.Config.Source)
+	assert.Equal(t, config.DockerType, logSource.Config.Type)
+	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
+}
+
 func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 	scheduler, spy := setup()
 	configSource := integration.Config{


### PR DESCRIPTION
### What does this PR do?

Relies on CRD spec change: https://github.com/DataDog/datadog-operator/pull/3198

Adds a dedicated DatadogInstrumentation logs handler that translates `spec.config.logs` into logs-only Autodiscovery configs in the shared check store.

It also renames the existing Autodiscovery handler to `ChecksHandler` and bumps `datadog-operator/api` to the logs CRD update.

### Motivation

The CRD now separates logs from checks, but the node agent should still pull those logs configs through the same Autodiscovery path. This keeps logs scoped by `containerName` and the workload CEL filter without mixing them into check definitions.

### Describe how you validated your changes

- Adde tests and they pass ✅ 

#### Manually QA'd

1. Deploy agent with instrumentation CRD enabled
2. Create temp workload
```yaml
apiVersion: v1
kind: Service
metadata:
  name: redis
spec:
  selector:
    app: redis
  ports:
    - port: 6379
      targetPort: 6379
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: redis
spec:
  replicas: 2
  serviceName: redis
  selector:
    matchLabels:
      app: redis
  template:
    metadata:
      labels:
        app: redis
    spec:
      containers:
        - name: redis
          image: redis:latest
          ports:
            - containerPort: 6379
          env:
            - name: REDIS_PASS
              valueFrom:
                secretKeyRef:
                  name: redis-secret
                  key: password
          command: ["sh", "-c", "redis-server --requirepass \"$REDIS_PASS\" --loglevel debug"]
        - name: sidecar
          image: busybox:latest
          command: [ "sh", "-c", "while true; do echo 'demo-service running'; sleep 30; done" ]
          ports:
            - containerPort: 8080
```

3. Apply DDI CR with logs config
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogInstrumentation
metadata:
  name: redis-instrumentation
  namespace: cache
spec:
  targetRef:
    apiVersion: apps/v1
    kind: StatefulSet
    name: redis
  config:
    logs:
      - containerName: redis
        tags:
          - env:dev
      - containerName: sidecar
```

4. Check `agent configcheck` for running logs

<img width="606" height="326" alt="image" src="https://github.com/user-attachments/assets/8915f58b-304c-4781-bb3a-01f741037709" />
