### PR TITLE
feat(serverless-init): send SIGUSR2 to child on MicroVM /run hook

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -199,8 +199,9 @@ func (m *MicroVM) Run(modeConf mode.Conf, logConfig *serverlessInitLog.Config) e
 		log.Fatalf("MicroVM does not support sidecar mode")
 	}
 	return mode.RunInit(logConfig, &mode.ProcessHooks{
-		OnAlive: m.child.MarkAlive,
-		OnDead:  m.child.MarkDead,
+		OnProcess: m.child.StoreProcess,
+		OnAlive:   m.child.MarkAlive,
+		OnDead:    m.child.MarkDead,
 	})
 }
 

--- a/cmd/serverless-init/lifecycle/childhandle.go
+++ b/cmd/serverless-init/lifecycle/childhandle.go
@@ -3,9 +3,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !windows
+
 package lifecycle
 
-import "go.uber.org/atomic"
+import (
+	"os"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
 
 // ChildHandle exposes the user process's liveness to the lifecycle server.
 // /ready maps it directly: alive → 200, anything else → 503. The
@@ -18,11 +26,15 @@ type ChildHandle interface {
 // cmd.Start succeeds and defers MarkDead so it fires whenever cmd.Wait
 // returns (clean exit, signal, panic, runtime.Goexit). Safe for concurrent use.
 type Child struct {
-	alive *atomic.Bool
+	alive atomic.Bool
+	proc  atomic.Pointer[os.Process]
 }
 
 // NewChild returns a Child in the not-alive state.
-func NewChild() *Child { return &Child{alive: atomic.NewBool(false)} }
+func NewChild() *Child { return &Child{} }
+
+// StoreProcess records the OS process handle for use by SignalRun.
+func (c *Child) StoreProcess(p *os.Process) { c.proc.Store(p) }
 
 // IsAlive reports whether the child process is currently running.
 func (c *Child) IsAlive() bool { return c.alive.Load() }
@@ -42,3 +54,29 @@ type noopChild struct{}
 // NewNoopChildHandle returns a ChildHandle that always reports not-alive.
 func NewNoopChildHandle() ChildHandle { return noopChild{} }
 func (noopChild) IsAlive() bool       { return false }
+
+// RunSignal is sent to the child on /run. SIGUSR2 lets tracer libraries
+// (e.g. dd-trace-js) reseed their PRNG after a Firecracker clone restore.
+var RunSignal os.Signal = syscall.SIGUSR2
+
+// SignalRun delivers sig to the child. Returns nil if no process has been
+// stored yet — /run may arrive before cmd.Start returns.
+func (c *Child) SignalRun(sig os.Signal) error {
+	p := c.proc.Load()
+	if p == nil {
+		return nil
+	}
+	return p.Signal(sig)
+}
+
+func (s *Server) sendRunSignal() {
+	if !s.runSignalEnabled {
+		return
+	}
+	if s.child == nil {
+		return
+	}
+	if err := s.child.SignalRun(RunSignal); err != nil {
+		log.Warnf("MicroVM lifecycle: /run signal (%v) to child failed: %v", RunSignal, err)
+	}
+}

--- a/cmd/serverless-init/lifecycle/childhandle_test.go
+++ b/cmd/serverless-init/lifecycle/childhandle_test.go
@@ -6,9 +6,14 @@
 package lifecycle
 
 import (
+	"os"
+	"os/signal"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChild_StartsNotAlive(t *testing.T) {
@@ -30,4 +35,33 @@ func TestChild_MarkDeadClearsAlive(t *testing.T) {
 
 func TestNoopChildHandle_AlwaysNotAlive(t *testing.T) {
 	assert.False(t, NewNoopChildHandle().IsAlive())
+}
+
+func TestRunSignal_IsSIGUSR2(t *testing.T) {
+	assert.Equal(t, syscall.SIGUSR2, RunSignal)
+}
+
+func TestChild_SignalRun_NilProcess_ReturnsNil(t *testing.T) {
+	c := NewChild()
+	assert.NoError(t, c.SignalRun(syscall.SIGUSR2))
+}
+
+func TestChild_StoreProcess_SignalRun_DeliversSignal(t *testing.T) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGUSR2)
+	defer signal.Stop(sigCh)
+
+	c := NewChild()
+	self, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	c.StoreProcess(self)
+
+	require.NoError(t, c.SignalRun(syscall.SIGUSR2))
+
+	select {
+	case sig := <-sigCh:
+		assert.Equal(t, syscall.SIGUSR2, sig)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("SIGUSR2 not received within 500ms after SignalRun")
+	}
 }

--- a/cmd/serverless-init/lifecycle/config.go
+++ b/cmd/serverless-init/lifecycle/config.go
@@ -26,6 +26,11 @@ const ReadyTimeoutMsEnvVar = "DD_AWS_MICROVM_READY_TIMEOUT_MS"
 // ValidateTimeoutMsEnvVar overrides the timeout (ms) for /validate.
 const ValidateTimeoutMsEnvVar = "DD_AWS_MICROVM_VALIDATE_TIMEOUT_MS"
 
+// RunSignalEnvVar opts in to sending SIGUSR2 to the child on /run.
+// SIGUSR2's default Linux disposition is termination; enable only when the
+// user application installs a SIGUSR2 handler (e.g. dd-trace-js).
+const RunSignalEnvVar = "DD_AWS_MICROVM_SEND_RUN_SIGNAL"
+
 // parsePort parses a port number from a raw env-var string.
 // Returns defaultVal when raw is empty. Parsed port must not equal any value in forbidden.
 func parsePort(envVar, raw string, defaultVal int, forbidden ...int) (int, error) {

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -51,6 +51,7 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -174,10 +175,11 @@ type Server struct {
 	metricSource  metrics.MetricSource
 	flushTimeout  time.Duration
 
-	childHandle ChildHandle // production: *Child (init) or NewNoopChildHandle() (sidecar); always non-nil after lifecycle.SetupFromEnv. nil only in legacy unit tests; logs WARN if hit.
-	child       *Child      // non-nil only in init-container mode; nil in sidecar and unit tests. Derived from childHandle when it is a *Child.
-	fwd         *Forwarder  // nil = no opt-in; today's behavior preserved
-	heartbeat   *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
+	childHandle      ChildHandle // production: *Child (init) or NewNoopChildHandle() (sidecar); always non-nil after lifecycle.SetupFromEnv. nil only in legacy unit tests; logs WARN if hit.
+	child            *Child      // non-nil only in init-container mode; nil in sidecar and unit tests. Derived from childHandle when it is a *Child.
+	fwd              *Forwarder  // nil = no opt-in; today's behavior preserved
+	heartbeat        *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
+	runSignalEnabled bool        // true when DD_AWS_MICROVM_SEND_RUN_SIGNAL=true
 
 	logsTagSetter  LogsTagSetter     // nil-safe; set via SetLogsTagSetter after construction
 	baseTags       []string          // startup tag snapshot; lambda_microvm_id is appended at /run
@@ -202,17 +204,18 @@ func NewServer(
 	heartbeat *Heartbeat, // may be nil
 ) *Server {
 	s := &Server{
-		metricFlusher: metricFlusher,
-		traceFlusher:  traceFlusher,
-		logsFlusher:   logsFlusher,
-		metricEmitter: metricEmitter,
-		sampleDrainer: sampleDrainer,
-		metricSource:  metricSource,
-		flushTimeout:  flushTimeout,
-		childHandle:   childHandle,
-		fwd:           fwd,
-		instanceID:    atomic.NewString(""),
-		heartbeat:     heartbeat,
+		metricFlusher:    metricFlusher,
+		traceFlusher:     traceFlusher,
+		logsFlusher:      logsFlusher,
+		metricEmitter:    metricEmitter,
+		sampleDrainer:    sampleDrainer,
+		metricSource:     metricSource,
+		flushTimeout:     flushTimeout,
+		childHandle:      childHandle,
+		fwd:              fwd,
+		instanceID:       atomic.NewString(""),
+		heartbeat:        heartbeat,
+		runSignalEnabled: os.Getenv(RunSignalEnvVar) == "true",
 	}
 	// Derive the concrete *Child from the handle when possible so callers can
 	// reach it via Server.Child() without a separate return value.
@@ -525,7 +528,14 @@ func (s *Server) aliveCheckReady(w http.ResponseWriter) {
 // handleRun is the only hook that reads r.Body and is therefore not
 // collapsed into dispatchHook directly. The ID is captured before Start
 // so the first heartbeat emission already carries the correct microvm_id tag.
+//
+// SIGUSR2 is sent first (no-forwarder path) so the child can reseed its PRNG
+// before any telemetry work. Skipped when a forwarder is configured.
 func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
+	if s.fwd == nil {
+		s.sendRunSignal()
+	}
+
 	// Read the body once so we can parse the instance ID AND still forward the
 	// original payload to the user app. Without this, the forwarder path would
 	// consume r.Body before the decode, losing the instance_id tag on all

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -126,6 +126,17 @@ func newTestServer() (*Server, *mockFlusher, *mockFlusher, *mockLogsAgent, *mock
 	return srv, metric, trace, logs, emitter, drainer
 }
 
+func TestNewServer_RunSignalDisabledByDefault(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	assert.False(t, srv.runSignalEnabled, "runSignalEnabled must be false when %s is unset", RunSignalEnvVar)
+}
+
+func TestNewServer_RunSignalEnabledByEnvVar(t *testing.T) {
+	t.Setenv(RunSignalEnvVar, "true")
+	srv, _, _, _, _, _ := newTestServer()
+	assert.True(t, srv.runSignalEnabled, "runSignalEnabled must be true when %s=true", RunSignalEnvVar)
+}
+
 // /ready with a nil ChildHandle is a wiring bug. The handler logs WARN and
 // returns 503. Production setup() always constructs a non-nil handle (real
 // *Child in init mode, NoopChildHandle in sidecar mode); only legacy unit
@@ -1482,4 +1493,81 @@ func TestHandleRun_WithForwarder_UpdatesTraceTags(t *testing.T) {
 
 	require.Equal(t, 1, setter.callCount(), "SetTraceTags must be called even when forwarder is configured")
 	assert.Equal(t, "vm-fwd789", setter.lastCall()["lambda_microvm_id"])
+}
+
+func TestHandleRun_NoForwarder_SendsRunSignalToChild(t *testing.T) {
+	t.Setenv(RunSignalEnvVar, "true")
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGUSR2)
+	defer signal.Stop(sigCh)
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.child = NewChild()
+	self, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	srv.child.StoreProcess(self)
+
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
+
+	select {
+	case sig := <-sigCh:
+		assert.Equal(t, syscall.SIGUSR2, sig, "/run must deliver RunSignal to child")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("/run must deliver RunSignal to child; SIGUSR2 not received within 500ms")
+	}
+}
+
+func TestHandleRun_NoForwarder_RunSignalDisabled_NoSignalSent(t *testing.T) {
+	// DD_AWS_MICROVM_SEND_RUN_SIGNAL is intentionally NOT set — default behavior.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGUSR2)
+	defer signal.Stop(sigCh)
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.child = NewChild()
+	self, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	srv.child.StoreProcess(self)
+
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
+
+	select {
+	case sig := <-sigCh:
+		t.Fatalf("/run without %s must NOT send RunSignal; got %v", RunSignalEnvVar, sig)
+	case <-time.After(100 * time.Millisecond):
+		// Pass — no signal observed.
+	}
+}
+
+func TestHandleRun_WithForwarder_NoSignalSent(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGUSR2)
+	defer signal.Stop(sigCh)
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.child = NewChild()
+	self, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	srv.child.StoreProcess(self)
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
+
+	select {
+	case sig := <-sigCh:
+		t.Fatalf("/run with forwarder must NOT send RunSignal; got %v", sig)
+	case <-time.After(100 * time.Millisecond):
+		// Pass — no signal observed.
+	}
 }

--- a/cmd/serverless-init/mode/initcontainer_mode.go
+++ b/cmd/serverless-init/mode/initcontainer_mode.go
@@ -21,12 +21,11 @@ import (
 	"github.com/spf13/afero"
 )
 
-// ProcessHooks carries optional callbacks that are invoked around subprocess
-// lifecycle transitions. MicroVM supplies OnAlive/OnDead to drive its /ready
-// alive-check; other cloud services pass nil.
+// ProcessHooks carries optional callbacks around subprocess lifecycle events.
 type ProcessHooks struct {
-	OnAlive func() // called after cmd.Start succeeds
-	OnDead  func() // called when cmd.Wait returns (deferred, fires on panic too)
+	OnProcess func(*os.Process) // called after cmd.Start succeeds
+	OnAlive   func()            // called after cmd.Start succeeds
+	OnDead    func()            // called when cmd.Wait returns (deferred, fires on panic too)
 }
 
 // RunInit is the entrypoint of the init process. It spawns the customer
@@ -66,6 +65,9 @@ func execute(logConfig *serverlessLog.Config, args []string, hooks *ProcessHooks
 
 	if err := cmd.Start(); err != nil {
 		return err
+	}
+	if hooks != nil && hooks.OnProcess != nil {
+		hooks.OnProcess(cmd.Process)
 	}
 	if hooks != nil && hooks.OnAlive != nil {
 		hooks.OnAlive()

--- a/cmd/serverless-init/mode/initcontainer_mode_test.go
+++ b/cmd/serverless-init/mode/initcontainer_mode_test.go
@@ -23,6 +23,7 @@ import (
 	serverlessLog "github.com/DataDog/datadog-agent/cmd/serverless-init/log"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestDetectMode_Sidecar_HasRunnerSet verifies that sidecar mode (no args)
@@ -105,6 +106,38 @@ func TestPropagateChildError(t *testing.T) {
 		err := execute(&serverlessLog.Config{}, []string{"bash", "-c", "exit " + strconv.Itoa(expectedError)}, nil)
 		assert.Equal(t, expectedError<<8, int(err.(*exec.ExitError).ProcessState.Sys().(syscall.WaitStatus)))
 	})
+}
+
+// TestExecute_OnProcessHookCalled verifies that OnProcess receives the actual
+// OS process immediately after cmd.Start succeeds (before OnAlive).
+func TestExecute_OnProcessHookCalled(t *testing.T) {
+	runTestOnLinuxOnly(t, func(t *testing.T) {
+		var gotProcess *os.Process
+		hooks := &ProcessHooks{
+			OnProcess: func(p *os.Process) { gotProcess = p },
+			OnAlive:   func() {},
+			OnDead:    func() {},
+		}
+		err := execute(&serverlessLog.Config{}, []string{"sh", "-c", "exit 0"}, hooks)
+		assert.NoError(t, err)
+		require.NotNil(t, gotProcess, "OnProcess must be called with the OS process after cmd.Start succeeds")
+		assert.Positive(t, gotProcess.Pid, "process PID must be positive")
+	})
+}
+
+// TestExecute_StartFailure_NeverCallsOnProcess verifies that OnProcess is not
+// invoked when cmd.Start fails (binary not found). Mirrors the existing
+// TestExecute_StartFailure_NeverCallsOnAlive test for OnAlive.
+func TestExecute_StartFailure_NeverCallsOnProcess(t *testing.T) {
+	var onProcessCalled bool
+	hooks := &ProcessHooks{
+		OnProcess: func(*os.Process) { onProcessCalled = true },
+		OnAlive:   func() {},
+		OnDead:    func() {},
+	}
+	err := execute(&serverlessLog.Config{}, []string{"/nonexistent/binary/that/cannot/be/found"}, hooks)
+	assert.Error(t, err, "cmd.Start must fail for a missing binary")
+	assert.False(t, onProcessCalled, "OnProcess must not be called when cmd.Start fails")
 }
 
 // When cmd.Start fails (e.g. binary not found), execute must return the error


### PR DESCRIPTION
## What does this PR do?

When the MicroVM platform sends the `/run` lifecycle hook, serverless-init can deliver **SIGUSR2** to the child process (no-forwarder path) as the very first action, before any telemetry work.

SIGUSR2 delivery is **opt-in** via `DD_AWS_MICROVM_SEND_RUN_SIGNAL=true`. When the env var is absent (the default), no signal is sent.

## When to enable `DD_AWS_MICROVM_SEND_RUN_SIGNAL=true`

Enable this **only when all three conditions are met**:

1. **The user app does not register its own `/run` lifecycle handler.** When `DD_AWS_MICROVM_USER_APP_PORT` is set, the platform forwards `/run` directly to the user app over HTTP — the app already receives the event and can perform any necessary re-initialization itself. Sending SIGUSR2 on top of that would be redundant and potentially disruptive.

2. **The dd-trace runtime in use has implemented a SIGUSR2 handler.** SIGUSR2's default Linux disposition is **termination** — a process without an explicit handler will be killed. SIGUSR2 handler support is **pending implementation across all supported dd-trace runtimes** (dd-trace-js, dd-trace-py, dd-trace-java, dd-trace-go, etc.). This env var should remain unset until the corresponding runtime support is confirmed and shipped.

3. **The user application does not register its own SIGUSR2 handler.** If the app has installed a custom handler for SIGUSR2 (e.g. for debug profiling, heap dumps, or other runtime signals), the serverless-init–delivered signal would conflict with that handler's intended purpose.

## Motivation

Certain IDs — such as `runtime-id` in dd-trace-js — are generated once at module load time and are expected to remain **stable for the lifetime of a single image instance**. When Firecracker snapshots the VM, those IDs are frozen into the snapshot. Every clone that restores from that snapshot inherits the same ID values, causing collisions across instances.

Previously, tracer libraries could rely on \`AWS_LAMBDA_MICROVM_IMAGE_ARN\` being present to trigger a reseed. That only works when IDs are regenerated on each process start — it does not cover the snapshot-restore case where the process is already running with frozen state.

What we need is a **one-time notification** on each \`/run\` (i.e. each clone restore or cold start), so the tracer runtime can refresh those stable IDs **once and only once** per instance lifecycle.

## Implementation

- \`Child\` gains \`proc atomic.Pointer[os.Process]\` and \`StoreProcess\` — wired via a new \`ProcessHooks.OnProcess\` callback called immediately after \`cmd.Start\` in \`execute()\`.
- \`RunSignal = syscall.SIGUSR2\`, \`SignalRun(sig os.Signal) error\`, and \`sendRunSignal()\` live in \`childhandle.go\` (marked \`!windows\`; serverless-init does not run on Windows).
- \`RunSignalEnvVar = "DD_AWS_MICROVM_SEND_RUN_SIGNAL"\` is declared in \`config.go\`, following the existing \`DD_AWS_MICROVM_*\` naming convention.
- \`Server\` stores \`runSignalEnabled bool\`, set once in \`NewServer\` from the env var. \`sendRunSignal()\` returns early when the flag is false.
- \`handleRun\` calls \`s.sendRunSignal()\` as its first statement when no forwarder is configured.

## Test plan

```bash
dda inv test --targets=./cmd/serverless-init/lifecycle/...,./cmd/serverless-init/mode/...
```