### PR TITLE
fix(clusterchecks): decrement nodeAgents gauge on store reset

### DIFF
--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -42,6 +42,7 @@ func newClusterStore() *clusterStore {
 func (s *clusterStore) reset() {
 	for _, node := range s.nodes {
 		dispatchedConfigs.Delete(node.name, le.JoinLeaderValue)
+		nodeAgents.Dec(le.JoinLeaderValue)
 	}
 
 	s.active = false

--- a/releasenotes-dca/notes/fix-cluster-checks-nodes-reporting-1b51336df1273fb6.yaml
+++ b/releasenotes-dca/notes/fix-cluster-checks-nodes-reporting-1b51336df1273fb6.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix ``cluster_checks.nodes_reporting`` gauge drifting upward across
+    leader elections. The metric is now correctly decremented when the
+    cluster agent loses leadership and the node store is reset.


### PR DESCRIPTION
### What does this PR do?

Fix `cluster_checks.nodes_reporting` telemetry overcounting during leadership transitions.

https://github.com/search?q=repo%3ADataDog%2Fdatadog-agent+nodeAgents&type=code

We can only see `Inc` but `Dec` exists only for node expiration, not leader transitions.

### Motivation

When the cluster agent loses leadership, reset() wipes the node map without decrementing the nodeAgents gauge for each node removed. On the next leadership acquisition those nodes re-register and Inc() fires again, causing the cluster_checks.nodes_reporting gauge to drift upward with each leadership cycle.

[CONTP-1761]

[CONTP-1761]: https://datadoghq.atlassian.net/browse/CONTP-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ