### PR TITLE
Move xperf from WaitForDaemonToStop to MustStartExperiment*Version

### DIFF
--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -478,6 +478,11 @@ func (s *BaseSuite) MustStartExperimentPreviousVersion() {
 	// Arrange
 	agentVersion := s.StableAgentVersion().Version()
 
+	// xperf covers the full experiment window: from daemon restart through installer
+	// service startup, capturing the SCM service start sequence on failure.
+	s.startxperf()
+	defer s.collectxperf()
+
 	// Act
 	s.WaitForDaemonToStop(func() {
 		_, err := s.startExperimentPreviousVersion()
@@ -689,6 +694,11 @@ func (s *BaseSuite) MustStartExperimentCurrentVersion() {
 	// Arrange
 	agentVersion := s.CurrentAgentVersion().Version()
 
+	// xperf covers the full experiment window: from daemon restart through installer
+	// service startup, capturing the SCM service start sequence on failure.
+	s.startxperf()
+	defer s.collectxperf()
+
 	// Act
 	s.WaitForDaemonToStop(func() {
 		_, err := s.StartExperimentCurrentVersion()
@@ -824,9 +834,6 @@ func (s *BaseSuite) WaitForDaemonToStop(f func(), opts ...backoff.RetryOption) {
 
 	originalStartTime, err := windowscommon.GetProcessStartTimeAsFileTimeUtc(s.Env().RemoteHost, originalPID)
 	s.Require().NoError(err)
-
-	s.startxperf()
-	defer s.collectxperf()
 
 	f()
 

--- a/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
+++ b/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v6"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
@@ -100,7 +102,7 @@ func (s *testPersistingIntegrationsSuite) TestPersistingIntegrations() {
 	assert.NotEqual(s.T(), productVersionPre, productVersionPost, "product version should be different after upgrade")
 
 	// check that the third party integration is still installed
-	s.checkIntegrationInstall(vm, thirdPartyIntegration)
+	s.checkIntegrationInstall(vm, thirdPartyIntegration, filepath.Join(s.SessionOutputDir(), "upgrade.log"))
 
 	// check that the pip package is still installed
 	s.checkPipPackageInstalled(vm, pipPackage)
@@ -417,7 +419,7 @@ func (s *testIntegrationRollback) TestIntegrationRollback() {
 	s.Require().NoError(err, "should write file")
 
 	// check to see if datadog-ping==1.0.2 is still installed
-	s.checkIntegrationInstall(vm, thirdPartyIntegration)
+	s.checkIntegrationInstall(vm, thirdPartyIntegration, filepath.Join(s.SessionOutputDir(), "upgrade.log"))
 
 	// upgrade again without failure
 	if !s.Run("upgrade to "+s.upgradeAgentPackge.AgentVersion(), func() {
@@ -432,7 +434,7 @@ func (s *testIntegrationRollback) TestIntegrationRollback() {
 		s.T().FailNow()
 	}
 
-	s.checkIntegrationInstall(vm, thirdPartyIntegration)
+	s.checkIntegrationInstall(vm, thirdPartyIntegration, filepath.Join(s.SessionOutputDir(), "upgrade.log"))
 
 	s.uninstallAgent()
 
@@ -515,7 +517,7 @@ func (s *testPersistingIntegrationsDuringUninstall) TestPersistingIntegrationsDu
 	assert.NotEqual(s.T(), productVersionPre, productVersionPost, "product version should be different after upgrade")
 
 	// check that the third party integration is still installed
-	s.checkIntegrationInstall(vm, thirdPartyIntegration)
+	s.checkIntegrationInstall(vm, thirdPartyIntegration, filepath.Join(s.SessionOutputDir(), "upgrade.log"))
 
 	// check that the pip package is still installed
 	s.checkPipPackageInstalled(vm, pipPackage)
@@ -613,12 +615,35 @@ func (s *baseAgentMSISuite) getInstalledIntegrations(vm *components.RemoteHost) 
 	return out, nil
 }
 
-func (s *baseAgentMSISuite) checkIntegrationInstall(vm *components.RemoteHost, integration string) {
+func (s *baseAgentMSISuite) checkIntegrationInstall(vm *components.RemoteHost, integration string, msiLogFile string) {
 	out, err := s.getInstalledIntegrations(vm)
 	s.Require().NoError(err, "should get installed integrations")
 
 	// we use strings.Contains to limit output on failure
-	assert.True(s.T(), strings.Contains(out, integration), "third party integration should be installed")
+	if !assert.True(s.T(), strings.Contains(out, integration), "third party integration should be installed") {
+		// Check the MSI log for known transient failure modes to aid investigation
+		if content, readErr := readMSILog(msiLogFile); readErr == nil {
+			for _, line := range strings.Split(content, "\n") {
+				if strings.Contains(line, "DownloadHTTPError") {
+					s.T().Logf("NOTE: %s: TUF DownloadHTTPError detected — the post-upgrade integration restore failed because the download service was temporarily unavailable. This is a transient infrastructure flake unrelated to the MSI code. For a permanent fix, contact agent-delivery/agent-integrations.\n  %s", filepath.Base(msiLogFile), strings.TrimSpace(line))
+				}
+			}
+		}
+	}
+}
+
+// readMSILog reads an MSI log file and returns its contents as a UTF-8 string.
+// MSI log files are written in UTF-16LE with a BOM.
+func readMSILog(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	decoded, _, err := transform.Bytes(unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder(), data)
+	if err != nil {
+		return "", err
+	}
+	return string(decoded), nil
 }
 
 func (s *baseAgentMSISuite) checkIntegrationNotInstalled(vm *components.RemoteHost, integration string) {


### PR DESCRIPTION
### What does this PR do?

Moves the xperf kernel trace from `WaitForDaemonToStop` into `MustStartExperimentCurrentVersion` and `MustStartExperimentPreviousVersion`, so the trace spans the full experiment lifecycle: daemon restart → MSI install → installer service startup → `WaitForInstallerService`.

### Motivation

Investigation of [WINA-2857](https://datadoghq.atlassian.net/browse/WINA-2857) found that the xperf trace never covered the window that matters. `WaitForDaemonToStop` stopped the trace when the daemon PID changed (~15s in), but installer service startup failures (SCM 30-second timeouts) happen during `WaitForInstallerService` 2+ minutes later. The trace was also being silently overwritten by subsequent `collectxperf` calls before it could be collected.

[WINA-2857]: https://datadoghq.atlassian.net/browse/WINA-2857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ