### PR TITLE
fix(clusterchecks): break instead of continue on moveConfig failure

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -302,7 +302,7 @@ func (d *dispatcher) rebalanceUsingBusyness() []types.RebalanceResponse {
 				err = d.moveConfig(sourceNodeName, destNodeName, digest)
 				if err != nil {
 					log.Debugf("Cannot move config %s: %v", digest, err)
-					continue
+					break
 				}
 
 				successfulRebalancing.Inc(le.JoinLeaderValue)

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -10,6 +10,7 @@ package clusterchecks
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2050,4 +2051,66 @@ func TestRebalanceIsWorthIt(t *testing.T) {
 	proposedDistribution.addConfig("check3", "check3", 1, "runner3", false)
 
 	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10))
+}
+
+// TestRebalanceUsingBusyness_BreaksOnMoveConfigFailure verifies that the inner
+// rebalancing loop exits (break) when moveConfig fails, rather than retrying
+// the same failing move indefinitely (continue). The latter would spike the
+// rebalancing_decisions telemetry counter and potentially hang the process.
+func TestRebalanceUsingBusyness_BreaksOnMoveConfigFailure(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	dispatcher := newDispatcher(fakeTagger)
+
+	mockClient := &rebalanceTestClcRunnerClient{
+		testStats: make(map[string]types.CLCRunnersStats),
+	}
+	dispatcher.clcRunnersClient = mockClient
+	dispatcher.store.active = true
+
+	// Deliberately leave digestToConfig empty for "digestA1".
+	// This causes moveConfig to return "no config registered" without moving
+	// anything, while pickConfigToMove still selects "digestA1" (it only needs
+	// idToDigest, not digestToConfig).
+	dispatcher.store.idToDigest[checkid.ID("checkA0")] = "digestA0"
+	dispatcher.store.idToDigest[checkid.ID("checkA1")] = "digestA1"
+	dispatcher.store.digestToConfig["digestA0"] = integration.Config{Name: "checkA0"}
+	// digestToConfig["digestA1"] intentionally absent to force moveConfig failure
+	dispatcher.store.digestToNode["digestA0"] = "A"
+	dispatcher.store.digestToNode["digestA1"] = "A"
+
+	// Node A: two cluster checks; checkA1 is heavier and will be picked first.
+	// With default weights (checkMetricSamplesWeight=1), busyness(A) = 100.
+	nodeAStats := types.CLCRunnersStats{
+		"checkA0": {MetricSamples: 30},
+		"checkA1": {MetricSamples: 70},
+	}
+	dispatcher.store.nodes["A"] = newNodeStore("A", "10.0.0.1")
+	mockClient.testStats["10.0.0.1"] = nodeAStats
+
+	// Node B: empty, busyness 0. avg = 50, diffMap[A]=+50, diffMap[B]=-50.
+	dispatcher.store.nodes["B"] = newNodeStore("B", "10.0.0.2")
+	mockClient.testStats["10.0.0.2"] = types.CLCRunnersStats{}
+
+	// The algorithm will:
+	//   1. pickConfigToMove("A") → "digestA1"
+	//   2. moveConfig("A", "B", "digestA1") → error (no digestToConfig entry)
+	//   3. With the fix (break): loop exits; node A is unchanged
+	//      Without the fix (continue): loop spins indefinitely
+	done := make(chan struct{})
+	go func() {
+		dispatcher.rebalanceUsingBusyness()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Algorithm terminated as expected.
+	case <-time.After(5 * time.Second):
+		t.Fatal("rebalanceUsingBusyness did not terminate: possible infinite loop on moveConfig failure (continue vs break bug)")
+	}
+
+	// No move should have occurred: digestA1 still belongs to A and A's stats are intact.
+	assert.Equal(t, "A", dispatcher.store.digestToNode["digestA1"])
+	assert.Contains(t, dispatcher.store.nodes["A"].clcRunnerStats, "checkA1")
+	assert.Empty(t, dispatcher.store.nodes["B"].clcRunnerStats)
 }


### PR DESCRIPTION
### What does this PR do?

When moveConfig fails, the inner loop would **continue** without updating diffMap, causing pickConfigToMove to return the same digest repeatedly and spiking rebalancing_decisions/successful_rebalancing_moves counters. This changes it to **break** like all of the other exit conditions within the loop.

### Motivation

Fix `rebalancing_decisions` and `successful_rebalancing_moves` to properly report values.

[CONTP-1759]

### Describe how you validated your changes

Unit tests, if you run the new unit tests on the old version of the code, you can see the rebal algo infinitely cycling. With the fix, it's able to exit gracefully.

[CONTP-1759]: https://datadoghq.atlassian.net/browse/CONTP-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ