### PR TITLE
Fix the `omnibus.build-repackaged-agent` task

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -239,6 +239,7 @@ elsif do_package
   dependency 'datadog-agent-installer-symlinks'
   if do_repackage?
     dependency "existing-agent-package"
+    dependency "systemd" if linux_target?
     dependency "datadog-agent"
   else
     dependency "package-artifact"

--- a/omnibus/config/software/datadog-agent-installer-symlinks.rb
+++ b/omnibus/config/software/datadog-agent-installer-symlinks.rb
@@ -10,7 +10,8 @@ build do
 
   block do
     if linux_target? and install_dir == '/opt/datadog-agent'
-      command "bazel run --//:install_dir=#{install_dir} -- //packages/agent/linux:install --destdir='/'",
+      destdir = ENV["OMNIBUS_BASE_DIR"] || "/"
+      command "bazel run --//:install_dir=#{install_dir} -- //packages/agent/linux:install --destdir='#{destdir}'",
         :live_stream => Omnibus.logger.live_stream(:info)
       project.extra_package_file "/opt/datadog-packages/datadog-agent"
       project.extra_package_file "/opt/datadog-packages/run"

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -32,7 +32,13 @@ end
 
 source path: '..',
        options: {
-         exclude: ["**/.cache/**/*", "**/testdata/**/*"],
+         exclude: [
+           "**/.cache/**/*",
+           "**/testdata/**/*",
+           # Git's fsmonitor daemon creates a Unix socket that breaks builds both
+           # on the host and in a container with a bind-mounted repo.
+           "**/.git/fsmonitor--daemon.ipc",
+         ],
        }
 relative_path 'src/github.com/DataDog/datadog-agent'
 

--- a/omnibus/config/software/datadog-dogstatsd.rb
+++ b/omnibus/config/software/datadog-dogstatsd.rb
@@ -10,7 +10,7 @@ skip_transitive_dependency_licensing true
 
 source path: '..',
        options: {
-         exclude: ["**/.cache/**/*"],
+         exclude: ["**/.cache/**/*", "**/.git/fsmonitor--daemon.ipc"],
        }
 relative_path 'src/github.com/DataDog/datadog-agent'
 

--- a/omnibus/config/software/datadog-iot-agent.rb
+++ b/omnibus/config/software/datadog-iot-agent.rb
@@ -10,7 +10,7 @@ name 'datadog-iot-agent'
 
 source path: '..',
        options: {
-         exclude: ["**/.cache/**/*"],
+         exclude: ["**/.cache/**/*", "**/.git/fsmonitor--daemon.ipc"],
        }
 relative_path 'src/github.com/DataDog/datadog-agent'
 

--- a/omnibus/config/software/datadog-otel-agent.rb
+++ b/omnibus/config/software/datadog-otel-agent.rb
@@ -15,6 +15,7 @@ source path: '..',
          exclude: [
            "**/.cache/**/*",
            "**/testdata/**/*",
+           "**/.git/fsmonitor--daemon.ipc",
          ],
        }
 relative_path 'src/github.com/DataDog/datadog-agent'

--- a/omnibus/config/software/existing-agent-package.rb
+++ b/omnibus/config/software/existing-agent-package.rb
@@ -2,6 +2,9 @@ name 'existing-agent-package'
 
 description 'A previously built artifact, unpacked'
 
+require 'fileutils'
+require 'shellwords'
+
 always_build true
 
 source_url = ENV['OMNIBUS_REPACKAGE_SOURCE_URL']
@@ -11,5 +14,20 @@ source url: source_url,
        target_filename: target_package
 
 build do
-  command "dpkg --unpack #{target_package}"
+  destdir = ENV["OMNIBUS_BASE_DIR"] || "/"
+
+  block "Prepare package extraction root" do
+    FileUtils.mkdir_p(destdir)
+  end
+
+  command "dpkg-deb -x #{Shellwords.escape(target_package)} #{Shellwords.escape(destdir)}"
+
+  if destdir != "/"
+    staged_install_dir = File.join(destdir, install_dir.sub(%r{\A/+}, ""))
+
+    block "Populate install directory from extracted package" do
+      FileUtils.mkdir_p(install_dir)
+      FileUtils.cp_r("#{staged_install_dir}/.", install_dir, preserve: true)
+    end
+  end
 end

--- a/omnibus/config/software/existing-agent-package.rb
+++ b/omnibus/config/software/existing-agent-package.rb
@@ -27,7 +27,7 @@ build do
 
     block "Populate install directory from extracted package" do
       FileUtils.mkdir_p(install_dir)
-      FileUtils.cp_r("#{staged_install_dir}/.", install_dir, preserve: true)
+      FileUtils.cp_r("#{staged_install_dir}/.", install_dir)
     end
   end
 end

--- a/omnibus/config/software/existing-agent-package.rb
+++ b/omnibus/config/software/existing-agent-package.rb
@@ -25,8 +25,12 @@ build do
   if destdir != "/"
     staged_install_dir = File.join(destdir, install_dir.sub(%r{\A/+}, ""))
 
+    # GNU `chmod -R` skips symlinks; `FileUtils.chmod_R` with a symbolic mode stats each
+    # entry and raises ENOENT on the package's absolute symlinks, which dangle until the
+    # install dir is repopulated.
+    command "chmod -R u+rwX #{Shellwords.escape(staged_install_dir)}"
+
     block "Populate install directory from extracted package" do
-      FileUtils.chmod_R("u+rwX", staged_install_dir)
       FileUtils.mkdir_p(install_dir)
       FileUtils.cp_r("#{staged_install_dir}/.", install_dir)
     end

--- a/omnibus/config/software/existing-agent-package.rb
+++ b/omnibus/config/software/existing-agent-package.rb
@@ -26,6 +26,7 @@ build do
     staged_install_dir = File.join(destdir, install_dir.sub(%r{\A/+}, ""))
 
     block "Populate install directory from extracted package" do
+      FileUtils.chmod_R("u+rwX", staged_install_dir)
       FileUtils.mkdir_p(install_dir)
       FileUtils.cp_r("#{staged_install_dir}/.", install_dir)
     end

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -11,7 +11,7 @@ name 'installer'
 
 source path: '..',
        options: {
-         exclude: ["**/.cache/**/*", "**/testdata/**/*"],
+         exclude: ["**/.cache/**/*", "**/testdata/**/*", "**/.git/fsmonitor--daemon.ipc"],
        }
 relative_path 'src/github.com/DataDog/datadog-agent'
 

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -286,7 +286,12 @@ module Omnibus
   # absolute files from the staged root when available.
   module PackagerExtraPackageFileStagedRoot
     def copy_file(source, destination)
-      super(staged_extra_package_source(source), destination)
+      staged_source = staged_extra_package_source(source)
+      if staged_source != source.to_s && File.directory?(staged_source)
+        FileUtils.cp_r(staged_source.chomp("/"), destination)
+      else
+        super(staged_source, destination)
+      end
     end
 
     private

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -280,6 +280,30 @@ module Omnibus
 
   Packager::PKG.prepend PackagerPKGNotarizer
 
+  # Repackaged builds may extract external package files under OMNIBUS_BASE_DIR
+  # because non-root dev environments cannot write paths like /usr/bin. Keep the
+  # declared extra_package_file path as the final package path, but source missing
+  # absolute files from the staged root when available.
+  module PackagerExtraPackageFileStagedRoot
+    def copy_file(source, destination)
+      super(staged_extra_package_source(source), destination)
+    end
+
+    private
+
+    def staged_extra_package_source(source)
+      base_dir = ENV["OMNIBUS_BASE_DIR"]
+      source = source.to_s
+      return source if base_dir.nil? || base_dir.empty? || !source.start_with?("/") || File.exist?(source)
+
+      staged_source = File.join(base_dir, source.sub(%r{\A/+}, ""))
+      File.exist?(staged_source) ? staged_source : source
+    end
+  end
+
+  Packager::DEB.prepend PackagerExtraPackageFileStagedRoot
+  Packager::RPM.prepend PackagerExtraPackageFileStagedRoot
+
   # The legacy Omnibus RPM packager builds its file list by globbing the staging
   # tree. When Omnibus stages an external extra_package_file, it creates parent
   # directories in that tree as an implementation detail. Without filtering,

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -299,7 +299,7 @@ module Omnibus
     def staged_extra_package_source(source)
       base_dir = ENV["OMNIBUS_BASE_DIR"]
       source = source.to_s
-      return source if base_dir.nil? || base_dir.empty? || !source.start_with?("/") || File.exist?(source)
+      return source if base_dir.nil? || base_dir.empty? || !source.start_with?("/")
 
       staged_source = File.join(base_dir, source.sub(%r{\A/+}, ""))
       File.exist?(staged_source) ? staged_source : source

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -36,6 +36,7 @@ ENV_PASSHTROUGH = {
     'INTEGRATIONS_WHEELS_STORAGE': 'Storage tier ("dev" or "stable") for integration dependency wheels, expanded by pip in lockfiles',
     'MY_RUBY_HOME': 'rvm / Ruby stuff to make sure Omnibus itself runs correctly',
     'OMNIBUS_FORCE_PACKAGES': 'Force Omnibus to build actual packages',
+    'OMNIBUS_BASE_DIR': 'Base directory used by Omnibus for build state and staged filesystem roots',
     'OMNIBUS_GIT_CACHE_DIR': 'Local directory used by Omnibus for the local git cache',
     'OMNIBUS_PACKAGE_ARTIFACT_DIR': 'Directory to take the base artifact from on "packaging-only" mode',
     'PACKAGE_ARCH': 'Target architecture',

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -36,7 +36,6 @@ ENV_PASSHTROUGH = {
     'INTEGRATIONS_WHEELS_STORAGE': 'Storage tier ("dev" or "stable") for integration dependency wheels, expanded by pip in lockfiles',
     'MY_RUBY_HOME': 'rvm / Ruby stuff to make sure Omnibus itself runs correctly',
     'OMNIBUS_FORCE_PACKAGES': 'Force Omnibus to build actual packages',
-    'OMNIBUS_BASE_DIR': 'Base directory used by Omnibus for build state and staged filesystem roots',
     'OMNIBUS_GIT_CACHE_DIR': 'Local directory used by Omnibus for the local git cache',
     'OMNIBUS_PACKAGE_ARTIFACT_DIR': 'Directory to take the base artifact from on "packaging-only" mode',
     'PACKAGE_ARCH': 'Target architecture',

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -517,7 +517,7 @@ def build_repackaged_agent(ctx, log_level="info"):
         ctx,
         "build",
         "agent",
-        base_dir=None,
+        base_dir=_resolve_omnibus_path_override(None, "OMNIBUS_BASE_DIR"),
         env=env,
         log_level=log_level,
         cache_dir=_resolve_omnibus_path_override(None, "OMNIBUS_CACHE_DIR"),

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -62,6 +63,15 @@ def omnibus_run_task(
 
         with gitlab_section(f"Running omnibus task {task}", collapsed=True):
             ctx.run(cmd.format(**args), env=env, replace_env=True, err_stream=sys.stdout)
+
+
+def _clear_agent_install_directory(agent_path):
+    with os.scandir(agent_path) as entries:
+        for entry in entries:
+            if entry.is_dir(follow_symlinks=False):
+                shutil.rmtree(entry.path)
+            else:
+                os.unlink(entry.path)
 
 
 def bundle_install_omnibus(ctx, gem_path=None, env=None, max_try=2):
@@ -462,9 +472,7 @@ def build_repackaged_agent(ctx, log_level="info"):
         ):
             raise Exit("Operation cancelled")
 
-        import shutil
-
-        shutil.rmtree("/opt/datadog-agent")
+        _clear_agent_install_directory(agent_path)
 
     architecture = ctx.run("dpkg --print-architecture", hide=True).stdout.strip()
 

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -493,6 +493,10 @@ def build_repackaged_agent(ctx, log_level="info"):
 
     env['OMNIBUS_REPACKAGE_SOURCE_URL'] = f"https://apt.datad0g.com/{latest_package.filename}"
     env['OMNIBUS_REPACKAGE_SOURCE_SHA256'] = latest_package.sha256
+    base_dir = _resolve_omnibus_path_override(None, "OMNIBUS_BASE_DIR")
+    if base_dir:
+        env['OMNIBUS_BASE_DIR'] = base_dir
+
     # Set up compiler flags (assumes an environment based on our glibc-targeting toolchains)
     if architecture == "amd64":
         env.update(
@@ -517,7 +521,7 @@ def build_repackaged_agent(ctx, log_level="info"):
         ctx,
         "build",
         "agent",
-        base_dir=_resolve_omnibus_path_override(None, "OMNIBUS_BASE_DIR"),
+        base_dir=base_dir,
         env=env,
         log_level=log_level,
         cache_dir=_resolve_omnibus_path_override(None, "OMNIBUS_CACHE_DIR"),

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -257,6 +257,14 @@ class TestOmnibusRunTask(unittest.TestCase):
         self.assertEqual(command.count("--override="), 1)
 
 
+class TestOmnibusEnvPassthrough(unittest.TestCase):
+    def test_omnibus_base_dir_is_forwarded_to_recipes(self):
+        with mock.patch('tasks.omnibus.warnings.warn'):
+            env = omnibus._passthrough_env_for_os({'OMNIBUS_BASE_DIR': '/var/cache/dd/omnibus'}, 'linux')
+
+        self.assertEqual(env['OMNIBUS_BASE_DIR'], '/var/cache/dd/omnibus')
+
+
 class TestOmnibusInstall(unittest.TestCase):
     def setUp(self):
         self.mock_ctx = MockContextRaising(run={})

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -258,11 +258,11 @@ class TestOmnibusRunTask(unittest.TestCase):
 
 
 class TestOmnibusEnvPassthrough(unittest.TestCase):
-    def test_omnibus_base_dir_is_forwarded_to_recipes(self):
+    def test_omnibus_base_dir_is_not_forwarded_to_regular_builds(self):
         with mock.patch('tasks.omnibus.warnings.warn'):
             env = omnibus._passthrough_env_for_os({'OMNIBUS_BASE_DIR': '/var/cache/dd/omnibus'}, 'linux')
 
-        self.assertEqual(env['OMNIBUS_BASE_DIR'], '/var/cache/dd/omnibus')
+        self.assertNotIn('OMNIBUS_BASE_DIR', env)
 
 
 class TestOmnibusInstall(unittest.TestCase):
@@ -452,3 +452,41 @@ Description: Datadog Monitoring Agent
                 'https://apt.datad0g.com/pool/d/da/datadog-agent_7.67.0~devel.git.113.2750233.pipeline.63448947-1_amd64.deb',
             )
             self.assertEqual(env['OMNIBUS_REPACKAGE_SOURCE_SHA256'], 'def456abc789')
+
+    def test_repackaged_agent_uses_omnibus_path_overrides(self):
+        packages_content = """
+Package: datadog-agent
+Version: 1:7.67.0~devel.git.113.2750233.pipeline.63448947-1
+Architecture: amd64
+Filename: pool/d/da/datadog-agent_7.67.0~devel.git.113.2750233.pipeline.63448947-1_amd64.deb
+SHA256: def456abc789
+Description: Datadog Monitoring Agent
+"""
+        mock_ctx = MockContextRaising(run={})
+        mock_ctx.set_result_for('run', re.compile(r'dpkg --print-architecture'), Result('amd64'))
+
+        with (
+            mock.patch.dict(
+                os.environ,
+                {
+                    'OMNIBUS_BASE_DIR': '/var/cache/dd/omnibus',
+                    'OMNIBUS_CACHE_DIR': '/var/cache/dd/omnibus/cache',
+                },
+                clear=True,
+            ),
+            mock.patch('os.path.exists', return_value=False),
+            mock.patch('tasks.omnibus.get_omnibus_env', return_value={}),
+            mock.patch('tasks.omnibus.bundle_install_omnibus'),
+            mock.patch('tasks.omnibus.omnibus_run_task') as mock_run_task,
+            mock.patch('requests.get') as mock_get,
+        ):
+            mock_response = mock.MagicMock()
+            mock_response.__enter__.return_value.iter_lines.return_value = packages_content.splitlines()
+            mock_get.return_value = mock_response
+
+            omnibus.build_repackaged_agent(mock_ctx)
+
+        _, kwargs = mock_run_task.call_args
+        self.assertEqual(kwargs['base_dir'], '/var/cache/dd/omnibus')
+        self.assertEqual(kwargs['cache_dir'], '/var/cache/dd/omnibus/cache')
+        self.assertEqual(kwargs['env']['OMNIBUS_BASE_DIR'], '/var/cache/dd/omnibus')


### PR DESCRIPTION
### Motivation

When one has permission to write to `/opt/datadog-agent/` but not `/opt/`, like the new `dd` user in our developer environments, the task fails:

```
❯ dda inv -- -e omnibus.build-repackaged-agent
The Agent installation directory /opt/datadog-agent already exists, and will be overwritten by this build. Continue? [y/N] y
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/var/lib/dd/dda/venvs/legacy/lib/python3.12/site-packages/invoke/__main__.py", line 3, in <module>
    program.run()
  File "/var/lib/dd/dda/venvs/legacy/lib/python3.12/site-packages/invoke/program.py", line 398, in run
    self.execute()
  File "/var/lib/dd/dda/venvs/legacy/lib/python3.12/site-packages/invoke/program.py", line 583, in execute
    executor.execute(*self.tasks)
  File "/var/lib/dd/dda/venvs/legacy/lib/python3.12/site-packages/invoke/executor.py", line 140, in execute
    result = call.task(*args, **call.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/repos/datadog-agent/tasks/custom_task/custom_task.py", line 149, in custom__call__
    result = self.body(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/repos/datadog-agent/tasks/omnibus.py", line 467, in build_repackaged_agent
    shutil.rmtree("/opt/datadog-agent")
  File "/usr/lib/python3.12/shutil.py", line 796, in rmtree
    onexc(os.rmdir, path, err)
  File "/usr/lib/python3.12/shutil.py", line 794, in rmtree
    os.rmdir(path, dir_fd=dir_fd)
PermissionError: [Errno 13] Permission denied: '/opt/datadog-agent'
```