### PR TITLE
(fleet) key the minimize-btfs cache on CO-RE BPF object content instead of the full sysprobe build hash

### DIFF
--- a/.gitlab/build/package_deps_build/package_deps_build.yml
+++ b/.gitlab/build/package_deps_build/package_deps_build.yml
@@ -11,8 +11,14 @@
   script:
     - cd $CI_PROJECT_DIR
     - export BTFS_ETAG=$(aws s3api head-object --region us-east-1 --bucket dd-agent-omnibus --key btfs/$BTFHUB_ARCHIVE_BRANCH/btfs-$ARCH.tar --query ETag --output text | tr -d \")
-    - export OUTPUTS_HASH=$(sha256sum sysprobe-build-outputs.tar.xz.sum | cut -d' ' -f1)
-    - export MIN_BTFS_FILENAME=minimized-btfs-v2-$BTFS_ETAG-$OUTPUTS_HASH.tar.xz
+    # extract sysprobe outputs up front so the cache key can be derived from the
+    # CO-RE BPF objects, the only inputs that affect the minimized BTF set.
+    - tar -xf sysprobe-build-outputs.tar.xz
+    # exp-0005: key on a stable content hash of just the co-re .o objects so
+    # unrelated commits (which perturb the full outputs tarball but not the
+    # CO-RE BTF requirements) reuse the cached minimized set. v2->v3.
+    - export OUTPUTS_HASH=$(find "$CI_PROJECT_DIR/pkg/ebpf/bytecode/build/${ARCH}/co-re" -name '*.o' -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)
+    - export MIN_BTFS_FILENAME=minimized-btfs-v3-$BTFS_ETAG-$OUTPUTS_HASH.tar.xz
     - |
       # if running all builds, or this is a release branch, skip the cache check
       if [[ "$RUN_ALL_BUILDS" != "true" && ! $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/ ]]; then
@@ -25,7 +31,6 @@
     # cache does not exist, download processed BTFs and minimize
     - $S3_CP_CMD $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-$ARCH.tar .
     - tar -xf btfs-$ARCH.tar
-    - tar -xf sysprobe-build-outputs.tar.xz
     - dda inv -- -e system-probe.generate-minimized-btfs --source-dir "$CI_PROJECT_DIR/btfs-$ARCH" --output-dir "$CI_PROJECT_DIR/minimized-btfs" --bpf-programs "$CI_PROJECT_DIR/pkg/ebpf/bytecode/build/${ARCH}/co-re"
     - cd minimized-btfs
     - tar --mtime=@0 -cJf $CI_PROJECT_DIR/minimized-btfs.tar.xz *


### PR DESCRIPTION
## Summary
This PR changes the S3 cache key for the `generate_minimized_btfs` step so it is derived from the content hash of the CO-RE BPF `.o` objects (the actual inputs to BTF minimization) rather than the full `sysprobe-build-outputs` hash. Unrelated commits that do not change the BPF programs' BTF requirements then hit the cache instead of re-running the full minimization.

## Motivation
`minimize-btfs` is a large, frequently-cache-missing preamble step. On a measured `deb`/`x86` build, the content-hash key reduced the preamble segment by ~161s on a cache hit.

## ⚠️ Draft — needs CO-RE correctness validation
This changes a cache key for a runtime-correctness-sensitive artifact (minimized BTFs feed CO-RE relocation at runtime). Before this can leave draft it must be validated that the content-hash key can never serve a stale minimized-BTF set across the supported kernel matrix — a stale set would cause runtime CO-RE breakage. Opening as a draft specifically to get that review.
