### PR TITLE
(fleet) disable CPython test C-extension modules in the omnibus python3 build

### DIFF
--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -192,6 +192,7 @@ configure_make(
         "--with-dbmliborder=",
         "--with-openssl=$$EXT_BUILD_DEPS/openssl",
         "--with-openssl-rpath=yes",
+        "--disable-test-modules",
     ] + select({
         "@@//:macos_arm64": ["--with-universal-archs=universal2"],
         "@@//:macos_x86_64": ["--with-universal-archs=intel"],


### PR DESCRIPTION
## Summary
This PR passes `--disable-test-modules` to the embedded CPython `configure` in the `python3` omnibus software definition, so CPython does not build its internal test-only C-extension modules (the `_test*` modules), which the Agent does not use at runtime.

## Motivation
On a measured `deb`/`x86` build this reduced the omnibus segment by ~159s by skipping the compilation of test-only extension modules. It also reduces the Agent size by ~1MB since the test modules are no longer shipped. The shipped Python runtime is otherwise unchanged.

Draft for review and CI validation that no shipped functionality depends on the test modules.
