### PR TITLE
(fleet) prune non-core integrations from the omnibus integrations build on non-deploy builds

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -38,6 +38,22 @@ excluded_folders = [
   'tokumx',                        # py2-only, unsupported by current Agent
 ]
 
+# Prune non-core integrations for fast deb/x86 non-deploy testing builds.
+# Gated by OMNIBUS_INTEGRATIONS_CORE_ONLY (set in tasks/omnibus.py only on
+# non-deploy testing builds), so production/deploy debs are unaffected.
+# collect-integrations (tasks/agent.py) skips any folder named in `excluded`,
+# so these checks are never wheel-built, never installed, and never iterated
+# in the conf-copy loop. base/downloader packages are installed explicitly
+# outside this loop and are not affected.
+if ENV['OMNIBUS_INTEGRATIONS_CORE_ONLY'] == 'true'
+  non_core_integrations = [
+    'ibm_mq', 'ibm_ace', 'ibm_db2', 'ibm_i', 'ibm_was',
+    'aerospike', 'teradata', 'sap_hana', 'cloudera', 'aspdotnet',
+    'oracle', 'snowflake', 'vertica', 'voltdb', 'singlestore',
+  ]
+  excluded_folders.concat(non_core_integrations)
+end
+
 if osx_target?
   # Temporarily exclude Aerospike until builder supports new dependency
   excluded_folders.push('aerospike')

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -184,6 +184,14 @@ def get_omnibus_env(
     if kubernetes_cpu_request:
         env['OMNIBUS_WORKERS_OVERRIDE'] = str(int(kubernetes_cpu_request) + 1)
 
+    # On non-deploy (testing) builds, prune the non-core long-tail integrations
+    # from the datadog-agent-integrations-py3 software def. The artifact is not
+    # shipped, so it does not need the full vendor integration set. This shrinks
+    # the wheel-install set and the per-check conf-copy loop (see
+    # omnibus/config/software/datadog-agent-integrations-py3.rb).
+    if os.environ.get('OMNIBUS_PACKAGE_ARTIFACT_DIR') is None and os.environ.get('DEPLOY_AGENT') != 'true':
+        env['OMNIBUS_INTEGRATIONS_CORE_ONLY'] = 'true'
+
     env_to_forward = _passthrough_env_for_os(os.environ, sys.platform)
     env.update(env_to_forward)
 


### PR DESCRIPTION
## Summary
This PR excludes a set of non-core Python integrations (e.g. `ibm_*`, `aerospike`, `teradata`, `oracle`, `snowflake`) from the `datadog-agent-integrations-py3` omnibus build on non-deploy (testing) builds, via `excluded_folders` gated on a new `OMNIBUS_INTEGRATIONS_CORE_ONLY` flag set only for non-deploy builds. Deploy/release builds are unaffected and still ship the full integration set.

## Motivation
The per-integration pip wheel builds are a large part of the omnibus segment. On a measured `deb`/`x86` testing build, pruning the non-core set reduced the omnibus segment by ~229s. The change is scoped to non-deploy builds so released packages are unchanged.

Draft for review of the excluded set and the non-deploy gating.
