### PR TITLE
(fleet) migrate minimize-btfs to Bazel (bpftool toolchain + min_core_btf rule)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -199,6 +199,23 @@ use_repo(llvm_bpf_ext, "llvm_bpf")
 
 register_toolchains("@llvm_bpf//:llvm_bpf_toolchain")
 
+######################################
+## bpftool toolchain for BTF minimization ##
+####################################
+
+bpftool_ext = use_extension("//bazel/toolchains/bpftool:bpftool_configure.bzl", "bpftool_extension")
+bpftool_ext.configure(
+    base_url = "https://github.com/libbpf/bpftool/releases/download/v7.5.0",
+    sha256s = {
+        "amd64": "6b81db78c797e63f13e644ceb2064e5236afaf904bbaaa367785170819768f0a",
+        "arm64": "80e0d5b59bfbc7ecce06985802babf4c2b4ff78be3640202a19e3d7278fceb7b",
+    },
+    version = "v7.5.0",
+)
+use_repo(bpftool_ext, "bpftool")
+
+register_toolchains("@bpftool//:bpftool_toolchain")
+
 ## Linux kernel headers for eBPF prebuilt compilation
 ## Registers three repos: host auto-detect + explicit x86_64 + explicit aarch64
 ## for cross-compilation via --//bazel/rules/ebpf:target_arch=<arch>.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -267,6 +267,27 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "//bazel/toolchains/bpftool:bpftool_configure.bzl%bpftool_extension": {
+      "general": {
+        "bzlTransitiveDigest": "qDgY8Ue6TyhftZHIp8HCd32KOBE7cVOYBEBJLGxRVLY=",
+        "usagesDigest": "aEsSiHd9mgMRBaR508s1Q8iHN978iuHlPyguWYZTVCo=",
+        "recordedInputs": [],
+        "generatedRepoSpecs": {
+          "bpftool": {
+            "repoRuleId": "@@//bazel/toolchains/bpftool:bpftool_configure.bzl%download_bpftool",
+            "attributes": {
+              "base_url": "https://github.com/libbpf/bpftool/releases/download/v7.5.0",
+              "version": "v7.5.0",
+              "sha256s": {
+                "amd64": "6b81db78c797e63f13e644ceb2064e5236afaf904bbaaa367785170819768f0a",
+                "arm64": "80e0d5b59bfbc7ecce06985802babf4c2b4ff78be3640202a19e3d7278fceb7b"
+              },
+              "verbose": false
+            }
+          }
+        }
+      }
+    },
     "//bazel/toolchains/linux_headers:linux_headers.bzl%linux_headers_extension": {
       "general": {
         "bzlTransitiveDigest": "st+R/ulVqPkT0R/t3yLLAqOk8EAK4MzET2sMpfW8YB4=",

--- a/bazel/rules/ebpf/BUILD.bazel
+++ b/bazel/rules/ebpf/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//bazel/rules/ebpf:cgo_godefs_test.bzl", "cgo_godefs_test_suite")
+load("//bazel/rules/ebpf:min_core_btf_test.bzl", "min_core_btf_test_suite")
 
 string_flag(
     name = "target_arch",
@@ -18,3 +19,5 @@ config_setting(
 )
 
 cgo_godefs_test_suite(name = "cgo_godefs_tests")
+
+min_core_btf_test_suite(name = "min_core_btf_tests")

--- a/bazel/rules/ebpf/min_core_btf.bzl
+++ b/bazel/rules/ebpf/min_core_btf.bzl
@@ -1,0 +1,62 @@
+"""Bazel rule to generate a minimized CO-RE BTF for a single kernel.
+
+Replaces the ninja `minimize_btf` rule in `tasks/system_probe.py`
+(`bpftool gen min_core_btf <full-btf> <out-btf> <co-re .o files...>`), one Bazel
+action per kernel BTF.
+
+Why per-kernel actions: the cache key becomes hash(full BTF + CO-RE objects +
+bpftool + command line), content-addressed by Bazel and shared through the
+Buildbarn remote cache across CI pipelines and local dev. A btfhub update then
+re-minimizes only the kernels whose full BTF actually changed. (Note: because
+`min_core_btf` takes the union of all programs, any CO-RE `.o` change still
+re-minimizes every kernel — same blast radius as the current S3-cache approach on
+that axis.)
+"""
+
+_TOOLCHAIN_TYPE = "@@//bazel/toolchains/bpftool:bpftool_toolchain_type"
+
+def _min_core_btf_impl(ctx):
+    tc = ctx.toolchains[_TOOLCHAIN_TYPE].bpftool
+    if not tc.valid:
+        fail("bpftool toolchain is not available")
+
+    out = ctx.actions.declare_file(ctx.label.name + ".btf")
+    programs = ctx.files.programs
+
+    args = ctx.actions.args()
+    args.add("gen")
+    args.add("min_core_btf")
+    args.add(ctx.file.btf)
+    args.add(out)
+    args.add_all(programs)
+
+    ctx.actions.run(
+        inputs = depset([ctx.file.btf] + programs),
+        outputs = [out],
+        executable = tc.bpftool,
+        arguments = [args],
+        mnemonic = "MinCoreBtf",
+        toolchain = _TOOLCHAIN_TYPE,
+        progress_message = "Minimizing BTF %{label}",
+    )
+
+    return [DefaultInfo(files = depset([out]))]
+
+min_core_btf = rule(
+    implementation = _min_core_btf_impl,
+    doc = "Generate a minimized CO-RE BTF from one full kernel BTF and a set of " +
+          "CO-RE eBPF object files, using `bpftool gen min_core_btf`. Linux-only.",
+    attrs = {
+        "btf": attr.label(
+            mandatory = True,
+            allow_single_file = [".btf"],
+            doc = "The full (decompressed) kernel BTF to minimize.",
+        ),
+        "programs": attr.label_list(
+            allow_files = [".o"],
+            doc = "CO-RE eBPF object files whose referenced types the minimized " +
+                  "BTF must retain. Pass the ebpf_prog targets directly.",
+        ),
+    },
+    toolchains = [_TOOLCHAIN_TYPE],
+)

--- a/bazel/rules/ebpf/min_core_btf_test.bzl
+++ b/bazel/rules/ebpf/min_core_btf_test.bzl
@@ -1,0 +1,72 @@
+"""Analysis test for the min_core_btf rule.
+
+Validates the action graph (mnemonic, declared inputs, command line) without
+executing bpftool, so it is hermetic and free of any kernel-BTF runtime
+assumptions. This is the cache-correctness gate: it pins down exactly which
+inputs feed the action's cache key.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load(":min_core_btf.bzl", "min_core_btf")
+
+def _action_shape_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+
+    actions = analysistest.target_actions(env)
+    min_actions = [a for a in actions if a.mnemonic == "MinCoreBtf"]
+    asserts.equals(env, 1, len(min_actions), "expected exactly one MinCoreBtf action")
+
+    action = min_actions[0]
+    input_names = [f.basename for f in action.inputs.to_list()]
+
+    # The full BTF and every CO-RE program object must be declared inputs (they
+    # are what the action's cache key is content-addressed on).
+    asserts.true(
+        env,
+        "rc-btf-test.btf" in input_names,
+        "full BTF must be a declared input, got: {}".format(input_names),
+    )
+    asserts.true(
+        env,
+        "btf_test.o" in input_names,
+        "CO-RE program object must be a declared input, got: {}".format(input_names),
+    )
+
+    argv = action.argv
+    asserts.true(env, "gen" in argv, "argv must invoke `gen`")
+    asserts.true(env, "min_core_btf" in argv, "argv must invoke `min_core_btf`")
+
+    # The declared output is the minimized BTF.
+    outputs = [f.basename for f in tut[DefaultInfo].files.to_list()]
+    asserts.equals(env, ["min_btf_demo.btf"], outputs)
+
+    return analysistest.end(env)
+
+_action_shape_test = analysistest.make(_action_shape_test_impl)
+
+def min_core_btf_test_suite(name):
+    """Create the min_core_btf demo target plus its analysis test.
+
+    Args:
+        name: name of the generated test_suite.
+    """
+    min_core_btf(
+        name = "min_btf_demo",
+        btf = "//pkg/ebpf:testdata/rc-btf-test.btf",
+        programs = ["//cmd/system-probe/subcommands/ebpf/testdata:btf_test"],
+        target_compatible_with = ["@platforms//os:linux"],
+        tags = ["manual"],
+        visibility = ["//visibility:private"],
+    )
+
+    _action_shape_test(
+        name = "min_btf_demo_action_shape_test",
+        target_under_test = ":min_btf_demo",
+        target_compatible_with = ["@platforms//os:linux"],
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [":min_btf_demo_action_shape_test"],
+    )

--- a/bazel/toolchains/bpftool/BUILD.bazel
+++ b/bazel/toolchains/bpftool/BUILD.bazel
@@ -1,0 +1,14 @@
+"""bpftool toolchain for CO-RE BTF minimization."""
+
+load(":bpftool.bzl", "bpftool_toolchain")
+
+toolchain_type(
+    name = "bpftool_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+bpftool_toolchain(
+    name = "no_bpftool",
+    version = "unavailable",
+    visibility = ["//visibility:public"],
+)

--- a/bazel/toolchains/bpftool/bpftool.bzl
+++ b/bazel/toolchains/bpftool/bpftool.bzl
@@ -1,0 +1,34 @@
+"""bpftool toolchain rule and provider for CO-RE BTF minimization."""
+
+BpftoolToolchainInfo = provider(
+    doc = "bpftool binary used to generate minimized CO-RE BTFs.",
+    fields = {
+        "bpftool": "bpftool executable File, or None",
+        "version": "bpftool version string",
+        "valid": "Whether the toolchain is usable",
+    },
+)
+
+def _bpftool_toolchain_impl(ctx):
+    tool = ctx.executable.bpftool if ctx.attr.bpftool else None
+    return [platform_common.ToolchainInfo(
+        bpftool = BpftoolToolchainInfo(
+            bpftool = tool,
+            version = ctx.attr.version,
+            valid = tool != None,
+        ),
+    )]
+
+bpftool_toolchain = rule(
+    implementation = _bpftool_toolchain_impl,
+    doc = "Collects a bpftool binary and exposes it as a ToolchainInfo. Creates no actions.",
+    attrs = {
+        "bpftool": attr.label(
+            doc = "bpftool executable",
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
+        "version": attr.string(default = "unknown"),
+    },
+)

--- a/bazel/toolchains/bpftool/bpftool_configure.bzl
+++ b/bazel/toolchains/bpftool/bpftool_configure.bzl
@@ -1,0 +1,121 @@
+"""Repository rule to download a prebuilt bpftool binary for CO-RE BTF minimization.
+
+Mirrors `bazel/toolchains/llvm_bpf/llvm_bpf_configure.bzl`: a repository rule
+downloads a pinned, sha256-checked bpftool release and exposes it as a toolchain.
+
+The btf-gen build image builds bpftool from source (libbpf submodule, pinned to a
+git commit). For the Bazel migration we instead pull the upstream prebuilt static
+release: any recent bpftool produces a correct minimized BTF (a superset of the
+types referenced by the CO-RE programs), and pinning the exact bytes via sha256 is
+what makes the action hermetic and cacheable. The long-term home for these binaries
+is the `dd-agent-omnibus` S3 mirror used by the llvm_bpf toolchain (see PR notes);
+the GitHub release URL keeps the spike self-contained until that mirror exists.
+"""
+
+NAME = "bpftool"
+
+def _download_bpftool_impl(rctx):
+    # bpftool is a Linux-only tool. On other hosts we still create a (invalid)
+    # toolchain so analysis works everywhere; min_core_btf targets are
+    # target_compatible_with linux and are skipped on non-Linux platforms.
+    if "linux" not in rctx.os.name:
+        _write_build(rctx, valid = False)
+        return
+
+    arch = rctx.os.arch
+    if arch in ("x86_64", "amd64"):
+        arch = "amd64"
+    elif arch in ("aarch64", "arm64"):
+        arch = "arm64"
+    else:
+        fail("Unsupported architecture for bpftool toolchain: " + arch)
+
+    url = "{}/bpftool-{}-{}.tar.gz".format(rctx.attr.base_url, rctx.attr.version, arch)
+    sha256 = rctx.attr.sha256s.get(arch, "")
+
+    if rctx.attr.verbose:
+        # buildifier: disable=print
+        print("Downloading bpftool from {}".format(url))
+
+    # The release tarball contains a single top-level `bpftool` binary.
+    result = rctx.download_and_extract(url = url, sha256 = sha256)
+    if not result.success:
+        fail("Failed to download bpftool from {}".format(url))
+
+    # download_and_extract preserves tar permissions (the release binary is 0755),
+    # but chmod defensively so the executable label attr always resolves.
+    rctx.execute(["chmod", "0755", "bpftool"])
+
+    _write_build(rctx, valid = True)
+
+def _write_build(rctx, valid):
+    if valid:
+        bpftool_attr = '    bpftool = "bpftool",'
+    else:
+        bpftool_attr = ""
+
+    rctx.file("BUILD.bazel", content = """\
+load("@@//bazel/toolchains/bpftool:bpftool.bzl", "bpftool_toolchain")
+
+exports_files(glob(["bpftool"], allow_empty = True))
+
+bpftool_toolchain(
+    name = "bpftool_impl",
+{bpftool_attr}
+    version = "{version}",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "bpftool_toolchain",
+    target_compatible_with = ["@platforms//os:linux"],
+    toolchain = ":bpftool_impl",
+    toolchain_type = "@@//bazel/toolchains/bpftool:bpftool_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+""".format(
+        bpftool_attr = bpftool_attr,
+        version = rctx.attr.version,
+    ))
+
+download_bpftool = repository_rule(
+    implementation = _download_bpftool_impl,
+    doc = "Download a prebuilt bpftool binary from a pinned release.",
+    attrs = {
+        "base_url": attr.string(mandatory = True),
+        "version": attr.string(mandatory = True),
+        "sha256s": attr.string_dict(doc = "SHA256 checksums keyed by arch ('amd64', 'arm64')."),
+        "verbose": attr.bool(default = False),
+    },
+)
+
+_DEFAULTS = struct(
+    base_url = "https://github.com/libbpf/bpftool/releases/download/v7.5.0",
+    version = "v7.5.0",
+    sha256s = {},
+    verbose = False,
+)
+
+_configure = tag_class(
+    attrs = {
+        "base_url": attr.string(default = _DEFAULTS.base_url),
+        "version": attr.string(default = _DEFAULTS.version),
+        "sha256s": attr.string_dict(doc = "SHA256 checksums keyed by arch ('amd64', 'arm64')."),
+        "verbose": attr.bool(default = False),
+    },
+)
+
+def _bpftool_extension_impl(ctx):
+    cfg = ctx.modules[0].tags.configure[0] if ctx.modules[0].tags.configure else _DEFAULTS
+    download_bpftool(
+        name = NAME,
+        base_url = cfg.base_url,
+        version = cfg.version,
+        sha256s = cfg.sha256s,
+        verbose = cfg.verbose,
+    )
+
+bpftool_extension = module_extension(
+    implementation = _bpftool_extension_impl,
+    tag_classes = {"configure": _configure},
+)

--- a/pkg/ebpf/BUILD.bazel
+++ b/pkg/ebpf/BUILD.bazel
@@ -7,6 +7,7 @@ load("//bazel/rules/ebpf:cgo_godefs.bzl", "cgo_godefs")
 exports_files([
     "types_linux.go",
     "types_linux_test.go",
+    "testdata/rc-btf-test.btf",
 ])
 
 cgo_godefs(


### PR DESCRIPTION
## Summary
This PR migrates generation of the minimized-BTF artifact to Bazel. It lands the building blocks — a `bpftool` toolchain (a pinned, sha256-checked release exposed as a toolchain, mirroring `bazel/toolchains/llvm_bpf`) and a `min_core_btf` rule that wraps `bpftool gen min_core_btf` as one action per kernel BTF over the already-Bazel-native CO-RE `.o` set. An analysis test gates the action shape; the full per-kernel matrix, btfhub-as-input, and deb staging are follow-ups.

This replaces #52889, which re-keyed the hand-rolled S3 cache on a sha256 of the CO-RE objects. A fresh branch is cleaner than force-pushing a different approach, so #52889 is closed in favor of this.

## Motivation
The `generate_minimized_btfs` step caches its whole tarball under a hand-rolled S3 key. Moving generation into Bazel makes the cache key `hash(declared inputs + tool + command)` — content-addressed by the build system and shared through the Buildbarn remote cache, removing the path-in-hash risk class flagged on #52889, and re-minimizing only the kernels whose BTF changed on a btfhub update.

Tradeoff: this uses the upstream prebuilt bpftool release rather than the from-source build in the btf-gen image. `min_core_btf` produces a superset of the referenced types, so any recent bpftool yields a correct artifact and the sha256 pin keeps the action hermetic. Opening as a draft for review and CI validation.
