### PR TITLE
fix(metadata): break CGo import chain from comp/metadata/host/impl/utils

### DIFF
--- a/comp/metadata/host/impl/utils/host.go
+++ b/comp/metadata/host/impl/utils/host.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	"github.com/DataDog/datadog-agent/comp/metadata/host/impl/hosttags"
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/configcheck"
-	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/fips"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
@@ -193,7 +192,7 @@ func GetPayload(ctx context.Context, conf model.Reader, hostname hostnameinterfa
 	p := &Payload{
 		Os:            osName,
 		AgentFlavor:   flavor.GetFlavor(),
-		PythonVersion: python.GetPythonInfo(),
+		PythonVersion: getPythonVersion(),
 		SystemStats:   getSystemStats(),
 		Meta:          meta,
 		HostTags:      hosttags.Get(ctx, false, conf),

--- a/comp/metadata/host/impl/utils/host_nix.go
+++ b/comp/metadata/host/impl/utils/host_nix.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/shirou/gopsutil/v4/cpu"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	hostinfoutils "github.com/DataDog/datadog-agent/pkg/util/hostinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -40,7 +39,7 @@ func getSystemStats() *systemStats {
 				Platform:  runtime.GOOS,
 				Processor: CPUModel,
 				CPUCores:  CPUCores,
-				Pythonv:   python.GetPythonVersion(),
+				Pythonv:   getPythonVersion(),
 			}
 
 			hostInfo := hostinfoutils.GetInformation()

--- a/comp/metadata/host/impl/utils/host_nix_test.go
+++ b/comp/metadata/host/impl/utils/host_nix_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/hostinfo"
 )
@@ -33,7 +32,7 @@ func TestGetSystemStats(t *testing.T) {
 	assert.Equal(t, runtime.GOOS, ss.Platform)
 	assert.Equal(t, cpuInfo[0].ModelName, ss.Processor)
 	assert.Equal(t, cpuInfo[0].Cores, ss.CPUCores)
-	assert.Equal(t, python.GetPythonVersion(), ss.Pythonv)
+	assert.Equal(t, getPythonVersion(), ss.Pythonv)
 
 	hostInfo := hostinfo.GetInformation()
 

--- a/comp/metadata/host/impl/utils/host_test.go
+++ b/comp/metadata/host/impl/utils/host_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
-	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
@@ -135,7 +134,7 @@ func TestGetPayload(t *testing.T) {
 	}
 
 	assert.Equal(t, flavor.GetFlavor(), p.AgentFlavor)
-	assert.Equal(t, python.GetPythonVersion(), p.PythonVersion)
+	assert.Equal(t, getPythonInfo(), p.PythonVersion)
 	assert.NotNil(t, p.SystemStats)
 	assert.NotNil(t, p.Meta)
 	assert.NotNil(t, p.HostTags)

--- a/comp/metadata/host/impl/utils/host_windows.go
+++ b/comp/metadata/host/impl/utils/host_windows.go
@@ -12,7 +12,6 @@ package utils
 import (
 	"runtime"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/gohai/cpu"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	hostinfoutils "github.com/DataDog/datadog-agent/pkg/util/hostinfo"
@@ -40,7 +39,7 @@ func getSystemStats() *systemStats {
 				Platform:  runtime.GOOS,
 				Processor: modelName,
 				CPUCores:  c32,
-				Pythonv:   python.GetPythonVersion(),
+				Pythonv:   getPythonVersion(),
 			}
 
 			hostInfo := hostinfoutils.GetInformation()

--- a/comp/metadata/host/impl/utils/host_windows_test.go
+++ b/comp/metadata/host/impl/utils/host_windows_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/gohai/cpu"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	hostinfoutils "github.com/DataDog/datadog-agent/pkg/util/hostinfo"
@@ -27,7 +26,7 @@ func TestGetSystemStats(t *testing.T) {
 	assert.Equal(t, runtime.GOOS, ss.Platform)
 	assert.Equal(t, cpuInfo.ModelName.ValueOrDefault(), ss.Processor)
 	assert.Equal(t, int32(cpuInfo.CPUCores.ValueOrDefault()), ss.CPUCores)
-	assert.Equal(t, python.GetPythonVersion(), ss.Pythonv)
+	assert.Equal(t, getPythonVersion(), ss.Pythonv)
 
 	hostInfo := hostinfoutils.GetInformation()
 	assert.Equal(t, osVersion{hostInfo.Platform, hostInfo.PlatformVersion}, ss.Winver)

--- a/comp/metadata/host/impl/utils/python_version.go
+++ b/comp/metadata/host/impl/utils/python_version.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build python
+
+package utils
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+)
+
+// pythonInfoCacheKey matches the key used by pkg/collector/python to store the
+// Python interpreter info string in the shared agent cache. We read from the cache
+// directly to avoid importing the CGo-heavy pkg/collector/python package here,
+// which would pull in rtloader build constraints into the host metadata component.
+var pythonInfoCacheKey = cache.BuildAgentKey("pythonInfo")
+
+func getPythonInfo() string {
+	if x, found := cache.Cache.Get(pythonInfoCacheKey); found {
+		return x.(string)
+	}
+	return "n/a"
+}
+
+func getPythonVersion() string {
+	return strings.SplitN(getPythonInfo(), " ", 2)[0]
+}

--- a/comp/metadata/host/impl/utils/python_version_nopy.go
+++ b/comp/metadata/host/impl/utils/python_version_nopy.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !python
+
+package utils
+
+func getPythonInfo() string {
+	return "n/a"
+}
+
+func getPythonVersion() string {
+	return "n/a"
+}


### PR DESCRIPTION
## Summary

- `comp/metadata/host/impl/utils` unconditionally imported `pkg/collector/python`, pulling in CGo rtloader bindings (`discovery.go`, `embed_python.go`) whenever the `python` build tag was active
- This caused a typecheck failure when linting `cmd/otel-agent` (or any target using the default base lint flavor) without the rtloader headers installed, because `discovery.go` references `C.discover_config` from `datadog_agent_rtloader.h`
- Fix: introduce two build-tagged helper files that read the Python info from the shared agent cache — matching the key `pkg/collector/python` populates at runtime — with no CGo dependency of their own

## Changes

- `comp/metadata/host/impl/utils/python_version.go` (`//go:build python`): reads Python info from the agent cache without importing `pkg/collector/python`
- `comp/metadata/host/impl/utils/python_version_nopy.go` (`//go:build !python`): returns `"n/a"` stubs
- `host.go`, `host_nix.go`, `host_windows.go`: drop `pkg/collector/python` import, call local `getPythonInfo()` / `getPythonVersion()`
- Test files: same import removal, use local helpers for assertions

## Test plan

- [x] `dda inv linter.go --targets=./cmd/otel-agent/...` — 0 issues (was: typecheck failure on `discovery.go`)
- [x] `dda inv linter.go --targets=./comp/metadata/host/...` — 0 issues
- [x] `dda inv test --targets=./comp/metadata/host/...` — 37 passed, 1 skipped (platform-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)