### PR TITLE
ci(e2e): add qa_agent_linux to needs of new-e2e-otel and new-e2e-netpath

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -988,6 +988,11 @@ new-e2e-anomalydetection:
 
 new-e2e-netpath:
   extends: .new_e2e_template_needs_deb_x64
+  needs:
+    - !reference [.new_e2e_template_needs_deb_x64, needs]
+    # netpath dynamic-tests run the agent as a Docker container, pulling the
+    # agent-qa:<pipeline>-<sha>-linux image built by qa_agent_linux
+    - qa_agent_linux
   rules:
     - !reference [.on_netpath_or_e2e_changes]
     - !reference [.manual]

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -1046,6 +1046,7 @@ new-e2e-otel:
     - qa_dca
     - qa_agent_full
     - qa_ot_agent_standalone
+    - qa_agent_linux
   variables:
     TARGETS: ./tests/otel
     EXTRA_PARAMS: --skip "TestOTelAgentIA(EKS|USTEKS)"


### PR DESCRIPTION
### What does this PR do?

Adds the `qa_agent_linux` job to the `needs` of `new-e2e-otel` and `new-e2e-netpath` in `.gitlab/test/e2e/e2e.yml`.

### Motivation

Both jobs run e2e tests that deploy the Agent as a **Docker container** and therefore pull the `agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-linux` image, which is built/pushed by the `qa_agent_linux` job:

- `new-e2e-otel` runs the non-EKS OTel suite (e.g. `TestOTLPIngestDockerV3`).
- `new-e2e-netpath` runs the `dynamic-tests` suites (`TestNetflowDynamicPathSuite`, `TestHostTrafficDynamicPathSuite`).

Neither job declared `qa_agent_linux` as a dependency. Because the GitLab DAG only waits on declared `needs`, both jobs could be scheduled and run **before** `qa_agent_linux` finished pushing the image, failing with:

```
manifest for 669783387624.dkr.ecr.us-east-1.amazonaws.com/agent-qa:<pipeline>-<sha>-linux not found: manifest unknown: Requested image not found
```

This is intermittent — it only fails when the test job happens to start before the image is published. In the failing pipeline, `new-e2e-otel` ran and failed ~20 min before `qa_agent_linux` even started.

Related to incident-56883.

### Describe how you validated your changes

- Confirmed from the failing job traces that the missing image (`agent-qa:...-linux`) is produced by `qa_agent_linux` (`.gitlab/deploy/dev_container_deploy/e2e.yml`).
- e2e test succeed in this pipeline

### Additional Notes

CI-only change; no code/behavior change.
