### PR TITLE
test(discovery): add E2E test for integration config discovery via krakend

### DIFF
--- a/comp/core/autodiscovery/impl/configmgr_discovery.go
+++ b/comp/core/autodiscovery/impl/configmgr_discovery.go
@@ -9,10 +9,13 @@ package autodiscoveryimpl
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/configresolver"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/discoverer"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/listeners"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -133,6 +136,7 @@ func (cm *reconcilingConfigManager) applyDiscoveredConfigsLocked(svcID, tplDiges
 		errorStats.setResolveWarning(tpl.Name, err.Error())
 		return changes
 	}
+	resolved.Source = rewriteSource(resolved.Source, svcAndADIDs.svc)
 	decrypted, err := decryptConfig(resolved, cm.secretResolver, tplDigest)
 	if err != nil {
 		log.Errorf("error decrypting discovered config %s for service %s: %v", resolved.Name, svcID, err)
@@ -155,4 +159,24 @@ func (cm *reconcilingConfigManager) applyDiscoveredConfigsLocked(svcID, tplDiges
 	changes.ScheduleConfig(decrypted)
 	errorStats.removeResolveWarnings(tpl.Name)
 	return cm.applyChanges(changes)
+}
+
+// rewriteSource rewrites a resolved config's file-based Source to encode that
+// it was applied via a configuration-discovery probe result, and whether the
+// target service is a process or a container. Only the "file" provider is
+// rewritten since that's where we expect discovery configs to come from.
+//
+// This rewritten source is included in the configuration metadata sent to the
+// backend.
+//
+// Config.Provider is intentionally left unchanged — it is used by the secret
+// resolver security mechanism and must not vary with the service type.
+func rewriteSource(source string, svc listeners.Service) string {
+	if !strings.HasPrefix(source, names.File+":") {
+		return source
+	}
+	if strings.HasPrefix(svc.GetServiceID(), "process://") {
+		return names.ADProcessDiscovery + source[len(names.File):]
+	}
+	return names.ADContainerDiscovery + source[len(names.File):]
 }

--- a/comp/core/autodiscovery/impl/configmgr_discovery_test.go
+++ b/comp/core/autodiscovery/impl/configmgr_discovery_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/discoverer"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
@@ -88,50 +89,77 @@ func TestConfigMgr_DiscoveryTemplate_NoPythonNeverSchedules(t *testing.T) {
 // TestConfigMgr_DiscoveryTemplate_RoutesThroughDiscoverer verifies the full
 // end-to-end path: the configmgr enqueues a probe instead of resolving the
 // template, the worker calls the stub, and the resolved config is delivered
-// via discoveredChanges() to be applied by AutoConfig.
+// via discoveredChanges() to be applied by AutoConfig. It covers both a
+// container and a process service, which should get distinct
+// discovery-specific Source prefixes.
 func TestConfigMgr_DiscoveryTemplate_RoutesThroughDiscoverer(t *testing.T) {
-	mockResolver := MockSecretResolver{}
-	disco := newStubDiscoverer(func(_, _ string) (string, error) {
-		return `[{"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics"}]}]`, nil
-	})
-	cm := newReconcilingConfigManager(&mockResolver, nil, nil, disco, nil).(*reconcilingConfigManager)
-	cm.start()
-	defer cm.stop()
-
-	tpl := integration.Config{
-		Name:          "krakend",
-		ADIdentifiers: []string{"krakend"},
-		Discovery:     &integration.DiscoveryConfig{},
-	}
-	svc := &dummyService{
-		ID:            "docker://k1",
-		ADIdentifiers: []string{"krakend"},
-		Hosts:         map[string]string{"main": "10.0.0.1"},
+	tests := []struct {
+		name       string
+		svcID      string
+		wantSource string
+	}{
+		{
+			name:       "container service",
+			svcID:      "docker://k1",
+			wantSource: names.ADContainerDiscovery + ":/etc/datadog-agent/conf.d/krakend.d/auto_conf.yaml",
+		},
+		{
+			name:       "process service",
+			svcID:      "process://1234",
+			wantSource: names.ADProcessDiscovery + ":/etc/datadog-agent/conf.d/krakend.d/auto_conf.yaml",
+		},
 	}
 
-	// processNewConfig + processNewService should NOT schedule synchronously
-	// — the template goes through the discovery path instead.
-	_, _ = cm.processNewConfig(tpl)
-	changes := cm.processNewService(svc)
-	assertConfigsMatch(t, changes.Schedule)
-	assertConfigsMatch(t, changes.Unschedule)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockResolver := MockSecretResolver{}
+			disco := newStubDiscoverer(func(_, _ string) (string, error) {
+				return `[{"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics"}]}]`, nil
+			})
+			cm := newReconcilingConfigManager(&mockResolver, nil, nil, disco, nil).(*reconcilingConfigManager)
+			cm.start()
+			defer cm.stop()
 
-	// Drain the discovered-changes channel for up to one second.
-	ch := cm.discoveredChanges()
-	require.NotNil(t, ch)
-	select {
-	case discovered := <-ch:
-		assertConfigsMatch(t, discovered.Schedule, matchName("krakend"))
-		require.Len(t, discovered.Schedule, 1)
-		// %%host%% in the discovered config should have been resolved
-		// through the normal configresolver path against the live service.
-		assert.Contains(t, string(discovered.Schedule[0].Instances[0]), "10.0.0.1",
-			"discovered instance config should have %%host%% resolved via the configresolver path")
-	case <-time.After(2 * time.Second):
-		t.Fatalf("timed out waiting for discovered changes")
+			tpl := integration.Config{
+				Name:          "krakend",
+				ADIdentifiers: []string{"krakend"},
+				Discovery:     &integration.DiscoveryConfig{},
+				Source:        "file:/etc/datadog-agent/conf.d/krakend.d/auto_conf.yaml",
+				Provider:      names.File,
+			}
+			svc := &dummyService{
+				ID:            tc.svcID,
+				ADIdentifiers: []string{"krakend"},
+				Hosts:         map[string]string{"main": "10.0.0.1"},
+			}
+
+			// processNewConfig + processNewService should NOT schedule synchronously
+			// — the template goes through the discovery path instead.
+			_, _ = cm.processNewConfig(tpl)
+			changes := cm.processNewService(svc)
+			assertConfigsMatch(t, changes.Schedule)
+			assertConfigsMatch(t, changes.Unschedule)
+
+			// Drain the discovered-changes channel for up to one second.
+			ch := cm.discoveredChanges()
+			require.NotNil(t, ch)
+			select {
+			case discovered := <-ch:
+				assertConfigsMatch(t, discovered.Schedule, matchName("krakend"))
+				require.Len(t, discovered.Schedule, 1)
+				// %%host%% in the discovered config should have been resolved
+				// through the normal configresolver path against the live service.
+				assert.Contains(t, string(discovered.Schedule[0].Instances[0]), "10.0.0.1",
+					"discovered instance config should have %%host%% resolved via the configresolver path")
+				assert.Equal(t, tc.wantSource, discovered.Schedule[0].Source,
+					"discovered config's Source should be tagged with the discovery provider")
+			case <-time.After(2 * time.Second):
+				t.Fatalf("timed out waiting for discovered changes")
+			}
+
+			assert.GreaterOrEqual(t, int(disco.called.Load()), 1, "stub discoverer should have been called")
+		})
 	}
-
-	assert.GreaterOrEqual(t, int(disco.called.Load()), 1, "stub discoverer should have been called")
 }
 
 // TestConfigMgr_DiscoveryTemplate_ServiceDeletionCancels confirms that

--- a/comp/core/autodiscovery/providers/names/provider_names.go
+++ b/comp/core/autodiscovery/providers/names/provider_names.go
@@ -67,6 +67,12 @@ const (
 	PrometheusHTTPSD = "prometheus-http-sd"
 	// InstrumentationChecks pulls AD configurations derived from DatadogInstrumentation CRs via the cluster-agent.
 	InstrumentationChecks = "instrumentation-checks"
+	// ADContainerDiscovery is the source prefix for configuration discovery file templates resolved
+	// against non-process services (containers, k8s pods, etc.).
+	ADContainerDiscovery = "ad-container-discovery+file"
+	// ADProcessDiscovery is the source prefix for configuration discovery file templates resolved
+	// against process services.
+	ADProcessDiscovery = "ad-process-discovery+file"
 )
 
 // Internal Autodiscovery names for the config providers

--- a/test/new-e2e/tests/discovery/config_discovery_linux_test.go
+++ b/test/new-e2e/tests/discovery/config_discovery_linux_test.go
@@ -1,0 +1,154 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package discovery
+
+import (
+	_ "embed"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/dockeragentparams"
+	scendocker "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2docker"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awsdocker "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/docker"
+)
+
+//go:embed testdata/compose/docker-compose.fake-krakend.yaml
+var fakeKrakendComposeStr string
+
+type configDiscoverySuite struct {
+	e2e.BaseSuite[environments.DockerHost]
+}
+
+func TestConfigDiscoverySuite(t *testing.T) {
+	t.Parallel()
+
+	options := []e2e.SuiteOption{
+		e2e.WithProvisioner(awsdocker.Provisioner(
+			awsdocker.WithRunOptions(
+				scendocker.WithAgentOptions(
+					dockeragentparams.WithExtraComposeManifest("fake-krakend", pulumi.String(fakeKrakendComposeStr)),
+				),
+			),
+		)),
+	}
+	e2e.Run(t, &configDiscoverySuite{}, options...)
+}
+
+// TestKrakendConfigDiscovery verifies that integration config discovery works
+// end-to-end: the agent discovers the fake-krakend container via the Docker
+// listener (matching ad_identifiers: [krakend] from the shipped auto_conf.yaml),
+// calls krakend's discover_config callback with the container's host and
+// exposed ports, discover_config probes candidate ports in order (starting
+// with krakend's default metrics port 9090) and returns an OpenMetrics check
+// config for the first one that yields real krakend metrics. The fake
+// container serves a non-krakend decoy on 9090 and the real krakend metrics
+// on 9091, so a successful test proves discover_config actually probes and
+// validates candidates rather than blindly using the first exposed port.
+func (s *configDiscoverySuite) TestKrakendConfigDiscovery() {
+	t := s.T()
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		s.verifyKrakendConfigDiscovery(c)
+	}, 3*time.Minute, 10*time.Second, "krakend check should be scheduled and running via config discovery")
+}
+
+func (s *configDiscoverySuite) verifyKrakendConfigDiscovery(c *assert.CollectT) {
+	t := s.T()
+
+	configCheckOutput := s.Env().Docker.Client.ExecuteCommand(s.Env().Agent.ContainerName, "agent", "configcheck")
+	if !assert.True(c, strings.Contains(configCheckOutput, "=== krakend check ==="), "krakend check should appear in configcheck") {
+		t.Logf("configcheck output: %s", configCheckOutput)
+		return
+	}
+	if !assert.True(c, strings.Contains(configCheckOutput, "openmetrics_endpoint"), "krakend config should have openmetrics_endpoint") {
+		t.Logf("configcheck output: %s", configCheckOutput)
+		return
+	}
+	if !assert.True(c, strings.Contains(configCheckOutput, ":9091/metrics"), "openmetrics_endpoint should point to port 9091 (the real krakend metrics endpoint, not the 9090 decoy)") {
+		t.Logf("configcheck output: %s", configCheckOutput)
+		return
+	}
+
+	statusOutput := s.Env().Docker.Client.ExecuteCommand(s.Env().Agent.ContainerName, "agent", "status", "collector", "--json")
+	var status collectorStatus
+	err := json.Unmarshal([]byte(statusOutput), &status)
+	if !assert.NoError(c, err, "failed to parse collector status JSON") {
+		t.Logf("status output: %s", statusOutput)
+		return
+	}
+	instances, exists := status.RunnerStats.Checks["krakend"]
+	if !assert.True(c, exists, "krakend check should be running; available: %v", getCheckNames(status.RunnerStats.Checks)) {
+		return
+	}
+	ran := false
+	for name, stat := range instances {
+		if len(stat.ExecutionTimes) > 0 {
+			t.Logf("krakend instance %s: runs=%d", name, len(stat.ExecutionTimes))
+			ran = true
+			break
+		}
+	}
+	if !assert.True(c, ran, "krakend check is configured but has not executed yet") {
+		return
+	}
+
+	// Verify config.provider in inventory-checks metadata reflects that the
+	// config came from the configuration-discovery path (via the Docker
+	// listener), not a plain file provider.
+	s.verifyKrakendCheckProvider(c)
+}
+
+// adContainerDiscoveryProvider mirrors names.ADContainerDiscovery in
+// comp/core/autodiscovery/providers/names (not importable here: it lives in
+// the root module, which test/new-e2e does not depend on). It is the source
+// prefix that configmgr_discovery.go's rewriteSource applies to file-based
+// configs resolved via configuration discovery against non-process services
+// (e.g. containers, discovered via the Docker listener here).
+const adContainerDiscoveryProvider = "ad-container-discovery+file"
+
+// verifyKrakendCheckProvider checks that the krakend check has
+// config.provider = adContainerDiscoveryProvider in the inventory-checks
+// metadata, confirming it was resolved via configuration discovery against
+// a container (as opposed to a process).
+func (s *configDiscoverySuite) verifyKrakendCheckProvider(c *assert.CollectT) {
+	t := s.T()
+
+	metadataOut := s.Env().Docker.Client.ExecuteCommand(s.Env().Agent.ContainerName, "agent", "diagnose", "show-metadata", "inventory-checks")
+
+	var payload struct {
+		CheckMetadata map[string][]map[string]interface{} `json:"check_metadata"`
+	}
+	if !assert.NoError(c, json.Unmarshal([]byte(metadataOut), &payload), "failed to parse inventory-checks metadata") {
+		t.Logf("inventory-checks output: %s", metadataOut)
+		return
+	}
+
+	instances, exists := payload.CheckMetadata["krakend"]
+	if !assert.True(c, exists, "krakend should appear in inventory-checks metadata") {
+		keys := make([]string, 0, len(payload.CheckMetadata))
+		for k := range payload.CheckMetadata {
+			keys = append(keys, k)
+		}
+		t.Logf("available checks in inventory metadata: %v", keys)
+		return
+	}
+	if !assert.NotEmpty(c, instances, "krakend metadata should have at least one instance") {
+		return
+	}
+
+	// Always logged (not just on failure) so the raw metadata is available for
+	// manual debugging, e.g. when config.provider matches but other fields look off.
+	t.Logf("krakend inventory-checks metadata: %+v", instances)
+
+	assert.Equal(c, adContainerDiscoveryProvider, instances[0]["config.provider"],
+		"krakend resolved via configuration discovery should have config.provider = %s", adContainerDiscoveryProvider)
+}

--- a/test/new-e2e/tests/discovery/testdata/compose/docker-compose.fake-krakend.yaml
+++ b/test/new-e2e/tests/discovery/testdata/compose/docker-compose.fake-krakend.yaml
@@ -1,0 +1,67 @@
+services:
+  fake-krakend:
+    container_name: fake-krakend
+    # python:3.12-slim is already pulled by the mutatedbyadmissioncontroller
+    # k8s e2e test (test/e2e-framework/components/datadog/apps/mutatedbyadmissioncontroller/k8s.go)
+    # through the same ${DD_REGISTRY}/dockerhub/library/python ECR pull-through
+    # cache path, so reusing it here avoids warming the cache for a new tag.
+    image: ${DD_REGISTRY:-docker.io}/library/python:3.12-slim
+    command:
+      - sh
+      - -c
+      - |
+        python3 << 'EOF'
+        import http.server, socketserver, threading
+
+        class MetricsHandler(http.server.BaseHTTPRequestHandler):
+            # The real krakend metrics endpoint. Deliberately NOT on 9090 (see
+            # below) so that the test proves discover_config actually probes
+            # and picks the right port among several exposed ones, rather
+            # than trivially succeeding because there's only one candidate.
+            BODY = (
+                b"# HELP krakend_requests_total Total requests.\n"
+                b"# TYPE krakend_requests_total counter\n"
+                b"krakend_requests_total 42\n"
+                b"# HELP go_goroutines Number of goroutines.\n"
+                b"# TYPE go_goroutines gauge\n"
+                b"go_goroutines 17\n"
+            )
+
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+                self.send_header("Content-Length", str(len(self.BODY)))
+                self.end_headers()
+                self.wfile.write(self.BODY)
+
+            def log_message(self, *args):
+                pass
+
+        class DummyHandler(http.server.BaseHTTPRequestHandler):
+            # A decoy endpoint on krakend's default metrics port (9090) that
+            # is NOT valid krakend/openmetrics output. If config discovery
+            # picked a port blindly instead of probing and validating each
+            # candidate, it would pick this one and the test would fail.
+            BODY = b"not krakend metrics\n"
+
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Content-Length", str(len(self.BODY)))
+                self.end_headers()
+                self.wfile.write(self.BODY)
+
+            def log_message(self, *args):
+                pass
+
+        threading.Thread(
+            target=lambda: socketserver.TCPServer(("", 9090), DummyHandler).serve_forever(),
+            daemon=True,
+        ).start()
+        socketserver.TCPServer(("", 9091), MetricsHandler).serve_forever()
+        EOF
+    labels:
+      com.datadoghq.ad.check.id: krakend
+    expose:
+      - "9090"
+      - "9091"


### PR DESCRIPTION
### What does this PR do?

Adds an E2E test for the integration config discovery feature — the mechanism by which integrations implement a `discover_config` callback that probes a service and returns check configuration automatically.

We use krakend for the test since it's the first integration which has support for config discovery. We use a fake krakend metrics server to simplify the setup. Currently, we only test containers. When krakend gains process discovery support, we can extend this test to support that.

### Motivation

Each individual integration with configuration discovery support already has specific E2E tests in the `integrations-core` using `agent check`, but this test here:
- prevents agent changes from breaking the feature
- tests the normal full agent flow instead of just via `agent check`
- asserts some more things like the `config.provider` on the check metadata

### Describe how you validated your changes

CI