### PR TITLE
fix(anomalydetection): increase timeout on scorer tests

### DIFF
--- a/test/new-e2e/tests/anomalydetection/scorer_helper_nix_test.go
+++ b/test/new-e2e/tests/anomalydetection/scorer_helper_nix_test.go
@@ -194,7 +194,7 @@ func (s *scorerHelperSuite) TestScorerHelperEmitsSeverityTransitionOnMultiSeries
 		assert.NoError(c, err, "journalctl execution failed")
 		assert.Contains(c, out, scorerHelperEscalationMarker,
 			"journald should contain the scorer watcher's severity escalation log line")
-	}, 3*time.Minute, 5*time.Second)
+	}, 5*time.Minute, 5*time.Second)
 
 	s.T().Log("scorer severity escalation marker found — anomaly scorer watcher wired correctly")
 }


### PR DESCRIPTION
### What does this PR do?

Bumps the `EventuallyWithT` timeout in `TestScorerHelperEmitsSeverityTransitionOnMultiSeriesSpike` from 3 minutes to 5 minutes.

### Motivation

Reduce flakiness on `new-e2e-anomalydetection`.

### Describe how you validated your changes

### Additional Notes
