### PR TITLE
fix(test): update User-Agent regex to accept RC Go versions

### DIFF
--- a/pkg/config/remote/api/http_test.go
+++ b/pkg/config/remote/api/http_test.go
@@ -50,9 +50,10 @@ func TestUserAgent(t *testing.T) {
 	case ua := <-userAgentCh:
 		// Regex explained:
 		//   * ^datadog-agent\/ == must start with "datadog-agent/"
-		//   * (unknown|\d+\.\d+\.\d+) == either "unknown" or a semver string
-		//   * \(go\d+\.\d+\.\d+\)$ == ends in " (go1.2.3)" where 1.2.3 is a semver string
-		uaRegex := regexp.MustCompile(`^datadog-agent\/(.+) \(go\d+\.\d+\.\d+\)$`)
+		//   * (.+) == agent version: either "unknown" or a semver string
+		//   * \(go...\)$ == ends with the Go toolchain version in parens, which is
+		//     either a stable release (go1.26.4) or a release candidate (go1.27rc1).
+		uaRegex := regexp.MustCompile(`^datadog-agent\/(.+) \(go\d+\.\d+(?:\.\d+|rc\d+)\)$`)
 		parts := uaRegex.FindStringSubmatch(ua)
 		assert.Len(parts, 2) // Original string + the extracted group.
 


### PR DESCRIPTION
### What does this PR do?

The User-Agent regex `\(go\d+\.\d+\.\d+\)$` requires exactly three dot-separated numbers, which fails for RC versions like \`go1.27rc1\` — the regex doesn't match, \`parts\` is empty, and \`parts[1]\` panics.

Updated to `\(go\d+\.\d+(?:\.\d+|rc\d+)\)$` which matches both stable releases (`go1.26.4`) and release candidates (`go1.27rc1`).

### Motivation

The test panics whenever we test Go rc versions (eg. #52848), causing a lot of noise, it makes a lot of other tests in the package fail as well, and prevents seeing actual failures easily.

### Describe how you validated your changes

Passes locally with Go 1.26.4. Verified it also passes on the Go 1.27rc1 branch.

### Additional Notes