### PR TITLE
replace_prefix: delete existing rpath's when patching macos binaries

### DIFF
--- a/bazel/rules/replace_prefix.sh
+++ b/bazel/rules/replace_prefix.sh
@@ -48,7 +48,16 @@ for f in "$@"; do
                 ${PATCHELF} --force-rpath --set-rpath "$PREFIX"/lib "$f"
             elif file "$f" | grep -q "Mach-O"; then
                 # Handle macOS binaries (executables and other Mach-O files)
-                install_name_tool -add_rpath "$PREFIX/lib" "$f" 2>/dev/null || true
+                # Match the Linux patchelf --set-rpath behavior: replace existing paths
+                # instead of just appending them.
+                new_rpath="$PREFIX/lib"
+                otool -l "$f" | awk '
+                    $1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next }
+                    in_rpath && $1 == "path" { print $2; in_rpath = 0 }
+                ' | while read -r rpath; do
+                    install_name_tool -delete_rpath "$rpath" "$f" 2>/dev/null || true
+                done
+                install_name_tool -add_rpath "$new_rpath" "$f" 2>/dev/null || true
                 # Get the old install name/ID
                 dylib_name=$(basename "$f")
                 new_id="$PREFIX/lib/$dylib_name"


### PR DESCRIPTION
### What does this PR do?

Makes rpath replacing script remove all existing rpaths when setting a new one via the `replace_prefix` mechanism.

### Motivation

Building the Agent locally with `--enable-bazel` (the default since https://github.com/DataDog/datadog-agent/pull/52546) causes runtime `SIGBUS: bus error` errors on macos, crashing the Agent. The culprit is that with the current setup, we're leaving the default install_dir of `/opt/datadog-agent`, which gets added as an rpath to all binaries. Then, the current build task code does:

https://github.com/DataDog/datadog-agent/blob/ca75ed6ddf44350ea76fbf253f4529d4a1266116/tasks/rtloader.py#L148

Which adds the paths it needs, but without deleting the original ones. Thus, in a machine that has an existing Agent install, DYLD gets confused and dlopen's the one from the existing Agent install instead of the one locally built, leading to the crash.

### Describe how you validated your changes

Locally run:

```
dda inv agent.build --rebuild
bin/agent/agent run -c bin/agent/dist/datadog.yaml
```

without seeing the SIGBUS crash.

### Additional Notes

`replace_prefix` is not currently being used in the Agent build for rpath replacement, as we're using another mechanism. Therefore, this doesn't affect any shipped artifact. That being said, I'll be looking into the current mechanism as a follow-up, as it may be worth fixing there as well in order to avoid shipping binaries with rpaths pointing to bazel sandboxes (like I've confirmed locally for `otool -l /opt/datadog-agent/embedded/lib/libpython3.13.dylib | grep -A3 LC_RPATH`).

I considered setting `--//:install_dir` in the rtloader install-with-bazel task, which would probably also work, but openssl depends on install_dir, which would cause remote cache misses.