### PR TITLE
[Closed] Add agent-side on-demand connectivity (ICMP) check via AGENT_TASK

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -41,6 +41,7 @@ import (
 	doqueryactionsfx "github.com/DataDog/datadog-agent/comp/dataobs/queryactions/fx"
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
 	logondurationfx "github.com/DataDog/datadog-agent/comp/logonduration/fx"
+	ndmconnectivitycheckfx "github.com/DataDog/datadog-agent/comp/ndmconnectivitycheck/fx"
 	networkconfigmanagement "github.com/DataDog/datadog-agent/comp/networkconfigmanagement/def"
 	networkconfigmanagementfx "github.com/DataDog/datadog-agent/comp/networkconfigmanagement/fx"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
@@ -539,6 +540,7 @@ func getSharedFxOption() fx.Option {
 		getSnmptrapsOptions(),
 		snmpscanfx.Module(),
 		snmpscanmanagerfx.Module(),
+		ndmconnectivitycheckfx.Module(),
 		networkconfigmanagementfx.Module(),
 		collectorimpl.Module(),
 		fx.Provide(func(demux demultiplexer.Component, hostname hostnameinterface.Component) (ddgostatsd.ClientInterface, error) {

--- a/comp/ndmconnectivitycheck/def/component.go
+++ b/comp/ndmconnectivitycheck/def/component.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package ndmconnectivitycheck is a light component that performs an on-demand,
+// credential-free connectivity (ICMP) check against device IPs and reports the
+// per-device reachability back to the backend. It is the creds-free counterpart
+// to the snmpscan device scan, intended for the NDM onboarding "validation" step.
+package ndmconnectivitycheck
+
+// team: network-device-monitoring-core
+
+// Component is the component type.
+type Component interface {
+	// CheckConnectivity pings each IP in the request and sends the per-device
+	// reachability result to the network-devices-metadata event platform.
+	CheckConnectivity(req Request)
+}
+
+// Request describes an on-demand connectivity check.
+type Request struct {
+	// DeviceIPs is the set of device IPs to ping. IPv4 only for now.
+	DeviceIPs []string
+	// Namespace is the NDM namespace the results are reported under. When empty,
+	// the Agent's configured `network_devices.namespace` (or "default") is used.
+	Namespace string
+}

--- a/comp/ndmconnectivitycheck/fx/fx.go
+++ b/comp/ndmconnectivitycheck/fx/fx.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package fx provides the fx module for the ndmconnectivitycheck component
+package fx
+
+import (
+	ndmconnectivitycheck "github.com/DataDog/datadog-agent/comp/ndmconnectivitycheck/def"
+	ndmconnectivitycheckimpl "github.com/DataDog/datadog-agent/comp/ndmconnectivitycheck/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			ndmconnectivitycheckimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[ndmconnectivitycheck.Component](),
+	)
+}

--- a/comp/ndmconnectivitycheck/impl/connectivitycheck.go
+++ b/comp/ndmconnectivitycheck/impl/connectivitycheck.go
@@ -1,0 +1,160 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package ndmconnectivitycheckimpl implements the ndmconnectivitycheck component interface.
+package ndmconnectivitycheckimpl
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	eventplatform "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/def"
+	ndmconnectivitycheck "github.com/DataDog/datadog-agent/comp/ndmconnectivitycheck/def"
+	rcclienttypes "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/types"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/pinger"
+)
+
+const defaultNamespace = "default"
+
+// Requires defines the dependencies for the ndmconnectivitycheck component.
+type Requires struct {
+	compdef.In
+	Logger        log.Component
+	Config        config.Component
+	EventPlatform eventplatform.Component
+}
+
+// Provides defines the output of the ndmconnectivitycheck component.
+type Provides struct {
+	Comp       ndmconnectivitycheck.Component
+	RCListener rcclienttypes.TaskListenerProvider
+}
+
+// NewComponent creates a new ndmconnectivitycheck component.
+func NewComponent(reqs Requires) (Provides, error) {
+	forwarder, ok := reqs.EventPlatform.Get()
+	if !ok {
+		return Provides{}, errors.New("event platform forwarder not initialized")
+	}
+
+	checker := &connectivityCheckerImpl{
+		log:         reqs.Logger,
+		config:      reqs.Config,
+		epforwarder: forwarder,
+		pingCfg: pinger.Config{
+			// UDP/raw socket selection follows the same model as the SNMP check's ping:
+			// raw sockets require CAP_NET_RAW; otherwise the request is routed through
+			// system-probe. Defaulting to config so deployments can opt in/out.
+			UseRawSocket: reqs.Config.GetBool("network_devices.connectivity_check.use_raw_sockets"),
+			Count:        3,
+			Interval:     20 * time.Millisecond,
+			Timeout:      3 * time.Second,
+		},
+	}
+
+	return Provides{
+		Comp:       checker,
+		RCListener: rcclienttypes.NewTaskListener(checker.handleAgentTask),
+	}, nil
+}
+
+type connectivityCheckerImpl struct {
+	log         log.Component
+	config      config.Component
+	epforwarder eventplatform.Forwarder
+	pingCfg     pinger.Config
+}
+
+// handleAgentTask is the RCAgentTaskListener entrypoint. It only handles the
+// connectivity-check task type and ignores everything else.
+func (c *connectivityCheckerImpl) handleAgentTask(taskType rcclienttypes.TaskType, task rcclienttypes.AgentTaskConfig) (bool, error) {
+	if taskType != rcclienttypes.TaskConnectivityCheck {
+		return false, nil
+	}
+
+	ip, ok := task.Config.TaskArgs["ip_address"]
+	if !ok || ip == "" {
+		return true, errors.New("connectivity check task is missing required 'ip_address' arg")
+	}
+
+	c.CheckConnectivity(ndmconnectivitycheck.Request{
+		DeviceIPs: []string{ip},
+		Namespace: task.Config.TaskArgs["namespace"],
+	})
+	return true, nil
+}
+
+// CheckConnectivity pings each IP and reports the per-device reachability.
+func (c *connectivityCheckerImpl) CheckConnectivity(req ndmconnectivitycheck.Request) {
+	namespace := req.Namespace
+	if namespace == "" {
+		if namespace = c.config.GetString("network_devices.namespace"); namespace == "" {
+			namespace = defaultNamespace
+		}
+	}
+
+	for _, ip := range req.DeviceIPs {
+		status := c.pingOne(ip)
+		if err := c.sendPingResult(namespace, ip, status); err != nil {
+			c.log.Errorf("Unable to report connectivity result for %s: %v", ip, err)
+		}
+	}
+}
+
+// pingOne returns the reachability status for a single IP. A failed ping (or an
+// error constructing/running the pinger) is reported as Unreachable rather than
+// failing the whole task, so a UI validation step sees a definitive per-IP answer.
+func (c *connectivityCheckerImpl) pingOne(ip string) metadata.DeviceStatus {
+	p, err := pinger.New(c.pingCfg)
+	if err != nil {
+		c.log.Warnf("Could not create pinger for %s: %v", ip, err)
+		return metadata.DeviceStatusUnreachable
+	}
+
+	result, err := p.Ping(ip)
+	if err != nil {
+		c.log.Debugf("Ping to %s failed: %v", ip, err)
+		return metadata.DeviceStatusUnreachable
+	}
+	if result.CanConnect {
+		return metadata.DeviceStatusReachable
+	}
+	return metadata.DeviceStatusUnreachable
+}
+
+// sendPingResult emits a network-devices-metadata payload carrying the ping result
+// for a single device IP, mirroring how snmpscan reports scan status.
+//
+// NOTE (design, to coordinate with the NDM backend): emitting a DeviceMetadata may
+// cause the EVP consumer to add the IP to the device inventory. For a pre-enrollment
+// connectivity check the result should likely be treated as ephemeral (validation
+// only) and NOT auto-enroll the device. The exact backend semantics are a follow-up.
+func (c *connectivityCheckerImpl) sendPingResult(namespace, ip string, status metadata.DeviceStatus) error {
+	payload := metadata.NetworkDevicesMetadata{
+		Namespace:        namespace,
+		Integration:      "snmp",
+		CollectTimestamp: time.Now().Unix(),
+		Devices: []metadata.DeviceMetadata{
+			{
+				ID:         namespace + ":" + ip,
+				IPAddress:  ip,
+				PingStatus: status,
+			},
+		},
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	m := message.NewMessage(payloadBytes, nil, "", 0)
+	return c.epforwarder.SendEventPlatformEventBlocking(m, eventplatform.EventTypeNetworkDevicesMetadata)
+}

--- a/comp/remote-config/rcclient/types/types.go
+++ b/comp/remote-config/rcclient/types/types.go
@@ -24,6 +24,10 @@ const (
 	TaskFlare TaskType = "flare"
 	// TaskDeviceScan is the task sent to request a device scan for NDM device onboarding.
 	TaskDeviceScan TaskType = "ndm-device-scan"
+	// TaskConnectivityCheck is the task sent to request an on-demand connectivity (ICMP) check
+	// against one or more device IPs for NDM device onboarding. Unlike TaskDeviceScan it does not
+	// require any SNMP credentials to be present on the Agent.
+	TaskConnectivityCheck TaskType = "ndm-connectivity-check"
 )
 
 // AgentTaskConfig is a deserialized agent task configuration file


### PR DESCRIPTION
Adds an ndmconnectivitycheck component that handles a new ndm-connectivity-check AGENT_TASK: it pings a device IP using the existing networkdevice pinger and reports per-device reachability over network-devices-metadata. Credential-free validation primitive for NDM onboarding; mirrors the snmpscan device-scan pattern. SNMP/credentials are out of scope.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
