### PR TITLE
feat(collector): add checks.first_execution_time metric

### DIFF
--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -4,11 +4,11 @@ profiles:
     exclude:
       zero_metric: true
     metrics:
-      - name: execution_time
+      - name: checks.execution_time
         preserve_tags:
           - check_name
           - check_loader
-      - name: first_execution_time
+      - name: checks.first_execution_time
         preserve_tags:
           - check_name
           - check_loader

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -4,11 +4,11 @@ profiles:
     exclude:
       zero_metric: true
     metrics:
-      - name: checks.execution_time
+      - name: execution_time
         preserve_tags:
           - check_name
           - check_loader
-      - name: checks.first_execution_time
+      - name: first_execution_time
         preserve_tags:
           - check_name
           - check_loader

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -8,6 +8,7 @@ profiles:
         preserve_tags:
           - check_name
           - check_loader
+          - first_run
       - name: checks.delay
         preserve_tags:
           - check_name

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -8,7 +8,10 @@ profiles:
         preserve_tags:
           - check_name
           - check_loader
-          - first_run
+      - name: checks.first_execution_time
+        preserve_tags:
+          - check_name
+          - check_loader
       - name: checks.delay
         preserve_tags:
           - check_name

--- a/pkg/collector/check/stats/BUILD.bazel
+++ b/pkg/collector/check/stats/BUILD.bazel
@@ -33,6 +33,7 @@ dd_agent_go_test(
     embed = [":stats"],
     deps = [
         "//comp/core/telemetry/impl",
+        "//comp/haagent/mock",
         "//comp/healthplatform/store/mock",
         "//pkg/collector/check/id",
         "//pkg/config/mock",

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -218,9 +218,10 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats S
 	cs.ExecutionTimes[cs.TotalRuns%uint64(len(cs.ExecutionTimes))] = tms
 	cs.TotalRuns++
 	if cs.Telemetry {
-		tlmExecutionTime.Set(float64(tms), cs.CheckName, cs.CheckLoader)
 		if cs.TotalRuns == 1 {
 			tlmFirstExecutionTime.Set(float64(tms), cs.CheckName, cs.CheckLoader)
+		} else {
+			tlmExecutionTime.Set(float64(tms), cs.CheckName, cs.CheckLoader)
 		}
 	}
 	var totalExecutionTime int64

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -74,7 +74,9 @@ var (
 	tlmHistogramBuckets = telemetryimpl.GetCompatComponent().NewCounter("checks", "histogram_buckets",
 		[]string{"check_name"}, "Histogram buckets count")
 	tlmExecutionTime = telemetryimpl.GetCompatComponent().NewGauge("checks", "execution_time",
-		[]string{"check_name", "check_loader", "first_run"}, "Check execution time")
+		[]string{"check_name", "check_loader"}, "Check execution time")
+	tlmFirstExecutionTime = telemetryimpl.GetCompatComponent().NewGauge("checks", "first_execution_time",
+		[]string{"check_name", "check_loader"}, "Check first execution time")
 	tlmCheckDelay = telemetryimpl.GetCompatComponent().NewGauge("checks",
 		"delay",
 		[]string{"check_name"},
@@ -215,12 +217,11 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats S
 	cs.LastExecutionTime = t
 	cs.ExecutionTimes[cs.TotalRuns%uint64(len(cs.ExecutionTimes))] = tms
 	cs.TotalRuns++
-	isFirstRun := "false"
-	if cs.TotalRuns == 1 {
-		isFirstRun = "true"
-	}
 	if cs.Telemetry {
-		tlmExecutionTime.Set(float64(tms), cs.CheckName, cs.CheckLoader, isFirstRun)
+		tlmExecutionTime.Set(float64(tms), cs.CheckName, cs.CheckLoader)
+		if cs.TotalRuns == 1 {
+			tlmFirstExecutionTime.Set(float64(tms), cs.CheckName, cs.CheckLoader)
+		}
 	}
 	var totalExecutionTime int64
 	ringSize := min(cs.TotalRuns, uint64(len(cs.ExecutionTimes)))

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -74,7 +74,7 @@ var (
 	tlmHistogramBuckets = telemetryimpl.GetCompatComponent().NewCounter("checks", "histogram_buckets",
 		[]string{"check_name"}, "Histogram buckets count")
 	tlmExecutionTime = telemetryimpl.GetCompatComponent().NewGauge("checks", "execution_time",
-		[]string{"check_name", "check_loader"}, "Check execution time")
+		[]string{"check_name", "check_loader", "first_run"}, "Check execution time")
 	tlmCheckDelay = telemetryimpl.GetCompatComponent().NewGauge("checks",
 		"delay",
 		[]string{"check_name"},
@@ -215,8 +215,12 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats S
 	cs.LastExecutionTime = t
 	cs.ExecutionTimes[cs.TotalRuns%uint64(len(cs.ExecutionTimes))] = tms
 	cs.TotalRuns++
+	isFirstRun := "false"
+	if cs.TotalRuns == 1 {
+		isFirstRun = "true"
+	}
 	if cs.Telemetry {
-		tlmExecutionTime.Set(float64(tms), cs.CheckName, cs.CheckLoader)
+		tlmExecutionTime.Set(float64(tms), cs.CheckName, cs.CheckLoader, isFirstRun)
 	}
 	var totalExecutionTime int64
 	ringSize := min(cs.TotalRuns, uint64(len(cs.ExecutionTimes)))

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -73,9 +73,9 @@ var (
 		[]string{"check_name"}, "Service checks count")
 	tlmHistogramBuckets = telemetryimpl.GetCompatComponent().NewCounter("checks", "histogram_buckets",
 		[]string{"check_name"}, "Histogram buckets count")
-	tlmExecutionTime = telemetryimpl.GetCompatComponent().NewGauge("checks", "execution_time",
+	tlmExecutionTime = telemetryimpl.GetCompatComponent().NewGauge("", "execution_time",
 		[]string{"check_name", "check_loader"}, "Check execution time")
-	tlmFirstExecutionTime = telemetryimpl.GetCompatComponent().NewGauge("checks", "first_execution_time",
+	tlmFirstExecutionTime = telemetryimpl.GetCompatComponent().NewGauge("", "first_execution_time",
 		[]string{"check_name", "check_loader"}, "Check first execution time")
 	tlmCheckDelay = telemetryimpl.GetCompatComponent().NewGauge("checks",
 		"delay",

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -144,6 +144,7 @@ type Stats struct {
 	EventPlatformEvents      map[string]int64
 	TotalEventPlatformEvents map[string]int64
 	ExecutionTimes           [32]int64     // circular buffer of recent run durations, most recent at [(TotalRuns+31) % 32]
+	FirstExecutionTime       int64         // duration of the first run in milliseconds
 	AverageExecutionTime     int64         // average run duration
 	LastExecutionTime        time.Duration // most recent run duration, provided for convenience
 	LastSuccessDate          int64         // most recent successful execution date, unix timestamp in seconds
@@ -217,12 +218,13 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats S
 	cs.LastExecutionTime = t
 	cs.ExecutionTimes[cs.TotalRuns%uint64(len(cs.ExecutionTimes))] = tms
 	cs.TotalRuns++
-	if cs.Telemetry {
-		if cs.TotalRuns == 1 {
+	if cs.TotalRuns == 1 {
+		cs.FirstExecutionTime = tms
+		if cs.Telemetry {
 			tlmFirstExecutionTime.Set(float64(tms), cs.CheckName, cs.CheckLoader)
-		} else {
-			tlmExecutionTime.Set(float64(tms), cs.CheckName, cs.CheckLoader)
 		}
+	} else if cs.Telemetry {
+		tlmExecutionTime.Set(float64(tms), cs.CheckName, cs.CheckLoader)
 	}
 	var totalExecutionTime int64
 	ringSize := min(cs.TotalRuns, uint64(len(cs.ExecutionTimes)))

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -73,9 +73,9 @@ var (
 		[]string{"check_name"}, "Service checks count")
 	tlmHistogramBuckets = telemetryimpl.GetCompatComponent().NewCounter("checks", "histogram_buckets",
 		[]string{"check_name"}, "Histogram buckets count")
-	tlmExecutionTime = telemetryimpl.GetCompatComponent().NewGauge("", "execution_time",
+	tlmExecutionTime = telemetryimpl.GetCompatComponent().NewGauge("checks", "execution_time",
 		[]string{"check_name", "check_loader"}, "Check execution time")
-	tlmFirstExecutionTime = telemetryimpl.GetCompatComponent().NewGauge("", "first_execution_time",
+	tlmFirstExecutionTime = telemetryimpl.GetCompatComponent().NewGauge("checks", "first_execution_time",
 		[]string{"check_name", "check_loader"}, "Check first execution time")
 	tlmCheckDelay = telemetryimpl.GetCompatComponent().NewGauge("checks",
 		"delay",

--- a/pkg/collector/check/stats/stats_test.go
+++ b/pkg/collector/check/stats/stats_test.go
@@ -124,7 +124,7 @@ func TestFirstExecutionTimeMetric(t *testing.T) {
 	tlmData, err := getTelemetryData()
 	require.NoError(t, err)
 	assert.Contains(t, tlmData,
-		`checks__first_execution_time{check_loader="mockLoader",check_name="checkString"} 100`,
+		`first_execution_time{check_loader="mockLoader",check_name="checkString"} 100`,
 	)
 
 	stats.Add(50*time.Millisecond, nil, []error{}, SenderStats{}, haagent)
@@ -133,10 +133,10 @@ func TestFirstExecutionTimeMetric(t *testing.T) {
 	require.NoError(t, err)
 	// first_execution_time must not be updated on subsequent runs
 	assert.Contains(t, tlmData,
-		`checks__first_execution_time{check_loader="mockLoader",check_name="checkString"} 100`,
+		`first_execution_time{check_loader="mockLoader",check_name="checkString"} 100`,
 	)
 	assert.NotContains(t, tlmData,
-		`checks__first_execution_time{check_loader="mockLoader",check_name="checkString"} 50`,
+		`first_execution_time{check_loader="mockLoader",check_name="checkString"} 50`,
 	)
 }
 

--- a/pkg/collector/check/stats/stats_test.go
+++ b/pkg/collector/check/stats/stats_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
+	haagentmock "github.com/DataDog/datadog-agent/comp/haagent/mock"
 	healthplatformmock "github.com/DataDog/datadog-agent/comp/healthplatform/store/mock"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
@@ -108,6 +109,30 @@ func TestNewStatsStateTelemetryInitialized(t *testing.T) {
 		t,
 		tlmData,
 		"checks__runs{check_name=\"checkString\",state=\"ok\"} 0",
+	)
+}
+
+func TestExecutionTimeFirstRunTag(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.SetInTest("telemetry.checks", "*")
+
+	stats := NewStats(newMockCheck(), healthplatformmock.Mock(t))
+	haagent := haagentmock.NewMockHaAgent()
+
+	stats.Add(100*time.Millisecond, nil, []error{}, SenderStats{}, haagent)
+
+	tlmData, err := getTelemetryData()
+	require.NoError(t, err)
+	assert.Contains(t, tlmData,
+		`checks__execution_time{check_loader="mockLoader",check_name="checkString",first_run="true"}`,
+	)
+
+	stats.Add(50*time.Millisecond, nil, []error{}, SenderStats{}, haagent)
+
+	tlmData, err = getTelemetryData()
+	require.NoError(t, err)
+	assert.Contains(t, tlmData,
+		`checks__execution_time{check_loader="mockLoader",check_name="checkString",first_run="false"}`,
 	)
 }
 

--- a/pkg/collector/check/stats/stats_test.go
+++ b/pkg/collector/check/stats/stats_test.go
@@ -124,7 +124,7 @@ func TestFirstExecutionTimeMetric(t *testing.T) {
 	tlmData, err := getTelemetryData()
 	require.NoError(t, err)
 	assert.Contains(t, tlmData,
-		`first_execution_time{check_loader="mockLoader",check_name="checkString"} 100`,
+		`checks__first_execution_time{check_loader="mockLoader",check_name="checkString"} 100`,
 	)
 
 	stats.Add(50*time.Millisecond, nil, []error{}, SenderStats{}, haagent)
@@ -133,10 +133,10 @@ func TestFirstExecutionTimeMetric(t *testing.T) {
 	require.NoError(t, err)
 	// first_execution_time must not be updated on subsequent runs
 	assert.Contains(t, tlmData,
-		`first_execution_time{check_loader="mockLoader",check_name="checkString"} 100`,
+		`checks__first_execution_time{check_loader="mockLoader",check_name="checkString"} 100`,
 	)
 	assert.NotContains(t, tlmData,
-		`first_execution_time{check_loader="mockLoader",check_name="checkString"} 50`,
+		`checks__first_execution_time{check_loader="mockLoader",check_name="checkString"} 50`,
 	)
 }
 

--- a/pkg/collector/check/stats/stats_test.go
+++ b/pkg/collector/check/stats/stats_test.go
@@ -112,7 +112,7 @@ func TestNewStatsStateTelemetryInitialized(t *testing.T) {
 	)
 }
 
-func TestExecutionTimeFirstRunTag(t *testing.T) {
+func TestFirstExecutionTimeMetric(t *testing.T) {
 	mockConfig := configmock.New(t)
 	mockConfig.SetInTest("telemetry.checks", "*")
 
@@ -124,15 +124,19 @@ func TestExecutionTimeFirstRunTag(t *testing.T) {
 	tlmData, err := getTelemetryData()
 	require.NoError(t, err)
 	assert.Contains(t, tlmData,
-		`checks__execution_time{check_loader="mockLoader",check_name="checkString",first_run="true"}`,
+		`checks__first_execution_time{check_loader="mockLoader",check_name="checkString"} 100`,
 	)
 
 	stats.Add(50*time.Millisecond, nil, []error{}, SenderStats{}, haagent)
 
 	tlmData, err = getTelemetryData()
 	require.NoError(t, err)
+	// first_execution_time must not be updated on subsequent runs
 	assert.Contains(t, tlmData,
-		`checks__execution_time{check_loader="mockLoader",check_name="checkString",first_run="false"}`,
+		`checks__first_execution_time{check_loader="mockLoader",check_name="checkString"} 100`,
+	)
+	assert.NotContains(t, tlmData,
+		`checks__first_execution_time{check_loader="mockLoader",check_name="checkString"} 50`,
 	)
 }
 

--- a/pkg/collector/check/stats/stats_test.go
+++ b/pkg/collector/check/stats/stats_test.go
@@ -123,20 +123,22 @@ func TestFirstExecutionTimeMetric(t *testing.T) {
 
 	tlmData, err := getTelemetryData()
 	require.NoError(t, err)
+	// first run goes only to checks.first_execution_time
 	assert.Contains(t, tlmData,
 		`checks__first_execution_time{check_loader="mockLoader",check_name="checkString"} 100`,
 	)
+	assert.NotContains(t, tlmData, `checks__execution_time{check_loader="mockLoader",check_name="checkString"}`)
 
 	stats.Add(50*time.Millisecond, nil, []error{}, SenderStats{}, haagent)
 
 	tlmData, err = getTelemetryData()
 	require.NoError(t, err)
-	// first_execution_time must not be updated on subsequent runs
+	// subsequent runs go only to checks.execution_time, first_execution_time stays frozen
+	assert.Contains(t, tlmData,
+		`checks__execution_time{check_loader="mockLoader",check_name="checkString"} 50`,
+	)
 	assert.Contains(t, tlmData,
 		`checks__first_execution_time{check_loader="mockLoader",check_name="checkString"} 100`,
-	)
-	assert.NotContains(t, tlmData,
-		`checks__first_execution_time{check_loader="mockLoader",check_name="checkString"} 50`,
 	)
 }
 

--- a/pkg/status/collector/fixtures/status_info.html
+++ b/pkg/status/collector/fixtures/status_info.html
@@ -16,7 +16,8 @@
               Instance ID: cpu [<span class="ok">OK</span>]<br>
               Total Runs: 1<br>
               Metric Samples: 1, Total: 1<br>
-              Events: 0, Total: 0<br>Service Checks: 0, Total: 0<br>Average Execution Time : 1ms<br>
+              Events: 0, Total: 0<br>Service Checks: 0, Total: 0<br>First Execution Time : 0s<br>
+              Average Execution Time : 1ms<br>
               Last Execution Date : 2024-02-20 10:27:30 UTC (1708424850000)<br>
               Last Successful Execution Date : 2024-02-20 10:27:30 UTC (1708424850000)<br></span>
         
@@ -26,7 +27,8 @@
               Instance ID: file_handle [<span class="ok">OK</span>]<br>
               Total Runs: 1<br>
               Metric Samples: 2, Total: 2<br>
-              Events: 0, Total: 0<br>Service Checks: 0, Total: 0<br>Average Execution Time : 0s<br>
+              Events: 0, Total: 0<br>Service Checks: 0, Total: 0<br>First Execution Time : 0s<br>
+              Average Execution Time : 0s<br>
               Last Execution Date : 2024-02-20 10:27:34 UTC (1708424854000)<br>
               Last Successful Execution Date : 2024-02-20 10:27:34 UTC (1708424854000)<br></span>
         
@@ -46,7 +48,8 @@
               Metric Samples: 2, Total: 2<br>
               Events: 0, Total: 0<br>
               dbm-samples: Last Run: 12, Total: 132<br>
-              unknown-type: Last Run: 34, Total: 342<br>Service Checks: 0, Total: 0<br>Average Execution Time : 0s<br>
+              unknown-type: Last Run: 34, Total: 342<br>Service Checks: 0, Total: 0<br>First Execution Time : 0s<br>
+              Average Execution Time : 0s<br>
               Last Execution Date : 2024-02-20 10:27:35 UTC (1708424855000)<br>
               Last Successful Execution Date : 2024-02-20 10:27:35 UTC (1708424855000)<br></span>
         <span/>

--- a/pkg/status/collector/fixtures/status_info.json
+++ b/pkg/status/collector/fixtures/status_info.json
@@ -42,6 +42,7 @@
     "Checks": {
       "cpu": {
         "cpu": {
+          "FirstExecutionTime": 0,
           "AverageExecutionTime": 1,
           "CheckConfigSource": "file:/opt/datadog-agent/etc/conf.d/cpu.d/conf.yaml.default",
           "CheckID": "cpu",
@@ -106,6 +107,7 @@
       },
       "file_handle": {
         "file_handle": {
+          "FirstExecutionTime": 0,
           "AverageExecutionTime": 0,
           "CheckConfigSource": "file:/Users/datadog/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/conf.d/file_handle.d/conf.yaml.default",
           "CheckID": "file_handle",
@@ -170,6 +172,7 @@
       },
       "ntp": {
         "ntp:3c427a42a70bbf8": {
+          "FirstExecutionTime": 0,
           "AverageExecutionTime": 579,
           "CheckConfigSource": "file:/opt/datadog-agent/etc/conf.d/ntp.d/conf.yaml.default",
           "CheckID": "ntp:3c427a42a70bbf8",
@@ -234,6 +237,7 @@
       },
       "telemetry": {
         "telemetry": {
+          "FirstExecutionTime": 0,
           "AverageExecutionTime": 0,
           "CheckConfigSource": "file:/opt/datadog-agent/etc/conf.d/telemetry.d/conf.yaml.default",
           "CheckID": "telemetry",

--- a/pkg/status/collector/status_templates/collector.tmpl
+++ b/pkg/status/collector/status_templates/collector.tmpl
@@ -26,6 +26,7 @@
       {{- if .TotalHistogramBuckets}}
       Histogram Buckets: Last Run: {{humanize .HistogramBuckets}}, Total: {{humanize .TotalHistogramBuckets}}
       {{- end }}
+      First Execution Time : {{humanizeDuration .FirstExecutionTime "ms"}}
       Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
       Last Execution Date : {{formatUnixTime .UpdateTimestamp}}
       Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}

--- a/pkg/status/collector/status_templates/collectorHTML.tmpl
+++ b/pkg/status/collector/status_templates/collectorHTML.tmpl
@@ -24,6 +24,7 @@
               {{- if .TotalHistogramBuckets}}
               Histogram Buckets: {{humanize .HistogramBuckets}}, Total: {{humanize .TotalHistogramBuckets}}<br>
               {{- end -}}
+              First Execution Time : {{humanizeDuration .FirstExecutionTime "ms"}}<br>
               Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}<br>
               Last Execution Date : {{formatUnixTime .UpdateTimestamp}}<br>
               Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}<br>


### PR DESCRIPTION
## Summary

- Adds a new `checks.first_execution_time` gauge that records the duration of a check's **first run only**
- `checks.execution_time` now records **run 2 and beyond only** — the two metrics are mutually exclusive
- Updates `defaultProfiles.yaml` to include `checks.first_execution_time` in the `checks` telemetry profile
- Adds `//comp/haagent/mock` to the `stats_test` Bazel target deps
- Adds `TestFirstExecutionTimeMetric` to verify the mutual exclusion: run 1 sets only `checks.first_execution_time`, run 2 sets only `checks.execution_time`

## Motivation

The first run of a check is typically slower than subsequent runs (cold imports, JIT warm-up, cache population). Exposing this as a dedicated metric gives dashboards and alerts a clean way to compare cold-start cost against steady-state execution time.

A label-based approach (`first_run="true"/"false"` on the existing gauge) was considered and rejected: the `first_run="true"` child would persist in the Prometheus registry and be re-emitted on every agent telemetry profile flush (every 15 minutes) forever, sending stale data on each flush. A dedicated one-shot gauge is the standard Prometheus pattern for this kind of metadata (cf. `process_start_time_seconds`).