### PR TITLE
[CWS-5311] Fix process attribution of NAT-translated ingress packets

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/network/parser.h
+++ b/pkg/security/ebpf/c/include/helpers/network/parser.h
@@ -40,6 +40,13 @@ __attribute__((always_inline)) void parse_tuple(struct nf_conntrack_tuple *tuple
 
     bpf_probe_read(&flow->saddr, sizeof(flow->saddr), &tuple->src.u3.all);
     bpf_probe_read(&flow->daddr, sizeof(flow->daddr), &tuple->dst.u3.all);
+
+    // The conntrack map key is the whole namespaced_flow_t, so l3_protocol/l4_protocol must be filled
+    // the same way parse_packet fills pkt->ns_flow. Otherwise the stored key (proto 0) never matches
+    // the lookup key (ETH_P_IP/IPPROTO_TCP) and NAT translations (e.g. SNAT/masquerade source-port
+    // rewrites) are never reversed on the ingress path.
+    flow->l4_protocol = tuple->dst.protonum;
+    flow->l3_protocol = (tuple->src.l3num == AF_INET6) ? ETH_P_IPV6 : ETH_P_IP;
 }
 
 __attribute__((always_inline)) struct packet_t * parse_packet(struct __sk_buff *skb, int direction) {

--- a/releasenotes/notes/fix-cws-nat-ingress-attribution-b0fbecef21a80398.yaml
+++ b/releasenotes/notes/fix-cws-nat-ingress-attribution-b0fbecef21a80398.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    CWS: Network packets of NAT-translated connections (for example source-port
+    masquerading) are now correctly attributed to the owning process on the
+    ingress path.


### PR DESCRIPTION
### What does this PR do?

Fills `l3_protocol`/`l4_protocol` in `parse_tuple` so the `conntrack` eBPF map key matches between its write (NAT hooks) and read (packet parser) paths, restoring ingress NAT reversal.

### Motivation

On ingress, CWS un-translates NAT via the `conntrack` map before resolving a packet's owning socket. That key is the full flow tuple including L3/L4 protocol, but the write path left those fields `0` while the read path sets them, so the key never matched and NAT was never reversed. NAT-translated ingress packets were then looked up with their post-NAT port, matched no socket, and got no PID. Hit constantly on EKS, where host IMDS (`169.254.169.254`) traffic is source-port masqueraded.

```
conntrack map key = full tuple (addr + port + L3/L4 proto)

  WRITE  nf_nat hook → parse_tuple        READ  TC ingress → parse_packet
  addr/port        ✓                      addr/port        ✓
  l3/l4 proto = 0  ✗  ── never match ──   l3/l4 proto = ETH_P_IP / IPPROTO_TCP

  ⇒ NAT never reversed ⇒ ingress keeps the masqueraded port
  ⇒ flow_pid lookup has no entry ⇒ packet has no PID
```

### Describe how you validated your changes

Deployed to an EKS node and traced ingress resolution of IMDS responses: the masqueraded port is now reversed to the socket's real port and the lookup resolves the owning PID (was a miss before).

### Additional Notes

