### PR TITLE
[CWS-5311] always load network tracking probes when network is enabled

### DIFF
--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -133,8 +133,30 @@ func GetCapabilitiesMonitoringSelectors() []manager.ProbesSelector {
 	}
 }
 
+// GetNetworkSelectors returns the probes that track network interfaces and sockets.
+// These probes must be loaded independently of the current ruleset or network filter actions as
+// these are used to track resources that are needed if we later dynamically load network rules
+// or network filter actions.
+func GetNetworkSelectors(hasCgroupSocket bool) []manager.ProbesSelector {
+	selectors := []manager.ProbesSelector{
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.AllOf{Selectors: NetworkSelectors(hasCgroupSocket)},
+			&manager.AllOf{Selectors: NetworkVethSelectors()},
+		}},
+	}
+
+	// add probes depending on loaded modules
+	if loadedModules, err := utils.FetchLoadedModules(); err == nil {
+		if _, ok := loadedModules["nf_nat"]; ok {
+			selectors = append(selectors, NetworkNFNatSelectors()...)
+		}
+	}
+
+	return selectors
+}
+
 // GetSelectorsPerEventType returns the list of probes that should be activated for each event
-func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.EventType][]manager.ProbesSelector {
+func GetSelectorsPerEventType(hasFentry bool) map[eval.EventType][]manager.ProbesSelector {
 	selectorsPerEventTypeStore := map[eval.EventType][]manager.ProbesSelector{
 		// The following probes will always be activated, regardless of the loaded rules
 		"*": {
@@ -622,29 +644,14 @@ func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.Eve
 		},
 	}
 
-	// Add probes required to track network interfaces and map network flows to processes
-	// networkEventTypes: dns, imds, packet, network_monitor
+	// Register the network event types so they are correctly reflected in the enabled_events map when
+	// requested by rules, activity dumps, security profiles or event sampling. The probes that track
+	// network interfaces and sockets are activated in updateProbes whenever the network
+	// feature is enabled (see GetNetworkSelectors), because they are required to track these resources.
 	networkEventTypes := model.GetEventTypePerCategory(model.NetworkCategory)[model.NetworkCategory]
 	for _, networkEventType := range networkEventTypes {
 		if model.EventTypeDependsOnInterfaceTracking(networkEventType) {
-			selectorsPerEventTypeStore[networkEventType] = []manager.ProbesSelector{
-				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.AllOf{Selectors: NetworkSelectors(hasCgroupSocket)},
-					&manager.AllOf{Selectors: NetworkVethSelectors()},
-				}},
-			}
-		}
-	}
-
-	// add probes depending on loaded modules
-	loadedModules, err := utils.FetchLoadedModules()
-	if err == nil {
-		if _, ok := loadedModules["nf_nat"]; ok {
-			for _, networkEventType := range networkEventTypes {
-				if model.EventTypeDependsOnInterfaceTracking(networkEventType) {
-					selectorsPerEventTypeStore[networkEventType] = append(selectorsPerEventTypeStore[networkEventType], NetworkNFNatSelectors()...)
-				}
-			}
+			selectorsPerEventTypeStore[networkEventType] = []manager.ProbesSelector{}
 		}
 	}
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2268,12 +2268,19 @@ func (p *EBPFProbe) updateProbes(ruleSetEventTypes []eval.EventType, needRawSysc
 
 	activatedProbes := probes.SnapshotSelectors(p.useFentry)
 
+	// Network interface and socket tracking probes are required independently of the current ruleset or
+	// network filter actions as these are used to track resources that are needed if we later
+	// dynamically load network rules or network filter actions.
+	if p.config.Probe.NetworkEnabled {
+		activatedProbes = append(activatedProbes, probes.GetNetworkSelectors(p.kernelVersion.HasBpfGetSocketCookieForCgroupSocket())...)
+	}
+
 	if p.config.Probe.CapabilitiesMonitoringEnabled {
 		activatedProbes = append(activatedProbes, probes.GetCapabilitiesMonitoringSelectors()...)
 	}
 
 	// extract probe to activate per the event types
-	for eventType, selectors := range probes.GetSelectorsPerEventType(p.useFentry, p.kernelVersion.HasBpfGetSocketCookieForCgroupSocket()) {
+	for eventType, selectors := range probes.GetSelectorsPerEventType(p.useFentry) {
 		if (eventType == "*" || slices.Contains(requestedEventTypes, eventType) ||
 			p.isNeededForActivityDump(eventType) ||
 			p.isNeededForSecurityProfile(eventType) ||


### PR DESCRIPTION
### What does this PR do?

Loads the network interface and network flow tracking probes whenever the network feature is enabled, instead of only when a rule for a network event type is loaded.

### Motivation

Attributing a network flow to the process that owns it relies on probes that record flow/PID associations as network flows are created. If those probes are only loaded when a network rule is present, any flow established before the rule was loaded cannot be attributed to a process. Loading them as soon as the network feature is enabled keeps flow/PID tracking in place at all times, so that a process can be correctly matched to a network rule is loaded later.

This also makes sure that we can properly apply network remediation actions when no network rules is loaded (as we need the packet-to-process attribution to work for this purpose). 

### Describe how you validated your changes

Existing network functional tests.

### Additional Notes
