### PR TITLE
fix(autoscaling): always re-sync local-owner DPA state on every reconcile

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -395,8 +395,6 @@ func (c *Controller) syncPodAutoscaler(ctx context.Context, key, ns, name string
 		// Fall through to normal scaling logic.
 	} else if podAutoscalerInternal.Spec().Owner == datadoghqcommon.DatadogPodAutoscalerLocalOwner {
 		// Sync logic for local ownership: Kubernetes is the source of truth.
-		// UpdateFromPodAutoscaler internally short-circuits when neither .metadata.generation
-		// nor any of the watched labels/annotations has changed.
 		podAutoscalerInternal.UpdateFromPodAutoscaler(podAutoscaler)
 	}
 

--- a/pkg/clusteragent/autoscaling/workload/model/BUILD.bazel
+++ b/pkg/clusteragent/autoscaling/workload/model/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusteragent/autoscaling",
-        "//pkg/util/kubernetes",
         "//pkg/util/pointer",
         "@com_github_datadog_agent_payload_v5//autoscaling/kubernetes",
         "@com_github_datadog_datadog_operator_api//datadoghq/common",
@@ -26,7 +25,6 @@ go_library(
         "@com_github_datadog_datadog_operator_api//datadoghq/v1alpha2",
         "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//assert",
-        "@com_github_twmb_murmur3//:murmur3",
         "@io_k8s_api//autoscaling/v2:autoscaling",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/resource",

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
@@ -18,10 +18,8 @@ import (
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 
-	"github.com/twmb/murmur3"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,21 +44,6 @@ const (
 	// CustomRecommenderAnnotationKey is the key used to store custom recommender configuration in annotations
 	CustomRecommenderAnnotationKey = "autoscaling.datadoghq.com/custom-recommender"
 )
-
-// resyncLabelKeysFromPodAutoscaler lists the label keys read by UpdateFromPodAutoscaler.
-var resyncLabelKeysFromPodAutoscaler = []string{
-	ProfileLabelKey,
-}
-
-// resyncAnnotationKeysFromPodAutoscaler lists annotation keys whose value must trigger a re-sync
-// when changed. Edits to these don't bump .metadata.generation, so they're part of the metadata
-// fingerprint. Includes annotations consumed downstream, e.g. ad.datadoghq.com/tags (metric tags).
-var resyncAnnotationKeysFromPodAutoscaler = []string{
-	PreviewAnnotationKey,
-	ProfileTemplateHashAnnotation,
-	CustomRecommenderAnnotationKey,
-	kubernetes.ADTagsAnnotation,
-}
 
 // PodAutoscalerInternal holds the necessary data to work with the `DatadogPodAutoscaler` CRD.
 type PodAutoscalerInternal struct {
@@ -99,11 +82,6 @@ type PodAutoscalerInternal struct {
 
 	// previewOptions holds the parsed preview feature flags from the DPA annotations
 	previewOptions previewOptions
-
-	// metadataHash fingerprints the K8s state read by UpdateFromPodAutoscaler
-	// (.metadata.generation plus watched labels/annotations), so that a single
-	// equality check captures both spec changes and out-of-spec edits.
-	metadataHash uint64
 
 	// scalingValues represents the active scaling values that should be used
 	scalingValues ScalingValues
@@ -323,16 +301,7 @@ func (p *PodAutoscalerInternal) UpdateFromProfile(
 }
 
 // UpdateFromPodAutoscaler updates the PodAutoscalerInternal from a PodAutoscaler object inside K8S.
-// For local-owner DPAs it short-circuits when the cached metadata fingerprint is unchanged.
 func (p *PodAutoscalerInternal) UpdateFromPodAutoscaler(podAutoscaler *datadoghq.DatadogPodAutoscaler) {
-	if podAutoscaler.Spec.Owner == datadoghqcommon.DatadogPodAutoscalerLocalOwner {
-		newHash := computePodAutoscalerMetadataHash(podAutoscaler)
-		if p.metadataHash == newHash {
-			return
-		}
-		p.metadataHash = newHash
-	}
-
 	if v, ok := podAutoscaler.Labels[ProfileLabelKey]; ok {
 		p.profileName = v
 	}
@@ -1441,19 +1410,4 @@ func parseCustomConfigurationAnnotation(annotations map[string]string) (*Recomme
 	}
 
 	return &customConfiguration, nil
-}
-
-// computePodAutoscalerMetadataHash returns a fingerprint of the K8s state
-// read by UpdateFromPodAutoscaler — .metadata.generation plus the watched
-// labels/annotations — used to identify any change worth re-syncing.
-func computePodAutoscalerMetadataHash(podAutoscaler *datadoghq.DatadogPodAutoscaler) uint64 {
-	hasher := murmur3.New64()
-	_, _ = fmt.Fprintf(hasher, "G\x00%d\x00", podAutoscaler.Generation)
-	for _, key := range resyncLabelKeysFromPodAutoscaler {
-		_, _ = hasher.Write([]byte("L\x00" + key + "\x00" + podAutoscaler.Labels[key] + "\x00"))
-	}
-	for _, key := range resyncAnnotationKeysFromPodAutoscaler {
-		_, _ = hasher.Write([]byte("A\x00" + key + "\x00" + podAutoscaler.Annotations[key] + "\x00"))
-	}
-	return hasher.Sum64()
 }

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test.go
@@ -936,38 +936,46 @@ func TestContainerResourcesForStatus(t *testing.T) {
 	}
 }
 
-// TestUpdateFromPodAutoscalerResyncsOnWatchedMetadata verifies that, for local-owner DPAs,
-// UpdateFromPodAutoscaler picks up changes to the watched labels/annotations even when
-// .metadata.generation is unchanged (e.g. an annotation-only edit to PreviewAnnotationKey).
-func TestUpdateFromPodAutoscalerResyncsOnWatchedMetadata(t *testing.T) {
-	dpa := &datadoghq.DatadogPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{Name: "dpa", Namespace: "default", Generation: 1},
-		Spec:       datadoghq.DatadogPodAutoscalerSpec{Owner: datadoghqcommon.DatadogPodAutoscalerLocalOwner},
-	}
+func TestUpdateFromPodAutoscaler(t *testing.T) {
+	t.Run("annotation change", func(t *testing.T) {
+		dpa := &datadoghq.DatadogPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{Name: "dpa", Namespace: "default", Generation: 1},
+			Spec:       datadoghq.DatadogPodAutoscalerSpec{Owner: datadoghqcommon.DatadogPodAutoscalerLocalOwner},
+		}
 
-	pai := NewPodAutoscalerInternal(dpa)
-	assert.False(t, pai.IsBurstable())
+		pai := NewPodAutoscalerInternal(dpa)
+		assert.False(t, pai.IsBurstable())
 
-	// Annotation-only edit: same generation, new preview annotation.
-	dpa.Annotations = map[string]string{PreviewAnnotationKey: `{"burstable":true}`}
-	pai.UpdateFromPodAutoscaler(dpa)
-	assert.True(t, pai.IsBurstable(), "annotation-only edit must be picked up")
+		// Annotation-only edit (no generation bump): must be picked up immediately.
+		dpa.Annotations = map[string]string{PreviewAnnotationKey: `{"burstable":true}`}
+		pai.UpdateFromPodAutoscaler(dpa)
+		assert.True(t, pai.IsBurstable(), "annotation-only edit must be picked up")
 
-	// Calling again with the same object is a no-op (gate kicks in).
-	previousHash := pai.metadataHash
-	pai.UpdateFromPodAutoscaler(dpa)
-	assert.Equal(t, previousHash, pai.metadataHash)
+		// A tags annotation-only edit (no generation bump) must refresh the cached upstream CR.
+		dpa.Annotations["ad.datadoghq.com/tags"] = `{"team":"foo"}`
+		pai.UpdateFromPodAutoscaler(dpa)
+		assert.Equal(t, `{"team":"foo"}`, pai.UpstreamCR().Annotations["ad.datadoghq.com/tags"])
+	})
 
-	// An unrelated annotation change does not retrigger the parse but is harmless.
-	dpa.Annotations["unrelated"] = "x"
-	pai.UpdateFromPodAutoscaler(dpa)
-	assert.True(t, pai.IsBurstable())
+	t.Run("status change", func(t *testing.T) {
+		dpa := &datadoghq.DatadogPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{Name: "dpa", Namespace: "default", Generation: 1},
+			Spec:       datadoghq.DatadogPodAutoscalerSpec{Owner: datadoghqcommon.DatadogPodAutoscalerLocalOwner},
+			Status: datadoghqcommon.DatadogPodAutoscalerStatus{
+				Horizontal: &datadoghqcommon.DatadogPodAutoscalerHorizontalStatus{
+					Target: &datadoghqcommon.DatadogPodAutoscalerHorizontalRecommendation{Replicas: 3},
+				},
+			},
+		}
 
-	// A tags annotation-only edit (no generation bump) must refresh the cached upstream CR.
-	dpa.Annotations["ad.datadoghq.com/tags"] = `{"team":"foo"}`
-	pai.UpdateFromPodAutoscaler(dpa)
-	assert.Equal(t, `{"team":"foo"}`, pai.UpstreamCR().Annotations["ad.datadoghq.com/tags"],
-		"ad.datadoghq.com/tags edit must be picked up without a generation bump")
+		pai := NewPodAutoscalerInternal(dpa)
+		assert.Equal(t, int32(3), pai.UpstreamCR().Status.Horizontal.Target.Replicas)
+
+		// Status-only update (generation unchanged): upstreamCR must reflect the new status.
+		dpa.Status.Horizontal.Target.Replicas = 7
+		pai.UpdateFromPodAutoscaler(dpa)
+		assert.Equal(t, int32(7), pai.UpstreamCR().Status.Horizontal.Target.Replicas, "status-only update must be picked up")
+	})
 }
 
 // TestSetActiveScalingValues_NilSource_ClearsVertical verifies that a nil verticalActiveSource
@@ -1002,4 +1010,32 @@ func TestSetActiveScalingValues_NilSource_ClearsVertical(t *testing.T) {
 		"SetActiveScalingValues(nil source) must set scalingValues.Vertical to nil, not "+
 			"self-assign the sentinel-containing constrained value; the sentinel would cause "+
 			"applyVerticalConstraints(burstable=false) to early-return and suppress the rollout")
+}
+
+func BenchmarkUpdateFromPodAutoscaler(b *testing.B) {
+	dpa := &datadoghq.DatadogPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "burner-server",
+			Namespace:  "default",
+			Generation: 1,
+			Labels: map[string]string{
+				ProfileLabelKey: "default-profile",
+			},
+			Annotations: map[string]string{
+				PreviewAnnotationKey:           `{"burstable":true}`,
+				ProfileTemplateHashAnnotation:  "abc123def456",
+				CustomRecommenderAnnotationKey: `{"endpoint":"https://recommender.internal/v1"}`,
+			},
+		},
+		Spec: datadoghq.DatadogPodAutoscalerSpec{
+			Owner: datadoghqcommon.DatadogPodAutoscalerLocalOwner,
+		},
+	}
+
+	pai := NewPodAutoscalerInternal(dpa)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		pai.UpdateFromPodAutoscaler(dpa)
+	}
 }

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test_utils.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test_utils.go
@@ -104,21 +104,11 @@ func (f FakePodAutoscalerInternal) Build() PodAutoscalerInternal {
 		upstreamCR.Annotations[PreviewAnnotationKey] = f.PreviewAnnotationKey
 	}
 
-	// Mirror UpdateFromPodAutoscaler: cache the metadata fingerprint so equality checks
-	// against a PodAutoscalerInternal that came through the real code path match.
-	// Only populate when the test passes an explicit local-owner UpstreamCR — settings-driven
-	// shells (and non-local owners) do not go through the gated path in production.
-	var metadataHash uint64
-	if f.UpstreamCR != nil && f.UpstreamCR.Spec.Owner == datadoghqcommon.DatadogPodAutoscalerLocalOwner {
-		metadataHash = computePodAutoscalerMetadataHash(upstreamCR)
-	}
-
 	return PodAutoscalerInternal{
 		namespace:                          f.Namespace,
 		name:                               f.Name,
 		generation:                         f.Generation,
 		upstreamCR:                         upstreamCR,
-		metadataHash:                       metadataHash,
 		settingsTimestamp:                  f.SettingsTimestamp,
 		creationTimestamp:                  f.CreationTimestamp,
 		scalingValues:                      f.ScalingValues,

--- a/releasenotes/notes/fix-dpa-status-metrics-stale-fbb6a0c7d7c6b2b4.yaml
+++ b/releasenotes/notes/fix-dpa-status-metrics-stale-fbb6a0c7d7c6b2b4.yaml
@@ -1,0 +1,15 @@
+---
+fixes:
+  - |
+    Fix stale metrics for locally-owned ``DatadogPodAutoscaler`` objects. The
+    cluster agent cached the CRD object only on the first reconcile; status
+    subresource writes (which do not bump ``.metadata.generation``) were never
+    reflected in the cached copy, causing the following metrics to report their
+    initial values until the next spec or annotation change:
+    ``datadog.cluster_agent.autoscaling.workload.status.desired.replicas``,
+    ``datadog.cluster_agent.autoscaling.workload.status.vertical.desired.container.cpu.request``,
+    ``datadog.cluster_agent.autoscaling.workload.status.vertical.desired.container.cpu.limit``,
+    ``datadog.cluster_agent.autoscaling.workload.status.vertical.desired.container.memory.request``,
+    ``datadog.cluster_agent.autoscaling.workload.status.vertical.desired.container.memory.limit``,
+    ``datadog.cluster_agent.autoscaling.workload.autoscaler_conditions``.
+    The controller now unconditionally refreshes the cached object on every reconcile.


### PR DESCRIPTION
### What does this PR do?

UpdateFromPodAutoscaler now unconditionally re-applies all fields from the current informer snapshot to
avoid stale metrics derived from autoscaler status.

### Motivation

PR #51173 fixed a real bug: annotation-only edits (e.g. adding autoscaling.datadoghq.com/preview) were silently ignored because the caller gated UpdateFromPodAutoscaler on metadata.generation, which annotations don't bump. The fix moved the gate inside the function as a murmur3 hash of generation plus watched annotations/labels.

However the optimization was never justified. All the guarded work — map lookups, a few arithmetic ops for retention windows, JSON unmarshal of a small annotation string — runs in well under 1 µs per call. The hash computation itself (murmur3 over a handful of strings) costs about as much as the work it avoids. At the DPA reconcile rate (~15-30s per autoscaler) this is immeasurable.

```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model
cpu: Apple M4 Max
BenchmarkUpdateFromPodAutoscaler-16    	 1932051	       618.4 ns/op	     568 B/op	      13 allocs/op
BenchmarkUpdateFromPodAutoscaler-16    	 1938516	       616.3 ns/op	     568 B/op	      13 allocs/op
BenchmarkUpdateFromPodAutoscaler-16    	 1935860	       621.7 ns/op	     568 B/op	      13 allocs/op
BenchmarkUpdateFromPodAutoscaler-16    	 1936916	       618.8 ns/op	     568 B/op	      13 allocs/op
BenchmarkUpdateFromPodAutoscaler-16    	 1950974	       617.5 ns/op	     568 B/op	      13 allocs/op
BenchmarkUpdateFromPodAutoscaler-16    	 1936854	       619.0 ns/op	     568 B/op	      13 allocs/op
BenchmarkUpdateFromPodAutoscaler-16    	 1940514	       618.3 ns/op	     568 B/op	      13 allocs/op
BenchmarkUpdateFromPodAutoscaler-16    	 1937865	       617.4 ns/op	     568 B/op	      13 allocs/op
BenchmarkUpdateFromPodAutoscaler-16    	 1935842	       619.3 ns/op	     568 B/op	      13 allocs/op
BenchmarkUpdateFromPodAutoscaler-16    	 1941636	       617.8 ns/op	     568 B/op	      13 allocs/op
```

The pre-existing generation gate also meant upstreamCR was never refreshed by status subresource writes, since those don't bump metadata.generation. PR #51173 preserved this behavior by keeping p.upstreamCR inside the short-circuit. This made all status-derived metrics stale indefinitely:
- status.desired.replicas: frozen at the initial horizontal target
- status.vertical.desired.container.{cpu,memory}.{request,limit}: frozen at the initial vertical recommendation
- autoscaler_conditions: condition flaps never reflected

Remove the hash gate entirely. UpdateFromPodAutoscaler now unconditionally re-applies all fields from the current informer snapshot, which is both correct and trivially cheap.

### Describe how you validated your changes

Unit tests, benchmark.

### Additional Notes
