### PR TITLE
[CWS] Attach accept probe only when accept events are requested

### DIFF
--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -41,7 +41,6 @@ func NetworkSelectors(hasCgroupSocket bool) []manager.ProbesSelector {
 	ps := []manager.ProbesSelector{
 		// flow classification probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			hookFunc("hook_accept"),
 			hookFunc("hook_security_socket_bind"),
 			hookFunc("hook_security_socket_connect"),
 			hookFunc("hook_security_sk_classify_flow"),

--- a/releasenotes/notes/cws-accept-probe-on-demand-c431c9b51894a589.yaml
+++ b/releasenotes/notes/cws-accept-probe-on-demand-c431c9b51894a589.yaml
@@ -1,5 +1,0 @@
----
-fixes:
-  - |
-    CWS: The ``accept`` probe is now attached only when ``accept`` events are requested,
-    instead of whenever network monitoring is enabled.

--- a/releasenotes/notes/cws-accept-probe-on-demand-c431c9b51894a589.yaml
+++ b/releasenotes/notes/cws-accept-probe-on-demand-c431c9b51894a589.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    CWS: The ``accept`` probe is now attached only when ``accept`` events are requested,
+    instead of whenever network monitoring is enabled.


### PR DESCRIPTION
### What does this PR do?

Attaches the `hook_accept` eBPF probe only when `accept` rules are loaded, instead of whenever network monitoring is enabled (true by default).

### Motivation

`hook_accept` unconditionally emits an event, including it in the always-on network probe set caused an accept event to be sent to user space for every accepted connection on hosts with inbound traffic, even when no rule or consumer requested accept events.

### Describe how you validated your changes

`TestAcceptEvent/*` tests pass

### Additional Notes
