### PR TITLE
fix(test): set MaxConnections in TestOOMKill to match production default

### DIFF
--- a/pkg/trace/api/api_oom_test.go
+++ b/pkg/trace/api/api_oom_test.go
@@ -40,6 +40,7 @@ func TestOOMKill(t *testing.T) {
 	conf.WatchdogInterval = time.Millisecond
 	conf.MaxMemory = 0.1 * 1000 * 1000 // 100KB
 	conf.ReceiverPort = port
+	conf.MaxConnections = 1000 // default value of apm_config.max_connections
 
 	r := newTestReceiverFromConfig(conf)
 	r.Start()


### PR DESCRIPTION
### What does this PR do?

Sets `conf.MaxConnections = 1000` in `TestOOMKill`, matching the production default (`apm_config.max_connections` defaults to 1000).

### Motivation

`config.New()` zero-initialises the struct, leaving `MaxConnections = 0`. The `MeasuredListener` converts 0 to 1, meaning only one TCP connection is accepted at a time. The test sends 50 concurrent requests, so 49 connections sit in the kernel accept queue while the server processes one at a time.
This happened to work in Go 1.26 because `resp.Body.Close()` without reading the body always closed the connection, releasing the listener semaphore for the next accept. Go 1.27 added automatic response-body draining before closing, which recycles the connection into the idle pool instead — the semaphore is never released and the test deadlocks.

### Describe how you validated your changes

Passes locally with Go 1.26. Also verified with Go 1.27rc1.

### Additional Notes
Surfaced by Go 1.27 compatibility testing (#52848).
