### PR TITLE
updated default evp subdomain for ai usage agent

### DIFF
--- a/cmd/ai_prompt_logger/ai_usage_native_host.yaml.example
+++ b/cmd/ai_prompt_logger/ai_usage_native_host.yaml.example
@@ -18,7 +18,7 @@ trace_agent_url: "http://127.0.0.1:8126"
 evp_proxy_api_version: 2
 
 # AI usage EVP intake subdomain header.
-ai_usage_evp_subdomain: "softinv-intake"
+ai_usage_evp_subdomain: "eudm-intake"
 
 # Standalone desktop monitoring settings. These are used only when the binary is
 # launched with --desktop-monitor; Chrome native messaging mode ignores them.

--- a/releasenotes/notes/update-default-subdomain-for-ai-usage-agent-7a06463a34a5f2fc.yaml
+++ b/releasenotes/notes/update-default-subdomain-for-ai-usage-agent-7a06463a34a5f2fc.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Updated the default EVP subdomain for AI Usage Agent.


### PR DESCRIPTION
### What does this PR do?
This PR updates the default EVP subdomain for Datadog AI Usage Agent.

### Motivation
[WINA-2863](https://datadoghq.atlassian.net/browse/WINA-2863)

### Describe how you validated your changes
Conduct end-to-end test with AI Usage Agent Chrome extension.

### Additional Notes


[WINA-2863]: https://datadoghq.atlassian.net/browse/WINA-2863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ