### PR TITLE
(cluster-agent): Dedicated Client for Leader Election

### DIFF
--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -77,6 +77,10 @@ const (
 	// This is mostly required for built-in controllers in Cluster Agent (ExternalMetrics, Autoscaling that can generate a high number of `Update` requests)
 	controllerClientQPSLimit = 150
 	controllerClientQPSBurst = 300
+	// Leader election operations are low-frequency (one lease update every ~15-60s) but must be
+	// isolated from other components so they cannot be starved by other components' API traffic.
+	leaderElectionClientQPSLimit = 20
+	leaderElectionClientQPSBurst = 40
 )
 
 // APIClient provides authenticated access to the
@@ -88,6 +92,10 @@ type APIClient struct {
 
 	// Cl holds the main kubernetes client
 	Cl kubernetes.Interface
+
+	// LeaderElectionCl holds a dedicated kubernetes client for leader election with independently
+	// managed client-side rate limiting, so leader election is never starved by other components.
+	LeaderElectionCl kubernetes.Interface
 
 	// DynamicCl holds a dynamic kubernetes client
 	DynamicCl dynamic.Interface
@@ -363,6 +371,12 @@ func (c *APIClient) connect() error {
 	c.Cl, err = GetKubeClient(c.defaultClientTimeout, c.defaultClientQPS, c.defaultClientBurst)
 	if err != nil {
 		log.Infof("Could not get apiserver client: %v", err)
+		return err
+	}
+
+	c.LeaderElectionCl, err = GetKubeClient(c.defaultClientTimeout, leaderElectionClientQPSLimit, leaderElectionClientQPSBurst)
+	if err != nil {
+		log.Infof("Could not get leader election apiserver client: %v", err)
 		return err
 	}
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -161,16 +161,16 @@ func (le *LeaderEngine) init() error {
 		return err
 	}
 
-	serverVersion, err := common.KubeServerVersion(apiClient.Cl.Discovery(), 10*time.Second)
+	serverVersion, err := common.KubeServerVersion(apiClient.LeaderElectionCl.Discovery(), 10*time.Second)
 	if err == nil && semver.IsValid(serverVersion.String()) && semver.Compare(serverVersion.String(), "v1.14.0") < 0 {
 		log.Warn("[DEPRECATION WARNING] DataDog will drop support of Kubernetes older than v1.14. Please update to a newer version to ensure proper functionality and security.")
 	}
 
-	le.coreClient = apiClient.Cl.CoreV1()
-	le.coordClient = apiClient.Cl.CoordinationV1()
-	le.discoveryClient = apiClient.Cl.DiscoveryV1()
+	le.coreClient = apiClient.LeaderElectionCl.CoreV1()
+	le.coordClient = apiClient.LeaderElectionCl.CoordinationV1()
+	le.discoveryClient = apiClient.LeaderElectionCl.DiscoveryV1()
 
-	usingLease, err := CanUseLeases(apiClient.Cl.Discovery())
+	usingLease, err := CanUseLeases(apiClient.LeaderElectionCl.Discovery())
 	if err != nil {
 		log.Errorf("Unable to retrieve available resources: %v", err)
 		return err

--- a/releasenotes-dca/notes/dca-leader-election-dedicated-client-61673e1ad9e711da.yaml
+++ b/releasenotes-dca/notes/dca-leader-election-dedicated-client-61673e1ad9e711da.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The Cluster Agent's leader election now uses a dedicated Kubernetes API server
+    client with independently managed client-side rate limiting to be more resilient.


### PR DESCRIPTION
### What does this PR do?

Provides a dedicated client for cluster-agent leadership election related activities

### Motivation

Create an independent client for cluster-agent leadership election activities. This is a critical Agent component that only makes a few requests primarily around leadership transitions and pod startup. These clients have client-side rate limiting to protect the API Server. We don't want the leadership related queries to get rate limited from other components which can saturate the queue like autoscaling, ksm checks, external metrics, k8s actions, etc.

### Describe how you validated your changes

CI has leadership election coverage