### PR TITLE
[CSI-1694] Deprecate S3 git strategy: default to fetch and migrate OVERRIDE_GIT_STRATEGY to GIT_STRATEGY

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -372,7 +372,8 @@ variables:
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 
   # Job cloning strategy
-  GIT_STRATEGY: "s3"
+  GIT_STRATEGY: "fetch"
+  DISABLE_GIT_CACHE: true
 
   # Job stage attempts (see https://docs.gitlab.com/ee/ci/runners/configure_runners.html#job-stages-attempts)
   ARTIFACT_DOWNLOAD_ATTEMPTS: 2

--- a/.gitlab/build/source_test/golang_deps_diff.yml
+++ b/.gitlab/build/source_test/golang_deps_diff.yml
@@ -12,7 +12,7 @@ golang_deps_diff:
   needs: ["go_deps"]
   variables:
     KUBERNETES_CPU_REQUEST: 8
-    OVERRIDE_GIT_STRATEGY: "clone" # needed because this job uses `git merge-base`
+    GIT_STRATEGY: "clone" # needed because this job uses `git merge-base`
     KUBERNETES_MEMORY_REQUEST: "16Gi"
     KUBERNETES_MEMORY_LIMIT: "16Gi"
   before_script:

--- a/.gitlab/deploy/conditions.yml
+++ b/.gitlab/deploy/conditions.yml
@@ -163,7 +163,7 @@
     # Windows runners don't support the s3 strategy
     # Clone is required since cancelled Windows jobs with fetch strategy
     # can cause CIEXE-1152 which makes the runner unusable.
-    OVERRIDE_GIT_STRATEGY: "clone"
+    GIT_STRATEGY: "clone"
     # Avoid using ~/.aws/credentials to avoid conflicts with other CI jobs
     # this env var is understood by both ci-identities-gitlab-job-client.exe and aws.exe
     AWS_SHARED_CREDENTIALS_FILE: ${CI_PROJECT_DIR}\.aws\credentials-by-job-id\${CI_JOB_ID}
@@ -182,7 +182,7 @@
     # Windows runners don't support the s3 strategy
     # Clone is required since cancelled Windows jobs with fetch strategy
     # can cause CIEXE-1152 which makes the runner unusable.
-    OVERRIDE_GIT_STRATEGY: "clone"
+    GIT_STRATEGY: "clone"
     # Avoid using ~/.aws/credentials to avoid conflicts with other CI jobs
     # this env var is understood by both ci-identities-gitlab-job-client.exe and aws.exe
     AWS_SHARED_CREDENTIALS_FILE: ${CI_PROJECT_DIR}\.aws\credentials-by-job-id\${CI_JOB_ID}
@@ -204,7 +204,7 @@
     # Windows runners don't support the s3 strategy
     # Clone is required since cancelled Windows jobs with fetch strategy
     # can cause CIEXE-1152 which makes the runner unusable.
-    OVERRIDE_GIT_STRATEGY: "clone"
+    GIT_STRATEGY: "clone"
     # Avoid using ~/.aws/credentials to avoid conflicts with other CI jobs
     # this env var is understood by both ci-identities-gitlab-job-client.exe and aws.exe
     AWS_SHARED_CREDENTIALS_FILE: ${CI_PROJECT_DIR}\.aws\credentials-by-job-id\${CI_JOB_ID}

--- a/.gitlab/test/functional_test/files_inventory_check.yml
+++ b/.gitlab/test/functional_test/files_inventory_check.yml
@@ -10,7 +10,7 @@ files_inventory_check:
   tags: ["arch:amd64", "specific:true"]
   variables:
     GIT_DEPTH: 0
-    OVERRIDE_GIT_STRATEGY: clone
+    GIT_STRATEGY: clone
   needs:
     - agent_deb-x64-a7
   before_script:

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -84,7 +84,7 @@ static_quality_gates:
     expire_in: 1 week
   variables:
     GIT_DEPTH: 0
-    OVERRIDE_GIT_STRATEGY: "clone" # needed because this job uses git merge-base
+    GIT_STRATEGY: "clone" # needed because this job uses git merge-base
     KUBERNETES_CPU_REQUEST: 8
 
 manual_gate_threshold_update:

--- a/.gitlab/windows/deploy/container_build/agent7.yml
+++ b/.gitlab/windows/deploy/container_build/agent7.yml
@@ -95,7 +95,7 @@ docker_build_agent7_windows:
         WITH_JMX: "true"
   tags: [$WINDOWS_RUNNER]
   variables:
-    OVERRIDE_GIT_STRATEGY: "clone"
+    GIT_STRATEGY: "clone"
 
 # FIPS builds: ltsc2022 only (with/without JMX)
 docker_build_fips_agent7_windows:
@@ -110,4 +110,4 @@ docker_build_fips_agent7_windows:
         WITH_JMX: "true"
   tags: [$WINDOWS_RUNNER]
   variables:
-    OVERRIDE_GIT_STRATEGY: "clone"
+    GIT_STRATEGY: "clone"


### PR DESCRIPTION
### What does this PR do?

Consolidates two stacked PRs into one so the S3 git strategy can be fully deprecated atomically:

- **From #51750 (Omri Zohar):** flip the pipeline default `GIT_STRATEGY` from `s3` to `fetch` and set `DISABLE_GIT_CACHE: true` in `.gitlab-ci.yml`.
- **From #52930 (Nicolas Schweitzer):** replace the custom `OVERRIDE_GIT_STRATEGY: clone` per-job escape hatch with the native GitLab `GIT_STRATEGY: clone` in the jobs that require a full clone (`golang_deps_diff`, `static_quality_gate`, `files_inventory_check`, Windows deploy jobs).

With the introduction of gitretriever the S3 strategy is no longer needed. This is the last repo still using it; migrating off lets DDCI decommission the supporting S3 infrastructure and reduce CI cost.

### Motivation

`OVERRIDE_GIT_STRATEGY` was a custom variable only meaningful while the default was the non-native `s3` strategy. Once the default becomes the native `fetch`, those jobs must use the native `GIT_STRATEGY` to override it, otherwise they would silently inherit `fetch` and break (`git merge-base` jobs, and Windows runners hitting CIEXE-1152). The two changes therefore must land together.

Metric to track: https://app.datadoghq.com/s/yB5yjZ/45h-gma-i7n

Supersedes / consolidates:
- https://github.com/DataDog/datadog-agent/pull/51750
- https://github.com/DataDog/datadog-agent/pull/52930

### Describe how you validated your changes

_Pending CI._

### Additional Notes

Both original commits are preserved with their authorship.