### PR TITLE
[ AGNTLOG-663 ] Combine Go stack traces when the header has no trailing blank line

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser.go
+++ b/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser.go
@@ -120,12 +120,28 @@ func (g *GoStackTraceParser) AcceptLine(line []byte) bool {
 		return true
 
 	case goStateInChunk:
+		// A chunk-start line ends the current chunk just as a blank line would.
+		// Sources that strip the header's blank-line separator strip the
+		// separators between later chunks too, so without this a multi-goroutine
+		// dump would combine only its first chunk. Re-dispatch through
+		// betweenChunks (which resets uncommitted and counts the new chunk),
+		// yielding the same end-state as the blank-line path.
+		if _, ok := goDetectChunkStart(line); ok {
+			g.st = goStateBetweenChunks
+			return g.AcceptLine(line)
+		}
 		return g.validStackLine(line)
 
 	case goStateInRegDump:
 		if goValidRegisterLine(line) {
 			g.uncommitted = 0
 			return true
+		}
+		// As above: a chunk-start line directly after a register dump (no blank
+		// line) begins a new chunk rather than ending the trace.
+		if _, ok := goDetectChunkStart(line); ok {
+			g.st = goStateBetweenChunks
+			return g.AcceptLine(line)
 		}
 		return false
 	}

--- a/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser.go
+++ b/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser.go
@@ -183,6 +183,11 @@ func goHasPrefix(line []byte, prefix string) bool {
 	return len(line) >= len(prefix) && string(line[:len(prefix)]) == prefix
 }
 
+// goHasDigitAt reports whether line has an ASCII digit at index i.
+func goHasDigitAt(line []byte, i int) bool {
+	return i < len(line) && line[i] >= '0' && line[i] <= '9'
+}
+
 func goValidHeaderContinuation(line []byte) bool {
 	if len(line) == 0 {
 		return false
@@ -210,7 +215,17 @@ func goDetectChunkStart(line []byte) (goChunkType, bool) {
 	}
 	switch line[0] {
 	case 'g':
-		if goHasPrefix(line, "goroutine ") {
+		// A real goroutine header is always "goroutine <goid> [<status>]:",
+		// where <goid> is numeric — runtime/traceback.go goroutineheader emits
+		// print("goroutine ", gp.goid). Requiring a digit immediately after the
+		// prefix rejects benign prose that merely starts with "goroutine "
+		// (e.g. "goroutine to watchExperiments has terminated", "goroutine
+		// profile: total 5"), which would otherwise be mistaken for the first
+		// chunk of a trace and let an errant start marker combine unrelated
+		// lines. A digit is the only reliable discriminator: the verbose
+		// GOTRACEBACK=system form ("goroutine 1 gp=0x.. m=0 mp=0x.. [running]:")
+		// still leads with the numeric goid, so we must not require " [" here.
+		if goHasPrefix(line, "goroutine ") && goHasDigitAt(line, len("goroutine ")) {
 			return goChunkStack, true
 		}
 	case 'r':

--- a/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser.go
+++ b/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser.go
@@ -91,7 +91,18 @@ func (g *GoStackTraceParser) AcceptLine(line []byte) bool {
 			g.uncommitted = 0
 			return true
 		}
-		return false
+		// The Go runtime prints a blank line between the header and the first
+		// goroutine/stack chunk, and normally that blank line is what ends the
+		// header (handled by the empty-line case above). But many log sources
+		// (container runtimes, loggers) strip blank lines before they reach the
+		// aggregator, so the chunk-start line arrives directly after the header.
+		// Treat a chunk start as an implicit end of the header; otherwise the
+		// trace could never reach betweenChunks and would always be abandoned.
+		if _, ok := goDetectChunkStart(line); !ok {
+			return false
+		}
+		g.st = goStateBetweenChunks
+		fallthrough
 
 	case goStateBetweenChunks:
 		ct, ok := goDetectChunkStart(line)

--- a/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser_test.go
@@ -423,3 +423,67 @@ func TestGoStackTraceParser_ChunkBoundaryWithoutBlankLine(t *testing.T) {
 		assert.True(t, p.ShouldCombine())
 	})
 }
+
+// TestGoDetectChunkStart_GoroutineHeaderShape verifies that only a real
+// goroutine header ("goroutine <goid> ...", where <goid> is numeric) is
+// treated as a chunk start. A real header always leads with the numeric goid
+// (runtime/traceback.go goroutineheader: print("goroutine ", gp.goid)), so a
+// digit is the reliable discriminator against benign prose that merely begins
+// with "goroutine ".
+func TestGoDetectChunkStart_GoroutineHeaderShape(t *testing.T) {
+	accepts := []string{
+		"goroutine 1 [running]:",
+		"goroutine 0 [idle]:",
+		"goroutine 4294967296 [chan receive, 2 minutes]:",
+		// GOTRACEBACK=system/crash verbose form: "gp=" follows the goid, so a
+		// matcher must NOT require " [" immediately after the digits.
+		"goroutine 0 gp=0x1021a3080 m=0 mp=0x1021a3880 [idle]:",
+		"goroutine 1 gp=0x7df94bf261e0 m=nil [sleep]:",
+	}
+	for _, line := range accepts {
+		line := line
+		t.Run("accept/"+line, func(t *testing.T) {
+			ct, ok := goDetectChunkStart([]byte(line))
+			assert.True(t, ok, "expected chunk start: %q", line)
+			assert.Equal(t, goChunkStack, ct)
+		})
+	}
+
+	// Benign lines that start with "goroutine " but are not headers. These were
+	// observed as real log lines (koutris-intake, squire) and must not be
+	// mistaken for the first chunk of a trace.
+	rejects := []string{
+		"goroutine to watchExperiments has terminated",
+		"goroutine profile: total 5",
+		"goroutine leak detected",
+		"goroutine running on other thread; stack unavailable",
+		"goroutine ", // prefix only, no goid
+		"goroutines are cheap",
+	}
+	for _, line := range rejects {
+		line := line
+		t.Run("reject/"+line, func(t *testing.T) {
+			_, ok := goDetectChunkStart([]byte(line))
+			assert.False(t, ok, "did not expect chunk start: %q", line)
+		})
+	}
+}
+
+// TestGoStackTraceParser_ErrantStartFollowedByGoroutineProse is the regression
+// for the false-combine risk opened by the header-ends-on-chunk-start change
+// (AGNTLOG-663). A benign line that trips IsStart ("runtime:") directly
+// followed by benign "goroutine " prose (no blank line) must NOT be accepted
+// as a chunk — otherwise the two unrelated lines would combine into a bogus
+// stack trace instead of being abandoned.
+func TestGoStackTraceParser_ErrantStartFollowedByGoroutineProse(t *testing.T) {
+	// "runtime: set GOMAXPROCS to: 2" trips IsStart today (benign diagnostic).
+	require.True(t, NewGoStackTraceParser().IsStart([]byte("runtime: set GOMAXPROCS to: 2")))
+
+	p := NewGoStackTraceParser()
+	p.Reset()
+	// The next line begins with "goroutine " but is prose, not a header. The
+	// tightened chunk detector rejects it, so the header cannot end here and
+	// the trace is abandoned.
+	assert.False(t, p.AcceptLine([]byte("goroutine to watchExperiments has terminated")))
+	assert.False(t, p.ShouldCombine())
+}

--- a/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser_test.go
@@ -388,3 +388,38 @@ func TestGoStackTraceParser_HeaderEndsOnChunkStartWithoutBlankLine(t *testing.T)
 		assert.False(t, p.ShouldCombine())
 	})
 }
+
+// TestGoStackTraceParser_ChunkBoundaryWithoutBlankLine is a regression for the
+// inter-chunk case of AGNTLOG-663. Sources that strip the header's blank-line
+// separator strip the separators between later chunks too, so a chunk-start
+// line arriving mid-trace must end the current chunk and begin a new one rather
+// than being mistaken for a frame (which would combine only the first chunk).
+func TestGoStackTraceParser_ChunkBoundaryWithoutBlankLine(t *testing.T) {
+	t.Run("goroutine boundary directly after a frame", func(t *testing.T) {
+		p := NewGoStackTraceParser()
+		require.True(t, p.IsStart([]byte("panic: boom")))
+		p.Reset()
+		require.True(t, p.AcceptLine([]byte("goroutine 1 [running]:")))
+		require.True(t, p.AcceptLine([]byte("main.foo()")))
+		require.True(t, p.AcceptLine([]byte("\t/path/main.go:1 +0x1")))
+		// No blank line before the next goroutine.
+		require.True(t, p.AcceptLine([]byte("goroutine 2 [running]:")))
+		require.True(t, p.AcceptLine([]byte("main.bar()")))
+		require.True(t, p.AcceptLine([]byte("\t/path/main.go:2 +0x2")))
+		assert.True(t, p.ShouldCombine())
+	})
+
+	t.Run("goroutine boundary directly after a register dump", func(t *testing.T) {
+		p := NewGoStackTraceParser()
+		require.True(t, p.IsStart([]byte("SIGSEGV: segmentation violation")))
+		p.Reset()
+		require.True(t, p.AcceptLine([]byte("PC=0x192bf82f4 m=0 sigcode=2 addr=0x0")))
+		require.True(t, p.AcceptLine([]byte("rax 0x7fffabcd1234")))
+		require.True(t, p.AcceptLine([]byte("rbx 0x0")))
+		// No blank line before the goroutine chunk.
+		require.True(t, p.AcceptLine([]byte("goroutine 1 [running]:")))
+		require.True(t, p.AcceptLine([]byte("runtime.main()")))
+		require.True(t, p.AcceptLine([]byte("\t/usr/local/go/src/runtime/proc.go:267 +0x1")))
+		assert.True(t, p.ShouldCombine())
+	})
+}

--- a/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser_test.go
@@ -363,6 +363,21 @@ func TestGoStackTraceParser_HeaderEndsOnChunkStartWithoutBlankLine(t *testing.T)
 		assert.True(t, p.ShouldCombine())
 	})
 
+	t.Run("garbage after implicitly-started register dump is rejected", func(t *testing.T) {
+		p := NewGoStackTraceParser()
+		require.True(t, p.IsStart([]byte("SIGSEGV: segmentation violation")))
+		p.Reset()
+		require.True(t, p.AcceptLine([]byte("PC=0x192bf82f4 m=0 sigcode=2 addr=0x0")))
+		// Register dump entered directly from the header via the new
+		// fallthrough (no blank-line separator).
+		require.True(t, p.AcceptLine([]byte("rax 0x7fffabcd1234")))
+		// A structured log line is not a valid register line and must be
+		// rejected — the register-line validation still guards the dump even
+		// when it was reached through the implicit header-end path.
+		assert.False(t, p.AcceptLine([]byte("level=info ts=2026-01-01 msg=hi")),
+			"non-register line must not be absorbed into an implicitly-started register dump")
+	})
+
 	t.Run("non-chunk line after header is still rejected", func(t *testing.T) {
 		p := NewGoStackTraceParser()
 		require.True(t, p.IsStart([]byte("panic: boom")))

--- a/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/go_stack_trace_parser_test.go
@@ -323,3 +323,53 @@ func TestGoStackTraceParser_RegDumpInjectionRejected(t *testing.T) {
 	require.True(t, p2.AcceptLine([]byte("rbx 0xee")))
 	require.True(t, p2.AcceptLine([]byte("rip 0xdead")))
 }
+
+// TestGoStackTraceParser_HeaderEndsOnChunkStartWithoutBlankLine is a focused
+// regression for AGNTLOG-663. The Go runtime prints a blank line between the
+// crash header and the first chunk, and that blank line normally ends the
+// header. Many log sources strip blank lines before they reach the parser, so
+// the parser must also treat a chunk-start line as an implicit end of the
+// header — otherwise it can never reach a chunk and every trace is abandoned.
+func TestGoStackTraceParser_HeaderEndsOnChunkStartWithoutBlankLine(t *testing.T) {
+	t.Run("goroutine directly after panic header", func(t *testing.T) {
+		p := NewGoStackTraceParser()
+		require.True(t, p.IsStart([]byte("panic: boom")))
+		p.Reset()
+		// No blank line: the goroutine chunk follows the header immediately.
+		require.True(t, p.AcceptLine([]byte("goroutine 1 [running]:")))
+		require.True(t, p.AcceptLine([]byte("main.main()")))
+		require.True(t, p.AcceptLine([]byte("\t/path/main.go:1 +0x1")))
+		assert.True(t, p.ShouldCombine())
+	})
+
+	t.Run("runtime stack directly after fatal error header", func(t *testing.T) {
+		p := NewGoStackTraceParser()
+		require.True(t, p.IsStart([]byte("fatal error: oom")))
+		p.Reset()
+		require.True(t, p.AcceptLine([]byte("runtime stack:")))
+		require.True(t, p.AcceptLine([]byte("runtime.throw(...)")))
+		require.True(t, p.AcceptLine([]byte("\t/usr/local/go/src/runtime/panic.go:1229 +0x38")))
+		assert.True(t, p.ShouldCombine())
+	})
+
+	t.Run("register dump directly after header continuation", func(t *testing.T) {
+		p := NewGoStackTraceParser()
+		require.True(t, p.IsStart([]byte("SIGSEGV: segmentation violation")))
+		p.Reset()
+		require.True(t, p.AcceptLine([]byte("PC=0x192bf82f4 m=0 sigcode=2 addr=0x0")))
+		// No blank line before the register dump chunk.
+		require.True(t, p.AcceptLine([]byte("rax 0x7fffabcd1234")))
+		require.True(t, p.AcceptLine([]byte("rbx 0x0")))
+		assert.True(t, p.ShouldCombine())
+	})
+
+	t.Run("non-chunk line after header is still rejected", func(t *testing.T) {
+		p := NewGoStackTraceParser()
+		require.True(t, p.IsStart([]byte("panic: boom")))
+		p.Reset()
+		// A normal log line that is neither a header continuation nor a chunk
+		// start must still be rejected — no false combine.
+		assert.False(t, p.AcceptLine([]byte("some normal log line")))
+		assert.False(t, p.ShouldCombine())
+	})
+}

--- a/pkg/logs/internal/decoder/preprocessor/stack_trace_aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/stack_trace_aggregator_test.go
@@ -153,6 +153,73 @@ func TestGoStackTrace_NoTrailingNewline(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Regression: missing blank line between the header and the first chunk
+// (AGNTLOG-663)
+//
+// The Go runtime prints a blank line between the crash header and the first
+// "goroutine N [running]:" / "runtime stack:" / register-dump chunk, and that
+// blank line is normally what ends the header. Many log sources (container
+// runtimes, loggers) strip blank lines before they reach the aggregator, so the
+// chunk-start line arrives directly after the header. Before the fix the parser
+// could never leave the header state without the blank line, so every such
+// trace was abandoned and the fleet-wide "combined" count was stuck at zero.
+// These cases reproduce the real captured shapes and assert they now combine.
+// ---------------------------------------------------------------------------
+
+func TestGoStackTrace_NoBlankLine_PanicThenGoroutine_Combines(t *testing.T) {
+	agg := NewStackTraceAggregator(NewGoStackTraceParser(), testMaxContentSize, true)
+	// Captured from service:koutris-intake — no blank line between the panic
+	// header and the goroutine section.
+	input := "panic: lookup koutris-storage-distributions-az1.fabric.dog on 169.254.20.10:53: no such host\n" +
+		"goroutine 213 [running]:\n" +
+		"github.com/DataDog/dd-go/alerting/koutris/apps/koutris-intake/intake.(*DataSender).run(0xc002a0c700, 0xc002a9ed30)\n" +
+		"\t/go/src/github.com/DataDog/dd-go/alerting/koutris/apps/koutris-intake/intake/sender.go:371 +0x2cb\n" +
+		"created by github.com/DataDog/dd-go/alerting/koutris/apps/koutris-intake/intake.NewDataSender in goroutine 1\n" +
+		"\t/go/src/github.com/DataDog/dd-go/alerting/koutris/apps/koutris-intake/intake/sender.go:286 +0x119f\n"
+	msgs := feedLines(agg, input)
+	assertCombined(t, msgs)
+	assert.Contains(t, string(msgs[0].GetContent()), "goroutine 213 [running]:",
+		"the goroutine chunk must be folded into the combined message")
+}
+
+func TestGoStackTrace_NoBlankLine_RuntimeStackChunk_Combines(t *testing.T) {
+	agg := NewStackTraceAggregator(NewGoStackTraceParser(), testMaxContentSize, true)
+	// fatal error header followed directly by a "runtime stack:" chunk.
+	input := "fatal error: concurrent map writes\n" +
+		"runtime stack:\n" +
+		"runtime.throw({0x104ebbfb2?, 0x104f980b0?})\n" +
+		"\t/usr/local/go/src/runtime/panic.go:1229 +0x38\n"
+	msgs := feedLines(agg, input)
+	assertCombined(t, msgs)
+}
+
+func TestGoStackTrace_NoBlankLine_RegisterDumpChunk_Combines(t *testing.T) {
+	agg := NewStackTraceAggregator(NewGoStackTraceParser(), testMaxContentSize, true)
+	// SIGSEGV header + PC line (valid header continuation), then a register dump
+	// chunk arrives with no blank-line separator.
+	input := "SIGSEGV: segmentation violation\n" +
+		"PC=0x192bf82f4 m=0 sigcode=2 addr=0x0\n" +
+		"rax 0x7fffabcd1234\n" +
+		"rbx 0x0\n" +
+		"rip 0x192bf82f4\n"
+	msgs := feedLines(agg, input)
+	assertCombined(t, msgs)
+}
+
+func TestGoStackTrace_NoBlankLine_SignalContinuationThenGoroutine_Combines(t *testing.T) {
+	agg := NewStackTraceAggregator(NewGoStackTraceParser(), testMaxContentSize, true)
+	// Header has a valid [signal ...] continuation, then the goroutine chunk
+	// arrives with no blank-line separator.
+	input := "panic: runtime error: invalid memory address or nil pointer dereference\n" +
+		"[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x10436ffd0]\n" +
+		"goroutine 1 [running]:\n" +
+		"main.main()\n" +
+		"\t/path/main.go:50 +0x3b4\n"
+	msgs := feedLines(agg, input)
+	assertCombined(t, msgs)
+}
+
+// ---------------------------------------------------------------------------
 // Ported negative tests from parser_test.go — these should NOT combine
 // ---------------------------------------------------------------------------
 
@@ -589,8 +656,10 @@ func TestGoStackTrace_Overflow_SmallBuffer(t *testing.T) {
 	assert.Empty(t, out)
 	// Next line triggers overflow
 	out = agg.Process(makeMsg("goroutine 1 [running]:"))
-	// "goroutine 1..." is not a valid header continuation, so it triggers rejection
-	// with chunkCount==0 -> abandoned, NOT overflow
+	// "goroutine 1..." ends the header implicitly (the blank-line separator may
+	// be stripped upstream) and is accepted as a chunk start, but appending it
+	// would exceed maxContentSize, so the buffer is abandoned with the overflow
+	// tag. Either way, no combined (IsMultiLine) message is produced.
 	for _, m := range out {
 		assert.False(t, m.ParsingExtra.IsMultiLine)
 	}

--- a/pkg/logs/internal/decoder/preprocessor/stack_trace_aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/stack_trace_aggregator_test.go
@@ -219,6 +219,49 @@ func TestGoStackTrace_NoBlankLine_SignalContinuationThenGoroutine_Combines(t *te
 	assertCombined(t, msgs)
 }
 
+func TestGoStackTrace_NoBlankLine_MultipleGoroutines_Combines(t *testing.T) {
+	agg := NewStackTraceAggregator(NewGoStackTraceParser(), testMaxContentSize, true)
+	// Real Go panics dump every goroutine; the sources that strip the header's
+	// blank line strip the separators between goroutines too. All chunks must
+	// still fold into a single combined message, not just the first.
+	input := "panic: boom\n" +
+		"goroutine 1 [running]:\n" +
+		"main.foo()\n" +
+		"\t/path/main.go:1 +0x1\n" +
+		"goroutine 2 [running]:\n" +
+		"main.bar()\n" +
+		"\t/path/main.go:2 +0x2\n" +
+		"goroutine 3 [chan receive]:\n" +
+		"main.baz()\n" +
+		"\t/path/main.go:3 +0x3\n"
+	msgs := feedLines(agg, input)
+	assertCombined(t, msgs)
+	content := string(msgs[0].GetContent())
+	assert.Contains(t, content, "goroutine 1 [running]:")
+	assert.Contains(t, content, "goroutine 2 [running]:", "later goroutines must be folded in, not emitted standalone")
+	assert.Contains(t, content, "goroutine 3 [chan receive]:")
+}
+
+func TestGoStackTrace_NoBlankLine_RegisterDumpThenGoroutine_Combines(t *testing.T) {
+	agg := NewStackTraceAggregator(NewGoStackTraceParser(), testMaxContentSize, true)
+	// Register dump immediately followed by a goroutine chunk, no blank-line
+	// separators anywhere. The goroutine section must begin a new chunk rather
+	// than ending the trace at the register dump.
+	input := "SIGSEGV: segmentation violation\n" +
+		"PC=0x192bf82f4 m=0 sigcode=2 addr=0x0\n" +
+		"rax 0x7fffabcd1234\n" +
+		"rbx 0x0\n" +
+		"rip 0x192bf82f4\n" +
+		"goroutine 1 [running]:\n" +
+		"runtime.main()\n" +
+		"\t/usr/local/go/src/runtime/proc.go:267 +0x1\n"
+	msgs := feedLines(agg, input)
+	assertCombined(t, msgs)
+	content := string(msgs[0].GetContent())
+	assert.Contains(t, content, "rax 0x7fffabcd1234")
+	assert.Contains(t, content, "goroutine 1 [running]:", "the goroutine chunk after the register dump must be folded in")
+}
+
 // ---------------------------------------------------------------------------
 // Ported negative tests from parser_test.go — these should NOT combine
 // ---------------------------------------------------------------------------

--- a/pkg/logs/internal/decoder/preprocessor/stack_trace_aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/stack_trace_aggregator_test.go
@@ -397,6 +397,20 @@ func TestGoStackTrace_Abandon_FalsePositiveHeader(t *testing.T) {
 	assertAbandoned(t, msgs, 3)
 }
 
+// TestGoStackTrace_Abandon_ErrantRuntimeStartThenGoroutineProse guards the
+// false-combine risk from the header-ends-on-chunk-start change (AGNTLOG-663).
+// An errant "runtime:" line (a benign Go runtime diagnostic that trips IsStart)
+// immediately followed by benign "goroutine " prose — both observed together on
+// production nodes — must abandon as two individual lines, not combine into a
+// bogus multi-line trace. The tightened goroutine-header detection (requires a
+// numeric goid) is what keeps the prose line from being read as the first chunk.
+func TestGoStackTrace_Abandon_ErrantRuntimeStartThenGoroutineProse(t *testing.T) {
+	agg := NewStackTraceAggregator(NewGoStackTraceParser(), testMaxContentSize, true)
+	input := "runtime: set GOMAXPROCS to: 2\ngoroutine to watchExperiments has terminated\n"
+	msgs := feedLines(agg, input)
+	assertAbandoned(t, msgs, 2)
+}
+
 func TestGoStackTrace_Abandon_HeaderPlusSignal_NoGoroutines(t *testing.T) {
 	agg := NewStackTraceAggregator(NewGoStackTraceParser(), testMaxContentSize, true)
 	input := "panic: runtime error: nil pointer dereference\n[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10436ffd0]\n\nsome unrelated line\n"

--- a/releasenotes/notes/fix-go-stack-trace-missing-blank-line-3d9f1c2a7b6e4f08.yaml
+++ b/releasenotes/notes/fix-go-stack-trace-missing-blank-line-3d9f1c2a7b6e4f08.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fix Go stack trace aggregation in the auto multi-line log pipeline so that
+    crash dumps whose ``panic:``/``fatal error:`` header is immediately followed
+    by the ``goroutine``/``runtime stack:``/register-dump section are combined
+    into a single log entry. Previously the parser only ended the header on the
+    blank line the Go runtime prints before the first stack section; log sources
+    that strip blank lines (many container runtimes and loggers) prevented the
+    trace from ever being combined.


### PR DESCRIPTION
### What does this PR do?

Fixes Go stack trace aggregation in the auto multi-line log pipeline so combined traces are produced even when upstream log sources strip the blank lines the Go runtime prints around a crash dump. Three related changes:

1. **Header → first chunk without a blank line.** The parser now treats a chunk-start line (`goroutine …`, `runtime stack:`, or a register dump) as an implicit end of the crash header, in addition to the blank-line separator it already recognized.
2. **Inter-chunk boundaries without blank lines.** A chunk-start line arriving mid-trace (while in a stack chunk or a register dump) now ends the current chunk and begins a new one, so multi-goroutine dumps combine fully instead of stopping after the first chunk.
3. **Tighter goroutine chunk-start detection (precision).** `goDetectChunkStart` now requires a numeric goid after the `goroutine ` prefix, matching the runtime's `goroutineheader` output. This prevents the newly-widened header exit from combining an errant start marker (e.g. a benign `runtime:` diagnostic) with a following line that merely begins with `goroutine ` (prose such as `goroutine to watchExperiments has terminated`).

### Motivation

The Go runtime prints a blank line between the crash header and the first stack section, and that blank line was the *only* way the parser left its header state. Many log sources (container runtimes, loggers) strip blank lines before they reach the aggregator, so the chunk-start line arrived directly after the header, the parser bailed, and the trace was abandoned line-by-line. Fleet-wide telemetry for `datadog.agent.logs.auto_multi_line_go_stack_trace_aggregator_flush` confirmed the impact: ~660K flushes over 30 days, 100% tagged `result:abandoned` and zero `combined`. In other words the feature never delivered a combined trace in production for any source that drops blank lines. Reported and analyzed in AGNTLOG-663.

Removing the blank-line requirement widened the set of lines that can end the header, so a benign line that trips `IsStart` followed by a loose `goroutine `-prefixed line could combine two unrelated lines into a bogus trace. Change (3) closes that hole. The `goroutine <goid>` shape is a reliable discriminator: `runtime/traceback.go` always emits `print("goroutine ", gp.goid)`, and the verbose `GOTRACEBACK=system` form (`goroutine 1 gp=0x.. m=0 mp=0x.. [running]:`) still leads with the numeric goid — so the check requires a digit, not a following `[`. `IsStart`'s `runtime:` arm is intentionally left unchanged: every real `runtime:`-led crash is also introduced by a `fatal error:`/`panic:` line (both start markers), so tightening it there would risk false negatives without adding correctness.

### Describe how you validated your changes

Parser regression tests (`TestGoStackTraceParser_HeaderEndsOnChunkStartWithoutBlankLine`, `TestGoStackTraceParser_ChunkBoundaryWithoutBlankLine`) and end-to-end aggregator tests cover the real captured `koutris-intake` panic→goroutine sequence plus the `runtime stack:`, register-dump, and `[signal]`-continuation shapes — all with blank lines stripped. For the precision hardening: `TestGoDetectChunkStart_GoroutineHeaderShape` (accepts numeric/verbose headers, rejects benign `goroutine ` prose), `TestGoStackTraceParser_ErrantStartFollowedByGoroutineProse`, and `TestGoStackTrace_Abandon_ErrantRuntimeStartThenGoroutineProse` (errant `runtime:` + `goroutine ` prose abandons rather than combines). Existing negative tests (garbage continuations, false-positive headers, overflow) still pass. Run via `dda inv test --targets=./pkg/logs/internal/decoder/preprocessor` and `dda inv linter.go --only-modified-packages` (0 issues).

### Additional Notes

N/A
