### PR TITLE
Preserve parameters in calls to getAllEntries.

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -17,6 +18,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const timeFormat = "2006-01-02T15:04:05"
@@ -346,18 +349,33 @@ func (client *Client) GetCloudExpressMetrics() ([]CloudXStatistics, error) {
 	return cloudApplications.Data, nil
 }
 
-// GetBGPNeighbors gets BGP neighbors
-func (client *Client) GetBGPNeighbors() ([]BGPNeighbor, error) {
-	params := map[string]string{
-		"count": client.maxCount,
+// GetBGPNeighbors gets BGP neighbors per device using the real-time endpoint
+func (client *Client) GetBGPNeighbors(devices []Device) ([]BGPNeighbor, error) {
+	var allNeighbors []BGPNeighbor
+	var failed int
+	for _, device := range devices {
+		params := map[string]string{
+			"deviceId": device.SystemIP,
+		}
+		bgpNeighbors, err := getAllEntries[BGPNeighbor](client, "/dataservice/device/bgp/neighbors", params)
+		if err != nil {
+			log.Warnf("Error getting BGP neighbors for device %s: %s", device.SystemIP, err)
+			failed++
+			continue
+		}
+		for i := range bgpNeighbors.Data {
+			if bgpNeighbors.Data[i].VmanageSystemIP == "" {
+				bgpNeighbors.Data[i].VmanageSystemIP = device.SystemIP
+			}
+		}
+		allNeighbors = append(allNeighbors, bgpNeighbors.Data...)
 	}
 
-	bgpNeighbors, err := getAllEntries[BGPNeighbor](client, "/dataservice/data/device/state/BGPNeighbor", params)
-	if err != nil {
-		return nil, err
+	if failed > 0 && failed == len(devices) {
+		return nil, fmt.Errorf("failed to get BGP neighbors for all %d devices", failed)
 	}
 
-	return bgpNeighbors.Data, nil
+	return allNeighbors, nil
 }
 
 func (client *Client) statisticsTimeRange() (string, string) {

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client_test.go
@@ -596,15 +596,15 @@ func TestGetBGPNeighbors(t *testing.T) {
 
 	handler := newHandler(func(w http.ResponseWriter, r *http.Request, _ int32) {
 		query := r.URL.Query()
-		count := query.Get("count")
+		deviceID := query.Get("deviceId")
 
-		require.Equal(t, "2000", count)
+		require.Equal(t, "10.10.1.1", deviceID)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(fixtures.FakePayload(fixtures.GetBGPNeighbors)))
 	})
 
-	mux.HandleFunc("/dataservice/data/device/state/BGPNeighbor", handler.Func)
+	mux.HandleFunc("/dataservice/device/bgp/neighbors", handler.Func)
 
 	server := httptest.NewServer(mux)
 	defer server.Close()
@@ -612,18 +612,88 @@ func TestGetBGPNeighbors(t *testing.T) {
 	client, err := testClient(server)
 	require.NoError(t, err)
 
-	devices, err := client.GetBGPNeighbors()
+	testDevices := []Device{{SystemIP: "10.10.1.1"}}
+	neighbors, err := client.GetBGPNeighbors(testDevices)
 	require.NoError(t, err)
 
-	require.Equal(t, "10.10.1.11", devices[0].VmanageSystemIP)
-	require.Equal(t, "ipv4-unicast", devices[0].Afi)
-	require.Equal(t, float64(1), devices[0].VpnID)
-	require.Equal(t, "10.60.1.1", devices[0].PeerAddr)
-	require.Equal(t, float64(2024), devices[0].AS)
-	require.Equal(t, "established", devices[0].State)
+	require.Equal(t, "10.10.1.11", neighbors[0].VmanageSystemIP)
+	require.Equal(t, "ipv4-unicast", neighbors[0].Afi)
+	require.Equal(t, float64(1), neighbors[0].VpnID)
+	require.Equal(t, "10.60.1.1", neighbors[0].PeerAddr)
+	require.Equal(t, float64(2024), neighbors[0].AS)
+	require.Equal(t, "established", neighbors[0].State)
 
-	// Ensure endpoint has been called 1 times
+	// Ensure endpoint has been called once per device
 	require.Equal(t, 1, handler.numberOfCalls())
+}
+
+func TestGetBGPNeighborsAllDevicesFail(t *testing.T) {
+	mux := setupCommonServerMux()
+
+	handler := newHandler(func(w http.ResponseWriter, _ *http.Request, _ int32) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	mux.HandleFunc("/dataservice/device/bgp/neighbors", handler.Func)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := testClient(server)
+	require.NoError(t, err)
+
+	testDevices := []Device{{SystemIP: "10.10.1.1"}, {SystemIP: "10.10.1.2"}}
+	neighbors, err := client.GetBGPNeighbors(testDevices)
+
+	// When every device query fails we surface an error instead of an empty result
+	require.Error(t, err)
+	require.Nil(t, neighbors)
+}
+
+func TestGetBGPNeighborsPartialFailureAndBackfill(t *testing.T) {
+	mux := setupCommonServerMux()
+
+	// Payload with an empty vmanage-system-ip to exercise the backfill path
+	const bgpNeighborNoSystemIP = `
+[
+	{
+		"afi": "ipv4-unicast",
+		"vpn-id": 1,
+		"peer-addr": "10.60.1.1",
+		"as": 2024,
+		"vmanage-system-ip": "",
+		"state": "established"
+	}
+]
+`
+
+	handler := newHandler(func(w http.ResponseWriter, r *http.Request, _ int32) {
+		// One device succeeds, the other returns an error
+		if r.URL.Query().Get("deviceId") == "10.10.1.2" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(fixtures.FakePayload(bgpNeighborNoSystemIP)))
+	})
+
+	mux.HandleFunc("/dataservice/device/bgp/neighbors", handler.Func)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := testClient(server)
+	require.NoError(t, err)
+
+	testDevices := []Device{{SystemIP: "10.10.1.1"}, {SystemIP: "10.10.1.2"}}
+	neighbors, err := client.GetBGPNeighbors(testDevices)
+
+	// A partial failure is not fatal: we keep the neighbors we could retrieve
+	require.NoError(t, err)
+	require.Len(t, neighbors, 1)
+	// The empty vmanage-system-ip is backfilled with the device's system IP
+	require.Equal(t, "10.10.1.1", neighbors[0].VmanageSystemIP)
+	require.Equal(t, "10.60.1.1", neighbors[0].PeerAddr)
 }
 
 func TestFlexFloat64UnmarshalJSON(t *testing.T) {

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/fixtures/payloads.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/fixtures/payloads.go
@@ -437,7 +437,7 @@ const GetCloudExpressMetrics = `
 ]
 `
 
-// GetBGPNeighbors /dataservice/data/device/state/BGPNeighbor
+// GetBGPNeighbors /dataservice/device/bgp/neighbors
 const GetBGPNeighbors = `
 [
 	{

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -107,9 +108,13 @@ func isValidStatusCode(code int) bool {
 }
 
 // getMoreEntries gets all results from paginated endpoints
-func getMoreEntries[T Content](client *Client, endpoint string, pageInfo PageInfo) ([]T, error) {
+func getMoreEntries[T Content](client *Client, endpoint string, pageInfo PageInfo, params map[string]string) ([]T, error) {
 	var responses []T
 	currentPageInfo := pageInfo
+	newParams := maps.Clone(params)
+	if newParams == nil {
+		newParams = make(map[string]string)
+	}
 
 	// Loop while API response indicates there is more entries
 	for page := 0; currentPageInfo.MoreEntries || currentPageInfo.HasMoreData; page++ {
@@ -125,9 +130,9 @@ func getMoreEntries[T Content](client *Client, endpoint string, pageInfo PageInf
 			return nil, err
 		}
 		log.Tracef("Pagination params for page %d from endpoint %s : %v", page+1+1, endpoint, nextParams)
-
+		maps.Copy(newParams, nextParams)
 		// Call the endpoint with the new params
-		data, err := get[T](client, endpoint, nextParams)
+		data, err := get[T](client, endpoint, newParams)
 		if err != nil {
 			return nil, err
 		}
@@ -163,7 +168,7 @@ func getAllEntries[T Content](client *Client, endpoint string, params map[string
 	}
 
 	// If API response is paginated, get the rest
-	entries, err := getMoreEntries[T](client, endpoint, data.PageInfo)
+	entries, err := getMoreEntries[T](client, endpoint, data.PageInfo, params)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request_test.go
@@ -292,7 +292,7 @@ func TestGetMoreEntriesMaxPages(t *testing.T) {
 		MoreEntries: true,
 	}
 
-	_, err = getMoreEntries[Device](client, "/dataservice/device", pageInfo)
+	_, err = getMoreEntries[Device](client, "/dataservice/device", pageInfo, nil)
 	require.ErrorContains(t, err, "max number of page reached")
 
 	// Ensure endpoint has been called 20 times
@@ -351,7 +351,7 @@ func TestGetMoreEntriesIndexPagination(t *testing.T) {
 		MoreEntries: true,
 	}
 
-	_, err = getMoreEntries[Device](client, "/dataservice/device", pageInfo)
+	_, err = getMoreEntries[Device](client, "/dataservice/device", pageInfo, nil)
 	require.NoError(t, err)
 
 	// Ensure endpoint has been called 2 times
@@ -414,7 +414,69 @@ func TestGetMoreEntriesScrollPagination(t *testing.T) {
 		HasMoreData: true,
 	}
 
-	_, err = getMoreEntries[Device](client, "/dataservice/device", pageInfo)
+	_, err = getMoreEntries[Device](client, "/dataservice/device", pageInfo, make(map[string]string))
+	require.NoError(t, err)
+
+	// Ensure endpoint has been called 2 times
+	require.Equal(t, 2, handler.numberOfCalls())
+}
+
+func TestGetMoreEntriesPreserveParams(t *testing.T) {
+	mux := setupCommonServerMux()
+
+	handler := newHandler(func(w http.ResponseWriter, r *http.Request, calls int32) {
+		otherParam := r.URL.Query().Get("otherParam")
+		startID := r.URL.Query().Get("startId")
+		if calls == 1 {
+			// First call, expect startId to be 15
+
+			require.Equal(t, "15", startID, "startId should be correct")
+			require.Equal(t, "other value", otherParam, "otherParam should be preserved")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`
+				{
+  					"pageInfo": {
+        				"startId": "15",
+						"endId": "30",
+        				"moreEntries": true,
+        				"count": 14
+					}
+				}
+			`))
+			return
+		}
+
+		// Second call, expect startId to be 31
+		require.Equal(t, "30", startID, "startId should be correct")
+		require.Equal(t, "other value", otherParam, "otherParam should be preserved")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			{
+  				"pageInfo": {
+       	 			"startId": "30",
+        			"endId": "35",
+        			"moreEntries": false,
+        			"count": 4
+    			}
+			}
+		`))
+	})
+
+	mux.Handle("/dataservice/device", handler.Func)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := testClient(server)
+	require.NoError(t, err)
+
+	pageInfo := PageInfo{
+		StartID:     "1",
+		EndID:       "15",
+		MoreEntries: true,
+	}
+
+	_, err = getMoreEntries[Device](client, "/dataservice/device", pageInfo, map[string]string{"otherParam": "other value"})
 	require.NoError(t, err)
 
 	// Ensure endpoint has been called 2 times

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/test_utils.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/test_utils.go
@@ -108,7 +108,7 @@ func SetupMockAPIServer() *httptest.Server {
 	mux.HandleFunc("/dataservice/data/device/state/BFDSessions", fixtureHandler(fixtures.GetBFDSessionsState))
 	mux.HandleFunc("/dataservice/data/device/state/HardwareEnvironment", fixtureHandler(fixtures.GetHardwareStates))
 	mux.HandleFunc("/dataservice/data/device/statistics/cloudxstatistics", fixtureHandler(fixtures.GetCloudExpressMetrics))
-	mux.HandleFunc("/dataservice/data/device/state/BGPNeighbor", fixtureHandler(fixtures.GetBGPNeighbors))
+	mux.HandleFunc("/dataservice/device/bgp/neighbors", fixtureHandler(fixtures.GetBGPNeighbors))
 
 	return httptest.NewServer(mux)
 }

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/types.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/types.go
@@ -470,7 +470,7 @@ type CloudXStatistics struct {
 	ID               string      `json:"id"`
 }
 
-// BGPNeighbor /dataservice/data/device/state/BGPNeighbor
+// BGPNeighbor /dataservice/device/bgp/neighbors
 type BGPNeighbor struct {
 	RecordID        string  `json:"recordId"`
 	VdeviceName     string  `json:"vdevice-name"`

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan.go
@@ -181,7 +181,7 @@ func (c *CiscoSdwanCheck) Run() error {
 
 	// Disabled  by default
 	if *c.config.CollectBGPNeighborStates {
-		bgpNeighbors, err := client.GetBGPNeighbors()
+		bgpNeighbors, err := client.GetBGPNeighbors(devices)
 		if err != nil {
 			log.Warnf("Error getting BGP neighbors from Cisco SD-WAN API: %s", err)
 		}


### PR DESCRIPTION
### What does this PR do?
This fixes a bug in `getAllEntries` where parameters unrelated to pagination would be dropped before subsequent calls were made.

### Motivation
No current methods pass in non-pagination params, but #52880 wants to.

### Describe how you validated your changes


### Additional Notes
