### PR TITLE
Make rpath setting in macos delete existing ones

### DIFF
--- a/bazel/rules/rewrite_rpath/macos.sh
+++ b/bazel/rules/rewrite_rpath/macos.sh
@@ -12,6 +12,16 @@ cp "$INPUT" "$OUTPUT"
 # Restore owner-write so install_name_tool can modify dylibs installed as
 # read-only by their build system (e.g. Python lib-dynload modules).
 chmod u+w "$OUTPUT"
+
+# Match Linux patchelf --set-rpath semantics: the packaged output should have
+# exactly the packaging rpath, to avoid leaving in existing ones that may
+# point to build-time paths.
+${OTOOL} -l "$OUTPUT" | awk '
+    $1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next }
+    in_rpath && $1 == "path" { print $2; in_rpath = 0 }
+' | while read -r rpath; do
+    install_name_tool -delete_rpath "$rpath" "$OUTPUT" 2>/dev/null || true
+done
 install_name_tool -add_rpath "$PREFIX" "$OUTPUT" 2>/dev/null || true
 dylib_name=$(basename "$OUTPUT")
 new_id="$PREFIX/$dylib_name"

--- a/bazel/rules/rewrite_rpath/tests/macos_dir_test.sh
+++ b/bazel/rules/rewrite_rpath/tests/macos_dir_test.sh
@@ -22,10 +22,17 @@ PREFIX="@loader_path/../../embedded/lib"
 
 FAILED=0
 while IFS= read -r outfile; do
-    if /usr/bin/otool -l "$outfile" | grep -q "$PREFIX"; then
-        echo "OK: $(basename "$outfile") has rpath $PREFIX"
+    rpaths=()
+    while IFS= read -r rpath; do
+        rpaths+=("$rpath")
+    done < <(/usr/bin/otool -l "$outfile" | awk '
+        $1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next }
+        in_rpath && $1 == "path" { print $2; in_rpath = 0 }
+    ')
+    if [ "${#rpaths[@]}" -eq 1 ] && [ "${rpaths[0]}" = "$PREFIX" ]; then
+        echo "OK: $(basename "$outfile") has only rpath $PREFIX"
     else
-        echo "FAIL: $(basename "$outfile") missing rpath $PREFIX"
+        echo "FAIL: $(basename "$outfile") rpaths: ${rpaths[*]:-<none>}"
         FAILED=1
     fi
 done < <(find "$OUTPUT_DIR" \( -name "*.dylib" -o -name "*.so" \))


### PR DESCRIPTION
### What does this PR do?

Makes `install_name_tool`-based rpath patching match the behavior we get from `patchelf --set-path`, that is, entirely replacing the path, leaving no traces of the original.

This is essentially the same as https://github.com/DataDog/datadog-agent/pull/52913, but this one _is_ in the build path for CI, and thus, released artifacts.

### Motivation

Some of the binaries we distribute in macos end up with paths pointing at build-time folders:

```
❯ otool -l /opt/datadog-agent/embedded/lib/libdatadog-agent-three.dylib | grep -A2 LC_RPATH
          cmd LC_RPATH
      cmdsize 64
         path @loader_path/../_solib_darwin_arm64/_Urtloader (offset 12)
--
          cmd LC_RPATH
      cmdsize 104
         path @loader_path/libdatadog-agent-three.dylib.runfiles/_main/_solib_darwin_arm64/_Urtloader (offset 12)
--
          cmd LC_RPATH
      cmdsize 64
         path @loader_path/../../_solib_darwin_arm64/_Urtloader (offset 12)
--
          cmd LC_RPATH
      cmdsize 152
         path @loader_path/../_solib_darwin_arm64/_U_A_A+_Urepo_Urules+cpython_S_S_Cpython_Uunix___Uexternal_S+_Urepo_Urules+cpython_Spython_Uunix_Slib (offset 12)
--
          cmd LC_RPATH
      cmdsize 192
         path @loader_path/libdatadog-agent-three.dylib.runfiles/_main/_solib_darwin_arm64/_U_A_A+_Urepo_Urules+cpython_S_S_Cpython_Uunix___Uexternal_S+_Urepo_Urules+cpython_Spython_Uunix_Slib (offset 12)
--
          cmd LC_RPATH
      cmdsize 160
         path @loader_path/../../_solib_darwin_arm64/_U_A_A+_Urepo_Urules+cpython_S_S_Cpython_Uunix___Uexternal_S+_Urepo_Urules+cpython_Spython_Uunix_Slib (offset 12)
--
          cmd LC_RPATH
      cmdsize 48
         path @loader_path/../../embedded/lib (offset 12)

```

Even though they're probably harmless in practice (the paths are specific enough that it's unlikely anything extraneous may be loaded), they don't belong in shipped artifacts.

### Describe how you validated your changes

- Green CI (including passing health check).
- Local build shows those extra paths being gone.

### Additional Notes

The duplication (with what https://github.com/DataDog/datadog-agent/pull/52913 touched) is transitional, and the replace_prefix mechanism could be considered as "deprecated". Cleaning up will take a bit more time, better to get this done with some duplication than to wait.
