### PR TITLE
[CWS-6625] preallocate the basename_approvers map

### DIFF
--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -55,13 +55,13 @@ BPF_HASH_MAP(security_profiles, u64, struct security_profile_t, 1) // max entrie
 BPF_HASH_MAP(secprofs_syscalls, u64, struct security_profile_syscalls_t, 1) // max entries will be overriden at runtime
 BPF_HASH_MAP(auid_approvers, u32, struct event_mask_filter_t, 128)
 BPF_HASH_MAP(auid_range_approvers, u32, struct u32_range_filter_t, EVENT_MAX)
+BPF_HASH_MAP(basename_approvers, struct basename_t, struct event_mask_filter_t, 1) // max entries updated at runtime; preallocated (written only from userspace)
 BPF_HASH_MAP(active_flows_spin_locks, u32, struct active_flows_spin_lock_t, 1) // max entry will be overridden at runtime
 BPF_HASH_MAP(inode_file, u64, struct file_t, 32)
 BPF_HASH_MAP(cgroup_mount_id, u32, u32, 1)
 
 BPF_HASH_MAP_FLAGS(active_flows, u32, struct active_flows_t, 1, BPF_F_NO_PREALLOC) // max entry will be overridden at runtime
 BPF_HASH_MAP_FLAGS(inet_bind_args, u64, struct inet_bind_args_t, 1, BPF_F_NO_PREALLOC) // max entries will be overridden at runtime
-BPF_HASH_MAP_FLAGS(basename_approvers, struct basename_t, struct event_mask_filter_t, 1, BPF_F_NO_PREALLOC) // max entries updated at runtime
 
 BPF_LRU_MAP(activity_dumps_config, u64, struct activity_dump_config, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(cgroup_wait_list, u64, u64, 1) // max entries will be overridden at runtime

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -285,6 +285,10 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 			MaxEntries: capabilitiesContextsMaxEntries,
 			EditorFlag: manager.EditMaxEntries,
 		},
+		"basename_approvers": {
+			MaxEntries: uint32(opts.BasenameApproversSize),
+			EditorFlag: manager.EditMaxEntries,
+		},
 	}
 
 	if opts.SecurityProfileSyscallAnomaly {
@@ -403,11 +407,6 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 			Flags:      unix.BPF_ANY,
 			EditorFlag: manager.EditMaxEntries | manager.EditFlags,
 		}
-		editors["basename_approvers"] = manager.MapSpecEditor{
-			MaxEntries: uint32(opts.BasenameApproversSize),
-			Flags:      unix.BPF_ANY,
-			EditorFlag: manager.EditMaxEntries,
-		}
 	} else {
 		editors["active_flows"] = manager.MapSpecEditor{
 			MaxEntries: activeFlowsMaxEntries,
@@ -415,10 +414,6 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 		}
 		editors["inet_bind_args"] = manager.MapSpecEditor{
 			MaxEntries: superReducedProcPidCacheSize,
-			EditorFlag: manager.EditMaxEntries,
-		}
-		editors["basename_approvers"] = manager.MapSpecEditor{
-			MaxEntries: uint32(opts.BasenameApproversSize),
 			EditorFlag: manager.EditMaxEntries,
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Keeps the `basename_approvers` eBPF map preallocated instead of `BPF_F_NO_PREALLOC`.

### Motivation

#50441 switched this map to `NO_PREALLOC`. It is only ever written from userspace (the eBPF side just does lookups), so allocating entries on demand as limited positive impact and can fail with `ENOMEM` under memory pressure when a ruleset inserts many approvers at once:

```
Error while adding approvers fallback in-kernel policy to `accept` for `open`: failed applying new kfilter: update: cannot allocate memory
```

### Describe how you validated your changes

`pkg/security/probe/kfilters` unit tests pass.

### Additional Notes
