### PR TITLE
compliance/tests: preparatory work for bazel migration

### DIFF
--- a/pkg/compliance/tests/docker_test.go
+++ b/pkg/compliance/tests/docker_test.go
@@ -136,7 +136,6 @@ valid_image(i) {
 	has_key(i, "id")
 	has_key(i, "inspect")
 	has_key(i.inspect, "Architecture")
-	has_key(i.inspect, "Comment")
 	has_key(i.inspect, "Config")
 }
 

--- a/pkg/compliance/tests/process_test.go
+++ b/pkg/compliance/tests/process_test.go
@@ -47,7 +47,7 @@ has_key(o, k) {
 }
 
 valid(p) {
-	p.name = "tests.test"
+	p.name = "%s"
 	has_key(p, "cmdLine")
 	has_key(p, "envs")
 	has_key(p, "exe")
@@ -64,7 +64,7 @@ findings[f] {
 		{}
 	)
 }
-`).
+`, self).
 		AssertPassedEvent(func(t *testing.T, evt *compliance.CheckEvent) {
 			assert.Equal(t, "Self", evt.RuleID)
 			assert.Equal(t, 0, evt.RuleVersion)
@@ -92,7 +92,7 @@ has_key(o, k) {
 }
 
 valid(p) {
-	p.name == "tests.test"
+	p.name == "%s"
 	has_key(p, "cmdLine")
 	has_key(p, "envs")
 	has_key(p, "exe")
@@ -120,7 +120,7 @@ findings[f] {
 		{"name": proc.name},
 	)
 }
-`).
+`, self).
 		AssertPassedEvent(func(t *testing.T, evt *compliance.CheckEvent) {
 			assert.Equal(t, "SelfDuplicated", evt.RuleID)
 			assert.Equal(t, 0, evt.RuleVersion)


### PR DESCRIPTION
### What does this PR do?

Stop hardcoding the expected test name & remove a failing check

### Motivation

This is preparatory work for the bazel migration.
* When built with bazel, the test will be named `tests_test`, which causes it to fail while it expects `tests.test`
* The `TestDockerInfoInput` test checks for a `Comment` field which is now omitted when empty, causing the test to fail depending on which images are available when running.

### Describe how you validated your changes

Local tests run

### Additional Notes
