### PR TITLE
Update 7.80 release note for AI Usage Chrome Native Messaging Host

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -193,14 +193,10 @@ Upgrade Notes
 New Features
 ------------
 
-- The Windows MSI installer now ships the AI usage Chrome native messaging
-  host (``ai-usage-agent-native-host.exe``) under ``bin\agent``. The
-  installer generates a Chrome Native Messaging Host
-  manifest under ``bin\agent\dist`` and registers it machine-wide under
-  ``HKLM\SOFTWARE\Google\Chrome\NativeMessagingHosts`` (including the
-  ``WOW6432Node`` view for 32-bit Chrome). The host's runtime configuration is
-  generated as ``C:\ProgramData\Datadog\ai_usage_native_host.yaml`` and uses
-  the Agent's configured APM receiver port.
+- The Windows MSI installer now includes the AI Usage Chrome Native Messaging
+  Host, which is intended to work with a companion Chrome extension to power
+  EUDM AI usage features. The host is currently dormant because the Chrome
+  extension is not yet enabled, so no AI usage host process runs on the system.
 
 - Adds a new ``discovery.service_map.enabled`` system-probe configuration
   option that boots the universal service monitoring (USM) eBPF monitor in

--- a/releasenotes/notes/add-ai-usage-native-host-windows-msi-1dd33b6b232bae8c.yaml
+++ b/releasenotes/notes/add-ai-usage-native-host-windows-msi-1dd33b6b232bae8c.yaml
@@ -1,11 +1,7 @@
 ---
 features:
   - |
-    The Windows MSI installer now ships the AI usage Chrome native messaging
-    host (``ai-usage-agent-native-host.exe``) under ``bin\agent``. The
-    installer generates a Chrome Native Messaging Host
-    manifest under ``bin\agent\dist`` and registers it machine-wide under
-    ``HKLM\SOFTWARE\Google\Chrome\NativeMessagingHosts`` (including the
-    ``WOW6432Node`` view for 32-bit Chrome). The host's runtime configuration is
-    generated as ``C:\ProgramData\Datadog\ai_usage_native_host.yaml`` and uses
-    the Agent's configured APM receiver port.
+    The Windows MSI installer now includes the AI Usage Chrome Native Messaging
+    Host, which is intended to work with a companion Chrome extension to power
+    EUDM AI usage features. The host is currently dormant because the Chrome
+    extension is not yet enabled, so no AI usage host process runs on the system.


### PR DESCRIPTION
### What does this PR do?

Updates the 7.80 release note for the AI Usage Chrome Native Messaging Host to clarify that the host is currently dormant — the companion Chrome extension is not yet enabled, so no AI usage host process runs on customer systems.

The previous note described internal implementation details (registry keys, file paths, executable names) that caused customer confusion about an unexpected AI process being installed.

### Motivation

Customers were confused by the original note, which read like an active running process was being installed. This update makes it clear the feature is present but inactive until the Chrome extension ships.

### Testing

Documentation-only change; no code changes.