### PR TITLE
[observer] Optimize metric / log filtering

### DIFF
--- a/comp/anomalydetection/internal/logsfilter/rules.go
+++ b/comp/anomalydetection/internal/logsfilter/rules.go
@@ -46,8 +46,8 @@ type ProcessingRule struct {
 
 // Rules evaluates the ordered rule list against incoming log sources.
 type Rules struct {
-	rules        []compiledRule
-	hasTagRules  bool // true if any rule has tag predicates, requiring sorted input
+	rules       []compiledRule
+	hasTagRules bool // true if any rule has tag predicates, requiring sorted input
 }
 
 type compiledRule struct {
@@ -115,7 +115,7 @@ func LoadRules(cfg config.Component, key string) (*Rules, error) {
 
 // NeedsSortedTags reports whether any rule has tag predicates requiring sorted input to IsAllowed.
 func (r *Rules) NeedsSortedTags() bool {
-	return r.hasTagRules
+	return r != nil && r.hasTagRules
 }
 
 // IsAllowed returns true if the log should be ingested.

--- a/comp/anomalydetection/internal/logsfilter/rules.go
+++ b/comp/anomalydetection/internal/logsfilter/rules.go
@@ -46,7 +46,8 @@ type ProcessingRule struct {
 
 // Rules evaluates the ordered rule list against incoming log sources.
 type Rules struct {
-	rules []compiledRule
+	rules        []compiledRule
+	hasTagRules  bool // true if any rule has tag predicates, requiring sorted input
 }
 
 type compiledRule struct {
@@ -87,7 +88,14 @@ func NewRules(rules []ProcessingRule) (*Rules, error) {
 			tags:    tags,
 		})
 	}
-	return &Rules{rules: compiled}, nil
+	hasTagRules := false
+	for _, r := range compiled {
+		if len(r.tags) > 0 {
+			hasTagRules = true
+			break
+		}
+	}
+	return &Rules{rules: compiled, hasTagRules: hasTagRules}, nil
 }
 
 // LoadRules reads processing rules from the given config key and compiles them.
@@ -105,8 +113,13 @@ func LoadRules(cfg config.Component, key string) (*Rules, error) {
 	return NewRules(raw)
 }
 
+// NeedsSortedTags reports whether any rule has tag predicates requiring sorted input to IsAllowed.
+func (r *Rules) NeedsSortedTags() bool {
+	return r.hasTagRules
+}
+
 // IsAllowed returns true if the log should be ingested.
-// tags must be sorted in ascending order.
+// tags must be sorted when NeedsSortedTags returns true.
 // A nil receiver always allows.
 func (r *Rules) IsAllowed(source string, tags []string) bool {
 	if r == nil {

--- a/comp/anomalydetection/internal/logsfilter/rules.go
+++ b/comp/anomalydetection/internal/logsfilter/rules.go
@@ -106,6 +106,7 @@ func LoadRules(cfg config.Component, key string) (*Rules, error) {
 }
 
 // IsAllowed returns true if the log should be ingested.
+// tags must be sorted in ascending order.
 // A nil receiver always allows.
 func (r *Rules) IsAllowed(source string, tags []string) bool {
 	if r == nil {
@@ -119,16 +120,25 @@ func (r *Rules) IsAllowed(source string, tags []string) bool {
 	return true
 }
 
+// matches reports whether the rule applies to the given log.
+// tags must be sorted in ascending order (guaranteed by callers of IsAllowed).
 func (r compiledRule) matches(source string, tags []string) bool {
 	if r.source != "" && r.source != source {
 		return false
 	}
-	for _, ruleTag := range r.tags {
-		if !containsTag(tags, ruleTag) {
-			return false
+	return containsAllTagsSorted(tags, r.tags)
+}
+
+// containsAllTagsSorted reports whether all ruleTags appear in sampleTags.
+// Both slices must be sorted in ascending order.
+func containsAllTagsSorted(sampleTags, ruleTags []string) bool {
+	j := 0
+	for i := 0; i < len(sampleTags) && j < len(ruleTags); i++ {
+		if sampleTags[i] == ruleTags[j] {
+			j++
 		}
 	}
-	return true
+	return j == len(ruleTags)
 }
 
 func compileRuleTags(tags []string) ([]string, error) {
@@ -144,14 +154,6 @@ func compileRuleTags(tags []string) ([]string, error) {
 		compiled = append(compiled, trimmed)
 	}
 	slices.Sort(compiled)
+	compiled = slices.Compact(compiled)
 	return compiled, nil
-}
-
-func containsTag(tags []string, want string) bool {
-	for _, tag := range tags {
-		if tag == want {
-			return true
-		}
-	}
-	return false
 }

--- a/comp/anomalydetection/internal/logsfilter/rules_test.go
+++ b/comp/anomalydetection/internal/logsfilter/rules_test.go
@@ -112,3 +112,55 @@ func TestIsAllowed_AllTagsMustPresent(t *testing.T) {
 	assert.False(t, r.IsAllowed("x", []string{"env:dev", "team:foo"}))
 	assert.True(t, r.IsAllowed("x", []string{"env:dev"})) // missing team:foo
 }
+
+// --- containsAllTagsSorted ---
+
+func TestContainsAllTagsSorted_EmptyRuleTags(t *testing.T) {
+	assert.True(t, containsAllTagsSorted(nil, nil))
+	assert.True(t, containsAllTagsSorted([]string{"env:prod"}, nil))
+}
+
+func TestContainsAllTagsSorted_EmptySampleTags(t *testing.T) {
+	assert.False(t, containsAllTagsSorted(nil, []string{"env:prod"}))
+}
+
+func TestContainsAllTagsSorted_AllMatch(t *testing.T) {
+	sample := []string{"env:prod", "service:web", "team:foo"}
+	rule := []string{"env:prod", "service:web"}
+	assert.True(t, containsAllTagsSorted(sample, rule))
+}
+
+func TestContainsAllTagsSorted_PartialMatch(t *testing.T) {
+	sample := []string{"env:prod", "service:web"}
+	rule := []string{"env:prod", "team:foo"}
+	assert.False(t, containsAllTagsSorted(sample, rule))
+}
+
+func TestContainsAllTagsSorted_SampleExhaustedBeforeAllRuleTags(t *testing.T) {
+	sample := []string{"a:1"}
+	rule := []string{"a:1", "z:9"}
+	assert.False(t, containsAllTagsSorted(sample, rule))
+}
+
+func TestContainsAllTagsSorted_ExactMatch(t *testing.T) {
+	tags := []string{"env:dev", "service:api"}
+	assert.True(t, containsAllTagsSorted(tags, tags))
+}
+
+// --- compileRuleTags deduplication ---
+
+func TestCompileRuleTagsDeduplicate(t *testing.T) {
+	compiled, err := compileRuleTags([]string{"env:prod", "env:prod", "service:web"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"env:prod", "service:web"}, compiled)
+}
+
+func TestIsAllowed_DuplicateRuleTagsBehaveAsIfUnique(t *testing.T) {
+	r := rules(t, ProcessingRule{
+		Name: "r", Type: "exclude_at_match",
+		Tags: []string{"env:prod", "env:prod"},
+	})
+	// Should match the same as a rule with a single "env:prod".
+	assert.False(t, r.IsAllowed("x", []string{"env:prod"}))
+	assert.True(t, r.IsAllowed("x", []string{"env:dev"}))
+}

--- a/comp/anomalydetection/logssource/impl/pipeline.go
+++ b/comp/anomalydetection/logssource/impl/pipeline.go
@@ -85,7 +85,10 @@ func (p *observerPipeline) drainOutputChan() {
 		// config when one is set (e.g. "nginx"), overriding the container runtime.
 		// Rules using source: containerd/docker will not match AD-scheduled container
 		// logs that carry a custom source.
-		msgTags := slices.Sorted(slices.Values(msg.Tags()))
+		msgTags := msg.Tags()
+		if p.rules.NeedsSortedTags() {
+			msgTags = slices.Sorted(slices.Values(msgTags))
+		}
 		if !p.rules.IsAllowed(msg.Origin.Source(), msgTags) {
 			continue
 		}

--- a/comp/anomalydetection/logssource/impl/pipeline.go
+++ b/comp/anomalydetection/logssource/impl/pipeline.go
@@ -7,6 +7,7 @@ package logssourceimpl
 
 import (
 	"context"
+	"slices"
 
 	"github.com/DataDog/datadog-agent/comp/anomalydetection/internal/logsfilter"
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
@@ -84,7 +85,8 @@ func (p *observerPipeline) drainOutputChan() {
 		// config when one is set (e.g. "nginx"), overriding the container runtime.
 		// Rules using source: containerd/docker will not match AD-scheduled container
 		// logs that carry a custom source.
-		if !p.rules.IsAllowed(msg.Origin.Source(), msg.Tags()) {
+		msgTags := slices.Sorted(slices.Values(msg.Tags()))
+		if !p.rules.IsAllowed(msg.Origin.Source(), msgTags) {
 			continue
 		}
 		if p.sampler != nil && !p.sampler.ShouldForward(msg) {

--- a/comp/anomalydetection/observer/impl/agent_logs.go
+++ b/comp/anomalydetection/observer/impl/agent_logs.go
@@ -65,7 +65,9 @@ func installAgentLogTap(handle observerdef.Handle, minSeverity string, maxRateHi
 			tags = append(tags, "component:"+name)
 		}
 		tags = append(tags, "level:"+strings.ToLower(level.String()))
-		slices.Sort(tags)
+		if rules.NeedsSortedTags() {
+			slices.Sort(tags)
+		}
 		if !rules.IsAllowed(agentLogSource, tags) {
 			return
 		}

--- a/comp/anomalydetection/observer/impl/agent_logs.go
+++ b/comp/anomalydetection/observer/impl/agent_logs.go
@@ -7,6 +7,7 @@ package observerimpl
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"time"
 
@@ -64,6 +65,7 @@ func installAgentLogTap(handle observerdef.Handle, minSeverity string, maxRateHi
 			tags = append(tags, "component:"+name)
 		}
 		tags = append(tags, "level:"+strings.ToLower(level.String()))
+		slices.Sort(tags)
 		if !rules.IsAllowed(agentLogSource, tags) {
 			return
 		}

--- a/comp/anomalydetection/observer/impl/filter_rules.go
+++ b/comp/anomalydetection/observer/impl/filter_rules.go
@@ -162,6 +162,7 @@ func compileRuleTags(tags []string) ([]string, error) {
 		compiled = append(compiled, trimmed)
 	}
 	slices.Sort(compiled)
+	compiled = slices.Compact(compiled)
 	return compiled, nil
 }
 
@@ -197,6 +198,8 @@ func (f *metricsFilterRules) setMuted(m map[uint64]struct{}) {
 	f.muted.Store(&m)
 }
 
+// matches reports whether the rule applies to the given metric.
+// tags must be sorted in ascending order (guaranteed by canonicalizeTags in prepareMetricIngest).
 func (r metricsCompiledRule) matches(name, source string, tags []string) bool {
 	if r.source != "" && source != r.source {
 		return false
@@ -206,20 +209,17 @@ func (r metricsCompiledRule) matches(name, source string, tags []string) bool {
 		return false
 	}
 
-	for _, ruleTag := range r.tags {
-		if !containsRuleTag(tags, ruleTag) {
-			return false
-		}
-	}
-
-	return true
+	return containsAllTagsSorted(tags, r.tags)
 }
 
-func containsRuleTag(tags []string, want string) bool {
-	for _, tag := range tags {
-		if tag == want {
-			return true
+// containsAllTagsSorted reports whether all ruleTags appear in sampleTags.
+// Both slices must be sorted in ascending order.
+func containsAllTagsSorted(sampleTags, ruleTags []string) bool {
+	j := 0
+	for i := 0; i < len(sampleTags) && j < len(ruleTags); i++ {
+		if sampleTags[i] == ruleTags[j] {
+			j++
 		}
 	}
-	return false
+	return j == len(ruleTags)
 }

--- a/comp/anomalydetection/observer/impl/filter_rules_test.go
+++ b/comp/anomalydetection/observer/impl/filter_rules_test.go
@@ -149,7 +149,7 @@ func TestMetricsFilterRulesTagAndSemantics(t *testing.T) {
 	}})
 	require.NoError(t, err)
 
-	assert.False(t, filter.isAllowed("system.cpu.user", "dogstatsd", []string{"service:web", "env:dev"}))
+	assert.False(t, filter.isAllowed("system.cpu.user", "dogstatsd", []string{"env:dev", "service:web"}))
 	assert.True(t, filter.isAllowed("system.cpu.user", "dogstatsd", []string{"env:dev"}))
 	assert.True(t, filter.isAllowed("system.cpu.user", "dogstatsd", []string{"service:web"}))
 }
@@ -755,6 +755,61 @@ func TestAsyncAndSyncFilteringForCheckSourceRemainConsistent(t *testing.T) {
 
 	assert.Empty(t, storage.ListSeries(observerdef.SeriesFilter{Namespace: "check"}))
 	requireCounterMetricValueBySource(t, "check", 2.0, telComp)
+}
+
+// --- containsAllTagsSorted ---
+
+func TestContainsAllTagsSorted_EmptyRuleTags(t *testing.T) {
+	assert.True(t, containsAllTagsSorted(nil, nil))
+	assert.True(t, containsAllTagsSorted([]string{"env:prod"}, nil))
+}
+
+func TestContainsAllTagsSorted_EmptySampleTags(t *testing.T) {
+	assert.False(t, containsAllTagsSorted(nil, []string{"env:prod"}))
+}
+
+func TestContainsAllTagsSorted_AllMatch(t *testing.T) {
+	sample := []string{"env:prod", "service:web", "team:foo"}
+	rule := []string{"env:prod", "service:web"}
+	assert.True(t, containsAllTagsSorted(sample, rule))
+}
+
+func TestContainsAllTagsSorted_PartialMatch(t *testing.T) {
+	sample := []string{"env:prod", "service:web"}
+	rule := []string{"env:prod", "team:foo"}
+	assert.False(t, containsAllTagsSorted(sample, rule))
+}
+
+func TestContainsAllTagsSorted_SampleExhaustedBeforeAllRuleTags(t *testing.T) {
+	sample := []string{"a:1"}
+	rule := []string{"a:1", "z:9"}
+	assert.False(t, containsAllTagsSorted(sample, rule))
+}
+
+func TestContainsAllTagsSorted_ExactMatch(t *testing.T) {
+	tags := []string{"env:dev", "service:api"}
+	assert.True(t, containsAllTagsSorted(tags, tags))
+}
+
+// --- compileRuleTags deduplication ---
+
+func TestCompileRuleTagsDeduplicate(t *testing.T) {
+	compiled, err := compileRuleTags([]string{"env:prod", "env:prod", "service:web"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"env:prod", "service:web"}, compiled)
+}
+
+func TestMetricsFilterRulesDuplicateRuleTagsBehaveAsIfUnique(t *testing.T) {
+	filter, err := newMetricsFilterRules([]metricsProcessingRule{{
+		Type: excludeAtMatch,
+		Name: "drop_prod",
+		Tags: []string{"env:prod", "env:prod"},
+	}})
+	require.NoError(t, err)
+
+	// Should match the same as a rule with a single "env:prod".
+	assert.False(t, filter.isAllowed("system.cpu.user", "dogstatsd", []string{"env:prod"}))
+	assert.True(t, filter.isAllowed("system.cpu.user", "dogstatsd", []string{"env:dev"}))
 }
 
 func TestFilteredMetricsAndChannelDropsIncrementSeparateCounters(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Tag matching is currently `O(N*M)` but could be optimized in `O(N + M)` if tags are sorted  using a two pointers method (`O(N + M + Nlog N + M log M)` exactly, even though we need the sorting cost in most cases).

This:
1. Sorts log tags like what is done in metrics
2. Replaces the tag matcher algorithm by a 2 pointers linear method

We sort tags only once and we don't need to do it further in the pipeline (could be useful if we hash log tags like what we do for metrics).

### Motivation

Reduce CPU.

### Describe how you validated your changes

### Additional Notes

- I ensured that sorted logs / metrics don't have any side effect outside our package (always copied)