### PR TITLE
Use llvm version of install_name_tool instead of the system one

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -108,6 +108,14 @@ single_version_override(
     ],
 )
 
+# Temporary until https://github.com/bazel-contrib/toolchains_llvm/pull/790 lands in a release
+archive_override(
+    module_name = "toolchains_llvm",
+    sha256 = "addeebfa8fdcf9fbc1c339e451cbb285e1c0d4c078c3718e42bd1791d0d96d4e",
+    strip_prefix = "toolchains_llvm-ffe407ca2423f4d171b7a0f3897c23bbb7e40310",
+    urls = ["https://github.com/bazel-contrib/toolchains_llvm/archive/ffe407ca2423f4d171b7a0f3897c23bbb7e40310.tar.gz"],
+)
+
 #########################
 ## Prebuilt binaries   ##
 #########################

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -255,8 +255,6 @@
     "https://bcr.bazel.build/modules/tar.bzl/0.6.0/source.json": "4a620381df075a16cb3a7ed57bd1d05f7480222394c64a20fa51bdb636fda658",
     "https://bcr.bazel.build/modules/toml.bzl/0.4.1/MODULE.bazel": "6bc0b938f03ade8d58c2fca0ad5c3fa12b4764e1e1927ad50b0c860286db2167",
     "https://bcr.bazel.build/modules/toml.bzl/0.4.1/source.json": "86a90afd8b43c9b69ad31f5c03998c3adcf4b08175e621addb93e3a38eec538b",
-    "https://bcr.bazel.build/modules/toolchains_llvm/1.8.0/MODULE.bazel": "68259b66e5fb84f94fa37125ad476c3eb8edf602a34bf58377cde9a16dd8fa98",
-    "https://bcr.bazel.build/modules/toolchains_llvm/1.8.0/source.json": "70d80fe5b626a3fadf812af41dda4a028640a1184f5a3c7e6cb20130d93ed783",
     "https://bcr.bazel.build/modules/xz/5.4.5.bcr.7/MODULE.bazel": "6ad4a612745322cb1b64b971f9de54d1e604810043da14ca5578f963075b5dac",
     "https://bcr.bazel.build/modules/xz/5.4.5.bcr.7/source.json": "8f42ea24ea4bf0d34e9fca53ee39de4fd4aeb93459a777600975ba18857fd2a9",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
@@ -827,7 +825,7 @@
     "@@toolchains_llvm+//toolchain/extensions:distributions.bzl%llvm_distributions": {
       "general": {
         "bzlTransitiveDigest": "gCdXpBt3HBBc280OILOFheHmO7lXWXJYnPgYiTtyapI=",
-        "usagesDigest": "VyKGZSw79ryPJ9gt0sqBfIkA7qGOU6tnlDHd7awkb6Q=",
+        "usagesDigest": "3B/1Qf38oum/lRpBvi3mnJwV6XMAQF+4//DH0B29rNA=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "llvm_distributions_data": {

--- a/bazel/rules/BUILD.bazel
+++ b/bazel/rules/BUILD.bazel
@@ -9,10 +9,15 @@ sh_binary(
             "--patchelf",
             "$(location @patchelf)",
         ],
+        "@platforms//os:macos": [
+            "--install-name-tool",
+            "$(location @llvm_toolchain_llvm//:install-name-tool)",
+        ],
         "//conditions:default": [],
     }),
     data = select({
         "@platforms//os:linux": ["@patchelf"],
+        "@platforms//os:macos": ["@llvm_toolchain_llvm//:install-name-tool"],
         "//conditions:default": [],
     }),
     tags = ["manual"],

--- a/bazel/rules/dd_packaging/dd_cc_packaged.bzl
+++ b/bazel/rules/dd_packaging/dd_cc_packaged.bzl
@@ -71,7 +71,7 @@ _dd_packaged_files_rule = rule(
             cfg = "exec",
         ),
         "_install_name_tool": attr.label(
-            default = "@llvm_toolchain_llvm//:install-name-tool",
+            default = "@@//bazel/tools:install_name_tool",
             executable = True,
             cfg = "exec",
         ),

--- a/bazel/rules/dd_packaging/dd_cc_packaged.bzl
+++ b/bazel/rules/dd_packaging/dd_cc_packaged.bzl
@@ -70,6 +70,11 @@ _dd_packaged_files_rule = rule(
             allow_single_file = True,
             cfg = "exec",
         ),
+        "_install_name_tool": attr.label(
+            default = "@llvm_toolchain_llvm//:install-name-tool",
+            executable = True,
+            cfg = "exec",
+        ),
         "_install_dir": attr.label(default = "@@//:install_dir"),
     },
     toolchains = [

--- a/bazel/rules/foreign_cc_runnable/foreign_cc_runnable.bzl
+++ b/bazel/rules/foreign_cc_runnable/foreign_cc_runnable.bzl
@@ -105,19 +105,24 @@ def _foreign_cc_runnable_impl(ctx):
         patchelf_path = patchelf.executable.path
         patchelf_tools = [patchelf]
 
+    install_name_tool = ctx.executable._install_name_tool if is_macos else None
+
     args = ctx.actions.args()
     args.add("linux" if is_linux else "darwin")
     args.add(patchelf_path)
+    args.add(install_name_tool.path if install_name_tool else "")
     args.add(input_tree.path)
     args.add(output_tree.path)
     args.add(manifest.path)
     args.add_all(rpath_dirs)
 
+    tools = patchelf_tools + ([install_name_tool] if install_name_tool else [])
+
     ctx.actions.run(
         executable = ctx.file._script,
         arguments = [args],
         inputs = [input_tree, manifest],
-        tools = patchelf_tools,
+        tools = tools,
         outputs = [output_tree],
         mnemonic = "ForeignCcRunnable",
         progress_message = "Rewriting rpaths for %{label}",
@@ -167,6 +172,11 @@ foreign_cc_runnable = rule(
             allow_single_file = True,
             cfg = "exec",
             executable = True,
+        ),
+        "_install_name_tool": attr.label(
+            default = "@llvm_toolchain_llvm//:install-name-tool",
+            executable = True,
+            cfg = "exec",
         ),
         "_linux_constraint": attr.label(
             default = "@platforms//os:linux",

--- a/bazel/rules/foreign_cc_runnable/foreign_cc_runnable.bzl
+++ b/bazel/rules/foreign_cc_runnable/foreign_cc_runnable.bzl
@@ -174,7 +174,7 @@ foreign_cc_runnable = rule(
             executable = True,
         ),
         "_install_name_tool": attr.label(
-            default = "@llvm_toolchain_llvm//:install-name-tool",
+            default = "@@//bazel/tools:install_name_tool",
             executable = True,
             cfg = "exec",
         ),

--- a/bazel/rules/foreign_cc_runnable/foreign_cc_runnable.bzl
+++ b/bazel/rules/foreign_cc_runnable/foreign_cc_runnable.bzl
@@ -97,26 +97,24 @@ def _foreign_cc_runnable_impl(ctx):
     if not is_linux and not is_macos:
         fail("{}: unsupported platform (Linux and macOS only)".format(ctx.label))
 
-    patchelf_path = ""
-    patchelf_tools = []
+    args = ctx.actions.args()
+
+    tools = []
     if is_linux:
         patchelf_toolchain = ctx.toolchains["@@//bazel/toolchains/patchelf:patchelf_toolchain_type"].patchelf
         patchelf = patchelf_toolchain.label[DefaultInfo].files_to_run
-        patchelf_path = patchelf.executable.path
-        patchelf_tools = [patchelf]
+        args.add("--patchelf", patchelf.executable.path)
+        tools.append(patchelf)
+    else:
+        install_name_tool = ctx.executable._install_name_tool
+        args.add("--install-name-tool", install_name_tool.path)
+        tools.append(install_name_tool)
 
-    install_name_tool = ctx.executable._install_name_tool if is_macos else None
-
-    args = ctx.actions.args()
     args.add("linux" if is_linux else "darwin")
-    args.add(patchelf_path)
-    args.add(install_name_tool.path if install_name_tool else "")
     args.add(input_tree.path)
     args.add(output_tree.path)
     args.add(manifest.path)
     args.add_all(rpath_dirs)
-
-    tools = patchelf_tools + ([install_name_tool] if install_name_tool else [])
 
     ctx.actions.run(
         executable = ctx.file._script,

--- a/bazel/rules/foreign_cc_runnable/patch_rpaths.sh
+++ b/bazel/rules/foreign_cc_runnable/patch_rpaths.sh
@@ -12,10 +12,11 @@ set -euo pipefail
 
 PLATFORM="$1"
 PATCHELF="$2"
-INPUT="$3"
-OUTPUT="$4"
-MANIFEST="$5"
-shift 5
+INSTALL_NAME_TOOL="$3"
+INPUT="$4"
+OUTPUT="$5"
+MANIFEST="$6"
+shift 6
 RPATH_DIRS=("$@")
 
 # `cp -rL` materializes a real copy and dereferences any symlinks that
@@ -36,8 +37,9 @@ patch_file() {
     done
 
     if [[ "$PLATFORM" == "darwin" ]]; then
+        "$INSTALL_NAME_TOOL" -delete_all_rpaths "$f"
         for dir in "${RPATH_DIRS[@]}"; do
-            install_name_tool -add_rpath "@loader_path/${ups}${dir}" "$f"
+            "$INSTALL_NAME_TOOL" -add_rpath "@loader_path/${ups}${dir}" "$f"
         done
         # Re-sign with an ad-hoc signature; install_name_tool invalidates any existing code signature.
         codesign --sign - --force "$f" 2>/dev/null

--- a/bazel/rules/foreign_cc_runnable/patch_rpaths.sh
+++ b/bazel/rules/foreign_cc_runnable/patch_rpaths.sh
@@ -10,13 +10,36 @@
 # A FILE must exist; a GLOB must match at least one file.
 set -euo pipefail
 
+PATCHELF=""
+INSTALL_NAME_TOOL=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --patchelf)
+            shift
+            PATCHELF="$1"
+            ;;
+        --install-name-tool)
+            shift
+            INSTALL_NAME_TOOL="$1"
+            ;;
+        *)
+            break
+            ;;
+    esac
+    shift
+done
+
+if [ "$#" -lt 4 ]; then
+    echo "Usage: patch_rpaths.sh [--patchelf <path>|--install-name-tool <path>] <platform> <input> <output> <manifest> [rpath dirs...]" >&2
+    exit 1
+fi
+
 PLATFORM="$1"
-PATCHELF="$2"
-INSTALL_NAME_TOOL="$3"
-INPUT="$4"
-OUTPUT="$5"
-MANIFEST="$6"
-shift 6
+INPUT="$2"
+OUTPUT="$3"
+MANIFEST="$4"
+shift 4
 RPATH_DIRS=("$@")
 
 # `cp -rL` materializes a real copy and dereferences any symlinks that

--- a/bazel/rules/replace_prefix.sh
+++ b/bazel/rules/replace_prefix.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+INSTALL_NAME_TOOL=""
+
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --prefix | -p)
@@ -11,6 +13,10 @@ while [ "$#" -gt 0 ]; do
         --patchelf)
             shift
             PATCHELF="$1"
+            ;;
+        --install-name-tool)
+            shift
+            INSTALL_NAME_TOOL="$1"
             ;;
         *)
             break
@@ -47,31 +53,29 @@ for f in "$@"; do
             if file "$f" | grep -q ELF; then
                 ${PATCHELF} --force-rpath --set-rpath "$PREFIX"/lib "$f"
             elif file "$f" | grep -q "Mach-O"; then
+                if [ -z "$INSTALL_NAME_TOOL" ]; then
+                    echo "replace_prefix.sh: --install-name-tool is required for Mach-O files" >&2
+                    exit 1
+                fi
+
                 # Handle macOS binaries (executables and other Mach-O files)
                 # Match the Linux patchelf --set-rpath behavior: replace existing paths
                 # instead of just appending them.
                 new_rpath="$PREFIX/lib"
-                otool -l "$f" | awk '
-                    $1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next }
-                    in_rpath && $1 == "path" { print $2; in_rpath = 0 }
-                ' | while read -r rpath; do
-                    install_name_tool -delete_rpath "$rpath" "$f" 2>/dev/null || true
-                done
-                install_name_tool -add_rpath "$new_rpath" "$f" 2>/dev/null || true
+                "$INSTALL_NAME_TOOL" -delete_all_rpaths -add_rpath "$new_rpath" "$f"
                 # Get the old install name/ID
                 dylib_name=$(basename "$f")
                 new_id="$PREFIX/lib/$dylib_name"
 
                 # Change the dylib's own ID
-                install_name_tool -id "$new_id" "$f"
+                "$INSTALL_NAME_TOOL" -id "$new_id" "$f"
 
                 # Update all dependency paths that point to sandbox locations
                 otool -L "$f" | tail -n +2 | awk '{print $1}' | while read -r dep; do
                     if [[ "$dep" == *"sandbox"* ]] || [[ "$dep" == *"bazel-out"* ]]; then
                         dep_name=$(basename "$dep")
                         new_dep="$PREFIX/lib/$dep_name"
-                        install_name_tool -change "$dep" "$new_dep" "$f" 2>/dev/null || true
-                        install_name_tool -add_rpath "$PREFIX/lib" "$dep" 2>/dev/null || true
+                        "$INSTALL_NAME_TOOL" -change "$dep" "$new_dep" "$f" 2>/dev/null || true
                     fi
                 done
                 # Re-sign with an ad-hoc signature after modification as install_name_tool invalidates

--- a/bazel/rules/rewrite_rpath/macos.sh
+++ b/bazel/rules/rewrite_rpath/macos.sh
@@ -2,10 +2,11 @@
 
 set -euo pipefail
 
-OTOOL=$1
-PREFIX=$2
-INPUT=$3
-OUTPUT=$4
+INSTALL_NAME_TOOL=$1
+OTOOL=$2
+PREFIX=$3
+INPUT=$4
+OUTPUT=$5
 
 # PREFIX is the full rpath (e.g. {install_dir}/embedded/lib); use as-is, do not append /lib
 cp "$INPUT" "$OUTPUT"
@@ -16,17 +17,11 @@ chmod u+w "$OUTPUT"
 # Match Linux patchelf --set-rpath semantics: the packaged output should have
 # exactly the packaging rpath, to avoid leaving in existing ones that may
 # point to build-time paths.
-${OTOOL} -l "$OUTPUT" | awk '
-    $1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next }
-    in_rpath && $1 == "path" { print $2; in_rpath = 0 }
-' | while read -r rpath; do
-    install_name_tool -delete_rpath "$rpath" "$OUTPUT" 2>/dev/null || true
-done
-install_name_tool -add_rpath "$PREFIX" "$OUTPUT" 2>/dev/null || true
+"$INSTALL_NAME_TOOL" -delete_all_rpaths -add_rpath "$PREFIX" "$OUTPUT"
 dylib_name=$(basename "$OUTPUT")
 new_id="$PREFIX/$dylib_name"
 
-install_name_tool -id "$new_id" "$OUTPUT"
+"$INSTALL_NAME_TOOL" -id "$new_id" "$OUTPUT"
 
 # Dylibs built in the Bazel sandbox record their dependencies with absolute
 # sandbox paths as install names (e.g. bazel-out/.../libfoo.dylib). Those paths
@@ -37,8 +32,7 @@ ${OTOOL} -L "$OUTPUT" | tail -n +2 | awk '{print $1}' | while read -r dep; do
     if [[ "$dep" == *"sandbox"* ]] || [[ "$dep" == *"bazel-out"* ]]; then
         dep_name=$(basename "$dep")
         new_dep="$PREFIX/$dep_name"
-        install_name_tool -change "$dep" "$new_dep" "$OUTPUT" 2>/dev/null || true
-        install_name_tool -add_rpath "$PREFIX" "$dep" 2>/dev/null || true
+        "$INSTALL_NAME_TOOL" -change "$dep" "$new_dep" "$OUTPUT" 2>/dev/null || true
     fi
 done
 

--- a/bazel/rules/rewrite_rpath/macos_dir.sh
+++ b/bazel/rules/rewrite_rpath/macos_dir.sh
@@ -3,10 +3,11 @@
 set -euo pipefail
 
 MACOS_SH=$1
-OTOOL=$2
-PREFIX=$3
-INPUT_DIR=$4
-OUTPUT_DIR=$5
+INSTALL_NAME_TOOL=$2
+OTOOL=$3
+PREFIX=$4
+INPUT_DIR=$5
+OUTPUT_DIR=$6
 
 # Walk the input tree once: route Mach-O libraries through macos.sh (which writes
 # a fresh output file with rewritten install names, rpaths, and ad-hoc signature)
@@ -17,7 +18,7 @@ find -L "$INPUT_DIR" -type f | while read -r input_f; do
     mkdir -p "$(dirname "$output_f")"
     case "$input_f" in
         *.dylib | *.so)
-            "$MACOS_SH" "$OTOOL" "$PREFIX" "$input_f" "$output_f"
+            "$MACOS_SH" "$INSTALL_NAME_TOOL" "$OTOOL" "$PREFIX" "$input_f" "$output_f"
             ;;
         *)
             cp -p "$input_f" "$output_f"

--- a/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
+++ b/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
@@ -40,14 +40,16 @@ def otool_file_action(ctx, input_file, output_file, rpath):
       output_file: the output File to write.
       rpath: the rpath string to set.
     """
-    toolchain = ctx.toolchains["@@//bazel/toolchains/otool:otool_toolchain_type"].otool
+    otool = ctx.toolchains["@@//bazel/toolchains/otool:otool_toolchain_type"].otool
     args = ctx.actions.args()
-    args.add(toolchain.path)
+    args.add(ctx.executable._install_name_tool.path)
+    args.add(otool.path)
     args.add(rpath)
     args.add(input_file.path)
     args.add(output_file.path)
     ctx.actions.run(
         inputs = [input_file],
+        tools = [ctx.executable._install_name_tool],
         outputs = [output_file],
         executable = ctx.file._script,
         arguments = [args],
@@ -93,15 +95,17 @@ def otool_dir_action(ctx, input_dir, output_dir, rpath):
       output_dir: the output directory artifact to write.
       rpath: the rpath string to set.
     """
-    toolchain = ctx.toolchains["@@//bazel/toolchains/otool:otool_toolchain_type"].otool
+    otool = ctx.toolchains["@@//bazel/toolchains/otool:otool_toolchain_type"].otool
     args = ctx.actions.args()
     args.add(ctx.file._script.path)
-    args.add(toolchain.path)
+    args.add(ctx.executable._install_name_tool.path)
+    args.add(otool.path)
     args.add(rpath)
     args.add(input_dir.path)
     args.add(output_dir.path)
     ctx.actions.run(
         inputs = [input_dir, ctx.file._script],
+        tools = [ctx.executable._install_name_tool],
         outputs = [output_dir],
         executable = ctx.file._dir_script,
         arguments = [args],
@@ -150,6 +154,11 @@ rewrite_rpath = rule(
         "_script": attr.label(
             default = "@@//bazel/rules/rewrite_rpath:macos.sh",
             allow_single_file = True,
+            cfg = "exec",
+        ),
+        "_install_name_tool": attr.label(
+            default = "@llvm_toolchain_llvm//:install-name-tool",
+            executable = True,
             cfg = "exec",
         ),
         "_install_dir": attr.label(

--- a/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
+++ b/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
@@ -157,7 +157,7 @@ rewrite_rpath = rule(
             cfg = "exec",
         ),
         "_install_name_tool": attr.label(
-            default = "@llvm_toolchain_llvm//:install-name-tool",
+            default = "@@//bazel/tools:install_name_tool",
             executable = True,
             cfg = "exec",
         ),

--- a/bazel/rules/rewrite_rpath/tests/BUILD.bazel
+++ b/bazel/rules/rewrite_rpath/tests/BUILD.bazel
@@ -31,12 +31,14 @@ genrule(
 sh_test(
     name = "macos_dir_test",
     srcs = ["macos_dir_test.sh"],
+    args = ["$(location @llvm_toolchain_llvm//:install-name-tool)"],
     data = [
         ":bar",
         ":baz_so",
         ":foo",
         "//bazel/rules/rewrite_rpath:macos.sh",
         "//bazel/rules/rewrite_rpath:macos_dir.sh",
+        "@llvm_toolchain_llvm//:install-name-tool",
     ],
     target_compatible_with = ["@platforms//os:macos"],
 )

--- a/bazel/rules/rewrite_rpath/tests/macos_dir_test.sh
+++ b/bazel/rules/rewrite_rpath/tests/macos_dir_test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 MACOS_SH="$(find "$TEST_SRCDIR" -path "*/rewrite_rpath/macos.sh" | head -1)"
 MACOS_DIR_SH="$(find "$TEST_SRCDIR" -path "*/rewrite_rpath/macos_dir.sh" | head -1)"
+INSTALL_NAME_TOOL="${1:?usage: $0 <install-name-tool>}"
 
 LIBS=()
 while IFS= read -r f; do LIBS+=("$f"); done < <(find "$TEST_SRCDIR" \( -name "*.dylib" -o -name "*.so" \))
@@ -18,7 +19,7 @@ for lib in "${LIBS[@]}"; do
 done
 
 PREFIX="@loader_path/../../embedded/lib"
-"$MACOS_DIR_SH" "$MACOS_SH" /usr/bin/otool "$PREFIX" "$INPUT_DIR" "$OUTPUT_DIR"
+"$MACOS_DIR_SH" "$MACOS_SH" "$INSTALL_NAME_TOOL" /usr/bin/otool "$PREFIX" "$INPUT_DIR" "$OUTPUT_DIR"
 
 FAILED=0
 while IFS= read -r outfile; do

--- a/bazel/tools/BUILD.bazel
+++ b/bazel/tools/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 
 py_binary(
@@ -13,4 +14,22 @@ py_binary(
     name = "generate_module_bazel",
     srcs = ["generate_module_bazel.py"],
     visibility = ["//deps:__subpackages__"],
+)
+
+# @llvm_toolchain_llvm//:install-name-tool is only defined for macos and linux.
+# This acts as a replacement to avoid analysis-time failures on windows.
+write_file(
+    name = "_empty_install_name_tool",
+    out = "empty_install_name_tool",
+    is_executable = True,
+)
+
+alias(
+    name = "install_name_tool",
+    actual = select({
+        "@platforms//os:linux": "@llvm_toolchain_llvm//:install-name-tool",
+        "@platforms//os:macos": "@llvm_toolchain_llvm//:install-name-tool",
+        "//conditions:default": ":_empty_install_name_tool",
+    }),
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
### What does this PR do?

It moves bazel usage of host `install_name_tool` to [llvm's version](https://llvm.org/docs/CommandGuide/llvm-install-name-tool.html) of it and replaces ad-hoc rpath removal logic with a single command.

### Motivation

Mainly for the benefit of being able to use `--delete_all_rpaths` (https://github.com/DataDog/datadog-agent/pull/52964#discussion_r3497496980), simplifying recently implemented logic (https://github.com/DataDog/datadog-agent/pull/52964) to manually do that.

Of course, it also adds improved hermeticity is an extra bonus, though considering that we won't ever get all the tools needed for rpath patching hermetically (i.e. we'll always need `codesign` at least), and that these are tools that are pretty much guaranteed to be installed on macos systems, that might not be such a big deal.

### Describe how you validated your changes

Local testing and green CI build (including health check).

### Additional Notes

This leverages the llvm toolchain we already had set up, which exposes the tool thanks to https://github.com/bazel-contrib/toolchains_llvm/pull/790.

There's still possible cleanup to do and too many places where we're rewriting rpaths, but that will require follow-up targeted work.