### PR TITLE
Add support for regexp to locate setting in the schema

### DIFF
--- a/.claude/skills/locate-config-setting/SKILL.md
+++ b/.claude/skills/locate-config-setting/SKILL.md
@@ -25,6 +25,15 @@ dda inv -- schema.locate <setting.path>
 `datadog.yaml` / `system-probe.yaml` — e.g. `api_key`, `proxy.https`,
 `apm_config.enabled`. (Use `--` so invoke treats the path as a positional arg.)
 
+It can also be a **pattern**: any argument containing a character outside
+`[A-Za-z0-9_.]` (e.g. `*`, `$`, `[`) is matched against *every* full dotted path
+in the schema instead of looked up exactly. The pattern is treated as a regular
+expression (`re.search`); if it isn't valid regex it falls back to shell-style
+glob (`fnmatch`). So `'*enabled'` lists every setting whose path ends with
+`enabled`. Pattern matches are printed as a compact, sorted
+`[<schema>] <path>  ->  <file>:<line>` list (one line per match) rather than full
+node blocks; pass `--json` for the full `{schema, path, file, line, node}` array.
+
 ### Flags
 
 | Flag | Effect |
@@ -76,6 +85,13 @@ dda inv -- schema.locate apm_config
 
 # Restrict to one schema and get machine-readable output
 dda inv -- schema.locate process_config.enabled --target core --json
+
+# Pattern (glob): every setting whose full path ends with 'enabled'
+dda inv -- schema.locate '*enabled'
+
+# Pattern (regex): every path containing 'proxy' (a bare word like 'proxy' is an
+# exact lookup, so add metacharacters to force a pattern/contains-match)
+dda inv -- schema.locate '.*proxy'
 ```
 
 ## Related

--- a/docs/public/agent-schema/cli.md
+++ b/docs/public/agent-schema/cli.md
@@ -108,6 +108,44 @@ dda inv schema.template-all \
 
 ---
 
+## `schema.locate`
+
+Find where a setting or section is defined in the schema source and print its
+node plus the exact file and line.
+
+```bash
+dda inv -- schema.locate apm_config.enabled
+```
+
+| Argument | Required | Description |
+| --- | --- | --- | --- |
+| `setting` | yes | A dotted config path (`api_key`, `proxy.https`, `apm_config.enabled`) **or** a pattern (see below). Positional — use `--` so invoke does not treat a leading `-` or `*` as a flag. |
+| `--target` | no | Restrict the search to a single schema: `core` or `system-probe`. |
+| `--json` | no | Emit a JSON array of `{schema, path, file, line, node}` instead of human-readable text. |
+
+**Exact paths** print the full node with a `[<schema>] <file>:<line>` header. A setting inside a split section (e.g.
+`apm_config.enabled`) is reported in its sub-file (`pkg/config/schema/yaml/apm_config.yaml:<line>`) — the file you would
+edit. A bare split section is reported at its `$ref:` line in `core_schema.yaml`, with its `properties` collapsed to the
+sorted list of child key names.
+
+**Patterns** — any argument containing a character outside `[A-Za-z0-9_.]` is matched against *every* full dotted path
+in the schema instead of looked up exactly. The pattern is treated as a regular expression (`re.search`); if it is not
+valid regex it falls back to shell-style glob (`fnmatch`). Pattern matches print as a compact, sorted `[<schema>] <path>
+-> <file>:<line>` list (one line per match); use `--json` for the full node array.
+
+```bash
+# Exact: setting inside a split section → resolves into the sub-file
+dda inv -- schema.locate apm_config.enabled
+
+# Pattern (glob): every setting whose full path ends with "enabled"
+dda inv -- schema.locate '*enabled'
+
+# Pattern (regex): every path under apm_config ending in "enabled", as JSON
+dda inv -- schema.locate 'apm_config\..*enabled' --json
+```
+
+---
+
 ## Typical workflows
 
 **I edited a setting in `pkg/config/setup` and want the schema to reflect it:**
@@ -124,6 +162,13 @@ dda inv schema.lint                                  # validate it
 dda inv schema.template \
   --schema=./pkg/config/schema/yaml/core_schema.yaml \
   --build-type=agent-py3 --os-target=linux --output=/tmp/datadog.yaml.example
+```
+
+**I want to find where a setting is defined, or list every setting matching a pattern:**
+
+```bash
+dda inv -- schema.locate apm_config.enabled   # exact: node + file:line
+dda inv -- schema.locate '*enabled'           # pattern: all paths ending in "enabled"
 ```
 
 ## See also

--- a/tasks/schema/locate.py
+++ b/tasks/schema/locate.py
@@ -5,9 +5,16 @@ Given a dotted config path (e.g. ``api_key``, ``proxy.https``,
 ``apm_config.enabled``), find where it is defined in the YAML schema source
 files under ``pkg/config/schema/yaml`` and print the matching schema node.
 
+The argument can also be a pattern instead of an exact path: anything containing
+a character outside ``[A-Za-z0-9_.]`` (e.g. ``*``, ``$``, ``[``) is treated as a
+pattern and matched against every full dotted path in the schema. The pattern is
+interpreted as a regular expression (``re.search``); if it is not a valid regex
+it falls back to shell-style glob matching (``fnmatch``). So ``'*enabled'`` lists
+every setting whose full path ends with ``enabled``.
+
 Run with:
 
-    dda inv -- schema.locate <setting>
+    dda inv -- schema.locate <setting-or-pattern>
 
 The core schema is split across a top file (``core_schema.yaml``) and
 per-section sub-files referenced via ``$ref``. This module reads the YAML
@@ -16,8 +23,11 @@ locations point at editable source, and reuses ``resolve_schema`` to inline
 ``$ref``s when extracting the node content.
 """
 
+import fnmatch
 import json as _json
 import os
+import re
+from functools import lru_cache
 
 import yaml
 from invoke import task
@@ -42,8 +52,15 @@ SCHEMAS = [
 # ---------------------------------------------------------------------------
 
 
+@lru_cache(maxsize=None)
 def _compose(path):
-    """Return the root composed node of a YAML file (carries ``start_mark``)."""
+    """Return the root composed node of a YAML file (carries ``start_mark``).
+
+    Memoized by path: the composed tree is only read (walked for line numbers,
+    never mutated), and pattern matching calls this once per match — without the
+    cache, locating a pattern with hundreds of hits re-parses the multi-thousand
+    line schema files hundreds of times.
+    """
     with open(path) as f:
         return yaml.compose(f)
 
@@ -189,6 +206,80 @@ def locate_setting(setting, schemas=SCHEMAS):
 
 
 # ---------------------------------------------------------------------------
+# Pattern matching (regex / glob over full dotted paths)
+# ---------------------------------------------------------------------------
+
+
+def is_pattern(setting):
+    """True if *setting* should be treated as a regex/glob pattern, not an exact path.
+
+    Exact config paths are dotted identifiers — only ``[A-Za-z0-9_.]``. Any other
+    character (``*``, ``$``, ``[``, ``^``, ...) marks the argument as a pattern.
+    """
+    return re.search(r"[^A-Za-z0-9_.]", setting) is not None
+
+
+def _compile_matcher(pattern):
+    """Return a ``predicate(path) -> bool`` for *pattern*.
+
+    The pattern is treated as a regular expression matched with ``re.search``. If
+    it is not a valid regex (e.g. a glob like ``*enabled``), fall back to
+    shell-style glob matching via ``fnmatch`` so common glob syntax still works.
+    """
+    try:
+        regex = re.compile(pattern)
+    except re.error:
+        return lambda path: fnmatch.fnmatch(path, pattern)
+    return lambda path: regex.search(path) is not None
+
+
+def _walk_paths(merged, prefix=()):
+    """Yield ``(dotted_path, parts, node)`` for every setting/section descendant.
+
+    Walks named ``properties`` children recursively, depth-first, yielding each
+    node (both leaf settings and intermediate sections).
+    """
+    if not isinstance(merged, dict):
+        return
+    props = merged.get("properties")
+    if not isinstance(props, dict):
+        return
+    for key, child in props.items():
+        parts = (*prefix, key)
+        yield ".".join(parts), list(parts), child
+        yield from _walk_paths(child, parts)
+
+
+def locate_pattern(pattern, schemas=SCHEMAS):
+    """Locate every path matching *pattern* across *schemas*.
+
+    Returns a list of match dicts ``{schema, path, file, line, node}``, one per
+    matching path per schema, sorted by ``(path, schema)``.
+    """
+    match = _compile_matcher(pattern)
+    matches = []
+    for label, top_file in schemas:
+        for dotted, parts, node in _walk_paths(resolve_schema(top_file)):
+            if not match(dotted):
+                continue
+            physical = _locate_physical(top_file, parts)
+            if physical is None:
+                continue
+            file_path, line = physical
+            matches.append(
+                {
+                    "schema": label,
+                    "path": dotted,
+                    "file": file_path,
+                    "line": line,
+                    "node": _display_node(node),
+                }
+            )
+    matches.sort(key=lambda m: (m["path"], m["schema"]))
+    return matches
+
+
+# ---------------------------------------------------------------------------
 # Rendering + task entry point
 # ---------------------------------------------------------------------------
 
@@ -199,10 +290,18 @@ def _str_presenter(dumper, data):
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
 
-def _render(matches, as_json):
-    """Render *matches* as a string: a JSON array if *as_json*, else human text."""
+def _render(matches, as_json, compact=False):
+    """Render *matches* as a string: a JSON array if *as_json*, else human text.
+
+    When *compact* (used for pattern matches, which can be numerous), each match
+    is rendered as a single ``[schema] path  ->  file:line`` line instead of the
+    full node block.
+    """
     if as_json:
         return _json.dumps(matches, indent=2, sort_keys=False)
+
+    if compact:
+        return "\n".join(f"[{m['schema']}] {m['path']}  ->  {m['file']}:{m['line']}" for m in matches)
 
     yaml.add_representer(str, _str_presenter)
     blocks = []
@@ -227,19 +326,26 @@ def _select_schemas(schemas, target):
 def run_locate(setting, target=None, as_json=False, schemas=SCHEMAS):
     """Locate *setting* and return the rendered output string.
 
-    Raises ``Exit(code=1)`` if *target* is invalid or the path is not found.
+    *setting* may be an exact dotted path or a regex/glob pattern (see
+    :func:`is_pattern`). Raises ``Exit(code=1)`` if *target* is invalid or nothing
+    matches.
     """
     selected = _select_schemas(schemas, target)
-    matches = locate_setting(setting, selected)
+    pattern = is_pattern(setting)
+    matches = locate_pattern(setting, selected) if pattern else locate_setting(setting, selected)
     if not matches:
         scope = f" in schema '{target}'" if target else ""
-        raise Exit(f"Setting or section '{setting}' not found{scope}.", code=1)
-    return _render(matches, as_json)
+        what = f"pattern '{setting}'" if pattern else f"Setting or section '{setting}'"
+        raise Exit(f"No match for {what}{scope}.", code=1)
+    return _render(matches, as_json, compact=pattern)
 
 
 @task(
     help={
-        "setting": "Dotted config path to locate, e.g. 'api_key', 'proxy.https', 'apm_config.enabled'.",
+        "setting": (
+            "Dotted config path to locate (e.g. 'api_key', 'apm_config.enabled'), "
+            "or a regex/glob pattern matched against every full path (e.g. '*enabled')."
+        ),
         "target": "Restrict the search to a single schema: 'core' or 'system-probe' (default: both).",
         "json": "Emit a JSON array of matches instead of human-readable text.",
     },
@@ -251,5 +357,9 @@ def locate(_ctx, setting, target=None, json=False):
 
     Prints the schema node and the source file + line where it is defined,
     searching both the core and system-probe schemas.
+
+    If *setting* is a pattern (contains a character outside [A-Za-z0-9_.]) it is
+    matched against every full dotted path, so 'schema.locate "*enabled"' lists
+    every setting whose path ends with 'enabled'.
     """
     print(run_locate(setting, target=target, as_json=json))

--- a/tasks/unit_tests/schema_locate_tests.py
+++ b/tasks/unit_tests/schema_locate_tests.py
@@ -211,6 +211,64 @@ class TestLocateSetting(_SchemaFixture):
         self.assertEqual(locate.locate_setting("does.not.exist", self._schemas()), [])
 
 
+class TestIsPattern(unittest.TestCase):
+    def test_dotted_path_is_not_a_pattern(self):
+        self.assertFalse(locate.is_pattern("api_key"))
+        self.assertFalse(locate.is_pattern("apm_config.enabled"))
+        # Keys may contain dots internally (e.g. patternProperties leaves).
+        self.assertFalse(locate.is_pattern("_dd.origin"))
+
+    def test_glob_and_regex_metacharacters_are_patterns(self):
+        for s in ("*enabled", "enabled$", r"apm_config\..*", "proxy.[a-z]+", "^api"):
+            self.assertTrue(locate.is_pattern(s), s)
+
+
+class TestLocatePattern(_SchemaFixture):
+    def _schemas(self):
+        return [("core", self._path("core.yaml")), ("system-probe", self._path("sysprobe.yaml"))]
+
+    def test_glob_suffix_lists_all_paths_ending_in_token(self):
+        # '*enabled' is not valid regex -> falls back to fnmatch (ends-with).
+        matches = locate.locate_pattern("*enabled", self._schemas())
+        self.assertEqual([m["path"] for m in matches], ["apm_config.enabled"])
+        # The split-section setting is located in its sub-file.
+        self.assertEqual(matches[0]["file"], self._path("apm_config.yaml"))
+        self.assertEqual(matches[0]["node"]["type"], "boolean")
+
+    def test_regex_anchor_matches_full_paths(self):
+        matches = locate.locate_pattern(r"\.enabled$", self._schemas())
+        self.assertEqual([m["path"] for m in matches], ["apm_config.enabled"])
+
+    def test_pattern_matches_across_schemas_and_sorts(self):
+        # 'log_level' lives in both schemas; a contains-match finds both, sorted by (path, schema).
+        matches = locate.locate_pattern("log.*", self._schemas())
+        self.assertEqual(
+            [(m["path"], m["schema"]) for m in matches],
+            [("log_level", "core"), ("log_level", "system-probe")],
+        )
+
+    def test_pattern_matches_sections_too(self):
+        matches = locate.locate_pattern("^proxy$", self._schemas())
+        self.assertEqual([m["path"] for m in matches], ["proxy"])
+        # Section node: properties reduced to a sorted key list.
+        self.assertEqual(matches[0]["node"]["properties"], ["https"])
+
+    def test_no_match_returns_empty(self):
+        self.assertEqual(locate.locate_pattern("does_not_match_anything", self._schemas()), [])
+
+    def test_run_locate_dispatches_to_pattern_and_renders_compact(self):
+        out = locate.run_locate("*enabled", schemas=self._schemas())
+        self.assertIn("[core] apm_config.enabled  ->  " + self._path("apm_config.yaml"), out)
+        # Compact mode does not dump the node body.
+        self.assertNotIn("node_type:", out)
+
+    def test_run_locate_pattern_no_match_raises_exit(self):
+        from invoke.exceptions import Exit
+
+        with self.assertRaises(Exit):
+            locate.run_locate("*nope_nope", schemas=self._schemas())
+
+
 class TestRender(unittest.TestCase):
     MATCHES = [
         {


### PR DESCRIPTION
### What does this PR do?

Add support for regexp to locate setting in the schema.

Example:

```
❯ dda inv schema.locate '*direct_*'
[system-probe] network_config.direct_send  ->  pkg/config/schema/yaml/system-probe_schema.yaml:659
[core] runtime_security_config.direct_send_from_system_probe  ->  pkg/config/schema/yaml/runtime_security_config.yaml:118
[system-probe] runtime_security_config.direct_send_from_system_probe  ->  pkg/config/schema/yaml/system-probe_schema.yaml:1371
[core] sbom.container_image.overlayfs_direct_scan  ->  pkg/config/schema/yaml/sbom.yaml:110
[system-probe] service_monitoring_config.direct_consumer  ->  pkg/config/schema/yaml/system-probe_schema.yaml:827
[system-probe] service_monitoring_config.direct_consumer.buffer_wakeup_count_per_cpu  ->  pkg/config/schema/yaml/system-probe_schema.yaml:831
[system-probe] service_monitoring_config.direct_consumer.channel_size  ->  pkg/config/schema/yaml/system-probe_schema.yaml:835
[system-probe] service_monitoring_config.direct_consumer.kernel_buffer_size_per_cpu  ->  pkg/config/schema/yaml/system-probe_schema.yaml:839
[system-probe] service_monitoring_config.http.use_direct_consumer  ->  pkg/config/schema/yaml/system-probe_schema.yaml:920
```