### PR TITLE
feat(agent-data-plane): extended agent flare capabilities to capture …

### DIFF
--- a/comp/core/remoteagentregistry/impl/services.go
+++ b/comp/core/remoteagentregistry/impl/services.go
@@ -72,7 +72,15 @@ func (ra *remoteAgentRegistry) fillFlare(_ context.Context, builder flarebuilder
 	}
 	processor := func(details remoteagentregistry.RegisteredAgent, resp *pb.GetFlareFilesResponse, err error) *remoteagentregistry.FlareData {
 		if err != nil {
-			return nil
+			// The remote agent is registered but unreachable (crashed, gRPC failure, timeout).
+			// Surface the error as UNREACHABLE.txt without blocking the rest of the flare.
+			log.Warnf("Remote agent %q could not be reached during flare collection: %v", details.DisplayName, err)
+			return &remoteagentregistry.FlareData{
+				RegisteredAgent: details,
+				Files: map[string][]byte{
+					"UNREACHABLE.txt": []byte(fmt.Sprintf("%s could not be reached: %v\n", details.DisplayName, err)),
+				},
+			}
 		}
 		return &remoteagentregistry.FlareData{
 			RegisteredAgent: details,

--- a/comp/core/remoteagentregistry/impl/services_test.go
+++ b/comp/core/remoteagentregistry/impl/services_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	io_prometheus_client "github.com/prometheus/client_model/go"
@@ -61,6 +62,41 @@ func TestFlareProvider(t *testing.T) {
 
 	fb.AssertFileExists(flareFilePath)
 	fb.AssertFileContent("test_content", flareFilePath)
+}
+
+// TestFillFlareWritesUnreachableOnGRPCError verifies that when ADP is enabled
+// but the gRPC call to GetFlareFiles fails, fillFlare writes an UNREACHABLE.txt
+// file instead of silently dropping the failure.
+func TestFillFlareWritesUnreachableOnGRPCError(t *testing.T) {
+	provides, _, cfg, _, ipcComp := buildComponent(t)
+	// Use a short timeout so the test doesn't wait 3 s for the default.
+	cfg.SetInTest("remote_agent.registry.query_timeout", 500*time.Millisecond)
+
+	component := provides.Comp
+	flareProvider := provides.FlareProvider
+
+	// Register an agent with a flare provider, then immediately stop its gRPC server
+	// so that the subsequent GetFlareFiles RPC fails.
+	agent := buildAndRegisterRemoteAgent(t, ipcComp, component, "adp", "Agent Data Plane", "42",
+		WithFlareProvider(map[string][]byte{
+			"runtime_config_dump.yaml": []byte("config: true"),
+		}),
+	)
+	agent.Stop() // bring down the gRPC server before the flare is collected
+
+	fb := helpers.NewFlareBuilderMock(t, false)
+
+	err := flareProvider.FlareFiller.Callback(context.Background(), fb)
+	require.NoError(t, err)
+
+	// The nominal artifact must NOT be written because the server is down.
+	fb.AssertNoFileExists("agent-data-plane/runtime_config_dump.yaml")
+
+	// UNREACHABLE.txt must be present under the agent's sanitized display name.
+	fb.AssertFileExists("agent-data-plane/UNREACHABLE.txt")
+	// The file should contain a non-empty error message.
+	unreachablePath := "agent-data-plane/UNREACHABLE.txt"
+	fb.AssertFileContentMatch("could not be reached:", unreachablePath)
 }
 
 func TestGetTelemetry(t *testing.T) {

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -7,6 +7,7 @@ This guide will help you to develop and contribute code to the project.
 * [Custom checks developer guide](checks/README.md)
   * [Python builtin modules](checks/builtins)
 * [Agent IPC API](agent_api.md)
+* [Agent Data Plane — Flare Artifacts](agent-data-plane.md)
 * [How to build the Agent packages][agent-omnibus]
 * [Testing guide][testing]
 * [Troubleshooting Memory Guide][memory]

--- a/docs/dev/agent-data-plane.md
+++ b/docs/dev/agent-data-plane.md
@@ -1,0 +1,135 @@
+# Agent Data Plane — Flare Artifacts
+
+When `data_plane.enabled: true` is set in `datadog.yaml`, running `agent flare`
+collects diagnostics from the Agent Data Plane (ADP) process and bundles them
+under a `<adp-display-name>/` subdirectory inside the flare archive
+(e.g. `agent-data-plane/`).
+
+Artifacts are collected over the Remote Agent Registry gRPC interface
+(`FlareProvider`) and scrubbed for secrets (API keys, proxy credentials, etc.)
+before being written to the archive.
+
+## Collection behaviour
+
+| Condition | Outcome |
+|---|---|
+| ADP healthy | All artifacts below are collected and written under the ADP display-name subdirectory. |
+| ADP unreachable (crash, gRPC failure, timeout) | A single `UNREACHABLE.txt` file is written; the rest of the flare completes normally. |
+| ADP not running / `data_plane.enabled: false` | ADP is not registered with the agent; no ADP subdirectory appears in the flare. |
+
+## Artifact reference
+
+### `UNREACHABLE.txt`
+
+**Present only when** ADP is enabled but the gRPC `GetFlareFiles` call failed
+(process crashed, timeout, connection refused).
+
+Contains the raw gRPC error string returned by the registry client. Use it to
+determine whether ADP was alive at the time the flare was triggered.
+
+---
+
+### `runtime_config_dump.yaml`
+
+Resolved ADP configuration at the time of flare collection — the full merged
+view after defaults, environment variables, and runtime overrides are applied.
+
+**Useful for:** confirming which config values ADP is actually running with and
+diagnosing misconfiguration (e.g. DogStatsD listen address, pipeline settings).
+
+---
+
+### `health.yaml`
+
+Results of ADP's `/health`, `/ready`, and `/live` HTTP probes captured at the
+moment the flare was requested. Each endpoint returns a pass/fail status and a
+per-component breakdown.
+
+**Useful for:** identifying which ADP subsystem is unhealthy or not yet ready;
+correlating with DogStatsD or pipeline startup failures; differentiating between
+a hard crash (see `UNREACHABLE.txt`) and a degraded-but-running process.
+
+---
+
+### `memory_status.yaml`
+
+Snapshot of ADP's memory usage from the `/memory/status` endpoint: RSS,
+virtual size, allocator stats, and per-component heap summaries.
+
+**Useful for:** OOM investigation; tracking allocator fragmentation; comparing
+before/after a config change that affects pipeline cardinality.
+
+---
+
+### `workload-tags-dump.json`
+
+Full dump of the ADP tagger's in-memory state: every entity (container, pod,
+task) and its associated tag set at the time of collection.
+
+**Useful for:** debugging origin-detection failures and tag-cardinality issues.
+
+**Exposure:** container IDs and pod names are present and scrubbed before
+the file is written to the archive.
+
+---
+
+### `workload-external-data-dump.json`
+
+Dump of ADP's external-data resolver state: the set of external (non-local)
+workload identifiers and their cached metadata as seen by ADP.
+
+**Useful for:** diagnosing tag enrichment gaps and external workload resolution
+failures.
+
+---
+
+### `runtime_debug_info.log`
+
+Process-level snapshot collected at flare time:
+
+- PID and process uptime
+- Resident Set Size (RSS) and virtual memory size
+- Command-line arguments
+- Open file-descriptor count
+- Thread count
+
+**Useful for:** confirming the correct ADP binary is running; spotting fd
+leaks; cross-referencing with `memory_status.yaml` for memory accounting.
+
+---
+
+## Already-collected ADP data (not under `data-plane/`)
+
+The following ADP diagnostics are collected through other mechanisms and appear
+at the top level of the flare archive:
+
+| Flare path | Source |
+|---|---|
+| `logs/agent-data-plane.log` | Generic log-directory sweep |
+| `logs/agent-data-plane.log.1` | Rotated log, same sweep |
+| `telemetry.log` | Remote Agent Registry `TelemetryProvider` fan-out |
+| `status.log` (ADP section) | Remote Agent Registry `StatusProvider` fan-out |
+
+## Triage checklist
+
+When a customer submits a flare and ADP is involved:
+
+1. **Is `data_plane.enabled` set?**
+   Check the top-level `runtime_config_dump.yaml`. If absent, ADP was not active.
+
+2. **Is there an `UNREACHABLE.txt`?**
+   ADP was configured but could not be contacted at flare time. Check
+   `logs/agent-data-plane.log` for crash or startup errors.
+
+3. **Health degraded but process alive?**
+   Check `health.yaml` for the failing component.
+
+4. **Tag or enrichment issues?**
+   Check `workload-tags-dump.json` and `workload-external-data-dump.json`.
+
+5. **Memory or OOM?**
+   Start with `memory_status.yaml`, then cross-check RSS in
+   `runtime_debug_info.log`.
+
+6. **Stuck pipeline or deadlock?**
+   Check `logs/agent-data-plane.log` for stalled tasks or error patterns.

--- a/releasenotes/notes/agent-data-plane-flare-artifacts-f01fa1610fb0e107.yaml
+++ b/releasenotes/notes/agent-data-plane-flare-artifacts-f01fa1610fb0e107.yaml
@@ -1,0 +1,18 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    When ``data_plane.enabled`` is set to ``true``, ``agent flare`` now collects
+    diagnostic artifacts from the Agent Data Plane (ADP) process and includes
+    them in a dedicated subdirectory of the flare archive. Collected artifacts
+    include the resolved ADP configuration, health probe results, memory status,
+    workload tag state, external-data resolver state, and process-level runtime
+    info. If ADP is enabled but unreachable at flare time, an ``UNREACHABLE.txt``
+    file containing the connection error is written instead, and the rest of the
+    flare completes normally.

--- a/releasenotes/notes/agent-data-plane-flare-artifacts-f01fa1610fb0e107.yaml
+++ b/releasenotes/notes/agent-data-plane-flare-artifacts-f01fa1610fb0e107.yaml
@@ -1,18 +1,8 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
 ---
 features:
   - |
-    When ``data_plane.enabled`` is set to ``true``, ``agent flare`` now collects
-    diagnostic artifacts from the Agent Data Plane (ADP) process and includes
-    them in a dedicated subdirectory of the flare archive. Collected artifacts
-    include the resolved ADP configuration, health probe results, memory status,
-    workload tag state, external-data resolver state, and process-level runtime
-    info. If ADP is enabled but unreachable at flare time, an ``UNREACHABLE.txt``
-    file containing the connection error is written instead, and the rest of the
-    flare completes normally.
+    ``agent flare`` now includes diagnostic artifacts from the Agent Data Plane
+    (ADP) process when ``data_plane.enabled`` is set to ``true``. If ADP is
+    unreachable at flare time, an ``UNREACHABLE.txt`` file containing the
+    connection error is written to ADP's subdirectory and the rest of the flare
+    completes normally.


### PR DESCRIPTION
…more ADP state data

### What does this PR do?

- `data-plane/UNREACHABLE.txt` created which returns the error message returned by the gRPC client when ADP is enabled but unreachable
- ADP fan-out is gated on `data_plane.enabled = true`. If it's not enabled, then it will be skipped silently.
- Document what each of the newly created artifact contains

### Motivation

This PR is part of an initiative to expand the capabilities of agent flare to collect Agent Data Plane telemetry, config, and runtime state - as documented here: 
- https://github.com/DataDog/saluki/issues/1703

### Describe how you validated your changes

Unit tests and local testing

<img width="144" height="129" alt="Screenshot 2026-06-30 at 11 17 44 AM" src="https://github.com/user-attachments/assets/a1210530-7cbf-4e09-a52f-ee6bb788081f" />
<img width="535" height="243" alt="Screenshot 2026-06-29 at 3 12 43 PM" src="https://github.com/user-attachments/assets/341bb300-b3ad-4687-ba12-1cb9896c31a4" />
<img width="736" height="207" alt="Screenshot 2026-06-30 at 11 50 46 AM" src="https://github.com/user-attachments/assets/467fd062-0319-46c0-9e80-62028d0518b6" />

### Additional Notes
- Saluki-Side PR: https://github.com/DataDog/saluki/pull/1946