### PR TITLE
refactor(serverless-init): align MicroVM lifecycle hooks with GA contract

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -51,9 +51,9 @@ type LifecycleContext struct {
 	SampleDrainer  lifecycle.SampleDrainer
 	FlushTimeout   time.Duration
 	SidecarMode    bool
-	LogsTagSetter  lifecycle.LogsTagSetter  // nil-safe; applied via server.SetLogsTagSetter after /launch
+	LogsTagSetter  lifecycle.LogsTagSetter  // nil-safe; applied via server.SetLogsTagSetter after /run
 	BaseTags       []string                 // startup log tag snapshot passed alongside LogsTagSetter
-	TraceTagSetter lifecycle.TraceTagSetter // nil-safe; applied via server.SetTraceTagSetter after /launch
+	TraceTagSetter lifecycle.TraceTagSetter // nil-safe; applied via server.SetTraceTagSetter after /run
 	BaseTraceTags  map[string]string        // startup trace tag snapshot passed alongside TraceTagSetter
 }
 
@@ -93,7 +93,7 @@ func (m *MicroVM) GetTags() map[string]string {
 
 // GetEnhancedMetricTags returns base (low-cardinality) and usage tags.
 // instance_id is absent from Usage tags at startup because the MicroVM ID is
-// not known until the /launch lifecycle hook fires.
+// not known until the /run lifecycle hook fires.
 func (m *MicroVM) GetEnhancedMetricTags(tags map[string]string) EnhancedMetricTags {
 	baseTags := map[string]string{
 		"account_id":        tagValueOrUnknown(tags["account_id"]),
@@ -218,8 +218,8 @@ func (m *MicroVM) Shutdown(_ serverlessMetrics.ServerlessMetricAgent, _ bool, _ 
 	}
 }
 
-// AddStartMetric is a no-op for MicroVM. The lifecycle server emits the launch
-// metric when the /launch hook fires; emitting it here would double-count.
+// AddStartMetric is a no-op for MicroVM. The lifecycle server emits the run
+// metric when the /run hook fires; emitting it here would double-count.
 func (m *MicroVM) AddStartMetric(_ *serverlessMetrics.ServerlessMetricAgent) {}
 
 // ShouldForceFlushAllOnForceFlushToSerializer returns false for MicroVM.

--- a/cmd/serverless-init/lifecycle/config.go
+++ b/cmd/serverless-init/lifecycle/config.go
@@ -17,7 +17,7 @@ const UserAppPortEnvVar = "DD_AWS_MICROVM_USER_APP_PORT"
 // LifecyclePortEnvVar overrides the port the lifecycle hook server listens on (default 9000).
 const LifecyclePortEnvVar = "DD_AWS_MICROVM_LIFECYCLE_PORT"
 
-// ForwardTimeoutMsEnvVar overrides the timeout (ms) for /launch, /resume, /suspend, /terminate.
+// ForwardTimeoutMsEnvVar overrides the timeout (ms) for /run, /resume, /suspend, /terminate.
 const ForwardTimeoutMsEnvVar = "DD_AWS_MICROVM_FORWARD_TIMEOUT_MS"
 
 // ReadyTimeoutMsEnvVar overrides the timeout (ms) for /ready.

--- a/cmd/serverless-init/lifecycle/forwarder.go
+++ b/cmd/serverless-init/lifecycle/forwarder.go
@@ -30,14 +30,14 @@ const defaultMaxResponseBodyBytes int64 = 1 << 20
 type Forwarder struct {
 	target               string        // e.g. "http://127.0.0.1:8080"
 	client               *http.Client  // shared; no client-level Timeout (per-call deadlines via ctx)
-	forwardTimeout       time.Duration // default 1s, used for suspend/terminate/launch/resume
+	forwardTimeout       time.Duration // default 1s, used for suspend/terminate/run/resume
 	readyTimeout         time.Duration // default 60s, used for /ready
 	validateTimeout      time.Duration // default 1s, used for /validate
 	maxResponseBodyBytes int64         // default defaultMaxResponseBodyBytes; cap on user-app body surfaced to platform
 }
 
 // NewForwarder constructs a Forwarder targeting 127.0.0.1:<port>. The forwardTimeout
-// is used for /launch, /resume, /suspend, and /terminate; readyTimeout for /ready;
+// is used for /run, /resume, /suspend, and /terminate; readyTimeout for /ready;
 // validateTimeout for /validate. Callers should pass the wire.go default constants
 // or values parsed from the DD_AWS_MICROVM_*_TIMEOUT_MS env vars.
 func NewForwarder(port int, forwardTimeout, readyTimeout, validateTimeout time.Duration) *Forwarder {
@@ -116,9 +116,9 @@ func (f *Forwarder) waitForUserApp(ctx context.Context) error {
 	}
 }
 
-// PassThrough forwards a per-MicroVM lifecycle hook (/launch, /resume,
+// PassThrough forwards a per-MicroVM lifecycle hook (/run, /resume,
 // /suspend, /terminate) to the user app and returns the user-app response.
-// Bounded by forwardTimeout (default 30s) — sized as <50% of the tightest
+// Bounded by forwardTimeout (default 1s) — sized as <50% of the tightest
 // AWS Lambda MicroVM platform bound (/terminate's 60s) so the agent always
 // returns within the platform's window. Dial errors map to 503; deadline
 // exceeded maps to 504. The returned *http.Response always has a non-nil

--- a/cmd/serverless-init/lifecycle/forwarder_test.go
+++ b/cmd/serverless-init/lifecycle/forwarder_test.go
@@ -104,7 +104,7 @@ func TestForwarder_PassThrough_TruncatesBodyAtCap(t *testing.T) {
 // This matters for MicroVM snapshot/restore: any connection pooled inside a
 // Firecracker snapshot is stale on resume, and Go's HTTP transport does not
 // auto-retry POST on a stale connection. Forcing a fresh dial per call
-// eliminates the class of "first /launch hook fails with 503/504" failures.
+// eliminates the class of "first /run hook fails with 503/504" failures.
 func TestNewForwarder_DisableKeepAlives_OpensNewConnectionPerRequest(t *testing.T) {
 	var newConns atomic.Int32
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/cmd/serverless-init/lifecycle/heartbeat.go
+++ b/cmd/serverless-init/lifecycle/heartbeat.go
@@ -25,14 +25,14 @@ const (
 	activeInstancesMetricName = "aws.lambda.enhanced.microvm.active_instances"
 
 	// UnknownTagValue is the placeholder used when a tag value has not yet
-	// been observed (e.g. MicroVM ID before /launch, or ARN fields that
+	// been observed (e.g. MicroVM ID before /run, or ARN fields that
 	// cannot be parsed). Exported so cloudservice can reference the sentinel
 	// without duplicating the string literal.
 	UnknownTagValue = "unknown"
 )
 
 // Heartbeat periodically emits a heartbeat metric while the MicroVM is in
-// the "running" phase (between /launch and /suspend or /terminate).
+// the "running" phase (between /run and /suspend or /terminate).
 //
 // This type is MicroVM-specific: it is constructed only by main.go's
 // newLifecycleServerIfMicroVM, which itself short-circuits to nil for
@@ -65,7 +65,7 @@ type Heartbeat struct {
 // DefaultHeartbeatInterval. baseTags are tags known at construction time
 // (typically derived from env vars, e.g., microvm_image_arn); the
 // microvm_id tag is appended at emit time and is set at runtime via
-// SetMicroVMID from the /launch request.
+// SetMicroVMID from the /run request.
 func NewHeartbeat(interval time.Duration, emitter MetricEmitter, source metrics.MetricSource, baseTags []string) *Heartbeat {
 	if interval <= 0 {
 		interval = DefaultHeartbeatInterval
@@ -88,7 +88,7 @@ func (h *Heartbeat) BaseTags() []string {
 	return slices.Clone(h.baseTags)
 }
 
-// SetMicroVMID records the MicroVM instance ID extracted from the /launch
+// SetMicroVMID records the MicroVM instance ID extracted from the /run
 // request header. Empty input is ignored so the existing value (default
 // "unknown" or a previously-set ID) is preserved. Safe to call concurrently
 // with the emitting goroutine; the change is visible on the next tick.
@@ -187,7 +187,7 @@ func (h *Heartbeat) emit() {
 }
 
 // tagsForEmit returns a fresh tag slice combining the immutable base tags
-// (set at construction) with the current microvm_id (set at /launch).
+// (set at construction) with the current microvm_id (set at /run).
 func (h *Heartbeat) tagsForEmit() []string {
 	h.mu.Lock()
 	id := h.microVMID

--- a/cmd/serverless-init/lifecycle/heartbeat_test.go
+++ b/cmd/serverless-init/lifecycle/heartbeat_test.go
@@ -181,7 +181,7 @@ func TestHeartbeat_StopIsUnblockedWhenEmitterStucks(t *testing.T) {
 }
 
 // Until SetMicroVMID is called, the heartbeat tags microvm_id with the
-// placeholder "unknown". Production wiring sets the ID at /launch before
+// placeholder "unknown". Production wiring sets the ID at /run before
 // Start, so this state should never reach an emitted metric in practice;
 // the test pins the contract anyway in case wiring changes.
 func TestHeartbeat_TagsForEmit_DefaultsMicroVMIDToUnknown(t *testing.T) {
@@ -237,7 +237,7 @@ func TestHeartbeat_EmittedMetric_CarriesARNTag(t *testing.T) {
 }
 
 // Empty SetMicroVMID input is ignored — preserves the existing value rather
-// than clobbering with empty. Defends against a /launch where the platform
+// than clobbering with empty. Defends against a /run where the platform
 // header is missing: the heartbeat keeps emitting with whatever ID was
 // last seen (or "unknown" if never set).
 func TestHeartbeat_SetMicroVMID_EmptyIsIgnored(t *testing.T) {

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -5,14 +5,18 @@
 
 // Package lifecycle implements the AWS Lambda MicroVM lifecycle hook server.
 // The MicroVM platform calls POST endpoints on port 9000 at key points in
-// the MicroVM lifecycle: ready, validate, launch, resume, suspend, terminate.
+// the MicroVM lifecycle: ready, validate, run, resume, suspend, terminate.
 //
 // Hook semantics:
 //   - /ready    — "I am booted and ready to be snapshotted." The platform
-//     sends this once after cold start; a 200 triggers snapshot.
-//   - /validate — "I was resumed from a snapshot and everything is good."
-//     The platform sends this after each resume from snapshot.
-//   - /launch   — VM is starting (cold start or from snapshot).
+//     sends this during image build, before snapshot capture; a 200 triggers
+//     snapshot, and it is retried on 503 until a 200 or the configured timeout.
+//   - /validate — build-time hook. After the snapshot is captured the platform
+//     runs a test MicroVM from it and sends /validate to smoke-test the
+//     snapshot (retried on 503 until a 200 or the configured timeout); a 200
+//     marks the image version valid. It is NOT sent during the normal
+//     run/resume lifecycle of a production MicroVM.
+//   - /run      — VM is starting (cold start or from snapshot).
 //   - /resume   — VM is resuming from a suspended snapshot.
 //   - /suspend  — VM is about to be snapshotted/frozen.
 //   - /terminate — VM is being torn down permanently.
@@ -21,14 +25,14 @@
 //
 //   - When DD_AWS_MICROVM_USER_APP_PORT is unset: the agent responds
 //     to each hook itself. /ready checks child-process liveness; /validate
-//     returns 200 directly; /launch, /resume, /suspend, and /terminate emit
+//     returns 200 directly; /run, /resume, /suspend, and /terminate emit
 //     an enhanced metric and, for /suspend and /terminate, flush telemetry
 //     before responding.
 //
 //   - When the env var is set: the agent forwards each hook to
 //     127.0.0.1:<user-app-port> on the same path and mirrors the user app's
 //     response (status, body, Content-Type) back to the platform. /ready and
-//     /validate wait for TCP reachability before forwarding. For /launch,
+//     /validate wait for TCP reachability before forwarding. For /run,
 //     /resume, /suspend, and /terminate the agent's own work — metric
 //     emission, /suspend and /terminate telemetry flush — runs in a goroutine
 //     in parallel with the pass-through.
@@ -60,17 +64,17 @@ import (
 const DefaultPort = 9000
 
 const (
-	basePath      = "/aws/lambda-microvms/runtime/beta/v1/"
+	basePath      = "/aws/lambda-microvms/runtime/v1/"
 	pathReady     = basePath + "ready"
 	pathValidate  = basePath + "validate"
-	pathLaunch    = basePath + "launch"
+	pathRun       = basePath + "run"
 	pathSuspend   = basePath + "suspend"
 	pathResume    = basePath + "resume"
 	pathTerminate = basePath + "terminate"
 
 	postReady     = "POST " + pathReady
 	postValidate  = "POST " + pathValidate
-	postLaunch    = "POST " + pathLaunch
+	postRun       = "POST " + pathRun
 	postSuspend   = "POST " + pathSuspend
 	postResume    = "POST " + pathResume
 	postTerminate = "POST " + pathTerminate
@@ -80,7 +84,7 @@ const (
 	flushWorkerCount = 3
 
 	baseMetricPrefix    = "aws.lambda.enhanced.microvm."
-	launchMetricName    = baseMetricPrefix + "launch"
+	runMetricName       = baseMetricPrefix + "run"
 	suspendMetricName   = baseMetricPrefix + "suspend"
 	resumeMetricName    = baseMetricPrefix + "resume"
 	terminateMetricName = baseMetricPrefix + "terminate"
@@ -101,7 +105,7 @@ const (
 type flushMode int
 
 const (
-	noFlush         flushMode = iota // /launch, /resume: no flush
+	noFlush         flushMode = iota // /run, /resume: no flush
 	flushParallel                    // /suspend: flush concurrently with forward
 	flushSequential                  // /terminate: flush after forward completes
 )
@@ -154,9 +158,9 @@ type TraceTagSetterFunc func(map[string]string)
 // SetTraceTags implements TraceTagSetter.
 func (f TraceTagSetterFunc) SetTraceTags(tags map[string]string) { f(tags) }
 
-// launchBody is the JSON payload sent by the MicroVM platform on /launch.
-type launchBody struct {
-	MicroVMID string `json:"microVmId"`
+// runBody is the JSON payload sent by the MicroVM platform on /run.
+type runBody struct {
+	MicroVMID string `json:"microvmId"`
 }
 
 // Server is the MicroVM lifecycle hook HTTP server.
@@ -166,7 +170,7 @@ type Server struct {
 	logsFlusher   LogsFlusher
 	metricEmitter MetricEmitter
 	sampleDrainer SampleDrainer
-	instanceID    *atomic.String // set once from /launch body
+	instanceID    *atomic.String // set once from /run body
 	metricSource  metrics.MetricSource
 	flushTimeout  time.Duration
 
@@ -176,9 +180,9 @@ type Server struct {
 	heartbeat   *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
 
 	logsTagSetter  LogsTagSetter     // nil-safe; set via SetLogsTagSetter after construction
-	baseTags       []string          // startup tag snapshot; lambda_microvm_id is appended at /launch
+	baseTags       []string          // startup tag snapshot; lambda_microvm_id is appended at /run
 	traceTagSetter TraceTagSetter    // nil-safe; set via SetTraceTagSetter after construction
-	baseTraceTags  map[string]string // startup trace tag snapshot; lambda_microvm_id is added at /launch
+	baseTraceTags  map[string]string // startup trace tag snapshot; lambda_microvm_id is added at /run
 
 	httpServer *http.Server
 }
@@ -217,7 +221,7 @@ func NewServer(
 	}
 	// WriteTimeout must cover the full handler wall-clock for every path:
 	//   - No forwarder: flushTimeout (flush budget + write headroom)
-	//   - /launch, /resume, /suspend, /terminate: forwardTimeout (default 30s)
+	//   - /run, /resume, /suspend, /terminate: forwardTimeout (default 1s)
 	//   - /ready: readyTimeout (default 60s, matching platform /ready timeout)
 	//   - /validate: validateTimeout (default 60s, matching platform /validate timeout)
 	// Use the largest of all applicable budgets so the HTTP server does not
@@ -240,16 +244,16 @@ func NewServer(
 }
 
 // SetLogsTagSetter wires a LogsTagSetter and a baseline tag slice into the server.
-// Must be called before the first /launch request. baseTags is the startup tag
-// snapshot; lambda_microvm_id is appended to it when /launch fires.
+// Must be called before the first /run request. baseTags is the startup tag
+// snapshot; lambda_microvm_id is appended to it when /run fires.
 func (s *Server) SetLogsTagSetter(setter LogsTagSetter, baseTags []string) {
 	s.logsTagSetter = setter
 	s.baseTags = baseTags
 }
 
 // SetTraceTagSetter wires a TraceTagSetter and a baseline trace tag map into the
-// server. Must be called before the first /launch request. baseTraceTags is the
-// startup trace tag snapshot; lambda_microvm_id is added to it when /launch fires.
+// server. Must be called before the first /run request. baseTraceTags is the
+// startup trace tag snapshot; lambda_microvm_id is added to it when /run fires.
 func (s *Server) SetTraceTagSetter(setter TraceTagSetter, baseTraceTags map[string]string) {
 	s.traceTagSetter = setter
 	s.baseTraceTags = baseTraceTags
@@ -302,7 +306,7 @@ func (s *Server) handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc(postReady, s.handleReady)
 	mux.HandleFunc(postValidate, s.handleValidate)
-	mux.HandleFunc(postLaunch, s.handleLaunch)
+	mux.HandleFunc(postRun, s.handleRun)
 	mux.HandleFunc(postSuspend, s.handleSuspend)
 	mux.HandleFunc(postResume, s.handleResume)
 	mux.HandleFunc(postTerminate, s.handleTerminate)
@@ -336,17 +340,26 @@ func (s *Server) passThroughReady(w http.ResponseWriter, r *http.Request) {
 	mirrorResponse(w, resp)
 }
 
-// handleValidate answers the platform's "you were resumed from a snapshot —
-// is everything good?" signal. The platform sends /validate after each resume
-// from snapshot; a 200 confirms the restored VM is healthy.
+// handleValidate answers the platform's build-time snapshot smoke test. After
+// the snapshot is captured the platform runs a test MicroVM from it and sends
+// /validate; a 200 marks the image version valid, a 503 asks the platform to
+// retry until validateTimeout. It is NOT sent during the normal run/resume
+// lifecycle of a production MicroVM.
 //
 // When a Forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT set):
-// pass-through to the user app with TCP-wait, mirroring the response. The
-// TCP-wait handles the rare crash-then-restart window between resume and this
-// call. Without a forwarder the agent returns 200 directly; the user app is
-// not required to implement /validate in that mode.
+// pass-through to the user app with TCP-wait, mirroring the response, so the
+// user app's own smoke test drives the build's validity decision. The TCP-wait
+// absorbs the window before the app is reachable on the test run. Without a
+// forwarder the agent returns 200 directly; the user app is not required to
+// implement /validate in that mode.
 func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: validate")
+	// TODO(microvm-validate-metric): /validate is a build-time hook that only
+	// fires on the ephemeral test MicroVM during image build (and may be retried
+	// on 503), never during a production instance's run/resume lifecycle. This
+	// metric therefore reflects build-step activity, not production behavior, and
+	// may not reliably flush before the test VM is torn down. Revisit whether it
+	// carries enough value to keep alongside the genuine runtime lifecycle metrics.
 	s.emitLifecycleMetric(validateMetricName)
 	if s.fwd != nil {
 		s.passThroughValidate(w, r)
@@ -419,7 +432,7 @@ func (s *Server) flushAll(flushCtx context.Context) {
 // for the user app's response, then joins and mirrors the user app's
 // response back to the platform.
 //
-// Used for /launch and /resume (noFlush), /suspend (flushParallel), and
+// Used for /run and /resume (noFlush), /suspend (flushParallel), and
 // /terminate (flushSequential). /ready and /validate use passThroughReady
 // and passThroughValidate directly (TCP-wait path, not this function).
 //
@@ -506,25 +519,25 @@ func (s *Server) aliveCheckReady(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusServiceUnavailable)
 }
 
-// handleLaunch emits the launch metric, captures the MicroVM instance ID
+// handleRun emits the run metric, captures the MicroVM instance ID
 // from the platform's request body, starts the periodic heartbeat, and
 // (when a forwarder is configured) mirrors the user app's response.
-// handleLaunch is the only hook that reads r.Body and is therefore not
+// handleRun is the only hook that reads r.Body and is therefore not
 // collapsed into dispatchHook directly. The ID is captured before Start
 // so the first heartbeat emission already carries the correct microvm_id tag.
-func (s *Server) handleLaunch(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 	// Read the body once so we can parse the instance ID AND still forward the
 	// original payload to the user app. Without this, the forwarder path would
 	// consume r.Body before the decode, losing the instance_id tag on all
 	// subsequent lifecycle metrics.
 	bodyBytes, _ := io.ReadAll(r.Body)
 	_ = r.Body.Close()
-	var body launchBody
+	var body runBody
 	if err := json.Unmarshal(bodyBytes, &body); err != nil {
-		log.Debugf("MicroVM lifecycle: could not parse launch body: %v", err)
+		log.Debugf("MicroVM lifecycle: could not parse run body: %v", err)
 	}
 	if body.MicroVMID != "" {
-		log.Infof("MicroVM lifecycle: launch (microvm_id=%s)", body.MicroVMID)
+		log.Infof("MicroVM lifecycle: run (microvm_id=%s)", body.MicroVMID)
 		s.instanceID.Store(body.MicroVMID)
 		s.heartbeat.SetMicroVMID(body.MicroVMID)
 		if s.logsTagSetter != nil {
@@ -536,17 +549,17 @@ func (s *Server) handleLaunch(w http.ResponseWriter, r *http.Request) {
 			s.traceTagSetter.SetTraceTags(tags)
 		}
 	} else {
-		log.Info("MicroVM lifecycle: launch")
+		log.Info("MicroVM lifecycle: run")
 	}
 	s.heartbeat.Start()
 	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 	// Go strips Content-Length from server request headers into r.ContentLength
 	// so the forwarder's header-based Content-Length path in do() sees an empty
 	// string. Put it back now that we know the exact buffered length, so the
-	// forwarded /launch request carries a fixed Content-Length rather than
+	// forwarded /run request carries a fixed Content-Length rather than
 	// chunked encoding (which some user-app HTTP servers reject).
 	r.Header.Set("Content-Length", strconv.Itoa(len(bodyBytes)))
-	s.dispatchHook(launchMetricName, pathLaunch, noFlush, w, r)
+	s.dispatchHook(runMetricName, pathRun, noFlush, w, r)
 }
 
 // handleResume emits the resume metric, restarts the heartbeat (stopped at
@@ -612,7 +625,7 @@ func (s *Server) handleTerminate(w http.ResponseWriter, r *http.Request) {
 	s.dispatchHook(terminateMetricName, pathTerminate, flushSequential, w, r)
 }
 
-// dispatchHook is the shared dispatch path for launch, resume, suspend, and
+// dispatchHook is the shared dispatch path for run, resume, suspend, and
 // terminate. When a forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT
 // set): delegates to handleWithForwarder which mirrors the user app's response.
 // When no forwarder is configured: emit metric, optionally flush, return 200.
@@ -633,7 +646,7 @@ func (s *Server) dispatchHook(metricName, path string, mode flushMode, w http.Re
 }
 
 // emitLifecycleMetric records a lifecycle event metric, appending the stored
-// MicroVM instance ID tag when one has been captured from the /launch body.
+// MicroVM instance ID tag when one has been captured from the /run body.
 func (s *Server) emitLifecycleMetric(name string) {
 	var extraTags []string
 	if id := s.instanceID.Load(); id != "" {

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -146,34 +146,34 @@ func TestHandleValidateEmitsMetricAndReturns200(t *testing.T) {
 	assert.Contains(t, emitter.getEmitted(), validateMetricName)
 }
 
-func TestHandleLaunchEmitsMetricAndReturns200(t *testing.T) {
+func TestHandleRunEmitsMetricAndReturns200(t *testing.T) {
 	srv, _, _, _, emitter, _ := newTestServer()
-	req := httptest.NewRequest(http.MethodPost, pathLaunch, nil)
+	req := httptest.NewRequest(http.MethodPost, pathRun, nil)
 	rec := httptest.NewRecorder()
-	srv.handleLaunch(rec, req)
+	srv.handleRun(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, emitter.getEmitted(), launchMetricName)
+	assert.Contains(t, emitter.getEmitted(), runMetricName)
 }
 
-func TestHandleLaunchParsesInstanceID(t *testing.T) {
+func TestHandleRunParsesInstanceID(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 
-	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
-	req := httptest.NewRequest(http.MethodPost, pathLaunch, body)
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
+	req := httptest.NewRequest(http.MethodPost, pathRun, body)
 	rec := httptest.NewRecorder()
-	srv.handleLaunch(rec, req)
+	srv.handleRun(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	id := srv.instanceID.Load()
 	assert.Equal(t, "vm-abc123", id, "instance ID must be stored on the server for lifecycle metric tags")
 }
 
-// TestHandleLaunchWithForwarderParsesInstanceID verifies that when a forwarder is
-// configured, /launch still decodes the MicroVM instance ID from the request body
+// TestHandleRunWithForwarderParsesInstanceID verifies that when a forwarder is
+// configured, /run still decodes the MicroVM instance ID from the request body
 // before delegating to handleWithForwarder. Without the decode-then-restore fix, the
 // forwarder path consumed r.Body first, so instanceID was never stored and all
 // subsequent lifecycle metrics lost the instance_id tag.
-func TestHandleLaunchWithForwarderParsesInstanceID(t *testing.T) {
+func TestHandleRunWithForwarderParsesInstanceID(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -187,19 +187,19 @@ func TestHandleLaunchWithForwarderParsesInstanceID(t *testing.T) {
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
 
-	body := strings.NewReader(`{"microVmId":"vm-fwd123"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+	body := strings.NewReader(`{"microvmId":"vm-fwd123"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
 	id := srv.instanceID.Load()
 	assert.Equal(t, "vm-fwd123", id, "instance ID must be stored even when forwarder is configured")
 }
 
-func TestHandleLaunchEmptyBodyDoesNotSetInstanceID(t *testing.T) {
+func TestHandleRunEmptyBodyDoesNotSetInstanceID(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 
-	req := httptest.NewRequest(http.MethodPost, pathLaunch, nil)
+	req := httptest.NewRequest(http.MethodPost, pathRun, nil)
 	rec := httptest.NewRecorder()
-	srv.handleLaunch(rec, req)
+	srv.handleRun(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	id := srv.instanceID.Load()
@@ -257,7 +257,7 @@ func TestHandleTerminate_NoForwarder_FlushesAndEmitsMetric_NoSigterm(t *testing.
 	assert.Equal(t, int32(1), drainer.count.Load(), "pending samples must be drained before flush")
 
 	// No SIGTERM should reach the test process within a reasonable window.
-	// 100ms is generous: today's removed code launched the syscall in a
+	// 100ms is generous: today's removed code runed the syscall in a
 	// fire-and-forget goroutine that fires immediately after WriteHeader.
 	select {
 	case sig := <-sigCh:
@@ -276,7 +276,7 @@ func TestEmittedMetricsCarryCurrentTimestamp(t *testing.T) {
 
 	before := float64(time.Now().UnixNano()) / float64(time.Second)
 	rec := httptest.NewRecorder()
-	srv.handleLaunch(rec, httptest.NewRequest(http.MethodPost, pathLaunch, nil))
+	srv.handleRun(rec, httptest.NewRequest(http.MethodPost, pathRun, nil))
 	after := float64(time.Now().UnixNano()) / float64(time.Second)
 
 	emitted := emitter.getEmittedMetrics()
@@ -306,7 +306,7 @@ func TestEmittedMetricsCarryCurrentTimestamp_ForwarderPath(t *testing.T) {
 	}
 
 	before := float64(time.Now().UnixNano()) / float64(time.Second)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, nil))
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
 	after := float64(time.Now().UnixNano()) / float64(time.Second)
 
 	emitted := emitter.getEmittedMetrics()
@@ -324,7 +324,7 @@ func TestRoutes(t *testing.T) {
 	h := newFakeChildHandle()
 	h.alive.Store(true)
 	srv.childHandle = h
-	routes := []string{pathReady, pathValidate, pathLaunch, pathSuspend, pathResume, pathTerminate}
+	routes := []string{pathReady, pathValidate, pathRun, pathSuspend, pathResume, pathTerminate}
 	handler := srv.handler()
 	for _, route := range routes {
 		req := httptest.NewRequest(http.MethodPost, route, nil)
@@ -340,7 +340,7 @@ func TestRoutes(t *testing.T) {
 func TestRoutes_NonPost_Returns405(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	handler := srv.handler()
-	routes := []string{pathReady, pathValidate, pathLaunch, pathSuspend, pathResume, pathTerminate}
+	routes := []string{pathReady, pathValidate, pathRun, pathSuspend, pathResume, pathTerminate}
 	for _, route := range routes {
 		req := httptest.NewRequest(http.MethodGet, route, nil)
 		rec := httptest.NewRecorder()
@@ -401,12 +401,12 @@ func TestHandleReady_WithForwarder_PassesThrough(t *testing.T) {
 	assert.Equal(t, `{"ready":false,"reason":"warming"}`, rec.Body.String())
 }
 
-// /launch with a forwarder configured mirrors the user-app's status code,
-// body, and Content-Type, and emits the launch metric. Replaces the prior
+// /run with a forwarder configured mirrors the user-app's status code,
+// body, and Content-Type, and emits the run metric. Replaces the prior
 // fire-and-forget contract.
-func TestHandleLaunch_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
+func TestHandleRun_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/x-launch")
+		w.Header().Set("Content-Type", "application/x-run")
 		w.WriteHeader(207)
 		_, _ = w.Write([]byte(`{"warmed":true}`))
 	}))
@@ -421,14 +421,14 @@ func TestHandleLaunch_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	srv.handleLaunch(rec, httptest.NewRequest(http.MethodPost, pathLaunch, nil))
+	srv.handleRun(rec, httptest.NewRequest(http.MethodPost, pathRun, nil))
 
 	assert.Equal(t, 207, rec.Code, "must mirror user-app status, not hardcoded 200")
-	assert.Equal(t, "application/x-launch", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "application/x-run", rec.Header().Get("Content-Type"))
 	assert.Equal(t, `{"warmed":true}`, rec.Body.String())
-	assert.Contains(t, emitter.getEmitted(), launchMetricName)
-	// /launch does NOT flush — these are no-op for launch/resume.
-	assert.Equal(t, int32(0), metric.count.Load(), "launch must not flush")
+	assert.Contains(t, emitter.getEmitted(), runMetricName)
+	// /run does NOT flush — these are no-op for run/resume.
+	assert.Equal(t, int32(0), metric.count.Load(), "run must not flush")
 	assert.Equal(t, int32(0), trace.count.Load())
 	assert.Equal(t, int32(0), logs.count.Load())
 }
@@ -890,17 +890,17 @@ func TestNewServerWithForwarderWriteTimeoutCoversForwardBudget(t *testing.T) {
 		"WriteTimeout must cover forwardTimeout+flushTimeout (terminate sequential-flush path)")
 }
 
-// TestInstanceIDTagAppearsInMetricsAfterLaunch verifies that once /launch stores a
+// TestInstanceIDTagAppearsInMetricsAfterRun verifies that once /run stores a
 // MicroVM instance ID, subsequent lifecycle metrics include lambda_microvm_id:<id> as
 // an extra tag. This is the primary tagging path for identifying individual MicroVM
 // instances in lifecycle metrics.
-func TestInstanceIDTagAppearsInMetricsAfterLaunch(t *testing.T) {
+func TestInstanceIDTagAppearsInMetricsAfterRun(t *testing.T) {
 	srv, _, _, _, emitter, _ := newTestServer()
 
-	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
-	// Suspend after launch — the suspend metric must carry the instance_id tag.
+	// Suspend after run — the suspend metric must carry the instance_id tag.
 	srv.handleSuspend(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathSuspend, nil))
 
 	emitted := emitter.getEmittedMetrics()
@@ -971,7 +971,7 @@ func TestMirrorResponse_BodyReadError_DoesNotPanic(t *testing.T) {
 // calls it, to pin the contract of the extracted shared path.
 
 // TestDispatchHook_NoForwarder_WithFlushFalse emits a metric and returns 200
-// without flushing (the launch/resume path).
+// without flushing (the run/resume path).
 func TestDispatchHook_NoForwarder_WithFlushFalse_EmitsMetricReturns200NoFlush(t *testing.T) {
 	srv, metric, trace, logs, emitter, drainer := newTestServer()
 	rec := httptest.NewRecorder()
@@ -1055,58 +1055,58 @@ func withFakeHeartbeat(t *testing.T, srv *Server) (started func() bool, teardown
 	return started, teardown
 }
 
-func TestHandleLaunch_StartsHeartbeat(t *testing.T) {
+func TestHandleRun_StartsHeartbeat(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	started, teardown := withFakeHeartbeat(t, srv)
 	defer teardown()
 
 	rec := httptest.NewRecorder()
-	srv.handleLaunch(rec, httptest.NewRequest(http.MethodPost, pathLaunch, nil))
+	srv.handleRun(rec, httptest.NewRequest(http.MethodPost, pathRun, nil))
 
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.True(t, started(), "/launch must start the heartbeat")
+	assert.True(t, started(), "/run must start the heartbeat")
 }
 
-// /launch must extract the MicroVM ID from the JSON body and apply it to the
+// /run must extract the MicroVM ID from the JSON body and apply it to the
 // heartbeat before Start so the very first emission carries the correct
-// microvm_id. The test calls handleLaunch then inspects the tags that the
+// microvm_id. The test calls handleRun then inspects the tags that the
 // heartbeat would emit on its next tick.
-func TestHandleLaunch_AppliesMicroVMIDFromBody(t *testing.T) {
+func TestHandleRun_AppliesMicroVMIDFromBody(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	_, teardown := withFakeHeartbeat(t, srv)
 	defer teardown()
 
-	body := strings.NewReader(`{"microVmId":"vm-from-body"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+	body := strings.NewReader(`{"microvmId":"vm-from-body"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
 	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:vm-from-body")
 	id := srv.instanceID.Load()
 	assert.Equal(t, "vm-from-body", id)
 }
 
-// When the platform body does not include microVmId, the heartbeat keeps the
+// When the platform body does not include microvmId, the heartbeat keeps the
 // "unknown" placeholder rather than crashing or emitting an empty value.
-func TestHandleLaunch_MissingBodyIDUsesUnknown(t *testing.T) {
+func TestHandleRun_MissingBodyIDUsesUnknown(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	_, teardown := withFakeHeartbeat(t, srv)
 	defer teardown()
 
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, nil))
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
 
 	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:unknown")
 }
 
 // traced_invocations is emitted by the Heartbeat on each tick, not directly by
-// handleLaunch. This test verifies the separation of concerns: the server's own
+// handleRun. This test verifies the separation of concerns: the server's own
 // emitter must never receive traced_invocations. Billing tag correctness is
 // covered in heartbeat_test.go.
-func TestHandleLaunch_ServerDoesNotDirectlyEmitTracedInvocations(t *testing.T) {
+func TestHandleRun_ServerDoesNotDirectlyEmitTracedInvocations(t *testing.T) {
 	srv, _, _, _, emitter, _ := newTestServer()
 	_, teardown := withFakeHeartbeat(t, srv)
 	defer teardown()
 
-	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
 	for _, m := range emitter.getEmittedMetrics() {
 		assert.NotEqual(t, activeInstancesMetricName, m.name,
@@ -1118,7 +1118,7 @@ func TestHandleSuspend_StopsHeartbeat(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	started, teardown := withFakeHeartbeat(t, srv)
 	defer teardown()
-	srv.heartbeat.Start() // simulate post-launch state
+	srv.heartbeat.Start() // simulate post-run state
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -1234,65 +1234,65 @@ func TestSetLogsTagSetter_WiresFields(t *testing.T) {
 	assert.Equal(t, baseTags, srv.baseTags)
 }
 
-// TestHandleLaunch_UpdatesLogTagsWithMicroVMID is the primary feature test:
-// /launch with a microVmId body calls SetLogsTags with baseTags + lambdaMicroVMID + id.
-func TestHandleLaunch_UpdatesLogTagsWithMicroVMID(t *testing.T) {
+// TestHandleRun_UpdatesLogTagsWithMicroVMID is the primary feature test:
+// /run with a microvmId body calls SetLogsTags with baseTags + lambdaMicroVMID + id.
+func TestHandleRun_UpdatesLogTagsWithMicroVMID(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	setter := &mockLogsTagSetter{}
 	srv.SetLogsTagSetter(setter, []string{"env:prod", "region:us-east-1"})
 
-	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
-	require.Equal(t, 1, setter.callCount(), "SetLogsTags must be called exactly once on /launch")
+	require.Equal(t, 1, setter.callCount(), "SetLogsTags must be called exactly once on /run")
 	assert.Equal(t, []string{"env:prod", "region:us-east-1", lambdaMicroVMID + "vm-abc123"}, setter.lastCall())
 }
 
-// TestHandleLaunch_NoMicroVmID_DoesNotUpdateLogTags verifies that when the platform
-// sends /launch with no microVmId, SetLogsTags is not called — the tag pipeline
+// TestHandleRun_NoMicroVmID_DoesNotUpdateLogTags verifies that when the platform
+// sends /run with no microvmId, SetLogsTags is not called — the tag pipeline
 // should not be updated with an unknown value.
-func TestHandleLaunch_NoMicroVmID_DoesNotUpdateLogTags(t *testing.T) {
+func TestHandleRun_NoMicroVmID_DoesNotUpdateLogTags(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	setter := &mockLogsTagSetter{}
 	srv.SetLogsTagSetter(setter, []string{"env:prod"})
 
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, nil))
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
 
-	assert.Equal(t, 0, setter.callCount(), "SetLogsTags must not be called when microVmId is absent")
+	assert.Equal(t, 0, setter.callCount(), "SetLogsTags must not be called when microvmId is absent")
 }
 
-// TestHandleLaunch_NilLogsTagSetter_DoesNotPanic verifies nil-safety: a server
-// constructed without SetLogsTagSetter must not panic when /launch fires.
-func TestHandleLaunch_NilLogsTagSetter_DoesNotPanic(t *testing.T) {
+// TestHandleRun_NilLogsTagSetter_DoesNotPanic verifies nil-safety: a server
+// constructed without SetLogsTagSetter must not panic when /run fires.
+func TestHandleRun_NilLogsTagSetter_DoesNotPanic(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	// logsTagSetter is nil by default
 
-	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
 	assert.NotPanics(t, func() {
-		srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+		srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 	})
 }
 
-// TestHandleLaunch_BaseTagsNotMutated verifies the safe-append contract: each
-// call to handleLaunch produces an independent slice and does not modify the
+// TestHandleRun_BaseTagsNotMutated verifies the safe-append contract: each
+// call to handleRun produces an independent slice and does not modify the
 // baseTags stored on the server. This guards against the naive
 // append(s.baseTags, ...) pattern which can corrupt baseTags when the slice
 // has spare capacity.
-func TestHandleLaunch_BaseTagsNotMutated(t *testing.T) {
+func TestHandleRun_BaseTagsNotMutated(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	setter := &mockLogsTagSetter{}
 	baseTags := []string{"env:prod", "service:foo"}
 	originalBase := slices.Clone(baseTags)
 	srv.SetLogsTagSetter(setter, baseTags)
 
-	body1 := strings.NewReader(`{"microVmId":"vm-first"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body1))
-	assert.Equal(t, originalBase, baseTags, "handleLaunch must not mutate the baseTags slice")
+	body1 := strings.NewReader(`{"microvmId":"vm-first"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body1))
+	assert.Equal(t, originalBase, baseTags, "handleRun must not mutate the baseTags slice")
 
-	// Simulate a second /launch (e.g. resumed from snapshot with a new ID) to
+	// Simulate a second /run (e.g. resumed from snapshot with a new ID) to
 	// confirm each call produces an independent result.
-	body2 := strings.NewReader(`{"microVmId":"vm-second"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body2))
+	body2 := strings.NewReader(`{"microvmId":"vm-second"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body2))
 
 	calls := setter.allCalls()
 	require.Len(t, calls, 2)
@@ -1300,25 +1300,25 @@ func TestHandleLaunch_BaseTagsNotMutated(t *testing.T) {
 	assert.Equal(t, []string{"env:prod", "service:foo", lambdaMicroVMID + "vm-second"}, calls[1])
 }
 
-// TestHandleLaunch_EmptyBaseTags_AppendsMicroVMIDOnly verifies that when the
+// TestHandleRun_EmptyBaseTags_AppendsMicroVMIDOnly verifies that when the
 // server is started with no base tags, the resulting tag slice contains only
 // the microvm_id tag (not an empty leading element).
-func TestHandleLaunch_EmptyBaseTags_AppendsMicroVMIDOnly(t *testing.T) {
+func TestHandleRun_EmptyBaseTags_AppendsMicroVMIDOnly(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	setter := &mockLogsTagSetter{}
 	srv.SetLogsTagSetter(setter, nil)
 
-	body := strings.NewReader(`{"microVmId":"vm-solo"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+	body := strings.NewReader(`{"microvmId":"vm-solo"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
 	require.Equal(t, 1, setter.callCount())
 	assert.Equal(t, []string{lambdaMicroVMID + "vm-solo"}, setter.lastCall())
 }
 
-// TestHandleLaunch_WithForwarder_UpdatesLogTags verifies that the log tag update
-// fires even when a user-app forwarder is configured. handleLaunch parses the
+// TestHandleRun_WithForwarder_UpdatesLogTags verifies that the log tag update
+// fires even when a user-app forwarder is configured. handleRun parses the
 // body and calls the setter before delegating to handleWithForwarder.
-func TestHandleLaunch_WithForwarder_UpdatesLogTags(t *testing.T) {
+func TestHandleRun_WithForwarder_UpdatesLogTags(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -1334,8 +1334,8 @@ func TestHandleLaunch_WithForwarder_UpdatesLogTags(t *testing.T) {
 	setter := &mockLogsTagSetter{}
 	srv.SetLogsTagSetter(setter, []string{"env:staging"})
 
-	body := strings.NewReader(`{"microVmId":"vm-fwd456"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+	body := strings.NewReader(`{"microvmId":"vm-fwd456"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
 	require.Equal(t, 1, setter.callCount(), "SetLogsTags must be called even when forwarder is configured")
 	assert.Equal(t, []string{"env:staging", lambdaMicroVMID + "vm-fwd456"}, setter.lastCall())
@@ -1396,72 +1396,72 @@ func TestSetTraceTagSetter_WiresFields(t *testing.T) {
 	assert.Equal(t, base, srv.baseTraceTags)
 }
 
-// TestHandleLaunch_UpdatesTraceTagsWithMicroVMID is the primary feature test:
-// /launch with a microVmId body calls SetTraceTags with baseTraceTags + lambda_microvm_id.
-func TestHandleLaunch_UpdatesTraceTagsWithMicroVMID(t *testing.T) {
+// TestHandleRun_UpdatesTraceTagsWithMicroVMID is the primary feature test:
+// /run with a microvmId body calls SetTraceTags with baseTraceTags + lambda_microvm_id.
+func TestHandleRun_UpdatesTraceTagsWithMicroVMID(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	setter := &mockTraceTagSetter{}
 	srv.SetTraceTagSetter(setter, map[string]string{"env": "prod", "region": "us-east-1"})
 
-	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
-	require.Equal(t, 1, setter.callCount(), "SetTraceTags must be called exactly once on /launch")
+	require.Equal(t, 1, setter.callCount(), "SetTraceTags must be called exactly once on /run")
 	got := setter.lastCall()
 	assert.Equal(t, "vm-abc123", got["lambda_microvm_id"])
 	assert.Equal(t, "prod", got["env"])
 	assert.Equal(t, "us-east-1", got["region"])
 }
 
-// TestHandleLaunch_NoMicroVmID_DoesNotUpdateTraceTags verifies that when the
-// platform sends /launch with no microVmId, SetTraceTags is not called.
-func TestHandleLaunch_NoMicroVmID_DoesNotUpdateTraceTags(t *testing.T) {
+// TestHandleRun_NoMicroVmID_DoesNotUpdateTraceTags verifies that when the
+// platform sends /run with no microvmId, SetTraceTags is not called.
+func TestHandleRun_NoMicroVmID_DoesNotUpdateTraceTags(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	setter := &mockTraceTagSetter{}
 	srv.SetTraceTagSetter(setter, map[string]string{"env": "prod"})
 
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, nil))
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
 
-	assert.Equal(t, 0, setter.callCount(), "SetTraceTags must not be called when microVmId is absent")
+	assert.Equal(t, 0, setter.callCount(), "SetTraceTags must not be called when microvmId is absent")
 }
 
-// TestHandleLaunch_NilTraceTagSetter_DoesNotPanic verifies nil-safety: a server
-// constructed without SetTraceTagSetter must not panic when /launch fires.
-func TestHandleLaunch_NilTraceTagSetter_DoesNotPanic(t *testing.T) {
+// TestHandleRun_NilTraceTagSetter_DoesNotPanic verifies nil-safety: a server
+// constructed without SetTraceTagSetter must not panic when /run fires.
+func TestHandleRun_NilTraceTagSetter_DoesNotPanic(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 
-	body := strings.NewReader(`{"microVmId":"vm-abc123"}`)
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
 	assert.NotPanics(t, func() {
-		srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+		srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 	})
 }
 
-// TestHandleLaunch_BaseTraceTagsNotMutated verifies the safe-copy contract: each
-// /launch call produces an independent map and does not modify baseTraceTags.
-func TestHandleLaunch_BaseTraceTagsNotMutated(t *testing.T) {
+// TestHandleRun_BaseTraceTagsNotMutated verifies the safe-copy contract: each
+// /run call produces an independent map and does not modify baseTraceTags.
+func TestHandleRun_BaseTraceTagsNotMutated(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	setter := &mockTraceTagSetter{}
 	base := map[string]string{"env": "prod"}
 	srv.SetTraceTagSetter(setter, base)
 
-	body1 := strings.NewReader(`{"microVmId":"vm-first"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body1))
+	body1 := strings.NewReader(`{"microvmId":"vm-first"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body1))
 
-	assert.Equal(t, map[string]string{"env": "prod"}, base, "handleLaunch must not mutate baseTraceTags")
+	assert.Equal(t, map[string]string{"env": "prod"}, base, "handleRun must not mutate baseTraceTags")
 	assert.Equal(t, "vm-first", setter.lastCall()["lambda_microvm_id"])
 
-	// A second /launch (e.g. resume from snapshot with new ID) must produce an
+	// A second /run (e.g. resume from snapshot with new ID) must produce an
 	// independent result without leaking the first ID into baseTraceTags.
-	body2 := strings.NewReader(`{"microVmId":"vm-second"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body2))
+	body2 := strings.NewReader(`{"microvmId":"vm-second"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body2))
 
-	assert.Equal(t, map[string]string{"env": "prod"}, base, "baseTraceTags must still be unmodified after second /launch")
+	assert.Equal(t, map[string]string{"env": "prod"}, base, "baseTraceTags must still be unmodified after second /run")
 	assert.Equal(t, "vm-second", setter.lastCall()["lambda_microvm_id"])
 }
 
-// TestHandleLaunch_WithForwarder_UpdatesTraceTags verifies that the trace tag
+// TestHandleRun_WithForwarder_UpdatesTraceTags verifies that the trace tag
 // update fires even when a user-app forwarder is configured.
-func TestHandleLaunch_WithForwarder_UpdatesTraceTags(t *testing.T) {
+func TestHandleRun_WithForwarder_UpdatesTraceTags(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -1477,8 +1477,8 @@ func TestHandleLaunch_WithForwarder_UpdatesTraceTags(t *testing.T) {
 	setter := &mockTraceTagSetter{}
 	srv.SetTraceTagSetter(setter, map[string]string{"env": "staging"})
 
-	body := strings.NewReader(`{"microVmId":"vm-fwd789"}`)
-	srv.handleLaunch(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathLaunch, body))
+	body := strings.NewReader(`{"microvmId":"vm-fwd789"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
 	require.Equal(t, 1, setter.callCount(), "SetTraceTags must be called even when forwarder is configured")
 	assert.Equal(t, "vm-fwd789", setter.lastCall()["lambda_microvm_id"])

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -154,7 +154,7 @@ func setup(secretComp secrets.Component, delegatedAuthComp delegatedauth.Compone
 	// Note: we do not modify tags for the LogsAgent.
 	logsAgent := serverlessInitLog.SetupLogAgent(agentLogConfig, tagConfig.Tags, tagger, compression, hostname, origin)
 	// Snapshot the startup log tags so the lifecycle server can append lambda_microvm_id
-	// at /launch without losing the base set. Must be computed after SetupLogAgent
+	// at /run without losing the base set. Must be computed after SetupLogAgent
 	// since MapToArray normalises the same map that SetupLogAgent passes to SetLogsTags.
 	logTagsBase := serverlessTag.MapToArray(tagConfig.Tags)
 

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -170,7 +170,7 @@ func TestLogTagsBaseComputedFromTagConfigTags(t *testing.T) {
 
 // TestBaseTraceTagsComputedFromTagConfigTags verifies that traceTags —
 // passed as BaseTraceTags to LifecycleContext — contains all tags from DD_TAGS
-// so that the lifecycle server can extend the map with lambda_microvm_id at /launch
+// so that the lifecycle server can extend the map with lambda_microvm_id at /run
 // without losing any startup tags.
 func TestBaseTraceTagsComputedFromTagConfigTags(t *testing.T) {
 	configmock.New(t)


### PR DESCRIPTION
As [PR 52746](https://github.com/DataDog/datadog-agent/pull/52746) was closed accidentally while it could not be reopened, I had to open this one to preserve the work.

### What does this PR do?

Aligns the serverless-init MicroVM lifecycle hook server with the **GA** AWS Lambda MicroVMs contract (the code was written against the beta API):

- **Hook base path** `…/runtime/beta/v1/` → **`…/runtime/v1/`** (drops the `beta/` segment).
- **Renames the post-snapshot run hook** `/launch` → **`/run`** across routes, the handler (`handleLaunch`→`handleRun`), the emitted metric (`aws.lambda.enhanced.microvm.launch` → **`…microvm.run`**), and the JSON body field (`microVmId` → **`microvmId`**).\n- **Corrects `/validate` and `/ready` comments** to their actual build-time semantics — both are image-build hooks, retried on 503 until a 200 or the configured timeout, and `/validate` is **not** part of a production instance's run/resume lifecycle. The `validate` metric is kept, with a `TODO` to revisit whether it carries enough value (it only fires on the ephemeral build-time test MicroVM).
- Updates the `docs/dev/microvm-*` developer docs and unit tests to match.

### Motivation

The GA reference ([aws/agent-toolkit-for-aws](https://github.com/aws/agent-toolkit-for-aws/tree/847f477649252b98f8fb828bbfeaf109b57b8cac/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references)) changed the hook path prefix (`beta/v1` → `v1`) and renamed `/launch` → `/run`. Against a GA platform, the beta routes would **404 on every hook** — breaking build-time `/ready`, lifecycle metrics, telemetry flush on suspend/terminate, and user-app pass-through. The `/launch`→`/run` rename specifically restores instance-ID tagging, heartbeat start, and log/trace tag propagation (all wired in the run handler).

### Describe how you validated your changes

- `dda inv test --targets=./cmd/serverless-init/lifecycle` — **134/134 pass**.
- `dda inv test --targets=./cmd/serverless-init/cloudservice` — green (also fixed 4 pre-existing `resource_type` assertions that expected `lambda_microvm` instead of the actual constant `lambdamicrovm`).
- `gofmt` clean on all changed Go files.
- Cross-checked every path/method/timeout/status-code against the pinned GA reference.

### Additional Notes

- Stacked on `tianning.li/21-sequential-flush-and-bounded-mirror-response` (PR base is that branch, not `main`).
- **Open question (tracked via `TODO(microvm-validate-metric)`):** whether to keep the build-time `validate` metric.
- Out of scope / untouched: pre-existing gofmt nits at `microvm.go:24` and `main_test.go:188`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🔁 **Mirror of internal PR:** https://github.com/DataDog/datadog-agent-internal/pull/48