### PR TITLE
Fix `pclntab_test.go` to make it use specified toolchains

### DIFF
--- a/comp/host-profiler/symboluploader/pclntab/pclntab_test.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab_test.go
@@ -29,9 +29,6 @@ func getGoToolChain(goMinorVersion int) string {
 	if goMinorVersion >= 21 {
 		suffix = ".0"
 	}
-	if goMinorVersion == 26 {
-		suffix = "rc2"
-	}
 	return fmt.Sprintf("GOTOOLCHAIN=go1.%v%v", goMinorVersion, suffix)
 }
 

--- a/comp/host-profiler/symboluploader/pclntab/pclntab_test.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab_test.go
@@ -183,7 +183,7 @@ func TestGoPCLnTabExtraction(t *testing.T) {
 						cmd := exec.CommandContext(t.Context(), "go", buildArgs...) // #nosec G204
 						cmd.Args = append(cmd.Args, srcFile)
 						cmd.Dir = testDataDir
-						cmd.Env = append(cmd.Environ(), getGoToolChain(goMinorVersion), "GO111MODULE=off")
+						cmd.Env = append(cmd.Environ(), getGoToolChain(goMinorVersion), "GOWORK=off")
 						out, err := cmd.CombinedOutput()
 						require.NoError(t, err, "failed to build test binary with `%v`: %s\n%s", cmd.String(), err, out)
 


### PR DESCRIPTION
### What does this PR do?

- removes `GOMODULE1111=off` from command builder for `pclntab_test.go`
- removes `rc2` suffix for go26

### Motivation

- when go modules are disabled, go uses `GOPATH` and doesn't care for `GOTOOLCHAIN` since it is a module override.
- add `GOWORK=off` to force go to use ignore go.work in the repo


### Describe how you validated your changes

Before these changes, running the testsuite against `go1.27rc1`, which has breaking changes in its `moduledata` struct, would fail for unrelated versions since we were never building binaries using the specified `GOTOOLCHAIN` but using the toolchain the tests were ran with.

### Additional Notes

CI jobs will now need to download the toolchain for each version we're testing if not present in its cache.