### PR TITLE
Correct directory permissions of RPM builds

### DIFF
--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -286,17 +286,31 @@ module Omnibus
   # those synthetic parents are emitted as %dir entries, so our RPM starts
   # owning distro-owned directories like /usr/lib/systemd or /lib/systemd/system.
   #
-  # Keep explicit extra_package_file entries, but drop only the parent
-  # directories that were created to stage external extra_package_file paths.
+  # Keep explicit extra_package_file entries, with metadata overrides for shared
+  # external directories that must match other Datadog RPMs, but drop only the
+  # parent directories created to stage external extra_package_file paths.
   module PackagerRPMExtraPackageParentFilter
+    SHARED_EXTERNAL_DIRECTORY_ATTRIBUTES = {
+      "/var/log/datadog" => "0755,root,root",
+    }.freeze
+
     def build_filepath(path, debug = false)
       filepath = "/" + path.gsub("#{build_dir(debug)}/", "")
+      shared_directory_entry = shared_external_directory_entry(path, filepath)
+      return shared_directory_entry if shared_directory_entry
       return "" if extra_package_parent_directory?(filepath)
 
       super
     end
 
     private
+
+    def shared_external_directory_entry(path, filepath)
+      attributes = SHARED_EXTERNAL_DIRECTORY_ATTRIBUTES[File.expand_path(filepath)]
+      return unless attributes && File.directory?(path)
+
+      "%dir %attr(#{attributes}) #{rpm_safe(filepath)}"
+    end
 
     def extra_package_parent_directory?(filepath)
       extra_package_parent_directories.include?(File.expand_path(filepath))


### PR DESCRIPTION
### Motivation

The build image now uses shared-write build directories so developer environments and CI can build as non-root without creating host-owned permission problems. However, legacy Omnibus packages some files directly from the build filesystem, and RPM records file and directory metadata from the package manifest. As a result, build-only permissions such as group-write could leak into RPM metadata.

This appeared when installing `datadog-agent` with `datadog-fips-proxy` in the same RPM transaction. Both packages declare `/var/log/datadog`: the Agent RPM had changed that directory’s package metadata from `0755 root root` to `0775 root root`, while `datadog-fips-proxy` declared different metadata. RPM rejects co-owned paths when metadata conflicts, so the transaction failed before any install scripts or runtime permission repair could run.

The fix is intentionally scoped to Omnibus RPM metadata generation:

- Synthetic parent directories created by Omnibus staging, such as `/usr/lib/systemd`, are filtered so our RPMs do not incorrectly own distro-managed directories.
- The explicit shared directory `/var/log/datadog` is emitted with stable RPM metadata: `0755 root root`.
- The build image behavior remains unchanged, preserving non-root developer and CI build support.
- Runtime install scripts/Fleet [logic](https://github.com/DataDog/datadog-agent/blob/bdfab4957b81bd960f7bbbac1cc0e46445004d2a/pkg/fleet/installer/packages/datadog_agent_linux.go#L71-L112) remain responsible for final runtime ownership and mode, such as setting `/var/log/datadog` to the expected `dd-agent:dd-agent` runtime state.