### PR TITLE
[CWS-6655] Only send activity-dumps to MRF endpoint under active failover

### DIFF
--- a/pkg/security/security_profile/storage/backend/BUILD.bazel
+++ b/pkg/security/security_profile/storage/backend/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "backend",
@@ -10,12 +10,27 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/logs/agent/config",
+        "//pkg/config/model",
         "//pkg/config/setup",
         "//pkg/security/metrics",
         "//pkg/security/seclog",
         "//pkg/security/utils",
         "//pkg/util/http",
         "@com_github_datadog_datadog_go_v5//statsd",
+        "@org_uber_go_atomic//:atomic",
+    ],
+)
+
+go_test(
+    name = "backend_test",
+    srcs = ["forwarder_test.go"],
+    embed = [":backend"],
+    gotags = ["test"],
+    deps = [
+        "//comp/logs/agent/config",
+        "//pkg/config/mock",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/pkg/security/security_profile/storage/backend/forwarder.go
+++ b/pkg/security/security_profile/storage/backend/forwarder.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/atomic"
 
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -140,7 +141,18 @@ func (backend *ActivityDumpRemoteBackend) HandleActivityDump(imageName string, i
 		return fmt.Errorf("couldn't build request: %w", err)
 	}
 
+	// The Multi-Region Failover (MRF) endpoint must only receive dumps while a failover is
+	// actually active. Activity dumps are shipped over the EvP (logs) intake, so they honor the
+	// `multi_region_failover.failover_logs` switch that Remote Configuration toggles during a
+	// failover. Outside of a failover there is no secdump MRF intake, so posting to it fails with
+	// a 404 on every dump; skip it unless the failover is on.
+	mrfActive := mrfFailoverActive(pkgconfigsetup.Datadog())
+
 	for _, endpoint := range backend.endpoints.Endpoints {
+		if endpoint.IsMRF && !mrfActive {
+			continue
+		}
+
 		url := utils.GetEndpointURL(endpoint, "api/v2/secdump")
 
 		if err := backend.sendToEndpoint(url, endpoint.GetAPIKey(), writer, body); err != nil {
@@ -151,6 +163,14 @@ func (backend *ActivityDumpRemoteBackend) HandleActivityDump(imageName string, i
 	}
 
 	return nil
+}
+
+// mrfFailoverActive reports whether a Multi-Region Failover is currently active for the EvP/logs
+// intake. Activity dumps ride the EvP (logs) intake track, so they follow the
+// `multi_region_failover.failover_logs` switch toggled by Remote Configuration — mirroring
+// comp/logs-library/sender.(*DestinationSender).canSend.
+func mrfFailoverActive(cfg pkgconfigmodel.Reader) bool {
+	return cfg.GetBool("multi_region_failover.enabled") && cfg.GetBool("multi_region_failover.failover_logs")
 }
 
 // SendTelemetry sends telemetry for the current storage

--- a/pkg/security/security_profile/storage/backend/forwarder_test.go
+++ b/pkg/security/security_profile/storage/backend/forwarder_test.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package backend holds files related to forwarder backends for security profiles
+package backend
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+)
+
+func TestMRFFailoverActive(t *testing.T) {
+	tests := []struct {
+		name         string
+		enabled      bool
+		failoverLogs bool
+		want         bool
+	}{
+		{name: "mrf disabled", enabled: false, failoverLogs: false, want: false},
+		{name: "enabled but no active failover", enabled: true, failoverLogs: false, want: false},
+		{name: "failover flag set but mrf disabled", enabled: false, failoverLogs: true, want: false},
+		{name: "enabled and failing over", enabled: true, failoverLogs: true, want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := configmock.New(t)
+			cfg.SetInTest("multi_region_failover.enabled", tc.enabled)
+			cfg.SetInTest("multi_region_failover.failover_logs", tc.failoverLogs)
+
+			assert.Equal(t, tc.want, mrfFailoverActive(cfg))
+		})
+	}
+}
+
+// newCountingServer returns an httptest server that accepts every request (202 Accepted, the
+// status sendToEndpoint treats as success) and increments hits on each call.
+func newCountingServer(hits *atomic.Int64) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Inc()
+		w.WriteHeader(http.StatusAccepted)
+	}))
+}
+
+// endpointForServer builds a plain-HTTP Endpoint targeting the given test server so that
+// GetEndpointURL produces an http:// URL matching httptest.
+func endpointForServer(t *testing.T, srv *httptest.Server, apiKeyPath string) logsconfig.Endpoint {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	host, portStr, err := net.SplitHostPort(u.Host)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+	return logsconfig.NewEndpoint("api-key", apiKeyPath, host, port, "", false /* useSSL */)
+}
+
+func TestHandleActivityDumpGatesMRFEndpointOnFailover(t *testing.T) {
+	primaryHits := atomic.NewInt64(0)
+	mrfHits := atomic.NewInt64(0)
+
+	primarySrv := newCountingServer(primaryHits)
+	defer primarySrv.Close()
+	mrfSrv := newCountingServer(mrfHits)
+	defer mrfSrv.Close()
+
+	primaryEp := endpointForServer(t, primarySrv, "api_key")
+	mrfEp := endpointForServer(t, mrfSrv, "multi_region_failover.api_key")
+	mrfEp.IsMRF = true
+
+	backend := &ActivityDumpRemoteBackend{
+		tooLargeEntities: atomic.NewUint64(0),
+		client:           primarySrv.Client(),
+		endpoints:        logsconfig.NewEndpoints(primaryEp, []logsconfig.Endpoint{mrfEp}, false, true),
+	}
+
+	cfg := configmock.New(t)
+	cfg.SetInTest("multi_region_failover.enabled", true)
+
+	// No active failover: the MRF endpoint must be skipped while the primary still receives the dump.
+	cfg.SetInTest("multi_region_failover.failover_logs", false)
+	require.NoError(t, backend.HandleActivityDump("image", "tag", []byte(`{}`), []byte("dump")))
+	assert.Equal(t, int64(1), primaryHits.Load(), "primary endpoint should always receive the dump")
+	assert.Equal(t, int64(0), mrfHits.Load(), "MRF endpoint must not be used outside of an active failover")
+
+	// Remote Configuration switches the failover on: the MRF endpoint now receives the dump too.
+	cfg.SetInTest("multi_region_failover.failover_logs", true)
+	require.NoError(t, backend.HandleActivityDump("image", "tag", []byte(`{}`), []byte("dump")))
+	assert.Equal(t, int64(2), primaryHits.Load())
+	assert.Equal(t, int64(1), mrfHits.Load(), "MRF endpoint should receive the dump while failing over")
+}


### PR DESCRIPTION
### What does this PR do?

Sends CWS activity dumps to the Multi-Region Failover endpoint only while a logs failover is active, instead of on every dump.

### Motivation

With MRF enabled, every activity dump was sent to the failover endpoint even when no failover was active, and each of those requests returned an HTTP 404

### Describe how you validated your changes

New unit test.

### Additional Notes
