### PR TITLE
(clusteragent): Cluster Check Rebalancing Stickiness

### DIFF
--- a/CHANGELOG-DCA.rst
+++ b/CHANGELOG-DCA.rst
@@ -16,20 +16,6 @@ Released on: 2026-06-24
 Pinned to datadog-agent v7.80.3: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7803>`_.
 
 
-.. _Release Notes_7.80.3_Enhancement Notes:
-
-Enhancement Notes
------------------
-
-- Cluster check stickiness is now enabled by default. When assigning checks to
-  runners, the dispatcher biases placement toward the runner where a check
-  previously ran, reducing unnecessary check migrations. The behavior can be
-  tuned or disabled via ``cluster_checks.stickiness_enabled``,
-  ``cluster_checks.stickiness_factor``,
-  ``cluster_checks.stickiness_upper_limit``, and
-  ``cluster_checks.stickiness_lower_limit``.
-
-
 .. _Release Notes_7.80.2:
 
 7.80.2

--- a/CHANGELOG-DCA.rst
+++ b/CHANGELOG-DCA.rst
@@ -16,6 +16,20 @@ Released on: 2026-06-24
 Pinned to datadog-agent v7.80.3: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7803>`_.
 
 
+.. _Release Notes_7.80.3_Enhancement Notes:
+
+Enhancement Notes
+-----------------
+
+- Cluster check stickiness is now enabled by default. When assigning checks to
+  runners, the dispatcher biases placement toward the runner where a check
+  previously ran, reducing unnecessary check migrations. The behavior can be
+  tuned or disabled via ``cluster_checks.stickiness_enabled``,
+  ``cluster_checks.stickiness_factor``,
+  ``cluster_checks.stickiness_upper_limit``, and
+  ``cluster_checks.stickiness_lower_limit``.
+
+
 .. _Release Notes_7.80.2:
 
 7.80.2

--- a/pkg/clusteragent/clusterchecks/checks_distribution.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution.go
@@ -44,14 +44,15 @@ func (ns RunnerStatus) utilization() float64 {
 // configsDistribution represents the placement of cluster check configs
 // across the runners of a cluster. Each entry is keyed by config digest.
 type configsDistribution struct {
-	Configs           map[string]*ConfigStatus
-	Runners           map[string]*RunnerStatus
-	stickinessEnabled bool
-	stickinessFactor  float64
-	stickinessLimit   float64
+	Configs              map[string]*ConfigStatus
+	Runners              map[string]*RunnerStatus
+	stickinessEnabled    bool
+	stickinessFactor     float64
+	stickinessUpperLimit float64
+	stickinessLowerLimit float64
 }
 
-func newConfigsDistribution(workersPerRunner map[string]int, stickinessEnabled bool, stickinessFactor float64, stickinessLimit float64) configsDistribution {
+func newConfigsDistribution(workersPerRunner map[string]int, stickinessEnabled bool, stickinessFactor float64, stickinessUpperLimit float64, stickinessLowerLimit float64) configsDistribution {
 	runners := map[string]*RunnerStatus{}
 	for runnerName, runnerWorkers := range workersPerRunner {
 		runners[runnerName] = &RunnerStatus{
@@ -62,11 +63,12 @@ func newConfigsDistribution(workersPerRunner map[string]int, stickinessEnabled b
 	}
 
 	return configsDistribution{
-		Configs:           map[string]*ConfigStatus{},
-		Runners:           runners,
-		stickinessEnabled: stickinessEnabled,
-		stickinessFactor:  stickinessFactor,
-		stickinessLimit:   stickinessLimit,
+		Configs:              map[string]*ConfigStatus{},
+		Runners:              runners,
+		stickinessEnabled:    stickinessEnabled,
+		stickinessFactor:     stickinessFactor,
+		stickinessUpperLimit: stickinessUpperLimit,
+		stickinessLowerLimit: stickinessLowerLimit,
 	}
 }
 
@@ -89,7 +91,8 @@ func (distribution *configsDistribution) leastBusyRunner(preferredRunner string,
 		runnerNumChecks := runnerStatus.NumChecks
 
 		if distribution.stickinessEnabled && runnerName == preferredRunner {
-			runnerUtilization -= min(workersNeeded*distribution.stickinessFactor, distribution.stickinessLimit)
+			bias := max(min(workersNeeded*distribution.stickinessFactor, distribution.stickinessUpperLimit), distribution.stickinessLowerLimit)
+			runnerUtilization -= bias
 		}
 
 		selectRunner := (leastBusyRunner == "") ||

--- a/pkg/clusteragent/clusterchecks/checks_distribution_test.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution_test.go
@@ -147,7 +147,7 @@ func TestAddToLeastBusy(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			distribution := newConfigsDistribution(test.existingRunners, false, 4.0, 1.0)
+			distribution := newConfigsDistribution(test.existingRunners, false, 4.0, 1.0, 0.05)
 
 			for checkID, checkStatus := range test.existingChecks {
 				distribution.addConfig(checkID, checkStatus.CheckName, checkStatus.WorkersNeeded, checkStatus.Runner, false)
@@ -163,7 +163,7 @@ func TestAddToLeastBusy(t *testing.T) {
 func TestAddCheck(t *testing.T) {
 	distribution := newConfigsDistribution(map[string]int{
 		"runner1": 4,
-	}, false, 4.0, 1.0)
+	}, false, 4.0, 1.0, 0.05)
 
 	distribution.addConfig("check1", "check1", 3, "runner1", false)
 	assert.Equal(t, "runner1", distribution.runnerForConfig("check1"))
@@ -176,7 +176,7 @@ func TestChecksSortedByWorkersNeeded(t *testing.T) {
 		"runner1": 4,
 		"runner2": 4,
 		"runner3": 4,
-	}, false, 4.0, 1.0)
+	}, false, 4.0, 1.0, 0.05)
 
 	distribution.addConfig("check1", "check1", 3, "runner1", false)
 	distribution.addConfig("check2", "check2", 1, "runner1", false)
@@ -189,7 +189,7 @@ func TestChecksSortedByWorkersNeeded(t *testing.T) {
 	distribution = newConfigsDistribution(map[string]int{
 		"runner1": 4,
 		"runner2": 4,
-	}, false, 4.0, 1.0)
+	}, false, 4.0, 1.0, 0.05)
 
 	distribution.addConfig("check_B", "check_B", 1, "runner1", false)
 	distribution.addConfig("check_A", "check_A", 1, "runner2", false)
@@ -203,7 +203,7 @@ func TestNumEmptyRunners(t *testing.T) {
 	distribution := newConfigsDistribution(map[string]int{
 		"runner1": 4,
 		"runner2": 2,
-	}, false, 4.0, 1.0)
+	}, false, 4.0, 1.0, 0.05)
 	assert.Equal(t, 2, distribution.numEmptyRunners())
 
 	distribution.addConfig("check1", "check1", 1, "runner1", false)
@@ -217,7 +217,7 @@ func TestNumRunnersWithHighUtilization(t *testing.T) {
 	distribution := newConfigsDistribution(map[string]int{
 		"runner1": 4,
 		"runner2": 2,
-	}, false, 4.0, 1.0)
+	}, false, 4.0, 1.0, 0.05)
 	assert.Equal(t, 0, distribution.numRunnersWithHighUtilization())
 
 	distribution.addConfig("check1", "check1", 1, "runner1", false) // runner 1 at 25%
@@ -234,7 +234,7 @@ func TestAddConfigConflictTransfersAccumulatedWeight(t *testing.T) {
 	distribution := newConfigsDistribution(map[string]int{
 		"runner1": 4,
 		"runner2": 4,
-	}, false, 4.0, 1.0)
+	}, false, 4.0, 1.0, 0.05)
 
 	// Two instances of digestA are processed on runner1 first.
 	distribution.addConfig("digestA", "configA", 2.0, "runner1", false)
@@ -259,7 +259,7 @@ func TestUtilizationStdDev(t *testing.T) {
 		"runner1": 4,
 		"runner2": 4,
 		"runner3": 4,
-	}, false, 4.0, 1.0)
+	}, false, 4.0, 1.0, 0.05)
 	distribution.addConfig("check1", "check1", 1, "runner1", false)
 	distribution.addConfig("check2", "check2", 2, "runner1", false)
 	distribution.addConfig("check3", "check3", 2, "runner2", false)

--- a/pkg/clusteragent/clusterchecks/dispatcher_isolate.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_isolate.go
@@ -46,7 +46,7 @@ func (d *dispatcher) isolateCheck(isolateCheckID string) types.IsolateResponse {
 		}
 	}
 
-	proposedDistribution := newConfigsDistribution(currentDistribution.runnerWorkers(), pkgconfigsetup.Datadog().GetBool("cluster_checks.experimental_stickiness_enabled"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.experimental_stickiness_factor"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.experimental_stickiness_limit"))
+	proposedDistribution := newConfigsDistribution(currentDistribution.runnerWorkers(), pkgconfigsetup.Datadog().GetBool("cluster_checks.stickiness_enabled"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.stickiness_factor"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.stickiness_upper_limit"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.stickiness_lower_limit"))
 
 	for _, digest := range currentDistribution.configsSortedByWorkersNeeded() {
 		if digest == isolateDigest {

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -385,7 +385,7 @@ func (d *dispatcher) rebalanceUsingUtilization(force bool) []types.RebalanceResp
 	}()
 
 	currentConfigsDistribution := d.currentDistribution()
-	proposedDistribution := newConfigsDistribution(currentConfigsDistribution.runnerWorkers(), pkgconfigsetup.Datadog().GetBool("cluster_checks.experimental_stickiness_enabled"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.experimental_stickiness_factor"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.experimental_stickiness_limit"))
+	proposedDistribution := newConfigsDistribution(currentConfigsDistribution.runnerWorkers(), pkgconfigsetup.Datadog().GetBool("cluster_checks.stickiness_enabled"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.stickiness_factor"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.stickiness_upper_limit"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.stickiness_lower_limit"))
 
 	// Place configs in proposed: pinned ones stay on their current runner,
 	for digest, config := range currentConfigsDistribution.Configs {
@@ -452,7 +452,7 @@ func (d *dispatcher) currentDistribution() configsDistribution {
 		currentWorkersPerRunner[nodeName] = nodeInfo.workers
 	}
 
-	distribution := newConfigsDistribution(currentWorkersPerRunner, pkgconfigsetup.Datadog().GetBool("cluster_checks.experimental_stickiness_enabled"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.experimental_stickiness_factor"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.experimental_stickiness_limit"))
+	distribution := newConfigsDistribution(currentWorkersPerRunner, pkgconfigsetup.Datadog().GetBool("cluster_checks.stickiness_enabled"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.stickiness_factor"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.stickiness_upper_limit"), pkgconfigsetup.Datadog().GetFloat64("cluster_checks.stickiness_lower_limit"))
 
 	for nodeName, nodeStoreInfo := range d.store.nodes {
 		nodeStoreInfo.RLock()

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -2029,23 +2029,23 @@ func TestRebalanceIsWorthIt(t *testing.T) {
 
 	// The proposed solution is worth it if it leaves less unused runners
 
-	currentDistribution := newConfigsDistribution(workersPerRunner, false, 4.0, 1.0)
+	currentDistribution := newConfigsDistribution(workersPerRunner, false, 4.0, 1.0, 0.05)
 	currentDistribution.addConfig("check1", "check1", 1, "runner1", false)
 	currentDistribution.addConfig("check2", "check2", 1, "runner1", false)
 
-	proposedDistribution := newConfigsDistribution(workersPerRunner, false, 4.0, 1.0)
+	proposedDistribution := newConfigsDistribution(workersPerRunner, false, 4.0, 1.0, 0.05)
 	proposedDistribution.addConfig("check1", "check1", 1, "runner1", false)
 	proposedDistribution.addConfig("check2", "check2", 1, "runner2", false)
 
 	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10))
 
 	// The proposed	solution is worth it if it has fewer runners with a high utilization
-	currentDistribution = newConfigsDistribution(workersPerRunner, false, 4.0, 1.0)
+	currentDistribution = newConfigsDistribution(workersPerRunner, false, 4.0, 1.0, 0.05)
 	currentDistribution.addConfig("check1", "check1", 1, "runner1", false)
 	currentDistribution.addConfig("check2", "check2", 1, "runner1", false)
 	currentDistribution.addConfig("check3", "check3", 1, "runner1", false)
 
-	proposedDistribution = newConfigsDistribution(workersPerRunner, false, 4.0, 1.0)
+	proposedDistribution = newConfigsDistribution(workersPerRunner, false, 4.0, 1.0, 0.05)
 	proposedDistribution.addConfig("check1", "check1", 1, "runner1", false)
 	proposedDistribution.addConfig("check2", "check2", 1, "runner2", false)
 	proposedDistribution.addConfig("check3", "check3", 1, "runner3", false)

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -19,6 +19,7 @@ import (
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -1570,6 +1571,7 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 	//   other tests specific for the configsDistribution struct that test more
 	//   complex scenarios.
 
+	configmock.New(t).SetInTest("cluster_checks.stickiness_enabled", false)
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	testDispatcher := newDispatcher(fakeTagger)
 
@@ -1666,6 +1668,7 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 // configs are stacked on node1 alongside a lightweight config on node2, the
 // utilization rebalancer moves one heavy config to node2, spreading the load.
 func TestRebalanceUsingUtilization_GroupsAndSpreadsMultiInstanceConfigs(t *testing.T) {
+	configmock.New(t).SetInTest("cluster_checks.stickiness_enabled", false)
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	testDispatcher := newDispatcher(fakeTagger)
 
@@ -1866,6 +1869,7 @@ func TestRebalanceUsingUtilization_PinsChecksWithoutExecutionTime(t *testing.T) 
 // first while both runners still look empty, which anchors it to its current
 // (overloaded) runner.
 func TestRebalanceUsingUtilization_PinnedLoadAccountedBeforeGreedyPlacement(t *testing.T) {
+	configmock.New(t).SetInTest("cluster_checks.stickiness_enabled", false)
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	testDispatcher := newDispatcher(fakeTagger)
 

--- a/pkg/config/schema/yaml/cluster_checks.yaml
+++ b/pkg/config/schema/yaml/cluster_checks.yaml
@@ -114,28 +114,32 @@ properties:
     default: []
     items:
       type: string
-  experimental_stickiness_enabled:
+  stickiness_enabled:
     node_type: setting
     type: boolean
-    default: false
-    comment: Experimental. Subject to change. Biases check placement toward the runner
-      where a check previously ran.
-  experimental_stickiness_factor:
+    default: true
+    comment: Biases check placement toward the runner where a check previously ran.
+  stickiness_factor:
     node_type: setting
     type: number
     default: 4
     tags:
     - golang_type:float64
-    comment: Experimental. Subject to change. Multiplier applied to workersNeeded
-      when computing the stickiness bias.
-  experimental_stickiness_limit:
+    comment: Multiplier applied to workersNeeded when computing the stickiness bias.
+  stickiness_upper_limit:
     node_type: setting
     type: number
     default: 1
     tags:
     - golang_type:float64
-    comment: Experimental. Subject to change. Maximum stickiness bias applied regardless
-      of workersNeeded.
+    comment: Maximum stickiness bias applied regardless of workersNeeded.
+  stickiness_lower_limit:
+    node_type: setting
+    type: number
+    default: 0.05
+    tags:
+    - golang_type:float64
+    comment: Minimum stickiness bias applied when stickiness is enabled.
   ksm_sharding_enabled:
     node_type: setting
     type: boolean

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -637,9 +637,10 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_period", 10*time.Minute)
 	config.BindEnvAndSetDefault("cluster_checks.ksm_sharding_enabled", false) // KSM resource sharding: splits KSM check by resource type (pods, nodes, others)
 	config.BindEnvAndSetDefault("cluster_checks.crd_collection", false)
-	config.BindEnvAndSetDefault("cluster_checks.experimental_stickiness_enabled", false) // Experimental. Subject to change. Biases check placement toward the runner where a check previously ran.
-	config.BindEnvAndSetDefault("cluster_checks.experimental_stickiness_factor", 4.0)    // Experimental. Subject to change. Multiplier applied to workersNeeded when computing the stickiness bias.
-	config.BindEnvAndSetDefault("cluster_checks.experimental_stickiness_limit", 1.0)     // Experimental. Subject to change. Maximum stickiness bias applied regardless of workersNeeded.
+	config.BindEnvAndSetDefault("cluster_checks.stickiness_enabled", true)     // Biases check placement toward the runner where a check previously ran.
+	config.BindEnvAndSetDefault("cluster_checks.stickiness_factor", 4.0)       // Multiplier applied to workersNeeded when computing the stickiness bias.
+	config.BindEnvAndSetDefault("cluster_checks.stickiness_upper_limit", 1.0)  // Maximum stickiness bias applied regardless of workersNeeded.
+	config.BindEnvAndSetDefault("cluster_checks.stickiness_lower_limit", 0.05) // Minimum stickiness bias applied when stickiness is enabled.
 
 	// Cluster check runner
 	config.BindEnvAndSetDefault("clc_runner_enabled", false)

--- a/releasenotes-dca/notes/notes/promote-stickiness-config-beea5e9b4b544a5c.yaml
+++ b/releasenotes-dca/notes/notes/promote-stickiness-config-beea5e9b4b544a5c.yaml
@@ -1,0 +1,12 @@
+---
+enhancements:
+  - |
+    Cluster check stickiness is now enabled by default. The dispatcher biases
+    check placement toward the runner where a check previously ran, reducing
+    unnecessary check migrations. The behavior can be tuned or disabled via the
+    following configuration options:
+
+    - ``cluster_checks.stickiness_enabled`` — enable or disable stickiness (default: ``true``)
+    - ``cluster_checks.stickiness_factor`` — multiplier applied to check cost when computing the bias (default: ``4.0``)
+    - ``cluster_checks.stickiness_upper_limit`` — maximum bias applied regardless of check cost (default: ``1.0``)
+    - ``cluster_checks.stickiness_lower_limit`` — minimum bias applied when stickiness is enabled (default: ``0.05``)


### PR DESCRIPTION
### What does this PR do?

Exposes Cluster Agent rebalancing algorithm stickiness for cluster checks. By default, will bias checks to staying on the previously assigned runner, allowing for some uneven distribution of work across the runner fleet.

### Motivation

Our data on how much work a check takes is only an approximation and can sometimes be flakey for a variety of random and uncontrollable reasons. This changes makes the rebalancing algorithm resistant to small changes in check execution time, avoiding completely reshuffling all checks across all runners to attempt to bring the std dev down to 0.

### Describe how you validated your changes

Unit Tests and CI

### Additional Notes

From testing on various clusters, we expect these default configuration options to deliver between 50% to 99% reduction in cluster check config moves, not including cases where leader election changes or new CCR pods are scheduled which inherently require a rebalance. This largely depends on the composition of cluster checks and number of cluster check runners.
