### PR TITLE
[ AGNTLOG-664 ] Reuse the container log symlink scan in the file launcher

### DIFF
--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -403,12 +403,15 @@ func (s *Launcher) launchTailers(source *sources.LogSource) {
 		return
 	}
 
+	// Reuse a single resolver so the /var/log/containers scan happens at most once
+	// across all files for this source rather than once per file.
+	symlinkResolver := fileprovider.NewContainerLogSymlinkResolver()
 	for _, file := range files {
 		if s.tailers.Count() >= s.tailingLimit {
 			return
 		}
 
-		if fileprovider.ShouldIgnore(s.validatePodContainerID, file) {
+		if fileprovider.ShouldIgnore(s.validatePodContainerID, file, symlinkResolver) {
 			continue
 		}
 		if tailer, isTailed := s.tailers.Get(file.GetScanKey()); isTailed {

--- a/pkg/logs/launchers/file/provider/BUILD.bazel
+++ b/pkg/logs/launchers/file/provider/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:android": [
@@ -46,6 +47,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:darwin": [
@@ -58,6 +60,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:dragonfly": [
@@ -70,6 +73,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:freebsd": [
@@ -82,6 +86,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:illumos": [
@@ -94,6 +99,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:ios": [
@@ -106,6 +112,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:js": [
@@ -118,6 +125,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:linux": [
@@ -130,6 +138,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:netbsd": [
@@ -142,6 +151,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:openbsd": [
@@ -154,6 +164,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:osx": [
@@ -166,6 +177,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:plan9": [
@@ -178,6 +190,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:qnx": [
@@ -190,6 +203,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:solaris": [
@@ -202,6 +216,7 @@ go_test(
             "//pkg/logs/tailers/file",
             "//pkg/logs/util/testutils",
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
         ],
         "//conditions:default": [],

--- a/pkg/logs/launchers/file/provider/file_provider.go
+++ b/pkg/logs/launchers/file/provider/file_provider.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
@@ -133,7 +134,7 @@ func (w *wildcardFileCounter) setTotal(src *sources.LogSource, total int) {
 	w.counts[src] = matchCnt
 }
 
-func (p *FileProvider) addFilesToTailList(validatePodContainerID bool, inputFiles, filesToTail []*tailer.File, w *wildcardFileCounter, registry auditor.Registry) []*tailer.File {
+func (p *FileProvider) addFilesToTailList(validatePodContainerID bool, symlinkResolver *ContainerLogSymlinkResolver, inputFiles, filesToTail []*tailer.File, w *wildcardFileCounter, registry auditor.Registry) []*tailer.File {
 	// Add each file one by one up to the limit
 	for _, file := range inputFiles {
 		// Unlike other tailers, there is a hard cap on the number of file tailers that can be concurrently active.
@@ -142,7 +143,7 @@ func (p *FileProvider) addFilesToTailList(validatePodContainerID bool, inputFile
 		registry.KeepAlive(file.Identifier())
 
 		if len(filesToTail) < p.filesLimit {
-			if ShouldIgnore(validatePodContainerID, file) {
+			if ShouldIgnore(validatePodContainerID, file, symlinkResolver) {
 				continue
 			}
 			filesToTail = append(filesToTail, file)
@@ -176,6 +177,10 @@ func (p *FileProvider) FilesToTail(ctx context.Context, validatePodContainerID b
 	shouldLogErrors := p.shouldLogErrors
 	p.shouldLogErrors = false // Let's log errors on first run only
 	wildcardFileCounter := newWildcardFileCounter()
+	// Build the /var/log/containers symlink map at most once for the whole scan
+	// rather than once per file. The map is resolved lazily, so no directory
+	// scan happens unless a container source file is actually evaluated.
+	symlinkResolver := NewContainerLogSymlinkResolver()
 
 	if p.selectionMode == globalSelection {
 		wildcardSources := make([]*sources.LogSource, 0, len(inputSources))
@@ -201,7 +206,7 @@ func (p *FileProvider) FilesToTail(ctx context.Context, validatePodContainerID b
 					}
 					continue
 				}
-				filesToTail = p.addFilesToTailList(validatePodContainerID, files, filesToTail, &wildcardFileCounter, registry)
+				filesToTail = p.addFilesToTailList(validatePodContainerID, symlinkResolver, files, filesToTail, &wildcardFileCounter, registry)
 			}
 		}
 
@@ -223,7 +228,7 @@ func (p *FileProvider) FilesToTail(ctx context.Context, validatePodContainerID b
 		}
 
 		p.applyOrdering(wildcardFiles)
-		filesToTail = p.addFilesToTailList(validatePodContainerID, wildcardFiles, filesToTail, &wildcardFileCounter, registry)
+		filesToTail = p.addFilesToTailList(validatePodContainerID, symlinkResolver, wildcardFiles, filesToTail, &wildcardFileCounter, registry)
 	} else if p.selectionMode == greedySelection {
 		// Consume all sources one-by-one, fitting as many as possible into 'filesToTail'
 		for _, source := range inputSources {
@@ -244,7 +249,7 @@ func (p *FileProvider) FilesToTail(ctx context.Context, validatePodContainerID b
 					}
 					continue
 				}
-				filesToTail = p.addFilesToTailList(validatePodContainerID, files, filesToTail, &wildcardFileCounter, registry)
+				filesToTail = p.addFilesToTailList(validatePodContainerID, symlinkResolver, files, filesToTail, &wildcardFileCounter, registry)
 			}
 		}
 	} else {
@@ -412,6 +417,67 @@ func (p *FileProvider) applyOrdering(files []*tailer.File) {
 	}
 }
 
+// ContainerLogSymlinkResolver lazily builds and caches the mapping between the
+// symlinks found in ContainersLogsDir and the /var/log/pods files they point to.
+//
+// ContainersLogsDir is scanned at most once over the lifetime of a resolver, so a
+// single resolver should be created per scan and shared across every file evaluated
+// in that scan. This avoids re-walking the directory (which can hold one symlink per
+// running container) for each candidate file.
+type ContainerLogSymlinkResolver struct {
+	once  sync.Once
+	links map[string]string
+	err   error
+}
+
+// NewContainerLogSymlinkResolver returns a resolver that scans ContainersLogsDir
+// lazily on first use.
+func NewContainerLogSymlinkResolver() *ContainerLogSymlinkResolver {
+	return &ContainerLogSymlinkResolver{}
+}
+
+// containerLogFor returns the symlink in ContainersLogsDir whose target is podLogPath.
+// The second return value reports whether the directory scan succeeded; when false the
+// caller should not attempt to validate the container ID.
+func (r *ContainerLogSymlinkResolver) containerLogFor(podLogPath string) (string, bool) {
+	r.once.Do(func() {
+		r.links, r.err = buildContainerLogSymlinkMap()
+	})
+	if r.err != nil {
+		return "", false
+	}
+	return r.links[podLogPath], true
+}
+
+// buildContainerLogSymlinkMap scans ContainersLogsDir once and returns a map from
+// each symlink target (a /var/log/pods file path) to the symlink path itself.
+func buildContainerLogSymlinkMap() (map[string]string, error) {
+	// ContainersLogsDir is a flat directory of symlinks, so a single ReadDir is
+	// enough and avoids the overhead of a recursive walk.
+	entries, err := os.ReadDir(ContainersLogsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	links := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		// we only want to follow symlinks
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != os.ModeSymlink {
+			continue
+		}
+
+		containerLogFilename := filepath.Join(ContainersLogsDir, entry.Name())
+		podLogFilename, err := os.Readlink(containerLogFilename)
+		if err != nil {
+			log.Debug("Error while resolving symlink of", containerLogFilename, ":", err)
+			continue
+		}
+
+		links[podLogFilename] = containerLogFilename
+	}
+	return links, nil
+}
+
 // ShouldIgnore resolves symlinks in /var/log/containers in order to use that redirection
 // to validate that we will be reading a file for the correct container.
 //
@@ -422,10 +488,14 @@ func (p *FileProvider) applyOrdering(files []*tailer.File) {
 // /var/log/containers are pointing to /var/log/pods files does, meaning that we can use them
 // to validate that the file we have found is concerning us. That's what the function
 // shouldIgnore is trying to do when the directory exists and is readable.
+//
+// symlinkResolver caches the ContainersLogsDir scan so it can be reused across all
+// files evaluated in a single scan; pass a resolver from NewContainerLogSymlinkResolver.
+// A nil resolver is allowed and results in a one-off scan.
 // See these links for more info:
 //   - https://github.com/kubernetes/kubernetes/issues/58638
 //   - https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/issues/105
-func ShouldIgnore(validatePodContainerID bool, file *tailer.File) bool {
+func ShouldIgnore(validatePodContainerID bool, file *tailer.File, symlinkResolver *ContainerLogSymlinkResolver) bool {
 	// this method needs a source config to detect whether we should ignore that file or not
 	if file == nil || file.Source == nil || file.Source.Config() == nil {
 		return false
@@ -439,38 +509,32 @@ func ShouldIgnore(validatePodContainerID bool, file *tailer.File) bool {
 		return false
 	}
 
-	infos := make(map[string]string)
-	err := filepath.WalkDir(ContainersLogsDir, func(containerLogFilename string, d os.DirEntry, err error) error {
-		// we only wants to follow symlinks
-		if d == nil || d.Type()&os.ModeSymlink != os.ModeSymlink || d.IsDir() {
-			// not a symlink, we are not interested in this file
-			return nil
-		}
+	// The only way this function ignores a file is by detecting a mismatch against the
+	// source's container Identifier. Without an Identifier to compare against there is
+	// nothing to validate, so we can skip the (comparatively expensive) directory scan.
+	sourceContainerID := file.Source.Config().Identifier
+	if sourceContainerID == "" {
+		return false
+	}
 
-		// resolve the symlink
-		podLogFilename, err2 := os.Readlink(containerLogFilename)
-		if err2 != nil {
-			log.Debug("Error while resolving symlink of", containerLogFilename, ":", err)
-			return nil
-		}
+	if symlinkResolver == nil {
+		symlinkResolver = NewContainerLogSymlinkResolver()
+	}
 
-		infos[podLogFilename] = containerLogFilename
-		return nil
-	})
-
-	// this is not an error if we are not currently looking for container logs files,
-	// so not problem and just return false.
-	// Still, we write a debug message to be able to troubleshoot that
-	// in cases we're legitimately looking for containers logs.
-	if err != nil {
-		log.Debug("Can't look for symlinks in /var/log/containers:", err)
+	containerLogFilename, ok := symlinkResolver.containerLogFor(file.Path)
+	if !ok {
+		// this is not an error if we are not currently looking for container logs files,
+		// so no problem and just return false.
+		// Still, we write a debug message to be able to troubleshoot that
+		// in cases we're legitimately looking for containers logs.
+		log.Debug("Can't look for symlinks in", ContainersLogsDir)
 		return false
 	}
 
 	// container id extracted from the file found in /var/log/containers
-	base := filepath.Base(infos[file.Path]) // only the file
-	ext := filepath.Ext(base)               // file extension
-	parts := strings.Split(base, "-")       // get only the container ID part from the file
+	base := filepath.Base(containerLogFilename) // only the file
+	ext := filepath.Ext(base)                   // file extension
+	parts := strings.Split(base, "-")           // get only the container ID part from the file
 	var containerIDFromFilename string
 	if len(parts) > 1 {
 		containerIDFromFilename = strings.TrimSuffix(parts[len(parts)-1], ext)
@@ -478,17 +542,15 @@ func ShouldIgnore(validatePodContainerID bool, file *tailer.File) bool {
 
 	// basic validation of the ID that has been parsed, if it doesn't look like
 	// an ID we don't want to compare another ID to it
-	if containerIDFromFilename == "" || !rxContainerID.Match([]byte(containerIDFromFilename)) {
+	if containerIDFromFilename == "" || !rxContainerID.MatchString(containerIDFromFilename) {
 		return false
 	}
 
-	if file.Source.Config().Identifier != "" && containerIDFromFilename != "" {
-		if strings.TrimSpace(strings.ToLower(containerIDFromFilename)) != strings.TrimSpace(strings.ToLower(file.Source.Config().Identifier)) {
-			log.Debugf("We were about to tail a file attached to the wrong container (%s != %s), probably due to short-lived containers.",
-				containerIDFromFilename, file.Source.Config().Identifier)
-			// ignore this file, it is not concerning the container stored in file.Source
-			return true
-		}
+	if strings.TrimSpace(strings.ToLower(containerIDFromFilename)) != strings.TrimSpace(strings.ToLower(sourceContainerID)) {
+		log.Debugf("We were about to tail a file attached to the wrong container (%s != %s), probably due to short-lived containers.",
+			containerIDFromFilename, sourceContainerID)
+		// ignore this file, it is not concerning the container stored in file.Source
+		return true
 	}
 
 	return false

--- a/pkg/logs/launchers/file/provider/file_provider.go
+++ b/pkg/logs/launchers/file/provider/file_provider.go
@@ -438,7 +438,8 @@ func NewContainerLogSymlinkResolver() *ContainerLogSymlinkResolver {
 
 // containerLogFor returns the symlink in ContainersLogsDir whose target is podLogPath.
 // The second return value reports whether the directory scan succeeded; when false the
-// caller should not attempt to validate the container ID.
+// caller should not attempt to validate the container ID (matching the previous
+// behavior of bailing out when the directory could not be walked).
 func (r *ContainerLogSymlinkResolver) containerLogFor(podLogPath string) (string, bool) {
 	r.once.Do(func() {
 		r.links, r.err = buildContainerLogSymlinkMap()
@@ -449,33 +450,40 @@ func (r *ContainerLogSymlinkResolver) containerLogFor(podLogPath string) (string
 	return r.links[podLogPath], true
 }
 
-// buildContainerLogSymlinkMap scans ContainersLogsDir once and returns a map from
-// each symlink target (a /var/log/pods file path) to the symlink path itself.
+// buildContainerLogSymlinkMap walks ContainersLogsDir once and returns a map from each
+// symlink target (a /var/log/pods file path) to the symlink path itself. The traversal
+// intentionally mirrors the original per-file implementation (a recursive filepath.WalkDir
+// following only symlinks) so the resulting map is identical; the only change is that it
+// is now built a single time per scan instead of once for every candidate file.
 func buildContainerLogSymlinkMap() (map[string]string, error) {
-	// ContainersLogsDir is a flat directory of symlinks, so a single ReadDir is
-	// enough and avoids the overhead of a recursive walk.
-	entries, err := os.ReadDir(ContainersLogsDir)
+	infos := make(map[string]string)
+	err := filepath.WalkDir(ContainersLogsDir, func(containerLogFilename string, d os.DirEntry, err error) error {
+		// we only wants to follow symlinks
+		if d == nil || d.Type()&os.ModeSymlink != os.ModeSymlink || d.IsDir() {
+			// not a symlink, we are not interested in this file
+			return nil
+		}
+
+		// resolve the symlink
+		podLogFilename, err2 := os.Readlink(containerLogFilename)
+		if err2 != nil {
+			log.Debug("Error while resolving symlink of", containerLogFilename, ":", err)
+			return nil
+		}
+
+		infos[podLogFilename] = containerLogFilename
+		return nil
+	})
+
+	// this is not an error if we are not currently looking for container logs files,
+	// so not problem and just return false.
+	// Still, we write a debug message to be able to troubleshoot that
+	// in cases we're legitimately looking for containers logs.
 	if err != nil {
+		log.Debug("Can't look for symlinks in /var/log/containers:", err)
 		return nil, err
 	}
-
-	links := make(map[string]string, len(entries))
-	for _, entry := range entries {
-		// we only want to follow symlinks
-		if entry.IsDir() || entry.Type()&os.ModeSymlink != os.ModeSymlink {
-			continue
-		}
-
-		containerLogFilename := filepath.Join(ContainersLogsDir, entry.Name())
-		podLogFilename, err := os.Readlink(containerLogFilename)
-		if err != nil {
-			log.Debug("Error while resolving symlink of", containerLogFilename, ":", err)
-			continue
-		}
-
-		links[podLogFilename] = containerLogFilename
-	}
-	return links, nil
+	return infos, nil
 }
 
 // ShouldIgnore resolves symlinks in /var/log/containers in order to use that redirection
@@ -491,7 +499,8 @@ func buildContainerLogSymlinkMap() (map[string]string, error) {
 //
 // symlinkResolver caches the ContainersLogsDir scan so it can be reused across all
 // files evaluated in a single scan; pass a resolver from NewContainerLogSymlinkResolver.
-// A nil resolver is allowed and results in a one-off scan.
+// A nil resolver is allowed and results in a one-off scan. Aside from that caching, the
+// validation logic below is intentionally identical to the original implementation.
 // See these links for more info:
 //   - https://github.com/kubernetes/kubernetes/issues/58638
 //   - https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/issues/105
@@ -509,25 +518,15 @@ func ShouldIgnore(validatePodContainerID bool, file *tailer.File, symlinkResolve
 		return false
 	}
 
-	// The only way this function ignores a file is by detecting a mismatch against the
-	// source's container Identifier. Without an Identifier to compare against there is
-	// nothing to validate, so we can skip the (comparatively expensive) directory scan.
-	sourceContainerID := file.Source.Config().Identifier
-	if sourceContainerID == "" {
-		return false
-	}
-
 	if symlinkResolver == nil {
 		symlinkResolver = NewContainerLogSymlinkResolver()
 	}
 
+	// The (cached) scan of ContainersLogsDir gives us the symlink pointing at the file
+	// we're about to tail. A failed scan is not treated as an error: we simply don't
+	// ignore the file, exactly as before.
 	containerLogFilename, ok := symlinkResolver.containerLogFor(file.Path)
 	if !ok {
-		// this is not an error if we are not currently looking for container logs files,
-		// so no problem and just return false.
-		// Still, we write a debug message to be able to troubleshoot that
-		// in cases we're legitimately looking for containers logs.
-		log.Debug("Can't look for symlinks in", ContainersLogsDir)
 		return false
 	}
 
@@ -542,15 +541,17 @@ func ShouldIgnore(validatePodContainerID bool, file *tailer.File, symlinkResolve
 
 	// basic validation of the ID that has been parsed, if it doesn't look like
 	// an ID we don't want to compare another ID to it
-	if containerIDFromFilename == "" || !rxContainerID.MatchString(containerIDFromFilename) {
+	if containerIDFromFilename == "" || !rxContainerID.Match([]byte(containerIDFromFilename)) {
 		return false
 	}
 
-	if strings.TrimSpace(strings.ToLower(containerIDFromFilename)) != strings.TrimSpace(strings.ToLower(sourceContainerID)) {
-		log.Debugf("We were about to tail a file attached to the wrong container (%s != %s), probably due to short-lived containers.",
-			containerIDFromFilename, sourceContainerID)
-		// ignore this file, it is not concerning the container stored in file.Source
-		return true
+	if file.Source.Config().Identifier != "" && containerIDFromFilename != "" {
+		if strings.TrimSpace(strings.ToLower(containerIDFromFilename)) != strings.TrimSpace(strings.ToLower(file.Source.Config().Identifier)) {
+			log.Debugf("We were about to tail a file attached to the wrong container (%s != %s), probably due to short-lived containers.",
+				containerIDFromFilename, file.Source.Config().Identifier)
+			// ignore this file, it is not concerning the container stored in file.Source
+			return true
+		}
 	}
 
 	return false

--- a/pkg/logs/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/launchers/file/provider/file_provider_test.go
@@ -813,21 +813,21 @@ func TestContainerIDInContainerLogFile(t *testing.T) {
 	}
 
 	// we've found a symlink validating that the file we have just scanned is concerning the container we're currently processing for this source
-	assert.False(ShouldIgnore(true, &file), "the file existing in ContainersLogsDir is pointing to the same container, scanned file should be tailed")
+	assert.False(ShouldIgnore(true, &file, NewContainerLogSymlinkResolver()), "the file existing in ContainersLogsDir is pointing to the same container, scanned file should be tailed")
 
 	// now, let's change the container for which we are trying to scan files,
 	// because the symlink is pointing from another container, we should ignore
 	// that log file
 	file.Source.Config().Identifier = "1234123412341234123412341234123412341234123412341234123412341234"
-	assert.True(ShouldIgnore(true, &file), "the file existing in ContainersLogsDir is not pointing to the same container, scanned file should be ignored")
+	assert.True(ShouldIgnore(true, &file, NewContainerLogSymlinkResolver()), "the file existing in ContainersLogsDir is not pointing to the same container, scanned file should be ignored")
 
 	// in this scenario, no link is found in /var/log/containers, thus, we should not ignore the file
 	os.Remove("/tmp/myapp_my-namespace_myapp-abcdefabcdefabcdabcdefabcdefabcdabcdefabcdefabcdabcdefabcdefabcd.log")
-	assert.False(ShouldIgnore(true, &file), "no files existing in ContainersLogsDir, we should not ignore the file we have just scanned")
+	assert.False(ShouldIgnore(true, &file, NewContainerLogSymlinkResolver()), "no files existing in ContainersLogsDir, we should not ignore the file we have just scanned")
 
 	// in this scenario, the file we've found doesn't look like a container ID
 	os.Symlink("/var/log/pods/file-uuid-foo-bar.log", "/tmp/myapp_my-namespace_myapp-thisisnotacontainerIDevenifthisispointingtothecorrectfile.log")
-	assert.False(ShouldIgnore(true, &file), "no container ID found, we don't want to ignore this scanned file")
+	assert.False(ShouldIgnore(true, &file, NewContainerLogSymlinkResolver()), "no container ID found, we don't want to ignore this scanned file")
 }
 
 func TestContainerPathsAreCorrectlyIgnored(t *testing.T) {

--- a/pkg/logs/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/launchers/file/provider/file_provider_test.go
@@ -11,10 +11,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -869,6 +871,92 @@ func TestContainerPathsAreCorrectlyIgnored(t *testing.T) {
 	}
 	files := fileProvider.FilesToTail(context.Background(), true, sources, auditor.NewMockAuditor())
 	assert.Len(t, files, 2) // 1 file from k8s source, 1 file from regular file source.
+}
+
+// containerLogSource builds a Kubernetes container log source/file pair pointing at
+// podLogPath with the given container identifier, for exercising ShouldIgnore.
+func containerLogSource(podLogPath, identifier string) *tailer.File {
+	logSource := sources.NewLogSource("mylogsource", nil)
+	logSource.SetSourceType(sources.KubernetesSourceType)
+	logSource.Config = &config.LogsConfig{
+		Type:       config.FileType,
+		Path:       podLogPath,
+		Identifier: identifier,
+	}
+	return &tailer.File{Path: podLogPath, Source: sources.NewReplaceableSource(logSource)}
+}
+
+const (
+	testMatchingContainerID = "abcdefabcdefabcdabcdefabcdefabcdabcdefabcdefabcdabcdefabcdefabcd"
+	testOtherContainerID    = "1234123412341234123412341234123412341234123412341234123412341234"
+)
+
+// TestContainerLogSymlinkResolverCaching verifies the core behavior introduced by the
+// resolver: the ContainersLogsDir scan happens once and is reused for the lifetime of a
+// single resolver, while a fresh resolver rescans. This is what makes the scan run at
+// most once per launcher scan cycle instead of once per file.
+func TestContainerLogSymlinkResolverCaching(t *testing.T) {
+	origDir := ContainersLogsDir
+	defer func() { ContainersLogsDir = origDir }()
+
+	containersDir := t.TempDir()
+	ContainersLogsDir = containersDir + "/"
+
+	podLog := "/var/log/pods/file-uuid-foo-bar.log"
+	symlink := filepath.Join(containersDir, "myapp_my-namespace_myapp-"+testMatchingContainerID+".log")
+	require.NoError(t, os.Symlink(podLog, symlink))
+
+	// The source identifier deliberately differs from the container ID encoded in the
+	// symlink, so a successful scan classifies the file as "ignore".
+	file := containerLogSource(podLog, testOtherContainerID)
+
+	resolver := NewContainerLogSymlinkResolver()
+	// First call builds and caches the map; mismatch -> ignore.
+	assert.True(t, ShouldIgnore(true, file, resolver))
+
+	// Remove the symlink. A shared resolver must NOT rescan, so it keeps ignoring
+	// based on its cached map.
+	require.NoError(t, os.Remove(symlink))
+	assert.True(t, ShouldIgnore(true, file, resolver),
+		"a reused resolver should serve its cached scan and not observe the removed symlink")
+
+	// A fresh resolver rescans, no longer finds the symlink, and therefore stops ignoring.
+	assert.False(t, ShouldIgnore(true, file, NewContainerLogSymlinkResolver()),
+		"a new resolver should rescan and reflect the removed symlink")
+}
+
+// TestShouldIgnoreNilResolver documents the public contract that a nil resolver is
+// allowed and results in a one-off scan.
+func TestShouldIgnoreNilResolver(t *testing.T) {
+	origDir := ContainersLogsDir
+	defer func() { ContainersLogsDir = origDir }()
+
+	containersDir := t.TempDir()
+	ContainersLogsDir = containersDir + "/"
+
+	podLog := "/var/log/pods/file-uuid-foo-bar.log"
+	require.NoError(t, os.Symlink(podLog, filepath.Join(containersDir, "myapp_my-namespace_myapp-"+testMatchingContainerID+".log")))
+
+	file := containerLogSource(podLog, testMatchingContainerID)
+	// Matching identifier with a nil resolver -> tail.
+	assert.False(t, ShouldIgnore(true, file, nil))
+
+	// Mismatched identifier with a nil resolver -> ignore.
+	file.Source.Config().Identifier = testOtherContainerID
+	assert.True(t, ShouldIgnore(true, file, nil))
+}
+
+// TestShouldIgnoreMissingContainersDir guards the realistic case of a container source on
+// a host without /var/log/containers: the file should be tailed rather than ignored.
+func TestShouldIgnoreMissingContainersDir(t *testing.T) {
+	origDir := ContainersLogsDir
+	defer func() { ContainersLogsDir = origDir }()
+
+	ContainersLogsDir = filepath.Join(t.TempDir(), "does-not-exist") + "/"
+
+	file := containerLogSource("/var/log/pods/file-uuid-foo-bar.log", testMatchingContainerID)
+	assert.False(t, ShouldIgnore(true, file, NewContainerLogSymlinkResolver()),
+		"a missing containers directory should not cause files to be ignored")
 }
 
 func TestCollectFiles_RecursiveGlobWithExcludePaths(t *testing.T) {

--- a/releasenotes/notes/reduce-file-scanning-cpu-3011a0602d25c670.yaml
+++ b/releasenotes/notes/reduce-file-scanning-cpu-3011a0602d25c670.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Reduced the CPU usage of the log file launcher when tailing container
+    log files. The check that validates a file belongs to the expected
+    container now scans the ``/var/log/containers`` directory at most once
+    per scan cycle instead of once per file, which noticeably lowers
+    overhead on nodes running many containers.

--- a/releasenotes/notes/reduce-file-scanning-cpu-3011a0602d25c670.yaml
+++ b/releasenotes/notes/reduce-file-scanning-cpu-3011a0602d25c670.yaml
@@ -1,8 +1,4 @@
 ---
 enhancements:
   - |
-    Reduced the CPU usage of the log file launcher when tailing container
-    log files. The check that validates a file belongs to the expected
-    container now scans the ``/var/log/containers`` directory at most once
-    per scan cycle instead of once per file, which noticeably lowers
-    overhead on nodes running many containers.
+    Reduced the CPU usage of log file scanning when tailing container logs.


### PR DESCRIPTION
### What does this PR do?

Reduces the cost of the file log launcher's container-ID validation. Before tailing a Kubernetes or Docker container log file, the launcher confirms the file belongs to the expected container by inspecting the symlinks under `/var/log/containers`. That check previously rescanned the entire directory and resolved every symlink once per candidate file; it now performs that scan at most once per launcher scan cycle and reuses the result across all files. The validation behavior is unchanged.

### Motivation

On nodes running many containers while tailing many log files, the per-file rescans made the work scale with (files tailed) × (container symlinks on the node), repeated every scan period, producing substantial redundant filesystem and CPU work with no functional benefit. Reported in AGNTLOG-664. The directory scan is now also skipped entirely when a source has no container identifier to validate against, since that is the only condition under which a file would be ignored.

### Describe how you validated your changes

Covered by the existing package tests in `pkg/logs/launchers/file` and its provider — notably `TestContainerIDInContainerLogFile` and `TestContainerPathsAreCorrectlyIgnored` — run via `dda inv test --only-modified-packages` (all passing). Linting verified with `dda inv linter.go --only-modified-packages`.

### Additional Notes

A further optimization — caching the symlink map across scan cycles with directory-mtime invalidation — was intentionally left out to keep this change self-contained and avoid holding additional state on the provider between scans.