### PR TITLE
[QB1HZ-16] Add metric lookback shadow config metadata

### DIFF
--- a/pkg/collector/metriclookback/BUILD.bazel
+++ b/pkg/collector/metriclookback/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "metriclookback",
+    srcs = ["metadata.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/collector/metriclookback",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/autodiscovery/integration",
+        "@in_yaml_go_yaml_v2//:yaml",
+    ],
+)
+
+dd_agent_go_test(
+    name = "metriclookback_test",
+    srcs = [
+        "metadata_test.go",
+    ],
+    embed = [":metriclookback"],
+    deps = [
+        "//comp/core/autodiscovery/integration",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@in_yaml_go_yaml_v2//:yaml",
+    ],
+)

--- a/pkg/collector/metriclookback/metadata.go
+++ b/pkg/collector/metriclookback/metadata.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package metriclookback contains helpers for 1Hz check metric lookback.
+package metriclookback
+
+import (
+	yaml "go.yaml.in/yaml/v2"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+)
+
+const (
+	// ExecutionMetadataKey is the internal instance-config namespace used for
+	// Datadog-owned execution metadata.
+	ExecutionMetadataKey = "_datadog"
+	// ExecutionModeKey identifies the execution mode under ExecutionMetadataKey.
+	ExecutionModeKey = "execution_mode"
+	// ShadowExecutionMode marks a copied check instance as a shadow execution.
+	ShadowExecutionMode = "shadow"
+)
+
+// WithShadowExecutionMode returns a copied instance config marked for shadow
+// execution without mutating the source instance bytes.
+func WithShadowExecutionMode(instance integration.Data) (integration.Data, error) {
+	rawConfig := integration.RawMap{}
+	if err := yaml.Unmarshal(cloneData(instance), &rawConfig); err != nil {
+		return nil, err
+	}
+	if rawConfig == nil {
+		rawConfig = integration.RawMap{}
+	}
+
+	var metadata map[interface{}]interface{}
+	switch typedMetadata := rawConfig[ExecutionMetadataKey].(type) {
+	case integration.RawMap:
+		metadata = typedMetadata
+	case map[interface{}]interface{}:
+		metadata = typedMetadata
+	default:
+		metadata = map[interface{}]interface{}{}
+	}
+	metadata[ExecutionModeKey] = ShadowExecutionMode
+	rawConfig[ExecutionMetadataKey] = metadata
+
+	out, err := yaml.Marshal(&rawConfig)
+	if err != nil {
+		return nil, err
+	}
+	return integration.Data(out), nil
+}
+
+func cloneData(data integration.Data) integration.Data {
+	return append(integration.Data(nil), data...)
+}

--- a/pkg/collector/metriclookback/metadata_test.go
+++ b/pkg/collector/metriclookback/metadata_test.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metriclookback
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "go.yaml.in/yaml/v2"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+)
+
+func TestWithShadowExecutionModeAddsInternalMetadataToCopy(t *testing.T) {
+	source := integration.Config{
+		Name:       "cpu",
+		InitConfig: integration.Data("loader: python\n"),
+		Instances: []integration.Data{
+			integration.Data("name: first\ntags:\n  - env:test\n"),
+			integration.Data("name: second\n"),
+		},
+	}
+	originalConfig := source
+	originalConfig.InitConfig = append(integration.Data(nil), source.InitConfig...)
+	originalConfig.Instances = append([]integration.Data(nil), source.Instances...)
+	for i := range originalConfig.Instances {
+		originalConfig.Instances[i] = append(integration.Data(nil), source.Instances[i]...)
+	}
+
+	shadowInstance, err := WithShadowExecutionMode(source.Instances[0])
+
+	require.NoError(t, err)
+	assert.Equal(t, originalConfig, source)
+	assert.NotEqual(t, source.Instances[0], shadowInstance)
+
+	raw := integration.RawMap{}
+	require.NoError(t, yaml.Unmarshal(shadowInstance, &raw))
+	assert.Equal(t, "first", raw["name"])
+	assert.Equal(t, []interface{}{"env:test"}, raw["tags"])
+	assert.Equal(t, integration.RawMap{"execution_mode": "shadow"}, raw["_datadog"])
+}
+
+func TestWithShadowExecutionModePreservesExistingInternalMetadata(t *testing.T) {
+	instance := integration.Data("_datadog:\n  existing: value\nname: cpu\n")
+
+	shadowInstance, err := WithShadowExecutionMode(instance)
+
+	require.NoError(t, err)
+	raw := integration.RawMap{}
+	require.NoError(t, yaml.Unmarshal(shadowInstance, &raw))
+	assert.Equal(t, integration.RawMap{
+		"existing":       "value",
+		"execution_mode": "shadow",
+	}, raw["_datadog"])
+}
+
+func TestWithShadowExecutionModeOverridesUserExecutionMode(t *testing.T) {
+	instance := integration.Data("_datadog:\n  execution_mode: normal\nname: cpu\n")
+
+	shadowInstance, err := WithShadowExecutionMode(instance)
+
+	require.NoError(t, err)
+	raw := integration.RawMap{}
+	require.NoError(t, yaml.Unmarshal(shadowInstance, &raw))
+	assert.Equal(t, integration.RawMap{"execution_mode": "shadow"}, raw["_datadog"])
+}
+
+func TestWithShadowExecutionModeReturnsParseErrors(t *testing.T) {
+	_, err := WithShadowExecutionMode(integration.Data("invalid: ["))
+
+	require.Error(t, err)
+}


### PR DESCRIPTION
### What does this PR do?

Adds internal shadow execution metadata to copied metric lookback check instance configs.

When the metric lookback shadow pipeline creates a shadow instance, it can mark the copied instance config with:

```yaml
_datadog:
  execution_mode: shadow
```

The helper preserves existing instance fields and existing Datadog-owned metadata, while ensuring the shadow execution mode is set only on the copied instance config.

### Motivation

This is part of the Metric Lookback V2 shadow pipeline work for [QB1HZ-16](https://datadoghq.atlassian.net/browse/QB1HZ-16).

Some checks need a lightweight way to detect shadow execution before configure/load completes, without adding a Go-only interface or requiring every check implementation to grow a new method. Encoding the signal in copied instance YAML keeps the contract available to both Go and Python checks while leaving normal config bytes unchanged.

### Describe how you validated your changes

- Added unit tests covering metadata injection into copied instance configs.
- Added unit tests covering preservation of existing instance fields and existing `_datadog` metadata.
- Added unit tests covering user-provided `execution_mode` being overridden to `shadow` for shadow copies.
- Added unit tests covering invalid YAML error propagation.

```bash
dda inv test --targets=./pkg/collector/metriclookback
```

### Additional Notes

This PR only adds the config metadata boundary. It does not wire shadow loading, scheduler routing, sender manager behavior, or metric lookback storage/flush behavior.

[QB1HZ-16]: https://datadoghq.atlassian.net/browse/QB1HZ-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ