### PR TITLE
Remove atomics section from codereview_guideline.md

### DIFF
--- a/codereview_guideline.md
+++ b/codereview_guideline.md
@@ -56,14 +56,6 @@ incorrect assumptions.
 
 Apply these when the PR touches Go code.
 
-### Atomics — use `go.uber.org/atomic`, not `sync/atomic`
-The standard `sync/atomic` package has an alignment bug on 32-bit and some ARM
-platforms and allows mixing atomic and non-atomic access to the same variable.
-Flag any new use of `sync/atomic`; the project standard is `go.uber.org/atomic`.
-Atomic values in structs must be declared as a pointer (`*atomic.Uint64` etc.)
-to guarantee alignment, unless placed as the first field with a comment
-explaining why a pointer was not used.
-
 ### Testing: `require` vs `assert`
 Use `require` (from `github.com/stretchr/testify/require`) when each assertion
 depends on the previous one succeeding — it aborts the test immediately on


### PR DESCRIPTION
### What does this PR do?

Due to https://github.com/golang/go/issues/50860, with [the adoption of go version 1.19](https://go.dev/doc/go1.19#atomic_types):

> The sync/atomic package defines new atomic types Bool, Int32, Int64, Uint32, Uint64, Uintptr, and Pointer. These types hide the underlying values so that all accesses are forced to use the atomic APIs. Int64 and Uint64 are automatically aligned to 64-bit boundaries in structs and allocated data, **even on 32-bit systems**.

This repo is already >1.19, so we don't need to move over to the uber atomic library.

### Motivation

### Describe how you validated your changes

### Additional Notes
