### PR TITLE
Add connect event tree node support in activity tree

### DIFF
--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -518,6 +518,8 @@ func (at *ActivityTree) insertEvent(event *model.Event, dryRun bool, insertMissi
 		return node.InsertIMDSEvent(event, imageTagID, generationType, at.Stats, dryRun), nil
 	case model.BindEventType:
 		return node.InsertBindEvent(event, imageTagID, generationType, at.Stats, dryRun), nil
+	case model.ConnectEventType:
+		return node.InsertConnectEvent(event, imageTagID, generationType, at.Stats, dryRun), nil
 	case model.SyscallsEventType:
 		return node.InsertSyscalls(event, imageTagID, at.SyscallsMask, at.Stats, dryRun), nil
 	case model.NetworkFlowMonitorEventType:

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -441,6 +441,37 @@ func (pn *ProcessNode) InsertBindEvent(evt *model.Event, imageTagID uint64, gene
 	return newNode
 }
 
+// InsertConnectEvent inserts a connect event in a process node
+func (pn *ProcessNode) InsertConnectEvent(evt *model.Event, imageTagID uint64, generationType NodeGenerationType, stats *Stats, dryRun bool) bool {
+	if evt.Connect.SyscallEvent.Retval != 0 {
+		return false
+	}
+	var newNode bool
+	evtFamily := model.AddressFamily(evt.Connect.AddrFamily).String()
+
+	var sock *SocketNode
+	for _, s := range pn.Sockets {
+		if s.Family == evtFamily {
+			sock = s
+		}
+	}
+	if sock == nil {
+		sock = NewSocketNode(evtFamily, generationType)
+		if !dryRun {
+			stats.SocketNodes++
+			stats.SizeBytes += sock.size()
+			pn.Sockets = append(pn.Sockets, sock)
+		}
+		newNode = true
+	}
+
+	if sock.InsertConnectEvent(&evt.Connect, evt, imageTagID, generationType, evt.Rules, stats, dryRun) {
+		newNode = true
+	}
+
+	return newNode
+}
+
 // InsertCapabilitiesUsageEvent inserts a capabilities usage event in a process node
 func (pn *ProcessNode) InsertCapabilitiesUsageEvent(evt *model.Event, imageTagID uint64, stats *Stats, dryRun bool) bool {
 	hasNewCapabilitiesUsage := false

--- a/pkg/security/security_profile/activity_tree/socket_node.go
+++ b/pkg/security/security_profile/activity_tree/socket_node.go
@@ -27,12 +27,30 @@ type BindNode struct {
 	Protocol       uint16
 }
 
+// ConnectNode is used to store a connect node
+type ConnectNode struct {
+	NodeBase
+
+	MatchedRules []*model.MatchedRule
+
+	GenerationType NodeGenerationType
+	Port           uint16
+	IP             string
+	Protocol       uint16
+}
+
+// Matches returns true if ConnectNodes matches
+func (cn *ConnectNode) Matches(toMatch *ConnectNode) bool {
+	return cn.Port == toMatch.Port && cn.IP == toMatch.IP && cn.Protocol == toMatch.Protocol
+}
+
 // SocketNode is used to store a Socket node and associated events
 type SocketNode struct {
 	NodeBase
 	Family         string
 	GenerationType NodeGenerationType
 	Bind           []*BindNode
+	Connect        []*ConnectNode
 }
 
 // size approximates this node's heap footprint, including all owned BindNodes.
@@ -48,6 +66,10 @@ func (sn *SocketNode) size() int64 {
 	for _, bind := range sn.Bind {
 		s += bindSize(bind)
 	}
+	s += sliceBackingBytes(cap(sn.Connect), unsafe.Sizeof((*ConnectNode)(nil)))
+	for _, conn := range sn.Connect {
+		s += connectSize(conn)
+	}
 	return s
 }
 
@@ -61,6 +83,17 @@ func bindSize(bn *BindNode) int64 {
 	s += seenBytes(bn.NodeBase)
 	s += int64(len(bn.IP))
 	s += sliceBackingBytes(cap(bn.MatchedRules), unsafe.Sizeof((*model.MatchedRule)(nil)))
+	return s
+}
+
+func connectSize(cn *ConnectNode) int64 {
+	if cn == nil {
+		return 0
+	}
+	s := int64(unsafe.Sizeof(*cn))
+	s += seenBytes(cn.NodeBase)
+	s += int64(len(cn.IP))
+	s += sliceBackingBytes(cap(cn.MatchedRules), unsafe.Sizeof((*model.MatchedRule)(nil)))
 	return s
 }
 
@@ -80,8 +113,7 @@ func (sn *SocketNode) Matches(toMatch *SocketNode) bool {
 // and additionally subtracts sn.size() if the socket itself ends up empty.
 func (sn *SocketNode) evictImageTag(imageTagID uint64) (bool, int64) {
 	var removed int64
-	// Filter in place, then clear the tail so we don't pin evicted *BindNode pointers in the
-	// backing array (they'd otherwise stay alive until the SocketNode itself is GC'd).
+
 	newBind := sn.Bind[:0]
 	for _, bind := range sn.Bind {
 		if bind.EvictImageTag(imageTagID) {
@@ -92,7 +124,19 @@ func (sn *SocketNode) evictImageTag(imageTagID uint64) (bool, int64) {
 	}
 	clear(sn.Bind[len(newBind):])
 	sn.Bind = newBind
-	return len(newBind) == 0, removed
+
+	newConnect := sn.Connect[:0]
+	for _, conn := range sn.Connect {
+		if conn.EvictImageTag(imageTagID) {
+			removed += connectSize(conn)
+			continue
+		}
+		newConnect = append(newConnect, conn)
+	}
+	clear(sn.Connect[len(newConnect):])
+	sn.Connect = newConnect
+
+	return len(newBind) == 0 && len(newConnect) == 0, removed
 }
 
 // InsertBindEvent inserts a bind event inside a socket node. When a new BindNode is
@@ -129,6 +173,38 @@ func (sn *SocketNode) InsertBindEvent(evt *model.BindEvent, event *model.Event, 
 		node.AppendImageTagID(imageTagID, event.ResolveEventTime())
 		sn.Bind = append(sn.Bind, node)
 		stats.SizeBytes += bindSize(node)
+	}
+	return true
+}
+
+// InsertConnectEvent inserts a connect event inside a socket node.
+func (sn *SocketNode) InsertConnectEvent(evt *model.ConnectEvent, event *model.Event, imageTagID uint64, generationType NodeGenerationType, rules []*model.MatchedRule, stats *Stats, dryRun bool) bool {
+	evtIP := utils.GetIPStringFromIPNet(evt.Addr.IPNet)
+	for _, n := range sn.Connect {
+		if evt.Addr.Port == n.Port && evtIP == n.IP && evt.Protocol == n.Protocol {
+			if !dryRun {
+				n.MatchedRules = model.AppendMatchedRule(n.MatchedRules, rules)
+			}
+			if imageTagID == 0 || n.HasImageTag(imageTagID) {
+				return false
+			}
+			n.AppendImageTagID(imageTagID, event.ResolveEventTime())
+			return false
+		}
+	}
+
+	if !dryRun {
+		node := &ConnectNode{
+			MatchedRules:   rules,
+			GenerationType: generationType,
+			Port:           evt.Addr.Port,
+			IP:             evtIP,
+			Protocol:       evt.Protocol,
+		}
+		node.NodeBase = NewNodeBase()
+		node.AppendImageTagID(imageTagID, event.ResolveEventTime())
+		sn.Connect = append(sn.Connect, node)
+		stats.SizeBytes += connectSize(node)
 	}
 	return true
 }


### PR DESCRIPTION
Connect events were listed in the V2 event types but had no case in insertEvent, silently falling through to the default no-op path. Add ConnectNode (mirroring BindNode), InsertConnectEvent on SocketNode and ProcessNode, and wire the ConnectEventType case in insertEvent.

Proto serialization support requires an agent-payload update and is left as a follow-up.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
