### PR TITLE
Drop stale `replace` directives from `anomalydetection-testbench`

### DIFF
--- a/internal/qbranch/anomalydetection-testbench/go.mod
+++ b/internal/qbranch/anomalydetection-testbench/go.mod
@@ -273,9 +273,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/fips => ../../../pkg/fips
 	github.com/DataDog/datadog-agent/pkg/fleet/installer => ../../../pkg/fleet/installer
 	github.com/DataDog/datadog-agent/pkg/gohai => ../../../pkg/gohai
-	github.com/DataDog/datadog-agent/pkg/logs/client => ../../../pkg/logs/client
 	github.com/DataDog/datadog-agent/pkg/logs/message => ../../../pkg/logs/message
-	github.com/DataDog/datadog-agent/pkg/logs/metrics => ../../../pkg/logs/metrics
 	github.com/DataDog/datadog-agent/pkg/logs/sources => ../../../pkg/logs/sources
 	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface => ../../../pkg/logs/status/statusinterface
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils => ../../../pkg/logs/status/utils


### PR DESCRIPTION
### What does this PR do?
Remove two broken `replace` directives from
`internal/qbranch/anomalydetection-testbench/go.mod`:
```
  replace github.com/DataDog/datadog-agent/pkg/logs/client \
    => ../../../pkg/logs/client
  replace github.com/DataDog/datadog-agent/pkg/logs/metrics \
    => ../../../pkg/logs/metrics
```

### Motivation
`pkg/logs/client` and `pkg/logs/metrics` were moved to `comp/logs-library/client` in #45598 (May 15, 2026).
The testbench was added 17 days later in #51083 already referencing the deleted paths, so these directives were broken and have no effect.