### PR TITLE
Drop stale `otel/sdk/metric` pre-release `replace` directives

### DIFF
--- a/comp/otelcol/collector-contrib/def/go.mod
+++ b/comp/otelcol/collector-contrib/def/go.mod
@@ -132,8 +132,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260116114154-8c4c4ae446ca // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/comp/otelcol/ddflareextension/impl/go.mod
+++ b/comp/otelcol/ddflareextension/impl/go.mod
@@ -530,8 +530,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.155.1-0.20260626121343-03d2fb4a4514
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually

--- a/comp/otelcol/ddprofilingextension/impl/go.mod
+++ b/comp/otelcol/ddprofilingextension/impl/go.mod
@@ -149,8 +149,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260116114154-8c4c4ae446ca // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -252,8 +252,6 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.155.1-0.20260626121343-03d2fb4a4514
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -189,8 +189,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260116114154-8c4c4ae446ca // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.155.1-0.20260626121343-03d2fb4a4514
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -217,8 +217,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260116114154-8c4c4ae446ca
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.155.1-0.20260626121343-03d2fb4a4514
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually

--- a/comp/otelcol/otlp/components/metricsclient/go.mod
+++ b/comp/otelcol/otlp/components/metricsclient/go.mod
@@ -29,8 +29,6 @@ require (
 	golang.org/x/sys v0.46.0 // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/go.mod
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/go.mod
@@ -178,8 +178,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260116114154-8c4c4ae446ca // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/go.mod
+++ b/go.mod
@@ -1250,8 +1250,6 @@ replace github.com/iceber/iouring-go => github.com/lebauce/iouring-go v0.0.0-202
 // Fork to remove some text/template usage, https://github.com/DataDog/opa/tree/lightweight-1.7.1
 replace github.com/open-policy-agent/opa => github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.155.1-0.20260626121343-03d2fb4a4514
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually

--- a/pkg/config/remote/go.mod
+++ b/pkg/config/remote/go.mod
@@ -122,8 +122,6 @@ require (
 	google.golang.org/grpc v1.81.1
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/pkg/opentelemetry-mapping-go/inframetadata/go.mod
+++ b/pkg/opentelemetry-mapping-go/inframetadata/go.mod
@@ -33,8 +33,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/pkg/opentelemetry-mapping-go/otlp/attributes/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/attributes/go.mod
@@ -41,8 +41,6 @@ require (
 
 retract v0.4.0 // see #107
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/pkg/opentelemetry-mapping-go/otlp/logs/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/go.mod
@@ -63,8 +63,6 @@ require (
 
 retract v0.4.0 // see #107
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/go.mod
@@ -57,8 +57,6 @@ require (
 
 retract v0.4.0 // see #107
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/pkg/proto/go.mod
+++ b/pkg/proto/go.mod
@@ -34,8 +34,6 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -131,8 +131,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260618152121-87f3d3e198d3 // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/pkg/trace/otel/go.mod
+++ b/pkg/trace/otel/go.mod
@@ -186,8 +186,6 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/pkg/util/grpc/go.mod
+++ b/pkg/util/grpc/go.mod
@@ -104,8 +104,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260116114154-8c4c4ae446ca // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (

--- a/pkg/util/otel/go.mod
+++ b/pkg/util/otel/go.mod
@@ -35,8 +35,6 @@ require (
 	go.uber.org/zap v1.28.0 // indirect
 )
 
-replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 => go.opentelemetry.io/otel/sdk/metric v1.44.0
-
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (


### PR DESCRIPTION
### What does this PR do?
Remove a dead `replace` directive present in 19 `go.mod` files across the repo (root, `pkg/*`, `comp/otelcol/*`):
```
replace go.opentelemetry.io/otel/sdk/metric v1.43.1-0.20260514180605-442cdbdd9466 \
     => go.opentelemetry.io/otel/sdk/metric v1.44.0
```

### Motivation
The directive was added in #51481 (Jun 3, 2026) during an OTel Collector bump across 20 files.
The pre-release (dated May 14, 2026) was likely used during development, but `v1.44.0` was already the MVS-selected version at merge time: the pre-release appears in no `go.sum`.

A versioned `replace` has no effect when the specified version is absent from the build list.

#52047 (Jun 10, 2026) already removed the directive from the OCB-generated `collector-contrib/impl/go.mod` as a side-effect of regeneration.

This PR covers the remaining 19.