### PR TITLE
feat(serverless-init): introduce lifecycle package — config and child-handle

### DIFF
--- a/cmd/serverless-init/lifecycle/BUILD.bazel
+++ b/cmd/serverless-init/lifecycle/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "lifecycle",
+    srcs = [
+        "childhandle.go",
+        "config.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/cmd/serverless-init/lifecycle",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_uber_go_atomic//:atomic",
+    ],
+)
+
+dd_agent_go_test(
+    name = "lifecycle_test",
+    srcs = [
+        "childhandle_test.go",
+        "config_test.go",
+    ],
+    embed = [":lifecycle"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/cmd/serverless-init/lifecycle/childhandle.go
+++ b/cmd/serverless-init/lifecycle/childhandle.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package lifecycle
+
+import "go.uber.org/atomic"
+
+// ChildHandle exposes the user process's liveness to the lifecycle server.
+// /ready maps it directly: alive → 200, anything else → 503. The
+// pre-spawn race is absorbed by the platform's /ready retry behavior.
+type ChildHandle interface {
+	IsAlive() bool
+}
+
+// Child is the production ChildHandle. mode.RunInit calls MarkAlive once
+// cmd.Start succeeds and defers MarkDead so it fires whenever cmd.Wait
+// returns (clean exit, signal, panic, runtime.Goexit). Safe for concurrent use.
+type Child struct {
+	alive atomic.Bool
+}
+
+// NewChild returns a Child in the not-alive state.
+func NewChild() *Child { return &Child{} }
+
+// IsAlive reports whether the child process is currently running.
+func (c *Child) IsAlive() bool { return c.alive.Load() }
+
+// MarkAlive records that the child process has started.
+func (c *Child) MarkAlive() { c.alive.Store(true) }
+
+// MarkDead records that the child process has exited.
+func (c *Child) MarkDead() { c.alive.Store(false) }
+
+// noopChild is the stub used in sidecar mode. IsAlive always reports false
+// so /ready returns 503 — accurate for the no-managed-child scenario.
+// Sidecar+MicroVM is documented as out of scope; the 503 surfaces that fact
+// rather than papering over it with a static 200.
+type noopChild struct{}
+
+// NewNoopChildHandle returns a ChildHandle that always reports not-alive.
+func NewNoopChildHandle() ChildHandle { return noopChild{} }
+func (noopChild) IsAlive() bool       { return false }

--- a/cmd/serverless-init/lifecycle/childhandle_test.go
+++ b/cmd/serverless-init/lifecycle/childhandle_test.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package lifecycle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChild_StartsNotAlive(t *testing.T) {
+	assert.False(t, NewChild().IsAlive())
+}
+
+func TestChild_MarkAliveSetsAlive(t *testing.T) {
+	h := NewChild()
+	h.MarkAlive()
+	assert.True(t, h.IsAlive())
+}
+
+func TestChild_MarkDeadClearsAlive(t *testing.T) {
+	h := NewChild()
+	h.MarkAlive()
+	h.MarkDead()
+	assert.False(t, h.IsAlive())
+}
+
+func TestNoopChildHandle_AlwaysNotAlive(t *testing.T) {
+	assert.False(t, NewNoopChildHandle().IsAlive())
+}
+
+func TestChild_ZeroValueIsSafe(t *testing.T) {
+	var c Child
+	assert.False(t, c.IsAlive())
+	c.MarkAlive()
+	assert.True(t, c.IsAlive())
+	c.MarkDead()
+	assert.False(t, c.IsAlive())
+}

--- a/cmd/serverless-init/lifecycle/config.go
+++ b/cmd/serverless-init/lifecycle/config.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package lifecycle implements the AWS Lambda MicroVM lifecycle hook server.
+package lifecycle
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+)
+
+// DefaultPort is the port the MicroVM platform expects the lifecycle hook server on.
+const DefaultPort = 9000
+
+// UserAppPortEnvVar opts in to forwarding lifecycle hooks to the user app.
+const UserAppPortEnvVar = "DD_AWS_MICROVM_USER_APP_PORT"
+
+// LifecyclePortEnvVar overrides the port the lifecycle hook server listens on (default 9000).
+const LifecyclePortEnvVar = "DD_AWS_MICROVM_LIFECYCLE_PORT"
+
+// ForwardTimeoutMsEnvVar overrides the timeout (ms) for /run, /resume, /suspend, /terminate.
+const ForwardTimeoutMsEnvVar = "DD_AWS_MICROVM_FORWARD_TIMEOUT_MS"
+
+// ReadyTimeoutMsEnvVar overrides the timeout (ms) for /ready.
+const ReadyTimeoutMsEnvVar = "DD_AWS_MICROVM_READY_TIMEOUT_MS"
+
+// ValidateTimeoutMsEnvVar overrides the timeout (ms) for /validate.
+const ValidateTimeoutMsEnvVar = "DD_AWS_MICROVM_VALIDATE_TIMEOUT_MS"
+
+// parsePort parses a port number from a raw env-var string.
+// Returns defaultVal when raw is empty. Parsed port must not equal any value in forbidden.
+func parsePort(envVar, raw string, defaultVal int, forbidden ...int) (int, error) {
+	if raw == "" {
+		return defaultVal, nil
+	}
+	port, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s: must be an integer (got %q)", envVar, raw)
+	}
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("%s: must be in [1, 65535] (got %d)", envVar, port)
+	}
+	for _, f := range forbidden {
+		if port == f {
+			return 0, fmt.Errorf("%s: must not equal %d", envVar, f)
+		}
+	}
+	return port, nil
+}
+
+// parseDurationMs parses a millisecond integer env var. Returns defaultVal when raw is empty.
+func parseDurationMs(envVar, raw string, defaultVal time.Duration) (time.Duration, error) {
+	if raw == "" {
+		return defaultVal, nil
+	}
+	ms, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s: must be an integer number of milliseconds (got %q)", envVar, raw)
+	}
+	if ms <= 0 {
+		return 0, fmt.Errorf("%s: must be a positive number of milliseconds (got %d)", envVar, ms)
+	}
+	if ms > int64(math.MaxInt64/time.Millisecond) {
+		return 0, fmt.Errorf("%s: too large to represent as a duration (got %d ms)", envVar, ms)
+	}
+	return time.Duration(ms) * time.Millisecond, nil
+}

--- a/cmd/serverless-init/lifecycle/config_test.go
+++ b/cmd/serverless-init/lifecycle/config_test.go
@@ -1,0 +1,153 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package lifecycle
+
+import (
+	"math"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- parsePort: user-app-port semantics (defaultVal=0, forbidden=DefaultPort) ---
+
+func TestParsePort_UserApp_UnsetReturnsZeroNoError(t *testing.T) {
+	port, err := parsePort(UserAppPortEnvVar, "", 0, DefaultPort)
+	require.NoError(t, err)
+	assert.Equal(t, 0, port) // 0 = "not set"
+}
+
+func TestParsePort_UserApp_ValidPort(t *testing.T) {
+	port, err := parsePort(UserAppPortEnvVar, "8080", 0, DefaultPort)
+	require.NoError(t, err)
+	assert.Equal(t, 8080, port)
+}
+
+func TestParsePort_UserApp_AcceptsLowerBound(t *testing.T) {
+	port, err := parsePort(UserAppPortEnvVar, "1", 0, DefaultPort)
+	require.NoError(t, err)
+	assert.Equal(t, 1, port)
+}
+
+func TestParsePort_UserApp_AcceptsUpperBound(t *testing.T) {
+	port, err := parsePort(UserAppPortEnvVar, "65535", 0, DefaultPort)
+	require.NoError(t, err)
+	assert.Equal(t, 65535, port)
+}
+
+func TestParsePort_UserApp_RejectsNonNumeric(t *testing.T) {
+	_, err := parsePort(UserAppPortEnvVar, "abc", 0, DefaultPort)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, UserAppPortEnvVar)
+	assert.ErrorContains(t, err, "abc")
+}
+
+func TestParsePort_UserApp_RejectsZero(t *testing.T) {
+	_, err := parsePort(UserAppPortEnvVar, "0", 0, DefaultPort)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, UserAppPortEnvVar)
+	assert.ErrorContains(t, err, "0")
+}
+
+func TestParsePort_UserApp_RejectsAboveRange(t *testing.T) {
+	_, err := parsePort(UserAppPortEnvVar, "65536", 0, DefaultPort)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, UserAppPortEnvVar)
+	assert.ErrorContains(t, err, "65536")
+}
+
+func TestParsePort_UserApp_RejectsNegative(t *testing.T) {
+	_, err := parsePort(UserAppPortEnvVar, "-1", 0, DefaultPort)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, UserAppPortEnvVar)
+	assert.ErrorContains(t, err, "-1")
+}
+
+func TestParsePort_UserApp_RejectsForbiddenPort(t *testing.T) {
+	_, err := parsePort(UserAppPortEnvVar, "9000", 0, DefaultPort)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, UserAppPortEnvVar)
+	assert.ErrorContains(t, err, "9000")
+}
+
+// --- parsePort: lifecycle-port semantics (defaultVal=DefaultPort, no forbidden) ---
+
+func TestParsePort_Lifecycle_UnsetReturnsDefaultPort(t *testing.T) {
+	port, err := parsePort(LifecyclePortEnvVar, "", DefaultPort)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultPort, port)
+}
+
+func TestParsePort_Lifecycle_ValidPort(t *testing.T) {
+	port, err := parsePort(LifecyclePortEnvVar, "9001", DefaultPort)
+	require.NoError(t, err)
+	assert.Equal(t, 9001, port)
+}
+
+func TestParsePort_Lifecycle_AcceptsBounds(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want int
+	}{
+		{"1", 1}, {"65535", 65535},
+	} {
+		port, err := parsePort(LifecyclePortEnvVar, tc.raw, DefaultPort)
+		require.NoError(t, err, "raw=%q", tc.raw)
+		assert.Equal(t, tc.want, port)
+	}
+}
+
+func TestParsePort_Lifecycle_RejectsInvalid(t *testing.T) {
+	for _, raw := range []string{"abc", "0", "65536", "-1"} {
+		_, err := parsePort(LifecyclePortEnvVar, raw, DefaultPort)
+		assert.Error(t, err, "raw=%q should fail", raw)
+		assert.ErrorContains(t, err, LifecyclePortEnvVar)
+	}
+}
+
+// --- parseDurationMs ---
+
+func TestParseDurationMs_UnsetReturnsDefault(t *testing.T) {
+	got, err := parseDurationMs(ForwardTimeoutMsEnvVar, "", 30*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, got)
+}
+
+func TestParseDurationMs_ValidMs(t *testing.T) {
+	got, err := parseDurationMs(ForwardTimeoutMsEnvVar, "5000", 30*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Second, got)
+}
+
+func TestParseDurationMs_RejectsNonNumeric(t *testing.T) {
+	_, err := parseDurationMs(ForwardTimeoutMsEnvVar, "abc", 30*time.Second)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, ForwardTimeoutMsEnvVar)
+}
+
+func TestParseDurationMs_RejectsZeroAndNegative(t *testing.T) {
+	for _, raw := range []string{"0", "-1", "-1000"} {
+		_, err := parseDurationMs(ForwardTimeoutMsEnvVar, raw, 30*time.Second)
+		assert.Error(t, err, "raw=%q should fail", raw)
+	}
+}
+
+func TestParseDurationMs_AcceptsMaxRepresentableMs(t *testing.T) {
+	maxMs := int64(math.MaxInt64 / time.Millisecond)
+	got, err := parseDurationMs(ForwardTimeoutMsEnvVar, strconv.FormatInt(maxMs, 10), 30*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(maxMs)*time.Millisecond, got)
+}
+
+func TestParseDurationMs_RejectsOverflow(t *testing.T) {
+	maxMs := int64(math.MaxInt64 / time.Millisecond)
+	_, err := parseDurationMs(ForwardTimeoutMsEnvVar, strconv.FormatInt(maxMs+1, 10), 30*time.Second)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, ForwardTimeoutMsEnvVar)
+}


### PR DESCRIPTION
### What does this PR do?

Introduces the `cmd/serverless-init/lifecycle` package with two foundational files and the Bazel build file:

- **`config.go`** — parses `DD_AWS_MICROVM_*` environment variables (lifecycle server port, forward/ready/validate timeout overrides) via `parsePort` and `parseDurationMs` helpers; exports the five env-var name constants.
- **`childhandle.go`** — defines the `ChildHandle` interface and its two implementations: `Child` (a concurrency-safe alive/dead flag that the mode layer sets around `cmd.Start`/`cmd.Wait`) and `noopChild` (a stub for sidecar mode that always reports not-alive).

### Motivation

The MicroVM platform sends a `POST /ready` hook to ask whether the agent and user app are ready to be snapshotted. The lifecycle server needs to answer that question in real time. `ChildHandle` is the minimal contract for this: the mode layer records process liveness, the HTTP server reads it — neither needs to know about the other's implementation details.

`config.go` is kept separate from the server so that `wire.go` (a later PR) can parse all env vars before constructing the server or forwarder. Having the constants in one file also makes them easy to audit at a glance.

### Describe how you validated your changes

- Unit tests cover the `Child` alive/dead state machine and the `noopChild` stub.
- `config_test.go` exercises port and duration parsing, boundary conditions, and the forbidden-port collision check.

### Additional Notes

**PR stack** — this is PR 3/8:
1. `microvm-01-foundation` — shared infrastructure ✓
2. `microvm-02-cloudservice-run` — `Run()` on `CloudService` ✓
3. **This PR** — lifecycle config + child-handle
4. `microvm-04-lifecycle-forwarder` — HTTP pass-through proxy
5. `microvm-05-lifecycle-heartbeat` — periodic heartbeat metric
6. `microvm-06-lifecycle-server-wire` — lifecycle HTTP server
7. `microvm-07-microvm-service-wiring` — MicroVM `CloudService` + main wiring
8. `microvm-08-sigusr2-on-run` — SIGUSR2 on `/run`