### PR TITLE
feat(serverless-init): add MicroVM lifecycle HTTP forwarder

### DIFF
--- a/cmd/serverless-init/lifecycle/BUILD.bazel
+++ b/cmd/serverless-init/lifecycle/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "childhandle.go",
         "config.go",
+        "forwarder.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/cmd/serverless-init/lifecycle",
     visibility = ["//visibility:public"],
@@ -19,6 +20,7 @@ dd_agent_go_test(
     srcs = [
         "childhandle_test.go",
         "config_test.go",
+        "forwarder_test.go",
     ],
     embed = [":lifecycle"],
     deps = [

--- a/cmd/serverless-init/lifecycle/BUILD.bazel
+++ b/cmd/serverless-init/lifecycle/BUILD.bazel
@@ -7,10 +7,13 @@ go_library(
         "childhandle.go",
         "config.go",
         "forwarder.go",
+        "heartbeat.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/cmd/serverless-init/lifecycle",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/metrics",
+        "//pkg/util/log",
         "@org_uber_go_atomic//:atomic",
     ],
 )
@@ -21,9 +24,11 @@ dd_agent_go_test(
         "childhandle_test.go",
         "config_test.go",
         "forwarder_test.go",
+        "heartbeat_test.go",
     ],
     embed = [":lifecycle"],
     deps = [
+        "//pkg/metrics",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/cmd/serverless-init/lifecycle/forwarder.go
+++ b/cmd/serverless-init/lifecycle/forwarder.go
@@ -1,0 +1,242 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package lifecycle
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// defaultMaxResponseBodyBytes caps the user-app response body that PassThrough
+// will surface to the platform. Lifecycle responses are expected to be small
+// or empty; a 1 MiB cap prevents a misbehaving user app from OOMing the agent
+// or wedging the handler with an unbounded chunked body.
+const defaultMaxResponseBodyBytes int64 = 1 << 20
+
+const (
+	defaultForwardTimeout  = 1 * time.Second
+	defaultReadyTimeout    = 60 * time.Second
+	defaultValidateTimeout = 1 * time.Second
+)
+
+// Forwarder POSTs lifecycle hooks to the user app. It is constructed only
+// when DD_AWS_MICROVM_USER_APP_PORT is set and we're in init-container
+// mode + MicroVM origin.
+type Forwarder struct {
+	target               string        // e.g. "http://127.0.0.1:8080"
+	client               *http.Client  // shared; no client-level Timeout (per-call deadlines via ctx)
+	forwardTimeout       time.Duration // default 1s, used for suspend/terminate/run/resume
+	readyTimeout         time.Duration // default 60s, used for /ready
+	validateTimeout      time.Duration // default 1s, used for /validate
+	maxResponseBodyBytes int64         // default defaultMaxResponseBodyBytes; cap on user-app body surfaced to platform
+}
+
+// NewForwarder constructs a Forwarder targeting 127.0.0.1:<port>. The forwardTimeout
+// is used for /run, /resume, /suspend, and /terminate; readyTimeout for /ready;
+// validateTimeout for /validate. Callers should pass the default* constants above
+// or values parsed from the DD_AWS_MICROVM_*_TIMEOUT_MS env vars.
+func NewForwarder(port int, forwardTimeout, readyTimeout, validateTimeout time.Duration) *Forwarder {
+	return &Forwarder{
+		target: fmt.Sprintf("http://127.0.0.1:%d", port),
+		// DisableKeepAlives prevents the transport from caching idle connections.
+		// MicroVM instances are restored from a Firecracker snapshot, so any
+		// connection the transport pooled before the snapshot is stale on resume.
+		// Since Go's HTTP transport does not auto-retry POST on a stale connection,
+		// disabling keep-alives ensures every lifecycle hook uses a fresh dial.
+		// The overhead is negligible for loopback calls at this frequency.
+		client: &http.Client{
+			// DisableCompression prevents the transport from adding its own
+			// Accept-Encoding: gzip and transparently decompressing a gzipped
+			// response, which would strip Content-Encoding/Content-Length and
+			// change the body the platform sees. Responses must be mirrored
+			// verbatim, so compression negotiation is left to the user app.
+			Transport: &http.Transport{DisableKeepAlives: true, DisableCompression: true},
+			// Lifecycle hooks are mirrored to the platform verbatim (status, body,
+			// Content-Type). A 3xx from the user app is not part of the documented
+			// hook contract (only 200, or 503 for /ready and /validate) — silently
+			// following it would report the redirect target's response instead of
+			// the hook's own, and for 301/302/303 would replay the request as a
+			// GET with the body dropped, letting the actual hook handler's logic
+			// run before we ever observe it. Returning the 3xx as-is preserves
+			// both the mirroring contract and the platform's hook status semantics.
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		forwardTimeout:       forwardTimeout,
+		readyTimeout:         readyTimeout,
+		validateTimeout:      validateTimeout,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+}
+
+// PassThroughWaiting waits for the user app to accept TCP connections bounded
+// by timeout, then forwards the request and mirrors the response. Used for:
+//   - /ready    ("I am booted and ready to be snapshotted"): the platform
+//     retries on non-200, so the TCP wait absorbs the startup race.
+//   - /validate ("I was resumed from a snapshot and everything is good"): the
+//     TCP wait handles a crash-then-restart between resume and this
+//     call.
+//
+// Body is buffered before the TCP wait so the bytes survive waitForUserApp.
+// Deadline exceeded maps to 504. Body Close contract documented on PassThrough.
+func (f *Forwarder) PassThroughWaiting(timeout time.Duration, path string, headers http.Header, body io.Reader) *http.Response {
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		// Read the full inbound body before the TCP wait. A read error is a
+		// server-side failure (network, OS, memory) — not a client mistake —
+		// so return 500 rather than 400. We still forward nothing to the user
+		// app to avoid passing a partial body (which could make it answer
+		// /validate "healthy" off incomplete data).
+		if bodyBytes, err = io.ReadAll(body); err != nil {
+			return statusOnlyResponse(http.StatusInternalServerError)
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	if err := f.waitForUserApp(ctx); err != nil {
+		cancel()
+		return statusOnlyResponse(mapErrToStatus(err))
+	}
+	resp, err := f.do(ctx, path, headers, bytes.NewReader(bodyBytes))
+	if err != nil {
+		cancel()
+		return statusOnlyResponse(mapErrToStatus(err))
+	}
+	resp.Body = wrapResponseBody(resp.Body, f.maxResponseBodyBytes, cancel)
+	return resp
+}
+
+// waitForUserApp polls the user app's TCP port until a connection succeeds or
+// ctx is cancelled. Returns nil when the port is reachable, ctx.Err() when
+// the deadline is exceeded. Polls every 50ms.
+func (f *Forwarder) waitForUserApp(ctx context.Context) error {
+	addr := strings.TrimPrefix(f.target, "http://")
+	dialer := &net.Dialer{}
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		conn, err := dialer.DialContext(ctx, "tcp", addr)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// PassThrough forwards a per-MicroVM lifecycle hook (/run, /resume,
+// /suspend, /terminate) to the user app and returns the user-app response.
+// Bounded by forwardTimeout (default 1s) — sized as <50% of the tightest
+// AWS Lambda MicroVM platform bound (/terminate's 60s) so the agent always
+// returns within the platform's window. Dial errors map to 503; deadline
+// exceeded maps to 504. The returned *http.Response always has a non-nil
+// Body that the caller MUST Close. On the error path the Body is an empty
+// NopCloser (Close is a no-op). On the happy path the Body is wrapped
+// twice: io.LimitReader (inner) caps reads at maxResponseBodyBytes;
+// cancelOnCloseReader (outer) keeps the ctx alive across the caller's body
+// read and cancels it on Close. The cap reader MUST be the inner layer;
+// inverting the layering leaks the ctx cancel.
+func (f *Forwarder) PassThrough(path string, headers http.Header, body io.Reader) *http.Response {
+	return f.passThroughWith(f.forwardTimeout, path, headers, body)
+}
+
+func (f *Forwarder) passThroughWith(timeout time.Duration, path string, headers http.Header, body io.Reader) *http.Response {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	resp, err := f.do(ctx, path, headers, body)
+	if err != nil {
+		cancel()
+		return statusOnlyResponse(mapErrToStatus(err))
+	}
+	resp.Body = wrapResponseBody(resp.Body, f.maxResponseBodyBytes, cancel)
+	return resp
+}
+
+// wrapResponseBody applies the LimitReader-inner / cancelOnCloseReader-outer
+// layering required by PassThrough. cap <= 0 disables the cap (used in tests
+// that need the raw body); production callers always pass a positive cap.
+func wrapResponseBody(body io.ReadCloser, cap int64, cancel context.CancelFunc) io.ReadCloser {
+	inner := body
+	if cap > 0 {
+		inner = &limitedReadCloser{
+			Reader: io.LimitReader(body, cap),
+			Closer: body,
+		}
+	}
+	return &cancelOnCloseReader{ReadCloser: inner, cancel: cancel}
+}
+
+// limitedReadCloser combines io.LimitReader's Read with the original body's
+// Close. Needed because io.LimitReader returns a Reader, not a ReadCloser.
+type limitedReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func (f *Forwarder) do(ctx context.Context, path string, headers http.Header, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, f.target+path, body)
+	if err != nil {
+		return nil, err
+	}
+	if ct := headers.Get("Content-Type"); ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+	if cl := headers.Get("Content-Length"); cl != "" {
+		// Parse the platform-supplied Content-Length and assign it to
+		// req.ContentLength. Without this, net/http treats the body as having
+		// an unknown length and falls back to chunked transfer encoding, which
+		// some user-app HTTP servers reject or misparse on lifecycle endpoints.
+		// ParseInt args: base 10 (decimal string), 64-bit result size (fits
+		// int64, the type of req.ContentLength). Malformed values are logged
+		// and the request is sent without a Content-Length header.
+		if n, parseErr := strconv.ParseInt(cl, 10, 64); parseErr == nil {
+			req.ContentLength = n
+		} else {
+			log.Debugf("MicroVM lifecycle: could not parse platform Content-Length %q: %s", cl, parseErr)
+		}
+	}
+	return f.client.Do(req)
+}
+
+func mapErrToStatus(err error) int {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return http.StatusGatewayTimeout
+	}
+	return http.StatusServiceUnavailable
+}
+
+func statusOnlyResponse(status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+		Header:     make(http.Header),
+	}
+}
+
+type cancelOnCloseReader struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c *cancelOnCloseReader) Close() error {
+	err := c.ReadCloser.Close()
+	c.cancel()
+	return err
+}

--- a/cmd/serverless-init/lifecycle/forwarder_test.go
+++ b/cmd/serverless-init/lifecycle/forwarder_test.go
@@ -1,0 +1,401 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package lifecycle
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestForwarder(target string) *Forwarder {
+	return &Forwarder{
+		target:          target,
+		client:          &http.Client{},
+		forwardTimeout:  200 * time.Millisecond,
+		readyTimeout:    200 * time.Millisecond,
+		validateTimeout: 200 * time.Millisecond,
+	}
+}
+
+func TestForwarder_PassThrough_MirrorsStatusAndBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(503)
+		_, _ = w.Write([]byte(`{"ready":false}`))
+	}))
+	defer srv.Close()
+
+	f := newTestForwarder(srv.URL)
+	resp := f.PassThrough("/x", http.Header{"Content-Type": []string{"application/json"}}, bytes.NewReader([]byte("{}")))
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, 503, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, `{"ready":false}`, string(body))
+}
+
+func TestForwarder_PassThrough_TimeoutMapsTo504(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	f := newTestForwarder(srv.URL)
+	resp := f.PassThrough("/x", nil, nil)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusGatewayTimeout, resp.StatusCode)
+}
+
+func TestForwarder_PassThrough_ConnRefusedMapsTo503(t *testing.T) {
+	f := newTestForwarder("http://127.0.0.1:1") // unbound port
+	resp := f.PassThrough("/x", nil, nil)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// User-app responses that exceed the configured body cap must be truncated
+// at the cap; a misbehaving or malicious user app cannot OOM the agent or
+// wedge the handler with an unbounded body. Status code is preserved.
+func TestForwarder_PassThrough_TruncatesBodyAtCap(t *testing.T) {
+	const cap = 256
+	payload := bytes.Repeat([]byte("A"), cap*4) // 4x the cap
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	f := newTestForwarder(srv.URL)
+	f.maxResponseBodyBytes = cap
+	resp := f.PassThrough("/x", nil, nil)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, cap, len(body), "body must be truncated at maxResponseBodyBytes")
+}
+
+// TestNewForwarder_DisableKeepAlives_OpensNewConnectionPerRequest is the
+// behavioral counterpart to TestNewForwarder_Defaults. It verifies that
+// DisableKeepAlives actually prevents TCP connection reuse by counting the
+// number of new connections the test server accepts: with keep-alives disabled
+// each request must open a fresh connection, so the connection count must equal
+// the request count. A keep-alives-enabled client would reuse one connection
+// for all three requests and the counter would stay at 1.
+//
+// This matters for MicroVM snapshot/restore: any connection pooled inside a
+// Firecracker snapshot is stale on resume, and Go's HTTP transport does not
+// auto-retry POST on a stale connection. Forcing a fresh dial per call
+// eliminates the class of "first /run hook fails with 503/504" failures.
+func TestNewForwarder_DisableKeepAlives_OpensNewConnectionPerRequest(t *testing.T) {
+	var newConns atomic.Int32
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+	}))
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConns.Add(1)
+		}
+	}
+	srv.Start()
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(u.Port())
+	require.NoError(t, err)
+
+	f := NewForwarder(port, defaultForwardTimeout, defaultReadyTimeout, defaultValidateTimeout)
+	const requests = 3
+	for i := 0; i < requests; i++ {
+		resp := f.PassThrough("/x", nil, nil)
+		require.NotNil(t, resp)
+		resp.Body.Close()
+	}
+	assert.Equal(t, int32(requests), newConns.Load(),
+		"DisableKeepAlives must open a fresh TCP connection per request; with keep-alives enabled only 1 connection would be accepted")
+}
+
+// NewForwarder defaults reflect the configured wire.go constants. /ready keeps
+// a 60s budget (matches the platform hook timeout); the remaining hooks default
+// to 1s. Changing these defaults is a deliberate behavior change — the test
+// failure is intentional.
+func TestNewForwarder_Defaults(t *testing.T) {
+	f := NewForwarder(8080, defaultForwardTimeout, defaultReadyTimeout, defaultValidateTimeout)
+	assert.Equal(t, 1*time.Second, f.forwardTimeout, "forwardTimeout default must be 1s")
+	assert.Equal(t, 60*time.Second, f.readyTimeout, "readyTimeout default must be 60s (matches platform /ready hook timeout)")
+	assert.Equal(t, 1*time.Second, f.validateTimeout, "validateTimeout default must be 1s")
+	assert.Equal(t, defaultMaxResponseBodyBytes, f.maxResponseBodyBytes, "maxResponseBodyBytes default must be 1 MiB")
+	tr, ok := f.client.Transport.(*http.Transport)
+	require.True(t, ok, "transport must be *http.Transport")
+	assert.True(t, tr.DisableKeepAlives, "DisableKeepAlives must be true: MicroVM instances resume from a Firecracker snapshot, so pooled connections are stale on resume and POST is not auto-retried")
+	assert.True(t, tr.DisableCompression, "DisableCompression must be true: responses are mirrored verbatim, and transparent gzip decompression would strip Content-Encoding/Content-Length")
+}
+
+// PassThrough must not silently follow redirects returned by the user app.
+// The hook contract only recognizes 200 (success) and 503 (retry, for /ready
+// and /validate) — a 3xx is outside that contract, and Go's default client
+// would replay a POST redirect as a GET with the body dropped, letting a
+// different handler answer for the hook instead of the one the platform
+// actually invoked. PassThrough must mirror the 3xx as-is.
+func TestForwarder_PassThrough_DoesNotFollowRedirects(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/x" {
+			t.Errorf("redirect target %s must not be contacted", r.URL.Path)
+			return
+		}
+		w.Header().Set("Location", "/x/")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(u.Port())
+	require.NoError(t, err)
+
+	f := NewForwarder(port, defaultForwardTimeout, defaultReadyTimeout, defaultValidateTimeout)
+	resp := f.PassThrough("/x", nil, nil)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusFound, resp.StatusCode, "redirect must be mirrored, not followed")
+	assert.Equal(t, "/x/", resp.Header.Get("Location"))
+}
+
+// On the error path (dial error, deadline) PassThrough returns a non-nil
+// response with an empty body whose Close is a no-op. Deferred Close in
+// callers MUST be safe regardless of which path produced the response.
+func TestForwarder_PassThrough_ErrorStubBodyCloseIsNoop(t *testing.T) {
+	f := newTestForwarder("http://127.0.0.1:1") // dial-error path
+	resp := f.PassThrough("/x", nil, nil)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Body)
+	// Two consecutive closes must not error or panic — pin no-op semantics.
+	assert.NoError(t, resp.Body.Close())
+	assert.NoError(t, resp.Body.Close())
+}
+
+// PassThrough must propagate the incoming Content-Type to the user app.
+// Header forwarding is the only caller-visible piece of the request shape
+// (path is fixed, body is opaque), so it gets a dedicated pin.
+func TestForwarder_PassThrough_ForwardsContentType(t *testing.T) {
+	got := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got <- r.Header.Get("Content-Type")
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	f := newTestForwarder(srv.URL)
+	resp := f.PassThrough("/h", http.Header{"Content-Type": []string{"application/x-test"}}, nil)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	select {
+	case ct := <-got:
+		assert.Equal(t, "application/x-test", ct)
+	case <-time.After(time.Second):
+		t.Fatal("user app handler never invoked")
+	}
+}
+
+// A malformed platform Content-Length must not block the request: do() logs
+// and skips setting req.ContentLength, so net/http falls back to chunked
+// transfer instead of failing the forward.
+func TestForwarder_PassThrough_MalformedContentLengthIsIgnored(t *testing.T) {
+	got := make(chan int64, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got <- r.ContentLength
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	f := newTestForwarder(srv.URL)
+	// io.NopCloser hides the concrete *bytes.Reader type from net/http's
+	// length auto-detection, so ContentLength can only come from the header.
+	body := io.NopCloser(bytes.NewReader([]byte("payload")))
+	resp := f.PassThrough("/h", http.Header{"Content-Length": []string{"not-a-number"}}, body)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, 200, resp.StatusCode)
+	select {
+	case cl := <-got:
+		assert.Equal(t, int64(-1), cl, "malformed Content-Length must not be forwarded")
+	case <-time.After(time.Second):
+		t.Fatal("user app handler never invoked")
+	}
+}
+
+// PassThroughWaiting mirrors the user-app's status, Content-Type, and body.
+// The platform expects the user-app's actual signal, not an agent-synthesized
+// response — this pins the mirror contract shared by /ready and /validate.
+func TestForwarder_PassThroughWaiting_MirrorsStatusAndBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ready")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ready":true}`))
+	}))
+	defer srv.Close()
+
+	f := newTestForwarder(srv.URL)
+	resp := f.PassThroughWaiting(200*time.Millisecond, "/ready", nil, nil)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "application/x-ready", resp.Header.Get("Content-Type"))
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, `{"ready":true}`, string(body))
+}
+
+// PassThroughWaiting must honor the timeout it receives. The caller (server.go)
+// passes readyTimeout or validateTimeout — PassThroughWaiting must not apply
+// any other field. This test uses a 50ms timeout against a 200ms upstream: the
+// context expires and the call returns 504.
+func TestForwarder_PassThroughWaiting_HonorsProvidedTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	f := newTestForwarder(srv.URL)
+	resp := f.PassThroughWaiting(50*time.Millisecond, "/ready", nil, nil)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusGatewayTimeout, resp.StatusCode,
+		"PassThroughWaiting must time out on the provided timeout")
+}
+
+// On the happy path the response body is wrapped by cancelOnCloseReader.
+// Closing the body MUST cancel the per-call context — without this, the
+// timeout goroutine and any associated transport state leaks for the
+// remainder of the timeout window. This pins the cleanup contract that the
+// passThroughWith / wrapResponseBody layering relies on.
+func TestForwarder_PassThrough_BodyCloseCancelsContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	f := newTestForwarder(srv.URL)
+	resp := f.PassThrough("/x", nil, nil)
+	require.NotNil(t, resp)
+
+	cor, ok := resp.Body.(*cancelOnCloseReader)
+	require.True(t, ok, "happy-path body must be wrapped by cancelOnCloseReader")
+
+	called := atomic.Int32{}
+	original := cor.cancel
+	cor.cancel = func() {
+		called.Add(1)
+		original()
+	}
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, int32(1), called.Load(), "Close must invoke the per-call cancel exactly once")
+}
+
+// wrapResponseBody with cap <= 0 must skip the LimitReader layer and return
+// the body unmodified through cancelOnCloseReader. Production callers always
+// pass a positive cap, but the disable-cap branch is reachable from any test
+// that constructs a Forwarder without setting maxResponseBodyBytes — pinning
+// it here prevents accidental panic / wrong-layering regressions.
+func TestWrapResponseBody_CapZero_DisablesCap(t *testing.T) {
+	const payload = "long-enough-to-have-been-truncated-if-cap-applied"
+	body := io.NopCloser(bytes.NewReader([]byte(payload)))
+	wrapped := wrapResponseBody(body, 0, func() {})
+	defer wrapped.Close()
+
+	got, err := io.ReadAll(wrapped)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(got),
+		"cap=0 must read the full body — LimitReader must NOT be applied")
+}
+
+// PassThroughWaiting retries TCP dials until the context expires when the port
+// is unbound, so the response is always 504 (deadline exceeded) — never 503.
+// This is distinct from PassThrough which returns 503 on the very first
+// connect-refused error. The behavioral difference is intentional: /ready and
+// /validate must wait for the user app to start, not fail-fast on a transient
+// dial error.
+func TestForwarder_PassThroughWaiting_UnboundPort_RetriesUntilTimeout504(t *testing.T) {
+	f := &Forwarder{
+		target: "http://127.0.0.1:1", // unbound — every dial attempt is refused
+		client: &http.Client{},
+	}
+	resp := f.PassThroughWaiting(150*time.Millisecond, "/ready", nil, nil)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusGatewayTimeout, resp.StatusCode,
+		"unbound port must retry until timeout (504), not immediately 503 like PassThrough")
+}
+
+// passThroughWaiting buffers the request body before the TCP wait so it is
+// still available after waitForUserApp returns. Without buffering, the body
+// reader would be exhausted during the wait loop and f.do would send an empty
+// body to the user app. This pins the buffer-then-forward contract.
+func TestForwarder_PassThroughWaiting_ForwardsBodyAfterTCPWait(t *testing.T) {
+	received := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		received <- b
+	}))
+	defer srv.Close()
+
+	f := newTestForwarder(srv.URL)
+	payload := []byte(`{"checksum":"abc123"}`)
+	resp := f.PassThroughWaiting(200*time.Millisecond, "/ready", nil, bytes.NewReader(payload))
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+
+	select {
+	case got := <-received:
+		assert.Equal(t, payload, got, "body must survive the TCP wait and arrive at the user app intact")
+	case <-time.After(time.Second):
+		t.Fatal("user app handler never invoked")
+	}
+}
+
+// errReader fails on Read, simulating a truncated/aborted inbound platform
+// request body (e.g. the platform disconnects mid-transfer).
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+
+// A failed read of the inbound body must NOT forward a partial body to the
+// user app. PassThroughWaiting returns 500 (server-side read failure) and
+// short-circuits before the TCP wait so no partial body reaches the user app.
+func TestForwarder_PassThroughWaiting_BodyReadError_Returns500(t *testing.T) {
+	var reached atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	f := newTestForwarder(srv.URL)
+	resp := f.PassThroughWaiting(200*time.Millisecond, "/validate", nil, errReader{})
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode,
+		"a failed inbound body read is a server-side error and must return 500")
+	assert.Equal(t, int32(0), reached.Load(),
+		"user app must not be contacted when the inbound body cannot be read")
+}

--- a/cmd/serverless-init/lifecycle/heartbeat.go
+++ b/cmd/serverless-init/lifecycle/heartbeat.go
@@ -1,0 +1,232 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package lifecycle
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// DefaultHeartbeatInterval is the period between heartbeat metrics. The
+// interval is hardcoded for now; if the platform team needs to tune it,
+// promote to a config value (see DD_AWS_MICROVM_* convention used by
+// the forwarder port env var).
+const DefaultHeartbeatInterval = 5 * time.Minute
+
+const (
+	activeInstancesMetricName = "aws.lambda.enhanced.microvm.active_instances"
+
+	// UnknownTagValue is the placeholder used when a tag value has not yet
+	// been observed (e.g. MicroVM ID before /run, or ARN fields that
+	// cannot be parsed). Exported so cloudservice can reference the sentinel
+	// without duplicating the string literal.
+	UnknownTagValue = "unknown"
+)
+
+// MetricEmitter can emit a single enhanced metric. Satisfied by
+// *serverlessMetrics.ServerlessMetricAgent.
+type MetricEmitter interface {
+	AddEnhancedMetric(name string, value float64, source metrics.MetricSource, timestamp float64, extraTags ...string)
+}
+
+// Heartbeat periodically emits a heartbeat metric while the MicroVM is in
+// the "running" phase (between /run and /suspend or /terminate).
+//
+// This type is MicroVM-specific: it is constructed only by main.go's
+// newLifecycleServerIfMicroVM, which itself short-circuits to nil for
+// non-MicroVM cloud services. Do not wire Heartbeat into other code paths.
+//
+// Start and Stop are idempotent and safe to call from concurrent goroutines.
+// Stop waits up to heartbeatStopTimeout for the goroutine to exit. If it times
+// out (goroutine blocked in AddEnhancedMetric), h.cancel is left set so a Start
+// that races the drain does not spawn a second, overlapping emit goroutine.
+// Instead Start records the desired running state (wantRunning); when the
+// blocked goroutine finally drains it relaunches a fresh goroutine if a Start
+// arrived in the meantime, so a /resume that raced a slow /suspend is not
+// silently dropped.
+type Heartbeat struct {
+	interval      time.Duration
+	metricEmitter MetricEmitter
+	metricSource  metrics.MetricSource
+
+	// baseTags are Datadog "key:value" tag strings, immutable after
+	// construction. Supplied by cloudservice.MicroVM.Init, which currently
+	// passes a single entry: "microvm_image_arn:<arn>" (the raw image ARN from
+	// AWS_LAMBDA_MICROVM_IMAGE_ARN, or "unknown" when the env var is unset). The
+	// per-emit "microvm_id:<id>" tag is appended separately in tagsForEmit.
+	baseTags []string
+
+	mu          sync.Mutex
+	wantRunning bool // desired running state: Start sets true, Stop false
+	cancel      context.CancelFunc
+	done        chan struct{}
+	microVMID   string // mutable via SetMicroVMID; "unknown" until set
+}
+
+// NewHeartbeat constructs a Heartbeat. Non-positive interval falls back to
+// DefaultHeartbeatInterval. baseTags are tags known at construction time
+// (typically derived from env vars, e.g., microvm_image_arn); the
+// microvm_id tag is appended at emit time and is set at runtime via
+// SetMicroVMID from the /run request.
+func NewHeartbeat(interval time.Duration, emitter MetricEmitter, source metrics.MetricSource, baseTags []string) *Heartbeat {
+	if interval <= 0 {
+		interval = DefaultHeartbeatInterval
+	}
+	return &Heartbeat{
+		interval:      interval,
+		metricEmitter: emitter,
+		metricSource:  source,
+		baseTags:      slices.Clone(baseTags),
+		microVMID:     UnknownTagValue,
+	}
+}
+
+// BaseTags returns the immutable tags set at construction (e.g. microvm_image_arn).
+// Safe to call on a nil receiver. Exposed for white-box tests in external packages.
+func (h *Heartbeat) BaseTags() []string {
+	if h == nil {
+		return nil
+	}
+	return slices.Clone(h.baseTags)
+}
+
+// SetMicroVMID records the MicroVM instance ID extracted from the /run
+// request header. Empty input is ignored so the existing value (default
+// "unknown" or a previously-set ID) is preserved. Safe to call concurrently
+// with the emitting goroutine; the change is visible on the next tick.
+func (h *Heartbeat) SetMicroVMID(id string) {
+	if h == nil || id == "" {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.microVMID = id
+}
+
+// Start launches the heartbeat goroutine. It records the desired running state
+// (wantRunning) and spawns the goroutine unless one is already running or still
+// draining after a timed-out Stop. In the draining case the goroutine's cleanup
+// relaunches it (see run), so a /resume that races a slow /suspend is honored
+// rather than dropped. No-op on a nil receiver, so callers can invoke
+// unconditionally.
+func (h *Heartbeat) Start() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.wantRunning = true
+	if h.cancel != nil {
+		// A goroutine is running, or a previous one is still draining after a
+		// timed-out Stop. Don't spawn an overlapping goroutine; if it is
+		// draining, its cleanup relaunches because wantRunning is now set.
+		return
+	}
+	h.startLocked()
+}
+
+// startLocked spawns the heartbeat goroutine. The caller must hold h.mu and
+// must have verified h.cancel == nil.
+func (h *Heartbeat) startLocked() {
+	ctx, cancel := context.WithCancel(context.Background())
+	h.cancel = cancel
+	h.done = make(chan struct{})
+	go h.run(ctx, h.done)
+	log.Debugf("MicroVM lifecycle: heartbeat started (interval=%s)", h.interval)
+}
+
+// heartbeatStopTimeout bounds how long Stop waits for the emit goroutine to
+// exit. AddEnhancedMetric can block when the metric-agent samples channel is
+// full; without a deadline, /suspend and /terminate would hang past
+// flushTimeout waiting for the heartbeat to drain.
+const heartbeatStopTimeout = 1 * time.Second
+
+// Stop cancels the heartbeat goroutine and waits up to heartbeatStopTimeout
+// for it to exit. No-op if not running or if the receiver is nil. It clears
+// wantRunning first so that if the goroutine is still blocked after the
+// timeout, its eventual drain does not relaunch (Stop wins over an earlier
+// Start). If the goroutine is still blocked after the timeout, Stop returns
+// without clearing h.cancel so a racing Start does not spawn an overlapping
+// goroutine.
+func (h *Heartbeat) Stop() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	h.wantRunning = false
+	if h.cancel == nil {
+		h.mu.Unlock()
+		return
+	}
+	cancel := h.cancel
+	done := h.done
+	h.mu.Unlock()
+
+	cancel()
+	select {
+	case <-done:
+		log.Debug("MicroVM lifecycle: heartbeat stopped")
+	case <-time.After(heartbeatStopTimeout):
+		log.Warn("MicroVM lifecycle: heartbeat goroutine did not stop within deadline; continuing shutdown")
+	}
+}
+
+func (h *Heartbeat) run(ctx context.Context, done chan struct{}) {
+	defer func() {
+		// Clear h.cancel and h.done under the lock before signalling done, so
+		// that once Stop() returns (or once done is closed), Start() sees nil
+		// and can safely spawn a new goroutine. The identity check on h.done
+		// guards against a hypothetical second goroutine clearing a newer done.
+		h.mu.Lock()
+		if h.done == done {
+			h.cancel = nil
+			h.done = nil
+			// If a Start (e.g. a /resume) arrived while this goroutine was
+			// draining after a timed-out Stop, honor it now by relaunching a
+			// fresh goroutine so the resumed MicroVM keeps emitting heartbeats.
+			if h.wantRunning {
+				h.startLocked()
+			}
+		}
+		h.mu.Unlock()
+		close(done)
+	}()
+	// Emit once immediately so a metric is recorded even if the MicroVM
+	// instance is terminated before the first ticker interval elapses.
+	h.emit()
+	ticker := time.NewTicker(h.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.emit()
+		}
+	}
+}
+
+func (h *Heartbeat) emit() {
+	timestamp := float64(time.Now().UnixNano()) / float64(time.Second)
+	h.metricEmitter.AddEnhancedMetric(activeInstancesMetricName, 1.0, h.metricSource, timestamp, h.tagsForEmit()...)
+}
+
+// tagsForEmit returns a fresh tag slice combining the immutable base tags
+// (set at construction) with the current microvm_id (set at /run).
+func (h *Heartbeat) tagsForEmit() []string {
+	h.mu.Lock()
+	id := h.microVMID
+	h.mu.Unlock()
+	tags := make([]string, 0, len(h.baseTags)+1)
+	tags = append(tags, h.baseTags...)
+	tags = append(tags, "microvm_id:"+id)
+	return tags
+}

--- a/cmd/serverless-init/lifecycle/heartbeat.go
+++ b/cmd/serverless-init/lifecycle/heartbeat.go
@@ -19,7 +19,7 @@ import (
 // interval is hardcoded for now; if the platform team needs to tune it,
 // promote to a config value (see DD_AWS_MICROVM_* convention used by
 // the forwarder port env var).
-const DefaultHeartbeatInterval = 5 * time.Minute
+const DefaultHeartbeatInterval = 10 * time.Second
 
 const (
 	activeInstancesMetricName = "aws.lambda.enhanced.microvm.active_instances"

--- a/cmd/serverless-init/lifecycle/heartbeat_test.go
+++ b/cmd/serverless-init/lifecycle/heartbeat_test.go
@@ -1,0 +1,481 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package lifecycle
+
+import (
+	"runtime"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// emittedMetric records one AddEnhancedMetric call.
+type emittedMetric struct {
+	name      string
+	value     float64
+	timestamp float64
+	extraTags []string
+}
+
+// mockMetricEmitter records metric calls. Protected by mu for goroutine safety.
+type mockMetricEmitter struct {
+	mu      sync.Mutex
+	metrics []emittedMetric
+}
+
+func (m *mockMetricEmitter) AddEnhancedMetric(name string, value float64, _ metrics.MetricSource, ts float64, tags ...string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.metrics = append(m.metrics, emittedMetric{name: name, value: value, timestamp: ts, extraTags: slices.Clone(tags)})
+}
+
+func (m *mockMetricEmitter) getEmitted() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	names := make([]string, len(m.metrics))
+	for i, em := range m.metrics {
+		names[i] = em.name
+	}
+	return names
+}
+
+func (m *mockMetricEmitter) getEmittedMetrics() []emittedMetric {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]emittedMetric, len(m.metrics))
+	copy(result, m.metrics)
+	return result
+}
+
+// lastTags returns the tag slice from the most recent emission, or nil if
+// nothing has been emitted yet.
+func (m *mockMetricEmitter) lastTags() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.metrics) == 0 {
+		return nil
+	}
+	return slices.Clone(m.metrics[len(m.metrics)-1].extraTags)
+}
+
+func newTestHeartbeat(interval time.Duration) (*Heartbeat, *mockMetricEmitter) {
+	emitter := &mockMetricEmitter{}
+	hb := NewHeartbeat(interval, emitter, metrics.MetricSourceAWSMicroVMEnhanced, []string{"microvm_image_arn:test-arn"})
+	return hb, emitter
+}
+
+func TestNewHeartbeat_NonPositiveIntervalFallsBackToDefault(t *testing.T) {
+	for _, in := range []time.Duration{0, -1, -time.Second} {
+		hb := NewHeartbeat(in, &mockMetricEmitter{}, metrics.MetricSourceAWSMicroVMEnhanced, nil)
+		assert.Equal(t, DefaultHeartbeatInterval, hb.interval, "interval=%s should fall back to default", in)
+	}
+}
+
+// TestHeartbeat_EmitsImmediatelyOnStart verifies that a heartbeat metric is
+// recorded as soon as the goroutine starts, before the first ticker interval
+// elapses. This guarantees at least one emission for very short-lived instances.
+func TestHeartbeat_EmitsImmediatelyOnStart(t *testing.T) {
+	// Use a very long interval so the ticker cannot fire during the test window.
+	hb, emitter := newTestHeartbeat(time.Hour)
+	hb.Start()
+	defer hb.Stop()
+
+	require.Eventually(t, func() bool {
+		return countOfMetric(emitter, activeInstancesMetricName) >= 1
+	}, 500*time.Millisecond, time.Millisecond, "must emit once immediately, without waiting for the ticker")
+}
+
+// TestHeartbeat_EmitsAtInterval verifies the goroutine emits at the configured
+// cadence and that emitted metrics carry the configured tags + source.
+func TestHeartbeat_EmitsAtInterval(t *testing.T) {
+	const interval = 20 * time.Millisecond
+	hb, emitter := newTestHeartbeat(interval)
+	hb.Start()
+	defer hb.Stop()
+
+	// Wait long enough for at least 3 ticks. Allow generous slack so a slow
+	// CI runner doesn't flake.
+	require.Eventually(t, func() bool {
+		return countOfMetric(emitter, activeInstancesMetricName) >= 3
+	}, 2*time.Second, 5*time.Millisecond, "expected at least 3 heartbeat emissions")
+
+	for _, name := range emitter.getEmitted() {
+		assert.Equal(t, activeInstancesMetricName, name,
+			"unexpected metric name from heartbeat goroutine: %s", name)
+	}
+}
+
+// TestHeartbeat_StartIsIdempotent_NoDoubleEmission verifies that calling
+// Start twice does not spawn a second goroutine — the emission rate stays
+// consistent with a single goroutine.
+func TestHeartbeat_StartIsIdempotent_NoDoubleEmission(t *testing.T) {
+	hb, emitter := newTestHeartbeat(50 * time.Millisecond)
+	hb.Start()
+	hb.Start() // duplicate call
+
+	// Wait deterministically for at least 3 emissions (1 immediate + 2 ticks),
+	// then stop to freeze the count before checking the upper bound.
+	// With two goroutines (bug): count would be ~2× the single-goroutine rate.
+	require.Eventually(t, func() bool {
+		return countOfMetric(emitter, activeInstancesMetricName) >= 3
+	}, 2*time.Second, 5*time.Millisecond, "should have emitted at least 3 times (1 immediate + 2 ticks)")
+	hb.Stop()
+
+	count := countOfMetric(emitter, activeInstancesMetricName)
+	assert.GreaterOrEqual(t, count, 3, "should have emitted at least 3 times (1 immediate + 2 ticks)")
+	assert.LessOrEqual(t, count, 5, "double-Start must not double the emission rate")
+}
+
+func TestHeartbeat_StopIsIdempotent(t *testing.T) {
+	hb, _ := newTestHeartbeat(50 * time.Millisecond)
+	hb.Start()
+	hb.Stop()
+	assert.NotPanics(t, func() { hb.Stop() }, "second Stop must be a no-op, not a panic")
+}
+
+func TestHeartbeat_StopOnNilReceiverIsSafe(t *testing.T) {
+	var hb *Heartbeat
+	assert.NotPanics(t, func() { hb.Stop() })
+}
+
+func TestHeartbeat_StartOnNilReceiverIsSafe(t *testing.T) {
+	var hb *Heartbeat
+	assert.NotPanics(t, func() { hb.Start() })
+}
+
+// TestHeartbeat_RestartAfterStopWorks pins the resume scenario: /suspend
+// stops the heartbeat, /resume starts it again, and emissions continue.
+func TestHeartbeat_RestartAfterStopWorks(t *testing.T) {
+	hb, emitter := newTestHeartbeat(20 * time.Millisecond)
+	hb.Start()
+	require.Eventually(t, func() bool {
+		return countOfMetric(emitter, activeInstancesMetricName) >= 1
+	}, 500*time.Millisecond, 5*time.Millisecond)
+	hb.Stop()
+	beforeRestart := countOfMetric(emitter, activeInstancesMetricName)
+
+	hb.Start()
+	defer hb.Stop()
+	require.Eventually(t, func() bool {
+		return countOfMetric(emitter, activeInstancesMetricName) > beforeRestart+1
+	}, 500*time.Millisecond, 5*time.Millisecond, "heartbeat must resume emissions after restart")
+}
+
+// TestHeartbeat_StopWaitsForGoroutineToExit verifies that Stop blocks until
+// the goroutine is actually gone, not just until ctx is cancelled. run's
+// deferred cleanup clears h.cancel/h.done under the lock before closing
+// done, and Stop blocks on <-done, so once Stop returns, cancel/done being
+// nil proves the goroutine's cleanup already ran.
+func TestHeartbeat_StopWaitsForGoroutineToExit(t *testing.T) {
+	hb, _ := newTestHeartbeat(50 * time.Millisecond)
+	hb.Start()
+	hb.Stop()
+
+	hb.mu.Lock()
+	defer hb.mu.Unlock()
+	assert.Nil(t, hb.cancel, "heartbeat goroutine's cleanup must have run before Stop returns")
+	assert.Nil(t, hb.done, "heartbeat goroutine's cleanup must have run before Stop returns")
+}
+
+// TestHeartbeat_StopIsUnblockedWhenEmitterStuck verifies that Stop returns
+// within heartbeatStopTimeout even when AddEnhancedMetric blocks indefinitely
+// (e.g. the metric-agent samples channel is full). Without the timeout,
+// /suspend and /terminate would hang past flushTimeout.
+//
+// It also verifies that, absent a racing Start, the goroutine does NOT relaunch
+// after it finally drains: Stop cleared wantRunning, so the cleanup leaves the
+// heartbeat stopped.
+func TestHeartbeat_StopIsUnblockedWhenEmitterStuck(t *testing.T) {
+	block := make(chan struct{}) // closed later to unblock the emitter
+	blocker := &blockingMetricEmitter{block: block}
+	hb := NewHeartbeat(time.Millisecond /* fire immediately */, blocker, metrics.MetricSourceAWSMicroVMEnhanced, nil)
+	hb.Start()
+
+	// Wait until the goroutine is blocked inside AddEnhancedMetric.
+	require.Eventually(t, func() bool { return blocker.isBlocked() }, time.Second, time.Millisecond)
+
+	start := time.Now()
+	hb.Stop()
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, heartbeatStopTimeout+200*time.Millisecond,
+		"Stop must return within heartbeatStopTimeout even when emitter is stuck")
+
+	// Unblock the emitter. The stuck goroutine exits AddEnhancedMetric, sees the
+	// cancelled context, and self-cleans. Because Stop cleared wantRunning, the
+	// cleanup must NOT relaunch.
+	close(block)
+	require.Eventually(t, func() bool {
+		hb.mu.Lock()
+		defer hb.mu.Unlock()
+		return hb.cancel == nil // drained and cleaned up
+	}, time.Second, time.Millisecond, "goroutine must self-clean after emitter unblocks")
+
+	countAfterDrain := blocker.callCount()
+	// No relaunch: a relaunched goroutine would emit immediately and then every
+	// millisecond, so the call count would keep climbing. It must stay flat.
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, countAfterDrain, blocker.callCount(),
+		"without a racing Start, the drained goroutine must not relaunch")
+
+	hb.mu.Lock()
+	assert.False(t, hb.wantRunning, "Stop must leave wantRunning false")
+	assert.Nil(t, hb.cancel, "no goroutine should be running")
+	hb.mu.Unlock()
+}
+
+// TestHeartbeat_ResumeDuringStuckStopRestartsHeartbeat pins the fix for the
+// resume-during-drain race: when /suspend's Stop times out because
+// AddEnhancedMetric is blocked, a /resume (Start) that arrives during the drain
+// window must not be dropped. Start records the intent without spawning an
+// overlapping goroutine; once the blocked goroutine drains, the heartbeat
+// relaunches so active-instance emissions resume for the resumed MicroVM.
+func TestHeartbeat_ResumeDuringStuckStopRestartsHeartbeat(t *testing.T) {
+	block := make(chan struct{})
+	blocker := &blockingMetricEmitter{block: block}
+	hb := NewHeartbeat(time.Millisecond /* fire immediately */, blocker, metrics.MetricSourceAWSMicroVMEnhanced, nil)
+	hb.Start()
+
+	require.Eventually(t, func() bool { return blocker.isBlocked() }, time.Second, time.Millisecond)
+
+	// /suspend: Stop times out because the emitter is stuck; h.cancel stays set.
+	hb.Stop()
+
+	// /resume during the drain window: must record intent but not spawn an
+	// overlapping goroutine while the old one is still blocked. The no-op path
+	// acquires the mutex and returns synchronously, so the goroutine count is
+	// stable across the call.
+	before := runtime.NumGoroutine()
+	hb.Start()
+	assert.Equal(t, before, runtime.NumGoroutine(),
+		"Start during drain must not spawn an overlapping goroutine")
+	hb.mu.Lock()
+	wantRunning := hb.wantRunning
+	hb.mu.Unlock()
+	assert.True(t, wantRunning, "Start must record the desired running state")
+
+	countAtResume := blocker.callCount()
+
+	// Unblock the stuck goroutine. It drains and, because wantRunning is set,
+	// its cleanup relaunches a fresh goroutine that resumes emitting.
+	close(block)
+	require.Eventually(t, func() bool {
+		return blocker.callCount() > countAtResume
+	}, 2*time.Second, time.Millisecond,
+		"heartbeat must relaunch and resume emitting after the stuck goroutine drains")
+
+	hb.Stop() // clean up the relaunched goroutine
+}
+
+// Until SetMicroVMID is called, the heartbeat tags microvm_id with the
+// placeholder "unknown". Production wiring sets the ID at /run before
+// Start, so this state should never reach an emitted metric in practice;
+// the test pins the contract anyway in case wiring changes.
+func TestHeartbeat_TagsForEmit_DefaultsMicroVMIDToUnknown(t *testing.T) {
+	hb := NewHeartbeat(time.Hour, &mockMetricEmitter{}, metrics.MetricSourceAWSMicroVMEnhanced, []string{"microvm_image_arn:test-arn"})
+	tags := hb.tagsForEmit()
+	assert.Contains(t, tags, "microvm_image_arn:test-arn")
+	assert.Contains(t, tags, "microvm_id:unknown")
+}
+
+// When resourceName is empty the microvm_image_arn tag must be absent — an
+// empty tag value would create a junk time-series in the metrics backend.
+func TestHeartbeat_TagsForEmit_NoARNTagWhenResourceNameEmpty(t *testing.T) {
+	hb := NewHeartbeat(time.Hour, &mockMetricEmitter{}, metrics.MetricSourceAWSMicroVMEnhanced, nil)
+	for _, tag := range hb.tagsForEmit() {
+		assert.NotContains(t, tag, "microvm_image_arn",
+			"microvm_image_arn must not appear when resourceName is empty")
+	}
+}
+
+func TestHeartbeat_SetMicroVMID_ReflectsOnEmittedTags(t *testing.T) {
+	hb := NewHeartbeat(time.Hour, &mockMetricEmitter{}, metrics.MetricSourceAWSMicroVMEnhanced, []string{"microvm_image_arn:test-arn"})
+	hb.SetMicroVMID("mvm-abc123")
+	tags := hb.tagsForEmit()
+	assert.Contains(t, tags, "microvm_image_arn:test-arn")
+	assert.Contains(t, tags, "microvm_id:mvm-abc123")
+}
+
+// TestHeartbeat_EmittedMetric_CarriesARNTag verifies end-to-end that the
+// microvm_image_arn tag derived from resourceName reaches AddEnhancedMetric.
+// Testing tagsForEmit() in isolation does not prove emitAll passes the tags
+// through correctly; this test closes that gap.
+func TestHeartbeat_EmittedMetric_CarriesARNTag(t *testing.T) {
+	emitter := &mockMetricEmitter{}
+	hb := NewHeartbeat(time.Hour, emitter, metrics.MetricSourceAWSMicroVMEnhanced, []string{"microvm_image_arn:my-image-arn"})
+	hb.Start()
+	defer hb.Stop()
+
+	require.Eventually(t, func() bool {
+		return countOfMetric(emitter, activeInstancesMetricName) >= 1
+	}, 500*time.Millisecond, time.Millisecond)
+
+	var hbMetric *emittedMetric
+	for _, m := range emitter.getEmittedMetrics() {
+		m := m
+		if m.name == activeInstancesMetricName {
+			hbMetric = &m
+			break
+		}
+	}
+	require.NotNil(t, hbMetric)
+	assert.Contains(t, hbMetric.extraTags, "microvm_image_arn:my-image-arn",
+		"ARN from resourceName must appear in the emitted heartbeat metric tags")
+}
+
+// Empty SetMicroVMID input is ignored — preserves the existing value rather
+// than clobbering with empty. Defends against a /run where the platform
+// header is missing: the heartbeat keeps emitting with whatever ID was
+// last seen (or "unknown" if never set).
+func TestHeartbeat_SetMicroVMID_EmptyIsIgnored(t *testing.T) {
+	hb := NewHeartbeat(time.Hour, &mockMetricEmitter{}, metrics.MetricSourceAWSMicroVMEnhanced, nil)
+	hb.SetMicroVMID("first-id")
+	hb.SetMicroVMID("")
+	tags := hb.tagsForEmit()
+	assert.Contains(t, tags, "microvm_id:first-id", "empty ID must not clobber the existing value")
+}
+
+func TestHeartbeat_SetMicroVMID_OnNilReceiverIsSafe(t *testing.T) {
+	var hb *Heartbeat
+	assert.NotPanics(t, func() { hb.SetMicroVMID("anything") })
+}
+
+// When the heartbeat goroutine is running, a SetMicroVMID call must be
+// reflected on subsequent emissions. The mock emitter records full tag
+// slices so we can assert on what reached AddEnhancedMetric.
+func TestHeartbeat_SetMicroVMID_VisibleOnNextTick(t *testing.T) {
+	emitter := &mockMetricEmitter{}
+	hb := NewHeartbeat(20*time.Millisecond, emitter, metrics.MetricSourceAWSMicroVMEnhanced, nil)
+	hb.Start()
+	defer hb.Stop()
+
+	require.Eventually(t, func() bool {
+		return countOfMetric(emitter, activeInstancesMetricName) >= 1
+	}, 500*time.Millisecond, 5*time.Millisecond)
+
+	hb.SetMicroVMID("mvm-after-start")
+	// Wait for at least one tick after the SetMicroVMID call.
+	emittedBefore := countOfMetric(emitter, activeInstancesMetricName)
+	require.Eventually(t, func() bool {
+		return countOfMetric(emitter, activeInstancesMetricName) > emittedBefore
+	}, 500*time.Millisecond, 5*time.Millisecond)
+
+	// The most recent emission must carry the updated ID.
+	last := emitter.lastTags()
+	require.NotNil(t, last)
+	assert.Contains(t, last, "microvm_id:mvm-after-start")
+}
+
+// TestHeartbeat_EmittedMetricsCarryCurrentTimestamp verifies that heartbeat
+// emissions go through emitMetric (current wall-clock) rather than the 0
+// sentinel. The window bounds the timestamp to the observed emission window,
+// guarding against unit regressions (e.g. reverting to the 0 sentinel).
+func TestHeartbeat_EmittedMetricsCarryCurrentTimestamp(t *testing.T) {
+	hb, emitter := newTestHeartbeat(20 * time.Millisecond)
+
+	before := float64(time.Now().UnixNano()) / float64(time.Second)
+	hb.Start()
+	defer hb.Stop()
+
+	require.Eventually(t, func() bool {
+		return countOfMetric(emitter, activeInstancesMetricName) >= 1
+	}, 500*time.Millisecond, 5*time.Millisecond, "expected at least one heartbeat emission")
+
+	after := float64(time.Now().UnixNano()) / float64(time.Second)
+
+	for _, m := range emitter.getEmittedMetrics() {
+		assert.Greater(t, m.timestamp, 0.0, "timestamp must not be the 0 sentinel")
+		assert.GreaterOrEqual(t, m.timestamp, before, "timestamp must be at or after pre-start time")
+		assert.LessOrEqual(t, m.timestamp, after, "timestamp must be at or before observation time")
+	}
+}
+
+// countOfMetric returns the number of times metricName appears in the mock
+// emitter's recorded emissions.
+func countOfMetric(m *mockMetricEmitter, metricName string) int {
+	emitted := m.getEmitted()
+	count := 0
+	for _, n := range emitted {
+		if n == metricName {
+			count++
+		}
+	}
+	return count
+}
+
+// blockingMetricEmitter blocks inside AddEnhancedMetric until its block
+// channel is closed. Used to simulate a full metric-agent samples channel.
+type blockingMetricEmitter struct {
+	mu      sync.Mutex
+	blocked bool
+	count   int
+	block   chan struct{}
+}
+
+func (b *blockingMetricEmitter) AddEnhancedMetric(_ string, _ float64, _ metrics.MetricSource, _ float64, _ ...string) {
+	b.mu.Lock()
+	b.blocked = true
+	b.count++
+	b.mu.Unlock()
+	<-b.block // blocks until closed
+	b.mu.Lock()
+	b.blocked = false
+	b.mu.Unlock()
+}
+
+func (b *blockingMetricEmitter) isBlocked() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.blocked
+}
+
+func (b *blockingMetricEmitter) callCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.count
+}
+
+// noopMetricEmitter discards metrics. Used by benchmarks to isolate the
+// Start/Stop lifecycle cost from any emitter bookkeeping/allocations.
+type noopMetricEmitter struct{}
+
+func (noopMetricEmitter) AddEnhancedMetric(_ string, _ float64, _ metrics.MetricSource, _ float64, _ ...string) {
+}
+
+// BenchmarkHeartbeat_StartStopCycle measures a full lifecycle churn: Start
+// spawns the emit goroutine and Stop cancels and joins it. This is the path
+// driven by /run, /suspend, /resume, /terminate. A long interval keeps the
+// ticker from firing, so the measurement reflects goroutine spawn+join plus the
+// wantRunning bookkeeping the fix added — not the emit cadence.
+func BenchmarkHeartbeat_StartStopCycle(b *testing.B) {
+	hb := NewHeartbeat(time.Hour, noopMetricEmitter{}, metrics.MetricSourceAWSMicroVMEnhanced, []string{"microvm_image_arn:bench"})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hb.Start()
+		hb.Stop()
+	}
+}
+
+// BenchmarkHeartbeat_StartWhileRunning isolates the idempotent Start path
+// (heartbeat already running): acquire the mutex, set wantRunning, observe
+// cancel != nil, return. This is exactly the per-call overhead the fix adds on
+// the no-op path — it should be a handful of ns with zero allocations.
+func BenchmarkHeartbeat_StartWhileRunning(b *testing.B) {
+	hb := NewHeartbeat(time.Hour, noopMetricEmitter{}, metrics.MetricSourceAWSMicroVMEnhanced, nil)
+	hb.Start()
+	defer hb.Stop()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hb.Start() // no-op: already running
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds `lifecycle/forwarder.go`: an HTTP proxy that passes MicroVM lifecycle hooks (`/ready`, `/validate`, `/run`, `/resume`, `/suspend`, `/terminate`) from the platform through to the user application, when `DD_AWS_MICROVM_USER_APP_PORT` is set.

Key behaviours:
- Mirrors status code, response body (up to 1 MiB), and `Content-Type` back to the platform so the platform sees the user app's response, not the agent's.
- Does not follow redirects returned by the user app — a 3xx is mirrored back as-is instead of being silently followed, which would otherwise replay a POST as a GET (dropping the body) and report the redirect target's response instead of the hook's own.
- `/ready` and `/validate` perform a TCP dial-wait before forwarding: the forwarder retries until the user app's port is reachable or the timeout expires. This absorbs the race between the platform's first `/ready` and the user app's TCP listener coming up.
- `/run`, `/resume`, `/suspend`, `/terminate` forward with a short deadline (`DD_AWS_MICROVM_FORWARD_TIMEOUT_MS`, default 1 s), which is appropriate since these are informational hooks with tight platform deadlines.

Also lowers `DefaultHeartbeatInterval` from 5 minutes to 10 seconds, per review feedback: relying on a steady multi-minute submission for billing is risky since a missed or double-submitted point has outsized impact. Emitting more frequently and deduping downstream is safer.

### Motivation

By default the agent handles all lifecycle hooks autonomously — it answers `/ready` based on child-process liveness, emits metrics, flushes telemetry, and so on. But some user applications also need to react to lifecycle events (e.g. warm their own caches on `/run`, checkpoint state on `/suspend`). The forwarder enables this opt-in pass-through mode: the agent does its own work _and_ lets the user app participate in each hook.

The TCP dial-wait on `/ready` and `/validate` is especially important: the platform sends `/ready` as soon as the VM boots, which is often before the user app has had time to bind its port.

### Describe how you validated your changes

- `forwarder_test.go` covers: mirror of status/body/headers, TCP wait-for-port logic, dial-error → 503, deadline → 504, body truncation, the sidecar-mode guard, and that redirects from the user app are mirrored rather than followed.

Run the relevant unit tests locally:
```
dda inv test --targets=./cmd/serverless-init/lifecycle
```

### Additional Notes

**PR stack** — this is PR 4/8:
1. `microvm-01-foundation` — shared infrastructure ✓
2. `microvm-02-cloudservice-run` — `Run()` on `CloudService` ✓
3. `microvm-03-lifecycle-config-childhandle` — lifecycle config + child-handle ✓
4. **This PR** — HTTP pass-through forwarder
5. `microvm-05-lifecycle-heartbeat` — periodic heartbeat metric
6. `microvm-06-lifecycle-server-wire` — lifecycle HTTP server
7. `microvm-07-microvm-service-wiring` — MicroVM `CloudService` + main wiring
8. `microvm-08-sigusr2-on-run` — SIGUSR2 on `/run`