### PR TITLE
Drop stale `replace` directives from `otelcol/collector-contrib`

### DIFF
--- a/comp/otelcol/collector-contrib/impl/go.mod
+++ b/comp/otelcol/collector-contrib/impl/go.mod
@@ -545,12 +545,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/googleapis/gnostic v0.5.6 => github.com/googleapis/gnostic v0.5.5
-
-replace github.com/docker/go-connections v0.4.1-0.20210727194412-58542c764a11 => github.com/docker/go-connections v0.4.0
-
-replace github.com/mattn/go-ieproxy => github.com/mattn/go-ieproxy v0.0.1
-
 replace github.com/openshift/api => github.com/openshift/api v0.0.0-20230726162818-81f778f3b3ec
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.155.1-0.20260626121343-03d2fb4a4514

--- a/comp/otelcol/collector-contrib/impl/manifest.yaml
+++ b/comp/otelcol/collector-contrib/impl/manifest.yaml
@@ -89,9 +89,5 @@ receivers:
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
     v0.155.0
 replaces:
-- github.com/googleapis/gnostic v0.5.6 => github.com/googleapis/gnostic v0.5.5
-- github.com/docker/go-connections v0.4.1-0.20210727194412-58542c764a11 => github.com/docker/go-connections
-  v0.4.0
-- github.com/mattn/go-ieproxy => github.com/mattn/go-ieproxy v0.0.1
 - github.com/openshift/api => github.com/openshift/api v0.0.0-20230726162818-81f778f3b3ec
 - github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/def => ../def

--- a/tasks/unit_tests/testdata/collector/valid_datadog_manifest.yaml
+++ b/tasks/unit_tests/testdata/collector/valid_datadog_manifest.yaml
@@ -54,12 +54,6 @@ connectors:
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 replaces:
-  # See https://github.com/google/gnostic/issues/262
-  - github.com/googleapis/gnostic v0.5.6 => github.com/googleapis/gnostic v0.5.5
-  # See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12322#issuecomment-1185029670
-  - github.com/docker/go-connections v0.4.1-0.20210727194412-58542c764a11 => github.com/docker/go-connections v0.4.0
-  # see https://github.com/mattn/go-ieproxy/issues/45
-  - github.com/mattn/go-ieproxy => github.com/mattn/go-ieproxy v0.0.1
   # see https://github.com/openshift/api/pull/1515
   - github.com/openshift/api => github.com/openshift/api v0.0.0-20230726162818-81f778f3b3ec
   - github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/def => ../def

--- a/tasks/unit_tests/testdata/collector/valid_manifest_without_specified_version.yaml
+++ b/tasks/unit_tests/testdata/collector/valid_manifest_without_specified_version.yaml
@@ -15,12 +15,6 @@ receivers:
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 replaces:
-  # See https://github.com/google/gnostic/issues/262
-  - github.com/googleapis/gnostic v0.5.6 => github.com/googleapis/gnostic v0.5.5
-  # See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12322#issuecomment-1185029670
-  - github.com/docker/go-connections v0.4.1-0.20210727194412-58542c764a11 => github.com/docker/go-connections v0.4.0
-  # see https://github.com/mattn/go-ieproxy/issues/45
-  - github.com/mattn/go-ieproxy => github.com/mattn/go-ieproxy v0.0.1
   # see https://github.com/openshift/api/pull/1515
   - github.com/openshift/api => github.com/openshift/api v0.0.0-20230726162818-81f778f3b3ec
   - github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/def => ../def


### PR DESCRIPTION
### What does this PR do?
Remove 3 `replace` directives from the OCB manifest `comp/otelcol/collector-contrib/impl/manifest.yaml`, the generated `go.mod`, and both test-fixture manifests under `tasks/unit_tests/testdata/collector/`:
- `github.com/googleapis/gnostic v0.5.6 => v0.5.5` (google/gnostic#262): `gnostic` only ever appeared as `v0.4.1/go.mod` (`go.mod` fetched transiently, module never downloaded) and `v0.5.6` was never selected. All of `gnostic` anyway dropped from `go.sum` in #38378 (Jul 2025),
- `github.com/docker/go-connections v0.4.1-0.20210727194412 => v0.4.0` (open-telemetry/opentelemetry-collector-contrib#12322): the `replace` guards against a bug in `v0.4.1`, but `v0.5.0` was already selected when the `replace` was added in #26986 (Jun 2024), meaning that the buggy pseudo-version was never reachable here,
- `github.com/mattn/go-ieproxy => v0.0.1` (mattn/go-ieproxy#45): pins away from versions with a Windows compilation failure, and v0.0.11 was being selected before the `replace` was added in #26986 (Jun 2024). Became stale in #27597 (Jul 2024) when `ieproxy` dropped out of the module graph entirely.

This change is only about dropping _stale_ entries, so the `replace` for `github.com/openshift/api` (openshift/api#1515) is kept (there's a matching `require`, albeit potentially outdated).

### Motivation
Stale `replace` directives without a matching `require` are ignored by the Go toolchain ignores them, yet they're noisy leftovers.