### PR TITLE
dyninst/decode: surface context.Context trace ids as a map

### DIFF
--- a/pkg/dyninst/decode/BUILD.bazel
+++ b/pkg/dyninst/decode/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
     name = "decode_test",
     srcs = [
         "decoder_test.go",
+        "go_context_trace_test.go",
         "redaction_test.go",
         "return_marshal_test.go",
         "template_test.go",

--- a/pkg/dyninst/decode/go_context_trace_test.go
+++ b/pkg/dyninst/decode/go_context_trace_test.go
@@ -1,0 +1,153 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package decode
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"slices"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/output"
+)
+
+// TestDecoderContextTraceMap decodes a context.Context argument that carries an
+// active trace span and asserts the decoder surfaces its trace/span/parent ids
+// as a map of [key, value] entries.
+func TestDecoderContextTraceMap(t *testing.T) {
+	irProg := generateIrForProbes(t, "sample", goVersionSwissMap, "testTakeContext")
+	item := simpleTraceContextEvent(t, irProg)
+
+	decoder, err := NewDecoder(irProg, &noopTypeNameResolver{}, time.Now())
+	require.NoError(t, err)
+	buf, probe, err := decoder.Decode(Event{
+		EntryOrLine: output.SingleEvent(item),
+		ServiceName: "foo",
+	}, &noopSymbolicator{}, nil, []byte{})
+	require.NoError(t, err)
+	require.Equal(t, "testTakeContext", probe.GetID())
+
+	var e eventCaptures
+	require.NoError(t, json.Unmarshal(buf, &e))
+
+	expected := map[string]any{
+		"ctx": map[string]any{
+			"type": "context.Context",
+			"entries": []any{
+				[]any{
+					map[string]any{"type": "string", "value": "trace_id"},
+					map[string]any{"type": "big.Int", "value": "204258382862869200743700091125539174280"},
+				},
+				[]any{
+					map[string]any{"type": "string", "value": "span_id"},
+					map[string]any{"type": "uint64", "value": "123"},
+				},
+				[]any{
+					map[string]any{"type": "string", "value": "parent_id"},
+					map[string]any{"type": "uint64", "value": "456"},
+				},
+			},
+		},
+	}
+	require.Equal(t, expected, e.Debugger.Snapshot.Captures.Entry.Arguments)
+}
+
+// simpleTraceContextEvent builds a synthetic event for the testTakeContext
+// probe: the captured ctx points at an address for which the BPF chain walk
+// published a synthetic trace-context data item carrying a valid span.
+func simpleTraceContextEvent(t testing.TB, irProg *ir.Program) []byte {
+	probeIdx := slices.IndexFunc(irProg.Probes, func(p *ir.Probe) bool {
+		return p.GetID() == "testTakeContext"
+	})
+	require.NotEqual(t, -1, probeIdx)
+	eventType := irProg.Probes[probeIdx].Instances[0].Events[0].Type
+
+	ctxIdx := slices.IndexFunc(eventType.Expressions, func(e *ir.RootExpression) bool {
+		return e.Name == "ctx"
+	})
+	require.NotEqual(t, -1, ctxIdx)
+	ctxOff := int(eventType.Expressions[ctxIdx].Offset)
+
+	var traceCtxTypeID ir.TypeID
+	for _, typ := range irProg.Types {
+		if _, ok := typ.(*ir.TraceContextType); ok {
+			traceCtxTypeID = typ.GetID()
+		}
+	}
+	require.NotZero(t, traceCtxTypeID, "no TraceContextType in IR")
+
+	const ctxAddr = uint64(0xc000010000)
+
+	rootLen := int(eventType.GetByteSize())
+	rootData := make([]byte, rootLen)
+	copy(rootData, packExprStatuses(ir.ExprStatusPresent))
+	// ctx interface header: nonzero runtime type word + concrete context pointer.
+	binary.NativeEndian.PutUint64(rootData[ctxOff:ctxOff+8], 0x1234)
+	binary.NativeEndian.PutUint64(rootData[ctxOff+8:ctxOff+16], ctxAddr)
+
+	// Synthetic trace-context payload (trace_context_t): little-endian
+	// trace_id lower/upper, span id, parent id, then a non-zero valid byte.
+	tcData := make([]byte, ir.TraceContextByteSize)
+	binary.LittleEndian.PutUint64(tcData[0:8], 0x1122334455667788)
+	binary.LittleEndian.PutUint64(tcData[8:16], 0x99aabbccddeeff00)
+	binary.LittleEndian.PutUint64(tcData[16:24], 123)
+	binary.LittleEndian.PutUint64(tcData[24:32], 456)
+	tcData[32] = 1
+
+	dataItems := []struct {
+		typeID  ir.TypeID
+		address uint64
+		data    []byte
+	}{
+		{eventType.GetID(), 0, rootData},
+		{traceCtxTypeID, ctxAddr, tcData},
+	}
+
+	const (
+		eventHeaderSize    = int(unsafe.Sizeof(output.EventHeader{}))
+		dataItemHeaderSize = int(unsafe.Sizeof(output.DataItemHeader{}))
+	)
+	nextMultipleOf8 := func(v int) int { return (v + 7) & ^7 }
+	sz := eventHeaderSize
+	for _, di := range dataItems {
+		sz += dataItemHeaderSize + len(di.data)
+		sz = nextMultipleOf8(sz)
+	}
+
+	eventHeader := output.EventHeader{
+		Data_byte_len:  uint32(sz),
+		Prog_id:        1,
+		Stack_byte_len: 0,
+		Stack_hash:     1,
+		Ktime_ns:       1,
+	}
+	var item []byte
+	item = append(item, unsafe.Slice(
+		(*byte)(unsafe.Pointer(&eventHeader)), unsafe.Sizeof(eventHeader))...,
+	)
+	for _, di := range dataItems {
+		header := output.DataItemHeader{
+			Type:    uint32(di.typeID),
+			Length:  uint32(len(di.data)),
+			Address: di.address,
+		}
+		item = append(item, unsafe.Slice(
+			(*byte)(unsafe.Pointer(&header)), unsafe.Sizeof(header))...,
+		)
+		item = append(item, di.data...)
+		for len(item)%8 != 0 {
+			item = append(item, 0)
+		}
+	}
+	return item
+}

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"reflect"
 	"slices"
 	"strconv"
@@ -2254,7 +2255,92 @@ func (i *goInterfaceType) encodeValueFields(
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
+	if i.Name == "context.Context" {
+		return encodeContextTraceMap(c, enc, data)
+	}
 	return encodeInterface(c, enc, data)
+}
+
+// encodeContextTraceMap renders a context.Context interface value as a map of
+// the trace-correlation ids carried by the context. Each entry is a [key, value]
+// pair of typed values:
+//
+//	"entries": [
+//	  [{"type": "string", "value": "trace_id"},  {"type": "big.Int", "value": "<128-bit decimal>"}],
+//	  [{"type": "string", "value": "span_id"},   {"type": "uint64", "value": "<id>"}],
+//	  [{"type": "string", "value": "parent_id"}, {"type": "uint64", "value": "<id>"}],
+//	]
+//
+// trace_id is a 128-bit id rendered as a decimal big.Int (a uint64 cannot hold
+// it); span_id and parent_id are 64-bit unsigned integers. The ids come from the
+// synthetic trace-context data item the BPF chain walk publishes for the context
+// (keyed by the concrete context pointer address). parent_id is omitted when
+// zero; a context with no active span renders as an empty entries list.
+func encodeContextTraceMap(
+	c *encodingContext,
+	enc *jsontext.Encoder,
+	data []byte,
+) error {
+	if len(data) != 16 {
+		return fmt.Errorf("go interface data must be 16 bytes, got %d", len(data))
+	}
+	runtimeType := binary.NativeEndian.Uint64(data[goRuntimeTypeOffset : goRuntimeTypeOffset+8])
+	if runtimeType == 0 {
+		return writeTokens(enc, jsontext.String("isNull"), jsontext.Bool(true))
+	}
+	if err := writeTokens(enc, jsontext.String("entries"), jsontext.BeginArray); err != nil {
+		return err
+	}
+	addr := binary.NativeEndian.Uint64(data[goInterfaceDataOffset : goInterfaceDataOffset+8])
+	if c.traceContextTypeID != 0 && addr != 0 {
+		if item, ok := c.dataItems[typeAndAddr{
+			irType: uint32(c.traceContextTypeID),
+			addr:   addr,
+		}]; ok {
+			if tc, ok := parseTraceContextDataItem(item); ok {
+				var traceIDBytes [16]byte
+				binary.BigEndian.PutUint64(traceIDBytes[0:8], tc.traceIDUpper)
+				binary.BigEndian.PutUint64(traceIDBytes[8:16], tc.traceIDLower)
+				if err := writeContextTraceEntry(enc,
+					"trace_id", "big.Int", new(big.Int).SetBytes(traceIDBytes[:]).String(),
+				); err != nil {
+					return err
+				}
+				if err := writeContextTraceEntry(enc,
+					"span_id", "uint64", strconv.FormatUint(tc.spanID, 10),
+				); err != nil {
+					return err
+				}
+				if tc.parentID != 0 {
+					if err := writeContextTraceEntry(enc,
+						"parent_id", "uint64", strconv.FormatUint(tc.parentID, 10),
+					); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return writeTokens(enc, jsontext.EndArray)
+}
+
+// writeContextTraceEntry writes a single [key, value] map entry. The key is
+// always a string; valueType is the type label for the value ("uint64" for the
+// 64-bit span and parent ids, "big.Int" for the 128-bit trace id), matching how
+// the decoder renders map entries elsewhere.
+func writeContextTraceEntry(enc *jsontext.Encoder, key, valueType, value string) error {
+	return writeTokens(enc,
+		jsontext.BeginArray,
+		jsontext.BeginObject,
+		jsontext.String("type"), jsontext.String("string"),
+		jsontext.String("value"), jsontext.String(key),
+		jsontext.EndObject,
+		jsontext.BeginObject,
+		jsontext.String("type"), jsontext.String(valueType),
+		jsontext.String("value"), jsontext.String(value),
+		jsontext.EndObject,
+		jsontext.EndArray,
+	)
 }
 
 func (i *goInterfaceType) formatValueFields(

--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -807,13 +807,15 @@ func waitForLogMessages(
 			exactMatcher(`/dd.span_id`),
 			replacement(`"[span_id]"`),
 		))
-		// Field-site span_id (rendered inside a captured context.Context's
-		// fields). Same source of non-determinism. dd.trace_id and dd.parent_id
-		// (and their field-site equivalents) are deterministic from the test's
-		// outbound traceparent and are NOT redacted.
+		// span_id inside a captured context.Context's entries map is dd-trace-go's
+		// server-generated child span, non-deterministic across runs. It is now an
+		// entry value rather than a path segment, so the path-based matcher no
+		// longer catches it; redact it from the entries map instead. trace_id and
+		// parent_id are deterministic from the test's outbound traceparent and are
+		// left intact.
 		redactors = append(redactors, redactor(
-			matchRegexp(`/debugger/snapshot/captures/[^/]+/arguments/.*/span_id$`),
-			replacement(`"[span_id]"`),
+			prefixSuffixMatcher{"/debugger/snapshot/captures/", "/entries"},
+			replacerFunc(redactContextSpanID),
 		))
 		redactors = append(redactors, redactor(
 			prefixMatcher("/debugger/snapshot/stack"),

--- a/pkg/dyninst/json_redaction_test.go
+++ b/pkg/dyninst/json_redaction_test.go
@@ -158,6 +158,45 @@ func (e entriesSorter) replace(v jsontext.Value) jsontext.Value {
 	return sorted
 }
 
+// redactContextSpanID replaces the value of the span_id entry inside a
+// context.Context entries map. dd-trace-go generates the server span id per
+// request, so it is non-deterministic across runs, whereas trace_id and
+// parent_id are fixed by the test's traceparent and are left intact. It is safe
+// to apply to any entries map: only a "span_id" key is touched, which appears
+// only in the context map.
+func redactContextSpanID(v jsontext.Value) jsontext.Value {
+	var entries [][2]jsontext.Value
+	if err := json.Unmarshal(v, &entries); err != nil {
+		return v
+	}
+	for i := range entries {
+		var key struct {
+			Value string `json:"value"`
+		}
+		if err := json.Unmarshal(entries[i][0], &key); err != nil || key.Value != "span_id" {
+			continue
+		}
+		var value struct {
+			Type  string `json:"type"`
+			Value string `json:"value"`
+		}
+		if err := json.Unmarshal(entries[i][1], &value); err != nil {
+			continue
+		}
+		value.Value = "[span_id]"
+		marshaled, err := json.Marshal(value)
+		if err != nil {
+			continue
+		}
+		entries[i][1] = marshaled
+	}
+	out, err := json.Marshal(entries)
+	if err != nil {
+		return v
+	}
+	return out
+}
+
 type stackFrame struct {
 	Function   string `json:"function"`
 	FileName   string `json:"fileName"`

--- a/pkg/dyninst/testdata/decoded/sample/testTakeContext.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTakeContext.json
@@ -59,15 +59,28 @@
             "arguments": {
               "ctx": {
                 "type": "context.Context",
-                "fields": {
-                  "data": {
-                    "type": "context.Context",
-                    "value": {
-                      "trace_id": "00000000000000000123456789abcdef",
-                      "span_id": "81985529216486895"
+                "entries": [
+                  [
+                    {
+                      "type": "string",
+                      "value": "span_id"
+                    },
+                    {
+                      "type": "uint64",
+                      "value": "81985529216486895"
                     }
-                  }
-                }
+                  ],
+                  [
+                    {
+                      "type": "string",
+                      "value": "trace_id"
+                    },
+                    {
+                      "type": "big.Int",
+                      "value": "81985529216486895"
+                    }
+                  ]
+                ]
               }
             }
           }

--- a/pkg/dyninst/testdata/e2e/rc_tester.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester.json
@@ -1645,16 +1645,38 @@
                   },
                   "ctx": {
                     "type": "context.Context",
-                    "fields": {
-                      "data": {
-                        "type": "context.Context",
-                        "value": {
-                          "trace_id": "00000000000000000123456789abcdef",
-                          "span_id": "[span_id]",
-                          "parent_id": "1229782938247303441"
+                    "entries": [
+                      [
+                        {
+                          "type": "string",
+                          "value": "parent_id"
+                        },
+                        {
+                          "type": "uint64",
+                          "value": "1229782938247303441"
                         }
-                      }
-                    }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "span_id"
+                        },
+                        {
+                          "type": "uint64",
+                          "value": "[span_id]"
+                        }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "trace_id"
+                        },
+                        {
+                          "type": "big.Int",
+                          "value": "81985529216486895"
+                        }
+                      ]
+                    ]
                   },
                   "pat": {
                     "type": "*net/http.pattern",
@@ -3366,16 +3388,38 @@
                   },
                   "ctx": {
                     "type": "context.Context",
-                    "fields": {
-                      "data": {
-                        "type": "context.Context",
-                        "value": {
-                          "trace_id": "00000000000000000123456789abcdef",
-                          "span_id": "[span_id]",
-                          "parent_id": "2459565876494606882"
+                    "entries": [
+                      [
+                        {
+                          "type": "string",
+                          "value": "parent_id"
+                        },
+                        {
+                          "type": "uint64",
+                          "value": "2459565876494606882"
                         }
-                      }
-                    }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "span_id"
+                        },
+                        {
+                          "type": "uint64",
+                          "value": "[span_id]"
+                        }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "trace_id"
+                        },
+                        {
+                          "type": "big.Int",
+                          "value": "81985529216486895"
+                        }
+                      ]
+                    ]
                   },
                   "pat": {
                     "type": "*net/http.pattern",
@@ -5087,16 +5131,38 @@
                   },
                   "ctx": {
                     "type": "context.Context",
-                    "fields": {
-                      "data": {
-                        "type": "context.Context",
-                        "value": {
-                          "trace_id": "00000000000000000123456789abcdef",
-                          "span_id": "[span_id]",
-                          "parent_id": "3689348814741910323"
+                    "entries": [
+                      [
+                        {
+                          "type": "string",
+                          "value": "parent_id"
+                        },
+                        {
+                          "type": "uint64",
+                          "value": "3689348814741910323"
                         }
-                      }
-                    }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "span_id"
+                        },
+                        {
+                          "type": "uint64",
+                          "value": "[span_id]"
+                        }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "trace_id"
+                        },
+                        {
+                          "type": "big.Int",
+                          "value": "81985529216486895"
+                        }
+                      ]
+                    ]
                   },
                   "pat": {
                     "type": "*net/http.pattern",

--- a/pkg/dyninst/testdata/e2e/rc_tester_v1.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester_v1.json
@@ -1645,16 +1645,38 @@
                   },
                   "ctx": {
                     "type": "context.Context",
-                    "fields": {
-                      "data": {
-                        "type": "context.Context",
-                        "value": {
-                          "trace_id": "00000000000000000123456789abcdef",
-                          "span_id": "[span_id]",
-                          "parent_id": "1229782938247303441"
+                    "entries": [
+                      [
+                        {
+                          "type": "string",
+                          "value": "parent_id"
+                        },
+                        {
+                          "type": "uint64",
+                          "value": "1229782938247303441"
                         }
-                      }
-                    }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "span_id"
+                        },
+                        {
+                          "type": "uint64",
+                          "value": "[span_id]"
+                        }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "trace_id"
+                        },
+                        {
+                          "type": "big.Int",
+                          "value": "81985529216486895"
+                        }
+                      ]
+                    ]
                   },
                   "pat": {
                     "type": "*net/http.pattern",
@@ -3366,16 +3388,38 @@
                   },
                   "ctx": {
                     "type": "context.Context",
-                    "fields": {
-                      "data": {
-                        "type": "context.Context",
-                        "value": {
-                          "trace_id": "00000000000000000123456789abcdef",
-                          "span_id": "[span_id]",
-                          "parent_id": "2459565876494606882"
+                    "entries": [
+                      [
+                        {
+                          "type": "string",
+                          "value": "parent_id"
+                        },
+                        {
+                          "type": "uint64",
+                          "value": "2459565876494606882"
                         }
-                      }
-                    }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "span_id"
+                        },
+                        {
+                          "type": "uint64",
+                          "value": "[span_id]"
+                        }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "trace_id"
+                        },
+                        {
+                          "type": "big.Int",
+                          "value": "81985529216486895"
+                        }
+                      ]
+                    ]
                   },
                   "pat": {
                     "type": "*net/http.pattern",
@@ -5087,16 +5131,38 @@
                   },
                   "ctx": {
                     "type": "context.Context",
-                    "fields": {
-                      "data": {
-                        "type": "context.Context",
-                        "value": {
-                          "trace_id": "00000000000000000123456789abcdef",
-                          "span_id": "[span_id]",
-                          "parent_id": "3689348814741910323"
+                    "entries": [
+                      [
+                        {
+                          "type": "string",
+                          "value": "parent_id"
+                        },
+                        {
+                          "type": "uint64",
+                          "value": "3689348814741910323"
                         }
-                      }
-                    }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "span_id"
+                        },
+                        {
+                          "type": "uint64",
+                          "value": "[span_id]"
+                        }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "trace_id"
+                        },
+                        {
+                          "type": "big.Int",
+                          "value": "81985529216486895"
+                        }
+                      ]
+                    ]
                   },
                   "pat": {
                     "type": "*net/http.pattern",


### PR DESCRIPTION
### What does this PR do?

  Renders a captured context.Context in debugger snapshots as a map of its trace correlation ids (trace_id, span_id, and parent_id when non-zero) instead of the opaque nested interface object. A context with no
  active span renders as an empty entries list. Each id is typed as the integer it is: span_id and parent_id are uint64, and trace_id is a decimal big.Int (a 128-bit id does not fit a uint64).

### Motivation

  The only information worth surfacing from a context.Context is its trace correlation ids; the concrete implementation's struct contents are intentionally not captured. A map is clearer than the opaque interface
  object. The ids must also be typed correctly rather than as strings: the backend Go redactor scrubs any captured value whose type is not in its safe set (Go's primitive numerics), so string-typed ids would be
  redacted out of the snapshot entirely, and string misrepresents values that are integers. uint64 is already safe; big.Int is whitelisted in a companion change (it mirrors java.math.BigInteger, which the Java
  redactor already treats as safe).

### Describe how you validated your changes

  - Decode unit tests pass (TestDecoderContextTraceMap), asserting the typed entries map.
  - Regenerated the snapshot golden (testTakeContext.json) and the e2e goldens (rc_tester.json, rc_tester_v1.json).
  - TestEndToEnd passes without REWRITE, confirming the non-deterministic server span_id is redacted from the context map and the goldens are stable across runs.

### Additional Notes

  Depends on a companion logs-backend change adding "big.Int" to GoRedactor.SAFE_TYPES; it must deploy before or with this PR, or trace_id renders as [REDACTED] until then. span_id/parent_id (uint64) are
  unaffected. The e2e span_id redactor was updated because the id is now an entry value rather than a path segment, so the old path-based matcher no longer caught it; trace_id and parent_id are deterministic from
  the test's traceparent and stay unredacted.
