### PR TITLE
[CONTP-1569]  KSM pod `.total` aggregation through a clc `cluster_aggregates_only` check

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -126,6 +126,25 @@ const (
 	// enabled on the node agents, because unassigned pods cannot be collected
 	// from node agents.
 	clusterUnassignedPodCollection podCollectionMode = "cluster_unassigned"
+
+	// clusterAggregatesOnlyPodCollection is the authoritative source for the
+	// cluster-aggregate `.total` metric family. It emits only the `.total`
+	// aggregators (no per-pod metrics). Meant to run on the cluster-agent or
+	// a cluster check runner (same isRunningOnNodeAgent guard as
+	// clusterUnassignedPodCollection) — never on a node agent. When a cluster
+	// check runner pool exists (a prerequisite for node_kubelet's
+	// clusterUnassignedPodCollection companion mode), the check's normal
+	// cluster-check dispatch (cluster_check: true in its instance config)
+	// assigns this to exactly one runner in that pool, same as any other
+	// cluster check; it only falls back to running directly on the
+	// cluster-agent if no runner pool exists. Other modes suppress these
+	// aggregators so the cluster sees exactly one authoritative source.
+	//
+	// Pod data is sourced via the same direct API-server reflector mechanism
+	// the default/cluster_unassigned modes use — not workloadmeta — to avoid
+	// depending on workloadmeta's pod store lifecycle (whether it's running,
+	// and whether it's already fully populated) for correctness.
+	clusterAggregatesOnlyPodCollection podCollectionMode = "cluster_aggregates_only"
 )
 
 // KSMConfig contains the check config parameters
@@ -231,8 +250,16 @@ type KSMConfig struct {
 	UseAPIServerCache bool `yaml:"use_apiserver_cache"`
 
 	// PodCollectionMode defines how pods are collected.
-	// Accepted values are: "default", "node_kubelet", and "cluster_unassigned".
+	// Accepted values are: "default", "node_kubelet", "cluster_unassigned",
+	// and "cluster_aggregates_only".
 	PodCollectionMode podCollectionMode `yaml:"pod_collection_mode"`
+
+	// ClusterAggregatesEnabled tells a node_kubelet or cluster_unassigned
+	// instance to suppress its .total accumulators, because a dedicated
+	// cluster_aggregates_only instance is deployed elsewhere in the cluster as
+	// the sole authoritative source. Off by default (legacy behavior). Set by
+	// the operator/helm on the suppressing instances alongside that deployment.
+	ClusterAggregatesEnabled bool `yaml:"cluster_aggregates_enabled"`
 }
 
 // KSMCheck wraps the config and the metric stores needed to run the check
@@ -328,7 +355,11 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 	// Prepare labels mapper
 	k.mergeLabelsMapper(defaultLabelsMapper())
 
-	if k.instance.usesCustomResourceMetrics() && k.instance.PodCollectionMode != nodeKubeletPodCollection {
+	// Start custom resource discovery if not running in a mode that only
+	// consumes pods from workloadmeta (no API discovery needed in those modes).
+	if k.instance.usesCustomResourceMetrics() &&
+		k.instance.PodCollectionMode != nodeKubeletPodCollection &&
+		k.instance.PodCollectionMode != clusterAggregatesOnlyPodCollection {
 		k.crMu.Lock()
 		if k.cancelCR == nil {
 			ctx, cancel := context.WithCancel(context.Background())
@@ -380,10 +411,26 @@ func (k *KSMCheck) buildStores() error {
 
 	switch k.instance.PodCollectionMode {
 	case nodeKubeletPodCollection:
-		// In this case we don't need to set up anything related to the API
-		// server.
+		// Pods come from the kubelet, nothing API-server related to set up.
 		collectors = []string{"pods"}
 		k.setupLabelsAndAnnotationsAsTagsFunc()
+	case clusterAggregatesOnlyPodCollection:
+		collectors = []string{"pods"}
+		k.setupLabelsAndAnnotationsAsTagsFunc()
+
+		// Watch pods directly via the same API-server client mechanism as
+		// defaultPodCollection, rather than through workloadmeta.
+		apiServerClient, err = apiserver.GetAPIClient()
+		if err != nil {
+			return err
+		}
+
+		err = apiserver.InitializeGlobalResourceTypeCache(apiServerClient.Cl.Discovery())
+		if err != nil {
+			return err
+		}
+
+		builder.WithKubeClient(apiServerClient.InformerCl)
 	case defaultPodCollection, clusterUnassignedPodCollection:
 		// We can try to get the API Client directly because this code will be retried if it fails
 		apiServerClient, err = apiserver.GetAPIClient()
@@ -575,6 +622,25 @@ func (k *KSMCheck) discoverCustomResources(c *apiserver.APIClient, collectors []
 			collectors: collectors,
 			factories: []customresource.RegistryFactory{
 				customresources.NewExtendedPodFactoryForKubelet(),
+			},
+		}
+	}
+
+	if k.instance.PodCollectionMode == clusterAggregatesOnlyPodCollection {
+		// Enable ONLY the extended pod store — it produces the 4
+		// owner-tagged source metrics for the .total family. Deliberately
+		// omit the plain "pods" collector so the standard pod store (~54
+		// per-pod generators, all discarded by processMetrics in this mode)
+		// is never built or watched. extendedCollectors["pods"] is
+		// "core/v1, Resource=pods_extended", the exact key
+		// WithCustomResourceStoreFactories registers NewExtendedPodFactory
+		// under (util.GVRFromType("pods_extended", *v1.Pod)), so BuildStores
+		// finds and builds it. Returning nil collectors instead would build
+		// neither store and make .total disappear.
+		return customResources{
+			collectors: []string{extendedCollectors["pods"]},
+			factories: []customresource.RegistryFactory{
+				customresources.NewExtendedPodFactory(c),
 			},
 		}
 	}
@@ -791,8 +857,38 @@ func (k *KSMCheck) Cancel() {
 
 // processMetrics attaches tags and forwards metrics to the aggregator
 func (k *KSMCheck) processMetrics(sender sender.Sender, metrics map[string][]ksmstore.DDMetricsFam, labelJoiner *labelJoiner, now time.Time) {
+	// Suppress .total accumulation on the per-node instances that would otherwise
+	// collide, but only when the instance sets cluster_aggregates_enabled: true:
+	//   - node_kubelet      (per-node agents — same reduced-tag gauge collides across nodes)
+	//   - cluster_unassigned (CLC runner — partial view, would emit an incomplete .total)
+	// default mode is intentionally excluded: a single full-pod check is already the
+	// authoritative source for .total (no collision), so it must stay unaffected (design goal #5).
+	//
+	// Turning this on also starts the DCA's cluster_aggregates_only reflector
+	// warmup in the same window these instances start suppressing — there is no
+	// clean "DCA serving first, then nodes go quiet" handoff. Expect a brief
+	// (seconds-scale) window at flag-flip where .total is absent, then correct.
+	// The flag is a config signal, not a live DCA health check. While it is off
+	// (the default), nodes fall back to the pre-fix under-reported emission
+	// rather than going silent.
+	suppressClusterAggregates := (k.instance.PodCollectionMode == nodeKubeletPodCollection ||
+		k.instance.PodCollectionMode == clusterUnassignedPodCollection) &&
+		k.instance.ClusterAggregatesEnabled
+	// In cluster_aggregates_only mode, the check emits only the .total family
+	// (via aggregator flush). Skip per-pod transformer/mapper dispatch to avoid
+	// double-emission of per-pod metrics already produced by node-agents.
+	aggregatesOnly := k.instance.PodCollectionMode == clusterAggregatesOnlyPodCollection
 	for _, metricsList := range metrics {
 		for _, metricFamily := range metricsList {
+			if suppressClusterAggregates && isClusterAggregateSourceMetric(metricFamily.Name) {
+				continue
+			}
+			// In cluster_aggregates_only mode accumulate only the four .total source
+			// metrics. Accumulating other aggregators (e.g. pod.count) would double-count
+			// with node-agents which already emit those metrics individually.
+			if aggregatesOnly && !isClusterAggregateSourceMetric(metricFamily.Name) {
+				continue
+			}
 			// First check for aggregator, because the check use _labels metrics to aggregate values.
 			if aggregator, found := k.metricAggregators[metricFamily.Name]; found {
 				for _, m := range metricFamily.ListMetrics {
@@ -800,6 +896,9 @@ func (k *KSMCheck) processMetrics(sender sender.Sender, metrics map[string][]ksm
 				}
 				// Some metrics can be aggregated and consumed as-is or by a transformer.
 				// So, let’s continue the processing.
+			}
+			if aggregatesOnly {
+				continue
 			}
 			if transform, found := k.metricTransformers[metricFamily.Name]; found {
 				lMapperOverride := labelsMapperOverride(metricFamily.Name)
@@ -1121,6 +1220,18 @@ func (k *KSMCheck) configurePodCollection(builder *kubestatemetrics.Builder, col
 		} else {
 			builder.WithUnassignedPodsCollection()
 		}
+	case clusterAggregatesOnlyPodCollection:
+		if k.isRunningOnNodeAgent {
+			log.Warnf("cluster_aggregates_only is enabled but KSM is running in a node agent, so the option will be ignored " +
+				"(it is only supported on the cluster agent or a cluster check runner)")
+			k.instance.PodCollectionMode = defaultPodCollection
+		}
+		// Else: leave the builder unconfigured here. buildStores() takes the
+		// same API-server-client branch it uses for defaultPodCollection, and
+		// the default (non-WLM) reflector path runs as-is — no field selector
+		// is set, so it watches all pods in the configured namespaces (all
+		// namespaces by default, same as this mode needs; still subject to
+		// instance.Namespaces if the user has restricted it).
 	default:
 		log.Warnf("invalid pod collection mode %q, falling back to the default mode", k.instance.PodCollectionMode)
 		k.instance.PodCollectionMode = defaultPodCollection
@@ -1209,6 +1320,7 @@ func KubeStateMetricsFactoryWithParam(labelsMapper map[string]string, labelJoins
 func newKSMCheck(base core.CheckBase, instance *KSMConfig, tagger tagger.Component, wmeta workloadmeta.Component) *KSMCheck {
 	k := &KSMCheck{
 		CheckBase:                  base,
+		agentConfig:                pkgconfigsetup.Datadog(),
 		instance:                   instance,
 		telemetry:                  newTelemetryCache(),
 		tagger:                     tagger,

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -299,6 +299,23 @@ func (a *lastCronJobAggregator) flush(sender sender.Sender, k *KSMCheck, labelJo
 	a.accumulator = make(map[cronJob]cronJobState)
 }
 
+// clusterAggregateSourceMetrics lists the KSM source metrics that feed the
+// cluster-aggregate `.total` family with a reduced tag set (no host/pod/node).
+// These must be accumulated only by the single authoritative instance
+// (cluster_aggregates_only mode); any other instance emitting them causes
+// gauge collapse at ingestion.
+var clusterAggregateSourceMetrics = map[string]struct{}{
+	"kube_pod_container_resource_with_owner_tag_requests":      {},
+	"kube_pod_container_resource_with_owner_tag_limits":        {},
+	"kube_pod_init_container_resource_with_owner_tag_requests": {},
+	"kube_pod_init_container_resource_with_owner_tag_limits":   {},
+}
+
+func isClusterAggregateSourceMetric(name string) bool {
+	_, ok := clusterAggregateSourceMetrics[name]
+	return ok
+}
+
 func defaultMetricAggregators() map[string]metricAggregator {
 	cronJobAggregator := newLastCronJobAggregator()
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -9,21 +9,25 @@ package ksm
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apiv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kube-state-metrics/v2/pkg/allowdenylist"
 	"k8s.io/kube-state-metrics/v2/pkg/customresourcestate"
 	"k8s.io/kube-state-metrics/v2/pkg/options"
+	ksmutil "k8s.io/kube-state-metrics/v2/pkg/util"
 
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/customresources"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -1989,4 +1993,179 @@ func BenchmarkOwnerTags(b *testing.B) {
 			_ = ownerTags("Job", "foo-1627309500")
 		}
 	})
+}
+
+func TestProcessMetrics_SuppressModeMatrix(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+
+	sourceMetric := map[string][]ksmstore.DDMetricsFam{
+		"kube_pod_container_resource_with_owner_tag_requests": {{
+			Name: "kube_pod_container_resource_with_owner_tag_requests",
+			ListMetrics: []ksmstore.DDMetric{{
+				Labels: map[string]string{"namespace": "kube-system", "container": "kindnet", "owner_name": "kindnet", "owner_kind": "DaemonSet", "resource": "cpu"},
+				Val:    0.1,
+			}},
+		}},
+		// A non-.total aggregator source (pod.count) must not double-count in aggregatesOnly mode.
+		"kube_pod_info": {{
+			Name: "kube_pod_info",
+			ListMetrics: []ksmstore.DDMetric{{
+				Labels: map[string]string{"namespace": "default", "pod": "p1", "uid": "u1", "node": "node-a", "created_by_kind": "Deployment", "created_by_name": "d1"},
+				Val:    1,
+			}},
+		}},
+	}
+
+	hasTotalGauge := func(s *mocksender.MockSender) bool {
+		for _, call := range s.Mock.Calls {
+			if call.Method == "Gauge" {
+				if name, ok := call.Arguments.Get(0).(string); ok && strings.Contains(name, ".total") {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	tests := []struct {
+		name         string
+		mode         podCollectionMode
+		flagEnabled  bool
+		wantSuppress bool // node should NOT emit .total when true
+		wantHasTotal bool // node SHOULD emit .total when true
+	}{
+		{
+			name: "node_kubelet + flag=true → suppress (DCA is authoritative)",
+			mode: nodeKubeletPodCollection, flagEnabled: true,
+			wantSuppress: true, wantHasTotal: false,
+		},
+		{
+			name: "node_kubelet + flag=false → emit (safe rollout, DCA not ready)",
+			mode: nodeKubeletPodCollection, flagEnabled: false,
+			wantSuppress: false, wantHasTotal: true,
+		},
+		{
+			name: "cluster_unassigned + flag=true → suppress",
+			mode: clusterUnassignedPodCollection, flagEnabled: true,
+			wantSuppress: true, wantHasTotal: false,
+		},
+		{
+			name: "cluster_unassigned + flag=false → emit",
+			mode: clusterUnassignedPodCollection, flagEnabled: false,
+			wantSuppress: false, wantHasTotal: true,
+		},
+		{
+			name: "default + flag=true → emit (single full-pod check is authoritative, design goal #5)",
+			mode: defaultPodCollection, flagEnabled: true,
+			wantSuppress: false, wantHasTotal: true,
+		},
+		{
+			name: "default + flag=false → emit (backwards-compat: feature off, no change)",
+			mode: defaultPodCollection, flagEnabled: false,
+			wantSuppress: false, wantHasTotal: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := newKSMCheck(core.NewCheckBase(CheckName), &KSMConfig{PodCollectionMode: tt.mode, ClusterAggregatesEnabled: tt.flagEnabled}, fakeTagger, nil)
+
+			s := mocksender.NewMockSender(t, k.ID())
+			s.SetupAcceptAll()
+
+			k.processMetrics(s, sourceMetric, newLabelJoiner(nil), time.Now())
+			for _, agg := range k.metricAggregators {
+				agg.flush(s, k, newLabelJoiner(nil))
+			}
+
+			if tt.wantSuppress {
+				for _, call := range s.Mock.Calls {
+					if call.Method == "Gauge" {
+						name, _ := call.Arguments.Get(0).(string)
+						assert.NotContains(t, name, ".total", "mode=%s flag=%v must suppress .total", tt.mode, tt.flagEnabled)
+					}
+				}
+			}
+			if tt.wantHasTotal {
+				assert.True(t, hasTotalGauge(s), "mode=%s flag=%v must emit .total", tt.mode, tt.flagEnabled)
+			}
+		})
+	}
+}
+
+func TestProcessMetrics_ClusterAggregatesOnly_EmitsOnlyTotalFamily(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+
+	k := newKSMCheck(core.NewCheckBase(CheckName), &KSMConfig{PodCollectionMode: clusterAggregatesOnlyPodCollection, ClusterAggregatesEnabled: true}, fakeTagger, nil)
+
+	metrics := map[string][]ksmstore.DDMetricsFam{
+		"kube_pod_container_resource_with_owner_tag_requests": {{
+			Name: "kube_pod_container_resource_with_owner_tag_requests",
+			ListMetrics: []ksmstore.DDMetric{{
+				Labels: map[string]string{"namespace": "kube-system", "container": "kindnet", "owner_name": "kindnet", "owner_kind": "DaemonSet", "resource": "cpu"},
+				Val:    0.1,
+			}},
+		}},
+		// pod.count source: must NOT be accumulated (double-count prevention)
+		"kube_pod_info": {{
+			Name: "kube_pod_info",
+			ListMetrics: []ksmstore.DDMetric{{
+				Labels: map[string]string{"namespace": "default", "pod": "p1", "uid": "u1", "node": "node-a", "created_by_kind": "Deployment", "created_by_name": "d1"},
+				Val:    1,
+			}},
+		}},
+	}
+
+	s := mocksender.NewMockSender(t, k.ID())
+	s.SetupAcceptAll()
+
+	k.processMetrics(s, metrics, newLabelJoiner(nil), time.Now())
+	for _, agg := range k.metricAggregators {
+		agg.flush(s, k, newLabelJoiner(nil))
+	}
+
+	for _, call := range s.Mock.Calls {
+		if call.Method == "Gauge" {
+			name, _ := call.Arguments.Get(0).(string)
+			// Only .total metrics should be emitted
+			assert.True(t, strings.HasSuffix(name, ".total") || strings.HasPrefix(name, "kubernetes_state.telemetry"),
+				"cluster_aggregates_only must not emit non-.total metric %q", name)
+			// pod.count must not appear (it's a non-.total aggregator)
+			assert.NotContains(t, name, "pod.count")
+		}
+	}
+}
+
+// TestDiscoverCustomResources_ClusterAggregatesOnly guards the wiring that makes
+// cluster_aggregates_only build ONLY the extended pod store: discoverCustomResources
+// must return exactly the extended pods GVR key (not the plain "pods" collector, and
+// not nil). If this regresses, the aggregate pod store is never built and the .total
+// family silently disappears.
+func TestDiscoverCustomResources_ClusterAggregatesOnly(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	k := newKSMCheck(core.NewCheckBase(CheckName), &KSMConfig{PodCollectionMode: clusterAggregatesOnlyPodCollection}, fakeTagger, nil)
+	c := &apiserver.APIClient{Cl: fakeclientset.NewSimpleClientset()}
+
+	cr := k.discoverCustomResources(c, []string{"pods"}, nil)
+
+	assert.Equal(t, []string{extendedCollectors["pods"]}, cr.collectors,
+		"cluster_aggregates_only must enable ONLY the extended pods store, not the standard 'pods' collector")
+	assert.NotContains(t, cr.collectors, "pods",
+		"the standard pods collector must not be enabled in cluster_aggregates_only mode")
+	assert.Len(t, cr.factories, 1, "cluster_aggregates_only should register exactly the extended pod factory")
+}
+
+// TestExtendedPodsCollectorKeyMatchesFactory guards the invariant the whole
+// cluster_aggregates_only fix hinges on: extendedCollectors["pods"] must be byte-for-byte
+// equal to the GVR key the extended pod factory registers under
+// (util.GVRFromType(factory.Name(), factory.ExpectedType())). If either side drifts,
+// enabledResources won't match availableStores, no pod store is built, and .total vanishes.
+func TestExtendedPodsCollectorKeyMatchesFactory(t *testing.T) {
+	f := customresources.NewExtendedPodFactoryForKubelet() // same Name()/ExpectedType() as NewExtendedPodFactory
+	gvr, err := ksmutil.GVRFromType(f.Name(), f.ExpectedType())
+	require.NoError(t, err)
+	require.NotNil(t, gvr)
+	assert.Equal(t, extendedCollectors["pods"], gvr.String(),
+		"extendedCollectors[\"pods\"] must equal the extended pod factory's registered GVR key; "+
+			"if these drift, cluster_aggregates_only builds no pod store and .total disappears")
 }

--- a/releasenotes-dca/notes/ksm-total-aggregation-fix-a1b2c3d4e5f60718.yaml
+++ b/releasenotes-dca/notes/ksm-total-aggregation-fix-a1b2c3d4e5f60718.yaml
@@ -1,0 +1,20 @@
+---
+fixes:
+  - |
+    Fixed an issue in the KSM check where cluster-aggregate metrics
+    (``kubernetes_state.container.<cpu|memory>_requested.total``,
+    ``kubernetes_state.container.<cpu|memory|gpu|mig>_limit.total``,
+    and the ``initcontainer`` equivalents) reported incorrect cluster totals
+    when the check ran with ``pod_collection_mode: node_kubelet``. The
+    aggregate metrics are now computed from a dedicated instance (running on
+    the cluster-agent or a cluster-checks runner) in the new
+    ``pod_collection_mode: cluster_aggregates_only`` mode, which watches all
+    pods directly from the API server. To enable the fix, set the
+    ``cluster_aggregates_enabled: true`` instance option on the
+    ``node_kubelet`` and ``cluster_unassigned`` instances; those instances then
+    suppress the affected accumulators, eliminating multi-source gauge collision
+    at ingestion. Without that option the previous (colliding) behavior is
+    unchanged, so it must be set alongside deploying the
+    ``cluster_aggregates_only`` instance. The fix preserves the per-pod metric
+    scaling benefit of ``node_kubelet`` mode while restoring correct cluster
+    aggregates.


### PR DESCRIPTION
### What does this PR do?
<img width="4452" height="1660" alt="image" src="https://github.com/user-attachments/assets/801431b2-f957-4441-a959-6f53c6b93cc3" />

Fixes under-reporting of the `kubernetes_state.{container}.<cpu|memory|gpu>_{requested,limit}.total`
family when the KSM check runs in `pod_collection_mode: node_kubelet`.

### Motivation
In `node_kubelet` mode every node agent computes the `.total` family from its *local* pod view and emits it with a **reduced tag set** —`[namespace, container, owner_kind, owner_name]`, with **no host/pod/node tag**.
Because every node emits a byte-identical series at (roughly) the same timestamp, the backend's same-tags/same-timestamp collision rule keeps only **one** node's value. Result: the cluster aggregation metrics are total under-reported, sum does not work either. 

Count-style metrics (`pod.count`, etc.) are unaffected — they carry a `node` tag, so per-node series stay distinct and sum correctly. Only the tag-collapsed `.total` family breaks.

A new `pod_collection_mode: cluster_aggregates_only`  watches all** pods and emits only the `.total` family. It will be run on clc runner but aggregate  just the 4 owner-tagged source metrics.

### Describe how you validated your changes
Suppression is enabled per-instance via the `cluster_aggregates_enabled` KSM check option, set on the `node_kubelet` and `cluster_unassigned` instances (the `cluster_aggregates_only` instance omits it).

For operator Datadog CR, related [PR](https://github.com/DataDog/datadog-operator/pull/3027)
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: datadog
spec:
  global:
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
  features:
    kubeStateMetricsCore:
      enabled: true
      conf:
        configData: |-
          cluster_check: true
          init_config:
          instances:
            # non-pod resources + unassigned pods
            - skip_leader_election: true
              pod_collection_mode: cluster_unassigned
              cluster_aggregates_enabled: true
            - skip_leader_election: true
              pod_collection_mode: cluster_aggregates_only
    clusterChecks:
      enabled: true
  override:
    nodeAgent:
      extraConfd:
        configDataMap:
          kubernetes_state_core.yaml: |-
            init_config:
            instances:
              - collectors:
                  - pods
                pod_collection_mode: node_kubelet
                cluster_aggregates_enabled: true
```
For Helm install
```
datadog:
  clusterChecks:
    enabled: true
  kubeStateMetricsCore:
    enabled: true

  # node agents → node_kubelet (scheduled pods)
  confd:
    kubernetes_state_core.yaml: |-
      init_config:
      instances:
        - collectors:
            - pods
          pod_collection_mode: node_kubelet
          cluster_aggregates_enabled: true

clusterAgent:
  confd:
    kubernetes_state_core.yaml: |-
      cluster_check: true
      init_config:
      instances:
        - skip_leader_election: true
          pod_collection_mode: cluster_unassigned
          cluster_aggregates_enabled: true
        - skip_leader_election: true
          pod_collection_mode: cluster_aggregates_only
```

### Additional Notes
