### PR TITLE
Add telemetry assertions for discovery worker

### DIFF
--- a/comp/core/autodiscovery/discoverer/BUILD.bazel
+++ b/comp/core/autodiscovery/discoverer/BUILD.bazel
@@ -35,7 +35,11 @@ go_test(
     tags = ["manual"],
     deps = [
         "//comp/core/autodiscovery/integration",
+        "//comp/core/autodiscovery/telemetry",
+        "//comp/core/telemetry/def",
+        "//comp/core/telemetry/mock",
         "//comp/core/workloadmeta/def",
+        "//pkg/util/fxutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_atomic//:atomic",

--- a/comp/core/autodiscovery/discoverer/worker_test.go
+++ b/comp/core/autodiscovery/discoverer/worker_test.go
@@ -18,6 +18,10 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	adtelemetry "github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	mocktelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 // fakeDiscoverer is a ConfigDiscoverer stub whose DiscoverConfig is supplied
@@ -78,17 +82,26 @@ func newSvc(id string) ServiceInfo {
 	}
 }
 
+func newTestTelemetryStore(t testing.TB) *adtelemetry.Store {
+	t.Helper()
+	telemetryComp := fxutil.Test[telemetry.Component](t, mocktelemetry.Module())
+	return adtelemetry.NewStore(telemetryComp)
+}
+
 // TestWorker_Success_TriggersCallbackOnce: a probe that returns valid JSON
 // fires onResult exactly once and does not retry.
 func TestWorker_Success_TriggersCallbackOnce(t *testing.T) {
+	const svcID = "docker://svc-1"
 	disco := &fakeDiscoverer{fn: func(_, _ string) (string, error) {
 		return `[{"instances":[{"host":"x"}]}]`, nil
 	}}
-	lookup := &fixedLookup{services: map[string]ServiceInfo{"svc-1": newSvc("svc-1")}}
+	lookup := &fixedLookup{services: map[string]ServiceInfo{svcID: newSvc(svcID)}}
 	cb := &recordingCallback{}
+	telStore := newTestTelemetryStore(t)
 
-	w := NewWorker(disco, lookup, cb.callback, Config{MaxAttempts: 3, RetryDelay: 10 * time.Millisecond}, nil)
-	w.Enqueue("svc-1", testTplDigest, "myinteg")
+	w := NewWorker(disco, lookup, cb.callback, Config{MaxAttempts: 3, RetryDelay: 10 * time.Millisecond}, telStore)
+	w.Enqueue(svcID, testTplDigest, "myinteg")
+	assert.Equal(t, float64(1), telStore.DiscoveryQueueDepth.WithValues("myinteg", "docker").Get())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -96,33 +109,40 @@ func TestWorker_Success_TriggersCallbackOnce(t *testing.T) {
 
 	require.Eventually(t, func() bool { return len(cb.snapshot()) == 1 }, time.Second, 5*time.Millisecond)
 	got := cb.snapshot()[0]
-	assert.Equal(t, "svc-1", got.svcID)
+	assert.Equal(t, svcID, got.svcID)
 	assert.Equal(t, testTplDigest, got.tplDigest)
 	require.Len(t, got.configs, 1)
 	assert.Equal(t, "myinteg", got.configs[0].Name)
 	assert.Equal(t, 1, disco.callCount())
+	assert.Equal(t, float64(0), telStore.DiscoveryQueueDepth.WithValues("myinteg", "docker").Get())
+	assert.Equal(t, float64(1), telStore.DiscoveryResults.WithValues("myinteg", "success", "docker").Get())
 }
 
 // TestWorker_RetriesUpToMax: a probe that always returns an error retries
 // until maxAttempts is reached, then gives up — onResult is never fired.
 func TestWorker_RetriesUpToMax(t *testing.T) {
+	const svcID = "containerd://svc-1"
 	disco := &fakeDiscoverer{fn: func(_, _ string) (string, error) {
 		return "", errors.New("nope")
 	}}
-	lookup := &fixedLookup{services: map[string]ServiceInfo{"svc-1": newSvc("svc-1")}}
+	lookup := &fixedLookup{services: map[string]ServiceInfo{svcID: newSvc(svcID)}}
 	cb := &recordingCallback{}
+	telStore := newTestTelemetryStore(t)
 
 	const max = 4
-	w := NewWorker(disco, lookup, cb.callback, Config{MaxAttempts: max, RetryDelay: 5 * time.Millisecond}, nil)
+	w := NewWorker(disco, lookup, cb.callback, Config{MaxAttempts: max, RetryDelay: 5 * time.Millisecond}, telStore)
 	w.Start()
 	defer w.Stop()
-	w.Enqueue("svc-1", testTplDigest, "myinteg")
+	w.Enqueue(svcID, testTplDigest, "myinteg")
+	assert.Equal(t, float64(1), telStore.DiscoveryQueueDepth.WithValues("myinteg", "containerd").Get())
 
 	require.Eventually(t, func() bool { return disco.callCount() >= max }, time.Second, 2*time.Millisecond)
 	// Give one extra retry window to confirm there's no (max+1)th attempt.
 	time.Sleep(20 * time.Millisecond)
 	assert.Equal(t, max, disco.callCount(), "worker should give up after max attempts")
 	assert.Empty(t, cb.snapshot(), "onResult should never fire when discovery fails")
+	assert.Equal(t, float64(0), telStore.DiscoveryQueueDepth.WithValues("myinteg", "containerd").Get())
+	assert.Equal(t, float64(1), telStore.DiscoveryResults.WithValues("myinteg", "max_attempts_exceeded", "containerd").Get())
 }
 
 // TestWorker_PermFail_DropsImmediately: a PermFail error drops the job after
@@ -205,20 +225,25 @@ func TestWorker_ServiceRemovedBetweenRetries(t *testing.T) {
 // TestWorker_DropsWhenServiceGone: if the service has disappeared from the
 // lookup, the worker drops the job without calling DiscoverConfig at all.
 func TestWorker_DropsWhenServiceGone(t *testing.T) {
+	const svcID = "process://svc-gone"
 	disco := &fakeDiscoverer{fn: func(_, _ string) (string, error) {
 		return "", errors.New("should not be called")
 	}}
 	lookup := &fixedLookup{services: map[string]ServiceInfo{}} // empty
 	cb := &recordingCallback{}
+	telStore := newTestTelemetryStore(t)
 
-	w := NewWorker(disco, lookup, cb.callback, Config{MaxAttempts: 3, RetryDelay: 5 * time.Millisecond}, nil)
+	w := NewWorker(disco, lookup, cb.callback, Config{MaxAttempts: 3, RetryDelay: 5 * time.Millisecond}, telStore)
 	w.Start()
 	defer w.Stop()
-	w.Enqueue("svc-gone", testTplDigest, "myinteg")
+	w.Enqueue(svcID, testTplDigest, "myinteg")
+	assert.Equal(t, float64(1), telStore.DiscoveryQueueDepth.WithValues("myinteg", "process").Get())
 
 	time.Sleep(40 * time.Millisecond)
 	assert.Zero(t, disco.callCount())
 	assert.Empty(t, cb.snapshot())
+	assert.Equal(t, float64(0), telStore.DiscoveryQueueDepth.WithValues("myinteg", "process").Get())
+	assert.Equal(t, float64(1), telStore.DiscoveryResults.WithValues("myinteg", "service_not_found", "process").Get())
 }
 
 // TestWorker_NoHost_TriggersRetry: a service whose GetHosts returns nothing


### PR DESCRIPTION
## Summary

Adds telemetry assertions to existing autodiscovery discovery worker unit tests.

The tests now verify that discovery queue depth increments when work is enqueued, returns to zero on terminal outcomes, and that discovery result counters are recorded for representative success, retry exhaustion, and service-not-found paths.

## Validation

- `dda inv tidy`
- `dda inv test --targets=./comp/core/autodiscovery/discoverer`
- pre-commit hooks during `git commit`
- pre-push hooks during `git push`