### PR TITLE
bazel: fix gazelle invocation example in AGENTS.md

### DIFF
--- a/bazel/AGENTS.md
+++ b/bazel/AGENTS.md
@@ -187,8 +187,8 @@ generators and for other languages, sourced from third-party rulesets or written
 **The workflow for any new package is always:**
 
 ```sh
-bazel run //:gazelle -- update ./path/to/package   # generate or update BUILD.bazel
-bazel run //bazel/buildifier                       # format
+bazel run //:gazelle -- ./path/to/package   # generate or update BUILD.bazel
+bazel run //bazel/buildifier                # format
 ```
 
 Do not hand-write `BUILD.bazel` content that Gazelle can infer. A Gazelle extension's job is precisely to keep that


### PR DESCRIPTION
### What does this PR do?

Fix `AGENTS.md` `gazelle` examples

### Motivation

gazelle-runner.bash replaces its baked-in flags (build_tags, strict, build_file_name) instead of augmenting them whenever the first arg is literally "update"/"fix"/"help"/"update-repos". The documented example passed "update" explicitly, silently dropping the build-tag configuration. Passing just the target path augments the baked-in args instead.

### Describe how you validated your changes

### Additional Notes
