### PR TITLE
Drop the no_dynamic_plugins build tag now that we're on containerd v2

### DIFF
--- a/.claude-plugins/datadog-agent-gopls/.claude-plugin/plugin.json
+++ b/.claude-plugins/datadog-agent-gopls/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-agent-gopls",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Go LSP (gopls) pre-configured for the datadog-agent repository with build tags and performance flags",
   "author": {
     "name": "L\u00e9na\u00efc Huard",
@@ -14,7 +14,7 @@
       },
       "initializationOptions": {
         "build.buildFlags": [
-          "-tags=cel,clusterchecks,consul,containerd,cri,crio,datadog.no_waf,docker,ec2,etcd,fargateprocess,grpcnotrace,jetson,jmx,kubeapiserver,kubelet,linux_bpf,ncm,netcgo,netgo,no_dynamic_plugins,no_gogo,npm,nvml,oracle,orchestrator,osusergo,otlp,pcap,podman,python,remove_all_sd,retrynotrace,seclmax,serverless,sharedlibrarycheck,systemd,systemprobechecks,test,trivy,trivy_no_javadb,zk,zlib,zstd",
+          "-tags=cel,clusterchecks,consul,containerd,cri,crio,datadog.no_waf,docker,ec2,etcd,fargateprocess,grpcnotrace,jetson,jmx,kubeapiserver,kubelet,linux_bpf,ncm,netcgo,netgo,no_gogo,npm,nvml,oracle,orchestrator,osusergo,otlp,pcap,podman,python,remove_all_sd,retrynotrace,seclmax,serverless,sharedlibrarycheck,systemd,systemprobechecks,test,trivy,trivy_no_javadb,zk,zlib,zstd",
           "-buildvcs=false"
         ],
         "formatting.local": "github.com/DataDog/datadog-agent"

--- a/tasks/build_tags.bzl
+++ b/tasks/build_tags.bzl
@@ -20,10 +20,6 @@ COMMON_TAGS = set([
     # removes the import to golang.org/x/net/trace in github.com/grpc-ecosystem/go-grpc-middleware
     # which prevents dead code elimination, see https://github.com/golang/go/issues/62024
     "retrynotrace",
-    # Disables dynamic plugins in containerd v1, which removes the import to std "plugin" package on Linux amd64,
-    # which makes the agent significantly smaller.
-    # This can be removed when we start using containerd v2.1 or later.
-    "no_dynamic_plugins",
     # Remove some dependencies from Trivy to reduce binary size.
     "trivy_no_javadb",
 ])


### PR DESCRIPTION
### What does this PR do?
Removes the `no_dynamic_plugins` build tag from the common build tags.

### Motivation
The tag disabled containerd v1's dynamic plugin loader to keep the standard-library `plugin` package (which blocks dead-code elimination) out of the binary. Since the move to containerd v2, that loader lives in the containerd daemon's `cmd/containerd/server` package, which the Agent doesn't import — so the tag no longer gates any compiled code.

### Describe how you validated your changes
- Built the agent with and without the tag: identical binary size and symbol table, with no standard-library `plugin` symbols in either.
- `dda inv invoke-unit-tests.run --tests=build_tags` (py/bzl parity + codegen)
- SQG will ensure no size increase incurs from the change

### Additional Notes