### PR TITLE
Make SNMP device scan method and batch sizes configurable

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/spf13/cobra"
@@ -49,6 +50,14 @@ const (
 	defaultTimeout = 10 // Timeout better suited to walking
 	defaultRetries = 3
 )
+
+// scanFlags holds the tunable device-scan options set via CLI flags.
+type scanFlags struct {
+	useGetBulk      bool
+	bulkBatchSize   uint32
+	flushEveryNOIDs int
+	flushInterval   time.Duration
+}
 
 // argsType is an alias so we can inject the args via fx.
 type argsType []string
@@ -85,6 +94,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		// Similar to the snmpwalk command, we accept responses from a different IP address
 		UseUnconnectedUDPSocket: true,
 	}
+	scanOpts := &scanFlags{}
 	snmpCmd := &cobra.Command{
 		Use:   "snmp",
 		Short: "Snmp tools",
@@ -168,7 +178,7 @@ With --analyze, the walk is matched against SNMP device profiles and a summary r
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			err := fxutil.OneShot(scanDevice,
-				fx.Supply(connParams, globalParams, cmd),
+				fx.Supply(connParams, globalParams, cmd, scanOpts),
 				fx.Provide(func() argsType { return args }),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
@@ -219,6 +229,15 @@ With --analyze, the walk is matched against SNMP device profiles and a summary r
 	// general communication options
 	snmpScanCmd.Flags().IntVarP(&connParams.Retries, "retries", "r", defaultRetries, "Set the number of retries")
 	snmpScanCmd.Flags().IntVarP(&connParams.Timeout, "timeout", "t", defaultTimeout, "Set the request timeout (in seconds)")
+
+	// scan tuning options
+	snmpScanCmd.Flags().BoolVar(&scanOpts.useGetBulk, "use-getbulk", true, "Walk the device with GetBulk (set to false to fall back to the legacy GetNext walk)")
+	snmpScanCmd.Flags().Uint32Var(&scanOpts.bulkBatchSize, "bulk-batch-size", 0, "Starting number of values requested per GetBulk call (0 uses the default)")
+	// Hidden advanced knobs for tuning partial result reporting.
+	snmpScanCmd.Flags().IntVar(&scanOpts.flushEveryNOIDs, "flush-every-n-oids", 0, "Report partial results every N collected OIDs (0 uses the default)")
+	snmpScanCmd.Flags().DurationVar(&scanOpts.flushInterval, "flush-interval", 0, "Report partial results at least this often (0 uses the default)")
+	_ = snmpScanCmd.Flags().MarkHidden("flush-every-n-oids")
+	_ = snmpScanCmd.Flags().MarkHidden("flush-interval")
 
 	// This command does nothing until the backend supports it, so it isn't enabled yet.
 	snmpCmd.AddCommand(snmpScanCmd)
@@ -278,7 +297,7 @@ func setDefaultsFromAgent(connParams *snmpparse.SNMPConfig, agentParams *snmppar
 	}
 }
 
-func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snmpscan.Component, conf config.Component, client ipc.HTTPClient) error {
+func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, scanOpts *scanFlags, snmpScanner snmpscan.Component, conf config.Component, client ipc.HTTPClient) error {
 	// Parse args
 	if len(args) == 0 {
 		return confErrf("missing argument: IP address")
@@ -298,11 +317,19 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 		setDefaultsFromAgent(connParams, agentParams)
 	}
 	deviceID := namespace + ":" + connParams.IPAddress
+	scanMethod := snmpscan.ScanMethodGetBulk
+	if !scanOpts.useGetBulk {
+		scanMethod = snmpscan.ScanMethodGetNext
+	}
 	// Start the scan
 	fmt.Printf("Launching scan for device: %s\n", deviceID)
 	err := snmpScanner.ScanDeviceAndSendData(context.Background(), connParams, namespace,
 		snmpscan.ScanParams{
-			ScanType: metadata.ManualScan,
+			ScanType:        metadata.ManualScan,
+			ScanMethod:      scanMethod,
+			BulkBatchSize:   scanOpts.bulkBatchSize,
+			FlushEveryNOIDs: scanOpts.flushEveryNOIDs,
+			FlushInterval:   scanOpts.flushInterval,
 		})
 	if err != nil {
 		fmt.Printf("Unable to perform device scan for device %s: %v\n", deviceID, err)

--- a/cmd/agent/subcommands/snmp/command_test.go
+++ b/cmd/agent/subcommands/snmp/command_test.go
@@ -7,6 +7,7 @@ package snmp
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,11 +37,28 @@ func TestScanCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "scan", "1.2.3.4", "-v", "3", "-r", "10"},
 		scanDevice,
-		func(cliParams *snmpparse.SNMPConfig, args argsType) {
+		func(cliParams *snmpparse.SNMPConfig, args argsType, scanOpts *scanFlags) {
 			require.Equal(t, argsType{"1.2.3.4"}, args)
 			require.Equal(t, "3", cliParams.Version)
 			require.Equal(t, 10, cliParams.Retries)
 			require.True(t, cliParams.UseUnconnectedUDPSocket)
+			// scan tuning flags default to GetBulk; batch size 0 means the scan
+			// falls back to its configured default.
+			require.True(t, scanOpts.useGetBulk)
+			require.Equal(t, uint32(0), scanOpts.bulkBatchSize)
+		})
+}
+
+func TestScanCommandTuningFlags(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"snmp", "scan", "1.2.3.4", "--use-getbulk=false", "--bulk-batch-size", "7", "--flush-every-n-oids", "50", "--flush-interval", "30s"},
+		scanDevice,
+		func(_ *snmpparse.SNMPConfig, _ argsType, scanOpts *scanFlags) {
+			require.False(t, scanOpts.useGetBulk)
+			require.Equal(t, uint32(7), scanOpts.bulkBatchSize)
+			require.Equal(t, 50, scanOpts.flushEveryNOIDs)
+			require.Equal(t, 30*time.Second, scanOpts.flushInterval)
 		})
 }
 

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -25,6 +25,16 @@ type Component interface {
 	ScanDeviceAndSendData(ctx context.Context, connParams *snmpparse.SNMPConfig, namespace string, scanParams ScanParams) error
 }
 
+// ScanMethod selects the SNMP walk method used for a device scan.
+type ScanMethod string
+
+const (
+	// ScanMethodGetBulk walks the device using SNMP GetBulk requests.
+	ScanMethodGetBulk ScanMethod = "getbulk"
+	// ScanMethodGetNext walks the device using SNMP GetNext requests.
+	ScanMethodGetNext ScanMethod = "getnext"
+)
+
 // ScanParams contains options for a device scan
 type ScanParams struct {
 	ScanType metadata.ScanType
@@ -36,4 +46,22 @@ type ScanParams struct {
 	// MaxCallCount limits the total number of SNMP calls in a scan.
 	// A value of 0 means there is no limit.
 	MaxCallCount int
+
+	// ScanMethod selects the SNMP walk method. The zero value defaults to
+	// GetBulk; GetBulk is automatically downgraded to GetNext for SNMPv1
+	// devices, which do not support GetBulk.
+	ScanMethod ScanMethod
+
+	// BulkBatchSize sets the starting number of values requested per GetBulk
+	// call (the SNMP max-repetitions). A value of 0 uses the default. No effect
+	// when walking with GetNext.
+	BulkBatchSize uint32
+
+	// FlushEveryNOIDs reports partial scan results once this many OIDs have been
+	// collected. A value of 0 uses the default batch size.
+	FlushEveryNOIDs int
+
+	// FlushInterval reports partial scan results when this much time has elapsed
+	// since the last report. A value of 0 uses the default interval.
+	FlushInterval time.Duration
 }

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -72,16 +72,38 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 		)
 	}
 
-	// GetBulk is used for the scan, but it does not exist in SNMPv1, so fall
-	// back to the legacy GetNext walk for v1 devices.
-	useBulk := snmp.Version != gosnmp.Version1
-	if !useBulk {
+	// GetBulk is the default, but it does not exist in SNMPv1, so fall back to
+	// the legacy GetNext walk for v1 devices or when GetNext is requested.
+	useBulk := resolveUseBulk(scanParams.ScanMethod, snmp.Version)
+	if !useBulk && scanParams.ScanMethod != snmpscan.ScanMethodGetNext {
 		s.log.Infof("device %s is SNMPv1, using GetNext for the scan (GetBulk unsupported)", deviceID)
 	}
+	bulkMaxRep := int(scanParams.BulkBatchSize)
+	if bulkMaxRep <= 0 {
+		bulkMaxRep = defaultBulkMaxRepetitions
+	}
+	flushEveryNOIDs := scanParams.FlushEveryNOIDs
+	// A single payload holds up to PayloadMetadataBatchSize OIDs, so flushing
+	// more often than that gains nothing and only multiplies payloads. Treat it
+	// as the floor; 0 means "use the default".
+	if flushEveryNOIDs <= 0 {
+		flushEveryNOIDs = metadata.PayloadMetadataBatchSize
+	} else if flushEveryNOIDs < metadata.PayloadMetadataBatchSize {
+		s.log.Warnf("flush_every_n_oids=%d is below the minimum of %d; using %d", flushEveryNOIDs, metadata.PayloadMetadataBatchSize, metadata.PayloadMetadataBatchSize)
+		flushEveryNOIDs = metadata.PayloadMetadataBatchSize
+	}
+	flushInterval := scanParams.FlushInterval
+	if flushInterval <= 0 {
+		flushInterval = defaultFlushInterval
+	}
+
+	s.log.Debugf("device scan for %s: useBulk=%v bulkMaxRep=%d flushEveryNOIDs=%d flushInterval=%s",
+		deviceID, useBulk, bulkMaxRep, flushEveryNOIDs, flushInterval)
+
 	scanStart := time.Now()
 	err = s.runDeviceScan(ctx, snmp, namespace, deviceID, useBulk,
-		scanParams.CallInterval, scanParams.MaxCallCount, defaultBulkMaxRepetitions,
-		metadata.PayloadMetadataBatchSize, defaultFlushInterval)
+		scanParams.CallInterval, scanParams.MaxCallCount, bulkMaxRep,
+		flushEveryNOIDs, flushInterval)
 	if err != nil {
 		errs := []error{err}
 
@@ -115,6 +137,16 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 		return fmt.Errorf("unable to send completed status: %w", err)
 	}
 	return nil
+}
+
+// resolveUseBulk returns whether a scan should walk the device with GetBulk.
+// GetBulk is used by default and only disabled when GetNext is explicitly
+// requested or when the device speaks SNMPv1, which has no GetBulk.
+func resolveUseBulk(method snmpscan.ScanMethod, version gosnmp.SnmpVersion) bool {
+	if method == snmpscan.ScanMethodGetNext {
+		return false
+	}
+	return version != gosnmp.Version1
 }
 
 func (s snmpScannerImpl) runDeviceScan(

--- a/comp/snmpscanmanager/impl/snmpscanmanager.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager.go
@@ -214,11 +214,21 @@ func (m *snmpScanManagerImpl) processScanRequest(req snmpscanmanager.ScanRequest
 		return err
 	}
 
+	bulkBatchSize := m.agentConfig.GetInt("network_devices.default_scan.bulk_batch_size")
+	if bulkBatchSize < 0 {
+		// A negative value would wrap around when cast to uint32; fall back to
+		// letting the scanner apply its own default instead.
+		bulkBatchSize = 0
+	}
+
 	err = m.scanner.ScanDeviceAndSendData(m.ctx, snmpConfig, namespace,
 		snmpscan.ScanParams{
-			ScanType:     metadata.DefaultScan,
-			CallInterval: snmpCallInterval,
-			MaxCallCount: maxSnmpCallCount,
+			ScanType:        metadata.DefaultScan,
+			CallInterval:    snmpCallInterval,
+			MaxCallCount:    maxSnmpCallCount,
+			BulkBatchSize:   uint32(bulkBatchSize),
+			FlushEveryNOIDs: m.agentConfig.GetInt("network_devices.default_scan.flush_every_n_oids"),
+			FlushInterval:   m.agentConfig.GetDuration("network_devices.default_scan.flush_interval"),
 		})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -255,6 +265,10 @@ func (m *snmpScanManagerImpl) onDeviceScanSuccess(req snmpscanmanager.ScanReques
 
 func (m *snmpScanManagerImpl) onDeviceScanFailure(req snmpscanmanager.ScanRequest, canRetry bool) {
 	now := time.Now()
+
+	if !canRetry {
+		m.log.Warnf("Default scan for device %s failed with a non-retryable error, will not be retried", req.DeviceIP)
+	}
 
 	m.mtx.Lock()
 	var failuresCount int
@@ -382,12 +396,16 @@ func (m *snmpScanManagerImpl) scheduleScanRefresh(req snmpscanmanager.ScanReques
 func (m *snmpScanManagerImpl) scheduleScanRetry(req snmpscanmanager.ScanRequest, lastScanTs time.Time, failuresCount int) {
 	idx := failuresCount - 1
 	if idx < 0 || idx >= len(scanRetryDelays) {
+		m.log.Warnf("Giving up on default scan for device %s after %d failed attempts", req.DeviceIP, failuresCount)
 		return
 	}
 
+	delay := scanRetryDelays[idx]
+	m.log.Infof("Scheduling default scan retry %d/%d for device %s in %s", failuresCount, len(scanRetryDelays), req.DeviceIP, delay)
+
 	m.scanScheduler.QueueScanTask(scanTask{
 		req:        req,
-		nextScanTs: lastScanTs.Add(scanRetryDelays[idx]),
+		nextScanTs: lastScanTs.Add(delay),
 	})
 }
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4365,6 +4365,14 @@ api_key:
 #
 #     excluded_ips: []
 
+#     # @param bulk_batch_size - integer - optional - default: 20
+#     # @env DD_NETWORK_DEVICES_DEFAULT_SCAN_BULK_BATCH_SIZE - integer - optional - default: 20
+#     # Starting number of values requested per GetBulk call during the automatic
+#     # device scan. The scan adjusts this down on failures and back up on
+#     # successes, so this is the ceiling it works toward.
+#
+#     bulk_batch_size: 20
+
 #   # @param autodiscovery - custom object - optional
 #   # Creates and schedules a listener to automatically discover your SNMP devices.
 #   # Discovered devices can then be monitored with the SNMP integration by using

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -4230,6 +4230,24 @@ properties:
             description: |-
               List of IP addresses to exclude from automatic scanning.
               Devices with these IP addresses will be skipped during default scan.
+          bulk_batch_size:
+            node_type: setting
+            type: integer
+            default: 20
+            visibility: public
+            description: |-
+              Starting number of values requested per GetBulk call during the automatic
+              device scan. The scan adjusts this down on failures and back up on
+              successes, so this is the ceiling it works toward.
+          flush_every_n_oids:
+            node_type: setting
+            type: integer
+            default: 0
+            comment: Internal, undocumented knobs for tuning partial result reporting.
+          flush_interval:
+            node_type: setting
+            type: string
+            default: 0s
       autodiscovery:
         node_type: section
         type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -220,6 +220,10 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 
 	config.BindEnvAndSetDefault("network_devices.default_scan.enabled", true)
 	config.BindEnvAndSetDefault("network_devices.default_scan.excluded_ips", []string{})
+	config.BindEnvAndSetDefault("network_devices.default_scan.bulk_batch_size", 20)
+	// Internal, undocumented knobs for tuning partial result reporting.
+	config.BindEnvAndSetDefault("network_devices.default_scan.flush_every_n_oids", 0)
+	config.BindEnvAndSetDefault("network_devices.default_scan.flush_interval", "0s")
 
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.snmp_traps.forwarder.")
 	config.BindEnvAndSetDefault("network_devices.snmp_traps.enabled", false)


### PR DESCRIPTION
Exposes the device scan tuning knobs added earlier in the stack.

CLI (agent snmp scan):
- --use-getbulk (default true; set false to use the legacy GetNext walk)
- --bulk-max-rep (starting GetBulk max-repetitions, default 20)
- hidden --flush-every-n-oids / --flush-interval for partial reporting

Default (automatic) scan config:
- network_devices.default_scan.bulk_max_repetitions (default 20, documented)
- undocumented network_devices.default_scan.flush_every_n_oids / flush_interval

Stacked on #52320.