### PR TITLE
fix(ebpf): use dynamic offset for vm_area_struct.vm_start and vm_end

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/mprotect.h
+++ b/pkg/security/ebpf/c/include/hooks/mprotect.h
@@ -30,12 +30,16 @@ int hook_security_file_mprotect(ctx_t *ctx) {
 
     u64 flags_offset;
     LOAD_CONSTANT("vm_area_struct_flags_offset", flags_offset);
+    u64 vm_start_offset;
+    LOAD_CONSTANT("vm_area_struct_vm_start_offset", vm_start_offset);
+    u64 vm_end_offset;
+    LOAD_CONSTANT("vm_area_struct_vm_end_offset", vm_end_offset);
 
     // Retrieve vma information
     struct vm_area_struct *vma = (struct vm_area_struct *)CTX_PARM1(ctx);
     bpf_probe_read(&syscall->mprotect.vm_protection, sizeof(syscall->mprotect.vm_protection), (char *)vma + flags_offset);
-    bpf_probe_read(&syscall->mprotect.vm_start, sizeof(syscall->mprotect.vm_start), &vma->vm_start);
-    bpf_probe_read(&syscall->mprotect.vm_end, sizeof(syscall->mprotect.vm_end), &vma->vm_end);
+    bpf_probe_read(&syscall->mprotect.vm_start, sizeof(syscall->mprotect.vm_start), (char *)vma + vm_start_offset);
+    bpf_probe_read(&syscall->mprotect.vm_end, sizeof(syscall->mprotect.vm_end), (char *)vma + vm_end_offset);
     syscall->mprotect.req_protection = (u64)CTX_PARM2(ctx);
     return 0;
 }

--- a/pkg/security/probe/constantfetch/btfhub/constants_amd64.json
+++ b/pkg/security/probe/constantfetch/btfhub/constants_amd64.json
@@ -75,7 +75,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -152,7 +154,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -229,7 +233,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -306,7 +312,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -383,7 +391,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -460,7 +470,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -534,7 +546,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -608,7 +622,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -685,7 +701,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -762,7 +780,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -839,7 +859,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -916,7 +938,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -993,7 +1017,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1070,7 +1096,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1146,7 +1174,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1222,7 +1252,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1299,7 +1331,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1376,7 +1410,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -1455,7 +1491,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -1533,7 +1571,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -1613,7 +1653,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1692,7 +1734,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1771,7 +1815,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1850,7 +1896,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1929,7 +1977,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2008,7 +2058,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2087,7 +2139,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2166,7 +2220,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2245,7 +2301,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2324,7 +2382,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2403,7 +2463,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2482,7 +2544,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -2562,7 +2626,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -2642,7 +2708,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -2722,7 +2790,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -2802,7 +2872,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -2882,7 +2954,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -2962,7 +3036,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3036,7 +3112,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3110,7 +3188,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3185,7 +3265,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3259,7 +3341,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3336,7 +3420,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3410,7 +3496,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3485,7 +3573,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3564,7 +3654,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3644,7 +3736,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3723,7 +3817,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 176,
@@ -3802,7 +3898,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -3883,7 +3981,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -3963,7 +4063,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -4044,7 +4146,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -4118,7 +4222,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -4192,7 +4298,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -4269,7 +4377,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -4346,7 +4456,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -4427,7 +4539,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -4508,7 +4622,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -4589,7 +4705,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -4670,7 +4788,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -4748,7 +4868,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -4828,7 +4950,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -4909,7 +5033,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -4986,7 +5112,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -5063,7 +5191,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -5141,7 +5271,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -5219,7 +5351,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -5300,7 +5434,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -5381,7 +5517,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -5462,7 +5600,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -5543,7 +5683,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -5619,7 +5761,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -5695,7 +5839,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -5773,7 +5919,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -5853,7 +6001,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -5927,7 +6077,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -6001,7 +6153,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -6078,7 +6232,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -6155,7 +6311,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -6233,7 +6391,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -6314,7 +6474,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -6395,7 +6557,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -6470,7 +6634,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -6545,7 +6711,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -6620,7 +6788,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -6695,7 +6865,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -6770,7 +6942,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -6845,7 +7019,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -6922,7 +7098,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7001,7 +7179,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7080,7 +7260,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7159,7 +7341,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7238,7 +7422,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7317,7 +7503,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7396,7 +7584,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7475,7 +7665,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7555,7 +7747,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7629,7 +7823,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7703,7 +7899,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7777,7 +7975,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7851,7 +8051,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7925,7 +8127,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -7999,7 +8203,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8073,7 +8279,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8147,7 +8355,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8221,7 +8431,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8295,7 +8507,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8369,7 +8583,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8443,7 +8659,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8517,7 +8735,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8591,7 +8811,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8665,7 +8887,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8739,7 +8963,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8813,7 +9039,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8887,7 +9115,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -8961,7 +9191,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -9038,7 +9270,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -9117,7 +9351,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -9196,7 +9432,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -9275,7 +9513,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -9354,7 +9594,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -9433,7 +9675,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -9512,7 +9756,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -9592,7 +9838,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -9672,7 +9920,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -9752,7 +10002,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 176,
@@ -9831,7 +10083,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 176,
@@ -9910,7 +10164,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 176,
@@ -9989,7 +10245,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 176,
@@ -10068,7 +10326,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 176,
@@ -10147,7 +10407,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -10228,7 +10490,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -10309,7 +10573,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -10390,7 +10656,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -10471,7 +10739,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -10552,7 +10822,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -10633,7 +10905,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -10714,7 +10988,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -10795,7 +11071,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -10876,7 +11154,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -10957,7 +11237,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -11038,7 +11320,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -11119,7 +11403,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -11200,7 +11486,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -11280,7 +11568,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -11360,7 +11650,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -11440,7 +11732,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -11521,7 +11815,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -11602,7 +11898,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -11683,7 +11981,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -11764,7 +12064,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -11845,7 +12147,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -11926,7 +12230,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -12007,7 +12313,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -12088,7 +12396,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -12169,7 +12479,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -12250,7 +12562,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -12331,7 +12645,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -12412,7 +12728,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -12493,7 +12811,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -12574,7 +12894,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -12655,7 +12977,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -12735,7 +13059,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -12815,7 +13141,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -12895,7 +13223,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -12975,7 +13305,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -13055,7 +13387,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -13135,7 +13469,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		}
 	],
 	"kernels": [
@@ -14131,6 +14467,13 @@
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.355-284.735.amzn2.x86_64",
+			"cindex": 4
+		},
+		{
+			"distrib": "amzn",
+			"version": "2",
+			"arch": "x86_64",
+			"uname_release": "4.14.355-284.737.amzn2.x86_64",
 			"cindex": 4
 		},
 		{

--- a/pkg/security/probe/constantfetch/btfhub/constants_arm64.json
+++ b/pkg/security/probe/constantfetch/btfhub/constants_arm64.json
@@ -75,7 +75,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -152,7 +154,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -229,7 +233,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -306,7 +312,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -383,7 +391,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -460,7 +470,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -530,7 +542,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -601,7 +615,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -672,7 +688,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -745,7 +763,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -820,7 +840,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -895,7 +917,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -971,7 +995,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -1047,7 +1073,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -1123,7 +1151,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -1199,7 +1229,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -1277,7 +1309,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1354,7 +1388,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1431,7 +1467,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1503,7 +1541,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1575,7 +1615,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -1653,7 +1695,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -1732,7 +1776,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -1810,7 +1856,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -1890,7 +1938,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -1969,7 +2019,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2048,7 +2100,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2127,7 +2181,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2206,7 +2262,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2285,7 +2343,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2364,7 +2424,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2443,7 +2505,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2522,7 +2586,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2601,7 +2667,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2680,7 +2748,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2759,7 +2829,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -2839,7 +2911,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -2919,7 +2993,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -2999,7 +3075,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -3079,7 +3157,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -3159,7 +3239,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -3239,7 +3321,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3313,7 +3397,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3392,7 +3478,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 176,
@@ -3471,7 +3559,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3551,7 +3641,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -3632,7 +3724,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -3712,7 +3806,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -3793,7 +3889,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -3870,7 +3968,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -3951,7 +4051,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -4032,7 +4134,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -4113,7 +4217,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -4191,7 +4297,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -4271,7 +4379,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -4352,7 +4462,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -4429,7 +4541,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -4507,7 +4621,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -4588,7 +4704,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -4669,7 +4787,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -4742,7 +4862,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -4817,7 +4939,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -4895,7 +5019,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 296,
@@ -4975,7 +5101,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -5052,7 +5180,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -5130,7 +5260,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -5211,7 +5343,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -5292,7 +5426,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -5369,7 +5505,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -5448,7 +5586,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -5527,7 +5667,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 168,
@@ -5607,7 +5749,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 176,
@@ -5686,7 +5830,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 176,
@@ -5765,7 +5911,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 176,
@@ -5844,7 +5992,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -5925,7 +6075,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -6006,7 +6158,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -6087,7 +6241,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -6168,7 +6324,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -6249,7 +6407,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -6329,7 +6489,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -6409,7 +6571,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -6490,7 +6654,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -6571,7 +6737,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -6652,7 +6820,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -6733,7 +6903,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 48,
@@ -6814,7 +6986,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -6894,7 +7068,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		},
 		{
 			"binprm_file_offset": 64,
@@ -6974,7 +7150,9 @@
 			"vfsmount_mnt_flags_offset": 16,
 			"vfsmount_mnt_root_offset": 0,
 			"vfsmount_mnt_sb_offset": 8,
-			"vm_area_struct_flags_offset": 80
+			"vm_area_struct_flags_offset": 80,
+			"vm_area_struct_vm_end_offset": 8,
+			"vm_area_struct_vm_start_offset": 0
 		}
 	],
 	"kernels": [
@@ -7949,6 +8127,13 @@
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.355-284.735.amzn2.aarch64",
+			"cindex": 4
+		},
+		{
+			"distrib": "amzn",
+			"version": "2",
+			"arch": "arm64",
+			"uname_release": "4.14.355-284.737.amzn2.aarch64",
 			"cindex": 4
 		},
 		{

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -26,6 +26,8 @@ const (
 	OffsetNameLinuxBinprmArgc           = "linux_binprm_argc_offset"
 	OffsetNameLinuxBinprmEnvc           = "linux_binprm_envc_offset"
 	OffsetNameVMAreaStructFlags         = "vm_area_struct_flags_offset"
+	OffsetNameVMAreaStructVMStart       = "vm_area_struct_vm_start_offset"
+	OffsetNameVMAreaStructVMEnd         = "vm_area_struct_vm_end_offset"
 	OffsetNameKernelCloneArgsExitSignal = "kernel_clone_args_exit_signal_offset"
 	OffsetNameFileFinode                = "file_f_inode_offset"
 	OffsetNameFileFpath                 = "file_f_path_offset"

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -61,6 +61,8 @@ func computeRawsTable() map[string]uint64 {
 		OffsetNameSockCommonStructSKCFamily:       16,
 		OffsetNameDentryDSb:                       104,
 		OffsetNameNetDeviceStructName:             0,
+		OffsetNameVMAreaStructVMStart:             0,
+		OffsetNameVMAreaStructVMEnd:               8,
 		OffsetNameRenameStructOldDentry:           16,
 		OffsetNameRenameStructNewDentry:           40,
 		OffsetNameSbDev:                           16,

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3473,6 +3473,8 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameLinuxBinprmArgc, "struct linux_binprm", "argc")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameLinuxBinprmEnvc, "struct linux_binprm", "envc")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVMAreaStructFlags, "struct vm_area_struct", "vm_flags")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVMAreaStructVMStart, "struct vm_area_struct", "vm_start")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVMAreaStructVMEnd, "struct vm_area_struct", "vm_end")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameFileFinode, "struct file", "f_inode")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameFileFpath, "struct file", "f_path")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameDentryDSb, "struct dentry", "d_sb")


### PR DESCRIPTION
### What does this PR do?

Replace direct `&vma->vm_start` and `&vma->vm_end` accesses with LOAD_CONSTANT-based offsets. The same `hook_security_file_mprotect` function already used a dynamic offset for vm_flags, making the direct access of vm_start and vm_end an inconsistency.

### Motivation

Direct field access relies on compile-time struct layout from the kernel headers the program was built against. When the running kernel has a different layout (different version, different CONFIG_ options), the read silently targets the wrong memory location, causing corrupt security events. The LOAD_CONSTANT mechanism resolves offsets at eBPF load time via BTF (or other fallbacks), making the programs portable across kernel versions.

### Describe how you validated your changes

Existing functional tests.

### Additional Notes

Memory layout on a 6.17.0-29-generic Ubuntu kernel:

```
struct vm_area_struct {                                                                                                                                                                 
        union {                                                                                                                                                                         
                struct {                                                                                                                                                                
                        long unsigned int vm_start;      /*     0     8 */                                                                                                              
                        long unsigned int vm_end;        /*     8     8 */
                };                                       /*     0    16 */
                freeptr_t          vm_freeptr;           /*     0     8 */
        };                                               /*     0    16 */
        struct mm_struct *         vm_mm;                /*    16     8 */
        pgprot_t                   vm_page_prot;         /*    24     8 */
        union {
                const vm_flags_t   vm_flags;             /*    32     8 */
                vm_flags_t         __vm_flags;           /*    32     8 */
        };                                               /*    32     8 */
        unsigned int               vm_lock_seq;          /*    40     4 */

        /* XXX 4 bytes hole, try to pack */

        struct list_head           anon_vma_chain;       /*    48    16 */
        /* --- cacheline 1 boundary (64 bytes) --- */
        struct anon_vma *          anon_vma;             /*    64     8 */
        const struct vm_operations_struct  * vm_ops;     /*    72     8 */
        long unsigned int          vm_pgoff;             /*    80     8 */
        struct file *              vm_file;              /*    88     8 */
        void *                     vm_private_data;      /*    96     8 */
        atomic_long_t              swap_readahead_info;  /*   104     8 */
        struct mempolicy *         vm_policy;            /*   112     8 */
        struct vma_numab_state *   numab_state;          /*   120     8 */
        /* --- cacheline 2 boundary (128 bytes) --- */
        refcount_t                 vm_refcnt;            /*   128     4 */

        /* XXX 4 bytes hole, try to pack */

        struct {
                struct rb_node     rb;                   /*   136    24 */
                long unsigned int  rb_subtree_last;      /*   160     8 */
        } shared;                                        /*   136    32 */
        struct anon_vma_name *     anon_name;            /*   168     8 */
        struct vm_userfaultfd_ctx  vm_userfaultfd_ctx;   /*   176     8 */
        struct pfnmap_track_ctx *  pfnmap_track_ctx;     /*   184     8 */

        /* size: 192, cachelines: 3, members: 19 */
        /* sum members: 184, holes: 2, sum holes: 8 */
};
```
