### PR TITLE
[CWS]  Many Workload Profile v2 fixes

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -506,6 +506,11 @@ var (
 	// Tags: source (runtime or replay)
 	MetricSecurityProfileV2EventsImmediate = newRuntimeMetric(".security_profile_v2.events.immediate")
 
+	// MetricSecurityProfileV2InsertionErrors is the name of the metric used to report activity-tree
+	// insertion failures that are not routine filtering rejections (i.e. unexpected errors).
+	// Tags: event_type
+	MetricSecurityProfileV2InsertionErrors = newRuntimeMetric(".security_profile_v2.insertion_errors")
+
 	// Tag Resolution metrics
 
 	// MetricSecurityProfileV2TagResolutionEventsQueued is the name of the metric used to report the total events queued waiting for tag resolution

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -499,11 +499,11 @@ var (
 	// Event Processing metrics
 
 	// MetricSecurityProfileV2EventsReceived is the name of the metric used to report events received by ProcessEvent (after filters)
-	// Tags: source (runtime or replay)
+	// Tags: source (runtime, replay or related), event_type
 	MetricSecurityProfileV2EventsReceived = newRuntimeMetric(".security_profile_v2.events.received")
 
 	// MetricSecurityProfileV2EventsImmediate is the name of the metric used to report events processed immediately (tags already resolved)
-	// Tags: source (runtime or replay)
+	// Tags: source (runtime, replay or related), event_type
 	MetricSecurityProfileV2EventsImmediate = newRuntimeMetric(".security_profile_v2.events.immediate")
 
 	// MetricSecurityProfileV2InsertionErrors is the name of the metric used to report activity-tree

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -508,7 +508,7 @@ var (
 
 	// MetricSecurityProfileV2InsertionErrors is the name of the metric used to report activity-tree
 	// insertion failures that are not routine filtering rejections (i.e. unexpected errors).
-	// Tags: event_type
+	// Tags: event_type, error_type
 	MetricSecurityProfileV2InsertionErrors = newRuntimeMetric(".security_profile_v2.insertion_errors")
 
 	// Tag Resolution metrics

--- a/pkg/security/security_profile/BUILD.bazel
+++ b/pkg/security/security_profile/BUILD.bazel
@@ -100,12 +100,15 @@ go_test(
     srcs = [
         "image_excluder_test.go",
         "manager_test.go",
+        "manager_v2_test.go",
     ],
     embed = [":security_profile"],
     gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:android": [
             "//pkg/security/config",
+            "//pkg/security/resolvers",
+            "//pkg/security/resolvers/cgroup",
             "//pkg/security/resolvers/cgroup/model",
             "//pkg/security/resolvers/tags",
             "//pkg/security/secl/containerutils",
@@ -114,6 +117,7 @@ go_test(
             "//pkg/security/security_profile/activity_tree/metadata",
             "//pkg/security/security_profile/dump",
             "//pkg/security/security_profile/profile",
+            "//pkg/security/security_profile/storage",
             "@com_github_datadog_datadog_go_v5//statsd",
             "@com_github_hashicorp_golang_lru_v2//:golang-lru",
             "@com_github_stretchr_testify//assert",
@@ -122,6 +126,8 @@ go_test(
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/security/config",
+            "//pkg/security/resolvers",
+            "//pkg/security/resolvers/cgroup",
             "//pkg/security/resolvers/cgroup/model",
             "//pkg/security/resolvers/tags",
             "//pkg/security/secl/containerutils",
@@ -130,6 +136,7 @@ go_test(
             "//pkg/security/security_profile/activity_tree/metadata",
             "//pkg/security/security_profile/dump",
             "//pkg/security/security_profile/profile",
+            "//pkg/security/security_profile/storage",
             "@com_github_datadog_datadog_go_v5//statsd",
             "@com_github_hashicorp_golang_lru_v2//:golang-lru",
             "@com_github_stretchr_testify//assert",

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -402,6 +402,29 @@ func IsExpectedFilterError(err error) bool {
 		errors.Is(err, ErrIMDSMissingURL)
 }
 
+// Insertion error type labels used to tag the unexpected-insertion-error metric.
+// Keep this list bounded to avoid metric tag cardinality explosion.
+const (
+	// InsertionErrorBrokenLineage labels insertion failures caused by a broken process lineage.
+	InsertionErrorBrokenLineage = "broken_lineage"
+	// InsertionErrorOther labels any other unexpected insertion failure.
+	InsertionErrorOther = "other"
+)
+
+// InsertionErrorTypes is the exhaustive list of labels InsertionErrorType can return.
+var InsertionErrorTypes = []string{InsertionErrorBrokenLineage, InsertionErrorOther}
+
+// InsertionErrorType categorizes an unexpected insertion error into one of the
+// bounded InsertionErrorTypes labels, suitable for use as a low-cardinality metric tag.
+func InsertionErrorType(err error) string {
+	switch {
+	case errors.Is(err, ErrBrokenLineage):
+		return InsertionErrorBrokenLineage
+	default:
+		return InsertionErrorOther
+	}
+}
+
 // isEventValid evaluates if the provided event is valid
 func (at *ActivityTree) isEventValid(event *model.Event, dryRun bool) (bool, error) {
 	// check event type

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -95,7 +95,7 @@ type ManagerV2 struct {
 
 	insertionErrors map[model.EventType]*atomic.Uint64
 
-	eventMetrics [metricSourceCount][model.MaxKernelEventType]*perEventTypeMetrics
+	eventMetrics [metricSourceCount]map[model.EventType]*perEventTypeMetrics
 
 	// storage
 	localStorage              *storage.Directory
@@ -219,15 +219,19 @@ func (m *ManagerV2) initMetricsMap() {
 	}
 }
 
-// initEventMetrics precomputes the {source, event_type} tags and counters for every source/event type.
+// initEventMetrics precomputes the {source, event_type} tags and counters for every source and
+// every configured profile event type. Event types that are never captured by V2 profiles are
+// filtered out in ProcessEvent, so there's no point allocating counters for them.
 func (m *ManagerV2) initEventMetrics() {
 	sources := [metricSourceCount]model.EventSource{
 		metricSourceRuntime: model.EventSourceRuntime,
 		metricSourceReplay:  model.EventSourceReplay,
 		metricSourceRelated: model.EventSourceRelated,
 	}
+	eventTypes := m.config.RuntimeSecurity.SecurityProfileV2EventTypes
 	for src, sourceName := range sources {
-		for et := model.EventType(0); et < model.MaxKernelEventType; et++ {
+		m.eventMetrics[src] = make(map[model.EventType]*perEventTypeMetrics, len(eventTypes))
+		for _, et := range eventTypes {
 			m.eventMetrics[src][et] = &perEventTypeMetrics{
 				tags:            []string{"source:" + string(sourceName), "event_type:" + et.String()},
 				eventsReceived:  atomic.NewUint64(0),
@@ -239,12 +243,9 @@ func (m *ManagerV2) initEventMetrics() {
 }
 
 // eventMetricsFor returns the metric counters for the given source/event type, or nil if the
-// event type is out of range. The three known sources (runtime, replay, related) each map to
-// their own shard so related traffic isn't misreported as runtime.
+// event type isn't one of the configured profile event types. The three known sources (runtime,
+// replay, related) each map to their own shard so related traffic isn't misreported as runtime.
 func (m *ManagerV2) eventMetricsFor(source model.EventSource, et model.EventType) *perEventTypeMetrics {
-	if et >= model.MaxKernelEventType {
-		return nil
-	}
 	src := metricSourceRuntime
 	switch source {
 	case model.EventSourceReplay:
@@ -723,14 +724,9 @@ func (m *ManagerV2) SendStats() error {
 		}
 	}
 
-	// Per-(source, event_type) event counters (range over pointers to avoid copying the atomics).
-	for src := range &m.eventMetrics {
-		shard := &m.eventMetrics[src]
-		for et := range shard {
-			em := shard[et]
-			if em == nil {
-				continue
-			}
+	// Per-(source, event_type) event counters.
+	for src := range m.eventMetrics {
+		for _, em := range m.eventMetrics[src] {
 			if value := em.eventsReceived.Swap(0); value > 0 {
 				if err := m.statsdClient.Count(metrics.MetricSecurityProfileV2EventsReceived, int64(value), em.tags, 1.0); err != nil {
 					return err

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -744,7 +744,7 @@ func (m *ManagerV2) insertEventIntoProfile(event *model.Event) (*profile.Profile
 	// accurate heap footprint — V1's activity_dump.max_dump_size keeps its legacy shallow
 	// semantics for ActivityDump/legacy Manager paths.
 	// TODO: we should handle this in a better way
-	
+
 	if secprof.ComputeHeapSize() >= int64(m.config.RuntimeSecurity.SecurityProfileV2MaxDumpSize()) {
 		secprof.Disable()
 		seclog.Infof("Activity dump of %s was stopped because it reached the maximum allowed size of %d.", secprof.GetSelectorStr(), int64(m.config.RuntimeSecurity.SecurityProfileV2MaxDumpSize()))

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -77,6 +77,8 @@ type ManagerV2 struct {
 
 	eventFiltering map[eventFilteringEntry]*atomic.Uint64
 
+	insertionErrors map[model.EventType]*atomic.Uint64
+
 	// storage
 	localStorage              *storage.Directory
 	remoteStorage             *storage.ActivityDumpRemoteStorageForwarder
@@ -167,6 +169,7 @@ func NewManagerV2(cfg *config.Config, statsdClient statsd.ClientInterface, resol
 		hostname:                  hostname,
 		sendAnomalyDetection:      sendAnomalyDetection,
 		eventFiltering:            make(map[eventFilteringEntry]*atomic.Uint64),
+		insertionErrors:           make(map[model.EventType]*atomic.Uint64),
 		resolvedCgroups:           make(map[containerutils.CGroupID]struct{}),
 		pendingProfileRemovals:    make(map[cgroupModel.WorkloadSelector]time.Time),
 		sampleCookieMap:           cookieMap,
@@ -184,6 +187,7 @@ func NewManagerV2(cfg *config.Config, statsdClient statsd.ClientInterface, resol
 // initMetricsMap initializes the event filtering metrics map with all combinations of event types, states, and results
 func (m *ManagerV2) initMetricsMap() {
 	for i := model.EventType(0); i < model.MaxKernelEventType; i++ {
+		m.insertionErrors[i] = atomic.NewUint64(0)
 		for _, state := range model.AllEventFilteringProfileState {
 			for _, result := range allEventFilteringResults {
 				m.eventFiltering[eventFilteringEntry{
@@ -657,6 +661,16 @@ func (m *ManagerV2) SendStats() error {
 		}
 	}
 
+	// Activity-tree insertion errors (unexpected failures only)
+	for eventType, count := range m.insertionErrors {
+		if value := count.Swap(0); value > 0 {
+			tags := []string{"event_type:" + eventType.String()}
+			if err := m.statsdClient.Count(metrics.MetricSecurityProfileV2InsertionErrors, int64(value), tags, 1.0); err != nil {
+				return err
+			}
+		}
+	}
+
 	// Per-profile size (RAM and disk reported under the same metric, differentiated by storage tag).
 	// Snapshot the active-profiles map under the lock and then call ComputeHeapSize / statsd
 	// outside it — ComputeHeapSize takes the per-profile lock, and we don't want to hold
@@ -760,6 +774,7 @@ func (m *ManagerV2) insertEventIntoProfile(event *model.Event) (*profile.Profile
 	inserted, processNode, eventNodeBase, err := secprof.Insert(event, true, imageTag, activity_tree.Runtime, m.resolvers)
 	if err != nil {
 		if !activity_tree.IsExpectedFilterError(err) {
+			m.incrementInsertionError(event.GetEventType())
 			seclog.Debugf("couldn't insert event into profile: %v", err)
 		}
 		return nil, false
@@ -1078,6 +1093,13 @@ func (m *ManagerV2) FillProfileContextFromWorkloadID(id containerutils.WorkloadI
 
 func (m *ManagerV2) incrementEventFilteringStat(eventType model.EventType, state model.EventFilteringProfileState, result EventFilteringResult) {
 	if entry, ok := m.eventFiltering[eventFilteringEntry{eventType, state, result}]; ok {
+		entry.Inc()
+	}
+}
+
+// incrementInsertionError records an unexpected activity-tree insertion failure for the given event type.
+func (m *ManagerV2) incrementInsertionError(eventType model.EventType) {
+	if entry, ok := m.insertionErrors[eventType]; ok {
 		entry.Inc()
 	}
 }

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -744,11 +744,7 @@ func (m *ManagerV2) insertEventIntoProfile(event *model.Event) (*profile.Profile
 	// accurate heap footprint — V1's activity_dump.max_dump_size keeps its legacy shallow
 	// semantics for ActivityDump/legacy Manager paths.
 	// TODO: we should handle this in a better way
-	if !secprof.IsEnabled() {
-		m.incrementEventFilteringStat(event.GetEventType(), model.ProfileAtMaxSize, NA)
-		return nil, false
-	}
-
+	
 	if secprof.ComputeHeapSize() >= int64(m.config.RuntimeSecurity.SecurityProfileV2MaxDumpSize()) {
 		secprof.Disable()
 		seclog.Infof("Activity dump of %s was stopped because it reached the maximum allowed size of %d.", secprof.GetSelectorStr(), int64(m.config.RuntimeSecurity.SecurityProfileV2MaxDumpSize()))

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -1099,7 +1099,7 @@ func (m *ManagerV2) evictUnusedNodes() {
 	defer m.profilesLock.Unlock()
 
 	for selector, profile := range m.profiles {
-		if profile == nil {
+		if profile == nil || !profile.IsEnabled() {
 			continue
 		}
 
@@ -1110,9 +1110,6 @@ func (m *ManagerV2) evictUnusedNodes() {
 		}
 		evicted := profile.ActivityTree.EvictUnusedNodes(evictionTime, filepathsInProcessCache, selector.Image, selector.Tag)
 		if evicted > 0 {
-			if !profile.IsEnabled() && profile.ActivityTree.Stats.HeapSize() < int64(m.config.RuntimeSecurity.SecurityProfileV2MaxDumpSize()) {
-				profile.Enable()
-			}
 			totalEvicted += evicted
 			seclog.Debugf("evicted %d unused process nodes from profile [%s] ", evicted, selector.String())
 

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -61,6 +61,22 @@ type sampleCookieEntry struct {
 // so the cookie LRU can hold mappings for every possible dedup entry.
 const sampleCookieMapSize = 4096
 
+const (
+	metricSourceRuntime = iota
+	metricSourceReplay
+	metricSourceRelated
+	metricSourceCount
+)
+
+// perEventTypeMetrics holds the precomputed statsd tags and the counters for a
+// (source, event_type) pair. Counters are incremented on the hot path and flushed in SendStats.
+type perEventTypeMetrics struct {
+	tags            []string
+	eventsReceived  *atomic.Uint64
+	eventsImmediate *atomic.Uint64
+	eventsDropped   *atomic.Uint64
+}
+
 type ManagerV2 struct {
 	config        *config.Config
 	statsdClient  statsd.ClientInterface
@@ -78,6 +94,11 @@ type ManagerV2 struct {
 	eventFiltering map[eventFilteringEntry]*atomic.Uint64
 
 	insertionErrors map[model.EventType]*atomic.Uint64
+
+	// eventMetrics holds per-(source, event_type) event counters, indexed by source then event
+	// type. Prefilled at startup so the hot path only reads the array and increments the pointer
+	// atomics (no lock, no allocation), then flushed in SendStats.
+	eventMetrics [metricSourceCount][model.MaxKernelEventType]*perEventTypeMetrics
 
 	// storage
 	localStorage              *storage.Directory
@@ -181,6 +202,7 @@ func NewManagerV2(cfg *config.Config, statsdClient statsd.ClientInterface, resol
 	}
 
 	m.initMetricsMap()
+	m.initEventMetrics()
 	return m, nil
 }
 
@@ -198,6 +220,42 @@ func (m *ManagerV2) initMetricsMap() {
 			}
 		}
 	}
+}
+
+// initEventMetrics precomputes the {source, event_type} tags and counters for every source/event type.
+func (m *ManagerV2) initEventMetrics() {
+	sources := [metricSourceCount]model.EventSource{
+		metricSourceRuntime: model.EventSourceRuntime,
+		metricSourceReplay:  model.EventSourceReplay,
+		metricSourceRelated: model.EventSourceRelated,
+	}
+	for src, sourceName := range sources {
+		for et := model.EventType(0); et < model.MaxKernelEventType; et++ {
+			m.eventMetrics[src][et] = &perEventTypeMetrics{
+				tags:            []string{"source:" + string(sourceName), "event_type:" + et.String()},
+				eventsReceived:  atomic.NewUint64(0),
+				eventsImmediate: atomic.NewUint64(0),
+				eventsDropped:   atomic.NewUint64(0),
+			}
+		}
+	}
+}
+
+// eventMetricsFor returns the metric counters for the given source/event type, or nil if the
+// event type is out of range. The three known sources (runtime, replay, related) each map to
+// their own shard so related traffic isn't misreported as runtime.
+func (m *ManagerV2) eventMetricsFor(source model.EventSource, et model.EventType) *perEventTypeMetrics {
+	if et >= model.MaxKernelEventType {
+		return nil
+	}
+	src := metricSourceRuntime
+	switch source {
+	case model.EventSourceReplay:
+		src = metricSourceReplay
+	case model.EventSourceRelated:
+		src = metricSourceRelated
+	}
+	return m.eventMetrics[src][et]
 }
 
 func (m *ManagerV2) Start(ctx context.Context) {
@@ -434,14 +492,12 @@ func (m *ManagerV2) ProcessEvent(event *model.Event) {
 		return
 	}
 
-	// Resolve event source (runtime or replay) and event type
+	// Resolve event source and look up its precomputed (source, event_type) counters.
 	source := event.FieldHandlers.ResolveSource(event, &event.BaseEvent)
-	eventType := event.GetType()
-	metricTags := []string{"source:" + source, "event_type:" + eventType}
+	em := m.eventMetricsFor(source, model.EventType(event.Type))
 
-	// Emit metric for events that pass initial filters
-	if err := m.statsdClient.Count(metrics.MetricSecurityProfileV2EventsReceived, 1, metricTags, 1.0); err != nil {
-		seclog.Warnf("couldn't send %s metric: %v", metrics.MetricSecurityProfileV2EventsReceived, err)
+	if em != nil {
+		em.eventsReceived.Inc()
 	}
 
 	// Try to resolve tags for this workload
@@ -452,12 +508,12 @@ func (m *ManagerV2) ProcessEvent(event *model.Event) {
 		// Set resolved tags on the event for downstream processing
 		event.ProcessContext.Process.ContainerContext.Tags = workloadTags
 
-		if err := m.statsdClient.Count(metrics.MetricSecurityProfileV2EventsImmediate, 1, metricTags, 1.0); err != nil {
-			seclog.Warnf("couldn't send %s metric: %v", metrics.MetricSecurityProfileV2EventsImmediate, err)
+		if em != nil {
+			em.eventsImmediate.Inc()
 		}
 		m.processEventWithResolvedTags(event)
 	} else {
-		m.queueEventForTagResolution(event, metricTags)
+		m.queueEventForTagResolution(event, em)
 	}
 }
 
@@ -525,7 +581,7 @@ func (m *ManagerV2) processEventWithResolvedTags(event *model.Event) {
 }
 
 // queueEventForTagResolution queues an event while waiting for tag resolution
-func (m *ManagerV2) queueEventForTagResolution(event *model.Event, tags []string) {
+func (m *ManagerV2) queueEventForTagResolution(event *model.Event, em *perEventTypeMetrics) {
 	cgroupID := event.ProcessContext.Process.CGroup.CGroupID
 
 	m.profilePendingEventsLock.Lock()
@@ -551,9 +607,8 @@ func (m *ManagerV2) queueEventForTagResolution(event *model.Event, tags []string
 			// Decrement queue size BEFORE clearing the list
 			m.queueSize.Sub(uint64(eventsLen))
 			pendingEvents.events.Init()
-			// Emit dropped metric
-			if err := m.statsdClient.Count(metrics.MetricSecurityProfileV2TagResolutionEventsDropped, int64(eventsLen), tags, 1.0); err != nil {
-				seclog.Warnf("couldn't send %s metric: %v", metrics.MetricSecurityProfileV2TagResolutionEventsDropped, err)
+			if em != nil {
+				em.eventsDropped.Add(uint64(eventsLen))
 			}
 		}
 		return
@@ -667,6 +722,32 @@ func (m *ManagerV2) SendStats() error {
 			tags := []string{"event_type:" + eventType.String()}
 			if err := m.statsdClient.Count(metrics.MetricSecurityProfileV2InsertionErrors, int64(value), tags, 1.0); err != nil {
 				return err
+			}
+		}
+	}
+
+	// Per-(source, event_type) event counters (range over pointers to avoid copying the atomics).
+	for src := range &m.eventMetrics {
+		shard := &m.eventMetrics[src]
+		for et := range shard {
+			em := shard[et]
+			if em == nil {
+				continue
+			}
+			if value := em.eventsReceived.Swap(0); value > 0 {
+				if err := m.statsdClient.Count(metrics.MetricSecurityProfileV2EventsReceived, int64(value), em.tags, 1.0); err != nil {
+					return err
+				}
+			}
+			if value := em.eventsImmediate.Swap(0); value > 0 {
+				if err := m.statsdClient.Count(metrics.MetricSecurityProfileV2EventsImmediate, int64(value), em.tags, 1.0); err != nil {
+					return err
+				}
+			}
+			if value := em.eventsDropped.Swap(0); value > 0 {
+				if err := m.statsdClient.Count(metrics.MetricSecurityProfileV2TagResolutionEventsDropped, int64(value), em.tags, 1.0); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -68,6 +68,13 @@ const (
 	metricSourceCount
 )
 
+// insertionErrorKey identifies an unexpected activity-tree insertion failure by
+// event type and a bounded error-type label.
+type insertionErrorKey struct {
+	eventType model.EventType
+	errorType string
+}
+
 // perEventTypeMetrics holds the precomputed statsd tags and the counters for a
 // (source, event_type) pair.
 type perEventTypeMetrics struct {
@@ -93,7 +100,7 @@ type ManagerV2 struct {
 
 	eventFiltering map[eventFilteringEntry]*atomic.Uint64
 
-	insertionErrors map[model.EventType]*atomic.Uint64
+	insertionErrors map[insertionErrorKey]*atomic.Uint64
 
 	eventMetrics [metricSourceCount]map[model.EventType]*perEventTypeMetrics
 
@@ -187,7 +194,7 @@ func NewManagerV2(cfg *config.Config, statsdClient statsd.ClientInterface, resol
 		hostname:                  hostname,
 		sendAnomalyDetection:      sendAnomalyDetection,
 		eventFiltering:            make(map[eventFilteringEntry]*atomic.Uint64),
-		insertionErrors:           make(map[model.EventType]*atomic.Uint64),
+		insertionErrors:           make(map[insertionErrorKey]*atomic.Uint64),
 		resolvedCgroups:           make(map[containerutils.CGroupID]struct{}),
 		pendingProfileRemovals:    make(map[cgroupModel.WorkloadSelector]time.Time),
 		sampleCookieMap:           cookieMap,
@@ -206,7 +213,9 @@ func NewManagerV2(cfg *config.Config, statsdClient statsd.ClientInterface, resol
 // initMetricsMap initializes the event filtering metrics map with all combinations of event types, states, and results
 func (m *ManagerV2) initMetricsMap() {
 	for i := model.EventType(0); i < model.MaxKernelEventType; i++ {
-		m.insertionErrors[i] = atomic.NewUint64(0)
+		for _, errorType := range activity_tree.InsertionErrorTypes {
+			m.insertionErrors[insertionErrorKey{eventType: i, errorType: errorType}] = atomic.NewUint64(0)
+		}
 		for _, state := range model.AllEventFilteringProfileState {
 			for _, result := range allEventFilteringResults {
 				m.eventFiltering[eventFilteringEntry{
@@ -715,9 +724,9 @@ func (m *ManagerV2) SendStats() error {
 	}
 
 	// Activity-tree insertion errors (unexpected failures only)
-	for eventType, count := range m.insertionErrors {
+	for key, count := range m.insertionErrors {
 		if value := count.Swap(0); value > 0 {
-			tags := []string{"event_type:" + eventType.String()}
+			tags := []string{"event_type:" + key.eventType.String(), "error_type:" + key.errorType}
 			if err := m.statsdClient.Count(metrics.MetricSecurityProfileV2InsertionErrors, int64(value), tags, 1.0); err != nil {
 				return err
 			}
@@ -848,7 +857,7 @@ func (m *ManagerV2) insertEventIntoProfile(event *model.Event) (*profile.Profile
 	inserted, processNode, eventNodeBase, err := secprof.Insert(event, true, imageTag, activity_tree.Runtime, m.resolvers)
 	if err != nil {
 		if !activity_tree.IsExpectedFilterError(err) {
-			m.incrementInsertionError(event.GetEventType())
+			m.incrementInsertionError(event.GetEventType(), err)
 			seclog.Debugf("couldn't insert event into profile: %v", err)
 		}
 		return nil, false
@@ -1171,9 +1180,11 @@ func (m *ManagerV2) incrementEventFilteringStat(eventType model.EventType, state
 	}
 }
 
-// incrementInsertionError records an unexpected activity-tree insertion failure for the given event type.
-func (m *ManagerV2) incrementInsertionError(eventType model.EventType) {
-	if entry, ok := m.insertionErrors[eventType]; ok {
+// incrementInsertionError records an unexpected activity-tree insertion failure for the given
+// event type, categorizing err into a bounded error-type label.
+func (m *ManagerV2) incrementInsertionError(eventType model.EventType, err error) {
+	key := insertionErrorKey{eventType: eventType, errorType: activity_tree.InsertionErrorType(err)}
+	if entry, ok := m.insertionErrors[key]; ok {
 		entry.Inc()
 	}
 }

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -69,7 +69,7 @@ const (
 )
 
 // perEventTypeMetrics holds the precomputed statsd tags and the counters for a
-// (source, event_type) pair. Counters are incremented on the hot path and flushed in SendStats.
+// (source, event_type) pair.
 type perEventTypeMetrics struct {
 	tags            []string
 	eventsReceived  *atomic.Uint64
@@ -95,9 +95,6 @@ type ManagerV2 struct {
 
 	insertionErrors map[model.EventType]*atomic.Uint64
 
-	// eventMetrics holds per-(source, event_type) event counters, indexed by source then event
-	// type. Prefilled at startup so the hot path only reads the array and increments the pointer
-	// atomics (no lock, no allocation), then flushed in SendStats.
 	eventMetrics [metricSourceCount][model.MaxKernelEventType]*perEventTypeMetrics
 
 	// storage

--- a/pkg/security/security_profile/manager_v2_test.go
+++ b/pkg/security/security_profile/manager_v2_test.go
@@ -1,0 +1,145 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package securityprofile holds security profiles related files
+package securityprofile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
+	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
+	"github.com/DataDog/datadog-agent/pkg/security/security_profile/profile"
+	"github.com/DataDog/datadog-agent/pkg/security/security_profile/storage"
+)
+
+// newTestManagerV2WithLocalStorage builds a minimal ManagerV2 wired to a real on-disk local
+// storage backend, configured to persist profiles as uncompressed protobuf. Only the fields used
+// by persistProfile are populated.
+func newTestManagerV2WithLocalStorage(t *testing.T) (*ManagerV2, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	localStorage, err := storage.NewDirectory(dir, 100)
+	require.NoError(t, err)
+
+	m := &ManagerV2{
+		statsdClient: &statsd.NoOpClient{},
+		localStorage: localStorage,
+		configuredStorageRequests: perFormatStorageRequests([]config.StorageRequest{
+			config.NewStorageRequest(config.LocalStorage, config.Protobuf, false, dir),
+		}),
+	}
+	return m, dir
+}
+
+func newTestProfileWithNodes(name string, nodeCount int) *profile.Profile {
+	p := profile.New(profile.WithWorkloadSelector(cgroupModel.WorkloadSelector{Image: "img", Tag: "v1"}))
+	p.Metadata = mtdt.Metadata{Name: name}
+	for i := 0; i < nodeCount; i++ {
+		p.ActivityTree.ProcessNodes = append(p.ActivityTree.ProcessNodes, &activity_tree.ProcessNode{
+			NodeBase: activity_tree.NewNodeBase(),
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/usr/bin/proc",
+					BasenameStr: "proc",
+				},
+			},
+		})
+	}
+	p.ActivityTree.ComputeActivityTreeStats()
+	return p
+}
+
+// TestManagerV2_persistProfile_skipsDisabled guards against persisting a profile that has been
+// disabled by the max-size safeguard. Disable() drops the activity tree, so persisting would
+// overwrite the last good on-disk profile with an empty, enabled-looking one and break the
+// self-heal path that re-disables over-limit workloads after a restart.
+func TestManagerV2_persistProfile_skipsDisabled(t *testing.T) {
+	// A fresh profile that gets disabled before it was ever persisted must not create a file.
+	t.Run("never persists a disabled profile", func(t *testing.T) {
+		m, dir := newTestManagerV2WithLocalStorage(t)
+		p := newTestProfileWithNodes("disabled-only", 8)
+		p.Disable()
+
+		m.persistProfile(p)
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Empty(t, entries, "a disabled profile must not be written to disk")
+	})
+
+	// The realistic scenario: a profile is persisted while enabled, then crosses the max size and
+	// is disabled. A later persistence tick must leave the existing on-disk profile untouched.
+	t.Run("preserves the existing on-disk profile after disable", func(t *testing.T) {
+		m, dir := newTestManagerV2WithLocalStorage(t)
+		p := newTestProfileWithNodes("over-limit", 8)
+
+		m.persistProfile(p)
+
+		filePath := filepath.Join(dir, "over-limit."+config.Protobuf.String())
+		before, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		require.NotEmpty(t, before, "an enabled profile should have been persisted")
+
+		// The workload crosses the max size: the safeguard disables it and drops its tree.
+		p.Disable()
+		require.True(t, p.ActivityTree.IsEmpty())
+
+		m.persistProfile(p)
+
+		after, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, before, after, "persisting a disabled profile must not overwrite the on-disk profile")
+	})
+}
+
+// TestManagerV2_evictUnusedNodes_skipsDisabledProfile verifies the eviction tick leaves disabled
+// profiles untouched: Disable() already empties the activity tree, so there is nothing to evict,
+// and re-enabling a disabled profile is owned by a separate path, not the eviction loop.
+func TestManagerV2_evictUnusedNodes_skipsDisabledProfile(t *testing.T) {
+	cgr, err := cgroup.NewResolver(&statsd.NoOpClient{}, nil, nil)
+	require.NoError(t, err)
+
+	maxSize := 1 << 20
+	m := &ManagerV2{
+		statsdClient: &statsd.NoOpClient{},
+		resolvers:    &resolvers.EBPFResolvers{CGroupResolver: cgr},
+		profiles:     make(map[cgroupModel.WorkloadSelector]*profile.Profile),
+		config: &config.Config{
+			RuntimeSecurity: &config.RuntimeSecurityConfig{
+				SecurityProfileNodeEvictionTimeout: time.Hour,
+				ActivityDumpTraceSystemdCgroups:    false,
+				SecurityProfileV2MaxDumpSize:       func() int { return maxSize },
+			},
+		},
+	}
+
+	selector := cgroupModel.WorkloadSelector{Image: "img", Tag: "v1"}
+	p := newTestProfileWithNodes("over-limit", 8)
+	// The max-size safeguard disables the profile and drops its tree.
+	p.Disable()
+	require.False(t, p.IsEnabled())
+	require.True(t, p.ActivityTree.IsEmpty())
+	m.profiles[selector] = p
+
+	m.evictUnusedNodes()
+
+	assert.False(t, p.IsEnabled(), "eviction must not re-enable a disabled profile")
+}

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -90,20 +90,20 @@ type Profile struct {
 	// V2
 	// First has been sent
 	hasAlreadyBeenSent *atomic.Bool
-	isEnabled          *atomic.Bool
+	isEnabled          bool
 }
 
 // IsEnabled returns true if the profile is enabled
 func (p *Profile) IsEnabled() bool {
-	return p.isEnabled.Load()
+	return p.isEnabled
 }
 
 // Disable disables the profile and drops its activity tree to free the memory it held.
 func (p *Profile) Disable() {
-	p.isEnabled.Store(false)
-
 	p.Lock()
 	defer p.Unlock()
+
+	p.isEnabled = false
 	p.resetActivityTreeLocked()
 }
 
@@ -118,7 +118,7 @@ func (p *Profile) resetActivityTreeLocked() {
 
 // Enable enables the profile
 func (p *Profile) Enable() {
-	p.isEnabled.Store(true)
+	p.isEnabled = true
 }
 
 // HasAlreadyBeenSent returns true if the profile has already been sent
@@ -180,7 +180,7 @@ func New(opts ...Opts) *Profile {
 		hasAlreadyBeenSent: atomic.NewBool(false),
 		versionContexts:    make(map[string]*VersionContext),
 		profileCookie:      utils.RandNonZeroUint64(),
-		isEnabled:          atomic.NewBool(true),
+		isEnabled:          true,
 	}
 
 	for _, opt := range opts {

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -95,6 +95,9 @@ type Profile struct {
 
 // IsEnabled returns true if the profile is enabled
 func (p *Profile) IsEnabled() bool {
+	p.Lock()
+	defer p.Unlock()
+
 	return p.isEnabled
 }
 

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -101,14 +101,6 @@ func (p *Profile) IsEnabled() bool {
 	return p.isEnabled
 }
 
-// Enable enables the profile
-func (p *Profile) Enable() {
-	p.Lock()
-	defer p.Unlock()
-
-	p.isEnabled = true
-}
-
 // Disable disables the profile and drops its activity tree to free the memory it held.
 func (p *Profile) Disable() {
 	p.Lock()

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -101,6 +101,14 @@ func (p *Profile) IsEnabled() bool {
 	return p.isEnabled
 }
 
+// Enable enables the profile
+func (p *Profile) Enable() {
+	p.Lock()
+	defer p.Unlock()
+
+	p.isEnabled = true
+}
+
 // Disable disables the profile and drops its activity tree to free the memory it held.
 func (p *Profile) Disable() {
 	p.Lock()
@@ -117,11 +125,6 @@ func (p *Profile) resetActivityTreeLocked() {
 	if p.treeOpts.differentiateArgs {
 		p.ActivityTree.DifferentiateArgs()
 	}
-}
-
-// Enable enables the profile
-func (p *Profile) Enable() {
-	p.isEnabled = true
 }
 
 // HasAlreadyBeenSent returns true if the profile has already been sent


### PR DESCRIPTION
### What does this PR do?

* Made Profile.isEnabled a plain bool guarded by the profile mutex instead of an atomic, and moved the flag flip inside the lock in Disable()
* Fixed the resulting data race by having IsEnabled() take the lock internally
* Removed a dead max-size IsEnabled() check that could never be true (already handled by an earlier return)
* Skip disabled profiles in the eviction loop (their tree is already empty) and dropped the dead re-enable-after-eviction block; updated the corresponding test
* Added a metric tracking unexpected activity-tree insertion errors, per event type
* Moved the per-event EventsReceived/EventsImmediate/EventsDropped metrics off the hot path into precomputed atomic counters flushed in SendStats — with a dedicated related source shard (no longer mislabeled runtime) and pointer-based atomics

### Motivation

### Describe how you validated your changes

### Additional Notes
