### PR TITLE
Update datadog-operator API version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -163,7 +163,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.82.0-devel.0.20260624113434-509b872045c2
 	github.com/DataDog/datadog-agent/pkg/version v0.81.0-devel.0.20260603133502-a41610237dba
 	github.com/DataDog/datadog-go/v5 v5.8.3
-	github.com/DataDog/datadog-operator/api v0.0.0-20260626143205-3481300263ec
+	github.com/DataDog/datadog-operator/api v0.0.0-20260626172128-45c4b00ac27b
 	github.com/DataDog/datadog-traceroute v1.0.17
 	github.com/DataDog/dd-trace-go/v2 v2.9.0
 	github.com/DataDog/ebpf-manager v0.7.18

--- a/go.sum
+++ b/go.sum
@@ -2545,8 +2545,8 @@ github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dX
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSqGF5n0s=
 github.com/DataDog/datadog-go/v5 v5.8.3/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
-github.com/DataDog/datadog-operator/api v0.0.0-20260626143205-3481300263ec h1:CerkrVwSfyqPnTr7tn3udEkavki+xSvjFCGA1XTGkYg=
-github.com/DataDog/datadog-operator/api v0.0.0-20260626143205-3481300263ec/go.mod h1:uBJ12iaiqhAc0NExRYjhD9X8YnZckba80Ypz8HTFLuI=
+github.com/DataDog/datadog-operator/api v0.0.0-20260626172128-45c4b00ac27b h1:KDZ/qTEB7wjMDJe831bgglyTi4+kOzVAqWxdnQ6WN3Q=
+github.com/DataDog/datadog-operator/api v0.0.0-20260626172128-45c4b00ac27b/go.mod h1:sFOkv8MUOOjgCmbunaHsUlPzD0RVaQpGuzBAPOPCSmY=
 github.com/DataDog/datadog-traceroute v1.0.17 h1:MyBJCb+pFLjN3tt0boZprYmyj4iegHmKzst5iWil/Dw=
 github.com/DataDog/datadog-traceroute v1.0.17/go.mod h1:gtDOEd1qCVGULNYdHULzFBbdDLJwpP+nJMKSXiuVi78=
 github.com/DataDog/dd-trace-go/v2 v2.9.0 h1:J/EsZ7nPqkf3Pa56AAre306ylYMhtzz6oylmchqc6JA=


### PR DESCRIPTION
## What changed

Updates `github.com/DataDog/datadog-operator/api` from the orphaned pseudo-version `v0.0.0-20260626143205-3481300263ec` to the reachable squash commit pseudo-version `v0.0.0-20260626172128-45c4b00ac27b`.
Original PR commit: https://github.com/DataDog/datadog-operator/pull/3196/changes/3481300263ec4c4925bfcad37b91502bd0e2e32c
Squashed PR: https://github.com/DataDog/datadog-operator/commit/45c4b00ac27b15ee401bd5001c0da23e07bb501f

## Why

The previous operator commit became unreachable after the operator PR was squash-merged, which prevents module tidy/download flows from resolving it locally.
Introduced in https://github.com/DataDog/datadog-agent/pull/52803/changes#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6

## Validation

- `dda inv tidy`
- pre-commit hooks during `git commit`
- pre-push hooks during `git push` (`go-mod-tidy`, `go-mod-replace`, `go-test`, `go-linter`)