### PR TITLE
feat(aix): add AIX cross-compiler support to the Go linter task

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -101,6 +101,8 @@ def run_golangci_lint(
                         instr = "cloning https://github.com/tpoechtrager/osxcross.git, pulling the macos SDK from https://github.com/joseluisq/macosx-sdks/releases, building OSXcross and adding it to your PATH"
                     elif goos == "windows":
                         instr = "the mingw-w64 toolchain (eg. `apt install gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64`)"
+                    elif goos == "aix":
+                        instr = "the AIX cross-compiler from dd/experimental/teams/agent-build/aix/toolchain/build-aix-cross.sh (requires an AIX sysroot)"
                     else:
                         instr = "the appropriate cross-compilation toolchain"
                     print(

--- a/tasks/libs/types/arch.py
+++ b/tasks/libs/types/arch.py
@@ -62,6 +62,11 @@ class Arch:
             return f"{self.gcc_arch}-linux-gnu"
         elif platform == "windows":
             return f"{self.gcc_arch}-w64-mingw32"
+        elif platform == "aix":
+            # AIX cross-compiler triplet uses "powerpc" (not "powerpc64"); 64-bit mode
+            # is selected at compile time via -maix64. Target AIX 7.3 by default —
+            # match the version baked into the toolchain built by build-aix-cross.sh.
+            return "powerpc-ibm-aix7.3.0.0"
         else:
             raise ValueError(f"Unknown platform: {platform}")
 


### PR DESCRIPTION
## What does this PR do?

Enables running the Go linter targeting AIX (`GOOS=aix GOARCH=ppc64`) from a Linux host, using a custom built cross-compiler.

## Motivation
Eventually being able to run linters from Linux runners in CI, this is a first step.

## Describe how you validated your changes
Local validation.

## Additional Notes
The cross-compiler is not added to the buildimages yet, but soon