### PR TITLE
feat(serverless-init): wire MicroVM lifecycle server config from env vars

### DIFF
--- a/cmd/serverless-init/lifecycle/BUILD.bazel
+++ b/cmd/serverless-init/lifecycle/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "config.go",
         "forwarder.go",
         "heartbeat.go",
+        "wire.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/cmd/serverless-init/lifecycle",
     visibility = ["//visibility:public"],
@@ -25,6 +26,7 @@ dd_agent_go_test(
         "config_test.go",
         "forwarder_test.go",
         "heartbeat_test.go",
+        "wire_test.go",
     ],
     embed = [":lifecycle"],
     deps = [

--- a/cmd/serverless-init/lifecycle/config.go
+++ b/cmd/serverless-init/lifecycle/config.go
@@ -46,7 +46,7 @@ func parsePort(envVar, raw string, defaultVal int, forbidden ...int) (int, error
 	}
 	for _, f := range forbidden {
 		if port == f {
-			return 0, fmt.Errorf("%s: must not equal %d", envVar, f)
+			return 0, fmt.Errorf("%s: must not equal %d (collides with the lifecycle server)", envVar, f)
 		}
 	}
 	return port, nil

--- a/cmd/serverless-init/lifecycle/wire.go
+++ b/cmd/serverless-init/lifecycle/wire.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package lifecycle
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// SetupComponents holds the lifecycle dependencies that setup() threads
+// into the lifecycle server and into mode.RunInit.
+type SetupComponents struct {
+	Port      int         // lifecycle hook server port; always set (defaults to DefaultPort)
+	Handle    ChildHandle // always non-nil; noop in sidecar mode
+	Child     *Child      // non-nil only in init-container mode (used by mode.RunInit)
+	Forwarder *Forwarder  // non-nil only when env var is valid AND init-container mode
+}
+
+// setupInput holds the raw string values for setupComponents. Empty string means
+// "unset / use default" for each field, matching env-var semantics.
+type setupInput struct {
+	userAppPort   string
+	lifecyclePort string
+	forwardMs     string
+	readyMs       string
+	validateMs    string
+	sidecarMode   bool
+}
+
+// SetupFromEnv reads lifecycle configuration from environment variables and
+// delegates to setupComponents.
+func SetupFromEnv(sidecarMode bool) (SetupComponents, error) {
+	return setupComponents(setupInput{
+		userAppPort:   os.Getenv(UserAppPortEnvVar),
+		lifecyclePort: os.Getenv(LifecyclePortEnvVar),
+		forwardMs:     os.Getenv(ForwardTimeoutMsEnvVar),
+		readyMs:       os.Getenv(ReadyTimeoutMsEnvVar),
+		validateMs:    os.Getenv(ValidateTimeoutMsEnvVar),
+		sidecarMode:   sidecarMode,
+	})
+}
+
+// SetupFallback returns components with the default port and no forwarder. Used
+// when SetupFromEnv fails (e.g. invalid user-app port) so the lifecycle server
+// still starts and the platform can complete lifecycle handshakes.
+func SetupFallback(sidecarMode bool) SetupComponents {
+	// zero-value setupInput → all defaults; always succeeds
+	c, err := setupComponents(setupInput{sidecarMode: sidecarMode})
+	if err != nil {
+		panic(fmt.Sprintf("BUG: SetupFallback failed with zero-value setupInput: %v", err))
+	}
+	return c
+}
+
+// setupComponents is the testable inner function.
+func setupComponents(in setupInput) (SetupComponents, error) {
+	lifecyclePort, err := parsePort(LifecyclePortEnvVar, in.lifecyclePort, DefaultPort)
+	if err != nil {
+		return SetupComponents{}, err
+	}
+
+	// The forwarder is never built in sidecar mode, so userAppPort and the
+	// forward/ready/validate timeouts are irrelevant here. Returning before
+	// parsing them means a stale or colliding value inherited from an
+	// init-mode config (e.g. equal to the lifecycle port) only produces a
+	// warning instead of failing setup and forcing a fallback that would
+	// also discard unrelated, valid settings like a custom lifecycle port.
+	if in.sidecarMode {
+		if in.userAppPort != "" {
+			log.Warnf("%s is set in sidecar mode; forwarder is disabled (init-container mode is required)", UserAppPortEnvVar)
+		}
+		return SetupComponents{Port: lifecyclePort, Handle: NewNoopChildHandle()}, nil
+	}
+
+	userAppPort, err := parsePort(UserAppPortEnvVar, in.userAppPort, 0, lifecyclePort)
+	if err != nil {
+		return SetupComponents{}, err
+	}
+
+	forwardTimeout, err := parseDurationMs(ForwardTimeoutMsEnvVar, in.forwardMs, defaultForwardTimeout)
+	if err != nil {
+		return SetupComponents{}, err
+	}
+
+	readyTimeout, err := parseDurationMs(ReadyTimeoutMsEnvVar, in.readyMs, defaultReadyTimeout)
+	if err != nil {
+		return SetupComponents{}, err
+	}
+
+	validateTimeout, err := parseDurationMs(ValidateTimeoutMsEnvVar, in.validateMs, defaultValidateTimeout)
+	if err != nil {
+		return SetupComponents{}, err
+	}
+
+	c := SetupComponents{Port: lifecyclePort}
+	c.Child = NewChild()
+	c.Handle = c.Child
+	if userAppPort != 0 {
+		c.Forwarder = NewForwarder(userAppPort, forwardTimeout, readyTimeout, validateTimeout)
+	}
+	return c, nil
+}

--- a/cmd/serverless-init/lifecycle/wire_test.go
+++ b/cmd/serverless-init/lifecycle/wire_test.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package lifecycle
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupComponents_EnvUnsetInitMode_HandleAlive_NoForwarder(t *testing.T) {
+	got, err := setupComponents(setupInput{})
+	require.NoError(t, err)
+	assert.Nil(t, got.Forwarder)
+	require.NotNil(t, got.Child) // production handle, mutable by mode
+	assert.Equal(t, ChildHandle(got.Child), got.Handle)
+	assert.Equal(t, DefaultPort, got.Port)
+}
+
+func TestSetupComponents_EnvSetInitMode_ForwarderEnabled(t *testing.T) {
+	got, err := setupComponents(setupInput{userAppPort: "8080"})
+	require.NoError(t, err)
+	require.NotNil(t, got.Forwarder)
+	require.NotNil(t, got.Child)
+}
+
+func TestSetupComponents_EnvSetSidecarMode_ForwarderDisabledWithWarn(t *testing.T) {
+	got, err := setupComponents(setupInput{userAppPort: "8080", sidecarMode: true})
+	require.NoError(t, err)
+	assert.Nil(t, got.Forwarder, "sidecar mode must disable the forwarder")
+	assert.Nil(t, got.Child, "sidecar mode uses noop child")
+	require.NotNil(t, got.Handle) // noop handle still provided
+}
+
+func TestSetupComponents_EnvUnsetSidecarMode_NoForwarderNoopHandle(t *testing.T) {
+	got, err := setupComponents(setupInput{sidecarMode: true})
+	require.NoError(t, err)
+	assert.Nil(t, got.Forwarder)
+	assert.Nil(t, got.Child)
+	require.NotNil(t, got.Handle)
+}
+
+func TestSetupComponents_EnvInvalid_ReturnsError(t *testing.T) {
+	for _, raw := range []string{"abc", "0", "65536", "9000"} {
+		_, err := setupComponents(setupInput{userAppPort: raw})
+		assert.Error(t, err, "raw=%q should fail", raw)
+	}
+}
+
+// In sidecar mode userAppPort is only used for a warning log — the forwarder
+// is never built — so a stale or colliding value (e.g. inherited from an
+// init-mode config) must not fail setup the way it does in init mode above.
+func TestSetupComponents_SidecarMode_InvalidUserAppPort_NoError(t *testing.T) {
+	for _, raw := range []string{"abc", "0", "65536", "9000"} {
+		got, err := setupComponents(setupInput{userAppPort: raw, sidecarMode: true})
+		require.NoError(t, err, "raw=%q must not fail setup in sidecar mode", raw)
+		assert.Nil(t, got.Forwarder)
+		assert.Nil(t, got.Child)
+		require.NotNil(t, got.Handle)
+	}
+}
+
+func TestSetupComponents_CustomLifecyclePort(t *testing.T) {
+	got, err := setupComponents(setupInput{lifecyclePort: "9001"})
+	require.NoError(t, err)
+	assert.Equal(t, 9001, got.Port)
+}
+
+func TestSetupComponents_InvalidLifecyclePort_ReturnsError(t *testing.T) {
+	for _, raw := range []string{"abc", "0", "65536", "-1"} {
+		_, err := setupComponents(setupInput{lifecyclePort: raw})
+		assert.Error(t, err, "lifecycle port %q should fail", raw)
+	}
+}
+
+// Unlike userAppPort, lifecyclePort is parsed before the sidecar early
+// return and is used regardless of mode (it sets SetupComponents.Port), so
+// it must still be validated in sidecar mode.
+func TestSetupComponents_SidecarMode_InvalidLifecyclePort_StillReturnsError(t *testing.T) {
+	for _, raw := range []string{"abc", "0", "65536", "-1"} {
+		_, err := setupComponents(setupInput{lifecyclePort: raw, sidecarMode: true})
+		assert.Error(t, err, "lifecycle port %q should fail even in sidecar mode", raw)
+	}
+}
+
+func TestSetupComponents_UserAppPortCollidesWithCustomLifecyclePort_ReturnsError(t *testing.T) {
+	// Both ports set to 9001 — must be rejected regardless of the default (9000).
+	_, err := setupComponents(setupInput{lifecyclePort: "9001", userAppPort: "9001"})
+	assert.Error(t, err, "user-app port equal to a non-default lifecycle port must be rejected")
+}
+
+func TestSetupComponents_UserAppPortOnDefaultWhenLifecycleMoved_IsAccepted(t *testing.T) {
+	// Lifecycle moved to 9001; user app on 9000 is now free.
+	got, err := setupComponents(setupInput{lifecyclePort: "9001", userAppPort: "9000"})
+	require.NoError(t, err)
+	assert.Equal(t, 9001, got.Port)
+	require.NotNil(t, got.Forwarder)
+}
+
+func TestSetupComponents_CustomTimeouts(t *testing.T) {
+	got, err := setupComponents(setupInput{userAppPort: "8080", forwardMs: "5000", readyMs: "10000", validateMs: "15000"})
+	require.NoError(t, err)
+	require.NotNil(t, got.Forwarder)
+	assert.Equal(t, 5*time.Second, got.Forwarder.forwardTimeout)
+	assert.Equal(t, 10*time.Second, got.Forwarder.readyTimeout)
+	assert.Equal(t, 15*time.Second, got.Forwarder.validateTimeout)
+}
+
+func TestSetupComponents_InvalidTimeoutMs_ReturnsError(t *testing.T) {
+	for _, raw := range []string{"abc", "0", "-1"} {
+		_, err := setupComponents(setupInput{userAppPort: "8080", forwardMs: raw})
+		assert.Error(t, err, "forward timeout %q should fail", raw)
+	}
+}
+
+// Timeouts are only used to construct the Forwarder, which sidecar mode never
+// builds, so an invalid timeout inherited from an init-mode config must not
+// fail setup in sidecar mode either.
+func TestSetupComponents_SidecarMode_InvalidTimeoutMs_NoError(t *testing.T) {
+	for _, raw := range []string{"abc", "0", "-1"} {
+		got, err := setupComponents(setupInput{userAppPort: "8080", forwardMs: raw, sidecarMode: true})
+		require.NoError(t, err, "forward timeout %q must not fail setup in sidecar mode", raw)
+		assert.Nil(t, got.Forwarder)
+	}
+}
+
+// SetupFromEnv must read UserAppPortEnvVar from the process environment
+// and delegate to setupComponents. Pins the env binding so a refactor
+// can't silently swap the env-var name or skip the lookup.
+func TestSetupFromEnv_ReadsEnvVar_BuildsForwarder(t *testing.T) {
+	t.Setenv(UserAppPortEnvVar, "8080")
+	got, err := SetupFromEnv(false /*sidecar*/)
+	require.NoError(t, err)
+	require.NotNil(t, got.Forwarder)
+	require.NotNil(t, got.Child)
+}
+
+func TestSetupFromEnv_UnsetEnv_NoForwarder(t *testing.T) {
+	t.Setenv(UserAppPortEnvVar, "")
+	got, err := SetupFromEnv(false)
+	require.NoError(t, err)
+	assert.Nil(t, got.Forwarder)
+}
+
+func TestSetupFromEnv_PropagatesParseError(t *testing.T) {
+	t.Setenv(UserAppPortEnvVar, "abc")
+	_, err := SetupFromEnv(false)
+	require.Error(t, err)
+}
+
+// TestSetupFallback_InitMode verifies that SetupFallback returns a no-forwarder
+// init-mode setup regardless of the env var's value. Called by MicroVM.Init
+// when SetupFromEnv fails (invalid port) so the lifecycle server still starts
+// on port 9000 and the platform can complete handshakes.
+//
+// SetupFallback calls setupComponents with an empty port, which always
+// succeeds (see TestParseUserAppPort_UnsetReturnsZeroNoError). The panic
+// branch is therefore unreachable and not exercised here.
+func TestSetupFallback_InitMode(t *testing.T) {
+	t.Setenv(UserAppPortEnvVar, "abc") // invalid — must be ignored by SetupFallback
+	got := SetupFallback(false /*sidecar*/)
+	assert.Nil(t, got.Forwarder, "fallback must have no forwarder")
+	require.NotNil(t, got.Child, "fallback init mode must provide a Child for RunInit")
+	assert.Equal(t, ChildHandle(got.Child), got.Handle)
+}
+
+// TestSetupFallback_SidecarMode verifies the noop-handle path. Like
+// TestSetupFallback_InitMode, the panic branch is unreachable because
+// SetupFallback always passes an empty port to setupComponents.
+func TestSetupFallback_SidecarMode(t *testing.T) {
+	t.Setenv(UserAppPortEnvVar, "abc") // invalid — must be ignored by SetupFallback
+	got := SetupFallback(true /*sidecar*/)
+	assert.Nil(t, got.Forwarder)
+	assert.Nil(t, got.Child)
+	require.NotNil(t, got.Handle)
+}


### PR DESCRIPTION
## Summary

This adds the environment-variable-driven wiring code for the MicroVM
lifecycle HTTP server: reading `DD_AWS_MICROVM_LIFECYCLE_PORT` and the
other lifecycle-related env vars, and assembling the config needed to
construct the server. No HTTP server or handlers are introduced yet —
those land in the next PR in this stack.

The motivation is to let the AWS MicroVM platform's serverless-init
sidecar/init-container learn, purely from its environment, which port
to listen on and how to configure the lifecycle server, without
hardcoding values or requiring code changes per deployment.

## Stack

This is **PR 1 of 4** in a split of
https://github.com/DataDog/datadog-agent/pull/53035 ("feat(serverless-init):
add MicroVM lifecycle HTTP server and env-var wiring"), which was too
large to review as a single PR. The full stack, in merge order:

1. **(this PR)** wire MicroVM lifecycle server config from env vars
2. add standalone MicroVM lifecycle HTTP server
3. propagate MicroVM ID to logs and trace tags
4. add MicroVM lifecycle user-app forwarder pass-through

The tip of PR 4 is byte-for-byte identical to the original
`tianning.li/microvm-06-lifecycle-server-wire` branch.

## Test plan

```
bazel test //cmd/serverless-init/lifecycle:lifecycle_test
```

- [x] `bazel build //cmd/serverless-init/lifecycle:lifecycle`
- [x] `bazel test //cmd/serverless-init/lifecycle:lifecycle_test`
- [x] `dda inv linter.go --targets=./cmd/serverless-init/lifecycle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)