### PR TITLE
feat(serverless-init): add MicroVM lifecycle user-app forwarder pass-through

### DIFF
--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -21,16 +21,28 @@
 //   - /suspend  — VM is about to be snapshotted/frozen.
 //   - /terminate — VM is being torn down permanently.
 //
-// The agent responds to each hook itself: /ready checks child-process
-// liveness; /validate returns 200 directly; /run, /resume, /suspend, and
-// /terminate emit an enhanced metric and, for /suspend and /terminate, flush
-// telemetry before responding.
+// This server handles those hooks in two modes:
+//
+//   - When DD_AWS_MICROVM_USER_APP_PORT is unset: the agent responds
+//     to each hook itself. /ready checks child-process liveness; /validate
+//     returns 200 directly; /run, /resume, /suspend, and /terminate emit
+//     an enhanced metric and, for /suspend and /terminate, flush telemetry
+//     before responding.
+//
+//   - When the env var is set: the agent forwards each hook to
+//     127.0.0.1:<user-app-port> on the same path and mirrors the user app's
+//     response (status, body, Content-Type) back to the platform. /ready and
+//     /validate wait for TCP reachability before forwarding. For /run,
+//     /resume, /suspend, and /terminate the agent's own work — metric
+//     emission, /suspend and /terminate telemetry flush — runs in a goroutine
+//     in parallel with the pass-through.
 //
 // /terminate does NOT synthesize SIGTERM. The platform owns process
 // termination via OS signals delivered independently of this HTTP event.
 package lifecycle
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -39,6 +51,7 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"go.uber.org/atomic"
@@ -76,6 +89,13 @@ const (
 
 	lambdaMicroVMIDKey = "lambda_microvm_id"      // for map[string]string trace tags: key only
 	lambdaMicroVMID    = lambdaMicroVMIDKey + ":" // for []string log/metric tags: key:value concatenated
+
+	// mirrorResponseTimeout is the deadline for writing the mirrored response
+	// back to the platform after the handler's main work (forward + optional
+	// flush) is done. It covers the io.Copy in mirrorResponse, which has no
+	// other deadline. Lifecycle responses are expected to be small; 5s is
+	// generous even for slow platform connections.
+	mirrorResponseTimeout = 5 * time.Second
 )
 
 // flushMode controls whether and how telemetry is flushed during a lifecycle hook.
@@ -83,8 +103,8 @@ type flushMode int
 
 const (
 	noFlush         flushMode = iota // /run, /resume: no flush
-	flushParallel                    // /suspend: flush concurrently
-	flushSequential                  // /terminate: flush after the hook's own work completes
+	flushParallel                    // /suspend: flush concurrently with forward
+	flushSequential                  // /terminate: flush after forward completes
 )
 
 // Flusher is satisfied by serverless.FlushableAgent.
@@ -147,6 +167,7 @@ type Server struct {
 
 	childHandle ChildHandle // production: *Child (init) or NewNoopChildHandle() (sidecar); always non-nil after lifecycle.SetupFromEnv. nil only in legacy unit tests; logs WARN if hit.
 	child       *Child      // non-nil only in init-container mode; nil in sidecar and unit tests. Derived from childHandle when it is a *Child.
+	fwd         *Forwarder  // nil = no opt-in; today's behavior preserved
 	heartbeat   *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
 
 	logsTagSetter  LogsTagSetter     // nil-safe; set via SetLogsTagSetter after construction
@@ -158,18 +179,16 @@ type Server struct {
 }
 
 // writeTimeoutHeadroom covers work that shares WriteTimeout's wall clock but
-// falls outside flushAll's own budget: heartbeat.Stop() (bounded by
-// heartbeatStopTimeout) runs before /suspend and /terminate ever reach
-// dispatchHook. Without this headroom, WriteTimeout can expire in that gap
-// even though the flush completed, and the platform sees a failed hook.
+// falls outside the per-path budget computed in NewServer:
+//   - heartbeatStopTimeout bounds heartbeat.Stop(), which runs before
+//     /suspend and /terminate ever reach dispatchHook.
+//   - mirrorResponseTimeout bounds the final mirrored-response write
+//     (io.Copy in mirrorResponse), which runs after the handler's main work.
 //
-// The extra 500ms is not a bounded blocking call like heartbeatStopTimeout —
-// it's scheduling/response-write jitter margin (goroutine scheduling delay,
-// GC pauses, the final WriteHeader network write). 500ms is comfortably
-// above single-digit-millisecond typical jitter while staying small relative
-// to flushTimeout (seconds) and the platform's own hook timeout budget
-// (1-60s), so it doesn't meaningfully erode either.
-const writeTimeoutHeadroom = heartbeatStopTimeout + 500*time.Millisecond
+// Without this headroom, WriteTimeout can expire in one of those gaps even
+// though the handler's own work already completed, and the platform sees a
+// failed hook.
+const writeTimeoutHeadroom = heartbeatStopTimeout + mirrorResponseTimeout
 
 // NewServer constructs a lifecycle Server. port is typically DefaultPort (9000) but can be overridden via DD_AWS_MICROVM_LIFECYCLE_PORT.
 func NewServer(
@@ -182,6 +201,7 @@ func NewServer(
 	metricSource metrics.MetricSource,
 	flushTimeout time.Duration,
 	childHandle ChildHandle, // may be nil
+	fwd *Forwarder, // may be nil
 	heartbeat *Heartbeat, // may be nil
 ) *Server {
 	s := &Server{
@@ -193,6 +213,7 @@ func NewServer(
 		metricSource:  metricSource,
 		flushTimeout:  flushTimeout,
 		childHandle:   childHandle,
+		fwd:           fwd,
 		instanceID:    atomic.NewString(""),
 		heartbeat:     heartbeat,
 	}
@@ -201,9 +222,22 @@ func NewServer(
 	if c, ok := childHandle.(*Child); ok {
 		s.child = c
 	}
-	// WriteTimeout must cover the full handler wall-clock: the flush budget
-	// (for /suspend and /terminate) plus write headroom.
-	writeTimeout := s.flushTimeout + writeTimeoutHeadroom
+	// WriteTimeout must cover the full handler wall-clock for every path:
+	//   - No forwarder: flushTimeout (flush budget)
+	//   - /run, /resume, /suspend, /terminate: forwardTimeout (default 1s)
+	//   - /ready: readyTimeout (default 60s, matching platform /ready timeout)
+	//   - /validate: validateTimeout (default 60s, matching platform /validate timeout)
+	// plus writeTimeoutHeadroom (heartbeat.Stop() before /suspend and
+	// /terminate, and the final mirrored-response write). Use the largest of
+	// all applicable budgets so the HTTP server does not close the
+	// platform-facing connection before the handler writes the response.
+	maxTimeout := s.flushTimeout
+	if s.fwd != nil {
+		// /terminate uses flushSequential: flush runs after the forward, so its
+		// wall-clock is forwardTimeout+flushTimeout, not max of the two.
+		maxTimeout = max(maxTimeout, s.fwd.forwardTimeout+s.flushTimeout, s.fwd.readyTimeout, s.fwd.validateTimeout)
+	}
+	writeTimeout := maxTimeout + writeTimeoutHeadroom
 	s.httpServer = &http.Server{
 		Addr:         fmt.Sprintf(":%d", port),
 		Handler:      s.handler(),
@@ -287,14 +321,27 @@ func (s *Server) handler() http.Handler {
 // signal. A 200 tells the platform it may take a snapshot of the VM; non-200
 // causes a retry (the platform does not treat /ready failures as fatal).
 //
-// Alive-check via ChildHandle: child alive → 200, anything else (not yet
-// started, already exited, or nil handle) → 503. The pre-spawn race is
-// absorbed by the platform's /ready retry behavior; diagnostic detail
-// (cmd.Start / cmd.Wait errors) is logged at the call site in mode.RunInit,
-// where the actual error value is available.
-func (s *Server) handleReady(w http.ResponseWriter, _ *http.Request) {
+// Dispatcher:
+//   - If a Forwarder is configured (env-var opt-in), pass-through to the user
+//     app with TCP-wait: dial errors map to 503, deadline to 504.
+//   - Otherwise, alive-check via ChildHandle: child alive → 200, anything
+//     else (not yet started, already exited, or nil handle) → 503. The
+//     pre-spawn race is absorbed by the platform's /ready retry behavior;
+//     diagnostic detail (cmd.Start / cmd.Wait errors) is logged at the
+//     call site in mode.RunInit, where the actual error value is available.
+func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: ready")
+	if s.fwd != nil {
+		s.passThroughReady(w, r)
+		return
+	}
 	s.aliveCheckReady(w)
+}
+
+func (s *Server) passThroughReady(w http.ResponseWriter, r *http.Request) {
+	resp := s.fwd.PassThroughWaiting(s.fwd.readyTimeout, pathReady, r.Header, r.Body)
+	defer resp.Body.Close()
+	mirrorResponse(w, resp)
 }
 
 // handleValidate answers the platform's build-time snapshot smoke test. After
@@ -302,7 +349,14 @@ func (s *Server) handleReady(w http.ResponseWriter, _ *http.Request) {
 // /validate; a 200 marks the image version valid, a 503 asks the platform to
 // retry until validateTimeout. It is NOT sent during the normal run/resume
 // lifecycle of a production MicroVM.
-func (s *Server) handleValidate(w http.ResponseWriter, _ *http.Request) {
+//
+// When a Forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT set):
+// pass-through to the user app with TCP-wait, mirroring the response, so the
+// user app's own smoke test drives the build's validity decision. The TCP-wait
+// absorbs the window before the app is reachable on the test run. Without a
+// forwarder the agent returns 200 directly; the user app is not required to
+// implement /validate in that mode.
+func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: validate")
 	// TODO(microvm-validate-metric): /validate is a build-time hook that only
 	// fires on the ephemeral test MicroVM during image build (and may be retried
@@ -311,13 +365,52 @@ func (s *Server) handleValidate(w http.ResponseWriter, _ *http.Request) {
 	// may not reliably flush before the test VM is torn down. Revisit whether it
 	// carries enough value to keep alongside the genuine runtime lifecycle metrics.
 	s.emitLifecycleMetric(validateMetricName)
+	if s.fwd != nil {
+		s.passThroughValidate(w, r)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 }
 
+func (s *Server) passThroughValidate(w http.ResponseWriter, r *http.Request) {
+	resp := s.fwd.PassThroughWaiting(s.fwd.validateTimeout, pathValidate, r.Header, r.Body)
+	defer resp.Body.Close()
+	mirrorResponse(w, resp)
+}
+
+// mirrorResponse writes the user app's status, Content-Type (if set), and
+// body to the platform-facing ResponseWriter. Used by every pass-through path.
+//
+// Only Content-Type is forwarded: without it, Go's ResponseWriter.Write would
+// sniff the first 512 bytes via http.DetectContentType and may misidentify the
+// body (e.g. a JSON error payload detected as text/plain). See
+// https://pkg.go.dev/net/http#ResponseWriter — "If the Header does not contain
+// a Content-Type line, Write adds a Content-Type set to the result of passing
+// the initial 512 bytes of written data to DetectContentType."
+// Other response headers (Set-Cookie, cache directives, custom headers) are
+// irrelevant to the platform's machine-to-machine lifecycle calls and are
+// intentionally dropped.
+func mirrorResponse(w http.ResponseWriter, resp *http.Response) {
+	// Bound the write to the platform so a slow or stalled connection does not
+	// block the handler indefinitely. mirrorResponseTimeout is sized to cover
+	// the io.Copy below; it is also reflected in the server's WriteTimeout.
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(mirrorResponseTimeout)); err != nil {
+		log.Warnf("MicroVM lifecycle: could not set write deadline on mirror response: %v", err)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		w.Header().Set("Content-Type", ct)
+	}
+	w.WriteHeader(resp.StatusCode)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		log.Warnf("MicroVM lifecycle: error copying response body to platform: %v", err)
+	}
+}
+
 // flushAll runs metric/trace/logs flushes in parallel and waits for them,
-// bounded by flushCtx. Used by handleSuspend / handleTerminate. It first
-// drains any pending metric samples so that lifecycle metrics emitted
-// immediately before this call are included in the flush.
+// bounded by flushCtx. Used by handleWithForwarder for the env-var-set path
+// and by handleSuspend / handleTerminate for the env-var-unset path.
+// It first drains any pending metric samples so that lifecycle metrics
+// emitted immediately before this call are included in the flush.
 func (s *Server) flushAll(flushCtx context.Context) {
 	if s.sampleDrainer != nil {
 		drained := make(chan struct{})
@@ -338,9 +431,79 @@ func (s *Server) flushAll(flushCtx context.Context) {
 	s.waitForFlushes(flushCtx, flushDone)
 }
 
-// aliveCheckReady answers /ready. Binary mapping: child alive → 200, anything
-// else → 503. The platform's retry behavior absorbs the pre-spawn window, so
-// we don't wait here.
+// handleWithForwarder runs the agent-side path (metric emission, optionally
+// followed by flush) in a goroutine while a synchronous PassThrough waits
+// for the user app's response, then joins and mirrors the user app's
+// response back to the platform.
+//
+// Used for /run and /resume (noFlush), /suspend (flushParallel), and
+// /terminate (flushSequential). /ready and /validate use passThroughReady
+// and passThroughValidate directly (TCP-wait path, not this function).
+//
+// flushParallel: flush runs concurrently with the forward; wall-clock is
+// max(forwardTimeout, flushTimeout)+ε. Known limitation: telemetry produced
+// by the user app during PassThrough may arrive in the pipeline after
+// Flush() returns and be missed. Residual items survive a suspend→resume
+// cycle (Firecracker preserves process memory), so the race is recoverable.
+//
+// flushSequential: flush runs after PassThrough returns; wall-clock is
+// forwardTimeout+flushTimeout. Eliminates the race at the cost of higher
+// latency. Used for /terminate where in-memory buffers are discarded with
+// the VM and residual items cannot be recovered.
+//
+// flushCtx is deliberately NOT derived from r.Context(): if the platform
+// disconnects mid-handler, the flush still runs to its own budget.
+func (s *Server) handleWithForwarder(metricName, path string, mode flushMode, w http.ResponseWriter, r *http.Request) {
+	sideDone := make(chan struct{})
+
+	var parallelCtx context.Context
+	var cancelParallel context.CancelFunc
+	if mode == flushParallel {
+		parallelCtx, cancelParallel = context.WithTimeout(context.Background(), s.flushTimeout)
+		defer cancelParallel()
+	}
+
+	go func() {
+		defer close(sideDone)
+		s.emitLifecycleMetric(metricName)
+		if mode == flushParallel {
+			s.flushAll(parallelCtx)
+		}
+	}()
+
+	resp := s.fwd.PassThrough(path, r.Header, r.Body)
+
+	// Buffer the response body immediately, before waiting on the flush.
+	// PassThrough returns as soon as response headers arrive; the body is
+	// still tied to the forwardTimeout context (via cancelOnCloseReader).
+	// Both flushParallel (/suspend) and flushSequential (/terminate) can run
+	// longer than forwardTimeout (default 1s vs flushTimeout default 5s), so
+	// waiting on sideDone/flushAll before reading resp.Body risks the context
+	// firing mid-read and making the io.Copy in mirrorResponse fail with a
+	// partial or empty body. Buffering here — while the context is fresh —
+	// makes mirrorResponse context-independent. The body is already capped at
+	// 1 MiB by limitedReadCloser, so io.ReadAll cannot allocate unboundedly.
+	bodyBytes, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		log.Debugf("MicroVM lifecycle: partial %s response body (%d bytes read): %v", path, len(bodyBytes), err)
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	<-sideDone
+
+	if mode == flushSequential {
+		seqCtx, cancel := context.WithTimeout(context.Background(), s.flushTimeout)
+		defer cancel()
+		s.flushAll(seqCtx)
+	}
+
+	mirrorResponse(w, resp)
+}
+
+// aliveCheckReady answers /ready when no user-app forwarder is configured.
+// Binary mapping: child alive → 200, anything else → 503. The platform's
+// retry behavior absorbs the pre-spawn window, so we don't wait here.
 func (s *Server) aliveCheckReady(w http.ResponseWriter) {
 	if s.childHandle == nil {
 		// Wiring bug: setup() MUST construct either *Child (init-container
@@ -358,11 +521,17 @@ func (s *Server) aliveCheckReady(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusServiceUnavailable)
 }
 
-// handleRun emits the run metric, captures the MicroVM instance ID from the
-// platform's request body, and starts the periodic heartbeat. The ID is
-// captured before Start so the first heartbeat emission already carries the
-// correct microvm_id tag.
+// handleRun emits the run metric, captures the MicroVM instance ID
+// from the platform's request body, starts the periodic heartbeat, and
+// (when a forwarder is configured) mirrors the user app's response.
+// handleRun is the only hook that reads r.Body and is therefore not
+// collapsed into dispatchHook directly. The ID is captured before Start
+// so the first heartbeat emission already carries the correct microvm_id tag.
 func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
+	// Read the body once so we can parse the instance ID AND still forward the
+	// original payload to the user app. Without this, the forwarder path would
+	// consume r.Body before the decode, losing the instance_id tag on all
+	// subsequent lifecycle metrics.
 	bodyBytes, _ := io.ReadAll(r.Body)
 	_ = r.Body.Close()
 	var body runBody
@@ -388,42 +557,90 @@ func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 		log.Info("MicroVM lifecycle: run")
 	}
 	s.heartbeat.Start()
-	s.dispatchHook(runMetricName, noFlush, w)
+	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	// Go strips Content-Length from server request headers into r.ContentLength
+	// so the forwarder's header-based Content-Length path in do() sees an empty
+	// string. Put it back now that we know the exact buffered length, so the
+	// forwarded /run request carries a fixed Content-Length rather than
+	// chunked encoding (which some user-app HTTP servers reject).
+	r.Header.Set("Content-Length", strconv.Itoa(len(bodyBytes)))
+	s.dispatchHook(runMetricName, pathRun, noFlush, w, r)
 }
 
-// handleResume emits the resume metric and restarts the heartbeat (stopped at
-// /suspend).
-func (s *Server) handleResume(w http.ResponseWriter, _ *http.Request) {
+// handleResume emits the resume metric, restarts the heartbeat (stopped at
+// /suspend), and (when a forwarder is configured) mirrors the user app's response.
+func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: resume")
 	s.heartbeat.Start()
-	s.dispatchHook(resumeMetricName, noFlush, w)
+	s.dispatchHook(resumeMetricName, pathResume, noFlush, w, r)
 }
 
-// handleSuspend stops the heartbeat and flushes telemetry. Heartbeat is
-// stopped before flushing so any in-flight tick finishes before the metric
-// agent drains; /resume restarts it.
-func (s *Server) handleSuspend(w http.ResponseWriter, _ *http.Request) {
+// handleSuspend stops the heartbeat, flushes telemetry, and (when a forwarder
+// is configured) mirrors the user app's response. Heartbeat is stopped before
+// flushing so any in-flight tick finishes before the metric agent drains;
+// /resume restarts it.
+//
+// Flush mode rationale: flushParallel is used here because Firecracker
+// snapshots the full process memory, preserving any pipeline-buffer items that
+// the parallel flush misses. Those residual items are drained by the agent's
+// periodic flush on the next resume. /terminate uses flushSequential (which
+// buffers the response body, waits for the user app to finish writing it, then
+// flushes) because the VM is torn down with no recovery path.
+//
+// TODO(platform-contract): verify whether the AWS MicroVM platform guarantees
+// that /terminate is always called before a suspended VM is permanently
+// discarded (e.g., snapshot eviction, spot termination, platform crash).
+// If /terminate is NOT guaranteed after /suspend, residual pipeline-buffer
+// items that survived the parallel flush on /suspend will be lost with no
+// recovery path — identical to the /terminate data-loss risk we already
+// address with flushSequential.
+//
+// If the guarantee cannot be confirmed, change flushParallel → flushSequential
+// here. The implementation already supports it (handleWithForwarder and
+// dispatchHook both handle flushSequential). The impact of that change:
+//   - /suspend wall-clock increases from max(forwardTimeout, flushTimeout) to
+//     forwardTimeout + flushTimeout (default: 1s + 5s = 6s vs 5s today).
+//   - The response body from the user app is fully buffered before flushing
+//     (same as /terminate), so logs emitted by the user app while writing its
+//     suspend response are included in the flush rather than risking the race.
+//   - Server WriteTimeout must be updated: the formula in NewServer already
+//     uses forwardTimeout+flushTimeout for the sequential path; adding /suspend
+//     to that path requires no additional change to the WriteTimeout formula
+//     since /terminate already sets the ceiling.
+func (s *Server) handleSuspend(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: suspend — flushing telemetry")
 	s.heartbeat.Stop()
-	s.dispatchHook(suspendMetricName, flushParallel, w)
+	s.dispatchHook(suspendMetricName, pathSuspend, flushParallel, w, r)
 }
 
-// handleTerminate flushes all telemetry.
+// handleTerminate flushes all telemetry and, when a forwarder is configured,
+// mirrors the user app's response.
 //
 // No synthetic SIGTERM is sent. AWS Lambda MicroVM does not promise a
 // separate SIGTERM (the 200 IS the termination trigger and Firecracker
 // destroys the VM on response or at the 60s platform deadline); the agent
 // must not simulate a signal channel that the platform does not provide.
-// Heartbeat is stopped here so it cannot fire after the VM is torn down.
-func (s *Server) handleTerminate(w http.ResponseWriter, _ *http.Request) {
+// User apps that opt in receive /terminate via pass-through and own their
+// own graceful exit; users without a /terminate handler rely on the
+// platform's own termination of the VM. Heartbeat is stopped here so it
+// cannot fire after the VM is torn down.
+func (s *Server) handleTerminate(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: terminate — flushing telemetry")
 	s.heartbeat.Stop()
-	s.dispatchHook(terminateMetricName, flushSequential, w)
+	s.dispatchHook(terminateMetricName, pathTerminate, flushSequential, w, r)
 }
 
 // dispatchHook is the shared dispatch path for run, resume, suspend, and
-// terminate: emit metric, optionally flush, respond 200.
-func (s *Server) dispatchHook(metricName string, mode flushMode, w http.ResponseWriter) {
+// terminate. When a forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT
+// set): delegates to handleWithForwarder which mirrors the user app's response.
+// When no forwarder is configured: emit metric, optionally flush, return 200.
+// In standalone mode the parallel/sequential distinction does not apply, so
+// both flush modes result in a single flushAll call.
+func (s *Server) dispatchHook(metricName, path string, mode flushMode, w http.ResponseWriter, r *http.Request) {
+	if s.fwd != nil {
+		s.handleWithForwarder(metricName, path, mode, w, r)
+		return
+	}
 	s.emitLifecycleMetric(metricName)
 	if mode != noFlush {
 		flushCtx, cancel := context.WithTimeout(context.Background(), s.flushTimeout)

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -7,6 +7,8 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -68,9 +70,10 @@ func newTestServer() (*Server, *mockFlusher, *mockFlusher, *mockLogsAgent, *mock
 	logs := &mockLogsAgent{}
 	emitter := &mockMetricEmitter{}
 	drainer := &mockSampleDrainer{}
-	// port 0 — handler-level tests don't bind. Tests that need a childHandle
-	// or heartbeat assign srv.childHandle / srv.heartbeat after construction.
-	srv := NewServer(0, metric, trace, logs, emitter, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil)
+	// port 0 — handler-level tests don't bind. Tests that need a childHandle,
+	// forwarder, or heartbeat assign srv.childHandle / srv.fwd / srv.heartbeat
+	// after construction.
+	srv := NewServer(0, metric, trace, logs, emitter, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, nil)
 	return srv, metric, trace, logs, emitter, drainer
 }
 
@@ -114,6 +117,32 @@ func TestHandleRunParsesInstanceID(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	id := srv.instanceID.Load()
 	assert.Equal(t, "vm-abc123", id, "instance ID must be stored on the server for lifecycle metric tags")
+}
+
+// TestHandleRunWithForwarderParsesInstanceID verifies that when a forwarder is
+// configured, /run still decodes the MicroVM instance ID from the request body
+// before delegating to handleWithForwarder. Without the decode-then-restore fix, the
+// forwarder path consumed r.Body first, so instanceID was never stored and all
+// subsequent lifecycle metrics lost the instance_id tag.
+func TestHandleRunWithForwarderParsesInstanceID(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	body := strings.NewReader(`{"microvmId":"vm-fwd123"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
+
+	id := srv.instanceID.Load()
+	assert.Equal(t, "vm-fwd123", id, "instance ID must be stored even when forwarder is configured")
 }
 
 func TestHandleRunEmptyBodyDoesNotSetInstanceID(t *testing.T) {
@@ -209,6 +238,36 @@ func TestEmittedMetricsCarryCurrentTimestamp(t *testing.T) {
 	assert.LessOrEqual(t, ts, after, "timestamp must be at or before post-call time")
 }
 
+// TestEmittedMetricsCarryCurrentTimestamp_ForwarderPath verifies the same
+// timestamp guarantee for the handleWithForwarder code path (forwarder enabled).
+// handleWithForwarder runs metric emission in a goroutine but joins before the
+// handler returns, so the before/after window technique still applies.
+func TestEmittedMetricsCarryCurrentTimestamp_ForwarderPath(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	before := float64(time.Now().UnixNano()) / float64(time.Second)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
+	after := float64(time.Now().UnixNano()) / float64(time.Second)
+
+	emitted := emitter.getEmittedMetrics()
+	require.Len(t, emitted, 1)
+	ts := emitted[0].timestamp
+	assert.Greater(t, ts, 0.0, "timestamp must not be the 0 sentinel")
+	assert.GreaterOrEqual(t, ts, before, "timestamp must be at or after pre-call time")
+	assert.LessOrEqual(t, ts, after, "timestamp must be at or before post-call time")
+}
+
 func TestRoutes(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
 	// /ready needs an alive child handle to return 200; the other hooks
@@ -247,8 +306,7 @@ type fakeChildHandle struct {
 }
 
 func newFakeChildHandle() *fakeChildHandle { return &fakeChildHandle{} }
-
-func (f *fakeChildHandle) IsAlive() bool { return f.alive.Load() }
+func (f *fakeChildHandle) IsAlive() bool   { return f.alive.Load() }
 
 func TestHandleReady_NoForwarder_ChildAlive_Returns200(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
@@ -266,6 +324,251 @@ func TestHandleReady_NoForwarder_ChildNotAlive_Returns503(t *testing.T) {
 	rec := httptest.NewRecorder()
 	srv.handleReady(rec, httptest.NewRequest(http.MethodPost, pathReady, nil))
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestHandleReady_WithForwarder_PassesThrough(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ready")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"ready":false,"reason":"warming"}`))
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		readyTimeout:         200 * time.Millisecond,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	rec := httptest.NewRecorder()
+	srv.handleReady(rec, httptest.NewRequest(http.MethodPost, pathReady, nil))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	// /ready must mirror the user app's Content-Type AND body, not just the
+	// status code. The platform may surface the user-app reason string in
+	// readiness diagnostics; dropping body/Content-Type would silently
+	// hide that.
+	assert.Equal(t, "application/x-ready", rec.Header().Get("Content-Type"))
+	assert.Equal(t, `{"ready":false,"reason":"warming"}`, rec.Body.String())
+}
+
+// /run with a forwarder configured mirrors the user-app's status code,
+// body, and Content-Type, and emits the run metric. Replaces the prior
+// fire-and-forget contract.
+func TestHandleRun_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-run")
+		w.WriteHeader(207)
+		_, _ = w.Write([]byte(`{"warmed":true}`))
+	}))
+	defer upstream.Close()
+
+	srv, metric, trace, logs, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	rec := httptest.NewRecorder()
+	srv.handleRun(rec, httptest.NewRequest(http.MethodPost, pathRun, nil))
+
+	assert.Equal(t, 207, rec.Code, "must mirror user-app status, not hardcoded 200")
+	assert.Equal(t, "application/x-run", rec.Header().Get("Content-Type"))
+	assert.Equal(t, `{"warmed":true}`, rec.Body.String())
+	assert.Contains(t, emitter.getEmitted(), runMetricName)
+	// /run does NOT flush — these are no-op for run/resume.
+	assert.Equal(t, int32(0), metric.count.Load(), "run must not flush")
+	assert.Equal(t, int32(0), trace.count.Load())
+	assert.Equal(t, int32(0), logs.count.Load())
+}
+
+// /resume with a forwarder configured mirrors the user-app's response and
+// does NOT flush.
+func TestHandleResume_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(418)
+	}))
+	defer upstream.Close()
+
+	srv, metric, trace, logs, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	rec := httptest.NewRecorder()
+	srv.handleResume(rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
+
+	assert.Equal(t, 418, rec.Code)
+	assert.Contains(t, emitter.getEmitted(), resumeMetricName)
+	assert.Equal(t, int32(0), metric.count.Load(), "resume must not flush")
+	assert.Equal(t, int32(0), trace.count.Load())
+	assert.Equal(t, int32(0), logs.count.Load())
+}
+
+// /terminate with a forwarder configured mirrors the user-app's response,
+// emits the terminate metric, AND flushes telemetry. After the amendment,
+// /terminate also no longer synthesizes a SIGTERM (separate test).
+func TestHandleTerminate_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(503)
+	}))
+	defer upstream.Close()
+
+	srv, metric, trace, logs, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	rec := httptest.NewRecorder()
+	srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
+
+	assert.Equal(t, 503, rec.Code, "must mirror user-app status, not hardcoded 200")
+	assert.Contains(t, emitter.getEmitted(), terminateMetricName)
+	assert.Equal(t, int32(1), metric.count.Load(), "terminate must flush")
+	assert.Equal(t, int32(1), trace.count.Load())
+	assert.Equal(t, int32(1), logs.count.Load())
+}
+
+// When a forwarder is configured, /suspend must mirror the user app's
+// status code, body, and Content-Type back to the platform — not the
+// agent's previous hardcoded 200. This is the core behavior change of
+// the user-app-owns-response amendment.
+func TestHandleSuspend_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-suspend")
+		w.WriteHeader(207) // distinctive status to rule out any agent default
+		_, _ = w.Write([]byte(`{"drained":true}`))
+	}))
+	defer upstream.Close()
+
+	srv, metric, trace, logs, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	rec := httptest.NewRecorder()
+	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+
+	assert.Equal(t, 207, rec.Code, "must mirror user-app status, not hardcoded 200")
+	assert.Equal(t, "application/x-suspend", rec.Header().Get("Content-Type"))
+	assert.Equal(t, `{"drained":true}`, rec.Body.String())
+
+	// Side-effect path still runs alongside the pass-through.
+	assert.Equal(t, int32(1), metric.count.Load(), "metric flush must still run")
+	assert.Equal(t, int32(1), trace.count.Load(), "trace flush must still run")
+	assert.Equal(t, int32(1), logs.count.Load(), "logs flush must still run")
+	assert.Contains(t, emitter.getEmitted(), suspendMetricName, "metric must still be emitted")
+}
+
+// Parallelism pin: with a slow user-app forward, flush mocks must complete
+// BEFORE the forward returns. A sequential "forward then flush" implementation
+// would flip this ordering. (A "flush then forward" implementation would also
+// pass this assertion, but that variant is benign: it's still bounded and
+// telemetry still flushes — just slower. The assertion catches the
+// correctness-violating ordering.)
+func TestHandleSuspend_WithForwarder_FlushCompletesBeforeForwardReturns(t *testing.T) {
+	forwardCompletedAt := atomic.Pointer[time.Time]{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(150 * time.Millisecond) // give flush mocks ample time to land first
+		now := time.Now()
+		forwardCompletedAt.Store(&now)
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	srv, metric, trace, logs, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	rec := httptest.NewRecorder()
+	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+
+	require.NotNil(t, forwardCompletedAt.Load(), "forward must have completed")
+	fwd := *forwardCompletedAt.Load()
+	for _, name := range []struct {
+		label string
+		ts    *time.Time
+	}{
+		{"metric", metric.completedAt.Load()},
+		{"trace", trace.completedAt.Load()},
+		{"logs", logs.completedAt.Load()},
+	} {
+		require.NotNilf(t, name.ts, "%s flush must have completed", name.label)
+		assert.Truef(t, name.ts.Before(fwd), "%s flush_completed_ts must precede forward_completed_ts (parallel execution)", name.label)
+	}
+}
+
+// Dial-error pin: when the user app is not listening, /suspend returns 503
+// (mirrored from the Forwarder's error stub) AND all three flushers were
+// invoked anyway. This guards against an implementation that conditioned
+// the side-effect path on the forward succeeding.
+func TestHandleSuspend_WithForwarder_DialErrorStillRunsFlush(t *testing.T) {
+	srv, metric, trace, logs, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               "http://127.0.0.1:1", // unbound port → dial error
+		client:               &http.Client{},
+		forwardTimeout:       200 * time.Millisecond,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	rec := httptest.NewRecorder()
+	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code, "must mirror the Forwarder's 503 error stub")
+	assert.Equal(t, int32(1), metric.count.Load(), "metric flush must run even on forward dial error")
+	assert.Equal(t, int32(1), trace.count.Load(), "trace flush must run even on forward dial error")
+	assert.Equal(t, int32(1), logs.count.Load(), "logs flush must run even on forward dial error")
+}
+
+func TestHandleSuspend_WithForwarder_WaitsForForwardBeforeResponse(t *testing.T) {
+	forwardEntered := make(chan struct{})
+	releaseForward := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(forwardEntered)
+		<-releaseForward
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	srv, metric, trace, logs, _, _ := newTestServer()
+	srv.fwd = &Forwarder{target: upstream.URL, client: &http.Client{}, forwardTimeout: 5 * time.Second}
+
+	handlerReturned := make(chan struct{})
+	rec := httptest.NewRecorder()
+	go func() {
+		srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+		close(handlerReturned)
+	}()
+
+	<-forwardEntered
+	// Forward is mid-flight; handleSuspend must not have returned yet.
+	select {
+	case <-handlerReturned:
+		t.Fatal("handleSuspend returned before forward completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(releaseForward)
+	<-handlerReturned
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, int32(1), metric.count.Load())
+	assert.Equal(t, int32(1), trace.count.Load())
+	assert.Equal(t, int32(1), logs.count.Load())
 }
 
 // flushAll uses waitForFlushes to bound how long it waits for the metric,
@@ -304,6 +607,194 @@ type slowLogsFlusher struct {
 
 func (s *slowLogsFlusher) Flush(_ context.Context) {
 	time.Sleep(s.block)
+}
+
+// When a forwarder is configured and the flush goroutine exceeds flushTimeout,
+// handleSuspend must still return promptly. The flush runs concurrently with
+// PassThrough inside handleWithForwarder; flushAll's waitForFlushes honours the
+// timeout and closes sideDone so the handler is not blocked on the slow flusher.
+func TestHandleSuspend_WithForwarder_FlushTimeout_ReturnsPromptly(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.flushTimeout = 50 * time.Millisecond
+	srv.logsFlusher = &slowLogsFlusher{block: 1 * time.Second}
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	start := time.Now()
+	rec := httptest.NewRecorder()
+	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+	elapsed := time.Since(start)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"handleSuspend with forwarder must return promptly when flush times out (≪ slow flusher's 1s)")
+}
+
+// TestHandleSuspend_WithForwarder_BodyBufferedBeforeFlush verifies that the
+// response body from the user app is fully mirrored even when the parallel
+// flush runs past the point where the forwardTimeout context would have
+// expired. Without buffering, the forwardTimeout context deadline fires
+// while flushAll is still running, cancels the underlying TCP connection,
+// and mirrorResponse reads an empty or partial body. With buffering the body
+// is read immediately after PassThrough returns — while the context is
+// still alive — so mirrorResponse reads from an in-memory buffer that is
+// context-independent.
+func TestHandleSuspend_WithForwarder_BodyBufferedBeforeFlush(t *testing.T) {
+	// Larger than the transport's read-ahead buffer so the client cannot fully
+	// receive the body in the single read that happens while parsing headers —
+	// finishing the read requires an additional network read against the
+	// connection, which is what the forwardTimeout context cancellation breaks
+	// when the read is delayed until after the flush.
+	wantBody := strings.Repeat("A", 256*1024)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, wantBody)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	// flushTimeout is longer than forwardTimeout so the parallel flush runs
+	// past the point where the forwardTimeout context would have expired.
+	srv.flushTimeout = 200 * time.Millisecond
+	srv.logsFlusher = &slowLogsFlusher{block: 150 * time.Millisecond}
+	srv.fwd = &Forwarder{
+		target: upstream.URL,
+		client: &http.Client{},
+		// forwardTimeout is short: expires during the flush, which means the
+		// cancelOnCloseReader's context deadline fires before mirrorResponse
+		// reads the body — unless the body was already buffered.
+		forwardTimeout:       100 * time.Millisecond,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	rec := httptest.NewRecorder()
+	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, wantBody, rec.Body.String(),
+		"response body must be fully mirrored even after parallel flush runs past forwardTimeout")
+}
+
+// Same as TestHandleSuspend_WithForwarder_FlushTimeout_ReturnsPromptly but for
+// /terminate, which also calls handleWithForwarder with flushSequential.
+func TestHandleTerminate_WithForwarder_FlushTimeout_ReturnsPromptly(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.flushTimeout = 50 * time.Millisecond
+	srv.logsFlusher = &slowLogsFlusher{block: 1 * time.Second}
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	start := time.Now()
+	rec := httptest.NewRecorder()
+	srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
+	elapsed := time.Since(start)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"handleTerminate with forwarder must return promptly when flush times out (≪ slow flusher's 1s)")
+}
+
+// TestHandleTerminate_WithForwarder_BodyBufferedBeforeFlush verifies that the
+// response body from the user app is fully mirrored even when the sequential
+// flush runs after PassThrough returns and the forwardTimeout context expires
+// during the flush. Without buffering, the forwardTimeout context deadline
+// fires mid-flush, cancels the underlying TCP connection, and mirrorResponse
+// reads an empty or partial body. With buffering the body is read immediately
+// after PassThrough returns — while the context is still alive — so
+// mirrorResponse reads from an in-memory buffer that is context-independent.
+func TestHandleTerminate_WithForwarder_BodyBufferedBeforeFlush(t *testing.T) {
+	const wantBody = "terminate-response-body"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, wantBody)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	// flushTimeout is longer than forwardTimeout so the sequential flush runs
+	// past the point where the forwardTimeout context would have expired.
+	srv.flushTimeout = 200 * time.Millisecond
+	srv.logsFlusher = &slowLogsFlusher{block: 150 * time.Millisecond}
+	srv.fwd = &Forwarder{
+		target: upstream.URL,
+		client: &http.Client{},
+		// forwardTimeout is short: expires during the flush, which means the
+		// cancelOnCloseReader's context deadline fires before mirrorResponse
+		// reads the body — unless the body was already buffered.
+		forwardTimeout:       100 * time.Millisecond,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	rec := httptest.NewRecorder()
+	srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, wantBody, rec.Body.String(),
+		"response body must be fully mirrored even after sequential flush runs past forwardTimeout")
+}
+
+// /terminate with a forwarder waits for the user-app forward to complete
+// before responding. Without this wait, /terminate's parallel
+// flush-then-mirror would race against the platform's destruction of the VM
+// at WriteHeader time.
+func TestHandleTerminate_WithForwarder_WaitsForSlowForward(t *testing.T) {
+	forwardEntered := make(chan struct{})
+	releaseForward := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(forwardEntered)
+		<-releaseForward
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       5 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	handlerReturned := make(chan struct{})
+	rec := httptest.NewRecorder()
+	go func() {
+		srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
+		close(handlerReturned)
+	}()
+
+	<-forwardEntered
+	// Forward is mid-flight inside the upstream handler. handleTerminate MUST
+	// NOT have returned yet — that would mean it skipped the forward wait.
+	select {
+	case <-handlerReturned:
+		t.Fatal("handleTerminate returned before forward completed")
+	case <-time.After(50 * time.Millisecond):
+		// Good — handler is correctly blocked on the forward.
+	}
+	close(releaseForward)
+	<-handlerReturned
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must mirror user-app's 200")
 }
 
 // Stop on a nil *Server is safe so callers can defer Stop unconditionally —
@@ -362,15 +853,39 @@ func TestServeAndStopGracefulShutdown(t *testing.T) {
 }
 
 // TestNewServerConfiguresHTTPTimeouts verifies that NewServer sets ReadTimeout and
-// WriteTimeout on the underlying http.Server. WriteTimeout is flushTimeout plus
-// writeTimeoutHeadroom, so heartbeat.Stop() (called before flushAll on /suspend
-// and /terminate) and response-write jitter can't cause a false-negative
-// timeout after the flush itself has already completed.
+// WriteTimeout on the underlying http.Server.
+//
+// Without a forwarder, WriteTimeout is flushTimeout+writeTimeoutHeadroom (flush
+// budget + heartbeat.Stop() + write headroom).
+//
+// With a forwarder, WriteTimeout is max(flushTimeout, forwardTimeout)+writeTimeoutHeadroom.
+// The forwardTimeout (default 30s) exceeds the flush budget (default 5s), so
+// the forwarder-path WriteTimeout must be sized to forwardTimeout+writeTimeoutHeadroom,
+// not flushTimeout+writeTimeoutHeadroom. Otherwise the HTTP server closes the
+// platform-facing connection before the handler can write the mirrored response
+// for any user app that responds after the flush-only deadline.
 func TestNewServerConfiguresHTTPTimeouts(t *testing.T) {
 	flushTimeout := 5 * time.Second
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, nil, nil)
 	assert.Equal(t, 30*time.Second, srv.httpServer.ReadTimeout)
 	assert.Equal(t, flushTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout)
+}
+
+// TestNewServerWithForwarderWriteTimeoutCoversForwardBudget verifies that when a
+// Forwarder is configured, WriteTimeout accounts for the /terminate sequential
+// flush path whose wall-clock is forwardTimeout+flushTimeout. This prevents the
+// HTTP server from closing the platform-facing connection before the handler
+// finishes forwarding and flushing.
+func TestNewServerWithForwarderWriteTimeoutCoversForwardBudget(t *testing.T) {
+	flushTimeout := 5 * time.Second
+	fwd := &Forwarder{
+		forwardTimeout:       30 * time.Second,
+		client:               &http.Client{},
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, nil)
+	assert.Equal(t, fwd.forwardTimeout+flushTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout,
+		"WriteTimeout must cover forwardTimeout+flushTimeout (terminate sequential-flush path)")
 }
 
 // TestInstanceIDTagAppearsInMetricsAfterRun verifies that once /run stores a
@@ -398,6 +913,56 @@ func TestInstanceIDTagAppearsInMetricsAfterRun(t *testing.T) {
 	assert.Contains(t, found.extraTags, lambdaMicroVMID+"vm-abc123")
 }
 
+// errorReader is a helper io.Reader that always returns the provided error.
+// Used to simulate a body read failure in mirrorResponse tests.
+type errorReader struct{ err error }
+
+func (e *errorReader) Read(_ []byte) (int, error) { return 0, e.err }
+
+// TestMirrorResponse_CopiesStatusContentTypeAndBody verifies the happy path:
+// status code, Content-Type, and body are all forwarded to the platform.
+func TestMirrorResponse_CopiesStatusContentTypeAndBody(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 207,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+	}
+	rec := httptest.NewRecorder()
+	mirrorResponse(rec, resp)
+	assert.Equal(t, 207, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.Equal(t, `{"ok":true}`, rec.Body.String())
+}
+
+// TestMirrorResponse_NoContentType_HeaderOmitted verifies that an absent
+// Content-Type in the upstream response is not forwarded (no sniff-trigger).
+func TestMirrorResponse_NoContentType_HeaderOmitted(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+	rec := httptest.NewRecorder()
+	mirrorResponse(rec, resp)
+	assert.Equal(t, 200, rec.Code)
+	assert.Empty(t, rec.Header().Get("Content-Type"))
+}
+
+// TestMirrorResponse_BodyReadError_DoesNotPanic verifies that a mid-body read
+// failure (e.g. user app drops connection) is logged and does not panic. The
+// status code is already committed by WriteHeader, so recovery is impossible;
+// the test confirms the handler survives gracefully.
+func TestMirrorResponse_BodyReadError_DoesNotPanic(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{},
+		Body:       io.NopCloser(&errorReader{err: errors.New("simulated read failure")}),
+	}
+	rec := httptest.NewRecorder()
+	assert.NotPanics(t, func() { mirrorResponse(rec, resp) })
+	assert.Equal(t, 200, rec.Code, "status already committed before body copy")
+}
+
 // --- dispatchHook unit tests ---
 //
 // These tests exercise dispatchHook directly, independent of which handler
@@ -408,7 +973,7 @@ func TestInstanceIDTagAppearsInMetricsAfterRun(t *testing.T) {
 func TestDispatchHook_NoForwarder_WithFlushFalse_EmitsMetricReturns200NoFlush(t *testing.T) {
 	srv, metric, trace, logs, emitter, drainer := newTestServer()
 	rec := httptest.NewRecorder()
-	srv.dispatchHook("test.metric", noFlush, rec)
+	srv.dispatchHook("test.metric", "/test", noFlush, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, emitter.getEmitted(), "test.metric")
 	assert.Equal(t, int32(0), metric.count.Load(), "noFlush must not flush")
@@ -422,7 +987,7 @@ func TestDispatchHook_NoForwarder_WithFlushFalse_EmitsMetricReturns200NoFlush(t 
 func TestDispatchHook_NoForwarder_WithFlushTrue_EmitsMetricAndFlushes(t *testing.T) {
 	srv, metric, trace, logs, emitter, drainer := newTestServer()
 	rec := httptest.NewRecorder()
-	srv.dispatchHook("test.metric", flushParallel, rec)
+	srv.dispatchHook("test.metric", "/test", flushParallel, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, emitter.getEmitted(), "test.metric")
 	assert.Equal(t, int32(1), metric.count.Load(), "flushParallel must flush metric agent")
@@ -431,12 +996,36 @@ func TestDispatchHook_NoForwarder_WithFlushTrue_EmitsMetricAndFlushes(t *testing
 	assert.Equal(t, int32(1), drainer.count.Load())
 }
 
+// TestDispatchHook_WithForwarder_DelegatesToHandleParallel verifies that when
+// a forwarder is configured, dispatchHook mirrors the user app's response and
+// emits the metric (via handleWithForwarder). The no-forwarder 200 path must NOT
+// fire.
+func TestDispatchHook_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(418)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	rec := httptest.NewRecorder()
+	srv.dispatchHook("test.metric", pathResume, noFlush, rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
+	assert.Equal(t, 418, rec.Code, "must mirror user-app status, not hardcoded 200")
+	assert.Contains(t, emitter.getEmitted(), "test.metric")
+}
+
 // TestFlushAllDrainTimeoutDoesNotBlock verifies that flushAll returns within the flush
 // timeout even when the sample drainer never completes. This guards against the
 // lifecycle server stalling — and blocking the MicroVM platform's suspend/terminate
 // handshake — when the metric aggregator worker is deadlocked or slow.
 func TestFlushAllDrainTimeoutDoesNotBlock(t *testing.T) {
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &neverDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 50*time.Millisecond, nil, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &neverDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 50*time.Millisecond, nil, nil, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
@@ -724,6 +1313,32 @@ func TestHandleRun_EmptyBaseTags_AppendsMicroVMIDOnly(t *testing.T) {
 	assert.Equal(t, []string{lambdaMicroVMID + "vm-solo"}, setter.lastCall())
 }
 
+// TestHandleRun_WithForwarder_UpdatesLogTags verifies that the log tag update
+// fires even when a user-app forwarder is configured. handleRun parses the
+// body and calls the setter before delegating to handleWithForwarder.
+func TestHandleRun_WithForwarder_UpdatesLogTags(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	setter := &mockLogsTagSetter{}
+	srv.SetLogsTagSetter(setter, []string{"env:staging"})
+
+	body := strings.NewReader(`{"microvmId":"vm-fwd456"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
+
+	require.Equal(t, 1, setter.callCount(), "SetLogsTags must be called even when forwarder is configured")
+	assert.Equal(t, []string{"env:staging", lambdaMicroVMID + "vm-fwd456"}, setter.lastCall())
+}
+
 // ---------------------------------------------------------------------------
 // Trace tag setter tests
 // ---------------------------------------------------------------------------
@@ -858,4 +1473,29 @@ func TestHandleRun_BaseTraceTagsNotMutated(t *testing.T) {
 
 	assert.Equal(t, map[string]string{"env": "prod"}, base, "baseTraceTags must still be unmodified after second /run")
 	assert.Equal(t, "vm-second", setter.lastCall()["lambda_microvm_id"])
+}
+
+// TestHandleRun_WithForwarder_UpdatesTraceTags verifies that the trace tag
+// update fires even when a user-app forwarder is configured.
+func TestHandleRun_WithForwarder_UpdatesTraceTags(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	setter := &mockTraceTagSetter{}
+	srv.SetTraceTagSetter(setter, map[string]string{"env": "staging"})
+
+	body := strings.NewReader(`{"microvmId":"vm-fwd789"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
+
+	require.Equal(t, 1, setter.callCount(), "SetTraceTags must be called even when forwarder is configured")
+	assert.Equal(t, "vm-fwd789", setter.lastCall()["lambda_microvm_id"])
 }


### PR DESCRIPTION
## Summary

This wires the previously-added `Forwarder`
(`DD_AWS_MICROVM_USER_APP_PORT`) into the lifecycle `Server` so the
agent can optionally pass each lifecycle hook through to the user's
own application instead of answering it directly.

The motivation is to let a customer's own application observe and
react to MicroVM lifecycle events end-to-end (e.g. to run its own
readiness check, or do custom work on suspend/terminate), rather than
only the agent doing so — while preserving today's default (no
forwarder configured) behavior for everyone else.

When `DD_AWS_MICROVM_USER_APP_PORT` is set: `/ready` and `/validate`
wait for TCP reachability before forwarding (so a not-yet-listening
user app doesn't fail these platform-facing checks); `/run`, `/resume`,
`/suspend`, and `/terminate` run the agent's own work (metric emission,
and for `/suspend`/`/terminate`, the telemetry flush) in a goroutine in
parallel with the pass-through to the user app, then mirror the user
app's response (status, body, `Content-Type`) back to the platform.
`/suspend` flushes in parallel with the forward (Firecracker's snapshot
preserves any residual buffered telemetry, recoverable on the next
resume); `/terminate` flushes sequentially after the forward completes,
since a torn-down VM has no recovery path for anything left unflushed.

When the env var is unset, behavior is unchanged from the prior PR in
this stack.

### Fix: response body could be truncated on `/suspend`

A [Codex review comment](https://github.com/DataDog/datadog-agent/pull/53087#discussion_r3507498849)
flagged that `/suspend`'s parallel-flush path could mirror an empty or
truncated user-app response to the platform. `Forwarder.PassThrough`'s
returned `resp.Body` is tied to a `forwardTimeout`-bounded context
(default 1s). The handler only buffered the body upfront for the
sequential-flush path (`/terminate`); the parallel-flush path
(`/suspend`) instead waited for the concurrent flush (default
`flushTimeout` of 5s) before ever reading `resp.Body`. Since
`forwardTimeout < flushTimeout` by default, the forward's context had
already expired by the time `mirrorResponse` read the body — so a
successful user-app response could reach the platform as empty or
truncated. Fixed by buffering the body unconditionally right after
`PassThrough` returns, before waiting on the flush, so every mode
(`/run`, `/resume`, `/suspend`, `/terminate`) is covered. Added
`TestHandleSuspend_WithForwarder_BodyBufferedBeforeFlush`, verified to
fail with `context deadline exceeded` against the pre-fix code.

## Stack

This is **PR 4 of 4** (the final PR) in a split of
https://github.com/DataDog/datadog-agent/pull/53035 ("feat(serverless-init):
add MicroVM lifecycle HTTP server and env-var wiring"), which was too
large to review as a single PR. The full stack, in merge order:

1. wire MicroVM lifecycle server config from env vars
2. add standalone MicroVM lifecycle HTTP server
3. propagate MicroVM ID to logs and trace tags
4. **(this PR)** add MicroVM lifecycle user-app forwarder pass-through

This PR's tip started out byte-for-byte identical to the original
`tianning.li/microvm-06-lifecycle-server-wire` branch, confirming the
split stack reconstituted the original change exactly; it has since
diverged from that original branch due to the response-body-buffering
fix above.

**Reviewer note:** this PR is larger than the ~300-line target used
for the rest of the split. The forwarder pass-through logic
(`handleWithForwarder`, `mirrorResponse`, the TCP-wait pass-through for
`/ready` and `/validate`) and its test coverage form one cohesive,
hard-to-subdivide unit, so it's kept as a single PR rather than being
split further — this exception was already discussed and agreed on
before starting this split.

## Test plan

```
bazel test //cmd/serverless-init/lifecycle:lifecycle_test
```

- [x] `bazel build //cmd/serverless-init/lifecycle:lifecycle`
- [x] `bazel test //cmd/serverless-init/lifecycle:lifecycle_test`
- [x] `dda inv linter.go --targets=./cmd/serverless-init/lifecycle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
