### PR TITLE
fix goFunc retrieval for go1.27rc1

### DIFF
--- a/comp/host-profiler/symboluploader/pclntab/BUILD.bazel
+++ b/comp/host-profiler/symboluploader/pclntab/BUILD.bazel
@@ -47,3 +47,10 @@ go_test(
         "//conditions:default": [],
     }),
 )
+
+go_test(
+    name = "pclntab_internal_test",
+    srcs = ["pclntab_internal_test.go"],
+    embed = [":pclntab"],
+    gotags = ["test"],
+)

--- a/comp/host-profiler/symboluploader/pclntab/pclntab.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab.go
@@ -198,17 +198,6 @@ func sectionContaining(elfFile *pfelf.File, addr uint64) *pfelf.Section {
 	return nil
 }
 
-// goFuncOffset returns the offset of the goFunc field in moduledata.
-func goFuncOffset(v HeaderVersion) (uint32, error) {
-	if v < ver118 {
-		return 0, fmt.Errorf("unsupported pclntab version: %v", v.String())
-	}
-	if v < ver120 {
-		return 38 * ptrSize, nil
-	}
-	return 40 * ptrSize, nil
-}
-
 func FindModuleData(ef *pfelf.File, goPCLnTabInfo *GoPCLnTabInfo, runtimeFirstModuleDataSymbolValue libpf.SymbolValue) (data []byte, address uint64, returnedErr error) {
 	// First: try to use the 'go.module' section introduced in Go 1.26.
 	moduleSection := ef.Section(".go.module")
@@ -309,20 +298,38 @@ func findGoFuncEnd(data []byte, version HeaderVersion) int {
 }
 
 func findGoFuncVal(ef *pfelf.File, goPCLnTabInfo *GoPCLnTabInfo, runtimeFirstModuleDataSymbolValue libpf.SymbolValue) (uint64, error) {
+	if goPCLnTabInfo.Version < ver118 {
+		return 0, fmt.Errorf("unsupported pclntab version: %v", goPCLnTabInfo.Version.String())
+	}
+
+	// in go 1.26+, moduledata has its own section
+	if ef.Section(".go.module") != nil {
+		// funcdata (beginning of go:func.*) is now in pclntab, right after functab so goFunc is simply Address +
+		// funcTabEndOffset() (https://go.dev/doc/go1.26#compiler)
+		// this avoids moduledata gofunc offsets for recent versions that can change between releases (e.g. Go 1.27).
+		off := goPCLnTabInfo.funcTabEndOffset()
+		if off <= 0 {
+			return 0, fmt.Errorf("could not compute functab end offset")
+		}
+
+		return goPCLnTabInfo.Address + uint64(off), nil
+	}
+
+	// Before Go 1.26, goFunc is a separate region located via the gofunc pointer in moduledata. Its offset is frozen
+	// for those released versions.
 	moduleData, _, err := FindModuleData(ef, goPCLnTabInfo, runtimeFirstModuleDataSymbolValue)
 	if err != nil {
 		return 0, fmt.Errorf("could not find module data: %w", err)
 	}
-	goFuncOff, err := goFuncOffset(goPCLnTabInfo.Version)
-	if err != nil {
-		return 0, fmt.Errorf("could not get go func offset: %w", err)
+	goFuncOff := uint32(40 * ptrSize) // Go 1.20-1.25
+	if goPCLnTabInfo.Version < ver120 {
+		goFuncOff = 38 * ptrSize // Go 1.18-1.19
 	}
-	if goFuncOff+ptrSize >= uint32(len(moduleData)) {
+
+	if int(goFuncOff)+ptrSize > len(moduleData) {
 		return 0, fmt.Errorf("invalid go func offset: %v", goFuncOff)
 	}
-	goFuncVal := binary.NativeEndian.Uint64(moduleData[goFuncOff:])
-
-	return goFuncVal, nil
+	return binary.NativeEndian.Uint64(moduleData[goFuncOff:]), nil
 }
 
 func FindGoFunc(ef *pfelf.File, goPCLnTabInfo *GoPCLnTabInfo, runtimeFirstModuleDataSymbolValue, goFuncSymbolValue libpf.SymbolValue) (data []byte, goFuncVal uint64, err error) {
@@ -436,7 +443,7 @@ func alignUp(v, align int) int {
 	return (v + align - 1) &^ (align - 1)
 }
 
-func (g *GoPCLnTabInfo) findFuncDataSize() int {
+func (g *GoPCLnTabInfo) funcTabSize() int {
 	maxFuncOffset := -1
 	maxFuncOffsetIdx := -1
 	for i := range g.numFuncs {
@@ -457,16 +464,16 @@ func (g *GoPCLnTabInfo) findFuncDataSize() int {
 	return maxFuncOffset + g.funcSize + npcdata*4 + nfuncdata*g.fieldSize
 }
 
-func (g *GoPCLnTabInfo) computePCLnTabSize() int {
+func (g *GoPCLnTabInfo) funcTabEndOffset() int {
 	if g.Version < ver116 {
 		return -1
 	}
 
-	funcDataSize := g.findFuncDataSize()
-	if funcDataSize == -1 {
+	funcTabSize := g.funcTabSize()
+	if funcTabSize == -1 {
 		return -1
 	}
-	return alignUp(int(g.Offsets.FuncTabOffset)+funcDataSize, ptrSize)
+	return alignUp(int(g.Offsets.FuncTabOffset)+funcTabSize, ptrSize)
 }
 
 func (g *GoPCLnTabInfo) trimGoFunc(goFuncData []byte, goFuncAddr uint64, runtimeGcbitsSymbolValue libpf.SymbolValue) ([]byte, error) {
@@ -773,7 +780,12 @@ func findGoPCLnTab(ef *pfelf.File, additionalChecks bool) (goPCLnTabInfo *GoPCLn
 		// internal linker which does not merge the .data.rel.ro* sections).
 		//
 		// Starting from Go 1.26, .gopclntab has no more relocation and therefore stays in its own .gopclntab section even with buildmode=pie.
-		goPCLnTabSize := goPCLnTabInfo.computePCLnTabSize()
+		//
+		// funcTabEndOffset() equals the full .gopclntab size only up to Go 1.25, where funcdata lives outside the
+		// gopclntab. From Go 1.26 the funcdata blob is embedded after functab, so this is smaller than the real size.
+		// That regime is handled earlier (goFunc found inside the gopclntab returns before reaching here), so this path
+		// only sees the pre-1.26 layout where the two coincide.
+		goPCLnTabSize := goPCLnTabInfo.funcTabEndOffset()
 		if additionalChecks && goPCLnTabEndKnown {
 			// check that the computed size matches the known size
 			if len(goPCLnTabInfo.Data) != goPCLnTabSize {

--- a/comp/host-profiler/symboluploader/pclntab/pclntab.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab.go
@@ -297,8 +297,8 @@ func findGoFuncEnd(data []byte, version HeaderVersion) int {
 	return findGoFuncEnd120(data)
 }
 
-// findGoFuncInModuleData loops over fields in moduleData (following 8-byte alignment) to find exact goFunc pointer from
-// address range between the end of functab and the end of pclntab
+// findGoFuncInModuleData scans moduleData (8-byte aligned fields) for the exact goFunc pointer, returning the smallest
+// field value in [minGoFunc, maxGoFunc[.
 func findGoFuncInModuleData(moduleData []byte, minGoFunc, maxGoFunc uint64) (uint64, bool) {
 	goFuncVal := maxGoFunc
 	for off := 0; off+ptrSize <= len(moduleData); off += ptrSize {
@@ -330,14 +330,20 @@ func findGoFuncVal(ef *pfelf.File, goPCLnTabInfo *GoPCLnTabInfo, runtimeFirstMod
 
 	if ef.Section(".go.module") != nil {
 		// funcdata (beginning of go:func.*) is now in pclntab, right after functab. it is aligned independently of
-		// functab, so its address is not always pclntab.Address + funcTabEndOffset() and requires us to scan moduleData
+		// functab, so its address is not always pclntab.Address + funcTabEndOffset() and requires to scan moduleData
 		// with the possible address range to determine exact pointer value (https://go.dev/doc/go1.26#compiler)
 		off := goPCLnTabInfo.funcTabEndOffset()
 		if off <= 0 {
 			return 0, errors.New("could not compute functab end offset")
 		}
 		minGoFunc := goPCLnTabInfo.Address + uint64(off)
+		// goFunc sits at most one alignment slot of padding past the functab end. The gopclntab section is at least as
+		// aligned as go:func.*, so its Addralign bounds that padding; if the section can't be found, fall back to the
+		// whole gopclntab extent (its end is Address + len(Data)).
 		maxGoFunc := goPCLnTabInfo.Address + uint64(len(goPCLnTabInfo.Data))
+		if sec := sectionContaining(ef, goPCLnTabInfo.Address); sec != nil {
+			maxGoFunc = minGoFunc + sec.Addralign
+		}
 		if goFuncVal, ok := findGoFuncInModuleData(moduleData, minGoFunc, maxGoFunc); ok {
 			return goFuncVal, nil
 		}

--- a/comp/host-profiler/symboluploader/pclntab/pclntab.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab.go
@@ -297,24 +297,15 @@ func findGoFuncEnd(data []byte, version HeaderVersion) int {
 	return findGoFuncEnd120(data)
 }
 
-// findGoFuncInModuleData scans moduleData (8-byte aligned fields) for the exact goFunc pointer, returning the smallest
-// field value in [minGoFunc, maxGoFunc[.
-func findGoFuncInModuleData(moduleData []byte, minGoFunc, maxGoFunc uint64) (uint64, bool) {
-	goFuncVal := maxGoFunc
-	for off := 0; off+ptrSize <= len(moduleData); off += ptrSize {
-		w := binary.NativeEndian.Uint64(moduleData[off:])
-		if w < minGoFunc || w >= maxGoFunc {
-			continue
-		}
-		// minGoFunc is the smallest pointer value goFunc can be (no alignment padding)
-		if w == minGoFunc {
-			return w, true
-		}
-		if w < goFuncVal {
-			goFuncVal = w
+// findGoFuncInModuleData returns moduledata.gofunc, which sits immediately before
+// moduledata.epclntab (the end of the gopclntab).
+func findGoFuncInModuleData(moduleData []byte, epclntab uint64) (uint64, bool) {
+	for off := ptrSize; off+ptrSize <= len(moduleData); off += ptrSize {
+		if binary.NativeEndian.Uint64(moduleData[off:]) == epclntab {
+			return binary.NativeEndian.Uint64(moduleData[off-ptrSize:]), true
 		}
 	}
-	return goFuncVal, goFuncVal != maxGoFunc
+	return 0, false
 }
 
 func findGoFuncVal(ef *pfelf.File, goPCLnTabInfo *GoPCLnTabInfo, runtimeFirstModuleDataSymbolValue libpf.SymbolValue) (uint64, error) {
@@ -329,22 +320,8 @@ func findGoFuncVal(ef *pfelf.File, goPCLnTabInfo *GoPCLnTabInfo, runtimeFirstMod
 	}
 
 	if ef.Section(".go.module") != nil {
-		// funcdata (beginning of go:func.*) is now in pclntab, right after functab. it is aligned independently of
-		// functab, so its address is not always pclntab.Address + funcTabEndOffset() and requires to scan moduleData
-		// with the possible address range to determine exact pointer value (https://go.dev/doc/go1.26#compiler)
-		off := goPCLnTabInfo.funcTabEndOffset()
-		if off <= 0 {
-			return 0, errors.New("could not compute functab end offset")
-		}
-		minGoFunc := goPCLnTabInfo.Address + uint64(off)
-		// goFunc sits at most one alignment slot of padding past the functab end. The gopclntab section is at least as
-		// aligned as go:func.*, so its Addralign bounds that padding; if the section can't be found, fall back to the
-		// whole gopclntab extent (its end is Address + len(Data)).
-		maxGoFunc := goPCLnTabInfo.Address + uint64(len(goPCLnTabInfo.Data))
-		if sec := sectionContaining(ef, goPCLnTabInfo.Address); sec != nil {
-			maxGoFunc = minGoFunc + sec.Addralign
-		}
-		if goFuncVal, ok := findGoFuncInModuleData(moduleData, minGoFunc, maxGoFunc); ok {
+		epclntab := goPCLnTabInfo.Address + uint64(len(goPCLnTabInfo.Data))
+		if goFuncVal, ok := findGoFuncInModuleData(moduleData, epclntab); ok {
 			return goFuncVal, nil
 		}
 		return 0, errors.New("could not locate gofunc in moduledata")
@@ -812,10 +789,7 @@ func findGoPCLnTab(ef *pfelf.File, additionalChecks bool) (goPCLnTabInfo *GoPCLn
 		//
 		// Starting from Go 1.26, .gopclntab has no more relocation and therefore stays in its own .gopclntab section even with buildmode=pie.
 		//
-		// funcTabEndOffset() equals the full .gopclntab size only up to Go 1.25, where funcdata lives outside the
-		// gopclntab. From Go 1.26 the funcdata blob is embedded after functab, so this is smaller than the real size.
-		// That regime is handled earlier (goFunc found inside the gopclntab returns before reaching here), so this path
-		// only sees the pre-1.26 layout where the two coincide.
+		// funcTabEndOffset() is the full .gopclntab size only pre-1.26 (funcdata external); the 1.26+ path returns earlier.
 		goPCLnTabSize := goPCLnTabInfo.funcTabEndOffset()
 		if additionalChecks && goPCLnTabEndKnown {
 			// check that the computed size matches the known size

--- a/comp/host-profiler/symboluploader/pclntab/pclntab.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab.go
@@ -297,30 +297,55 @@ func findGoFuncEnd(data []byte, version HeaderVersion) int {
 	return findGoFuncEnd120(data)
 }
 
+// findGoFuncInModuleData loops over fields in moduleData (following 8-byte alignment) to find exact goFunc pointer from
+// address range between the end of functab and the end of pclntab
+func findGoFuncInModuleData(moduleData []byte, minGoFunc, maxGoFunc uint64) (uint64, bool) {
+	goFuncVal := maxGoFunc
+	for off := 0; off+ptrSize <= len(moduleData); off += ptrSize {
+		w := binary.NativeEndian.Uint64(moduleData[off:])
+		if w < minGoFunc || w >= maxGoFunc {
+			continue
+		}
+		// minGoFunc is the smallest pointer value goFunc can be (no alignment padding)
+		if w == minGoFunc {
+			return w, true
+		}
+		if w < goFuncVal {
+			goFuncVal = w
+		}
+	}
+	return goFuncVal, goFuncVal != maxGoFunc
+}
+
 func findGoFuncVal(ef *pfelf.File, goPCLnTabInfo *GoPCLnTabInfo, runtimeFirstModuleDataSymbolValue libpf.SymbolValue) (uint64, error) {
 	if goPCLnTabInfo.Version < ver118 {
 		return 0, fmt.Errorf("unsupported pclntab version: %v", goPCLnTabInfo.Version.String())
 	}
 
 	// in go 1.26+, moduledata has its own section
-	if ef.Section(".go.module") != nil {
-		// funcdata (beginning of go:func.*) is now in pclntab, right after functab so goFunc is simply Address +
-		// funcTabEndOffset() (https://go.dev/doc/go1.26#compiler)
-		// this avoids moduledata gofunc offsets for recent versions that can change between releases (e.g. Go 1.27).
-		off := goPCLnTabInfo.funcTabEndOffset()
-		if off <= 0 {
-			return 0, fmt.Errorf("could not compute functab end offset")
-		}
-
-		return goPCLnTabInfo.Address + uint64(off), nil
-	}
-
-	// Before Go 1.26, goFunc is a separate region located via the gofunc pointer in moduledata. Its offset is frozen
-	// for those released versions.
 	moduleData, _, err := FindModuleData(ef, goPCLnTabInfo, runtimeFirstModuleDataSymbolValue)
 	if err != nil {
 		return 0, fmt.Errorf("could not find module data: %w", err)
 	}
+
+	if ef.Section(".go.module") != nil {
+		// funcdata (beginning of go:func.*) is now in pclntab, right after functab. it is aligned independently of
+		// functab, so its address is not always pclntab.Address + funcTabEndOffset() and requires us to scan moduleData
+		// with the possible address range to determine exact pointer value (https://go.dev/doc/go1.26#compiler)
+		off := goPCLnTabInfo.funcTabEndOffset()
+		if off <= 0 {
+			return 0, errors.New("could not compute functab end offset")
+		}
+		minGoFunc := goPCLnTabInfo.Address + uint64(off)
+		maxGoFunc := goPCLnTabInfo.Address + uint64(len(goPCLnTabInfo.Data))
+		if goFuncVal, ok := findGoFuncInModuleData(moduleData, minGoFunc, maxGoFunc); ok {
+			return goFuncVal, nil
+		}
+		return 0, errors.New("could not locate gofunc in moduledata")
+	}
+
+	// Before Go 1.26, goFunc is a separate region located via the gofunc pointer in moduledata. Its offset is frozen
+	// for those released versions.
 	goFuncOff := uint32(40 * ptrSize) // Go 1.20-1.25
 	if goPCLnTabInfo.Version < ver120 {
 		goFuncOff = 38 * ptrSize // Go 1.18-1.19

--- a/comp/host-profiler/symboluploader/pclntab/pclntab_internal_test.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab_internal_test.go
@@ -23,7 +23,7 @@ func moduleDataOf(words ...uint64) []byte {
 
 // TestFindGoFuncInModuleData covers the Go 1.26+ recovery of the real goFunc
 // address from moduledata. goFunc is identified by value: it is the smallest
-// pointer in [minGoFunc, maxGoFunc) = [functab end, gopclntab end). This must
+// pointer in [minGoFunc, maxGoFunc[ = [functab end, gopclntab end[. This must
 // return the exact stored value regardless of any alignment padding the linker
 // inserted between functab and go:func.* (which would make the naive
 // Address+funcTabEndOffset() computation land in the padding instead), and it
@@ -100,5 +100,19 @@ func TestFindGoFuncInModuleData(t *testing.T) {
 				t.Fatalf("gofunc = %#x, want %#x", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestFindGoFuncInModuleDataTightWindow locks the alignment boundary: with an
+// Addralign=16 window, the functab end is ptrSize-aligned, so the largest possible
+// padding is Addralign-ptrSize. goFunc then sits at hi-ptrSize and must still be
+// matched (not skipped by the w >= hi check), while a decoy exactly at hi is excluded.
+func TestFindGoFuncInModuleDataTightWindow(t *testing.T) {
+	const lo = uint64(0x480000)
+	const hi = lo + 16 // Addralign = 16
+
+	got, ok := findGoFuncInModuleData(moduleDataOf(0x400000, lo+8, hi), lo, hi)
+	if !ok || got != lo+8 {
+		t.Fatalf("got (%#x, %v), want (%#x, true)", got, ok, lo+8)
 	}
 }

--- a/comp/host-profiler/symboluploader/pclntab/pclntab_internal_test.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab_internal_test.go
@@ -21,17 +21,10 @@ func moduleDataOf(words ...uint64) []byte {
 	return b
 }
 
-// TestFindGoFuncInModuleData covers the Go 1.26+ recovery of the real goFunc
-// address from moduledata. goFunc is identified by value: it is the smallest
-// pointer in [minGoFunc, maxGoFunc[ = [functab end, gopclntab end[. This must
-// return the exact stored value regardless of any alignment padding the linker
-// inserted between functab and go:func.* (which would make the naive
-// Address+funcTabEndOffset() computation land in the padding instead), and it
-// must not depend on where the gofunc field sits in moduledata.
 func TestFindGoFuncInModuleData(t *testing.T) {
 	const (
-		minGoFunc = uint64(0x480000) // functab end
-		maxGoFunc = uint64(0x4a0000) // gopclntab end (Address + len(Data))
+		gofunc   = uint64(0x480000) // moduledata.gofunc value
+		epclntab = uint64(0x4a0000) // gopclntab end (Address + len(Data))
 	)
 
 	tests := []struct {
@@ -41,46 +34,19 @@ func TestFindGoFuncInModuleData(t *testing.T) {
 		wantOK bool
 	}{
 		{
-			name:   "no padding: gofunc == functab end",
-			module: moduleDataOf(0x400000, 0x401000, minGoFunc, 0x4a0000),
-			want:   minGoFunc,
+			name:   "gofunc immediately precedes epclntab",
+			module: moduleDataOf(0x400000, 0x401000, gofunc, epclntab, 0x111111),
+			want:   gofunc,
 			wantOK: true,
 		},
 		{
-			name: "8-byte alignment padding: gofunc is 8 past functab end",
-			// The naive computation would return minGoFunc (in the padding);
-			// the stored field holds the real value minGoFunc+8.
-			module: moduleDataOf(0x400000, minGoFunc + 8, 0x4a0000),
-			want:   minGoFunc + 8,
-			wantOK: true,
-		},
-		{
-			name: "field position does not matter (gofunc near the end)",
-			module: moduleDataOf(0x400000, 0x401000, 0x402000, 0x403000, minGoFunc + 16),
-			want:   minGoFunc + 16,
-			wantOK: true,
-		},
-		{
-			name: "smallest in-window pointer wins over a farther in-window value",
-			// A larger unrelated pointer also falls in the window; gofunc is the
-			// smaller one (nothing points into the [functab end, gofunc[ padding).
-			module: moduleDataOf(minGoFunc + 200, minGoFunc + 8, 0x4a0000),
-			want:   minGoFunc + 8,
-			wantOK: true,
-		},
-		{
-			name:   "pointer just below the window is ignored",
-			module: moduleDataOf(minGoFunc - ptrSize, 0x4a0000),
+			name:   "no epclntab present",
+			module: moduleDataOf(0x400000, gofunc, 0x111111),
 			wantOK: false,
 		},
 		{
-			name:   "pointer at/after the window end is ignored",
-			module: moduleDataOf(maxGoFunc, maxGoFunc + 0x1000),
-			wantOK: false,
-		},
-		{
-			name:   "no pointer in window",
-			module: moduleDataOf(0x400000, 0x401000, 0x4a0000),
+			name:   "epclntab with no preceding word",
+			module: moduleDataOf(epclntab),
 			wantOK: false,
 		},
 		{
@@ -92,7 +58,7 @@ func TestFindGoFuncInModuleData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := findGoFuncInModuleData(tt.module, minGoFunc, maxGoFunc)
+			got, ok := findGoFuncInModuleData(tt.module, epclntab)
 			if ok != tt.wantOK {
 				t.Fatalf("ok = %v, want %v (got %#x)", ok, tt.wantOK, got)
 			}
@@ -100,19 +66,5 @@ func TestFindGoFuncInModuleData(t *testing.T) {
 				t.Fatalf("gofunc = %#x, want %#x", got, tt.want)
 			}
 		})
-	}
-}
-
-// TestFindGoFuncInModuleDataTightWindow locks the alignment boundary: with an
-// Addralign=16 window, the functab end is ptrSize-aligned, so the largest possible
-// padding is Addralign-ptrSize. goFunc then sits at hi-ptrSize and must still be
-// matched (not skipped by the w >= hi check), while a decoy exactly at hi is excluded.
-func TestFindGoFuncInModuleDataTightWindow(t *testing.T) {
-	const lo = uint64(0x480000)
-	const hi = lo + 16 // Addralign = 16
-
-	got, ok := findGoFuncInModuleData(moduleDataOf(0x400000, lo+8, hi), lo, hi)
-	if !ok || got != lo+8 {
-		t.Fatalf("got (%#x, %v), want (%#x, true)", got, ok, lo+8)
 	}
 }

--- a/comp/host-profiler/symboluploader/pclntab/pclntab_internal_test.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab_internal_test.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package pclntab
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// moduleDataOf builds a fake moduledata from a list of pointer-sized words.
+func moduleDataOf(words ...uint64) []byte {
+	b := make([]byte, len(words)*ptrSize)
+	for i, w := range words {
+		binary.NativeEndian.PutUint64(b[i*ptrSize:], w)
+	}
+	return b
+}
+
+// TestFindGoFuncInModuleData covers the Go 1.26+ recovery of the real goFunc
+// address from moduledata. goFunc is identified by value: it is the smallest
+// pointer in [minGoFunc, maxGoFunc) = [functab end, gopclntab end). This must
+// return the exact stored value regardless of any alignment padding the linker
+// inserted between functab and go:func.* (which would make the naive
+// Address+funcTabEndOffset() computation land in the padding instead), and it
+// must not depend on where the gofunc field sits in moduledata.
+func TestFindGoFuncInModuleData(t *testing.T) {
+	const (
+		minGoFunc = uint64(0x480000) // functab end
+		maxGoFunc = uint64(0x4a0000) // gopclntab end (Address + len(Data))
+	)
+
+	tests := []struct {
+		name   string
+		module []byte
+		want   uint64
+		wantOK bool
+	}{
+		{
+			name:   "no padding: gofunc == functab end",
+			module: moduleDataOf(0x400000, 0x401000, minGoFunc, 0x4a0000),
+			want:   minGoFunc,
+			wantOK: true,
+		},
+		{
+			name: "8-byte alignment padding: gofunc is 8 past functab end",
+			// The naive computation would return minGoFunc (in the padding);
+			// the stored field holds the real value minGoFunc+8.
+			module: moduleDataOf(0x400000, minGoFunc + 8, 0x4a0000),
+			want:   minGoFunc + 8,
+			wantOK: true,
+		},
+		{
+			name: "field position does not matter (gofunc near the end)",
+			module: moduleDataOf(0x400000, 0x401000, 0x402000, 0x403000, minGoFunc + 16),
+			want:   minGoFunc + 16,
+			wantOK: true,
+		},
+		{
+			name: "smallest in-window pointer wins over a farther in-window value",
+			// A larger unrelated pointer also falls in the window; gofunc is the
+			// smaller one (nothing points into the [functab end, gofunc[ padding).
+			module: moduleDataOf(minGoFunc + 200, minGoFunc + 8, 0x4a0000),
+			want:   minGoFunc + 8,
+			wantOK: true,
+		},
+		{
+			name:   "pointer just below the window is ignored",
+			module: moduleDataOf(minGoFunc - ptrSize, 0x4a0000),
+			wantOK: false,
+		},
+		{
+			name:   "pointer at/after the window end is ignored",
+			module: moduleDataOf(maxGoFunc, maxGoFunc + 0x1000),
+			wantOK: false,
+		},
+		{
+			name:   "no pointer in window",
+			module: moduleDataOf(0x400000, 0x401000, 0x4a0000),
+			wantOK: false,
+		},
+		{
+			name:   "empty moduledata",
+			module: nil,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := findGoFuncInModuleData(tt.module, minGoFunc, maxGoFunc)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (got %#x)", ok, tt.wantOK, got)
+			}
+			if ok && got != tt.want {
+				t.Fatalf("gofunc = %#x, want %#x", got, tt.want)
+			}
+		})
+	}
+}

--- a/comp/host-profiler/symboluploader/pclntab/pclntab_test.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab_test.go
@@ -29,6 +29,11 @@ func getGoToolChain(goMinorVersion int) string {
 	if goMinorVersion >= 21 {
 		suffix = ".0"
 	}
+
+	if goMinorVersion == 27 {
+		suffix = "rc1"
+	}
+
 	return fmt.Sprintf("GOTOOLCHAIN=go1.%v%v", goMinorVersion, suffix)
 }
 
@@ -143,7 +148,7 @@ func TestGoPCLnTabExtraction(t *testing.T) {
 	srcFile := "helloworld.go"
 
 	tmpDir := t.TempDir()
-	goMinorVersions := []int{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
+	goMinorVersions := []int{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27}
 	for _, goMinorVersion := range goMinorVersions {
 		for _, pie := range []bool{false, true} {
 			for _, linkexternal := range []bool{false, true} {


### PR DESCRIPTION
### What does this PR do?

We were using different offsets to reach the gofunc pointer from moduledata.
These offsets were differentiated on the pclntab version, which is not is not aligned with changes to the moduledata struct. go1.27rc1 changes that struct without bumping pclntab version.

We now get `epclntab`'s address and walk parts of `moduledata` until hitting the same value, from there we know that `gofunc` is the field before.

### Motivation

fixes goFunc pointer retrieval for `go1.27rc1`

### Describe how you validated your changes

### Additional Notes