### PR TITLE
Remove vestigial gRPC test dependency

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2136,7 +2136,6 @@ core,github.com/outcaste-io/ristretto/z/simd,MIT,"Copyright (c) 2014 Andreas Bri
 core,github.com/outscale/osc-sdk-go/v2,BSD-3-Clause,Copyright (c) Outscale SAS. All rights reserved
 core,github.com/ovh/go-ovh/ovh,BSD-3-Clause,"Copyright (c) 2015-2025, OVH SAS"
 core,github.com/package-url/packageurl-go,MIT,Copyright (c) the purl authors
-core,github.com/pahanini/go-grpc-bidirectional-streaming-example/src/proto,MIT,Copyright (c) 2017 Pavel Tetyaev
 core,github.com/pandatix/go-cvss/30,MIT,Copyright (c) 2022 Lucas TESSON - PandatiX <lucastesson@protonmail.com>
 core,github.com/pandatix/go-cvss/31,MIT,Copyright (c) 2022 Lucas TESSON - PandatiX <lucastesson@protonmail.com>
 core,github.com/pandatix/go-cvss/40,MIT,Copyright (c) 2022 Lucas TESSON - PandatiX <lucastesson@protonmail.com>

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -331,7 +331,6 @@ use_repo(
     "com_github_opencontainers_runtime_spec",
     "com_github_openshift_api",
     "com_github_outcaste_io_ristretto",
-    "com_github_pahanini_go_grpc_bidirectional_streaming_example",
     "com_github_patrickmn_go_cache",
     "com_github_pierrec_lz4_v4",
     "com_github_pkg_sftp",

--- a/go.mod
+++ b/go.mod
@@ -283,7 +283,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.3.0
 	github.com/openshift/api v3.9.0+incompatible
-	github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/pkg/errors v0.9.1 // indirect
@@ -1168,8 +1167,6 @@ require (
 
 // TODO(songy23): remove this once https://github.com/kubernetes/apiserver/commit/b887c9ebecf558a2001fc5c5dbd5c87fd672500c is brought to agent
 replace go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0
-
-replace github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be => github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe
 
 replace github.com/vishvananda/netlink => github.com/DataDog/netlink v1.0.1-0.20240223195320-c7a4f832a3d1
 

--- a/go.sum
+++ b/go.sum
@@ -2557,8 +2557,6 @@ github.com/DataDog/go-acl v1.0.1 h1:uRbp98YmlVZYqNNyTBFNI3Y6bnziBLyCIR4nRu0bIpU=
 github.com/DataDog/go-acl v1.0.1/go.mod h1:YJx333qSb3GUqCLIbqKeGaZS2pUYh2IYGI7+FsX18CU=
 github.com/DataDog/go-cmp v0.0.0-20250605161605-8f326bf2ab9d h1:ErpIQikDqtpE21afk2ExlJn0wg7gGWyUVu/RY4rBlMI=
 github.com/DataDog/go-cmp v0.0.0-20250605161605-8f326bf2ab9d/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=
-github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe/go.mod h1:90sqV0j7E8wYCyqIp5d9HmYWLTFQttqPFFtNYDyAybQ=
 github.com/DataDog/go-libddwaf/v4 v4.10.0 h1:e1kqR5yqqttLRuFXHb8FrrgLfMWTx5LnZICMwQwTDYM=
 github.com/DataDog/go-libddwaf/v4 v4.10.0/go.mod h1:/AZqP6zw3qGJK5mLrA0PkfK3UQDk1zCI2fUNCt4xftE=
 github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20260217080614-b0f4edc38a6d h1:cH9Bm0tJ8FEQbA4FRi0iRm7Zr/5Lata/Or31c+Dth0E=
@@ -6545,7 +6543,6 @@ google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnD
 google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
-google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=

--- a/pkg/network/usm/testutil/grpc/client.go
+++ b/pkg/network/usm/testutil/grpc/client.go
@@ -13,9 +13,9 @@ import (
 	"io"
 	"math/rand"
 	"net"
+	"sync/atomic"
 	"time"
 
-	pbStream "github.com/pahanini/go-grpc-bidirectional-streaming-example/src/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -27,34 +27,39 @@ const (
 	defaultDialTimeout = 5 * time.Second
 )
 
+var nextStreamID atomic.Int32
+
 // HandleUnary performs a gRPC unary call to SayHello RPC of the greeter service.
 func (c *Client) HandleUnary(ctx context.Context, name string) error {
 	_, err := c.greeterClient.SayHello(ctx, &pb.HelloRequest{Name: name}, grpc.MaxCallRecvMsgSize(100*1024*1024), grpc.MaxCallSendMsgSize(100*1024*1024))
 	return err
 }
 
-// HandleStream performs a gRPC stream call to FetchResponse RPC of StreamService service.
+// HandleStream performs a gRPC stream call to RouteChat RPC of RouteGuide service.
 func (c *Client) HandleStream(ctx context.Context, numberOfMessages int32) error {
-	stream, err := c.streamClient.Max(ctx)
+	stream, err := c.routeGuideClient.RouteChat(ctx)
 	if err != nil {
 		return err
 	}
 
 	input := make([]int32, numberOfMessages)
+	pending := make(map[int32]struct{}, numberOfMessages)
 	for i := int32(0); i < numberOfMessages; i++ {
 		// The array is zero based, but we want the values to be 1 based.
-		input[i] = i + 1
+		elem := i + 1
+		input[i] = elem
+		pending[elem] = struct{}{}
 	}
 
 	rand.Shuffle(len(input), func(i, j int) { input[i], input[j] = input[j], input[i] })
 
-	var max int32
+	id := nextStreamID.Add(1) // so unrelated streams don't interfere as RouteChat accumulates notes by point
 	var sendErr error
 	// A go routine to send input requests
 	go func() {
 		defer func() { _ = stream.CloseSend() }()
 		for _, elem := range input {
-			if err := stream.Send(&pbStream.Request{Num: elem}); err != nil {
+			if err := stream.Send(&routeguide.RouteNote{Location: &routeguide.Point{Latitude: elem, Longitude: id}}); err != nil {
 				sendErr = err
 				return
 			}
@@ -62,7 +67,7 @@ func (c *Client) HandleStream(ctx context.Context, numberOfMessages int32) error
 	}()
 
 	var receiveErr error
-	// A go routine to receive the requests and save the max number
+	// A go routine to receive the responses and keep track of those still expected
 	go func() {
 		for {
 			resp, err := stream.Recv()
@@ -73,7 +78,12 @@ func (c *Client) HandleStream(ctx context.Context, numberOfMessages int32) error
 				receiveErr = err
 				return
 			}
-			max = resp.Result
+			elem := resp.Location.Latitude
+			if _, ok := pending[elem]; !ok {
+				receiveErr = fmt.Errorf("received duplicate response %v", resp)
+				return
+			}
+			delete(pending, elem)
 		}
 	}()
 
@@ -86,8 +96,8 @@ func (c *Client) HandleStream(ctx context.Context, numberOfMessages int32) error
 	if receiveErr != nil {
 		return receiveErr
 	}
-	if max != numberOfMessages {
-		return fmt.Errorf("expected to have %d as max, but instead got %d", numberOfMessages, max)
+	if len(pending) != 0 {
+		return fmt.Errorf("expected to receive %d responses, but %d are missing", numberOfMessages, len(pending))
 	}
 	return nil
 }
@@ -135,7 +145,6 @@ func (c *Client) ListFeatures(ctx context.Context, longLo, latLo, longHi, latHi 
 type Client struct {
 	conn             *grpc.ClientConn
 	greeterClient    pb.GreeterClient
-	streamClient     pbStream.MathClient
 	routeGuideClient routeguide.RouteGuideClient
 }
 
@@ -175,7 +184,6 @@ func NewClient(addr string, options Options, withTLS bool) (Client, error) {
 	return Client{
 		conn:             conn,
 		greeterClient:    pb.NewGreeterClient(conn),
-		streamClient:     pbStream.NewMathClient(conn),
 		routeGuideClient: routeguide.NewRouteGuideClient(conn),
 	}, nil
 }

--- a/pkg/network/usm/testutil/grpc/server.go
+++ b/pkg/network/usm/testutil/grpc/server.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	pbStream "github.com/pahanini/go-grpc-bidirectional-streaming-example/src/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -41,46 +40,11 @@ type Server struct {
 
 	pb.UnimplementedGreeterServer
 	routeguide.UnimplementedRouteGuideServer
-	pbStream.UnimplementedMathServer
 }
 
 // SayHello implements helloworld.GreeterServer.
 func (*Server) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
 	return &pb.HelloReply{Message: "Hello " + in.GetName()}, nil
-}
-
-// Max implements MathServer.
-func (*Server) Max(srv pbStream.Math_MaxServer) error {
-	var max int32
-	for {
-		select {
-		case <-srv.Context().Done():
-			return srv.Context().Err()
-		default:
-		}
-
-		// receive data from stream
-		req, err := srv.Recv()
-		if err == io.EOF {
-			// return will close stream from server side
-			return nil
-		}
-		if err != nil {
-			log.Printf("receive error %v", err)
-			continue
-		}
-
-		if req.Num <= max {
-			continue
-		}
-
-		// update max and send it to stream
-		max = req.Num
-		resp := pbStream.Response{Result: max}
-		if err := srv.Send(&resp); err != nil {
-			log.Printf("send error %v", err)
-		}
-	}
 }
 
 // GetFeature returns the feature at the given point.
@@ -269,8 +233,6 @@ func NewServerWithoutBind(opts ...grpc.ServerOption) *Server {
 	server.loadFeatures()
 	pb.RegisterGreeterServer(server.grpcSrv, server)
 	routeguide.RegisterRouteGuideServer(server.grpcSrv, server)
-	pbStream.RegisterMathServer(server.grpcSrv, server)
-
 	return server
 }
 

--- a/pkg/network/usm/usm_grpc_monitor_test.go
+++ b/pkg/network/usm/usm_grpc_monitor_test.go
@@ -240,7 +240,7 @@ func (s *usmGRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]captureRange{
 				{
-					Path:   http.Path{Content: http.Interner.GetString("/protobuf.Math/Max")},
+					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/RouteChat")},
 					Method: http.MethodPost,
 				}: {
 					lower: 25,
@@ -260,7 +260,7 @@ func (s *usmGRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]captureRange{
 				{
-					Path:   http.Path{Content: http.Interner.GetString("/protobuf.Math/Max")},
+					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/RouteChat")},
 					Method: http.MethodPost,
 				}: {
 					lower: 2,


### PR DESCRIPTION
### What does this PR do?
Replace the `/protobuf.Math/Max` bidirectional RPC in `pkg/network/usm/testutil/grpc/` with `/routeguide.RouteGuide/RouteChat`.

Update test path assertions accordingly.

### Motivation
[pahanini/go-grpc-bidirectional-streaming-example](https://github.com/pahanini/go-grpc-bidirectional-streaming-example) is an unmaintained demo repo targeting Go 1.17.1, patched through a 4-year old DataDog fork ([DataDog/go-grpc-bidirectional-streaming-example](https://github.com/DataDog/go-grpc-bidirectional-streaming-example)) meant to insert generated Go stubs.

Carrying that fork as a dependency solely for a test fixture is unnecessary overhead: `routeguide.RouteChat` is the official gRPC [bidirectional streaming example](https://grpc.io/docs/languages/go/basics/#bidirectional-streaming-rpc), bundled with the `google.golang.org/grpc` library already in the dependency graph.

### Describe how you validated your changes
CI.

### Additional Notes
`HandleStream` stays as close as possible to what it was, except it now sends `RouteNote` messages (also with `1`-based elements[^1], but with an explicit stream identifier[^2]), tracks pending responses via a map, and reports any duplicates or missing responses on stream completion.

[^1]: `0` being the default value for integer fields in protobuf messages.

[^2]: Like the removed `Max` server, the `RouteChat` server is process-stateful: the former keeps track of the maximum seen so far, while the latter accumulates notes by location across all streams.
We therefore use a per-process atomic counter to generate unique stream identifiers, ensuring each `HandleStream` has distinct location keys and preventing cross-stream interference that would fail tests.