### PR TITLE
feat(serverless-init): add MicroVM CloudService implementation

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -1,0 +1,255 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cloudservice
+
+import (
+	"context"
+	"maps"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"log"
+
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/lifecycle"
+	serverlessInitLog "github.com/DataDog/datadog-agent/cmd/serverless-init/log"
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	serverlessenv "github.com/DataDog/datadog-agent/pkg/serverless/env"
+	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
+)
+
+const (
+	// MicroVM's resource_type tag value. Its naming convention follows
+	// https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/4784095253/How+we+bill+for+Azure+Google+Serverless
+	MicroVMResourceType = "lambdamicrovm"
+
+	// MicroVMOrigin origin tag value
+	MicroVMOrigin = MicroVMResourceType
+
+	// MicroVM resource_provider tag value
+	MicroVMResourceProvider = "aws"
+
+	// Microvm metric prefix
+	MicroVMPrefix = "aws.lambda.microvm."
+
+	// MicroVm usage metric name suffix
+	MicroVMUsageMetricSuffix = "instance"
+)
+
+// LifecycleContext carries the telemetry dependencies needed by MicroVM.Init to
+// construct and start the lifecycle hook server. Populated by main.go before
+// calling CloudService.Init; nil (and ignored) for all non-MicroVM services.
+type LifecycleContext struct {
+	MetricFlusher  lifecycle.Flusher
+	LogsFlusher    lifecycle.LogsFlusher
+	MetricEmitter  lifecycle.MetricEmitter
+	SampleDrainer  lifecycle.SampleDrainer
+	FlushTimeout   time.Duration
+	SidecarMode    bool
+	LogsTagSetter  lifecycle.LogsTagSetter  // nil-safe; applied via server.SetLogsTagSetter after /run
+	BaseTags       []string                 // startup log tag snapshot passed alongside LogsTagSetter
+	TraceTagSetter lifecycle.TraceTagSetter // nil-safe; applied via server.SetTraceTagSetter after /run
+	BaseTraceTags  map[string]string        // startup trace tag snapshot passed alongside TraceTagSetter
+}
+
+// MicroVM implements CloudService for AWS Lambda MicroVMs.
+type MicroVM struct {
+	server       *lifecycle.Server
+	child        *lifecycle.Child
+	flushTimeout time.Duration
+}
+
+// GetTags returns MicroVM-specific tags parsed from the image ARN env var.
+func (m *MicroVM) GetTags() map[string]string {
+	tags := map[string]string{
+		"origin":            MicroVMOrigin,
+		"_dd.origin":        MicroVMOrigin,
+		"resource_type":     MicroVMResourceType,
+		"resource_provider": MicroVMResourceProvider,
+	}
+
+	arn := os.Getenv(serverlessenv.MicroVMImageARNEnvVar)
+	if arn == "" {
+		tags["region"] = "unknown"
+		tags["account_id"] = "unknown"
+		tags["image_name"] = "unknown"
+		tags["resource_id"] = "unknown"
+		return tags
+	}
+
+	region, accountID, imageName := parseMicroVMARN(arn)
+	tags["region"] = region
+	tags["account_id"] = accountID
+	tags["image_name"] = imageName
+	tags["resource_id"] = arn
+
+	return tags
+}
+
+// GetEnhancedMetricTags returns base (low-cardinality) and usage tags.
+// instance_id is absent from Usage tags at startup because the MicroVM ID is
+// not known until the /run lifecycle hook fires.
+func (m *MicroVM) GetEnhancedMetricTags(tags map[string]string) EnhancedMetricTags {
+	baseTags := map[string]string{
+		"account_id":        tagValueOrUnknown(tags["account_id"]),
+		"image_name":        tagValueOrUnknown(tags["image_name"]),
+		"origin":            tagValueOrUnknown(tags["origin"]),
+		"region":            tagValueOrUnknown(tags["region"]),
+		"resource_type":     tagValueOrUnknown(tags["resource_type"]),
+		"resource_provider": tagValueOrUnknown(tags["resource_provider"]),
+		"resource_id":       tagValueOrUnknown(tags["resource_id"]),
+	}
+	return EnhancedMetricTags{Base: baseTags, Usage: maps.Clone(baseTags)}
+}
+
+// GetDefaultLogsSource returns the default logs source.
+func (m *MicroVM) GetDefaultLogsSource() string { return MicroVMOrigin }
+
+// GetMetricPrefix returns the AWS MicroVM metric prefix.
+func (m *MicroVM) GetMetricPrefix() string { return MicroVMPrefix }
+
+// GetUsageMetricSuffix returns the usage metric suffix.
+func (m *MicroVM) GetUsageMetricSuffix() string { return MicroVMUsageMetricSuffix }
+
+// GetOrigin returns the origin tag value.
+func (m *MicroVM) GetOrigin() string { return MicroVMOrigin }
+
+// GetSource returns the metrics source.
+func (m *MicroVM) GetSource() metrics.MetricSource {
+	return metrics.MetricSourceAWSMicroVMEnhanced
+}
+
+// isSupportedArch reports whether arch is supported by MicroVM.
+// MicroVM supports both amd64 and arm64; all other cloud services are amd64-only.
+func isSupportedArch(arch string) bool {
+	return arch == archAMD64 || arch == archARM64
+}
+
+// Init starts the MicroVM lifecycle hook server.
+func (m *MicroVM) Init(ctx *TracingContext) error {
+	if arch := runtime.GOARCH; !isSupportedArch(arch) {
+		log.Fatalf(unsupportedArchMsg, arch)
+	}
+	if ctx == nil || ctx.LifecycleCtx == nil {
+		return nil
+	}
+	lc := ctx.LifecycleCtx
+	m.flushTimeout = lc.FlushTimeout
+
+	components, err := lifecycle.SetupFromEnv(lc.SidecarMode)
+	if err != nil {
+		log.Printf("Invalid lifecycle env-var config (%v); starting with defaults", err)
+		components = lifecycle.SetupFallback(lc.SidecarMode)
+	}
+	m.child = components.Child
+
+	arn := os.Getenv(serverlessenv.MicroVMImageARNEnvVar)
+	if arn == "" {
+		arn = "unknown"
+	}
+	heartbeat := lifecycle.NewHeartbeat(
+		lifecycle.DefaultHeartbeatInterval,
+		lc.MetricEmitter,
+		m.GetSource(),
+		[]string{"microvm_image_arn:" + arn},
+	)
+	m.server = lifecycle.NewServer(
+		components.Port,
+		lc.MetricFlusher,
+		ctx.TraceAgent, // satisfies lifecycle.Flusher via TraceAgent.Flush()
+		lc.LogsFlusher,
+		lc.MetricEmitter,
+		lc.SampleDrainer,
+		m.GetSource(),
+		lc.FlushTimeout,
+		components.Handle,
+		components.Forwarder,
+		heartbeat,
+	)
+	if lc.LogsTagSetter != nil {
+		m.server.SetLogsTagSetter(lc.LogsTagSetter, lc.BaseTags)
+	}
+	if lc.TraceTagSetter != nil {
+		m.server.SetTraceTagSetter(lc.TraceTagSetter, lc.BaseTraceTags)
+	}
+	l, err := m.server.Listen()
+	if err != nil {
+		log.Fatalf("MicroVM lifecycle server failed to bind: %v", err)
+	}
+	go m.server.Serve(l)
+	return nil
+}
+
+// Child returns the *lifecycle.Child that mode.RunInit uses for /ready
+// alive-checking. Nil in sidecar mode or when Init has not been called.
+func (m *MicroVM) Child() *lifecycle.Child { return m.child }
+
+// Run spawns the user process in init-container mode. ProcessHooks bind
+// m.child.MarkAlive/MarkDead so the lifecycle server's /ready alive-check
+// reflects the user app's state without exposing *lifecycle.Child to the
+// mode package. MicroVM is exclusively an init-container deployment; sidecar
+// mode is a wiring error and is treated as fatal.
+func (m *MicroVM) Run(modeConf mode.Conf, logConfig *serverlessInitLog.Config) error {
+	if modeConf.SidecarMode {
+		log.Fatalf("MicroVM does not support sidecar mode")
+	}
+	return mode.RunInit(logConfig, &mode.ProcessHooks{
+		OnAlive: m.child.MarkAlive,
+		OnDead:  m.child.MarkDead,
+	})
+}
+
+// Shutdown stops the MicroVM lifecycle hook server so that any in-flight
+// /suspend or /terminate request can complete before the metric and trace
+// agents are torn down.
+func (m *MicroVM) Shutdown(_ serverlessMetrics.ServerlessMetricAgent, _ bool, _ error) {
+	if m.server == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), m.flushTimeout)
+	defer cancel()
+	if err := m.server.Stop(ctx); err != nil {
+		log.Printf("MicroVM lifecycle server shutdown error: %v", err)
+	}
+}
+
+// AddStartMetric is a no-op for MicroVM. The lifecycle server emits the run
+// metric when the /run hook fires; emitting it here would double-count.
+func (m *MicroVM) AddStartMetric(_ *serverlessMetrics.ServerlessMetricAgent) {}
+
+// ShouldForceFlushAllOnForceFlushToSerializer returns false for MicroVM.
+func (m *MicroVM) ShouldForceFlushAllOnForceFlushToSerializer() bool { return false }
+
+// isMicroVM returns true when running inside an AWS Lambda MicroVM.
+func isMicroVM() bool {
+	_, exists := os.LookupEnv(serverlessenv.MicroVMImageARNEnvVar)
+	return exists
+}
+
+// parseMicroVMARN extracts region, accountID, and imageName from an ARN of the
+// form arn:aws:lambda:<region>:<account>:microvm-image:<name>.
+// Returns "unknown" for any field that cannot be parsed.
+func parseMicroVMARN(arn string) (region, accountID, imageName string) {
+	parts := strings.Split(arn, ":")
+	region = "unknown"
+	accountID = "unknown"
+	imageName = "unknown"
+	// ARN format: arn:aws:lambda:region:account:microvm-image:name
+	if len(parts) >= 5 {
+		if parts[3] != "" {
+			region = parts[3]
+		}
+		if parts[4] != "" {
+			accountID = parts[4]
+		}
+	}
+	if len(parts) >= 7 && parts[6] != "" {
+		imageName = strings.Join(parts[6:], ":")
+	}
+	return region, accountID, imageName
+}

--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -24,8 +24,7 @@ import (
 )
 
 const (
-	// MicroVM's resource_type tag value. Its naming convention follows
-	// https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/4784095253/How+we+bill+for+Azure+Google+Serverless
+	// MicroVM's resource_type tag value
 	MicroVMResourceType = "lambdamicrovm"
 
 	// MicroVMOrigin origin tag value

--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -1,0 +1,464 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cloudservice
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/lifecycle"
+	serverlessInitLog "github.com/DataDog/datadog-agent/cmd/serverless-init/log"
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
+	serverlessenv "github.com/DataDog/datadog-agent/pkg/serverless/env"
+	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
+	"github.com/DataDog/datadog-agent/pkg/trace/api"
+)
+
+// Compile-time guards: the concrete types passed via LifecycleContext must
+// satisfy the lifecycle interfaces.  Failures here mean Init() would panic at
+// runtime when the lifecycle server calls the missing methods.
+var _ lifecycle.Flusher = (*serverlessMetrics.ServerlessMetricAgent)(nil)
+var _ lifecycle.SampleDrainer = (*serverlessMetrics.ServerlessMetricAgent)(nil)
+var _ lifecycle.MetricEmitter = (*serverlessMetrics.ServerlessMetricAgent)(nil)
+
+// freeLifecyclePort returns an OS-assigned free TCP port as a string, for tests
+// that exercise MicroVM.Init through the real DD_AWS_MICROVM_LIFECYCLE_PORT env
+// var (which rejects "0" as out of range) without colliding with the real
+// port 9000 or other tests in this package.
+func freeLifecyclePort(t *testing.T) string {
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return strconv.Itoa(port)
+}
+
+// noopTraceAgent is a local stub that satisfies the TraceAgent interface
+// without importing pkg/serverless/trace (which imports cloudservice, creating
+// a cycle).
+type noopTraceAgent struct{}
+
+func (n *noopTraceAgent) Process(_ *api.Payload) {}
+func (n *noopTraceAgent) Flush()                 {}
+func (n *noopTraceAgent) Stop()                  {}
+
+const testImageARN = "arn:aws:lambda:us-east-1:123456789012:microvm-image:my-image"
+
+func TestIsMicroVM(t *testing.T) {
+	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, testImageARN)
+	assert.True(t, isMicroVM())
+}
+
+func TestIsMicroVMNotSet(t *testing.T) {
+	assert.False(t, isMicroVM())
+}
+
+func TestMicroVMGetTags(t *testing.T) {
+	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, testImageARN)
+	m := &MicroVM{}
+	tags := m.GetTags()
+
+	assert.Equal(t, "us-east-1", tags["region"])
+	assert.Equal(t, "123456789012", tags["account_id"])
+	assert.Equal(t, "my-image", tags["image_name"])
+	assert.Equal(t, MicroVMOrigin, tags["origin"])
+	assert.Equal(t, MicroVMOrigin, tags["_dd.origin"])
+	assert.Equal(t, MicroVMResourceType, tags["resource_type"])
+	assert.Equal(t, "aws", tags["resource_provider"])
+	assert.Equal(t, testImageARN, tags["resource_id"])
+	assert.NotContains(t, tags, "microvm_image_arn")
+}
+
+func TestMicroVMGetTagsMissingARN(t *testing.T) {
+	m := &MicroVM{}
+	tags := m.GetTags()
+	assert.Equal(t, "unknown", tags["region"])
+	assert.Equal(t, "unknown", tags["account_id"])
+	assert.Equal(t, "unknown", tags["image_name"])
+	assert.Equal(t, "unknown", tags["resource_id"])
+	assert.Equal(t, MicroVMResourceType, tags["resource_type"])
+	assert.Equal(t, "aws", tags["resource_provider"])
+}
+
+func TestMicroVMGetEnhancedMetricTags(t *testing.T) {
+	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, testImageARN)
+	m := &MicroVM{}
+	cloudTags := m.GetTags()
+	result := m.GetEnhancedMetricTags(cloudTags)
+
+	assert.Equal(t, "us-east-1", result.Base["region"])
+	assert.Equal(t, "123456789012", result.Base["account_id"])
+	assert.Equal(t, "my-image", result.Base["image_name"])
+	assert.Equal(t, MicroVMResourceType, result.Base["resource_type"])
+	assert.Equal(t, "aws", result.Base["resource_provider"])
+	assert.Equal(t, testImageARN, result.Base["resource_id"])
+	assert.NotContains(t, result.Base, "instance_id", "Base must not carry the high-cardinality instance_id")
+
+	assert.Equal(t, result.Base["region"], result.Usage["region"])
+	assert.Equal(t, result.Base["account_id"], result.Usage["account_id"])
+	assert.Equal(t, result.Base["resource_type"], result.Usage["resource_type"])
+	assert.Equal(t, result.Base["resource_provider"], result.Usage["resource_provider"])
+	assert.Equal(t, result.Base["resource_id"], result.Usage["resource_id"])
+	assert.NotContains(t, result.Usage, "instance_id", "instance_id is absent until SetInstanceID is called from /launch")
+}
+
+func TestMicroVMGetEnhancedMetricTagsMissingARN(t *testing.T) {
+	m := &MicroVM{}
+	cloudTags := m.GetTags() // ARN not set → all "unknown"
+	result := m.GetEnhancedMetricTags(cloudTags)
+
+	assert.Equal(t, "unknown", result.Base["region"])
+	assert.Equal(t, "unknown", result.Base["account_id"])
+	assert.Equal(t, "unknown", result.Base["resource_id"])
+	assert.Equal(t, MicroVMResourceType, result.Base["resource_type"])
+	assert.Equal(t, "aws", result.Base["resource_provider"])
+	assert.Equal(t, result.Base["resource_id"], result.Usage["resource_id"])
+}
+
+// Compile-time guard: *MicroVM must satisfy the CloudService interface,
+// including the new Run method.
+var _ CloudService = (*MicroVM)(nil)
+
+// TestMicroVM_Run_InitMode_ThreadsChildLiveness verifies that MicroVM.Run in
+// init-container mode threads m.child into RunInit so the lifecycle server's
+// /ready alive-check reflects the user app's actual state.
+func TestMicroVM_Run_InitMode_ThreadsChildLiveness(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("serverless-init is not supported on windows")
+	}
+	if testing.Short() {
+		t.Skip("spawns a subprocess")
+	}
+	saved := os.Args
+	defer func() { os.Args = saved }()
+	os.Args = []string{"datadog-init", "sh", "-c", "sleep 0.3"}
+
+	child := lifecycle.NewChild()
+	m := &MicroVM{child: child}
+
+	// Poll for the alive transition instead of sleeping a fixed delay: a
+	// single sample after a guessed delay can land before cmd.Start has
+	// invoked MarkAlive, or after the short-lived subprocess has already
+	// exited, on a loaded host. Polling records the alive state the instant
+	// it appears, so the race window is eliminated regardless of host load.
+	var midRunAlive atomic.Bool
+	probeDone := make(chan struct{})
+	go func() {
+		defer close(probeDone)
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if child.IsAlive() {
+				midRunAlive.Store(true)
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	err := m.Run(mode.Conf{SidecarMode: false}, &serverlessInitLog.Config{})
+	<-probeDone
+
+	require.NoError(t, err)
+	assert.True(t, midRunAlive.Load(), "child must be alive while Run is blocked on the subprocess")
+	assert.False(t, child.IsAlive(), "child must be dead after Run returns")
+}
+
+func TestParseMicroVMARNWithColonInName(t *testing.T) {
+	region, accountID, imageName := parseMicroVMARN("arn:aws:lambda:eu-west-1:999:microvm-image:my:image:v2")
+	assert.Equal(t, "eu-west-1", region)
+	assert.Equal(t, "999", accountID)
+	assert.Equal(t, "my:image:v2", imageName)
+}
+
+func TestMicroVMOrigin(t *testing.T) {
+	assert.Equal(t, MicroVMOrigin, (&MicroVM{}).GetOrigin())
+}
+
+func TestMicroVMMetricPrefix(t *testing.T) {
+	assert.Equal(t, MicroVMPrefix, (&MicroVM{}).GetMetricPrefix())
+}
+
+// TestLifecycleContext_NilLogsTagSetter_IsAccepted verifies that
+// LifecycleContext.LogsTagSetter is nil-safe: passing nil must not cause any
+// compile or runtime issue. This pins the nil-check added to MicroVM.Init so
+// callers that don't need log-tag forwarding are not required to supply a setter.
+func TestLifecycleContext_NilLogsTagSetter_IsAccepted(t *testing.T) {
+	lc := &LifecycleContext{LogsTagSetter: nil, BaseTags: nil}
+	assert.Nil(t, lc.LogsTagSetter, "nil LogsTagSetter must be accepted by LifecycleContext")
+}
+
+// TestMicroVM_LogsTagSetter_InvokedOnLaunch verifies the behaviour that
+// MicroVM.Init wires when LogsTagSetter is non-nil: SetLogsTagSetter is called
+// on the server, and the server then invokes the setter on /launch with the
+// base tags plus the microvm_id from the request body.
+//
+// The test constructs the server directly with port 0 (random free port) to
+// avoid the log.Fatalf that Init emits when port 9000 is already bound.
+func TestMicroVM_LogsTagSetter_InvokedOnLaunch(t *testing.T) {
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+
+	var mu sync.Mutex
+	var receivedTags []string
+	setter := lifecycle.LogsTagSetterFunc(func(tags []string) {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedTags = tags
+	})
+	baseTags := []string{"env:test", "service:myapp"}
+
+	// Construct the server directly with port 0 — same path Init takes, minus
+	// the port-9000 binding that would log.Fatalf in a shared test environment.
+	srv := lifecycle.NewServer(
+		0, // random free port
+		metricAgent, &noopTraceAgent{}, &noopLogsFlusher{},
+		metricAgent, metricAgent,
+		(&MicroVM{}).GetSource(),
+		time.Second,
+		lifecycle.NewNoopChildHandle(),
+		nil, // no forwarder
+		nil, // no heartbeat
+	)
+	// This is the call Init makes when lc.LogsTagSetter != nil.
+	srv.SetLogsTagSetter(setter, baseTags)
+
+	l, err := srv.Listen()
+	require.NoError(t, err)
+	go srv.Serve(l)
+	t.Cleanup(func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Stop(shutCtx)
+	})
+
+	launchPath := "/aws/lambda-microvms/runtime/v1/run"
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
+	resp, err := http.Post("http://"+l.Addr().String()+launchPath, "application/json", body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	mu.Lock()
+	got := receivedTags
+	mu.Unlock()
+
+	assert.Contains(t, got, "env:test", "base tags must be forwarded to LogsTagSetter on /launch")
+	assert.Contains(t, got, "service:myapp", "base tags must be forwarded to LogsTagSetter on /launch")
+	assert.Contains(t, got, "lambda_microvm_id:vm-abc123", "microvm_id from /launch body must be appended to tags")
+}
+
+// TestLifecycleContext_NilTraceTagSetter_IsAccepted verifies that
+// LifecycleContext.TraceTagSetter is nil-safe: passing nil must not cause any
+// compile or runtime issue. Mirrors TestLifecycleContext_NilLogsTagSetter_IsAccepted.
+func TestLifecycleContext_NilTraceTagSetter_IsAccepted(t *testing.T) {
+	lc := &LifecycleContext{TraceTagSetter: nil, BaseTraceTags: nil}
+	assert.Nil(t, lc.TraceTagSetter, "nil TraceTagSetter must be accepted by LifecycleContext")
+}
+
+// TestMicroVM_TraceTagSetter_InvokedOnLaunch verifies the end-to-end wiring of
+// TraceTagSetter: MicroVM.Init passes it to the server, and the server calls it
+// on /launch with base trace tags extended by lambda_microvm_id from the body.
+//
+// Mirrors TestMicroVM_LogsTagSetter_InvokedOnLaunch.
+func TestMicroVM_TraceTagSetter_InvokedOnLaunch(t *testing.T) {
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+
+	var mu sync.Mutex
+	var receivedTags map[string]string
+	setter := lifecycle.TraceTagSetterFunc(func(tags map[string]string) {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedTags = tags
+	})
+	baseTraceTags := map[string]string{"env": "test", "service": "myapp"}
+
+	srv := lifecycle.NewServer(
+		0,
+		metricAgent, &noopTraceAgent{}, &noopLogsFlusher{},
+		metricAgent, metricAgent,
+		(&MicroVM{}).GetSource(),
+		time.Second,
+		lifecycle.NewNoopChildHandle(),
+		nil, // no forwarder
+		nil, // no heartbeat
+	)
+	// This is the call Init makes when lc.TraceTagSetter != nil.
+	srv.SetTraceTagSetter(setter, baseTraceTags)
+
+	l, err := srv.Listen()
+	require.NoError(t, err)
+	go srv.Serve(l)
+	t.Cleanup(func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Stop(shutCtx)
+	})
+
+	launchPath := "/aws/lambda-microvms/runtime/v1/run"
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
+	resp, err := http.Post("http://"+l.Addr().String()+launchPath, "application/json", body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	mu.Lock()
+	got := receivedTags
+	mu.Unlock()
+
+	assert.Equal(t, "test", got["env"], "base trace tags must be forwarded to TraceTagSetter on /launch")
+	assert.Equal(t, "myapp", got["service"], "base trace tags must be forwarded to TraceTagSetter on /launch")
+	assert.Equal(t, "vm-abc123", got["lambda_microvm_id"], "microvm_id from /launch body must appear in trace tags")
+}
+
+func TestMicroVMInit_NilTracingCtx_DoesNotStartServer(t *testing.T) {
+	m := &MicroVM{}
+	err := m.Init(nil)
+	require.NoError(t, err)
+	assert.Nil(t, m.server, "Init with nil TracingContext must not start a lifecycle server")
+}
+
+func TestMicroVMInit_NilLifecycleCtx_DoesNotStartServer(t *testing.T) {
+	m := &MicroVM{}
+	err := m.Init(&TracingContext{TraceAgent: &noopTraceAgent{}})
+	require.NoError(t, err)
+	assert.Nil(t, m.server, "Init without LifecycleCtx must not start a lifecycle server")
+}
+
+func TestMicroVMInit_WithLifecycleCtx_ServerIsConstructed(t *testing.T) {
+	t.Setenv(lifecycle.LifecyclePortEnvVar, freeLifecyclePort(t)) // avoid colliding with the real port 9000
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+	m := &MicroVM{}
+	ctx := &TracingContext{
+		TraceAgent: &noopTraceAgent{},
+		LifecycleCtx: &LifecycleContext{
+			MetricFlusher: metricAgent,
+			LogsFlusher:   &noopLogsFlusher{},
+			MetricEmitter: metricAgent,
+			SampleDrainer: metricAgent,
+			FlushTimeout:  time.Second,
+		},
+	}
+	err := m.Init(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { m.Shutdown(*metricAgent, false, nil) })
+}
+
+func TestMicroVMShutdown_NilServer_NoPanic(t *testing.T) {
+	m := &MicroVM{}
+	assert.NotPanics(t, func() { m.Shutdown(serverlessMetrics.ServerlessMetricAgent{}, false, nil) })
+}
+
+// TestMicroVMShutdown_LiveServer uses port 0 (random) to avoid colliding with
+// port 9000, and sets m.server directly (same-package access) to bypass Init's
+// hardcoded DefaultPort.
+func TestMicroVMShutdown_LiveServer_StopsCleanly(t *testing.T) {
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+	srv := lifecycle.NewServer(
+		0, // random free port
+		metricAgent, &noopTraceAgent{}, &noopLogsFlusher{},
+		metricAgent, metricAgent,
+		(&MicroVM{}).GetSource(),
+		time.Second,
+		lifecycle.NewNoopChildHandle(),
+		nil, // no forwarder
+		nil, // no heartbeat
+	)
+	l, err := srv.Listen()
+	require.NoError(t, err)
+	go srv.Serve(l)
+
+	m := &MicroVM{server: srv, flushTimeout: time.Second}
+	assert.NotPanics(t, func() { m.Shutdown(serverlessMetrics.ServerlessMetricAgent{}, false, nil) })
+}
+
+func TestMicroVMInit_NonMicroVMServicesIgnoreLifecycleCtx(t *testing.T) {
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+	lc := &LifecycleContext{
+		MetricFlusher: metricAgent,
+		LogsFlusher:   &noopLogsFlusher{},
+		MetricEmitter: metricAgent,
+		SampleDrainer: metricAgent,
+		FlushTimeout:  time.Second,
+	}
+	ctx := &TracingContext{TraceAgent: &noopTraceAgent{}, LifecycleCtx: lc}
+
+	for _, svc := range []CloudService{&LocalService{}, &AppService{}} {
+		assert.NotPanics(t, func() { _ = svc.Init(ctx) },
+			"%T.Init must not panic when passed a LifecycleCtx", svc)
+	}
+}
+
+// TestMicroVMInit_SidecarMode_ServerStartedChildNil verifies that sidecar mode
+// starts the lifecycle server (for /ready 503s) but returns a nil Child — the
+// noop ChildHandle reports not-alive, surfacing 503 rather than papering over a
+// sidecar+MicroVM misconfiguration.
+func TestMicroVMInit_SidecarMode_ServerStartedChildNil(t *testing.T) {
+	t.Setenv(lifecycle.LifecyclePortEnvVar, freeLifecyclePort(t)) // avoid colliding with the real port 9000
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+	m := &MicroVM{}
+	ctx := &TracingContext{
+		TraceAgent: &noopTraceAgent{},
+		LifecycleCtx: &LifecycleContext{
+			MetricFlusher: metricAgent,
+			LogsFlusher:   &noopLogsFlusher{},
+			MetricEmitter: metricAgent,
+			SampleDrainer: metricAgent,
+			FlushTimeout:  time.Second,
+			SidecarMode:   true,
+		},
+	}
+	err := m.Init(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { m.Shutdown(*metricAgent, false, nil) })
+	assert.Nil(t, m.Child(), "sidecar mode must not expose a Child — no user process to track")
+}
+
+// TestMicroVMInit_InitMode_ExposesChild verifies that init-container mode (non-sidecar)
+// exposes a non-nil Child after Init so that RunInit can MarkAlive/MarkDead it.
+func TestMicroVMInit_InitMode_ExposesChild(t *testing.T) {
+	t.Setenv(lifecycle.LifecyclePortEnvVar, freeLifecyclePort(t)) // avoid colliding with the real port 9000
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+	m := &MicroVM{}
+	ctx := &TracingContext{
+		TraceAgent: &noopTraceAgent{},
+		LifecycleCtx: &LifecycleContext{
+			MetricFlusher: metricAgent,
+			LogsFlusher:   &noopLogsFlusher{},
+			MetricEmitter: metricAgent,
+			SampleDrainer: metricAgent,
+			FlushTimeout:  time.Second,
+			SidecarMode:   false,
+		},
+	}
+	err := m.Init(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { m.Shutdown(*metricAgent, false, nil) })
+	assert.NotNil(t, m.Child(), "init-container mode must expose a Child for RunInit to alive-check")
+}
+
+type noopLogsFlusher struct{}
+
+func (n *noopLogsFlusher) Flush(_ context.Context) {}
+
+// TestIsSupportedArch pins the MicroVM arch allowlist — lives here because
+// isSupportedArch is defined in microvm.go.
+func TestIsSupportedArch(t *testing.T) {
+	for _, arch := range []string{archAMD64, archARM64} {
+		assert.True(t, isSupportedArch(arch), "%s must be supported for MicroVM", arch)
+	}
+	for _, arch := range []string{"386", "mips", "mips64", "riscv64", "s390x", ""} {
+		assert.False(t, isSupportedArch(arch), "%s must be unsupported", arch)
+	}
+}

--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -138,9 +137,6 @@ var _ CloudService = (*MicroVM)(nil)
 // init-container mode threads m.child into RunInit so the lifecycle server's
 // /ready alive-check reflects the user app's actual state.
 func TestMicroVM_Run_InitMode_ThreadsChildLiveness(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("serverless-init is not supported on windows")
-	}
 	if testing.Short() {
 		t.Skip("spawns a subprocess")
 	}
@@ -151,23 +147,12 @@ func TestMicroVM_Run_InitMode_ThreadsChildLiveness(t *testing.T) {
 	child := lifecycle.NewChild()
 	m := &MicroVM{child: child}
 
-	// Poll for the alive transition instead of sleeping a fixed delay: a
-	// single sample after a guessed delay can land before cmd.Start has
-	// invoked MarkAlive, or after the short-lived subprocess has already
-	// exited, on a loaded host. Polling records the alive state the instant
-	// it appears, so the race window is eliminated regardless of host load.
 	var midRunAlive atomic.Bool
 	probeDone := make(chan struct{})
 	go func() {
 		defer close(probeDone)
-		deadline := time.Now().Add(2 * time.Second)
-		for time.Now().Before(deadline) {
-			if child.IsAlive() {
-				midRunAlive.Store(true)
-				return
-			}
-			time.Sleep(time.Millisecond)
-		}
+		time.Sleep(100 * time.Millisecond)
+		midRunAlive.Store(child.IsAlive())
 	}()
 
 	err := m.Run(mode.Conf{SidecarMode: false}, &serverlessInitLog.Config{})

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -28,9 +28,13 @@ type TraceAgent interface {
 
 // TracingContext holds dependencies passed to CloudService.Init.
 // TraceAgent and SpanTags are used by CloudRunJobs for span creation.
+// LifecycleCtx is populated by main.go for MicroVM environments so that
+// MicroVM.Init can construct and start the lifecycle hook server; it is nil
+// for all other cloud services and ignored by their Init implementations.
 type TracingContext struct {
-	TraceAgent TraceAgent
-	SpanTags   map[string]string
+	TraceAgent   TraceAgent
+	SpanTags     map[string]string
+	LifecycleCtx *LifecycleContext
 }
 
 // EnhancedMetricTags holds base tags and high-cardinality tags for enhanced metrics.

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -214,6 +214,10 @@ func (l *LocalService) ShouldForceFlushAllOnForceFlushToSerializer() bool {
 func GetCloudServiceType() CloudService {
 	arch := runtime.GOARCH
 
+	if isMicroVM() {
+		return &MicroVM{}
+	}
+
 	if arch != archAMD64 {
 		log.Errorf(unsupportedArchMsg, arch)
 	}

--- a/cmd/serverless-init/cloudservice/service_test.go
+++ b/cmd/serverless-init/cloudservice/service_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	serverlessenv "github.com/DataDog/datadog-agent/pkg/serverless/env"
 )
 
 func TestGetCloudServiceType(t *testing.T) {
@@ -35,4 +37,21 @@ func TestGetCloudServiceTypeForCloudRunJob(t *testing.T) {
 	// Verify it's the correct type
 	_, ok := cloudService.(*CloudRunJobs)
 	assert.True(t, ok)
+}
+
+func TestGetCloudServiceTypeMicroVM(t *testing.T) {
+	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, "arn:aws:lambda:us-east-1:123456789012:microvm-image:my-image")
+	svc := GetCloudServiceType()
+	_, ok := svc.(*MicroVM)
+	assert.True(t, ok, "expected MicroVM CloudService")
+}
+
+func TestGetCloudServiceTypeMicroVMTakesPriorityOverCloudRun(t *testing.T) {
+	// MicroVM is checked first — both would never be set in practice,
+	// but the ordering must be explicit.
+	t.Setenv(ServiceNameEnvVar, "my-service")
+	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, "arn:aws:lambda:us-east-1:123456789012:microvm-image:my-image")
+	svc := GetCloudServiceType()
+	_, ok := svc.(*MicroVM)
+	assert.True(t, ok, "MicroVM should take priority over CloudRun")
 }

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -223,14 +223,13 @@ func NewServer(
 		s.child = c
 	}
 	// WriteTimeout must cover the full handler wall-clock for every path:
-	//   - No forwarder: flushTimeout (flush budget)
+	//   - No forwarder: flushTimeout (flush budget + write headroom)
 	//   - /run, /resume, /suspend, /terminate: forwardTimeout (default 1s)
 	//   - /ready: readyTimeout (default 60s, matching platform /ready timeout)
 	//   - /validate: validateTimeout (default 60s, matching platform /validate timeout)
-	// plus writeTimeoutHeadroom (heartbeat.Stop() before /suspend and
-	// /terminate, and the final mirrored-response write). Use the largest of
-	// all applicable budgets so the HTTP server does not close the
-	// platform-facing connection before the handler writes the response.
+	// Use the largest of all applicable budgets so the HTTP server does not
+	// close the platform-facing connection before the handler writes the
+	// mirrored response.
 	maxTimeout := s.flushTimeout
 	if s.fwd != nil {
 		// /terminate uses flushSequential: flush runs after the forward, so its
@@ -427,7 +426,12 @@ func (s *Server) flushAll(flushCtx context.Context) {
 	flushDone := make(chan struct{}, flushWorkerCount)
 	go func() { s.metricFlusher.Flush(); flushDone <- struct{}{} }()
 	go func() { s.traceFlusher.Flush(); flushDone <- struct{}{} }()
-	go func() { s.logsFlusher.Flush(flushCtx); flushDone <- struct{}{} }()
+	go func() {
+		if s.logsFlusher != nil {
+			s.logsFlusher.Flush(flushCtx)
+		}
+		flushDone <- struct{}{}
+	}()
 	s.waitForFlushes(flushCtx, flushDone)
 }
 

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -1034,6 +1034,32 @@ func TestFlushAllDrainTimeoutDoesNotBlock(t *testing.T) {
 	assert.Less(t, time.Since(start), 500*time.Millisecond, "flushAll must return within flushTimeout even when drainer blocks")
 }
 
+// TestFlushAllNilLogsFlusherDoesNotPanic verifies that flushAll tolerates a nil
+// logsFlusher without panicking, and still flushes the metric and trace
+// flushers promptly. Production setup() can pass a nil logsFlusher into the
+// LifecycleContext when the logs agent failed to start (SetupLogAgent
+// returns nil on error), so MicroVM's /suspend and /terminate handshake must
+// not crash on that value. A nil-interface method call in the flushAll
+// goroutine wouldn't be caught by assert.NotPanics (it panics in a different
+// goroutine), so this also asserts flushAll returns promptly via the normal
+// "all workers done" path rather than falling back to the flushTimeout path,
+// which is what happens when the logs-flush goroutine never signals
+// completion.
+func TestFlushAllNilLogsFlusherDoesNotPanic(t *testing.T) {
+	metric := &mockFlusher{}
+	trace := &mockFlusher{}
+	drainer := &mockSampleDrainer{}
+	srv := NewServer(0, metric, trace, nil, &mockMetricEmitter{}, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
+	defer cancel()
+	start := time.Now()
+	assert.NotPanics(t, func() { srv.flushAll(ctx) })
+	assert.Less(t, time.Since(start), 500*time.Millisecond, "flushAll must not fall back to the flushTimeout path when logsFlusher is nil")
+	assert.Equal(t, int32(1), metric.count.Load())
+	assert.Equal(t, int32(1), trace.count.Load())
+}
+
 // withFakeHeartbeat installs a real *Heartbeat with a long interval that
 // will never tick during the test, lets us observe Start/Stop side effects
 // via running goroutine count, and returns a teardown that ensures cleanup.

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"context"
+	"github.com/DataDog/datadog-agent/comp/logs-library/processor"
 	"os"
 	"strings"
 	"sync"
@@ -44,11 +45,13 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
 	enhancedmetrics "github.com/DataDog/datadog-agent/cmd/serverless-init/enhanced-metrics"
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/lifecycle"
 	serverlessInitTag "github.com/DataDog/datadog-agent/cmd/serverless-init/tag"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
+	serverlessLogs "github.com/DataDog/datadog-agent/pkg/serverless/logs"
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serverless/otlp"
 	serverlessTag "github.com/DataDog/datadog-agent/pkg/serverless/tags"
@@ -150,6 +153,10 @@ func setup(secretComp secrets.Component, delegatedAuthComp delegatedauth.Compone
 	origin := cloudService.GetOrigin()
 	// Note: we do not modify tags for the LogsAgent.
 	logsAgent := serverlessInitLog.SetupLogAgent(agentLogConfig, tagConfig.Tags, tagger, compression, hostname, origin)
+	// Snapshot the startup log tags so the lifecycle server can append lambda_microvm_id
+	// at /run without losing the base set. Must be computed after SetupLogAgent
+	// since MapToArray normalises the same map that SetupLogAgent passes to SetLogsTags.
+	logTagsBase := serverlessTag.MapToArray(tagConfig.Tags)
 
 	// When no API key is configured, skip trace and metric agent initialization
 	// to avoid noisy error logs. The process wrapper and logs agent still function normally.
@@ -159,9 +166,34 @@ func setup(secretComp secrets.Component, delegatedAuthComp delegatedauth.Compone
 	if apiKey == "" && apmAPIKey == "" {
 		log.Warnf("DD_API_KEY is not set; trace and metric collection are disabled. Set DD_API_KEY to enable monitoring.")
 		traceAgent := trace.NewNoopTraceAgent()
-		tracingCtx := &cloudservice.TracingContext{TraceAgent: traceAgent}
-		metricAgent := &metrics.ServerlessMetricAgent{
-			Tagger: tagger,
+		metricAgent := &metrics.ServerlessMetricAgent{Tagger: tagger}
+		tracingCtx := &cloudservice.TracingContext{
+			TraceAgent: traceAgent,
+			LifecycleCtx: &cloudservice.LifecycleContext{
+				MetricFlusher: metricAgent,
+				LogsFlusher:   logsAgent,
+				MetricEmitter: metricAgent,
+				SampleDrainer: metricAgent,
+				FlushTimeout:  agentLogConfig.FlushTimeout,
+				SidecarMode:   modeConf.SidecarMode,
+				LogsTagSetter: lifecycle.LogsTagSetterFunc(func(tags []string) {
+					serverlessLogs.SetLogsTags(tags)
+					processor.SetServerlessInitTagCache(tags)
+				}),
+				BaseTags: logTagsBase,
+				TraceTagSetter: lifecycle.TraceTagSetterFunc(func(tags map[string]string) {
+					traceAgent.SetTags(tags)
+				}),
+				BaseTraceTags: serverlessInitTag.MakeTraceAgentTags(tagConfig.Tags),
+			},
+		}
+		// Only MicroVM needs initialization without an API key: its Init starts the
+		// lifecycle hook server so the platform can complete lifecycle handshakes.
+		// Initializing other services here would create trace spans even though
+		// tracing is disabled and span tags are unset, leading to a nil-map panic
+		// on shutdown (e.g. Cloud Run Jobs writing error tags into a nil span Meta).
+		if origin == cloudservice.MicroVMOrigin {
+			_ = cloudService.Init(tracingCtx)
 		}
 		return cloudService, agentLogConfig, tracingCtx, metricAgent, logsAgent, nil, false
 	}
@@ -169,15 +201,32 @@ func setup(secretComp secrets.Component, delegatedAuthComp delegatedauth.Compone
 	traceTags := serverlessInitTag.MakeTraceAgentTags(tagConfig.Tags)
 	traceAgent := setupTraceAgent(traceTags, tagConfig.ConfiguredTags, tagger, origin)
 
+	metricAgent := setupMetricAgent(tagConfig.Tags, tagConfig.EnhancedMetricTags, tagConfig.EnhancedUsageMetricTags, tagger, cloudService.ShouldForceFlushAllOnForceFlushToSerializer())
+
 	tracingCtx := &cloudservice.TracingContext{
 		TraceAgent: traceAgent,
 		SpanTags:   traceTags,
+		LifecycleCtx: &cloudservice.LifecycleContext{
+			MetricFlusher: metricAgent,
+			LogsFlusher:   logsAgent,
+			MetricEmitter: metricAgent,
+			SampleDrainer: metricAgent,
+			FlushTimeout:  agentLogConfig.FlushTimeout,
+			SidecarMode:   modeConf.SidecarMode,
+			LogsTagSetter: lifecycle.LogsTagSetterFunc(func(tags []string) {
+				serverlessLogs.SetLogsTags(tags)
+				processor.SetServerlessInitTagCache(tags)
+			}),
+			BaseTags: logTagsBase,
+			TraceTagSetter: lifecycle.TraceTagSetterFunc(func(tags map[string]string) {
+				traceAgent.SetTags(tags)
+			}),
+			BaseTraceTags: serverlessInitTag.MakeTraceAgentTags(tagConfig.Tags),
+		},
 	}
 
 	// TODO check for errors and exit
 	_ = cloudService.Init(tracingCtx)
-
-	metricAgent := setupMetricAgent(tagConfig.Tags, tagConfig.EnhancedMetricTags, tagConfig.EnhancedUsageMetricTags, tagger, cloudService.ShouldForceFlushAllOnForceFlushToSerializer())
 
 	enhancedMetricsEnabled := pkgconfigsetup.Datadog().GetBool("enhanced_metrics")
 	if enhancedMetricsEnabled {
@@ -197,6 +246,7 @@ func setup(secretComp secrets.Component, delegatedAuthComp delegatedauth.Compone
 	}
 
 	go flushMetricsAgent(metricAgent)
+
 	return cloudService, agentLogConfig, tracingCtx, metricAgent, logsAgent, enhancedMetricsCollector, enhancedMetricsEnabled
 }
 
@@ -289,6 +339,7 @@ func setupTraceAgent(tags map[string]string, configuredTags []string, tagger tag
 		FunctionTags:          functionTags,
 	})
 	traceAgent.SetTags(tags)
+
 	go func() {
 		for range time.Tick(3 * time.Second) {
 			traceAgent.Flush()

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -8,7 +8,10 @@
 package main
 
 import (
+	"os"
+	"os/signal"
 	"slices"
+	"syscall"
 	"testing"
 	"time"
 
@@ -16,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
+	serverlessInitLog "github.com/DataDog/datadog-agent/cmd/serverless-init/log"
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
 	serverlessInitTag "github.com/DataDog/datadog-agent/cmd/serverless-init/tag"
 	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
@@ -29,6 +33,19 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
+
+// TestMetricAgentNoOpWithoutDemux verifies that the methods called by the
+// lifecycle server on the metric agent are safe when the agent has not been
+// started (Demux and dogStatsDServer are nil). In the no-API-key path the
+// agent is never started, so /suspend and /terminate must not panic when
+// they call Flush and WaitForPendingSamples.
+func TestMetricAgentNoOpWithoutDemux(t *testing.T) {
+	agent := &metrics.ServerlessMetricAgent{}
+	assert.NotPanics(t, func() {
+		agent.Flush()
+		agent.WaitForPendingSamples()
+	})
+}
 
 func TestTagsSetup(t *testing.T) {
 	configmock.New(t)
@@ -133,6 +150,45 @@ func TestSetupWithoutAPIKey(t *testing.T) {
 	})
 }
 
+// TestLogTagsBaseComputedFromTagConfigTags verifies that the logTagsBase variable
+// computed in setup() — as serverlessTag.MapToArray(tagConfig.Tags) — contains all
+// tags configured via DD_TAGS. This documents the contract: BaseTags passed to
+// LifecycleContext must be the full startup tag slice so the lifecycle server can
+// append microvm_id to it without losing any base tags.
+func TestLogTagsBaseComputedFromTagConfigTags(t *testing.T) {
+	configmock.New(t)
+	modeConf = mode.DetectMode()
+	t.Setenv("DD_TAGS", "env:prod region:us-east-1")
+
+	cloudService := &cloudservice.LocalService{}
+	tagConfig := configureTags(cloudService)
+	logTagsBase := serverlessTag.MapToArray(tagConfig.Tags)
+
+	assert.Contains(t, logTagsBase, "env:prod",
+		"logTagsBase must include all DD_TAGS entries (used as BaseTags on the lifecycle server)")
+	assert.Contains(t, logTagsBase, "region:us-east-1")
+	assert.NotEmpty(t, logTagsBase)
+}
+
+// TestBaseTraceTagsComputedFromTagConfigTags verifies that traceTags —
+// passed as BaseTraceTags to LifecycleContext — contains all tags from DD_TAGS
+// so that the lifecycle server can extend the map with lambda_microvm_id at /run
+// without losing any startup tags.
+func TestBaseTraceTagsComputedFromTagConfigTags(t *testing.T) {
+	configmock.New(t)
+	modeConf = mode.DetectMode()
+	t.Setenv("DD_TAGS", "env:prod region:us-east-1")
+
+	cloudService := &cloudservice.LocalService{}
+	tagConfig := configureTags(cloudService)
+	baseTraceTags := serverlessInitTag.MakeTraceAgentTags(tagConfig.Tags)
+
+	assert.Equal(t, "prod", baseTraceTags["env"],
+		"BaseTraceTags must include all DD_TAGS entries (used as BaseTraceTags on the lifecycle server)")
+	assert.Equal(t, "us-east-1", baseTraceTags["region"])
+	assert.NotEmpty(t, baseTraceTags)
+}
+
 // TestSetupOtlpAgentNoPanic ensures setupOtlpAgent does not panic when OTLP is enabled.
 func TestSetupOtlpAgentNoPanic(t *testing.T) {
 	t.Setenv("DD_OTLP_CONFIG_LOGS_ENABLED", "true")
@@ -150,4 +206,55 @@ func TestSetupOtlpAgentNoPanic(t *testing.T) {
 	// If it panics the process crashes. Without this the test can pass flakily when the goroutine hasn't run yet.
 	const panicWindow = 500 * time.Millisecond
 	<-time.After(panicWindow)
+}
+
+// TestRun_LocalService_InitMode executes the user app through LocalService.Run
+// in init-container mode, verifying the CloudService.Run interface routes
+// correctly to RunInit(cfg, nil) — no child tracking, user app runs normally.
+func TestRun_LocalService_InitMode(t *testing.T) {
+	saved := os.Args
+	defer func() { os.Args = saved }()
+	os.Args = []string{"datadog-init", "sh", "-c", "exit 0"}
+
+	svc := &cloudservice.LocalService{}
+	err := svc.Run(mode.Conf{SidecarMode: false}, &serverlessInitLog.Config{})
+	assert.NoError(t, err)
+}
+
+// TestRun_LocalService_SidecarMode verifies that the defaultRun sidecar path
+// calls RunSidecar (not RunInit). RunSidecar registers a real signal.Notify
+// for SIGINT/SIGTERM and blocks until one arrives, in both production and
+// tests, so we send ourselves a real SIGTERM to let it return instead of
+// leaking a goroutine that intercepts SIGTERM for the rest of the test
+// binary's life — which would otherwise swallow a genuine SIGTERM (e.g. CI
+// cancellation) instead of letting the process terminate.
+func TestRun_LocalService_SidecarMode(t *testing.T) {
+	saved := os.Args
+	defer func() { os.Args = saved }()
+	os.Args = []string{"datadog-init"} // sidecar mode: no cmd args
+
+	// Register our own listener first so the default terminate-on-SIGTERM
+	// disposition is already overridden before we signal ourselves below,
+	// regardless of whether RunSidecar's own signal.Notify has run yet.
+	guard := make(chan os.Signal, 1)
+	signal.Notify(guard, syscall.SIGTERM)
+	defer signal.Stop(guard)
+
+	svc := &cloudservice.LocalService{}
+	done := make(chan error, 1)
+	assert.NotPanics(t, func() {
+		go func() { done <- svc.Run(mode.Conf{SidecarMode: true}, &serverlessInitLog.Config{}) }()
+	})
+
+	// Give RunSidecar's own signal.Notify time to register before we signal.
+	time.Sleep(50 * time.Millisecond)
+	assert.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGTERM))
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunSidecar did not return after SIGTERM")
+	}
+	<-guard // drain our own copy so it doesn't leak into later tests
 }


### PR DESCRIPTION
### What does this PR do?

Adds `cloudservice.MicroVM`, a `CloudService` implementation for AWS Lambda MicroVMs, and a `LifecycleContext` type carried on `TracingContext.LifecycleCtx`:

- `GetTags` parses `DD_AWS_MICROVM_IMAGE_ARN` for `region`/`account_id`/`image_name` (falling back to `"unknown"` for any field it can't parse).
- `GetEnhancedMetricTags` derives base/usage tag sets from those tags.
- `Init` reads a `LifecycleContext` (metric/log flushers, trace-tag/log-tag setters, flush timeout, sidecar flag) and constructs + starts the lifecycle hook server.
- `Run` spawns the user process via `mode.RunInit`, binding `ProcessHooks.OnAlive`/`OnDead` to the lifecycle server's child so its `/ready` check reflects real liveness. Sidecar mode is fatal for MicroVM — there's no child process to track, so `/ready` would silently return 503 forever instead of surfacing the misconfiguration.
- `Shutdown` stops the lifecycle server within a bounded timeout so in-flight `/suspend`/`/terminate` requests can complete before the metric/trace agents tear down.
- MicroVM supports both amd64 and arm64 (every other cloud service here is amd64-only).

`MicroVM` is a complete, self-contained type in this PR but is **not yet reachable**: `GetCloudServiceType` still doesn't know about it, so nothing in the running agent changes yet.

### Motivation

This is the core piece of the MicroVM integration: everything needed to answer the lifecycle server's HTTP hooks and track the user process's liveness, in one type that satisfies `CloudService` end-to-end. Landing it as its own PR — before wiring it into `main.go` or registering it in `GetCloudServiceType` (PR 5) — lets it be reviewed as a unit without also having to reason about the wiring changes, and avoids any intermediate state where `MicroVM` could be selected by `GetCloudServiceType` before `main.go` populates its `LifecycleContext` (which would leave `Init` a no-op and `Run` dereferencing a nil child).

This is PR 2 of 5 in the split of #53036 (`tianning.li/microvm-07-microvm-service-wiring`). See PR 1 (#53092) for the full stack list.

### Describe how you validated your changes

```
dda inv test --targets=./cmd/serverless-init/...
```
All 242 tests pass (3 platform-skips) — this PR adds no new tests of its own; `MicroVM`'s tests land in PRs 3 and 4 so each stays under ~300 lines. Existing tests confirm nothing else regresses with the new type and field present but unused.
