### PR TITLE
test(serverless-init): add MicroVM tag, metric, and arch tests

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cloudservice
+
+import (
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/lifecycle"
+	serverlessInitLog "github.com/DataDog/datadog-agent/cmd/serverless-init/log"
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
+	serverlessenv "github.com/DataDog/datadog-agent/pkg/serverless/env"
+)
+
+const testImageARN = "arn:aws:lambda:us-east-1:123456789012:microvm-image:my-image"
+
+func TestIsMicroVM(t *testing.T) {
+	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, testImageARN)
+	assert.True(t, isMicroVM())
+}
+
+func TestIsMicroVMNotSet(t *testing.T) {
+	assert.False(t, isMicroVM())
+}
+
+func TestMicroVMGetTags(t *testing.T) {
+	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, testImageARN)
+	m := &MicroVM{}
+	tags := m.GetTags()
+
+	assert.Equal(t, "us-east-1", tags["region"])
+	assert.Equal(t, "123456789012", tags["account_id"])
+	assert.Equal(t, "my-image", tags["image_name"])
+	assert.Equal(t, MicroVMOrigin, tags["origin"])
+	assert.Equal(t, MicroVMOrigin, tags["_dd.origin"])
+	assert.Equal(t, MicroVMResourceType, tags["resource_type"])
+	assert.Equal(t, "aws", tags["resource_provider"])
+	assert.Equal(t, testImageARN, tags["resource_id"])
+	assert.NotContains(t, tags, "microvm_image_arn")
+}
+
+func TestMicroVMGetTagsMissingARN(t *testing.T) {
+	m := &MicroVM{}
+	tags := m.GetTags()
+	assert.Equal(t, "unknown", tags["region"])
+	assert.Equal(t, "unknown", tags["account_id"])
+	assert.Equal(t, "unknown", tags["image_name"])
+	assert.Equal(t, "unknown", tags["resource_id"])
+	assert.Equal(t, MicroVMResourceType, tags["resource_type"])
+	assert.Equal(t, "aws", tags["resource_provider"])
+}
+
+func TestMicroVMGetEnhancedMetricTags(t *testing.T) {
+	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, testImageARN)
+	m := &MicroVM{}
+	cloudTags := m.GetTags()
+	result := m.GetEnhancedMetricTags(cloudTags)
+
+	assert.Equal(t, "us-east-1", result.Base["region"])
+	assert.Equal(t, "123456789012", result.Base["account_id"])
+	assert.Equal(t, "my-image", result.Base["image_name"])
+	assert.Equal(t, MicroVMResourceType, result.Base["resource_type"])
+	assert.Equal(t, "aws", result.Base["resource_provider"])
+	assert.Equal(t, testImageARN, result.Base["resource_id"])
+	assert.NotContains(t, result.Base, "instance_id", "Base must not carry the high-cardinality instance_id")
+
+	assert.Equal(t, result.Base["region"], result.Usage["region"])
+	assert.Equal(t, result.Base["account_id"], result.Usage["account_id"])
+	assert.Equal(t, result.Base["resource_type"], result.Usage["resource_type"])
+	assert.Equal(t, result.Base["resource_provider"], result.Usage["resource_provider"])
+	assert.Equal(t, result.Base["resource_id"], result.Usage["resource_id"])
+	assert.NotContains(t, result.Usage, "instance_id", "instance_id is absent until SetInstanceID is called from /launch")
+}
+
+func TestMicroVMGetEnhancedMetricTagsMissingARN(t *testing.T) {
+	m := &MicroVM{}
+	cloudTags := m.GetTags() // ARN not set → all "unknown"
+	result := m.GetEnhancedMetricTags(cloudTags)
+
+	assert.Equal(t, "unknown", result.Base["region"])
+	assert.Equal(t, "unknown", result.Base["account_id"])
+	assert.Equal(t, "unknown", result.Base["resource_id"])
+	assert.Equal(t, MicroVMResourceType, result.Base["resource_type"])
+	assert.Equal(t, "aws", result.Base["resource_provider"])
+	assert.Equal(t, result.Base["resource_id"], result.Usage["resource_id"])
+}
+
+// Compile-time guard: *MicroVM must satisfy the CloudService interface,
+// including the new Run method.
+var _ CloudService = (*MicroVM)(nil)
+
+// TestMicroVM_Run_InitMode_ThreadsChildLiveness verifies that MicroVM.Run in
+// init-container mode threads m.child into RunInit so the lifecycle server's
+// /ready alive-check reflects the user app's actual state.
+func TestMicroVM_Run_InitMode_ThreadsChildLiveness(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("serverless-init is not supported on windows")
+	}
+	if testing.Short() {
+		t.Skip("spawns a subprocess")
+	}
+	saved := os.Args
+	defer func() { os.Args = saved }()
+	os.Args = []string{"datadog-init", "sh", "-c", "sleep 0.3"}
+
+	child := lifecycle.NewChild()
+	m := &MicroVM{child: child}
+
+	// Poll for the alive transition instead of sleeping a fixed delay: a
+	// single sample after a guessed delay can land before cmd.Start has
+	// invoked MarkAlive, or after the short-lived subprocess has already
+	// exited, on a loaded host. Polling records the alive state the instant
+	// it appears, so the race window is eliminated regardless of host load.
+	var midRunAlive atomic.Bool
+	probeDone := make(chan struct{})
+	go func() {
+		defer close(probeDone)
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if child.IsAlive() {
+				midRunAlive.Store(true)
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	err := m.Run(mode.Conf{SidecarMode: false}, &serverlessInitLog.Config{})
+	<-probeDone
+
+	require.NoError(t, err)
+	assert.True(t, midRunAlive.Load(), "child must be alive while Run is blocked on the subprocess")
+	assert.False(t, child.IsAlive(), "child must be dead after Run returns")
+}
+
+func TestParseMicroVMARNWithColonInName(t *testing.T) {
+	region, accountID, imageName := parseMicroVMARN("arn:aws:lambda:eu-west-1:999:microvm-image:my:image:v2")
+	assert.Equal(t, "eu-west-1", region)
+	assert.Equal(t, "999", accountID)
+	assert.Equal(t, "my:image:v2", imageName)
+}
+
+func TestMicroVMOrigin(t *testing.T) {
+	assert.Equal(t, MicroVMOrigin, (&MicroVM{}).GetOrigin())
+}
+
+func TestMicroVMMetricPrefix(t *testing.T) {
+	assert.Equal(t, MicroVMPrefix, (&MicroVM{}).GetMetricPrefix())
+}
+
+// TestIsSupportedArch pins the MicroVM arch allowlist — lives here because
+// isSupportedArch is defined in microvm.go.
+func TestIsSupportedArch(t *testing.T) {
+	for _, arch := range []string{archAMD64, archARM64} {
+		assert.True(t, isSupportedArch(arch), "%s must be supported for MicroVM", arch)
+	}
+	for _, arch := range []string{"386", "mips", "mips64", "riscv64", "s390x", ""} {
+		assert.False(t, isSupportedArch(arch), "%s must be unsupported", arch)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds unit tests for the tag/metric/arch-related surface of `cloudservice.MicroVM` added in #53093: `GetTags`/`GetEnhancedMetricTags` with a well-formed ARN, with a missing ARN (`"unknown"` fallback), `isMicroVM`, `parseMicroVMARN` (including a colon-containing image name), `isSupportedArch`'s amd64/arm64 allowlist, and `Run`'s threading of the child handle into `RunInit`'s liveness hooks.

### Motivation

`MicroVM`'s tag-parsing and metric-tagging logic is pure and cheap to test in isolation, so it's split out from the heavier lifecycle-server tests (PR 4) to keep this PR small and fast to review. Landing tests in a separate PR from the implementation (PR 2) — rather than one 700+ line PR — keeps each PR in this stack under the ~300 line target while still shipping full coverage before the type is wired into the running agent (PR 5).

This is PR 3 of 5 in the split of #53036 (`tianning.li/microvm-07-microvm-service-wiring`). See PR 1 (#53092) for the full stack list.

### Describe how you validated your changes

```
dda inv test --targets=./cmd/serverless-init/...
```
253 tests, 249 passed, 4 skipped (3 pre-existing platform skips + `TestMicroVM_Run_InitMode_ThreadsChildLiveness`, which spawns a subprocess and is skipped under `-short`).
