### PR TITLE
test(serverless-init): add MicroVM lifecycle-server tests

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -6,8 +6,14 @@
 package cloudservice
 
 import (
+	"context"
+	"net"
+	"net/http"
 	"os"
 	"runtime"
+	"strconv"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -19,7 +25,37 @@ import (
 	serverlessInitLog "github.com/DataDog/datadog-agent/cmd/serverless-init/log"
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
 	serverlessenv "github.com/DataDog/datadog-agent/pkg/serverless/env"
+	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
+	"github.com/DataDog/datadog-agent/pkg/trace/api"
 )
+
+// Compile-time guards: the concrete types passed via LifecycleContext must
+// satisfy the lifecycle interfaces.  Failures here mean Init() would panic at
+// runtime when the lifecycle server calls the missing methods.
+var _ lifecycle.Flusher = (*serverlessMetrics.ServerlessMetricAgent)(nil)
+var _ lifecycle.SampleDrainer = (*serverlessMetrics.ServerlessMetricAgent)(nil)
+var _ lifecycle.MetricEmitter = (*serverlessMetrics.ServerlessMetricAgent)(nil)
+
+// freeLifecyclePort returns an OS-assigned free TCP port as a string, for tests
+// that exercise MicroVM.Init through the real DD_AWS_MICROVM_LIFECYCLE_PORT env
+// var (which rejects "0" as out of range) without colliding with the real
+// port 9000 or other tests in this package.
+func freeLifecyclePort(t *testing.T) string {
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return strconv.Itoa(port)
+}
+
+// noopTraceAgent is a local stub that satisfies the TraceAgent interface
+// without importing pkg/serverless/trace (which imports cloudservice, creating
+// a cycle).
+type noopTraceAgent struct{}
+
+func (n *noopTraceAgent) Process(_ *api.Payload) {}
+func (n *noopTraceAgent) Flush()                 {}
+func (n *noopTraceAgent) Stop()                  {}
 
 const testImageARN = "arn:aws:lambda:us-east-1:123456789012:microvm-image:my-image"
 
@@ -156,6 +192,265 @@ func TestMicroVMOrigin(t *testing.T) {
 func TestMicroVMMetricPrefix(t *testing.T) {
 	assert.Equal(t, MicroVMPrefix, (&MicroVM{}).GetMetricPrefix())
 }
+
+// TestLifecycleContext_NilLogsTagSetter_IsAccepted verifies that
+// LifecycleContext.LogsTagSetter is nil-safe: passing nil must not cause any
+// compile or runtime issue. This pins the nil-check added to MicroVM.Init so
+// callers that don't need log-tag forwarding are not required to supply a setter.
+func TestLifecycleContext_NilLogsTagSetter_IsAccepted(t *testing.T) {
+	lc := &LifecycleContext{LogsTagSetter: nil, BaseTags: nil}
+	assert.Nil(t, lc.LogsTagSetter, "nil LogsTagSetter must be accepted by LifecycleContext")
+}
+
+// TestMicroVM_LogsTagSetter_InvokedOnLaunch verifies the behaviour that
+// MicroVM.Init wires when LogsTagSetter is non-nil: SetLogsTagSetter is called
+// on the server, and the server then invokes the setter on /launch with the
+// base tags plus the microvm_id from the request body.
+//
+// The test constructs the server directly with port 0 (random free port) to
+// avoid the log.Fatalf that Init emits when port 9000 is already bound.
+func TestMicroVM_LogsTagSetter_InvokedOnLaunch(t *testing.T) {
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+
+	var mu sync.Mutex
+	var receivedTags []string
+	setter := lifecycle.LogsTagSetterFunc(func(tags []string) {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedTags = tags
+	})
+	baseTags := []string{"env:test", "service:myapp"}
+
+	// Construct the server directly with port 0 — same path Init takes, minus
+	// the port-9000 binding that would log.Fatalf in a shared test environment.
+	srv := lifecycle.NewServer(
+		0, // random free port
+		metricAgent, &noopTraceAgent{}, &noopLogsFlusher{},
+		metricAgent, metricAgent,
+		(&MicroVM{}).GetSource(),
+		time.Second,
+		lifecycle.NewNoopChildHandle(),
+		nil, // no forwarder
+		nil, // no heartbeat
+	)
+	// This is the call Init makes when lc.LogsTagSetter != nil.
+	srv.SetLogsTagSetter(setter, baseTags)
+
+	l, err := srv.Listen()
+	require.NoError(t, err)
+	go srv.Serve(l)
+	t.Cleanup(func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Stop(shutCtx)
+	})
+
+	launchPath := "/aws/lambda-microvms/runtime/v1/run"
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
+	resp, err := http.Post("http://"+l.Addr().String()+launchPath, "application/json", body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	mu.Lock()
+	got := receivedTags
+	mu.Unlock()
+
+	assert.Contains(t, got, "env:test", "base tags must be forwarded to LogsTagSetter on /launch")
+	assert.Contains(t, got, "service:myapp", "base tags must be forwarded to LogsTagSetter on /launch")
+	assert.Contains(t, got, "lambda_microvm_id:vm-abc123", "microvm_id from /launch body must be appended to tags")
+}
+
+// TestLifecycleContext_NilTraceTagSetter_IsAccepted verifies that
+// LifecycleContext.TraceTagSetter is nil-safe: passing nil must not cause any
+// compile or runtime issue. Mirrors TestLifecycleContext_NilLogsTagSetter_IsAccepted.
+func TestLifecycleContext_NilTraceTagSetter_IsAccepted(t *testing.T) {
+	lc := &LifecycleContext{TraceTagSetter: nil, BaseTraceTags: nil}
+	assert.Nil(t, lc.TraceTagSetter, "nil TraceTagSetter must be accepted by LifecycleContext")
+}
+
+// TestMicroVM_TraceTagSetter_InvokedOnLaunch verifies the end-to-end wiring of
+// TraceTagSetter: MicroVM.Init passes it to the server, and the server calls it
+// on /launch with base trace tags extended by lambda_microvm_id from the body.
+//
+// Mirrors TestMicroVM_LogsTagSetter_InvokedOnLaunch.
+func TestMicroVM_TraceTagSetter_InvokedOnLaunch(t *testing.T) {
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+
+	var mu sync.Mutex
+	var receivedTags map[string]string
+	setter := lifecycle.TraceTagSetterFunc(func(tags map[string]string) {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedTags = tags
+	})
+	baseTraceTags := map[string]string{"env": "test", "service": "myapp"}
+
+	srv := lifecycle.NewServer(
+		0,
+		metricAgent, &noopTraceAgent{}, &noopLogsFlusher{},
+		metricAgent, metricAgent,
+		(&MicroVM{}).GetSource(),
+		time.Second,
+		lifecycle.NewNoopChildHandle(),
+		nil, // no forwarder
+		nil, // no heartbeat
+	)
+	// This is the call Init makes when lc.TraceTagSetter != nil.
+	srv.SetTraceTagSetter(setter, baseTraceTags)
+
+	l, err := srv.Listen()
+	require.NoError(t, err)
+	go srv.Serve(l)
+	t.Cleanup(func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Stop(shutCtx)
+	})
+
+	launchPath := "/aws/lambda-microvms/runtime/v1/run"
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
+	resp, err := http.Post("http://"+l.Addr().String()+launchPath, "application/json", body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	mu.Lock()
+	got := receivedTags
+	mu.Unlock()
+
+	assert.Equal(t, "test", got["env"], "base trace tags must be forwarded to TraceTagSetter on /launch")
+	assert.Equal(t, "myapp", got["service"], "base trace tags must be forwarded to TraceTagSetter on /launch")
+	assert.Equal(t, "vm-abc123", got["lambda_microvm_id"], "microvm_id from /launch body must appear in trace tags")
+}
+
+func TestMicroVMInit_NilTracingCtx_DoesNotStartServer(t *testing.T) {
+	m := &MicroVM{}
+	err := m.Init(nil)
+	require.NoError(t, err)
+	assert.Nil(t, m.server, "Init with nil TracingContext must not start a lifecycle server")
+}
+
+func TestMicroVMInit_NilLifecycleCtx_DoesNotStartServer(t *testing.T) {
+	m := &MicroVM{}
+	err := m.Init(&TracingContext{TraceAgent: &noopTraceAgent{}})
+	require.NoError(t, err)
+	assert.Nil(t, m.server, "Init without LifecycleCtx must not start a lifecycle server")
+}
+
+func TestMicroVMInit_WithLifecycleCtx_ServerIsConstructed(t *testing.T) {
+	t.Setenv(lifecycle.LifecyclePortEnvVar, freeLifecyclePort(t)) // avoid colliding with the real port 9000
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+	m := &MicroVM{}
+	ctx := &TracingContext{
+		TraceAgent: &noopTraceAgent{},
+		LifecycleCtx: &LifecycleContext{
+			MetricFlusher: metricAgent,
+			LogsFlusher:   &noopLogsFlusher{},
+			MetricEmitter: metricAgent,
+			SampleDrainer: metricAgent,
+			FlushTimeout:  time.Second,
+		},
+	}
+	err := m.Init(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { m.Shutdown(*metricAgent, false, nil) })
+}
+
+func TestMicroVMShutdown_NilServer_NoPanic(t *testing.T) {
+	m := &MicroVM{}
+	assert.NotPanics(t, func() { m.Shutdown(serverlessMetrics.ServerlessMetricAgent{}, false, nil) })
+}
+
+// TestMicroVMShutdown_LiveServer uses port 0 (random) to avoid colliding with
+// port 9000, and sets m.server directly (same-package access) to bypass Init's
+// hardcoded DefaultPort.
+func TestMicroVMShutdown_LiveServer_StopsCleanly(t *testing.T) {
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+	srv := lifecycle.NewServer(
+		0, // random free port
+		metricAgent, &noopTraceAgent{}, &noopLogsFlusher{},
+		metricAgent, metricAgent,
+		(&MicroVM{}).GetSource(),
+		time.Second,
+		lifecycle.NewNoopChildHandle(),
+		nil, // no forwarder
+		nil, // no heartbeat
+	)
+	l, err := srv.Listen()
+	require.NoError(t, err)
+	go srv.Serve(l)
+
+	m := &MicroVM{server: srv, flushTimeout: time.Second}
+	assert.NotPanics(t, func() { m.Shutdown(serverlessMetrics.ServerlessMetricAgent{}, false, nil) })
+}
+
+func TestMicroVMInit_NonMicroVMServicesIgnoreLifecycleCtx(t *testing.T) {
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+	lc := &LifecycleContext{
+		MetricFlusher: metricAgent,
+		LogsFlusher:   &noopLogsFlusher{},
+		MetricEmitter: metricAgent,
+		SampleDrainer: metricAgent,
+		FlushTimeout:  time.Second,
+	}
+	ctx := &TracingContext{TraceAgent: &noopTraceAgent{}, LifecycleCtx: lc}
+
+	for _, svc := range []CloudService{&LocalService{}, &AppService{}} {
+		assert.NotPanics(t, func() { _ = svc.Init(ctx) },
+			"%T.Init must not panic when passed a LifecycleCtx", svc)
+	}
+}
+
+// TestMicroVMInit_SidecarMode_ServerStartedChildNil verifies that sidecar mode
+// starts the lifecycle server (for /ready 503s) but returns a nil Child — the
+// noop ChildHandle reports not-alive, surfacing 503 rather than papering over a
+// sidecar+MicroVM misconfiguration.
+func TestMicroVMInit_SidecarMode_ServerStartedChildNil(t *testing.T) {
+	t.Setenv(lifecycle.LifecyclePortEnvVar, freeLifecyclePort(t)) // avoid colliding with the real port 9000
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+	m := &MicroVM{}
+	ctx := &TracingContext{
+		TraceAgent: &noopTraceAgent{},
+		LifecycleCtx: &LifecycleContext{
+			MetricFlusher: metricAgent,
+			LogsFlusher:   &noopLogsFlusher{},
+			MetricEmitter: metricAgent,
+			SampleDrainer: metricAgent,
+			FlushTimeout:  time.Second,
+			SidecarMode:   true,
+		},
+	}
+	err := m.Init(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { m.Shutdown(*metricAgent, false, nil) })
+	assert.Nil(t, m.Child(), "sidecar mode must not expose a Child — no user process to track")
+}
+
+// TestMicroVMInit_InitMode_ExposesChild verifies that init-container mode (non-sidecar)
+// exposes a non-nil Child after Init so that RunInit can MarkAlive/MarkDead it.
+func TestMicroVMInit_InitMode_ExposesChild(t *testing.T) {
+	t.Setenv(lifecycle.LifecyclePortEnvVar, freeLifecyclePort(t)) // avoid colliding with the real port 9000
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+	m := &MicroVM{}
+	ctx := &TracingContext{
+		TraceAgent: &noopTraceAgent{},
+		LifecycleCtx: &LifecycleContext{
+			MetricFlusher: metricAgent,
+			LogsFlusher:   &noopLogsFlusher{},
+			MetricEmitter: metricAgent,
+			SampleDrainer: metricAgent,
+			FlushTimeout:  time.Second,
+			SidecarMode:   false,
+		},
+	}
+	err := m.Init(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { m.Shutdown(*metricAgent, false, nil) })
+	assert.NotNil(t, m.Child(), "init-container mode must expose a Child for RunInit to alive-check")
+}
+
+type noopLogsFlusher struct{}
+
+func (n *noopLogsFlusher) Flush(_ context.Context) {}
 
 // TestIsSupportedArch pins the MicroVM arch allowlist — lives here because
 // isSupportedArch is defined in microvm.go.


### PR DESCRIPTION
### What does this PR do?

Adds unit tests for the lifecycle-server-facing surface of `cloudservice.MicroVM` added in #53093:

- `Init`: no-op with a nil `TracingContext` or nil `LifecycleCtx`; constructs and starts a real server when given one; sidecar mode starts the server but exposes a nil `Child` (so `/ready` correctly falls back to a not-alive noop handle instead of a MicroVM being wired into a mode it doesn't support); init-container mode exposes a non-nil `Child`.
- `Shutdown`: no-op/no-panic with a nil server; cleanly stops a live one.
- `LogsTagSetter`/`TraceTagSetter`: nil is accepted without issue, and when set, an end-to-end `/launch` request against a real (random-port) server forwards the base tags plus the `microvm_id` from the request body into both the logs and trace tag setters.

### Motivation

These tests exercise the parts of `MicroVM` that talk to a real (loopback) HTTP server and to `*lifecycle.Server`/`*lifecycle.Child`, which is heavier and slower than the pure tag/arch tests in PR 3 — kept separate so PR 3 stays fast and focused, and so this PR's ~300 lines don't also have to carry the simpler tests. Together with PR 3, this gives `MicroVM` full test coverage before it's wired into `GetCloudServiceType`/`main.go` in PR 5, so that wiring PR only has to prove the wiring itself, not the `MicroVM` logic underneath it.

This is PR 4 of 5 in the split of #53036 (`tianning.li/microvm-07-microvm-service-wiring`). See PR 1 (#53092) for the full stack list.

### Describe how you validated your changes

```
dda inv test --targets=./cmd/serverless-init/...
```
265 tests, 261 passed, 4 skipped (3 pre-existing platform skips + the subprocess-spawning test from PR 3, skipped under `-short`).

### Additional Notes

No `BUILD.bazel` changes needed — `cloudservice/` is Gazelle-excluded (root `BUILD.bazel` lines 97-100).