### PR TITLE
Increase memory allotment for quality gate idle

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 176 MiB
+  memory_allotment: 185 MiB
 
   environment:
     DD_API_KEY: a0000001


### PR DESCRIPTION
### What does this PR do?

This bumps the memory allotment the container is allowed for `quality_gate_idle`.

### Motivation

Folks started seeing some oom kills of the Agent in regression detector reports.

Ex: https://github.com/DataDog/datadog-agent/pull/52988#issuecomment-4853589629
Ex: https://github.com/DataDog/datadog-agent/pull/53081#issuecomment-4858584137

### Describe how you validated your changes

Regression Detector is going to run in CI and I expect to see no oom kills of the Agent during the `quality_gate_idle` experiment.

### Additional Notes
The memory allotment is not the bounds value and isn't what we assert on.