### PR TITLE
fix(serverless-init): eliminate GlobalTags data race in MicroVM trace tags

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -115,6 +115,19 @@ func (m *MicroVM) GetMetricPrefix() string { return MicroVMPrefix }
 // GetUsageMetricSuffix returns the usage metric suffix.
 func (m *MicroVM) GetUsageMetricSuffix() string { return MicroVMUsageMetricSuffix }
 
+// CurrentUsageMetricTags returns the dynamic tags to attach to the enhanced
+// usage metric on each periodic emission: the per-instance tag, once known
+// from /run, or nil before that (see GetEnhancedMetricTags's doc comment on
+// why Usage never carries it directly). "instance" matches the tag key
+// AppService.GetEnhancedMetricTags and CloudRun.GetEnhancedMetricTags use for
+// their own per-instance usage tag.
+func (m *MicroVM) CurrentUsageMetricTags() []string {
+	if id := m.server.InstanceID(); id != "" {
+		return []string{"instance:" + id}
+	}
+	return nil
+}
+
 // GetOrigin returns the origin tag value.
 func (m *MicroVM) GetOrigin() string { return MicroVMOrigin }
 

--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -44,16 +44,18 @@ const (
 // construct and start the lifecycle hook server. Populated by main.go before
 // calling CloudService.Init; nil (and ignored) for all non-MicroVM services.
 type LifecycleContext struct {
-	MetricFlusher  lifecycle.Flusher
-	LogsFlusher    lifecycle.LogsFlusher
-	MetricEmitter  lifecycle.MetricEmitter
-	SampleDrainer  lifecycle.SampleDrainer
-	FlushTimeout   time.Duration
-	SidecarMode    bool
-	LogsTagSetter  lifecycle.LogsTagSetter  // nil-safe; applied via server.SetLogsTagSetter after /run
-	BaseTags       []string                 // startup log tag snapshot passed alongside LogsTagSetter
-	TraceTagSetter lifecycle.TraceTagSetter // nil-safe; applied via server.SetTraceTagSetter after /run
-	BaseTraceTags  map[string]string        // startup trace tag snapshot passed alongside TraceTagSetter
+	MetricFlusher       lifecycle.Flusher
+	LogsFlusher         lifecycle.LogsFlusher
+	MetricEmitter       lifecycle.MetricEmitter
+	SampleDrainer       lifecycle.SampleDrainer
+	FlushTimeout        time.Duration
+	SidecarMode         bool
+	LogsTagSetter       lifecycle.LogsTagSetter   // nil-safe; applied via server.SetLogsTagSetter after /run
+	BaseTags            []string                  // startup log tag snapshot passed alongside LogsTagSetter
+	TraceTagSetter      lifecycle.TraceTagSetter  // nil-safe; applied via server.SetTraceTagSetter after /run
+	BaseTraceTags       map[string]string         // startup trace tag snapshot passed alongside TraceTagSetter
+	MetricTagSetter     lifecycle.MetricTagSetter // nil-safe; applied via server.SetMetricTagSetter after /run
+	BaseUsageMetricTags []string                  // startup enhanced usage metric tag snapshot passed alongside MetricTagSetter
 }
 
 // MicroVM implements CloudService for AWS Lambda MicroVMs.
@@ -175,6 +177,9 @@ func (m *MicroVM) Init(ctx *TracingContext) error {
 	}
 	if lc.TraceTagSetter != nil {
 		m.server.SetTraceTagSetter(lc.TraceTagSetter, lc.BaseTraceTags)
+	}
+	if lc.MetricTagSetter != nil {
+		m.server.SetMetricTagSetter(lc.MetricTagSetter, lc.BaseUsageMetricTags)
 	}
 	if err := m.server.ListenAndServe(func(err error) {
 		log.Fatalf("MicroVM lifecycle server error: %v", err)

--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -65,13 +65,15 @@ type MicroVM struct {
 	flushTimeout time.Duration
 }
 
-// GetTags returns MicroVM-specific tags parsed from the image ARN env var.
+// GetTags returns MicroVM-specific tags parsed from the image ARN env var,
+// plus the image version read directly from its own env var.
 func (m *MicroVM) GetTags() map[string]string {
 	tags := map[string]string{
-		"origin":            MicroVMOrigin,
-		"_dd.origin":        MicroVMOrigin,
-		"resource_type":     MicroVMResourceType,
-		"resource_provider": MicroVMResourceProvider,
+		"origin":                       MicroVMOrigin,
+		"_dd.origin":                   MicroVMOrigin,
+		"resource_type":                MicroVMResourceType,
+		"resource_provider":            MicroVMResourceProvider,
+		"lambda_microvm_image_version": tagValueOrUnknown(os.Getenv(serverlessenv.MicroVMImageVersionEnvVar)),
 	}
 
 	arn := os.Getenv(serverlessenv.MicroVMImageARNEnvVar)
@@ -170,6 +172,7 @@ func (m *MicroVM) Init(ctx *TracingContext) error {
 		lc.FlushTimeout,
 		components.Handle,
 		components.Forwarder,
+		components.EnabledHooks,
 		heartbeat,
 	)
 	if lc.LogsTagSetter != nil {
@@ -225,9 +228,6 @@ func (m *MicroVM) Shutdown(_ *serverlessMetrics.ServerlessMetricAgent, _ bool, _
 // AddStartMetric is a no-op for MicroVM. The lifecycle server emits the run
 // metric when the /run hook fires; emitting it here would double-count.
 func (m *MicroVM) AddStartMetric(_ *serverlessMetrics.ServerlessMetricAgent) {}
-
-// ShouldForceFlushAllOnForceFlushToSerializer returns false for MicroVM.
-func (m *MicroVM) ShouldForceFlushAllOnForceFlushToSerializer() bool { return false }
 
 // isMicroVM returns true when running inside an AWS Lambda MicroVM.
 func isMicroVM() bool {

--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -128,6 +128,82 @@ func TestMicroVMGetEnhancedMetricTagsMissingARN(t *testing.T) {
 	assert.Equal(t, result.Base["resource_id"], result.Usage["resource_id"])
 }
 
+// TestMicroVM_CurrentUsageMetricTags_NilServer_ReturnsNil verifies that
+// CurrentUsageMetricTags is safe to call before Init (m.server is nil) — the
+// enhanced-metrics collector may call it before the lifecycle server exists.
+func TestMicroVM_CurrentUsageMetricTags_NilServer_ReturnsNil(t *testing.T) {
+	m := &MicroVM{}
+	assert.Nil(t, m.CurrentUsageMetricTags())
+}
+
+// TestMicroVM_CurrentUsageMetricTags_BeforeRun_ReturnsNil verifies that no
+// instance tag is produced before /run fires, matching GetEnhancedMetricTags'
+// documented behavior that instance_id is unknown until then.
+func TestMicroVM_CurrentUsageMetricTags_BeforeRun_ReturnsNil(t *testing.T) {
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+	srv := lifecycle.NewServer(
+		0,
+		metricAgent, &noopTraceAgent{}, &noopLogsFlusher{},
+		metricAgent, nil,
+		(&MicroVM{}).GetSource(),
+		time.Second,
+		lifecycle.NewNoopChildHandle(),
+		nil, // no forwarder
+		nil, // no heartbeat
+	)
+	m := &MicroVM{server: srv}
+	assert.Nil(t, m.CurrentUsageMetricTags())
+}
+
+// TestMicroVM_CurrentUsageMetricTags_AfterRun_ReturnsInstanceTag verifies the
+// end-to-end path: once /run has captured the MicroVM instance ID,
+// CurrentUsageMetricTags returns the "instance:<id>" tag the enhanced-metrics
+// collector attaches to the usage metric on every subsequent tick.
+func TestMicroVM_CurrentUsageMetricTags_AfterRun_ReturnsInstanceTag(t *testing.T) {
+	metricAgent := &serverlessMetrics.ServerlessMetricAgent{}
+	srv := lifecycle.NewServer(
+		0,
+		metricAgent, &noopTraceAgent{}, &noopLogsFlusher{},
+		metricAgent, nil,
+		(&MicroVM{}).GetSource(),
+		time.Second,
+		lifecycle.NewNoopChildHandle(),
+		nil, // no forwarder
+		nil, // no heartbeat
+	)
+	l, err := srv.Listen()
+	require.NoError(t, err)
+	go srv.Serve(l)
+	t.Cleanup(func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Stop(shutCtx)
+	})
+
+	port := l.Addr().(*net.TCPAddr).Port
+	runPath := "/aws/lambda-microvms/runtime/v1/run"
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
+	resp, err := http.Post("http://127.0.0.1:"+strconv.Itoa(port)+runPath, "application/json", body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	m := &MicroVM{server: srv}
+	assert.Equal(t, []string{"instance:vm-abc123"}, m.CurrentUsageMetricTags())
+}
+
+// TestMicroVM_SatisfiesUsageMetricTagProvider is a compile-time guard: main.go
+// duck-types cloudService against an unexported usageMetricTagProvider
+// interface with this exact method set to wire the enhanced-metrics
+// collector's dynamic tag hook. If CurrentUsageMetricTags' signature ever
+// drifts, that type assertion silently stops matching instead of failing to
+// compile — this pins the method set so such drift shows up here instead.
+func TestMicroVM_SatisfiesUsageMetricTagProvider(t *testing.T) {
+	var m any = &MicroVM{}
+	provider, ok := m.(interface{ CurrentUsageMetricTags() []string })
+	require.True(t, ok, "*MicroVM must implement CurrentUsageMetricTags() []string")
+	assert.NotPanics(t, func() { provider.CurrentUsageMetricTags() })
+}
+
 // Compile-time guard: *MicroVM must satisfy the CloudService interface,
 // including the new Run method.
 var _ CloudService = (*MicroVM)(nil)

--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -56,6 +56,7 @@ func (n *noopTraceAgent) Flush()                 {}
 func (n *noopTraceAgent) Stop()                  {}
 
 const testImageARN = "arn:aws:lambda:us-east-1:123456789012:microvm-image:my-image"
+const testImageVersion = "v1.2.3"
 
 func TestIsMicroVM(t *testing.T) {
 	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, testImageARN)
@@ -68,6 +69,7 @@ func TestIsMicroVMNotSet(t *testing.T) {
 
 func TestMicroVMGetTags(t *testing.T) {
 	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, testImageARN)
+	t.Setenv(serverlessenv.MicroVMImageVersionEnvVar, testImageVersion)
 	m := &MicroVM{}
 	tags := m.GetTags()
 
@@ -79,6 +81,7 @@ func TestMicroVMGetTags(t *testing.T) {
 	assert.Equal(t, MicroVMResourceType, tags["resource_type"])
 	assert.Equal(t, "aws", tags["resource_provider"])
 	assert.Equal(t, testImageARN, tags["resource_id"])
+	assert.Equal(t, testImageVersion, tags["lambda_microvm_image_version"])
 	assert.NotContains(t, tags, "microvm_image_arn")
 }
 
@@ -89,8 +92,24 @@ func TestMicroVMGetTagsMissingARN(t *testing.T) {
 	assert.Equal(t, "unknown", tags["account_id"])
 	assert.Equal(t, "unknown", tags["image_name"])
 	assert.Equal(t, "unknown", tags["resource_id"])
+	assert.Equal(t, "unknown", tags["lambda_microvm_image_version"])
 	assert.Equal(t, MicroVMResourceType, tags["resource_type"])
 	assert.Equal(t, "aws", tags["resource_provider"])
+}
+
+// TestMicroVMGetTagsImageVersionIndependentOfARN proves the image version tag
+// is read independently of the ARN: it's populated even when the ARN env var
+// (and thus all ARN-derived tags) is unset.
+func TestMicroVMGetTagsImageVersionIndependentOfARN(t *testing.T) {
+	t.Setenv(serverlessenv.MicroVMImageVersionEnvVar, testImageVersion)
+	m := &MicroVM{}
+	tags := m.GetTags()
+
+	assert.Equal(t, testImageVersion, tags["lambda_microvm_image_version"])
+	assert.Equal(t, "unknown", tags["resource_id"])
+	assert.Equal(t, "unknown", tags["region"])
+	assert.Equal(t, "unknown", tags["account_id"])
+	assert.Equal(t, "unknown", tags["image_name"])
 }
 
 func TestMicroVMGetEnhancedMetricTags(t *testing.T) {
@@ -215,8 +234,9 @@ func TestMicroVM_LogsTagSetter_InvokedOnRun(t *testing.T) {
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	// This is the call Init makes when lc.LogsTagSetter != nil.
 	srv.SetLogsTagSetter(setter, baseTags)
@@ -275,8 +295,9 @@ func TestMicroVM_TraceTagSetter_InvokedOnRun(t *testing.T) {
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	// This is the call Init makes when lc.TraceTagSetter != nil.
 	srv.SetTraceTagSetter(setter, baseTraceTags)
@@ -352,8 +373,9 @@ func TestMicroVMShutdown_LiveServer_StopsCleanly(t *testing.T) {
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	require.NoError(t, srv.ListenAndServe(nil))
 

--- a/cmd/serverless-init/enhanced-metrics/collector.go
+++ b/cmd/serverless-init/enhanced-metrics/collector.go
@@ -78,10 +78,15 @@ type Collector struct {
 	usageMetricSuffix  string
 	// Previous stats for rate calculation
 	previousRateStats ServerlessRateStats
+	// usageMetricTagsFunc, when non-nil, is called on every collection tick to
+	// obtain extra tags for the enhanced usage metric — e.g. MicroVM's
+	// per-instance tag, which is only known once the /run lifecycle hook
+	// fires. nil for every cloud service that has no such dynamic tag.
+	usageMetricTagsFunc func() []string
 }
 
-// NewCollector creates a new Collector
-func NewCollector(metricAgent EnhancedMetricSender, metricSource metrics.MetricSource, metricPrefix string, usageMetricSuffix string, collectionInterval time.Duration) (*Collector, error) {
+// NewCollector creates a new Collector. usageMetricTagsFunc may be nil.
+func NewCollector(metricAgent EnhancedMetricSender, metricSource metrics.MetricSource, metricPrefix string, usageMetricSuffix string, collectionInterval time.Duration, usageMetricTagsFunc func() []string) (*Collector, error) {
 	if metricAgent == nil || reflect.ValueOf(metricAgent).IsNil() {
 		return nil, errors.New("metricAgent cannot be nil")
 	}
@@ -92,13 +97,14 @@ func NewCollector(metricAgent EnhancedMetricSender, metricSource metrics.MetricS
 	}
 
 	return &Collector{
-		metricAgent:        metricAgent,
-		metricSource:       metricSource,
-		cgroupReader:       cgroupReader,
-		collectionInterval: collectionInterval,
-		metricPrefix:       metricPrefix + "enhanced.",
-		usageMetricSuffix:  usageMetricSuffix,
-		previousRateStats:  NullServerlessRateStats,
+		metricAgent:         metricAgent,
+		metricSource:        metricSource,
+		cgroupReader:        cgroupReader,
+		collectionInterval:  collectionInterval,
+		metricPrefix:        metricPrefix + "enhanced.",
+		usageMetricSuffix:   usageMetricSuffix,
+		previousRateStats:   NullServerlessRateStats,
+		usageMetricTagsFunc: usageMetricTagsFunc,
 	}, nil
 }
 
@@ -151,7 +157,11 @@ func (c *Collector) collect() {
 
 	// Always send the usage metric, regardless of cgroup collection success.
 	if c.usageMetricSuffix != "" {
-		c.metricAgent.AddEnhancedUsageMetric(c.metricPrefix+c.usageMetricSuffix, 1, c.metricSource, timestamp)
+		var extraTags []string
+		if c.usageMetricTagsFunc != nil {
+			extraTags = c.usageMetricTagsFunc()
+		}
+		c.metricAgent.AddEnhancedUsageMetric(c.metricPrefix+c.usageMetricSuffix, 1, c.metricSource, timestamp, extraTags...)
 	}
 
 	if err := c.cgroupReader.RefreshCgroups(0); err != nil {

--- a/cmd/serverless-init/enhanced-metrics/collector_test.go
+++ b/cmd/serverless-init/enhanced-metrics/collector_test.go
@@ -310,14 +310,93 @@ func TestCollectorSendsUsageMetricOnCgroupFailure(t *testing.T) {
 
 func TestNewCollectorNilMetricAgent(t *testing.T) {
 	// Untyped nil interface.
-	c, err := NewCollector(nil, metrics.MetricSourceGoogleCloudRunEnhanced, "gcp.run.", "instance", time.Second)
+	c, err := NewCollector(nil, metrics.MetricSourceGoogleCloudRunEnhanced, "gcp.run.", "instance", time.Second, nil)
 	assert.Nil(t, c)
 	assert.Error(t, err)
 
 	// Typed nil implementing EnhancedMetricSender, which is what main.go passes
 	// when metricAgent is a nil *ServerlessMetricAgent (use_dogstatsd disabled).
 	var typedNil *mockEnhancedMetricSender
-	c, err = NewCollector(typedNil, metrics.MetricSourceGoogleCloudRunEnhanced, "gcp.run.", "instance", time.Second)
+	c, err = NewCollector(typedNil, metrics.MetricSourceGoogleCloudRunEnhanced, "gcp.run.", "instance", time.Second, nil)
 	assert.Nil(t, c)
 	assert.Error(t, err)
+}
+
+// TestCollectorUsageMetricIncludesDynamicTags verifies that when
+// usageMetricTagsFunc is set (MicroVM's use case: attaching the per-instance
+// tag once known from /run), its return value is forwarded as extraTags on
+// every AddEnhancedUsageMetric call.
+func TestCollectorUsageMetricIncludesDynamicTags(t *testing.T) {
+	mockAgent := new(mockEnhancedMetricSender)
+	mockAgent.On("AddEnhancedUsageMetric", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+	mockReader := &mockCgroupReader{refreshErr: errors.New("cgroup failure"), version: 1}
+
+	c := &Collector{
+		metricAgent:         mockAgent,
+		metricSource:        metrics.MetricSourceAWSMicroVMEnhanced,
+		cgroupReader:        mockReader,
+		metricPrefix:        "aws.lambda.microvm.enhanced.",
+		usageMetricSuffix:   "instance",
+		previousRateStats:   NullServerlessRateStats,
+		usageMetricTagsFunc: func() []string { return []string{"instance:vm-abc123"} },
+	}
+
+	c.collect()
+
+	mockAgent.AssertCalled(t, "AddEnhancedUsageMetric",
+		"aws.lambda.microvm.enhanced.instance", float64(1),
+		metrics.MetricSourceAWSMicroVMEnhanced, mock.Anything, []string{"instance:vm-abc123"})
+}
+
+// TestCollectorUsageMetricNilTagsFuncSendsNoExtraTags verifies that when
+// usageMetricTagsFunc is nil (every cloud service except MicroVM), no extra
+// tags are added to the usage metric — pinning today's behavior.
+func TestCollectorUsageMetricNilTagsFuncSendsNoExtraTags(t *testing.T) {
+	mockAgent := new(mockEnhancedMetricSender)
+	mockAgent.On("AddEnhancedUsageMetric", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+	mockReader := &mockCgroupReader{refreshErr: errors.New("cgroup failure"), version: 1}
+
+	c := &Collector{
+		metricAgent:       mockAgent,
+		metricSource:      metrics.MetricSourceGoogleCloudRunEnhanced,
+		cgroupReader:      mockReader,
+		metricPrefix:      "gcp.run.container.enhanced.",
+		usageMetricSuffix: "instance",
+		previousRateStats: NullServerlessRateStats,
+	}
+
+	c.collect()
+
+	mockAgent.AssertCalled(t, "AddEnhancedUsageMetric",
+		"gcp.run.container.enhanced.instance", float64(1),
+		metrics.MetricSourceGoogleCloudRunEnhanced, mock.Anything, []string(nil))
+}
+
+// TestNewCollectorWiresUsageMetricTagsFunc verifies that NewCollector stores
+// the provided usageMetricTagsFunc on the returned Collector so collect()
+// picks it up on every tick.
+func TestNewCollectorWiresUsageMetricTagsFunc(t *testing.T) {
+	mockAgent := new(mockEnhancedMetricSender)
+	tagsFunc := func() []string { return []string{"instance:vm-abc123"} }
+
+	c, err := NewCollector(mockAgent, metrics.MetricSourceAWSMicroVMEnhanced, "aws.lambda.microvm.", "instance", time.Second, tagsFunc)
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, c.usageMetricTagsFunc) {
+		assert.Equal(t, []string{"instance:vm-abc123"}, c.usageMetricTagsFunc())
+	}
+}
+
+// TestNewCollectorNilUsageMetricTagsFuncIsAccepted verifies that
+// NewCollector accepts a nil usageMetricTagsFunc — the case for every cloud
+// service except MicroVM.
+func TestNewCollectorNilUsageMetricTagsFuncIsAccepted(t *testing.T) {
+	mockAgent := new(mockEnhancedMetricSender)
+
+	c, err := NewCollector(mockAgent, metrics.MetricSourceGoogleCloudRunEnhanced, "gcp.run.container.", "instance", time.Second, nil)
+
+	assert.NoError(t, err)
+	assert.Nil(t, c.usageMetricTagsFunc)
 }

--- a/cmd/serverless-init/enhanced-metrics/collector_test.go
+++ b/cmd/serverless-init/enhanced-metrics/collector_test.go
@@ -321,3 +321,27 @@ func TestNewCollectorNilMetricAgent(t *testing.T) {
 	assert.Nil(t, c)
 	assert.Error(t, err)
 }
+
+// TestCollectorUsageMetricNilTagsFuncSendsNoExtraTags verifies that the usage
+// metric is sent without any extra tags — pinning today's behavior.
+func TestCollectorUsageMetricNilTagsFuncSendsNoExtraTags(t *testing.T) {
+	mockAgent := new(mockEnhancedMetricSender)
+	mockAgent.On("AddEnhancedUsageMetric", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+	mockReader := &mockCgroupReader{refreshErr: errors.New("cgroup failure"), version: 1}
+
+	c := &Collector{
+		metricAgent:       mockAgent,
+		metricSource:      metrics.MetricSourceGoogleCloudRunEnhanced,
+		cgroupReader:      mockReader,
+		metricPrefix:      "gcp.run.container.enhanced.",
+		usageMetricSuffix: "instance",
+		previousRateStats: NullServerlessRateStats,
+	}
+
+	c.collect()
+
+	mockAgent.AssertCalled(t, "AddEnhancedUsageMetric",
+		"gcp.run.container.enhanced.instance", float64(1),
+		metrics.MetricSourceGoogleCloudRunEnhanced, mock.Anything, []string(nil))
+}

--- a/cmd/serverless-init/enhanced-metrics/collector_unsupported.go
+++ b/cmd/serverless-init/enhanced-metrics/collector_unsupported.go
@@ -20,7 +20,7 @@ type EnhancedMetricSender interface{}
 
 type Collector struct{}
 
-func NewCollector(_ EnhancedMetricSender, _ metrics.MetricSource, _ string, _ string, _ time.Duration) (*Collector, error) {
+func NewCollector(_ EnhancedMetricSender, _ metrics.MetricSource, _ string, _ string, _ time.Duration, _ func() []string) (*Collector, error) {
 	return nil, errors.New("Collector is only supported on Linux")
 }
 

--- a/cmd/serverless-init/lifecycle/config.go
+++ b/cmd/serverless-init/lifecycle/config.go
@@ -11,6 +11,8 @@ import (
 	"math"
 	"strconv"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // DefaultPort is the port the MicroVM platform expects the lifecycle hook server on.
@@ -30,6 +32,38 @@ const ReadyTimeoutMsEnvVar = "DD_AWS_MICROVM_READY_TIMEOUT_MS"
 
 // ValidateTimeoutMsEnvVar overrides the timeout (ms) for /validate.
 const ValidateTimeoutMsEnvVar = "DD_AWS_MICROVM_VALIDATE_TIMEOUT_MS"
+
+// EnableReadyEnvVar opts the /ready hook into forwarding. Requires UserAppPortEnvVar too; defaults to false.
+const EnableReadyEnvVar = "DD_AWS_MICROVM_ENABLE_READY"
+
+// EnableValidateEnvVar opts the /validate hook into forwarding. Requires UserAppPortEnvVar too; defaults to false.
+const EnableValidateEnvVar = "DD_AWS_MICROVM_ENABLE_VALIDATE"
+
+// EnableRunEnvVar opts the /run hook into forwarding. Requires UserAppPortEnvVar too; defaults to false.
+const EnableRunEnvVar = "DD_AWS_MICROVM_ENABLE_RUN"
+
+// EnableResumeEnvVar opts the /resume hook into forwarding. Requires UserAppPortEnvVar too; defaults to false.
+const EnableResumeEnvVar = "DD_AWS_MICROVM_ENABLE_RESUME"
+
+// EnableSuspendEnvVar opts the /suspend hook into forwarding. Requires UserAppPortEnvVar too; defaults to false.
+const EnableSuspendEnvVar = "DD_AWS_MICROVM_ENABLE_SUSPEND"
+
+// EnableTerminateEnvVar opts the /terminate hook into forwarding. Requires UserAppPortEnvVar too; defaults to false.
+const EnableTerminateEnvVar = "DD_AWS_MICROVM_ENABLE_TERMINATE"
+
+// HookToggles controls, per lifecycle hook, whether the hook is forwarded to
+// the user app (true) or handled by the agent itself (false, the default).
+// A hook is only actually forwarded when both its toggle is true AND a
+// Forwarder is configured (UserAppPortEnvVar set); a toggle set to true with
+// no Forwarder configured has no effect (see setupComponents in wire.go).
+type HookToggles struct {
+	Ready     bool
+	Validate  bool
+	Run       bool
+	Resume    bool
+	Suspend   bool
+	Terminate bool
+}
 
 // parsePort parses a port number from a raw env-var string.
 // Returns defaultVal when raw is empty. Parsed port must not equal any value in forbidden.
@@ -68,4 +102,20 @@ func parseDurationMs(envVar, raw string, defaultVal time.Duration) (time.Duratio
 		return 0, fmt.Errorf("%s: too large to represent as a duration (got %d ms)", envVar, ms)
 	}
 	return time.Duration(ms) * time.Millisecond, nil
+}
+
+// parseBoolFlag parses a boolean env var. Returns defaultVal when raw is
+// empty. Unlike parsePort/parseDurationMs, a malformed (non-empty, non-bool)
+// value does not fail setup — it logs a warning and falls back to defaultVal,
+// so a typo in one hook's toggle cannot take down the others.
+func parseBoolFlag(envVar, raw string, defaultVal bool) bool {
+	if raw == "" {
+		return defaultVal
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		log.Warnf("%s: invalid boolean value %q; using default %t", envVar, raw, defaultVal)
+		return defaultVal
+	}
+	return v
 }

--- a/cmd/serverless-init/lifecycle/config_test.go
+++ b/cmd/serverless-init/lifecycle/config_test.go
@@ -151,3 +151,29 @@ func TestParseDurationMs_RejectsOverflow(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, ForwardTimeoutMsEnvVar)
 }
+
+// --- parseBoolFlag ---
+
+func TestParseBoolFlag_UnsetReturnsDefault(t *testing.T) {
+	assert.False(t, parseBoolFlag(EnableRunEnvVar, "", false))
+	assert.True(t, parseBoolFlag(EnableRunEnvVar, "", true))
+}
+
+func TestParseBoolFlag_ValidTrue(t *testing.T) {
+	assert.True(t, parseBoolFlag(EnableRunEnvVar, "true", false))
+}
+
+func TestParseBoolFlag_ValidFalse(t *testing.T) {
+	assert.False(t, parseBoolFlag(EnableRunEnvVar, "false", true))
+}
+
+// TestParseBoolFlag_Malformed_FallsBackToDefault verifies that a malformed
+// (non-empty, non-bool) value does not error — it logs a warning and falls
+// back to defaultVal, so a typo in one hook's toggle cannot fail the whole
+// lifecycle setup the way an invalid port or timeout does.
+func TestParseBoolFlag_Malformed_FallsBackToDefault(t *testing.T) {
+	for _, raw := range []string{"yes", "on", "enabled", "2"} {
+		assert.False(t, parseBoolFlag(EnableRunEnvVar, raw, false), "raw=%q should fall back to default", raw)
+		assert.True(t, parseBoolFlag(EnableRunEnvVar, raw, true), "raw=%q should fall back to default", raw)
+	}
+}

--- a/cmd/serverless-init/lifecycle/forwarder.go
+++ b/cmd/serverless-init/lifecycle/forwarder.go
@@ -27,10 +27,24 @@ import (
 const defaultMaxResponseBodyBytes int64 = 1 << 20
 
 const (
+	// Per AWS, Run/Resume/Suspend/Terminate: 1 second
+	// Ready/Validate: 30 seconds
 	defaultForwardTimeout  = 1 * time.Second
-	defaultReadyTimeout    = 60 * time.Second
-	defaultValidateTimeout = 1 * time.Second
+	defaultReadyTimeout    = 30 * time.Second
+	defaultValidateTimeout = 30 * time.Second
 )
+
+// dialCheckTimeout bounds the single TCP dial attempt PassThroughWaiting uses
+// to check user-app reachability for /ready and /validate. Per the hook
+// contract, the platform — not the hook — owns the retry loop for these two
+// hooks, so the check must answer fast rather than block until the app is up.
+// A refused loopback connection fails in microseconds (the kernel sends RST
+// immediately), so this timeout only matters for a slow/hung connect (e.g.
+// host scheduling jitter on an oversubscribed MicroVM host). 200ms is
+// generous enough to absorb that jitter while staying well inside the "answer
+// fast" contract, and costs at most one extra platform retry (a 503) on the
+// rare call where it's hit.
+const dialCheckTimeout = 200 * time.Millisecond
 
 // Forwarder POSTs lifecycle hooks to the user app. It is constructed only
 // when DD_AWS_MICROVM_USER_APP_PORT is set and we're in init-container
@@ -39,8 +53,8 @@ type Forwarder struct {
 	target               string        // e.g. "http://127.0.0.1:8080"
 	client               *http.Client  // shared; no client-level Timeout (per-call deadlines via ctx)
 	forwardTimeout       time.Duration // default 1s, used for suspend/terminate/run/resume
-	readyTimeout         time.Duration // default 60s, used for /ready
-	validateTimeout      time.Duration // default 1s, used for /validate
+	readyTimeout         time.Duration // default 30s, used for /ready
+	validateTimeout      time.Duration // default 30s, used for /validate
 	maxResponseBodyBytes int64         // default defaultMaxResponseBodyBytes; cap on user-app body surfaced to platform
 }
 
@@ -83,63 +97,58 @@ func NewForwarder(port int, forwardTimeout, readyTimeout, validateTimeout time.D
 	}
 }
 
-// PassThroughWaiting waits for the user app to accept TCP connections bounded
-// by timeout, then forwards the request and mirrors the response. Used for:
+// PassThroughWaiting checks user-app reachability with a single fast TCP dial
+// (bounded by dialCheckTimeout), then forwards the request bounded by timeout
+// and mirrors the response. Used for:
 //   - /ready    ("I am booted and ready to be snapshotted"): the platform
-//     retries on non-200, so the TCP wait absorbs the startup race.
+//     retries on non-200 until its own configured timeout, so the hook
+//     answers fast rather than blocking on the startup race.
 //   - /validate ("I was resumed from a snapshot and everything is good"): the
-//     TCP wait handles a crash-then-restart between resume and this
-//     call.
+//     same fast-answer contract applies to the crash-then-restart window
+//     between resume and this call.
 //
-// Body is buffered before the TCP wait so the bytes survive waitForUserApp.
-// Deadline exceeded maps to 504. Body Close contract documented on PassThrough.
+// Per the /ready and /validate hook contract, only 200 and 503 are meaningful
+// responses — the platform retries on 503 until its own configured timeout,
+// while any other non-200 (including 504) fails the build. So unlike
+// PassThrough, an unreachable app or a deadline exceeded here always maps to
+// 503, never 504. Body Close contract documented on PassThrough.
 func (f *Forwarder) PassThroughWaiting(timeout time.Duration, path string, headers http.Header, body io.Reader) *http.Response {
 	var bodyBytes []byte
 	if body != nil {
 		var err error
-		// Read the full inbound body before the TCP wait. A read error is a
-		// server-side failure (network, OS, memory) — not a client mistake —
-		// so return 500 rather than 400. We still forward nothing to the user
-		// app to avoid passing a partial body (which could make it answer
-		// /validate "healthy" off incomplete data).
+		// Read the full inbound body before the reachability check. A read
+		// error is a server-side failure (network, OS, memory) — not a client
+		// mistake — so return 500 rather than 400. We still forward nothing to
+		// the user app to avoid passing a partial body (which could make it
+		// answer /validate "healthy" off incomplete data).
 		if bodyBytes, err = io.ReadAll(body); err != nil {
 			return statusOnlyResponse(http.StatusInternalServerError)
 		}
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	if err := f.waitForUserApp(ctx); err != nil {
-		cancel()
-		return statusOnlyResponse(mapErrToStatus(err))
+	if !f.reachable(dialCheckTimeout) {
+		return statusOnlyResponse(http.StatusServiceUnavailable)
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	resp, err := f.do(ctx, path, headers, bytes.NewReader(bodyBytes))
 	if err != nil {
 		cancel()
-		return statusOnlyResponse(mapErrToStatus(err))
+		return statusOnlyResponse(http.StatusServiceUnavailable)
 	}
 	resp.Body = wrapResponseBody(resp.Body, f.maxResponseBodyBytes, cancel)
 	return resp
 }
 
-// waitForUserApp polls the user app's TCP port until a connection succeeds or
-// ctx is cancelled. Returns nil when the port is reachable, ctx.Err() when
-// the deadline is exceeded. Polls every 50ms.
-func (f *Forwarder) waitForUserApp(ctx context.Context) error {
+// reachable performs a single TCP dial attempt to the user app, bounded by
+// timeout. No polling/retrying: per the hook contract, the platform (not the
+// hook) owns the retry loop for /ready and /validate.
+func (f *Forwarder) reachable(timeout time.Duration) bool {
 	addr := strings.TrimPrefix(f.target, "http://")
-	dialer := &net.Dialer{}
-	ticker := time.NewTicker(50 * time.Millisecond)
-	defer ticker.Stop()
-	for {
-		conn, err := dialer.DialContext(ctx, "tcp", addr)
-		if err == nil {
-			_ = conn.Close()
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-		}
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return false
 	}
+	_ = conn.Close()
+	return true
 }
 
 // PassThrough forwards a per-MicroVM lifecycle hook (/run, /resume,

--- a/cmd/serverless-init/lifecycle/forwarder_test.go
+++ b/cmd/serverless-init/lifecycle/forwarder_test.go
@@ -134,15 +134,15 @@ func TestNewForwarder_DisableKeepAlives_OpensNewConnectionPerRequest(t *testing.
 		"DisableKeepAlives must open a fresh TCP connection per request; with keep-alives enabled only 1 connection would be accepted")
 }
 
-// NewForwarder defaults reflect the configured wire.go constants. /ready keeps
-// a 60s budget (matches the platform hook timeout); the remaining hooks default
-// to 1s. Changing these defaults is a deliberate behavior change — the test
-// failure is intentional.
+// NewForwarder defaults reflect the configured wire.go constants. /ready and
+// /validate each keep a 30s budget, and runtime hooks default to 1s. Changing
+// these defaults is a deliberate behavior change — the test failure is
+// intentional.
 func TestNewForwarder_Defaults(t *testing.T) {
 	f := NewForwarder(8080, defaultForwardTimeout, defaultReadyTimeout, defaultValidateTimeout)
 	assert.Equal(t, 1*time.Second, f.forwardTimeout, "forwardTimeout default must be 1s")
-	assert.Equal(t, 60*time.Second, f.readyTimeout, "readyTimeout default must be 60s (matches platform /ready hook timeout)")
-	assert.Equal(t, 1*time.Second, f.validateTimeout, "validateTimeout default must be 1s")
+	assert.Equal(t, 30*time.Second, f.readyTimeout, "readyTimeout default must be 30s (matches platform /ready hook timeout)")
+	assert.Equal(t, 30*time.Second, f.validateTimeout, "validateTimeout default must be 30s")
 	assert.Equal(t, defaultMaxResponseBodyBytes, f.maxResponseBodyBytes, "maxResponseBodyBytes default must be 1 MiB")
 	tr, ok := f.client.Transport.(*http.Transport)
 	require.True(t, ok, "transport must be *http.Transport")
@@ -267,7 +267,8 @@ func TestForwarder_PassThroughWaiting_MirrorsStatusAndBody(t *testing.T) {
 // PassThroughWaiting must honor the timeout it receives. The caller (server.go)
 // passes readyTimeout or validateTimeout — PassThroughWaiting must not apply
 // any other field. This test uses a 50ms timeout against a 200ms upstream: the
-// context expires and the call returns 504.
+// context expires and the call returns 503 (per the /ready and /validate hook
+// contract, only 200 and 503 are meaningful — never 504).
 func TestForwarder_PassThroughWaiting_HonorsProvidedTimeout(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(200 * time.Millisecond)
@@ -279,8 +280,8 @@ func TestForwarder_PassThroughWaiting_HonorsProvidedTimeout(t *testing.T) {
 	resp := f.PassThroughWaiting(50*time.Millisecond, "/ready", nil, nil)
 	require.NotNil(t, resp)
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusGatewayTimeout, resp.StatusCode,
-		"PassThroughWaiting must time out on the provided timeout")
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"PassThroughWaiting must time out on the provided timeout and return 503, never 504")
 }
 
 // On the happy path the response body is wrapped by cancelOnCloseReader.
@@ -329,29 +330,36 @@ func TestWrapResponseBody_CapZero_DisablesCap(t *testing.T) {
 		"cap=0 must read the full body — LimitReader must NOT be applied")
 }
 
-// PassThroughWaiting retries TCP dials until the context expires when the port
-// is unbound, so the response is always 504 (deadline exceeded) — never 503.
-// This is distinct from PassThrough which returns 503 on the very first
-// connect-refused error. The behavioral difference is intentional: /ready and
-// /validate must wait for the user app to start, not fail-fast on a transient
-// dial error.
-func TestForwarder_PassThroughWaiting_UnboundPort_RetriesUntilTimeout504(t *testing.T) {
+// PassThroughWaiting makes a single reachability dial attempt, bounded by
+// dialCheckTimeout — it must not retry/poll, and must not wait out the
+// timeout parameter, before answering. Per the hook contract the platform
+// (not the hook) owns the retry loop for /ready and /validate, so an
+// unreachable app must return 503 fast, the same fail-fast contract
+// PassThrough already applies to connect-refused errors.
+func TestForwarder_PassThroughWaiting_UnboundPort_FailsFastWith503(t *testing.T) {
 	f := &Forwarder{
-		target: "http://127.0.0.1:1", // unbound — every dial attempt is refused
+		target: "http://127.0.0.1:1", // unbound — dial attempt is refused
 		client: &http.Client{},
 	}
-	resp := f.PassThroughWaiting(150*time.Millisecond, "/ready", nil, nil)
+	start := time.Now()
+	// timeout is deliberately much larger than dialCheckTimeout so a passing
+	// assertion below can only be explained by the fast dial-check path, not
+	// by this parameter.
+	resp := f.PassThroughWaiting(2*time.Second, "/ready", nil, nil)
+	elapsed := time.Since(start)
 	require.NotNil(t, resp)
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusGatewayTimeout, resp.StatusCode,
-		"unbound port must retry until timeout (504), not immediately 503 like PassThrough")
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"unreachable app must return 503, not 504")
+	assert.Less(t, elapsed, dialCheckTimeout+100*time.Millisecond,
+		"an unreachable app must fail within dialCheckTimeout, not retry until the much larger timeout parameter (2s) elapses")
 }
 
-// passThroughWaiting buffers the request body before the TCP wait so it is
-// still available after waitForUserApp returns. Without buffering, the body
-// reader would be exhausted during the wait loop and f.do would send an empty
-// body to the user app. This pins the buffer-then-forward contract.
-func TestForwarder_PassThroughWaiting_ForwardsBodyAfterTCPWait(t *testing.T) {
+// passThroughWaiting buffers the request body before the reachability check
+// so it is still available once that check returns. Without buffering, the
+// body reader would be exhausted during the dial attempt and f.do would send
+// an empty body to the user app. This pins the buffer-then-forward contract.
+func TestForwarder_PassThroughWaiting_ForwardsBodyAfterReachabilityCheck(t *testing.T) {
 	received := make(chan []byte, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		b, _ := io.ReadAll(r.Body)
@@ -381,7 +389,8 @@ func (errReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
 
 // A failed read of the inbound body must NOT forward a partial body to the
 // user app. PassThroughWaiting returns 500 (server-side read failure) and
-// short-circuits before the TCP wait so no partial body reaches the user app.
+// short-circuits before the reachability check so no partial body reaches the
+// user app.
 func TestForwarder_PassThroughWaiting_BodyReadError_Returns500(t *testing.T) {
 	var reached atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/cmd/serverless-init/lifecycle/heartbeat.go
+++ b/cmd/serverless-init/lifecycle/heartbeat.go
@@ -61,7 +61,7 @@ type Heartbeat struct {
 	// construction. Supplied by cloudservice.MicroVM.Init, which currently
 	// passes a single entry: "microvm_image_arn:<arn>" (the raw image ARN from
 	// AWS_LAMBDA_MICROVM_IMAGE_ARN, or "unknown" when the env var is unset). The
-	// per-emit "microvm_id:<id>" tag is appended separately in tagsForEmit.
+	// per-emit "lambda_microvm_id:<id>" tag is appended separately in tagsForEmit.
 	baseTags []string
 
 	mu          sync.Mutex
@@ -74,7 +74,7 @@ type Heartbeat struct {
 // NewHeartbeat constructs a Heartbeat. Non-positive interval falls back to
 // DefaultHeartbeatInterval. baseTags are tags known at construction time
 // (typically derived from env vars, e.g., microvm_image_arn); the
-// microvm_id tag is appended at emit time and is set at runtime via
+// lambda_microvm_id tag is appended at emit time and is set at runtime via
 // SetMicroVMID from the /run request.
 func NewHeartbeat(interval time.Duration, emitter MetricEmitter, source metrics.MetricSource, baseTags []string) *Heartbeat {
 	if interval <= 0 {
@@ -220,13 +220,13 @@ func (h *Heartbeat) emit() {
 }
 
 // tagsForEmit returns a fresh tag slice combining the immutable base tags
-// (set at construction) with the current microvm_id (set at /run).
+// (set at construction) with the current lambda_microvm_id (set at /run).
 func (h *Heartbeat) tagsForEmit() []string {
 	h.mu.Lock()
 	id := h.microVMID
 	h.mu.Unlock()
 	tags := make([]string, 0, len(h.baseTags)+1)
 	tags = append(tags, h.baseTags...)
-	tags = append(tags, "microvm_id:"+id)
+	tags = append(tags, lambdaMicroVMIDPrefix+id)
 	return tags
 }

--- a/cmd/serverless-init/lifecycle/heartbeat_test.go
+++ b/cmd/serverless-init/lifecycle/heartbeat_test.go
@@ -275,15 +275,15 @@ func TestHeartbeat_ResumeDuringStuckStopRestartsHeartbeat(t *testing.T) {
 	hb.Stop() // clean up the relaunched goroutine
 }
 
-// Until SetMicroVMID is called, the heartbeat tags microvm_id with the
-// placeholder "unknown". Production wiring sets the ID at /run before
+// Until SetMicroVMID is called, the heartbeat tags lambda_microvm_id with
+// the placeholder "unknown". Production wiring sets the ID at /run before
 // Start, so this state should never reach an emitted metric in practice;
 // the test pins the contract anyway in case wiring changes.
 func TestHeartbeat_TagsForEmit_DefaultsMicroVMIDToUnknown(t *testing.T) {
 	hb := NewHeartbeat(time.Hour, &mockMetricEmitter{}, metrics.MetricSourceAWSMicroVMEnhanced, []string{"microvm_image_arn:test-arn"})
 	tags := hb.tagsForEmit()
 	assert.Contains(t, tags, "microvm_image_arn:test-arn")
-	assert.Contains(t, tags, "microvm_id:unknown")
+	assert.Contains(t, tags, "lambda_microvm_id:unknown")
 }
 
 // When resourceName is empty the microvm_image_arn tag must be absent — an
@@ -301,7 +301,7 @@ func TestHeartbeat_SetMicroVMID_ReflectsOnEmittedTags(t *testing.T) {
 	hb.SetMicroVMID("mvm-abc123")
 	tags := hb.tagsForEmit()
 	assert.Contains(t, tags, "microvm_image_arn:test-arn")
-	assert.Contains(t, tags, "microvm_id:mvm-abc123")
+	assert.Contains(t, tags, "lambda_microvm_id:mvm-abc123")
 }
 
 // TestHeartbeat_EmittedMetric_CarriesARNTag verifies end-to-end that the
@@ -340,7 +340,7 @@ func TestHeartbeat_SetMicroVMID_EmptyIsIgnored(t *testing.T) {
 	hb.SetMicroVMID("first-id")
 	hb.SetMicroVMID("")
 	tags := hb.tagsForEmit()
-	assert.Contains(t, tags, "microvm_id:first-id", "empty ID must not clobber the existing value")
+	assert.Contains(t, tags, "lambda_microvm_id:first-id", "empty ID must not clobber the existing value")
 }
 
 func TestHeartbeat_SetMicroVMID_OnNilReceiverIsSafe(t *testing.T) {
@@ -371,7 +371,7 @@ func TestHeartbeat_SetMicroVMID_VisibleOnNextTick(t *testing.T) {
 	// The most recent emission must carry the updated ID.
 	last := emitter.lastTags()
 	require.NotNil(t, last)
-	assert.Contains(t, last, "microvm_id:mvm-after-start")
+	assert.Contains(t, last, "lambda_microvm_id:mvm-after-start")
 }
 
 // TestHeartbeat_EmittedMetricsCarryCurrentTimestamp verifies that heartbeat

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -140,7 +140,7 @@ type LogsTagSetterFunc func([]string)
 func (f LogsTagSetterFunc) SetLogsTags(tags []string) { f(tags) }
 
 // TraceTagSetter can replace the full tag map on the live trace pipeline.
-// Satisfied by trace.ServerlessTraceAgent.SetTags (wrapped via TraceTagSetterFunc).
+// Satisfied by trace.ServerlessTraceAgent.UpdateRuntimeTags (wrapped via TraceTagSetterFunc).
 type TraceTagSetter interface {
 	SetTraceTags(tags map[string]string)
 }

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -32,10 +32,12 @@
 //   - When the env var is set: the agent forwards each hook to
 //     127.0.0.1:<user-app-port> on the same path and mirrors the user app's
 //     response (status, body, Content-Type) back to the platform. /ready and
-//     /validate wait for TCP reachability before forwarding. For /run,
-//     /resume, /suspend, and /terminate the agent's own work — metric
-//     emission, /suspend and /terminate telemetry flush — runs in a goroutine
-//     in parallel with the pass-through.
+//     /validate check TCP reachability with a single fast dial before
+//     forwarding, answering 503 immediately if the app isn't up yet rather
+//     than blocking — the platform owns the retry loop for those two hooks.
+//     For /run, /resume, /suspend, and /terminate the agent's own work —
+//     metric emission, /suspend and /terminate telemetry flush — runs in a
+//     goroutine in parallel with the pass-through.
 //
 // /terminate does NOT synthesize SIGTERM. The platform owns process
 // termination via OS signals delivered independently of this HTTP event.
@@ -233,14 +235,16 @@ func NewServer(
 		s.child = c
 	}
 	// WriteTimeout must cover the full wall-clock of every hook path (see
-	// forwardTimeout/readyTimeout/validateTimeout on Forwarder, and
-	// writeTimeoutHeadroom above), or the HTTP server closes the
-	// platform-facing connection before the handler finishes writing.
+	// forwardTimeout/readyTimeout/validateTimeout/dialCheckTimeout on
+	// Forwarder, and writeTimeoutHeadroom above), or the HTTP server closes
+	// the platform-facing connection before the handler finishes writing.
 	maxTimeout := s.flushTimeout
 	if s.fwd != nil {
 		// /terminate uses flushSequential: flush runs after the forward, so its
 		// wall-clock is forwardTimeout+flushTimeout, not max of the two.
-		maxTimeout = max(maxTimeout, s.fwd.forwardTimeout+s.flushTimeout, s.fwd.readyTimeout, s.fwd.validateTimeout)
+		readyBudget := dialCheckTimeout + s.fwd.readyTimeout
+		validateBudget := dialCheckTimeout + s.fwd.validateTimeout
+		maxTimeout = max(maxTimeout, s.fwd.forwardTimeout+s.flushTimeout, readyBudget, validateBudget)
 	}
 	writeTimeout := maxTimeout + writeTimeoutHeadroom
 	log.Debugf("MicroVM lifecycle: server WriteTimeout=%s (maxTimeout=%s + writeTimeoutHeadroom=%s)", writeTimeout, maxTimeout, writeTimeoutHeadroom)
@@ -316,6 +320,18 @@ func (s *Server) Child() *Child {
 // Exposed for white-box tests in external packages; not part of the stable API.
 func (s *Server) Heartbeat() *Heartbeat { return s.heartbeat }
 
+// InstanceID returns the MicroVM instance ID captured from /run, or "" if
+// /run has not fired yet (or the server is nil). Lets callers outside this
+// package — e.g. the enhanced-metrics collector — attach the current
+// per-instance tag to metrics emitted after Init, without this package
+// needing to know about metric-agent internals.
+func (s *Server) InstanceID() string {
+	if s == nil {
+		return ""
+	}
+	return s.instanceID.Load()
+}
+
 func (s *Server) handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc(postReady, s.handleReady)
@@ -333,7 +349,8 @@ func (s *Server) handler() http.Handler {
 //
 // Dispatcher:
 //   - If a Forwarder is configured (env-var opt-in), pass-through to the user
-//     app with TCP-wait: dial errors map to 503, deadline to 504.
+//     app with a fast reachability check: dial errors and deadline exceeded
+//     both map to 503.
 //   - Otherwise, alive-check via ChildHandle: child alive → 200, anything
 //     else (not yet started, already exited, or nil handle) → 503. The
 //     pre-spawn race is absorbed by the platform's /ready retry behavior;
@@ -361,9 +378,10 @@ func (s *Server) passThroughReady(w http.ResponseWriter, r *http.Request) {
 // lifecycle of a production MicroVM.
 //
 // When a Forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT set):
-// pass-through to the user app with TCP-wait, mirroring the response, so the
-// user app's own smoke test drives the build's validity decision. The TCP-wait
-// absorbs the window before the app is reachable on the test run. Without a
+// pass-through to the user app with a fast reachability check, mirroring the
+// response, so the user app's own smoke test drives the build's validity
+// decision. A 503 while the app isn't yet reachable on the test run relies on
+// the platform's own /validate retry to absorb the window. Without a
 // forwarder the agent returns 200 directly; the user app is not required to
 // implement /validate in that mode.
 func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
@@ -456,7 +474,8 @@ func (s *Server) flushAll(flushCtx context.Context) {
 //
 // Used for /run and /resume (noFlush), /suspend (flushParallel), and
 // /terminate (flushSequential). /ready and /validate use passThroughReady
-// and passThroughValidate directly (TCP-wait path, not this function).
+// and passThroughValidate directly (fast-reachability-check path, not this
+// function).
 //
 // flushParallel: flush runs concurrently with the forward; wall-clock is
 // max(forwardTimeout, flushTimeout)+ε. Known limitation: telemetry produced
@@ -559,7 +578,7 @@ func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, err := io.ReadAll(r.Body)
 	_ = r.Body.Close()
 	if err != nil {
-		log.Debugf("MicroVM lifecycle: could not read run body: %v", err)
+		log.Warnf("MicroVM lifecycle: could not read run body: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -32,10 +32,12 @@
 //   - When the env var is set: the agent forwards each hook to
 //     127.0.0.1:<user-app-port> on the same path and mirrors the user app's
 //     response (status, body, Content-Type) back to the platform. /ready and
-//     /validate wait for TCP reachability before forwarding. For /run,
-//     /resume, /suspend, and /terminate the agent's own work — metric
-//     emission, /suspend and /terminate telemetry flush — runs in a goroutine
-//     in parallel with the pass-through.
+//     /validate check TCP reachability with a single fast dial before
+//     forwarding, answering 503 immediately if the app isn't up yet rather
+//     than blocking — the platform owns the retry loop for those two hooks.
+//     For /run, /resume, /suspend, and /terminate the agent's own work —
+//     metric emission, /suspend and /terminate telemetry flush — runs in a
+//     goroutine in parallel with the pass-through.
 //
 // /terminate does NOT synthesize SIGTERM. The platform owns process
 // termination via OS signals delivered independently of this HTTP event.
@@ -151,6 +153,19 @@ type TraceTagSetterFunc func(map[string]string)
 // SetTraceTags implements TraceTagSetter.
 func (f TraceTagSetterFunc) SetTraceTags(tags map[string]string) { f(tags) }
 
+// MetricTagSetter can replace the tags on the enhanced usage metric.
+// Satisfied by ServerlessMetricAgent.SetEnhancedUsageMetricTags (wrapped via
+// MetricTagSetterFunc).
+type MetricTagSetter interface {
+	SetMetricTags(tags []string)
+}
+
+// MetricTagSetterFunc wraps a bare function so it satisfies MetricTagSetter.
+type MetricTagSetterFunc func([]string)
+
+// SetMetricTags implements MetricTagSetter.
+func (f MetricTagSetterFunc) SetMetricTags(tags []string) { f(tags) }
+
 // runBody is the JSON payload sent by the MicroVM platform on /run.
 type runBody struct {
 	MicroVMID string `json:"microvmId"`
@@ -172,10 +187,12 @@ type Server struct {
 	fwd         *Forwarder  // nil = no opt-in; today's behavior preserved
 	heartbeat   *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
 
-	logsTagSetter  LogsTagSetter     // nil-safe; set via SetLogsTagSetter after construction
-	baseLogTags    []string          // startup log tag snapshot; lambda_microvm_id is appended at /run
-	traceTagSetter TraceTagSetter    // nil-safe; set via SetTraceTagSetter after construction
-	baseTraceTags  map[string]string // startup trace tag snapshot; lambda_microvm_id is added at /run
+	logsTagSetter       LogsTagSetter     // nil-safe; set via SetLogsTagSetter after construction
+	baseLogTags         []string          // startup log tag snapshot; lambda_microvm_id is appended at /run
+	traceTagSetter      TraceTagSetter    // nil-safe; set via SetTraceTagSetter after construction
+	baseTraceTags       map[string]string // startup trace tag snapshot; lambda_microvm_id is added at /run
+	metricTagSetter     MetricTagSetter   // nil-safe; set via SetMetricTagSetter after construction
+	baseUsageMetricTags []string          // startup enhanced usage metric tag snapshot; instance:<id> is appended at /run
 
 	httpServer *http.Server
 	listener   net.Listener // set once ListenAndServe binds successfully
@@ -234,14 +251,16 @@ func NewServer(
 		s.child = c
 	}
 	// WriteTimeout must cover the full wall-clock of every hook path (see
-	// forwardTimeout/readyTimeout/validateTimeout on Forwarder, and
-	// writeTimeoutHeadroom above), or the HTTP server closes the
-	// platform-facing connection before the handler finishes writing.
+	// forwardTimeout/readyTimeout/validateTimeout/dialCheckTimeout on
+	// Forwarder, and writeTimeoutHeadroom above), or the HTTP server closes
+	// the platform-facing connection before the handler finishes writing.
 	maxTimeout := s.flushTimeout
 	if s.fwd != nil {
 		// /terminate uses flushSequential: flush runs after the forward, so its
 		// wall-clock is forwardTimeout+flushTimeout, not max of the two.
-		maxTimeout = max(maxTimeout, s.fwd.forwardTimeout+s.flushTimeout, s.fwd.readyTimeout, s.fwd.validateTimeout)
+		readyBudget := dialCheckTimeout + s.fwd.readyTimeout
+		validateBudget := dialCheckTimeout + s.fwd.validateTimeout
+		maxTimeout = max(maxTimeout, s.fwd.forwardTimeout+s.flushTimeout, readyBudget, validateBudget)
 	}
 	writeTimeout := maxTimeout + writeTimeoutHeadroom
 	log.Debugf("MicroVM lifecycle: server WriteTimeout=%s (maxTimeout=%s + writeTimeoutHeadroom=%s)", writeTimeout, maxTimeout, writeTimeoutHeadroom)
@@ -272,6 +291,14 @@ func (s *Server) SetLogsTagSetter(setter LogsTagSetter, baseLogTags []string) {
 func (s *Server) SetTraceTagSetter(setter TraceTagSetter, baseTraceTags map[string]string) {
 	s.traceTagSetter = setter
 	s.baseTraceTags = baseTraceTags
+}
+
+// SetMetricTagSetter wires a MetricTagSetter and baseline usage-metric tags
+// into the server. Optional; nil is a no-op. Must be called before the first
+// /run request. instance:<id> is appended to baseUsageMetricTags at /run.
+func (s *Server) SetMetricTagSetter(setter MetricTagSetter, baseUsageMetricTags []string) {
+	s.metricTagSetter = setter
+	s.baseUsageMetricTags = baseUsageMetricTags
 }
 
 // listen binds the TCP port synchronously. Call before serve so the socket is
@@ -348,6 +375,18 @@ func (s *Server) Child() *Child {
 // Exposed for white-box tests in external packages; not part of the stable API.
 func (s *Server) Heartbeat() *Heartbeat { return s.heartbeat }
 
+// InstanceID returns the MicroVM instance ID captured from /run, or "" if
+// /run has not fired yet (or the server is nil). Lets callers outside this
+// package — e.g. the enhanced-metrics collector — attach the current
+// per-instance tag to metrics emitted after Init, without this package
+// needing to know about metric-agent internals.
+func (s *Server) InstanceID() string {
+	if s == nil {
+		return ""
+	}
+	return s.instanceID.Load()
+}
+
 func (s *Server) handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc(postReady, s.handleReady)
@@ -365,7 +404,8 @@ func (s *Server) handler() http.Handler {
 //
 // Dispatcher:
 //   - If a Forwarder is configured (env-var opt-in), pass-through to the user
-//     app with TCP-wait: dial errors map to 503, deadline to 504.
+//     app with a fast reachability check: dial errors and deadline exceeded
+//     both map to 503.
 //   - Otherwise, alive-check via ChildHandle: child alive → 200, anything
 //     else (not yet started, already exited, or nil handle) → 503. The
 //     pre-spawn race is absorbed by the platform's /ready retry behavior;
@@ -393,9 +433,10 @@ func (s *Server) passThroughReady(w http.ResponseWriter, r *http.Request) {
 // lifecycle of a production MicroVM.
 //
 // When a Forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT set):
-// pass-through to the user app with TCP-wait, mirroring the response, so the
-// user app's own smoke test drives the build's validity decision. The TCP-wait
-// absorbs the window before the app is reachable on the test run. Without a
+// pass-through to the user app with a fast reachability check, mirroring the
+// response, so the user app's own smoke test drives the build's validity
+// decision. A 503 while the app isn't yet reachable on the test run relies on
+// the platform's own /validate retry to absorb the window. Without a
 // forwarder the agent returns 200 directly; the user app is not required to
 // implement /validate in that mode.
 func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
@@ -503,7 +544,8 @@ func (s *Server) waitForFlushes(flushCtx context.Context, wg *sync.WaitGroup) {
 //
 // Used for /run and /resume (noFlush), /suspend (flushParallel), and
 // /terminate (flushSequential). /ready and /validate use passThroughReady
-// and passThroughValidate directly (TCP-wait path, not this function).
+// and passThroughValidate directly (fast-reachability-check path, not this
+// function).
 //
 // flushParallel: flush runs concurrently with the forward; wall-clock is
 // max(forwardTimeout, flushTimeout)+ε. Known limitation: telemetry produced
@@ -606,7 +648,7 @@ func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, err := io.ReadAll(r.Body)
 	_ = r.Body.Close()
 	if err != nil {
-		log.Debugf("MicroVM lifecycle: could not read run body: %v", err)
+		log.Warnf("MicroVM lifecycle: could not read run body: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -628,6 +670,9 @@ func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 			}
 			tags[lambdaMicroVMIDKey] = body.MicroVMID
 			s.traceTagSetter.SetTraceTags(tags)
+		}
+		if s.metricTagSetter != nil {
+			s.metricTagSetter.SetMetricTags(append(append([]string{}, s.baseUsageMetricTags...), "instance:"+body.MicroVMID))
 		}
 	} else {
 		log.Info("MicroVM lifecycle: run")

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -21,23 +21,27 @@
 //   - /suspend  — VM is about to be snapshotted/frozen.
 //   - /terminate — VM is being torn down permanently.
 //
-// This server handles those hooks in two modes:
+// Each hook is forwarded independently based on a pair of conditions:
 //
-//   - When DD_AWS_MICROVM_USER_APP_PORT is unset: the agent responds
-//     to each hook itself. /ready checks child-process liveness; /validate
-//     returns 200 directly; /run, /resume, /suspend, and /terminate emit
-//     an enhanced metric and, for /suspend and /terminate, flush telemetry
-//     before responding.
+//   - DD_AWS_MICROVM_USER_APP_PORT must be set (a Forwarder is configured).
+//   - That hook's own DD_AWS_MICROVM_ENABLE_{READY,VALIDATE,RUN,RESUME,
+//     SUSPEND,TERMINATE} toggle must be true (defaults to false).
 //
-//   - When the env var is set: the agent forwards each hook to
-//     127.0.0.1:<user-app-port> on the same path and mirrors the user app's
-//     response (status, body, Content-Type) back to the platform. /ready and
-//     /validate check TCP reachability with a single fast dial before
-//     forwarding, answering 503 immediately if the app isn't up yet rather
-//     than blocking — the platform owns the retry loop for those two hooks.
-//     For /run, /resume, /suspend, and /terminate the agent's own work —
-//     metric emission, /suspend and /terminate telemetry flush — runs in a
-//     goroutine in parallel with the pass-through.
+// When both are true for a given hook, the agent forwards it to
+// 127.0.0.1:<user-app-port> on the same path and mirrors the user app's
+// response (status, body, Content-Type) back to the platform. /ready and
+// /validate check TCP reachability with a single fast dial before
+// forwarding, answering 503 immediately if the app isn't up yet rather than
+// blocking — the platform owns the retry loop for those two hooks. For
+// /run, /resume, /suspend, and /terminate the agent's own work — metric
+// emission, /suspend and /terminate telemetry flush — runs in a goroutine in
+// parallel with the pass-through.
+//
+// Otherwise (no Forwarder, or the hook's own toggle is false) the agent
+// responds to that hook itself: /ready checks child-process liveness;
+// /validate returns 200 directly; /run, /resume, /suspend, and /terminate
+// emit an enhanced metric and, for /suspend and /terminate, flush telemetry
+// before responding.
 //
 // /terminate does NOT synthesize SIGTERM. The platform owns process
 // termination via OS signals delivered independently of this HTTP event.
@@ -116,6 +120,15 @@ type Flusher interface {
 	Flush()
 }
 
+// ForceFlusher is optionally satisfied by metricFlusher (ServerlessMetricAgent
+// does; the trace flusher doesn't). flushAll calls it only for /terminate,
+// never /suspend: /suspend can resume, and forcing the open bucket there would
+// let a later flush send a second, partial point for that bucket — overwriting
+// the pre-suspend data in the backend instead of merging with it.
+type ForceFlusher interface {
+	FlushAll()
+}
+
 // LogsFlusher is satisfied by logsAgent.ServerlessLogsAgent.
 type LogsFlusher interface {
 	Flush(ctx context.Context)
@@ -182,10 +195,11 @@ type Server struct {
 	metricSource  metrics.MetricSource
 	flushTimeout  time.Duration
 
-	childHandle ChildHandle // production: *Child (init) or NewNoopChildHandle() (sidecar); always non-nil after lifecycle.SetupFromEnv. nil only in legacy unit tests; logs WARN if hit.
-	child       *Child      // non-nil only in init-container mode; nil in sidecar and unit tests. Derived from childHandle when it is a *Child.
-	fwd         *Forwarder  // nil = no opt-in; today's behavior preserved
-	heartbeat   *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
+	childHandle  ChildHandle // production: *Child (init) or NewNoopChildHandle() (sidecar); always non-nil after lifecycle.SetupFromEnv. nil only in legacy unit tests; logs WARN if hit.
+	child        *Child      // non-nil only in init-container mode; nil in sidecar and unit tests. Derived from childHandle when it is a *Child.
+	fwd          *Forwarder  // nil = no forwarder configured; forwarding also requires the hook's own enabledHooks.* toggle
+	enabledHooks HookToggles // per-hook forwarding opt-in; only meaningful when fwd != nil
+	heartbeat    *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
 
 	logsTagSetter       LogsTagSetter     // nil-safe; set via SetLogsTagSetter after construction
 	baseLogTags         []string          // startup log tag snapshot; lambda_microvm_id is appended at /run
@@ -230,6 +244,7 @@ func NewServer(
 	flushTimeout time.Duration,
 	childHandle ChildHandle, // may be nil
 	fwd *Forwarder, // may be nil
+	enabledHooks HookToggles, // only meaningful when fwd != nil
 	heartbeat *Heartbeat, // may be nil
 ) *Server {
 	s := &Server{
@@ -242,6 +257,7 @@ func NewServer(
 		flushTimeout:  flushTimeout,
 		childHandle:   childHandle,
 		fwd:           fwd,
+		enabledHooks:  enabledHooks,
 		instanceID:    atomic.NewString(""),
 		heartbeat:     heartbeat,
 	}
@@ -403,9 +419,9 @@ func (s *Server) handler() http.Handler {
 // causes a retry (the platform does not treat /ready failures as fatal).
 //
 // Dispatcher:
-//   - If a Forwarder is configured (env-var opt-in), pass-through to the user
-//     app with a fast reachability check: dial errors and deadline exceeded
-//     both map to 503.
+//   - If a Forwarder is configured AND the /ready hook is enabled
+//     (DD_AWS_MICROVM_ENABLE_READY), pass-through to the user app with a fast
+//     reachability check: dial errors and deadline exceeded both map to 503.
 //   - Otherwise, alive-check via ChildHandle: child alive → 200, anything
 //     else (not yet started, already exited, or nil handle) → 503. The
 //     pre-spawn race is absorbed by the platform's /ready retry behavior;
@@ -413,7 +429,7 @@ func (s *Server) handler() http.Handler {
 //     call site in mode.RunInit, where the actual error value is available.
 func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: ready")
-	if s.fwd != nil {
+	if s.fwd != nil && s.enabledHooks.Ready {
 		s.passThroughReady(w, r)
 		return
 	}
@@ -432,13 +448,13 @@ func (s *Server) passThroughReady(w http.ResponseWriter, r *http.Request) {
 // retry until validateTimeout. It is NOT sent during the normal run/resume
 // lifecycle of a production MicroVM.
 //
-// When a Forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT set):
-// pass-through to the user app with a fast reachability check, mirroring the
-// response, so the user app's own smoke test drives the build's validity
-// decision. A 503 while the app isn't yet reachable on the test run relies on
-// the platform's own /validate retry to absorb the window. Without a
-// forwarder the agent returns 200 directly; the user app is not required to
-// implement /validate in that mode.
+// When a Forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT set) AND the
+// /validate hook is enabled (DD_AWS_MICROVM_ENABLE_VALIDATE): pass-through to
+// the user app with a fast reachability check, mirroring the response, so the
+// user app's own smoke test drives the build's validity decision. A 503
+// while the app isn't yet reachable on the test run relies on the platform's
+// own /validate retry to absorb the window. Otherwise the agent returns 200
+// directly; the user app is not required to implement /validate in that mode.
 func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: validate")
 	// TODO(microvm-validate-metric): /validate is a build-time hook that only
@@ -448,7 +464,7 @@ func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
 	// may not reliably flush before the test VM is torn down. Revisit whether it
 	// carries enough value to keep alongside the genuine runtime lifecycle metrics.
 	s.emitLifecycleMetric(validateMetricName)
-	if s.fwd != nil {
+	if s.fwd != nil && s.enabledHooks.Validate {
 		s.passThroughValidate(w, r)
 		return
 	}
@@ -494,7 +510,8 @@ func mirrorResponse(w http.ResponseWriter, resp *http.Response) {
 // and by handleSuspend / handleTerminate for the env-var-unset path.
 // It first drains any pending metric samples so that lifecycle metrics
 // emitted immediately before this call are included in the flush.
-func (s *Server) flushAll(flushCtx context.Context) {
+// forceFlushAll is true only for /terminate (see ForceFlusher).
+func (s *Server) flushAll(flushCtx context.Context, forceFlushAll bool) {
 	if s.sampleDrainer != nil {
 		drained := make(chan struct{})
 		go func() {
@@ -508,7 +525,13 @@ func (s *Server) flushAll(flushCtx context.Context) {
 		}
 	}
 	var wg sync.WaitGroup
-	wg.Go(s.metricFlusher.Flush)
+	wg.Go(func() {
+		if ff, ok := s.metricFlusher.(ForceFlusher); ok && forceFlushAll {
+			ff.FlushAll()
+		} else {
+			s.metricFlusher.Flush()
+		}
+	})
 	wg.Go(s.traceFlusher.Flush)
 	wg.Go(func() {
 		if s.logsFlusher != nil {
@@ -574,7 +597,7 @@ func (s *Server) handleWithForwarder(metricName, path string, mode flushMode, w 
 		defer close(sideDone)
 		s.emitLifecycleMetric(metricName)
 		if mode == flushParallel {
-			s.flushAll(parallelCtx)
+			s.flushAll(parallelCtx, false)
 		}
 	}()
 
@@ -602,7 +625,7 @@ func (s *Server) handleWithForwarder(metricName, path string, mode flushMode, w 
 	if mode == flushSequential {
 		seqCtx, cancel := context.WithTimeout(context.Background(), s.flushTimeout)
 		defer cancel()
-		s.flushAll(seqCtx)
+		s.flushAll(seqCtx, true)
 	}
 
 	mirrorResponse(w, resp)
@@ -633,7 +656,7 @@ func (s *Server) aliveCheckReady(w http.ResponseWriter) {
 // (when a forwarder is configured) mirrors the user app's response.
 // handleRun is the only hook that reads r.Body and is therefore not
 // collapsed into dispatchHook directly. The ID is captured before Start
-// so the first heartbeat emission already carries the correct microvm_id tag.
+// so the first heartbeat emission already carries the correct lambda_microvm_id tag.
 func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 	// Read the body once so we can parse the instance ID AND still forward the
 	// original payload to the user app. Without this, the forwarder path would
@@ -685,15 +708,16 @@ func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 	// forwarded /run request carries a fixed Content-Length rather than
 	// chunked encoding (which some user-app HTTP servers reject).
 	r.Header.Set("Content-Length", strconv.Itoa(len(bodyBytes)))
-	s.dispatchHook(runMetricName, pathRun, noFlush, w, r)
+	s.dispatchHook(runMetricName, pathRun, noFlush, s.enabledHooks.Run, w, r)
 }
 
 // handleResume emits the resume metric, restarts the heartbeat (stopped at
-// /suspend), and (when a forwarder is configured) mirrors the user app's response.
+// /suspend), and (when a forwarder is configured and enabled) mirrors the
+// user app's response.
 func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: resume")
 	s.heartbeat.Start()
-	s.dispatchHook(resumeMetricName, pathResume, noFlush, w, r)
+	s.dispatchHook(resumeMetricName, pathResume, noFlush, s.enabledHooks.Resume, w, r)
 }
 
 // handleSuspend stops the heartbeat, flushes telemetry, and (when a forwarder
@@ -731,7 +755,7 @@ func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSuspend(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: suspend — flushing telemetry")
 	s.heartbeat.Stop()
-	s.dispatchHook(suspendMetricName, pathSuspend, flushParallel, w, r)
+	s.dispatchHook(suspendMetricName, pathSuspend, flushParallel, s.enabledHooks.Suspend, w, r)
 }
 
 // handleTerminate flushes all telemetry and, when a forwarder is configured,
@@ -748,17 +772,18 @@ func (s *Server) handleSuspend(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleTerminate(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: terminate — flushing telemetry")
 	s.heartbeat.Stop()
-	s.dispatchHook(terminateMetricName, pathTerminate, flushSequential, w, r)
+	s.dispatchHook(terminateMetricName, pathTerminate, flushSequential, s.enabledHooks.Terminate, w, r)
 }
 
 // dispatchHook is the shared dispatch path for run, resume, suspend, and
 // terminate. When a forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT
-// set): delegates to handleWithForwarder which mirrors the user app's response.
-// When no forwarder is configured: emit metric, optionally flush, return 200.
-// In standalone mode the parallel/sequential distinction does not apply, so
+// set) AND forwardEnabled is true (the hook's own DD_AWS_MICROVM_ENABLE_*
+// toggle): delegates to handleWithForwarder which mirrors the user app's
+// response. Otherwise: emit metric, optionally flush, return 200. In
+// standalone mode the parallel/sequential distinction does not apply, so
 // both flush modes result in a single flushAll call.
-func (s *Server) dispatchHook(metricName, path string, mode flushMode, w http.ResponseWriter, r *http.Request) {
-	if s.fwd != nil {
+func (s *Server) dispatchHook(metricName, path string, mode flushMode, forwardEnabled bool, w http.ResponseWriter, r *http.Request) {
+	if s.fwd != nil && forwardEnabled {
 		s.handleWithForwarder(metricName, path, mode, w, r)
 		return
 	}
@@ -766,7 +791,7 @@ func (s *Server) dispatchHook(metricName, path string, mode flushMode, w http.Re
 	if mode != noFlush {
 		flushCtx, cancel := context.WithTimeout(context.Background(), s.flushTimeout)
 		defer cancel()
-		s.flushAll(flushCtx)
+		s.flushAll(flushCtx, mode == flushSequential)
 	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -74,6 +74,10 @@ type neverDrainer struct{}
 
 func (n *neverDrainer) WaitForPendingSamples() { select {} }
 
+type serverErrReader struct{}
+
+func (serverErrReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+
 func newTestServer() (*Server, *mockFlusher, *mockFlusher, *mockLogsAgent, *mockMetricEmitter, *mockSampleDrainer) {
 	metric := &mockFlusher{}
 	trace := &mockFlusher{}
@@ -158,6 +162,26 @@ func TestHandleRun_OversizedBody_Returns500(t *testing.T) {
 	assert.NotContains(t, emitter.getEmitted(), runMetricName, "run metric must not be emitted when the body exceeds the cap")
 }
 
+// TestInstanceID_EmptyBeforeRun verifies that InstanceID returns "" before
+// /run fires, and the captured ID afterward — the accessor the enhanced
+// metrics collector uses to attach a per-instance tag to the usage metric.
+func TestInstanceID_EmptyBeforeRun(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	assert.Empty(t, srv.InstanceID(), "InstanceID must be empty before /run fires")
+
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
+
+	assert.Equal(t, "vm-abc123", srv.InstanceID())
+}
+
+// TestInstanceID_NilServer verifies InstanceID is safe to call on a nil
+// *Server, mirroring the existing nil-safety of Child().
+func TestInstanceID_NilServer(t *testing.T) {
+	var srv *Server
+	assert.Empty(t, srv.InstanceID())
+}
+
 // TestHandleRunWithForwarderParsesInstanceID verifies that when a forwarder is
 // configured, /run still decodes the MicroVM instance ID from the request body
 // before delegating to handleWithForwarder. Without the decode-then-restore fix, the
@@ -194,6 +218,44 @@ func TestHandleRunEmptyBodyDoesNotSetInstanceID(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	id := srv.instanceID.Load()
 	assert.Empty(t, id, "empty body must not set instance ID")
+}
+
+func TestHandleRunBodyReadErrorReturns500(t *testing.T) {
+	srv, _, _, _, emitter, _ := newTestServer()
+
+	req := httptest.NewRequest(http.MethodPost, pathRun, serverErrReader{})
+	rec := httptest.NewRecorder()
+	srv.handleRun(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Empty(t, srv.InstanceID(), "failed body read must not set instance ID")
+	assert.NotContains(t, emitter.getEmitted(), runMetricName, "failed body read must not emit run metric")
+}
+
+func TestHandleRunWithForwarderBodyReadErrorDoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, pathRun, serverErrReader{})
+	rec := httptest.NewRecorder()
+	srv.handleRun(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Equal(t, int32(0), reached.Load(), "user app must not receive a partial runHookPayload")
+	assert.Empty(t, srv.InstanceID(), "failed body read must not set instance ID")
+	assert.NotContains(t, emitter.getEmitted(), runMetricName, "failed body read must not emit run metric")
 }
 
 func TestHandleSuspendFlushesBeforeResponding(t *testing.T) {
@@ -389,6 +451,32 @@ func TestHandleReady_WithForwarder_PassesThrough(t *testing.T) {
 	// hide that.
 	assert.Equal(t, "application/x-ready", rec.Header().Get("Content-Type"))
 	assert.Equal(t, `{"ready":false,"reason":"warming"}`, rec.Body.String())
+}
+
+// /validate shares passThroughReady's PassThroughWaiting code path (same
+// reachability-check-then-forward shape, just bounded by validateTimeout
+// instead of readyTimeout) but had no server-level pass-through coverage of
+// its own — this pins the mirror contract for /validate specifically.
+func TestHandleValidate_WithForwarder_PassesThrough(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-validate")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"valid":false,"reason":"warming"}`))
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		validateTimeout:      200 * time.Millisecond,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	rec := httptest.NewRecorder()
+	srv.handleValidate(rec, httptest.NewRequest(http.MethodPost, pathValidate, nil))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "application/x-validate", rec.Header().Get("Content-Type"))
+	assert.Equal(t, `{"valid":false,"reason":"warming"}`, rec.Body.String())
 }
 
 // /run with a forwarder configured mirrors the user-app's status code,
@@ -924,6 +1012,24 @@ func TestNewServerWithForwarderWriteTimeoutCoversForwardBudget(t *testing.T) {
 	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, nil)
 	assert.Equal(t, fwd.forwardTimeout+flushTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout,
 		"WriteTimeout must cover forwardTimeout+flushTimeout (terminate sequential-flush path)")
+}
+
+// TestNewServerWithForwarderWriteTimeoutCoversReadinessBudgets verifies that
+// WriteTimeout covers the fast reachability dial plus the forwarded /ready or
+// /validate request. Without the dial budget, the HTTP server can close the
+// platform-facing connection just before the handler mirrors a valid response.
+func TestNewServerWithForwarderWriteTimeoutCoversReadinessBudgets(t *testing.T) {
+	flushTimeout := 5 * time.Second
+	fwd := &Forwarder{
+		forwardTimeout:       time.Second,
+		readyTimeout:         2 * time.Second,
+		validateTimeout:      30 * time.Second,
+		client:               &http.Client{},
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, nil)
+	assert.Equal(t, dialCheckTimeout+fwd.validateTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout,
+		"WriteTimeout must cover dialCheckTimeout+validateTimeout for /validate")
 }
 
 // TestInstanceIDTagAppearsInMetricsAfterRun verifies that once /run stores a

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -74,6 +74,10 @@ type neverDrainer struct{}
 
 func (n *neverDrainer) WaitForPendingSamples() { select {} }
 
+type serverErrReader struct{}
+
+func (serverErrReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+
 func newTestServer() (*Server, *mockFlusher, *mockFlusher, *mockLogsAgent, *mockMetricEmitter, *mockSampleDrainer) {
 	metric := &mockFlusher{}
 	trace := &mockFlusher{}
@@ -158,6 +162,26 @@ func TestHandleRun_OversizedBody_Returns500(t *testing.T) {
 	assert.NotContains(t, emitter.getEmitted(), runMetricName, "run metric must not be emitted when the body exceeds the cap")
 }
 
+// TestInstanceID_EmptyBeforeRun verifies that InstanceID returns "" before
+// /run fires, and the captured ID afterward — the accessor the enhanced
+// metrics collector uses to attach a per-instance tag to the usage metric.
+func TestInstanceID_EmptyBeforeRun(t *testing.T) {
+	srv, _, _, _, _, _ := newTestServer()
+	assert.Empty(t, srv.InstanceID(), "InstanceID must be empty before /run fires")
+
+	body := strings.NewReader(`{"microvmId":"vm-abc123"}`)
+	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
+
+	assert.Equal(t, "vm-abc123", srv.InstanceID())
+}
+
+// TestInstanceID_NilServer verifies InstanceID is safe to call on a nil
+// *Server, mirroring the existing nil-safety of Child().
+func TestInstanceID_NilServer(t *testing.T) {
+	var srv *Server
+	assert.Empty(t, srv.InstanceID())
+}
+
 // TestHandleRunWithForwarderParsesInstanceID verifies that when a forwarder is
 // configured, /run still decodes the MicroVM instance ID from the request body
 // before delegating to handleWithForwarder. Without the decode-then-restore fix, the
@@ -194,6 +218,44 @@ func TestHandleRunEmptyBodyDoesNotSetInstanceID(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	id := srv.instanceID.Load()
 	assert.Empty(t, id, "empty body must not set instance ID")
+}
+
+func TestHandleRunBodyReadErrorReturns500(t *testing.T) {
+	srv, _, _, _, emitter, _ := newTestServer()
+
+	req := httptest.NewRequest(http.MethodPost, pathRun, serverErrReader{})
+	rec := httptest.NewRecorder()
+	srv.handleRun(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Empty(t, srv.InstanceID(), "failed body read must not set instance ID")
+	assert.NotContains(t, emitter.getEmitted(), runMetricName, "failed body read must not emit run metric")
+}
+
+func TestHandleRunWithForwarderBodyReadErrorDoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, pathRun, serverErrReader{})
+	rec := httptest.NewRecorder()
+	srv.handleRun(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Equal(t, int32(0), reached.Load(), "user app must not receive a partial runHookPayload")
+	assert.Empty(t, srv.InstanceID(), "failed body read must not set instance ID")
+	assert.NotContains(t, emitter.getEmitted(), runMetricName, "failed body read must not emit run metric")
 }
 
 func TestHandleSuspendFlushesBeforeResponding(t *testing.T) {
@@ -389,6 +451,32 @@ func TestHandleReady_WithForwarder_PassesThrough(t *testing.T) {
 	// hide that.
 	assert.Equal(t, "application/x-ready", rec.Header().Get("Content-Type"))
 	assert.Equal(t, `{"ready":false,"reason":"warming"}`, rec.Body.String())
+}
+
+// /validate shares passThroughReady's PassThroughWaiting code path (same
+// reachability-check-then-forward shape, just bounded by validateTimeout
+// instead of readyTimeout) but had no server-level pass-through coverage of
+// its own — this pins the mirror contract for /validate specifically.
+func TestHandleValidate_WithForwarder_PassesThrough(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-validate")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"valid":false,"reason":"warming"}`))
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		validateTimeout:      200 * time.Millisecond,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	rec := httptest.NewRecorder()
+	srv.handleValidate(rec, httptest.NewRequest(http.MethodPost, pathValidate, nil))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "application/x-validate", rec.Header().Get("Content-Type"))
+	assert.Equal(t, `{"valid":false,"reason":"warming"}`, rec.Body.String())
 }
 
 // /run with a forwarder configured mirrors the user-app's status code,
@@ -1007,6 +1095,24 @@ func TestNewServerWithForwarderWriteTimeoutCoversForwardBudget(t *testing.T) {
 	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, nil)
 	assert.Equal(t, fwd.forwardTimeout+flushTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout,
 		"WriteTimeout must cover forwardTimeout+flushTimeout (terminate sequential-flush path)")
+}
+
+// TestNewServerWithForwarderWriteTimeoutCoversReadinessBudgets verifies that
+// WriteTimeout covers the fast reachability dial plus the forwarded /ready or
+// /validate request. Without the dial budget, the HTTP server can close the
+// platform-facing connection just before the handler mirrors a valid response.
+func TestNewServerWithForwarderWriteTimeoutCoversReadinessBudgets(t *testing.T) {
+	flushTimeout := 5 * time.Second
+	fwd := &Forwarder{
+		forwardTimeout:       time.Second,
+		readyTimeout:         2 * time.Second,
+		validateTimeout:      30 * time.Second,
+		client:               &http.Client{},
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, nil)
+	assert.Equal(t, dialCheckTimeout+fwd.validateTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout,
+		"WriteTimeout must cover dialCheckTimeout+validateTimeout for /validate")
 }
 
 // TestInstanceIDTagAppearsInMetricsAfterRun verifies that once /run stores a

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -46,6 +46,16 @@ func (m *mockFlusher) Flush() {
 	}
 }
 
+// mockForceFlusher tracks Flush and FlushAll calls separately; it satisfies
+// both Flusher and ForceFlusher.
+type mockForceFlusher struct {
+	flushCount    atomic.Int32
+	flushAllCount atomic.Int32
+}
+
+func (m *mockForceFlusher) Flush()    { m.flushCount.Add(1) }
+func (m *mockForceFlusher) FlushAll() { m.flushAllCount.Add(1) }
+
 // mockLogsAgent counts how many times Flush was called and records when each
 // call returned. onFlush, if set, is invoked after each Flush.
 type mockLogsAgent struct {
@@ -85,9 +95,9 @@ func newTestServer() (*Server, *mockFlusher, *mockFlusher, *mockLogsAgent, *mock
 	emitter := &mockMetricEmitter{}
 	drainer := &mockSampleDrainer{}
 	// port 0 — handler-level tests don't bind. Tests that need a childHandle,
-	// forwarder, or heartbeat assign srv.childHandle / srv.fwd / srv.heartbeat
-	// after construction.
-	srv := NewServer(0, metric, trace, logs, emitter, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, nil)
+	// forwarder, enabled hooks, or heartbeat assign srv.childHandle / srv.fwd /
+	// srv.enabledHooks / srv.heartbeat after construction.
+	srv := NewServer(0, metric, trace, logs, emitter, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
 	return srv, metric, trace, logs, emitter, drainer
 }
 
@@ -200,6 +210,7 @@ func TestHandleRunWithForwarderParsesInstanceID(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 
 	body := strings.NewReader(`{"microvmId":"vm-fwd123"}`)
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
@@ -247,6 +258,7 @@ func TestHandleRunWithForwarderBodyReadErrorDoesNotForward(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 
 	req := httptest.NewRequest(http.MethodPost, pathRun, serverErrReader{})
 	rec := httptest.NewRecorder()
@@ -319,6 +331,30 @@ func TestHandleTerminate_NoForwarder_FlushesAndEmitsMetric_NoSigterm(t *testing.
 	}
 }
 
+// TestHandleSuspend_UsesFlushNotFlushAll pins that /suspend calls Flush, not
+// FlushAll (see ForceFlusher for why).
+func TestHandleSuspend_UsesFlushNotFlushAll(t *testing.T) {
+	metric := &mockForceFlusher{}
+	srv := NewServer(0, metric, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
+
+	srv.handleSuspend(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+
+	assert.Equal(t, int32(1), metric.flushCount.Load(), "/suspend must call Flush")
+	assert.Equal(t, int32(0), metric.flushAllCount.Load(), "/suspend must not call FlushAll")
+}
+
+// TestHandleTerminate_UsesFlushAllNotFlush pins that /terminate calls
+// FlushAll, not Flush (see ForceFlusher for why).
+func TestHandleTerminate_UsesFlushAllNotFlush(t *testing.T) {
+	metric := &mockForceFlusher{}
+	srv := NewServer(0, metric, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
+
+	srv.handleTerminate(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathTerminate, nil))
+
+	assert.Equal(t, int32(1), metric.flushAllCount.Load(), "/terminate must call FlushAll")
+	assert.Equal(t, int32(0), metric.flushCount.Load(), "/terminate must not call Flush")
+}
+
 // TestEmittedMetricsCarryCurrentTimestamp verifies the lifecycle handlers pass
 // a current Unix-seconds timestamp to AddEnhancedMetric rather than the `0`
 // sentinel that defers timestamp assignment to the metric agent. The window
@@ -356,6 +392,7 @@ func TestEmittedMetricsCarryCurrentTimestamp_ForwarderPath(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 
 	before := float64(time.Now().UnixNano()) / float64(time.Second)
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
@@ -442,6 +479,7 @@ func TestHandleReady_WithForwarder_PassesThrough(t *testing.T) {
 		readyTimeout:         200 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Ready = true
 	rec := httptest.NewRecorder()
 	srv.handleReady(rec, httptest.NewRequest(http.MethodPost, pathReady, nil))
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
@@ -451,6 +489,38 @@ func TestHandleReady_WithForwarder_PassesThrough(t *testing.T) {
 	// hide that.
 	assert.Equal(t, "application/x-ready", rec.Header().Get("Content-Type"))
 	assert.Equal(t, `{"ready":false,"reason":"warming"}`, rec.Body.String())
+}
+
+// TestHandleReady_WithForwarderButHookDisabled_UsesBuiltInAliveCheck verifies
+// that a configured Forwarder alone is not enough to forward /ready — the
+// hook's own enabledHooks.Ready toggle (default false) must also be set.
+// With the toggle left false, /ready must use the built-in alive-check
+// instead of contacting the upstream user app.
+func TestHandleReady_WithForwarderButHookDisabled_UsesBuiltInAliveCheck(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		readyTimeout:         200 * time.Millisecond,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Ready left false (the default).
+	h := newFakeChildHandle()
+	h.alive.Store(true)
+	srv.childHandle = h
+
+	rec := httptest.NewRecorder()
+	srv.handleReady(rec, httptest.NewRequest(http.MethodPost, pathReady, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must use the built-in alive-check result")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /ready toggle is disabled")
 }
 
 // /validate shares passThroughReady's PassThroughWaiting code path (same
@@ -472,11 +542,40 @@ func TestHandleValidate_WithForwarder_PassesThrough(t *testing.T) {
 		validateTimeout:      200 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Validate = true
 	rec := httptest.NewRecorder()
 	srv.handleValidate(rec, httptest.NewRequest(http.MethodPost, pathValidate, nil))
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 	assert.Equal(t, "application/x-validate", rec.Header().Get("Content-Type"))
 	assert.Equal(t, `{"valid":false,"reason":"warming"}`, rec.Body.String())
+}
+
+// TestHandleValidate_WithForwarderButHookDisabled_ReturnsBuiltIn200 mirrors
+// TestHandleReady_WithForwarderButHookDisabled_UsesBuiltInAliveCheck for
+// /validate: a configured Forwarder alone does not forward /validate without
+// enabledHooks.Validate also being true.
+func TestHandleValidate_WithForwarderButHookDisabled_ReturnsBuiltIn200(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		validateTimeout:      200 * time.Millisecond,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Validate left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleValidate(rec, httptest.NewRequest(http.MethodPost, pathValidate, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200, not the upstream's 503")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /validate toggle is disabled")
 }
 
 // /run with a forwarder configured mirrors the user-app's status code,
@@ -497,6 +596,7 @@ func TestHandleRun_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 
 	rec := httptest.NewRecorder()
 	srv.handleRun(rec, httptest.NewRequest(http.MethodPost, pathRun, nil))
@@ -509,6 +609,36 @@ func TestHandleRun_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	assert.Equal(t, int32(0), metric.count.Load(), "run must not flush")
 	assert.Equal(t, int32(0), trace.count.Load())
 	assert.Equal(t, int32(0), logs.count.Load())
+}
+
+// TestHandleRun_WithForwarderButHookDisabled_DoesNotForward verifies dispatchHook's
+// enabled gate for the run/resume/suspend/terminate group: a configured
+// Forwarder alone is not enough to forward /run — enabledHooks.Run (default
+// false) must also be true. With it left false, /run must take the built-in
+// metric-only path and never contact the upstream user app.
+func TestHandleRun_WithForwarderButHookDisabled_DoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Run left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleRun(rec, httptest.NewRequest(http.MethodPost, pathRun, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /run toggle is disabled")
+	assert.Contains(t, emitter.getEmitted(), runMetricName, "the run metric must still be emitted")
 }
 
 // /resume with a forwarder configured mirrors the user-app's response and
@@ -526,6 +656,7 @@ func TestHandleResume_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Resume = true
 
 	rec := httptest.NewRecorder()
 	srv.handleResume(rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
@@ -535,6 +666,38 @@ func TestHandleResume_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	assert.Equal(t, int32(0), metric.count.Load(), "resume must not flush")
 	assert.Equal(t, int32(0), trace.count.Load())
 	assert.Equal(t, int32(0), logs.count.Load())
+}
+
+// TestHandleResume_WithForwarderButHookDisabled_DoesNotForward mirrors
+// TestHandleRun_WithForwarderButHookDisabled_DoesNotForward for /resume: a
+// configured Forwarder alone does not forward /resume without
+// enabledHooks.Resume also being true. Also guards against a hardcoded
+// enabled=true regression in handleResume's dispatchHook call, which the
+// WithForwarder_MirrorsUserAppResponse test above would not catch since it
+// sets the toggle true anyway.
+func TestHandleResume_WithForwarderButHookDisabled_DoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Resume left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleResume(rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /resume toggle is disabled")
+	assert.Contains(t, emitter.getEmitted(), resumeMetricName, "the resume metric must still be emitted")
 }
 
 // /terminate with a forwarder configured mirrors the user-app's response,
@@ -553,6 +716,7 @@ func TestHandleTerminate_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Terminate = true
 
 	rec := httptest.NewRecorder()
 	srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
@@ -560,6 +724,39 @@ func TestHandleTerminate_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	assert.Equal(t, 503, rec.Code, "must mirror user-app status, not hardcoded 200")
 	assert.Contains(t, emitter.getEmitted(), terminateMetricName)
 	assert.Equal(t, int32(1), metric.count.Load(), "terminate must flush")
+	assert.Equal(t, int32(1), trace.count.Load())
+	assert.Equal(t, int32(1), logs.count.Load())
+}
+
+// TestHandleTerminate_WithForwarderButHookDisabled_DoesNotForward mirrors
+// TestHandleRun_WithForwarderButHookDisabled_DoesNotForward for /terminate: a
+// configured Forwarder alone does not forward /terminate without
+// enabledHooks.Terminate also being true. The built-in path still flushes
+// telemetry — only the pass-through to the user app is skipped.
+func TestHandleTerminate_WithForwarderButHookDisabled_DoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, metric, trace, logs, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Terminate left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /terminate toggle is disabled")
+	assert.Contains(t, emitter.getEmitted(), terminateMetricName, "the terminate metric must still be emitted")
+	assert.Equal(t, int32(1), metric.count.Load(), "the built-in path must still flush")
 	assert.Equal(t, int32(1), trace.count.Load())
 	assert.Equal(t, int32(1), logs.count.Load())
 }
@@ -583,6 +780,7 @@ func TestHandleSuspend_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -596,6 +794,39 @@ func TestHandleSuspend_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	assert.Equal(t, int32(1), trace.count.Load(), "trace flush must still run")
 	assert.Equal(t, int32(1), logs.count.Load(), "logs flush must still run")
 	assert.Contains(t, emitter.getEmitted(), suspendMetricName, "metric must still be emitted")
+}
+
+// TestHandleSuspend_WithForwarderButHookDisabled_DoesNotForward mirrors
+// TestHandleRun_WithForwarderButHookDisabled_DoesNotForward for /suspend: a
+// configured Forwarder alone does not forward /suspend without
+// enabledHooks.Suspend also being true. The built-in path still flushes
+// telemetry — only the pass-through to the user app is skipped.
+func TestHandleSuspend_WithForwarderButHookDisabled_DoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, metric, trace, logs, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Suspend left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /suspend toggle is disabled")
+	assert.Contains(t, emitter.getEmitted(), suspendMetricName, "the suspend metric must still be emitted")
+	assert.Equal(t, int32(1), metric.count.Load(), "the built-in path must still flush")
+	assert.Equal(t, int32(1), trace.count.Load())
+	assert.Equal(t, int32(1), logs.count.Load())
 }
 
 // Parallelism pin: the upstream handler blocks until all three flush mocks
@@ -634,6 +865,7 @@ func TestHandleSuspend_WithForwarder_FlushCompletesBeforeForwardReturns(t *testi
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -656,6 +888,7 @@ func TestHandleSuspend_WithForwarder_DialErrorStillRunsFlush(t *testing.T) {
 		forwardTimeout:       200 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -678,6 +911,7 @@ func TestHandleSuspend_WithForwarder_WaitsForForwardBeforeResponse(t *testing.T)
 
 	srv, metric, trace, logs, _, _ := newTestServer()
 	srv.fwd = &Forwarder{target: upstream.URL, client: &http.Client{}, forwardTimeout: 5 * time.Second}
+	srv.enabledHooks.Suspend = true
 
 	handlerReturned := make(chan struct{})
 	rec := httptest.NewRecorder()
@@ -759,6 +993,7 @@ func TestHandleSuspend_WithForwarder_FlushTimeout_ReturnsPromptly(t *testing.T) 
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	start := time.Now()
 	rec := httptest.NewRecorder()
@@ -807,6 +1042,7 @@ func TestHandleSuspend_WithForwarder_BodyBufferedBeforeFlush(t *testing.T) {
 		forwardTimeout:       100 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -833,6 +1069,7 @@ func TestHandleTerminate_WithForwarder_FlushTimeout_ReturnsPromptly(t *testing.T
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Terminate = true
 
 	start := time.Now()
 	rec := httptest.NewRecorder()
@@ -875,6 +1112,7 @@ func TestHandleTerminate_WithForwarder_BodyBufferedBeforeFlush(t *testing.T) {
 		forwardTimeout:       100 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Terminate = true
 
 	rec := httptest.NewRecorder()
 	srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
@@ -905,6 +1143,7 @@ func TestHandleTerminate_WithForwarder_WaitsForSlowForward(t *testing.T) {
 		forwardTimeout:       5 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Terminate = true
 
 	handlerReturned := make(chan struct{})
 	rec := httptest.NewRecorder()
@@ -1016,7 +1255,7 @@ func TestListenAndServe_BindFailureReturnsErrorDirectly(t *testing.T) {
 	defer occupied.Close()
 	port := occupied.Addr().(*net.TCPAddr).Port
 
-	srv := NewServer(port, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, nil)
+	srv := NewServer(port, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
 
 	called := false
 	err = srv.ListenAndServe(func(error) { called = true })
@@ -1075,7 +1314,7 @@ func TestListenAndServe_StopDoesNotInvokeOnServeError(t *testing.T) {
 // TestNewServerWithForwarderWriteTimeoutCoversForwardBudget below.
 func TestNewServerConfiguresHTTPTimeouts(t *testing.T) {
 	flushTimeout := 5 * time.Second
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, nil, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, nil, HookToggles{}, nil)
 	assert.Equal(t, 30*time.Second, srv.httpServer.ReadTimeout)
 	assert.Equal(t, flushTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout)
 }
@@ -1092,7 +1331,7 @@ func TestNewServerWithForwarderWriteTimeoutCoversForwardBudget(t *testing.T) {
 		client:               &http.Client{},
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, HookToggles{}, nil)
 	assert.Equal(t, fwd.forwardTimeout+flushTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout,
 		"WriteTimeout must cover forwardTimeout+flushTimeout (terminate sequential-flush path)")
 }
@@ -1110,7 +1349,7 @@ func TestNewServerWithForwarderWriteTimeoutCoversReadinessBudgets(t *testing.T) 
 		client:               &http.Client{},
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, HookToggles{}, nil)
 	assert.Equal(t, dialCheckTimeout+fwd.validateTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout,
 		"WriteTimeout must cover dialCheckTimeout+validateTimeout for /validate")
 }
@@ -1200,7 +1439,7 @@ func TestMirrorResponse_BodyReadError_DoesNotPanic(t *testing.T) {
 func TestDispatchHook_NoForwarder_WithFlushFalse_EmitsMetricReturns200NoFlush(t *testing.T) {
 	srv, metric, trace, logs, emitter, drainer := newTestServer()
 	rec := httptest.NewRecorder()
-	srv.dispatchHook("test.metric", "/test", noFlush, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
+	srv.dispatchHook("test.metric", "/test", noFlush, false, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, emitter.getEmitted(), "test.metric")
 	assert.Equal(t, int32(0), metric.count.Load(), "noFlush must not flush")
@@ -1214,7 +1453,7 @@ func TestDispatchHook_NoForwarder_WithFlushFalse_EmitsMetricReturns200NoFlush(t 
 func TestDispatchHook_NoForwarder_WithFlushTrue_EmitsMetricAndFlushes(t *testing.T) {
 	srv, metric, trace, logs, emitter, drainer := newTestServer()
 	rec := httptest.NewRecorder()
-	srv.dispatchHook("test.metric", "/test", flushParallel, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
+	srv.dispatchHook("test.metric", "/test", flushParallel, false, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, emitter.getEmitted(), "test.metric")
 	assert.Equal(t, int32(1), metric.count.Load(), "flushParallel must flush metric agent")
@@ -1242,7 +1481,7 @@ func TestDispatchHook_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	srv.dispatchHook("test.metric", pathResume, noFlush, rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
+	srv.dispatchHook("test.metric", pathResume, noFlush, true, rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
 	assert.Equal(t, 418, rec.Code, "must mirror user-app status, not hardcoded 200")
 	assert.Contains(t, emitter.getEmitted(), "test.metric")
 }
@@ -1252,12 +1491,12 @@ func TestDispatchHook_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 // lifecycle server stalling — and blocking the MicroVM platform's suspend/terminate
 // handshake — when the metric aggregator worker is deadlocked or slow.
 func TestFlushAllDrainTimeoutDoesNotBlock(t *testing.T) {
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &neverDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 50*time.Millisecond, nil, nil, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &neverDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 50*time.Millisecond, nil, nil, HookToggles{}, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
 	start := time.Now()
-	srv.flushAll(ctx)
+	srv.flushAll(ctx, false)
 	assert.Less(t, time.Since(start), 500*time.Millisecond, "flushAll must return within flushTimeout even when drainer blocks")
 }
 
@@ -1276,12 +1515,12 @@ func TestFlushAllNilLogsFlusherDoesNotPanic(t *testing.T) {
 	metric := &mockFlusher{}
 	trace := &mockFlusher{}
 	drainer := &mockSampleDrainer{}
-	srv := NewServer(0, metric, trace, nil, &mockMetricEmitter{}, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, nil)
+	srv := NewServer(0, metric, trace, nil, &mockMetricEmitter{}, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
 	start := time.Now()
-	assert.NotPanics(t, func() { srv.flushAll(ctx) })
+	assert.NotPanics(t, func() { srv.flushAll(ctx, false) })
 	assert.Less(t, time.Since(start), 500*time.Millisecond, "flushAll must not fall back to the flushTimeout path when logsFlusher is nil")
 	assert.Equal(t, int32(1), metric.count.Load())
 	assert.Equal(t, int32(1), trace.count.Load())
@@ -1320,7 +1559,7 @@ func TestHandleRun_StartsHeartbeat(t *testing.T) {
 
 // /run must extract the MicroVM ID from the JSON body and apply it to the
 // heartbeat before Start so the very first emission carries the correct
-// microvm_id. The test calls handleRun then inspects the tags that the
+// lambda_microvm_id. The test calls handleRun then inspects the tags that the
 // heartbeat would emit on its next tick.
 func TestHandleRun_AppliesMicroVMIDFromBody(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
@@ -1330,7 +1569,7 @@ func TestHandleRun_AppliesMicroVMIDFromBody(t *testing.T) {
 	body := strings.NewReader(`{"microvmId":"vm-from-body"}`)
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
-	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:vm-from-body")
+	assert.Contains(t, srv.heartbeat.tagsForEmit(), "lambda_microvm_id:vm-from-body")
 	id := srv.instanceID.Load()
 	assert.Equal(t, "vm-from-body", id)
 }
@@ -1344,7 +1583,7 @@ func TestHandleRun_MissingBodyIDUsesUnknown(t *testing.T) {
 
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
 
-	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:unknown")
+	assert.Contains(t, srv.heartbeat.tagsForEmit(), "lambda_microvm_id:unknown")
 }
 
 // traced_invocations is emitted by the Heartbeat on each tick, not directly by
@@ -1582,6 +1821,7 @@ func TestHandleRun_WithForwarder_UpdatesLogTags(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 	setter := &mockLogsTagSetter{}
 	srv.SetLogsTagSetter(setter, []string{"env:staging"})
 
@@ -1743,6 +1983,7 @@ func TestHandleRun_WithForwarder_UpdatesTraceTags(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 	setter := &mockTraceTagSetter{}
 	srv.SetTraceTagSetter(setter, map[string]string{"env": "staging"})
 

--- a/cmd/serverless-init/lifecycle/wire.go
+++ b/cmd/serverless-init/lifecycle/wire.go
@@ -15,33 +15,46 @@ import (
 // SetupComponents holds the lifecycle dependencies that setup() threads
 // into the lifecycle server and into mode.RunInit.
 type SetupComponents struct {
-	Port      int         // lifecycle hook server port; always set (defaults to DefaultPort)
-	Handle    ChildHandle // always non-nil; noop in sidecar mode
-	Child     *Child      // non-nil only in init-container mode (used by mode.RunInit)
-	Forwarder *Forwarder  // non-nil only when env var is valid AND init-container mode
+	Port         int         // lifecycle hook server port; always set (defaults to DefaultPort)
+	Handle       ChildHandle // always non-nil; noop in sidecar mode
+	Child        *Child      // non-nil only in init-container mode (used by mode.RunInit)
+	Forwarder    *Forwarder  // non-nil only when env var is valid AND init-container mode
+	EnabledHooks HookToggles // per-hook forwarding opt-in; only meaningful when Forwarder != nil
 }
 
 // setupInput holds the raw string values for setupComponents. Empty string means
 // "unset / use default" for each field, matching env-var semantics.
 type setupInput struct {
-	userAppPort   string
-	lifecyclePort string
-	forwardMs     string
-	readyMs       string
-	validateMs    string
-	sidecarMode   bool
+	userAppPort     string
+	lifecyclePort   string
+	forwardMs       string
+	readyMs         string
+	validateMs      string
+	enableReady     string
+	enableValidate  string
+	enableRun       string
+	enableResume    string
+	enableSuspend   string
+	enableTerminate string
+	sidecarMode     bool
 }
 
 // SetupFromEnv reads lifecycle configuration from environment variables and
 // delegates to setupComponents.
 func SetupFromEnv(sidecarMode bool) (SetupComponents, error) {
 	return setupComponents(setupInput{
-		userAppPort:   os.Getenv(UserAppPortEnvVar),
-		lifecyclePort: os.Getenv(LifecyclePortEnvVar),
-		forwardMs:     os.Getenv(ForwardTimeoutMsEnvVar),
-		readyMs:       os.Getenv(ReadyTimeoutMsEnvVar),
-		validateMs:    os.Getenv(ValidateTimeoutMsEnvVar),
-		sidecarMode:   sidecarMode,
+		userAppPort:     os.Getenv(UserAppPortEnvVar),
+		lifecyclePort:   os.Getenv(LifecyclePortEnvVar),
+		forwardMs:       os.Getenv(ForwardTimeoutMsEnvVar),
+		readyMs:         os.Getenv(ReadyTimeoutMsEnvVar),
+		validateMs:      os.Getenv(ValidateTimeoutMsEnvVar),
+		enableReady:     os.Getenv(EnableReadyEnvVar),
+		enableValidate:  os.Getenv(EnableValidateEnvVar),
+		enableRun:       os.Getenv(EnableRunEnvVar),
+		enableResume:    os.Getenv(EnableResumeEnvVar),
+		enableSuspend:   os.Getenv(EnableSuspendEnvVar),
+		enableTerminate: os.Getenv(EnableTerminateEnvVar),
+		sidecarMode:     sidecarMode,
 	})
 }
 
@@ -97,11 +110,60 @@ func setupComponents(in setupInput) (SetupComponents, error) {
 		return SetupComponents{}, err
 	}
 
-	c := SetupComponents{Port: lifecyclePort}
+	enabled := HookToggles{
+		Ready:     parseBoolFlag(EnableReadyEnvVar, in.enableReady, false),
+		Validate:  parseBoolFlag(EnableValidateEnvVar, in.enableValidate, false),
+		Run:       parseBoolFlag(EnableRunEnvVar, in.enableRun, false),
+		Resume:    parseBoolFlag(EnableResumeEnvVar, in.enableResume, false),
+		Suspend:   parseBoolFlag(EnableSuspendEnvVar, in.enableSuspend, false),
+		Terminate: parseBoolFlag(EnableTerminateEnvVar, in.enableTerminate, false),
+	}
+	warnHookTogglesMismatch(userAppPort != 0, enabled)
+
+	c := SetupComponents{Port: lifecyclePort, EnabledHooks: enabled}
 	c.Child = NewChild()
 	c.Handle = c.Child
 	if userAppPort != 0 {
 		c.Forwarder = NewForwarder(userAppPort, forwardTimeout, readyTimeout, validateTimeout)
 	}
 	return c, nil
+}
+
+// warnHookTogglesMismatch logs when the forwarder and the per-hook toggles
+// disagree in a way the user likely did not intend:
+//   - a forwarder is configured but no hook opted in (forwarding is fully
+//     off, a change from the previous all-hooks-forward behavior), or
+//   - a hook opted in but there is no forwarder to forward to.
+func warnHookTogglesMismatch(hasForwarder bool, enabled HookToggles) {
+	names := enabledHookNames(enabled)
+	switch {
+	case hasForwarder && len(names) == 0:
+		log.Warnf("MicroVM lifecycle: %s is set but no hooks are enabled via DD_AWS_MICROVM_ENABLE_*; all hooks will use built-in handling instead of forwarding", UserAppPortEnvVar)
+	case !hasForwarder && len(names) > 0:
+		log.Warnf("MicroVM lifecycle: hook(s) %v enabled via DD_AWS_MICROVM_ENABLE_* but %s is not set; those hooks will use built-in handling", names, UserAppPortEnvVar)
+	}
+}
+
+// enabledHookNames returns the lowercase hook names with their toggle set to true.
+func enabledHookNames(t HookToggles) []string {
+	var names []string
+	if t.Ready {
+		names = append(names, "ready")
+	}
+	if t.Validate {
+		names = append(names, "validate")
+	}
+	if t.Run {
+		names = append(names, "run")
+	}
+	if t.Resume {
+		names = append(names, "resume")
+	}
+	if t.Suspend {
+		names = append(names, "suspend")
+	}
+	if t.Terminate {
+		names = append(names, "terminate")
+	}
+	return names
 }

--- a/cmd/serverless-init/lifecycle/wire_test.go
+++ b/cmd/serverless-init/lifecycle/wire_test.go
@@ -6,6 +6,7 @@
 package lifecycle
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -129,6 +130,76 @@ func TestSetupComponents_SidecarMode_InvalidTimeoutMs_NoError(t *testing.T) {
 	}
 }
 
+// --- HookToggles (DD_AWS_MICROVM_ENABLE_*) ---
+
+// Every hook toggle defaults to false — a hook is not forwarded unless
+// explicitly enabled, even when a Forwarder is configured.
+func TestSetupComponents_EnabledHooks_DefaultFalse(t *testing.T) {
+	got, err := setupComponents(setupInput{userAppPort: "8080"})
+	require.NoError(t, err)
+	require.NotNil(t, got.Forwarder)
+	assert.Equal(t, HookToggles{}, got.EnabledHooks)
+}
+
+// TestSetupComponents_EnabledHooks_ParsedFromEnv enables exactly one hook per
+// case and asserts that ONLY that hook ends up true. Setting all six at once
+// would not catch a field-swap bug (e.g. Resume accidentally wired to
+// in.enableSuspend) since both inputs would be "true" either way; isolating
+// each hook makes such a swap show up as an unexpected field being set.
+func TestSetupComponents_EnabledHooks_ParsedFromEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input setupInput
+		want  HookToggles
+	}{
+		{"ready", setupInput{enableReady: "true"}, HookToggles{Ready: true}},
+		{"validate", setupInput{enableValidate: "true"}, HookToggles{Validate: true}},
+		{"run", setupInput{enableRun: "true"}, HookToggles{Run: true}},
+		{"resume", setupInput{enableResume: "true"}, HookToggles{Resume: true}},
+		{"suspend", setupInput{enableSuspend: "true"}, HookToggles{Suspend: true}},
+		{"terminate", setupInput{enableTerminate: "true"}, HookToggles{Terminate: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := tc.input
+			in.userAppPort = "8080"
+			got, err := setupComponents(in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got.EnabledHooks)
+		})
+	}
+}
+
+// A hook enabled without a Forwarder configured (no USER_APP_PORT) has no
+// effect on the Forwarder — the toggle is still recorded on EnabledHooks —
+// but there's nothing to forward to, so server.go's fwd!=nil check keeps it
+// on the built-in path.
+func TestSetupComponents_EnabledHooks_TrueWithoutUserAppPort_NoForwarder(t *testing.T) {
+	got, err := setupComponents(setupInput{enableRun: "true"})
+	require.NoError(t, err)
+	assert.Nil(t, got.Forwarder)
+	assert.True(t, got.EnabledHooks.Run)
+}
+
+// A malformed toggle value falls back to false for that hook only — it does
+// not fail setup or affect the Forwarder or the other hooks' toggles.
+func TestSetupComponents_EnabledHooks_MalformedValue_ScopedToThatHook(t *testing.T) {
+	got, err := setupComponents(setupInput{userAppPort: "8080", enableRun: "not-a-bool", enableSuspend: "true"})
+	require.NoError(t, err)
+	require.NotNil(t, got.Forwarder)
+	assert.False(t, got.EnabledHooks.Run, "malformed value must fall back to false")
+	assert.True(t, got.EnabledHooks.Suspend, "other hooks must be unaffected by a malformed sibling toggle")
+}
+
+// Sidecar mode returns before the enable-toggle parsing block (the forwarder
+// is never built there), so EnabledHooks stays zero-value regardless of the
+// env vars — mirrors how userAppPort and the timeouts are ignored in sidecar
+// mode.
+func TestSetupComponents_SidecarMode_EnabledHooksIgnored(t *testing.T) {
+	got, err := setupComponents(setupInput{sidecarMode: true, enableRun: "true"})
+	require.NoError(t, err)
+	assert.Equal(t, HookToggles{}, got.EnabledHooks)
+}
+
 // SetupFromEnv must read UserAppPortEnvVar from the process environment
 // and delegate to setupComponents. Pins the env binding so a refactor
 // can't silently swap the env-var name or skip the lookup.
@@ -145,6 +216,52 @@ func TestSetupFromEnv_UnsetEnv_NoForwarder(t *testing.T) {
 	got, err := SetupFromEnv(false)
 	require.NoError(t, err)
 	assert.Nil(t, got.Forwarder)
+}
+
+// SetupFromEnv must read each DD_AWS_MICROVM_ENABLE_* env var from the
+// process environment. Pins the env-var-name binding for all six toggles the
+// same way TestSetupFromEnv_ReadsEnvVar_BuildsForwarder pins UserAppPortEnvVar
+// — setupComponents-level tests alone can't catch a typo'd env var name in
+// SetupFromEnv's os.Getenv calls, since they bypass os.Getenv entirely.
+func TestSetupFromEnv_ReadsEnableEnvVars(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		envVar string
+		want   HookToggles
+	}{
+		{"ready", EnableReadyEnvVar, HookToggles{Ready: true}},
+		{"validate", EnableValidateEnvVar, HookToggles{Validate: true}},
+		{"run", EnableRunEnvVar, HookToggles{Run: true}},
+		{"resume", EnableResumeEnvVar, HookToggles{Resume: true}},
+		{"suspend", EnableSuspendEnvVar, HookToggles{Suspend: true}},
+		{"terminate", EnableTerminateEnvVar, HookToggles{Terminate: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(UserAppPortEnvVar, "8080")
+			t.Setenv(tc.envVar, "true")
+			got, err := SetupFromEnv(false /*sidecar*/)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got.EnabledHooks)
+		})
+	}
+}
+
+// enabledHookNames hand-lists each HookToggles field; nothing forces that
+// list to grow when a field is added. This test fails loudly if HookToggles
+// ever gains a field that enabledHookNames doesn't report, by comparing its
+// output (with every toggle set to true) against the struct's field count.
+func TestEnabledHookNames_CoversAllHookTogglesFields(t *testing.T) {
+	allEnabled := HookToggles{
+		Ready:     true,
+		Validate:  true,
+		Run:       true,
+		Resume:    true,
+		Suspend:   true,
+		Terminate: true,
+	}
+	fieldCount := reflect.TypeOf(allEnabled).NumField()
+	names := enabledHookNames(allEnabled)
+	assert.Len(t, names, fieldCount, "enabledHookNames must report one name per HookToggles field; update it after adding/removing a field")
 }
 
 func TestSetupFromEnv_PropagatesParseError(t *testing.T) {

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -496,7 +496,7 @@ func setup(
 				}),
 				BaseTags: logTagsBase,
 				TraceTagSetter: lifecycle.TraceTagSetterFunc(func(tags map[string]string) {
-					traceAgent.SetTags(tags)
+					traceAgent.UpdateRuntimeTags(tags)
 				}),
 				BaseTraceTags: serverlessInitTag.MakeTraceAgentTags(tagConfig.Tags),
 			},
@@ -532,7 +532,7 @@ func setup(
 			}),
 			BaseTags: logTagsBase,
 			TraceTagSetter: lifecycle.TraceTagSetterFunc(func(tags map[string]string) {
-				traceAgent.SetTags(tags)
+				traceAgent.UpdateRuntimeTags(tags)
 			}),
 			BaseTraceTags: serverlessInitTag.MakeTraceAgentTags(tagConfig.Tags),
 		},

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -434,6 +434,14 @@ func run(
 	return err
 }
 
+// usageMetricTagProvider is satisfied by cloud services whose enhanced usage
+// metric needs a tag that isn't known until after Init — e.g. MicroVM's
+// per-instance tag, only available once the /run lifecycle hook fires.
+// Ignored (via the type assertion in setup) by every other cloud service.
+type usageMetricTagProvider interface {
+	CurrentUsageMetricTags() []string
+}
+
 func setup(
 	secretComp secrets.Component,
 	delegatedAuthComp delegatedauth.Component,
@@ -548,9 +556,14 @@ func setup(
 
 	setupOtlpAgent(metricAgent, tagger)
 
+	var usageMetricTagsFunc func() []string
+	if p, ok := cloudService.(usageMetricTagProvider); ok {
+		usageMetricTagsFunc = p.CurrentUsageMetricTags
+	}
+
 	var enhancedMetricsCollector *enhancedmetrics.Collector
 	if enhancedMetricsEnabled {
-		enhancedMetricsCollector, err = enhancedmetrics.NewCollector(metricAgent, cloudService.GetSource(), cloudService.GetMetricPrefix(), cloudService.GetUsageMetricSuffix(), 3*time.Second)
+		enhancedMetricsCollector, err = enhancedmetrics.NewCollector(metricAgent, cloudService.GetSource(), cloudService.GetMetricPrefix(), cloudService.GetUsageMetricSuffix(), 3*time.Second, usageMetricTagsFunc)
 		if err != nil {
 			log.Warnf("Failed to initialize enhanced metrics collector: %v", err)
 		} else {

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -499,6 +499,10 @@ func setup(
 					traceAgent.UpdateRuntimeTags(tags)
 				}),
 				BaseTraceTags: serverlessInitTag.MakeTraceAgentTags(tagConfig.Tags),
+				MetricTagSetter: lifecycle.MetricTagSetterFunc(func(tags []string) {
+					metricAgent.SetEnhancedUsageMetricTags(tags)
+				}),
+				BaseUsageMetricTags: metricTags.EnhancedUsageMetric,
 			},
 		}
 		// Only MicroVM needs initialization without an API key: its Init starts the
@@ -535,6 +539,10 @@ func setup(
 				traceAgent.UpdateRuntimeTags(tags)
 			}),
 			BaseTraceTags: serverlessInitTag.MakeTraceAgentTags(tagConfig.Tags),
+			MetricTagSetter: lifecycle.MetricTagSetterFunc(func(tags []string) {
+				metricAgent.SetEnhancedUsageMetricTags(tags)
+			}),
+			BaseUsageMetricTags: metricTags.EnhancedUsageMetric,
 		},
 	}
 

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -488,6 +488,7 @@ func setup(
 				MetricFlusher: metricAgent,
 				LogsFlusher:   logsAgent,
 				MetricEmitter: metricAgent,
+				SampleDrainer: metricAgent,
 				FlushTimeout:  agentLogConfig.FlushTimeout,
 				SidecarMode:   modeConf.SidecarMode,
 				LogsTagSetter: lifecycle.LogsTagSetterFunc(func(tags []string) {
@@ -528,6 +529,7 @@ func setup(
 			MetricFlusher: metricAgent,
 			LogsFlusher:   logsAgent,
 			MetricEmitter: metricAgent,
+			SampleDrainer: metricAgent,
 			FlushTimeout:  agentLogConfig.FlushTimeout,
 			SidecarMode:   modeConf.SidecarMode,
 			LogsTagSetter: lifecycle.LogsTagSetterFunc(func(tags []string) {

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -150,6 +150,37 @@ func TestBaseTraceTagsComputedFromTagConfigTags(t *testing.T) {
 	assert.NotEmpty(t, baseTraceTags)
 }
 
+// TestUsageMetricTagProvider_MicroVMSatisfiesInterface verifies that
+// *cloudservice.MicroVM implements usageMetricTagProvider — the interface
+// setup() type-asserts cloudService against to wire the enhanced-metrics
+// collector's dynamic per-instance usage tag. If CurrentUsageMetricTags'
+// signature ever drifts, the assertion in setup() would silently stop
+// matching (no compile error) instead of failing loudly; this test is what
+// would catch that.
+func TestUsageMetricTagProvider_MicroVMSatisfiesInterface(t *testing.T) {
+	var cloudService cloudservice.CloudService = &cloudservice.MicroVM{}
+	_, ok := cloudService.(usageMetricTagProvider)
+	assert.True(t, ok, "*MicroVM must satisfy usageMetricTagProvider so setup() wires its dynamic usage-metric tags")
+}
+
+// TestUsageMetricTagProvider_OtherServicesDoNotSatisfy documents that cloud
+// services with no dynamic usage-metric tag are intentionally left out of
+// usageMetricTagProvider; setup()'s type assertion falls through to a nil
+// usageMetricTagsFunc for them, and NewCollector treats nil as "no extra tags".
+func TestUsageMetricTagProvider_OtherServicesDoNotSatisfy(t *testing.T) {
+	services := []cloudservice.CloudService{
+		&cloudservice.LocalService{},
+		&cloudservice.AppService{},
+		&cloudservice.CloudRun{},
+		&cloudservice.CloudRunJobs{},
+		&cloudservice.ContainerApp{},
+	}
+	for _, svc := range services {
+		_, ok := svc.(usageMetricTagProvider)
+		assert.False(t, ok, "%T must not satisfy usageMetricTagProvider — it has no dynamic usage-metric tag", svc)
+	}
+}
+
 // TestSetupOtlpAgentNoPanic ensures setupOtlpAgent does not panic when OTLP is enabled.
 func TestSetupOtlpAgentNoPanic(t *testing.T) {
 	t.Setenv("DD_OTLP_CONFIG_LOGS_ENABLED", "true")

--- a/comp/logs-library/processor/encoder_test.go
+++ b/comp/logs-library/processor/encoder_test.go
@@ -734,6 +734,35 @@ func TestSetServerlessInitTagCache_ResetCausesRederive(t *testing.T) {
 	assert.Equal(t, "new:tag", p2.Tags, "post-reset message must re-derive tags from the message")
 }
 
+// TestJSONServerlessInitEncoder_ColdPathPrimeNeverClobbersConcurrentUpdate pins
+// the ordering guarantee that Encode's cold-path CAS depends on: a stale
+// prime — computed from a pre-launch message before a concurrent
+// SetServerlessInitTagCache update, but landing after it — must never
+// overwrite the authoritative value. Real goroutines aren't needed since the
+// two writes are sequenced explicitly here in the exact order the race would
+// produce; this exercises the same primeTagsFromMessage method Encode's cold
+// path calls, so it would fail if that method were changed back to a plain
+// Store (as the reviewed-then-reverted change in PR #53030 did).
+func TestJSONServerlessInitEncoder_ColdPathPrimeNeverClobbersConcurrentUpdate(t *testing.T) {
+	enc := &jsonServerlessInitEncoder{}
+
+	// t1: SetServerlessInitTagCache lands first with the authoritative,
+	// updated tags (e.g. from a /run hook).
+	authoritative := "env:prod,account_id:123,lambda_microvm_id:vm-xyz"
+	enc.cachedTags.Store(&authoritative)
+
+	// t2: a slow cold-path Encode call, which computed its (now stale) tags
+	// from a pre-launch message before the update landed, finally attempts
+	// to prime the cache.
+	enc.primeTagsFromMessage("env:prod,account_id:123")
+
+	got := enc.cachedTags.Load()
+	if assert.NotNil(t, got) {
+		assert.Equal(t, authoritative, *got,
+			"a stale cold-path prime must not clobber a concurrent SetServerlessInitTagCache update")
+	}
+}
+
 // TestJSONServerlessInitEncoder_ConcurrentSafety verifies that concurrent calls
 // to Encode and SetServerlessInitTagCache do not race. Run with -race to
 // exercise the atomic guarantees; the assertions confirm no crashes and

--- a/comp/logs-library/processor/json_serverless_init.go
+++ b/comp/logs-library/processor/json_serverless_init.go
@@ -33,10 +33,22 @@ type jsonServerlessInitEncoder struct {
 	cachedTags atomic.Pointer[string]
 }
 
+// primeTagsFromMessage atomically primes the cache from a message's computed
+// tags, but only if the cache is currently nil. This must be a CAS rather
+// than a plain Store: it can race with a concurrent SetServerlessInitTagCache
+// call (e.g. from a MicroVM /run hook), and a plain Store could overwrite that
+// authoritative, possibly newer, value with this message's stale snapshot.
+// The CAS only ever transitions nil -> primed, so it can never clobber a
+// value SetServerlessInitTagCache already wrote.
+func (j *jsonServerlessInitEncoder) primeTagsFromMessage(tagsStr string) {
+	s := tagsStr
+	j.cachedTags.CompareAndSwap(nil, &s)
+}
+
 // SetServerlessInitTagCache pre-populates the JSONServerlessInitEncoder's cache
 // with the provided tags. This must be called (instead of clearing the cache)
-// whenever the log tag set changes at runtime (e.g. after /launch appends
-// lambda_microvm_id). Setting the cache directly prevents in-flight pre-launch
+// whenever the log tag set changes at runtime (e.g. after /run appends
+// lambda_microvm_id). Setting the cache directly prevents in-flight pre-run
 // messages — whose origin.tags were snapshotted before the update — from being
 // encoded first and re-priming the cache with stale tags.
 //
@@ -82,16 +94,14 @@ func (j *jsonServerlessInitEncoder) Encode(msg *message.Message, hostname string
 		tagsStr = *p
 	} else {
 		// Cache uninitialised (startup or post-reset): derive from the message
-		// and prime it for subsequent calls. All callers compute the same
-		// static tags in a serverless-init environment, so a plain Store is
-		// fine even if multiple goroutines race here.
+		// and prime it for subsequent calls.
 		//
 		// This assumes every message primes the cache with the same tags. That's
 		// only true because SetServerlessInitTagCache is the sole path for changing
 		// tags after startup; if a caller ever needs per-message tags, this cache
 		// needs to go away, not be patched.
 		tagsStr = msg.TagsToString()
-		j.cachedTags.Store(&tagsStr)
+		j.primeTagsFromMessage(tagsStr)
 	}
 
 	encoded, err := json.Marshal(jsonServerlessInitPayload{

--- a/pkg/aggregator/BUILD.bazel
+++ b/pkg/aggregator/BUILD.bazel
@@ -109,6 +109,7 @@ dd_agent_go_test(
         "tagfilter_cache_test.go",
         "tagset_telem_test.go",
         "time_sampler_test.go",
+        "time_sampler_worker_test.go",
     ],
     embed = [":aggregator"],
     gotags_sets = [[

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -384,7 +384,7 @@ func TestSeriesTooManyTags(t *testing.T) {
 			s.On("SendServiceChecks", mock.Anything).Return(nil)
 			s.On("SendIterableSeries", mock.Anything).Return(nil)
 
-			demux.ForceFlushToSerializer(start, true)
+			demux.ForceFlushToSerializer(start, true, false)
 			s.AssertNotCalled(t, "SendEvents")
 			s.AssertNotCalled(t, "SendSketch")
 
@@ -453,7 +453,7 @@ func TestDistributionsTooManyTags(t *testing.T) {
 			s.On("SendIterableSeries", mock.Anything).Return(nil).Times(1)
 			s.On("SendSketch", mock.Anything).Return(nil).Times(1)
 
-			demux.ForceFlushToSerializer(start, true)
+			demux.ForceFlushToSerializer(start, true, false)
 			s.AssertNotCalled(t, "SendEvents")
 
 			expMap := map[string]uint64{}
@@ -540,7 +540,7 @@ func TestRecurrentSeries(t *testing.T) {
 	})
 
 	s.On("SendServiceChecks", agentUpMatcher).Return(nil).Times(1)
-	demux.ForceFlushToSerializer(start, true)
+	demux.ForceFlushToSerializer(start, true, false)
 	require.EqualValues(t, expectedSeries, s.series)
 	s.series = nil
 
@@ -550,7 +550,7 @@ func TestRecurrentSeries(t *testing.T) {
 	// Assert that recurrentSeries are sent on each flushed
 	// same goes for the service check
 	s.On("SendServiceChecks", agentUpMatcher).Return(nil).Times(1)
-	demux.ForceFlushToSerializer(start, true)
+	demux.ForceFlushToSerializer(start, true, false)
 	require.EqualValues(t, expectedSeries, s.series)
 	s.series = nil
 
@@ -759,7 +759,7 @@ func flushSomeSamples(demux *AgentDemultiplexer) map[string]*metrics.Serie {
 	// sure all samples have been processed by the sampler
 	time.Sleep(1 * time.Second)
 
-	demux.ForceFlushToSerializer(time.Unix(int64(timeSamplerBucketSize)*3, 0), true)
+	demux.ForceFlushToSerializer(time.Unix(int64(timeSamplerBucketSize)*3, 0), true, false)
 	return expectedSeries
 }
 

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -46,8 +46,9 @@ type Demultiplexer interface {
 	SendSamplesWithoutAggregation(metrics metrics.MetricSampleBatch)
 
 	// ForceFlushToSerializer flushes all the aggregated data from the different samplers to
-	// the serialization/forwarding parts.
-	ForceFlushToSerializer(start time.Time, waitForSerializer bool)
+	// the serialization/forwarding parts. forceFlushAll additionally includes samples in
+	// the current, not-yet-closed time bucket (otherwise they wait for the next flush).
+	ForceFlushToSerializer(start time.Time, waitForSerializer bool, forceFlushAll bool)
 	// GetMetricSamplePool returns a shared resource used in the whole DogStatsD
 	// pipeline to re-use metric samples slices: the server is getting a slice
 	// and filling it with samples, the rest of the pipeline process them the

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -519,12 +519,12 @@ func (d *AgentDemultiplexer) Stop() {
 // ForceFlushToSerializer triggers the execution of a flush from all data of samplers
 // and the BufferedAggregator to the serializer.
 // Safe to call from multiple threads.
-func (d *AgentDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSerializer bool) {
+func (d *AgentDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSerializer bool, forceFlushAll bool) {
 	trigger := trigger{
 		time:              start,
 		waitForSerializer: waitForSerializer,
 		blockChan:         make(chan struct{}),
-		forceFlushAll:     false,
+		forceFlushAll:     forceFlushAll,
 	}
 	d.flushChan <- trigger
 	<-trigger.blockChan
@@ -690,11 +690,23 @@ func (d *AgentDemultiplexer) AggregateSamples(shard TimeSamplerID, samples metri
 	d.statsd.workers[shard].addSamples(samples)
 }
 
+// singleSampleShard is the time sampler shard used by AggregateSample.
+// WaitForPendingSamples drains this same shard, so the two must stay in sync.
+const singleSampleShard TimeSamplerID = 0
+
 // AggregateSample adds a MetricSample in the first DogStatsD time sampler.
 func (d *AgentDemultiplexer) AggregateSample(sample metrics.MetricSample) {
 	batch := d.GetMetricSamplePool().GetBatch()
 	batch[0] = sample
-	d.statsd.workers[0].addSamples(batch[:1])
+	d.statsd.workers[singleSampleShard].addSamples(batch[:1])
+}
+
+// WaitForPendingSamples blocks until samples enqueued on singleSampleShard
+// before this call have been consumed. Used by serverless-init's on-demand
+// flush, where a sample submitted right before a flush could otherwise race
+// it.
+func (d *AgentDemultiplexer) WaitForPendingSamples() {
+	d.statsd.workers[singleSampleShard].waitForPendingSamples()
 }
 
 // AggregateCheckSample adds check sample sent by a check from one of the collectors into a check sampler pipeline.

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -433,7 +433,7 @@ func TestUpdateTagFilterList(t *testing.T) {
 		require.Eventually(func() bool {
 			return len(demux.statsd.workers[0].samplesChan) == 0
 		}, time.Second, time.Millisecond)
-		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true)
+		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true, false)
 
 		metric := slices.IndexFunc(s.sketches, func(serie metrics.Distribution) bool {
 			return serie.GetName() == "dist.metric"
@@ -561,7 +561,7 @@ func TestUpdateTagFilterListCheckSamplerCacheInvalidation(t *testing.T) {
 		require.Eventually(func() bool {
 			return len(demux.aggregator.checkItems) == 0
 		}, time.Second, time.Millisecond)
-		demux.ForceFlushToSerializer(time.Now(), true)
+		demux.ForceFlushToSerializer(time.Now(), true, false)
 	}
 
 	// First send: tag1 and tag2 are excluded. This is a cache miss so the
@@ -642,7 +642,7 @@ func TestUpdateMetricFilterList(t *testing.T) {
 		require.Eventually(func() bool {
 			return len(demux.statsd.workers[0].samplesChan) == 0
 		}, time.Second, time.Millisecond)
-		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true)
+		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true, false)
 
 		// We should always contain the average of the histogram.
 		require.Equal(blockCount, slices.ContainsFunc(s.series, func(serie *metrics.Serie) bool {

--- a/pkg/aggregator/time_sampler_worker.go
+++ b/pkg/aggregator/time_sampler_worker.go
@@ -49,6 +49,10 @@ type timeSamplerWorker struct {
 	samplesChan chan []metrics.MetricSample
 	// samplesDrained is closed after last sample is read from samplesChan
 	samplesDrained chan struct{}
+	// drainChan requests a synchronous drain of samplesChan. Unlike
+	// shutdown/samplesDrained, it's repeatable and doesn't touch the worker's
+	// lifecycle.
+	drainChan chan chan struct{}
 	// use this chan to trigger a flush of the time sampler
 	flushChan chan flushTrigger
 	// use this chan to trigger a filterList reconfiguration
@@ -83,6 +87,7 @@ func newTimeSamplerWorker(sampler *TimeSampler, flushInterval time.Duration, buf
 
 		samplesChan:          make(chan []metrics.MetricSample, bufferSize),
 		samplesDrained:       make(chan struct{}),
+		drainChan:            make(chan chan struct{}),
 		stopChan:             make(chan struct{}),
 		flushChan:            make(chan flushTrigger),
 		dumpChan:             make(chan dumpTrigger),
@@ -112,15 +117,7 @@ func (w *timeSamplerWorker) run() {
 				close(w.samplesDrained)
 				continue
 			}
-
-			aggregatorDogstatsdMetricSample.Add(int64(len(ms)))
-			tlmProcessed.Add(float64(len(ms)), shard, "dogstatsd_metrics")
-			t := timeNowNano()
-
-			for i := 0; i < len(ms); i++ {
-				w.sampler.sample(&ms[i], t, w.tagFilterList)
-			}
-			w.metricSamplePool.PutBatch(ms)
+			w.processBatch(ms)
 		case matcher := <-w.metricFilterListChan:
 			w.flushFilterList = matcher
 		case matcher := <-w.tagFilterListChan:
@@ -130,8 +127,38 @@ func (w *timeSamplerWorker) run() {
 			w.tagsStore.Shrink()
 		case trigger := <-w.dumpChan:
 			trigger.done <- w.sampler.dumpContexts(trigger.dest)
+		case done := <-w.drainChan:
+			// select doesn't order drainChan against samplesChan, so drain
+			// whatever's already buffered before acking.
+		drainLoop:
+			for {
+				select {
+				case ms := <-w.samplesChan:
+					if ms == nil {
+						close(w.samplesDrained)
+						continue
+					}
+					w.processBatch(ms)
+				default:
+					break drainLoop
+				}
+			}
+			close(done)
 		}
 	}
+}
+
+// processBatch samples ms, called from run()'s normal loop or from a drain.
+func (w *timeSamplerWorker) processBatch(ms []metrics.MetricSample) {
+	shard := w.sampler.idString
+	aggregatorDogstatsdMetricSample.Add(int64(len(ms)))
+	tlmProcessed.Add(float64(len(ms)), shard, "dogstatsd_metrics")
+	t := timeNowNano()
+
+	for i := 0; i < len(ms); i++ {
+		w.sampler.sample(&ms[i], t, w.tagFilterList)
+	}
+	w.metricSamplePool.PutBatch(ms)
 }
 
 // Set a new filterlist, ensuring we also clear the context resolver strip cache
@@ -177,4 +204,12 @@ func (w *timeSamplerWorker) waitForShutdown(ctx context.Context) {
 	case <-w.samplesDrained:
 	case <-ctx.Done():
 	}
+}
+
+// waitForPendingSamples blocks until samples enqueued before this call have
+// been processed. Safe to call repeatedly, unlike shutdown/waitForShutdown.
+func (w *timeSamplerWorker) waitForPendingSamples() {
+	done := make(chan struct{})
+	w.drainChan <- done
+	<-done
 }

--- a/pkg/aggregator/time_sampler_worker_test.go
+++ b/pkg/aggregator/time_sampler_worker_test.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+// A sample sent right before WaitForPendingSamples must be processed by the
+// time the call returns, and the call must be repeatable.
+func TestWaitForPendingSamplesDrainsBeforeReturning(t *testing.T) {
+	require := require.New(t)
+
+	deps := createDemultiplexerAgentTestDeps(t)
+	opts := demuxTestOptions()
+	// InitAndStartAgentDemultiplexer (not initAgentDemultiplexer) is required
+	// here: WaitForPendingSamples needs the worker's run() goroutine actually
+	// running to service drainChan.
+	demux := InitAndStartAgentDemultiplexer(deps.Log, NewForwarderTest(deps.Log), deps.OrchestratorFwd, opts, deps.EventPlatform, deps.HaAgent, deps.Compressor, deps.Tagger, deps.FilterList, "")
+	defer demux.Stop()
+
+	worker := demux.statsd.workers[0]
+	require.Equal(0, worker.sampler.contextResolver.length())
+
+	demux.AggregateSample(metrics.MetricSample{
+		Name:      "test.metric",
+		Value:     1,
+		Mtype:     metrics.GaugeType,
+		Timestamp: 1657099120.0,
+		Tags:      []string{"tag:1"},
+	})
+
+	demux.WaitForPendingSamples()
+
+	require.Len(worker.samplesChan, 0, "the sample must have been drained from samplesChan")
+	require.Equal(1, worker.sampler.contextResolver.length(), "the sample must have been aggregated into a context, not just dequeued")
+
+	// Calling it again with nothing pending must not block or panic.
+	demux.WaitForPendingSamples()
+}

--- a/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents_test.go
+++ b/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents_test.go
@@ -262,7 +262,7 @@ func TestKubernetesAdmissionEvents(t *testing.T) {
 			mockSender.On("Event", mock.AnythingOfType("event.Event")).Return().Once()
 			validated, err := kubernetesAuditWebhook.emitEvent(&tt.request, "", nil)
 			// Force flush to serializer to ensure the event is emitted and received.
-			demultiplexerMock.ForceFlushToSerializer(start, true)
+			demultiplexerMock.ForceFlushToSerializer(start, true, false)
 			assert.NoError(t, err)
 			assert.True(t, validated)
 			if tt.expectedEmitted {

--- a/pkg/serverless/env/env.go
+++ b/pkg/serverless/env/env.go
@@ -19,6 +19,9 @@ const (
 
 	// MicroVMImageARNEnvVar is injected by the AWS Lambda MicroVM platform at runtime.
 	MicroVMImageARNEnvVar = "AWS_LAMBDA_MICROVM_IMAGE_ARN"
+
+	// MicroVMImageVersionEnvVar is injected by the AWS Lambda MicroVM platform at runtime.
+	MicroVMImageVersionEnvVar = "AWS_LAMBDA_MICROVM_IMAGE_VERSION"
 )
 
 // IsAzureAppServicesExtension returns true if running in Datadog Azure App

--- a/pkg/serverless/metrics/BUILD.bazel
+++ b/pkg/serverless/metrics/BUILD.bazel
@@ -17,6 +17,7 @@ dd_agent_go_test(
     name = "metrics_test",
     srcs = [
         "metric_add_test.go",
+        "metric_drain_test.go",
         "metric_test.go",
     ],
     embed = [":metrics"],
@@ -30,6 +31,7 @@ dd_agent_go_test(
         "//comp/core/log/mock",
         "//comp/core/secrets/def",
         "//comp/core/secrets/mock",
+        "//comp/core/tagger/fx-mock",
         "//comp/core/tagger/impl-noop",
         "//comp/filterlist/fx-mock",
         "//comp/forwarder/defaultforwarder/def",

--- a/pkg/serverless/metrics/metric.go
+++ b/pkg/serverless/metrics/metric.go
@@ -73,15 +73,43 @@ func (c *ServerlessMetricAgent) SetEnhancedUsageMetricTags(tags []string) {
 	c.enhancedUsageMetricTags.Store(&tags)
 }
 
-// Flush forces an immediate flush of aggregated samples to the serializer.
+// Flush forces an immediate flush of already-closed buckets to the serializer.
 // Satisfied interface: cmd/serverless-init/lifecycle.Flusher, used by MicroVM
-// to flush telemetry on-demand before a Firecracker snapshot (/suspend,
-// /terminate), independent of the Fx-managed shutdown flush.
+// to flush telemetry on-demand before a Firecracker snapshot on /suspend,
+// independent of the Fx-managed shutdown flush. /terminate uses FlushAll instead.
 func (c *ServerlessMetricAgent) Flush() {
 	if c.Demux == nil {
 		return
 	}
-	c.Demux.ForceFlushToSerializer(time.Now(), true)
+	c.Demux.ForceFlushToSerializer(time.Now(), true, false)
+}
+
+// FlushAll additionally includes the current, not-yet-closed bucket. Satisfied
+// interface: cmd/serverless-init/lifecycle.ForceFlusher — see that doc for why
+// this must stay off /suspend's path.
+func (c *ServerlessMetricAgent) FlushAll() {
+	if c.Demux == nil {
+		return
+	}
+	c.Demux.ForceFlushToSerializer(time.Now(), true, true)
+}
+
+// pendingSampleDrainer is satisfied by *aggregator.AgentDemultiplexer, and by
+// anything embedding it — notably the Fx demultiplexer component's wrapper
+// struct, which is what c.Demux actually holds in production. Asserting
+// against this interface instead of the concrete *AgentDemultiplexer type
+// lets Go's method promotion see through that wrapper.
+type pendingSampleDrainer interface {
+	WaitForPendingSamples()
+}
+
+// WaitForPendingSamples blocks until samples enqueued before this call have
+// been consumed. Satisfied interface: cmd/serverless-init/lifecycle.SampleDrainer.
+// No-op if the demux doesn't support draining (e.g. unset in tests).
+func (c *ServerlessMetricAgent) WaitForPendingSamples() {
+	if d, ok := c.Demux.(pendingSampleDrainer); ok {
+		d.WaitForPendingSamples()
+	}
 }
 
 // sendMetricSample records a distribution metric sample using the agent's extra tags plus any

--- a/pkg/serverless/metrics/metric.go
+++ b/pkg/serverless/metrics/metric.go
@@ -7,6 +7,7 @@
 package metrics
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -30,11 +31,17 @@ type Tags struct {
 type ServerlessMetricAgent struct {
 	Demux aggregator.Demultiplexer
 	tags  Tags
+	// enhancedUsageMetricTags backs AddEnhancedUsageMetric. Swapped via
+	// SetEnhancedUsageMetricTags once MicroVM's /run hook learns the
+	// instance tag; same pattern as spanModifier.tags.
+	enhancedUsageMetricTags atomic.Pointer[[]string]
 }
 
 // New constructs a ServerlessMetricAgent.
 func New(demux aggregator.Demultiplexer, tags Tags) *ServerlessMetricAgent {
-	return &ServerlessMetricAgent{Demux: demux, tags: tags}
+	agent := &ServerlessMetricAgent{Demux: demux, tags: tags}
+	agent.enhancedUsageMetricTags.Store(&tags.EnhancedUsageMetric)
+	return agent
 }
 
 // AddLegacyEnhancedMetric reports a metric value to the intake with all tags.
@@ -53,7 +60,17 @@ func (c *ServerlessMetricAgent) AddEnhancedMetric(name string, value float64, me
 // AddEnhancedUsageMetric reports a metric value to the intake with the given timestamp and tags selected for enhanced usage metrics.
 // optional tags supplied as `key:value` strings through extraTags.
 func (c *ServerlessMetricAgent) AddEnhancedUsageMetric(name string, value float64, metricSource metrics.MetricSource, timestamp float64, extraTags ...string) {
-	c.sendMetricSample(name, value, metricSource, metrics.GaugeType, timestamp, c.tags.EnhancedUsageMetric, extraTags...)
+	tags := c.tags.EnhancedUsageMetric
+	if loaded := c.enhancedUsageMetricTags.Load(); loaded != nil {
+		tags = *loaded
+	}
+	c.sendMetricSample(name, value, metricSource, metrics.GaugeType, timestamp, tags, extraTags...)
+}
+
+// SetEnhancedUsageMetricTags atomically replaces the enhanced usage metric's
+// tags. Safe to call concurrently with AddEnhancedUsageMetric.
+func (c *ServerlessMetricAgent) SetEnhancedUsageMetricTags(tags []string) {
+	c.enhancedUsageMetricTags.Store(&tags)
 }
 
 // Flush forces an immediate flush of aggregated samples to the serializer.

--- a/pkg/serverless/metrics/metric_drain_test.go
+++ b/pkg/serverless/metrics/metric_drain_test.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
+	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
+	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	filterlistmock "github.com/DataDog/datadog-agent/comp/filterlist/fx-mock"
+	defaultforwarder "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/def"
+	haagentmock "github.com/DataDog/datadog-agent/comp/haagent/mock"
+	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
+	metricscompression "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx-mock"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	pkgmetrics "github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/serverless/metrics/metricstest"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Same nil-Demux safety already covered for Flush/FlushAll by
+// TestMetricAgentNoOpWithoutDemux in main_test.go.
+func TestWaitForPendingSamplesNoOpWithoutDemux(t *testing.T) {
+	agent := &ServerlessMetricAgent{}
+	assert.NotPanics(t, func() {
+		agent.WaitForPendingSamples()
+	})
+}
+
+// TestWaitForPendingSamplesDrainsRealDemux runs against the actual Fx wiring
+// production code gets. bundle.Demux's dynamic type is the demultiplexerimpl
+// wrapper struct, not a bare *aggregator.AgentDemultiplexer — a concrete-type
+// assertion in WaitForPendingSamples would silently no-op here.
+func TestWaitForPendingSamplesDrainsRealDemux(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	bundle := metricstest.New(t, fakeTagger)
+
+	_, ok := bundle.Demux.(pendingSampleDrainer)
+	require.True(t, ok, "the Fx-provided demux must satisfy pendingSampleDrainer, or WaitForPendingSamples silently no-ops in production")
+
+	agent := New(bundle.Demux, Tags{EnhancedMetric: []string{"tag:1"}})
+	assert.NotPanics(t, func() {
+		agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, 0)
+		agent.WaitForPendingSamples()
+		agent.WaitForPendingSamples()
+	})
+}
+
+// TestWaitForPendingSamplesDrainsThroughWrappedDemux mirrors
+// TestStopDrainsThroughWrappedDemux above (same wrappedDemux type): proves a
+// sample submitted through the wrapped Demux is actually drained, not just
+// that the type assertion succeeds. Without a working drain, AddEnhancedMetric
+// and the worker processing it race FlushAll — same race TestStopDrainsBeforeFlush
+// documents — so a single iteration can pass by luck; 100 iterations make a
+// broken drain reliably show up as a sketchCount short of iterations.
+func TestWaitForPendingSamplesDrainsThroughWrappedDemux(t *testing.T) {
+	mockConfig := configmock.New(t)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
+
+	cf := newCountingForwarder()
+
+	deps := fxutil.Test[aggregator.TestDeps](t,
+		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		fx.Provide(func() defaultforwarder.Component { return cf }),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		haagentmock.Module(),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		filterlistmock.MockModule(),
+	)
+
+	const iterations = 100
+	future := float64(time.Now().Add(time.Hour).UnixNano()) / float64(time.Second)
+	for i := 0; i < iterations; i++ {
+		opts := aggregator.DefaultAgentDemultiplexerOptions()
+		opts.FlushInterval = time.Hour
+		opts.DontStartForwarders = true
+		demux := aggregator.InitAndStartAgentDemultiplexerForTest(deps, opts, "")
+
+		agent := New(wrappedDemux{AgentDemultiplexer: demux}, Tags{})
+		agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, future)
+
+		agent.WaitForPendingSamples()
+		agent.FlushAll()
+
+		demux.Stop()
+	}
+
+	require.Equal(t, int64(iterations), cf.sketchCount.Load(),
+		"WaitForPendingSamples must drain every sample submitted through the wrapped Demux before FlushAll runs")
+}

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -234,3 +234,83 @@ func TestShutdownCascadeFlushesLateSample(t *testing.T) {
 	require.Equal(t, int64(1), cf.sketchCount.Load(),
 		"the OnStop cascade must drain and flush the late sample to the forwarder")
 }
+
+// TestFlushAllDeliversOpenBucketSample proves FlushAll delivers a sample still
+// sitting in the current, open bucket — no periodic flush needed.
+// require.Eventually retries because AddEnhancedMetric and the worker
+// processing it race (the still-open SampleDrainer gap); that's not what this
+// test covers.
+func TestFlushAllDeliversOpenBucketSample(t *testing.T) {
+	mockConfig := configmock.New(t)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
+
+	cf := newCountingForwarder()
+
+	deps := fxutil.Test[aggregator.TestDeps](t,
+		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		fx.Provide(func() defaultforwarder.Component { return cf }),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		haagentmock.Module(),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		filterlistmock.MockModule(),
+	)
+
+	opts := aggregator.DefaultAgentDemultiplexerOptions()
+	opts.FlushInterval = time.Hour // disable automatic flushes
+	opts.DontStartForwarders = true
+	demux := aggregator.InitAndStartAgentDemultiplexerForTest(deps, opts, "")
+	defer demux.Stop()
+
+	agent := New(demux, Tags{})
+	// An hour out so the bucket can never close mid-test, regardless of real
+	// bucket-boundary timing.
+	future := float64(time.Now().Add(time.Hour).UnixNano()) / float64(time.Second)
+	agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, future)
+
+	require.Eventually(t, func() bool {
+		agent.FlushAll()
+		return cf.sketchCount.Load() >= 1
+	}, time.Second, time.Millisecond,
+		"FlushAll must deliver a sample from the still-open bucket")
+}
+
+// TestFlushSkipsOpenBucket is the negative control for
+// TestFlushAllDeliversOpenBucketSample: Flush must never include a sample
+// from the still-open bucket.
+func TestFlushSkipsOpenBucket(t *testing.T) {
+	mockConfig := configmock.New(t)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
+
+	cf := newCountingForwarder()
+
+	deps := fxutil.Test[aggregator.TestDeps](t,
+		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		fx.Provide(func() defaultforwarder.Component { return cf }),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		haagentmock.Module(),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		filterlistmock.MockModule(),
+	)
+
+	opts := aggregator.DefaultAgentDemultiplexerOptions()
+	opts.FlushInterval = time.Hour // disable automatic flushes
+	opts.DontStartForwarders = true
+	demux := aggregator.InitAndStartAgentDemultiplexerForTest(deps, opts, "")
+	defer demux.Stop()
+
+	agent := New(demux, Tags{})
+	future := float64(time.Now().Add(time.Hour).UnixNano()) / float64(time.Second)
+	agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, future)
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		agent.Flush()
+		time.Sleep(time.Millisecond)
+	}
+	assert.Equal(t, int64(0), cf.sketchCount.Load(),
+		"Flush must not deliver a sample from the still-open bucket")
+}

--- a/pkg/serverless/trace/BUILD.bazel
+++ b/pkg/serverless/trace/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/trace/traceutil",
         "//pkg/util/log",
         "@com_github_datadog_datadog_go_v5//statsd",
+        "@org_uber_go_atomic//:atomic",
     ],
 )
 

--- a/pkg/serverless/trace/span_modifer_test.go
+++ b/pkg/serverless/trace/span_modifer_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
 	gzip "github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -108,4 +109,90 @@ func TestSpanModifierDetectsCloudService(t *testing.T) {
 		testOriginTags(false, origin)
 		os.Unsetenv(cloudServiceEnvVar)
 	}
+}
+
+// TestSpanModifierModifySpanBeforeSetTags verifies that ModifySpan only
+// applies the _dd.origin tag when SetTags has never been called, since
+// spanModifier.tags starts as an unset atomic.Pointer.
+func TestSpanModifierModifySpanBeforeSetTags(t *testing.T) {
+	sm := &spanModifier{ddOrigin: "lambda"}
+	span := &pb.Span{Meta: map[string]string{}}
+
+	sm.ModifySpan(&pb.TraceChunk{}, span)
+
+	assert.Equal(t, "lambda", span.Meta[ddOriginTagName])
+	assert.Len(t, span.Meta, 1)
+}
+
+// TestSpanModifierModifySpanAppliesTagsSetDynamically verifies that tags
+// applied via SetTags after construction are picked up by ModifySpan, the
+// mechanism MicroVM uses to deliver the lambda_microvm_id tag once it becomes
+// known at /run time.
+func TestSpanModifierModifySpanAppliesTagsSetDynamically(t *testing.T) {
+	sm := &spanModifier{ddOrigin: "lambda"}
+	sm.SetTags(map[string]string{"lambda_microvm_id": "vm-123"})
+
+	span := &pb.Span{Meta: map[string]string{}}
+	sm.ModifySpan(&pb.TraceChunk{}, span)
+
+	assert.Equal(t, "lambda", span.Meta[ddOriginTagName])
+	assert.Equal(t, "vm-123", span.Meta["lambda_microvm_id"])
+}
+
+// TestSpanModifierModifySpanPreservesExistingOrigin verifies that ModifySpan
+// does not overwrite a span's existing _dd.origin when the dynamically-set
+// tags also contain _dd.origin. Every CloudService.GetTags() sets _dd.origin
+// (e.g. MicroVM sets "lambdamicrovm"), and that value flows into the tags
+// applied here via SetTags/UpdateRuntimeTags — so without this guard, every
+// span would have a tracer-supplied origin (e.g. "rum") silently replaced.
+func TestSpanModifierModifySpanPreservesExistingOrigin(t *testing.T) {
+	sm := &spanModifier{ddOrigin: "lambda"}
+	sm.SetTags(map[string]string{ddOriginTagName: "lambdamicrovm", "lambda_microvm_id": "vm-123"})
+
+	span := &pb.Span{Meta: map[string]string{ddOriginTagName: "rum"}}
+	sm.ModifySpan(&pb.TraceChunk{}, span)
+
+	assert.Equal(t, "rum", span.Meta[ddOriginTagName], "must not overwrite a tracer-supplied origin")
+	assert.Equal(t, "vm-123", span.Meta["lambda_microvm_id"])
+}
+
+// TestSpanModifierModifySpanReflectsLatestSetTags verifies that a later
+// SetTags call replaces the tag set used by subsequent ModifySpan calls.
+func TestSpanModifierModifySpanReflectsLatestSetTags(t *testing.T) {
+	sm := &spanModifier{ddOrigin: "lambda"}
+	sm.SetTags(map[string]string{"lambda_microvm_id": "vm-1"})
+	sm.SetTags(map[string]string{"lambda_microvm_id": "vm-2"})
+
+	span := &pb.Span{Meta: map[string]string{}}
+	sm.ModifySpan(&pb.TraceChunk{}, span)
+
+	assert.Equal(t, "vm-2", span.Meta["lambda_microvm_id"])
+}
+
+// TestSpanModifierSetTagsConcurrentWithModifySpan exercises SetTags and
+// ModifySpan concurrently under the race detector. This is a regression test
+// for the data race Codex flagged on PR #53036: MicroVM's /run hook calls
+// SetTags from a goroutine that runs concurrently with the trace agent's
+// span-processing loop, which calls ModifySpan on every span.
+func TestSpanModifierSetTagsConcurrentWithModifySpan(t *testing.T) {
+	sm := &spanModifier{ddOrigin: "lambda"}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			sm.SetTags(map[string]string{"lambda_microvm_id": "vm-1"})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			span := &pb.Span{Meta: map[string]string{}}
+			sm.ModifySpan(&pb.TraceChunk{}, span)
+		}
+	}()
+	wg.Wait()
+
+	assert.Equal(t, map[string]string{"lambda_microvm_id": "vm-1"}, *sm.tags.Load())
 }

--- a/pkg/serverless/trace/span_modifier.go
+++ b/pkg/serverless/trace/span_modifier.go
@@ -7,6 +7,8 @@
 package trace
 
 import (
+	"go.uber.org/atomic"
+
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
@@ -16,7 +18,7 @@ const (
 )
 
 type spanModifier struct {
-	tags     map[string]string
+	tags     atomic.Pointer[map[string]string]
 	ddOrigin string
 }
 
@@ -26,9 +28,17 @@ func (s *spanModifier) ModifySpan(_ *pb.TraceChunk, span *pb.Span) {
 	if origin := span.Meta[ddOriginTagName]; origin == "" {
 		traceutil.SetMeta(span, ddOriginTagName, s.ddOrigin)
 	}
+	if tags := s.tags.Load(); tags != nil {
+		for k, v := range *tags {
+			if k == ddOriginTagName {
+				continue
+			}
+			traceutil.SetMeta(span, k, v)
+		}
+	}
 }
 
 // SetTags sets the tags to be used by the span modifier.
 func (s *spanModifier) SetTags(tags map[string]string) {
-	s.tags = tags
+	s.tags.Store(&tags)
 }

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -43,6 +43,7 @@ type ServerlessTraceAgent interface {
 	Flush()
 	Process(p *api.Payload)
 	SetTags(map[string]string)
+	UpdateRuntimeTags(map[string]string)
 	SetTargetTPS(float64)
 	SetSpanModifier(agent.SpanModifier)
 	GetSpanModifier() agent.SpanModifier
@@ -204,6 +205,15 @@ func (t *serverlessTraceAgent) SetTags(tags map[string]string) {
 	}
 }
 
+// UpdateRuntimeTags updates the tags applied by the span modifier only. Unlike
+// SetTags, it does not touch the trace agent's GlobalTags, so it is safe to
+// call concurrently with span processing.
+func (t *serverlessTraceAgent) UpdateRuntimeTags(tags map[string]string) {
+	if tagger, ok := t.ta.SpanModifier.(taggable); ok {
+		tagger.SetTags(tags)
+	}
+}
+
 // Stop cancels the trace agent's context and waits for its Run loop to finish.
 // The Run loop handles the full shutdown sequence: draining in-flight traces,
 // flushing stats producers, sending buffered data to the network, and stopping
@@ -300,6 +310,7 @@ func (t noopTraceAgent) Stop()                               {}
 func (t noopTraceAgent) Flush()                              {}
 func (t noopTraceAgent) Process(*api.Payload)                {}
 func (t noopTraceAgent) SetTags(map[string]string)           {}
+func (t noopTraceAgent) UpdateRuntimeTags(map[string]string) {}
 func (t noopTraceAgent) SetTargetTPS(float64)                {}
 func (t noopTraceAgent) SetSpanModifier(agent.SpanModifier)  {}
 func (t noopTraceAgent) GetSpanModifier() agent.SpanModifier { return nil }

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -8,6 +8,7 @@
 package trace
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -19,12 +20,30 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
+	gzip "github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
+
+// newTestServerlessTraceAgent builds a minimal serverlessTraceAgent backed by
+// a real *agent.Agent and spanModifier, without starting the agent's Run loop.
+func newTestServerlessTraceAgent(t *testing.T) (*serverlessTraceAgent, *config.AgentConfig) {
+	t.Helper()
+	cfg := config.New()
+	cfg.Endpoints[0].APIKey = "test"
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ta := agent.NewAgent(ctx, cfg, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, gzip.NewComponent())
+	ta.SpanModifier = &spanModifier{ddOrigin: "lambda"}
+	return &serverlessTraceAgent{ta: ta, cancel: cancel}, cfg
+}
 
 func setupTraceAgentTest(t *testing.T) {
 	// ensure a free port is used for starting the trace agent
@@ -246,4 +265,54 @@ func TestServerlessTraceAgentDisableTraceStats(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestServerlessTraceAgentSetTagsUpdatesGlobalTagsAndSpanModifier verifies
+// that the synchronous SetTags path (used once at startup, before the trace
+// agent starts processing spans) still updates both GlobalTags and the span
+// modifier, as it did before this fix.
+func TestServerlessTraceAgentSetTagsUpdatesGlobalTagsAndSpanModifier(t *testing.T) {
+	sta, cfg := newTestServerlessTraceAgent(t)
+
+	sta.SetTags(map[string]string{"lambda_microvm_id": "vm-1"})
+
+	assert.Equal(t, map[string]string{"lambda_microvm_id": "vm-1"}, cfg.GlobalTags)
+
+	sm, ok := sta.ta.SpanModifier.(*spanModifier)
+	require.True(t, ok)
+	got := sm.tags.Load()
+	require.NotNil(t, got)
+	assert.Equal(t, map[string]string{"lambda_microvm_id": "vm-1"}, *got)
+}
+
+// TestServerlessTraceAgentUpdateRuntimeTagsDoesNotTouchGlobalTags is the core
+// regression test for the fix: UpdateRuntimeTags (used by MicroVM's async
+// /run hook) must only update the span modifier and must never write to
+// GlobalTags, since GlobalTags is read unsynchronized by the trace agent's
+// span-processing hot path.
+func TestServerlessTraceAgentUpdateRuntimeTagsDoesNotTouchGlobalTags(t *testing.T) {
+	sta, cfg := newTestServerlessTraceAgent(t)
+	cfg.GlobalTags = map[string]string{"env": "prod"}
+
+	sta.UpdateRuntimeTags(map[string]string{"lambda_microvm_id": "vm-2"})
+
+	assert.Equal(t, map[string]string{"env": "prod"}, cfg.GlobalTags)
+
+	sm, ok := sta.ta.SpanModifier.(*spanModifier)
+	require.True(t, ok)
+	got := sm.tags.Load()
+	require.NotNil(t, got)
+	assert.Equal(t, map[string]string{"lambda_microvm_id": "vm-2"}, *got)
+}
+
+// TestServerlessTraceAgentUpdateRuntimeTagsNoSpanModifier verifies
+// UpdateRuntimeTags is safe to call when SpanModifier doesn't implement
+// taggable (e.g. nil, or some other SpanModifier set via SetSpanModifier).
+func TestServerlessTraceAgentUpdateRuntimeTagsNoSpanModifier(t *testing.T) {
+	sta, _ := newTestServerlessTraceAgent(t)
+	sta.ta.SpanModifier = nil
+
+	assert.NotPanics(t, func() {
+		sta.UpdateRuntimeTags(map[string]string{"lambda_microvm_id": "vm-3"})
+	})
 }


### PR DESCRIPTION
### What does this PR do?

Stops MicroVM's async `/run` lifecycle hook from mutating `Agent.GlobalTags` and routes the dynamic `lambda_microvm_id` tag update through the (already serverless-owned) span modifier instead.

Concretely:
- `pkg/serverless/trace/span_modifier.go`: `tags` field is now `atomic.Pointer[map[string]string]` (using `go.uber.org/atomic`, per repo convention); `ModifySpan` applies each tag lock-free via `Load()`.
- `pkg/serverless/trace/trace.go`: adds `UpdateRuntimeTags`, which updates only the span modifier — never `GlobalTags`. The existing `SetTags` (called once, synchronously, at startup before the trace agent runs) is untouched and still updates both.
- `cmd/serverless-init/main.go`: the two async `TraceTagSetterFunc` closures wired into the MicroVM lifecycle server now call `UpdateRuntimeTags` instead of `SetTags`.
- `cmd/serverless-init/lifecycle/server.go`: updated a doc comment that named the (now stale) method satisfying `TraceTagSetter`.

### Motivation

Codex flagged a data race on #53036: `serverlessTraceAgent.SetTags` is invoked from a goroutine inside the MicroVM lifecycle server's `/run` handler, which runs concurrently with the trace agent's span-processing loop. `SetTags` calls `Agent.SetGlobalTagsUnsafe`, whose own doc comment says "Unsafe for concurrent use" — it does a bare `a.conf.GlobalTags = tags` write, while `pkg/trace/agent/agent.go` (hot path, lines 531/711) and `pkg/trace/api/telemetry.go` read `a.conf.GlobalTags` with no synchronization at all. `GlobalTags` is computed once at config-build time, before the trace agent starts running, and every one of those readers assumes that invariant holds forever — MicroVM's dynamic per-invocation tag update is the only thing in the codebase that breaks it.

In practice the write is a pointer swap to a new map rather than an in-place mutation, so the realistic worst case is a span in flight at the moment of the swap missing `lambda_microvm_id` — not a crash. But it's a genuine data race under the Go memory model: `go test -race` / `bazel test --config=race` will flag it the moment a concurrent test exercises this path, and nothing guarantees it stays benign under future compiler optimizations.

The fix avoids touching any code shared with the non-serverless trace agent (`pkg/trace/agent`, `pkg/trace/api`, `pkg/trace/config`) by reusing `SpanModifier`, which already runs at the identical point in `agent.go`'s span-processing loop (right after the `GlobalTags` loop) and is exclusively serverless-owned. Its `tags` field existed before this change but was dead code — written by `SetTags`, never read by `ModifySpan`; this fix makes it real.

This is scoped entirely to MicroVM. Every other cloud service (`AppService`, `CloudRun`, `ContainerApp`, `CloudRunJobs`) ignores `LifecycleCtx` in `Init`, so they never invoke the async closures — they only ever call the original, still-synchronous `SetTags` once at startup, unchanged by this PR.

### Describe how you validated your changes

Added regression coverage for every change (7 new/extended tests):
- `TestSpanModifierSetTagsConcurrentWithModifySpan` — hammers `SetTags`/`ModifySpan` from two goroutines under the race detector; this is the actual bug repro.
- `TestSpanModifierModifySpanBeforeSetTags`, `...AppliesTagsSetDynamically`, `...ReflectsLatestSetTags` — functional coverage of the new atomic-pointer-backed tag application.
- `TestServerlessTraceAgentSetTagsUpdatesGlobalTagsAndSpanModifier` — confirms the untouched synchronous `SetTags` path still updates both `GlobalTags` and the span modifier.
- `TestServerlessTraceAgentUpdateRuntimeTagsDoesNotTouchGlobalTags` — the core assertion: `UpdateRuntimeTags` never writes `GlobalTags`.
- `TestServerlessTraceAgentUpdateRuntimeTagsNoSpanModifier` — no-op safety when `SpanModifier` doesn't implement `taggable`.
- Extended `TestSetupWithoutAPIKey` to also exercise `noopTraceAgent.UpdateRuntimeTags`.

Run locally with:

```sh
dda inv test --targets=./pkg/serverless/trace,./cmd/serverless-init,./cmd/serverless-init/lifecycle,./cmd/serverless-init/cloudservice --race
dda inv linter.go --targets=./pkg/serverless/trace,./cmd/serverless-init,./cmd/serverless-init/lifecycle,./cmd/serverless-init/cloudservice
```

All 302 tests pass (4 skipped, platform-gated) with the race detector enabled; linter reports 0 issues.

### Additional Notes

Stacked on #53096 (`tianning.li/microvm-07-05-main-wiring`) — base branch will move to `main` once that merges. `BUILD.bazel` files were checked (`bazel run //:gazelle -- update` + buildifier on the one Gazelle-managed directory touched, `cmd/serverless-init/lifecycle`); no changes needed since the rest of the touched files are under pre-existing `gazelle:exclude` directives (not yet Bazel-migrated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)