### PR TITLE
usm: http2: add eBPF direct-consumer output path

### DIFF
--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -933,6 +933,10 @@ properties:
             node_type: setting
             type: boolean
             default: false
+          http2_use_direct_consumer:
+            node_type: setting
+            type: boolean
+            default: false
       http2_dynamic_table_map_cleaner_interval_seconds:
         node_type: setting
         type: integer

--- a/pkg/config/setup/system_probe_usm.go
+++ b/pkg/config/setup/system_probe_usm.go
@@ -96,6 +96,7 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// Tree structure
 	cfg.BindEnvAndSetDefault("service_monitoring_config.http2.enabled", false)
 	cfg.BindEnvAndSetDefault("service_monitoring_config.http2.dynamic_table_map_cleaner_interval_seconds", 30)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http2.http2_use_direct_consumer", false)
 
 	// Legacy bindings for backward compatibility (deprecated)
 	cfg.BindEnvAndSetDefault("service_monitoring_config.enable_http2_monitoring", false)

--- a/pkg/network/config/usm_config.go
+++ b/pkg/network/config/usm_config.go
@@ -95,6 +95,11 @@ type USMConfig struct {
 	// When false (default), batch consumer is always used regardless of kernel version
 	HTTPUseDirectConsumer bool
 
+	// HTTP2UseDirectConsumer forces the use of direct consumer for HTTP/2 monitoring instead of batch consumer
+	// When true, direct consumer is used if kernel supports it (>=5.8.0), otherwise falls back to batch consumer
+	// When false (default), batch consumer is always used regardless of kernel version
+	HTTP2UseDirectConsumer bool
+
 	// HTTP Windows-specific Configuration
 	// MaxTrackedHTTPConnections max number of http(s) flows that will be concurrently tracked (Windows only)
 	MaxTrackedHTTPConnections int64
@@ -218,6 +223,7 @@ func NewUSMConfig(cfg model.Config) *USMConfig {
 		// HTTP2 Protocol Configuration
 		EnableHTTP2Monitoring:               cfg.GetBool(sysconfig.FullKeyPath(smNS, "http2", "enabled")),
 		HTTP2DynamicTableMapCleanerInterval: time.Duration(cfg.GetInt(sysconfig.FullKeyPath(smNS, "http2", "dynamic_table_map_cleaner_interval_seconds"))) * time.Second,
+		HTTP2UseDirectConsumer:              cfg.GetBool(sysconfig.FullKeyPath(smNS, "http2", "http2_use_direct_consumer")),
 
 		// Kafka Protocol Configuration
 		EnableKafkaMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "kafka", "enabled")),

--- a/pkg/network/config/usm_config_test.go
+++ b/pkg/network/config/usm_config_test.go
@@ -1782,3 +1782,28 @@ func TestHTTPUseDirectConsumer(t *testing.T) {
 		assert.True(t, cfg.HTTPUseDirectConsumer)
 	})
 }
+
+func TestHTTP2UseDirectConsumer(t *testing.T) {
+	t.Run("default value", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		cfg := New()
+
+		assert.False(t, cfg.HTTP2UseDirectConsumer)
+	})
+
+	t.Run("via YAML", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetInTest("service_monitoring_config.http2.http2_use_direct_consumer", true)
+		cfg := New()
+
+		assert.True(t, cfg.HTTP2UseDirectConsumer)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP2_HTTP2_USE_DIRECT_CONSUMER", "true")
+		cfg := New()
+
+		assert.True(t, cfg.HTTP2UseDirectConsumer)
+	})
+}

--- a/pkg/network/ebpf/c/protocols/helpers/pktbuf.h
+++ b/pkg/network/ebpf/c/protocols/helpers/pktbuf.h
@@ -82,6 +82,23 @@ static __always_inline __maybe_unused u32 pktbuf_data_end(pktbuf_t pkt)
     return 0;
 }
 
+// pktbuf_get_ctx returns the raw eBPF program context backing the packet
+// buffer: the __sk_buff for socket-filter (SKB) programs, or the pt_regs for
+// TLS uprobe programs. This is the context expected by bpf_perf_event_output,
+// used by the direct-consumer output path.
+static __always_inline __maybe_unused void *pktbuf_get_ctx(pktbuf_t pkt)
+{
+    switch (pkt.type) {
+    case PKTBUF_SKB:
+        return pkt.skb;
+    case PKTBUF_TLS:
+        return pkt.ctx;
+    }
+
+    pktbuf_invalid_operation();
+    return NULL;
+}
+
 static __always_inline long pktbuf_load_bytes_with_telemetry(pktbuf_t pkt, u32 offset, void *to, u32 len)
 {
     switch (pkt.type) {

--- a/pkg/network/ebpf/c/protocols/http2/decoding-common.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-common.h
@@ -124,7 +124,31 @@ static __always_inline void update_path_size_telemetry(http2_telemetry_t *http2_
 // stream, before it actually enqueues the stream's stats.
 //
 // See RFC 7540 section 5.1: https://datatracker.ietf.org/doc/html/rfc7540#section-5.1
-static __always_inline void handle_end_of_stream(http2_stream_t *current_stream, http2_stream_key_t *http2_stream_key_template, http2_telemetry_t *http2_tel) {
+
+static __always_inline void http2_batch_enqueue_wrapper(void *ctx, conn_tuple_t *tuple, http2_stream_t *http) {
+    u32 zero = 0;
+    http2_event_t *event = bpf_map_lookup_elem(&http2_scratch_buffer, &zero);
+    if (!event) {
+        return;
+    }
+
+    bpf_memcpy(&event->tuple, tuple, sizeof(conn_tuple_t));
+    bpf_memcpy(&event->stream, http, sizeof(http2_stream_t));
+
+    // Check which consumer type to use based on kernel version capability
+    __u64 http2_use_direct_consumer = 0;
+    LOAD_CONSTANT("http2_use_direct_consumer", http2_use_direct_consumer);
+
+    if (http2_use_direct_consumer) {
+        // Direct consumer path - use perf/ring buffer output (kernel >= 5.8)
+        http2_output_event(ctx, event);
+    } else {
+        // Batch consumer path - use map-based batching (kernel < 5.8)
+        http2_batch_enqueue(event);
+    }
+}
+
+static __always_inline void handle_end_of_stream(void *ctx, http2_stream_t *current_stream, http2_stream_key_t *http2_stream_key_template, http2_telemetry_t *http2_tel) {
     // We want to see the EOS twice for a given stream: one for the client, one for the server.
     if (!current_stream->end_of_stream_seen) {
         current_stream->end_of_stream_seen = true;
@@ -134,14 +158,9 @@ static __always_inline void handle_end_of_stream(http2_stream_t *current_stream,
     // response end of stream;
     current_stream->response_last_seen = bpf_ktime_get_ns();
 
-    const __u32 zero = 0;
-    http2_event_t *event = bpf_map_lookup_elem(&http2_scratch_buffer, &zero);
-    if (event) {
-        event->tuple = http2_stream_key_template->tup;
-        event->stream = *current_stream;
-        // enqueue
-        http2_batch_enqueue(event);
-    }
+    // Emit the completed stream via the batch/direct consumer wrapper, which
+    // handles staging into the scratch buffer and selecting the output path.
+    http2_batch_enqueue_wrapper(ctx, &http2_stream_key_template->tup, current_stream);
 
     bpf_map_delete_elem(&http2_in_flight, http2_stream_key_template);
 }

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -1190,7 +1190,7 @@ static __always_inline void eos_parser(pktbuf_t pkt, void *map_key, conn_tuple_t
         } else if ((current_frame.frame.flags & HTTP2_END_OF_STREAM) == HTTP2_END_OF_STREAM) {
             __sync_fetch_and_add(&http2_tel->end_of_stream, 1);
         }
-        handle_end_of_stream(current_stream, &http2_ctx->http2_stream_key, http2_tel);
+        handle_end_of_stream(pktbuf_get_ctx(pkt), current_stream, &http2_ctx->http2_stream_key, http2_tel);
 
         // If we reached here, it means that we saw End Of Stream. If the End of Stream came from a request,
         // thus we except it to have a valid path and method. If the End of Stream came from a response, we except it to

--- a/pkg/network/ebpf/c/protocols/http2/usm-events.h
+++ b/pkg/network/ebpf/c/protocols/http2/usm-events.h
@@ -8,4 +8,7 @@ USM_EVENTS_INIT(http2, http2_event_t, HTTP2_BATCH_SIZE);
 
 USM_EVENTS_INIT(terminated_http2, conn_tuple_t, HTTP2_TERMINATED_BATCH_SIZE);
 
+// Initialize DirectConsumer utilities for HTTP2 protocol
+USM_DIRECT_CONSUMER_INIT(http2, http2_event_t, http2_batch_events)
+
 #endif


### PR DESCRIPTION
### What does this PR do?
Adds the kernel-side plumbing to emit a completed HTTP/2 stream through either the batch path (`http2_batch_enqueue`) or the direct path (`http2_output_event`), selected at runtime by the `use_direct_consumer` constant.

- `pktbuf.h`: new generic `pktbuf_get_ctx()` (returns `__sk_buff` / `pt_regs` for `bpf_perf_event_output`)
- `decoding-common.h`: new `http2_batch_enqueue_wrapper()`; `handle_end_of_stream()` gains a `void *ctx` param
- `decoding.h`: pass `pktbuf_get_ctx(pkt)` at the sole call site
- `usm-events.h`: `USM_DIRECT_CONSUMER_INIT` for http2 (generates `http2_output_event`)

### Motivation
Second of three stacked PRs extending USM DirectConsumer (#39774) to HTTP/2. The `use_direct_consumer` constant **defaults to `0`**, so the batch path is functionally unchanged until userspace (PR 3) enables direct mode. Stacked on #53111.

### Describe how you validated your changes
Compiles via the eBPF build; batch path behavior is unchanged. End-to-end direct-mode validation lands with the userspace wiring PR.

Jira: APMB-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)