### PR TITLE
[AGENT-16482] Add missing privateactionrunner wrapper for simple-all-in-one entrypoint

### DIFF
--- a/Dockerfiles/agent/entrypoint.d/privateactionrunner
+++ b/Dockerfiles/agent/entrypoint.d/privateactionrunner
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -x /opt/datadog-agent/embedded/bin/privateactionrunner ]]; then
+exec /opt/datadog-agent/embedded/bin/privateactionrunner run --cfgpath=/etc/datadog-agent/datadog.yaml
+fi

--- a/releasenotes/notes/fix-privateactionrunner-simple-all-in-one-a86ad253d1f06448.yaml
+++ b/releasenotes/notes/fix-privateactionrunner-simple-all-in-one-a86ad253d1f06448.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix a startup crash of the ``simple-all-in-one`` Docker image (used for
+    ECS Fargate sidecar deployments) caused by a missing entrypoint wrapper
+    for the Private Action Runner.


### PR DESCRIPTION
### What does this PR do?
Adds the missing `privateactionrunner` wrapper under `Dockerfiles/agent/entrypoint.d/`, so the `simple-all-in-one` entrypoint (ECS Fargate) can start it like every other process.

### Motivation
PR #44642 added privateactionrunner support for s6-supervised images but missed the `simple-all-in-one` entrypoint. That entrypoint unconditionally execs a wrapper per process, so the missing file crashes the whole container on startup, taking down all agent processes.

### Describe how you validated your changes
Reproduced the issue before this fix and ensure that it worked as expected with the fix.

### Additional Notes