### PR TITLE
Prevent config schema drift from being merged again

### DIFF
--- a/.gitlab/build/binary_build/schema_generation.yml
+++ b/.gitlab/build/binary_build/schema_generation.yml
@@ -2,22 +2,28 @@
 include:
   - .gitlab/.pre/common/macos.yml
 
+.on_schema_paths_changed:
+  - changes:
+      paths:
+        - pkg/config/**/*
+        - tasks/schema/**/*
+      compare_to: $COMPARE_TO_BRANCH
 
 .generate_config_schema:
   stage: binary_build
   rules:
     - !reference [.except_mergequeue]
     - !reference [.on_main_or_release_branch]
-    - changes:
-        paths:
-          - pkg/config/**/*
-          - tasks/schema/**/*
-        compare_to: $COMPARE_TO_BRANCH
+    - !reference [.on_schema_paths_changed]
 
 generate_config_schema-linux:
   extends:
     - .generate_config_schema
     - .bazel:defs:cache:progressive
+  rules:
+    # inhibit `.except_mergequeue` to validate accumulated schema changes and prevent drift from landing on `main`
+    - !reference [.on_main_or_release_branch]
+    - !reference [.on_schema_paths_changed]
   variables:
     KUBERNETES_CPU_REQUEST: 16
     KUBERNETES_MEMORY_REQUEST: 16Gi
@@ -33,6 +39,7 @@ generate_config_schema-linux:
     - dda inv -- schema.generate --agent-bin=./bin/agent/agent
     - bash $CI_PROJECT_DIR/tasks/schema/check_schema_refresh.sh $CI_PROJECT_DIR
     - bash $CI_PROJECT_DIR/tasks/schema/check_config_templates.sh $CI_PROJECT_DIR
+    - dda inv -- schema.lint --schema-dir $CI_PROJECT_DIR/pkg/config/schema/yaml/
   artifacts:
     when: always
     expire_in: 2 weeks
@@ -60,17 +67,6 @@ generate_config_schema-macos:
     expire_in: 2 weeks
     paths:
       - $CI_PROJECT_DIR/pkg/config/schema/yaml/*.yaml
-
-lint_config_schema:
-  stage: binary_build
-  extends: .generate_config_schema
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64", "specific:true"]
-  needs:
-    - job: "generate_config_schema-linux"
-  script:
-    - dda inv -- schema.lint --schema-dir $CI_PROJECT_DIR/pkg/config/schema/yaml/
-  allow_failure: false
 
 generate_config_schema-windows:
   extends:

--- a/docs/public/agent-schema/cli.md
+++ b/docs/public/agent-schema/cli.md
@@ -48,7 +48,7 @@ The command:
 
 Validate the schema against the schema quality rules and exit
 non-zero on any violation. This is the check enforced in CI
-(`lint_config_schema`).
+(`generate_config_schema-linux`).
 
 ```bash
 dda inv schema.lint


### PR DESCRIPTION
### What does this PR do?
Run the `generate_config_schema-linux` job in the merge queue too, using the same `pkg/config/**/tasks/schema/**` path filter already used on regular branches.

Fold the `lint_config_schema` job into it, to keep this addition roughly latency-neutral for the merge queue.

### Motivation
#52998 passed `generate_config_schema-linux` on its own branch, then landed on `main` as a new, never-tested commit: `mergegate` rebased it onto a much newer `main` before pushing, but `generate_config_schema-linux` was excluded from the merge queue pipeline entirely (`.except_mergequeue`), so the schema-refresh check only ran after the commit was already on `main` where it logically failed:
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1823290308 ❌

The resulting breakage is fixed by an automatic revert:
- #53109.

=> this change is therefore about bridging the process gap.

`lint_config_schema` only ever added a separate job incurring ~110s of scheduling, checkout and artifact transfer for an actual payload of ~2s lint call, so merging it into `generate_config_schema-linux`'s own script recovers close to that whole amount, offsetting most of the latency this adds to the merge queue.

### Additional Notes
`-macos` and `-windows` variants keep running only on non-MQ pipelines: they only check config templates, not schema refresh, so they are lower value for gating merges (and Windows builds are costly).