### PR TITLE
[DOIO-136] Fix DO query matcher to resolve database_identifier.template and host:port

### DIFF
--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"strconv"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
@@ -133,11 +135,12 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 		// Remove previous DO config version if this config_id was already active.
 		c.removeActiveConfig(configID, &changes)
 
+		instanceLiteralHost, _ := instance["host"].(string)
 		c.activeConfigsMu.Lock()
 		c.activeConfigs[configID] = activeConfigEntry{
 			checkConfig: checkConfig,
 			baseCfg:     baseCfg,
-			matchHost:   payload.DBIdentifier.Host,
+			matchHost:   instanceLiteralHost,
 		}
 		c.activeConfigsMu.Unlock()
 		changes.Schedule = append(changes.Schedule, checkConfig)
@@ -331,10 +334,66 @@ func (c *component) findPostgresConfig(dbID *DBIdentifier) (*integration.Config,
 }
 
 // matchesIdentifier checks if an instance matches the given DB identifier.
-// Matching is by host only — per-query dbname fields handle database routing.
+// Three forms are tried in order:
+//  1. Literal host: instance["host"] == dbID.Host.
+//  2. Host:port form: "<host>:<port>" == dbID.Host, for backends that key on the port-qualified form.
+//  3. database_identifier template: render instance["database_identifier"]["template"] substituting
+//     $resolved_hostname (dbID.AgentHostname when set, else the literal host) and $port, then
+//     compare to dbID.Host. This handles database_identifier.template templating and agent hostname
+//     overrides where the literal host (e.g. "localhost") differs from the identifier the backend
+//     keyed the config on (e.g. "agent-hostname:5432").
+//
+// Per-query dbname fields handle database routing; matching is host-only.
 func matchesIdentifier(instance map[string]any, dbID *DBIdentifier) bool {
 	host, _ := instance["host"].(string)
-	return host == dbID.Host
+
+	// 1. Literal host match (existing behavior, no change).
+	if host == dbID.Host {
+		return true
+	}
+
+	// 2. host:port form.
+	port := instancePort(instance)
+	if port != "" && host+":"+port == dbID.Host {
+		return true
+	}
+
+	// 3. database_identifier.template rendering.
+	dbIDSection, ok := instance["database_identifier"].(map[string]any)
+	if !ok {
+		return false
+	}
+	tmpl, _ := dbIDSection["template"].(string)
+	if tmpl == "" {
+		return false
+	}
+	resolvedHostname := dbID.AgentHostname
+	if resolvedHostname == "" {
+		resolvedHostname = host
+	}
+	rendered := renderDBIdentifierTemplate(tmpl, resolvedHostname, port)
+	return rendered == dbID.Host
+}
+
+// instancePort returns the port from an instance config as a string, or "" if absent/unparseable.
+func instancePort(instance map[string]any) string {
+	switch p := instance["port"].(type) {
+	case int:
+		return strconv.Itoa(p)
+	case float64:
+		return strconv.Itoa(int(p))
+	case string:
+		return p
+	}
+	return ""
+}
+
+// renderDBIdentifierTemplate substitutes $resolved_hostname and $port in a database_identifier
+// template string, mirroring the Python check's template expansion in metadata.py.
+func renderDBIdentifierTemplate(tmpl, resolvedHostname, port string) string {
+	r := strings.ReplaceAll(tmpl, "$resolved_hostname", resolvedHostname)
+	r = strings.ReplaceAll(r, "$port", port)
+	return r
 }
 
 // buildCheckConfig creates a postgres check config with data_observability queries injected.

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -87,6 +87,144 @@ func TestMatchesIdentifier_RDS(t *testing.T) {
 	assert.False(t, matchesIdentifier(instance, dbID))
 }
 
+// TestMatchesIdentifier_HostPort verifies that "host:port" in the RC identifier matches an
+// instance whose literal host + port fields produce that pair. This covers cases where the
+// backend keys on the port-qualified form even when no database_identifier template is set.
+func TestMatchesIdentifier_HostPort(t *testing.T) {
+	instance := map[string]any{"host": "localhost", "port": 5432}
+
+	t.Run("matching host:port", func(t *testing.T) {
+		dbID := &DBIdentifier{Type: "self-hosted", Host: "localhost:5432"}
+		assert.True(t, matchesIdentifier(instance, dbID))
+	})
+
+	t.Run("wrong port", func(t *testing.T) {
+		dbID := &DBIdentifier{Type: "self-hosted", Host: "localhost:5433"}
+		assert.False(t, matchesIdentifier(instance, dbID))
+	})
+
+	t.Run("wrong host", func(t *testing.T) {
+		dbID := &DBIdentifier{Type: "self-hosted", Host: "otherhost:5432"}
+		assert.False(t, matchesIdentifier(instance, dbID))
+	})
+}
+
+// TestMatchesIdentifier_DatabaseIdentifierTemplate verifies the case from DOIO-136: an instance
+// with host: localhost and database_identifier.template: "$resolved_hostname:$port" matches an
+// RC identifier whose host is "<agent_hostname>:<port>".
+func TestMatchesIdentifier_DatabaseIdentifierTemplate(t *testing.T) {
+	instance := map[string]any{
+		"host": "localhost",
+		"port": 5432,
+		"database_identifier": map[string]any{
+			"template": "$resolved_hostname:$port",
+		},
+	}
+
+	t.Run("matches when agent_hostname resolves template", func(t *testing.T) {
+		dbID := &DBIdentifier{
+			Type:          "self-hosted",
+			Host:          "do-test-postgres-staging:5432",
+			AgentHostname: "do-test-postgres-staging",
+		}
+		assert.True(t, matchesIdentifier(instance, dbID))
+	})
+
+	t.Run("no match when agent_hostname differs", func(t *testing.T) {
+		dbID := &DBIdentifier{
+			Type:          "self-hosted",
+			Host:          "other-host:5432",
+			AgentHostname: "do-test-postgres-staging",
+		}
+		assert.False(t, matchesIdentifier(instance, dbID))
+	})
+
+	t.Run("falls back to literal host when agent_hostname unset", func(t *testing.T) {
+		dbID := &DBIdentifier{
+			Type: "self-hosted",
+			Host: "localhost:5432",
+		}
+		assert.True(t, matchesIdentifier(instance, dbID))
+	})
+}
+
+// TestMatchesIdentifier_TwoPortsNoCrossMatch verifies that two instances on the same host but
+// different ports each only match their own RC config, with no cross-matching.
+func TestMatchesIdentifier_TwoPortsNoCrossMatch(t *testing.T) {
+	instance5432 := map[string]any{
+		"host": "localhost",
+		"port": 5432,
+		"database_identifier": map[string]any{
+			"template": "$resolved_hostname:$port",
+		},
+	}
+	instance5433 := map[string]any{
+		"host": "localhost",
+		"port": 5433,
+		"database_identifier": map[string]any{
+			"template": "$resolved_hostname:$port",
+		},
+	}
+	dbID5432 := &DBIdentifier{Type: "self-hosted", Host: "myhost:5432", AgentHostname: "myhost"}
+	dbID5433 := &DBIdentifier{Type: "self-hosted", Host: "myhost:5433", AgentHostname: "myhost"}
+
+	assert.True(t, matchesIdentifier(instance5432, dbID5432), "5432 instance should match 5432 RC config")
+	assert.False(t, matchesIdentifier(instance5432, dbID5433), "5432 instance must not match 5433 RC config")
+	assert.False(t, matchesIdentifier(instance5433, dbID5432), "5433 instance must not match 5432 RC config")
+	assert.True(t, matchesIdentifier(instance5433, dbID5433), "5433 instance should match 5433 RC config")
+}
+
+// TestOnRCUpdate_TemplatedIdentifier_SchedulesCheck is an integration test for the DOIO-136
+// scenario: instance has host:localhost + database_identifier template, RC config carries the
+// resolved identifier. The check should be scheduled and the warning should NOT fire.
+func TestOnRCUpdate_TemplatedIdentifier_SchedulesCheck(t *testing.T) {
+	postgresCfg := integration.Config{
+		Name:     "postgres",
+		Provider: "file",
+		NodeName: "node1",
+		Instances: []integration.Data{
+			integration.Data("host: localhost\nport: 5432\ndatabase_identifier:\n  template: \"$resolved_hostname:$port\"\ndata_observability:\n  enabled: true\n"),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+
+	payload := DOQueryPayload{
+		ConfigID: "cfg-templated",
+		DBIdentifier: DBIdentifier{
+			Type:          "self-hosted",
+			Host:          "do-test-postgres-staging:5432",
+			AgentHostname: "do-test-postgres-staging",
+		},
+		Queries: []QuerySpec{
+			{
+				MonitorID:       1,
+				Type:            "run_query",
+				Query:           "SELECT 1",
+				IntervalSeconds: 60,
+				TimeoutSeconds:  10,
+				Entity:          EntityMetadata{Platform: "postgres", Database: "mydb"},
+			},
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-templated": {Config: payloadJSON, Metadata: state.Metadata{ID: "rc-id-templated"}},
+	})
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-templated"].State, "should acknowledge the config")
+	require.Len(t, changes.Schedule, 1, "should schedule the DO check")
+	require.Len(t, changes.Unschedule, 1, "should unschedule the base file-provider config")
+	assert.Equal(t, "postgres", changes.Schedule[0].Name)
+	require.Contains(t, c.activeConfigs, "cfg-templated")
+
+	// Verify the matched instance's literal host is used (not the RC identifier) so that
+	// buildRemainder correctly excludes it and no double-run occurs.
+	entry := c.activeConfigs["cfg-templated"]
+	assert.Equal(t, "localhost", entry.matchHost, "matchHost must be the literal instance host")
+}
+
 func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 	c := &component{
 		log: logmock.New(t),


### PR DESCRIPTION
## Summary

The DO query-action matcher only compared the RC config's `db_identifier.host` against the instance's literal `host` YAML field. This caused queries to be silently dropped for any instance that uses `database_identifier.template` templating or an agent hostname override — the backend keys the RC config on the *resolved* identifier (e.g. `do-test-postgres-staging:5432`) while the agent only knows the literal `localhost`.

**Root cause:** `matchesIdentifier` in `handler.go` never consulted the instance's `database_identifier` section.

**Fix:**
1. Added two new matching forms (tried after the existing literal-host check):
   - `host:port` form: `"<host>:<port>" == dbID.Host`
   - `database_identifier.template` rendering: expand `$resolved_hostname` (from `dbID.AgentHostname`) and `$port` in the instance's template, compare result to `dbID.Host`
2. Fixed `matchHost` storage in `activeConfigEntry` to use the instance's *literal* host (not the RC identifier), so `buildRemainder` correctly excludes matched instances and prevents double-running.

Existing literal-host matching is preserved as the first fallback, so instances without `database_identifier` templating are unaffected.

## Tests added (`comp/dataobs/queryactions/impl/handler_test.go`)

- `TestMatchesIdentifier_HostPort` — host:port matching, wrong port, wrong host
- `TestMatchesIdentifier_DatabaseIdentifierTemplate` — template match, wrong hostname, fallback when AgentHostname unset
- `TestMatchesIdentifier_TwoPortsNoCrossMatch` — two instances on same host differ by port, each only matches its own RC config
- `TestOnRCUpdate_TemplatedIdentifier_SchedulesCheck` — end-to-end: instance with `database_identifier.template` receives and schedules RC config keyed on the resolved identifier; verifies `matchHost` is the literal instance host

## Acceptance criteria

- [x] A postgres instance with `host: localhost` + `database_identifier.template: "$resolved_hostname:$port"` under an agent hostname override matches an RC config whose `db_identifier.host` is `<resolved_hostname>:<port>`.
- [x] Existing behavior preserved: instances without `database_identifier` templating still match by `host` / `host:port`.
- [x] Two instances on one host (e.g. `:5432` and `:5433`) each match only their own RC config — no cross-matching.
- [x] Unit tests covering: templated identifier match, hostname-override match, and the no-templating fallback.
- [x] When no instance matches, the existing warning still fires.

Closes https://linear.app/datadog/issue/DOIO-136