### PR TITLE
bazel: dd_agent_go_test: fix revert to plain go_test when directive flips to off

### DIFF
--- a/bazel/rules/go/_gazelle_extension.go
+++ b/bazel/rules/go/_gazelle_extension.go
@@ -129,6 +129,7 @@ func (l *lang) GenerateRules(args language.GenerateArgs) language.GenerateResult
 				addStringToListIfMissing(r, "gotags", "test")
 			}
 		}
+		result = l.revertDdAgentGoTests(result, args.File)
 	}
 	if linuxBPFEnabled(args.Config) {
 		result = l.applyLinuxBPF(result, args)
@@ -247,6 +248,34 @@ func (l *lang) replaceGoTests(result language.GenerateResult, file *rule.File, p
 		Empty:   append(result.Empty, empty...),
 		Imports: imports,
 	}
+}
+
+// revertDdAgentGoTests is the inverse of replaceGoTests: it runs when a
+// package's directive has just flipped from "on" back to "off". Deleting the
+// old rule and inserting the fresh go_test candidate as new would lose any
+// `# keep`-marked deps, since those only survive a match against an existing
+// rule at the PostResolve merge, well after this function returns.
+//
+// So instead of deleting, change the existing rule's kind to "go_test" in
+// place: the rule stays put with everything on it, and the ordinary go_test
+// merge path (kind now matches) takes over as if the package had never been
+// converted. "flavors" has no go_test equivalent and is dropped; everything
+// else carries over untouched.
+//
+// A whole-rule `# keep` is left as dd_agent_go_test, so the go_test candidate
+// fails to match it (different kind) and is dropped rather than duplicated.
+func (l *lang) revertDdAgentGoTests(result language.GenerateResult, file *rule.File) language.GenerateResult {
+	if file == nil {
+		return result
+	}
+	for _, r := range file.Rules {
+		if r.Kind() != "dd_agent_go_test" || r.ShouldKeep() {
+			continue
+		}
+		r.DelAttr("flavors")
+		r.SetKind("go_test")
+	}
+	return result
 }
 
 // Resolve delegates to the Go extension's resolver. For dd_agent_go_test rules it

--- a/bazel/rules/go/_gazelle_extension_test.go
+++ b/bazel/rules/go/_gazelle_extension_test.go
@@ -197,6 +197,185 @@ func TestReplaceGoTests_MixedRules(t *testing.T) {
 	}
 }
 
+// fakeGoLang stubs the embedded Go extension so GenerateRules can be tested
+// against a chosen GenerateResult without a real source-file scan.
+type fakeGoLang struct {
+	language.BaseLang
+	result language.GenerateResult
+}
+
+func (f *fakeGoLang) Kinds() map[string]rule.KindInfo {
+	return map[string]rule.KindInfo{
+		"go_test": {
+			MergeableAttrs: map[string]bool{"srcs": true, "embed": true},
+			ResolveAttrs:   map[string]bool{"deps": true},
+		},
+	}
+}
+
+func (f *fakeGoLang) GenerateRules(language.GenerateArgs) language.GenerateResult {
+	return f.result
+}
+
+// TestGenerateRules_OffDirectiveRevertsExistingConversion reproduces the
+// observed bug: a package that was previously converted to dd_agent_go_test
+// (an on-disk dd_agent_go_test rule exists) has its directive flipped back to
+// "off". GenerateRules is Gazelle's real entry point; running its output
+// through the same two-phase merge Gazelle itself performs must leave the
+// package with a plain go_test, not a stale dd_agent_go_test rule that the
+// merge can't reconcile because the kinds differ.
+func TestGenerateRules_OffDirectiveRevertsExistingConversion(t *testing.T) {
+	old := rule.NewRule("dd_agent_go_test", "pkg_test")
+	old.SetAttr("srcs", []string{"pkg_test.go"})
+	old.SetAttr("embed", []string{":pkg"})
+	file := rule.EmptyFile("BUILD.bazel", "some/pkg")
+	old.Insert(file)
+
+	fresh := rule.NewRule("go_test", "pkg_test")
+	fresh.SetAttr("srcs", []string{"pkg_test.go"})
+	fresh.SetAttr("embed", []string{":pkg"})
+
+	l := &lang{Language: &fakeGoLang{result: language.GenerateResult{
+		Gen:     []*rule.Rule{fresh},
+		Imports: []interface{}{nil},
+	}}}
+	c := &config.Config{Exts: map[string]interface{}{extName: ddAgentGoTestConfig{enabled: false}}}
+
+	result := l.GenerateRules(language.GenerateArgs{Config: c, File: file})
+	merger.MergeFile(file, result.Empty, result.Gen, merger.PreResolve, l.Kinds(), nil)
+
+	if len(file.Rules) != 1 {
+		t.Fatalf("expected 1 rule after merge, got %d: %v", len(file.Rules), file.Rules)
+	}
+	if file.Rules[0].Kind() != "go_test" {
+		t.Errorf("expected go_test after reverting, got %s", file.Rules[0].Kind())
+	}
+}
+
+// TestGenerateRules_OffDirectiveNoOpWithoutExistingConversion guards the
+// already-working case (e.g. cmd/cluster-agent/subcommands/coverage): a
+// package that was never converted keeps its plain go_test untouched when
+// "off" is (still) in effect.
+func TestGenerateRules_OffDirectiveNoOpWithoutExistingConversion(t *testing.T) {
+	existing := rule.NewRule("go_test", "pkg_test")
+	existing.SetAttr("srcs", []string{"pkg_test.go"})
+	file := rule.EmptyFile("BUILD.bazel", "some/pkg")
+	existing.Insert(file)
+
+	fresh := rule.NewRule("go_test", "pkg_test")
+	fresh.SetAttr("srcs", []string{"pkg_test.go"})
+
+	l := &lang{Language: &fakeGoLang{result: language.GenerateResult{
+		Gen:     []*rule.Rule{fresh},
+		Imports: []interface{}{nil},
+	}}}
+	c := &config.Config{Exts: map[string]interface{}{extName: ddAgentGoTestConfig{enabled: false}}}
+
+	result := l.GenerateRules(language.GenerateArgs{Config: c, File: file})
+	merger.MergeFile(file, result.Empty, result.Gen, merger.PreResolve, l.Kinds(), nil)
+
+	if len(file.Rules) != 1 || file.Rules[0].Kind() != "go_test" {
+		t.Errorf("expected the untouched go_test to survive, got %v", file.Rules)
+	}
+}
+
+// TestGenerateRules_OffDirectiveRespectsKeptRule guards against deleting a
+// whole-rule `# keep` dd_agent_go_test out from under the user: the direct
+// Delete() used to revert a stale rule bypasses MergeFile's own ShouldKeep()
+// check, so without an explicit guard a hand-protected rule would vanish the
+// moment its package's directive flips to off.
+func TestGenerateRules_OffDirectiveRespectsKeptRule(t *testing.T) {
+	file, err := rule.LoadData("BUILD.bazel", "some/pkg", []byte(`
+dd_agent_go_test(
+    name = "pkg_test",
+    srcs = ["pkg_test.go"],
+    embed = [":pkg"],
+)  # keep
+`))
+	if err != nil {
+		t.Fatalf("LoadData: %v", err)
+	}
+	if !file.Rules[0].ShouldKeep() {
+		t.Fatalf("expected fixture rule to be marked keep")
+	}
+
+	fresh := rule.NewRule("go_test", "pkg_test")
+	fresh.SetAttr("srcs", []string{"pkg_test.go"})
+	fresh.SetAttr("embed", []string{":pkg"})
+
+	l := &lang{Language: &fakeGoLang{result: language.GenerateResult{
+		Gen:     []*rule.Rule{fresh},
+		Imports: []interface{}{nil},
+	}}}
+	c := &config.Config{Exts: map[string]interface{}{extName: ddAgentGoTestConfig{enabled: false}}}
+
+	result := l.GenerateRules(language.GenerateArgs{Config: c, File: file})
+	merger.MergeFile(file, result.Empty, result.Gen, merger.PreResolve, l.Kinds(), nil)
+
+	if len(file.Rules) != 1 || file.Rules[0].Kind() != "dd_agent_go_test" {
+		t.Errorf("expected the kept dd_agent_go_test rule to survive untouched, got %v", file.Rules)
+	}
+}
+
+// TestGenerateRules_OffDirectiveSurvivesResolveWithKeptDep replays the full
+// three-step pipeline (PreResolve merge, Resolve, PostResolve merge) against
+// an existing dd_agent_go_test rule with a `# keep`-marked dep, the same
+// scenario TestDepsMerge_KeptItemSurvivesResolveUpdate guards for a package
+// that stays dd_agent_go_test. Deleting the old rule during GenerateRules (as
+// opposed to mutating it in place) removes it before the PostResolve merge
+// ever runs, so whatever the real Go resolver's DelAttr("deps")+SetAttr does
+// to the freshly-inserted go_test candidate has no prior rule to reconcile
+// kept deps against.
+func TestGenerateRules_OffDirectiveSurvivesResolveWithKeptDep(t *testing.T) {
+	file, err := rule.LoadData("BUILD.bazel", "some/pkg", []byte(`
+dd_agent_go_test(
+    name = "pkg_test",
+    srcs = ["pkg_test.go"],
+    embed = [":pkg"],
+    deps = [
+        "//kept/dep",  # keep
+        "//stale/dep",
+    ],
+)
+`))
+	if err != nil {
+		t.Fatalf("LoadData: %v", err)
+	}
+
+	fresh := rule.NewRule("go_test", "pkg_test")
+	fresh.SetAttr("srcs", []string{"pkg_test.go"})
+	fresh.SetAttr("embed", []string{":pkg"})
+
+	l := &lang{Language: &fakeGoLang{result: language.GenerateResult{
+		Gen:     []*rule.Rule{fresh},
+		Imports: []interface{}{nil},
+	}}}
+	c := &config.Config{Exts: map[string]interface{}{extName: ddAgentGoTestConfig{enabled: false}}}
+
+	result := l.GenerateRules(language.GenerateArgs{Config: c, File: file})
+	merger.MergeFile(file, result.Empty, result.Gen, merger.PreResolve, l.Kinds(), nil)
+
+	if len(file.Rules) != 1 {
+		t.Fatalf("expected 1 rule after PreResolve merge, got %d: %v", len(file.Rules), file.Rules)
+	}
+	// Simulate Resolve(): it operates on the generated candidate (fresh), not
+	// the existing file rule -- see the real pipeline in cmd/gazelle/update.go,
+	// which calls Resolve on v.rules (the GenerateRules output) and only later
+	// merges that back into the file at PostResolve.
+	fresh.SetAttr("deps", []string{"//fresh/dep"})
+
+	merger.MergeFile(file, nil, []*rule.Rule{fresh}, merger.PostResolve, l.Kinds(), nil)
+
+	got := file.Rules[0].AttrStrings("deps")
+	want := []string{"//kept/dep", "//fresh/dep"}
+	if !stringSlicesEqual(got, want) {
+		t.Errorf("deps after full pipeline: got %v, want %v", got, want)
+	}
+	if file.Rules[0].Kind() != "go_test" {
+		t.Errorf("expected go_test after reverting, got %s", file.Rules[0].Kind())
+	}
+}
+
 func TestLoads(t *testing.T) {
 	mal, ok := NewLanguage().(language.ModuleAwareLanguage)
 	if !ok {

--- a/pkg/kubestatemetrics/builder/BUILD.bazel
+++ b/pkg/kubestatemetrics/builder/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "builder",
@@ -43,13 +42,14 @@ go_library(
     ],
 )
 
-dd_agent_go_test(
+go_test(
     name = "builder_test",
     srcs = [
         "workloadmeta_conversion_test.go",
         "workloadmeta_pods_test.go",
     ],
     embed = [":builder"],
+    gotags = ["test"],
     deps = [
         "//comp/core",
         "//comp/core/workloadmeta/def",

--- a/pkg/process/metadata/parser/java/BUILD.bazel
+++ b/pkg/process/metadata/parser/java/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "java",
@@ -18,7 +17,7 @@ go_library(
     ],
 )
 
-dd_agent_go_test(
+go_test(
     name = "java_test",
     srcs = [
         "spring_test.go",
@@ -27,5 +26,6 @@ dd_agent_go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":java"],
+    gotags = ["test"],
     deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/process/metadata/parser/nodejs/BUILD.bazel
+++ b/pkg/process/metadata/parser/nodejs/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 filegroup(
     name = "nodejs_testdata",
@@ -15,10 +14,11 @@ go_library(
     deps = ["//pkg/util/log"],
 )
 
-dd_agent_go_test(
+go_test(
     name = "nodejs_test",
     srcs = ["nodejs_test.go"],
     data = glob(["testdata/**"]),
     embed = [":nodejs"],
+    gotags = ["test"],
     deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/pkg/security/resolvers/sbom/collectorv2/BUILD.bazel
+++ b/pkg/security/resolvers/sbom/collectorv2/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "collectorv2",
@@ -31,10 +30,11 @@ go_library(
     }),
 )
 
-dd_agent_go_test(
+go_test(
     name = "collectorv2_test",
     srcs = ["apk_test.go"],
     embed = [":collectorv2"],
+    gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:android": [
             "@com_github_stretchr_testify//assert",

--- a/pkg/security/resolvers/sign/BUILD.bazel
+++ b/pkg/security/resolvers/sign/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "sign",
@@ -44,10 +43,11 @@ go_library(
     }),
 )
 
-dd_agent_go_test(
+go_test(
     name = "sign_test",
     srcs = ["resolver_unix_test.go"],
     embed = [":sign"],
+    gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:aix": [
             "//pkg/security/secl/containerutils",


### PR DESCRIPTION
## What does this PR do?

Fixes the Gazelle `dd_agent_go_test` extension so that flipping a package's `# gazelle:dd_agent_go_test` directive from `on` back to `off` actually reverts an already-converted rule to a plain `go_test`.

## Motivation

`GenerateRules`'s `!shouldReplace` branch just returned the freshly generated `go_test` candidate without doing anything about a pre-existing on-disk `dd_agent_go_test` rule of the same name. Since the two rules are different kinds, Gazelle's merge can't reconcile them, so the stale `dd_agent_go_test` rule was never cleaned up — the file stayed stuck in the converted state no matter how many times gazelle ran.

The fix mutates the existing rule's kind to `go_test` in place instead of deleting and re-inserting: this way `# keep`-marked deps and comments stay exactly where they are, and the ordinary go_test merge/resolve path (which already correctly preserves kept deps across regens) takes over from there. A whole-rule `# keep` is left untouched, and the sole dd_agent_go_test-only attribute (`flavors`) is dropped since go_test has no equivalent.

## Describe how you validated your changes

- Added unit tests in `_gazelle_extension_test.go` covering: reverting a stale conversion, no-op when never converted, respecting a whole-rule `# keep`, and preserving `# keep`-marked deps through the full PreResolve → Resolve → PostResolve pipeline.
- Verified end-to-end against real packages with `# keep`-marked deps (e.g. `pkg/collector/corechecks/ebpf/probe/ebpfcheck`) and confirmed the resulting `go_test` targets build.
- Re-running gazelle repo-wide with the fix also corrected several pre-existing packages that were stuck in the same latent bad state.