### PR TITLE
[procmgr] Supervise Private Action Runner via dd-procmgr on Windows

### DIFF
--- a/cmd/agent/subcommands/run/dependent_services_windows.go
+++ b/cmd/agent/subcommands/run/dependent_services_windows.go
@@ -90,6 +90,9 @@ func subservices(coreConf model.Reader, sysprobeConf model.Reader) []Servicedef 
 			configKeys: map[string]model.Reader{
 				"private_action_runner.enabled": coreConf,
 			},
+			suppressIf: func() bool {
+				return parProcmgrProcessDefinitionExists() && coreConf.GetBool("process_manager.enabled")
+			},
 			serviceName:    "datadog-agent-action",
 			serviceInit:    parInit,
 			shouldShutdown: true,
@@ -233,16 +236,29 @@ func stopDependentServices(coreConf model.Reader, sysprobeConf model.Reader) {
 	}
 }
 
-const ddotProcmgrProcessDefinitionFile = "datadog-agent-ddot.yaml"
+const (
+	ddotProcmgrProcessDefinitionFile = "datadog-agent-ddot.yaml"
+	parProcmgrProcessDefinitionFile  = "datadog-agent-action.yaml"
+)
 
 // True if the fleet DDOT processes.d definition exists (dd-procmgr supervises DDOT). With
 // process_manager.enabled, the Agent skips starting the datadog-otel-agent Windows service.
 func ddotProcmgrProcessDefinitionExists() bool {
+	return procmgrProcessDefinitionExists(ddotProcmgrProcessDefinitionFile)
+}
+
+// True if the fleet PAR processes.d definition exists (dd-procmgr supervises PAR). With
+// process_manager.enabled, the Agent skips starting the datadog-agent-action Windows service.
+func parProcmgrProcessDefinitionExists() bool {
+	return procmgrProcessDefinitionExists(parProcmgrProcessDefinitionFile)
+}
+
+func procmgrProcessDefinitionExists(fileName string) bool {
 	installPath, err := winutil.GetProgramFilesDirForProduct("Datadog Agent")
 	if err != nil || installPath == "" {
 		return false
 	}
-	p := filepath.Join(installPath, "processes.d", ddotProcmgrProcessDefinitionFile)
+	p := filepath.Join(installPath, "processes.d", fileName)
 	st, err := os.Stat(p)
 	return err == nil && !st.IsDir()
 }

--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -145,6 +145,9 @@ func postInstallDatadogAgent(ctx HookContext) error {
 	if err := ensureADPProcmgrConfig(); err != nil {
 		return fmt.Errorf("failed to write ADP process manager config: %w", err)
 	}
+	if err := ensurePARProcmgrConfig(); err != nil {
+		return fmt.Errorf("failed to write PAR process manager config: %w", err)
+	}
 
 	// No need to explicitly start the Agent here
 	// - MSI: done at the end in StartDDServices custom action
@@ -173,7 +176,7 @@ func preRemoveDatadogAgent(ctx HookContext) (err error) {
 	if resolved, err := filepath.EvalSymlinks(ctx.PackagePath); err == nil {
 		packagePath = resolved
 	}
-	// ADP processes.d YAML is not an MSI component; keep it across upgrade prerm so a rolled-back
+	// Fleet processes.d YAML is not an MSI component; keep it across upgrade prerm so a rolled-back
 	// install still has supervision config until postinst rewrites it. Full uninstall removes it.
 	if !ctx.Upgrade {
 		installRoot := paths.ResolveDatadogProgramFilesDir()
@@ -185,6 +188,9 @@ func preRemoveDatadogAgent(ctx HookContext) (err error) {
 		}
 		if err := processmanager.RemoveADPProcmgrConfig(installRoot); err != nil {
 			log.Warnf("failed to remove ADP process manager config: %v", err)
+		}
+		if err := processmanager.RemovePARProcmgrConfig(installRoot); err != nil {
+			log.Warnf("failed to remove PAR process manager config: %v", err)
 		}
 		if env.FromEnv().ProcessManagerEnabled {
 			processmanager.ReloadOrRestartProcmgr()
@@ -221,6 +227,25 @@ func ensureADPProcmgrConfig() error {
 	}
 	if err := processmanager.RemoveADPProcmgrConfig(installRoot); err != nil {
 		log.Warnf("ADP: could not remove stale process manager config: %v", err)
+	}
+	return nil
+}
+
+func ensurePARProcmgrConfig() error {
+	installRoot := paths.ResolveDatadogProgramFilesDir()
+	if installRoot == "" {
+		return errors.New("cannot resolve Datadog Agent install path for PAR processes.d")
+	}
+	if resolved, err := filepath.EvalSymlinks(installRoot); err == nil {
+		installRoot = resolved
+	}
+	paths.DatadogProgramFilesDir = installRoot
+
+	if env.FromEnv().ProcessManagerEnabled {
+		return processmanager.WritePARProcmgrConfig(installRoot)
+	}
+	if err := processmanager.RemovePARProcmgrConfig(installRoot); err != nil {
+		log.Warnf("PAR: could not remove stale process manager config: %v", err)
 	}
 	return nil
 }

--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -172,28 +172,6 @@ func preRemoveDatadogAgent(ctx HookContext) (err error) {
 		log.Warnf("failed to remove extensions: %s", err)
 	}
 
-	packagePath := ctx.PackagePath
-	if resolved, err := filepath.EvalSymlinks(ctx.PackagePath); err == nil {
-		packagePath = resolved
-	}
-	// Fleet processes.d YAML is not an MSI component; keep it across upgrade prerm so a rolled-back
-	// install still has supervision config until postinst rewrites it. Full uninstall removes it.
-	if !ctx.Upgrade {
-		installRoot, err := resolveDatadogProgramFilesInstallRoot()
-		if err != nil {
-			installRoot = packagePath
-		}
-		if err := processmanager.RemoveADPProcmgrConfig(installRoot); err != nil {
-			log.Warnf("failed to remove ADP process manager config: %v", err)
-		}
-		if err := processmanager.RemovePARProcmgrConfig(installRoot); err != nil {
-			log.Warnf("failed to remove PAR process manager config: %v", err)
-		}
-		if env.FromEnv().ProcessManagerEnabled {
-			processmanager.ReloadOrRestartProcmgr()
-		}
-	}
-
 	if ctx.PackageType == PackageTypeMSI {
 		// MSI custom action calling hook - done.
 		// Note: the save file written above lives in ProtectedDir which intentionally persists

--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -179,12 +179,9 @@ func preRemoveDatadogAgent(ctx HookContext) (err error) {
 	// Fleet processes.d YAML is not an MSI component; keep it across upgrade prerm so a rolled-back
 	// install still has supervision config until postinst rewrites it. Full uninstall removes it.
 	if !ctx.Upgrade {
-		installRoot := paths.ResolveDatadogProgramFilesDir()
-		if installRoot == "" {
+		installRoot, err := resolveDatadogProgramFilesInstallRoot()
+		if err != nil {
 			installRoot = packagePath
-		} else if resolved, err := filepath.EvalSymlinks(installRoot); err == nil {
-			installRoot = resolved
-			paths.DatadogProgramFilesDir = installRoot
 		}
 		if err := processmanager.RemoveADPProcmgrConfig(installRoot); err != nil {
 			log.Warnf("failed to remove ADP process manager config: %v", err)
@@ -212,15 +209,23 @@ func preRemoveDatadogAgent(ctx HookContext) (err error) {
 	return nil
 }
 
-func ensureADPProcmgrConfig() error {
+func resolveDatadogProgramFilesInstallRoot() (string, error) {
 	installRoot := paths.ResolveDatadogProgramFilesDir()
 	if installRoot == "" {
-		return errors.New("cannot resolve Datadog Agent install path for ADP processes.d")
+		return "", errors.New("cannot resolve Datadog Agent install path for processes.d")
 	}
 	if resolved, err := filepath.EvalSymlinks(installRoot); err == nil {
 		installRoot = resolved
 	}
 	paths.DatadogProgramFilesDir = installRoot
+	return installRoot, nil
+}
+
+func ensureADPProcmgrConfig() error {
+	installRoot, err := resolveDatadogProgramFilesInstallRoot()
+	if err != nil {
+		return err
+	}
 
 	if env.FromEnv().ProcessManagerEnabled {
 		return processmanager.WriteADPProcmgrConfig(installRoot)
@@ -232,14 +237,10 @@ func ensureADPProcmgrConfig() error {
 }
 
 func ensurePARProcmgrConfig() error {
-	installRoot := paths.ResolveDatadogProgramFilesDir()
-	if installRoot == "" {
-		return errors.New("cannot resolve Datadog Agent install path for PAR processes.d")
+	installRoot, err := resolveDatadogProgramFilesInstallRoot()
+	if err != nil {
+		return err
 	}
-	if resolved, err := filepath.EvalSymlinks(installRoot); err == nil {
-		installRoot = resolved
-	}
-	paths.DatadogProgramFilesDir = installRoot
 
 	if env.FromEnv().ProcessManagerEnabled {
 		return processmanager.WritePARProcmgrConfig(installRoot)

--- a/pkg/fleet/installer/packages/embedded/BUILD.bazel
+++ b/pkg/fleet/installer/packages/embedded/BUILD.bazel
@@ -31,6 +31,7 @@ service_srcs = [
     "tmpl/gen/debrpm/datadog-agent-trace-exp.service",
     "tmpl/gen/debrpm/datadog-agent-trace.service",
     "tmpl/gen/debrpm/datadog-agent.service",
+    "tmpl/gen/windows/datadog-agent-action.yaml",
     "tmpl/gen/windows/datadog-agent-data-plane.yaml",
     "tmpl/gen/windows/datadog-agent-ddot.yaml",
     "tmpl/gen/oci/datadog-agent-action-exp.service",
@@ -75,6 +76,7 @@ go_library(
     srcs = ["tmpl/main.go"],
     embedsrcs = [
         "tmpl/datadog-agent-action.service.tmpl",
+        "tmpl/datadog-agent-action-windows.yaml.tmpl",
         "tmpl/datadog-agent-data-plane.service.tmpl",
         "tmpl/datadog-agent-data-plane-windows.yaml.tmpl",
         "tmpl/datadog-agent-ddot.service.tmpl",

--- a/pkg/fleet/installer/packages/embedded/embed.go
+++ b/pkg/fleet/installer/packages/embedded/embed.go
@@ -47,6 +47,12 @@ var DDOTWindowsProcmgrConfig string
 //go:embed tmpl/gen/windows/datadog-agent-data-plane.yaml
 var ADPWindowsProcmgrConfig string
 
+// PARWindowsProcmgrConfig is the codegen-rendered process manager config for PAR on Windows
+// (see embedded/tmpl/main.go). Install time replaces __PAR_*__ placeholders.
+//
+//go:embed tmpl/gen/windows/datadog-agent-action.yaml
+var PARWindowsProcmgrConfig string
+
 // SystemdUnitType is the type of systemd unit.
 type SystemdUnitType string
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-action-windows.yaml.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-action-windows.yaml.tmpl
@@ -1,0 +1,16 @@
+description: Datadog Private Action Runner
+command: '{{.InstallDir}}/bin/agent/privateactionrunner.exe'
+args:
+  - run
+  - --cfgpath
+  - '{{.EtcDir}}/datadog.yaml'
+auto_start: true
+condition_path_exists: '{{.InstallDir}}/bin/agent/privateactionrunner.exe'
+restart: on-failure
+restart_sec: 2
+start_limit_interval_sec: 10
+start_limit_burst: 5
+env:
+  DD_FLEET_POLICIES_DIR: {{.FleetPoliciesDir}}
+stdout: inherit
+stderr: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/windows/datadog-agent-action.yaml
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/windows/datadog-agent-action.yaml
@@ -1,0 +1,16 @@
+description: Datadog Private Action Runner
+command: '__PAR_INSTALL_ROOT__/bin/agent/privateactionrunner.exe'
+args:
+  - run
+  - --cfgpath
+  - '__PAR_ETC_ROOT__/datadog.yaml'
+auto_start: true
+condition_path_exists: '__PAR_INSTALL_ROOT__/bin/agent/privateactionrunner.exe'
+restart: on-failure
+restart_sec: 2
+start_limit_interval_sec: 10
+start_limit_burst: 5
+env:
+  DD_FLEET_POLICIES_DIR: __PAR_FLEET_POLICIES_DIR__
+stdout: inherit
+stderr: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/main.go
+++ b/pkg/fleet/installer/packages/embedded/tmpl/main.go
@@ -191,9 +191,17 @@ var (
 		FleetPoliciesDir: "__ADP_FLEET_POLICIES_DIR__",
 		Stable:           true,
 	}
+	windowsPARCodegenData = installerTemplateData{
+		InstallDir:       "__PAR_INSTALL_ROOT__",
+		EtcDir:           "__PAR_ETC_ROOT__",
+		FleetPoliciesDir: "__PAR_FLEET_POLICIES_DIR__",
+		PIDDir:           "",
+		Stable:           true,
+	}
 	windowsProcmgrLayouts = []embeddedLayout{
 		{subdir: "windows", units: windowsProcmgrYAMLFile("datadog-agent-ddot.yaml", "datadog-agent-ddot-windows.yaml", windowsDDOTCodegenData)},
 		{subdir: "windows", units: windowsProcmgrYAMLFile("datadog-agent-data-plane.yaml", "datadog-agent-data-plane-windows.yaml", windowsADPCodegenData)},
+		{subdir: "windows", units: windowsProcmgrYAMLFile("datadog-agent-action.yaml", "datadog-agent-action-windows.yaml", windowsPARCodegenData)},
 	}
 	linuxProcmgrYAMLLayouts = []embeddedLayout{
 		{subdir: "oci", units: linuxProcmgrYAMLFiles(stableDataOCI, expDataOCI)},

--- a/pkg/fleet/installer/packages/processmanager/BUILD.bazel
+++ b/pkg/fleet/installer/packages/processmanager/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
             "//pkg/fleet/installer/paths",
             "//pkg/util/log",
             "//pkg/util/winutil",
+            "@org_golang_x_sys//windows/registry",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/fleet/installer/packages/processmanager/BUILD.bazel
+++ b/pkg/fleet/installer/packages/processmanager/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
             "//pkg/fleet/installer/paths",
             "//pkg/util/log",
             "//pkg/util/winutil",
-            "@org_golang_x_sys//windows/registry",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/fleet/installer/packages/processmanager/BUILD.bazel
+++ b/pkg/fleet/installer/packages/processmanager/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "adp_procmgr_config_windows.go",
         "ddot_procmgr_config_windows.go",
+        "par_procmgr_config_windows.go",
         "reload_windows.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/processmanager",

--- a/pkg/fleet/installer/packages/processmanager/BUILD.bazel
+++ b/pkg/fleet/installer/packages/processmanager/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "adp_procmgr_config_windows.go",
         "ddot_procmgr_config_windows.go",
+        "install_root_procmgr_config_windows.go",
         "par_procmgr_config_windows.go",
         "reload_windows.go",
     ],

--- a/pkg/fleet/installer/packages/processmanager/adp_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/adp_procmgr_config_windows.go
@@ -8,84 +8,24 @@
 package processmanager
 
 import (
-	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/embedded"
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const adpProcmgrConfigFileName = "datadog-agent-data-plane.yaml"
-
-// WriteADPProcmgrConfig writes datadog-agent-data-plane.yaml next to the MSI install layout so
-// dd-procmgrd picks it up (default_config_dir is InstallPath\processes.d on Windows).
-func WriteADPProcmgrConfig(installRootResolved string) error {
-	adpExe := filepath.Join(installRootResolved, "bin", "agent", "agent-data-plane.exe")
-	if _, err := os.Stat(adpExe); err != nil {
-		log.Debugf("ADP processes.d: skip write (agent-data-plane.exe stat %s: %v)", adpExe, err)
-		return nil
-	}
-	installPF := paths.DatadogProgramFilesDir
-	if installPF == "" {
-		log.Debugf("ADP processes.d: cannot write, DatadogProgramFilesDir is empty (installRoot=%s)", installRootResolved)
-		return errors.New("DatadogProgramFilesDir is empty; cannot write processes.d for ADP")
-	}
-	processesDir := filepath.Join(installPF, "processes.d")
-	if err := os.MkdirAll(processesDir, 0o755); err != nil {
-		log.Debugf("ADP processes.d: mkdir %s: %v", processesDir, err)
-		return fmt.Errorf("create processes.d: %w", err)
-	}
-
-	installRootRepl := filepath.ToSlash(filepath.Clean(installRootResolved))
-	etcRootRepl := filepath.ToSlash(filepath.Clean(paths.DatadogDataDir))
-	fleetPolicies := paths.FleetPoliciesDirForManagedProcess()
-	fleetPoliciesRepl := filepath.ToSlash(filepath.Clean(fleetPolicies))
-	log.Debugf("ADP processes.d: template replace __ADP_INSTALL_ROOT__=%q __ADP_ETC_ROOT__=%q __ADP_FLEET_POLICIES_DIR__=%q",
-		installRootRepl, etcRootRepl, fleetPoliciesRepl)
-
-	config := embedded.ADPWindowsProcmgrConfig
-	config = strings.ReplaceAll(config, "__ADP_INSTALL_ROOT__", installRootRepl)
-	config = strings.ReplaceAll(config, "__ADP_ETC_ROOT__", etcRootRepl)
-	config = strings.ReplaceAll(config, "__ADP_FLEET_POLICIES_DIR__", fleetPoliciesRepl)
-
-	path := filepath.Join(processesDir, adpProcmgrConfigFileName)
-	log.Debugf("ADP processes.d: writing %q", path)
-	return os.WriteFile(path, []byte(config), 0o644)
+var adpInstallRootProcmgrSpec = installRootProcmgrSpec{
+	logLabel:          "ADP",
+	binaryRelPath:     "bin/agent/agent-data-plane.exe",
+	configFileName:    "datadog-agent-data-plane.yaml",
+	embeddedConfig:    embedded.ADPWindowsProcmgrConfig,
+	placeholderPrefix: "ADP",
 }
 
-// RemoveADPProcmgrConfig removes the ADP processes.d YAML from the install layout and from
-// legacy package-relative processes.d.
-func RemoveADPProcmgrConfig(packageRootResolved string) error {
-	if installPF := paths.DatadogProgramFilesDir; installPF != "" {
-		p := filepath.Join(installPF, "processes.d", adpProcmgrConfigFileName)
-		log.Debugf("ADP processes.d: remove %q", p)
-		if err := os.Remove(p); err != nil {
-			if os.IsNotExist(err) {
-				log.Debugf("ADP processes.d: remove %q: not present", p)
-			} else {
-				log.Debugf("ADP processes.d: remove %q: %v", p, err)
-				return err
-			}
-		}
-	} else {
-		log.Debugf("ADP processes.d: remove skip primary (DatadogProgramFilesDir is empty)")
-	}
-	legacy := filepath.Join(packageRootResolved, "processes.d", adpProcmgrConfigFileName)
-	log.Debugf("ADP processes.d: remove legacy %q", legacy)
-	if err := os.Remove(legacy); err != nil {
-		if os.IsNotExist(err) {
-			log.Debugf("ADP processes.d: remove legacy %q: not present", legacy)
-		} else {
-			log.Debugf("ADP processes.d: remove legacy %q: %v", legacy, err)
-			return err
-		}
-	}
-	if installPF := paths.DatadogProgramFilesDir; installPF != "" {
-		removeEmptyProcessesDir(installPF)
-	}
-	return nil
+// WriteADPProcmgrConfig writes datadog-agent-data-plane.yaml under installRootResolved\processes.d so
+// dd-procmgrd picks it up. installRootResolved is the resolved MSI Program Files install root.
+func WriteADPProcmgrConfig(installRootResolved string) error {
+	return writeInstallRootProcmgrConfig(installRootResolved, adpInstallRootProcmgrSpec, RemoveADPProcmgrConfig)
+}
+
+// RemoveADPProcmgrConfig removes the ADP processes.d YAML from installRootResolved\processes.d.
+func RemoveADPProcmgrConfig(installRootResolved string) error {
+	return removeInstallRootProcmgrConfig(installRootResolved, adpInstallRootProcmgrSpec)
 }

--- a/pkg/fleet/installer/packages/processmanager/adp_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/adp_procmgr_config_windows.go
@@ -22,7 +22,7 @@ var adpInstallRootProcmgrSpec = installRootProcmgrSpec{
 // WriteADPProcmgrConfig writes datadog-agent-data-plane.yaml under installRootResolved\processes.d so
 // dd-procmgrd picks it up. installRootResolved is the resolved MSI Program Files install root.
 func WriteADPProcmgrConfig(installRootResolved string) error {
-	return writeInstallRootProcmgrConfig(installRootResolved, adpInstallRootProcmgrSpec, RemoveADPProcmgrConfig)
+	return writeInstallRootProcmgrConfig(installRootResolved, adpInstallRootProcmgrSpec)
 }
 
 // RemoveADPProcmgrConfig removes the ADP processes.d YAML from installRootResolved\processes.d.

--- a/pkg/fleet/installer/packages/processmanager/install_root_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/install_root_procmgr_config_windows.go
@@ -8,7 +8,6 @@
 package processmanager
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,7 +48,7 @@ func (s installRootProcmgrSpec) renderConfig(installRootResolved string) string 
 	return config
 }
 
-func writeInstallRootProcmgrConfig(installRootResolved string, spec installRootProcmgrSpec, remove func(string) error) error {
+func writeInstallRootProcmgrConfig(installRootResolved string, spec installRootProcmgrSpec) error {
 	installRoot, err := os.OpenRoot(installRootResolved)
 	if err != nil {
 		return fmt.Errorf("open install root: %w", err)
@@ -59,11 +58,6 @@ func writeInstallRootProcmgrConfig(installRootResolved string, spec installRootP
 	binaryPath := filepath.Join(installRootResolved, filepath.FromSlash(spec.binaryRelPath))
 	if _, err := installRoot.Stat(spec.binaryRelPath); err != nil {
 		log.Debugf("%s processes.d: skip write (%s stat %s: %v)", spec.logLabel, filepath.Base(spec.binaryRelPath), binaryPath, err)
-		if errors.Is(err, os.ErrNotExist) {
-			// Drop a stale processes.d YAML when the supervised binary is absent, e.g. after
-			// upgrading to a build/flavor that no longer ships it.
-			return remove(installRootResolved)
-		}
 		return nil
 	}
 

--- a/pkg/fleet/installer/packages/processmanager/install_root_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/install_root_procmgr_config_windows.go
@@ -1,0 +1,111 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package processmanager
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// installRootProcmgrSpec describes a processes.d config whose binary and YAML both
+// live under the same MSI Program Files install root (ADP, PAR). DDOT is different:
+// its binary is under the fleet package path while processes.d stays on the install root.
+type installRootProcmgrSpec struct {
+	logLabel          string
+	binaryRelPath     string
+	configFileName    string
+	embeddedConfig    string
+	placeholderPrefix string
+}
+
+func (s installRootProcmgrSpec) configRelPath() string {
+	return filepath.ToSlash(filepath.Join("processes.d", s.configFileName))
+}
+
+func (s installRootProcmgrSpec) renderConfig(installRootResolved string) string {
+	installRootRepl := filepath.ToSlash(filepath.Clean(installRootResolved))
+	etcRootRepl := filepath.ToSlash(filepath.Clean(paths.DatadogDataDir))
+	fleetPoliciesRepl := filepath.ToSlash(filepath.Clean(paths.FleetPoliciesDirForManagedProcess()))
+	log.Debugf("%s processes.d: template replace __%s_INSTALL_ROOT__=%q __%s_ETC_ROOT__=%q __%s_FLEET_POLICIES_DIR__=%q",
+		s.logLabel, s.placeholderPrefix, installRootRepl,
+		s.placeholderPrefix, etcRootRepl,
+		s.placeholderPrefix, fleetPoliciesRepl)
+
+	config := s.embeddedConfig
+	config = strings.ReplaceAll(config, "__"+s.placeholderPrefix+"_INSTALL_ROOT__", installRootRepl)
+	config = strings.ReplaceAll(config, "__"+s.placeholderPrefix+"_ETC_ROOT__", etcRootRepl)
+	config = strings.ReplaceAll(config, "__"+s.placeholderPrefix+"_FLEET_POLICIES_DIR__", fleetPoliciesRepl)
+	return config
+}
+
+func writeInstallRootProcmgrConfig(installRootResolved string, spec installRootProcmgrSpec, remove func(string) error) error {
+	installRoot, err := os.OpenRoot(installRootResolved)
+	if err != nil {
+		return fmt.Errorf("open install root: %w", err)
+	}
+	defer installRoot.Close()
+
+	binaryPath := filepath.Join(installRootResolved, filepath.FromSlash(spec.binaryRelPath))
+	if _, err := installRoot.Stat(spec.binaryRelPath); err != nil {
+		log.Debugf("%s processes.d: skip write (%s stat %s: %v)", spec.logLabel, filepath.Base(spec.binaryRelPath), binaryPath, err)
+		if errors.Is(err, os.ErrNotExist) {
+			// Drop a stale processes.d YAML when the supervised binary is absent, e.g. after
+			// upgrading to a build/flavor that no longer ships it.
+			return remove(installRootResolved)
+		}
+		return nil
+	}
+
+	processesDir := filepath.Join(installRootResolved, "processes.d")
+	if err := installRoot.MkdirAll("processes.d", 0o755); err != nil {
+		log.Debugf("%s processes.d: mkdir %s: %v", spec.logLabel, processesDir, err)
+		return fmt.Errorf("create processes.d: %w", err)
+	}
+
+	configPath := filepath.Join(processesDir, spec.configFileName)
+	log.Debugf("%s processes.d: writing %q", spec.logLabel, configPath)
+	if err := installRoot.WriteFile(spec.configRelPath(), []byte(spec.renderConfig(installRootResolved)), 0o644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func removeInstallRootProcmgrConfig(installRootResolved string, spec installRootProcmgrSpec) error {
+	installRoot, err := os.OpenRoot(installRootResolved)
+	if err != nil {
+		return fmt.Errorf("open install root: %w", err)
+	}
+	defer installRoot.Close()
+
+	configPath := filepath.Join(installRootResolved, "processes.d", spec.configFileName)
+	if err := removeInstallRootProcmgrConfigAtRoot(installRoot, configPath, spec); err != nil {
+		return err
+	}
+
+	removeEmptyProcessesDir(installRootResolved)
+	return nil
+}
+
+func removeInstallRootProcmgrConfigAtRoot(root *os.Root, absPathForLog string, spec installRootProcmgrSpec) error {
+	log.Debugf("%s processes.d: remove %q", spec.logLabel, absPathForLog)
+	if err := root.Remove(spec.configRelPath()); err != nil {
+		if os.IsNotExist(err) {
+			log.Debugf("%s processes.d: remove %q: not present", spec.logLabel, absPathForLog)
+			return nil
+		}
+		log.Debugf("%s processes.d: remove %q: %v", spec.logLabel, absPathForLog, err)
+		return err
+	}
+	return nil
+}

--- a/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
@@ -17,9 +17,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/embedded"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"golang.org/x/sys/windows/registry"
 )
 
-const parProcmgrConfigFileName = "datadog-agent-action.yaml"
+const (
+	parProcmgrConfigFileName = "datadog-agent-action.yaml"
+
+	datadogAgentRegistryKey                       = `SOFTWARE\Datadog\Datadog Agent`
+	parProcmgrConfigWrittenThisInstallRegistryKey = "PARProcmgrConfigWrittenThisInstall"
+)
 
 // WritePARProcmgrConfig writes datadog-agent-action.yaml next to the MSI install layout so
 // dd-procmgrd picks it up (default_config_dir is InstallPath\processes.d on Windows).
@@ -56,8 +62,18 @@ func WritePARProcmgrConfig(installRootResolved string) error {
 	config = strings.ReplaceAll(config, "__PAR_FLEET_POLICIES_DIR__", fleetPoliciesRepl)
 
 	path := filepath.Join(processesDir, parProcmgrConfigFileName)
+	_, statErr := os.Stat(path)
+	existedBefore := statErr == nil
 	log.Debugf("PAR processes.d: writing %q", path)
-	return os.WriteFile(path, []byte(config), 0o644)
+	if err := os.WriteFile(path, []byte(config), 0o644); err != nil {
+		return err
+	}
+	if !existedBefore {
+		if err := setPARProcmgrConfigWrittenThisInstall(); err != nil {
+			log.Warnf("PAR processes.d: could not mark config written this install: %v", err)
+		}
+	}
+	return nil
 }
 
 // RemovePARProcmgrConfig removes the PAR processes.d YAML from the install layout and from
@@ -89,6 +105,35 @@ func RemovePARProcmgrConfig(packageRootResolved string) error {
 	}
 	if installPF := paths.DatadogProgramFilesDir; installPF != "" {
 		removeEmptyProcessesDir(installPF)
+	}
+	if err := clearPARProcmgrConfigWrittenThisInstall(); err != nil {
+		log.Debugf("PAR processes.d: clear install marker: %v", err)
+	}
+	return nil
+}
+
+func setPARProcmgrConfigWrittenThisInstall() error {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, datadogAgentRegistryKey, registry.SET_VALUE)
+	if err != nil {
+		return err
+	}
+	defer k.Close()
+	return k.SetDWordValue(parProcmgrConfigWrittenThisInstallRegistryKey, 1)
+}
+
+func clearPARProcmgrConfigWrittenThisInstall() error {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, datadogAgentRegistryKey, registry.SET_VALUE)
+	if err != nil {
+		if err == registry.ErrNotExist {
+			return nil
+		}
+		return err
+	}
+	defer k.Close()
+	if err := k.DeleteValue(parProcmgrConfigWrittenThisInstallRegistryKey); err == registry.ErrNotExist {
+		return nil
+	} else if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
@@ -27,6 +27,9 @@ func WritePARProcmgrConfig(installRootResolved string) error {
 	parExe := filepath.Join(installRootResolved, "bin", "agent", "privateactionrunner.exe")
 	if _, err := os.Stat(parExe); err != nil {
 		log.Debugf("PAR processes.d: skip write (privateactionrunner.exe stat %s: %v)", parExe, err)
+		if os.IsNotExist(err) {
+			return RemovePARProcmgrConfig(installRootResolved)
+		}
 		return nil
 	}
 	installPF := paths.DatadogProgramFilesDir

--- a/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
@@ -22,7 +22,7 @@ var parInstallRootProcmgrSpec = installRootProcmgrSpec{
 // WritePARProcmgrConfig writes datadog-agent-action.yaml under installRootResolved\processes.d so
 // dd-procmgrd picks it up. installRootResolved is the resolved MSI Program Files install root.
 func WritePARProcmgrConfig(installRootResolved string) error {
-	return writeInstallRootProcmgrConfig(installRootResolved, parInstallRootProcmgrSpec, RemovePARProcmgrConfig)
+	return writeInstallRootProcmgrConfig(installRootResolved, parInstallRootProcmgrSpec)
 }
 
 // RemovePARProcmgrConfig removes the PAR processes.d YAML from installRootResolved\processes.d.

--- a/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
@@ -21,15 +21,26 @@ import (
 
 const (
 	parProcmgrConfigFileName = "datadog-agent-action.yaml"
+	parBinaryRelPath         = "bin/agent/privateactionrunner.exe"
 )
+
+func parProcmgrConfigRelPath() string {
+	return filepath.ToSlash(filepath.Join("processes.d", parProcmgrConfigFileName))
+}
 
 // WritePARProcmgrConfig writes datadog-agent-action.yaml next to the MSI install layout so
 // dd-procmgrd picks it up (default_config_dir is InstallPath\processes.d on Windows).
 func WritePARProcmgrConfig(installRootResolved string) error {
-	parExe := filepath.Join(installRootResolved, "bin", "agent", "privateactionrunner.exe")
-	if _, err := os.Stat(parExe); err != nil {
+	installRoot, err := os.OpenRoot(installRootResolved)
+	if err != nil {
+		return fmt.Errorf("open install root: %w", err)
+	}
+	defer installRoot.Close()
+
+	parExe := filepath.Join(installRootResolved, filepath.FromSlash(parBinaryRelPath))
+	if _, err := installRoot.Stat(parBinaryRelPath); err != nil {
 		log.Debugf("PAR processes.d: skip write (privateactionrunner.exe stat %s: %v)", parExe, err)
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return RemovePARProcmgrConfig(installRootResolved)
 		}
 		return nil
@@ -39,8 +50,14 @@ func WritePARProcmgrConfig(installRootResolved string) error {
 		log.Debugf("PAR processes.d: cannot write, DatadogProgramFilesDir is empty (installRoot=%s)", installRootResolved)
 		return errors.New("DatadogProgramFilesDir is empty; cannot write processes.d for PAR")
 	}
+	installPFRoot, err := os.OpenRoot(installPF)
+	if err != nil {
+		return fmt.Errorf("open program files root: %w", err)
+	}
+	defer installPFRoot.Close()
+
 	processesDir := filepath.Join(installPF, "processes.d")
-	if err := os.MkdirAll(processesDir, 0o755); err != nil {
+	if err := installPFRoot.MkdirAll("processes.d", 0o755); err != nil {
 		log.Debugf("PAR processes.d: mkdir %s: %v", processesDir, err)
 		return fmt.Errorf("create processes.d: %w", err)
 	}
@@ -57,9 +74,9 @@ func WritePARProcmgrConfig(installRootResolved string) error {
 	config = strings.ReplaceAll(config, "__PAR_ETC_ROOT__", etcRootRepl)
 	config = strings.ReplaceAll(config, "__PAR_FLEET_POLICIES_DIR__", fleetPoliciesRepl)
 
-	path := filepath.Join(processesDir, parProcmgrConfigFileName)
-	log.Debugf("PAR processes.d: writing %q", path)
-	if err := os.WriteFile(path, []byte(config), 0o644); err != nil {
+	configPath := filepath.Join(processesDir, parProcmgrConfigFileName)
+	log.Debugf("PAR processes.d: writing %q", configPath)
+	if err := installPFRoot.WriteFile(parProcmgrConfigRelPath(), []byte(config), 0o644); err != nil {
 		return err
 	}
 	return nil
@@ -69,31 +86,49 @@ func WritePARProcmgrConfig(installRootResolved string) error {
 // legacy package-relative processes.d.
 func RemovePARProcmgrConfig(packageRootResolved string) error {
 	if installPF := paths.DatadogProgramFilesDir; installPF != "" {
-		p := filepath.Join(installPF, "processes.d", parProcmgrConfigFileName)
-		log.Debugf("PAR processes.d: remove %q", p)
-		if err := os.Remove(p); err != nil {
-			if os.IsNotExist(err) {
-				log.Debugf("PAR processes.d: remove %q: not present", p)
-			} else {
-				log.Debugf("PAR processes.d: remove %q: %v", p, err)
-				return err
-			}
+		installPFRoot, err := os.OpenRoot(installPF)
+		if err != nil {
+			return fmt.Errorf("open program files root: %w", err)
+		}
+		defer installPFRoot.Close()
+
+		if err := removePARProcmgrConfigAtRoot(
+			installPFRoot,
+			filepath.Join(installPF, "processes.d", parProcmgrConfigFileName),
+		); err != nil {
+			return err
 		}
 	} else {
 		log.Debugf("PAR processes.d: remove skip primary (DatadogProgramFilesDir is empty)")
 	}
+
+	packageRoot, err := os.OpenRoot(packageRootResolved)
+	if err != nil {
+		return fmt.Errorf("open package root: %w", err)
+	}
+	defer packageRoot.Close()
+
 	legacy := filepath.Join(packageRootResolved, "processes.d", parProcmgrConfigFileName)
 	log.Debugf("PAR processes.d: remove legacy %q", legacy)
-	if err := os.Remove(legacy); err != nil {
-		if os.IsNotExist(err) {
-			log.Debugf("PAR processes.d: remove legacy %q: not present", legacy)
-		} else {
-			log.Debugf("PAR processes.d: remove legacy %q: %v", legacy, err)
-			return err
-		}
+	if err := removePARProcmgrConfigAtRoot(packageRoot, legacy); err != nil {
+		return err
 	}
+
 	if installPF := paths.DatadogProgramFilesDir; installPF != "" {
 		removeEmptyProcessesDir(installPF)
+	}
+	return nil
+}
+
+func removePARProcmgrConfigAtRoot(root *os.Root, absPathForLog string) error {
+	log.Debugf("PAR processes.d: remove %q", absPathForLog)
+	if err := root.Remove(parProcmgrConfigRelPath()); err != nil {
+		if os.IsNotExist(err) {
+			log.Debugf("PAR processes.d: remove %q: not present", absPathForLog)
+			return nil
+		}
+		log.Debugf("PAR processes.d: remove %q: %v", absPathForLog, err)
+		return err
 	}
 	return nil
 }

--- a/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package processmanager
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/embedded"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const parProcmgrConfigFileName = "datadog-agent-action.yaml"
+
+// WritePARProcmgrConfig writes datadog-agent-action.yaml next to the MSI install layout so
+// dd-procmgrd picks it up (default_config_dir is InstallPath\processes.d on Windows).
+func WritePARProcmgrConfig(installRootResolved string) error {
+	parExe := filepath.Join(installRootResolved, "bin", "agent", "privateactionrunner.exe")
+	if _, err := os.Stat(parExe); err != nil {
+		log.Debugf("PAR processes.d: skip write (privateactionrunner.exe stat %s: %v)", parExe, err)
+		return nil
+	}
+	installPF := paths.DatadogProgramFilesDir
+	if installPF == "" {
+		log.Debugf("PAR processes.d: cannot write, DatadogProgramFilesDir is empty (installRoot=%s)", installRootResolved)
+		return errors.New("DatadogProgramFilesDir is empty; cannot write processes.d for PAR")
+	}
+	processesDir := filepath.Join(installPF, "processes.d")
+	if err := os.MkdirAll(processesDir, 0o755); err != nil {
+		log.Debugf("PAR processes.d: mkdir %s: %v", processesDir, err)
+		return fmt.Errorf("create processes.d: %w", err)
+	}
+
+	installRootRepl := filepath.ToSlash(filepath.Clean(installRootResolved))
+	etcRootRepl := filepath.ToSlash(filepath.Clean(paths.DatadogDataDir))
+	fleetPolicies := paths.FleetPoliciesDirForManagedProcess()
+	fleetPoliciesRepl := filepath.ToSlash(filepath.Clean(fleetPolicies))
+	log.Debugf("PAR processes.d: template replace __PAR_INSTALL_ROOT__=%q __PAR_ETC_ROOT__=%q __PAR_FLEET_POLICIES_DIR__=%q",
+		installRootRepl, etcRootRepl, fleetPoliciesRepl)
+
+	config := embedded.PARWindowsProcmgrConfig
+	config = strings.ReplaceAll(config, "__PAR_INSTALL_ROOT__", installRootRepl)
+	config = strings.ReplaceAll(config, "__PAR_ETC_ROOT__", etcRootRepl)
+	config = strings.ReplaceAll(config, "__PAR_FLEET_POLICIES_DIR__", fleetPoliciesRepl)
+
+	path := filepath.Join(processesDir, parProcmgrConfigFileName)
+	log.Debugf("PAR processes.d: writing %q", path)
+	return os.WriteFile(path, []byte(config), 0o644)
+}
+
+// RemovePARProcmgrConfig removes the PAR processes.d YAML from the install layout and from
+// legacy package-relative processes.d.
+func RemovePARProcmgrConfig(packageRootResolved string) error {
+	if installPF := paths.DatadogProgramFilesDir; installPF != "" {
+		p := filepath.Join(installPF, "processes.d", parProcmgrConfigFileName)
+		log.Debugf("PAR processes.d: remove %q", p)
+		if err := os.Remove(p); err != nil {
+			if os.IsNotExist(err) {
+				log.Debugf("PAR processes.d: remove %q: not present", p)
+			} else {
+				log.Debugf("PAR processes.d: remove %q: %v", p, err)
+				return err
+			}
+		}
+	} else {
+		log.Debugf("PAR processes.d: remove skip primary (DatadogProgramFilesDir is empty)")
+	}
+	legacy := filepath.Join(packageRootResolved, "processes.d", parProcmgrConfigFileName)
+	log.Debugf("PAR processes.d: remove legacy %q", legacy)
+	if err := os.Remove(legacy); err != nil {
+		if os.IsNotExist(err) {
+			log.Debugf("PAR processes.d: remove legacy %q: not present", legacy)
+		} else {
+			log.Debugf("PAR processes.d: remove legacy %q: %v", legacy, err)
+			return err
+		}
+	}
+	if installPF := paths.DatadogProgramFilesDir; installPF != "" {
+		removeEmptyProcessesDir(installPF)
+	}
+	return nil
+}

--- a/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
@@ -8,127 +8,24 @@
 package processmanager
 
 import (
-	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/embedded"
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const (
-	parProcmgrConfigFileName = "datadog-agent-action.yaml"
-	parBinaryRelPath         = "bin/agent/privateactionrunner.exe"
-)
-
-func parProcmgrConfigRelPath() string {
-	return filepath.ToSlash(filepath.Join("processes.d", parProcmgrConfigFileName))
+var parInstallRootProcmgrSpec = installRootProcmgrSpec{
+	logLabel:          "PAR",
+	binaryRelPath:     "bin/agent/privateactionrunner.exe",
+	configFileName:    "datadog-agent-action.yaml",
+	embeddedConfig:    embedded.PARWindowsProcmgrConfig,
+	placeholderPrefix: "PAR",
 }
 
-// WritePARProcmgrConfig writes datadog-agent-action.yaml next to the MSI install layout so
-// dd-procmgrd picks it up (default_config_dir is InstallPath\processes.d on Windows).
+// WritePARProcmgrConfig writes datadog-agent-action.yaml under installRootResolved\processes.d so
+// dd-procmgrd picks it up. installRootResolved is the resolved MSI Program Files install root.
 func WritePARProcmgrConfig(installRootResolved string) error {
-	installRoot, err := os.OpenRoot(installRootResolved)
-	if err != nil {
-		return fmt.Errorf("open install root: %w", err)
-	}
-	defer installRoot.Close()
-
-	parExe := filepath.Join(installRootResolved, filepath.FromSlash(parBinaryRelPath))
-	if _, err := installRoot.Stat(parBinaryRelPath); err != nil {
-		log.Debugf("PAR processes.d: skip write (privateactionrunner.exe stat %s: %v)", parExe, err)
-		if errors.Is(err, os.ErrNotExist) {
-			return RemovePARProcmgrConfig(installRootResolved)
-		}
-		return nil
-	}
-	installPF := paths.DatadogProgramFilesDir
-	if installPF == "" {
-		log.Debugf("PAR processes.d: cannot write, DatadogProgramFilesDir is empty (installRoot=%s)", installRootResolved)
-		return errors.New("DatadogProgramFilesDir is empty; cannot write processes.d for PAR")
-	}
-	installPFRoot, err := os.OpenRoot(installPF)
-	if err != nil {
-		return fmt.Errorf("open program files root: %w", err)
-	}
-	defer installPFRoot.Close()
-
-	processesDir := filepath.Join(installPF, "processes.d")
-	if err := installPFRoot.MkdirAll("processes.d", 0o755); err != nil {
-		log.Debugf("PAR processes.d: mkdir %s: %v", processesDir, err)
-		return fmt.Errorf("create processes.d: %w", err)
-	}
-
-	installRootRepl := filepath.ToSlash(filepath.Clean(installRootResolved))
-	etcRootRepl := filepath.ToSlash(filepath.Clean(paths.DatadogDataDir))
-	fleetPolicies := paths.FleetPoliciesDirForManagedProcess()
-	fleetPoliciesRepl := filepath.ToSlash(filepath.Clean(fleetPolicies))
-	log.Debugf("PAR processes.d: template replace __PAR_INSTALL_ROOT__=%q __PAR_ETC_ROOT__=%q __PAR_FLEET_POLICIES_DIR__=%q",
-		installRootRepl, etcRootRepl, fleetPoliciesRepl)
-
-	config := embedded.PARWindowsProcmgrConfig
-	config = strings.ReplaceAll(config, "__PAR_INSTALL_ROOT__", installRootRepl)
-	config = strings.ReplaceAll(config, "__PAR_ETC_ROOT__", etcRootRepl)
-	config = strings.ReplaceAll(config, "__PAR_FLEET_POLICIES_DIR__", fleetPoliciesRepl)
-
-	configPath := filepath.Join(processesDir, parProcmgrConfigFileName)
-	log.Debugf("PAR processes.d: writing %q", configPath)
-	if err := installPFRoot.WriteFile(parProcmgrConfigRelPath(), []byte(config), 0o644); err != nil {
-		return err
-	}
-	return nil
+	return writeInstallRootProcmgrConfig(installRootResolved, parInstallRootProcmgrSpec, RemovePARProcmgrConfig)
 }
 
-// RemovePARProcmgrConfig removes the PAR processes.d YAML from the install layout and from
-// legacy package-relative processes.d.
-func RemovePARProcmgrConfig(packageRootResolved string) error {
-	if installPF := paths.DatadogProgramFilesDir; installPF != "" {
-		installPFRoot, err := os.OpenRoot(installPF)
-		if err != nil {
-			return fmt.Errorf("open program files root: %w", err)
-		}
-		defer installPFRoot.Close()
-
-		if err := removePARProcmgrConfigAtRoot(
-			installPFRoot,
-			filepath.Join(installPF, "processes.d", parProcmgrConfigFileName),
-		); err != nil {
-			return err
-		}
-	} else {
-		log.Debugf("PAR processes.d: remove skip primary (DatadogProgramFilesDir is empty)")
-	}
-
-	packageRoot, err := os.OpenRoot(packageRootResolved)
-	if err != nil {
-		return fmt.Errorf("open package root: %w", err)
-	}
-	defer packageRoot.Close()
-
-	legacy := filepath.Join(packageRootResolved, "processes.d", parProcmgrConfigFileName)
-	log.Debugf("PAR processes.d: remove legacy %q", legacy)
-	if err := removePARProcmgrConfigAtRoot(packageRoot, legacy); err != nil {
-		return err
-	}
-
-	if installPF := paths.DatadogProgramFilesDir; installPF != "" {
-		removeEmptyProcessesDir(installPF)
-	}
-	return nil
-}
-
-func removePARProcmgrConfigAtRoot(root *os.Root, absPathForLog string) error {
-	log.Debugf("PAR processes.d: remove %q", absPathForLog)
-	if err := root.Remove(parProcmgrConfigRelPath()); err != nil {
-		if os.IsNotExist(err) {
-			log.Debugf("PAR processes.d: remove %q: not present", absPathForLog)
-			return nil
-		}
-		log.Debugf("PAR processes.d: remove %q: %v", absPathForLog, err)
-		return err
-	}
-	return nil
+// RemovePARProcmgrConfig removes the PAR processes.d YAML from installRootResolved\processes.d.
+func RemovePARProcmgrConfig(installRootResolved string) error {
+	return removeInstallRootProcmgrConfig(installRootResolved, parInstallRootProcmgrSpec)
 }

--- a/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
@@ -17,14 +17,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/embedded"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"golang.org/x/sys/windows/registry"
 )
 
 const (
 	parProcmgrConfigFileName = "datadog-agent-action.yaml"
-
-	datadogAgentRegistryKey                       = `SOFTWARE\Datadog\Datadog Agent`
-	parProcmgrConfigWrittenThisInstallRegistryKey = "PARProcmgrConfigWrittenThisInstall"
 )
 
 // WritePARProcmgrConfig writes datadog-agent-action.yaml next to the MSI install layout so
@@ -62,16 +58,9 @@ func WritePARProcmgrConfig(installRootResolved string) error {
 	config = strings.ReplaceAll(config, "__PAR_FLEET_POLICIES_DIR__", fleetPoliciesRepl)
 
 	path := filepath.Join(processesDir, parProcmgrConfigFileName)
-	_, statErr := os.Stat(path)
-	existedBefore := statErr == nil
 	log.Debugf("PAR processes.d: writing %q", path)
 	if err := os.WriteFile(path, []byte(config), 0o644); err != nil {
 		return err
-	}
-	if !existedBefore {
-		if err := setPARProcmgrConfigWrittenThisInstall(); err != nil {
-			log.Warnf("PAR processes.d: could not mark config written this install: %v", err)
-		}
 	}
 	return nil
 }
@@ -105,35 +94,6 @@ func RemovePARProcmgrConfig(packageRootResolved string) error {
 	}
 	if installPF := paths.DatadogProgramFilesDir; installPF != "" {
 		removeEmptyProcessesDir(installPF)
-	}
-	if err := clearPARProcmgrConfigWrittenThisInstall(); err != nil {
-		log.Debugf("PAR processes.d: clear install marker: %v", err)
-	}
-	return nil
-}
-
-func setPARProcmgrConfigWrittenThisInstall() error {
-	k, err := registry.OpenKey(registry.LOCAL_MACHINE, datadogAgentRegistryKey, registry.SET_VALUE)
-	if err != nil {
-		return err
-	}
-	defer k.Close()
-	return k.SetDWordValue(parProcmgrConfigWrittenThisInstallRegistryKey, 1)
-}
-
-func clearPARProcmgrConfigWrittenThisInstall() error {
-	k, err := registry.OpenKey(registry.LOCAL_MACHINE, datadogAgentRegistryKey, registry.SET_VALUE)
-	if err != nil {
-		if err == registry.ErrNotExist {
-			return nil
-		}
-		return err
-	}
-	defer k.Close()
-	if err := k.DeleteValue(parProcmgrConfigWrittenThisInstallRegistryKey); err == registry.ErrNotExist {
-		return nil
-	} else if err != nil {
-		return err
 	}
 	return nil
 }

--- a/releasenotes/notes/windows-par-procmgr-dual-mode-a8c3f1e2b9d04756.yaml
+++ b/releasenotes/notes/windows-par-procmgr-dual-mode-a8c3f1e2b9d04756.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    On Windows, when ``process_manager.enabled`` is true and the fleet installer writes
+    ``processes.d/datadog-agent-action.yaml``, the Private Action Runner is supervised by
+    dd-procmgr instead of the legacy ``datadog-agent-action`` Windows service. When the
+    processes.d definition is absent or process manager is disabled, the Agent continues
+    to start PAR via SCM when ``private_action_runner.enabled`` is true.

--- a/test/new-e2e/tests/agent-runtimes/procmgr/par_procmgr_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/par_procmgr_win_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+	paridentity "github.com/DataDog/datadog-agent/test/new-e2e/tests/privateactionrunner"
 	windowsagent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 )
 
@@ -30,24 +30,18 @@ const (
 	parProcmgrConfigFileName = "datadog-agent-action.yaml"
 )
 
-func withPAREnabled() agentparams.Option {
-	return func(p *agentparams.Params) error {
-		p.ExtraAgentConfig = append(p.ExtraAgentConfig, pulumi.String("private_action_runner.enabled: true"))
-		return nil
-	}
-}
-
 type parProcmgrWindowsSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
 
 func TestPARManagedByProcmgrWindows(t *testing.T) {
 	t.Parallel()
+	config := paridentity.GenerateTestPrivateActionRunnerConfig(t)
 	e2e.Run(t, &parProcmgrWindowsSuite{}, e2e.WithProvisioner(
 		awshost.ProvisionerNoFakeIntake(
 			awshost.WithRunOptions(
 				ec2.WithEC2InstanceOptions(ec2.WithOS(e2eos.WindowsServerDefault)),
-				ec2.WithAgentOptions(withPAREnabled()),
+				ec2.WithAgentOptions(agentparams.WithAgentConfig(config)),
 			),
 		),
 	))

--- a/test/new-e2e/tests/agent-runtimes/procmgr/par_procmgr_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/par_procmgr_win_test.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package procmgr
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+	windowsagent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+)
+
+const (
+	parProcessName           = "datadog-agent-action"
+	parLegacySCMServiceName  = "datadog-agent-action"
+	parProcmgrConfigFileName = "datadog-agent-action.yaml"
+)
+
+func withPAREnabled() agentparams.Option {
+	return func(p *agentparams.Params) error {
+		p.ExtraAgentConfig = append(p.ExtraAgentConfig, pulumi.String("private_action_runner.enabled: true"))
+		return nil
+	}
+}
+
+type parProcmgrWindowsSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+func TestPARManagedByProcmgrWindows(t *testing.T) {
+	t.Parallel()
+	e2e.Run(t, &parProcmgrWindowsSuite{}, e2e.WithProvisioner(
+		awshost.ProvisionerNoFakeIntake(
+			awshost.WithRunOptions(
+				ec2.WithEC2InstanceOptions(ec2.WithOS(e2eos.WindowsServerDefault)),
+				ec2.WithAgentOptions(withPAREnabled()),
+			),
+		),
+	))
+}
+
+func (s *parProcmgrWindowsSuite) TestPARSupervisedByProcmgrAndLegacySCMStopped() {
+	host := s.Env().RemoteHost
+	installRoot, err := windowsagent.GetInstallPathFromRegistry(host)
+	require.NoError(s.T(), err)
+
+	parBin := filepath.Join(installRoot, "bin", "agent", "privateactionrunner.exe")
+	_, err = host.Execute(fmt.Sprintf(`powershell -NoProfile -Command "if (-not (Test-Path -LiteralPath '%s')) { exit 1 }"`, parBin))
+	if err != nil {
+		s.T().Skip("privateactionrunner.exe not installed; skipping PAR procmgr test")
+	}
+
+	cfg := filepath.Join(installRoot, "processes.d", parProcmgrConfigFileName)
+	_, err = host.Execute(fmt.Sprintf(`powershell -NoProfile -Command "if (-not (Test-Path -LiteralPath '%s')) { exit 1 }"`, cfg))
+	require.NoError(s.T(), err, "fleet PAR processes.d config should exist at %s", cfg)
+
+	cli := filepath.Join(installRoot, "bin", "agent", "dd-procmgr.exe")
+	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
+		out, err := host.Execute(fmt.Sprintf(`& "%s" describe %s`, cli, parProcessName))
+		assert.NoError(ct, err)
+		assert.Contains(ct, out, "State")
+		assert.Contains(ct, out, "Running")
+	}, 120*time.Second, 3*time.Second)
+
+	_, err = host.Execute(
+		fmt.Sprintf(`powershell -NoProfile -Command "$s = Get-Service -Name '%s' -ErrorAction SilentlyContinue; if ($null -eq $s) { exit 0 }; if ($s.Status -eq 'Running') { exit 1 }; exit 0"`, parLegacySCMServiceName))
+	require.NoError(s.T(), err, "%s Windows service must not be Running when PAR is managed by dd-procmgr", parLegacySCMServiceName)
+}

--- a/test/new-e2e/tests/agent-runtimes/procmgr/par_procmgr_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/par_procmgr_win_test.go
@@ -8,6 +8,7 @@ package procmgr
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -53,14 +54,16 @@ func (s *parProcmgrWindowsSuite) TestPARSupervisedByProcmgrAndLegacySCMStopped()
 	require.NoError(s.T(), err)
 
 	parBin := filepath.Join(installRoot, "bin", "agent", "privateactionrunner.exe")
-	_, err = host.Execute(fmt.Sprintf(`powershell -NoProfile -Command "if (-not (Test-Path -LiteralPath '%s')) { exit 1 }"`, parBin))
-	if err != nil {
+	exists, err := host.FileExists(parBin)
+	require.NoError(s.T(), err)
+	if !exists {
 		s.T().Skip("privateactionrunner.exe not installed; skipping PAR procmgr test")
 	}
 
 	cfg := filepath.Join(installRoot, "processes.d", parProcmgrConfigFileName)
-	_, err = host.Execute(fmt.Sprintf(`powershell -NoProfile -Command "if (-not (Test-Path -LiteralPath '%s')) { exit 1 }"`, cfg))
-	require.NoError(s.T(), err, "fleet PAR processes.d config should exist at %s", cfg)
+	exists, err = host.FileExists(cfg)
+	require.NoError(s.T(), err)
+	require.True(s.T(), exists, "fleet PAR processes.d config should exist at %s", cfg)
 
 	cli := filepath.Join(installRoot, "bin", "agent", "dd-procmgr.exe")
 	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
@@ -70,7 +73,11 @@ func (s *parProcmgrWindowsSuite) TestPARSupervisedByProcmgrAndLegacySCMStopped()
 		assert.Contains(ct, out, "Running")
 	}, 120*time.Second, 3*time.Second)
 
-	_, err = host.Execute(
-		fmt.Sprintf(`powershell -NoProfile -Command "$s = Get-Service -Name '%s' -ErrorAction SilentlyContinue; if ($null -eq $s) { exit 0 }; if ($s.Status -eq 'Running') { exit 1 }; exit 0"`, parLegacySCMServiceName))
-	require.NoError(s.T(), err, "%s Windows service must not be Running when PAR is managed by dd-procmgr", parLegacySCMServiceName)
+	out, err := host.Execute(fmt.Sprintf(
+		`$s = Get-Service -Name '%s' -ErrorAction SilentlyContinue; if ($null -eq $s) { 'Absent' } else { $s.Status }`,
+		parLegacySCMServiceName,
+	))
+	require.NoError(s.T(), err)
+	require.NotEqual(s.T(), "Running", strings.TrimSpace(out),
+		"%s Windows service must not be Running when PAR is managed by dd-procmgr", parLegacySCMServiceName)
 }

--- a/test/new-e2e/tests/privateactionrunner/helpers_test.go
+++ b/test/new-e2e/tests/privateactionrunner/helpers_test.go
@@ -7,35 +7,10 @@
 package privateactionrunner
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"encoding/base64"
-	"encoding/json"
 	"testing"
-
-	"github.com/go-jose/go-jose/v4"
-	"github.com/stretchr/testify/require"
 )
 
-const testRunnerURN = "urn:dd:apps:on-prem-runner:us1:123456:test-runner-e2e"
-
-// generateTestRunnerIdentity generates a fresh ECDSA key pair and returns the
-// runner URN and base64-encoded private JWK, suitable for use in both agent
-// config and provisioner Helm values.
+// generateTestRunnerIdentity is a test-local alias for GenerateTestRunnerIdentity.
 func generateTestRunnerIdentity(t *testing.T) (urn string, privateKeyB64 string) {
-	t.Helper()
-
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err, "failed to generate ECDSA key")
-
-	privateJwk := jose.JSONWebKey{
-		Algorithm: "ES256",
-		Key:       privateKey,
-		Use:       "sig",
-	}
-	jwkJSON, err := json.Marshal(privateJwk)
-	require.NoError(t, err, "failed to marshal JWK")
-
-	return testRunnerURN, base64.RawURLEncoding.EncodeToString(jwkJSON)
+	return GenerateTestRunnerIdentity(t)
 }

--- a/test/new-e2e/tests/privateactionrunner/identity.go
+++ b/test/new-e2e/tests/privateactionrunner/identity.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package privateactionrunner
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/require"
+)
+
+const testRunnerURN = "urn:dd:apps:on-prem-runner:us1:123456:test-runner-e2e"
+
+// GenerateTestRunnerIdentity generates a fresh ECDSA key pair and returns the
+// runner URN and base64-encoded private JWK for agent config or Helm values.
+func GenerateTestRunnerIdentity(t *testing.T) (urn string, privateKeyB64 string) {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "failed to generate ECDSA key")
+
+	privateJwk := jose.JSONWebKey{
+		Algorithm: "ES256",
+		Key:       privateKey,
+		Use:       "sig",
+	}
+	jwkJSON, err := json.Marshal(privateJwk)
+	require.NoError(t, err, "failed to marshal JWK")
+
+	return testRunnerURN, base64.RawURLEncoding.EncodeToString(jwkJSON)
+}
+
+// GenerateTestPrivateActionRunnerConfig returns datadog.yaml snippet with PAR enabled
+// and a valid test identity so the runner can start without self-enrollment.
+func GenerateTestPrivateActionRunnerConfig(t *testing.T) string {
+	t.Helper()
+	urn, privateKeyB64 := GenerateTestRunnerIdentity(t)
+	return fmt.Sprintf(`private_action_runner:
+  enabled: true
+  private_key: %s
+  urn: %s
+`, privateKeyB64, urn)
+}

--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
@@ -26,13 +26,7 @@ const (
 )
 
 func generateTestPrivateActionRunnerConfig(t *testing.T) string {
-	t.Helper()
-	urn, privateKeyB64 := generateTestRunnerIdentity(t)
-	return fmt.Sprintf(`private_action_runner:
-  enabled: true
-  private_key: %s
-  urn: %s
-`, privateKeyB64, urn)
+	return GenerateTestPrivateActionRunnerConfig(t)
 }
 
 type linuxPrivateActionRunnerEnabledSuite struct {

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -333,6 +333,17 @@ func (t *Tester) testCurrentVersionExpectations(tt *testing.T) {
 		assert.NoError(tt, err, "install should create %s", adpProcmgrConfigPath)
 	})
 
+	tt.Run("creates par process manager config", func(tt *testing.T) {
+		parBin := filepath.Join(t.expectedInstallPath, "bin", "agent", "privateactionrunner.exe")
+		exists, err := t.host.FileExists(parBin)
+		if !assert.NoError(tt, err) || !exists {
+			tt.Skip("privateactionrunner.exe not installed; skipping PAR procmgr config assertion")
+		}
+		parProcmgrConfigPath := filepath.Join(t.expectedInstallPath, "processes.d", "datadog-agent-action.yaml")
+		_, err = t.host.Lstat(parProcmgrConfigPath)
+		assert.NoError(tt, err, "install should create %s", parProcmgrConfigPath)
+	})
+
 	tt.Run("removes embedded extraction artifacts", func(tt *testing.T) {
 		paths := []string{
 			filepath.Join(t.expectedInstallPath, "embedded3.COMPRESSED"),

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
@@ -102,6 +102,12 @@ namespace Datadog.AgentCustomActions
         }
 
         [CustomAction]
+        public static ActionResult RemoveParFleetProcmgrConfigOnUpgradeRollback(Session session)
+        {
+            return Datadog.CustomActions.CleanUpFilesCustomAction.RemoveParFleetProcmgrConfigOnUpgradeRollback(session);
+        }
+
+        [CustomAction]
         public static ActionResult RemoveEmptyInstallDirOnRollback(Session session)
         {
             return Datadog.CustomActions.CleanUpFilesCustomAction.RemoveEmptyInstallDirOnRollback(session);

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
@@ -96,18 +96,6 @@ namespace Datadog.AgentCustomActions
         }
 
         [CustomAction]
-        public static ActionResult RemoveFleetProcmgrConfigOnRollback(Session session)
-        {
-            return Datadog.CustomActions.CleanUpFilesCustomAction.RemoveFleetProcmgrConfigOnRollback(session);
-        }
-
-        [CustomAction]
-        public static ActionResult RemoveParFleetProcmgrConfigOnUpgradeRollback(Session session)
-        {
-            return Datadog.CustomActions.CleanUpFilesCustomAction.RemoveParFleetProcmgrConfigOnUpgradeRollback(session);
-        }
-
-        [CustomAction]
         public static ActionResult RemoveEmptyInstallDirOnRollback(Session session)
         {
             return Datadog.CustomActions.CleanUpFilesCustomAction.RemoveEmptyInstallDirOnRollback(session);

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
@@ -178,6 +178,8 @@ namespace Datadog.AgentCustomActions
             {
                 "bin\\agent",
                 "embedded3",
+                // Fleet postinst writes processes.d/*.yaml (untracked by MSI)
+                "processes.d",
                 // embedded2 only exists in Agent 6, so an error will be logged, but install will continue
                 "embedded2",
             };

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
@@ -32,6 +32,15 @@ namespace Datadog.CustomActions
         }
 
         /// <summary>
+        /// Rollback-only: remove fleet-written PAR processes.d YAML after a failed upgrade.
+        /// Older agents start PAR via SCM and do not suppress it when this file is left behind.
+        /// </summary>
+        public static ActionResult RemoveParFleetProcmgrConfigOnUpgradeRollback(Session session)
+        {
+            return RemoveParFleetProcmgrConfigOnUpgradeRollback(new SessionWrapper(session));
+        }
+
+        /// <summary>
         /// Rollback-only: drop an otherwise-empty install root left by a failed fresh install.
         /// </summary>
         public static ActionResult RemoveEmptyInstallDirOnRollback(Session session)
@@ -56,7 +65,14 @@ namespace Datadog.CustomActions
 
         private static ActionResult RemoveFleetProcmgrConfigOnRollback(ISession session)
         {
-            TryRemoveFleetProcmgrConfigFiles(session, session.Property("PROJECTLOCATION"));
+            TryRemoveFleetProcmgrConfigFiles(session, session.Property("PROJECTLOCATION"),
+                AdpProcmgrConfigFileName, DdotProcmgrConfigFileName, ParProcmgrConfigFileName);
+            return ActionResult.Success;
+        }
+
+        private static ActionResult RemoveParFleetProcmgrConfigOnUpgradeRollback(ISession session)
+        {
+            TryRemoveFleetProcmgrConfigFiles(session, session.Property("PROJECTLOCATION"), ParProcmgrConfigFileName);
             return ActionResult.Success;
         }
 
@@ -112,7 +128,7 @@ namespace Datadog.CustomActions
             }
         }
 
-        private static void TryRemoveFleetProcmgrConfigFiles(ISession session, string projectLocation)
+        private static void TryRemoveFleetProcmgrConfigFiles(ISession session, string projectLocation, params string[] fileNames)
         {
             if (string.IsNullOrEmpty(projectLocation))
             {
@@ -120,7 +136,7 @@ namespace Datadog.CustomActions
             }
 
             var processesDir = Path.Combine(projectLocation, "processes.d");
-            foreach (var fileName in new[] { AdpProcmgrConfigFileName, DdotProcmgrConfigFileName, ParProcmgrConfigFileName })
+            foreach (var fileName in fileNames)
             {
                 var path = Path.Combine(processesDir, fileName);
                 try

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
@@ -4,6 +4,7 @@ using WixToolset.Dtf.WindowsInstaller;
 using System;
 using System.IO;
 using System.Linq;
+using Microsoft.Win32;
 
 namespace Datadog.CustomActions
 {
@@ -41,6 +42,14 @@ namespace Datadog.CustomActions
         }
 
         /// <summary>
+        /// Clear the install-session marker after a successful MSI install/upgrade.
+        /// </summary>
+        public static ActionResult ClearPARProcmgrConfigWrittenThisInstallMarker(Session session)
+        {
+            return ClearPARProcmgrConfigWrittenThisInstallMarker(new SessionWrapper(session));
+        }
+
+        /// <summary>
         /// Rollback-only: drop an otherwise-empty install root left by a failed fresh install.
         /// </summary>
         public static ActionResult RemoveEmptyInstallDirOnRollback(Session session)
@@ -72,7 +81,19 @@ namespace Datadog.CustomActions
 
         private static ActionResult RemoveParFleetProcmgrConfigOnUpgradeRollback(ISession session)
         {
+            if (!PARProcmgrConfigMarkedWrittenThisInstall(session))
+            {
+                session.Log("PAR processes.d was not written this install; skip upgrade rollback cleanup.");
+                return ActionResult.Success;
+            }
             TryRemoveFleetProcmgrConfigFiles(session, session.Property("PROJECTLOCATION"), ParProcmgrConfigFileName);
+            clearParProcmgrInstallMarkerRegistry(session);
+            return ActionResult.Success;
+        }
+
+        private static ActionResult ClearPARProcmgrConfigWrittenThisInstallMarker(ISession session)
+        {
+            clearParProcmgrInstallMarkerRegistry(session);
             return ActionResult.Success;
         }
 
@@ -190,6 +211,39 @@ namespace Datadog.CustomActions
             catch (Exception e)
             {
                 session.Log($"Error while deleting empty install directory: {e}");
+            }
+        }
+
+        private static bool PARProcmgrConfigMarkedWrittenThisInstall(ISession session)
+        {
+            try
+            {
+                using var key = Registry.LocalMachine.OpenSubKey(Constants.DatadogAgentRegistryKey, writable: false);
+                if (key == null)
+                {
+                    return false;
+                }
+
+                var value = key.GetValue(Constants.PARProcmgrConfigWrittenThisInstallValue);
+                return value is int marker && marker != 0;
+            }
+            catch (Exception e)
+            {
+                session.Log($"Error reading PAR procmgr install marker: {e}");
+                return false;
+            }
+        }
+
+        private static void clearParProcmgrInstallMarkerRegistry(ISession session)
+        {
+            try
+            {
+                using var key = Registry.LocalMachine.OpenSubKey(Constants.DatadogAgentRegistryKey, writable: true);
+                key?.DeleteValue(Constants.PARProcmgrConfigWrittenThisInstallValue, throwOnMissingValue: false);
+            }
+            catch (Exception e)
+            {
+                session.Log($"Error clearing PAR procmgr install marker: {e}");
             }
         }
     }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
@@ -4,16 +4,11 @@ using WixToolset.Dtf.WindowsInstaller;
 using System;
 using System.IO;
 using System.Linq;
-using Microsoft.Win32;
 
 namespace Datadog.CustomActions
 {
     public class CleanUpFilesCustomAction
     {
-        private const string AdpProcmgrConfigFileName = "datadog-agent-data-plane.yaml";
-        private const string DdotProcmgrConfigFileName = "datadog-agent-ddot.yaml";
-        private const string ParProcmgrConfigFileName = "datadog-agent-action.yaml";
-
         /// <summary>
         /// Removes generated install artifacts (embedded2/embedded3, python-scripts, session-generated paths).
         /// Used before InstallFiles, during uninstall, and on rollback.
@@ -21,32 +16,6 @@ namespace Datadog.CustomActions
         public static ActionResult CleanupFiles(Session session)
         {
             return CleanupFiles(new SessionWrapper(session));
-        }
-
-        /// <summary>
-        /// Rollback-only: remove fleet-written processes.d YAML that MSI does not track.
-        /// Scheduled only on fresh install rollbacks (see Conditions.FirstInstall on the WiX action).
-        /// </summary>
-        public static ActionResult RemoveFleetProcmgrConfigOnRollback(Session session)
-        {
-            return RemoveFleetProcmgrConfigOnRollback(new SessionWrapper(session));
-        }
-
-        /// <summary>
-        /// Rollback-only: remove fleet-written PAR processes.d YAML after a failed upgrade.
-        /// Older agents start PAR via SCM and do not suppress it when this file is left behind.
-        /// </summary>
-        public static ActionResult RemoveParFleetProcmgrConfigOnUpgradeRollback(Session session)
-        {
-            return RemoveParFleetProcmgrConfigOnUpgradeRollback(new SessionWrapper(session));
-        }
-
-        /// <summary>
-        /// Clear the install-session marker after a successful MSI install/upgrade.
-        /// </summary>
-        public static ActionResult ClearPARProcmgrConfigWrittenThisInstallMarker(Session session)
-        {
-            return ClearPARProcmgrConfigWrittenThisInstallMarker(new SessionWrapper(session));
         }
 
         /// <summary>
@@ -59,7 +28,6 @@ namespace Datadog.CustomActions
 
         /// <summary>
         /// Uninstall tail: drop empty processes.d and empty install root after MSI components are removed.
-        /// Fleet prerm already removed processes.d YAML on full uninstall.
         /// </summary>
         public static ActionResult RemoveEmptyInstallDirAfterUninstall(Session session)
         {
@@ -69,31 +37,6 @@ namespace Datadog.CustomActions
         private static ActionResult CleanupFiles(ISession session)
         {
             RemoveGeneratedArtifactPaths(session, session.Property("PROJECTLOCATION"));
-            return ActionResult.Success;
-        }
-
-        private static ActionResult RemoveFleetProcmgrConfigOnRollback(ISession session)
-        {
-            TryRemoveFleetProcmgrConfigFiles(session, session.Property("PROJECTLOCATION"),
-                AdpProcmgrConfigFileName, DdotProcmgrConfigFileName, ParProcmgrConfigFileName);
-            return ActionResult.Success;
-        }
-
-        private static ActionResult RemoveParFleetProcmgrConfigOnUpgradeRollback(ISession session)
-        {
-            if (!PARProcmgrConfigMarkedWrittenThisInstall(session))
-            {
-                session.Log("PAR processes.d was not written this install; skip upgrade rollback cleanup.");
-                return ActionResult.Success;
-            }
-            TryRemoveFleetProcmgrConfigFiles(session, session.Property("PROJECTLOCATION"), ParProcmgrConfigFileName);
-            clearParProcmgrInstallMarkerRegistry(session);
-            return ActionResult.Success;
-        }
-
-        private static ActionResult ClearPARProcmgrConfigWrittenThisInstallMarker(ISession session)
-        {
-            clearParProcmgrInstallMarkerRegistry(session);
             return ActionResult.Success;
         }
 
@@ -117,6 +60,9 @@ namespace Datadog.CustomActions
                 Path.Combine(projectLocation, "embedded2"),
                 Path.Combine(projectLocation, "embedded3"),
                 Path.Combine(projectLocation, "python-scripts"),
+                // fleet postinst writes processes.d/*.yaml (untracked by MSI); RemoveFolderEx owns
+                // uninstall, this covers install/upgrade/repair rollback and the repair pre-clean.
+                Path.Combine(projectLocation, "processes.d"),
             }
             // installation specific files
             .Concat(session.GeneratedPaths());
@@ -145,35 +91,6 @@ namespace Datadog.CustomActions
                     session.Log($"Error while deleting file: {e}");
                     // Don't fail in cleanup/rollback actions otherwise
                     // we may brick the installation.
-                }
-            }
-        }
-
-        private static void TryRemoveFleetProcmgrConfigFiles(ISession session, string projectLocation, params string[] fileNames)
-        {
-            if (string.IsNullOrEmpty(projectLocation))
-            {
-                return;
-            }
-
-            var processesDir = Path.Combine(projectLocation, "processes.d");
-            foreach (var fileName in fileNames)
-            {
-                var path = Path.Combine(processesDir, fileName);
-                try
-                {
-                    if (!File.Exists(path))
-                    {
-                        session.Log($"{path} not found, skip deletion.");
-                        continue;
-                    }
-
-                    session.Log($"Deleting fleet process manager config \"{path}\"");
-                    File.Delete(path);
-                }
-                catch (Exception e)
-                {
-                    session.Log($"Error while deleting fleet process manager config {path}: {e}");
                 }
             }
         }
@@ -214,37 +131,5 @@ namespace Datadog.CustomActions
             }
         }
 
-        private static bool PARProcmgrConfigMarkedWrittenThisInstall(ISession session)
-        {
-            try
-            {
-                using var key = Registry.LocalMachine.OpenSubKey(Constants.DatadogAgentRegistryKey, writable: false);
-                if (key == null)
-                {
-                    return false;
-                }
-
-                var value = key.GetValue(Constants.PARProcmgrConfigWrittenThisInstallValue);
-                return value is int marker && marker != 0;
-            }
-            catch (Exception e)
-            {
-                session.Log($"Error reading PAR procmgr install marker: {e}");
-                return false;
-            }
-        }
-
-        private static void clearParProcmgrInstallMarkerRegistry(ISession session)
-        {
-            try
-            {
-                using var key = Registry.LocalMachine.OpenSubKey(Constants.DatadogAgentRegistryKey, writable: true);
-                key?.DeleteValue(Constants.PARProcmgrConfigWrittenThisInstallValue, throwOnMissingValue: false);
-            }
-            catch (Exception e)
-            {
-                session.Log($"Error clearing PAR procmgr install marker: {e}");
-            }
-        }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
@@ -11,6 +11,7 @@ namespace Datadog.CustomActions
     {
         private const string AdpProcmgrConfigFileName = "datadog-agent-data-plane.yaml";
         private const string DdotProcmgrConfigFileName = "datadog-agent-ddot.yaml";
+        private const string ParProcmgrConfigFileName = "datadog-agent-action.yaml";
 
         /// <summary>
         /// Removes generated install artifacts (embedded2/embedded3, python-scripts, session-generated paths).
@@ -119,7 +120,7 @@ namespace Datadog.CustomActions
             }
 
             var processesDir = Path.Combine(projectLocation, "processes.d");
-            foreach (var fileName in new[] { AdpProcmgrConfigFileName, DdotProcmgrConfigFileName })
+            foreach (var fileName in new[] { AdpProcmgrConfigFileName, DdotProcmgrConfigFileName, ParProcmgrConfigFileName })
             {
                 var path = Path.Combine(processesDir, fileName);
                 try

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Constants.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Constants.cs
@@ -14,10 +14,6 @@ namespace Datadog.CustomActions
         public const string ProcmonServiceName = "ddprocmon";
         public const string ProcmgrServiceName = "dd-procmgr-service";
 
-        // Set to 1 when postinst creates processes.d/datadog-agent-action.yaml for the first time
-        // during an MSI install/upgrade; used to scope upgrade rollback cleanup.
-        public const string PARProcmgrConfigWrittenThisInstallValue = "PARProcmgrConfigWrittenThisInstall";
-
         // Key under HKLM that contains our options
         public const string DatadogAgentRegistryKey = @"Software\Datadog\Datadog Agent";
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Constants.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Constants.cs
@@ -14,6 +14,10 @@ namespace Datadog.CustomActions
         public const string ProcmonServiceName = "ddprocmon";
         public const string ProcmgrServiceName = "dd-procmgr-service";
 
+        // Set to 1 when postinst creates processes.d/datadog-agent-action.yaml for the first time
+        // during an MSI install/upgrade; used to scope upgrade rollback cleanup.
+        public const string PARProcmgrConfigWrittenThisInstallValue = "PARProcmgrConfigWrittenThisInstall";
+
         // Key under HKLM that contains our options
         public const string DatadogAgentRegistryKey = @"Software\Datadog\Datadog Agent";
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Telemetry.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Telemetry.cs
@@ -88,7 +88,6 @@ namespace Datadog.CustomActions
 
         public static ActionResult ReportSuccess(Session session)
         {
-            CleanUpFilesCustomAction.ClearPARProcmgrConfigWrittenThisInstallMarker(session);
             return Report(new SessionWrapper(session), "agent.installation.success");
         }
     }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Telemetry.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Telemetry.cs
@@ -88,6 +88,7 @@ namespace Datadog.CustomActions
 
         public static ActionResult ReportSuccess(Session session)
         {
+            CleanUpFilesCustomAction.ClearPARProcmgrConfigWrittenThisInstallMarker(session);
             return Report(new SessionWrapper(session), "agent.installation.success");
         }
     }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -662,7 +662,7 @@ namespace WixSetup.Datadog_Agent
                     Return.ignore,
                     When.After,
                     Step.InstallFinalize,
-                    Conditions.FirstInstall | Conditions.Upgrading
+                    Conditions.FirstInstall | Conditions.Upgrading | Conditions.Maintenance
                 )
                 .SetProperties("APIKEY=[APIKEY], SITE=[SITE]")
                 .HideTarget(true);

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -48,10 +48,6 @@ namespace WixSetup.Datadog_Agent
 
         public ManagedAction DecompressPythonDistributions { get; }
 
-        public ManagedAction RemoveFleetProcmgrConfigOnRollback { get; }
-
-        public ManagedAction RemoveParFleetProcmgrConfigOnUpgradeRollback { get; }
-
         public ManagedAction CleanupOnRollback { get; }
 
         public ManagedAction RemoveEmptyInstallDirOnRollback { get; }
@@ -297,26 +293,12 @@ namespace WixSetup.Datadog_Agent
             }
                 .SetProperties("PROJECTLOCATION=[PROJECTLOCATION]");
 
-            RemoveFleetProcmgrConfigOnRollback = new CustomAction<CustomActions>(
-                    new Id(nameof(RemoveFleetProcmgrConfigOnRollback)),
-                    CustomActions.RemoveFleetProcmgrConfigOnRollback,
-                    Return.check,
-                    When.After,
-                    new Step(CleanupOnRollback.Id),
-                    Conditions.FirstInstall
-                )
-            {
-                Execute = Execute.rollback,
-                Impersonate = false
-            }
-                .SetProperties("PROJECTLOCATION=[PROJECTLOCATION]");
-
             DecompressPythonDistributions = new CustomAction<CustomActions>(
                     new Id(nameof(DecompressPythonDistributions)),
                     CustomActions.DecompressPythonDistributions,
                     Return.check,
                     When.After,
-                    new Step(RemoveFleetProcmgrConfigOnRollback.Id),
+                    new Step(CleanupOnRollback.Id),
                     Conditions.FirstInstall | Conditions.Upgrading | Conditions.Maintenance
                 )
             {
@@ -871,24 +853,6 @@ namespace WixSetup.Datadog_Agent
                                "DD_INSTALLER_REGISTRY_PASSWORD=[DD_INSTALLER_REGISTRY_PASSWORD], " +
                                "DD_OTELCOLLECTOR_ENABLED=[DD_OTELCOLLECTOR_ENABLED]")
                 .HideTarget(true);
-
-            // Upgrade rollback only: postinst may have written PAR processes.d YAML that older
-            // agents do not suppress via SCM. Only remove YAML created during this install session.
-            // Must be sequenced before RunPostInstallHook so the rollback script is registered
-            // before postinst can write the config (see StartDDServicesRollback).
-            RemoveParFleetProcmgrConfigOnUpgradeRollback = new CustomAction<CustomActions>(
-                    new Id(nameof(RemoveParFleetProcmgrConfigOnUpgradeRollback)),
-                    CustomActions.RemoveParFleetProcmgrConfigOnUpgradeRollback,
-                    Return.check,
-                    When.Before,
-                    new Step(RunPostInstallHook.Id),
-                    Conditions.Upgrading
-                )
-            {
-                Execute = Execute.rollback,
-                Impersonate = false
-            }
-                .SetProperties("PROJECTLOCATION=[PROJECTLOCATION]");
 
             ConfigureAutoLogger = new CustomAction<CustomActions>(
                     new Id(nameof(ConfigureAutoLogger)),

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -874,11 +874,13 @@ namespace WixSetup.Datadog_Agent
 
             // Upgrade rollback only: postinst may have written PAR processes.d YAML that older
             // agents do not suppress via SCM. Only remove YAML created during this install session.
+            // Must be sequenced before RunPostInstallHook so the rollback script is registered
+            // before postinst can write the config (see StartDDServicesRollback).
             RemoveParFleetProcmgrConfigOnUpgradeRollback = new CustomAction<CustomActions>(
                     new Id(nameof(RemoveParFleetProcmgrConfigOnUpgradeRollback)),
                     CustomActions.RemoveParFleetProcmgrConfigOnUpgradeRollback,
                     Return.check,
-                    When.After,
+                    When.Before,
                     new Step(RunPostInstallHook.Id),
                     Conditions.Upgrading
                 )

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -873,7 +873,7 @@ namespace WixSetup.Datadog_Agent
                 .HideTarget(true);
 
             // Upgrade rollback only: postinst may have written PAR processes.d YAML that older
-            // agents do not suppress via SCM, so remove it before restoring the previous install.
+            // agents do not suppress via SCM. Only remove YAML created during this install session.
             RemoveParFleetProcmgrConfigOnUpgradeRollback = new CustomAction<CustomActions>(
                     new Id(nameof(RemoveParFleetProcmgrConfigOnUpgradeRollback)),
                     CustomActions.RemoveParFleetProcmgrConfigOnUpgradeRollback,

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -50,6 +50,8 @@ namespace WixSetup.Datadog_Agent
 
         public ManagedAction RemoveFleetProcmgrConfigOnRollback { get; }
 
+        public ManagedAction RemoveParFleetProcmgrConfigOnUpgradeRollback { get; }
+
         public ManagedAction CleanupOnRollback { get; }
 
         public ManagedAction RemoveEmptyInstallDirOnRollback { get; }
@@ -869,6 +871,22 @@ namespace WixSetup.Datadog_Agent
                                "DD_INSTALLER_REGISTRY_PASSWORD=[DD_INSTALLER_REGISTRY_PASSWORD], " +
                                "DD_OTELCOLLECTOR_ENABLED=[DD_OTELCOLLECTOR_ENABLED]")
                 .HideTarget(true);
+
+            // Upgrade rollback only: postinst may have written PAR processes.d YAML that older
+            // agents do not suppress via SCM, so remove it before restoring the previous install.
+            RemoveParFleetProcmgrConfigOnUpgradeRollback = new CustomAction<CustomActions>(
+                    new Id(nameof(RemoveParFleetProcmgrConfigOnUpgradeRollback)),
+                    CustomActions.RemoveParFleetProcmgrConfigOnUpgradeRollback,
+                    Return.check,
+                    When.After,
+                    new Step(RunPostInstallHook.Id),
+                    Conditions.Upgrading
+                )
+            {
+                Execute = Execute.rollback,
+                Impersonate = false
+            }
+                .SetProperties("PROJECTLOCATION=[PROJECTLOCATION]");
 
             ConfigureAutoLogger = new CustomAction<CustomActions>(
                     new Id(nameof(ConfigureAutoLogger)),


### PR DESCRIPTION
### What does this PR do?

Adds Windows dual-mode supervision for Private Action Runner (PAR):

- Fleet installer writes `processes.d/datadog-agent-action.yaml` when process manager is enabled.
- If that file exists and `process_manager.enabled` is true, the Agent skips starting the legacy `datadog-agent-action` SCM service and dd-procmgr supervises PAR.
- Otherwise, PAR still starts via SCM when `private_action_runner.enabled` is true.
- MSI rollback cleanup removes the fleet-written PAR processes.d config.

PAR runs as `ddagentuser`, same as today so no new service account or privileges.

### Motivation

Fleet-managed Windows installs should supervise PAR through dd-procmgr, with SCM as fallback when the processes.d definition is not present.

### Describe how you validated your changes

- Regenerated `tmpl/gen/windows/datadog-agent-action.yaml`.
- Windows install e2e checks the PAR processes.d config is created (skipped when `privateactionrunner.exe` is absent, e.g. FIPS).
- New e2e `TestPARManagedByProcmgrWindows`: PAR is running under dd-procmgr and the legacy SCM service is not.

### Additional Notes
- PAR is not shipped on the FIPS MSI flavor.