### PR TITLE
docs(tasks): document dda inv sync race

### DIFF
--- a/tasks/AGENTS.md
+++ b/tasks/AGENTS.md
@@ -37,6 +37,9 @@ Key patterns:
   single source of truth. Do not hardcode tag lists in task code.
 - `libs/common/go.py` contains pure Go-related helpers (module downloading, etc.)
   that do not depend on `@task`.
+- Do not run multiple `dda inv` commands in parallel from the same checkout.
+  The legacy-task virtualenv dependency sync can race on its temporary `uv`
+  wrapper; run `dda inv` validations serially.
 
 ### CI / Pipeline
 


### PR DESCRIPTION
### What does this PR do?

Documents that `dda inv` validations should run serially from the same checkout because the legacy-task virtualenv dependency sync can race on its temporary `uv` wrapper.

### Motivation

This came up while validating local task changes: parallel `dda inv` invocations from the same checkout can fail intermittently during dependency sync. Keeping the note in `tasks/AGENTS.md` avoids future agent sessions reproducing the same failure mode.

### Describe how you validated your changes

Documentation-only change. Verified the diff only touches `tasks/AGENTS.md`.