### PR TITLE
[WP] Fix mkdir events on Linux >= 7.0

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/mkdir.h
+++ b/pkg/security/ebpf/c/include/hooks/mkdir.h
@@ -130,8 +130,24 @@ int hook_do_mkdirat(ctx_t *ctx) {
     return 0;
 }
 
+HOOK_ENTRY("filename_mkdirat")
+int hook_filename_mkdirat(ctx_t *ctx) {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_MKDIR);
+    if (!syscall) {
+        umode_t mode = (umode_t)CTX_PARM3(ctx);
+        return trace__sys_mkdir(ctx, ASYNC_SYSCALL, NULL, mode);
+    }
+    return 0;
+}
+
 HOOK_EXIT("do_mkdirat")
 int rethook_do_mkdirat(ctx_t *ctx) {
+    int retval = CTX_PARMRET(ctx);
+    return sys_mkdir_ret(ctx, retval, KPROBE_OR_FENTRY_TYPE);
+}
+
+HOOK_EXIT("filename_mkdirat")
+int rethook_filename_mkdirat(ctx_t *ctx) {
     int retval = CTX_PARMRET(ctx);
     return sys_mkdir_ret(ctx, retval, KPROBE_OR_FENTRY_TYPE);
 }

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -214,6 +214,22 @@ func GetSelectorsPerEventType(hasFentry, haveIOURing bool) map[eval.EventType][]
 		}
 	}
 
+	mkdirIOUringProbes := []manager.ProbesSelector{}
+	if haveIOURing {
+		mkdirIOUringProbes = []manager.ProbesSelector{
+			&manager.AllOf{Selectors: []manager.ProbesSelector{
+				hookFunc("hook_do_mkdirat"),
+				hookFunc("rethook_do_mkdirat"),
+			}},
+			// Since 7.0, do_mkdirat was removed from the kernel so we need to hook the filename_mkdirat function instead
+			// It is also used by the io_uring code path
+			&manager.AllOf{Selectors: []manager.ProbesSelector{
+				hookFunc("hook_filename_mkdirat"),
+				hookFunc("rethook_filename_mkdirat"),
+			}},
+		}
+	}
+
 	selectorsPerEventTypeStore := map[eval.EventType][]manager.ProbesSelector{
 		// The following probes will always be activated, regardless of the loaded rules
 		"*": {
@@ -478,10 +494,7 @@ func GetSelectorsPerEventType(hasFentry, haveIOURing bool) map[eval.EventType][]
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mkdir", hasFentry, EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mkdirat", hasFentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				hookFunc("hook_do_mkdirat"),
-				hookFunc("rethook_do_mkdirat"),
-			}}},
+			&manager.BestEffort{Selectors: mkdirIOUringProbes}},
 
 		// List of probes required to capture removexattr events
 		"removexattr": {

--- a/pkg/security/ebpf/probes/mkdir.go
+++ b/pkg/security/ebpf/probes/mkdir.go
@@ -42,6 +42,18 @@ func getMkdirProbes(fentry bool) []*manager.Probe {
 				EBPFFuncName: "rethook_do_mkdirat",
 			},
 		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_filename_mkdirat",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_filename_mkdirat",
+			},
+		},
 	}
 
 	mkdirProbes = append(mkdirProbes, ExpandSyscallProbes(&manager.Probe{


### PR DESCRIPTION
### What does this PR do?

Hook into filename_mkdirat on newer Kernel

### Motivation

`mkdir` event was broken on Linux 7

### Describe how you validated your changes

### Additional Notes
