### PR TITLE
[workloadmeta] Fix context leak in remote collector on stream reconnect

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/generic.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/generic.go
@@ -180,6 +180,9 @@ func (c *GenericCollector) startWorkloadmetaStream(maxElapsed time.Duration) err
 
 		c.stream, err = c.client.StreamEntities(c.streamCtx)
 		if err != nil {
+			// Cancel the context created for this failed attempt so it is not
+			// leaked when the next retry overwrites c.streamCancel.
+			c.streamCancel()
 			log.Infof("unable to establish stream, will possibly retry: %s", err)
 			return nil, err
 		}

--- a/releasenotes/notes/fix-remote-workloadmeta-context-leak-7f887eda9d9dc2c4.yaml
+++ b/releasenotes/notes/fix-remote-workloadmeta-context-leak-7f887eda9d9dc2c4.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a slow memory leak in the remote workloadmeta collector where a new
+    context was created on every stream reconnection attempt without cancelling
+    the previous one. This could cause unbounded growth in the number of
+    orphaned contexts when the remote workloadmeta endpoint was repeatedly
+    unreachable.


### PR DESCRIPTION
### What does this PR do?

Fixes a slow context (memory) leak in the remote workloadmeta collector
(`comp/core/workloadmeta/collectors/internal/remote/generic.go`).

In `startWorkloadmetaStream`, the `backoff.Retry` closure reassigns
`c.streamCtx` / `c.streamCancel` via `context.WithCancel` on every attempt.
When `StreamEntities` fails, the closure returned the error without calling
the just-created `c.streamCancel()`. On the next retry the field was
overwritten, orphaning the previous cancel func. Because the parent chain
resolves up to the long-lived collector context `c.ctx`, each orphaned child
stayed registered in `c.ctx`'s children map and was never released, growing
unbounded whenever the remote endpoint was repeatedly unreachable.

The fix cancels the failed attempt's context on the error branch, mirroring
the existing handling on the `Recv()` error path.

### Motivation

This was caught while searching through the agent for patterns that match this upstream kubelet fix
[kubernetes/kubernetes#139850](https://github.com/kubernetes/kubernetes/pull/139850)
(a stored `CancelFunc` overwritten without cancelling the previous context).

### Describe how you validated your changes

- `go build ./comp/core/workloadmeta/collectors/internal/remote/` passes.
- The change is minimal and mirrors the already-correct cancel handling on the
  `Recv()` error path.

### Additional Notes