### PR TITLE
[WP] Fix unlink events when using io-uring

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -35,6 +35,15 @@ int hook_do_rmdir(ctx_t *ctx) {
     return 0;
 }
 
+HOOK_ENTRY("filename_rmdir")
+int hook_filename_rmdir(ctx_t *ctx) {
+    struct syscall_cache_t *syscall = peek_syscall_with(rmdir_predicate);
+    if (!syscall) {
+        return trace__sys_rmdir(ctx, ASYNC_SYSCALL, NULL);
+    }
+    return 0;
+}
+
 // security_inode_rmdir is shared between rmdir and unlink syscalls
 HOOK_ENTRY("security_inode_rmdir")
 int hook_security_inode_rmdir(ctx_t *ctx) {
@@ -171,6 +180,12 @@ int __attribute__((always_inline)) sys_rmdir_ret(void *ctx, int retval) {
 
 HOOK_EXIT("do_rmdir")
 int rethook_do_rmdir(ctx_t *ctx) {
+    int retval = CTX_PARMRET(ctx);
+    return sys_rmdir_ret(ctx, retval);
+}
+
+HOOK_EXIT("filename_rmdir")
+int rethook_filename_rmdir(ctx_t *ctx) {
     int retval = CTX_PARMRET(ctx);
     return sys_rmdir_ret(ctx, retval);
 }

--- a/pkg/security/ebpf/c/include/hooks/unlink.h
+++ b/pkg/security/ebpf/c/include/hooks/unlink.h
@@ -44,6 +44,15 @@ int hook_do_unlinkat(ctx_t *ctx) {
     return 0;
 }
 
+HOOK_ENTRY("filename_unlinkat")
+int hook_filename_unlinkat(ctx_t *ctx) {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
+    if (!syscall) {
+        return trace__sys_unlink(ctx, ASYNC_SYSCALL, 0, NULL, 0);
+    }
+    return 0;
+}
+
 HOOK_ENTRY("vfs_unlink")
 int hook_vfs_unlink(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
@@ -181,6 +190,12 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
 
 HOOK_EXIT("do_unlinkat")
 int rethook_do_unlinkat(ctx_t *ctx) {
+    int retval = CTX_PARMRET(ctx);
+    return sys_unlink_ret(ctx, retval);
+}
+
+HOOK_EXIT("filename_unlinkat")
+int rethook_filename_unlinkat(ctx_t *ctx) {
     int retval = CTX_PARMRET(ctx);
     return sys_unlink_ret(ctx, retval);
 }

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -193,6 +193,22 @@ func GetSelectorsPerEventType(hasFentry, haveIOURing bool) map[eval.EventType][]
 		}
 	}
 
+	rmdirIOUringProbes := []manager.ProbesSelector{}
+	if haveIOURing {
+		rmdirIOUringProbes = []manager.ProbesSelector{
+			&manager.AllOf{Selectors: []manager.ProbesSelector{
+				hookFunc("hook_do_rmdir"),
+				hookFunc("rethook_do_rmdir"),
+			}},
+			// Since 7.0, do_rmdir was removed from the kernel so we need to hook the filename_rmdir function instead
+			// It is also used by the io_uring code path
+			&manager.AllOf{Selectors: []manager.ProbesSelector{
+				hookFunc("hook_filename_rmdir"),
+				hookFunc("rethook_filename_rmdir"),
+			}},
+		}
+	}
+
 	selectorsPerEventTypeStore := map[eval.EventType][]manager.ProbesSelector{
 		// The following probes will always be activated, regardless of the loaded rules
 		"*": {
@@ -380,10 +396,7 @@ func GetSelectorsPerEventType(hasFentry, haveIOURing bool) map[eval.EventType][]
 				hookFunc("hook_security_inode_rmdir"),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "rmdir", hasFentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				hookFunc("hook_do_rmdir"),
-				hookFunc("rethook_do_rmdir"),
-			}},
+			&manager.BestEffort{Selectors: rmdirIOUringProbes},
 
 			// Unlink probes
 			&manager.AllOf{Selectors: []manager.ProbesSelector{

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -177,6 +177,22 @@ func GetSelectorsPerEventType(hasFentry, haveIOURing bool) map[eval.EventType][]
 		}
 	}
 
+	unlinkIOUringProbes := []manager.ProbesSelector{}
+	if haveIOURing {
+		unlinkIOUringProbes = []manager.ProbesSelector{
+			&manager.AllOf{Selectors: []manager.ProbesSelector{
+				hookFunc("hook_do_unlinkat"),
+				hookFunc("rethook_do_unlinkat"),
+			}},
+			// Since 7.0, do_unlinkat was removed from the kernel so we need to hook the filename_unlinkat function instead
+			// It is also used by the io_uring code path
+			&manager.AllOf{Selectors: []manager.ProbesSelector{
+				hookFunc("hook_filename_unlinkat"),
+				hookFunc("rethook_filename_unlinkat"),
+			}},
+		}
+	}
+
 	selectorsPerEventTypeStore := map[eval.EventType][]manager.ProbesSelector{
 		// The following probes will always be activated, regardless of the loaded rules
 		"*": {
@@ -344,10 +360,20 @@ func GetSelectorsPerEventType(hasFentry, haveIOURing bool) map[eval.EventType][]
 				hookFunc("hook_mnt_want_write"),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unlinkat", hasFentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				hookFunc("hook_do_unlinkat"),
-				hookFunc("rethook_do_unlinkat"),
-			}},
+			&manager.OneOf{
+				Selectors: []manager.ProbesSelector{
+					&manager.AllOf{Selectors: []manager.ProbesSelector{
+						hookFunc("hook_do_unlinkat"),
+						hookFunc("rethook_do_unlinkat"),
+					}},
+					// Since 7.0, do_unlinkat was removed from the kernel so we need to hook the filename_unlinkat function instead
+					// It is also used by the io_uring code path
+					&manager.AllOf{Selectors: []manager.ProbesSelector{
+						hookFunc("hook_filename_unlinkat"),
+						hookFunc("rethook_filename_unlinkat"),
+					}},
+				},
+			},
 
 			// Rmdir probes
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
@@ -364,10 +390,7 @@ func GetSelectorsPerEventType(hasFentry, haveIOURing bool) map[eval.EventType][]
 				hookFunc("hook_vfs_unlink"),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unlink", hasFentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				hookFunc("hook_do_linkat"),
-				hookFunc("rethook_do_linkat"),
-			}},
+			&manager.BestEffort{Selectors: unlinkIOUringProbes},
 
 			// ioctl probes
 			&manager.AllOf{Selectors: []manager.ProbesSelector{

--- a/pkg/security/ebpf/probes/rmdir.go
+++ b/pkg/security/ebpf/probes/rmdir.go
@@ -30,6 +30,18 @@ func getRmdirProbe(fentry bool) []*manager.Probe {
 				EBPFFuncName: "rethook_do_rmdir",
 			},
 		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_filename_rmdir",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_filename_rmdir",
+			},
+		},
 	}
 
 	rmdirProbes = append(rmdirProbes, ExpandSyscallProbes(&manager.Probe{

--- a/pkg/security/ebpf/probes/unlink.go
+++ b/pkg/security/ebpf/probes/unlink.go
@@ -30,6 +30,18 @@ func getUnlinkProbes(fentry bool) []*manager.Probe {
 				EBPFFuncName: "rethook_do_unlinkat",
 			},
 		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_filename_unlinkat",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_filename_unlinkat",
+			},
+		},
 	}
 
 	unlinkProbes = append(unlinkProbes, ExpandSyscallProbes(&manager.Probe{


### PR DESCRIPTION
### What does this PR do?

Fix unlink events when using io-uring

### Motivation

do_unlinkat was removed since Linux 7.0 so we hook on filename_unlinkat instead.

### Describe how you validated your changes

### Additional Notes
