### PR TITLE
feat(otel-metrics): guard traces.span.sdk.metrics.duration from remapping

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_remapping.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_remapping.go
@@ -25,12 +25,23 @@ const (
 	divMebibytes = 1024 * 1024
 	// divPercentage specifies the division necessary for converting fractions to percentages.
 	divPercentage = 0.01
+
+	// sdkTraceMetricName is the histogram emitted by Datadog SDKs that ship
+	// trace metrics via OTLP (see the OTLP Trace Metrics Export RFC). The
+	// otlp-intake-metrics backend routes this exact name to trace metrics and
+	// remaps it to the trace.* namespace, so the Agent/DDOT OTLP pipeline must
+	// forward it unchanged: it must never be prefixed or renamed here.
+	sdkTraceMetricName = "traces.span.sdk.metrics.duration"
 )
 
 var emptyAttributesMapping = attributesMapping{}
 
 // remapMetrics extracts any Datadog specific metrics from m and appends them to all.
 func remapMetrics(all pmetric.MetricSlice, m pmetric.Metric) {
+	if m.Name() == sdkTraceMetricName {
+		// The backend routes this metric by its exact name; forward it as-is.
+		return
+	}
 	remapSystemMetrics(all, m)
 	remapContainerMetrics(all, m)
 	remapKafkaMetrics(all, m)
@@ -39,6 +50,10 @@ func remapMetrics(all pmetric.MetricSlice, m pmetric.Metric) {
 
 // renameMetrics adds the `otel.` or `otelcol_` prefix to metrics.
 func renameMetrics(m pmetric.Metric) {
+	if m.Name() == sdkTraceMetricName {
+		// The backend routes this metric by its exact name; never rename it.
+		return
+	}
 	renameHostMetrics(m)
 	renameKafkaMetrics(m)
 	renameAgentInternalOTelMetric(m)

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_remapping_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_remapping_test.go
@@ -843,6 +843,20 @@ func TestRenameAgentMetrics(t *testing.T) {
 	}
 }
 
+func TestSDKTraceMetricPassthrough(t *testing.T) {
+	// The otlp-intake-metrics backend routes this metric by its exact name, so
+	// neither remapMetrics nor renameMetrics may rename or duplicate it.
+	dest := pmetric.NewMetricSlice()
+	m := testMetric(sdkTraceMetricName, testPoint{f: 1})
+
+	remapMetrics(dest, m)
+	require.Equal(t, 0, dest.Len(), "remapMetrics must not derive new metrics from the SDK trace metric")
+	require.Equal(t, sdkTraceMetricName, m.Name())
+
+	renameMetrics(m)
+	require.Equal(t, sdkTraceMetricName, m.Name(), "renameMetrics must not rename the SDK trace metric")
+}
+
 func TestCopyMetricWithAttr(t *testing.T) {
 	m := pmetric.NewMetric()
 	m.SetName("test.metric")

--- a/releasenotes/notes/otel-guard-sdk-trace-metric-remap-4d9f1a2c7b3e5a08.yaml
+++ b/releasenotes/notes/otel-guard-sdk-trace-metric-remap-4d9f1a2c7b3e5a08.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The OTLP metrics pipeline no longer renames or remaps the SDK trace metric
+    ``traces.span.sdk.metrics.duration``. The metric is now forwarded to the
+    intake with its literal name so backend routing to trace metrics works
+    correctly.


### PR DESCRIPTION
### What does this PR do?

Guards the SDK trace metric \`traces.span.sdk.metrics.duration\` from being renamed or remapped in the Agent/DDOT OTLP metrics pipeline.

In both \`remapMetrics\` and \`renameMetrics\` (pkg/opentelemetry-mapping-go/otlp/metrics/metrics_remapping.go), we now short-circuit when the metric name matches this literal name and forward it unchanged.

### Motivation

The \`otlp-intake-metrics\` backend routes this metric to the TraceMetrics destination by its exact name and remaps it into the \`trace.*\` namespace. If the OTLP pipeline prefixes it (e.g. \`otel.\`) or derives new metrics from it, backend routing breaks. This guard ensures the metric reaches the intake with its literal name.

### Describe how you validated your changes

Added \`TestSDKTraceMetricPassthrough\` verifying that neither \`remapMetrics\` nor \`renameMetrics\` renames or duplicates the metric. Ran the metrics package tests locally:

\`\`\`
go test ./otlp/metrics/ -run TestSDKTraceMetricPassthrough -v
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)