### PR TITLE
Correct nil-panic for distributions with non-finite sample rates

### DIFF
--- a/pkg/util/quantile/agent.go
+++ b/pkg/util/quantile/agent.go
@@ -65,7 +65,10 @@ func (a *Agent) Reset() {
 func (a *Agent) Insert(v float64, sampleRate float64) {
 	k := agentConfig.key(v)
 	// bounds enforcement
-	if sampleRate <= 0 || sampleRate > 1 {
+	//
+	// A rate outside (0, 1] is invalid and falls back to unsampled. This
+	// inequality must handle non-finite values, hence the negation.
+	if !(sampleRate > 0 && sampleRate <= 1) {
 		sampleRate = 1
 	}
 

--- a/pkg/util/quantile/agent_test.go
+++ b/pkg/util/quantile/agent_test.go
@@ -121,6 +121,18 @@ func TestAgentFinish(t *testing.T) {
 	})
 }
 
+// TestAgentNaNSampleRate guards against a NaN sample rate corrupting the sketch
+// count. See SMPTNG-761.
+func TestAgentNaNSampleRate(t *testing.T) {
+	a := &Agent{}
+	a.Insert(1, math.NaN())
+	a.Insert(1, math.NaN())
+
+	s := a.Finish()
+	require.NotNil(t, s, "an even count of NaN-sample-rate inserts must not yield a nil sketch")
+	require.EqualValues(t, 2, s.Basic.Cnt, "two samples must count as two observations")
+}
+
 func TestAgentInterpolation(t *testing.T) {
 	a := &Agent{}
 

--- a/releasenotes/notes/fix-dogstatsd-nan-sample-rate-sketch-panic-032970ed700d612b.yaml
+++ b/releasenotes/notes/fix-dogstatsd-nan-sample-rate-sketch-panic-032970ed700d612b.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix ``panic: runtime error: invalid memory address or nil pointer dereference`` when a
+    DogStatsD distribution metric is submitted with a non-finite sample rate such as ``NaN``
+    (for example ``s.dist:1|d|@nan``). The invalid sample rate is now treated as unsampled
+    instead of corrupting the sketch's sample count.


### PR DESCRIPTION
### What does this PR do?

This commit fixes a rate bound bug where Agent did not correctly
compute sample rate bounds for non-finite values. These resulted
in sketches incorrectly being marked as "empty" by way of wrapping
arithmetic on non-finite values causing `Finish()` to return a typed 
nil which we immediately assign to a  non-nil interface. This causes 
`(*Sketch).Cols` to be called on a nil `*Sketch`, crashing the program.

### Motivation

Avoid nil-panic of the Agent. 

### Describe how you validated your changes

Confirmed after rebuild sending nan samples does not panic Agent.

### Additional Notes

REF SMPTNG-761
REF https://github.com/DataDog/saluki/pull/1891
