### PR TITLE
usm: http2: add use_direct_consumer to http2 protocol

### DIFF
--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -880,6 +880,10 @@ properties:
             node_type: setting
             type: boolean
             default: false
+          use_direct_consumer:
+            node_type: setting
+            type: boolean
+            default: false
       http2_dynamic_table_map_cleaner_interval_seconds:
         node_type: setting
         type: integer

--- a/pkg/config/setup/system_probe_usm.go
+++ b/pkg/config/setup/system_probe_usm.go
@@ -96,6 +96,7 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// Tree structure
 	cfg.BindEnvAndSetDefault("service_monitoring_config.http2.enabled", false)
 	cfg.BindEnvAndSetDefault("service_monitoring_config.http2.dynamic_table_map_cleaner_interval_seconds", 30)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http2.use_direct_consumer", false)
 
 	// Legacy bindings for backward compatibility (deprecated)
 	cfg.BindEnvAndSetDefault("service_monitoring_config.enable_http2_monitoring", false)

--- a/pkg/network/config/usm_config.go
+++ b/pkg/network/config/usm_config.go
@@ -95,6 +95,11 @@ type USMConfig struct {
 	// When false (default), batch consumer is always used regardless of kernel version
 	HTTPUseDirectConsumer bool
 
+	// HTTP2UseDirectConsumer forces the use of direct consumer for HTTP/2 monitoring instead of batch consumer
+	// When true, direct consumer is used if kernel supports it (>=5.8.0), otherwise falls back to batch consumer
+	// When false (default), batch consumer is always used regardless of kernel version
+	HTTP2UseDirectConsumer bool
+
 	// HTTP Windows-specific Configuration
 	// MaxTrackedHTTPConnections max number of http(s) flows that will be concurrently tracked (Windows only)
 	MaxTrackedHTTPConnections int64
@@ -218,6 +223,7 @@ func NewUSMConfig(cfg model.Config) *USMConfig {
 		// HTTP2 Protocol Configuration
 		EnableHTTP2Monitoring:               cfg.GetBool(sysconfig.FullKeyPath(smNS, "http2", "enabled")),
 		HTTP2DynamicTableMapCleanerInterval: time.Duration(cfg.GetInt(sysconfig.FullKeyPath(smNS, "http2", "dynamic_table_map_cleaner_interval_seconds"))) * time.Second,
+		HTTP2UseDirectConsumer:              cfg.GetBool(sysconfig.FullKeyPath(smNS, "http2", "use_direct_consumer")),
 
 		// Kafka Protocol Configuration
 		EnableKafkaMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "kafka", "enabled")),

--- a/pkg/network/config/usm_config_test.go
+++ b/pkg/network/config/usm_config_test.go
@@ -1782,3 +1782,28 @@ func TestHTTPUseDirectConsumer(t *testing.T) {
 		assert.True(t, cfg.HTTPUseDirectConsumer)
 	})
 }
+
+func TestHTTP2UseDirectConsumer(t *testing.T) {
+	t.Run("default value", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		cfg := New()
+
+		assert.False(t, cfg.HTTP2UseDirectConsumer)
+	})
+
+	t.Run("via YAML", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetInTest("service_monitoring_config.http2.use_direct_consumer", true)
+		cfg := New()
+
+		assert.True(t, cfg.HTTP2UseDirectConsumer)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP2_USE_DIRECT_CONSUMER", "true")
+		cfg := New()
+
+		assert.True(t, cfg.HTTP2UseDirectConsumer)
+	})
+}

--- a/pkg/network/ebpf/c/protocols/helpers/pktbuf.h
+++ b/pkg/network/ebpf/c/protocols/helpers/pktbuf.h
@@ -82,6 +82,23 @@ static __always_inline __maybe_unused u32 pktbuf_data_end(pktbuf_t pkt)
     return 0;
 }
 
+// pktbuf_get_ctx returns the raw eBPF program context backing the packet
+// buffer: the __sk_buff for socket-filter (SKB) programs, or the pt_regs for
+// TLS uprobe programs. This is the context expected by bpf_perf_event_output,
+// used by the direct-consumer output path.
+static __always_inline __maybe_unused void *pktbuf_get_ctx(pktbuf_t pkt)
+{
+    switch (pkt.type) {
+    case PKTBUF_SKB:
+        return pkt.skb;
+    case PKTBUF_TLS:
+        return pkt.ctx;
+    }
+
+    pktbuf_invalid_operation();
+    return NULL;
+}
+
 static __always_inline long pktbuf_load_bytes_with_telemetry(pktbuf_t pkt, u32 offset, void *to, u32 len)
 {
     switch (pkt.type) {

--- a/pkg/network/ebpf/c/protocols/http2/decoding-common.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-common.h
@@ -10,6 +10,7 @@
 #include "protocols/http2/decoding-defs.h"
 #include "protocols/http2/helpers.h"
 #include "protocols/http2/maps-defs.h"
+#include "protocols/http2/usm-events.h"
 #include "protocols/classification/defs.h"
 
 // Returns true if the given index represents a path index.
@@ -124,7 +125,50 @@ static __always_inline void update_path_size_telemetry(http2_telemetry_t *http2_
 // stream, before it actually enqueues the stream's stats.
 //
 // See RFC 7540 section 5.1: https://datatracker.ietf.org/doc/html/rfc7540#section-5.1
-static __always_inline void handle_end_of_stream(http2_stream_t *current_stream, http2_stream_key_t *http2_stream_key_template, http2_telemetry_t *http2_tel) {
+
+static __always_inline void http2_batch_enqueue_wrapper(void *ctx, conn_tuple_t *tuple, http2_stream_t *http) {
+    u32 zero = 0;
+    http2_event_t *event = bpf_map_lookup_elem(&http2_scratch_buffer, &zero);
+    if (!event) {
+        return;
+    }
+
+    bpf_memcpy(&event->tuple, tuple, sizeof(conn_tuple_t));
+    bpf_memcpy(&event->stream, http, sizeof(http2_stream_t));
+
+    // Check which consumer type to use based on kernel version capability
+    __u64 http2_use_direct_consumer = 0;
+    LOAD_CONSTANT("http2_use_direct_consumer", http2_use_direct_consumer);
+
+    if (http2_use_direct_consumer) {
+        // Direct consumer path - use perf/ring buffer output (kernel >= 5.8)
+        http2_output_event(ctx, event);
+    } else {
+        // Batch consumer path - use map-based batching (kernel < 5.8)
+        http2_batch_enqueue(event);
+    }
+}
+
+// terminated_http2_batch_enqueue_wrapper emits a terminated-connection event via
+// the direct or batch consumer, matching the consumer selected for the main
+// http2 stream (same http2_use_direct_consumer constant). Unlike the main
+// stream, the event payload is just the connection tuple, so no scratch buffer
+// staging is needed.
+static __always_inline void terminated_http2_batch_enqueue_wrapper(void *ctx, conn_tuple_t *tuple) {
+    // Check which consumer type to use based on kernel version capability
+    __u64 http2_use_direct_consumer = 0;
+    LOAD_CONSTANT("http2_use_direct_consumer", http2_use_direct_consumer);
+
+    if (http2_use_direct_consumer) {
+        // Direct consumer path - use perf/ring buffer output (kernel >= 5.8)
+        terminated_http2_output_event(ctx, tuple);
+    } else {
+        // Batch consumer path - use map-based batching (kernel < 5.8)
+        terminated_http2_batch_enqueue(tuple);
+    }
+}
+
+static __always_inline void handle_end_of_stream(void *ctx, http2_stream_t *current_stream, http2_stream_key_t *http2_stream_key_template, http2_telemetry_t *http2_tel) {
     // We want to see the EOS twice for a given stream: one for the client, one for the server.
     if (!current_stream->end_of_stream_seen) {
         current_stream->end_of_stream_seen = true;
@@ -134,14 +178,9 @@ static __always_inline void handle_end_of_stream(http2_stream_t *current_stream,
     // response end of stream;
     current_stream->response_last_seen = bpf_ktime_get_ns();
 
-    const __u32 zero = 0;
-    http2_event_t *event = bpf_map_lookup_elem(&http2_scratch_buffer, &zero);
-    if (event) {
-        event->tuple = http2_stream_key_template->tup;
-        event->stream = *current_stream;
-        // enqueue
-        http2_batch_enqueue(event);
-    }
+    // Emit the completed stream via the batch/direct consumer wrapper, which
+    // handles staging into the scratch buffer and selecting the output path.
+    http2_batch_enqueue_wrapper(ctx, &http2_stream_key_template->tup, current_stream);
 
     bpf_map_delete_elem(&http2_in_flight, http2_stream_key_template);
 }

--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -149,7 +149,7 @@ int uprobe__http2_tls_termination(struct pt_regs *ctx) {
 
     bpf_map_delete_elem(&tls_http2_iterations, &args->tup);
 
-    terminated_http2_batch_enqueue(&args->tup);
+    terminated_http2_batch_enqueue_wrapper(ctx, &args->tup);
     // Deleting the entry for the original tuple.
     bpf_map_delete_elem(&http2_incomplete_frames, &args->tup);
     bpf_map_delete_elem(&http2_dynamic_counter_table, &args->tup);

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -757,7 +757,7 @@ int socket__http2_handle_first_frame(struct __sk_buff *skb) {
         // Deleting the entry for the original tuple.
         bpf_map_delete_elem(&http2_incomplete_frames, &dispatcher_args_copy.tup);
         bpf_map_delete_elem(&http2_dynamic_counter_table, &dispatcher_args_copy.tup);
-        terminated_http2_batch_enqueue(&dispatcher_args_copy.tup);
+        terminated_http2_batch_enqueue_wrapper(skb, &dispatcher_args_copy.tup);
         // In case of local host, the protocol will be deleted for both (client->server) and (server->client),
         // so we won't reach for that path again in the code, so we're deleting the opposite side as well.
         flip_tuple(&dispatcher_args_copy.tup);
@@ -1190,7 +1190,7 @@ static __always_inline void eos_parser(pktbuf_t pkt, void *map_key, conn_tuple_t
         } else if ((current_frame.frame.flags & HTTP2_END_OF_STREAM) == HTTP2_END_OF_STREAM) {
             __sync_fetch_and_add(&http2_tel->end_of_stream, 1);
         }
-        handle_end_of_stream(current_stream, &http2_ctx->http2_stream_key, http2_tel);
+        handle_end_of_stream(pktbuf_get_ctx(pkt), current_stream, &http2_ctx->http2_stream_key, http2_tel);
 
         // If we reached here, it means that we saw End Of Stream. If the End of Stream came from a request,
         // thus we except it to have a valid path and method. If the End of Stream came from a response, we except it to

--- a/pkg/network/ebpf/c/protocols/http2/usm-events.h
+++ b/pkg/network/ebpf/c/protocols/http2/usm-events.h
@@ -2,10 +2,16 @@
 #define __HTTP2_USM_EVENTS_H
 
 #include "protocols/http2/decoding-defs.h"
+#include "protocols/direct_consumer.h"
 #include "protocols/events.h"
 
 USM_EVENTS_INIT(http2, http2_event_t, HTTP2_BATCH_SIZE);
 
 USM_EVENTS_INIT(terminated_http2, conn_tuple_t, HTTP2_TERMINATED_BATCH_SIZE);
+
+// Initialize DirectConsumer utilities for HTTP2 protocol
+USM_DIRECT_CONSUMER_INIT(http2, http2_event_t, http2_batch_events);
+
+USM_DIRECT_CONSUMER_INIT(terminated_http2, conn_tuple_t, terminated_http2_batch_events);
 
 #endif

--- a/pkg/network/protocols/http2/dynamic_table.go
+++ b/pkg/network/protocols/http2/dynamic_table.go
@@ -29,7 +29,10 @@ type DynamicTable struct {
 	cfg *config.Config
 
 	// terminatedConnectionsEventsConsumer is the consumer used to receive terminated connections events from the kernel.
-	terminatedConnectionsEventsConsumer *events.BatchConsumer[netebpf.ConnTuple]
+	// It wraps either a batch or a direct consumer, matching the mode selected for the main http2 stream.
+	terminatedConnectionsEventsConsumer *events.KernelAdaptiveConsumer[netebpf.ConnTuple]
+	// useDirectConsumer indicates whether the terminated connections stream uses the direct consumer.
+	useDirectConsumer bool
 	// terminatedConnections is the list of terminated connections received from the kernel.
 	terminatedConnections []netebpf.ConnTuple
 	// terminatedConnectionMux is used to protect the terminated connections list from concurrent access.
@@ -45,6 +48,44 @@ func NewDynamicTable(cfg *config.Config) *DynamicTable {
 	}
 }
 
+// createDirectConsumer sets up the terminated connections stream to use the
+// direct consumer. It MUST be called with the same decision as the main http2
+// stream (Protocol.useDirectConsumer): both streams share the single
+// http2_use_direct_consumer eBPF constant, so the kernel output path and the
+// userspace consumer type must agree, otherwise terminated events would be
+// emitted on the direct path while a batch consumer reads them (or vice versa).
+//
+// When direct mode is not selected, this is a no-op: the batch consumer is
+// created later in preStart (after manager init), since it needs no modifier.
+// When it is selected, the direct consumer must be created here so its
+// EventHandler modifier is exposed via modifiers() before the manager is
+// initialized (right after protocol construction).
+func (dt *DynamicTable) createDirectConsumer(useDirectConsumer bool) error {
+	if !useDirectConsumer {
+		return nil
+	}
+
+	directConsumer, err := events.NewDirectConsumer(terminatedConnectionsEventStream, dt.processTerminatedConnectionDirect, dt.cfg)
+	if err != nil {
+		return err
+	}
+	dt.terminatedConnectionsEventsConsumer = events.NewKernelAdaptiveConsumer[netebpf.ConnTuple](
+		directConsumer,
+		[]ddebpf.Modifier{&directConsumer.EventHandler},
+	)
+	dt.useDirectConsumer = true
+	return nil
+}
+
+// modifiers returns the eBPF manager modifiers contributed by the terminated
+// connections consumer (the direct consumer's EventHandler, if any).
+func (dt *DynamicTable) modifiers() []ddebpf.Modifier {
+	if dt.terminatedConnectionsEventsConsumer == nil {
+		return nil
+	}
+	return dt.terminatedConnectionsEventsConsumer.Modifiers()
+}
+
 // configureOptions configures the perf handler options for the map cleaner.
 func (dt *DynamicTable) configureOptions(mgr *manager.Manager, opts *manager.Options) {
 	events.Configure(dt.cfg, terminatedConnectionsEventStream, mgr, opts)
@@ -52,15 +93,25 @@ func (dt *DynamicTable) configureOptions(mgr *manager.Manager, opts *manager.Opt
 
 // preStart sets up the terminated connections events consumer.
 func (dt *DynamicTable) preStart(mgr *manager.Manager) (err error) {
-	dt.terminatedConnectionsEventsConsumer, err = events.NewBatchConsumer(
-		terminatedConnectionsEventStream,
-		mgr,
-		dt.processTerminatedConnections,
-	)
-	if err != nil {
-		return
+	// If using the batch consumer, create it now (after manager initialization).
+	// The direct consumer, when used, was already created in NewDynamicTable so
+	// its modifier could be registered before the manager was initialized.
+	if !dt.useDirectConsumer {
+		batchConsumer, err := events.NewBatchConsumer(
+			terminatedConnectionsEventStream,
+			mgr,
+			dt.processTerminatedConnections,
+		)
+		if err != nil {
+			return err
+		}
+		dt.terminatedConnectionsEventsConsumer = events.NewKernelAdaptiveConsumer[netebpf.ConnTuple](
+			batchConsumer,
+			[]ddebpf.Modifier{}, // BatchConsumer needs no modifiers
+		)
 	}
 
+	// Start the consumer (works for both direct and batch consumers).
 	dt.terminatedConnectionsEventsConsumer.Start()
 
 	return nil
@@ -71,11 +122,18 @@ func (dt *DynamicTable) postStart(mgr *manager.Manager, cfg *config.Config) erro
 	return dt.setupDynamicTableMapCleaner(mgr, cfg)
 }
 
-// processTerminatedConnections processes the terminated connections received from the kernel.
+// processTerminatedConnections processes a batch of terminated connections received from the kernel.
 func (dt *DynamicTable) processTerminatedConnections(events []netebpf.ConnTuple) {
 	dt.terminatedConnectionMux.Lock()
 	defer dt.terminatedConnectionMux.Unlock()
 	dt.terminatedConnections = append(dt.terminatedConnections, events...)
+}
+
+// processTerminatedConnectionDirect processes a single terminated connection received via the direct consumer.
+func (dt *DynamicTable) processTerminatedConnectionDirect(event *netebpf.ConnTuple) {
+	dt.terminatedConnectionMux.Lock()
+	defer dt.terminatedConnectionMux.Unlock()
+	dt.terminatedConnections = append(dt.terminatedConnections, *event)
 }
 
 // setupDynamicTableMapCleaner sets up the map cleaner used to clear entries of terminated connections from the kernel map.

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -34,7 +35,8 @@ type Protocol struct {
 	telemetry               *http.Telemetry
 	statkeeper              *http.StatKeeper
 	http2InFlightMapCleaner *ddebpf.MapCleaner[HTTP2StreamKey, HTTP2Stream]
-	eventsConsumer          *events.BatchConsumer[EbpfTx]
+	consumer                *events.KernelAdaptiveConsumer[EbpfTx]
+	useDirectConsumer       bool
 
 	// http2Telemetry is used to retrieve metrics from the kernel
 	http2Telemetry             *kernelTelemetry
@@ -103,6 +105,9 @@ var Spec = &protocols.ProtocolSpec{
 		},
 		{
 			Name: "http2_ctx_heap",
+		},
+		{
+			Name: "http2_scratch_buffer",
 		},
 		{
 			Name: "http2_batch_events",
@@ -225,14 +230,40 @@ func newHTTP2Protocol(mgr *manager.Manager, cfg *config.Config) (protocols.Proto
 	telemetry := http.NewTelemetry("http2")
 	http2KernelTelemetry := newHTTP2KernelTelemetry()
 
-	return &Protocol{
+	p := &Protocol{
 		cfg:                        cfg,
 		mgr:                        mgr,
 		telemetry:                  telemetry,
 		http2Telemetry:             http2KernelTelemetry,
 		kernelTelemetryStopChannel: make(chan struct{}),
 		dynamicTable:               NewDynamicTable(cfg),
-	}, nil
+	}
+
+	// Create adaptive consumer that determines kernel version and callback internally
+	if err := p.createAdaptiveConsumer(); err != nil {
+		return nil, err
+	}
+
+	// The terminated connections stream must use the same consumer type as the
+	// main stream, since both share the http2_use_direct_consumer eBPF constant.
+	if err := p.dynamicTable.createDirectConsumer(p.useDirectConsumer); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Modifiers implements the ModifierProvider interface. It aggregates the
+// modifiers from both http2 event streams: the main stream (p.consumer) and the
+// terminated connections stream (owned by the dynamic table). Each contributes a
+// direct consumer EventHandler modifier when running in direct mode.
+func (p *Protocol) Modifiers() []ddebpf.Modifier {
+	var mods []ddebpf.Modifier
+	if p.consumer != nil {
+		mods = append(mods, p.consumer.Modifiers()...)
+	}
+	mods = append(mods, p.dynamicTable.modifiers()...)
+	return mods
 }
 
 // Name returns the protocol name.
@@ -275,14 +306,25 @@ func (p *Protocol) ConfigureOptions(opts *manager.Options) {
 		EditorFlag: manager.EditMaxEntries,
 	}
 
-	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          eventStream,
-			EBPFFuncName: netifProbe,
-		},
-	})
+	// The netif flush tracepoint drains both the main and terminated http2 batch
+	// streams. Activate it only when using the batch consumer; when the direct
+	// consumer is in use both streams emit events directly, so no netif flush is
+	// needed and the probe is excluded to avoid loading/verifying it.
+	if !p.useDirectConsumer {
+		opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: netifProbe,
+				UID:          eventStream,
+			},
+		})
+	} else {
+		opts.ExcludedFunctions = append(opts.ExcludedFunctions, netifProbe)
+	}
 	utils.EnableOption(opts, "http2_monitoring_enabled")
 	utils.EnableOption(opts, "terminated_http2_monitoring_enabled")
+	// Route the main http2 event stream through the direct or batch consumer in
+	// the kernel, matching the consumer selected in createAdaptiveConsumer.
+	utils.AddBoolConst(opts, p.useDirectConsumer, "http2_use_direct_consumer")
 	// Configure event stream
 	events.Configure(p.cfg, eventStream, p.mgr, opts)
 	p.dynamicTable.configureOptions(p.mgr, opts)
@@ -292,13 +334,16 @@ func (p *Protocol) ConfigureOptions(opts *manager.Options) {
 // Additional initialisation steps, such as starting an event consumer,
 // should be performed here.
 func (p *Protocol) PreStart() (err error) {
-	p.eventsConsumer, err = events.NewBatchConsumer(
-		eventStream,
-		p.mgr,
-		p.processHTTP2,
-	)
-	if err != nil {
-		return
+	// If using BatchConsumer, create it now (after manager initialization)
+	if !p.useDirectConsumer {
+		batchConsumer, err := events.NewBatchConsumer(eventStream, p.mgr, p.processHTTP2)
+		if err != nil {
+			return err
+		}
+		p.consumer = events.NewKernelAdaptiveConsumer[EbpfTx](
+			batchConsumer,
+			[]ddebpf.Modifier{}, // BatchConsumer needs no modifiers
+		)
 	}
 
 	if err = p.dynamicTable.preStart(p.mgr); err != nil {
@@ -306,7 +351,9 @@ func (p *Protocol) PreStart() (err error) {
 	}
 
 	p.statkeeper = http.NewStatkeeper(p.cfg, p.telemetry, NewIncompleteBuffer(p.cfg))
-	p.eventsConsumer.Start()
+
+	// Start the consumer (works for both DirectConsumer and BatchConsumer)
+	p.consumer.Start()
 
 	return
 }
@@ -369,8 +416,8 @@ func (p *Protocol) Stop() {
 	// http2InFlightMapCleaner handles nil pointer receivers
 	p.http2InFlightMapCleaner.Stop()
 
-	if p.eventsConsumer != nil {
-		p.eventsConsumer.Stop()
+	if p.consumer != nil {
+		p.consumer.Stop()
 	}
 
 	if p.statkeeper != nil {
@@ -421,6 +468,14 @@ func (p *Protocol) processHTTP2(events []EbpfTx) {
 	}
 }
 
+func (p *Protocol) processHTTP2Direct(event *EbpfTx) {
+	eventWrapper := &EventWrapper{
+		EbpfTx: event,
+	}
+	p.telemetry.Count(eventWrapper)
+	p.statkeeper.Process(eventWrapper)
+}
+
 func (p *Protocol) setupHTTP2InFlightMapCleaner() {
 	http2Map, _, err := p.mgr.GetMap(InFlightMap)
 	if err != nil {
@@ -450,7 +505,7 @@ func (p *Protocol) setupHTTP2InFlightMapCleaner() {
 // The format of HTTP2 stats:
 // [source, dest tuple, request path] -> RequestStats object
 func (p *Protocol) GetStats() (*protocols.ProtocolStats, func()) {
-	p.eventsConsumer.Sync()
+	p.consumer.Sync()
 	p.telemetry.Log()
 	stats := p.statkeeper.GetAndResetAllStats()
 	return &protocols.ProtocolStats{
@@ -466,4 +521,40 @@ func (p *Protocol) GetStats() (*protocols.ProtocolStats, func()) {
 // IsBuildModeSupported returns always true, as http2 module is supported by all modes.
 func (*Protocol) IsBuildModeSupported(buildmode.Type) bool {
 	return true
+}
+
+// createAdaptiveConsumer creates the appropriate consumer based on configuration and kernel version
+// and determines which callback method to use internally
+func (p *Protocol) createAdaptiveConsumer() error {
+	// Check if direct consumer is explicitly requested via configuration
+	if p.cfg.HTTP2UseDirectConsumer {
+		if events.SupportsDirectConsumer() {
+			// Use DirectConsumer for kernel ≥5.8 (supports bpf_perf_event_output in socket filters)
+			directConsumer, err := events.NewDirectConsumer("http2", p.processHTTP2Direct, p.cfg)
+			if err != nil {
+				return err
+			}
+			p.consumer = events.NewKernelAdaptiveConsumer[EbpfTx](
+				directConsumer,
+				[]ddebpf.Modifier{&directConsumer.EventHandler},
+			)
+			p.useDirectConsumer = true
+			log.Debugf("HTTP2 monitoring: using direct consumer (requested via configuration)")
+		} else {
+			// Fall back to BatchConsumer on unsupported kernels
+			kernelVersion, err := kernel.HostVersion()
+			if err != nil {
+				log.Warnf("HTTP2 monitoring: direct consumer requested but unable to determine kernel version (%v), falling back to batch consumer", err)
+			} else {
+				log.Warnf("HTTP2 monitoring: direct consumer requested but kernel version %v < 5.8.0, falling back to batch consumer", kernelVersion)
+			}
+			p.useDirectConsumer = false
+		}
+	} else {
+		// Default behavior: use BatchConsumer regardless of kernel version
+		log.Debugf("HTTP2 monitoring: using batch consumer (default behavior)")
+		p.useDirectConsumer = false
+	}
+
+	return nil
 }

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -37,9 +37,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
 	usmhttp "github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	usmhttp2 "github.com/DataDog/datadog-agent/pkg/network/protocols/http2"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	ebpftls "github.com/DataDog/datadog-agent/pkg/network/protocols/tls"
 	gotlsutils "github.com/DataDog/datadog-agent/pkg/network/protocols/tls/gotls/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil/proxy"
@@ -73,7 +75,8 @@ var (
 
 type usmHTTP2Suite struct {
 	suite.Suite
-	isTLS bool
+	isTLS             bool
+	useDirectConsumer bool
 }
 
 func (s *usmHTTP2Suite) getCfg() *config.Config {
@@ -81,30 +84,50 @@ func (s *usmHTTP2Suite) getCfg() *config.Config {
 	cfg.EnableHTTP2Monitoring = true
 	cfg.EnableGoTLSSupport = s.isTLS
 	cfg.GoTLSExcludeSelf = s.isTLS
+	cfg.HTTP2UseDirectConsumer = s.useDirectConsumer
 	return cfg
 }
 
 func TestHTTP2Scenarios(t *testing.T) {
 	skipIfKernelNotSupported(t, usmhttp2.MinimumKernelVersion, "HTTP2")
 	ebpftest.TestBuildModes(t, usmtestutil.SupportedBuildModes(), "", func(t *testing.T) {
-		for _, tc := range []struct {
-			name  string
-			isTLS bool
+		for _, consumer := range []struct {
+			name              string
+			useDirectConsumer bool
 		}{
 			{
-				name:  "without TLS",
-				isTLS: false,
+				name:              "batch consumer",
+				useDirectConsumer: false,
 			},
 			{
-				name:  "with TLS",
-				isTLS: true,
+				name:              "direct consumer",
+				useDirectConsumer: true,
 			},
 		} {
-			t.Run(tc.name, func(t *testing.T) {
-				if tc.isTLS && !gotlsutils.GoTLSSupported(t, config.New()) {
-					t.Skip("GoTLS not supported for this setup")
+			t.Run(consumer.name, func(t *testing.T) {
+				if consumer.useDirectConsumer && !events.SupportsDirectConsumer() {
+					t.Skip("Direct consumer requires kernel >= 5.8.0")
 				}
-				suite.Run(t, &usmHTTP2Suite{isTLS: tc.isTLS})
+				for _, tc := range []struct {
+					name  string
+					isTLS bool
+				}{
+					{
+						name:  "without TLS",
+						isTLS: false,
+					},
+					{
+						name:  "with TLS",
+						isTLS: true,
+					},
+				} {
+					t.Run(tc.name, func(t *testing.T) {
+						if tc.isTLS && !gotlsutils.GoTLSSupported(t, config.New()) {
+							t.Skip("GoTLS not supported for this setup")
+						}
+						suite.Run(t, &usmHTTP2Suite{isTLS: tc.isTLS, useDirectConsumer: consumer.useDirectConsumer})
+					})
+				}
 			})
 		}
 	})
@@ -141,6 +164,13 @@ func (s *usmHTTP2Suite) TestHTTP2DynamicTableCleanup() {
 		utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 
+	// Capture the terminated_http2 event counter so we can assert the terminated
+	// connections stream actually delivered events to userspace (via the batch or
+	// direct consumer, whichever the matrix selected). NewCounter returns the
+	// existing global counter with this name if it already exists.
+	terminatedEventsCounter := telemetry.NewCounter("usm.terminated_http2.events_captured", telemetry.OptStatsd)
+	terminatedEventsBefore := terminatedEventsCounter.Get()
+
 	clients := getHTTP2UnixClientArray(2, unixPath)
 	for i := 0; i < usmhttp2.HTTP2TerminatedBatchSize; i++ {
 		req, err := clients[i%2].Post(fmt.Sprintf("%s/test-%d", http2SrvAddr, i+1), "application/json", bytes.NewReader([]byte("test")))
@@ -172,6 +202,42 @@ func (s *usmHTTP2Suite) TestHTTP2DynamicTableCleanup() {
 	require.Eventually(t, func() bool {
 		return utils.CountMapEntries(t, dynamicTableMap) == 0
 	}, cfg.HTTP2DynamicTableMapCleanerInterval*4, time.Millisecond*100)
+
+	// The dynamic table only drains once the terminated_http2 stream delivers the
+	// terminated connection tuples to userspace, so the counter must have advanced.
+	// This guards against a false positive where the map is empty simply because no
+	// terminated events were ever received.
+	assert.Greater(t, terminatedEventsCounter.Get(), terminatedEventsBefore, "terminated_http2 stream delivered no events")
+}
+
+// TestHTTP2NetifProbeMatchesConsumerMode verifies that the netif_receive_skb flush
+// tracepoint is attached only when the batch consumer is used. In direct consumer
+// mode both http2 event streams (the main stream and the terminated connections
+// stream) emit events directly, so the flush probe is excluded. This proves the
+// configured consumer mode is genuinely in effect rather than silently falling back
+// to the batch consumer, which the stats-based tests cannot distinguish.
+func (s *usmHTTP2Suite) TestHTTP2NetifProbeMatchesConsumerMode() {
+	t := s.T()
+	cfg := s.getCfg()
+
+	monitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
+
+	// The http2 netif flush program (see flush.h). It is unexported in the http2
+	// package, so we match on its eBPF function name, as other tests do with map names.
+	const netifProbeFuncName = "tracepoint__net__netif_receive_skb_http2"
+	netifRunning := false
+	for _, p := range monitor.ebpfProgram.Manager.Manager.GetProbes() {
+		if p.EBPFFuncName == netifProbeFuncName {
+			netifRunning = p.IsRunning()
+			break
+		}
+	}
+
+	if s.useDirectConsumer {
+		assert.False(t, netifRunning, "netif flush probe must not be running when using the direct consumer")
+	} else {
+		assert.True(t, netifRunning, "netif flush probe must be running when using the batch consumer")
+	}
 }
 
 func (s *usmHTTP2Suite) TestSimpleHTTP2() {


### PR DESCRIPTION
Add the service_monitoring_config.http2.use_direct_consumer setting (and the HTTP2UseDirectConsumer USMConfig field), mirroring the existing HTTPUseDirectConsumer option. Off by default; no behavior change yet — consumed by a follow-up that wires HTTP/2 through the kernel-adaptive consumer.

Jira: APMB-16



usm: http2: add eBPF direct-consumer output path

Emit completed HTTP/2 streams through either the batch path (http2_batch_enqueue) or the direct path (http2_output_event), selected at runtime by the use_direct_consumer constant. The constant defaults to 0, so the batch path is unchanged until userspace enables direct mode.

- pktbuf.h: add generic pktbuf_get_ctx() (returns __sk_buff / pt_regs)
- decoding-common.h: add http2_batch_enqueue_wrapper(); handle_end_of_stream() takes ctx
- decoding.h: pass pktbuf_get_ctx(pkt) at the sole call site
- usm-events.h: USM_DIRECT_CONSUMER_INIT for http2 (generates http2_output_event)

Jira: APMB-16



usm: http2: use kernel-adaptive consumer

Switch the HTTP/2 protocol from a hardcoded BatchConsumer to the KernelAdaptiveConsumer, selecting the direct consumer when HTTP2UseDirectConsumer is set and the kernel supports it (>=5.8), otherwise falling back to the batch consumer. Mirrors the HTTP protocol.

- protocol.go: createAdaptiveConsumer(), Modifiers(), processHTTP2Direct(), AddBoolConst(use_direct_consumer), track http2_scratch_buffer in Spec.Maps, keep the netif-flush tracepoint active in both modes
- usm_http2_monitor_test.go: run TestHTTP2Scenarios across batch/direct modes

Jira: APMB-16

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
