### PR TITLE
[QB1HZ-19/20] Load metric lookback shadows in check scheduler

### DIFF
--- a/comp/collector/collector/impl/internal/middleware/BUILD.bazel
+++ b/comp/collector/collector/impl/internal/middleware/BUILD.bazel
@@ -29,7 +29,9 @@ go_test(
     deps = [
         "//comp/core/agenttelemetry/def",
         "//comp/healthplatform/store/def",
+        "//pkg/aggregator/sender",
         "//pkg/collector/check",
+        "//pkg/collector/check/id",
         "//pkg/fleet/installer/telemetry",
         "//pkg/util/option",
         "@com_github_stretchr_testify//assert",

--- a/comp/collector/collector/impl/internal/middleware/check_wrapper.go
+++ b/comp/collector/collector/impl/internal/middleware/check_wrapper.go
@@ -42,6 +42,9 @@ func NewCheckWrapper(inner check.Check, senderManager sender.SenderManager, agen
 			aware.SetIssueReporter(reporter)
 		}
 	}
+	if override, ok := check.SenderManagerOverride(inner); ok {
+		senderManager = override
+	}
 	return &CheckWrapper{
 		inner:          inner,
 		senderManager:  senderManager,

--- a/comp/collector/collector/impl/internal/middleware/check_wrapper_test.go
+++ b/comp/collector/collector/impl/internal/middleware/check_wrapper_test.go
@@ -7,11 +7,15 @@ package middleware
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	agenttelemetry "github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def"
 	healthplatformstore "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	installertelemetry "github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/stretchr/testify/assert"
@@ -21,11 +25,24 @@ import (
 type mockCheck struct {
 	check.Check
 	runCalled bool
+	cancelled bool
+	id        checkid.ID
 }
 
 func (m *mockCheck) Run() error {
 	m.runCalled = true
 	return nil
+}
+
+func (m *mockCheck) Cancel() {
+	m.cancelled = true
+}
+
+func (m *mockCheck) ID() checkid.ID {
+	if m.id == "" {
+		return checkid.ID("mock_check")
+	}
+	return m.id
 }
 
 func (m *mockCheck) String() string {
@@ -148,4 +165,81 @@ func TestCheckWrapperPreservesShadowIdentity(t *testing.T) {
 
 	assert.True(t, check.IsShadow(wrapper))
 	assert.Same(t, shadow, wrapper.Unwrap())
+}
+
+func TestCheckWrapperUsesShadowSenderManagerForShadowCleanup(t *testing.T) {
+	normalSenderManager := newRecordingSenderManager()
+	shadowSenderManager := newRecordingSenderManager()
+	inner := &mockCheck{id: checkid.ID("cpu:abc123")}
+	shadow := check.NewShadowCheckWithSenderManagerOverride(inner, 0, shadowSenderManager)
+
+	wrapper := NewCheckWrapper(
+		shadow,
+		normalSenderManager,
+		option.None[agenttelemetry.Component](),
+		option.None[healthplatformstore.Component](),
+	)
+
+	wrapper.Cancel()
+
+	shadowSenderManager.requireDestroyed(t, checkid.ID("cpu:abc123:shadow"))
+	assert.True(t, inner.cancelled)
+	assert.Empty(t, normalSenderManager.destroyedIDs)
+}
+
+func TestCheckWrapperUsesNormalSenderManagerWhenThereIsNoOverride(t *testing.T) {
+	normalSenderManager := newRecordingSenderManager()
+	inner := &mockCheck{id: checkid.ID("cpu:abc123")}
+
+	wrapper := NewCheckWrapper(
+		inner,
+		normalSenderManager,
+		option.None[agenttelemetry.Component](),
+		option.None[healthplatformstore.Component](),
+	)
+
+	wrapper.Cancel()
+
+	normalSenderManager.requireDestroyed(t, checkid.ID("cpu:abc123"))
+	assert.True(t, inner.cancelled)
+}
+
+type recordingSenderManager struct {
+	mu           sync.Mutex
+	destroyedIDs []checkid.ID
+	destroyedCh  chan checkid.ID
+}
+
+func newRecordingSenderManager() *recordingSenderManager {
+	return &recordingSenderManager{destroyedCh: make(chan checkid.ID, 1)}
+}
+
+func (m *recordingSenderManager) GetSender(checkid.ID) (sender.Sender, error) {
+	return nil, nil
+}
+
+func (m *recordingSenderManager) SetSender(sender.Sender, checkid.ID) error {
+	return nil
+}
+
+func (m *recordingSenderManager) DestroySender(id checkid.ID) {
+	m.mu.Lock()
+	m.destroyedIDs = append(m.destroyedIDs, id)
+	m.mu.Unlock()
+	m.destroyedCh <- id
+}
+
+func (m *recordingSenderManager) GetDefaultSender() (sender.Sender, error) {
+	return nil, nil
+}
+
+func (m *recordingSenderManager) requireDestroyed(t *testing.T, expectedID checkid.ID) {
+	t.Helper()
+
+	select {
+	case gotID := <-m.destroyedCh:
+		assert.Equal(t, expectedID, gotID)
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for sender cleanup of %s", expectedID)
+	}
 }

--- a/pkg/collector/BUILD.bazel
+++ b/pkg/collector/BUILD.bazel
@@ -22,6 +22,8 @@ go_library(
         "//pkg/collector/check",
         "//pkg/collector/check/id",
         "//pkg/collector/loaders",
+        "//pkg/collector/metriclookback",
+        "//pkg/collector/metriclookback/lookbacksender",
         "//pkg/config/model",
         "//pkg/config/setup",
         "//pkg/util/log",
@@ -52,5 +54,6 @@ dd_agent_go_test(
         "//pkg/config/model",
         "//pkg/util/option",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/collector/BUILD.bazel
+++ b/pkg/collector/BUILD.bazel
@@ -53,6 +53,7 @@ dd_agent_go_test(
         "//pkg/config/mock",
         "//pkg/config/model",
         "//pkg/util/option",
+        "@//pkg/util/infratags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/collector/BUILD.bazel
+++ b/pkg/collector/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//pkg/collector/check/id",
         "//pkg/collector/loaders",
         "//pkg/collector/metriclookback",
-        "//pkg/collector/metriclookback/lookbacksender",
         "//pkg/config/model",
         "//pkg/config/setup",
         "//pkg/util/log",

--- a/pkg/collector/check/shadow.go
+++ b/pkg/collector/check/shadow.go
@@ -8,6 +8,7 @@ package check
 import (
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 )
 
@@ -22,14 +23,36 @@ type shadowMarker interface {
 type ShadowCheck struct {
 	Check
 
-	interval time.Duration
+	// sourceCheckID preserves the normal check ID when the wrapped check was
+	// loaded from shadow-mutated config bytes. In that case, the inner check's
+	// own ID may be derived from the shadow config instead of the source config.
+	sourceCheckID checkid.ID
+	interval      time.Duration
+	senderManager sender.SenderManager
 }
 
 // NewShadowCheck wraps inner with shadow identity and interval overrides.
 func NewShadowCheck(inner Check, interval time.Duration) *ShadowCheck {
+	return NewShadowCheckWithSenderManagerOverride(inner, interval, nil)
+}
+
+// NewShadowCheckWithSenderManagerOverride wraps inner with shadow identity,
+// interval, and sender manager overrides.
+func NewShadowCheckWithSenderManagerOverride(inner Check, interval time.Duration, senderManager sender.SenderManager) *ShadowCheck {
+	return newShadowCheck(inner, "", interval, senderManager)
+}
+
+// NewShadowCheckForSource wraps inner as a shadow of sourceCheckID.
+func NewShadowCheckForSource(inner Check, sourceCheckID checkid.ID, interval time.Duration, senderManager sender.SenderManager) *ShadowCheck {
+	return newShadowCheck(inner, sourceCheckID, interval, senderManager)
+}
+
+func newShadowCheck(inner Check, sourceCheckID checkid.ID, interval time.Duration, senderManager sender.SenderManager) *ShadowCheck {
 	return &ShadowCheck{
-		Check:    inner,
-		interval: interval,
+		Check:         inner,
+		sourceCheckID: sourceCheckID,
+		interval:      interval,
+		senderManager: senderManager,
 	}
 }
 
@@ -40,6 +63,9 @@ func ShadowID(sourceID checkid.ID) checkid.ID {
 
 // ID returns the shadow check ID.
 func (c *ShadowCheck) ID() checkid.ID {
+	if c.sourceCheckID != "" {
+		return ShadowID(c.sourceCheckID)
+	}
 	return ShadowID(c.Check.ID())
 }
 
@@ -59,4 +85,14 @@ func (*ShadowCheck) isShadowCheck() {}
 func IsShadow(c Check) bool {
 	_, ok := As[shadowMarker](c)
 	return ok
+}
+
+// SenderManagerOverride returns the sender manager that should be used for c
+// when it differs from the collector's normal sender manager.
+func SenderManagerOverride(c Check) (sender.SenderManager, bool) {
+	shadow, ok := As[*ShadowCheck](c)
+	if !ok || shadow.senderManager == nil {
+		return nil, false
+	}
+	return shadow.senderManager, true
 }

--- a/pkg/collector/check/shadow_test.go
+++ b/pkg/collector/check/shadow_test.go
@@ -45,6 +45,16 @@ func TestShadowCheckIDTracksInnerCheckID(t *testing.T) {
 	assert.Equal(t, checkid.ID("cpu:def456:shadow"), shadow.ID())
 }
 
+func TestShadowCheckCanUseExplicitSourceID(t *testing.T) {
+	inner := &recordingCheck{id: checkid.ID("cpu:shadow-config-digest")}
+	shadow := NewShadowCheckForSource(inner, checkid.ID("cpu:source-digest"), time.Second, nil)
+
+	assert.Equal(t, checkid.ID("cpu:source-digest:shadow"), shadow.ID())
+
+	inner.id = checkid.ID("cpu:changed-inner-digest")
+	assert.Equal(t, checkid.ID("cpu:source-digest:shadow"), shadow.ID())
+}
+
 func TestShadowCheckDelegatesInnerCheckBehavior(t *testing.T) {
 	expectedErr := errors.New("run failed")
 	expectedWarnings := []error{errors.New("warning")}
@@ -131,6 +141,27 @@ type recordingWrapper struct {
 
 func (w *recordingWrapper) Unwrap() Check {
 	return w.Check
+}
+
+func TestShadowCheckExposesSenderManagerOverride(t *testing.T) {
+	inner := &recordingCheck{id: checkid.ID("cpu:abc123")}
+	shadowSenderManager := &recordingSenderManager{}
+	shadow := NewShadowCheckWithSenderManagerOverride(inner, time.Second, shadowSenderManager)
+
+	gotSenderManager, ok := SenderManagerOverride(shadow)
+	require.True(t, ok)
+	assert.Same(t, shadowSenderManager, gotSenderManager)
+}
+
+func TestSenderManagerOverrideIgnoresNormalChecksAndUnsetShadowChecks(t *testing.T) {
+	inner := &recordingCheck{id: checkid.ID("cpu:abc123")}
+	shadow := NewShadowCheck(inner, time.Second)
+
+	_, ok := SenderManagerOverride(inner)
+	assert.False(t, ok)
+
+	_, ok = SenderManagerOverride(shadow)
+	assert.False(t, ok)
 }
 
 type recordingCheck struct {
@@ -254,4 +285,8 @@ type issueAwareRecordingCheck struct {
 
 func (c *issueAwareRecordingCheck) SetIssueReporter(reporter healthplatformstore.Component) {
 	c.reporter = reporter
+}
+
+type recordingSenderManager struct {
+	sender.SenderManager
 }

--- a/pkg/collector/metriclookback/lookbacksender/BUILD.bazel
+++ b/pkg/collector/metriclookback/lookbacksender/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/metrics/event",
         "//pkg/metrics/servicecheck",
         "//pkg/serializer/types",
+        "//pkg/util/infratags",
         "//pkg/util/log",
         "@//pkg/util/infratags",
     ],

--- a/pkg/collector/metriclookback/lookbacksender/BUILD.bazel
+++ b/pkg/collector/metriclookback/lookbacksender/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/metrics/event",
         "//pkg/metrics/servicecheck",
         "//pkg/serializer/types",
-        "//pkg/util/infratags",
         "//pkg/util/log",
         "@//pkg/util/infratags",
     ],

--- a/pkg/collector/metriclookback/policy.go
+++ b/pkg/collector/metriclookback/policy.go
@@ -19,8 +19,12 @@ import (
 const (
 	enabledConfigKey       = "metric_lookback.enabled"
 	enabledChecksConfigKey = "metric_lookback.enabled_checks"
+	collectionIntervalKey  = "metric_lookback.collection_interval"
 	instanceConfigKey      = "metric_lookback"
 	instanceEnabledKey     = "enabled"
+
+	// The scheduler rejects recurring check intervals below one second.
+	minShadowCheckInterval = time.Second
 
 	// defaultShadowCheckInterval is the collection interval for selected metric
 	// lookback shadow checks.
@@ -31,6 +35,7 @@ const (
 type ShadowPolicyOptions struct {
 	ShadowChecksEnabled bool
 	ChecksToShadow      []string
+	ShadowInterval      time.Duration
 }
 
 // ShadowPolicyOptionsFromConfig reads metric lookback policy options from Agent config.
@@ -38,6 +43,7 @@ func ShadowPolicyOptionsFromConfig(cfg model.Reader) ShadowPolicyOptions {
 	return ShadowPolicyOptions{
 		ShadowChecksEnabled: cfg.GetBool(enabledConfigKey),
 		ChecksToShadow:      cfg.GetStringSlice(enabledChecksConfigKey),
+		ShadowInterval:      normalizeShadowInterval(cfg.GetDuration(collectionIntervalKey)),
 	}
 }
 
@@ -54,6 +60,7 @@ type ShadowCandidate struct {
 // Loading, scheduling, and execution routing are handled by the caller.
 func SelectShadowCandidates(configs []integration.Config, opts ShadowPolicyOptions) []ShadowCandidate {
 	candidates := []ShadowCandidate{}
+	shadowInterval := normalizeShadowInterval(opts.ShadowInterval)
 	for _, config := range configs {
 		if !isSupportedCheckConfig(config, opts) {
 			continue
@@ -77,11 +84,18 @@ func SelectShadowCandidates(configs []integration.Config, opts ShadowPolicyOptio
 				Instance:           shadowInstance,
 				InstanceIndex:      instanceIndex,
 				SourceConfigDigest: config.Digest(),
-				ShadowInterval:     defaultShadowCheckInterval,
+				ShadowInterval:     shadowInterval,
 			})
 		}
 	}
 	return candidates
+}
+
+func normalizeShadowInterval(interval time.Duration) time.Duration {
+	if interval < minShadowCheckInterval {
+		return defaultShadowCheckInterval
+	}
+	return interval
 }
 
 func isSupportedCheckConfig(config integration.Config, opts ShadowPolicyOptions) bool {

--- a/pkg/collector/metriclookback/policy.go
+++ b/pkg/collector/metriclookback/policy.go
@@ -7,6 +7,7 @@ package metriclookback
 
 import (
 	"slices"
+	"time"
 
 	yaml "go.yaml.in/yaml/v2"
 
@@ -20,6 +21,10 @@ const (
 	enabledChecksConfigKey = "metric_lookback.enabled_checks"
 	instanceConfigKey      = "metric_lookback"
 	instanceEnabledKey     = "enabled"
+
+	// defaultShadowCheckInterval is the collection interval for selected metric
+	// lookback shadow checks.
+	defaultShadowCheckInterval = time.Second
 )
 
 // ShadowPolicyOptions controls which source check instances get shadow candidates.
@@ -42,6 +47,7 @@ type ShadowCandidate struct {
 	Instance           integration.Data
 	InstanceIndex      int
 	SourceConfigDigest string
+	ShadowInterval     time.Duration
 }
 
 // SelectShadowCandidates returns copied shadow candidates for selected config instances.
@@ -71,6 +77,7 @@ func SelectShadowCandidates(configs []integration.Config, opts ShadowPolicyOptio
 				Instance:           shadowInstance,
 				InstanceIndex:      instanceIndex,
 				SourceConfigDigest: config.Digest(),
+				ShadowInterval:     defaultShadowCheckInterval,
 			})
 		}
 	}

--- a/pkg/collector/metriclookback/policy.go
+++ b/pkg/collector/metriclookback/policy.go
@@ -23,11 +23,9 @@ const (
 	instanceConfigKey      = "metric_lookback"
 	instanceEnabledKey     = "enabled"
 
-	// The scheduler rejects recurring check intervals below one second.
-	minShadowCheckInterval = time.Second
-
 	// defaultShadowCheckInterval is the collection interval for selected metric
-	// lookback shadow checks.
+	// lookback shadow checks and the minimum recurring interval accepted by the
+	// scheduler.
 	defaultShadowCheckInterval = time.Second
 )
 
@@ -93,7 +91,8 @@ func SelectShadowCandidates(configs []integration.Config, opts ShadowPolicyOptio
 }
 
 func normalizeShadowInterval(interval time.Duration) time.Duration {
-	if interval < minShadowCheckInterval {
+	// The default is also the scheduler's minimum recurring check interval.
+	if interval < defaultShadowCheckInterval {
 		return defaultShadowCheckInterval
 	}
 	return interval

--- a/pkg/collector/metriclookback/policy.go
+++ b/pkg/collector/metriclookback/policy.go
@@ -60,7 +60,6 @@ type ShadowCandidate struct {
 // Loading, scheduling, and execution routing are handled by the caller.
 func SelectShadowCandidates(configs []integration.Config, opts ShadowPolicyOptions) []ShadowCandidate {
 	candidates := []ShadowCandidate{}
-	shadowInterval := normalizeShadowInterval(opts.ShadowInterval)
 	for _, config := range configs {
 		if !isSupportedCheckConfig(config, opts) {
 			continue
@@ -86,7 +85,7 @@ func SelectShadowCandidates(configs []integration.Config, opts ShadowPolicyOptio
 				Instance:           shadowInstance,
 				InstanceIndex:      instanceIndex,
 				SourceConfigDigest: config.Digest(),
-				ShadowInterval:     shadowInterval,
+				ShadowInterval:     opts.ShadowInterval,
 			})
 		}
 	}

--- a/pkg/collector/metriclookback/policy.go
+++ b/pkg/collector/metriclookback/policy.go
@@ -79,8 +79,10 @@ func SelectShadowCandidates(configs []integration.Config, opts ShadowPolicyOptio
 			if err != nil {
 				continue
 			}
+			sourceConfig := cloneConfig(config)
+			sourceConfig.LogsConfig = nil
 			candidates = append(candidates, ShadowCandidate{
-				SourceConfig:       cloneConfig(config),
+				SourceConfig:       sourceConfig,
 				Instance:           shadowInstance,
 				InstanceIndex:      instanceIndex,
 				SourceConfigDigest: config.Digest(),

--- a/pkg/collector/metriclookback/policy_test.go
+++ b/pkg/collector/metriclookback/policy_test.go
@@ -169,7 +169,9 @@ func TestSelectShadowCandidatesDoesNotMutateSourceConfig(t *testing.T) {
 
 	require.Len(t, candidates, 1)
 	assert.Equal(t, original, source)
-	assert.Equal(t, original, candidates[0].SourceConfig)
+	expectedShadowConfig := original
+	expectedShadowConfig.LogsConfig = nil
+	assert.Equal(t, expectedShadowConfig, candidates[0].SourceConfig)
 	assert.NotEqual(t, source.Instances[0], candidates[0].Instance)
 
 	candidates[0].SourceConfig.Instances[0][0] = 'X'

--- a/pkg/collector/metriclookback/policy_test.go
+++ b/pkg/collector/metriclookback/policy_test.go
@@ -55,6 +55,7 @@ func TestSelectShadowCandidatesSelectsEnabledChecks(t *testing.T) {
 	assert.Equal(t, "cpu", candidate.SourceConfig.Name)
 	assert.Equal(t, 0, candidate.InstanceIndex)
 	assert.Equal(t, configs[0].Digest(), candidate.SourceConfigDigest)
+	assert.Equal(t, defaultShadowCheckInterval, candidate.ShadowInterval)
 
 	raw := integration.RawMap{}
 	require.NoError(t, yaml.Unmarshal(candidate.Instance, &raw))
@@ -78,6 +79,7 @@ func TestSelectShadowCandidatesAllowsPerInstanceEnablement(t *testing.T) {
 
 	require.Len(t, candidates, 1)
 	assert.Equal(t, 1, candidates[0].InstanceIndex)
+	assert.Equal(t, defaultShadowCheckInterval, candidates[0].ShadowInterval)
 }
 
 func TestSelectShadowCandidatesTreatsMalformedInstanceSettingAsUnset(t *testing.T) {

--- a/pkg/collector/metriclookback/policy_test.go
+++ b/pkg/collector/metriclookback/policy_test.go
@@ -86,7 +86,7 @@ func TestSelectShadowCandidatesAllowsPerInstanceEnablement(t *testing.T) {
 		},
 	}
 
-	candidates := SelectShadowCandidates(configs, ShadowPolicyOptions{})
+	candidates := SelectShadowCandidates(configs, ShadowPolicyOptions{ShadowInterval: defaultShadowCheckInterval})
 
 	require.Len(t, candidates, 1)
 	assert.Equal(t, 1, candidates[0].InstanceIndex)

--- a/pkg/collector/metriclookback/policy_test.go
+++ b/pkg/collector/metriclookback/policy_test.go
@@ -33,7 +33,7 @@ func TestShadowPolicyOptionsFromConfig(t *testing.T) {
 
 func TestShadowPolicyOptionsFromConfigDefaultsInvalidShadowInterval(t *testing.T) {
 	cfg := configmock.New(t)
-	cfg.SetInTest("metric_lookback.collection_interval", minShadowCheckInterval-time.Millisecond)
+	cfg.SetInTest("metric_lookback.collection_interval", defaultShadowCheckInterval-time.Millisecond)
 
 	assert.Equal(t, defaultShadowCheckInterval, ShadowPolicyOptionsFromConfig(cfg).ShadowInterval)
 }

--- a/pkg/collector/metriclookback/policy_test.go
+++ b/pkg/collector/metriclookback/policy_test.go
@@ -7,6 +7,7 @@ package metriclookback
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,11 +22,20 @@ func TestShadowPolicyOptionsFromConfig(t *testing.T) {
 	cfg := configmock.New(t)
 	cfg.SetInTest("metric_lookback.enabled", true)
 	cfg.SetInTest("metric_lookback.enabled_checks", []string{"cpu", "disk"})
+	cfg.SetInTest("metric_lookback.collection_interval", 3*time.Second)
 
 	assert.Equal(t, ShadowPolicyOptions{
 		ShadowChecksEnabled: true,
 		ChecksToShadow:      []string{"cpu", "disk"},
+		ShadowInterval:      3 * time.Second,
 	}, ShadowPolicyOptionsFromConfig(cfg))
+}
+
+func TestShadowPolicyOptionsFromConfigDefaultsInvalidShadowInterval(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("metric_lookback.collection_interval", minShadowCheckInterval-time.Millisecond)
+
+	assert.Equal(t, defaultShadowCheckInterval, ShadowPolicyOptionsFromConfig(cfg).ShadowInterval)
 }
 
 func TestSelectShadowCandidatesSelectsEnabledChecks(t *testing.T) {
@@ -48,6 +58,7 @@ func TestSelectShadowCandidatesSelectsEnabledChecks(t *testing.T) {
 	candidates := SelectShadowCandidates(configs, ShadowPolicyOptions{
 		ShadowChecksEnabled: true,
 		ChecksToShadow:      []string{"cpu"},
+		ShadowInterval:      2 * time.Second,
 	})
 
 	require.Len(t, candidates, 1)
@@ -55,7 +66,7 @@ func TestSelectShadowCandidatesSelectsEnabledChecks(t *testing.T) {
 	assert.Equal(t, "cpu", candidate.SourceConfig.Name)
 	assert.Equal(t, 0, candidate.InstanceIndex)
 	assert.Equal(t, configs[0].Digest(), candidate.SourceConfigDigest)
-	assert.Equal(t, defaultShadowCheckInterval, candidate.ShadowInterval)
+	assert.Equal(t, 2*time.Second, candidate.ShadowInterval)
 
 	raw := integration.RawMap{}
 	require.NoError(t, yaml.Unmarshal(candidate.Instance, &raw))

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -53,11 +53,6 @@ type loadInstanceResult struct {
 	loaderErrors map[string]error
 }
 
-type loadChecksOptions struct {
-	includeShadowChecks bool
-	populateCache       bool
-}
-
 func init() {
 	schedulerErrs = expvar.NewMap("CheckScheduler")
 	schedulerErrs.Set("LoaderErrors", expvar.Func(func() interface{} {
@@ -361,10 +356,6 @@ func (s *CheckScheduler) GetChecksFromConfigs(configs []integration.Config, popu
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	opts := loadChecksOptions{
-		includeShadowChecks: populateCache,
-		populateCache:       populateCache,
-	}
 	var allChecks []check.Check
 	for _, config := range configs {
 		if !config.IsCheckConfig() {
@@ -376,14 +367,14 @@ func (s *CheckScheduler) GetChecksFromConfigs(configs []integration.Config, popu
 			continue
 		}
 		configDigest := config.Digest()
-		checks, err := s.getChecks(config, opts.includeShadowChecks)
+		checks, err := s.getChecks(config, populateCache)
 		if err != nil {
 			log.Errorf("Unable to load the check: %v", err)
 			continue
 		}
 		for _, c := range checks {
 			allChecks = append(allChecks, c)
-			if opts.populateCache {
+			if populateCache {
 				// store the checks we schedule for this config locally
 				s.configToChecks[configDigest] = append(s.configToChecks[configDigest], c.ID())
 			}

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -7,6 +7,7 @@
 package collector
 
 import (
+	"errors"
 	"expvar"
 	"fmt"
 	"slices"
@@ -298,7 +299,7 @@ func (s *CheckScheduler) applyInfraTagger(senderManager sender.SenderManager, ch
 func (s *CheckScheduler) loadShadowCheck(candidate metriclookback.ShadowCandidate, loader check.Loader, sourceCheckID checkid.ID) (check.Check, error) {
 	shadowSenderManager := s.shadowSenderManager
 	if shadowSenderManager == nil {
-		return nil, fmt.Errorf("metric lookback shadow sender manager is not configured")
+		return nil, errors.New("metric lookback shadow sender manager is not configured")
 	}
 	shadowCheckID := check.ShadowID(sourceCheckID)
 	checkSenderManager := shadowCheckSenderManager{

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -7,7 +7,6 @@
 package collector
 
 import (
-	"context"
 	"expvar"
 	"fmt"
 	"slices"
@@ -28,7 +27,6 @@ import (
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/DataDog/datadog-agent/pkg/collector/metriclookback"
-	"github.com/DataDog/datadog-agent/pkg/collector/metriclookback/lookbacksender"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/infratags"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -305,8 +303,7 @@ func (s *CheckScheduler) applyInfraTagger(senderManager sender.SenderManager, ch
 func (s *CheckScheduler) loadShadowCheck(candidate metriclookback.ShadowCandidate, loader check.Loader, sourceCheckID checkid.ID) (check.Check, error) {
 	shadowSenderManager := s.shadowSenderManager
 	if shadowSenderManager == nil {
-		shadowSenderManager = lookbacksender.NewSenderManager(context.Background(), "", nil, nil)
-		s.shadowSenderManager = shadowSenderManager
+		return nil, fmt.Errorf("metric lookback shadow sender manager is not configured")
 	}
 	shadowCheckID := check.ShadowID(sourceCheckID)
 	checkSenderManager := shadowCheckSenderManager{

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -7,6 +7,7 @@
 package collector
 
 import (
+	"context"
 	"expvar"
 	"fmt"
 	"slices"
@@ -26,6 +27,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
+	"github.com/DataDog/datadog-agent/pkg/collector/metriclookback"
+	"github.com/DataDog/datadog-agent/pkg/collector/metriclookback/lookbacksender"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/infratags"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -46,6 +49,17 @@ type commonInstanceConfig struct {
 	LoaderName string `yaml:"loader"`
 }
 
+type loadInstanceResult struct {
+	check        check.Check
+	loader       check.Loader
+	loaderErrors map[string]error
+}
+
+type loadChecksOptions struct {
+	includeShadowChecks bool
+	populateCache       bool
+}
+
 func init() {
 	schedulerErrs = expvar.NewMap("CheckScheduler")
 	schedulerErrs.Set("LoaderErrors", expvar.Func(func() interface{} {
@@ -58,12 +72,13 @@ func init() {
 
 // CheckScheduler is the check scheduler
 type CheckScheduler struct {
-	configToChecks map[string][]checkid.ID // cache the ID of checks we load for each config
-	loaders        []check.Loader
-	collector      option.Option[collectorcomp.Component]
-	senderManager  sender.SenderManager
-	infraTagger    *infratags.Tagger // nil = no infra mode tagging
-	m              sync.RWMutex
+	configToChecks      map[string][]checkid.ID // cache the ID of checks we load for each config
+	loaders             []check.Loader
+	collector           option.Option[collectorcomp.Component]
+	senderManager       sender.SenderManager
+	shadowSenderManager sender.SenderManager
+	infraTagger         *infratags.Tagger // nil = no infra mode tagging
+	m                   sync.RWMutex
 }
 
 // InitCheckScheduler creates and returns a check scheduler
@@ -167,9 +182,13 @@ func (s *CheckScheduler) addLoader(loader check.Loader) {
 
 // getChecks takes a check configuration and returns a slice of Check instances
 // along with any error it might happen during the process
-func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, error) {
+func (s *CheckScheduler) getChecks(config integration.Config, includeShadowChecks bool) ([]check.Check, error) {
 	checks := []check.Check{}
 	numLoaders := len(s.loaders)
+	var shadowCandidates map[int]metriclookback.ShadowCandidate
+	if includeShadowChecks {
+		shadowCandidates = shadowCandidatesByInstance(config)
+	}
 
 	initConfig := commonInitConfig{}
 	err := yaml.Unmarshal(config.InitConfig, &initConfig)
@@ -202,32 +221,27 @@ func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, er
 			log.Debugf("Loading check instance for check '%s' using default loaders", config.Name)
 		}
 
-		loaderErrors := make(map[string]error, len(s.loaders))
-		for _, loader := range s.loaders {
-			// the loader is skipped if the loader name is set and does not match
-			if (selectedInstanceLoader != "") && (selectedInstanceLoader != loader.Name()) {
-				log.Debugf("Loader name %v does not match, skip loader %v for check %v", selectedInstanceLoader, loader.Name(), config.Name)
-				continue
-			}
-			c, err := loader.Load(s.senderManager, config, instance, instanceIndex)
-			if err == nil {
-				log.Debugf("%v: successfully loaded check '%s'", loader, config.Name)
-				if s.infraTagger != nil && s.infraTagger.IsCheckEligible(config.Name) {
-					if chkSender, senderErr := s.senderManager.GetSender(c.ID()); senderErr == nil {
-						chkSender.SetInfraTagger(s.infraTagger)
+		result := s.loadCheckInstance(s.senderManager, config, instance, instanceIndex, selectedInstanceLoader)
+
+		if result.check != nil {
+			log.Debugf("%v: successfully loaded check '%s'", result.loader, config.Name)
+			s.applyInfraTagger(s.senderManager, config.Name, result.check.ID())
+			checks = append(checks, result.check)
+			if includeShadowChecks {
+				if candidate, found := shadowCandidates[instanceIndex]; found {
+					sourceCheckID := result.check.ID()
+					if shadowCheck, err := s.loadShadowCheck(candidate, result.loader, sourceCheckID); err != nil {
+						log.Warnf("Unable to load metric lookback shadow check %s: %v", check.ShadowID(sourceCheckID), err)
 					} else {
-						log.Debugf("infra mode tags: skipping %s (%s): %v", config.Name, c.ID(), senderErr)
+						checks = append(checks, shadowCheck)
 					}
 				}
-				checks = append(checks, c)
-				break
 			}
-			loaderErrors[fmt.Sprintf("%v", loader)] = err
 		}
 
-		if len(loaderErrors) == numLoaders {
+		if len(result.loaderErrors) == numLoaders {
 			var concatErr strings.Builder
-			for loaderName, err := range loaderErrors {
+			for loaderName, err := range result.loaderErrors {
 				errMsg := err.Error()
 				errorStats.setLoaderError(config.Name, loaderName, errMsg)
 
@@ -243,6 +257,86 @@ func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, er
 	}
 
 	return checks, nil
+}
+
+func shadowCandidatesByInstance(config integration.Config) map[int]metriclookback.ShadowCandidate {
+	candidates := metriclookback.SelectShadowCandidates([]integration.Config{config}, metriclookback.ShadowPolicyOptionsFromConfig(setup.Datadog()))
+	if len(candidates) == 0 {
+		return nil
+	}
+	byInstance := make(map[int]metriclookback.ShadowCandidate, len(candidates))
+	for _, candidate := range candidates {
+		byInstance[candidate.InstanceIndex] = candidate
+	}
+	return byInstance
+}
+
+func (s *CheckScheduler) loadCheckInstance(senderManager sender.SenderManager, config integration.Config, instance integration.Data, instanceIndex int, selectedInstanceLoader string) loadInstanceResult {
+	result := loadInstanceResult{loaderErrors: make(map[string]error, len(s.loaders))}
+	for _, loader := range s.loaders {
+		// the loader is skipped if the loader name is set and does not match
+		if (selectedInstanceLoader != "") && (selectedInstanceLoader != loader.Name()) {
+			log.Debugf("Loader name %v does not match, skip loader %v for check %v", selectedInstanceLoader, loader.Name(), config.Name)
+			continue
+		}
+		c, err := loader.Load(senderManager, config, instance, instanceIndex)
+		if err == nil {
+			result.check = c
+			result.loader = loader
+			return result
+		}
+		result.loaderErrors[fmt.Sprintf("%v", loader)] = err
+	}
+	return result
+}
+
+func (s *CheckScheduler) applyInfraTagger(senderManager sender.SenderManager, checkName string, checkID checkid.ID) {
+	if s.infraTagger == nil || !s.infraTagger.IsCheckEligible(checkName) {
+		return
+	}
+	chkSender, err := senderManager.GetSender(checkID)
+	if err != nil {
+		log.Debugf("infra mode tags: skipping %s (%s): %v", checkName, checkID, err)
+		return
+	}
+	chkSender.SetInfraTagger(s.infraTagger)
+}
+
+func (s *CheckScheduler) loadShadowCheck(candidate metriclookback.ShadowCandidate, loader check.Loader, sourceCheckID checkid.ID) (check.Check, error) {
+	shadowSenderManager := s.shadowSenderManager
+	if shadowSenderManager == nil {
+		shadowSenderManager = lookbacksender.NewSenderManager(context.Background(), "", nil, nil)
+		s.shadowSenderManager = shadowSenderManager
+	}
+	shadowCheckID := check.ShadowID(sourceCheckID)
+	checkSenderManager := shadowCheckSenderManager{
+		SenderManager: shadowSenderManager,
+		shadowCheckID: shadowCheckID,
+	}
+	loadedCheck, err := loader.Load(checkSenderManager, candidate.SourceConfig, candidate.Instance, candidate.InstanceIndex)
+	if err != nil {
+		checkSenderManager.DestroySender(shadowCheckID)
+		return nil, err
+	}
+	s.applyInfraTagger(checkSenderManager, candidate.SourceConfig.Name, shadowCheckID)
+	return check.NewShadowCheckForSource(loadedCheck, sourceCheckID, candidate.ShadowInterval, checkSenderManager), nil
+}
+
+type shadowCheckSenderManager struct {
+	sender.SenderManager
+	shadowCheckID checkid.ID
+}
+
+func (m shadowCheckSenderManager) GetSender(checkid.ID) (sender.Sender, error) {
+	return m.SenderManager.GetSender(m.shadowCheckID)
+}
+
+func (m shadowCheckSenderManager) SetSender(s sender.Sender, _ checkid.ID) error {
+	return m.SenderManager.SetSender(s, m.shadowCheckID)
+}
+
+func (m shadowCheckSenderManager) DestroySender(checkid.ID) {
+	m.SenderManager.DestroySender(m.shadowCheckID)
 }
 
 // GetChecksByNameForConfigs returns checks matching name for passed in configs
@@ -263,12 +357,17 @@ func GetChecksByNameForConfigs(checkName string, configs []integration.Config) [
 	return checks
 }
 
-// GetChecksFromConfigs gets all the check instances for given configurations
-// optionally can populate the configToChecks cache
+// GetChecksFromConfigs gets all the check instances for given configurations.
+// When populateCache is true, the call is part of scheduling and includes
+// selected metric lookback shadow checks in the scheduler cache.
 func (s *CheckScheduler) GetChecksFromConfigs(configs []integration.Config, populateCache bool) []check.Check {
 	s.m.Lock()
 	defer s.m.Unlock()
 
+	opts := loadChecksOptions{
+		includeShadowChecks: populateCache,
+		populateCache:       populateCache,
+	}
 	var allChecks []check.Check
 	for _, config := range configs {
 		if !config.IsCheckConfig() {
@@ -280,14 +379,14 @@ func (s *CheckScheduler) GetChecksFromConfigs(configs []integration.Config, popu
 			continue
 		}
 		configDigest := config.Digest()
-		checks, err := s.getChecks(config)
+		checks, err := s.getChecks(config, opts.includeShadowChecks)
 		if err != nil {
 			log.Errorf("Unable to load the check: %v", err)
 			continue
 		}
 		for _, c := range checks {
 			allChecks = append(allChecks, c)
-			if populateCache {
+			if opts.populateCache {
 				// store the checks we schedule for this config locally
 				s.configToChecks[configDigest] = append(s.configToChecks[configDigest], c.ID())
 			}

--- a/pkg/collector/scheduler_test.go
+++ b/pkg/collector/scheduler_test.go
@@ -225,6 +225,34 @@ func TestGetChecksFromConfigsDoesNotLoadShadowChecksWhenCacheIsNotPopulated(t *t
 	assert.Empty(t, shadowSenderManager.requestedIDs)
 }
 
+func TestGetChecksFromConfigsKeepsNormalCheckWhenShadowSenderManagerMissing(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("metric_lookback.enabled", true)
+	cfg.SetInTest("metric_lookback.enabled_checks", []string{"cpu"})
+
+	normalSenderManager := &recordingSchedulerSenderManager{name: "normal"}
+	loader := &recordingSchedulerLoader{name: "core"}
+	s := CheckScheduler{
+		configToChecks: make(map[string][]checkid.ID),
+		senderManager:  normalSenderManager,
+	}
+	s.addLoader(loader)
+
+	config := integration.Config{
+		Name:       "cpu",
+		Instances:  []integration.Data{integration.Data("name: first\n")},
+		InitConfig: integration.Data("{}"),
+	}
+
+	checks := s.GetChecksFromConfigs([]integration.Config{config}, true)
+
+	require.Len(t, checks, 1)
+	assert.False(t, check.IsShadow(checks[0]))
+	assert.Equal(t, []checkid.ID{checks[0].ID()}, s.configToChecks[config.Digest()])
+	require.Len(t, loader.calls, 1)
+	assert.Same(t, normalSenderManager, loader.calls[0].senderManager)
+}
+
 func TestGetChecksFromConfigsKeepsNormalCheckWhenShadowLoadFails(t *testing.T) {
 	cfg := configmock.New(t)
 	cfg.SetInTest("metric_lookback.enabled", true)

--- a/pkg/collector/scheduler_test.go
+++ b/pkg/collector/scheduler_test.go
@@ -6,9 +6,13 @@
 package collector
 
 import (
+	"bytes"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	collectorcomp "github.com/DataDog/datadog-agent/comp/collector/collector/def"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
@@ -16,6 +20,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/infratags"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
@@ -23,6 +29,7 @@ type MockCheck struct {
 	core.CheckBase
 	Name       string
 	LoaderName string
+	CheckID    checkid.ID
 }
 
 func (m MockCheck) Run() error {
@@ -36,6 +43,10 @@ func (m MockCheck) Loader() string {
 
 func (m MockCheck) String() string {
 	return m.Name
+}
+
+func (m MockCheck) ID() checkid.ID {
+	return m.CheckID
 }
 
 type MockCoreLoader struct{}
@@ -125,10 +136,200 @@ func TestGetChecksFromConfigs(t *testing.T) {
 	}, actualChecks)
 }
 
+func TestGetChecksFromConfigsLoadsSelectedShadowCheckWithSenderManagerOverride(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("metric_lookback.enabled", true)
+	cfg.SetInTest("metric_lookback.enabled_checks", []string{"cpu"})
+	cfg.SetInTest("infrastructure_mode", "cloud_cost_only")
+
+	normalSenderManager := &recordingSchedulerSenderManager{name: "normal"}
+	shadowSenderManager := &recordingSchedulerSenderManager{name: "shadow"}
+	sourceID := checkid.ID("cpu:loaded-source-id")
+	loader := &recordingSchedulerLoader{name: "core", normalCheckID: sourceID}
+	s := CheckScheduler{
+		configToChecks:      make(map[string][]checkid.ID),
+		senderManager:       normalSenderManager,
+		shadowSenderManager: shadowSenderManager,
+		infraTagger:         infratags.NewTagger(cfg),
+	}
+	s.addLoader(loader)
+
+	config := integration.Config{
+		Name:       "cpu",
+		Instances:  []integration.Data{integration.Data("name: first\n")},
+		InitConfig: integration.Data("{}"),
+	}
+
+	checks := s.GetChecksFromConfigs([]integration.Config{config}, true)
+
+	require.Len(t, checks, 2)
+	normalCheck := checks[0]
+	shadowCheck := checks[1]
+	assert.False(t, check.IsShadow(normalCheck))
+	require.True(t, check.IsShadow(shadowCheck))
+
+	assert.Equal(t, sourceID, normalCheck.ID())
+	assert.Equal(t, check.ShadowID(sourceID), shadowCheck.ID())
+	assert.Equal(t, time.Second, shadowCheck.Interval())
+
+	shadowSenderOverride, ok := check.SenderManagerOverride(shadowCheck)
+	require.True(t, ok)
+	shadowSenderOverrideAdapter, ok := shadowSenderOverride.(shadowCheckSenderManager)
+	require.True(t, ok)
+	assert.Same(t, shadowSenderManager, shadowSenderOverrideAdapter.SenderManager)
+
+	assert.Equal(t, []checkid.ID{sourceID, check.ShadowID(sourceID)}, s.configToChecks[config.Digest()])
+	require.Len(t, loader.calls, 2)
+	assert.Same(t, normalSenderManager, loader.calls[0].senderManager)
+	shadowLoadSenderManager, ok := loader.calls[1].senderManager.(shadowCheckSenderManager)
+	require.True(t, ok)
+	assert.Same(t, shadowSenderManager, shadowLoadSenderManager.SenderManager)
+	assert.NotContains(t, string(loader.calls[0].instance), "_datadog")
+	assert.Contains(t, string(loader.calls[1].instance), "_datadog")
+	assert.Contains(t, string(loader.calls[1].instance), "execution_mode")
+	assert.NotEqual(t, check.ShadowID(sourceID), loader.calls[1].checkID)
+	assert.Equal(t, []checkid.ID{sourceID, sourceID}, normalSenderManager.requestedIDs)
+	assert.Equal(t, []checkid.ID{sourceID}, normalSenderManager.infraTaggedIDs)
+	assert.Equal(t, []checkid.ID{check.ShadowID(sourceID), check.ShadowID(sourceID)}, shadowSenderManager.requestedIDs)
+	assert.Equal(t, []checkid.ID{check.ShadowID(sourceID)}, shadowSenderManager.infraTaggedIDs)
+}
+
+func TestGetChecksFromConfigsDoesNotLoadShadowChecksWhenCacheIsNotPopulated(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("metric_lookback.enabled", true)
+	cfg.SetInTest("metric_lookback.enabled_checks", []string{"cpu"})
+
+	normalSenderManager := &recordingSchedulerSenderManager{name: "normal"}
+	shadowSenderManager := &recordingSchedulerSenderManager{name: "shadow"}
+	loader := &recordingSchedulerLoader{name: "core"}
+	s := CheckScheduler{
+		configToChecks:      make(map[string][]checkid.ID),
+		senderManager:       normalSenderManager,
+		shadowSenderManager: shadowSenderManager,
+	}
+	s.addLoader(loader)
+
+	config := integration.Config{
+		Name:       "cpu",
+		Instances:  []integration.Data{integration.Data("name: first\n")},
+		InitConfig: integration.Data("{}"),
+	}
+
+	checks := s.GetChecksFromConfigs([]integration.Config{config}, false)
+
+	require.Len(t, checks, 1)
+	assert.False(t, check.IsShadow(checks[0]))
+	assert.Empty(t, s.configToChecks)
+	require.Len(t, loader.calls, 1)
+	assert.Same(t, normalSenderManager, loader.calls[0].senderManager)
+	assert.Empty(t, shadowSenderManager.requestedIDs)
+}
+
+func TestGetChecksFromConfigsKeepsNormalCheckWhenShadowLoadFails(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("metric_lookback.enabled", true)
+	cfg.SetInTest("metric_lookback.enabled_checks", []string{"cpu"})
+
+	normalSenderManager := &recordingSchedulerSenderManager{name: "normal"}
+	shadowSenderManager := &recordingSchedulerSenderManager{name: "shadow"}
+	loader := &recordingSchedulerLoader{name: "core", failShadowLoad: true}
+	s := CheckScheduler{
+		configToChecks:      make(map[string][]checkid.ID),
+		senderManager:       normalSenderManager,
+		shadowSenderManager: shadowSenderManager,
+	}
+	s.addLoader(loader)
+
+	config := integration.Config{
+		Name:       "cpu",
+		Instances:  []integration.Data{integration.Data("name: first\n")},
+		InitConfig: integration.Data("{}"),
+	}
+
+	checks := s.GetChecksFromConfigs([]integration.Config{config}, true)
+
+	require.Len(t, checks, 1)
+	assert.False(t, check.IsShadow(checks[0]))
+	assert.Equal(t, []checkid.ID{checks[0].ID()}, s.configToChecks[config.Digest()])
+	assert.Len(t, loader.calls, 2)
+	assert.Equal(t, []checkid.ID{check.ShadowID(checks[0].ID())}, shadowSenderManager.destroyedIDs)
+}
+
 // MockCollector is a mock implementation of collectorcomp.Component for testing
 type MockCollector struct {
 	RunCheckCalls []check.Check // Track which checks were run
 	RunCheckError error         // Error to return from RunCheck
+}
+
+type schedulerLoadCall struct {
+	senderManager sender.SenderManager
+	config        integration.Config
+	instance      integration.Data
+	instanceIndex int
+	checkID       checkid.ID
+}
+
+type recordingSchedulerLoader struct {
+	name           string
+	normalCheckID  checkid.ID
+	failShadowLoad bool
+	calls          []schedulerLoadCall
+}
+
+func (l *recordingSchedulerLoader) Name() string {
+	return l.name
+}
+
+func (l *recordingSchedulerLoader) Load(senderManager sender.SenderManager, config integration.Config, instance integration.Data, instanceIndex int) (check.Check, error) {
+	checkID := checkid.BuildID(config.Name, config.FastDigest(), instance, config.InitConfig)
+	if l.normalCheckID != "" && !bytes.Contains(instance, []byte("_datadog")) {
+		checkID = l.normalCheckID
+	}
+	l.calls = append(l.calls, schedulerLoadCall{
+		senderManager: senderManager,
+		config:        config,
+		instance:      append(integration.Data(nil), instance...),
+		instanceIndex: instanceIndex,
+		checkID:       checkID,
+	})
+	if l.failShadowLoad && bytes.Contains(instance, []byte("_datadog")) {
+		return nil, errors.New("shadow load failed")
+	}
+	if _, err := senderManager.GetSender(checkID); err != nil {
+		return nil, err
+	}
+	return &MockCheck{
+		Name:       config.Name,
+		LoaderName: l.Name(),
+		CheckID:    checkID,
+	}, nil
+}
+
+type recordingSchedulerSenderManager struct {
+	sender.SenderManager
+	name           string
+	requestedIDs   []checkid.ID
+	destroyedIDs   []checkid.ID
+	infraTaggedIDs []checkid.ID
+}
+
+func (m *recordingSchedulerSenderManager) GetSender(id checkid.ID) (sender.Sender, error) {
+	m.requestedIDs = append(m.requestedIDs, id)
+	return &recordingSchedulerSender{id: id, manager: m}, nil
+}
+
+func (m *recordingSchedulerSenderManager) DestroySender(id checkid.ID) {
+	m.destroyedIDs = append(m.destroyedIDs, id)
+}
+
+type recordingSchedulerSender struct {
+	sender.Sender
+	id      checkid.ID
+	manager *recordingSchedulerSenderManager
+}
+
+func (s *recordingSchedulerSender) SetInfraTagger(*infratags.Tagger) {
+	s.manager.infraTaggedIDs = append(s.manager.infraTaggedIDs, s.id)
 }
 
 func (m *MockCollector) RunCheck(c check.Check) (checkid.ID, error) {

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -9152,6 +9152,14 @@ properties:
     node_type: section
     type: object
     properties:
+      collection_interval:
+        node_type: setting
+        type: string
+        default: 1s
+        format: duration
+        tags:
+        - golang_type:duration
+        - full-agent-only:true
       enabled:
         node_type: setting
         type: boolean

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -36,6 +36,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 
 	config.BindEnvAndSetDefault("metric_lookback.enabled", false)
 	config.BindEnvAndSetDefault("metric_lookback.enabled_checks", []string{})
+	config.BindEnvAndSetDefault("metric_lookback.collection_interval", time.Second)
 
 	config.BindEnvAndSetDefault("host_aliases", []string{})
 	config.BindEnvAndSetDefault("collect_ccrid", true)

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -109,22 +109,26 @@ func TestMetricLookbackDefaults(t *testing.T) {
 
 	assert.False(t, config.GetBool("metric_lookback.enabled"))
 	assert.Empty(t, config.GetStringSlice("metric_lookback.enabled_checks"))
+	assert.Equal(t, time.Second, config.GetDuration("metric_lookback.collection_interval"))
 }
 
 func TestMetricLookbackEnvOverride(t *testing.T) {
 	t.Setenv("DD_METRIC_LOOKBACK_ENABLED", "true")
 	t.Setenv("DD_METRIC_LOOKBACK_ENABLED_CHECKS", `["cpu","disk"]`)
+	t.Setenv("DD_METRIC_LOOKBACK_COLLECTION_INTERVAL", "3s")
 
 	config := newTestConf(t)
 
 	assert.True(t, config.GetBool("metric_lookback.enabled"))
 	assert.Equal(t, []string{"cpu", "disk"}, config.GetStringSlice("metric_lookback.enabled_checks"))
+	assert.Equal(t, 3*time.Second, config.GetDuration("metric_lookback.collection_interval"))
 }
 
 func TestMetricLookbackYAML(t *testing.T) {
 	cfg := confFromYAML(t, `
 metric_lookback:
   enabled: true
+  collection_interval: 5s
   enabled_checks:
     - cpu
     - disk
@@ -132,6 +136,7 @@ metric_lookback:
 
 	assert.True(t, cfg.GetBool("metric_lookback.enabled"))
 	assert.Equal(t, []string{"cpu", "disk"}, cfg.GetStringSlice("metric_lookback.enabled_checks"))
+	assert.Equal(t, 5*time.Second, cfg.GetDuration("metric_lookback.collection_interval"))
 }
 
 func TestUnexpectedUnicode(t *testing.T) {

--- a/tasks/schema/fixes.py
+++ b/tasks/schema/fixes.py
@@ -200,6 +200,7 @@ full_agent_only_paths = [
     "metric_filterlist",
     "metric_filterlist_match_prefix",
     "metric_lookback",
+    "metric_lookback.collection_interval",
     "metric_lookback.enabled",
     "metric_lookback.enabled_checks",
     "metric_tag_filterlist",


### PR DESCRIPTION
### What does this PR do?

Loads metric lookback shadow checks through the shared check scheduler when `metric_lookback` selects a check instance.

- The scheduler loads the normal check first, then loads the selected shadow instance through the same loader with the lookback sender manager.
- Shadow checks are wrapped with source-check identity, the configured metric lookback collection interval, and the shadow sender manager used for cleanup.
- Shadow load failures clean up the shadow sender and leave normal check scheduling unaffected.
- The scheduler no longer creates a noop shadow sender fallback; if no real shadow sender manager is configured, shadow loading is skipped non-fatally while normal checks continue.
- Ad-hoc check loading paths such as `agent check` and local diagnose continue to load only normal checks.
- Adds `metric_lookback.collection_interval` / `DD_METRIC_LOOKBACK_COLLECTION_INTERVAL` for configuring the shadow collection cadence, with a default and minimum of `1s`.

```yaml
metric_lookback:
  enabled: true
  enabled_checks:
    - cpu
  collection_interval: 1s
```

### Motivation

This is part of the Metric Lookback shadow pipeline and covers [QB1HZ-20](https://datadoghq.atlassian.net/browse/QB1HZ-20) plus the sender lifecycle hook from [QB1HZ-19](https://datadoghq.atlassian.net/browse/QB1HZ-19).

Metric lookback should derive normal and shadow checks from the same AutoConfig event instead of using a separate shadow scheduler. The shadow copy still needs shadow-mode config metadata before load, but collector lifecycle should identify it as a deterministic sibling of the normal source check. Because the shadow metadata changes the loaded inner check ID, the wrapper stores the normal source check ID and exposes `<source-check-id>:shadow` for scheduling, status, and cleanup.

The collection interval is exposed as config so operators can tune the lookback shadow cadence without changing code. Values below `1s` fall back to the default because the scheduler rejects recurring check intervals below one second.

### Describe how you validated your changes

- Added unit tests for loading a selected shadow check beside the normal check.
- Added unit tests for keeping non-scheduling check loading paths normal-only.
- Added unit tests for preserving normal scheduling when shadow loading fails or no real shadow sender manager is configured.
- Added unit tests for shadow sender manager cleanup through the existing check wrapper cancellation path.
- Added unit tests for source-check identity and sender manager override behavior on shadow checks.
- Added unit tests for `metric_lookback.collection_interval` defaults, YAML/env overrides, and minimum interval handling.
- Regenerated the Agent config schema after adding the new config key.

```bash
dda inv test --targets=./pkg/collector --build-exclude=python
dda inv test --targets=./pkg/collector/metriclookback,./pkg/collector/scheduler
dda inv test --targets=./pkg/config/setup --build-exclude=python
dda inv linter.go --targets=./pkg/collector/metriclookback,./pkg/collector/scheduler --cpus=8 --timeout=20
bazel test //pkg/collector:collector_test_base //pkg/collector/check:check_test_base //pkg/collector/metriclookback:metriclookback_test_base //pkg/collector/metriclookback/lookbacksender:lookbacksender_test_base //pkg/config/setup:setup_test_base //comp/collector/collector/impl/internal/middleware:middleware_test
dda inv agent.build --build-exclude=systemd
dda inv -- schema.generate --agent-bin=./bin/agent/agent
git diff --check
```

### Additional Notes

Stacked on [#53148](https://github.com/DataDog/datadog-agent/pull/53148).

The retention-backed shadow sender manager is expected to be owned by metric lookback wiring/storage. This PR does not create a noop sender manager inside `CheckScheduler`, because that can make shadow checks appear to load while dropping samples.

Follow-up work is expected for Python check callback routing: Go checks use the loader-provided sender manager directly, while Python submissions cross the rtloader aggregator callback path and need separate sender-manager routing before Python shadow samples can land in the lookback buffer.


[QB1HZ-20]: https://datadoghq.atlassian.net/browse/QB1HZ-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ