### PR TITLE
[QB1HZ-21] Wire metric lookback shadow checks

### DIFF
--- a/comp/collector/collector/impl/collector.go
+++ b/comp/collector/collector/impl/collector.go
@@ -68,11 +68,10 @@ type collectorImpl struct {
 	healthPlatform healthplatform.Component
 	hostname       hostnameinterface.Component
 
-	senderManager        sender.SenderManager
-	metricSerializer     option.Option[serializer.MetricSerializer]
-	agentTelemetry       option.Option[agenttelemetry.Component]
-	checkInstances       int64
-	shadowCheckInstances int64
+	senderManager    sender.SenderManager
+	metricSerializer option.Option[serializer.MetricSerializer]
+	agentTelemetry   option.Option[agenttelemetry.Component]
+	checkInstances   int64
 
 	// state is 'started' or 'stopped'
 	state *atomic.Uint32
@@ -232,7 +231,6 @@ func (c *collectorImpl) RunCheck(inner check.Check) (checkid.ID, error) {
 
 	isShadowCheck := check.IsShadow(ch)
 	if isShadowCheck {
-		c.shadowCheckInstances++
 		c.log.Infof("Adding an extra runner for the '%s' shadow check", ch)
 		c.runner.AddShadowWorker()
 	} else if ch.Interval() == 0 {
@@ -303,22 +301,7 @@ func (c *collectorImpl) StopCheck(id checkid.ID) error {
 		return fmt.Errorf("an error occurred while calling check.Cancel(): %s", err)
 	}
 
-	c.decrementShadowCheckInstances(ch)
-
 	return nil
-}
-
-func (c *collectorImpl) decrementShadowCheckInstances(ch check.Check) {
-	if !check.IsShadow(ch) {
-		return
-	}
-
-	c.m.Lock()
-	defer c.m.Unlock()
-
-	if c.shadowCheckInstances > 0 {
-		c.shadowCheckInstances--
-	}
 }
 
 // cancelCheck calls Cancel on the passed check, with a timeout

--- a/comp/collector/collector/impl/collector.go
+++ b/comp/collector/collector/impl/collector.go
@@ -229,8 +229,7 @@ func (c *collectorImpl) RunCheck(inner check.Check) (checkid.ID, error) {
 		return emptyID, fmt.Errorf("unable to schedule the check: %s", err)
 	}
 
-	isShadowCheck := check.IsShadow(ch)
-	if isShadowCheck {
+	if check.IsShadow(ch) {
 		c.log.Infof("Adding an extra runner for the '%s' shadow check", ch)
 		c.runner.AddShadowWorker()
 	} else if ch.Interval() == 0 {

--- a/comp/collector/collector/impl/collector.go
+++ b/comp/collector/collector/impl/collector.go
@@ -214,13 +214,13 @@ func (c *collectorImpl) RunCheck(inner check.Check) (checkid.ID, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
+	ch := middleware.NewCheckWrapper(inner, c.senderManager, c.agentTelemetry, option.New[healthplatform.Component](c.healthPlatform))
+
 	var emptyID checkid.ID
 
 	if c.state.Load() != started {
 		return emptyID, errors.New("the collector is not running")
 	}
-
-	ch := middleware.NewCheckWrapper(inner, c.senderManager, c.agentTelemetry, option.New[healthplatform.Component](c.healthPlatform))
 
 	if _, found := c.checks[ch.ID()]; found {
 		return emptyID, fmt.Errorf("a check with ID %s is already running", ch.ID())
@@ -230,24 +230,23 @@ func (c *collectorImpl) RunCheck(inner check.Check) (checkid.ID, error) {
 		return emptyID, fmt.Errorf("unable to schedule the check: %s", err)
 	}
 
-	// Track the total number of checks running in order to have an appropriate number of workers
-	checkInstances := &c.checkInstances
 	isShadowCheck := check.IsShadow(ch)
 	if isShadowCheck {
-		checkInstances = &c.shadowCheckInstances
-	}
-	*checkInstances = *checkInstances + 1
-	if isShadowCheck {
+		c.shadowCheckInstances++
 		c.log.Infof("Adding an extra runner for the '%s' shadow check", ch)
 		c.runner.AddShadowWorker()
 	} else if ch.Interval() == 0 {
+		// Track the total number of checks running in order to have an appropriate number of workers
+		c.checkInstances++
 		// Adding a temporary runner for long running check in case the
 		// number of runners is lower than the number of long running
 		// checks.
 		c.log.Infof("Adding an extra runner for the '%s' long running check", ch)
 		c.runner.AddWorker()
 	} else {
-		c.runner.UpdateNumWorkers(*checkInstances)
+		// Track the total number of checks running in order to have an appropriate number of workers
+		c.checkInstances++
+		c.runner.UpdateNumWorkers(c.checkInstances)
 	}
 
 	c.checks[ch.ID()] = ch

--- a/comp/collector/collector/impl/collector.go
+++ b/comp/collector/collector/impl/collector.go
@@ -68,18 +68,22 @@ type collectorImpl struct {
 	healthPlatform healthplatform.Component
 	hostname       hostnameinterface.Component
 
-	senderManager    sender.SenderManager
-	metricSerializer option.Option[serializer.MetricSerializer]
-	agentTelemetry   option.Option[agenttelemetry.Component]
-	checkInstances   int64
+	senderManager        sender.SenderManager
+	metricSerializer     option.Option[serializer.MetricSerializer]
+	agentTelemetry       option.Option[agenttelemetry.Component]
+	checkInstances       int64
+	shadowCheckInstances int64
 
 	// state is 'started' or 'stopped'
 	state *atomic.Uint32
 
-	scheduler      *scheduler.Scheduler
-	runner         *runner.Runner
-	checks         map[checkid.ID]*middleware.CheckWrapper
-	eventReceivers []collector.EventReceiver
+	scheduler           *scheduler.Scheduler
+	runner              *runner.Runner
+	shadowScheduler     *scheduler.Scheduler
+	shadowRunner        *runner.Runner
+	shadowSenderManager sender.SenderManager
+	checks              map[checkid.ID]*middleware.CheckWrapper
+	eventReceivers      []collector.EventReceiver
 
 	cancelCheckTimeout     time.Duration
 	watchdogWarningTimeout time.Duration
@@ -204,6 +208,14 @@ func (c *collectorImpl) stop(_ context.Context) error {
 		c.runner.Stop()
 		c.runner = nil
 	}
+	if c.shadowScheduler != nil {
+		_ = c.shadowScheduler.Stop()
+		c.shadowScheduler = nil
+	}
+	if c.shadowRunner != nil {
+		c.shadowRunner.Stop()
+		c.shadowRunner = nil
+	}
 	c.state.Store(stopped)
 	return nil
 }
@@ -213,42 +225,71 @@ func (c *collectorImpl) RunCheck(inner check.Check) (checkid.ID, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	ch := middleware.NewCheckWrapper(inner, c.senderManager, c.agentTelemetry, option.New[healthplatform.Component](c.healthPlatform))
-
 	var emptyID checkid.ID
 
 	if c.state.Load() != started {
 		return emptyID, errors.New("the collector is not running")
 	}
 
+	sched, run, senderManager := c.ensureRouteForCheck(inner)
+	ch := middleware.NewCheckWrapper(inner, senderManager, c.agentTelemetry, option.New[healthplatform.Component](c.healthPlatform))
+
 	if _, found := c.checks[ch.ID()]; found {
 		return emptyID, fmt.Errorf("a check with ID %s is already running", ch.ID())
 	}
 
-	if err := c.scheduler.Enter(ch); err != nil {
+	if err := sched.Enter(ch); err != nil {
 		return emptyID, fmt.Errorf("unable to schedule the check: %s", err)
 	}
 
+	// Track the total number of checks running in order to have an appropriate number of workers
+	checkInstances := &c.checkInstances
 	if check.IsShadow(ch) {
-		c.log.Infof("Adding an extra runner for the '%s' shadow check", ch)
-		c.runner.AddShadowWorker()
-	} else if ch.Interval() == 0 {
-		// Track the total number of checks running in order to have an appropriate number of workers
-		c.checkInstances++
+		checkInstances = &c.shadowCheckInstances
+	}
+	*checkInstances = *checkInstances + 1
+	if ch.Interval() == 0 {
 		// Adding a temporary runner for long running check in case the
 		// number of runners is lower than the number of long running
 		// checks.
 		c.log.Infof("Adding an extra runner for the '%s' long running check", ch)
-		c.runner.AddWorker()
+		run.AddWorker()
 	} else {
-		// Track the total number of checks running in order to have an appropriate number of workers
-		c.checkInstances++
-		c.runner.UpdateNumWorkers(c.checkInstances)
+		run.UpdateNumWorkers(*checkInstances)
 	}
 
 	c.checks[ch.ID()] = ch
 	c.notify(ch.ID(), collector.CheckRun)
 	return ch.ID(), nil
+}
+
+func (c *collectorImpl) routeForCheck(ch check.Check) (*scheduler.Scheduler, *runner.Runner, sender.SenderManager) {
+	if check.IsShadow(ch) {
+		return c.shadowScheduler, c.shadowRunner, c.shadowSenderManager
+	}
+	return c.scheduler, c.runner, c.senderManager
+}
+
+func (c *collectorImpl) ensureRouteForCheck(ch check.Check) (*scheduler.Scheduler, *runner.Runner, sender.SenderManager) {
+	if !check.IsShadow(ch) {
+		return c.scheduler, c.runner, c.senderManager
+	}
+	shadowSenderManager := c.senderManager
+	if override, ok := check.SenderManagerOverride(ch); ok {
+		shadowSenderManager = override
+	}
+	if c.shadowSenderManager == nil {
+		c.shadowSenderManager = shadowSenderManager
+	}
+	if c.shadowRunner == nil {
+		c.shadowRunner = runner.NewRunner(c.shadowSenderManager, c.haAgent, c.healthPlatform)
+	}
+	if c.shadowScheduler == nil {
+		c.shadowScheduler = scheduler.NewScheduler(c.shadowRunner.GetChan(), c.shadowRunner.GetShadowChan())
+		c.shadowRunner.SetScheduler(c.shadowScheduler)
+		c.shadowScheduler.Run()
+	}
+	return c.shadowScheduler, c.shadowRunner, c.shadowSenderManager
 }
 
 // StopCheck halts a check and remove the instance
@@ -272,8 +313,7 @@ func (c *collectorImpl) StopCheck(id checkid.ID) error {
 	}
 
 	// These two are not nil because we checked that the collector is started
-	collectorScheduler = c.scheduler
-	collectorRunner = c.runner
+	collectorScheduler, collectorRunner, _ = c.routeForCheck(ch)
 	c.m.RUnlock()
 
 	// unschedule the instance
@@ -302,7 +342,24 @@ func (c *collectorImpl) StopCheck(id checkid.ID) error {
 		return fmt.Errorf("an error occurred while calling check.Cancel(): %s", err)
 	}
 
+	c.decrementCheckInstances(ch)
+
 	return nil
+}
+
+func (c *collectorImpl) decrementCheckInstances(ch check.Check) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if check.IsShadow(ch) {
+		if c.shadowCheckInstances > 0 {
+			c.shadowCheckInstances--
+		}
+		return
+	}
+	if c.checkInstances > 0 {
+		c.checkInstances--
+	}
 }
 
 // cancelCheck calls Cancel on the passed check, with a timeout

--- a/comp/collector/collector/impl/collector.go
+++ b/comp/collector/collector/impl/collector.go
@@ -77,13 +77,10 @@ type collectorImpl struct {
 	// state is 'started' or 'stopped'
 	state *atomic.Uint32
 
-	scheduler           *scheduler.Scheduler
-	runner              *runner.Runner
-	shadowScheduler     *scheduler.Scheduler
-	shadowRunner        *runner.Runner
-	shadowSenderManager sender.SenderManager
-	checks              map[checkid.ID]*middleware.CheckWrapper
-	eventReceivers      []collector.EventReceiver
+	scheduler      *scheduler.Scheduler
+	runner         *runner.Runner
+	checks         map[checkid.ID]*middleware.CheckWrapper
+	eventReceivers []collector.EventReceiver
 
 	cancelCheckTimeout     time.Duration
 	watchdogWarningTimeout time.Duration
@@ -208,14 +205,6 @@ func (c *collectorImpl) stop(_ context.Context) error {
 		c.runner.Stop()
 		c.runner = nil
 	}
-	if c.shadowScheduler != nil {
-		_ = c.shadowScheduler.Stop()
-		c.shadowScheduler = nil
-	}
-	if c.shadowRunner != nil {
-		c.shadowRunner.Stop()
-		c.shadowRunner = nil
-	}
 	c.state.Store(stopped)
 	return nil
 }
@@ -231,31 +220,34 @@ func (c *collectorImpl) RunCheck(inner check.Check) (checkid.ID, error) {
 		return emptyID, errors.New("the collector is not running")
 	}
 
-	sched, run, senderManager := c.ensureRouteForCheck(inner)
-	ch := middleware.NewCheckWrapper(inner, senderManager, c.agentTelemetry, option.New[healthplatform.Component](c.healthPlatform))
+	ch := middleware.NewCheckWrapper(inner, c.senderManager, c.agentTelemetry, option.New[healthplatform.Component](c.healthPlatform))
 
 	if _, found := c.checks[ch.ID()]; found {
 		return emptyID, fmt.Errorf("a check with ID %s is already running", ch.ID())
 	}
 
-	if err := sched.Enter(ch); err != nil {
+	if err := c.scheduler.Enter(ch); err != nil {
 		return emptyID, fmt.Errorf("unable to schedule the check: %s", err)
 	}
 
 	// Track the total number of checks running in order to have an appropriate number of workers
 	checkInstances := &c.checkInstances
-	if check.IsShadow(ch) {
+	isShadowCheck := check.IsShadow(ch)
+	if isShadowCheck {
 		checkInstances = &c.shadowCheckInstances
 	}
 	*checkInstances = *checkInstances + 1
-	if ch.Interval() == 0 {
+	if isShadowCheck {
+		c.log.Infof("Adding an extra runner for the '%s' shadow check", ch)
+		c.runner.AddShadowWorker()
+	} else if ch.Interval() == 0 {
 		// Adding a temporary runner for long running check in case the
 		// number of runners is lower than the number of long running
 		// checks.
 		c.log.Infof("Adding an extra runner for the '%s' long running check", ch)
-		run.AddWorker()
+		c.runner.AddWorker()
 	} else {
-		run.UpdateNumWorkers(*checkInstances)
+		c.runner.UpdateNumWorkers(*checkInstances)
 	}
 
 	c.checks[ch.ID()] = ch
@@ -263,40 +255,9 @@ func (c *collectorImpl) RunCheck(inner check.Check) (checkid.ID, error) {
 	return ch.ID(), nil
 }
 
-func (c *collectorImpl) routeForCheck(ch check.Check) (*scheduler.Scheduler, *runner.Runner, sender.SenderManager) {
-	if check.IsShadow(ch) {
-		return c.shadowScheduler, c.shadowRunner, c.shadowSenderManager
-	}
-	return c.scheduler, c.runner, c.senderManager
-}
-
-func (c *collectorImpl) ensureRouteForCheck(ch check.Check) (*scheduler.Scheduler, *runner.Runner, sender.SenderManager) {
-	if !check.IsShadow(ch) {
-		return c.scheduler, c.runner, c.senderManager
-	}
-	shadowSenderManager := c.senderManager
-	if override, ok := check.SenderManagerOverride(ch); ok {
-		shadowSenderManager = override
-	}
-	if c.shadowSenderManager == nil {
-		c.shadowSenderManager = shadowSenderManager
-	}
-	if c.shadowRunner == nil {
-		c.shadowRunner = runner.NewRunner(c.shadowSenderManager, c.haAgent, c.healthPlatform)
-	}
-	if c.shadowScheduler == nil {
-		c.shadowScheduler = scheduler.NewScheduler(c.shadowRunner.GetChan(), c.shadowRunner.GetShadowChan())
-		c.shadowRunner.SetScheduler(c.shadowScheduler)
-		c.shadowScheduler.Run()
-	}
-	return c.shadowScheduler, c.shadowRunner, c.shadowSenderManager
-}
-
 // StopCheck halts a check and remove the instance
 func (c *collectorImpl) StopCheck(id checkid.ID) error {
 	var ch check.Check
-	var collectorScheduler *scheduler.Scheduler
-	var collectorRunner *runner.Runner
 
 	// This lock is needed because stop() can be called concurrently and sets
 	// c.runner and c.scheduler to nil
@@ -312,8 +273,9 @@ func (c *collectorImpl) StopCheck(id checkid.ID) error {
 		return fmt.Errorf("cannot find a check with ID %s", id)
 	}
 
-	// These two are not nil because we checked that the collector is started
-	collectorScheduler, collectorRunner, _ = c.routeForCheck(ch)
+	// These two are not nil because we checked that the collector is started.
+	collectorScheduler := c.scheduler
+	collectorRunner := c.runner
 	c.m.RUnlock()
 
 	// unschedule the instance
@@ -342,23 +304,21 @@ func (c *collectorImpl) StopCheck(id checkid.ID) error {
 		return fmt.Errorf("an error occurred while calling check.Cancel(): %s", err)
 	}
 
-	c.decrementCheckInstances(ch)
+	c.decrementShadowCheckInstances(ch)
 
 	return nil
 }
 
-func (c *collectorImpl) decrementCheckInstances(ch check.Check) {
+func (c *collectorImpl) decrementShadowCheckInstances(ch check.Check) {
+	if !check.IsShadow(ch) {
+		return
+	}
+
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	if check.IsShadow(ch) {
-		if c.shadowCheckInstances > 0 {
-			c.shadowCheckInstances--
-		}
-		return
-	}
-	if c.checkInstances > 0 {
-		c.checkInstances--
+	if c.shadowCheckInstances > 0 {
+		c.shadowCheckInstances--
 	}
 }
 

--- a/comp/collector/collector/impl/collector_test.go
+++ b/comp/collector/collector/impl/collector_test.go
@@ -175,7 +175,6 @@ func (suite *CollectorTestSuite) TestRunShadowCheckDoesNotIncrementNormalCheckIn
 	assert.NotNil(suite.T(), id)
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), int64(1), suite.c.checkInstances)
-	assert.Equal(suite.T(), int64(1), suite.c.shadowCheckInstances)
 }
 
 func (suite *CollectorTestSuite) TestRunShadowCheckUsesSchedulerShadowRoute() {
@@ -190,7 +189,6 @@ func (suite *CollectorTestSuite) TestRunShadowCheckUsesSchedulerShadowRoute() {
 	assert.True(suite.T(), check.IsShadow(suite.c.checks[id]))
 	assert.True(suite.T(), suite.c.scheduler.IsCheckScheduled(id))
 	assert.Equal(suite.T(), int64(0), suite.c.checkInstances)
-	assert.Equal(suite.T(), int64(1), suite.c.shadowCheckInstances)
 }
 
 func (suite *CollectorTestSuite) TestRunOneTimeShadowCheckStartsShadowWorker() {
@@ -222,7 +220,6 @@ func (suite *CollectorTestSuite) TestStopShadowCheckUsesShadowRoute() {
 	assert.Zero(suite.T(), len(suite.c.checks))
 	assert.False(suite.T(), suite.c.scheduler.IsCheckScheduled(id))
 	ch.AssertNumberOfCalls(suite.T(), "Cancel", 1)
-	assert.Equal(suite.T(), int64(0), suite.c.shadowCheckInstances)
 }
 
 func (suite *CollectorTestSuite) TestStopCheck() {

--- a/comp/collector/collector/impl/collector_test.go
+++ b/comp/collector/collector/impl/collector_test.go
@@ -120,6 +120,9 @@ func (suite *CollectorTestSuite) TearDownTest() {
 func (suite *CollectorTestSuite) TestNewCollector() {
 	assert.NotNil(suite.T(), suite.c.runner)
 	assert.NotNil(suite.T(), suite.c.scheduler)
+	assert.Nil(suite.T(), suite.c.shadowRunner)
+	assert.Nil(suite.T(), suite.c.shadowScheduler)
+	assert.Nil(suite.T(), suite.c.shadowSenderManager)
 	assert.Equal(suite.T(), started, suite.c.state.Load())
 }
 
@@ -160,6 +163,41 @@ func (suite *CollectorTestSuite) TestRunShadowCheckDoesNotIncrementNormalCheckIn
 	assert.NotNil(suite.T(), id)
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), int64(1), suite.c.checkInstances)
+	assert.Equal(suite.T(), int64(1), suite.c.shadowCheckInstances)
+}
+
+func (suite *CollectorTestSuite) TestRunShadowCheckUsesShadowRoute() {
+	ch := NewCheckUnique("lookback-source", "TestCheck")
+	shadowSenderManager := aggregator.NewNoOpSenderManager()
+	shadow := check.NewShadowCheckWithSenderManagerOverride(ch, time.Second, shadowSenderManager)
+
+	id, err := suite.c.RunCheck(shadow)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), checkid.ID("lookback-source:shadow"), id)
+	assert.Equal(suite.T(), 1, len(suite.c.checks))
+	assert.True(suite.T(), check.IsShadow(suite.c.checks[id]))
+	assert.NotNil(suite.T(), suite.c.shadowRunner)
+	assert.NotNil(suite.T(), suite.c.shadowScheduler)
+	assert.Equal(suite.T(), shadowSenderManager, suite.c.shadowSenderManager)
+	assert.True(suite.T(), suite.c.shadowScheduler.IsCheckScheduled(id))
+	assert.False(suite.T(), suite.c.scheduler.IsCheckScheduled(id))
+	assert.Equal(suite.T(), int64(0), suite.c.checkInstances)
+	assert.Equal(suite.T(), int64(1), suite.c.shadowCheckInstances)
+}
+
+func (suite *CollectorTestSuite) TestStopShadowCheckUsesShadowRoute() {
+	ch := NewCheckUnique("lookback-source", "TestCheck")
+	shadow := check.NewShadowCheck(ch, time.Second)
+
+	id, err := suite.c.RunCheck(shadow)
+	assert.NoError(suite.T(), err)
+
+	err = suite.c.StopCheck(id)
+	assert.NoError(suite.T(), err)
+	assert.Zero(suite.T(), len(suite.c.checks))
+	assert.False(suite.T(), suite.c.shadowScheduler.IsCheckScheduled(id))
+	ch.AssertNumberOfCalls(suite.T(), "Cancel", 1)
+	assert.Equal(suite.T(), int64(0), suite.c.shadowCheckInstances)
 }
 
 func (suite *CollectorTestSuite) TestStopCheck() {

--- a/comp/collector/collector/impl/collector_test.go
+++ b/comp/collector/collector/impl/collector_test.go
@@ -10,6 +10,7 @@ package collectorimpl
 import (
 	"context"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -41,12 +42,18 @@ type TestCheck struct {
 	uniqueID checkid.ID
 	name     string
 	stop     chan bool
+	started  chan struct{}
+	start    sync.Once
 }
 
 func (c *TestCheck) Stop()                   { c.stop <- true }
 func (c *TestCheck) Cancel()                 { c.Called() }
 func (c *TestCheck) Interval() time.Duration { return 1 * time.Minute }
-func (c *TestCheck) Run() error              { <-c.stop; return nil }
+func (c *TestCheck) Run() error {
+	c.start.Do(func() { close(c.started) })
+	<-c.stop
+	return nil
+}
 func (c *TestCheck) ID() checkid.ID {
 	if c.uniqueID != "" {
 		return c.uniqueID
@@ -63,7 +70,8 @@ func (c *TestCheck) String() string {
 
 func NewCheck() *TestCheck {
 	c := &TestCheck{
-		stop: make(chan bool),
+		stop:    make(chan bool),
+		started: make(chan struct{}),
 	}
 	c.On("Cancel").Maybe()
 	return c
@@ -78,11 +86,18 @@ func NewCheckUnique(id checkid.ID, name string) *TestCheck {
 
 func NewCheckSlowCancel(after time.Duration) *TestCheck {
 	c := &TestCheck{
-		stop: make(chan bool),
+		stop:    make(chan bool),
+		started: make(chan struct{}),
 	}
 	c.On("Cancel").After(after)
 	return c
 }
+
+type oneTimeTestCheck struct {
+	*TestCheck
+}
+
+func (c *oneTimeTestCheck) Interval() time.Duration { return 0 }
 
 // ChecksList is a sort.Interface so we can use the Sort function
 type ChecksList []checkid.ID
@@ -120,9 +135,6 @@ func (suite *CollectorTestSuite) TearDownTest() {
 func (suite *CollectorTestSuite) TestNewCollector() {
 	assert.NotNil(suite.T(), suite.c.runner)
 	assert.NotNil(suite.T(), suite.c.scheduler)
-	assert.Nil(suite.T(), suite.c.shadowRunner)
-	assert.Nil(suite.T(), suite.c.shadowScheduler)
-	assert.Nil(suite.T(), suite.c.shadowSenderManager)
 	assert.Equal(suite.T(), started, suite.c.state.Load())
 }
 
@@ -166,7 +178,7 @@ func (suite *CollectorTestSuite) TestRunShadowCheckDoesNotIncrementNormalCheckIn
 	assert.Equal(suite.T(), int64(1), suite.c.shadowCheckInstances)
 }
 
-func (suite *CollectorTestSuite) TestRunShadowCheckUsesShadowRoute() {
+func (suite *CollectorTestSuite) TestRunShadowCheckUsesSchedulerShadowRoute() {
 	ch := NewCheckUnique("lookback-source", "TestCheck")
 	shadowSenderManager := aggregator.NewNoOpSenderManager()
 	shadow := check.NewShadowCheckWithSenderManagerOverride(ch, time.Second, shadowSenderManager)
@@ -176,13 +188,26 @@ func (suite *CollectorTestSuite) TestRunShadowCheckUsesShadowRoute() {
 	assert.Equal(suite.T(), checkid.ID("lookback-source:shadow"), id)
 	assert.Equal(suite.T(), 1, len(suite.c.checks))
 	assert.True(suite.T(), check.IsShadow(suite.c.checks[id]))
-	assert.NotNil(suite.T(), suite.c.shadowRunner)
-	assert.NotNil(suite.T(), suite.c.shadowScheduler)
-	assert.Equal(suite.T(), shadowSenderManager, suite.c.shadowSenderManager)
-	assert.True(suite.T(), suite.c.shadowScheduler.IsCheckScheduled(id))
-	assert.False(suite.T(), suite.c.scheduler.IsCheckScheduled(id))
+	assert.True(suite.T(), suite.c.scheduler.IsCheckScheduled(id))
 	assert.Equal(suite.T(), int64(0), suite.c.checkInstances)
 	assert.Equal(suite.T(), int64(1), suite.c.shadowCheckInstances)
+}
+
+func (suite *CollectorTestSuite) TestRunOneTimeShadowCheckStartsShadowWorker() {
+	ch := &oneTimeTestCheck{TestCheck: NewCheckUnique("lookback-source", "TestCheck")}
+	shadow := check.NewShadowCheck(ch, 0)
+
+	id, err := suite.c.RunCheck(shadow)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), checkid.ID("lookback-source:shadow"), id)
+	select {
+	case <-ch.started:
+	case <-time.After(time.Second):
+		suite.T().Fatal("timed out waiting for shadow check to start")
+	}
+
+	err = suite.c.StopCheck(id)
+	assert.NoError(suite.T(), err)
 }
 
 func (suite *CollectorTestSuite) TestStopShadowCheckUsesShadowRoute() {
@@ -195,7 +220,7 @@ func (suite *CollectorTestSuite) TestStopShadowCheckUsesShadowRoute() {
 	err = suite.c.StopCheck(id)
 	assert.NoError(suite.T(), err)
 	assert.Zero(suite.T(), len(suite.c.checks))
-	assert.False(suite.T(), suite.c.shadowScheduler.IsCheckScheduled(id))
+	assert.False(suite.T(), suite.c.scheduler.IsCheckScheduled(id))
 	ch.AssertNumberOfCalls(suite.T(), "Cancel", 1)
 	assert.Equal(suite.T(), int64(0), suite.c.shadowCheckInstances)
 }

--- a/pkg/collector/BUILD.bazel
+++ b/pkg/collector/BUILD.bazel
@@ -46,6 +46,7 @@ dd_agent_go_test(
     deps = [
         "//comp/collector/collector/def",
         "//comp/core/autodiscovery/integration",
+        "//comp/logs/integrations/def",
         "//pkg/aggregator/sender",
         "//pkg/collector/check",
         "//pkg/collector/check/id",

--- a/pkg/collector/BUILD.bazel
+++ b/pkg/collector/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/collector/check/id",
         "//pkg/collector/loaders",
         "//pkg/collector/metriclookback",
+        "//pkg/collector/metriclookback/lookbacksender",
         "//pkg/config/model",
         "//pkg/config/setup",
         "//pkg/util/log",

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -7,7 +7,7 @@
 package collector
 
 import (
-	"errors"
+	"context"
 	"expvar"
 	"fmt"
 	"slices"
@@ -28,6 +28,7 @@ import (
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/DataDog/datadog-agent/pkg/collector/metriclookback"
+	"github.com/DataDog/datadog-agent/pkg/collector/metriclookback/lookbacksender"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/infratags"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -71,18 +72,23 @@ type CheckScheduler struct {
 	collector           option.Option[collectorcomp.Component]
 	senderManager       sender.SenderManager
 	shadowSenderManager sender.SenderManager
+	shadowSenderContext context.Context
+	shadowSenderCancel  context.CancelFunc
 	infraTagger         *infratags.Tagger // nil = no infra mode tagging
 	m                   sync.RWMutex
 }
 
 // InitCheckScheduler creates and returns a check scheduler
 func InitCheckScheduler(collector option.Option[collectorcomp.Component], senderManager sender.SenderManager, logReceiver option.Option[integrations.Component], tagger tagger.Component, filterStore filter.Component) *CheckScheduler {
+	shadowSenderContext, shadowSenderCancel := context.WithCancel(context.Background())
 	checkScheduler = &CheckScheduler{
-		collector:      collector,
-		senderManager:  senderManager,
-		configToChecks: make(map[string][]checkid.ID),
-		loaders:        make([]check.Loader, 0, len(loaders.LoaderCatalog(senderManager, logReceiver, tagger, filterStore))),
-		infraTagger:    infratags.NewTagger(setup.Datadog()),
+		collector:           collector,
+		senderManager:       senderManager,
+		shadowSenderContext: shadowSenderContext,
+		shadowSenderCancel:  shadowSenderCancel,
+		configToChecks:      make(map[string][]checkid.ID),
+		loaders:             make([]check.Loader, 0, len(loaders.LoaderCatalog(senderManager, logReceiver, tagger, filterStore))),
+		infraTagger:         infratags.NewTagger(setup.Datadog()),
 	}
 	// add the check loaders
 	for _, loader := range loaders.LoaderCatalog(senderManager, logReceiver, tagger, filterStore) {
@@ -162,8 +168,17 @@ func (s *CheckScheduler) Unschedule(configs []integration.Config) {
 	}
 }
 
-// Stop is a stub to satisfy the scheduler interface
-func (s *CheckScheduler) Stop() {}
+// Stop releases scheduler-owned resources.
+func (s *CheckScheduler) Stop() {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.shadowSenderCancel != nil {
+		s.shadowSenderCancel()
+		s.shadowSenderCancel = nil
+		s.shadowSenderContext = nil
+	}
+}
 
 // addLoader adds a new Loader that AutoConfig can use to load a check.
 func (s *CheckScheduler) addLoader(loader check.Loader) {
@@ -296,10 +311,18 @@ func (s *CheckScheduler) applyInfraTagger(senderManager sender.SenderManager, ch
 	chkSender.SetInfraTagger(s.infraTagger)
 }
 
+func (s *CheckScheduler) ensureShadowSenderContext() context.Context {
+	if s.shadowSenderContext == nil {
+		s.shadowSenderContext, s.shadowSenderCancel = context.WithCancel(context.Background())
+	}
+	return s.shadowSenderContext
+}
+
 func (s *CheckScheduler) loadShadowCheck(candidate metriclookback.ShadowCandidate, loader check.Loader, sourceCheckID checkid.ID) (check.Check, error) {
 	shadowSenderManager := s.shadowSenderManager
 	if shadowSenderManager == nil {
-		return nil, errors.New("metric lookback shadow sender manager is not configured")
+		shadowSenderManager = lookbacksender.NewSenderManager(s.ensureShadowSenderContext(), "", nil, nil)
+		s.shadowSenderManager = shadowSenderManager
 	}
 	shadowCheckID := check.ShadowID(sourceCheckID)
 	checkSenderManager := shadowCheckSenderManager{

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -80,15 +80,12 @@ type CheckScheduler struct {
 
 // InitCheckScheduler creates and returns a check scheduler
 func InitCheckScheduler(collector option.Option[collectorcomp.Component], senderManager sender.SenderManager, logReceiver option.Option[integrations.Component], tagger tagger.Component, filterStore filter.Component) *CheckScheduler {
-	shadowSenderContext, shadowSenderCancel := context.WithCancel(context.Background())
 	checkScheduler = &CheckScheduler{
-		collector:           collector,
-		senderManager:       senderManager,
-		shadowSenderContext: shadowSenderContext,
-		shadowSenderCancel:  shadowSenderCancel,
-		configToChecks:      make(map[string][]checkid.ID),
-		loaders:             make([]check.Loader, 0, len(loaders.LoaderCatalog(senderManager, logReceiver, tagger, filterStore))),
-		infraTagger:         infratags.NewTagger(setup.Datadog()),
+		collector:      collector,
+		senderManager:  senderManager,
+		configToChecks: make(map[string][]checkid.ID),
+		loaders:        make([]check.Loader, 0, len(loaders.LoaderCatalog(senderManager, logReceiver, tagger, filterStore))),
+		infraTagger:    infratags.NewTagger(setup.Datadog()),
 	}
 	// add the check loaders
 	for _, loader := range loaders.LoaderCatalog(senderManager, logReceiver, tagger, filterStore) {

--- a/pkg/collector/scheduler_test.go
+++ b/pkg/collector/scheduler_test.go
@@ -17,6 +17,7 @@ import (
 
 	collectorcomp "github.com/DataDog/datadog-agent/comp/collector/collector/def"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
@@ -303,6 +304,19 @@ func TestStopCancelsShadowSenderContext(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for shadow sender context cancellation")
 	}
+}
+
+func TestInitCheckSchedulerDoesNotCreateShadowSenderContext(t *testing.T) {
+	s := InitCheckScheduler(
+		option.None[collectorcomp.Component](),
+		&recordingSchedulerSenderManager{},
+		option.None[integrations.Component](),
+		nil,
+		nil,
+	)
+
+	assert.Nil(t, s.shadowSenderContext)
+	assert.Nil(t, s.shadowSenderCancel)
 }
 
 // MockCollector is a mock implementation of collectorcomp.Component for testing

--- a/pkg/collector/scheduler_test.go
+++ b/pkg/collector/scheduler_test.go
@@ -7,6 +7,7 @@ package collector
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -225,7 +226,7 @@ func TestGetChecksFromConfigsDoesNotLoadShadowChecksWhenCacheIsNotPopulated(t *t
 	assert.Empty(t, shadowSenderManager.requestedIDs)
 }
 
-func TestGetChecksFromConfigsKeepsNormalCheckWhenShadowSenderManagerMissing(t *testing.T) {
+func TestGetChecksFromConfigsUsesFallbackShadowSenderManager(t *testing.T) {
 	cfg := configmock.New(t)
 	cfg.SetInTest("metric_lookback.enabled", true)
 	cfg.SetInTest("metric_lookback.enabled_checks", []string{"cpu"})
@@ -246,11 +247,18 @@ func TestGetChecksFromConfigsKeepsNormalCheckWhenShadowSenderManagerMissing(t *t
 
 	checks := s.GetChecksFromConfigs([]integration.Config{config}, true)
 
-	require.Len(t, checks, 1)
+	require.Len(t, checks, 2)
 	assert.False(t, check.IsShadow(checks[0]))
-	assert.Equal(t, []checkid.ID{checks[0].ID()}, s.configToChecks[config.Digest()])
-	require.Len(t, loader.calls, 1)
+	assert.True(t, check.IsShadow(checks[1]))
+	assert.Equal(t, []checkid.ID{checks[0].ID(), checks[1].ID()}, s.configToChecks[config.Digest()])
+	require.Len(t, loader.calls, 2)
 	assert.Same(t, normalSenderManager, loader.calls[0].senderManager)
+	assert.NotNil(t, s.shadowSenderManager)
+	assert.NotEqual(t, normalSenderManager, loader.calls[1].senderManager)
+	shadowCallSenderManager, ok := loader.calls[1].senderManager.(shadowCheckSenderManager)
+	require.True(t, ok)
+	assert.Equal(t, s.shadowSenderManager, shadowCallSenderManager.SenderManager)
+	assert.Equal(t, checks[1].ID(), shadowCallSenderManager.shadowCheckID)
 }
 
 func TestGetChecksFromConfigsKeepsNormalCheckWhenShadowLoadFails(t *testing.T) {
@@ -281,6 +289,20 @@ func TestGetChecksFromConfigsKeepsNormalCheckWhenShadowLoadFails(t *testing.T) {
 	assert.Equal(t, []checkid.ID{checks[0].ID()}, s.configToChecks[config.Digest()])
 	assert.Len(t, loader.calls, 2)
 	assert.Equal(t, []checkid.ID{check.ShadowID(checks[0].ID())}, shadowSenderManager.destroyedIDs)
+}
+
+func TestStopCancelsShadowSenderContext(t *testing.T) {
+	s := CheckScheduler{}
+	ctx := s.ensureShadowSenderContext()
+
+	s.Stop()
+
+	select {
+	case <-ctx.Done():
+		assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shadow sender context cancellation")
+	}
 }
 
 // MockCollector is a mock implementation of collectorcomp.Component for testing


### PR DESCRIPTION
### What does this PR do?

Adds Agent-side plumbing for metric lookback shadow checks when `metric_lookback.enabled` is enabled and a check is listed in `metric_lookback.enabled_checks`.

- Loads isolated shadow instances for eligible Go/core and Python checks, while skipping long-running checks.
- Schedules shadow checks through the existing scheduler/runner shadow lanes so they use shadow workers without changing normal check cadence or normal runner sizing.
- Routes shadow check sender traffic to the lookback sender path, so shadow samples do not publish through the normal aggregator/backend stream.
- Adds the active config surface used by this stack:

```yaml
metric_lookback:
  enabled: true
  interval: 1s
  enabled_checks:
    - system.cpu
```

### Motivation

This is part of [QB1HZ-21](https://datadoghq.atlassian.net/browse/QB1HZ-21), which adds the Agent execution plumbing needed for 1Hz metric lookback. The goal is to let selected node-level checks run on a faster shadow cadence without changing their normal collection cadence or backend payload stream.

### Describe how you validated your changes

- ✅ Added unit coverage for shadow check creation, disabled-policy behavior, Go/core and Python check shadowing, sender-manager override cleanup, fallback sender-manager lifecycle cancellation, shared scheduler shadow routing, and one-time shadow worker execution.
- ✅ Ran `dda inv test --targets=./pkg/collector/metriclookback`.
- ✅ Ran `dda inv test --targets=./pkg/collector`.
- ✅ Ran `dda inv test --targets=./comp/collector/collector/impl`.

### Additional Notes

The lookback sender intentionally writes to a no-op tap in this PR instead of publishing shadow samples to the normal Agent pipeline. Durable local storage/query behavior is deferred to follow-up storage/WAL work.

Shadow checks share the collector scheduler and runner with normal checks. The scheduler already maintains separate normal and shadow queues, and the runner maintains separate normal and shadow workers; this PR wires metric lookback into those existing shadow lanes instead of introducing a second scheduler or runner.

Only config keys consumed by this stack are exposed: `metric_lookback.enabled`, `metric_lookback.interval`, and `metric_lookback.enabled_checks`.


[QB1HZ-21]: https://datadoghq.atlassian.net/browse/QB1HZ-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ