### PR TITLE
[DOIO-123] Consolidate data-jobs-monitoring team into data-observability

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -629,7 +629,7 @@
 /pkg/flare/*_windows.go                 @DataDog/windows-products @DataDog/agent-configuration
 /pkg/flare/*_windows_test.go            @DataDog/windows-products @DataDog/agent-configuration
 /pkg/fleet/                             @DataDog/fleet @DataDog/windows-products
-/pkg/fleet/installer/setup/djm/         @DataDog/fleet @DataDog/data-jobs-monitoring
+/pkg/fleet/installer/setup/djm/         @DataDog/fleet @DataDog/data-observability
 /pkg/inventory/                         @DataDog/windows-products
 /pkg/inventory/software/                @DataDog/windows-products
 /pkg/inventory/systeminfo/              @DataDog/windows-products
@@ -953,7 +953,7 @@
 /test/new-e2e/tests/ssi-gradual-rollout       @DataDog/apm-release-platform
 /test/new-e2e/tests/fleet                     @DataDog/fleet @DataDog/windows-products
 /test/new-e2e/tests/installer                 @DataDog/fleet @DataDog/windows-products
-/test/new-e2e/tests/installer/script          @DataDog/fleet @DataDog/data-jobs-monitoring
+/test/new-e2e/tests/installer/script          @DataDog/fleet @DataDog/data-observability
 /test/new-e2e/tests/sbom                      @DataDog/agent-security
 # windows-products primary owner for windows tests so we get failure notifications
 /test/new-e2e/tests/installer/windows         @DataDog/windows-products @DataDog/fleet

--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -223,13 +223,6 @@
   review:
     name: '#aaa-authn'
     id: 'C02S3STU39N'
-'@datadog/data-jobs-monitoring':
-  notification:
-    name: ''
-    id: ''
-  review:
-    name: '#data-jobs-monitoring'
-    id: 'C05DAN6ULF6'
 '@datadog/data-observability':
   notification:
     name: '#data-observability-ops'


### PR DESCRIPTION
Linear: DOIO-125

## Summary

DJM and DO frontend GitHub teams were merged into a single team, `data-observability`. This follows up the same consolidation already merged in `web-ui`, applied here to `datadog-agent`.

Replaces `@DataDog/data-jobs-monitoring` with `@DataDog/data-observability` across `.github/CODEOWNERS`, keeping `@DataDog/fleet` as co-owner on both lines.

## Test plan

- [ ] CI passes
- [ ] Diff reviewed against expected team ownership mapping