### PR TITLE
[PROF-15317] add seccomp logging

### DIFF
--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -288,6 +288,7 @@ docker_build_base_image_arm64:
     - cp bin/host-profiler/host-profiler $BUILD_CONTEXT/
     - cp cmd/host-profiler/dist/host-profiler-config.yaml $BUILD_CONTEXT/
     - cp cmd/host-profiler/deploy/seccomp-profile.json $BUILD_CONTEXT/
+    - "jq '. + {flags: [\"SECCOMP_FILTER_FLAG_LOG\"]}' cmd/host-profiler/deploy/seccomp-profile.json > $BUILD_CONTEXT/logging-seccomp.json"
     - ls -l $BUILD_CONTEXT/
   rules:
     - when: on_success

--- a/Dockerfiles/ddot-ebpf/Dockerfile
+++ b/Dockerfiles/ddot-ebpf/Dockerfile
@@ -41,6 +41,7 @@ LABEL org.opencontainers.image.title="DDOT Ebpf"
 COPY --from=builder /workspace/datadog-agent/bin/host-profiler/host-profiler /opt/datadog-agent/embedded/bin/host-profiler
 COPY --from=builder /workspace/datadog-agent/bin/host-profiler/dist/host-profiler-config.yaml /etc/datadog-agent/host-profiler-config.yaml
 COPY seccomp-profile.json /etc/dd-host-profiler/seccomp.json
+COPY logging-seccomp.json /etc/dd-host-profiler/logging-seccomp.json
 # Find all directories and files in /etc with world-writable permissions and remove write permissions for group and others
 RUN find /etc -type d,f -perm -o+w -print0 | xargs -r -0 chmod g-w,o-w
 # Prefer reliable Ubuntu mirrors in CI to reduce transient network failures


### PR DESCRIPTION
### What does this PR do?

Add a CI job step to dynamically create a logging seccomp profile in the image.

### Motivation

Monitor and catch seccomp denials more easily.

### Describe how you validated your changes

Deployed on rel-env and experimented with
https://ddstaging.datadoghq.com/dashboard/fxx-848-yzq?fromUser=true&refresh_mode=sliding&tpl_var_host%5B0%5D=%2A&from_ts=1783078256326&to_ts=1783079156326&live=true
These denials are expected as only `nightly` contains https://github.com/DataDog/datadog-agent/pull/53146

### Additional Notes

Some of these widgets should probably be included in our dashboard.
Only nightly clusters will log seccomp warning, if we want observability over the preview image, this PR should be added and image bumped.
Right now we're having all rel env deployments log denials because of https://github.com/DataDog/datadog-reliability-env/pull/1323/changes/b064333f98e45eeb5518e087d5ee1977bedf65ea
