### PR TITLE
fix(autodiscovery): don't report not-ready services as health issues

### DIFF
--- a/comp/core/autodiscovery/configresolver/configresolver.go
+++ b/comp/core/autodiscovery/configresolver/configresolver.go
@@ -21,6 +21,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/tmplvar"
 )
 
+// ErrServiceNotReady is transient: the service isn't ready yet and the config
+// will resolve on a later reconcile. Callers must not treat it as a misconfiguration.
+var ErrServiceNotReady = errors.New("unable to resolve, service not ready")
+
 // SubstituteTemplateEnvVars replaces %%ENV_VARIABLE%% from environment
 // variables in the config init, instances, and logs config.
 // When there is an error, it continues replacing. When there are multiple
@@ -59,7 +63,7 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 	}
 
 	if resolvedConfig.IsCheckConfig() && !svc.IsReady() {
-		return resolvedConfig, errors.New("unable to resolve, service not ready")
+		return resolvedConfig, ErrServiceNotReady
 	}
 
 	var tags []string

--- a/comp/core/autodiscovery/impl/configmgr.go
+++ b/comp/core/autodiscovery/impl/configmgr.go
@@ -6,6 +6,7 @@
 package autodiscoveryimpl
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"sync"
@@ -465,6 +466,10 @@ func (cm *reconcilingConfigManager) resolveTemplateForService(tpl integration.Co
 	digest := tpl.Digest()
 	config, err := configresolver.Resolve(tpl, svc)
 	if err != nil {
+		if errors.Is(err, configresolver.ErrServiceNotReady) {
+			log.Debugf("autodiscovery: config for %s not resolved yet, service %s not ready", tpl.Name, svc.GetServiceID())
+			return tpl, false
+		}
 		msg := fmt.Sprintf("error resolving template %s for service %s: %v", tpl.Name, svc.GetServiceID(), err)
 		log.Errorf("autodiscovery: skipping config - %s", msg)
 		errorStats.setResolveWarning(tpl.Name, msg)

--- a/comp/core/autodiscovery/impl/configmgr_discovery.go
+++ b/comp/core/autodiscovery/impl/configmgr_discovery.go
@@ -8,6 +8,8 @@
 package autodiscoveryimpl
 
 import (
+	"errors"
+
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/configresolver"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/discoverer"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
@@ -123,6 +125,10 @@ func (cm *reconcilingConfigManager) applyDiscoveredConfigsLocked(svcID, tplDiges
 
 	resolved, err := configresolver.Resolve(merged, svcAndADIDs.svc)
 	if err != nil {
+		if errors.Is(err, configresolver.ErrServiceNotReady) {
+			log.Debugf("autodiscovery: discovered config %s for service %s not resolved yet, service not ready", merged.Name, svcID)
+			return changes
+		}
 		log.Errorf("error resolving discovered config %s for service %s: %v", merged.Name, svcID, err)
 		errorStats.setResolveWarning(tpl.Name, err.Error())
 		return changes

--- a/comp/core/autodiscovery/impl/configmgr_test.go
+++ b/comp/core/autodiscovery/impl/configmgr_test.go
@@ -735,3 +735,34 @@ func TestResolveTemplateForService_ClearsHealthPlatformOnSuccess(t *testing.T) {
 	count, _ = hp.GetAllIssues()
 	assert.Equal(t, 0, count, "health issue should be cleared after successful resolution")
 }
+
+func TestResolveTemplateForService_SkipsReportWhenServiceNotReady(t *testing.T) {
+	mockResolver := MockSecretResolver{}
+	hp := healthplatformmock.Mock(t)
+
+	cm := newReconcilingConfigManager(&mockResolver, hp, nil, nil, nil).(*reconcilingConfigManager)
+
+	tpl := integration.Config{
+		Name:          "postgres",
+		ADIdentifiers: []string{"postgres"},
+		Instances:     []integration.Data{integration.Data("host: %%host%%")},
+	}
+
+	svc := &notReadyService{dummyService{
+		ID:            "docker://abc123",
+		ADIdentifiers: []string{"postgres"},
+	}}
+
+	_, ok := cm.resolveTemplateForService(tpl, svc)
+	assert.False(t, ok, "a not-ready service must not resolve")
+
+	count, _ := hp.GetAllIssues()
+	assert.Equal(t, 0, count, "transient 'service not ready' must not be reported as a health issue")
+}
+
+// notReadyService exercises the transient configresolver.ErrServiceNotReady path.
+type notReadyService struct {
+	dummyService
+}
+
+func (notReadyService) IsReady() bool { return false }


### PR DESCRIPTION
### What does this PR do?

Stops the transient autodiscovery `service not ready` condition from being reported as an "Autodiscovery Misconfiguration" health-platform issue.

`configresolver.Resolve` returns `service not ready` when a check template is resolved against a container whose pod isn't `Ready` yet — a startup race that resolves itself on the next reconcile, not a misconfiguration. `resolveTemplateForService` was forwarding *every* resolution error to the health platform (and logging at ERROR), so this transient race was reported as a MEDIUM misconfiguration.

Change:
- Export the transient error as `configresolver.ErrServiceNotReady`.
- In `resolveTemplateForService`, short-circuit on `errors.Is(err, ErrServiceNotReady)`: log at DEBUG and skip both the resolve-warning and the health-platform report. Genuine resolution errors are unchanged; the config still schedules once the service is `Ready`.
- Apply the same guard in the Config Discovery resolve path (`configmgr_discovery.go`, `python` build): **log-only change** — the transient goes ERROR→DEBUG. This path never touched the health platform, so there is no health-platform behavior change here (only the main path reports issues).

Behavior note: not-ready services no longer surface a resolve-warning in `agent status` / `agent configcheck`. The condition is transient and self-heals once the pod is `Ready`; genuine resolution errors still surface as before.

### Motivation

Across the fleet, `service not ready` accounts for ~100% of the Autodiscovery misconfiguration health signal (~10M reports/day), concentrated on ephemeral/batch workloads (Spark jobs, CI runners, synthetics, short-lived pods). It buries the genuinely misconfigured entities and, now that the health platform is enabled by default, surfaces as noise in Fleet Automation on upgrade.

### Describe how you validated your changes

**Unit + lint** (devcontainer):
- `dda inv test --targets=./comp/core/autodiscovery/configresolver` → 43/43 pass
- `dda inv test --targets=./comp/core/autodiscovery/impl` → all pass; existing `TestResolveTemplateForService_ReportsToHealthPlatform` and `…ClearsHealthPlatformOnSuccess` unchanged (genuine resolution errors and the resolve→clear lifecycle still behave correctly)
- `dda inv linter.go` on both packages → 0 issues
- Added regression test `TestResolveTemplateForService_SkipsReportWhenServiceNotReady` (not-ready service → `ok == false`, **0** health issues) — impl 55/55 with it.

**End-to-end on Kubernetes** (minikube + Datadog operator; node agent & cluster-agent images built from this branch; `logLevel: debug`; redis workload with a `redisdb` AD check):
- Node agent 3/3, cluster-agent and cluster-checks-runner Running; `redisdb` autodiscovered and resolved — no regression.
- The transient not-ready now takes the new DEBUG path (`configmgr.go`: `config for … not resolved yet, service … not ready`); **0** occurrences of the old ERROR-level `unable to resolve, service not ready`.
- **0** `Autodiscovery Misconfiguration` / `Template Resolution Error` health issues created for the transient.
- A genuine annotation misconfiguration on the workload (an unresolvable `%%env_…%%` tag) was still correctly reported via the untouched `reportConfigurationError` path — confirming the change is surgical: the false positive is suppressed while real misconfigurations still surface.

### Additional Notes

- No release note yet (intentional) — a reno note or `changelog/no-changelog` label is required before merge.
- Targets `main`; intended for backport to `7.81.x` (7.81 is the first release with `health_platform.enabled` defaulting on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
