### PR TITLE
Replace the sysconfigdata based on install_dir during build

### DIFF
--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -297,6 +297,8 @@ configure_make(
         # and removing the sandbox path from the paths recorded in them.
         'install COMPILEALL_OPTS="--invalidation-mode checked-hash -s $$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$"',
     ],
+    # $(INSTALL_DIR) is the make-variable provided by //:install_dir.
+    toolchains = ["@@//:install_dir"],
     target_compatible_with = select({
         "@platforms//os:macos": [],
         "@platforms//os:linux": [],
@@ -311,7 +313,7 @@ configure_make(
     # sandbox paths with their install-prefix-relative equivalents.
     postfix_script = """
     $(execpath @python_3_12//:python3) $(execpath @@//deps/cpython:fix_sysconfigdata.py) \
-      --install-prefix "##PREFIX##" \
+      --install-prefix "$(INSTALL_DIR)/embedded" \
       --sandbox-prefix "$$BUILD_TMPDIR/$$INSTALL_PREFIX" \
       $$INSTALLDIR/lib/python{version}/_sysconfigdata__*.py
     rm -f $$INSTALLDIR/lib/python{version}/config-*/Makefile

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -13,12 +13,4 @@ build do
 
   command "bazel run #{flavor_flag} --//:install_dir=#{install_dir} -- @cpython//:install --destdir=#{install_dir}",
       :live_stream => Omnibus.logger.live_stream(:info)
-
-  if !windows_target?
-    # Libraries and binaries are rpath-patched by dd_cc_packaged in cpython.BUILD.bazel;
-    # this call is now only for the ##PREFIX## text substitution in _sysconfigdata.
-    command "bazel run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
-      " #{install_dir}/embedded/lib/python3.*/_sysconfigdata__*.py",
-      :live_stream => Omnibus.logger.live_stream(:info)
-  end
 end


### PR DESCRIPTION
### What does this PR do?

It moves the replacement of Python sysconfigdata with the correct references to the install_dir from a runnable after-the-build action to the build itself, making it part of the Python build itself.

### Motivation

We want to get rid of the `replace_prefix` rule that runs after the build. This also eliminates an extra bazel invocation during bazel builds (which can take a minute in macos) and further eats at omnibus code.

### Describe how you validated your changes

Passing and working builds, and manually confirming that sysconfigdata still looks correct.

### Additional Notes

This makes the cpython build be "contaminated" with `install_dir` (in terms of caching impact), which is something we probably want to avoid. However, openssl already depends on it and thus contaminates the build graph, so there is no actual practical impact the way the build is implemented today. Implementing a generic way of replacing these values closer to the edge of the packaging graph is probably the future work needed to make this ultimately right.

The short-term alternative would've required a lot of contortion or a full extra copy of the python lib folder just to do this replacement. Therefore the proposed implementation looks like the right compromise at this point.

_Note: I checked the size delta reported by SQGs and it seems to come from ebpf artifact size variation, sysconfidata actually remains identical._