### PR TITLE
add gpu-monitoring-agent to JIRA mappings

### DIFF
--- a/tasks/libs/pipeline/github_jira_map.yaml
+++ b/tasks/libs/pipeline/github_jira_map.yaml
@@ -58,3 +58,4 @@
 '@datadog/agent-health': AGTHEAL
 '@datadog/profiling-full-host': 'PROF'
 '@datadog/q-branch': DEFAULT_JIRA_PROJECT
+'@datadog/gpu-monitoring-agent': EBPF


### PR DESCRIPTION
### What does this PR do?

Adds the gpu-monitoring-agent Github team to the JIRA mappings

### Motivation

Fix failing CI checks

### Describe how you validated your changes

CI passing

### Additional Notes
