### PR TITLE
Replace remote cache config overrides with explicit selection

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,11 @@ common --experimental_proto_descriptor_sets_include_source_info # Preserve comme
 common --experimental_strict_repo_env # Do not leak uncontrolled environment variables into repository rules
 common --experimental_ui_max_stdouterr_bytes=1073741819 # why?
 common --http_timeout_scaling=3.0 # At least one attempt reaches 30s (3,6,12,24,30,30,30,30) instead of only 10s (1,2,4,8,10,10,10,10)
+common --incompatible_remote_local_fallback_for_remote_cache # works only if --remote_local_fallback is also set
+common --remote_instance_name=ci/datadog-agent # entries missing from datadog-agent will be searched in remote-caching
+common --remote_local_fallback # best-effort on transient connection errors (no such host)
+common --remote_retries=1
+common --remote_timeout=60
 common --repo_env=DEPLOY_AGENT # Keep in sync with env_vars in MODULE.bazel
 common --repo_env=FORCED_PACKAGE_COMPRESSION_LEVEL # Keep in sync with env_vars in MODULE.bazel
 common --repo_env=GOCACHE # https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
@@ -81,25 +86,17 @@ common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
 common:windows --extra_toolchains=@rust_toolchains//:rw-2070622084
 
 # Remote cache config --------------------------------------------------------------------------------------------------
-# datadog-agent virtually isolates caching instance from its parent (which is remote-caching).
-# If entry isn't found in datadog-agent, it will be searched in remote-caching.
-common:cache --remote_cache=grpcs://buildbarn-frontend-datadog-agent.us1.ddbuild.io:443
-common:cache --remote_instance_name=ci/datadog-agent
-common:cache --remote_local_fallback # best-effort on transient connection errors (no such host)
-common:cache --incompatible_remote_local_fallback_for_remote_cache # works only if --remote_local_fallback is also set
-common:cache --remote_retries=1
-common:cache --remote_timeout=60
-# Don't upload to remote cache from developers machines. Reenabled for CI below
+# Available remote cache endpoints - only Linux CI runs in k8s and can reach the in-cluster edge cache
+common:cache:edge --remote_cache=grpc://buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog:443
+common:cache:frontend --remote_cache=grpcs://buildbarn-frontend-datadog-agent.us1.ddbuild.io:443
+
+# Developer cache config, kept as `--config=cache` for backward compatibility
+common:cache --config=cache:frontend
 common:cache --noremote_upload_local_results
 
 # CI config ------------------------------------------------------------------------------------------------------------
 common:ci --config=adms
-common:ci --config=cache
-common:ci --remote_upload_local_results
 common:ci --config=lint
-# Opt-in override: only Linux CI runs in k8s and can reach the in-cluster edge cache.
-# tools/bazel adds `--config=ci-edge-cache` when `uname -s = Linux`.
-common:ci-edge-cache --remote_cache=grpc://buildbarn-edge-cache.buildbarn.local-cluster.local-dc.fabric.dog:443
 common:ci --noexperimental_convenience_symlinks # not CI-suitable: "These symlinks are only for the user's convenience"
 
 # Project/Language configs --------------------------------------------------------------------------------------

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -339,8 +339,8 @@
         "usagesDigest": "CKsn1dtme4oztWA0td45Tt6oCZK6MZnpIocVVZK14sU=",
         "recordedInputs": [
           "FILE:@@//.bazelversion 7b6188c072705b1c51d6ccdedea92238feb4199b75c58b321c5b632d981b0aba",
-          "FILE:@@//tools/bazel 8cd8e05bc6563f0ec312c10447f63c0d984f3bee34418ee07490e007f3ebfc3f",
-          "FILE:@@//tools/bazel.bat 44c2cabd3fb22bd06abf1eb64f11b8eacd046190b221edb1d2cd9aa9922df319",
+          "FILE:@@//tools/bazel 690073a0ab1e62a71c0acbe7eb9312b9a5937951759be4c0f457d97fa7e992e4",
+          "FILE:@@//tools/bazel.bat 9ead9c74fdd6e8200f38c5b68b1f0caae77d6e15b0434fc42043ce87ae41ec7b",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
         ],
         "generatedRepoSpecs": {}

--- a/tools/bazel
+++ b/tools/bazel
@@ -32,9 +32,15 @@ if [ -n "${XDG_CACHE_HOME-}" ]; then
   extra_args+=(--disk_cache="$XDG_CACHE_HOME/bazel/disk-cache")
   # https://github.com/bazelbuild/bazel/issues/26384
   [ "$XDG_CACHE_HOME" = "$(dirname "$(dirname "$0")")/.cache" ] && extra_args+=(--repo_contents_cache=)
-  [ -n "${CI-}" ] && [ -z "${GITHUB_ACTIONS-}" ] && extra_args+=(--config=ci)
-  # Edge cache is only reachable from inside the k8s cluster (Linux CI runners).
-  [ -n "${CI-}" ] && [ -z "${GITHUB_ACTIONS-}" ] && [ "$(uname -s)" = Linux ] && extra_args+=(--config=ci-edge-cache)
+  if [ -n "${CI-}" ] && [ -z "${GITHUB_ACTIONS-}" ]; then
+    extra_args+=(--config=ci)
+    # Edge cache is only reachable from inside the k8s cluster (Linux CI runners).
+    if [ "$(uname -s)" = Linux ]; then
+      extra_args+=(--config=cache:edge)
+    else
+      extra_args+=(--config=cache:frontend)
+    fi
+  fi
 else
   # Without `XDG_CACHE_HOME`, fall back Go caches to official defaults so Go repo rules work under strict repo_env
   [ -z "${GOCACHE-}" ] && export GOCACHE=~/.cache/go-build

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -40,7 +40,7 @@ if defined XDG_CACHE_HOME (
   set extra_args="--disk_cache=!bazel_home!\disk-cache"
   :: https://github.com/bazelbuild/bazel/issues/26384
   for %%i in ("%~dp0..\.cache") do if "!XDG_CACHE_HOME!" == "%%~fi" set "extra_args=!extra_args! --repo_contents_cache="
-  if defined CI if not defined GITHUB_ACTIONS set "extra_args=!extra_args! --config=ci"
+  if defined CI if not defined GITHUB_ACTIONS set "extra_args=!extra_args! --config=ci --config=cache:frontend"
 ) else (
   :: Without XDG_CACHE_HOME, fall back Go caches to official defaults so Go repo rules work under strict repo_env
   if not defined GOCACHE set "GOCACHE=%LOCALAPPDATA%\go-build"


### PR DESCRIPTION
### What does this PR do?

Restructure the Bazel remote cache config so each execution context (developer, CI/Linux, CI/macOS, CI/Windows) selects:
1. at most one remote upload flag, `true` (the default) or `false` (through `--noremote_upload_local_result`),
2. at most one named remote cache config, `cache:edge` or `cache:frontend`.

... instead of layering overrides.

### Motivation

The previous setup applied `common:ci --config=cache` (frontend URL, upload disabled) unconditionally, then overrode it a second time in two independent ways:
1. `--remote_upload_local_results` re-enabled uploads,
2. `tools/bazel` conditionally appended `--config=ci-edge-cache` on Linux to swap the endpoint to edge.

Correctness for both the resolved endpoint and whether uploads happened depended on Bazel's flag precedence rule (last flag _should_ win) rather than on an explicit choice, making both outcomes seemingly unpredictable and leading to [warnings in CI](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1828210972#L85):
```
Starting local Bazel server (9.1.1) and connecting to it...
WARNING: option '--remote_upload_local_results' was expanded from both option '--config=ci' (source command line options) and option '--config=ci' (source command line options)
WARNING: option '--remote_cache' was expanded from both option '--config=ci' (source command line options) and option '--config=ci-edge-cache' (source command line options)
```

Remote cache endpoint:

| Context | Before | After | Resolved endpoint |
|---|---|---|---|
| Developer | `--config=cache` sets `--remote_cache` to frontend directly | `--config=cache` aliases `--config=cache:frontend` | frontend (unchanged) |
| CI / Linux | `--config=ci` (frontend by default) + `--config=ci-edge-cache` overriding `--remote_cache`, relying on last-flag-wins | `--config=ci --config=cache:edge`, a single explicit choice | edge (unchanged) |
| CI / macOS | `--config=ci` only, frontend by default, no override ever applies | `--config=ci --config=cache:frontend`, explicit | frontend (unchanged) |
| CI / Windows | `--config=ci` only, frontend by default, no override mechanism existed | `--config=ci --config=cache:frontend`, explicit | frontend (unchanged) |

Upload of local results:

| Context | Before | After |
|---|---|---|
| Developer | `--config=cache` sets `--noremote_upload_local_results` directly | unchanged |
| CI | `--config=cache` disables upload, then `--remote_upload_local_results` two lines later re-enables it, an override | nothing sets it; relies on Bazel's own default (`true`), no flag needed |

This is a behavior-preserving refactor: the resolved outcome is identical in every case for both dimensions.

Only Linux CI's endpoint, and every CI platform's upload flag, actually depended on override/flag-ordering semantics before and now every context makes a single, explicit selection for each.

Each context now resolves to exactly one of:

| Context | Config(s) applied | Remote cache endpoint | Upload local results |
|---|---|---|---|
| Developer | `--config=cache` (aliases `cache:frontend`) | frontend (`buildbarn-frontend-datadog-agent`) | disabled |
| CI / Linux | `--config=ci --config=cache:edge` | edge (in-cluster `buildbarn-edge-cache`) | enabled |
| CI / macOS | `--config=ci --config=cache:frontend` | frontend | enabled |
| CI / Windows | `--config=ci --config=cache:frontend` | frontend | enabled |

GitHub Actions CI still gets no cache config at all, unchanged from before (`tools/bazel`/`tools/bazel.bat` skip `--config=ci` whenever `GITHUB_ACTIONS` is set).

### Describe how you validated your changes

Traced the config resolution for each of the four contexts above, for both the cache endpoint and the upload flag, by reading `.bazelrc` and both `tools/bazel` wrapper scripts side by side, and confirmed neither `--remote_cache` nor the upload flag is set by more than one active `--config` for any given context.
Grepped the repo for the retired `ci-edge-cache` config name to confirm no dangling references remain.

### Additional Notes

> [!NOTE]
> Settings shared by both endpoints (`remote_instance_name`, `remote_local_fallback`, `remote_retries`, `remote_timeout`) moved from `common:cache` to unconditional `common`, since they are no-ops without `--remote_cache` set and this decouples them from whichever of `cache:edge`/`cache:frontend` ends up selected.

