### PR TITLE
[WP] Support capabilities monitoring on kernels >= 6.14

### DIFF
--- a/pkg/security/ebpf/c/include/constants/offsets/process.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/process.h
@@ -39,4 +39,16 @@ u64 __attribute__((always_inline)) get_task_struct_pid_offset() {
     return task_struct_pid_offset;
 }
 
+u64 __attribute__((always_inline)) get_task_struct_cred_offset() {
+    u64 task_struct_cred_offset;
+    LOAD_CONSTANT("task_struct_cred_offset", task_struct_cred_offset);
+    return task_struct_cred_offset;
+}
+
+u64 __attribute__((always_inline)) get_task_struct_real_cred_offset() {
+    u64 task_struct_real_cred_offset;
+    LOAD_CONSTANT("task_struct_real_cred_offset", task_struct_real_cred_offset);
+    return task_struct_real_cred_offset;
+}
+
 #endif

--- a/pkg/security/ebpf/c/include/hooks/caps.h
+++ b/pkg/security/ebpf/c/include/hooks/caps.h
@@ -1,56 +1,33 @@
 #ifndef _HOOKS_CAPS_H_
 #define _HOOKS_CAPS_H_
 
-HOOK_ENTRY("override_creds")
-int hook_override_creds(ctx_t *ctx) {
-    u64 tgid_tid = bpf_get_current_pid_tgid();
-    u32 tid = (u32)tgid_tid;
+// Since kernel 6.13, override_creds/revert_creds are static inline and can no longer be hooked to
+// track whether we are running under temporarily overridden credentials. Instead we detect it
+// directly: override_creds only swaps current->cred and leaves current->real_cred untouched, so
+// cred != real_cred exactly while an override is in effect (commit_creds sets both, so they are
+// otherwise equal).
+static __attribute__((always_inline)) int is_in_creds_override() {
+    void *task = (void *)bpf_get_current_task();
 
-    struct capabilities_context_t *cap_context = bpf_map_lookup_elem(&capabilities_contexts, &tid);
-    if (!cap_context) {
-        struct capabilities_context_t new_context = {
-            .cap_as_mask = 0, // No capabilities checked yet
-            .override_creds_depth = 1, // We are entering an override_creds context
-        };
-        bpf_map_update_elem(&capabilities_contexts, &tid, &new_context, BPF_ANY);
-    } else {
-        cap_context->override_creds_depth++;
-    }
+    void *cred = NULL;
+    bpf_probe_read(&cred, sizeof(cred), (char *)task + get_task_struct_cred_offset());
 
-    return 0;
-}
+    void *real_cred = NULL;
+    bpf_probe_read(&real_cred, sizeof(real_cred), (char *)task + get_task_struct_real_cred_offset());
 
-HOOK_ENTRY("revert_creds")
-int hook_revert_creds(ctx_t *ctx) {
-    u64 tgid_tid = bpf_get_current_pid_tgid();
-    u32 tid = (u32)tgid_tid;
-
-    struct capabilities_context_t *cap_context = bpf_map_lookup_elem(&capabilities_contexts, &tid);
-    if (!cap_context) {
-        // unexpected but we handle it gracefully
-        return 0;
-    }
-
-    if (cap_context->override_creds_depth > 0) {
-        cap_context->override_creds_depth--;
-        if (cap_context->override_creds_depth == 0) {
-            // If we reached zero, we can remove the context
-            bpf_map_delete_elem(&capabilities_contexts, &tid);
-        }
-    }
-
-    return 0;
+    return cred != real_cred;
 }
 
 HOOK_ENTRY("security_capable")
 int hook_security_capable(ctx_t *ctx) {
+    if (is_in_creds_override()) {
+        // do not track capabilities checked under temporarily overridden credentials
+        return 0;
+    }
+
     u64 tgid_tid = bpf_get_current_pid_tgid();
     u32 tid = (u32)tgid_tid;
     struct capabilities_context_t *cap_context = bpf_map_lookup_elem(&capabilities_contexts, &tid);
-    if (cap_context && cap_context->override_creds_depth != 0) {
-        // do not track capabilities in override_creds context
-        return 0;
-    }
 
     u64 cap = CTX_PARM3(ctx); // The capability being checked
 
@@ -95,7 +72,6 @@ int hook_security_capable(ctx_t *ctx) {
         // If no context exists, we create a new one
         struct capabilities_context_t new_context = {
             .cap_as_mask = cap_as_mask,
-            .override_creds_depth = 0, // Not in an override_creds context
         };
         bpf_map_update_elem(&capabilities_contexts, &tid, &new_context, BPF_ANY);
     }
@@ -113,8 +89,8 @@ int rethook_security_capable(ctx_t *ctx) {
         return 0;
     }
 
-    if (cap_context->override_creds_depth != 0) {
-        // do not track capabilities in override_creds context
+    if (is_in_creds_override()) {
+        // do not track capabilities checked under temporarily overridden credentials
         return 0;
     }
 

--- a/pkg/security/ebpf/c/include/hooks/caps.h
+++ b/pkg/security/ebpf/c/include/hooks/caps.h
@@ -2,32 +2,84 @@
 #define _HOOKS_CAPS_H_
 
 // Since kernel 6.13, override_creds/revert_creds are static inline and can no longer be hooked to
-// track whether we are running under temporarily overridden credentials. Instead we detect it
-// directly: override_creds only swaps current->cred and leaves current->real_cred untouched, so
-// cred != real_cred exactly while an override is in effect (commit_creds sets both, so they are
-// otherwise equal).
+// track whether we are running under temporarily overridden credentials. On such kernels (which
+// always ship BTF) we detect it directly: override_creds only swaps current->cred and leaves
+// current->real_cred untouched, so cred != real_cred exactly while an override is in effect
+// (commit_creds sets both, so they are otherwise equal). This requires the task_struct cred/real_cred
+// offsets, which are only resolved through BTF; when they are unavailable the offsets are 0 and this
+// returns false, in which case the override_creds/revert_creds depth counter below is relied upon.
 static __attribute__((always_inline)) int is_in_creds_override() {
+    u64 cred_offset = get_task_struct_cred_offset();
+    u64 real_cred_offset = get_task_struct_real_cred_offset();
+    if (cred_offset == 0 || real_cred_offset == 0) {
+        return 0;
+    }
+
     void *task = (void *)bpf_get_current_task();
 
     void *cred = NULL;
-    bpf_probe_read(&cred, sizeof(cred), (char *)task + get_task_struct_cred_offset());
+    bpf_probe_read(&cred, sizeof(cred), (char *)task + cred_offset);
 
     void *real_cred = NULL;
-    bpf_probe_read(&real_cred, sizeof(real_cred), (char *)task + get_task_struct_real_cred_offset());
+    bpf_probe_read(&real_cred, sizeof(real_cred), (char *)task + real_cred_offset);
 
     return cred != real_cred;
 }
 
-HOOK_ENTRY("security_capable")
-int hook_security_capable(ctx_t *ctx) {
-    if (is_in_creds_override()) {
-        // do not track capabilities checked under temporarily overridden credentials
+// On kernels < 6.13, override_creds/revert_creds are still out-of-line and hookable. They maintain a
+// per-thread depth counter so that capability checks made under overridden credentials are skipped,
+// which also covers kernels without BTF where is_in_creds_override() cannot resolve the cred offsets.
+HOOK_ENTRY("override_creds")
+int hook_override_creds(ctx_t *ctx) {
+    u64 tgid_tid = bpf_get_current_pid_tgid();
+    u32 tid = (u32)tgid_tid;
+
+    struct capabilities_context_t *cap_context = bpf_map_lookup_elem(&capabilities_contexts, &tid);
+    if (!cap_context) {
+        struct capabilities_context_t new_context = {
+            .cap_as_mask = 0, // No capabilities checked yet
+            .override_creds_depth = 1, // We are entering an override_creds context
+        };
+        bpf_map_update_elem(&capabilities_contexts, &tid, &new_context, BPF_ANY);
+    } else {
+        cap_context->override_creds_depth++;
+    }
+
+    return 0;
+}
+
+HOOK_ENTRY("revert_creds")
+int hook_revert_creds(ctx_t *ctx) {
+    u64 tgid_tid = bpf_get_current_pid_tgid();
+    u32 tid = (u32)tgid_tid;
+
+    struct capabilities_context_t *cap_context = bpf_map_lookup_elem(&capabilities_contexts, &tid);
+    if (!cap_context) {
+        // unexpected but we handle it gracefully
         return 0;
     }
 
+    if (cap_context->override_creds_depth > 0) {
+        cap_context->override_creds_depth--;
+        if (cap_context->override_creds_depth == 0) {
+            // If we reached zero, we can remove the context
+            bpf_map_delete_elem(&capabilities_contexts, &tid);
+        }
+    }
+
+    return 0;
+}
+
+HOOK_ENTRY("security_capable")
+int hook_security_capable(ctx_t *ctx) {
     u64 tgid_tid = bpf_get_current_pid_tgid();
     u32 tid = (u32)tgid_tid;
     struct capabilities_context_t *cap_context = bpf_map_lookup_elem(&capabilities_contexts, &tid);
+
+    if (is_in_creds_override() || (cap_context && cap_context->override_creds_depth != 0)) {
+        // do not track capabilities checked under temporarily overridden credentials
+        return 0;
+    }
 
     u64 cap = CTX_PARM3(ctx); // The capability being checked
 
@@ -89,7 +141,7 @@ int rethook_security_capable(ctx_t *ctx) {
         return 0;
     }
 
-    if (is_in_creds_override()) {
+    if (is_in_creds_override() || cap_context->override_creds_depth != 0) {
         // do not track capabilities checked under temporarily overridden credentials
         return 0;
     }

--- a/pkg/security/ebpf/c/include/structs/caps.h
+++ b/pkg/security/ebpf/c/include/structs/caps.h
@@ -3,7 +3,6 @@
 
 struct capabilities_context_t {
     u64 cap_as_mask; // bitmask of capabilities that are being checked in the current task context
-    u64 override_creds_depth; // depth of override_creds calls, used to track if the capability checks are performed against user capabilities
 };
 
 struct capabilities_usage_t {

--- a/pkg/security/ebpf/c/include/structs/caps.h
+++ b/pkg/security/ebpf/c/include/structs/caps.h
@@ -3,6 +3,7 @@
 
 struct capabilities_context_t {
     u64 cap_as_mask; // bitmask of capabilities that are being checked in the current task context
+    u64 override_creds_depth; // depth of override_creds calls; used on kernels where override_creds/revert_creds are still hookable (< 6.13)
 };
 
 struct capabilities_usage_t {

--- a/pkg/security/ebpf/probes/capabilities.go
+++ b/pkg/security/ebpf/probes/capabilities.go
@@ -30,18 +30,6 @@ func getCapabilitiesMonitoringProbes() []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "hook_override_creds",
-			},
-		},
-		{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				UID:          SecurityAgentUID,
-				EBPFFuncName: "hook_revert_creds",
-			},
-		},
-		{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				UID:          SecurityAgentUID,
 				EBPFFuncName: "capabilities_usage_ticker",
 			},
 			SampleFrequency:   1,
@@ -57,8 +45,6 @@ func GetCapabilitiesMonitoringProgramFunctions() []string {
 	return []string{
 		"hook_security_capable",
 		"rethook_security_capable",
-		"hook_override_creds",
-		"hook_revert_creds",
 		"capabilities_usage_ticker",
 	}
 }

--- a/pkg/security/ebpf/probes/capabilities.go
+++ b/pkg/security/ebpf/probes/capabilities.go
@@ -30,6 +30,18 @@ func getCapabilitiesMonitoringProbes() []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_override_creds",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_revert_creds",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
 				EBPFFuncName: "capabilities_usage_ticker",
 			},
 			SampleFrequency:   1,
@@ -45,6 +57,8 @@ func GetCapabilitiesMonitoringProgramFunctions() []string {
 	return []string{
 		"hook_security_capable",
 		"rethook_security_capable",
+		"hook_override_creds",
+		"hook_revert_creds",
 		"capabilities_usage_ticker",
 	}
 }

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -124,8 +124,6 @@ func GetCapabilitiesMonitoringSelectors() []manager.ProbesSelector {
 			Selectors: []manager.ProbesSelector{
 				hookFunc("hook_security_capable"),
 				hookFunc("rethook_security_capable"),
-				hookFunc("hook_override_creds"),
-				hookFunc("hook_revert_creds"),
 				&manager.ProbeSelector{
 					ProbeIdentificationPair: manager.ProbeIdentificationPair{
 						UID:          SecurityAgentUID,

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -130,6 +130,13 @@ func GetCapabilitiesMonitoringSelectors() []manager.ProbesSelector {
 						EBPFFuncName: "capabilities_usage_ticker",
 					},
 				},
+				// override_creds/revert_creds are inlined since kernel 6.13, so they are best-effort:
+				// where attachable (< 6.13, including kernels without BTF) they drive the override
+				// depth counter; on 6.13+ the cred/real_cred comparison is used instead
+				&manager.BestEffort{Selectors: []manager.ProbesSelector{
+					hookFunc("hook_override_creds"),
+					hookFunc("hook_revert_creds"),
+				}},
 			},
 		},
 	}

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -88,13 +88,15 @@ const (
 	OffsetNameBPFProgAuxStructName            = "bpf_prog_aux_name_offset"
 
 	// namespace nr offsets
-	OffsetNamePIDStructLevel    = "pid_level_offset"
-	OffsetNamePIDStructNumbers  = "pid_numbers_offset"
-	OffsetNameDentryStructDSB   = "dentry_sb_offset"
-	OffsetNameTaskStructPID     = "task_struct_pid_offset"      // kernels >= 4.19
-	OffsetNameTaskStructPIDLink = "task_struct_pid_link_offset" // kernels < 4.19
-	OffsetNamePIDLinkStructPID  = "pid_link_pid_offset"         // kernels < 4.19
-	OffsetNameTaskStructSignal  = "task_struct_signal_offset"
+	OffsetNamePIDStructLevel     = "pid_level_offset"
+	OffsetNamePIDStructNumbers   = "pid_numbers_offset"
+	OffsetNameDentryStructDSB    = "dentry_sb_offset"
+	OffsetNameTaskStructPID      = "task_struct_pid_offset"      // kernels >= 4.19
+	OffsetNameTaskStructPIDLink  = "task_struct_pid_link_offset" // kernels < 4.19
+	OffsetNamePIDLinkStructPID   = "pid_link_pid_offset"         // kernels < 4.19
+	OffsetNameTaskStructCred     = "task_struct_cred_offset"
+	OffsetNameTaskStructRealCred = "task_struct_real_cred_offset"
+	OffsetNameTaskStructSignal   = "task_struct_signal_offset"
 
 	// splice event
 	OffsetNamePipeInodeInfoStructBufs     = "pipe_inode_info_bufs_offset"

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3529,6 +3529,10 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameTTYStructStructName, "struct tty_struct", "name")
 	// since kernel 5.19, exit_itimers takes a struct task_struct* so we need the offset of its signal field
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameTaskStructSignal, "struct task_struct", "signal")
+	// since kernel 6.13, override_creds/revert_creds are inlined; we detect credential overrides by
+	// comparing task_struct->cred and task_struct->real_cred in the capabilities hooks
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameTaskStructCred, "struct task_struct", "cred")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameTaskStructRealCred, "struct task_struct", "real_cred")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameCredStructUID, "struct cred", "uid")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameCredStructCapInheritable, "struct cred", "cap_inheritable")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameLinuxBinprmP, "struct linux_binprm", "p")

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -88,10 +88,8 @@ func IsNetworkFlowMonitorNotSupported(kv *kernel.Version) bool {
 }
 
 // IsCapabilitiesMonitoringSupported returns if the capabilities monitoring feature is supported
-// override_creds/restore_creds kernel functions must not be inlined
-// https://github.com/torvalds/linux/commit/6771e004b40962402d0e973fc7d2e0e61364fdfb
 func IsCapabilitiesMonitoringSupported(kv *kernel.Version) bool {
-	return kv.HasBPFForEachMapElemHelper() && kv.Code != 0 && kv.Code < kernel.Kernel6_14
+	return kv.HasBPFForEachMapElemHelper() && kv.Code != 0
 }
 
 // NewAgentContainerContext returns the agent container context


### PR DESCRIPTION
### What does this PR do?

Since kernel 6.13/6.14 override_creds/revert_creds are static inline and can no longer be hooked, which forced capabilities monitoring to be disabled on recent kernels. Instead of hooking those functions to track credential-override windows, detect them directly in security_capable by comparing task_struct->cred and task_struct->real_cred: override_creds only swaps ->cred and leaves ->real_cred untouched, so they differ exactly while an override is in effect. This removes the override_creds/revert_creds hooks and re-enables the feature on all supported kernels.

### Motivation

Since kernel 6.13/6.14 override_creds/revert_creds are static inline and can no longer be hooked, which forced capabilities monitoring to be disabled on recent kernels.

### Describe how you validated your changes

### Additional Notes
