### PR TITLE
[WP] Handle attach_recursive_mnt pinned_mountpoint argument on recent kernels

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -489,11 +489,31 @@ int hook_attach_recursive_mnt(ctx_t *ctx) {
         return 0;
     }
 
+    struct mount *parent;
+    struct mountpoint *mp;
+
+    // Since kernel 6.18, attach_recursive_mnt takes (source_mnt, const struct pinned_mountpoint *dest)
+    // instead of (source_mnt, dest_mnt, dest_mp). When the pinned_mountpoint offsets are resolved,
+    // read the parent mount and the mountpoint from that struct; otherwise fall back to the legacy
+    // argument positions.
+    u64 pinned_mountpoint_parent_offset;
+    LOAD_CONSTANT("pinned_mountpoint_parent_offset", pinned_mountpoint_parent_offset);
+
+    if (pinned_mountpoint_parent_offset != -1) {
+        u64 pinned_mountpoint_mp_offset;
+        LOAD_CONSTANT("pinned_mountpoint_mp_offset", pinned_mountpoint_mp_offset);
+
+        void *dest = (void *)CTX_PARM2(ctx);
+        bpf_probe_read(&parent, sizeof(parent), (char *)dest + pinned_mountpoint_parent_offset);
+        bpf_probe_read(&mp, sizeof(mp), (char *)dest + pinned_mountpoint_mp_offset);
+    } else {
+        parent = (struct mount *)CTX_PARM2(ctx);
+        mp = (struct mountpoint *)CTX_PARM3(ctx);
+    }
+
     syscall->mount.newmnt = newmnt;
-    syscall->mount.parent = (struct mount *)CTX_PARM2(ctx);
-    struct mountpoint *mp = (struct mountpoint *)CTX_PARM3(ctx);
-    struct mount *topmnt = (struct mount *)CTX_PARM2(ctx);
-    syscall->mount.ns_inum = get_mount_mount_ns_inum(topmnt);
+    syscall->mount.parent = parent;
+    syscall->mount.ns_inum = get_mount_mount_ns_inum(parent);
     syscall->mount.mountpoint_dentry = get_mountpoint_dentry(mp);
 
     if (syscall->type != EVENT_MOUNT) {

--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -493,13 +493,16 @@ int hook_attach_recursive_mnt(ctx_t *ctx) {
     struct mountpoint *mp;
 
     // Since kernel 6.18, attach_recursive_mnt takes (source_mnt, const struct pinned_mountpoint *dest)
-    // instead of (source_mnt, dest_mnt, dest_mp). When the pinned_mountpoint offsets are resolved,
-    // read the parent mount and the mountpoint from that struct; otherwise fall back to the legacy
-    // argument positions.
+    // instead of (source_mnt, dest_mnt, dest_mp). On kernels without struct pinned_mountpoint the
+    // offset fetch fails and the constant is loaded as 0 (missing constants are rewritten to 0
+    // before being pushed to eBPF), so a non-zero parent offset means the new signature is in use:
+    // read the parent mount and the mountpoint from that struct. Otherwise fall back to the legacy
+    // argument positions. The parent field always follows the embedded hlist_node, so its offset is
+    // never legitimately 0.
     u64 pinned_mountpoint_parent_offset;
     LOAD_CONSTANT("pinned_mountpoint_parent_offset", pinned_mountpoint_parent_offset);
 
-    if (pinned_mountpoint_parent_offset != -1) {
+    if (pinned_mountpoint_parent_offset != 0) {
         u64 pinned_mountpoint_mp_offset;
         LOAD_CONSTANT("pinned_mountpoint_mp_offset", pinned_mountpoint_mp_offset);
 

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -113,6 +113,8 @@ var (
 	Kernel6_11 = kernel.VersionCode(6, 11, 0)
 	// Kernel6_14 is the KernelVersion representation of kernel version 6.14
 	Kernel6_14 = kernel.VersionCode(6, 14, 0)
+	// Kernel6_18 is the KernelVersion representation of kernel version 6.18
+	Kernel6_18 = kernel.VersionCode(6, 18, 0)
 )
 
 // Version defines a kernel version helper

--- a/pkg/security/probe/constantfetch/available.go
+++ b/pkg/security/probe/constantfetch/available.go
@@ -63,18 +63,28 @@ func getBTFFuncProto(funcName string) (*btf.FuncProto, error) {
 	return proto, nil
 }
 
-// GetHasUsernamespaceFirstArgWithBtf uses BTF to check if the security_inode_setattr function has a user namespace as its first argument
-func GetHasUsernamespaceFirstArgWithBtf() (bool, error) {
-	proto, err := getBTFFuncProto("security_inode_setattr")
+// HasAttachRecursiveMntPinnedMountpointArg uses BTF to check if the attach_recursive_mnt function has a pinned mountpoint as its second argument
+func HasAttachRecursiveMntPinnedMountpointArg() (bool, error) {
+	proto, err := getBTFFuncProto("attach_recursive_mnt")
 	if err != nil {
 		return false, err
 	}
 
-	if len(proto.Params) == 0 {
-		return false, errors.New("security_inode_setattr has no parameters")
+	if len(proto.Params) < 2 {
+		return false, errors.New("attach_recursive_mnt has less than 2 parameters")
 	}
 
-	return proto.Params[0].Name != "dentry", nil
+	pointer, ok := proto.Params[1].Type.(*btf.Pointer)
+	if !ok {
+		return false, errors.New("attach_recursive_mnt second parameter is not a pointer")
+	}
+
+	st, ok := pointer.Target.(*btf.Struct)
+	if !ok {
+		return false, errors.New("attach_recursive_mnt second parameter is not a pointer to a struct")
+	}
+
+	return st.Name == "pinned_mountpoint", nil
 }
 
 // GetExitItimersTakesTaskStructWithBtf uses BTF to check whether exit_itimers takes a
@@ -129,6 +139,24 @@ func GetBTFFunctionArgCount(funcName string) (int, error) {
 	}
 
 	return len(proto.Params), nil
+}
+
+// GetHasUsernamespaceFirstArgWithBtf uses BTF to check if the security_inode_setattr function has a user namespace as its first argument
+func GetHasUsernamespaceFirstArgWithBtf() (bool, error) {
+	proto, err := getBTFFuncProto("vfs_rename")
+	if err != nil {
+		return false, err
+	}
+
+	if len(proto.Params) == 0 {
+		return false, errors.New("vfs_rename has no parameters")
+	}
+
+	if len(proto.Params) == 1 && proto.Params[0].Name == "rd" {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // AreFentryTailCallsBroken checks if fentry tail calls are broken

--- a/pkg/security/probe/constantfetch/available_unsupported.go
+++ b/pkg/security/probe/constantfetch/available_unsupported.go
@@ -57,3 +57,8 @@ func GetBTFFunctionArgCount(_ string) (int, error) {
 func AreFentryTailCallsBroken() (bool, error) {
 	return false, errors.New("unsupported BTF request")
 }
+
+// HasAttachRecursiveMntPinnedMountpointArg not available
+func HasAttachRecursiveMntPinnedMountpointArg() (bool, error) {
+	return false, errors.New("unsupported BTF request")
+}

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -46,6 +46,8 @@ const (
 	OffsetNamePathMnt                   = "path_mnt_offset"
 	OffsetNameMountMntMountpoint        = "mount_mnt_mountpoint_offset"
 	OffsetNameMountpointDentry          = "mountpoint_dentry_offset"
+	OffsetNamePinnedMountpointMp        = "pinned_mountpoint_mp_offset"
+	OffsetNamePinnedMountpointParent    = "pinned_mountpoint_parent_offset"
 	OffsetNameVfsmountMntFlags          = "vfsmount_mnt_flags_offset"
 	OffsetNameVfsmountMntRoot           = "vfsmount_mnt_root_offset"
 	OffsetNameVfsmountMntSb             = "vfsmount_mnt_sb_offset"

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -91,6 +91,8 @@ func computeRawsTable() map[string]uint64 {
 		OffsetNameIoSocketStructDomain:            8,
 		OffsetNameIoSocketStructType:              12,
 		OffsetNameIoSocketStructProtocol:          16,
+		OffsetNamePinnedMountpointMp:              8,
+		OffsetNamePinnedMountpointParent:          16,
 		OffsetNameSocketType:                      4,
 	}
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3726,6 +3726,11 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameInodeSuperblock, "struct inode", "i_sb")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameMountMntMountpoint, "struct mount", "mnt_mountpoint")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameMountpointDentry, "struct mountpoint", "m_dentry")
+	// since kernel 6.18, attach_recursive_mnt takes a struct pinned_mountpoint* holding the parent
+	// mount and mountpoint; the offsets resolve to the sentinel on older kernels where the struct
+	// does not exist, in which case the hook falls back to the legacy argument positions
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNamePinnedMountpointMp, "struct pinned_mountpoint", "mp")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNamePinnedMountpointParent, "struct pinned_mountpoint", "parent")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVfsmountMntFlags, "struct vfsmount", "mnt_flags")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVfsmountMntRoot, "struct vfsmount", "mnt_root")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVfsmountMntSb, "struct vfsmount", "mnt_sb")

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3432,6 +3432,19 @@ func getHasUsernamespaceFirstArg(kernelVersion *kernel.Version) uint64 {
 	}
 }
 
+func hasPinnedMountpointStruct(kernelVersion *kernel.Version) bool {
+	if val, err := constantfetch.HasAttachRecursiveMntPinnedMountpointArg(); err == nil {
+		return val
+	}
+
+	switch {
+	case kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel6_18:
+		return true
+	default:
+		return false
+	}
+}
+
 func getVFSRenameRegisterArgsOrStruct(kernelVersion *kernel.Version) uint64 {
 	if val, err := constantfetch.GetHasVFSRenameStructArgs(); err == nil {
 		if val {
@@ -3726,11 +3739,15 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameInodeSuperblock, "struct inode", "i_sb")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameMountMntMountpoint, "struct mount", "mnt_mountpoint")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameMountpointDentry, "struct mountpoint", "m_dentry")
-	// since kernel 6.18, attach_recursive_mnt takes a struct pinned_mountpoint* holding the parent
-	// mount and mountpoint; the offsets resolve to the sentinel on older kernels where the struct
-	// does not exist, in which case the hook falls back to the legacy argument positions
-	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNamePinnedMountpointMp, "struct pinned_mountpoint", "mp")
-	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNamePinnedMountpointParent, "struct pinned_mountpoint", "parent")
+
+	if hasPinnedMountpointStruct(kv) {
+		// since kernel 6.18, attach_recursive_mnt takes a struct pinned_mountpoint* holding the parent
+		// mount and mountpoint; the offsets resolve to the sentinel on older kernels where the struct
+		// does not exist, in which case the hook falls back to the legacy argument positions
+		appendOffsetofRequest(constantFetcher, constantfetch.OffsetNamePinnedMountpointMp, "struct pinned_mountpoint", "mp")
+		appendOffsetofRequest(constantFetcher, constantfetch.OffsetNamePinnedMountpointParent, "struct pinned_mountpoint", "parent")
+	}
+
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVfsmountMntFlags, "struct vfsmount", "mnt_flags")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVfsmountMntRoot, "struct vfsmount", "mnt_root")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVfsmountMntSb, "struct vfsmount", "mnt_sb")


### PR DESCRIPTION
### What does this PR do?

Since kernel 6.18, attach_recursive_mnt takes (source_mnt, const struct pinned_mountpoint *dest) instead of (source_mnt, dest_mnt, dest_mp), so the hook read the parent mount and mountpoint from the wrong registers, corrupting the mount event (attach_recursive_mnt is the only hook covering plain mount events). Read the parent and mp from the pinned_mountpoint struct when its offsets are resolved, falling back to the legacy argument positions otherwise.

### Motivation

Wrong read could lead to corrupted mount events.

### Describe how you validated your changes

### Additional Notes
