### PR TITLE
[WP] Fix exit_itimers tty resolution on kernels >= 5.19

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -412,6 +412,17 @@ int hook_exit_itimers(ctx_t *ctx) {
     }
 
     void *signal = (void *)CTX_PARM1(ctx);
+
+    // Since kernel 5.19, exit_itimers takes a struct task_struct* instead of a struct signal_struct*,
+    // so we need to read the signal_struct pointer from the task_struct first
+    u64 exit_itimers_takes_task_struct;
+    LOAD_CONSTANT("exit_itimers_takes_task_struct", exit_itimers_takes_task_struct);
+    if (exit_itimers_takes_task_struct) {
+        u64 task_struct_signal_offset;
+        LOAD_CONSTANT("task_struct_signal_offset", task_struct_signal_offset);
+        bpf_probe_read(&signal, sizeof(signal), (char *)signal + task_struct_signal_offset);
+    }
+
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 tgid = pid_tgid >> 32;
 

--- a/pkg/security/probe/constantfetch/available.go
+++ b/pkg/security/probe/constantfetch/available.go
@@ -77,6 +77,32 @@ func GetHasUsernamespaceFirstArgWithBtf() (bool, error) {
 	return proto.Params[0].Name != "dentry", nil
 }
 
+// GetExitItimersTakesTaskStructWithBtf uses BTF to check whether exit_itimers takes a
+// struct task_struct* as its first argument (kernel >= 5.19 and its stable backports) rather
+// than the legacy struct signal_struct*.
+func GetExitItimersTakesTaskStructWithBtf() (bool, error) {
+	proto, err := getBTFFuncProto("exit_itimers")
+	if err != nil {
+		return false, err
+	}
+
+	if len(proto.Params) == 0 {
+		return false, errors.New("exit_itimers has no parameters")
+	}
+
+	ptr, ok := btf.UnderlyingType(proto.Params[0].Type).(*btf.Pointer)
+	if !ok {
+		return false, errors.New("exit_itimers first parameter is not a pointer")
+	}
+
+	strct, ok := btf.UnderlyingType(ptr.Target).(*btf.Struct)
+	if !ok {
+		return false, errors.New("exit_itimers first parameter is not a pointer to a struct")
+	}
+
+	return strct.Name == "task_struct", nil
+}
+
 // GetHasVFSRenameStructArgs uses BTF to check if the vfs_rename function has a struct renamedata as its only argument
 func GetHasVFSRenameStructArgs() (bool, error) {
 	proto, err := getBTFFuncProto("vfs_rename")

--- a/pkg/security/probe/constantfetch/available_unsupported.go
+++ b/pkg/security/probe/constantfetch/available_unsupported.go
@@ -38,6 +38,11 @@ func GetHasUsernamespaceFirstArgWithBtf() (bool, error) {
 	return false, errors.New("unsupported BTF request")
 }
 
+// GetExitItimersTakesTaskStructWithBtf not available
+func GetExitItimersTakesTaskStructWithBtf() (bool, error) {
+	return false, errors.New("unsupported BTF request")
+}
+
 // GetHasVFSRenameStructArgs not available
 func GetHasVFSRenameStructArgs() (bool, error) {
 	return false, errors.New("unsupported BTF request")

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -93,6 +93,7 @@ const (
 	OffsetNameTaskStructPID     = "task_struct_pid_offset"      // kernels >= 4.19
 	OffsetNameTaskStructPIDLink = "task_struct_pid_link_offset" // kernels < 4.19
 	OffsetNamePIDLinkStructPID  = "pid_link_pid_offset"         // kernels < 4.19
+	OffsetNameTaskStructSignal  = "task_struct_signal_offset"
 
 	// splice event
 	OffsetNamePipeInodeInfoStructBufs     = "pipe_inode_info_bufs_offset"

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3398,8 +3398,17 @@ func getDoTruncateHasIdmapArg(kernelVersion *kernel.Version) uint64 {
 	return 0
 }
 
-func getExitItimersTakesTaskStruct(kernelversion *kernel.Version) uint64 {
-	if kernelversion.Code != 0 && kernelversion.Code >= kernel.Kernel5_19 {
+func getExitItimersTakesTaskStruct(kernelVersion *kernel.Version) uint64 {
+	// prefer the actual BTF prototype, as the exit_itimers(struct task_struct *) signature was
+	// backported to stable kernels (e.g. 5.10.y, 5.15.y) below the 5.19 mainline cut-off
+	if val, err := constantfetch.GetExitItimersTakesTaskStructWithBtf(); err == nil {
+		if val {
+			return 1
+		}
+		return 0
+	}
+
+	if kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel5_19 {
 		return 1
 	}
 	return 0

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2817,6 +2817,10 @@ func (p *EBPFProbe) initManagerOptionsConstants() {
 			Value: getDoDentryOpenWithoutInode(p.kernelVersion),
 		},
 		manager.ConstantEditor{
+			Name:  "exit_itimers_takes_task_struct",
+			Value: getExitItimersTakesTaskStruct(p.kernelVersion),
+		},
+		manager.ConstantEditor{
 			Name:  "has_usernamespace_first_arg",
 			Value: getHasUsernamespaceFirstArg(p.kernelVersion),
 		},
@@ -3394,6 +3398,13 @@ func getDoTruncateHasIdmapArg(kernelVersion *kernel.Version) uint64 {
 	return 0
 }
 
+func getExitItimersTakesTaskStruct(kernelversion *kernel.Version) uint64 {
+	if kernelversion.Code != 0 && kernelversion.Code >= kernel.Kernel5_19 {
+		return 1
+	}
+	return 0
+}
+
 func getHasUsernamespaceFirstArg(kernelVersion *kernel.Version) uint64 {
 	if val, err := constantfetch.GetHasUsernamespaceFirstArgWithBtf(); err == nil {
 		if val {
@@ -3507,6 +3518,8 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameDentryStructDSB, "struct dentry", "d_sb")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameSignalStructStructTTY, "struct signal_struct", "tty")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameTTYStructStructName, "struct tty_struct", "name")
+	// since kernel 5.19, exit_itimers takes a struct task_struct* so we need the offset of its signal field
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameTaskStructSignal, "struct task_struct", "signal")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameCredStructUID, "struct cred", "uid")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameCredStructCapInheritable, "struct cred", "cap_inheritable")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameLinuxBinprmP, "struct linux_binprm", "p")


### PR DESCRIPTION
### What does this PR do?

Since kernel 5.19 exit_itimers takes a struct task_struct* instead of a struct signal_struct*. The hook read CTX_PARM1 directly as a signal_struct and applied the signal_struct->tty offset to it, reading the wrong memory on recent kernels. Dereference the task_struct->signal field first when the kernel uses the new signature.

### Motivation

Wrong tty could be reported in exec events.

### Describe how you validated your changes

### Additional Notes
