### PR TITLE
[WP] Fix do_truncate file argument position on idmapped mounts kernels

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -130,10 +130,15 @@ int __attribute__((always_inline)) handle_truncate_path(ctx_t *ctx, struct path 
 
 HOOK_ENTRY("do_truncate")
 int hook_do_truncate(ctx_t *ctx) {
-    // filp is the 4th argument on older kernels; the idmapped-mounts series prepended an
-    // idmap/user_namespace argument to do_truncate, shifting filp to the 5th position
+    // filp is the 4th argument on older kernels; the idmapped-mounts series (kernel 5.12) prepended
+    // an idmap/user_namespace argument to do_truncate, shifting filp to the 5th position. This is
+    // detected specifically for do_truncate, as its argument gained the idmap argument independently
+    // of the security_* hooks.
+    u64 do_truncate_has_idmap_arg;
+    LOAD_CONSTANT("do_truncate_has_idmap_arg", do_truncate_has_idmap_arg);
+
     struct file *f = (struct file *)CTX_PARM4(ctx);
-    if (security_have_usernamespace_first_arg()) {
+    if (do_truncate_has_idmap_arg) {
         // prevent the verifier from whining
         bpf_probe_read(&f, sizeof(f), &f);
         f = (struct file *)CTX_PARM5(ctx);

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -130,7 +130,14 @@ int __attribute__((always_inline)) handle_truncate_path(ctx_t *ctx, struct path 
 
 HOOK_ENTRY("do_truncate")
 int hook_do_truncate(ctx_t *ctx) {
+    // filp is the 4th argument on older kernels; the idmapped-mounts series prepended an
+    // idmap/user_namespace argument to do_truncate, shifting filp to the 5th position
     struct file *f = (struct file *)CTX_PARM4(ctx);
+    if (security_have_usernamespace_first_arg()) {
+        // prevent the verifier from whining
+        bpf_probe_read(&f, sizeof(f), &f);
+        f = (struct file *)CTX_PARM5(ctx);
+    }
     if (f == NULL) {
         return 0;
     }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2821,6 +2821,10 @@ func (p *EBPFProbe) initManagerOptionsConstants() {
 			Value: getHasUsernamespaceFirstArg(p.kernelVersion),
 		},
 		manager.ConstantEditor{
+			Name:  "do_truncate_has_idmap_arg",
+			Value: getDoTruncateHasIdmapArg(p.kernelVersion),
+		},
+		manager.ConstantEditor{
 			Name:  "ovl_path_in_ovl_inode",
 			Value: getOvlPathInOvlInode(p.kernelVersion),
 		},
@@ -3366,6 +3370,25 @@ func getDoForkInput(kernelVersion *kernel.Version) uint64 {
 
 func getDoDentryOpenWithoutInode(kernelversion *kernel.Version) uint64 {
 	if kernelversion.Code != 0 && kernelversion.Code >= kernel.Kernel6_10 {
+		return 1
+	}
+	return 0
+}
+
+// getDoTruncateHasIdmapArg reports whether do_truncate takes an idmap/user_namespace first argument,
+// which shifts the filp argument from the 4th to the 5th position. This is do_truncate-specific: the
+// idmapped-mounts series added it in 5.12, independently of when other hooks gained an idmap argument.
+func getDoTruncateHasIdmapArg(kernelVersion *kernel.Version) uint64 {
+	// do_truncate is an exported symbol, so prefer its actual BTF prototype: the legacy signature has
+	// 4 arguments (dentry, length, time_attrs, filp) while the idmapped one has 5
+	if count, err := constantfetch.GetBTFFunctionArgCount("do_truncate"); err == nil {
+		if count >= 5 {
+			return 1
+		}
+		return 0
+	}
+
+	if kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel5_12 {
 		return 1
 	}
 	return 0


### PR DESCRIPTION
### What does this PR do?

The idmapped-mounts series prepended an idmap/user_namespace argument to do_truncate, shifting the filp argument from the 4th to the 5th position. Read it from the right register depending on has_usernamespace_first_arg.

### Motivation

do_truncate-path truncate events get a garbage file pointer

### Describe how you validated your changes

### Additional Notes
