### PR TITLE
[WP] Hook dev_index_reserve to resolve ifindex on recent kernels

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/network/net_device.h
+++ b/pkg/security/ebpf/c/include/hooks/network/net_device.h
@@ -97,6 +97,35 @@ int rethook_dev_new_index(ctx_t *ctx) {
     return 0;
 };
 
+// Since kernel 6.6, dev_new_index was replaced by dev_index_reserve(struct net *net, u32 ifindex),
+// which reserves and returns the ifindex just like dev_new_index did.
+HOOK_ENTRY("dev_index_reserve")
+int hook_dev_index_reserve(ctx_t *ctx) {
+    u64 id = bpf_get_current_pid_tgid();
+
+    struct register_netdevice_cache_t *entry = bpf_map_lookup_elem(&register_netdevice_cache, &id);
+    if (entry != NULL) {
+        struct net *net = (struct net *)CTX_PARM1(ctx);
+        entry->ifindex.netns = get_netns_from_net(net);
+    }
+    return 0;
+};
+
+HOOK_EXIT("dev_index_reserve")
+int rethook_dev_index_reserve(ctx_t *ctx) {
+    u64 id = bpf_get_current_pid_tgid();
+
+    struct register_netdevice_cache_t *entry = bpf_map_lookup_elem(&register_netdevice_cache, &id);
+    if (entry != NULL) {
+        // dev_index_reserve returns the reserved ifindex, or a negative error code on failure
+        int ret = (int)CTX_PARMRET(ctx);
+        if (ret >= 0) {
+            entry->ifindex.ifindex = (u32)ret;
+        }
+    }
+    return 0;
+};
+
 HOOK_ENTRY("__dev_get_by_index")
 int hook___dev_get_by_index(ctx_t *ctx) {
     u64 id = bpf_get_current_pid_tgid();

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -72,8 +72,12 @@ func NetworkSelectors(hasCgroupSocket bool) []manager.ProbesSelector {
 		}},
 		&manager.BestEffort{Selectors: []manager.ProbesSelector{
 			hookFunc("hook_dev_get_valid_name"),
+			// dev_new_index was replaced by dev_index_reserve in kernel 6.6; both are best-effort
+			// alternatives used to resolve the ifindex of a newly registered device
 			hookFunc("hook_dev_new_index"),
 			hookFunc("rethook_dev_new_index"),
+			hookFunc("hook_dev_index_reserve"),
+			hookFunc("rethook_dev_index_reserve"),
 			hookFunc("hook___dev_get_by_index"),
 		}},
 	}

--- a/pkg/security/ebpf/probes/net_device.go
+++ b/pkg/security/ebpf/probes/net_device.go
@@ -45,6 +45,18 @@ func getNetDeviceProbes() []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_dev_index_reserve",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_dev_index_reserve",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook___dev_get_by_index",
 			},
 		},


### PR DESCRIPTION
### What does this PR do?

Hook dev_index_reserve to resolve ifindex on recent kernels

### Motivation

Since kernel 6.6, dev_new_index was removed and replaced by dev_index_reserve, so the dev_new_index kprobes no longer attach and the device ifindex was only resolved via the register_netdevice fallback. Hook dev_index_reserve as a best-effort alternative: it takes the net namespace as its first argument and returns the reserved ifindex, matching the old dev_new_index hooks.

### Describe how you validated your changes

### Additional Notes
