### PR TITLE
[WP] Hook __get_unmapped_area to read mmap offset on recent kernels

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/mmap.h
+++ b/pkg/security/ebpf/c/include/hooks/mmap.h
@@ -45,6 +45,22 @@ int hook_get_unmapped_area(ctx_t *ctx) {
     return 0;
 }
 
+// Since kernel 6.13, get_unmapped_area is a static inline wrapper and can no longer be hooked.
+// It calls __get_unmapped_area, which keeps `pgoff` in the same argument position, so we hook it
+// as a fallback to still read the mmap offset.
+HOOK_ENTRY("__get_unmapped_area")
+int hook___get_unmapped_area(ctx_t *ctx) {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_MMAP);
+    if (!syscall) {
+        return 0;
+    }
+
+    u64 offset = CTX_PARM4(ctx);
+    syscall->mmap.offset = offset;
+
+    return 0;
+}
+
 int __attribute__((always_inline)) sys_mmap_ret(void *ctx, int retval, u64 addr) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_MMAP);
     if (!syscall) {

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -496,8 +496,13 @@ func GetSelectorsPerEventType(hasFentry bool) map[eval.EventType][]manager.Probe
 				hookFunc("rethook_vm_mmap_pgoff"),
 				hookFunc("hook_security_mmap_file"),
 			}},
+			// get_unmapped_area is inlined since kernel 6.13; fall back to __get_unmapped_area,
+			// which keeps pgoff in the same argument position, so we can still read the mmap offset
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				hookFunc("hook_get_unmapped_area"),
+				&manager.OneOf{Selectors: []manager.ProbesSelector{
+					hookFunc("hook_get_unmapped_area"),
+					hookFunc("hook___get_unmapped_area"),
+				}},
 			}},
 		},
 

--- a/pkg/security/ebpf/probes/mmap.go
+++ b/pkg/security/ebpf/probes/mmap.go
@@ -36,5 +36,11 @@ func getMMapProbes() []*manager.Probe {
 				EBPFFuncName: "hook_get_unmapped_area",
 			},
 		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook___get_unmapped_area",
+			},
+		},
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Hook __get_unmapped_area to read mmap offset on recent kernels

### Motivation

Since kernel 6.13 get_unmapped_area is a static inline wrapper and can no longer be kprobed, so the mmap event offset was always 0 on recent kernels. Hook __get_unmapped_area as a fallback: it keeps pgoff in the same argument position (4th), so the offset can still be read. The two hooks are selected via a OneOf so whichever symbol is attachable is used.

### Describe how you validated your changes

### Additional Notes
