### PR TITLE
Simplify transaction sorting

### DIFF
--- a/comp/forwarder/defaultforwarder/impl/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/impl/default_forwarder.go
@@ -330,7 +330,6 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 	}
 
 	flushToDiskMemRatio := config.GetFloat64("forwarder_flush_to_disk_mem_ratio")
-	transactionSorter := transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}
 
 	for domain, resolver := range options.DomainResolvers {
 		domain, _ := utils.AddAgentVersionToDomain(domain, "app")
@@ -355,7 +354,6 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 				flushToDiskMemRatio,
 				domainFolderPath,
 				diskUsageLimit,
-				transactionSorter,
 				resolver,
 				pointCountTelemetry)
 			f.domainResolvers[domain] = resolver
@@ -373,7 +371,6 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 				transactionContainer,
 				numberOfWorkers,
 				options.ConnectionResetInterval,
-				transactionSorter,
 				pointCountTelemetry,
 				options.transport)
 			f.domainForwarders[domain] = fwd

--- a/comp/forwarder/defaultforwarder/impl/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/impl/domain_forwarder.go
@@ -33,28 +33,27 @@ var (
 // HTTP and retrying them if needed. One domainForwarder is created per HTTP
 // backend.
 type domainForwarder struct {
-	config                    config.Component
-	log                       log.Component
-	secrets                   secrets.Component
-	isRetrying                *atomic.Bool
-	domain                    string
-	isMRF                     bool
-	isLocal                   bool
-	numberOfWorkers           int
-	highPrio                  chan transaction.Transaction // use to receive new transactions
-	lowPrio                   chan transaction.Transaction // use to retry transactions
-	requeuedTransaction       chan transaction.Transaction
-	stopRetry                 chan bool
-	stopConnectionReset       chan bool
-	Client                    *SharedConnection
-	workers                   []*Worker
-	retryQueue                *retry.TransactionRetryQueue
-	connectionResetInterval   time.Duration
-	internalState             uint32
-	m                         sync.Mutex // To control Start/Stop races
-	transactionPrioritySorter retry.TransactionPrioritySorter
-	blockedList               *blockedEndpoints
-	pointCountTelemetry       *retry.PointCountTelemetry
+	config                  config.Component
+	log                     log.Component
+	secrets                 secrets.Component
+	isRetrying              *atomic.Bool
+	domain                  string
+	isMRF                   bool
+	isLocal                 bool
+	numberOfWorkers         int
+	highPrio                chan transaction.Transaction // use to receive new transactions
+	lowPrio                 chan transaction.Transaction // use to retry transactions
+	requeuedTransaction     chan transaction.Transaction
+	stopRetry               chan bool
+	stopConnectionReset     chan bool
+	Client                  *SharedConnection
+	workers                 []*Worker
+	retryQueue              *retry.TransactionRetryQueue
+	connectionResetInterval time.Duration
+	internalState           uint32
+	m                       sync.Mutex // To control Start/Stop races
+	blockedList             *blockedEndpoints
+	pointCountTelemetry     *retry.PointCountTelemetry
 }
 
 func newDomainForwarder(
@@ -67,25 +66,23 @@ func newDomainForwarder(
 	retryQueue *retry.TransactionRetryQueue,
 	numberOfWorkers int,
 	connectionResetInterval time.Duration,
-	transactionPrioritySorter retry.TransactionPrioritySorter,
 	pointCountTelemetry *retry.PointCountTelemetry,
 	transport http.RoundTripper) *domainForwarder {
 	return &domainForwarder{
-		config:                    config,
-		log:                       log,
-		secrets:                   secrets,
-		isRetrying:                atomic.NewBool(false),
-		isMRF:                     mrf,
-		isLocal:                   isLocal,
-		domain:                    domain,
-		numberOfWorkers:           numberOfWorkers,
-		retryQueue:                retryQueue,
-		connectionResetInterval:   connectionResetInterval,
-		internalState:             Stopped,
-		blockedList:               newBlockedEndpoints(config, log),
-		transactionPrioritySorter: transactionPrioritySorter,
-		pointCountTelemetry:       pointCountTelemetry,
-		Client:                    NewSharedConnection(log, isLocal, numberOfWorkers, config, transport),
+		config:                  config,
+		log:                     log,
+		secrets:                 secrets,
+		isRetrying:              atomic.NewBool(false),
+		isMRF:                   mrf,
+		isLocal:                 isLocal,
+		domain:                  domain,
+		numberOfWorkers:         numberOfWorkers,
+		retryQueue:              retryQueue,
+		connectionResetInterval: connectionResetInterval,
+		internalState:           Stopped,
+		blockedList:             newBlockedEndpoints(config, log),
+		pointCountTelemetry:     pointCountTelemetry,
+		Client:                  NewSharedConnection(log, isLocal, numberOfWorkers, config, transport),
 	}
 }
 
@@ -109,7 +106,7 @@ func (f *domainForwarder) retryTransactions(_ time.Time) {
 		f.log.Errorf("Error when getting transactions from the retry queue: %v", err)
 	}
 
-	f.transactionPrioritySorter.Sort(transactions)
+	transaction.SortByCreatedTimeAndPriority(transactions)
 
 	blockedList := f.blockedList.startRetry()
 

--- a/comp/forwarder/defaultforwarder/impl/domain_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/impl/domain_forwarder_test.go
@@ -373,7 +373,6 @@ func TestDomainForwarderRetryQueueAllPayloadsMaxSize(t *testing.T) {
 
 	telemetry := retry.NewTransactionRetryQueueTelemetry("domain")
 	transactionRetryQueue := retry.NewTransactionRetryQueue(
-		transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true},
 		nil,
 		1+2,
 		0,
@@ -382,7 +381,7 @@ func TestDomainForwarderRetryQueueAllPayloadsMaxSize(t *testing.T) {
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	forwarder := newDomainForwarder(mockConfig, log, secrets, "test", false, false, transactionRetryQueue, 0, 10, transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}, retry.NewPointCountTelemetry("domain"), nil)
+	forwarder := newDomainForwarder(mockConfig, log, secrets, "test", false, false, transactionRetryQueue, 0, 10, retry.NewPointCountTelemetry("domain"), nil)
 	forwarder.blockedList.close("blocked", time.Now())
 	forwarder.blockedList.errorPerEndpoint["blocked"].until = time.Now().Add(1 * time.Minute)
 
@@ -480,10 +479,8 @@ func TestDomainForwarderStopFlushesRetryQueueAndLowPrioToDisk(t *testing.T) {
 	flushInterval = time.Hour
 
 	storage := &mockDiskStorage{}
-	sorter := transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}
 	telemetry := retry.NewTransactionRetryQueueTelemetry("domain")
 	retryQueue := retry.NewTransactionRetryQueue(
-		sorter,
 		storage,
 		100,
 		0,
@@ -494,7 +491,7 @@ func TestDomainForwarderStopFlushesRetryQueueAndLowPrioToDisk(t *testing.T) {
 	mockConfig.SetInTest("forwarder_max_concurrent_requests", 1)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	forwarder := newDomainForwarder(mockConfig, log, secrets, "test", false, false, retryQueue, 1, 0, sorter, retry.NewPointCountTelemetry("domain"), nil)
+	forwarder := newDomainForwarder(mockConfig, log, secrets, "test", false, false, retryQueue, 1, 0, retry.NewPointCountTelemetry("domain"), nil)
 	forwarder.Start()
 
 	forwarder.workers[0].Stop(false)
@@ -526,10 +523,8 @@ func TestDomainForwarderStopFlushesRetryQueueAndLowPrioToDisk(t *testing.T) {
 func newDomainForwarderForTest(t *testing.T, config config.Component, log log.Component, connectionResetInterval time.Duration, ha bool) *domainForwarder {
 	config.SetInTest("forwarder_max_concurrent_requests", 1)
 
-	sorter := transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}
 	telemetry := retry.NewTransactionRetryQueueTelemetry("domain")
 	transactionRetryQueue := retry.NewTransactionRetryQueue(
-		transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true},
 		nil,
 		2,
 		0,
@@ -537,7 +532,7 @@ func newDomainForwarderForTest(t *testing.T, config config.Component, log log.Co
 		retry.NewPointCountTelemetryMock())
 
 	secrets := secretsmock.New(t)
-	return newDomainForwarder(config, log, secrets, "test", ha, false, transactionRetryQueue, 1, connectionResetInterval, sorter, retry.NewPointCountTelemetry("domain"), nil)
+	return newDomainForwarder(config, log, secrets, "test", ha, false, transactionRetryQueue, 1, connectionResetInterval, retry.NewPointCountTelemetry("domain"), nil)
 }
 
 func requireLenForwarderRetryQueue(t *testing.T, forwarder *domainForwarder, expectedValue int) {

--- a/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
@@ -22,11 +22,6 @@ type TransactionDiskStorage interface {
 	GetDiskSpaceUsed() int64
 }
 
-// TransactionPrioritySorter is an interface to sort transactions.
-type TransactionPrioritySorter interface {
-	Sort([]transaction.Transaction)
-}
-
 // TransactionRetryQueue stores transactions in memory and flush them to disk when the memory
 // limit is exceeded.
 type TransactionRetryQueue struct {
@@ -34,7 +29,6 @@ type TransactionRetryQueue struct {
 	currentMemSizeInBytes int
 	maxMemSizeInBytes     int
 	flushToStorageRatio   float64
-	dropPrioritySorter    TransactionPrioritySorter
 	optionalStorage       TransactionDiskStorage
 	telemetry             TransactionRetryQueueTelemetry
 	pointCountTelemetry   *PointCountTelemetry
@@ -48,7 +42,6 @@ func BuildTransactionRetryQueue(
 	flushToStorageRatio float64,
 	optionalDomainFolderPath string,
 	optionalDiskUsageLimit *DiskUsageLimit,
-	dropPrioritySorter TransactionPrioritySorter,
 	resolver resolver.DomainResolver,
 	pointCountTelemetry *PointCountTelemetry) *TransactionRetryQueue {
 	var storage TransactionDiskStorage
@@ -67,7 +60,6 @@ func BuildTransactionRetryQueue(
 	}
 
 	return NewTransactionRetryQueue(
-		dropPrioritySorter,
 		storage,
 		maxMemSizeInBytes,
 		flushToStorageRatio,
@@ -77,7 +69,6 @@ func BuildTransactionRetryQueue(
 
 // NewTransactionRetryQueue creates a new instance of NewTransactionRetryQueue
 func NewTransactionRetryQueue(
-	dropPrioritySorter TransactionPrioritySorter,
 	optionalTransactionStorage TransactionDiskStorage,
 	maxMemSizeInBytes int,
 	flushToStorageRatio float64,
@@ -86,7 +77,6 @@ func NewTransactionRetryQueue(
 	return &TransactionRetryQueue{
 		maxMemSizeInBytes:   maxMemSizeInBytes,
 		flushToStorageRatio: flushToStorageRatio,
-		dropPrioritySorter:  dropPrioritySorter,
 		optionalStorage:     optionalTransactionStorage,
 		telemetry:           telemetry,
 		pointCountTelemetry: pointCountTelemetry,
@@ -247,12 +237,12 @@ func (tc *TransactionRetryQueue) extractTransactionsFromMemory(payloadSizeInByte
 	sizeInBytesExtracted := 0
 	var transactionsExtracted []transaction.Transaction
 
-	// dropPrioritySorter places high-priority/newest transactions at the front
-	// (index 0) and low-priority/oldest at the tail. Extracting from the tail
+	// SortByCreatedTimeAndPriority places high-priority/newest transactions at the
+	// front (index 0) and low-priority/oldest at the tail. Extracting from the tail
 	// evicts the least-valuable transactions first and lets us shrink the slice
 	// with a simple reslice instead of cutting from the front, so this way we
 	// preserve the capacity.
-	tc.dropPrioritySorter.Sort(tc.transactions)
+	transaction.SortByCreatedTimeAndPriority(tc.transactions)
 	for ; i >= 0 && sizeInBytesExtracted < payloadSizeInBytesToExtract; i-- {
 		transaction := tc.transactions[i]
 		sizeInBytesExtracted += transaction.GetPayloadSize()

--- a/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue_test.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue_test.go
@@ -35,7 +35,7 @@ func TestTransactionRetryQueueAdd(t *testing.T) {
 	pointDropped := transactionContainerPointDroppedCountTelemetry.expvar.Value()
 	q := newOnDiskRetryQueueTest(t, a)
 
-	container := NewTransactionRetryQueue(createDropPrioritySorter(), q, 100, 0.6, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
+	container := NewTransactionRetryQueue(q, 100, 0.6, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
 
 	// When adding the last element `15`, the buffer becomes full and the first 3
 	// transactions are flushed to the disk as 10 + 20 + 30 >= 100 * 0.6
@@ -63,7 +63,7 @@ func TestTransactionRetryQueueSeveralFlushToDisk(t *testing.T) {
 	a := assert.New(t)
 	q := newOnDiskRetryQueueTest(t, a)
 
-	container := NewTransactionRetryQueue(createDropPrioritySorter(), q, 50, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
+	container := NewTransactionRetryQueue(q, 50, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
 
 	// Flush to disk when adding `40`
 	for _, payloadSize := range []int{9, 10, 11, 40} {
@@ -84,7 +84,7 @@ func TestTransactionRetryQueueFlushAllToDisk(t *testing.T) {
 	a := assert.New(t)
 	q := newOnDiskRetryQueueTest(t, a)
 
-	container := NewTransactionRetryQueue(createDropPrioritySorter(), q, 50, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
+	container := NewTransactionRetryQueue(q, 50, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
 
 	// We're under the limit here, so should all be in memory
 	for _, payloadSize := range []int{9, 10, 11} {
@@ -108,7 +108,7 @@ func TestTransactionRetryQueueFlushAllToDisk(t *testing.T) {
 func TestTransactionRetryQueueNoTransactionStorage(t *testing.T) {
 	a := assert.New(t)
 	pointDropped := transactionContainerPointDroppedCountTelemetry.expvar.Value()
-	container := NewTransactionRetryQueue(createDropPrioritySorter(), nil, 50, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
+	container := NewTransactionRetryQueue(nil, 50, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
 
 	for _, payloadSize := range []int{9, 10, 11} {
 		dropCount, err := container.Add(createTransactionWithPayloadSize(payloadSize))
@@ -133,7 +133,7 @@ func TestTransactionRetryQueueZeroMaxMemSizeInBytes(t *testing.T) {
 
 	maxMemSizeInBytes := 0
 	pointDropped := transactionContainerPointDroppedCountTelemetry.expvar.Value()
-	container := NewTransactionRetryQueue(createDropPrioritySorter(), q, maxMemSizeInBytes, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
+	container := NewTransactionRetryQueue(q, maxMemSizeInBytes, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
 
 	inMemTrDropped, err := container.Add(createTransactionWithPayloadSize(10))
 	a.NoError(err)
@@ -151,11 +151,11 @@ func TestTransactionRetryQueueZeroMaxMemSizeInBytes(t *testing.T) {
 // before high-priority ones regardless of insertion order.
 //
 // Setup: max=15, queue has high(5)+normal(5)=10. Adding new(10) needs 5 bytes freed.
-// The drop sorter extracts from the low-priority tail, so normal(5) is dropped, high(5) survives.
+// Extraction happens from the low-priority tail, so normal(5) is dropped, high(5) survives.
 func TestTransactionRetryQueueDropsNormalPriorityBeforeHigh(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
-	container := NewTransactionRetryQueue(createDropPrioritySorter(), nil, 15, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
+	container := NewTransactionRetryQueue(nil, 15, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
 
 	high := createTransactionWithPayloadSize(5)
 	high.Priority = transaction.TransactionPriorityHigh
@@ -190,7 +190,7 @@ func TestTransactionRetryQueueDropsNormalPriorityBeforeHigh(t *testing.T) {
 func TestTransactionRetryQueueDropsOldestFirst(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
-	container := NewTransactionRetryQueue(createDropPrioritySorter(), nil, 25, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
+	container := NewTransactionRetryQueue(nil, 25, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
 
 	old := createTransactionWithPayloadSize(10)
 	old.Priority = transaction.TransactionPriorityNormal
@@ -242,10 +242,6 @@ func assertPayloadSizeFromExtractTransactions(
 		payloadSizes = append(payloadSizes, t.GetPayloadSize())
 	}
 	a.EqualValues(expectedPayloadSize, payloadSizes)
-}
-
-func createDropPrioritySorter() transaction.SortByCreatedTimeAndPriority {
-	return transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}
 }
 
 func newOnDiskRetryQueueTest(t *testing.T, a *assert.Assertions) *onDiskRetryQueue {

--- a/comp/forwarder/defaultforwarder/transaction/sort_by_created_time_and_priority.go
+++ b/comp/forwarder/defaultforwarder/transaction/sort_by_created_time_and_priority.go
@@ -7,19 +7,10 @@ package transaction
 
 import "sort"
 
-// SortByCreatedTimeAndPriority sorts transactions by creation time and priority
-type SortByCreatedTimeAndPriority struct {
-	HighPriorityFirst bool
-}
-
-// Sort sorts transactions by creation time and priority
-func (s SortByCreatedTimeAndPriority) Sort(transactions []Transaction) {
-	sorter := byCreatedTimeAndPriority(transactions)
-	if s.HighPriorityFirst {
-		sort.Sort(sorter)
-	} else {
-		sort.Sort(sort.Reverse(sorter))
-	}
+// SortByCreatedTimeAndPriority sorts transactions by priority (highest first) and,
+// for transactions with equal priority, by creation time (newest first).
+func SortByCreatedTimeAndPriority(transactions []Transaction) {
+	sort.Sort(byCreatedTimeAndPriority(transactions))
 }
 
 type byCreatedTimeAndPriority []Transaction


### PR DESCRIPTION
### What does this PR do?

Remove unneded TransactionSorter interface and stateful sorters. Replace them with stateless function call.

### Motivation

We used to sort transactions in domain forwarder and in transaction retry queue in a different order. Due to the changes in #52864 we no more need that, and we always sort them in high-to-low priority order. So, separate stateful sorters are no more needed, and we simplify the code to remove the unneeded complication.

### Describe how you validated your changes

We have unit tests that validate this behavior.

### Additional Notes
