### PR TITLE
(agenthealth): Node Agent monitoring DCA/CLC

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/cmd/agent/subcommands/run/internal/clcrunnerapi"
 	internalsettings "github.com/DataDog/datadog-agent/cmd/agent/subcommands/run/internal/settings"
+	agentstackmonitorfx "github.com/DataDog/datadog-agent/comp/agentstackmonitor/fx"
 	logssourcefx "github.com/DataDog/datadog-agent/comp/anomalydetection/logssource/fx"
 	observerfx "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/fx"
 	recordernoopfx "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/fx-noop"
@@ -579,6 +580,7 @@ func getSharedFxOption() fx.Option {
 		}),
 		settingsfx.Module(),
 		agenttelemetryfx.Module(),
+		agentstackmonitorfx.Module(),
 		remotetraceroute.Module(),
 		networkpath.Bundle(),
 		syntheticsTestsfx.Module(),

--- a/comp/agentstackmonitor/def/BUILD.bazel
+++ b/comp/agentstackmonitor/def/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "def",
+    srcs = ["component.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/agentstackmonitor/def",
+    visibility = ["//visibility:public"],
+)

--- a/comp/agentstackmonitor/def/component.go
+++ b/comp/agentstackmonitor/def/component.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package agentstackmonitor observes Datadog cluster-agent and
+// cluster-check-runner pods co-scheduled on the node and reports
+// sustained health problems (memory pressure, restarts, OOMKilled,
+// CrashLoopBackOff) as healthplatform issues, while also exposing raw
+// resource signals via pkg/telemetry for internal-org egress.
+package agentstackmonitor
+
+// team: container-platform
+
+// Component has no external API.
+type Component interface{}

--- a/comp/agentstackmonitor/fx/BUILD.bazel
+++ b/comp/agentstackmonitor/fx/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/agentstackmonitor/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/agentstackmonitor/impl",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/agentstackmonitor/fx/fx.go
+++ b/comp/agentstackmonitor/fx/fx.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package fx provides the fx module for the agentstackmonitor component.
+package fx
+
+import (
+	agentstackmonitorimpl "github.com/DataDog/datadog-agent/comp/agentstackmonitor/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(agentstackmonitorimpl.NewComponent),
+	)
+}

--- a/comp/agentstackmonitor/impl/BUILD.bazel
+++ b/comp/agentstackmonitor/impl/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "impl",
+    srcs = [
+        "buffer.go",
+        "evaluator.go",
+        "gauges.go",
+        "matcher.go",
+        "monitor.go",
+        "state.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/agentstackmonitor/impl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/agentstackmonitor/def",
+        "//comp/core/config",
+        "//comp/core/log/def",
+        "//comp/core/telemetry/def",
+        "//comp/core/workloadmeta/def",
+        "//comp/def",
+        "//comp/healthplatform/issues/agentstackmonitor",
+        "//comp/healthplatform/runner/def",
+        "//comp/healthplatform/scheduler/def",
+        "//comp/healthplatform/store/def",
+        "//pkg/config/env",
+        "//pkg/util/containers/metrics",
+        "//pkg/util/containers/metrics/provider",
+        "//pkg/util/option",
+    ],
+)
+
+go_test(
+    name = "impl_test",
+    srcs = [
+        "buffer_test.go",
+        "evaluator_test.go",
+        "matcher_test.go",
+        "monitor_test.go",
+    ],
+    embed = [":impl"],
+    gotags = ["test"],
+    deps = [
+        "//comp/core/telemetry/impl/noops",
+        "//comp/core/workloadmeta/def",
+        "//comp/healthplatform/issues/agentstackmonitor",
+        "//comp/healthplatform/runner/def",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/comp/agentstackmonitor/impl/buffer.go
+++ b/comp/agentstackmonitor/impl/buffer.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package agentstackmonitorimpl
+
+// bufferSize gives a 10-minute observation window at the default 60s tick.
+const bufferSize = 10
+
+type ring[T any] struct {
+	buf    [bufferSize]T
+	idx    int
+	filled int
+}
+
+func (r *ring[T]) push(v T) {
+	r.buf[r.idx] = v
+	r.idx = (r.idx + 1) % bufferSize
+	if r.filled < bufferSize {
+		r.filled++
+	}
+}
+
+// values returns the buffered samples in chronological order.
+func (r *ring[T]) values() []T {
+	if r.filled == 0 {
+		return nil
+	}
+	out := make([]T, r.filled)
+	if r.filled < bufferSize {
+		copy(out, r.buf[:r.filled])
+		return out
+	}
+	copy(out, r.buf[r.idx:])
+	copy(out[bufferSize-r.idx:], r.buf[:r.idx])
+	return out
+}
+
+func (r *ring[T]) countMatching(match func(T) bool) int {
+	n := 0
+	for i := 0; i < r.filled; i++ {
+		if match(r.buf[i]) {
+			n++
+		}
+	}
+	return n
+}
+
+func sumInt(r *ring[int32]) int32 {
+	var s int32
+	for i := 0; i < r.filled; i++ {
+		s += r.buf[i]
+	}
+	return s
+}

--- a/comp/agentstackmonitor/impl/buffer_test.go
+++ b/comp/agentstackmonitor/impl/buffer_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package agentstackmonitorimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRingFillAndWrap(t *testing.T) {
+	var r ring[int]
+	for i := 1; i <= bufferSize; i++ {
+		r.push(i)
+	}
+	assert.Equal(t, bufferSize, r.filled)
+	assert.Equal(t, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, r.values())
+
+	// Wrap: push three more, oldest three should drop off.
+	r.push(11)
+	r.push(12)
+	r.push(13)
+	assert.Equal(t, bufferSize, r.filled)
+	assert.Equal(t, []int{4, 5, 6, 7, 8, 9, 10, 11, 12, 13}, r.values())
+}
+
+func TestRingCountMatching(t *testing.T) {
+	var r ring[float64]
+	// Six of these ten values exceed 0.9.
+	for _, v := range []float64{0.5, 0.6, 0.95, 0.95, 0.4, 0.99, 0.95, 0.8, 0.95, 0.95} {
+		r.push(v)
+	}
+	assert.Equal(t, 6, r.countMatching(func(v float64) bool { return v > 0.9 }))
+}
+
+func TestSumInt(t *testing.T) {
+	var r ring[int32]
+	assert.EqualValues(t, 0, sumInt(&r), "empty ring")
+
+	for _, v := range []int32{0, 1, 0, 2, 0} {
+		r.push(v)
+	}
+	assert.EqualValues(t, 3, sumInt(&r))
+}

--- a/comp/agentstackmonitor/impl/evaluator.go
+++ b/comp/agentstackmonitor/impl/evaluator.go
@@ -1,0 +1,145 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package agentstackmonitorimpl
+
+import (
+	"fmt"
+	"maps"
+	"strconv"
+	"strings"
+
+	issuetemplates "github.com/DataDog/datadog-agent/comp/healthplatform/issues/agentstackmonitor"
+	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
+)
+
+// Each threshold acts as its own minimum-evidence bar; we don't wait for the
+// buffer to fill. bufferSize only bounds how far back history is retained.
+const (
+	memRatioThreshold        = 0.9
+	memPressureMinSamples    = 8
+	restartDeltaMinSum       = 3 // "delta > 2"
+	crashLoopMinObservations = 3
+)
+
+// evaluate returns at most one report per rule per tick. The healthplatform
+// runner handles create/resolve diffing by IssueID.
+func evaluate(s *subjectState) []runnerdef.IssueReport {
+	if s == nil {
+		return nil
+	}
+	var reports []runnerdef.IssueReport
+	ctx := baseContext(s)
+
+	if r, ok := evaluateMemoryPressure(s, ctx); ok {
+		reports = append(reports, r)
+	}
+	if r, ok := evaluateContainerRestart(s, ctx); ok {
+		reports = append(reports, r)
+	}
+	if r, ok := evaluateOOMKilled(s, ctx); ok {
+		reports = append(reports, r)
+	}
+	if r, ok := evaluateCrashLoopBackOff(s, ctx); ok {
+		reports = append(reports, r)
+	}
+	return reports
+}
+
+func baseContext(s *subjectState) map[string]string {
+	return map[string]string{
+		issuetemplates.CtxSubjectKind:    string(s.subjectKind),
+		issuetemplates.CtxNamespace:      s.controller.Namespace,
+		issuetemplates.CtxControllerKind: s.controller.Kind,
+		issuetemplates.CtxControllerName: s.controller.Name,
+		issuetemplates.CtxContainerName:  s.containerName,
+		issuetemplates.CtxPodName:        s.podName,
+		issuetemplates.CtxPodUID:         s.podUID,
+	}
+}
+
+// issueID is controller-anchored so reports survive pod reschedules.
+func issueID(slug string, s *subjectState) string {
+	return fmt.Sprintf("%s:%s/%s/%s:%s",
+		slug, s.controller.Namespace, s.controller.Kind, s.controller.Name, s.containerName)
+}
+
+func evaluateMemoryPressure(s *subjectState, base map[string]string) (runnerdef.IssueReport, bool) {
+	over := s.memRatio.countMatching(func(v float64) bool { return v > memRatioThreshold })
+	if over < memPressureMinSamples {
+		return runnerdef.IssueReport{}, false
+	}
+	ctx := copyMap(base)
+	ctx[issuetemplates.CtxMemoryUsage] = strconv.FormatFloat(s.memUsage, 'f', 0, 64)
+	ctx[issuetemplates.CtxMemoryLimit] = strconv.FormatFloat(s.memLimit, 'f', 0, 64)
+	if s.memLimit > 0 {
+		ctx[issuetemplates.CtxMemoryRatio] = strconv.FormatFloat(s.memUsage/s.memLimit, 'f', 3, 64)
+	}
+	ctx[issuetemplates.CtxSamplesOverThresh] = strconv.Itoa(over)
+	return runnerdef.IssueReport{
+		IssueID:   issueID("agentstackmonitor.memory-pressure", s),
+		IssueName: issuetemplates.IssueNameMemoryPressure,
+		Source:    issuetemplates.Source,
+		Context:   ctx,
+	}, true
+}
+
+func evaluateContainerRestart(s *subjectState, base map[string]string) (runnerdef.IssueReport, bool) {
+	total := sumInt(&s.restartDeltas)
+	if total < restartDeltaMinSum {
+		return runnerdef.IssueReport{}, false
+	}
+	ctx := copyMap(base)
+	ctx[issuetemplates.CtxRestartsInWindow] = strconv.Itoa(int(total))
+	ctx[issuetemplates.CtxLastTermReason] = s.lastTermReason
+	return runnerdef.IssueReport{
+		IssueID:   issueID("agentstackmonitor.container-restart", s),
+		IssueName: issuetemplates.IssueNameContainerRestart,
+		Source:    issuetemplates.Source,
+		Context:   ctx,
+	}, true
+}
+
+// evaluateOOMKilled requires a restart within the window so stale
+// LastTerminationState (kubelet keeps it forever) doesn't re-fire.
+func evaluateOOMKilled(s *subjectState, base map[string]string) (runnerdef.IssueReport, bool) {
+	if !strings.EqualFold(s.lastTermReason, "OOMKilled") {
+		return runnerdef.IssueReport{}, false
+	}
+	if sumInt(&s.restartDeltas) == 0 {
+		return runnerdef.IssueReport{}, false
+	}
+	ctx := copyMap(base)
+	ctx[issuetemplates.CtxLastTermReason] = s.lastTermReason
+	ctx[issuetemplates.CtxMemoryLimit] = strconv.FormatFloat(s.memLimit, 'f', 0, 64)
+	return runnerdef.IssueReport{
+		IssueID:   issueID("agentstackmonitor.oomkilled", s),
+		IssueName: issuetemplates.IssueNameContainerOOMKilled,
+		Source:    issuetemplates.Source,
+		Context:   ctx,
+	}, true
+}
+
+func evaluateCrashLoopBackOff(s *subjectState, base map[string]string) (runnerdef.IssueReport, bool) {
+	observed := s.waitingReason.countMatching(func(r string) bool { return r == "CrashLoopBackOff" })
+	if observed < crashLoopMinObservations {
+		return runnerdef.IssueReport{}, false
+	}
+	ctx := copyMap(base)
+	ctx[issuetemplates.CtxWaitingObservedIn] = strconv.Itoa(observed)
+	ctx[issuetemplates.CtxLastTermReason] = s.lastTermReason
+	return runnerdef.IssueReport{
+		IssueID:   issueID("agentstackmonitor.crashloopbackoff", s),
+		IssueName: issuetemplates.IssueNameCrashLoopBackOff,
+		Source:    issuetemplates.Source,
+		Context:   ctx,
+	}, true
+}
+
+func copyMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	maps.Copy(out, in)
+	return out
+}

--- a/comp/agentstackmonitor/impl/evaluator_test.go
+++ b/comp/agentstackmonitor/impl/evaluator_test.go
@@ -1,0 +1,185 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package agentstackmonitorimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	issuetemplates "github.com/DataDog/datadog-agent/comp/healthplatform/issues/agentstackmonitor"
+	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
+)
+
+// baseState constructs a subjectState with identity fields set but no
+// observations. Tests push signals via the ring helpers.
+func baseState() *subjectState {
+	return &subjectState{
+		subjectKind:   SubjectKindClusterAgent,
+		controller:    controllerRef{Namespace: "monitoring", Kind: "Deployment", Name: "datadog-cluster-agent"},
+		containerName: "cluster-agent",
+		podName:       "datadog-cluster-agent-7f9c8d5b4-x2j9k",
+		podUID:        "abc-uid",
+	}
+}
+
+// reportByName returns the report with the matching IssueName, or nil.
+func reportByName(reports []runnerdef.IssueReport, name string) *runnerdef.IssueReport {
+	for i := range reports {
+		if reports[i].IssueName == name {
+			return &reports[i]
+		}
+	}
+	return nil
+}
+
+func TestEvaluate_MemoryPressure(t *testing.T) {
+	t.Run("no fire below the sample threshold", func(t *testing.T) {
+		// Fewer than memPressureMinSamples samples over threshold — even if
+		// every sample so far is over, we haven't seen 8 yet.
+		s := baseState()
+		for _, v := range []float64{0.95, 0.95, 0.95, 0.95, 0.95} {
+			s.memRatio.push(v)
+		}
+		assert.Nil(t, reportByName(evaluate(s), issuetemplates.IssueNameMemoryPressure))
+	})
+
+	t.Run("no fire when only some samples exceed threshold", func(t *testing.T) {
+		s := baseState()
+		for _, v := range []float64{0.8, 0.85, 0.95, 0.6, 0.5, 0.99, 0.7, 0.4, 0.3, 0.95} {
+			s.memRatio.push(v)
+		}
+		assert.Nil(t, reportByName(evaluate(s), issuetemplates.IssueNameMemoryPressure))
+	})
+
+	t.Run("fires as soon as 8 samples exceed threshold (partial buffer)", func(t *testing.T) {
+		// 8-of-8 = 100% duty cycle at minute 8, no need to wait for a
+		// full 10-sample window.
+		s := baseState()
+		for _, v := range []float64{0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95} {
+			s.memRatio.push(v)
+		}
+		s.memUsage = 9.5e8
+		s.memLimit = 1e9
+		got := reportByName(evaluate(s), issuetemplates.IssueNameMemoryPressure)
+		require.NotNil(t, got, "expected memory pressure issue on 8-of-8")
+		assert.Equal(t, "8", got.Context[issuetemplates.CtxSamplesOverThresh])
+		assert.Equal(t,
+			"agentstackmonitor.memory-pressure:monitoring/Deployment/datadog-cluster-agent:cluster-agent",
+			got.IssueID)
+	})
+
+	t.Run("fires on 8-of-10 with two breather samples below threshold", func(t *testing.T) {
+		s := baseState()
+		for _, v := range []float64{0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.5, 0.4} {
+			s.memRatio.push(v)
+		}
+		assert.NotNil(t, reportByName(evaluate(s), issuetemplates.IssueNameMemoryPressure))
+	})
+}
+
+func TestEvaluate_ContainerRestart(t *testing.T) {
+	t.Run("no fire below the delta-sum threshold", func(t *testing.T) {
+		s := baseState()
+		// Only 2 restarts observed so far — below the > 2 threshold.
+		for _, d := range []int32{0, 1, 0, 1} {
+			s.restartDeltas.push(d)
+		}
+		assert.Nil(t, reportByName(evaluate(s), issuetemplates.IssueNameContainerRestart))
+	})
+
+	t.Run("no fire on a single restart flake in an otherwise quiet window", func(t *testing.T) {
+		s := baseState()
+		for _, d := range []int32{0, 0, 0, 0, 0, 1, 0, 0, 0, 0} {
+			s.restartDeltas.push(d)
+		}
+		assert.Nil(t, reportByName(evaluate(s), issuetemplates.IssueNameContainerRestart))
+	})
+
+	t.Run("fires as soon as delta sum exceeds threshold (partial buffer)", func(t *testing.T) {
+		// 3 restarts in 3 ticks — the "sustained and increasing" pattern
+		// should fire at tick 3, not wait for a full 10-tick window.
+		s := baseState()
+		for _, d := range []int32{1, 1, 1} {
+			s.restartDeltas.push(d)
+		}
+		got := reportByName(evaluate(s), issuetemplates.IssueNameContainerRestart)
+		require.NotNil(t, got, "expected container restart issue at tick 3")
+		assert.Equal(t, "3", got.Context[issuetemplates.CtxRestartsInWindow])
+	})
+
+	t.Run("fires when total deltas across a full window exceed threshold", func(t *testing.T) {
+		s := baseState()
+		for _, d := range []int32{0, 1, 0, 1, 0, 1, 0, 1, 0, 0} {
+			s.restartDeltas.push(d)
+		}
+		got := reportByName(evaluate(s), issuetemplates.IssueNameContainerRestart)
+		require.NotNil(t, got)
+		assert.Equal(t, "4", got.Context[issuetemplates.CtxRestartsInWindow])
+	})
+}
+
+func TestEvaluate_OOMKilled(t *testing.T) {
+	t.Run("does not fire on stale LastTerminationState without a restart", func(t *testing.T) {
+		s := baseState()
+		for i := 0; i < bufferSize; i++ {
+			s.restartDeltas.push(0)
+		}
+		s.lastTermReason = "OOMKilled"
+		assert.Nil(t, reportByName(evaluate(s), issuetemplates.IssueNameContainerOOMKilled))
+	})
+
+	t.Run("fires when OOMKilled coincides with a restart in the window", func(t *testing.T) {
+		s := baseState()
+		for _, d := range []int32{0, 0, 0, 1, 0, 0, 0, 0, 0, 0} {
+			s.restartDeltas.push(d)
+		}
+		s.lastTermReason = "OOMKilled"
+		s.memLimit = 5.12e8
+		got := reportByName(evaluate(s), issuetemplates.IssueNameContainerOOMKilled)
+		assert.NotNil(t, got)
+	})
+
+	t.Run("does not fire when reason is not OOMKilled", func(t *testing.T) {
+		s := baseState()
+		s.restartDeltas.push(1)
+		s.lastTermReason = "Error"
+		assert.Nil(t, reportByName(evaluate(s), issuetemplates.IssueNameContainerOOMKilled))
+	})
+}
+
+func TestEvaluate_CrashLoopBackOff(t *testing.T) {
+	t.Run("no fire on a single observation", func(t *testing.T) {
+		s := baseState()
+		for _, r := range []string{"", "", "", "", "", "CrashLoopBackOff", "", "", "", ""} {
+			s.waitingReason.push(r)
+		}
+		assert.Nil(t, reportByName(evaluate(s), issuetemplates.IssueNameCrashLoopBackOff))
+	})
+
+	t.Run("fires after 3 or more observations", func(t *testing.T) {
+		s := baseState()
+		for _, r := range []string{"", "", "CrashLoopBackOff", "CrashLoopBackOff", "", "", "CrashLoopBackOff", "", "", ""} {
+			s.waitingReason.push(r)
+		}
+		got := reportByName(evaluate(s), issuetemplates.IssueNameCrashLoopBackOff)
+		require.NotNil(t, got)
+		assert.Equal(t, "3", got.Context[issuetemplates.CtxWaitingObservedIn])
+	})
+
+	t.Run("ignores other waiting reasons", func(t *testing.T) {
+		s := baseState()
+		for _, r := range []string{"", "ImagePullBackOff", "ImagePullBackOff", "ImagePullBackOff", "", "", "", "", "", ""} {
+			s.waitingReason.push(r)
+		}
+		assert.Nil(t, reportByName(evaluate(s), issuetemplates.IssueNameCrashLoopBackOff))
+	})
+}
+
+func TestEvaluate_NilState(t *testing.T) {
+	assert.Nil(t, evaluate(nil))
+}

--- a/comp/agentstackmonitor/impl/gauges.go
+++ b/comp/agentstackmonitor/impl/gauges.go
@@ -1,0 +1,150 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package agentstackmonitorimpl
+
+import (
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+)
+
+const subsystem = "agentstackmonitor"
+
+// Multiple pods of the same subject_kind collapse to one series: resource
+// gauges sum, state gauges are 1 if any container matches. Per-pod detail
+// lives in the healthplatform issues, not here.
+var (
+	subjectLabels       = []string{"subject_kind"}
+	subjectReasonLabels = []string{"subject_kind", "reason"}
+)
+
+type resourceSums struct {
+	cpu, mem, memLimit, restart float64
+}
+
+type tickAggregate struct {
+	resources     map[string]*resourceSums
+	terminated    map[[2]string]struct{}
+	waiting       map[[2]string]struct{}
+	podTerminated map[[2]string]struct{}
+}
+
+func newTickAggregate() *tickAggregate {
+	return &tickAggregate{
+		resources:     make(map[string]*resourceSums),
+		terminated:    make(map[[2]string]struct{}),
+		waiting:       make(map[[2]string]struct{}),
+		podTerminated: make(map[[2]string]struct{}),
+	}
+}
+
+func (a *tickAggregate) addResource(s *subjectState) {
+	kind := string(s.subjectKind)
+	sums, ok := a.resources[kind]
+	if !ok {
+		sums = &resourceSums{}
+		a.resources[kind] = sums
+	}
+	sums.cpu += s.cpuTotal
+	sums.mem += s.memUsage
+	sums.memLimit += s.memLimit
+	sums.restart += float64(s.lastRestartCount)
+}
+
+func (a *tickAggregate) addStatus(s *subjectState) {
+	kind := string(s.subjectKind)
+	if r := currentWaitingReason(s); r != "" {
+		a.waiting[[2]string{kind, r}] = struct{}{}
+	}
+	if s.lastTermReason != "" {
+		a.terminated[[2]string{kind, s.lastTermReason}] = struct{}{}
+	}
+}
+
+func (a *tickAggregate) addPodStatus(s *subjectState) {
+	if s.podReason != "" {
+		a.podTerminated[[2]string{string(s.subjectKind), s.podReason}] = struct{}{}
+	}
+}
+
+type gauges struct {
+	cpuUsage      telemetry.Gauge
+	memoryUsage   telemetry.Gauge
+	memoryLimit   telemetry.Gauge
+	restartCount  telemetry.Gauge
+	terminated    telemetry.Gauge
+	waiting       telemetry.Gauge
+	podTerminated telemetry.Gauge
+
+	// Label combinations written last tick, kept so stale entries can be
+	// deleted before the next set.
+	lastResources     map[string]struct{}
+	lastTerminated    map[[2]string]struct{}
+	lastWaiting       map[[2]string]struct{}
+	lastPodTerminated map[[2]string]struct{}
+}
+
+func newGauges(t telemetry.Component) *gauges {
+	return &gauges{
+		cpuUsage:          t.NewGauge(subsystem, "cpu_usage", subjectLabels, "Cumulative CPU usage (seconds) summed across all containers of a Datadog-agent-stack subject kind."),
+		memoryUsage:       t.NewGauge(subsystem, "memory_usage", subjectLabels, "Memory usage (bytes) summed across all containers of a Datadog-agent-stack subject kind."),
+		memoryLimit:       t.NewGauge(subsystem, "memory_limit", subjectLabels, "Memory limit (bytes) summed across all containers of a Datadog-agent-stack subject kind."),
+		restartCount:      t.NewGauge(subsystem, "restart_count", subjectLabels, "Cumulative restart count summed across all containers of a Datadog-agent-stack subject kind."),
+		terminated:        t.NewGauge(subsystem, "terminated", subjectReasonLabels, "1 if any container of the given subject kind is currently terminated with the given reason, 0 otherwise."),
+		waiting:           t.NewGauge(subsystem, "waiting", subjectReasonLabels, "1 if any container of the given subject kind is currently waiting with the given reason, 0 otherwise."),
+		podTerminated:     t.NewGauge(subsystem, "pod_terminated", subjectReasonLabels, "1 if any pod of the given subject kind is currently in a terminal state with the given reason, 0 otherwise."),
+		lastResources:     make(map[string]struct{}),
+		lastTerminated:    make(map[[2]string]struct{}),
+		lastWaiting:       make(map[[2]string]struct{}),
+		lastPodTerminated: make(map[[2]string]struct{}),
+	}
+}
+
+// commit deletes any label combos from the previous tick that are missing
+// from a, then writes the current tick's values.
+func (g *gauges) commit(a *tickAggregate) {
+	for kind := range g.lastResources {
+		if _, live := a.resources[kind]; !live {
+			g.cpuUsage.Delete(kind)
+			g.memoryUsage.Delete(kind)
+			g.memoryLimit.Delete(kind)
+			g.restartCount.Delete(kind)
+		}
+	}
+	newResources := make(map[string]struct{}, len(a.resources))
+	for kind, sums := range a.resources {
+		g.cpuUsage.Set(sums.cpu, kind)
+		g.memoryUsage.Set(sums.mem, kind)
+		g.memoryLimit.Set(sums.memLimit, kind)
+		g.restartCount.Set(sums.restart, kind)
+		newResources[kind] = struct{}{}
+	}
+	g.lastResources = newResources
+
+	g.lastTerminated = diffAndSet(g.terminated, g.lastTerminated, a.terminated)
+	g.lastWaiting = diffAndSet(g.waiting, g.lastWaiting, a.waiting)
+	g.lastPodTerminated = diffAndSet(g.podTerminated, g.lastPodTerminated, a.podTerminated)
+}
+
+func diffAndSet(g telemetry.Gauge, last, current map[[2]string]struct{}) map[[2]string]struct{} {
+	for tags := range last {
+		if _, live := current[tags]; !live {
+			g.Delete(tags[0], tags[1])
+		}
+	}
+	next := make(map[[2]string]struct{}, len(current))
+	for tags := range current {
+		g.Set(1, tags[0], tags[1])
+		next[tags] = struct{}{}
+	}
+	return next
+}
+
+func currentWaitingReason(s *subjectState) string {
+	if s.waitingReason.filled == 0 {
+		return ""
+	}
+	prev := (s.waitingReason.idx + bufferSize - 1) % bufferSize
+	return s.waitingReason.buf[prev]
+}

--- a/comp/agentstackmonitor/impl/matcher.go
+++ b/comp/agentstackmonitor/impl/matcher.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package agentstackmonitorimpl
+
+import (
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+// SubjectKind identifies which part of the Datadog agent stack a pod belongs to.
+type SubjectKind string
+
+const (
+	SubjectKindClusterAgent       SubjectKind = "cluster_agent"
+	SubjectKindClusterCheckRunner SubjectKind = "cluster_check_runner"
+)
+
+const (
+	labelKey                = "app.kubernetes.io/name"
+	clusterAgentValue       = "datadog-cluster-agent"
+	clusterCheckRunnerValue = "datadog-cluster-checks-runner"
+)
+
+func subjectKindFor(pod *workloadmeta.KubernetesPod) (SubjectKind, bool) {
+	if pod == nil {
+		return "", false
+	}
+	switch pod.Labels[labelKey] {
+	case clusterAgentValue:
+		return SubjectKindClusterAgent, true
+	case clusterCheckRunnerValue:
+		return SubjectKindClusterCheckRunner, true
+	}
+	return "", false
+}
+
+// controllerRef anchors issue identity to the pod's owning workload so that
+// reports survive pod restarts within the same Deployment revision.
+type controllerRef struct {
+	Namespace string
+	Kind      string
+	Name      string
+}

--- a/comp/agentstackmonitor/impl/matcher_test.go
+++ b/comp/agentstackmonitor/impl/matcher_test.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package agentstackmonitorimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+func TestSubjectKindFor(t *testing.T) {
+	cases := []struct {
+		name      string
+		labels    map[string]string
+		wantKind  SubjectKind
+		wantMatch bool
+	}{
+		{
+			name:      "cluster-agent label matches",
+			labels:    map[string]string{"app.kubernetes.io/name": "datadog-cluster-agent"},
+			wantKind:  SubjectKindClusterAgent,
+			wantMatch: true,
+		},
+		{
+			name:      "cluster-check-runner label matches",
+			labels:    map[string]string{"app.kubernetes.io/name": "datadog-cluster-checks-runner"},
+			wantKind:  SubjectKindClusterCheckRunner,
+			wantMatch: true,
+		},
+		{
+			name:      "unrelated pod does not match",
+			labels:    map[string]string{"app.kubernetes.io/name": "some-customer-app"},
+			wantMatch: false,
+		},
+		{
+			name:      "wrong label key does not match",
+			labels:    map[string]string{"app": "datadog-cluster-agent"},
+			wantMatch: false,
+		},
+		{
+			name:      "missing labels does not match",
+			labels:    nil,
+			wantMatch: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &workloadmeta.KubernetesPod{}
+			pod.EntityMeta.Labels = tc.labels
+			gotKind, gotMatch := subjectKindFor(pod)
+			assert.Equal(t, tc.wantMatch, gotMatch)
+			if tc.wantMatch {
+				assert.Equal(t, tc.wantKind, gotKind)
+			}
+		})
+	}
+
+	t.Run("nil pod does not match", func(t *testing.T) {
+		_, ok := subjectKindFor(nil)
+		assert.False(t, ok)
+	})
+}

--- a/comp/agentstackmonitor/impl/monitor.go
+++ b/comp/agentstackmonitor/impl/monitor.go
@@ -1,0 +1,234 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package agentstackmonitorimpl implements the agentstackmonitor component.
+package agentstackmonitorimpl
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	agentstackmonitor "github.com/DataDog/datadog-agent/comp/agentstackmonitor/def"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	issuetemplates "github.com/DataDog/datadog-agent/comp/healthplatform/issues/agentstackmonitor"
+	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
+	schedulerdef "github.com/DataDog/datadog-agent/comp/healthplatform/scheduler/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
+	metrics "github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+const (
+	configHealthPlatformKey = "health_platform.enabled"
+	configClusterAgentKey   = "cluster_agent.enabled"
+	defaultTickInterval     = 60 * time.Second
+	defaultCacheValidity    = 60 * time.Second
+	staleness               = 3 * defaultTickInterval
+)
+
+// Requires defines the dependencies for the agentstackmonitor component.
+type Requires struct {
+	Lifecycle compdef.Lifecycle
+	Log       log.Component
+	Config    config.Component
+	WMeta     workloadmeta.Component
+	Telemetry telemetry.Component
+	Scheduler schedulerdef.Component
+	Store     storedef.Component
+}
+
+// Provides is the fx output.
+type Provides struct {
+	Comp agentstackmonitor.Component
+}
+
+type component struct {
+	log       log.Component
+	wmeta     workloadmeta.Component
+	scheduler schedulerdef.Component
+	store     storedef.Component
+	gauges    *gauges
+	provider  provider.Provider
+
+	tickInterval  time.Duration
+	cacheValidity time.Duration
+	now           func() time.Time
+
+	mu       sync.Mutex
+	subjects map[stateKey]*subjectState
+}
+
+// NewComponent is the fx constructor.
+func NewComponent(reqs Requires) Provides {
+	c := &component{
+		log:           reqs.Log,
+		wmeta:         reqs.WMeta,
+		scheduler:     reqs.Scheduler,
+		store:         reqs.Store,
+		gauges:        newGauges(reqs.Telemetry),
+		tickInterval:  defaultTickInterval,
+		cacheValidity: defaultCacheValidity,
+		now:           time.Now,
+		subjects:      make(map[stateKey]*subjectState),
+	}
+
+	switch {
+	case !reqs.Config.GetBool(configHealthPlatformKey):
+		c.log.Info("agentstackmonitor: health_platform.enabled=false, not running")
+	case !reqs.Config.GetBool(configClusterAgentKey):
+		c.log.Info("agentstackmonitor: cluster_agent.enabled=false, not running")
+	case !env.IsFeaturePresent(env.Kubernetes):
+		c.log.Info("agentstackmonitor: Kubernetes feature not detected, not running")
+	default:
+		reqs.Lifecycle.Append(compdef.Hook{
+			OnStart: c.start,
+			OnStop:  c.stop,
+		})
+	}
+	return Provides{Comp: c}
+}
+
+func (c *component) start(_ context.Context) error {
+	c.provider = metrics.GetProvider(option.New(c.wmeta))
+
+	var initialIDs []string
+	for _, name := range issuetemplates.AllIssueNames {
+		initialIDs = append(initialIDs, c.store.GetActiveIssueIDsByIssueName(name)...)
+	}
+
+	if err := c.scheduler.Schedule(issuetemplates.Source, c.evaluateTick, c.tickInterval, initialIDs); err != nil {
+		c.log.Warnf("agentstackmonitor: scheduler.Schedule failed: %v", err)
+		return nil
+	}
+	c.log.Infof("agentstackmonitor: registered periodic health check (interval=%s)", c.tickInterval)
+	return nil
+}
+
+func (c *component) stop(_ context.Context) error { return nil }
+
+func (c *component) evaluateTick() ([]runnerdef.IssueReport, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	pods := c.wmeta.ListKubernetesPods()
+	seen := make(map[stateKey]struct{})
+	agg := newTickAggregate()
+	var reports []runnerdef.IssueReport
+
+	for _, pod := range pods {
+		kind, ok := subjectKindFor(pod)
+		if !ok {
+			continue
+		}
+		// Fall back to the pod itself for bare / static pods with no owner.
+		ctrl := controllerRef{Namespace: pod.Namespace, Kind: "Pod", Name: pod.Name}
+		if len(pod.Owners) > 0 && pod.Owners[0].Name != "" {
+			ctrl.Kind = pod.Owners[0].Kind
+			ctrl.Name = pod.Owners[0].Name
+		}
+
+		for _, orch := range pod.GetAllContainers() {
+			key := stateKey{podUID: string(pod.EntityID.ID), containerName: orch.Name}
+			seen[key] = struct{}{}
+			st := c.getOrCreateState(key, pod, kind, ctrl, orch.Name)
+			st.lastSeenAt = c.now()
+
+			c.refreshStats(st, orch.ID)
+			c.applyContainerStatus(st, pod, orch.Name)
+			st.observePod(pod)
+
+			agg.addResource(st)
+			agg.addStatus(st)
+			agg.addPodStatus(st)
+
+			reports = append(reports, evaluate(st)...)
+		}
+	}
+
+	c.gauges.commit(agg)
+	c.purgeStale(seen)
+	return reports, nil
+}
+
+func (c *component) getOrCreateState(key stateKey, pod *workloadmeta.KubernetesPod, kind SubjectKind, ctrl controllerRef, containerName string) *subjectState {
+	if st, ok := c.subjects[key]; ok {
+		st.subjectKind = kind
+		st.controller = ctrl
+		st.observePod(pod)
+		return st
+	}
+	st := &subjectState{
+		subjectKind:   kind,
+		controller:    ctrl,
+		containerName: containerName,
+	}
+	st.observePod(pod)
+	c.subjects[key] = st
+	return st
+}
+
+func (c *component) refreshStats(st *subjectState, orchContainerID string) {
+	if c.provider == nil || orchContainerID == "" {
+		return
+	}
+	ctr, err := c.wmeta.GetContainer(orchContainerID)
+	if err != nil || ctr == nil {
+		return
+	}
+	collector := c.provider.GetCollector(provider.NewRuntimeMetadata(string(ctr.Runtime), string(ctr.RuntimeFlavor)))
+	if collector == nil {
+		return
+	}
+	stats, err := collector.GetContainerStats(ctr.Namespace, ctr.ID, c.cacheValidity)
+	if err != nil || stats == nil {
+		return
+	}
+	st.observeStats(stats)
+}
+
+func (c *component) applyContainerStatus(st *subjectState, pod *workloadmeta.KubernetesPod, containerName string) {
+	if status := findStatus(pod.ContainerStatuses, containerName); status != nil {
+		st.observeStatus(status)
+		return
+	}
+	if status := findStatus(pod.InitContainerStatuses, containerName); status != nil {
+		st.observeStatus(status)
+		return
+	}
+	if status := findStatus(pod.EphemeralContainerStatuses, containerName); status != nil {
+		st.observeStatus(status)
+	}
+}
+
+func findStatus(statuses []workloadmeta.KubernetesContainerStatus, name string) *workloadmeta.KubernetesContainerStatus {
+	for i := range statuses {
+		if statuses[i].Name == name {
+			return &statuses[i]
+		}
+	}
+	return nil
+}
+
+// purgeStale drops subjects not seen this tick and past the staleness cutoff.
+// Gauge cleanup is handled by gauges.commit's diff against the tick aggregate.
+func (c *component) purgeStale(seen map[stateKey]struct{}) {
+	cutoff := c.now().Add(-staleness)
+	for key, st := range c.subjects {
+		if _, alive := seen[key]; alive {
+			continue
+		}
+		if st.lastSeenAt.After(cutoff) {
+			continue
+		}
+		delete(c.subjects, key)
+	}
+}

--- a/comp/agentstackmonitor/impl/monitor_test.go
+++ b/comp/agentstackmonitor/impl/monitor_test.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package agentstackmonitorimpl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	nooptelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+// newTestComponent builds a component with a no-op telemetry sink and the
+// clock pinned to a fixed instant. wmeta / scheduler / store / provider are
+// deliberately left nil — the tests only exercise state and gauge cleanup
+// paths that don't call them.
+func newTestComponent(t *testing.T) *component {
+	t.Helper()
+	return &component{
+		gauges:        newGauges(nooptelemetry.GetCompatComponent()),
+		tickInterval:  defaultTickInterval,
+		cacheValidity: defaultCacheValidity,
+		now:           func() time.Time { return time.Unix(1000, 0) },
+		subjects:      make(map[stateKey]*subjectState),
+	}
+}
+
+func TestGetOrCreateState_ReturnsSameEntryAndRefreshesController(t *testing.T) {
+	c := newTestComponent(t)
+	key := stateKey{podUID: "pod-uid-1", containerName: "cluster-agent"}
+
+	// Seed with an outdated controller (e.g. from a prior tick).
+	first := c.getOrCreateState(key, fakePod("pod-uid-1"), SubjectKindClusterAgent,
+		controllerRef{Namespace: "monitoring", Kind: "ReplicaSet", Name: "old"}, "cluster-agent")
+	require.NotNil(t, first)
+
+	// A subsequent call with a different controller must reuse the same
+	// entry (preserving buffered state) but reflect the new controller.
+	second := c.getOrCreateState(key, fakePod("pod-uid-1"), SubjectKindClusterAgent,
+		controllerRef{Namespace: "monitoring", Kind: "Deployment", Name: "datadog-cluster-agent"}, "cluster-agent")
+	assert.Same(t, first, second, "getOrCreateState should return the same subjectState pointer")
+	assert.Equal(t, "datadog-cluster-agent", second.controller.Name, "controller should be refreshed")
+}
+
+func TestPurgeStale_KeepsRecentAndDropsExpired(t *testing.T) {
+	c := newTestComponent(t)
+	now := c.now()
+
+	recentKey := stateKey{podUID: "recent", containerName: "cluster-agent"}
+	expiredKey := stateKey{podUID: "expired", containerName: "agent"}
+
+	c.subjects[recentKey] = &subjectState{
+		subjectKind:   SubjectKindClusterAgent,
+		controller:    controllerRef{Namespace: "monitoring", Kind: "Deployment", Name: "cluster-agent"},
+		containerName: "cluster-agent",
+		lastSeenAt:    now.Add(-staleness / 2),
+	}
+	c.subjects[expiredKey] = &subjectState{
+		subjectKind:   SubjectKindClusterCheckRunner,
+		controller:    controllerRef{Namespace: "monitoring", Kind: "Deployment", Name: "cluster-checks-runner"},
+		containerName: "agent",
+		lastSeenAt:    now.Add(-2 * staleness),
+	}
+
+	// Simulate a tick that only observed the recent entry.
+	c.purgeStale(map[stateKey]struct{}{recentKey: {}})
+
+	assert.Contains(t, c.subjects, recentKey, "recent entry should be preserved")
+	assert.NotContains(t, c.subjects, expiredKey, "expired entry should be purged")
+}
+
+// fakePod returns a KubernetesPod stub with just enough identity for
+// observePod to populate the subjectState.
+func fakePod(uid string) *workloadmeta.KubernetesPod {
+	pod := &workloadmeta.KubernetesPod{}
+	pod.EntityID.ID = uid
+	pod.EntityID.Kind = workloadmeta.KindKubernetesPod
+	pod.EntityMeta.Name = "some-pod"
+	pod.EntityMeta.Namespace = "monitoring"
+	return pod
+}

--- a/comp/agentstackmonitor/impl/state.go
+++ b/comp/agentstackmonitor/impl/state.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package agentstackmonitorimpl
+
+import (
+	"time"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
+)
+
+type stateKey struct {
+	podUID        string
+	containerName string
+}
+
+type subjectState struct {
+	subjectKind   SubjectKind
+	controller    controllerRef
+	namespace     string
+	podName       string
+	podUID        string
+	containerName string
+
+	memRatio      ring[float64]
+	restartDeltas ring[int32]
+	waitingReason ring[string]
+
+	cpuTotal float64
+	memUsage float64
+	memLimit float64
+
+	// haveRestartBaseline avoids treating a container's very first observed
+	// RestartCount as a fresh delta — historical restarts predate our window.
+	lastRestartCount    int32
+	haveRestartBaseline bool
+
+	lastTermReason    string
+	restartAtLastTerm int32
+	haveTermBaseline  bool
+
+	podReason string
+	podPhase  string
+
+	lastSeenAt time.Time
+}
+
+func (s *subjectState) observeStats(stats *provider.ContainerStats) {
+	if stats == nil {
+		return
+	}
+	if stats.CPU != nil && stats.CPU.Total != nil {
+		s.cpuTotal = *stats.CPU.Total
+	}
+	if stats.Memory != nil {
+		if stats.Memory.UsageTotal != nil {
+			s.memUsage = *stats.Memory.UsageTotal
+		}
+		if stats.Memory.Limit != nil {
+			s.memLimit = *stats.Memory.Limit
+		}
+		if s.memLimit > 0 && s.memUsage > 0 {
+			s.memRatio.push(s.memUsage / s.memLimit)
+		}
+	}
+}
+
+func (s *subjectState) observeStatus(status *workloadmeta.KubernetesContainerStatus) {
+	if s.haveRestartBaseline {
+		delta := status.RestartCount - s.lastRestartCount
+		if delta < 0 {
+			delta = 0
+		}
+		s.restartDeltas.push(delta)
+	} else {
+		s.restartDeltas.push(0)
+		s.haveRestartBaseline = true
+	}
+	s.lastRestartCount = status.RestartCount
+
+	waitReason := ""
+	if status.State.Waiting != nil {
+		waitReason = status.State.Waiting.Reason
+	}
+	s.waitingReason.push(waitReason)
+
+	termReason := ""
+	if status.LastTerminationState.Terminated != nil {
+		termReason = status.LastTerminationState.Terminated.Reason
+	}
+	if termReason != s.lastTermReason {
+		s.lastTermReason = termReason
+		s.restartAtLastTerm = status.RestartCount
+		s.haveTermBaseline = termReason != ""
+	}
+}
+
+func (s *subjectState) observePod(pod *workloadmeta.KubernetesPod) {
+	s.podReason = pod.Reason
+	s.podPhase = pod.Phase
+	s.namespace = pod.Namespace
+	s.podName = pod.Name
+	s.podUID = string(pod.EntityID.ID)
+}

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -439,3 +439,26 @@ profiles:
     start_after: 300 # 5 minutes
     iterations: 1
     period: 900
+- name: agentstackmonitor
+  metric:
+    exclude:
+      zero_metric: true
+    metrics:
+      - name: agentstackmonitor.cpu_usage
+        preserve_tags: [subject_kind]
+      - name: agentstackmonitor.memory_usage
+        preserve_tags: [subject_kind]
+      - name: agentstackmonitor.memory_limit
+        preserve_tags: [subject_kind]
+      - name: agentstackmonitor.restart_count
+        preserve_tags: [subject_kind]
+      - name: agentstackmonitor.terminated
+        preserve_tags: [subject_kind, reason]
+      - name: agentstackmonitor.waiting
+        preserve_tags: [subject_kind, reason]
+      - name: agentstackmonitor.pod_terminated
+        preserve_tags: [subject_kind, reason]
+  schedule:
+    start_after: 60
+    iterations: 0
+    period: 900

--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//comp/healthplatform/issueregistry/def",
         "//comp/healthplatform/issueregistry/fx",
         "//comp/healthplatform/issues/admissionprobe",
+        "//comp/healthplatform/issues/agentstackmonitor",
         "//comp/healthplatform/issues/checkfailure",
         "//comp/healthplatform/issues/dockerpermissions",
         "//comp/healthplatform/issues/invalidconfig",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -27,6 +27,7 @@ import (
 	registrydef "github.com/DataDog/datadog-agent/comp/healthplatform/issueregistry/def"
 	registryfx "github.com/DataDog/datadog-agent/comp/healthplatform/issueregistry/fx"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"    // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/agentstackmonitor" // registers templates via init()
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"      // registers templates via init()
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions" // registers templates via init()
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/invalidconfig"     // registers templates via init()

--- a/comp/healthplatform/issues/agentstackmonitor/BUILD.bazel
+++ b/comp/healthplatform/issues/agentstackmonitor/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "agentstackmonitor",
+    srcs = [
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/agentstackmonitor",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "//comp/healthplatform/runner/def",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/comp/healthplatform/issues/agentstackmonitor/issue.go
+++ b/comp/healthplatform/issues/agentstackmonitor/issue.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package agentstackmonitor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Context keys populated by the detection component and consumed by BuildIssue.
+const (
+	CtxSubjectKind       = "subject_kind"
+	CtxNamespace         = "kube_namespace"
+	CtxControllerKind    = "controller_kind"
+	CtxControllerName    = "controller_name"
+	CtxContainerName     = "container_name"
+	CtxPodName           = "pod_name"
+	CtxPodUID            = "pod_uid"
+	CtxMemoryUsage       = "memory_usage_bytes"
+	CtxMemoryLimit       = "memory_limit_bytes"
+	CtxMemoryRatio       = "memory_usage_ratio"
+	CtxSamplesOverThresh = "samples_over_threshold"
+	CtxRestartsInWindow  = "restarts_in_window"
+	CtxLastTermReason    = "last_termination_reason"
+	CtxLastExitCode      = "last_exit_code"
+	CtxWaitingObservedIn = "waiting_observed_in_window"
+	CtxPodReason         = "pod_reason"
+)
+
+func location(ctx map[string]string) string {
+	return fmt.Sprintf("%s/%s/%s", ctx[CtxNamespace], ctx[CtxControllerKind], ctx[CtxControllerName])
+}
+
+func tagList(ctx map[string]string) []string {
+	tags := []string{
+		"agent_health",
+		"subject_kind:" + ctx[CtxSubjectKind],
+		"kube_namespace:" + ctx[CtxNamespace],
+	}
+	if v := ctx[CtxContainerName]; v != "" {
+		tags = append(tags, "container_name:"+v)
+	}
+	if v := ctx[CtxPodName]; v != "" {
+		tags = append(tags, "pod_name:"+v)
+	}
+	return tags
+}
+
+func extraStruct(ctx map[string]string, extras map[string]any) *structpb.Struct {
+	base := map[string]any{
+		"pod_uid":         ctx[CtxPodUID],
+		"pod_name":        ctx[CtxPodName],
+		"kube_namespace":  ctx[CtxNamespace],
+		"controller_kind": ctx[CtxControllerKind],
+		"controller_name": ctx[CtxControllerName],
+		"container_name":  ctx[CtxContainerName],
+	}
+	for k, v := range extras {
+		base[k] = v
+	}
+	s, _ := structpb.NewStruct(base)
+	return s
+}
+
+func buildMemoryPressureIssue(ctx map[string]string) (*healthplatform.Issue, error) {
+	title := fmt.Sprintf("Sustained memory pressure on %s/%s (%s)",
+		ctx[CtxControllerName], ctx[CtxContainerName], ctx[CtxSubjectKind])
+	desc := fmt.Sprintf(
+		"%s of the last 10 samples showed memory usage above 90%% of the container limit (last reading: %s / %s bytes) for container %s in %s/%s.",
+		ctx[CtxSamplesOverThresh], ctx[CtxMemoryUsage], ctx[CtxMemoryLimit],
+		ctx[CtxContainerName], ctx[CtxNamespace], ctx[CtxControllerName])
+	return &healthplatform.Issue{
+		IssueName:   IssueNameMemoryPressure,
+		Title:       title,
+		Description: desc,
+		Category:    "agent-self-health",
+		Location:    location(ctx),
+		Severity:    healthplatform.IssueSeverity_ISSUE_SEVERITY_HIGH,
+		Source:      Source,
+		Extra: extraStruct(ctx, map[string]any{
+			"memory_usage_bytes":     ctx[CtxMemoryUsage],
+			"memory_limit_bytes":     ctx[CtxMemoryLimit],
+			"memory_usage_ratio":     ctx[CtxMemoryRatio],
+			"samples_over_threshold": ctx[CtxSamplesOverThresh],
+		}),
+		Tags: append(tagList(ctx), "condition:memory_pressure"),
+	}, nil
+}
+
+func buildContainerRestartIssue(ctx map[string]string) (*healthplatform.Issue, error) {
+	title := fmt.Sprintf("Container restarting repeatedly (%s/%s in %s)",
+		ctx[CtxControllerName], ctx[CtxContainerName], ctx[CtxSubjectKind])
+	desc := fmt.Sprintf(
+		"Container %s in %s/%s restarted %s times over the last 10 minutes (most recent termination reason: %s).",
+		ctx[CtxContainerName], ctx[CtxNamespace], ctx[CtxControllerName],
+		ctx[CtxRestartsInWindow], displayReason(ctx[CtxLastTermReason]))
+	return &healthplatform.Issue{
+		IssueName:   IssueNameContainerRestart,
+		Title:       title,
+		Description: desc,
+		Category:    "agent-self-health",
+		Location:    location(ctx),
+		Severity:    healthplatform.IssueSeverity_ISSUE_SEVERITY_MEDIUM,
+		Source:      Source,
+		Extra: extraStruct(ctx, map[string]any{
+			"restarts_in_window":      ctx[CtxRestartsInWindow],
+			"last_termination_reason": ctx[CtxLastTermReason],
+			"last_exit_code":          ctx[CtxLastExitCode],
+		}),
+		Tags: appendReasonTags(tagList(ctx), ctx, "condition:container_restart"),
+	}, nil
+}
+
+func buildContainerOOMKilledIssue(ctx map[string]string) (*healthplatform.Issue, error) {
+	title := fmt.Sprintf("Container OOMKilled (%s/%s in %s)",
+		ctx[CtxControllerName], ctx[CtxContainerName], ctx[CtxSubjectKind])
+	desc := fmt.Sprintf(
+		"Container %s in %s/%s was OOMKilled within the observation window (memory limit: %s bytes).",
+		ctx[CtxContainerName], ctx[CtxNamespace], ctx[CtxControllerName], ctx[CtxMemoryLimit])
+	return &healthplatform.Issue{
+		IssueName:   IssueNameContainerOOMKilled,
+		Title:       title,
+		Description: desc,
+		Category:    "agent-self-health",
+		Location:    location(ctx),
+		Severity:    healthplatform.IssueSeverity_ISSUE_SEVERITY_HIGH,
+		Source:      Source,
+		Extra: extraStruct(ctx, map[string]any{
+			"memory_limit_bytes": ctx[CtxMemoryLimit],
+			"last_exit_code":     ctx[CtxLastExitCode],
+		}),
+		Tags: appendReasonTags(tagList(ctx), ctx, "condition:oomkilled", "termination_reason:oomkilled"),
+	}, nil
+}
+
+func buildCrashLoopBackOffIssue(ctx map[string]string) (*healthplatform.Issue, error) {
+	title := fmt.Sprintf("Container in CrashLoopBackOff (%s/%s in %s)",
+		ctx[CtxControllerName], ctx[CtxContainerName], ctx[CtxSubjectKind])
+	desc := fmt.Sprintf(
+		"Container %s in %s/%s has been observed in CrashLoopBackOff for %s of the last 10 checks.",
+		ctx[CtxContainerName], ctx[CtxNamespace], ctx[CtxControllerName],
+		ctx[CtxWaitingObservedIn])
+	return &healthplatform.Issue{
+		IssueName:   IssueNameCrashLoopBackOff,
+		Title:       title,
+		Description: desc,
+		Category:    "agent-self-health",
+		Location:    location(ctx),
+		Severity:    healthplatform.IssueSeverity_ISSUE_SEVERITY_HIGH,
+		Source:      Source,
+		Extra: extraStruct(ctx, map[string]any{
+			"crashloop_observations": ctx[CtxWaitingObservedIn],
+			"last_exit_code":         ctx[CtxLastExitCode],
+		}),
+		Tags: appendReasonTags(tagList(ctx), ctx, "condition:crashloopbackoff"),
+	}, nil
+}
+
+func appendReasonTags(tags []string, ctx map[string]string, extra ...string) []string {
+	out := append(tags, extra...)
+	if v := ctx[CtxLastTermReason]; v != "" {
+		out = append(out, "termination_reason:"+strings.ToLower(v))
+	}
+	if v := ctx[CtxLastExitCode]; v != "" {
+		out = append(out, "exit_code:"+v)
+	}
+	return out
+}
+
+func displayReason(reason string) string {
+	if reason == "" {
+		return "unknown"
+	}
+	return reason
+}

--- a/comp/healthplatform/issues/agentstackmonitor/module.go
+++ b/comp/healthplatform/issues/agentstackmonitor/module.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package agentstackmonitor provides healthplatform issue templates for the
+// agent-stack self-monitoring component. Detection lives in
+// comp/agentstackmonitor; this package only builds the proto Issues.
+package agentstackmonitor
+
+import (
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
+)
+
+// Source is the reporting label on every IssueReport this component emits,
+// and the key used with scheduler.Schedule for resolution diffing.
+const Source = "agentstackmonitor"
+
+const (
+	IssueNameMemoryPressure     = "AgentStackMonitor: Memory Pressure"
+	IssueNameContainerRestart   = "AgentStackMonitor: Container Restart"
+	IssueNameContainerOOMKilled = "AgentStackMonitor: Container OOMKilled"
+	IssueNameCrashLoopBackOff   = "AgentStackMonitor: CrashLoopBackOff"
+)
+
+// AllIssueNames lets the component look up persisted issues at startup so
+// the scheduler can resolve any that no longer reproduce.
+var AllIssueNames = []string{
+	IssueNameMemoryPressure,
+	IssueNameContainerRestart,
+	IssueNameContainerOOMKilled,
+	IssueNameCrashLoopBackOff,
+}
+
+func init() {
+	issues.RegisterModuleFactory(newMemoryPressureModule)
+	issues.RegisterModuleFactory(newContainerRestartModule)
+	issues.RegisterModuleFactory(newContainerOOMKilledModule)
+	issues.RegisterModuleFactory(newCrashLoopBackOffModule)
+}
+
+// templateModule provides only the remediation side; detection is driven
+// externally, so both BuiltIn*HealthCheck accessors return nil.
+type templateModule struct {
+	issueName string
+	build     func(map[string]string) (*healthplatform.Issue, error)
+}
+
+func (m *templateModule) IssueName() string { return m.issueName }
+
+func (m *templateModule) BuildIssue(ctx map[string]string) (*healthplatform.Issue, error) {
+	return m.build(ctx)
+}
+
+func (m *templateModule) BuiltInPeriodicHealthCheck() *runnerdef.BuiltInPeriodicHealthCheck {
+	return nil
+}
+
+func (m *templateModule) BuiltInStartupHealthCheck() *runnerdef.BuiltInHealthCheck {
+	return nil
+}
+
+func newMemoryPressureModule(config.Component) issues.Module {
+	return &templateModule{issueName: IssueNameMemoryPressure, build: buildMemoryPressureIssue}
+}
+
+func newContainerRestartModule(config.Component) issues.Module {
+	return &templateModule{issueName: IssueNameContainerRestart, build: buildContainerRestartIssue}
+}
+
+func newContainerOOMKilledModule(config.Component) issues.Module {
+	return &templateModule{issueName: IssueNameContainerOOMKilled, build: buildContainerOOMKilledIssue}
+}
+
+func newCrashLoopBackOffModule(config.Component) issues.Module {
+	return &templateModule{issueName: IssueNameCrashLoopBackOff, build: buildCrashLoopBackOffIssue}
+}


### PR DESCRIPTION
### What does this PR do?

Expose additional telemetry for Cluster Agent and Cluster Check Runner pods via the Node Agent to power the Agent Health product.

```
  comp/agentstackmonitor/
  ├── def/component.go     empty Component interface
  ├── impl/                                                                                                                          
  │   ├── monitor.go       fx wiring, evaluateTick, gate switch
  │   ├── matcher.go       labels-only agent-stack matcher + controllerRef                                                           
  │   ├── buffer.go        10-slot generic ring                                                                                      
  │   ├── state.go         per-container subjectState + observation methods
  │   ├── evaluator.go     four issue rules, pure function    
```

### Motivation

### Describe how you validated your changes

### Additional Notes

To be determined:

1. Do we need to create the health alerts Agent side? Agent signals can already be created in the backend from ingested metrics such as `kubernetes.container.running` OR `container.memory.usage`. This does rely on having the Agent included in infra monitoring but this could be a reasonable requirement.
2. Are we fine with generating the COAT metrics async from the checks? (probably fine)