### PR TITLE
bazel: migrate pkg/ebpf/verifier/calculator to Bazel

### DIFF
--- a/bazel/rules/ebpf/ebpf_object_dir.bzl
+++ b/bazel/rules/ebpf/ebpf_object_dir.bzl
@@ -1,0 +1,38 @@
+"""Assemble a directory of built eBPF .o programs for tools that read DD_SYSTEM_PROBE_BPF_DIR."""
+
+def _ebpf_object_dir_impl(ctx):
+    out = ctx.actions.declare_directory(ctx.label.name)
+    inputs = []
+    copies = []
+    for target in ctx.attr.prebuilt:
+        f = target.files.to_list()[0]
+        inputs.append(f)
+        copies.append("cp {src} {dst}/{name}.o".format(src = f.path, dst = out.path, name = target.label.name))
+    for target in ctx.attr.core:
+        f = target.files.to_list()[0]
+        inputs.append(f)
+        copies.append("cp {src} {dst}/co-re/{name}.o".format(src = f.path, dst = out.path, name = target.label.name))
+
+    ctx.actions.run_shell(
+        outputs = [out],
+        inputs = inputs,
+        command = "mkdir -p {root}/co-re && {copies}".format(root = out.path, copies = " && ".join(copies)),
+        mnemonic = "EbpfObjectDir",
+        progress_message = "Assembling eBPF object directory %{output}",
+    )
+    return [DefaultInfo(files = depset([out]), runfiles = ctx.runfiles(files = [out]))]
+
+ebpf_object_dir = rule(
+    implementation = _ebpf_object_dir_impl,
+    doc = "Copies prebuilt/CO-RE eBPF .o targets into a single flat directory, with CO-RE variants under co-re/.",
+    attrs = {
+        "prebuilt": attr.label_list(
+            allow_files = [".o"],
+            doc = "eBPF .o targets, placed directly under the output directory as <target name>.o.",
+        ),
+        "core": attr.label_list(
+            allow_files = [".o"],
+            doc = "eBPF .o targets, placed under the output directory's co-re/ subdirectory as <target name>.o.",
+        ),
+    },
+)

--- a/pkg/ebpf/testdata/c/BUILD.bazel
+++ b/pkg/ebpf/testdata/c/BUILD.bazel
@@ -30,6 +30,7 @@ ebpf_prog(
     src = "sleepable.c",
     core = True,
     extra_flags = _TEST_FLAGS,
+    visibility = ["//visibility:public"],
     deps = _COMMON_DEPS,
 )
 

--- a/pkg/ebpf/verifier/BUILD.bazel
+++ b/pkg/ebpf/verifier/BUILD.bazel
@@ -1,4 +1,14 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("//bazel/rules/ebpf:ebpf_object_dir.bzl", "ebpf_object_dir")
+load("//tasks:ebpf_targets.bzl", "CORE_TARGETS", "PREBUILT_TARGETS")
+
+# keep
+ebpf_object_dir(
+    name = "verifier_bpf_dir",
+    core = CORE_TARGETS,
+    prebuilt = PREBUILT_TARGETS,
+    visibility = ["//pkg/ebpf/verifier:__subpackages__"],
+)
 
 #gazelle:dd_linux_bpf on
 
@@ -34,11 +44,16 @@ go_test(
         "stats_test.go",
         "verifier_log_parser_test.go",
     ],
+    data = [":verifier_bpf_dir"],
     embed = [":verifier"],
+    env = {
+        "DD_SYSTEM_PROBE_BPF_DIR": "$(rootpath :verifier_bpf_dir)",
+    },
     gotags = [
         "test",
         "linux_bpf",
     ],
+    rundir = ".",
     tags = ["manual"],  # keep
     target_compatible_with = ["@platforms//os:linux"],
     deps = [

--- a/pkg/ebpf/verifier/calculator/BUILD.bazel
+++ b/pkg/ebpf/verifier/calculator/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "calculator_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/ebpf/verifier/calculator",
+    tags = ["manual"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/ebpf/verifier",
+        "@com_github_cilium_ebpf//rlimit",
+    ],
+)
+
+go_binary(
+    name = "calculator",
+    data = ["//pkg/ebpf/verifier:verifier_bpf_dir"],
+    embed = [":calculator_lib"],
+    env = {
+        "DD_SYSTEM_PROBE_BPF_DIR": "$(rootpath //pkg/ebpf/verifier:verifier_bpf_dir)",
+    },
+    gotags = ["linux_bpf"],
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/ebpf/verifier/calculator/main.go
+++ b/pkg/ebpf/verifier/calculator/main.go
@@ -75,6 +75,12 @@ func main() {
 	if directory == "" {
 		log.Fatalf("DD_SYSTEM_PROBE_BPF_DIR env var not set")
 	}
+	// filepath.WalkDir does not descend into its root argument if that root
+	// itself is a symlink (e.g. a Bazel data dependency's runfiles entry).
+	directory, err = filepath.EvalSymlinks(directory)
+	if err != nil {
+		log.Fatalf("failed to resolve %s: %v", directory, err)
+	}
 	hasAbsPaths := false
 	for _, f := range filterFiles {
 		if filepath.IsAbs(f) {

--- a/tasks/ebpf.py
+++ b/tasks/ebpf.py
@@ -5,13 +5,13 @@ import shutil
 
 from tasks.github_tasks import pr_commenter
 from tasks.kmt import download_complexity_data
+from tasks.libs.build.bazel import bazel
 from tasks.libs.ciproviders.github_api import GithubAPI
 from tasks.libs.common.git import (
     get_commit_sha,
     get_common_ancestor,
     get_current_branch,
 )
-from tasks.libs.types.arch import Arch
 
 try:
     from termcolor import colored
@@ -41,9 +41,6 @@ except ImportError:
     tabulate = None
 
 from .system_probe import (
-    build_cws_object_files,
-    build_object_files,
-    get_ebpf_build_dir,
     is_root,
 )
 
@@ -141,7 +138,6 @@ def format_verifier_stats(verifier_stats) -> ComplexitySummary:
 
 @task(
     help={
-        "skip_object_files": "Do not build ebpf object files",
         "debug_build": "Collect verification statistics for debug builds",
         "filter_file": "List of files to load ebpf program from, specified without extension. By default we load everything",
         "grep": "Regex to filter program statistics",
@@ -152,7 +148,6 @@ def format_verifier_stats(verifier_stats) -> ComplexitySummary:
 )
 def collect_verification_stats(
     ctx,
-    skip_object_files=False,
     debug_build=False,
     filter_file: list[str] = None,  # type: ignore
     grep: list[str] = None,  # type: ignore
@@ -160,14 +155,6 @@ def collect_verification_stats(
     save_verifier_logs=False,
 ):
     sudo = "sudo -E" if not is_root() else ""
-    if not skip_object_files:
-        build_object_files(ctx)
-        build_cws_object_files(ctx)
-
-    ctx.run("go build -tags linux_bpf pkg/ebpf/verifier/calculator/main.go")
-
-    arch = Arch.local()
-    env = {"DD_SYSTEM_PROBE_BPF_DIR": f"./{get_ebpf_build_dir(arch)}"}
 
     # ensure all files are object files
     for f in filter_file or []:
@@ -175,29 +162,35 @@ def collect_verification_stats(
         if ext != ".o":
             raise Exit(f"File {f} does not have the valid '.o' extension")
 
-    args = (
-        [
-            "-debug" if debug_build else "",
-            "-summary-output",
-            os.fspath(VERIFIER_STATS),
-        ]
-        + [f"-filter-file {f}" for f in filter_file or []]
-        + [f"-filter-prog {p}" for p in grep or []]
-    )
+    args = [
+        *(["-debug"] if debug_build else []),
+        "-summary-output",
+        os.path.abspath(VERIFIER_STATS),
+    ]
+    for f in filter_file or []:
+        args += ["-filter-file", f]
+    for p in grep or []:
+        args += ["-filter-prog", p]
 
     if save_verifier_logs:
         LOGS_DIR.mkdir(exist_ok=True, parents=True)
-        args += ["-verifier-logs", os.fspath(LOGS_DIR)]
+        args += ["-verifier-logs", os.path.abspath(LOGS_DIR)]
 
     if line_complexity:
         COMPLEXITY_DATA_DIR.mkdir(exist_ok=True, parents=True)
         args += [
             "-line-complexity",
             "-complexity-data-dir",
-            os.fspath(COMPLEXITY_DATA_DIR),
+            os.path.abspath(COMPLEXITY_DATA_DIR),
         ]
 
-    ctx.run(f"{sudo} ./main {' '.join(args)}", env=env)
+    # The calculator's own Bazel target builds the eBPF object files it needs
+    # and points DD_SYSTEM_PROBE_BPF_DIR at them; sudo is applied via
+    # --run_under so only the calculator binary is elevated, not bazel itself.
+    bazel_args = ["run", "//pkg/ebpf/verifier/calculator"]
+    if sudo:
+        bazel_args.insert(1, f"--run_under={sudo}")
+    bazel(ctx, *bazel_args, "--", *args)
 
     # Ensure permissions are correct
     ctx.run(f"{sudo} chmod a+wr -R {VERIFIER_DATA_DIR}")

--- a/tasks/ebpf_targets.bzl
+++ b/tasks/ebpf_targets.bzl
@@ -1,0 +1,65 @@
+"""Canonical eBPF program target lists, shared by Python and Bazel.
+
+This is the single source of truth for the Bazel targets that produce the
+compiled eBPF .o programs consumed via DD_SYSTEM_PROBE_BPF_DIR (prebuilt
+programs go to build_dir/, CO-RE programs go to build_dir/co-re/). It is
+deliberately written in the common subset of Starlark and Python so that:
+
+  - Bazel BUILD files can `load()` PREBUILT_TARGETS / CORE_TARGETS directly, and
+  - tasks/system_probe.py can exec it to obtain the same data.
+"""
+
+PREBUILT_TARGETS = [
+    "//pkg/network/ebpf/c/prebuilt:dns",
+    "//pkg/network/ebpf/c/prebuilt:dns-debug",
+    "//pkg/network/ebpf/c/prebuilt:offset-guess",
+    "//pkg/network/ebpf/c/prebuilt:offset-guess-debug",
+    "//pkg/network/ebpf/c/prebuilt:tracer",
+    "//pkg/network/ebpf/c/prebuilt:tracer-debug",
+    "//pkg/network/ebpf/c/prebuilt:usm",
+    "//pkg/network/ebpf/c/prebuilt:usm-debug",
+    "//pkg/network/ebpf/c/prebuilt:usm_events_test",
+    "//pkg/network/ebpf/c/prebuilt:usm_events_test-debug",
+    "//pkg/network/ebpf/c/prebuilt:shared-libraries",
+    "//pkg/network/ebpf/c/prebuilt:shared-libraries-debug",
+    "//pkg/network/ebpf/c/prebuilt:conntrack",
+    "//pkg/network/ebpf/c/prebuilt:conntrack-debug",
+    "//pkg/security/ebpf/c/prebuilt:runtime-security",
+    "//pkg/security/ebpf/c/prebuilt:runtime-security-syscall-wrapper",
+    "//pkg/security/ebpf/c/prebuilt:runtime-security-fentry",
+    "//pkg/security/ebpf/c/prebuilt:runtime-security-offset-guesser",
+]
+
+CORE_TARGETS = [
+    "//pkg/ebpf/c:lock_contention",
+    "//pkg/ebpf/c:ksyms_iter",
+    "//pkg/network/ebpf/c:tracer",
+    "//pkg/network/ebpf/c/sk:sk_tracer",
+    "//pkg/network/ebpf/c/sk:sk_tracer-debug",
+    "//pkg/network/ebpf/c:tracer-debug",
+    "//pkg/network/ebpf/c/co-re:tracer-fentry",
+    "//pkg/network/ebpf/c/co-re:tracer-fentry-debug",
+    "//pkg/network/ebpf/c/runtime:usm",
+    "//pkg/network/ebpf/c/runtime:usm-debug",
+    "//pkg/network/ebpf/c/runtime:shared-libraries",
+    "//pkg/network/ebpf/c/runtime:shared-libraries-debug",
+    "//pkg/network/ebpf/c/runtime:conntrack",
+    "//pkg/network/ebpf/c/runtime:conntrack-debug",
+    "//pkg/collector/corechecks/ebpf/c/runtime:oom-kill",
+    "//pkg/collector/corechecks/ebpf/c/runtime:oom-kill-debug",
+    "//pkg/collector/corechecks/ebpf/c/runtime:tcp-queue-length",
+    "//pkg/collector/corechecks/ebpf/c/runtime:tcp-queue-length-debug",
+    "//pkg/collector/corechecks/ebpf/c/runtime:ebpf",
+    "//pkg/collector/corechecks/ebpf/c/runtime:ebpf-debug",
+    "//pkg/collector/corechecks/ebpf/c/runtime:noisy-neighbor",
+    "//pkg/collector/corechecks/ebpf/c/runtime:noisy-neighbor-debug",
+    "//pkg/gpu/ebpf/c/runtime:gpu",
+    "//pkg/gpu/ebpf/c/runtime:gpu-debug",
+    "//pkg/dyninst/ebpf:dyninst_event",
+    "//pkg/dyninst/ebpf:dyninst_event-debug",
+    "//pkg/ebpf/testdata/c:logdebug-test",
+    "//pkg/ebpf/testdata/c:error_telemetry",
+    "//pkg/ebpf/testdata/c:sleepable",
+    "//pkg/ebpf/testdata/c:uprobe_attacher-test",
+    "//cmd/system-probe/subcommands/ebpf/testdata:btf_test",
+]

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -778,20 +778,7 @@ def ninja_build_dependencies(ctx: Context, nw: NinjaWriter, kmt_paths: KMTPaths,
         variables={"mode": "-m744"},
     )
 
-    verifier_files = glob("pkg/ebpf/verifier/*")
-    nw.build(
-        rule="gobin",
-        pool="gobuild",
-        inputs=[os.path.abspath("./pkg/ebpf/verifier/calculator/main.go")],
-        outputs=[os.fspath(kmt_paths.dependencies / "verifier-calculator")],
-        implicit=[os.path.abspath(f) for f in verifier_files],
-        variables={
-            "go": go_path,
-            "chdir": "true",
-            "env": env_str,
-            "tags": f"-tags=\"{','.join(get_sysprobe_test_buildtags(False, False))}\"",
-        },
-    )
+    build_verifier_calculator(ctx, kmt_paths)
 
 
 def ninja_copy_ebpf_files(
@@ -1055,6 +1042,21 @@ def build_object_files(ctx, arch: Arch):
     runtime_dir = get_ebpf_runtime_dir()
     bazel_build_ebpf(ctx, arch, str(build_dir), str(runtime_dir), strip=False)
     bazel(ctx, "test", *ebpf_bazel_flags(arch), "//pkg/ebpf:verify_generated_files")
+
+
+def build_verifier_calculator(ctx, kmt_paths: KMTPaths):
+    # KMT always runs on a runner matching the target VM's architecture, so
+    # this builds natively rather than cross-compiling via --platforms=.
+    info("[+] Building verifier calculator via Bazel...")
+    bazel(ctx, "build", "//pkg/ebpf/verifier/calculator")
+    execroot = bazel(ctx, "info", "execution_root", capture_output=True).strip()
+    # cquery resolves the actual output path, accounting for the gotags-driven
+    # self-transition on this target; "bazel info bazel-bin" does not.
+    rel_path = bazel(ctx, "cquery", "--output=files", "//pkg/ebpf/verifier/calculator", capture_output=True).strip()
+    dest = kmt_paths.dependencies / "verifier-calculator"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(os.path.join(execroot, rel_path), dest)
+    os.chmod(dest, 0o755)
 
 
 def compute_package_dependencies(ctx: Context, packages: list[str], build_tags: list[str]) -> dict[str, set[str]]:

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -778,7 +778,10 @@ def ninja_build_dependencies(ctx: Context, nw: NinjaWriter, kmt_paths: KMTPaths,
         variables={"mode": "-m744"},
     )
 
-    build_verifier_calculator(ctx, kmt_paths)
+    if arch.is_cross_compiling():
+        build_verifier_calculator_ninja(nw, kmt_paths, go_path, env_str)
+    else:
+        build_verifier_calculator_bazel(ctx, kmt_paths)
 
 
 def ninja_copy_ebpf_files(
@@ -1044,9 +1047,10 @@ def build_object_files(ctx, arch: Arch):
     bazel(ctx, "test", *ebpf_bazel_flags(arch), "//pkg/ebpf:verify_generated_files")
 
 
-def build_verifier_calculator(ctx, kmt_paths: KMTPaths):
-    # KMT always runs on a runner matching the target VM's architecture, so
-    # this builds natively rather than cross-compiling via --platforms=.
+def build_verifier_calculator_bazel(ctx, kmt_paths: KMTPaths):
+    # Bazel builds this target natively only (no --platforms= cross-compilation
+    # support yet); callers must fall back to build_verifier_calculator_ninja
+    # when cross-compiling for a KMT VM of a different arch than the host.
     info("[+] Building verifier calculator via Bazel...")
     bazel(ctx, "build", "//pkg/ebpf/verifier/calculator")
     execroot = bazel(ctx, "info", "execution_root", capture_output=True).strip()
@@ -1057,6 +1061,25 @@ def build_verifier_calculator(ctx, kmt_paths: KMTPaths):
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(os.path.join(execroot, rel_path), dest)
     os.chmod(dest, 0o755)
+
+
+def build_verifier_calculator_ninja(nw: NinjaWriter, kmt_paths: KMTPaths, go_path: str, env_str: str):
+    # Cross-compilation fallback: `go build` cross-compiles cleanly via the
+    # GOARCH/CC/CXX vars already baked into env_str, unlike the Bazel path above.
+    verifier_files = glob("pkg/ebpf/verifier/*")
+    nw.build(
+        rule="gobin",
+        pool="gobuild",
+        inputs=[os.path.abspath("./pkg/ebpf/verifier/calculator/main.go")],
+        outputs=[os.fspath(kmt_paths.dependencies / "verifier-calculator")],
+        implicit=[os.path.abspath(f) for f in verifier_files],
+        variables={
+            "go": go_path,
+            "chdir": "true",
+            "env": env_str,
+            "tags": f"-tags=\"{','.join(get_sysprobe_test_buildtags(False, False))}\"",
+        },
+    )
 
 
 def compute_package_dependencies(ctx: Context, packages: list[str], build_tags: list[str]) -> dict[str, set[str]]:

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -92,6 +92,19 @@ def bazel_not_found_message(color: str) -> str:
     return color_message("Please run `inv install-tools` for `bazel` support!", color)
 
 
+_PLATFORM_BY_KMT_ARCH = {
+    "x86_64": "//bazel/platforms:linux_x86_64",
+    "arm64": "//bazel/platforms:linux_arm64",
+}
+
+
+def bazel_platform_flags(arch) -> list[str]:
+    """Return --platforms flags to cross-compile for the given KMT arch, if supported."""
+    if arch.kmt_arch in _PLATFORM_BY_KMT_ARCH:
+        return [f"--platforms={_PLATFORM_BY_KMT_ARCH[arch.kmt_arch]}"]
+    return []
+
+
 def bazel(
     ctx: Context,
     *args: str,

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import contextlib
 import glob
+import importlib.machinery
+import importlib.util
 import itertools
 import json
 import os
@@ -37,6 +39,17 @@ from tasks.libs.common.utils import (
     parse_kernel_version,
 )
 from tasks.libs.types.arch import ALL_ARCHS, Arch
+
+# Load the shared Starlark/Python eBPF target list. It is valid Python (plain
+# list literals), so we exec it and rebind the names below. An explicit
+# SourceFileLoader is needed because importlib won't infer one from the .bzl
+# extension.
+_EBPF_TARGETS_BZL_PATH = Path(__file__).with_name("ebpf_targets.bzl")
+_ebpf_targets_loader = importlib.machinery.SourceFileLoader("tasks._ebpf_targets_data", str(_EBPF_TARGETS_BZL_PATH))
+_ebpf_targets_spec = importlib.util.spec_from_loader(_ebpf_targets_loader.name, _ebpf_targets_loader)
+assert _ebpf_targets_spec is not None
+_ebpf_targets_data = importlib.util.module_from_spec(_ebpf_targets_spec)
+_ebpf_targets_loader.exec_module(_ebpf_targets_data)
 
 BIN_DIR = os.path.join(".", "bin", "system-probe")
 BIN_PATH = os.path.join(BIN_DIR, bin_name("system-probe"))
@@ -906,60 +919,10 @@ def validate_object_file_metadata(ctx: Context, build_dir: str | Path = "pkg/ebp
 
 # All Bazel eBPF targets, grouped by output directory.
 # Prebuilt targets go to build_dir/, CO-RE targets go to build_dir/co-re/.
-_BAZEL_EBPF_PREBUILT_TARGETS = [
-    "//pkg/network/ebpf/c/prebuilt:dns",
-    "//pkg/network/ebpf/c/prebuilt:dns-debug",
-    "//pkg/network/ebpf/c/prebuilt:offset-guess",
-    "//pkg/network/ebpf/c/prebuilt:offset-guess-debug",
-    "//pkg/network/ebpf/c/prebuilt:tracer",
-    "//pkg/network/ebpf/c/prebuilt:tracer-debug",
-    "//pkg/network/ebpf/c/prebuilt:usm",
-    "//pkg/network/ebpf/c/prebuilt:usm-debug",
-    "//pkg/network/ebpf/c/prebuilt:usm_events_test",
-    "//pkg/network/ebpf/c/prebuilt:usm_events_test-debug",
-    "//pkg/network/ebpf/c/prebuilt:shared-libraries",
-    "//pkg/network/ebpf/c/prebuilt:shared-libraries-debug",
-    "//pkg/network/ebpf/c/prebuilt:conntrack",
-    "//pkg/network/ebpf/c/prebuilt:conntrack-debug",
-    "//pkg/security/ebpf/c/prebuilt:runtime-security",
-    "//pkg/security/ebpf/c/prebuilt:runtime-security-syscall-wrapper",
-    "//pkg/security/ebpf/c/prebuilt:runtime-security-fentry",
-    "//pkg/security/ebpf/c/prebuilt:runtime-security-offset-guesser",
-]
+# Canonical list lives in ebpf_targets.bzl, shared with Bazel BUILD files.
+_BAZEL_EBPF_PREBUILT_TARGETS = _ebpf_targets_data.PREBUILT_TARGETS
 
-_BAZEL_EBPF_CORE_TARGETS = [
-    "//pkg/ebpf/c:lock_contention",
-    "//pkg/ebpf/c:ksyms_iter",
-    "//pkg/network/ebpf/c:tracer",
-    "//pkg/network/ebpf/c/sk:sk_tracer",
-    "//pkg/network/ebpf/c/sk:sk_tracer-debug",
-    "//pkg/network/ebpf/c:tracer-debug",
-    "//pkg/network/ebpf/c/co-re:tracer-fentry",
-    "//pkg/network/ebpf/c/co-re:tracer-fentry-debug",
-    "//pkg/network/ebpf/c/runtime:usm",
-    "//pkg/network/ebpf/c/runtime:usm-debug",
-    "//pkg/network/ebpf/c/runtime:shared-libraries",
-    "//pkg/network/ebpf/c/runtime:shared-libraries-debug",
-    "//pkg/network/ebpf/c/runtime:conntrack",
-    "//pkg/network/ebpf/c/runtime:conntrack-debug",
-    "//pkg/collector/corechecks/ebpf/c/runtime:oom-kill",
-    "//pkg/collector/corechecks/ebpf/c/runtime:oom-kill-debug",
-    "//pkg/collector/corechecks/ebpf/c/runtime:tcp-queue-length",
-    "//pkg/collector/corechecks/ebpf/c/runtime:tcp-queue-length-debug",
-    "//pkg/collector/corechecks/ebpf/c/runtime:ebpf",
-    "//pkg/collector/corechecks/ebpf/c/runtime:ebpf-debug",
-    "//pkg/collector/corechecks/ebpf/c/runtime:noisy-neighbor",
-    "//pkg/collector/corechecks/ebpf/c/runtime:noisy-neighbor-debug",
-    "//pkg/gpu/ebpf/c/runtime:gpu",
-    "//pkg/gpu/ebpf/c/runtime:gpu-debug",
-    "//pkg/dyninst/ebpf:dyninst_event",
-    "//pkg/dyninst/ebpf:dyninst_event-debug",
-    "//pkg/ebpf/testdata/c:logdebug-test",
-    "//pkg/ebpf/testdata/c:error_telemetry",
-    "//pkg/ebpf/testdata/c:sleepable",
-    "//pkg/ebpf/testdata/c:uprobe_attacher-test",
-    "//cmd/system-probe/subcommands/ebpf/testdata:btf_test",
-]
+_BAZEL_EBPF_CORE_TARGETS = _ebpf_targets_data.CORE_TARGETS
 
 # Targets that go to their own source directory, not build_dir/co-re/
 _BAZEL_EBPF_INPLACE_TARGETS = {

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -24,7 +24,7 @@ from invoke.tasks import task
 
 from tasks.build_tags import UNIT_TEST_TAGS, get_default_build_tags
 from tasks.flavor import AgentFlavor
-from tasks.libs.build.bazel import bazel
+from tasks.libs.build.bazel import bazel, bazel_platform_flags
 from tasks.libs.build.ninja import NinjaWriter
 from tasks.libs.ciproviders.gitlab_api import ReferenceTag
 from tasks.libs.common.color import color_message
@@ -1197,14 +1197,7 @@ def build_rust_binaries(ctx: Context, arch: Arch, output_dir: Path | None = None
     if is_windows or is_macos:
         return
 
-    platform_map = {
-        "x86_64": "//bazel/platforms:linux_x86_64",
-        "arm64": "//bazel/platforms:linux_arm64",
-    }
-
-    platform_flags = []
-    if arch.kmt_arch in platform_map:
-        platform_flags.append(f"--platforms={platform_map[arch.kmt_arch]}")
+    platform_flags = bazel_platform_flags(arch)
 
     for source_path in RUST_BINARIES:
         if packages and not any(source_path.startswith(package) for package in packages):


### PR DESCRIPTION
### What does this PR do?

Migrates pkg/ebpf/verifier/calculator to Bazel.

### Motivation

Ongoing bazel migration

### Describe how you validated your changes

- bazel build //pkg/ebpf/verifier/... succeeds
- CI for most KMT operations

### Additional Notes
