### PR TITLE
[NDM] Apply decrypted SNMP secret inputs in connectivityCheck action

### DIFF
--- a/pkg/privateactionrunner/bundles/remoteaction/networkdevices/BUILD.bazel
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkdevices/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/privateactionrunner/libs/privateconnection",
         "//pkg/privateactionrunner/types",
         "//pkg/snmp/gosnmplib",
-        "//pkg/util/log",
         "@com_github_gosnmp_gosnmp//:gosnmp",
     ],
 )

--- a/pkg/privateactionrunner/bundles/remoteaction/networkdevices/connectivity_check.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkdevices/connectivity_check.go
@@ -50,18 +50,6 @@ type PingOptions struct {
 	TimeoutMs int `json:"timeoutMs"`
 }
 
-type SNMPCredential struct {
-	ID           string `json:"id"`
-	Version      string `json:"version"`
-	Community    string `json:"community,omitempty"`
-	User         string `json:"user,omitempty"`
-	AuthProtocol string `json:"authProtocol,omitempty"`
-	AuthKey      string `json:"authKey,omitempty"`
-	PrivProtocol string `json:"privProtocol,omitempty"`
-	PrivKey      string `json:"privKey,omitempty"`
-	ContextName  string `json:"contextName,omitempty"`
-}
-
 type SNMPOptions struct {
 	Port      int `json:"port"`
 	TimeoutMs int `json:"timeoutMs"`
@@ -75,6 +63,18 @@ type ConnectivityCheckRequest struct {
 	SNMPOptions          *SNMPOptions                        `json:"snmpOptions,omitempty"`
 	EncryptedCredentials string                              `json:"encryptedCredentials"`
 	EncryptionContext    encryptioncontext.EncryptionContext `json:"encryptionContext"`
+}
+
+type SNMPCredential struct {
+	ID           string `json:"id"`
+	Version      string `json:"version"`
+	Community    string `json:"community,omitempty"`
+	User         string `json:"user,omitempty"`
+	AuthProtocol string `json:"authProtocol,omitempty"`
+	AuthKey      string `json:"authKey,omitempty"`
+	PrivProtocol string `json:"privProtocol,omitempty"`
+	PrivKey      string `json:"privKey,omitempty"`
+	ContextName  string `json:"contextName,omitempty"`
 }
 
 type secretInputs struct {

--- a/pkg/privateactionrunner/bundles/remoteaction/networkdevices/connectivity_check.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkdevices/connectivity_check.go
@@ -21,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -78,8 +77,6 @@ type ConnectivityCheckRequest struct {
 	EncryptionContext    encryptioncontext.EncryptionContext `json:"encryptionContext"`
 }
 
-// secretInputs is the decrypted per-task secret_inputs payload — the SNMP
-// credentials the API sends encrypted instead of in the plaintext action inputs.
 type secretInputs struct {
 	SNMP []SNMPCredential `json:"snmp"`
 }
@@ -126,15 +123,12 @@ func (h *ConnectivityCheckHandler) Run(ctx context.Context, task *types.Task, _ 
 		return nil, fmt.Errorf("failed to parse connectivityCheck inputs: %w", err)
 	}
 
-	// Decrypt the per-task secret inputs — the SNMP credentials, sent encrypted in
-	// encryptedCredentials rather than in the plaintext action inputs.
 	secrets, err := encryptioncontext.DecryptInto[secretInputs](h.encryptionStore, req.EncryptionContext, req.EncryptedCredentials)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decrypt secret inputs: %w", err)
 	}
-	log.Debugf("connectivityCheck decrypted %d SNMP secret input(s) (encryptionContextId=%s)", len(secrets.SNMP), req.EncryptionContext.EncryptionContextID)
 
-	res, err := runChecks(ctx, req, secrets.SNMP)
+	res, err := runChecks(ctx, req, secrets)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run connectivity checks: %w", err)
 	}
@@ -142,7 +136,7 @@ func (h *ConnectivityCheckHandler) Run(ctx context.Context, task *types.Task, _ 
 	return res, nil
 }
 
-func runChecks(ctx context.Context, req ConnectivityCheckRequest, snmpCreds []SNMPCredential) (ConnectivityCheckResult, error) {
+func runChecks(ctx context.Context, req ConnectivityCheckRequest, secrets secretInputs) (ConnectivityCheckResult, error) {
 	devices := make([]DeviceResult, 0, len(req.TargetIPs))
 	for _, ip := range req.TargetIPs {
 		if err := ctx.Err(); err != nil {
@@ -160,7 +154,7 @@ func runChecks(ctx context.Context, req ConnectivityCheckRequest, snmpCreds []SN
 
 				dr.PingResult = res
 			case checkSNMP:
-				res, err := runSNMP(ctx, ip, req.SNMPOptions, snmpCreds)
+				res, err := runSNMP(ctx, ip, req.SNMPOptions, secrets.SNMP)
 				if err != nil {
 					return ConnectivityCheckResult{}, fmt.Errorf("failed to run SNMP check for host '%s': %w", ip, err)
 				}

--- a/pkg/privateactionrunner/bundles/remoteaction/networkdevices/connectivity_check.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkdevices/connectivity_check.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -62,14 +63,11 @@ type SNMPCredential struct {
 	ContextName  string `json:"contextName,omitempty"`
 }
 
-type Credentials struct {
-	Creds []SNMPCredential `json:"creds"`
-}
-
 type SNMPOptions struct {
-	Port      int `json:"port"`
-	TimeoutMs int `json:"timeoutMs"`
-	Retries   int `json:"retries"`
+	Port      int              `json:"port"`
+	Creds     []SNMPCredential `json:"creds"`
+	TimeoutMs int              `json:"timeoutMs"`
+	Retries   int              `json:"retries"`
 }
 
 type ConnectivityCheckRequest struct {
@@ -79,6 +77,12 @@ type ConnectivityCheckRequest struct {
 	SNMPOptions          *SNMPOptions                        `json:"snmpOptions,omitempty"`
 	EncryptedCredentials string                              `json:"encryptedCredentials"`
 	EncryptionContext    encryptioncontext.EncryptionContext `json:"encryptionContext"`
+}
+
+// secretInputs is the decrypted per-task secret_inputs payload — the SNMP
+// credentials the API sends encrypted instead of in the plaintext action inputs.
+type secretInputs struct {
+	SNMP []SNMPCredential `json:"snmp"`
 }
 
 type CheckResult struct {
@@ -123,12 +127,21 @@ func (h *ConnectivityCheckHandler) Run(ctx context.Context, task *types.Task, _ 
 		return nil, fmt.Errorf("failed to parse connectivityCheck inputs: %w", err)
 	}
 
-	decryptedCredentials, err := encryptioncontext.DecryptInto[Credentials](h.encryptionStore, req.EncryptionContext, req.EncryptedCredentials)
+	// Decrypt the per-task secret inputs (SNMP credentials, sent encrypted rather
+	// than in the plaintext action inputs) and apply them to the SNMP options.
+	secrets, err := encryptioncontext.DecryptInto[secretInputs](h.encryptionStore, req.EncryptionContext, req.EncryptedCredentials)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt credentials: %w", err)
+		return nil, fmt.Errorf("failed to decrypt secret inputs: %w", err)
 	}
+	if len(secrets.SNMP) > 0 {
+		if req.SNMPOptions == nil {
+			req.SNMPOptions = &SNMPOptions{}
+		}
+		req.SNMPOptions.Creds = secrets.SNMP
+	}
+	log.Debugf("connectivityCheck applied %d decrypted SNMP secret input(s) (encryptionContextId=%s)", len(secrets.SNMP), req.EncryptionContext.EncryptionContextID)
 
-	res, err := runChecks(ctx, req, decryptedCredentials.Creds)
+	res, err := runChecks(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run connectivity checks: %w", err)
 	}
@@ -136,7 +149,7 @@ func (h *ConnectivityCheckHandler) Run(ctx context.Context, task *types.Task, _ 
 	return res, nil
 }
 
-func runChecks(ctx context.Context, req ConnectivityCheckRequest, credentials []SNMPCredential) (ConnectivityCheckResult, error) {
+func runChecks(ctx context.Context, req ConnectivityCheckRequest) (ConnectivityCheckResult, error) {
 	devices := make([]DeviceResult, 0, len(req.TargetIPs))
 	for _, ip := range req.TargetIPs {
 		if err := ctx.Err(); err != nil {
@@ -154,7 +167,7 @@ func runChecks(ctx context.Context, req ConnectivityCheckRequest, credentials []
 
 				dr.PingResult = res
 			case checkSNMP:
-				res, err := runSNMP(ctx, ip, req.SNMPOptions, credentials)
+				res, err := runSNMP(ctx, ip, req.SNMPOptions)
 				if err != nil {
 					return ConnectivityCheckResult{}, fmt.Errorf("failed to run SNMP check for host '%s': %w", ip, err)
 				}
@@ -218,13 +231,13 @@ func buildPinger(opts *PingOptions) (pinger.Pinger, error) {
 	})
 }
 
-func runSNMP(ctx context.Context, host string, opts *SNMPOptions, credentials []SNMPCredential) (*SNMPResult, error) {
+func runSNMP(ctx context.Context, host string, opts *SNMPOptions) (*SNMPResult, error) {
 	if opts == nil {
 		return nil, errors.New("options are required for SNMP")
 	}
 
 	var lastResult *SNMPResult
-	for _, cred := range credentials {
+	for _, cred := range opts.Creds {
 		res, err := trySNMPCredential(ctx, host, opts, cred)
 		if err != nil {
 			return nil, err

--- a/pkg/privateactionrunner/bundles/remoteaction/networkdevices/connectivity_check.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkdevices/connectivity_check.go
@@ -64,10 +64,9 @@ type SNMPCredential struct {
 }
 
 type SNMPOptions struct {
-	Port      int              `json:"port"`
-	Creds     []SNMPCredential `json:"creds"`
-	TimeoutMs int              `json:"timeoutMs"`
-	Retries   int              `json:"retries"`
+	Port      int `json:"port"`
+	TimeoutMs int `json:"timeoutMs"`
+	Retries   int `json:"retries"`
 }
 
 type ConnectivityCheckRequest struct {
@@ -127,21 +126,15 @@ func (h *ConnectivityCheckHandler) Run(ctx context.Context, task *types.Task, _ 
 		return nil, fmt.Errorf("failed to parse connectivityCheck inputs: %w", err)
 	}
 
-	// Decrypt the per-task secret inputs (SNMP credentials, sent encrypted rather
-	// than in the plaintext action inputs) and apply them to the SNMP options.
+	// Decrypt the per-task secret inputs — the SNMP credentials, sent encrypted in
+	// encryptedCredentials rather than in the plaintext action inputs.
 	secrets, err := encryptioncontext.DecryptInto[secretInputs](h.encryptionStore, req.EncryptionContext, req.EncryptedCredentials)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decrypt secret inputs: %w", err)
 	}
-	if len(secrets.SNMP) > 0 {
-		if req.SNMPOptions == nil {
-			req.SNMPOptions = &SNMPOptions{}
-		}
-		req.SNMPOptions.Creds = secrets.SNMP
-	}
-	log.Debugf("connectivityCheck applied %d decrypted SNMP secret input(s) (encryptionContextId=%s)", len(secrets.SNMP), req.EncryptionContext.EncryptionContextID)
+	log.Debugf("connectivityCheck decrypted %d SNMP secret input(s) (encryptionContextId=%s)", len(secrets.SNMP), req.EncryptionContext.EncryptionContextID)
 
-	res, err := runChecks(ctx, req)
+	res, err := runChecks(ctx, req, secrets.SNMP)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run connectivity checks: %w", err)
 	}
@@ -149,7 +142,7 @@ func (h *ConnectivityCheckHandler) Run(ctx context.Context, task *types.Task, _ 
 	return res, nil
 }
 
-func runChecks(ctx context.Context, req ConnectivityCheckRequest) (ConnectivityCheckResult, error) {
+func runChecks(ctx context.Context, req ConnectivityCheckRequest, snmpCreds []SNMPCredential) (ConnectivityCheckResult, error) {
 	devices := make([]DeviceResult, 0, len(req.TargetIPs))
 	for _, ip := range req.TargetIPs {
 		if err := ctx.Err(); err != nil {
@@ -167,7 +160,7 @@ func runChecks(ctx context.Context, req ConnectivityCheckRequest) (ConnectivityC
 
 				dr.PingResult = res
 			case checkSNMP:
-				res, err := runSNMP(ctx, ip, req.SNMPOptions)
+				res, err := runSNMP(ctx, ip, req.SNMPOptions, snmpCreds)
 				if err != nil {
 					return ConnectivityCheckResult{}, fmt.Errorf("failed to run SNMP check for host '%s': %w", ip, err)
 				}
@@ -231,13 +224,13 @@ func buildPinger(opts *PingOptions) (pinger.Pinger, error) {
 	})
 }
 
-func runSNMP(ctx context.Context, host string, opts *SNMPOptions) (*SNMPResult, error) {
+func runSNMP(ctx context.Context, host string, opts *SNMPOptions, creds []SNMPCredential) (*SNMPResult, error) {
 	if opts == nil {
 		return nil, errors.New("options are required for SNMP")
 	}
 
 	var lastResult *SNMPResult
-	for _, cred := range opts.Creds {
+	for _, cred := range creds {
 		res, err := trySNMPCredential(ctx, host, opts, cred)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### What does this PR do?

Builds on #53073 (which decrypts the connectivityCheck per-task secret inputs but only logs them): threads the decrypted **SNMP credentials** into the SNMP check.

The decrypted `encryptedCredentials` payload is parsed as `{"snmp": [ ... ]}` and threaded directly into the SNMP check (`runChecks` → `runSNMP`), so `runSNMP` probes with the decrypted-per-task credentials. The `creds` field is dropped from `SNMPOptions` — SNMP credentials now come **only** from `encryptedCredentials`, never the plaintext action inputs. `Decrypt` → `DecryptInto[secretInputs]`, and the placeholder that logged the decrypted plaintext is removed (only a count + `encryptionContextId` are logged now).

### Motivation

Deliver SNMP credentials to the connectivityCheck action **encrypted per task** instead of in the plaintext action inputs. This is the Agent (decrypt) half; the API (encrypt/send) half is ddoghq/dd-source#11347, which sends the same `{snmp: [...]}` shape via `ExecuteOboWithSecretInputs`' `secret_inputs`.

### Describe how you validated your changes

`bazel build //pkg/privateactionrunner/bundles/remoteaction/networkdevices:all`. End-to-end validation is pending the paired dd-source PRs (#6911 + #11347) landing.

### Possible Drawbacks / Trade-offs

The `snmp` secret-input shape (the `SNMPCredential` fields) must stay in sync with the API side (dd-source#11347).

### Additional Notes

Stacked on #53073 (base branch `martin.prevost/ACTP-1609/add-encryption-layer`); draft until #53073 and the dd-source side merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

