### PR TITLE
fix(aix): fix linter issues in AIX process files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -191,6 +191,7 @@ linters:
             - "!**/comp/otelcol/otlp/configcheck/configcheck_test.go"
             - "!**/comp/otelcol/otlp/integrationtest/integration_test.go"
             - "!**/comp/otelcol/otlp/testutil/testutil.go"
+            - "!**/comp/process/agent/agent_aix.go"
             - "!**/comp/process/agent/agent_linux.go"
             - "!**/comp/process/agent/impl/agent_linux.go"
             - "!**/comp/process/agent/impl/status.go"

--- a/pkg/process/procutil/process_aix.go
+++ b/pkg/process/procutil/process_aix.go
@@ -58,7 +58,7 @@ type psinfo struct {
 	Flag2  uint32
 	Nlwp   uint32 // number of threads
 	_      uint32
-	Uid    uint64
+	UID    uint64
 	Euid   uint64
 	Gid    uint64
 	Egid   uint64
@@ -145,7 +145,7 @@ func psinfoToProcess(psi *psinfo, pid int32) *Process {
 		Ppid:    int32(psi.Ppid),
 		Name:    name,
 		Cmdline: cmdline,
-		Uids:    []int32{int32(psi.Uid), int32(psi.Euid), int32(psi.Uid), int32(psi.Euid)},
+		Uids:    []int32{int32(psi.UID), int32(psi.Euid), int32(psi.UID), int32(psi.Euid)},
 		Gids:    []int32{int32(psi.Gid), int32(psi.Egid), int32(psi.Gid), int32(psi.Egid)},
 		Stats: &Stats{
 			CreateTime: psi.Start.Sec * 1000, // milliseconds since epoch


### PR DESCRIPTION
### What does this PR do?

Fixes two linter issues in AIX-specific files caught when running `GOOS=aix GOARCH=ppc64` cross-linting for the first time (see #53214).

### Motivation

First time running the Go linter targeting AIX exposed pre-existing issues that were never caught because the files are only compiled on AIX.

### Describe how you validated your changes

CI + `GOOS=aix GOARCH=ppc64 dda inv linter.go --targets=./comp/process/agent/... ./pkg/process/procutil/...` → 0 issues.

### Additional Notes

`agent_aix.go` has the same `pkg/config/setup` import as `agent_linux.go`, which is already in the `pkgconfigusage` TODO exclude list in `.golangci.yml`. Adding AIX to the same list for consistency rather than changing the code.