### PR TITLE
fix(network-path): restrict traceroute module to supported platforms

### DIFF
--- a/cmd/system-probe/modules/traceroute.go
+++ b/cmd/system-probe/modules/traceroute.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux || windows || darwin
+
 package modules
 
 import (


### PR DESCRIPTION
### What does this PR do?

Adds `//go:build linux || windows || darwin` to `cmd/system-probe/modules/traceroute.go`, restricting the traceroute module to platforms that actually support it.

### Motivation

The file had no build tag, causing it to compile on all platforms including AIX where it has no implementation.
This surfaced when running cross-linting for AIX (`GOOS=aix GOARCH=ppc64`). 
### Describe how you validated your changes

`GOOS=aix GOARCH=ppc64 dda inv linter.go --targets=./cmd/system-probe/modules/...` → 0 issues. CI.

### Additional Notes
