### PR TITLE
fix(healthplatform): include config filename in invalid-config issue title

### DIFF
--- a/comp/healthplatform/README.md
+++ b/comp/healthplatform/README.md
@@ -54,7 +54,7 @@ On-disk state uses human-readable strings (`"active"`, `"resolved"`). The store 
 | Package | `id` | `issue_name` | `title` |
 |---|---|---|---|
 | `admisconfig` | set by caller | `Autodiscovery Misconfiguration` | `"Autodiscovery Misconfiguration on '<entityName>'"` |
-| `invalidconfig` | `invalid-config` | `Invalid Config` | `"Datadog Agent Configuration Has Schema Violations"` |
+| `invalidconfig` | `invalid-config` | `Invalid Config` | `"Datadog Agent Configuration Has <N> Schema Violation(s) in <filename>"` |
 | `rofspermissions` | `rofs-permissions` | `Read-Only Filesystem Error` | `"Agent cannot write to: <directories>"` |
 | `checkfailure` | `check-execution-failure` | `Check Execution Failure` | `"Check '<checkName>' Failed"` |
 | `admissionprobe` | `admission-controller-connectivity-failure` | `Admission Controller Unreachable` | `"Admission Controller Unreachable"` |

--- a/comp/healthplatform/issues/invalidconfig/invalidconfig_test.go
+++ b/comp/healthplatform/issues/invalidconfig/invalidconfig_test.go
@@ -39,7 +39,7 @@ func TestBuildIssue_SchemaViolationProducesMediumSeverity(t *testing.T) {
 	assert.Empty(t, issue.GetId(), "Id is set by the runner (ReportIssue), not by the template")
 	assert.Equal(t, IssueName, issue.GetIssueName())
 	assert.Equal(t, healthplatform.IssueSeverity_ISSUE_SEVERITY_MEDIUM, issue.GetSeverity())
-	assert.Equal(t, "Datadog Agent Configuration Has 2 Schema Violations in /etc/datadog-agent/datadog.yaml", issue.GetTitle())
+	assert.Equal(t, "Datadog Agent Configuration Has 2 Schema Violations in datadog.yaml", issue.GetTitle())
 	assert.Equal(t, float64(2),
 		issue.GetExtra().GetFields()[contextKeyErrorCount].GetNumberValue())
 	assert.Contains(t, issue.GetDescription(), "agent_ipc/port")

--- a/comp/healthplatform/issues/invalidconfig/invalidconfig_test.go
+++ b/comp/healthplatform/issues/invalidconfig/invalidconfig_test.go
@@ -39,7 +39,7 @@ func TestBuildIssue_SchemaViolationProducesMediumSeverity(t *testing.T) {
 	assert.Empty(t, issue.GetId(), "Id is set by the runner (ReportIssue), not by the template")
 	assert.Equal(t, IssueName, issue.GetIssueName())
 	assert.Equal(t, healthplatform.IssueSeverity_ISSUE_SEVERITY_MEDIUM, issue.GetSeverity())
-	assert.Equal(t, "Datadog Agent Configuration Has Schema Violations in datadog.yaml", issue.GetTitle())
+	assert.Equal(t, "Datadog Agent Configuration Has 2 Schema Violations in datadog.yaml", issue.GetTitle())
 	assert.Equal(t, float64(2),
 		issue.GetExtra().GetFields()[contextKeyErrorCount].GetNumberValue())
 	assert.Contains(t, issue.GetDescription(), "agent_ipc/port")

--- a/comp/healthplatform/issues/invalidconfig/invalidconfig_test.go
+++ b/comp/healthplatform/issues/invalidconfig/invalidconfig_test.go
@@ -39,7 +39,7 @@ func TestBuildIssue_SchemaViolationProducesMediumSeverity(t *testing.T) {
 	assert.Empty(t, issue.GetId(), "Id is set by the runner (ReportIssue), not by the template")
 	assert.Equal(t, IssueName, issue.GetIssueName())
 	assert.Equal(t, healthplatform.IssueSeverity_ISSUE_SEVERITY_MEDIUM, issue.GetSeverity())
-	assert.Equal(t, "Datadog Agent Configuration Has 2 Schema Violations in datadog.yaml", issue.GetTitle())
+	assert.Equal(t, "Datadog Agent Configuration Has Schema Violations in datadog.yaml", issue.GetTitle())
 	assert.Equal(t, float64(2),
 		issue.GetExtra().GetFields()[contextKeyErrorCount].GetNumberValue())
 	assert.Contains(t, issue.GetDescription(), "agent_ipc/port")

--- a/comp/healthplatform/issues/invalidconfig/invalidconfig_test.go
+++ b/comp/healthplatform/issues/invalidconfig/invalidconfig_test.go
@@ -39,7 +39,7 @@ func TestBuildIssue_SchemaViolationProducesMediumSeverity(t *testing.T) {
 	assert.Empty(t, issue.GetId(), "Id is set by the runner (ReportIssue), not by the template")
 	assert.Equal(t, IssueName, issue.GetIssueName())
 	assert.Equal(t, healthplatform.IssueSeverity_ISSUE_SEVERITY_MEDIUM, issue.GetSeverity())
-	assert.Equal(t, "Datadog Agent Configuration Has 2 Schema Violations", issue.GetTitle())
+	assert.Equal(t, "Datadog Agent Configuration Has 2 Schema Violations in /etc/datadog-agent/datadog.yaml", issue.GetTitle())
 	assert.Equal(t, float64(2),
 		issue.GetExtra().GetFields()[contextKeyErrorCount].GetNumberValue())
 	assert.Contains(t, issue.GetDescription(), "agent_ipc/port")

--- a/comp/healthplatform/issues/invalidconfig/issue.go
+++ b/comp/healthplatform/issues/invalidconfig/issue.go
@@ -81,7 +81,7 @@ func (InvalidConfigIssue) BuildIssue(ctx map[string]string) (*healthplatform.Iss
 
 	return &healthplatform.Issue{
 		IssueName:   IssueName,
-		Title:       fmt.Sprintf("Datadog Agent Configuration Has %d Schema Violation%s", count, suffix),
+		Title:       fmt.Sprintf("Datadog Agent Configuration Has %d Schema Violation%s in %s", count, suffix, path),
 		Description: desc,
 		Category:    "configuration",
 		Location:    "agent",

--- a/comp/healthplatform/issues/invalidconfig/issue.go
+++ b/comp/healthplatform/issues/invalidconfig/issue.go
@@ -82,7 +82,7 @@ func (InvalidConfigIssue) BuildIssue(ctx map[string]string) (*healthplatform.Iss
 
 	return &healthplatform.Issue{
 		IssueName:   IssueName,
-		Title:       "Datadog Agent Configuration Has Schema Violations in " + filepath.Base(path),
+		Title:       fmt.Sprintf("Datadog Agent Configuration Has %d Schema Violation%s in %s", count, suffix, filepath.Base(path)),
 		Description: desc,
 		Category:    "configuration",
 		Location:    "agent",

--- a/comp/healthplatform/issues/invalidconfig/issue.go
+++ b/comp/healthplatform/issues/invalidconfig/issue.go
@@ -7,6 +7,7 @@ package invalidconfig
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -81,7 +82,7 @@ func (InvalidConfigIssue) BuildIssue(ctx map[string]string) (*healthplatform.Iss
 
 	return &healthplatform.Issue{
 		IssueName:   IssueName,
-		Title:       fmt.Sprintf("Datadog Agent Configuration Has %d Schema Violation%s in %s", count, suffix, path),
+		Title:       fmt.Sprintf("Datadog Agent Configuration Has %d Schema Violation%s in %s", count, suffix, filepath.Base(path)),
 		Description: desc,
 		Category:    "configuration",
 		Location:    "agent",

--- a/comp/healthplatform/issues/invalidconfig/issue.go
+++ b/comp/healthplatform/issues/invalidconfig/issue.go
@@ -82,7 +82,7 @@ func (InvalidConfigIssue) BuildIssue(ctx map[string]string) (*healthplatform.Iss
 
 	return &healthplatform.Issue{
 		IssueName:   IssueName,
-		Title:       fmt.Sprintf("Datadog Agent Configuration Has %d Schema Violation%s in %s", count, suffix, filepath.Base(path)),
+		Title:       "Datadog Agent Configuration Has Schema Violations in " + filepath.Base(path),
 		Description: desc,
 		Category:    "configuration",
 		Location:    "agent",


### PR DESCRIPTION
### What does this PR do?

- Add config filename to the issue title, keeping the schema violation count (e.g. `Datadog Agent Configuration Has 2 Schema Violations in datadog.yaml`).

### Motivation

- Split issues between config file and track the same issue accros fixes

### Describe how you validated your changes

Ran `dda inv test --targets=./comp/healthplatform/issues/invalidconfig/...` (4/4 passing) and `dda inv linter.go` on the package.

### Additional Notes