### PR TITLE
[comp/otelcol] Stop generating running metric with empty hostname when only seeing APM metrics

### DIFF
--- a/comp/otelcol/otlp/components/exporter/serializerexporter/consumer_collector.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/consumer_collector.go
@@ -9,12 +9,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter"
+
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes/source"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/exporter"
 )
 
 // collectorConsumer is a consumer OSS collector uses to send metrics to the DataDog.
@@ -48,7 +49,7 @@ func (c *collectorConsumer) addRuntimeTelemetryMetric(_ string, languageTags []s
 			nonFargateTags = append(nonFargateTags, tag)
 		}
 	}
-	if len(c.seenTags) == 0 || len(nonFargateTags) > 0 {
+	if (len(c.seenHosts) > 0 && len(c.seenTags) == 0) || len(nonFargateTags) > 0 {
 		tags := append(buildTags, nonFargateTags...)
 		series = append(series, exporterDefaultMetrics("metrics", "", timestamp, tags))
 	}

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/consumer_collector_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/consumer_collector_test.go
@@ -40,9 +40,7 @@ func TestAddRuntimeTelemetryMetric_NoTags(t *testing.T) {
 
 	c.addRuntimeTelemetryMetric("", nil)
 
-	assert.Len(t, c.series, 1)
-	assert.Equal(t, "otel.datadog_exporter.metrics.running", c.series[0].Name)
-	assert.Equal(t, "", c.series[0].Host)
+	assert.Empty(t, c.series)
 }
 
 func TestAddRuntimeTelemetryMetric_HostSource(t *testing.T) {

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
@@ -45,6 +45,7 @@ import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
 	source "github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes/source"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
@@ -459,6 +460,74 @@ func testMetricPrefixWithFeatureGates(t *testing.T, disablePrefix bool, inName s
 		}
 	}
 	t.Errorf("%s not found in metrics", outName)
+}
+
+func TestRunningMetricForPayloadContents(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(m pmetric.Metric)
+		wantRunning bool
+	}{
+		{
+			name: "apm stats only",
+			setup: func(m pmetric.Metric) {
+				m.SetName("dd.internal.stats.payload")
+				m.SetEmptySum()
+			},
+			wantRunning: false,
+		},
+		{
+			name: "real metric",
+			setup: func(m pmetric.Metric) {
+				m.SetName("my.metric")
+				m.SetEmptyGauge().DataPoints().AppendEmpty().SetDoubleValue(1)
+			},
+			wantRunning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newDefaultConfig().(*ExporterConfig)
+
+			set := exportertest.NewNopSettings(component.MustNewType("datadog"))
+			attributesTranslator, err := attributes.NewTranslator(set.TelemetrySettings)
+			require.NoError(t, err)
+			hostGetter := SourceProviderFunc(func(context.Context) (string, error) { return "test-hostname", nil })
+			tr, err := translatorFromConfig(set.TelemetrySettings, attributesTranslator, cfg.Metrics.Metrics, hostGetter, nil)
+			require.NoError(t, err)
+
+			createConsumer := func([]string, string, component.BuildInfo) SerializerConsumer {
+				return &collectorConsumer{
+					serializerConsumer: &serializerConsumer{},
+					seenHosts:          make(map[string]struct{}),
+					seenTags:           make(map[string]struct{}),
+					getPushTime:        func() uint64 { return 0 },
+				}
+			}
+
+			rec := &metricRecorder{}
+			exp, err := NewExporter(rec, cfg, hostGetter, createConsumer, tr, set, nil, otel.NewDisabledGatewayUsage(), nil, nil, ossCollector)
+			require.NoError(t, err)
+
+			md := pmetric.NewMetrics()
+			m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+			tt.setup(m)
+
+			require.NoError(t, exp.ConsumeMetrics(t.Context(), md))
+
+			var names []string
+			for _, serie := range rec.series {
+				names = append(names, serie.Name)
+			}
+			if tt.wantRunning {
+				assert.Contains(t, names, "otel.datadog_exporter.metrics.running")
+			} else {
+				assert.NotContains(t, names, "otel.datadog_exporter.metrics.running")
+				assert.NotContains(t, names, "otel.datadog_exporter.metrics.running.fargate")
+			}
+		})
+	}
 }
 
 func newMetrics(

--- a/releasenotes/notes/otlp-running-metric-apm-only-95555aaea2f8ef8e.yaml
+++ b/releasenotes/notes/otlp-running-metric-apm-only-95555aaea2f8ef8e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    OTLP: The ``otel.datadog_exporter.metrics.running`` telemetry metric is no
+    longer emitted for payloads that contain only APM metrics.

--- a/releasenotes/notes/otlp-running-metric-apm-only-95555aaea2f8ef8e.yaml
+++ b/releasenotes/notes/otlp-running-metric-apm-only-95555aaea2f8ef8e.yaml
@@ -1,5 +1,0 @@
----
-fixes:
-  - |
-    OTLP: The ``otel.datadog_exporter.metrics.running`` telemetry metric is no
-    longer emitted for payloads that contain only APM metrics.


### PR DESCRIPTION
### What does this PR do?

Stops emitting `otel.datadog_exporter.metrics.running` when only sending APM metrics

### Motivation

https://datadoghq.atlassian.net/browse/OTEL-3068

### Describe how you validated your changes

Added unit test. End to end local testing.
