### PR TITLE
fix(networkv2): restrict const.go to linux to match network.go

### DIFF
--- a/pkg/collector/corechecks/net/networkv2/const.go
+++ b/pkg/collector/corechecks/net/networkv2/const.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !darwin && !windows
+//go:build linux
 
 // Package networkv2 provides a check for network connection and socket statistics
 package networkv2


### PR DESCRIPTION
### What does this PR do?

Fixes `const.go` build tag in `pkg/collector/corechecks/net/networkv2`: changes `//go:build !darwin && !windows` to `//go:build linux` to match `network.go`.

### Motivation

`const.go` defines Linux-specific network constants (ethtool metrics, TCP state mappings, procfs paths) that are only used by `network.go` (`//go:build linux`). The old `!darwin && !windows` tag compiled these constants on AIX and other non-Linux Unix systems where they're unused, triggering the `unused` linter when cross-linting with `GOOS=aix` (see #53214).

### Describe how you validated your changes

`GOOS=aix GOARCH=ppc64 dda inv linter.go --targets=./pkg/collector/corechecks/net/networkv2/...`