### PR TITLE
Fix Go linters on AIX for system-probe code

### DIFF
--- a/pkg/system-probe/config/config_unsupported.go
+++ b/pkg/system-probe/config/config_unsupported.go
@@ -18,7 +18,7 @@ const (
 )
 
 // ValidateSocketAddress is not supported on this platform
-func ValidateSocketAddress(sockPath string) error {
+func ValidateSocketAddress(_ string) error {
 	return errors.New("system-probe unsupported")
 }
 


### PR DESCRIPTION
### What does this PR do?

Renames the unused `sockPath` parameter to `_` in `pkg/system-probe/config/config_unsupported.go`.

### Motivation

Caught by cross-linting with `GOOS=aix GOARCH=ppc64` (`revive` unused-parameter rule, see #53214).

### Describe how you validated your changes

`GOOS=aix GOARCH=ppc64 dda inv linter.go --targets=./pkg/system-probe/config/...`
