### PR TITLE
feat(anomalydetection): duration config keys for scorer and storage

### DIFF
--- a/comp/anomalydetection/AGENTS.md
+++ b/comp/anomalydetection/AGENTS.md
@@ -164,7 +164,7 @@ Keys are registered in `pkg/config/setup/common_settings.go`.
 | `anomaly_detection.logs.internal.enabled` | `true` | Agent-internal log tap |
 | `anomaly_detection.detectors.<name>.enabled` | varies | Per detector/correlator/extractor |
 | `anomaly_detection.storage.max_series` | `50000` | Storage series cap |
-| `anomaly_detection.storage.point_retention_secs` | `120` | Per-series point retention |
+| `anomaly_detection.storage.point_retention` | `120s` | Per-series point retention |
 
 Per-source log rate limits and min severity live under
 `anomaly_detection.logs.{internal,kubelet,containers}.*`.

--- a/comp/anomalydetection/observer/AGENTS.md
+++ b/comp/anomalydetection/observer/AGENTS.md
@@ -72,13 +72,13 @@ anomaly_detection:
   anomaly_scorer:
     enabled: true
     alpha: 0.3
-    window_secs: 30
+    window: 30s
     low_threshold: 0.030
     high_threshold: 0.060
     output:
       logs: true
       correlation_events: false
-      cooldown_secs: 300
+      cooldown: 300s
 ```
 
 The scorer is also available standalone (without the engine) via `NewAnomalyScorer` in `impl/` for testbench replay.

--- a/comp/anomalydetection/observer/impl/anomaly_scorer.go
+++ b/comp/anomalydetection/observer/impl/anomaly_scorer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"time"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 	severityeventsdef "github.com/DataDog/datadog-agent/comp/anomalydetection/severityevents/def"
@@ -163,12 +164,12 @@ type AnomalyScorerConfig struct {
 // Per-detector thresholds are set based on empirical score distributions across
 // kafka-partition-saturation, postmark, and dns-upstream-outage scenarios.
 func DefaultAnomalyScorerConfig() AnomalyScorerConfig {
-	const windowSecs = 15
+	const window = 15
 	return AnomalyScorerConfig{
 		AnomalyScorerConfig: observerdef.AnomalyScorerConfig{
 			Alpha:         0.014,
 			SaturationK:   5.0,
-			WindowSecs:    windowSecs,
+			WindowSecs:    window,
 			LowThreshold:  0.15,
 			HighThreshold: 0.40,
 			MarginPct:     0.20,
@@ -215,13 +216,13 @@ func readAnomalyScorerConfig(r ConfigReader, prefix string) AnomalyScorerConfig 
 		}
 		ewma.SaturationK = v
 	}
-	if key := prefix + "window_secs"; r.IsConfigured(key) {
-		v := r.GetInt(key)
-		if v < 1 {
-			pkglog.Warnf("anomaly_scorer: %s must be >= 1, got %d — using default %d", key, v, defaults.WindowSecs)
-			v = int(defaults.WindowSecs)
+	if key := prefix + "window"; r.IsConfigured(key) {
+		d := r.GetDuration(key)
+		if d < time.Second {
+			pkglog.Warnf("anomaly_scorer: %s must be >= 1s, got %s — using default %ds", key, d, defaults.WindowSecs)
+			d = time.Duration(defaults.WindowSecs) * time.Second
 		}
-		ewma.WindowSecs = int64(v)
+		ewma.WindowSecs = int64(d.Seconds())
 	}
 	if key := prefix + "low_threshold"; r.IsConfigured(key) {
 		ewma.LowThreshold = r.GetFloat64(key)
@@ -240,8 +241,13 @@ func readAnomalyScorerConfig(r ConfigReader, prefix string) AnomalyScorerConfig 
 	if key := outPrefix + "correlation_events"; r.IsConfigured(key) {
 		cfg.CorrelationEvents = r.GetBool(key)
 	}
-	if key := outPrefix + "cooldown_secs"; r.IsConfigured(key) {
-		cfg.CooldownSecs = int64(r.GetInt(key))
+	if key := outPrefix + "cooldown"; r.IsConfigured(key) {
+		d := r.GetDuration(key)
+		if d < 0 {
+			pkglog.Warnf("anomaly_scorer: %s must be >= 0, got %s — using default %ds", key, d, defaults.CooldownSecs)
+			d = time.Duration(defaults.CooldownSecs) * time.Second
+		}
+		cfg.CooldownSecs = int64(d.Seconds())
 	}
 	if key := outPrefix + "max_anomalies"; r.IsConfigured(key) {
 		cfg.MaxEpisodeAnomalies = r.GetInt(key)

--- a/comp/anomalydetection/observer/impl/anomaly_scorer_test.go
+++ b/comp/anomalydetection/observer/impl/anomaly_scorer_test.go
@@ -172,8 +172,8 @@ func TestWindowExpiry(t *testing.T) {
 
 	src := observer.SeriesDescriptor{Namespace: "ns", Name: "m", Tags: []string{"host:h"}}
 	// Series fires once at t=1000; last seen = 1000.
-	// Window at t=1014: windowStart = 1014-15+1 = 1000 → series still alive (lastSeen >= windowStart).
-	// Window at t=1015: windowStart = 1015-15+1 = 1001 → series expired (lastSeen=1000 < 1001).
+	// WindowSecs at t=1014: windowStart = 1014-15+1 = 1000 → series still alive (lastSeen >= windowStart).
+	// WindowSecs at t=1015: windowStart = 1015-15+1 = 1001 → series expired (lastSeen=1000 < 1001).
 	s.ProcessAnomaly(observer.Anomaly{DetectorName: "bocpd", Timestamp: 1000, Source: src})
 	s.Advance(1014)
 
@@ -544,7 +544,7 @@ func TestSubscribeCooldown(t *testing.T) {
 	s.Advance(1001) // EWMA≈0.632 → High
 
 	// Advance with no anomalies: EWMA decays near 0 quickly (alpha=0.99).
-	// Cooldown=60 should block de-escalation for 60 seconds after the escalation.
+	// CooldownSecs=60 should block de-escalation for 60 seconds after the escalation.
 	s.Advance(1002) // EWMA=0 → raw Low, but cooldown blocks it
 
 	escalations, deescalations := 0, 0

--- a/comp/anomalydetection/observer/impl/component_catalog.go
+++ b/comp/anomalydetection/observer/impl/component_catalog.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -67,6 +68,7 @@ type ConfigReader interface {
 	GetInt(key string) int
 	GetFloat64(key string) float64
 	GetString(key string) string
+	GetDuration(key string) time.Duration
 	IsConfigured(key string) bool
 }
 

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -237,8 +237,13 @@ func NewComponent(deps Requires) (Provides, error) {
 		if cfg.IsConfigured("anomaly_detection.storage.eviction_floor_ratio") {
 			storageCfg.EvictionFloorRatio = cfg.GetFloat64("anomaly_detection.storage.eviction_floor_ratio")
 		}
-		if cfg.IsConfigured("anomaly_detection.storage.point_retention_secs") {
-			storageCfg.PointRetentionSecs = cfg.GetInt64("anomaly_detection.storage.point_retention_secs")
+		if cfg.IsConfigured("anomaly_detection.storage.point_retention") {
+			d := cfg.GetDuration("anomaly_detection.storage.point_retention")
+			if d < 0 {
+				pkglog.Warnf("anomaly_detection.storage.point_retention must be >= 0, got %s — using default", d)
+			} else {
+				storageCfg.PointRetentionSecs = int64(d.Seconds())
+			}
 		}
 	}
 

--- a/internal/qbranch/anomalydetection-testbench/bench/api.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/api.go
@@ -1217,7 +1217,7 @@ func (api *BenchAPI) handleScores(w http.ResponseWriter, r *http.Request) {
 
 // handleScoresConfig returns the server-side default AnomalyScorerConfig so the UI
 // never needs to hardcode threshold values. The response also includes
-// cooldown_secs so the Scorer tab can initialise its replay form correctly.
+// cooldown so the Scorer tab can initialise its replay form correctly.
 // GET /api/scores/config
 func (api *BenchAPI) handleScoresConfig(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -1235,7 +1235,7 @@ func (api *BenchAPI) handleScoresConfig(w http.ResponseWriter, r *http.Request) 
 // by timestamp and fed second-by-second, with Advance called once per unique
 // second (and for any empty seconds in between).
 //
-// POST /api/scores/replay   body: { AnomalyScorerConfig fields... , "cooldown_secs": N }
+// POST /api/scores/replay   body: { AnomalyScorerConfig fields... , "cooldown": N }
 func (api *BenchAPI) handleScoresReplay(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		api.writeError(w, http.StatusMethodNotAllowed, "use POST")

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -6098,10 +6098,10 @@ properties:
             node_type: section
             type: object
             properties:
-              cooldown_secs:
+              cooldown:
                 node_type: setting
-                type: integer
-                default: 300
+                type: string
+                default: 300s
               correlation_events:
                 node_type: setting
                 type: boolean
@@ -6120,10 +6120,10 @@ properties:
             default: 5
             tags:
             - golang_type:float64
-          window_secs:
+          window:
             node_type: setting
-            type: integer
-            default: 15
+            type: string
+            default: 15s
       baseline_analysis:
         node_type: section
         type: object
@@ -6490,10 +6490,10 @@ properties:
             type: integer
             default: 50000
             comment: Storage tuning. See storageConfig in the observer component.
-          point_retention_secs:
+          point_retention:
             node_type: setting
-            type: integer
-            default: 120
+            type: string
+            default: 120s
   appsec:
     node_type: section
     type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -2211,19 +2211,19 @@ func anomalyDetection(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.enabled", false)
 	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.alpha", 0.014)
 	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.saturation_k", 5.0)
-	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.window_secs", 15)
+	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.window", 15*time.Second)
 	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.low_threshold", 0.15)
 	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.high_threshold", 0.40)
 	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.margin_pct", 0.20)
 	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.output.correlation_events", false)
 	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.output.logs", false)
-	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.output.cooldown_secs", 300)
+	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.output.cooldown", 300*time.Second)
 	config.BindEnvAndSetDefault("anomaly_detection.anomaly_scorer.output.max_anomalies", 50)
 
 	// Storage tuning. See storageConfig in the observer component.
 	config.BindEnvAndSetDefault("anomaly_detection.storage.max_series", 50000)
 	config.BindEnvAndSetDefault("anomaly_detection.storage.eviction_floor_ratio", 0.5)
-	config.BindEnvAndSetDefault("anomaly_detection.storage.point_retention_secs", 120)
+	config.BindEnvAndSetDefault("anomaly_detection.storage.point_retention", 120*time.Second)
 
 	// Baseline analysis window.
 	config.BindEnvAndSetDefault("anomaly_detection.baseline_analysis.enabled", true)

--- a/test/new-e2e/tests/anomalydetection/scorer_helper_nix_test.go
+++ b/test/new-e2e/tests/anomalydetection/scorer_helper_nix_test.go
@@ -76,7 +76,7 @@ anomaly_detection:
   anomaly_scorer:
     enabled: true
     alpha: 0.3
-    window_secs: 5
+    window: 5s
     low_threshold: 0.005
     high_threshold: 0.010
     output:


### PR DESCRIPTION
## Summary
- Replace `window_secs`, `cooldown_secs`, `point_retention_secs` with duration keys (`window`, `cooldown`, `point_retention`)
- Parse via `GetDuration()`; keep internal `*Secs` int64 fields

## Test plan
- [x] `go test ./comp/anomalydetection/observer/impl ./comp/anomalydetection/severityevents/impl`


Made with [Cursor](https://cursor.com)