### PR TITLE
Fix flaky DrainIsBoundedToSnapshot test

### DIFF
--- a/comp/core/agenttelemetry/impl/errortracking_sender_test.go
+++ b/comp/core/agenttelemetry/impl/errortracking_sender_test.go
@@ -406,13 +406,29 @@ func TestFlushErrortracking_DrainsWholeBufferInOneCall(t *testing.T) {
 	}
 }
 
+type blockingSender struct {
+	senderMock
+	sendStarted chan struct{}
+	releaseSend chan struct{}
+	once        sync.Once
+}
+
+func (s *blockingSender) sendLogsBatch(ctx context.Context, logs []Log) error {
+	s.once.Do(func() { close(s.sendStarted) })
+	<-s.releaseSend
+	return s.senderMock.sendLogsBatch(ctx, logs)
+}
+
 // TestFlushErrortracking_DrainIsBoundedToSnapshot: a producer that keeps
 // writing into the channel during a flush must not extend the current
 // batch beyond the items that were already queued at flush start. Only the
 // snapshot-at-start items are dispatched; the new arrivals wait for the
 // next tick.
 func TestFlushErrortracking_DrainIsBoundedToSnapshot(t *testing.T) {
-	sm := &senderMock{}
+	sm := &blockingSender{
+		sendStarted: make(chan struct{}),
+		releaseSend: make(chan struct{}),
+	}
 	const bufSize = 10
 	a := newTestAtelMinimal(t, sm, bufSize)
 	defer a.cancel()
@@ -423,22 +439,28 @@ func TestFlushErrortracking_DrainIsBoundedToSnapshot(t *testing.T) {
 		a.SubmitErrorLog(errorLog(fmt.Sprintf("pre-%d", i)))
 	}
 
-	// Inject 3 more items concurrently while the flush runs. Because the
-	// flush is bounded to len(ch) at start (= preFilled), these arrivals
-	// must not be included in this batch.
+	flushDone := make(chan struct{})
 	go func() {
-		for i := range 3 {
-			a.SubmitErrorLog(errorLog(fmt.Sprintf("late-%d", i)))
-		}
+		a.flushErrortracking(context.Background())
+		close(flushDone)
 	}()
 
-	a.flushErrortracking(context.Background())
+	<-sm.sendStarted
+	for i := range 3 {
+		a.SubmitErrorLog(errorLog(fmt.Sprintf("late-%d", i)))
+	}
+	close(sm.releaseSend)
+	<-flushDone
 
 	got := sm.capturedLogs()
-	assert.LessOrEqual(t, len(got), preFilled,
-		"flush must not dispatch more than the snapshot count (%d)", preFilled)
+	assert.Equal(t, preFilled, len(got),
+		"flush must dispatch exactly the snapshot count (%d)", preFilled)
 	assert.Equal(t, 1, sm.sendLogsCalls(),
 		"snapshot-bounded flush must still dispatch in exactly one sendLogsBatch call")
+
+	a.flushErrortracking(context.Background())
+	assert.Equal(t, preFilled+3, len(sm.capturedLogs()),
+		"records submitted while first flush was in-flight must be sent in the next flush")
 }
 
 // TestFlushErrortracking_FinalDrain: records enqueued shortly before


### PR DESCRIPTION
<!-- dd-meta {"pullId":"418c8d7e-d5dd-436e-b5aa-fdd6fe82f621","source":"chat","resourceId":"e801153f-0165-477d-b59a-9c82fc2c87dc","workflowId":"96fcfc55-dc9b-4525-a23b-ad0e6a8b62ee","codeChangeId":"96fcfc55-dc9b-4525-a23b-ad0e6a8b62ee","sourceType":"test-optimization"} -->
### What does this PR do?

Fixing `TestFlushErrortracking_DrainIsBoundedToSnapshot` • **Questions?** Ask in #code-gen-flaky-tests

- Stabilizes `TestFlushErrortracking_DrainIsBoundedToSnapshot` by removing scheduler-dependent timing.
- Replaces the unsynchronized concurrent writer with a deterministic in-flight flush scenario using a blocking sender test helper.
- Verifies that records present at flush start are sent in the first flush, while records submitted during that flush are deferred to the next flush.

### Motivation
The flaky failure (`"8" is not less than or equal to "5"`) comes from a race in the test setup, not from deterministic product behavior: the "late" goroutine can run before `flushErrortracking` snapshots channel length, causing more than the prefilled count to be included. This produced nondeterministic pass/fail outcomes based on goroutine scheduling.

### Describe how you validated your changes
- Attempted to reproduce by running the test 4 times with `go test ./comp/core/agenttelemetry/impl -run TestFlushErrortracking_DrainIsBoundedToSnapshot -count=1`, but execution is blocked in this sandbox because `goenv` requires Go `1.26.4` which is not installed.
- Attempted Bazel-based validation with `bazel test //comp/core/agenttelemetry/impl:all --test_filter=TestFlushErrortracking_DrainIsBoundedToSnapshot`, but Bazel bootstrap download is blocked by network/proxy limits (`Bad Gateway`).
- Validation therefore relies on code-level determinism of the updated synchronization pattern in the test.

### Additional Notes
- Scope is intentionally limited to test code only (`comp/core/agenttelemetry/impl/errortracking_sender_test.go`).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e801153f-0165-477d-b59a-9c82fc2c87dc)

Comment @datadog to request changes