### PR TITLE
Fix Windows exe suffix in TestConfigHostname

### DIFF
--- a/comp/trace/config/impl/config_test.go
+++ b/comp/trace/config/impl/config_test.go
@@ -389,6 +389,9 @@ func TestConfigHostname(t *testing.T) {
 			t.Fatal(err)
 		}
 		binpath := strings.TrimSuffix(srcpath, ".go")
+		if runtime.GOOS == "windows" {
+			binpath += ".exe"
+		}
 		if err := testutil.IsolatedGoBuildCmd(t.TempDir(), binpath, srcpath).Run(); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1955ca89-8700-4910-a1c8-0a6a5cea9408","source":"chat","resourceId":"ee826d90-c296-41b6-a192-28d912ddda73","workflowId":"e8b81557-ccd9-4ff0-963a-f4465d1ed0cb","codeChangeId":"e8b81557-ccd9-4ff0-963a-f4465d1ed0cb","sourceType":"bits_ai_sre"} -->
### What does this PR do?

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/eea6f178-0634-4946-b7f2-f007cbe1ad75)

Appends `.exe` to the helper binary path on Windows in `TestConfigHostname/external` (`comp/trace/config/impl/config_test.go`).

### Motivation

Commit aa5e91bc refactored the test to compile a helper binary once with `binpath := strings.TrimSuffix(srcpath, ".go")`. On Windows, `go build -o trace-test-hostname` actually produces `trace-test-hostname.exe`. Under Go 1.26.x, `exec.Command` no longer implicitly appends `.exe` for paths containing directory separators, so `cfg.DDAgentBin = binpath` pointed at a nonexistent file. All three subtests failed on `tests_windows-x64` with "executable file not found in %PATH%", blocking main-branch CI on Windows.

### Changes

- After computing `binpath`, append `.exe` when `runtime.GOOS == "windows"` so both the `go build -o` output and the later `exec` path match. (`runtime` was already imported.)

### Describe how you validated your changes

- Verified `IsolatedGoBuildCmd` passes `binpath` as the `-o` output and that `cfg.DDAgentBin` is set to the same path, confirming the two must agree.
- Change is isolated to test code; no production behavior affected.

### Additional Notes

Fix is Windows-only; other platforms are unaffected since the suffix is only added when `GOOS == "windows"`.

#incident-57267

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ee826d90-c296-41b6-a192-28d912ddda73)

Comment @datadog to request changes