### PR TITLE
Removing SetKnown from the config interface

### DIFF
--- a/.claude/skills/create-config-field/SKILL.md
+++ b/.claude/skills/create-config-field/SKILL.md
@@ -91,7 +91,6 @@ Commit the resulting changes under `pkg/config/schema/yaml/` alongside your Go c
 
 ## Important Notes
 
-- Do NOT use `SetKnown` for new fields — it's deprecated. Use `BindEnvAndSetDefault`.
 - Config priority: `default < file < env-var < fleet-policies < agent-runtime < remote-config < cli`.
 - Define exported string constants for keys when creating a dedicated setup file.
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -364,9 +364,6 @@ linters:
         - pattern: ^setup.SetSystemProbe.*$
           pkg: ^github.com/DataDog/datadog-agent/pkg/config/setup$
           msg: use pkg/config/mock instead for tests or the config component
-        - pattern: ^.*\.SetKnown$
-          pkg: ^github.com/DataDog/datadog-agent/pkg/config/model$
-          msg: usage of SetKnown is discouraged
         - pattern: RevertFinishedBackToBuilder
           msg: RevertFinishedBackToBuilder is typically not needed, so using it is discouraged. Only existing OTel usage is allowed.
       analyze-types: true

--- a/comp/core/sysprobeconfig/mock/mock.go
+++ b/comp/core/sysprobeconfig/mock/mock.go
@@ -34,9 +34,8 @@ func NewMockWithOverrides(t testing.TB, overrides map[string]interface{}) syspro
 		cfg.SetInTest(k, v)
 	}
 
-	// Viper's `GetXxx` methods read environment variables at the time they are
-	// called, if those names were passed explicitly to BindEnv*(), so we must
-	// also strip all `DD_` environment variables for the duration of the test.
+	// The config automatically load environment variables starting by DD_*,
+	// so we must also strip all `DD_` environment variables for the duration of the test.
 	oldEnv := os.Environ()
 	for _, kv := range oldEnv {
 		if strings.HasPrefix(kv, "DD_") {

--- a/comp/metadata/inventoryagent/impl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/impl/inventoryagent.go
@@ -200,8 +200,8 @@ func (ia *inventoryagent) getCorrectConfig(name string, localConf model.Reader, 
 	// We query the configuration from another agent itself to have accurate data. If the other process isn't
 	// available we fallback on the current configuration.
 	if remoteConfig, err := configFetcher(localConf, ia.client); err == nil {
-		// Build a config object from the fetched YAML only. No env var is bound on this config
-		// (we never call BindEnv), so the current process's environment variables are not applied
+		// Build a config object from the fetched YAML only. No env var is bound on this config,
+		// so the current process's environment variables are not applied
 		// and the values reflect the remote process's YAML exactly. A dynamic schema is used since
 		// the remote config's keys are not part of this freshly created config's schema.
 		cfg := create.NewConfig(name)

--- a/docs/public/agent-schema/index.md
+++ b/docs/public/agent-schema/index.md
@@ -7,10 +7,9 @@ is fully compatible with JSON Schema tooling.
 
 ## Why it exists
 
-Previously, Agent configuration was defined through a combination of imperative Go code (`BindEnv` and
-`BindEnvAndSetDefault` calls in `pkg/config/setup`), YAML example files maintained by-hand, and scattered validation
-logic. This made it hard to understand what a setting does, what values it accepts, or what its default is — without
-reading source code.
+Previously, Agent configuration was defined through a combination of imperative Go code (`BindEnvAndSetDefault` calls in
+`pkg/config/setup`), YAML example files maintained by-hand, and scattered validation logic. This made it hard to
+understand what a setting does, what values it accepts, or what its default is — without reading source code.
 
 The schema replaces this with a **single source of truth**. All information
 about a setting — its type, default value, documentation, environment variables,

--- a/pkg/config/buildschema/config.go
+++ b/pkg/config/buildschema/config.go
@@ -70,10 +70,6 @@ func (b *builder) ParseEnvJSON(key string, _ any) {
 	b.setEnvParser(key, "json")
 }
 
-func (b *builder) SetKnown(key string) {
-	b.addToSchema(key, nil, nil, true)
-}
-
 func (b *builder) BindEnvAndSetDefault(key string, val interface{}, env ...string) {
 	b.addToSchema(key, val, env, false)
 }

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -194,9 +194,8 @@ type Reader interface {
 	// IsSetting returns whether the key identifies a setting (and not a section)
 	IsSetting(key string) bool
 
-	// GetKnownKeysLowercased returns all the keys that meet at least one of these criteria:
-	// 1) have a default, 2) have an environment variable binded, 3) are an alias or 4) have been SetKnown()
-	// Note that it returns the keys lowercased.
+	// GetKnownKeysLowercased returns all the keys that are known by the config
+	// Note: that it returns the keys lowercased.
 	GetKnownKeysLowercased() map[string]interface{}
 
 	// GetEnvVars returns a list of the env vars that the config supports.
@@ -257,9 +256,6 @@ type Setup interface {
 	ParseEnvAsStringSlice(key string, fx func(string) []string)
 	ParseEnvAsMapStringInterface(key string, fx func(string) map[string]interface{})
 
-	// SetKnown adds a key to the set of known valid config keys
-	SetKnown(key string)
-
 	// API not implemented by viper.Viper and that have proven useful for our config usage
 
 	// BindEnvAndSetDefault sets the default value for a config parameter and adds an env binding
@@ -296,9 +292,6 @@ type Compound interface {
 type Config interface {
 	ReaderWriter
 	Compound
-	// TODO: This method shouldn't be here, but it is depended upon by an external repository
-	// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/e7c3295769637e61558c6892be732398840dd5f5/pkg/datadog/agentcomponents/agentcomponents.go#L166
-	SetKnown(key string)
 }
 
 // BuildableConfig is the most-general interface for the Config, it can be

--- a/pkg/config/nodetreemodel/compatibility_test.go
+++ b/pkg/config/nodetreemodel/compatibility_test.go
@@ -121,7 +121,7 @@ func TestAllFlattenedSettingsWithSequenceIDUnknownParentChild(t *testing.T) {
 func TestGetEnvVarsBindings(t *testing.T) {
 	dataYaml := `unknown_setting: 123`
 
-	t.Run("With BindEnv", func(t *testing.T) {
+	t.Run("With BindEnvAndSetDefault", func(t *testing.T) {
 		conf := constructNtmConfig(dataYaml, false, func(cfg model.Setup) {
 			cfg.BindEnvAndSetDefault("port", "", "TEST_PORT")
 			cfg.BindEnvAndSetDefault("host", "", "TEST_HOST")
@@ -134,9 +134,9 @@ func TestGetEnvVarsBindings(t *testing.T) {
 		assert.Equal(t, []string{"TEST_HOST", "TEST_LOG_LEVEL", "TEST_PORT"}, envVars)
 	})
 
-	t.Run("Without BindEnv", func(t *testing.T) {
+	t.Run("Without BindEnvAndSetDefault", func(t *testing.T) {
 		conf := constructNtmConfig(dataYaml, false, nil)
-		assert.Empty(t, conf.GetEnvVars(), "should return no env vars without BindEnv")
+		assert.Empty(t, conf.GetEnvVars(), "should return no env vars without BindEnvAndSetDefault")
 	})
 
 	t.Run("With EnvPrefix", func(t *testing.T) {
@@ -170,7 +170,6 @@ func TestGetEnvVarsBindings(t *testing.T) {
 
 	t.Run("Adding an unknown setting in the yaml", func(t *testing.T) {
 		conf := constructNtmConfig(dataYaml, false, func(cfg model.Setup) {
-			cfg.SetKnown("PORT") //nolint:forbidigo // testing behavior
 			cfg.SetDefault("HOST", "localhost")
 			cfg.BindEnvAndSetDefault("log_level", "")
 		})
@@ -209,7 +208,7 @@ runtime_security_config:
 unknown_section:
   info:
 `
-	// apm_config.telemetry        - declared "known" (silences warnings, not added to schema, not very useful to do)
+	// apm_config.telemetry        - empty section declared only in the yaml (neither default nor env var)
 	// database_monitoring.samples - defines a default
 	// logs_config.auto_multi_line - bind an env var and assign a value to that env var
 	// runtime_security_config.endpoints - bind an env var but leave that env var undefined
@@ -219,7 +218,6 @@ unknown_section:
 	t.Setenv("DD_LOGS_CONFIG_AUTO_MULTI_LINE_TOKENIZER_MAX_INPUT_BYTES", "100")
 
 	conf := constructNtmConfig(dataYaml, true, func(cfg model.Setup) {
-		cfg.SetKnown("apm_config.telemetry.dd_url") //nolint:forbidigo // test behavior
 		cfg.SetDefault("database_monitoring.samples.dd_url", "")
 		cfg.BindEnvAndSetDefault("runtime_security_config.endpoints.dd_url", "", "DD_RUNTIME_SECURITY_CONFIG_ENDPOINTS_DD_URL")
 		cfg.BindEnvAndSetDefault("logs_config.auto_multi_line.tokenizer_max_input_bytes", "", "DD_LOGS_CONFIG_AUTO_MULTI_LINE_TOKENIZER_MAX_INPUT_BYTES")
@@ -229,7 +227,6 @@ unknown_section:
 	expectedKeys := []string{
 		"additional_endpoints",
 		"apm_config.telemetry",
-		"apm_config.telemetry.dd_url",
 		"database_monitoring.samples.dd_url",
 		//"logs_config.auto_multi_line",
 		"logs_config.auto_multi_line.tokenizer_max_input_bytes",
@@ -268,7 +265,7 @@ unknown_section:
 	////////////
 	// tests for IsConfigured
 
-	// not configured because known does not define a setting
+	// not configured because the empty yaml section does not define a value
 	assert.False(t, conf.IsConfigured("apm_config.telemetry"))
 
 	// not configured by the file nor env var
@@ -371,8 +368,8 @@ func TestReadConfigReset(t *testing.T) {
 	overrideYAML := `host: localhost`
 
 	conf := constructNtmConfig(initialYAML, true, func(cfg model.Setup) {
-		cfg.SetKnown("port") //nolint:forbidigo // testing behavior
-		cfg.SetKnown("host") //nolint:forbidigo // testing behavior
+		cfg.BindEnvAndSetDefault("port", 0)
+		cfg.BindEnvAndSetDefault("host", "")
 	})
 
 	assert.Equal(t, 1234, conf.GetInt("port"))
@@ -475,8 +472,8 @@ fruit:
 		// default wins over invalid file
 		cfg.BindEnvAndSetDefault("fruit.apple.core.seeds", 2)
 
-		// file only (missing default)
-		cfg.SetKnown("fruit.banana.peel.color") //nolint:forbidigo // testing behavior
+		// fruit.banana.peel.color is intentionally left undeclared: it only appears
+		// in the file (as an empty section) and has no default
 
 		// env wins over file
 		cfg.BindEnvAndSetDefault("fruit.cherry.seed.num", 0)

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -125,7 +125,6 @@ type ntmConfig struct {
 	envVarsCleared atomic.Bool
 
 	// known keys are the set of valid keys to get either leaf or inner node values
-	// they are defined by one of (1) SetDefault (2) BindEnv (3) SetKnown
 	// the map value represents `isLeaf` for each key
 	knownKeys map[string]bool
 
@@ -459,20 +458,6 @@ func (c *ntmConfig) addToKnownKeys(key string) {
 		// Set true if leaf, false for inner nodes
 		c.knownKeys[base] = i == len(keyParts)-1
 	}
-}
-
-// SetKnown adds a key to the set of known valid config keys.
-//
-// Important: this doesn't add the key to the default layer. The "known keys" are a legacy feature we inherited from our Viper
-// wrapper. Once all settings have a default we'll be able to remove this concept entirely.
-func (c *ntmConfig) SetKnown(key string) {
-	c.Lock()
-	defer c.Unlock()
-	if c.isReady() && !c.allowDynamicSchema.Load() {
-		panic("cannot SetKnown() once the config has been marked as ready for use")
-	}
-	key = strings.ToLower(key)
-	c.addToKnownKeys(key)
 }
 
 // IsKnown returns whether a key is in the set of "known keys", which is a legacy feature from Viper
@@ -847,8 +832,7 @@ func (c *ntmConfig) collectFlattenedKeys() []string {
 	return slices.Collect(maps.Keys(allKeys))
 }
 
-// AllKeysLowercased returns all keys, including unknown keys and those without default values
-// Unlike AllSettings, this returns keys defined by SetKnown or BindEnv
+// AllKeysLowercased returns all keys, including unknown keys
 func (c *ntmConfig) AllKeysLowercased() []string {
 	c.maybeRebuild()
 

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -278,7 +278,7 @@ func TestAllSettings(t *testing.T) {
 	cfg.SetDefault("a", 0)                         // "a"   @ file
 	cfg.SetDefault("b.c", 0)                       // "b.c" @ agent-runtime
 	cfg.SetDefault("b.d", 0)                       // "b.d" @ default
-	cfg.SetKnown("b.e")                            //nolint:forbidigo // "b.e" @ known
+	cfg.BindEnvAndSetDefault("b.e", 0)             // "b.e" @ default
 	cfg.BindEnvAndSetDefault("f.g", 0, "TEST_F_G") // "f.g" @ env-var (defined)
 	cfg.BindEnvAndSetDefault("f.h", 0, "TEST_F_H") // "f.h" @ env-var (undefined, falls back to default)
 	t.Setenv("TEST_F_G", "456")
@@ -293,7 +293,7 @@ func TestAllSettings(t *testing.T) {
 		"b": map[string]interface{}{
 			"c": 123, // agent-runtime
 			"d": 0,   // default
-			// b.e is not included
+			"e": 0,   // default
 		},
 		"f": map[string]interface{}{
 			"g": 456, // env-var defined
@@ -305,10 +305,10 @@ func TestAllSettings(t *testing.T) {
 
 func TestAllSettingsWithoutDefault(t *testing.T) {
 	cfg := NewNodeTreeConfig("test", "TEST", nil)
-	cfg.SetDefault("a", 0)   // "a"   @ file
-	cfg.SetDefault("b.c", 0) // "b.c" @ agent-runtime
-	cfg.SetDefault("b.d", 0) // "b.d" @ default
-	cfg.SetKnown("b.e")      //nolint:forbidigo // "b.e" @ known
+	cfg.SetDefault("a", 0)             // "a"   @ file
+	cfg.SetDefault("b.c", 0)           // "b.c" @ agent-runtime
+	cfg.SetDefault("b.d", 0)           // "b.d" @ default
+	cfg.BindEnvAndSetDefault("b.e", 0) // "b.e" @ default
 	cfg.BuildSchema()
 
 	cfg.ReadConfig(strings.NewReader("a: 987"))
@@ -414,7 +414,7 @@ func TestIsConfigured(t *testing.T) {
 	cfg := NewNodeTreeConfig("test", "TEST", nil)
 	cfg.SetDefault("a", 0)
 	cfg.SetDefault("b", 0)
-	cfg.SetKnown("c") //nolint:forbidigo // testing behavior
+	cfg.BindEnvAndSetDefault("c", 0)
 	cfg.BindEnvAndSetDefault("d", 0)
 
 	t.Setenv("TEST_D", "123")
@@ -465,7 +465,7 @@ func TestAllKeysLowercased(t *testing.T) {
 	cfg.SetDefault("a", 0)                         // "a"   @ file
 	cfg.SetDefault("b.c", 0)                       // "b.c" @ agent-runtime
 	cfg.SetDefault("b.d", 0)                       // "b.d" @ default
-	cfg.SetKnown("b.e")                            //nolint:forbidigo // "b.e" @ known
+	cfg.BindEnvAndSetDefault("b.e", 0)             // "b.e" @ default
 	cfg.BindEnvAndSetDefault("f.g", 0, "TEST_F_G") // "f.g" @ env-var
 	cfg.BindEnvAndSetDefault("f.h", 0, "TEST_F_H") // "f.h" @ env-var
 	t.Setenv("TEST_F_G", "456")
@@ -493,7 +493,6 @@ logs_config:
 	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
 	cfg.SetConfigType("yaml")
 	cfg.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	cfg.SetKnown("apm_config") //nolint:forbidigo // test behavior
 	cfg.BindEnvAndSetDefault("network_path.collector.input_chan_size", 100000)
 	cfg.BindEnvAndSetDefault("network_path.collector.processing_chan_size", 100000)
 	cfg.BindEnvAndSetDefault("network_path.collector.workers", 4)
@@ -1375,7 +1374,9 @@ user:
 
 func TestUnsetForSourceRemoveIfNotPrevious(t *testing.T) {
 	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
-	cfg.SetKnown("api_key") //nolint:forbidigo // api_key must be known but have no default value for this test
+	// Enable the dynamic schema so api_key can be Set even though it has no default value,
+	// which is required to exercise the "unset with no previous value" behavior below.
+	cfg.SetTestOnlyDynamicSchema(true)
 	cfg.BuildSchema()
 
 	// api_key is not in the config (does not have a default value)
@@ -1554,9 +1555,6 @@ func TestPanicAfterBuildSchema(t *testing.T) {
 	assert.Equal(t, 1, cfg.Get("a"))
 	assert.Equal(t, model.SourceDefault, cfg.GetSource("a"))
 
-	assert.PanicsWithValue(t, "cannot SetKnown() once the config has been marked as ready for use", func() {
-		cfg.SetKnown("a") //nolint:forbidigo // testing behavior
-	})
 	assert.PanicsWithValue(t, "cannot SetEnvKeyReplacer() once the config has been marked as ready for use", func() {
 		cfg.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	})

--- a/pkg/config/nodetreemodel/getter.go
+++ b/pkg/config/nodetreemodel/getter.go
@@ -25,7 +25,7 @@ func (c *ntmConfig) leafAtPath(key string) *nodeImpl {
 }
 
 // GetKnownKeysLowercased returns all the keys that meet at least one of these criteria:
-// 1) have a default, 2) have an environment variable binded or 3) have been SetKnown()
+// 1) have a default, 2) have an environment variable binded
 // Note that it returns the keys lowercased.
 //
 // TODO: remove once viper is no longer used. This is only used to detect unknown configuration from YAML which we do

--- a/pkg/config/nodetreemodel/getter_test.go
+++ b/pkg/config/nodetreemodel/getter_test.go
@@ -18,7 +18,7 @@ func TestGetKnownKeysLowercased(t *testing.T) {
 	cfg := NewNodeTreeConfig("test", "", nil)
 	cfg.SetDefault("a", 1234)
 	cfg.SetDefault("b.C", "test")
-	cfg.SetKnown("d.E.f") //nolint:forbidigo // testing behavior
+	cfg.BindEnvAndSetDefault("d.E.f", "")
 	cfg.BuildSchema()
 
 	assert.Equal(t,
@@ -52,8 +52,8 @@ func TestGet(t *testing.T) {
 
 func TestGetDefaultType(t *testing.T) {
 	cfg := NewNodeTreeConfig("test", "", nil)
-	cfg.SetKnown("a") //nolint:forbidigo // testing behavior
-	cfg.SetKnown("b") //nolint:forbidigo // testing behavior
+	cfg.BindEnvAndSetDefault("a", map[string]interface{}{})
+	cfg.BindEnvAndSetDefault("b", map[string]interface{}{})
 	cfg.BuildSchema()
 
 	cfg.ReadConfig(strings.NewReader(`---

--- a/pkg/config/nodetreemodel/read_config_file.go
+++ b/pkg/config/nodetreemodel/read_config_file.go
@@ -152,7 +152,7 @@ func loadYamlInto(dest *nodeImpl, source model.Source, inData map[string]interfa
 		if err != nil {
 			isLeaf, isKnown := knownKeys[currPath]
 			if isLeaf {
-				// Not found but known, the leaf setting must be valueless (defined by BindEnv or SetKnown)
+				// Not found but known, the leaf setting must be valueless. This should never happen
 				schemaChild = valuelessLeaf
 			} else {
 				if !isKnown {

--- a/pkg/config/structure/compatibility_test.go
+++ b/pkg/config/structure/compatibility_test.go
@@ -50,7 +50,6 @@ network_devices:
         12
 `
 	conf := constructNtmConfig(dataYaml, false, func(cfg model.Setup) {
-		cfg.SetKnown("network_devices.autodiscovery.workers") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 		cfg.SetDefault("network_devices.autodiscovery.workers", 5)
 	})
 
@@ -75,10 +74,10 @@ network_devices:
     - workers: 10
 `
 	conf := constructNtmConfig(dataYaml, false, func(cfg model.Setup) {
-		cfg.SetKnown("network_devices.autodiscovery.workers") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+		cfg.BindEnvAndSetDefault("network_devices.autodiscovery", []interface{}{})
 	})
 
-	// Keys are declared using SetKnown, no warnings generated
+	// Keys are declared with a default, no warnings generated
 	warnings := conf.Warnings()
 	assert.Equal(t, 0, len(warnings.Errors))
 
@@ -236,7 +235,7 @@ my_target:
   int_slice:       7
 `
 	conf := constructNtmConfig(dataYaml, false, func(cfg model.Setup) {
-		cfg.SetKnown("my_target") //nolint:forbidigo // legit usage, often used for UnmarshalKey settings
+		cfg.BindEnvAndSetDefault("my_target", map[string]interface{}{})
 	})
 
 	var target TargetStruct

--- a/pkg/config/structure/unmarshal_test.go
+++ b/pkg/config/structure/unmarshal_test.go
@@ -319,7 +319,7 @@ endpoints:
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockConfig := newConfigFromYaml(t, tc.conf)
-			mockConfig.SetKnown("endpoints") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+			mockConfig.BindEnvAndSetDefault("endpoints", []endpoint{})
 
 			var endpoints = []endpoint{}
 			err := UnmarshalKey(mockConfig, "endpoints", &endpoints)
@@ -336,7 +336,7 @@ endpoints:
 
 func TestUnmarshalAllMapString(t *testing.T) {
 	mockConfig := newEmptyMockConf(t)
-	mockConfig.SetKnown("test") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	mockConfig.BindEnvAndSetDefault("test", map[string]interface{}{})
 
 	type testString struct {
 		A string
@@ -363,7 +363,7 @@ func TestUnmarshalAllMapString(t *testing.T) {
 
 func TestUnmarshalAllMapInt(t *testing.T) {
 	mockConfig := newEmptyMockConf(t)
-	mockConfig.SetKnown("test") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	mockConfig.BindEnvAndSetDefault("test", map[string]interface{}{})
 
 	type testInt struct {
 		A int
@@ -387,7 +387,7 @@ func TestUnmarshalAllMapInt(t *testing.T) {
 
 func TestUnmarshalAllMapBool(t *testing.T) {
 	mockConfig := newEmptyMockConf(t)
-	mockConfig.SetKnown("test") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	mockConfig.BindEnvAndSetDefault("test", map[string]interface{}{})
 
 	type testBool struct {
 		A bool
@@ -552,7 +552,7 @@ feature:
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockConfig := newConfigFromYaml(t, tc.conf)
-			mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+			mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 			var feature = featureConfig{}
 			err := UnmarshalKey(mockConfig, "feature", &feature)
@@ -704,7 +704,7 @@ feature:
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockConfig := newConfigFromYaml(t, tc.conf)
-			mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+			mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 			var feature = uintConfig{}
 			err := UnmarshalKey(mockConfig, "feature", &feature)
@@ -801,7 +801,7 @@ feature:
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockConfig := newConfigFromYaml(t, tc.conf)
-			mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+			mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 			var feature = floatConfig{}
 			err := UnmarshalKey(mockConfig, "feature", &feature)
@@ -938,7 +938,7 @@ feature:
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockConfig := newConfigFromYaml(t, tc.conf)
-			mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+			mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 			var feature = stringConfig{}
 			err := UnmarshalKey(mockConfig, "feature", &feature)
@@ -970,7 +970,7 @@ feature:
   EnABLeD: "true"
 `
 	mockConfig := newConfigFromYaml(t, confYaml)
-	mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 	var feature = featureConfig{}
 	err := UnmarshalKey(mockConfig, "feature", &feature)
@@ -991,7 +991,7 @@ feature:
   enabled: "true"
 `
 	mockConfig := newConfigFromYaml(t, confYaml)
-	mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 	// If the data from the config is missing, UnmarshalKey is a no-op, does
 	// nothing, and returns no error
@@ -1008,7 +1008,7 @@ feature:
 `
 
 		mockConfig := newConfigFromYaml(t, confYaml)
-		mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+		mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 		feature := struct {
 			Enabled int `mapstructure:"enabled"`
@@ -1026,7 +1026,7 @@ feature:
 `
 
 		mockConfig := newConfigFromYaml(t, confYaml)
-		mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+		mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 		feature := struct {
 			Enabled float64 `mapstructure:"enabled"`
@@ -1044,7 +1044,7 @@ feature:
 `
 
 		mockConfig := newConfigFromYaml(t, confYaml)
-		mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+		mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 		feature := struct {
 			Enabled bool `mapstructure:"enabled"`
@@ -1062,7 +1062,7 @@ feature:
 `
 
 		mockConfig := newConfigFromYaml(t, confYaml)
-		mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+		mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 		feature := struct {
 			Enabled bool `mapstructure:"enabled"`
@@ -1080,7 +1080,7 @@ feature:
 `
 
 		mockConfig := newConfigFromYaml(t, confYaml)
-		mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+		mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 		feature := struct {
 			Enabled int `mapstructure:"enabled"`
@@ -1098,7 +1098,7 @@ feature:
 `
 
 		mockConfig := newConfigFromYaml(t, confYaml)
-		mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+		mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 		feature := struct {
 			Enabled float64 `mapstructure:"enabled"`
@@ -1116,7 +1116,7 @@ feature:
 `
 
 		mockConfig := newConfigFromYaml(t, confYaml)
-		mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+		mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 		feature := struct {
 			Enabled string `mapstructure:"enabled"`
@@ -1135,7 +1135,7 @@ feature:
 `
 
 		mockConfig := newConfigFromYaml(t, confYaml)
-		mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+		mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 		feature := struct {
 			Enabled string `mapstructure:"enabled"`
@@ -1154,7 +1154,7 @@ feature:
 `
 
 	mockConfig := newConfigFromYaml(t, confYaml)
-	mockConfig.SetKnown("feature") //nolint: forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 	feature := struct {
 		Enabled uint `mapstructure:"enabled"`
@@ -1180,7 +1180,7 @@ feature:
 	want := "true"
 
 	mockConfig := newConfigFromYaml(t, confYaml)
-	mockConfig.SetKnown("feature") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	mockConfig.BindEnvAndSetDefault("feature", map[string]interface{}{})
 
 	t.Run("json omitempty", func(t *testing.T) {
 		feature := struct {
@@ -1309,7 +1309,7 @@ service:
   apikey: abc1
 `
 	mockConfig := newConfigFromYaml(t, confYaml)
-	mockConfig.SetKnown("service") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	mockConfig.BindEnvAndSetDefault("service", map[string]interface{}{})
 	var svc = squashConfig{}
 
 	t.Run("squash flag succeeds with option", func(t *testing.T) {
@@ -1354,7 +1354,7 @@ service:
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockConfig := newConfigFromYaml(t, tc.conf)
-			mockConfig.SetKnown("service") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+			mockConfig.BindEnvAndSetDefault("service", map[string]interface{}{})
 
 			svc := &serviceConfig{}
 			err := UnmarshalKey(mockConfig, "service", svc, ErrorUnused)
@@ -1379,7 +1379,7 @@ service:
   disabled: f
 `
 	mockConfig := newConfigFromYaml(t, confYaml)
-	mockConfig.SetKnown("service") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	mockConfig.BindEnvAndSetDefault("service", map[string]interface{}{})
 	var svc = make(map[string]string)
 
 	err := UnmarshalKey(mockConfig, "service", &svc)
@@ -1400,7 +1400,7 @@ service:
   disabled: false
 `
 	mockConfig := newConfigFromYaml(t, confYaml)
-	mockConfig.SetKnown("service") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	mockConfig.BindEnvAndSetDefault("service", map[string]interface{}{})
 	var svc = make(map[string]bool)
 
 	err := UnmarshalKey(mockConfig, "service", &svc)
@@ -1431,7 +1431,7 @@ feature_flags:
 	}
 
 	mockConfig := newConfigFromYaml(t, confYaml)
-	mockConfig.SetKnown("feature_flags") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	mockConfig.BindEnvAndSetDefault("feature_flags", map[string]interface{}{})
 
 	flags := FeatureFlags{}
 
@@ -1524,7 +1524,7 @@ some_config:
     memory: 5g
 `
 	mockConfig := newConfigFromYaml(t, confYaml)
-	mockConfig.SetKnown("some_config.resources.memory") //nolint:forbidigo, using SetKnown to test behavior
+	mockConfig.BindEnvAndSetDefault("some_config.resources.memory", "")
 
 	var res myStruct
 	err := UnmarshalKey(mockConfig, "some_config", &res)

--- a/tasks/schema/codegen_init_settings.py
+++ b/tasks/schema/codegen_init_settings.py
@@ -356,8 +356,6 @@ def retrieve_method_to_declare(keypath, schema):
     if tags:
         if 'no-env' in tags:
             return 'SetDefault'
-        if 'TODO:fix-no-default' in tags:
-            return 'BindEnv'
     return 'BindEnvAndSetDefault'
 
 
@@ -433,8 +431,6 @@ def output_single_setting(name, kind, internal_comment, schema, target):
     method_name = retrieve_method_to_declare(name.split('.'), schema)
     if method_name == 'BindEnvAndSetDefault':
         line = f"\tconfig.BindEnvAndSetDefault({settingname}, {defaultval}{envsuffix})"
-    elif method_name == 'BindEnv':
-        line = f"\tconfig.BindEnv({settingname}{envsuffix})"
     elif method_name == 'SetDefault':
         line = f"\tconfig.SetDefault({settingname}, {defaultval})"
     else:

--- a/tasks/schema/settings_source_analyzer.py
+++ b/tasks/schema/settings_source_analyzer.py
@@ -199,9 +199,6 @@ class Processor:
         if text.startswith('//'):
             text = text[2:]
         text = text.strip()
-        # ignore this common case:
-        if re.match(r'^TODO: replace by .SetDefaultAndBindEnv.', text):
-            return
         self.internal_comment.append(text)
 
     def clean_param(self, params, index):


### PR DESCRIPTION
### What does this PR do?

Now that all default have a default we can remove this method.
