### PR TITLE
Disable noisy `rules_python` coverage tool until needed

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -320,7 +320,7 @@ PYTHON_VERSION = "3.12"
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.defaults(python_version = PYTHON_VERSION)
 python.toolchain(
-    configure_coverage_tool = True,
+    configure_coverage_tool = False,  # when enabling, please find a way to turn off warnings for unsupported platforms
     is_default = True,
     python_version = PYTHON_VERSION,
 )


### PR DESCRIPTION
### What does this PR do?
Disable `rules_python`'s coverage-tool wiring for the hermetic Python toolchain.

### Motivation
`python.toolchain(configure_coverage_tool = True, ...)` makes `rules_python` register a coverage tool for each and every platform in its `PLATFORMS` registry (dozens of architectures), not just the 5 this repo ships for.

4 of them (`ppc64le`, `riscv64`, `s390x`, and `musl-linux`) have no `coverage.py` wheel at any `cp312` patch version, so `bazel` commands lead to annoying and unactionable [warnings](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1831971532#L92):
```
DEBUG: /go/src/github.com/DataDog/datadog-agent/.cache/bazel/_bazel_root/8595a61ca643e2561dc364b98a410786/external/rules_python+/python/private/repo_utils.bzl:101:16:
rules_python:coverage_dep WARNING: rules_python's bundled coverage tool has no wheel for python_version=3.12.13, platform=ppc64le-unknown-linux-gnu. `bazel coverage` will produce empty lcov for py_test targets in this configuration. Either pin python_version to a version in the bundled set (see python/private/coverage_deps.bzl), or configure coverage manually via py_runtime.coverage_tool. See docs/coverage.md.
DEBUG: /go/src/github.com/DataDog/datadog-agent/.cache/bazel/_bazel_root/8595a61ca643e2561dc364b98a410786/external/rules_python+/python/private/repo_utils.bzl:101:16:
rules_python:coverage_dep WARNING: rules_python's bundled coverage tool has no wheel for python_version=3.12.13, platform=riscv64-unknown-linux-gnu. `bazel coverage` will produce empty lcov for py_test targets in this configuration. Either pin python_version to a version in the bundled set (see python/private/coverage_deps.bzl), or configure coverage manually via py_runtime.coverage_tool. See docs/coverage.md.
DEBUG: /go/src/github.com/DataDog/datadog-agent/.cache/bazel/_bazel_root/8595a61ca643e2561dc364b98a410786/external/rules_python+/python/private/repo_utils.bzl:101:16:
rules_python:coverage_dep WARNING: rules_python's bundled coverage tool has no wheel for python_version=3.12.13, platform=s390x-unknown-linux-gnu. `bazel coverage` will produce empty lcov for py_test targets in this configuration. Either pin python_version to a version in the bundled set (see python/private/coverage_deps.bzl), or configure coverage manually via py_runtime.coverage_tool. See docs/coverage.md.
DEBUG: /go/src/github.com/DataDog/datadog-agent/.cache/bazel/_bazel_root/8595a61ca643e2561dc364b98a410786/external/rules_python+/python/private/repo_utils.bzl:101:16:
rules_python:coverage_dep WARNING: rules_python's bundled coverage tool has no wheel for python_version=3.12.13, platform=x86_64-unknown-linux-musl. `bazel coverage` will produce empty lcov for py_test targets in this configuration. Either pin python_version to a version in the bundled set (see python/private/coverage_deps.bzl), or configure coverage manually via py_runtime.coverage_tool. See docs/coverage.md.
```

Python coverage is not used anywhere in this repo's tasks or CI configs at this stage, so what the coverage tool wiring warns about is dead weight regardless of the missing wheels.

As of today, `rules_python` has no `bzlmod`-level way to restrict the platform set itself, so dsabling the coverage tool is the only non-invasive fix available.

### Describe how you validated your changes
Confirmed the warning disappears without affecting `MODULE.bazel.lock`.

### Additional Notes
We would of course revisit this when/if `integrations-core` gets merged to the `datadog-agent` monorepo.