### PR TITLE
(clusterchecks): Release lock on getState handler

### DIFF
--- a/pkg/clusteragent/clusterchecks/handler_api.go
+++ b/pkg/clusteragent/clusterchecks/handler_api.go
@@ -44,10 +44,13 @@ func (h *Handler) RejectOrForwardLeaderQuery(rw http.ResponseWriter, req *http.R
 
 // GetState returns the state of the dispatching, for the clusterchecks cmd
 func (h *Handler) GetState(scrub bool) (types.StateResponse, error) {
+	// Release h.m before calling getState: holding it for the scrubbing
+	// duration blocks updateLeaderIP and starves the leadership health probe.
 	h.m.RLock()
-	defer h.m.RUnlock()
+	currentState := h.state
+	h.m.RUnlock()
 
-	switch h.state {
+	switch currentState {
 	case leader:
 		return h.dispatcher.getState(scrub)
 	case follower:


### PR DESCRIPTION
### What does this PR do?

Read the state of the cluster agent (leader or follower) and release the lock before doing a potentially expensive task like `getState` which only environments with thousands of cluster-checks and cluster-agents can cause issues.

### Motivation

Increase resiliency on potentially expensive `getState` calls in order to allow health probes and leadership channels to drain without being blocked.

```
  GetState() holds h.m.RLock()
      → updateLeaderIP() blocks on h.m.Lock()                                                                                              
          → leaderWatch goroutine stuck in watchTicker.C case                                                                            
              → healthProbe.C never drained                                                                                                
                  → clusterchecks-leadership = unhealthy
```

### Describe how you validated your changes

Unit tests and CI

### Additional Notes

We can also look into make the `getState` method a little more lock efficient. We can copy over the node state before doing the expensive regex scrubbing work. This can be done as a follow up action item.

