### PR TITLE
Emit Stable Helm release and chart CRs with labels, revision history, and version rollups

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
@@ -48,6 +48,28 @@ type RevisionSummary struct {
 	Config map[string]interface{}
 }
 
+// ChartAggregate collapses every release's chart to one entry per chart name. A
+// chart is a package identified by its content, not a per-namespace/cluster
+type ChartAggregate struct {
+	// Latest is the representative content: the highest version seen.
+	Latest *Chart
+	// Versions is every distinct version seen, newest first.
+	Versions []ChartVersionSummary
+	// ReleaseCount is the number of distinct releases using this chart (any version).
+	ReleaseCount int
+}
+
+// ChartVersionSummary summarizes one version of a chart.
+type ChartVersionSummary struct {
+	Version    string
+	AppVersion string
+	// Releases is the number of distinct releases that used this version.
+	Releases int
+	// DefaultValues holds this version's chart default values, so the UI can diff
+	// defaults across versions without re-collecting each one over time.
+	DefaultValues map[string]interface{}
+}
+
 // Info describes the deployment state of a release.
 type Info struct {
 	FirstDeployed string `json:"first_deployed,omitempty"`

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
@@ -28,6 +28,21 @@ type Release struct {
 	Manifest string `json:"manifest,omitempty"`
 	// ResourceVersion is the backing storage object's resourceVersion.
 	ResourceVersion string `json:"-"`
+	// History holds a compact summary of every revision of this release. It is
+	// computed by the collector (not part of Helm's stored payload) and surfaced
+	// on the current release CR so the UI can render release history.
+	History []RevisionSummary `json:"-"`
+}
+
+// RevisionSummary is a compact per-revision record surfaced on the current
+// release CR.
+type RevisionSummary struct {
+	Revision     int
+	Status       string
+	ChartVersion string
+	AppVersion   string
+	// Updated is the revision's last-deployed time.
+	Updated string
 }
 
 // Info describes the deployment state of a release.

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
@@ -26,7 +26,7 @@ type Release struct {
 	Config map[string]interface{} `json:"config,omitempty"`
 	// Manifest is the fully rendered Kubernetes YAML applied to the cluster.
 	Manifest string `json:"manifest,omitempty"`
-	// ResourceVersion is the backing storage object's resourceVersion. 
+	// ResourceVersion is the backing storage object's resourceVersion.
 	ResourceVersion string `json:"-"`
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/release.go
@@ -43,6 +43,9 @@ type RevisionSummary struct {
 	AppVersion   string
 	// Updated is the revision's last-deployed time.
 	Updated string
+	// Config holds the user-supplied values for this revision, so the UI can
+	// diff values across revisions without re-collecting each one over time.
+	Config map[string]interface{}
 }
 
 // Info describes the deployment state of a release.

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
@@ -82,9 +82,11 @@ func ReleaseToUnstructured(clusterID string, r *Release) *unstructured.Unstructu
 	}
 
 	// Keep manifests structured so the scrubber can inspect nested fields.
-	if resources := parseManifest(r.Manifest); len(resources) > 0 {
+	resources := parseManifest(r.Manifest)
+	if len(resources) > 0 {
 		spec["resources"] = resources
 	}
+	spec["resourceCount"] = int64(len(resources))
 
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -96,13 +98,14 @@ func ReleaseToUnstructured(clusterID string, r *Release) *unstructured.Unstructu
 				"uid":             releaseUID(clusterID, r),
 				"resourceVersion": r.ResourceVersion,
 				"labels": map[string]interface{}{
-					"helm_release":       r.Name,
-					"helm_revision":      strconv.Itoa(r.Version),
-					"helm_status":        status,
-					"helm_chart":         chart,
-					"helm_chart_version": chartVersion,
-					"helm_app_version":   appVersion,
-					"helm_last_deployed": lastDeployed,
+					"helm_release":        r.Name,
+					"helm_revision":       strconv.Itoa(r.Version),
+					"helm_status":         status,
+					"helm_chart":          chart,
+					"helm_chart_version":  chartVersion,
+					"helm_app_version":    appVersion,
+					"helm_last_deployed":  lastDeployed,
+					"helm_resource_count": strconv.Itoa(len(resources)),
 				},
 			},
 			"spec": spec,

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
@@ -10,11 +10,13 @@ package helm
 import (
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -38,8 +40,9 @@ const HelmChartKind = "HelmChart"
 const helmReleaseAPIVersion = HelmReleaseGroup + "/" + HelmReleaseVersion
 
 // ReleaseToUnstructured converts a parsed Helm release revision into a
-// synthetic custom resource.
-func ReleaseToUnstructured(r *Release) *unstructured.Unstructured {
+// synthetic custom resource. clusterID scopes the release identity to its
+// cluster so releases sharing a namespace/name across clusters stay distinct.
+func ReleaseToUnstructured(clusterID string, r *Release) *unstructured.Unstructured {
 	var chart, chartVersion, appVersion string
 	if r.Chart != nil && r.Chart.Metadata != nil {
 		chart = r.Chart.Metadata.Name
@@ -90,14 +93,16 @@ func ReleaseToUnstructured(r *Release) *unstructured.Unstructured {
 			"metadata": map[string]interface{}{
 				"name":            r.Name,
 				"namespace":       r.Namespace,
-				"uid":             releaseUID(r),
+				"uid":             releaseUID(clusterID, r),
 				"resourceVersion": r.ResourceVersion,
 				"labels": map[string]interface{}{
-					"helm_release":     r.Name,
-					"helm_revision":    strconv.Itoa(r.Version),
-					"helm_status":      status,
-					"helm_chart":       chart,
-					"helm_app_version": appVersion,
+					"helm_release":       r.Name,
+					"helm_revision":      strconv.Itoa(r.Version),
+					"helm_status":        status,
+					"helm_chart":         chart,
+					"helm_chart_version": chartVersion,
+					"helm_app_version":   appVersion,
+					"helm_last_deployed": lastDeployed,
 				},
 			},
 			"spec": spec,
@@ -144,32 +149,37 @@ func parseManifest(manifest string) []interface{} {
 	return resources
 }
 
-// releaseUID returns a deterministic UUID for a release, stable across revisions.
-func releaseUID(r *Release) string {
-	key := fmt.Sprintf("%s/%s", r.Namespace, r.Name)
+// releaseUID returns a deterministic UUID for a release, stable across revisions
+// and unique per cluster
+func releaseUID(clusterID string, r *Release) string {
+	key := fmt.Sprintf("%s/%s/%s", clusterID, r.Namespace, r.Name)
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(key)).String()
 }
 
-// ChartToUnstructured converts a packaged chart into a synthetic custom resource.
-func ChartToUnstructured(c *Chart) *unstructured.Unstructured {
-	if c == nil || c.Metadata == nil || c.Metadata.Name == "" {
+// ChartToUnstructured converts a name-aggregated chart into a synthetic custom
+// resource: one row per chart name, with the versions seen and how many releases
+// use them rolled up. The representative metadata/content is the latest version's.
+func ChartToUnstructured(a *ChartAggregate) *unstructured.Unstructured {
+	if a == nil || a.Latest == nil || a.Latest.Metadata == nil || a.Latest.Metadata.Name == "" {
 		return nil
 	}
 
+	c := a.Latest
 	name := c.Metadata.Name
-	version := c.Metadata.Version
+	latestVersion := c.Metadata.Version
 
 	spec := map[string]interface{}{
 		"name":        name,
-		"version":     version,
+		"version":     latestVersion, // the latest version stands in for the chart
 		"appVersion":  c.Metadata.AppVersion,
 		"apiVersion":  c.Metadata.APIVersion,
 		"description": c.Metadata.Description,
+		// Rollups so the UI can show one chart summarizing all its versions.
+		"versionCount": int64(len(a.Versions)),
+		"releaseCount": int64(a.ReleaseCount),
+		"versions":     chartVersionsToInterface(a.Versions),
 	}
 
-	if len(c.Values) > 0 {
-		spec["defaultValues"] = c.Values
-	}
 	if len(c.Templates) > 0 {
 		spec["templates"] = templatesToInterface(c.Templates)
 	}
@@ -182,18 +192,40 @@ func ChartToUnstructured(c *Chart) *unstructured.Unstructured {
 			"apiVersion": helmReleaseAPIVersion,
 			"kind":       HelmChartKind,
 			"metadata": map[string]interface{}{
-				"name":            fmt.Sprintf("%s.%s", name, version),
-				"uid":             chartUID(name, version),
-				"resourceVersion": "1", // chart content for a version is immutable
+				"name":            name,
+				"uid":             chartUID(name),
+				"resourceVersion": chartResourceVersion(a),
 				"labels": map[string]interface{}{
 					"helm_chart":         name,
-					"helm_chart_version": version,
+					"helm_chart_version": latestVersion,
 					"helm_app_version":   c.Metadata.AppVersion,
+					// Surfaced as labels so the counts reach the table as tags.
+					"helm_version_count": strconv.Itoa(len(a.Versions)),
+					"helm_release_count": strconv.Itoa(a.ReleaseCount),
 				},
 			},
 			"spec": spec,
 		},
 	}
+}
+
+// chartVersionsToInterface converts a chart's per-version rollup into
+// JSON-compatible maps (newest first), embedding each version's default values so
+// the UI can diff defaults across versions.
+func chartVersionsToInterface(versions []ChartVersionSummary) []interface{} {
+	out := make([]interface{}, 0, len(versions))
+	for _, v := range versions {
+		entry := map[string]interface{}{
+			"version":    v.Version,
+			"appVersion": v.AppVersion,
+			"releases":   int64(v.Releases),
+		}
+		if len(v.DefaultValues) > 0 {
+			entry["defaultValues"] = v.DefaultValues
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 // dependenciesToInterface converts chart dependencies into JSON-compatible maps.
@@ -215,9 +247,23 @@ func dependenciesToInterface(deps []*Dependency) []interface{} {
 	return out
 }
 
-func chartUID(name, version string) string {
-	key := fmt.Sprintf("%s/%s", name, version)
-	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(key)).String()
+// chartUID returns a deterministic UUID for a chart, keyed only by name. A chart
+// is a package, not a per-namespace/cluster installation, so its identity is
+// intentionally independent of version, namespace, and cluster: the same chart is
+// shown once wherever it is used.
+func chartUID(name string) string {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(name)).String()
+}
+
+// chartResourceVersion derives a resourceVersion from the aggregate's content so
+// the orchestrator re-sends the chart when its versions or release counts change.
+func chartResourceVersion(a *ChartAggregate) string {
+	h := fnv.New64a()
+	for _, v := range a.Versions {
+		fmt.Fprintf(h, "%s:%s:%d;", v.Version, v.AppVersion, v.Releases)
+	}
+	fmt.Fprintf(h, "|%d", a.ReleaseCount)
+	return strconv.FormatUint(h.Sum64(), 10)
 }
 
 // CurrentReleases returns the latest revision of each release (namespace/name),
@@ -305,20 +351,95 @@ func revisionSummariesToInterface(summaries []RevisionSummary) []interface{} {
 	return out
 }
 
-// UniqueCharts returns one chart per distinct (name, version).
-func UniqueCharts(releases []*Release) []*Chart {
-	seen := make(map[string]struct{})
-	charts := make([]*Chart, 0)
+// AggregateCharts collapses the charts referenced by releases into one entry per
+// chart name, rolling up the versions seen and how many releases use them.
+func AggregateCharts(releases []*Release) []*ChartAggregate {
+	groups := make(map[string][]*Release)
+	names := make([]string, 0)
 	for _, r := range releases {
 		if r == nil || r.Chart == nil || r.Chart.Metadata == nil || r.Chart.Metadata.Name == "" {
 			continue
 		}
-		key := r.Chart.Metadata.Name + "\x00" + r.Chart.Metadata.Version
-		if _, ok := seen[key]; ok {
-			continue
+		name := r.Chart.Metadata.Name
+		if _, ok := groups[name]; !ok {
+			names = append(names, name)
 		}
-		seen[key] = struct{}{}
-		charts = append(charts, r.Chart)
+		groups[name] = append(groups[name], r)
 	}
-	return charts
+	sort.Strings(names)
+
+	out := make([]*ChartAggregate, 0, len(names))
+	for _, name := range names {
+		out = append(out, aggregateChart(groups[name]))
+	}
+	return out
+}
+
+// aggregateChart reduces every release/revision that references a chart name to a
+// single ChartAggregate: the latest version's content plus a per-version rollup of
+// the distinct releases (namespace/name) that used it.
+func aggregateChart(group []*Release) *ChartAggregate {
+	type versionAcc struct {
+		chart      *Chart
+		appVersion string
+		releases   map[string]struct{}
+	}
+	byVersion := make(map[string]*versionAcc)
+	order := make([]string, 0)
+	releases := make(map[string]struct{})
+
+	for _, r := range group {
+		version := r.Chart.Metadata.Version
+		acc := byVersion[version]
+		if acc == nil {
+			acc = &versionAcc{
+				chart:      r.Chart,
+				appVersion: r.Chart.Metadata.AppVersion,
+				releases:   make(map[string]struct{}),
+			}
+			byVersion[version] = acc
+			order = append(order, version)
+		}
+		releaseKey := r.Namespace + "/" + r.Name
+		acc.releases[releaseKey] = struct{}{}
+		releases[releaseKey] = struct{}{}
+	}
+
+	sortChartVersionsDesc(order)
+
+	versions := make([]ChartVersionSummary, 0, len(order))
+	for _, version := range order {
+		acc := byVersion[version]
+		versions = append(versions, ChartVersionSummary{
+			Version:       version,
+			AppVersion:    acc.appVersion,
+			Releases:      len(acc.releases),
+			DefaultValues: acc.chart.Values,
+		})
+	}
+
+	return &ChartAggregate{
+		Latest:       byVersion[order[0]].chart,
+		Versions:     versions,
+		ReleaseCount: len(releases),
+	}
+}
+
+// sortChartVersionsDesc orders chart versions newest-first by semver, keeping any
+// non-semver versions in reverse-lexical order after the valid ones.
+func sortChartVersionsDesc(versions []string) {
+	sort.SliceStable(versions, func(i, j int) bool {
+		vi, ei := semver.NewVersion(versions[i])
+		vj, ej := semver.NewVersion(versions[j])
+		switch {
+		case ei == nil && ej == nil:
+			return vi.GreaterThan(vj)
+		case ei == nil:
+			return true
+		case ej == nil:
+			return false
+		default:
+			return versions[i] > versions[j]
+		}
+	})
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -73,6 +74,10 @@ func ReleaseToUnstructured(r *Release) *unstructured.Unstructured {
 		spec["config"] = r.Config
 	}
 
+	if len(r.History) > 0 {
+		spec["history"] = revisionSummariesToInterface(r.History)
+	}
+
 	// Keep manifests structured so the scrubber can inspect nested fields.
 	if resources := parseManifest(r.Manifest); len(resources) > 0 {
 		spec["resources"] = resources
@@ -83,7 +88,7 @@ func ReleaseToUnstructured(r *Release) *unstructured.Unstructured {
 			"apiVersion": helmReleaseAPIVersion,
 			"kind":       HelmReleaseKind,
 			"metadata": map[string]interface{}{
-				"name":            fmt.Sprintf("%s.v%d", r.Name, r.Version),
+				"name":            r.Name,
 				"namespace":       r.Namespace,
 				"uid":             releaseUID(r),
 				"resourceVersion": r.ResourceVersion,
@@ -139,9 +144,9 @@ func parseManifest(manifest string) []interface{} {
 	return resources
 }
 
-// releaseUID returns a deterministic UUID for a release revision.
+// releaseUID returns a deterministic UUID for a release, stable across revisions.
 func releaseUID(r *Release) string {
-	key := fmt.Sprintf("%s/%s/%d", r.Namespace, r.Name, r.Version)
+	key := fmt.Sprintf("%s/%s", r.Namespace, r.Name)
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(key)).String()
 }
 
@@ -213,6 +218,86 @@ func dependenciesToInterface(deps []*Dependency) []interface{} {
 func chartUID(name, version string) string {
 	key := fmt.Sprintf("%s/%s", name, version)
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(key)).String()
+}
+
+// CurrentReleases returns the latest revision of each release (namespace/name),
+// mirroring `helm list`. Helm retains one storage object per revision; we surface
+// only the most recent so each release appears once, and attach a summary of all
+// revisions as its history.
+func CurrentReleases(releases []*Release) []*Release {
+	groups := make(map[string][]*Release)
+	for _, r := range releases {
+		if r == nil {
+			continue
+		}
+		key := r.Namespace + "/" + r.Name
+		groups[key] = append(groups[key], r)
+	}
+	out := make([]*Release, 0, len(groups))
+	for _, group := range groups {
+		current := group[0]
+		for _, r := range group[1:] {
+			if r.Version > current.Version {
+				current = r
+			}
+		}
+		current.History = revisionSummaries(group)
+		out = append(out, current)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// revisionSummaries builds a per-revision summary for a release's revisions,
+// newest first.
+func revisionSummaries(releases []*Release) []RevisionSummary {
+	summaries := make([]RevisionSummary, 0, len(releases))
+	for _, r := range releases {
+		if r == nil {
+			continue
+		}
+		var chartVersion, appVersion string
+		if r.Chart != nil && r.Chart.Metadata != nil {
+			chartVersion = r.Chart.Metadata.Version
+			appVersion = r.Chart.Metadata.AppVersion
+		}
+		var status, updated string
+		if r.Info != nil {
+			status = r.Info.Status
+			updated = r.Info.LastDeployed
+		}
+		summaries = append(summaries, RevisionSummary{
+			Revision:     r.Version,
+			Status:       status,
+			ChartVersion: chartVersion,
+			AppVersion:   appVersion,
+			Updated:      updated,
+		})
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].Revision > summaries[j].Revision
+	})
+	return summaries
+}
+
+// revisionSummariesToInterface converts revision summaries into JSON-compatible maps.
+func revisionSummariesToInterface(summaries []RevisionSummary) []interface{} {
+	out := make([]interface{}, 0, len(summaries))
+	for _, s := range summaries {
+		out = append(out, map[string]interface{}{
+			"revision":     int64(s.Revision),
+			"status":       s.Status,
+			"chartVersion": s.ChartVersion,
+			"appVersion":   s.AppVersion,
+			"updated":      s.Updated,
+		})
+	}
+	return out
 }
 
 // UniqueCharts returns one chart per distinct (name, version).

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
@@ -277,6 +277,7 @@ func revisionSummaries(releases []*Release) []RevisionSummary {
 			ChartVersion: chartVersion,
 			AppVersion:   appVersion,
 			Updated:      updated,
+			Config:       r.Config,
 		})
 	}
 	sort.Slice(summaries, func(i, j int) bool {
@@ -289,13 +290,17 @@ func revisionSummaries(releases []*Release) []RevisionSummary {
 func revisionSummariesToInterface(summaries []RevisionSummary) []interface{} {
 	out := make([]interface{}, 0, len(summaries))
 	for _, s := range summaries {
-		out = append(out, map[string]interface{}{
+		entry := map[string]interface{}{
 			"revision":     int64(s.Revision),
 			"status":       s.Status,
 			"chartVersion": s.ChartVersion,
 			"appVersion":   s.AppVersion,
 			"updated":      s.Updated,
-		})
+		}
+		if len(s.Config) > 0 {
+			entry["config"] = s.Config
+		}
+		out = append(out, entry)
 	}
 	return out
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helm/unstructured.go
@@ -88,9 +88,11 @@ func ReleaseToUnstructured(r *Release) *unstructured.Unstructured {
 				"uid":             releaseUID(r),
 				"resourceVersion": r.ResourceVersion,
 				"labels": map[string]interface{}{
-					"helm_release":  r.Name,
-					"helm_revision": strconv.Itoa(r.Version),
-					"helm_status":   status,
+					"helm_release":     r.Name,
+					"helm_revision":    strconv.Itoa(r.Version),
+					"helm_status":      status,
+					"helm_chart":       chart,
+					"helm_app_version": appVersion,
 				},
 			},
 			"spec": spec,
@@ -181,6 +183,7 @@ func ChartToUnstructured(c *Chart) *unstructured.Unstructured {
 				"labels": map[string]interface{}{
 					"helm_chart":         name,
 					"helm_chart_version": version,
+					"helm_app_version":   c.Metadata.AppVersion,
 				},
 			},
 			"spec": spec,

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helmchart.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helmchart.go
@@ -83,7 +83,7 @@ func (c *HelmChartCollector) Run(rcfg *collectors.CollectorRunConfig) (*collecto
 	}
 
 	releases := helm.ReleasesFromConfigMaps(configMaps)
-	charts := helm.UniqueCharts(releases)
+	charts := helm.AggregateCharts(releases)
 	list := make([]runtime.Object, 0, len(charts))
 	for _, chart := range charts {
 		if u := helm.ChartToUnstructured(chart); u != nil {

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helmrelease.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helmrelease.go
@@ -85,7 +85,7 @@ func (c *HelmReleaseCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 	releases := helm.CurrentReleases(helm.ReleasesFromConfigMaps(configMaps))
 	list := make([]runtime.Object, 0, len(releases))
 	for _, r := range releases {
-		list = append(list, helm.ReleaseToUnstructured(r))
+		list = append(list, helm.ReleaseToUnstructured(rcfg.ClusterID, r))
 	}
 
 	return c.Process(rcfg, list)

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helmrelease.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/helmrelease.go
@@ -82,7 +82,7 @@ func (c *HelmReleaseCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		return nil, collectors.NewListingError(err)
 	}
 
-	releases := helm.ReleasesFromConfigMaps(configMaps)
+	releases := helm.CurrentReleases(helm.ReleasesFromConfigMaps(configMaps))
 	list := make([]runtime.Object, 0, len(releases))
 	for _, r := range releases {
 		list = append(list, helm.ReleaseToUnstructured(r))


### PR DESCRIPTION
### What does this PR do?
**Release**
-  Emit only the current revision per release, with its revision history attached, so the UI shows past revisions from the current release row.
- Embed each revision's config in that history, read from retained ConfigMaps so pre-existing revisions are captured even if the agent is deployed later.
- Key HelmRelease names/UIDs on cluster/namespace/name — stable across revisions, distinct across clusters.
- Add helm_chart, helm_app_version, helm_chart_version, helm_last_deployed,  helm_resource_count labels

**Charts**
-  Aggregate HelmChart CRs by name (one row per chart, not per name+version) with version/release rollups; name-only UID so a chart shows once across versions/namespaces/clusters.
- Embed each version's default values in spec.versions[] (from retained ConfigMaps, incl. pre-agent versions) to diff defaults across versions.
- Add helm_app_version, helm_version_count, helm_release_count labels.
- Content-hash the HelmChart resourceVersion so the aggregated chart re-emits on change.

### Motivation

https://datadoghq.atlassian.net/browse/CONTINT-5409


### Describe how you validated your changes
- HelmRelease: open a CR and confirm one row per release, a name/UID stable across revisions (keyed on cluster/namespace/name), tags helm_chart / helm_app_version / helm_chart_version / helm_last_deployed /  helm_resource_count, and emitted revision history including each revision's config. ([Link](https://dd.datad0g.com/orchestration/explorer/cr?query=kube_cluster_name%3Aminikube-helm-test&explorer-na-groups=false&highlight=%5B%5D&panel_tab=overview&panel_view=namespace&pte=1783974009961&ptfu=true&ptilt=false&ptm=sliding&pts=1783887609961&rrv=list&sp=%5B%7B%22p%22%3A%7B%22type%22%3A%22cr%22%2C%22inspectedNodeId%22%3A%22d42c2b06-56b3-583a-9406-62de9bc9a4b1%22%7D%2C%22iid%22%3A%22cr%23d42c2b06-56b3-583a-9406-62de9bc9a4b1%22%2C%22mp%22%3A%7B%22size%22%3A%22lg%22%7D%2C%22b%22%3A%22Back%22%2C%22i%22%3A%22orchestration-entity-panel%22%7D%5D))
- HelmChart: open a CR and confirm one CR per chart name (not per version), tags helm_app_version / helm_version_count / helm_release_count, and spec.versions[] carrying each version's app version, release count, and default values. ([Link](https://dd.datad0g.com/orchestration/explorer/cr?query=kube_cluster_name%3Aminikube-helm-test&crd-sort=name%3Adesc&explorer-na-groups=false&highlight=%5B%5D&panel_tab=overview&panel_view=crd&pte=1783974048667&ptfu=false&ptilt=false&ptm=sliding&pts=1783887648667&rrv=list&sp=%5B%7B%22p%22%3A%7B%22type%22%3A%22cr%22%2C%22inspectedNodeId%22%3A%226cf7fbdc-d3c0-50e8-a458-fd05025f7a34%22%7D%2C%22iid%22%3A%22cr%236cf7fbdc-d3c0-50e8-a458-fd05025f7a34%22%2C%22mp%22%3A%7B%22size%22%3A%22lg%22%7D%2C%22b%22%3A%22Back%22%2C%22i%22%3A%22orchestration-entity-panel%22%7D%5D))
### Additional Notes
