### PR TITLE
fix(ci): match nested BUILD.bazel files in bazel_paths change detection

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,9 +60,11 @@
   - cmd/otel-agent/**/*
 
 # Bazel build system paths - single source of truth for all Bazel-related change detection.
-# Covers MODULE.bazel, MODULE.bazel.lock, BUILD.bazel, REPO.bazel, .bazelrc, .bazelversion.
+# Covers MODULE.bazel, MODULE.bazel.lock, BUILD.bazel, REPO.bazel, .bazelrc, .bazelversion,
+# including nested BUILD.bazel files (a single "*" does not cross "/" in GitLab's changes:paths glob).
 .bazel_paths: &bazel_paths
   - "*.bazel*"
+  - "**/*.bazel*"
   - deps/**/*
   - bazel/**/*
   - tasks/build_tags.bzl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,6 @@
 # Covers MODULE.bazel, MODULE.bazel.lock, BUILD.bazel, REPO.bazel, .bazelrc, .bazelversion,
 # including nested BUILD.bazel files (a single "*" does not cross "/" in GitLab's changes:paths glob).
 .bazel_paths: &bazel_paths
-  - "*.bazel*"
   - "**/*.bazel*"
   - deps/**/*
   - bazel/**/*


### PR DESCRIPTION
### What does this PR do?

Adds `**/*.bazel*` to `.bazel_paths` in `.gitlab-ci.yml` so nested `BUILD.bazel` file changes are detected as Bazel-relevant changes for CI purposes.

### Motivation

GitLab's `changes:paths` glob matching doesn't let a single `*` cross a `/` boundary, so `*.bazel*` only ever matched root-level files (`MODULE.bazel`, `.bazelrc`, ...), not nested files like `comp/trace/config/impl/BUILD.bazel`.

This matters because `bazel_paths` also feeds the `SKIP_WINDOWS` workflow variable: if a PR doesn't touch a Windows-specific path or a Bazel path, `SKIP_WINDOWS` stays `"true"` and the entire `.gitlab/windows/**.yml` include is skipped, meaning **no classic Windows test jobs are generated for that pipeline at all** (as opposed to being skipped/gated — they simply don't exist in the pipeline).

This is exactly what happened on #53200: the PR only changed `comp/trace/config/impl/BUILD.bazel` (plus non-Bazel test files), which didn't match `*.bazel*`, so `tests_windows-x64`, `tests_windows_sysprobe_x64`, and `tests_windows_secagent_x64` never ran (only the unconditionally-included `bazel:test:windows-amd64` job ran).

Related discussion: https://app.datadoghq.com/incidents/57267

### Describe how you validated your changes

- `dda inv linter.gitlab-ci` passes across all tested contexts.
- Confirmed via the GitLab API that pipeline 122599420 (PR #53200) has zero jobs named `tests_windows*`, while `bazel:test:windows-amd64` did run — consistent with the `.gitlab/windows/**.yml` include being skipped due to `SKIP_WINDOWS=true`.

### Possible Drawbacks / Questions

This will cause the Windows job set (and its associated CI time) to run on more PRs going forward — specifically any PR touching a nested `BUILD.bazel`/`BUILD` file that previously wouldn't have triggered it.