### PR TITLE
feat(windows): gate AI-usage native host install behind EUDM mode

### DIFF
--- a/releasenotes/notes/gate-ai-usage-native-host-eudm-12ea3e1e20777b58.yaml
+++ b/releasenotes/notes/gate-ai-usage-native-host-eudm-12ea3e1e20777b58.yaml
@@ -1,0 +1,11 @@
+---
+enhancements:
+  - |
+    On Windows, the AI Usage Chrome Native Messaging Host and its desktop-monitor
+    scheduled task are now installed only when End-User Device Monitoring (EUDM)
+    is enabled at install time (``DD_INFRASTRUCTURE_MODE=end_user_device``). When
+    EUDM is not enabled, the MSI no longer lays down the native host binary, the
+    Chrome ``NativeMessagingHosts`` registry entries, the ``ai_usage_native_host.yaml``
+    configuration, the Chrome host manifest, or the ``Datadog AI Usage Agent`` task.
+    The infrastructure mode is persisted to the registry so upgrades and repairs
+    that do not re-supply the property preserve the original choice.

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
@@ -44,6 +44,7 @@ namespace Datadog.AgentCustomActions
                     RegistryValueProperty(_session, "PROJECTLOCATION", subkey, "InstallPath");
                     RegistryValueProperty(_session, "APPLICATIONDATADIRECTORY", subkey, "ConfigRoot");
                     RegistryValueProperty(_session, ConfigureUserCustomActions.KeepRightsPropertyName, subkey, KeepRightsRegistryValueName);
+                    RegistryValueProperty(_session, "DD_INFRASTRUCTURE_MODE", subkey, InfrastructureModeRegistryValueName);
                 }
 
                 GetWindowsBuildVersion();
@@ -220,6 +221,7 @@ namespace Datadog.AgentCustomActions
 
                 StoreAgentUserInRegistry(subkey);
                 StoreKeepUserRightsInRegistry(subkey);
+                StoreInfrastructureModeInRegistry(subkey);
             }
             catch (Exception e)
             {

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/WriteConfigUnitTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/WriteConfigUnitTests.cs
@@ -97,6 +97,7 @@ random_property: test
                 File.WriteAllText(Path.Combine(AiUsageManifestDir(projectLocation), "com.datadoghq.ai_prompt_logger.native_host.json"), "{}");
                 sessionMock.Setup(session => session["APPLICATIONDATADIRECTORY"]).Returns(configFolder);
                 sessionMock.Setup(session => session["PROJECTLOCATION"]).Returns(projectLocation);
+                sessionMock.Setup(session => session["DD_INFRASTRUCTURE_MODE"]).Returns("end_user_device");
 
                 var result = InvokeWriteConfig(sessionMock.Object);
 
@@ -126,6 +127,7 @@ random_property: test
                 WriteAiUsageNativeHostExample(configFolder);
                 sessionMock.Setup(session => session["APPLICATIONDATADIRECTORY"]).Returns(configFolder);
                 sessionMock.Setup(session => session["PROJECTLOCATION"]).Returns(projectLocation);
+                sessionMock.Setup(session => session["DD_INFRASTRUCTURE_MODE"]).Returns("end_user_device");
 
                 var result = InvokeWriteConfig(sessionMock.Object);
 
@@ -151,6 +153,7 @@ random_property: test
                 File.WriteAllText(Path.Combine(configFolder, "ai_usage_native_host.yaml"), existingAiUsageConfig);
                 sessionMock.Setup(session => session["APPLICATIONDATADIRECTORY"]).Returns(configFolder);
                 sessionMock.Setup(session => session["PROJECTLOCATION"]).Returns(projectLocation);
+                sessionMock.Setup(session => session["DD_INFRASTRUCTURE_MODE"]).Returns("end_user_device");
 
                 var result = InvokeWriteConfig(sessionMock.Object);
 
@@ -170,6 +173,7 @@ random_property: test
                 File.WriteAllText(Path.Combine(configFolder, "datadog.yaml.example"), "api_key:\n");
                 sessionMock.Setup(session => session["APPLICATIONDATADIRECTORY"]).Returns(configFolder);
                 sessionMock.Setup(session => session["PROJECTLOCATION"]).Returns(projectLocation);
+                sessionMock.Setup(session => session["DD_INFRASTRUCTURE_MODE"]).Returns("end_user_device");
 
                 var result = InvokeWriteConfig(sessionMock.Object);
 
@@ -183,6 +187,30 @@ random_property: test
                         It.IsAny<string>(),
                         It.IsAny<int>()),
                     Times.Once);
+            });
+        }
+
+        [Theory]
+        [InlineAutoData("")]
+        [InlineAutoData("full")]
+        public void WriteConfig_Should_Not_Generate_AiUsage_Artifacts_When_Not_Eudm(string infraMode, Mock<ISession> sessionMock)
+        {
+            WithTempInstallFolders((configFolder, projectLocation) =>
+            {
+                File.WriteAllText(Path.Combine(configFolder, "datadog.yaml.example"), "api_key:\n");
+                WriteAiUsageNativeHostExample(configFolder);
+                sessionMock.Setup(session => session["APPLICATIONDATADIRECTORY"]).Returns(configFolder);
+                sessionMock.Setup(session => session["PROJECTLOCATION"]).Returns(projectLocation);
+                sessionMock.Setup(session => session["DD_INFRASTRUCTURE_MODE"]).Returns(infraMode);
+
+                var result = InvokeWriteConfig(sessionMock.Object);
+
+                Assert.Equal(ActionResult.Success, result);
+                // The CA still runs and writes datadog.yaml ...
+                Assert.True(File.Exists(Path.Combine(configFolder, "datadog.yaml")));
+                // ... but generates no AI-usage yaml or Chrome manifest when EUDM is not enabled.
+                Assert.False(File.Exists(Path.Combine(configFolder, "ai_usage_native_host.yaml")));
+                Assert.False(File.Exists(AiUsageManifestPath(projectLocation)));
             });
         }
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
@@ -494,6 +494,11 @@ namespace Datadog.CustomActions
         {
             var configFolder = session.Property("APPLICATIONDATADIRECTORY");
             var projectLocation = session.Property("PROJECTLOCATION");
+            // DD_INFRASTRUCTURE_MODE arrives via CustomActionData (WriteConfig is deferred) and
+            // reflects the value re-hydrated by ReadInstallState or supplied on the command line.
+            // Match the EUDM-gated feature value exactly (case-sensitive), consistent with the
+            // Go-side canonical "end_user_device".
+            var eudmEnabled = session.Property("DD_INFRASTRUCTURE_MODE") == "end_user_device";
             try
             {
                 var copyFileFn = new Action<string>(c => File.Copy(c + ".example", c));
@@ -527,32 +532,38 @@ namespace Datadog.CustomActions
                                     output.Write(yaml);
                                 })
                             }
-                        })
-                        .Concat(new[]
-                        {
-                            new
-                            {
-                                Path = AiUsageNativeHostConfigName,
-                                CreateFn = new Action<string>(c =>
-                                {
-                                    string yaml;
-                                    using (var input = new StreamReader(Path.Combine(configFolder, $"{AiUsageNativeHostConfigName}.example")))
-                                    {
-                                        yaml = input.ReadToEnd();
-                                    }
-
-                                    var port = ReadAgentReceiverPort(configFolder);
-                                    yaml = Regex.Replace(
-                                        yaml,
-                                        "^[ #]*trace_agent_url:.*$",
-                                        $"trace_agent_url: \"http://127.0.0.1:{port}\"",
-                                        RegexOptions.Multiline);
-
-                                    using var output = new StreamWriter(c);
-                                    output.Write(yaml);
-                                })
-                            }
                         });
+
+                // The AI-usage native host config is generated only when EUDM is enabled, matching
+                // the EUDM-gated feature that installs the binary and Chrome registrations.
+                if (eudmEnabled)
+                {
+                    configFiles = configFiles.Concat(new[]
+                    {
+                        new
+                        {
+                            Path = AiUsageNativeHostConfigName,
+                            CreateFn = new Action<string>(c =>
+                            {
+                                string yaml;
+                                using (var input = new StreamReader(Path.Combine(configFolder, $"{AiUsageNativeHostConfigName}.example")))
+                                {
+                                    yaml = input.ReadToEnd();
+                                }
+
+                                var port = ReadAgentReceiverPort(configFolder);
+                                yaml = Regex.Replace(
+                                    yaml,
+                                    "^[ #]*trace_agent_url:.*$",
+                                    $"trace_agent_url: \"http://127.0.0.1:{port}\"",
+                                    RegexOptions.Multiline);
+
+                                using var output = new StreamWriter(c);
+                                output.Write(yaml);
+                            })
+                        }
+                    });
+                }
 
                 foreach (var c in configFiles)
                 {
@@ -579,7 +590,10 @@ namespace Datadog.CustomActions
                     }
                 }
 
-                WriteAiUsageNativeMessagingManifest(projectLocation, configFolder, session);
+                if (eudmEnabled)
+                {
+                    WriteAiUsageNativeMessagingManifest(projectLocation, configFolder, session);
+                }
             }
             catch (Exception e)
             {

--- a/tools/windows/DatadogAgentInstaller/CustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/InstallStateCustomActions.cs
@@ -19,6 +19,12 @@ namespace Datadog.CustomActions
         // operator's opt-out without it being re-supplied on the command line.
         protected const string KeepRightsRegistryValueName = "keepRights";
 
+        // Registry value name under HKLM\Constants.DatadogAgentRegistryKey that mirrors the
+        // DD_INFRASTRUCTURE_MODE MSI property. Persisting it lets upgrades/repairs (which inherit
+        // only on-disk state, not command-line properties) keep the operator's EUDM choice, which
+        // gates whether the AI-usage native host artifacts are installed.
+        protected const string InfrastructureModeRegistryValueName = "infrastructureMode";
+
         protected readonly ISession _session;
         protected readonly IRegistryServices _registryServices;
         protected readonly IServiceController _serviceController;
@@ -149,7 +155,7 @@ namespace Datadog.CustomActions
 
         protected void RemoveAgentUserInRegistry(IRegistryKey subkey)
         {
-            foreach (var value in new[] { "installedDomain", "installedUser", KeepRightsRegistryValueName })
+            foreach (var value in new[] { "installedDomain", "installedUser", KeepRightsRegistryValueName, InfrastructureModeRegistryValueName })
             {
                 try
                 {
@@ -182,6 +188,33 @@ namespace Datadog.CustomActions
                 try
                 {
                     subkey.DeleteValue(KeepRightsRegistryValueName);
+                }
+                catch (Exception)
+                {
+                    // Value was not previously set; nothing to do.
+                }
+            }
+        }
+
+        /// <summary>
+        /// Persist DD_INFRASTRUCTURE_MODE so upgrades/repairs that inherit only on-disk state
+        /// (not command-line properties) keep the operator's EUDM choice, which gates the AI-usage
+        /// native host. The value is cleared from the registry when the property is empty so
+        /// reverting to the default takes effect on the next run.
+        /// </summary>
+        protected void StoreInfrastructureModeInRegistry(IRegistryKey subkey)
+        {
+            var mode = _session.Property("DD_INFRASTRUCTURE_MODE");
+            if (!string.IsNullOrEmpty(mode))
+            {
+                _session.Log($"Storing {InfrastructureModeRegistryValueName}={mode}");
+                subkey.SetValue(InfrastructureModeRegistryValueName, mode, RegistryValueKind.String);
+            }
+            else
+            {
+                try
+                {
+                    subkey.DeleteValue(InfrastructureModeRegistryValueName);
                 }
                 catch (Exception)
                 {

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -12,6 +12,14 @@ namespace WixSetup.Datadog_Agent
         [SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Condition NOT_Being_Reinstalled = Condition.NOT(Being_Reinstalled);
 
+        // End-User Device Monitoring (EUDM) gate. Matches infrastructure_mode == "end_user_device".
+        // DD_INFRASTRUCTURE_MODE is public + Secure and re-hydrated from the registry by
+        // ReadInstallState, so this evaluates consistently across install/upgrade/repair.
+        private static readonly Condition EudmEnabled = Condition.Create("DD_INFRASTRUCTURE_MODE=\"end_user_device\"");
+
+        [SuppressMessage("ReSharper", "InconsistentNaming")]
+        private static readonly Condition NOT_EudmEnabled = Condition.NOT(EudmEnabled);
+
         public ManagedAction RunAsAdmin { get; }
 
         public ManagedAction ReadConfig { get; }
@@ -259,7 +267,8 @@ namespace WixSetup.Datadog_Agent
                     "PYVER=[PYVER], " +
                     "HOSTNAME_FQDN_ENABLED=[HOSTNAME_FQDN_ENABLED], " +
                     "NPM=[NPM], " +
-                    "EC2_USE_WINDOWS_PREFIX_DETECTION=[EC2_USE_WINDOWS_PREFIX_DETECTION]")
+                    "EC2_USE_WINDOWS_PREFIX_DETECTION=[EC2_USE_WINDOWS_PREFIX_DETECTION], " +
+                    "DD_INFRASTRUCTURE_MODE=[DD_INFRASTRUCTURE_MODE]")
                 .HideTarget(true);
 
             // Cleanup leftover files on rollback. DecompressPythonDistributions must be sequenced
@@ -377,7 +386,8 @@ namespace WixSetup.Datadog_Agent
                     Return.ignore,
                     When.After,
                     new Step(WriteConfig.Id),
-                    Conditions.FirstInstall | Conditions.Upgrading | Conditions.Maintenance
+                    // Only register the desktop-monitor task when EUDM is enabled.
+                    (Conditions.FirstInstall | Conditions.Upgrading | Conditions.Maintenance) & EudmEnabled
                 )
             {
                 Execute = Execute.deferred,
@@ -408,7 +418,10 @@ namespace WixSetup.Datadog_Agent
                     Return.ignore,
                     When.Before,
                     new Step(CleanupOnUninstall.Id),
-                    Conditions.RemovingForUpgrade | Conditions.Uninstalling
+                    // Keep removal EUDM-independent so the task is always cleaned up on uninstall/
+                    // upgrade-removal. The extra (Maintenance & NOT_EudmEnabled) term deletes a stale
+                    // task on a same-version change that turns EUDM off. Removal is idempotent.
+                    Conditions.RemovingForUpgrade | Conditions.Uninstalling | (Conditions.Maintenance & NOT_EudmEnabled)
                 )
             {
                 Execute = Execute.deferred,
@@ -762,7 +775,8 @@ namespace WixSetup.Datadog_Agent
             }
                 .SetProperties("DDAGENTUSER_PROCESSED_DOMAIN=[DDAGENTUSER_PROCESSED_DOMAIN], " +
                                "DDAGENTUSER_PROCESSED_NAME=[DDAGENTUSER_PROCESSED_NAME], " +
-                               "DDAGENTUSER_KEEP_RIGHTS=[DDAGENTUSER_KEEP_RIGHTS]");
+                               "DDAGENTUSER_KEEP_RIGHTS=[DDAGENTUSER_KEEP_RIGHTS], " +
+                               "DD_INFRASTRUCTURE_MODE=[DD_INFRASTRUCTURE_MODE]");
 
             DeleteInstallState = new CustomAction<CustomActions>(
                     new Id(nameof(DeleteInstallState)),

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentFeatures.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentFeatures.cs
@@ -7,10 +7,13 @@ namespace WixSetup.Datadog_Agent
     {
         public const string MainApplicationName = "Datadog Agent";
         public const string NpmFeatureName = "Network Performance Monitoring";
+        public const string AiUsageNativeHostFeatureName = "AI Usage Native Host";
 
         public Feature MainApplication { get; }
 
         public Feature Npm { get; }
+
+        public Feature AiUsageNativeHost { get; }
 
         public AgentFeatures()
         {
@@ -36,6 +39,32 @@ namespace WixSetup.Datadog_Agent
                 }
             };
 
+            // AI-usage Chrome native messaging host artifacts (binary, HKLM NativeMessagingHosts
+            // registrations, and the yaml.example) install ONLY when End-User Device Monitoring
+            // (EUDM) is enabled. The feature is absent by default (Level 100 > INSTALLLEVEL 1); the
+            // FeatureCondition lowers the level to 1 (installed) when DD_INFRASTRUCTURE_MODE is
+            // "end_user_device". DD_INFRASTRUCTURE_MODE is re-hydrated from the registry by the
+            // ReadInstallState CA before CostFinalize, so this decision is stable across
+            // upgrades/repairs that don't re-supply the property on the command line.
+            AiUsageNativeHost = new Feature(
+                AiUsageNativeHostFeatureName,
+                description: string.Empty,
+                configurableDir: "PROJECTLOCATION")
+            {
+                Id = new Id("AiUsageNativeHost"),
+                // WiX 5 migration: Absent was renamed to AllowAbsent, values changed to yes/no
+                Attributes = new Dictionary<string, string>
+                {
+                    {"AllowAdvertise", "no"},
+                    {"AllowAbsent", "yes"},
+                    {"Display", "hidden"},
+                    {"InstallDefault", "local"},
+                    {"TypicalDefault", "install"},
+                    {"Level", "100"}
+                },
+                Condition = new FeatureCondition("DD_INFRASTRUCTURE_MODE=\"end_user_device\"", level: 1)
+            };
+
             MainApplication = new Feature(
                 MainApplicationName,
                 description: string.Empty,
@@ -53,7 +82,8 @@ namespace WixSetup.Datadog_Agent
                 },
                 Children = new List<Feature>
                 {
-                    Npm
+                    Npm,
+                    AiUsageNativeHost
                 }
             };
         }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -204,7 +204,7 @@ namespace WixSetup.Datadog_Agent
                     Win64 = true
                 },
                 new RegKey(
-                    _agentFeatures.MainApplication,
+                    _agentFeatures.AiUsageNativeHost,
                     RegistryHive.LocalMachine, @"Software\Google\Chrome\NativeMessagingHosts\com.datadoghq.ai_usage_agent.native_host",
                     new RegValue("", @"[AGENT]dist\com.datadoghq.ai_usage_agent.native_host.json") { Win64 = true, AttributesDefinition = "KeyPath=yes" }
                 )
@@ -212,7 +212,7 @@ namespace WixSetup.Datadog_Agent
                     Win64 = true
                 },
                 new RegKey(
-                    _agentFeatures.MainApplication,
+                    _agentFeatures.AiUsageNativeHost,
                     RegistryHive.LocalMachine, @"Software\WOW6432Node\Google\Chrome\NativeMessagingHosts\com.datadoghq.ai_usage_agent.native_host",
                     new RegValue("", @"[AGENT]dist\com.datadoghq.ai_usage_agent.native_host.json") { Win64 = true, AttributesDefinition = "KeyPath=yes" }
                 )
@@ -727,7 +727,7 @@ namespace WixSetup.Datadog_Agent
 
             // AI usage Chrome native messaging host (Rust). Plain non-service file in bin\agent.
             // Explicit Id only on the .exe so future custom actions can reference it via [#ai_usage_agent_native_host].
-            agentBinDir.AddFile(new WixSharp.File(_agentBinaries.AiUsageAgentNativeHostId, _agentBinaries.AiUsageAgentNativeHost));
+            agentBinDir.AddFile(new WixSharp.File(_agentBinaries.AiUsageAgentNativeHostId, _agentFeatures.AiUsageNativeHost, _agentBinaries.AiUsageAgentNativeHost));
 
             var targetBinFolder = new Dir(new Id("BIN"), "bin",
                 new WixSharp.File(_agentBinaries.Agent, agentService),
@@ -782,7 +782,10 @@ namespace WixSetup.Datadog_Agent
         private Dir CreateAppDataFolder()
         {
             var appData = new Dir(new Id("APPLICATIONDATADIRECTORY"), "Datadog",
-                new DirFiles($@"{EtcSource}\*.yaml.example"),
+                // ai_usage_native_host.yaml.example is excluded here and re-added below under the
+                // EUDM-gated AiUsageNativeHost feature so it only ships when EUDM is enabled.
+                new DirFiles($@"{EtcSource}\*.yaml.example",
+                    f => !f.EndsWith("ai_usage_native_host.yaml.example", StringComparison.OrdinalIgnoreCase)),
                 new Dir("checks.d"),
                 new Dir("protected"),
                 new Dir("run"),
@@ -799,6 +802,10 @@ namespace WixSetup.Datadog_Agent
             appData.AddDir(new Dir("private-action-runner",
                        new Files($@"{EtcSource}\private-action-runner\*.*")
             ));
+
+            // Ships only when EUDM is enabled (gated via the AiUsageNativeHost feature).
+            appData.AddFile(new WixSharp.File(_agentFeatures.AiUsageNativeHost,
+                $@"{EtcSource}\ai_usage_native_host.yaml.example"));
 
             return new Dir(new Id("%CommonAppData%"), appData)
             {


### PR DESCRIPTION
### What does this PR do?

On **Windows**, gates the AI Usage Chrome Native Messaging host at MSI install time on **EUDM mode** (`DD_INFRASTRUCTURE_MODE=end_user_device`). When EUDM is not enabled, the MSI installs **none** of the following:

- the `ai-usage-agent-native-host.exe` binary,
- the two Chrome `NativeMessagingHosts` HKLM registry entries,
- the `ai_usage_native_host.yaml` config (and `.yaml.example`),
- the Chrome host manifest JSON,
- the `Datadog AI Usage Agent` desktop-monitor scheduled task.

How it's done:
- **Declarative artifacts** (binary, both regkeys, `yaml.example`) move into a new hidden `AiUsageNativeHost` WixSharp feature gated by a `FeatureCondition` (absent by default at `Level=100`; the condition lowers it to `Level=1` when EUDM is enabled — same idiom as the hidden NPM feature).
- **CA-generated artifacts** (`ai_usage_native_host.yaml` + Chrome manifest in `ConfigCustomActions.WriteConfig`) and the **scheduled-task custom action** (`ConfigureAiUsageMonitorDesktopMonitor`) are gated on the same property.
- **Upgrade/repair stability**: `DD_INFRASTRUCTURE_MODE` is persisted to the registry (`WriteInstallState`) and re-hydrated (`ReadInstallState`) before `CostFinalize`, mirroring the existing `keepRights` idiom — so an upgrade/repair that doesn't re-supply the property keeps the prior choice, while an explicit change (e.g. `=full`) still takes effect and removes the host. The task removal CA is kept EUDM-independent (plus a `Maintenance & NOT_EudmEnabled` term) so a flip-off cleans up the stale task.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2867

The AI-usage native host + desktop monitor currently install unconditionally on every Windows Agent install. They should only be present for customers with EUDM enabled. `DD_INFRASTRUCTURE_MODE=end_user_device` is the established canonical EUDM signal (already a `Secure=yes` MSI property, used by host tags / system-probe / softinv), so we reuse it rather than introducing a new flag.

### Describe how you validated your changes

- Added a negative unit test (`WriteConfig_Should_Not_Generate_AiUsage_Artifacts_When_Not_Eudm`, cases `""` and `"full"`) asserting `WriteConfig` still writes `datadog.yaml` but produces no `ai_usage_native_host.yaml` and no Chrome manifest; updated the 4 existing AI-usage tests to set `DD_INFRASTRUCTURE_MODE=end_user_device`.
- Verified every WixSharp API against upstream (`FeatureCondition(string, int)`, `Feature.Condition`, `DirFiles(string, Predicate<string>)`, `File(Id, Feature, string)`).
- **Note:** the installer projects are `.NET Framework`/`net472` + WixSharp and build only on Windows/CI — please rely on CI (`dda inv msi.test`, `dda inv msi.build`) for compilation + unit tests.

Manual QA matrix (Windows):
1. Install with `DD_INFRASTRUCTURE_MODE=end_user_device` → binary, both HKLM keys, yaml (+`.example`), `dist\...json` manifest, and the scheduled task all present.
2. Install without it → none present.
3. Upgrade the EUDM install without re-passing the property → everything persists (validates registry re-hydration).
4. Upgrade/repair passing `DD_INFRASTRUCTURE_MODE=full` → everything removed.

### Additional Notes

Windows-only; macOS DMG gating is out of scope. On an explicit flip to non-EUDM, the CA-written `ai_usage_native_host.yaml` (not MSI-tracked) is left behind as an inert file — the functional pieces (binary, registry, task) are removed.
