### PR TITLE
fix(ci): Add config discovery paths to discovery e2e tests trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1090,6 +1090,8 @@ workflow:
   - changes:
       paths:
         - cmd/agent/dist/conf.d/discovery.d/*
+        - comp/core/autodiscovery/discoverer/**/*
+        - comp/core/autodiscovery/impl/configmgr*
         - comp/core/autodiscovery/providers/process_log.go
         - test/new-e2e/tests/discovery/**/*
         - pkg/collector/corechecks/discovery/**/*


### PR DESCRIPTION
### What does this PR do?

Adds `comp/core/autodiscovery/discoverer/**/*` and `comp/core/autodiscovery/impl/configmgr*` to the GitLab CI `changes` paths that trigger the discovery E2E test job.

### Motivation

The config discovery E2E test added in #52909 exercises code in these paths, but changes to them weren't triggering the discovery E2E test job in CI.

### Describe how you validated your changes

N/A — CI configuration change only.