### PR TITLE
test/e2e-framework: pin the flannel CNI manifest

### DIFF
--- a/test/e2e-framework/components/kubernetes/kubeadm.go
+++ b/test/e2e-framework/components/kubernetes/kubeadm.go
@@ -217,7 +217,7 @@ kubeadm init \
 		cni, err := runner.Command(namer.ResourceName("kubeadm-cni"), &command.Args{
 			Sudo: true,
 			Create: rootScript(`export KUBECONFIG=/etc/kubernetes/admin.conf
-kubectl apply -f https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml`),
+kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/v0.28.6/Documentation/kube-flannel.yml`),
 		}, utils.MergeOptions(opts, utils.PulumiDependsOn(initCluster))...)
 		if err != nil {
 			return err


### PR DESCRIPTION
The kubeadm provisioner applied the flannel CNI from the
releases/latest/download/kube-flannel.yml asset. Flannel no longer
attaches that manifest to its releases. The current latest release
carries no assets at all, so the URL returns 404. The CNI step then
fails, the cluster never finishes provisioning, and every kubeadm-based
e2e suite fails during setup.

Point kubectl at the manifest checked into the flannel repository at a
pinned tag. This fixes the CNI version for reproducible runs and no
longer depends on release assets.