### PR TITLE
Avoid setting LD_LIBRARY_PATH for builds

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -309,8 +309,6 @@ def get_build_flags(
             print(
                 f"--- Setting rtloader paths to lib:{','.join(rtloader_lib)} | header:{rtloader_headers} | common headers:{rtloader_common_headers}"
             )
-        env['DYLD_LIBRARY_PATH'] = os.environ.get('DYLD_LIBRARY_PATH', '') + f":{':'.join(rtloader_lib)}"  # OSX
-        env['LD_LIBRARY_PATH'] = os.environ.get('LD_LIBRARY_PATH', '') + f":{':'.join(rtloader_lib)}"  # linux
         if sys.platform == "aix":
             env['LIBPATH'] = os.environ.get('LIBPATH', '') + f":{':'.join(rtloader_lib)}"  # AIX
         env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + f" -L{' -L '.join(rtloader_lib)}"


### PR DESCRIPTION
### What does this PR do?

It removes the setting of `LD_LIBRARY_PATH` for builds and tasks that request build_tags.

### Motivation

When running `agent.build` with `--enable-bazel` (the default), we get lots of warnings that look like this:

```
as: /repos/datadog-agent/dev/embedded/lib/libz.so.1: no version information available (required by /lib/aarch64-linux-gnu/libbfd-2.42-system.so)
```

The reason for this is that `libz` is present under `LD_LIBRARY_PATH`, causing `as` to find it and loading it instead of the one in the system.

### Describe how you validated your changes

CI and local testing.

### Additional Notes

These variables only affect the runtime and not the build, and should therefore not be necessary. `CGO_LDFLAGS` should be sufficient.

I left the equivalent AIX branch alone because I can't test it as easily and is anyway not causing any problems.
