### PR TITLE
[WP] Change log message from 'warn' to 'info'

### DIFF
--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -90,7 +90,7 @@ func (pn *ProcessNode) snapshotAllFiles(p *process.Process, stats *Stats, newEve
 		}
 	}
 	if isSampling {
-		seclog.Warnf("sampled open files while snapshotting (pid: %v): kept %d of %d files", p.Pid, len(files), len(fileFDs))
+		seclog.Infof("sampled open files while snapshotting (pid: %v): kept %d of %d files", p.Pid, len(files), len(fileFDs))
 	}
 
 	// list the mmaped files of the process


### PR DESCRIPTION
### What does this PR do?

Change log message from 'warn' to 'info' 

### Motivation

Snapshotted workflows that have more than 500 cause a non-error message
to be displayed as "warn", causing noise.

### Describe how you validated your changes

### Additional Notes
