### PR TITLE
[e2e-framework] Decouple agent installation from Pulumi (Host, incremental)

### DIFF
--- a/test/e2e-framework/components/datadog/agent/host_linuxos.go
+++ b/test/e2e-framework/components/datadog/agent/host_linuxos.go
@@ -30,21 +30,38 @@ func (am *agentLinuxManager) directInstallCommand(_ config.Env, packagePath stri
 	return am.targetOS.PackageManager().Ensure("./"+packagePath, nil, "", os.AllowUnsignedPackages(true), os.WithPulumiResourceOptions(opts...))
 }
 
-func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersion, apiKey pulumi.StringInput, _ []string) (pulumi.StringOutput, error) {
-	var commandLine string
+func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersion, apiKey pulumi.StringInput, additionalInstallParameters []string) (pulumi.StringOutput, error) {
+	// linuxInstallCommandTemplate returns a command with a single `%s` placeholder for the
+	// API key, so it can be filled either lazily via pulumi.Sprintf (Pulumi path, apiKey is an
+	// output) or eagerly via fmt.Sprintf (SSH path, apiKey is a plain string).
+	template := linuxInstallCommandTemplate(am.targetOS.Descriptor().Architecture, version, additionalInstallParameters)
+	return pulumi.Sprintf(template, apiKey), nil
+}
+
+// LinuxInstallCommand returns the shell command that installs the Agent on a Linux host via the
+// install script, with the API key inlined. It is Pulumi-free and shared by the Pulumi manager
+// (see getInstallCommand) and the SSH-based installer (client.HostAgentInstaller), so the two
+// cannot drift.
+func LinuxInstallCommand(arch os.Architecture, version agentparams.PackageVersion, apiKey string, additionalInstallParameters []string) string {
+	return fmt.Sprintf(linuxInstallCommandTemplate(arch, version, additionalInstallParameters), apiKey)
+}
+
+// linuxInstallCommandTemplate builds the install command with a single `%s` placeholder for the
+// API key. The command carries no other `%` verbs, so a single substitution fills it in.
+func linuxInstallCommandTemplate(arch os.Architecture, version agentparams.PackageVersion, _ []string) string {
 	testEnvVars := []string{}
 
 	if version.PipelineID != "" {
 		testEnvVars = append(testEnvVars, fmt.Sprintf("TESTING_APT_URL=apttesting.datad0g.com/datadog-agent/pipeline-%v-a%v", version.PipelineID, version.Major))
 		// apt testing repo
 		// TESTING_APT_REPO_VERSION="pipeline-xxxxx-a7 7"
-		testEnvVars = append(testEnvVars, fmt.Sprintf(`TESTING_APT_REPO_VERSION="stable-%[1]s %[2]v"`, am.targetOS.Descriptor().Architecture, version.Major))
+		testEnvVars = append(testEnvVars, fmt.Sprintf(`TESTING_APT_REPO_VERSION="stable-%[1]s %[2]v"`, arch, version.Major))
 		testEnvVars = append(testEnvVars, "TESTING_YUM_URL=yumtesting.datad0g.com")
 		// yum testing repo
 		// TESTING_YUM_VERSION_PATH="testing/pipeline-xxxxx-a7/7"
 		testEnvVars = append(testEnvVars, fmt.Sprintf("TESTING_YUM_VERSION_PATH=testing/pipeline-%[1]v-a%[2]v/%[2]v", version.PipelineID, version.Major))
 		// target testing keys
-		testEnvVars = append(testEnvVars, fmt.Sprintf("TESTING_KEYS_URL=apttesting.datad0g.com/test-keys"))
+		testEnvVars = append(testEnvVars, "TESTING_KEYS_URL=apttesting.datad0g.com/test-keys")
 	} else {
 		testEnvVars = append(testEnvVars, fmt.Sprintf("DD_AGENT_MAJOR_VERSION=%v", version.Major))
 
@@ -62,13 +79,12 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 		testEnvVars = append(testEnvVars, fmt.Sprintf("DD_AGENT_FLAVOR=%s", version.Flavor))
 	}
 
-	commandLine = strings.Join(testEnvVars, " ")
+	commandLine := strings.Join(testEnvVars, " ")
 
-	commandLine = fmt.Sprintf(
+	return fmt.Sprintf(
 		`for i in 1 2 3 4 5; do curl -fsSL https://s3.amazonaws.com/dd-agent/scripts/%v -o install-script.sh && break || sleep $((2**$i)); done &&  for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && exit 0 || sleep $((2**$i)); done; exit 1`,
 		fmt.Sprintf("install_script_agent%s.sh", version.Major),
 		commandLine)
-	return pulumi.Sprintf(commandLine, apiKey), nil
 }
 
 func (am *agentLinuxManager) getAgentConfigFolder() string {

--- a/test/e2e-framework/components/datadog/agent/host_linuxos_test.go
+++ b/test/e2e-framework/components/datadog/agent/host_linuxos_test.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+)
+
+func TestLinuxInstallCommand(t *testing.T) {
+	t.Run("version-based install inlines the api key", func(t *testing.T) {
+		version := agentparams.PackageVersion{Major: "7", Channel: agentparams.StableChannel}
+		got := LinuxInstallCommand(os.AMD64Arch, version, "abc123", nil)
+
+		want := `for i in 1 2 3 4 5; do curl -fsSL https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh -o install-script.sh && break || sleep $((2**$i)); done &&  for i in 1 2 3; do DD_API_KEY=abc123 DD_AGENT_MAJOR_VERSION=7 DD_INSTALL_ONLY=true bash install-script.sh  && exit 0 || sleep $((2**$i)); done; exit 1`
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("pipeline-based install uses the testing repos", func(t *testing.T) {
+		version := agentparams.PackageVersion{Major: "7", PipelineID: "12345", Flavor: "datadog-agent"}
+		got := LinuxInstallCommand(os.AMD64Arch, version, "abc123", nil)
+
+		assert.Contains(t, got, "DD_API_KEY=abc123 ")
+		assert.Contains(t, got, "TESTING_APT_URL=apttesting.datad0g.com/datadog-agent/pipeline-12345-a7")
+		assert.Contains(t, got, `TESTING_APT_REPO_VERSION="stable-x86_64 7"`)
+		assert.Contains(t, got, "TESTING_YUM_VERSION_PATH=testing/pipeline-12345-a7/7")
+		assert.Contains(t, got, "DD_AGENT_FLAVOR=datadog-agent")
+		assert.Contains(t, got, "install_script_agent7.sh")
+	})
+
+	t.Run("template carries exactly one format verb (the api key)", func(t *testing.T) {
+		// The command must contain no stray `%` verbs, otherwise inlining the key would corrupt it.
+		version := agentparams.PackageVersion{Major: "7", PipelineID: "12345", Flavor: "datadog-agent"}
+		template := linuxInstallCommandTemplate(os.AMD64Arch, version, nil)
+		require.Equal(t, 1, strings.Count(template, "%"), "template must contain exactly one %% verb")
+		assert.Equal(t, fmt.Sprintf(template, "abc123"), LinuxInstallCommand(os.AMD64Arch, version, "abc123", nil))
+	})
+}

--- a/test/e2e-framework/components/datadog/agentparams/params.go
+++ b/test/e2e-framework/components/datadog/agentparams/params.go
@@ -94,6 +94,22 @@ func NewParams(env config.Env, options ...Option) (*Params, error) {
 	return common.ApplyOption(p, options)
 }
 
+// ResolveParams builds Params from options WITHOUT a Pulumi config.Env, for the non-Pulumi
+// (SSH/Helm) install path. It applies the same defaults NewParams would in the absence of
+// environment overrides (latest nightly Agent 7, base flavor) and then the caller-supplied
+// options. Environment-derived defaults (pipeline id, FIPS, version, major version) are NOT
+// read here — the caller (which owns the runner profile) passes them as leading options so
+// this package stays free of any testing/runner dependency. Later options override earlier
+// ones, exactly like NewParams.
+func ResolveParams(options ...Option) (*Params, error) {
+	p := &Params{
+		Integrations: make(map[string]*FileDefinition),
+		Files:        make(map[string]*FileDefinition),
+	}
+	options = append([]Option{WithLatestNightly(), WithFlavor(DefaultFlavor)}, options...)
+	return common.ApplyOption(p, options)
+}
+
 // WithLatest uses the latest Agent 7 version in the stable channel.
 func WithLatest() func(*Params) error {
 	return func(p *Params) error {

--- a/test/e2e-framework/components/datadog/agentparams/params.go
+++ b/test/e2e-framework/components/datadog/agentparams/params.go
@@ -284,9 +284,11 @@ func WithPulumiResourceOptions(resources ...pulumi.ResourceOption) func(*Params)
 	}
 }
 
-func withIntakeHostname(scheme pulumi.StringInput, hostname pulumi.StringInput, port pulumi.IntInput) func(*Params) error {
-	return func(p *Params) error {
-		extraConfig := pulumi.Sprintf(`dd_url: %[3]s://%[1]s:%[2]d
+// intakeConfigTemplate is the datadog.yaml fragment that points the Agent's various forwarders at
+// an intake endpoint. Verbs: %[1]s hostname, %[2]d port, %[3]s scheme. It is shared by the Pulumi
+// path (withIntakeHostname, via pulumi.Sprintf) and the Pulumi-free path (IntakeConfig, via
+// fmt.Sprintf) so the two cannot drift.
+const intakeConfigTemplate = `dd_url: %[3]s://%[1]s:%[2]d
 logs_config.logs_dd_url: %[1]s:%[2]d
 logs_config.logs_no_ssl: true
 logs_config.force_use_http: true
@@ -327,8 +329,30 @@ event_management.forwarder.logs_no_ssl: true
 agent_telemetry.logs_dd_url: %[1]s:%[2]d
 agent_telemetry.logs_no_ssl: true
 agent_telemetry.use_compression: false
-`, hostname, port, scheme)
+`
+
+// IntakeConfig returns the datadog.yaml fragment (as a plain string) that points the Agent at the
+// given intake endpoint. It is the Pulumi-free counterpart of withIntakeHostname, used by the
+// SSH/Helm install path to wire an already-provisioned fakeintake by its resolved host/port.
+func IntakeConfig(scheme, hostname string, port int) string {
+	return fmt.Sprintf(intakeConfigTemplate, hostname, port, scheme)
+}
+
+func withIntakeHostname(scheme pulumi.StringInput, hostname pulumi.StringInput, port pulumi.IntInput) func(*Params) error {
+	return func(p *Params) error {
+		extraConfig := pulumi.Sprintf(intakeConfigTemplate, hostname, port, scheme)
 		p.ExtraAgentConfig = append(p.ExtraAgentConfig, extraConfig)
+		return nil
+	}
+}
+
+// WithExtraConfig appends a plain datadog.yaml fragment to the Agent configuration. Unlike the
+// pulumi.Sprintf-based options (WithFakeintake, WithTags, ...), the value is a constant string, so
+// it is resolvable by the Pulumi-free installer. Use it to inject already-resolved config (e.g. a
+// fakeintake endpoint via IntakeConfig) on the SSH/Helm install path.
+func WithExtraConfig(config string) func(*Params) error {
+	return func(p *Params) error {
+		p.ExtraAgentConfig = append(p.ExtraAgentConfig, pulumi.String(config))
 		return nil
 	}
 }

--- a/test/e2e-framework/components/datadog/agentparams/params_test.go
+++ b/test/e2e-framework/components/datadog/agentparams/params_test.go
@@ -56,6 +56,17 @@ func TestParams(t *testing.T) {
 		assert.Equal(t, FIPSFlavor, p.Version.Flavor)
 		assert.Equal(t, "log_level: debug", p.AgentConfig)
 	})
+	t.Run("IntakeConfig points the forwarders at the given endpoint", func(t *testing.T) {
+		cfg := IntakeConfig("http", "10.0.0.5", 8080)
+		assert.Contains(t, cfg, "dd_url: http://10.0.0.5:8080")
+		assert.Contains(t, cfg, "logs_config.logs_dd_url: 10.0.0.5:8080")
+		assert.Contains(t, cfg, "apm_config.apm_dd_url: http://10.0.0.5:8080")
+	})
+	t.Run("WithExtraConfig appends a constant config fragment", func(t *testing.T) {
+		p, err := ResolveParams(WithExtraConfig("logs_enabled: true"))
+		assert.NoError(t, err)
+		assert.Len(t, p.ExtraAgentConfig, 1)
+	})
 	t.Run("WithIntegration should correctly add conf.d/integration/conf.yaml to the path", func(t *testing.T) {
 		p := &Params{
 			Integrations: make(map[string]*FileDefinition),

--- a/test/e2e-framework/components/datadog/agentparams/params_test.go
+++ b/test/e2e-framework/components/datadog/agentparams/params_test.go
@@ -40,6 +40,22 @@ func TestParams(t *testing.T) {
 			PipelineID: "16362517",
 		})
 	})
+	t.Run("ResolveParams defaults to the latest nightly Agent 7 with the base flavor", func(t *testing.T) {
+		p, err := ResolveParams()
+		assert.NoError(t, err)
+		assert.Equal(t, "7", p.Version.Major)
+		assert.Equal(t, NightlyChannel, p.Version.Channel)
+		assert.Equal(t, DefaultFlavor, p.Version.Flavor)
+		assert.NotNil(t, p.Integrations)
+		assert.NotNil(t, p.Files)
+	})
+	t.Run("ResolveParams lets caller options override the defaults", func(t *testing.T) {
+		p, err := ResolveParams(WithPipeline("16362517"), WithFlavor(FIPSFlavor), WithAgentConfig("log_level: debug"))
+		assert.NoError(t, err)
+		assert.Equal(t, "16362517", p.Version.PipelineID)
+		assert.Equal(t, FIPSFlavor, p.Version.Flavor)
+		assert.Equal(t, "log_level: debug", p.AgentConfig)
+	})
 	t.Run("WithIntegration should correctly add conf.d/integration/conf.yaml to the path", func(t *testing.T) {
 		p := &Params{
 			Integrations: make(map[string]*FileDefinition),

--- a/test/e2e-framework/testing/e2e/suite.go
+++ b/test/e2e-framework/testing/e2e/suite.go
@@ -503,6 +503,17 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners provisioners.Provision
 		}
 	}
 
+	// Run any provisioner post-provision hooks (e.g. installing the Agent over SSH declared via a
+	// provisioner option like awshost.WithSSHInstalledAgent). These run once the environment is built
+	// and initialized, on initial provisioning and on every UpdateEnv.
+	for id, provisioner := range targetProvisioners {
+		if pp, ok := provisioner.(provisioners.PostProvisioner[Env]); ok {
+			if err := pp.PostProvision(bs, newEnv); err != nil {
+				return fmt.Errorf("post-provision step for provisioner %s failed: %w", id, err)
+			}
+		}
+	}
+
 	// If the suite opted into a Pulumi-free agent install (see WithInstalledAgent), run it now that
 	// the environment is provisioned and initialized. This also runs on every UpdateEnv, so it
 	// doubles as the reconfiguration path.

--- a/test/e2e-framework/testing/e2e/suite.go
+++ b/test/e2e-framework/testing/e2e/suite.go
@@ -503,6 +503,15 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners provisioners.Provision
 		}
 	}
 
+	// If the suite opted into a Pulumi-free agent install (see WithInstalledAgent), run it now that
+	// the environment is provisioned and initialized. This also runs on every UpdateEnv, so it
+	// doubles as the reconfiguration path.
+	if bs.params.agentInstall != nil {
+		if err := bs.params.agentInstall(bs, any(newEnv)); err != nil {
+			return fmt.Errorf("failed to install agent: %w", err)
+		}
+	}
+
 	// On success we update the current environment
 	// We need top copy provisioners to protect against external modifications
 	bs.currentProvisioners = provisioners.CopyProvisioners(targetProvisioners)

--- a/test/e2e-framework/testing/e2e/suite_params.go
+++ b/test/e2e-framework/testing/e2e/suite_params.go
@@ -6,10 +6,14 @@
 package e2e
 
 import (
+	"fmt"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/common"
 )
 
 // Params implements [BaseSuite] options
@@ -29,6 +33,11 @@ type suiteParams struct {
 	coverageRequired map[string]bool
 
 	provisioners provisioners.ProvisionerMap
+
+	// agentInstall, when set, installs the Agent as a separate Pulumi-free step after the
+	// environment is provisioned and initialized (and after every UpdateEnv). It is populated by
+	// [WithInstalledAgent].
+	agentInstall func(ctx common.Context, env any) error
 }
 
 // SuiteOption is an optional function parameter type for e2e options
@@ -81,6 +90,27 @@ func WithUntypedPulumiProvisioner(runFunc pulumi.RunFunc, configMap runner.Confi
 // WithPulumiProvisioner adds a typed Pulumi provisioner to the suite
 func WithPulumiProvisioner[Env any](runFunc provisioners.PulumiEnvRunFunc[Env], configMap runner.ConfigMap) SuiteOption {
 	return WithProvisioner(provisioners.NewTypedPulumiProvisioner("", runFunc, configMap))
+}
+
+// WithInstalledAgent installs the Datadog Agent as a separate, Pulumi-free step after the
+// environment is provisioned (and after every UpdateEnv), instead of during Pulumi provisioning.
+// Provision the infrastructure without an Agent (e.g. ec2.WithoutAgent()) and declare this option;
+// the suite then calls the environment's InstallAgent with the given options — no per-test wiring.
+//
+// O is the environment's agent-params option type (agentparams.Option for Host,
+// kubernetesagentparams.Option for Kubernetes, ...); it is inferred from opts, or given explicitly
+// (e.g. WithInstalledAgent[agentparams.Option]()) when no options are passed. The environment must
+// implement environments.AgentInstaller[O].
+func WithInstalledAgent[O any](opts ...O) SuiteOption {
+	return func(options *suiteParams) {
+		options.agentInstall = func(ctx common.Context, env any) error {
+			installer, ok := env.(environments.AgentInstaller[O])
+			if !ok {
+				return fmt.Errorf("environment %T does not implement AgentInstaller[%T]", env, *new(O))
+			}
+			return installer.InstallAgent(ctx, opts...)
+		}
+	}
 }
 
 // WithSkipCoverage skips the coverage of the environment.

--- a/test/e2e-framework/testing/environments/environments.go
+++ b/test/e2e-framework/testing/environments/environments.go
@@ -19,6 +19,19 @@ const (
 	importKey = "import"
 )
 
+// AgentInstaller is implemented by every environment that can install the Datadog Agent as a
+// separate, Pulumi-free step (over the environment's own client: SSH for hosts, the Kubernetes API
+// / Helm for clusters, and so on). Installing the Agent is intrinsic to what makes an environment
+// useful, so each environment defines how to do it.
+//
+// Options is that environment's agent-params option type — agentparams.Option for Host,
+// kubernetesagentparams.Option for Kubernetes, dockeragentparams.Option for DockerHost, etc. — so
+// the contract is generic rather than a single fixed signature. InstallAgent is idempotent:
+// calling it again reconfigures/reinstalls the Agent.
+type AgentInstaller[Options any] interface {
+	InstallAgent(ctx common.Context, opts ...Options) error
+}
+
 func CreateEnv[Env any]() (*Env, []reflect.StructField, []reflect.Value, error) {
 	var env Env
 

--- a/test/e2e-framework/testing/environments/host.go
+++ b/test/e2e-framework/testing/environments/host.go
@@ -13,12 +13,15 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/updater"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/remote"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/outputs"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner/parameters"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/common"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client/agentclient"
@@ -42,6 +45,60 @@ var _ common.Initializable = (*Host)(nil)
 // Init initializes the environment
 func (e *Host) Init(_ common.Context) error {
 	return nil
+}
+
+// Ensure Host satisfies the Pulumi-free agent-install contract.
+var _ AgentInstaller[agentparams.Option] = (*Host)(nil)
+
+// InstallAgent installs and configures the Datadog Agent on the host over SSH, without Pulumi.
+// It resolves the environment defaults the Pulumi config would otherwise provide (pipeline id,
+// FIPS, major version, API key) from the runner profile, wires the environment's fakeintake (if
+// present) as plain config, applies the caller options on top, and delegates the SSH mechanics to
+// the host client's installer. It is idempotent, so it can also be used to reconfigure the Agent.
+func (e *Host) InstallAgent(_ common.Context, opts ...agentparams.Option) error {
+	if e.RemoteHost == nil {
+		return errors.New("RemoteHost component is not initialized")
+	}
+
+	profile := runner.GetProfile()
+	apiKey, err := profile.SecretStore().GetWithDefault(parameters.APIKey, "")
+	if err != nil {
+		return fmt.Errorf("failed to read the API key from the runner profile: %w", err)
+	}
+	majorVersion, err := profile.ParamStore().GetWithDefault(parameters.MajorVersion, "7")
+	if err != nil {
+		return fmt.Errorf("failed to read the major version from the runner profile: %w", err)
+	}
+	pipelineID, err := profile.ParamStore().GetWithDefault(parameters.PipelineID, "")
+	if err != nil {
+		return fmt.Errorf("failed to read the pipeline id from the runner profile: %w", err)
+	}
+	fips, err := profile.ParamStore().GetBoolWithDefault(parameters.FIPS, false)
+	if err != nil {
+		return fmt.Errorf("failed to read the FIPS flag from the runner profile: %w", err)
+	}
+
+	// Environment defaults are applied before the caller options so callers can override them.
+	leading := []agentparams.Option{agentparams.WithMajorVersion(majorVersion)}
+	if pipelineID != "" {
+		leading = append(leading, agentparams.WithPipeline(pipelineID))
+	}
+	if fips {
+		leading = append(leading, agentparams.WithFlavor(agentparams.FIPSFlavor))
+	}
+	// Wire the environment's fakeintake as plain config (the Pulumi WithFakeintake option builds a
+	// computed value the SSH installer cannot resolve).
+	if e.FakeIntake != nil {
+		leading = append(leading, agentparams.WithExtraConfig(
+			agentparams.IntakeConfig(e.FakeIntake.Scheme, e.FakeIntake.Host, int(e.FakeIntake.Port))))
+	}
+
+	params, err := agentparams.ResolveParams(append(leading, opts...)...)
+	if err != nil {
+		return fmt.Errorf("failed to resolve agent params: %w", err)
+	}
+
+	return e.RemoteHost.AgentInstaller().Install(params, apiKey)
 }
 
 // RemoteHostOutput implements outputs.HostOutputs

--- a/test/e2e-framework/testing/provisioners/aws/host/host.go
+++ b/test/e2e-framework/testing/provisioners/aws/host/host.go
@@ -9,11 +9,13 @@ package awshost
 import (
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/common"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/optional"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -25,6 +27,12 @@ type ProvisionerParams struct {
 	awsEnv            *aws.Environment
 	extraConfigParams runner.ConfigMap
 	runOptions        []ec2.Option
+
+	// sshAgentInstall, when set, installs the Agent over SSH (Pulumi-free) after provisioning
+	// instead of during Pulumi. WithSSHInstalledAgent also forces the Pulumi program to provision a
+	// bare host (ec2.WithoutAgent()).
+	sshAgentInstall     bool
+	sshAgentInstallOpts []agentparams.Option
 }
 
 type ProvisionerOption func(*ProvisionerParams) error
@@ -64,6 +72,19 @@ func WithRunOptions(runOptions ...ec2.Option) ProvisionerOption {
 	}
 }
 
+// WithSSHInstalledAgent provisions a bare host (no Agent in Pulumi) and installs the Agent over SSH
+// after provisioning, using the given agentparams options. Because the provisioner is already bound
+// to the Host environment, the option type is implied — no type parameter needed at the call site —
+// and the install runs on every UpdateEnv, so it doubles as the reconfiguration path.
+func WithSSHInstalledAgent(opts ...agentparams.Option) ProvisionerOption {
+	return func(params *ProvisionerParams) error {
+		params.sshAgentInstall = true
+		params.sshAgentInstallOpts = opts
+		params.runOptions = append(params.runOptions, ec2.WithoutAgent())
+		return nil
+	}
+}
+
 // Provisioner creates a VM environment with an EC2 VM, an ECS Fargate FakeIntake and a Host Agent configured to talk to each other.
 // FakeIntake and Agent creation can be deactivated by using [WithoutFakeIntake] and [WithoutAgent] options.
 func Provisioner(opts ...ProvisionerOption) provisioners.TypedProvisioner[environments.Host] {
@@ -92,7 +113,27 @@ func Provisioner(opts ...ProvisionerOption) provisioners.TypedProvisioner[enviro
 		return ec2.Run(ctx, awsEnv, env, runParams)
 	}, params.extraConfigParams)
 
+	if params.sshAgentInstall {
+		return &sshAgentHostProvisioner{
+			TypedProvisioner: provisioner,
+			agentOpts:        params.sshAgentInstallOpts,
+		}
+	}
+
 	return provisioner
+}
+
+// sshAgentHostProvisioner decorates a Host provisioner with a post-provision step that installs the
+// Agent over SSH (see WithSSHInstalledAgent). It embeds the underlying provisioner so it still
+// satisfies provisioners.TypedProvisioner[environments.Host], and additionally implements
+// provisioners.PostProvisioner[environments.Host].
+type sshAgentHostProvisioner struct {
+	provisioners.TypedProvisioner[environments.Host]
+	agentOpts []agentparams.Option
+}
+
+func (p *sshAgentHostProvisioner) PostProvision(ctx common.Context, env *environments.Host) error {
+	return env.InstallAgent(ctx, p.agentOpts...)
 }
 
 func ProvisionerNoFakeIntake(opts ...ProvisionerOption) provisioners.TypedProvisioner[environments.Host] {

--- a/test/e2e-framework/testing/provisioners/provisioners.go
+++ b/test/e2e-framework/testing/provisioners/provisioners.go
@@ -10,11 +10,21 @@ import (
 	"context"
 	"io"
 	"maps"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/common"
 )
 
 // Diagnosable defines the interface for a diagnosable provisioner.
 type Diagnosable interface {
 	Diagnose(ctx context.Context, stackName string) (string, error)
+}
+
+// PostProvisioner is an optional interface a typed provisioner can implement to run an extra step
+// after the environment has been built and initialized — for example installing the Agent over SSH
+// (Pulumi-free) once the environment's clients are available. It runs on initial provisioning and on
+// every UpdateEnv.
+type PostProvisioner[Env any] interface {
+	PostProvision(ctx common.Context, env *Env) error
 }
 
 // Provisioner defines the interface for a provisioner.

--- a/test/e2e-framework/testing/utils/e2e/client/host.go
+++ b/test/e2e-framework/testing/utils/e2e/client/host.go
@@ -70,6 +70,7 @@ type Host struct {
 
 	convertPathSeparator convertPathSeparatorFn
 	osFamily             oscomp.Family
+	arch                 oscomp.Architecture
 	// as per the documentation of http.Transport: "Transports should be reused instead of created as needed."
 	httpTransport *http.Transport
 }
@@ -120,6 +121,7 @@ func NewHost(context Context, hostOutput remote.HostOutput) (*Host, error) {
 		sshExecutor:          sshExecutor,
 		convertPathSeparator: convertPathSeparatorFactory(hostOutput.OSFamily),
 		osFamily:             hostOutput.OSFamily,
+		arch:                 hostOutput.Architecture,
 	}
 
 	host.httpTransport = host.newHTTPTransport()

--- a/test/e2e-framework/testing/utils/e2e/client/host_agent_install.go
+++ b/test/e2e-framework/testing/utils/e2e/client/host_agent_install.go
@@ -1,0 +1,191 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package client
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	oscomp "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+)
+
+// HostAgentInstaller installs and configures the Datadog Agent on a host over SSH, without
+// Pulumi. It reuses the host's existing SSH primitives (Execute, WriteFile) and the same
+// install-command builder as the Pulumi path (agent.LinuxInstallCommand), so the two cannot
+// drift. Linux is supported today; Windows/macOS are follow-ups.
+type HostAgentInstaller struct {
+	host *Host
+}
+
+// AgentInstaller returns an installer that manages the Datadog Agent on this host over SSH.
+func (h *Host) AgentInstaller() *HostAgentInstaller {
+	return &HostAgentInstaller{host: h}
+}
+
+// Install installs the Agent described by params and writes its configuration, then restarts it
+// so the configuration takes effect. apiKey is inlined into the install command and merged into
+// datadog.yaml (unless params.SkipAPIKeyInConfig). This mirrors the Pulumi installAgent flow
+// (install → write config → restart) but runs entirely over SSH.
+func (i *HostAgentInstaller) Install(params *agentparams.Params, apiKey string) error {
+	if i.host.osFamily != oscomp.LinuxFamily {
+		return fmt.Errorf("HostAgentInstaller supports Linux only for now, got OS family %v", i.host.osFamily)
+	}
+
+	installCmd := agent.LinuxInstallCommand(i.host.arch, params.Version, apiKey, params.AdditionalInstallParameters)
+	if _, err := i.host.Execute(installCmd); err != nil {
+		return fmt.Errorf("agent install command failed: %w", err)
+	}
+
+	if err := i.writeConfigs(params, apiKey); err != nil {
+		return err
+	}
+
+	return i.Restart()
+}
+
+// Restart restarts the Datadog Agent service.
+func (i *HostAgentInstaller) Restart() error {
+	if _, err := i.host.Execute("sudo systemctl restart datadog-agent"); err != nil {
+		return fmt.Errorf("failed to restart datadog-agent: %w", err)
+	}
+	return nil
+}
+
+// writeConfigs writes datadog.yaml (merged with the API key and extra config), the system-probe
+// and security-agent configs, integration configs, and any extra files declared in params.
+func (i *HostAgentInstaller) writeConfigs(params *agentparams.Params, apiKey string) error {
+	configDir, err := i.host.GetAgentConfigFolder()
+	if err != nil {
+		return err
+	}
+
+	datadogYAML, err := mergeDatadogConfig(params, apiKey)
+	if err != nil {
+		return err
+	}
+
+	// Core config files live under the agent config folder and must be readable by the dd-agent user.
+	for _, f := range []struct{ name, content string }{
+		{"datadog.yaml", datadogYAML},
+		{"system-probe.yaml", params.SystemProbeConfig},
+		{"security-agent.yaml", params.SecurityAgentConfig},
+	} {
+		if err := i.writeAgentOwnedFile(path.Join(configDir, f.name), f.content); err != nil {
+			return err
+		}
+	}
+
+	// Integration configs are relative to the agent config folder (e.g. conf.d/nginx.d/conf.yaml).
+	for relPath, def := range params.Integrations {
+		if err := i.writeFileDefinition(path.Join(configDir, relPath), def); err != nil {
+			return err
+		}
+	}
+
+	// Extra files use absolute paths.
+	for absPath, def := range params.Files {
+		if err := i.writeFileDefinition(absPath, def); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeAgentOwnedFile writes content to destPath as root and hands ownership to the dd-agent user,
+// matching where the Pulumi path places core agent config.
+func (i *HostAgentInstaller) writeAgentOwnedFile(destPath, content string) error {
+	if err := i.stageAndInstallFile(destPath, content, true); err != nil {
+		return err
+	}
+	if _, err := i.host.Execute(fmt.Sprintf("sudo chown dd-agent:dd-agent %s", destPath)); err != nil {
+		return fmt.Errorf("failed to chown %s: %w", destPath, err)
+	}
+	return nil
+}
+
+// writeFileDefinition writes a single FileDefinition (integration config or extra file), honoring
+// its UseSudo flag and optional file permissions.
+func (i *HostAgentInstaller) writeFileDefinition(destPath string, def *agentparams.FileDefinition) error {
+	if err := i.stageAndInstallFile(destPath, def.Content, def.UseSudo); err != nil {
+		return err
+	}
+	if p, ok := def.Permissions.Get(); ok {
+		if cmd := p.SetupPermissionsCommand(destPath); cmd != "" {
+			if _, err := i.host.Execute(cmd); err != nil {
+				return fmt.Errorf("failed to set permissions on %s: %w", destPath, err)
+			}
+		}
+	}
+	return nil
+}
+
+// stageAndInstallFile writes content to destPath. When privileged is true it stages the file in a
+// user-writable temp location (via SFTP) and moves it into place with sudo, so root-owned
+// destinations like /etc/datadog-agent work without embedding the content in a shell command
+// (which would break on quoting).
+func (i *HostAgentInstaller) stageAndInstallFile(destPath, content string, privileged bool) error {
+	if !privileged {
+		if _, err := i.host.WriteFile(destPath, []byte(content)); err != nil {
+			return fmt.Errorf("failed to write %s: %w", destPath, err)
+		}
+		return nil
+	}
+
+	tmpPath := path.Join("/tmp", "e2e-agent-install-"+strings.ReplaceAll(strings.TrimPrefix(destPath, "/"), "/", "_"))
+	if _, err := i.host.WriteFile(tmpPath, []byte(content)); err != nil {
+		return fmt.Errorf("failed to stage %s: %w", destPath, err)
+	}
+	cmd := fmt.Sprintf("sudo mkdir -p %s && sudo cp %s %s && rm -f %s", path.Dir(destPath), tmpPath, destPath, tmpPath)
+	if _, err := i.host.Execute(cmd); err != nil {
+		return fmt.Errorf("failed to install %s: %w", destPath, err)
+	}
+	return nil
+}
+
+// mergeDatadogConfig builds the datadog.yaml content the same way the Pulumi path does: the base
+// AgentConfig, then each extra config, then the API key (unless skipped), each merged in turn.
+func mergeDatadogConfig(params *agentparams.Params, apiKey string) (string, error) {
+	extras, err := resolveExtraAgentConfig(params.ExtraAgentConfig)
+	if err != nil {
+		return "", err
+	}
+	if !params.SkipAPIKeyInConfig {
+		extras = append(extras, fmt.Sprintf("api_key: %s", apiKey))
+	}
+
+	merged := params.AgentConfig
+	for _, extra := range extras {
+		merged, err = utils.MergeYAMLWithSlices(merged, extra)
+		if err != nil {
+			return "", err
+		}
+	}
+	return merged, nil
+}
+
+// resolveExtraAgentConfig turns the Pulumi-typed ExtraAgentConfig into plain strings. Only
+// constant values (pulumi.String) can be resolved without a Pulumi context; computed values
+// (e.g. fakeintake/tags wiring built with pulumi.Sprintf) must be supplied as plain config
+// strings by the environment-level installer instead.
+func resolveExtraAgentConfig(extra []pulumi.StringInput) ([]string, error) {
+	out := make([]string, 0, len(extra))
+	for _, in := range extra {
+		s, ok := in.(pulumi.String)
+		if !ok {
+			return nil, fmt.Errorf("the SSH agent installer cannot resolve a computed pulumi value in ExtraAgentConfig; " +
+				"supply such config (e.g. fakeintake, tags, hostname) as a plain string via the environment-level installer")
+		}
+		out = append(out, string(s))
+	}
+	return out, nil
+}

--- a/test/e2e-framework/testing/utils/e2e/client/host_agent_install_test.go
+++ b/test/e2e-framework/testing/utils/e2e/client/host_agent_install_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+)
+
+func TestMergeDatadogConfig(t *testing.T) {
+	t.Run("merges the api key into the base config", func(t *testing.T) {
+		params := &agentparams.Params{AgentConfig: "log_level: debug"}
+		got, err := mergeDatadogConfig(params, "abc123")
+		require.NoError(t, err)
+		assert.Contains(t, got, "log_level: debug")
+		assert.Contains(t, got, "api_key: abc123")
+	})
+
+	t.Run("omits the api key when SkipAPIKeyInConfig is set", func(t *testing.T) {
+		params := &agentparams.Params{AgentConfig: "log_level: debug", SkipAPIKeyInConfig: true}
+		got, err := mergeDatadogConfig(params, "abc123")
+		require.NoError(t, err)
+		assert.NotContains(t, got, "api_key")
+	})
+
+	t.Run("merges constant extra config entries", func(t *testing.T) {
+		params := &agentparams.Params{ExtraAgentConfig: []pulumi.StringInput{pulumi.String("logs_enabled: true")}}
+		got, err := mergeDatadogConfig(params, "k")
+		require.NoError(t, err)
+		assert.Contains(t, got, "logs_enabled: true")
+		assert.Contains(t, got, "api_key: k")
+	})
+
+	t.Run("rejects computed (pulumi output) extra config", func(t *testing.T) {
+		params := &agentparams.Params{ExtraAgentConfig: []pulumi.StringInput{pulumi.Sprintf("tags: [%s]", "team:agent")}}
+		_, err := mergeDatadogConfig(params, "k")
+		require.Error(t, err)
+	})
+}

--- a/test/new-e2e/examples/agentenv_ssh_install_test.go
+++ b/test/new-e2e/examples/agentenv_ssh_install_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
@@ -19,24 +20,20 @@ import (
 
 // This example demonstrates installing the Agent as a separate, Pulumi-free step. Pulumi provisions
 // only the infrastructure (a bare host via ec2.WithoutAgent(), plus a fakeintake); the Agent is then
-// installed over SSH via env.InstallAgent, which auto-wires the environment's fakeintake. Once the
-// BaseSuite opt-in hook lands, this becomes an option rather than an explicit call in the test body.
+// installed over SSH after provisioning via e2e.WithInstalledAgent, which auto-wires the
+// environment's fakeintake. The install is transparent — no per-test wiring — and the test body is
+// identical to a suite whose Agent was installed by Pulumi.
 type sshInstalledAgentSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
 
 func TestSSHInstalledAgentSuite(t *testing.T) {
 	e2e.Run(t, &sshInstalledAgentSuite{},
-		e2e.WithProvisioner(awshost.Provisioner(awshost.WithRunOptions(ec2.WithoutAgent()))))
+		e2e.WithProvisioner(awshost.Provisioner(awshost.WithRunOptions(ec2.WithoutAgent()))),
+		e2e.WithInstalledAgent[agentparams.Option]())
 }
 
-// Test0 runs first (suite methods run in name order) and installs the Agent over SSH, so the later
-// assertions see a running, fakeintake-configured Agent.
-func (v *sshInstalledAgentSuite) Test0_InstallAgentOverSSH() {
-	v.Require().NoError(v.Env().InstallAgent(v))
-}
-
-func (v *sshInstalledAgentSuite) Test1_FakeIntakeReceivesMetrics() {
+func (v *sshInstalledAgentSuite) TestFakeIntakeReceivesMetrics() {
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		metricNames, err := v.Env().FakeIntake.Client().GetMetricNames()
 		assert.NoError(c, err)

--- a/test/new-e2e/examples/agentenv_ssh_install_test.go
+++ b/test/new-e2e/examples/agentenv_ssh_install_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package examples
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+)
+
+// This example demonstrates installing the Agent as a separate, Pulumi-free step. Pulumi provisions
+// only the infrastructure (a bare host via ec2.WithoutAgent(), plus a fakeintake); the Agent is then
+// installed over SSH via env.InstallAgent, which auto-wires the environment's fakeintake. Once the
+// BaseSuite opt-in hook lands, this becomes an option rather than an explicit call in the test body.
+type sshInstalledAgentSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+func TestSSHInstalledAgentSuite(t *testing.T) {
+	e2e.Run(t, &sshInstalledAgentSuite{},
+		e2e.WithProvisioner(awshost.Provisioner(awshost.WithRunOptions(ec2.WithoutAgent()))))
+}
+
+// Test0 runs first (suite methods run in name order) and installs the Agent over SSH, so the later
+// assertions see a running, fakeintake-configured Agent.
+func (v *sshInstalledAgentSuite) Test0_InstallAgentOverSSH() {
+	v.Require().NoError(v.Env().InstallAgent(v))
+}
+
+func (v *sshInstalledAgentSuite) Test1_FakeIntakeReceivesMetrics() {
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		metricNames, err := v.Env().FakeIntake.Client().GetMetricNames()
+		assert.NoError(c, err)
+		assert.Greater(c, len(metricNames), 0)
+	}, 5*time.Minute, 10*time.Second)
+}

--- a/test/new-e2e/examples/agentenv_ssh_install_test.go
+++ b/test/new-e2e/examples/agentenv_ssh_install_test.go
@@ -11,26 +11,23 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
 )
 
 // This example demonstrates installing the Agent as a separate, Pulumi-free step. Pulumi provisions
-// only the infrastructure (a bare host via ec2.WithoutAgent(), plus a fakeintake); the Agent is then
-// installed over SSH after provisioning via e2e.WithInstalledAgent, which auto-wires the
-// environment's fakeintake. The install is transparent — no per-test wiring — and the test body is
-// identical to a suite whose Agent was installed by Pulumi.
+// only the infrastructure (a bare host plus a fakeintake); the Agent is then installed over SSH after
+// provisioning via awshost.WithSSHInstalledAgent, which also auto-wires the environment's fakeintake.
+// The install is transparent — no per-test wiring — and the test body is identical to a suite whose
+// Agent was installed by Pulumi.
 type sshInstalledAgentSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
 
 func TestSSHInstalledAgentSuite(t *testing.T) {
 	e2e.Run(t, &sshInstalledAgentSuite{},
-		e2e.WithProvisioner(awshost.Provisioner(awshost.WithRunOptions(ec2.WithoutAgent()))),
-		e2e.WithInstalledAgent[agentparams.Option]())
+		e2e.WithProvisioner(awshost.Provisioner(awshost.WithSSHInstalledAgent())))
 }
 
 func (v *sshInstalledAgentSuite) TestFakeIntakeReceivesMetrics() {


### PR DESCRIPTION
### What does this PR do?

Makes it possible to install the Datadog Agent as a separate, **Pulumi-free** step, instead of always installing it during Pulumi provisioning. Pulumi provisions the infrastructure; the Agent is then installed/configured over the environment's own client (SSH for hosts).

This first increment covers the **Host** environment (Linux) end to end:

- **Pulumi-free cores** (`agent.LinuxInstallCommand`, `agentparams.ResolveParams`, `agentparams.IntakeConfig`) shared with the existing Pulumi path via common templates so the two cannot drift — no behavior change to the Pulumi path.
- **`client.HostAgentInstaller`** (via `host.AgentInstaller()`): installs + configures + restarts the Agent entirely over the existing SSH client (`Execute`/`WriteFile`), reusing `agentparams.Params`.
- **`environments.AgentInstaller[Options]`** contract + **`Host.InstallAgent`**: every environment defines how to install its Agent (typed to its own params package); `Host` resolves environment defaults (pipeline id / FIPS / major version / API key) from the runner profile and auto-wires the environment's fakeintake.
- **Two transparent opt-in entry points** (no per-test wiring, test bodies unchanged):
  - `awshost.Provisioner(awshost.WithSSHInstalledAgent(...))` — stock host suites; the provisioner is bound to the Host environment, so no option-type annotation is needed and `ec2.WithoutAgent()` is folded in.
  - `e2e.WithInstalledAgent[O](...)` — escape hatch for custom environments.
  Both run in `reconcileEnv` right after `Init`, so they also cover `UpdateEnv` (Pulumi-free reconfiguration for free).
- An example under `test/new-e2e/examples` provisioning a bare host + fakeintake and installing the Agent over SSH.

### Motivation

Today Pulumi does two jobs in one run: provision infrastructure **and** install/configure the Agent. Decoupling them lets us provision infrastructure once and later install/reconfigure the Agent and run tests against it without re-entering Pulumi — the enabler for "provision first, execute later" flows (e.g. E2E-as-a-Service) and for cheap agent reconfiguration. This lands incrementally on `main`: existing tests are unchanged, and suites opt in one at a time.

### Describe how you validated your changes

- Unit tests (cloud-free) for the extracted cores and merge/resolve logic:
  `dda inv test --module=test/e2e-framework --targets=./components/datadog/agent,./components/datadog/agentparams,./testing/utils/e2e/client,./testing/environments,./testing/e2e` — all green.
- Confirmed the Pulumi path is behavior-preserving (extracted command/values templates are shared).
- Verified the new example compiles against the local framework (`test/new-e2e/examples`).
- Live end-to-end validation on a real Linux host (provision bare host + fakeintake → SSH install → assert fakeintake receives metrics) is the next step before undrafting.

### Additional Notes

- **Scope**: Host / Linux only in this PR. Kubernetes (Helm), Windows/macOS, direct-package install, and Docker/ECS are follow-ups behind the same `AgentInstaller[Options]` contract.
- **Not migrating existing tests here** — this only adds the opt-in mechanism. Suites with agent-dependent Pulumi workloads (e.g. `ssi`) keep the Pulumi-native Agent until a dedicated post-agent-workload phase lands.
- Design decisions: API key / pipeline / FIPS are sourced from the runner profile (same origin the Pulumi config uses); fakeintake is wired as plain config to avoid computed Pulumi values on the SSH path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)