### PR TITLE
Apply the SBOM image-size disk check only to tarball scans

### DIFF
--- a/pkg/config/schema/yaml/sbom.yaml
+++ b/pkg/config/schema/yaml/sbom.yaml
@@ -106,7 +106,7 @@ properties:
       min_available_disk:
         node_type: setting
         type: string
-        default: 1Gb
+        default: 10Mb
       overlayfs_direct_scan:
         node_type: setting
         type: boolean

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -863,7 +863,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("sbom.container_image.scan_timeout", 10*60) // Integer seconds
 	config.BindEnvAndSetDefault("sbom.container_image.analyzers", []string{"os"})
 	config.BindEnvAndSetDefault("sbom.container_image.check_disk_usage", true)
-	config.BindEnvAndSetDefault("sbom.container_image.min_available_disk", "1Gb")
+	config.BindEnvAndSetDefault("sbom.container_image.min_available_disk", "10Mb")
 	config.BindEnvAndSetDefault("sbom.container_image.overlayfs_direct_scan", false)
 	config.BindEnvAndSetDefault("sbom.container_image.overlayfs_disable_cache", true)
 	config.BindEnvAndSetDefault("sbom.container_image.container_exclude", []string{})

--- a/pkg/sbom/scanner/BUILD.bazel
+++ b/pkg/sbom/scanner/BUILD.bazel
@@ -36,6 +36,7 @@ dd_agent_go_test(
         "//pkg/config/model",
         "//pkg/sbom",
         "//pkg/sbom/collectors",
+        "//pkg/util/filesystem",
         "//pkg/util/fxutil",
         "//pkg/util/option",
         "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",

--- a/pkg/sbom/scanner/scanner.go
+++ b/pkg/sbom/scanner/scanner.go
@@ -125,7 +125,7 @@ func (s *Scanner) Scan(request sbom.ScanRequest) error {
 	return nil
 }
 
-func (s *Scanner) enoughDiskSpace(opts sbom.ScanOptions, imgMeta *workloadmeta.ContainerImageMetadata) error {
+func (s *Scanner) enoughDiskSpace(collectorName string, opts sbom.ScanOptions, imgMeta *workloadmeta.ContainerImageMetadata) error {
 	if !opts.CheckDiskUsage {
 		return nil
 	}
@@ -139,7 +139,9 @@ func (s *Scanner) enoughDiskSpace(opts sbom.ScanOptions, imgMeta *workloadmeta.C
 		return fmt.Errorf("not enough disk space to safely collect sbom, %d available, %d required", usage.Available, opts.MinAvailableDisk)
 	}
 
-	if imgMeta == nil || opts.OverlayFsScan || opts.UseMount {
+	// Beyond the flat minimum, only scans that export the whole image to a
+	// tarball on disk (the "docker save" path) need room for the image itself.
+	if imgMeta == nil || !mayStoreTarball(collectorName, opts) {
 		return nil
 	}
 
@@ -151,6 +153,24 @@ func (s *Scanner) enoughDiskSpace(opts sbom.ScanOptions, imgMeta *workloadmeta.C
 	}
 
 	return nil
+}
+
+// mayStoreTarball reports whether the collector, with these options, may export
+// the whole image to a tarball on disk (the "docker save" path), which is the
+// only scan mode that needs room for the image itself. CRI-O always scans
+// overlayfs in place; containerd exports only when neither overlayfs_direct_scan
+// nor use_mount is set; the Docker collector may always fall back to the tarball
+// export (it only uses the overlayfs path on the overlay2 graph driver and
+// ignores use_mount), so it cannot be ruled out ahead of the scan.
+func mayStoreTarball(collectorName string, opts sbom.ScanOptions) bool {
+	switch collectorName {
+	case collectors.CrioCollector:
+		return false
+	case collectors.ContainerdCollector:
+		return !opts.OverlayFsScan && !opts.UseMount
+	default:
+		return true
+	}
 }
 
 // sendResult sends a ScanResult to the channel associated with the collector.
@@ -276,7 +296,7 @@ func (s *Scanner) getImageMetadata(request sbom.ScanRequest) *workloadmeta.Conta
 }
 
 func (s *Scanner) processScan(ctx context.Context, request sbom.ScanRequest, imgMeta *workloadmeta.ContainerImageMetadata, collector collectors.Collector) {
-	result := s.checkDiskSpace(imgMeta, collector)
+	result := s.checkDiskSpace(request.Collector(), imgMeta, collector)
 	errorType := "disk_space"
 
 	if result == nil {
@@ -293,8 +313,8 @@ func (s *Scanner) processScan(ctx context.Context, request sbom.ScanRequest, img
 // checkDiskSpace checks if there is enough disk space to perform the scan
 // It sends a scan result wrapping an error if there is not enough space
 // If everything is correct it returns nil.
-func (s *Scanner) checkDiskSpace(imgMeta *workloadmeta.ContainerImageMetadata, collector collectors.Collector) *sbom.ScanResult {
-	err := s.enoughDiskSpace(collector.Options(), imgMeta)
+func (s *Scanner) checkDiskSpace(collectorName string, imgMeta *workloadmeta.ContainerImageMetadata, collector collectors.Collector) *sbom.ScanResult {
+	err := s.enoughDiskSpace(collectorName, collector.Options(), imgMeta)
 	if err == nil {
 		return nil
 	}

--- a/pkg/sbom/scanner/scanner_test.go
+++ b/pkg/sbom/scanner/scanner_test.go
@@ -11,6 +11,7 @@ package scanner
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 
@@ -77,6 +79,43 @@ func (m mockReport) Tags() []string {
 }
 
 var _ sbom.Report = mockReport{}
+
+// Test that the flat min_available_disk floor applies to every scan, while the
+// image-size headroom check runs only for scans that may store a tarball.
+func TestEnoughDiskSpaceImageSizeOnlyForTarballScans(t *testing.T) {
+	s := &Scanner{disk: filesystem.NewDisk()}
+	// A huge image makes the 1.2x-size check fail whenever it runs; leaving
+	// MinAvailableDisk at 0 lets the flat floor pass, isolating the two checks.
+	imgMeta := &workloadmeta.ContainerImageMetadata{SizeBytes: 1 << 60}
+
+	// In-place scans (CRI-O, containerd with overlayfs/mount) never store a
+	// tarball, so the image-size check is skipped.
+	for _, tc := range []struct {
+		collector string
+		opts      sbom.ScanOptions
+	}{
+		{collectors.CrioCollector, sbom.ScanOptions{CheckDiskUsage: true, OverlayFsScan: true}},
+		{collectors.ContainerdCollector, sbom.ScanOptions{CheckDiskUsage: true, OverlayFsScan: true}},
+		{collectors.ContainerdCollector, sbom.ScanOptions{CheckDiskUsage: true, UseMount: true}},
+	} {
+		assert.NoError(t, s.enoughDiskSpace(tc.collector, tc.opts, imgMeta))
+	}
+
+	// Tarball scans (containerd default, and Docker, which may fall back to the
+	// tarball export) run the image-size check, which fails for this huge image.
+	for _, tc := range []struct {
+		collector string
+		opts      sbom.ScanOptions
+	}{
+		{collectors.ContainerdCollector, sbom.ScanOptions{CheckDiskUsage: true}},
+		{collectors.DockerCollector, sbom.ScanOptions{CheckDiskUsage: true, OverlayFsScan: true}},
+	} {
+		assert.Error(t, s.enoughDiskSpace(tc.collector, tc.opts, imgMeta))
+	}
+
+	// The flat floor still applies to every scan, including in-place ones.
+	assert.Error(t, s.enoughDiskSpace(collectors.CrioCollector, sbom.ScanOptions{CheckDiskUsage: true, MinAvailableDisk: math.MaxUint64, OverlayFsScan: true}, imgMeta))
+}
 
 // Test retry handling in case of an error
 func TestRetryLogic_Error(t *testing.T) {

--- a/releasenotes/notes/sbom-disk-check-tarball-only-c22adbab70bb8e9e.yaml
+++ b/releasenotes/notes/sbom-disk-check-tarball-only-c22adbab70bb8e9e.yaml
@@ -1,0 +1,18 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The image-size portion of the available-disk check performed before a
+    container image SBOM scan now runs only for scans that export the image to a
+    tarball on disk (the containerd default mode and the Docker collector), and
+    is skipped for scans that read the image layers in place (CRI-O, and
+    containerd with ``sbom.container_image.overlayfs_direct_scan`` or
+    ``sbom.container_image.use_mount``). The flat
+    ``sbom.container_image.min_available_disk`` floor still applies to every
+    scan, and its default is lowered from 1GB to 10MB.


### PR DESCRIPTION
The available-disk check before a container image SBOM scan has two
parts: a flat sbom.container_image.min_available_disk floor for every
scan, and a "20% more than the image size" requirement for the tarball
("docker save") path that writes the whole image to disk.

The image-size part was skipped whenever opts.OverlayFsScan or
opts.UseMount was set, but that is an imprecise proxy for an in-place
scan: the Docker collector ignores use_mount and only takes the overlayfs
path on the overlay2 graph driver, so it can still fall back to the
tarball export. Replace that condition with a per-collector check: CRI-O
never stores a tarball, containerd stores one only in its default mode,
and the Docker collector may always fall back, so it is always checked.

The flat floor still applies to every scan, but lower its default
(sbom.container_image.min_available_disk) from 1GB to 10MB: with the
image-size requirement now scoped to the tarball path, the floor only
needs to guard against scanning a nearly-full disk.