### PR TITLE
FIPS pipelines for SGC

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -49,6 +49,7 @@ cluster_agent-build*                 @DataDog/container-integrations
 cluster_agent_fips-build*            @DataDog/container-integrations
 cws_instrumentation-build*           @DataDog/agent-security
 secret_generic_connector-build*      @DataDog/agent-configuration
+secret_generic_connector_fips-build* @DataDog/agent-configuration
 build_windows_container_entrypoint   @DataDog/windows-products
 generate_config_schema-linux         @DataDog/agent-configuration
 generate_config_schema-macos         @DataDog/agent-configuration

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -49,7 +49,7 @@ cluster_agent-build*                 @DataDog/container-integrations
 cluster_agent_fips-build*            @DataDog/container-integrations
 cws_instrumentation-build*           @DataDog/agent-security
 secret_generic_connector-build*      @DataDog/agent-configuration
-secret_generic_connector_fips-build* @DataDog/agent-configuration
+secret_generic_connector_fips-build* @DataDog/fleet-automation
 build_windows_container_entrypoint   @DataDog/windows-products
 generate_config_schema-linux         @DataDog/agent-configuration
 generate_config_schema-macos         @DataDog/agent-configuration

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -53,6 +53,7 @@ cluster_agent-build*                 @DataDog/container-integrations
 cluster_agent_fips-build*            @DataDog/container-integrations
 cws_instrumentation-build*           @DataDog/agent-security
 secret_generic_connector-build*      @DataDog/fleet-automation
+secret_generic_connector_fips-build* @DataDog/fleet-automation
 build_windows_container_entrypoint   @DataDog/windows-products
 # Cross-compiled binary builds for validation purpose
 cross_build_agent-binary_aix_ppc64        @DataDog/agent-build

--- a/.gitlab/build/binary_build/secret_generic_connector.yml
+++ b/.gitlab/build/binary_build/secret_generic_connector.yml
@@ -36,3 +36,22 @@ secret_generic_connector-build_amd64:
 
 secret_generic_connector-build_arm64:
   extends: [.secret_generic_connector-build_common, .secret_generic_connector_arm64]
+
+# FIPS variant: extends the non-FIPS build job and overrides the script to 
+# pass --fips-mode. Built with GOEXPERIMENT=boringcrypto, matching 
+# how the cluster-agent already builds the FIPS secret-generic-connector.
+secret_generic_connector_fips-build_amd64:
+  extends: secret_generic_connector-build_amd64
+  variables:
+    GOEXPERIMENT: boringcrypto
+  script:
+    - dda inv -- check-go-version
+    - dda inv -- -e secret-generic-connector.build --arch-suffix --fips-mode
+
+secret_generic_connector_fips-build_arm64:
+  extends: secret_generic_connector-build_arm64
+  variables:
+    GOEXPERIMENT: boringcrypto
+  script:
+    - dda inv -- check-go-version
+    - dda inv -- -e secret-generic-connector.build --arch-suffix --fips-mode

--- a/.gitlab/build/binary_build/secret_generic_connector.yml
+++ b/.gitlab/build/binary_build/secret_generic_connector.yml
@@ -38,8 +38,8 @@ secret_generic_connector-build_amd64:
 secret_generic_connector-build_arm64:
   extends: [.secret_generic_connector-build_common, .secret_generic_connector_arm64]
 
-# FIPS variant: extends the non-FIPS build job and overrides the script to 
-# pass --fips-mode. Built with GOEXPERIMENT=boringcrypto, matching 
+# FIPS variant: extends the non-FIPS build job and overrides the script to
+# pass --fips-mode. Built with GOEXPERIMENT=boringcrypto, matching
 # how the cluster-agent already builds the FIPS secret-generic-connector.
 secret_generic_connector_fips-build_amd64:
   extends: secret_generic_connector-build_amd64

--- a/.gitlab/build/binary_build/secret_generic_connector.yml
+++ b/.gitlab/build/binary_build/secret_generic_connector.yml
@@ -37,3 +37,22 @@ secret_generic_connector-build_amd64:
 
 secret_generic_connector-build_arm64:
   extends: [.secret_generic_connector-build_common, .secret_generic_connector_arm64]
+
+# FIPS variant: extends the non-FIPS build job and overrides the script to 
+# pass --fips-mode. Built with GOEXPERIMENT=boringcrypto, matching 
+# how the cluster-agent already builds the FIPS secret-generic-connector.
+secret_generic_connector_fips-build_amd64:
+  extends: secret_generic_connector-build_amd64
+  variables:
+    GOEXPERIMENT: boringcrypto
+  script:
+    - dda inv -- check-go-version
+    - dda inv -- -e secret-generic-connector.build --arch-suffix --fips-mode
+
+secret_generic_connector_fips-build_arm64:
+  extends: secret_generic_connector-build_arm64
+  variables:
+    GOEXPERIMENT: boringcrypto
+  script:
+    - dda inv -- check-go-version
+    - dda inv -- -e secret-generic-connector.build --arch-suffix --fips-mode

--- a/.gitlab/build/binary_build/secret_generic_connector.yml
+++ b/.gitlab/build/binary_build/secret_generic_connector.yml
@@ -41,6 +41,7 @@ secret_generic_connector-build_arm64:
 # FIPS variant: extends the non-FIPS build job and overrides the script to
 # pass --fips-mode. Built with GOEXPERIMENT=boringcrypto, matching
 # how the cluster-agent already builds the FIPS secret-generic-connector.
+# The nm checks prevent a non-FIPS binary from reaching the image build.
 secret_generic_connector_fips-build_amd64:
   extends: secret_generic_connector-build_amd64
   variables:
@@ -48,6 +49,8 @@ secret_generic_connector_fips-build_amd64:
   script:
     - dda inv -- check-go-version
     - dda inv -- -e secret-generic-connector.build --arch-suffix --fips-mode
+    - go tool nm $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} | grep '_Cfunc__goboringcrypto_'
+    - go tool nm $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} | grep 'crypto/tls/fipsonly'
 
 secret_generic_connector_fips-build_arm64:
   extends: secret_generic_connector-build_arm64
@@ -56,3 +59,5 @@ secret_generic_connector_fips-build_arm64:
   script:
     - dda inv -- check-go-version
     - dda inv -- -e secret-generic-connector.build --arch-suffix --fips-mode
+    - go tool nm $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} | grep '_Cfunc__goboringcrypto_'
+    - go tool nm $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} | grep 'crypto/tls/fipsonly'

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -546,12 +546,15 @@ docker_build_secret_generic_connector_arm64:
   variables:
     STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_secret_generic_connector_arm64"
 
-# FIPS variant: the boringcrypto binary is statically linked, so the same scratch image is reused.
-# The nm check fails the build if the binary is not boringcrypto-linked, rather than publishing a non-FIPS image.
+# FIPS variant: the FIPS binary is CGO/boringcrypto, so it is dynamically linked and needs glibc at
+# runtime — it cannot run on scratch. Build it against the FIPS distroless base via a dedicated build
+# context (Dockerfiles/secret-generic-connector-fips). The nm check fails the build if the binary is
+# not boringcrypto-linked, rather than publishing a non-FIPS image.
 .docker_build_secret_generic_connector_fips:
   extends: .docker_build_secret_generic_connector
   variables:
     TAG_SUFFIX: -fips
+    BUILD_CONTEXT: Dockerfiles/secret-generic-connector-fips
   before_script:
     - !reference [.docker_build_secret_generic_connector, before_script]
     - go tool nm $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} | grep '_Cfunc__goboringcrypto_'

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -546,6 +546,28 @@ docker_build_secret_generic_connector_arm64:
   variables:
     STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_secret_generic_connector_arm64"
 
+# FIPS variant: the boringcrypto binary is statically linked, so the same scratch image is reused.
+# The nm check fails the build if the binary is not boringcrypto-linked, rather than publishing a non-FIPS image.
+.docker_build_secret_generic_connector_fips:
+  extends: .docker_build_secret_generic_connector
+  variables:
+    TAG_SUFFIX: -fips
+  before_script:
+    - !reference [.docker_build_secret_generic_connector, before_script]
+    - go tool nm $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} | grep '_Cfunc__goboringcrypto_'
+
+docker_build_secret_generic_connector_fips_amd64:
+  extends: [.docker_build_secret_generic_connector_fips, .docker_build_amd64]
+  needs:
+    - job: secret_generic_connector_fips-build_amd64
+      artifacts: true
+
+docker_build_secret_generic_connector_fips_arm64:
+  extends: [.docker_build_secret_generic_connector_fips, .docker_build_arm64]
+  needs:
+    - job: secret_generic_connector_fips-build_arm64
+      artifacts: true
+
 # build the dogstatsd image
 .docker_build_dogstatsd:
   extends: [.docker_build_job_definition, .docker_build_s3]

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -548,12 +548,15 @@ docker_build_secret_generic_connector_arm64:
   variables:
     STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_secret_generic_connector_arm64"
 
-# FIPS variant: the boringcrypto binary is statically linked, so the same scratch image is reused.
-# The nm check fails the build if the binary is not boringcrypto-linked, rather than publishing a non-FIPS image.
+# FIPS variant: the FIPS binary is CGO/boringcrypto, so it is dynamically linked and needs glibc at
+# runtime — it cannot run on scratch. Build it against the FIPS distroless base via a dedicated build
+# context (Dockerfiles/secret-generic-connector-fips). The nm check fails the build if the binary is
+# not boringcrypto-linked, rather than publishing a non-FIPS image.
 .docker_build_secret_generic_connector_fips:
   extends: .docker_build_secret_generic_connector
   variables:
     TAG_SUFFIX: -fips
+    BUILD_CONTEXT: Dockerfiles/secret-generic-connector-fips
   before_script:
     - !reference [.docker_build_secret_generic_connector, before_script]
     - go tool nm $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} | grep '_Cfunc__goboringcrypto_'

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -550,17 +550,12 @@ docker_build_secret_generic_connector_arm64:
 
 # FIPS variant: the FIPS binary is CGO/boringcrypto, so it is dynamically linked and needs glibc at
 # runtime - it cannot run on scratch. Build it against the public Ubuntu glibc base via a dedicated build
-# context (Dockerfiles/secret-generic-connector-fips). The nm check fails the build if the binary is
-# not boringcrypto-linked, rather than publishing a non-FIPS image.
+# context (Dockerfiles/secret-generic-connector-fips).
 .docker_build_secret_generic_connector_fips:
   extends: .docker_build_secret_generic_connector
   variables:
     TAG_SUFFIX: -fips
     BUILD_CONTEXT: Dockerfiles/secret-generic-connector-fips
-  before_script:
-    - !reference [.docker_build_secret_generic_connector, before_script]
-    - go tool nm $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} | grep '_Cfunc__goboringcrypto_'
-    - go tool nm $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} | grep 'crypto/tls/fipsonly'
 
 docker_build_secret_generic_connector_fips_amd64:
   extends: [.docker_build_secret_generic_connector_fips, .docker_build_amd64]

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -548,6 +548,28 @@ docker_build_secret_generic_connector_arm64:
   variables:
     STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_secret_generic_connector_arm64"
 
+# FIPS variant: the boringcrypto binary is statically linked, so the same scratch image is reused.
+# The nm check fails the build if the binary is not boringcrypto-linked, rather than publishing a non-FIPS image.
+.docker_build_secret_generic_connector_fips:
+  extends: .docker_build_secret_generic_connector
+  variables:
+    TAG_SUFFIX: -fips
+  before_script:
+    - !reference [.docker_build_secret_generic_connector, before_script]
+    - go tool nm $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} | grep '_Cfunc__goboringcrypto_'
+
+docker_build_secret_generic_connector_fips_amd64:
+  extends: [.docker_build_secret_generic_connector_fips, .docker_build_amd64]
+  needs:
+    - job: secret_generic_connector_fips-build_amd64
+      artifacts: true
+
+docker_build_secret_generic_connector_fips_arm64:
+  extends: [.docker_build_secret_generic_connector_fips, .docker_build_arm64]
+  needs:
+    - job: secret_generic_connector_fips-build_arm64
+      artifacts: true
+
 # build the dogstatsd image
 .docker_build_dogstatsd:
   extends: [.docker_build_job_definition, .docker_build_s3]

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -549,7 +549,7 @@ docker_build_secret_generic_connector_arm64:
     STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_secret_generic_connector_arm64"
 
 # FIPS variant: the FIPS binary is CGO/boringcrypto, so it is dynamically linked and needs glibc at
-# runtime — it cannot run on scratch. Build it against the FIPS distroless base via a dedicated build
+# runtime - it cannot run on scratch. Build it against the public Ubuntu glibc base via a dedicated build
 # context (Dockerfiles/secret-generic-connector-fips). The nm check fails the build if the binary is
 # not boringcrypto-linked, rather than publishing a non-FIPS image.
 .docker_build_secret_generic_connector_fips:

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -560,6 +560,7 @@ docker_build_secret_generic_connector_arm64:
   before_script:
     - !reference [.docker_build_secret_generic_connector, before_script]
     - go tool nm $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} | grep '_Cfunc__goboringcrypto_'
+    - go tool nm $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} | grep 'crypto/tls/fipsonly'
 
 docker_build_secret_generic_connector_fips_amd64:
   extends: [.docker_build_secret_generic_connector_fips, .docker_build_amd64]

--- a/.gitlab/distribute/deploy_secret_generic_connector.yml
+++ b/.gitlab/distribute/deploy_secret_generic_connector.yml
@@ -17,3 +17,18 @@ deploy_containers-secret-generic-connector:
   extends: .deploy_containers-secret-generic-connector-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
   needs: []
+
+.deploy_containers-secret-generic-connector-fips-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_secret_generic_connector
+  before_script:
+    - if [[ "$VERSION" == "" ]]; then VERSION="$(dda inv agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
+    - if [[ "$SECRET_GENERIC_CONNECTOR_REPOSITORY" == "" ]]; then export SECRET_GENERIC_CONNECTOR_REPOSITORY="secret-generic-connector"; fi
+    - export IMG_BASE_SRC="${SRC_SGC}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    - export IMG_SOURCES="${IMG_BASE_SRC}-fips-amd64,${IMG_BASE_SRC}-fips-arm64"
+    - export IMG_DESTINATIONS="${SECRET_GENERIC_CONNECTOR_REPOSITORY}:${VERSION}-fips"
+
+deploy_containers-secret-generic-connector-fips:
+  extends: .deploy_containers-secret-generic-connector-fips-base
+  rules: !reference [.on_deploy_manual_auto_on_rc]
+  needs: []

--- a/.gitlab/distribute/deploy_secret_generic_connector_mutable_tags.yml
+++ b/.gitlab/distribute/deploy_secret_generic_connector_mutable_tags.yml
@@ -26,3 +26,29 @@ deploy_mutable_secret_generic_connector_tags-latest:
       artifacts: false
   variables:
     IMG_NEW_TAGS: latest
+
+.deploy_mutable_secret_generic_connector_tags-fips-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_secret_generic_connector_mutable_tags
+  dependencies: []
+  before_script:
+    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
+    - export IMG_TAG_REFERENCE=${SECRET_GENERIC_CONNECTOR_REPOSITORY}:${VERSION}-fips
+
+deploy_mutable_secret_generic_connector_tags-fips-rc:
+  extends: .deploy_mutable_secret_generic_connector_tags-fips-base
+  rules: !reference [.on_deploy_rc]
+  needs:
+    - job: deploy_containers-secret-generic-connector-fips
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc-fips
+
+deploy_mutable_secret_generic_connector_tags-fips-latest:
+  extends: .deploy_mutable_secret_generic_connector_tags-fips-base
+  rules: !reference [.on_deploy_manual_final]
+  needs:
+    - job: deploy_containers-secret-generic-connector-fips
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest-fips

--- a/Dockerfiles/secret-generic-connector-fips/Dockerfile
+++ b/Dockerfiles/secret-generic-connector-fips/Dockerfile
@@ -1,0 +1,10 @@
+# FIPS secret-generic-connector image.
+# The FIPS binary is built with CGO (boringcrypto), so it is dynamically linked and needs glibc
+# at runtime — a scratch base is not enough. Use the FIPS-blessed distroless base, which ships
+# glibc (it already runs the boringcrypto operator/agent binaries) and no OpenSSL (boringcrypto
+# bundles its own crypto module).
+# hadolint ignore=DL3026
+FROM registry.ddbuild.io/images/base/gbi-distroless-nossl-fips:release
+ARG TARGETARCH
+COPY --chmod=0755 ./secret-generic-connector.$TARGETARCH /secret-generic-connector
+USER 1000

--- a/Dockerfiles/secret-generic-connector-fips/Dockerfile
+++ b/Dockerfiles/secret-generic-connector-fips/Dockerfile
@@ -18,3 +18,4 @@ LABEL org.opencontainers.image.base.name="ubuntu:${BASE_IMAGE_UBUNTU_VERSION}"
 ARG TARGETARCH
 COPY --chmod=0755 ./secret-generic-connector.$TARGETARCH /secret-generic-connector
 USER 1000
+RUN ["/secret-generic-connector", "--version"]

--- a/Dockerfiles/secret-generic-connector-fips/Dockerfile
+++ b/Dockerfiles/secret-generic-connector-fips/Dockerfile
@@ -1,10 +1,20 @@
 # FIPS secret-generic-connector image.
-# The FIPS binary is built with CGO (boringcrypto), so it is dynamically linked and needs glibc
-# at runtime — a scratch base is not enough. Use the FIPS-blessed distroless base, which ships
-# glibc (it already runs the boringcrypto operator/agent binaries) and no OpenSSL (boringcrypto
-# bundles its own crypto module).
-# hadolint ignore=DL3026
-FROM registry.ddbuild.io/images/base/gbi-distroless-nossl-fips:release
+#
+# The FIPS binary is built with GOEXPERIMENT=boringcrypto + CGO_ENABLED=1, so its FIPS-validated
+# crypto module (BoringSSL) is compiled INTO the binary. The base image therefore does not need a
+# FIPS OpenSSL — it only needs glibc for the dynamically linked CGO binary (a scratch base, as used
+# by the non-FIPS image, cannot run a dynamically linked binary). We use the same public,
+# customer-reproducible Ubuntu base as the agent/cluster-agent images.
+ARG BASE_IMAGE_UBUNTU_VERSION=24.04
+ARG BASE_IMAGE_UBUNTU_NAME=noble
+ARG BASE_IMAGE_REGISTRY=docker.io
+
+FROM ${BASE_IMAGE_REGISTRY}/ubuntu:$BASE_IMAGE_UBUNTU_VERSION
+ARG BASE_IMAGE_UBUNTU_VERSION
+ARG BASE_IMAGE_UBUNTU_NAME
+LABEL baseimage.os="ubuntu ${BASE_IMAGE_UBUNTU_NAME}"
+LABEL baseimage.name="ubuntu:${BASE_IMAGE_UBUNTU_VERSION}"
+LABEL org.opencontainers.image.base.name="ubuntu:${BASE_IMAGE_UBUNTU_VERSION}"
 ARG TARGETARCH
 COPY --chmod=0755 ./secret-generic-connector.$TARGETARCH /secret-generic-connector
 USER 1000

--- a/cmd/secret-generic-connector/BUILD.bazel
+++ b/cmd/secret-generic-connector/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//cmd/secret-generic-connector/backend",
         "//cmd/secret-generic-connector/secret",
+        "//pkg/fips",
     ],
 )
 

--- a/cmd/secret-generic-connector/main.go
+++ b/cmd/secret-generic-connector/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/secret-generic-connector/backend"
 	"github.com/DataDog/datadog-agent/cmd/secret-generic-connector/secret"
+	_ "github.com/DataDog/datadog-agent/pkg/fips" // Enforce FIPS-only mode in FIPS builds.
 )
 
 var appVersion = "dev"

--- a/tasks/secret_generic_connector.py
+++ b/tasks/secret_generic_connector.py
@@ -18,8 +18,6 @@ BINARY_NAME = "secret-generic-connector"
 BIN_DIR = os.path.join(".", "bin", "secret-generic-connector")
 BIN_PATH = os.path.join(BIN_DIR, bin_name(BINARY_NAME))
 
-FIPS_TAGS = ["goexperiment.systemcrypto", "requirefips"]
-
 
 @task
 def build(

--- a/tasks/secret_generic_connector.py
+++ b/tasks/secret_generic_connector.py
@@ -20,8 +20,6 @@ BINARY_NAME = "secret-generic-connector"
 BIN_DIR = os.path.join(".", "bin", "secret-generic-connector")
 BIN_PATH = os.path.join(BIN_DIR, bin_name(BINARY_NAME))
 
-FIPS_TAGS = ["goexperiment.systemcrypto", "requirefips"]
-
 
 @task
 def build(

--- a/tasks/secret_generic_connector.py
+++ b/tasks/secret_generic_connector.py
@@ -62,7 +62,7 @@ def build(
     # https://github.com/DataDog/datadog-secret-backend/blob/v1/.github/workflows/release.yaml
     gcflags = "all=-l"
 
-    # FIPS mode requires CGO for OpenSSL bindings
+    # FIPS mode requires CGO for BoringCrypto bindings
     # Non-FIPS builds use CGO_ENABLED=0 for static binary
     env = {
         "GO111MODULE": "on",


### PR DESCRIPTION
### What does this PR do?
builds on https://github.com/DataDog/datadog-agent/pull/49388 to provide a FIPS compliant SGC image in the build & distribute pipeline to docker hub and ECR

### Motivation
Provides the FIPS flavor of SGC in the SGC build & distribute pipeline

### Describe how you validated your changes
- `dda inv -- -e secret-generic-connector.build --arch-suffix --fips-mode` produces the arch-suffixed FIPS binary
- `dda inv linter.gitlab-ci` passes
- CI: `secret_generic_connector_fips-build_{amd64,arm64}` and `docker_build_secret_generic_connector_fips_{amd64,arm64}` are green

### Additional Notes
