### PR TITLE
Fix TestWorker_DropsWhenServiceGone flakiness

### DIFF
--- a/comp/core/autodiscovery/discoverer/worker_test.go
+++ b/comp/core/autodiscovery/discoverer/worker_test.go
@@ -234,15 +234,17 @@ func TestWorker_DropsWhenServiceGone(t *testing.T) {
 	telStore := newTestTelemetryStore(t)
 
 	w := NewWorker(disco, lookup, cb.callback, Config{MaxAttempts: 3, RetryDelay: 5 * time.Millisecond}, telStore)
-	w.Start()
-	defer w.Stop()
 	w.Enqueue(svcID, testTplDigest, "myinteg")
 	assert.Equal(t, float64(1), telStore.DiscoveryQueueDepth.WithValues("myinteg", "process").Get())
 
-	time.Sleep(40 * time.Millisecond)
+	w.Start()
+	defer w.Stop()
+
+	require.Eventually(t, func() bool {
+		return telStore.DiscoveryQueueDepth.WithValues("myinteg", "process").Get() == float64(0)
+	}, time.Second, 2*time.Millisecond, "worker must drain queue depth")
 	assert.Zero(t, disco.callCount())
 	assert.Empty(t, cb.snapshot())
-	assert.Equal(t, float64(0), telStore.DiscoveryQueueDepth.WithValues("myinteg", "process").Get())
 	assert.Equal(t, float64(1), telStore.DiscoveryResults.WithValues("myinteg", "service_not_found", "process").Get())
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition in `TestWorker_DropsWhenServiceGone` that caused intermittent test failures.

### Motivation

The test called `w.Start()` before `w.Enqueue()`, so the worker goroutines were already running when the job was added to the queue. Because the job completes almost instantly (no `DiscoverConfig` call — the service-not-found path drops immediately), the worker could pop it and decrement `DiscoveryQueueDepth` back to 0 before this assertion ran:

```go
assert.Equal(t, float64(1), telStore.DiscoveryQueueDepth.WithValues("myinteg", "process").Get())
```

A secondary issue was using `time.Sleep(40ms)` to wait for job completion, which is fragile on loaded CI machines.

### Additional Notes

The fix mirrors the pattern in `TestWorker_Success_TriggersCallbackOnce`, which deliberately avoids starting the worker before asserting the initial queue depth (it uses `runOnce` instead of `Start`). Here we achieve the same by calling `Enqueue` → assert → `Start`.
