### PR TITLE
[QB1HZ-24] Add shadow loading safety gates

### DIFF
--- a/pkg/collector/BUILD.bazel
+++ b/pkg/collector/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/collector/aggregator",
         "//pkg/collector/check",
         "//pkg/collector/check/id",
+        "//pkg/collector/corechecks",
         "//pkg/collector/loaders",
         "//pkg/collector/metriclookback",
         "//pkg/collector/metriclookback/lookbacksender",

--- a/pkg/collector/corechecks/BUILD.bazel
+++ b/pkg/collector/corechecks/BUILD.bazel
@@ -6,6 +6,7 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 go_library(
     name = "corechecks",
     srcs = [
+        "catalog_test_util.go",
         "checkbase.go",
         "loader.go",
         "longrunning.go",

--- a/pkg/collector/corechecks/catalog_test_util.go
+++ b/pkg/collector/corechecks/catalog_test_util.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package corechecks
+
+import "testing"
+
+// WithTestCatalog replaces the global core-check catalog for the duration of a test.
+func WithTestCatalog(t testing.TB) {
+	t.Helper()
+	originalCatalog := catalog
+	catalog = make(map[string]ContextualCheckFactory)
+	t.Cleanup(func() {
+		catalog = originalCatalog
+	})
+}

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -24,14 +24,42 @@ import (
 // CheckFactory factory function type to instantiate checks
 type CheckFactory func() check.Check
 
+// LoadMode describes why a core check is being constructed.
+type LoadMode string
+
+const (
+	// NormalLoadMode constructs a normal collector check.
+	NormalLoadMode LoadMode = "normal"
+	// ShadowLoadMode constructs a shadow collector check.
+	ShadowLoadMode LoadMode = "shadow"
+)
+
+// ConstructionContext is passed to factories that need mode-specific
+// dependencies while constructing a check instance.
+type ConstructionContext struct {
+	Mode LoadMode
+}
+
+// ContextualCheckFactory instantiates checks with construction context.
+type ContextualCheckFactory func(ConstructionContext) check.Check
+
 // Catalog keeps track of Go checks by name
-var catalog = make(map[string]CheckFactory)
+var catalog = make(map[string]ContextualCheckFactory)
 
 // GoCheckLoaderName is the name of the Go loader
 const GoCheckLoaderName string = "core"
 
 // RegisterCheck adds a check to the catalog
 func RegisterCheck(name string, checkFactory option.Option[func() check.Check]) {
+	if v, ok := checkFactory.Get(); ok {
+		catalog[name] = func(ConstructionContext) check.Check {
+			return v()
+		}
+	}
+}
+
+// RegisterContextualCheck adds a context-aware check factory to the catalog.
+func RegisterContextualCheck(name string, checkFactory option.Option[func(ConstructionContext) check.Check]) {
 	if v, ok := checkFactory.Get(); ok {
 		catalog[name] = v
 	}
@@ -48,11 +76,32 @@ func GetRegisteredFactoryKeys() []string {
 }
 
 // GoCheckLoader is a specific loader for checks living in this package
-type GoCheckLoader struct{}
+type GoCheckLoader struct {
+	mode LoadMode
+}
+
+// GoCheckLoaderOption configures a GoCheckLoader.
+type GoCheckLoaderOption func(*GoCheckLoader)
+
+// WithLoadMode configures the construction mode for loaded checks.
+func WithLoadMode(mode LoadMode) GoCheckLoaderOption {
+	return func(gl *GoCheckLoader) {
+		gl.mode = mode
+	}
+}
+
+// LoadMode returns the loader's check construction mode.
+func (gl *GoCheckLoader) LoadMode() LoadMode {
+	return gl.mode
+}
 
 // NewGoCheckLoader creates a loader for go checks
-func NewGoCheckLoader() (*GoCheckLoader, error) {
-	return &GoCheckLoader{}, nil
+func NewGoCheckLoader(opts ...GoCheckLoaderOption) (*GoCheckLoader, error) {
+	loader := &GoCheckLoader{mode: NormalLoadMode}
+	for _, opt := range opts {
+		opt(loader)
+	}
+	return loader, nil
 }
 
 // Name return returns Go loader name
@@ -70,7 +119,11 @@ func (gl *GoCheckLoader) Load(senderManger sender.SenderManager, config integrat
 		return c, errors.New(msg)
 	}
 
-	c = factory()
+	c = factory(ConstructionContext{Mode: gl.mode})
+	if c == nil {
+		msg := fmt.Sprintf("Check %s factory returned nil", config.Name)
+		return c, errors.New(msg)
+	}
 
 	configSource := config.Source
 	if instanceIndex >= 0 {

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -20,9 +20,19 @@ import (
 // FIXTURE
 type TestCheck struct {
 	stub.StubCheck
+	configured     bool
+	configDigest   uint64
+	configData     integration.Data
+	configSource   string
+	configProvider string
 }
 
-func (c *TestCheck) Configure(_ sender.SenderManager, _ uint64, data integration.Data, _ integration.Data, _ string, _ string) error {
+func (c *TestCheck) Configure(_ sender.SenderManager, digest uint64, data integration.Data, _ integration.Data, source string, provider string) error {
+	c.configured = true
+	c.configDigest = digest
+	c.configData = data
+	c.configSource = source
+	c.configProvider = provider
 	if string(data) == "err" {
 		return errors.New("testError")
 	}
@@ -30,6 +40,15 @@ func (c *TestCheck) Configure(_ sender.SenderManager, _ uint64, data integration
 		return check.ErrSkipCheckInstance
 	}
 	return nil
+}
+
+func withTestCatalog(t *testing.T) {
+	t.Helper()
+	originalCatalog := catalog
+	catalog = make(map[string]ContextualCheckFactory)
+	t.Cleanup(func() {
+		catalog = originalCatalog
+	})
 }
 
 func TestNewGoCheckLoader(t *testing.T) {
@@ -45,6 +64,7 @@ func testCheckNew() option.Option[func() check.Check] {
 }
 
 func TestRegisterCheck(t *testing.T) {
+	withTestCatalog(t)
 	RegisterCheck("foo", testCheckNew())
 	_, found := catalog["foo"]
 	if !found {
@@ -52,19 +72,93 @@ func TestRegisterCheck(t *testing.T) {
 	}
 }
 
+func TestGoCheckLoaderPassesDefaultNormalMode(t *testing.T) {
+	withTestCatalog(t)
+
+	var gotMode LoadMode
+	RegisterContextualCheck("foo", option.New(func(ctx ConstructionContext) check.Check {
+		gotMode = ctx.Mode
+		return &TestCheck{}
+	}))
+
+	l, _ := NewGoCheckLoader()
+	_, err := l.Load(aggregator.NewNoOpSenderManager(), integration.Config{Name: "foo"}, integration.Data("foo: bar"), 0)
+	if err != nil {
+		t.Fatalf("Expected nil error, found: %v", err)
+	}
+	if gotMode != NormalLoadMode {
+		t.Fatalf("Expected mode %q, found %q", NormalLoadMode, gotMode)
+	}
+}
+
+func TestGoCheckLoaderPassesShadowMode(t *testing.T) {
+	withTestCatalog(t)
+
+	var gotMode LoadMode
+	RegisterContextualCheck("foo", option.New(func(ctx ConstructionContext) check.Check {
+		gotMode = ctx.Mode
+		return &TestCheck{}
+	}))
+
+	l, _ := NewGoCheckLoader(WithLoadMode(ShadowLoadMode))
+	_, err := l.Load(aggregator.NewNoOpSenderManager(), integration.Config{Name: "foo"}, integration.Data("foo: bar"), 0)
+	if err != nil {
+		t.Fatalf("Expected nil error, found: %v", err)
+	}
+	if gotMode != ShadowLoadMode {
+		t.Fatalf("Expected mode %q, found %q", ShadowLoadMode, gotMode)
+	}
+}
+
+func TestRegisterCheckWrapsLegacyFactory(t *testing.T) {
+	withTestCatalog(t)
+
+	called := false
+	RegisterCheck("foo", option.New(func() check.Check {
+		called = true
+		return &TestCheck{}
+	}))
+
+	l, _ := NewGoCheckLoader(WithLoadMode(ShadowLoadMode))
+	_, err := l.Load(aggregator.NewNoOpSenderManager(), integration.Config{Name: "foo"}, integration.Data("foo: bar"), 0)
+	if err != nil {
+		t.Fatalf("Expected nil error, found: %v", err)
+	}
+	if !called {
+		t.Fatal("Expected legacy factory to be called")
+	}
+}
+
 func TestLoad(t *testing.T) {
+	withTestCatalog(t)
 	RegisterCheck("foo", testCheckNew())
 
 	// check is in catalog, pass 1 good instance
 	i := []integration.Data{
 		integration.Data("foo: bar"),
 	}
-	cc := integration.Config{Name: "foo", Instances: i}
+	cc := integration.Config{Name: "foo", Instances: i, Source: "file:foo.yaml", Provider: "file"}
 	l, _ := NewGoCheckLoader()
 
-	_, err := l.Load(aggregator.NewNoOpSenderManager(), cc, i[0], 0)
+	loadedCheck, err := l.Load(aggregator.NewNoOpSenderManager(), cc, i[0], 0)
 	if err != nil {
 		t.Fatalf("Expected nil error, found: %v", err)
+	}
+	tc := loadedCheck.(*TestCheck)
+	if !tc.configured {
+		t.Fatal("Expected check to be configured")
+	}
+	if tc.configDigest != cc.FastDigest() {
+		t.Fatalf("Expected digest %d, found %d", cc.FastDigest(), tc.configDigest)
+	}
+	if string(tc.configData) != string(i[0]) {
+		t.Fatalf("Expected instance data %q, found %q", i[0], tc.configData)
+	}
+	if tc.configSource != "file:foo.yaml[0]" {
+		t.Fatalf("Expected source %q, found %q", "file:foo.yaml[0]", tc.configSource)
+	}
+	if tc.configProvider != "file" {
+		t.Fatalf("Expected provider %q, found %q", "file", tc.configProvider)
 	}
 
 	// check is in catalog, pass 1 bad instance

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -44,11 +44,7 @@ func (c *TestCheck) Configure(_ sender.SenderManager, digest uint64, data integr
 
 func withTestCatalog(t *testing.T) {
 	t.Helper()
-	originalCatalog := catalog
-	catalog = make(map[string]ContextualCheckFactory)
-	t.Cleanup(func() {
-		catalog = originalCatalog
-	})
+	WithTestCatalog(t)
 }
 
 func TestNewGoCheckLoader(t *testing.T) {

--- a/pkg/collector/python/loader_test.go
+++ b/pkg/collector/python/loader_test.go
@@ -7,9 +7,7 @@
 
 package python
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestLoadWheelCheck(t *testing.T) {
 	testLoadWheelCheck(t)

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -76,6 +76,7 @@ type CheckScheduler struct {
 	shadowSenderManager sender.SenderManager
 	shadowSenderContext context.Context
 	shadowSenderCancel  context.CancelFunc
+	shadowCoreLoader    check.Loader
 	infraTagger         *infratags.Tagger // nil = no infra mode tagging
 	m                   sync.RWMutex
 }
@@ -238,7 +239,7 @@ func (s *CheckScheduler) getChecks(config integration.Config, includeShadowCheck
 			if includeShadowChecks {
 				if candidate, found := shadowCandidates[instanceIndex]; found {
 					sourceCheckID := result.check.ID()
-					shadowLoader, ok := shadowLoaderFor(result.loader)
+					shadowLoader, ok := s.shadowLoaderFor(result.loader)
 					if !ok {
 						log.Debugf("Skipping metric lookback shadow check %s: loader %s does not support shadow execution", check.ShadowID(sourceCheckID), result.loader.Name())
 						continue
@@ -272,14 +273,18 @@ func (s *CheckScheduler) getChecks(config integration.Config, includeShadowCheck
 	return checks, nil
 }
 
-func shadowLoaderFor(loader check.Loader) (check.Loader, bool) {
+func (s *CheckScheduler) shadowLoaderFor(loader check.Loader) (check.Loader, bool) {
 	switch loader.Name() {
 	case corecheckLoader.GoCheckLoaderName:
+		if s.shadowCoreLoader != nil {
+			return s.shadowCoreLoader, true
+		}
 		shadowLoader, err := corecheckLoader.NewGoCheckLoader(corecheckLoader.WithLoadMode(corecheckLoader.ShadowLoadMode))
 		if err != nil {
 			log.Debugf("Unable to create metric lookback shadow loader for %s: %v", loader.Name(), err)
 			return nil, false
 		}
+		s.shadowCoreLoader = shadowLoader
 		return shadowLoader, true
 	case "python":
 		return loader, true

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -27,6 +27,7 @@ import (
 	collectoraggregator "github.com/DataDog/datadog-agent/pkg/collector/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/DataDog/datadog-agent/pkg/collector/metriclookback"
 	"github.com/DataDog/datadog-agent/pkg/collector/metriclookback/lookbacksender"
@@ -237,7 +238,12 @@ func (s *CheckScheduler) getChecks(config integration.Config, includeShadowCheck
 			if includeShadowChecks {
 				if candidate, found := shadowCandidates[instanceIndex]; found {
 					sourceCheckID := result.check.ID()
-					if shadowCheck, err := s.loadShadowCheck(candidate, result.loader, sourceCheckID); err != nil {
+					shadowLoader, ok := shadowLoaderFor(result.loader)
+					if !ok {
+						log.Debugf("Skipping metric lookback shadow check %s: loader %s does not support shadow execution", check.ShadowID(sourceCheckID), result.loader.Name())
+						continue
+					}
+					if shadowCheck, err := s.loadShadowCheck(candidate, shadowLoader, sourceCheckID); err != nil {
 						log.Warnf("Unable to load metric lookback shadow check %s: %v", check.ShadowID(sourceCheckID), err)
 					} else {
 						checks = append(checks, shadowCheck)
@@ -264,6 +270,22 @@ func (s *CheckScheduler) getChecks(config integration.Config, includeShadowCheck
 	}
 
 	return checks, nil
+}
+
+func shadowLoaderFor(loader check.Loader) (check.Loader, bool) {
+	switch loader.Name() {
+	case corecheckLoader.GoCheckLoaderName:
+		shadowLoader, err := corecheckLoader.NewGoCheckLoader(corecheckLoader.WithLoadMode(corecheckLoader.ShadowLoadMode))
+		if err != nil {
+			log.Debugf("Unable to create metric lookback shadow loader for %s: %v", loader.Name(), err)
+			return nil, false
+		}
+		return shadowLoader, true
+	case "python":
+		return loader, true
+	default:
+		return nil, false
+	}
 }
 
 func shadowCandidatesByInstance(config integration.Config) map[int]metriclookback.ShadowCandidate {

--- a/pkg/collector/scheduler_test.go
+++ b/pkg/collector/scheduler_test.go
@@ -142,6 +142,7 @@ func TestGetChecksFromConfigs(t *testing.T) {
 }
 
 func TestGetChecksFromConfigsLoadsSelectedShadowCheckWithSenderManagerOverride(t *testing.T) {
+	core.WithTestCatalog(t)
 	cfg := configmock.New(t)
 	cfg.SetInTest("metric_lookback.enabled", true)
 	cfg.SetInTest("metric_lookback.enabled_checks", []string{"cpu"})
@@ -211,6 +212,7 @@ func TestGetChecksFromConfigsLoadsSelectedShadowCheckWithSenderManagerOverride(t
 }
 
 func TestGetChecksFromConfigsDoesNotLoadShadowChecksWhenCacheIsNotPopulated(t *testing.T) {
+	core.WithTestCatalog(t)
 	cfg := configmock.New(t)
 	cfg.SetInTest("metric_lookback.enabled", true)
 	cfg.SetInTest("metric_lookback.enabled_checks", []string{"cpu"})
@@ -247,6 +249,7 @@ func TestGetChecksFromConfigsDoesNotLoadShadowChecksWhenCacheIsNotPopulated(t *t
 }
 
 func TestGetChecksFromConfigsUsesFallbackShadowSenderManager(t *testing.T) {
+	core.WithTestCatalog(t)
 	cfg := configmock.New(t)
 	cfg.SetInTest("metric_lookback.enabled", true)
 	cfg.SetInTest("metric_lookback.enabled_checks", []string{"cpu"})
@@ -287,6 +290,7 @@ func TestGetChecksFromConfigsUsesFallbackShadowSenderManager(t *testing.T) {
 }
 
 func TestGetChecksFromConfigsKeepsNormalCheckWhenShadowLoadFails(t *testing.T) {
+	core.WithTestCatalog(t)
 	cfg := configmock.New(t)
 	cfg.SetInTest("metric_lookback.enabled", true)
 	cfg.SetInTest("metric_lookback.enabled_checks", []string{"cpu"})
@@ -381,8 +385,9 @@ func TestGetChecksFromConfigsSkipsShadowCheckForUnsupportedLoader(t *testing.T) 
 
 func TestShadowLoaderForPythonReusesLoadedLoader(t *testing.T) {
 	loader := &recordingSchedulerLoader{name: "python"}
+	s := CheckScheduler{}
 
-	shadowLoader, ok := shadowLoaderFor(loader)
+	shadowLoader, ok := s.shadowLoaderFor(loader)
 
 	require.True(t, ok)
 	assert.Same(t, loader, shadowLoader)
@@ -391,13 +396,27 @@ func TestShadowLoaderForPythonReusesLoadedLoader(t *testing.T) {
 func TestShadowLoaderForCoreUsesShadowLoadMode(t *testing.T) {
 	loader, err := core.NewGoCheckLoader()
 	require.NoError(t, err)
+	s := CheckScheduler{}
 
-	shadowLoader, ok := shadowLoaderFor(loader)
+	shadowLoader, ok := s.shadowLoaderFor(loader)
 
 	require.True(t, ok)
 	shadowCoreLoader, ok := shadowLoader.(*core.GoCheckLoader)
 	require.True(t, ok)
 	assert.Equal(t, core.ShadowLoadMode, shadowCoreLoader.LoadMode())
+}
+
+func TestShadowLoaderForCoreReusesShadowLoader(t *testing.T) {
+	loader, err := core.NewGoCheckLoader()
+	require.NoError(t, err)
+	s := CheckScheduler{}
+
+	firstShadowLoader, ok := s.shadowLoaderFor(loader)
+	require.True(t, ok)
+	secondShadowLoader, ok := s.shadowLoaderFor(loader)
+
+	require.True(t, ok)
+	assert.Same(t, firstShadowLoader, secondShadowLoader)
 }
 
 // MockCollector is a mock implementation of collectorcomp.Component for testing

--- a/pkg/collector/scheduler_test.go
+++ b/pkg/collector/scheduler_test.go
@@ -156,7 +156,11 @@ func TestGetChecksFromConfigsLoadsSelectedShadowCheckWithSenderManagerOverride(t
 	t.Cleanup(releaseCheckContext)
 
 	sourceID := checkid.ID("cpu:loaded-source-id")
-	loader := &recordingSchedulerLoader{name: "core", normalCheckID: sourceID}
+	var calls []schedulerLoadCall
+	var modes []core.LoadMode
+	registerRecordingCoreCheck("cpu", sourceID, false, &calls, &modes)
+	loader, err := core.NewGoCheckLoader()
+	require.NoError(t, err)
 	s := CheckScheduler{
 		configToChecks:      make(map[string][]checkid.ID),
 		senderManager:       normalSenderManager,
@@ -182,6 +186,7 @@ func TestGetChecksFromConfigsLoadsSelectedShadowCheckWithSenderManagerOverride(t
 	assert.Equal(t, sourceID, normalCheck.ID())
 	assert.Equal(t, check.ShadowID(sourceID), shadowCheck.ID())
 	assert.Equal(t, time.Second, shadowCheck.Interval())
+	assert.Equal(t, []core.LoadMode{core.NormalLoadMode, core.ShadowLoadMode}, modes)
 
 	shadowSenderOverride, ok := check.SenderManagerOverride(shadowCheck)
 	require.True(t, ok)
@@ -190,15 +195,15 @@ func TestGetChecksFromConfigsLoadsSelectedShadowCheckWithSenderManagerOverride(t
 	assert.Same(t, shadowSenderManager, shadowSenderOverrideAdapter.SenderManager)
 
 	assert.Equal(t, []checkid.ID{sourceID, check.ShadowID(sourceID)}, s.configToChecks[config.Digest()])
-	require.Len(t, loader.calls, 2)
-	assert.Same(t, normalSenderManager, loader.calls[0].senderManager)
-	shadowLoadSenderManager, ok := loader.calls[1].senderManager.(*shadowCheckSenderManager)
+	require.Len(t, calls, 2)
+	assert.Same(t, normalSenderManager, calls[0].senderManager)
+	shadowLoadSenderManager, ok := calls[1].senderManager.(*shadowCheckSenderManager)
 	require.True(t, ok)
 	assert.Same(t, shadowSenderManager, shadowLoadSenderManager.SenderManager)
-	assert.NotContains(t, string(loader.calls[0].instance), "_datadog")
-	assert.Contains(t, string(loader.calls[1].instance), "_datadog")
-	assert.Contains(t, string(loader.calls[1].instance), "execution_mode")
-	assert.NotEqual(t, check.ShadowID(sourceID), loader.calls[1].checkID)
+	assert.NotContains(t, string(calls[0].instance), "_datadog")
+	assert.Contains(t, string(calls[1].instance), "_datadog")
+	assert.Contains(t, string(calls[1].instance), "execution_mode")
+	assert.NotEqual(t, check.ShadowID(sourceID), calls[1].checkID)
 	assert.Equal(t, []checkid.ID{sourceID, sourceID}, normalSenderManager.requestedIDs)
 	assert.Equal(t, []checkid.ID{sourceID}, normalSenderManager.infraTaggedIDs)
 	assert.Equal(t, []checkid.ID{check.ShadowID(sourceID), check.ShadowID(sourceID)}, shadowSenderManager.requestedIDs)
@@ -212,7 +217,11 @@ func TestGetChecksFromConfigsDoesNotLoadShadowChecksWhenCacheIsNotPopulated(t *t
 
 	normalSenderManager := &recordingSchedulerSenderManager{name: "normal"}
 	shadowSenderManager := &recordingSchedulerSenderManager{name: "shadow"}
-	loader := &recordingSchedulerLoader{name: "core"}
+	var calls []schedulerLoadCall
+	var modes []core.LoadMode
+	registerRecordingCoreCheck("cpu", "", false, &calls, &modes)
+	loader, err := core.NewGoCheckLoader()
+	require.NoError(t, err)
 	s := CheckScheduler{
 		configToChecks:      make(map[string][]checkid.ID),
 		senderManager:       normalSenderManager,
@@ -231,8 +240,9 @@ func TestGetChecksFromConfigsDoesNotLoadShadowChecksWhenCacheIsNotPopulated(t *t
 	require.Len(t, checks, 1)
 	assert.False(t, check.IsShadow(checks[0]))
 	assert.Empty(t, s.configToChecks)
-	require.Len(t, loader.calls, 1)
-	assert.Same(t, normalSenderManager, loader.calls[0].senderManager)
+	assert.Equal(t, []core.LoadMode{core.NormalLoadMode}, modes)
+	require.Len(t, calls, 1)
+	assert.Same(t, normalSenderManager, calls[0].senderManager)
 	assert.Empty(t, shadowSenderManager.requestedIDs)
 }
 
@@ -242,7 +252,11 @@ func TestGetChecksFromConfigsUsesFallbackShadowSenderManager(t *testing.T) {
 	cfg.SetInTest("metric_lookback.enabled_checks", []string{"cpu"})
 
 	normalSenderManager := &recordingSchedulerSenderManager{name: "normal"}
-	loader := &recordingSchedulerLoader{name: "core"}
+	var calls []schedulerLoadCall
+	var modes []core.LoadMode
+	registerRecordingCoreCheck("cpu", "", false, &calls, &modes)
+	loader, err := core.NewGoCheckLoader()
+	require.NoError(t, err)
 	s := CheckScheduler{
 		configToChecks: make(map[string][]checkid.ID),
 		senderManager:  normalSenderManager,
@@ -261,11 +275,12 @@ func TestGetChecksFromConfigsUsesFallbackShadowSenderManager(t *testing.T) {
 	assert.False(t, check.IsShadow(checks[0]))
 	assert.True(t, check.IsShadow(checks[1]))
 	assert.Equal(t, []checkid.ID{checks[0].ID(), checks[1].ID()}, s.configToChecks[config.Digest()])
-	require.Len(t, loader.calls, 2)
-	assert.Same(t, normalSenderManager, loader.calls[0].senderManager)
+	assert.Equal(t, []core.LoadMode{core.NormalLoadMode, core.ShadowLoadMode}, modes)
+	require.Len(t, calls, 2)
+	assert.Same(t, normalSenderManager, calls[0].senderManager)
 	assert.NotNil(t, s.shadowSenderManager)
-	assert.NotEqual(t, normalSenderManager, loader.calls[1].senderManager)
-	shadowCallSenderManager, ok := loader.calls[1].senderManager.(*shadowCheckSenderManager)
+	assert.NotEqual(t, normalSenderManager, calls[1].senderManager)
+	shadowCallSenderManager, ok := calls[1].senderManager.(*shadowCheckSenderManager)
 	require.True(t, ok)
 	assert.Equal(t, s.shadowSenderManager, shadowCallSenderManager.SenderManager)
 	assert.Equal(t, checks[1].ID(), shadowCallSenderManager.shadowCheckID)
@@ -278,7 +293,11 @@ func TestGetChecksFromConfigsKeepsNormalCheckWhenShadowLoadFails(t *testing.T) {
 
 	normalSenderManager := &recordingSchedulerSenderManager{name: "normal"}
 	shadowSenderManager := &recordingSchedulerSenderManager{name: "shadow"}
-	loader := &recordingSchedulerLoader{name: "core", failShadowLoad: true}
+	var calls []schedulerLoadCall
+	var modes []core.LoadMode
+	registerRecordingCoreCheck("cpu", "", true, &calls, &modes)
+	loader, err := core.NewGoCheckLoader()
+	require.NoError(t, err)
 	s := CheckScheduler{
 		configToChecks:      make(map[string][]checkid.ID),
 		senderManager:       normalSenderManager,
@@ -297,7 +316,8 @@ func TestGetChecksFromConfigsKeepsNormalCheckWhenShadowLoadFails(t *testing.T) {
 	require.Len(t, checks, 1)
 	assert.False(t, check.IsShadow(checks[0]))
 	assert.Equal(t, []checkid.ID{checks[0].ID()}, s.configToChecks[config.Digest()])
-	assert.Len(t, loader.calls, 2)
+	assert.Equal(t, []core.LoadMode{core.NormalLoadMode, core.ShadowLoadMode}, modes)
+	assert.Len(t, calls, 2)
 	assert.Equal(t, []checkid.ID{check.ShadowID(checks[0].ID())}, shadowSenderManager.destroyedIDs)
 }
 
@@ -326,6 +346,58 @@ func TestInitCheckSchedulerDoesNotCreateShadowSenderContext(t *testing.T) {
 
 	assert.Nil(t, s.shadowSenderContext)
 	assert.Nil(t, s.shadowSenderCancel)
+}
+
+func TestGetChecksFromConfigsSkipsShadowCheckForUnsupportedLoader(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("metric_lookback.enabled", true)
+
+	normalSenderManager := &recordingSchedulerSenderManager{name: "normal"}
+	shadowSenderManager := &recordingSchedulerSenderManager{name: "shadow"}
+	loader := &recordingSchedulerLoader{name: "sharedlibrary"}
+	s := CheckScheduler{
+		configToChecks:      make(map[string][]checkid.ID),
+		senderManager:       normalSenderManager,
+		shadowSenderManager: shadowSenderManager,
+	}
+	s.addLoader(loader)
+
+	config := integration.Config{
+		Name:       "custom_native",
+		Instances:  []integration.Data{integration.Data("name: first\n")},
+		InitConfig: integration.Data("{}"),
+	}
+
+	checks := s.GetChecksFromConfigs([]integration.Config{config}, true)
+
+	require.Len(t, checks, 1)
+	assert.False(t, check.IsShadow(checks[0]))
+	assert.Equal(t, []checkid.ID{checks[0].ID()}, s.configToChecks[config.Digest()])
+	require.Len(t, loader.calls, 1)
+	assert.Same(t, normalSenderManager, loader.calls[0].senderManager)
+	assert.Empty(t, shadowSenderManager.requestedIDs)
+	assert.Empty(t, shadowSenderManager.destroyedIDs)
+}
+
+func TestShadowLoaderForPythonReusesLoadedLoader(t *testing.T) {
+	loader := &recordingSchedulerLoader{name: "python"}
+
+	shadowLoader, ok := shadowLoaderFor(loader)
+
+	require.True(t, ok)
+	assert.Same(t, loader, shadowLoader)
+}
+
+func TestShadowLoaderForCoreUsesShadowLoadMode(t *testing.T) {
+	loader, err := core.NewGoCheckLoader()
+	require.NoError(t, err)
+
+	shadowLoader, ok := shadowLoaderFor(loader)
+
+	require.True(t, ok)
+	shadowCoreLoader, ok := shadowLoader.(*core.GoCheckLoader)
+	require.True(t, ok)
+	assert.Equal(t, core.ShadowLoadMode, shadowCoreLoader.LoadMode())
 }
 
 // MockCollector is a mock implementation of collectorcomp.Component for testing
@@ -376,6 +448,51 @@ func (l *recordingSchedulerLoader) Load(senderManager sender.SenderManager, conf
 		LoaderName: l.Name(),
 		CheckID:    checkID,
 	}, nil
+}
+
+type recordingCoreCheck struct {
+	MockCheck
+	mode           core.LoadMode
+	normalCheckID  checkid.ID
+	failShadowLoad bool
+	calls          *[]schedulerLoadCall
+	modes          *[]core.LoadMode
+}
+
+func registerRecordingCoreCheck(name string, normalCheckID checkid.ID, failShadowLoad bool, calls *[]schedulerLoadCall, modes *[]core.LoadMode) {
+	core.RegisterContextualCheck(name, option.New(func(ctx core.ConstructionContext) check.Check {
+		return &recordingCoreCheck{
+			MockCheck: MockCheck{
+				Name:       name,
+				LoaderName: core.GoCheckLoaderName,
+			},
+			mode:           ctx.Mode,
+			normalCheckID:  normalCheckID,
+			failShadowLoad: failShadowLoad,
+			calls:          calls,
+			modes:          modes,
+		}
+	}))
+}
+
+func (c *recordingCoreCheck) Configure(senderManager sender.SenderManager, digest uint64, instance integration.Data, initConfig integration.Data, _ string, _ string) error {
+	checkID := checkid.BuildID(c.Name, digest, instance, initConfig)
+	if c.normalCheckID != "" && c.mode == core.NormalLoadMode {
+		checkID = c.normalCheckID
+	}
+	c.CheckID = checkID
+	*c.calls = append(*c.calls, schedulerLoadCall{
+		senderManager: senderManager,
+		config:        integration.Config{Name: c.Name, InitConfig: initConfig},
+		instance:      append(integration.Data(nil), instance...),
+		checkID:       checkID,
+	})
+	*c.modes = append(*c.modes, c.mode)
+	if c.failShadowLoad && c.mode == core.ShadowLoadMode {
+		return errors.New("shadow load failed")
+	}
+	_, err := senderManager.GetSender(checkID)
+	return err
 }
 
 type recordingSchedulerSenderManager struct {

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -20,6 +20,7 @@ import (
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
 	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/agentprofiling"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cloud/hostinfo"
@@ -80,16 +81,22 @@ func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Com
 	telemetry telemetry.Component, rcClient rcclient.Component, flare flare.Component, snmpScanManager snmpscanmanager.Component,
 	traceroute traceroute.Component, ncmComp option.Option[networkconfigmanagement.Component],
 ) {
+	telemetryForMode := telemetryProviderForLoadMode(telemetry)
+
 	// Required checks
 	corecheckLoader.RegisterCheck(cpu.CheckName, cpu.Factory())
 	corecheckLoader.RegisterCheck(memory.CheckName, memory.Factory())
 	corecheckLoader.RegisterCheck(uptime.CheckName, uptime.Factory())
 	corecheckLoader.RegisterCheck(hostinfo.CheckName, hostinfo.Factory())
-	corecheckLoader.RegisterCheck(telemetryCheck.CheckName, telemetryCheck.Factory(telemetry))
+	corecheckLoader.RegisterContextualCheck(telemetryCheck.CheckName, contextualCoreFactory(func(corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
+		return telemetryCheck.Factory(telemetry)
+	}))
 	corecheckLoader.RegisterCheck(ntp.CheckName, ntp.Factory())
 	corecheckLoader.RegisterCheck(wlan.CheckName, wlan.Factory())
 	corecheckLoader.RegisterCheck(snmp.CheckName, snmp.Factory(cfg, rcClient, snmpScanManager))
-	corecheckLoader.RegisterCheck(networkpath.CheckName, networkpath.Factory(telemetry, traceroute))
+	corecheckLoader.RegisterContextualCheck(networkpath.CheckName, contextualCoreFactory(func(ctx corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
+		return networkpath.Factory(telemetryForMode(ctx), traceroute)
+	}))
 	corecheckLoader.RegisterCheck(io.CheckName, io.Factory())
 	corecheckLoader.RegisterCheck(filehandles.CheckName, filehandles.Factory())
 	corecheckLoader.RegisterCheck(containerimage.CheckName, containerimage.Factory(store, tagger))
@@ -104,8 +111,12 @@ func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Com
 	corecheckLoader.RegisterCheck(helm.CheckName, helm.Factory())
 	corecheckLoader.RegisterCheck(pod.CheckName, pod.Factory(store, cfg, tagger))
 	corecheckLoader.RegisterCheck(kubeletconfig.CheckName, kubeletconfig.Factory(store, cfg, tagger))
-	corecheckLoader.RegisterCheck(gpu.CheckName, gpu.Factory(tagger, telemetry, store))
-	corecheckLoader.RegisterCheck(nccl.CheckName, nccl.Factory(tagger, telemetry, store))
+	corecheckLoader.RegisterContextualCheck(gpu.CheckName, contextualCoreFactory(func(ctx corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
+		return gpu.Factory(tagger, telemetryForMode(ctx), store)
+	}))
+	corecheckLoader.RegisterContextualCheck(nccl.CheckName, contextualCoreFactory(func(ctx corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
+		return nccl.Factory(tagger, telemetryForMode(ctx), store)
+	}))
 	corecheckLoader.RegisterCheck(ecs.CheckName, ecs.Factory(store, tagger))
 	corecheckLoader.RegisterCheck(apm.CheckName, apm.Factory())
 	corecheckLoader.RegisterCheck(process.CheckName, process.Factory())

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -88,8 +88,8 @@ func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Com
 	corecheckLoader.RegisterCheck(memory.CheckName, memory.Factory())
 	corecheckLoader.RegisterCheck(uptime.CheckName, uptime.Factory())
 	corecheckLoader.RegisterCheck(hostinfo.CheckName, hostinfo.Factory())
-	corecheckLoader.RegisterContextualCheck(telemetryCheck.CheckName, contextualCoreFactory(func(corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
-		return telemetryCheck.Factory(telemetry)
+	corecheckLoader.RegisterContextualCheck(telemetryCheck.CheckName, contextualCoreFactory(func(ctx corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
+		return telemetryCheck.Factory(telemetryForMode(ctx))
 	}))
 	corecheckLoader.RegisterCheck(ntp.CheckName, ntp.Factory())
 	corecheckLoader.RegisterCheck(wlan.CheckName, wlan.Factory())

--- a/pkg/commonchecks/corechecks_context.go
+++ b/pkg/commonchecks/corechecks_context.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package commonchecks
+
+import (
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	noopsimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+func telemetryProviderForLoadMode(normalTelemetry telemetry.Component) func(corecheckLoader.ConstructionContext) telemetry.Component {
+	shadowTelemetry := noopsimpl.NewComponent()
+	return func(ctx corecheckLoader.ConstructionContext) telemetry.Component {
+		if ctx.Mode == corecheckLoader.ShadowLoadMode {
+			return shadowTelemetry
+		}
+		return normalTelemetry
+	}
+}
+
+func contextualCoreFactory(factoryForContext func(corecheckLoader.ConstructionContext) option.Option[func() check.Check]) option.Option[func(corecheckLoader.ConstructionContext) check.Check] {
+	normalFactory := factoryForContext(corecheckLoader.ConstructionContext{Mode: corecheckLoader.NormalLoadMode})
+	_, ok := normalFactory.Get()
+	if !ok {
+		return option.None[func(corecheckLoader.ConstructionContext) check.Check]()
+	}
+
+	return option.New(func(ctx corecheckLoader.ConstructionContext) check.Check {
+		factoryForMode := factoryForContext(ctx)
+		factory, ok := factoryForMode.Get()
+		if !ok {
+			return nil
+		}
+		return factory()
+	})
+}

--- a/pkg/commonchecks/corechecks_test.go
+++ b/pkg/commonchecks/corechecks_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package commonchecks
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/stub"
+	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+func TestTelemetryProviderForLoadMode(t *testing.T) {
+	normalTelemetry := telemetryimpl.NewMockComponent()
+	provider := telemetryProviderForLoadMode(normalTelemetry)
+
+	require.Equal(t, componentPointer(normalTelemetry), componentPointer(provider(corecheckLoader.ConstructionContext{Mode: corecheckLoader.NormalLoadMode})))
+
+	shadowTelemetry := provider(corecheckLoader.ConstructionContext{Mode: corecheckLoader.ShadowLoadMode})
+	require.NotEqual(t, componentPointer(normalTelemetry), componentPointer(shadowTelemetry))
+	require.Equal(t, componentPointer(shadowTelemetry), componentPointer(provider(corecheckLoader.ConstructionContext{Mode: corecheckLoader.ShadowLoadMode})))
+}
+
+func componentPointer(component any) uintptr {
+	return reflect.ValueOf(component).Pointer()
+}
+
+func TestContextualCoreFactoryEvaluatesContextAtConstructionTime(t *testing.T) {
+	var modes []corecheckLoader.LoadMode
+	contextualFactory := contextualCoreFactory(func(ctx corecheckLoader.ConstructionContext) option.Option[func() check.Check] {
+		modes = append(modes, ctx.Mode)
+		return option.New(func() check.Check {
+			return &stub.StubCheck{}
+		})
+	})
+
+	factory, ok := contextualFactory.Get()
+	require.True(t, ok)
+
+	loadedCheck := factory(corecheckLoader.ConstructionContext{Mode: corecheckLoader.ShadowLoadMode})
+
+	require.NotNil(t, loadedCheck)
+	require.Equal(t, []corecheckLoader.LoadMode{corecheckLoader.NormalLoadMode, corecheckLoader.ShadowLoadMode}, modes)
+}


### PR DESCRIPTION
### What does this PR do?

Adds safety gates for metric lookback shadow loading so only supported loaders can construct shadow checks, and core shadow checks use shadow-safe telemetry dependencies.

- Core checks are constructed with normal or shadow mode so checks with internal telemetry can avoid duplicate telemetry registration in shadow runs.
- Python shadow checks continue to use the Python loader with shadow execution indicated by the mutated instance config and routed through the shadow sender.
- Unsupported loaders are skipped for shadow execution while still allowing the normal check to load.

### Motivation

[QB1HZ-24](https://datadoghq.atlassian.net/browse/QB1HZ-24) follows up on the metric lookback shadow-loading stack after GPU shadow loading exposed duplicate check-internal telemetry registration when a normal core check and its shadow copy run in the same Agent process.

The shadow path should preserve normal check behavior and still evaluate emitted metric streams, but it should not accidentally run unsupported loader types or duplicate constructor-level telemetry collectors.

### Describe how you validated your changes

- Added unit coverage for core loader normal/shadow construction mode and legacy factory registration.
- Added scheduler coverage for shadow loader selection, unsupported loader skips, shadow sender routing, and core shadow-mode loading.
- Added commonchecks coverage for normal vs shadow telemetry provider behavior.
- Added the missing Bazel dependency for the collector library.

```bash
dda inv test --targets=./pkg/collector --build-exclude=python
dda inv test --targets=./pkg/commonchecks --build-exclude=python
dda inv test --targets=./pkg/collector/python
dda inv linter.go --targets=./pkg/collector,./pkg/collector/check,./pkg/collector/corechecks,./pkg/collector/python,./pkg/commonchecks --cpus=8 --timeout=20
bazel build //pkg/collector:collector
git diff --check ella/mlb-v2-shared-check-loading..HEAD
```

### Additional Notes

Related stack PR: [DataDog/datadog-agent#53174](https://github.com/DataDog/datadog-agent/pull/53174).

Shadow core checks use noop check-internal telemetry for mode-aware factories, while normal check telemetry and metric lookback feature telemetry remain real. Python shadow mode is config-driven rather than loader-construction-driven.

[QB1HZ-24]: https://datadoghq.atlassian.net/browse/QB1HZ-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ