### PR TITLE
SLES-2913: stop dogstatsd if there are no listeners, optionally

### DIFF
--- a/comp/dogstatsd/server/impl/server.go
+++ b/comp/dogstatsd/server/impl/server.go
@@ -373,7 +373,7 @@ func (s *dsdServer) startHook(context context.Context) error {
 		return nil
 	}
 	if s.config.GetBool("dogstatsd_require_listener") {
-		return err
+		return fmt.Errorf("dogstatsd start failed: %w", err)
 	}
 	s.log.Errorf("Could not start dogstatsd: %s", err)
 	return nil

--- a/comp/dogstatsd/server/impl/server.go
+++ b/comp/dogstatsd/server/impl/server.go
@@ -368,11 +368,14 @@ func newServerCompat(cfg model.ReaderWriter, log log.Component, hostname hostnam
 
 func (s *dsdServer) startHook(context context.Context) error {
 	err := s.start(context)
-	if err != nil {
-		s.log.Errorf("Could not start dogstatsd: %s", err)
-	} else {
+	if err == nil {
 		s.log.Debug("dogstatsd started")
+		return nil
 	}
+	if s.config.GetBool("dogstatsd_require_listener") {
+		return err
+	}
+	s.log.Errorf("Could not start dogstatsd: %s", err)
 	return nil
 }
 

--- a/comp/dogstatsd/server/impl/server.go
+++ b/comp/dogstatsd/server/impl/server.go
@@ -366,13 +366,19 @@ func newServerCompat(cfg model.ReaderWriter, log log.Component, hostname hostnam
 	return s
 }
 
+// errNoListeners is returned by start when no listener could be created, leaving
+// DogStatsD with no way to receive metrics. It is the only startup failure that
+// dogstatsd_require_listener treats as fatal. The message is preserved verbatim
+// because operators may match on it; add context by wrapping rather than editing.
+var errNoListeners = errors.New("listening on neither udp nor socket, please check your configuration")
+
 func (s *dsdServer) startHook(context context.Context) error {
 	err := s.start(context)
 	if err == nil {
 		s.log.Debug("dogstatsd started")
 		return nil
 	}
-	if s.config.GetBool("dogstatsd_require_listener") {
+	if errors.Is(err, errNoListeners) && s.config.GetBool("dogstatsd_require_listener") {
 		return fmt.Errorf("dogstatsd start failed: %w", err)
 	}
 	s.log.Errorf("Could not start dogstatsd: %s", err)
@@ -451,7 +457,7 @@ func (s *dsdServer) start(context.Context) error {
 	}
 
 	if len(tmpListeners) == 0 {
-		return errors.New("listening on neither udp nor socket, please check your configuration")
+		return errNoListeners
 	}
 
 	s.packetsIn = packetsChannel

--- a/comp/dogstatsd/server/impl/server.go
+++ b/comp/dogstatsd/server/impl/server.go
@@ -366,10 +366,8 @@ func newServerCompat(cfg model.ReaderWriter, log log.Component, hostname hostnam
 	return s
 }
 
-// errNoListeners is returned by start when no listener could be created, leaving
-// DogStatsD with no way to receive metrics. It is the only startup failure that
-// dogstatsd_require_listener treats as fatal. The message is preserved verbatim
-// because operators may match on it; add context by wrapping rather than editing.
+// errNoListeners is the only startup failure that dogstatsd_require_listener
+// treats as fatal.
 var errNoListeners = errors.New("listening on neither udp nor socket, please check your configuration")
 
 func (s *dsdServer) startHook(context context.Context) error {

--- a/comp/dogstatsd/server/impl/server_test.go
+++ b/comp/dogstatsd/server/impl/server_test.go
@@ -49,7 +49,7 @@ func TestStartHookNoListenerRequireListener(t *testing.T) {
 	cfg["dogstatsd_require_listener"] = true
 
 	_, s := fulfillDepsWithInactiveServer(t, cfg)
-	require.Error(t, s.startHook(context.Background()), "startHook should return an error when no listener could be created and dogstatsd_require_listener is set")
+	require.ErrorIs(t, s.startHook(context.Background()), errNoListeners, "startHook should return errNoListeners when no listener could be created and dogstatsd_require_listener is set")
 }
 
 func TestStartHookNoListenerDefault(t *testing.T) {

--- a/comp/dogstatsd/server/impl/server_test.go
+++ b/comp/dogstatsd/server/impl/server_test.go
@@ -8,6 +8,7 @@
 package serverimpl
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -30,6 +31,30 @@ func TestNewServer(t *testing.T) {
 
 	deps := fulfillDepsWithConfigOverride(t, cfg)
 	requireStart(t, deps.Server)
+}
+
+// noListenerConfig disables every listener (no UDP port, socket, or named pipe) so that
+// start() ends up with zero listeners.
+func noListenerConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"dogstatsd_port":          0,
+		"dogstatsd_socket":        "",
+		"dogstatsd_pipe_name":     "",
+		"dogstatsd_stream_socket": "",
+	}
+}
+
+func TestStartHookNoListenerRequireListener(t *testing.T) {
+	cfg := noListenerConfig()
+	cfg["dogstatsd_require_listener"] = true
+
+	_, s := fulfillDepsWithInactiveServer(t, cfg)
+	require.Error(t, s.startHook(context.Background()), "startHook should return an error when no listener could be created and dogstatsd_require_listener is set")
+}
+
+func TestStartHookNoListenerDefault(t *testing.T) {
+	_, s := fulfillDepsWithInactiveServer(t, noListenerConfig())
+	require.NoError(t, s.startHook(context.Background()), "startHook should swallow the no-listener error when dogstatsd_require_listener is not set")
 }
 
 func TestNewServerUseDogstatsdFalse(t *testing.T) {

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2480,6 +2480,15 @@ api_key:
 #
 # dogstatsd_port: 8125
 
+## @param dogstatsd_require_listener - boolean - optional - default: false
+## @env DD_DOGSTATSD_REQUIRE_LISTENER - boolean - optional - default: false
+## When enabled, DogStatsD fails to start (the process exits with a non-zero status) if it
+## cannot create any listener (UDP port, Unix socket, or named pipe). When disabled, such a
+## failure is only logged and the process keeps running with no way to receive metrics.
+## Enable this so a process supervisor can detect and restart a non-functional DogStatsD.
+#
+# dogstatsd_require_listener: false
+
 ## @param bind_host - string - optional - default: ""
 ## @env DD_BIND_HOST - string - optional - default: ""
 ## The host to listen on for Dogstatsd and traces. This is ignored by APM when

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2482,11 +2482,11 @@ api_key:
 
 ## @param dogstatsd_require_listener - boolean - optional - default: false
 ## @env DD_DOGSTATSD_REQUIRE_LISTENER - boolean - optional - default: false
-## When enabled, DogStatsD fails to start (the process exits with a non-zero status) on any
-## startup error. The most common such error is being unable to create any listener (UDP
-## port, Unix socket, or named pipe), which would leave DogStatsD with no way to receive
-## metrics. When disabled, a startup failure is only logged and the process keeps running.
-## Enable this so a process supervisor can detect and restart a non-functional DogStatsD.
+## When enabled, DogStatsD fails to start (the process exits with a non-zero status) if it
+## cannot create any listener (UDP port, Unix socket, or named pipe), which would leave
+## DogStatsD with no way to receive metrics. When disabled, this failure is only logged and
+## the process keeps running. Enable this so a process supervisor can detect and restart a
+## non-functional DogStatsD.
 #
 # dogstatsd_require_listener: false
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2482,9 +2482,10 @@ api_key:
 
 ## @param dogstatsd_require_listener - boolean - optional - default: false
 ## @env DD_DOGSTATSD_REQUIRE_LISTENER - boolean - optional - default: false
-## When enabled, DogStatsD fails to start (the process exits with a non-zero status) if it
-## cannot create any listener (UDP port, Unix socket, or named pipe). When disabled, such a
-## failure is only logged and the process keeps running with no way to receive metrics.
+## When enabled, DogStatsD fails to start (the process exits with a non-zero status) on any
+## startup error. The most common such error is being unable to create any listener (UDP
+## port, Unix socket, or named pipe), which would leave DogStatsD with no way to receive
+## metrics. When disabled, a startup failure is only logged and the process keeps running.
 ## Enable this so a process supervisor can detect and restart a non-functional DogStatsD.
 #
 # dogstatsd_require_listener: false

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -2203,16 +2203,17 @@ properties:
     default: false
     visibility: public
     description: |-
-      When enabled, DogStatsD fails to start (the process exits with a non-zero status) if it
-      cannot create any listener (UDP port, Unix socket, or named pipe). When disabled, such a
-      failure is only logged and the process keeps running with no way to receive metrics.
+      When enabled, DogStatsD fails to start (the process exits with a non-zero status) on any
+      startup error. The most common such error is being unable to create any listener (UDP
+      port, Unix socket, or named pipe), which would leave DogStatsD with no way to receive
+      metrics. When disabled, a startup failure is only logged and the process keeps running.
       Enable this so a process supervisor can detect and restart a non-functional DogStatsD.
     tags:
     - template_section:Dogstatsd
     comment: |-
-      When true, DogStatsD fails to start (the process exits non-zero) if no listener
-      (UDP port, UDS socket, or named pipe) could be created. When false, the failure is
-      only logged and the process keeps running without any way to receive metrics.
+      When true, DogStatsD fails to start (the process exits non-zero) on any startup error,
+      most commonly when no listener (UDP port, UDS socket, or named pipe) could be created.
+      When false, the failure is only logged and the process keeps running.
   bind_host:
     node_type: setting
     type: string

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -2197,6 +2197,22 @@ properties:
     tags:
     - template_section:Dogstatsd
     comment: 'Notice: 0 means UDP port closed'
+  dogstatsd_require_listener:
+    node_type: setting
+    type: boolean
+    default: false
+    visibility: public
+    description: |-
+      When enabled, DogStatsD fails to start (the process exits with a non-zero status) if it
+      cannot create any listener (UDP port, Unix socket, or named pipe). When disabled, such a
+      failure is only logged and the process keeps running with no way to receive metrics.
+      Enable this so a process supervisor can detect and restart a non-functional DogStatsD.
+    tags:
+    - template_section:Dogstatsd
+    comment: |-
+      When true, DogStatsD fails to start (the process exits non-zero) if no listener
+      (UDP port, UDS socket, or named pipe) could be created. When false, the failure is
+      only logged and the process keeps running without any way to receive metrics.
   bind_host:
     node_type: setting
     type: string

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -2203,17 +2203,17 @@ properties:
     default: false
     visibility: public
     description: |-
-      When enabled, DogStatsD fails to start (the process exits with a non-zero status) on any
-      startup error. The most common such error is being unable to create any listener (UDP
-      port, Unix socket, or named pipe), which would leave DogStatsD with no way to receive
-      metrics. When disabled, a startup failure is only logged and the process keeps running.
-      Enable this so a process supervisor can detect and restart a non-functional DogStatsD.
+      When enabled, DogStatsD fails to start (the process exits with a non-zero status) if it
+      cannot create any listener (UDP port, Unix socket, or named pipe), which would leave
+      DogStatsD with no way to receive metrics. When disabled, this failure is only logged and
+      the process keeps running. Enable this so a process supervisor can detect and restart a
+      non-functional DogStatsD.
     tags:
     - template_section:Dogstatsd
     comment: |-
-      When true, DogStatsD fails to start (the process exits non-zero) on any startup error,
-      most commonly when no listener (UDP port, UDS socket, or named pipe) could be created.
-      When false, the failure is only logged and the process keeps running.
+      When true, DogStatsD fails to start (the process exits non-zero) when no listener
+      (UDP port, UDS socket, or named pipe) could be created. When false, the failure is
+      only logged and the process keeps running.
   bind_host:
     node_type: setting
     type: string

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1655,9 +1655,9 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("use_dogstatsd", true)
 	config.BindEnvAndSetDefault("dogstatsd_port", 8125) // Notice: 0 means UDP port closed
 	config.BindEnvAndSetDefault("dogstatsd_pipe_name", "")
-	// When true, DogStatsD fails to start (the process exits non-zero) on any startup error,
-	// most commonly when no listener (UDP port, UDS socket, or named pipe) could be created.
-	// When false, the failure is only logged and the process keeps running.
+	// When true, DogStatsD fails to start (the process exits non-zero) when no listener
+	// (UDP port, UDS socket, or named pipe) could be created. When false, the failure is
+	// only logged and the process keeps running.
 	config.BindEnvAndSetDefault("dogstatsd_require_listener", false)
 	// https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format
 	// https://learn.microsoft.com/en-us/windows/win32/secauthz/ace-strings

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1655,6 +1655,10 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("use_dogstatsd", true)
 	config.BindEnvAndSetDefault("dogstatsd_port", 8125) // Notice: 0 means UDP port closed
 	config.BindEnvAndSetDefault("dogstatsd_pipe_name", "")
+	// When true, DogStatsD fails to start (the process exits non-zero) if no listener
+	// (UDP port, UDS socket, or named pipe) could be created. When false, the failure is
+	// only logged and the process keeps running without any way to receive metrics.
+	config.BindEnvAndSetDefault("dogstatsd_require_listener", false)
 	// https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format
 	// https://learn.microsoft.com/en-us/windows/win32/secauthz/ace-strings
 	// https://learn.microsoft.com/en-us/windows/win32/secauthz/sid-strings

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1655,9 +1655,9 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("use_dogstatsd", true)
 	config.BindEnvAndSetDefault("dogstatsd_port", 8125) // Notice: 0 means UDP port closed
 	config.BindEnvAndSetDefault("dogstatsd_pipe_name", "")
-	// When true, DogStatsD fails to start (the process exits non-zero) if no listener
-	// (UDP port, UDS socket, or named pipe) could be created. When false, the failure is
-	// only logged and the process keeps running without any way to receive metrics.
+	// When true, DogStatsD fails to start (the process exits non-zero) on any startup error,
+	// most commonly when no listener (UDP port, UDS socket, or named pipe) could be created.
+	// When false, the failure is only logged and the process keeps running.
 	config.BindEnvAndSetDefault("dogstatsd_require_listener", false)
 	// https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format
 	// https://learn.microsoft.com/en-us/windows/win32/secauthz/ace-strings

--- a/releasenotes/notes/dogstatsd-require-listener-9a012473dfb5235d.yaml
+++ b/releasenotes/notes/dogstatsd-require-listener-9a012473dfb5235d.yaml
@@ -2,9 +2,7 @@
 enhancements:
   - |
     Add a new ``dogstatsd_require_listener`` configuration option (disabled by
-    default). When enabled, DogStatsD exits with a non-zero status on any
-    startup failure instead of continuing to run in a degraded state. The most
-    common such failure is being unable to create any listener (UDP port, Unix
-    socket, or named pipe), which would otherwise leave DogStatsD running with
-    no way to receive metrics. Enable it so a process supervisor can detect and
-    restart a non-functional DogStatsD.
+    default). When enabled, DogStatsD exits with a non-zero status if it cannot
+    create any listener (UDP port, Unix socket, or named pipe), which would
+    otherwise leave DogStatsD running with no way to receive metrics. Enable it
+    so a process supervisor can detect and restart a non-functional DogStatsD.

--- a/releasenotes/notes/dogstatsd-require-listener-9a012473dfb5235d.yaml
+++ b/releasenotes/notes/dogstatsd-require-listener-9a012473dfb5235d.yaml
@@ -2,7 +2,9 @@
 enhancements:
   - |
     Add a new ``dogstatsd_require_listener`` configuration option (disabled by
-    default). When enabled, DogStatsD exits with a non-zero status if it cannot
-    create any listener (UDP port, Unix socket, or named pipe) at startup,
-    instead of continuing to run without any way to receive metrics. Enable it
-    so a process supervisor can detect and restart a non-functional DogStatsD.
+    default). When enabled, DogStatsD exits with a non-zero status on any
+    startup failure instead of continuing to run in a degraded state. The most
+    common such failure is being unable to create any listener (UDP port, Unix
+    socket, or named pipe), which would otherwise leave DogStatsD running with
+    no way to receive metrics. Enable it so a process supervisor can detect and
+    restart a non-functional DogStatsD.

--- a/releasenotes/notes/dogstatsd-require-listener-9a012473dfb5235d.yaml
+++ b/releasenotes/notes/dogstatsd-require-listener-9a012473dfb5235d.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Add a new ``dogstatsd_require_listener`` configuration option (disabled by
+    default). When enabled, DogStatsD exits with a non-zero status if it cannot
+    create any listener (UDP port, Unix socket, or named pipe) at startup,
+    instead of continuing to run without any way to receive metrics. Enable it
+    so a process supervisor can detect and restart a non-functional DogStatsD.


### PR DESCRIPTION
### What does this PR do?
Optionally crashes dogstatsd if it doesn't manage to set up any listeners. This error already existed, but previously it was only logged.

### Motivation
Azure App Services sometimes tries to start overlapping `dogstatsd` servers with the Azure App Service Extension. These all try to use the same named pipe, and only the first one wins. The rest fail to get a pipe (and therefore any listener), but then just sit there, doing nothing.

### Describe how you validated your changes
Unit tests. Will also test in an actual azure app service environment to test this.