### PR TITLE
bazel: migrate cmd/privateactionrunner

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -71,8 +71,6 @@ exports_files(["go.mod"])
 # gazelle:exclude cmd/iot-agent
 # gazelle:exclude cmd/otel-agent/command
 # gazelle:exclude cmd/otel-agent/subcommands/run
-# gazelle:exclude cmd/privateactionrunner/subcommands/*.go
-# gazelle:exclude cmd/privateactionrunner/subcommands/run
 # gazelle:exclude cmd/process-agent/command
 # gazelle:exclude cmd/process-agent/subcommands
 # gazelle:exclude cmd/security-agent/*.go

--- a/cmd/privateactionrunner/BUILD.bazel
+++ b/cmd/privateactionrunner/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 go_library(
     name = "privateactionrunner_lib",
@@ -128,4 +130,15 @@ go_test(
         "@com_github_spf13_cobra//:cobra",
         "@com_github_stretchr_testify//require",
     ],
+)
+
+pkg_files(
+    name = "par_bin",
+    srcs = [":privateactionrunner"],
+    prefix = "bin/",
+)
+
+pkg_install(
+    name = "install",
+    srcs = [":par_bin"],
 )

--- a/cmd/privateactionrunner/BUILD.bazel
+++ b/cmd/privateactionrunner/BUILD.bazel
@@ -1,1 +1,131 @@
-# gazelle:ignore
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "privateactionrunner_lib",
+    srcs = [
+        "main.go",
+        "main_windows.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/cmd/privateactionrunner",
+    visibility = ["//visibility:private"],
+    deps = select({
+        "@rules_go//go/platform:aix": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:android": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:dragonfly": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:freebsd": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:illumos": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:js": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:netbsd": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:openbsd": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:osx": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:plan9": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:qnx": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:solaris": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//pkg/util/flavor",
+        ],
+        "@rules_go//go/platform:windows": [
+            "//cmd/internal/runcmd",
+            "//cmd/privateactionrunner/command",
+            "//cmd/privateactionrunner/subcommands",
+            "//cmd/privateactionrunner/subcommands/run",
+            "//pkg/util/flavor",
+            "//pkg/util/winutil/servicemain",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_binary(
+    name = "privateactionrunner",
+    embed = [":privateactionrunner_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "privateactionrunner_test",
+    srcs = ["main_test.go"],
+    embed = [":privateactionrunner_lib"],
+    gotags = ["test"],
+    deps = [
+        "//cmd/privateactionrunner/command",
+        "//cmd/privateactionrunner/subcommands",
+        "@com_github_spf13_cobra//:cobra",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/cmd/privateactionrunner/subcommands/BUILD.bazel
+++ b/cmd/privateactionrunner/subcommands/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "subcommands",
+    srcs = ["subcommands.go"],
+    importpath = "github.com/DataDog/datadog-agent/cmd/privateactionrunner/subcommands",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/privateactionrunner/command",
+        "//cmd/privateactionrunner/subcommands/rotateidentity",
+        "//cmd/privateactionrunner/subcommands/run",
+        "//cmd/privateactionrunner/subcommands/version",
+    ],
+)

--- a/cmd/privateactionrunner/subcommands/run/BUILD.bazel
+++ b/cmd/privateactionrunner/subcommands/run/BUILD.bazel
@@ -1,0 +1,73 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "run",
+    srcs = [
+        "command.go",
+        "service_windows.go",
+        "tagger.go",
+        "tagger_mock.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/cmd/privateactionrunner/subcommands/run",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/privateactionrunner/command",
+        "//comp/core",
+        "//comp/core/config",
+        "//comp/core/hostname/remotehostnameimpl",
+        "//comp/core/ipc/fx",
+        "//comp/core/log/def",
+        "//comp/core/settings/def",
+        "//comp/core/settings/fx",
+        "//comp/core/tagger/def",
+        "//comp/core/tagger/fx",
+        "//comp/core/tagger/fx-mock",
+        "//comp/core/tagger/mock",
+        "//comp/core/workloadmeta/def",
+        "//comp/core/workloadmeta/fx",
+        "//comp/core/workloadmeta/fx-mock",
+        "//comp/dogstatsd/statsd/fx",
+        "//comp/forwarder/eventplatform/def",
+        "//comp/forwarder/eventplatform/fx",
+        "//comp/forwarder/eventplatformreceiver/impl",
+        "//comp/networkpath/traceroute/fx-remote",
+        "//comp/privateactionrunner/def",
+        "//comp/privateactionrunner/fx",
+        "//comp/remote-config/rcclient/def",
+        "//comp/remote-config/rcclient/fx",
+        "//comp/remote-config/rcservice/fx",
+        "//comp/serializer/logscompression/fx",
+        "//pkg/config/settings",
+        "//pkg/config/setup",
+        "//pkg/util/defaultpaths",
+        "//pkg/util/fxutil",
+        "//pkg/version",
+        "@com_github_spf13_cobra//:cobra",
+        "@org_uber_go_fx//:fx",
+    ] + select({
+        "@rules_go//go/platform:windows": [
+            "//pkg/util/winutil/servicemain",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "run_test",
+    srcs = [
+        "command_test.go",
+        "service_windows_test.go",
+    ],
+    embed = [":run"],
+    gotags = ["test"],
+    deps = [
+        "//cmd/privateactionrunner/command",
+        "//pkg/util/fxutil",
+        "@com_github_stretchr_testify//require",
+    ] + select({
+        "@rules_go//go/platform:windows": [
+            "@com_github_stretchr_testify//assert",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -179,14 +179,7 @@ build do
 
   # Private action runner
   if not heroku_target? and not fips_mode?
-    command "dda inv -- -e privateactionrunner.build --install-path=#{install_dir} --flavor #{flavor_arg}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
-
-    if windows_target?
-      copy 'bin/privateactionrunner/privateactionrunner.exe', "#{install_dir}/bin/agent"
-      copy 'bin/privateactionrunner/privateactionrunner.exe.pdb', "#{install_dir}/bin/agent"
-    elsif not heroku_target?
-      copy 'bin/privateactionrunner/privateactionrunner', "#{install_dir}/embedded/bin"
-    end
+    command "bazel run #{bazel_flags} -- //cmd/privateactionrunner:install --destdir='#{install_dir}'"
   end
 
   # System-probe


### PR DESCRIPTION
### What does this PR do?

Migrate cmd/privateactionrunner and switch omnibus build to rely on bazel

### Motivation

Ongoing migration to bazel

### Describe how you validated your changes

Local builds, and CI for non-Linux platforms

### Additional Notes
