### PR TITLE
[ AGNTLOG-663 ] Forward complete blank lines through the multiline log parser

### DIFF
--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -769,3 +769,60 @@ func TestDecoderWithDockerJSONPartialLineDetectionOnlyMarksOversizedLogicalLineT
 	assert.Contains(t, output.ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
 	assert.Equal(t, len(line1)+len(line2), output.RawDataLen)
 }
+
+// TestDecoderKubernetesGoStackTraceAggregatesBlankLine is a regression test for
+// blank lines being silently dropped on the partial-line parser path used by
+// container/CRI log sources (Kubernetes, Docker JSON file). The Go stack trace
+// aggregator relies on the blank line that separates a panic header from its
+// goroutine block; when the MultiLineParser dropped that blank line the parser
+// state machine could not transition and abandoned aggregation, emitting the
+// crash as many individual lines instead of one combined message.
+func TestDecoderKubernetesGoStackTraceAggregatesBlankLine(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.Set("logs_config.auto_multi_line_detection", true, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.auto_multi_line.stack_trace_parsers", []string{"go"}, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.tag_multi_line_logs", true, pkgconfigmodel.SourceAgentRuntime)
+
+	source := sources.NewLogSource("", &config.LogsConfig{})
+	d := InitializeDecoderForTest(source, kubernetes.New())
+	d.Start()
+
+	// A Go panic exactly as a container runtime would emit it in CRI format:
+	// '<timestamp> <stream> <flag> <content>'. Note the blank line (empty
+	// content) between the panic header and the goroutine block.
+	criLine := func(content string) string {
+		return "2024-01-01T00:00:00.000000000Z stderr F " + content + "\n"
+	}
+	panicLines := []string{
+		"panic: something went wrong",
+		"",
+		"goroutine 1 [running]:",
+		"main.plainPanic(...)",
+		"\t/path/main.go:81",
+		"main.main()",
+		"\t/path/main.go:46 +0x5b4",
+	}
+	var input []byte
+	for _, l := range panicLines {
+		input = append(input, []byte(criLine(l))...)
+	}
+	d.InputChan() <- NewInput(input)
+
+	// Closing the input flushes the stack trace aggregator, emitting the
+	// combined crash as a single message.
+	d.Stop()
+
+	var outputs []*message.Message
+	for output := range d.OutputChan() {
+		outputs = append(outputs, output)
+	}
+
+	require.Len(t, outputs, 1, "expected the whole Go panic to aggregate into a single message")
+	combined := outputs[0]
+	assert.True(t, combined.ParsingExtra.IsMultiLine, "expected the combined crash to be tagged multi-line")
+	assert.Contains(t, combined.ParsingExtra.Tags, message.MultiLineSourceTag("go_stack"))
+	content := string(combined.GetContent())
+	assert.Contains(t, content, "panic: something went wrong")
+	assert.Contains(t, content, "goroutine 1 [running]:")
+	assert.Contains(t, content, "main.main()")
+}

--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -826,3 +826,319 @@ func TestDecoderKubernetesGoStackTraceAggregatesBlankLine(t *testing.T) {
 	assert.Contains(t, content, "goroutine 1 [running]:")
 	assert.Contains(t, content, "main.main()")
 }
+
+// TestDecoderGoStackTraceDisabledWithEmptyParsers confirms that even with auto
+// multi-line detection enabled, an empty logs_config.auto_multi_line.stack_trace_parsers
+// override disables Go stack trace aggregation: the same panic that combines into
+// a single go_stack-tagged message in TestDecoderKubernetesGoStackTraceAggregatesBlankLine
+// is instead emitted line-by-line, with no message carrying the go_stack tag.
+func TestDecoderGoStackTraceDisabledWithEmptyParsers(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.Set("logs_config.auto_multi_line_detection", true, pkgconfigmodel.SourceAgentRuntime)
+	// Empty override: no stack trace parsers -> feature disabled.
+	mockConfig.Set("logs_config.auto_multi_line.stack_trace_parsers", []string{}, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.tag_multi_line_logs", true, pkgconfigmodel.SourceAgentRuntime)
+
+	source := sources.NewLogSource("", &config.LogsConfig{})
+	d := InitializeDecoderForTest(source, kubernetes.New())
+	d.Start()
+
+	criLine := func(content string) string {
+		return "2024-01-01T00:00:00.000000000Z stderr F " + content + "\n"
+	}
+	panicLines := []string{
+		"panic: something went wrong",
+		"",
+		"goroutine 1 [running]:",
+		"main.plainPanic(...)",
+		"\t/path/main.go:81",
+		"main.main()",
+		"\t/path/main.go:46 +0x5b4",
+	}
+	var input []byte
+	for _, l := range panicLines {
+		input = append(input, []byte(criLine(l))...)
+	}
+	d.InputChan() <- NewInput(input)
+
+	d.Stop()
+
+	var outputs []*message.Message
+	for output := range d.OutputChan() {
+		outputs = append(outputs, output)
+	}
+
+	// With the feature disabled the panic is NOT combined: it comes through as
+	// multiple individual messages, and none of them carry the go_stack tag.
+	require.Greater(t, len(outputs), 1, "expected the panic to NOT be aggregated into a single message")
+	for _, out := range outputs {
+		assert.NotContains(t, out.ParsingExtra.Tags, message.MultiLineSourceTag("go_stack"),
+			"no message should be tagged go_stack when stack_trace_parsers is empty")
+	}
+	// The panic header line is still present in the (un-aggregated) output.
+	var sawPanicHeader bool
+	for _, out := range outputs {
+		if string(out.GetContent()) == "panic: something went wrong" {
+			sawPanicHeader = true
+		}
+	}
+	assert.True(t, sawPanicHeader, "expected the panic header to be emitted as its own message")
+}
+
+// TestGoStackTraceParsersEmptyListFromYAML confirms that the exact YAML string
+// "[]" for logs_config.auto_multi_line.stack_trace_parsers overrides the ["go"]
+// default with an empty slice (rather than being ignored and falling back to the
+// default), which is what disables Go stack trace aggregation.
+func TestGoStackTraceParsersEmptyListFromYAML(t *testing.T) {
+	// Sanity check: with the key absent, the default is ["go"].
+	defaultCfg := configmock.NewFromYAML(t, "logs_config:\n  auto_multi_line_detection: true\n")
+	require.Equal(t, []string{"go"},
+		defaultCfg.GetStringSlice("logs_config.auto_multi_line.stack_trace_parsers"),
+		"expected the built-in default to be [\"go\"] when the key is not set")
+
+	// The exact string "[]" in YAML must parse to an empty slice, overriding the default.
+	yaml := "logs_config:\n" +
+		"  auto_multi_line_detection: true\n" +
+		"  auto_multi_line:\n" +
+		"    stack_trace_parsers: []\n"
+	cfg := configmock.NewFromYAML(t, yaml)
+	got := cfg.GetStringSlice("logs_config.auto_multi_line.stack_trace_parsers")
+	assert.Empty(t, got, "expected YAML \"[]\" to produce an empty slice, got %#v", got)
+
+	// End-to-end: an empty slice yields the no-op aggregator (feature disabled).
+	agg := preprocessor.NewStackTraceAggregatorFromNames(got, 1000, true)
+	assert.True(t, agg.IsEmpty())
+	out := agg.Process(message.NewMessage([]byte("panic: boom"), nil, "", 0))
+	require.Len(t, out, 1, "no-op aggregator should pass the panic through unchanged")
+	assert.NotContains(t, out[0].ParsingExtra.Tags, message.MultiLineSourceTag("go_stack"))
+}
+
+// TestGoStackTraceParsersFromEnvVar confirms that
+// DD_LOGS_CONFIG_AUTO_MULTI_LINE_STACK_TRACE_PARSERS is the correct environment
+// variable binding for logs_config.auto_multi_line.stack_trace_parsers, and that
+// list values are provided space-separated.
+func TestGoStackTraceParsersFromEnvVar(t *testing.T) {
+	const key = "logs_config.auto_multi_line.stack_trace_parsers"
+
+	// Multiple values: space-separated, as the agent parses env string slices.
+	t.Setenv("DD_LOGS_CONFIG_AUTO_MULTI_LINE_STACK_TRACE_PARSERS", "go java")
+	cfg := configmock.New(t)
+	assert.Equal(t, []string{"go", "java"}, cfg.GetStringSlice(key),
+		"env var should override the default and parse as a space-separated list")
+
+	// Single value.
+	t.Setenv("DD_LOGS_CONFIG_AUTO_MULTI_LINE_STACK_TRACE_PARSERS", "go")
+	cfg = configmock.New(t)
+	assert.Equal(t, []string{"go"}, cfg.GetStringSlice(key))
+}
+
+// TestGoStackTraceParsersDisableViaEnvVar probes which env var VALUE actually
+// disables the feature, documenting the empty-string gotcha.
+func TestGoStackTraceParsersDisableViaEnvVar(t *testing.T) {
+	const key = "logs_config.auto_multi_line.stack_trace_parsers"
+	const envName = "DD_LOGS_CONFIG_AUTO_MULTI_LINE_STACK_TRACE_PARSERS"
+
+	// A real (enabled) aggregator buffers a "panic:" start line and emits
+	// nothing yet; the no-op (disabled) aggregator passes it straight through.
+	disabled := func(cfg pkgconfigmodel.Reader) bool {
+		agg := preprocessor.NewStackTraceAggregatorFromNames(
+			cfg.GetStringSlice(key), 1000, true)
+		out := agg.Process(message.NewMessage([]byte("panic: boom"), nil, "", 0))
+		return len(out) == 1 && agg.IsEmpty()
+	}
+
+	// Gotcha: an empty-string env var is treated as unset and falls back to the
+	// ["go"] default, so it does NOT disable the feature.
+	t.Run("empty string falls back to default", func(t *testing.T) {
+		t.Setenv(envName, "")
+		cfg := configmock.New(t)
+		assert.Equal(t, []string{"go"}, cfg.GetStringSlice(key))
+		assert.False(t, disabled(cfg), "empty-string env falls back to default, not disabled")
+	})
+
+	// To disable via env, provide a non-empty value with no known parser names.
+	// Unknown names are skipped, leaving zero parsers -> the no-op aggregator.
+	t.Run("sentinel value disables", func(t *testing.T) {
+		t.Setenv(envName, "none")
+		cfg := configmock.New(t)
+		assert.Equal(t, []string{"none"}, cfg.GetStringSlice(key))
+		assert.True(t, disabled(cfg), "an unknown parser name resolves to no parsers -> disabled")
+	})
+
+	// The literal string "[]" is recognized as JSON-style empty-list syntax and
+	// parsed to an empty slice, cleanly disabling the feature (no unknown-parser
+	// warning), unlike an empty string which falls back to the default.
+	t.Run("literal brackets string", func(t *testing.T) {
+		t.Setenv(envName, "[]")
+		cfg := configmock.New(t)
+		assert.Empty(t, cfg.GetStringSlice(key), "\"[]\" should parse to an empty slice")
+		assert.True(t, disabled(cfg), "\"[]\" -> empty slice -> disabled")
+	})
+
+	t.Run("known value stays enabled", func(t *testing.T) {
+		t.Setenv(envName, "go")
+		cfg := configmock.New(t)
+		assert.False(t, disabled(cfg), "'go' should keep the feature enabled")
+	})
+}
+
+// TestDecoderBlankLineNewlineHandling verifies how blank lines emitted on the
+// container/CRI partial-line path are represented after the fix: standalone
+// blanks vs blanks embedded in an aggregated Go stack trace, and whether a
+// trailing blank produces a trailing (escaped) newline.
+func TestDecoderBlankLineNewlineHandling(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.Set("logs_config.auto_multi_line_detection", true, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.auto_multi_line.stack_trace_parsers", []string{"go"}, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.tag_multi_line_logs", true, pkgconfigmodel.SourceAgentRuntime)
+
+	criLine := func(content string) string {
+		return "2024-01-01T00:00:00.000000000Z stderr F " + content + "\n"
+	}
+	run := func(t *testing.T, lines []string) []*message.Message {
+		source := sources.NewLogSource("", &config.LogsConfig{})
+		d := InitializeDecoderForTest(source, kubernetes.New())
+		d.Start()
+		var input []byte
+		for _, l := range lines {
+			input = append(input, []byte(criLine(l))...)
+		}
+		d.InputChan() <- NewInput(input)
+		d.Stop()
+		var outs []*message.Message
+		for o := range d.OutputChan() {
+			outs = append(outs, o)
+		}
+		return outs
+	}
+
+	// A standalone blank line (not part of any aggregate) becomes its own
+	// message with EMPTY content. It is NOT merged into or appended to the
+	// neighbouring messages, so no embedded/trailing newline appears in them.
+	// Downstream, tailers drop empty messages via HasContent() before the
+	// processor, so it never reaches the backend.
+	t.Run("standalone blank line yields empty message, not embedded newline", func(t *testing.T) {
+		outs := run(t, []string{"hello", "", "world"})
+		require.Len(t, outs, 3)
+		assert.Equal(t, "hello", string(outs[0].GetContent()))
+		assert.Empty(t, outs[1].GetContent(), "blank line is its own empty message")
+		assert.False(t, outs[1].GetContent() != nil && len(outs[1].GetContent()) > 0)
+		assert.False(t, outs[1].HasContent(), "empty message is dropped by tailers before the processor")
+		assert.Equal(t, "world", string(outs[2].GetContent()))
+	})
+
+	// A blank line WITHIN an aggregated trace is preserved as an embedded
+	// (escaped) newline in the middle of the combined message — never a real
+	// newline, and no trailing newline.
+	t.Run("blank line inside stack trace is embedded, no trailing newline", func(t *testing.T) {
+		outs := run(t, []string{
+			"panic: boom",
+			"",
+			"goroutine 1 [running]:",
+			"main.main()",
+			"\t/app/main.go:14 +0x2c",
+		})
+		require.Len(t, outs, 1)
+		content := string(outs[0].GetContent())
+		assert.Contains(t, content, `\n\n`, "the blank line survives as an embedded escaped newline")
+		assert.NotContains(t, content, "\n", "no real newline bytes are embedded")
+		assert.False(t, strings.HasSuffix(content, `\n`), "no trailing escaped newline")
+	})
+
+	// EDGE CASE: when an aggregated trace ENDS with a blank line, that trailing
+	// blank is currently included, producing a trailing escaped "\n" in the
+	// combined message. This matches the pre-existing file-source (SingleLineParser)
+	// behavior; the fix brings the container path to parity. It is an escaped
+	// "\n", never a real newline.
+	t.Run("trailing blank line produces a trailing escaped newline", func(t *testing.T) {
+		outs := run(t, []string{
+			"panic: boom",
+			"",
+			"goroutine 1 [running]:",
+			"main.main()",
+			"\t/app/main.go:14 +0x2c",
+			"",
+		})
+		require.Len(t, outs, 1)
+		content := string(outs[0].GetContent())
+		assert.True(t, strings.HasSuffix(content, `\n`), "trailing blank is kept as an escaped newline")
+		assert.NotContains(t, content, "\n", "still no real newline bytes")
+	})
+}
+
+// TestDecoderAutoMultilineTimestampBlankLine exercises the DEFAULT auto-multiline
+// path (timestamp-based combiningAggregator, NOT the stack trace aggregator) to
+// observe how blank lines behave there.
+func TestDecoderAutoMultilineTimestampBlankLine(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.Set("logs_config.auto_multi_line_detection", true, pkgconfigmodel.SourceAgentRuntime)
+	// Isolate the timestamp-based path: no stack trace parsers.
+	mockConfig.Set("logs_config.auto_multi_line.stack_trace_parsers", []string{}, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.tag_multi_line_logs", true, pkgconfigmodel.SourceAgentRuntime)
+
+	criLine := func(content string) string {
+		return "2024-01-01T00:00:00.000000000Z stderr F " + content + "\n"
+	}
+	run := func(t *testing.T, lines []string) []*message.Message {
+		source := sources.NewLogSource("", &config.LogsConfig{})
+		d := InitializeDecoderForTest(source, kubernetes.New())
+		d.Start()
+		var input []byte
+		for _, l := range lines {
+			input = append(input, []byte(criLine(l))...)
+		}
+		d.InputChan() <- NewInput(input)
+		d.Stop()
+		var outs []*message.Message
+		for o := range d.OutputChan() {
+			outs = append(outs, o)
+		}
+		return outs
+	}
+
+	// A blank line following a timestamped log has no timestamp, so the timestamp
+	// detector leaves it labeled "aggregate": it folds into the preceding group as a
+	// trailing escaped newline and flips that log to multi-line. The next timestamped
+	// line starts a fresh group. This confirms grouping is driven by timestamp presence,
+	// and that the blank line is carried through (not dropped) as an escaped newline.
+	t.Run("blank between two timestamped lines folds into the preceding group", func(t *testing.T) {
+		outs := run(t, []string{
+			"2024-03-28 13:45:30 line one",
+			"",
+			"2024-03-28 13:45:31 line two",
+		})
+		require.Len(t, outs, 2)
+
+		first := string(outs[0].GetContent())
+		assert.Equal(t, `2024-03-28 13:45:30 line one\n`, first)
+		assert.True(t, outs[0].ParsingExtra.IsMultiLine, "the folded-in blank line makes this a multi-line log")
+		assert.Contains(t, outs[0].ParsingExtra.Tags, "multiline:auto_multiline")
+		assert.NotContains(t, first, "\n", "no real newline bytes, only the escaped sequence")
+
+		second := string(outs[1].GetContent())
+		assert.Equal(t, "2024-03-28 13:45:31 line two", second)
+		assert.False(t, outs[1].ParsingExtra.IsMultiLine)
+	})
+
+	// A blank line in the middle of a timestamp-grouped block becomes an embedded
+	// escaped newline (\n\n) rather than splitting the group or being dropped.
+	t.Run("blank in middle of a timestamped group is embedded as an escaped newline", func(t *testing.T) {
+		outs := run(t, []string{
+			"2024-03-28 13:45:30 ERROR boom",
+			"    at Foo",
+			"",
+			"    at Bar",
+			"2024-03-28 13:45:31 INFO next",
+		})
+		require.Len(t, outs, 2)
+
+		grouped := string(outs[0].GetContent())
+		assert.Equal(t, `2024-03-28 13:45:30 ERROR boom\n    at Foo\n\n    at Bar`, grouped)
+		assert.True(t, outs[0].ParsingExtra.IsMultiLine)
+		assert.Contains(t, outs[0].ParsingExtra.Tags, "multiline:auto_multiline")
+		assert.NotContains(t, grouped, "\n", "no real newline bytes, only escaped sequences")
+
+		assert.Equal(t, "2024-03-28 13:45:31 INFO next", string(outs[1].GetContent()))
+		assert.False(t, outs[1].ParsingExtra.IsMultiLine)
+	})
+}

--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -995,7 +995,7 @@ func TestDecoderBlankLineNewlineHandling(t *testing.T) {
 	criLine := func(content string) string {
 		return "2024-01-01T00:00:00.000000000Z stderr F " + content + "\n"
 	}
-	run := func(t *testing.T, lines []string) []*message.Message {
+	run := func(_ *testing.T, lines []string) []*message.Message {
 		source := sources.NewLogSource("", &config.LogsConfig{})
 		d := InitializeDecoderForTest(source, kubernetes.New())
 		d.Start()
@@ -1079,7 +1079,7 @@ func TestDecoderAutoMultilineTimestampBlankLine(t *testing.T) {
 	criLine := func(content string) string {
 		return "2024-01-01T00:00:00.000000000Z stderr F " + content + "\n"
 	}
-	run := func(t *testing.T, lines []string) []*message.Message {
+	run := func(_ *testing.T, lines []string) []*message.Message {
 		source := sources.NewLogSource("", &config.LogsConfig{})
 		d := InitializeDecoderForTest(source, kubernetes.New())
 		d.Start()

--- a/pkg/logs/internal/decoder/line_parser.go
+++ b/pkg/logs/internal/decoder/line_parser.go
@@ -160,16 +160,9 @@ func (p *MultiLineParser) sendLine() {
 		p.isBufferTruncated = false
 	}()
 
-	// Bail only when there is genuinely nothing to forward. A complete but
-	// empty line (for example the blank line separating a Go panic header from
-	// its goroutine block, or any blank line in a container/CRI stream) has
-	// empty buffered content but a non-zero rawDataLen. It must still be
-	// forwarded so downstream aggregators can observe the blank line. The
-	// SingleLineParser path already forwards these; previously the
-	// buffer.Len() == 0 short-circuit silently dropped them on the partial-line
-	// parser paths (Kubernetes/CRI, Docker JSON file), which broke stack-trace
-	// aggregation for container log sources.
-	if p.bufferedMsg == nil || (p.buffer.Len() == 0 && p.rawDataLen == 0) {
+	// Forward complete but empty lines (empty content, non-zero rawDataLen) so
+	// downstream aggregators can observe blank lines.
+	if p.bufferedMsg == nil || p.rawDataLen == 0 {
 		return
 	}
 

--- a/pkg/logs/internal/decoder/line_parser.go
+++ b/pkg/logs/internal/decoder/line_parser.go
@@ -160,16 +160,23 @@ func (p *MultiLineParser) sendLine() {
 		p.isBufferTruncated = false
 	}()
 
-	if p.bufferedMsg == nil || p.buffer.Len() == 0 {
+	// Bail only when there is genuinely nothing to forward. A complete but
+	// empty line (for example the blank line separating a Go panic header from
+	// its goroutine block, or any blank line in a container/CRI stream) has
+	// empty buffered content but a non-zero rawDataLen. It must still be
+	// forwarded so downstream aggregators can observe the blank line. The
+	// SingleLineParser path already forwards these; previously the
+	// buffer.Len() == 0 short-circuit silently dropped them on the partial-line
+	// parser paths (Kubernetes/CRI, Docker JSON file), which broke stack-trace
+	// aggregation for container log sources.
+	if p.bufferedMsg == nil || (p.buffer.Len() == 0 && p.rawDataLen == 0) {
 		return
 	}
 
 	content := make([]byte, p.buffer.Len())
 	copy(content, p.buffer.Bytes())
-	if len(content) > 0 || p.rawDataLen > 0 {
-		p.bufferedMsg.RawDataLen = p.rawDataLen
-		p.bufferedMsg.SetContent(content)
-		p.bufferedMsg.ParsingExtra.IsTruncated = p.bufferedMsg.ParsingExtra.IsTruncated || p.isBufferTruncated
-		p.lineHandler.process(p.bufferedMsg)
-	}
+	p.bufferedMsg.RawDataLen = p.rawDataLen
+	p.bufferedMsg.SetContent(content)
+	p.bufferedMsg.ParsingExtra.IsTruncated = p.bufferedMsg.ParsingExtra.IsTruncated || p.isBufferTruncated
+	p.lineHandler.process(p.bufferedMsg)
 }

--- a/pkg/logs/internal/decoder/line_parser.go
+++ b/pkg/logs/internal/decoder/line_parser.go
@@ -160,8 +160,9 @@ func (p *MultiLineParser) sendLine() {
 		p.isBufferTruncated = false
 	}()
 
-	// Forward complete but empty lines (empty content, non-zero rawDataLen) so
-	// downstream aggregators can observe blank lines.
+	// Skip only when there is nothing to send. Complete but empty lines (empty
+	// content, non-zero rawDataLen) are still forwarded so downstream
+	// aggregators can observe blank lines.
 	if p.bufferedMsg == nil || p.rawDataLen == 0 {
 		return
 	}

--- a/pkg/logs/internal/decoder/line_parser_test.go
+++ b/pkg/logs/internal/decoder/line_parser_test.go
@@ -131,6 +131,64 @@ func TestMultilineParser(t *testing.T) {
 	assert.Equal(t, message.RawDataLen, 11+12+14)
 }
 
+func TestMultilineParserForwardsCompleteEmptyLine(t *testing.T) {
+	// A complete (non-partial) blank line must be forwarded to the line
+	// handler rather than dropped. Downstream aggregators (e.g. the Go stack
+	// trace aggregator) rely on observing the blank line that separates a
+	// panic header from its goroutine block. Regression test for blank lines
+	// being silently swallowed on the partial-line parser path used by
+	// container/CRI log sources.
+	p := NewMockFailingParser(header)
+	timeout := 1000 * time.Millisecond
+	contentLenLimit := 256 * 100
+
+	lineHandler := NewMockLineHandler()
+	lineParser := NewMultiLineParser(lineHandler, timeout, p, contentLenLimit)
+
+	// empty content, but a non-zero raw length (the trailing newline)
+	logMessage := message.NewMessage([]byte(""), nil, "", 0)
+	lineParser.process(logMessage, 1)
+
+	select {
+	case msg := <-lineHandler.ch:
+		assert.Equal(t, "", string(msg.GetContent()))
+		assert.Equal(t, 1, msg.RawDataLen)
+	case <-time.After(time.Second):
+		t.Fatal("expected the complete blank line to be forwarded to the line handler")
+	}
+}
+
+func TestMultilineParserForwardsBlankLineBetweenAggregatedLines(t *testing.T) {
+	// A blank line arriving between two aggregated (partial) lines must be
+	// forwarded on its own once complete, preserving the blank line for
+	// downstream aggregators instead of collapsing it away.
+	p := NewMockFailingParser(header)
+	timeout := 1000 * time.Millisecond
+	contentLenLimit := 256 * 100
+
+	lineHandler := NewMockLineHandler()
+	lineParser := NewMultiLineParser(lineHandler, timeout, p, contentLenLimit)
+
+	// complete line "foo"
+	logMessage := message.NewMessage([]byte(header+"foo\\n"), nil, "", 0)
+	lineParser.process(logMessage, 5)
+	msg := <-lineHandler.ch
+	assert.Equal(t, "foo", string(msg.GetContent()))
+
+	// complete blank line
+	logMessage = message.NewMessage([]byte(""), nil, "", 0)
+	lineParser.process(logMessage, 1)
+	msg = <-lineHandler.ch
+	assert.Equal(t, "", string(msg.GetContent()))
+	assert.Equal(t, 1, msg.RawDataLen)
+
+	// complete line "bar"
+	logMessage = message.NewMessage([]byte(header+"bar\\n"), nil, "", 0)
+	lineParser.process(logMessage, 5)
+	msg = <-lineHandler.ch
+	assert.Equal(t, "bar", string(msg.GetContent()))
+}
+
 func TestMultilineParserTimeout(t *testing.T) {
 	p := NewMockFailingParser(header)
 	timeout := 100 * time.Millisecond

--- a/pkg/logs/internal/decoder/preprocessor/preprocessor.go
+++ b/pkg/logs/internal/decoder/preprocessor/preprocessor.go
@@ -70,9 +70,16 @@ func (p *Preprocessor) tokenizeLabelAndAggregate(msg *message.Message) {
 	tokens, tokenIndices := p.tokenizer.Tokenize(msg.GetContent())
 
 	var label Label
-	if msg.ParsingExtra.IsMultiLine {
+	switch {
+	case msg.ParsingExtra.IsMultiLine:
 		label = noAggregate
-	} else {
+	case len(tokens) == 0:
+		// Empty lines tokenize to nothing, so token-based heuristics (notably the
+		// timestamp detector) would log errors about missing tokens. Skip the labeler
+		// and treat the line as a continuation, which matches the labeler's default
+		// label and lets a blank line fold into the current group.
+		label = aggregate
+	default:
 		labelTokens, labelIndices := limitTokensToBytes(tokens, tokenIndices, p.labelerMaxBytes)
 		label = p.labeler.Label(msg.GetContent(), labelTokens, labelIndices)
 	}

--- a/pkg/logs/internal/decoder/preprocessor/sampler.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler.go
@@ -222,6 +222,11 @@ func (s *AdaptiveSampler) appendPatternHashTagIfEnabled(msg *message.Message, to
 // Process applies credit-based rate limiting to the message.
 // Returns the message if allowed, nil if dropped.
 func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message.Message {
+	// tailers skip no-content messages via HasContent() before the processor, don't use
+	// space in the pattern table for them.
+	if !msg.HasContent() {
+		return msg
+	}
 	if s.config.IsSourceDisabled != nil && s.config.IsSourceDisabled() {
 		return msg
 	}

--- a/pkg/logs/internal/decoder/preprocessor/sampler_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_test.go
@@ -415,14 +415,15 @@ func TestAdaptiveSampler_FlushReturnsNil(t *testing.T) {
 	assert.Nil(t, s.Flush())
 }
 
-// A message with no tokens (e.g. empty log line) never matches an existing entry
-// and is always treated as a new pattern.
-func TestAdaptiveSampler_EmptyTokensNewPattern(t *testing.T) {
+// A message with no content (e.g. empty log line) is ignored by the sampler: it is
+// passed through untouched and does not create or match a pattern entry. The guard
+// keys off HasContent(), so structured messages that carry metadata are still sampled.
+func TestAdaptiveSampler_EmptyContentIgnored(t *testing.T) {
 	s := newSampler(10, 5.0, 0)
-	msg := testMsg()
+	msg := message.NewMessage([]byte{}, nil, message.StatusInfo, 0)
 	out := s.Process(msg, nil)
-	assert.NotNil(t, out, "empty-token message should be allowed as new pattern")
-	require.Len(t, s.entries, 1)
+	assert.Same(t, msg, out, "empty-content message should pass through untouched")
+	require.Empty(t, s.entries, "empty-content message must not create a pattern entry")
 }
 
 func TestAdaptiveSampler_DoesNotTagPatternHashByDefault(t *testing.T) {

--- a/releasenotes/notes/fix-container-stack-trace-aggregation-44a5ead529efd0a5.yaml
+++ b/releasenotes/notes/fix-container-stack-trace-aggregation-44a5ead529efd0a5.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed automatic multi-line stack trace aggregation for container-based log
+    formats (Kubernetes/CRI and the Docker JSON file format). Blank lines within
+    a log stream were previously dropped before reaching the aggregator, which
+    could cause a single stack trace (such as a Go panic) to be ingested as many
+    separate log lines. Stack traces from container log sources are now combined
+    into a single log, matching the behavior of file-based log tailing.

--- a/releasenotes/notes/fix-container-stack-trace-aggregation-44a5ead529efd0a5.yaml
+++ b/releasenotes/notes/fix-container-stack-trace-aggregation-44a5ead529efd0a5.yaml
@@ -1,9 +1,4 @@
 ---
 fixes:
   - |
-    Fixed automatic multi-line stack trace aggregation for container-based log
-    formats (Kubernetes/CRI and the Docker JSON file format). Blank lines within
-    a log stream were previously dropped before reaching the aggregator, which
-    could cause a single stack trace (such as a Go panic) to be ingested as many
-    separate log lines. Stack traces from container log sources are now combined
-    into a single log, matching the behavior of file-based log tailing.
+    Fixed automatic multi-line Go stack trace aggregation for container-based log formats.


### PR DESCRIPTION
### What does this PR do?

Stops the logs decoder from silently dropping complete blank lines on the partial-line parser paths used by container log sources (Kubernetes/CRI and the Docker JSON file format). Blank lines are now forwarded to the line handler, matching the behavior the file tailer already had.

### Motivation

Go crash dumps rely on the blank line that separates a panic header from its goroutine block. On container sources the multiline parser discarded that blank line before it reached the stack trace aggregator, so the aggregator's state machine could not advance and abandoned aggregation — emitting a single crash as many individual log lines instead of one combined message. This did not affect raw file tailing, which uses a different parser path that already forwarded blank lines.

Forwarding blank lines does not flood the processor with empty logs: any blank line that is not consumed by an aggregator is pruned downstream by the tailer's `HasContent()` check before it is passed to the processor. For container log files (Kubernetes/CRI and Docker JSON file) this is the file tailer guard at `pkg/logs/tailers/file/tailer.go:421`; the API-based container tailer has the equivalent guards at `pkg/logs/tailers/container/tailer.go:459` (Docker socket) and `pkg/logs/tailers/container/tailer.go:499` (kubelet).

### Describe how you validated your changes

Added unit tests for the multiline parser (`TestMultilineParserForwardsCompleteEmptyLine`, `TestMultilineParserForwardsBlankLineBetweenAggregatedLines`) and a decoder-level integration test (`TestDecoderKubernetesGoStackTraceAggregatesBlankLine`) that reproduces a container/CRI Go panic through the Kubernetes parser and asserts it aggregates into a single combined message. All three fail without the fix (the integration test emits 6 messages instead of 1) and pass with it. Run via `dda inv test --targets=./pkg/logs/internal/decoder`.

### Additional Notes

N/A