### PR TITLE
refactor(review): use action guideline discovery

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -17,18 +17,15 @@ jobs:
       contents: read
       pull-requests: write
       checks: write
-    uses: DataDog/code-review-action/.github/workflows/code-review.yml@ed7f36e34dff9247ddb602d22ac097708d06cc83 # v1.0.1
+    uses: DataDog/code-review-action/.github/workflows/code-review.yml@56d6862711348b11ec2603edfb29c52c09f4b84c # v1.1.0
     with:
       provider: codex
       # 'always'    → runs automatically on pull_request events above
       # 'on_demand' → runs when a write-access collaborator comments /dd-review
       trigger_mode: on_demand
-      # Root-level file applies to every PR.
+      # Root-level files apply to every PR.
       # Sub-directory files apply only when the PR touches files under that prefix.
-      prompt_file: |
-        codereview_guideline.md
-        bazel/codereview_guideline.md
-        .claude/skills/codereview_guideline.md
+      prompt_file_pattern: "**/codereview_guideline.md"
       review_event: COMMENT_ONLY
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/tasks/libs/code_review/prompt.py
+++ b/tasks/libs/code_review/prompt.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
+import io
+import json
+import re
+import shlex
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
 from tasks.libs.common.git import get_changed_files, get_origin_default_branch
+from tasks.libs.common.utils import is_installed
 
-DEFAULT_PROMPT_FILES = (
-    "codereview_guideline.md",
-    "bazel/codereview_guideline.md",
-    ".claude/skills/codereview_guideline.md",
-)
-WORKFLOW_PATH = ".github/workflows/code-review.yml"
+PROMPT_FILE_PATTERN = "**/codereview_guideline.md"
+CODE_REVIEW_ACTION_REPOSITORY = "DataDog/code-review-action"
+CODE_REVIEW_ACTION_WORKFLOW = f"{CODE_REVIEW_ACTION_REPOSITORY}/.github/workflows/code-review.yml"
+WORKFLOW_PATH = Path(".github/workflows/code-review.yml")
+CODE_REVIEW_ACTION_USES_RE = re.compile(rf"^\s*uses:\s*{re.escape(CODE_REVIEW_ACTION_WORKFLOW)}@(?P<ref>[^\s#]+)")
 
 
 class CodeReviewError(RuntimeError):
@@ -58,87 +62,9 @@ def build_review_prompt(
         )
 
     changed_files = tuple(get_changed_files(ctx, resolved_base))
-    guidelines = load_guidelines(repo_root, changed_files)
+    guidelines = load_guidelines(ctx, repo_root, changed_files)
     content = render_prompt(guidelines, extra_prompt=extra_prompt)
     return ReviewPrompt(base=resolved_base, changed_files=changed_files, guidelines=guidelines, content=content)
-
-
-def load_guidelines(
-    repo_root: Path,
-    changed_files: tuple[str, ...],
-    prompt_files: tuple[str, ...] | None = None,
-) -> tuple[Guideline, ...]:
-    """
-    Read the guideline files that apply to the changed files.
-    """
-    guidelines = []
-    for prompt_file in select_guideline_paths(changed_files, prompt_files or get_prompt_files(repo_root)):
-        path = repo_root / prompt_file
-        if not path.is_file():
-            raise CodeReviewError(f"Review prompt file does not exist: {prompt_file}")
-        guidelines.append(Guideline(path=prompt_file, content=path.read_text(encoding="utf-8").strip()))
-    return tuple(guidelines)
-
-
-def select_guideline_paths(
-    changed_files: tuple[str, ...],
-    prompt_files: tuple[str, ...] = DEFAULT_PROMPT_FILES,
-) -> tuple[str, ...]:
-    """
-    Keep root guidelines and scoped guidelines whose parent directory was touched.
-    """
-    return tuple(prompt_file for prompt_file in prompt_files if _guideline_applies(prompt_file, changed_files))
-
-
-def _guideline_applies(prompt_file: str, changed_files: tuple[str, ...]) -> bool:
-    """
-    Return whether a configured guideline file applies to the current diff.
-    """
-    path = PurePosixPath(prompt_file)
-    if str(path.parent) == ".":
-        return True
-
-    prefix = f"{path.parent.as_posix().rstrip('/')}/"
-    return any(changed_file.startswith(prefix) for changed_file in changed_files)
-
-
-def get_prompt_files(repo_root: Path) -> tuple[str, ...]:
-    """
-    Load the guideline file list from the code-review workflow when available.
-    """
-    workflow_path = repo_root / WORKFLOW_PATH
-    if not workflow_path.is_file():
-        return DEFAULT_PROMPT_FILES
-
-    workflow = workflow_path.read_text(encoding="utf-8")
-    prompt_files = _prompt_files_from_block_scalar(workflow)
-    return prompt_files or DEFAULT_PROMPT_FILES
-
-
-def _prompt_files_from_block_scalar(workflow: str) -> tuple[str, ...]:
-    """
-    Extract the workflow's literal prompt_file block without parsing the whole YAML file.
-    """
-    lines = workflow.splitlines()
-    for index, line in enumerate(lines):
-        stripped = line.strip()
-        if stripped != "prompt_file: |":
-            continue
-
-        prompt_indent = len(line) - len(line.lstrip())
-        prompt_files = []
-        for block_line in lines[index + 1 :]:
-            if not block_line.strip():
-                continue
-
-            block_indent = len(block_line) - len(block_line.lstrip())
-            if block_indent <= prompt_indent:
-                break
-            prompt_files.append(block_line.strip())
-
-        return tuple(prompt_files)
-
-    return ()
 
 
 def render_prompt(guidelines: tuple[Guideline, ...], *, extra_prompt: str | None = None) -> str:
@@ -172,3 +98,61 @@ def render_prompt(guidelines: tuple[Guideline, ...], *, extra_prompt: str | None
         )
 
     return "\n".join(sections).rstrip() + "\n"
+
+
+def load_guidelines(ctx, repo_root: Path, changed_files: tuple[str, ...]) -> tuple[Guideline, ...]:
+    """
+    Read the guideline files that apply to the changed files.
+    """
+    if not is_installed("npm"):
+        raise CodeReviewError("Cannot compute review guidelines: `npm` is not installed or is not on PATH")
+
+    result = _run_find_guidelines(ctx, repo_root, changed_files)
+    if result.get("error"):
+        raise CodeReviewError(str(result["error"]))
+
+    return tuple(Guideline(path=guideline["path"], content=guideline["content"]) for guideline in result["guidelines"])
+
+
+def _run_find_guidelines(ctx, repo_root: Path, changed_files: tuple[str, ...]) -> dict:
+    command = (
+        f"npm exec --yes --package {shlex.quote(_get_code_review_action_package(repo_root))} "
+        "-- find-guidelines "
+        f"--repo-root {shlex.quote(str(repo_root))} "
+        f"--pattern {shlex.quote(PROMPT_FILE_PATTERN)} "
+        "--changed-files -"
+    )
+    result = ctx.run(
+        command,
+        hide=True,
+        warn=True,
+        in_stream=io.StringIO("\n".join(changed_files)),
+    )
+
+    try:
+        parsed_result = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise CodeReviewError(result.stderr.strip() or f"Failed to parse guideline discovery output: {e}") from e
+
+    if result.exited != 0 and not parsed_result.get("error"):
+        raise CodeReviewError(result.stderr.strip() or "Guideline discovery failed")
+
+    return parsed_result
+
+
+def _get_code_review_action_package(repo_root: Path) -> str:
+    return f"github:{CODE_REVIEW_ACTION_REPOSITORY}#{_get_code_review_action_ref(repo_root)}"
+
+
+def _get_code_review_action_ref(repo_root: Path) -> str:
+    workflow_path = repo_root / WORKFLOW_PATH
+    if not workflow_path.is_file():
+        raise CodeReviewError(f"Cannot find code review workflow: {WORKFLOW_PATH}")
+
+    workflow = workflow_path.read_text(encoding="utf-8")
+    for line in workflow.splitlines():
+        match = CODE_REVIEW_ACTION_USES_RE.match(line)
+        if match:
+            return match.group("ref")
+
+    raise CodeReviewError(f"Cannot find {CODE_REVIEW_ACTION_WORKFLOW} pin in {WORKFLOW_PATH}")

--- a/tasks/libs/code_review/prompt.py
+++ b/tasks/libs/code_review/prompt.py
@@ -4,6 +4,7 @@ import io
 import json
 import re
 import shlex
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -11,6 +12,7 @@ from tasks.libs.common.git import get_changed_files, get_origin_default_branch
 from tasks.libs.common.utils import is_installed
 
 PROMPT_FILE_PATTERN = "**/codereview_guideline.md"
+PROMPT_FILE_GIT_PATHSPEC = f":(glob){PROMPT_FILE_PATTERN}"
 CODE_REVIEW_ACTION_REPOSITORY = "DataDog/code-review-action"
 CODE_REVIEW_ACTION_WORKFLOW = f"{CODE_REVIEW_ACTION_REPOSITORY}/.github/workflows/code-review.yml"
 WORKFLOW_PATH = Path(".github/workflows/code-review.yml")
@@ -62,9 +64,32 @@ def build_review_prompt(
         )
 
     changed_files = tuple(get_changed_files(ctx, resolved_base))
+    _warn_deleted_prompt_files(ctx, resolved_base)
     guidelines = load_guidelines(ctx, repo_root, changed_files)
     content = render_prompt(guidelines, extra_prompt=extra_prompt)
     return ReviewPrompt(base=resolved_base, changed_files=changed_files, guidelines=guidelines, content=content)
+
+
+def _warn_deleted_prompt_files(ctx, base: str) -> None:
+    deleted_prompt_files = _get_deleted_prompt_files(ctx, base)
+    if not deleted_prompt_files:
+        return
+
+    print(
+        "Warning: deleted code review prompt file(s) match "
+        f"{PROMPT_FILE_PATTERN}: {', '.join(deleted_prompt_files)}. "
+        "They will not be included in local review prompts; make sure the deletion is intentional.",
+        file=sys.stderr,
+    )
+
+
+def _get_deleted_prompt_files(ctx, base: str) -> tuple[str, ...]:
+    base_to_head = shlex.quote(f"{base}...HEAD")
+    result = ctx.run(
+        f"git diff --name-only --diff-filter=D {base_to_head} -- {shlex.quote(PROMPT_FILE_GIT_PATHSPEC)}",
+        hide=True,
+    )
+    return tuple(line for line in result.stdout.splitlines() if line)
 
 
 def render_prompt(guidelines: tuple[Guideline, ...], *, extra_prompt: str | None = None) -> str:

--- a/tasks/libs/code_review/prompt.py
+++ b/tasks/libs/code_review/prompt.py
@@ -2,21 +2,19 @@ from __future__ import annotations
 
 import io
 import json
-import re
 import shlex
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+import yaml
+
 from tasks.libs.common.git import get_changed_files, get_origin_default_branch
 from tasks.libs.common.utils import is_installed
 
-PROMPT_FILE_PATTERN = "**/codereview_guideline.md"
-PROMPT_FILE_GIT_PATHSPEC = f":(glob){PROMPT_FILE_PATTERN}"
 CODE_REVIEW_ACTION_REPOSITORY = "DataDog/code-review-action"
 CODE_REVIEW_ACTION_WORKFLOW = f"{CODE_REVIEW_ACTION_REPOSITORY}/.github/workflows/code-review.yml"
 WORKFLOW_PATH = Path(".github/workflows/code-review.yml")
-CODE_REVIEW_ACTION_USES_RE = re.compile(rf"^\s*uses:\s*{re.escape(CODE_REVIEW_ACTION_WORKFLOW)}@(?P<ref>[^\s#]+)")
 
 
 class CodeReviewError(RuntimeError):
@@ -64,29 +62,31 @@ def build_review_prompt(
         )
 
     changed_files = tuple(get_changed_files(ctx, resolved_base))
-    _warn_deleted_prompt_files(ctx, resolved_base)
-    guidelines = load_guidelines(ctx, repo_root, changed_files)
+    prompt_file_pattern = _get_prompt_file_pattern(repo_root)
+    _warn_deleted_prompt_files(ctx, resolved_base, prompt_file_pattern)
+    guidelines = load_guidelines(ctx, repo_root, changed_files, prompt_file_pattern=prompt_file_pattern)
     content = render_prompt(guidelines, extra_prompt=extra_prompt)
     return ReviewPrompt(base=resolved_base, changed_files=changed_files, guidelines=guidelines, content=content)
 
 
-def _warn_deleted_prompt_files(ctx, base: str) -> None:
-    deleted_prompt_files = _get_deleted_prompt_files(ctx, base)
+def _warn_deleted_prompt_files(ctx, base: str, prompt_file_pattern: str) -> None:
+    deleted_prompt_files = _get_deleted_prompt_files(ctx, base, prompt_file_pattern)
     if not deleted_prompt_files:
         return
 
     print(
         "Warning: deleted code review prompt file(s) match "
-        f"{PROMPT_FILE_PATTERN}: {', '.join(deleted_prompt_files)}. "
+        f"{prompt_file_pattern}: {', '.join(deleted_prompt_files)}. "
         "They will not be included in local review prompts; make sure the deletion is intentional.",
         file=sys.stderr,
     )
 
 
-def _get_deleted_prompt_files(ctx, base: str) -> tuple[str, ...]:
+def _get_deleted_prompt_files(ctx, base: str, prompt_file_pattern: str) -> tuple[str, ...]:
     base_to_head = shlex.quote(f"{base}...HEAD")
+    prompt_file_pathspec = f":(glob){prompt_file_pattern}"
     result = ctx.run(
-        f"git diff --name-only --diff-filter=D {base_to_head} -- {shlex.quote(PROMPT_FILE_GIT_PATHSPEC)}",
+        f"git diff --name-only --diff-filter=D {base_to_head} -- {shlex.quote(prompt_file_pathspec)}",
         hide=True,
     )
     return tuple(line for line in result.stdout.splitlines() if line)
@@ -125,26 +125,34 @@ def render_prompt(guidelines: tuple[Guideline, ...], *, extra_prompt: str | None
     return "\n".join(sections).rstrip() + "\n"
 
 
-def load_guidelines(ctx, repo_root: Path, changed_files: tuple[str, ...]) -> tuple[Guideline, ...]:
+def load_guidelines(
+    ctx,
+    repo_root: Path,
+    changed_files: tuple[str, ...],
+    *,
+    prompt_file_pattern: str | None = None,
+) -> tuple[Guideline, ...]:
     """
     Read the guideline files that apply to the changed files.
     """
     if not is_installed("npm"):
         raise CodeReviewError("Cannot compute review guidelines: `npm` is not installed or is not on PATH")
 
-    result = _run_find_guidelines(ctx, repo_root, changed_files)
+    result = _run_find_guidelines(
+        ctx, repo_root, changed_files, prompt_file_pattern or _get_prompt_file_pattern(repo_root)
+    )
     if result.get("error"):
         raise CodeReviewError(str(result["error"]))
 
     return tuple(Guideline(path=guideline["path"], content=guideline["content"]) for guideline in result["guidelines"])
 
 
-def _run_find_guidelines(ctx, repo_root: Path, changed_files: tuple[str, ...]) -> dict:
+def _run_find_guidelines(ctx, repo_root: Path, changed_files: tuple[str, ...], prompt_file_pattern: str) -> dict:
     command = (
         f"npm exec --yes --package {shlex.quote(_get_code_review_action_package(repo_root))} "
         "-- find-guidelines "
         f"--repo-root {shlex.quote(str(repo_root))} "
-        f"--pattern {shlex.quote(PROMPT_FILE_PATTERN)} "
+        f"--pattern {shlex.quote(prompt_file_pattern)} "
         "--changed-files -"
     )
     result = ctx.run(
@@ -170,14 +178,37 @@ def _get_code_review_action_package(repo_root: Path) -> str:
 
 
 def _get_code_review_action_ref(repo_root: Path) -> str:
+    uses = _get_code_review_job(repo_root).get("uses")
+    if not isinstance(uses, str) or not uses.startswith(f"{CODE_REVIEW_ACTION_WORKFLOW}@"):
+        raise CodeReviewError(f"Cannot find {CODE_REVIEW_ACTION_WORKFLOW} pin in {WORKFLOW_PATH}")
+
+    return uses.removeprefix(f"{CODE_REVIEW_ACTION_WORKFLOW}@")
+
+
+def _get_prompt_file_pattern(repo_root: Path) -> str:
+    inputs = _get_code_review_job(repo_root).get("with")
+    if not isinstance(inputs, dict):
+        raise CodeReviewError(f"Cannot find code review workflow inputs in {WORKFLOW_PATH}")
+
+    prompt_file_pattern = inputs.get("prompt_file_pattern")
+    if not isinstance(prompt_file_pattern, str) or not prompt_file_pattern.strip():
+        raise CodeReviewError(f"Cannot find prompt_file_pattern in {WORKFLOW_PATH}")
+
+    return prompt_file_pattern.strip()
+
+
+def _get_code_review_job(repo_root: Path) -> dict:
     workflow_path = repo_root / WORKFLOW_PATH
     if not workflow_path.is_file():
         raise CodeReviewError(f"Cannot find code review workflow: {WORKFLOW_PATH}")
 
-    workflow = workflow_path.read_text(encoding="utf-8")
-    for line in workflow.splitlines():
-        match = CODE_REVIEW_ACTION_USES_RE.match(line)
-        if match:
-            return match.group("ref")
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    try:
+        job = workflow["jobs"]["review"]
+    except (KeyError, TypeError) as e:
+        raise CodeReviewError(f"Cannot find code review job in {WORKFLOW_PATH}") from e
 
-    raise CodeReviewError(f"Cannot find {CODE_REVIEW_ACTION_WORKFLOW} pin in {WORKFLOW_PATH}")
+    if not isinstance(job, dict):
+        raise CodeReviewError(f"Cannot find code review job in {WORKFLOW_PATH}")
+
+    return job

--- a/tasks/libs/code_review/providers.py
+++ b/tasks/libs/code_review/providers.py
@@ -102,7 +102,6 @@ def build_provider_invocation(
     if provider == "codex":
         prompt = (
             f"Review the current git changes against {review_prompt.base} using the precomputed diff below.\n"
-            "Do not run shell commands. The local wrapper already collected the patch for you.\n"
             "Do not modify files. Return only review findings and an overall correctness verdict.\n\n"
             f"{review_prompt.content}\n"
             "## Precomputed Diff\n\n"

--- a/tasks/libs/code_review/providers.py
+++ b/tasks/libs/code_review/providers.py
@@ -35,15 +35,24 @@ def run_review(
     prompt_path.write_text(review_prompt.content, encoding="utf-8")
     print(f"Review prompt written to {prompt_path}", file=sys.stderr)
 
-    invocations = [
-        build_provider_invocation(
-            provider=provider_name,
-            review_prompt=review_prompt,
-            prompt_path=prompt_path,
-            artifact_dir=artifact_dir,
+    invocations = []
+    for provider_name in expand_providers(provider):
+        review_diff = None
+        if provider_name == "codex":
+            review_diff = collect_review_diff(ctx, repo_root, review_prompt.base)
+            diff_path = artifact_dir / "codex-diff.md"
+            diff_path.write_text(review_diff, encoding="utf-8")
+            print(f"Codex review diff written to {diff_path}", file=sys.stderr)
+
+        invocations.append(
+            build_provider_invocation(
+                provider=provider_name,
+                review_prompt=review_prompt,
+                prompt_path=prompt_path,
+                artifact_dir=artifact_dir,
+                review_diff=review_diff,
+            )
         )
-        for provider_name in expand_providers(provider)
-    ]
 
     for invocation in invocations:
         _ensure_command_exists(invocation.executable)
@@ -86,17 +95,18 @@ def build_provider_invocation(
     review_prompt: ReviewPrompt,
     prompt_path: Path,
     artifact_dir: Path,
+    review_diff: str | None = None,
 ) -> ProviderInvocation:
     output_path = artifact_dir / f"{provider}.md"
 
     if provider == "codex":
-        # `codex review --base ... [PROMPT]` rejects combining a base ref and a prompt.
-        # Use `codex exec` instead and ask Codex to inspect the same diff explicitly.
         prompt = (
-            f"Review the current git changes against {review_prompt.base}.\n"
-            f"Use `git diff --find-renames {review_prompt.base}...HEAD` to inspect the patch.\n"
+            f"Review the current git changes against {review_prompt.base} using the precomputed diff below.\n"
+            "Do not run shell commands. The local wrapper already collected the patch for you.\n"
             "Do not modify files. Return only review findings and an overall correctness verdict.\n\n"
-            f"{review_prompt.content}"
+            f"{review_prompt.content}\n"
+            "## Precomputed Diff\n\n"
+            f"{review_diff or 'No diff was provided.'}"
         )
         return ProviderInvocation(
             provider=provider,
@@ -131,6 +141,22 @@ def build_provider_invocation(
         )
 
     raise CodeReviewError(f"Unknown provider {provider!r}")
+
+
+def collect_review_diff(ctx, repo_root: Path, base: str) -> str:
+    diff_range = shlex.quote(f"{base}...HEAD")
+    sections = []
+    for title, command in (
+        ("DIFF STAT", f"git diff --find-renames --stat {diff_range}"),
+        ("CHANGED FILES", f"git diff --find-renames --name-only {diff_range}"),
+        ("PATCH", f"git diff --find-renames {diff_range}"),
+    ):
+        result = ctx.run(f"cd {shlex.quote(str(repo_root))} && {command}", hide=True, warn=True)
+        if result.exited != 0:
+            raise CodeReviewError(result.stderr.strip() or f"{command} failed")
+        sections.extend([f"--- {title} ---", result.stdout.strip() or "(empty)", ""])
+
+    return "\n".join(sections).rstrip() + "\n"
 
 
 def expand_providers(provider: str) -> tuple[str, ...]:

--- a/tasks/libs/code_review/providers.py
+++ b/tasks/libs/code_review/providers.py
@@ -148,7 +148,6 @@ def collect_review_diff(ctx, repo_root: Path, base: str) -> str:
     sections = []
     for title, command in (
         ("DIFF STAT", f"git diff --find-renames --stat {diff_range}"),
-        ("CHANGED FILES", f"git diff --find-renames --name-only {diff_range}"),
         ("PATCH", f"git diff --find-renames {diff_range}"),
     ):
         result = ctx.run(f"cd {shlex.quote(str(repo_root))} && {command}", hide=True, warn=True)

--- a/tasks/unit_tests/code_review_tests.py
+++ b/tasks/unit_tests/code_review_tests.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 from tasks.libs.code_review.prompt import (
-    PROMPT_FILE_PATTERN,
     CodeReviewError,
     Guideline,
     build_review_prompt,
@@ -74,7 +73,11 @@ class FakePromptContext:
         return type("Result", (), {"stdout": stdout})()
 
 
-def write_code_review_workflow(repo_root: Path, ref: str = "test-action-ref") -> None:
+def write_code_review_workflow(
+    repo_root: Path,
+    ref: str = "test-action-ref",
+    prompt_file_pattern: str = "**/codereview_guideline.md",
+) -> None:
     workflow_dir = repo_root / ".github" / "workflows"
     workflow_dir.mkdir(parents=True)
     (workflow_dir / "code-review.yml").write_text(
@@ -82,6 +85,8 @@ def write_code_review_workflow(repo_root: Path, ref: str = "test-action-ref") ->
 jobs:
   review:
     uses: DataDog/code-review-action/.github/workflows/code-review.yml@{ref} # v1.1.0
+    with:
+      prompt_file_pattern: "{prompt_file_pattern}"
 """.lstrip(),
         encoding="utf-8",
     )
@@ -96,7 +101,7 @@ class TestCodeReviewPrompt(unittest.TestCase):
             patch("tasks.libs.code_review.prompt.is_installed", return_value=True),
         ):
             repo_root = Path(tmp)
-            write_code_review_workflow(repo_root)
+            write_code_review_workflow(repo_root, prompt_file_pattern="**/custom_guideline.md")
             guidelines = load_guidelines(ctx, repo_root, ("bazel/BUILD.bazel", "pkg/foo.go"))
 
         self.assertEqual(
@@ -109,7 +114,7 @@ class TestCodeReviewPrompt(unittest.TestCase):
         self.assertIn("npm exec --yes --package", ctx.commands[0][0])
         self.assertIn("github:DataDog/code-review-action#test-action-ref", ctx.commands[0][0])
         self.assertIn("-- find-guidelines ", ctx.commands[0][0])
-        self.assertIn(f"--pattern '{PROMPT_FILE_PATTERN}'", ctx.commands[0][0])
+        self.assertIn("--pattern '**/custom_guideline.md'", ctx.commands[0][0])
         self.assertIn("--changed-files -", ctx.commands[0][0])
         self.assertEqual(ctx.stdin, "bazel/BUILD.bazel\npkg/foo.go")
 
@@ -153,24 +158,28 @@ class TestCodeReviewPrompt(unittest.TestCase):
 
     def test_build_review_prompt_warns_when_prompt_file_is_deleted(self):
         ctx = FakePromptContext(
-            changed_files="pkg/foo.go\nbazel/codereview_guideline.md\n",
-            deleted_prompt_files="bazel/codereview_guideline.md\n",
+            changed_files="pkg/foo.go\nbazel/custom_guideline.md\n",
+            deleted_prompt_files="bazel/custom_guideline.md\n",
         )
 
         with (
+            tempfile.TemporaryDirectory() as tmp,
             patch(
                 "tasks.libs.code_review.prompt.load_guidelines",
                 return_value=(Guideline(path="codereview_guideline.md", content="root rules"),),
             ),
             patch("sys.stderr", new_callable=io.StringIO) as stderr,
         ):
-            build_review_prompt(ctx=ctx, repo_root=Path("."), base="origin/main")
+            repo_root = Path(tmp)
+            write_code_review_workflow(repo_root, prompt_file_pattern="**/custom_guideline.md")
+            build_review_prompt(ctx=ctx, repo_root=repo_root, base="origin/main")
 
         self.assertIn("Warning: deleted code review prompt file(s)", stderr.getvalue())
-        self.assertIn("bazel/codereview_guideline.md", stderr.getvalue())
+        self.assertIn("**/custom_guideline.md", stderr.getvalue())
+        self.assertIn("bazel/custom_guideline.md", stderr.getvalue())
         deleted_file_commands = [command for command in ctx.commands if "--diff-filter=D" in command]
         self.assertEqual(len(deleted_file_commands), 1)
-        self.assertIn(":(glob)**/codereview_guideline.md", deleted_file_commands[0])
+        self.assertIn(":(glob)**/custom_guideline.md", deleted_file_commands[0])
 
     def test_render_prompt_appends_extra_prompt(self):
         prompt = render_prompt(

--- a/tasks/unit_tests/code_review_tests.py
+++ b/tasks/unit_tests/code_review_tests.py
@@ -266,9 +266,9 @@ class TestCodeReviewProviders(unittest.TestCase):
         review_diff = collect_review_diff(ctx, Path("/repo"), "origin/main")
 
         self.assertIn("--- DIFF STAT ---\ntasks/foo.py | 2 ++", review_diff)
-        self.assertIn("--- CHANGED FILES ---\ntasks/foo.py", review_diff)
+        self.assertNotIn("--- CHANGED FILES ---", review_diff)
         self.assertIn("--- PATCH ---\ndiff --git a/tasks/foo.py b/tasks/foo.py", review_diff)
-        self.assertEqual(len(ctx.commands), 3)
+        self.assertEqual(len(ctx.commands), 2)
         self.assertTrue(all("origin/main...HEAD" in command for command in ctx.commands))
 
     def test_build_claude_invocation_references_prompt_file(self):

--- a/tasks/unit_tests/code_review_tests.py
+++ b/tasks/unit_tests/code_review_tests.py
@@ -254,7 +254,6 @@ class TestCodeReviewProviders(unittest.TestCase):
 
         self.assertEqual(invocation.executable, "codex")
         self.assertEqual(invocation.command, "codex exec --sandbox read-only -")
-        self.assertIn("Do not run shell commands", invocation.stdin or "")
         self.assertIn("--- DIFF STAT ---", invocation.stdin or "")
         self.assertIn("diff --git a/tasks/foo.py b/tasks/foo.py", invocation.stdin or "")
         self.assertIn("custom review instructions", invocation.stdin or "")

--- a/tasks/unit_tests/code_review_tests.py
+++ b/tasks/unit_tests/code_review_tests.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
 from tasks.libs.code_review.prompt import (
+    PROMPT_FILE_PATTERN,
     CodeReviewError,
     Guideline,
     build_review_prompt,
-    get_prompt_files,
     load_guidelines,
     render_prompt,
-    select_guideline_paths,
 )
 from tasks.libs.code_review.providers import (
     ProviderInvocation,
@@ -36,36 +36,52 @@ class FakeContext:
         return type("Result", (), {"exited": 0, "stdout": "review output\n", "stderr": "review warning\n"})()
 
 
+class FakeGuidelineContext:
+    def __init__(self, *, exited=0, stdout=None, stderr=""):
+        self.commands = []
+        self.stdin = None
+        self.exited = exited
+        self.stdout = stdout or json.dumps(
+            {
+                "error": None,
+                "guidelines": [
+                    {"path": "codereview_guideline.md", "content": "root rules"},
+                    {"path": "bazel/codereview_guideline.md", "content": "bazel rules"},
+                ],
+            }
+        )
+        self.stderr = stderr
+
+    def run(self, command, **kwargs):
+        self.commands.append((command, kwargs))
+        self.stdin = kwargs["in_stream"].read()
+        return type("Result", (), {"exited": self.exited, "stdout": self.stdout, "stderr": self.stderr})()
+
+
+def write_code_review_workflow(repo_root: Path, ref: str = "test-action-ref") -> None:
+    workflow_dir = repo_root / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "code-review.yml").write_text(
+        f"""
+jobs:
+  review:
+    uses: DataDog/code-review-action/.github/workflows/code-review.yml@{ref} # v1.1.0
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
 class TestCodeReviewPrompt(unittest.TestCase):
-    def test_select_guideline_paths_includes_root_for_any_change(self):
-        self.assertEqual(
-            select_guideline_paths(("pkg/foo.go",)),
-            ("codereview_guideline.md",),
-        )
+    def test_load_guidelines_uses_code_review_action_helper(self):
+        ctx = FakeGuidelineContext()
 
-    def test_select_guideline_paths_includes_matching_scoped_guidelines(self):
-        self.assertEqual(
-            select_guideline_paths(("bazel/rules/foo.bzl", ".claude/skills/my-skill/SKILL.md")),
-            (
-                "codereview_guideline.md",
-                "bazel/codereview_guideline.md",
-                ".claude/skills/codereview_guideline.md",
-            ),
-        )
-
-    def test_load_guidelines_reads_selected_files(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch("tasks.libs.code_review.prompt.is_installed", return_value=True),
+        ):
             repo_root = Path(tmp)
-            (repo_root / "codereview_guideline.md").write_text("root rules\n", encoding="utf-8")
-            (repo_root / "bazel").mkdir()
-            (repo_root / "bazel" / "codereview_guideline.md").write_text("bazel rules\n", encoding="utf-8")
-            (repo_root / ".claude" / "skills").mkdir(parents=True)
-            (repo_root / ".claude" / "skills" / "codereview_guideline.md").write_text(
-                "skill rules\n",
-                encoding="utf-8",
-            )
-
-            guidelines = load_guidelines(repo_root, ("bazel/BUILD.bazel",))
+            write_code_review_workflow(repo_root)
+            guidelines = load_guidelines(ctx, repo_root, ("bazel/BUILD.bazel", "pkg/foo.go"))
 
         self.assertEqual(
             guidelines,
@@ -74,28 +90,50 @@ class TestCodeReviewPrompt(unittest.TestCase):
                 Guideline(path="bazel/codereview_guideline.md", content="bazel rules"),
             ),
         )
+        self.assertIn("npm exec --yes --package", ctx.commands[0][0])
+        self.assertIn("github:DataDog/code-review-action#test-action-ref", ctx.commands[0][0])
+        self.assertIn("-- find-guidelines ", ctx.commands[0][0])
+        self.assertIn(f"--pattern '{PROMPT_FILE_PATTERN}'", ctx.commands[0][0])
+        self.assertIn("--changed-files -", ctx.commands[0][0])
+        self.assertEqual(ctx.stdin, "bazel/BUILD.bazel\npkg/foo.go")
 
-    def test_get_prompt_files_reads_workflow_prompt_file_block(self):
-        with tempfile.TemporaryDirectory() as tmp:
+    def test_load_guidelines_reports_missing_npm(self):
+        with (
+            patch("tasks.libs.code_review.prompt.is_installed", return_value=False),
+            self.assertRaisesRegex(CodeReviewError, "`npm` is not installed or is not on PATH"),
+        ):
+            load_guidelines(NoopContext(), Path("."), ("pkg/foo.go",))
+
+    def test_load_guidelines_reports_action_error(self):
+        ctx = FakeGuidelineContext(
+            exited=1,
+            stdout=json.dumps({"error": "prompt_file and prompt_file_pattern are mutually exclusive"}),
+        )
+
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch("tasks.libs.code_review.prompt.is_installed", return_value=True),
+            self.assertRaisesRegex(CodeReviewError, "mutually exclusive"),
+        ):
             repo_root = Path(tmp)
-            (repo_root / ".github" / "workflows").mkdir(parents=True)
-            (repo_root / ".github" / "workflows" / "code-review.yml").write_text(
-                """
-name: Code review
-jobs:
-  review:
-    with:
-      prompt_file: |
-        codereview_guideline.md
-        bazel/codereview_guideline.md
-""".lstrip(),
-                encoding="utf-8",
-            )
+            write_code_review_workflow(repo_root)
+            load_guidelines(ctx, repo_root, ("pkg/foo.go",))
 
-            self.assertEqual(
-                get_prompt_files(repo_root),
-                ("codereview_guideline.md", "bazel/codereview_guideline.md"),
-            )
+    def test_load_guidelines_reports_unstructured_action_failure(self):
+        ctx = FakeGuidelineContext(
+            exited=1,
+            stdout=json.dumps({"guidelines": []}),
+            stderr="find-guidelines failed",
+        )
+
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch("tasks.libs.code_review.prompt.is_installed", return_value=True),
+            self.assertRaisesRegex(CodeReviewError, "find-guidelines failed"),
+        ):
+            repo_root = Path(tmp)
+            write_code_review_workflow(repo_root)
+            load_guidelines(ctx, repo_root, ("pkg/foo.go",))
 
     def test_render_prompt_appends_extra_prompt(self):
         prompt = render_prompt(

--- a/tasks/unit_tests/code_review_tests.py
+++ b/tasks/unit_tests/code_review_tests.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import tempfile
 import unittest
@@ -56,6 +57,21 @@ class FakeGuidelineContext:
         self.commands.append((command, kwargs))
         self.stdin = kwargs["in_stream"].read()
         return type("Result", (), {"exited": self.exited, "stdout": self.stdout, "stderr": self.stderr})()
+
+
+class FakePromptContext:
+    def __init__(self, *, changed_files="", deleted_prompt_files=""):
+        self.changed_files = changed_files
+        self.deleted_prompt_files = deleted_prompt_files
+        self.commands = []
+
+    def run(self, command, **_kwargs):
+        self.commands.append(command)
+        if "--diff-filter=D" in command:
+            stdout = self.deleted_prompt_files
+        else:
+            stdout = self.changed_files
+        return type("Result", (), {"stdout": stdout})()
 
 
 def write_code_review_workflow(repo_root: Path, ref: str = "test-action-ref") -> None:
@@ -134,6 +150,27 @@ class TestCodeReviewPrompt(unittest.TestCase):
             repo_root = Path(tmp)
             write_code_review_workflow(repo_root)
             load_guidelines(ctx, repo_root, ("pkg/foo.go",))
+
+    def test_build_review_prompt_warns_when_prompt_file_is_deleted(self):
+        ctx = FakePromptContext(
+            changed_files="pkg/foo.go\nbazel/codereview_guideline.md\n",
+            deleted_prompt_files="bazel/codereview_guideline.md\n",
+        )
+
+        with (
+            patch(
+                "tasks.libs.code_review.prompt.load_guidelines",
+                return_value=(Guideline(path="codereview_guideline.md", content="root rules"),),
+            ),
+            patch("sys.stderr", new_callable=io.StringIO) as stderr,
+        ):
+            build_review_prompt(ctx=ctx, repo_root=Path("."), base="origin/main")
+
+        self.assertIn("Warning: deleted code review prompt file(s)", stderr.getvalue())
+        self.assertIn("bazel/codereview_guideline.md", stderr.getvalue())
+        deleted_file_commands = [command for command in ctx.commands if "--diff-filter=D" in command]
+        self.assertEqual(len(deleted_file_commands), 1)
+        self.assertIn(":(glob)**/codereview_guideline.md", deleted_file_commands[0])
 
     def test_render_prompt_appends_extra_prompt(self):
         prompt = render_prompt(

--- a/tasks/unit_tests/code_review_tests.py
+++ b/tasks/unit_tests/code_review_tests.py
@@ -17,6 +17,7 @@ from tasks.libs.code_review.prompt import (
 from tasks.libs.code_review.providers import (
     ProviderInvocation,
     build_provider_invocation,
+    collect_review_diff,
     expand_providers,
     run_provider,
 )
@@ -71,6 +72,22 @@ class FakePromptContext:
         else:
             stdout = self.changed_files
         return type("Result", (), {"stdout": stdout})()
+
+
+class FakeDiffContext:
+    def __init__(self):
+        self.commands = []
+
+    def run(self, command, **_kwargs):
+        self.commands.append(command)
+        stdout = {
+            "--stat": " tasks/foo.py | 2 ++\n",
+            "--name-only": "tasks/foo.py\n",
+        }
+        for marker, output in stdout.items():
+            if marker in command:
+                return type("Result", (), {"exited": 0, "stdout": output, "stderr": ""})()
+        return type("Result", (), {"exited": 0, "stdout": "diff --git a/tasks/foo.py b/tasks/foo.py\n", "stderr": ""})()
 
 
 def write_code_review_workflow(
@@ -232,13 +249,27 @@ class TestCodeReviewProviders(unittest.TestCase):
             review_prompt=review_prompt,
             prompt_path=Path(".tmp/code-review/prompt.md"),
             artifact_dir=Path(".tmp/code-review"),
+            review_diff="--- DIFF STAT ---\ntasks/foo.py | 2 ++\n\n--- PATCH ---\ndiff --git a/tasks/foo.py b/tasks/foo.py\n",
         )
 
         self.assertEqual(invocation.executable, "codex")
         self.assertEqual(invocation.command, "codex exec --sandbox read-only -")
-        self.assertIn("git diff --find-renames origin/main...HEAD", invocation.stdin or "")
+        self.assertIn("Do not run shell commands", invocation.stdin or "")
+        self.assertIn("--- DIFF STAT ---", invocation.stdin or "")
+        self.assertIn("diff --git a/tasks/foo.py b/tasks/foo.py", invocation.stdin or "")
         self.assertIn("custom review instructions", invocation.stdin or "")
         self.assertEqual(invocation.output_path, Path(".tmp/code-review/codex.md"))
+
+    def test_collect_review_diff(self):
+        ctx = FakeDiffContext()
+
+        review_diff = collect_review_diff(ctx, Path("/repo"), "origin/main")
+
+        self.assertIn("--- DIFF STAT ---\ntasks/foo.py | 2 ++", review_diff)
+        self.assertIn("--- CHANGED FILES ---\ntasks/foo.py", review_diff)
+        self.assertIn("--- PATCH ---\ndiff --git a/tasks/foo.py b/tasks/foo.py", review_diff)
+        self.assertEqual(len(ctx.commands), 3)
+        self.assertTrue(all("origin/main...HEAD" in command for command in ctx.commands))
 
     def test_build_claude_invocation_references_prompt_file(self):
         review_prompt = build_review_prompt(


### PR DESCRIPTION
### What does this PR do?

Updates the local `dda review` prompt generation to reuse `DataDog/code-review-action` v1.1.0 guideline discovery via its `find-guidelines` CLI instead of maintaining local Python logic for workflow prompt-file parsing and changed-file scoping.

Also bumps the GitHub workflow to code-review-action v1.1.0 and switches it to `prompt_file_pattern: "**/codereview_guideline.md"`.

### Motivation

Keep local `dda review` guideline selection aligned with the GitHub action implementation and avoid maintaining duplicate selection logic in the Agent repo.
https://datadoghq.atlassian.net/browse/ACIX-1781
### Describe how you validated your changes

- `dda inv invoke-unit-tests.run --directory=tasks/unit_tests --tests=code_review`
- `dda review show-prompt --base=HEAD`
- `dda inv linter.python`
- `git diff --check`
