### PR TITLE
Make macOS test jobs manual on dev branches, mandatory in the merge queue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1479,7 +1479,7 @@ workflow:
       <<: *fakeintake_paths
     <<: *if_main_branch
 
-.fast_on_dev_branch_only:
+.fast_tests_variables_named_branches:
   - <<: *if_main_branch
     variables:
       FAST_TESTS: "false"
@@ -1501,10 +1501,40 @@ workflow:
     variables:
       FAST_TESTS: "false"
       COVERAGE_CACHE_FLAG: ""
+
+.fast_on_dev_branch_only:
+  - !reference [.fast_tests_variables_named_branches]
   - variables:
       FAST_TESTS: "true"
       # Pull coverage cache on dev branches
       COVERAGE_CACHE_FLAG: "--pull-coverage-cache"
+
+# macOS runners are scarce and queue for tens of minutes under load. These jobs stay
+# mandatory wherever they gate a merge (main/release/mergequeue/forced runs), but on
+# regular dev branches they become manual so they don't contend for runners on every push.
+.fast_tests_mergequeue_mandatory_manual_on_dev_branch:
+  - !reference [.fast_tests_variables_named_branches]
+  - <<: *if_mergequeue
+    variables:
+      FAST_TESTS: "true"
+      COVERAGE_CACHE_FLAG: "--pull-coverage-cache"
+  - variables:
+      FAST_TESTS: "true"
+      COVERAGE_CACHE_FLAG: "--pull-coverage-cache"
+    when: manual
+    allow_failure: true
+
+# Same "mandatory on merge/mergequeue, manual on dev branches" policy for jobs that
+# don't use the FAST_TESTS/coverage-cache mechanism above.
+.on_mergequeue_mandatory_manual_on_dev_branches:
+  - !reference [.on_mergequeue]
+  - <<: *if_main_branch
+  - <<: *if_release_branch
+  - <<: *if_tagged_commit
+  - <<: *if_triggered_pipeline
+  - <<: *if_run_all_unit_tests
+  - when: manual
+    allow_failure: true
 
 .on_gitlab_changes:
   changes:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1524,18 +1524,6 @@ workflow:
     when: manual
     allow_failure: true
 
-# Same "mandatory on merge/mergequeue, manual on dev branches" policy for jobs that
-# don't use the FAST_TESTS/coverage-cache mechanism above.
-.on_mergequeue_mandatory_manual_on_dev_branches:
-  - !reference [.on_mergequeue]
-  - <<: *if_main_branch
-  - <<: *if_release_branch
-  - <<: *if_tagged_commit
-  - <<: *if_triggered_pipeline
-  - <<: *if_run_all_unit_tests
-  - when: manual
-    allow_failure: true
-
 .on_gitlab_changes:
   changes:
     paths:

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -44,6 +44,8 @@ bazel:test:linux-arm64:
 
 bazel:test:macos-amd64:
   extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:macos-amd64 ]
+  rules:
+    - !reference [.on_mergequeue_mandatory_manual_on_dev_branches]
   script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting:ci_links]
@@ -54,6 +56,8 @@ bazel:test:macos-amd64:
 
 bazel:test:macos-arm64:
   extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:macos-arm64 ]
+  rules:
+    - !reference [.on_mergequeue_mandatory_manual_on_dev_branches]
   script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting:ci_links]
@@ -134,21 +138,29 @@ bazel:test:linux-arm64:iot:
 
 bazel:test:macos-amd64:base:
   extends: [ .bazel:test:flavor:macos, .bazel:runner:macos-amd64 ]
+  rules:
+    - !reference [.on_mergequeue_mandatory_manual_on_dev_branches]
   variables:
     FLAVOR: base
 
 bazel:test:macos-amd64:dogstatsd:
   extends: [ .bazel:test:flavor:macos, .bazel:runner:macos-amd64 ]
+  rules:
+    - !reference [.on_mergequeue_mandatory_manual_on_dev_branches]
   variables:
     FLAVOR: dogstatsd
 
 bazel:test:macos-arm64:base:
   extends: [ .bazel:test:flavor:macos, .bazel:runner:macos-arm64 ]
+  rules:
+    - !reference [.on_mergequeue_mandatory_manual_on_dev_branches]
   variables:
     FLAVOR: base
 
 bazel:test:macos-arm64:dogstatsd:
   extends: [ .bazel:test:flavor:macos, .bazel:runner:macos-arm64 ]
+  rules:
+    - !reference [.on_mergequeue_mandatory_manual_on_dev_branches]
   variables:
     FLAVOR: dogstatsd
 

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -44,8 +44,6 @@ bazel:test:linux-arm64:
 
 bazel:test:macos-amd64:
   extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:macos-amd64 ]
-  rules:
-    - !reference [.on_mergequeue_mandatory_manual_on_dev_branches]
   script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting:ci_links]
@@ -56,8 +54,6 @@ bazel:test:macos-amd64:
 
 bazel:test:macos-arm64:
   extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:macos-arm64 ]
-  rules:
-    - !reference [.on_mergequeue_mandatory_manual_on_dev_branches]
   script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting:ci_links]
@@ -138,29 +134,21 @@ bazel:test:linux-arm64:iot:
 
 bazel:test:macos-amd64:base:
   extends: [ .bazel:test:flavor:macos, .bazel:runner:macos-amd64 ]
-  rules:
-    - !reference [.on_mergequeue_mandatory_manual_on_dev_branches]
   variables:
     FLAVOR: base
 
 bazel:test:macos-amd64:dogstatsd:
   extends: [ .bazel:test:flavor:macos, .bazel:runner:macos-amd64 ]
-  rules:
-    - !reference [.on_mergequeue_mandatory_manual_on_dev_branches]
   variables:
     FLAVOR: dogstatsd
 
 bazel:test:macos-arm64:base:
   extends: [ .bazel:test:flavor:macos, .bazel:runner:macos-arm64 ]
-  rules:
-    - !reference [.on_mergequeue_mandatory_manual_on_dev_branches]
   variables:
     FLAVOR: base
 
 bazel:test:macos-arm64:dogstatsd:
   extends: [ .bazel:test:flavor:macos, .bazel:runner:macos-arm64 ]
-  rules:
-    - !reference [.on_mergequeue_mandatory_manual_on_dev_branches]
   variables:
     FLAVOR: dogstatsd
 

--- a/.gitlab/build/source_test/macos.yml
+++ b/.gitlab/build/source_test/macos.yml
@@ -9,7 +9,7 @@ include:
     - .macos_gitlab
   rules:
     - !reference [.except_disable_unit_tests]
-    - !reference [.fast_on_dev_branch_only]
+    - !reference [.fast_tests_mergequeue_mandatory_manual_on_dev_branch]
   variables:
     FLAKY_PATTERNS_CONFIG: $CI_PROJECT_DIR/flaky-patterns-runtime.yaml
     TEST_OUTPUT_FILE: test_output


### PR DESCRIPTION
### What does this PR do?

Changes the scheduling policy of the macOS test jobs that run on every pipeline:
- `tests_macos_gitlab_arm64` (`.gitlab/build/source_test/macos.yml`)
- `bazel:test:macos-amd64`, `bazel:test:macos-arm64`, and their `:base`/`:dogstatsd` flavor variants (`.gitlab/build/bazel/test.yml`)

They now run automatically (`on_success`) only in the merge queue, on `main`/release branches, and on forced/triggered pipelines (`RUN_UNIT_TESTS=on`, triggered pipelines, tags). On regular dev branches they become `manual` (non-blocking, `allow_failure: true`), so engineers can still run them on demand but they no longer compete for macOS runner capacity on every push.

### Motivation

Our macOS runner pool is a scarce, shared resource. These jobs currently run unconditionally on every pipeline (dev branches included), and are queuing for a long time under load (~50 min for some macOS jobs, per current CI Visibility data: `tests_macos_gitlab_arm64` and `bazel:test:macos-arm64*` show p90 queue times of 35-42 minutes over the last 7 days). Keeping them mandatory in the merge queue preserves pre-merge signal while freeing up runners for other dev-branch pipelines.

### Describe how you validated your changes

- Ran `dda inv -- -e linter.full-gitlab-ci`, which validates the full resolved config across 9 representative contexts (main, merge queue, release/tag, deploy, forced unit tests, etc.) — passes with only pre-existing warnings.
- Used `dda inv -- -e gitlab.compute-gitlab-ci-config` (resolves the config via the GitLab CI Lint API) to confirm the resolved `rules:` for each affected job: `on_success` on `mq-working-branch-*`/`main`/release/tag/triggered/`RUN_UNIT_TESTS=on`, and `when: manual, allow_failure: true` as the dev-branch fallback.

### Additional Notes

Scope was picked by querying Datadog CI Visibility for job-level queue time (`@ci.queue_time`) grouped by macOS job name on the `DataDog/datadog-agent` pipeline, to confirm which macOS jobs are actually the ones bottlenecking runner capacity.