### PR TITLE
fix(flare): collect dynamic instrumentation tombstone from run_path

### DIFF
--- a/pkg/flare/BUILD.bazel
+++ b/pkg/flare/BUILD.bazel
@@ -58,9 +58,11 @@ go_library(
     ] + select({
         "@rules_go//go/platform:android": [
             "//pkg/system-probe/config",
+            "//pkg/util/defaultpaths",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/system-probe/config",
+            "//pkg/util/defaultpaths",
         ],
         "@rules_go//go/platform:windows": [
             "//pkg/util/winutil",

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/flare/priviledged"
 	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
 	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
+	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 )
 
 // DatadogBinaries is the list of Datadog agent binary names used to filter
@@ -60,7 +61,7 @@ func addSystemProbePlatformSpecificEntries(fb flaretypes.FlareBuilder) {
 		// Copy the dynamic instrumentation tombstone file if it exists.
 		// This file persists probe definitions across restarts and is
 		// valuable for debugging even when system-probe is not running.
-		dyninstTombstonePath := filepath.Join(os.TempDir(), "datadog-agent", "system-probe", "dynamic-instrumentation", "debugger-probes-tombstone.json")
+		dyninstTombstonePath := filepath.Join(defaultpaths.GetDefaultRunPath(), "system-probe", "dynamic-instrumentation", "debugger-probes-tombstone.json")
 		fb.CopyFileTo(dyninstTombstonePath, filepath.Join("system-probe", "dyninst_tombstone.json")) //nolint:errcheck
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Points the flare at the current location of the dynamic instrumentation tombstone file, `run_path/system-probe/dynamic-instrumentation/debugger-probes-tombstone.json`, instead of the old world-writable `/tmp` path.

### Motivation

PR #53286 moved the dynamic instrumentation tombstone out of `/tmp` and into the agent's root-owned run directory, but the flare was still copying it from the old `/tmp` path. As a result the tombstone was silently missing from generated flares, removing a signal that is valuable for debugging probe-load crashes even when system-probe is not running. This updates the flare to read  from the location the module now writes.

### Describe how you validated your changes

Built `pkg/flare`. Confirmed the path matches `dynamicInstrumentationStateDir()` introduced in #53286 (`run_path/system-probe/dynamic-instrumentation`).

### Additional Notes

Follow-up to #53286, which relocated the writable state but did not update the  flare's hardcoded path.