### PR TITLE
packaging/aix: build under a private TMPDIR off /tmp

### DIFF
--- a/packaging/aix/lib/env.sh
+++ b/packaging/aix/lib/env.sh
@@ -163,14 +163,10 @@ unset _mem_kb
 # Redirect the Go build cache off /tmp (which is only 12 GB) to the larger
 # build volume so that large packages like datadogV2 don't exhaust /tmp.
 GOCACHE=/opt/dd-build/gocache
-# Redirect the general temp dir off /tmp as well, for two reasons:
-#   1. /tmp is small (12 GB); pip wheel builds, cargo scratch dirs, and Go
-#      linker inputs can exhaust it.
-#   2. A stray file left in /tmp by another user can poison cargo-based wheel
-#      builds (maturin, cryptography): cargo walks up the directory tree from
-#      its build dir looking for a workspace root and will pick up a stray
-#      /tmp/Cargo.toml, failing with "failed to find a workspace root".
-#      Building under a private temp dir isolates us from the rest of /tmp.
+# Give the build its own temp dir instead of the shared /tmp, so it is not
+# affected by a full /tmp or by unrelated files other processes leave there
+# (which can, for example, confuse cargo's workspace-root lookup during
+# wheel builds).
 TMPDIR=/opt/dd-build/buildtmp
 mkdir -p "$GOCACHE" "$TMPDIR"
 

--- a/packaging/aix/lib/env.sh
+++ b/packaging/aix/lib/env.sh
@@ -163,9 +163,18 @@ unset _mem_kb
 # Redirect the Go build cache off /tmp (which is only 12 GB) to the larger
 # build volume so that large packages like datadogV2 don't exhaust /tmp.
 GOCACHE=/opt/dd-build/gocache
-mkdir -p "$GOCACHE"
+# Redirect the general temp dir off /tmp as well, for two reasons:
+#   1. /tmp is small (12 GB); pip wheel builds, cargo scratch dirs, and Go
+#      linker inputs can exhaust it.
+#   2. A stray file left in /tmp by another user can poison cargo-based wheel
+#      builds (maturin, cryptography): cargo walks up the directory tree from
+#      its build dir looking for a workspace root and will pick up a stray
+#      /tmp/Cargo.toml, failing with "failed to find a workspace root".
+#      Building under a private temp dir isolates us from the rest of /tmp.
+TMPDIR=/opt/dd-build/buildtmp
+mkdir -p "$GOCACHE" "$TMPDIR"
 
-export PATH GOPATH GOROOT CGO_ENABLED CGO_CFLAGS CGO_LDFLAGS GOPROXY GOTOOLCHAIN GOCACHE
+export PATH GOPATH GOROOT CGO_ENABLED CGO_CFLAGS CGO_LDFLAGS GOPROXY GOTOOLCHAIN GOCACHE TMPDIR
 
 # ── Utility functions ─────────────────────────────────────────────────────────
 

--- a/packaging/aix/stages/05-python-extensions.sh
+++ b/packaging/aix/stages/05-python-extensions.sh
@@ -138,7 +138,7 @@ log "Installing cffi==$CFFI_VERSION (C extension, bundled libffi)"
 log "  Downloading cffi source and patching for AIX TLS compatibility"
 
 # Download cffi source via pip (handles URL resolution, caching, etc.)
-CFFI_SRCDIR="/tmp/cffi-${CFFI_VERSION}-aix-src"
+CFFI_SRCDIR="$TMPDIR/cffi-${CFFI_VERSION}-aix-src"
 rm -rf "$CFFI_SRCDIR"
 mkdir -p "$CFFI_SRCDIR"
 $PIP download --no-deps --no-binary cffi "cffi==$CFFI_VERSION" -d "$CFFI_SRCDIR"
@@ -148,12 +148,12 @@ if [ -z "$CFFI_TARBALL" ]; then
     exit 1
 fi
 log "  cffi source: $CFFI_TARBALL"
-CFFI_BUILDDIR="/tmp/cffi-${CFFI_VERSION}-build"
+CFFI_BUILDDIR="$TMPDIR/cffi-${CFFI_VERSION}-build"
 rm -rf "$CFFI_BUILDDIR"
 # Use Python tarfile module for extraction: AIX native tar rejects modern
 # tar formats (pax headers) used by cffi's PyPI distribution.
-$PYTHON_BIN -c "import tarfile, os; tarfile.open('$CFFI_TARBALL').extractall('/tmp')"
-mv "/tmp/cffi-${CFFI_VERSION}" "$CFFI_BUILDDIR"
+$PYTHON_BIN -c "import tarfile, os; tarfile.open('$CFFI_TARBALL').extractall('$TMPDIR')"
+mv "$TMPDIR/cffi-${CFFI_VERSION}" "$CFFI_BUILDDIR"
 
 # Patch setup.py: add sys.platform != 'aix' check to ask_supports_thread()
 # so that __thread is not used in the shared library (causes 0509-187 on AIX).


### PR DESCRIPTION
### What does this PR do?

Points `TMPDIR` at the build volume (`/opt/dd-build/buildtmp`) for the AIX package build, instead of relying on the shared `/tmp`.

### Motivation

Avoid failures due to /tmp being full or when it contains specific files left from different processes (eg. a Cargo.toml can confuse cargo and make it fail).

This mirrors what we already do for `GOCACHE`.

### Describe how you validated your changes

Ran a full from-scratch AIX package build with the change in place; the Python-extension stage (maturin + cryptography) built successfully and the package was produced.

### Additional Notes

AIX packaging only; no runtime/agent behavior change.
