### PR TITLE
packaging/aix: always rebuild rtloader (drop the .done sentinel)

### DIFF
--- a/packaging/aix/stages/03-rtloader.sh
+++ b/packaging/aix/stages/03-rtloader.sh
@@ -15,10 +15,6 @@ exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
 
-# No completion sentinel: this stage always runs so the built library stays in
-# sync with its source. The build directory is wiped on every run to avoid stale
-# cmake cache or mtime-based make decisions (see Step 1).
-
 # --- Input validation ---
 : "${STAGING:?STAGING must be set}"
 : "${EMBEDDED:?EMBEDDED must be set}"
@@ -49,14 +45,9 @@ cleanup() {
 trap cleanup EXIT
 
 # ─── Step 1: Clean and create rtloader build directory ────────────────────────
-#
-# The build directory is wiped on every run so cmake always starts from a clean
-# state. This avoids stale cache entries and mtime-based make decisions that
-# could cause make to silently skip rebuilding object files after a source
-# refresh (tar preserves original mtimes, so extracted sources may be older
-# than the previous build outputs).
 
 log "Cleaning rtloader build directory"
+# The build directory is wiped to avoid stale cache entries mtime-based make decisions.
 rm -rf "$AGENT_SRC/rtloader/build"
 mkdir -p "$AGENT_SRC/rtloader/build"
 

--- a/packaging/aix/stages/03-rtloader.sh
+++ b/packaging/aix/stages/03-rtloader.sh
@@ -16,8 +16,8 @@ exec > "$LOG" 2>&1
 log "=== Stage: $STAGE_NAME ==="
 
 # No completion sentinel: this stage always runs so the built library stays in
-# sync with its source. rtloader builds in seconds and cmake/make rebuild
-# incrementally (see Step 1), so always running it is cheap.
+# sync with its source. The build directory is wiped on every run to avoid stale
+# cmake cache or mtime-based make decisions (see Step 1).
 
 # --- Input validation ---
 : "${STAGING:?STAGING must be set}"
@@ -48,14 +48,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# ─── Step 1: Create rtloader build directory ──────────────────────────────────
+# ─── Step 1: Clean and create rtloader build directory ────────────────────────
 #
-# The build directory is deliberately NOT wiped between runs: this stage always
-# runs (no sentinel), and cmake/make do incremental rebuilds, recompiling only
-# what changed since the last run. The failure-cleanup trap removes the build
-# directory on error, so a broken configure self-heals on the next run.
+# The build directory is wiped on every run so cmake always starts from a clean
+# state. This avoids stale cache entries and mtime-based make decisions that
+# could cause make to silently skip rebuilding object files after a source
+# refresh (tar preserves original mtimes, so extracted sources may be older
+# than the previous build outputs).
 
-log "Preparing rtloader build directory"
+log "Cleaning rtloader build directory"
+rm -rf "$AGENT_SRC/rtloader/build"
 mkdir -p "$AGENT_SRC/rtloader/build"
 
 # ─── Step 2: CMake configure ──────────────────────────────────────────────────

--- a/packaging/aix/stages/03-rtloader.sh
+++ b/packaging/aix/stages/03-rtloader.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/../lib/env.sh"
 
 STAGE_NAME="03-rtloader"
-SENTINEL="$BUILD_DIR/.done/$STAGE_NAME"
 LOG="$BUILD_DIR/logs/$STAGE_NAME.log"
 
 # Redirect all output to log file (follow with: tail -f "$LOG")
@@ -16,11 +15,9 @@ exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
 
-# --- Idempotency check ---
-if [ -f "$SENTINEL" ]; then
-    log "Already complete (sentinel: $SENTINEL) — skipping."
-    exit 0
-fi
+# No completion sentinel: this stage always runs so the built library stays in
+# sync with its source. rtloader builds in seconds and cmake/make rebuild
+# incrementally (see Step 1), so always running it is cheap.
 
 # --- Input validation ---
 : "${STAGING:?STAGING must be set}"
@@ -51,10 +48,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# ─── Step 1: Clean and create rtloader build directory ────────────────────────
+# ─── Step 1: Create rtloader build directory ──────────────────────────────────
+#
+# The build directory is deliberately NOT wiped between runs: this stage always
+# runs (no sentinel), and cmake/make do incremental rebuilds, recompiling only
+# what changed since the last run. The failure-cleanup trap removes the build
+# directory on error, so a broken configure self-heals on the next run.
 
-log "Cleaning rtloader build directory"
-rm -rf "$AGENT_SRC/rtloader/build"
+log "Preparing rtloader build directory"
 mkdir -p "$AGENT_SRC/rtloader/build"
 
 # ─── Step 2: CMake configure ──────────────────────────────────────────────────
@@ -259,7 +260,4 @@ if [ "$MAGIC" != "01f7" ]; then
 fi
 log "XCOFF64 magic verified for libdatadog-agent-rtloader.so (magic: $MAGIC)"
 
-# --- Mark complete ---
-mkdir -p "$(dirname "$SENTINEL")"
-touch "$SENTINEL"
 log "=== $STAGE_NAME complete ==="


### PR DESCRIPTION
### What does this PR do?

Removes the `.done/03-rtloader` completion sentinel so the rtloader stage runs on every AIX package build instead of being skipped once "done". The build directory is no longer wiped between runs, so cmake/make rebuild incrementally.

### Motivation

Avoids not rebuilding rtloader when it should be rebuilt, which has actually happened, breaking a build and resulting in surprising behavior.

rtloader builds in seconds, so always running the stage is cheap; letting cmake handle incremental rebuilds keeps it fast while guaranteeing the shipped library always matches the current source.

### Describe how you validated your changes

Ran a full from-scratch AIX package build with the change.

### Additional Notes

AIX packaging only; no runtime/agent behavior change.
