### PR TITLE
Enable Bazel action rewinding for `Lost inputs no longer available remotely`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,6 +29,7 @@ common --remote_instance_name=ci/datadog-agent # entries missing from datadog-ag
 common --remote_local_fallback # best-effort on transient connection errors (no such host)
 common --remote_retries=1
 common --remote_timeout=60
+common --rewind_lost_inputs # https://github.com/bazelbuild/bazel/pull/25477
 common --repo_env=DEPLOY_AGENT # Keep in sync with env_vars in MODULE.bazel
 common --repo_env=FORCED_PACKAGE_COMPRESSION_LEVEL # Keep in sync with env_vars in MODULE.bazel
 common --repo_env=GOCACHE # https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching


### PR DESCRIPTION
### What does this PR do?
Turn on Bazel's finer-grained action rewinding (`--rewind_lost_inputs`), so a lost remote-cache input can be recovered by rerunning just the actions that produced it, **within the same invocation**.

### Motivation
[#incident-56814](https://dd.enterprise.slack.com/archives/C0BDJA57NLU) where CI jobs have been hitting recurring:
> [...] failed: Lost inputs no longer available remotely: [...]

- example: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1839544846#L3296 (~50 minutes!)
- known issue: bazelbuild/bazel#27929

This is likely caused by inconsistent retention periods[^1] between:
- either the local disk cache and the remote cache,
- or the layers composing the remote caching stack (frontend / backend / storage).

In this case, Bazel already retries a lost-input failure **at the whole-invocation level** by default (`--experimental_remote_cache_eviction_retries=5`).
This mechanism indeed allows jobs to recover and even report success (unless retries are exhausted), but at the expense of a retry cost in minutes redoing analysis and re-running actions from a fresh invocation.

From [Troubleshooting RBE Failures](https://www.buildbuddy.io/docs/troubleshooting-rbe/#cachenotfoundexception-missing-digest):
> The ideal solution is for Bazel to either re-upload the missing blob or re-execute the action that created it. This process is also known as "Action Rewinding" in Bazel. However, this feature is not yet available as of Bazel 8.0

We're now running Bazel 9.1.1.

Action rewinding complements the existing retry by recovering inside the same invocation, at the action level, without discarding completed work or waiting on a full restart.
Its concurrency races were fixed by Bazel 9.1.0 (bazelbuild/bazel#25477) and 9.1.1 (bazelbuild/bazel#29551), which we are pinned to.

### Describe how you validated your changes
I managed to trigger the lightweight mechanism on my machine, but only once.

CI monitoring will tell ([logs](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%22lost%20inputs%22%20%40git.branch%3Amain&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1782209760301&to_ts=1783505760301&live=true)).

### Additional Notes
It is an acknowledged best effort, as some lost-input shapes (tree artifacts, deduplicated Merkle subtrees) are not yet covered upstream:
- bazelbuild/bazel#30065,
- bazelbuild/bazel#30085.

[^1]: e.g. a 2-hour retention is advertised but actual is 1 hour.