### PR TITLE
discovery: disable discovery after successive timeouts error

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -10,6 +10,10 @@ package process
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -34,7 +38,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/discovery/core"
 	"github.com/DataDog/datadog-agent/pkg/discovery/model"
 	tracermetadata "github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata/model"
-	"github.com/DataDog/datadog-agent/pkg/errors"
+	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -50,8 +54,9 @@ const (
 	cacheValidityNoRT = 2 * time.Second
 
 	// Service discovery constants
-	maxPortCheckTries                   = 10
-	serviceCollectionBatchSizeConfigKey = "discovery.service_collection_batch_size"
+	maxPortCheckTries                                = 10
+	serviceCollectionBatchSizeConfigKey              = "discovery.service_collection_batch_size"
+	serviceCollectionMaxConsecutiveTimeoutsConfigKey = "discovery.service_collection_max_consecutive_timeouts"
 )
 
 type collector struct {
@@ -68,13 +73,15 @@ type collector struct {
 	containerProvider      proccontainers.ContainerProvider
 
 	// Service discovery fields
-	sysProbeClient             *sysprobeclient.CheckClient
-	serviceCollectionBatchSize int
-	serviceRetries             map[int32]uint
-	ignoredPids                core.PidSet
-	pidHeartbeats              map[int32]time.Time
-	knownInjectionStatusPids   core.PidSet // Track PIDs whose injection status we've already reported (but have no service data yet)
-	metricDiscoveredServices   telemetry.Gauge
+	sysProbeClient                          *sysprobeclient.CheckClient
+	serviceCollectionBatchSize              int
+	serviceCollectionMaxConsecutiveTimeouts int
+	consecutiveServiceDiscoveryTimeouts     int
+	serviceRetries                          map[int32]uint
+	ignoredPids                             core.PidSet
+	pidHeartbeats                           map[int32]time.Time
+	knownInjectionStatusPids                core.PidSet // Track PIDs whose injection status we've already reported (but have no service data yet)
+	metricDiscoveredServices                telemetry.Gauge
 }
 
 // EventType represents the type of collector event
@@ -116,13 +123,14 @@ func newProcessCollector(id string, catalog workloadmeta.AgentType, clock clock.
 		lastCollectedProcesses: make(map[int32]*procutil.Process),
 
 		// Initialize service discovery fields
-		sysProbeClient:             sysprobeclient.GetCheckClient(),
-		serviceCollectionBatchSize: systemProbeConfig.GetInt(serviceCollectionBatchSizeConfigKey),
-		serviceRetries:             make(map[int32]uint),
-		ignoredPids:                make(core.PidSet),
-		pidHeartbeats:              make(map[int32]time.Time),
-		knownInjectionStatusPids:   make(core.PidSet),
-		metricDiscoveredServices:   discoveredServicesGauge,
+		sysProbeClient:                          sysprobeclient.GetCheckClient(),
+		serviceCollectionBatchSize:              systemProbeConfig.GetInt(serviceCollectionBatchSizeConfigKey),
+		serviceCollectionMaxConsecutiveTimeouts: systemProbeConfig.GetInt(serviceCollectionMaxConsecutiveTimeoutsConfigKey),
+		serviceRetries:                          make(map[int32]uint),
+		ignoredPids:                             make(core.PidSet),
+		pidHeartbeats:                           make(map[int32]time.Time),
+		knownInjectionStatusPids:                make(core.PidSet),
+		metricDiscoveredServices:                discoveredServicesGauge,
 	}
 }
 
@@ -214,7 +222,7 @@ func (c *collector) processCollectionIntervalConfig() time.Duration {
 // can use Notify, or get access to other entities in the store.
 func (c *collector) Start(ctx context.Context, store workloadmeta.Component) error {
 	if !c.isProcessCollectionEnabled() && !c.isServiceDiscoveryEnabled() && !c.isLanguageCollectionEnabled() && !c.isGPUMonitoringEnabled() {
-		return errors.NewDisabled(componentName, "process collection, service discovery, language collection, and GPU monitoring are disabled")
+		return dderrors.NewDisabled(componentName, "process collection, service discovery, language collection, and GPU monitoring are disabled")
 	}
 
 	if c.containerProvider == nil {
@@ -385,6 +393,13 @@ func (c *collector) getDiscoveryServices(newPids []int32, heartbeatPids []int32)
 	return &response, nil
 }
 
+var (
+	errServiceDiscoveryRequestStartup = errors.New("system-probe not started")
+	errServiceDiscoveryRequestTimeout = errors.New("service discovery request timeout")
+)
+
+const systemProbeStartupCheckURL = "http://sysprobe/debug/stats"
+
 type serviceDiscoveryPIDBatch struct {
 	newPids       []int32
 	heartbeatPids []int32
@@ -450,7 +465,7 @@ func mergeServiceDiscoveryResponses(dst *model.ServicesResponse, src *model.Serv
 	dst.GPUPIDs = append(dst.GPUPIDs, src.GPUPIDs...)
 }
 
-func (c *collector) getDiscoveryServicesBatched(ctx context.Context, newPids []int32, heartbeatPids []int32) (*model.ServicesResponse, []int32, []int32) {
+func (c *collector) getDiscoveryServicesBatched(ctx context.Context, newPids []int32, heartbeatPids []int32) (*model.ServicesResponse, []int32, []int32, error) {
 	batches := buildServiceDiscoveryPIDBatches(newPids, heartbeatPids, c.serviceCollectionBatchSize)
 	mergedResponse := &model.ServicesResponse{}
 	successfulNewPids := make([]int32, 0, len(newPids))
@@ -460,7 +475,7 @@ func (c *collector) getDiscoveryServicesBatched(ctx context.Context, newPids []i
 		select {
 		case <-ctx.Done():
 			log.Debugf("stopping service discovery batching after %d/%d batches: %s", batchIndex, len(batches), ctx.Err())
-			return mergedResponse, successfulNewPids, successfulHeartbeatPids
+			return mergedResponse, successfulNewPids, successfulHeartbeatPids, nil
 		default:
 		}
 
@@ -471,10 +486,12 @@ func (c *collector) getDiscoveryServicesBatched(ctx context.Context, newPids []i
 		if err != nil {
 			// CheckClient handles startup warnings internally, but we still need to suppress
 			// the error if system-probe hasn't started yet.
-			if sysprobeclient.IgnoreStartupError(err) != nil {
-				log.Errorf("failed to get services: %s", err)
+			if sysprobeclient.IgnoreStartupError(err) == nil {
+				err = fmt.Errorf("%w: %w", errServiceDiscoveryRequestStartup, err)
+			} else if isServiceDiscoveryRequestTimeout(err) {
+				err = fmt.Errorf("%w: %w", errServiceDiscoveryRequestTimeout, err)
 			}
-			return mergedResponse, successfulNewPids, successfulHeartbeatPids
+			return mergedResponse, successfulNewPids, successfulHeartbeatPids, fmt.Errorf("failed to get services: %w", err)
 		}
 
 		mergeServiceDiscoveryResponses(mergedResponse, resp)
@@ -482,7 +499,60 @@ func (c *collector) getDiscoveryServicesBatched(ctx context.Context, newPids []i
 		successfulHeartbeatPids = append(successfulHeartbeatPids, batch.heartbeatPids...)
 	}
 
-	return mergedResponse, successfulNewPids, successfulHeartbeatPids
+	return mergedResponse, successfulNewPids, successfulHeartbeatPids, nil
+}
+
+func isServiceDiscoveryRequestTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.URL == systemProbeStartupCheckURL {
+		return false
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+func (c *collector) serviceDiscoveryDisabledByTimeouts() bool {
+	return c.serviceCollectionMaxConsecutiveTimeouts > 0 &&
+		c.consecutiveServiceDiscoveryTimeouts >= c.serviceCollectionMaxConsecutiveTimeouts
+}
+
+func (c *collector) handleServiceDiscoveryRequestError(err error) {
+	if err == nil {
+		return
+	}
+
+	switch {
+	case errors.Is(err, errServiceDiscoveryRequestStartup):
+		return
+	case errors.Is(err, errServiceDiscoveryRequestTimeout):
+		log.Errorf("%s", err)
+		if c.serviceCollectionMaxConsecutiveTimeouts <= 0 {
+			return
+		}
+		if c.serviceDiscoveryDisabledByTimeouts() {
+			return
+		}
+
+		c.consecutiveServiceDiscoveryTimeouts++
+		if c.serviceDiscoveryDisabledByTimeouts() {
+			log.Warnf(
+				"disabling service discovery after %d consecutive system-probe request timeouts; restart the Agent to re-enable it",
+				c.consecutiveServiceDiscoveryTimeouts,
+			)
+		}
+	default:
+		log.Errorf("%s", err)
+		c.consecutiveServiceDiscoveryTimeouts = 0
+	}
 }
 
 func (c *collector) handleServiceRetries(pid int32) {
@@ -593,12 +663,23 @@ func (c *collector) getProcessEntitiesFromServices(newPids []int32, heartbeatPid
 
 // updateServices retrieves service discovery data for alive processes and returns workloadmeta entities
 func (c *collector) updateServices(ctx context.Context, alivePids core.PidSet, procs map[int32]*procutil.Process) ([]*workloadmeta.Process, core.PidSet) {
+	if c.serviceDiscoveryDisabledByTimeouts() {
+		return nil, nil
+	}
+
 	newPids, heartbeatPids := c.filterPidsToRequest(alivePids, procs)
 	if len(newPids) == 0 && len(heartbeatPids) == 0 {
 		return nil, nil
 	}
 
-	resp, successfulNewPids, successfulHeartbeatPids := c.getDiscoveryServicesBatched(ctx, newPids, heartbeatPids)
+	resp, successfulNewPids, successfulHeartbeatPids, err := c.getDiscoveryServicesBatched(ctx, newPids, heartbeatPids)
+	if err == nil || len(successfulNewPids) > 0 || len(successfulHeartbeatPids) > 0 {
+		c.consecutiveServiceDiscoveryTimeouts = 0
+	}
+	if err != nil {
+		c.handleServiceDiscoveryRequestError(err)
+	}
+
 	if len(successfulNewPids) == 0 && len(successfulHeartbeatPids) == 0 {
 		return nil, nil
 	}

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -10,9 +10,11 @@ package process
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"sync"
 	"testing"
@@ -256,8 +258,9 @@ func TestServiceDiscoveryBatchingSuccessfulRequestsMergeResponses(t *testing.T) 
 	})
 	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
-	resp, successfulNewPids, successfulHeartbeatPids := c.collector.getDiscoveryServicesBatched(context.Background(), []int32{101, 102}, nil)
+	resp, successfulNewPids, successfulHeartbeatPids, err := c.collector.getDiscoveryServicesBatched(context.Background(), []int32{101, 102}, nil)
 
+	require.NoError(t, err)
 	require.Equal(t, []int32{101, 102}, successfulNewPids)
 	require.Empty(t, successfulHeartbeatPids)
 	require.NotNil(t, resp)
@@ -291,14 +294,37 @@ func TestServiceDiscoveryBatchingStopsWhenContextCanceled(t *testing.T) {
 	})
 	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
-	resp, successfulNewPids, successfulHeartbeatPids := c.collector.getDiscoveryServicesBatched(ctx, []int32{101, 102, 103}, nil)
+	resp, successfulNewPids, successfulHeartbeatPids, err := c.collector.getDiscoveryServicesBatched(ctx, []int32{101, 102, 103}, nil)
 
+	require.NoError(t, err)
 	require.Equal(t, []int32{101}, successfulNewPids)
 	require.Empty(t, successfulHeartbeatPids)
 	require.NotNil(t, resp)
 	require.Len(t, resp.Services, 1)
 	assert.Equal(t, 101, resp.Services[0].PID)
 	assert.Equal(t, 1, requests())
+}
+
+func TestServiceDiscoveryBatchingFailureReturnsOperationError(t *testing.T) {
+	sysConfigOverrides := map[string]interface{}{
+		serviceCollectionBatchSizeConfigKey: 0,
+	}
+	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
+
+	socketPath, _ := startScriptedServiceDiscoveryServer(t, func(_ int, _ core.Params) serviceDiscoveryTestResponse {
+		return serviceDiscoveryTestResponse{
+			response: &model.ServicesResponse{},
+			status:   http.StatusInternalServerError,
+		}
+	})
+	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
+
+	_, successfulNewPids, successfulHeartbeatPids, err := c.collector.getDiscoveryServicesBatched(context.Background(), []int32{101}, nil)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to get services")
+	assert.Empty(t, successfulNewPids)
+	assert.Empty(t, successfulHeartbeatPids)
 }
 
 func TestServiceDiscoveryPartialBatchFailurePreservesRetries(t *testing.T) {
@@ -366,6 +392,176 @@ func TestServiceDiscoveryPartialBatchFailurePreservesRetries(t *testing.T) {
 	c.mockClock.Add(3 * time.Minute)
 	nextNewPids, _ := c.collector.filterPidsToRequest(alivePids, procs)
 	assert.Subset(t, nextNewPids, unsuccessfulPids)
+}
+
+func TestServiceDiscoveryConsecutiveTimeoutsDisableRequests(t *testing.T) {
+	const maxConsecutiveTimeouts = 5
+	sysConfigOverrides := map[string]interface{}{
+		serviceCollectionBatchSizeConfigKey:              0,
+		serviceCollectionMaxConsecutiveTimeoutsConfigKey: maxConsecutiveTimeouts,
+	}
+	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
+	c.mockClock.Set(baseTime)
+
+	socketPath, requests := startScriptedServiceDiscoveryServer(t, func(_ int, _ core.Params) serviceDiscoveryTestResponse {
+		time.Sleep(50 * time.Millisecond)
+		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{}}
+	})
+	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(
+		sysprobeclient.WithSocketPath(socketPath),
+		sysprobeclient.WithCheckTimeout(5*time.Millisecond),
+	)
+
+	alivePids, procs := makeAlivePidsAndProcesses([]int32{101})
+	for i := 0; i < maxConsecutiveTimeouts; i++ {
+		entities, injectedPids := c.collector.updateServices(context.Background(), alivePids, procs)
+		require.Empty(t, entities)
+		require.Empty(t, injectedPids)
+	}
+
+	assert.True(t, c.collector.serviceDiscoveryDisabledByTimeouts())
+	assert.Equal(t, maxConsecutiveTimeouts, c.collector.consecutiveServiceDiscoveryTimeouts)
+	assert.Equal(t, maxConsecutiveTimeouts, requests())
+
+	entities, injectedPids := c.collector.updateServices(context.Background(), alivePids, procs)
+	require.Empty(t, entities)
+	require.Empty(t, injectedPids)
+	assert.Equal(t, maxConsecutiveTimeouts, requests(), "disabled service discovery should not send more requests")
+}
+
+func TestServiceDiscoverySuccessfulRequestResetsConsecutiveTimeouts(t *testing.T) {
+	sysConfigOverrides := map[string]interface{}{
+		serviceCollectionMaxConsecutiveTimeoutsConfigKey: 5,
+	}
+	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
+	c.mockClock.Set(baseTime)
+	c.collector.consecutiveServiceDiscoveryTimeouts = 2
+	require.Equal(t, 2, c.collector.consecutiveServiceDiscoveryTimeouts)
+
+	socketPath, _ := startScriptedServiceDiscoveryServer(t, func(_ int, _ core.Params) serviceDiscoveryTestResponse {
+		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{
+			Services: []model.Service{makeModelService(101, "reset-service")},
+		}}
+	})
+	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
+
+	alivePids, procs := makeAlivePidsAndProcesses([]int32{101})
+	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
+
+	require.Len(t, entities, 1)
+	assert.Equal(t, int32(101), entities[0].Pid)
+	assert.False(t, c.collector.serviceDiscoveryDisabledByTimeouts())
+	assert.Zero(t, c.collector.consecutiveServiceDiscoveryTimeouts)
+}
+
+func TestServiceDiscoveryNonTimeoutErrorsResetConsecutiveTimeouts(t *testing.T) {
+	sysConfigOverrides := map[string]interface{}{
+		serviceCollectionMaxConsecutiveTimeoutsConfigKey: 5,
+	}
+	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
+	c.collector.consecutiveServiceDiscoveryTimeouts = 2
+	require.Equal(t, 2, c.collector.consecutiveServiceDiscoveryTimeouts)
+
+	c.collector.handleServiceDiscoveryRequestError(assert.AnError)
+
+	assert.False(t, c.collector.serviceDiscoveryDisabledByTimeouts())
+	assert.Zero(t, c.collector.consecutiveServiceDiscoveryTimeouts)
+}
+
+func TestServiceDiscoveryStartupErrorsDoNotCountTowardTimeoutDisable(t *testing.T) {
+	sysConfigOverrides := map[string]interface{}{
+		serviceCollectionMaxConsecutiveTimeoutsConfigKey: 1,
+	}
+	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
+
+	c.collector.handleServiceDiscoveryRequestError(fmt.Errorf("%w: %w", errServiceDiscoveryRequestStartup, sysprobeclient.ErrNotStartedYet))
+
+	assert.False(t, c.collector.serviceDiscoveryDisabledByTimeouts())
+	assert.Zero(t, c.collector.consecutiveServiceDiscoveryTimeouts)
+}
+
+func TestServiceDiscoveryStartupCheckTimeoutIsNotRequestTimeout(t *testing.T) {
+	startupCheckErr := &url.Error{
+		Op:  "Get",
+		URL: systemProbeStartupCheckURL,
+		Err: context.DeadlineExceeded,
+	}
+	serviceDiscoveryErr := &url.Error{
+		Op:  "Post",
+		URL: "http://sysprobe/discovery/services",
+		Err: context.DeadlineExceeded,
+	}
+
+	assert.False(t, isServiceDiscoveryRequestTimeout(startupCheckErr))
+	assert.True(t, isServiceDiscoveryRequestTimeout(serviceDiscoveryErr))
+}
+
+func TestServiceDiscoveryTimeoutGuardDisabledWhenThresholdIsZero(t *testing.T) {
+	sysConfigOverrides := map[string]interface{}{
+		serviceCollectionMaxConsecutiveTimeoutsConfigKey: 0,
+	}
+	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
+
+	for i := 0; i < 10; i++ {
+		c.collector.handleServiceDiscoveryRequestError(fmt.Errorf("%w: %w", errServiceDiscoveryRequestTimeout, context.DeadlineExceeded))
+	}
+
+	assert.False(t, c.collector.serviceDiscoveryDisabledByTimeouts())
+	assert.Zero(t, c.collector.consecutiveServiceDiscoveryTimeouts)
+}
+
+func TestServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPreviousTimeouts(t *testing.T) {
+	sysConfigOverrides := map[string]interface{}{
+		serviceCollectionBatchSizeConfigKey:              2,
+		serviceCollectionMaxConsecutiveTimeoutsConfigKey: 5,
+	}
+	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
+	c.mockClock.Set(baseTime)
+	c.collector.store = c.mockStore
+	c.collector.consecutiveServiceDiscoveryTimeouts = 4
+
+	var requestMux sync.Mutex
+	var successfulRequestPIDs []int32
+	socketPath, requests := startScriptedServiceDiscoveryServer(t, func(call int, params core.Params) serviceDiscoveryTestResponse {
+		if call == 1 {
+			time.Sleep(50 * time.Millisecond)
+			return serviceDiscoveryTestResponse{response: &model.ServicesResponse{}}
+		}
+
+		requestMux.Lock()
+		successfulRequestPIDs = append([]int32(nil), params.NewPids...)
+		requestMux.Unlock()
+
+		services := make([]model.Service, 0, len(params.NewPids))
+		for _, pid := range params.NewPids {
+			services = append(services, makeModelService(pid, "timeout-batch-"+strconv.Itoa(int(pid))))
+		}
+		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{
+			Services: services,
+		}}
+	})
+	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(
+		sysprobeclient.WithSocketPath(socketPath),
+		sysprobeclient.WithCheckTimeout(5*time.Millisecond),
+	)
+
+	alivePids, procs := makeAlivePidsAndProcesses([]int32{101, 102, 103, 104, 105})
+	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
+
+	assert.Equal(t, 2, requests())
+	requestMux.Lock()
+	successfulPidsSlice := append([]int32(nil), successfulRequestPIDs...)
+	requestMux.Unlock()
+	require.Len(t, successfulPidsSlice, 2)
+
+	require.Len(t, entities, len(successfulPidsSlice))
+	entityPids := make([]int32, 0, len(entities))
+	for _, entity := range entities {
+		entityPids = append(entityPids, entity.Pid)
+	}
+	assert.ElementsMatch(t, successfulPidsSlice, entityPids)
+	assert.Equal(t, 1, c.collector.consecutiveServiceDiscoveryTimeouts)
+	assert.False(t, c.collector.serviceDiscoveryDisabledByTimeouts())
 }
 
 func TestServiceDiscoverySuccessfulNoServiceIncrementsRetries(t *testing.T) {

--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -2707,6 +2707,10 @@ properties:
         type: integer
         default: 500
         minimum: 0
+      service_collection_max_consecutive_timeouts:
+        node_type: setting
+        type: integer
+        default: 5
       service_map:
         node_type: section
         type: object

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -370,6 +370,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("discovery.cpu_usage_update_delay", "60s")
 	cfg.BindEnvAndSetDefault("discovery.service_collection_interval", "60s")
 	cfg.BindEnvAndSetDefault("discovery.service_collection_batch_size", 500)
+	cfg.BindEnvAndSetDefault("discovery.service_collection_max_consecutive_timeouts", 5)
 	cfg.BindEnvAndSetDefault("discovery.service_map.enabled", false)
 
 	// Privileged Logs config

--- a/pkg/config/setup/system_probe_test.go
+++ b/pkg/config/setup/system_probe_test.go
@@ -54,6 +54,7 @@ func TestSystemProbeDefaultConfig(t *testing.T) {
 		{key: "network_config.closed_channel_size", defaultValue: 500},
 		{key: "gpu_monitoring.nvml_lib_path", defaultValue: ""},
 		{key: "discovery.service_collection_batch_size", defaultValue: 500},
+		{key: "discovery.service_collection_max_consecutive_timeouts", defaultValue: 5},
 	} {
 		t.Run(tc.key, func(t *testing.T) {
 			switch expected := tc.defaultValue.(type) {

--- a/pkg/system-probe/config/adjust_discovery.go
+++ b/pkg/system-probe/config/adjust_discovery.go
@@ -29,10 +29,14 @@ var discoveryForceDisabledProtocols = []string{
 	smNS("redis", "enabled"),
 }
 
-const defaultDiscoveryServiceCollectionBatchSize = 500
+const (
+	defaultDiscoveryServiceCollectionBatchSize              = 500
+	defaultDiscoveryServiceCollectionMaxConsecutiveTimeouts = 5
+)
 
 func adjustDiscovery(cfg model.Config) {
 	adjustDiscoveryServiceCollectionBatchSize(cfg)
+	adjustDiscoveryServiceCollectionMaxConsecutiveTimeouts(cfg)
 
 	if !cfg.GetBool(discoveryNS("service_map", "enabled")) {
 		return
@@ -109,4 +113,15 @@ func adjustDiscoveryServiceCollectionBatchSize(cfg model.Config) {
 
 	log.Warnf("%s cannot be negative: %d, using default value %d", key, batchSize, defaultDiscoveryServiceCollectionBatchSize)
 	cfg.Set(key, defaultDiscoveryServiceCollectionBatchSize, model.SourceAgentRuntime)
+}
+
+func adjustDiscoveryServiceCollectionMaxConsecutiveTimeouts(cfg model.Config) {
+	key := discoveryNS("service_collection_max_consecutive_timeouts")
+	maxTimeouts := cfg.GetInt(key)
+	if maxTimeouts >= 0 {
+		return
+	}
+
+	log.Warnf("%s cannot be negative: %d, using default value %d", key, maxTimeouts, defaultDiscoveryServiceCollectionMaxConsecutiveTimeouts)
+	cfg.Set(key, defaultDiscoveryServiceCollectionMaxConsecutiveTimeouts, model.SourceAgentRuntime)
 }

--- a/pkg/system-probe/config/adjust_discovery_test.go
+++ b/pkg/system-probe/config/adjust_discovery_test.go
@@ -52,6 +52,30 @@ func TestAdjustDiscoveryServiceCollectionBatchSize(t *testing.T) {
 	}
 }
 
+func TestAdjustDiscoveryServiceCollectionMaxConsecutiveTimeouts(t *testing.T) {
+	key := discoveryNS("service_collection_max_consecutive_timeouts")
+	tests := []struct {
+		name  string
+		input int
+		want  int
+	}{
+		{"positive value preserved", 7, 7},
+		{"zero disables timeout guard", 0, 0},
+		{"negative value falls back to default", -1, defaultDiscoveryServiceCollectionMaxConsecutiveTimeouts},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := mock.NewSystemProbe(t)
+			setInt(cfg, key, tc.input)
+
+			adjustDiscovery(cfg)
+
+			assert.Equal(t, tc.want, cfg.GetInt(key))
+		})
+	}
+}
+
 func TestAdjustDiscovery_Coexistence(t *testing.T) {
 	tests := []struct {
 		name                     string


### PR DESCRIPTION
### What does this PR do?

This PR makes service discovery turns itself off after successive failures to get services from system-probe, when those failures are timeouts.

By default, the max number of timeouts is 5 in a row, and it is configurable with `discovery.service_collection_max_consecutive_timeouts`.

### Motivation
DSCVR-567

### Describe how you validated your changes
Unit tests

### Additional Notes