### PR TITLE
bazel: reduce system-probe build duration by fixing Bazel cache invalidation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -116,8 +116,5 @@ common:release --config=rust-release
 common:release --//:release
 common --config=release
 
-test --@rules_go//go/config:race
-test --test_env=GORACE=atexit_sleep_ms=50
-
 # Local development options --------------------------------------------------------------------------------------------
 try-import %workspace%/user.bazelrc

--- a/bazel/configs/flavors.bazelrc
+++ b/bazel/configs/flavors.bazelrc
@@ -1,12 +1,16 @@
+# Go race detector for test invocations. Usage: bazel test --config=gorace //...
+test:gorace --@rules_go//go/config:race
+test:gorace --test_env=GORACE=atexit_sleep_ms=50
+
 # Flavor configs — run only the test variants for a specific agent flavor.
 # Usage: bazel test --config=iot //...
-test:base         --test_tag_filters=flavor_base
-test:dogstatsd    --test_tag_filters=flavor_dogstatsd
-test:fips         --test_tag_filters=flavor_fips
-test:heroku       --test_tag_filters=flavor_heroku
-test:iot          --test_tag_filters=flavor_iot
+test:base         --test_tag_filters=flavor_base      --config=gorace
+test:dogstatsd    --test_tag_filters=flavor_dogstatsd --config=gorace
+test:fips         --test_tag_filters=flavor_fips      --config=gorace
+test:heroku       --test_tag_filters=flavor_heroku    --config=gorace
+test:iot          --test_tag_filters=flavor_iot       --config=gorace
 
 # Exclude the per-flavor dd_agent_go_test variants. Used by the monolithic CI
 # jobs so they do not re-run tests already covered by the per-flavor jobs.
 # Usage: bazel test --config=no-dd-agent-go-tests //...
-test:no-dd-agent-go-tests  --test_tag_filters=-dd_agent_go_test
+test:no-dd-agent-go-tests  --test_tag_filters=-dd_agent_go_test --config=gorace

--- a/bazel/rules/ebpf/ebpf.bzl
+++ b/bazel/rules/ebpf/ebpf.bzl
@@ -39,6 +39,7 @@ _COMMON_FLAGS = [
 _PREBUILT_FLAGS = [
     "-DCONFIG_64BIT",
     "-DCOMPILE_PREBUILT",
+    "-fdebug-compilation-dir=.",
 ]
 
 _CORE_FLAGS = [

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -774,7 +774,7 @@ def test(
 
     exclude_packages: set[str] = set()
     bazel_targets: dict[str, str] = {}
-    bazel_flags = []
+    bazel_flags = ["--config=gorace"]
     if unit_tests_tags:
         # Critically important to sort the gotags because their order matters for configuration calculation.
         # That is, you don't cache unless they come out the same way.

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -774,7 +774,9 @@ def test(
 
     exclude_packages: set[str] = set()
     bazel_targets: dict[str, str] = {}
-    bazel_flags = ["--config=gorace"]
+    bazel_flags = []
+    if race:
+        bazel_flags.append("--config=gorace")
     if unit_tests_tags:
         # Critically important to sort the gotags because their order matters for configuration calculation.
         # That is, you don't cache unless they come out the same way.

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1240,7 +1240,7 @@ def build_rust_binaries(ctx: Context, arch: Arch, output_dir: Path | None = None
     }
 
     platform_flags = []
-    if arch.kmt_arch in platform_map:
+    if arch.is_cross_compiling() and arch.kmt_arch in platform_map:
         platform_flags.append(f"--platforms={platform_map[arch.kmt_arch]}")
 
     for source_path in RUST_BINARIES:


### PR DESCRIPTION
### What does this PR do?

Reduces system-probe CI build duration by fixing some Bazel analysis-cache thrashing and non-reproducible build outputs:

- Stop passing `--@rules_go//go/config:race` to all `bazel test` command, so it no longer toggles on/off between `bazel build`/`bazel run`/`bazel test` invocations inside the same job.
- Only passes `--platforms` to the Rust `install`/`install_libs` bazel run commands when actually cross-compiling, instead of unconditionally for every arch, which would cause bazel to trash its analysis cache due to the global options being different.
- Add `-fdebug-compilation-dir=.` to the "prebuilt" eBPF compile flags, matching what CORE targets already do, so their debug info no longer embeds Bazel's volatile per-action sandbox path.

### Motivation

`build_system-probe-x64`/`arm64` run `bazel build`/`bazel run`/`bazel test` as several sequential invocations within `system-probe.build-object-files`. The first two flag inconsistencies above each independently trigger `WARNING: Build option ... has changed, discarding analysis cache` mid-job, forcing Bazel to fully re-analyze targets from scratch instead of reusing the already-warm analysis graph.

The third fixes non-reproducible checksums for the "prebuilt" eBPF objects, which feed into the downstream `generate_minimized_btfs` job's S3 cache key (it hashes the whole build-outputs bundle). The non-determinism made that job rebuild BTFs from scratch on every pipeline run instead of reusing a cached artifact, adding unnecessary time there too.

### Describe how you validated your changes

- Race-flag and `--platforms` fixes: reproduced the "discarding analysis cache" warnings locally, confirmed they no longer trigger once the flags are consistent across invocations; confirmed rust `install`/`install_libs` output is byte-identical with and without `--platforms` in the native-arch case.
- eBPF debug-dir fix: confirmed two independent `bazel clean` rebuilds of `//pkg/network/ebpf/c/prebuilt:conntrack` now produce byte-identical output (previously only the embedded sandbox path differed); confirmed the full `sysprobe-build-outputs.tar.xz.sum` hash is now stable across clean rebuilds.

CI and our internal agent-build dashboard will be used to monitor the results

### Additional Notes
