### PR TITLE
Fix flaky `TestDNSExceedsMaxPortsTruncates`

### DIFF
--- a/pkg/network/dns/snooper_test.go
+++ b/pkg/network/dns/snooper_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"strconv"
 	"syscall"
 	"testing"
@@ -344,11 +345,23 @@ func TestDNSOverCustomPort(t *testing.T) {
 //   - traffic to one of the first 8 (sorted ascending) ports IS captured
 //   - traffic to a dropped port (slot index >= 8) is NOT captured
 func TestDNSExceedsMaxPortsTruncates(t *testing.T) {
-	// 9 distinct ports, sorted ascending: 53, 1001, 1002, ..., 1008.
-	// DNSPortsMax = 8, so port 1008 (slot index 8 after sort) is dropped.
+	// OS-assigned ephemeral ports, starting at 32768 on Linux, avoid conflicts
+	// with host services and sort well-after the fixed ports below.
+	var ports [2]uint16
+	for i := range ports {
+		shutdown, port := newTestServer(t, localhost, "udp")
+		defer shutdown()
+		require.Greater(t, port, uint16(1006), "assumption about OS-assigned ports does not hold: got %d", port)
+		ports[i] = port
+	}
+	slices.Sort(ports[:])
+	portKept, portDropped := int(ports[0]), int(ports[1])
+
+	// 9 distinct ports, sorted ascending: 53, 1001, ..., 1006, N >1006, M >N.
+	// DNSPortsMax = 8, so `portDropped` (slot index 8 after sort) is dropped.
 	mock.NewSystemProbe(t).SetInTest(
 		"network_config.dns_monitoring_ports",
-		[]int{53, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008},
+		[]int{53, 1001, 1002, 1003, 1004, 1005, 1006, portKept, portDropped},
 	)
 	cfg := config.New()
 	cfg.CollectDNSStats = true
@@ -363,27 +376,23 @@ func TestDNSExceedsMaxPortsTruncates(t *testing.T) {
 	defer reverseDNS.Close()
 	statKeeper := reverseDNS.statKeeper
 
-	// Traffic to port 1007 (the last kept slot, index 7) MUST be captured.
-	shutdownKept, portKept := newTestServerOnPort(t, localhost, "udp", 1007)
-	defer shutdownKept()
-	queryIPKept, queryPortKept, repsKept, err := testdns.SendDNSQueriesOnPort([]string{"golang.org"}, net.ParseIP(localhost), strconv.Itoa(int(portKept)), "udp")
+	// Traffic to `portKept` (the last kept slot, index 7) MUST be captured.
+	queryIPKept, queryPortKept, repsKept, err := testdns.SendDNSQueriesOnPort([]string{"golang.org"}, net.ParseIP(localhost), strconv.Itoa(portKept), "udp")
 	require.NoError(t, err)
 	require.NotNil(t, repsKept[0])
 	keyKept := getKey(queryIPKept, queryPortKept, localhost, syscall.IPPROTO_UDP)
 	require.Eventually(t, func() bool {
 		return statKeeper.Snapshot()[keyKept] != nil
-	}, 3*time.Second, 10*time.Millisecond, "kept port 1007 (slot 7) should have been captured")
+	}, 3*time.Second, 10*time.Millisecond, "kept port %d (slot 7) should have been captured", portKept)
 
-	// Traffic to port 1008 (the dropped port) MUST NOT be captured.
-	shutdownDropped, portDropped := newTestServerOnPort(t, localhost, "udp", 1008)
-	defer shutdownDropped()
-	queryIPDropped, queryPortDropped, repsDropped, err := testdns.SendDNSQueriesOnPort([]string{"golang.org"}, net.ParseIP(localhost), strconv.Itoa(int(portDropped)), "udp")
+	// Traffic to `portDropped` (the dropped port) MUST NOT be captured.
+	queryIPDropped, queryPortDropped, repsDropped, err := testdns.SendDNSQueriesOnPort([]string{"golang.org"}, net.ParseIP(localhost), strconv.Itoa(portDropped), "udp")
 	require.NoError(t, err)
 	require.NotNil(t, repsDropped[0])
 	keyDropped := getKey(queryIPDropped, queryPortDropped, localhost, syscall.IPPROTO_UDP)
 	require.Never(t, func() bool {
 		return statKeeper.Snapshot()[keyDropped] != nil
-	}, 500*time.Millisecond, 10*time.Millisecond, "dropped port 1008 (beyond slot 7) should NOT be captured")
+	}, 500*time.Millisecond, 10*time.Millisecond, "dropped port %d (beyond slot 7) should NOT be captured", portDropped)
 }
 
 // TestDNSDeduplicatesPorts verifies that duplicate entries in


### PR DESCRIPTION
### What does this PR do?
Replace the two hardcoded ports (1007, 1008) in `TestDNSExceedsMaxPortsTruncates` with OS-assigned ephemeral ports, sorted to determine which slot is kept and which is dropped.

### Motivation
pkg/network/dns'`TestDNSExceedsMaxPortsTruncates` has been exhibiting [flakiness](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20FAIL%20TestDNSExceedsMaxPortsTruncates&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1782209304172&to_ts=1783505304172&live=true):
```
=== RUN   TestDNSExceedsMaxPortsTruncates
1783493706060578922 [Warn] network_config.dns_monitoring_ports has 9 distinct entries, exceeding the maximum of 8. Monitoring only [53 1001 1002 1003 1004 1005 1006 1007] (sorted ascending). Ports [1008] will NOT be monitored.
1783493706061520871 [Debug] creating tpacket source with frame_size=8192 block_size=32768 num_blocks=128
1783493706084551384 [Info] DNS monitoring ports: [53 1001 1002 1003 1004 1005 1006 1007]
1783493706085599007 [Info] DNS Stats Collection has been enabled. Maximum number of stats objects: 20000
1783493706085669792 [Info] DNS domain collection has been enabled
1783493706085728111 [Info] Recording dns query types: [A AAAA]
    snooper_test.go:367: could not initialize DNS server: listen udp 127.0.0.1:1007: bind: address already in use
    snooper_test.go:370: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/pkg/network/dns/snooper_test.go:370
        	Error:      	Received unexpected error:
        	            	failed sending dns query for domain golang.org to server 127.0.0.1: read udp 127.0.0.1:41878->127.0.0.1:0: read: connection refused
        	Test:       	TestDNSExceedsMaxPortsTruncates
--- FAIL: TestDNSExceedsMaxPortsTruncates (0.06s)
```
Retrying the entire job may allow the test to pass, but it takes time and [isn't always effective](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1840144882).

A hardcoded port can already be bound by another process on the host (or by another executing test thread), making the `bind` fail or the traffic assertions unreliable.

### Describe how you validated your changes
The ephemeral range (32768-60999 on Linux) is asserted to stay above the highest remaining fixed port (1006), preserving the sort order the test relies on.