### PR TITLE
fix(collector): match JMX agent_checks IDs to inventory config.hash

### DIFF
--- a/comp/collector/collector/impl/agent_check_metadata.go
+++ b/comp/collector/collector/impl/agent_check_metadata.go
@@ -35,10 +35,11 @@ const (
 
 // jmxInstanceData stores metadata about a JMX instance for building consistent check IDs
 type jmxInstanceData struct {
-	host string
-	port string
-	name string // explicit "name:" from the instance config; empty if none was set
-	tags interface{}
+	host    string
+	port    string
+	name    string // value of the explicit "name:" key (may be empty)
+	hasName bool   // whether the instance config set a "name:" key at all
+	tags    interface{}
 }
 
 // Payload handles the JSON unmarshalling of the metadata payload
@@ -152,22 +153,25 @@ func (c *collectorImpl) GetPayload(ctx context.Context) *Payload {
 				tags = tagsNode
 			}
 
+			name, hasName := instanceconfig["name"].(string)
 			data := &jmxInstanceData{
-				host: host,
-				port: port,
-				tags: tags,
+				host:    host,
+				port:    port,
+				name:    name,
+				hasName: hasName,
+				tags:    tags,
 			}
 
 			// Key the instance by the same string JMXFetch reports as instance_name in
 			// its runtime status, so the lookup below succeeds for both named and unnamed
 			// instances.
-			if name, ok := instanceconfig["name"].(string); ok {
+			if hasName && name != "" {
 				// Named instance: JMXFetch reports instance_name == the configured name.
-				data.name = name
 				instanceConfByName[name] = data
 			} else {
-				// Unnamed instance: JMXFetch auto-generates instance_name as
-				// "<check>-<host>-<port>". Key by that so the status lookup hits.
+				// Unnamed instance (no "name:" key, or an empty one): JMXFetch
+				// auto-generates instance_name as "<check>-<host>-<port>". Key by that
+				// so the status lookup hits.
 				instanceConfByName[fmt.Sprintf("%s-%s-%s", checkName, host, port)] = data
 			}
 		}
@@ -203,9 +207,11 @@ func (c *collectorImpl) GetPayload(ctx context.Context) *Payload {
 						if instanceData, found := instanceConfByName[instanceName]; found {
 							// Build checkID to match the config.hash format in inventory
 							// metadata (integrations_jmx.go:77-80): "<check>-<host>-<port>",
-							// with a ":<name>" suffix only when the instance set an explicit name.
+							// with a ":<name>" suffix whenever the instance set a "name:" key
+							// (matching integrations_jmx.go's presence check, so an explicit
+							// empty name still yields a trailing ":").
 							checkID = fmt.Sprintf("%s-%s-%s", checkName, instanceData.host, instanceData.port)
-							if instanceData.name != "" {
+							if instanceData.hasName {
 								checkID = fmt.Sprintf("%s:%s", checkID, instanceData.name)
 							}
 							tags = instanceData.tags

--- a/comp/collector/collector/impl/agent_check_metadata.go
+++ b/comp/collector/collector/impl/agent_check_metadata.go
@@ -37,6 +37,7 @@ const (
 type jmxInstanceData struct {
 	host string
 	port string
+	name string // explicit "name:" from the instance config; empty if none was set
 	tags interface{}
 }
 
@@ -131,6 +132,7 @@ func (c *collectorImpl) GetPayload(ctx context.Context) *Payload {
 	jmxStatus.PopulateStatus(stats)
 	instanceConfByName := map[string]*jmxInstanceData{}
 	for _, config := range jmxfetch.GetScheduledConfigs() {
+		checkName := config.Name
 		for _, instance := range config.Instances {
 			instanceconfig := map[interface{}]interface{}{}
 			err := yaml.Unmarshal(instance, &instanceconfig)
@@ -139,23 +141,10 @@ func (c *collectorImpl) GetPayload(ctx context.Context) *Payload {
 				continue
 			}
 
-			// Instance name is required to map this data
-			instanceName, hasName := instanceconfig["name"].(string)
-			if !hasName {
-				continue
-			}
-
-			// Extract host with default
-			host := "unknown"
-			if h, ok := instanceconfig["host"]; ok {
-				host = fmt.Sprint(h)
-			}
-
-			// Extract port with default
-			port := "unknown"
-			if p, ok := instanceconfig["port"]; ok {
-				port = fmt.Sprint(p)
-			}
+			// Use fmt.Sprint (no "unknown" default) so the resulting check ID matches
+			// the config.hash built in integrations_jmx.go (getJMXChecksMetadata).
+			host := fmt.Sprint(instanceconfig["host"])
+			port := fmt.Sprint(instanceconfig["port"])
 
 			// Extract tags
 			var tags interface{} = []string{}
@@ -163,10 +152,23 @@ func (c *collectorImpl) GetPayload(ctx context.Context) *Payload {
 				tags = tagsNode
 			}
 
-			instanceConfByName[instanceName] = &jmxInstanceData{
+			data := &jmxInstanceData{
 				host: host,
 				port: port,
 				tags: tags,
+			}
+
+			// Key the instance by the same string JMXFetch reports as instance_name in
+			// its runtime status, so the lookup below succeeds for both named and unnamed
+			// instances.
+			if name, ok := instanceconfig["name"].(string); ok {
+				// Named instance: JMXFetch reports instance_name == the configured name.
+				data.name = name
+				instanceConfByName[name] = data
+			} else {
+				// Unnamed instance: JMXFetch auto-generates instance_name as
+				// "<check>-<host>-<port>". Key by that so the status lookup hits.
+				instanceConfByName[fmt.Sprintf("%s-%s-%s", checkName, host, port)] = data
 			}
 		}
 	}
@@ -199,9 +201,13 @@ func (c *collectorImpl) GetPayload(ctx context.Context) *Payload {
 					} else {
 						// Instance name exists - look up full instance data
 						if instanceData, found := instanceConfByName[instanceName]; found {
-							// Build checkID in format: checkName-host-port:instanceName
-							// This matches the format used in inventory metadata (integrations_jmx.go:77-79)
-							checkID = fmt.Sprintf("%s-%s-%s:%s", checkName, instanceData.host, instanceData.port, instanceName)
+							// Build checkID to match the config.hash format in inventory
+							// metadata (integrations_jmx.go:77-80): "<check>-<host>-<port>",
+							// with a ":<name>" suffix only when the instance set an explicit name.
+							checkID = fmt.Sprintf("%s-%s-%s", checkName, instanceData.host, instanceData.port)
+							if instanceData.name != "" {
+								checkID = fmt.Sprintf("%s:%s", checkID, instanceData.name)
+							}
 							tags = instanceData.tags
 						} else {
 							// Instance not found in config - fall back with unknown host/port

--- a/comp/collector/collector/impl/agent_check_metadata_jmx_test.go
+++ b/comp/collector/collector/impl/agent_check_metadata_jmx_test.go
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build jmx
+
+package collectorimpl
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	agenttelemetry "github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/mock"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	haagentmock "github.com/DataDog/datadog-agent/comp/haagent/mock"
+	healthplatformnoopimpl "github.com/DataDog/datadog-agent/comp/healthplatform/store/noop-impl"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	jmxStatus "github.com/DataDog/datadog-agent/pkg/status/jmx"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+// TestJMXCheckIDMatchesInventoryHash asserts that the check ID emitted in the
+// agent_checks payload for JMX checks matches the config.hash format built by
+// getJMXChecksMetadata() in integrations_jmx.go, including the common case where
+// the instance config does not set an explicit "name:" field.
+//
+// Regression test for the bug where an unnamed instance produced
+// "<check>-unknown-unknown:<jmxfetch-instance-name>" instead of the expected
+// "<check>-<host>-<port>".
+func TestJMXCheckIDMatchesInventoryHash(t *testing.T) {
+	// GIVEN two scheduled JMX configs: one instance WITHOUT an explicit name
+	// (the buggy case) and one WITH a name (the regression guard).
+	jmxfetch.AddScheduledConfig(integration.Config{
+		Name: "cassandra",
+		Instances: []integration.Data{
+			integration.Data("host: 10.112.199.52\nport: 7199\n"),
+		},
+	})
+	jmxfetch.AddScheduledConfig(integration.Config{
+		Name: "kafka",
+		Instances: []integration.Data{
+			integration.Data("host: localhost\nport: 9999\nname: mykafka\n"),
+		},
+	})
+
+	// AND matching JMX runtime status. JMXFetch reports instance_name as the
+	// auto-generated "<check>-<host>-<port>" for unnamed instances, and as the
+	// configured name for named instances. The ChecksStatus type is unexported,
+	// so the status is built via JSON.
+	statusJSON := `{
+		"checks": {
+			"initialized_checks": {
+				"cassandra": [
+					{"instance_name": "cassandra-10.112.199.52-7199", "status": "OK", "message": ""}
+				],
+				"kafka": [
+					{"instance_name": "mykafka", "status": "OK", "message": ""}
+				]
+			}
+		}
+	}`
+	var status jmxStatus.Status
+	require.NoError(t, json.Unmarshal([]byte(statusJSON), &status))
+	jmxStatus.SetStatus(status)
+	t.Cleanup(jmxStatus.ClearStatus)
+
+	hostname, _ := hostnameinterface.NewMock("my-hostname")
+	c := newCollector(dependencies{
+		Lc:               compdef.NewTestLifecycle(t),
+		Config:           config.NewMockWithOverrides(t, map[string]interface{}{"check_cancel_timeout": 500 * time.Millisecond}),
+		Log:              logmock.New(t),
+		HaAgent:          haagentmock.NewMockHaAgent(),
+		HealthPlatform:   healthplatformnoopimpl.NewNoopComponent(),
+		Hostname:         hostname,
+		SenderManager:    aggregator.NewNoOpSenderManager(),
+		MetricSerializer: option.None[serializer.MetricSerializer](),
+		AgentTelemetry:   option.None[agenttelemetry.Component](),
+	})
+
+	// WHEN building the agent_checks payload
+	payload := c.GetPayload(context.Background())
+
+	// THEN each JMX check ID matches the config.hash format from integrations_jmx.go.
+	checkIDs := jmxCheckIDsByName(payload)
+
+	// Unnamed instance: no "unknown-unknown", no ":name" suffix.
+	require.Contains(t, checkIDs, "cassandra")
+	assert.Equal(t, "cassandra-10.112.199.52-7199", checkIDs["cassandra"])
+
+	// Named instance: unchanged behavior, "<check>-<host>-<port>:<name>".
+	require.Contains(t, checkIDs, "kafka")
+	assert.Equal(t, "kafka-localhost-9999:mykafka", checkIDs["kafka"])
+}
+
+// jmxCheckIDsByName extracts, from the agent_checks payload, a map of check name
+// to check ID (the 3rd tuple element) for the two JMX checks under test.
+func jmxCheckIDsByName(payload *Payload) map[string]string {
+	out := map[string]string{}
+	for _, raw := range payload.AgentChecks {
+		tuple, ok := raw.([]interface{})
+		if !ok || len(tuple) < 3 {
+			continue
+		}
+		name, ok := tuple[0].(string)
+		if !ok || (name != "cassandra" && name != "kafka") {
+			continue
+		}
+		if checkID, ok := tuple[2].(string); ok {
+			out[name] = checkID
+		}
+	}
+	return out
+}

--- a/comp/collector/collector/impl/agent_check_metadata_jmx_test.go
+++ b/comp/collector/collector/impl/agent_check_metadata_jmx_test.go
@@ -54,6 +54,14 @@ func TestJMXCheckIDMatchesInventoryHash(t *testing.T) {
 			integration.Data("host: localhost\nport: 9999\nname: mykafka\n"),
 		},
 	})
+	// Instance with an explicit but empty name: integrations_jmx.go appends the
+	// suffix on key presence, so config.hash ends with a trailing ":".
+	jmxfetch.AddScheduledConfig(integration.Config{
+		Name: "zookeeper",
+		Instances: []integration.Data{
+			integration.Data("host: localhost\nport: 2181\nname: \"\"\n"),
+		},
+	})
 
 	// AND matching JMX runtime status. JMXFetch reports instance_name as the
 	// auto-generated "<check>-<host>-<port>" for unnamed instances, and as the
@@ -67,6 +75,9 @@ func TestJMXCheckIDMatchesInventoryHash(t *testing.T) {
 				],
 				"kafka": [
 					{"instance_name": "mykafka", "status": "OK", "message": ""}
+				],
+				"zookeeper": [
+					{"instance_name": "zookeeper-localhost-2181", "status": "OK", "message": ""}
 				]
 			}
 		}
@@ -102,11 +113,17 @@ func TestJMXCheckIDMatchesInventoryHash(t *testing.T) {
 	// Named instance: unchanged behavior, "<check>-<host>-<port>:<name>".
 	require.Contains(t, checkIDs, "kafka")
 	assert.Equal(t, "kafka-localhost-9999:mykafka", checkIDs["kafka"])
+
+	// Explicit empty name: the "name:" key is present, so the suffix is kept,
+	// producing a trailing ":" to match integrations_jmx.go's presence check.
+	require.Contains(t, checkIDs, "zookeeper")
+	assert.Equal(t, "zookeeper-localhost-2181:", checkIDs["zookeeper"])
 }
 
 // jmxCheckIDsByName extracts, from the agent_checks payload, a map of check name
-// to check ID (the 3rd tuple element) for the two JMX checks under test.
+// to check ID (the 3rd tuple element) for the JMX checks under test.
 func jmxCheckIDsByName(payload *Payload) map[string]string {
+	wanted := map[string]struct{}{"cassandra": {}, "kafka": {}, "zookeeper": {}}
 	out := map[string]string{}
 	for _, raw := range payload.AgentChecks {
 		tuple, ok := raw.([]interface{})
@@ -114,7 +131,10 @@ func jmxCheckIDsByName(payload *Payload) map[string]string {
 			continue
 		}
 		name, ok := tuple[0].(string)
-		if !ok || (name != "cassandra" && name != "kafka") {
+		if !ok {
+			continue
+		}
+		if _, want := wanted[name]; !want {
 			continue
 		}
 		if checkID, ok := tuple[2].(string); ok {

--- a/releasenotes/notes/jmx-agent-checks-config-hash-04a5d113765fae6a.yaml
+++ b/releasenotes/notes/jmx-agent-checks-config-hash-04a5d113765fae6a.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed the check identifier reported for JMX checks in the ``agent_checks``
+    metadata payload so that it matches the ``config.hash`` reported in the
+    ``checks_metadata`` payload. Previously, JMX instances configured without an
+    explicit ``name`` field produced an identifier of the form
+    ``<check>-unknown-unknown:<instance_name>``, which could not be correlated
+    with the corresponding ``config.hash`` (``<check>-<host>-<port>``).


### PR DESCRIPTION
### What

For JMX checks, the `agent_checks` metadata payload (`GetPayload()` in `comp/collector/collector/impl/agent_check_metadata.go`) produced a check ID that did not match the `config.hash` in the `checks_metadata` payload (`getJMXChecksMetadata()` in `comp/metadata/inventorychecks/impl/integrations_jmx.go`), so the two payloads could not be correlated by ID.

### Why

`GetPayload()` only indexed JMX instances that set an explicit `name:` field; instances without a name were skipped. The JMX status lookup then missed and fell into a fallback that emitted:

```
<check>-unknown-unknown:<jmxfetch-instance-name>
```

The reference side builds `config.hash` as `<check>-<host>-<port>`, appending `:<name>` **only** when the instance sets an explicit name. Unnamed JMX instances (common — e.g. Cassandra configured by host/port only) therefore never matched.

Example (Cassandra, no `name:`):
- `checks_metadata` → `cassandra-10.112.199.52-7199`
- `agent_checks` (before) → `cassandra-unknown-unknown:cassandra-10.112.199.52-7199`

### How

- Index unnamed instances by the `<check>-<host>-<port>` string JMXFetch uses for `instance_name`, so the status lookup succeeds.
- Build the check ID to mirror `config.hash` exactly: base `<check>-<host>-<port>`, with the `:<name>` suffix gated on an explicit name.
- Use `fmt.Sprint` for host/port (no `unknown` default) to match the reference format.

Named instances are unchanged; the `unknown-unknown` fallback remains only for genuinely missing configs.

### Result

| Case | agent_checks (after) | matches config.hash |
|---|---|---|
| Unnamed (Cassandra) | `cassandra-10.112.199.52-7199` | ✅ |
| Named (`name: foo`) | `cassandra-host-port:foo` | ✅ (unchanged) |

### Testing

- [ ] Local build/tests via `dda inv` (the wrapper was unavailable in my dev shell — needs a run in CI / a proper env).

Draft: no release note or unit test added yet.