### PR TITLE
fix(healthplatform): deflake TestIssueStateLifecycleForwarded

### DIFF
--- a/comp/healthplatform/bundle_test.go
+++ b/comp/healthplatform/bundle_test.go
@@ -240,10 +240,20 @@ func TestIssueStateLifecycleForwarded(t *testing.T) {
 	deps.HP.ResolveIssue(issueAID)
 	deps.HP.ResolveIssue(issueBID)
 
-	require.Eventually(t, func() bool {
-		return latestHasIssueState(issueAID, healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED) &&
-			latestHasIssueState(issueBID, healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED)
-	}, waitTimeout, waitInterval, "expected a forwarded payload with issueA=RESOLVED and issueB=RESOLVED")
+	// The egress component may split issues resolved back-to-back across separate
+	// ticks/reports, so issueA and issueB reaching RESOLVED is not guaranteed to land in
+	// the same latest payload. Latch each as seen once observed, and stop once both have.
+	var seenAResolved, seenBResolved bool
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		if latestHasIssueState(issueAID, healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED) {
+			seenAResolved = true
+		}
+		if latestHasIssueState(issueBID, healthplatformpayload.IssueState_ISSUE_STATE_RESOLVED) {
+			seenBResolved = true
+		}
+		assert.True(c, seenAResolved, "issueA never observed as RESOLVED")
+		assert.True(c, seenBResolved, "issueB never observed as RESOLVED")
+	}, waitTimeout, waitInterval, "expected issueA and issueB to each be forwarded as RESOLVED")
 
 	deps.HP.ReportIssue(issueA)
 	require.Eventually(t, func() bool {

--- a/comp/healthplatform/bundle_test.go
+++ b/comp/healthplatform/bundle_test.go
@@ -166,7 +166,7 @@ func TestIssueStateLifecycleForwarded(t *testing.T) {
 		HP storedef.Component
 	}
 
-	const tickInterval = 50 * time.Millisecond
+	const tickInterval = 500 * time.Millisecond
 
 	deps := fxutil.Test[appDeps](t,
 		Bundle(),


### PR DESCRIPTION
### What does this PR do?

Deflakes `comp/healthplatform.TestIssueStateLifecycleForwarded` (tracked in AGTHEAL-209):

- The egress component can split issues resolved back-to-back (`ResolveIssue(A)` then `ResolveIssue(B)`) across separate ticks/reports, so both reaching RESOLVED is not guaranteed to land in the same forwarded payload. The test now latches each issue's RESOLVED state independently as it's observed via `require.EventuallyWithT`, instead of requiring both in a single "latest" snapshot.
- Widens the test's egress tick interval from 50ms to 500ms, giving the run loop enough headroom to reliably drain both resolved tombstones into the same tick under scheduler jitter (observed under `-race`), and giving the test's poll more chances to observe each report before the next tick supersedes it.

### Motivation

This test was reported flaky in CI: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1834735866

### Describe how you validated your changes

- `dda inv test --targets=./comp/healthplatform/...` passes.
- Stress-tested `TestIssueStateLifecycleForwarded` with `-race -count=1000`:
  - Before this fix (50ms interval, original assertion): failed intermittently in CI.
  - Intermediate 50ms interval + latch-based assertion: 2/1000 failures.
  - 200ms interval + latch-based assertion: 0/1000 failures.
  - 500ms interval (current) + latch-based assertion: validation run in progress.

### Additional Notes

No production code changes — this is a test-only fix.