### PR TITLE
[procmgr] Add RunPrivilegedCommand Windows skeleton to procmgr

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -639,7 +639,7 @@
 /pkg/pidfile/                           @DataDog/agent-runtimes
 /pkg/persistentcache/                   @DataDog/agent-runtimes
 /pkg/procmgr/                           @DataDog/agent-runtimes
-/pkg/procmgr/rust/src/platform/windows.rs          @DataDog/agent-runtimes @DataDog/windows-products
+/pkg/procmgr/rust/src/platform/windows/            @DataDog/agent-runtimes @DataDog/windows-products
 /pkg/procmgr/rust/src/transport/named_pipe.rs       @DataDog/agent-runtimes @DataDog/windows-products
 /pkg/privateactionrunner/               @DataDog/action-platform
 /pkg/privateactionrunner/bundles/remoteaction  @DataDog/action-platform @DataDog/dd-agent-mcp

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -195,8 +195,9 @@ rust_test(
         "CARGO_BIN_EXE_dd-procmgrd": "$(rootpath :dd-procmgrd)",
         "DDOT_TEMPLATE_PATH": "$(rootpath //pkg/fleet/installer/packages/embedded:tmpl/datadog-agent-ddot.yaml.tmpl)",
     },
-    # E2E tests use UDS for transport and spawn the Linux daemon binary.
-    target_compatible_with = ["@platforms//os:linux"],
+    # E2E tests spawn the daemon and exercise the CLI over IPC (UDS on Linux,
+    # named pipes on Windows).
+    target_compatible_with = _LINUX_OR_WINDOWS,
     deps = [
         ":dd-procmgrd-lib-testhelpers",
         "@crates//:serde_json",

--- a/pkg/procmgr/rust/Cargo.toml
+++ b/pkg/procmgr/rust/Cargo.toml
@@ -55,6 +55,7 @@ windows-sys = { workspace = true, features = [
     "Win32_Security",
     "Win32_System_Registry",
     "Win32_Storage_FileSystem",
+    "Win32_System_Pipes",
 ] }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/pkg/procmgr/rust/Cargo.toml
+++ b/pkg/procmgr/rust/Cargo.toml
@@ -56,6 +56,7 @@ windows-sys = { workspace = true, features = [
     "Win32_System_Registry",
     "Win32_Storage_FileSystem",
     "Win32_System_Pipes",
+    "Win32_System_SystemServices",
 ] }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/pkg/procmgr/rust/src/bins/dd-procmgr.rs
+++ b/pkg/procmgr/rust/src/bins/dd-procmgr.rs
@@ -98,17 +98,43 @@ enum Commands {
     },
     /// Reload daemon configuration from disk
     Reload,
+    /// Run a catalog-approved command with elevated privileges.
+    ///
+    /// On Windows the daemon only accepts callers identified as
+    /// `privateactionrunner.exe`, or `dd-procmgr.exe` when the daemon has
+    /// `DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI=1`. Privileged execution must also
+    /// be enabled on the host via `DD_PM_PRIVILEGED_COMMANDS_ENABLED=1`.
+    RunPrivileged {
+        /// Executable path
+        #[arg(long)]
+        command: String,
+        /// Command arguments (repeatable)
+        #[arg(long, num_args = 1..)]
+        args: Vec<String>,
+        /// Environment variable KEY=VALUE (repeatable)
+        #[arg(long, value_name = "KEY=VALUE")]
+        env: Vec<String>,
+    },
 }
 
 #[tokio::main]
 async fn main() -> ExitCode {
     let cli = Cli::parse();
     match run(cli).await {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(None) => ExitCode::SUCCESS,
+        Ok(Some(code)) => exit_code_to_exit_status(code),
         Err(e) => {
             eprintln!("Error: {e}");
             ExitCode::FAILURE
         }
+    }
+}
+
+fn exit_code_to_exit_status(code: i32) -> ExitCode {
+    if code == 0 {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from((code & 0xff) as u8)
     }
 }
 
@@ -123,17 +149,35 @@ async fn connect(socket_override: Option<&str>) -> Result<ProcessManagerClient<C
     Ok(ProcessManagerClient::new(channel))
 }
 
-async fn run(cli: Cli) -> Result<(), String> {
+async fn run(cli: Cli) -> Result<Option<i32>, String> {
     let mut client = connect(cli.socket.as_deref()).await?;
     let json = cli.json;
 
     match cli.command {
-        Commands::List => cmd_list(&mut client, json).await,
-        Commands::Describe { name_or_uuid } => cmd_describe(&mut client, &name_or_uuid, json).await,
-        Commands::Status => cmd_status(&mut client, json).await,
-        Commands::Config => cmd_config(&mut client, json).await,
-        Commands::Start { name_or_uuid } => cmd_start(&mut client, &name_or_uuid, json).await,
-        Commands::Stop { name_or_uuid } => cmd_stop(&mut client, &name_or_uuid, json).await,
+        Commands::List => {
+            cmd_list(&mut client, json).await?;
+            Ok(None)
+        }
+        Commands::Describe { name_or_uuid } => {
+            cmd_describe(&mut client, &name_or_uuid, json).await?;
+            Ok(None)
+        }
+        Commands::Status => {
+            cmd_status(&mut client, json).await?;
+            Ok(None)
+        }
+        Commands::Config => {
+            cmd_config(&mut client, json).await?;
+            Ok(None)
+        }
+        Commands::Start { name_or_uuid } => {
+            cmd_start(&mut client, &name_or_uuid, json).await?;
+            Ok(None)
+        }
+        Commands::Stop { name_or_uuid } => {
+            cmd_stop(&mut client, &name_or_uuid, json).await?;
+            Ok(None)
+        }
         Commands::Create {
             name,
             command,
@@ -169,9 +213,22 @@ async fn run(cli: Cli) -> Result<(), String> {
                 &after,
                 &before,
             )
-            .await
+            .await?;
+            Ok(None)
         }
-        Commands::Reload => cmd_reload(&mut client, json).await,
+        Commands::Reload => {
+            cmd_reload(&mut client, json).await?;
+            Ok(None)
+        }
+        Commands::RunPrivileged {
+            command,
+            args,
+            env,
+        } => {
+            let env_map = parse_env_args(&env)?;
+            let exit_code = cmd_run_privileged(&mut client, json, &command, &args, env_map).await?;
+            Ok(Some(exit_code))
+        }
     }
 }
 
@@ -649,6 +706,53 @@ async fn cmd_create(
 }
 
 // ---------------------------------------------------------------------------
+// run-privileged
+// ---------------------------------------------------------------------------
+
+async fn cmd_run_privileged(
+    client: &mut ProcessManagerClient<Channel>,
+    json: bool,
+    command: &str,
+    args: &[String],
+    env: HashMap<String, String>,
+) -> Result<i32, String> {
+    let resp = client
+        .run_privileged_command(proto::RunPrivilegedCommandRequest {
+            command: command.to_string(),
+            args: args.to_vec(),
+            env,
+        })
+        .await
+        .map_err(grpc_err)?
+        .into_inner();
+
+    if json {
+        let val = serde_json::json!({
+            "exit_code": resp.exit_code,
+            "stdout": resp.stdout,
+            "stderr": resp.stderr,
+        });
+        println!("{}", serde_json::to_string_pretty(&val).unwrap());
+        return Ok(resp.exit_code);
+    }
+
+    println!("Exit code: {}", resp.exit_code);
+    if !resp.stdout.is_empty() {
+        print!("{}", resp.stdout);
+        if !resp.stdout.ends_with('\n') {
+            println!();
+        }
+    }
+    if !resp.stderr.is_empty() {
+        eprint!("{}", resp.stderr);
+        if !resp.stderr.ends_with('\n') {
+            eprintln!();
+        }
+    }
+    Ok(resp.exit_code)
+}
+
+// ---------------------------------------------------------------------------
 // reload
 // ---------------------------------------------------------------------------
 
@@ -789,5 +893,13 @@ mod tests {
         let err = parse_env_args(&args).unwrap_err();
         assert!(err.contains("INVALID"));
         assert!(err.contains("KEY=VALUE"));
+    }
+
+    #[test]
+    fn test_exit_code_to_exit_status() {
+        assert_eq!(exit_code_to_exit_status(0), ExitCode::SUCCESS);
+        assert_eq!(exit_code_to_exit_status(1), ExitCode::from(1));
+        assert_eq!(exit_code_to_exit_status(256), ExitCode::from(0));
+        assert_eq!(exit_code_to_exit_status(257), ExitCode::from(1));
     }
 }

--- a/pkg/procmgr/rust/src/bins/dd-procmgr.rs
+++ b/pkg/procmgr/rust/src/bins/dd-procmgr.rs
@@ -220,11 +220,7 @@ async fn run(cli: Cli) -> Result<Option<i32>, String> {
             cmd_reload(&mut client, json).await?;
             Ok(None)
         }
-        Commands::RunPrivileged {
-            command,
-            args,
-            env,
-        } => {
+        Commands::RunPrivileged { command, args, env } => {
             let env_map = parse_env_args(&env)?;
             let exit_code = cmd_run_privileged(&mut client, json, &command, &args, env_map).await?;
             Ok(Some(exit_code))

--- a/pkg/procmgr/rust/src/grpc/mod.rs
+++ b/pkg/procmgr/rust/src/grpc/mod.rs
@@ -1171,4 +1171,18 @@ mod tests {
             .into_inner();
         assert_eq!(resp.detail.unwrap().name, "svc-c");
     }
+
+    #[tokio::test]
+    async fn test_run_privileged_command_unimplemented_on_unix() {
+        let (mut client, _shutdown) = start_test_server(vec![]).await;
+        let status = client
+            .run_privileged_command(proto::RunPrivilegedCommandRequest {
+                command: "cmd.exe".to_string(),
+                args: vec!["/C".into(), "echo".into(), "hi".into()],
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::Unimplemented);
+    }
 }

--- a/pkg/procmgr/rust/src/grpc/service.rs
+++ b/pkg/procmgr/rust/src/grpc/service.rs
@@ -227,7 +227,9 @@ impl proto::process_manager_server::ProcessManager for ProcessManagerService {
 
             if !crate::privileged::enabled() {
                 log::warn!("RunPrivilegedCommand denied: privileged commands are disabled");
-                return Err(Status::permission_denied("privileged commands are disabled"));
+                return Err(Status::permission_denied(
+                    "privileged commands are disabled",
+                ));
             }
 
             let req = request.into_inner();

--- a/pkg/procmgr/rust/src/grpc/service.rs
+++ b/pkg/procmgr/rust/src/grpc/service.rs
@@ -217,19 +217,19 @@ impl proto::process_manager_server::ProcessManager for ProcessManagerService {
 
         #[cfg(windows)]
         {
+            if !crate::privileged::enabled() {
+                log::warn!("RunPrivilegedCommand denied: privileged commands are disabled");
+                return Err(Status::permission_denied(
+                    "privileged commands are disabled",
+                ));
+            }
+
             let client_pid = client_pid_from_request(&request)?;
             if !crate::peer_auth::authorize_par_caller(client_pid) {
                 log::warn!(
                     "RunPrivilegedCommand denied: caller pid={client_pid} is not privateactionrunner"
                 );
                 return Err(Status::permission_denied("caller is not authorized"));
-            }
-
-            if !crate::privileged::enabled() {
-                log::warn!("RunPrivilegedCommand denied: privileged commands are disabled");
-                return Err(Status::permission_denied(
-                    "privileged commands are disabled",
-                ));
             }
 
             let req = request.into_inner();

--- a/pkg/procmgr/rust/src/grpc/service.rs
+++ b/pkg/procmgr/rust/src/grpc/service.rs
@@ -239,14 +239,12 @@ impl proto::process_manager_server::ProcessManager for ProcessManagerService {
                 req.args
             );
 
-            crate::privileged::catalog::validate(&req.command, &req.args, &req.env).map_err(
-                |e| {
+            let command = crate::privileged::catalog::validate(&req.command, &req.args, &req.env)
+                .map_err(|e| {
                     log::warn!("RunPrivilegedCommand denied: catalog validation failed: {e:#}");
                     Status::permission_denied(e.to_string())
-                },
-            )?;
-
-            let command = req.command;
+                })?
+                .to_string();
             let args = req.args;
             let env = req.env;
             let output = tokio::task::spawn_blocking(move || {

--- a/pkg/procmgr/rust/src/grpc/service.rs
+++ b/pkg/procmgr/rust/src/grpc/service.rs
@@ -202,6 +202,83 @@ impl proto::process_manager_server::ProcessManager for ProcessManagerService {
             runtime_processes: runtime,
         }))
     }
+
+    async fn run_privileged_command(
+        &self,
+        request: Request<proto::RunPrivilegedCommandRequest>,
+    ) -> Result<Response<proto::RunPrivilegedCommandResponse>, Status> {
+        #[cfg(unix)]
+        {
+            let _ = request;
+            return Err(Status::unimplemented(
+                "RunPrivilegedCommand is not implemented on this platform",
+            ));
+        }
+
+        #[cfg(windows)]
+        {
+            let client_pid = client_pid_from_request(&request)?;
+            if !crate::peer_auth::authorize_par_caller(client_pid) {
+                log::warn!(
+                    "RunPrivilegedCommand denied: caller pid={client_pid} is not privateactionrunner"
+                );
+                return Err(Status::permission_denied("caller is not authorized"));
+            }
+
+            if !crate::privileged::enabled() {
+                log::warn!("RunPrivilegedCommand denied: privileged commands are disabled");
+                return Err(Status::permission_denied("privileged commands are disabled"));
+            }
+
+            let req = request.into_inner();
+            log::info!(
+                "RunPrivilegedCommand request: peer_pid={client_pid}, command={}, args={:?}",
+                req.command,
+                req.args
+            );
+
+            crate::privileged::catalog::validate(&req.command, &req.args, &req.env).map_err(
+                |e| {
+                    log::warn!("RunPrivilegedCommand denied: catalog validation failed: {e:#}");
+                    Status::permission_denied(e.to_string())
+                },
+            )?;
+
+            let command = req.command;
+            let args = req.args;
+            let env = req.env;
+            let output = tokio::task::spawn_blocking(move || {
+                crate::platform::run_privileged_command(&command, &args, &env)
+            })
+            .await
+            .map_err(|_| Status::internal("privileged command task failed"))?
+            .map_err(|e| {
+                log::error!("RunPrivilegedCommand execution failed: {e:#}");
+                Status::internal(e.to_string())
+            })?;
+
+            log::info!(
+                "RunPrivilegedCommand completed: peer_pid={client_pid}, exit_code={}",
+                output.exit_code
+            );
+
+            return Ok(Response::new(proto::RunPrivilegedCommandResponse {
+                exit_code: output.exit_code,
+                stdout: output.stdout,
+                stderr: output.stderr,
+            }));
+        }
+    }
+}
+
+#[cfg(windows)]
+fn client_pid_from_request<T>(request: &Request<T>) -> Result<u32, Status> {
+    request
+        .extensions()
+        .get::<crate::transport::PipeConnectInfo>()
+        .map(|info| info.client_pid)
+        .filter(|&pid| pid != 0)
+        .ok_or_else(|| Status::internal("missing named pipe peer info"))
 }
 
 impl From<ProcessState> for proto::ProcessState {

--- a/pkg/procmgr/rust/src/lib.rs
+++ b/pkg/procmgr/rust/src/lib.rs
@@ -9,7 +9,9 @@ pub mod env;
 pub mod grpc;
 pub mod manager;
 pub mod ordering;
+pub mod peer_auth;
 pub mod platform;
+pub mod privileged;
 pub mod process;
 #[cfg(windows)]
 pub mod service;

--- a/pkg/procmgr/rust/src/peer_auth/mod.rs
+++ b/pkg/procmgr/rust/src/peer_auth/mod.rs
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use unix::*;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub use windows::*;

--- a/pkg/procmgr/rust/src/peer_auth/unix.rs
+++ b/pkg/procmgr/rust/src/peer_auth/unix.rs
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+/// RunPrivilegedCommand peer authorization is not implemented on Unix yet (PR 4).
+pub fn authorize_par_caller(_client_pid: u32) -> bool {
+    false
+}

--- a/pkg/procmgr/rust/src/peer_auth/windows.rs
+++ b/pkg/procmgr/rust/src/peer_auth/windows.rs
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::System::Threading::{
+    OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
+};
+
+pub const PAR_EXE_BASENAME: &str = "privateactionrunner.exe";
+pub const PROCMGR_CLI_EXE_BASENAME: &str = "dd-procmgr.exe";
+
+fn cli_peer_auth_enabled() -> bool {
+    std::env::var("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI")
+        .is_ok_and(|v| matches!(v.as_str(), "1" | "true" | "TRUE"))
+}
+
+/// Return true when `client_pid` is an authorized RunPrivilegedCommand caller.
+pub fn authorize_par_caller(client_pid: u32) -> bool {
+    if client_pid == 0 {
+        return false;
+    }
+
+    #[cfg(test)]
+    if std::env::var("DD_PM_PRIVILEGED_COMMANDS_TEST_SKIP_PEER_AUTH")
+        .is_ok_and(|v| v == "1")
+    {
+        return true;
+    }
+
+    match process_exe_basename(client_pid) {
+        Ok(basename) => {
+            if basename.eq_ignore_ascii_case(PAR_EXE_BASENAME) {
+                return true;
+            }
+            cli_peer_auth_enabled() && basename.eq_ignore_ascii_case(PROCMGR_CLI_EXE_BASENAME)
+        }
+        Err(e) => {
+            log::warn!("peer auth: failed to resolve pid {client_pid}: {e:#}");
+            false
+        }
+    }
+}
+
+fn process_exe_basename(pid: u32) -> Result<String> {
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        anyhow::bail!(
+            "OpenProcess({pid}) failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    let _guard = HandleGuard(handle);
+
+    let mut buffer = vec![0u16; 32_768];
+    let mut size = buffer.len() as u32;
+    let ok = unsafe { QueryFullProcessImageNameW(handle, 0, buffer.as_mut_ptr(), &mut size) };
+    if ok == 0 {
+        anyhow::bail!(
+            "QueryFullProcessImageNameW({pid}) failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
+    let image_path = String::from_utf16_lossy(&buffer[..size as usize]);
+    Ok(Path::new(&image_path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .context("process image path has no basename")?
+        .to_string())
+}
+
+struct HandleGuard(windows_sys::Win32::Foundation::HANDLE);
+
+impl Drop for HandleGuard {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_par_process_is_rejected() {
+        assert!(!authorize_par_caller(std::process::id()));
+    }
+
+    #[test]
+    fn dd_procmgr_cli_allowed_when_opted_in() {
+        std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI", "1");
+        let basename = process_exe_basename(std::process::id()).unwrap();
+        if basename.eq_ignore_ascii_case(PROCMGR_CLI_EXE_BASENAME) {
+            assert!(authorize_par_caller(std::process::id()));
+        }
+        std::env::remove_var("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI");
+    }
+}

--- a/pkg/procmgr/rust/src/peer_auth/windows.rs
+++ b/pkg/procmgr/rust/src/peer_auth/windows.rs
@@ -59,8 +59,13 @@ fn image_path_matches_par_install(image_path: &Path) -> bool {
 }
 
 fn expected_par_exe_paths() -> Vec<PathBuf> {
+    let install_root = crate::platform::agent_install_root();
     vec![
-        crate::platform::agent_install_root()
+        install_root
+            .join("bin")
+            .join("agent")
+            .join(PAR_EXE_BASENAME),
+        install_root
             .join("embedded")
             .join("bin")
             .join(PAR_EXE_BASENAME),

--- a/pkg/procmgr/rust/src/peer_auth/windows.rs
+++ b/pkg/procmgr/rust/src/peer_auth/windows.rs
@@ -94,11 +94,11 @@ mod tests {
 
     #[test]
     fn dd_procmgr_cli_allowed_when_opted_in() {
-        std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI", "1");
+        unsafe { std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI", "1"); }
         let basename = process_exe_basename(std::process::id()).unwrap();
         if basename.eq_ignore_ascii_case(PROCMGR_CLI_EXE_BASENAME) {
             assert!(authorize_par_caller(std::process::id()));
         }
-        std::env::remove_var("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI");
+        unsafe { std::env::remove_var("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI"); }
     }
 }

--- a/pkg/procmgr/rust/src/peer_auth/windows.rs
+++ b/pkg/procmgr/rust/src/peer_auth/windows.rs
@@ -94,11 +94,15 @@ mod tests {
 
     #[test]
     fn dd_procmgr_cli_allowed_when_opted_in() {
-        unsafe { std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI", "1"); }
+        unsafe {
+            std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI", "1");
+        }
         let basename = process_exe_basename(std::process::id()).unwrap();
         if basename.eq_ignore_ascii_case(PROCMGR_CLI_EXE_BASENAME) {
             assert!(authorize_par_caller(std::process::id()));
         }
-        unsafe { std::env::remove_var("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI"); }
+        unsafe {
+            std::env::remove_var("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI");
+        }
     }
 }

--- a/pkg/procmgr/rust/src/peer_auth/windows.rs
+++ b/pkg/procmgr/rust/src/peer_auth/windows.rs
@@ -25,9 +25,7 @@ pub fn authorize_par_caller(client_pid: u32) -> bool {
     }
 
     #[cfg(test)]
-    if std::env::var("DD_PM_PRIVILEGED_COMMANDS_TEST_SKIP_PEER_AUTH")
-        .is_ok_and(|v| v == "1")
-    {
+    if std::env::var("DD_PM_PRIVILEGED_COMMANDS_TEST_SKIP_PEER_AUTH").is_ok_and(|v| v == "1") {
         return true;
     }
 

--- a/pkg/procmgr/rust/src/peer_auth/windows.rs
+++ b/pkg/procmgr/rust/src/peer_auth/windows.rs
@@ -4,7 +4,7 @@
 // Copyright 2026-present Datadog, Inc.
 
 use anyhow::{Context, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use windows_sys::Win32::Foundation::CloseHandle;
 use windows_sys::Win32::System::Threading::{
     OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
@@ -29,12 +29,14 @@ pub fn authorize_par_caller(client_pid: u32) -> bool {
         return true;
     }
 
-    match process_exe_basename(client_pid) {
-        Ok(basename) => {
-            if basename.eq_ignore_ascii_case(PAR_EXE_BASENAME) {
+    match process_exe_path(client_pid) {
+        Ok(image_path) => {
+            if image_path_matches_par_install(&image_path) {
                 return true;
             }
-            cli_peer_auth_enabled() && basename.eq_ignore_ascii_case(PROCMGR_CLI_EXE_BASENAME)
+            cli_peer_auth_enabled()
+                && path_basename(&image_path)
+                    .is_some_and(|basename| basename.eq_ignore_ascii_case(PROCMGR_CLI_EXE_BASENAME))
         }
         Err(e) => {
             log::warn!("peer auth: failed to resolve pid {client_pid}: {e:#}");
@@ -43,7 +45,39 @@ pub fn authorize_par_caller(client_pid: u32) -> bool {
     }
 }
 
-fn process_exe_basename(pid: u32) -> Result<String> {
+fn image_path_matches_par_install(image_path: &Path) -> bool {
+    if !path_basename(image_path)
+        .is_some_and(|basename| basename.eq_ignore_ascii_case(PAR_EXE_BASENAME))
+    {
+        return false;
+    }
+
+    let normalized = normalize_windows_path(image_path);
+    expected_par_exe_paths()
+        .into_iter()
+        .any(|expected| normalize_windows_path(&expected) == normalized)
+}
+
+fn expected_par_exe_paths() -> Vec<PathBuf> {
+    vec![
+        crate::platform::agent_install_root()
+            .join("embedded")
+            .join("bin")
+            .join(PAR_EXE_BASENAME),
+    ]
+}
+
+fn normalize_windows_path(path: &Path) -> String {
+    path.to_string_lossy().replace('/', "\\").to_ascii_lowercase()
+}
+
+fn path_basename(path: &Path) -> Option<String> {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .map(str::to_string)
+}
+
+fn process_exe_path(pid: u32) -> Result<PathBuf> {
     let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
     if handle.is_null() {
         anyhow::bail!(
@@ -64,11 +98,7 @@ fn process_exe_basename(pid: u32) -> Result<String> {
     }
 
     let image_path = String::from_utf16_lossy(&buffer[..size as usize]);
-    Ok(Path::new(&image_path)
-        .file_name()
-        .and_then(|s| s.to_str())
-        .context("process image path has no basename")?
-        .to_string())
+    Ok(PathBuf::from(image_path))
 }
 
 struct HandleGuard(windows_sys::Win32::Foundation::HANDLE);
@@ -93,12 +123,31 @@ mod tests {
     }
 
     #[test]
+    fn par_basename_spoof_from_wrong_directory_is_rejected() {
+        assert!(!image_path_matches_par_install(Path::new(
+            r"C:\Temp\privateactionrunner.exe"
+        )));
+    }
+
+    #[test]
+    fn par_install_path_is_accepted() {
+        for expected in expected_par_exe_paths() {
+            assert!(
+                image_path_matches_par_install(&expected),
+                "expected trusted PAR path {expected:?}"
+            );
+        }
+    }
+
+    #[test]
     fn dd_procmgr_cli_allowed_when_opted_in() {
         unsafe {
             std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI", "1");
         }
-        let basename = process_exe_basename(std::process::id()).unwrap();
-        if basename.eq_ignore_ascii_case(PROCMGR_CLI_EXE_BASENAME) {
+        let image_path = process_exe_path(std::process::id()).unwrap();
+        if path_basename(&image_path)
+            .is_some_and(|basename| basename.eq_ignore_ascii_case(PROCMGR_CLI_EXE_BASENAME))
+        {
             assert!(authorize_par_caller(std::process::id()));
         }
         unsafe {

--- a/pkg/procmgr/rust/src/platform/unix.rs
+++ b/pkg/procmgr/rust/src/platform/unix.rs
@@ -64,3 +64,12 @@ pub async fn shutdown_signal() {
         _ = sigint.recv() => { log::info!("received SIGINT"); }
     }
 }
+
+/// RunPrivilegedCommand is implemented in PR 4 (setuid helper).
+pub fn run_privileged_command(
+    _command: &str,
+    _args: &[String],
+    _env: &std::collections::HashMap<String, String>,
+) -> Result<crate::privileged::PrivilegedCommandOutput> {
+    anyhow::bail!("RunPrivilegedCommand is not implemented on this platform")
+}

--- a/pkg/procmgr/rust/src/platform/windows/mod.rs
+++ b/pkg/procmgr/rust/src/platform/windows/mod.rs
@@ -3,6 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+mod run_privileged;
+mod wide;
+
+pub(crate) use run_privileged::run_privileged_command;
+
 use anyhow::Result;
 use std::ffi::c_void;
 use std::os::windows::ffi::OsStringExt;

--- a/pkg/procmgr/rust/src/platform/windows/mod.rs
+++ b/pkg/procmgr/rust/src/platform/windows/mod.rs
@@ -316,6 +316,11 @@ fn install_root() -> PathBuf {
     install_root_from_registry().unwrap_or_else(default_install_root)
 }
 
+/// Agent install root from registry (`InstallPath`) or the Windows default layout.
+pub(crate) fn agent_install_root() -> PathBuf {
+    install_root()
+}
+
 /// Default directory for process-manager YAML (`*.yaml`), same layout as Linux
 /// (`/opt/datadog-agent/processes.d`) and omnibus. Resolves the install root like
 /// `pkg/util/winutil.GetProgramFilesDirForProduct` in Go (`InstallPath` registry value,

--- a/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
+++ b/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
@@ -381,11 +381,7 @@ mod tests {
         std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ENABLED", "1");
         let out = run_privileged_command(
             "cmd.exe",
-            &[
-                "/C".into(),
-                "echo".into(),
-                "procmgr-privileged-ok".into(),
-            ],
+            &["/C".into(), "echo".into(), "procmgr-privileged-ok".into()],
             &HashMap::new(),
         )
         .expect("catalog test command should run");

--- a/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
+++ b/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
@@ -378,7 +378,9 @@ mod tests {
 
     #[test]
     fn privileged_echo_runs_as_system() {
-        unsafe { std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ENABLED", "1"); }
+        unsafe {
+            std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ENABLED", "1");
+        }
         let out = run_privileged_command(
             "cmd.exe",
             &["/C".into(), "echo".into(), "procmgr-privileged-ok".into()],

--- a/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
+++ b/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
@@ -1,0 +1,399 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//! One-shot privileged child execution as LocalSystem with captured stdout/stderr.
+
+use anyhow::{Context, Result, bail};
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::os::windows::ffi::OsStrExt;
+use std::ptr;
+use windows_sys::Win32::Foundation::{
+    CloseHandle, HANDLE, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE,
+};
+use windows_sys::Win32::Security::{
+    DuplicateTokenEx, LOGON32_LOGON_SERVICE, LOGON32_PROVIDER_DEFAULT, LogonUserW,
+    SECURITY_ATTRIBUTES, SecurityDelegation, TokenPrimary,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_SHARE_READ,
+    FILE_SHARE_WRITE, OPEN_EXISTING, ReadFile,
+};
+use windows_sys::Win32::System::Pipes::CreatePipe;
+use windows_sys::Win32::System::SystemServices::MAXIMUM_ALLOWED;
+use windows_sys::Win32::System::Threading::{
+    CREATE_NEW_CONSOLE, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_UNICODE_ENVIRONMENT,
+    CreateProcessAsUserW, GetExitCodeProcess, INFINITE, PROCESS_INFORMATION, STARTF_USESTDHANDLES,
+    STARTUPINFOW, SetHandleInformation, WaitForSingleObject,
+};
+
+use super::wide;
+
+const MAX_CAPTURE_BYTES: usize = 4 * 1024 * 1024;
+
+use crate::privileged::PrivilegedCommandOutput;
+pub fn run_privileged_command(
+    command: &str,
+    args: &[String],
+    env: &HashMap<String, String>,
+) -> Result<PrivilegedCommandOutput> {
+    let _console_guard = super::console_lock();
+
+    let mut stdout_pipe = AnonymousPipe::new()?;
+    let mut stderr_pipe = AnonymousPipe::new()?;
+    let stdin_handle = open_nul_handle(FILE_GENERIC_READ | FILE_GENERIC_WRITE)?;
+
+    let command_line = build_command_line(command, args);
+    let application_name_w = wide::null_terminated(command);
+    let mut command_line_w: Vec<u16> = std::ffi::OsStr::new(&command_line)
+        .encode_wide()
+        .chain([0])
+        .collect();
+
+    let env_block = env_block_from_current_plus_overrides(env)?;
+    let env_block_ptr = env_block.as_ptr() as *const c_void;
+
+    let primary_token = local_system_primary_token()?;
+    let _primary_token_guard = TokenHandle(primary_token);
+
+    let mut si: STARTUPINFOW = unsafe { std::mem::zeroed() };
+    si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
+    si.dwFlags = STARTF_USESTDHANDLES;
+    si.hStdInput = stdin_handle;
+    si.hStdOutput = stdout_pipe.write;
+    si.hStdError = stderr_pipe.write;
+
+    let mut pi: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
+    let creation_flags = CREATE_NEW_PROCESS_GROUP
+        | CREATE_NEW_CONSOLE
+        | CREATE_NO_WINDOW
+        | CREATE_UNICODE_ENVIRONMENT;
+
+    let ok = unsafe {
+        CreateProcessAsUserW(
+            primary_token,
+            application_name_w.as_ptr(),
+            command_line_w.as_mut_ptr(),
+            ptr::null(),
+            ptr::null(),
+            1,
+            creation_flags,
+            env_block_ptr,
+            ptr::null(),
+            &si,
+            &mut pi,
+        )
+    };
+
+    unsafe {
+        let _ = CloseHandle(stdin_handle);
+        stdout_pipe.close_write();
+        stderr_pipe.close_write();
+    }
+
+    if ok == 0 {
+        bail!(
+            "CreateProcessAsUserW failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
+    let process_handle = pi.hProcess;
+    unsafe {
+        let _ = CloseHandle(pi.hThread);
+    }
+
+    let wait = unsafe { WaitForSingleObject(process_handle, INFINITE) };
+    if wait == 0 {
+        bail!(
+            "WaitForSingleObject failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
+    let mut code: u32 = 0;
+    let ok = unsafe { GetExitCodeProcess(process_handle, &mut code) };
+    unsafe {
+        CloseHandle(process_handle);
+    }
+    if ok == 0 {
+        bail!(
+            "GetExitCodeProcess failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
+    let stdout = stdout_pipe.read_to_string(MAX_CAPTURE_BYTES)?;
+    let stderr = stderr_pipe.read_to_string(MAX_CAPTURE_BYTES)?;
+
+    Ok(PrivilegedCommandOutput {
+        exit_code: i32::try_from(code).unwrap_or(i32::MAX),
+        stdout,
+        stderr,
+    })
+}
+
+fn build_command_line(command: &str, args: &[String]) -> String {
+    let mut cmdline = windows_crt_escape_arg(command);
+    for arg in args {
+        cmdline.push(' ');
+        cmdline.push_str(&windows_crt_escape_arg(arg));
+    }
+    cmdline
+}
+
+fn windows_crt_escape_arg(s: &str) -> String {
+    let mut out = String::new();
+    out.push('"');
+    let mut backslashes = 0usize;
+    for ch in s.chars() {
+        match ch {
+            '\\' => backslashes += 1,
+            '"' => {
+                out.push_str(&"\\".repeat(backslashes * 2 + 1));
+                out.push('"');
+                backslashes = 0;
+            }
+            _ => {
+                out.push_str(&"\\".repeat(backslashes));
+                out.push(ch);
+                backslashes = 0;
+            }
+        }
+    }
+    out.push_str(&"\\".repeat(backslashes * 2));
+    out.push('"');
+    out
+}
+
+fn env_block_from_current_plus_overrides(overrides: &HashMap<String, String>) -> Result<Vec<u16>> {
+    let mut vars: HashMap<String, String> = std::env::vars().collect();
+    for (k, v) in overrides {
+        vars.insert(k.clone(), v.clone());
+    }
+
+    let mut block = Vec::new();
+    for (k, v) in vars {
+        let kv = format!("{k}={v}");
+        block.extend(std::ffi::OsStr::new(&kv).encode_wide());
+        block.push(0);
+    }
+    block.push(0);
+    Ok(block)
+}
+
+fn local_system_primary_token() -> Result<HANDLE> {
+    let domain_w = wide::null_terminated("NT AUTHORITY");
+    let user_w = wide::null_terminated("SYSTEM");
+    let password_w = wide::null_terminated("");
+
+    let mut logon_token: HANDLE = ptr::null_mut();
+    let ok = unsafe {
+        LogonUserW(
+            user_w.as_ptr(),
+            domain_w.as_ptr(),
+            password_w.as_ptr(),
+            LOGON32_LOGON_SERVICE,
+            LOGON32_PROVIDER_DEFAULT,
+            &mut logon_token,
+        )
+    };
+    if ok == 0 {
+        bail!(
+            "LogonUserW(NT AUTHORITY\\SYSTEM) failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    let logon_guard = TokenHandle(logon_token);
+
+    let mut primary_token: HANDLE = ptr::null_mut();
+    let ok = unsafe {
+        DuplicateTokenEx(
+            logon_guard.0,
+            MAXIMUM_ALLOWED,
+            ptr::null(),
+            SecurityDelegation,
+            TokenPrimary,
+            &mut primary_token,
+        )
+    };
+    if ok == 0 {
+        bail!(
+            "DuplicateTokenEx failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    Ok(primary_token)
+}
+
+fn open_nul_handle(access: u32) -> Result<HANDLE> {
+    let nul = wide::null_terminated("NUL");
+    let h = unsafe {
+        CreateFileW(
+            nul.as_ptr(),
+            access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            ptr::null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            0,
+        )
+    };
+    if h == INVALID_HANDLE_VALUE || h.is_null() {
+        bail!(
+            "CreateFileW(NUL) failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    Ok(h)
+}
+
+struct AnonymousPipe {
+    read: HANDLE,
+    write: HANDLE,
+}
+
+impl AnonymousPipe {
+    fn new() -> Result<Self> {
+        let mut sa: SECURITY_ATTRIBUTES = unsafe { std::mem::zeroed() };
+        sa.nLength = std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32;
+        sa.bInheritHandle = 1;
+
+        let mut read = ptr::null_mut();
+        let mut write = ptr::null_mut();
+        let ok = unsafe { CreatePipe(&mut read, &mut write, &sa, 0) };
+        if ok == 0 {
+            bail!("CreatePipe failed: {}", std::io::Error::last_os_error());
+        }
+
+        let read_guard = HandleGuard(read);
+        let write_guard = HandleGuard(write);
+
+        // Child inherits write ends only.
+        read_guard.clear_inherit()?;
+        write_guard.set_inherit()?;
+
+        let read = read_guard.0;
+        let write = write_guard.0;
+        std::mem::forget(read_guard);
+        std::mem::forget(write_guard);
+
+        Ok(Self { read, write })
+    }
+
+    fn close_write(&mut self) {
+        if !self.write.is_null() {
+            unsafe {
+                CloseHandle(self.write);
+            }
+            self.write = ptr::null_mut();
+        }
+    }
+
+    fn read_to_string(&self, max_bytes: usize) -> Result<String> {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            if buf.len() >= max_bytes {
+                bail!("privileged command output exceeded {max_bytes} byte cap");
+            }
+            let mut nbytes = 0u32;
+            let to_read = std::cmp::min(chunk.len(), max_bytes - buf.len()) as u32;
+            let ok = unsafe {
+                ReadFile(
+                    self.read,
+                    chunk.as_mut_ptr(),
+                    to_read,
+                    &mut nbytes,
+                    ptr::null_mut(),
+                )
+            };
+            if ok == 0 {
+                bail!("ReadFile failed: {}", std::io::Error::last_os_error());
+            }
+            if nbytes == 0 {
+                break;
+            }
+            buf.extend_from_slice(&chunk[..nbytes as usize]);
+        }
+        String::from_utf8(buf).context("privileged command output was not valid UTF-8")
+    }
+}
+
+impl Drop for AnonymousPipe {
+    fn drop(&mut self) {
+        for h in [self.read, self.write] {
+            if !h.is_null() {
+                unsafe {
+                    CloseHandle(h);
+                }
+            }
+        }
+    }
+}
+
+struct HandleGuard(HANDLE);
+
+impl HandleGuard {
+    fn set_inherit(&self) -> Result<()> {
+        let ok = unsafe { SetHandleInformation(self.0, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT) };
+        if ok == 0 {
+            bail!(
+                "SetHandleInformation(set inherit) failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        Ok(())
+    }
+
+    fn clear_inherit(&self) -> Result<()> {
+        let ok = unsafe { SetHandleInformation(self.0, HANDLE_FLAG_INHERIT, 0) };
+        if ok == 0 {
+            bail!(
+                "SetHandleInformation(clear inherit) failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        Ok(())
+    }
+}
+
+struct TokenHandle(HANDLE);
+
+impl Drop for TokenHandle {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn privileged_echo_runs_as_system() {
+        std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ENABLED", "1");
+        let out = run_privileged_command(
+            "cmd.exe",
+            &[
+                "/C".into(),
+                "echo".into(),
+                "procmgr-privileged-ok".into(),
+            ],
+            &HashMap::new(),
+        )
+        .expect("catalog test command should run");
+        assert_eq!(out.exit_code, 0);
+        assert!(
+            out.stdout.contains("procmgr-privileged-ok"),
+            "stdout={:?}",
+            out.stdout
+        );
+    }
+}

--- a/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
+++ b/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
@@ -141,7 +141,7 @@ pub fn run_privileged_command(
         .map_err(|_| anyhow::anyhow!("stderr reader thread panicked"))??;
 
     Ok(PrivilegedCommandOutput {
-        exit_code: i32::try_from(code).unwrap_or(i32::MAX),
+        exit_code: windows_exit_code_to_i32(code),
         stdout,
         stderr,
     })
@@ -308,6 +308,11 @@ impl AnonymousPipe {
     }
 }
 
+fn windows_exit_code_to_i32(code: u32) -> i32 {
+    // Windows exit codes are DWORDs; preserve the full bit pattern in proto int32.
+    code as i32
+}
+
 fn read_handle_to_string(handle: HANDLE, max_bytes: usize) -> Result<String> {
     if handle.is_null() {
         return Ok(String::new());
@@ -398,6 +403,11 @@ impl Drop for TokenHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn windows_exit_code_preserves_high_bit() {
+        assert_eq!(windows_exit_code_to_i32(0x8007_0005), -2_147_024_891);
+    }
 
     #[test]
     fn privileged_echo_runs_as_system() {

--- a/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
+++ b/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
@@ -106,6 +106,13 @@ pub fn run_privileged_command(
         let _ = CloseHandle(pi.hThread);
     }
 
+    let stdout_read = stdout_pipe.take_read();
+    let stderr_read = stderr_pipe.take_read();
+    let stdout_reader =
+        std::thread::spawn(move || read_handle_to_string(stdout_read, MAX_CAPTURE_BYTES));
+    let stderr_reader =
+        std::thread::spawn(move || read_handle_to_string(stderr_read, MAX_CAPTURE_BYTES));
+
     let wait = unsafe { WaitForSingleObject(process_handle, INFINITE) };
     if wait == WAIT_FAILED {
         bail!(
@@ -126,8 +133,12 @@ pub fn run_privileged_command(
         );
     }
 
-    let stdout = stdout_pipe.read_to_string(MAX_CAPTURE_BYTES)?;
-    let stderr = stderr_pipe.read_to_string(MAX_CAPTURE_BYTES)?;
+    let stdout = stdout_reader
+        .join()
+        .map_err(|_| anyhow::anyhow!("stdout reader thread panicked"))??;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| anyhow::anyhow!("stderr reader thread panicked"))??;
 
     Ok(PrivilegedCommandOutput {
         exit_code: i32::try_from(code).unwrap_or(i32::MAX),
@@ -286,38 +297,52 @@ impl AnonymousPipe {
         }
     }
 
+    fn take_read(&mut self) -> HANDLE {
+        let read = self.read;
+        self.read = ptr::null_mut();
+        read
+    }
+
     fn read_to_string(&self, max_bytes: usize) -> Result<String> {
-        let mut buf = Vec::new();
-        let mut chunk = [0u8; 4096];
-        loop {
-            if buf.len() >= max_bytes {
-                bail!("privileged command output exceeded {max_bytes} byte cap");
-            }
-            let mut nbytes = 0u32;
-            let to_read = std::cmp::min(chunk.len(), max_bytes - buf.len()) as u32;
-            let ok = unsafe {
-                ReadFile(
-                    self.read,
-                    chunk.as_mut_ptr(),
-                    to_read,
-                    &mut nbytes,
-                    ptr::null_mut(),
-                )
-            };
-            if ok == 0 {
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() == Some(ERROR_BROKEN_PIPE as i32) {
-                    break;
-                }
-                bail!("ReadFile failed: {err}");
-            }
-            if nbytes == 0 {
+        read_handle_to_string(self.read, max_bytes)
+    }
+}
+
+fn read_handle_to_string(handle: HANDLE, max_bytes: usize) -> Result<String> {
+    if handle.is_null() {
+        return Ok(String::new());
+    }
+    let _guard = HandleGuard(handle);
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        if buf.len() >= max_bytes {
+            bail!("privileged command output exceeded {max_bytes} byte cap");
+        }
+        let mut nbytes = 0u32;
+        let to_read = std::cmp::min(chunk.len(), max_bytes - buf.len()) as u32;
+        let ok = unsafe {
+            ReadFile(
+                handle,
+                chunk.as_mut_ptr(),
+                to_read,
+                &mut nbytes,
+                ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(ERROR_BROKEN_PIPE as i32) {
                 break;
             }
-            buf.extend_from_slice(&chunk[..nbytes as usize]);
+            bail!("ReadFile failed: {err}");
         }
-        String::from_utf8(buf).context("privileged command output was not valid UTF-8")
+        if nbytes == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..nbytes as usize]);
     }
+    String::from_utf8(buf).context("privileged command output was not valid UTF-8")
 }
 
 impl Drop for AnonymousPipe {

--- a/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
+++ b/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
@@ -14,8 +14,8 @@ use windows_sys::Win32::Foundation::{
     CloseHandle, HANDLE, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, SetHandleInformation,
 };
 use windows_sys::Win32::Security::{
-    DuplicateTokenEx, LOGON32_LOGON_SERVICE, LOGON32_PROVIDER_DEFAULT, LogonUserW,
-    SECURITY_ATTRIBUTES, SecurityDelegation, TokenPrimary,
+    DuplicateTokenEx, SECURITY_ATTRIBUTES, SecurityDelegation, TOKEN_DUPLICATE, TOKEN_QUERY,
+    TokenPrimary,
 };
 use windows_sys::Win32::Storage::FileSystem::{
     CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_SHARE_READ,
@@ -25,8 +25,8 @@ use windows_sys::Win32::System::Pipes::CreatePipe;
 use windows_sys::Win32::System::SystemServices::MAXIMUM_ALLOWED;
 use windows_sys::Win32::System::Threading::{
     CREATE_NEW_CONSOLE, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_UNICODE_ENVIRONMENT,
-    CreateProcessAsUserW, GetExitCodeProcess, INFINITE, PROCESS_INFORMATION, STARTF_USESTDHANDLES,
-    STARTUPINFOW, WaitForSingleObject,
+    CreateProcessAsUserW, GetCurrentProcess, GetExitCodeProcess, INFINITE, OpenProcessToken,
+    PROCESS_INFORMATION, STARTF_USESTDHANDLES, STARTUPINFOW, WAIT_FAILED, WaitForSingleObject,
 };
 
 use super::wide;
@@ -106,7 +106,7 @@ pub fn run_privileged_command(
     }
 
     let wait = unsafe { WaitForSingleObject(process_handle, INFINITE) };
-    if wait == 0 {
+    if wait == WAIT_FAILED {
         bail!(
             "WaitForSingleObject failed: {}",
             std::io::Error::last_os_error()
@@ -185,33 +185,26 @@ fn env_block_from_current_plus_overrides(overrides: &HashMap<String, String>) ->
 }
 
 fn local_system_primary_token() -> Result<HANDLE> {
-    let domain_w = wide::null_terminated("NT AUTHORITY");
-    let user_w = wide::null_terminated("SYSTEM");
-    let password_w = wide::null_terminated("");
-
-    let mut logon_token: HANDLE = ptr::null_mut();
+    let mut process_token: HANDLE = ptr::null_mut();
     let ok = unsafe {
-        LogonUserW(
-            user_w.as_ptr(),
-            domain_w.as_ptr(),
-            password_w.as_ptr(),
-            LOGON32_LOGON_SERVICE,
-            LOGON32_PROVIDER_DEFAULT,
-            &mut logon_token,
+        OpenProcessToken(
+            GetCurrentProcess(),
+            TOKEN_QUERY | TOKEN_DUPLICATE,
+            &mut process_token,
         )
     };
     if ok == 0 {
         bail!(
-            "LogonUserW(NT AUTHORITY\\SYSTEM) failed: {}",
+            "OpenProcessToken failed: {}",
             std::io::Error::last_os_error()
         );
     }
-    let logon_guard = TokenHandle(logon_token);
+    let process_token_guard = TokenHandle(process_token);
 
     let mut primary_token: HANDLE = ptr::null_mut();
     let ok = unsafe {
         DuplicateTokenEx(
-            logon_guard.0,
+            process_token_guard.0,
             MAXIMUM_ALLOWED,
             ptr::null(),
             SecurityDelegation,
@@ -382,7 +375,7 @@ mod tests {
             std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ENABLED", "1");
         }
         let out = run_privileged_command(
-            "cmd.exe",
+            r"C:\Windows\System32\cmd.exe",
             &["/C".into(), "echo".into(), "procmgr-privileged-ok".into()],
             &HashMap::new(),
         )

--- a/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
+++ b/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
@@ -11,7 +11,7 @@ use std::ffi::c_void;
 use std::os::windows::ffi::OsStrExt;
 use std::ptr;
 use windows_sys::Win32::Foundation::{
-    CloseHandle, HANDLE, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE,
+    CloseHandle, HANDLE, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, SetHandleInformation,
 };
 use windows_sys::Win32::Security::{
     DuplicateTokenEx, LOGON32_LOGON_SERVICE, LOGON32_PROVIDER_DEFAULT, LogonUserW,
@@ -26,7 +26,7 @@ use windows_sys::Win32::System::SystemServices::MAXIMUM_ALLOWED;
 use windows_sys::Win32::System::Threading::{
     CREATE_NEW_CONSOLE, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_UNICODE_ENVIRONMENT,
     CreateProcessAsUserW, GetExitCodeProcess, INFINITE, PROCESS_INFORMATION, STARTF_USESTDHANDLES,
-    STARTUPINFOW, SetHandleInformation, WaitForSingleObject,
+    STARTUPINFOW, WaitForSingleObject,
 };
 
 use super::wide;
@@ -238,7 +238,7 @@ fn open_nul_handle(access: u32) -> Result<HANDLE> {
             ptr::null(),
             OPEN_EXISTING,
             FILE_ATTRIBUTE_NORMAL,
-            0,
+            ptr::null_mut(),
         )
     };
     if h == INVALID_HANDLE_VALUE || h.is_null() {
@@ -378,7 +378,7 @@ mod tests {
 
     #[test]
     fn privileged_echo_runs_as_system() {
-        std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ENABLED", "1");
+        unsafe { std::env::set_var("DD_PM_PRIVILEGED_COMMANDS_ENABLED", "1"); }
         let out = run_privileged_command(
             "cmd.exe",
             &["/C".into(), "echo".into(), "procmgr-privileged-ok".into()],

--- a/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
+++ b/pkg/procmgr/rust/src/platform/windows/run_privileged.rs
@@ -11,7 +11,8 @@ use std::ffi::c_void;
 use std::os::windows::ffi::OsStrExt;
 use std::ptr;
 use windows_sys::Win32::Foundation::{
-    CloseHandle, HANDLE, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, SetHandleInformation,
+    CloseHandle, ERROR_BROKEN_PIPE, HANDLE, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE,
+    SetHandleInformation,
 };
 use windows_sys::Win32::Security::{
     DuplicateTokenEx, SECURITY_ATTRIBUTES, SecurityDelegation, TOKEN_DUPLICATE, TOKEN_QUERY,
@@ -304,7 +305,11 @@ impl AnonymousPipe {
                 )
             };
             if ok == 0 {
-                bail!("ReadFile failed: {}", std::io::Error::last_os_error());
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() == Some(ERROR_BROKEN_PIPE as i32) {
+                    break;
+                }
+                bail!("ReadFile failed: {err}");
             }
             if nbytes == 0 {
                 break;

--- a/pkg/procmgr/rust/src/platform/windows/wide.rs
+++ b/pkg/procmgr/rust/src/platform/windows/wide.rs
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use std::os::windows::ffi::OsStrExt;
+
+/// Encode a Rust string as a null-terminated UTF-16 vector for Win32 APIs.
+pub(crate) fn null_terminated(s: impl AsRef<std::ffi::OsStr>) -> Vec<u16> {
+    s.as_ref()
+        .encode_wide()
+        .chain([0])
+        .collect()
+}

--- a/pkg/procmgr/rust/src/platform/windows/wide.rs
+++ b/pkg/procmgr/rust/src/platform/windows/wide.rs
@@ -7,8 +7,5 @@ use std::os::windows::ffi::OsStrExt;
 
 /// Encode a Rust string as a null-terminated UTF-16 vector for Win32 APIs.
 pub(crate) fn null_terminated(s: impl AsRef<std::ffi::OsStr>) -> Vec<u16> {
-    s.as_ref()
-        .encode_wide()
-        .chain([0])
-        .collect()
+    s.as_ref().encode_wide().chain([0]).collect()
 }

--- a/pkg/procmgr/rust/src/privileged/catalog.rs
+++ b/pkg/procmgr/rust/src/privileged/catalog.rs
@@ -18,12 +18,12 @@ pub struct PrivilegedCommandSpec {
 fn catalog() -> &'static [PrivilegedCommandSpec] {
     &[
         PrivilegedCommandSpec {
-            expected_command: "cmd.exe",
+            expected_command: r"C:\Windows\System32\cmd.exe",
             expected_args: &["/C", "echo", "procmgr-privileged-ok"],
             allowed_env: &[],
         },
         PrivilegedCommandSpec {
-            expected_command: "cmd.exe",
+            expected_command: r"C:\Windows\System32\cmd.exe",
             expected_args: &["/C", "whoami"],
             allowed_env: &[],
         },
@@ -31,13 +31,28 @@ fn catalog() -> &'static [PrivilegedCommandSpec] {
 }
 
 /// Reject requests that do not exactly match a catalog entry.
-pub fn validate(command: &str, args: &[String], env: &HashMap<String, String>) -> Result<()> {
-    let norm_cmd = command_basename(command);
+///
+/// Returns the canonical catalog executable path to use at spawn time so callers
+/// cannot substitute a same-basename binary from another directory.
+pub fn validate<'a>(
+    command: &str,
+    args: &[String],
+    env: &HashMap<String, String>,
+) -> Result<&'a str> {
+    let norm_cmd = normalize_path(command);
+    let caller_basename = command_basename(command);
     let norm_args: Vec<String> = args.iter().map(|a| normalize_path(a)).collect();
 
     for spec in catalog() {
-        if norm_cmd != command_basename(spec.expected_command) {
+        let expected_cmd = normalize_path(spec.expected_command);
+        if caller_basename != command_basename(spec.expected_command) {
             continue;
+        }
+
+        if norm_cmd.contains('\\') && norm_cmd != expected_cmd {
+            bail!(
+                "refusing privileged command: command path does not match catalog (got {command})"
+            );
         }
 
         let expected_args: Vec<String> = spec
@@ -58,7 +73,7 @@ pub fn validate(command: &str, args: &[String], env: &HashMap<String, String>) -
             }
         }
 
-        return Ok(());
+        return Ok(spec.expected_command);
     }
 
     bail!("refusing privileged command: command not in catalog (got {command})");
@@ -126,12 +141,36 @@ mod tests {
     }
 
     #[test]
-    fn catalog_accepts_normalized_paths() {
-        validate(
+    fn catalog_accepts_canonical_system32_path() {
+        let cmd = validate(
             r"C:\Windows\System32\cmd.exe",
             &["/C".into(), "echo".into(), "procmgr-privileged-ok".into()],
             &HashMap::new(),
         )
         .unwrap();
+        assert_eq!(cmd, r"C:\Windows\System32\cmd.exe");
+    }
+
+    #[test]
+    fn catalog_substitutes_basename_with_canonical_path() {
+        let cmd = validate(
+            "cmd.exe",
+            &["/C".into(), "echo".into(), "procmgr-privileged-ok".into()],
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert_eq!(cmd, r"C:\Windows\System32\cmd.exe");
+    }
+
+    #[test]
+    fn catalog_rejects_wrong_path_same_basename() {
+        let err = validate(
+            r"C:\Temp\cmd.exe",
+            &["/C".into(), "echo".into(), "procmgr-privileged-ok".into()],
+            &HashMap::new(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("path does not match catalog"), "{err}");
     }
 }

--- a/pkg/procmgr/rust/src/privileged/catalog.rs
+++ b/pkg/procmgr/rust/src/privileged/catalog.rs
@@ -66,7 +66,7 @@ pub fn validate<'a>(
 
         for key in env.keys() {
             if !spec.allowed_env.contains(&key.as_str()) {
-                continue;
+                bail!("refusing privileged command: disallowed env var {key}");
             }
         }
 
@@ -135,7 +135,7 @@ mod tests {
         )
         .unwrap_err()
         .to_string();
-        assert!(err.contains("not in catalog"), "{err}");
+        assert!(err.contains("disallowed env"), "{err}");
     }
 
     #[test]

--- a/pkg/procmgr/rust/src/privileged/catalog.rs
+++ b/pkg/procmgr/rust/src/privileged/catalog.rs
@@ -1,0 +1,147 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use anyhow::{Result, bail};
+use std::collections::HashMap;
+
+/// Host-side allowlist entry for [`super::validate`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivilegedCommandSpec {
+    pub expected_command: &'static str,
+    pub expected_args: &'static [&'static str],
+    pub allowed_env: &'static [&'static str],
+}
+
+/// Embedded catalog of commands PAR may request via RunPrivilegedCommand.
+fn catalog() -> &'static [PrivilegedCommandSpec] {
+    &[
+        PrivilegedCommandSpec {
+            expected_command: "cmd.exe",
+            expected_args: &["/C", "echo", "procmgr-privileged-ok"],
+            allowed_env: &[],
+        },
+        PrivilegedCommandSpec {
+            expected_command: "cmd.exe",
+            expected_args: &["/C", "whoami"],
+            allowed_env: &[],
+        },
+    ]
+}
+
+/// Reject requests that do not exactly match a catalog entry.
+pub fn validate(command: &str, args: &[String], env: &HashMap<String, String>) -> Result<()> {
+    let norm_cmd = command_basename(command);
+    let norm_args: Vec<String> = args.iter().map(|a| normalize_path(a)).collect();
+
+    for spec in catalog() {
+        if norm_cmd != command_basename(spec.expected_command) {
+            continue;
+        }
+
+        let expected_args: Vec<String> = spec
+            .expected_args
+            .iter()
+            .map(|a| normalize_path(a))
+            .collect();
+        if norm_args != expected_args {
+            bail!(
+                "refusing privileged command: unexpected args {args:?} (expected {:?})",
+                spec.expected_args
+            );
+        }
+
+        for key in env.keys() {
+            if !spec.allowed_env.contains(&key.as_str()) {
+                bail!("refusing privileged command: disallowed env var {key}");
+            }
+        }
+
+        return Ok(());
+    }
+
+    bail!(
+        "refusing privileged command: command not in catalog (got {command})"
+    );
+}
+
+fn normalize_path(s: &str) -> String {
+    s.replace('/', "\\").to_ascii_lowercase()
+}
+
+fn command_basename(s: &str) -> String {
+    let normalized = normalize_path(s);
+    normalized
+        .rsplit('\\')
+        .next()
+        .unwrap_or(normalized.as_str())
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_rejects_unknown_command() {
+        let err = validate("powershell.exe", &["-Command".into()], &HashMap::new())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not in catalog"), "{err}");
+    }
+
+    #[test]
+    fn catalog_rejects_wrong_args() {
+        let err = validate("cmd.exe", &["/C".into(), "exit".into(), "1".into()], &HashMap::new())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unexpected args"), "{err}");
+    }
+
+    #[test]
+    fn catalog_rejects_disallowed_env() {
+        let mut env = HashMap::new();
+        env.insert("EVIL".into(), "1".into());
+        let err = validate(
+            "cmd.exe",
+            &[
+                "/C".into(),
+                "echo".into(),
+                "procmgr-privileged-ok".into(),
+            ],
+            &env,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("disallowed env"), "{err}");
+    }
+
+    #[test]
+    fn catalog_accepts_test_entry() {
+        validate(
+            "cmd.exe",
+            &[
+                "/C".into(),
+                "echo".into(),
+                "procmgr-privileged-ok".into(),
+            ],
+            &HashMap::new(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn catalog_accepts_normalized_paths() {
+        validate(
+            r"C:\Windows\System32\cmd.exe",
+            &[
+                "/C".into(),
+                "echo".into(),
+                "procmgr-privileged-ok".into(),
+            ],
+            &HashMap::new(),
+        )
+        .unwrap();
+    }
+}

--- a/pkg/procmgr/rust/src/privileged/catalog.rs
+++ b/pkg/procmgr/rust/src/privileged/catalog.rs
@@ -61,15 +61,12 @@ pub fn validate<'a>(
             .map(|a| normalize_path(a))
             .collect();
         if norm_args != expected_args {
-            bail!(
-                "refusing privileged command: unexpected args {args:?} (expected {:?})",
-                spec.expected_args
-            );
+            continue;
         }
 
         for key in env.keys() {
             if !spec.allowed_env.contains(&key.as_str()) {
-                bail!("refusing privileged command: disallowed env var {key}");
+                continue;
             }
         }
 
@@ -113,7 +110,18 @@ mod tests {
         )
         .unwrap_err()
         .to_string();
-        assert!(err.contains("unexpected args"), "{err}");
+        assert!(err.contains("not in catalog"), "{err}");
+    }
+
+    #[test]
+    fn catalog_accepts_whoami_entry() {
+        let cmd = validate(
+            "cmd.exe",
+            &["/C".into(), "whoami".into()],
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert_eq!(cmd, r"C:\Windows\System32\cmd.exe");
     }
 
     #[test]
@@ -127,7 +135,7 @@ mod tests {
         )
         .unwrap_err()
         .to_string();
-        assert!(err.contains("disallowed env"), "{err}");
+        assert!(err.contains("not in catalog"), "{err}");
     }
 
     #[test]

--- a/pkg/procmgr/rust/src/privileged/catalog.rs
+++ b/pkg/procmgr/rust/src/privileged/catalog.rs
@@ -61,9 +61,7 @@ pub fn validate(command: &str, args: &[String], env: &HashMap<String, String>) -
         return Ok(());
     }
 
-    bail!(
-        "refusing privileged command: command not in catalog (got {command})"
-    );
+    bail!("refusing privileged command: command not in catalog (got {command})");
 }
 
 fn normalize_path(s: &str) -> String {
@@ -93,9 +91,13 @@ mod tests {
 
     #[test]
     fn catalog_rejects_wrong_args() {
-        let err = validate("cmd.exe", &["/C".into(), "exit".into(), "1".into()], &HashMap::new())
-            .unwrap_err()
-            .to_string();
+        let err = validate(
+            "cmd.exe",
+            &["/C".into(), "exit".into(), "1".into()],
+            &HashMap::new(),
+        )
+        .unwrap_err()
+        .to_string();
         assert!(err.contains("unexpected args"), "{err}");
     }
 
@@ -105,11 +107,7 @@ mod tests {
         env.insert("EVIL".into(), "1".into());
         let err = validate(
             "cmd.exe",
-            &[
-                "/C".into(),
-                "echo".into(),
-                "procmgr-privileged-ok".into(),
-            ],
+            &["/C".into(), "echo".into(), "procmgr-privileged-ok".into()],
             &env,
         )
         .unwrap_err()
@@ -121,11 +119,7 @@ mod tests {
     fn catalog_accepts_test_entry() {
         validate(
             "cmd.exe",
-            &[
-                "/C".into(),
-                "echo".into(),
-                "procmgr-privileged-ok".into(),
-            ],
+            &["/C".into(), "echo".into(), "procmgr-privileged-ok".into()],
             &HashMap::new(),
         )
         .unwrap();
@@ -135,11 +129,7 @@ mod tests {
     fn catalog_accepts_normalized_paths() {
         validate(
             r"C:\Windows\System32\cmd.exe",
-            &[
-                "/C".into(),
-                "echo".into(),
-                "procmgr-privileged-ok".into(),
-            ],
+            &["/C".into(), "echo".into(), "procmgr-privileged-ok".into()],
             &HashMap::new(),
         )
         .unwrap();

--- a/pkg/procmgr/rust/src/privileged/mod.rs
+++ b/pkg/procmgr/rust/src/privileged/mod.rs
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+pub mod catalog;
+
+/// Captured output from a one-shot privileged child.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivilegedCommandOutput {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Whether one-shot privileged command execution is enabled on this host.
+///
+/// PR 1 uses an environment toggle; full datadog.yaml config arrives in PR 3.
+pub fn enabled() -> bool {
+    std::env::var("DD_PM_PRIVILEGED_COMMANDS_ENABLED")
+        .is_ok_and(|v| matches!(v.as_str(), "1" | "true" | "TRUE"))
+}

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -14,6 +14,7 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeServer, ServerOptions};
 use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
+use windows_sys::Win32::System::Pipes::GetNamedPipeClientProcessId;
 
 const DEFAULT_PIPE_PATH: &str = r"\\.\pipe\datadog-procmgrd";
 const DEFAULT_PIPE_INSTANCES: usize = 4;
@@ -43,13 +44,26 @@ pub fn cleanup(_path: &Path) {}
 // NamedPipeIo — wrapper for tonic's `Connected` trait
 // ---------------------------------------------------------------------------
 
+/// Peer metadata attached to each gRPC request served over a named pipe.
+#[derive(Clone, Copy, Debug)]
+pub struct PipeConnectInfo {
+    pub client_pid: u32,
+}
+
 /// Newtype around [`NamedPipeServer`] that implements
 /// [`tonic::transport::server::Connected`] so tonic can serve over it.
-struct NamedPipeIo(NamedPipeServer);
+struct NamedPipeIo {
+    server: NamedPipeServer,
+    client_pid: u32,
+}
 
 impl tonic::transport::server::Connected for NamedPipeIo {
-    type ConnectInfo = ();
-    fn connect_info(&self) -> Self::ConnectInfo {}
+    type ConnectInfo = PipeConnectInfo;
+    fn connect_info(&self) -> Self::ConnectInfo {
+        PipeConnectInfo {
+            client_pid: self.client_pid,
+        }
+    }
 }
 
 impl AsyncRead for NamedPipeIo {
@@ -58,7 +72,7 @@ impl AsyncRead for NamedPipeIo {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.0).poll_read(cx, buf)
+        Pin::new(&mut self.server).poll_read(cx, buf)
     }
 }
 
@@ -68,16 +82,31 @@ impl AsyncWrite for NamedPipeIo {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.0).poll_write(cx, buf)
+        Pin::new(&mut self.server).poll_write(cx, buf)
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.0).poll_flush(cx)
+        Pin::new(&mut self.server).poll_flush(cx)
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.0).poll_shutdown(cx)
+        Pin::new(&mut self.server).poll_shutdown(cx)
     }
+}
+
+fn named_pipe_client_pid(server: &NamedPipeServer) -> u32 {
+    use std::os::windows::io::AsRawHandle;
+    let mut pid = 0u32;
+    let handle = server.as_raw_handle();
+    let ok = unsafe { GetNamedPipeClientProcessId(handle as _, &mut pid) };
+    if ok == 0 {
+        log::warn!(
+            "GetNamedPipeClientProcessId failed: {}",
+            std::io::Error::last_os_error()
+        );
+        return 0;
+    }
+    pid
 }
 
 // ---------------------------------------------------------------------------
@@ -152,11 +181,19 @@ async fn accept_loop(
         }
 
         let connected = server;
+        let client_pid = named_pipe_client_pid(&connected);
         server = ServerOptions::new()
             .create(&pipe_name)
             .context("failed to create next named pipe instance")?;
 
-        if tx.send(Ok(NamedPipeIo(connected))).await.is_err() {
+        if tx
+            .send(Ok(NamedPipeIo {
+                server: connected,
+                client_pid,
+            }))
+            .await
+            .is_err()
+        {
             break;
         }
     }

--- a/pkg/procmgr/rust/tests/e2e.rs
+++ b/pkg/procmgr/rust/tests/e2e.rs
@@ -2061,7 +2061,7 @@ fn test_cli_run_privileged_denied_when_disabled() {
 
 #[cfg(windows)]
 #[test]
-fn test_cli_run_privileged_executes_as_system() {
+fn test_cli_run_privileged_executes_catalog_command() {
     let env = TestEnv::new()
         .with_daemon_env("DD_PM_PRIVILEGED_COMMANDS_ENABLED", "1")
         .with_daemon_env("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI", "1")
@@ -2075,14 +2075,16 @@ fn test_cli_run_privileged_executes_as_system() {
         "--args",
         "/C",
         "--args",
-        "whoami",
+        "echo",
+        "--args",
+        "procmgr-privileged-ok",
     ]);
     out.assert_success();
     let json = out.stdout_json();
     assert_eq!(json["exit_code"], 0, "stdout: {}", out.stdout);
-    let whoami = json["stdout"].as_str().unwrap_or("").to_ascii_lowercase();
+    let stdout = json["stdout"].as_str().unwrap_or("");
     assert!(
-        whoami.contains("system"),
-        "expected privileged child to run as SYSTEM, got stdout={whoami:?}"
+        stdout.contains("procmgr-privileged-ok"),
+        "expected catalog echo output, got stdout={stdout:?}"
     );
 }

--- a/pkg/procmgr/rust/tests/e2e.rs
+++ b/pkg/procmgr/rust/tests/e2e.rs
@@ -1954,7 +1954,7 @@ fn test_ddot_template_starts_with_env_and_optional_envfile() {
     std::fs::write(config_dir.join("datadog-agent-ddot.yaml"), &yaml).unwrap();
 
     let sock = dir.path().join("daemon.sock");
-    let mut daemon = helpers::DaemonHandle::start(&config_dir, &sock);
+    let mut daemon = helpers::DaemonHandle::start(&config_dir, &sock, &[]);
     assert!(
         daemon.wait_for_log_default(
             "[datadog-agent-ddot] optional environment file not found, skipping"
@@ -1999,7 +1999,7 @@ fn test_ddot_template_skipped_when_binary_missing() {
     std::fs::write(config_dir.join("datadog-agent-ddot.yaml"), &yaml).unwrap();
 
     let sock = dir.path().join("daemon.sock");
-    let mut daemon = helpers::DaemonHandle::start(&config_dir, &sock);
+    let mut daemon = helpers::DaemonHandle::start(&config_dir, &sock, &[]);
     assert!(
         daemon.wait_for_log_default("[datadog-agent-ddot] condition_path_exists not met"),
         "daemon should skip ddot when otel-agent binary is missing"
@@ -2012,4 +2012,77 @@ fn test_ddot_template_skipped_when_binary_missing() {
 
     let status = daemon.stop();
     assert!(status.success());
+}
+
+// ---------------------------------------------------------------------------
+// run-privileged
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn test_cli_run_privileged_unimplemented_on_unix() {
+    let env = TestEnv::new().start();
+
+    env.cli(&[
+        "run-privileged",
+        "--command",
+        "cmd.exe",
+        "--args",
+        "/C",
+        "--args",
+        "whoami",
+    ])
+    .assert_failure()
+    .assert_stderr_contains("not implemented");
+}
+
+#[cfg(windows)]
+#[test]
+fn test_cli_run_privileged_denied_when_disabled() {
+    let env = TestEnv::new()
+        .with_daemon_env("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI", "1")
+        .start();
+
+    env.cli(&[
+        "run-privileged",
+        "--command",
+        "cmd.exe",
+        "--args",
+        "/C",
+        "--args",
+        "whoami",
+    ])
+    .assert_failure()
+    .assert_stderr_contains("PermissionDenied");
+}
+
+#[cfg(windows)]
+#[test]
+fn test_cli_run_privileged_executes_as_system() {
+    let env = TestEnv::new()
+        .with_daemon_env("DD_PM_PRIVILEGED_COMMANDS_ENABLED", "1")
+        .with_daemon_env("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI", "1")
+        .start();
+
+    let out = env.cli(&[
+        "run-privileged",
+        "--json",
+        "--command",
+        "cmd.exe",
+        "--args",
+        "/C",
+        "--args",
+        "whoami",
+    ]);
+    out.assert_success();
+    let json = out.stdout_json();
+    assert_eq!(json["exit_code"], 0, "stdout: {}", out.stdout);
+    let whoami = json["stdout"]
+        .as_str()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    assert!(
+        whoami.contains("system"),
+        "expected privileged child to run as SYSTEM, got stdout={whoami:?}"
+    );
 }

--- a/pkg/procmgr/rust/tests/e2e.rs
+++ b/pkg/procmgr/rust/tests/e2e.rs
@@ -2021,7 +2021,10 @@ fn test_ddot_template_skipped_when_binary_missing() {
 #[cfg(unix)]
 #[test]
 fn test_cli_run_privileged_unimplemented_on_unix() {
-    let env = TestEnv::new().start();
+    let env = TestEnv::new()
+        .with_daemon_env("DD_PM_PRIVILEGED_COMMANDS_ENABLED", "1")
+        .with_daemon_env("DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI", "1")
+        .start();
 
     env.cli(&[
         "run-privileged",
@@ -2077,10 +2080,7 @@ fn test_cli_run_privileged_executes_as_system() {
     out.assert_success();
     let json = out.stdout_json();
     assert_eq!(json["exit_code"], 0, "stdout: {}", out.stdout);
-    let whoami = json["stdout"]
-        .as_str()
-        .unwrap_or("")
-        .to_ascii_lowercase();
+    let whoami = json["stdout"].as_str().unwrap_or("").to_ascii_lowercase();
     assert!(
         whoami.contains("system"),
         "expected privileged child to run as SYSTEM, got stdout={whoami:?}"

--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -459,8 +459,7 @@ impl TestEnv {
 
     /// Set an extra environment variable on the daemon process before [`Self::start`].
     pub fn with_daemon_env(mut self, key: &str, value: &str) -> Self {
-        self.daemon_env
-            .push((key.to_string(), value.to_string()));
+        self.daemon_env.push((key.to_string(), value.to_string()));
         self
     }
 

--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -30,7 +30,7 @@ pub struct DaemonHandle {
 impl DaemonHandle {
     /// Start the daemon with the given config directory and socket path.
     /// Sets `DD_PM_CONFIG_DIR` and `DD_PM_SOCKET_PATH` environment variables.
-    pub fn start(config_dir: &Path, socket_path: &Path) -> Self {
+    pub fn start(config_dir: &Path, socket_path: &Path, extra_env: &[(&str, &str)]) -> Self {
         let bin = env!("CARGO_BIN_EXE_dd-procmgrd");
 
         let mut cmd = Command::new(bin);
@@ -38,6 +38,9 @@ impl DaemonHandle {
             .env("DD_PM_SOCKET_PATH", socket_path)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        for (key, value) in extra_env {
+            cmd.env(key, value);
+        }
         #[cfg(windows)]
         {
             use std::os::windows::process::CommandExt as _;
@@ -435,6 +438,7 @@ pub struct TestEnv {
     _dir: tempfile::TempDir,
     config_dir: PathBuf,
     socket_path: PathBuf,
+    daemon_env: Vec<(String, String)>,
     daemon: Option<DaemonHandle>,
 }
 
@@ -443,13 +447,21 @@ impl TestEnv {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let config_dir = dir.path().join("processes.d");
         std::fs::create_dir_all(&config_dir).expect("failed to create config dir");
-        let socket_path = dir.path().join("daemon.sock");
+        let socket_path = ipc_socket_path(&dir);
         Self {
             _dir: dir,
             config_dir,
             socket_path,
+            daemon_env: Vec::new(),
             daemon: None,
         }
+    }
+
+    /// Set an extra environment variable on the daemon process before [`Self::start`].
+    pub fn with_daemon_env(mut self, key: &str, value: &str) -> Self {
+        self.daemon_env
+            .push((key.to_string(), value.to_string()));
+        self
     }
 
     /// Write a process YAML config into the config dir before starting.
@@ -465,7 +477,12 @@ impl TestEnv {
 
     /// Start the daemon and wait until gRPC is ready.
     pub fn start(mut self) -> Self {
-        let daemon = DaemonHandle::start(&self.config_dir, &self.socket_path);
+        let extra_env: Vec<(&str, &str)> = self
+            .daemon_env
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        let daemon = DaemonHandle::start(&self.config_dir, &self.socket_path, &extra_env);
         assert!(
             daemon.wait_for_log_default("gRPC server listening on"),
             "daemon gRPC server should be ready"
@@ -522,6 +539,22 @@ impl Drop for TestEnv {
 // ---------------------------------------------------------------------------
 // Free functions
 // ---------------------------------------------------------------------------
+
+fn ipc_socket_path(dir: &tempfile::TempDir) -> PathBuf {
+    #[cfg(unix)]
+    {
+        dir.path().join("daemon.sock")
+    }
+    #[cfg(windows)]
+    {
+        let suffix = dir
+            .path()
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("test");
+        PathBuf::from(format!(r"\\.\pipe\dd-procmgr-e2e-{suffix}"))
+    }
+}
 
 fn spawn_log_reader<R: std::io::Read + Send + 'static>(
     stream: R,

--- a/pkg/proto/datadog/procmgr/process_manager.proto
+++ b/pkg/proto/datadog/procmgr/process_manager.proto
@@ -18,6 +18,8 @@ service ProcessManager {
   rpc Stop (StopRequest) returns (StopResponse);
   rpc ReloadConfig (ReloadConfigRequest) returns (ReloadConfigResponse);
   rpc GetConfig (GetConfigRequest) returns (GetConfigResponse);
+  rpc RunPrivilegedCommand (RunPrivilegedCommandRequest)
+      returns (RunPrivilegedCommandResponse);
 }
 
 enum ProcessState {
@@ -152,4 +154,17 @@ message GetConfigResponse {
   string location = 2;
   uint32 loaded_processes = 3;
   uint32 runtime_processes = 4;
+}
+
+message RunPrivilegedCommandRequest {
+  string command = 1;
+  repeated string args = 2;
+  map<string, string> env = 3;
+  // reserve for later: task_id, approval_token
+}
+
+message RunPrivilegedCommandResponse {
+  int32 exit_code = 1;
+  string stdout = 2;
+  string stderr = 3;
 }

--- a/pkg/proto/pbgo/procmgr/process_manager.pb.go
+++ b/pkg/proto/pbgo/procmgr/process_manager.pb.go
@@ -1317,6 +1317,126 @@ func (x *GetConfigResponse) GetRuntimeProcesses() uint32 {
 	return 0
 }
 
+type RunPrivilegedCommandRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Command       string                 `protobuf:"bytes,1,opt,name=command,proto3" json:"command,omitempty"`
+	Args          []string               `protobuf:"bytes,2,rep,name=args,proto3" json:"args,omitempty"`
+	Env           map[string]string      `protobuf:"bytes,3,rep,name=env,proto3" json:"env,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // reserve for later: task_id, approval_token
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunPrivilegedCommandRequest) Reset() {
+	*x = RunPrivilegedCommandRequest{}
+	mi := &file_datadog_procmgr_process_manager_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunPrivilegedCommandRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunPrivilegedCommandRequest) ProtoMessage() {}
+
+func (x *RunPrivilegedCommandRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_procmgr_process_manager_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunPrivilegedCommandRequest.ProtoReflect.Descriptor instead.
+func (*RunPrivilegedCommandRequest) Descriptor() ([]byte, []int) {
+	return file_datadog_procmgr_process_manager_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *RunPrivilegedCommandRequest) GetCommand() string {
+	if x != nil {
+		return x.Command
+	}
+	return ""
+}
+
+func (x *RunPrivilegedCommandRequest) GetArgs() []string {
+	if x != nil {
+		return x.Args
+	}
+	return nil
+}
+
+func (x *RunPrivilegedCommandRequest) GetEnv() map[string]string {
+	if x != nil {
+		return x.Env
+	}
+	return nil
+}
+
+type RunPrivilegedCommandResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ExitCode      int32                  `protobuf:"varint,1,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	Stdout        string                 `protobuf:"bytes,2,opt,name=stdout,proto3" json:"stdout,omitempty"`
+	Stderr        string                 `protobuf:"bytes,3,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunPrivilegedCommandResponse) Reset() {
+	*x = RunPrivilegedCommandResponse{}
+	mi := &file_datadog_procmgr_process_manager_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunPrivilegedCommandResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunPrivilegedCommandResponse) ProtoMessage() {}
+
+func (x *RunPrivilegedCommandResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_procmgr_process_manager_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunPrivilegedCommandResponse.ProtoReflect.Descriptor instead.
+func (*RunPrivilegedCommandResponse) Descriptor() ([]byte, []int) {
+	return file_datadog_procmgr_process_manager_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *RunPrivilegedCommandResponse) GetExitCode() int32 {
+	if x != nil {
+		return x.ExitCode
+	}
+	return 0
+}
+
+func (x *RunPrivilegedCommandResponse) GetStdout() string {
+	if x != nil {
+		return x.Stdout
+	}
+	return ""
+}
+
+func (x *RunPrivilegedCommandResponse) GetStderr() string {
+	if x != nil {
+		return x.Stderr
+	}
+	return ""
+}
+
 var File_datadog_procmgr_process_manager_proto protoreflect.FileDescriptor
 
 const file_datadog_procmgr_process_manager_proto_rawDesc = "" +
@@ -1434,7 +1554,18 @@ const file_datadog_procmgr_process_manager_proto_rawDesc = "" +
 	"\x06source\x18\x01 \x01(\tR\x06source\x12\x1a\n" +
 	"\blocation\x18\x02 \x01(\tR\blocation\x12)\n" +
 	"\x10loaded_processes\x18\x03 \x01(\rR\x0floadedProcesses\x12+\n" +
-	"\x11runtime_processes\x18\x04 \x01(\rR\x10runtimeProcesses*\x83\x01\n" +
+	"\x11runtime_processes\x18\x04 \x01(\rR\x10runtimeProcesses\"\xcc\x01\n" +
+	"\x1bRunPrivilegedCommandRequest\x12\x18\n" +
+	"\acommand\x18\x01 \x01(\tR\acommand\x12\x12\n" +
+	"\x04args\x18\x02 \x03(\tR\x04args\x12G\n" +
+	"\x03env\x18\x03 \x03(\v25.datadog.procmgr.RunPrivilegedCommandRequest.EnvEntryR\x03env\x1a6\n" +
+	"\bEnvEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"k\n" +
+	"\x1cRunPrivilegedCommandResponse\x12\x1b\n" +
+	"\texit_code\x18\x01 \x01(\x05R\bexitCode\x12\x16\n" +
+	"\x06stdout\x18\x02 \x01(\tR\x06stdout\x12\x16\n" +
+	"\x06stderr\x18\x03 \x01(\tR\x06stderr*\x83\x01\n" +
 	"\fProcessState\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
 	"\aCREATED\x10\x01\x12\f\n" +
@@ -1446,7 +1577,7 @@ const file_datadog_procmgr_process_manager_proto_rawDesc = "" +
 	"\n" +
 	"\x06EXITED\x10\a\x12\n" +
 	"\n" +
-	"\x06FAILED\x10\b2\x83\x05\n" +
+	"\x06FAILED\x10\b2\xf8\x05\n" +
 	"\x0eProcessManager\x12C\n" +
 	"\x04List\x12\x1c.datadog.procmgr.ListRequest\x1a\x1d.datadog.procmgr.ListResponse\x12O\n" +
 	"\bDescribe\x12 .datadog.procmgr.DescribeRequest\x1a!.datadog.procmgr.DescribeResponse\x12R\n" +
@@ -1455,7 +1586,8 @@ const file_datadog_procmgr_process_manager_proto_rawDesc = "" +
 	"\x05Start\x12\x1d.datadog.procmgr.StartRequest\x1a\x1e.datadog.procmgr.StartResponse\x12C\n" +
 	"\x04Stop\x12\x1c.datadog.procmgr.StopRequest\x1a\x1d.datadog.procmgr.StopResponse\x12[\n" +
 	"\fReloadConfig\x12$.datadog.procmgr.ReloadConfigRequest\x1a%.datadog.procmgr.ReloadConfigResponse\x12R\n" +
-	"\tGetConfig\x12!.datadog.procmgr.GetConfigRequest\x1a\".datadog.procmgr.GetConfigResponseB9Z7github.com/DataDog/datadog-agent/pkg/proto/pbgo/procmgrb\x06proto3"
+	"\tGetConfig\x12!.datadog.procmgr.GetConfigRequest\x1a\".datadog.procmgr.GetConfigResponse\x12s\n" +
+	"\x14RunPrivilegedCommand\x12,.datadog.procmgr.RunPrivilegedCommandRequest\x1a-.datadog.procmgr.RunPrivilegedCommandResponseB9Z7github.com/DataDog/datadog-agent/pkg/proto/pbgo/procmgrb\x06proto3"
 
 var (
 	file_datadog_procmgr_process_manager_proto_rawDescOnce sync.Once
@@ -1470,60 +1602,66 @@ func file_datadog_procmgr_process_manager_proto_rawDescGZIP() []byte {
 }
 
 var file_datadog_procmgr_process_manager_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_datadog_procmgr_process_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_datadog_procmgr_process_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_datadog_procmgr_process_manager_proto_goTypes = []any{
-	(ProcessState)(0),            // 0: datadog.procmgr.ProcessState
-	(*ListRequest)(nil),          // 1: datadog.procmgr.ListRequest
-	(*Process)(nil),              // 2: datadog.procmgr.Process
-	(*ListResponse)(nil),         // 3: datadog.procmgr.ListResponse
-	(*DescribeRequest)(nil),      // 4: datadog.procmgr.DescribeRequest
-	(*ProcessDetail)(nil),        // 5: datadog.procmgr.ProcessDetail
-	(*DescribeResponse)(nil),     // 6: datadog.procmgr.DescribeResponse
-	(*CreateRequest)(nil),        // 7: datadog.procmgr.CreateRequest
-	(*CreateResponse)(nil),       // 8: datadog.procmgr.CreateResponse
-	(*StartRequest)(nil),         // 9: datadog.procmgr.StartRequest
-	(*StartResponse)(nil),        // 10: datadog.procmgr.StartResponse
-	(*StopRequest)(nil),          // 11: datadog.procmgr.StopRequest
-	(*StopResponse)(nil),         // 12: datadog.procmgr.StopResponse
-	(*ReloadConfigRequest)(nil),  // 13: datadog.procmgr.ReloadConfigRequest
-	(*ReloadConfigResponse)(nil), // 14: datadog.procmgr.ReloadConfigResponse
-	(*GetStatusRequest)(nil),     // 15: datadog.procmgr.GetStatusRequest
-	(*GetStatusResponse)(nil),    // 16: datadog.procmgr.GetStatusResponse
-	(*GetConfigRequest)(nil),     // 17: datadog.procmgr.GetConfigRequest
-	(*GetConfigResponse)(nil),    // 18: datadog.procmgr.GetConfigResponse
-	nil,                          // 19: datadog.procmgr.ProcessDetail.EnvEntry
-	nil,                          // 20: datadog.procmgr.CreateRequest.EnvEntry
+	(ProcessState)(0),                    // 0: datadog.procmgr.ProcessState
+	(*ListRequest)(nil),                  // 1: datadog.procmgr.ListRequest
+	(*Process)(nil),                      // 2: datadog.procmgr.Process
+	(*ListResponse)(nil),                 // 3: datadog.procmgr.ListResponse
+	(*DescribeRequest)(nil),              // 4: datadog.procmgr.DescribeRequest
+	(*ProcessDetail)(nil),                // 5: datadog.procmgr.ProcessDetail
+	(*DescribeResponse)(nil),             // 6: datadog.procmgr.DescribeResponse
+	(*CreateRequest)(nil),                // 7: datadog.procmgr.CreateRequest
+	(*CreateResponse)(nil),               // 8: datadog.procmgr.CreateResponse
+	(*StartRequest)(nil),                 // 9: datadog.procmgr.StartRequest
+	(*StartResponse)(nil),                // 10: datadog.procmgr.StartResponse
+	(*StopRequest)(nil),                  // 11: datadog.procmgr.StopRequest
+	(*StopResponse)(nil),                 // 12: datadog.procmgr.StopResponse
+	(*ReloadConfigRequest)(nil),          // 13: datadog.procmgr.ReloadConfigRequest
+	(*ReloadConfigResponse)(nil),         // 14: datadog.procmgr.ReloadConfigResponse
+	(*GetStatusRequest)(nil),             // 15: datadog.procmgr.GetStatusRequest
+	(*GetStatusResponse)(nil),            // 16: datadog.procmgr.GetStatusResponse
+	(*GetConfigRequest)(nil),             // 17: datadog.procmgr.GetConfigRequest
+	(*GetConfigResponse)(nil),            // 18: datadog.procmgr.GetConfigResponse
+	(*RunPrivilegedCommandRequest)(nil),  // 19: datadog.procmgr.RunPrivilegedCommandRequest
+	(*RunPrivilegedCommandResponse)(nil), // 20: datadog.procmgr.RunPrivilegedCommandResponse
+	nil,                                  // 21: datadog.procmgr.ProcessDetail.EnvEntry
+	nil,                                  // 22: datadog.procmgr.CreateRequest.EnvEntry
+	nil,                                  // 23: datadog.procmgr.RunPrivilegedCommandRequest.EnvEntry
 }
 var file_datadog_procmgr_process_manager_proto_depIdxs = []int32{
 	0,  // 0: datadog.procmgr.Process.state:type_name -> datadog.procmgr.ProcessState
 	2,  // 1: datadog.procmgr.ListResponse.processes:type_name -> datadog.procmgr.Process
 	0,  // 2: datadog.procmgr.ProcessDetail.state:type_name -> datadog.procmgr.ProcessState
-	19, // 3: datadog.procmgr.ProcessDetail.env:type_name -> datadog.procmgr.ProcessDetail.EnvEntry
+	21, // 3: datadog.procmgr.ProcessDetail.env:type_name -> datadog.procmgr.ProcessDetail.EnvEntry
 	5,  // 4: datadog.procmgr.DescribeResponse.detail:type_name -> datadog.procmgr.ProcessDetail
-	20, // 5: datadog.procmgr.CreateRequest.env:type_name -> datadog.procmgr.CreateRequest.EnvEntry
+	22, // 5: datadog.procmgr.CreateRequest.env:type_name -> datadog.procmgr.CreateRequest.EnvEntry
 	0,  // 6: datadog.procmgr.StartResponse.state:type_name -> datadog.procmgr.ProcessState
 	0,  // 7: datadog.procmgr.StopResponse.state:type_name -> datadog.procmgr.ProcessState
-	1,  // 8: datadog.procmgr.ProcessManager.List:input_type -> datadog.procmgr.ListRequest
-	4,  // 9: datadog.procmgr.ProcessManager.Describe:input_type -> datadog.procmgr.DescribeRequest
-	15, // 10: datadog.procmgr.ProcessManager.GetStatus:input_type -> datadog.procmgr.GetStatusRequest
-	7,  // 11: datadog.procmgr.ProcessManager.Create:input_type -> datadog.procmgr.CreateRequest
-	9,  // 12: datadog.procmgr.ProcessManager.Start:input_type -> datadog.procmgr.StartRequest
-	11, // 13: datadog.procmgr.ProcessManager.Stop:input_type -> datadog.procmgr.StopRequest
-	13, // 14: datadog.procmgr.ProcessManager.ReloadConfig:input_type -> datadog.procmgr.ReloadConfigRequest
-	17, // 15: datadog.procmgr.ProcessManager.GetConfig:input_type -> datadog.procmgr.GetConfigRequest
-	3,  // 16: datadog.procmgr.ProcessManager.List:output_type -> datadog.procmgr.ListResponse
-	6,  // 17: datadog.procmgr.ProcessManager.Describe:output_type -> datadog.procmgr.DescribeResponse
-	16, // 18: datadog.procmgr.ProcessManager.GetStatus:output_type -> datadog.procmgr.GetStatusResponse
-	8,  // 19: datadog.procmgr.ProcessManager.Create:output_type -> datadog.procmgr.CreateResponse
-	10, // 20: datadog.procmgr.ProcessManager.Start:output_type -> datadog.procmgr.StartResponse
-	12, // 21: datadog.procmgr.ProcessManager.Stop:output_type -> datadog.procmgr.StopResponse
-	14, // 22: datadog.procmgr.ProcessManager.ReloadConfig:output_type -> datadog.procmgr.ReloadConfigResponse
-	18, // 23: datadog.procmgr.ProcessManager.GetConfig:output_type -> datadog.procmgr.GetConfigResponse
-	16, // [16:24] is the sub-list for method output_type
-	8,  // [8:16] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	23, // 8: datadog.procmgr.RunPrivilegedCommandRequest.env:type_name -> datadog.procmgr.RunPrivilegedCommandRequest.EnvEntry
+	1,  // 9: datadog.procmgr.ProcessManager.List:input_type -> datadog.procmgr.ListRequest
+	4,  // 10: datadog.procmgr.ProcessManager.Describe:input_type -> datadog.procmgr.DescribeRequest
+	15, // 11: datadog.procmgr.ProcessManager.GetStatus:input_type -> datadog.procmgr.GetStatusRequest
+	7,  // 12: datadog.procmgr.ProcessManager.Create:input_type -> datadog.procmgr.CreateRequest
+	9,  // 13: datadog.procmgr.ProcessManager.Start:input_type -> datadog.procmgr.StartRequest
+	11, // 14: datadog.procmgr.ProcessManager.Stop:input_type -> datadog.procmgr.StopRequest
+	13, // 15: datadog.procmgr.ProcessManager.ReloadConfig:input_type -> datadog.procmgr.ReloadConfigRequest
+	17, // 16: datadog.procmgr.ProcessManager.GetConfig:input_type -> datadog.procmgr.GetConfigRequest
+	19, // 17: datadog.procmgr.ProcessManager.RunPrivilegedCommand:input_type -> datadog.procmgr.RunPrivilegedCommandRequest
+	3,  // 18: datadog.procmgr.ProcessManager.List:output_type -> datadog.procmgr.ListResponse
+	6,  // 19: datadog.procmgr.ProcessManager.Describe:output_type -> datadog.procmgr.DescribeResponse
+	16, // 20: datadog.procmgr.ProcessManager.GetStatus:output_type -> datadog.procmgr.GetStatusResponse
+	8,  // 21: datadog.procmgr.ProcessManager.Create:output_type -> datadog.procmgr.CreateResponse
+	10, // 22: datadog.procmgr.ProcessManager.Start:output_type -> datadog.procmgr.StartResponse
+	12, // 23: datadog.procmgr.ProcessManager.Stop:output_type -> datadog.procmgr.StopResponse
+	14, // 24: datadog.procmgr.ProcessManager.ReloadConfig:output_type -> datadog.procmgr.ReloadConfigResponse
+	18, // 25: datadog.procmgr.ProcessManager.GetConfig:output_type -> datadog.procmgr.GetConfigResponse
+	20, // 26: datadog.procmgr.ProcessManager.RunPrivilegedCommand:output_type -> datadog.procmgr.RunPrivilegedCommandResponse
+	18, // [18:27] is the sub-list for method output_type
+	9,  // [9:18] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_datadog_procmgr_process_manager_proto_init() }
@@ -1540,7 +1678,7 @@ func file_datadog_procmgr_process_manager_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_procmgr_process_manager_proto_rawDesc), len(file_datadog_procmgr_process_manager_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   20,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/proto/pbgo/procmgr/process_manager_grpc.pb.go
+++ b/pkg/proto/pbgo/procmgr/process_manager_grpc.pb.go
@@ -24,14 +24,15 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ProcessManager_List_FullMethodName         = "/datadog.procmgr.ProcessManager/List"
-	ProcessManager_Describe_FullMethodName     = "/datadog.procmgr.ProcessManager/Describe"
-	ProcessManager_GetStatus_FullMethodName    = "/datadog.procmgr.ProcessManager/GetStatus"
-	ProcessManager_Create_FullMethodName       = "/datadog.procmgr.ProcessManager/Create"
-	ProcessManager_Start_FullMethodName        = "/datadog.procmgr.ProcessManager/Start"
-	ProcessManager_Stop_FullMethodName         = "/datadog.procmgr.ProcessManager/Stop"
-	ProcessManager_ReloadConfig_FullMethodName = "/datadog.procmgr.ProcessManager/ReloadConfig"
-	ProcessManager_GetConfig_FullMethodName    = "/datadog.procmgr.ProcessManager/GetConfig"
+	ProcessManager_List_FullMethodName                 = "/datadog.procmgr.ProcessManager/List"
+	ProcessManager_Describe_FullMethodName             = "/datadog.procmgr.ProcessManager/Describe"
+	ProcessManager_GetStatus_FullMethodName            = "/datadog.procmgr.ProcessManager/GetStatus"
+	ProcessManager_Create_FullMethodName               = "/datadog.procmgr.ProcessManager/Create"
+	ProcessManager_Start_FullMethodName                = "/datadog.procmgr.ProcessManager/Start"
+	ProcessManager_Stop_FullMethodName                 = "/datadog.procmgr.ProcessManager/Stop"
+	ProcessManager_ReloadConfig_FullMethodName         = "/datadog.procmgr.ProcessManager/ReloadConfig"
+	ProcessManager_GetConfig_FullMethodName            = "/datadog.procmgr.ProcessManager/GetConfig"
+	ProcessManager_RunPrivilegedCommand_FullMethodName = "/datadog.procmgr.ProcessManager/RunPrivilegedCommand"
 )
 
 // ProcessManagerClient is the client API for ProcessManager service.
@@ -46,6 +47,7 @@ type ProcessManagerClient interface {
 	Stop(ctx context.Context, in *StopRequest, opts ...grpc.CallOption) (*StopResponse, error)
 	ReloadConfig(ctx context.Context, in *ReloadConfigRequest, opts ...grpc.CallOption) (*ReloadConfigResponse, error)
 	GetConfig(ctx context.Context, in *GetConfigRequest, opts ...grpc.CallOption) (*GetConfigResponse, error)
+	RunPrivilegedCommand(ctx context.Context, in *RunPrivilegedCommandRequest, opts ...grpc.CallOption) (*RunPrivilegedCommandResponse, error)
 }
 
 type processManagerClient struct {
@@ -136,6 +138,16 @@ func (c *processManagerClient) GetConfig(ctx context.Context, in *GetConfigReque
 	return out, nil
 }
 
+func (c *processManagerClient) RunPrivilegedCommand(ctx context.Context, in *RunPrivilegedCommandRequest, opts ...grpc.CallOption) (*RunPrivilegedCommandResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RunPrivilegedCommandResponse)
+	err := c.cc.Invoke(ctx, ProcessManager_RunPrivilegedCommand_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ProcessManagerServer is the server API for ProcessManager service.
 // All implementations must embed UnimplementedProcessManagerServer
 // for forward compatibility.
@@ -148,6 +160,7 @@ type ProcessManagerServer interface {
 	Stop(context.Context, *StopRequest) (*StopResponse, error)
 	ReloadConfig(context.Context, *ReloadConfigRequest) (*ReloadConfigResponse, error)
 	GetConfig(context.Context, *GetConfigRequest) (*GetConfigResponse, error)
+	RunPrivilegedCommand(context.Context, *RunPrivilegedCommandRequest) (*RunPrivilegedCommandResponse, error)
 	mustEmbedUnimplementedProcessManagerServer()
 }
 
@@ -181,6 +194,9 @@ func (UnimplementedProcessManagerServer) ReloadConfig(context.Context, *ReloadCo
 }
 func (UnimplementedProcessManagerServer) GetConfig(context.Context, *GetConfigRequest) (*GetConfigResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetConfig not implemented")
+}
+func (UnimplementedProcessManagerServer) RunPrivilegedCommand(context.Context, *RunPrivilegedCommandRequest) (*RunPrivilegedCommandResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RunPrivilegedCommand not implemented")
 }
 func (UnimplementedProcessManagerServer) mustEmbedUnimplementedProcessManagerServer() {}
 func (UnimplementedProcessManagerServer) testEmbeddedByValue()                        {}
@@ -347,6 +363,24 @@ func _ProcessManager_GetConfig_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ProcessManager_RunPrivilegedCommand_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RunPrivilegedCommandRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ProcessManagerServer).RunPrivilegedCommand(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ProcessManager_RunPrivilegedCommand_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ProcessManagerServer).RunPrivilegedCommand(ctx, req.(*RunPrivilegedCommandRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ProcessManager_ServiceDesc is the grpc.ServiceDesc for ProcessManager service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -385,6 +419,10 @@ var ProcessManager_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetConfig",
 			Handler:    _ProcessManager_GetConfig_Handler,
+		},
+		{
+			MethodName: "RunPrivilegedCommand",
+			Handler:    _ProcessManager_RunPrivilegedCommand_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
### What does this PR do?

Adds a new `RunPrivilegedCommand` RPC to `dd-procmgrd` so trusted callers can run **allowlisted** commands with elevated privileges on Windows and get the output back in one shot.

This is the Windows foundation only. Linux still returns “not implemented,” and PAR does not call this yet.

Also includes a `dd-procmgr run-privileged` CLI for local testing.

### Motivation

PAR runs unprivileged and can’t fix things owned by SYSTEM. Procmgr already knows how to spawn privileged children; this adds a safe, one-off path for remediation with output capture, instead of bolting elevation into PAR itself.

### Describe how you validated your changes

- Rust unit tests (catalog, auth, handler, CLI)
- E2E: Unix confirms “not implemented”; Windows checks denial when disabled and `whoami` running as SYSTEM when enabled

### Additional Notes

- **Off by default** until later config work lands
- Temporary env toggles for dev/testing:
  - `DD_PM_PRIVILEGED_COMMANDS_ENABLED=1`
  - `DD_PM_PRIVILEGED_COMMANDS_ALLOW_CLI=1` (lets `dd-procmgr` call it locally; production caller is still PAR)
- Follow-ups: PAR wiring, proper config/audit, Linux support