### PR TITLE
fix(e2e): keep local flare archive after successful upload in diagnose flow

### DIFF
--- a/test/e2e-framework/testing/environments/dockerhost.go
+++ b/test/e2e-framework/testing/environments/dockerhost.go
@@ -211,7 +211,9 @@ func (e *DockerHost) generateAndDownloadAgentFlare(outputDir string) (string, er
 	}
 	// generate a flare, it will fallback to local flare generation if the running agent cannot be reached
 	// discard error, flare command might return error if there is no intake, but the archive is still generated
-	flareCommandOutput, err := e.Agent.Client.FlareWithError(agentclient.WithArgs([]string{"--email", "e2e-tests@datadog-agent", "--send"}))
+	// --keep-archive is required because the archive is deleted from disk after a successful upload, which would
+	// otherwise race with the download of the archive below
+	flareCommandOutput, err := e.Agent.Client.FlareWithError(agentclient.WithArgs([]string{"--email", "e2e-tests@datadog-agent", "--send", "--keep-archive"}))
 
 	lines := []string{flareCommandOutput}
 	if err != nil {

--- a/test/e2e-framework/testing/environments/host.go
+++ b/test/e2e-framework/testing/environments/host.go
@@ -127,7 +127,9 @@ func generateAndDownloadAgentFlare(agent *components.RemoteHostAgent, host *comp
 	// to redirect stdin to null, on linux adding `</dev/null`
 	// on windows prepending command with `@() |`, pre-piping with an empty array
 	// discard error, flare command might return error if there is no intake, but it the archive is still generated
-	flareCommandOutput, err := agent.Client.FlareWithError(agentclient.WithArgs([]string{"--email", "e2e-tests@datadog-agent", "--send"}))
+	// --keep-archive is required because the archive is deleted from disk after a successful upload, which would
+	// otherwise race with the download of the archive below
+	flareCommandOutput, err := agent.Client.FlareWithError(agentclient.WithArgs([]string{"--email", "e2e-tests@datadog-agent", "--send", "--keep-archive"}))
 
 	lines := []string{flareCommandOutput}
 	if err != nil {

--- a/test/e2e-framework/testing/environments/kubernetes.go
+++ b/test/e2e-framework/testing/environments/kubernetes.go
@@ -181,7 +181,13 @@ func podRejectsExec(pod v1.Pod) bool {
 }
 
 func (e *Kubernetes) generateAndDownloadAgentFlare(agentBinary string, pod v1.Pod, container string, outputDir string) (string, error) {
-	stdout, stderr, err := e.KubernetesCluster.KubernetesClient.PodExec(pod.Namespace, pod.Name, container, []string{agentBinary, "flare", "--email", "e2e-tests@datadog-agent", "--send"})
+	flareArgs := []string{agentBinary, "flare", "--email", "e2e-tests@datadog-agent", "--send"}
+	// --keep-archive is required because the archive is deleted from disk after a successful upload, which would
+	// otherwise race with the download of the archive below. The cluster-agent flare command doesn't support this flag.
+	if agentBinary != "datadog-cluster-agent" {
+		flareArgs = append(flareArgs, "--keep-archive")
+	}
+	stdout, stderr, err := e.KubernetesCluster.KubernetesClient.PodExec(pod.Namespace, pod.Name, container, flareArgs)
 	flareOutput := strings.Join([]string{stdout, stderr}, "\n")
 	if err != nil {
 		flareOutput = fmt.Sprintf("%s\n%s", flareOutput, err.Error())


### PR DESCRIPTION
### What does this PR do?

Adds `--keep-archive` to that flare invocation for the `Host`, `WindowsHost`, `DockerHost`, and `Kubernetes` (agent container only, not cluster-agent) environments.

### Motivation

`comp/core/flare/flare.go`'s `Send()` deletes the local flare archive after a successful upload unless `--keep-archive` is passed. The e2e diagnose worked only when the upload happened to fail. When the flare upload actually succeeds we face `failed to stat flare archive: file does not exist`, see https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1839359374.

The cluster-agent flare command (`pkg/cli/subcommands/dcaflare`) doesn't support `--keep-archive` and doesn't delete its archive on send, so the `Kubernetes` environment only adds the flag for the regular agent binary, not `datadog-cluster-agent`.

### Describe how you validated your changes

`go build ./testing/environments/...` in `test/e2e-framework` succeeds. This is a test-framework-only change with no Agent binary code affected, so no new automated test was added.

### Additional Notes

Ran `codex review` against `main` before opening this PR; it caught that passing `--keep-archive` unconditionally would have broken cluster-agent flare collection during Kubernetes diagnosis, which is now handled by only adding the flag for the regular agent binary.