### PR TITLE
chore(js): update default version from v5 to v6

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -38,7 +38,7 @@ var defaultContainerNames = []string{defaultTestContainer}
 var defaultLibraries = map[string]string{
 	"dotnet": "v3",
 	"java":   "v1",
-	"js":     "v5",
+	"js":     "v6",
 	"php":    "v1",
 	"python": "v4",
 	"ruby":   "v2",
@@ -2702,7 +2702,7 @@ func TestAutoinstrumentation(t *testing.T) {
 			shouldMutate: true,
 			expected: &expected{
 				injectorVersion: defaultInjectorVersion,
-				libraryVersions: defaultLibraries, // Should resolve to v1, v3, v4, v2, v5, v1
+				libraryVersions: defaultLibraries, // Should resolve to v1, v3, v4, v2, v6, v1
 				containerNames:  defaultContainerNames,
 			},
 		},

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -457,7 +457,7 @@ func TestGetPinnedLibraries(t *testing.T) {
 			libVersions: map[string]string{
 				"java":   "v1",
 				"python": "v4",
-				"js":     "v5",
+				"js":     "v6",
 				"dotnet": "v3",
 				"ruby":   "v2",
 				"php":    "v1",
@@ -482,7 +482,7 @@ func TestGetPinnedLibraries(t *testing.T) {
 			libVersions: map[string]string{
 				"java":   "v1",
 				"python": "v4",
-				"js":     "v5",
+				"js":     "v6",
 				"dotnet": "v3",
 				"ruby":   "v2",
 				"c":      "v0",
@@ -541,7 +541,7 @@ func TestGetPinnedLibraries(t *testing.T) {
 			libVersions: map[string]string{
 				"java":   "v1",
 				"python": "v4",
-				"js":     "v5",
+				"js":     "v6",
 				"dotnet": "v3",
 				"ruby":   "v2",
 				"php":    "v1",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -111,7 +111,7 @@ var languageVersions = map[language]string{
 	dotnet: "v3", // https://datadoghq.atlassian.net/browse/APMON-1390
 	python: "v4", // https://datadoghq.atlassian.net/browse/INPLAT-852
 	ruby:   "v2", // https://datadoghq.atlassian.net/browse/APMON-1066
-	js:     "v6", // https://datadoghq.atlassian.net/browse/APMON-1065
+	js:     "v6",
 	php:    "v1", // https://datadoghq.atlassian.net/browse/APMON-1128
 	c:      "v0",
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -111,7 +111,7 @@ var languageVersions = map[language]string{
 	dotnet: "v3", // https://datadoghq.atlassian.net/browse/APMON-1390
 	python: "v4", // https://datadoghq.atlassian.net/browse/INPLAT-852
 	ruby:   "v2", // https://datadoghq.atlassian.net/browse/APMON-1066
-	js:     "v5", // https://datadoghq.atlassian.net/browse/APMON-1065
+	js:     "v6", // https://datadoghq.atlassian.net/browse/APMON-1065
 	php:    "v1", // https://datadoghq.atlassian.net/browse/APMON-1128
 	c:      "v0",
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -664,11 +664,11 @@ func TestGetTargetLibraries(t *testing.T) {
 			},
 			expected: &targetInternal{
 				libVersions: []libInfo{
-						defaultLibInfoWithVersion(js, "v5"),
-					},
+					defaultLibInfoWithVersion(js, "v5"),
 				},
 			},
-			"a pod that matches no targets gets no values": {
+		},
+		"a pod that matches no targets gets no values": {
 			configPath: "testdata/filter_no_default.yaml",
 			in: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -39,7 +39,7 @@ var (
 		"python": "v4",
 		"ruby":   "v2",
 		"dotnet": "v3",
-		"js":     "v5",
+		"js":     "v6",
 		"php":    "v1",
 	}
 
@@ -664,11 +664,11 @@ func TestGetTargetLibraries(t *testing.T) {
 			},
 			expected: &targetInternal{
 				libVersions: []libInfo{
-					defaultLibInfoWithVersion(js, "v5"),
+						defaultLibInfoWithVersion(js, "v5"),
+					},
 				},
 			},
-		},
-		"a pod that matches no targets gets no values": {
+			"a pod that matches no targets gets no values": {
 			configPath: "testdata/filter_no_default.yaml",
 			in: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -798,7 +798,7 @@ func TestGetTargetLibraries(t *testing.T) {
 			expected: &targetInternal{
 				libVersions: []libInfo{
 					defaultLibInfoWithVersion(java, "v1"),
-					defaultLibInfoWithVersion(js, "v5"),
+					defaultLibInfoWithVersion(js, "v6"),
 					defaultLibInfoWithVersion(python, "v4"),
 					defaultLibInfoWithVersion(dotnet, "v3"),
 					defaultLibInfoWithVersion(ruby, "v2"),
@@ -854,7 +854,7 @@ func TestGetTargetLibraries(t *testing.T) {
 			expected: &targetInternal{
 				libVersions: []libInfo{
 					defaultLibInfoWithVersion(java, "v1"),
-					defaultLibInfoWithVersion(js, "v5"),
+					defaultLibInfoWithVersion(js, "v6"),
 					defaultLibInfoWithVersion(python, "v4"),
 					defaultLibInfoWithVersion(dotnet, "v3"),
 					defaultLibInfoWithVersion(ruby, "v2"),

--- a/releasenotes/notes/bump-k8s-js-lib-default-v6-ac1a93f96436e6fa.yaml
+++ b/releasenotes/notes/bump-k8s-js-lib-default-v6-ac1a93f96436e6fa.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    APM: Updates the default JS (Node.js) library used for Kubernetes auto-instrumentation
+    (Cluster Agent admission controller) from major version 5 to major version 6.


### PR DESCRIPTION
### What does this PR do?
This PR bumps the k8 default version for js from v5 to v6. 

### Motivation
Keep default versions up to date with the current version of dd-trace-js.

### Describe how you validated your changes

### Additional Notes
