### PR TITLE
Add procmgr processes.d to RemoveFolder

### DIFF
--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -172,27 +172,10 @@ func preRemoveDatadogAgent(ctx HookContext) (err error) {
 		log.Warnf("failed to remove extensions: %s", err)
 	}
 
-	packagePath := ctx.PackagePath
-	if resolved, err := filepath.EvalSymlinks(ctx.PackagePath); err == nil {
-		packagePath = resolved
-	}
-	// Fleet processes.d YAML is not an MSI component; keep it across upgrade prerm so a rolled-back
-	// install still has supervision config until postinst rewrites it. Full uninstall removes it.
-	if !ctx.Upgrade {
-		installRoot, err := resolveDatadogProgramFilesInstallRoot()
-		if err != nil {
-			installRoot = packagePath
-		}
-		if err := processmanager.RemoveADPProcmgrConfig(installRoot); err != nil {
-			log.Warnf("failed to remove ADP process manager config: %v", err)
-		}
-		if err := processmanager.RemovePARProcmgrConfig(installRoot); err != nil {
-			log.Warnf("failed to remove PAR process manager config: %v", err)
-		}
-		if env.FromEnv().ProcessManagerEnabled {
-			processmanager.ReloadOrRestartProcmgr()
-		}
-	}
+	// processes.d cleanup is owned by the MSI: RemoveFolderEx removes the directory on
+	// uninstall (StopDDServices stops dd-procmgr-service first, releasing supervised
+	// binaries), and the general rollback cleanup handles install/upgrade/repair rollback.
+	// The prerm no longer touches processes.d.
 
 	if ctx.PackageType == PackageTypeMSI {
 		// MSI custom action calling hook - done.

--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -172,11 +172,6 @@ func preRemoveDatadogAgent(ctx HookContext) (err error) {
 		log.Warnf("failed to remove extensions: %s", err)
 	}
 
-	// processes.d cleanup is owned by the MSI: RemoveFolderEx removes the directory on
-	// uninstall (StopDDServices stops dd-procmgr-service first, releasing supervised
-	// binaries), and the general rollback cleanup handles install/upgrade/repair rollback.
-	// The prerm no longer touches processes.d.
-
 	if ctx.PackageType == PackageTypeMSI {
 		// MSI custom action calling hook - done.
 		// Note: the save file written above lives in ProtectedDir which intentionally persists

--- a/pkg/fleet/installer/packages/processmanager/BUILD.bazel
+++ b/pkg/fleet/installer/packages/processmanager/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
             "//pkg/fleet/installer/paths",
             "//pkg/util/log",
             "//pkg/util/winutil",
-            "@org_golang_x_sys//windows/registry",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/par_procmgr_config_windows.go
@@ -17,14 +17,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/embedded"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"golang.org/x/sys/windows/registry"
 )
 
 const (
 	parProcmgrConfigFileName = "datadog-agent-action.yaml"
-
-	datadogAgentRegistryKey                       = `SOFTWARE\Datadog\Datadog Agent`
-	parProcmgrConfigWrittenThisInstallRegistryKey = "PARProcmgrConfigWrittenThisInstall"
 )
 
 // WritePARProcmgrConfig writes datadog-agent-action.yaml next to the MSI install layout so
@@ -62,16 +58,9 @@ func WritePARProcmgrConfig(installRootResolved string) error {
 	config = strings.ReplaceAll(config, "__PAR_FLEET_POLICIES_DIR__", fleetPoliciesRepl)
 
 	path := filepath.Join(processesDir, parProcmgrConfigFileName)
-	_, statErr := os.Stat(path)
-	existedBefore := statErr == nil
 	log.Debugf("PAR processes.d: writing %q", path)
 	if err := os.WriteFile(path, []byte(config), 0o644); err != nil {
 		return err
-	}
-	if !existedBefore {
-		if err := setPARProcmgrConfigWrittenThisInstall(); err != nil {
-			log.Warnf("PAR processes.d: could not mark config written this install: %v", err)
-		}
 	}
 	return nil
 }
@@ -105,35 +94,6 @@ func RemovePARProcmgrConfig(packageRootResolved string) error {
 	}
 	if installPF := paths.DatadogProgramFilesDir; installPF != "" {
 		removeEmptyProcessesDir(installPF)
-	}
-	if err := clearPARProcmgrConfigWrittenThisInstall(); err != nil {
-		log.Debugf("PAR processes.d: clear install marker: %v", err)
-	}
-	return nil
-}
-
-func setPARProcmgrConfigWrittenThisInstall() error {
-	k, err := registry.OpenKey(registry.LOCAL_MACHINE, datadogAgentRegistryKey, registry.SET_VALUE)
-	if err != nil {
-		return err
-	}
-	defer k.Close()
-	return k.SetDWordValue(parProcmgrConfigWrittenThisInstallRegistryKey, 1)
-}
-
-func clearPARProcmgrConfigWrittenThisInstall() error {
-	k, err := registry.OpenKey(registry.LOCAL_MACHINE, datadogAgentRegistryKey, registry.SET_VALUE)
-	if err != nil {
-		if err == registry.ErrNotExist {
-			return nil
-		}
-		return err
-	}
-	defer k.Close()
-	if err := k.DeleteValue(parProcmgrConfigWrittenThisInstallRegistryKey); err == registry.ErrNotExist {
-		return nil
-	} else if err != nil {
-		return err
 	}
 	return nil
 }

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
@@ -96,12 +96,6 @@ namespace Datadog.AgentCustomActions
         }
 
         [CustomAction]
-        public static ActionResult RemoveFleetProcmgrConfigOnRollback(Session session)
-        {
-            return Datadog.CustomActions.CleanUpFilesCustomAction.RemoveFleetProcmgrConfigOnRollback(session);
-        }
-
-        [CustomAction]
         public static ActionResult RemoveEmptyInstallDirOnRollback(Session session)
         {
             return Datadog.CustomActions.CleanUpFilesCustomAction.RemoveEmptyInstallDirOnRollback(session);

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
@@ -102,12 +102,6 @@ namespace Datadog.AgentCustomActions
         }
 
         [CustomAction]
-        public static ActionResult RemoveParFleetProcmgrConfigOnUpgradeRollback(Session session)
-        {
-            return Datadog.CustomActions.CleanUpFilesCustomAction.RemoveParFleetProcmgrConfigOnUpgradeRollback(session);
-        }
-
-        [CustomAction]
         public static ActionResult RemoveEmptyInstallDirOnRollback(Session session)
         {
             return Datadog.CustomActions.CleanUpFilesCustomAction.RemoveEmptyInstallDirOnRollback(session);

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
@@ -178,6 +178,8 @@ namespace Datadog.AgentCustomActions
             {
                 "bin\\agent",
                 "embedded3",
+                // Fleet postinst writes processes.d/*.yaml (untracked by MSI)
+                "processes.d",
                 // embedded2 only exists in Agent 6, so an error will be logged, but install will continue
                 "embedded2",
             };

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
@@ -4,16 +4,11 @@ using WixToolset.Dtf.WindowsInstaller;
 using System;
 using System.IO;
 using System.Linq;
-using Microsoft.Win32;
 
 namespace Datadog.CustomActions
 {
     public class CleanUpFilesCustomAction
     {
-        private const string AdpProcmgrConfigFileName = "datadog-agent-data-plane.yaml";
-        private const string DdotProcmgrConfigFileName = "datadog-agent-ddot.yaml";
-        private const string ParProcmgrConfigFileName = "datadog-agent-action.yaml";
-
         /// <summary>
         /// Removes generated install artifacts (embedded2/embedded3, python-scripts, session-generated paths).
         /// Used before InstallFiles, during uninstall, and on rollback.
@@ -24,29 +19,18 @@ namespace Datadog.CustomActions
         }
 
         /// <summary>
-        /// Rollback-only: remove fleet-written processes.d YAML that MSI does not track.
-        /// Scheduled only on fresh install rollbacks (see Conditions.FirstInstall on the WiX action).
+        /// Rollback-only: remove the fleet-written processes.d directory that MSI does not track.
+        /// Runs on install/upgrade/repair rollback; RemoveFolderEx handles the uninstall path.
         /// </summary>
+        /// <remarks>
+        /// TODO(WINA-2538): once CleanupOnUninstall is sequenced after RemoveFiles (so an imperative
+        /// pre-RemoveFiles delete no longer defeats MSI rollback-restore), fold this into the general
+        /// RemoveGeneratedArtifactPaths cleanup by adding "processes.d" to its directory list, and
+        /// drop this rollback-only action.
+        /// </remarks>
         public static ActionResult RemoveFleetProcmgrConfigOnRollback(Session session)
         {
             return RemoveFleetProcmgrConfigOnRollback(new SessionWrapper(session));
-        }
-
-        /// <summary>
-        /// Rollback-only: remove fleet-written PAR processes.d YAML after a failed upgrade.
-        /// Older agents start PAR via SCM and do not suppress it when this file is left behind.
-        /// </summary>
-        public static ActionResult RemoveParFleetProcmgrConfigOnUpgradeRollback(Session session)
-        {
-            return RemoveParFleetProcmgrConfigOnUpgradeRollback(new SessionWrapper(session));
-        }
-
-        /// <summary>
-        /// Clear the install-session marker after a successful MSI install/upgrade.
-        /// </summary>
-        public static ActionResult ClearPARProcmgrConfigWrittenThisInstallMarker(Session session)
-        {
-            return ClearPARProcmgrConfigWrittenThisInstallMarker(new SessionWrapper(session));
         }
 
         /// <summary>
@@ -74,26 +58,7 @@ namespace Datadog.CustomActions
 
         private static ActionResult RemoveFleetProcmgrConfigOnRollback(ISession session)
         {
-            TryRemoveFleetProcmgrConfigFiles(session, session.Property("PROJECTLOCATION"),
-                AdpProcmgrConfigFileName, DdotProcmgrConfigFileName, ParProcmgrConfigFileName);
-            return ActionResult.Success;
-        }
-
-        private static ActionResult RemoveParFleetProcmgrConfigOnUpgradeRollback(ISession session)
-        {
-            if (!PARProcmgrConfigMarkedWrittenThisInstall(session))
-            {
-                session.Log("PAR processes.d was not written this install; skip upgrade rollback cleanup.");
-                return ActionResult.Success;
-            }
-            TryRemoveFleetProcmgrConfigFiles(session, session.Property("PROJECTLOCATION"), ParProcmgrConfigFileName);
-            clearParProcmgrInstallMarkerRegistry(session);
-            return ActionResult.Success;
-        }
-
-        private static ActionResult ClearPARProcmgrConfigWrittenThisInstallMarker(ISession session)
-        {
-            clearParProcmgrInstallMarkerRegistry(session);
+            TryRemoveFleetProcmgrConfigDir(session, session.Property("PROJECTLOCATION"));
             return ActionResult.Success;
         }
 
@@ -149,7 +114,7 @@ namespace Datadog.CustomActions
             }
         }
 
-        private static void TryRemoveFleetProcmgrConfigFiles(ISession session, string projectLocation, params string[] fileNames)
+        private static void TryRemoveFleetProcmgrConfigDir(ISession session, string projectLocation)
         {
             if (string.IsNullOrEmpty(projectLocation))
             {
@@ -157,24 +122,20 @@ namespace Datadog.CustomActions
             }
 
             var processesDir = Path.Combine(projectLocation, "processes.d");
-            foreach (var fileName in fileNames)
+            try
             {
-                var path = Path.Combine(processesDir, fileName);
-                try
+                if (!Directory.Exists(processesDir))
                 {
-                    if (!File.Exists(path))
-                    {
-                        session.Log($"{path} not found, skip deletion.");
-                        continue;
-                    }
+                    session.Log($"{processesDir} not found, skip deletion.");
+                    return;
+                }
 
-                    session.Log($"Deleting fleet process manager config \"{path}\"");
-                    File.Delete(path);
-                }
-                catch (Exception e)
-                {
-                    session.Log($"Error while deleting fleet process manager config {path}: {e}");
-                }
+                session.Log($"Deleting fleet process manager config directory \"{processesDir}\"");
+                Directory.Delete(processesDir, true);
+            }
+            catch (Exception e)
+            {
+                session.Log($"Error while deleting fleet process manager config directory {processesDir}: {e}");
             }
         }
 
@@ -214,37 +175,5 @@ namespace Datadog.CustomActions
             }
         }
 
-        private static bool PARProcmgrConfigMarkedWrittenThisInstall(ISession session)
-        {
-            try
-            {
-                using var key = Registry.LocalMachine.OpenSubKey(Constants.DatadogAgentRegistryKey, writable: false);
-                if (key == null)
-                {
-                    return false;
-                }
-
-                var value = key.GetValue(Constants.PARProcmgrConfigWrittenThisInstallValue);
-                return value is int marker && marker != 0;
-            }
-            catch (Exception e)
-            {
-                session.Log($"Error reading PAR procmgr install marker: {e}");
-                return false;
-            }
-        }
-
-        private static void clearParProcmgrInstallMarkerRegistry(ISession session)
-        {
-            try
-            {
-                using var key = Registry.LocalMachine.OpenSubKey(Constants.DatadogAgentRegistryKey, writable: true);
-                key?.DeleteValue(Constants.PARProcmgrConfigWrittenThisInstallValue, throwOnMissingValue: false);
-            }
-            catch (Exception e)
-            {
-                session.Log($"Error clearing PAR procmgr install marker: {e}");
-            }
-        }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
@@ -19,21 +19,6 @@ namespace Datadog.CustomActions
         }
 
         /// <summary>
-        /// Rollback-only: remove the fleet-written processes.d directory that MSI does not track.
-        /// Runs on install/upgrade/repair rollback; RemoveFolderEx handles the uninstall path.
-        /// </summary>
-        /// <remarks>
-        /// TODO(WINA-2538): once CleanupOnUninstall is sequenced after RemoveFiles (so an imperative
-        /// pre-RemoveFiles delete no longer defeats MSI rollback-restore), fold this into the general
-        /// RemoveGeneratedArtifactPaths cleanup by adding "processes.d" to its directory list, and
-        /// drop this rollback-only action.
-        /// </remarks>
-        public static ActionResult RemoveFleetProcmgrConfigOnRollback(Session session)
-        {
-            return RemoveFleetProcmgrConfigOnRollback(new SessionWrapper(session));
-        }
-
-        /// <summary>
         /// Rollback-only: drop an otherwise-empty install root left by a failed fresh install.
         /// </summary>
         public static ActionResult RemoveEmptyInstallDirOnRollback(Session session)
@@ -43,7 +28,6 @@ namespace Datadog.CustomActions
 
         /// <summary>
         /// Uninstall tail: drop empty processes.d and empty install root after MSI components are removed.
-        /// Fleet prerm already removed processes.d YAML on full uninstall.
         /// </summary>
         public static ActionResult RemoveEmptyInstallDirAfterUninstall(Session session)
         {
@@ -53,12 +37,6 @@ namespace Datadog.CustomActions
         private static ActionResult CleanupFiles(ISession session)
         {
             RemoveGeneratedArtifactPaths(session, session.Property("PROJECTLOCATION"));
-            return ActionResult.Success;
-        }
-
-        private static ActionResult RemoveFleetProcmgrConfigOnRollback(ISession session)
-        {
-            TryRemoveFleetProcmgrConfigDir(session, session.Property("PROJECTLOCATION"));
             return ActionResult.Success;
         }
 
@@ -82,6 +60,9 @@ namespace Datadog.CustomActions
                 Path.Combine(projectLocation, "embedded2"),
                 Path.Combine(projectLocation, "embedded3"),
                 Path.Combine(projectLocation, "python-scripts"),
+                // fleet postinst writes processes.d/*.yaml (untracked by MSI); RemoveFolderEx owns
+                // uninstall, this covers install/upgrade/repair rollback and the repair pre-clean.
+                Path.Combine(projectLocation, "processes.d"),
             }
             // installation specific files
             .Concat(session.GeneratedPaths());
@@ -111,31 +92,6 @@ namespace Datadog.CustomActions
                     // Don't fail in cleanup/rollback actions otherwise
                     // we may brick the installation.
                 }
-            }
-        }
-
-        private static void TryRemoveFleetProcmgrConfigDir(ISession session, string projectLocation)
-        {
-            if (string.IsNullOrEmpty(projectLocation))
-            {
-                return;
-            }
-
-            var processesDir = Path.Combine(projectLocation, "processes.d");
-            try
-            {
-                if (!Directory.Exists(processesDir))
-                {
-                    session.Log($"{processesDir} not found, skip deletion.");
-                    return;
-                }
-
-                session.Log($"Deleting fleet process manager config directory \"{processesDir}\"");
-                Directory.Delete(processesDir, true);
-            }
-            catch (Exception e)
-            {
-                session.Log($"Error while deleting fleet process manager config directory {processesDir}: {e}");
             }
         }
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Constants.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Constants.cs
@@ -14,10 +14,6 @@ namespace Datadog.CustomActions
         public const string ProcmonServiceName = "ddprocmon";
         public const string ProcmgrServiceName = "dd-procmgr-service";
 
-        // Set to 1 when postinst creates processes.d/datadog-agent-action.yaml for the first time
-        // during an MSI install/upgrade; used to scope upgrade rollback cleanup.
-        public const string PARProcmgrConfigWrittenThisInstallValue = "PARProcmgrConfigWrittenThisInstall";
-
         // Key under HKLM that contains our options
         public const string DatadogAgentRegistryKey = @"Software\Datadog\Datadog Agent";
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Telemetry.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Telemetry.cs
@@ -88,7 +88,6 @@ namespace Datadog.CustomActions
 
         public static ActionResult ReportSuccess(Session session)
         {
-            CleanUpFilesCustomAction.ClearPARProcmgrConfigWrittenThisInstallMarker(session);
             return Report(new SessionWrapper(session), "agent.installation.success");
         }
     }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -50,8 +50,6 @@ namespace WixSetup.Datadog_Agent
 
         public ManagedAction RemoveFleetProcmgrConfigOnRollback { get; }
 
-        public ManagedAction RemoveParFleetProcmgrConfigOnUpgradeRollback { get; }
-
         public ManagedAction CleanupOnRollback { get; }
 
         public ManagedAction RemoveEmptyInstallDirOnRollback { get; }
@@ -303,7 +301,10 @@ namespace WixSetup.Datadog_Agent
                     Return.check,
                     When.After,
                     new Step(CleanupOnRollback.Id),
-                    Conditions.FirstInstall
+                    // Rollback for any install-type transaction: postinst may have written
+                    // processes.d YAML on fresh install, upgrade, or repair. RemoveFolderEx
+                    // (uninstall-only) does not cover install-time rollback, so clean it here.
+                    Conditions.FirstInstall | Conditions.Upgrading | Conditions.Maintenance
                 )
             {
                 Execute = Execute.rollback,
@@ -871,24 +872,6 @@ namespace WixSetup.Datadog_Agent
                                "DD_INSTALLER_REGISTRY_PASSWORD=[DD_INSTALLER_REGISTRY_PASSWORD], " +
                                "DD_OTELCOLLECTOR_ENABLED=[DD_OTELCOLLECTOR_ENABLED]")
                 .HideTarget(true);
-
-            // Upgrade rollback only: postinst may have written PAR processes.d YAML that older
-            // agents do not suppress via SCM. Only remove YAML created during this install session.
-            // Must be sequenced before RunPostInstallHook so the rollback script is registered
-            // before postinst can write the config (see StartDDServicesRollback).
-            RemoveParFleetProcmgrConfigOnUpgradeRollback = new CustomAction<CustomActions>(
-                    new Id(nameof(RemoveParFleetProcmgrConfigOnUpgradeRollback)),
-                    CustomActions.RemoveParFleetProcmgrConfigOnUpgradeRollback,
-                    Return.check,
-                    When.Before,
-                    new Step(RunPostInstallHook.Id),
-                    Conditions.Upgrading
-                )
-            {
-                Execute = Execute.rollback,
-                Impersonate = false
-            }
-                .SetProperties("PROJECTLOCATION=[PROJECTLOCATION]");
 
             ConfigureAutoLogger = new CustomAction<CustomActions>(
                     new Id(nameof(ConfigureAutoLogger)),

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -48,8 +48,6 @@ namespace WixSetup.Datadog_Agent
 
         public ManagedAction DecompressPythonDistributions { get; }
 
-        public ManagedAction RemoveFleetProcmgrConfigOnRollback { get; }
-
         public ManagedAction CleanupOnRollback { get; }
 
         public ManagedAction RemoveEmptyInstallDirOnRollback { get; }
@@ -295,29 +293,12 @@ namespace WixSetup.Datadog_Agent
             }
                 .SetProperties("PROJECTLOCATION=[PROJECTLOCATION]");
 
-            RemoveFleetProcmgrConfigOnRollback = new CustomAction<CustomActions>(
-                    new Id(nameof(RemoveFleetProcmgrConfigOnRollback)),
-                    CustomActions.RemoveFleetProcmgrConfigOnRollback,
-                    Return.check,
-                    When.After,
-                    new Step(CleanupOnRollback.Id),
-                    // Rollback for any install-type transaction: postinst may have written
-                    // processes.d YAML on fresh install, upgrade, or repair. RemoveFolderEx
-                    // (uninstall-only) does not cover install-time rollback, so clean it here.
-                    Conditions.FirstInstall | Conditions.Upgrading | Conditions.Maintenance
-                )
-            {
-                Execute = Execute.rollback,
-                Impersonate = false
-            }
-                .SetProperties("PROJECTLOCATION=[PROJECTLOCATION]");
-
             DecompressPythonDistributions = new CustomAction<CustomActions>(
                     new Id(nameof(DecompressPythonDistributions)),
                     CustomActions.DecompressPythonDistributions,
                     Return.check,
                     When.After,
-                    new Step(RemoveFleetProcmgrConfigOnRollback.Id),
+                    new Step(CleanupOnRollback.Id),
                     Conditions.FirstInstall | Conditions.Upgrading | Conditions.Maintenance
                 )
             {


### PR DESCRIPTION
### What does this PR do?
Add procmgr processes.d to `RemoveFolder` so it's removed on uninstall and restored on rollback

to be merged into jose/add-par-windows-procmgr

### Motivation
`processes.d` is a new non-MSI managed folder in the install root

### Describe how you validated your changes
existing e2e tests should pass

manual tests run

| # | Scenario | Action | Expected | Observed | Result |
|---|----------|--------|----------|----------|--------|
| 1 | Fresh install | `msiexec /i ddbase.msi DD_INSTALL_ONLY=1` | `processes.d` written by postinst | exit 0; product `7.82.0.0`; `processes.d` = `datadog-agent-action.yaml, datadog-agent-data-plane.yaml` | ✅ |
| 2 | Uninstall | `msiexec /x ddbase.msi` | `processes.d` + install root removed | exit 0; install root `False` (gone) | ✅ |
| 3 | Fresh-install rollback | `msiexec /i ddbase.msi WIXFAILWHENDEFERRED=1` | install fails, `processes.d` cleaned | exit 1603; `processes.d` `False` (only known ai-usage `TBD*.tmp` reboot-pending left in `bin\agent`) | ✅ |
| 4 | Major upgrade | install `7.82.0` → `msiexec /i ddupgrade.msi` (`7.82.1`) | single product upgraded, `processes.d` intact | exit 0; product `7.82.1.0` (no duplicate); `processes.d` = both configs | ✅ |
| 5 | Upgrade rollback | mark `action.yaml` on `7.82.0` → `msiexec /i ddupgrade.msi WIXFAILWHENDEFERRED=1` | roll back to `7.82.0`, **original** `processes.d` restored | exit 1603; product `7.82.0.0`; marker present; SHA256 after == before (`3ECAEFF8…`) — byte-identical | ✅ |

### Additional Notes
full uninstall rollback is broken, will leave install without a processes.d folder, this is a separate known issue: https://datadoghq.atlassian.net/browse/WINA-2538

open question: do we want to restore exactly the files on rollback (this PR) or do we want to reinstall them cleanly by running `postinst` again? We currently don't run `postinst` in rollback but i think eventually we'll have something like
fleet prerm (old) -> fleet postinst (new) -> fleet prerm (new) -> fleet postinst (old)