### PR TITLE
[ABLD-509] Remove target_compatible_with=linux for pkg/util/trivy

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/BUILD.bazel
+++ b/comp/core/workloadmeta/collectors/internal/containerd/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "stub.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/containerd",
-    target_compatible_with = ["@platforms//os:linux"],  # keep
     visibility = ["//comp/core/workloadmeta/collectors:__subpackages__"],
     deps = [
         "//comp/core/config",

--- a/comp/core/workloadmeta/collectors/internal/crio/BUILD.bazel
+++ b/comp/core/workloadmeta/collectors/internal/crio/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "stub.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/crio",
-    target_compatible_with = ["@platforms//os:linux"],  # keep
     visibility = ["//comp/core/workloadmeta/collectors:__subpackages__"],
     deps = [
         "//comp/core/config",

--- a/pkg/util/trivy/BUILD.bazel
+++ b/pkg/util/trivy/BUILD.bazel
@@ -94,7 +94,7 @@ dd_agent_go_test(
         "base",
         "fips",
     ],
-    # This tests is meaningless except on linux.
+    # These tests are meaningless except on linux.
     # - the library is only functional with the gotag 'trivy'
     # - test rule strips 'trivy' because it is a LINUX_ONLY_FLAG
     target_compatible_with = ["@platforms//os:linux"],  # keep

--- a/pkg/util/trivy/BUILD.bazel
+++ b/pkg/util/trivy/BUILD.bazel
@@ -3,6 +3,10 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 # gazelle:dd_agent_go_test on
 
+# This library requires the go tag "trivy" to have any impact, and
+# trivy is only used in linux builds. But we still do not want to mark
+# it as linux only because the top level binaries depend on this and
+# expect go tag inclusion to save them.
 go_library(
     name = "trivy",
     srcs = [
@@ -20,7 +24,6 @@ go_library(
         "trivy.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/util/trivy",
-    target_compatible_with = ["@platforms//os:linux"],  # keep
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
@@ -91,6 +94,9 @@ dd_agent_go_test(
         "base",
         "fips",
     ],
+    # This tests is meaningless except on linux.
+    # - the library is only functional with the gotag 'trivy'
+    # - test rule strips 'trivy' because it is a LINUX_ONLY_FLAG
     target_compatible_with = ["@platforms//os:linux"],  # keep
     deps = [
         "//comp/core",


### PR DESCRIPTION
### What does this PR do?

- Remove target_compatible_with=linux for pkg/util/trivy, comp/core/workloadmeta/collectors/internal/containerd, and comp/core/workloadmeta/collectors/internal/crio.
- Move/leave it on the test

### Motivation

The top level binaries such as //cmd/agent and //cmd/dogstatsd transitively depend on this library on all platforms, so we need to have it as a valid target on all platforms. 
However, all the code is behind the go tag 'trivy' which is declared as linux only, and stripped from `dd_agent_go_test` and `dd_agent_go_binary` actions on macos and windows. So there is no point running the test on macos. That would give the false impression that we are testing something, even though it is empty.

### Describe how you validated your changes

- CI passes
- Try it on linux
```
$ bazel test  --config=base //pkg/util/trivy/...
//pkg/util/trivy:trivy_test_base                                (cached) PASSED in 8.7s
//pkg/util/trivy/walker:walker_test_base                        (cached) PASSED in 0.2s
```
and macos
```
$ bazel test  --config=base //pkg/util/trivy/...
//pkg/util/trivy:trivy_test_base                                        SKIPPED
//pkg/util/trivy/walker:walker_test_base                                 PASSED in 0.6s
```

But the killer validation is that dogstatsd now actually builds on macos.
```
$ bazel run //cmd/dogstatsd:dogstatsd -- version
INFO: Analyzed target //cmd/dogstatsd:dogstatsd (0 packages loaded, 0 targets configured).
INFO: Running command line: /Users/tony.aiuto/Library/Caches/bazel/_bazel_tony.aiuto/715660098b42a952d784ef0dae7ec6a5/execroot/_main/bazel-out/darwin_arm64-fastbuild-ST-0d85c46b0463/bin/cmd/dogstatsd/dogstatsd_/dogstatsd <args omitted>
DogStatsD 7.82.0-localbuild - Commit: dev - Serialization version: v5.0.205 - Go version: go1.26.5
```


### Additional Notes

We have to apply this same pattern to many more places. Let's refine it in this PR, decide if we need the commentary about why everywhere, and then apply it. Excluding EBPF, which is very much linux only, there are O(50) places.
```
grep -r target_comp.*linux pkg comp cmd | grep -v ebpf | wc
     57     258    5402
```