### PR TITLE
[anomalydetection] Smart adaptive log sampling logic 3/4

### DIFF
--- a/pkg/logs/internal/decoder/BUILD.bazel
+++ b/pkg/logs/internal/decoder/BUILD.bazel
@@ -31,9 +31,11 @@ go_library(
         "@com_github_datadog_datadog_agent_pkg_logs_util_testutils//:__subpackages__",
     ],
     deps = [
+        "//comp/anomalydetection/severityevents/def",
         "//comp/core/telemetry/def",
         "//comp/logs-library/metrics",
         "//comp/logs/agent/config",
+        "//comp/logs/severityprovider/def",
         "//pkg/config/setup",
         "//pkg/config/structure",
         "//pkg/logs/internal/decoder/preprocessor",
@@ -65,6 +67,7 @@ dd_agent_go_test(
     ],
     embed = [":decoder"],
     deps = [
+        "//comp/anomalydetection/severityevents/def",
         "//comp/logs/agent/config",
         "//pkg/config/mock",
         "//pkg/config/model",

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -9,7 +9,9 @@ import (
 	"regexp"
 	"time"
 
+	severityeventsdef "github.com/DataDog/datadog-agent/comp/anomalydetection/severityevents/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	severityprovider "github.com/DataDog/datadog-agent/comp/logs/severityprovider/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder/preprocessor"
@@ -189,6 +191,47 @@ func resolveNoisyLogDetectionEnabled(sourceNoisyLogDetection *bool) bool {
 
 const disabledSourcesConfigKey = "logs_config.experimental_adaptive_sampling.disabled_sources"
 
+const (
+	smartSeverityProfilesEnabledConfigKey         = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled"
+	smartSeverityProfilesMediumRateLimitConfigKey = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit"
+	smartSeverityProfilesMediumBurstSizeConfigKey = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.burst_size"
+	smartSeverityProfilesHighRateLimitConfigKey   = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.rate_limit"
+	smartSeverityProfilesHighBurstSizeConfigKey   = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.burst_size"
+)
+
+// resolveSmartSeverityProfiles builds the Low/Medium/High profile triple. Each field of
+// Medium/High cascades independently from the level below when left unconfigured (Low ->
+// Medium -> High), so no combination of partially-configured fields can leave a higher
+// severity level less permissive than the one below it.
+func resolveSmartSeverityProfiles(low preprocessor.SamplerProfile) [severityeventsdef.NumSeverityLevels]preprocessor.SamplerProfile {
+	cfg := pkgconfigsetup.Datadog()
+
+	profiles := [severityeventsdef.NumSeverityLevels]preprocessor.SamplerProfile{
+		severityeventsdef.SeverityLow:    low,
+		severityeventsdef.SeverityMedium: low,
+		severityeventsdef.SeverityHigh:   low,
+	}
+
+	if cfg.IsConfigured(smartSeverityProfilesMediumRateLimitConfigKey) {
+		profiles[severityeventsdef.SeverityMedium].RateLimit = cfg.GetFloat64(smartSeverityProfilesMediumRateLimitConfigKey)
+	}
+	if cfg.IsConfigured(smartSeverityProfilesMediumBurstSizeConfigKey) {
+		profiles[severityeventsdef.SeverityMedium].BurstSize = clampBurstSize(cfg.GetFloat64(smartSeverityProfilesMediumBurstSizeConfigKey))
+	}
+
+	// High starts from Medium's already-resolved profile, then applies its own
+	// overrides per field.
+	profiles[severityeventsdef.SeverityHigh] = profiles[severityeventsdef.SeverityMedium]
+	if cfg.IsConfigured(smartSeverityProfilesHighRateLimitConfigKey) {
+		profiles[severityeventsdef.SeverityHigh].RateLimit = cfg.GetFloat64(smartSeverityProfilesHighRateLimitConfigKey)
+	}
+	if cfg.IsConfigured(smartSeverityProfilesHighBurstSizeConfigKey) {
+		profiles[severityeventsdef.SeverityHigh].BurstSize = clampBurstSize(cfg.GetFloat64(smartSeverityProfilesHighBurstSizeConfigKey))
+	}
+
+	return profiles
+}
+
 func newDisabledSet() map[string]struct{} {
 	entries := pkgconfigsetup.Datadog().GetStringSlice(disabledSourcesConfigKey)
 	m := make(map[string]struct{}, len(entries))
@@ -276,7 +319,15 @@ func resolveAdaptiveSamplerConfig(sourceAdaptiveSampling *config.SourceAdaptiveS
 		}
 	}
 
-	return validateAdaptiveSamplerConfig(c)
+	c = validateAdaptiveSamplerConfig(c)
+
+	c.SmartSeverityProfilesEnabled = pkgconfigsetup.Datadog().GetBool(smartSeverityProfilesEnabledConfigKey)
+	if c.SmartSeverityProfilesEnabled {
+		c.Profiles = resolveSmartSeverityProfiles(preprocessor.SamplerProfile{RateLimit: c.RateLimit, BurstSize: c.BurstSize})
+		c.SeverityProvider = severityprovider.Current
+	}
+
+	return c
 }
 
 func resolveNoisyLogDetectionConfig(sourceAdaptiveSampling *config.SourceAdaptiveSamplingOptions, tok *preprocessor.Tokenizer) preprocessor.AdaptiveSamplerConfig {
@@ -425,11 +476,17 @@ func validateAdaptiveSamplerConfig(c preprocessor.AdaptiveSamplerConfig) preproc
 		c.MaxPatterns = 1
 	}
 
-	if c.BurstSize <= 0 {
-		c.BurstSize = 1
-	}
+	c.BurstSize = clampBurstSize(c.BurstSize)
 
 	return c
+}
+
+// clampBurstSize floors burstSize at 1, avoiding negative starting credits.
+func clampBurstSize(burstSize float64) float64 {
+	if burstSize <= 0 {
+		return 1
+	}
+	return burstSize
 }
 
 func getLegacyAutoMultilineHandler(outputFn func(*message.Message), multiLinePattern *regexp.Regexp, maxContentSize int, source *sources.ReplaceableSource, detectedPattern *DetectedPattern, tailerInfo *status.InfoRegistry) LineHandler {

--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	severityeventsdef "github.com/DataDog/datadog-agent/comp/anomalydetection/severityevents/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -740,6 +741,101 @@ func TestResolveAdaptiveSamplerConfig(t *testing.T) {
 		assert.Equal(t, 50.0, got.BurstSize)
 		assert.Equal(t, 0.8, got.MatchThreshold)
 		assert.True(t, got.DetectionOnly)
+	})
+
+	t.Run("smart severity profiles enabled: unconfigured medium/high fall back to the base (low) values", func(t *testing.T) {
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", true, pkgconfigmodel.SourceAgentRuntime)
+		defer mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+
+		got := resolveAdaptiveSamplerConfig(nil, preprocessor.NewTokenizer(0))
+
+		assert.True(t, got.SmartSeverityProfilesEnabled)
+		low := preprocessor.SamplerProfile{RateLimit: got.RateLimit, BurstSize: got.BurstSize}
+		assert.Equal(t, low, got.Profiles[severityeventsdef.SeverityLow])
+		assert.Equal(t, low, got.Profiles[severityeventsdef.SeverityMedium])
+		assert.Equal(t, low, got.Profiles[severityeventsdef.SeverityHigh])
+	})
+
+	// Must run before any subtest that Sets (and later resets) medium.burst_size:
+	// mockConfig has no true "unset", so a prior Set — even one whose deferred
+	// cleanup restores the default value — permanently marks the key as
+	// configured for every subtest that follows.
+	t.Run("smart severity profiles enabled: high cascades a partially-configured medium field-by-field", func(t *testing.T) {
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", true, pkgconfigmodel.SourceAgentRuntime)
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit", 5.0, pkgconfigmodel.SourceAgentRuntime)
+		defer func() {
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit", 1.0, pkgconfigmodel.SourceAgentRuntime)
+		}()
+
+		got := resolveAdaptiveSamplerConfig(nil, preprocessor.NewTokenizer(0))
+
+		want := preprocessor.SamplerProfile{RateLimit: 5.0, BurstSize: got.BurstSize}
+		assert.Equal(t, want, got.Profiles[severityeventsdef.SeverityMedium])
+		assert.Equal(t, want, got.Profiles[severityeventsdef.SeverityHigh], "high's unconfigured rate_limit must cascade from medium, not revert to low, so high is never less permissive than medium")
+	})
+
+	t.Run("smart severity profiles enabled: unset high falls back to configured medium", func(t *testing.T) {
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", true, pkgconfigmodel.SourceAgentRuntime)
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit", 5.0, pkgconfigmodel.SourceAgentRuntime)
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.burst_size", 200.0, pkgconfigmodel.SourceAgentRuntime)
+		defer func() {
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit", 1.0, pkgconfigmodel.SourceAgentRuntime)
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.burst_size", 1000.0, pkgconfigmodel.SourceAgentRuntime)
+		}()
+
+		got := resolveAdaptiveSamplerConfig(nil, preprocessor.NewTokenizer(0))
+
+		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 5.0, BurstSize: 200.0}, got.Profiles[severityeventsdef.SeverityMedium])
+		assert.Equal(t, got.Profiles[severityeventsdef.SeverityMedium], got.Profiles[severityeventsdef.SeverityHigh])
+	})
+
+	t.Run("smart severity profiles enabled: explicit medium/high overrides win", func(t *testing.T) {
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", true, pkgconfigmodel.SourceAgentRuntime)
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit", 5.0, pkgconfigmodel.SourceAgentRuntime)
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.burst_size", 200.0, pkgconfigmodel.SourceAgentRuntime)
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.rate_limit", 20.0, pkgconfigmodel.SourceAgentRuntime)
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.burst_size", 500.0, pkgconfigmodel.SourceAgentRuntime)
+		defer func() {
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit", 1.0, pkgconfigmodel.SourceAgentRuntime)
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.burst_size", 1000.0, pkgconfigmodel.SourceAgentRuntime)
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.rate_limit", 1.0, pkgconfigmodel.SourceAgentRuntime)
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.burst_size", 1000.0, pkgconfigmodel.SourceAgentRuntime)
+		}()
+
+		got := resolveAdaptiveSamplerConfig(nil, preprocessor.NewTokenizer(0))
+
+		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 2.5, BurstSize: 50.0}, got.Profiles[severityeventsdef.SeverityLow])
+		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 5.0, BurstSize: 200.0}, got.Profiles[severityeventsdef.SeverityMedium])
+		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 20.0, BurstSize: 500.0}, got.Profiles[severityeventsdef.SeverityHigh])
+	})
+
+	t.Run("smart severity profiles enabled: a non-positive configured burst size is clamped to 1", func(t *testing.T) {
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", true, pkgconfigmodel.SourceAgentRuntime)
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.burst_size", 0.0, pkgconfigmodel.SourceAgentRuntime)
+		defer func() {
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.burst_size", 1000.0, pkgconfigmodel.SourceAgentRuntime)
+		}()
+
+		got := resolveAdaptiveSamplerConfig(nil, preprocessor.NewTokenizer(0))
+
+		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 1.0, BurstSize: 1.0}, got.Profiles[severityeventsdef.SeverityHigh])
+	})
+
+	t.Run("smart severity profiles enabled: a negative configured burst size is clamped to 1", func(t *testing.T) {
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", true, pkgconfigmodel.SourceAgentRuntime)
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.burst_size", -50.0, pkgconfigmodel.SourceAgentRuntime)
+		defer func() {
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.burst_size", 1000.0, pkgconfigmodel.SourceAgentRuntime)
+		}()
+
+		got := resolveAdaptiveSamplerConfig(nil, preprocessor.NewTokenizer(0))
+
+		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 1.0, BurstSize: 1.0}, got.Profiles[severityeventsdef.SeverityHigh])
 	})
 }
 

--- a/pkg/logs/internal/decoder/preprocessor/BUILD.bazel
+++ b/pkg/logs/internal/decoder/preprocessor/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "@com_github_datadog_datadog_agent_pkg_logs_util_testutils//:__subpackages__",
     ],
     deps = [
+        "//comp/anomalydetection/severityevents/def",
         "//comp/core/telemetry/def",
         "//comp/core/telemetry/impl",
         "//comp/logs-library/metrics",
@@ -63,6 +64,7 @@ dd_agent_go_test(
         "pattern_table_test.go",
         "preprocessor_test.go",
         "sampler_benchmark_test.go",
+        "sampler_smart_severity_profile_test.go",
         "sampler_test.go",
         "stack_trace_aggregator_test.go",
         "timestamp_detector_test.go",
@@ -73,6 +75,7 @@ dd_agent_go_test(
     ],
     embed = [":preprocessor"],
     deps = [
+        "//comp/anomalydetection/severityevents/def",
         "//comp/logs-library/metrics",
         "//comp/logs/agent/config",
         "//pkg/config/mock",

--- a/pkg/logs/internal/decoder/preprocessor/sampler.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	severityeventsdef "github.com/DataDog/datadog-agent/comp/anomalydetection/severityevents/def"
 	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
@@ -117,6 +118,23 @@ type AdaptiveSamplerConfig struct {
 	// message through without rate-limiting. Using a closure lets the check track
 	// ReplaceableSource swaps and future Remote Config updates.
 	IsSourceDisabled func() bool
+	// SmartSeverityProfilesEnabled switches RateLimit/BurstSize based on the level
+	// read from SeverityProvider (see Profiles). Profiles[SeverityLow] must match
+	// RateLimit/BurstSize above.
+	SmartSeverityProfilesEnabled bool
+	// Profiles holds the RateLimit/BurstSize pair per SeverityLevel.
+	// Only consulted when SmartSeverityProfilesEnabled is true.
+	Profiles [severityeventsdef.NumSeverityLevels]SamplerProfile
+	// SeverityProvider returns the current anomaly-detection severity level, or false
+	// when no reader is registered yet. Only consulted when SmartSeverityProfilesEnabled
+	// is true. Left nil in tests that don't exercise smart severity profiles.
+	SeverityProvider func() (severityeventsdef.SeverityLevel, bool)
+}
+
+// SamplerProfile is a RateLimit/BurstSize pair for one SeverityLevel.
+type SamplerProfile struct {
+	RateLimit float64
+	BurstSize float64
 }
 
 // AdaptiveSamplerFilter matches messages by raw-content regex, structural sample,
@@ -148,6 +166,13 @@ type AdaptiveSampler struct {
 	source            string // used as a telemetry tag
 	now               func() time.Time
 	baseBytesEstimate int
+
+	// appliedLevel tracks the last severity profile applied by
+	// applyProfileIfChanged. appliedLevelInitialized stays false until a real
+	// reader is registered, so the sampler does not treat the no-reader case as
+	// an implicit Low profile.
+	appliedLevel            severityeventsdef.SeverityLevel
+	appliedLevelInitialized bool
 }
 
 // NewAdaptiveSampler creates a new AdaptiveSampler.
@@ -219,6 +244,37 @@ func (s *AdaptiveSampler) appendPatternHashTagIfEnabled(msg *message.Message, to
 	}
 }
 
+// applyProfileIfChanged switches RateLimit/BurstSize to the currently published
+// level, when SmartSeverityProfilesEnabled is set. Escalation grants every
+// pattern a fresh burst immediately; de-escalation leaves credits untouched,
+// letting the refill-time clamp in processMatchedEntry shrink them naturally.
+func (s *AdaptiveSampler) applyProfileIfChanged() {
+	if s.config.SeverityProvider == nil {
+		return
+	}
+	level, ok := s.config.SeverityProvider()
+	if !ok {
+		return
+	}
+	if s.appliedLevelInitialized && level == s.appliedLevel {
+		return
+	}
+
+	profile := s.config.Profiles[level]
+	escalation := s.appliedLevelInitialized && level > s.appliedLevel
+	s.config.RateLimit = profile.RateLimit
+	s.config.BurstSize = profile.BurstSize
+
+	if escalation {
+		for i := range s.entries {
+			s.entries[i].credits = s.config.BurstSize
+		}
+	}
+
+	s.appliedLevel = level
+	s.appliedLevelInitialized = true
+}
+
 // Process applies credit-based rate limiting to the message.
 // Returns the message if allowed, nil if dropped.
 func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message.Message {
@@ -226,6 +282,9 @@ func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message
 	// space in the pattern table for them.
 	if !msg.HasContent() {
 		return msg
+	}
+	if s.config.SmartSeverityProfilesEnabled {
+		s.applyProfileIfChanged()
 	}
 	if s.config.IsSourceDisabled != nil && s.config.IsSourceDisabled() {
 		return msg

--- a/pkg/logs/internal/decoder/preprocessor/sampler.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler.go
@@ -246,8 +246,10 @@ func (s *AdaptiveSampler) appendPatternHashTagIfEnabled(msg *message.Message, to
 
 // applyProfileIfChanged switches RateLimit/BurstSize to the currently published
 // level, when SmartSeverityProfilesEnabled is set. Escalation grants every
-// pattern a fresh burst immediately; de-escalation leaves credits untouched,
-// letting the refill-time clamp in processMatchedEntry shrink them naturally.
+// pattern a fresh burst immediately. The first available Medium/High level is
+// also treated as an escalation from the base Low profile. De-escalation leaves
+// credits untouched, letting the refill-time clamp in processMatchedEntry
+// shrink them naturally.
 func (s *AdaptiveSampler) applyProfileIfChanged() {
 	if s.config.SeverityProvider == nil {
 		return
@@ -260,8 +262,11 @@ func (s *AdaptiveSampler) applyProfileIfChanged() {
 		return
 	}
 
+	wasInitialized := s.appliedLevelInitialized
+	previousLevel := s.appliedLevel
 	profile := s.config.Profiles[level]
-	escalation := s.appliedLevelInitialized && level > s.appliedLevel
+	escalation := (wasInitialized && level > previousLevel) ||
+		(!wasInitialized && level > severityeventsdef.SeverityLow)
 	s.config.RateLimit = profile.RateLimit
 	s.config.BurstSize = profile.BurstSize
 

--- a/pkg/logs/internal/decoder/preprocessor/sampler_smart_severity_profile_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_smart_severity_profile_test.go
@@ -1,0 +1,211 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package preprocessor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	severityeventsdef "github.com/DataDog/datadog-agent/comp/anomalydetection/severityevents/def"
+)
+
+// activateSeverity returns a SeverityProvider (to be assigned to
+// AdaptiveSamplerConfig.SeverityProvider) and an emit function that simulates severity
+// transitions, without depending on a real severity reader/scorer.
+func activateSeverity() (provider func() (severityeventsdef.SeverityLevel, bool), emit func(severityeventsdef.SeverityLevel)) {
+	var level severityeventsdef.SeverityLevel
+	var active bool
+	return func() (severityeventsdef.SeverityLevel, bool) {
+			return level, active
+		}, func(toLevel severityeventsdef.SeverityLevel) {
+			level = toLevel
+			active = true
+		}
+}
+
+// testProfiles mirrors Low into Medium and makes High much more permissive,
+// so escalation is easy to observe.
+func testProfiles() [severityeventsdef.NumSeverityLevels]SamplerProfile {
+	return [severityeventsdef.NumSeverityLevels]SamplerProfile{
+		severityeventsdef.SeverityLow:    {RateLimit: 1, BurstSize: 5},
+		severityeventsdef.SeverityMedium: {RateLimit: 1, BurstSize: 5},
+		severityeventsdef.SeverityHigh:   {RateLimit: 10, BurstSize: 100},
+	}
+}
+
+func newAnomalyProfileSampler(profiles [severityeventsdef.NumSeverityLevels]SamplerProfile, provider func() (severityeventsdef.SeverityLevel, bool)) *AdaptiveSampler {
+	low := profiles[severityeventsdef.SeverityLow]
+	return NewAdaptiveSampler(AdaptiveSamplerConfig{
+		MaxPatterns:                  10,
+		RateLimit:                    low.RateLimit,
+		BurstSize:                    low.BurstSize,
+		MatchThreshold:               0.9,
+		SmartSeverityProfilesEnabled: true,
+		Profiles:                     profiles,
+		SeverityProvider:             provider,
+	}, "test", 0)
+}
+
+func TestAdaptiveSampler_SmartSeverityProfilesDisabled_IgnoresPublishedLevel(t *testing.T) {
+	provider, emit := activateSeverity()
+	emit(severityeventsdef.SeverityHigh)
+
+	s := newSampler(10, 5, 1)
+	s.config.SeverityProvider = provider
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	assert.Equal(t, 1.0, s.config.RateLimit)
+	assert.Equal(t, 5.0, s.config.BurstSize)
+}
+
+func TestAdaptiveSampler_NewSamplerPicksUpActiveLevelOnFirstMessage(t *testing.T) {
+	provider, emit := activateSeverity()
+	emit(severityeventsdef.SeverityHigh)
+
+	s := newAnomalyProfileSampler(testProfiles(), provider)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	assert.Equal(t, 10.0, s.config.RateLimit)
+	assert.Equal(t, 100.0, s.config.BurstSize)
+}
+
+func TestAdaptiveSampler_EscalationGrantsFreshBurstImmediately(t *testing.T) {
+	provider, emit := activateSeverity()
+	emit(severityeventsdef.SeverityLow)
+
+	s := newAnomalyProfileSampler(testProfiles(), provider)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	for i := 0; i < 5; i++ {
+		require.NotNilf(t, s.Process(testMsg(), patternA), "message %d should fit in the initial burst", i)
+	}
+	require.Nil(t, s.Process(testMsg(), patternA), "burst is exhausted")
+
+	emit(severityeventsdef.SeverityHigh)
+
+	out := s.Process(testMsg(), patternA)
+	require.NotNil(t, out, "fresh burst applied before matching, despite zero elapsed time")
+	assert.Equal(t, 10.0, s.config.RateLimit)
+	assert.Equal(t, 100.0, s.config.BurstSize)
+}
+
+func TestAdaptiveSampler_DeescalationClampsCreditsNaturallyWithoutForcedReset(t *testing.T) {
+	provider, emit := activateSeverity()
+	emit(severityeventsdef.SeverityHigh)
+
+	s := newAnomalyProfileSampler(testProfiles(), provider)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	require.Len(t, s.entries, 1)
+	require.InDelta(t, 99.0, s.entries[0].credits, 0.0001, "new pattern seeds BurstSize-1 credits")
+
+	emit(severityeventsdef.SeverityLow)
+
+	// No forced reset: the refill-time clamp in processMatchedEntry shrinks
+	// credits to the new BurstSize on the next match instead.
+	out := s.Process(testMsg(), patternA)
+	require.NotNil(t, out, "clamped credits (5) still satisfy the >=1 check")
+	assert.Equal(t, 1.0, s.config.RateLimit)
+	assert.Equal(t, 5.0, s.config.BurstSize)
+	assert.InDelta(t, 4.0, s.entries[0].credits, 0.0001, "clamped to 5, then one credit spent")
+}
+
+func TestAdaptiveSampler_EscalationResetsEveryTrackedPattern(t *testing.T) {
+	provider, emit := activateSeverity()
+	emit(severityeventsdef.SeverityLow)
+
+	s := newAnomalyProfileSampler(testProfiles(), provider)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	require.NotNil(t, s.Process(testMsg(), patternB))
+	require.Len(t, s.entries, 2)
+
+	emit(severityeventsdef.SeverityHigh)
+	// Escalation resets every tracked pattern, not just the matched one.
+	require.NotNil(t, s.Process(testMsg(), patternA))
+
+	require.Len(t, s.entries, 2)
+	assert.InDelta(t, 99.0, s.entries[0].credits, 0.0001, "patternA: reset to 100, then one credit spent")
+	assert.InDelta(t, 100.0, s.entries[1].credits, 0.0001, "patternB: reset to 100, untouched by the match")
+}
+
+func TestAdaptiveSampler_MultipleStepTransitionsApplyEachProfile(t *testing.T) {
+	provider, emit := activateSeverity()
+	emit(severityeventsdef.SeverityLow)
+
+	profiles := [severityeventsdef.NumSeverityLevels]SamplerProfile{
+		severityeventsdef.SeverityLow:    {RateLimit: 1, BurstSize: 5},
+		severityeventsdef.SeverityMedium: {RateLimit: 4, BurstSize: 20},
+		severityeventsdef.SeverityHigh:   {RateLimit: 10, BurstSize: 100},
+	}
+	s := newAnomalyProfileSampler(profiles, provider)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	require.Len(t, s.entries, 1)
+	assert.Equal(t, 1.0, s.config.RateLimit)
+	assert.Equal(t, 5.0, s.config.BurstSize)
+	assert.InDelta(t, 4.0, s.entries[0].credits, 0.0001)
+
+	emit(severityeventsdef.SeverityMedium)
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	assert.Equal(t, 4.0, s.config.RateLimit)
+	assert.Equal(t, 20.0, s.config.BurstSize)
+	assert.InDelta(t, 19.0, s.entries[0].credits, 0.0001, "escalation to medium resets burst, then spends one credit")
+
+	emit(severityeventsdef.SeverityHigh)
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	assert.Equal(t, 10.0, s.config.RateLimit)
+	assert.Equal(t, 100.0, s.config.BurstSize)
+	assert.InDelta(t, 99.0, s.entries[0].credits, 0.0001, "escalation to high resets burst, then spends one credit")
+
+	emit(severityeventsdef.SeverityMedium)
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	assert.Equal(t, 4.0, s.config.RateLimit)
+	assert.Equal(t, 20.0, s.config.BurstSize)
+	assert.InDelta(t, 19.0, s.entries[0].credits, 0.0001, "de-escalation to medium clamps to new burst, then spends one credit")
+
+	emit(severityeventsdef.SeverityLow)
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	assert.Equal(t, 1.0, s.config.RateLimit)
+	assert.Equal(t, 5.0, s.config.BurstSize)
+	assert.InDelta(t, 4.0, s.entries[0].credits, 0.0001, "de-escalation to low clamps again, then spends one credit")
+}
+
+func TestAdaptiveSampler_NewPatternAfterSeverityChangeUsesActiveProfile(t *testing.T) {
+	provider, emit := activateSeverity()
+	emit(severityeventsdef.SeverityLow)
+
+	s := newAnomalyProfileSampler(testProfiles(), provider)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	require.Len(t, s.entries, 1)
+	assert.InDelta(t, 4.0, s.entries[0].credits, 0.0001, "low profile seeds BurstSize-1 credits")
+
+	emit(severityeventsdef.SeverityHigh)
+	require.NotNil(t, s.Process(testMsg(), patternB))
+
+	require.Len(t, s.entries, 2)
+	assert.Equal(t, 10.0, s.config.RateLimit)
+	assert.Equal(t, 100.0, s.config.BurstSize)
+	assert.InDelta(t, 100.0, s.entries[0].credits, 0.0001, "existing pattern is reset on escalation before the new pattern is tracked")
+	assert.InDelta(t, 99.0, s.entries[1].credits, 0.0001, "new pattern seeds High BurstSize-1 credits after the severity change")
+}

--- a/pkg/logs/internal/decoder/preprocessor/sampler_smart_severity_profile_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_smart_severity_profile_test.go
@@ -100,6 +100,29 @@ func TestAdaptiveSampler_EscalationGrantsFreshBurstImmediately(t *testing.T) {
 	assert.Equal(t, 100.0, s.config.BurstSize)
 }
 
+func TestAdaptiveSampler_FirstAvailableHigherSeverityGrantsFreshBurst(t *testing.T) {
+	provider, emit := activateSeverity()
+	s := newAnomalyProfileSampler(testProfiles(), provider)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	// Before a severity is available, the sampler uses the base Low profile and
+	// can exhaust an existing pattern's credits.
+	for i := 0; i < 5; i++ {
+		require.NotNilf(t, s.Process(testMsg(), patternA), "message %d should fit in the base burst", i)
+	}
+	require.Nil(t, s.Process(testMsg(), patternA), "base burst is exhausted")
+	require.False(t, s.appliedLevelInitialized, "an unavailable provider must not be treated as a reported Low severity")
+
+	// The first available High profile is an escalation from the effective base
+	// Low profile, so existing entries receive High's burst immediately.
+	emit(severityeventsdef.SeverityHigh)
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	assert.True(t, s.appliedLevelInitialized)
+	assert.Equal(t, severityeventsdef.SeverityHigh, s.appliedLevel)
+	assert.InDelta(t, 99.0, s.entries[0].credits, 0.0001)
+}
+
 func TestAdaptiveSampler_DeescalationClampsCreditsNaturallyWithoutForcedReset(t *testing.T) {
 	provider, emit := activateSeverity()
 	emit(severityeventsdef.SeverityHigh)

--- a/test/new-e2e/tests/anomalydetection/anomalydetection_nix_test.go
+++ b/test/new-e2e/tests/anomalydetection/anomalydetection_nix_test.go
@@ -74,17 +74,6 @@ anomaly_detection:
 	))
 }
 
-// sendGauge sends one DogStatsD gauge over UDP to the local agent.
-// Uses Execute rather than MustExecute: a transient SSH error in the background
-// goroutine would otherwise propagate as an unrecovered panic, terminating the
-// test process and tearing down the DEV_MODE stack before assertions complete.
-func (s *metricsTriggeredSuite) sendGauge(name string, value float64) {
-	cmd := fmt.Sprintf("bash -c 'echo -n \"%s:%f|g\" > /dev/udp/127.0.0.1/8125'", name, value)
-	if _, err := s.Env().RemoteHost.Execute(cmd); err != nil {
-		s.T().Logf("sendGauge(%q, %f): SSH error (metric may not have been sent): %v", name, value, err)
-	}
-}
-
 // TestMetricsTriggeredEmitsOnDSDSpike sends a stable gauge baseline then a large
 // spike, expecting CUSUM to fire and the stdout reporter to emit its marker.
 //
@@ -124,7 +113,7 @@ func (s *metricsTriggeredSuite) TestMetricsTriggeredEmitsOnDSDSpike() {
 				return
 			default:
 			}
-			s.sendGauge(metricName, baseline)
+			sendGauge(s, metricName, baseline)
 			if (i+1)%10 == 0 {
 				s.T().Logf("baseline: sent %d/%d", i+1, baselinePoints)
 			}
@@ -141,7 +130,7 @@ func (s *metricsTriggeredSuite) TestMetricsTriggeredEmitsOnDSDSpike() {
 				return
 			default:
 			}
-			s.sendGauge(metricName, spike)
+			sendGauge(s, metricName, spike)
 			if (i+1)%10 == 0 {
 				s.T().Logf("spike: sent %d/%d", i+1, spikePoints)
 			}

--- a/test/new-e2e/tests/anomalydetection/helpers_test.go
+++ b/test/new-e2e/tests/anomalydetection/helpers_test.go
@@ -163,6 +163,17 @@ func waitForScorerHelperReady(s observerTestSuite) {
 	s.T().Log("anomaly scorer helper registered")
 }
 
+// sendGauge sends one DogStatsD gauge over UDP to the local agent.
+// Uses Execute rather than MustExecute: a transient SSH error in a background
+// goroutine would otherwise propagate as an unrecovered panic, terminating the
+// test process and tearing down the DEV_MODE stack before assertions complete.
+func sendGauge(s observerTestSuite, name string, value float64) {
+	cmd := fmt.Sprintf("bash -c 'echo -n \"%s:%f|g\" > /dev/udp/127.0.0.1/8125'", name, value)
+	if _, err := s.Env().RemoteHost.Execute(cmd); err != nil {
+		s.T().Logf("sendGauge(%q, %f): SSH error (metric may not have been sent): %v", name, value, err)
+	}
+}
+
 func waitForReportsTelemetry(s observerTestSuite) {
 	s.T().Helper()
 	s.T().Log("waiting for observer reports telemetry...")

--- a/test/new-e2e/tests/anomalydetection/scorer_helper_nix_test.go
+++ b/test/new-e2e/tests/anomalydetection/scorer_helper_nix_test.go
@@ -98,14 +98,6 @@ anomaly_detection:
 	), e2e.WithStackName("anomalydetection-scorer-helper"))
 }
 
-// sendHelperGauge sends one DogStatsD gauge over UDP to the local agent.
-func (s *scorerHelperSuite) sendHelperGauge(name string, value float64) {
-	cmd := fmt.Sprintf("bash -c 'echo -n \"%s:%f|g\" > /dev/udp/127.0.0.1/8125'", name, value)
-	if _, err := s.Env().RemoteHost.Execute(cmd); err != nil {
-		s.T().Logf("sendHelperGauge(%q, %f): SSH error (metric may not have been sent): %v", name, value, err)
-	}
-}
-
 // TestScorerHelperEmitsSeverityTransitionOnMultiSeriesSpike sends a stable baseline
 // on 20 metric series then spikes all 20 simultaneously. CUSUM fires on every analysis
 // cycle while the spike is active (continuous re-emission), so the scorer EWMA rises
@@ -150,7 +142,7 @@ func (s *scorerHelperSuite) TestScorerHelperEmitsSeverityTransitionOnMultiSeries
 			default:
 			}
 			for n := 0; n < seriesCount; n++ {
-				s.sendHelperGauge(fmt.Sprintf("%s%d", metricPrefix, n), baseline)
+				sendGauge(s, fmt.Sprintf("%s%d", metricPrefix, n), baseline)
 			}
 			if (i+1)%5 == 0 {
 				s.T().Logf("baseline: tick %d/%d", i+1, baselinePoints)
@@ -172,7 +164,7 @@ func (s *scorerHelperSuite) TestScorerHelperEmitsSeverityTransitionOnMultiSeries
 			default:
 			}
 			for n := 0; n < seriesCount; n++ {
-				s.sendHelperGauge(fmt.Sprintf("%s%d", metricPrefix, n), spike)
+				sendGauge(s, fmt.Sprintf("%s%d", metricPrefix, n), spike)
 			}
 			if (i+1)%5 == 0 {
 				s.T().Logf("spike: tick %d/%d", i+1, spikePoints)

--- a/test/new-e2e/tests/anomalydetection/smart_adaptive_log_sampling_nix_test.go
+++ b/test/new-e2e/tests/anomalydetection/smart_adaptive_log_sampling_nix_test.go
@@ -1,0 +1,322 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package anomalydetection
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	logutils "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-log-pipelines/utils"
+)
+
+const (
+	smartSeverityLogFileName = "smart-severity-profiles.log"
+	smartSeverityLogFilePath = logutils.LinuxLogsFolderPath + "/" + smartSeverityLogFileName
+	smartSeverityService     = "smart-severity-e2e"
+	smartSeverityScorerEWMA  = "observer.scorer.ewma"
+	smartSeverityScorerState = "observer.scorer.state"
+
+	smartSeverityFakeintakeTick = 10 * time.Second
+	smartSeverityLowThreshold   = 0.04
+	smartSeverityStartupTicks   = 1
+
+	// In noisy-log-detection (dry-run) mode, logs that would have been dropped
+	// are still forwarded but tagged with noisy_log:true.
+	smartSeverityNoisyLogTag = "noisy_log:true"
+)
+
+// smartSeverityProfilesSuite validates that smart severity profiles:
+//   - activate scorer telemetry when smart severity is enabled,
+//   - drive adaptive sampling via scorer transitions, and
+//   - change delivered log volume as the scorer transitions Low -> Medium -> Low.
+type smartSeverityProfilesSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+func TestSmartSeverityProfilesAdaptiveSampling(t *testing.T) {
+	t.Parallel()
+
+	// language=yaml
+	logConfig := `
+logs:
+  - type: file
+    path: /var/log/e2e_test_logs/smart-severity-profiles.log
+    service: smart-severity-e2e
+    source: e2e
+    experimental_noisy_log_detection: true
+`
+
+	// language=yaml
+	agentConfig := `
+log_level: debug
+logs_config:
+  file_scan_period: 1
+  experimental_noisy_log_detection: true
+  experimental_adaptive_sampling:
+    enabled: false
+    rate_limit: 0.01
+    burst_size: 1
+    protect_important_logs: false
+    smart_severity_profiles:
+      enabled: true
+      medium:
+        rate_limit: 1000
+        burst_size: 200
+      high:
+        rate_limit: 1000
+        burst_size: 200
+anomaly_detection:
+  metrics:
+    enabled: true
+    # Discard everything except our own test metric, so the EWMA is only ever
+    # driven by the spikes/baselines this test sends, never by unrelated
+    # DogStatsD traffic. Rules are evaluated in order, first match wins.
+    processing_rules:
+      - type: include_at_match
+        name: keep_smartseverity_metric
+        name_pattern: "e2e.anomalydetection.smartseverity.s*"
+      - type: exclude_at_match
+        name: drop_everything_else
+  logs:
+    enabled: false
+    internal:
+      enabled: false
+  anomaly_scorer:
+    alpha: 0.3
+    window: 5s
+    low_threshold: 0.04
+    high_threshold: 0.50
+    margin_pct: 0.1
+    output:
+      cooldown: 2s
+  detectors:
+    cusum:
+      enabled: true
+    bocpd:
+      enabled: false
+    holt_residual:
+      enabled: false
+    tukey_biweight:
+      enabled: false
+` + baselineAnalysisDisabledYAML
+
+	e2e.Run(t, &smartSeverityProfilesSuite{}, e2e.WithProvisioner(
+		awshost.Provisioner(
+			awshost.WithRunOptions(scenec2.WithAgentOptions(
+				agentparams.WithLogs(),
+				agentparams.WithTelemetry(),
+				agentparams.WithAgentConfig(agentConfig),
+				agentparams.WithIntegration("custom_logs.d", logConfig),
+			)),
+		),
+	), e2e.WithStackName("anomalydetection-smart-severity-profiles"))
+}
+
+func (s *smartSeverityProfilesSuite) BeforeTest(suiteName, testName string) {
+	s.BaseSuite.BeforeTest(suiteName, testName)
+	logutils.CleanUp(s)
+	s.Env().RemoteHost.MustExecute("sudo mkdir -p " + logutils.LinuxLogsFolderPath)
+	s.Env().RemoteHost.MustExecute("sudo rm -f " + smartSeverityLogFilePath)
+	s.Env().RemoteHost.MustExecute("sudo touch " + smartSeverityLogFilePath)
+	s.Env().RemoteHost.MustExecute("sudo chmod 644 " + smartSeverityLogFilePath)
+}
+
+func (s *smartSeverityProfilesSuite) TearDownSuite() {
+	logutils.CleanUp(s)
+	s.BaseSuite.TearDownSuite()
+}
+
+func (s *smartSeverityProfilesSuite) TestSmartSeverityProfilesDriveAdaptiveSampling() {
+	const (
+		seriesCount   = 8
+		metricPrefix  = "e2e.anomalydetection.smartseverity.s"
+		baseline      = 1.0
+		spike         = 5000.0
+		baselineTicks = 8
+		spikeTicks    = 5
+		logBurst      = 12
+	)
+
+	lowMessage := "smart severity low phase"
+	mediumMessage := "smart severity medium phase"
+
+	// 1. Init (low)
+	s.T().Log("starting smart severity adaptive sampling test")
+	logutils.AssertAgentTailerOK(s, smartSeverityLogFileName)
+	s.T().Log("waiting for scorer registration, smart severity profiles must enable anomaly detection + the scorer")
+	waitForScorerHelperReady(s)
+	s.waitForStartupLowProfile(metricPrefix, seriesCount, baseline)
+
+	s.T().Logf("phase=low-log-burst message=%q count=%d", lowMessage, logBurst)
+	s.appendRepeatedLog(lowMessage, logBurst)
+	lowLogs := s.waitForLogsDelivered(lowMessage, logBurst)
+	lowCount := len(lowLogs)
+	lowNoisy := countLogsWithTag(lowLogs, smartSeverityNoisyLogTag)
+	s.T().Logf("phase=low-log-burst delivered=%d noisy=%d", lowCount, lowNoisy)
+	require.Greater(s.T(), lowNoisy, 0, "expected low-phase logs to be tagged noisy in dry-run mode")
+
+	// 2. Anomaly (medium/high)
+	s.T().Log("triggering anomaly")
+	s.T().Logf("phase=baseline metrics prefix=%s series=%d ticks=%d value=%.1f", metricPrefix, seriesCount, baselineTicks, baseline)
+	s.sendMetricTicks(metricPrefix, seriesCount, baseline, baselineTicks)
+	s.T().Logf("phase=spike metrics prefix=%s series=%d ticks=%d value=%.1f", metricPrefix, seriesCount, spikeTicks, spike)
+	s.sendMetricTicks(metricPrefix, seriesCount, spike, spikeTicks)
+	s.T().Log("waiting for scorer escalation state")
+	s.waitForScorerState("direction:escalation")
+
+	s.T().Logf("phase=medium-log-burst message=%q count=%d", mediumMessage, logBurst)
+	s.appendRepeatedLog(mediumMessage, logBurst)
+	mediumLogs := s.waitForLogsDelivered(mediumMessage, logBurst)
+	mediumCount := len(mediumLogs)
+	mediumNoisy := countLogsWithTag(mediumLogs, smartSeverityNoisyLogTag)
+	s.T().Logf("phase=medium-log-burst delivered=%d noisy=%d", mediumCount, mediumNoisy)
+	require.Zero(s.T(), mediumNoisy, "expected medium-phase logs to avoid noisy tagging in dry-run mode")
+
+	s.T().Logf(
+		"adaptive sampling dry-run delivered low=%d medium=%d logs; noisy low=%d medium=%d",
+		lowCount,
+		mediumCount,
+		lowNoisy,
+		mediumNoisy,
+	)
+
+	require.Greater(s.T(), lowNoisy, mediumNoisy, "low severity should tag more logs noisy than medium severity in dry-run mode")
+}
+
+func (s *smartSeverityProfilesSuite) sendMetricTicks(metricPrefix string, seriesCount int, value float64, ticks int) {
+	s.T().Helper()
+	s.T().Logf("sending metric ticks prefix=%s series=%d ticks=%d value=%.1f", metricPrefix, seriesCount, ticks, value)
+	for tick := 0; tick < ticks; tick++ {
+		for series := 0; series < seriesCount; series++ {
+			sendGauge(s, fmt.Sprintf("%s%d", metricPrefix, series), value)
+		}
+		s.T().Logf("sent metric tick %d/%d value=%.1f", tick+1, ticks, value)
+		time.Sleep(time.Second)
+	}
+	s.T().Logf("finished sending metric ticks prefix=%s value=%.1f", metricPrefix, value)
+}
+
+func (s *smartSeverityProfilesSuite) appendRepeatedLog(message string, count int) {
+	s.T().Helper()
+	s.T().Logf("appending repeated logs message=%q count=%d", message, count)
+	logutils.AppendLog(s, smartSeverityLogFileName, message, count)
+}
+
+// waitForStartupLowProfile nudges the scorer with stable baseline input and waits
+// for the EWMA to settle back under the configured low threshold before the first
+// low-phase log burst. This avoids assuming the scorer starts clean when a reused
+// dev-mode agent may still carry some prior non-zero EWMA state.
+func (s *smartSeverityProfilesSuite) waitForStartupLowProfile(metricPrefix string, seriesCount int, baseline float64) {
+	s.T().Helper()
+	s.T().Logf(
+		"settling scorer toward low profile with %d baseline ticks before low-phase logs",
+		smartSeverityStartupTicks,
+	)
+	// Wake up the scorer with some data
+	s.sendMetricTicks(metricPrefix, seriesCount, baseline, smartSeverityStartupTicks)
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		tel := observerTelemetryOutput(s)
+		line := findMetricLine(tel, metricNameVariants(smartSeverityScorerEWMA)...)
+		s.T().Logf("startup low-profile probe ewma line=%q", line)
+		require.NotEmpty(c, line, "expected scorer ewma telemetry while settling startup state")
+		ewma, ok := scorerStateValue(line)
+		require.True(c, ok, "could not parse scorer ewma value from line %q", line)
+		require.LessOrEqual(c, ewma, smartSeverityLowThreshold,
+			"expected startup ewma %.6f to be at or below low threshold %.2f before low-phase logs",
+			ewma, smartSeverityLowThreshold,
+		)
+	}, 2*time.Minute, 3*time.Second)
+}
+
+func (s *smartSeverityProfilesSuite) waitForScorerState(directionTag string) {
+	s.T().Helper()
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		tel := observerTelemetryOutput(s)
+		tagParts := strings.SplitN(directionTag, ":", 2)
+		require.Len(s.T(), tagParts, 2, "direction tag must be key:value")
+		s.T().Logf(
+			"poll scorer state telemetry: present=%t wanted_tag=%q tagged=%t",
+			containsMetric(tel, smartSeverityScorerState),
+			directionTag,
+			containsMetricWithTag(tel, smartSeverityScorerState, tagParts[0], tagParts[1]),
+		)
+		line := findMetricLine(tel, metricNameVariants(smartSeverityScorerState)...)
+		if line != "" {
+			s.T().Logf("sample scorer state line=%s", line)
+		}
+		require.True(c, containsMetric(tel, smartSeverityScorerState), "expected scorer state telemetry")
+		require.True(c, containsMetricWithTag(tel, smartSeverityScorerState, tagParts[0], tagParts[1]),
+			"expected scorer state telemetry tagged with %s", directionTag)
+	}, 2*time.Minute, smartSeverityFakeintakeTick)
+}
+
+// waitForLogsDelivered polls fakeintake until at least wantCount logs matching
+// message have been delivered, then returns them. Fetches are cumulative
+// (fakeintake never drops previously-seen payloads), so the count only grows;
+// waiting for ">=" rather than "==" avoids getting stuck if delivery
+// occasionally over-delivers (e.g. an agent-side retry redelivering a line).
+func (s *smartSeverityProfilesSuite) waitForLogsDelivered(message string, wantCount int) []*aggregator.Log {
+	s.T().Helper()
+	var delivered []*aggregator.Log
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		logs, err := logutils.FetchAndFilterLogs(s.Env().FakeIntake, smartSeverityService, message)
+		require.NoError(c, err, "failed to fetch logs for %q", message)
+		noisy := countLogsWithTag(logs, smartSeverityNoisyLogTag)
+		s.T().Logf("poll logs message=%q delivered=%d/%d noisy=%d err=%v", message, len(logs), wantCount, noisy, err)
+		require.GreaterOrEqual(c, len(logs), wantCount, "expected at least %d delivered logs for %q", wantCount, message)
+		delivered = logs
+	}, 1*time.Minute, smartSeverityFakeintakeTick)
+	return delivered
+}
+
+func countLogsWithTag(logs []*aggregator.Log, want string) int {
+	count := 0
+	for _, log := range logs {
+		for _, tag := range log.GetTags() {
+			if tag == want {
+				count++
+				break
+			}
+		}
+	}
+	return count
+}
+
+func findMetricLine(output string, prefixes ...string) string {
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(trimmed, prefix) {
+				return trimmed
+			}
+		}
+	}
+	return ""
+}
+
+func scorerStateValue(line string) (float64, bool) {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return 0, false
+	}
+	value, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+	return value, err == nil
+}


### PR DESCRIPTION
### What does this PR do?

> [!NOTE]
> [Feature documentation](https://datadoghq.atlassian.net/wiki/x/EgK5nQE).

This links anomaly detection events to adaptive sampling to have different profiles given severity state.

```yaml
logs_config:
  experimental_adaptive_sampling:
    enabled: true
    rate_limit: 1
    burst_size: 100
    # New config
    smart_severity_profiles:
      enabled: true
      medium:
        rate_limit: 1
        burst_size: 1000
      high:
        rate_limit: 100
        burst_size: 1000
```

Adds:

- Logic to `preprocessor/sampler.go` such that it reads the `severityevents` state and apply the specific sampling profile given the severity
- `smart_adaptive_log_sampling_nix_test.go` e2e test to test this feature (1. check high sampling in low state, 2. check low sampling in high state)

### Motivation

### Describe how you validated your changes

1. Config smart severity profiles + adaptive sampling
2. The low profile must be the first one applied
3. When we have anomalies (medium / high severity), the other profiles must be set. We can set the burst size to a high value and check if bursts of logs are sent or not

There is an e2e tests for this.

### Additional Notes

Passthrough / cooldown are left for a [future PR](https://github.com/DataDog/datadog-agent/pull/53432).

<img width="573" height="800" alt="Screenshot 2026-07-09 at 09 41 50" src="https://github.com/user-attachments/assets/343e59d4-ab53-4977-8f81-071dbc2cbe6d" />

[AAD-4]: https://datadoghq.atlassian.net/browse/AAD-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ