### PR TITLE
[anomalydetection] Smart adaptive log sampling extra 4/4

### DIFF
--- a/comp/logs/severityprovider/impl/BUILD.bazel
+++ b/comp/logs/severityprovider/impl/BUILD.bazel
@@ -34,6 +34,7 @@ dd_agent_go_test(
         "//comp/anomalydetection/config",
         "//comp/anomalydetection/observer/def",
         "//comp/anomalydetection/severityevents/def",
+        "//comp/anomalydetection/severityevents/impl",
         "//comp/core/config",
         "//comp/core/log/def",
         "//comp/def",

--- a/comp/logs/severityprovider/impl/severityprovider.go
+++ b/comp/logs/severityprovider/impl/severityprovider.go
@@ -11,6 +11,7 @@ package severityproviderimpl
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	anomalydetectionconfig "github.com/DataDog/datadog-agent/comp/anomalydetection/config"
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
@@ -43,6 +44,18 @@ type component struct {
 	reader atomic.Pointer[readerState]
 }
 
+const smartSeverityProfilesCooldownConfigKey = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.cooldown"
+
+// smartSeverityProfilesSubscriptionConfig returns the reader configuration for
+// smart severity profiles. CooldownSecs has whole-second granularity, so
+// sub-second values are rounded rather than truncated to zero.
+func smartSeverityProfilesSubscriptionConfig(cfg config.Component) severityeventsdef.SeverityEventsConfiguration {
+	cooldown := cfg.GetDuration(smartSeverityProfilesCooldownConfigKey)
+	return severityeventsdef.SeverityEventsConfiguration{
+		CooldownSecs: int64(cooldown.Round(time.Second) / time.Second),
+	}
+}
+
 // NewComponent creates the severity provider component.
 func NewComponent(reqs Requires) (Provides, error) {
 	comp := &component{}
@@ -60,7 +73,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 				return nil
 			}
 
-			subscription, err := observer.SubscribeSeverityEventsReader(severityeventsdef.SeverityEventsConfiguration{})
+			subscription, err := observer.SubscribeSeverityEventsReader(smartSeverityProfilesSubscriptionConfig(reqs.Config))
 			if err != nil {
 				return err
 			}

--- a/comp/logs/severityprovider/impl/severityprovider_test.go
+++ b/comp/logs/severityprovider/impl/severityprovider_test.go
@@ -18,6 +18,7 @@ import (
 	anomalydetectionconfig "github.com/DataDog/datadog-agent/comp/anomalydetection/config"
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 	severityeventsdef "github.com/DataDog/datadog-agent/comp/anomalydetection/severityevents/def"
+	severityeventsimpl "github.com/DataDog/datadog-agent/comp/anomalydetection/severityevents/impl"
 	config "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
@@ -53,13 +54,23 @@ type fakeObserverComponent struct {
 	err               error
 	unsubscribeCalled bool
 	config            severityeventsdef.SeverityEventsConfiguration
+	dispatcher        *severityeventsimpl.Dispatcher
 }
 
 func (f *fakeObserverComponent) GetHandle(string) observerdef.Handle { return nil }
 func (f *fakeObserverComponent) RecordSamplerDropped(string, string) {}
 func (f *fakeObserverComponent) DumpMetrics(string) error            { return nil }
-func (f *fakeObserverComponent) SubscribeSeverityEvents(severityeventsdef.SeverityEventsConfiguration, severityeventsdef.SeverityEventListener) (severityeventsdef.SeverityEventsSubscription, error) {
-	return severityeventsdef.SeverityEventsSubscription{}, nil
+func (f *fakeObserverComponent) SubscribeSeverityEvents(cfg severityeventsdef.SeverityEventsConfiguration, listener severityeventsdef.SeverityEventListener) (severityeventsdef.SeverityEventsSubscription, error) {
+	if f.err != nil {
+		return severityeventsdef.SeverityEventsSubscription{}, f.err
+	}
+	f.dispatcher = severityeventsimpl.NewDispatcher(cfg, listener)
+	return severityeventsdef.SeverityEventsSubscription{
+		Dispatcher: f.dispatcher,
+		Unsubscribe: func() {
+			f.unsubscribeCalled = true
+		},
+	}, nil
 }
 
 func (f *fakeObserverComponent) SubscribeSeverityEventsReader(cfg severityeventsdef.SeverityEventsConfiguration) (severityeventsdef.SeverityEventsReaderSubscription, error) {
@@ -67,7 +78,14 @@ func (f *fakeObserverComponent) SubscribeSeverityEventsReader(cfg severityevents
 	if f.err != nil {
 		return severityeventsdef.SeverityEventsReaderSubscription{}, f.err
 	}
+	if f.sub.Reader == nil {
+		return severityeventsimpl.NewSeverityReader(f, cfg)
+	}
 	return f.sub, nil
+}
+
+func (f *fakeObserverComponent) advance(sec int64, level severityeventsdef.SeverityLevel) {
+	f.dispatcher.Advance(sec, level)
 }
 
 var _ observerdef.Component = (*fakeObserverComponent)(nil)
@@ -133,4 +151,28 @@ func TestLifecycleRegistersAndUnsubscribesReader(t *testing.T) {
 	assert.True(t, observer.unsubscribeCalled)
 	_, ok = comp.Current()
 	assert.False(t, ok)
+}
+
+func TestLifecycleReaderHonorsSmartSeverityProfilesCooldown(t *testing.T) {
+	observer := &fakeObserverComponent{}
+	comp, lifecycle := newComponent(t, true, 10*time.Second, option.New[observerdef.Component](observer))
+
+	require.NoError(t, lifecycle.Start(context.Background()))
+	require.NotNil(t, observer.dispatcher)
+	assert.Equal(t, int64(10), observer.config.CooldownSecs)
+
+	observer.advance(100, severityeventsdef.SeverityHigh)
+	level, ok := comp.Current()
+	require.True(t, ok)
+	assert.Equal(t, severityeventsdef.SeverityHigh, level)
+
+	observer.advance(101, severityeventsdef.SeverityLow)
+	level, ok = comp.Current()
+	require.True(t, ok)
+	assert.Equal(t, severityeventsdef.SeverityHigh, level, "cooldown must delay the reader's de-escalation")
+
+	observer.advance(110, severityeventsdef.SeverityLow)
+	level, ok = comp.Current()
+	require.True(t, ok)
+	assert.Equal(t, severityeventsdef.SeverityLow, level)
 }

--- a/comp/logs/severityprovider/impl/severityprovider_test.go
+++ b/comp/logs/severityprovider/impl/severityprovider_test.go
@@ -10,6 +10,7 @@ package severityproviderimpl
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,6 +52,7 @@ type fakeObserverComponent struct {
 	sub               severityeventsdef.SeverityEventsReaderSubscription
 	err               error
 	unsubscribeCalled bool
+	config            severityeventsdef.SeverityEventsConfiguration
 }
 
 func (f *fakeObserverComponent) GetHandle(string) observerdef.Handle { return nil }
@@ -60,7 +62,8 @@ func (f *fakeObserverComponent) SubscribeSeverityEvents(severityeventsdef.Severi
 	return severityeventsdef.SeverityEventsSubscription{}, nil
 }
 
-func (f *fakeObserverComponent) SubscribeSeverityEventsReader(severityeventsdef.SeverityEventsConfiguration) (severityeventsdef.SeverityEventsReaderSubscription, error) {
+func (f *fakeObserverComponent) SubscribeSeverityEventsReader(cfg severityeventsdef.SeverityEventsConfiguration) (severityeventsdef.SeverityEventsReaderSubscription, error) {
+	f.config = cfg
 	if f.err != nil {
 		return severityeventsdef.SeverityEventsReaderSubscription{}, f.err
 	}
@@ -69,13 +72,14 @@ func (f *fakeObserverComponent) SubscribeSeverityEventsReader(severityeventsdef.
 
 var _ observerdef.Component = (*fakeObserverComponent)(nil)
 
-func newComponent(t *testing.T, enabled bool, observer option.Option[observerdef.Component]) (*component, *compdef.TestLifecycle) {
+func newComponent(t *testing.T, enabled bool, cooldown time.Duration, observer option.Option[observerdef.Component]) (*component, *compdef.TestLifecycle) {
 	t.Helper()
 	lifecycle := compdef.NewTestLifecycle(t)
 	provides, err := NewComponent(Requires{
 		Lifecycle: lifecycle,
 		Config: config.NewMockWithOverrides(t, map[string]interface{}{
 			anomalydetectionconfig.SmartSeverityProfilesEnabledConfigKey: enabled,
+			smartSeverityProfilesCooldownConfigKey:                       cooldown,
 		}),
 		Observer: observer,
 		Log:      noopLogComponent{},
@@ -85,7 +89,7 @@ func newComponent(t *testing.T, enabled bool, observer option.Option[observerdef
 }
 
 func TestLifecycleDisabled(t *testing.T) {
-	comp, lifecycle := newComponent(t, false, option.New[observerdef.Component](&fakeObserverComponent{}))
+	comp, lifecycle := newComponent(t, false, 0, option.New[observerdef.Component](&fakeObserverComponent{}))
 	require.NoError(t, lifecycle.Start(context.Background()))
 
 	level, ok := comp.Current()
@@ -94,7 +98,7 @@ func TestLifecycleDisabled(t *testing.T) {
 }
 
 func TestLifecycleNoObserverProvided(t *testing.T) {
-	comp, lifecycle := newComponent(t, true, option.None[observerdef.Component]())
+	comp, lifecycle := newComponent(t, true, 0, option.None[observerdef.Component]())
 	require.NoError(t, lifecycle.Start(context.Background()))
 
 	level, ok := comp.Current()
@@ -103,7 +107,7 @@ func TestLifecycleNoObserverProvided(t *testing.T) {
 }
 
 func TestLifecyclePropagatesSubscriptionError(t *testing.T) {
-	comp, lifecycle := newComponent(t, true, option.New[observerdef.Component](&fakeObserverComponent{err: assert.AnError}))
+	comp, lifecycle := newComponent(t, true, 0, option.New[observerdef.Component](&fakeObserverComponent{err: assert.AnError}))
 	assert.ErrorIs(t, lifecycle.Start(context.Background()), assert.AnError)
 
 	_, ok := comp.Current()
@@ -117,9 +121,10 @@ func TestLifecycleRegistersAndUnsubscribesReader(t *testing.T) {
 		Reader:      reader,
 		Unsubscribe: func() { observer.unsubscribeCalled = true },
 	}
-	comp, lifecycle := newComponent(t, true, option.New[observerdef.Component](observer))
+	comp, lifecycle := newComponent(t, true, 500*time.Millisecond, option.New[observerdef.Component](observer))
 
 	require.NoError(t, lifecycle.Start(context.Background()))
+	assert.Equal(t, int64(1), observer.config.CooldownSecs)
 	level, ok := comp.Current()
 	require.True(t, ok)
 	assert.Equal(t, severityeventsdef.SeverityHigh, level)

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -192,11 +192,13 @@ func resolveNoisyLogDetectionEnabled(sourceNoisyLogDetection *bool) bool {
 const disabledSourcesConfigKey = "logs_config.experimental_adaptive_sampling.disabled_sources"
 
 const (
-	smartSeverityProfilesEnabledConfigKey         = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled"
-	smartSeverityProfilesMediumRateLimitConfigKey = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit"
-	smartSeverityProfilesMediumBurstSizeConfigKey = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.burst_size"
-	smartSeverityProfilesHighRateLimitConfigKey   = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.rate_limit"
-	smartSeverityProfilesHighBurstSizeConfigKey   = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.burst_size"
+	smartSeverityProfilesEnabledConfigKey           = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled"
+	smartSeverityProfilesMediumPassThroughConfigKey = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.pass_through"
+	smartSeverityProfilesMediumRateLimitConfigKey   = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit"
+	smartSeverityProfilesMediumBurstSizeConfigKey   = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.burst_size"
+	smartSeverityProfilesHighPassThroughConfigKey   = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.pass_through"
+	smartSeverityProfilesHighRateLimitConfigKey     = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.rate_limit"
+	smartSeverityProfilesHighBurstSizeConfigKey     = "logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.burst_size"
 )
 
 // resolveSmartSeverityProfiles builds the Low/Medium/High profile triple. Each field of
@@ -218,6 +220,9 @@ func resolveSmartSeverityProfiles(low preprocessor.SamplerProfile) [severityeven
 	if cfg.IsConfigured(smartSeverityProfilesMediumBurstSizeConfigKey) {
 		profiles[severityeventsdef.SeverityMedium].BurstSize = clampBurstSize(cfg.GetFloat64(smartSeverityProfilesMediumBurstSizeConfigKey))
 	}
+	if cfg.IsConfigured(smartSeverityProfilesMediumPassThroughConfigKey) {
+		profiles[severityeventsdef.SeverityMedium].PassThrough = cfg.GetBool(smartSeverityProfilesMediumPassThroughConfigKey)
+	}
 
 	// High starts from Medium's already-resolved profile, then applies its own
 	// overrides per field.
@@ -227,6 +232,9 @@ func resolveSmartSeverityProfiles(low preprocessor.SamplerProfile) [severityeven
 	}
 	if cfg.IsConfigured(smartSeverityProfilesHighBurstSizeConfigKey) {
 		profiles[severityeventsdef.SeverityHigh].BurstSize = clampBurstSize(cfg.GetFloat64(smartSeverityProfilesHighBurstSizeConfigKey))
+	}
+	if cfg.IsConfigured(smartSeverityProfilesHighPassThroughConfigKey) {
+		profiles[severityeventsdef.SeverityHigh].PassThrough = cfg.GetBool(smartSeverityProfilesHighPassThroughConfigKey)
 	}
 
 	return profiles

--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -777,30 +777,36 @@ func TestResolveAdaptiveSamplerConfig(t *testing.T) {
 
 	t.Run("smart severity profiles enabled: unset high falls back to configured medium", func(t *testing.T) {
 		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", true, pkgconfigmodel.SourceAgentRuntime)
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.pass_through", true, pkgconfigmodel.SourceAgentRuntime)
 		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit", 5.0, pkgconfigmodel.SourceAgentRuntime)
 		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.burst_size", 200.0, pkgconfigmodel.SourceAgentRuntime)
 		defer func() {
 			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.pass_through", false, pkgconfigmodel.SourceAgentRuntime)
 			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit", 1.0, pkgconfigmodel.SourceAgentRuntime)
 			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.burst_size", 1000.0, pkgconfigmodel.SourceAgentRuntime)
 		}()
 
 		got := resolveAdaptiveSamplerConfig(nil, preprocessor.NewTokenizer(0))
 
-		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 5.0, BurstSize: 200.0}, got.Profiles[severityeventsdef.SeverityMedium])
-		assert.Equal(t, got.Profiles[severityeventsdef.SeverityMedium], got.Profiles[severityeventsdef.SeverityHigh])
+		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 5.0, BurstSize: 200.0, PassThrough: true}, got.Profiles[severityeventsdef.SeverityMedium])
+		assert.Equal(t, got.Profiles[severityeventsdef.SeverityMedium], got.Profiles[severityeventsdef.SeverityHigh], "high must fall back to medium's full profile, including PassThrough")
 	})
 
 	t.Run("smart severity profiles enabled: explicit medium/high overrides win", func(t *testing.T) {
 		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", true, pkgconfigmodel.SourceAgentRuntime)
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.pass_through", true, pkgconfigmodel.SourceAgentRuntime)
 		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit", 5.0, pkgconfigmodel.SourceAgentRuntime)
 		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.burst_size", 200.0, pkgconfigmodel.SourceAgentRuntime)
+		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.pass_through", true, pkgconfigmodel.SourceAgentRuntime)
 		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.rate_limit", 20.0, pkgconfigmodel.SourceAgentRuntime)
 		mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.burst_size", 500.0, pkgconfigmodel.SourceAgentRuntime)
 		defer func() {
 			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.pass_through", false, pkgconfigmodel.SourceAgentRuntime)
 			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.rate_limit", 1.0, pkgconfigmodel.SourceAgentRuntime)
 			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.medium.burst_size", 1000.0, pkgconfigmodel.SourceAgentRuntime)
+			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.pass_through", false, pkgconfigmodel.SourceAgentRuntime)
 			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.rate_limit", 1.0, pkgconfigmodel.SourceAgentRuntime)
 			mockConfig.Set("logs_config.experimental_adaptive_sampling.smart_severity_profiles.high.burst_size", 1000.0, pkgconfigmodel.SourceAgentRuntime)
 		}()
@@ -808,8 +814,8 @@ func TestResolveAdaptiveSamplerConfig(t *testing.T) {
 		got := resolveAdaptiveSamplerConfig(nil, preprocessor.NewTokenizer(0))
 
 		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 2.5, BurstSize: 50.0}, got.Profiles[severityeventsdef.SeverityLow])
-		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 5.0, BurstSize: 200.0}, got.Profiles[severityeventsdef.SeverityMedium])
-		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 20.0, BurstSize: 500.0}, got.Profiles[severityeventsdef.SeverityHigh])
+		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 5.0, BurstSize: 200.0, PassThrough: true}, got.Profiles[severityeventsdef.SeverityMedium])
+		assert.Equal(t, preprocessor.SamplerProfile{RateLimit: 20.0, BurstSize: 500.0, PassThrough: true}, got.Profiles[severityeventsdef.SeverityHigh])
 	})
 
 	t.Run("smart severity profiles enabled: a non-positive configured burst size is clamped to 1", func(t *testing.T) {

--- a/pkg/logs/internal/decoder/preprocessor/sampler.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler.go
@@ -323,7 +323,7 @@ func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message
 			return s.processMatchedEntry(i, msg, now, detectionOnly, passThrough)
 		}
 	}
-	return s.trackNewPattern(msg, tokens, now, passThrough)
+	return s.trackNewPattern(msg, tokens, now)
 }
 
 // processMatchedEntry handles a log that matched the pattern at index i: it refills
@@ -373,20 +373,16 @@ func (s *AdaptiveSampler) processMatchedEntry(i int, msg *message.Message, now t
 
 // trackNewPattern records a never-before-seen pattern, evicting the
 // least-frequently-matched entry when the table is full, and emits the message.
-func (s *AdaptiveSampler) trackNewPattern(msg *message.Message, tokens []Token, now time.Time, passThrough bool) *message.Message {
+func (s *AdaptiveSampler) trackNewPattern(msg *message.Message, tokens []Token, now time.Time) *message.Message {
 	tlmAdaptiveSamplerNewPatterns.Inc(s.source)
 	if len(s.entries) >= s.config.MaxPatterns {
 		tlmAdaptiveSamplerEvictions.Inc(s.source)
 		s.entries = s.entries[:len(s.entries)-1]
 	}
-	initialCredits := s.config.BurstSize - 1
-	if passThrough {
-		initialCredits = s.config.BurstSize
-	}
 	// New patterns start with matchCount=1 and belong at the end of the sorted list.
 	s.entries = append(s.entries, samplerEntry{
 		tokens:     tokens,
-		credits:    initialCredits,
+		credits:    s.config.BurstSize - 1,
 		lastSeen:   now,
 		matchCount: 1,
 		sampled:    0,

--- a/pkg/logs/internal/decoder/preprocessor/sampler.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler.go
@@ -118,6 +118,10 @@ type AdaptiveSamplerConfig struct {
 	// message through without rate-limiting. Using a closure lets the check track
 	// ReplaceableSource swaps and future Remote Config updates.
 	IsSourceDisabled func() bool
+	// PassThrough temporarily disables adaptive sampling for matched messages.
+	// When it turns back off, the sampler resumes from the current profile's
+	// BurstSize after existing entries are reseeded.
+	PassThrough bool
 	// SmartSeverityProfilesEnabled switches RateLimit/BurstSize based on the level
 	// read from SeverityProvider (see Profiles). Profiles[SeverityLow] must match
 	// RateLimit/BurstSize above.
@@ -135,6 +139,8 @@ type AdaptiveSamplerConfig struct {
 type SamplerProfile struct {
 	RateLimit float64
 	BurstSize float64
+	// PassThrough skips adaptive-sampler drops while this profile is active.
+	PassThrough bool
 }
 
 // AdaptiveSamplerFilter matches messages by raw-content regex, structural sample,
@@ -267,12 +273,17 @@ func (s *AdaptiveSampler) applyProfileIfChanged() {
 	profile := s.config.Profiles[level]
 	escalation := (wasInitialized && level > previousLevel) ||
 		(!wasInitialized && level > severityeventsdef.SeverityLow)
+	leavingPassThrough := wasInitialized && s.config.PassThrough && !profile.PassThrough
 	s.config.RateLimit = profile.RateLimit
 	s.config.BurstSize = profile.BurstSize
+	s.config.PassThrough = profile.PassThrough
 
-	if escalation {
+	if escalation || leavingPassThrough {
 		for i := range s.entries {
 			s.entries[i].credits = s.config.BurstSize
+			if leavingPassThrough {
+				s.entries[i].sampled = 0
+			}
 		}
 	}
 
@@ -305,19 +316,20 @@ func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message
 	}
 	now := s.now()
 	detectionOnly := s.config.DetectionOnly
+	passThrough := s.config.PassThrough
 
 	for i := range s.entries {
 		if IsMatch(s.entries[i].tokens, tokens, s.config.MatchThreshold) {
-			return s.processMatchedEntry(i, msg, now, detectionOnly)
+			return s.processMatchedEntry(i, msg, now, detectionOnly, passThrough)
 		}
 	}
-	return s.trackNewPattern(msg, tokens, now)
+	return s.trackNewPattern(msg, tokens, now, passThrough)
 }
 
 // processMatchedEntry handles a log that matched the pattern at index i: it refills
 // and spends credits, updates tags and counters, re-sorts the pattern table, and
 // returns the message when emitted or nil when dropped.
-func (s *AdaptiveSampler) processMatchedEntry(i int, msg *message.Message, now time.Time, detectionOnly bool) *message.Message {
+func (s *AdaptiveSampler) processMatchedEntry(i int, msg *message.Message, now time.Time, detectionOnly, passThrough bool) *message.Message {
 	e := &s.entries[i]
 	matchedTokens := e.tokens
 
@@ -330,8 +342,8 @@ func (s *AdaptiveSampler) processMatchedEntry(i int, msg *message.Message, now t
 	e.lastSeen = now
 	e.matchCount++
 
-	allow := e.credits >= 1.0
-	if allow {
+	allow := passThrough || e.credits >= 1.0
+	if allow && !passThrough {
 		e.credits--
 	}
 
@@ -361,16 +373,20 @@ func (s *AdaptiveSampler) processMatchedEntry(i int, msg *message.Message, now t
 
 // trackNewPattern records a never-before-seen pattern, evicting the
 // least-frequently-matched entry when the table is full, and emits the message.
-func (s *AdaptiveSampler) trackNewPattern(msg *message.Message, tokens []Token, now time.Time) *message.Message {
+func (s *AdaptiveSampler) trackNewPattern(msg *message.Message, tokens []Token, now time.Time, passThrough bool) *message.Message {
 	tlmAdaptiveSamplerNewPatterns.Inc(s.source)
 	if len(s.entries) >= s.config.MaxPatterns {
 		tlmAdaptiveSamplerEvictions.Inc(s.source)
 		s.entries = s.entries[:len(s.entries)-1]
 	}
+	initialCredits := s.config.BurstSize - 1
+	if passThrough {
+		initialCredits = s.config.BurstSize
+	}
 	// New patterns start with matchCount=1 and belong at the end of the sorted list.
 	s.entries = append(s.entries, samplerEntry{
 		tokens:     tokens,
-		credits:    s.config.BurstSize - 1,
+		credits:    initialCredits,
 		lastSeen:   now,
 		matchCount: 1,
 		sampled:    0,

--- a/pkg/logs/internal/decoder/preprocessor/sampler_smart_severity_profile_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_smart_severity_profile_test.go
@@ -232,3 +232,53 @@ func TestAdaptiveSampler_NewPatternAfterSeverityChangeUsesActiveProfile(t *testi
 	assert.InDelta(t, 100.0, s.entries[0].credits, 0.0001, "existing pattern is reset on escalation before the new pattern is tracked")
 	assert.InDelta(t, 99.0, s.entries[1].credits, 0.0001, "new pattern seeds High BurstSize-1 credits after the severity change")
 }
+
+func TestAdaptiveSampler_PassThroughKeepsTrackedPatternsAtMaxCredits(t *testing.T) {
+	provider, emit := activateSeverity()
+	profiles := testProfiles()
+	profiles[severityeventsdef.SeverityHigh].PassThrough = true
+	emit(severityeventsdef.SeverityHigh)
+
+	s := newAnomalyProfileSampler(profiles, provider)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	for i := 0; i < 3; i++ {
+		require.NotNilf(t, s.Process(testMsg(), patternA), "message %d should pass through", i)
+	}
+
+	require.Len(t, s.entries, 1)
+	assert.True(t, s.config.PassThrough)
+	assert.InDelta(t, 100.0, s.entries[0].credits, 0.0001, "pass-through should behave like an infinite rate limit and keep credits full")
+}
+
+func TestAdaptiveSampler_DeescalationFromPassThroughSeedsEveryTrackedPatternWithMaxCredits(t *testing.T) {
+	provider, emit := activateSeverity()
+	profiles := testProfiles()
+	profiles[severityeventsdef.SeverityHigh].PassThrough = true
+	emit(severityeventsdef.SeverityHigh)
+
+	s := newAnomalyProfileSampler(profiles, provider)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	require.NotNil(t, s.Process(testMsg(), patternB))
+	require.Len(t, s.entries, 2)
+	assert.InDelta(t, 100.0, s.entries[0].credits, 0.0001)
+	assert.InDelta(t, 100.0, s.entries[1].credits, 0.0001)
+	s.entries[0].sampled = 3
+	s.entries[1].sampled = 4
+
+	emit(severityeventsdef.SeverityLow)
+
+	require.NotNil(t, s.Process(testMsg(), patternA))
+	require.Len(t, s.entries, 2)
+	assert.False(t, s.config.PassThrough)
+	assert.Equal(t, 1.0, s.config.RateLimit)
+	assert.Equal(t, 5.0, s.config.BurstSize)
+	assert.InDelta(t, 4.0, s.entries[0].credits, 0.0001, "matched pattern should be reset to the new burst size, then spend one credit")
+	assert.InDelta(t, 5.0, s.entries[1].credits, 0.0001, "unmatched patterns should still be reseeded to the new burst size")
+	assert.Zero(t, s.entries[0].sampled, "matched pattern stale sampled count should be cleared when pass-through ends")
+	assert.Zero(t, s.entries[1].sampled, "unmatched pattern stale sampled count should be cleared when pass-through ends")
+}

--- a/pkg/logs/internal/decoder/preprocessor/sampler_smart_severity_profile_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_smart_severity_profile_test.go
@@ -233,25 +233,6 @@ func TestAdaptiveSampler_NewPatternAfterSeverityChangeUsesActiveProfile(t *testi
 	assert.InDelta(t, 99.0, s.entries[1].credits, 0.0001, "new pattern seeds High BurstSize-1 credits after the severity change")
 }
 
-func TestAdaptiveSampler_PassThroughKeepsTrackedPatternsAtMaxCredits(t *testing.T) {
-	provider, emit := activateSeverity()
-	profiles := testProfiles()
-	profiles[severityeventsdef.SeverityHigh].PassThrough = true
-	emit(severityeventsdef.SeverityHigh)
-
-	s := newAnomalyProfileSampler(profiles, provider)
-	t0 := time.Now()
-	s.now = func() time.Time { return t0 }
-
-	for i := 0; i < 3; i++ {
-		require.NotNilf(t, s.Process(testMsg(), patternA), "message %d should pass through", i)
-	}
-
-	require.Len(t, s.entries, 1)
-	assert.True(t, s.config.PassThrough)
-	assert.InDelta(t, 100.0, s.entries[0].credits, 0.0001, "pass-through should behave like an infinite rate limit and keep credits full")
-}
-
 func TestAdaptiveSampler_DeescalationFromPassThroughSeedsEveryTrackedPatternWithMaxCredits(t *testing.T) {
 	provider, emit := activateSeverity()
 	profiles := testProfiles()
@@ -265,8 +246,6 @@ func TestAdaptiveSampler_DeescalationFromPassThroughSeedsEveryTrackedPatternWith
 	require.NotNil(t, s.Process(testMsg(), patternA))
 	require.NotNil(t, s.Process(testMsg(), patternB))
 	require.Len(t, s.entries, 2)
-	assert.InDelta(t, 100.0, s.entries[0].credits, 0.0001)
-	assert.InDelta(t, 100.0, s.entries[1].credits, 0.0001)
 	s.entries[0].sampled = 3
 	s.entries[1].sampled = 4
 

--- a/test/new-e2e/tests/anomalydetection/smart_adaptive_log_sampling_nix_test.go
+++ b/test/new-e2e/tests/anomalydetection/smart_adaptive_log_sampling_nix_test.go
@@ -74,6 +74,7 @@ logs_config:
     protect_important_logs: false
     smart_severity_profiles:
       enabled: true
+      cooldown: 0s
       medium:
         rate_limit: 1000
         burst_size: 200


### PR DESCRIPTION
### What does this PR do?

> [!NOTE]
> [Feature documentation](https://datadoghq.atlassian.net/wiki/x/EgK5nQE).

Adds `pass_through` and `cooldown` options to smart severity profiles.

```yaml
logs_config:
  experimental_adaptive_sampling:
    smart_severity_profiles:
      enabled: true
      cooldown: 5m # Deescalation cooldown
      high:
        # you can use pass_through: true to not rate limit
        rate_limit: 100
        burst_size: 1000
        pass_through: true
```

- `pass_through`: Disables adaptive log sampling on this profile (all logs are sent)
- `cooldown`: Waits before de-escalation

### Motivation

### Describe how you validated your changes

### Additional Notes

<img width="642" height="825" alt="Screenshot 2026-07-09 at 10 05 09" src="https://github.com/user-attachments/assets/4de584ef-3d0d-41ba-ac5b-04b84b89f0f8" />

[AAD-4]: https://datadoghq.atlassian.net/browse/AAD-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ