### PR TITLE
Temporarily disable Bazel's `--disk_cache` in CI

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -337,8 +337,8 @@
         "usagesDigest": "CKsn1dtme4oztWA0td45Tt6oCZK6MZnpIocVVZK14sU=",
         "recordedInputs": [
           "FILE:@@//.bazelversion 7b6188c072705b1c51d6ccdedea92238feb4199b75c58b321c5b632d981b0aba",
-          "FILE:@@//tools/bazel 690073a0ab1e62a71c0acbe7eb9312b9a5937951759be4c0f457d97fa7e992e4",
-          "FILE:@@//tools/bazel.bat 9ead9c74fdd6e8200f38c5b68b1f0caae77d6e15b0434fc42043ce87ae41ec7b",
+          "FILE:@@//tools/bazel ef4b6d604f4271360466b120a594075f033a5ac127d272d1dfd4c28d28057d70",
+          "FILE:@@//tools/bazel.bat b4d1cf9bd2a8c3abfae0ff53c207584c7a0a91f7f06d1fe681861f13652d3132",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
         ],
         "generatedRepoSpecs": {}

--- a/tools/bazel
+++ b/tools/bazel
@@ -29,7 +29,7 @@ if [ -n "${XDG_CACHE_HOME-}" ]; then
   fi
   export GOCACHE="$XDG_CACHE_HOME/go-build"
   export GOMODCACHE="$XDG_CACHE_HOME/go/mod"
-  extra_args+=(--disk_cache="$XDG_CACHE_HOME/bazel/disk-cache")
+  [ -z "${CI-}" ] && extra_args+=(--disk_cache="$XDG_CACHE_HOME/bazel/disk-cache")
   # https://github.com/bazelbuild/bazel/issues/26384
   [ "$XDG_CACHE_HOME" = "$(dirname "$(dirname "$0")")/.cache" ] && extra_args+=(--repo_contents_cache=)
   if [ -n "${CI-}" ] && [ -z "${GITHUB_ACTIONS-}" ]; then

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -37,7 +37,7 @@ if defined XDG_CACHE_HOME (
   set startup_options="--output_user_root=!bazel_home!"
   :: Use container-scoped `outputBase` to prevent races on `outputUserRoot\<same workspace hash>\server\jvm.out`
   if defined DOTNET_RUNNING_IN_CONTAINER set startup_options=!startup_options! "--output_base=%SYSTEMDRIVE%\bob"
-  set extra_args="--disk_cache=!bazel_home!\disk-cache"
+  if not defined CI set extra_args="--disk_cache=!bazel_home!\disk-cache"
   :: https://github.com/bazelbuild/bazel/issues/26384
   for %%i in ("%~dp0..\.cache") do if "!XDG_CACHE_HOME!" == "%%~fi" set "extra_args=!extra_args! --repo_contents_cache="
   if defined CI if not defined GITHUB_ACTIONS set "extra_args=!extra_args! --config=ci --config=cache:frontend"


### PR DESCRIPTION
### What does this PR do?
Drop `--disk_cache` from `tools/bazel` and `tools/bazel.bat` whenever `CI` is set, keeping local/dev usage unchanged.

### Motivation
Despite #53356, some jobs are still in `main` with `lost input too many times (#NN) for the same action` during remote execution ([example job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1844090858), mind also siblings).

The local disk cache is suspected of masking blobs from the remote CAS, so disabling it in CI isolates whether it is a culprit or not.