### PR TITLE
[DSEC] [POC] Rust-checks, build and run once through RC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -432,6 +432,7 @@
 /comp/autoscaling/datadogclient @DataDog/container-integrations
 /comp/connectivitychecker @DataDog/fleet
 /comp/dataobs/queryactions @DataDog/data-observability
+/comp/exampletaskmanager @DataDog/sensitive-data-scanner
 /comp/etw @DataDog/windows-products
 /comp/filterlist @DataDog/agent-metric-pipelines
 /comp/fleetstatus @DataDog/fleet
@@ -840,6 +841,7 @@
 /tasks/static_quality_gates/            @DataDog/agent-build
 /tasks/files_inventory.py               @DataDog/agent-build
 /tasks/rtloader.py                      @DataDog/agent-runtimes
+/tasks/rust_shared_checks.py            @DataDog/agent-runtimes
 /tasks/secret_generic_connector.py      @DataDog/agent-configuration
 /tasks/security_agent.py                @DataDog/agent-security
 /tasks/sbomgen.py                       @DataDog/agent-security

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -432,8 +432,8 @@
 /comp/autoscaling/datadogclient @DataDog/container-integrations
 /comp/connectivitychecker @DataDog/fleet
 /comp/dataobs/queryactions @DataDog/data-observability
-/comp/exampletaskmanager @DataDog/sensitive-data-scanner
 /comp/etw @DataDog/windows-products
+/comp/exampletaskmanager @DataDog/sensitive-data-scanner
 /comp/filterlist @DataDog/agent-metric-pipelines
 /comp/fleetstatus @DataDog/fleet
 /comp/haagent @DataDog/network-device-monitoring-core

--- a/Dockerfiles/agent-ddot/Dockerfile
+++ b/Dockerfiles/agent-ddot/Dockerfile
@@ -15,4 +15,5 @@ RUN chmod 755 -R /opt/entrypoints \
   && chown dd-agent:root /etc/datadog-agent/otel-config.yaml \
   && rm -rf /var/run && mkdir -p /var/run/s6 && mkdir -p /var/run/datadog && mkdir -p /opt/datadog-agent/run \
   && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
-  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run
+  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
+  && chmod 0500 /etc/datadog-agent/checks.d/*

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -203,6 +203,8 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
   && rm /var/run && mkdir -p /var/run/s6 && mkdir -p /var/run/datadog && mkdir -p /opt/datadog-agent/run \
   && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
   && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
+  # Shared-library checks require owner-only permissions (see pkg/util/filesystem/rights_nix.go).
+  && chmod 0500 /etc/datadog-agent/checks.d/* \
   && chmod 755 /probe.sh /initlog.sh \
   && chown root:secret-manager /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh /opt/datadog-agent/embedded/bin/secret-generic-connector \
   && chmod 550 /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh /opt/datadog-agent/embedded/bin/secret-generic-connector \

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -39,6 +39,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/datastreams"
 	fxinstrumentation "github.com/DataDog/datadog-agent/comp/core/fxinstrumentation/fx"
 	doqueryactionsfx "github.com/DataDog/datadog-agent/comp/dataobs/queryactions/fx"
+	exampletaskmanagerfx "github.com/DataDog/datadog-agent/comp/exampletaskmanager/fx"
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
 	logondurationfx "github.com/DataDog/datadog-agent/comp/logonduration/fx"
 	networkconfigmanagement "github.com/DataDog/datadog-agent/comp/networkconfigmanagement/def"
@@ -586,6 +587,7 @@ func getSharedFxOption() fx.Option {
 		remoteagentregistryfx.Module(),
 		haagentfx.Module(),
 		doqueryactionsfx.Module(),
+		exampletaskmanagerfx.Module(),
 		metricscompressorfx.Module(),
 		diagnosefx.Module(),
 		ipcfx.ModuleReadWrite(),

--- a/comp/README.md
+++ b/comp/README.md
@@ -852,6 +852,12 @@ Package connectivitychecker is responsible for running connectivity checks that 
 
 Package queryactions provides the Data Observability query actions component
 
+### [comp/exampletaskmanager](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/exampletaskmanager)
+
+*Datadog Team*: sensitive-data-scanner
+
+Package exampletaskmanager schedules one-shot example Rust shared-library checks from RC DEBUG tasks.
+
 ### [comp/etw](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/etw)
 
 *Datadog Team*: windows-products

--- a/comp/README.md
+++ b/comp/README.md
@@ -852,17 +852,17 @@ Package connectivitychecker is responsible for running connectivity checks that 
 
 Package queryactions provides the Data Observability query actions component
 
-### [comp/exampletaskmanager](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/exampletaskmanager)
-
-*Datadog Team*: sensitive-data-scanner
-
-Package exampletaskmanager schedules one-shot example Rust shared-library checks from RC DEBUG tasks.
-
 ### [comp/etw](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/etw)
 
 *Datadog Team*: windows-products
 
 Package etw provides an ETW tracing interface
+
+### [comp/exampletaskmanager](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/exampletaskmanager)
+
+*Datadog Team*: sensitive-data-scanner
+
+Package exampletaskmanager provides a minimal RC-to-check task bridge.
 
 ### [comp/filterlist](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/filterlist)
 

--- a/comp/core/autodiscovery/providers/names/provider_names.go
+++ b/comp/core/autodiscovery/providers/names/provider_names.go
@@ -63,6 +63,8 @@ const (
 	DataStreamsKafkaActions = "dsm-kafka-actions"
 	// DOQueryActions provides check configurations for Database Observability query-level actions.
 	DOQueryActions = "do-query-actions"
+	// ExampleTaskManager schedules one-shot example shared-library checks from RC DEBUG tasks.
+	ExampleTaskManager = "example-task-manager"
 	// PrometheusHTTPSD discovers check configurations from a Prometheus HTTP Service Discovery endpoint.
 	PrometheusHTTPSD = "prometheus-http-sd"
 	// InstrumentationChecks pulls AD configurations derived from DatadogInstrumentation CRs via the cluster-agent.

--- a/comp/exampletaskmanager/def/BUILD.bazel
+++ b/comp/exampletaskmanager/def/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "def",
+    srcs = ["component.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/exampletaskmanager/def",
+    visibility = ["//visibility:public"],
+)

--- a/comp/exampletaskmanager/def/component.go
+++ b/comp/exampletaskmanager/def/component.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package exampletaskmanager provides a minimal RC-to-check task bridge.
+//
+// The component subscribes to the DEBUG remote-config product. Each payload
+// may contain a task named "trigger"; when present, it schedules a one-shot
+// example shared-library check via autodiscovery.
+package exampletaskmanager
+
+// team: sensitive-data-scanner
+
+// Component is the example task manager interface.
+type Component interface{}

--- a/comp/exampletaskmanager/fx/BUILD.bazel
+++ b/comp/exampletaskmanager/fx/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/exampletaskmanager/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/exampletaskmanager/def",
+        "//comp/exampletaskmanager/impl",
+        "//pkg/util/fxutil",
+        "@org_uber_go_fx//:fx",
+    ],
+)

--- a/comp/exampletaskmanager/fx/fx.go
+++ b/comp/exampletaskmanager/fx/fx.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package fx provides the fx module for the example task manager component.
+package fx
+
+import (
+	"go.uber.org/fx"
+
+	exampletaskmanager "github.com/DataDog/datadog-agent/comp/exampletaskmanager/def"
+	exampletaskmanagerimpl "github.com/DataDog/datadog-agent/comp/exampletaskmanager/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for the example task manager component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			exampletaskmanagerimpl.NewComponent,
+		),
+		fx.Invoke(func(_ exampletaskmanager.Component) {}),
+	)
+}

--- a/comp/exampletaskmanager/impl/BUILD.bazel
+++ b/comp/exampletaskmanager/impl/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "impl",
+    srcs = [
+        "exampletaskmanager.go",
+        "handler.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/exampletaskmanager/impl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/autodiscovery/def",
+        "//comp/core/autodiscovery/integration",
+        "//comp/core/autodiscovery/providers/names",
+        "//comp/core/autodiscovery/providers/types",
+        "//comp/core/config",
+        "//comp/core/log/def",
+        "//comp/def",
+        "//comp/exampletaskmanager/def",
+        "//comp/remote-config/rcclient/def",
+        "//pkg/config/remote/data",
+        "//pkg/remoteconfig/state",
+    ],
+)

--- a/comp/exampletaskmanager/impl/exampletaskmanager.go
+++ b/comp/exampletaskmanager/impl/exampletaskmanager.go
@@ -1,0 +1,122 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package exampletaskmanagerimpl implements the example task manager component.
+package exampletaskmanagerimpl
+
+import (
+	"context"
+	"runtime"
+	"sync"
+
+	autodiscovery "github.com/DataDog/datadog-agent/comp/core/autodiscovery/def"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	exampletaskmanager "github.com/DataDog/datadog-agent/comp/exampletaskmanager/def"
+	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
+	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
+)
+
+// Requires defines the dependencies of the example task manager component.
+type Requires struct {
+	Lc       compdef.Lifecycle
+	Log      log.Component
+	Config   config.Component
+	RcClient rcclient.Component
+	Ac       autodiscovery.Component
+}
+
+// Provides defines the output of the example task manager component.
+type Provides struct {
+	Comp exampletaskmanager.Component
+}
+
+type component struct {
+	log           log.Component
+	enabled       bool
+	rcclient      rcclient.Component
+	ac            autodiscovery.Component
+	configChanges chan integration.ConfigChanges
+	closeMutex    sync.RWMutex
+	closed        bool
+}
+
+// NewComponent creates a new example task manager component.
+func NewComponent(reqs Requires) (Provides, error) {
+	c := &component{
+		log:           reqs.Log,
+		enabled:       reqs.Config.GetBool("shared_library_check.enabled"),
+		rcclient:      reqs.RcClient,
+		ac:            reqs.Ac,
+		configChanges: make(chan integration.ConfigChanges, 10),
+	}
+
+	reqs.Lc.Append(compdef.Hook{
+		OnStart: c.start,
+	})
+
+	return Provides{Comp: c}, nil
+}
+
+func (c *component) String() string {
+	return names.ExampleTaskManager
+}
+
+func (c *component) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return map[string]types.ErrorMsgSet{}
+}
+
+func (c *component) Stream(ctx context.Context) <-chan integration.ConfigChanges {
+	c.configChanges <- integration.ConfigChanges{}
+
+	go func() {
+		defer func() {
+			c.closeMutex.Lock()
+			defer c.closeMutex.Unlock()
+			if c.closed {
+				return
+			}
+			c.closed = true
+			close(c.configChanges)
+		}()
+
+		if !c.enabled || runtime.GOOS == "windows" {
+			<-ctx.Done()
+			return
+		}
+
+		c.rcclient.Subscribe(data.ProductDebug, c.onUpdate)
+		c.log.Infof("exampletaskmanager: subscribed to RC product %q", data.ProductDebug)
+		<-ctx.Done()
+	}()
+
+	return c.configChanges
+}
+
+func (c *component) sendChanges(changes integration.ConfigChanges) {
+	c.closeMutex.RLock()
+	defer c.closeMutex.RUnlock()
+	if c.closed {
+		return
+	}
+	c.configChanges <- changes
+}
+
+func (c *component) start(_ context.Context) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	if !c.enabled {
+		c.log.Info("exampletaskmanager: shared_library_check.enabled is false, not registering config provider")
+		return nil
+	}
+	c.ac.AddConfigProvider(c, false, 0)
+	c.log.Info("exampletaskmanager: registered autodiscovery config provider")
+	return nil
+}

--- a/comp/exampletaskmanager/impl/handler.go
+++ b/comp/exampletaskmanager/impl/handler.go
@@ -1,0 +1,100 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package exampletaskmanagerimpl
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+)
+
+const (
+	triggerTaskName  = "trigger"
+	exampleCheckName = "example"
+	oneShotInstance  = "min_collection_interval: 0\n"
+)
+
+// Example payload for the example task manager
+//
+//	{
+//	  "tasks": [
+//	    {
+//	      "name": "trigger"
+//	    }
+//	  ]
+//	}
+type rcPayload struct {
+	Tasks []rcTask `json:"tasks"`
+}
+
+type rcTask struct {
+	Name string `json:"name"`
+}
+
+func (c *component) onUpdate(updates map[string]state.RawConfig, applyStatus func(string, state.ApplyStatus)) {
+	if len(updates) == 0 {
+		c.log.Debugf("exampletaskmanager: RC DEBUG update with 0 active config(s)")
+		return
+	}
+
+	changes := integration.ConfigChanges{}
+	for path, rawConfig := range updates {
+		var payload rcPayload
+		if err := json.Unmarshal(rawConfig.Config, &payload); err != nil {
+			c.log.Warnf("exampletaskmanager: failed to unmarshal DEBUG config %s: %v", path, err)
+			applyStatus(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+			continue
+		}
+
+		if !hasTriggerTask(payload) {
+			c.log.Debugf("exampletaskmanager: skipping DEBUG config %s: no %q task", configShortName(path), triggerTaskName)
+			applyStatus(path, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+			continue
+		}
+
+		// Schedule the check configuration for the example check
+		changes.Schedule = append(changes.Schedule, buildCheckConfig(c.String(), path))
+		c.log.Infof("exampletaskmanager: scheduled one-shot %q check for %s", exampleCheckName, configShortName(path))
+		applyStatus(path, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+	}
+
+	if !changes.IsEmpty() {
+		c.sendChanges(changes)
+	}
+}
+
+func hasTriggerTask(payload rcPayload) bool {
+	for _, task := range payload.Tasks {
+		if task.Name == triggerTaskName {
+			return true
+		}
+	}
+	return false
+}
+
+func buildCheckConfig(providerName, path string) integration.Config {
+	return integration.Config{
+		Name:       exampleCheckName,
+		Source:     fmt.Sprintf("%s:%s", providerName, configShortName(path)),
+		Instances:  []integration.Data{integration.Data(oneShotInstance)},
+		InitConfig: integration.Data("{}"),
+	}
+}
+
+func configShortName(path string) string {
+	const prefix = "datadog/2/DEBUG/"
+	if len(path) > len(prefix) && path[:len(prefix)] == prefix {
+		rest := path[len(prefix):]
+		if i := strings.IndexByte(rest, '/'); i >= 0 {
+			return rest[:i]
+		}
+		return rest
+	}
+	return path
+}

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -91,7 +91,18 @@ build do
 
             # Create empty directories so that they're owned by the package
             # (also requires `extra_package_file` directive in project def)
-            mkdir "#{output_config_dir}/etc/datadog-agent/checks.d"
+            staged_checks_d = "#{install_dir}/etc/datadog-agent/checks.d"
+            target_checks_d = "#{output_config_dir}/etc/datadog-agent/checks.d"
+
+            if Dir.exist?(staged_checks_d) && !Dir.children(staged_checks_d).empty?
+              move staged_checks_d, target_checks_d, :force => true
+            else
+              mkdir target_checks_d
+            end
+
+            # Rust shared-library checks must be owner-only (group/others no access)
+            # so the shared library loader permission checks pass.
+            command "chmod 0500 #{target_checks_d}/libdatadog-agent-*.so 2>/dev/null || true"
             mkdir "/var/log/datadog"
 
             # Process manager config directory (read-only, under install dir)

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -103,6 +103,13 @@ build do
   else
     conf_dir = "#{install_dir}/etc/datadog-agent"
   end
+
+  # Stage Rust shared-library checks (Linux + macOS only).
+  unless windows_target?
+    command "dda inv -- -e rust-shared-checks.build --checks-d-dir=\"#{conf_dir}/checks.d\"",
+      env: env,
+      :live_stream => Omnibus.logger.live_stream(:info)
+  end
   # TODO(agent-build): sort out the use of bin/agen/dist/conf.d
   # dda inv agent.build  leaves many files in bin/agen/dist/conf.d
   # Now we place them into the pacakge via the //packages/agent/product:post_build_install

--- a/omnibus/package-scripts/agent-dmg/postinst
+++ b/omnibus/package-scripts/agent-dmg/postinst
@@ -182,6 +182,15 @@ chown -vR "$DDAGENT_USER:admin" $CONF_DIR
 chmod -v 770 $CONF_DIR
 find $CONF_DIR -type f -exec chmod 660 {} \;
 
+# Shared-library checks rely on strict loader permissions:
+# - owner must be trusted (handled by chown above)
+# - group/others must have no access (mode bits)
+if [ -d "$CONF_DIR/checks.d" ]; then
+  find "$CONF_DIR/checks.d" -maxdepth 1 -type f \
+    \( -name 'libdatadog-agent-*.dylib' -o -name 'libdatadog-agent-*.so' \) \
+    -exec chmod 0500 {} \; 2>/dev/null || true
+fi
+
 # Ensure _dd-agent can read/write config even after a user edits a file with
 # an editor that replaces the file (TextEdit, VS Code, vim, etc.), changing
 # Unix ownership.  macOS editors use atomic save (write temp + rename), which

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/ffi.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/ffi.rs
@@ -8,7 +8,7 @@ macro_rules! generate_ffi {
             check_id_cstr: *const std::ffi::c_char,
             init_config_cstr: *const std::ffi::c_char,
             instance_config_cstr: *const std::ffi::c_char,
-            aggregator_ptr: *const core::Aggregator,
+            aggregator_ptr: *const $crate::Aggregator,
             error_handler: *mut *mut std::ffi::c_char,
         ) {
             if let Err(e) = create_and_run_check(
@@ -30,22 +30,22 @@ macro_rules! generate_ffi {
             check_id_cstr: *const std::ffi::c_char,
             init_config_cstr: *const std::ffi::c_char,
             instance_config_cstr: *const std::ffi::c_char,
-            aggregator_ptr: *const core::Aggregator,
+            aggregator_ptr: *const $crate::Aggregator,
         ) -> Result<(), Box<dyn std::error::Error>> {
             // convert C args to Rust structs
-            let check_id = core::to_rust_string(check_id_cstr)?;
+            let check_id = $crate::to_rust_string(check_id_cstr)?;
 
-            let init_config_str = core::to_rust_string(init_config_cstr)?;
-            let init_config = core::Config::from_str(&init_config_str)?;
+            let init_config_str = $crate::to_rust_string(init_config_cstr)?;
+            let init_config = $crate::Config::from_str(&init_config_str)?;
 
-            let instance_config_str = core::to_rust_string(instance_config_cstr)?;
-            let instance_config = core::Config::from_str(&instance_config_str)?;
+            let instance_config_str = $crate::to_rust_string(instance_config_cstr)?;
+            let instance_config = $crate::Config::from_str(&instance_config_str)?;
 
-            let aggregator = core::Aggregator::from_ptr(aggregator_ptr);
+            let aggregator = $crate::Aggregator::from_ptr(aggregator_ptr);
 
             // create the check instance
             let agent_check =
-                core::AgentCheck::new(check_id, init_config, instance_config, aggregator);
+                $crate::AgentCheck::new(check_id, init_config, instance_config, aggregator);
 
             // run the custom implementation
             $check_function(&agent_check)?;

--- a/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.json
+++ b/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "checks": [
+    {
+      "id": "example",
+      "crate": "example",
+      "default": true,
+      "platforms": ["linux", "darwin"]
+    }
+  ]
+}

--- a/pkg/collector/sharedlibrary/sharedlibraryimpl/check.go
+++ b/pkg/collector/sharedlibrary/sharedlibraryimpl/check.go
@@ -153,8 +153,16 @@ func (c *Check) Configure(_ sender.SenderManager, integrationConfigDigest uint64
 		return err
 	}
 
-	// See if a collection interval was specified
-	if commonOptions.MinCollectionInterval > 0 {
+	// See if a collection interval was specified. An explicit
+	// min_collection_interval: 0 schedules a one-shot check (interval 0).
+	if commonOptions.MinCollectionInterval == 0 {
+		var rawInst integration.RawMap
+		if err := yaml.Unmarshal(instanceConfig, &rawInst); err == nil {
+			if _, ok := rawInst["min_collection_interval"]; ok {
+				c.interval = 0
+			}
+		}
+	} else if commonOptions.MinCollectionInterval > 0 {
 		c.interval = time.Duration(commonOptions.MinCollectionInterval) * time.Second
 	}
 

--- a/pkg/config/remote/data/product.go
+++ b/pkg/config/remote/data/product.go
@@ -46,6 +46,8 @@ const (
 	ProductAgentFlags = "AGENT_REMOTE_FLAGS"
 	// ProductDOQueryActions is to execute database queries remotely for Data Observability
 	ProductDOQueryActions Product = "DO_QUERY_ACTIONS"
+	// ProductDebug is a free-form RC product used for development/debug scaffolding.
+	ProductDebug Product = "DEBUG"
 )
 
 // ProductListToString converts a product list to string list

--- a/pkg/remoteconfig/state/products.go
+++ b/pkg/remoteconfig/state/products.go
@@ -6,6 +6,7 @@
 package state
 
 var validProducts = map[string]struct{}{
+	"DEBUG":                             {}, // DEBUG product is used for development/debug scaffolding.
 	ProductInstallerConfig:              {},
 	ProductUpdaterCatalogDD:             {},
 	ProductUpdaterAgent:                 {},

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -75,6 +75,7 @@ from tasks import (
     release,
     renovate,
     rtloader,
+    rust_shared_checks,
     sbomgen,
     schema,
     secret_generic_connector,
@@ -252,6 +253,7 @@ ns.add_collection(systray)
 ns.add_collection(release)
 ns.add_collection(renovate)
 ns.add_collection(rtloader)
+ns.add_collection(rust_shared_checks)
 ns.add_collection(system_probe)
 ns.add_collection(process_agent)
 ns.add_collection(privateactionrunner)

--- a/tasks/libs/pipeline/github_jira_map.yaml
+++ b/tasks/libs/pipeline/github_jira_map.yaml
@@ -60,3 +60,4 @@
 '@datadog/profiling-full-host': 'PROF'
 '@datadog/q-branch': DEFAULT_JIRA_PROJECT
 '@datadog/gpu-monitoring-agent': EBPF
+'@datadog/sensitive-data-scanner': SDS

--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -384,6 +384,13 @@
   review:
     name: '#sdlc-security'
     id: 'C027P1CK07N'
+'@datadog/sensitive-data-scanner':
+  notification:
+    name: '#sensitive-data-scanner'
+    id: 'C035A167T0S'
+  review:
+    name: '#sensitive-data-scanner'
+    id: 'C035A167T0S'
 '@datadog/serverless':
   notification:
     name: '#serverless-agent'

--- a/tasks/rust_shared_checks.py
+++ b/tasks/rust_shared_checks.py
@@ -1,0 +1,196 @@
+"""
+Invoke tasks for building Rust-based shared-library checks.
+
+These checks compile to `cdylib` and must be staged into `checks.d` with the
+expected loader naming convention:
+  libdatadog-agent-<check_id>.(so|dylib)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from invoke import task
+from invoke.exceptions import Exit
+
+from tasks.libs.build.bazel import bazel
+from tasks.libs.common.utils import gitlab_section
+
+RUSTCHECKS_MANIFEST_REL_PATH = "pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.json"
+
+
+@dataclass(frozen=True)
+class CheckSpec:
+    id: str
+    crate: str
+    default: bool
+    platforms: list[str]
+
+
+def _repo_root(ctx) -> Path:
+    repo_root = ctx.run("git rev-parse --show-toplevel", hide=True).stdout.strip()
+    return Path(repo_root)
+
+
+def _current_platform() -> str:
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "darwin":
+        return "darwin"
+    return "windows"
+
+
+def _lib_extension(platform: str) -> str:
+    if platform == "darwin":
+        return "dylib"
+    return "so"
+
+
+def _parse_csv_env(var_name: str) -> set[str]:
+    raw = os.environ.get(var_name, "")
+    if not raw.strip():
+        return set()
+    return {v.strip() for v in raw.split(",") if v.strip()}
+
+
+def _env_bool(var_name: str) -> bool:
+    return os.environ.get(var_name, "").lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _load_manifest(manifest_path: Path) -> list[CheckSpec]:
+    try:
+        payload: dict[str, Any] = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as e:
+        raise Exit(f"Rust shared checks manifest not found: {manifest_path}") from e
+
+    checks = payload.get("checks", [])
+    specs: list[CheckSpec] = []
+    for c in checks:
+        specs.append(
+            CheckSpec(
+                id=c["id"],
+                crate=c["crate"],
+                default=bool(c.get("default", False)),
+                platforms=list(c.get("platforms", [])),
+            )
+        )
+    return specs
+
+
+def _select_checks(specs: list[CheckSpec], platform: str) -> tuple[list[CheckSpec], list[str]]:
+    include = _parse_csv_env("DD_RUST_SHARED_CHECKS_INCLUDE")
+    exclude = _parse_csv_env("DD_RUST_SHARED_CHECKS_EXCLUDE")
+
+    if _env_bool("DD_RUST_SHARED_CHECKS_INCLUDE_EXAMPLE") or _env_bool("DD_RUST_SHARED_CHECKS_ENABLE_EXAMPLE"):
+        include.add("example")
+
+    selected_ids = {s.id for s in specs if s.default}
+    selected_ids |= include
+    selected_ids -= exclude
+
+    final: list[CheckSpec] = []
+    skipped: list[str] = []
+    for s in specs:
+        if s.id not in selected_ids:
+            continue
+
+        if platform not in s.platforms:
+            skipped.append(f"{s.id} (platform={platform})")
+            continue
+
+        final.append(s)
+
+    return final, skipped
+
+
+def _cargo_build_env(repo_root: Path) -> dict[str, str]:
+    cargo_home = repo_root / "pkg/collector/sharedlibrary/rustchecks/.cargo-home"
+    cargo_home.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["CARGO_HOME"] = str(cargo_home)
+    return env
+
+
+@task
+def build(ctx, checks_d_dir, manifest_path=None):
+    """
+    Build and stage Rust shared-library checks into the provided `checks.d` dir.
+
+    Environment configuration:
+      - `DD_RUST_SHARED_CHECKS_INCLUDE` (comma-separated ids)
+      - `DD_RUST_SHARED_CHECKS_EXCLUDE` (comma-separated ids)
+      - `DD_RUST_SHARED_CHECKS_INCLUDE_EXAMPLE` / `DD_RUST_SHARED_CHECKS_ENABLE_EXAMPLE` (true/1)
+    """
+
+    if not checks_d_dir:
+        raise Exit("Missing required argument: checks_d_dir")
+
+    checks_d_path = Path(checks_d_dir)
+    repo_root = _repo_root(ctx)
+
+    default_manifest_path = repo_root / RUSTCHECKS_MANIFEST_REL_PATH
+    manifest = Path(manifest_path) if manifest_path else default_manifest_path
+
+    platform = _current_platform()
+    if platform == "windows":
+        raise Exit("Refusing to build Rust shared-library checks on windows")
+
+    specs = _load_manifest(manifest)
+    selected, skipped = _select_checks(specs, platform)
+
+    if skipped:
+        print(f"Skipping checks not supported on this platform: {skipped}")
+
+    if not selected:
+        print("No Rust shared-library checks selected; leaving checks.d untouched.")
+        return
+
+    checks_d_path.mkdir(parents=True, exist_ok=True)
+
+    ext = _lib_extension(platform)
+
+    managed_ids = {s.id for s in specs}
+    for check_id in managed_ids:
+        candidate = checks_d_path / f"libdatadog-agent-{check_id}.{ext}"
+        if candidate.exists():
+            candidate.unlink()
+
+    rustchecks_dir = repo_root / "pkg/collector/sharedlibrary/rustchecks"
+    build_env = _cargo_build_env(repo_root)
+    cargo_args = [
+        "@rules_rust//tools/upstream_wrapper:cargo",
+        "--",
+        "build",
+        "--release",
+        "--manifest-path",
+        str(rustchecks_dir / "Cargo.toml"),
+    ]
+    for s in selected:
+        cargo_args += ["-p", s.crate]
+
+    bazel_run_args = [
+        "run",
+        "--remote_download_outputs=all",
+        f"--action_env=CARGO_HOME={build_env['CARGO_HOME']}",
+    ]
+
+    with gitlab_section("Build Rust shared-library checks", collapsed=True):
+        bazel(ctx, *bazel_run_args, *cargo_args)
+
+    target_mode = 0o500
+    for s in selected:
+        built_lib = rustchecks_dir / "target" / "release" / f"lib{s.crate}.{ext}"
+        if not built_lib.exists():
+            raise Exit(f"Expected built library not found: {built_lib}")
+
+        staged_lib = checks_d_path / f"libdatadog-agent-{s.id}.{ext}"
+        shutil.copy2(built_lib, staged_lib)
+        os.chmod(staged_lib, target_mode)
+
+        print(f"Staged {staged_lib}")


### PR DESCRIPTION
### What does this PR do?

End-to-end path from RC `DEBUG` task to a run-once Rust `example` shared-library check.

```
RC DEBUG {"tasks":[{"name":"trigger"}]}
  → exampletaskmanager subscribes & receives
  → Autodiscovery ConfigChanges.Schedule (in-memory check config)
  → sharedlibrary loader dlopen + Run
  → Rust check::check()
```

Same pattern as [kafka_actions](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/core/autodiscovery/providers/datastreams/kafka_actions.go): Autodiscovery provider → RC → [`ConfigChanges.Schedule`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/core/autodiscovery/providers/datastreams/kafka_actions.go#L201). For Python, kafka_actions sets [`run_once: true`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/core/autodiscovery/providers/datastreams/kafka_actions.go#L190) on the instance; the [python loader](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/python/check.go#L295-L297) maps that to `interval = 0` at **check configure time** (runtime). This PR does the equivalent for shared-library checks via [`min_collection_interval: 0`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/impl/handler.go#L20).

---

### Step 1 — Connect to RC

- Register Autodiscovery config provider: [exampletaskmanager.go](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/impl/exampletaskmanager.go#L119)
- Subscribe to RC `DEBUG` product: [exampletaskmanager.go](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/impl/exampletaskmanager.go#L94)

---

### Step 2 — Receive RC payload

- [`onUpdate` handler](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/impl/handler.go#L40-L69)

Expected RC payload:

```json
{"tasks": [{"name": "trigger"}]}
```

---

### Step 3 — Build → Schedule → **interval 0** → Run once

1. **Build** — [`buildCheckConfig`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/impl/handler.go#L81-L87) assembles an in-memory [`integration.Config`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/impl/handler.go#L81-L87) (no file on disk). Equivalent check YAML sent downstream to Autodiscovery / the collector:

   ```yaml
   # check name: example  (integration.Config.Name)
   init_config: {}

   instances:
     - min_collection_interval: 0
   ```

   Go struct ([`oneShotInstance`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/impl/handler.go#L20)):

   ```go
   integration.Config{
       Name:       "example",
       Source:     "exampletaskmanager:<rc-config-short-name>",  // e.g. exampletaskmanager:my-debug-key
       InitConfig: []byte("{}"),
       Instances:  []integration.Data{[]byte("min_collection_interval: 0\n")},
   }
   ```
2. **Schedule** — append to [`ConfigChanges.Schedule`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/impl/handler.go#L62) and [push to Autodiscovery](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/impl/handler.go#L67-L68); [config poller applies the change](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/core/autodiscovery/impl/config_poller.go#L106-L116) → collector [`getChecks` → `loader.Load`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/scheduler.go#L230-L288) → shared-library [`Open(libPath)`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/sharedlibraryimpl/loader.go#L55-L56) (**`dlopen` happens here**, not earlier)
3. **interval = 0** *(runtime change — this PR)* — at [`Configure`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/sharedlibraryimpl/check.go#L147), an explicit `min_collection_interval: 0` in instance YAML now sets [`c.interval = 0`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/sharedlibraryimpl/check.go#L158-L163). **Before:** missing key and explicit `0` both unmarshaled as `0`; only `> 0` updated the interval, so one-shot configs kept the [default 15s loop](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/check/defaults/defaults.go#L15). **After:** key present + `0` → one-shot. Same outcome as [python `run_once` → `interval = 0`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/python/check.go#L295-L297). 
4. **Run once** — [`Scheduler.Enter`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/scheduler/scheduler.go#L87-L91) sees `interval == 0` → [`enqueueOnce`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/scheduler/scheduler.go#L277-L294) → worker runs the check a single time



---

### Step 4 — Rust check execution

- [**`check()` implementation**](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/rustchecks/checks/example/src/check.rs#L6)

---

### State of the code

**Lines changed** (`main`…branch, 25 files, **+593 / −14**):

| Area | Files | + / − | Lines touched |
|------|------:|------:|----------------:|
| `exampletaskmanager` component | 10 | +319 / −0 | 319 |
| Runtime change (Rust check run once) | 1 | +10 / −2 | 12 |
| Build / packaging scripts | 8 | +239 / −2 | 241 |
| Misc (RC `DEBUG`, Jira/Slack, CODEOWNERS, FFI) | 6 | +23 / −10 | 33 |

---

**Component + example check** *(+319 / −0)*
- [comp/exampletaskmanager/](https://github.com/DataDog/datadog-agent/tree/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/) — Autodiscovery provider, RC `DEBUG` → schedule one-shot `example` check
- [checks/example/](https://github.com/DataDog/datadog-agent/tree/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/rustchecks/checks/example/) — POC Rust shared-library check (gauge / service_check / event)
- Wired in [cmd/agent/subcommands/run/command.go](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/cmd/agent/subcommands/run/command.go)
- RC `DEBUG` product: [product.go](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/config/remote/data/product.go), [products.go](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/remoteconfig/state/products.go)
- Provider name: [provider_names.go](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/core/autodiscovery/providers/names/provider_names.go)

**Build / packaging** *(+239 / −2)*

- [tasks/rust_shared_checks.py](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/tasks/rust_shared_checks.py) — `dda inv rust-shared-checks.build`; compiles Rust `cdylib` checks and stages `libdatadog-agent-<id>.(so|dylib)` into `checks.d` with **`chmod 0500`** at copy time
- [shared_checks_manifest.json](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.json) — which checks to build (`example` by default)
- [datadog-agent.rb](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/omnibus/config/software/datadog-agent.rb) — invokes the invoke task during omnibus build
- [datadog-agent-finalize.rb](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/omnibus/config/software/datadog-agent-finalize.rb#L94-L105) — moves staged `checks.d` into the package and enforces **`chmod 0500`** on `libdatadog-agent-*.so`
- [agent-dmg/postinst](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/omnibus/package-scripts/agent-dmg/postinst#L185-L193) — same owner-only mode on macOS after install
- [Dockerfiles/agent/Dockerfile](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/Dockerfiles/agent/Dockerfile#L206-L207), [agent-ddot/Dockerfile](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/Dockerfiles/agent-ddot/Dockerfile#L18-L19) — `chmod 0500` on `checks.d/*` after image `chmod -R` so shared-library loader permission checks pass ([rights_nix.go](https://github.com/DataDog/datadog-agent/blob/main/pkg/util/filesystem/rights_nix.go))

**Runtime scheduling change (Go loader)** *(+10 / −2)*
- [sharedlibraryimpl/check.go](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/sharedlibraryimpl/check.go#L156-L167) — explicit `min_collection_interval: 0` → `interval = 0`

**Misc** *(+23 / −10)*
- [ffi.rs](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/rustchecks/core/src/ffi.rs) — `$crate::` macro fix for shared-library FFI
- [CODEOWNERS](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/.github/CODEOWNERS), [github_jira_map.yaml](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/tasks/libs/pipeline/github_jira_map.yaml), [github_slack_map.yaml](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/tasks/libs/pipeline/github_slack_map.yaml)

### Describe how you validated your changes

**Local agent** — `docker-compose.yaml` at repo root *(not committed; local validation harness)*:

```yaml
services:
  agent:
    image: registry.ddbuild.io/ci/datadog-agent/agent:v123715649-8733a243-7-amd64
    container_name: dd-data-security-agent
    environment:
      DD_API_KEY: ${DD_API_KEY}
      DD_HOSTNAME: dbm-postgres
      DD_SITE: datad0g.com
      DD_APM_ENABLED: "true"
      DD_APM_NON_LOCAL_TRAFFIC: "true"
      DD_LOGS_ENABLED: "true"
      DD_DOGSTATSD_NON_LOCAL_TRAFFIC: "true"
      DD_LOG_LEVEL: "INFO"
      DD_SHARED_LIBRARY_CHECK_ENABLED: "true"
      DD_SHARED_LIBRARY_CHECK_LIBRARY_FOLDER_PATH: "/etc/datadog-agent/checks.d"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
```

```bash
export DD_API_KEY=<org2-staging-api-key>   # org2 staging
docker compose up
```

- **Image** — `registry.ddbuild.io/ci/datadog-agent/agent:v123715649-8733a243-7-amd64` is a **CI-built** agent image from this [PR’s pipeline ](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1844522202); it ships `libdatadog-agent-example.so` under `/etc/datadog-agent/checks.d`.
- `DD_SHARED_LIBRARY_CHECK_ENABLED=true` + `DD_SHARED_LIBRARY_CHECK_LIBRARY_FOLDER_PATH=/etc/datadog-agent/checks.d` — enables the shared-library loader / `exampletaskmanager` and loads the Rust check from `checks.d`.
- RC `DEBUG` [`test-aimene-example-tasks`](https://remote-config-admin.us1.prod.dog/?datacenter=us1.staging.dog&product=DEBUG&version=1&config_id=test-aimene-example-tasks) (`{"tasks":[{"name":"trigger"}]}`) → `exampletaskmanager` receives update → Autodiscovery schedules one-shot `example` (`min_collection_interval: 0`) → collector `dlopen` + single run.
- Result: [`hello.event`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/rustchecks/checks/example/src/check.rs#L15-L26) visible in org2 staging [Event Explorer (`host:dbm-postgres`)](https://dd.datad0g.com/event/explorer?query=host%3Adbm-postgres&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=&event=AwAAAZ9GygMASyVAkgAAABhBWjlHeWdNQUFBQVBibFM1R0M5akFBQUEAAAAkZjE5ZjQ2Y2ItNWFjMC00ZGFhLTg3MTYtNTY4MmNkNGM4ODlhAAAU-g&messageDisplay=expanded-lg&options=&refresh_mode=sliding&sort=DESC&from_ts=1783598279761&to_ts=1783599179761&live=true).

### Additional Notes

- `DEBUG` RC product is for dev/test only
- Example check only (`checks/example`)


### Q/A

#### When is `libdatadog-agent-example.so` loaded (`dlopen`)?

**On schedule (collector load), not on `exampletaskmanager` start.**

| Phase | What happens | `.so` loaded? |
|-------|----------------|---------------|
| Agent startup (`shared_library_check.enabled`) | [`InitSharedLibraryChecksLoader`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/sharedlibraryimpl/init.go#L24-L40) registers the shared-library check loader with the collector | No — only registers a loader factory |
| [`exampletaskmanager` `start`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/impl/exampletaskmanager.go#L111-L121) | [`AddConfigProvider`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/impl/exampletaskmanager.go#L119) registers the Autodiscovery provider; [`Stream`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/comp/exampletaskmanager/impl/exampletaskmanager.go#L75) subscribes to RC `DEBUG` when the poller starts | No |
| RC `onUpdate` → `ConfigChanges.Schedule` | In-memory check config pushed to Autodiscovery | No — config only |
| Autodiscovery applies schedule → collector | [`CheckLoader.Load`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/sharedlibraryimpl/loader.go#L46-L76) → [`Open(libPath)`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/sharedlibraryimpl/loader.go#L55-L56) then [`Configure`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/sharedlibraryimpl/loader.go#L74) | **Yes** |
| Worker `enqueueOnce` | FFI call into already-loaded `.so` | Already loaded |

**Unload:** `dlclose` runs when the check is stopped/unscheduled ([`Check.Cancel`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/rust-check-task-executions/pkg/collector/sharedlibrary/sharedlibraryimpl/check.go)). This POC does not `Unschedule` after the one-shot run, so the `.so` stays mapped until agent exit.







