### PR TITLE
[NDM] Apply SNMPv3 context_engine_id in connectivityCheck action

### DIFF
--- a/pkg/privateactionrunner/bundles/remoteaction/networkdevices/connectivity_check.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkdevices/connectivity_check.go
@@ -66,15 +66,16 @@ type ConnectivityCheckRequest struct {
 }
 
 type SNMPCredential struct {
-	ID           string `json:"id"`
-	Version      string `json:"version"`
-	Community    string `json:"community,omitempty"`
-	User         string `json:"user,omitempty"`
-	AuthProtocol string `json:"authProtocol,omitempty"`
-	AuthKey      string `json:"authKey,omitempty"`
-	PrivProtocol string `json:"privProtocol,omitempty"`
-	PrivKey      string `json:"privKey,omitempty"`
-	ContextName  string `json:"contextName,omitempty"`
+	ID              string `json:"id"`
+	Version         string `json:"version"`
+	Community       string `json:"community,omitempty"`
+	User            string `json:"user,omitempty"`
+	AuthProtocol    string `json:"authProtocol,omitempty"`
+	AuthKey         string `json:"authKey,omitempty"`
+	PrivProtocol    string `json:"privProtocol,omitempty"`
+	PrivKey         string `json:"privKey,omitempty"`
+	ContextName     string `json:"contextName,omitempty"`
+	ContextEngineID string `json:"contextEngineId,omitempty"`
 }
 
 type secretInputs struct {
@@ -340,6 +341,7 @@ func buildSNMPClient(ctx context.Context, host string, opts *SNMPOptions, cred S
 
 		c.SecurityModel = gosnmp.UserSecurityModel
 		c.ContextName = cred.ContextName
+		c.ContextEngineID = cred.ContextEngineID
 
 		c.SecurityParameters = &gosnmp.UsmSecurityParameters{
 			UserName:                 cred.User,


### PR DESCRIPTION
### What does this PR do?

Adds SNMPv3 `context_engine_id` to the connectivityCheck action: `ContextEngineID` on the decrypted `SNMPCredential`, and sets gosnmp's v3 `ContextEngineID` when building the client so it's used when probing the device.

### Motivation

Completes `context_engine_id` support end-to-end. The API side (ddoghq/dd-source#15432) sends it in the encrypted `secret_inputs` (`contextEngineId`); this is the Agent half that applies it.

### Describe how you validated your changes

`bazel build //pkg/privateactionrunner/bundles/remoteaction/networkdevices:all` passes.

### Additional Notes

Stacked on #53073 (base `martin.prevost/ACTP-1609/add-encryption-layer`); draft until #53073 and the dd-source side merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)