### PR TITLE
[EBPF] Track NVML utilization-only GPU processes

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -10,7 +10,6 @@ package nvml
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strconv"
 	"time"
 
@@ -147,6 +146,14 @@ func (c *collector) fillNVMLAttributes(gpuDeviceInfo *workloadmeta.GPU, device d
 
 func (c *collector) fillProcesses(gpuDeviceInfo *workloadmeta.GPU, device ddnvml.Device) {
 	seenPIDs := make(map[int]struct{})
+	appendPID := func(pid uint32) {
+		activePID := int(pid)
+		if _, ok := seenPIDs[activePID]; ok {
+			return
+		}
+		seenPIDs[activePID] = struct{}{}
+		gpuDeviceInfo.ActivePIDs = append(gpuDeviceInfo.ActivePIDs, activePID)
+	}
 
 	procs, err := device.GetComputeRunningProcesses()
 	if err != nil {
@@ -156,7 +163,7 @@ func (c *collector) fillProcesses(gpuDeviceInfo *workloadmeta.GPU, device ddnvml
 	}
 
 	for _, proc := range procs {
-		seenPIDs[int(proc.Pid)] = struct{}{}
+		appendPID(proc.Pid)
 	}
 
 	// GetProcessUtilization can show more processes than GetComputeRunningProcesses, but it might not be supported by all devices.
@@ -168,14 +175,8 @@ func (c *collector) fillProcesses(gpuDeviceInfo *workloadmeta.GPU, device ddnvml
 	}
 
 	for _, proc := range utilizationProcs {
-		seenPIDs[int(proc.Pid)] = struct{}{}
+		appendPID(proc.Pid)
 	}
-
-	gpuDeviceInfo.ActivePIDs = make([]int, 0, len(seenPIDs))
-	for pid := range seenPIDs {
-		gpuDeviceInfo.ActivePIDs = append(gpuDeviceInfo.ActivePIDs, pid)
-	}
-	slices.Sort(gpuDeviceInfo.ActivePIDs)
 }
 
 // newCollector creates a new collector with the default values, useful for testing.

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -180,6 +181,7 @@ func (c *collector) fillProcesses(gpuDeviceInfo *workloadmeta.GPU, device ddnvml
 	for pid := range seenPIDs {
 		gpuDeviceInfo.ActivePIDs = append(gpuDeviceInfo.ActivePIDs, pid)
 	}
+	slices.Sort(gpuDeviceInfo.ActivePIDs) // Sort to ensure the gpu device info doesn't change due to PID ordering changes
 }
 
 // newCollector creates a new collector with the default values, useful for testing.

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -44,7 +44,7 @@ type collector struct {
 	seenPIDsToGPUs                     map[int][]string // PID -> GPU UUIDs
 	reportedDriverNotLoaded            bool
 	integrateWithWorkloadmetaProcesses bool
-	lastCollectionTimestamp            uint64
+	lastCollectionTimestamp            time.Time
 }
 
 func (c *collector) getGPUDeviceInfo(device ddnvml.Device) (*workloadmeta.GPU, error) {
@@ -160,7 +160,7 @@ func (c *collector) fillProcesses(gpuDeviceInfo *workloadmeta.GPU, device ddnvml
 	}
 
 	// GetProcessUtilization can show more processes than GetComputeRunningProcesses, but it might not be supported by all devices.
-	utilizationProcs, err := device.GetProcessUtilization(c.lastCollectionTimestamp)
+	utilizationProcs, err := device.GetProcessUtilization(uint64(c.lastCollectionTimestamp.UnixMicro()))
 	if err != nil {
 		var nvmlErr *ddnvml.NvmlAPIError
 		if errors.As(err, &nvmlErr) && errors.Is(nvmlErr.NvmlErrorCode, nvml.ERROR_NOT_FOUND) {
@@ -192,7 +192,7 @@ func newCollector(store workloadmeta.Component, config config.Component) *collec
 		seenUUIDs:               map[string]struct{}{},
 		seenPIDsToGPUs:          make(map[int][]string),
 		store:                   store,
-		lastCollectionTimestamp: uint64(time.Now().UnixMicro()),
+		lastCollectionTimestamp: time.Now(),
 	}
 
 	if config != nil {
@@ -273,7 +273,7 @@ func (c *collector) Pull(ctx context.Context) error {
 	// add/update current devices
 	currentUUIDs := map[string]struct{}{}
 	pidToGPUs := make(map[int][]string) // PID -> GPU UUIDs
-	timestamp := time.Now().UnixMicro()
+	timestamp := time.Now()
 	var events []workloadmeta.CollectorEvent
 	for _, dev := range allDevices {
 		gpu, err := c.getGPUDeviceInfo(dev)
@@ -326,7 +326,7 @@ func (c *collector) Pull(ctx context.Context) error {
 	}
 
 	c.store.Notify(events)
-	c.lastCollectionTimestamp = uint64(timestamp)
+	c.lastCollectionTimestamp = timestamp
 
 	return nil
 }

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -9,6 +9,7 @@ package nvml
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -20,7 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
-	"github.com/DataDog/datadog-agent/pkg/errors"
+	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	gpuutil "github.com/DataDog/datadog-agent/pkg/util/gpu"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -146,15 +147,6 @@ func (c *collector) fillNVMLAttributes(gpuDeviceInfo *workloadmeta.GPU, device d
 
 func (c *collector) fillProcesses(gpuDeviceInfo *workloadmeta.GPU, device ddnvml.Device) {
 	seenPIDs := make(map[int]struct{})
-	appendPID := func(pid uint32) {
-		activePID := int(pid)
-		if _, ok := seenPIDs[activePID]; ok {
-			return
-		}
-		seenPIDs[activePID] = struct{}{}
-		gpuDeviceInfo.ActivePIDs = append(gpuDeviceInfo.ActivePIDs, activePID)
-	}
-
 	procs, err := device.GetComputeRunningProcesses()
 	if err != nil {
 		if logLimiter.ShouldLog() {
@@ -163,19 +155,30 @@ func (c *collector) fillProcesses(gpuDeviceInfo *workloadmeta.GPU, device ddnvml
 	}
 
 	for _, proc := range procs {
-		appendPID(proc.Pid)
+		seenPIDs[int(proc.Pid)] = struct{}{}
 	}
 
 	// GetProcessUtilization can show more processes than GetComputeRunningProcesses, but it might not be supported by all devices.
 	utilizationProcs, err := device.GetProcessUtilization(c.lastCollectionTimestamp)
 	if err != nil {
-		if logLimiter.ShouldLog() {
-			log.Debugf("%v for %d", err, gpuDeviceInfo.Index)
+		var nvmlErr *ddnvml.NvmlAPIError
+		if errors.As(err, &nvmlErr) && errors.Is(nvmlErr.NvmlErrorCode, nvml.ERROR_NOT_FOUND) {
+			utilizationProcs = nil // error not found occurs normally when no process is using the GPU, clear the array to avoid processing any data
+		} else {
+			// only logs
+			if logLimiter.ShouldLog() {
+				log.Debugf("%v for %d", err, gpuDeviceInfo.Index)
+			}
 		}
 	}
 
 	for _, proc := range utilizationProcs {
-		appendPID(proc.Pid)
+		seenPIDs[int(proc.Pid)] = struct{}{}
+	}
+
+	gpuDeviceInfo.ActivePIDs = make([]int, 0, len(seenPIDs))
+	for pid := range seenPIDs {
+		gpuDeviceInfo.ActivePIDs = append(gpuDeviceInfo.ActivePIDs, pid)
 	}
 }
 
@@ -212,7 +215,7 @@ func GetFxOptions() fx.Option {
 // Start initializes the NVML library and sets the store
 func (c *collector) Start(_ context.Context, store workloadmeta.Component) error {
 	if !env.IsFeaturePresent(env.NVML) {
-		return errors.NewDisabled(componentName, "Agent does not have NVML library available")
+		return dderrors.NewDisabled(componentName, "Agent does not have NVML library available")
 	}
 
 	c.store = store
@@ -268,6 +271,7 @@ func (c *collector) Pull(ctx context.Context) error {
 	// add/update current devices
 	currentUUIDs := map[string]struct{}{}
 	pidToGPUs := make(map[int][]string) // PID -> GPU UUIDs
+	timestamp := time.Now().UnixMicro()
 	var events []workloadmeta.CollectorEvent
 	for _, dev := range allDevices {
 		gpu, err := c.getGPUDeviceInfo(dev)
@@ -320,7 +324,7 @@ func (c *collector) Pull(ctx context.Context) error {
 	}
 
 	c.store.Notify(events)
-	c.lastCollectionTimestamp = uint64(time.Now().UnixMicro())
+	c.lastCollectionTimestamp = uint64(timestamp)
 
 	return nil
 }

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -10,6 +10,7 @@ package nvml
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -42,6 +43,7 @@ type collector struct {
 	seenPIDsToGPUs                     map[int][]string // PID -> GPU UUIDs
 	reportedDriverNotLoaded            bool
 	integrateWithWorkloadmetaProcesses bool
+	lastCollectionTimestamp            uint64
 }
 
 func (c *collector) getGPUDeviceInfo(device ddnvml.Device) (*workloadmeta.GPU, error) {
@@ -144,27 +146,47 @@ func (c *collector) fillNVMLAttributes(gpuDeviceInfo *workloadmeta.GPU, device d
 }
 
 func (c *collector) fillProcesses(gpuDeviceInfo *workloadmeta.GPU, device ddnvml.Device) {
+	seenPIDs := make(map[int]struct{})
+
 	procs, err := device.GetComputeRunningProcesses()
 	if err != nil {
 		if logLimiter.ShouldLog() {
 			log.Warnf("%v for %d", err, gpuDeviceInfo.Index)
 		}
-		return
 	}
 
 	for _, proc := range procs {
-		gpuDeviceInfo.ActivePIDs = append(gpuDeviceInfo.ActivePIDs, int(proc.Pid))
+		seenPIDs[int(proc.Pid)] = struct{}{}
 	}
+
+	// GetProcessUtilization can show more processes than GetComputeRunningProcesses, but it might not be supported by all devices.
+	utilizationProcs, err := device.GetProcessUtilization(c.lastCollectionTimestamp)
+	if err != nil {
+		if logLimiter.ShouldLog() {
+			log.Debugf("%v for %d", err, gpuDeviceInfo.Index)
+		}
+	}
+
+	for _, proc := range utilizationProcs {
+		seenPIDs[int(proc.Pid)] = struct{}{}
+	}
+
+	gpuDeviceInfo.ActivePIDs = make([]int, 0, len(seenPIDs))
+	for pid := range seenPIDs {
+		gpuDeviceInfo.ActivePIDs = append(gpuDeviceInfo.ActivePIDs, pid)
+	}
+	slices.Sort(gpuDeviceInfo.ActivePIDs)
 }
 
 // newCollector creates a new collector with the default values, useful for testing.
 func newCollector(store workloadmeta.Component, config config.Component) *collector {
 	collector := &collector{
-		id:             collectorID,
-		catalog:        workloadmeta.NodeAgent,
-		seenUUIDs:      map[string]struct{}{},
-		seenPIDsToGPUs: make(map[int][]string),
-		store:          store,
+		id:                      collectorID,
+		catalog:                 workloadmeta.NodeAgent,
+		seenUUIDs:               map[string]struct{}{},
+		seenPIDsToGPUs:          make(map[int][]string),
+		store:                   store,
+		lastCollectionTimestamp: uint64(time.Now().UnixMicro()),
 	}
 
 	if config != nil {
@@ -297,6 +319,7 @@ func (c *collector) Pull(ctx context.Context) error {
 	}
 
 	c.store.Notify(events)
+	c.lastCollectionTimestamp = uint64(time.Now().UnixMicro())
 
 	return nil
 }

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -35,15 +35,20 @@ func TestPull(t *testing.T) {
 	gpus := wmetaMock.ListGPUs()
 	require.Equal(t, testutil.GetTotalExpectedDevices(), len(gpus))
 	expectedActivePIDs := testutil.DefaultActivePIDs()
+	expectedPhysicalActivePIDs := slices.Clone(expectedActivePIDs)
+	expectedPhysicalActivePIDs = append(expectedPhysicalActivePIDs, 1234)
+	slices.Sort(expectedPhysicalActivePIDs)
 
 	foundIDs := make(map[string]bool)
 	for _, gpu := range gpus {
 		foundIDs[gpu.ID] = true
 		var expectedName string
+		expectedGPUActivePIDs := expectedActivePIDs
 		if gpu.DeviceType == workloadmeta.GPUDeviceTypeMIG {
 			expectedName = testutil.DefaultGPUName + " MIG 3g.40gb"
 		} else if gpu.DeviceType == workloadmeta.GPUDeviceTypePhysical {
 			expectedName = testutil.DefaultGPUName
+			expectedGPUActivePIDs = expectedPhysicalActivePIDs
 			//for now, we test totalMemory only for physical devices
 			require.Equal(t, testutil.DefaultTotalMemory, gpu.TotalMemory, "unexpected device memory for device %s", gpu.ID)
 		}
@@ -56,7 +61,7 @@ func TestPull(t *testing.T) {
 		require.Equal(t, testutil.DefaultGPUComputeCapMinor, gpu.ComputeCapability.Minor)
 		require.Equal(t, testutil.DefaultMaxClockRates[nvml.CLOCK_SM], gpu.MaxClockRates[workloadmeta.GPUSM])
 		require.Equal(t, testutil.DefaultMaxClockRates[nvml.CLOCK_MEM], gpu.MaxClockRates[workloadmeta.GPUMemory])
-		require.Equal(t, expectedActivePIDs, gpu.ActivePIDs)
+		require.Equal(t, expectedGPUActivePIDs, gpu.ActivePIDs)
 		require.Equal(t, "none", gpu.VirtualizationMode)
 	}
 
@@ -101,6 +106,7 @@ func TestGpuProcessInfoUpdate(t *testing.T) {
 	// Now change those PIDs and make sure the store is updated and we get a complete override
 	// of the previous PIDs
 	expectedActivePIDs = []int{9761, 1234}
+	slices.Sort(expectedActivePIDs)
 	processInfo = testutil.MockProcessInfoList{
 		{Pid: uint32(expectedActivePIDs[0]), UsedGpuMemory: 100},
 		{Pid: uint32(expectedActivePIDs[1]), UsedGpuMemory: 200},

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -61,7 +61,7 @@ func TestPull(t *testing.T) {
 		require.Equal(t, testutil.DefaultGPUComputeCapMinor, gpu.ComputeCapability.Minor)
 		require.Equal(t, testutil.DefaultMaxClockRates[nvml.CLOCK_SM], gpu.MaxClockRates[workloadmeta.GPUSM])
 		require.Equal(t, testutil.DefaultMaxClockRates[nvml.CLOCK_MEM], gpu.MaxClockRates[workloadmeta.GPUMemory])
-		require.Equal(t, expectedGPUActivePIDs, gpu.ActivePIDs)
+		require.ElementsMatch(t, expectedGPUActivePIDs, gpu.ActivePIDs)
 		require.Equal(t, "none", gpu.VirtualizationMode)
 	}
 
@@ -74,16 +74,6 @@ func TestPull(t *testing.T) {
 			require.True(t, foundIDs[migChildUUID], "MIG child GPU %s not found", migChildUUID)
 		}
 	}
-}
-
-func requireSamePIDs(t *testing.T, expected, actual []int) {
-	t.Helper()
-
-	expected = slices.Clone(expected)
-	actual = slices.Clone(actual)
-	slices.Sort(expected)
-	slices.Sort(actual)
-	require.Equal(t, expected, actual)
 }
 
 func TestGpuProcessInfoUpdate(t *testing.T) {
@@ -110,7 +100,7 @@ func TestGpuProcessInfoUpdate(t *testing.T) {
 	require.Equal(t, testutil.GetTotalExpectedDevices(), len(gpus))
 
 	for _, gpu := range gpus {
-		requireSamePIDs(t, expectedActivePIDs, gpu.ActivePIDs)
+		require.ElementsMatch(t, expectedActivePIDs, gpu.ActivePIDs)
 	}
 
 	// Now change those PIDs and make sure the store is updated and we get a complete override
@@ -126,7 +116,7 @@ func TestGpuProcessInfoUpdate(t *testing.T) {
 	require.Equal(t, testutil.GetTotalExpectedDevices(), len(gpus))
 
 	for _, gpu := range gpus {
-		requireSamePIDs(t, expectedActivePIDs, gpu.ActivePIDs)
+		require.ElementsMatch(t, expectedActivePIDs, gpu.ActivePIDs)
 	}
 }
 

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -371,7 +371,7 @@ func TestPullWithMIGDevices(t *testing.T) {
 			require.Less(t, migGPU.TotalMemory, parentGPU.TotalMemory, "MIG device should have less memory than parent")
 
 			// Verify MIG device has process info
-			require.Equal(t, testutil.DefaultActivePIDs(), migGPU.ActivePIDs)
+			require.ElementsMatch(t, testutil.DefaultActivePIDs(), migGPU.ActivePIDs)
 		}
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -76,6 +76,16 @@ func TestPull(t *testing.T) {
 	}
 }
 
+func requireSamePIDs(t *testing.T, expected, actual []int) {
+	t.Helper()
+
+	expected = slices.Clone(expected)
+	actual = slices.Clone(actual)
+	slices.Sort(expected)
+	slices.Sort(actual)
+	require.Equal(t, expected, actual)
+}
+
 func TestGpuProcessInfoUpdate(t *testing.T) {
 	// Seed the callback with the default process info so the first pull mirrors
 	// the package defaults without mutating any global state.
@@ -100,13 +110,12 @@ func TestGpuProcessInfoUpdate(t *testing.T) {
 	require.Equal(t, testutil.GetTotalExpectedDevices(), len(gpus))
 
 	for _, gpu := range gpus {
-		require.Equal(t, expectedActivePIDs, gpu.ActivePIDs)
+		requireSamePIDs(t, expectedActivePIDs, gpu.ActivePIDs)
 	}
 
 	// Now change those PIDs and make sure the store is updated and we get a complete override
 	// of the previous PIDs
 	expectedActivePIDs = []int{9761, 1234}
-	slices.Sort(expectedActivePIDs)
 	processInfo = testutil.MockProcessInfoList{
 		{Pid: uint32(expectedActivePIDs[0]), UsedGpuMemory: 100},
 		{Pid: uint32(expectedActivePIDs[1]), UsedGpuMemory: 200},
@@ -117,7 +126,7 @@ func TestGpuProcessInfoUpdate(t *testing.T) {
 	require.Equal(t, testutil.GetTotalExpectedDevices(), len(gpus))
 
 	for _, gpu := range gpus {
-		require.Equal(t, expectedActivePIDs, gpu.ActivePIDs)
+		requireSamePIDs(t, expectedActivePIDs, gpu.ActivePIDs)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Includes GPU processes reported by NVML utilization sampling in workloadmeta GPU active PIDs.

### Motivation

Some active GPU processes can be absent from `GetComputeRunningProcesses`, which makes workloadmeta miss their GPU association.

### Describe how you validated your changes

Updated unit test expectations. Local execution skipped because the package is gated by `linux && nvml` on this macOS host.

### Additional Notes