### PR TITLE
[Test 6.53.x] Trigger baseline CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To build the Agent you need:
       interpreter and libraries. By default, this environment is only used for dev dependencies
       listed in `requirements.txt`.
 
-**Note:** You may have previously installed `invoke` via brew on MacOS, or `pip` in
+**Note:** You may have previously installed `invoke` via brew on macOS, or `pip` in
       any other platform. We recommend you use the version pinned in the requirements
       file for a smooth development/build experience.
 


### PR DESCRIPTION
## What

Creates a README-only change on top of current 6.53.x to trigger a baseline PR pipeline.

## Why

This checks whether current 6.53.x CI is already broken independently of the buildimage backport.

## Validation

- Signed commit created locally
- Pre-push hooks passed