### PR TITLE
fix(e2e): accept auto multi-line log tags

### DIFF
--- a/test/new-e2e/tests/containers/base_test.go
+++ b/test/new-e2e/tests/containers/base_test.go
@@ -292,9 +292,20 @@ func (suite *baseSuite[Env]) testLog(args *testLogArgs) {
 
 			// Check tags
 			if expectedTags != nil {
-				// Allow additional logsource tags (e.g. logsource:stdout, logsource:stderr) without failing the test.
+				// Allow additional tags that the Agent may legitimately attach but that
+				// are not deterministic per log line, so they must not fail the assertion:
+				//   - logsource:*            e.g. logsource:stdout, logsource:stderr
+				//   - multiline:*            added by auto multi-line detection when lines are
+				//                            combined (e.g. multiline:auto_multiline, multiline:go_stack).
+				//                            auto_multi_line_detection defaults to true, so any log
+				//                            line may carry this tag depending on its content.
+				//   - auto_multiline_detected:*  added when a multi-line group start is detected.
+				//   - truncated:*            added when a log line is truncated.
 				optionalTags := []*regexp.Regexp{
 					regexp.MustCompile("logsource:.*"),
+					regexp.MustCompile("multiline:.*"),
+					regexp.MustCompile("auto_multiline_detected:.*"),
+					regexp.MustCompile("truncated:.*"),
 				}
 				err := assertTags(logs[len(logs)-1].GetTags(), expectedTags, optionalTags, false)
 				assert.NoErrorf(c, err, "Tags mismatch on `%s`", prettyLogQuery)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5fb8722f-0ac3-4b44-8b11-48306dc526a1","source":"chat","resourceId":"94fb370f-b825-4328-b85a-d7e52bd3e6dd","workflowId":"7cf1009f-7d00-4afd-b279-0f5066e0ed27","codeChangeId":"7cf1009f-7d00-4afd-b279-0f5066e0ed27","sourceType":"bits_ai_sre"} -->
### What does this PR do?

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/31220f19-e84d-467f-9b56-3a32c68959c7)

Extends the optional-tags allowlist in the shared `testLog` helper (`test/new-e2e/tests/containers/base_test.go`) so container log assertions tolerate the non-deterministic tags attached by auto multi-line log detection: `multiline:*`, `auto_multiline_detected:*`, and `truncated:*` (in addition to the existing `logsource:*`).

### Motivation

Commit #53007 intentionally flipped `logs_config.auto_multi_line_detection` to default `true` (shipped enhancement with release note). With this feature on — and `tag_multi_line_logs`/`auto_multi_line_detection_tagging` also defaulting to `true` — the logs preprocessor may attach extra tags to any log line depending on its content and timing:

- `multiline:auto_multiline` / `multiline:go_stack` — combining and stack-trace aggregators
- `auto_multiline_detected:true` — detecting aggregator
- `truncated:<reason>` — truncation path

The shared `testLog` helper only allowed `logsource:.*` as optional and asserted with `acceptUnexpectedTags=false`, so these new tags produced an "unexpected tags" mismatch, failing the `new-e2e-containers-eks` test `TestNginxFargate` (and putting every other container log assertion at risk). The config default change is the intended feature, so the correct fix is on the test side. `testLog` is the single helper shared by all container log tests (k8s/eks/ecs), so updating its optional-tags list here fixes all of them in one place.

### Describe how you validated your changes

- Traced the tag producers in `pkg/logs/internal/decoder/preprocessor/` (combining/detecting/stack-trace aggregators) and `pkg/logs/message/message.go` to confirm the exact tag keys emitted when the feature is enabled.
- Confirmed via `git log` that the default flip came from #53007 (has a release note), so reverting the config would be wrong.
- `go build ./tests/containers/` in the `test/new-e2e` module passes (exit 0).
- `gofmt` reports no diff on the edited file.

### Additional Notes

Tags are added to the optional list (not the expected list) because they appear only when lines are combined/detected/truncated, which is content- and timing-dependent — requiring them would make the assertions flaky in the opposite direction.

This should address #incident-57446

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/94fb370f-b825-4328-b85a-d7e52bd3e6dd)

Comment @datadog to request changes