### PR TITLE
Revert "enable auto multi line detection by default"

### DIFF
--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -673,17 +673,7 @@ func (c *LogsConfig) AutoMultiLineStatus(coreConfig pkgconfigmodel.Reader) (enab
 // considering both the agent-wide logs_config.auto_multi_line_detection and any config for this
 // particular log source.
 func (c *LogsConfig) AutoMultiLineEnabled(coreConfig pkgconfigmodel.Reader) bool {
-	enabled, isDefault := c.AutoMultiLineStatus(coreConfig)
-	if c.Type == UDPType {
-		if isDefault {
-			// UDP datagrams are documented as complete messages; don't let them
-			// silently inherit the global auto-multi-line default.
-			return false
-		}
-		if enabled {
-			log.Warn("Auto multi line detection is not supported for UDP sources, but it has been enabled for log source:", c.Source)
-		}
-	}
+	enabled, _ := c.AutoMultiLineStatus(coreConfig)
 	return enabled
 }
 

--- a/comp/logs/agent/config/integration_config_test.go
+++ b/comp/logs/agent/config/integration_config_test.go
@@ -155,10 +155,10 @@ func TestAutoMultiLineStatus(t *testing.T) {
 		assert.False(t, isDefault)
 	})
 
-	t.Run("autoMultiLine is configured by default", func(t *testing.T) {
+	t.Run("nothing configured is default", func(t *testing.T) {
 		mockConfig := config.NewMock(t)
 		enabled, isDefault := decode(`{}`).AutoMultiLineStatus(mockConfig)
-		assert.True(t, enabled)
+		assert.False(t, enabled)
 		assert.True(t, isDefault)
 	})
 

--- a/comp/metadata/host/impl/utils/host_test.go
+++ b/comp/metadata/host/impl/utils/host_test.go
@@ -57,15 +57,15 @@ func TestGetLogsMeta(t *testing.T) {
 
 	status.SetCurrentTransport("")
 	meta := getLogsMeta(conf)
-	assert.Equal(t, &LogsMeta{Transport: "", AutoMultilineEnabled: true}, meta)
+	assert.Equal(t, &LogsMeta{Transport: "", AutoMultilineEnabled: false}, meta)
 
 	status.SetCurrentTransport(status.TransportTCP)
 	meta = getLogsMeta(conf)
-	assert.Equal(t, &LogsMeta{Transport: "TCP", AutoMultilineEnabled: true}, meta)
-
-	conf.SetInTest("logs_config.auto_multi_line_detection", false)
-	meta = getLogsMeta(conf)
 	assert.Equal(t, &LogsMeta{Transport: "TCP", AutoMultilineEnabled: false}, meta)
+
+	conf.SetInTest("logs_config.auto_multi_line_detection", true)
+	meta = getLogsMeta(conf)
+	assert.Equal(t, &LogsMeta{Transport: "TCP", AutoMultilineEnabled: true}, meta)
 }
 
 func TestGetInstallMethod(t *testing.T) {

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1267,8 +1267,8 @@ api_key:
 #       name: <RULE_NAME>
 #       pattern: <RULE_PATTERN>
 
-#   # @param auto_multi_line_detection - boolean - optional - default: true
-#   # @env DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION - boolean - optional - default: true
+#   # @param auto_multi_line_detection - boolean - optional - default: false
+#   # @env DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION - boolean - optional - default: false
 #   # Enable automatic aggregation of multi-line logs for common log patterns.
 #   # More information can be found in Datadog documentation:
 #   # https://docs.datadoghq.com/agent/logs/auto_multiline_detection/?tab=configurationfile

--- a/pkg/config/schema/yaml/logs_config.yaml
+++ b/pkg/config/schema/yaml/logs_config.yaml
@@ -65,12 +65,13 @@ properties:
   auto_multi_line_detection:
     node_type: setting
     type: boolean
-    default: true
+    default: false
     visibility: public
     description: |-
       Enable automatic aggregation of multi-line logs for common log patterns.
       More information can be found in Datadog documentation:
       https://docs.datadoghq.com/agent/logs/auto_multiline_detection/?tab=configurationfile
+    example: 'true'
     comment: Auto multiline detection settings
   force_use_http:
     node_type: setting

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1890,7 +1890,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.windows_open_file_timeout", 5)
 
 	// Auto multiline detection settings
-	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection", true)
+	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection", false)
 	config.BindEnvAndSetDefault("logs_config.experimental_auto_multi_line_detection", false)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection_custom_samples", []map[string]interface{}{})
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.enable_json_detection", true)

--- a/releasenotes/notes/enable-auto-multi-line-detection-by-default-3deaa845f348b700.yaml
+++ b/releasenotes/notes/enable-auto-multi-line-detection-by-default-3deaa845f348b700.yaml
@@ -1,9 +1,0 @@
----
-enhancements:
-  - |
-    Automatic multi-line log detection (``logs_config.auto_multi_line_detection``)
-    is now enabled by default. Multi-line log messages such as stack traces and
-    JSON blobs are aggregated into a single log entry out of the box, instead of
-    being split into separate entries. To restore the previous behavior, set
-    ``logs_config.auto_multi_line_detection`` to ``false`` (or the environment
-    variable ``DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION=false``).


### PR DESCRIPTION
Reverts DataDog/datadog-agent#53007

[#incident-57446](https://dd.enterprise.slack.com/archives/C0BFSELLSDV)