### PR TITLE
Use toolchain-resolution for os-specific rpath patching (individual files)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -173,6 +173,12 @@ register_toolchains(
     dev_dependency = True,
 )
 
+register_toolchains(
+    "//bazel/toolchains/rpath_rewriter:install_name_tool_toolchain",
+    "//bazel/toolchains/rpath_rewriter:noop_windows_toolchain",
+    "//bazel/toolchains/rpath_rewriter:patchelf_toolchain",
+)
+
 find_rpmbuild = use_extension("@rules_pkg//toolchains/rpm:rpmbuild_configure.bzl", "find_system_rpmbuild_bzlmod", dev_dependency = True)
 use_repo(find_rpmbuild, "rules_pkg_rpmbuild")
 

--- a/bazel/rules/dd_packaging/dd_cc_packaged.bzl
+++ b/bazel/rules/dd_packaging/dd_cc_packaged.bzl
@@ -7,7 +7,7 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
 load("//bazel/rules:so_symlink.bzl", "so_symlink")
 load("//bazel/rules/dd_packaging:dd_packaging_info.bzl", "DdPackagingInfo")
-load("//bazel/rules/rewrite_rpath:rewrite_rpath.bzl", "otool_dir_action", "otool_file_action", "patchelf_dir_action", "patchelf_file_action", "rewrite_rpath")
+load("//bazel/rules/rewrite_rpath:rewrite_rpath.bzl", "otool_dir_action", "patchelf_dir_action", "rewrite_rpath", "rewrite_rpaths_for_files")
 
 def _is_os(ctx, constraint):
     return ctx.target_platform_has_constraint(constraint[platform_common.ConstraintValueInfo])
@@ -32,14 +32,7 @@ def _dd_packaged_files_impl(ctx):
                     out = f
                 dest = prefix
             else:
-                if is_linux:
-                    out = ctx.actions.declare_file("patched/" + f.basename)
-                    patchelf_file_action(ctx, f, out, rpath)
-                elif is_macos:
-                    out = ctx.actions.declare_file("patched/" + f.basename)
-                    otool_file_action(ctx, f, out, rpath)
-                else:
-                    out = f
+                out = rewrite_rpaths_for_files(ctx, inputs = [f], rpath = rpath)[0]
                 dest = (prefix + "/" + f.basename) if prefix else f.basename
             dest_src_map[dest] = out
 
@@ -78,6 +71,7 @@ _dd_packaged_files_rule = rule(
         "_install_dir": attr.label(default = "@@//:install_dir"),
     },
     toolchains = [
+        "//bazel/toolchains/rpath_rewriter",
         "@@//bazel/toolchains/patchelf:patchelf_toolchain_type",
         "@@//bazel/toolchains/otool:otool_toolchain_type",
     ],
@@ -125,6 +119,7 @@ _dd_cc_packaged_rule = rule(
 
 def _dd_cc_packaged_impl(name, input, version = "", installed_files = [], installed_executables = {}, libname = "", prefix = "", dest_dir = "", visibility = None, **kwargs):
     patched_name = "{}_patched".format(name)
+
     rewrite_rpath(
         name = patched_name,
         inputs = [input],

--- a/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
+++ b/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
@@ -1,59 +1,6 @@
-"""Set a binary's rpath to the provided value.
-
-If no rpath is provided, this defaults to <@@//:install_dir>/embedded/lib.
-"""
+"""Set a binary's rpath to the provided value."""
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-
-def _is_os(ctx, constraint):
-    return ctx.target_platform_has_constraint(constraint[platform_common.ConstraintValueInfo])
-
-def patchelf_file_action(ctx, input_file, output_file, rpath):
-    """Registers a patchelf action to rewrite the rpath of a single file.
-
-    Args:
-      ctx: the rule context.
-      input_file: the source File to patch.
-      output_file: the output File to write.
-      rpath: the rpath string to set.
-    """
-    toolchain = ctx.toolchains["@@//bazel/toolchains/patchelf:patchelf_toolchain_type"].patchelf
-    patchelf = toolchain.label[DefaultInfo].files_to_run
-    args = ctx.actions.args()
-    args.add("--set-rpath", rpath)
-    args.add("--force-rpath")
-    args.add(input_file.path)
-    args.add("--output", output_file.path)
-    ctx.actions.run(
-        inputs = [input_file],
-        outputs = [output_file],
-        arguments = [args],
-        executable = patchelf,
-    )
-
-def otool_file_action(ctx, input_file, output_file, rpath):
-    """Registers an install_name_tool action to rewrite the rpath of a single file.
-
-    Args:
-      ctx: the rule context.
-      input_file: the source File to patch.
-      output_file: the output File to write.
-      rpath: the rpath string to set.
-    """
-    otool = ctx.toolchains["@@//bazel/toolchains/otool:otool_toolchain_type"].otool
-    args = ctx.actions.args()
-    args.add(ctx.executable._install_name_tool.path)
-    args.add(otool.path)
-    args.add(rpath)
-    args.add(input_file.path)
-    args.add(output_file.path)
-    ctx.actions.run(
-        inputs = [input_file],
-        tools = [ctx.executable._install_name_tool],
-        outputs = [output_file],
-        executable = ctx.file._script,
-        arguments = [args],
-    )
 
 def patchelf_dir_action(ctx, input_dir, output_dir, rpath):
     """Registers a patchelf action to rewrite the rpath of all shared libraries inside a directory.
@@ -111,24 +58,43 @@ def otool_dir_action(ctx, input_dir, output_dir, rpath):
         arguments = [args],
     )
 
+def rewrite_rpaths_for_files(ctx, inputs, rpath):
+    """Creates actions to apply an rpath rewriter to the inputs.
+
+    Args:
+      ctx: the rule context.
+      inputs: the files to patch.
+      rpath: the rpath to set.
+
+    Returns:
+      A list of the generated outputs
+    """
+    toolchain = ctx.toolchains["//bazel/toolchains/rpath_rewriter"]
+
+    # No-op: just pass the inputs through.
+    if toolchain.patch_file == None:
+        return inputs
+
+    outputs = []
+    for input in inputs:
+        output = ctx.actions.declare_file("patched/" + input.basename)
+        args = ctx.actions.args()
+        args.add(input)
+        args.add(rpath)
+        args.add(output)
+        ctx.actions.run(
+            inputs = [input],
+            outputs = [output],
+            arguments = [args],
+            executable = toolchain.patch_file,
+        )
+        outputs.append(output)
+
+    return outputs
+
 def _rewrite_rpath_impl(ctx):
-    is_linux = _is_os(ctx, ctx.attr._linux_constraint)
-    is_macos = _is_os(ctx, ctx.attr._macos_constraint)
-
-    if not is_linux and not is_macos:
-        return DefaultInfo(files = depset(ctx.files.inputs))
-
-    processed_files = []
     rpath = ctx.attr.rpath.format(install_dir = ctx.attr._install_dir[BuildSettingInfo].value)
-    for input in ctx.files.inputs:
-        processed_file = ctx.actions.declare_file("patched/" + input.basename)
-        if is_linux:
-            patchelf_file_action(ctx, input, processed_file, rpath)
-        else:
-            otool_file_action(ctx, input, processed_file, rpath)
-        processed_files.append(processed_file)
-
-    return DefaultInfo(files = depset(processed_files))
+    return DefaultInfo(files = depset(rewrite_rpaths_for_files(ctx, inputs = ctx.files.inputs, rpath = rpath)))
 
 rewrite_rpath = rule(
     implementation = _rewrite_rpath_impl,
@@ -145,29 +111,10 @@ rewrite_rpath = rule(
             Supports '{install_dir}' variable.""",
             default = "{install_dir}/embedded/lib",
         ),
-        "_linux_constraint": attr.label(
-            default = "@platforms//os:linux",
-        ),
-        "_macos_constraint": attr.label(
-            default = "@platforms//os:macos",
-        ),
-        "_script": attr.label(
-            default = "@@//bazel/rules/rewrite_rpath:macos.sh",
-            allow_single_file = True,
-            cfg = "exec",
-        ),
-        "_install_name_tool": attr.label(
-            default = "@@//bazel/tools:install_name_tool",
-            executable = True,
-            cfg = "exec",
-        ),
         "_install_dir": attr.label(
             doc = "Private label used for the default rpath",
             default = "@@//:install_dir",
         ),
     },
-    toolchains = [
-        "@@//bazel/toolchains/patchelf:patchelf_toolchain_type",
-        "@@//bazel/toolchains/otool:otool_toolchain_type",
-    ],
+    toolchains = ["//bazel/toolchains/rpath_rewriter"],
 )

--- a/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
+++ b/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
@@ -87,6 +87,7 @@ def rewrite_rpaths_for_files(ctx, inputs, rpath):
             outputs = [output],
             arguments = [args],
             executable = toolchain.patch_file,
+            toolchain = "//bazel/toolchains/rpath_rewriter",
         )
         outputs.append(output)
 

--- a/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
+++ b/bazel/rules/rewrite_rpath/rewrite_rpath.bzl
@@ -72,7 +72,7 @@ def rewrite_rpaths_for_files(ctx, inputs, rpath):
     toolchain = ctx.toolchains["//bazel/toolchains/rpath_rewriter"]
 
     # No-op: just pass the inputs through.
-    if toolchain.patch_file == None:
+    if toolchain.rewriter_tool == None:
         return inputs
 
     outputs = []
@@ -86,7 +86,7 @@ def rewrite_rpaths_for_files(ctx, inputs, rpath):
             inputs = [input],
             outputs = [output],
             arguments = [args],
-            executable = toolchain.patch_file,
+            executable = toolchain.rewriter_tool,
             toolchain = "//bazel/toolchains/rpath_rewriter",
         )
         outputs.append(output)

--- a/bazel/toolchains/rpath_rewriter/BUILD.bazel
+++ b/bazel/toolchains/rpath_rewriter/BUILD.bazel
@@ -4,7 +4,7 @@ load(":install_name_tool.bzl", "macos_rpath_rewriter")
 load(":patchelf.bzl", "patchelf_rpath_rewriter")
 load(":toolchain.bzl", "noop_toolchain", "rpath_rewriter_toolchain")
 
-# Provides rpath rewriting toolchains. Rewriters either expose a `patch_file`
+# Provides rpath rewriting toolchains. Rewriters either expose a `rewriter_tool`
 # executable taking <thing-to-patch> <new-rpath> <output-path>, or expose no
 # executable to signal that rpath rewriting is not applicable for the target.
 toolchain_type(
@@ -19,7 +19,7 @@ patchelf_rpath_rewriter(
 
 rpath_rewriter_toolchain(
     name = "patchelf_rpath_rewriter_toolchain",
-    patch_file = ":patchelf_rpath_rewriter",
+    rewriter_tool = ":patchelf_rpath_rewriter",
 )
 
 macos_rpath_rewriter(
@@ -29,7 +29,7 @@ macos_rpath_rewriter(
 
 rpath_rewriter_toolchain(
     name = "install_name_tool_rpath_rewriter_toolchain",
-    patch_file = ":install_name_tool_rpath_rewriter",
+    rewriter_tool = ":install_name_tool_rpath_rewriter",
 )
 
 noop_toolchain(

--- a/bazel/toolchains/rpath_rewriter/BUILD.bazel
+++ b/bazel/toolchains/rpath_rewriter/BUILD.bazel
@@ -1,0 +1,60 @@
+"""toolchains for rpath-patching"""
+
+load(":install_name_tool.bzl", "macos_rpath_rewriter")
+load(":patchelf.bzl", "patchelf_rpath_rewriter")
+load(":toolchain.bzl", "noop_toolchain", "rpath_rewriter_toolchain")
+
+# Provides rpath rewriting toolchains. Rewriters either expose a `patch_file`
+# executable taking <thing-to-patch> <new-rpath> <output-path>, or expose no
+# executable to signal that rpath rewriting is not applicable for the target.
+toolchain_type(
+    name = "rpath_rewriter",
+    visibility = ["//visibility:public"],
+)
+
+patchelf_rpath_rewriter(
+    name = "patchelf_rpath_rewriter",
+    patchelf = "@patchelf//:patchelf",
+)
+
+rpath_rewriter_toolchain(
+    name = "patchelf_rpath_rewriter_toolchain",
+    patch_file = ":patchelf_rpath_rewriter",
+)
+
+macos_rpath_rewriter(
+    name = "install_name_tool_rpath_rewriter",
+    install_name_tool = "//bazel/tools:install_name_tool",
+)
+
+rpath_rewriter_toolchain(
+    name = "install_name_tool_rpath_rewriter_toolchain",
+    patch_file = ":install_name_tool_rpath_rewriter",
+)
+
+noop_toolchain(
+    name = "noop_rpath_rewriter_toolchain",
+)
+
+toolchain(
+    name = "patchelf_toolchain",
+    exec_compatible_with = ["@platforms//os:linux"],
+    target_compatible_with = ["@platforms//os:linux"],
+    toolchain = ":patchelf_rpath_rewriter_toolchain",
+    toolchain_type = ":rpath_rewriter",
+)
+
+toolchain(
+    name = "install_name_tool_toolchain",
+    exec_compatible_with = ["@platforms//os:macos"],
+    target_compatible_with = ["@platforms//os:macos"],
+    toolchain = ":install_name_tool_rpath_rewriter_toolchain",
+    toolchain_type = ":rpath_rewriter",
+)
+
+toolchain(
+    name = "noop_windows_toolchain",
+    target_compatible_with = ["@platforms//os:windows"],
+    toolchain = ":noop_rpath_rewriter_toolchain",
+    toolchain_type = ":rpath_rewriter",
+)

--- a/bazel/toolchains/rpath_rewriter/install_name_tool.bzl
+++ b/bazel/toolchains/rpath_rewriter/install_name_tool.bzl
@@ -1,9 +1,9 @@
 """Toolchain to provide a macOS install_name_tool-based rpath patcher."""
 
 def _macos_rpath_rewriter_impl(ctx):
-    patch_file = ctx.actions.declare_file(ctx.label.name + "_patch_file.sh")
+    rewriter_tool = ctx.actions.declare_file(ctx.label.name + "_rewriter_tool.sh")
     ctx.actions.write(
-        output = patch_file,
+        output = rewriter_tool,
         is_executable = True,
         content = """#!/usr/bin/env bash
 set -euo pipefail
@@ -51,8 +51,8 @@ done
     )
 
     return DefaultInfo(
-        executable = patch_file,
-        files = depset([patch_file, ctx.executable.install_name_tool]),
+        executable = rewriter_tool,
+        files = depset([rewriter_tool, ctx.executable.install_name_tool]),
     )
 
 macos_rpath_rewriter = rule(

--- a/bazel/toolchains/rpath_rewriter/install_name_tool.bzl
+++ b/bazel/toolchains/rpath_rewriter/install_name_tool.bzl
@@ -1,0 +1,69 @@
+"""Toolchain to provide a macOS install_name_tool-based rpath patcher."""
+
+def _macos_rpath_rewriter_impl(ctx):
+    patch_file = ctx.actions.declare_file(ctx.label.name + "_patch_file.sh")
+    ctx.actions.write(
+        output = patch_file,
+        is_executable = True,
+        content = """#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$1
+RPATH=$2
+OUTPUT=$3
+
+INSTALL_NAME_TOOL=\"{install_name_tool}\"
+
+# RPATH is the full rpath (e.g. /opt/datadog-agent/embedded/lib); use as-is.
+cp \"$INPUT\" \"$OUTPUT\"
+# Restore owner-write so install_name_tool can modify dylibs installed as
+# read-only by their build system (e.g. Python lib-dynload modules).
+chmod u+w \"$OUTPUT\"
+
+# Match Linux patchelf --set-rpath semantics: the packaged output should have
+# exactly the packaging rpath, to avoid leaving in existing ones that may
+# point to build-time paths.
+\"$INSTALL_NAME_TOOL\" -delete_all_rpaths -add_rpath \"$RPATH\" \"$OUTPUT\"
+dylib_name=$(basename \"$OUTPUT\")
+new_id=\"$RPATH/$dylib_name\"
+
+\"$INSTALL_NAME_TOOL\" -id \"$new_id\" \"$OUTPUT\"
+
+# Dylibs built in the Bazel sandbox record their dependencies with absolute
+# sandbox paths as install names (e.g. bazel-out/.../libfoo.dylib). Those paths
+# vanish after the build, so rewrite them to $RPATH/<basename> so the dynamic
+# linker can find them via the rpath we just added. Leave everything else
+# (system libraries, @rpath/... references) untouched.
+/usr/bin/otool -L \"$OUTPUT\" | tail -n +2 | awk '{{print $1}}' | while read -r dep; do
+    if [[ \"$dep\" == *\"sandbox\"* ]] || [[ \"$dep\" == *\"bazel-out\"* ]]; then
+        dep_name=$(basename \"$dep\")
+        new_dep=\"$RPATH/$dep_name\"
+        \"$INSTALL_NAME_TOOL\" -change \"$dep\" \"$new_dep\" \"$OUTPUT\" 2>/dev/null || true
+    fi
+done
+
+# Re-sign with an ad-hoc signature after modification as install_name_tool invalidates
+# any existing code signature.
+/usr/bin/codesign --sign - --force \"$OUTPUT\"
+""".format(
+            install_name_tool = ctx.executable.install_name_tool.path,
+        ),
+    )
+
+    return DefaultInfo(
+        executable = patch_file,
+        files = depset([patch_file, ctx.executable.install_name_tool]),
+    )
+
+macos_rpath_rewriter = rule(
+    implementation = _macos_rpath_rewriter_impl,
+    attrs = {
+        "install_name_tool": attr.label(
+            doc = "A valid label of a target pointing at an install_name_tool executable.",
+            cfg = "exec",
+            executable = True,
+            allow_files = True,
+            mandatory = True,
+        ),
+    },
+)

--- a/bazel/toolchains/rpath_rewriter/patchelf.bzl
+++ b/bazel/toolchains/rpath_rewriter/patchelf.bzl
@@ -1,0 +1,35 @@
+"""Toolchain to provide a hermetic patchelf-based rpath patcher."""
+
+def _patchelf_rpath_rewriter_impl(ctx):
+    patch_file = ctx.actions.declare_file(ctx.label.name + "_patch_file.sh")
+    ctx.actions.write(
+        output = patch_file,
+        is_executable = True,
+        content = """#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$1
+RPATH=$2
+OUTPUT=$3
+
+"{patchelf}" --set-rpath "$RPATH" --force-rpath "$INPUT" --output "$OUTPUT"
+""".format(patchelf = ctx.executable.patchelf.path),
+    )
+
+    return DefaultInfo(
+        executable = patch_file,
+        files = depset([patch_file, ctx.executable.patchelf]),
+    )
+
+patchelf_rpath_rewriter = rule(
+    implementation = _patchelf_rpath_rewriter_impl,
+    attrs = {
+        "patchelf": attr.label(
+            doc = "A valid label of a target pointing at a patchelf executable.",
+            cfg = "exec",
+            executable = True,
+            allow_files = True,
+            mandatory = True,
+        ),
+    },
+)

--- a/bazel/toolchains/rpath_rewriter/patchelf.bzl
+++ b/bazel/toolchains/rpath_rewriter/patchelf.bzl
@@ -1,9 +1,9 @@
 """Toolchain to provide a hermetic patchelf-based rpath patcher."""
 
 def _patchelf_rpath_rewriter_impl(ctx):
-    patch_file = ctx.actions.declare_file(ctx.label.name + "_patch_file.sh")
+    rewriter_tool = ctx.actions.declare_file(ctx.label.name + "_rewriter_tool.sh")
     ctx.actions.write(
-        output = patch_file,
+        output = rewriter_tool,
         is_executable = True,
         content = """#!/usr/bin/env bash
 set -euo pipefail
@@ -17,8 +17,8 @@ OUTPUT=$3
     )
 
     return DefaultInfo(
-        executable = patch_file,
-        files = depset([patch_file, ctx.executable.patchelf]),
+        executable = rewriter_tool,
+        files = depset([rewriter_tool, ctx.executable.patchelf]),
     )
 
 patchelf_rpath_rewriter = rule(

--- a/bazel/toolchains/rpath_rewriter/toolchain.bzl
+++ b/bazel/toolchains/rpath_rewriter/toolchain.bzl
@@ -1,14 +1,14 @@
 def _rpath_rewriter_toolchain_impl(ctx):
     return [
         platform_common.ToolchainInfo(
-            patch_file = ctx.attr.patch_file[DefaultInfo].files_to_run,
+            rewriter_tool = ctx.attr.rewriter_tool[DefaultInfo].files_to_run,
         ),
     ]
 
 rpath_rewriter_toolchain = rule(
     implementation = _rpath_rewriter_toolchain_impl,
     attrs = {
-        "patch_file": attr.label(
+        "rewriter_tool": attr.label(
             doc = """An executable accepting <input> <new-rpath> <output> arguments, able to rewrite rpaths for individual targets.""",
             cfg = "exec",
             executable = True,
@@ -21,7 +21,7 @@ rpath_rewriter_toolchain = rule(
 def _noop_toolchain_impl(_ctx):
     return [
         platform_common.ToolchainInfo(
-            patch_file = None,
+            rewriter_tool = None,
         ),
     ]
 
@@ -29,5 +29,5 @@ noop_toolchain = rule(
     implementation = _noop_toolchain_impl,
     doc = """A no-op rpath rewriter toolchain.
 
-    A None patch_file signals that rpath rewriting is not applicable for the target platform.""",
+    A None rewriter_tool signals that rpath rewriting is not applicable for the target platform.""",
 )

--- a/bazel/toolchains/rpath_rewriter/toolchain.bzl
+++ b/bazel/toolchains/rpath_rewriter/toolchain.bzl
@@ -1,0 +1,33 @@
+def _rpath_rewriter_toolchain_impl(ctx):
+    return [
+        platform_common.ToolchainInfo(
+            patch_file = ctx.attr.patch_file[DefaultInfo].files_to_run,
+        ),
+    ]
+
+rpath_rewriter_toolchain = rule(
+    implementation = _rpath_rewriter_toolchain_impl,
+    attrs = {
+        "patch_file": attr.label(
+            doc = """An executable accepting <input> <new-rpath> <output> arguments, able to rewrite rpaths for individual targets.""",
+            cfg = "exec",
+            executable = True,
+            allow_files = True,
+            mandatory = True,
+        ),
+    },
+)
+
+def _noop_toolchain_impl(_ctx):
+    return [
+        platform_common.ToolchainInfo(
+            patch_file = None,
+        ),
+    ]
+
+noop_toolchain = rule(
+    implementation = _noop_toolchain_impl,
+    doc = """A no-op rpath rewriter toolchain.
+
+    A None patch_file signals that rpath rewriting is not applicable for the target platform.""",
+)


### PR DESCRIPTION
### What does this PR do?

It changes the current rpath rewriting implementation (for files) to use a toolchain that handles platform resolution. For this:
- A new toolchain type is defined to create a sort of abstract rpath rewriter.
- New individual toolchains of this new type are created, one per platform (linux using patchelf, macos using install-name-tool, windows having a no-op).
- All callers of the file-input-based rpath rewriter are migrated to use these new toolchains.

### Motivation

The existing setup was somewhat confusing, and seemed not to be leveraging the right constructs:
- We have toolchains defined at a level that doesn't seem useful because there's no need for toolchain resolution.
- There's awkward os-checking conditionals in many places (requiring to pass constraints here and there), where a toolchain would be a more practical mechanism.
- Toolchains are the best way to handle cross platform RBE, where the exec and target configs might be different.

There seemed to be room for improvements and I have some future steps in mind that probably make this cleanup worth it.

### Describe how you validated your changes

Builds succeeding (with passing health-check confirming rpath rewriting is still correct).

### Additional Notes

A few planned follow-ups:
- Extend this to directory (TreeArtifact) variant to complete the conversion that this starts, and getting rid of the toolchains that will become unused at that point.
- Unify all rpath rewriting uses in the repo under this mechanism.
- Implement relative-path based rpath setting (at least for macos, where we currently have a post-processing invoke task to do the conversion).
