### PR TITLE
Fix eBPF verifier jump-out-of-range in fill_span_context_go

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/span_go.h
+++ b/pkg/security/ebpf/c/include/helpers/span_go.h
@@ -83,7 +83,17 @@ static void __attribute__((always_inline)) process_go_label(
     }
 }
 
-static int __attribute__((always_inline)) read_and_process_label(
+// __noinline: this is the shared body behind all 42 unrolled call sites
+// above (10x process_go_slice_pair + 4 buckets x 8x process_go_bucket_slot).
+// Kept always_inline, it was duplicated at every call site — ~930
+// instructions each, ~39000 total — which overflowed the BPF verifier's
+// 16-bit signed jump-offset encoding for branches inside this program
+// ("jump out of range"). As __noinline__ it compiles once and is reached via
+// BPF_PSEUDO_CALL from all 42 sites instead. Callers still resolve their
+// array/bucket offsets with compile-time-constant indices before calling in,
+// so this receives only fixed-offset pointers — no runtime-indexed map
+// access crosses the call boundary.
+static int __attribute__((__noinline__)) read_and_process_label(
     struct span_context_t *span,
     struct go_labels_scratch_t *s,
     struct go_string_t *key_hdr,


### PR DESCRIPTION
## Summary
- `fill_span_context_go` in `span_go.h` had grown to ~40k instructions because `read_and_process_label` was `always_inline` and got duplicated at all 42 unrolled call sites (10x via `process_go_slice_pair`, 32x via `process_go_bucket_slot` across 4 buckets x 8 slots).
- This overflowed the BPF verifier's 16-bit signed jump-offset encoding, producing the CI failure: `jump out of range from insn 3118 to -27435`.
- Fix: mark `read_and_process_label` `__noinline__` so it compiles once and is reached via `BPF_PSEUDO_CALL` from all call sites instead of being copy-pasted. Callers still resolve array/bucket offsets with compile-time-constant indices before calling in, so no runtime-indexed map access crosses the new call boundary.

## Test plan
- [ ] CI eBPF build/verifier checks pass on this branch
- [ ] Deploy resulting image to sandbox EKS cluster and confirm system-probe/security-agent start without verifier errors