### PR TITLE
[ACTP] Add Decrypt/DecryptInto helpers to encryptioncontext

### DIFF
--- a/pkg/privateactionrunner/libs/encryptioncontext/BUILD.bazel
+++ b/pkg/privateactionrunner/libs/encryptioncontext/BUILD.bazel
@@ -2,16 +2,29 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "encryptioncontext",
-    srcs = ["store.go"],
+    srcs = [
+        "decrypt.go",
+        "store.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/encryptioncontext",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_jellydator_ttlcache_v3//:ttlcache"],
+    deps = [
+        "@com_github_jellydator_ttlcache_v3//:ttlcache",
+        "@org_golang_x_crypto//curve25519",
+        "@org_golang_x_crypto//nacl/box",
+    ],
 )
 
 go_test(
     name = "encryptioncontext_test",
-    srcs = ["store_test.go"],
+    srcs = [
+        "decrypt_test.go",
+        "store_test.go",
+    ],
     embed = [":encryptioncontext"],
     gotags = ["test"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+        "@org_golang_x_crypto//nacl/box",
+    ],
 )

--- a/pkg/privateactionrunner/libs/encryptioncontext/decrypt.go
+++ b/pkg/privateactionrunner/libs/encryptioncontext/decrypt.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package encryptioncontext
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"golang.org/x/crypto/curve25519"
+	"golang.org/x/crypto/nacl/box"
+)
+
+// KeyTypeCurve25519 is the only supported EncryptionContext.KeyType.
+const KeyTypeCurve25519 = "curve25519"
+
+// EncryptionContext identifies the key pair an input was sealed with.
+type EncryptionContext struct {
+	KeyType             string `json:"keyType"`
+	EncryptionContextID string `json:"encryptionContextId"`
+}
+
+// Decrypt opens the base64-encoded, NaCl-sealed encryptedInput using the
+// private key evicted from store for encryptionContext.
+func Decrypt(store *Store, encryptionContext EncryptionContext, encryptedInput string) (string, error) {
+	if encryptionContext.EncryptionContextID == "" {
+		return "", errors.New("encryptionContext.encryptionContextId is required")
+	}
+	if encryptionContext.KeyType != KeyTypeCurve25519 {
+		return "", fmt.Errorf("unsupported keyType %q (expected %q)", encryptionContext.KeyType, KeyTypeCurve25519)
+	}
+	if encryptedInput == "" {
+		return "", errors.New("encryptedInput is required")
+	}
+
+	privateKey, found := store.GetAndDelete(encryptionContext.EncryptionContextID)
+	if !found {
+		return "", fmt.Errorf("no private key found for encryptionContextId %q", encryptionContext.EncryptionContextID)
+	}
+
+	ciphertext, err := base64.StdEncoding.DecodeString(encryptedInput)
+	if err != nil {
+		return "", fmt.Errorf("encryptedInput is not valid base64: %w", err)
+	}
+
+	publicKeyBytes, err := curve25519.X25519(privateKey[:], curve25519.Basepoint)
+	if err != nil {
+		return "", fmt.Errorf("failed to derive public key: %w", err)
+	}
+	var publicKey [32]byte
+	copy(publicKey[:], publicKeyBytes)
+
+	plaintext, ok := box.OpenAnonymous(nil, ciphertext, &publicKey, privateKey)
+	if !ok {
+		return "", errors.New("failed to open sealed input")
+	}
+	return string(plaintext), nil
+}
+
+// DecryptInto decrypts encryptedInput like Decrypt, then unmarshals the
+// JSON plaintext into T.
+func DecryptInto[T any](store *Store, encryptionContext EncryptionContext, encryptedInput string) (T, error) {
+	var out T
+
+	plaintext, err := Decrypt(store, encryptionContext, encryptedInput)
+	if err != nil {
+		return out, err
+	}
+
+	if err := json.Unmarshal([]byte(plaintext), &out); err != nil {
+		return out, fmt.Errorf("failed to unmarshal decrypted input: %w", err)
+	}
+	return out, nil
+}

--- a/pkg/privateactionrunner/libs/encryptioncontext/decrypt_test.go
+++ b/pkg/privateactionrunner/libs/encryptioncontext/decrypt_test.go
@@ -1,0 +1,142 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package encryptioncontext
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/nacl/box"
+)
+
+// sealForContext seals plaintext for a fresh key pair stored under encryptionContextID.
+func sealForContext(t *testing.T, store *Store, encryptionContextID string, plaintext []byte) string {
+	t.Helper()
+
+	publicKey, privateKey, err := box.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	store.Set(encryptionContextID, privateKey)
+
+	sealed, err := box.SealAnonymous(nil, plaintext, publicKey, nil)
+	require.NoError(t, err)
+	return base64.StdEncoding.EncodeToString(sealed)
+}
+
+func TestDecrypt(t *testing.T) {
+	cases := []struct {
+		name              string
+		encryptionContext EncryptionContext
+		plaintext         string
+		skipSeal          bool
+		wantErrContains   string
+	}{
+		{
+			name:              "decrypts a sealed payload",
+			encryptionContext: EncryptionContext{KeyType: KeyTypeCurve25519, EncryptionContextID: "ctx-1"},
+			plaintext:         "super-secret",
+		},
+		{
+			name:              "rejects missing encryptionContextId",
+			encryptionContext: EncryptionContext{KeyType: KeyTypeCurve25519},
+			plaintext:         "super-secret",
+			wantErrContains:   "encryptionContextId is required",
+		},
+		{
+			name:              "rejects unsupported keyType",
+			encryptionContext: EncryptionContext{KeyType: "rsa", EncryptionContextID: "ctx-1"},
+			plaintext:         "super-secret",
+			wantErrContains:   "unsupported keyType",
+		},
+		{
+			name:              "rejects unknown encryptionContextId",
+			encryptionContext: EncryptionContext{KeyType: KeyTypeCurve25519, EncryptionContextID: "ctx-unknown"},
+			plaintext:         "super-secret",
+			skipSeal:          true,
+			wantErrContains:   "no private key found",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := NewStoreWithTTL(time.Minute)
+
+			encryptedInput := "b25seSB1c2VkIGFzIGEgbm9uLWVtcHR5IHBsYWNlaG9sZGVy"
+			if !testCase.skipSeal {
+				encryptedInput = sealForContext(t, store, testCase.encryptionContext.EncryptionContextID, []byte(testCase.plaintext))
+			}
+			decrypted, err := Decrypt(store, testCase.encryptionContext, encryptedInput)
+			if testCase.wantErrContains != "" {
+				require.ErrorContains(t, err, testCase.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, testCase.plaintext, decrypted)
+
+			// private key is single-use
+			_, err = Decrypt(store, testCase.encryptionContext, encryptedInput)
+			require.ErrorContains(t, err, "no private key found")
+		})
+	}
+
+	t.Run("rejects empty encryptedInput", func(t *testing.T) {
+		store := NewStoreWithTTL(time.Minute)
+		_, err := Decrypt(store, EncryptionContext{KeyType: KeyTypeCurve25519, EncryptionContextID: "ctx-1"}, "")
+		require.ErrorContains(t, err, "encryptedInput is required")
+	})
+
+	t.Run("rejects non-base64 encryptedInput", func(t *testing.T) {
+		store := NewStoreWithTTL(time.Minute)
+		encryptionContext := EncryptionContext{KeyType: KeyTypeCurve25519, EncryptionContextID: "ctx-1"}
+		store.Set(encryptionContext.EncryptionContextID, &[32]byte{})
+
+		_, err := Decrypt(store, encryptionContext, "not-base64!!!")
+		require.ErrorContains(t, err, "not valid base64")
+	})
+}
+
+type decryptedCredentials struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func TestDecryptInto(t *testing.T) {
+	cases := []struct {
+		name            string
+		plaintext       string
+		want            decryptedCredentials
+		wantErrContains string
+	}{
+		{
+			name:      "unmarshals decrypted JSON into the requested type",
+			plaintext: `{"username":"admin","password":"hunter2"}`,
+			want:      decryptedCredentials{Username: "admin", Password: "hunter2"},
+		},
+		{
+			name:            "wraps invalid JSON as an error",
+			plaintext:       `not-json`,
+			wantErrContains: "failed to unmarshal decrypted input",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := NewStoreWithTTL(time.Minute)
+			encryptionContext := EncryptionContext{KeyType: KeyTypeCurve25519, EncryptionContextID: "ctx-1"}
+			encryptedInput := sealForContext(t, store, encryptionContext.EncryptionContextID, []byte(testCase.plaintext))
+
+			got, err := DecryptInto[decryptedCredentials](store, encryptionContext, encryptedInput)
+			if testCase.wantErrContains != "" {
+				require.ErrorContains(t, err, testCase.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, testCase.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### Description

Add curve25519/NaCl-box `Decrypt`/`DecryptInto` helpers on top of the `encryptioncontext` store, so callers can open a sealed per-task secret input using the private key evicted from the store.

### Test

Added table-driven unit tests covering successful decryption, single-use key eviction, invalid base64, invalid JSON payloads, and unsupported/missing encryption context fields.
Test locally with the action that will be introduced by https://github.com/DataDog/datadog-agent/pull/52174.