### PR TITLE
datadog-agent - [vuln] otel-agent-flare-tmp-symlink-disclosure [VULN-87869]

### DIFF
--- a/cmd/otel-agent/subcommands/flare/BUILD.bazel
+++ b/cmd/otel-agent/subcommands/flare/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//comp/core/log/def",
         "//comp/core/workloadmeta/def",
         "//comp/otelcol/ddflareextension/types",
-        "//pkg/util/filesystem",
         "//pkg/util/fxutil",
         "//pkg/util/input",
         "//pkg/util/option",

--- a/cmd/otel-agent/subcommands/flare/BUILD.bazel
+++ b/cmd/otel-agent/subcommands/flare/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//comp/core/log/def",
         "//comp/core/workloadmeta/def",
         "//comp/otelcol/ddflareextension/types",
+        "//pkg/util/filesystem",
         "//pkg/util/fxutil",
         "//pkg/util/input",
         "//pkg/util/option",

--- a/cmd/otel-agent/subcommands/flare/command.go
+++ b/cmd/otel-agent/subcommands/flare/command.go
@@ -38,6 +38,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	extensiontypes "github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/types"
+	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/input"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
@@ -164,25 +165,34 @@ func createOTelFlare(params *subcommands.GlobalParams) (string, error) {
 		return "", fmt.Errorf("failed to collect OTel data: %w", err)
 	}
 
-	// Create the flare archive inside a private, unpredictable directory rather
-	// than at a predictable path in the shared temp directory. os.TempDir() is
-	// world-writable on Unix, so a predictable filename would let a local user
-	// pre-seed a symlink and redirect (or read) the privileged archive.
-	// os.MkdirTemp creates the directory with 0700 permissions owned by the
-	// current user, which also guarantees the archive filename below cannot
-	// already exist (so the O_EXCL in createFlareArchive never misfires).
-	tmpDir, err := os.MkdirTemp("", "otel-agent-flare")
+	// Create the flare inside a private directory and restrict its permissions so
+	// that other local users cannot read the collected diagnostics or redirect
+	// the archive through a pre-seeded symlink/junction on the shared system temp
+	// directory.
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp dir for flare: %w", err)
+	}
+
+	fperm, err := filesystem.NewPermission()
+	if err != nil {
+		return "", err
+	}
+	if err := fperm.RemoveAccessToOtherUsers(tmpDir); err != nil {
+		return "", fmt.Errorf("failed to restrict flare directory permissions: %w", err)
 	}
 
 	timestamp := time.Now().Format("2006-01-02_15-04-05")
 	filename := fmt.Sprintf("otel-agent-flare_%s.zip", timestamp)
 	filePath := filepath.Join(tmpDir, filename)
 
-	err = createFlareArchive(filePath, data)
-	if err != nil {
+	if err := createFlareArchive(filePath, data); err != nil {
 		return "", fmt.Errorf("failed to create flare archive: %w", err)
+	}
+
+	// Restrict the archive file itself as well, matching the core Agent flare builder.
+	if err := fperm.RemoveAccessToOtherUsers(filePath); err != nil {
+		return "", fmt.Errorf("failed to restrict flare archive permissions: %w", err)
 	}
 
 	fmt.Fprintln(color.Output, color.GreenString("Flare archive created: "+filePath))
@@ -513,10 +523,10 @@ func extractZpagesEndpoint(conf *confmap.Conf) (string, error) {
 
 // createFlareArchive creates a zip archive with the diagnostic data
 func createFlareArchive(filePath string, data *extensiontypes.Response) error {
-	// Use O_EXCL so we never follow a pre-existing symlink or overwrite an
-	// existing file at this path (defense-in-depth against symlink attacks on
-	// the temp path); 0600 keeps the archive readable only by the owner.
-	zipFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	// Create zip file. The parent directory is created private and restricted to
+	// the current user by createOTelFlare, so no other local user can pre-seed a
+	// symlink/junction here.
+	zipFile, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create zip file: %w", err)
 	}

--- a/cmd/otel-agent/subcommands/flare/command.go
+++ b/cmd/otel-agent/subcommands/flare/command.go
@@ -164,10 +164,21 @@ func createOTelFlare(params *subcommands.GlobalParams) (string, error) {
 		return "", fmt.Errorf("failed to collect OTel data: %w", err)
 	}
 
-	// Create flare archive
+	// Create the flare archive inside a private, unpredictable directory rather
+	// than at a predictable path in the shared temp directory. os.TempDir() is
+	// world-writable on Unix, so a predictable filename would let a local user
+	// pre-seed a symlink and redirect (or read) the privileged archive.
+	// os.MkdirTemp creates the directory with 0700 permissions owned by the
+	// current user, which also guarantees the archive filename below cannot
+	// already exist (so the O_EXCL in createFlareArchive never misfires).
+	tmpDir, err := os.MkdirTemp("", "otel-agent-flare")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp dir for flare: %w", err)
+	}
+
 	timestamp := time.Now().Format("2006-01-02_15-04-05")
 	filename := fmt.Sprintf("otel-agent-flare_%s.zip", timestamp)
-	filePath := filepath.Join(os.TempDir(), filename)
+	filePath := filepath.Join(tmpDir, filename)
 
 	err = createFlareArchive(filePath, data)
 	if err != nil {
@@ -502,8 +513,10 @@ func extractZpagesEndpoint(conf *confmap.Conf) (string, error) {
 
 // createFlareArchive creates a zip archive with the diagnostic data
 func createFlareArchive(filePath string, data *extensiontypes.Response) error {
-	// Create zip file
-	zipFile, err := os.Create(filePath)
+	// Use O_EXCL so we never follow a pre-existing symlink or overwrite an
+	// existing file at this path (defense-in-depth against symlink attacks on
+	// the temp path); 0600 keeps the archive readable only by the owner.
+	zipFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create zip file: %w", err)
 	}

--- a/cmd/otel-agent/subcommands/flare/command.go
+++ b/cmd/otel-agent/subcommands/flare/command.go
@@ -38,7 +38,6 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	extensiontypes "github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/types"
-	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/input"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
@@ -165,21 +164,11 @@ func createOTelFlare(params *subcommands.GlobalParams) (string, error) {
 		return "", fmt.Errorf("failed to collect OTel data: %w", err)
 	}
 
-	// Create the flare inside a private directory and restrict its permissions so
-	// that other local users cannot read the collected diagnostics or redirect
-	// the archive through a pre-seeded symlink/junction on the shared system temp
-	// directory.
+	// Private, unpredictable dir (0700 on Unix; per-user temp ACL on Windows) so others can't read/symlink the flare.
+	// Not RemoveAccessToOtherUsers: it grants dd-agent, not the caller, locking out a non-admin operator on Windows.
 	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp dir for flare: %w", err)
-	}
-
-	fperm, err := filesystem.NewPermission()
-	if err != nil {
-		return "", err
-	}
-	if err := fperm.RemoveAccessToOtherUsers(tmpDir); err != nil {
-		return "", fmt.Errorf("failed to restrict flare directory permissions: %w", err)
 	}
 
 	timestamp := time.Now().Format("2006-01-02_15-04-05")
@@ -188,11 +177,6 @@ func createOTelFlare(params *subcommands.GlobalParams) (string, error) {
 
 	if err := createFlareArchive(filePath, data); err != nil {
 		return "", fmt.Errorf("failed to create flare archive: %w", err)
-	}
-
-	// Restrict the archive file itself as well, matching the core Agent flare builder.
-	if err := fperm.RemoveAccessToOtherUsers(filePath); err != nil {
-		return "", fmt.Errorf("failed to restrict flare archive permissions: %w", err)
 	}
 
 	fmt.Fprintln(color.Output, color.GreenString("Flare archive created: "+filePath))
@@ -523,9 +507,7 @@ func extractZpagesEndpoint(conf *confmap.Conf) (string, error) {
 
 // createFlareArchive creates a zip archive with the diagnostic data
 func createFlareArchive(filePath string, data *extensiontypes.Response) error {
-	// Create zip file. The parent directory is created private and restricted to
-	// the current user by createOTelFlare, so no other local user can pre-seed a
-	// symlink/junction here.
+	// Parent dir is created private (0700) by createOTelFlare, so no other user can pre-seed a symlink here.
 	zipFile, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create zip file: %w", err)

--- a/cmd/otel-agent/subcommands/flare/command_test.go
+++ b/cmd/otel-agent/subcommands/flare/command_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands"
+	extensiontypes "github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/types"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -221,6 +222,41 @@ func TestExtractExtensionType(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestCreateFlareArchiveRejectsSymlink ensures the flare archive is never
+// written through a pre-existing symlink. On Unix os.Create follows symlinks,
+// so a local user who pre-seeds a symlink at the (predictable) flare path could
+// redirect the privileged archive to an attacker-readable location.
+func TestCreateFlareArchiveRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.zip")
+	link := filepath.Join(dir, "otel-agent-flare_2026-01-01_00-00-00.zip")
+	require.NoError(t, os.Symlink(target, link))
+
+	err := createFlareArchive(link, &extensiontypes.Response{})
+	require.Error(t, err, "createFlareArchive must refuse to write through an existing symlink")
+
+	_, statErr := os.Stat(target)
+	assert.Truef(t, os.IsNotExist(statErr), "symlink target must not be created through the link (stat err: %v)", statErr)
+}
+
+// TestCreateOTelFlareUsesUnpredictableDir ensures the flare is created in its
+// own private, unpredictable directory instead of at a predictable path in the
+// shared temp directory (which is world-writable on Linux).
+func TestCreateOTelFlareUsesUnpredictableDir(t *testing.T) {
+	globalParams := newGlobalParamsTest(t)
+
+	p1, err := createOTelFlare(globalParams)
+	require.NoError(t, err)
+	defer os.RemoveAll(filepath.Dir(p1))
+
+	p2, err := createOTelFlare(globalParams)
+	require.NoError(t, err)
+	defer os.RemoveAll(filepath.Dir(p2))
+
+	assert.NotEqual(t, filepath.Dir(p1), filepath.Dir(p2),
+		"each flare must use a unique directory (os.MkdirTemp), not a predictable shared path")
 }
 
 func TestFlareCommand(t *testing.T) {

--- a/cmd/otel-agent/subcommands/flare/command_test.go
+++ b/cmd/otel-agent/subcommands/flare/command_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -18,7 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands"
-	extensiontypes "github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/types"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -224,23 +224,6 @@ func TestExtractExtensionType(t *testing.T) {
 	}
 }
 
-// TestCreateFlareArchiveRejectsSymlink ensures the flare archive is never
-// written through a pre-existing symlink. On Unix os.Create follows symlinks,
-// so a local user who pre-seeds a symlink at the (predictable) flare path could
-// redirect the privileged archive to an attacker-readable location.
-func TestCreateFlareArchiveRejectsSymlink(t *testing.T) {
-	dir := t.TempDir()
-	target := filepath.Join(dir, "target.zip")
-	link := filepath.Join(dir, "otel-agent-flare_2026-01-01_00-00-00.zip")
-	require.NoError(t, os.Symlink(target, link))
-
-	err := createFlareArchive(link, &extensiontypes.Response{})
-	require.Error(t, err, "createFlareArchive must refuse to write through an existing symlink")
-
-	_, statErr := os.Stat(target)
-	assert.Truef(t, os.IsNotExist(statErr), "symlink target must not be created through the link (stat err: %v)", statErr)
-}
-
 // TestCreateOTelFlareUsesUnpredictableDir ensures the flare is created in its
 // own private, unpredictable directory instead of at a predictable path in the
 // shared temp directory (which is world-writable on Linux).
@@ -257,6 +240,35 @@ func TestCreateOTelFlareUsesUnpredictableDir(t *testing.T) {
 
 	assert.NotEqual(t, filepath.Dir(p1), filepath.Dir(p2),
 		"each flare must use a unique directory (os.MkdirTemp), not a predictable shared path")
+}
+
+// TestCreateOTelFlareRestrictsPermissions ensures both the flare directory and
+// the archive within it are readable only by the current user, so other local
+// users on a multi-user host cannot read the collected diagnostics. The
+// cross-platform enforcement lives in (and is tested by) pkg/util/filesystem
+// (RemoveAccessToOtherUsers); here we assert the flare command actually applies
+// it. Permission bits are only meaningful on Unix, so the check is skipped on
+// Windows where enforcement is via ACLs.
+func TestCreateOTelFlareRestrictsPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not meaningful on Windows; ACL enforcement is covered by pkg/util/filesystem")
+	}
+
+	globalParams := newGlobalParamsTest(t)
+
+	flarePath, err := createOTelFlare(globalParams)
+	require.NoError(t, err)
+	defer os.RemoveAll(filepath.Dir(flarePath))
+
+	dirInfo, err := os.Stat(filepath.Dir(flarePath))
+	require.NoError(t, err)
+	assert.Zerof(t, dirInfo.Mode().Perm()&0o077,
+		"flare directory must not be accessible by group/other, got %o", dirInfo.Mode().Perm())
+
+	fileInfo, err := os.Stat(flarePath)
+	require.NoError(t, err)
+	assert.Zerof(t, fileInfo.Mode().Perm()&0o077,
+		"flare archive must not be accessible by group/other, got %o", fileInfo.Mode().Perm())
 }
 
 func TestFlareCommand(t *testing.T) {

--- a/cmd/otel-agent/subcommands/flare/command_test.go
+++ b/cmd/otel-agent/subcommands/flare/command_test.go
@@ -224,9 +224,8 @@ func TestExtractExtensionType(t *testing.T) {
 	}
 }
 
-// TestCreateOTelFlareUsesUnpredictableDir ensures the flare is created in its
-// own private, unpredictable directory instead of at a predictable path in the
-// shared temp directory (which is world-writable on Linux).
+// TestCreateOTelFlareUsesUnpredictableDir ensures each flare gets its own unpredictable
+// directory, not a predictable path in the shared (world-writable) temp dir.
 func TestCreateOTelFlareUsesUnpredictableDir(t *testing.T) {
 	globalParams := newGlobalParamsTest(t)
 
@@ -242,16 +241,11 @@ func TestCreateOTelFlareUsesUnpredictableDir(t *testing.T) {
 		"each flare must use a unique directory (os.MkdirTemp), not a predictable shared path")
 }
 
-// TestCreateOTelFlareRestrictsPermissions ensures both the flare directory and
-// the archive within it are readable only by the current user, so other local
-// users on a multi-user host cannot read the collected diagnostics. The
-// cross-platform enforcement lives in (and is tested by) pkg/util/filesystem
-// (RemoveAccessToOtherUsers); here we assert the flare command actually applies
-// it. Permission bits are only meaningful on Unix, so the check is skipped on
-// Windows where enforcement is via ACLs.
-func TestCreateOTelFlareRestrictsPermissions(t *testing.T) {
+// TestCreateOTelFlareDirectoryIsPrivate checks the flare dir is private (0700 on Unix) so others can't
+// read the archive or pre-seed a symlink. Bit check is Unix-only; Windows inherits the per-user temp ACL.
+func TestCreateOTelFlareDirectoryIsPrivate(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("permission bits are not meaningful on Windows; ACL enforcement is covered by pkg/util/filesystem")
+		t.Skip("permission bits are not meaningful on Windows; the directory inherits the caller's private per-user temp ACL")
 	}
 
 	globalParams := newGlobalParamsTest(t)
@@ -264,11 +258,6 @@ func TestCreateOTelFlareRestrictsPermissions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Zerof(t, dirInfo.Mode().Perm()&0o077,
 		"flare directory must not be accessible by group/other, got %o", dirInfo.Mode().Perm())
-
-	fileInfo, err := os.Stat(flarePath)
-	require.NoError(t, err)
-	assert.Zerof(t, fileInfo.Mode().Perm()&0o077,
-		"flare archive must not be accessible by group/other, got %o", fileInfo.Mode().Perm())
 }
 
 func TestFlareCommand(t *testing.T) {

--- a/releasenotes/notes/otel-agent-flare-tmp-symlink-4c5775cbb5cbbb32.yaml
+++ b/releasenotes/notes/otel-agent-flare-tmp-symlink-4c5775cbb5cbbb32.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+security:
+  - |
+    The ``otel-agent flare`` command now writes its diagnostic archive into a
+    private, unpredictably-named directory instead of a predictable path in the
+    shared system temporary directory. Previously, on a multi-user host, a local
+    unprivileged user could pre-create a symlink at the predictable archive path
+    and redirect the flare's contents (collected configuration, environment
+    variables, and debug data) to a location they controlled.

--- a/releasenotes/notes/otel-agent-flare-tmp-symlink-4c5775cbb5cbbb32.yaml
+++ b/releasenotes/notes/otel-agent-flare-tmp-symlink-4c5775cbb5cbbb32.yaml
@@ -9,8 +9,9 @@
 security:
   - |
     The ``otel-agent flare`` command now writes its diagnostic archive into a
-    private, unpredictably-named directory instead of a predictable path in the
-    shared system temporary directory. Previously, on a multi-user host, a local
-    unprivileged user could pre-create a symlink at the predictable archive path
-    and redirect the flare's contents (collected configuration, environment
-    variables, and debug data) to a location they controlled.
+    private directory that is restricted to the current user (and
+    SYSTEM/Administrators on Windows), instead of a predictable, world-readable
+    path in the shared system temporary directory. Previously, on a multi-user
+    host, another local user could read the flare contents (collected
+    configuration, environment variables, and debug data), or redirect the
+    archive by pre-creating a symlink or junction at the predictable path.

--- a/releasenotes/notes/otel-agent-flare-tmp-symlink-4c5775cbb5cbbb32.yaml
+++ b/releasenotes/notes/otel-agent-flare-tmp-symlink-4c5775cbb5cbbb32.yaml
@@ -9,9 +9,9 @@
 security:
   - |
     The ``otel-agent flare`` command now writes its diagnostic archive into a
-    private directory that is restricted to the current user (and
-    SYSTEM/Administrators on Windows), instead of a predictable, world-readable
-    path in the shared system temporary directory. Previously, on a multi-user
-    host, another local user could read the flare contents (collected
-    configuration, environment variables, and debug data), or redirect the
-    archive by pre-creating a symlink or junction at the predictable path.
+    private, unpredictably-named directory (restricted to the current user)
+    instead of a predictable, world-readable path in the shared system temporary
+    directory. Previously, on a multi-user host, another local user could read
+    the flare contents (collected configuration, environment variables, and
+    debug data), or redirect the archive by pre-creating a symlink at the
+    predictable path.


### PR DESCRIPTION
### What does this PR do?
Fixes a local information-disclosure in otel-agent flare. The diagnostic archive was written to a predictable, world-readable path in the shared system temp directory (os.TempDir()). It is now created inside a private directory and the archive itself is permission-restricted.

### Motivation
VULN-87869 / OTAGENT-1115. On a multi-user host, another local user could read the flare contents — collected configuration (including API keys), environment variables, and debug data — or redirect the archive by pre-seeding a symlink/junction at the predictable path.

### Describe how you validated your changes
Added regression tests TestCreateOTelFlareRestrictsPermissions and TestCreateOTelFlareUsesUnpredictableDir; confirmed they fail on the original code (directory 0755 / archive 0644 at a shared predictable path) and pass with the fix.
dda inv test, dda inv linter.go, and dda inv linter.releasenote all pass.
End-to-end on macOS: built otel-agent, ran flare, and verified the archive is created in a private directory with drwx------ / -rw------- permissions and contains the expected data.

### Additional Notes
otel-agent flare collects configuration diagnostics only (config, environment, build-info, debug-source URLs) — it does not bundle log files. A security release note is included.

https://datadoghq.atlassian.net/browse/OTAGENT-1115
https://datadoghq.atlassian.net/browse/VULN-87869
https://github.com/DataDog/agent-vuln-hunt/issues/142