### PR TITLE
bump bazel windows container disk size

### DIFF
--- a/.gitlab/windows/build/source_test/windows.yml
+++ b/.gitlab/windows/build/source_test/windows.yml
@@ -20,7 +20,6 @@
     - >
       .\tools\ci\docker-run-with-bazel-cache.ps1
       -m 24576M
-      --storage-opt "size=100GB"
       -v "$(Get-Location):c:\mnt"
       -e DD_ENV=prod
       -e DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS

--- a/tools/ci/docker-run-with-bazel-cache.ps1
+++ b/tools/ci/docker-run-with-bazel-cache.ps1
@@ -13,7 +13,7 @@ if (-not (($acl = Get-Acl $diskCache).Access | Where-Object { -not $_.IsInherite
     Get-ChildItem $diskCache -Recurse | ForEach-Object { Set-Acl $_.FullName $acl }
 }
 & docker run --rm `
-    --storage-opt "size=100GB"
+    --storage-opt "size=100GB" `
     --env=BAZELISK_HOME `
     --env=BUILDBARN_ID_TOKEN `
     --env=CI `

--- a/tools/ci/docker-run-with-bazel-cache.ps1
+++ b/tools/ci/docker-run-with-bazel-cache.ps1
@@ -13,6 +13,7 @@ if (-not (($acl = Get-Acl $diskCache).Access | Where-Object { -not $_.IsInherite
     Get-ChildItem $diskCache -Recurse | ForEach-Object { Set-Acl $_.FullName $acl }
 }
 & docker run --rm `
+    --storage-opt "size=100GB"
     --env=BAZELISK_HOME `
     --env=BUILDBARN_ID_TOKEN `
     --env=CI `


### PR DESCRIPTION
### What does this PR do?
Adds `--storage-opt "size=100GB"` arg to the shared bazel windows docker container invocation

### Motivation
resolve flakes/failures from lack of disk space in `bazel:test:windows-amd64` jobs which are missing the `--storage-opt` flag (https://github.com/DataDog/datadog-agent/pull/53433)
```
ERROR: Error while writing profile file: C:\bob\command-db340673-8984-4b35-908d-5685bbf8d197.profile.gz -> C:\bob\command.profile.gz: There is not enough space on the disk
```
matches the regular test job container configuration
https://github.com/DataDog/datadog-agent/blob/b8231acf508cd0c19534f8f1f7d8866734c53e15/.gitlab/windows/build/source_test/windows.yml#L23

