### PR TITLE
SLES-2938: less aggressive serverless-init in-container env overrides

### DIFF
--- a/cmd/serverless-init/mode/initcontainer_mode.go
+++ b/cmd/serverless-init/mode/initcontainer_mode.go
@@ -111,10 +111,10 @@ func instrumentJava() {
 }
 
 func instrumentDotnet() {
-	os.Setenv("CORECLR_ENABLE_PROFILING", "1")
-	os.Setenv("CORECLR_PROFILER", "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}")
-	os.Setenv("CORECLR_PROFILER_PATH", "/dd_tracer/dotnet/Datadog.Trace.ClrProfiler.Native.so")
-	os.Setenv("DD_DOTNET_TRACER_HOME", "/dd_tracer/dotnet/")
+	setEnvNoOverride("CORECLR_ENABLE_PROFILING", "1")
+	setEnvNoOverride("CORECLR_PROFILER", "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}")
+	setEnvNoOverride("CORECLR_PROFILER_PATH", "/dd_tracer/dotnet/Datadog.Trace.ClrProfiler.Native.so")
+	setEnvNoOverride("DD_DOTNET_TRACER_HOME", "/dd_tracer/dotnet/")
 }
 
 func instrumentPython() {
@@ -134,7 +134,6 @@ func autoInstrumentTracer(fs afero.Fs) {
 	for _, tracer := range tracers {
 		if ok, err := dirExists(fs, tracer.FsPath); ok {
 			log.Debugf("Found %v, automatically instrumenting tracer", tracer.FsPath)
-			os.Setenv("DD_TRACE_PROPAGATION_STYLE", "datadog")
 			tracer.InitFn()
 			return
 		} else if err != nil {
@@ -152,6 +151,16 @@ func dirExists(fs afero.Fs, path string) (bool, error) {
 		return false, nil
 	}
 	return false, err
+}
+
+// setEnvNoOverride sets key to val only when the customer has not already
+// provided a value, so explicit customer configuration always wins.
+func setEnvNoOverride(key, val string) {
+	if existing, ok := os.LookupEnv(key); ok {
+		log.Debugf("%s already set to %q; keeping customer value instead of %q", key, existing, val)
+		return
+	}
+	os.Setenv(key, val)
 }
 
 func addToString(path string, separator string, token string) string {

--- a/cmd/serverless-init/mode/initcontainer_mode_test.go
+++ b/cmd/serverless-init/mode/initcontainer_mode_test.go
@@ -105,6 +105,33 @@ func TestDotNetTracerIsAutoInstrumented(t *testing.T) {
 	assert.Equal(t, "/dd_tracer/dotnet/", os.Getenv("DD_DOTNET_TRACER_HOME"))
 }
 
+func TestDotNetTracerInstrumentationRespectsCustomerValues(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	fs.Create("/dd_tracer/dotnet/")
+
+	t.Setenv("CORECLR_ENABLE_PROFILING", "0")
+	t.Setenv("CORECLR_PROFILER", "{01234567-89AB-CDEF-0123-456789ABCDEF}")
+	t.Setenv("CORECLR_PROFILER_PATH", "/custom/profiler.so")
+	t.Setenv("DD_DOTNET_TRACER_HOME", "/custom/tracer/home/")
+
+	autoInstrumentTracer(fs)
+
+	assert.Equal(t, "0", os.Getenv("CORECLR_ENABLE_PROFILING"))
+	assert.Equal(t, "{01234567-89AB-CDEF-0123-456789ABCDEF}", os.Getenv("CORECLR_PROFILER"))
+	assert.Equal(t, "/custom/profiler.so", os.Getenv("CORECLR_PROFILER_PATH"))
+	assert.Equal(t, "/custom/tracer/home/", os.Getenv("DD_DOTNET_TRACER_HOME"))
+}
+
+func TestAutoInstrumentDoesNotSetPropagationStyle(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	fs.Create("/dd_tracer/python/")
+
+	autoInstrumentTracer(fs)
+
+	_, set := os.LookupEnv("DD_TRACE_PROPAGATION_STYLE")
+	assert.False(t, set, "auto-instrumentation should leave DD_TRACE_PROPAGATION_STYLE to the tracer default")
+}
+
 func TestJavaTracerIsAutoInstrumented(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	fs.Create("/dd_tracer/java/")

--- a/releasenotes/notes/serverless-init-respect-tracer-env-89a4163db51221b9.yaml
+++ b/releasenotes/notes/serverless-init-respect-tracer-env-89a4163db51221b9.yaml
@@ -1,0 +1,15 @@
+---
+enhancements:
+  - |
+    serverless-init no longer overrides customer-provided ``CORECLR_ENABLE_PROFILING``,
+    ``CORECLR_PROFILER``, ``CORECLR_PROFILER_PATH``, or ``DD_DOTNET_TRACER_HOME`` values
+    when auto-instrumenting a bundled .NET tracer. Any value already present in the
+    environment is now respected.
+upgrade:
+  - |
+    serverless-init no longer forces ``DD_TRACE_PROPAGATION_STYLE=datadog`` during
+    tracer auto-instrumentation. The tracer's own default (which includes W3C
+    ``tracecontext`` and ``baggage`` in addition to ``datadog``) now applies, and a
+    customer-provided ``DD_TRACE_PROPAGATION_STYLE`` is respected. Applications that
+    relied on serverless-init restricting propagation to ``datadog`` only should set
+    ``DD_TRACE_PROPAGATION_STYLE=datadog`` explicitly.


### PR DESCRIPTION
### What does this PR do?
1. Stop overriding `DD_TRACE_PROPAGATION_STYLE`. It's already set to a default of `datadog,tracecontext,baggage` in all of our tracers.
2. Don't override dotnet profiler env vars if they already exist in the environment

### Motivation
While auto-instrumentation may be nice, we shouldn't be too aggressive, especially since we haven't done a great job keeping it in sync with the tracers as they've evolved over the years.

### Describe how you validated your changes
Unit tests