### PR TITLE
[CWS] update bazel file to avoid miss-match between CI and local build

### DIFF
--- a/pkg/security/tests/BUILD.bazel
+++ b/pkg/security/tests/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "testopts.go",
         "trace_pipe.go",
     ],
+    # keep
     embedsrcs = select({
         "@rules_go//go/platform:android": [
             "syscall_tester/bin/.gitkeep",


### PR DESCRIPTION
### What does this PR do?

It updates pkg/security/test bazel file to avoid missmatch between CI and local build

Patch proposed by @aiuto 

### Motivation

### Describe how you validated your changes

### Additional Notes
