### PR TITLE
[WP] Stop retaining plain-text installed-files list

### DIFF
--- a/pkg/security/resolvers/sbom/file_querier.go
+++ b/pkg/security/resolvers/sbom/file_querier.go
@@ -36,26 +36,32 @@ and each part group is at the index of the given package
 for example here hash5 would match pkgs[2]
 */
 
-func newFileQuerier(report []sbomtypes.PackageWithInstalledFiles, usrMerged bool) fileQuerier {
+// newFileQuerier builds the file->package index from report. It stores murmur3
+// hashes of the installed file paths — never the paths themselves — together with
+// pointers into backing, the caller's long-lived per-package metadata slice. Using
+// backing (rather than report) for the pointers keeps LastAccess/SuidBit/
+// AccessedByRoot updates visible to the forwarding path while allowing report and
+// its plain-text InstalledFiles to be garbage-collected once this returns.
+// backing[i] must correspond to report[i].Package.
+func newFileQuerier(report []sbomtypes.PackageWithInstalledFiles, backing []sbomtypes.Package, usrMerged bool) fileQuerier {
 	fileCount := 0
-	pkgCount := 0
 	for _, pkg := range report {
 		fileCount += 2 + len(pkg.InstalledFiles)
-		pkgCount++
 	}
 
 	files := make([]uint64, 0, fileCount)
-	pkgs := make([]*sbomtypes.Package, 0, pkgCount)
+	pkgs := make([]*sbomtypes.Package, 0, len(backing))
 
 	for i := range report {
-		// IMPORTANT: Store pointer to Package field in the original slice, not a copy
-		// This ensures LastAccess updates are reflected in the stored packages
-		pkgs = append(pkgs, &report[i].Package)
+		// IMPORTANT: Store pointer into the retained backing slice, not into report,
+		// so LastAccess updates are reflected in the stored packages and report's
+		// InstalledFiles are not kept alive.
+		pkgs = append(pkgs, &backing[i])
 
 		files = append(files, uint64(len(report[i].InstalledFiles)))
 
 		for _, file := range report[i].InstalledFiles {
-			seclog.Tracef("indexing %s as %+v", file, report[i].Package)
+			seclog.Tracef("indexing %s as %+v", file, backing[i])
 
 			hash := murmur3.StringSum64(file)
 			files = append(files, hash)

--- a/pkg/security/resolvers/sbom/file_querier_test.go
+++ b/pkg/security/resolvers/sbom/file_querier_test.go
@@ -24,7 +24,12 @@ func TestQueryFileUsrMerge(t *testing.T) {
 		{Package: sbomtypes.Package{Name: "coreutils"}, InstalledFiles: []string{"/usr/bin/cat"}},
 	}
 
-	merged := newFileQuerier(report, true)
+	backing := make([]sbomtypes.Package, len(report))
+	for i := range report {
+		backing[i] = report[i].Package
+	}
+
+	merged := newFileQuerier(report, backing, true)
 	for _, tc := range []struct {
 		name    string
 		query   string
@@ -49,7 +54,7 @@ func TestQueryFileUsrMerge(t *testing.T) {
 
 	// Without usr-merge, /bin and /usr/bin are distinct trees: an unmatched
 	// /usr/bin/mount must not be cross-attributed to the /bin/mount package.
-	plain := newFileQuerier(report, false)
+	plain := newFileQuerier(report, backing, false)
 	if pkg := plain.queryFile("/usr/bin/mount"); pkg != nil {
 		t.Errorf("queryFile(/usr/bin/mount) attributed to %q on a non-usr-merged layout, want no match", pkg.Name)
 	}

--- a/pkg/security/resolvers/sbom/report.go
+++ b/pkg/security/resolvers/sbom/report.go
@@ -25,12 +25,12 @@ const (
 
 // PackagesReport wraps package data and implements the sbom.Report interface
 type PackagesReport struct {
-	packages    []sbomtypes.PackageWithInstalledFiles
+	packages    []sbomtypes.Package
 	containerID containerutils.ContainerID
 }
 
 // NewPackagesReport creates a new PackagesReport from a slice of packages
-func NewPackagesReport(packages []sbomtypes.PackageWithInstalledFiles, containerID containerutils.ContainerID) *PackagesReport {
+func NewPackagesReport(packages []sbomtypes.Package, containerID containerutils.ContainerID) *PackagesReport {
 	return &PackagesReport{
 		packages:    packages,
 		containerID: containerID,

--- a/pkg/security/resolvers/sbom/report_test.go
+++ b/pkg/security/resolvers/sbom/report_test.go
@@ -57,7 +57,7 @@ func TestToCycloneDXRuntimeProperties(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			report := NewPackagesReport([]sbomtypes.PackageWithInstalledFiles{{Package: tt.pkg}}, "")
+			report := NewPackagesReport([]sbomtypes.Package{tt.pkg}, "")
 			bom := report.ToCycloneDX()
 			if len(bom.Components) != 1 {
 				t.Fatalf("got %d components, want 1", len(bom.Components))

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -80,7 +80,26 @@ const (
 // container
 type Data struct {
 	files    fileQuerier
-	packages []sbomtypes.PackageWithInstalledFiles // Store original packages for forwarding
+	packages []sbomtypes.Package // per-package metadata (without the plain-text installed-file lists) kept for forwarding
+}
+
+// newData builds the cached scan Data from a freshly generated report. It keeps
+// only the compact representation: per-package metadata in packages (dropping the
+// plain-text InstalledFiles) and murmur3 hashes of the file paths in the file
+// querier. Runtime file->package lookups use the hashes and forwarding only needs
+// the package metadata, so retaining the paths would waste megabytes per workload
+// for the lifetime of the data cache. The file querier stores pointers into
+// packages so LastAccess updates stay visible to the forwarding path.
+func newData(report []sbomtypes.PackageWithInstalledFiles, usrMerged bool) *Data {
+	packages := make([]sbomtypes.Package, len(report))
+	for i := range report {
+		packages[i] = report[i].Package
+	}
+
+	return &Data{
+		files:    newFileQuerier(report, packages, usrMerged),
+		packages: packages,
+	}
 }
 
 // SBOM defines an SBOM
@@ -119,8 +138,8 @@ func (s *SBOM) IsComputed() bool {
 
 // SetReport sets the SBOM report
 func (s *SBOM) setReport(pkgs []sbomtypes.PackageWithInstalledFiles) {
-	// build file cache
-	s.data.files = newFileQuerier(pkgs, s.usrMerged)
+	// build the compact file cache and package metadata, dropping installed-file lists
+	s.data = newData(pkgs, s.usrMerged)
 }
 
 func (s *SBOM) stop() {
@@ -410,8 +429,13 @@ func (r *Resolver) triggerForwarding(sbom *SBOM) {
 
 				seclog.Debugf("Forwarding SBOM with LastAccess for container %s (%d packages)", sbom.ContainerID, len(sbom.data.packages))
 
+				// Snapshot the package metadata: the forwarded report outlives the
+				// lock and the backing slice keeps being mutated (LastAccess) at runtime.
+				packages := make([]sbomtypes.Package, len(sbom.data.packages))
+				copy(packages, sbom.data.packages)
+
 				// Create SBOM report and notify listeners
-				packagesReport := NewPackagesReport(sbom.data.packages, sbom.ContainerID)
+				packagesReport := NewPackagesReport(packages, sbom.ContainerID)
 				scanResult := &sbompkg.ScanResult{
 					Report:           packagesReport,
 					CreatedAt:        time.Now(),
@@ -635,10 +659,7 @@ func (r *Resolver) analyzeWorkload(sb *SBOM) error {
 		return scanErr
 	}
 
-	data := &Data{
-		files:    newFileQuerier(report, sb.usrMerged),
-		packages: report, // Store original packages for forwarding with LastAccess
-	}
+	data := newData(report, sb.usrMerged)
 	sb.data = data
 
 	// mark the SBOM as successful


### PR DESCRIPTION
### What does this PR do?

Stop retaining plain-text installed-files list of system packages.

### Motivation

The fileQuerier compresses each installed file to 8 bytes precisely to keep system-probe's footprint small. Meanwhile data.packages keeps every path as a full Go string (~16-byte header + 30–80 path bytes). A container image commonly has tens of thousands to >100k installed files, so each cached workload holds several MB of plain-text paths that are never read again, multiplied across the dataCache LRU → tens of MB of dead resident memory.

Keep a backing slice of []Package (no InstalledFiles) and have the fileQuerier point into that, so the plain-text InstalledFiles strings become unreferenced once the hashes and the policy def are computed and get GC'd

### Describe how you validated your changes

### Additional Notes
