### PR TITLE
comp/core/gui/impl: follow symlinks when classifying conf.d entries

### DIFF
--- a/comp/core/gui/impl/checks.go
+++ b/comp/core/gui/impl/checks.go
@@ -8,6 +8,7 @@ package guiimpl
 import (
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -272,7 +273,7 @@ func listChecks(w http.ResponseWriter, _ *http.Request) {
 		}
 
 		for _, file := range files {
-			if ext := filepath.Ext(file.Name()); ext == ".py" && file.Type().IsRegular() {
+			if ext := filepath.Ext(file.Name()); ext == ".py" && resolveEntryType(filepath.Join(path, file.Name()), file).IsRegular() {
 				integrations = append(integrations, file.Name())
 			}
 		}
@@ -366,6 +367,20 @@ func listConfigs(w http.ResponseWriter, _ *http.Request) {
 	w.Write(res)
 }
 
+// resolveEntryType returns entry's type, following symlinks so that
+// Bazel's runfiles-provided symlinked files/directories are classified correctly.
+func resolveEntryType(fullPath string, entry os.DirEntry) fs.FileMode {
+	t := entry.Type()
+	if t&fs.ModeSymlink == 0 {
+		return t
+	}
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return t
+	}
+	return info.Mode().Type()
+}
+
 // Helper function which returns all the filenames in a check config directory
 func readConfDir(path string) ([]string, error) {
 	var filenames []string
@@ -375,16 +390,18 @@ func readConfDir(path string) ([]string, error) {
 	}
 
 	for _, entry := range entries {
+		entryPath := filepath.Join(path, entry.Name())
+
 		// Some check configs are in nested subdirectories
-		if entry.IsDir() {
+		if resolveEntryType(entryPath, entry).IsDir() {
 			if filepath.Ext(entry.Name()) != ".d" {
 				continue
 			}
 
-			subEntries, err := os.ReadDir(filepath.Join(path, entry.Name()))
+			subEntries, err := os.ReadDir(entryPath)
 			if err == nil {
 				for _, subEntry := range subEntries {
-					if hasRightEnding(subEntry.Name()) && subEntry.Type().IsRegular() {
+					if hasRightEnding(subEntry.Name()) && resolveEntryType(filepath.Join(entryPath, subEntry.Name()), subEntry).IsRegular() {
 						// Save the full path of the config file {check_name.d}/{filename}
 						filenames = append(filenames, entry.Name()+"/"+subEntry.Name())
 					}
@@ -393,7 +410,7 @@ func readConfDir(path string) ([]string, error) {
 			continue
 		}
 
-		if hasRightEnding(entry.Name()) && entry.Type().IsRegular() {
+		if hasRightEnding(entry.Name()) && resolveEntryType(entryPath, entry).IsRegular() {
 			filenames = append(filenames, entry.Name())
 		}
 	}

--- a/releasenotes/notes/gui-readconfdir-symlink-272efcb7912f701a.yaml
+++ b/releasenotes/notes/gui-readconfdir-symlink-272efcb7912f701a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Agent GUI now follows symbolic links when processing conf.d items.


### PR DESCRIPTION
### What does this PR do?

Follow symlinks when loading configs from conf.d

### Motivation

This is meant as a preliminary PR for migrating `comp/core/gui/impl` build & tests to Bazel.
While running the tests in Bazel's sandbox, all config files will be symlinks, which currently causes the tests to fail as the config files aren't actual files.

### Describe how you validated your changes

- `dda inv test`
- `bazelisk test //comp/core/gui/impl/...` in the bazel migration branch

### Additional Notes

I'm a bit split about changing actual code in order to fix existing tests under Bazel.
On the other hand, this change makes sense as there are various reasons to use symlinks to manage config files.
The security aspect of things seems to be handled by getCheckConfigFile/setCheckConfigFile which ensure we don't read outside of a given volume/folder

I purposefully omited the no-changelog label & didn't include a changelog, I want this to be OK with agent-configuration as far as the code is concerned before bringing in the Documentation team 