### PR TITLE
[ AGNTLOG-645 ] Increase k8s-logs job pod start timeout to absorb cold image pulls

### DIFF
--- a/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go
@@ -73,7 +73,7 @@ func (v *k8sCCAOffSuite) TestADAnnotations() {
 	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpec, metav1.CreateOptions{})
 	require.NoError(v.T(), err, "Could not create autodiscovery job")
 
-	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "annotations-job", 30*time.Second)
+	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "annotations-job", jobPodStartTimeout)
 	if err != nil {
 		require.Fail(v.T(), "Annotations job pod failed to start",
 			"%v\n%s", err, k8sutils.DescribeJob(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "annotations-job"))
@@ -135,7 +135,7 @@ func (v *k8sCCAOffSuite) TestCCAOff() {
 	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpec, metav1.CreateOptions{})
 	require.NoError(v.T(), err, "Could not create CCA-off job")
 
-	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "cca-off-job", 30*time.Second)
+	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "cca-off-job", jobPodStartTimeout)
 	if err != nil {
 		require.Fail(v.T(), "CCA-off job pod failed to start",
 			"%v\n%s", err, k8sutils.DescribeJob(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "cca-off-job"))

--- a/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_test.go
@@ -69,7 +69,7 @@ func (v *k8sSuite) TestSingleLogAndMetadata() {
 	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpec, metav1.CreateOptions{})
 	require.NoError(v.T(), err, "Could not create job")
 
-	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "job-1", 30*time.Second)
+	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "job-1", jobPodStartTimeout)
 	if err != nil {
 		require.Fail(v.T(), "Job pod failed to start",
 			"%v\n%s", err, k8sutils.DescribeJob(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "job-1"))
@@ -136,7 +136,7 @@ func (v *k8sSuite) TestLongLogLine() {
 	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpec, metav1.CreateOptions{})
 	require.NoError(v.T(), err, "Could not create job")
 
-	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "long-line-job", 30*time.Second)
+	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "long-line-job", jobPodStartTimeout)
 	if err != nil {
 		require.Fail(v.T(), "Long line job pod failed to start",
 			"%v\n%s", err, k8sutils.DescribeJob(context.TODO(), v.Env().KubernetesCluster.Client(), "default", "long-line-job"))
@@ -209,7 +209,7 @@ func (v *k8sSuite) TestContainerExclude() {
 	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs(namespaceName).Create(context.TODO(), jobSpec, metav1.CreateOptions{})
 	require.NoError(v.T(), err, "Could not create job")
 
-	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), namespaceName, "exclude-job", 30*time.Second)
+	_, err = k8sutils.WaitForJobPodRunning(context.TODO(), v.Env().KubernetesCluster.Client(), namespaceName, "exclude-job", jobPodStartTimeout)
 	if err != nil {
 		require.Fail(v.T(), "Exclude job pod failed to start",
 			"%v\n%s", err, k8sutils.DescribeJob(context.TODO(), v.Env().KubernetesCluster.Client(), namespaceName, "exclude-job"))

--- a/test/new-e2e/tests/agent-log-pipelines/k8s-logs/helpers_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/k8s-logs/helpers_test.go
@@ -7,9 +7,19 @@ package k8sfiletailing
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
 )
+
+// jobPodStartTimeout is how long we wait for a Job's pod to leave the Pending
+// phase. The workload images (ghcr.io/datadog/apps-alpine) are pulled from a
+// public registry on a freshly-created kind node, so a cold image pull can take
+// well over the previous 30s budget and leave the pod in ContainerCreating.
+// Three minutes comfortably absorbs a cold ghcr.io pull without masking real
+// failures (bad image names, unschedulable pods, and image-pull backoffs are
+// still detected immediately by WaitForJobPodRunning).
+const jobPodStartTimeout = 3 * time.Minute
 
 func fakeintakeRouteStats(fi *components.FakeIntake) string {
 	stats, err := fi.Client().RouteStats()


### PR DESCRIPTION
### What does this PR do?

Increases the timeout the k8s-logs file-tailing E2E tests use when waiting for a Job's pod to leave the `Pending` phase, from 30 seconds to a shared 3-minute budget. A single package-level constant (`jobPodStartTimeout`) now drives every `WaitForJobPodRunning` call site across the k8s-logs suite.

This is a test-reliability fix, not an Agent product change. No agent binary code is touched.

### Motivation

`TestK8sCCAOff/TestADAnnotations` has flaked repeatedly (reported in AGNTLOG-645, ~6 recurrences). The tests create Kubernetes Jobs whose pods pull `ghcr.io/datadog/apps-alpine` from a public registry on a freshly-created kind node. On a cold node the image pull frequently does not finish within the old 30-second budget, so the pod is still in `ContainerCreating` (last event `Pulling image ...`, no `Pulled`/`Started`) when the wait deadline is reached, and the setup precondition fails with "job pod still pending after 30s".

The logs pipeline itself was healthy in the failing runs (fakeintake showed logs arriving); the workload pod simply had not started yet. This is an infra/image-pull timing flake, not an Agent bug. Three minutes comfortably absorbs a cold ghcr.io pull. The existing `WaitForJobPodRunning` helper still fails fast on genuine problems (invalid image names, unschedulable pods, and image-pull backoffs after a grace period), so widening the timeout does not mask real failures. The sibling tests in the same package share the identical pull pattern, so they were switched to the same constant to prevent the same flake recurring there.

### Describe how you validated your changes

These are new-e2e tests that require cloud infrastructure and cannot run locally. Verified the package compiles cleanly in the `test/new-e2e` module: `go vet ./tests/agent-log-pipelines/k8s-logs/...` and `go build ./tests/agent-log-pipelines/k8s-logs/...` both pass.

### Additional Notes

Test-only change; labeled `changelog/no-changelog` and `qa/no-code-change`, so no reno release note is added.