### PR TITLE
[ AGNTLOG-650 ] Make integration logs launcher Stop idempotent

### DIFF
--- a/pkg/logs/launchers/integration/launcher.go
+++ b/pkg/logs/launchers/integration/launcher.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/afero"
@@ -38,6 +39,7 @@ type Launcher struct {
 	sources              *sources.LogSources
 	addedConfigs         chan integrations.IntegrationConfig
 	stop                 chan struct{}
+	stopOnce             sync.Once
 	runPath              string
 	integrationsLogsChan chan integrations.IntegrationLog
 	integrationToFile    map[string]*fileInfo
@@ -115,9 +117,14 @@ func (s *Launcher) Start(_ launchers.SourceProvider, _ pipeline.Provider, _ audi
 	go s.run()
 }
 
-// Stop stops the launcher
+// Stop stops the launcher. It is safe to call multiple times: subsequent calls
+// are no-ops. Closing the stop channel (rather than sending on it) ensures the
+// run loop is unblocked even if it has already returned, avoiding a goroutine
+// leak / shutdown deadlock when Stop is called more than once.
 func (s *Launcher) Stop() {
-	s.stop <- struct{}{}
+	s.stopOnce.Do(func() {
+		close(s.stop)
+	})
 }
 
 // run checks if there are new files to tail and tails them

--- a/pkg/logs/launchers/integration/launcher_test.go
+++ b/pkg/logs/launchers/integration/launcher_test.go
@@ -746,6 +746,33 @@ func TestLauncherTestSuite(t *testing.T) {
 	suite.Run(t, new(LauncherTestSuite))
 }
 
+// TestStopIsIdempotent ensures calling Stop multiple times does not panic or
+// block. This guards against a regression where Stop sent on an unbuffered
+// channel, causing the second call to block forever after the run loop had
+// already returned (a goroutine leak / shutdown deadlock).
+func TestStopIsIdempotent(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("logs_config.run_path", t.TempDir())
+
+	integrationsComp := integrationsmock.Mock()
+	s := NewLauncher(afero.NewMemMapFs(), sources.NewLogSources(), integrationsComp)
+
+	s.Start(nil, nil, nil, nil)
+
+	done := make(chan struct{})
+	go func() {
+		s.Stop()
+		s.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop blocked when called multiple times")
+	}
+}
+
 // TestReadOnlyFileSystem ensures the launcher doesn't panic in a read-only
 // file system. There will be errors but it should handle them gracefully.
 func TestReadOnlyFileSystem(t *testing.T) {

--- a/releasenotes/notes/fix-integration-launcher-stop-deadlock-a1b2c3d4e5f60789.yaml
+++ b/releasenotes/notes/fix-integration-launcher-stop-deadlock-a1b2c3d4e5f60789.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a shutdown hang and goroutine leak in the integrations logs launcher.
+    Stopping the launcher more than once previously blocked forever on an
+    unbuffered channel once the run loop had already exited. Stopping the
+    launcher is now idempotent and safe to call multiple times.


### PR DESCRIPTION
### What does this PR do?

Makes stopping the integrations logs launcher safe to call any number of times. Previously the launcher's `Stop` sent a value on an unbuffered channel that its run loop received exactly once. After the run loop had exited (or when `Stop` was called more than once), a subsequent `Stop` blocked forever because no receiver remained. `Stop` now closes the stop channel through a `sync.Once`, which unblocks the run loop immediately and turns any further calls into no-ops.

### Motivation

The double-`Stop` case is hit in normal usage — for example an explicit `Stop()` followed by a deferred cleanup `Stop()` in tests — and it caused a permanent goroutine leak and shutdown deadlock. In tests this manifested as the Go test binary hanging until the overall timeout fired, producing a panic/timeout misattributed to whatever subtest happened to be running. This is a real shutdown hang, not a data race.

### Describe how you validated your changes

Added `TestStopIsIdempotent`, which starts the launcher and calls `Stop()` twice, asserting it returns quickly rather than blocking. The existing launcher suite plus the new test pass via `inv test --targets=./pkg/logs/launchers/integration` and `go build ./pkg/logs/launchers/integration/...`.

### Additional Notes

N/A