### PR TITLE
[DSEC-118] Build and ship Rust shared-library checks in agent packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -840,6 +840,7 @@
 /tasks/static_quality_gates/            @DataDog/agent-build
 /tasks/files_inventory.py               @DataDog/agent-build
 /tasks/rtloader.py                      @DataDog/agent-runtimes
+/tasks/rust_shared_checks.py            @DataDog/agent-build
 /tasks/secret_generic_connector.py      @DataDog/agent-configuration
 /tasks/security_agent.py                @DataDog/agent-security
 /tasks/sbomgen.py                       @DataDog/agent-security

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -840,7 +840,7 @@
 /tasks/static_quality_gates/            @DataDog/agent-build
 /tasks/files_inventory.py               @DataDog/agent-build
 /tasks/rtloader.py                      @DataDog/agent-runtimes
-/tasks/rust_shared_checks.py            @DataDog/agent-build
+/tasks/rust_shared_checks.py            @DataDog/agent-build @DataDog/agent-runtimes
 /tasks/secret_generic_connector.py      @DataDog/agent-configuration
 /tasks/security_agent.py                @DataDog/agent-security
 /tasks/sbomgen.py                       @DataDog/agent-security

--- a/Dockerfiles/agent-ddot/Dockerfile
+++ b/Dockerfiles/agent-ddot/Dockerfile
@@ -15,5 +15,7 @@ RUN chmod 755 -R /opt/entrypoints \
   && chown dd-agent:root /etc/datadog-agent/otel-config.yaml \
   && rm -rf /var/run && mkdir -p /var/run/s6 && mkdir -p /var/run/datadog && mkdir -p /opt/datadog-agent/run \
   && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
-  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
-  && find /etc/datadog-agent/checks.d -maxdepth 1 -type f -exec chmod 0500 {} \; 2>/dev/null || true
+  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run
+
+# Set owner-only (0500) perms on built-in Rust shared-library checks.
+RUN for f in /etc/datadog-agent/checks.d/libdatadog-agent-*.so; do [ -f "$f" ] && chmod 0500 "$f"; done

--- a/Dockerfiles/agent-ddot/Dockerfile
+++ b/Dockerfiles/agent-ddot/Dockerfile
@@ -17,5 +17,5 @@ RUN chmod 755 -R /opt/entrypoints \
   && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
   && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run
 
-# Set owner-only (0500) perms on built-in Rust shared-library checks.
-RUN for f in /etc/datadog-agent/checks.d/libdatadog-agent-*.so; do [ -f "$f" ] && chmod 0500 "$f"; done
+# Set owner-only (0500) perms on built-in Rust shared-library checks (no-op when none are present).
+RUN find /etc/datadog-agent/checks.d -name 'libdatadog-agent-*.so' -exec chmod 0500 {} \;

--- a/Dockerfiles/agent-ddot/Dockerfile
+++ b/Dockerfiles/agent-ddot/Dockerfile
@@ -15,4 +15,5 @@ RUN chmod 755 -R /opt/entrypoints \
   && chown dd-agent:root /etc/datadog-agent/otel-config.yaml \
   && rm -rf /var/run && mkdir -p /var/run/s6 && mkdir -p /var/run/datadog && mkdir -p /opt/datadog-agent/run \
   && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
-  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run
+  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
+  && find /etc/datadog-agent/checks.d -maxdepth 1 -type f -exec chmod 0500 {} \; 2>/dev/null || true

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -210,8 +210,8 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
   # copy it on OpenShift where containers run with a random UID in the root group.
   && chmod u=r,g=r,o= /etc/datadog-agent/private-action-runner/*
 
-# Set owner-only (0500) perms on built-in Rust shared-library checks.
-RUN for f in /etc/datadog-agent/checks.d/libdatadog-agent-*.so; do [ -f "$f" ] && chmod 0500 "$f"; done
+# Set owner-only (0500) perms on built-in Rust shared-library checks (no-op when none are present).
+RUN find /etc/datadog-agent/checks.d -name 'libdatadog-agent-*.so' -exec chmod 0500 {} \;
 
 # Check that the UID of dd-agent is still 100.
 #

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -203,6 +203,7 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
   && rm /var/run && mkdir -p /var/run/s6 && mkdir -p /var/run/datadog && mkdir -p /opt/datadog-agent/run \
   && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
   && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
+  && find /etc/datadog-agent/checks.d -maxdepth 1 -type f -exec chmod 0500 {} \; 2>/dev/null || true \
   && chmod 755 /probe.sh /initlog.sh \
   && chown root:secret-manager /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh /opt/datadog-agent/embedded/bin/secret-generic-connector \
   && chmod 550 /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh /opt/datadog-agent/embedded/bin/secret-generic-connector \

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -203,13 +203,15 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
   && rm /var/run && mkdir -p /var/run/s6 && mkdir -p /var/run/datadog && mkdir -p /opt/datadog-agent/run \
   && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
   && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
-  && find /etc/datadog-agent/checks.d -maxdepth 1 -type f -exec chmod 0500 {} \; 2>/dev/null || true \
   && chmod 755 /probe.sh /initlog.sh \
   && chown root:secret-manager /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh /opt/datadog-agent/embedded/bin/secret-generic-connector \
   && chmod 550 /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh /opt/datadog-agent/embedded/bin/secret-generic-connector \
   # Keep the PAR config read-only, but group-readable so init containers can
   # copy it on OpenShift where containers run with a random UID in the root group.
   && chmod u=r,g=r,o= /etc/datadog-agent/private-action-runner/*
+
+# Set owner-only (0500) perms on built-in Rust shared-library checks.
+RUN for f in /etc/datadog-agent/checks.d/libdatadog-agent-*.so; do [ -f "$f" ] && chmod 0500 "$f"; done
 
 # Check that the UID of dd-agent is still 100.
 #

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -72,7 +72,7 @@ build do
               # Rust checks are built under install_dir; Linux packages ship config from output_config_dir.
               move "#{install_dir}/etc/datadog-agent/checks.d", "#{output_config_dir}/etc/datadog-agent", :force => true
               # Owner-only perms on shipped shared-library checks (see agent-dmg/postinst).
-              command "find #{output_config_dir}/etc/datadog-agent/checks.d -maxdepth 1 -type f \\( -name 'libdatadog-agent-*.dylib' -o -name 'libdatadog-agent-*.so' \\) -exec chmod 0500 {} \\; 2>/dev/null || true"
+              command "find #{output_config_dir}/etc/datadog-agent/checks.d -maxdepth 1 -type f -name 'libdatadog-agent-*.so' -exec chmod 0500 {} \\; 2>/dev/null || true"
             end
             move "#{install_dir}/etc/datadog-agent/application_monitoring.yaml.example", "#{output_config_dir}/etc/datadog-agent"
             unless heroku_target?

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -68,6 +68,12 @@ build do
             move "#{install_dir}/bin/agent/dd-agent", "/usr/bin/dd-agent"
             move "#{install_dir}/etc/datadog-agent/datadog.yaml.example", "#{output_config_dir}/etc/datadog-agent"
             move "#{install_dir}/etc/datadog-agent/conf.d", "#{output_config_dir}/etc/datadog-agent", :force=>true
+            if Dir.exist?("#{install_dir}/etc/datadog-agent/checks.d")
+              # Rust checks are built under install_dir; Linux packages ship config from output_config_dir.
+              move "#{install_dir}/etc/datadog-agent/checks.d", "#{output_config_dir}/etc/datadog-agent", :force => true
+              # Owner-only perms on shipped shared-library checks (see agent-dmg/postinst).
+              command "find #{output_config_dir}/etc/datadog-agent/checks.d -maxdepth 1 -type f \\( -name 'libdatadog-agent-*.dylib' -o -name 'libdatadog-agent-*.so' \\) -exec chmod 0500 {} \\; 2>/dev/null || true"
+            end
             move "#{install_dir}/etc/datadog-agent/application_monitoring.yaml.example", "#{output_config_dir}/etc/datadog-agent"
             unless heroku_target?
               if sysprobe_enabled?

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -68,12 +68,6 @@ build do
             move "#{install_dir}/bin/agent/dd-agent", "/usr/bin/dd-agent"
             move "#{install_dir}/etc/datadog-agent/datadog.yaml.example", "#{output_config_dir}/etc/datadog-agent"
             move "#{install_dir}/etc/datadog-agent/conf.d", "#{output_config_dir}/etc/datadog-agent", :force=>true
-            if Dir.exist?("#{install_dir}/etc/datadog-agent/checks.d")
-              # Rust checks are built under install_dir; Linux packages ship config from output_config_dir.
-              move "#{install_dir}/etc/datadog-agent/checks.d", "#{output_config_dir}/etc/datadog-agent", :force => true
-              # Owner-only perms on shipped shared-library checks (see agent-dmg/postinst).
-              command "find #{output_config_dir}/etc/datadog-agent/checks.d -maxdepth 1 -type f -name 'libdatadog-agent-*.so' -exec chmod 0500 {} \\; 2>/dev/null || true"
-            end
             move "#{install_dir}/etc/datadog-agent/application_monitoring.yaml.example", "#{output_config_dir}/etc/datadog-agent"
             unless heroku_target?
               if sysprobe_enabled?
@@ -99,6 +93,14 @@ build do
             # (also requires `extra_package_file` directive in project def)
             mkdir "#{output_config_dir}/etc/datadog-agent/checks.d"
             mkdir "/var/log/datadog"
+
+            # Move the built-in shared-library checks (built under install_dir) into the
+            # package's checks.d and set owner-only permissions on them.
+            Dir.glob("#{install_dir}/etc/datadog-agent/checks.d/libdatadog-agent-*.so").each do |lib|
+              dest = "#{output_config_dir}/etc/datadog-agent/checks.d/#{File.basename(lib)}"
+              move lib, dest, :force => true
+              command "chmod 0500 #{dest}"
+            end
 
             # Process manager config directory (read-only, under install dir)
             mkdir "#{install_dir}/processes.d"

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -103,6 +103,13 @@ build do
   else
     conf_dir = "#{install_dir}/etc/datadog-agent"
   end
+
+  # Stage Rust shared-library checks (Linux + macOS only).
+  unless windows_target?
+    command "dda inv -- -e rust-shared-checks.build --checks-d-dir=\"#{conf_dir}/checks.d\"",
+      env: env,
+      :live_stream => Omnibus.logger.live_stream(:info)
+  end
   # TODO(agent-build): sort out the use of bin/agen/dist/conf.d
   # dda inv agent.build  leaves many files in bin/agen/dist/conf.d
   # Now we place them into the pacakge via the //packages/agent/product:post_build_install

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -104,8 +104,8 @@ build do
     conf_dir = "#{install_dir}/etc/datadog-agent"
   end
 
-  # Stage Rust shared-library checks (Linux + macOS only).
-  unless windows_target?
+  # Stage Rust shared-library checks (Linux only).
+  if linux_target?
     command "dda inv -- -e rust-shared-checks.build --checks-d-dir=\"#{conf_dir}/checks.d\"",
       env: env,
       :live_stream => Omnibus.logger.live_stream(:info)

--- a/omnibus/package-scripts/agent-dmg/postinst
+++ b/omnibus/package-scripts/agent-dmg/postinst
@@ -186,8 +186,7 @@ find $CONF_DIR -type f -exec chmod 660 {} \;
 # - owner must be trusted (handled by chown above)
 # - group/others must have no access (mode bits)
 if [ -d "$CONF_DIR/checks.d" ]; then
-  find "$CONF_DIR/checks.d" -maxdepth 1 -type f \
-    \( -name 'libdatadog-agent-*.dylib' -o -name 'libdatadog-agent-*.so' \) \
+  find "$CONF_DIR/checks.d" -maxdepth 1 -type f -name 'libdatadog-agent-*.dylib' \
     -exec chmod 0500 {} \; 2>/dev/null || true
 fi
 

--- a/omnibus/package-scripts/agent-dmg/postinst
+++ b/omnibus/package-scripts/agent-dmg/postinst
@@ -182,6 +182,15 @@ chown -vR "$DDAGENT_USER:admin" $CONF_DIR
 chmod -v 770 $CONF_DIR
 find $CONF_DIR -type f -exec chmod 660 {} \;
 
+# Shared-library checks rely on strict loader permissions:
+# - owner must be trusted (handled by chown above)
+# - group/others must have no access (mode bits)
+if [ -d "$CONF_DIR/checks.d" ]; then
+  find "$CONF_DIR/checks.d" -maxdepth 1 -type f \
+    \( -name 'libdatadog-agent-*.dylib' -o -name 'libdatadog-agent-*.so' \) \
+    -exec chmod 0500 {} \; 2>/dev/null || true
+fi
+
 # Ensure _dd-agent can read/write config even after a user edits a file with
 # an editor that replaces the file (TextEdit, VS Code, vim, etc.), changing
 # Unix ownership.  macOS editors use atomic save (write temp + rename), which

--- a/omnibus/package-scripts/agent-dmg/postinst
+++ b/omnibus/package-scripts/agent-dmg/postinst
@@ -182,14 +182,6 @@ chown -vR "$DDAGENT_USER:admin" $CONF_DIR
 chmod -v 770 $CONF_DIR
 find $CONF_DIR -type f -exec chmod 660 {} \;
 
-# Shared-library checks rely on strict loader permissions:
-# - owner must be trusted (handled by chown above)
-# - group/others must have no access (mode bits)
-if [ -d "$CONF_DIR/checks.d" ]; then
-  find "$CONF_DIR/checks.d" -maxdepth 1 -type f -name 'libdatadog-agent-*.dylib' \
-    -exec chmod 0500 {} \; 2>/dev/null || true
-fi
-
 # Ensure _dd-agent can read/write config even after a user edits a file with
 # an editor that replaces the file (TextEdit, VS Code, vim, etc.), changing
 # Unix ownership.  macOS editors use atomic save (write temp + rename), which

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/ffi.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/ffi.rs
@@ -8,7 +8,7 @@ macro_rules! generate_ffi {
             check_id_cstr: *const std::ffi::c_char,
             init_config_cstr: *const std::ffi::c_char,
             instance_config_cstr: *const std::ffi::c_char,
-            aggregator_ptr: *const core::Aggregator,
+            aggregator_ptr: *const $crate::Aggregator,
             error_handler: *mut *mut std::ffi::c_char,
         ) {
             if let Err(e) = create_and_run_check(
@@ -30,22 +30,22 @@ macro_rules! generate_ffi {
             check_id_cstr: *const std::ffi::c_char,
             init_config_cstr: *const std::ffi::c_char,
             instance_config_cstr: *const std::ffi::c_char,
-            aggregator_ptr: *const core::Aggregator,
+            aggregator_ptr: *const $crate::Aggregator,
         ) -> Result<(), Box<dyn std::error::Error>> {
             // convert C args to Rust structs
-            let check_id = core::to_rust_string(check_id_cstr)?;
+            let check_id = $crate::to_rust_string(check_id_cstr)?;
 
-            let init_config_str = core::to_rust_string(init_config_cstr)?;
-            let init_config = core::Config::from_str(&init_config_str)?;
+            let init_config_str = $crate::to_rust_string(init_config_cstr)?;
+            let init_config = $crate::Config::from_str(&init_config_str)?;
 
-            let instance_config_str = core::to_rust_string(instance_config_cstr)?;
-            let instance_config = core::Config::from_str(&instance_config_str)?;
+            let instance_config_str = $crate::to_rust_string(instance_config_cstr)?;
+            let instance_config = $crate::Config::from_str(&instance_config_str)?;
 
-            let aggregator = core::Aggregator::from_ptr(aggregator_ptr);
+            let aggregator = $crate::Aggregator::from_ptr(aggregator_ptr);
 
             // create the check instance
             let agent_check =
-                core::AgentCheck::new(check_id, init_config, instance_config, aggregator);
+                $crate::AgentCheck::new(check_id, init_config, instance_config, aggregator);
 
             // run the custom implementation
             $check_function(&agent_check)?;

--- a/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml
+++ b/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+checks:
+  - id: example
+    crate: example
+    include_in_build: true
+    platforms:
+      - linux
+      - darwin

--- a/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml
+++ b/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml
@@ -1,6 +1,6 @@
 checks:
   - id: example
     crate: example
-    include_in_build: true
+    include_in_build: false
     platforms:
       - linux

--- a/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml
+++ b/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml
@@ -4,4 +4,3 @@ checks:
     include_in_build: true
     platforms:
       - linux
-      - darwin

--- a/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml
+++ b/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml
@@ -1,4 +1,3 @@
-schema_version: 1
 checks:
   - id: example
     crate: example

--- a/releasenotes/notes/ship-built-in-rust-check-in-linux-agent-packages-b6caf0effcca3ec2.yaml
+++ b/releasenotes/notes/ship-built-in-rust-check-in-linux-agent-packages-b6caf0effcca3ec2.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The Linux Agent packages can now ship built-in Rust-based checks as shared
+    libraries under ``/etc/datadog-agent/checks.d``, restricted to owner-only access.
+    No such check is shipped for now; this only adds the packaging support.

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -75,6 +75,7 @@ from tasks import (
     release,
     renovate,
     rtloader,
+    rust_shared_checks,
     sbomgen,
     schema,
     secret_generic_connector,
@@ -252,6 +253,7 @@ ns.add_collection(systray)
 ns.add_collection(release)
 ns.add_collection(renovate)
 ns.add_collection(rtloader)
+ns.add_collection(rust_shared_checks)
 ns.add_collection(system_probe)
 ns.add_collection(process_agent)
 ns.add_collection(privateactionrunner)

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -447,6 +447,19 @@ def hacky_dev_image_build(
             f'perl -0777 -pe \'s|{extracted_python_dir}(/opt/datadog-agent/embedded/lib/python\\d+\\.\\d+/../..)|substr $1."\\0"x length$&,0,length$&|e or die "pattern not found"\' -i dev/lib/libdatadog-agent-three.so'
         )
 
+    copy_checks_d = ""
+    copy_checks_d_final = ""
+    if sys.platform.startswith("linux"):
+        from tasks.rust_shared_checks import build as rust_shared_checks_build
+
+        checks_d_staging = "bin/agent/dist/checks.d"
+        rust_shared_checks_build(ctx, checks_d_dir=checks_d_staging)
+        if os.path.isdir(checks_d_staging) and any(
+            f.startswith("libdatadog-agent-") for f in os.listdir(checks_d_staging)
+        ):
+            copy_checks_d = f"COPY {checks_d_staging} /etc/datadog-agent/checks.d\n"
+            copy_checks_d_final = "COPY --from=bin /etc/datadog-agent/checks.d /etc/datadog-agent/checks.d\n"
+
     copy_extra_agents = ""
     if security_agent:
         from tasks.security_agent import build as security_agent_build
@@ -526,6 +539,7 @@ RUN apt-get clean && \
 
 COPY bin/agent/agent                            /opt/datadog-agent/bin/agent/agent
 COPY bin/agent/dist/conf.d                      /etc/datadog-agent/conf.d
+{copy_checks_d}
 COPY dev/lib/libdatadog-agent-rtloader.so.0.1.0 /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0
 COPY dev/lib/libdatadog-agent-three.so          /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so
 {copy_ebpf_assets}
@@ -563,6 +577,7 @@ COPY --from=bin /opt/datadog-agent/bin/agent/agent                              
 COPY --from=bin /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0 /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0
 COPY --from=bin /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so          /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so
 COPY --from=bin /etc/datadog-agent/conf.d /etc/datadog-agent/conf.d
+{copy_checks_d_final}
 {copy_extra_agents}
 {copy_ebpf_assets_final}
 RUN agent          completion bash > /usr/share/bash-completion/completions/agent

--- a/tasks/rust_shared_checks.py
+++ b/tasks/rust_shared_checks.py
@@ -1,0 +1,174 @@
+"""
+Invoke tasks for building Rust-based shared-library checks.
+
+These checks compile to `cdylib` and must be staged into `checks.d` with the
+expected loader naming convention:
+  libdatadog-agent-<check_id>.(so|dylib)
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from invoke import task
+from invoke.exceptions import Exit
+
+from tasks.libs.build.bazel import bazel
+from tasks.libs.common.utils import gitlab_section
+
+RUSTCHECKS_MANIFEST_REL_PATH = "pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml"
+
+
+@dataclass(frozen=True)
+class CheckSpec:
+    id: str
+    crate: str
+    include_in_build: bool
+    platforms: list[str]
+
+
+def _repo_root(ctx) -> Path:
+    repo_root = ctx.run("git rev-parse --show-toplevel", hide=True).stdout.strip()
+    return Path(repo_root)
+
+
+def _current_platform() -> str:
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "darwin":
+        return "darwin"
+    return "windows"
+
+
+def _lib_extension(platform: str) -> str:
+    if platform == "darwin":
+        return "dylib"
+    return "so"
+
+
+def _load_manifest(manifest_path: Path) -> list[CheckSpec]:
+    try:
+        payload: dict[str, Any] = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as e:
+        raise Exit(f"Rust shared checks manifest not found: {manifest_path}") from e
+
+    if not payload:
+        raise Exit(f"Rust shared checks manifest is empty: {manifest_path}")
+
+    checks = payload.get("checks", [])
+    specs: list[CheckSpec] = []
+    for c in checks:
+        specs.append(
+            CheckSpec(
+                id=c["id"],
+                crate=c["crate"],
+                include_in_build=bool(c.get("include_in_build", False)),
+                platforms=list(c.get("platforms", [])),
+            )
+        )
+    return specs
+
+
+def _select_checks(specs: list[CheckSpec], platform: str) -> tuple[list[CheckSpec], list[str]]:
+    final: list[CheckSpec] = []
+    skipped: list[str] = []
+    for s in specs:
+        if not s.include_in_build:
+            continue
+
+        if platform not in s.platforms:
+            skipped.append(f"{s.id} (platform={platform})")
+            continue
+
+        final.append(s)
+
+    return final, skipped
+
+
+def _cargo_build_env(repo_root: Path) -> dict[str, str]:
+    cargo_home = repo_root / "pkg/collector/sharedlibrary/rustchecks/.cargo-home"
+    cargo_home.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["CARGO_HOME"] = str(cargo_home)
+    return env
+
+
+@task
+def build(ctx, checks_d_dir, manifest_path=None):
+    """Build and stage Rust shared-library checks into the provided `checks.d` dir."""
+
+    if not checks_d_dir:
+        raise Exit("Missing required argument: checks_d_dir")
+
+    checks_d_path = Path(checks_d_dir)
+    repo_root = _repo_root(ctx)
+
+    default_manifest_path = repo_root / RUSTCHECKS_MANIFEST_REL_PATH
+    manifest = Path(manifest_path) if manifest_path else default_manifest_path
+
+    platform = _current_platform()
+    if platform == "windows":
+        raise Exit("Refusing to build Rust shared-library checks on windows")
+
+    specs = _load_manifest(manifest)
+    selected, skipped = _select_checks(specs, platform)
+
+    if skipped:
+        print(f"Skipping checks not supported on this platform: {skipped}")
+
+    if not selected:
+        print("No Rust shared-library checks selected; leaving checks.d untouched.")
+        return
+
+    checks_d_path.mkdir(parents=True, exist_ok=True)
+
+    ext = _lib_extension(platform)
+
+    # Drop stale libs for manifest checks so deselected ones are not shipped.
+    managed_ids = {s.id for s in specs}
+    for check_id in managed_ids:
+        candidate = checks_d_path / f"libdatadog-agent-{check_id}.{ext}"
+        if candidate.exists():
+            candidate.unlink()
+
+    # Build selected crates via Bazel-wrapped cargo in the rustchecks workspace.
+    rustchecks_dir = repo_root / "pkg/collector/sharedlibrary/rustchecks"
+    build_env = _cargo_build_env(repo_root)
+    cargo_args = [
+        "@rules_rust//tools/upstream_wrapper:cargo",
+        "--",
+        "build",
+        "--release",
+        "--manifest-path",
+        str(rustchecks_dir / "Cargo.toml"),
+    ]
+    for s in selected:
+        cargo_args += ["-p", s.crate]
+
+    bazel_run_args = [
+        "run",
+        "--remote_download_outputs=all",
+        f"--action_env=CARGO_HOME={build_env['CARGO_HOME']}",
+    ]
+
+    with gitlab_section("Build Rust shared-library checks", collapsed=True):
+        bazel(ctx, *bazel_run_args, *cargo_args)
+
+    # Stage built libs with loader naming and owner-only perms.
+    target_mode = 0o500
+    for s in selected:
+        built_lib = rustchecks_dir / "target" / "release" / f"lib{s.crate}.{ext}"
+        if not built_lib.exists():
+            raise Exit(f"Expected built library not found: {built_lib}")
+
+        staged_lib = checks_d_path / f"libdatadog-agent-{s.id}.{ext}"
+        shutil.copy2(built_lib, staged_lib)
+        os.chmod(staged_lib, target_mode)
+
+        print(f"Staged {staged_lib}")

--- a/tasks/rust_shared_checks.py
+++ b/tasks/rust_shared_checks.py
@@ -3,7 +3,7 @@ Invoke tasks for building Rust-based shared-library checks.
 
 These checks compile to `cdylib` and must be staged into `checks.d` with the
 expected loader naming convention:
-  libdatadog-agent-<check_id>.(so|dylib)
+  libdatadog-agent-<check_id>.so
 """
 
 from __future__ import annotations
@@ -41,15 +41,7 @@ def _repo_root(ctx) -> Path:
 def _current_platform() -> str:
     if sys.platform.startswith("linux"):
         return "linux"
-    if sys.platform == "darwin":
-        return "darwin"
-    return "windows"
-
-
-def _lib_extension(platform: str) -> str:
-    if platform == "darwin":
-        return "dylib"
-    return "so"
+    return "unsupported"
 
 
 def _load_manifest(manifest_path: Path) -> list[CheckSpec]:
@@ -113,8 +105,8 @@ def build(ctx, checks_d_dir, manifest_path=None):
     manifest = Path(manifest_path) if manifest_path else default_manifest_path
 
     platform = _current_platform()
-    if platform == "windows":
-        raise Exit("Refusing to build Rust shared-library checks on windows")
+    if platform != "linux":
+        raise Exit("Refusing to build Rust shared-library checks outside linux")
 
     specs = _load_manifest(manifest)
     selected, skipped = _select_checks(specs, platform)
@@ -128,12 +120,10 @@ def build(ctx, checks_d_dir, manifest_path=None):
 
     checks_d_path.mkdir(parents=True, exist_ok=True)
 
-    ext = _lib_extension(platform)
-
     # Drop stale libs for manifest checks so deselected ones are not shipped.
     managed_ids = {s.id for s in specs}
     for check_id in managed_ids:
-        candidate = checks_d_path / f"libdatadog-agent-{check_id}.{ext}"
+        candidate = checks_d_path / f"libdatadog-agent-{check_id}.so"
         if candidate.exists():
             candidate.unlink()
 
@@ -163,11 +153,11 @@ def build(ctx, checks_d_dir, manifest_path=None):
     # Stage built libs with loader naming and owner-only perms.
     target_mode = 0o500
     for s in selected:
-        built_lib = rustchecks_dir / "target" / "release" / f"lib{s.crate}.{ext}"
+        built_lib = rustchecks_dir / "target" / "release" / f"lib{s.crate}.so"
         if not built_lib.exists():
             raise Exit(f"Expected built library not found: {built_lib}")
 
-        staged_lib = checks_d_path / f"libdatadog-agent-{s.id}.{ext}"
+        staged_lib = checks_d_path / f"libdatadog-agent-{s.id}.so"
         shutil.copy2(built_lib, staged_lib)
         os.chmod(staged_lib, target_mode)
 


### PR DESCRIPTION
### What does this PR do?

- Add [`shared_checks_manifest.yaml`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/build-rust-checks/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml) and a [`rust-shared-checks.build`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/build-rust-checks/tasks/rust_shared_checks.py) invoke task to build manifest-selected `cdylib` checks and stage them into `checks.d` as `libdatadog-agent-<id>.so` with `0500` permissions (Linux only).
- Wire the task into the omnibus agent build ([`datadog-agent.rb`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/build-rust-checks/omnibus/config/software/datadog-agent.rb#L108-L112)); it runs for Linux only (macOS and Windows excluded).
- Move staged shared libs into the Linux package config during [`datadog-agent-finalize.rb`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/build-rust-checks/omnibus/config/software/datadog-agent-finalize.rb#L99-L103) and enforce owner-only (`0500`) perms.
- Re-apply `0500` on the shared-library checks in the [`agent`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/build-rust-checks/Dockerfiles/agent/Dockerfile#L214) and [`agent-ddot`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/build-rust-checks/Dockerfiles/agent-ddot/Dockerfile#L21) Dockerfiles after the recursive config `chmod`.
- Fix the Rust shared-check FFI macro to resolve types via `$crate::` instead of `core::`.

### Motivation

Rust shared-library checks are not built or shipped in agent packages today. This wires the existing rustchecks workspace into omnibus/Docker so checks listed in the manifest can be included in Linux release artifacts.

### Describe how you validated your changes (with example check [enabled](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/build-rust-checks/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml#L4))

#### CI image (omnibus build)

Built from CI job [1848750354](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1848750354) and ran the agent with:

```yaml
services:
  agent:
    image: registry.ddbuild.io/ci/datadog-agent/agent:v124269439-678e1467-7-amd64
    container_name: new-agent-with-rust-checks
    environment:
      DD_API_KEY: ***
      DD_HOSTNAME: aimene-test-ci-image
      DD_SITE: datad0g.com
      DD_APM_ENABLED: "true"
      DD_APM_NON_LOCAL_TRAFFIC: "true"
      DD_LOGS_ENABLED: "true"
      DD_DOGSTATSD_NON_LOCAL_TRAFFIC: "true"
      DD_LOG_LEVEL: "INFO"
      DD_SHARED_LIBRARY_CHECK_ENABLED: "true"
      DD_SHARED_LIBRARY_CHECK_LIBRARY_FOLDER_PATH: "/etc/datadog-agent/checks.d"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
      - ./conf.d:/etc/datadog-agent/conf.d:ro
```

`conf.d` contains `example.d/conf.yaml`:

```yaml
init_config:
instances:
  -
    min_collection_interval: 15
```

The example shared-library check ran successfully and events were received in [Event Explorer (`host:aimene-test-ci-image`)](https://dd.datad0g.com/event/explorer?query=host%3Aaimene-test-ci-image&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=&messageDisplay=expanded-lg&options=&refresh_mode=paused&sort=DESC&from_ts=1783634400000&to_ts=1783687020000&live=false).

#### Hacky dev image

Also tested locally with:

```bash
dda env dev run -- dda inv agent.hacky-dev-image-build --target-image agent-with-rust-checks
```

Same check config and expected results (example shared-library check runs and [events are received](https://dd.datad0g.com/event/explorer?query=host%3Aaimene-test-hacky-build&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=&messageDisplay=expanded-lg&options=&refresh_mode=paused&sort=DESC&from_ts=1783634400000&to_ts=1783687020000&live=false)).

### Actions

- [x] Check selection is driven by [`include_in_build`](https://github.com/DataDog/datadog-agent/blob/aimene.belfodil/dsec/build-rust-checks/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml) in the manifest (default `false`). **Before merge:** set `example` to `include_in_build: false` since **the example check should not ship**.

### Question/Response

#### Why Only Linux?

To keep the scope and risk minimal, this PR targets the Linux platform only.

#### Why shipped shared libs need chmod 0500 (according to existing code)?
Shared-library loader rejects libs (rust checks) unless the owner is trusted and group/others have no access ([`CheckOwnerAndPermissionsAreRestricted`](https://github.com/DataDog/datadog-agent/blob/main/pkg/util/filesystem/permission_check.go#L14-L22) → [`CheckRights`](https://github.com/DataDog/datadog-agent/blob/main/pkg/util/filesystem/rights_nix.go#L17-L34), called from [`SharedLibraryLoader.Open`](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/sharedlibrary/ffi/library_loader.go#L111)). Packaging steps that `chmod` config broadly would otherwise leave libs group/world-readable and unloadable.
