### PR TITLE
[autoscaling] Add allowlist for external recommender endpoints

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/external/recommender.go
+++ b/pkg/clusteragent/autoscaling/workload/external/recommender.go
@@ -34,8 +34,8 @@ type Recommender struct {
 }
 
 // NewRecommender creates a new Recommender to start fetching external recommendations
-func NewRecommender(ctx context.Context, clock clock.Clock, podWatcher workload.PodWatcher, store *autoscalingstore.Store[model.PodAutoscalerInternal], clusterName string, tlsConfig *TLSFilesConfig) (*Recommender, error) {
-	recommenderClient, err := newRecommenderClient(ctx, clock, podWatcher, tlsConfig)
+func NewRecommender(ctx context.Context, clock clock.Clock, podWatcher workload.PodWatcher, store *autoscalingstore.Store[model.PodAutoscalerInternal], clusterName string, tlsConfig *TLSFilesConfig, allowedEndpoints []string) (*Recommender, error) {
+	recommenderClient, err := newRecommenderClient(ctx, clock, podWatcher, tlsConfig, allowedEndpoints)
 	if err != nil {
 		return nil, fmt.Errorf("error creating recommender client: %w", err)
 	}

--- a/pkg/clusteragent/autoscaling/workload/external/recommender_client.go
+++ b/pkg/clusteragent/autoscaling/workload/external/recommender_client.go
@@ -36,19 +36,26 @@ const (
 )
 
 type recommenderClient struct {
-	podWatcher workload.PodWatcher
-	client     *http.Client
+	podWatcher       workload.PodWatcher
+	client           *http.Client
+	allowedEndpoints map[string]struct{}
 }
 
-func newRecommenderClient(ctx context.Context, clock clock.Clock, podWatcher workload.PodWatcher, tlsConfig *TLSFilesConfig) (*recommenderClient, error) {
+func newRecommenderClient(ctx context.Context, clock clock.Clock, podWatcher workload.PodWatcher, tlsConfig *TLSFilesConfig, allowedEndpoints []string) (*recommenderClient, error) {
 	client, err := createHTTPClient(ctx, tlsConfig, clock)
 	if err != nil {
 		return nil, fmt.Errorf("error creating HTTP client: %w", err)
 	}
 
+	allowedEndpointsSet := make(map[string]struct{}, len(allowedEndpoints))
+	for _, endpoint := range allowedEndpoints {
+		allowedEndpointsSet[endpoint] = struct{}{}
+	}
+
 	return &recommenderClient{
-		podWatcher: podWatcher,
-		client:     client,
+		podWatcher:       podWatcher,
+		client:           client,
+		allowedEndpoints: allowedEndpointsSet,
 	}, nil
 }
 
@@ -56,6 +63,14 @@ func (r *recommenderClient) GetReplicaRecommendation(ctx context.Context, cluste
 	recommenderConfig := dpa.CustomRecommenderConfiguration()
 	if recommenderConfig == nil { // should not happen; we should not process autoscalers without recommender config
 		return nil, errors.New("external recommender spec is required")
+	}
+
+	if len(r.allowedEndpoints) == 0 {
+		return nil, errors.New("external recommender feature is disabled: no allowed endpoints configured")
+	}
+
+	if _, allowed := r.allowedEndpoints[recommenderConfig.Endpoint]; !allowed {
+		return nil, errors.New("endpoint is not in the allowed list of external recommender endpoints")
 	}
 
 	u, err := url.Parse(recommenderConfig.Endpoint)
@@ -81,7 +96,7 @@ func (r *recommenderClient) GetReplicaRecommendation(ctx context.Context, cluste
 	ctx, cancel := context.WithTimeout(ctx, apiTimeoutSeconds*time.Second)
 	defer cancel()
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(payload))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, recommenderConfig.Endpoint, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}

--- a/pkg/clusteragent/autoscaling/workload/external/recommender_client_build_request_test.go
+++ b/pkg/clusteragent/autoscaling/workload/external/recommender_client_build_request_test.go
@@ -8,7 +8,6 @@
 package external
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -21,11 +20,12 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 
 	kubeAutoscaling "github.com/DataDog/agent-payload/v5/autoscaling/kubernetes"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
+
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
-	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 )
 
 func TestBuildWorkloadRecommendationRequest_Table(t *testing.T) {
@@ -157,7 +157,7 @@ func TestBuildWorkloadRecommendationRequest_Table(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeClock := clock.NewFakeClock(time.Now())
-			client, err := newRecommenderClient(context.Background(), fakeClock, workload.NewPodWatcher(nil, nil), nil)
+			client, err := newRecommenderClient(t.Context(), fakeClock, workload.NewPodWatcher(nil, nil), nil, nil)
 			assert.NoError(t, err)
 			req, err := client.buildWorkloadRecommendationRequest(tc.cluster, tc.dpa.Build(), tc.dpa.CustomRecommenderConfiguration)
 			assert.NoError(t, err)

--- a/pkg/clusteragent/autoscaling/workload/external/recommender_client_test.go
+++ b/pkg/clusteragent/autoscaling/workload/external/recommender_client_test.go
@@ -8,7 +8,6 @@
 package external
 
 import (
-	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -22,10 +21,12 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/url"
 	"path/filepath"
 
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,12 +51,15 @@ import (
 )
 
 func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
+	const externalRecommenderTestEndpoint = "http://external-recommender.test"
+
 	tests := []struct {
-		name            string
-		dpa             model.FakePodAutoscalerInternal
-		expectedRequest *kubeAutoscaling.WorkloadRecommendationRequest
-		serverResponse  *kubeAutoscaling.WorkloadRecommendationReply
-		expectedError   string
+		name             string
+		dpa              model.FakePodAutoscalerInternal
+		allowedEndpoints []string
+		expectedRequest  *kubeAutoscaling.WorkloadRecommendationRequest
+		serverResponse   *kubeAutoscaling.WorkloadRecommendationReply
+		expectedError    string
 	}{
 		{
 			name: "successful recommendation with CPU objective and watermarks",
@@ -86,7 +90,7 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 				},
 				CurrentReplicas: pointer.Ptr[int32](3),
 				CustomRecommenderConfiguration: &model.RecommenderConfiguration{
-					Endpoint: "",
+					Endpoint: externalRecommenderTestEndpoint,
 					Settings: map[string]interface{}{
 						"custom_setting": "value",
 					},
@@ -97,6 +101,7 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 					},
 				},
 			},
+			allowedEndpoints: []string{externalRecommenderTestEndpoint},
 			expectedRequest: &kubeAutoscaling.WorkloadRecommendationRequest{
 				State: &kubeAutoscaling.WorkloadState{
 					CurrentReplicas: pointer.Ptr[int32](3),
@@ -145,9 +150,10 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 					},
 				},
 				CustomRecommenderConfiguration: &model.RecommenderConfiguration{
-					Endpoint: "",
+					Endpoint: externalRecommenderTestEndpoint,
 				},
 			},
+			allowedEndpoints: []string{externalRecommenderTestEndpoint},
 			expectedRequest: &kubeAutoscaling.WorkloadRecommendationRequest{
 				Targets: []*kubeAutoscaling.WorkloadRecommendationTarget{
 					{
@@ -193,9 +199,10 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 					},
 				},
 				CustomRecommenderConfiguration: &model.RecommenderConfiguration{
-					Endpoint: "",
+					Endpoint: externalRecommenderTestEndpoint,
 				},
 			},
+			allowedEndpoints: []string{externalRecommenderTestEndpoint},
 			expectedRequest: &kubeAutoscaling.WorkloadRecommendationRequest{
 				Targets: []*kubeAutoscaling.WorkloadRecommendationTarget{
 					{
@@ -210,6 +217,46 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 			},
 			serverResponse: &kubeAutoscaling.WorkloadRecommendationReply{
 				TargetReplicas: 5,
+			},
+		},
+		{
+			name: "successful recommendation with allowed endpoint containing a path",
+			dpa: model.FakePodAutoscalerInternal{
+				Namespace: "default",
+				Name:      "test-dpa",
+				Spec: &datadoghq.DatadogPodAutoscalerSpec{
+					TargetRef: autoscalingv2.CrossVersionObjectReference{
+						Kind:       "Deployment",
+						Name:       "test-deployment",
+						APIVersion: "apps/v1",
+					},
+					Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+						{
+							Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+							PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
+								Name: corev1.ResourceCPU,
+								Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+									Utilization: pointer.Ptr[int32](80),
+								},
+							},
+						},
+					},
+				},
+				CustomRecommenderConfiguration: &model.RecommenderConfiguration{
+					Endpoint: externalRecommenderTestEndpoint + "/v1/recommend",
+				},
+			},
+			allowedEndpoints: []string{externalRecommenderTestEndpoint + "/v1/recommend"},
+			expectedRequest: &kubeAutoscaling.WorkloadRecommendationRequest{
+				Targets: []*kubeAutoscaling.WorkloadRecommendationTarget{
+					{
+						Type:        "cpu",
+						TargetValue: 0.80,
+					},
+				},
+			},
+			serverResponse: &kubeAutoscaling.WorkloadRecommendationReply{
+				TargetReplicas: 4,
 			},
 		},
 		{
@@ -273,7 +320,8 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 					Endpoint: "http://in%val%%d",
 				},
 			},
-			expectedError: "error parsing url: parse \"http://in%val%%d\": invalid URL escape \"%va\"",
+			allowedEndpoints: []string{"http://in%val%%d"},
+			expectedError:    "error parsing url: parse \"http://in%val%%d\": invalid URL escape \"%va\"",
 		},
 		{
 			name: "invalid URL scheme",
@@ -306,7 +354,65 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 					Endpoint: "ftp://invalid-scheme",
 				},
 			},
-			expectedError: "only http and https schemes are supported",
+			allowedEndpoints: []string{"ftp://invalid-scheme"},
+			expectedError:    "only http and https schemes are supported",
+		},
+		{
+			name: "external recommender disabled when no endpoints are allowed",
+			dpa: model.FakePodAutoscalerInternal{
+				Namespace: "default",
+				Name:      "test-dpa",
+				Spec: &datadoghq.DatadogPodAutoscalerSpec{
+					TargetRef: autoscalingv2.CrossVersionObjectReference{
+						Kind:       "Deployment",
+						Name:       "test-deployment",
+						APIVersion: "apps/v1",
+					},
+				},
+				CustomRecommenderConfiguration: &model.RecommenderConfiguration{
+					Endpoint: "",
+				},
+			},
+			allowedEndpoints: []string{},
+			expectedError:    "external recommender feature is disabled: no allowed endpoints configured",
+		},
+		{
+			name: "endpoint not in the allowed list is refused",
+			dpa: model.FakePodAutoscalerInternal{
+				Namespace: "default",
+				Name:      "test-dpa",
+				Spec: &datadoghq.DatadogPodAutoscalerSpec{
+					TargetRef: autoscalingv2.CrossVersionObjectReference{
+						Kind:       "Deployment",
+						Name:       "test-deployment",
+						APIVersion: "apps/v1",
+					},
+				},
+				CustomRecommenderConfiguration: &model.RecommenderConfiguration{
+					Endpoint: "http://rejected-recommender.test",
+				},
+			},
+			allowedEndpoints: []string{externalRecommenderTestEndpoint},
+			expectedError:    `endpoint is not in the allowed list of external recommender endpoints`,
+		},
+		{
+			name: "endpoint with a path not matching the allowed list is refused",
+			dpa: model.FakePodAutoscalerInternal{
+				Namespace: "default",
+				Name:      "test-dpa",
+				Spec: &datadoghq.DatadogPodAutoscalerSpec{
+					TargetRef: autoscalingv2.CrossVersionObjectReference{
+						Kind:       "Deployment",
+						Name:       "test-deployment",
+						APIVersion: "apps/v1",
+					},
+				},
+				CustomRecommenderConfiguration: &model.RecommenderConfiguration{
+					Endpoint: externalRecommenderTestEndpoint + "/v2/recommend",
+				},
+			},
+			allowedEndpoints: []string{externalRecommenderTestEndpoint + "/v1/recommend"},
+			expectedError:    `endpoint is not in the allowed list of external recommender endpoints`,
 		},
 		{
 			name: "http call returns unexpected response code",
@@ -332,12 +438,13 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 					},
 				},
 				CustomRecommenderConfiguration: &model.RecommenderConfiguration{
-					Endpoint: "",
+					Endpoint: externalRecommenderTestEndpoint,
 					Settings: map[string]interface{}{
 						"custom_setting": "value",
 					},
 				},
 			},
+			allowedEndpoints: []string{externalRecommenderTestEndpoint},
 			serverResponse: &kubeAutoscaling.WorkloadRecommendationReply{
 				Error: &kubeAutoscaling.Error{
 					Code:    pointer.Ptr[int32](404),
@@ -370,13 +477,14 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 					},
 				},
 				CustomRecommenderConfiguration: &model.RecommenderConfiguration{
-					Endpoint: "",
+					Endpoint: externalRecommenderTestEndpoint,
 					Settings: map[string]interface{}{
 						"custom_setting": "value",
 					},
 				},
 			},
-			expectedError: "error from recommender: 200 Some random error",
+			allowedEndpoints: []string{externalRecommenderTestEndpoint},
+			expectedError:    "error from recommender: 200 Some random error",
 			serverResponse: &kubeAutoscaling.WorkloadRecommendationReply{
 				Error: &kubeAutoscaling.Error{
 					Code:    pointer.Ptr[int32](200),
@@ -398,6 +506,15 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 				assert.Equal(t, http.MethodPost, r.Method)
 				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 				assert.Equal(t, "datadog-cluster-agent", r.Header.Get("User-Agent"))
+
+				// Verify the request was sent to the endpoint's path
+				endpointURL, err := url.Parse(tt.dpa.CustomRecommenderConfiguration.Endpoint)
+				assert.NoError(t, err)
+				expectedPath := endpointURL.Path
+				if expectedPath == "" {
+					expectedPath = "/"
+				}
+				assert.Equal(t, expectedPath, r.URL.Path)
 
 				// If we expect a specific request, verify it
 				if tt.expectedRequest != nil {
@@ -448,19 +565,28 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 				w.Write(payload)
 			}))
 
-			// The endpoint is only set for test cases that expect an error
-			if tt.dpa.CustomRecommenderConfiguration != nil && tt.dpa.CustomRecommenderConfiguration.Endpoint == "" {
-				tt.dpa.CustomRecommenderConfiguration.Endpoint = server.URL
+			if tt.dpa.CustomRecommenderConfiguration != nil {
+				if trimmed := strings.TrimPrefix(tt.dpa.CustomRecommenderConfiguration.Endpoint, externalRecommenderTestEndpoint); trimmed != tt.dpa.CustomRecommenderConfiguration.Endpoint {
+					tt.dpa.CustomRecommenderConfiguration.Endpoint = server.URL + trimmed
+				}
+			}
+
+			allowedEndpoints := make([]string, len(tt.allowedEndpoints))
+			for i, endpoint := range tt.allowedEndpoints {
+				if trimmed := strings.TrimPrefix(endpoint, externalRecommenderTestEndpoint); trimmed != endpoint {
+					endpoint = server.URL + trimmed
+				}
+				allowedEndpoints[i] = endpoint
 			}
 
 			pw := workload.NewPodWatcher(nil, nil)
 			pw.HandleEvent(newFakeWLMPodEvent(tt.dpa.Namespace, tt.dpa.Spec.TargetRef.Name, "pod1", []string{"container-name1"}))
 
-			client, err := newRecommenderClient(context.Background(), fakeClock, pw, nil)
+			client, err := newRecommenderClient(t.Context(), fakeClock, pw, nil, allowedEndpoints)
 			require.NoError(t, err)
 			client.client = server.Client()
 
-			result, err := client.GetReplicaRecommendation(context.Background(), "test-cluster", tt.dpa.Build())
+			result, err := client.GetReplicaRecommendation(t.Context(), "test-cluster", tt.dpa.Build())
 
 			if tt.expectedError != "" {
 				assert.EqualError(t, err, tt.expectedError)
@@ -576,14 +702,14 @@ func TestRecommenderClientTLSClientCertificateReload(t *testing.T) {
 	pw := workload.NewPodWatcher(nil, nil)
 	pw.HandleEvent(newFakeWLMPodEvent(dpa.Namespace, dpa.Spec.TargetRef.Name, "pod1", []string{"container"}))
 
-	client, err := newRecommenderClient(context.Background(), fakeClock, pw, &TLSFilesConfig{
+	client, err := newRecommenderClient(t.Context(), fakeClock, pw, &TLSFilesConfig{
 		CAFile:   caPath,
 		CertFile: clientCertPath,
 		KeyFile:  clientKeyPath,
-	})
+	}, []string{server.URL})
 	require.NoError(t, err)
 
-	result, err := client.GetReplicaRecommendation(context.Background(), "test-cluster", dpa.Build())
+	result, err := client.GetReplicaRecommendation(t.Context(), "test-cluster", dpa.Build())
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/pkg/clusteragent/autoscaling/workload/external/recommender_test.go
+++ b/pkg/clusteragent/autoscaling/workload/external/recommender_test.go
@@ -128,7 +128,7 @@ func TestProcess(t *testing.T) {
 
 	// test
 	fakeClock := clock.NewFakeClock(time.Now())
-	recommender, err := NewRecommender(ctx, fakeClock, pw, store, "test-cluster", nil)
+	recommender, err := NewRecommender(ctx, fakeClock, pw, store, "test-cluster", nil, []string{server.URL})
 	assert.NoError(t, err)
 	recommender.process(ctx)
 

--- a/pkg/clusteragent/autoscaling/workload/provider/provider.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider.go
@@ -160,7 +160,8 @@ func StartWorkloadAutoscaling(
 	}
 
 	externalTLSConfig := buildExternalRecommenderTLSConfig(pkgconfigsetup.Datadog())
-	externalRecommender, err := external.NewRecommender(ctx, clock, podWatcher, store, clusterName, externalTLSConfig)
+	externalRecommenderAllowedEndpoints := pkgconfigsetup.Datadog().GetStringSlice("autoscaling.workload.external_recommender.allowed_endpoints")
+	externalRecommender, err := external.NewRecommender(ctx, clock, podWatcher, store, clusterName, externalTLSConfig, externalRecommenderAllowedEndpoints)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to start workload autoscaling external recommender: %w", err)
 	}

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -6396,6 +6396,13 @@ properties:
             node_type: section
             type: object
             properties:
+              allowed_endpoints:
+                node_type: setting
+                type: array
+                default: []
+                items:
+                  type: string
+                comment: Empty list disables the external recommender feature.
               tls:
                 node_type: section
                 type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1370,6 +1370,7 @@ func autoscaling(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("autoscaling.failover.enabled", false)
 	config.BindEnvAndSetDefault("autoscaling.workload.limit", 1000)
 	config.BindEnvAndSetDefault("autoscaling.workload.num_workers", 2)
+	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.allowed_endpoints", []string{}) // Empty list disables the external recommender feature.
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.ca_file", "")
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.cert_file", "")
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.key_file", "")


### PR DESCRIPTION
### What does this PR do?

External recommender endpoints from DPA annotations must now be present in `autoscaling.workload.external_recommender.allowed_endpoints`; an empty allowlist (the default) disables the external recommender feature entirely.

### Motivation

Disable by default and let agent operator to control what is allowed.

### Describe how you validated your changes

Unit tests.

### Additional Notes
