### PR TITLE
sbom: skip image scans when layers are not in the content store

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -7,6 +7,7 @@
 package sbom
 
 import (
+	"errors"
 	"time"
 
 	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
@@ -21,6 +22,13 @@ const (
 	ScanDaemonType     = "daemon"      // ScanDaemonType defines the type for daemon scan
 	ScanMethodTagName  = "scan_method" // ScanMethodTagName defines the tag name for scan method
 )
+
+// ErrScanNotSupported reports that a scan can never succeed for the given image
+// and must not be retried. Exporting an image on a remote snapshotter such as
+// nydus to a tarball is such a case. Its layers live in the snapshotter rather
+// than the content store, so the export cannot read them however often the scan
+// is retried.
+var ErrScanNotSupported = errors.New("sbom scan not supported for this image")
 
 // Report defines the report interface
 type Report interface {

--- a/pkg/sbom/scanner/scanner.go
+++ b/pkg/sbom/scanner/scanner.go
@@ -348,6 +348,13 @@ func (s *Scanner) handleScanResult(scanResult *sbom.ScanResult, collector collec
 	}
 	if scanResult.Error != nil {
 		telemetry.SBOMFailures.Inc(request.Collector(), request.Type(collector.Options()), errorType)
+		if errors.Is(scanResult.Error, sbom.ErrScanNotSupported) {
+			// This request can never succeed, so retrying it would keep the scan
+			// worker busy forever. Drop it.
+			log.Infof("dropping unsupported SBOM scan for '%s': %v", request.ID(), scanResult.Error)
+			s.scanQueue.Forget(request)
+			return
+		}
 		s.scanQueue.AddRateLimited(request)
 		return
 	}

--- a/pkg/sbom/scanner/scanner_test.go
+++ b/pkg/sbom/scanner/scanner_test.go
@@ -11,6 +11,7 @@ package scanner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -198,6 +199,61 @@ func TestRetryLogic_Error(t *testing.T) {
 			cancel()
 		})
 	}
+}
+
+// TestRetryLogic_NotSupported checks that a scan reported as unsupported is
+// delivered once and then dropped, not retried.
+func TestRetryLogic_NotSupported(t *testing.T) {
+	workloadmetaStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		fx.Provide(func() compConfig.Component { return compConfig.NewMock(t) }),
+		fx.Supply(context.Background()),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+
+	imageID := "id"
+	workloadmetaStore.Set(&workloadmeta.ContainerImageMetadata{
+		EntityID: workloadmeta.EntityID{
+			ID:   imageID,
+			Kind: workloadmeta.KindContainerImageMetadata,
+		},
+	})
+
+	cfg := configmock.New(t)
+	collName := "mock"
+	mockCollector := collectors.NewMockCollector()
+	resultCh := make(chan sbom.ScanResult, 1)
+	unsupported := sbom.ScanResult{Error: fmt.Errorf("%w: nydus", sbom.ErrScanNotSupported)}
+	mockCollector.On("Options").Return(sbom.ScanOptions{})
+	mockCollector.On("Scan", mock.Anything, mock.Anything).Return(unsupported)
+	mockCollector.On("Channel").Return(resultCh)
+	shutdown := mockCollector.On("Shutdown")
+	shutdown.After(5 * time.Second)
+	mockCollector.On("Type").Return(collectors.ContainerImageScanType)
+
+	// Keep the backoff short so a mistaken retry would show up quickly.
+	cfg.Set("sbom.scan_queue.base_backoff", "200ms", model.SourceAgentRuntime)
+	cfg.Set("sbom.scan_queue.max_backoff", "600ms", model.SourceAgentRuntime)
+	cfg.Set("sbom.cache.clean_interval", "10s", model.SourceAgentRuntime)
+
+	scanner := NewScanner(cfg, map[string]collectors.Collector{collName: mockCollector}, option.New[workloadmeta.Component](workloadmetaStore))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scanner.Start(ctx)
+
+	err := scanner.Scan(sbom.ScanRequest(&scanRequest{collectorName: collName, id: imageID, scanRequestType: sbom.ScanFilesystemType}))
+	assert.NoError(t, err)
+
+	res := <-resultCh
+	assert.ErrorIs(t, res.Error, sbom.ErrScanNotSupported)
+
+	// A retried scan would deliver a second result within the backoff window.
+	select {
+	case res := <-resultCh:
+		t.Errorf("unsupported scan was retried, unexpected result: %v", res)
+	case <-time.After(time.Second):
+	}
+	mockCollector.AssertNumberOfCalls(t, "Scan", 1)
 }
 
 func TestRetryLogic_ImageDeleted(t *testing.T) {

--- a/pkg/util/trivy/containerd.go
+++ b/pkg/util/trivy/containerd.go
@@ -283,8 +283,36 @@ func (c *Collector) ScanContainerdImageFromSnapshotter(ctx context.Context, imgM
 	return report, err
 }
 
+// verifyLayersInContentStore returns an error when any layer of img is missing
+// from the content store. Exporting the image to a tarball needs every layer
+// present. A remote snapshotter such as nydus keeps them elsewhere, so this is
+// how we tell that an export cannot succeed without attempting it first.
+func verifyLayersInContentStore(ctx context.Context, img containerd.Image) error {
+	manifest, err := images.Manifest(ctx, img.ContentStore(), img.Target(), img.Platform())
+	if err != nil {
+		return fmt.Errorf("read manifest: %w", err)
+	}
+	store := img.ContentStore()
+	for _, layer := range manifest.Layers {
+		if _, err := store.Info(ctx, layer.Digest); err != nil {
+			return fmt.Errorf("layer %s not in content store: %w", layer.Digest, err)
+		}
+	}
+	return nil
+}
+
 // ScanContainerdImage scans containerd image by exporting it and scanning the tarball
 func (c *Collector) ScanContainerdImage(ctx context.Context, imgMeta *workloadmeta.ContainerImageMetadata, img containerd.Image, client cutil.ContainerdItf, scanOptions sbom.ScanOptions) (sbom.Report, error) {
+	// Exporting the image to a tarball reads every layer blob from the content
+	// store. Images unpacked by a remote snapshotter (nydus, stargz, soci, ...)
+	// keep their layers outside it, so the export fails on a missing blob. Detect
+	// that up front and refuse as a terminal error rather than stream the whole
+	// image only to fail, which the scanner would otherwise retry forever.
+	ctx = namespaces.WithNamespace(ctx, imgMeta.Namespace)
+	if err := verifyLayersInContentStore(ctx, img); err != nil {
+		return nil, fmt.Errorf("%w: image %s: %v", sbom.ErrScanNotSupported, imgMeta.ID, err)
+	}
+
 	fanalImage, cleanup, err := convertContainerdImage(ctx, client.RawClient(), imgMeta, img)
 	if cleanup != nil {
 		defer cleanup()

--- a/releasenotes/notes/sbom-skip-unexportable-image-scans-3b9e1c7a5f0d2648.yaml
+++ b/releasenotes/notes/sbom-skip-unexportable-image-scans-3b9e1c7a5f0d2648.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    The container image SBOM collector no longer attempts to export an image to
+    a tarball when the image's layers are not present in the containerd content
+    store, as happens with remote snapshotters such as nydus. The export could
+    never succeed for these images, and the scan was retried indefinitely,
+    keeping the scan worker busy and increasing Agent memory usage. Such scans
+    are now skipped instead of retried.


### PR DESCRIPTION
On nodes using a remote snapshotter such as nydus, a container image's
layers live in the snapshotter rather than the containerd content store.
The container image SBOM collector exports the image to a tarball, which
reads every layer from the content store, so the export fails with a
"content not found" error. The scanner treats every scan error as
transient and requeues it with backoff, so these images were retried
forever. On dense nodes with hundreds of such images this pinned the
scan worker on work that could never succeed and drove the Agent's
memory up until it was OOM killed.

Check up front that every layer is present in the content store, which
is what the export needs, and refuse the scan with a terminal
ErrScanNotSupported when one is missing. The scanner drops a request
that fails with that error instead of requeuing it. Testing the export
precondition rather than the snapshotter name covers any remote
snapshotter, not just nydus.

An image handled this way produces no SBOM rather than a failed one,
which is no loss because the export could not have scanned it in any
case. Nodes that need SBOMs for these images can use the overlayfs or
mount scan paths, which read the snapshot instead of the content store.

