### PR TITLE
Also detect memfd seal via F_SEAL_SEAL

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/memfd.h
+++ b/pkg/security/ebpf/c/include/hooks/memfd.h
@@ -103,7 +103,9 @@ static int __attribute__((always_inline)) handle_memfd_fcntl(ctx_t *ctx) {
     unsigned int cmd = (unsigned int)CTX_PARM2(ctx);
     unsigned int arg = (unsigned int)CTX_PARM3(ctx);
 
-    if ((cmd != F_ADD_SEALS) || !(arg & F_SEAL_WRITE)) {
+    // dd-trace-go seals F_SEAL_SHRINK|F_SEAL_GROW|F_SEAL_WRITE|F_SEAL_SEAL while
+    // libdatadog seals F_SEAL_SHRINK|F_SEAL_GROW|F_SEAL_SEAL.
+    if ((cmd != F_ADD_SEALS) || !(arg & F_SEAL_WRITE || arg & F_SEAL_SEAL)) {
         return 0;
     }
 

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -37,6 +37,12 @@
 #error "SYS_gettid unavailable on this system"
 #endif
 
+// DD_TRACER_MEMFD_SEALS mirrors the seal set libdatadog applies
+#ifndef DD_TRACER_MEMFD_SEALS
+#define DD_TRACER_MEMFD_SEALS (F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_SEAL)
+#endif
+
+
 pid_t gettid(void) {
     pid_t tid = syscall(SYS_gettid);
     return tid;
@@ -1277,8 +1283,8 @@ int test_tracer_memfd(int argc, char **argv) {
         err(1, "%s failed: wrote %zd bytes, expected %lu", "write", written, sizeof(tracer_data));
     }
 
-    // Seal the memfd (this triggers the eBPF event)
-    if (fcntl(fd, F_ADD_SEALS, F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW) < 0) {
+    // Seal the memfd the same way a real tracer does
+    if (fcntl(fd, F_ADD_SEALS, DD_TRACER_MEMFD_SEALS) < 0) {
         err(1, "%s failed", "fcntl F_ADD_SEALS");
     }
 


### PR DESCRIPTION
### What does this PR do?

Changes the CWS memfd fcntl hook (`pkg/security/ebpf/c/include/hooks/memfd.h`) to gate on `F_SEAL_SEAL` in addition to `F_SEAL_WRITE` when deciding whether an `F_ADD_SEALS` call is a tracer-info memfd seal worth reporting.

It also updates the syscall tester (`syscall_tester.c`) to seal its test memfd with the same mask a real libdatadog-based tracer applies (`F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_SEAL`), exposed via the `DD_TRACER_MEMFD_SEALS` macro.

### Motivation

libdatadog seals its tracer-info memfds with `F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_SEAL` and deliberately omits `F_SEAL_WRITE`. The old hook required `F_SEAL_WRITE`, so it silently missed every libdatadog-based tracer (PHP, Ruby, Python, Node, ...) and only fired for dd-trace-go (which does set `F_SEAL_WRITE`).

### Describe how you validated your changes

Ran the CWS tracer memfd functional test, which now seals via the libdatadog mask and asserts the eBPF event still fires.

Also checked manually that dd-trace-py was working correctly.