### PR TITLE
discovery: make timeout tests deterministic

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -75,6 +75,7 @@ type collector struct {
 
 	// Service discovery fields
 	sysProbeClient                          *sysprobeclient.CheckClient
+	getServicesFromSystemProbe              func(client *sysprobeclient.CheckClient, newPids []int32, heartbeatPids []int32) (*model.ServicesResponse, error)
 	serviceCollectionBatchSize              int
 	serviceCollectionMaxConsecutiveTimeouts int
 	consecutiveServiceDiscoveryTimeouts     int
@@ -126,6 +127,7 @@ func newProcessCollector(id string, catalog workloadmeta.AgentType, clock clock.
 
 		// Initialize service discovery fields
 		sysProbeClient:                          sysprobeclient.GetCheckClient(),
+		getServicesFromSystemProbe:              getServicesFromSystemProbe,
 		serviceCollectionBatchSize:              systemProbeConfig.GetInt(serviceCollectionBatchSizeConfigKey),
 		serviceCollectionMaxConsecutiveTimeouts: systemProbeConfig.GetInt(serviceCollectionMaxConsecutiveTimeoutsConfigKey),
 		serviceCollectionMinProcessAge:          systemProbeConfig.GetDuration(serviceCollectionMinProcessAgeConfigKey),
@@ -380,15 +382,15 @@ func (c *collector) filterPidsToRequest(alivePids core.PidSet, procs map[int32]*
 	return newPids, heartbeatPids
 }
 
-// getDiscoveryServices calls the system-probe /discovery/services endpoint
-func (c *collector) getDiscoveryServices(newPids []int32, heartbeatPids []int32) (*model.ServicesResponse, error) {
+// getServicesFromSystemProbe calls the system-probe /discovery/services endpoint.
+func getServicesFromSystemProbe(client *sysprobeclient.CheckClient, newPids []int32, heartbeatPids []int32) (*model.ServicesResponse, error) {
 	// Create params with categorized PIDs
 	params := core.Params{
 		NewPids:       newPids,
 		HeartbeatPids: heartbeatPids,
 	}
 
-	response, err := sysprobeclient.Post[model.ServicesResponse](c.sysProbeClient, "/services", params, sysconfig.DiscoveryModule)
+	response, err := sysprobeclient.Post[model.ServicesResponse](client, "/services", params, sysconfig.DiscoveryModule)
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +487,7 @@ func (c *collector) getDiscoveryServicesBatched(ctx context.Context, newPids []i
 		log.Debugf("Requesting service discovery batch %d/%d with %d new PIDs and %d heartbeat PIDs",
 			batchIndex+1, len(batches), len(batch.newPids), len(batch.heartbeatPids))
 
-		resp, err := c.getDiscoveryServices(batch.newPids, batch.heartbeatPids)
+		resp, err := c.getServicesFromSystemProbe(c.sysProbeClient, batch.newPids, batch.heartbeatPids)
 		if err != nil {
 			// CheckClient handles startup warnings internally, but we still need to suppress
 			// the error if system-probe hasn't started yet.

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -427,14 +427,11 @@ func TestServiceDiscoveryConsecutiveTimeoutsDisableRequests(t *testing.T) {
 	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
 	c.mockClock.Set(baseTime)
 
-	socketPath, requests := startScriptedServiceDiscoveryServer(t, func(_ int, _ core.Params) serviceDiscoveryTestResponse {
-		time.Sleep(50 * time.Millisecond)
-		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{}}
-	})
-	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(
-		sysprobeclient.WithSocketPath(socketPath),
-		sysprobeclient.WithCheckTimeout(5*time.Millisecond),
-	)
+	requests := 0
+	c.collector.getServicesFromSystemProbe = func(_ *sysprobeclient.CheckClient, _ []int32, _ []int32) (*model.ServicesResponse, error) {
+		requests++
+		return nil, context.DeadlineExceeded
+	}
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101})
 	for i := 0; i < maxConsecutiveTimeouts; i++ {
@@ -445,12 +442,12 @@ func TestServiceDiscoveryConsecutiveTimeoutsDisableRequests(t *testing.T) {
 
 	assert.True(t, c.collector.serviceDiscoveryDisabledByTimeouts())
 	assert.Equal(t, maxConsecutiveTimeouts, c.collector.consecutiveServiceDiscoveryTimeouts)
-	assert.Equal(t, maxConsecutiveTimeouts, requests())
+	assert.Equal(t, maxConsecutiveTimeouts, requests)
 
 	entities, injectedPids := c.collector.updateServices(context.Background(), alivePids, procs)
 	require.Empty(t, entities)
 	require.Empty(t, injectedPids)
-	assert.Equal(t, maxConsecutiveTimeouts, requests(), "disabled service discovery should not send more requests")
+	assert.Equal(t, maxConsecutiveTimeouts, requests, "disabled service discovery should not send more requests")
 }
 
 func TestServiceDiscoverySuccessfulRequestResetsConsecutiveTimeouts(t *testing.T) {
@@ -544,38 +541,28 @@ func TestServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPrev
 	c.collector.store = c.mockStore
 	c.collector.consecutiveServiceDiscoveryTimeouts = 4
 
-	var requestMux sync.Mutex
+	requests := 0
 	var successfulRequestPIDs []int32
-	socketPath, requests := startScriptedServiceDiscoveryServer(t, func(call int, params core.Params) serviceDiscoveryTestResponse {
+	c.collector.getServicesFromSystemProbe = func(_ *sysprobeclient.CheckClient, newPids []int32, _ []int32) (*model.ServicesResponse, error) {
+		call := requests
+		requests++
 		if call == 1 {
-			time.Sleep(50 * time.Millisecond)
-			return serviceDiscoveryTestResponse{response: &model.ServicesResponse{}}
+			return nil, context.DeadlineExceeded
 		}
 
-		requestMux.Lock()
-		successfulRequestPIDs = append([]int32(nil), params.NewPids...)
-		requestMux.Unlock()
-
-		services := make([]model.Service, 0, len(params.NewPids))
-		for _, pid := range params.NewPids {
+		successfulRequestPIDs = append([]int32(nil), newPids...)
+		services := make([]model.Service, 0, len(newPids))
+		for _, pid := range newPids {
 			services = append(services, makeModelService(pid, "timeout-batch-"+strconv.Itoa(int(pid))))
 		}
-		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{
-			Services: services,
-		}}
-	})
-	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(
-		sysprobeclient.WithSocketPath(socketPath),
-		sysprobeclient.WithCheckTimeout(5*time.Millisecond),
-	)
+		return &model.ServicesResponse{Services: services}, nil
+	}
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101, 102, 103, 104, 105})
 	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 
-	assert.Equal(t, 2, requests())
-	requestMux.Lock()
+	assert.Equal(t, 2, requests)
 	successfulPidsSlice := append([]int32(nil), successfulRequestPIDs...)
-	requestMux.Unlock()
 	require.Len(t, successfulPidsSlice, 2)
 
 	require.Len(t, entities, len(successfulPidsSlice))


### PR DESCRIPTION
### What does this PR do?

Makes the service discovery timeout tests deterministic by allowing tests to replace the system-probe service request operation directly.

The affected tests now return `context.DeadlineExceeded` without relying on a short HTTP timeout and a sleeping test server. Production requests continue to use the existing system-probe client.

### Motivation

The tests previously used a 5 ms client timeout against a handler that slept for 50 ms. Under CI scheduling, the client could time out before the server handler ran, so the collector observed the expected timeout while the test server recorded fewer requests.

This became visible with batching because the tests assert the number and outcome of individual requests.

### Describe how you validated your changes

Unit tests

### Additional Notes
