### PR TITLE
CI: bazel: limit the number of jobs based on requested k8s CPUs

### DIFF
--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -67,7 +67,7 @@
   tags: [ "arch:amd64", "specific:true" ]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   variables:
-    KUBERNETES_CPU_REQUEST: 4
+    KUBERNETES_CPU_REQUEST: 8
     KUBERNETES_MEMORY_REQUEST: "32Gi"
     KUBERNETES_MEMORY_LIMIT: "32Gi"
 
@@ -78,7 +78,7 @@
   tags: [ "arch:arm64", "specific:true" ]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   variables:
-    KUBERNETES_CPU_REQUEST: 4
+    KUBERNETES_CPU_REQUEST: 8
     KUBERNETES_MEMORY_REQUEST: "32Gi"
     KUBERNETES_MEMORY_LIMIT: "32Gi"
 

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -34,13 +34,13 @@ bazel:test:linux-amd64:
   extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:linux-amd64 ]
   script:
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --config=no-dd-agent-go-tests //...
+    - bazel test --jobs=$KUBERNETES_CPU_REQUEST --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --config=no-dd-agent-go-tests //...
 
 bazel:test:linux-arm64:
   extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:linux-arm64 ]
   script:
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --config=no-dd-agent-go-tests //...
+    - bazel test --jobs=$KUBERNETES_CPU_REQUEST --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --config=no-dd-agent-go-tests //...
 
 bazel:test:macos-amd64:
   extends: [ .bazel:test, .bazel:test:reporting, .bazel:runner:macos-amd64 ]


### PR DESCRIPTION
### What does this PR do?

Enforce the number of bazel jobs.

### Motivation

In our setup, bazel seems to always assume we have more cores than available.
I initially attempted to set `KUBERNETES_CPU_LIMIT`, but that still causes bazel to assume we have 80 cores available for our CI jobs, while we explicitly request 4.
This PR ensures our CI jobs won't take more than they can chew.

### Describe how you validated your changes

Inspected the bazel logs to ensure we don't have 80+ actions running at once

### Additional Notes
