### PR TITLE
Fix CI predicate paths for multiline tagging regression

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1023,6 +1023,9 @@ workflow:
         - pkg/util/trivy/**/*
         - test/new-e2e/tests/containers/**/*
         - test/new-e2e/go.mod
+        - pkg/logs/internal/decoder/**/*
+        - pkg/config/schema/yaml/logs_config.yaml
+        - pkg/config/setup/common_settings.go
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
 


### PR DESCRIPTION
### What does this PR do?
Adds two paths to the .on_container_or_e2e_changes CI rule so that the new-e2e-containers-eks job (and any other job extending this predicate) is triggered when the multi-line log tagging logic or its config defaults change:

- pkg/logs/internal/decoder/**/* — where multi-line log tags are actually applied to messages (MultiLineHandler)
- pkg/config/setup/common_settings.go — where the logs_config.auto_multi_line_detection and --logs_config.tag_multi_line_logs defaults are set via BindEnvAndSetDefault

### Motivation
Following incident [link to incident], the new-e2e-containers-eks CI job started failing on main because auto_multi_line_detection and tag_multi_line_logs were enabled by default, adding log tags the test suite didn't expect. The immediate fix (marking multiline:auto_multiline as an optional tag in the test assertions) restored the job to green, but the PR that changed these defaults never triggered this test suite pre-merge. neither the decoder logic nor the config defaults file was included in .on_container_or_e2e_changes' path list. This meant the regression was only caught after landing on main, not during PR review.
This change closes that gap so future changes to multi-line log tagging behavior or its defaults will run the relevant E2E suite before merge.

### Describe how you validated your changes
CI-config-only change (path predicate in .gitlab-ci.yml). Validated by confirming:

The added paths correctly correspond to the code that caused the original regression (traced via grep to pkg/logs/internal/decoder/multiline_handler.go and pkg/config/setup/common_settings.go).
YAML syntax is valid and consistent with the existing style/convention used elsewhere in the same rule block.

### Additional Notes
This addresses the first of two follow-up items from the incident retro. The second — making the log tag test assertions actually catch a regression (moving multiline:auto_multiline from optionalTags into expectedTags, per Alex Lavigne's suggestion) — is a separate, test-code change and is tracked separately / will be addressed in a follow-up PR.
