### PR TITLE
fix(serverless-init): attach lambda_microvm_image_version tag to MicroVM logs and traces

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -63,13 +63,15 @@ type MicroVM struct {
 	flushTimeout time.Duration
 }
 
-// GetTags returns MicroVM-specific tags parsed from the image ARN env var.
+// GetTags returns MicroVM-specific tags parsed from the image ARN env var,
+// plus the image version read directly from its own env var.
 func (m *MicroVM) GetTags() map[string]string {
 	tags := map[string]string{
-		"origin":            MicroVMOrigin,
-		"_dd.origin":        MicroVMOrigin,
-		"resource_type":     MicroVMResourceType,
-		"resource_provider": MicroVMResourceProvider,
+		"origin":                       MicroVMOrigin,
+		"_dd.origin":                   MicroVMOrigin,
+		"resource_type":                MicroVMResourceType,
+		"resource_provider":            MicroVMResourceProvider,
+		"lambda_microvm_image_version": tagValueOrUnknown(os.Getenv(serverlessenv.MicroVMImageVersionEnvVar)),
 	}
 
 	arn := os.Getenv(serverlessenv.MicroVMImageARNEnvVar)

--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -56,6 +56,7 @@ func (n *noopTraceAgent) Flush()                 {}
 func (n *noopTraceAgent) Stop()                  {}
 
 const testImageARN = "arn:aws:lambda:us-east-1:123456789012:microvm-image:my-image"
+const testImageVersion = "v1.2.3"
 
 func TestIsMicroVM(t *testing.T) {
 	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, testImageARN)
@@ -68,6 +69,7 @@ func TestIsMicroVMNotSet(t *testing.T) {
 
 func TestMicroVMGetTags(t *testing.T) {
 	t.Setenv(serverlessenv.MicroVMImageARNEnvVar, testImageARN)
+	t.Setenv(serverlessenv.MicroVMImageVersionEnvVar, testImageVersion)
 	m := &MicroVM{}
 	tags := m.GetTags()
 
@@ -79,6 +81,7 @@ func TestMicroVMGetTags(t *testing.T) {
 	assert.Equal(t, MicroVMResourceType, tags["resource_type"])
 	assert.Equal(t, "aws", tags["resource_provider"])
 	assert.Equal(t, testImageARN, tags["resource_id"])
+	assert.Equal(t, testImageVersion, tags["lambda_microvm_image_version"])
 	assert.NotContains(t, tags, "microvm_image_arn")
 }
 
@@ -89,8 +92,24 @@ func TestMicroVMGetTagsMissingARN(t *testing.T) {
 	assert.Equal(t, "unknown", tags["account_id"])
 	assert.Equal(t, "unknown", tags["image_name"])
 	assert.Equal(t, "unknown", tags["resource_id"])
+	assert.Equal(t, "unknown", tags["lambda_microvm_image_version"])
 	assert.Equal(t, MicroVMResourceType, tags["resource_type"])
 	assert.Equal(t, "aws", tags["resource_provider"])
+}
+
+// TestMicroVMGetTagsImageVersionIndependentOfARN proves the image version tag
+// is read independently of the ARN: it's populated even when the ARN env var
+// (and thus all ARN-derived tags) is unset.
+func TestMicroVMGetTagsImageVersionIndependentOfARN(t *testing.T) {
+	t.Setenv(serverlessenv.MicroVMImageVersionEnvVar, testImageVersion)
+	m := &MicroVM{}
+	tags := m.GetTags()
+
+	assert.Equal(t, testImageVersion, tags["lambda_microvm_image_version"])
+	assert.Equal(t, "unknown", tags["resource_id"])
+	assert.Equal(t, "unknown", tags["region"])
+	assert.Equal(t, "unknown", tags["account_id"])
+	assert.Equal(t, "unknown", tags["image_name"])
 }
 
 func TestMicroVMGetEnhancedMetricTags(t *testing.T) {

--- a/pkg/serverless/env/env.go
+++ b/pkg/serverless/env/env.go
@@ -19,6 +19,9 @@ const (
 
 	// MicroVMImageARNEnvVar is injected by the AWS Lambda MicroVM platform at runtime.
 	MicroVMImageARNEnvVar = "AWS_LAMBDA_MICROVM_IMAGE_ARN"
+
+	// MicroVMImageVersionEnvVar is injected by the AWS Lambda MicroVM platform at runtime.
+	MicroVMImageVersionEnvVar = "AWS_LAMBDA_MICROVM_IMAGE_VERSION"
 )
 
 // IsAzureAppServicesExtension returns true if running in Datadog Azure App


### PR DESCRIPTION
## Summary
- Adds a new `lambda_microvm_image_version` tag sourced from `AWS_LAMBDA_MICROVM_IMAGE_VERSION`, read in `MicroVM.GetTags()` alongside the existing `AWS_LAMBDA_MICROVM_IMAGE_ARN` handling.
- The tag flows through the same startup tag map as the ARN-derived tags, so it becomes available on both the logs and trace pipelines at the same time as `resource_id`/`region`/`account_id`/`image_name`. Falls back to `"unknown"` when the env var is unset, matching the existing ARN fallback convention.

## Test plan
- [x] `dda inv linter.go --targets=./cmd/serverless-init/... ./pkg/serverless/env/...` — 0 issues
- [x] `dda inv test --targets=./cmd/serverless-init/cloudservice/...` — all tests pass
- [x] Added test coverage: version set + ARN set, neither set (both default to `"unknown"`), and version set with ARN unset (proves the two env vars are read independently)
- [x] Run real tests and confirm the tag can be found in [log](https://ddserverless.datadoghq.com/logs?query=%22Run%20hook%20called%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ9NkvW_KyYNhwAAABhBWjlOa3dBaEFBQnFFd3VSMmtBQ0ZnQUMAAAAkZjE5ZjRkOTMtOGY1YS00OGVmLTg5Y2UtYWNiNjg0ZmFkNjEyAAAgrw&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1783712877691&to_ts=1783712916729&live=false) and trace
<img width="2340" height="1728" alt="image" src="https://github.com/user-attachments/assets/a20959d9-f7ac-4085-9023-e8e1688013be" />

