### PR TITLE
feat(agenttelemetry): preserve emitter tag on ADP COAT metrics

### DIFF
--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -77,23 +77,30 @@ profiles:
       - name: logs.auto_multi_line_default_would_truncate
       - name: logs_destination.destination_workers
       - name: point.sent
-        aggregate_tags:
+        preserve_tags:
           - domain
-          - remote_agent
+          - emitter
       - name: point.dropped
-        aggregate_tags:
+        preserve_tags:
           - domain
-          - remote_agent
+          - emitter
       - name: transactions.input_count
-      - name: transactions.input_bytes
-        aggregate_tags:
+        preserve_tags:
+          - domain
           - endpoint
+          - emitter
+      - name: transactions.input_bytes
+        preserve_tags:
+          - domain
+          - endpoint
+          - emitter
       - name: transactions.requeued
       - name: transactions.retries
       - name: transactions.http_errors
         preserve_tags:
           - code
           - endpoint
+          - emitter
   schedule:
     start_after: 30
     iterations: 0


### PR DESCRIPTION
## Summary

Preserve the `emitter` tag on ADP-sourced metrics when they flow through the agent telemetry system to COAT. The Remote Agent Registry stamps `emitter=agent-data-plane` on every metric forwarded from ADP, but the COAT telemetry check only forwards metrics whose tags are listed in `preserve_tags` — metrics lacking those tags are dropped during aggregation. Update `defaultProfiles.yaml` entries for ADP-sourced metrics to include `emitter` in `preserve_tags` so the tag survives to COAT and the Datadog platform.

Also migrate `point.sent` and `point.dropped` from the deprecated `aggregate_tags` field to `preserve_tags` for consistency.

No changelog since not customer facing.

## Change Type
- [x] Bug fix

## How did you test this PR?

I was able to test this locally and observe the metrics in COAT with the added emitter tag.