### PR TITLE
[Backport 7.81.x] Default metrics v3 intake to Datadog URLs only

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -317,14 +317,14 @@ api_key:
 #
 #   series:
 
-#     # @param enabled - string - optional - default: "true"
-#     # @env DD_USE_V3_API_SERIES_ENABLED - string - optional - default: "true"
+#     # @param enabled - string - optional - default: "datadog_only"
+#     # @env DD_USE_V3_API_SERIES_ENABLED - string - optional - default: "datadog_only"
 #     # Global default for the non-distribution metrics intake version. Accepted values:
 #     #   - true: v3 for every destination except Observability Pipelines Worker.
 #     #   - datadog_only: v3 only when the destination URL is a Datadog endpoint.
 #     #   - false: v2 everywhere.
 #
-#     enabled: "true"
+#     enabled: "datadog_only"
 
 #     # @param endpoints - object - optional - default: {}
 #     # @env DD_USE_V3_API_SERIES_ENDPOINTS - JSON object of string to string - optional - default: {}

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -473,6 +473,47 @@ properties:
     description: Forwarder timeout in seconds
     tags:
     - template_section:Common
+  use_v3_api:
+    node_type: section
+    type: object
+    visibility: public
+    description: Controls the use of the v3 metrics intake.
+    tags:
+    - template_section:Common
+    properties:
+      series:
+        node_type: section
+        type: object
+        visibility: public
+        description: Controls the use of the v3 metrics intake for non-distribution
+          metrics (series).
+        tags:
+        - template_section:Common
+        properties:
+          enabled:
+            node_type: setting
+            type: string
+            default: datadog_only
+            visibility: public
+            description: |-
+              Global default for the non-distribution metrics intake version. Accepted values:
+                - true: v3 for every destination except Observability Pipelines Worker.
+                - datadog_only: v3 only when the destination URL is a Datadog endpoint.
+                - false: v2 everywhere.
+          endpoints:
+            node_type: setting
+            type: object
+            default: {}
+            additionalProperties:
+              type: string
+            visibility: public
+            description: |-
+              Per-URL override map for non-distribution metrics intake version. The URL
+              must match exactly what was configured under `dd_url` or `additional_endpoints`.
+              Accepted values:
+                - true: v3 for every destination except Observability Pipelines Worker.
+                - datadog_only: v3 only when the destination URL is a Datadog endpoint.
+                - false: v2 everywhere.
   forwarder_retry_queue_payloads_max_size:
     node_type: setting
     type: integer

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -473,47 +473,6 @@ properties:
     description: Forwarder timeout in seconds
     tags:
     - template_section:Common
-  use_v3_api:
-    node_type: section
-    type: object
-    visibility: public
-    description: Controls the use of the v3 metrics intake.
-    tags:
-    - template_section:Common
-    properties:
-      series:
-        node_type: section
-        type: object
-        visibility: public
-        description: Controls the use of the v3 metrics intake for non-distribution
-          metrics (series).
-        tags:
-        - template_section:Common
-        properties:
-          enabled:
-            node_type: setting
-            type: string
-            default: datadog_only
-            visibility: public
-            description: |-
-              Global default for the non-distribution metrics intake version. Accepted values:
-                - true: v3 for every destination except Observability Pipelines Worker.
-                - datadog_only: v3 only when the destination URL is a Datadog endpoint.
-                - false: v2 everywhere.
-          endpoints:
-            node_type: setting
-            type: object
-            default: {}
-            additionalProperties:
-              type: string
-            visibility: public
-            description: |-
-              Per-URL override map for non-distribution metrics intake version. The URL
-              must match exactly what was configured under `dd_url` or `additional_endpoints`.
-              Accepted values:
-                - true: v3 for every destination except Observability Pipelines Worker.
-                - datadog_only: v3 only when the destination URL is a Datadog endpoint.
-                - false: v2 everywhere.
   forwarder_retry_queue_payloads_max_size:
     node_type: setting
     type: integer

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1530,7 +1530,7 @@ func serializer(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.shadow_sample_rate", float64(0))
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.shadow_sites", []string{"datadoghq.com"})
 
-	config.BindEnvAndSetDefault("use_v3_api.series.enabled", "true")
+	config.BindEnvAndSetDefault("use_v3_api.series.enabled", "datadog_only")
 	config.BindEnvAndSetDefault("use_v3_api.series.endpoints", map[string]string{})
 
 	config.BindEnvAndSetDefault("use_v2_api.series", true)

--- a/pkg/serializer/metrics_test.go
+++ b/pkg/serializer/metrics_test.go
@@ -35,6 +35,7 @@ func TestBuildPipelines(t *testing.T) {
 
 	config.SetInTest("dd_url", "http://example.test")
 	config.SetInTest("api_key", "test_key")
+	config.SetInTest("use_v3_api.series.enabled", "true")
 	config.SetInTest("serializer_experimental_use_v3_api.series.shadow_sample_rate", 0)
 
 	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
@@ -61,6 +62,7 @@ func TestBuildPipelinesWithAdditionalEndpoints(t *testing.T) {
 
 	config.SetInTest("dd_url", "http://example.test")
 	config.SetInTest("api_key", "test_key")
+	config.SetInTest("use_v3_api.series.enabled", "true")
 	config.SetInTest("serializer_experimental_use_v3_api.series.shadow_sample_rate", 0)
 	config.SetInTest("additional_endpoints", map[string][]string{
 		"http://example.test": {"another_key"},
@@ -94,6 +96,7 @@ func TestBuildPipelinesWithAutoscalingFailover(t *testing.T) {
 
 	config.SetInTest("dd_url", "http://example.test")
 	config.SetInTest("api_key", "test_key")
+	config.SetInTest("use_v3_api.series.enabled", "true")
 	config.SetInTest("serializer_experimental_use_v3_api.series.shadow_sample_rate", 0)
 	config.SetInTest("autoscaling.failover.enabled", true)
 	config.SetInTest("cluster_agent.enabled", true)
@@ -136,6 +139,7 @@ func TestBuildPipelinesWithAutoscalingFailoverEmptyList(t *testing.T) {
 
 	config.SetInTest("dd_url", "http://example.test")
 	config.SetInTest("api_key", "test_key")
+	config.SetInTest("use_v3_api.series.enabled", "true")
 	config.SetInTest("serializer_experimental_use_v3_api.series.shadow_sample_rate", 0)
 	config.SetInTest("autoscaling.failover.enabled", true)
 	config.SetInTest("autoscaling.failover.metrics", []string{})
@@ -167,6 +171,7 @@ func TestBuildPipelinesWithMRFInactive(t *testing.T) {
 
 	config.SetInTest("dd_url", "http://example.test")
 	config.SetInTest("api_key", "test_key")
+	config.SetInTest("use_v3_api.series.enabled", "true")
 	config.SetInTest("serializer_experimental_use_v3_api.series.shadow_sample_rate", 0)
 	config.SetInTest("multi_region_failover.enabled", true)
 	config.SetInTest("multi_region_failover.dd_url", "http://mrf.example.test")
@@ -200,6 +205,7 @@ func TestBuildPipelinesWithMRFActive(t *testing.T) {
 
 	config.SetInTest("dd_url", "http://example.test")
 	config.SetInTest("api_key", "test_key")
+	config.SetInTest("use_v3_api.series.enabled", "true")
 	config.SetInTest("serializer_experimental_use_v3_api.series.shadow_sample_rate", 0)
 	config.SetInTest("multi_region_failover.enabled", true)
 	config.SetInTest("multi_region_failover.failover_metrics", true)
@@ -237,6 +243,7 @@ func TestBuildPipelinesWithMRFActiveFilter(t *testing.T) {
 
 	config.SetInTest("dd_url", "http://example.test")
 	config.SetInTest("api_key", "test_key")
+	config.SetInTest("use_v3_api.series.enabled", "true")
 	config.SetInTest("serializer_experimental_use_v3_api.series.shadow_sample_rate", 0)
 	config.SetInTest("multi_region_failover.enabled", true)
 	config.SetInTest("multi_region_failover.failover_metrics", true)
@@ -867,8 +874,8 @@ func TestSeriesV3ModeDatadogOnly(t *testing.T) {
 	)
 }
 
-// TestSeriesV3PerURLOverride covers `use_v3_api.series.endpoints`: the global default is
-// v3, but a specific URL can be pinned back to v2 without affecting other resolvers.
+// TestSeriesV3PerURLOverride covers `use_v3_api.series.endpoints`: a specific URL can
+// be pinned back to v2 without affecting other resolvers.
 func TestSeriesV3PerURLOverride(t *testing.T) {
 	config := configmock.New(t)
 	config.SetInTest("dd_url", "https://app.datadoghq.com")
@@ -885,12 +892,12 @@ func TestSeriesV3PerURLOverride(t *testing.T) {
 	require.Len(t, pipelines, 2)
 
 	testutil.ElementsMatchFn(t, maps.All(pipelines),
-		// global default v3 applies to the unlisted Datadog URL
+		// default datadog_only enables v3 for the unlisted Datadog URL
 		func(t require.TestingT, conf metrics.PipelineConfig, ctx *metrics.PipelineContext) {
 			require.Len(t, ctx.Destinations, 1)
 			dest := ctx.Destinations[0]
 			require.Equal(t, "https://app.datadoghq.com", dest.Resolver.GetConfigName())
-			require.True(t, conf.V3, "global default v3 must apply to unlisted URLs")
+			require.True(t, conf.V3, "default datadog_only must enable v3 for Datadog URLs")
 			require.Equal(t, endpoints.V3SeriesEndpoint, dest.Endpoint)
 		},
 		// per-URL override pins the third-party URL to v2

--- a/releasenotes/notes/series-v3-datadog-only-default-0754aa6a99260537.yaml
+++ b/releasenotes/notes/series-v3-datadog-only-default-0754aa6a99260537.yaml
@@ -1,0 +1,12 @@
+---
+upgrade:
+  - |
+    Metrics now use the Datadog v3 intake by default for Datadog
+    destinations.
+
+    Metric destinations configured with non-Datadog-looking URLs, such as
+    custom ``additional_endpoints`` and reverse proxies, continue to use the
+    v2 intake by default. To enable v3 for every destination, set
+    ``use_v3_api.series.enabled: "true"``. To keep using v2 intake, set
+    ``use_v3_api.series.enabled: "false"`` (global) or
+    ``use_v3_api.series.endpoints: { "<url>": "false" }`` (per-endpoint).

--- a/test/e2e-framework/components/datadog/agentparams/params.go
+++ b/test/e2e-framework/components/datadog/agentparams/params.go
@@ -401,8 +401,7 @@ func WithHostname(hostname string) func(*Params) error {
 }
 
 // WithV3MetricsDisabled forces the agent onto the V2 series intake API by setting
-// use_v3_api.series.enabled=false. V3 is the default, so this opts back out in order to
-// exercise the V2 wire format and /api/v2/series routing.
+// use_v3_api.series.enabled=false.
 func WithV3MetricsDisabled() func(*Params) error {
 	return func(p *Params) error {
 		p.ExtraAgentConfig = append(p.ExtraAgentConfig,

--- a/test/e2e-framework/components/datadog/dockeragentparams/params.go
+++ b/test/e2e-framework/components/datadog/dockeragentparams/params.go
@@ -230,8 +230,7 @@ func withIntakeHostname(url pulumi.StringInput, shouldSkipSSLValidation pulumi.B
 }
 
 // WithV3MetricsDisabled forces the Agent onto the V2 series intake API by setting
-// DD_USE_V3_API_SERIES_ENABLED=false. V3 is the default, so this opts back out in order to
-// exercise the V2 wire format and /api/v2/series routing.
+// DD_USE_V3_API_SERIES_ENABLED=false.
 func WithV3MetricsDisabled() func(*Params) error {
 	return func(p *Params) error {
 		return WithAgentServiceEnvVariable(

--- a/test/new-e2e/tests/agent-metric-pipelines/dogstatsd-unit/dogstatsd_unit_nix_test.go
+++ b/test/new-e2e/tests/agent-metric-pipelines/dogstatsd-unit/dogstatsd_unit_nix_test.go
@@ -53,21 +53,32 @@ type dogstatsdUnitSuite struct {
 func testDogstatsdMetricUnit(t *testing.T, adpEnabled, v3Enabled bool) {
 	t.Parallel()
 
-	agentOptions := []agentparams.Option{
-		agentparams.WithAgentConfig(`
+	agentConfig := `
 histogram_aggregates:
   - max
   - avg
   - count
 histogram_percentiles:
   - "0.95"
-`),
+`
+	if v3Enabled {
+		// The test fakeintake URL is not a Datadog intake URL, so explicitly opt in
+		// to V3 instead of relying on the default datadog_only mode.
+		agentConfig += `
+use_v3_api:
+  series:
+    enabled: "true"
+`
+	}
+
+	agentOptions := []agentparams.Option{
+		agentparams.WithAgentConfig(agentConfig),
 	}
 	if adpEnabled {
 		agentOptions = append(agentOptions, common.WithADPEnabled())
 	}
 	if !v3Enabled {
-		// V3 is the default intake; force V2 explicitly to exercise the V2 wire format.
+		// Force V2 explicitly to exercise the V2 wire format.
 		agentOptions = append(agentOptions, agentparams.WithV3MetricsDisabled())
 	}
 
@@ -116,7 +127,7 @@ func (s *dogstatsdUnitSuite) sendMetric(name string, value float32, metricType s
 
 // TestDogstatsdUnitOnlyOnTimingMetrics sends a counter, a histogram, and a timing metric in
 // parallel and verifies that only the timing metric carries a unit. The test runs for both V2
-// and V3 (default) intake protocols; in both cases it asserts that payloads were routed
+// and V3 intake protocols; in both cases it asserts that payloads were routed
 // exclusively to the expected endpoint.
 func (s *dogstatsdUnitSuite) TestDogstatsdUnitOnlyOnTimingMetrics() {
 	if s.adpEnabled {

--- a/test/new-e2e/tests/otel/otlp-ingest/docker_pipelines_test.go
+++ b/test/new-e2e/tests/otel/otlp-ingest/docker_pipelines_test.go
@@ -51,8 +51,13 @@ func testOTLPIngestDocker(t *testing.T, v3Enabled bool) {
 		dockeragentparams.WithAgentServiceEnvVariable("DD_OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS", pulumi.StringPtr("true")),
 		dockeragentparams.WithExtraComposeManifest("calendar-rest-go", pulumi.String(strings.ReplaceAll(otlpIngestCompose, "{APPS_VERSION}", apps.Version))),
 	}
-	if !v3Enabled {
-		// V3 is the default intake; force V2 explicitly to exercise the V2 wire format.
+	if v3Enabled {
+		// The test fakeintake URL is not a Datadog intake URL, so explicitly opt in
+		// to V3 instead of relying on the default datadog_only mode.
+		agentOptions = append(agentOptions,
+			dockeragentparams.WithAgentServiceEnvVariable("DD_USE_V3_API_SERIES_ENABLED", pulumi.StringPtr("true")))
+	} else {
+		// Force V2 explicitly to exercise the V2 wire format.
 		agentOptions = append(agentOptions, dockeragentparams.WithV3MetricsDisabled())
 	}
 
@@ -74,15 +79,14 @@ func testOTLPIngestDocker(t *testing.T, v3Enabled bool) {
 	)
 }
 
-// TestOTLPIngestDocker runs the OTLP ingest Docker e2e test with the V2 metrics intake API
-// (V3 is the default, so this variant disables it explicitly).
+// TestOTLPIngestDocker runs the OTLP ingest Docker e2e test with the V2 metrics intake API.
 func TestOTLPIngestDocker(t *testing.T) {
 	testOTLPIngestDocker(t, false)
 }
 
-// TestOTLPIngestDockerV3 runs the OTLP ingest Docker e2e test with the default V3 metrics intake
-// API. Metric assertions are identical to the V2 variant; the test additionally verifies
-// that payloads were routed to /api/intake/metrics/v3/series and not /api/v2/series.
+// TestOTLPIngestDockerV3 runs the OTLP ingest Docker e2e test with the V3 metrics intake API.
+// Metric assertions are identical to the V2 variant; the test additionally verifies that
+// payloads were routed to /api/intake/metrics/v3/series and not /api/v2/series.
 func TestOTLPIngestDockerV3(t *testing.T) {
 	testOTLPIngestDocker(t, true)
 }


### PR DESCRIPTION
Backport 0d473ac86779cfd669f3e5580042820ac8ca5806 from #53466 since the automatic backport failed. Merge conflict was on the schema since the use_v3_api section doesn't exist in this branch.

___

### What does this PR do?

Changes the default for `use_v3_api.series.enabled` from `"true"` to `"datadog_only"`.

With this default, metrics use the v3 intake for Datadog URLs, while destinations configured with non-Datadog-looking URLs, such as `additional_endpoints` and reverse proxies, continue using the v2 series intake unless explicitly opted into v3.

### Motivation
`additional_endpoints` may be configured to destinations that do not support the v3 metrics intake route. With v3 enabled for every destination by default, those endpoints can return 404s.

### Describe how you validated your changes
`dda inv test --targets=./pkg/serializer`

### Additional Notes