### PR TITLE
test(agenttelemetry): smoke test for the COAT metric PR reminder bot

### DIFF
--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -606,9 +606,10 @@ func TestRun(t *testing.T) {
 
 	a.start()
 
-	// Default configuration has 6 jobs with different schedules:
+	// Default configuration has 7 jobs with different schedules (temporarily +1 for the
+	// coat-metric-reminder-smoke-test profile added by #53566, not meant to be merged):
 	fmt.Println(r.(*runnerMock).jobs)
-	assert.Equal(t, 6, len(r.(*runnerMock).jobs))
+	assert.Equal(t, 7, len(r.(*runnerMock).jobs))
 
 	// Verify we have the expected number of profiles across all jobs
 	totalProfiles := 0
@@ -616,8 +617,8 @@ func TestRun(t *testing.T) {
 		totalProfiles += len(job.profiles)
 	}
 	fmt.Println(totalProfiles)
-	// Default config has 20 profiles total (checks, logs-and-metrics, database, synthetics, connectivity, csi-driver, agent-performance, service-discovery, runtime-started, runtime-running, hostname, rtloader, otlp, procmgr, trace-agent, gpu, cluster-agent, injector, ebpf, autodiscovery-discovery-probe)
-	assert.Equal(t, 20, totalProfiles)
+	// Default config has 21 profiles total (checks, logs-and-metrics, database, synthetics, connectivity, csi-driver, agent-performance, service-discovery, runtime-started, runtime-running, hostname, rtloader, otlp, procmgr, trace-agent, gpu, cluster-agent, injector, ebpf, autodiscovery-discovery-probe, coat-metric-reminder-smoke-test)
+	assert.Equal(t, 21, totalProfiles)
 }
 
 func TestReportMetricBasic(t *testing.T) {

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -502,6 +502,17 @@ profiles:
     start_after: 30
     iterations: 0
     period: 900
+- name: coat-metric-reminder-smoke-test
+  # Temporary profile used only to exercise the PR reminder bot from
+  # https://github.com/DataDog/datadog-agent/pull/53565. Not meant to be merged.
+  metric:
+    exclude:
+      zero_metric: true
+    metrics:
+      - name: coat_smoke_test.reminder_bot_check
+  schedule:
+    start_after: 30
+    iterations: 1
 - name: ebpf
   metric:
     exclude:


### PR DESCRIPTION
### What does this PR do?

Adds a throwaway `coat-metric-reminder-smoke-test` profile to `defaultProfiles.yaml` purely to exercise the automated reminders added in #53565 end-to-end (both the GitHub Actions checklist comment and the GitLab CI VM-command comment).

**Not meant to be merged.** Base branch is intentionally `louis-cqrl/coat-metric-pr-reminder` (not `main`), since the reminder bot only exists on that branch until #53565 merges.

### Motivation

Validate the bot actually fires and renders correctly on a real PR before merging #53565.

### Describe how you validated your changes

N/A — this PR *is* the validation. Will close once confirmed.

### Additional Notes

Related: #53565