### PR TITLE
[autoscaling] Gate external recommender behind an enabled flag

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/provider/provider.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider.go
@@ -159,12 +159,14 @@ func StartWorkloadAutoscaling(
 		go localRecommender.Run(ctx)
 	}
 
-	externalTLSConfig := buildExternalRecommenderTLSConfig(pkgconfigsetup.Datadog())
-	externalRecommender, err := external.NewRecommender(ctx, clock, podWatcher, store, clusterName, externalTLSConfig)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to start workload autoscaling external recommender: %w", err)
+	if pkgconfigsetup.Datadog().GetBool("autoscaling.workload.external_recommender.enabled") {
+		externalTLSConfig := buildExternalRecommenderTLSConfig(pkgconfigsetup.Datadog())
+		externalRecommender, err := external.NewRecommender(ctx, clock, podWatcher, store, clusterName, externalTLSConfig)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to start workload autoscaling external recommender: %w", err)
+		}
+		go externalRecommender.Run(ctx)
 	}
-	go externalRecommender.Run(ctx)
 
 	return podPatcher, nil
 }

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -6561,6 +6561,11 @@ properties:
             node_type: section
             type: object
             properties:
+              enabled:
+                node_type: setting
+                type: boolean
+                default: false
+                comment: Enables the external recommender feature.
               tls:
                 node_type: section
                 type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1381,6 +1381,7 @@ func autoscaling(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("autoscaling.failover.enabled", false)
 	config.BindEnvAndSetDefault("autoscaling.workload.limit", 1000)
 	config.BindEnvAndSetDefault("autoscaling.workload.num_workers", 2)
+	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.enabled", false) // Enables the external recommender feature.
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.ca_file", "")
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.cert_file", "")
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.key_file", "")


### PR DESCRIPTION
### What does this PR do?

Adds autoscaling.workload.external_recommender.enabled (default false).

### Motivation

Disable external recommender by default.

### Describe how you validated your changes

### Additional Notes
