### PR TITLE
Disable renovate Go deps major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -84,6 +84,12 @@
         "labels": ["dependencies", "dependencies-go", "changelog/no-changelog", "qa/no-code-change"]
       },
       {
+        "description": "Major Go dependency updates require manual migrations",
+        "matchManagers": ["gomod"],
+        "matchUpdateTypes": ["major"],
+        "enabled": false
+      },
+      {
         "matchManagers": ["gomod"],
         "matchDepNames": [
           "github.com/DataDog/datadog-agent/**",

--- a/renovate.json
+++ b/renovate.json
@@ -84,10 +84,10 @@
         "labels": ["dependencies", "dependencies-go", "changelog/no-changelog", "qa/no-code-change"]
       },
       {
-        "description": "Major Go dependency updates require manual migrations",
+        "description": "Require Dependency Dashboard approval for major Go dependency updates",
         "matchManagers": ["gomod"],
         "matchUpdateTypes": ["major"],
-        "enabled": false
+        "dependencyDashboardApproval": true
       },
       {
         "matchManagers": ["gomod"],


### PR DESCRIPTION
### What does this PR do?

Do not create the Go major updates by default, because they often lead to PR completely broken, due to `gomodImportPathsUpdate` not working on our repository.
When those major PR update are created someone should make sure that they can be merged, by doing the needed updates manually.
If the PR ends up in a state where it is completely broken Renovate will try to recreate the PR, leading to a PR with a lot of rebase triggering the CI multiple times for nothing

### Motivation

They lead to PR completely broken with dozens of rebase, to never be merged or merged with no changes.
Like: https://github.com/DataDog/datadog-agent/pull/53526
https://app.datadoghq.com/ci/ci-cd/explorer?query=ci_level%3Ajob%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%40git.branch%3A%28-mq%2A%20OR%20-main%29%20%40git.branch%3Arenovate%2F%2A%20%40ci.job.name%3A%2Amacos%2A&agg_m=count&agg_m_source=base&agg_q=%40git.branch&agg_q_source=base&agg_t=count&ci_cd_explorer_tab=pipelines&fromUser=false&index=cipipeline&refresh_mode=sliding&tab=overview&top_n=100&top_o=top&viz=toplist&x_missing=true&start=1783328087756&end=1783932887756&paused=false

### Describe how you validated your changes

### Additional Notes
