### PR TITLE
Fix flaky `TestServiceDiscovery*Timeout*` tests with `testing/synctest`

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -427,13 +428,22 @@ func TestServiceDiscoveryConsecutiveTimeoutsDisableRequests(t *testing.T) {
 	c := setUpCollectorTest(t, nil, sysConfigOverrides, nil)
 	c.mockClock.Set(baseTime)
 
-	socketPath, requests := startScriptedServiceDiscoveryServer(t, func(_ int, _ core.Params) serviceDiscoveryTestResponse {
-		time.Sleep(50 * time.Millisecond)
+	synctest.Test(t, func(t *testing.T) {
+		testServiceDiscoveryConsecutiveTimeoutsDisableRequests(t, c, maxConsecutiveTimeouts)
+	})
+}
+
+func testServiceDiscoveryConsecutiveTimeoutsDisableRequests(t *testing.T, c collectorTest, maxConsecutiveTimeouts int) {
+	transport, requests := startInProcessScriptedServiceDiscoveryServer(t, func(_ int, _ core.Params) serviceDiscoveryTestResponse {
+		select {
+		case <-t.Context().Done():
+		case <-time.After(50 * time.Millisecond):
+		}
 		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{}}
 	})
-	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(
-		sysprobeclient.WithSocketPath(socketPath),
-		sysprobeclient.WithCheckTimeout(5*time.Millisecond),
+	c.collector.sysProbeClient = sysprobeclient.NewCheckClient(
+		&http.Client{Timeout: 5 * time.Millisecond, Transport: transport},
+		&http.Client{Transport: transport},
 	)
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101})
@@ -544,11 +554,20 @@ func TestServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPrev
 	c.collector.store = c.mockStore
 	c.collector.consecutiveServiceDiscoveryTimeouts = 4
 
+	synctest.Test(t, func(t *testing.T) {
+		testServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPreviousTimeouts(t, c)
+	})
+}
+
+func testServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPreviousTimeouts(t *testing.T, c collectorTest) {
 	var requestMux sync.Mutex
 	var successfulRequestPIDs []int32
-	socketPath, requests := startScriptedServiceDiscoveryServer(t, func(call int, params core.Params) serviceDiscoveryTestResponse {
+	transport, requests := startInProcessScriptedServiceDiscoveryServer(t, func(call int, params core.Params) serviceDiscoveryTestResponse {
 		if call == 1 {
-			time.Sleep(50 * time.Millisecond)
+			select {
+			case <-t.Context().Done():
+			case <-time.After(50 * time.Millisecond):
+			}
 			return serviceDiscoveryTestResponse{response: &model.ServicesResponse{}}
 		}
 
@@ -564,9 +583,9 @@ func TestServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPrev
 			Services: services,
 		}}
 	})
-	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(
-		sysprobeclient.WithSocketPath(socketPath),
-		sysprobeclient.WithCheckTimeout(5*time.Millisecond),
+	c.collector.sysProbeClient = sysprobeclient.NewCheckClient(
+		&http.Client{Timeout: 5 * time.Millisecond, Transport: transport},
+		&http.Client{Transport: transport},
 	)
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101, 102, 103, 104, 105})
@@ -1330,7 +1349,7 @@ type serviceDiscoveryTestResponse struct {
 	status   int
 }
 
-func startScriptedServiceDiscoveryServer(t *testing.T, handler func(call int, params core.Params) serviceDiscoveryTestResponse) (string, func() int) {
+func newScriptedServiceDiscoveryHandler(t *testing.T, handler func(call int, params core.Params) serviceDiscoveryTestResponse) (http.Handler, func() int) {
 	t.Helper()
 
 	var mux sync.Mutex
@@ -1392,6 +1411,13 @@ func startScriptedServiceDiscoveryServer(t *testing.T, handler func(call int, pa
 		w.Write(responseBytes)
 	})
 
+	return httpHandler, requestCount
+}
+
+func startScriptedServiceDiscoveryServer(t *testing.T, handler func(call int, params core.Params) serviceDiscoveryTestResponse) (string, func() int) {
+	t.Helper()
+
+	httpHandler, requestCount := newScriptedServiceDiscoveryHandler(t, handler)
 	socketPath := testutil.SystemProbeSocketPath(t, "")
 	server, err := testutil.NewSystemProbeTestServer(httpHandler, socketPath)
 	require.NoError(t, err)
@@ -1400,6 +1426,31 @@ func startScriptedServiceDiscoveryServer(t *testing.T, handler func(call int, pa
 	t.Cleanup(server.Close)
 
 	return socketPath, requestCount
+}
+
+func startInProcessScriptedServiceDiscoveryServer(t *testing.T, handler func(call int, params core.Params) serviceDiscoveryTestResponse) (http.RoundTripper, func() int) {
+	t.Helper()
+
+	httpHandler, requestCount := newScriptedServiceDiscoveryHandler(t, handler)
+	return handlerTransport(httpHandler.ServeHTTP), requestCount
+}
+
+type handlerTransport http.HandlerFunc
+
+func (tr handlerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	done := make(chan *http.Response, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		tr(rec, req)
+		done <- rec.Result()
+	}()
+
+	select {
+	case resp := <-done: // handler finished first
+		return resp, nil
+	case <-req.Context().Done(): // client's timeout fired first
+		return nil, req.Context().Err()
+	}
 }
 
 func makeSequentialPIDs(count int, start int32) []int32 {

--- a/pkg/system-probe/api/client/check.go
+++ b/pkg/system-probe/api/client/check.go
@@ -128,8 +128,8 @@ func GetCheckClient(options ...CheckClientOption) *CheckClient {
 		option(config)
 	}
 
-	return &CheckClient{
-		checkClient: &http.Client{
+	return NewCheckClient(
+		&http.Client{
 			Timeout: config.checkRequestTimeout,
 			Transport: &http.Transport{
 				MaxIdleConns:          2,
@@ -140,7 +140,7 @@ func GetCheckClient(options ...CheckClientOption) *CheckClient {
 				ExpectContinueTimeout: 50 * time.Millisecond,
 			},
 		},
-		startupClient: &http.Client{
+		&http.Client{
 			Timeout: config.startupCheckRequestTimeout,
 			Transport: &http.Transport{
 				MaxIdleConns:          2,
@@ -151,6 +151,14 @@ func GetCheckClient(options ...CheckClientOption) *CheckClient {
 				ExpectContinueTimeout: 50 * time.Millisecond,
 			},
 		},
+	)
+}
+
+// NewCheckClient builds a check client with the given HTTP clients.
+func NewCheckClient(checkClient, startupClient *http.Client) *CheckClient {
+	return &CheckClient{
+		checkClient:    checkClient,
+		startupClient:  startupClient,
 		startupChecker: getStartChecker(),
 	}
 }


### PR DESCRIPTION
### What does this PR do?
- run `TestServiceDiscoveryConsecutiveTimeoutsDisableRequests` and `TestServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPreviousTimeouts` inside a `testing/synctest` bubble, backed by an in-process `http.RoundTripper` (`handlerTransport`) instead of a real `httptest`/socket server, so the client timeout and the handler's artificial delay are driven by the fake clock instead of real wall-clock scheduling,
- add `sysprobeclient.NewCheckClient`, building a `CheckClient` from already configured `*http.Client` values, so tests can inject the in-process transport without touching `GetCheckClient`'s socket-based defaults.

### Motivation
Both tests have been exhibiting [flakiness](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20FAIL%20TestServiceDiscovery%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1783327755881&to_ts=1783932555881&live=true):
- [TestServiceDiscoveryConsecutiveTimeoutsDisableRequests example on x86_64](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1844752324#L780)
```
=== RUN   TestServiceDiscoveryConsecutiveTimeoutsDisableRequests
    mock.go:28: 2026-07-09 10:44:26 UTC | INFO | (comp/core/workloadmeta/impl/store.go:135 in start) | workloadmeta store initialized successfully
    mock.go:28: 2026-07-09 10:44:26 UTC | DEBUG | (comp/core/workloadmeta/impl/store.go:96 in func3) | at least one workloadmeta collector ready, starting pull loop
    mock.go:28: 2026-07-09 10:44:26 UTC | INFO | (pkg/config/setup/config.go:806 in loadCustom) | Starting to load the configuration
    mock.go:28: 2026-07-09 10:44:26 UTC | DEBUG | (pkg/system-probe/api/server/listener_unix.go:57 in NewListener) | uds: /tmp/TestServiceDiscoveryConsecutiveTimeoutsDisableRequests91386365/001/sysprobe.sock successfully initialized
    mock.go:28: 2026-07-09 10:44:26 UTC | DEBUG | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:485 in getDiscoveryServicesBatched) | Requesting service discovery batch 1/1 with 1 new PIDs and 0 heartbeat PIDs
    mock.go:28: 2026-07-09 10:44:26 UTC | ERROR | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:540 in handleServiceDiscoveryRequestError) | failed to get services: service discovery request timeout: Post "http://sysprobe/discovery/services": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
    mock.go:28: 2026-07-09 10:44:26 UTC | DEBUG | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:485 in getDiscoveryServicesBatched) | Requesting service discovery batch 1/1 with 1 new PIDs and 0 heartbeat PIDs
    mock.go:28: 2026-07-09 10:44:26 UTC | ERROR | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:540 in handleServiceDiscoveryRequestError) | failed to get services: service discovery request timeout: Post "http://sysprobe/discovery/services": net/http: timeout awaiting response headers (Client.Timeout exceeded while awaiting headers)
    mock.go:28: 2026-07-09 10:44:26 UTC | DEBUG | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:485 in getDiscoveryServicesBatched) | Requesting service discovery batch 1/1 with 1 new PIDs and 0 heartbeat PIDs
    mock.go:28: 2026-07-09 10:44:26 UTC | ERROR | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:540 in handleServiceDiscoveryRequestError) | failed to get services: service discovery request timeout: Post "http://sysprobe/discovery/services": net/http: timeout awaiting response headers (Client.Timeout exceeded while awaiting headers)
    mock.go:28: 2026-07-09 10:44:26 UTC | DEBUG | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:485 in getDiscoveryServicesBatched) | Requesting service discovery batch 1/1 with 1 new PIDs and 0 heartbeat PIDs
    mock.go:28: 2026-07-09 10:44:26 UTC | ERROR | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:540 in handleServiceDiscoveryRequestError) | failed to get services: service discovery request timeout: Post "http://sysprobe/discovery/services": net/http: timeout awaiting response headers (Client.Timeout exceeded while awaiting headers)
    mock.go:28: 2026-07-09 10:44:26 UTC | DEBUG | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:485 in getDiscoveryServicesBatched) | Requesting service discovery batch 1/1 with 1 new PIDs and 0 heartbeat PIDs
    mock.go:28: 2026-07-09 10:44:26 UTC | ERROR | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:540 in handleServiceDiscoveryRequestError) | failed to get services: service discovery request timeout: Post "http://sysprobe/discovery/services": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
    mock.go:28: 2026-07-09 10:44:26 UTC | WARN | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:550 in handleServiceDiscoveryRequestError) | disabling service discovery after 5 consecutive system-probe request timeouts; restart the Agent to re-enable it
    process_service_collector_test.go:448: 
        	Error Trace:	comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go:448
        	Error:      	Not equal: 
        	            	expected: 5
        	            	actual  : 4
        	Test:       	TestServiceDiscoveryConsecutiveTimeoutsDisableRequests
    process_service_collector_test.go:453: 
        	Error Trace:	comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go:453
        	Error:      	Not equal: 
        	            	expected: 5
        	            	actual  : 4
        	Test:       	TestServiceDiscoveryConsecutiveTimeoutsDisableRequests
        	Messages:   	disabled service discovery should not send more requests
    mock.go:28: 2026-07-09 10:44:26 UTC | INFO | (comp/core/workloadmeta/impl/store.go:128 in func3) | stopped workloadmeta store
--- FAIL: TestServiceDiscoveryConsecutiveTimeoutsDisableRequests (0.37s)
```
- [TestServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPreviousTimeouts example on AArch64](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1844486855#L779)
```
=== RUN   TestServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPreviousTimeouts
    mock.go:28: 2026-07-09 09:32:14 UTC | INFO | (comp/core/workloadmeta/impl/store.go:135 in start) | workloadmeta store initialized successfully
    mock.go:28: 2026-07-09 09:32:14 UTC | DEBUG | (comp/core/workloadmeta/impl/store.go:96 in func3) | at least one workloadmeta collector ready, starting pull loop
    mock.go:28: 2026-07-09 09:32:14 UTC | INFO | (pkg/config/setup/config.go:806 in loadCustom) | Starting to load the configuration
    mock.go:28: 2026-07-09 09:32:14 UTC | DEBUG | (pkg/system-probe/api/server/listener_unix.go:57 in NewListener) | uds: /tmp/TestServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAn1649919467/001/sysprobe.sock successfully initialized
    mock.go:28: 2026-07-09 09:32:14 UTC | DEBUG | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:485 in getDiscoveryServicesBatched) | Requesting service discovery batch 1/3 with 2 new PIDs and 0 heartbeat PIDs
    mock.go:28: 2026-07-09 09:32:14 UTC | ERROR | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:540 in handleServiceDiscoveryRequestError) | failed to get services: service discovery request timeout: Post "http://sysprobe/discovery/services": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
    mock.go:28: 2026-07-09 09:32:14 UTC | WARN | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:550 in handleServiceDiscoveryRequestError) | disabling service discovery after 5 consecutive system-probe request timeouts; restart the Agent to re-enable it
    process_service_collector_test.go:575: 
        	Error Trace:	comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go:575
        	Error:      	Not equal: 
        	            	expected: 2
        	            	actual  : 1
        	Test:       	TestServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPreviousTimeouts
    process_service_collector_test.go:581: 
        	Error Trace:	comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go:581
        	Error:      	"[]" should have 2 item(s), but has 0
        	Test:       	TestServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPreviousTimeouts
    mock.go:28: 2026-07-09 09:32:14 UTC | INFO | (comp/core/workloadmeta/impl/store.go:128 in func3) | stopped workloadmeta store
--- FAIL: TestServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPreviousTimeouts (0.19s)
```
Each failures shows either an off-by-one on a request counter or an empty entities slice.

Reproduced locally with the `stress` tool under 14-way CPU contention with the race detector on: ~4.33% failure rate, no `DATA RACE` reported.
Root cause: the tests raced a real 5ms `http.Client.Timeout` against a real socket server with an injected 50ms handler delay but, under load, scheduling jitter alone could push even the fast branch past 5ms, or leave the server-side request counter lagging behind the client's own timeout decision.

Widening the timeout margin only reduced the failure rate (4.33% to 1.33%), it did not eliminate it, confirming the underlying race rather than fixing it.

### Describe how you validated your changes
Stress-tested with `stress -p 14 -count 300` on a race-instrumented full-package test binary: 0 failures in either target test across 300 runs, versus ~13/300 before the fix.

### Additional Notes
The proposed fix follows the same `handlerTransport`/ `testing/synctest` pattern already used in #51629 and #50180 for similar timing-sensitive tests in this repo.