### PR TITLE
[PROF-15378] fix gopclntab: validate numfuncs against functab

### DIFF
--- a/comp/host-profiler/symboluploader/pclntab/pclntab.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab.go
@@ -622,9 +622,9 @@ func parseGoPCLnTab(data []byte) (*GoPCLnTabInfo, error) {
 		return nil, fmt.Errorf(".gopclntab header: %x, %x", hdr.pad, hdr.ptrSize)
 	}
 
-	// functab holds numFuncs (pc, funcoff) pairs plus a trailing sentinel pc, (2*numFuncs + 1) fields. Without this
+	// functab holds (2*numFuncs + 1) fields: numFuncs (pc, funcoff) pairs plus a trailing sentinel pc. Without this
 	// bound a header-supplied numFuncs can spin those loops for an unbounded time (otel-ebpf-profiler#1602 class).
-	if hdr.numFuncs > uint64(len(functab)/(2*fieldSize)) {
+	if hdr.numFuncs > uint64((len(functab)/fieldSize-1)/2) {
 		return nil, fmt.Errorf(".gopclntab numFuncs %d exceeds functab capacity (%d bytes, fieldSize %d)",
 			hdr.numFuncs, len(functab), fieldSize)
 	}

--- a/comp/host-profiler/symboluploader/pclntab/pclntab.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab.go
@@ -469,6 +469,9 @@ func (g *GoPCLnTabInfo) funcTabSize() int {
 
 	nfuncdata := getUint8(g.funcdata, maxFuncOffset+g.funcNfuncdataOffset)
 	npcdata := getUInt32(g.funcdata, maxFuncOffset+g.funcNpcdataOffset)
+	if nfuncdata == -1 || npcdata == -1 {
+		return -1
+	}
 	return maxFuncOffset + g.funcSize + npcdata*4 + nfuncdata*g.fieldSize
 }
 
@@ -617,6 +620,13 @@ func parseGoPCLnTab(data []byte) (*GoPCLnTabInfo, error) {
 	}
 	if hdr.pad != 0 || hdr.ptrSize != ptrSize {
 		return nil, fmt.Errorf(".gopclntab header: %x, %x", hdr.pad, hdr.ptrSize)
+	}
+
+	// functab holds numFuncs (pc, funcoff) pairs plus a trailing sentinel pc, (2*numFuncs + 1) fields. Without this
+	// bound a header-supplied numFuncs can spin those loops for an unbounded time (otel-ebpf-profiler#1602 class).
+	if hdr.numFuncs > uint64(len(functab)/(2*fieldSize)) {
+		return nil, fmt.Errorf(".gopclntab numFuncs %d exceeds functab capacity (%d bytes, fieldSize %d)",
+			hdr.numFuncs, len(functab), fieldSize)
 	}
 
 	// nfuncdata is the last field in _func struct

--- a/comp/host-profiler/symboluploader/pclntab/pclntab_internal_test.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab_internal_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 )
 
-
 // moduleDataOf builds a fake moduledata from a list of pointer-sized words.
 func moduleDataOf(words ...uint64) []byte {
 	b := make([]byte, len(words)*ptrSize)
@@ -78,8 +77,8 @@ func syntheticPclntab116(numFuncs uint64) []byte {
 	b := make([]byte, hdrSize)
 	binary.NativeEndian.PutUint32(b[0:], magicGo1_16)
 	// pad (2 bytes) = 0, quantum (1 byte) = 0
-	b[7] = ptrSize                                    // ptrSize field
-	binary.NativeEndian.PutUint64(b[8:], numFuncs)   // numFuncs
+	b[7] = ptrSize                                 // ptrSize field
+	binary.NativeEndian.PutUint64(b[8:], numFuncs) // numFuncs
 	// nfiles at offset 16 = 0 (unused by bound check)
 	// all five uintptr offsets point to hdrSize so no "corrupt" error fires
 	for _, off := range []int{24, 32, 40, 48, 56} {

--- a/comp/host-profiler/symboluploader/pclntab/pclntab_internal_test.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab_internal_test.go
@@ -9,8 +9,10 @@ package pclntab
 
 import (
 	"encoding/binary"
+	"strings"
 	"testing"
 )
+
 
 // moduleDataOf builds a fake moduledata from a list of pointer-sized words.
 func moduleDataOf(words ...uint64) []byte {
@@ -66,5 +68,33 @@ func TestFindGoFuncInModuleData(t *testing.T) {
 				t.Fatalf("gofunc = %#x, want %#x", got, tt.want)
 			}
 		})
+	}
+}
+
+// syntheticPclntab116 builds a minimal Go 1.16 pclntab blob whose header is valid enough for parseGoPCLnTab to accept,
+// but with the given numFuncs. All section offsets point to the end of the header so functab is empty.
+func syntheticPclntab116(numFuncs uint64) []byte {
+	const hdrSize = 64 // unsafe.Sizeof(pclntabHeader116{})
+	b := make([]byte, hdrSize)
+	binary.NativeEndian.PutUint32(b[0:], magicGo1_16)
+	// pad (2 bytes) = 0, quantum (1 byte) = 0
+	b[7] = ptrSize                                    // ptrSize field
+	binary.NativeEndian.PutUint64(b[8:], numFuncs)   // numFuncs
+	// nfiles at offset 16 = 0 (unused by bound check)
+	// all five uintptr offsets point to hdrSize so no "corrupt" error fires
+	for _, off := range []int{24, 32, 40, 48, 56} {
+		binary.NativeEndian.PutUint64(b[off:], hdrSize)
+	}
+	return b
+}
+
+// TestMalformedNumFuncsNoDoS guards the CPU-DoS bound: parseGoPCLnTab must reject an inflated numFuncs immediately
+// (validated against the functab size) rather than spinning O(numFuncs) iterations (otel-ebpf-profiler#1602 class).
+func TestMalformedNumFuncsNoDoS(t *testing.T) {
+	const bigNumFuncs = uint64(1) << 62
+	blob := syntheticPclntab116(bigNumFuncs)
+	_, err := parseGoPCLnTab(blob)
+	if err == nil || !strings.Contains(err.Error(), "exceeds functab capacity") {
+		t.Fatalf("expected numFuncs bound error, got: %v", err)
 	}
 }

--- a/comp/host-profiler/symboluploader/pclntab/pclntab_internal_test.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab_internal_test.go
@@ -98,3 +98,29 @@ func TestMalformedNumFuncsNoDoS(t *testing.T) {
 		t.Fatalf("expected numFuncs bound error, got: %v", err)
 	}
 }
+
+// TestMalformedNumFuncsMissingSentinel guards the sentinel-entry check: a functab with exactly
+// 2*numFuncs*fieldSize bytes (pairs only, no trailing sentinel pc) must be rejected. The old bound
+// `numFuncs > len(functab)/(2*fieldSize)` accepted such blobs; the correct check requires
+// (2*numFuncs+1) fields.
+func TestMalformedNumFuncsMissingSentinel(t *testing.T) {
+	const hdrSize = 64 // unsafe.Sizeof(pclntabHeader116{})
+	const fieldSize = ptrSize
+	const numFuncs = uint64(4)
+
+	// Build a functab with exactly 2*numFuncs fields (pairs only, sentinel missing).
+	functabSize := int(2 * numFuncs * fieldSize)
+	b := make([]byte, hdrSize+functabSize)
+	binary.NativeEndian.PutUint32(b[0:], magicGo1_16)
+	b[7] = ptrSize
+	binary.NativeEndian.PutUint64(b[8:], numFuncs)
+	// pclnOffset (offset 56) points to hdrSize, so functab starts right after the header.
+	for _, off := range []int{24, 32, 40, 48, 56} {
+		binary.NativeEndian.PutUint64(b[off:], hdrSize)
+	}
+
+	_, err := parseGoPCLnTab(b)
+	if err == nil || !strings.Contains(err.Error(), "exceeds functab capacity") {
+		t.Fatalf("expected sentinel bound error, got: %v", err)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Validates the header `numFuncs` against the number of elements found in `functab`

### Motivation
if we try to find gopclntab over a binary without the .gopclntab section, we're looping over a trusted numFuncs without ever making sure its value is correctly bounded.
Unlike https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/1602 we weren't panicking as we're gating every operation behind a `recover()`, but it was possible to make our code hang indefinitely using `MaxInt64` for example.

### Describe how you validated your changes

### Additional Notes
