### PR TITLE
fix(tasks): retry compare_to_itself properly on branch-not-mirrored-yet

### DIFF
--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 
 import yaml
 from gitlab import GitlabError
+from gitlab.exceptions import GitlabGetError
 from gitlab.v4.objects import Project
 from invoke import task
 from invoke.exceptions import Exit
@@ -717,8 +718,12 @@ def compare_to_itself(ctx):
         for attempt in range(max_attempts):
             print(f"[{datetime.now()}] Waiting 10s for the branch to be created {attempt + 1}/{max_attempts}")
             time.sleep(10)
-            if agent.branches.get(new_branch, raise_exception=False):
-                break
+            try:
+                if agent.branches.get(new_branch):
+                    break
+            except GitlabGetError:
+                # Branch not mirrored to GitLab yet, keep waiting.
+                continue
         else:
             print(f"{color_message('ERROR', Color.RED)}: Branch {new_branch} not created", file=sys.stderr)
             raise RuntimeError(f"No branch found for {new_branch}")

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -721,7 +721,9 @@ def compare_to_itself(ctx):
             try:
                 if agent.branches.get(new_branch):
                     break
-            except GitlabGetError:
+            except GitlabGetError as e:
+                if e.response_code != 404:
+                    raise
                 # Branch not mirrored to GitLab yet, keep waiting.
                 continue
         else:

--- a/tasks/unit_tests/pipeline_tests.py
+++ b/tasks/unit_tests/pipeline_tests.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+from gitlab.exceptions import GitlabGetError
 from invoke import Exit, MockContext, Result
 
 from tasks import pipeline
@@ -55,6 +56,36 @@ class TestCompareToItself(unittest.TestCase):
         agent.commits = self.commits
         repo_mock.return_value = agent
         pipeline.compare_to_itself(self.context)
+        self.assertEqual(1, agent.pipelines.list.call_count)
+
+    @patch('tasks.pipeline.gitlab_configuration_is_modified', new=MagicMock(return_value=True))
+    @patch('builtins.open', new=MagicMock())
+    @patch.dict('os.environ', {"CI_COMMIT_REF_NAME": "Football"})
+    @patch('tasks.pipeline.time', new=MagicMock())
+    @patch('tasks.libs.releasing.json.load_release_json')
+    @patch('tasks.pipeline.datetime')
+    @patch('tasks.pipeline.GithubAPI')
+    @patch('tasks.pipeline.get_gitlab_repo')
+    def test_branch_not_mirrored_yet(self, repo_mock, gh_mock, dt_mock, release_mock):
+        dt_mock.now.return_value = self.now
+        gh_mock.return_value = self.gh
+        release_mock.return_value = {"base_branch": "main"}
+        created_pipeline = MagicMock()
+        created_pipeline.jobs.list.return_value = [1, 2, 3]
+        agent = MagicMock()
+        agent.pipelines.create.return_value = created_pipeline
+        agent.commits = self.commits
+        # The branch hasn't mirrored to GitLab yet on the first two checks (404),
+        # then shows up on the third — the loop must keep retrying instead of
+        # crashing on the first GitlabGetError.
+        agent.branches.get.side_effect = [
+            GitlabGetError(response_code=404),
+            GitlabGetError(response_code=404),
+            MagicMock(),
+        ]
+        repo_mock.return_value = agent
+        pipeline.compare_to_itself(self.context)
+        self.assertEqual(3, agent.branches.get.call_count)
         self.assertEqual(1, agent.pipelines.list.call_count)
 
     @patch('tasks.pipeline.gitlab_configuration_is_modified', new=MagicMock(return_value=True))

--- a/tasks/unit_tests/pipeline_tests.py
+++ b/tasks/unit_tests/pipeline_tests.py
@@ -96,6 +96,28 @@ class TestCompareToItself(unittest.TestCase):
     @patch('tasks.pipeline.datetime')
     @patch('tasks.pipeline.GithubAPI')
     @patch('tasks.pipeline.get_gitlab_repo')
+    def test_branch_get_non_404_error_propagates(self, repo_mock, gh_mock, dt_mock, release_mock):
+        dt_mock.now.return_value = self.now
+        gh_mock.return_value = self.gh
+        release_mock.return_value = {"base_branch": "main"}
+        agent = MagicMock()
+        agent.commits = self.commits
+        # A non-404 error (e.g. bad credentials) must fail fast instead of
+        # being mistaken for mirror latency and retried for ~3 minutes.
+        agent.branches.get.side_effect = GitlabGetError(response_code=401)
+        repo_mock.return_value = agent
+        with self.assertRaises(GitlabGetError):
+            pipeline.compare_to_itself(self.context)
+        self.assertEqual(1, agent.branches.get.call_count)
+
+    @patch('tasks.pipeline.gitlab_configuration_is_modified', new=MagicMock(return_value=True))
+    @patch('builtins.open', new=MagicMock())
+    @patch.dict('os.environ', {"CI_COMMIT_REF_NAME": "Football"})
+    @patch('tasks.pipeline.time', new=MagicMock())
+    @patch('tasks.libs.releasing.json.load_release_json')
+    @patch('tasks.pipeline.datetime')
+    @patch('tasks.pipeline.GithubAPI')
+    @patch('tasks.pipeline.get_gitlab_repo')
     def test_no_branch_found(self, repo_mock, gh_mock, dt_mock, release_mock):
         dt_mock.now.return_value = self.now
         gh_mock.return_value = self.gh

--- a/tasks/unit_tests/pipeline_tests.py
+++ b/tasks/unit_tests/pipeline_tests.py
@@ -96,6 +96,30 @@ class TestCompareToItself(unittest.TestCase):
     @patch('tasks.pipeline.datetime')
     @patch('tasks.pipeline.GithubAPI')
     @patch('tasks.pipeline.get_gitlab_repo')
+    def test_branch_never_mirrors(self, repo_mock, gh_mock, dt_mock, release_mock):
+        dt_mock.now.return_value = self.now
+        gh_mock.return_value = self.gh
+        release_mock.return_value = {"base_branch": "main"}
+        agent = MagicMock()
+        agent.commits = self.commits
+        # The branch 404s on every single attempt (e.g. the mirror is stuck) — the
+        # retry loop must exhaust all attempts and raise a clear RuntimeError
+        # instead of hanging forever or propagating the last GitlabGetError.
+        agent.branches.get.side_effect = GitlabGetError(response_code=404)
+        repo_mock.return_value = agent
+        with self.assertRaises(RuntimeError):
+            pipeline.compare_to_itself(self.context)
+        self.assertEqual(18, agent.branches.get.call_count)
+        agent.pipelines.create.assert_not_called()
+
+    @patch('tasks.pipeline.gitlab_configuration_is_modified', new=MagicMock(return_value=True))
+    @patch('builtins.open', new=MagicMock())
+    @patch.dict('os.environ', {"CI_COMMIT_REF_NAME": "Football"})
+    @patch('tasks.pipeline.time', new=MagicMock())
+    @patch('tasks.libs.releasing.json.load_release_json')
+    @patch('tasks.pipeline.datetime')
+    @patch('tasks.pipeline.GithubAPI')
+    @patch('tasks.pipeline.get_gitlab_repo')
     def test_branch_get_non_404_error_propagates(self, repo_mock, gh_mock, dt_mock, release_mock):
         dt_mock.now.return_value = self.now
         gh_mock.return_value = self.gh


### PR DESCRIPTION
### What does this PR do?

Fixes `tasks/pipeline.py::compare_to_itself`'s wait loop, which is supposed to retry up to 18 times (~3 minutes) while a throwaway branch mirrors from GitHub to GitLab, but was actually crashing on the very first check:

```python
if agent.branches.get(new_branch, raise_exception=False):
```

`python-gitlab==4.4.0`'s `ProjectBranchManager.get()` (and the base `GetMixin.get()`) has no `raise_exception` parameter at all — it's decorated with `@exc.on_http_error(exc.GitlabGetError)` and always raises on a 404. The kwarg was silently forwarded as a useless HTTP query param instead of suppressing the exception, so the loop died on attempt 1/18 instead of giving the mirror sync a fair chance to catch up.

Now the `.get()` call is wrapped in a `try/except GitlabGetError`, retrying only on a 404 (branch not mirrored yet) and re-raising any other error (e.g. bad credentials) immediately instead of masking it as a 3-minute timeout.

### Motivation

This is `test_gitlab_compare_to`, which runs on any PR touching `.gitlab/**.yml` files. It was failing intermittently (in practice, close to always, since GitHub→GitLab mirror sync usually takes longer than the first 10s check) — found and worked around by retrying the job manually on #53565.

### Describe how you validated your changes

- Added `test_branch_not_mirrored_yet`, which reproduces the exact production traceback when reverted (confirmed by temporarily stashing the fix and re-running).
- Added `test_branch_get_non_404_error_propagates` for the non-404 case.
- `dda inv invoke-unit-tests.run --tests=pipeline`: all 7 tests pass.
- `dda inv linter.python`: clean.

### Additional Notes

Related: #53565 (where this bug was first hit and worked around with a manual job retry).