### PR TITLE
Stabilize SSI Kind fakeintake

### DIFF
--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -45,7 +45,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"regexp"
 	"strings"
@@ -131,6 +130,7 @@ type Client struct {
 	// Get retry parameters
 	getBackoffRetries uint
 	getBackoffDelay   time.Duration
+	getHTTPClient     *http.Client
 
 	metricAggregator               aggregator.MetricAggregator
 	metricAggregatorV3             aggregator.MetricAggregator
@@ -168,6 +168,7 @@ func NewClient(fakeIntakeURL string, opts ...Option) *Client {
 		fakeintakeIDMutex:              sync.RWMutex{},
 		getBackoffRetries:              4,
 		getBackoffDelay:                5 * time.Second,
+		getHTTPClient:                  http.DefaultClient,
 		fakeIntakeURL:                  strings.TrimSuffix(fakeIntakeURL, "/"),
 		metricAggregator:               aggregator.NewMetricAggregator(),
 		metricAggregatorV3:             aggregator.NewMetricAggregatorV3(),
@@ -1106,7 +1107,7 @@ func (c *Client) GetOrchestratorManifests() ([]*aggregator.OrchestratorManifestP
 
 func (c *Client) get(route string) ([]byte, error) {
 	body, err := backoff.Retry(context.Background(), func() ([]byte, error) {
-		tmpResp, err := http.Get(fmt.Sprintf("%s/%s", c.fakeIntakeURL, route))
+		tmpResp, err := c.getHTTPClient.Get(fmt.Sprintf("%s/%s", c.fakeIntakeURL, route))
 		if err != nil {
 			return nil, err
 		}
@@ -1140,9 +1141,6 @@ func (c *Client) get(route string) ([]byte, error) {
 
 		return io.ReadAll(tmpResp.Body)
 	}, backoff.WithBackOff(backoff.NewConstantBackOff(c.getBackoffDelay)), backoff.WithMaxTries(c.getBackoffRetries))
-	if err, ok := err.(net.Error); ok && err.Timeout() {
-		panic(fmt.Sprintf("fakeintake call timed out: %v", err))
-	}
 	return body, err
 }
 

--- a/test/fakeintake/client/client_test.go
+++ b/test/fakeintake/client/client_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -79,6 +80,20 @@ func NewServer(handler http.Handler) *httptest.Server {
 
 	return httptest.NewServer(handlerWitHeader)
 }
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+var _ net.Error = timeoutError{}
 
 func newAgentDiscoveryPayloadData(t *testing.T, payloads ...*agentdiscovery.AgentDiscoveryPayload) []byte {
 	t.Helper()
@@ -781,6 +796,19 @@ func TestClient(t *testing.T) {
 		require.NoError(t, err)
 		_, err = client.get("fakeintake/health")
 		require.NoError(t, err)
+	})
+
+	t.Run("test get returns timeout errors", func(t *testing.T) {
+		client := NewClient("http://fakeintake", WithGetBackoffRetries(1), WithGetBackoffDelay(10*time.Millisecond))
+		client.getHTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, timeoutError{}
+		})}
+
+		_, err := client.get("fakeintake/toto")
+		require.Error(t, err)
+		var netErr net.Error
+		require.ErrorAs(t, err, &netErr)
+		require.True(t, netErr.Timeout())
 	})
 
 	t.Run("getAgentHealth", func(t *testing.T) {

--- a/test/new-e2e/tests/ssi/provisioner.go
+++ b/test/new-e2e/tests/ssi/provisioner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
 	kubeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
 	scenarioeks "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/eks"
+	scenariofakeintake "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
 	scenariogke "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/gcp/gke"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
@@ -135,7 +136,9 @@ func kindLocalProvisioner(opts ProvisionerOptions) provisioners.TypedProvisioner
 
 // kindProvisioner returns an AWS Kind VM provisioner
 func kindProvisioner(opts ProvisionerOptions) provisioners.TypedProvisioner[environments.Kubernetes] {
-	var runOpts []kindvm.RunOption
+	runOpts := []kindvm.RunOption{
+		kindvm.WithFakeintakeOptions(scenariofakeintake.WithLoadBalancer()),
+	}
 	if len(opts.AgentOptions) > 0 {
 		runOpts = append(runOpts, kindvm.WithAgentOptions(opts.AgentOptions...))
 	}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"12b446d4-f5dc-4c74-8579-173fa07f0b36","source":"chat","resourceId":"097b38ce-1381-4bcf-9684-f9545737b98b","workflowId":"5e37387f-2076-4b93-85a8-6f9ac1b3d17d","codeChangeId":"5e37387f-2076-4b93-85a8-6f9ac1b3d17d","sourceType":"bits_ai_sre"} -->
### What does this PR do?

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/67eff007-c4f5-422d-abeb-3486a1bb9f6b)

Routes the SSI AWS Kind fakeintake through the existing fakeintake load balancer path and makes fakeintake client GET timeouts return errors instead of panicking.

### Motivation

The `new-e2e-ssi-kind` job can run multiple sequential `UpdateEnv` phases over 15+ minutes. When the AWS Kind fakeintake is reached through the no-LB Fargate path, the client stores a raw task private IP that can become stale if ECS replaces the task. The fakeintake client then panicked on timeout errors, making transient fakeintake connectivity fatal instead of retryable by the existing test polling flow.

### Changes

- Enable `fakeintake.WithLoadBalancer()` for the SSI AWS Kind provisioner so CI uses a stable fakeintake endpoint instead of a raw Fargate task IP when the account has the configured listener.
- Route fakeintake client payload GETs through the client-owned HTTP client and return timeout errors after backoff instead of panicking.
- Add a client unit test covering timeout error propagation.

### Describe how you validated your changes

- `GOENV_VERSION=1.26.3 gofmt -w test/fakeintake/client/client.go test/fakeintake/client/client_test.go test/new-e2e/tests/ssi/provisioner.go`
- `GOENV_VERSION=1.26.3 go test ./test/fakeintake/client`
- `git diff --check`

### Additional Notes

- `dda inv test --targets=./test/fakeintake/client` could not be run because `dda` is not installed in the sandbox.
- `bazel test //test/fakeintake/client:client_test` could not be run because the sandbox could not download Bazel from releases.bazel.build.
- `GOENV_VERSION=1.26.3 go test ./test/new-e2e/tests/ssi -run TestNonExistent` and the same command with `-tags test -count=0` both exceeded the 10 minute sandbox command limit while compiling/downloading dependencies.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/097b38ce-1381-4bcf-9684-f9545737b98b)

Comment @datadog to request changes