### PR TITLE
[ACTP] Use HPKE instead of NaCl box for per-task secret inputs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -645,7 +645,7 @@
 /pkg/procmgr/rust/src/platform/windows.rs          @DataDog/agent-runtimes @DataDog/windows-products
 /pkg/procmgr/rust/src/transport/named_pipe.rs       @DataDog/agent-runtimes @DataDog/windows-products
 /pkg/privateactionrunner/               @DataDog/action-platform
-/pkg/privateactionrunner/bundles/remoteaction  @DataDog/action-platform @DataDog/dd-agent-mcp
+/pkg/privateactionrunner/bundles/remoteaction/rshell  @DataDog/action-platform @DataDog/dd-agent-mcp
 /pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement  @DataDog/action-platform @DataDog/ndm-integrations
 /pkg/privateactionrunner/bundles/remoteaction/networks  @DataDog/action-platform @Datadog/network-path
 /pkg/proto/                             @DataDog/agent-runtimes

--- a/pkg/privateactionrunner/bundles/remoteaction/internalactions/BUILD.bazel
+++ b/pkg/privateactionrunner/bundles/remoteaction/internalactions/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/privateactionrunner/libs/encryptioncontext",
         "//pkg/privateactionrunner/libs/privateconnection",
         "//pkg/privateactionrunner/types",
-        "@org_golang_x_crypto//nacl/box",
     ],
 )
 
@@ -25,6 +24,5 @@ go_test(
         "//pkg/privateactionrunner/libs/encryptioncontext",
         "//pkg/privateactionrunner/types",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_crypto//nacl/box",
     ],
 )

--- a/pkg/privateactionrunner/bundles/remoteaction/internalactions/prepare_encryption.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/internalactions/prepare_encryption.go
@@ -7,19 +7,16 @@ package com_datadoghq_remoteaction_internal
 
 import (
 	"context"
-	"crypto/rand"
+	"crypto/ecdh"
+	"crypto/hpke"
 	"encoding/base64"
 	"errors"
 	"fmt"
-
-	"golang.org/x/crypto/nacl/box"
 
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/encryptioncontext"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 )
-
-const keyTypeCurve25519 = "curve25519"
 
 type PrepareEncryptionHandler struct {
 	store *encryptioncontext.Store
@@ -38,7 +35,7 @@ type PrepareEncryptionOutputs struct {
 	PublicKey string `json:"publicKey"`
 }
 
-// Run generates a Curve25519 key pair and returns the public key.
+// Run generates an HPKE DHKEM(P-256) key pair and returns the public key.
 func (handler *PrepareEncryptionHandler) Run(
 	_ context.Context,
 	task *types.Task,
@@ -52,15 +49,15 @@ func (handler *PrepareEncryptionHandler) Run(
 		return nil, errors.New("encryptionContextId is required")
 	}
 
-	publicKey, privateKey, err := box.GenerateKey(rand.Reader)
+	privateKey, err := hpke.DHKEM(ecdh.P256()).GenerateKey()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate Curve25519 key pair: %w", err)
+		return nil, fmt.Errorf("failed to generate HPKE key pair: %w", err)
 	}
 
 	handler.store.Set(inputs.EncryptionContextID, privateKey)
 
 	return &PrepareEncryptionOutputs{
-		KeyType:   keyTypeCurve25519,
-		PublicKey: base64.StdEncoding.EncodeToString(publicKey[:]),
+		KeyType:   encryptioncontext.KeyTypeHPKE,
+		PublicKey: base64.StdEncoding.EncodeToString(privateKey.PublicKey().Bytes()),
 	}, nil
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/internalactions/prepare_encryption_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/internalactions/prepare_encryption_test.go
@@ -7,11 +7,12 @@ package com_datadoghq_remoteaction_internal
 
 import (
 	"context"
+	"crypto/ecdh"
+	"crypto/hpke"
 	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/nacl/box"
 
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/encryptioncontext"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
@@ -28,24 +29,24 @@ func newTask(taskID string, inputs map[string]any) *types.Task {
 	return task
 }
 
-func assertSealRoundTrip(t *testing.T, store *encryptioncontext.Store, encryptionContextID string, result *PrepareEncryptionOutputs) {
+func assertHPKESealRoundTrip(t *testing.T, store *encryptioncontext.Store, encryptionContextID string, result *PrepareEncryptionOutputs) {
 	t.Helper()
 
-	publicKey, err := base64.StdEncoding.DecodeString(result.PublicKey)
+	publicKeyBytes, err := base64.StdEncoding.DecodeString(result.PublicKey)
 	require.NoError(t, err)
-	require.Len(t, publicKey, 32, "Curve25519 public key must be 32 bytes")
 
 	privateKey, found := store.GetAndDelete(encryptionContextID)
 	require.True(t, found)
 	require.NotNil(t, privateKey)
 
-	var publicKeyArray [32]byte
-	copy(publicKeyArray[:], publicKey)
-	plaintext := []byte("hello")
-	sealed, err := box.SealAnonymous(nil, plaintext, &publicKeyArray, nil)
+	publicKey, err := hpke.DHKEM(ecdh.P256()).NewPublicKey(publicKeyBytes)
 	require.NoError(t, err)
-	opened, ok := box.OpenAnonymous(nil, sealed, &publicKeyArray, privateKey)
-	require.True(t, ok)
+
+	plaintext := []byte("hello")
+	sealed, err := hpke.Seal(publicKey, hpke.HKDFSHA256(), hpke.AES256GCM(), nil, plaintext)
+	require.NoError(t, err)
+	opened, err := hpke.Open(privateKey, hpke.HKDFSHA256(), hpke.AES256GCM(), nil, sealed)
+	require.NoError(t, err)
 	require.Equal(t, plaintext, opened)
 }
 
@@ -85,8 +86,8 @@ func TestPrepareEncryptionRun(t *testing.T) {
 
 			result, ok := output.(*PrepareEncryptionOutputs)
 			require.True(t, ok, "unexpected output type %T", output)
-			require.Equal(t, "curve25519", result.KeyType)
-			assertSealRoundTrip(t, store, testCase.inputs["encryptionContextId"].(string), result)
+			require.Equal(t, encryptioncontext.KeyTypeHPKE, result.KeyType)
+			assertHPKESealRoundTrip(t, store, testCase.inputs["encryptionContextId"].(string), result)
 		})
 	}
 }

--- a/pkg/privateactionrunner/libs/encryptioncontext/BUILD.bazel
+++ b/pkg/privateactionrunner/libs/encryptioncontext/BUILD.bazel
@@ -10,8 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_jellydator_ttlcache_v3//:ttlcache",
-        "@org_golang_x_crypto//curve25519",
-        "@org_golang_x_crypto//nacl/box",
     ],
 )
 
@@ -25,6 +23,5 @@ go_test(
     gotags = ["test"],
     deps = [
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_crypto//nacl/box",
     ],
 )

--- a/pkg/privateactionrunner/libs/encryptioncontext/decrypt.go
+++ b/pkg/privateactionrunner/libs/encryptioncontext/decrypt.go
@@ -6,17 +6,18 @@
 package encryptioncontext
 
 import (
+	"crypto/hpke"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-
-	"golang.org/x/crypto/curve25519"
-	"golang.org/x/crypto/nacl/box"
 )
 
-// KeyTypeCurve25519 is the only supported EncryptionContext.KeyType.
-const KeyTypeCurve25519 = "curve25519"
+const KeyTypeHPKE = "hpke-p256-hkdf-sha256-aes256gcm"
+
+// hpkeInfo is the HPKE `info` used for domain separation. It must match the
+// value used by the sealing side (wf-actions-server) byte-for-byte.
+var hpkeInfo = []byte("dd-par-per-task-secret-input")
 
 // EncryptionContext identifies the key pair an input was sealed with.
 type EncryptionContext struct {
@@ -24,14 +25,14 @@ type EncryptionContext struct {
 	EncryptionContextID string `json:"encryptionContextId"`
 }
 
-// Decrypt opens the base64-encoded, NaCl-sealed encryptedInput using the
+// Decrypt opens the base64-encoded, HPKE-sealed encryptedInput using the
 // private key evicted from store for encryptionContext.
 func Decrypt(store *Store, encryptionContext EncryptionContext, encryptedInput string) (string, error) {
 	if encryptionContext.EncryptionContextID == "" {
 		return "", errors.New("encryptionContext.encryptionContextId is required")
 	}
-	if encryptionContext.KeyType != KeyTypeCurve25519 {
-		return "", fmt.Errorf("unsupported keyType %q (expected %q)", encryptionContext.KeyType, KeyTypeCurve25519)
+	if encryptionContext.KeyType != KeyTypeHPKE {
+		return "", fmt.Errorf("unsupported keyType %q (expected %q)", encryptionContext.KeyType, KeyTypeHPKE)
 	}
 	if encryptedInput == "" {
 		return "", errors.New("encryptedInput is required")
@@ -47,16 +48,9 @@ func Decrypt(store *Store, encryptionContext EncryptionContext, encryptedInput s
 		return "", fmt.Errorf("encryptedInput is not valid base64: %w", err)
 	}
 
-	publicKeyBytes, err := curve25519.X25519(privateKey[:], curve25519.Basepoint)
+	plaintext, err := hpke.Open(privateKey, hpke.HKDFSHA256(), hpke.AES256GCM(), hpkeInfo, ciphertext)
 	if err != nil {
-		return "", fmt.Errorf("failed to derive public key: %w", err)
-	}
-	var publicKey [32]byte
-	copy(publicKey[:], publicKeyBytes)
-
-	plaintext, ok := box.OpenAnonymous(nil, ciphertext, &publicKey, privateKey)
-	if !ok {
-		return "", errors.New("failed to open sealed input")
+		return "", fmt.Errorf("failed to open sealed input: %w", err)
 	}
 	return string(plaintext), nil
 }

--- a/pkg/privateactionrunner/libs/encryptioncontext/decrypt_test.go
+++ b/pkg/privateactionrunner/libs/encryptioncontext/decrypt_test.go
@@ -6,24 +6,24 @@
 package encryptioncontext
 
 import (
-	"crypto/rand"
+	"crypto/ecdh"
+	"crypto/hpke"
 	"encoding/base64"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/nacl/box"
 )
 
 // sealForContext seals plaintext for a fresh key pair stored under encryptionContextID.
 func sealForContext(t *testing.T, store *Store, encryptionContextID string, plaintext []byte) string {
 	t.Helper()
 
-	publicKey, privateKey, err := box.GenerateKey(rand.Reader)
+	privateKey, err := hpke.DHKEM(ecdh.P256()).GenerateKey()
 	require.NoError(t, err)
 	store.Set(encryptionContextID, privateKey)
 
-	sealed, err := box.SealAnonymous(nil, plaintext, publicKey, nil)
+	sealed, err := hpke.Seal(privateKey.PublicKey(), hpke.HKDFSHA256(), hpke.AES256GCM(), hpkeInfo, plaintext)
 	require.NoError(t, err)
 	return base64.StdEncoding.EncodeToString(sealed)
 }
@@ -38,12 +38,12 @@ func TestDecrypt(t *testing.T) {
 	}{
 		{
 			name:              "decrypts a sealed payload",
-			encryptionContext: EncryptionContext{KeyType: KeyTypeCurve25519, EncryptionContextID: "ctx-1"},
+			encryptionContext: EncryptionContext{KeyType: KeyTypeHPKE, EncryptionContextID: "ctx-1"},
 			plaintext:         "super-secret",
 		},
 		{
 			name:              "rejects missing encryptionContextId",
-			encryptionContext: EncryptionContext{KeyType: KeyTypeCurve25519},
+			encryptionContext: EncryptionContext{KeyType: KeyTypeHPKE},
 			plaintext:         "super-secret",
 			wantErrContains:   "encryptionContextId is required",
 		},
@@ -55,7 +55,7 @@ func TestDecrypt(t *testing.T) {
 		},
 		{
 			name:              "rejects unknown encryptionContextId",
-			encryptionContext: EncryptionContext{KeyType: KeyTypeCurve25519, EncryptionContextID: "ctx-unknown"},
+			encryptionContext: EncryptionContext{KeyType: KeyTypeHPKE, EncryptionContextID: "ctx-unknown"},
 			plaintext:         "super-secret",
 			skipSeal:          true,
 			wantErrContains:   "no private key found",
@@ -86,16 +86,18 @@ func TestDecrypt(t *testing.T) {
 
 	t.Run("rejects empty encryptedInput", func(t *testing.T) {
 		store := NewStoreWithTTL(time.Minute)
-		_, err := Decrypt(store, EncryptionContext{KeyType: KeyTypeCurve25519, EncryptionContextID: "ctx-1"}, "")
+		_, err := Decrypt(store, EncryptionContext{KeyType: KeyTypeHPKE, EncryptionContextID: "ctx-1"}, "")
 		require.ErrorContains(t, err, "encryptedInput is required")
 	})
 
 	t.Run("rejects non-base64 encryptedInput", func(t *testing.T) {
 		store := NewStoreWithTTL(time.Minute)
-		encryptionContext := EncryptionContext{KeyType: KeyTypeCurve25519, EncryptionContextID: "ctx-1"}
-		store.Set(encryptionContext.EncryptionContextID, &[32]byte{})
+		encryptionContext := EncryptionContext{KeyType: KeyTypeHPKE, EncryptionContextID: "ctx-1"}
+		privateKey, err := hpke.DHKEM(ecdh.P256()).GenerateKey()
+		require.NoError(t, err)
+		store.Set(encryptionContext.EncryptionContextID, privateKey)
 
-		_, err := Decrypt(store, encryptionContext, "not-base64!!!")
+		_, err = Decrypt(store, encryptionContext, "not-base64!!!")
 		require.ErrorContains(t, err, "not valid base64")
 	})
 }
@@ -127,7 +129,7 @@ func TestDecryptInto(t *testing.T) {
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
 			store := NewStoreWithTTL(time.Minute)
-			encryptionContext := EncryptionContext{KeyType: KeyTypeCurve25519, EncryptionContextID: "ctx-1"}
+			encryptionContext := EncryptionContext{KeyType: KeyTypeHPKE, EncryptionContextID: "ctx-1"}
 			encryptedInput := sealForContext(t, store, encryptionContext.EncryptionContextID, []byte(testCase.plaintext))
 
 			got, err := DecryptInto[decryptedCredentials](store, encryptionContext, encryptedInput)

--- a/pkg/privateactionrunner/libs/encryptioncontext/store.go
+++ b/pkg/privateactionrunner/libs/encryptioncontext/store.go
@@ -10,6 +10,7 @@
 package encryptioncontext
 
 import (
+	"crypto/hpke"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -22,7 +23,7 @@ const DefaultTTL = 5 * time.Minute
 // Store keeps private keys indexed by encryptionContextID, evicted after
 // their TTL elapses or once explicitly deleted.
 type Store struct {
-	cache *ttlcache.Cache[string, *[32]byte]
+	cache *ttlcache.Cache[string, hpke.PrivateKey]
 }
 
 // NewStore returns an in-memory Store using DefaultTTL.
@@ -34,18 +35,18 @@ func NewStore() *Store {
 // retrievable after being stored.
 func NewStoreWithTTL(ttl time.Duration) *Store {
 	return &Store{
-		cache: ttlcache.New(ttlcache.WithTTL[string, *[32]byte](ttl)),
+		cache: ttlcache.New(ttlcache.WithTTL[string, hpke.PrivateKey](ttl)),
 	}
 }
 
 // Set stores privateKey under encryptionContextID, overwriting any existing entry.
-func (store *Store) Set(encryptionContextID string, privateKey *[32]byte) {
+func (store *Store) Set(encryptionContextID string, privateKey hpke.PrivateKey) {
 	store.cache.Set(encryptionContextID, privateKey, ttlcache.DefaultTTL)
 }
 
 // GetAndDelete retrieves and evicts the entry for encryptionContextID.
 // Returns (nil, false) if no live entry exists.
-func (store *Store) GetAndDelete(encryptionContextID string) (*[32]byte, bool) {
+func (store *Store) GetAndDelete(encryptionContextID string) (hpke.PrivateKey, bool) {
 	item, found := store.cache.GetAndDelete(encryptionContextID)
 	if !found {
 		return nil, false

--- a/pkg/privateactionrunner/libs/encryptioncontext/store_test.go
+++ b/pkg/privateactionrunner/libs/encryptioncontext/store_test.go
@@ -6,6 +6,8 @@
 package encryptioncontext
 
 import (
+	"crypto/ecdh"
+	"crypto/hpke"
 	"sync"
 	"testing"
 	"time"
@@ -13,12 +15,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPrivateKey(seed byte) *[32]byte {
-	var key [32]byte
-	for index := range key {
-		key[index] = seed
-	}
-	return &key
+func newPrivateKey(t *testing.T) hpke.PrivateKey {
+	t.Helper()
+	privateKey, err := hpke.DHKEM(ecdh.P256()).GenerateKey()
+	require.NoError(t, err)
+	return privateKey
 }
 
 func TestStoreGetAndDelete(t *testing.T) {
@@ -45,7 +46,7 @@ func TestStoreGetAndDelete(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			store := NewStoreWithTTL(time.Minute)
 
-			privateKey := newPrivateKey(0x42)
+			privateKey := newPrivateKey(t)
 			store.Set(testCase.setContextID, privateKey)
 
 			retrieved, found := store.GetAndDelete(testCase.takeContextID)
@@ -64,24 +65,27 @@ func TestStoreGetAndDelete(t *testing.T) {
 
 func TestStoreSetOverwritesExistingContextID(t *testing.T) {
 	store := NewStoreWithTTL(time.Minute)
-	store.Set("ctx-1", newPrivateKey(0x01))
-	store.Set("ctx-1", newPrivateKey(0x02))
+	first := newPrivateKey(t)
+	second := newPrivateKey(t)
+	store.Set("ctx-1", first)
+	store.Set("ctx-1", second)
 
 	retrieved, found := store.GetAndDelete("ctx-1")
 	require.True(t, found)
-	require.Equal(t, newPrivateKey(0x02), retrieved)
+	require.Equal(t, second, retrieved)
 }
 
 func TestStoreConcurrentAccess(t *testing.T) {
 	store := NewStoreWithTTL(time.Minute)
 
 	const goroutineCount = 100
+	privateKey := newPrivateKey(t)
 	var waitGroup sync.WaitGroup
 	waitGroup.Add(goroutineCount)
 	for index := range goroutineCount {
 		go func(index int) {
 			defer waitGroup.Done()
-			store.Set(string(rune('a'+index%26)), newPrivateKey(byte(index)))
+			store.Set(string(rune('a'+index%26)), privateKey)
 		}(index)
 	}
 	waitGroup.Wait()


### PR DESCRIPTION
### What does this PR do?

Replaces the NaCl sealed-box (Curve25519) encryption used by the `prepareEncryption` PAR internal action with HPKE (RFC 9180), using the ciphersuite DHKEM(P-256, HKDF-SHA256) + HKDF-SHA256 + AES-256-GCM from the `crypto/hpke` standard library.

The wire format is unchanged: the sealed input is still a single base64 blob (the HPKE encapsulated key concatenated with the ciphertext), and the `encryptionContext` schema is untouched — only the crypto primitive and the `keyType` value change.

### Motivation

`nacl/box` is not FIPS-compliant (it uses Blake2 as its KDF, which is not FIPS-approved), which blocks per-task secret inputs in Gov/FIPS environments. HPKE with a P-256 DHKEM is a NIST/FIPS-approved, standardized construction and is switchable for future changes.

### Describe how you validated your changes

- `go test ./pkg/privateactionrunner/libs/encryptioncontext/... ./pkg/privateactionrunner/bundles/remoteaction/internalactions/...` — passes.
- Updated the seal/open round-trip tests (`prepare_encryption_test.go`, `decrypt_test.go`) to exercise the HPKE path end to end, including the single-use key eviction behavior.

I tested it by running an end-to-end flow locally to validate that the action works correctly.
