### PR TITLE
Reduce trace payload string allocations

### DIFF
--- a/pkg/proto/pbgo/trace/idx/internal_span.go
+++ b/pkg/proto/pbgo/trace/idx/internal_span.go
@@ -92,6 +92,17 @@ func (s *StringTable) Add(str string) uint32 {
 	return s.addUnchecked(str)
 }
 
+// AddBytes adds a UTF-8 byte slice to the string table. It avoids copying the
+// bytes when the string is already present, but copies new values because the
+// input buffer may be reused after decoding.
+func (s *StringTable) AddBytes(value []byte) uint32 {
+	transient := msgp.UnsafeString(value)
+	if idx, ok := s.lookup[transient]; ok {
+		return idx
+	}
+	return s.addUnchecked(string(value))
+}
+
 // Get returns the string at the given index - panics if out of bounds
 func (s *StringTable) Get(idx uint32) string {
 	return s.strings[idx]

--- a/pkg/proto/pbgo/trace/idx/span.go
+++ b/pkg/proto/pbgo/trace/idx/span.go
@@ -1742,11 +1742,30 @@ func (s *InternalSpan) handlePromotedMetaFields(metaKey, metaVal uint32, convert
 // parseStringBytes reads the next type in the msgpack payload and
 // converts the BinType or the StrType in a valid string returning the index of the string in the string table
 func parseStringBytesRef(stringTable *StringTable, bts []byte) (uint32, []byte, error) {
-	ref, bts, err := parseStringBytes(bts)
+	if msgp.IsNil(bts) {
+		bts, err := msgp.ReadNilBytes(bts)
+		return 0, bts, err
+	}
+
+	var (
+		value []byte
+		err   error
+	)
+	switch typ := msgp.NextType(bts); typ {
+	case msgp.BinType:
+		value, bts, err = msgp.ReadBytesZC(bts)
+	case msgp.StrType:
+		value, bts, err = msgp.ReadStringZC(bts)
+	default:
+		return 0, bts, msgp.TypeError{Encoded: typ, Method: msgp.StrType}
+	}
 	if err != nil {
 		return 0, bts, err
 	}
-	return stringTable.Add(ref), bts, nil
+	if utf8.Valid(value) {
+		return stringTable.AddBytes(value), bts, nil
+	}
+	return stringTable.Add(repairUTF8(msgp.UnsafeString(value))), bts, nil
 }
 
 // parseStringBytesRef reads the next type in the msgpack payload and

--- a/pkg/proto/pbgo/trace/idx/span.go
+++ b/pkg/proto/pbgo/trace/idx/span.go
@@ -1739,26 +1739,10 @@ func (s *InternalSpan) handlePromotedMetaFields(metaKey, metaVal uint32, convert
 	}
 }
 
-// parseStringBytes reads the next type in the msgpack payload and
-// converts the BinType or the StrType in a valid string returning the index of the string in the string table
+// parseStringBytesRef reads the next string or byte slice in the msgpack payload
+// and returns its index in the string table.
 func parseStringBytesRef(stringTable *StringTable, bts []byte) (uint32, []byte, error) {
-	if msgp.IsNil(bts) {
-		bts, err := msgp.ReadNilBytes(bts)
-		return 0, bts, err
-	}
-
-	var (
-		value []byte
-		err   error
-	)
-	switch typ := msgp.NextType(bts); typ {
-	case msgp.BinType:
-		value, bts, err = msgp.ReadBytesZC(bts)
-	case msgp.StrType:
-		value, bts, err = msgp.ReadStringZC(bts)
-	default:
-		return 0, bts, msgp.TypeError{Encoded: typ, Method: msgp.StrType}
-	}
+	value, bts, err := parseStringBytesZC(bts)
 	if err != nil {
 		return 0, bts, err
 	}
@@ -1768,35 +1752,34 @@ func parseStringBytesRef(stringTable *StringTable, bts []byte) (uint32, []byte, 
 	return stringTable.Add(repairUTF8(msgp.UnsafeString(value))), bts, nil
 }
 
-// parseStringBytesRef reads the next type in the msgpack payload and
-// converts the BinType or the StrType in a valid string returning the string itself
+// parseStringBytes reads the next string or byte slice in the msgpack payload
+// and returns it as valid UTF-8.
 func parseStringBytes(bts []byte) (string, []byte, error) {
-	if msgp.IsNil(bts) {
-		bts, err := msgp.ReadNilBytes(bts)
-		return "", bts, err
-	}
-	// read the generic representation type without decoding
-	t := msgp.NextType(bts)
-
-	var (
-		err error
-		i   []byte
-	)
-	switch t {
-	case msgp.BinType:
-		i, bts, err = msgp.ReadBytesZC(bts)
-	case msgp.StrType:
-		i, bts, err = msgp.ReadStringZC(bts)
-	default:
-		return "", bts, msgp.TypeError{Encoded: t, Method: msgp.StrType}
-	}
+	value, bts, err := parseStringBytesZC(bts)
 	if err != nil {
 		return "", bts, err
 	}
-	if utf8.Valid(i) {
-		return string(i), bts, nil
+	if utf8.Valid(value) {
+		return string(value), bts, nil
 	}
-	return repairUTF8(msgp.UnsafeString(i)), bts, nil
+	return repairUTF8(msgp.UnsafeString(value)), bts, nil
+}
+
+// parseStringBytesZC reads the next string or byte slice in the msgpack payload
+// without copying it. The returned value aliases the payload.
+func parseStringBytesZC(bts []byte) ([]byte, []byte, error) {
+	typ := msgp.NextType(bts)
+	switch typ {
+	case msgp.NilType:
+		bts, err := msgp.ReadNilBytes(bts)
+		return nil, bts, err
+	case msgp.BinType:
+		return msgp.ReadBytesZC(bts)
+	case msgp.StrType:
+		return msgp.ReadStringZC(bts)
+	default:
+		return nil, bts, msgp.TypeError{Encoded: typ, Method: msgp.StrType}
+	}
 }
 
 // repairUTF8 ensures all characters in s are UTF-8 by replacing non-UTF-8 characters

--- a/pkg/proto/pbgo/trace/idx/span_test.go
+++ b/pkg/proto/pbgo/trace/idx/span_test.go
@@ -10,7 +10,39 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tinylib/msgp/msgp"
 )
+
+var benchmarkStringRef uint32
+
+func BenchmarkParseRepeatedStringBytesRef(b *testing.B) {
+	const stringCount = 1000
+	values := []string{
+		"service", "resource", "env:staging", "http.method", "GET",
+		"span.kind", "server", "component", "net/http", "version:1.2.3",
+	}
+	payload := make([]byte, 0, stringCount*16)
+	for i := 0; i < stringCount; i++ {
+		payload = msgp.AppendString(payload, values[i%len(values)])
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		table := NewStringTableWithCapacity(len(values) + 1)
+		remaining := payload
+		var ref uint32
+		for len(remaining) > 0 {
+			var err error
+			ref, remaining, err = parseStringBytesRef(table, remaining)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		benchmarkStringRef = ref
+	}
+}
 
 // TestReconcileSamplingPriorityAfterChunkSpan_preservesChildWhenRootHasNoSamplingMetric documents a
 // regression: ReconcileSamplingPriorityAfterChunkSpan treats every parent_id==0 span as authoritative,


### PR DESCRIPTION
### What does this PR do?

Avoids allocating strings when repeated trace payload values are already present in the indexed string table.

### Motivation

Internal deployments have shown trace string decoding accounting for 10 to 17% of trace-agent allocation bytes in some staging clusters.

In ten microbenchmark samples decoding 1,000 strings from 10 repeated values, typical results improved from 68.3–71.6 µs/op, 11,880 B/op, and 1,005 allocs/op to 43.0–46.7 µs/op, 792 B/op, and 15 allocs/op.

### Describe how you validated your changes
CI

### Additional Notes

None.
