### PR TITLE
[DSEC-124] Support run once for shared library checks

### DIFF
--- a/pkg/collector/sharedlibrary/sharedlibraryimpl/BUILD.bazel
+++ b/pkg/collector/sharedlibrary/sharedlibraryimpl/BUILD.bazel
@@ -53,6 +53,7 @@ dd_agent_go_test(
         "//pkg/aggregator",
         "//pkg/aggregator/mocksender",
         "//pkg/aggregator/sender",
+        "//pkg/collector/check/defaults",
         "//pkg/collector/sharedlibrary/ffi",
         "//pkg/util/option",
         "@com_github_stretchr_testify//assert",

--- a/pkg/collector/sharedlibrary/sharedlibraryimpl/check.go
+++ b/pkg/collector/sharedlibrary/sharedlibraryimpl/check.go
@@ -153,8 +153,16 @@ func (c *Check) Configure(_ sender.SenderManager, integrationConfigDigest uint64
 		return err
 	}
 
-	// See if a collection interval was specified
-	if commonOptions.MinCollectionInterval > 0 {
+	// See if a collection interval was specified. An explicit
+	// min_collection_interval: 0 schedules a one-shot check (interval 0).
+	if commonOptions.MinCollectionInterval == 0 {
+		var rawInst integration.RawMap
+		if err := yaml.Unmarshal(instanceConfig, &rawInst); err == nil {
+			if _, ok := rawInst["min_collection_interval"]; ok {
+				c.interval = 0
+			}
+		}
+	} else if commonOptions.MinCollectionInterval > 0 {
 		c.interval = time.Duration(commonOptions.MinCollectionInterval) * time.Second
 	}
 

--- a/pkg/collector/sharedlibrary/sharedlibraryimpl/check_test.go
+++ b/pkg/collector/sharedlibrary/sharedlibraryimpl/check_test.go
@@ -10,12 +10,15 @@ package sharedlibrarycheck
 import (
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 	"github.com/DataDog/datadog-agent/pkg/collector/sharedlibrary/ffi"
 )
 
@@ -47,6 +50,29 @@ func TestCancelCheck(t *testing.T) {
 
 	err = check.runCheckImpl(false)
 	assert.Error(t, err, "check %s is already cancelled", check.name)
+}
+
+func TestConfigureCollectionInterval(t *testing.T) {
+	tests := []struct {
+		name           string
+		instanceConfig string
+		expected       time.Duration
+	}{
+		{"explicit zero schedules a one-shot check", "min_collection_interval: 0", 0},
+		{"positive value is interpreted as seconds", "min_collection_interval: 15", 15 * time.Second},
+		{"unset keeps the default interval", "{}", defaults.DefaultCheckInterval},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			check, err := newFakeCheck(aggregator.NewNoOpSenderManager())
+			require.NoError(t, err)
+
+			err = check.Configure(check.senderManager, 0, integration.Data(tc.instanceConfig), nil, "test", "test")
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, check.Interval())
+		})
+	}
 }
 
 func newFakeCheck(senderManager sender.SenderManager) (*Check, error) {

--- a/releasenotes/notes/shared-library-check-one-shot-scheduling-0bf76d317bf5417b.yaml
+++ b/releasenotes/notes/shared-library-check-one-shot-scheduling-0bf76d317bf5417b.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Shared-library checks now honor an explicit ``min_collection_interval: 0`` as
+    one-shot scheduling (the check runs a single time), matching the behavior of
+    Python checks.


### PR DESCRIPTION
### What does this PR do?

Honors an explicit `min_collection_interval: 0` for shared-library (e.g. Rust) checks as one-shot scheduling: the check runs a single time instead of on a recurring interval. This mirrors the one-shot behavior [Python checks already support](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/python/check.go#L294-L300) (there via `run_once`, which sets the interval to `0`). Unset or positive values keep their usual meaning (default interval / seconds).

### Motivation

We want to trigger data security scanning a single time, on demand through Remote Config, following the [data streams run-once pattern](https://github.com/DataDog/datadog-agent/blob/main/comp/core/autodiscovery/providers/datastreams/kafka_actions.go#L188-L191) that pushes a `run_once` check instance via RC.

### Describe how you validated your changes

Added a [table-driven unit test](https://github.com/DataDog/datadog-agent/pull/53589/changes/89f2d19efafc2ec24a086fd04aa416acca24b8b3) that asserts `Interval()` after `Configure`:

- `min_collection_interval: 0` → `0` (one-shot)
- `min_collection_interval: 15` → `15s`
- unset → default interval

Run with (note the two build tags):

```bash
go test -tags "sharedlibrarycheck test" -run TestConfigureCollectionInterval ./pkg/collector/sharedlibrary/sharedlibraryimpl/ -v
```

### Additional Notes

The one-shot behavior is enforced by the collector scheduler: in [`Scheduler.Enter`](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/scheduler/scheduler.go#L84-L91), when `Interval() == 0` the check is routed to a one-time execution path (`enqueueOnce`) instead of a recurring job queue. In other words, if the interval is `0` the check is scheduled only once.
