### PR TITLE
chore(bazel): add --test_env=__COMPAT_LAYER=RunAsInvoker for Windows bazel test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -81,6 +81,7 @@ common:windows --repo_env=SYSTEMROOT # used by COM to load system DLLs, needed b
 common:windows --repo_env=USERPROFILE # used by MSYS2 bash to emulate HOME, needed by git to fetch repositories
 common:windows --repo_env=VSTUDIO_ROOT # visual_studio(path_variable) in MODULE.bazel
 common:windows --run_env=__COMPAT_LAYER=RunAsInvoker # install*.exe may otherwise fail claiming unneeded admin elevation
+common:windows --test_env=__COMPAT_LAYER=RunAsInvoker # same, for bazel test
 common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
 
 # Force the x86_64-pc-windows-gnu Rust toolchain (compact name for rust_windows_gnu_x86_64)


### PR DESCRIPTION
### What does this PR do?

Adds `--test_env=__COMPAT_LAYER=RunAsInvoker` to the Windows Bazel config in `.bazelrc`.

### Motivation

`--run_env=__COMPAT_LAYER=RunAsInvoker` was already set to prevent elevation prompts during `bazel run`. The same env var is needed for `bazel test` — without it, test binaries that invoke installer executables (e.g. `install*.exe`) trigger an unneeded UAC/elevation prompt on Windows.

### Describe how you validated your changes

`bazel test //pkg/fleet/installer/setup:setup_test` passes without elevation prompt.