### PR TITLE
Finish migrating `cenkalti/backoff` from v5 to v6

### DIFF
--- a/comp/core/configstreamconsumer/impl/BUILD.bazel
+++ b/comp/core/configstreamconsumer/impl/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
         "//pkg/util/defaultpaths",
         "//pkg/util/flavor",
         "//pkg/util/log",
-        "@com_github_cenkalti_backoff_v5//:backoff",
+        "@com_github_cenkalti_backoff_v6//:backoff",
         "@in_yaml_go_yaml_v3//:yaml",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//metadata",

--- a/comp/core/configstreamconsumer/impl/consumer.go
+++ b/comp/core/configstreamconsumer/impl/consumer.go
@@ -23,7 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cenkalti/backoff/v5"
+	"github.com/cenkalti/backoff/v6"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -146,7 +146,6 @@ use_repo(
     "com_github_bhmj_jsonslice",
     "com_github_blabber_go_freebsd_sysctl",
     "com_github_bmatcuk_doublestar_v4",
-    "com_github_cenkalti_backoff_v5",
     "com_github_cenkalti_backoff_v6",
     "com_github_cespare_xxhash_v2",
     "com_github_charlievieth_strcase",

--- a/go.mod
+++ b/go.mod
@@ -242,7 +242,6 @@ require (
 	github.com/bhmj/jsonslice v1.1.3
 	github.com/blabber/go-freebsd-sysctl v0.0.0-20201130114544-503969f39d8f
 	github.com/bmatcuk/doublestar/v4 v4.10.0
-	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cenkalti/backoff/v6 v6.0.1
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cilium/ebpf v0.21.0
@@ -632,6 +631,7 @@ require (
 	github.com/cavaliergopher/grab/v3 v3.0.1 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/charlievieth/strcase v0.0.5 // indirect
 	github.com/chrusty/protoc-gen-jsonschema v0.0.0-20240212064413-73d5723042b8 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect


### PR DESCRIPTION
### What does this PR do?
Update the last stray `github.com/cenkalti/backoff/v5` import, in `comp/core/configstreamconsumer/impl/consumer.go`, to `github.com/cenkalti/backoff/v6`.

Regenerate `BUILD.bazel` via `dda inv tidy`, which drops `go.mod`'s now-unused direct v5 requirement (still pulled in indirectly by `github.com/DataDog/datadog-traceroute`).

### Motivation
#52425 bumped `github.com/cenkalti/backoff/v5` to `v6` across 98 files, but missed this one: `consumer.go` already existed before that PR, yet its import was left untouched, so `go.mod` kept both majors as direct requirements.

`v6`'s `ExponentialBackOff` is byte-identical to `v5`'s for the fields and methods this file uses, so no other code changes were needed.

### Describe how you validated your changes
`bazel test //comp/core/configstreamconsumer/...`: 5/5 tests pass.