### PR TITLE
Add DD_AGENT_PIPELINE_ID option to Windows installer setup

### DIFF
--- a/pkg/fleet/installer/env/env.go
+++ b/pkg/fleet/installer/env/env.go
@@ -39,6 +39,7 @@ const (
 	envAgentMajorVersion     = "DD_AGENT_MAJOR_VERSION"
 	envAgentMinorVersion     = "DD_AGENT_MINOR_VERSION"
 	envAgentDistChannel      = "DD_AGENT_DIST_CHANNEL"
+	envAgentPipelineID       = "DD_AGENT_PIPELINE_ID"
 	envApmLanguages          = "DD_APM_INSTRUMENTATION_LANGUAGES"
 	envTags                  = "DD_TAGS"
 	envExtraTags             = "DD_EXTRA_TAGS"
@@ -212,6 +213,7 @@ type Env struct {
 	AgentMajorVersion string
 	AgentMinorVersion string
 	AgentDistChannel  string
+	AgentPipelineID   string
 
 	MsiParams MsiParamsEnv // windows only
 
@@ -313,6 +315,7 @@ func FromEnv() *Env {
 		AgentMajorVersion: os.Getenv(envAgentMajorVersion),
 		AgentMinorVersion: os.Getenv(envAgentMinorVersion),
 		AgentDistChannel:  os.Getenv(envAgentDistChannel),
+		AgentPipelineID:   os.Getenv(envAgentPipelineID),
 
 		MsiParams: MsiParamsEnv{
 			AgentUserName:            getEnvOrDefault(envAgentUserName, os.Getenv(envAgentUserNameCompat)),

--- a/pkg/fleet/installer/env/env_test.go
+++ b/pkg/fleet/installer/env/env_test.go
@@ -86,6 +86,7 @@ func TestFromEnv(t *testing.T) {
 				envAgentMajorVersion:                          "7",
 				envAgentMinorVersion:                          "79.0~rc.2",
 				envAgentDistChannel:                           "beta",
+				envAgentPipelineID:                            "118008542",
 			},
 			expected: &Env{
 				APIKey:                "123456",
@@ -144,6 +145,7 @@ func TestFromEnv(t *testing.T) {
 				AgentMajorVersion:   "7",
 				AgentMinorVersion:   "79.0~rc.2",
 				AgentDistChannel:    "beta",
+				AgentPipelineID:     "118008542",
 			},
 		},
 		{

--- a/pkg/fleet/installer/setup/setup.go
+++ b/pkg/fleet/installer/setup/setup.go
@@ -42,13 +42,13 @@ func Setup(ctx context.Context, env *env.Env, flavor string) error {
 	if !ok {
 		return fmt.Errorf("unknown flavor \"%s\"", flavor)
 	}
-	if err := applyAgentDistChannel(env); err != nil {
-		return err
-	}
 	// If the user has requested a specific Agent version and we are not
 	// ourselves the result of a prior handoff, fetch the matching
 	// installer.exe and re-exec from it.
 	if os.Getenv(envFromVersionHandoff) != "true" {
+		if err := applyAgentDistOptions(env); err != nil {
+			return err
+		}
 		tag, err := requestedAgentVersion(env)
 		if err != nil {
 			return err

--- a/pkg/fleet/installer/setup/setup_nonwindows.go
+++ b/pkg/fleet/installer/setup/setup_nonwindows.go
@@ -24,6 +24,6 @@ func runAgentInstaller(_ context.Context, _ *env.Env, _, _ string) error {
 	return nil
 }
 
-// applyAgentDistChannel is a no-op on non-Windows; DD_AGENT_DIST_CHANNEL
-// is handled upstream by the Linux/macOS install scripts.
-func applyAgentDistChannel(_ *env.Env) error { return nil }
+// applyAgentDistOptions is a no-op on non-Windows; distribution channel and
+// pipeline options are handled upstream by the Linux/macOS install scripts.
+func applyAgentDistOptions(_ *env.Env) error { return nil }

--- a/pkg/fleet/installer/setup/setup_windows.go
+++ b/pkg/fleet/installer/setup/setup_windows.go
@@ -49,6 +49,14 @@ const (
 // betaRegistry is the OCI registry that hosts beta / RC Agent builds.
 const betaRegistry = "install.datad0g.com"
 
+// pipelineRegistry is the OCI registry that hosts per-pipeline Agent builds.
+const pipelineRegistry = "installtesting.datad0g.com"
+
+// envInstallerDefaultVersionAgent is the env var the oci downloader and
+// env.FromEnv() both honor for per-package version overrides. We set this
+// for pipeline builds so the child re-exec inherits the pinned tag.
+const envInstallerDefaultVersionAgent = "DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT"
+
 // releaseSuffixRe matches a trailing `-N` release suffix (e.g. `-1`).
 var releaseSuffixRe = regexp.MustCompile(`-\d+$`)
 
@@ -113,6 +121,18 @@ func requestedAgentVersion(e *env.Env) (string, error) {
 	return v, nil
 }
 
+// applyAgentDistOptions resolves the options that select which Agent build to
+// install:
+//
+//   - DD_AGENT_PIPELINE_ID — a specific CI pipeline build (see applyAgentPipelineID)
+//   - DD_AGENT_DIST_CHANNEL — the release channel, stable or beta (see applyAgentDistChannel)
+func applyAgentDistOptions(e *env.Env) error {
+	if err := applyAgentPipelineID(e); err != nil {
+		return err
+	}
+	return applyAgentDistChannel(e)
+}
+
 // applyAgentDistChannel reads DD_AGENT_DIST_CHANNEL and overrides the
 // registry used for agent-package OCI fetches before running setup.
 //
@@ -151,6 +171,47 @@ func applyAgentDistChannel(e *env.Env) error {
 	}
 	e.RegistryOverrideByImage[agentPackageImage] = betaRegistry
 	return os.Setenv(envInstallerRegistryURLAgent, betaRegistry)
+}
+
+// applyAgentPipelineID reads DD_AGENT_PIPELINE_ID and overrides both the
+// registry and the version used for agent-package OCI fetches so setup
+// installs a specific CI pipeline build.
+//
+// Cases:
+//
+//   - DD_AGENT_PIPELINE_ID unset → no-op
+//   - DD_AGENT_DIST_CHANNEL, DD_AGENT_MAJOR_VERSION, or DD_AGENT_MINOR_VERSION
+//     is set → error (these high-level options are mutually exclusive with the
+//     pipeline build)
+//   - DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE or
+//     DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT is already set → that
+//     explicit override wins for its axis (no-op), matching applyAgentDistChannel
+//   - otherwise → registry flips to pipelineRegistry, version to pipeline-<id>
+func applyAgentPipelineID(e *env.Env) error {
+	id := e.AgentPipelineID
+	if id == "" {
+		return nil
+	}
+	if e.AgentDistChannel != "" {
+		return fmt.Errorf("DD_AGENT_PIPELINE_ID and DD_AGENT_DIST_CHANNEL=%s are mutually exclusive", e.AgentDistChannel)
+	}
+	if e.AgentMajorVersion != "" || e.AgentMinorVersion != "" {
+		return errors.New("DD_AGENT_PIPELINE_ID is mutually exclusive with DD_AGENT_MAJOR_VERSION and DD_AGENT_MINOR_VERSION")
+	}
+	tag := "pipeline-" + id
+	if _, set := e.RegistryOverrideByImage[agentPackageImage]; !set {
+		e.RegistryOverrideByImage[agentPackageImage] = pipelineRegistry
+		if err := os.Setenv(envInstallerRegistryURLAgent, pipelineRegistry); err != nil {
+			return err
+		}
+	}
+	if _, set := e.DefaultPackagesVersionOverride[agentPackage]; !set {
+		e.DefaultPackagesVersionOverride[agentPackage] = tag
+		if err := os.Setenv(envInstallerDefaultVersionAgent, tag); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // parseMinorPrefix returns the numeric minor at the start of s — e.g. "78"

--- a/pkg/fleet/installer/setup/setup_windows_test.go
+++ b/pkg/fleet/installer/setup/setup_windows_test.go
@@ -87,6 +87,67 @@ func TestRequestedAgentVersion(t *testing.T) {
 	}
 }
 
+func TestApplyAgentPipelineID(t *testing.T) {
+	cases := []struct {
+		name             string
+		pipelineID       string
+		channel          string
+		major            string
+		minor            string
+		existingRegistry string
+		existingVersion  string
+		wantRegistry     string
+		wantVersionTag   string
+		wantErr          bool
+	}{
+		{name: "unset is a no-op", pipelineID: ""},
+		{name: "sets registry and version tag", pipelineID: "118008542", wantRegistry: pipelineRegistry, wantVersionTag: "pipeline-118008542"},
+		{name: "conflict with beta channel", pipelineID: "118008542", channel: channelBeta, wantErr: true},
+		{name: "conflict with stable channel", pipelineID: "118008542", channel: channelStable, wantErr: true},
+		{name: "conflict with minor version", pipelineID: "118008542", minor: "79.0", wantErr: true},
+		{name: "conflict with major version", pipelineID: "118008542", major: "7", wantErr: true},
+		// An explicit low-level override wins for its axis; the pipeline
+		// default only fills in the axis the user did not set.
+		{name: "explicit registry override wins", pipelineID: "118008542", existingRegistry: "user.registry.example.com", wantRegistry: "user.registry.example.com", wantVersionTag: "pipeline-118008542"},
+		{name: "explicit version override wins", pipelineID: "118008542", existingVersion: "7.79.0-1", wantRegistry: pipelineRegistry, wantVersionTag: "7.79.0-1"},
+		// A child re-exec inherits the parent's overrides via FromEnv, so it
+		// sees the values already set and keeps them.
+		{name: "propagated overrides are kept", pipelineID: "118008542", existingRegistry: pipelineRegistry, existingVersion: "pipeline-118008542", wantRegistry: pipelineRegistry, wantVersionTag: "pipeline-118008542"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Model what FromEnv produces: an "existing" override is present
+			// in both the env var and the map.
+			t.Setenv(envInstallerRegistryURLAgent, c.existingRegistry)
+			t.Setenv(envInstallerDefaultVersionAgent, c.existingVersion)
+			e := &env.Env{
+				AgentPipelineID:                c.pipelineID,
+				AgentDistChannel:               c.channel,
+				AgentMajorVersion:              c.major,
+				AgentMinorVersion:              c.minor,
+				RegistryOverrideByImage:        map[string]string{},
+				DefaultPackagesVersionOverride: map[string]string{},
+			}
+			if c.existingRegistry != "" {
+				e.RegistryOverrideByImage[agentPackageImage] = c.existingRegistry
+			}
+			if c.existingVersion != "" {
+				e.DefaultPackagesVersionOverride[agentPackage] = c.existingVersion
+			}
+			err := applyAgentPipelineID(e)
+			if c.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, c.wantRegistry, e.RegistryOverrideByImage[agentPackageImage])
+			assert.Equal(t, c.wantVersionTag, e.DefaultPackagesVersionOverride[agentPackage])
+			assert.Equal(t, c.wantRegistry, os.Getenv(envInstallerRegistryURLAgent))
+			assert.Equal(t, c.wantVersionTag, os.Getenv(envInstallerDefaultVersionAgent))
+		})
+	}
+}
+
 func TestApplyAgentDistChannel(t *testing.T) {
 	cases := []struct {
 		name             string


### PR DESCRIPTION
### What does this PR do?

Adds a `DD_AGENT_PIPELINE_ID` option to the Windows installer `setup` flow. Setting `DD_AGENT_PIPELINE_ID=<id>` installs the Agent from the CI pipeline build: it points agent-package OCI fetches at `installtesting.datad0g.com` and pins the version to `pipeline-<id>`. It is mutually exclusive with `DD_AGENT_DIST_CHANNEL` and `DD_AGENT_MAJOR/MINOR_VERSION`; an explicit low-level registry/version override still wins per-axis.

### Motivation

Developers need an easy way to install and test a specific CI pipeline build of the Agent on Windows, alongside the existing `DD_AGENT_DIST_CHANNEL=beta` support. A single option that resolves both the registry and version is simpler than setting the two low-level `DD_INSTALLER_*` overrides by hand.

https://datadoghq.atlassian.net/browse/WINA-2862

### Describe how you validated your changes

- Added `TestApplyAgentPipelineID` (conflict cases, per-axis override precedence, re-exec propagation) and extended `TestFromEnv`.
- Manually installed pipeline build `124294178` on a Windows VM with `DD_OTELCOLLECTOR_ENABLED=true`; confirmed the Agent and the DDOT extension were both fetched from the pipeline registry at the `pipeline-<id>` tag.

### Additional Notes

Follows the same registry-override mechanism as the `DD_AGENT_DIST_CHANNEL=beta` work in #52883.