### PR TITLE
[apm/e2e] Filter fakeintake payloads by service in APM trace assertions

### DIFF
--- a/test/new-e2e/tests/apm/docker_test.go
+++ b/test/new-e2e/tests/apm/docker_test.go
@@ -126,7 +126,7 @@ func (s *DockerFakeintakeSuite) TestAutoVersionTraces() {
 	defer waitTracegenShutdown(&s.Suite, s.Env().FakeIntake)
 	defer runTracegenDocker(s.Env().RemoteHost, service, tracegenCfg{transport: s.transport})()
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		testAutoVersionTraces(s.T(), c, s.Env().FakeIntake)
+		testAutoVersionTraces(s.T(), c, service, s.Env().FakeIntake)
 	}, 2*time.Minute, 10*time.Second, "Failed finding version tags")
 }
 
@@ -138,7 +138,7 @@ func (s *DockerFakeintakeSuite) TestAutoVersionStats() {
 	defer waitTracegenShutdown(&s.Suite, s.Env().FakeIntake)
 	defer runTracegenDocker(s.Env().RemoteHost, service, tracegenCfg{transport: s.transport})()
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		testAutoVersionStats(s.T(), c, s.Env().FakeIntake)
+		testAutoVersionStats(s.T(), c, service, s.Env().FakeIntake)
 	}, 2*time.Minute, 10*time.Second, "Failed finding version tags")
 }
 
@@ -150,7 +150,7 @@ func (s *DockerFakeintakeSuite) TestIsTraceRootTag() {
 	defer waitTracegenShutdown(&s.Suite, s.Env().FakeIntake)
 	defer runTracegenDocker(s.Env().RemoteHost, service, tracegenCfg{transport: s.transport})()
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		testIsTraceRootTag(s.T(), c, s.Env().FakeIntake)
+		testIsTraceRootTag(s.T(), c, service, s.Env().FakeIntake)
 	}, 2*time.Minute, 10*time.Second, "Failed finding is_trace_root tag")
 }
 
@@ -225,7 +225,7 @@ func (s *DockerFakeintakeSuite) TestTPS() {
 
 	s.T().Log("Waiting for traces.")
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		testTPS(c, s.Env().FakeIntake, agentTPS)
+		testTPS(c, s.Env().FakeIntake, service, agentTPS)
 	}, 2*time.Minute, 10*time.Second, "Failed to test TargetTPS")
 }
 
@@ -257,7 +257,7 @@ func (s *DockerFakeintakeSuite) TestProbabilitySampler() {
 
 	s.T().Log("Waiting for traces.")
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		tracesSampledByProbabilitySampler(s.T(), c, s.Env().FakeIntake)
+		tracesSampledByProbabilitySampler(s.T(), c, service, s.Env().FakeIntake)
 	}, 2*time.Minute, 10*time.Second, "Failed to find traces sampled by the probability sampler")
 }
 
@@ -275,7 +275,7 @@ func (s *DockerFakeintakeSuite) TestAPMModeDefault() {
 
 	s.T().Log("Waiting for traces.")
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		testAPMMode(c, s.Env().FakeIntake, "")
+		testAPMMode(c, s.Env().FakeIntake, service, "")
 	}, 2*time.Minute, 10*time.Second, "Failed to find traces with _dd.apm_mode=default")
 }
 
@@ -301,6 +301,6 @@ func (s *DockerFakeintakeSuite) TestAPMModeEdge() {
 
 	s.T().Log("Waiting for traces.")
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		testAPMMode(c, s.Env().FakeIntake, "edge")
+		testAPMMode(c, s.Env().FakeIntake, service, "edge")
 	}, 2*time.Minute, 10*time.Second, "Failed to find traces with _dd.apm_mode=edge")
 }

--- a/test/new-e2e/tests/apm/tests.go
+++ b/test/new-e2e/tests/apm/tests.go
@@ -23,19 +23,74 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+// tracerPayloadHasService reports whether the tracer payload contains at least
+// one span for the given service.
+func tracerPayloadHasService(tp *trace.TracerPayload, service string) bool {
+	for _, chunk := range tp.Chunks {
+		for _, sp := range chunk.Spans {
+			if sp.Service == service {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// tracePayloadHasService reports whether any tracer payload in the agent payload
+// contains a span for the given service.
+func tracePayloadHasService(p *aggregator.TracePayload, service string) bool {
+	for _, tp := range p.TracerPayloads {
+		if tracerPayloadHasService(tp, service) {
+			return true
+		}
+	}
+	return false
+}
+
+// clientStatsHasService reports whether the client stats payload contains stats
+// for the given service.
+func clientStatsHasService(s *trace.ClientStatsPayload, service string) bool {
+	if s.Service == service {
+		return true
+	}
+	for _, bucket := range s.Stats {
+		for _, gs := range bucket.Stats {
+			if gs.Service == service {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func testBasicTraces(c *assert.CollectT, service string, intake *components.FakeIntake, agent agentclient.Agent) {
 	traces, err := intake.Client().GetTraces()
 	assert.NoError(c, err)
 	if !assert.NotEmpty(c, traces) {
 		return
 	}
-	trace := traces[0]
-	assert.Equal(c, agent.Hostname(), trace.HostName)
-	assert.Equal(c, "none", trace.Env)
-	if !assert.NotEmpty(c, trace.TracerPayloads) {
+	// The fakeintake accumulates every payload it receives, and a leaked
+	// environment whose agent keeps posting to a recycled intake IP can inject
+	// unrelated payloads (e.g. another suite's traces). Select the payload for
+	// our own tracegen service instead of blindly taking traces[0].
+	var tp *trace.TracerPayload
+	var hostName, env string
+	for _, tr := range traces {
+		for _, p := range tr.TracerPayloads {
+			if tracerPayloadHasService(p, service) {
+				tp, hostName, env = p, tr.HostName, tr.Env
+				break
+			}
+		}
+		if tp != nil {
+			break
+		}
+	}
+	if !assert.NotNil(c, tp, "no trace payload found for service %s", service) {
 		return
 	}
-	tp := trace.TracerPayloads[0]
+	assert.Equal(c, agent.Hostname(), hostName)
+	assert.Equal(c, "none", env)
 	assert.Equal(c, "go", tp.LanguageName)
 	assert.NotContains(c, tp.Tags, "_dd.apm_mode")
 	if !assert.NotEmpty(c, tp.Chunks) {
@@ -58,16 +113,24 @@ func testBasicTraces(c *assert.CollectT, service string, intake *components.Fake
 	}
 }
 
-func testTPS(c *assert.CollectT, intake *components.FakeIntake, tps float64) {
+func testTPS(c *assert.CollectT, intake *components.FakeIntake, service string, tps float64) {
 	traces, err := intake.Client().GetTraces()
 	assert.NoError(c, err)
 	if !assert.NotEmpty(c, traces) {
 		return
 	}
 
+	// Only assert on payloads produced by our own tracegen service; the intake
+	// may hold unrelated payloads with a different TargetTPS.
+	found := false
 	for _, p := range traces {
+		if !tracePayloadHasService(p, service) {
+			continue
+		}
+		found = true
 		assert.Equal(c, tps, p.TargetTPS, "invalid TargetTPS found in traces")
 	}
+	assert.True(c, found, "no trace payload found for service %s", service)
 }
 
 func testStatsForService(t *testing.T, c *assert.CollectT, service string, expectedPeerTag string, intake *components.FakeIntake) {
@@ -158,80 +221,100 @@ func testStatsHaveContainerTags(t *testing.T, c *assert.CollectT, service string
 	}
 }
 
-func testAutoVersionTraces(t *testing.T, c *assert.CollectT, intake *components.FakeIntake) {
+func testAutoVersionTraces(t *testing.T, c *assert.CollectT, service string, intake *components.FakeIntake) {
 	t.Helper()
 	traces, err := intake.Client().GetTraces()
 	assert.NoError(c, err)
 	assert.NotEmpty(c, traces)
 	t.Logf("Got %d apm traces", len(traces))
+	found := false
 	for _, tr := range traces {
 		for _, tp := range tr.TracerPayloads {
+			if !tracerPayloadHasService(tp, service) {
+				continue
+			}
+			found = true
 			t.Log("Tracer Payload Tags:", tp.Tags["_dd.tags.container"])
 			ctags, ok := getContainerTags(t, tp)
-			assert.True(t, ok, "expected to find container tags at _dd.tags.container")
+			assert.True(c, ok, "expected to find container tags at _dd.tags.container")
 			imageTag, ok := ctags["image_tag"]
-			assert.True(t, ok, "expected to find image_tag in container tags")
+			assert.True(c, ok, "expected to find image_tag in container tags")
 			t.Logf("Got image Tag: %v", imageTag)
-			assert.Equal(t, apps.Version, imageTag)
+			assert.Equal(c, apps.Version, imageTag)
 		}
 	}
+	assert.True(c, found, "no trace payload found for service %s", service)
 }
 
-func tracesSampledByProbabilitySampler(t *testing.T, c *assert.CollectT, intake *components.FakeIntake) {
+func tracesSampledByProbabilitySampler(t *testing.T, c *assert.CollectT, service string, intake *components.FakeIntake) {
 	t.Helper()
 	traces, err := intake.Client().GetTraces()
 	assert.NoError(c, err)
 	assert.NotEmpty(c, traces)
 	t.Logf("Got %d apm traces", len(traces))
+	found := false
 	for _, p := range traces {
-		for _, tp := range p.AgentPayload.TracerPayloads {
+		for _, tp := range p.TracerPayloads {
+			if !tracerPayloadHasService(tp, service) {
+				continue
+			}
 			for _, chunk := range tp.Chunks {
+				found = true
 				dm, ok := chunk.Tags["_dd.p.dm"]
-				if !ok {
-					t.Errorf("Expected trace chunk tags to contain _dd.p.dm, but it does not.")
-				}
-				if dm != "-9" {
-					t.Errorf("Expected dm == -9, but got %v for service %s", dm, chunk.Spans[0].Service)
-				}
+				assert.True(c, ok, "expected trace chunk tags to contain _dd.p.dm")
+				assert.Equal(c, "-9", dm, "expected dm == -9 for service %s", service)
 			}
 		}
 	}
+	assert.True(c, found, "no trace chunks found for service %s", service)
 }
 
-func testAutoVersionStats(t *testing.T, c *assert.CollectT, intake *components.FakeIntake) {
+func testAutoVersionStats(t *testing.T, c *assert.CollectT, service string, intake *components.FakeIntake) {
 	t.Helper()
 	stats, err := intake.Client().GetAPMStats()
 	assert.NoError(c, err)
 	assert.NotEmpty(c, stats)
 	t.Logf("Got %d apm stats", len(stats))
+	found := false
 	for _, p := range stats {
 		for _, s := range p.StatsPayload.Stats {
+			if !clientStatsHasService(s, service) {
+				continue
+			}
+			found = true
 			t.Log("Client Payload:", spew.Sdump(s))
 			t.Logf("Got image Tag: %v", s.GetImageTag())
-			assert.Equal(t, apps.Version, s.GetImageTag())
+			assert.Equal(c, apps.Version, s.GetImageTag())
 			t.Logf("Got git commit sha: %v", s.GetGitCommitSha())
-			assert.Equal(t, "abcd1234", s.GetGitCommitSha())
+			assert.Equal(c, "abcd1234", s.GetGitCommitSha())
 		}
 	}
+	assert.True(c, found, "no stats payload found for service %s", service)
 }
 
-func testIsTraceRootTag(t *testing.T, c *assert.CollectT, intake *components.FakeIntake) {
+func testIsTraceRootTag(t *testing.T, c *assert.CollectT, service string, intake *components.FakeIntake) {
 	t.Helper()
 	stats, err := intake.Client().GetAPMStats()
 	assert.NoError(c, err)
 	assert.NotEmpty(c, stats)
 	t.Logf("Got %d apm stats", len(stats))
+	found := false
 	for _, p := range stats {
 		for _, s := range p.StatsPayload.Stats {
 			t.Log("Client Payload:", spew.Sdump(s))
 			for _, b := range s.Stats {
 				for _, cs := range b.Stats {
+					if cs.Service != service {
+						continue
+					}
+					found = true
 					t.Logf("Got IsTraceRoot: %v", cs.GetIsTraceRoot())
-					assert.Equal(t, trace.Trilean_TRUE, cs.GetIsTraceRoot())
+					assert.Equal(c, trace.Trilean_TRUE, cs.GetIsTraceRoot())
 				}
 			}
 		}
 	}
+	assert.True(c, found, "no stats found for service %s", service)
 }
 
 func getContainerTags(t *testing.T, tp *trace.TracerPayload) (map[string]string, bool) {
@@ -451,22 +534,26 @@ func hasPoisonPill(t *testing.T, intake *components.FakeIntake) bool {
 	return hasTraceForResource(traces, "poison_pill")
 }
 
-func testAPMMode(c *assert.CollectT, intake *components.FakeIntake, expectedAPMMode string) {
+func testAPMMode(c *assert.CollectT, intake *components.FakeIntake, service string, expectedAPMMode string) {
 	traces, err := intake.Client().GetTraces()
 	assert.NoError(c, err)
 	if !assert.NotEmpty(c, traces) {
 		return
 	}
-	if expectedAPMMode == "" {
-		for _, p := range traces {
-			// assert that apm mod tag does not exist
+	found := false
+	for _, p := range traces {
+		if !tracePayloadHasService(p, service) {
+			continue
+		}
+		found = true
+		if expectedAPMMode == "" {
+			// assert that apm mode tag does not exist
 			v, ok := p.Tags["_dd.apm_mode"]
 			assert.False(c, ok)
 			assert.Empty(c, v)
+			continue
 		}
-		return
-	}
-	for _, p := range traces {
 		assert.Equal(c, expectedAPMMode, p.Tags["_dd.apm_mode"])
 	}
+	assert.True(c, found, "no trace payload found for service %s", service)
 }

--- a/test/new-e2e/tests/apm/vm_test.go
+++ b/test/new-e2e/tests/apm/vm_test.go
@@ -243,7 +243,7 @@ func (s *VMFakeintakeSuite) TestAutoVersionTraces() {
 
 	s.EventuallyWithTf(func(c *assert.CollectT) {
 		s.logStatus()
-		testAutoVersionTraces(s.T(), c, s.Env().FakeIntake)
+		testAutoVersionTraces(s.T(), c, service, s.Env().FakeIntake)
 		s.logJournal(false)
 	}, 3*time.Minute, 10*time.Second, "Failed finding traces")
 }
@@ -266,7 +266,7 @@ func (s *VMFakeintakeSuite) TestAutoVersionStats() {
 
 	s.EventuallyWithTf(func(c *assert.CollectT) {
 		s.logStatus()
-		testAutoVersionStats(s.T(), c, s.Env().FakeIntake)
+		testAutoVersionStats(s.T(), c, service, s.Env().FakeIntake)
 		s.logJournal(false)
 	}, 3*time.Minute, 10*time.Second, "Failed finding stats")
 }
@@ -289,7 +289,7 @@ func (s *VMFakeintakeSuite) TestIsTraceRootTag() {
 
 	s.EventuallyWithTf(func(c *assert.CollectT) {
 		s.logStatus()
-		testIsTraceRootTag(s.T(), c, s.Env().FakeIntake)
+		testIsTraceRootTag(s.T(), c, service, s.Env().FakeIntake)
 		s.logJournal(false)
 	}, 3*time.Minute, 10*time.Second, "Failed finding stats")
 }
@@ -395,7 +395,7 @@ apm_config.probabilistic_sampler.hash_seed: 22
 
 	s.T().Log("Waiting for traces.")
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		tracesSampledByProbabilitySampler(s.T(), c, s.Env().FakeIntake)
+		tracesSampledByProbabilitySampler(s.T(), c, service, s.Env().FakeIntake)
 	}, 2*time.Minute, 10*time.Second, "Failed to find traces sampled by the probability sampler")
 }
 
@@ -417,7 +417,7 @@ func (s *VMFakeintakeSuite) TestAPMModeDefault() {
 
 	s.EventuallyWithTf(func(c *assert.CollectT) {
 		s.logStatus()
-		testAPMMode(c, s.Env().FakeIntake, "")
+		testAPMMode(c, s.Env().FakeIntake, service, "")
 		s.logJournal(false)
 	}, 2*time.Minute, 10*time.Second, "Failed finding traces with correct APM mode")
 }
@@ -449,7 +449,7 @@ func (s *VMFakeintakeSuite) TestAPMModeEdge() {
 	s.T().Log("Waiting for traces.")
 	s.EventuallyWithTf(func(c *assert.CollectT) {
 		s.logStatus()
-		testAPMMode(c, s.Env().FakeIntake, "edge")
+		testAPMMode(c, s.Env().FakeIntake, service, "edge")
 		s.logJournal(false)
 	}, 2*time.Minute, 10*time.Second, "Failed to find traces with _dd.apm_mode=edge")
 }


### PR DESCRIPTION
### What does this PR do?

Makes the APM `VMFakeintakeSuite` / `DockerFakeintakeSuite` trace assertions
select the payloads produced by the test's **own** tracegen service instead of
asserting over the entire fakeintake contents.

Adds three predicates in `tests.go` — `tracerPayloadHasService`,
`tracePayloadHasService`, `clientStatsHasService` — and threads the `service`
name through the affected helpers:

- `testBasicTraces` (was `traces[0]` / `TracerPayloads[0]`)
- `testTPS`, `testAPMMode` (asserted on every trace payload)
- `testAutoVersionTraces`, `testAutoVersionStats`, `testIsTraceRootTag`,
  `tracesSampledByProbabilitySampler` (asserted on every payload/stat)

Also switches value assertions inside `EventuallyWithTf` loops from `t` to the
`assert.CollectT` so polling retries correctly, and asserts that a matching
payload was actually found.

### Motivation

A Docker APM suite run failed `TestBasicTrace` with 45 assertions comparing
against `workload-selection-inject` (a python/flask SSI app) instead of the
expected `tracegen-basic-trace-uds`. The leaked trace's hostname belonged to a
**different pipeline's** SSI kind cluster.

Root cause: the fakeintake accumulates every payload it receives. A leaked SSI
environment (not torn down) whose datadog-agent kept POSTing to a fakeintake
endpoint IP that AWS later recycled to this Docker suite's fakeintake was
actively re-populating the intake right after each `FlushServerAndResetAggregators`.
Because the assertions blindly read `traces[0]` / iterated all payloads, the
foreign traffic failed the test.

This PR does not fix the leaked-environment / IP-reuse contamination itself
(tracked separately), but it makes these assertions robust against unrelated
traffic in the intake.

### Describe how you validated your changes

`go vet -tags test ./tests/apm/...` passes. The changes are test-only; the
affected E2E suites (`TestVMFakeintakeSuite{UDS,TCP}`, `TestDockerFakeintakeSuite{UDS,TCP}`)
exercise these helpers.

### Possible Drawbacks / Trade-offs

None expected — test-only robustness change.
