### PR TITLE
Stream parquet input in headless anomaly testbench

### DIFF
--- a/internal/qbranch/anomalydetection-testbench/README.md
+++ b/internal/qbranch/anomalydetection-testbench/README.md
@@ -73,6 +73,7 @@ $ dda inv anomalydetection.eval-component-workspace-report evals # This will fet
 | `--output` | _(empty)_ | Path for observer JSON output |
 | `--verbose` | `false` | Include full detail in JSON output (titles, member series, individual anomalies) |
 | `--memprofile` | _(empty)_ | Write a heap profile to this file after the run |
+| `--batch-parquet` | `false` | Retain and sort all parquet rows in headless mode. Use for unordered local recordings; headless runs stream by default. |
 
 ## Components
 
@@ -147,6 +148,9 @@ dda inv -- anomalydetection.launch-testbench --headless-scenario <scenario-name>
   --scenarios-dir ./comp/anomalydetection/observer/scenarios
 
 dda inv -- anomalydetection.launch-testbench --headless-scenario <scenario-name> --logs-only
+
+# Fall back to retained loading and global sorting for unordered local recordings
+dda inv -- anomalydetection.launch-testbench --headless-scenario <scenario-name> --batch-parquet
 
 # Verbose output (includes anomaly detail, member series, titles)
 ./bin/anomalydetection-testbench \

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -90,6 +90,10 @@ type Config struct {
 
 	// ParquetFormat selects the parquet layout. Empty string = auto-detect.
 	ParquetFormat ParquetFormat
+
+	// StreamParquet ingests globally ordered parquet data without retaining raw rows.
+	// It is intended for one-shot headless runs, which do not need interactive reruns.
+	StreamParquet bool
 }
 
 // ScenarioInfo describes an available scenario.
@@ -187,6 +191,10 @@ type Bench struct {
 	api *BenchAPI
 
 	replayStats *ReplayStats
+
+	streamedLogStartMs int64
+	streamedLogEndMs   int64
+	hasStreamedLogSpan bool
 
 	// baselineMu protects baseline fields. Separate from tb.mu because the
 	// callback fires from the engine run goroutine while tb.mu may already be
@@ -350,6 +358,9 @@ func (tb *Bench) LoadScenario(name string) error {
 	tb.logAnomalies = []observerdef.Anomaly{}
 	tb.logAnomaliesByDetector = make(map[string][]observerdef.Anomaly)
 	tb.liveAdvanceTimes = nil
+	tb.streamedLogStartMs = 0
+	tb.streamedLogEndMs = 0
+	tb.hasStreamedLogSpan = false
 	tb.ready = false
 	tb.loadedScenario = name
 	tb.debug.SetReplayPhase("loading")
@@ -410,14 +421,20 @@ func (tb *Bench) LoadScenario(name string) error {
 	fmt.Printf("  Parquet loading took %s\n", time.Since(parquetStart))
 
 	analysisStart := time.Now()
-	tb.rerunDetectorsLocked()
+	if tb.config.StreamParquet {
+		// Parquet rows were already ingested while reading. Finish the same replay
+		// used by the retained-data path without resetting away streamed storage.
+		tb.finishReplayLocked()
+	} else {
+		tb.rerunDetectorsLocked()
+	}
 	fmt.Printf("  Detector phase took %s\n", time.Since(analysisStart))
 	fmt.Printf("  Total scenario load took %s\n", time.Since(scenarioStart))
 
 	sv := tb.debug.StateView()
 	rs := tb.replayStats
 	fmt.Printf("Scenario loaded: %d metric samples (%d unique series), %d metric anomalies, %d log entries, %d log anomalies\n",
-		rs.InputMetricsCount, rs.InputMetricsCardinality, sv.TotalAnomalyCount(), len(tb.rawLogs), len(tb.logAnomalies))
+		rs.InputMetricsCount, rs.InputMetricsCardinality, sv.TotalAnomalyCount(), rs.InputLogsCount, len(tb.logAnomalies))
 
 	close(progressDone)
 	tb.mu.Unlock()
@@ -436,6 +453,10 @@ func (tb *Bench) loadParquetDir(dir string) error {
 
 	if tb.config.LogsOnly {
 		fmt.Printf("  Logs-only mode: skipping parquet metrics and trace stats\n")
+	} else if tb.config.StreamParquet {
+		if err := tb.streamParquetMetrics(dir, format); err != nil {
+			return err
+		}
 	} else {
 		var metrics []recorderdef.MetricData
 		var err error
@@ -473,8 +494,31 @@ func (tb *Bench) loadParquetDir(dir string) error {
 		tb.feedRawMetrics()
 	}
 
-	var parquetLogs []recorderdef.LogData
-	var logsErr error
+	if tb.config.StreamParquet {
+		fmt.Printf("  Streaming globally ordered log rows from parquet files\n")
+		count, err := streamOrderedLogs(dir, format, func(entry recorderdef.LogData) error {
+			view := logDataView{data: &entry}
+			tb.debug.IngestTestbenchLog("parquet", &view)
+			tb.debug.AddTelemetry(telemetryTbInputLogsCount, 1, entry.TimestampMs/1000, nil)
+
+			if !tb.hasStreamedLogSpan {
+				tb.streamedLogStartMs = entry.TimestampMs
+				tb.hasStreamedLogSpan = true
+			}
+			tb.streamedLogEndMs = entry.TimestampMs
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("streaming parquet logs: %w", err)
+		}
+		fmt.Printf("  Streamed %d log rows from parquet files\n", count)
+		return nil
+	}
+
+	var (
+		parquetLogs []recorderdef.LogData
+		logsErr     error
+	)
 	if format == FormatV2 {
 		parquetLogs, logsErr = readAllLogsV2(dir)
 	} else {
@@ -489,6 +533,60 @@ func (tb *Bench) loadParquetDir(dir string) error {
 		tb.rawLogs = append(tb.rawLogs, &logDataView{data: &logCopy})
 	}
 
+	return nil
+}
+
+func (tb *Bench) streamParquetMetrics(dir string, format ParquetFormat) error {
+	fmt.Printf("  Streaming globally ordered metric rows from parquet files\n")
+
+	var (
+		haveTimestamp      bool
+		currentTimestamp   int64
+		currentCount       int64
+		currentCardinality map[string]struct{}
+		ingestedCount      int
+	)
+	flushTelemetry := func() {
+		if !haveTimestamp {
+			return
+		}
+		tb.debug.AddTelemetry(telemetryTbInputMetricsCount, float64(currentCount), currentTimestamp, nil)
+		tb.debug.AddTelemetry(telemetryTbInputMetricsCardinality, float64(len(currentCardinality)), currentTimestamp, nil)
+	}
+
+	_, err := streamOrderedMetrics(dir, format, func(metric recorderdef.MetricData) error {
+		if strings.HasPrefix(metric.Name, "datadog.") {
+			return nil
+		}
+		if tb.config.SkipDroppedMetrics && metric.Dropped {
+			return nil
+		}
+
+		if !haveTimestamp || metric.Timestamp != currentTimestamp {
+			flushTelemetry()
+			currentTimestamp = metric.Timestamp
+			currentCount = 0
+			currentCardinality = make(map[string]struct{})
+			haveTimestamp = true
+		}
+
+		view := parquetMetricView{
+			name:      metric.Name,
+			value:     metric.Value,
+			tags:      metric.Tags,
+			timestamp: metric.Timestamp,
+		}
+		tb.debug.IngestMetricSync("parquet", &view)
+		currentCount++
+		currentCardinality[metric.Name+"|"+strings.Join(metric.Tags, ",")] = struct{}{}
+		ingestedCount++
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("streaming parquet metrics: %w", err)
+	}
+	flushTelemetry()
+	fmt.Printf("  Streamed %d metric rows from parquet files\n", ingestedCount)
 	return nil
 }
 
@@ -605,6 +703,22 @@ func (tb *Bench) GetStatus() StatusResponse {
 			}
 		}
 	}
+	if tb.hasStreamedLogSpan {
+		startSec := tb.streamedLogStartMs / 1000
+		endSec := (tb.streamedLogEndMs + 999) / 1000
+		if !hasBounds {
+			scenarioStart = startSec
+			scenarioEnd = endSec
+			hasBounds = true
+		} else {
+			if startSec < scenarioStart {
+				scenarioStart = startSec
+			}
+			if endSec > scenarioEnd {
+				scenarioEnd = endSec
+			}
+		}
+	}
 
 	var scenarioStartPtr *int64
 	var scenarioEndPtr *int64
@@ -684,6 +798,12 @@ func (tb *Bench) rerunDetectorsLocked() {
 		tb.debug.AddTelemetry(telemetryTbInputLogsCount, 1, ts, nil)
 	}
 
+	tb.finishReplayLocked()
+}
+
+// finishReplayLocked runs analysis over data already loaded into observer storage
+// and refreshes all derived testbench output. Caller must hold tb.mu.
+func (tb *Bench) finishReplayLocked() {
 	// Run the full batch replay: reset analysis state (not storage), advance
 	// through every stored timestamp so detectors see the full accumulated
 	// dataset at each step. This matches what the old testbench achieved via

--- a/internal/qbranch/anomalydetection-testbench/bench/parquet.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/parquet.go
@@ -45,7 +45,6 @@ func detectParquetFormat(dir string) ParquetFormat {
 	return FormatV1
 }
 
-
 // ---- Metric reader ----
 
 type fgmMetric struct {
@@ -80,7 +79,7 @@ func newParquetMetricReader(dirPath string) (*parquetMetricReader, error) {
 		}
 		all = append(all, metrics...)
 	}
-	sort.Slice(all, func(i, j int) bool { return all[i].Time < all[j].Time })
+	sort.SliceStable(all, func(i, j int) bool { return all[i].Time < all[j].Time })
 	return &parquetMetricReader{metrics: all}, nil
 }
 
@@ -118,51 +117,65 @@ func findMetricParquetFiles(dirPath string) ([]string, error) {
 }
 
 func readMetricParquetFile(filePath string) ([]fgmMetric, error) {
+	var all []fgmMetric
+	err := streamMetricParquetFileV1(filePath, func(metric fgmMetric) error {
+		all = append(all, metric)
+		return nil
+	})
+	return all, err
+}
+
+func streamMetricParquetFileV1(filePath string, fn func(fgmMetric) error) error {
 	info, err := os.Stat(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("statting file: %w", err)
+		return fmt.Errorf("statting file: %w", err)
 	}
 	if info.Size() < minParquetFileSize {
-		return nil, nil
+		return fmt.Errorf("file is too small to be parquet (%d bytes)", info.Size())
 	}
 	f, err := os.Open(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("opening file: %w", err)
+		return fmt.Errorf("opening file: %w", err)
 	}
 	defer f.Close()
 
 	pf, err := file.NewParquetReader(f)
 	if err != nil {
-		return nil, fmt.Errorf("creating parquet reader: %w", err)
+		return fmt.Errorf("creating parquet reader: %w", err)
 	}
 	defer pf.Close()
 
 	arrowReader, err := pqarrow.NewFileReader(pf, pqarrow.ArrowReadProperties{BatchSize: 1024}, memory.DefaultAllocator)
 	if err != nil {
-		return nil, fmt.Errorf("creating arrow reader: %w", err)
+		return fmt.Errorf("creating arrow reader: %w", err)
 	}
 
 	ctx := context.Background()
 	rr, err := arrowReader.GetRecordReader(ctx, nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("getting record reader: %w", err)
+		return fmt.Errorf("getting record reader: %w", err)
 	}
 	defer rr.Release()
 
-	var all []fgmMetric
 	for rr.Next() {
 		rec := rr.Record()
 		metrics, err := extractMetricsFromRecord(rec)
 		if err != nil {
-			return nil, fmt.Errorf("extracting metrics: %w", err)
+			rec.Release()
+			return fmt.Errorf("extracting metrics: %w", err)
 		}
-		all = append(all, metrics...)
+		for _, metric := range metrics {
+			if err := fn(metric); err != nil {
+				rec.Release()
+				return err
+			}
+		}
 		rec.Release()
 	}
 	if err := rr.Err(); err != nil && err.Error() != "EOF" {
-		return nil, fmt.Errorf("reading records: %w", err)
+		return fmt.Errorf("reading records: %w", err)
 	}
-	return all, nil
+	return nil
 }
 
 func extractMetricsFromRecord(rec arrow.Record) ([]fgmMetric, error) {
@@ -322,37 +335,130 @@ func readAllMetrics(dir string) ([]recorderdef.MetricData, error) {
 		if m == nil {
 			break
 		}
-		var value float64
-		if m.ValueFloat != nil {
-			value = *m.ValueFloat
-		} else if m.ValueInt != nil {
-			value = float64(*m.ValueInt)
-		}
-		tags := make([]string, 0, len(m.Tags))
-		for k, v := range m.Tags {
-			if v != "" {
-				tags = append(tags, k+":"+v)
-			} else {
-				tags = append(tags, k)
-			}
-		}
-		out = append(out, recorderdef.MetricData{
-			Source:    m.RunID,
-			Name:      m.MetricName,
-			Value:     value,
-			Timestamp: m.Time / 1000,
-			Tags:      tags,
-			Dropped:   m.Dropped,
-		})
+		out = append(out, metricDataFromFGM(*m))
 	}
 	pkglog.Infof("ReadAllMetrics: loaded %d metrics", len(out))
 	return out, nil
 }
 
+func metricDataFromFGM(metric fgmMetric) recorderdef.MetricData {
+	var value float64
+	if metric.ValueFloat != nil {
+		value = *metric.ValueFloat
+	} else if metric.ValueInt != nil {
+		value = float64(*metric.ValueInt)
+	}
+	tags := make([]string, 0, len(metric.Tags))
+	for key, tagValue := range metric.Tags {
+		if tagValue != "" {
+			tags = append(tags, key+":"+tagValue)
+		} else {
+			tags = append(tags, key)
+		}
+	}
+	return recorderdef.MetricData{
+		Source:    metric.RunID,
+		Name:      metric.MetricName,
+		Value:     value,
+		Timestamp: metric.Time / 1000,
+		Tags:      tags,
+		Dropped:   metric.Dropped,
+	}
+}
+
+// streamOrderedMetrics reads metric parquet files in filename and row order
+// without retaining the full dataset. Equal timestamps are allowed.
+func streamOrderedMetrics(dir string, format ParquetFormat, fn func(recorderdef.MetricData) error) (int, error) {
+	var (
+		count        int
+		previousTime int64
+		havePrevious bool
+	)
+
+	consume := func(filePath string, metric recorderdef.MetricData) error {
+		if havePrevious && metric.Timestamp < previousTime {
+			return fmt.Errorf(
+				"metric timestamps are not globally ordered: %s contains %d after %d",
+				filepath.Base(filePath), metric.Timestamp, previousTime,
+			)
+		}
+		if err := fn(metric); err != nil {
+			return err
+		}
+		previousTime = metric.Timestamp
+		havePrevious = true
+		count++
+		return nil
+	}
+
+	var err error
+	if format == FormatV2 {
+		err = streamAllMetricsV2(dir, consume)
+	} else {
+		err = streamAllMetricsV1(dir, consume)
+	}
+	if err != nil {
+		return count, err
+	}
+	return count, nil
+}
+
+func streamAllMetricsV1(dir string, fn func(string, recorderdef.MetricData) error) error {
+	files, err := findMetricParquetFiles(dir)
+	if err != nil {
+		return fmt.Errorf("listing v1 metric parquet files: %w", err)
+	}
+	for _, filePath := range files {
+		if err := streamMetricParquetFileV1(filePath, func(metric fgmMetric) error {
+			return fn(filePath, metricDataFromFGM(metric))
+		}); err != nil {
+			return fmt.Errorf("streaming %s: %w", filePath, err)
+		}
+	}
+	return nil
+}
+
 // ---- Log reader ----
 
-// readAllLogs reads all log parquet files from dir and returns LogData records.
-func readAllLogs(dir string) ([]recorderdef.LogData, error) {
+// streamOrderedLogs reads log parquet files in filename and row order without
+// retaining the full dataset. The caller must provide parquet files whose rows
+// are globally ordered by timestamp; equal timestamps are allowed.
+func streamOrderedLogs(dir string, format ParquetFormat, fn func(recorderdef.LogData) error) (int, error) {
+	var (
+		count        int
+		previousTime int64
+		havePrevious bool
+	)
+
+	consume := func(filePath string, entry recorderdef.LogData) error {
+		if havePrevious && entry.TimestampMs < previousTime {
+			return fmt.Errorf(
+				"log timestamps are not globally ordered: %s contains %d after %d",
+				filepath.Base(filePath), entry.TimestampMs, previousTime,
+			)
+		}
+		if err := fn(entry); err != nil {
+			return err
+		}
+		previousTime = entry.TimestampMs
+		havePrevious = true
+		count++
+		return nil
+	}
+
+	var err error
+	if format == FormatV2 {
+		err = streamAllLogsV2(dir, consume)
+	} else {
+		err = streamAllLogsV1(dir, consume)
+	}
+	if err != nil {
+		return count, err
+	}
+	return count, nil
+}
+
+func findLogParquetFilesV1(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
@@ -367,12 +473,164 @@ func readAllLogs(dir string) ([]recorderdef.LogData, error) {
 		}
 	}
 	sort.Strings(files)
+	return files, nil
+}
+
+func streamAllLogsV1(dir string, fn func(string, recorderdef.LogData) error) error {
+	files, err := findLogParquetFilesV1(dir)
+	if err != nil {
+		return fmt.Errorf("listing v1 log parquet files: %w", err)
+	}
+	for _, filePath := range files {
+		if err := streamLogParquetFileV1(filePath, func(entry recorderdef.LogData) error {
+			return fn(filePath, entry)
+		}); err != nil {
+			return fmt.Errorf("streaming %s: %w", filePath, err)
+		}
+	}
+	return nil
+}
+
+func streamLogParquetFileV1(filePath string, fn func(recorderdef.LogData) error) error {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return fmt.Errorf("statting file: %w", err)
+	}
+	if info.Size() < minParquetFileSize {
+		return fmt.Errorf("file is too small to be parquet (%d bytes)", info.Size())
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("opening file: %w", err)
+	}
+	defer f.Close()
+
+	pf, err := file.NewParquetReader(f)
+	if err != nil {
+		return fmt.Errorf("creating parquet reader: %w", err)
+	}
+	defer pf.Close()
+
+	reader, err := pqarrow.NewFileReader(pf, pqarrow.ArrowReadProperties{BatchSize: 1024}, memory.DefaultAllocator)
+	if err != nil {
+		return fmt.Errorf("creating arrow reader: %w", err)
+	}
+
+	rr, err := reader.GetRecordReader(context.Background(), nil, nil)
+	if err != nil {
+		return fmt.Errorf("getting record reader: %w", err)
+	}
+	defer rr.Release()
+
+	for rr.Next() {
+		rec := rr.Record()
+		if err := streamLogsFromRecordV1(rec, fn); err != nil {
+			rec.Release()
+			return err
+		}
+		rec.Release()
+	}
+	if err := rr.Err(); err != nil && err.Error() != "EOF" {
+		return fmt.Errorf("reading records: %w", err)
+	}
+	return nil
+}
+
+func streamLogsFromRecordV1(rec arrow.Record, fn func(recorderdef.LogData) error) error {
+	schema := rec.Schema()
+	timeIdx := findCol(schema, "time")
+	if timeIdx < 0 {
+		return fmt.Errorf("missing required Time column")
+	}
+	timeCol, ok := rec.Column(timeIdx).(*array.Int64)
+	if !ok {
+		return fmt.Errorf("Time column has type %T, expected int64", rec.Column(timeIdx))
+	}
+
+	getString := func(name string) (*array.String, error) {
+		idx := findCol(schema, name)
+		if idx < 0 {
+			return nil, nil
+		}
+		col, ok := rec.Column(idx).(*array.String)
+		if !ok {
+			return nil, fmt.Errorf("%s column has type %T, expected string", name, rec.Column(idx))
+		}
+		return col, nil
+	}
+
+	runIDCol, err := getString("runid")
+	if err != nil {
+		return err
+	}
+	statusCol, err := getString("status")
+	if err != nil {
+		return err
+	}
+	hostnameCol, err := getString("hostname")
+	if err != nil {
+		return err
+	}
+
+	var contentCol *array.Binary
+	if idx := findCol(schema, "content"); idx >= 0 {
+		contentCol, ok = rec.Column(idx).(*array.Binary)
+		if !ok {
+			return fmt.Errorf("Content column has type %T, expected binary", rec.Column(idx))
+		}
+	}
+
+	var tagsCol *array.List
+	if idx := findCol(schema, "tags"); idx >= 0 {
+		tagsCol, ok = rec.Column(idx).(*array.List)
+		if !ok {
+			return fmt.Errorf("Tags column has type %T, expected list", rec.Column(idx))
+		}
+		if _, ok := tagsCol.ListValues().(*array.String); !ok {
+			return fmt.Errorf("Tags values have type %T, expected string", tagsCol.ListValues())
+		}
+	}
+
+	for i := 0; i < int(rec.NumRows()); i++ {
+		if timeCol.IsNull(i) {
+			return fmt.Errorf("Time is null at row %d", i)
+		}
+		entry := recorderdef.LogData{TimestampMs: timeCol.Value(i)}
+		if runIDCol != nil && !runIDCol.IsNull(i) {
+			entry.Source = runIDCol.Value(i)
+		}
+		if contentCol != nil && !contentCol.IsNull(i) {
+			entry.Content = append([]byte(nil), contentCol.Value(i)...)
+		}
+		if statusCol != nil && !statusCol.IsNull(i) {
+			entry.Status = statusCol.Value(i)
+		}
+		if hostnameCol != nil && !hostnameCol.IsNull(i) {
+			entry.Hostname = hostnameCol.Value(i)
+		}
+		if tagsCol != nil {
+			entry.Tags = readStringList(tagsCol, i)
+		}
+		if err := fn(entry); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readAllLogs reads all log parquet files from dir and returns LogData records.
+func readAllLogs(dir string) ([]recorderdef.LogData, error) {
+	files, err := findLogParquetFilesV1(dir)
+	if err != nil {
+		return nil, err
+	}
 
 	var logs []recorderdef.LogData
 	for _, f := range files {
 		readLogParquetFile(f, &logs)
 	}
-	sort.Slice(logs, func(i, j int) bool { return logs[i].TimestampMs < logs[j].TimestampMs })
+	sort.SliceStable(logs, func(i, j int) bool { return logs[i].TimestampMs < logs[j].TimestampMs })
 	pkglog.Infof("ReadAllLogs: loaded %d logs from %s", len(logs), dir)
 	return logs, nil
 }

--- a/internal/qbranch/anomalydetection-testbench/bench/parquet_stream_test.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/parquet_stream_test.go
@@ -1,0 +1,257 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package bench
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/stretchr/testify/require"
+
+	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
+)
+
+var benchmarkLogSink []recorderdef.LogData
+
+func TestStreamOrderedLogsV1MatchesBatchReader(t *testing.T) {
+	dir := t.TempDir()
+	want := []recorderdef.LogData{
+		{Source: "run", TimestampMs: 1000, Content: []byte("first"), Status: "info", Hostname: "host-a", Tags: []string{"service:api"}},
+		{Source: "run", TimestampMs: 1000, Content: []byte("same-time"), Status: "warn", Hostname: "host-a", Tags: []string{"service:api", "env:test"}},
+		{Source: "run", TimestampMs: 1001, Content: []byte("last"), Status: "error", Hostname: "host-b"},
+	}
+	writeLogParquetV1(t, filepath.Join(dir, "observer-logs-000000.parquet"), want[:2], 1)
+	writeLogParquetV1(t, filepath.Join(dir, "observer-logs-000001.parquet"), want[2:], 1)
+
+	var got []recorderdef.LogData
+	count, err := streamOrderedLogs(dir, FormatV1, func(entry recorderdef.LogData) error {
+		got = append(got, entry)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, len(want), count)
+	require.Equal(t, want, got)
+
+	batch, err := readAllLogs(dir)
+	require.NoError(t, err)
+	require.Equal(t, batch, got)
+}
+
+func TestStreamOrderedLogsV1RejectsDisorder(t *testing.T) {
+	t.Run("within a file", func(t *testing.T) {
+		dir := t.TempDir()
+		writeLogParquetV1(t, filepath.Join(dir, "observer-logs-000000.parquet"), []recorderdef.LogData{
+			{TimestampMs: 1001},
+			{TimestampMs: 1000},
+		}, 1)
+
+		count, err := streamOrderedLogs(dir, FormatV1, func(recorderdef.LogData) error { return nil })
+		require.Equal(t, 1, count)
+		require.ErrorContains(t, err, "observer-logs-000000.parquet contains 1000 after 1001")
+	})
+
+	t.Run("across files", func(t *testing.T) {
+		dir := t.TempDir()
+		writeLogParquetV1(t, filepath.Join(dir, "observer-logs-000000.parquet"), []recorderdef.LogData{{TimestampMs: 1001}}, 1)
+		writeLogParquetV1(t, filepath.Join(dir, "observer-logs-000001.parquet"), []recorderdef.LogData{{TimestampMs: 1000}}, 1)
+
+		count, err := streamOrderedLogs(dir, FormatV1, func(recorderdef.LogData) error { return nil })
+		require.Equal(t, 1, count)
+		require.ErrorContains(t, err, "observer-logs-000001.parquet contains 1000 after 1001")
+	})
+}
+
+func TestStreamOrderedMetricsV1MatchesBatchReader(t *testing.T) {
+	dir := t.TempDir()
+	want := []recorderdef.MetricData{
+		{Source: "run", Name: "system.cpu", Value: 1.5, Timestamp: 1000, Tags: []string{"host:a"}},
+		{Source: "run", Name: "system.cpu", Value: 2.5, Timestamp: 1001, Tags: []string{"host:a"}},
+		{Source: "run", Name: "system.memory", Value: 3.5, Timestamp: 1002, Tags: []string{"host:b"}},
+	}
+	writeMetricParquetV1(t, filepath.Join(dir, "observer-metrics-000000.parquet"), want[:2], 1)
+	writeMetricParquetV1(t, filepath.Join(dir, "observer-metrics-000001.parquet"), want[2:], 1)
+
+	var got []recorderdef.MetricData
+	count, err := streamOrderedMetrics(dir, FormatV1, func(metric recorderdef.MetricData) error {
+		got = append(got, metric)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, len(want), count)
+	require.Equal(t, want, got)
+
+	batch, err := readAllMetrics(dir)
+	require.NoError(t, err)
+	require.Equal(t, batch, got)
+}
+
+func TestStreamOrderedMetricsV1RejectsDisorderAcrossFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeMetricParquetV1(t, filepath.Join(dir, "observer-metrics-000000.parquet"), []recorderdef.MetricData{{Timestamp: 1001}}, 1)
+	writeMetricParquetV1(t, filepath.Join(dir, "observer-metrics-000001.parquet"), []recorderdef.MetricData{{Timestamp: 1000}}, 1)
+
+	count, err := streamOrderedMetrics(dir, FormatV1, func(recorderdef.MetricData) error { return nil })
+	require.Equal(t, 1, count)
+	require.ErrorContains(t, err, "observer-metrics-000001.parquet contains 1000 after 1001")
+}
+
+func BenchmarkLogParquetLoading(b *testing.B) {
+	dir := b.TempDir()
+	logs := make([]recorderdef.LogData, 20_000)
+	for i := range logs {
+		content := make([]byte, 512)
+		content[0] = byte(i)
+		logs[i] = recorderdef.LogData{
+			Source:      "run",
+			TimestampMs: int64(i),
+			Content:     content,
+			Status:      "info",
+			Hostname:    "host-a",
+			Tags:        []string{"service:api", "env:test"},
+		}
+	}
+	writeLogParquetV1(b, filepath.Join(dir, "observer-logs-000000.parquet"), logs, 1024)
+
+	b.Run("batch", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			runtime.GC()
+			var before runtime.MemStats
+			runtime.ReadMemStats(&before)
+			b.StartTimer()
+			loaded, err := readAllLogs(dir)
+			b.StopTimer()
+			require.NoError(b, err)
+			require.Len(b, loaded, len(logs))
+			benchmarkLogSink = loaded
+			runtime.GC()
+			var after runtime.MemStats
+			runtime.ReadMemStats(&after)
+			b.ReportMetric(float64(max(0, int64(after.HeapAlloc)-int64(before.HeapAlloc))), "retained-B")
+			benchmarkLogSink = nil
+		}
+	})
+
+	b.Run("stream", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			runtime.GC()
+			var before runtime.MemStats
+			runtime.ReadMemStats(&before)
+			b.StartTimer()
+			count, err := streamOrderedLogs(dir, FormatV1, func(recorderdef.LogData) error { return nil })
+			b.StopTimer()
+			require.NoError(b, err)
+			require.Equal(b, len(logs), count)
+			runtime.GC()
+			var after runtime.MemStats
+			runtime.ReadMemStats(&after)
+			b.ReportMetric(float64(max(0, int64(after.HeapAlloc)-int64(before.HeapAlloc))), "retained-B")
+		}
+	})
+}
+
+func writeLogParquetV1(t testing.TB, path string, logs []recorderdef.LogData, rowGroupSize int64) {
+	t.Helper()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "RunID", Type: arrow.BinaryTypes.String},
+		{Name: "Time", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "Content", Type: arrow.BinaryTypes.Binary, Nullable: true},
+		{Name: "Status", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "Hostname", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "Tags", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+	}, nil)
+
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer builder.Release()
+
+	runIDBuilder := builder.Field(0).(*array.StringBuilder)
+	timeBuilder := builder.Field(1).(*array.Int64Builder)
+	contentBuilder := builder.Field(2).(*array.BinaryBuilder)
+	statusBuilder := builder.Field(3).(*array.StringBuilder)
+	hostnameBuilder := builder.Field(4).(*array.StringBuilder)
+	tagsBuilder := builder.Field(5).(*array.ListBuilder)
+	tagValueBuilder := tagsBuilder.ValueBuilder().(*array.StringBuilder)
+
+	for _, entry := range logs {
+		runIDBuilder.Append(entry.Source)
+		timeBuilder.Append(entry.TimestampMs)
+		contentBuilder.Append(entry.Content)
+		statusBuilder.Append(entry.Status)
+		hostnameBuilder.Append(entry.Hostname)
+		if entry.Tags == nil {
+			tagsBuilder.AppendNull()
+		} else {
+			tagsBuilder.Append(true)
+			tagValueBuilder.AppendValues(entry.Tags, nil)
+		}
+	}
+
+	record := builder.NewRecord()
+	defer record.Release()
+	table := array.NewTableFromRecords(schema, []arrow.Record{record})
+	defer table.Release()
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(table, f, rowGroupSize, nil, pqarrow.DefaultWriterProps()))
+}
+
+func writeMetricParquetV1(t testing.TB, path string, metrics []recorderdef.MetricData, rowGroupSize int64) {
+	t.Helper()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "RunID", Type: arrow.BinaryTypes.String},
+		{Name: "Time", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "MetricName", Type: arrow.BinaryTypes.String},
+		{Name: "ValueFloat", Type: arrow.PrimitiveTypes.Float64},
+		{Name: "Tags", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+		{Name: "Dropped", Type: arrow.FixedWidthTypes.Boolean},
+	}, nil)
+
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer builder.Release()
+
+	runIDBuilder := builder.Field(0).(*array.StringBuilder)
+	timeBuilder := builder.Field(1).(*array.Int64Builder)
+	metricNameBuilder := builder.Field(2).(*array.StringBuilder)
+	valueBuilder := builder.Field(3).(*array.Float64Builder)
+	tagsBuilder := builder.Field(4).(*array.ListBuilder)
+	tagValueBuilder := tagsBuilder.ValueBuilder().(*array.StringBuilder)
+	droppedBuilder := builder.Field(5).(*array.BooleanBuilder)
+
+	for _, metric := range metrics {
+		runIDBuilder.Append(metric.Source)
+		timeBuilder.Append(metric.Timestamp * 1000)
+		metricNameBuilder.Append(metric.Name)
+		valueBuilder.Append(metric.Value)
+		if metric.Tags == nil {
+			tagsBuilder.AppendNull()
+		} else {
+			tagsBuilder.Append(true)
+			tagValueBuilder.AppendValues(metric.Tags, nil)
+		}
+		droppedBuilder.Append(metric.Dropped)
+	}
+
+	record := builder.NewRecord()
+	defer record.Release()
+	table := array.NewTableFromRecords(schema, []arrow.Record{record})
+	defer table.Release()
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(table, f, rowGroupSize, nil, pqarrow.DefaultWriterProps()))
+}

--- a/internal/qbranch/anomalydetection-testbench/bench/parquet_v2.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/parquet_v2.go
@@ -211,11 +211,10 @@ func readAllMetricsV2(dir string) ([]recorderdef.MetricData, error) {
 		return nil, fmt.Errorf("reading contexts: %w", err)
 	}
 
-	files, err := filepath.Glob(filepath.Join(dir, "metrics-*.parquet"))
+	files, err := findMetricParquetFilesV2(dir)
 	if err != nil {
-		return nil, fmt.Errorf("listing metrics files: %w", err)
+		return nil, err
 	}
-	sort.Strings(files)
 
 	var out []recorderdef.MetricData
 	collect := func(m recorderdef.MetricData) error {
@@ -227,17 +226,45 @@ func readAllMetricsV2(dir string) ([]recorderdef.MetricData, error) {
 			pkglog.Warnf("[parquet-v2] Skipping %s: %v", f, err)
 		}
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Timestamp < out[j].Timestamp })
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Timestamp < out[j].Timestamp })
 	return out, nil
+}
+
+func findMetricParquetFilesV2(dir string) ([]string, error) {
+	files, err := filepath.Glob(filepath.Join(dir, "metrics-*.parquet"))
+	if err != nil {
+		return nil, fmt.Errorf("listing metrics files: %w", err)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func streamAllMetricsV2(dir string, fn func(string, recorderdef.MetricData) error) error {
+	contexts, err := readContextsFileV2(filepath.Join(dir, "contexts.parquet"))
+	if err != nil {
+		return fmt.Errorf("reading contexts: %w", err)
+	}
+	files, err := findMetricParquetFilesV2(dir)
+	if err != nil {
+		return err
+	}
+	for _, filePath := range files {
+		if err := streamMetricFileV2(filePath, contexts, func(metric recorderdef.MetricData) error {
+			return fn(filePath, metric)
+		}); err != nil {
+			return fmt.Errorf("streaming %s: %w", filePath, err)
+		}
+	}
+	return nil
 }
 
 func streamMetricFileV2(filePath string, contexts map[uint64]contextEntryV2, fn func(recorderdef.MetricData) error) error {
 	info, err := os.Stat(filePath)
 	if err != nil {
-		return nil
+		return fmt.Errorf("statting %s: %w", filePath, err)
 	}
 	if info.Size() < minParquetFileSize {
-		return nil
+		return fmt.Errorf("%s is too small to be parquet (%d bytes)", filePath, info.Size())
 	}
 
 	f, err := os.Open(filePath)
@@ -259,7 +286,7 @@ func streamMetricFileV2(filePath string, contexts map[uint64]contextEntryV2, fn 
 	sourceIdx := findParquetColIdxV2(pf, "source")
 
 	if ctxKeyIdx < 0 || valueIdx < 0 || tsIdx < 0 {
-		return nil // not a v2 metrics file
+		return fmt.Errorf("missing one or more required columns: context_key, value, timestamp_ns")
 	}
 
 	ctxKeyMaxDef := s.Column(ctxKeyIdx).MaxDefinitionLevel()
@@ -400,6 +427,27 @@ func readAllLogsV2(dir string) ([]recorderdef.LogData, error) {
 		return nil, fmt.Errorf("reading contexts: %w", err)
 	}
 
+	files, err := findLogParquetFilesV2(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []recorderdef.LogData
+	collect := func(l recorderdef.LogData) error {
+		out = append(out, l)
+		return nil
+	}
+	for _, f := range files {
+		if err := streamLogFileV2(f, contexts, collect); err != nil {
+			pkglog.Warnf("[parquet-v2] Skipping %s: %v", f, err)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].TimestampMs < out[j].TimestampMs })
+	pkglog.Infof("[parquet-v2] Loaded %d logs from %s", len(out), dir)
+	return out, nil
+}
+
+func findLogParquetFilesV2(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
@@ -414,29 +462,35 @@ func readAllLogsV2(dir string) ([]recorderdef.LogData, error) {
 		}
 	}
 	sort.Strings(files)
+	return files, nil
+}
 
-	var out []recorderdef.LogData
-	collect := func(l recorderdef.LogData) error {
-		out = append(out, l)
-		return nil
+func streamAllLogsV2(dir string, fn func(string, recorderdef.LogData) error) error {
+	contexts, err := readContextsFileV2(filepath.Join(dir, "contexts.parquet"))
+	if err != nil {
+		return fmt.Errorf("reading contexts: %w", err)
 	}
-	for _, f := range files {
-		if err := streamLogFileV2(f, contexts, collect); err != nil {
-			pkglog.Warnf("[parquet-v2] Skipping %s: %v", f, err)
+	files, err := findLogParquetFilesV2(dir)
+	if err != nil {
+		return fmt.Errorf("listing v2 log parquet files: %w", err)
+	}
+	for _, filePath := range files {
+		if err := streamLogFileV2(filePath, contexts, func(entry recorderdef.LogData) error {
+			return fn(filePath, entry)
+		}); err != nil {
+			return fmt.Errorf("streaming %s: %w", filePath, err)
 		}
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].TimestampMs < out[j].TimestampMs })
-	pkglog.Infof("[parquet-v2] Loaded %d logs from %s", len(out), dir)
-	return out, nil
+	return nil
 }
 
 func streamLogFileV2(filePath string, contexts map[uint64]contextEntryV2, fn func(recorderdef.LogData) error) error {
 	info, err := os.Stat(filePath)
 	if err != nil {
-		return nil
+		return fmt.Errorf("statting %s: %w", filePath, err)
 	}
 	if info.Size() < minParquetFileSize {
-		return nil
+		return fmt.Errorf("%s is too small to be parquet (%d bytes)", filePath, info.Size())
 	}
 
 	f, err := os.Open(filePath)
@@ -457,7 +511,7 @@ func streamLogFileV2(filePath string, contexts map[uint64]contextEntryV2, fn fun
 	tsIdx := findParquetColIdxV2(pf, "timestamp_ns")
 
 	if ctxKeyIdx < 0 || contentIdx < 0 || tsIdx < 0 {
-		return nil // not a v2 log file
+		return fmt.Errorf("missing one or more required columns: context_key, content, timestamp_ns")
 	}
 
 	var ctxKeyMaxDef, contentMaxDef, tsMaxDef int16

--- a/internal/qbranch/anomalydetection-testbench/main.go
+++ b/internal/qbranch/anomalydetection-testbench/main.go
@@ -59,6 +59,9 @@ type CLIParams struct {
 
 	// ParquetFormat selects the parquet file layout. Empty string = auto-detect.
 	ParquetFormat bench.ParquetFormat
+
+	// BatchParquet retains and sorts raw metric and log rows in headless mode.
+	BatchParquet bool
 }
 
 func main() {
@@ -76,6 +79,7 @@ func main() {
 	skipDropped := flag.Bool("skip-dropped", true, "Skip metrics marked as dropped by the live observer's channel during parquet load")
 	logsOnly := flag.Bool("logs-only", false, "Load only log rows from scenarios; skip parquet metrics and trace stats (interactive and headless)")
 	parquetFormat := flag.String("parquet-format", "", "Parquet layout: v1 (observer-metrics-*/observer-logs-*), v2 (contexts.parquet + metrics-*/logs-*), or empty to auto-detect")
+	batchParquet := flag.Bool("batch-parquet", false, "Retain and sort all parquet rows instead of streaming them (headless mode only)")
 	baselineDuration := flag.String("baseline-duration", "", "Baseline analysis window duration (e.g. \"7m\", \"0\" to disable). Default: enabled with 10m window.")
 	muteNoisyMetrics := flag.Bool("mute-noisy-metrics", true, "Mute metrics that fire anomalies during the baseline window")
 	flag.Parse()
@@ -204,6 +208,7 @@ func main() {
 			SkipDroppedMetrics: *skipDropped,
 			LogsOnly:           *logsOnly,
 			ParquetFormat:      bench.ParquetFormat(*parquetFormat),
+			BatchParquet:       *batchParquet,
 		}),
 	)
 	if err != nil {
@@ -219,6 +224,10 @@ func run(
 	logger log.Component,
 	params CLIParams,
 ) error {
+	if err := validateCLIParams(params); err != nil {
+		return err
+	}
+
 	debug, ok := obs.(observerimpl.DebugView)
 	if !ok {
 		return fmt.Errorf("observer does not implement DebugView")
@@ -233,6 +242,7 @@ func run(
 		SkipDroppedMetrics: params.SkipDroppedMetrics,
 		LogsOnly:           params.LogsOnly,
 		ParquetFormat:      params.ParquetFormat,
+		StreamParquet:      params.Headless != "" && !params.BatchParquet,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create test bench: %v\n", err)
@@ -334,5 +344,12 @@ func run(
 		fmt.Fprintf(os.Stderr, "Error during shutdown: %v\n", err)
 	}
 
+	return nil
+}
+
+func validateCLIParams(params CLIParams) error {
+	if params.BatchParquet && params.Headless == "" {
+		return fmt.Errorf("--batch-parquet requires --headless")
+	}
 	return nil
 }

--- a/internal/qbranch/anomalydetection-testbench/main_test.go
+++ b/internal/qbranch/anomalydetection-testbench/main_test.go
@@ -26,29 +26,55 @@ import (
 )
 
 func TestFxApp(t *testing.T) {
+	testFxApp(t, CLIParams{})
+}
+
+func testFxApp(t *testing.T, params CLIParams) {
+	t.Helper()
 	fxutil.TestOneShot(t, func() {
-		err := fxutil.OneShot(run,
-			recordernoop.Module(),
-			observerfx.Module(),
-			reportertestbenchfx.Module(),
-			fx.Supply(option.None[workloadmetadef.Component]()),
-			fx.Supply(option.None[workloadfilterdef.Component]()),
-			fx.Supply(option.None[taggerdef.Component]()),
-			core.Bundle(),
-			// Mirror main(): force scorer dry-run on so NewComponent yields the full
-			// observerImpl (with DebugView) instead of the disabled stub, and
-			// keep the agent-internal log tap off so it never ingests scenario data.
-			fx.Decorate(func(c config.Component) config.Component {
-				c.Set("anomaly_detection.anomaly_scorer.dry_run.enabled", true, pkgconfigmodel.SourceAgentRuntime)
-				c.Set("anomaly_detection.logs.internal.enabled", false, pkgconfigmodel.SourceAgentRuntime)
-				return c
-			}),
-			fx.Supply(core.BundleParams{
-				ConfigParams: config.NewAgentParams(""),
-				LogParams:    log.ForOneShot("", "off", true),
-			}),
-			fx.Supply(CLIParams{}),
-		)
+		err := fxutil.OneShot(run, testbenchFXOptions(params)...)
+		require.NoError(t, err)
+	})
+}
+
+func runFxApp(t *testing.T, params CLIParams) {
+	t.Helper()
+	require.NoError(t, fxutil.OneShot(run, testbenchFXOptions(params)...))
+}
+
+func testbenchFXOptions(params CLIParams) []fx.Option {
+	return []fx.Option{
+		recordernoop.Module(),
+		observerfx.Module(),
+		reportertestbenchfx.Module(),
+		fx.Supply(option.None[workloadmetadef.Component]()),
+		fx.Supply(option.None[workloadfilterdef.Component]()),
+		fx.Supply(option.None[taggerdef.Component]()),
+		core.Bundle(),
+		// Mirror main(): force scorer dry-run on so NewComponent yields the full
+		// observerImpl (with DebugView) instead of the disabled stub, and
+		// keep the agent-internal log tap off so it never ingests scenario data.
+		fx.Decorate(func(c config.Component) config.Component {
+			c.Set("anomaly_detection.anomaly_scorer.dry_run.enabled", true, pkgconfigmodel.SourceAgentRuntime)
+			c.Set("anomaly_detection.logs.internal.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+			return c
+		}),
+		fx.Supply(core.BundleParams{
+			ConfigParams: config.NewAgentParams(""),
+			LogParams:    log.ForOneShot("", "off", true),
+		}),
+		fx.Supply(params),
+	}
+}
+
+func TestValidateCLIParams(t *testing.T) {
+	t.Run("batch override requires headless mode", func(t *testing.T) {
+		err := validateCLIParams(CLIParams{BatchParquet: true})
+		require.EqualError(t, err, "--batch-parquet requires --headless")
+	})
+
+	t.Run("batch override is accepted in headless mode", func(t *testing.T) {
+		err := validateCLIParams(CLIParams{BatchParquet: true, Headless: "scenario"})
 		require.NoError(t, err)
 	})
 }

--- a/internal/qbranch/anomalydetection-testbench/stream_parity_test.go
+++ b/internal/qbranch/anomalydetection-testbench/stream_parity_test.go
@@ -1,0 +1,147 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/stretchr/testify/require"
+
+	observerimpl "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/impl"
+	"github.com/DataDog/datadog-agent/internal/qbranch/anomalydetection-testbench/bench"
+)
+
+func TestHeadlessStreamParquetMatchesBatchOutput(t *testing.T) {
+	scenariosDir := t.TempDir()
+	parquetDir := filepath.Join(scenariosDir, "scenario", "parquet")
+	require.NoError(t, os.MkdirAll(parquetDir, 0o755))
+	writeParityLogParquet(t, filepath.Join(parquetDir, "observer-logs-000000.parquet"))
+	writeParityMetricParquet(t, filepath.Join(parquetDir, "observer-metrics-000000.parquet"))
+
+	settings := observerimpl.ComponentSettings{Baseline: observerimpl.BaselineConfig{Enabled: false}}
+	batchOutput := filepath.Join(t.TempDir(), "batch.json")
+	streamOutput := filepath.Join(t.TempDir(), "stream.json")
+
+	runFxApp(t, CLIParams{
+		ScenariosDir:      scenariosDir,
+		Headless:          "scenario",
+		Output:            batchOutput,
+		BatchParquet:      true,
+		ComponentSettings: settings,
+	})
+	runFxApp(t, CLIParams{
+		ScenariosDir:      scenariosDir,
+		Headless:          "scenario",
+		Output:            streamOutput,
+		ComponentSettings: settings,
+	})
+
+	batch := readObserverOutput(t, batchOutput)
+	stream := readObserverOutput(t, streamOutput)
+	// Processing durations vary between runs; counts and observer results must match.
+	batch.Metadata.Stats.DetectorStats = nil
+	stream.Metadata.Stats.DetectorStats = nil
+	require.Equal(t, batch, stream)
+}
+
+func readObserverOutput(t *testing.T, path string) bench.ObserverOutput {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var output bench.ObserverOutput
+	require.NoError(t, json.Unmarshal(data, &output))
+	require.NotNil(t, output.Metadata.Stats)
+	return output
+}
+
+func writeParityLogParquet(t *testing.T, path string) {
+	t.Helper()
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "RunID", Type: arrow.BinaryTypes.String},
+		{Name: "Time", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "Content", Type: arrow.BinaryTypes.Binary},
+		{Name: "Status", Type: arrow.BinaryTypes.String},
+		{Name: "Hostname", Type: arrow.BinaryTypes.String},
+		{Name: "Tags", Type: arrow.ListOf(arrow.BinaryTypes.String)},
+	}, nil)
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer builder.Release()
+
+	runIDBuilder := builder.Field(0).(*array.StringBuilder)
+	timeBuilder := builder.Field(1).(*array.Int64Builder)
+	contentBuilder := builder.Field(2).(*array.BinaryBuilder)
+	statusBuilder := builder.Field(3).(*array.StringBuilder)
+	hostnameBuilder := builder.Field(4).(*array.StringBuilder)
+	tagsBuilder := builder.Field(5).(*array.ListBuilder)
+	tagValueBuilder := tagsBuilder.ValueBuilder().(*array.StringBuilder)
+
+	for i := 0; i < 120; i++ {
+		runIDBuilder.Append("run")
+		timeBuilder.Append(int64(1_000_000 + i*1_000))
+		contentBuilder.Append([]byte("request failed while connecting to database"))
+		statusBuilder.Append("error")
+		hostnameBuilder.Append("host-a")
+		tagsBuilder.Append(true)
+		tagValueBuilder.AppendValues([]string{"service:api", "env:test"}, nil)
+	}
+
+	record := builder.NewRecord()
+	defer record.Release()
+	table := array.NewTableFromRecords(schema, []arrow.Record{record})
+	defer table.Release()
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(table, f, 8, nil, pqarrow.DefaultWriterProps()))
+}
+
+func writeParityMetricParquet(t *testing.T, path string) {
+	t.Helper()
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "RunID", Type: arrow.BinaryTypes.String},
+		{Name: "Time", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "MetricName", Type: arrow.BinaryTypes.String},
+		{Name: "ValueFloat", Type: arrow.PrimitiveTypes.Float64},
+		{Name: "Tags", Type: arrow.ListOf(arrow.BinaryTypes.String)},
+		{Name: "Dropped", Type: arrow.FixedWidthTypes.Boolean},
+	}, nil)
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer builder.Release()
+
+	runIDBuilder := builder.Field(0).(*array.StringBuilder)
+	timeBuilder := builder.Field(1).(*array.Int64Builder)
+	metricNameBuilder := builder.Field(2).(*array.StringBuilder)
+	valueBuilder := builder.Field(3).(*array.Float64Builder)
+	tagsBuilder := builder.Field(4).(*array.ListBuilder)
+	tagValueBuilder := tagsBuilder.ValueBuilder().(*array.StringBuilder)
+	droppedBuilder := builder.Field(5).(*array.BooleanBuilder)
+
+	for i := 0; i < 120; i++ {
+		runIDBuilder.Append("run")
+		timeBuilder.Append(int64(1_000_000 + i*1_000))
+		metricNameBuilder.Append("system.cpu.user")
+		valueBuilder.Append(float64(i))
+		tagsBuilder.Append(true)
+		tagValueBuilder.Append("host:a")
+		droppedBuilder.Append(false)
+	}
+
+	record := builder.NewRecord()
+	defer record.Release()
+	table := array.NewTableFromRecords(schema, []arrow.Record{record})
+	defer table.Release()
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, pqarrow.WriteTable(table, f, 8, nil, pqarrow.DefaultWriterProps()))
+}

--- a/tasks/anomalydetection.py
+++ b/tasks/anomalydetection.py
@@ -96,6 +96,7 @@ def launch_testbench(
     disable: str = "",
     timeout: int = 0,
     logs_only: bool = False,
+    batch_parquet: bool = False,
 ):
     """
     Launches the anomalydetection-testbench backend (and UI in interactive mode).
@@ -112,6 +113,7 @@ def launch_testbench(
         disable: Comma-separated components to disable (passed as --disable).
         timeout: Kill the headless process after this many seconds (0 = no limit).
         logs_only: Pass --logs-only (skip parquet metrics and trace stats).
+        batch_parquet: Pass --batch-parquet for unordered recordings (headless mode only).
     """
     if build:
         print("Building anomalydetection-testbench...")
@@ -122,6 +124,8 @@ def launch_testbench(
         flags += " --verbose"
     if logs_only:
         flags += " --logs-only"
+    if batch_parquet:
+        flags += " --batch-parquet"
     if config:
         flags += f" --config {shlex.quote(config)}"
     else:


### PR DESCRIPTION
### What does this PR do?

- Streams metric/log Parquet rows directly into observer storage for headless testbench runs.
- Keeps the interactive UI on retained batch loading so component toggles and raw-log views continue to work.
- Validates monotonic timestamps across batches and files, allowing equal timestamps.
- Adds `--batch-parquet` as a fallback for unordered recordings.
- Adds loader ordering/parity tests, a full headless batch-versus-stream output parity test, and a memory benchmark.

### Motivation

Headless evals previously used the Observer replay pipeline, which materialized the entire Parquet dataset as an in-memory Arrow table, converted its rows into Go observation structures, and retained those observations in Observer replay storage. Replay then processed the fully retained dataset. These overlapping in-memory representations caused very high peak memory usage. 

These changes are intended for DDEval, but also decreases memory usage for local runs (all headless runs). DDEval in particular needs a streaming path to reduce peak memory and OOM risk when many scenarios run concurrently.

### Describe how you validated your changes

- `dda inv test --targets=./internal/qbranch/anomalydetection-testbench/...`
- `dda inv anomalydetection.build-testbench`
- Full metrics-and-logs headless output parity between batch and streaming modes, excluding runtime timing measurements.
- Pre-commit hooks: Go formatting, Python linting, copyright, and module checks.
- Pre-push hooks: `go-mod-tidy`, Go tests, Go lint, and module replacement checks.

### Additional Notes

Headless runs now stream by default. Inputs must be globally monotonic within each data type; equal timestamps are accepted. Use `--batch-parquet` to retain and globally sort unordered local recordings.
