### PR TITLE
feat(config): register data_plane.serializer_zstd_compressor_level

### DIFF
--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -7092,6 +7092,14 @@ properties:
         node_type: setting
         type: string
         default: tcp://0.0.0.0:5101
+      serializer_zstd_compressor_level:
+        node_type: setting
+        type: integer
+        default: 3
+        comment: |-
+          ADP-specific zstd compression level, distinct from the core Agent's serializer_zstd_compressor_level
+          (default 1). ADP defaults to 3 for ~6% smaller payloads without a net CPU increase, since ADP is
+          more efficient than the Agent. Forwarded to ADP over the config stream.
       stop_timeout:
         node_type: setting
         type: integer

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1099,6 +1099,10 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("data_plane.otlp.proxy.logs.enabled", true)
 	// When the ADP OTLP proxy is enabled, ADP owns the gRPC endpoint configured for the receiver (default :4317) and the core agent uses the endpoint below
 	config.BindEnvAndSetDefault("data_plane.otlp.proxy.receiver.protocols.grpc.endpoint", "127.0.0.1:4319")
+	// ADP-specific zstd compression level, distinct from the core Agent's serializer_zstd_compressor_level
+	// (default 1). ADP defaults to 3 for ~6% smaller payloads without a net CPU increase, since ADP is
+	// more efficient than the Agent. Forwarded to ADP over the config stream.
+	config.BindEnvAndSetDefault("data_plane.serializer_zstd_compressor_level", 3)
 
 	// Agent Workload Filtering config
 	config.BindEnvAndSetDefault("cel_workload_exclude", []interface{}{})

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -956,6 +956,7 @@ func TestDataPlaneDefaults(t *testing.T) {
 	assert.True(t, cfg.GetBool("data_plane.remote_agent_enabled"))
 	assert.Equal(t, "tcp://0.0.0.0:5100", cfg.GetString("data_plane.api_listen_address"))
 	assert.Equal(t, "tcp://0.0.0.0:5101", cfg.GetString("data_plane.secure_api_listen_address"))
+	assert.Equal(t, 3, cfg.GetInt("data_plane.serializer_zstd_compressor_level"))
 	assert.False(t, cfg.GetBool("data_plane.telemetry_enabled"))
 	assert.Equal(t, "tcp://0.0.0.0:5102", cfg.GetString("data_plane.telemetry_listen_addr"))
 	assert.Equal(t, defaultpaths.GetDefaultDataPlaneLogFile(), cfg.GetString("data_plane.log_file"))


### PR DESCRIPTION
## Summary

Registers a new ADP-specific configuration key `data_plane.serializer_zstd_compressor_level` (default 3) so the Agent forwards it to the agent-data-plane process over the config stream. This lets ADP default to zstd compression level 3 — distinct from the core Agent's `serializer_zstd_compressor_level` (default 1) — which produces smaller payloads without a net CPU increase, since ADP is more efficient than the core Agent.

This is the Core Agent half of the change. The companion agent-data-plane PR that consumes this key is DataDog/saluki#2103.

## Test plan

- [x] `go test -tags test ./pkg/config/setup/ -run TestDataPlaneDefaults` passes (extended to assert the new default of 3)
- [x] `go test -tags test ./pkg/config/schema/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)