### PR TITLE
Only retry flare submission on connection-level errors

### DIFF
--- a/comp/core/flare/helpers/send_flare.go
+++ b/comp/core/flare/helpers/send_flare.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -298,18 +299,20 @@ func SendTo(cfg pkgconfigmodel.Reader, archivePath, caseID, email, apiKey, url s
 }
 
 // isRetryableFlareError reports whether a transport failure (no HTTP response) is safe to
-// retry: only connect/DNS-phase errors, where the non-idempotent flare POST never landed.
+// retry: only DNS- and dial-phase failures, where the non-idempotent POST never left.
 func isRetryableFlareError(err error) bool {
 	if err == nil {
 		return false
 	}
-
-	errStr := strings.ToLower(err.Error())
-	return strings.Contains(errStr, "connection refused") ||
-		strings.Contains(errStr, "network unreachable") ||
-		strings.Contains(errStr, "no route to host") ||
-		strings.Contains(errStr, "no such host") ||
-		strings.Contains(errStr, "temporary failure in name resolution")
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return opErr.Op == "dial"
+	}
+	return false
 }
 
 // buildFlareBaseURL returns the versioned flare domain for a given raw endpoint URL.

--- a/comp/core/flare/helpers/send_flare.go
+++ b/comp/core/flare/helpers/send_flare.go
@@ -312,7 +312,8 @@ func isRetryableFlareError(err error) bool {
 	if errors.As(err, &opErr) {
 		return opErr.Op == "dial"
 	}
-	return false
+	// net/http's TLS handshake timeout error is unexported, so match on its message.
+	return strings.Contains(err.Error(), "net/http: TLS handshake timeout")
 }
 
 // buildFlareBaseURL returns the versioned flare domain for a given raw endpoint URL.

--- a/comp/core/flare/helpers/send_flare.go
+++ b/comp/core/flare/helpers/send_flare.go
@@ -274,13 +274,15 @@ func SendTo(cfg pkgconfigmodel.Reader, archivePath, caseID, email, apiKey, url s
 	for attempt := 3; attempt > 0; attempt-- {
 		r, err := readAndPostFlareFile(archivePath, caseID, email, hostname, url, source, client, apiKey)
 		if err != nil {
-			// Always close the response body if it exists
+			// A response (even 5xx) means the server received the non-idempotent POST, so
+			// don't retry; only a transport failure with no response is a retry candidate.
+			responseReceived := r != nil
 			if r != nil {
 				r.Body.Close()
 			}
 			lastErr = err
 
-			if !isRetryableFlareError(err) {
+			if responseReceived || !isRetryableFlareError(err) {
 				return "", err
 			}
 			log.Warn("Failed to send flare, retrying in 1 second")
@@ -295,9 +297,8 @@ func SendTo(cfg pkgconfigmodel.Reader, archivePath, caseID, email, apiKey, url s
 	return "", fmt.Errorf("failed to send flare after 3 attempts: %w", lastErr)
 }
 
-// isRetryableFlareError reports whether a failed flare POST is safe to retry. The POST
-// creates a Zendesk ticket and is not idempotent, so we retry only on connect/DNS-phase
-// failures, where the request provably never reached the server.
+// isRetryableFlareError reports whether a transport failure (no HTTP response) is safe to
+// retry: only connect/DNS-phase errors, where the non-idempotent flare POST never landed.
 func isRetryableFlareError(err error) bool {
 	if err == nil {
 		return false

--- a/comp/core/flare/helpers/send_flare.go
+++ b/comp/core/flare/helpers/send_flare.go
@@ -278,7 +278,7 @@ func SendTo(cfg pkgconfigmodel.Reader, archivePath, caseID, email, apiKey, url s
 			// A response (even 5xx) means the server received the non-idempotent POST, so
 			// don't retry; only a transport failure with no response is a retry candidate.
 			responseReceived := r != nil
-			if r != nil {
+			if responseReceived {
 				r.Body.Close()
 			}
 			lastErr = err

--- a/comp/core/flare/helpers/send_flare.go
+++ b/comp/core/flare/helpers/send_flare.go
@@ -275,14 +275,12 @@ func SendTo(cfg pkgconfigmodel.Reader, archivePath, caseID, email, apiKey, url s
 		r, err := readAndPostFlareFile(archivePath, caseID, email, hostname, url, source, client, apiKey)
 		if err != nil {
 			// Always close the response body if it exists
-			statusCode := 0
 			if r != nil {
-				statusCode = r.StatusCode
 				r.Body.Close()
 			}
 			lastErr = err
 
-			if !isRetryableFlareError(err, statusCode) {
+			if !isRetryableFlareError(err) {
 				return "", err
 			}
 			log.Warn("Failed to send flare, retrying in 1 second")
@@ -297,22 +295,20 @@ func SendTo(cfg pkgconfigmodel.Reader, archivePath, caseID, email, apiKey, url s
 	return "", fmt.Errorf("failed to send flare after 3 attempts: %w", lastErr)
 }
 
-func isRetryableFlareError(err error, statusCode int) bool {
+// isRetryableFlareError reports whether a failed flare POST is safe to retry. The POST
+// creates a Zendesk ticket and is not idempotent, so we retry only on connect/DNS-phase
+// failures, where the request provably never reached the server.
+func isRetryableFlareError(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	if statusCode >= 500 && statusCode < 600 {
-		return true
-	}
-
 	errStr := strings.ToLower(err.Error())
-
-	return strings.Contains(errStr, "timeout") ||
-		strings.Contains(errStr, "connection refused") ||
-		strings.Contains(errStr, "connection reset") ||
+	return strings.Contains(errStr, "connection refused") ||
 		strings.Contains(errStr, "network unreachable") ||
-		strings.Contains(errStr, "temporary failure")
+		strings.Contains(errStr, "no route to host") ||
+		strings.Contains(errStr, "no such host") ||
+		strings.Contains(errStr, "temporary failure in name resolution")
 }
 
 // buildFlareBaseURL returns the versioned flare domain for a given raw endpoint URL.

--- a/comp/core/flare/helpers/send_flare_test.go
+++ b/comp/core/flare/helpers/send_flare_test.go
@@ -445,6 +445,12 @@ func TestIsRetryableFlareError(t *testing.T) {
 			expected: true,
 		},
 		{
+			// TLS handshake failed after dial succeeded; no request bytes were written.
+			name:     "tls handshake timeout",
+			err:      &url.Error{Op: "Post", URL: "https://example.com", Err: errors.New("net/http: TLS handshake timeout")},
+			expected: true,
+		},
+		{
 			// Request was sent, so it may have been processed.
 			name:     "read connection reset not retryable",
 			err:      &net.OpError{Op: "read", Net: "tcp", Err: errors.New("connection reset by peer")},

--- a/comp/core/flare/helpers/send_flare_test.go
+++ b/comp/core/flare/helpers/send_flare_test.go
@@ -9,8 +9,10 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -411,47 +413,52 @@ func TestIsRetryableFlareError(t *testing.T) {
 			expected: false,
 		},
 		{
-			// A timeout may occur after the request reached the server and a ticket was
-			// created, so retrying it risks a duplicate: not retryable.
-			name:     "timeout error not retryable",
-			err:      errors.New("context deadline exceeded (Client.Timeout exceeded while awaiting headers)"),
+			// url.Error wrapping, as http.Client returns it.
+			name:     "dial connection refused",
+			err:      &url.Error{Op: "Post", URL: "https://example.com", Err: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connect: connection refused")}},
+			expected: true,
+		},
+		{
+			name:     "dial network unreachable",
+			err:      &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("network unreachable")},
+			expected: true,
+		},
+		{
+			// Connect-phase timeout: connection never established.
+			name:     "dial timeout",
+			err:      &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("i/o timeout")},
+			expected: true,
+		},
+		{
+			name:     "dns i/o timeout",
+			err:      &net.DNSError{Err: "i/o timeout", Name: "example.com", IsTimeout: true},
+			expected: true,
+		},
+		{
+			name:     "dns server misbehaving",
+			err:      &net.DNSError{Err: "server misbehaving", Name: "example.com", IsTemporary: true},
+			expected: true,
+		},
+		{
+			name:     "dns no such host",
+			err:      &net.DNSError{Err: "no such host", Name: "example.com", IsNotFound: true},
+			expected: true,
+		},
+		{
+			// Request was sent, so it may have been processed.
+			name:     "read connection reset not retryable",
+			err:      &net.OpError{Op: "read", Net: "tcp", Err: errors.New("connection reset by peer")},
 			expected: false,
 		},
 		{
-			name:     "connection refused error",
-			err:      errors.New("dial tcp 127.0.0.1:8080: connection refused"),
-			expected: true,
-		},
-		{
-			// A reset can happen mid/after transmission, so the server may already have
-			// created the ticket: not retryable.
-			name:     "connection reset error not retryable",
-			err:      errors.New("read tcp 127.0.0.1:8080: connection reset by peer"),
+			// Can fire after the request was sent.
+			name:     "client timeout not retryable",
+			err:      &url.Error{Op: "Post", URL: "https://example.com", Err: errors.New("context deadline exceeded (Client.Timeout exceeded while awaiting headers)")},
 			expected: false,
 		},
 		{
-			name:     "network unreachable error",
-			err:      errors.New("dial tcp 192.168.1.1:8080: network unreachable"),
-			expected: true,
-		},
-		{
-			name:     "temporary failure error",
-			err:      errors.New("temporary failure in name resolution"),
-			expected: true,
-		},
-		{
-			name:     "non-retryable error",
+			name:     "generic error not retryable",
 			err:      errors.New("invalid request format"),
-			expected: false,
-		},
-		{
-			name:     "authentication error",
-			err:      errors.New("authentication failed"),
-			expected: false,
-		},
-		{
-			name:     "validation error",
-			err:      errors.New("validation failed"),
 			expected: false,
 		},
 	}

--- a/comp/core/flare/helpers/send_flare_test.go
+++ b/comp/core/flare/helpers/send_flare_test.go
@@ -297,6 +297,16 @@ func TestSendToRetryLogic(t *testing.T) {
 			expectedError:    "HTTP 500",
 		},
 		{
+			// A 5xx body embedding a dial error must not be treated as a transport failure.
+			name: "no retry on 5xx whose body mentions a dial error",
+			serverBehavior: func(_ int) (int, string, time.Duration) {
+				return 503, "upstream connect error or disconnect/reset before headers: connection refused", 0
+			},
+			expectedAttempts: 1,
+			expectSuccess:    false,
+			expectedError:    "HTTP 503",
+		},
+		{
 			name: "non-retryable 400 error",
 			serverBehavior: func(_ int) (int, string, time.Duration) {
 				return 400, "Bad Request", 0

--- a/comp/core/flare/helpers/send_flare_test.go
+++ b/comp/core/flare/helpers/send_flare_test.go
@@ -286,39 +286,15 @@ func TestSendToRetryLogic(t *testing.T) {
 			expectSuccess:    true,
 		},
 		{
-			name: "success on second attempt after 500 error",
-			serverBehavior: func(attempt int) (int, string, time.Duration) {
-				if attempt == 1 {
-					return 500, "Internal Server Error", 0
-				}
-				return 200, `{"case_id": 1234, "message": "Your logs were successfully uploaded"}`, 0
-			},
-			expectedAttempts: 2,
-			expectSuccess:    true,
-		},
-		{
-			name: "success on third attempt after 502 and 503 errors",
-			serverBehavior: func(attempt int) (int, string, time.Duration) {
-				switch attempt {
-				case 1:
-					return 502, "Bad Gateway", 0
-				case 2:
-					return 503, "Service Unavailable", 0
-				default:
-					return 200, `{"case_id": 1234, "message": "Your logs were successfully uploaded"}`, 0
-				}
-			},
-			expectedAttempts: 3,
-			expectSuccess:    true,
-		},
-		{
-			name: "exhausted retries with 5xx errors",
+			// A 5xx means the server received the request and may already have created a
+			// ticket; the flare POST is not idempotent, so it must not be retried.
+			name: "no retry on 500 error (non-idempotent create)",
 			serverBehavior: func(_ int) (int, string, time.Duration) {
 				return 500, "Internal Server Error", 0
 			},
-			expectedAttempts: 3,
+			expectedAttempts: 1,
 			expectSuccess:    false,
-			expectedError:    "failed to send flare after 3 attempts",
+			expectedError:    "HTTP 500",
 		},
 		{
 			name: "non-retryable 400 error",
@@ -415,70 +391,64 @@ func TestSendToRetryLogic(t *testing.T) {
 }
 func TestIsRetryableFlareError(t *testing.T) {
 	testCases := []struct {
-		name      string
-		err       error
-		errorCode int
-		expected  bool
+		name     string
+		err      error
+		expected bool
 	}{
 		{
-			name:      "nil error",
-			err:       nil,
-			errorCode: 200,
-			expected:  false,
+			name:     "nil error",
+			err:      nil,
+			expected: false,
 		},
 		{
-			name:      "timeout error",
-			err:       errors.New("context deadline exceeded (Client.Timeout exceeded while awaiting headers)"),
-			errorCode: 408,
-			expected:  true,
+			// A timeout may occur after the request reached the server and a ticket was
+			// created, so retrying it risks a duplicate: not retryable.
+			name:     "timeout error not retryable",
+			err:      errors.New("context deadline exceeded (Client.Timeout exceeded while awaiting headers)"),
+			expected: false,
 		},
 		{
-			name:      "connection refused error",
-			err:       errors.New("dial tcp 127.0.0.1:8080: connection refused"),
-			errorCode: 503,
-			expected:  true,
+			name:     "connection refused error",
+			err:      errors.New("dial tcp 127.0.0.1:8080: connection refused"),
+			expected: true,
 		},
 		{
-			name:      "connection reset error",
-			err:       errors.New("read tcp 127.0.0.1:8080: connection reset by peer"),
-			errorCode: 500,
-			expected:  true,
+			// A reset can happen mid/after transmission, so the server may already have
+			// created the ticket: not retryable.
+			name:     "connection reset error not retryable",
+			err:      errors.New("read tcp 127.0.0.1:8080: connection reset by peer"),
+			expected: false,
 		},
 		{
-			name:      "network unreachable error",
-			err:       errors.New("dial tcp 192.168.1.1:8080: network unreachable"),
-			errorCode: 504,
-			expected:  true,
+			name:     "network unreachable error",
+			err:      errors.New("dial tcp 192.168.1.1:8080: network unreachable"),
+			expected: true,
 		},
 		{
-			name:      "temporary failure error",
-			err:       errors.New("temporary failure in name resolution"),
-			errorCode: 500,
-			expected:  true,
+			name:     "temporary failure error",
+			err:      errors.New("temporary failure in name resolution"),
+			expected: true,
 		},
 		{
-			name:      "non-retryable error",
-			err:       errors.New("invalid request format"),
-			errorCode: 400,
-			expected:  false,
+			name:     "non-retryable error",
+			err:      errors.New("invalid request format"),
+			expected: false,
 		},
 		{
-			name:      "authentication error",
-			err:       errors.New("authentication failed"),
-			errorCode: 401,
-			expected:  false,
+			name:     "authentication error",
+			err:      errors.New("authentication failed"),
+			expected: false,
 		},
 		{
-			name:      "validation error",
-			err:       errors.New("validation failed"),
-			errorCode: 422,
-			expected:  false,
+			name:     "validation error",
+			err:      errors.New("validation failed"),
+			expected: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := isRetryableFlareError(tc.err, tc.errorCode)
+			result := isRetryableFlareError(tc.err)
 			assert.Equal(t, tc.expected, result, "isRetryableFlareError result mismatch")
 		})
 	}
@@ -487,43 +457,7 @@ func TestIsRetryableFlareError(t *testing.T) {
 func TestSendToWithNetworkErrors(t *testing.T) {
 	cfg := config.NewMock(t)
 
-	t.Run("retry on 500 errors then succeed", func(t *testing.T) {
-		attemptCount := 0
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == "HEAD" && r.URL.Path == "/support/flare/12345" {
-				w.Header().Set("Location", "/post-target")
-				w.WriteHeader(307)
-				return
-			}
-			if r.Method == "HEAD" && r.URL.Path == "/post-target" {
-				w.WriteHeader(200)
-				return
-			}
-			if r.Method == "POST" && r.URL.Path == "/post-target" {
-				attemptCount++
-
-				if attemptCount <= 2 {
-					w.WriteHeader(500)
-					w.Write([]byte("Internal Server Error"))
-					return
-				}
-
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(200)
-				w.Write([]byte(`{"case_id": 12345, "message": "Your logs were successfully uploaded"}`))
-			}
-		}))
-		defer server.Close()
-
-		result, err := SendTo(cfg, "./testdata/blank.zip", "12345", "test@example.com", "test-api-key", server.URL, FlareSource{})
-
-		assert.NoError(t, err, "Expected success after retries")
-		assert.Contains(t, result, "Your logs were successfully uploaded", "Expected success message")
-		assert.Equal(t, 3, attemptCount, "Expected 3 attempts before success")
-	})
-
-	t.Run("retry exhausted after max attempts", func(t *testing.T) {
+	t.Run("no retry on 500 error (non-idempotent create)", func(t *testing.T) {
 		attemptCount := 0
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -546,9 +480,9 @@ func TestSendToWithNetworkErrors(t *testing.T) {
 
 		result, err := SendTo(cfg, "./testdata/blank.zip", "12345", "test@example.com", "test-api-key", server.URL, FlareSource{})
 
-		assert.Error(t, err, "Expected error after exhausting retries")
-		assert.Contains(t, err.Error(), "failed to send flare after", "Expected retry exhaustion error")
-		assert.Equal(t, 3, attemptCount, "Expected 3 attempts (maxTries)")
+		assert.Error(t, err, "Expected error")
+		assert.Contains(t, err.Error(), "HTTP 500", "Expected the 500 to surface directly, not a retry-exhaustion error")
+		assert.Equal(t, 1, attemptCount, "A 5xx must not be retried: the ticket may already have been created")
 		assert.Empty(t, result, "Expected empty result on error")
 	})
 


### PR DESCRIPTION
### What does this PR do?

Narrows the flare-upload retry to failures where the request never reached the server. We retry only when there's no HTTP response and the transport error is a DNS- or dial-phase failure (classified via `errors.As` on `*net.DNSError` / `*net.OpError{Op:"dial"}`); any HTTP response, including a 5xx, is treated as received and not retried. The now-unused `statusCode` argument is dropped.

### Motivation

Posting a flare creates a Zendesk ticket and is not idempotent. Support saw single flare submissions produce 2–3 duplicate tickets ([Slack thread](https://dd.slack.com/archives/C04U1B77E84/p1783964815562099)).

On a timeout or 5xx the request may already have reached the backend and created a ticket, so retrying it duplicates. We now retry only when the connection was never established — DNS resolution or dial failures, where the request provably never left. The trade-off is deliberate: a transient 5xx/timeout now surfaces as a resubmittable failure rather than a silent duplicate ticket.

There was also a second, redundant retry of the same POST on the backend, added back when the agent didn't retry (before #38631). The companion PR removes it so the agent owns the single retry: https://github.com/ddoghq/dd-source/pull/18873.

### Describe how you validated your changes

unit tests
