### PR TITLE
Drop dead `.rust_internal_registry` extends from package builds

### DIFF
--- a/.gitlab/build/package_build/installer.yml
+++ b/.gitlab/build/package_build/installer.yml
@@ -3,9 +3,7 @@
 # Datadog installer payloads
 #
 .common_build_oci:
-  extends:
-    - .bazel:defs:cache:omnibus-transition
-    - .rust_internal_registry
+  extends: [ .bazel:defs:cache:omnibus-transition ]
   script:
     - AGENT_VERSION="$(dda inv agent.version -u)-1" || exit $?
     - export INSTALL_DIR=/opt/datadog-packages/datadog-agent/"$AGENT_VERSION"

--- a/.gitlab/build/package_build/linux.yml
+++ b/.gitlab/build/package_build/linux.yml
@@ -16,9 +16,7 @@
   - !reference [.upload_sbom_artifacts]
 
 .agent_build_common:
-  extends:
-    - .bazel:defs:cache:omnibus-transition
-    - .rust_internal_registry  # TODO(agent-build): bazelify
+  extends: [ .bazel:defs:cache:omnibus-transition ]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success


### PR DESCRIPTION
### What does this PR do?
Remove the `.rust_internal_registry` extend from `.agent_build_common` (`linux.yml`) and `.common_build_oci` (`installer.yml`).

### Motivation
Both templates only run `dda inv -- -e omnibus.build`.
That builds `dd-procmgrd`/`dd-procmgr` and `pkg/discovery/module/rust` via respectively:
- `bazel run //pkg/procmgr/rust:install` (since #46834),
- `bazel run //pkg/discovery/module/rust:install` (since #46837).

`.rust_internal_registry` (`.adms/rust/gitlab.yaml`) only rewrites `.cargo/config.toml`, which nothing in this pipeline reads anymore.

### Describe how you validated your changes
Ran `dda inv linter.gitlab-ci`, which passed across all 9 tested contexts.

### Additional Notes
Last occurrence of `.rust_internal_registry` is used in a redundant job that a dedicated PR will propose to remove.