### PR TITLE
[ABLD-495] Enable //pkg/network/go/bininspect tests.

### DIFF
--- a/pkg/network/go/BUILD.bazel
+++ b/pkg/network/go/BUILD.bazel
@@ -1,0 +1,1 @@
+# gazelle:dd_agent_go_test on

--- a/pkg/network/go/bininspect/BUILD.bazel
+++ b/pkg/network/go/bininspect/BUILD.bazel
@@ -55,9 +55,10 @@ dd_agent_go_test(
     ],
     data = ["//pkg/network/usm/testdata/site-packages/ddtrace:testdata"],
     embed = [":bininspect"],
-    flavors = ["base"],
-    tags = ["manual"],  # keep
-    cgo = True,
+    flavors = ["base"],  # keep
+    # Use static linking to prevent symbol stripping. The test introspects the
+    # binary to look at its symbols.
+    static = "on",  # keep
     target_compatible_with = ["@platforms//os:linux"],
     deps = select({
         "@rules_go//go/platform:android": [

--- a/pkg/network/go/bininspect/BUILD.bazel
+++ b/pkg/network/go/bininspect/BUILD.bazel
@@ -52,14 +52,10 @@ go_test(
         "pclntab_test.go",
         "symbols_test.go",
     ],
+    data = ["//pkg/network/usm/testdata/site-packages/ddtrace:testdata"],
     embed = [":bininspect"],
     gotags = ["test"],
-    # The symbols_test.go tests read fixtures from ../../usm/testdata/ at
-    # runtime. pkg/network/usm is still gazelle:exclude-d, so we can't
-    # express the data dep in bazel yet. Skip the test by default; it
-    # still runs under `dda inv test` (which uses the source tree
-    # directly).
-    tags = ["manual"],  # keep
+    target_compatible_with = ["@platforms//os:linux"],
     deps = select({
         "@rules_go//go/platform:android": [
             "//pkg/network/protocols/http/testutil",

--- a/pkg/network/go/bininspect/BUILD.bazel
+++ b/pkg/network/go/bininspect/BUILD.bazel
@@ -56,6 +56,8 @@ dd_agent_go_test(
     data = ["//pkg/network/usm/testdata/site-packages/ddtrace:testdata"],
     embed = [":bininspect"],
     flavors = ["base"],
+    tags = ["manual"],  # keep
+    cgo = True,
     target_compatible_with = ["@platforms//os:linux"],
     deps = select({
         "@rules_go//go/platform:android": [

--- a/pkg/network/go/bininspect/BUILD.bazel
+++ b/pkg/network/go/bininspect/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "bininspect",
@@ -46,7 +47,7 @@ go_library(
     }),
 )
 
-go_test(
+dd_agent_go_test(
     name = "bininspect_test",
     srcs = [
         "pclntab_test.go",
@@ -54,7 +55,7 @@ go_test(
     ],
     data = ["//pkg/network/usm/testdata/site-packages/ddtrace:testdata"],
     embed = [":bininspect"],
-    gotags = ["test"],
+    flavors = ["base"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = select({
         "@rules_go//go/platform:android": [


### PR DESCRIPTION
### What does this PR do?

- enables //pkg/network/go/bininspect tests by removing the manual tag and providing the testdata link.
