### PR TITLE
fix(windows): preserve service-test timeout overrides

### DIFF
--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -551,6 +551,12 @@ func (s *baseStartStopSuite) TestAgentStopsAllServices() {
 }
 
 func (s *baseStartStopSuite) SetupSuite() {
+	// Preserve timeout scales explicitly configured by specialized suites, such as
+	// the Driver Verifier suites. The zero value means no scale was configured.
+	if s.timeoutScale == 0 {
+		s.timeoutScale = defaultTimeoutScale
+	}
+
 	s.BaseSuite.SetupSuite()
 	// SetupSuite needs to defer CleanupOnSetupFailure() if what comes after BaseSuite.SetupSuite() can fail.
 	defer s.CleanupOnSetupFailure()
@@ -639,10 +645,6 @@ func (s *baseStartStopSuite) SetupSuite() {
 		}
 		return services
 	}
-
-	// By default driver verifier is disabled.
-	s.enableDriverVerifier = false
-	s.timeoutScale = defaultTimeoutScale
 }
 
 func (s *baseStartStopSuite) TearDownSuite() {


### PR DESCRIPTION
### What does this PR do?

Preserves timeout scales configured by specialized Windows service-test suites. https://datadoghq.atlassian.net/browse/WINA-2680

### Motivation

Driver Verifier suites configured a 20-minute timeout, but `SetupSuite` reset it to the default 2 minutes, causing slow successful startups to fail.

### Validation

Verified Go formatting and `git diff --check` locally.