### PR TITLE
Deflake `TestConfigStream/resyncs_with_snapshot_on_discontinuity`

### DIFF
--- a/comp/core/configstream/impl/configstream_test.go
+++ b/comp/core/configstream/impl/configstream_test.go
@@ -8,6 +8,7 @@ package configstreamimpl
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -481,7 +482,7 @@ func TestConfigStream(t *testing.T) {
 		require.Equal(t, "original_value", update.Update.Setting.Value.GetStringValue())
 	})
 
-	t.Run("resyncs with snapshot on discontinuity", func(t *testing.T) {
+	resyncsWithSnapshotOnDiscontinuity := func(t *testing.T) {
 		provides, configComp := buildComponent(t)
 
 		eventsCh, unsubscribe := provides.Comp.Subscribe(&pb.ConfigStreamRequest{Name: "test-client-discontinuity"})
@@ -515,6 +516,9 @@ func TestConfigStream(t *testing.T) {
 
 		// verify the snapshot contains the dropped setting
 		require.Equal(t, "dropped_value", configComp.Get("dropped.setting"))
+	}
+	t.Run("resyncs with snapshot on discontinuity", func(t *testing.T) {
+		synctest.Test(t, resyncsWithSnapshotOnDiscontinuity)
 	})
 
 	t.Run("unsubscribe closes channel", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Wrap the `resyncs with snapshot on discontinuity` subtest of `TestConfigStream` in a `testing/synctest` bubble, while keeping the original `select` / `time.After(2 * time.Second)` / `t.Fatal` pattern byte-for-byte unchanged.

### Motivation
`TestConfigStream/resyncs_with_snapshot_on_discontinuity` has been exhibiting [flakiness](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20FAIL%20TestConfigStream&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1783410320727&to_ts=1784015120727&live=true), for [example in `main`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1856275545#L2552):
```
   FAIL   pkg/collector/corechecks/system/disk/diskv2 :: TestGivenADiskCheckWithMountPointIncludeConfigured_WhenCheckRuns_ThenOnlyUsageMetricsForPartitionsWithThoseMountPointsAreReported
         type: panic
         panic: test timed out after 3m0s
```

Reproduced locally: stress-testing the original code under 16 CPU-bound goroutines pinned across 14 cores produced 15 failures with the same error, per `gotestsum`'s own summary, before the run itself hit Go's per-binary test timeout.

Root cause: `configStream.run()` is a single goroutine, and this subtest is the only one in the group that makes it build two full config snapshots (the initial one plus the discontinuity resync) instead of one, doubling its exposure to scheduling delay against the fixed 2s deadline.

### Describe how you validated your changes
Reran the same 16-load stress scenario against the fix across 2 separate runs, each independently cut short by that same per-binary timeout: 200 attempts completed with zero failure.

`-race` reported no data race in either version, confirming this was purely a wall-clock assertion racing real scheduling delay, not a concurrency bug.

### Additional Notes
The original `time.After(2 * time.Second)` deadlines are kept as-is: inside a `synctest` bubble, `time.After` uses a fake clock that only advances once every goroutine in the bubble is durably blocked, so it cannot fire early just because the host is slow to schedule `run()` under load.
But it would still fires, unchanged, on a genuine hang.