### PR TITLE
test(otel-agent): add platform-specific fleet policies dir fallback tests

### DIFF
--- a/cmd/otel-agent/subcommands/run/BUILD.bazel
+++ b/cmd/otel-agent/subcommands/run/BUILD.bazel
@@ -146,7 +146,9 @@ dd_agent_go_test(
     name = "run_test",
     srcs = [
         "command_test.go",
+        "fleet_policies_dir_nix_test.go",
         "fleet_policies_dir_test.go",
+        "fleet_policies_dir_windows_test.go",
     ],
     data = [
         "test_config.yaml",

--- a/cmd/otel-agent/subcommands/run/BUILD.bazel
+++ b/cmd/otel-agent/subcommands/run/BUILD.bazel
@@ -165,5 +165,10 @@ dd_agent_go_test(
         "//cmd/otel-agent/subcommands",
         "//pkg/util/fxutil",
         "@com_github_stretchr_testify//assert",
-    ],
+    ] + select({
+        "@rules_go//go/platform:windows": [
+            "//pkg/util/winutil",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/cmd/otel-agent/subcommands/run/fleet_policies_dir_nix_test.go
+++ b/cmd/otel-agent/subcommands/run/fleet_policies_dir_nix_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build otlp && test
+//go:build otlp && test && !windows
 
 package run
 
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestResolveFleetPoliciesDir_PrefersEnv(t *testing.T) {
-	t.Setenv("DD_FLEET_POLICIES_DIR", "/custom/fleet/policies")
-	assert.Equal(t, "/custom/fleet/policies", resolveFleetPoliciesDir())
+func TestResolveFleetPoliciesDir_EmptyWhenUnset(t *testing.T) {
+	t.Setenv("DD_FLEET_POLICIES_DIR", "")
+	assert.Empty(t, resolveFleetPoliciesDir())
 }

--- a/cmd/otel-agent/subcommands/run/fleet_policies_dir_windows_test.go
+++ b/cmd/otel-agent/subcommands/run/fleet_policies_dir_windows_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build otlp && test && windows
+
+package run
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Stable fleet policies layout under the managed configs root when registry is unset.
+const expectedStableFleetPoliciesRel = "datadog-agent/stable"
+
+func TestResolveFleetPoliciesDir_FallsBackToStableFleetPoliciesDirWhenUnset(t *testing.T) {
+	t.Setenv("DD_FLEET_POLICIES_DIR", "")
+	dir := resolveFleetPoliciesDir()
+	assert.NotEmpty(t, dir)
+	normalized := filepath.ToSlash(filepath.Clean(dir))
+	assert.True(t, strings.HasSuffix(normalized, expectedStableFleetPoliciesRel), normalized)
+}

--- a/cmd/otel-agent/subcommands/run/fleet_policies_dir_windows_test.go
+++ b/cmd/otel-agent/subcommands/run/fleet_policies_dir_windows_test.go
@@ -13,15 +13,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
 // Stable fleet policies layout under the managed configs root when registry is unset.
 const expectedStableFleetPoliciesRel = "datadog-agent/stable"
 
-func TestResolveFleetPoliciesDir_FallsBackToStableFleetPoliciesDirWhenUnset(t *testing.T) {
+func TestResolveFleetPoliciesDir_PlatformFallbackWhenEnvUnset(t *testing.T) {
 	t.Setenv("DD_FLEET_POLICIES_DIR", "")
+
 	dir := resolveFleetPoliciesDir()
 	assert.NotEmpty(t, dir)
+
+	if registryDir := winutil.ReadFleetPoliciesDirFromRegistry(); registryDir != "" {
+		assert.Equal(t, filepath.Clean(registryDir), filepath.Clean(dir))
+		return
+	}
+
 	normalized := filepath.ToSlash(filepath.Clean(dir))
 	assert.True(t, strings.HasSuffix(normalized, expectedStableFleetPoliciesRel), normalized)
 }


### PR DESCRIPTION
### What does this PR do?

Adds platform-specific unit tests for `resolveFleetPoliciesDir()` in otel-agent:

- **Shared** (`fleet_policies_dir_test.go`): env override via `DD_FLEET_POLICIES_DIR` still wins.
- **Unix** (`fleet_policies_dir_nix_test.go`): when the env var is unset, resolution is empty.
- **Windows** (`fleet_policies_dir_windows_test.go`): when the env var is unset, resolution falls back to the stable managed path (`...\datadog-agent\stable`).

Also registers the new test files in `BUILD.bazel`.

### Motivation

#53535 made DDOT under dd-procmgr resolve fleet policies via `resolveFleetPoliciesDir()` (env → registry → stable on Windows) instead of a baked `DD_FLEET_POLICIES_DIR` in `processes.d`. The old shared unset-env test was flaky on Windows (skip when registry is set). Platform-specific tests document the intended behavior per OS.

Split from #53249 — no procmgr or process-agent changes.

### Describe how you validated your changes

- `dda inv test --targets=./cmd/otel-agent/subcommands/run/...`
- CI: Bazel `run_test` for `cmd/otel-agent/subcommands/run` on Linux and Windows

### Additional Notes
