### PR TITLE
[procmgr] Omit DD_FLEET_POLICIES_DIR from PAR and ADP processes.d on Windows

### DIFF
--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-action-windows.yaml.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-action-windows.yaml.tmpl
@@ -10,7 +10,5 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-env:
-  DD_FLEET_POLICIES_DIR: {{.FleetPoliciesDir}}
 stdout: inherit
 stderr: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-data-plane-windows.yaml.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-data-plane-windows.yaml.tmpl
@@ -12,7 +12,5 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-env:
-  DD_FLEET_POLICIES_DIR: {{.FleetPoliciesDir}}
 stdout: inherit
 stderr: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/windows/datadog-agent-action.yaml
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/windows/datadog-agent-action.yaml
@@ -10,7 +10,5 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-env:
-  DD_FLEET_POLICIES_DIR: __PAR_FLEET_POLICIES_DIR__
 stdout: inherit
 stderr: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/windows/datadog-agent-data-plane.yaml
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/windows/datadog-agent-data-plane.yaml
@@ -12,7 +12,5 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-env:
-  DD_FLEET_POLICIES_DIR: __ADP_FLEET_POLICIES_DIR__
 stdout: inherit
 stderr: inherit

--- a/pkg/fleet/installer/packages/processmanager/install_root_procmgr_config_windows.go
+++ b/pkg/fleet/installer/packages/processmanager/install_root_procmgr_config_windows.go
@@ -18,7 +18,7 @@ import (
 )
 
 // installRootProcmgrSpec describes a processes.d config whose binary and YAML both
-// live under the same MSI Program Files install root (ADP, PAR). DDOT is different:
+// live under the same MSI Program Files install root (PAR, ADP). DDOT is different:
 // its binary is under the fleet package path while processes.d stays on the install root.
 type installRootProcmgrSpec struct {
 	logLabel          string
@@ -35,16 +35,13 @@ func (s installRootProcmgrSpec) configRelPath() string {
 func (s installRootProcmgrSpec) renderConfig(installRootResolved string) string {
 	installRootRepl := filepath.ToSlash(filepath.Clean(installRootResolved))
 	etcRootRepl := filepath.ToSlash(filepath.Clean(paths.DatadogDataDir))
-	fleetPoliciesRepl := filepath.ToSlash(filepath.Clean(paths.FleetPoliciesDirForManagedProcess()))
-	log.Debugf("%s processes.d: template replace __%s_INSTALL_ROOT__=%q __%s_ETC_ROOT__=%q __%s_FLEET_POLICIES_DIR__=%q",
+	log.Debugf("%s processes.d: template replace __%s_INSTALL_ROOT__=%q __%s_ETC_ROOT__=%q",
 		s.logLabel, s.placeholderPrefix, installRootRepl,
-		s.placeholderPrefix, etcRootRepl,
-		s.placeholderPrefix, fleetPoliciesRepl)
+		s.placeholderPrefix, etcRootRepl)
 
 	config := s.embeddedConfig
 	config = strings.ReplaceAll(config, "__"+s.placeholderPrefix+"_INSTALL_ROOT__", installRootRepl)
 	config = strings.ReplaceAll(config, "__"+s.placeholderPrefix+"_ETC_ROOT__", etcRootRepl)
-	config = strings.ReplaceAll(config, "__"+s.placeholderPrefix+"_FLEET_POLICIES_DIR__", fleetPoliciesRepl)
 	return config
 }
 

--- a/releasenotes/notes/fix-windows-par-adp-fleet-policies-procmgr-9f0e4a7e8b3dadbf.yaml
+++ b/releasenotes/notes/fix-windows-par-adp-fleet-policies-procmgr-9f0e4a7e8b3dadbf.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    On Windows, stop baking ``DD_FLEET_POLICIES_DIR`` into **Private Action Runner** and **Agent Data Plane** ``processes.d`` definitions at install time. Those processes now resolve fleet policy location from the Windows registry via ``FleetConfigOverride``, so fleet policy updates are not blocked by a stale install-time path.


### PR DESCRIPTION
## What does this PR do?

Removes `DD_FLEET_POLICIES_DIR` from Windows PAR (Private Action Runner) and ADP (Agent Data Plane) `processes.d` templates and from install-root procmgr config rendering for those profiles.

## Motivation

On Windows, fleet policy location is driven by registry state rather than an install-time environment variable. Injecting `DD_FLEET_POLICIES_DIR` into PAR/ADP processes.d was redundant and could diverge from the registry-backed source of truth.

## Describe how you validated your changes

- Verified template and generated YAML diffs remove only the fleet-policies env var for PAR/ADP.
- Confirmed install-root procmgr config no longer sets `DD_FLEET_POLICIES_DIR` for PAR/ADP profiles.

## Additional Notes
