### PR TITLE
[procmgr/coat] Check processes.d under install root on Windows

### DIFF
--- a/pkg/procmgr/coat/paths_windows.go
+++ b/pkg/procmgr/coat/paths_windows.go
@@ -19,8 +19,8 @@ func agentInstallRoot() string {
 	return defaultpaths.GetInstallPath()
 }
 
-func procmgrConfigPath(_ string, configFile string) string {
-	return filepath.Join(windowsProcmgrConfigDir(), configFile)
+func procmgrConfigPath(installRoot, configFile string) string {
+	return filepath.Join(installRoot, processesDirRel, configFile)
 }
 
 // installMarkerPaths returns paths to check for an installed DDOT payload on Windows.
@@ -50,7 +50,7 @@ func installMarkerPaths(installRoot string, service MigratableService) []string 
 
 // windowsDatadogDataDir returns the agent data directory (MSI ConfigRoot when set,
 // otherwise default ProgramData\Datadog), matching fleet installer layout for
-// Installer\packages and dd-procmgr\processes.d.
+// Installer\packages.
 func windowsDatadogDataDir() string {
 	if pd, err := winutil.GetProgramDataDir(); err == nil && pd != "" {
 		return pd
@@ -63,8 +63,4 @@ func windowsDatadogDataDir() string {
 
 func windowsPackagesPath() string {
 	return filepath.Join(windowsDatadogDataDir(), "Installer", "packages")
-}
-
-func windowsProcmgrConfigDir() string {
-	return filepath.Join(windowsDatadogDataDir(), "dd-procmgr", processesDirRel)
 }

--- a/releasenotes/notes/fix-windows-coat-ddot-procmgr-configured-4d2800176d3f0b28.yaml
+++ b/releasenotes/notes/fix-windows-coat-ddot-procmgr-configured-4d2800176d3f0b28.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    On Windows, fix Cross-Org Agent Telemetry (COAT) reporting for DDOT under **dd-procmgr**: ``runtime.agent_service_procmgr_configured{service:ddot}`` now checks ``InstallPath\processes.d`` where the installer writes the YAML, instead of ``ProgramData\Datadog\dd-procmgr\processes.d``.


### PR DESCRIPTION
## What does this PR do?

Aligns COAT's Windows `procmgrConfigPath` with where dd-procmgr and the fleet installer actually place process configs: `InstallPath\processes.d` under the collector install root, not `ProgramData\Datadog\dd-procmgr\processes.d`.

## Motivation

COAT was checking the wrong directory for process-agent procmgr config on Windows, so `runtime.agent_service_procmgr_configured{service:process}` stayed false even after a successful install. This fix uses the collector `installRoot` passed into the check, matching the non-Windows path logic.

## Describe how you validated your changes

- Verified `procmgrConfigPath` now joins `installRoot`, `processes.d`, and the config filename (same layout as fleet installer / dd-procmgr default).
- Removed the unused `windowsProcmgrConfigDir` helper left over from the old path.

## Additional Notes
