### PR TITLE
Make zstd build reproducible

### DIFF
--- a/bazel/rules/go_zstd/zstd-ndebug.patch
+++ b/bazel/rules/go_zstd/zstd-ndebug.patch
@@ -1,0 +1,10 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -143,6 +143,6 @@
+     ],
+     cgo = True,
+-    copts = ["-DZSTD_LEGACY_SUPPORT=4 -DZSTD_MULTITHREAD=1"],
++    copts = ["-DZSTD_LEGACY_SUPPORT=4 -DZSTD_MULTITHREAD=1 -DNDEBUG"],
+     importpath = "github.com/DataDog/zstd",
+     visibility = ["//visibility:public"],
+ )

--- a/bazel/rules/go_zstd/zstd_0-ndebug.patch
+++ b/bazel/rules/go_zstd/zstd_0-ndebug.patch
@@ -1,0 +1,10 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -74,6 +74,7 @@
+         "zstd_stream.go",
+     ],
+     cgo = True,
++    copts = ["-DNDEBUG"],
+     importpath = "github.com/DataDog/zstd_0",
+     visibility = ["//visibility:public"],
+ )

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -556,6 +556,23 @@ go_deps.module_override(
     path = "github.com/tinylib/msgp",
 )
 
+# zstd's vendored C (divsufsort.c) compiles assert() calls whose __FILE__ expands to
+# the absolute, per-invocation sandbox path (.../processwrapper-sandbox/<N>/...). That
+# makes zstd.a non-reproducible build-to-build, so every test linking it always misses
+# the remote cache. -DNDEBUG drops the asserts (also a perf win), yielding a stable,
+# path-independent object. Both the modern fork and the older github.com/DataDog/zstd_0
+# (a separate module pulled in by the OTel collector components) need the same treatment.
+go_deps.module_override(
+    patch_strip = 1,
+    patches = ["//bazel/rules/go_zstd:zstd-ndebug.patch"],
+    path = "github.com/DataDog/zstd",
+)
+go_deps.module_override(
+    patch_strip = 1,
+    patches = ["//bazel/rules/go_zstd:zstd_0-ndebug.patch"],
+    path = "github.com/DataDog/zstd_0",
+)
+
 # sdjournal wraps journald's C API and `#include <systemd/sd-journal.h>` at compile
 # time, but the hermetic toolchain sysroot ships no libsystemd headers. Patch the
 # Gazelle-generated BUILD to pull them from the vendored @systemd archive via cdeps.


### PR DESCRIPTION
### What does this PR do?

Add `-DNDEBUG` to the cgo copts of github.com/DataDog/zstd (and the older zstd_0). This is needed because `zstd` vendors C code (`divsufsort.c`) with `assert()` calls, and `assert()` bakes `__FILE__` — the absolute per-build sandbox path (.../processwrapper-sandbox/<N>/...) — into `zstd.a`, making it non-reproducible even when inputs and the action key are identical; since every Go test/binary links `zstd.a` by digest, the shifting digest changes each downstream action key and forces thousands of test actions to miss the remote cache and re-run. `-DNDEBUG` compiles out the asserts (removing the embedded path, plus a minor perf win) so `zstd.a` is byte-identical everywhere and the cache hit propagates downstream
