### PR TITLE
[CONTINT-5467] Simplify to a single source for kubernetes versions

### DIFF
--- a/.github/workflows/update-kubernetes-versions.yml
+++ b/.github/workflows/update-kubernetes-versions.yml
@@ -5,19 +5,7 @@ on:
     # Run once daily at 6am UTC
     - cron: "0 6 * * *"
 
-  # Allow manual trigger
-  workflow_dispatch:
-    inputs:
-      disable_dockerhub:
-        description: 'Disable fetching versions from Docker Hub'
-        required: false
-        default: false
-        type: boolean
-      disable_github:
-        description: 'Disable fetching RC versions from GitHub'
-        required: false
-        default: false
-        type: boolean
+  workflow_dispatch: # Leaving this empty allows manual triggering without fields
 
 permissions: {}
 
@@ -66,37 +54,30 @@ jobs:
       - name: Fetch latest Kubernetes version
         id: fetch-versions
         run: |
-          args=()
-          if [ "${{ inputs.disable_dockerhub }}" = "true" ]; then
-            args+=(--disable-dockerhub)
-          fi
-          if [ "${{ inputs.disable_github }}" = "true" ]; then
-            args+=(--disable-github)
-          fi
-          dda inv k8s-versions.fetch-versions "${args[@]}"
+          dda inv k8s-versions.fetch-versions
 
-      - name: Build RC images
-        if: steps.fetch-versions.outputs.has_new_rc_versions == 'true'
-        id: build-rc-images
+      - name: Build new Kubernetes images
+        if: steps.fetch-versions.outputs.has_new_versions == 'true'
+        id: build-images
         run: |
-          dda inv kind-node-image.build-rc-images --versions='${{ steps.fetch-versions.outputs.new_versions }}'
+          dda inv kind-node-image.build-images --versions='${{ steps.fetch-versions.outputs.new_versions }}'
 
       - name: Configure AWS credentials
-        if: steps.fetch-versions.outputs.has_new_rc_versions == 'true' && steps.build-rc-images.outputs.built_count > 0
+        if: steps.fetch-versions.outputs.has_new_versions == 'true' && steps.build-rc-images.outputs.built_count > 0
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/datadog-agent-kind-image-publisher-oidc
           aws-region: us-east-1
 
       - name: Log in to AWS ECR
-        if: steps.fetch-versions.outputs.has_new_rc_versions == 'true' && steps.build-rc-images.outputs.built_count > 0
+        if: steps.fetch-versions.outputs.has_new_versions == 'true' && steps.build-rc-images.outputs.built_count > 0
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.ECR_REGION }}.amazonaws.com
 
-      - name: Tag and push RC images to ECR
-        if: steps.fetch-versions.outputs.has_new_rc_versions == 'true' && steps.build-rc-images.outputs.built_count > 0
-        id: push-rc-images
+      - name: Tag and push new Kubernetes images to ECR
+        if: steps.fetch-versions.outputs.has_new_versions == 'true' && steps.build-images.outputs.built_count > 0
+        id: push-images
         env:
           ECR_REGISTRY: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.ECR_REGION }}.amazonaws.com
         run: |
@@ -104,10 +85,10 @@ jobs:
 
           new_versions='${{ steps.fetch-versions.outputs.new_versions }}'
 
-          # Capture the kind version used to build these RC images
+          # Capture the kind version used to build these images
           kind_version=$(kind version | awk '{print $2}')
 
-          for image in ${{ steps.build-rc-images.outputs.built_images }}; do
+          for image in ${{ steps.build-images.outputs.built_images }}; do
             tag="${image##*:}"
             ecr_image="$ECR_REGISTRY/$ECR_REPOSITORY:$tag"
 
@@ -128,20 +109,18 @@ jobs:
           echo "new_versions=$new_versions" >> "$GITHUB_OUTPUT"
 
       - name: Save new versions to file
-        if: steps.fetch-versions.outputs.has_new_versions == 'true'
+        if: steps.push-images.result == 'success'
         run: |
-          # Use push-rc-images output if RC images were built (includes digests from ECR)
-          # Otherwise use fetch-versions output (includes digests from Docker Hub for final releases)
-          VERSIONS='${{ steps.push-rc-images.outputs.new_versions || steps.fetch-versions.outputs.new_versions }}'
+          VERSIONS='${{ steps.push-images.outputs.new_versions }}'
           dda inv k8s-versions.save-versions --versions="$VERSIONS"
 
       - name: Update kind_versions.json
-        if: steps.fetch-versions.outputs.has_new_versions == 'true'
+        if: steps.push-images.result == 'success'
         run: dda inv k8s-versions.update-kind-versions-file
 
       - name: Update e2e.yml with new version
         id: update-yaml
-        if: steps.fetch-versions.outputs.has_new_versions == 'true'
+        if: steps.push-images.result == 'success'
         run: |
           dda inv k8s-versions.update-e2e-yaml
 

--- a/.github/workflows/update-kubernetes-versions.yml
+++ b/.github/workflows/update-kubernetes-versions.yml
@@ -63,14 +63,14 @@ jobs:
           dda inv kind-node-image.build-images --versions='${{ steps.fetch-versions.outputs.new_versions }}'
 
       - name: Configure AWS credentials
-        if: steps.fetch-versions.outputs.has_new_versions == 'true' && steps.build-rc-images.outputs.built_count > 0
+        if: steps.fetch-versions.outputs.has_new_versions == 'true' && steps.build-images.outputs.built_count > 0
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/datadog-agent-kind-image-publisher-oidc
           aws-region: us-east-1
 
       - name: Log in to AWS ECR
-        if: steps.fetch-versions.outputs.has_new_versions == 'true' && steps.build-rc-images.outputs.built_count > 0
+        if: steps.fetch-versions.outputs.has_new_versions == 'true' && steps.build-images.outputs.built_count > 0
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.ECR_REGION }}.amazonaws.com
@@ -109,18 +109,18 @@ jobs:
           echo "new_versions=$new_versions" >> "$GITHUB_OUTPUT"
 
       - name: Save new versions to file
-        if: steps.push-images.result == 'success'
+        if: steps.push-images.conclusion == 'success'
         run: |
           VERSIONS='${{ steps.push-images.outputs.new_versions }}'
           dda inv k8s-versions.save-versions --versions="$VERSIONS"
 
       - name: Update kind_versions.json
-        if: steps.push-images.result == 'success'
+        if: steps.push-images.conclusion == 'success'
         run: dda inv k8s-versions.update-kind-versions-file
 
       - name: Update e2e.yml with new version
         id: update-yaml
-        if: steps.push-images.result == 'success'
+        if: steps.push-images.conclusion == 'success'
         run: |
           dda inv k8s-versions.update-e2e-yaml
 

--- a/tasks/k8s_versions.py
+++ b/tasks/k8s_versions.py
@@ -42,6 +42,7 @@ KIND_VERSIONS_JSON_PATH = "test/e2e-framework/components/kubernetes/kind_version
 # Matches: v1.35.0, v1.35.0-rc.1, etc.
 K8S_VERSION_PATTERN = r'v?\d+\.\d+(?:\.\d+)?(?:-rc\.\d+)?'
 
+
 def get_kubernetes_releases(version_pattern: str = K8S_VERSION_PATTERN) -> list[dict[str, str]]:
     """Get releases from Kubernetes GitHub repository."""
     releases = []
@@ -138,11 +139,7 @@ def _get_latest_k8s_versions() -> dict[str, dict[str, str]]:
 
         if version and tag_name:
             is_rc = "rc" in tag_name
-            version_tags.append(
-                {'version': version,
-                 'tag': tag_name,
-                 'rc': is_rc}
-            )
+            version_tags.append({'version': version, 'tag': tag_name, 'rc': is_rc})
 
     # Sort by version (major, minor, patch)
     version_tags.sort(key=lambda x: x['version'], reverse=True)
@@ -347,7 +344,7 @@ def fetch_versions(_, output_file=VERSIONS_FILE):
     """
     _check_dependencies()
 
-    print(f"Fetching latest Kubernetes version...")
+    print("Fetching latest Kubernetes version...")
     current_versions = _get_latest_k8s_versions()
     if not current_versions:
         print("Error: Could not find any Kubernetes versions")
@@ -365,7 +362,7 @@ def fetch_versions(_, output_file=VERSIONS_FILE):
 
     if new_versions:
         print("\nNew version(s) found!")
-        for version, data in new_versions.items():
+        for version in new_versions.keys():
             print(f"  {version}")
 
         # Set GitHub Actions outputs

--- a/tasks/k8s_versions.py
+++ b/tasks/k8s_versions.py
@@ -15,8 +15,6 @@ from typing import TYPE_CHECKING
 from invoke.exceptions import Exit
 from invoke.tasks import task
 
-from tasks.kind_node_image import get_github_rc_releases
-
 if TYPE_CHECKING:
     import semver
 
@@ -35,7 +33,7 @@ try:
 except ImportError:
     _semver = None
 
-DOCKER_HUB_API_URL = "https://hub.docker.com/v2/repositories/kindest/node/tags"
+GITHUB_URL_BASE = "https://api.github.com"
 VERSIONS_FILE = "k8s_versions.json"
 E2E_YAML_PATH = ".gitlab/test/e2e/e2e.yml"
 KIND_VERSIONS_JSON_PATH = "test/e2e-framework/components/kubernetes/kind_versions.json"
@@ -43,6 +41,28 @@ KIND_VERSIONS_JSON_PATH = "test/e2e-framework/components/kubernetes/kind_version
 # Regex pattern for Kubernetes version (release and RC supported)
 # Matches: v1.35.0, v1.35.0-rc.1, etc.
 K8S_VERSION_PATTERN = r'v?\d+\.\d+(?:\.\d+)?(?:-rc\.\d+)?'
+
+def get_kubernetes_releases(version_pattern: str = K8S_VERSION_PATTERN) -> list[dict[str, str]]:
+    """Get releases from Kubernetes GitHub repository."""
+    releases = []
+
+    # Get the last 100 releases
+    # TODO(TBD): Should we fetch all releases or is the last 25 enough?
+    url = f"{GITHUB_URL_BASE}/repos/kubernetes/kubernetes/releases?per_page=25&page=1"
+
+    try:
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+
+        for release in response.json():
+            tag_name = release.get('tag_name', '')
+            if re.fullmatch(version_pattern, tag_name):
+                releases.append({'tag_name': tag_name})
+
+    except requests.exceptions.RequestException as e:
+        raise Exit(f"Error fetching releases from Github: {e}", code=1) from e
+
+    return releases
 
 
 def _check_dependencies():
@@ -84,37 +104,6 @@ def _parse_version(version_str: str) -> semver.VersionInfo | None:
         return None
 
 
-def _get_docker_hub_tags() -> list[dict]:
-    """
-    Fetch all tags from Docker Hub for kindest/node.
-    Returns a list of tag objects with name and images information.
-    """
-    all_tags = []
-    url = DOCKER_HUB_API_URL
-
-    while url:
-        try:
-            response = requests.get(url, timeout=30)
-            response.raise_for_status()
-            data = response.json()
-
-            all_tags.extend(data.get('results', []))
-            url = data.get('next')  # Pagination
-
-        except requests.exceptions.RequestException as e:
-            raise Exit(f"Error fetching tags from Docker Hub: {e}", code=1) from e
-
-    return all_tags
-
-
-def _extract_index_digest(tag_data: dict) -> str | None:
-    """
-    Extract the index digest (manifest list digest) from tag data.
-    The index digest is the digest field at the root level of the tag data.
-    """
-    return tag_data.get('digest')
-
-
 def _get_latest_kind_release() -> str | None:
     """
     Fetch the latest released kind version from GitHub.
@@ -122,7 +111,7 @@ def _get_latest_kind_release() -> str | None:
     """
     try:
         resp = requests.get(
-            "https://api.github.com/repos/kubernetes-sigs/kind/releases/latest",
+            f"{GITHUB_URL_BASE}/repos/kubernetes-sigs/kind/releases/latest",
             headers={"Accept": "application/vnd.github+json"},
             timeout=30,
         )
@@ -133,38 +122,27 @@ def _get_latest_kind_release() -> str | None:
         return None
 
 
-def _get_latest_k8s_versions(use_dockerhub: bool = True, use_github: bool = True) -> dict[str, dict[str, str]]:
+def _get_latest_k8s_versions() -> dict[str, dict[str, str]]:
     """
-    Fetch and parse the latest Kubernetes version from Docker Hub (stable) and/or GitHub (RC).
+    Fetch and parse the latest Kubernetes version from GitHub releases.
     Returns a dictionary with only the single latest version.
-
-    Args:
-        use_dockerhub: Whether to fetch versions from Docker Hub (default: True)
-        use_github: Whether to fetch RC versions from GitHub (default: True)
     """
 
     # Filter for valid Kubernetes version tags
     version_tags = []
 
-    # Final release Kubernetes version tags from Docker Hub
-    if use_dockerhub:
-        for tag in _get_docker_hub_tags():
-            tag_name = tag.get('name', '')
-            version = _parse_version(tag_name)
+    # Kubernetes version tags from GitHub
+    for tag in get_kubernetes_releases():
+        tag_name = tag.get('tag_name', '')
+        version = _parse_version(tag_name)
 
-            if version:
-                digest = _extract_index_digest(tag)
-                if digest:
-                    version_tags.append({'version': version, 'tag': tag_name, 'digest': digest})
-
-    # RC Kubernetes version tags from GitHub
-    if use_github:
-        for tag in get_github_rc_releases():
-            tag_name = tag.get('tag_name', '')
-            version = _parse_version(tag_name)
-            if version and tag_name:
-                # Hardcode 'rc' to True because get_github_rc_releases() only returns rc releases
-                version_tags.append({'version': version, 'tag': tag_name, 'rc': True})
+        if version and tag_name:
+            is_rc = "rc" in tag_name
+            version_tags.append(
+                {'version': version,
+                 'tag': tag_name,
+                 'rc': is_rc}
+            )
 
     # Sort by version (major, minor, patch)
     version_tags.sort(key=lambda x: x['version'], reverse=True)
@@ -175,16 +153,13 @@ def _get_latest_k8s_versions(use_dockerhub: bool = True, use_github: bool = True
 
         # Parse out the necessary fields
         tag = latest.get('tag')
-        digest = latest.get('digest')
         rc = latest.get('rc')
 
         # Build return dictionary
-        # Structure: {tag_name: {'tag': tag_name, 'digest': digest?, 'kind_version': str?, 'rc': bool?}}
+        # Structure: {tag_name: {'tag': tag_name, 'kind_version': str?, 'rc': bool?}}
         # Final releases include 'digest' and 'kind_version'; RC releases include 'rc'
         if tag:
             result = {tag: {'tag': tag}}
-            if digest:
-                result[tag]['digest'] = digest
             if rc:
                 result[tag]['rc'] = rc
             return result
@@ -212,29 +187,11 @@ def _save_versions(versions: dict[str, dict[str, str]], versions_file: str) -> N
 def _find_new_versions(
     current: dict[str, dict[str, str]], previous: dict[str, dict[str, str]]
 ) -> dict[str, dict[str, str]]:
-    """Find versions that are new or have different digests.
-
-    Notes:
-        - RC versions from GitHub won't have digests initially
-        - Only compare digests if BOTH current and previous have them
-        - If current has no digest (RC from GitHub) and version exists, don't mark as new
-    """
+    """Find versions that are new"""
     new_versions = {}
-
     for version, data in current.items():
         # Version doesn't exist in previous - it's new
         if version not in previous:
-            new_versions[version] = data
-            continue
-
-        # Version exists - check if digest changed
-        current_digest = data.get('digest')
-        previous_digest = previous[version].get('digest')
-
-        # Only compare digests if BOTH have them
-        # This prevents RC versions (no digest from GitHub) from being marked as new
-        # when they already exist in the saved file (with digest from build)
-        if current_digest and previous_digest and current_digest != previous_digest:
             new_versions[version] = data
 
     return new_versions
@@ -380,41 +337,18 @@ def _update_e2e_yaml_file(new_versions: dict[str, dict[str, str]]) -> tuple[bool
 
 
 @task
-def fetch_versions(_, output_file=VERSIONS_FILE, disable_dockerhub=False, disable_github=False):
+def fetch_versions(_, output_file=VERSIONS_FILE):
     """
-    Fetch the latest Kubernetes version from Docker Hub (stable) and/or GitHub (RC).
-
-    This task fetches the latest Kubernetes version from the kindest/node
-    Docker Hub repository and/or GitHub RC releases.
-
-    Args:
-        disable_dockerhub: Disable fetching versions from Docker Hub (default: False)
-        disable_github: Disable fetching RC versions from GitHub (default: False)
+    This task fetches the latest Kubernetes version from GitHub releases.
 
     Outputs (GitHub Actions):
-        has_new_versions: 'true' if a new stable version was found
-        has_new_rc_versions: 'true' if a new RC version was found
+        has_new_versions: 'true' if a new stable or RC version was found
         new_versions: JSON string with the new version data
     """
     _check_dependencies()
 
-    # Convert CLI arguments (--disable flags) to positive booleans
-    enable_dockerhub = not disable_dockerhub
-    enable_github = not disable_github
-
-    if not enable_dockerhub and not enable_github:
-        print("Error: At least one source must be enabled")
-        raise Exit("No sources enabled", code=1)
-
-    sources = []
-    if enable_dockerhub:
-        sources.append("Docker Hub")
-    if enable_github:
-        sources.append("GitHub")
-
-    print(f"Fetching latest Kubernetes version from {' and '.join(sources)}...")
-    current_versions = _get_latest_k8s_versions(use_dockerhub=enable_dockerhub, use_github=enable_github)
-
+    print(f"Fetching latest Kubernetes version...")
+    current_versions = _get_latest_k8s_versions()
     if not current_versions:
         print("Error: Could not find any Kubernetes versions")
         _set_github_output('has_new_versions', 'false')
@@ -422,10 +356,8 @@ def fetch_versions(_, output_file=VERSIONS_FILE, disable_dockerhub=False, disabl
 
     # Show the latest version
     latest_version = list(current_versions.keys())[0]
-    latest_data = current_versions[latest_version]
 
     print(f"Latest Kubernetes version: {latest_version}")
-    print(f"  Digest: {latest_data.get('digest', 'Digest unknown')}")
 
     # Load previous versions and compare
     previous_versions = _load_existing_versions(output_file)
@@ -434,19 +366,14 @@ def fetch_versions(_, output_file=VERSIONS_FILE, disable_dockerhub=False, disabl
     if new_versions:
         print("\nNew version(s) found!")
         for version, data in new_versions.items():
-            print(f"  {version}: {data.get('digest', 'Digest unknown')}")
-
-        # Check if any new versions are RCs
-        has_rc = any(data.get('rc', False) for data in new_versions.values())
+            print(f"  {version}")
 
         # Set GitHub Actions outputs
         _set_github_output('has_new_versions', 'true')
-        _set_github_output('has_new_rc_versions', 'true' if has_rc else 'false')
         _set_github_output('new_versions', json.dumps(new_versions))
     else:
         print(f"\nNo new version - {latest_version} is already tracked")
         _set_github_output('has_new_versions', 'false')
-        _set_github_output('has_new_rc_versions', 'false')
 
 
 @task

--- a/tasks/kind_node_image.py
+++ b/tasks/kind_node_image.py
@@ -16,7 +16,6 @@ try:
 except ImportError:
     boto3 = None
 
-GITHUB_URL_BASE = "https://api.github.com"
 IMAGE_NAME = "kindest/node"
 
 KIND = 'kind'
@@ -43,36 +42,6 @@ def _check_environment():
             f"Missing required binaries: {', '.join(missing)}",
             code=1,
         )
-
-
-def get_github_rc_releases() -> list[dict[str, str]]:
-    """Get RC releases from Kubernetes GitHub repository."""
-    releases = []
-
-    # Get the last 100 releases
-    # TODO(TBD): Should we fetch all releases or is the last 100 enough?
-    url = f"{GITHUB_URL_BASE}/repos/kubernetes/kubernetes/releases?per_page=100&page=1"
-
-    try:
-        response = requests.get(url, timeout=30)
-        response.raise_for_status()
-
-        for release in response.json():
-            tag_name = release.get('tag_name', '')
-            # Only return rc tags to build the kind image
-            if 'rc' in tag_name:
-                releases.append({'tag_name': tag_name})
-
-    except requests.exceptions.RequestException as e:
-        raise Exit(f"Error fetching releases from Github: {e}", code=1) from e
-
-    return releases
-
-
-@task
-def get_rc_releases(_) -> list[dict[str, str]]:
-    """Get RC releases from Kubernetes GitHub repository (Invoke task wrapper)."""
-    return get_github_rc_releases()
 
 
 def build_kind_node_image(version: str) -> str:
@@ -126,11 +95,11 @@ def _set_github_output(name: str, value: str) -> None:
 
 
 @task
-def build_rc_images(_, versions):
+def build_images(_, versions):
     """
-    Build kind node images for RC versions.
+    Build kind node images for specified versions.
 
-    This task processes new versions and builds Docker images for any RC versions.
+    This task processes new versions and builds Docker images.
     The images are built locally but not pushed.
 
     Args:
@@ -138,8 +107,8 @@ def build_rc_images(_, versions):
                       (e.g., '{"v1.35.0-rc.1": {"tag": "v1.35.0-rc.1", "rc": true}}')
 
     Outputs (GitHub Actions):
-        built_count: Number of RC images built
-        built_tags: Space delimited list of built image tags
+        built_count: Number of images built
+        built_images: Space delimited list of built image tags
     """
     # Parse if it's a JSON string
     if isinstance(versions, str):
@@ -151,23 +120,20 @@ def build_rc_images(_, versions):
     built_images = []
 
     for tag, version_data in versions.items():
-        if version_data.get('rc'):
-            try:
-                image = build_kind_node_image(tag)
-                built_images.append(image)
-                print(f"Successfully built: {image}")
+        try:
+            image = build_kind_node_image(tag)
+            built_images.append(image)
+            print(f"Successfully built: {image}")
 
-            except Exception as e:
-                print(f"Error building RC image {tag}: {e}")
-                raise
-        else:
-            print(f"Skipping non-RC version: {tag}")
+        except Exception as e:
+            print(f"Error building image {tag}: {e}")
+            raise
 
     # Set GitHub Actions outputs
     _set_github_output('built_count', str(len(built_images)))
     _set_github_output('built_images', ' '.join(built_images))
 
     if built_images:
-        print(f"\nSuccessfully built {len(built_images)} RC image(s): {', '.join(built_images)}")
+        print(f"\nSuccessfully built {len(built_images)} image(s): {', '.join(built_images)}")
     else:
-        print("\nNo RC images to build")
+        print("\nNo images to build")

--- a/tasks/kind_node_image.py
+++ b/tasks/kind_node_image.py
@@ -119,7 +119,7 @@ def build_images(_, versions):
 
     built_images = []
 
-    for tag, version_data in versions.items():
+    for tag in versions.keys():
         try:
             image = build_kind_node_image(tag)
             built_images.append(image)


### PR DESCRIPTION
### What does this PR do?
Simplify to a single source for new Kubernetes Releases. 

### Motivation
There can be a delay between a new Kubernetes release and its presence in `dockerhub/kindest/node` registry. We can build on-demand as soon as a GitHub release is published.

### Describe how you validated your changes
Executed `dda inv k8s-version.*` commands locally.

### Additional Notes
There is a follow-up PR #53635 
