### PR TITLE
[CONS-8427] - Remove "impossible to reach kubelet" warning when the agent is installed in a non-K8s environment

### DIFF
--- a/pkg/util/kubernetes/cloudprovider/BUILD.bazel
+++ b/pkg/util/kubernetes/cloudprovider/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/pkg/util/kubernetes/cloudprovider",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config/env",
         "//pkg/config/setup/constants",
         "//pkg/util/cache",
         "//pkg/util/clusteragent",
@@ -27,5 +28,8 @@ dd_agent_go_test(
     name = "cloudprovider_test",
     srcs = ["cloudprovider_test.go"],
     embed = [":cloudprovider"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "//pkg/config/env",
+        "@com_github_stretchr_testify//assert",
+    ],
 )

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"regexp"
 
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
@@ -24,6 +25,10 @@ var (
 // GetName returns the name of the kube distribution for the current node.
 // GetName shouldn't be used on DCA. For DCA please refer to DCAGetName.
 func GetName(ctx context.Context) (string, error) {
+	if !env.IsFeaturePresent(env.Kubernetes) {
+		return "", nil
+	}
+
 	cacheKey := cache.BuildAgentKey(constants.NodeKubeDistributionKey)
 	if cloudProvider, found := cache.Cache.Get(cacheKey); found {
 		return cloudProvider.(string), nil

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider_test.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider_test.go
@@ -6,9 +6,12 @@
 package cloudprovider
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 )
 
 func TestKubeDistributionName(t *testing.T) {
@@ -37,4 +40,16 @@ func TestKubeDistributionName(t *testing.T) {
 			assert.Equal(t, tc.expected, provider)
 		})
 	}
+}
+
+// TestGetNameNotKubernetes ensures GetName returns early without probing the
+// kubelet when the Agent is not running on Kubernetes.
+func TestGetNameNotKubernetes(t *testing.T) {
+	// The Kubernetes feature is intentionally not set: in test builds
+	// detection is disabled and features default to empty.
+	env.ClearFeatures()
+
+	name, err := GetName(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, name)
 }

--- a/releasenotes/notes/fix-kubelet-probe-non-kubernetes-03bffef4f6af6a06.yaml
+++ b/releasenotes/notes/fix-kubelet-probe-non-kubernetes-03bffef4f6af6a06.yaml
@@ -4,5 +4,5 @@ fixes:
     Stop the Agent from repeatedly attempting to connect to a Kubelet on hosts
     that are not running on Kubernetes. This removes the recurring
     ``Impossible to reach Kubelet through HTTPS, fallback to HTTP`` warning
-    logged by host-based (non-Kubernetes) installations. There is no change in
+    logged by host-based and non-Kubernetes containerized installations. There is no change in
     behavior on Kubernetes nodes.

--- a/releasenotes/notes/fix-kubelet-probe-non-kubernetes-03bffef4f6af6a06.yaml
+++ b/releasenotes/notes/fix-kubelet-probe-non-kubernetes-03bffef4f6af6a06.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Stop the Agent from repeatedly attempting to connect to a Kubelet on hosts
+    that are not running on Kubernetes. This removes the recurring
+    ``Impossible to reach Kubelet through HTTPS, fallback to HTTP`` warning
+    logged by host-based (non-Kubernetes) installations. There is no change in
+    behavior on Kubernetes nodes.


### PR DESCRIPTION
### What does this PR do?
Removes the following warning when installing the agent in a non-Kubernetes environment:
```
2026-07-09 18:07:59 JST | CORE | WARN | (pkg/util/kubernetes/kubelet/kubelet_client.go:288 in getKubeletClient) | Impossible to reach Kubelet through HTTPS, fallback to HTTP, err=Kubelet connection check failed
```
This was caused by this change that added the `kube_distribution` tag which was not guarded whenever the agent cannot detect a Kubernetes environment:  https://github.com/DataDog/datadog-agent/pull/41173

### Motivation
CONS-8427

### Describe how you validated your changes
Added a unit test for the `!env.IsFeaturePresent(env.Kubernetes)` guard.

Reproduced this in a host based environment and in Docker (no K8s). Built an image locally with the code changes and validated that the warning is gone.