### PR TITLE
Ensure we use the same commit sha and not branch

### DIFF
--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -145,6 +145,7 @@ docker_image_build_otel:
       BUILD_ARGS="\
         --build-arg AGENT_VERSION=$AGENT_VERSION \
         --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
+        --build-arg DD_GIT_COMMIT_SHA=$CI_COMMIT_SHA \
         --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
         --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
         --build-arg PACKAGE_TYPE=$DDOT_BYOC_PACKAGE_TYPE \
@@ -214,6 +215,7 @@ ddot_byoc_binary_build_test_ubuntu2004:
       BUILD_ARGS="\
         --build-arg AGENT_VERSION=$AGENT_VERSION \
         --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
+        --build-arg DD_GIT_COMMIT_SHA=$CI_COMMIT_SHA \
         --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
         --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
         --build-arg UBUNTU_VERSION=20.04 \

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -101,8 +101,12 @@ FROM builder_base AS builder
 # We also have to use the repo clone because some invoke tasks rely on git commands unavailable
 # in repo tarball archives. For the same reason a shallow clone will also not work.
 ARG AGENT_GIT_REF
+ARG DD_GIT_COMMIT_SHA
 ARG PACKAGE_TYPE
-RUN git clone --branch ${AGENT_GIT_REF} --filter=tree:0 https://github.com/DataDog/datadog-agent.git datadog-agent
+RUN git clone --branch "${AGENT_GIT_REF}" --filter=tree:0 https://github.com/DataDog/datadog-agent.git datadog-agent && \
+    if [ -n "${DD_GIT_COMMIT_SHA}" ]; then \
+        git -C datadog-agent checkout --detach "${DD_GIT_COMMIT_SHA}"; \
+    fi
 
 # Set the working directory to the source code
 WORKDIR /workspace/datadog-agent


### PR DESCRIPTION
### What does this PR do?
`docker_image_build_otel` is cloning `datadog-agent` repo using a ref (which is in case of the incident `main`).
Since the version of this package was updated a couple of minutes before the job started we faced a race condition that the manifest contained wrong version.
To prevent that from happening we now clone exactly the same SHA that the job was triggered on.

### Motivation
[#incident-57656](https://dd.enterprise.slack.com/archives/C0BH66UUSUV/p1784045233483109):
- [Race condition](https://app.datadoghq.com/logs?query=source%3Agitlab+%40ci.job.name%3Adocker_image_build_otel&from_ts=1783958682509&to_ts=1784045082509&live=false): OCB hardcoded in cloned repo differs from pinned component versions in external manifest:
  ```
  202.2 Failed to read manifest file: Component go.opentelemetry.io/collector/extension/zpagesextension v0.155.0) in manifest does not match required OCB version (0.156.0)
  ```
- [32 failures over 3 days](https://app.datadoghq.com/logs?query=source%3Agitlab+%40ci.job.name%3Adocker_image_build_otel+%22Failed+to+read+manifest%22&from_ts=1783785921946&to_ts=1784045121946&live=false): `zpagesextension` v0.155.0 mismatches OCB 0.154.0 and 0.156.0
- [Intermittent job flapping](https://app.datadoghq.com/event/explorer?query=docker_image_build_otel+datadog-agent&from_ts=1783440258720&to_ts=1784045058720&live=false): Recurring failures with triggered/recovered alerts across main and release branches