### PR TITLE
bump memory/cpu for tests_ebpf_* jobs

### DIFF
--- a/.gitlab/build/source_test/ebpf.yml
+++ b/.gitlab/build/source_test/ebpf.yml
@@ -40,6 +40,7 @@ tests_ebpf_x64:
 
 tests_ebpf_arm64:
   extends: .tests_linux_ebpf
+  timeout: 25m
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
   needs: ["go_deps", "go_tools_deps_arm64"]

--- a/.gitlab/build/source_test/ebpf.yml
+++ b/.gitlab/build/source_test/ebpf.yml
@@ -13,21 +13,21 @@
   extends: .unit_test_base
   needs: ["go_deps", "go_tools_deps"]
   variables:
-    KUBERNETES_MEMORY_REQUEST: "16Gi"
-    KUBERNETES_MEMORY_LIMIT: "16Gi"
-    KUBERNETES_CPU_REQUEST: 6
+    KUBERNETES_MEMORY_REQUEST: "24Gi"
+    KUBERNETES_MEMORY_LIMIT: "24Gi"
+    KUBERNETES_CPU_REQUEST: 8
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
   script:
     - dda inv -- -e system-probe.object-files
-    - dda inv -- -e linter.go --build system-probe-unit-tests --cpus 4 --targets ./pkg
+    - dda inv -- -e linter.go --build system-probe-unit-tests --cpus $KUBERNETES_CPU_REQUEST --targets ./pkg
     - dda inv -- -e security-agent.run-ebpf-unit-tests --verbose
     # Run a subset of the dyninst tests that will at least exercise analysis of
     # the test programs to try to prevent skew between concurrent changes.
     - dda inv -- -e system-probe.build-dyninst-test-programs
     - dda inv -- -e system-probe.test --packages='pkg/dyninst/irgen pkg/dyninst/symdb' --extra-arguments=--short --skip-object-files
-    - dda inv -- -e linter.go --targets=./pkg/security/tests --cpus 4 --build-tags="functionaltests stresstests trivy containerd linux_bpf ebpf_bindata"
+    - dda inv -- -e linter.go --targets=./pkg/security/tests --cpus $KUBERNETES_CPU_REQUEST --build-tags="functionaltests stresstests trivy containerd linux_bpf ebpf_bindata"
 
 tests_ebpf_x64:
   extends: .tests_linux_ebpf

--- a/.gitlab/build/source_test/ebpf.yml
+++ b/.gitlab/build/source_test/ebpf.yml
@@ -25,7 +25,7 @@
     - dda inv -- -e security-agent.run-ebpf-unit-tests --verbose
     # Run a subset of the dyninst tests that will at least exercise analysis of
     # the test programs to try to prevent skew between concurrent changes.
-    - dda inv -- -e system-probe.build-dyninst-test-programs
+    - dda inv -- -e system-probe.build-dyninst-test-programs --ci
     - dda inv -- -e system-probe.test --packages='pkg/dyninst/irgen pkg/dyninst/symdb' --extra-arguments=--short --skip-object-files
     - dda inv -- -e linter.go --targets=./pkg/security/tests --cpus $KUBERNETES_CPU_REQUEST --build-tags="functionaltests stresstests trivy containerd linux_bpf ebpf_bindata"
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1823,11 +1823,11 @@ def collect_gpu_events(ctx, output_dir: str, pod_name: str, event_count: int = 1
 
 
 @task
-def build_dyninst_test_programs(ctx: Context, output_root: Path = ".", debug: bool = False):
+def build_dyninst_test_programs(ctx: Context, output_root: Path = ".", debug: bool = False, ci: bool = False):
     nf_path = os.path.join(output_root, "system-probe-dyninst-test-programs.ninja")
     with open(nf_path, "w") as nf:
         nw = NinjaWriter(nf)
-        go_parallelism = compute_go_parallelism(debug, ci=False)
+        go_parallelism = compute_go_parallelism(debug, ci=ci)
         nw.pool(name="gobuild", depth=go_parallelism)
         nw.rule(
             name="gobin",


### PR DESCRIPTION
### What does this PR do?

- Bumps memory/cpu for `tests_ebpf_*` jobs
- Add timeout to `tests_ebpf_arm64` job
- Add parallelism for dyninst go builds

### Motivation

Avoid timeouts and OOMs

### Describe how you validated your changes

### Additional Notes
