### PR TITLE
fix(inventory/systeminfo): map Windows convertible/detachable chassis codes to Laptop

### DIFF
--- a/pkg/inventory/systeminfo/collector_windows.go
+++ b/pkg/inventory/systeminfo/collector_windows.go
@@ -9,11 +9,17 @@ package systeminfo
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/yusufpapurcu/wmi"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+// otherChassisLogOnce ensures we log the raw WMI chassis code at most once per
+// agent process when the mapping falls through to "Other", so future
+// misclassifications are diagnosable from agent.log without a customer round-trip.
+var otherChassisLogOnce sync.Once
 
 // Win32ComputerSystem WMI class
 //
@@ -77,6 +83,12 @@ func collect() (*SystemInfo, error) {
 		if len(enclosure[0].ChassisTypes) > 0 && len(cs) > 0 {
 			chassisType := enclosure[0].ChassisTypes[0]
 			systemInfo.ChassisType = getChassisTypeName(chassisType, cs[0].Model, cs[0].Manufacturer)
+			if systemInfo.ChassisType == "Other" {
+				otherChassisLogOnce.Do(func() {
+					log.Infof("host chassis type mapped to \"Other\": raw=%v model=%q manufacturer=%q",
+						enclosure[0].ChassisTypes, cs[0].Model, cs[0].Manufacturer)
+				})
+			}
 		}
 	} else {
 		log.Warnf("error querying Win32_SystemEnclosure: %v", err)
@@ -131,7 +143,7 @@ func getChassisTypeName(chassisType int32, model string, manufacturer string) st
 	switch chassisType {
 	case 3, 4, 5, 6, 7, 13, 15, 16, 24: // Desktop variants
 		return "Desktop"
-	case 8, 9, 10, 11, 14: // Portable/Mobile variants
+	case 8, 9, 10, 11, 14, 31, 32: // Portable/Mobile variants (incl. Convertible, Detachable)
 		return "Laptop"
 	default:
 		return "Other"

--- a/pkg/inventory/systeminfo/collector_windows_test.go
+++ b/pkg/inventory/systeminfo/collector_windows_test.go
@@ -66,6 +66,20 @@ func TestGetChassisTypeName_NonVirtualMachines(t *testing.T) {
 			manufacturer: "Dell Inc.",
 			expected:     "Desktop",
 		},
+		{
+			name:         "Convertible 2-in-1",
+			chassisType:  31,
+			model:        "HP EliteBook x360",
+			manufacturer: "HP",
+			expected:     "Laptop",
+		},
+		{
+			name:         "Detachable 2-in-1",
+			chassisType:  32,
+			model:        "Surface Pro",
+			manufacturer: "Microsoft Corporation",
+			expected:     "Laptop",
+		},
 	}
 
 	for _, tc := range nonVMCases {

--- a/releasenotes/notes/fix-windows-chassis-convertible-detachable-96ea26b54e0ee65a.yaml
+++ b/releasenotes/notes/fix-windows-chassis-convertible-detachable-96ea26b54e0ee65a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix chassis type detection on Windows for convertible and detachable
+    2-in-1 devices (SMBIOS codes 31 and 32), which were previously reported
+    as ``Other``.


### PR DESCRIPTION
### What does this PR do?

- Adds SMBIOS chassis codes 31 (Convertible) and 32 (Detachable) to the `"Laptop"` case in the Windows inventory/systeminfo collector, so modern 2-in-1 devices (e.g. HP EliteBook x360, Microsoft Surface Pro) report `chassis_type: "Laptop"` in the EUDM `host_system_info` payload instead of `"Other"`.
- Adds a `sync.Once`-gated `log.Infof` that emits the raw WMI chassis code + model + manufacturer the first time the mapping falls through to `"Other"`, so future misclassifications are diagnosable from `agent.log` without a customer round-trip.

### Motivation

A customer reported that their fleet of HP EliteBook x360 laptops report `chassis_type: "Other"` in the EUDM `host_system_info` payload, breaking their `device_type:Laptop` fleet filter. They confirmed via `Get-CimInstance Win32_SystemEnclosure` that the device reports SMBIOS chassis code **31 (Convertible)**, which is not currently mapped. Code 32 (Detachable) has the same problem for Surface Pro / Surface Book.

Fixes [WINA-2907](https://datadoghq.atlassian.net/browse/WINA-2907).

### Describe how you validated your changes

- Extended `TestGetChassisTypeName_NonVirtualMachines` with cases for codes 31 (HP EliteBook x360) and 32 (Surface Pro), both expecting `"Laptop"`.
- Local cross-compile: `GOOS=windows go build ./pkg/inventory/systeminfo/...` and `GOOS=windows go test -c ./pkg/inventory/systeminfo/` both clean.
- Windows CI will exercise the full test suite.

### Additional Notes

- Tablet (SMBIOS code 30) is deliberately left mapping to `"Other"`. Pure slate semantics are ambiguous in an EUDM fleet; the new diagnostic log will surface any real hits so we can decide with evidence.
- Release note added under `fixes:`, mirroring the wording of the earlier `fix-mac-chassis-detection` note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WINA-2907]: https://datadoghq.atlassian.net/browse/WINA-2907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ