### PR TITLE
[CONTINT-5446] Unbuffered queue for event collection queue

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -87,12 +87,12 @@ type KubeASConfig struct {
 	UseComponentStatus  bool `yaml:"use_component_status"`
 
 	// Event collection configuration
-	CollectEvent              bool   `yaml:"collect_events"`
-	MaxEventCollection        int    `yaml:"max_events_per_run"` // legacy path only; new path drains the full buffer each run
-	EventCollectionTimeoutMs  int    `yaml:"kubernetes_event_read_timeout_ms"`
-	ResyncPeriodEvents        int    `yaml:"kubernetes_event_resync_period_s"`
-	UnbundleEvents            bool   `yaml:"unbundle_events"`
-	BundleUnspecifiedEvents   bool   `yaml:"bundle_unspecified_events"`
+	CollectEvent                   bool   `yaml:"collect_events"`
+	MaxEventCollection             int    `yaml:"max_events_per_run"` // legacy path only; new path drains the full buffer each run
+	EventCollectionTimeoutMs       int    `yaml:"kubernetes_event_read_timeout_ms"`
+	ResyncPeriodEvents             int    `yaml:"kubernetes_event_resync_period_s"`
+	UnbundleEvents                 bool   `yaml:"unbundle_events"`
+	BundleUnspecifiedEvents        bool   `yaml:"bundle_unspecified_events"`
 	EventCollectionMode            string `yaml:"event_collection_mode"` // "poll" (default) or "watch"
 	EventCollectionBufferSize      int    `yaml:"event_collection_buffer_size"`
 	EventCollectionUnboundedBuffer bool   `yaml:"event_collection_unbounded_buffer"` // no dropped events, unbounded memory growth
@@ -216,7 +216,7 @@ func (k *KubeASCheck) Configure(senderManager sender.SenderManager, _ uint64, co
 	if k.instance.EventCollectionBufferSize < 1 {
 		k.instance.EventCollectionBufferSize = defaultEventCollectionBufferSize
 	}
-	if k.instance.EventCollectionUnboundedBuffer {
+	if k.instance.EventCollectionUnboundedBuffer && k.instance.CollectEvent && k.instance.useEventWatchCollection() {
 		log.Warn("event_collection_unbounded_buffer is enabled: event buffer memory is now unbounded")
 	}
 

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -93,8 +93,9 @@ type KubeASConfig struct {
 	ResyncPeriodEvents        int    `yaml:"kubernetes_event_resync_period_s"`
 	UnbundleEvents            bool   `yaml:"unbundle_events"`
 	BundleUnspecifiedEvents   bool   `yaml:"bundle_unspecified_events"`
-	EventCollectionMode       string `yaml:"event_collection_mode"` // "poll" (default) or "watch"
-	EventCollectionBufferSize int    `yaml:"event_collection_buffer_size"`
+	EventCollectionMode            string `yaml:"event_collection_mode"` // "poll" (default) or "watch"
+	EventCollectionBufferSize      int    `yaml:"event_collection_buffer_size"`
+	EventCollectionUnboundedBuffer bool   `yaml:"event_collection_unbounded_buffer"` // no dropped events, unbounded memory growth
 
 	// FilteredEventTypes is a slice of kubernetes field selectors that
 	// works as a deny list of events to filter out.
@@ -214,6 +215,9 @@ func (k *KubeASCheck) Configure(senderManager sender.SenderManager, _ uint64, co
 
 	if k.instance.EventCollectionBufferSize < 1 {
 		k.instance.EventCollectionBufferSize = defaultEventCollectionBufferSize
+	}
+	if k.instance.EventCollectionUnboundedBuffer {
+		log.Warn("event_collection_unbounded_buffer is enabled: event buffer memory is now unbounded")
 	}
 
 	hostnameDetected, _ := hostname.Get(context.TODO())
@@ -360,7 +364,7 @@ func (k *KubeASCheck) startEventCollection() error {
 		k.mu.Unlock()
 		return nil
 	}
-	ec := k.ac.NewEventCollector(k.eventCollection.Filter, k.instance.EventCollectionBufferSize)
+	ec := k.ac.NewEventCollector(k.eventCollection.Filter, k.instance.EventCollectionBufferSize, k.instance.EventCollectionUnboundedBuffer)
 	if ec == nil {
 		k.mu.Unlock()
 		return errors.New("could not create EventCollector: invalid buffer size")

--- a/pkg/util/kubernetes/apiserver/event_collector.go
+++ b/pkg/util/kubernetes/apiserver/event_collector.go
@@ -10,6 +10,7 @@ package apiserver
 import (
 	"context"
 	"strconv"
+	"sync"
 
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
@@ -35,23 +36,35 @@ type EventCollector struct {
 
 	events  chan *v1.Event
 	dropped *atomic.Uint64
+
+	// unbounded, when set, routes enqueue/Drain through buf/bufMu instead of events,
+	// trading the fixed capacity (and its drops) for unbounded memory growth.
+	unbounded bool
+	bufMu     sync.Mutex
+	buf       []*v1.Event
 }
 
-// NewEventCollector returns an EventCollector whose Reflector lists/watches
-// events matching filter (a field selector). Requires that the bufferSize be greater than 0.
-func (c *APIClient) NewEventCollector(filter string, bufferSize int) *EventCollector {
-	if bufferSize <= 0 {
+// NewEventCollector returns an EventCollector whose Reflector lists/watches events
+// matching filter (a field selector). If unbounded is true, bufferSize is ignored and
+// the buffer is never full: events are never dropped, but memory is unbounded. Otherwise
+// bufferSize must be greater than 0.
+func (c *APIClient) NewEventCollector(filter string, bufferSize int, unbounded bool) *EventCollector {
+	if !unbounded && bufferSize <= 0 {
 		log.Errorf("Event collection buffer size must be greater than 0, got %d", bufferSize)
 		return nil
 	}
-	return &EventCollector{
+	ec := &EventCollector{
 		client:       c.InformerCl,
 		filter:       filter,
 		lastRV:       atomic.NewUint64(0),
 		maxDrainedRV: atomic.NewUint64(0),
-		events:       make(chan *v1.Event, bufferSize),
 		dropped:      atomic.NewUint64(0),
+		unbounded:    unbounded,
 	}
+	if !unbounded {
+		ec.events = make(chan *v1.Event, bufferSize)
+	}
+	return ec
 }
 
 // SetCheckpoint seeds the relist-dedup watermark from a persisted resourceVersion
@@ -94,14 +107,30 @@ func (ec *EventCollector) Start(stopCh <-chan struct{}) error {
 // Drain returns the events buffered since the last call, advancing the
 // delivered-resourceVersion checkpoint.
 func (ec *EventCollector) Drain() []*v1.Event {
+	drained := ec.drain()
+	for _, ev := range drained {
+		if rv := parseResourceVersion(ev.ResourceVersion); rv > ec.maxDrainedRV.Load() {
+			ec.maxDrainedRV.Store(rv)
+		}
+	}
+	return drained
+}
+
+// drain empties the buffer without touching maxDrainedRV.
+func (ec *EventCollector) drain() []*v1.Event {
+	if ec.unbounded {
+		ec.bufMu.Lock()
+		defer ec.bufMu.Unlock()
+		drained := ec.buf
+		ec.buf = nil
+		return drained
+	}
+
 	var drained []*v1.Event
 	for {
 		select {
 		case ev := <-ec.events:
 			drained = append(drained, ev)
-			if rv := parseResourceVersion(ev.ResourceVersion); rv > ec.maxDrainedRV.Load() {
-				ec.maxDrainedRV.Store(rv)
-			}
 		default:
 			return drained
 		}
@@ -122,8 +151,16 @@ type noWatchListLW struct {
 // IsWatchListSemanticsUnSupported is read structurally by client-go's reflector.
 func (noWatchListLW) IsWatchListSemanticsUnSupported() bool { return true }
 
-// enqueue buffers an event, dropping it (and counting the drop) if the buffer is full.
+// enqueue buffers an event. If unbounded, it always succeeds; otherwise it drops
+// the event (and counts the drop) if the buffer is full.
 func (ec *EventCollector) enqueue(ev *v1.Event) {
+	if ec.unbounded {
+		ec.bufMu.Lock()
+		ec.buf = append(ec.buf, ev)
+		ec.bufMu.Unlock()
+		return
+	}
+
 	select {
 	case ec.events <- ev:
 	default:

--- a/pkg/util/kubernetes/apiserver/event_collector_test.go
+++ b/pkg/util/kubernetes/apiserver/event_collector_test.go
@@ -11,14 +11,25 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
 )
 
 func makeCollector(bufferSize int) *EventCollector {
 	return &EventCollector{
 		events:       make(chan *v1.Event, bufferSize),
+		dropped:      atomic.NewUint64(0),
+		lastRV:       atomic.NewUint64(0),
+		maxDrainedRV: atomic.NewUint64(0),
+	}
+}
+
+func makeUnboundedCollector() *EventCollector {
+	return &EventCollector{
+		unbounded:    true,
 		dropped:      atomic.NewUint64(0),
 		lastRV:       atomic.NewUint64(0),
 		maxDrainedRV: atomic.NewUint64(0),
@@ -68,6 +79,35 @@ func TestEnqueue(t *testing.T) {
 		ec.events <- ev // fill the buffer
 		ec.enqueue(ev)
 		assert.Equal(t, uint64(1), ec.DrainDropped())
+	})
+
+	t.Run("unbounded: events beyond any bounded capacity are never dropped", func(t *testing.T) {
+		ec := makeUnboundedCollector()
+		for i := 0; i < 100; i++ {
+			ec.enqueue(ev)
+		}
+		assert.Equal(t, uint64(0), ec.DrainDropped())
+		assert.Len(t, ec.Drain(), 100)
+		assert.Nil(t, ec.Drain())
+	})
+}
+
+// TestNewEventCollector verifies bufferSize validation is skipped when unbounded is requested.
+func TestNewEventCollector(t *testing.T) {
+	c := &APIClient{InformerCl: fakeclientset.NewSimpleClientset()}
+
+	t.Run("bounded, bufferSize zero: rejected", func(t *testing.T) {
+		assert.Nil(t, c.NewEventCollector("", 0, false))
+	})
+
+	t.Run("bounded, bufferSize positive: accepted", func(t *testing.T) {
+		assert.NotNil(t, c.NewEventCollector("", 1, false))
+	})
+
+	t.Run("unbounded, bufferSize zero: accepted, bufferSize ignored", func(t *testing.T) {
+		ec := c.NewEventCollector("", 0, true)
+		require.NotNil(t, ec)
+		assert.True(t, ec.unbounded)
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR adds a check config option `event_collection_unbounded_buffer` to the `kubernetes_apiserver` check's reflector-based event collector. When enabled:
- The fixed-size Go channel is replaced by an unbounded, slice-backed buffer guarded by a mutex
- `enqueue` never drops from a full buffer
- `Drain` swaps the buffer out under the lock and advances the resourceVersion checkpoint exactly as before

A warning is logged on startup when the option is active, since the buffer's memory is now bounded only by how fast the check drains it.

### Motivation
https://datadoghq.atlassian.net/browse/CONTINT-5446

### Describe how you validated your changes
- Added unit tests 
-

### Additional Notes
