### PR TITLE
fix(trace): only retry 403 when API key refresh is available

### DIFF
--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -151,6 +151,9 @@ func NewAgent(deps dependencies) (traceagent.Component, error) {
 		}
 		return deps.Secrets.RefreshNow()
 	}
+	tracecfg.APIKeyIsFromSecretFn = func(apiKey string) bool {
+		return deps.Secrets != nil && deps.Secrets.IsValueFromSecret(apiKey)
+	}
 
 	c.Agent = pkgagent.NewAgent(
 		ctx,

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -691,11 +691,12 @@ func New() *AgentConfig {
 		PipeSecurityDescriptor: "D:AI(A;;GA;;;WD)",
 		GUIPort:                "5002",
 
-		StatsWriter:                   new(WriterConfig),
-		TraceWriter:                   new(WriterConfig),
-		ConnectionResetInterval:       0, // disabled
-		MaxSenderRetries:              4,
-		APIKeyRefreshThrottleInterval: 2 * time.Minute,
+		StatsWriter:             new(WriterConfig),
+		TraceWriter:             new(WriterConfig),
+		ConnectionResetInterval: 0, // disabled
+		MaxSenderRetries:        4,
+		// opt in via secret_refresh_on_api_key_failure_interval (0 = disabled)
+		APIKeyRefreshThrottleInterval: 0,
 		ClientStatsFlushInterval:      2 * time.Second, // bucket duration (2s)
 
 		StatsdHost:    "localhost",

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -632,6 +632,10 @@ type AgentConfig struct {
 	// API key refresh from the secrets backend. It blocks until the refresh
 	// completes and returns a message and any error encountered.
 	SecretsRefreshFn func() (string, error) `json:"-"`
+
+	// APIKeyIsFromSecretFn reports whether an API key value was resolved from a
+	// secret handle (and can therefore be changed by a refresh).
+	APIKeyIsFromSecretFn func(apiKey string) bool `json:"-"`
 }
 
 // RemoteClient client is used to APM Sampling Updates from a remote source.

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -196,16 +196,18 @@ func (m *apiKeyManager) Update(newKey string) {
 	m.apiKey = newKey
 }
 
-func (m *apiKeyManager) refresh() {
+// refresh triggers a throttled API key refresh and reports whether the refresh
+// mechanism is available (false = disabled, so a 403 must not be retried).
+func (m *apiKeyManager) refresh() bool {
 	if m.refreshFn == nil || m.throttleInterval == 0 {
-		return
+		return false
 	}
 
 	m.Lock()
 	if time.Since(m.lastRefresh) < m.throttleInterval {
 		m.Unlock()
 		log.Debugf("API Key refresh throttled, last refresh was %v ago", time.Since(m.lastRefresh))
-		return
+		return true
 	}
 
 	// Update the last refresh time before calling refresh to prevent concurrent calls
@@ -217,6 +219,7 @@ func (m *apiKeyManager) refresh() {
 	} else if result != "" {
 		log.Infof("API Key refresh completed: %s", result)
 	}
+	return true
 }
 
 // sender is responsible for sending payloads to a given URL. It uses a size-limited
@@ -465,8 +468,16 @@ func (s *sender) do(req *http.Request) error {
 	resp.Body.Close()
 
 	if resp.StatusCode == http.StatusForbidden {
-		log.Debugf("API Key invalid (403), triggering secret refresh")
-		s.apiKeyManager.refresh()
+		// Retry a 403 only if a key refresh is available; otherwise the key can't
+		// change, so drop immediately instead of retrying against the same bad key.
+		if s.apiKeyManager.refresh() {
+			log.Debugf("API Key invalid (403), triggered secret refresh; retrying payload")
+			return &retriableError{
+				fmt.Errorf("server responded with %q", resp.Status),
+			}
+		}
+		log.Debugf("API Key invalid (403) and secret refresh is unavailable; dropping payload")
+		return errors.New(resp.Status)
 	}
 
 	if isRetriable(resp.StatusCode) {
@@ -482,10 +493,10 @@ func (s *sender) do(req *http.Request) error {
 	return nil
 }
 
-// isRetriable reports whether the give HTTP status code should be retried.
+// isRetriable reports whether an HTTP status code is inherently retriable.
+// 403 is excluded on purpose: it is only retried when refresh is available
 func isRetriable(code int) bool {
-	// TODO: Double check what response codes are expected from the backend when API Key is invalid
-	if code == http.StatusRequestTimeout || code == http.StatusTooManyRequests || code == http.StatusForbidden {
+	if code == http.StatusRequestTimeout || code == http.StatusTooManyRequests {
 		return true
 	}
 	// 5xx errors can be retried

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -60,6 +60,7 @@ func newSenders(cfg *config.AgentConfig, r eventRecorder, path string, climit, q
 			apiKey:           endpoint.APIKey,
 			refreshFn:        cfg.SecretsRefreshFn,
 			throttleInterval: cfg.APIKeyRefreshThrottleInterval,
+			isFromSecret:     cfg.APIKeyIsFromSecretFn,
 		}
 
 		senders[i] = newSender(scfg, apiKeyManager, statsd)
@@ -177,6 +178,9 @@ type apiKeyManager struct {
 	// refreshFn triggers blocking API key refresh from the secrets backend
 	refreshFn func() (string, error)
 
+	// isFromSecret reports whether the current key is secret-backed (nil = unknown, treated as yes)
+	isFromSecret func(apiKey string) bool
+
 	// throttleInterval specifies minimum time between refresh calls
 	throttleInterval time.Duration
 
@@ -200,6 +204,11 @@ func (m *apiKeyManager) Update(newKey string) {
 // mechanism is available (false = disabled, so a 403 must not be retried).
 func (m *apiKeyManager) refresh() bool {
 	if m.refreshFn == nil || m.throttleInterval == 0 {
+		return false
+	}
+	// A refresh can only change a secret-backed key; a static/plaintext key
+	// won't change, so don't retry the 403.
+	if m.isFromSecret != nil && !m.isFromSecret(m.Get()) {
 		return false
 	}
 

--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -367,6 +367,28 @@ func TestSender(t *testing.T) {
 		assert.False(callbackInvoked, "refresh must not run when disabled")
 	})
 
+	t.Run("403_not_retried_when_key_not_from_secret", func(t *testing.T) {
+		assert := assert.New(t)
+		server := newTestServer()
+		defer server.Close()
+		defer useBackoffDuration(time.Nanosecond)()
+
+		s, err := newTestSender(server.URL)
+		assert.NoError(err)
+
+		// Refresh enabled, but the key isn't secret-backed: refresh can't change it, so no retry.
+		callbackInvoked := false
+		s.apiKeyManager.refreshFn = func() (string, error) { callbackInvoked = true; return "", nil }
+		s.apiKeyManager.throttleInterval = 100 * time.Millisecond
+		s.apiKeyManager.isFromSecret = func(string) bool { return false }
+
+		s.Push(expectResponses(403, 403, 403, 403, 200))
+		s.Stop()
+
+		assert.Equal(1, server.Total(), "403 must not be retried when key is not secret-backed")
+		assert.False(callbackInvoked, "refresh must not run when key is not secret-backed")
+	})
+
 	t.Run("403_retries_with_backoff", func(t *testing.T) {
 		assert := assert.New(t)
 		server := newTestServer()

--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -20,9 +20,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
+
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
-	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 const testAPIKey = "123"
@@ -66,7 +67,7 @@ func TestMaxConns(t *testing.T) {
 func TestIsRetriable(t *testing.T) {
 	for code, want := range map[int]bool{
 		400: false,
-		403: true,
+		403: false, // 403 is only retried when API key refresh is available
 		404: false,
 		408: true,
 		409: false,
@@ -340,6 +341,30 @@ func TestSender(t *testing.T) {
 			s.Push(expectResponses(403))
 			s.Stop()
 		})
+	})
+
+	t.Run("403_refresh_disabled_not_retried", func(t *testing.T) {
+		assert := assert.New(t)
+		server := newTestServer()
+		defer server.Close()
+		defer useBackoffDuration(time.Nanosecond)()
+
+		s, err := newTestSender(server.URL)
+		assert.NoError(err)
+
+		// Refresh wired but disabled (throttle == 0): a 403 must not be retried.
+		callbackInvoked := false
+		s.apiKeyManager.refreshFn = func() (string, error) {
+			callbackInvoked = true
+			return "secrets refreshed", nil
+		}
+		s.apiKeyManager.throttleInterval = 0
+
+		s.Push(expectResponses(403, 403, 403, 403, 200))
+		s.Stop()
+
+		assert.Equal(1, server.Total(), "403 must not be retried when refresh is disabled")
+		assert.False(callbackInvoked, "refresh must not run when disabled")
 	})
 
 	t.Run("403_retries_with_backoff", func(t *testing.T) {

--- a/pkg/trace/writer/testserver.go
+++ b/pkg/trace/writer/testserver.go
@@ -151,7 +151,8 @@ func (ts *testServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	statusCode := ts.getNextCode(slurp)
 	w.WriteHeader(statusCode)
 	switch {
-	case isRetriable(statusCode):
+	// count a served 403 as retriable-category for the test server's accounting
+	case isRetriable(statusCode) || statusCode == http.StatusForbidden:
 		ts.retried.Inc()
 	case statusCode/100 == 2: // 2xx
 		ts.accepted.Inc()

--- a/releasenotes/notes/apm-api-403-refresh-fix-05323389c956bd23.yaml
+++ b/releasenotes/notes/apm-api-403-refresh-fix-05323389c956bd23.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: The trace-agent refreshes the API key and retries on a 403 only when
+    ``secret_refresh_on_api_key_failure_interval`` is set (> 0), now consistent with
+    metrics and logs


### PR DESCRIPTION
### What does this PR do?
Follow-up to #45674 and attempts to address this [comment](https://github.com/DataDog/datadog-agent/pull/45674#discussion_r2742183675) (perhaps the best course of action could be to close this PR and leave things as is)

That PR made the trace-agent retry payloads on a 403 (so a rotated api-key gets picked up, but it marked every 403 retriable unconditionally. So with a static/invalid api-key or if secret refresh is disabled, the sender would unnecessarily retry each payload `max_sender_retries` times before dropping it, even though the key can't change, which is unlike the behaviour of the other refresh-on-403 implementations

Now a 403 is only retried when a secret refresh is actually available, otherwise the payload is dropped immediately (same behavior the metrics forwarder & logs pipeline already have). Also flips the default refresh throttle to 0 so the feature is opt-in via `secret_refresh_on_api_key_failure_interval`, consistent with the others.

### Motivation
Caught while QA-ing the 403 api-key-refresh work across teams. `isRetriable(403)` was hardcoded true, so things got retried 4x wastefully. This brings APM in line to how Metrics and Logs and other refresh on 403 work.

### Describe how you validated your changes
- unit tests
- pointed the trace-agent at a local always-403, static key, `secret_refresh_on_api_key_failure_interval: 0`:
  1. before the fix: one payload hit the intake 4x -> Retried payload 4 times -> dropped
  2. after the fix: hit once -> Dropping Payload due to non-retryable error: 403 Forbidden
  3. refresh enabled: still retries on 403 and recovers once the key rotates
  4. ran the same setup against the core agent, metrics (Retried: 0, Dropped) and logs (RetryCount: 0) already drop immediately, so APM now matches

### Additional Notes
default `APIKeyRefreshThrottleInterval` goes from 2m -> 0, so on 403 APM is now opt-in like the others