### PR TITLE
scope `TestIntakeRefreshAPIKey` to the metrics endpoint instead of the global last-key

### DIFF
--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -599,6 +599,19 @@ func (c *Client) GetLastAPIKey() (string, error) {
 	return strings.TrimSpace(string(body)), nil
 }
 
+// GetLastMetricPayloadAPIKey fetches fakeintake on `/api/v2/series` endpoint and returns
+// the API key of the last received metric payload
+func (c *Client) GetLastMetricPayloadAPIKey() (string, error) {
+	payloads, err := c.getFakePayloads(metricsEndpoint)
+	if err != nil {
+		return "", err
+	}
+	if len(payloads) == 0 {
+		return "", errors.New("no metric payloads found")
+	}
+	return payloads[len(payloads)-1].APIKey, nil
+}
+
 func (c *Client) getMetric(name string) ([]*aggregator.MetricSeries, error) {
 	if err := c.getMetrics(); err != nil {
 		return nil, err

--- a/test/new-e2e/tests/agent-configuration/configrefresh_api_key_refresh_test.go
+++ b/test/new-e2e/tests/agent-configuration/configrefresh_api_key_refresh_test.go
@@ -73,9 +73,11 @@ api_key: ENC[api_key]
 		assert.Contains(t, status.Content, "API key ending with wxyz")
 	}, 1*time.Minute, 10*time.Second)
 
-	// Assert that the fakeIntake has received the new API Key
+	// Assert that the fakeIntake has received the new API Key on the metrics
+	// endpoint (GetLastAPIKey is unscoped across all routes, so it can be
+	// clobbered by unrelated traffic like remote-config polling)
 	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		lastAPIKey, err := v.Env().FakeIntake.Client().GetLastAPIKey()
+		lastAPIKey, err := v.Env().FakeIntake.Client().GetLastMetricPayloadAPIKey()
 		assert.NoError(t, err)
 		assert.Equal(t, secondAPIKey, lastAPIKey)
 	}, 1*time.Minute, 10*time.Second)


### PR DESCRIPTION
### What does this PR do?
Claude suggested fix to help alleviate rare transient E2E test failure: https://datadoghq.atlassian.net/jira/software/c/projects/AGENTCFG/boards/8668?selectedIssue=AGENTCFG-819

`TestIntakeRefreshAPIKey` asserts on fakeintake's `GetLastAPIKey()`, which is a single global field overwritten by every payload on every route. There can be a race which periodically flakes the test. Adds a route-scoped `GetLastMetricPayloadAPIKey()` client method and points the test at it.

### Motivation
Recurring CI flake ([job 1813051483](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1813051483)) 

### Describe how you validated your changes
Running tests

### Additional Notes
