### PR TITLE
test(status): pin time.Local to UTC instead of os.Setenv("TZ", "UTC")

### DIFF
--- a/comp/core/status/statusimpl/BUILD.bazel
+++ b/comp/core/status/statusimpl/BUILD.bazel
@@ -41,6 +41,7 @@ dd_agent_go_test(
         "common_header_provider_test.go",
         "status_api_endpoints_test.go",
         "status_test.go",
+        "tz_test.go",
     ],
     embed = [":statusimpl"],
     deps = [

--- a/comp/core/status/statusimpl/common_header_provider_test.go
+++ b/comp/core/status/statusimpl/common_header_provider_test.go
@@ -8,7 +8,6 @@ package statusimpl
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -34,13 +33,11 @@ func TestCommonHeaderProviderIndex(t *testing.T) {
 func TestCommonHeaderProviderJSON(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
-	originalTZ := os.Getenv("TZ")
-	os.Setenv("TZ", "UTC")
+	forceUTC(t)
 
 	defer func() {
 		nowFunc = time.Now
 		startTimeProvider = pkgconfigsetup.StartTime
-		os.Setenv("TZ", originalTZ)
 	}()
 
 	config := config.NewMock(t)
@@ -67,6 +64,7 @@ func TestCommonHeaderProviderJSON(t *testing.T) {
 func TestCommonHeaderProviderText(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
+	forceUTC(t)
 
 	defer func() {
 		nowFunc = time.Now
@@ -145,6 +143,7 @@ func TestCommonHeaderProviderConfig(t *testing.T) {
 func TestCommonHeaderProviderTextWithFipsInformation(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
+	forceUTC(t)
 
 	defer func() {
 		nowFunc = time.Now
@@ -173,13 +172,11 @@ func TestCommonHeaderProviderTextWithFipsInformation(t *testing.T) {
 func TestCommonHeaderProviderHTML(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
-	originalTZ := os.Getenv("TZ")
-	os.Setenv("TZ", "UTC")
+	forceUTC(t)
 
 	defer func() {
 		nowFunc = time.Now
 		startTimeProvider = pkgconfigsetup.StartTime
-		os.Setenv("TZ", originalTZ)
 	}()
 
 	config := config.NewMock(t)
@@ -231,13 +228,11 @@ func TestCommonHeaderProviderHTML(t *testing.T) {
 func TestCommonHeaderProviderHTMLWithFipsInformation(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
-	originalTZ := os.Getenv("TZ")
-	os.Setenv("TZ", "UTC")
+	forceUTC(t)
 
 	defer func() {
 		nowFunc = time.Now
 		startTimeProvider = pkgconfigsetup.StartTime
-		os.Setenv("TZ", originalTZ)
 	}()
 
 	overrides := map[string]interface{}{

--- a/comp/core/status/statusimpl/status_api_endpoints_test.go
+++ b/comp/core/status/statusimpl/status_api_endpoints_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -59,13 +58,11 @@ func getTestComp(t *testing.T, withError bool) provides {
 func TestStatusAPIEndpoints(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
-	originalTZ := os.Getenv("TZ")
-	os.Setenv("TZ", "UTC")
+	forceUTC(t)
 
 	defer func() {
 		nowFunc = time.Now
 		startTimeProvider = pkgconfigsetup.StartTime
-		os.Setenv("TZ", originalTZ)
 	}()
 
 	// Create a new instance of the statusImplementation struct

--- a/comp/core/status/statusimpl/status_test.go
+++ b/comp/core/status/statusimpl/status_test.go
@@ -177,13 +177,11 @@ func getTextStatusOutput(pid int, goVersion string, arch string, flavor string, 
 func TestGetStatus(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
-	originalTZ := os.Getenv("TZ")
-	os.Setenv("TZ", "UTC")
+	forceUTC(t)
 
 	defer func() {
 		nowFunc = time.Now
 		startTimeProvider = pkgconfigsetup.StartTime
-		os.Setenv("TZ", originalTZ)
 	}()
 
 	conf := config.NewMock(t)
@@ -489,13 +487,11 @@ X Section
 func TestGetStatusDoNotRenderHeaderIfNoProviders(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
-	originalTZ := os.Getenv("TZ")
-	os.Setenv("TZ", "UTC")
+	forceUTC(t)
 
 	defer func() {
 		nowFunc = time.Now
 		startTimeProvider = pkgconfigsetup.StartTime
-		os.Setenv("TZ", originalTZ)
 	}()
 
 	conf := config.NewMock(t)
@@ -542,13 +538,11 @@ Section
 func TestGetStatusWithErrors(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
-	originalTZ := os.Getenv("TZ")
-	os.Setenv("TZ", "UTC")
+	forceUTC(t)
 
 	defer func() {
 		nowFunc = time.Now
 		startTimeProvider = pkgconfigsetup.StartTime
-		os.Setenv("TZ", originalTZ)
 	}()
 
 	conf := config.NewMock(t)
@@ -801,13 +795,11 @@ X Section
 func TestGetStatusBySectionsWithErrors(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
-	originalTZ := os.Getenv("TZ")
-	os.Setenv("TZ", "UTC")
+	forceUTC(t)
 
 	defer func() {
 		nowFunc = time.Now
 		startTimeProvider = pkgconfigsetup.StartTime
-		os.Setenv("TZ", originalTZ)
 	}()
 
 	conf := config.NewMock(t)
@@ -931,13 +923,11 @@ Status render errors
 func TestGetStatusByMultipleSections(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
-	originalTZ := os.Getenv("TZ")
-	os.Setenv("TZ", "UTC")
+	forceUTC(t)
 
 	defer func() {
 		nowFunc = time.Now
 		startTimeProvider = pkgconfigsetup.StartTime
-		os.Setenv("TZ", originalTZ)
 	}()
 
 	deps := fxutil.Test[dependencies](t, fx.Options(
@@ -1059,13 +1049,11 @@ func TestGetStatusByMultipleSections(t *testing.T) {
 func TestFlareProvider(t *testing.T) {
 	nowFunc = func() time.Time { return time.Unix(1515151515, 0) }
 	startTimeProvider = time.Unix(1515151515, 0)
-	originalTZ := os.Getenv("TZ")
-	os.Setenv("TZ", "UTC")
+	forceUTC(t)
 
 	defer func() {
 		nowFunc = time.Now
 		startTimeProvider = pkgconfigsetup.StartTime
-		os.Setenv("TZ", originalTZ)
 	}()
 
 	deps := fxutil.Test[dependencies](t, fx.Options(

--- a/comp/core/status/statusimpl/tz_test.go
+++ b/comp/core/status/statusimpl/tz_test.go
@@ -15,12 +15,7 @@ import (
 //
 // It assigns time.Local directly rather than calling os.Setenv("TZ", "UTC").
 // Go resolves the local timezone only once, lazily, the first time time.Local
-// is used (see time.initLocal), and caches it for the rest of the process. If
-// anything reads local time before the test runs — the agent logger timestamps
-// every line in local time — then a later os.Setenv("TZ", ...) has no effect and
-// the status renderer emits "<local> / UTC" instead of "UTC", failing these
-// golden-output assertions on any host whose timezone is not already UTC.
-// Setting time.Local works regardless of when the local zone was first resolved.
+// is used (see time.initLocal), and caches it for the rest of the process.
 func forceUTC(t *testing.T) {
 	t.Helper()
 	original := time.Local

--- a/comp/core/status/statusimpl/tz_test.go
+++ b/comp/core/status/statusimpl/tz_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package statusimpl
+
+import (
+	"testing"
+	"time"
+)
+
+// forceUTC pins the process timezone to UTC for the duration of the test and
+// restores the previous value via t.Cleanup.
+//
+// It assigns time.Local directly rather than calling os.Setenv("TZ", "UTC").
+// Go resolves the local timezone only once, lazily, the first time time.Local
+// is used (see time.initLocal), and caches it for the rest of the process. If
+// anything reads local time before the test runs — the agent logger timestamps
+// every line in local time — then a later os.Setenv("TZ", ...) has no effect and
+// the status renderer emits "<local> / UTC" instead of "UTC", failing these
+// golden-output assertions on any host whose timezone is not already UTC.
+// Setting time.Local works regardless of when the local zone was first resolved.
+func forceUTC(t *testing.T) {
+	t.Helper()
+	original := time.Local
+	time.Local = time.UTC
+	t.Cleanup(func() { time.Local = original })
+}


### PR DESCRIPTION
### What does this PR do?

Makes the `comp/core/status/statusimpl` golden-output tests force UTC by setting `time.Local` directly (via a small `forceUTC(t)` helper, restored with `t.Cleanup`) instead of `os.Setenv("TZ", "UTC")`.

### Motivation

Go resolves `time.Local` once, lazily, on first use and caches it, so `os.Setenv("TZ", "UTC")` can be ignored. Assigning `time.Local` is effective regardless of when the local zone was resolved.

### Describe how you validated your changes

`TZ=Europe/Paris dda inv test --targets=comp/core/status/statusimpl` fails on `main` and passes with this change.

### Additional Notes
Fixes those tests on our AIX hosts.