### PR TITLE
fix(config): avoid full env scan/sort on every nodetreemodel `Get`/`Set`

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -67,7 +67,7 @@ type ntmConfig struct {
 	allowDynamicSchema *atomic.Bool
 	// state of env vars, only used by tests to decide when to rebuild the env var layer. Necessary because
 	// viper would lookup env vars at runtime, instead of storing them, and many many tests rely on this behavior
-	lastEnvVarState string
+	lastRawEnv []string
 
 	// tree debugger is used by the Stringify method, useful for debugging and test assertions
 	td *treeDebugger
@@ -488,18 +488,31 @@ func (c *ntmConfig) isKnownKey(key string) bool {
 
 func (c *ntmConfig) maybeRebuild() {
 	if c.allowDynamicSchema.Load() {
+		// Avoid taking the write lock and sorting in the common case where the raw
+		// environment snapshot is identical to the previous one.
+		rawEnv := os.Environ()
+		c.RLock()
+		unchanged := slices.Equal(c.lastRawEnv, rawEnv)
+		c.RUnlock()
+		if unchanged {
+			return
+		}
+
+		sortedEnv := slices.Clone(rawEnv)
+		slices.Sort(sortedEnv)
+
 		// Write-lock because the root will be written to in order to rebuild the state
 		c.Lock()
 		defer c.Unlock()
 
-		// Only need to rebuild if env vars have different state than last rebuild
-		envs := os.Environ()
-		sort.Strings(envs)
-		envVarState := strings.Join(envs, "$")
-		if c.lastEnvVarState == envVarState {
+		// Avoid an expensive rebuild if only the environment order changed while the
+		// environment content stayed the same.
+		slices.Sort(c.lastRawEnv)
+		unchanged = slices.Equal(c.lastRawEnv, sortedEnv)
+		c.lastRawEnv = rawEnv
+		if unchanged {
 			return
 		}
-		c.lastEnvVarState = envVarState
 
 		// building the schema may access data from the config, disable the dynamic schema
 		// flag to prevent recursive rebuilds

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -2041,3 +2041,15 @@ func TestClearEnvVars(t *testing.T) {
 	cfg.(*ntmConfig).buildEnvVars()
 	assert.Equal(t, "default-b", cfg.GetString("b"))
 }
+
+func BenchmarkMaybeRebuildUnchangedEnv(b *testing.B) {
+	cfg := NewNodeTreeConfig("test", "TEST", nil)
+	cfg.SetTestOnlyDynamicSchema(true)
+	cfg.SetDefault("key", "value")
+	cfg.BuildSchema()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cfg.Get("key")
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Change `nmConfig.maybeRebuild()`to skip the write lock and the full `os.Environ()` sort/join on the common case where the environment hasn't changed since the last check.

### Motivation
Address test flakiness in CI, observed for instance on the `main` branch where `tests_macos_gitlab_amd64` [failed 2 unrelated tests](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1856547151) with timeouts, both traced to this function:
- `pkg/collector/corechecks/system/disk/diskv2`'s test panicked with `test timed out after 3m0s` while its goroutine was caught mid-sort inside `maybeRebuild`,
- `comp/core/configstream/impl`'s test failed on `timed out waiting for recovery snapshot`.

Root cause: `allowDynamicSchema` is `true` for every `configmock.New(t)` config, so this cost is paid by every `Get`/`Set` call made by virtually the whole Go test suite, under a write lock that also serializes concurrent reads against each other.

The proposed fix consists in first taking a **read** lock to compare the raw, **unsorted** `os.Environ()` against the last-seen snapshot: order is stable unless a `Setenv` or `Unsetenv` call happened, so this alone catches the common unchanged case.
On a mismatch it escalates to the write lock and, before actually paying for `buildSchema()`, rules out a same-content reorder (e.g. unset A, unset B, then set B, set A) with an order-independent comparison.
That extra check matters because a spurious rebuild isn't free: it re-merges every config layer and re-appends to c.warnings without deduping, so it needs to be ruled out, not shrugged off.

### Describe how you validated your changes
Added `BenchmarkMaybeRebuildUnchangedEnv` (`Get()` in a loop against a dynamic-schema config with an unchanged environment, the steady-state case this targets).
Before/after on this branch, same machine:
benchmark            | before      | after      | change
---------------------|-------------|------------|-------
ns/op                | 7365        | 899.4      | -87.8%
ns/op (-race)        | 65209       | 8393       | -87.1%
B/op (-race)         | 11536       | 2064       | -82.1%
allocs/op (-race)    | 3           | 2          | -33.3%

`pkg/config/nodetreemodel`, `pkg/config/structure`, `pkg/config/setup`, `pkg/config/mock`, `comp/core/configstream/impl`, and `pkg/collector/corechecks/system/disk/diskv2` all pass under `-race` (900+ tests combined, several of which set env vars mid-test and expect a subsequent Get to pick them up without an explicit `BuildSchema` call, exercising the exact invariant this change must preserve).