### PR TITLE
[WP] Lock network namespace when freeing entry from LRU

### DIFF
--- a/pkg/security/resolvers/netns/resolver.go
+++ b/pkg/security/resolvers/netns/resolver.go
@@ -63,7 +63,13 @@ func NewResolver(config *config.Config, manager *manager.Manager, statsdClient s
 	}
 
 	lru, err := simplelru.NewLRU(1024, func(_ uint32, value *NetworkNamespace) {
-		nr.flushNetworkNamespace(value)
+		value.Lock()
+		defer value.Unlock()
+
+		// this callback is fired while the entry is being removed from the LRU, so it
+		// must only release the resources and never mutate the LRU (doing so would
+		// re-enter this callback and deadlock on value's lock)
+		nr.flushNetworkNamespaceResources(value)
 		tcResolver.FlushNetworkNamespaceID(value.nsID, manager)
 	})
 	if err != nil {
@@ -369,11 +375,21 @@ func (nr *Resolver) FlushNetworkNamespace(netns *NetworkNamespace) {
 // flushNetworkNamespace flushes the cached entries for the provided network namespace.
 func (nr *Resolver) flushNetworkNamespace(netns *NetworkNamespace) {
 	if _, ok := nr.networkNamespaces.Peek(netns.nsID); ok {
-		// remove the entry now, removing the entry will call this function again
+		// the entry is still tracked: removing it from the LRU triggers the eviction
+		// callback which locks the namespace and performs the actual flush
 		_ = nr.networkNamespaces.Remove(netns.nsID)
 		return
 	}
 
+	// the entry is no longer in the LRU, flush its resources directly
+	netns.Lock()
+	defer netns.Unlock()
+	nr.flushNetworkNamespaceResources(netns)
+}
+
+// flushNetworkNamespaceResources releases the resources associated with the provided
+// network namespace. The caller must hold netns' lock.
+func (nr *Resolver) flushNetworkNamespaceResources(netns *NetworkNamespace) {
 	// if we can, make sure the manager has a valid netlink socket to this handle before removing everything
 	handle, err := netns.getNamespaceHandleDup()
 	if err == nil {


### PR DESCRIPTION
### What does this PR do?

Lock network namespace when freeing entry from LRU

### Motivation

Fix data race:

2026-07-09T14:16:38.513880Z 01O === RUN   TestMountEvent/mount-in-container-legitimate
2026-07-09T14:16:38.513909Z 01O ==================
2026-07-09T14:16:38.513914Z 01O WARNING: DATA RACE
2026-07-09T14:16:38.513927Z 01O Write at 0x00c00227a7f0 by goroutine 68697:
2026-07-09T14:16:38.513940Z 01O   internal/poll.(*FD).destroy()
2026-07-09T14:16:38.513952Z 01O       /usr/local/go/src/internal/poll/fd_unix.go:84 +0xcc
2026-07-09T14:16:38.513979Z 01O   internal/poll.(*FD).decref()
2026-07-09T14:16:38.514003Z 01O       /usr/local/go/src/internal/poll/fd_mutex.go:213 +0x36
2026-07-09T14:16:38.514021Z 01O   internal/poll.(*FD).Close()
2026-07-09T14:16:38.514028Z 01O       /usr/local/go/src/internal/poll/fd_unix.go:105 +0x7c
2026-07-09T14:16:38.514032Z 01O   os.(*file).close()
2026-07-09T14:16:38.514040Z 01O       /usr/local/go/src/os/file_unix.go:315 +0xdc
2026-07-09T14:16:38.514043Z 01O   os.(*File).Close()
2026-07-09T14:16:38.514048Z 01O       /usr/local/go/src/os/file_posix.go:23 +0x274
2026-07-09T14:16:38.514058Z 01O   github.com/DataDog/datadog-agent/pkg/security/resolvers/netns.(*NetworkNamespace).close()
2026-07-09T14:16:38.514063Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/netns/network_namespace.go:170 +0x238
2026-07-09T14:16:38.514070Z 01O   github.com/DataDog/datadog-agent/pkg/security/resolvers/netns.(*Resolver).flushNetworkNamespace()
2026-07-09T14:16:38.514080Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/netns/resolver.go:390 +0x29c
2026-07-09T14:16:38.514086Z 01O   github.com/DataDog/datadog-agent/pkg/security/resolvers/netns.NewResolver.func1()
2026-07-09T14:16:38.514092Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/netns/resolver.go:66 +0x46
2026-07-09T14:16:38.514100Z 01O   github.com/hashicorp/golang-lru/v2/simplelru.(*LRU[go.shape.uint32,go.shape.*uint8]).removeElement()
2026-07-09T14:16:38.514105Z 01O       /var/cache/dd/go/pkg/mod/github.com/hashicorp/golang-lru/v2@v2.0.7/simplelru/lru.go:175 +0x392
2026-07-09T14:16:38.514110Z 01O   github.com/hashicorp/golang-lru/v2/simplelru.(*LRU[go.shape.uint32,go.shape.*uint8]).Remove()
2026-07-09T14:16:38.514118Z 01O       /var/cache/dd/go/pkg/mod/github.com/hashicorp/golang-lru/v2@v2.0.7/simplelru/lru.go:100 +0xc4
2026-07-09T14:16:38.514123Z 01O   github.com/DataDog/datadog-agent/pkg/security/resolvers/netns.(*Resolver).flushNetworkNamespace()
2026-07-09T14:16:38.514129Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/netns/resolver.go:373 +0x4a8
2026-07-09T14:16:38.514142Z 01O   github.com/DataDog/datadog-agent/pkg/security/resolvers/netns.(*Resolver).FlushNetworkNamespace()
2026-07-09T14:16:38.514149Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/netns/resolver.go:366 +0x87
2026-07-09T14:16:38.514156Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).FlushNetworkNamespace()
2026-07-09T14:16:38.514164Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:2532 +0x5c
2026-07-09T14:16:38.514169Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleRegularEvent()
2026-07-09T14:16:38.514175Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1424 +0x1584
2026-07-09T14:16:38.514181Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleEvent()
2026-07-09T14:16:38.514186Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1364 +0xb44
2026-07-09T14:16:38.514191Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleEvent-fm()
2026-07-09T14:16:38.514198Z 01O       <autogenerated>:1 +0x52
2026-07-09T14:16:38.514203Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer.(*RingBuffer).handleEvent()
2026-07-09T14:16:38.514253Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go:60 +0x86
2026-07-09T14:16:38.514261Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer.(*RingBuffer).handleEvent-fm()
2026-07-09T14:16:38.514268Z 01O       <autogenerated>:1 +0x48
2026-07-09T14:16:38.514271Z 01O   github.com/DataDog/ebpf-manager.(*RingBuffer).Start.func1()
2026-07-09T14:16:38.514277Z 01O       /var/cache/dd/go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.7.18/ringbuffer.go:138 +0x25b
2026-07-09T14:16:38.514283Z 01O   github.com/DataDog/ebpf-manager.(*RingBuffer).Start.func1()

### Describe how you validated your changes

### Additional Notes
