### PR TITLE
[WP] Trigger SBOM e2e tests on changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1354,6 +1354,7 @@ workflow:
   - changes:
       paths:
         - pkg/sbom/**/*
+        - pkg/security/resolvers/sbom/**/*
         - test/new-e2e/tests/sbom/**/*
       compare_to: $COMPARE_TO_BRANCH
     when: on_success


### PR DESCRIPTION
### What does this PR do?

Trigger SBOM e2e tests on Workload Protection changes

### Motivation

The `package-in-use` feature relies on Workload Protection monitoring.

### Describe how you validated your changes

### Additional Notes
