### PR TITLE
[EBPF] gpu: use single-value bucket for FEC metrics

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fec.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fec.go
@@ -134,7 +134,7 @@ func (c *nvlinkFECCollector) getPortMetrics(port int) ([]*Metric, error) {
 			continue
 		}
 
-		histBounds := [2]float64{float64(bucket), float64(bucket + 1)}
+		histBounds := [2]float64{float64(bucket), float64(bucket)}
 		metric := &Metric{
 			Name:     nvlinkFECHistoryMetricName,
 			Type:     metrics.HistogramType,

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fec_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fec_test.go
@@ -57,7 +57,7 @@ func TestNVLinkFECCollectorScopesAndBuckets(t *testing.T) {
 		require.Equal(t, Medium, metric.Priority)
 		require.Contains(t, metric.Tags, "nvlink_port:1")
 		require.NotNil(t, metric.HistogramBucket)
-		require.Equal(t, [2]float64{float64(bucket), float64(bucket + 1)}, metric.HistogramBucket.Bounds)
+		require.Equal(t, [2]float64{float64(bucket), float64(bucket)}, metric.HistogramBucket.Bounds)
 		require.True(t, metric.HistogramBucket.Monotonic)
 		require.False(t, metric.HistogramBucket.FlushFirstValue)
 	}


### PR DESCRIPTION
### What does this PR do?

Use a bucket with the specific counter value instead of an interval.

### Motivation

Average error rate is not calculated correctly if the bucket is (value, value + 1). Instead we need to specify the value is for a single bucket.

### Describe how you validated your changes

Tested in a NVLink node.

### Additional Notes
