### PR TITLE
fix: temporary disable new-e2e-installer-ansible

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -937,6 +937,7 @@ new-e2e-installer-ansible:
     FLEET_INSTALL_METHOD: "ansible"
     E2E_USE_AWS_PROFILE: "false"
     MAX_RETRIES_FLAG: "--max-retries=3"
+  allow_failure: true
 
 new-e2e-ndm-netflow:
   extends: .new_e2e_template


### PR DESCRIPTION
### What does this PR do?

Temporarily allow the job to fail while I investigate the root cause.