### PR TITLE
fix: use explicit python version to avoid 3.9 EOL

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -937,7 +937,6 @@ new-e2e-installer-ansible:
     FLEET_INSTALL_METHOD: "ansible"
     E2E_USE_AWS_PROFILE: "false"
     MAX_RETRIES_FLAG: "--max-retries=3"
-  allow_failure: true
 
 new-e2e-ndm-netflow:
   extends: .new_e2e_template

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -330,7 +330,7 @@ func (s *packageBaseSuite) installAnsible(flavor e2eos.Descriptor) string {
 		s.Env().RemoteHost.MustExecute("python3 -m pip install ansible")
 		pathPrefix = "/home/centos/.local/bin/"
 	case e2eos.AmazonLinux, e2eos.RedHat:
-		s.Env().RemoteHost.MustExecute("sudo yum install -y python3 python3-pip && yes | pip3 install ansible")
+		s.Env().RemoteHost.MustExecute("sudo yum install -y python3.14 python3.14-pip && yes | pip3.14 install ansible")
 		pathPrefix = "/home/ec2-user/.local/bin/"
 	case e2eos.Suse:
 		s.Env().RemoteHost.MustExecute("sudo zypper install -y python3 python3-pip && sudo pip3 install ansible")


### PR DESCRIPTION
### What does this PR do?

Install Ansible with Python 3.14 to use a supported Python version. This allows to update Ansible to a newer version and fixes SSL errors which induced incident 57703.

Waiting for [this job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1861216678) to succeed (and the rest of the pipeline for non-regression) before merging.