### PR TITLE
Stop emitting uselists for ebpf programs

### DIFF
--- a/bazel/rules/ebpf/ebpf.bzl
+++ b/bazel/rules/ebpf/ebpf.bzl
@@ -27,6 +27,9 @@ _COMMON_FLAGS = [
     "-Wall",
     "-Werror",
     "-O2",
+    # LLVM 12 can serialize use-list order nondeterministically for large modules.
+    "-Xclang",
+    "-no-emit-llvm-uselists",
     "-fno-stack-protector",
     "-fno-color-diagnostics",
     "-fno-unwind-tables",


### PR DESCRIPTION
### What does this PR do?

We've discovered that the build of `usm.o` is non-deterministic because entries in `USELIST_CODE_DEFAULT` swap between compilations. To prevent this from happening we stop producing uselists entirely.

### Motivation

AFAICS, this is one of two major working blocks before we achieve fully reproducible builds of EBPF programs. Another one is non-hermetic kernel headers