### PR TITLE
test(new-e2e): wait for sysprobe socket before restart test

### DIFF
--- a/test/new-e2e/tests/agent-platform/tests/macos_install_test.go
+++ b/test/new-e2e/tests/agent-platform/tests/macos_install_test.go
@@ -33,9 +33,10 @@ import (
 )
 
 const (
-	macosAgentAPIPort  = 5001
-	macosGUIPort       = 5002
-	macosAuthTokenPath = "/opt/datadog-agent/etc/auth_token"
+	macosAgentAPIPort       = 5001
+	macosGUIPort            = 5002
+	macosAuthTokenPath      = "/opt/datadog-agent/etc/auth_token"
+	macosSysprobeSocketPath = "/opt/datadog-agent/run/sysprobe.sock"
 )
 
 type macosInstallSuite struct {
@@ -110,6 +111,8 @@ func (m *macosInstallSuite) enableSysprobeForRestartTest(macosTestClient *common
 
 	m.EventuallyWithT(func(c *assert.CollectT) {
 		macosLaunchdPID(c, macosTestClient, "system/com.datadoghq.sysprobe")
+		// Wait for the sysprobe socket to be available, since testAgentRestart dials it directly.
+		macosTestClient.MustExecuteOn(c, "sudo test -S "+macosSysprobeSocketPath)
 	}, 20*time.Second, 1*time.Second)
 }
 


### PR DESCRIPTION
TestAgentRestart dials system-probe's unix socket directly, but the readiness check only waited for launchd to report a pid, which just means the binary was forked. The fx app can take longer to bind the socket, causing a "no such file or directory" dial error in CI.

### What does this PR do?

Adds a readiness check in `TestAgentRestart`'s sysprobe setup that waits for the sysprobe unix socket file to exist before proceeding, in addition to the existing launchd pid check.

### Motivation

Incident: https://app.datadoghq.com/incidents/57694

### Describe how you validated your changes

### Additional Notes
