### PR TITLE
[go migration] use dd_agent_go_test on //pkg/logs/...

### DIFF
--- a/pkg/logs/BUILD.bazel
+++ b/pkg/logs/BUILD.bazel
@@ -1,0 +1,3 @@
+# Package delimiter
+
+# gazelle:dd_agent_go_test on

--- a/pkg/logs/internal/decoder/BUILD.bazel
+++ b/pkg/logs/internal/decoder/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 # Top-level not migrated yet; subdirs (e.g. preprocessor/) are.
 
@@ -52,7 +53,7 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "decoder_test",
     srcs = [
         "auto_multiline_handler_test.go",
@@ -63,7 +64,6 @@ go_test(
         "single_line_handler_test.go",
     ],
     embed = [":decoder"],
-    gotags = ["test"],
     deps = [
         "//comp/logs/agent/config",
         "//pkg/config/mock",

--- a/pkg/logs/internal/decoder/preprocessor/BUILD.bazel
+++ b/pkg/logs/internal/decoder/preprocessor/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "preprocessor",
@@ -48,7 +49,7 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "preprocessor_test",
     srcs = [
         "aggregator_test.go",
@@ -71,7 +72,6 @@ go_test(
         "user_samples_test.go",
     ],
     embed = [":preprocessor"],
-    gotags = ["test"],
     deps = [
         "//comp/logs-library/metrics",
         "//comp/logs/agent/config",

--- a/pkg/logs/internal/framer/BUILD.bazel
+++ b/pkg/logs/internal/framer/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "framer",
@@ -31,7 +32,7 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "framer_test",
     srcs = [
         "docker_stream_test.go",
@@ -40,7 +41,6 @@ go_test(
         "syslog_test.go",
     ],
     embed = [":framer"],
-    gotags = ["test"],
     deps = [
         "//pkg/logs/message",
         "//pkg/logs/status/utils",

--- a/pkg/logs/internal/parsers/dockerfile/BUILD.bazel
+++ b/pkg/logs/internal/parsers/dockerfile/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "dockerfile",
@@ -22,14 +23,13 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "dockerfile_test",
     srcs = [
         "docker_file_fuzz_test.go",
         "docker_file_test.go",
     ],
     embed = [":dockerfile"],
-    gotags = ["test"],
     deps = [
         "//pkg/logs/message",
         "@com_github_stretchr_testify//assert",

--- a/pkg/logs/internal/parsers/dockerstream/BUILD.bazel
+++ b/pkg/logs/internal/parsers/dockerstream/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "dockerstream",
@@ -22,14 +23,13 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "dockerstream_test",
     srcs = [
         "docker_stream_fuzz_test.go",
         "docker_stream_test.go",
     ],
     embed = [":dockerstream"],
-    gotags = ["test"],
     deps = [
         "//pkg/logs/message",
         "@com_github_stretchr_testify//assert",

--- a/pkg/logs/internal/parsers/encodedtext/BUILD.bazel
+++ b/pkg/logs/internal/parsers/encodedtext/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "encodedtext",
@@ -25,14 +26,13 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "encodedtext_test",
     srcs = [
         "encodedtext_fuzz_test.go",
         "encodedtext_test.go",
     ],
     embed = [":encodedtext"],
-    gotags = ["test"],
     deps = [
         "//pkg/logs/message",
         "@com_github_stretchr_testify//assert",

--- a/pkg/logs/internal/parsers/integrations/BUILD.bazel
+++ b/pkg/logs/internal/parsers/integrations/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "integrations",
@@ -21,14 +22,13 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "integrations_test",
     srcs = [
         "integrations_fuzz_test.go",
         "integrations_test.go",
     ],
     embed = [":integrations"],
-    gotags = ["test"],
     deps = [
         "//pkg/logs/message",
         "@com_github_stretchr_testify//assert",

--- a/pkg/logs/internal/parsers/kubernetes/BUILD.bazel
+++ b/pkg/logs/internal/parsers/kubernetes/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "kubernetes",
@@ -22,14 +23,13 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "kubernetes_test",
     srcs = [
         "kubernetes_fuzz_test.go",
         "kubernetes_test.go",
     ],
     embed = [":kubernetes"],
-    gotags = ["test"],
     deps = [
         "//pkg/logs/message",
         "@com_github_stretchr_testify//assert",

--- a/pkg/logs/internal/parsers/noop/BUILD.bazel
+++ b/pkg/logs/internal/parsers/noop/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "noop",
@@ -21,11 +22,10 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "noop_test",
     srcs = ["noop_test.go"],
     embed = [":noop"],
-    gotags = ["test"],
     deps = [
         "//pkg/logs/message",
         "@com_github_stretchr_testify//assert",

--- a/pkg/logs/internal/parsers/syslog/BUILD.bazel
+++ b/pkg/logs/internal/parsers/syslog/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "syslog",
@@ -27,7 +28,7 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "syslog_test",
     srcs = [
         "cef_leef_test.go",
@@ -37,7 +38,6 @@ go_test(
         "syslog_test.go",
     ],
     embed = [":syslog"],
-    gotags = ["test"],
     deps = [
         "//comp/logs/agent/config",
         "//pkg/logs/message",

--- a/pkg/logs/internal/util/BUILD.bazel
+++ b/pkg/logs/internal/util/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "util",
@@ -28,14 +29,13 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "util_test",
     srcs = [
         "moving_sum_test.go",
         "service_name_test.go",
     ],
     embed = [":util"],
-    gotags = ["test"],
     deps = [
         "//comp/core/tagger/types",
         "@com_github_benbjohnson_clock//:clock",

--- a/pkg/logs/internal/util/adlistener/BUILD.bazel
+++ b/pkg/logs/internal/util/adlistener/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "adlistener",
@@ -21,11 +22,10 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "adlistener_test",
     srcs = ["ad_test.go"],
     embed = [":adlistener"],
-    gotags = ["test"],
     deps = [
         "//comp/core",
         "//comp/core/autodiscovery/integration",

--- a/pkg/logs/internal/util/containersorpods/BUILD.bazel
+++ b/pkg/logs/internal/util/containersorpods/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "containersorpods",
@@ -29,11 +30,10 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "containersorpods_test",
     srcs = ["containers_or_pods_test.go"],
     embed = [":containersorpods"],
-    gotags = ["test"],
     deps = [
         "//pkg/config/env",
         "//pkg/config/mock",

--- a/pkg/logs/launchers/container/BUILD.bazel
+++ b/pkg/logs/launchers/container/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "container",
@@ -23,11 +24,15 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "container_test",
     srcs = ["launcher_test.go"],
     embed = [":container"],
-    gotags = ["test"],
+    flavors = [
+        "base",
+        "dogstatsd",
+        "fips",
+    ],
     deps = [
         "//comp/core/tagger/fx-mock",
         "//comp/core/workloadmeta/def",

--- a/pkg/logs/launchers/container/tailerfactory/BUILD.bazel
+++ b/pkg/logs/launchers/container/tailerfactory/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "tailerfactory",
@@ -39,7 +40,7 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "tailerfactory_test",
     srcs = [
         "api_test.go",
@@ -50,7 +51,11 @@ go_test(
         "whichtailer_test.go",
     ],
     embed = [":tailerfactory"],
-    gotags = ["test"],
+    flavors = [
+        "base",
+        "dogstatsd",
+        "fips",
+    ],
     deps = [
         "//comp/core/config",
         "//comp/core/log/def",

--- a/pkg/logs/launchers/container/tailerfactory/tailers/BUILD.bazel
+++ b/pkg/logs/launchers/container/tailerfactory/tailers/BUILD.bazel
@@ -29,7 +29,8 @@ dd_agent_go_test(
     name = "tailers_test",
     srcs = ["tailer_test.go"],
     embed = [":tailers"],
-    flavors = ["base"],  # keep, other flavors do not build because they need kubelet tags.
+    # Only do base becuase other flavors do not build with the needed kubelet tags.
+    flavors = ["base"],  # keep
     deps = [
         "//pkg/logs/tailers/container",
         "@com_github_stretchr_testify//require",

--- a/pkg/logs/launchers/container/tailerfactory/tailers/BUILD.bazel
+++ b/pkg/logs/launchers/container/tailerfactory/tailers/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "tailers",
@@ -24,11 +25,11 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "tailers_test",
     srcs = ["tailer_test.go"],
     embed = [":tailers"],
-    gotags = ["test"],
+    flavors = ["base"],  # keep, other flavors do not build because they need kubelet tags.
     deps = [
         "//pkg/logs/tailers/container",
         "@com_github_stretchr_testify//require",

--- a/pkg/logs/launchers/file/BUILD.bazel
+++ b/pkg/logs/launchers/file/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "file",
@@ -31,7 +32,7 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "file_test",
     srcs = [
         "launcher_privileged_logs_test.go",
@@ -39,7 +40,6 @@ go_test(
         "position_test.go",
     ],
     embed = [":file"],
-    gotags = ["test"],
     deps = [
         "//comp/logs/agent/config",
         "//comp/logs/auditor/mock",

--- a/pkg/logs/launchers/file/provider/BUILD.bazel
+++ b/pkg/logs/launchers/file/provider/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "provider",
@@ -18,11 +19,10 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "provider_test",
     srcs = ["file_provider_test.go"],
     embed = [":provider"],
-    gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:aix": [
             "//comp/logs/agent/config",

--- a/pkg/logs/launchers/integration/BUILD.bazel
+++ b/pkg/logs/launchers/integration/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "integration",
@@ -21,11 +22,10 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "integration_test",
     srcs = ["launcher_test.go"],
     embed = [":integration"],
-    gotags = ["test"],
     deps = [
         "//comp/core/autodiscovery/integration",
         "//comp/logs-library/pipeline",

--- a/pkg/logs/launchers/journald/BUILD.bazel
+++ b/pkg/logs/launchers/journald/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "journald",
@@ -24,11 +25,15 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "journald_test",
     srcs = ["launcher_test.go"],
     embed = [":journald"],
-    gotags = ["test"],
+    flavors = [
+        "base",
+        "fips",
+        "iot",
+    ],
     deps = [
         "//comp/core/tagger/fx-mock",
         "//comp/logs-library/pipeline",

--- a/pkg/logs/launchers/listener/BUILD.bazel
+++ b/pkg/logs/launchers/listener/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "listener",
@@ -25,7 +26,7 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "listener_test",
     srcs = [
         "errors_test.go",
@@ -37,7 +38,6 @@ go_test(
         "udp_test.go",
     ],
     embed = [":listener"],
-    gotags = ["test"],
     deps = [
         "//comp/logs-library/pipeline/mock",
         "//comp/logs/agent/config",

--- a/pkg/logs/launchers/windowsevent/BUILD.bazel
+++ b/pkg/logs/launchers/windowsevent/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "windowsevent",
@@ -120,11 +121,10 @@ go_library(
     }),
 )
 
-go_test(
+dd_agent_go_test(
     name = "windowsevent_test",
     srcs = ["launcher_test.go"],
     embed = [":windowsevent"],
-    gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:windows": [
             "//comp/logs/agent/config",

--- a/pkg/logs/message/BUILD.bazel
+++ b/pkg/logs/message/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "message",
@@ -16,7 +17,7 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "message_test",
     srcs = [
         "message_test.go",
@@ -25,7 +26,6 @@ go_test(
         "status_test.go",
     ],
     embed = [":message"],
-    gotags = ["test"],
     deps = [
         "//comp/logs/agent/config",
         "//pkg/logs/sources",

--- a/pkg/logs/schedulers/BUILD.bazel
+++ b/pkg/logs/schedulers/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "schedulers",
@@ -15,11 +16,10 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "schedulers_test",
     srcs = ["base_test.go"],
     embed = [":schedulers"],
-    gotags = ["test"],
     deps = [
         "//pkg/logs/service",
         "//pkg/logs/sources",

--- a/pkg/logs/schedulers/ad/BUILD.bazel
+++ b/pkg/logs/schedulers/ad/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "ad",
@@ -22,11 +23,10 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "ad_test",
     srcs = ["scheduler_test.go"],
     embed = [":ad"],
-    gotags = ["test"],
     deps = [
         "//comp/core/autodiscovery/integration",
         "//comp/core/autodiscovery/providers/names",

--- a/pkg/logs/schedulers/channel/BUILD.bazel
+++ b/pkg/logs/schedulers/channel/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "channel",
@@ -13,11 +14,10 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "channel_test",
     srcs = ["scheduler_test.go"],
     embed = [":channel"],
-    gotags = ["test"],
     deps = [
         "//comp/logs/agent/config",
         "//pkg/logs/schedulers",

--- a/pkg/logs/service/BUILD.bazel
+++ b/pkg/logs/service/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "service",
@@ -11,10 +12,9 @@ go_library(
     deps = ["//pkg/util/log"],
 )
 
-go_test(
+dd_agent_go_test(
     name = "service_test",
     srcs = ["services_test.go"],
     embed = [":service"],
-    gotags = ["test"],
     deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/pkg/logs/sources/BUILD.bazel
+++ b/pkg/logs/sources/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "sources",
@@ -18,7 +19,7 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "sources_test",
     srcs = [
         "config_source_test.go",
@@ -26,7 +27,6 @@ go_test(
         "sources_test.go",
     ],
     embed = [":sources"],
-    gotags = ["test"],
     deps = [
         "//comp/logs/agent/config",
         "@com_github_stretchr_testify//assert",

--- a/pkg/logs/status/BUILD.bazel
+++ b/pkg/logs/status/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "status",
@@ -21,11 +22,10 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "status_test",
     srcs = ["status_test.go"],
     embed = [":status"],
-    gotags = ["test"],
     deps = [
         "//comp/logs-library/metrics",
         "//comp/logs/agent/config",

--- a/pkg/logs/status/utils/BUILD.bazel
+++ b/pkg/logs/status/utils/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "utils",
@@ -12,7 +13,7 @@ go_library(
     deps = ["@org_uber_go_atomic//:atomic"],
 )
 
-go_test(
+dd_agent_go_test(
     name = "utils_test",
     srcs = [
         "info_test.go",
@@ -20,7 +21,6 @@ go_test(
         "status_test.go",
     ],
     embed = [":utils"],
-    gotags = ["test"],
     deps = [
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//suite",

--- a/pkg/logs/tailers/BUILD.bazel
+++ b/pkg/logs/tailers/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "tailers",
@@ -11,11 +12,10 @@ go_library(
     deps = ["//pkg/logs/status/utils"],
 )
 
-go_test(
+dd_agent_go_test(
     name = "tailers_test",
     srcs = ["tailer_tracker_test.go"],
     embed = [":tailers"],
-    gotags = ["test"],
     deps = [
         "//pkg/logs/status/utils",
         "@com_github_stretchr_testify//require",

--- a/pkg/logs/tailers/channel/BUILD.bazel
+++ b/pkg/logs/tailers/channel/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "channel",
@@ -12,11 +13,10 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "channel_test",
     srcs = ["tailer_test.go"],
     embed = [":channel"],
-    gotags = ["test"],
     deps = [
         "//comp/logs/agent/config",
         "//pkg/logs/message",

--- a/pkg/logs/tailers/container/BUILD.bazel
+++ b/pkg/logs/tailers/container/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "container",
@@ -27,14 +28,18 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "container_test",
     srcs = [
         "reader_test.go",
         "tailer_test.go",
     ],
     embed = [":container"],
-    gotags = ["test"],
+    flavors = [
+        "base",
+        "dogstatsd",
+        "fips",
+    ],
     deps = [
         "//comp/logs/agent/config",
         "//comp/logs/auditor/mock",

--- a/pkg/logs/tailers/socket/BUILD.bazel
+++ b/pkg/logs/tailers/socket/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "socket",
@@ -20,7 +21,7 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "socket_test",
     srcs = [
         "datagram_tailer_test.go",
@@ -28,7 +29,6 @@ go_test(
         "syslog_bench_test.go",
     ],
     embed = [":socket"],
-    gotags = ["test"],
     deps = [
         "//comp/logs/agent/config",
         "//pkg/config/mock",

--- a/pkg/logs/tailers/windowsevent/BUILD.bazel
+++ b/pkg/logs/tailers/windowsevent/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "windowsevent",
@@ -27,11 +28,10 @@ go_library(
     }),
 )
 
-go_test(
+dd_agent_go_test(
     name = "windowsevent_test",
     srcs = ["tailer_test.go"],
     embed = [":windowsevent"],
-    gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:windows": [
             "//comp/logs/agent/config",

--- a/pkg/logs/util/windowsevent/BUILD.bazel
+++ b/pkg/logs/util/windowsevent/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "windowsevent",
@@ -25,14 +26,13 @@ go_library(
     }),
 )
 
-go_test(
+dd_agent_go_test(
     name = "windowsevent_test",
     srcs = [
         "message_test.go",
         "transform_test.go",
     ],
     embed = [":windowsevent"],
-    gotags = ["test"],
     deps = [
         "//comp/logs/agent/config",
         "//pkg/logs/message",


### PR DESCRIPTION
### What does this PR do?

- Use dd_agent_go_test on //pkg/logs/...
- Except //pkg/logs/launchers/container/tailerfactory/tailers, which is essentially base only, because it relies on tages that are not in dogstatsd and iot.

### Describe how you validated your changes
- CI
- Hand run test and compare
```
bazel run //pkg/logs/launchers/container/tailerfactory/tailers:tailers_test_base
dda inv test --targets pkg/logs/launchers/container/tailerfactory/tailers --verbose
```
