### PR TITLE
perf(config): avoid quadratic-time default registration at startup

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -57,6 +57,10 @@ type ntmConfig struct {
 	// ready is whether the schema has been built, which marks the config as ready for use
 	ready *atomic.Bool
 
+	// defaultSetAtMode controls how setDefault attaches a newly created node to an existing inner node:
+	// mutateInPlace until flipped to copyOnWrite for good, once nodes may become shared elsewhere.
+	defaultSetAtMode *atomic.Bool
+
 	// Bellow are all the different configuration layers. Each layers represents a source for our configuration.
 	// They are merge into the 'root' tree following order of importance (see pkg/model/viper.go:sourcesPriority).
 
@@ -289,7 +293,7 @@ func (c *ntmConfig) insertValueIntoTree(key string, value interface{}, source mo
 	}
 
 	parts := splitKey(key)
-	err = tree.setAt(parts, value, source)
+	err = tree.setAt(parts, value, source, copyOnWrite) // tree might already be shared
 	return tree, err
 }
 
@@ -323,7 +327,7 @@ func (c *ntmConfig) SetDefault(key string, value interface{}) {
 
 func (c *ntmConfig) setDefault(key string, value interface{}) {
 	parts := splitKey(key)
-	_ = c.defaults.setAt(parts, value, model.SourceDefault)
+	_ = c.defaults.setAt(parts, value, model.SourceDefault, setAtMode(c.defaultSetAtMode.Load()))
 }
 
 func (c *ntmConfig) findPreviousSourceNode(key string, source model.Source) (*nodeImpl, error) {
@@ -581,6 +585,7 @@ func (c *ntmConfig) mergeAllLayers() error {
 		return err
 	}
 	c.root = merged
+	c.defaultSetAtMode.Store(bool(copyOnWrite)) // c.defaults just became reachable through c.root
 	return nil
 }
 
@@ -675,7 +680,7 @@ func (c *ntmConfig) insertNodeFromString(curr *nodeImpl, key string, envval stri
 		}
 	}
 	parts := splitKeyFunc(key)
-	return curr.setAt(parts, actualValue, model.SourceEnvVar)
+	return curr.setAt(parts, actualValue, model.SourceEnvVar, mutateInPlace) // node is always new
 }
 
 // ParseEnvAsStringSlice registers a transform function to parse an environment variable as a []string.
@@ -1208,6 +1213,7 @@ func (c *ntmConfig) Object() model.Reader {
 func NewNodeTreeConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) model.BuildableConfig {
 	config := ntmConfig{
 		ready:              atomic.NewBool(false),
+		defaultSetAtMode:   atomic.NewBool(bool(mutateInPlace)),
 		allowDynamicSchema: atomic.NewBool(false),
 		sequenceID:         0,
 		configEnvVars:      map[string][]string{},

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -57,10 +57,6 @@ type ntmConfig struct {
 	// ready is whether the schema has been built, which marks the config as ready for use
 	ready *atomic.Bool
 
-	// defaultSetAtMode controls how setDefault attaches a newly created node to an existing inner node:
-	// mutateInPlace until flipped to copyOnWrite for good, once nodes may become shared elsewhere.
-	defaultSetAtMode *atomic.Bool
-
 	// Bellow are all the different configuration layers. Each layers represents a source for our configuration.
 	// They are merge into the 'root' tree following order of importance (see pkg/model/viper.go:sourcesPriority).
 
@@ -208,6 +204,9 @@ func (c *ntmConfig) SetTestOnlyDynamicSchema(allow bool) {
 // config, instead of treating it as sealed
 // NOTE: Only used by OTel, no new uses please!
 func (c *ntmConfig) RevertFinishedBackToBuilder() model.BuildableConfig {
+	c.Lock()
+	defer c.Unlock()
+	c.root = newInnerNode(nil) // invalidated with ready becoming false
 	c.ready.Store(false)
 	return c
 }
@@ -293,7 +292,7 @@ func (c *ntmConfig) insertValueIntoTree(key string, value interface{}, source mo
 	}
 
 	parts := splitKey(key)
-	err = tree.setAt(parts, value, source, copyOnWrite) // tree might already be shared
+	err = tree.setAt(parts, value, source, copyOnWrite) // config may already be in use
 	return tree, err
 }
 
@@ -326,8 +325,11 @@ func (c *ntmConfig) SetDefault(key string, value interface{}) {
 }
 
 func (c *ntmConfig) setDefault(key string, value interface{}) {
-	parts := splitKey(key)
-	_ = c.defaults.setAt(parts, value, model.SourceDefault, setAtMode(c.defaultSetAtMode.Load()))
+	mode := copyOnWrite
+	if !c.isReady() {
+		mode = mutateInPlace // still being initialized
+	}
+	_ = c.defaults.setAt(splitKey(key), value, model.SourceDefault, mode)
 }
 
 func (c *ntmConfig) findPreviousSourceNode(key string, source model.Source) (*nodeImpl, error) {
@@ -585,7 +587,6 @@ func (c *ntmConfig) mergeAllLayers() error {
 		return err
 	}
 	c.root = merged
-	c.defaultSetAtMode.Store(bool(copyOnWrite)) // c.defaults just became reachable through c.root
 	return nil
 }
 
@@ -680,7 +681,7 @@ func (c *ntmConfig) insertNodeFromString(curr *nodeImpl, key string, envval stri
 		}
 	}
 	parts := splitKeyFunc(key)
-	return curr.setAt(parts, actualValue, model.SourceEnvVar, mutateInPlace) // node is always new
+	return curr.setAt(parts, actualValue, model.SourceEnvVar, mutateInPlace) // still being initialized
 }
 
 // ParseEnvAsStringSlice registers a transform function to parse an environment variable as a []string.
@@ -1213,7 +1214,6 @@ func (c *ntmConfig) Object() model.Reader {
 func NewNodeTreeConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) model.BuildableConfig {
 	config := ntmConfig{
 		ready:              atomic.NewBool(false),
-		defaultSetAtMode:   atomic.NewBool(bool(mutateInPlace)),
 		allowDynamicSchema: atomic.NewBool(false),
 		sequenceID:         0,
 		configEnvVars:      map[string][]string{},

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -123,6 +123,7 @@ func TestNewConfig(t *testing.T) {
 	c := cfg.(*ntmConfig)
 
 	assert.False(t, c.ready.Load())
+	assert.Equal(t, bool(mutateInPlace), c.defaultSetAtMode.Load())
 
 	assert.Equal(t, "config_name", c.configName)
 	assert.Equal(t, "", c.configFile)
@@ -2040,6 +2041,26 @@ func TestClearEnvVars(t *testing.T) {
 	t.Setenv("TEST_B", "leaked-via-rebuild")
 	cfg.(*ntmConfig).buildEnvVars()
 	assert.Equal(t, "default-b", cfg.GetString("b"))
+}
+
+// TestSetDefaultAfterRevertToBuilderDoesNotCorruptSharedRoot verifies that a node fetched via
+// GetNode stays frozen even if SetDefault runs afterward through RevertFinishedBackToBuilder
+// (used by OTel): Merge() can alias a defaults node into c.root, so setDefault must not mutate
+// that node in place once it may be shared, regardless of ready's value.
+func TestSetDefaultAfterRevertToBuilderDoesNotCorruptSharedRoot(t *testing.T) {
+	cfg := NewNodeTreeConfig("test", "TEST", nil)
+	cfg.SetTestOnlyDynamicSchema(true)
+	cfg.SetDefault("ns.existing", "v1")
+	cfg.BuildSchema()
+
+	node, err := cfg.(NodeTreeConfig).GetNode("ns")
+	require.NoError(t, err)
+	before := node.ChildrenKeys()
+
+	cfg = cfg.RevertFinishedBackToBuilder() //nolint:forbidigo // for test purposes
+	cfg.SetDefault("ns.new", "v2")
+
+	assert.Equal(t, before, node.ChildrenKeys())
 }
 
 func BenchmarkMaybeRebuildUnchangedEnv(b *testing.B) {

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -123,7 +123,6 @@ func TestNewConfig(t *testing.T) {
 	c := cfg.(*ntmConfig)
 
 	assert.False(t, c.ready.Load())
-	assert.Equal(t, bool(mutateInPlace), c.defaultSetAtMode.Load())
 
 	assert.Equal(t, "config_name", c.configName)
 	assert.Equal(t, "", c.configFile)
@@ -2043,24 +2042,19 @@ func TestClearEnvVars(t *testing.T) {
 	assert.Equal(t, "default-b", cfg.GetString("b"))
 }
 
-// TestSetDefaultAfterRevertToBuilderDoesNotCorruptSharedRoot verifies that a node fetched via
-// GetNode stays frozen even if SetDefault runs afterward through RevertFinishedBackToBuilder
-// (used by OTel): Merge() can alias a defaults node into c.root, so setDefault must not mutate
-// that node in place once it may be shared, regardless of ready's value.
-func TestSetDefaultAfterRevertToBuilderDoesNotCorruptSharedRoot(t *testing.T) {
+// TestSetDefaultAfterRevertToBuilder follows the sequence cmd/otel-agent runs: revert a built
+// config back to a builder, register more defaults, then build it again.
+func TestSetDefaultAfterRevertToBuilder(t *testing.T) {
 	cfg := NewNodeTreeConfig("test", "TEST", nil)
-	cfg.SetTestOnlyDynamicSchema(true)
 	cfg.SetDefault("ns.existing", "v1")
 	cfg.BuildSchema()
 
-	node, err := cfg.(NodeTreeConfig).GetNode("ns")
-	require.NoError(t, err)
-	before := node.ChildrenKeys()
-
-	cfg = cfg.RevertFinishedBackToBuilder() //nolint:forbidigo // for test purposes
+	cfg = cfg.RevertFinishedBackToBuilder() //nolint:forbidigo // testing behavior
 	cfg.SetDefault("ns.new", "v2")
+	cfg.BuildSchema()
 
-	assert.Equal(t, before, node.ChildrenKeys())
+	assert.Equal(t, "v1", cfg.GetString("ns.existing"))
+	assert.Equal(t, "v2", cfg.GetString("ns.new"))
 }
 
 func BenchmarkMaybeRebuildUnchangedEnv(b *testing.B) {

--- a/pkg/config/nodetreemodel/node.go
+++ b/pkg/config/nodetreemodel/node.go
@@ -141,17 +141,29 @@ func (n *nodeImpl) ChildrenKeys() []string {
 	return mapkeys
 }
 
+// setAtMode controls how setAt attaches a newly created node to an existing inner node.
+type setAtMode bool
+
+const (
+	// copyOnWrite clones an existing inner node's children map instead of mutating it, ensuring a tree that has already
+	// been shared is never mutated while it may be read concurrently.
+	copyOnWrite setAtMode = false
+	// mutateInPlace mutates an existing inner node's children map directly. Safe only while the tree is still being
+	// built and has not yet become observable elsewhere.
+	mutateInPlace setAtMode = true
+)
+
 // setAt sets a value in the tree by either creating a leaf node or updating one if the priority is equal or higher than
 // the existing one. The function returns true if an update was done or false if nothing was changed.
 //
 // The key parts should already be lowercased.
 //
 // This method should only be called on the root of a tree, not on an inner node with parents.
-func (n *nodeImpl) setAt(key []string, value interface{}, source model.Source) error {
+func (n *nodeImpl) setAt(key []string, value interface{}, source model.Source, mode setAtMode) error {
 	if len(key) == 0 {
 		return errors.New("empty key given to Set")
 	}
-	newNode, err := setNodeAtPath(n, key, value, source)
+	newNode, err := setNodeAtPath(n, key, value, source, mode)
 	if newNode != nil && newNode.IsInnerNode() {
 		n.children = newNode.children
 	}
@@ -161,7 +173,7 @@ func (n *nodeImpl) setAt(key []string, value interface{}, source model.Source) e
 // setNodeAtPath allocates a new branch, ending in a leaf at the given path of fields, with the
 // given value, and returns the root of that branch. If a leaf already exists at that path,
 // instead it is modified and no branch is allocated and this returns nil
-func setNodeAtPath(n *nodeImpl, fields []string, value interface{}, source model.Source) (*nodeImpl, error) {
+func setNodeAtPath(n *nodeImpl, fields []string, value interface{}, source model.Source, mode setAtMode) (*nodeImpl, error) {
 	if len(fields) == 0 {
 		return newLeafNode(value, source), nil
 	}
@@ -182,12 +194,18 @@ func setNodeAtPath(n *nodeImpl, fields []string, value interface{}, source model
 	}
 
 	// Recursively set the node at the remaining part of the path
-	createdNode, err := setNodeAtPath(next, fields[1:], value, source)
+	createdNode, err := setNodeAtPath(next, fields[1:], value, source, mode)
 	if err != nil || createdNode == nil {
 		return nil, err
 	}
 
-	// Create a new inner node using the modified list of child nodes
+	// Either attach the child directly to the existing node
+	if n != nil && mode == mutateInPlace {
+		n.children[f] = createdNode
+		return n, nil
+	}
+
+	// Or create a new inner node using the modified list of child nodes
 	var copyChildren map[string]*nodeImpl
 	if n != nil {
 		copyChildren = maps.Clone(n.children)

--- a/pkg/config/nodetreemodel/node.go
+++ b/pkg/config/nodetreemodel/node.go
@@ -145,11 +145,9 @@ func (n *nodeImpl) ChildrenKeys() []string {
 type setAtMode bool
 
 const (
-	// copyOnWrite clones an existing inner node's children map instead of mutating it, ensuring a tree that has already
-	// been shared is never mutated while it may be read concurrently.
+	// copyOnWrite clones an existing inner node's children map instead of mutating it, for a config that is in use.
 	copyOnWrite setAtMode = false
-	// mutateInPlace mutates an existing inner node's children map directly. Safe only while the tree is still being
-	// built and has not yet become observable elsewhere.
+	// mutateInPlace mutates an existing inner node's children map directly, for a config still being initialized.
 	mutateInPlace setAtMode = true
 )
 

--- a/pkg/config/nodetreemodel/node_test.go
+++ b/pkg/config/nodetreemodel/node_test.go
@@ -6,6 +6,7 @@
 package nodetreemodel
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -58,4 +59,17 @@ func TestNewNodeAndNodeMethods(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.True(t, fifthLeaf.IsLeafNode())
+}
+
+func BenchmarkSetDefaultManyKeys(b *testing.B) {
+	for _, n := range []int{100, 500, 1000, 2000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				cfg := NewNodeTreeConfig("test", "TEST", nil)
+				for k := 0; k < n; k++ {
+					cfg.SetDefault(fmt.Sprintf("section%d.key%d", k%20, k), k)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
### What does this PR do?
Add `setAtMode` (`copyOnWrite`/`mutateInPlace`), a mode passed to `nodeImpl.setAt` that controls whether attaching a child to an existing inner node clones its children map or mutates it directly.

`setDefault` (used by `SetDefault`/`BindEnvAndSetDefault`) ~~reads a dedicated `defaultSetAtMode` field, flipped from `mutateInPlace` to `copyOnWrite` for good the moment `mergeAllLayers` first folds `c.defaults` into `c.root`~~ derives its mode from `isReady`: `mutateInPlace` while the config is still being initialized, `copyOnWrite` once it is in use.

`insertNodeFromString` (used by `buildEnvVars`) always uses `mutateInPlace`, since it builds into a fresh tree, ~~unpublished~~ not yet in use.

`insertValueIntoTree` (used by `Set`) always uses `copyOnWrite`, since it can target any layer that may already be merged into `c.root`.

`RevertFinishedBackToBuilder` (used by OTel) discards `c.root` along with the ready flag, so an unready config carries no merged tree, exactly as before its first build.

### Motivation
Found while stress-testing #53624: a goroutine dump caught `configmock.New(t)`'s ~2000 `BindEnvAndSetDefault` calls stuck in `maps.Clone` inside `nodetreemodel.setNodeAtPath`.

Each call that creates a new key clones its parent's children map, and that map only grows, so the Nth sibling key registered this way costs `O(N)` on its own: **`O(N^2)`** overall to register N of them, _not_ `O(N)`.

This isn't test-only: `pkg/config/create.NewConfig`, which backs both `configmock.New(t)` and the **production**
`setup.SetDatadog`/`setup.SetSystemProbe` calls at Agent startup, is `nodetreemodel.NewNodeTreeConfig`, so every Agent process pays this cost too (not just the ~270 test files across the repo accounting for ~980 call sites to `configmock.New`).

Cloning protects a tree that's already in use from being mutated while it's read concurrently, but `c.defaults` doesn't need that protection **while it's still being built**: ~~nothing can reach it through `GetNode` until `mergeAllLayers` folds it into `c.root`~~ the config is not in use until `BuildSchema` marks it ready.
The same applies to `buildEnvVars`' local root, which is always fresh and ~~unpublished~~ not yet in use at that point.

The catch is that `c.defaults` is long-lived, and `Merge` reuses its child pointers straight into `c.root` for any key no other layer contests (most keys).
Once merged, a later `SetDefault` (dynamic schema mode allows this) could mutate a node `c.root` still aliases.

~~`ready` can't gate that: `RevertFinishedBackToBuilder` (used by OTel) resets it to `false` _without un-merging_ `c.defaults` from `c.root`.~~
~~A repro test (`TestSetDefaultAfterRevertToBuilderDoesNotCorruptSharedRoot`) catches exactly that gap: a node fetched via `GetNode` picking up a key added after such a revert.~~
~~`defaultSetAtMode` fixes it by tracking the one fact that matters, independent of `ready`: whether `c.defaults` has been merged into `c.root`.~~
~~It's flipped inside `mergeAllLayers` itself, right next to where `c.root` gets reassigned to the merge result.~~
`ready` does gate that, once `RevertFinishedBackToBuilder` stops leaving a merged tree behind: discarding `c.root` there makes `isReady` false mean the config is genuinely back to being initialized, so no second flag is needed.

### Describe how you validated your changes
Added `BenchmarkSetDefaultManyKeys` (`SetDefault` in a loop across 20 shared namespaces, `n` from 100 to 2000 keys, mirroring how `pkg/config/setup` registers its ~2000 defaults).

Measured 10 independent runs per side in an isolated `origin/main` worktree and compared them with `benchstat`:
| n | sec/op (before -> after) | B/op (before -> after) | allocs/op (before -> after) |
|---|---|---|---|
| 100 | 138.3µ -> 77.3µ (-44%) | 151.9Ki -> 36.7Ki (-76%) | 1333 -> 613 (-54%) |
| 500 | 650.1µ -> 335.6µ (-48%) | 972.8Ki -> 163.8Ki (-83%) | 7767 -> 3205 (-59%) |
| 1000 | 1454.4µ -> 690.8µ (-53%) | 2516.4Ki -> 331.1Ki (-87%) | 16315 -> 6750 (-59%) |
| 2000 | 3.588m -> 1.322m (-63%) | 7147.3Ki -> 670.2Ki (-91%) | 33380 -> 13800 (-59%) |

All deltas are significant:
- B/op grows about 47x for a 20x increase in `n` before this change (superlinear, the `O(n)` clones of a growing map),
- and about 18x after (close to linear): the fix removes the growth-with-n behavior, not just its constant factor.

Also measured the production path (`create.NewConfig` + `setup.InitConfig`, what `setup.SetDatadog` runs at startup), `benchstat` over 6 runs per side:
| step | sec/op (before -> after) | B/op (before -> after) | allocs/op (before -> after) |
|---|---|---|---|
| InitConfig | 20.94m -> 3.46m (-83%) | 34.5Mi -> 1.6Mi (-95%) | 41.5k -> 20.9k (-50%) |
| + BuildSchema | 26.36m -> 6.02m (-77%) | 35.3Mi -> 2.4Mi (-93%) | 41.9k -> 21.3k (-49%) |

Every Agent process allocates ~35 MiB building its config before this change, and ~2.4 MiB after.

`pkg/config/nodetreemodel`, `pkg/config/structure`, `pkg/config/setup`, `pkg/config/mock`, `comp/core/configstream/impl`, and `pkg/collector/corechecks/system/disk/diskv2` all pass under `-race` (~700 tests combined).

After moving the gate to `isReady`, re-measured `BenchmarkSetDefaultManyKeys`: at n=2000, B/op 7318654 -> 686272 (-91%) and allocs/op 33376 -> 13799 (-59%), matching the table above. 673 tests pass across `pkg/config/nodetreemodel` and its dependents `setup`, `mock`, `structure` and `buildschema`, plus `comp/core/configstream/impl` and `cmd/otel-agent/config`, the only caller of `RevertFinishedBackToBuilder`.

~~`TestSetDefaultAfterRevertToBuilderDoesNotCorruptSharedRoot`~~ `TestSetDefaultAfterRevertToBuilder` now follows the sequence `cmd/otel-agent` runs, and guards what reassigning a tree in `RevertFinishedBackToBuilder` risks: it fails if that drops `c.defaults` instead of `c.root`, or leaves the ready flag set. What it no longer asserts is the aliasing invariant, unobservable now that `GetNode` is discounted.
