### PR TITLE
bump memory for KMT setup jobs to prevent OOMs

### DIFF
--- a/.gitlab/test/kernel_matrix_testing/common.yml
+++ b/.gitlab/test/kernel_matrix_testing/common.yml
@@ -166,8 +166,8 @@
     PIPELINE_ID: $CI_PIPELINE_ID
     TEAM: "ebpf-platform"
     RESOURCE_TAGS: "instance-type:${INSTANCE_TYPE},arch:${ARCH},test-component:${TEST_COMPONENT},git-branch:${CI_COMMIT_REF_NAME}"
-    KUBERNETES_MEMORY_REQUEST: "12Gi"
-    KUBERNETES_MEMORY_LIMIT: "16Gi"
+    KUBERNETES_MEMORY_REQUEST: "16Gi"
+    KUBERNETES_MEMORY_LIMIT: "20Gi"
     VMCONFIG_FILE: "${CI_PROJECT_DIR}/vmconfig-${CI_PIPELINE_ID}-${ARCH}.json"
     EXTERNAL_LINKS_PATH: external_links_$CI_JOB_ID.json
   before_script:


### PR DESCRIPTION
### What does this PR do?

Increase memory request and limit by 4GiB for KMT setup jobs

### Motivation

Increase in OOMs during this job.

### Describe how you validated your changes

### Additional Notes
