### PR TITLE
chore: bump Agent Data Plane to 1.4.0

### DIFF
--- a/deps/adp.json
+++ b/deps/adp.json
@@ -1,13 +1,13 @@
 {
-  "version": "1.3.1",
+  "version": "1.4.0",
   "hashes": {
-    "linux-amd64": "23b49fde8563a9a3a8dc68b46331c4dcb87373a4d50df74a3d40b26bdaa7b3e4",
-    "linux-arm64": "95c3ce251e686f371d516930d96d5b9357463faaec15dc361240403767e63450",
-    "fips-linux-amd64": "ba21cc727bfb117c05833a710ba14af492dd7e9b2cabe4c1e2e77f51e548799e",
-    "fips-linux-arm64": "9b92b8bbb33f00195205bdf07847d9e8fe6681f66faf401a62311f0b00db2d14",
-    "darwin-amd64": "e956ecbe696afb1a3e5f019a2f3594e40804e98f1bfe862ffc9e18850779cb5f",
-    "darwin-arm64": "cfdf28d45c68271eb24fc7fe6ec89c0d996a10d72fb681143fe899e7ffd97437",
-    "windows-amd64": "8c0370e37d1b544647dae9411955b1a6324ff23d485bf8be57ef4cf97cfe2b30",
-    "fips-windows-amd64": "f797704d3e2ac5da04c3cfc005841ed71be25cf412aea8436edc95a5e92a2ff0"
+    "linux-amd64": "3904f9ab8a11f6f21211ee87792122d3e66a72f0c103482057d44d11549738b8",
+    "linux-arm64": "c6dcca770e7df20266c68af73138cfa43db68aace57699c7557408e77925d7cc",
+    "fips-linux-amd64": "0f5d9c921a998f2b0b6b299deb3f194963f41fb0d32d55b4f6719d4da6fff7af",
+    "fips-linux-arm64": "9d079994e841d4986ae0efbefe009d3cd45b4b4c8e8831579d26c493b28c3d8d",
+    "darwin-amd64": "7586ef3041bcd11f9dad1baf7a7f26ff4e2dc239ef59c2d28ebd0e0879f41568",
+    "darwin-arm64": "e40ad02931ba893de49427d9c3a1c4683a0f615a58e96287fdd47e1b089b7699",
+    "windows-amd64": "a2692fa7d961b8e1b1f01ddcf86060f542195124397e69bfacf152ceda47d436",
+    "fips-windows-amd64": "30199587a487bf3312bad913929ee6a951e244f3cbdeafccec4ac8edbaf05cb9"
   }
 }

--- a/releasenotes/notes/bump-agent-data-plane-1-4-0-0c4ef41e86364713.yaml
+++ b/releasenotes/notes/bump-agent-data-plane-1-4-0-0c4ef41e86364713.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Agent Data Plane has been bumped to version 1.4.0. See the `Agent Data Plane 1.4.0 release notes <https://github.com/DataDog/saluki/releases/tag/1.4.0>`_.


### PR DESCRIPTION
### What does this PR do?

Bumps Agent Data Plane from 1.3.1 to 1.4.0 and updates the SHA-256 hashes for all Linux, macOS, and Windows artifacts in `deps/adp.json`.

Adds a release note linking to the upstream Agent Data Plane 1.4.0 release notes.

### Motivation

Package the Agent Data Plane 1.4.0 release in the Datadog Agent.

### Describe how you validated your changes

- Ran `dda inv invoke-unit-tests.run --tests=adp_macos_windows_packaging --directory=tasks/unit_tests --verbosity=2` (9 tests passed).
- Ran the release-note UID and RST linters.
- Verified all eight hashes against the release jobs in the Saluki pipeline.
- Verified all eight published artifact URLs are available.

### Additional Notes

- Release notes: https://github.com/DataDog/saluki/releases/tag/1.4.0
- Saluki pipeline: https://gitlab.ddbuild.io/DataDog/saluki/-/pipelines/124769753
