### PR TITLE
Codegen keep-orig-order works with func calls

### DIFF
--- a/pkg/config/schema/yaml/agent_telemetry.yaml
+++ b/pkg/config/schema/yaml/agent_telemetry.yaml
@@ -35,9 +35,8 @@ properties:
     node_type: setting
     type: integer
     default: 1
-    comment: |-
-      default compression first setup inside the next bindEnvAndSetLogsConfigKeys() function ...
-      ... and overridden by the following two lines - do not switch these 3 lines order
+    comment: '... and overridden by the following two lines - do not switch these
+      3 lines order'
   connection_reset_interval:
     node_type: setting
     type: integer

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -2056,9 +2056,7 @@ properties:
             default: false
             visibility: public
             description: '[Preview] Enables Synthetics tests.'
-            comment: |-
-              Generic resources configuration
-              Synthetics configuration
+            comment: Synthetics configuration
           workers:
             node_type: setting
             type: integer
@@ -4017,7 +4015,6 @@ properties:
           It should contain less than 100 characters and should not contain any of
           `<`, `>`, `\n`, `\t`, `\r` characters.
           This field is used by NDM features (SNMP check, SNMP Traps listener, etc).
-        comment: Network Devices Monitoring
       default_scan:
         node_type: section
         type: object
@@ -4959,7 +4956,6 @@ properties:
                 node_type: setting
                 type: boolean
                 default: false
-                comment: Network Config Management
       metadata:
         node_type: section
         type: object
@@ -5077,9 +5073,7 @@ properties:
         visibility: public
         description: The number of concurrent workers used to perform reverse DNS
           lookups.
-        comment: |-
-          Data Observability
-          Reverse DNS Enrichment
+        comment: Reverse DNS Enrichment
       chan_size:
         node_type: setting
         type: integer

--- a/pkg/config/schema/yaml/logs_config.yaml
+++ b/pkg/config/schema/yaml/logs_config.yaml
@@ -502,7 +502,6 @@ properties:
     tags:
     - golang_type:duration
     comment: |-
-      Delegated authentication for logs
       Duration during which the host tags will be submitted with log events.
       duration-formatted string (parsed by `time.ParseDuration`)
   experimental_adaptive_sampling:
@@ -874,3 +873,4 @@ properties:
     node_type: setting
     type: integer
     default: 1
+comment: Delegated authentication for logs

--- a/pkg/config/schema/yaml/process_config.yaml
+++ b/pkg/config/schema/yaml/process_config.yaml
@@ -396,7 +396,6 @@ properties:
     - DD_PROCESS_CONFIG_ORCHESTRATOR_DD_URL
     - DD_PROCESS_AGENT_ORCHESTRATOR_DD_URL
     comment: |-
-      Service discovery configuration
       Orchestrator Explorer - process agent
       DEPRECATED in favor of `orchestrator_explorer.orchestrator_dd_url` setting. If both are set `orchestrator_explorer.orchestrator_dd_url` will take precedence.
   process_dd_url:

--- a/pkg/config/schema/yaml/remote_configuration.yaml
+++ b/pkg/config/schema/yaml/remote_configuration.yaml
@@ -144,7 +144,6 @@ properties:
     node_type: setting
     type: boolean
     default: false
-    comment: Delegated authentication for remote_configuration
   no_tls_validation:
     node_type: setting
     type: boolean
@@ -169,3 +168,4 @@ properties:
     node_type: setting
     type: string
     default: 0s
+comment: Delegated authentication for remote_configuration

--- a/tasks/schema/codegen_init_settings.py
+++ b/tasks/schema/codegen_init_settings.py
@@ -431,8 +431,6 @@ def get_suffixes_for_pattern(pattern):
             'delegated_auth.aws.region',
             'api_key',
         ]
-    elif pattern == 'pattern_event_monitor':
-        return ['']
     else:
         raise RuntimeError(f"unknown pattern: {pattern}")
 

--- a/tasks/schema/codegen_init_settings.py
+++ b/tasks/schema/codegen_init_settings.py
@@ -70,6 +70,18 @@ class CodeGeneratorTarget:
             sourcecode = self.filesystem[filename]
             output_func_header(funcname, sourcecode)
             for row in settings:
+                # pattern
+                if row[1].startswith('pattern_'):
+                    suffix_list = get_suffixes_for_pattern(row[1])
+                    for suffix in suffix_list:
+                        keyname = join_key(row[0], suffix)
+                        if keyname not in self.buffer:
+                            continue
+                        setting = self.buffer[keyname]
+                        self.buffer[keyname].done = True
+                        sourcecode = sourcecode + setting.sourcecode
+                    continue
+                # single setting
                 keyname = row[0]
                 if keyname not in self.buffer:
                     continue
@@ -148,10 +160,12 @@ class CodeGeneratorTarget:
                 f.write('\n'.join(self.filesystem[filename]))
 
 
-def join_key(path, field):
-    if path == '':
+def join_key(prefix, field):
+    if prefix == '':
         return field
-    return f"{path}.{field}"
+    if prefix.endswith('.'):
+        return f"{prefix}{field}"
+    return f"{prefix}.{field}"
 
 
 def _is_node_leaf(node):
@@ -184,6 +198,12 @@ def retrieve_hint(hints_obj, keyname):
         for row in perFilenameFuncSettings['settings']:
             if row[0] == keyname:
                 return {'kind': row[1], 'internal_comment': row[2]}
+            elif row[1].startswith('pattern_') and keyname.startswith(row[0]):
+                # When multiple settings are created for a prefix, only add the
+                # comment to the first such setting.
+                internal_comment = row[2]
+                row[2] = ''
+                return {'kind': row[1], 'internal_comment': internal_comment}
     return None
 
 
@@ -376,6 +396,45 @@ def retrieve_method_to_declare(keypath, schema):
         if 'no-env' in tags:
             return 'SetDefault'
     return 'BindEnvAndSetDefault'
+
+
+def get_suffixes_for_pattern(pattern):
+    if pattern == 'pattern_logs_config':
+        return [
+            'logs_dd_url',
+            'dd_url',
+            'additional_endpoints',
+            'use_compression',
+            'compression_kind',
+            'zstd_compression_level',
+            'compression_level',
+            'batch_wait',
+            'connection_reset_interval',
+            'logs_no_ssl',
+            'batch_max_concurrent_send',
+            'batch_max_content_size',
+            'batch_max_size',
+            'input_chan_size',
+            'sender_backoff_factor',
+            'sender_backoff_base',
+            'sender_backoff_max',
+            'sender_recovery_interval',
+            'sender_recovery_reset',
+            'use_v2_api',
+            'dev_mode_no_ssl',
+        ]
+    elif pattern == 'pattern_delegate_auth':
+        return [
+            'delegated_auth.org_uuid',
+            'delegated_auth.refresh_interval_mins',
+            'delegated_auth.provider',
+            'delegated_auth.aws.region',
+            'api_key',
+        ]
+    elif pattern == 'pattern_event_monitor':
+        return ['']
+    else:
+        raise RuntimeError(f"unknown pattern: {pattern}")
 
 
 def env_parser_to_func_call(name, env_parser, get_vartype):

--- a/tasks/schema/settings_source_analyzer.py
+++ b/tasks/schema/settings_source_analyzer.py
@@ -5,6 +5,11 @@ func_start_regex = r'^func (\w+)\(\w+ pkgconfigmodel.Setup\)'
 declare_regex = r'^c\w+g\.BindEnvAndSetDefault\((.*)\)'
 set_default_regex = r'^c\w+g\.SetDefault\((.*)\)'
 proc_declare_regex = r'^procBindEnvAndSetDefault\(\w+, (.*)\)'
+event_monitor_regex = r'^eventMonitorBindEnvAndSetDefault\(\w+, (.*)\)'
+
+bind_env_logs = r'bindEnvAndSetLogsConfigKeys\(\w+, "([\w_\.]+)"'
+bind_delegate = r'bindDelegatedAuthConfig\(\w+, "([\w_\.]+)"'
+
 
 # Prefixes that begin a setting declaration. A declaration may span several lines (the arguments, a
 # `[]string{...}` default, or a `GetPlatformDefault(map[...]{...})` value), so we accumulate lines until the
@@ -154,19 +159,17 @@ class Processor:
                 self.dispatch(joined)
             return
 
-        # TODO: Handle these functions
         if line.startswith('bindEnvAndSetLogsConfigKeys'):
-            return
+            m = re.match(bind_env_logs, line)
+            if m:
+                self.register_pattern('pattern_logs_config', m.group(1))
+                return
+
         if line.startswith('bindDelegatedAuthConfig'):
-            return
-        if line.startswith('pkgconfigmodel.AddOverrideFunc'):
-            return
-        if line.startswith('config.ParseEnvAs'):
-            return
-        if line.startswith('setupProcesses'):
-            return
-        if line.startswith('setupPrivateActionRunner'):
-            return
+            m = re.match(bind_delegate, line)
+            if m:
+                self.register_pattern('pattern_delegate_auth', m.group(1))
+                return
 
         if not line.startswith(DECL_START_PREFIXES):
             return
@@ -196,6 +199,11 @@ class Processor:
             self.register_setting('proc', m.group(1))
             return
 
+        m = re.match(event_monitor_regex, line)
+        if m:
+            self.register_setting('eventmon', m.group(1))
+            return
+
     def append_internal_comment(self, text):
         text = text.strip()
         if text.startswith('//'):
@@ -211,6 +219,13 @@ class Processor:
             return None
         return params[index].strip('" \'')
 
+    def register_pattern(self, pattern_kind, setting_prefix):
+        if not self.currfunc:
+            raise RuntimeError('not currently in a function')
+        internal_comment = '\n'.join(self.internal_comment)
+        self.internal_comment = []
+        self.settings.append([setting_prefix, pattern_kind, internal_comment])
+
     def register_setting(self, kind, params):
         if not self.currfunc:
             raise RuntimeError('not currently in a function')
@@ -224,13 +239,7 @@ class Processor:
         internal_comment = '\n'.join(self.internal_comment)
         self.internal_comment = []
 
-        if kind == 'declare':
-            keyname = self.clean_param(parts, 0)
-            _unused_default = self.clean_param(parts, 1)
-        elif kind == 'default':
-            keyname = self.clean_param(parts, 0)
-            _unused_default = self.clean_param(parts, 1)
-        elif kind == 'proc':
+        if kind in ['declare', 'default', 'proc', 'eventmon']:
             keyname = self.clean_param(parts, 0)
             _unused_default = self.clean_param(parts, 1)
         else:


### PR DESCRIPTION
### What does this PR do?

Function calls like `bindEnvAndSetLogsConfigKeys` and `bindDelegatedAuthConfig` are handled by the code analyzer, such that the generated code has the relevant settings show up in the correct place. Calls to `eventMonitorBindEnvAndSetDefault` are handled just like `procBindEnvAndSetDefault`

### Motivation

Shrink the codegen diff to validate correct behavior

### Describe how you validated your changes

Run `dda inv schema.codegen --keep-orig-order` and diff the generated code against the in-tree source files.

### Additional Notes
