### PR TITLE
bazel: make pkg/discovery/module's cgo build hermetic

### DIFF
--- a/pkg/discovery/module/BUILD.bazel
+++ b/pkg/discovery/module/BUILD.bazel
@@ -12,25 +12,15 @@ go_library(
         "impl_services_rust_log_bridge_linux.go",
         "impl_services_rust_logger_linux.go",
     ],
+    cdeps = select({
+        "@rules_go//go/platform:linux": [
+            "//pkg/discovery/module/rust:dd_discovery_cc",
+        ],
+        "//conditions:default": [],
+    }),
     cgo = True,
-    clinkopts = select({
-        "@rules_go//go/platform:android": [
-            "-Lpkg/discovery/module/pkg/discovery/module/rust -Lpkg/discovery/module/pkg/discovery/module/rust/target/release -ldd_discovery",
-        ],
-        "@rules_go//go/platform:linux": [
-            "-Lpkg/discovery/module/pkg/discovery/module/rust -Lpkg/discovery/module/pkg/discovery/module/rust/target/release -ldd_discovery",
-        ],
-        "//conditions:default": [],
-    }),
-    copts = select({
-        "@rules_go//go/platform:android": [
-            "-Ipkg/discovery/module/pkg/discovery/module/rust/include",
-        ],
-        "@rules_go//go/platform:linux": [
-            "-Ipkg/discovery/module/pkg/discovery/module/rust/include",
-        ],
-        "//conditions:default": [],
-    }),
+    clinkopts = [],  # keep
+    copts = [],  # keep
     importpath = "github.com/DataDog/datadog-agent/pkg/discovery/module",
     visibility = ["//visibility:public"],
     deps = select({

--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -119,6 +119,15 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+cc_library(
+    name = "dd_discovery_cc",
+    hdrs = [":dd_discovery_headers"],
+    includes = ["include"],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [":libdd_discovery"],
+)
+
 # ============================================================================
 # Binary Targets
 # ============================================================================


### PR DESCRIPTION
### What does this PR do?

Adds a `cc_library` wrapping the Rust-built `libdd_discovery` static lib and its header (`pkg/discovery/module/rust/BUILD.bazel`), and depends on it via `cdeps` on the `go_library` (`pkg/discovery/module/BUILD.bazel`).

### Motivation

The `go_library`'s existing `copts`/`clinkopts` point at a source-tree path that only exists after manually running `bazel run //pkg/discovery/module/rust:install_libs` (the legacy `dda inv system-probe.build-object-files` step).
Bazel's own dependency graph knows nothing about that step. A clean `bazel build`/`bazel test` therefore fails with `dd_discovery.h: No such file or directory`. 

### Describe how you validated your changes

- `bazel test //...` from a clean worktree

### Additional Notes

Currently, the test appears to pass because it was run in a context where dd_discovery.h has been materialized and that result was cached.

The existing `copts`/`clinkopts` and the `#cgo CFLAGS`/`LDFLAGS` directives in the Go source are kept as is to avoid breaking the "legacy" build.
