### PR TITLE
Revert "Temporarily disable Bazel's `--disk_cache` in CI (#53434)"

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -326,8 +326,8 @@
         "usagesDigest": "CKsn1dtme4oztWA0td45Tt6oCZK6MZnpIocVVZK14sU=",
         "recordedInputs": [
           "FILE:@@//.bazelversion 1b9487d55bea47fea50d226cc9c53bc548877ad2a318bac8fbc8b320f429e5c5",
-          "FILE:@@//tools/bazel ef4b6d604f4271360466b120a594075f033a5ac127d272d1dfd4c28d28057d70",
-          "FILE:@@//tools/bazel.bat b4d1cf9bd2a8c3abfae0ff53c207584c7a0a91f7f06d1fe681861f13652d3132",
+          "FILE:@@//tools/bazel 690073a0ab1e62a71c0acbe7eb9312b9a5937951759be4c0f457d97fa7e992e4",
+          "FILE:@@//tools/bazel.bat 9ead9c74fdd6e8200f38c5b68b1f0caae77d6e15b0434fc42043ce87ae41ec7b",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
         ],
         "generatedRepoSpecs": {}

--- a/tools/bazel
+++ b/tools/bazel
@@ -29,7 +29,7 @@ if [ -n "${XDG_CACHE_HOME-}" ]; then
   fi
   export GOCACHE="$XDG_CACHE_HOME/go-build"
   export GOMODCACHE="$XDG_CACHE_HOME/go/mod"
-  [ -z "${CI-}" ] && extra_args+=(--disk_cache="$XDG_CACHE_HOME/bazel/disk-cache")
+  extra_args+=(--disk_cache="$XDG_CACHE_HOME/bazel/disk-cache")
   # https://github.com/bazelbuild/bazel/issues/26384
   [ "$XDG_CACHE_HOME" = "$(dirname "$(dirname "$0")")/.cache" ] && extra_args+=(--repo_contents_cache=)
   if [ -n "${CI-}" ] && [ -z "${GITHUB_ACTIONS-}" ]; then

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -37,7 +37,7 @@ if defined XDG_CACHE_HOME (
   set startup_options="--output_user_root=!bazel_home!"
   :: Use container-scoped `outputBase` to prevent races on `outputUserRoot\<same workspace hash>\server\jvm.out`
   if defined DOTNET_RUNNING_IN_CONTAINER set startup_options=!startup_options! "--output_base=%SYSTEMDRIVE%\bob"
-  if not defined CI set extra_args="--disk_cache=!bazel_home!\disk-cache"
+  set extra_args="--disk_cache=!bazel_home!\disk-cache"
   :: https://github.com/bazelbuild/bazel/issues/26384
   for %%i in ("%~dp0..\.cache") do if "!XDG_CACHE_HOME!" == "%%~fi" set "extra_args=!extra_args! --repo_contents_cache="
   if defined CI if not defined GITHUB_ACTIONS set "extra_args=!extra_args! --config=ci --config=cache:frontend"


### PR DESCRIPTION
### What does this PR do?
This reverts commit 479875c7e3c6488e197e67006aae623cc37867a1.

### Motivation
Buildbarn was not provisioned with enough storage to retain blobs long enough, causing remote-cache evictions that manifested as `lost input` failures.
The local disk cache was only ever a suspect, not the actual cause.

Bazel 9.2.0 also improves handling of lost inputs on top of #53356's action rewinding, reducing the impact of any remaining eviction-driven misses.

### Additional Notes
With the storage-layer root cause addressed:
- disabling the disk cache in CI no longer serves a purpose,
- reinstating it may only decrease data transfers.