### PR TITLE
Bump github.com/docker/docker to v29.3.1+incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -662,7 +662,7 @@ require (
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/docker/cli v29.6.1+incompatible // indirect
-	github.com/docker/docker v28.5.2+incompatible // indirect
+	github.com/docker/docker v29.3.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.4 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect


### PR DESCRIPTION
### What does this PR do?

Bump github.com/docker/docker to v29.3.1+incompatible

### Motivation

### Describe how you validated your changes

### Additional Notes
