### PR TITLE
Add qa_dca to privateactionrunner e2e needs

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -451,6 +451,7 @@ new-e2e-privateactionrunner:
     - job: publish_fakeintake
       optional: true
     - qa_agent_linux
+    - qa_dca
   rules:
     - !reference [.except_disable_e2e_tests]
     - !reference [.except_mergequeue]


### PR DESCRIPTION
<!-- dd-meta {"pullId":"8fe63aad-e7ff-4044-a021-21365b0ea078","source":"chat","resourceId":"10cddd8b-91ae-494b-aad3-719f46db2ea7","workflowId":"8b634009-e263-415f-9db2-01965d9ac562","codeChangeId":"8b634009-e263-415f-9db2-01965d9ac562","sourceType":"slack"} -->
### What does this PR do?

Adds `qa_dca` (the job that publishes the cluster agent QA image) as a dependency of the `new-e2e-privateactionrunner` CI job.

### Motivation

The `new-e2e-privateactionrunner` e2e job was failing on the main merge pipeline ([pipeline 124963909](#removed-for-safety)) because it requires the cluster agent image but did not declare `qa_dca` in its `needs`. This caused the job to run before the cluster agent image was published, leading to infrastructure failures.

Other e2e jobs that depend on the cluster agent image (e.g., `new-e2e-npm-docker`, `new-e2e-cws`, `new-e2e-otel`) already include `qa_dca` in their needs list.

### Describe how you validated your changes

- Verified the change follows the same pattern used by other e2e jobs that depend on the cluster agent image.
- Confirmed `qa_dca` is a valid job defined in `.gitlab/deploy/dev_container_deploy/e2e.yml` that publishes the `cluster-agent-qa` image.

### Additional Notes

Related failure: [new-e2e-privateactionrunner job 1864834586](#removed-for-safety)

<a name="removed-for-safety"></a>
> **_NOTE:_** some AI-generated links and images were removed to ensure safety.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/10cddd8b-91ae-494b-aad3-719f46db2ea7)

Comment @datadog to request changes