### PR TITLE
Revert "Stop emitting uselists for ebpf programs (#53686)"

### DIFF
--- a/bazel/rules/ebpf/ebpf.bzl
+++ b/bazel/rules/ebpf/ebpf.bzl
@@ -27,9 +27,6 @@ _COMMON_FLAGS = [
     "-Wall",
     "-Werror",
     "-O2",
-    # LLVM 12 can serialize use-list order nondeterministically for large modules.
-    "-Xclang",
-    "-no-emit-llvm-uselists",
     "-fno-stack-protector",
     "-fno-color-diagnostics",
     "-fno-unwind-tables",


### PR DESCRIPTION
This reverts commit 799eae90ae38240ff1ad2d98366c37c6e61f8ec5.
It is causing [#incident-57778](https://dd.enterprise.slack.com/archives/C0BHWCA6AS0).