### PR TITLE
chore(renovate): update rshell commit pins daily

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -131,6 +131,14 @@
         "prPriority": 10
       },
       {
+        "description": "Update rshell commit pins daily",
+        "matchManagers": ["gomod"],
+        "matchDepNames": ["github.com/DataDog/rshell"],
+        "matchUpdateTypes": ["digest"],
+        "enabled": true,
+        "schedule": ["* 2-6 * * *"]
+      },
+      {
         "matchManagers": ["gomod"],
         "matchDepNames": ["github.com/aws/aws-sdk-go-v2{,/**}"],
         "groupName": "aws-sdk-go-v2"


### PR DESCRIPTION
### What does this PR do?

Adds a Renovate package rule that enables daily digest updates for commit-pinned `github.com/DataDog/rshell` dependencies.

### Motivation

Keep rshell commit pins current without waiting for a tagged release.

### Describe how you validated your changes

### Additional Notes

The rule runs during the existing 02:00–06:59 Europe/Paris Renovate window.
