### PR TITLE
chore: bump rshell to v0.0.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -210,7 +210,7 @@ require (
 	github.com/DataDog/go-acl v1.0.1
 	github.com/DataDog/go-sqllexer v0.2.3
 	github.com/DataDog/jsonapi v0.13.0
-	github.com/DataDog/rshell v0.0.22
+	github.com/DataDog/rshell v0.0.23
 	github.com/DataDog/sketches-go v1.4.8
 	github.com/DataDog/watermarkpodautoscaler/apis v0.0.0-20250108152814-82e58d0231d1
 	github.com/DataDog/zstd v1.5.8-0.20260421145859-31a7e515a571

--- a/go.sum
+++ b/go.sum
@@ -2579,8 +2579,8 @@ github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816 h1:8diKw2aLYE6LsjWfYxD
 github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816/go.mod h1:7cPuErOAt7k/oVWAVJnxqAC6mwArrAazkvk0RXiih2A=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260710090740-d9125b4c5568 h1:/PzYkLJEFtwE0khmy3X0j/LIWoMtNqpa5Urukgwijyo=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260710090740-d9125b4c5568/go.mod h1:7QXgahrL0BuXFVnhw3vQUDftsjwabS02euIaNqPEleY=
-github.com/DataDog/rshell v0.0.22 h1:SO+CbjmL7iL2kHS0RJODcInaerZNEdQq6QeISqjRIO0=
-github.com/DataDog/rshell v0.0.22/go.mod h1:jZm0YIxCKYEyHJeSSH5rxqmlI1oUi+mXQF6Zf102q+k=
+github.com/DataDog/rshell v0.0.23 h1:SswT3UUSHu3wFZIcWiV1sBze3JC8bROUG9B1seB5oYE=
+github.com/DataDog/rshell v0.0.23/go.mod h1:DOG14otU3LPZ7P0L9Kdk4nWEbQMMpgk21C9vEdGI/bg=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=
 github.com/DataDog/sketches-go v1.4.8/go.mod h1:a/wjRUqzqtGS8qRHRPDCs4EAQfmvPDZGDlMIF5mxXOE=
 github.com/DataDog/trivy v0.0.0-20260519102929-2926d6041e57 h1:NjLZ7nbzMN1MsTotfQ6/W5a9WpHTREEB2acJOauyoQE=


### PR DESCRIPTION
### What does this PR do?

bump `github.com/DataDog/rshell` from `v0.0.22` to `v0.0.23`

### Motivation

### Describe how you validated your changes

### Additional Notes
