### PR TITLE
feat(privateactionrunner): add generateFlare actions

### DIFF
--- a/pkg/privateactionrunner/bundles/remoteaction/agent/BUILD.bazel
+++ b/pkg/privateactionrunner/bundles/remoteaction/agent/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "config.go",
         "diagnose.go",
         "entrypoint.go",
+        "flare.go",
         "status.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/agent",

--- a/pkg/privateactionrunner/bundles/remoteaction/agent/entrypoint.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/agent/entrypoint.go
@@ -20,9 +20,10 @@ type AgentBundle struct {
 func NewAgent(client ipc.HTTPClient) types.Bundle {
 	return &AgentBundle{
 		actions: map[string]types.Action{
-			"getStatus":   NewGetStatusHandler(client),
-			"getDiagnose": NewGetDiagnoseHandler(client),
-			"getConfig":   NewGetConfigHandler(client),
+			"getStatus":     NewGetStatusHandler(client),
+			"getDiagnose":   NewGetDiagnoseHandler(client),
+			"getConfig":     NewGetConfigHandler(client),
+			"generateFlare": NewGenerateFlareHandler(client),
 		},
 	}
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/agent/flare.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/agent/flare.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_remoteaction_agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	ipchttp "github.com/DataDog/datadog-agent/comp/core/ipc/httphelpers"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
+)
+
+// GenerateFlareHandler handles the generateFlare action, asking the local agent
+// to build a flare archive on the agent host.
+//
+// This creates the archive on the agent host's filesystem and returns its path;
+// it does not upload the archive to a Datadog support case. Uploading to a case
+// is a planned follow-up (it requires either an agent-side send endpoint or
+// upload support in the runner).
+type GenerateFlareHandler struct {
+	ipcClient ipc.HTTPClient
+}
+
+// NewGenerateFlareHandler creates a new GenerateFlareHandler.
+func NewGenerateFlareHandler(client ipc.HTTPClient) *GenerateFlareHandler {
+	return &GenerateFlareHandler{ipcClient: client}
+}
+
+// GenerateFlareInputs defines the inputs for the generateFlare action.
+type GenerateFlareInputs struct {
+	// ProviderTimeoutSeconds optionally bounds how long each flare provider may
+	// run. When zero the agent default is used.
+	ProviderTimeoutSeconds int `json:"providerTimeoutSeconds"`
+}
+
+// Run executes the generateFlare action.
+func (h *GenerateFlareHandler) Run(
+	ctx context.Context,
+	task *types.Task,
+	_ *privateconnection.PrivateCredentials,
+) (interface{}, error) {
+	if h.ipcClient == nil {
+		return nil, errors.New("generateFlare: IPC client is not available")
+	}
+
+	inputs, err := types.ExtractInputs[GenerateFlareInputs](task)
+	if err != nil {
+		return nil, fmt.Errorf("generateFlare: failed to parse inputs: %w", err)
+	}
+
+	base, err := agentBaseURL()
+	if err != nil {
+		return nil, fmt.Errorf("generateFlare: %w", err)
+	}
+	flareURL := base + "/agent/flare"
+	if inputs.ProviderTimeoutSeconds > 0 {
+		// The endpoint expects the provider timeout as a duration in nanoseconds.
+		timeoutNanos := int64(inputs.ProviderTimeoutSeconds) * int64(1_000_000_000)
+		q := url.Values{"provider_timeout": {strconv.FormatInt(timeoutNanos, 10)}}
+		flareURL += "?" + q.Encode()
+	}
+
+	// The endpoint takes the (optional) profile data as its JSON body; an empty
+	// object requests a flare with no profiling data attached.
+	resp, err := h.ipcClient.Post(flareURL, "application/json", strings.NewReader("{}"), ipchttp.WithContext(ctx))
+	if err != nil {
+		msg := strings.TrimSpace(string(resp))
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("generateFlare: request to agent failed: %s", msg)
+	}
+
+	return map[string]interface{}{
+		"archivePath": strings.TrimSpace(string(resp)),
+		"note":        "Flare archive was created on the agent host. It has not been uploaded to a Datadog support case.",
+	}, nil
+}

--- a/releasenotes/notes/par-agent-generate-flare-action-24e188d5c77a748f.yaml
+++ b/releasenotes/notes/par-agent-generate-flare-action-24e188d5c77a748f.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added a ``generateFlare`` action to the
+    ``com.datadoghq.remoteaction.agent`` Private Action Runner bundle that builds
+    a flare archive on the Agent host. (Preview)


### PR DESCRIPTION
### What does this PR do?

Adds the mutating actions to the `com.datadoghq.agent` PAR bundle:
- `generateFlare` — `POST /agent/flare` to build a flare archive on the Agent host, returning its local path.


### Motivation

Completes the `com.datadoghq.agent` bundle with the write actions. Confirmation gating for these consequential actions is enforced at the MCP tool layer (dd-source PR 5), not in the bundle — the bundle just executes.

### Describe how you validated your changes

`bazel build //pkg/privateactionrunner/bundles/agent:agent //pkg/privateactionrunner/bundles:bundles` passes; pre-push `go-linter`/`go-test` pass.

### Additional Notes

**Stacked series (merge in order).** datadog-agent: (1) read-only bundle (#53754) → **(2) this PR**. Based directly on `louis-cqrl/agent-par-bundle-readonly` (#53754) — this branch was rebased off the `getRemoteConfigState` action PR (#53755) on 2026-07-28: `getRemoteConfigState` is deferred (see below) and `generateFlare` never depended on it.

Known follow-up: `generateFlare` currently only creates the archive on the Agent host; uploading it to a Datadog support case is out of scope here (needs either an Agent-side send endpoint or upload support in the runner).

---

### Full stacked series

**Shipping now:**

**datadog-agent** (Go execution layer):
1. DataDog/datadog-agent#53754 — `com.datadoghq.agent` bundle read-only actions (`getStatus`, `getDiagnose`, `getConfig`)
2. DataDog/datadog-agent#53756 — this PR, `generateFlare` action (mutating, confirm-gated)

**dd-source** (catalog + MCP tools + authz):
3. ddoghq/dd-source#22260 — `com.datadoghq.agent` private bundle manifest (three read actions + flare)
4. ddoghq/dd-source#22261 — read-only MCP tools
5. ddoghq/dd-source#22262 — confirm-gated mutating MCP tool
6. ddoghq/dd-source#22263 — MCP OBO allow-list (optional hardening)

Cross-repo: land datadog-agent #53754/#53756 and dd-source #22260, and ship an agent build containing them, before the dd-source MCP tools (#22261–#22262) work end-to-end.

**Deferred (follow-up, not a dependency of this PR):**

- DataDog/datadog-agent#53753 — expose remote config state over the agent IPC HTTP API
- DataDog/datadog-agent#53755 — `getRemoteConfigState` action

Parked pending alignment with the remote-config team on backend-vs-agent sourcing — see the addendum in the [RFC](https://datadoghq.atlassian.net/wiki/spaces/FRM/pages/6996001355).
