### PR TITLE
[ACTP][fix] stop heartbeating on-prem tasks once the server reports the job is gone (NotFound)

### DIFF
--- a/pkg/privateactionrunner/opms/BUILD.bazel
+++ b/pkg/privateactionrunner/opms/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//pkg/config/mock",
         "//pkg/privateactionrunner/adapters/config",
         "//pkg/privateactionrunner/adapters/constants",
+        "//pkg/proto/pbgo/privateactionrunner/actionsclient",
         "@com_github_datadog_jsonapi//:jsonapi",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/privateactionrunner/opms/opms.go
+++ b/pkg/privateactionrunner/opms/opms.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -50,6 +51,19 @@ const (
 	// idle stretches.
 	maxRetryAfter = 2 * time.Minute
 )
+
+// ErrJobNotFound means the task no longer exists remotely; callers stop heartbeating.
+var ErrJobNotFound = errors.New("job not found")
+
+// HTTPError carries the HTTP status code of an unexpected response.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("request failed with status code %d and body %s", e.StatusCode, e.Body)
+}
 
 type DequeueJSONRequest struct {
 	ID                 string `jsonapi:"primary,dequeue"`
@@ -370,6 +384,10 @@ func (c *client) Heartbeat(ctx context.Context, client actionsclientpb.Client, t
 	}
 
 	if _, err := c.makeHeartbeatRequest(ctx, http.MethodPost, c.endpointURL(heartbeat), request); err != nil {
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("%w: %v", ErrJobNotFound, err)
+		}
 		return fmt.Errorf("error sending heartbeat: %w", err)
 	}
 
@@ -449,7 +467,7 @@ func (c *client) makeRequest(
 	}
 
 	if len(expectedStatusCodes) != 0 && !slices.Contains(expectedStatusCodes, res.StatusCode) {
-		return nil, res.Header, fmt.Errorf("request failed with status code %d and body %s", res.StatusCode, resBody)
+		return nil, res.Header, &HTTPError{StatusCode: res.StatusCode, Body: string(resBody)}
 	}
 
 	return resBody, res.Header, nil

--- a/pkg/privateactionrunner/opms/opms_test.go
+++ b/pkg/privateactionrunner/opms/opms_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -24,6 +25,7 @@ import (
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	app "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
+	actionsclientpb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/actionsclient"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -314,4 +316,31 @@ func TestDoEnrollRequestUsesOwnHttpClient(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, transportCalled, "doEnrollRequest must use p.httpClient, not http.DefaultClient")
+}
+
+func TestHeartbeat_NotFoundReturnsErrJobNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":["job info not found"]}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Heartbeat(context.Background(), actionsclientpb.Client_WORKFLOWS, "task-id", "com.datadoghq.test.action", "job-id")
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrJobNotFound), "expected ErrJobNotFound, got %v", err)
+}
+
+func TestHeartbeat_OtherErrorIsNotJobNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Heartbeat(context.Background(), actionsclientpb.Client_WORKFLOWS, "task-id", "com.datadoghq.test.action", "job-id")
+
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrJobNotFound), "500 must not be treated as job-not-found")
 }

--- a/pkg/privateactionrunner/runners/BUILD.bazel
+++ b/pkg/privateactionrunner/runners/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     gotags = ["test"],
     deps = [
         "//pkg/privateactionrunner/adapters/config",
+        "//pkg/privateactionrunner/adapters/logging",
         "//pkg/privateactionrunner/libs/privateconnection",
         "//pkg/privateactionrunner/observability",
         "//pkg/privateactionrunner/opms",

--- a/pkg/privateactionrunner/runners/workflow_runner.go
+++ b/pkg/privateactionrunner/runners/workflow_runner.go
@@ -7,6 +7,7 @@ package runners
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -226,6 +227,10 @@ func (n *WorkflowRunner) startHeartbeat(ctx context.Context, task *types.Task, l
 				log.String(observability.JobIDTagName, task.Data.Attributes.JobId))
 
 			if err != nil {
+				if errors.Is(err, opms.ErrJobNotFound) {
+					logger.Info("Task no longer exists remotely; stopping heartbeat")
+					return
+				}
 				logger.Error("Failed to send heartbeat", log.ErrorField(err))
 			} else {
 				logger.Info("Heartbeat sent successfully")

--- a/pkg/privateactionrunner/runners/workflow_task_executor_test.go
+++ b/pkg/privateactionrunner/runners/workflow_task_executor_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
+	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/opms"
 	testopms "github.com/DataDog/datadog-agent/pkg/privateactionrunner/opms/testing"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 	actionsclientpb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/actionsclient"
@@ -165,6 +167,30 @@ func TestWorkflowRunnerPublishesFailureWhenTaskPreparationFails(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for runner loop to stop")
+	}
+}
+
+func TestWorkflowRunner_StartHeartbeat_StopsOnJobNotFound(t *testing.T) {
+	runner := &WorkflowRunner{
+		config: &config.Config{HeartbeatInterval: 10 * time.Millisecond},
+		opmsClient: &testopms.FakeOpmsClient{
+			HeartbeatFn: func(_ context.Context, _ actionsclientpb.Client, _, _, _ string) error {
+				return opms.ErrJobNotFound
+			},
+		},
+	}
+	task := newWorkflowTask("task-id", "com.datadoghq.test", "action", "job-id")
+
+	done := make(chan struct{})
+	go func() {
+		runner.startHeartbeat(context.Background(), task, log.FromContext(context.Background()))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("heartbeat did not stop after job not found")
 	}
 }
 

--- a/releasenotes/notes/par-stop-heartbeat-completed-task-3f9c1a7b2d4e6a8b.yaml
+++ b/releasenotes/notes/par-stop-heartbeat-completed-task-3f9c1a7b2d4e6a8b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The private action runner now stops heartbeating a task once the backend
+    reports it no longer exists, instead of retrying indefinitely.


### PR DESCRIPTION
An on-prem private action runner keeps sending heartbeats for a task after it has completed and its record has been cleaned up remotely. The failure was indistinguishable from a transient error, so the runner retried forever — a single stuck runner produces a sustained heartbeat error rate.

The runner now recognizes the not-found response (HTTP 404) and stops its heartbeat loop for that task instead of retrying indefinitely.

- Heartbeat maps a 404 response to a new `ErrJobNotFound` sentinel.
- The workflow heartbeat loop exits on `ErrJobNotFound`.

Tests added for both paths.