### PR TITLE
Bind-mount Bazel's `outputBase` off Windows container's VHDX™

### DIFF
--- a/tools/ci/docker-run-with-bazel-cache.ps1
+++ b/tools/ci/docker-run-with-bazel-cache.ps1
@@ -2,6 +2,13 @@ $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 Set-StrictMode -Version 3.0
 
+# Set a job-specific bind mount for Bazel's `outputBase` in order to:
+# 1. prevent races on `outputUserRoot\<same workspace hash>\server\jvm.out`,
+# 2. avoid heavy I/O on the container's dynamically-expanding + differencing VHDX (`sandbox.vhdx` starts at 41MB),
+# 3. use the host's large volume without hitting VHDX expansion limits (`--storage-opt` does not preallocate).
+$outputBase = Join-Path $env:CI_PROJECT_DIR ".cache\bob" # $CI_PROJECT_DIR is unique per slot and swept at startup
+$null = New-Item $outputBase -ItemType Directory -Force
+
 # Allow any container user to refresh disk-cache files written by a prior job's container.
 $diskCache = Join-Path $env:XDG_CACHE_HOME "bazel\disk-cache"
 $null = New-Item $diskCache -ItemType Directory -Force
@@ -18,6 +25,7 @@ if (-not (($acl = Get-Acl $diskCache).Access | Where-Object { -not $_.IsInherite
     --env=BUILDBARN_ID_TOKEN `
     --env=CI `
     --env=XDG_CACHE_HOME `
+    --volume="${outputBase}:C:\bob" `
     --volume="${env:XDG_CACHE_HOME}:${env:XDG_CACHE_HOME}" `
     $args
 exit $LASTEXITCODE

--- a/tools/ci/docker-run-with-bazel-cache.ps1
+++ b/tools/ci/docker-run-with-bazel-cache.ps1
@@ -20,12 +20,12 @@ if (-not (($acl = Get-Acl $diskCache).Access | Where-Object { -not $_.IsInherite
     Get-ChildItem $diskCache -Recurse | ForEach-Object { Set-Acl $_.FullName $acl }
 }
 & docker run --rm `
-    --storage-opt "size=100GB" `
     --env=BAZELISK_HOME `
     --env=BUILDBARN_ID_TOKEN `
     --env=CI `
     --env=XDG_CACHE_HOME `
-    --volume="${outputBase}:C:\bob" `
-    --volume="${env:XDG_CACHE_HOME}:${env:XDG_CACHE_HOME}" `
+    --mount="type=bind,src=${outputBase},dst=C:\bob" `
+    --mount="type=bind,src=${env:XDG_CACHE_HOME},dst=${env:XDG_CACHE_HOME}" `
+    --storage-opt=size=100GB `
     $args
 exit $LASTEXITCODE


### PR DESCRIPTION
### What does this PR do?
Bind-mounts a per-job directory for Bazel's `--output_base` on Windows CI jobs, instead of leaving it on the container's own scratch disk.

### Motivation
As settled in #51154, `--output_base` must stay container-scoped to avoid concurrent instances racing on the same server lock (bazelbuild/bazel#12591, etc.).

That container-local path is the container's dynamically-expanding and differencing `sandbox.vhdx`, which has documented [allocate-on-write and differencing overhead](https://learn.microsoft.com/en-us/windows-server/administration/performance-tuning/role/hyper-v-server/storage-io-performance) and no way to be made fixed-size.

Writes there have also hit "not enough space on disk" in earlier `bazel:test:windows-amd64` job, well under the configured `--storage-opt` quota, on hosts otherwise showing hundreds of GB free.

`$CI_PROJECT_DIR` is already real disk, unique per concurrency slot, and swept at job startup, so no separate uniqueness scheme or cleanup of our own is needed.

### Describe how you validated your changes
Ran the real `bazel:test:windows-amd64` job with this bind mount in place, where `bazel` wrote hundreds of MB to tens of GB into `C:\bob` across several runs with no permission or disk errors, so no additional ACL handling was needed on top of the existing disk-cache ACL fix.

### Additional Notes
About [`There is not enough space on the disk`](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%22not%20enough%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1782924925026&to_ts=1784220925026&live=true):
- I confirm that that `--storage-opt "size=100GB"` genuinely sets the _virtual_ size of the VHDX (via `docker inspect`, `diskpart detail vdisk`, and in-container `DriveInfo`/`fsutil`), ruling out a silently-capped quota,
- a broader diagnostic investigation also ruled out host disk saturation, concurrent containers sharing a host, Hyper-V isolation, NTFS quotas, and instance-store volumes,.

The present change is therefore to be considered as a reliability improvement regardless of which mechanism was responsible.