### PR TITLE
Expose effective Observer component config in headless output

### DIFF
--- a/comp/anomalydetection/observer/impl/component_catalog.go
+++ b/comp/anomalydetection/observer/impl/component_catalog.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
@@ -57,6 +58,117 @@ type componentInstance struct {
 	instance     any
 	enabled      bool
 	activeConfig any // config actually passed to factory (nil for parameterless components)
+}
+
+// componentConfigSnapshot is the resolved configuration for one catalog
+// component. It intentionally excludes the runtime instance so retaining
+// metadata does not keep disabled components alive.
+type componentConfigSnapshot struct {
+	enabled bool
+	config  any
+}
+
+// snapshotComponentConfigs captures the exact enabled state and typed config
+// selected by Instantiate. Keeping this derived from componentInstance avoids
+// duplicating the catalog's default/override resolution rules in the testbench.
+func snapshotComponentConfigs(components map[string]*componentInstance) map[string]componentConfigSnapshot {
+	snapshots := make(map[string]componentConfigSnapshot, len(components))
+	for name, component := range components {
+		snapshots[name] = componentConfigSnapshot{
+			enabled: component.enabled,
+			config:  component.activeConfig,
+		}
+	}
+	return snapshots
+}
+
+// effectiveComponentConfigMaps converts resolved typed configs into the same
+// JSON object shape accepted by the testbench: "enabled" and component
+// hyperparameters are siblings. A fresh map is returned on every call.
+func effectiveComponentConfigMaps(snapshots map[string]componentConfigSnapshot) (map[string]map[string]any, error) {
+	configs := make(map[string]map[string]any, len(snapshots))
+	for name, snapshot := range snapshots {
+		fields := make(map[string]any)
+		if snapshot.config != nil {
+			data, err := json.Marshal(componentConfigMetadataValue(snapshot.config))
+			if err != nil {
+				return nil, fmt.Errorf("marshaling effective config for %q: %w", name, err)
+			}
+			if err := json.Unmarshal(data, &fields); err != nil {
+				return nil, fmt.Errorf("decoding effective config for %q: %w", name, err)
+			}
+		}
+		fields["enabled"] = snapshot.enabled
+		configs[name] = fields
+	}
+	return configs, nil
+}
+
+// componentConfigMetadataValue supplies readable JSON representations for
+// config fields that are intentionally excluded from their runtime JSON form.
+// All other configs use their existing JSON tags, keeping metadata aligned
+// with the testbench input schema.
+func componentConfigMetadataValue(config any) any {
+	switch cfg := config.(type) {
+	case BOCPDConfig:
+		aggregations := make([]string, len(cfg.Aggregations))
+		for i, aggregation := range cfg.Aggregations {
+			aggregations[i] = observerdef.AggregateString(aggregation)
+		}
+		return struct {
+			BOCPDConfig
+			Aggregations []string `json:"aggregations"`
+		}{BOCPDConfig: cfg, Aggregations: aggregations}
+
+	case RRCFConfig:
+		metrics := cfg.Metrics
+		if len(metrics) == 0 {
+			metrics = DefaultRRCFMetrics()
+		}
+		type metricConfig struct {
+			Namespace string `json:"namespace"`
+			Name      string `json:"name"`
+			Aggregate string `json:"aggregate"`
+		}
+		metadataMetrics := make([]metricConfig, len(metrics))
+		for i, metric := range metrics {
+			metadataMetrics[i] = metricConfig{
+				Namespace: metric.Namespace,
+				Name:      metric.Name,
+				Aggregate: observerdef.AggregateString(metric.Agg),
+			}
+		}
+		return struct {
+			RRCFConfig
+			Metrics []metricConfig `json:"metrics"`
+		}{RRCFConfig: cfg, Metrics: metadataMetrics}
+
+	case LogMetricsExtractorConfig:
+		return struct {
+			MaxEvalBytes  int      `json:"max_eval_bytes"`
+			IncludeFields []string `json:"include_fields,omitempty"`
+			ExcludeFields []string `json:"exclude_fields,omitempty"`
+		}{
+			MaxEvalBytes:  cfg.MaxEvalBytes,
+			IncludeFields: sortedStringSet(cfg.IncludeFields),
+			ExcludeFields: sortedStringSet(cfg.ExcludeFields),
+		}
+
+	default:
+		return config
+	}
+}
+
+func sortedStringSet(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
 }
 
 // ConfigReader provides read access to a key-value configuration source.

--- a/comp/anomalydetection/observer/impl/component_catalog_test.go
+++ b/comp/anomalydetection/observer/impl/component_catalog_test.go
@@ -6,6 +6,7 @@
 package observerimpl
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -13,6 +14,58 @@ import (
 
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
+
+func TestEffectiveComponentConfigMapsIncludesDefaultsAndOverrides(t *testing.T) {
+	settings, err := ParseSettingsFromJSON(map[string]json.RawMessage{
+		"bocpd": json.RawMessage(`{"enabled":false,"hazard":0.2}`),
+	})
+	require.NoError(t, err)
+
+	_, _, _, _, components := defaultCatalog().Instantiate(settings)
+	configs, err := effectiveComponentConfigMaps(snapshotComponentConfigs(components))
+	require.NoError(t, err)
+
+	bocpdJSON, err := json.Marshal(configs["bocpd"])
+	require.NoError(t, err)
+	var bocpd struct {
+		Enabled      bool     `json:"enabled"`
+		Hazard       float64  `json:"hazard"`
+		WarmupPoints int      `json:"warmup_points"`
+		Aggregations []string `json:"aggregations"`
+	}
+	require.NoError(t, json.Unmarshal(bocpdJSON, &bocpd))
+	require.False(t, bocpd.Enabled)
+	require.Equal(t, 0.2, bocpd.Hazard)
+	require.Equal(t, DefaultBOCPDConfig().WarmupPoints, bocpd.WarmupPoints)
+	require.Equal(t, []string{"avg", "count"}, bocpd.Aggregations)
+
+	rrcfJSON, err := json.Marshal(configs["rrcf"])
+	require.NoError(t, err)
+	var rrcf struct {
+		Enabled bool `json:"enabled"`
+		Metrics []struct {
+			Namespace string `json:"namespace"`
+			Name      string `json:"name"`
+			Aggregate string `json:"aggregate"`
+		} `json:"metrics"`
+	}
+	require.NoError(t, json.Unmarshal(rrcfJSON, &rrcf))
+	require.True(t, rrcf.Enabled)
+	require.Len(t, rrcf.Metrics, len(DefaultRRCFMetrics()))
+	require.Equal(t, "avg", rrcf.Metrics[0].Aggregate)
+
+	logMetricsJSON, err := json.Marshal(configs["log_metrics_extractor"])
+	require.NoError(t, err)
+	var logMetrics struct {
+		Enabled       bool     `json:"enabled"`
+		MaxEvalBytes  int      `json:"max_eval_bytes"`
+		ExcludeFields []string `json:"exclude_fields"`
+	}
+	require.NoError(t, json.Unmarshal(logMetricsJSON, &logMetrics))
+	require.True(t, logMetrics.Enabled)
+	require.Equal(t, DefaultLogMetricsExtractorConfig().MaxEvalBytes, logMetrics.MaxEvalBytes)
+	require.Contains(t, logMetrics.ExcludeFields, "timestamp")
+}
 
 // TestDefaultCatalog_DetectorTeardownContract is the structural guard that
 // every catalog detector either implements observerdef.SeriesRemover or is

--- a/comp/anomalydetection/observer/impl/debug.go
+++ b/comp/anomalydetection/observer/impl/debug.go
@@ -17,6 +17,9 @@ import (
 type DebugView interface {
 	StateView() StateView
 	CatalogEntries() []CatalogEntry
+	// EffectiveComponentConfigs returns every catalog component's resolved
+	// enabled state and hyperparameters after defaults and overrides are applied.
+	EffectiveComponentConfigs() (map[string]map[string]any, error)
 	// Flush blocks until all observations queued in the dispatch channel have
 	// been processed by the engine. The testbench calls this after feeding
 	// parquet data to ensure StateView reflects all ingested observations.

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -232,7 +232,8 @@ func NewComponent(deps Requires) (Provides, error) {
 
 	catalog := defaultCatalog()
 	settings := settingsFromAgentConfig(catalog, cfg)
-	detectors, correlators, rawScorer, extractors, _ := catalog.Instantiate(settings)
+	detectors, correlators, rawScorer, extractors, components := catalog.Instantiate(settings)
+	componentConfigs := snapshotComponentConfigs(components)
 
 	storageCfg := DefaultStorageConfig()
 	if cfg != nil {
@@ -315,6 +316,7 @@ func NewComponent(deps Requires) (Provides, error) {
 	obs := &observerImpl{
 		engine:               eng,
 		catalog:              catalog,
+		componentConfigs:     componentConfigs,
 		obsCh:                make(chan observation, 1000),
 		telemetry:            obsTelemetry,
 		ingestMetricsEnabled: !cfg.IsConfigured("anomaly_detection.metrics.enabled") || cfg.GetBool("anomaly_detection.metrics.enabled"),
@@ -432,10 +434,11 @@ func NewComponent(deps Requires) (Provides, error) {
 // It is a thin driver around the engine, which holds storage, extractors,
 // detectors, correlators, and raw anomaly tracking.
 type observerImpl struct {
-	engine     *engine
-	catalog    *componentCatalog
-	obsCh      chan observation
-	handleFunc observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
+	engine           *engine
+	catalog          *componentCatalog
+	componentConfigs map[string]componentConfigSnapshot
+	obsCh            chan observation
+	handleFunc       observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
 
 	telemetry         *observerTelemetry
 	digestCleanup     func() // flushes detect digest recording file
@@ -759,6 +762,14 @@ func (o *observerImpl) CatalogEntries() []CatalogEntry {
 	return result
 }
 
+// EffectiveComponentConfigs returns the resolved component configuration used
+// to construct the current engine. Implements DebugView.
+func (o *observerImpl) EffectiveComponentConfigs() (map[string]map[string]any, error) {
+	o.replayMu.Lock()
+	defer o.replayMu.Unlock()
+	return effectiveComponentConfigMaps(o.componentConfigs)
+}
+
 // Flush blocks until all observations currently queued in the dispatch channel
 // have been processed by the engine. Implements DebugView.
 func (o *observerImpl) Flush() {
@@ -770,10 +781,12 @@ func (o *observerImpl) Flush() {
 // Reset clears all engine state and reconfigures with new settings. Implements DebugView.
 func (o *observerImpl) Reset(settings ComponentSettings, storageCfg StorageConfig) {
 	o.Flush()
-	detectors, correlators, scorer, extractors, _ := o.catalog.Instantiate(settings)
+	detectors, correlators, scorer, extractors, components := o.catalog.Instantiate(settings)
+	componentConfigs := snapshotComponentConfigs(components)
 	o.replayMu.Lock()
 	o.metricFilter.muted.Store(nil)
 	o.engine.ResetForReplay(detectors, correlators, scorer, extractors, storageCfg, settings.Baseline)
+	o.componentConfigs = componentConfigs
 	o.replayMu.Unlock()
 }
 

--- a/internal/qbranch/anomalydetection-testbench/README.md
+++ b/internal/qbranch/anomalydetection-testbench/README.md
@@ -178,6 +178,14 @@ dda inv -- anomalydetection.launch-testbench --headless-scenario <scenario-name>
     "timeline_end": 1708203600,
     "detectors_enabled": ["bocpd"],
     "correlators_enabled": ["time_cluster"],
+    "component_configs": {
+      "bocpd": {
+        "enabled": true,
+        "warmup_points": 120,
+        "hazard": 0.05,
+        "aggregations": ["avg", "count"]
+      }
+    },
     "total_anomaly_periods": 2
   },
   "anomaly_periods": [

--- a/internal/qbranch/anomalydetection-testbench/bench/output.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/output.go
@@ -88,15 +88,10 @@ func (tb *Bench) WriteObserverOutput(path string, verbose bool) error {
 		}
 	}
 
-	// Build component configs from catalog + settings.
-	entries := tb.debug.CatalogEntries()
-	componentConfigs := make(map[string]map[string]any, len(entries))
-	for _, e := range entries {
-		enabled := e.DefaultEnabled
-		if v, ok := tb.settings.Enabled[e.Name]; ok {
-			enabled = v
-		}
-		componentConfigs[e.Name] = map[string]any{"enabled": enabled}
+	componentConfigs, err := tb.debug.EffectiveComponentConfigs()
+	if err != nil {
+		tb.mu.RUnlock()
+		return fmt.Errorf("collecting effective component configs: %w", err)
 	}
 
 	replayStats := tb.replayStats


### PR DESCRIPTION
### What does this PR do?

Expose the Observer component configuration resolved by the catalog after defaults and testbench overrides are applied. Headless output now records each component's effective enabled state and hyperparameters, including readable BOCPD aggregations and resolved RRCF metrics.

### Motivation

DDEval ablation studies need enough metadata to reproduce and compare runs. The raw `testbench_config` only contains the submitted override, while `component_configs` previously contained only enabled states. Recording the resolved configuration shows what actually ran without duplicating the catalog's resolution logic in the testbench.

### Describe how you validated your changes

- `dda inv test --targets=./comp/anomalydetection/observer/impl/`
- `dda inv test --targets=./internal/qbranch/anomalydetection-testbench/bench/`
- `dda inv anomalydetection.build-testbench`
- Datadog pre-push Go tests and linters

### Additional Notes

The raw submitted `testbench_config` remains unchanged; this only enriches the nested headless metadata.
