### PR TITLE
tasks: fix false negative in lint-codeowners

### DIFF
--- a/tasks/libs/owners/linter.py
+++ b/tasks/libs/owners/linter.py
@@ -8,6 +8,7 @@ def directory_has_packages_without_owner(owners, folder="pkg"):
     """Check every package in `pkg` has an owner"""
 
     error = False
+    folder_path = "/" + folder
 
     for x in os.listdir(folder):
         # Use forward slash concatenation instead of os.path.join to ensure consistent
@@ -16,7 +17,17 @@ def directory_has_packages_without_owner(owners, folder="pkg"):
         # to match against the CODEOWNERS rules. os.path.join would use backslashes on
         # Windows, causing the comparison to fail.
         path = "/" + folder + "/" + x
-        if all(owner[1].rstrip('/') != path for owner in owners.paths):
+        stripped = path.lstrip('/')
+        # codeowners represents directories with a trailing slash without
+        # it, a directory-only rule like `/pkg/api/` won't match.
+        if os.path.isdir(os.path.join(folder, x)):
+            stripped += '/'
+        rule_owners, _, rule_path, _ = owners.matching_line(stripped)
+        # A match against the folder's own blanket rule (e.g. `/pkg/`) doesn't count as a
+        # dedicated owner for this specific package — it covers everything under `folder`
+        # indiscriminately. A match with no owners (e.g. a "do not notify anyone" rule) doesn't
+        # count either.
+        if not rule_owners or (rule_path is not None and rule_path.rstrip('/') == folder_path):
             if not error:
                 print(
                     color_message("The following packages don't have owner in CODEOWNER file", "red"), file=sys.stderr

--- a/tasks/unit_tests/codeowner_linter_tests.py
+++ b/tasks/unit_tests/codeowner_linter_tests.py
@@ -33,19 +33,55 @@ class TestCodeownerLinter(unittest.TestCase):
         os.chdir(self.backup_cwd)
 
     def test_all_pkg_have_codeowner(self):
-        codeowner = CodeOwners("\n".join("/pkg/" + pkg for pkg in self.fake_pkgs))
+        codeowner = CodeOwners("\n".join("/pkg/" + pkg + " @owner" for pkg in self.fake_pkgs))
         self.assertFalse(directory_has_packages_without_owner(codeowner))
         self.assertFalse(codeowner_has_orphans(codeowner))
 
     def test_pkg_is_missing_codeowner(self):
-        codeowner = CodeOwners("\n".join(os.path.join("/pkg/", pkg) for pkg in self.fake_pkgs[:-1]))
+        codeowner = CodeOwners("\n".join(os.path.join("/pkg/", pkg) + " @owner" for pkg in self.fake_pkgs[:-1]))
         self.assertTrue(directory_has_packages_without_owner(codeowner))
         self.assertFalse(codeowner_has_orphans(codeowner))
 
     def test_codeowner_rule_is_outdated(self):
-        codeowner = CodeOwners("\n".join(os.path.join("/pkg/", pkg) for pkg in [*self.fake_pkgs, "old_deleted_pkg"]))
+        codeowner = CodeOwners(
+            "\n".join(os.path.join("/pkg/", pkg) + " @owner" for pkg in [*self.fake_pkgs, "old_deleted_pkg"])
+        )
         self.assertFalse(directory_has_packages_without_owner(codeowner))
         self.assertTrue(codeowner_has_orphans(codeowner))
+
+    def test_pkg_owned_by_glob_rule(self):
+        # A file only covered by a wildcard rule (no literal /pkg/<name> entry) must still
+        # count as owned.
+        open(os.path.join(self.pkg_dir, "BUILD.bazel"), "w").close()
+        codeowner = CodeOwners(
+            "\n".join(["/**/BUILD.bazel @owner", *("/pkg/" + pkg + " @owner" for pkg in self.fake_pkgs)])
+        )
+        self.assertFalse(directory_has_packages_without_owner(codeowner))
+        self.assertFalse(codeowner_has_orphans(codeowner))
+
+    def test_pkg_not_owned_by_blanket_folder_rule(self):
+        # A generic /pkg/ rule covers every path under pkg recursively, but it must not be
+        # treated as evidence that a specific package has its own dedicated owner.
+        codeowner = CodeOwners(
+            "\n".join(["/pkg/ @DataDog/agent-runtimes", *("/pkg/" + pkg + " @owner" for pkg in self.fake_pkgs[:-1])])
+        )
+        self.assertTrue(directory_has_packages_without_owner(codeowner))
+
+    def test_pkg_owned_by_unanchored_glob_rule(self):
+        # A rule with no leading '/' (e.g. `BUILD.bazel @owner`) matches after any path
+        # separator, not just at the start of the string.
+        open(os.path.join(self.pkg_dir, "BUILD.bazel"), "w").close()
+        codeowner = CodeOwners(
+            "\n".join(["BUILD.bazel @owner", *("/pkg/" + pkg + " @owner" for pkg in self.fake_pkgs)])
+        )
+        self.assertFalse(directory_has_packages_without_owner(codeowner))
+
+    def test_pkg_not_owned_by_noowner_glob_rule(self):
+        # A glob rule with no owners (e.g. a "do not notify anyone" suppression) still matches
+        # the path structurally, but must not count as ownership.
+        open(os.path.join(self.pkg_dir, "BUILD.bazel"), "w").close()
+        codeowner = CodeOwners("\n".join(["/**/BUILD.bazel", *("/pkg/" + pkg + " @owner" for pkg in self.fake_pkgs)]))
+        self.assertTrue(directory_has_packages_without_owner(codeowner))
 
 
 class TestAIArtefactsHaveOwner(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?

Fix false negatives in `github.lint-codeowners` task

### Motivation

We were not accounting for glob patterns when checking for codeowners in /pkg, which caused /pkg/BUILD.bazel to be reported as not owned by any team, while it is and is detected as such by GitHub

### Describe how you validated your changes

Unit test & rerun the task on a PR that was currently blocked by that linter failure (https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1865899508)

### Additional Notes
