### PR TITLE
Add slapr for #agent-release-sync

### DIFF
--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -31,3 +31,11 @@ jobs:
         slack-channel-id: ${{ vars.DEFAULT_CHANNEL_ID }}
         bot-user-id: ${{ vars.SLAPR_BOT_ID }}
         emoji-approved: done
+    - uses: DataDog/slapr@95312d6b8528460243ba27c7f8167bfe20a68bec # 1.1.0
+      # Re-run the job without the review map to put the emoji on backport PRs in #agent-release-sync
+      with:
+        github-token: ${{ steps.octo-sts.outputs.token }}
+        slack-api-token: ${{ secrets.SLACK_SLAPR_BOT_TOKEN }}
+        slack-channel-id: ${{ vars.AGENT_RELEASE_SYNC_CHANNEL_ID }}
+        bot-user-id: ${{ vars.SLAPR_BOT_ID }}
+        emoji-approved: done

--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -31,11 +31,3 @@ jobs:
         slack-channel-id: ${{ vars.DEFAULT_CHANNEL_ID }}
         bot-user-id: ${{ vars.SLAPR_BOT_ID }}
         emoji-approved: done
-    - uses: DataDog/slapr@95312d6b8528460243ba27c7f8167bfe20a68bec # 1.1.0
-      # Re-run the job without the review map to put the emoji on backport PRs in #agent-release-sync
-      with:
-        github-token: ${{ steps.octo-sts.outputs.token }}
-        slack-api-token: ${{ secrets.SLACK_SLAPR_BOT_TOKEN }}
-        slack-channel-id: ${{ vars.AGENT_RELEASE_SYNC_CHANNEL_ID }}
-        bot-user-id: ${{ vars.SLAPR_BOT_ID }}
-        emoji-approved: done

--- a/.github/workflows/slapr_backport.yml
+++ b/.github/workflows/slapr_backport.yml
@@ -1,8 +1,6 @@
 ---
 name: Slack emoji Backport PR updates
 on:
-  pull_request_review:
-    types: [submitted]
   pull_request:
     types: [closed]
     branches:

--- a/.github/workflows/slapr_backport.yml
+++ b/.github/workflows/slapr_backport.yml
@@ -1,6 +1,8 @@
 ---
 name: Slack emoji Backport PR updates
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request:
     types: [closed]
     branches:

--- a/.github/workflows/slapr_backport.yml
+++ b/.github/workflows/slapr_backport.yml
@@ -1,0 +1,24 @@
+---
+name: Slack emoji Backport PR updates
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [closed]
+    branches:
+        - '7.**.x'
+
+jobs:
+  run_slapr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+    - uses: DataDog/slapr@95312d6b8528460243ba27c7f8167bfe20a68bec # 1.1.0
+      # Run the job without the review map to put the emoji on backport PRs in #agent-release-sync
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        slack-api-token: ${{ secrets.SLACK_SLAPR_BOT_TOKEN }}
+        slack-channel-id: ${{ vars.AGENT_RELEASE_SYNC_CHANNEL_ID }}
+        bot-user-id: ${{ vars.SLAPR_BOT_ID }}
+        emoji-approved: done

--- a/.github/workflows/slapr_backport.yml
+++ b/.github/workflows/slapr_backport.yml
@@ -1,8 +1,7 @@
 ---
 name: Slack emoji Backport PR updates
 on:
-  pull_request_review:
-    types: [submitted]
+  # We don't need the comment emoji, we only care about merged/closed
   pull_request:
     types: [closed]
     branches:


### PR DESCRIPTION
### What does this PR do?

Add slapr for #agent-release-sync

I created a separate workflow to simplify how it runs because we're working on a different set of PRs with different rules

### Motivation

The backport requests are getting posted to #agent-release-sync and we would like to get it slapr-ed automatically to help the coordinators. For this particular use-case, we only need the merge/close event, we don't need to approved or comment emojis

### Describe how you validated your changes

Tested with a test thread in #agent-release-sync and relaxed some constraints to run this job https://github.com/DataDog/datadog-agent/actions/runs/29570726235/job/87853834591

### Additional Notes
