### PR TITLE
Don't set python compile flags when python is not included

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -95,12 +95,27 @@ def build(
                 rtloader_make(ctx, install_prefix=embedded_path, cmake_options=cmake_options)
                 rtloader_install(ctx)
 
+    if flavor.is_iot():
+        # Iot mode overrides whatever passed through `--build-exclude` and `--build-include`
+        build_tags = get_default_build_tags(build="agent", flavor=flavor)
+    else:
+        build_tags = compute_build_tags_for_flavor(
+            build="agent",
+            flavor=flavor,
+            build_include=build_include,
+            build_exclude=build_exclude,
+        )
+
+    if not glibc:
+        build_tags = list(set(build_tags).difference({"nvml"}))
+
     ldflags, gcflags, env = get_build_flags(
         ctx,
         install_path=install_path,
         embedded_path=embedded_path,
         rtloader_root=rtloader_root,
         python_home_3=python_home_3,
+        include_python="python" in build_tags,
     )
 
     if sys.platform == 'win32' or os.getenv("GOOS") == "windows":
@@ -118,20 +133,6 @@ def build(
                 vars=vars,
                 out="cmd/agent/rsrc.syso",
             )
-
-    if flavor.is_iot():
-        # Iot mode overrides whatever passed through `--build-exclude` and `--build-include`
-        build_tags = get_default_build_tags(build="agent", flavor=flavor)
-    else:
-        build_tags = compute_build_tags_for_flavor(
-            build="agent",
-            flavor=flavor,
-            build_include=build_include,
-            build_exclude=build_exclude,
-        )
-
-    if not glibc:
-        build_tags = list(set(build_tags).difference({"nvml"}))
 
     if not agent_bin:
         agent_bin = os.path.join(BIN_PATH, bin_name("agent"))

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -72,7 +72,12 @@ def run_golangci_lint(
     # Always add `test` tags while linting as test files are also linted
     tags.extend(UNIT_TEST_TAGS)
 
-    _, _, env = get_build_flags(ctx, rtloader_root=rtloader_root, headless_mode=headless_mode)
+    _, _, env = get_build_flags(
+        ctx,
+        rtloader_root=rtloader_root,
+        headless_mode=headless_mode,
+        include_python="python" in tags,
+    )
 
     # Cross-OS linting setup: configure cross-compilation environment
     if goos:

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -685,6 +685,7 @@ def test(
         ctx,
         rtloader_root=rtloader_root,
         python_home_3=python_home_3,
+        include_python="python" in unit_tests_tags,
     )
 
     # Use stdout if no profile is set

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -255,6 +255,7 @@ def get_build_flags(
     python_home_3=None,
     headless_mode=False,
     arch: Arch | None = None,
+    include_python: bool = False,
 ):
     """
     Build the common value for both ldflags and gcflags, and return an env accordingly.
@@ -300,11 +301,11 @@ def get_build_flags(
         extldflags += f"-Wl,--version-script={get_repo_root()}/datadog-agent.map "
 
     # setting python homes in the code
-    if python_home_3:
+    if include_python and python_home_3:
         ldflags += f"-X {REPO_PATH}/pkg/collector/python.pythonHome3={python_home_3} "
 
     # adding rtloader libs and headers to the env
-    if rtloader_lib:
+    if include_python and rtloader_lib:
         if not headless_mode:
             print(
                 f"--- Setting rtloader paths to lib:{','.join(rtloader_lib)} | header:{rtloader_headers} | common headers:{rtloader_common_headers}"
@@ -319,7 +320,7 @@ def get_build_flags(
     # Python is installed alongside rtloader under the same embedded prefix.
     # Must follow the rtloader block: that block also writes env['CGO_LDFLAGS'] from
     # os.environ, so placing this before it would cause the python flag to be dropped.
-    if sys.platform == 'aix':
+    if include_python and sys.platform == 'aix':
         aix_python_lib_path = python_home_3 or embedded_path
         if aix_python_lib_path:
             env['CGO_LDFLAGS'] = (
@@ -330,9 +331,9 @@ def get_build_flags(
         env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + ' -Wl,--allow-multiple-definition'
 
     extra_cgo_flags = " -Werror -Wno-deprecated-declarations"
-    if rtloader_headers:
+    if include_python and rtloader_headers:
         extra_cgo_flags += f" -I{rtloader_headers}"
-    if rtloader_common_headers:
+    if include_python and rtloader_common_headers:
         extra_cgo_flags += f" -I{rtloader_common_headers}"
     env['CGO_CFLAGS'] = os.environ.get('CGO_CFLAGS', '') + extra_cgo_flags
 
@@ -344,7 +345,7 @@ def get_build_flags(
     if static:
         ldflags += "-s -w -linkmode=external "
         extldflags += "-static "
-    elif rtloader_lib:
+    elif include_python and rtloader_lib:
         if sys.platform == "darwin":
             extldflags += " ".join(f"-Wl,-rpath,{lib_path}" for lib_path in rtloader_lib) + " "
         elif sys.platform != "aix":  # -r sets ELF RPATH; not valid for AIX XCOFF

--- a/tasks/unit_tests/libs/common/utils_tests.py
+++ b/tasks/unit_tests/libs/common/utils_tests.py
@@ -147,7 +147,9 @@ class TestGetBuildFlags(unittest.TestCase):
     @mock.patch("tasks.libs.common.utils.get_version_ldflags", return_value="")
     @mock.patch("tasks.libs.common.utils.get_rtloader_paths", return_value=(["/external/embedded/lib"], "", ""))
     def test_infers_python_home_from_selected_rtloader_root_path(self, _get_rtloader_paths, _get_version_ldflags):
-        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev", rtloader_root="/external", include_python=True)
+        ldflags, _, _ = get_build_flags(
+            mock.Mock(), embedded_path="/dev", rtloader_root="/external", include_python=True
+        )
 
         self.assertIn("python.pythonHome3=/external/embedded", ldflags.replace("\\", "/"))
 
@@ -167,7 +169,9 @@ class TestGetBuildFlags(unittest.TestCase):
     ):
         # The selected (first) rtloader is a legacy root; a stale embedded lib from a prior
         # Bazel build must not override the Python home for the rtloader actually linked.
-        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev", rtloader_root="/external", include_python=True)
+        ldflags, _, _ = get_build_flags(
+            mock.Mock(), embedded_path="/dev", rtloader_root="/external", include_python=True
+        )
 
         self.assertNotIn("python.pythonHome3", ldflags)
 

--- a/tasks/unit_tests/libs/common/utils_tests.py
+++ b/tasks/unit_tests/libs/common/utils_tests.py
@@ -140,21 +140,21 @@ class TestGetBuildFlags(unittest.TestCase):
     @mock.patch("tasks.libs.common.utils.get_version_ldflags", return_value="")
     @mock.patch("tasks.libs.common.utils.get_rtloader_paths", return_value=(["/dev/embedded/lib"], "", ""))
     def test_infers_python_home_from_bazel_rtloader_path(self, _get_rtloader_paths, _get_version_ldflags):
-        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev")
+        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev", include_python=True)
 
         self.assertIn("python.pythonHome3=/dev/embedded", ldflags.replace("\\", "/"))
 
     @mock.patch("tasks.libs.common.utils.get_version_ldflags", return_value="")
     @mock.patch("tasks.libs.common.utils.get_rtloader_paths", return_value=(["/external/embedded/lib"], "", ""))
     def test_infers_python_home_from_selected_rtloader_root_path(self, _get_rtloader_paths, _get_version_ldflags):
-        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev", rtloader_root="/external")
+        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev", rtloader_root="/external", include_python=True)
 
         self.assertIn("python.pythonHome3=/external/embedded", ldflags.replace("\\", "/"))
 
     @mock.patch("tasks.libs.common.utils.get_version_ldflags", return_value="")
     @mock.patch("tasks.libs.common.utils.get_rtloader_paths", return_value=(["/dev/lib"], "", ""))
     def test_does_not_infer_python_home_from_legacy_rtloader_path(self, _get_rtloader_paths, _get_version_ldflags):
-        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev")
+        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev", include_python=True)
 
         self.assertNotIn("python.pythonHome3", ldflags)
 
@@ -167,7 +167,7 @@ class TestGetBuildFlags(unittest.TestCase):
     ):
         # The selected (first) rtloader is a legacy root; a stale embedded lib from a prior
         # Bazel build must not override the Python home for the rtloader actually linked.
-        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev", rtloader_root="/external")
+        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev", rtloader_root="/external", include_python=True)
 
         self.assertNotIn("python.pythonHome3", ldflags)
 
@@ -178,7 +178,7 @@ class TestGetBuildFlags(unittest.TestCase):
     def test_uses_external_linker_for_multiple_rtloader_rpaths_on_macos(
         self, _get_xcode_version, _get_rtloader_paths, _get_version_ldflags
     ):
-        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev")
+        ldflags, _, _ = get_build_flags(mock.Mock(), embedded_path="/dev", include_python=True)
 
         self.assertIn("-Wl,-rpath,/dev/lib", ldflags)
         self.assertIn("-Wl,-rpath,/dev/embedded/lib", ldflags)


### PR DESCRIPTION
### What does this PR do?
Do not set python related compiler / linker flags when `python` is not included in Go build tags.

### Motivation
- simplify flags / environment variables when python is not used
- do not pass `-lpython` (ie. linking with libpython) for trace-agent on AIX
- make cross compilation easier

### Describe how you validated your changes
CI

### Additional Notes
