### PR TITLE
[AAD-14] Filter observer telemetry metrics

### DIFF
--- a/comp/anomalydetection/AGENTS.md
+++ b/comp/anomalydetection/AGENTS.md
@@ -90,8 +90,9 @@ Production callers of `observer.GetHandle()` use statically-defined source names
 
 Both paths share filtering primitives from `internal/logsfilter/`.
 
-Metrics with the `datadog.*` prefix are normalized as internal agent telemetry
-and dropped before they reach observer storage.
+Metrics with the `datadog.*` prefix are normalized as internal agent telemetry.
+Only observer telemetry under `datadog.agent.observer.*` is dropped before it
+reaches observer storage, preventing an ingestion loop.
 
 ## Severity Events (Scorer Push Contract)
 

--- a/comp/anomalydetection/observer/impl/filter_rules.go
+++ b/comp/anomalydetection/observer/impl/filter_rules.go
@@ -104,18 +104,22 @@ func newMetricsFilterRules(rules []metricsProcessingRule) (*metricsFilterRules, 
 	return &metricsFilterRules{rules: compiled}, nil
 }
 
-func defaultMetricsProcessingRules() []metricsProcessingRule {
+// implicitMetricsProcessingRules are evaluated before user-configured rules.
+// They protect the observer from ingesting its own Agent telemetry and must not
+// be overridable by an include_at_match rule.
+func implicitMetricsProcessingRules() []metricsProcessingRule {
 	return []metricsProcessingRule{
 		{
-			Type:   excludeAtMatch,
-			Name:   "drop_agent_metrics",
-			Source: observerdef.AgentNamespace,
+			Type:        excludeAtMatch,
+			Name:        "drop_observer_telemetry",
+			NamePattern: observerTelemetryMetricPrefix + "*",
+			Source:      observerdef.AgentNamespace,
 		},
 	}
 }
 
 func newDefaultMetricsFilterRules() (*metricsFilterRules, error) {
-	return newMetricsFilterRules(defaultMetricsProcessingRules())
+	return newMetricsFilterRules(implicitMetricsProcessingRules())
 }
 
 func loadMetricFilter(cfg config.Component) (*metricsFilterRules, error) {
@@ -126,7 +130,7 @@ func loadMetricFilter(cfg config.Component) (*metricsFilterRules, error) {
 		}
 	}
 
-	rules = append(rules, defaultMetricsProcessingRules()...)
+	rules = append(implicitMetricsProcessingRules(), rules...)
 
 	filter, err := newMetricsFilterRules(rules)
 	if err != nil {

--- a/comp/anomalydetection/observer/impl/filter_rules_test.go
+++ b/comp/anomalydetection/observer/impl/filter_rules_test.go
@@ -12,6 +12,7 @@ import (
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -197,25 +198,29 @@ func TestMetricsFilterRulesLogMetricsExtractorBypass(t *testing.T) {
 	assert.False(t, filter.isAllowed("system.cpu.user", "dogstatsd", nil))
 }
 
-func TestDefaultMetricsProcessingRulesExcludeAgentNamespace(t *testing.T) {
-	filter, err := newMetricsFilterRules(defaultMetricsProcessingRules())
+func TestImplicitMetricsProcessingRulesExcludeObserverTelemetry(t *testing.T) {
+	filter, err := newMetricsFilterRules(implicitMetricsProcessingRules())
 	require.NoError(t, err)
 
-	assert.False(t, filter.isAllowed("datadog.agent.running", observerdef.AgentNamespace, nil))
+	assert.False(t, filter.isAllowed(observerTelemetryMetricPrefix+"metrics.filtered", observerdef.AgentNamespace, nil))
+	assert.True(t, filter.isAllowed(observerTelemetryMetricPrefix+"metrics.filtered", "dogstatsd", nil))
+	assert.True(t, filter.isAllowed("datadog.agent.running", observerdef.AgentNamespace, nil))
 	assert.True(t, filter.isAllowed("system.cpu.user", "dogstatsd", nil))
 }
 
-func TestDefaultAgentRuleCanBeOverriddenByEarlierIncludeRule(t *testing.T) {
-	filter, err := newMetricsFilterRules(append([]metricsProcessingRule{
-		{
-			Type:   includeAtMatch,
-			Name:   "keep_agent_metrics",
-			Source: observerdef.AgentNamespace,
-		},
-	}, defaultMetricsProcessingRules()...))
+func TestImplicitObserverTelemetryRuleCannotBeOverridden(t *testing.T) {
+	cfg := configmock.NewFromYAML(t, `
+anomaly_detection:
+  metrics:
+    processing_rules:
+      - type: include_at_match
+        name: keep_observer_telemetry
+        name_pattern: datadog.agent.observer.*
+`)
+	filter, err := loadMetricFilter(cfg)
 	require.NoError(t, err)
 
-	assert.True(t, filter.isAllowed("datadog.agent.running", observerdef.AgentNamespace, nil))
+	assert.False(t, filter.isAllowed(observerTelemetryMetricPrefix+"metrics.filtered", observerdef.AgentNamespace, nil))
 }
 
 func TestLoadMetricFilterWithoutConfigUsesDefaultRules(t *testing.T) {
@@ -223,7 +228,8 @@ func TestLoadMetricFilterWithoutConfigUsesDefaultRules(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, filter)
 
-	assert.False(t, filter.isAllowed("datadog.agent.running", observerdef.AgentNamespace, nil))
+	assert.False(t, filter.isAllowed(observerTelemetryMetricPrefix+"metrics.filtered", observerdef.AgentNamespace, nil))
+	assert.True(t, filter.isAllowed("datadog.agent.running", observerdef.AgentNamespace, nil))
 	assert.True(t, filter.isAllowed("system.cpu.user", "dogstatsd", nil))
 }
 
@@ -285,14 +291,21 @@ func TestPrepareMetricIngestDropsMatchingMetrics(t *testing.T) {
 	assert.Equal(t, "system.cpu.user", kept.metric.name)
 }
 
-func TestPrepareMetricIngestDropsNormalizedAgentMetricsViaDefaultRule(t *testing.T) {
+func TestPrepareMetricIngestAllowsInternalAgentMetricsAndDropsObserverTelemetry(t *testing.T) {
 	filter, err := newDefaultMetricsFilterRules()
 	require.NoError(t, err)
-	decision := prepareMetricIngest("dogstatsd", &metricObs{
+	allowed := prepareMetricIngest("dogstatsd", &metricObs{
 		name:  "datadog.agent.running",
 		value: 1,
 	}, filter)
-	assert.Nil(t, decision.metric)
+	require.NotNil(t, allowed.metric)
+	assert.Equal(t, observerdef.AgentNamespace, allowed.source)
+
+	dropped := prepareMetricIngest("dogstatsd", &metricObs{
+		name:  observerTelemetryMetricPrefix + "metrics.filtered",
+		value: 1,
+	}, filter)
+	assert.Nil(t, dropped.metric)
 }
 
 func TestPrepareMetricIngestAllowsNormalizedAgentMetricsWhenIncludedEarlier(t *testing.T) {
@@ -302,7 +315,7 @@ func TestPrepareMetricIngestAllowsNormalizedAgentMetricsWhenIncludedEarlier(t *t
 			Name:   "keep_agent_metrics",
 			Source: observerdef.AgentNamespace,
 		},
-	}, defaultMetricsProcessingRules()...))
+	}, implicitMetricsProcessingRules()...))
 	require.NoError(t, err)
 
 	decision := prepareMetricIngest("dogstatsd", &metricObs{
@@ -327,7 +340,7 @@ func TestPrepareMetricIngestMixedAgentRulesKeepIncludedMetricAndDropOthers(t *te
 			Name:   "drop_other_agent_metrics",
 			Source: observerdef.AgentNamespace,
 		},
-	}, defaultMetricsProcessingRules()...))
+	}, implicitMetricsProcessingRules()...))
 	require.NoError(t, err)
 
 	kept := prepareMetricIngest("dogstatsd", &metricObs{
@@ -490,7 +503,7 @@ func TestFilteredMetricTelemetrySyncPath(t *testing.T) {
 	requireCounterMetricValueBySource(t, "check", 1.0, telComp)
 }
 
-func TestDefaultFilterAsyncPathIngestsNonAgentMetricsAndCountsFilteredAgentMetrics(t *testing.T) {
+func TestDefaultFilterAsyncPathIngestsAgentMetricsAndFiltersObserverTelemetry(t *testing.T) {
 	telComp := telemetryimpl.GetCompatComponent()
 	telComp.Reset()
 	t.Cleanup(telComp.Reset)
@@ -538,6 +551,11 @@ func TestDefaultFilterAsyncPathIngestsNonAgentMetricsAndCountsFilteredAgentMetri
 		value:     1,
 		timestamp: 1000,
 	})
+	obs.GetHandle("check").ObserveMetric(&metricObs{
+		name:      observerTelemetryMetricPrefix + "metrics.filtered",
+		value:     1,
+		timestamp: 1000,
+	})
 
 	stopFn()
 
@@ -550,7 +568,8 @@ func TestDefaultFilterAsyncPathIngestsNonAgentMetricsAndCountsFilteredAgentMetri
 	assert.Equal(t, "system.mem.used", checkSeries[0].Name)
 
 	agentSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: observerdef.AgentNamespace})
-	assert.Empty(t, agentSeries)
+	require.Len(t, agentSeries, 1)
+	assert.Equal(t, "datadog.agent.running", agentSeries[0].Name)
 
 	requireCounterMetricValueBySource(t, observerdef.AgentNamespace, 1.0, telComp)
 	requireNoCounterMetricForNameBySource(t, telemetryObsChannelDropped, "check", telComp)
@@ -650,7 +669,7 @@ func TestMixedAgentRulesAsyncPathKeepsIncludedMetricAndCountsDroppedMetric(t *te
 			Name:   "drop_other_agent_metrics",
 			Source: observerdef.AgentNamespace,
 		},
-	}, defaultMetricsProcessingRules()...))
+	}, implicitMetricsProcessingRules()...))
 	require.NoError(t, err)
 
 	telComp := telemetryimpl.GetCompatComponent()

--- a/comp/anomalydetection/observer/impl/ingest_metrics_disabled_test.go
+++ b/comp/anomalydetection/observer/impl/ingest_metrics_disabled_test.go
@@ -100,7 +100,7 @@ func TestObserverDropsMetricsWhenIngestMetricsDisabled(t *testing.T) {
 	requireNoCounterMetricForNameBySource(t, telemetryFilteredMetrics, "dogstatsd", telComp)
 }
 
-func TestAgentMetricsAreDropped(t *testing.T) {
+func TestInternalAgentMetricsAreIngestedAndObserverTelemetryIsDropped(t *testing.T) {
 	defaultFilter, err := newDefaultMetricsFilterRules()
 	require.NoError(t, err)
 
@@ -141,6 +141,11 @@ func TestAgentMetricsAreDropped(t *testing.T) {
 		value:     1,
 		timestamp: 1000,
 	})
+	h.ObserveMetric(&metricObs{
+		name:      observerTelemetryMetricPrefix + "metrics.filtered",
+		value:     1,
+		timestamp: 1000,
+	})
 
 	stopFn()
 
@@ -149,14 +154,14 @@ func TestAgentMetricsAreDropped(t *testing.T) {
 	assert.Equal(t, "system.cpu.user", dogstatsdSeries[0].Name)
 
 	agentSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: observerdef.AgentNamespace})
-	assert.Empty(t, agentSeries)
+	require.Len(t, agentSeries, 1)
+	assert.Equal(t, "datadog.agent.running", agentSeries[0].Name)
 
 	workloadSeries := storage.ListSeries(observerdef.WorkloadSeriesFilter())
-	require.Len(t, workloadSeries, 1)
-	assert.Equal(t, "dogstatsd", workloadSeries[0].Namespace)
+	require.Len(t, workloadSeries, 2)
 }
 
-func TestIngestMetricSyncDropsNormalizedAgentMetrics(t *testing.T) {
+func TestIngestMetricSyncAllowsInternalAgentMetricsAndDropsObserverTelemetry(t *testing.T) {
 	defaultFilter, err := newDefaultMetricsFilterRules()
 	require.NoError(t, err)
 
@@ -176,13 +181,19 @@ func TestIngestMetricSyncDropsNormalizedAgentMetrics(t *testing.T) {
 		value:     1,
 		timestamp: 1000,
 	})
+	obs.IngestMetricSync("dogstatsd", &metricObs{
+		name:      observerTelemetryMetricPrefix + "metrics.filtered",
+		value:     1,
+		timestamp: 1000,
+	})
 
 	dogstatsdSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: "dogstatsd"})
 	require.Len(t, dogstatsdSeries, 1)
 	assert.Equal(t, "system.cpu.user", dogstatsdSeries[0].Name)
 
 	agentSeries := storage.ListSeries(observerdef.SeriesFilter{Namespace: observerdef.AgentNamespace})
-	assert.Empty(t, agentSeries)
+	require.Len(t, agentSeries, 1)
+	assert.Equal(t, "datadog.agent.running", agentSeries[0].Name)
 }
 
 // TestMetricDropHandle covers the metricDropHandle wrapper in isolation.

--- a/comp/anomalydetection/observer/impl/telemetry.go
+++ b/comp/anomalydetection/observer/impl/telemetry.go
@@ -12,6 +12,11 @@ import (
 )
 
 const (
+	// observerTelemetryMetricPrefix is the Agent metric prefix used when observer
+	// telemetry is emitted through the metric pipeline. Keep this separate from
+	// the Prometheus subsystem/name used below so the ingestion loop guard stays
+	// correct if the emitted name changes.
+	observerTelemetryMetricPrefix            = "datadog.agent.observer."
 	telemetryObsChannelDropped               = "observer.channel.dropped"                     // Observations dropped when the observer channel is full.
 	telemetryRRCFScore                       = "observer.rrcf.score"                          // Latest RRCF score per detector.
 	telemetryRRCFThreshold                   = "observer.rrcf.threshold"                      // Current RRCF anomaly threshold per detector.


### PR DESCRIPTION
### What does this PR do?

Adds a mandatory first metric-processing rule that excludes observer telemetry from anomaly detection.

### Motivation

Prevent anomaly-detection observer telemetry from being ingested recursively while retaining other internal Agent metrics.

### Describe how you validated your changes

### Additional Notes