### PR TITLE
chore: remove no-op `//nolint:deadcode` (noisy warnings)

### DIFF
--- a/cmd/agent/common/misconfig/global.go
+++ b/cmd/agent/common/misconfig/global.go
@@ -24,7 +24,7 @@ type AgentType int
 
 type checkFn func() error
 
-// nolint: deadcode, unused
+//nolint:unused
 type check struct {
 	name            string
 	run             checkFn
@@ -40,7 +40,7 @@ const (
 
 var checks = map[string]check{}
 
-// nolint: deadcode, unused
+//nolint:unused
 func registerCheck(name string, c checkFn, supportedAgentsSet map[AgentType]struct{}) {
 	checks[name] = check{name: name, run: c, supportedAgents: supportedAgentsSet}
 }

--- a/cmd/agent/main_common.go
+++ b/cmd/agent/main_common.go
@@ -7,7 +7,7 @@
 
 package main
 
-// nolint: deadcode, unused
+//nolint:unused
 func setProcessName(_ string) error {
 	return nil
 }

--- a/cmd/system-probe/modules/modules.go
+++ b/cmd/system-probe/modules/modules.go
@@ -38,7 +38,7 @@ var moduleOrder = []types.ModuleName{
 	config.LogonDurationModule,
 }
 
-// nolint: deadcode, unused // may be unused with certain build tag combinations
+//nolint:unused // may be unused with certain build tag combinations
 func registerModule(mod *module.Factory) {
 	if mod.Name == "" {
 		return

--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -149,7 +149,7 @@ func commonReloadPoliciesCommands(globalParams *command.GlobalParams) []*cobra.C
 	return []*cobra.Command{commonReloadPoliciesCmd}
 }
 
-// nolint: deadcode, unused
+//nolint:unused
 func selfTestCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	selfTestCmd := &cobra.Command{
 		Use:   "self-test",
@@ -366,7 +366,7 @@ func discardersCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{discardersCmd}
 }
 
-// nolint: deadcode, unused
+//nolint:unused
 func dumpProcessCache(_ log.Component, _ config.Component, _ secrets.Component, processCacheDumpArgs *processCacheDumpCliParams) error {
 	client, err := secagent.NewRuntimeSecurityCmdClient()
 	if err != nil {
@@ -457,7 +457,7 @@ func evalRule(_ log.Component, _ config.Component, _ secrets.Component, evalArgs
 	})
 }
 
-// nolint: deadcode, unused
+//nolint:unused
 func runRuntimeSelfTest(_ log.Component, _ config.Component, _ secrets.Component) error {
 	client, err := secagent.NewRuntimeSecurityCmdClient()
 	if err != nil {
@@ -662,7 +662,7 @@ func downloadPolicy(log log.Component, config config.Component, _ secrets.Compon
 	return err
 }
 
-// nolint: deadcode, unused
+//nolint:unused
 func dumpDiscarders(_ log.Component, _ config.Component, _ secrets.Component) error {
 	runtimeSecurityClient, err := secagent.NewRuntimeSecurityCmdClient()
 	if err != nil {

--- a/comp/core/autodiscovery/impl/secrets_test.go
+++ b/comp/core/autodiscovery/impl/secrets_test.go
@@ -91,7 +91,7 @@ func (m *MockSecretResolver) haveAllScenariosNotCalled() bool {
 	return true
 }
 
-// nolint: deadcode, unused
+//nolint:unused
 func (m *MockSecretResolver) triggerCallback(handle, origin string, path []string, oldValue, newValue any) {
 	for _, subscriber := range m.subscribers {
 		subscriber(handle, origin, path, oldValue, newValue)

--- a/comp/core/autodiscovery/providers/utils.go
+++ b/comp/core/autodiscovery/providers/utils.go
@@ -24,11 +24,11 @@ const (
 	//nolint needed as these constants are defined in a file without a build tag,
 	// but only used in multiple files with different build tags, none of which
 	// are used in the IoT Agent.
-	//nolint:unused,deadcode
+	//nolint:unused
 	instancePath string = "instances"
-	//nolint:unused,deadcode
+	//nolint:unused
 	checkNamePath string = "check_names"
-	//nolint:unused,deadcode
+	//nolint:unused
 	initConfigPath string = "init_configs"
 )
 
@@ -72,7 +72,7 @@ type providerCache struct {
 // but only used in multiple files with different build tags, none of which
 // are used in the IoT Agent.
 //
-//nolint:deadcode,unused
+//nolint:unused
 func newProviderCache() *providerCache {
 	return &providerCache{
 		mostRecentMod: 0,
@@ -83,7 +83,7 @@ func newProviderCache() *providerCache {
 // ignoreADTagsFromAnnotations returns of the `ad.datadoghq.com/{endpoints,service}.ignore_autodiscovery_tags` annotation
 // TODO(CINT)(Agent 7.53+) Remove support for hybrid scenarios
 //
-//nolint:deadcode,unused
+//nolint:unused
 func ignoreADTagsFromAnnotations(annotations map[string]string, prefix string) bool {
 	ignoreAdForHybridScenariosTags, _ := strconv.ParseBool(annotations[prefix+"ignore_autodiscovery_tags"])
 	return ignoreAdForHybridScenariosTags

--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -627,7 +627,7 @@ func (l *loader) parseBool(v string) *bool {
 	return &b
 }
 
-//nolint:unused,deadcode
+//nolint:unused
 func (l *loader) parseFloat(v string) *float64 {
 	if v == "" {
 		return nil

--- a/pkg/config/env/environment_detection.go
+++ b/pkg/config/env/environment_detection.go
@@ -152,7 +152,7 @@ func excludeFeatures(detectedFeatures FeatureMap, excludedFeatures []string) {
 	}
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func registerFeature(f Feature) {
 	knownFeatures[f] = struct{}{}
 }

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -259,7 +259,7 @@ func (di *DriverInterface) RefreshStats() {
 	}
 }
 
-//nolint:deadcode,unused // debugging helper normally commented out
+//nolint:unused // debugging helper normally commented out
 func printClassification(fd *driver.PerFlowData) {
 	if fd.ClassificationStatus != driver.ClassificationUnclassified {
 		if fd.ClassifyRequest == driver.ClassificationRequestTLS || fd.ClassifyResponse == driver.ClassificationResponseTLS {

--- a/pkg/network/netlink/align.go
+++ b/pkg/network/netlink/align.go
@@ -28,7 +28,7 @@ func nlmsgAlign(len int) int {
 
 // #define NLMSG_LENGTH(len) ((len) + NLMSG_HDRLEN)
 //
-//nolint:unused,deadcode
+//nolint:unused
 func nlmsgLength(len int) int {
 	return len + nlmsgHeaderLen
 }

--- a/pkg/network/netlink/decoding.go
+++ b/pkg/network/netlink/decoding.go
@@ -25,7 +25,7 @@ const (
 const (
 	ctaTupleIP    = 1
 	ctaTupleProto = 2
-	ctaTupleZone  = 3 //nolint:deadcode
+	ctaTupleZone  = 3 //nolint:unused
 )
 
 const (

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -32,7 +32,7 @@ func testGroupID(groupID int32) func() int32 {
 	}
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func procsToHash(procs []*procutil.Process) (procsByPid map[int32]*procutil.Process) {
 	procsByPid = make(map[int32]*procutil.Process)
 	for _, p := range procs {

--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -315,7 +315,7 @@ func (rsa *RuntimeSecurityAgent) startActivityDumpStorageTelemetry(ctx context.C
 	}
 }
 
-//nolint:unused,deadcode
+//nolint:unused
 func (rsa *RuntimeSecurityAgent) setupGPRC() error {
 	if pkgconfigsetup.Datadog().GetString("runtime_security_config.event_grpc_server") == "security-agent" {
 		socketPath := pkgconfigsetup.Datadog().GetString("runtime_security_config.socket")

--- a/pkg/security/ebpf/probes/socket.go
+++ b/pkg/security/ebpf/probes/socket.go
@@ -65,7 +65,7 @@ func GetAllSocketProgramFunctions() []string {
 
 // CheckCgroupSocketReturnCode checks if the return code is 1(accept)
 //
-//nolint:unused,deadcode
+//nolint:unused
 func CheckCgroupSocketReturnCode(progSpecs map[string]*ebpf.ProgramSpec) error {
 	for _, progSpec := range progSpecs {
 		if progSpec.Type == ebpf.CGroupSock {

--- a/pkg/security/probe/discarders_linux.go
+++ b/pkg/security/probe/discarders_linux.go
@@ -39,7 +39,7 @@ const (
 	maxParentDiscarderDepth = 3
 
 	// allEventTypes is a mask to match all the events
-	allEventTypes = math.MaxUint32 //nolint:deadcode,unused
+	allEventTypes = math.MaxUint32 //nolint:unused
 
 	// inode/mountid that won't be resubmitted
 	maxRecentlyAddedCacheSize = uint64(64)

--- a/pkg/security/probe/selftests/self_tests.go
+++ b/pkg/security/probe/selftests/self_tests.go
@@ -17,10 +17,10 @@ import (
 )
 
 const (
-	policySource  = "self-test"                          //nolint: deadcode, unused
-	policyVersion = "1.0.0"                              //nolint: deadcode, unused
-	policyName    = "datadog-agent-cws-self-test-policy" //nolint: deadcode, unused
-	ruleIDPrefix  = "datadog_agent_cws_self_test_rule"   //nolint: deadcode, unused
+	policySource  = "self-test"                          //nolint:unused
+	policyVersion = "1.0.0"                              //nolint:unused
+	policyName    = "datadog-agent-cws-self-test-policy" //nolint:unused
+	ruleIDPrefix  = "datadog_agent_cws_self_test_rule"   //nolint:unused
 
 	// DefaultTimeout default timeout
 	DefaultTimeout = 30 * time.Second

--- a/pkg/security/security_profile/activity_tree/activity_tree_graph.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_graph.go
@@ -28,13 +28,13 @@ var (
 	processRuntimeColor      = "#edf3ff"
 	processSnapshotColor     = "white"
 	processShape             = "record"
-	//nolint:deadcode,unused
+	//nolint:unused
 	processClusterColor = "#c7ddff"
 
 	processCategoryColor = "#c7c7c7"
-	//nolint:deadcode,unused
+	//nolint:unused
 	processCategoryProfileDriftColor = "#e0e0e0"
-	//nolint:deadcode,unused
+	//nolint:unused
 	processCategoryRuntimeColor  = "#f5f5f5"
 	processCategorySnapshotColor = "white"
 	processCategoryShape         = "record"

--- a/pkg/security/serializers/helpers.go
+++ b/pkg/security/serializers/helpers.go
@@ -6,7 +6,7 @@
 // Package serializers defines functions aiming to serialize events
 package serializers
 
-// nolint: deadcode, unused
+//nolint:unused
 func createNumPointer[I uint32 | uint64](i I) *I {
 	if i == 0 {
 		return nil

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -392,7 +392,7 @@ func newMatchedRulesSerializer(r *model.MatchedRule) MatchedRuleSerializer {
 	return mrs
 }
 
-// nolint: deadcode, unused
+//nolint:unused
 func newDNSEventSerializer(d *model.DNSEvent) *DNSEventSerializer {
 	ret := &DNSEventSerializer{
 		ID:    d.ID,
@@ -425,7 +425,7 @@ func newDNSEventSerializer(d *model.DNSEvent) *DNSEventSerializer {
 	return ret
 }
 
-// nolint: deadcode, unused
+//nolint:unused
 func newAWSSecurityCredentialsSerializer(creds *model.AWSSecurityCredentials) *AWSSecurityCredentialsSerializer {
 	return &AWSSecurityCredentialsSerializer{
 		Code:        creds.Code,
@@ -436,7 +436,7 @@ func newAWSSecurityCredentialsSerializer(creds *model.AWSSecurityCredentials) *A
 	}
 }
 
-// nolint: deadcode, unused
+//nolint:unused
 func newIMDSEventSerializer(e *model.IMDSEvent) *IMDSEventSerializer {
 	var aws *AWSIMDSEventSerializer
 	if e.CloudProvider == model.IMDSAWSCloudProvider {
@@ -459,7 +459,7 @@ func newIMDSEventSerializer(e *model.IMDSEvent) *IMDSEventSerializer {
 	}
 }
 
-// nolint: deadcode, unused
+//nolint:unused
 func newIPPortSerializer(c *model.IPPortContext) IPPortSerializer {
 	return IPPortSerializer{
 		IP:   utils.GetIPStringFromIPNet(c.IPNet),
@@ -467,7 +467,7 @@ func newIPPortSerializer(c *model.IPPortContext) IPPortSerializer {
 	}
 }
 
-// nolint: deadcode, unused
+//nolint:unused
 func newIPPortFamilySerializer(c *model.IPPortContext, family string) IPPortFamilySerializer {
 	return IPPortFamilySerializer{
 		IP:     utils.GetIPStringFromIPNet(c.IPNet),

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -1489,7 +1489,7 @@ func newDDContextSerializer(e *model.Event) *DDContextSerializer {
 	return s
 }
 
-// nolint: deadcode, unused
+//nolint:unused
 func newNetworkContextSerializer(e *model.Event, networkCtx *model.NetworkContext) *NetworkContextSerializer {
 	return &NetworkContextSerializer{
 		Device:           newNetworkDeviceSerializer(&networkCtx.Device, e),

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -24,7 +24,7 @@ import (
 type wrapperType string
 
 const (
-	noWrapperType      wrapperType = "" //nolint:deadcode,unused
+	noWrapperType      wrapperType = "" //nolint:unused
 	stdWrapperType     wrapperType = "std"
 	dockerWrapperType  wrapperType = "docker"
 	podmanWrapperType  wrapperType = "podman"

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -589,13 +589,13 @@ func (tm *testModule) WaitSignalWithoutProcessContext(tb testing.TB, action func
 	})
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) marshalEvent(ev *model.Event) (string, error) {
 	b, err := serializers.MarshalEvent(ev, nil, tm.probe.GetScrubber())
 	return string(b), err
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) debugEvent(ev *model.Event) string {
 	b, err := tm.marshalEvent(ev)
 	if err != nil {
@@ -604,13 +604,13 @@ func (tm *testModule) debugEvent(ev *model.Event) string {
 	return string(b)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertTriggeredRule(tb testing.TB, r *rules.Rule, id string) bool {
 	tb.Helper()
 	return assert.Equal(tb, id, r.ID, "wrong triggered rule")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertFieldEqual(tb testing.TB, e *model.Event, field string, value interface{}, msgAndArgs ...interface{}) bool {
 	tb.Helper()
 	fieldValue, err := e.GetFieldValue(field)
@@ -621,7 +621,7 @@ func assertFieldEqual(tb testing.TB, e *model.Event, field string, value interfa
 	return assert.Equal(tb, value, fieldValue, msgAndArgs...)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertFieldEqualCaseInsensitve(tb testing.TB, e *model.Event, field string, value interface{}, msgAndArgs ...interface{}) bool {
 	tb.Helper()
 	fieldValue, err := e.GetFieldValue(field)
@@ -643,7 +643,7 @@ func assertFieldEqualCaseInsensitve(tb testing.TB, e *model.Event, field string,
 	return eq
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertFieldNotEqual(tb testing.TB, e *model.Event, field string, value interface{}, msgAndArgs ...interface{}) bool {
 	tb.Helper()
 	fieldValue, err := e.GetFieldValue(field)
@@ -654,7 +654,7 @@ func assertFieldNotEqual(tb testing.TB, e *model.Event, field string, value inte
 	return assert.NotEqual(tb, value, fieldValue, msgAndArgs...)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertFieldNotEmpty(tb testing.TB, e *model.Event, field string, msgAndArgs ...interface{}) bool {
 	tb.Helper()
 	fieldValue, err := e.GetFieldValue(field)
@@ -665,7 +665,7 @@ func assertFieldNotEmpty(tb testing.TB, e *model.Event, field string, msgAndArgs
 	return assert.NotEmpty(tb, fieldValue, msgAndArgs...)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertFieldContains(tb testing.TB, e *model.Event, field string, value interface{}, msgAndArgs ...interface{}) bool {
 	tb.Helper()
 	fieldValue, err := e.GetFieldValue(field)
@@ -676,7 +676,7 @@ func assertFieldContains(tb testing.TB, e *model.Event, field string, value inte
 	return assert.Contains(tb, fieldValue, value, msgAndArgs...)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertFieldIsOneOf(tb testing.TB, e *model.Event, field string, possibleValues interface{}, msgAndArgs ...interface{}) bool {
 	tb.Helper()
 	fieldValue, err := e.GetFieldValue(field)
@@ -687,7 +687,7 @@ func assertFieldIsOneOf(tb testing.TB, e *model.Event, field string, possibleVal
 	return assert.Contains(tb, possibleValues, fieldValue, msgAndArgs...)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertFieldStringArrayIndexedOneOf(tb *testing.T, e *model.Event, field string, index int, values []string, msgAndArgs ...interface{}) bool {
 	tb.Helper()
 	fieldValue, err := e.GetFieldValue(field)

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -246,7 +246,7 @@ type testModule struct {
 	grpcServer    *grpcutils.Server
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func getInode(tb testing.TB, path string) uint64 {
 	fileInfo, err := os.Lstat(path)
 	if err != nil {
@@ -263,7 +263,7 @@ func getInode(tb testing.TB, path string) uint64 {
 	return stats.Ino
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func which(tb testing.TB, name string) string {
 	executable, err := whichNonFatal(name)
 	if err != nil {
@@ -274,7 +274,7 @@ func which(tb testing.TB, name string) string {
 
 // whichNonFatal is "which" which returns an error instead of fatal
 //
-//nolint:deadcode,unused
+//nolint:unused
 func whichNonFatal(name string) (string, error) {
 	executable, err := exec.LookPath(name)
 	if err != nil {
@@ -288,7 +288,7 @@ func whichNonFatal(name string) (string, error) {
 	return executable, nil
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func copyFile(src string, dst string, mode fs.FileMode) error {
 	input, err := os.ReadFile(src)
 	if err != nil {
@@ -298,7 +298,7 @@ func copyFile(src string, dst string, mode fs.FileMode) error {
 	return os.WriteFile(dst, input, mode)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertMode(tb testing.TB, actualMode, expectedMode uint32, msgAndArgs ...interface{}) bool {
 	tb.Helper()
 	if len(msgAndArgs) == 0 {
@@ -307,7 +307,7 @@ func assertMode(tb testing.TB, actualMode, expectedMode uint32, msgAndArgs ...in
 	return assert.Equal(tb, strconv.FormatUint(uint64(expectedMode), 8), strconv.FormatUint(uint64(actualMode), 8), msgAndArgs...)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertInode(tb testing.TB, actualInode, expectedInode uint64, msgAndArgs ...interface{}) bool {
 	tb.Helper()
 
@@ -321,13 +321,13 @@ func assertInode(tb testing.TB, actualInode, expectedInode uint64, msgAndArgs ..
 	return assert.Equal(tb, strconv.FormatUint(uint64(expectedInode), 8), strconv.FormatUint(uint64(actualInode), 8), msgAndArgs...)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertRights(tb testing.TB, actualMode, expectedMode uint16, msgAndArgs ...interface{}) bool {
 	tb.Helper()
 	return assertMode(tb, uint32(actualMode)&01777, uint32(expectedMode), msgAndArgs...)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertNearTimeObject(tb testing.TB, eventTime time.Time) bool {
 	tb.Helper()
 	now := time.Now()
@@ -338,25 +338,25 @@ func assertNearTimeObject(tb testing.TB, eventTime time.Time) bool {
 	return true
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertNearTime(tb testing.TB, ns uint64) bool {
 	tb.Helper()
 	return assertNearTimeObject(tb, time.Unix(0, int64(ns)))
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertNotTriggeredRule(tb testing.TB, r *rules.Rule, id string) bool {
 	tb.Helper()
 	return assert.NotEqual(tb, id, r.ID, "wrong triggered rule")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func assertReturnValue(tb testing.TB, retval, expected int64) bool {
 	tb.Helper()
 	return assert.Equal(tb, expected, retval, "wrong return value")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func validateProcessContextLineage(tb testing.TB, event *model.Event) {
 	scrubber, err := utils.NewScrubber(nil, nil)
 	if err != nil {
@@ -449,7 +449,7 @@ func validateProcessContextLineage(tb testing.TB, event *model.Event) {
 	}
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func validateProcessContextSECL(tb testing.TB, event *model.Event) {
 	// Process file name values cannot be blank
 	nameFields := []string{
@@ -538,7 +538,7 @@ func checkProcessContextFieldsForBlankValues(tb testing.TB, event *model.Event, 
 	return validField, hasPath
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func validateSyscallContext(tb testing.TB, event *model.Event, jsonPath string) {
 	if ebpfLessEnabled {
 		return
@@ -570,7 +570,7 @@ func validateSyscallContext(tb testing.TB, event *model.Event, jsonPath string) 
 	}
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func validateProcessContext(tb testing.TB, event *model.Event) {
 	if event.ProcessContext.IsKworker {
 		return
@@ -580,7 +580,7 @@ func validateProcessContext(tb testing.TB, event *model.Event) {
 	validateProcessContextSECL(tb, event)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func validateEvent(tb testing.TB, validate func(event *model.Event, rule *rules.Rule)) func(event *model.Event, rule *rules.Rule) {
 	return func(event *model.Event, rule *rules.Rule) {
 		validate(event, rule)
@@ -588,7 +588,7 @@ func validateEvent(tb testing.TB, validate func(event *model.Event, rule *rules.
 	}
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateExecEvent(tb *testing.T, kind wrapperType, validate func(event *model.Event, rule *rules.Rule)) func(event *model.Event, rule *rules.Rule) {
 	return func(event *model.Event, rule *rules.Rule) {
 		validate(event, rule)
@@ -1107,7 +1107,7 @@ func swapLogLevel(logLevel log.LogLevel) (log.LogLevel, error) {
 // systemUmask caches the system umask between tests
 var systemUmask int //nolint:unused
 
-//nolint:deadcode,unused
+//nolint:unused
 func applyUmask(fileMode int) int {
 	if systemUmask == 0 {
 		// Get the system umask to compute the right access mode
@@ -1118,7 +1118,7 @@ func applyUmask(fileMode int) int {
 	return fileMode &^ systemUmask
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func ifSyscallSupported(syscall string, test func(t *testing.T, syscallNB uintptr)) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
@@ -1142,7 +1142,7 @@ type eventKeyValueFilter struct {
 // WARNING: this function may yield a "fatal error: concurrent map writes" error if the ruleset of testModule does not
 // contain a rule on "open.file.path"
 //
-//nolint:deadcode,unused
+//nolint:unused
 func waitForProbeEvent(test *testModule, action func() error, eventType model.EventType, filters ...eventKeyValueFilter) error {
 	return test.GetProbeEvent(action, func(event *model.Event) bool {
 		for _, filter := range filters {
@@ -1154,7 +1154,7 @@ func waitForProbeEvent(test *testModule, action func() error, eventType model.Ev
 	}, getEventTimeout, eventType)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func waitForOpenProbeEvent(test *testModule, action func() error, filename string) error {
 	return waitForProbeEvent(test, action, model.FileOpenEventType, eventKeyValueFilter{
 		key:   "open.file.path",
@@ -1162,7 +1162,7 @@ func waitForOpenProbeEvent(test *testModule, action func() error, filename strin
 	})
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func waitForIMDSResponseProbeEvent(test *testModule, action func() error, processFileName string) error {
 	return waitForProbeEvent(test, action, model.IMDSEventType, []eventKeyValueFilter{
 		{
@@ -1176,7 +1176,7 @@ func waitForIMDSResponseProbeEvent(test *testModule, action func() error, proces
 	}...)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func checkKernelCompatibility(tb testing.TB, why string, skipCheck func(kv *kernel.Version) bool) {
 	tb.Helper()
 	kv, err := kernel.NewKernelVersion()
@@ -1489,7 +1489,7 @@ func isSystemdAvailable() bool {
 	return true
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func findLearningContainerID(dumps []*activityDumpIdentifier, containerID containerutils.ContainerID) *activityDumpIdentifier {
 	for _, dump := range dumps {
 		if dump.ContainerID == containerID {
@@ -1499,7 +1499,7 @@ func findLearningContainerID(dumps []*activityDumpIdentifier, containerID contai
 	return nil
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func findLearningContainerName(dumps []*activityDumpIdentifier, name string) *activityDumpIdentifier {
 	for _, dump := range dumps {
 		if dump.Name == name {
@@ -1509,7 +1509,7 @@ func findLearningContainerName(dumps []*activityDumpIdentifier, name string) *ac
 	return nil
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) isDumpRunning(id *activityDumpIdentifier) bool {
 	dumps, err := tm.ListActivityDumps()
 	if err != nil {
@@ -1519,7 +1519,7 @@ func (tm *testModule) isDumpRunning(id *activityDumpIdentifier) bool {
 	return dump != nil
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) findCgroupDump(id *activityDumpIdentifier) *activityDumpIdentifier {
 	dumps, err := tm.ListActivityDumps()
 	if err != nil {
@@ -1532,7 +1532,7 @@ func (tm *testModule) findCgroupDump(id *activityDumpIdentifier) *activityDumpId
 	return dump
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) addAllEventTypesOnDump(dockerInstance *dockerCmdWrapper, syscallTester string, goSyscallTester string) {
 	// open
 	cmd := dockerInstance.Command("touch", []string{filepath.Join(tm.Root(), "open")}, []string{})
@@ -1553,7 +1553,7 @@ func (tm *testModule) addAllEventTypesOnDump(dockerInstance *dockerCmdWrapper, s
 	_, _ = cmd.CombinedOutput()
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) dockerCreateFiles(dockerInstance *dockerCmdWrapper, syscallTester string, directory string, numberOfFiles int) error {
 	var files []string
 	for i := 0; i < numberOfFiles; i++ {
@@ -1569,7 +1569,7 @@ func (tm *testModule) dockerCreateFiles(dockerInstance *dockerCmdWrapper, syscal
 	return nil
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) findNextPartialDump(dockerInstance *dockerCmdWrapper, id *activityDumpIdentifier) (*activityDumpIdentifier, error) {
 	for i := 0; i < 10; i++ { // retry during 5sec
 		dump := tm.findCgroupDump(id)
@@ -1586,7 +1586,7 @@ func (tm *testModule) findNextPartialDump(dockerInstance *dockerCmdWrapper, id *
 	return nil, errors.New("Unable to find the next partial dump")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func searchForOpen(ad *dump.ActivityDump) bool {
 	for _, node := range ad.Profile.ActivityTree.ProcessNodes {
 		if len(node.Files) > 0 {
@@ -1596,7 +1596,7 @@ func searchForOpen(ad *dump.ActivityDump) bool {
 	return false
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func searchForDNS(ad *dump.ActivityDump) bool {
 	for _, node := range ad.Profile.ActivityTree.ProcessNodes {
 		if len(node.DNSNames) > 0 {
@@ -1606,7 +1606,7 @@ func searchForDNS(ad *dump.ActivityDump) bool {
 	return false
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func searchForIMDS(ad *dump.ActivityDump) bool {
 	for _, node := range ad.Profile.ActivityTree.ProcessNodes {
 		if len(node.IMDSEvents) > 0 {
@@ -1616,7 +1616,7 @@ func searchForIMDS(ad *dump.ActivityDump) bool {
 	return false
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func searchForBind(ad *dump.ActivityDump) bool {
 	for _, node := range ad.Profile.ActivityTree.ProcessNodes {
 		if len(node.Sockets) > 0 {
@@ -1626,7 +1626,7 @@ func searchForBind(ad *dump.ActivityDump) bool {
 	return false
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func searchForSyscalls(ad *dump.ActivityDump) bool {
 	for _, node := range ad.Profile.ActivityTree.ProcessNodes {
 		if len(node.Syscalls) > 0 {
@@ -1636,7 +1636,7 @@ func searchForSyscalls(ad *dump.ActivityDump) bool {
 	return false
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func searchForNetworkFlowMonitorEvents(ad *dump.ActivityDump) bool {
 	for _, node := range ad.Profile.ActivityTree.ProcessNodes {
 		if len(node.NetworkDevices) > 0 {
@@ -1646,7 +1646,7 @@ func searchForNetworkFlowMonitorEvents(ad *dump.ActivityDump) bool {
 	return false
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) getADFromDumpID(id *activityDumpIdentifier) (*dump.ActivityDump, error) {
 	var fileProtobuf string
 	// decode the dump
@@ -1666,7 +1666,7 @@ func (tm *testModule) getADFromDumpID(id *activityDumpIdentifier) (*dump.Activit
 	return ad, nil
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) findNumberOfExistingDirectoryFiles(id *activityDumpIdentifier, testDir string) (int, error) {
 	ad, err := tm.getADFromDumpID(id)
 	if err != nil {
@@ -1698,7 +1698,7 @@ firstLoop:
 	return total, nil
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) extractAllDumpEventTypes(id *activityDumpIdentifier) ([]string, error) {
 	var res []string
 

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -32,13 +32,13 @@ func getUpstreamEventSchema() string {
 
 var upstreamEventSchema = getUpstreamEventSchema()
 
-//nolint:deadcode,unused
+//nolint:unused
 func validateActivityDumpProtoSchema(t *testing.T, ad string) bool {
 	t.Helper()
 	return validateStringSchema(t, ad, "file:///activity_dump_proto.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func validateMessageSchema(t *testing.T, msg string) bool {
 	t.Helper()
 	if !validateStringSchema(t, msg, "file:///message.schema.json") {
@@ -47,7 +47,7 @@ func validateMessageSchema(t *testing.T, msg string) bool {
 	return validateURLSchema(t, msg, upstreamEventSchema)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateEventSchema(t *testing.T, event *model.Event, path string) bool {
 	t.Helper()
 
@@ -60,13 +60,13 @@ func (tm *testModule) validateEventSchema(t *testing.T, event *model.Event, path
 	return validateStringSchema(t, eventJSON, path)
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateExecSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///exec.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateExitSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -76,7 +76,7 @@ func (tm *testModule) validateExitSchema(t *testing.T, event *model.Event) bool 
 	return tm.validateEventSchema(t, event, "file:///exit.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateOpenSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -86,7 +86,7 @@ func (tm *testModule) validateOpenSchema(t *testing.T, event *model.Event) bool 
 	return tm.validateEventSchema(t, event, "file:///open.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateRenameSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -96,7 +96,7 @@ func (tm *testModule) validateRenameSchema(t *testing.T, event *model.Event) boo
 	return tm.validateEventSchema(t, event, "file:///rename.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateChmodSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -106,7 +106,7 @@ func (tm *testModule) validateChmodSchema(t *testing.T, event *model.Event) bool
 	return tm.validateEventSchema(t, event, "file:///chmod.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateChownSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -116,13 +116,13 @@ func (tm *testModule) validateChownSchema(t *testing.T, event *model.Event) bool
 	return tm.validateEventSchema(t, event, "file:///chown.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateSELinuxSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///selinux.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateLinkSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -132,7 +132,7 @@ func (tm *testModule) validateLinkSchema(t *testing.T, event *model.Event) bool 
 	return tm.validateEventSchema(t, event, "file:///link.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateSpanSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -142,37 +142,37 @@ func (tm *testModule) validateSpanSchema(t *testing.T, event *model.Event) bool 
 	return tm.validateEventSchema(t, event, "file:///span.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateUserSessionSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///user_session.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateBPFSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///bpf.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateMMapSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///mmap.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateMProtectSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///mprotect.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validatePTraceSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///ptrace.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateSetrlimitSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -182,7 +182,7 @@ func (tm *testModule) validateSetrlimitSchema(t *testing.T, event *model.Event) 
 	return tm.validateEventSchema(t, event, "file:///setrlimit.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateLoadModuleSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -192,7 +192,7 @@ func (tm *testModule) validateLoadModuleSchema(t *testing.T, event *model.Event)
 	return tm.validateEventSchema(t, event, "file:///load_module.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateLoadModuleNoFileSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -202,7 +202,7 @@ func (tm *testModule) validateLoadModuleNoFileSchema(t *testing.T, event *model.
 	return tm.validateEventSchema(t, event, "file:///load_module_no_file.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateUnloadModuleSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -212,37 +212,37 @@ func (tm *testModule) validateUnloadModuleSchema(t *testing.T, event *model.Even
 	return tm.validateEventSchema(t, event, "file:///unload_module.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateSignalSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///signal.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateSpliceSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///splice.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateDNSSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///dns.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateIMDSSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///imds.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateSysctlSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///sysctl.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateAcceptSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -252,7 +252,7 @@ func (tm *testModule) validateAcceptSchema(t *testing.T, event *model.Event) boo
 	return tm.validateEventSchema(t, event, "file:///accept.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateBindSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -262,7 +262,7 @@ func (tm *testModule) validateBindSchema(t *testing.T, event *model.Event) bool 
 	return tm.validateEventSchema(t, event, "file:///bind.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateConnectSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -272,7 +272,7 @@ func (tm *testModule) validateConnectSchema(t *testing.T, event *model.Event) bo
 	return tm.validateEventSchema(t, event, "file:///connect.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateSocketSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -282,7 +282,7 @@ func (tm *testModule) validateSocketSchema(t *testing.T, event *model.Event) boo
 	return tm.validateEventSchema(t, event, "file:///socket.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func (tm *testModule) validateMountSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true
@@ -292,7 +292,7 @@ func (tm *testModule) validateMountSchema(t *testing.T, event *model.Event) bool
 	return tm.validateEventSchema(t, event, "file:///mount.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func validateRuleSetLoadedSchema(t *testing.T, event *events.CustomEvent) bool {
 	t.Helper()
 
@@ -305,14 +305,14 @@ func validateRuleSetLoadedSchema(t *testing.T, event *events.CustomEvent) bool {
 	return validateStringSchema(t, string(eventJSON), "file:///ruleset_loaded.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func validateRawPacketActionSchema(t *testing.T, msg string) bool {
 	t.Helper()
 
 	return validateStringSchema(t, msg, "file:///rawpacket_action.schema.json")
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func validateHeartbeatSchema(t *testing.T, event *events.CustomEvent) bool {
 	t.Helper()
 
@@ -327,12 +327,12 @@ func validateHeartbeatSchema(t *testing.T, event *events.CustomEvent) bool {
 
 // ValidInodeFormatChecker defines the format inode checker
 //
-//nolint:deadcode,unused
+//nolint:unused
 type ValidInodeFormatChecker struct{}
 
 // IsFormat check inode format
 //
-//nolint:deadcode,unused
+//nolint:unused
 func (v ValidInodeFormatChecker) IsFormat(input interface{}) bool {
 
 	var inode uint64
@@ -374,7 +374,7 @@ func validateSchema(t *testing.T, schemaLoader gojsonschema.JSONLoader, document
 	return success, nil
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func validateStringSchema(t *testing.T, json string, path string) bool {
 	t.Helper()
 
@@ -398,7 +398,7 @@ func validateStringSchema(t *testing.T, json string, path string) bool {
 	return true
 }
 
-//nolint:deadcode,unused
+//nolint:unused
 func validateURLSchema(t *testing.T, json string, url string) bool {
 	t.Helper()
 

--- a/pkg/util/containers/metrics/provider/provider.go
+++ b/pkg/util/containers/metrics/provider/provider.go
@@ -52,7 +52,7 @@ var (
 	}
 
 	// AllLinuxRuntimes lists all runtimes available on Linux
-	// nolint: deadcode, unused
+	//nolint:unused
 	AllLinuxRuntimes = []Runtime{
 		RuntimeNameDocker,
 		RuntimeNameContainerd,
@@ -65,7 +65,7 @@ var (
 	}
 
 	// AllWindowsRuntimes lists all runtimes available on Windows
-	// nolint: deadcode, unused
+	//nolint:unused
 	AllWindowsRuntimes = []Runtime{
 		RuntimeNameDocker,
 		RuntimeNameContainerd,

--- a/test/e2e-framework/run/main.go
+++ b/test/e2e-framework/run/main.go
@@ -17,16 +17,16 @@ import (
 )
 
 const (
-	//nolint:unused,deadcode
+	//nolint:unused
 	scenarioEnvVarName = "PULUMI_SCENARIO"
-	//nolint:unused,deadcode
+	//nolint:unused
 	scenarioParamName = "scenario"
 
-	//nolint:unused,deadcode
+	//nolint:unused
 	dummyScenario = "dummy"
 )
 
-//nolint:unused,deadcode
+//nolint:unused
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		scenarioName := os.Getenv(scenarioEnvVarName)


### PR DESCRIPTION
### Motivation
`golangci-lint` v2 dropped the `deadcode` linter, which was folded into `unused` back in v1.49, and `.golangci.yml` here only enables `unused`.

Every `//nolint:deadcode` directive was therefore already a no-op, and `golangci-lint`'s `nolint_filter` now logs a warning for each one:
> Found unknown linters in //nolint directives: deadcode

That warning fires roughly [25,000 times a week in CI](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%22Found%20unknown%20linters%20in%20%2F%2Fnolint%20directives%22%20deadcode&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1783682014931&to_ts=1784286814931&live=true), drowning out more actionable output both in CI logs and during iterative local runs.

### Additional Notes
There are other no-op directives (`gosimple`, `lostcancel`, etc.) that will be removed at a later point.