### PR TITLE
Add agent-delivery team to release branch restrictions

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -16,6 +16,7 @@ branches:
   ^6\.[0-9]+\.x$:
     github_teams_restrictions:
       - agent-supply-chain
+      - agent-delivery
 ---
 schema-version: v1
 kind: buildimpactanalysis


### PR DESCRIPTION
### What does this PR do?

Explicitly adds the `agent-delivery` GitHub team to the release branch restrictions in `repository.datadog.yml`.

### Motivation

The `agent-delivery` team is no longer part of the `agent-supply-chain` group, so it needs to be explicitly listed under `github_teams_restrictions` for release branches to maintain the same access level as before.

### Describe how you validated your changes

### Additional Notes
