### PR TITLE
configfilesdiscovery: only probe EvP intake when enabled

### DIFF
--- a/comp/forwarder/eventplatform/impl/epforwarder.go
+++ b/comp/forwarder/eventplatform/impl/epforwarder.go
@@ -119,6 +119,9 @@ func Diagnose() []diagnose.Diagnosis {
 	cfg := pkgconfigsetup.Datadog()
 
 	for _, desc := range getPassthroughPipelines() {
+		if desc.eventType == eventplatform.EventTypeAgentDiscovery && !cfg.GetBool("config_files_discovery.enabled") {
+			continue
+		}
 		//nolint:misspell
 		// TODO(ECT-4273): event-management-intake does not support the empty payload sent here
 		if desc.eventType == eventplatform.EventTypeEventManagement {


### PR DESCRIPTION
### What does this PR do?

This gates the agent probing of the EvP config files discovery endpoint behind the config flag to enable config files discovery.

This solves an issue with the agent produce a lot of error logs due to the EvP forwarding sending connectivity check probes to the intake, and the intake not being ready behind the default URL yet, thus causing 404 errors.

### Motivation

Prevent error logs due to a disabled feature.

### Describe how you validated your changes

Manual testing

### Additional Notes
