### PR TITLE
Allowlist OpenMetrics metric-limit telemetry

### DIFF
--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -2393,6 +2393,31 @@ func TestAgentTelemetryParseDefaultConfiguration(t *testing.T) {
 	assert.True(t, len(atCfg.Profiles) > len(atCfg.events))
 }
 
+func TestDefaultProfilesIncludeUntaggedOpenMetricsLimitMetric(t *testing.T) {
+	cfg := configmock.NewFromYAML(t, defaultProfiles)
+	atCfg, err := parseConfig(cfg)
+	require.NoError(t, err)
+
+	var matchingMetrics []MetricConfig
+	var matchingProfiles []string
+	for _, profile := range atCfg.Profiles {
+		if profile.Metric == nil {
+			continue
+		}
+		for _, metric := range profile.Metric.Metrics {
+			if metric.Name == "openmetrics.max_returned_metrics_reached" {
+				matchingMetrics = append(matchingMetrics, metric)
+				matchingProfiles = append(matchingProfiles, profile.Name)
+			}
+		}
+	}
+
+	require.Len(t, matchingMetrics, 1)
+	assert.Equal(t, []string{"checks"}, matchingProfiles)
+	assert.Nil(t, matchingMetrics[0].PreserveTags)
+	assert.False(t, matchingMetrics[0].preserveTagsExists)
+}
+
 func TestAgentTelemetryEventConfiguration(t *testing.T) {
 	// Use nearly full
 	c := `

--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -2405,7 +2405,7 @@ func TestDefaultProfilesIncludeUntaggedOpenMetricsLimitMetric(t *testing.T) {
 			continue
 		}
 		for _, metric := range profile.Metric.Metrics {
-			if metric.Name == "openmetrics.max_returned_metrics_reached" {
+			if metric.Name == "checks.max_returned_metrics_reached" {
 				matchingMetrics = append(matchingMetrics, metric)
 				matchingProfiles = append(matchingProfiles, profile.Name)
 			}

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -19,6 +19,7 @@ profiles:
         preserve_tags:
           - check_name
           - state
+      - name: openmetrics.max_returned_metrics_reached
       - name: pymem.inuse
       - name: health_platform.issues_detected
         preserve_tags:

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -19,7 +19,7 @@ profiles:
         preserve_tags:
           - check_name
           - state
-      - name: openmetrics.max_returned_metrics_reached
+      - name: checks.max_returned_metrics_reached
       - name: pymem.inuse
       - name: health_platform.issues_detected
         preserve_tags:


### PR DESCRIPTION
### What does this PR do?

Adds the untagged `openmetrics.max_returned_metrics_reached` metric to the built-in `checks` Agent Telemetry profile.

The metric is produced through the existing Python Agent telemetry bridge, so this change adds no producer, callback, label transport, or warning parsing. It intentionally preserves no tags.

### Motivation

AI-7012 asks for a fleet-wide COAT signal when OpenMetrics reaches `max_returned_metrics` and silently drops subsequent metrics. Keeping this first version untagged provides the signal without introducing a new cross-language labeled telemetry API or additional cardinality.

### Describe how you validated your changes

- Ran the focused default-profile test.
- Ran the full `comp/core/agenttelemetry/impl` package tests.
- Ran focused Go lint.
- Parsed `defaultProfiles.yaml` explicitly and ran Git diff checks.

### Additional Notes

The metric intentionally has no `check_name` or other preserved tags. End-to-end COAT/RC validation remains a follow-up after both producer and profile changes are available in a build.
