### PR TITLE
test(serverless): attempt to de-flake TestStartServerlessTraceAgentFunctionTags

### DIFF
--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -10,6 +10,7 @@ package trace
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -158,6 +159,7 @@ func TestStartServerlessTraceAgentFunctionTags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("DD_RECEIVER_PORT", "0")
+			t.Setenv("DD_APM_RECEIVER_SOCKET", filepath.Join(t.TempDir(), "apm.sock"))
 			configmock.New(t)
 
 			agent := StartServerlessTraceAgent(StartServerlessTraceAgentArgs{

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -154,17 +155,26 @@ func TestStartServerlessTraceAgentFunctionTags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setupTraceAgentTest(t)
+			// Disable the trace agent's HTTP receiver (apm_config.receiver_port: 0).
+			// This test only checks that the TracerPayloadModifier is wired up, which
+			// does not depend on the receiver. Binding a real TCP port pulls in
+			// FindTCPPort's close-then-rebind race and the receiver's fatal
+			// killProcess-on-bind-failure path, which made this test flaky in CI.
+			t.Setenv("DD_RECEIVER_PORT", "0")
+			configmock.New(t)
 
 			agent := StartServerlessTraceAgent(StartServerlessTraceAgentArgs{
 				Enabled:      true,
 				LoadConfig:   &LoadConfig{Path: "./testdata/valid.yml"},
 				FunctionTags: tt.functionTags,
+				// Wait for the agent to fully stop before the next subtest starts, so
+				// its goroutines never leak into and race with the following case.
+				StopTimeout: 30 * time.Second,
 			})
 			defer agent.Stop()
 
 			assert.NotNil(t, agent)
-			assert.IsType(t, &serverlessTraceAgent{}, agent)
+			require.IsType(t, &serverlessTraceAgent{}, agent)
 
 			// Access the underlying agent to check TracerPayloadModifier
 			serverlessAgent := agent.(*serverlessTraceAgent)

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -139,6 +139,8 @@ func TestGetDDOriginCloudServices(t *testing.T) {
 }
 
 func TestStartServerlessTraceAgentFunctionTags(t *testing.T) {
+	const functionTagsPayloadTag = "_dd.tags.function"
+
 	tests := []struct {
 		name         string
 		functionTags string
@@ -155,11 +157,6 @@ func TestStartServerlessTraceAgentFunctionTags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Disable the trace agent's HTTP receiver (apm_config.receiver_port: 0).
-			// This test only checks that the TracerPayloadModifier is wired up, which
-			// does not depend on the receiver. Binding a real TCP port pulls in
-			// FindTCPPort's close-then-rebind race and the receiver's fatal
-			// killProcess-on-bind-failure path, which made this test flaky in CI.
 			t.Setenv("DD_RECEIVER_PORT", "0")
 			configmock.New(t)
 
@@ -178,7 +175,16 @@ func TestStartServerlessTraceAgentFunctionTags(t *testing.T) {
 
 			// Access the underlying agent to check TracerPayloadModifier
 			serverlessAgent := agent.(*serverlessTraceAgent)
-			assert.NotNil(t, serverlessAgent.ta.TracerPayloadModifier)
+			require.NotNil(t, serverlessAgent.ta.TracerPayloadModifier)
+
+			payload := &pb.TracerPayload{}
+			serverlessAgent.ta.TracerPayloadModifier.Modify(payload)
+			if tt.functionTags == "" {
+				assert.NotContains(t, payload.Tags, functionTagsPayloadTag)
+			} else {
+				require.NotNil(t, payload.Tags)
+				assert.Equal(t, tt.functionTags, payload.Tags[functionTagsPayloadTag])
+			}
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Updates `TestStartServerlessTraceAgentFunctionTags` to avoid starting the trace-agent HTTP receiver by setting `DD_RECEIVER_PORT=0`.

The test still starts the serverless trace agent, but now verifies the function-tag wiring by applying the configured `TracerPayloadModifier` to a payload:

- non-empty `FunctionTags` sets `_dd.tags.function`
- empty `FunctionTags` leaves `_dd.tags.function` absent

It also uses a longer `StopTimeout` so each subtest waits for the agent to stop before the next subtest starts.

### Motivation

This test has flaked in CI, and the failure appears consistent with a real receiver bind or shutdown race between subtests. I was not able to reproduce the failure locally, so this PR removes the suspected source of fragility rather than claiming a confirmed root cause.

### Validation

- `dda inv test --targets=./pkg/serverless/trace --extra-args='-run TestStartServerlessTraceAgentFunctionTags'`
