### PR TITLE
Autogenerate delegated auth from the schema

### DIFF
--- a/pkg/config/setup/BUILD.bazel
+++ b/pkg/config/setup/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "config_test_accessor.go",
         "config_windows.go",
         "fixup_init.go",
+        "generated.go",
         "ipc_address.go",
         "multi_region_failover_settings.go",
         "otlp.go",

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"net"
 	"os"
 	"runtime"
@@ -36,17 +35,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
-// registeredDelegatedAuthConfigs tracks which prefixes have been registered for delegated auth.
-// Maps config prefix to API key config key (e.g., "" -> "api_key", "logs_config" -> "logs_config.api_key").
-// Using a map ensures each prefix is only registered once.
-// Protected by registeredDelegatedAuthConfigsMu for thread-safe access during concurrent tests.
-var (
-	registeredDelegatedAuthConfigs   = make(map[string]string)
-	registeredDelegatedAuthConfigsMu sync.Mutex
-)
-
 const (
-
 	// DefaultSite is the default site the Agent sends data to.
 	DefaultSite = "datadoghq.com"
 
@@ -268,11 +257,6 @@ func InitConfigObjects() {
 // InitConfig initializes the config defaults on a config used by all agents
 // (in particular more than just the serverless agent).
 func InitConfig(config pkgconfigmodel.Setup) {
-	// Reset registeredDelegatedAuthConfigs to avoid state leaking between tests
-	registeredDelegatedAuthConfigsMu.Lock()
-	registeredDelegatedAuthConfigs = make(map[string]string)
-	registeredDelegatedAuthConfigsMu.Unlock()
-
 	// -------------------------------------------------------------
 	// NOTE: Do not add more BindEnvAndSetDefault calls to this file
 	// Add them to common_settings.go instead
@@ -678,34 +662,15 @@ func configureDelegatedAuth(ctx context.Context, config pkgconfigmodel.Config, d
 		}
 	}
 
-	// Copy the registered configs map while holding the lock to avoid races during iteration
-	registeredDelegatedAuthConfigsMu.Lock()
-	configsCopy := maps.Clone(registeredDelegatedAuthConfigs)
-	registeredDelegatedAuthConfigsMu.Unlock()
-
 	// Scan all registered prefixes to find which ones have delegated auth enabled
-	for prefix, apiKeyConfigKey := range configsCopy {
-		// Build the config key prefix for delegated_auth settings
-		var configPrefix string
-		if prefix == "" {
-			configPrefix = "delegated_auth"
-		} else {
-			configPrefix = prefix + ".delegated_auth"
-		}
-
+	for _, section := range delegatedAuthKeys {
 		// Check if org_uuid is set for this prefix
-		orgUUID := config.GetString(configPrefix + ".org_uuid")
+		orgUUID := config.GetString(section.delegatedAuthPath + ".org_uuid")
 		if orgUUID == "" {
 			continue
 		}
 
-		// Build description for logging
-		description := "global"
-		if prefix != "" {
-			description = prefix
-		}
-
-		log.Infof("Configuring delegated authentication for '%s'", description)
+		log.Infof("Configuring delegated authentication for '%s'", section.description)
 
 		// Call AddInstance - the component auto-initializes on the first call
 		// Config and ProviderConfig are only used on the first call
@@ -713,11 +678,11 @@ func configureDelegatedAuth(ctx context.Context, config pkgconfigmodel.Config, d
 			Config:          config,
 			ProviderConfig:  providerConfig,
 			OrgUUID:         orgUUID,
-			RefreshInterval: config.GetInt(configPrefix + ".refresh_interval_mins"),
-			APIKeyConfigKey: apiKeyConfigKey,
+			RefreshInterval: config.GetInt(section.delegatedAuthPath + ".refresh_interval_mins"),
+			APIKeyConfigKey: section.apiKeyPath,
 		})
 		if err != nil {
-			log.Errorf("Failed to configure delegated auth for '%s': %v", description, err)
+			log.Errorf("Failed to configure delegated auth for '%s': %v", section.description, err)
 		}
 	}
 
@@ -752,21 +717,6 @@ func bindDelegatedAuthConfig(config pkgconfigmodel.Setup, prefix string) {
 
 	// Provider-specific configuration (nested under provider name)
 	config.BindEnvAndSetDefault(configPrefix+".aws.region", "")
-
-	// Register this prefix for use in configureDelegatedAuth
-	// Build the API key config key
-	var apiKeyConfigKey string
-	if prefix == "" {
-		apiKeyConfigKey = "api_key"
-	} else {
-		apiKeyConfigKey = prefix + ".api_key"
-	}
-
-	// Map automatically handles duplicates - repeated registrations just overwrite with same value
-	// Use mutex to protect concurrent access during tests
-	registeredDelegatedAuthConfigsMu.Lock()
-	registeredDelegatedAuthConfigs[prefix] = apiKeyConfigKey
-	registeredDelegatedAuthConfigsMu.Unlock()
 }
 
 // LoadSystemProbe reads config files and initializes config with decrypted secrets for system-probe

--- a/pkg/config/setup/generated.go
+++ b/pkg/config/setup/generated.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package setup
+
+//
+// The following code is generated from the schema and should never be manually edited
+//
+
+type delegatedAuthConfig struct {
+	apiKeyPath        string
+	delegatedAuthPath string
+	description       string
+}
+
+// delegatedAuthKeys list all the "delegated_auth" configuration section.
+// This list is used to fully initialize authentication through cloud provider instead of API key
+var delegatedAuthKeys = []delegatedAuthConfig{
+
+	{
+		apiKeyPath:        "remote_configuration.api_key",
+		delegatedAuthPath: "remote_configuration.delegated_auth",
+		description:       "remote_configuration",
+	},
+
+	{
+		apiKeyPath:        "logs_config.api_key",
+		delegatedAuthPath: "logs_config.delegated_auth",
+		description:       "logs_config",
+	},
+
+	{
+		apiKeyPath:        "api_key",
+		delegatedAuthPath: "delegated_auth",
+		description:       "global",
+	},
+
+	{
+		apiKeyPath:        "evp_proxy_config.api_key",
+		delegatedAuthPath: "evp_proxy_config.delegated_auth",
+		description:       "evp_proxy_config",
+	},
+
+	{
+		apiKeyPath:        "ol_proxy_config.api_key",
+		delegatedAuthPath: "ol_proxy_config.delegated_auth",
+		description:       "ol_proxy_config",
+	},
+}

--- a/tasks/schema/codegen_init_settings.py
+++ b/tasks/schema/codegen_init_settings.py
@@ -1,5 +1,6 @@
 import os
 import re
+import subprocess
 
 file_header = """// Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
@@ -7,6 +8,11 @@ file_header = """// Unless explicitly stated otherwise all files in this reposit
 // Copyright 2016-present Datadog, Inc.
 
 package setup
+"""
+
+constant_header = """//
+// The following code is generated from the schema and should never be manually edited
+//
 """
 
 
@@ -554,6 +560,116 @@ config_setup_func_names = [
     'initCWSSystemProbeConfig',
     'initUSMSystemProbeConfig',
 ]
+
+
+def gen_delegated_auth_map(core_schema, system_probe_schema, core_out, system_probe_out):
+    """
+    Constant generator: appends the delegated auth map to the relevant buffers.
+
+    core_schema         - loaded core schema object
+    system_probe_schema - loaded system-probe schema object
+    core_out            - Go source lines for the core constant file
+    system_probe_out    - Go source lines for the system-probe constant file
+    """
+
+    def collect_delegated_auth_keys(schema):
+        keys = []
+
+        # Visitor for each setting
+        def visit(curr_path, node):
+            if node.get("node_type") == "setting":
+                return
+
+            for name, child in node["properties"].items():
+                if name == "delegated_auth":
+                    keys.append(curr_path)
+                else:
+                    path = curr_path + "." + name if curr_path else name
+                    visit(path, child)
+
+        visit("", schema)
+        return keys
+
+    def emit(out, keys):
+        out.append("""
+            type delegatedAuthConfig struct {
+              apiKeyPath        string
+              delegatedAuthPath string
+              description       string
+            }
+
+            // delegatedAuthKeys list all the \"delegated_auth\" configuration section.
+            // This list is used to fully initialize authentication through cloud provider instead of API key
+            var delegatedAuthKeys = []delegatedAuthConfig{""")
+
+        for key in keys:
+            parent_section_name = key.rsplit(".")[0]
+            parent_section = key.rsplit(".")[0]
+
+            if parent_section != "":
+                parent_section += "."
+            if parent_section_name == "":
+                parent_section_name = "global"
+
+            out.append(f"""
+                {{
+                  apiKeyPath: "{parent_section}api_key",
+                  delegatedAuthPath : "{parent_section}delegated_auth",
+                  description: "{parent_section_name}",
+                }},""")
+        out.append("}")
+        out.append("")
+
+    emit(core_out, collect_delegated_auth_keys(core_schema))
+
+
+# Ordered list of generator functions used to produce the constant files.
+# Each is called with (core_schema, system_probe_schema, core_out, system_probe_out)
+# and may append Go code to either output buffer.
+constant_generators = [
+    gen_delegated_auth_map,
+]
+
+
+def run_constant_codegen(core_schema, system_probe_schema, outsource_dir):
+    """
+    Generate the core and system-probe constant files by running each generator
+    in `constant_generators` in order. Each generator receives both schemas and
+    both output buffers, so it can append Go code to either file.
+
+    core_schema         - loaded core schema object
+    system_probe_schema - loaded system-probe schema object
+    outsource_dir       - the directory to output source code to
+    """
+    header = file_header.split('\n') + constant_header.split('\n')
+    core_out = list(header)
+    system_probe_out = list(header)
+
+    for generator in constant_generators:
+        generator(core_schema, system_probe_schema, core_out, system_probe_out)
+
+    for filename, sourcecode in (
+        ("generated.go", core_out),
+        # For now we don't have any content for system_probe.
+        # ("system_probe_generated.go", system_probe_out),
+    ):
+        print('Output %s' % filename)
+        out_filename = os.path.join(outsource_dir, filename)
+        with open(out_filename, "w") as f:
+            f.write(gofmt('\n'.join(sourcecode)))
+
+
+def gofmt(source):
+    """
+    Format Go source code with gofmt and return the result.
+    """
+    return subprocess.run(
+        ["gofmt"],
+        input=source,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
 
 
 def run_codegen(schema, filename_filter, hints, keep_orig_order, outsource_dir):

--- a/tasks/schema/generate.py
+++ b/tasks/schema/generate.py
@@ -14,7 +14,7 @@ from invoke.exceptions import Exit
 from tasks.libs.build.bazel import bazel
 from tasks.libs.common.color import color_message
 from tasks.schema.add_comments import add_comments
-from tasks.schema.codegen_init_settings import run_codegen
+from tasks.schema.codegen_init_settings import run_codegen, run_constant_codegen
 from tasks.schema.fixes import fix_schema
 from tasks.schema.merge_schema import resolve_schema
 from tasks.schema.produce_byproduct import produce_byproduct
@@ -278,6 +278,7 @@ def codegen(ctx, keep_orig_order=False, check=False, fix=False, keeptmp=False):
     tmpdir = tempfile.mkdtemp()
     run_codegen(core_schema, filter(False, "system_probe_settings.go"), hints, keep_orig_order, tmpdir)
     run_codegen(system_probe_schema, filter(True, "system_probe_settings.go"), hints, keep_orig_order, tmpdir)
+    run_constant_codegen(core_schema, system_probe_schema, tmpdir)
 
     display = not check and not fix
 
@@ -300,6 +301,7 @@ def codegen(ctx, keep_orig_order=False, check=False, fix=False, keeptmp=False):
     if fix:
         # Fix any differences by copying the codegen results into SETUP_INIT_DIR
         ctx.run(f"cp {tmpdir}/*_settings.go {SETUP_INIT_DIR}/")
+        ctx.run(f"cp {tmpdir}/*generated.go {SETUP_INIT_DIR}/")
 
     if not keeptmp and not display:
         shutil.rmtree(tmpdir)


### PR DESCRIPTION
### What does this PR do?

This commit add the ability to generate co code from the schema (struct, maps, ...). The first use case is to replace the delegated code in the config with one generated from the schema. For now, pkg/config/setup/generated.go is commited to the repo but will soon be deleted just when we generate it at compile time.

## How to QA

Setup delegated authentication just like before and validate that it still works.
