### PR TITLE
[incident-57868] Attempt to self-heal Bazel builds on suspected remote cache poisoning

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -302,7 +302,7 @@
         "recordedInputs": [
           "FILE:@@//.bazelversion 1b9487d55bea47fea50d226cc9c53bc548877ad2a318bac8fbc8b320f429e5c5",
           "FILE:@@//tools/bazel 690073a0ab1e62a71c0acbe7eb9312b9a5937951759be4c0f457d97fa7e992e4",
-          "FILE:@@//tools/bazel.bat 9ead9c74fdd6e8200f38c5b68b1f0caae77d6e15b0434fc42043ce87ae41ec7b",
+          "FILE:@@//tools/bazel.bat b5a76cd9c65b13a3c07141128197ea83f1b11e58f14c693998961e0c4e12de23",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
         ],
         "generatedRepoSpecs": {}

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -78,7 +78,16 @@ for %%i in ("!more_than_8dot3_chars!") do if "%%~nxi"=="%%~snxi" (
 set "args=%*"
 if defined args if defined extra_args call :insert_extra_args
 "%BAZEL_REAL%" !startup_options! !args!
-exit /b !errorlevel!
+set "bazel_exit=!errorlevel!"
+if !bazel_exit! equ 36 (
+  >&2 echo 🟠 #incident-57868: attempting self-healing by retrying with `--noremote_accept_cached`
+  set "extra_args=!extra_args! --noremote_accept_cached"
+  set "args=%*"
+  call :insert_extra_args
+  "%BAZEL_REAL%" !startup_options! !args!
+  set "bazel_exit=!errorlevel!"
+)
+exit /b !bazel_exit!
 
 :: "--startup cmd ..." -> "--startup cmd --config=ci ..."
 :insert_extra_args


### PR DESCRIPTION
### What does this PR do?
Retry `bazel` once, without accepting remote cache hits, whenever it exits 36 (`LOCAL_ENVIRONMENTAL_ERROR`).

### Motivation
`windows_msi_and_bosh_zip_x64-a7(-fips)`, `tests_windows-x64` and `generate_config_schema-windows` jobs [had been failing](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%22This%20version%20of%20%251%20is%20not%20compatible%20with%20the%20version%20of%20Windows%20you%27re%20running%22&agg_m=count&agg_m_source=base&agg_t=count&bits_chat_id=258c92f9-52d1-4825-96d7-218145a242c1&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1783717512107&to_ts=1784322312107&live=true) while executing a freshly-fetched `rtloader/install.exe`, with Windows error 216 (`CreateProcessW` machine-type mismatch) and Bazel exiting **36**.
[Example occurrence on July 18](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1871398365#L4269):
```
INFO: Running command line: C:/bob/execroot/_main/bazel-out/x64_windows-fastbuild/bin/rtloader/install.exe <args omitted>
FATAL: ExecuteProgram(C:\bob\execroot\_main\bazel-out\x64_windows-fastbuild\bin\rtloader\install.exe) failed: ERROR: src/main/native/windows/process.cc(192): CreateProcessW("C:\bob\execroot\_main\bazel-out\x64_windows-fastbuild\bin\rtloader\install.exe"  --destdir=C:/opt/datadog-agent): This version of %1 is not compatible with the version of Windows you're running. Check your computer's system information and then contact the software publisher.
 (error: 216)
```

[#incident-57868](https://dd.enterprise.slack.com/archives/C0BJY9ZT2SU) root-caused this to a truncated upload into the shared Buildbarn remote cache: some client's write of `install.exe` did not upload all bytes, leaving a corrupted (in the observed case, 1-byte) blob under an otherwise valid cache key:
- hosts with a warm local copy were unaffected,
- hosts with no local match downloaded the truncated blob and failed.

An earlier automated root-cause pass blamed a Go 1.26.5 toolchain producing Windows-version-incompatible binaries, but a mismatched timeline (no buildimage bump around the failure window) already made that unlikely, and `dumpbin` confirming the file is 1 byte (`LNK1107: invalid or corrupt file`) ruled it out.

@rdesgroppes then floated a disk-space-exhaustion theory, since this branch's tip lacked #53758's `C:\bob` bind-mount fix but @Ishirui falsified it: the same failures occurred on `main`, which already carries that fix.

tl;dr: `--noremote_accept_cached` only gates the read side, so **retrying with it skips the poisoned entry while still uploading the freshly computed, correct result**.

### Describe how you validated your changes
On a Windows VM:
- forced the retry branch and confirmed the reconstructed command places `--noremote_accept_cached` before the `--` separator,
- confirmed the normal (non-retry) path is unaffected,
- confirmed real `bazel` accepts the flag and forces a fresh local execution of the affected action instead of a cache hit.

### Additional Notes
This favors healing the shared remote cache over a purely local fix: it does not address a host that already downloaded the truncated blob into its own local disk-cache, since `--noremote_accept_cached` does not affect local disk-cache reads.

If -and only if- this resurfaces, we'll consider inserting 2 steps prior to the self-heal retry:
1. shutdown `bazel` to clear its in-memory state,
2. clear its local disk-cache.