### PR TITLE
Add a devcontainer with extra arguments for the security agent

### DIFF
--- a/.devcontainer/datadog/agent-security/devcontainer.json
+++ b/.devcontainer/datadog/agent-security/devcontainer.json
@@ -1,0 +1,50 @@
+{
+  "name": "Datadog Security Agent Development Container",
+  "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace:v124282699-89230a57",
+  "features": {
+      "registry.ddbuild.io/workspaces/features/claude-code:0.1.122114922": {},
+      "registry.ddbuild.io/workspaces/features/trajectory:0.1.121704661": {},
+      "registry.ddbuild.io/workspaces/features/codex:0.1.116595837": {},
+      "registry.ddbuild.io/workspaces/features/base:0.4.116964598": {},
+      "../default/features/datadog-agent": {}
+  },
+  "forwardPorts": [
+    22
+  ],
+  "containerUser": "root",
+  "remoteUser": "bits",
+  "waitFor": "postStartCommand",
+  "runArgs": [
+    "--pid=host",
+    "--cgroupns=host",
+    //"-v",
+    //"/etc/passwd:/etc/passwd",
+    //"-v",
+    //"/etc/group:/etc/group",
+    "-v",
+    "/:/host/root:ro",
+    "-v",
+    "/sys/kernel/debug:/sys/kernel/debug",
+    "-v",
+    "/etc/os-release:/etc/os-release"
+  ],
+  "securityOpt": [
+    "apparmor:unconfined"
+  ],
+  "capAdd": [
+    "SYS_ADMIN",
+    "SYS_RESOURCE",
+    "SYS_PTRACE",
+    "NET_ADMIN",
+    "NET_BROADCAST",
+    "NET_RAW",
+    "IPC_LOCK",
+    "CHOWN",
+    "KILL"
+  ],
+  "containerEnv": {
+    "HOST_ROOT": "/host/root",
+    "HOST_PROC": "/host/root/proc",
+    "HOST_SYS": "/host/root/sys"
+  }
+}


### PR DESCRIPTION
### What does this PR do?

To make system-probe work we need to execute it in a container with some additional capabilities and volumes. Add a separate devcontainer.json to handle this setup.

### Motivation

Setup required for the security agent team.

### Describe how you validated your changes

Created a test workspace with
```
workspaces create danielm-deleteme-test --repo datadog-agent --branch daniel.mercier/agent-security-devcontainer --devcontainer-config .devcontainer/datadog/agent-security/devcontainer.json
```

### Additional Notes
