### PR TITLE
[CWS] Host-wide activity dumps (host start/stop)

### DIFF
--- a/cmd/system-probe/subcommands/runtime/activity_dump.go
+++ b/cmd/system-probe/subcommands/runtime/activity_dump.go
@@ -58,6 +58,7 @@ func activityDumpCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	activityDumpCmd.AddCommand(listCommands(globalParams)...)
 	activityDumpCmd.AddCommand(stopCommands(globalParams)...)
 	activityDumpCmd.AddCommand(diffCommands(globalParams)...)
+	activityDumpCmd.AddCommand(hostCommands(globalParams)...)
 	return []*cobra.Command{activityDumpCmd}
 }
 
@@ -116,6 +117,122 @@ func stopCommands(globalParams *command.GlobalParams) []*cobra.Command {
 		"a cgroup ID can be used to filter the activity dump.",
 	)
 	return []*cobra.Command{activityDumpStopCmd}
+}
+
+func hostCommands(globalParams *command.GlobalParams) []*cobra.Command {
+	hostCmd := &cobra.Command{
+		Use:   "host",
+		Short: "host-wide activity dump commands",
+		Long: "start/stop a host-wide activity dump capture window. Requires the agent to be " +
+			"configured to trace every cgroup (activity_dump.trace_systemd_cgroups=true with a " +
+			"large traced_cgroups_count and a long dump_duration). Intended to be driven from a " +
+			"CI job's pre/post steps to capture the whole host for the duration of a job.",
+	}
+
+	hostCmd.AddCommand(hostStartCommands(globalParams)...)
+	hostCmd.AddCommand(hostStopCommands(globalParams)...)
+	return []*cobra.Command{hostCmd}
+}
+
+func hostStartCommands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &activityDumpCliParams{
+		GlobalParams: globalParams,
+	}
+
+	hostStartCmd := &cobra.Command{
+		Use:   "start",
+		Short: "(re)start the host-wide capture window",
+		Long: "resets the capture window of every cgroup the agent is tracing, discarding any " +
+			"activity recorded before this call. Call this at the start of a CI job so the " +
+			"capture lines up with the job rather than agent/VM boot.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fxutil.OneShot(hostStartActivityDump,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
+					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
+				core.Bundle(),
+			)
+		},
+	}
+
+	return []*cobra.Command{hostStartCmd}
+}
+
+func hostStopCommands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &activityDumpCliParams{
+		GlobalParams: globalParams,
+	}
+
+	hostStopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "stop the host-wide capture and persist every dump",
+		Long: "stops every active activity dump, persisting each one to the configured local " +
+			"storage. Call this at the end of a CI job, then collect the output directory.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fxutil.OneShot(hostStopActivityDump,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
+					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
+				core.Bundle(),
+			)
+		},
+	}
+
+	return []*cobra.Command{hostStopCmd}
+}
+
+func hostStartActivityDump(_ log.Component, _ config.Component, _ secrets.Component, _ *activityDumpCliParams) error {
+	client, err := secagent.NewRuntimeSecurityCmdClient()
+	if err != nil {
+		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
+	}
+	defer client.Close()
+
+	output, err := client.GenerateActivityDump(&api.ActivityDumpParams{
+		Host: true,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to send request to system-probe: %w", err)
+	}
+	if len(output.Error) > 0 {
+		return fmt.Errorf("host activity dump start request failed: %s", output.Error)
+	}
+
+	// the server reports the outcome (including how many cgroups were reset) in the metadata name
+	if md := output.GetMetadata(); md != nil && len(md.GetName()) > 0 {
+		fmt.Println(md.GetName())
+	} else {
+		fmt.Println("host-wide capture window started")
+	}
+	return nil
+}
+
+func hostStopActivityDump(_ log.Component, _ config.Component, _ secrets.Component, _ *activityDumpCliParams) error {
+	client, err := secagent.NewRuntimeSecurityCmdClient()
+	if err != nil {
+		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
+	}
+	defer client.Close()
+
+	output, err := client.StopActivityDump(&api.ActivityDumpStopParams{All: true})
+	if err != nil {
+		return fmt.Errorf("unable to send request to system-probe: %w", err)
+	}
+	if len(output.Error) > 0 {
+		return fmt.Errorf("host activity dump stop request failed: %s", output.Error)
+	}
+
+	if len(output.Dumps) > 0 {
+		fmt.Printf("host-wide capture stopped, %d dumps persisted:\n", len(output.Dumps))
+		for _, d := range output.Dumps {
+			printSecurityActivityDumpMessage("\t", d)
+		}
+	} else {
+		fmt.Println("host-wide capture stopped: no active dumps found")
+	}
+	return nil
 }
 
 func generateCommands(globalParams *command.GlobalParams) []*cobra.Command {
@@ -616,7 +733,11 @@ func stopActivityDump(_ log.Component, _ config.Component, _ secrets.Component, 
 	}
 	defer client.Close()
 
-	output, err := client.StopActivityDump(activityDumpArgs.name, activityDumpArgs.containerID, activityDumpArgs.cgroupID)
+	output, err := client.StopActivityDump(&api.ActivityDumpStopParams{
+		Name:        activityDumpArgs.name,
+		ContainerID: activityDumpArgs.containerID,
+		CGroupID:    activityDumpArgs.cgroupID,
+	})
 	if err != nil {
 		return fmt.Errorf("unable to send request to system-probe: %w", err)
 	}

--- a/cmd/system-probe/subcommands/runtime/activity_dump_test.go
+++ b/cmd/system-probe/subcommands/runtime/activity_dump_test.go
@@ -53,3 +53,19 @@ func TestDumpActivityDumpCommand(t *testing.T) {
 		generateActivityDump,
 		func() {})
 }
+
+func TestHostStartActivityDumpCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"runtime", "activity-dump", "host", "start"},
+		hostStartActivityDump,
+		func() {})
+}
+
+func TestHostStopActivityDumpCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"runtime", "activity-dump", "host", "stop"},
+		hostStopActivityDump,
+		func() {})
+}

--- a/pkg/config/setup/system_probe_settings.go
+++ b/pkg/config/setup/system_probe_settings.go
@@ -450,6 +450,7 @@ func initCWSSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.min_timeout", "10m")
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.max_dump_size", 1750)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_cgroups_count", 5)
+	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.host_dump.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_event_types", []string{"exec", "open", "dns", "imds"})
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_dump_timeout", 900) // deprecated in favor of dump_duration
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.dump_duration", "900s")

--- a/pkg/security/agent/client.go
+++ b/pkg/security/agent/client.go
@@ -47,7 +47,7 @@ type SecurityModuleCmdClientWrapper interface {
 	DumpProcessCache(withArgs bool, format string) (string, error)
 	GenerateActivityDump(request *api.ActivityDumpParams) (*api.ActivityDumpMessage, error)
 	ListActivityDumps() (*api.ActivityDumpListMessage, error)
-	StopActivityDump(name, container, cgroup string) (*api.ActivityDumpStopMessage, error)
+	StopActivityDump(request *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error)
 	GenerateEncoding(request *api.TranscodingRequestParams) (*api.TranscodingRequestMessage, error)
 	DumpNetworkNamespace(snapshotInterfaces bool) (*api.DumpNetworkNamespaceMessage, error)
 	GetConfig() (*api.SecurityConfigMessage, error)
@@ -92,12 +92,8 @@ func (c *RuntimeSecurityCmdClient) GenerateActivityDump(request *api.ActivityDum
 }
 
 // StopActivityDump stops an active dump if it exists
-func (c *RuntimeSecurityCmdClient) StopActivityDump(name, container, cgroup string) (*api.ActivityDumpStopMessage, error) {
-	return c.apiClient.StopActivityDump(context.Background(), &api.ActivityDumpStopParams{
-		Name:        name,
-		ContainerID: container,
-		CGroupID:    cgroup,
-	})
+func (c *RuntimeSecurityCmdClient) StopActivityDump(request *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
+	return c.apiClient.StopActivityDump(context.Background(), request)
 }
 
 // GenerateEncoding sends a transcoding request

--- a/pkg/security/agent/mocks/security_module_cmd_client_wrapper.go
+++ b/pkg/security/agent/mocks/security_module_cmd_client_wrapper.go
@@ -897,8 +897,8 @@ func (_c *SecurityModuleCmdClientWrapper_SaveSecurityProfile_Call) RunAndReturn(
 }
 
 // StopActivityDump provides a mock function for the type SecurityModuleCmdClientWrapper
-func (_mock *SecurityModuleCmdClientWrapper) StopActivityDump(name string, container string, cgroup string) (*api.ActivityDumpStopMessage, error) {
-	ret := _mock.Called(name, container, cgroup)
+func (_mock *SecurityModuleCmdClientWrapper) StopActivityDump(request *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
+	ret := _mock.Called(request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StopActivityDump")
@@ -906,18 +906,18 @@ func (_mock *SecurityModuleCmdClientWrapper) StopActivityDump(name string, conta
 
 	var r0 *api.ActivityDumpStopMessage
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) (*api.ActivityDumpStopMessage, error)); ok {
-		return returnFunc(name, container, cgroup)
+	if returnFunc, ok := ret.Get(0).(func(*api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error)); ok {
+		return returnFunc(request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) *api.ActivityDumpStopMessage); ok {
-		r0 = returnFunc(name, container, cgroup)
+	if returnFunc, ok := ret.Get(0).(func(*api.ActivityDumpStopParams) *api.ActivityDumpStopMessage); ok {
+		r0 = returnFunc(request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*api.ActivityDumpStopMessage)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
-		r1 = returnFunc(name, container, cgroup)
+	if returnFunc, ok := ret.Get(1).(func(*api.ActivityDumpStopParams) error); ok {
+		r1 = returnFunc(request)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -930,31 +930,19 @@ type SecurityModuleCmdClientWrapper_StopActivityDump_Call struct {
 }
 
 // StopActivityDump is a helper method to define mock.On call
-//   - name string
-//   - container string
-//   - cgroup string
-func (_e *SecurityModuleCmdClientWrapper_Expecter) StopActivityDump(name any, container any, cgroup any) *SecurityModuleCmdClientWrapper_StopActivityDump_Call {
-	return &SecurityModuleCmdClientWrapper_StopActivityDump_Call{Call: _e.mock.On("StopActivityDump", name, container, cgroup)}
+//   - request *api.ActivityDumpStopParams
+func (_e *SecurityModuleCmdClientWrapper_Expecter) StopActivityDump(request any) *SecurityModuleCmdClientWrapper_StopActivityDump_Call {
+	return &SecurityModuleCmdClientWrapper_StopActivityDump_Call{Call: _e.mock.On("StopActivityDump", request)}
 }
 
-func (_c *SecurityModuleCmdClientWrapper_StopActivityDump_Call) Run(run func(name string, container string, cgroup string)) *SecurityModuleCmdClientWrapper_StopActivityDump_Call {
+func (_c *SecurityModuleCmdClientWrapper_StopActivityDump_Call) Run(run func(request *api.ActivityDumpStopParams)) *SecurityModuleCmdClientWrapper_StopActivityDump_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 *api.ActivityDumpStopParams
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg0 = args[0].(*api.ActivityDumpStopParams)
 		}
 		run(
 			arg0,
-			arg1,
-			arg2,
 		)
 	})
 	return _c
@@ -965,7 +953,7 @@ func (_c *SecurityModuleCmdClientWrapper_StopActivityDump_Call) Return(activityD
 	return _c
 }
 
-func (_c *SecurityModuleCmdClientWrapper_StopActivityDump_Call) RunAndReturn(run func(name string, container string, cgroup string) (*api.ActivityDumpStopMessage, error)) *SecurityModuleCmdClientWrapper_StopActivityDump_Call {
+func (_c *SecurityModuleCmdClientWrapper_StopActivityDump_Call) RunAndReturn(run func(request *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error)) *SecurityModuleCmdClientWrapper_StopActivityDump_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -239,6 +239,10 @@ type RuntimeSecurityConfig struct {
 	ActivityDumpTracedCgroupsCount int
 	// ActivityDumpTraceSystemdCgroups defines if you want to trace systemd cgroups
 	ActivityDumpTraceSystemdCgroups bool
+	// ActivityDumpHostDumpEnabled enables the host-wide activity dump start/stop commands. When enabled, the
+	// `activity-dump host start`/`host stop` CLI can capture every traced cgroup at once and persist the dumps
+	// to local storage only (never to the remote backend). Intended for local/CI use and off by default.
+	ActivityDumpHostDumpEnabled bool
 
 	// ActivityDumpTracedEventTypes defines the list of events that should be captured in an activity dump. Leave this
 	// parameter empty to monitor all event types. If not already present, the `exec` event will automatically be added
@@ -576,6 +580,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		// activity dump
 		ActivityDumpEnabled:                   pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.activity_dump.enabled"),
 		ActivityDumpTraceSystemdCgroups:       pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.activity_dump.trace_systemd_cgroups"),
+		ActivityDumpHostDumpEnabled:           pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.activity_dump.host_dump.enabled"),
 		ActivityDumpCleanupPeriod:             pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.cleanup_period"),
 		ActivityDumpTagsResolutionPeriod:      pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.tags_resolution_period"),
 		ActivityDumpLoadControlPeriod:         pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.load_controller_period"),
@@ -836,6 +841,25 @@ func (c *RuntimeSecurityConfig) sanitizeRuntimeSecurityConfigActivityDump() erro
 
 	if c.ActivityDumpTracedCgroupsCount > model.MaxTracedCgroupsCount {
 		c.ActivityDumpTracedCgroupsCount = model.MaxTracedCgroupsCount
+	}
+
+	// Host-wide activity dumps require tracing every cgroup on the host, so pull the
+	// prerequisites up (upward-only, never lowering an operator's explicit choice) when
+	// host_dump is enabled. Without this the host_dump start/stop commands succeed but
+	// silently capture almost nothing. Changes are logged so the coupling is visible.
+	if c.ActivityDumpHostDumpEnabled {
+		if !c.ActivityDumpEnabled {
+			seclog.Infof("activity_dump.host_dump.enabled=true: enabling activity_dump.enabled")
+			c.ActivityDumpEnabled = true
+		}
+		if !c.ActivityDumpTraceSystemdCgroups {
+			seclog.Infof("activity_dump.host_dump.enabled=true: enabling activity_dump.trace_systemd_cgroups to capture host (systemd) cgroups")
+			c.ActivityDumpTraceSystemdCgroups = true
+		}
+		if c.ActivityDumpTracedCgroupsCount < model.MaxTracedCgroupsCount {
+			seclog.Infof("activity_dump.host_dump.enabled=true: raising activity_dump.traced_cgroups_count from %d to %d", c.ActivityDumpTracedCgroupsCount, model.MaxTracedCgroupsCount)
+			c.ActivityDumpTracedCgroupsCount = model.MaxTracedCgroupsCount
+		}
 	}
 
 	if c.SecurityProfileEnabled && c.ActivityDumpEnabled && c.ActivityDumpLocalStorageDirectory != c.SecurityProfileDir {

--- a/pkg/security/config/config_test.go
+++ b/pkg/security/config/config_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package config holds config related files
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+func TestHostDumpPullsUpPrerequisites(t *testing.T) {
+	// host_dump on with the prerequisites off: they should be pulled up
+	c := &RuntimeSecurityConfig{
+		ActivityDumpHostDumpEnabled:     true,
+		ActivityDumpEnabled:             false,
+		ActivityDumpTraceSystemdCgroups: false,
+		ActivityDumpTracedCgroupsCount:  5,
+		SecurityProfileEnabled:          false,
+	}
+
+	assert.NoError(t, c.sanitizeRuntimeSecurityConfigActivityDump())
+	assert.True(t, c.ActivityDumpEnabled, "activity dumps should be force-enabled")
+	assert.True(t, c.ActivityDumpTraceSystemdCgroups, "systemd cgroup tracing should be force-enabled")
+	assert.Equal(t, model.MaxTracedCgroupsCount, c.ActivityDumpTracedCgroupsCount, "traced cgroups count should be raised to the max")
+}
+
+func TestHostDumpNeverLowersOperatorValues(t *testing.T) {
+	// operator already set a high count: upward-only means it is left untouched
+	c := &RuntimeSecurityConfig{
+		ActivityDumpHostDumpEnabled:     true,
+		ActivityDumpEnabled:             true,
+		ActivityDumpTraceSystemdCgroups: true,
+		ActivityDumpTracedCgroupsCount:  model.MaxTracedCgroupsCount,
+		SecurityProfileEnabled:          false,
+	}
+
+	assert.NoError(t, c.sanitizeRuntimeSecurityConfigActivityDump())
+	assert.Equal(t, model.MaxTracedCgroupsCount, c.ActivityDumpTracedCgroupsCount)
+}
+
+func TestHostDumpDisabledIsNoop(t *testing.T) {
+	// host_dump off: the prerequisites must not be touched
+	c := &RuntimeSecurityConfig{
+		ActivityDumpHostDumpEnabled:     false,
+		ActivityDumpEnabled:             false,
+		ActivityDumpTraceSystemdCgroups: false,
+		ActivityDumpTracedCgroupsCount:  5,
+		SecurityProfileEnabled:          false,
+	}
+
+	assert.NoError(t, c.sanitizeRuntimeSecurityConfigActivityDump())
+	assert.False(t, c.ActivityDumpTraceSystemdCgroups)
+	assert.Equal(t, 5, c.ActivityDumpTracedCgroupsCount)
+}

--- a/pkg/security/proto/api/api.pb.go
+++ b/pkg/security/proto/api/api.pb.go
@@ -1919,6 +1919,7 @@ type ActivityDumpParams struct {
 	Storage           *StorageRequestParams  `protobuf:"bytes,3,opt,name=Storage,proto3" json:"Storage,omitempty"`
 	ContainerID       string                 `protobuf:"bytes,4,opt,name=ContainerID,proto3" json:"ContainerID,omitempty"`
 	CGroupID          string                 `protobuf:"bytes,5,opt,name=CGroupID,proto3" json:"CGroupID,omitempty"`
+	Host              bool                   `protobuf:"varint,6,opt,name=Host,proto3" json:"Host,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -1986,6 +1987,13 @@ func (x *ActivityDumpParams) GetCGroupID() string {
 		return x.CGroupID
 	}
 	return ""
+}
+
+func (x *ActivityDumpParams) GetHost() bool {
+	if x != nil {
+		return x.Host
+	}
+	return false
 }
 
 type MetadataMessage struct {
@@ -2425,6 +2433,7 @@ type ActivityDumpStopParams struct {
 	Name          string                 `protobuf:"bytes,1,opt,name=Name,proto3" json:"Name,omitempty"`
 	ContainerID   string                 `protobuf:"bytes,2,opt,name=ContainerID,proto3" json:"ContainerID,omitempty"`
 	CGroupID      string                 `protobuf:"bytes,3,opt,name=CGroupID,proto3" json:"CGroupID,omitempty"`
+	All           bool                   `protobuf:"varint,4,opt,name=All,proto3" json:"All,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2480,9 +2489,17 @@ func (x *ActivityDumpStopParams) GetCGroupID() string {
 	return ""
 }
 
+func (x *ActivityDumpStopParams) GetAll() bool {
+	if x != nil {
+		return x.All
+	}
+	return false
+}
+
 type ActivityDumpStopMessage struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Error         string                 `protobuf:"bytes,1,opt,name=Error,proto3" json:"Error,omitempty"`
+	Dumps         []*ActivityDumpMessage `protobuf:"bytes,2,rep,name=Dumps,proto3" json:"Dumps,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2522,6 +2539,13 @@ func (x *ActivityDumpStopMessage) GetError() string {
 		return x.Error
 	}
 	return ""
+}
+
+func (x *ActivityDumpStopMessage) GetDumps() []*ActivityDumpMessage {
+	if x != nil {
+		return x.Dumps
+	}
+	return nil
 }
 
 type TranscodingRequestParams struct {
@@ -3559,13 +3583,14 @@ const file_pkg_security_proto_api_api_proto_rawDesc = "" +
 	"\x13LocalStorageFormats\x18\x02 \x03(\tR\x13LocalStorageFormats\x128\n" +
 	"\x17LocalStorageCompression\x18\x03 \x01(\bR\x17LocalStorageCompression\x122\n" +
 	"\x14RemoteStorageFormats\x18\x04 \x03(\tR\x14RemoteStorageFormats\x12:\n" +
-	"\x18RemoteStorageCompression\x18\x05 \x01(\bR\x18RemoteStorageCompression\"\xcf\x01\n" +
+	"\x18RemoteStorageCompression\x18\x05 \x01(\bR\x18RemoteStorageCompression\"\xe3\x01\n" +
 	"\x12ActivityDumpParams\x12\x18\n" +
 	"\aTimeout\x18\x01 \x01(\tR\aTimeout\x12,\n" +
 	"\x11DifferentiateArgs\x18\x02 \x01(\bR\x11DifferentiateArgs\x123\n" +
 	"\aStorage\x18\x03 \x01(\v2\x19.api.StorageRequestParamsR\aStorage\x12 \n" +
 	"\vContainerID\x18\x04 \x01(\tR\vContainerID\x12\x1a\n" +
-	"\bCGroupID\x18\x05 \x01(\tR\bCGroupID\"\x95\x04\n" +
+	"\bCGroupID\x18\x05 \x01(\tR\bCGroupID\x12\x12\n" +
+	"\x04Host\x18\x06 \x01(\bR\x04Host\"\x95\x04\n" +
 	"\x0fMetadataMessage\x12\"\n" +
 	"\fAgentVersion\x18\x01 \x01(\tR\fAgentVersion\x12 \n" +
 	"\vAgentCommit\x18\x02 \x01(\tR\vAgentCommit\x12$\n" +
@@ -3602,13 +3627,15 @@ const file_pkg_security_proto_api_api_proto_rawDesc = "" +
 	"\x16ActivityDumpListParams\"_\n" +
 	"\x17ActivityDumpListMessage\x12.\n" +
 	"\x05Dumps\x18\x01 \x03(\v2\x18.api.ActivityDumpMessageR\x05Dumps\x12\x14\n" +
-	"\x05Error\x18\x02 \x01(\tR\x05Error\"j\n" +
+	"\x05Error\x18\x02 \x01(\tR\x05Error\"|\n" +
 	"\x16ActivityDumpStopParams\x12\x12\n" +
 	"\x04Name\x18\x01 \x01(\tR\x04Name\x12 \n" +
 	"\vContainerID\x18\x02 \x01(\tR\vContainerID\x12\x1a\n" +
-	"\bCGroupID\x18\x03 \x01(\tR\bCGroupID\"/\n" +
+	"\bCGroupID\x18\x03 \x01(\tR\bCGroupID\x12\x10\n" +
+	"\x03All\x18\x04 \x01(\bR\x03All\"_\n" +
 	"\x17ActivityDumpStopMessage\x12\x14\n" +
-	"\x05Error\x18\x01 \x01(\tR\x05Error\"{\n" +
+	"\x05Error\x18\x01 \x01(\tR\x05Error\x12.\n" +
+	"\x05Dumps\x18\x02 \x03(\v2\x18.api.ActivityDumpMessageR\x05Dumps\"{\n" +
 	"\x18TranscodingRequestParams\x12*\n" +
 	"\x10ActivityDumpFile\x18\x01 \x01(\tR\x10ActivityDumpFile\x123\n" +
 	"\aStorage\x18\x02 \x01(\v2\x19.api.StorageRequestParamsR\aStorage\"g\n" +
@@ -3809,65 +3836,66 @@ var file_pkg_security_proto_api_api_proto_depIdxs = []int32{
 	37, // 20: api.ActivityDumpMessage.Metadata:type_name -> api.MetadataMessage
 	50, // 21: api.ActivityDumpMessage.Stats:type_name -> api.ActivityTreeStatsMessage
 	39, // 22: api.ActivityDumpListMessage.Dumps:type_name -> api.ActivityDumpMessage
-	35, // 23: api.TranscodingRequestParams.Storage:type_name -> api.StorageRequestParams
-	38, // 24: api.TranscodingRequestMessage.Storage:type_name -> api.StorageRequestMessage
-	47, // 25: api.ActivityDumpStreamMessage.Selector:type_name -> api.WorkloadSelectorMessage
-	60, // 26: api.ProfileContextMessage.event_type_state:type_name -> api.ProfileContextMessage.EventTypeStateEntry
-	47, // 27: api.SecurityProfileMessage.Selector:type_name -> api.WorkloadSelectorMessage
-	48, // 28: api.SecurityProfileMessage.LastAnomalies:type_name -> api.LastAnomalyTimestampMessage
-	49, // 29: api.SecurityProfileMessage.Instances:type_name -> api.InstanceMessage
-	37, // 30: api.SecurityProfileMessage.Metadata:type_name -> api.MetadataMessage
-	50, // 31: api.SecurityProfileMessage.Stats:type_name -> api.ActivityTreeStatsMessage
-	61, // 32: api.SecurityProfileMessage.profile_contexts:type_name -> api.SecurityProfileMessage.ProfileContextsEntry
-	53, // 33: api.SecurityProfileListMessage.Profiles:type_name -> api.SecurityProfileMessage
-	47, // 34: api.SecurityProfileSaveParams.Selector:type_name -> api.WorkloadSelectorMessage
-	27, // 35: api.ScopedVariableStore.KeyValuesEntry.value:type_name -> api.SECLVariableStateList
-	28, // 36: api.Status.ScopedVariablesEntry.value:type_name -> api.ScopedVariableStore
-	51, // 37: api.ProfileContextMessage.EventTypeStateEntry.value:type_name -> api.event_type_state
-	52, // 38: api.SecurityProfileMessage.ProfileContextsEntry.value:type_name -> api.ProfileContextMessage
-	63, // 39: api.SecurityModuleEvent.GetEventStream:input_type -> google.protobuf.Empty
-	63, // 40: api.SecurityModuleEvent.GetActivityDumpStream:input_type -> google.protobuf.Empty
-	1,  // 41: api.SecurityModuleCmd.DumpProcessCache:input_type -> api.DumpProcessCacheParams
-	5,  // 42: api.SecurityModuleCmd.GetConfig:input_type -> api.GetConfigParams
-	21, // 43: api.SecurityModuleCmd.GetStatus:input_type -> api.GetStatusParams
-	19, // 44: api.SecurityModuleCmd.RunSelfTest:input_type -> api.RunSelfTestParams
-	13, // 45: api.SecurityModuleCmd.GetRuleSetReport:input_type -> api.GetRuleSetReportParams
-	15, // 46: api.SecurityModuleCmd.ReloadPolicies:input_type -> api.ReloadPoliciesParams
-	17, // 47: api.SecurityModuleCmd.GetLoadedPolicies:input_type -> api.GetLoadedPoliciesParams
-	3,  // 48: api.SecurityModuleCmd.DumpNetworkNamespace:input_type -> api.DumpNetworkNamespaceParams
-	33, // 49: api.SecurityModuleCmd.DumpDiscarders:input_type -> api.DumpDiscardersParams
-	36, // 50: api.SecurityModuleCmd.DumpActivity:input_type -> api.ActivityDumpParams
-	40, // 51: api.SecurityModuleCmd.ListActivityDumps:input_type -> api.ActivityDumpListParams
-	42, // 52: api.SecurityModuleCmd.StopActivityDump:input_type -> api.ActivityDumpStopParams
-	44, // 53: api.SecurityModuleCmd.TranscodingRequest:input_type -> api.TranscodingRequestParams
-	54, // 54: api.SecurityModuleCmd.ListSecurityProfiles:input_type -> api.SecurityProfileListParams
-	56, // 55: api.SecurityModuleCmd.SaveSecurityProfile:input_type -> api.SecurityProfileSaveParams
-	0,  // 56: api.SecurityAgentAPI.SendEvent:input_type -> api.SecurityEventMessage
-	46, // 57: api.SecurityAgentAPI.SendActivityDumpStream:input_type -> api.ActivityDumpStreamMessage
-	0,  // 58: api.SecurityModuleEvent.GetEventStream:output_type -> api.SecurityEventMessage
-	46, // 59: api.SecurityModuleEvent.GetActivityDumpStream:output_type -> api.ActivityDumpStreamMessage
-	2,  // 60: api.SecurityModuleCmd.DumpProcessCache:output_type -> api.SecurityDumpProcessCacheMessage
-	6,  // 61: api.SecurityModuleCmd.GetConfig:output_type -> api.SecurityConfigMessage
-	29, // 62: api.SecurityModuleCmd.GetStatus:output_type -> api.Status
-	20, // 63: api.SecurityModuleCmd.RunSelfTest:output_type -> api.SecuritySelfTestResultMessage
-	14, // 64: api.SecurityModuleCmd.GetRuleSetReport:output_type -> api.GetRuleSetReportMessage
-	16, // 65: api.SecurityModuleCmd.ReloadPolicies:output_type -> api.ReloadPoliciesResultMessage
-	18, // 66: api.SecurityModuleCmd.GetLoadedPolicies:output_type -> api.GetLoadedPoliciesMessage
-	4,  // 67: api.SecurityModuleCmd.DumpNetworkNamespace:output_type -> api.DumpNetworkNamespaceMessage
-	34, // 68: api.SecurityModuleCmd.DumpDiscarders:output_type -> api.DumpDiscardersMessage
-	39, // 69: api.SecurityModuleCmd.DumpActivity:output_type -> api.ActivityDumpMessage
-	41, // 70: api.SecurityModuleCmd.ListActivityDumps:output_type -> api.ActivityDumpListMessage
-	43, // 71: api.SecurityModuleCmd.StopActivityDump:output_type -> api.ActivityDumpStopMessage
-	45, // 72: api.SecurityModuleCmd.TranscodingRequest:output_type -> api.TranscodingRequestMessage
-	55, // 73: api.SecurityModuleCmd.ListSecurityProfiles:output_type -> api.SecurityProfileListMessage
-	57, // 74: api.SecurityModuleCmd.SaveSecurityProfile:output_type -> api.SecurityProfileSaveMessage
-	63, // 75: api.SecurityAgentAPI.SendEvent:output_type -> google.protobuf.Empty
-	63, // 76: api.SecurityAgentAPI.SendActivityDumpStream:output_type -> google.protobuf.Empty
-	58, // [58:77] is the sub-list for method output_type
-	39, // [39:58] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	39, // 23: api.ActivityDumpStopMessage.Dumps:type_name -> api.ActivityDumpMessage
+	35, // 24: api.TranscodingRequestParams.Storage:type_name -> api.StorageRequestParams
+	38, // 25: api.TranscodingRequestMessage.Storage:type_name -> api.StorageRequestMessage
+	47, // 26: api.ActivityDumpStreamMessage.Selector:type_name -> api.WorkloadSelectorMessage
+	60, // 27: api.ProfileContextMessage.event_type_state:type_name -> api.ProfileContextMessage.EventTypeStateEntry
+	47, // 28: api.SecurityProfileMessage.Selector:type_name -> api.WorkloadSelectorMessage
+	48, // 29: api.SecurityProfileMessage.LastAnomalies:type_name -> api.LastAnomalyTimestampMessage
+	49, // 30: api.SecurityProfileMessage.Instances:type_name -> api.InstanceMessage
+	37, // 31: api.SecurityProfileMessage.Metadata:type_name -> api.MetadataMessage
+	50, // 32: api.SecurityProfileMessage.Stats:type_name -> api.ActivityTreeStatsMessage
+	61, // 33: api.SecurityProfileMessage.profile_contexts:type_name -> api.SecurityProfileMessage.ProfileContextsEntry
+	53, // 34: api.SecurityProfileListMessage.Profiles:type_name -> api.SecurityProfileMessage
+	47, // 35: api.SecurityProfileSaveParams.Selector:type_name -> api.WorkloadSelectorMessage
+	27, // 36: api.ScopedVariableStore.KeyValuesEntry.value:type_name -> api.SECLVariableStateList
+	28, // 37: api.Status.ScopedVariablesEntry.value:type_name -> api.ScopedVariableStore
+	51, // 38: api.ProfileContextMessage.EventTypeStateEntry.value:type_name -> api.event_type_state
+	52, // 39: api.SecurityProfileMessage.ProfileContextsEntry.value:type_name -> api.ProfileContextMessage
+	63, // 40: api.SecurityModuleEvent.GetEventStream:input_type -> google.protobuf.Empty
+	63, // 41: api.SecurityModuleEvent.GetActivityDumpStream:input_type -> google.protobuf.Empty
+	1,  // 42: api.SecurityModuleCmd.DumpProcessCache:input_type -> api.DumpProcessCacheParams
+	5,  // 43: api.SecurityModuleCmd.GetConfig:input_type -> api.GetConfigParams
+	21, // 44: api.SecurityModuleCmd.GetStatus:input_type -> api.GetStatusParams
+	19, // 45: api.SecurityModuleCmd.RunSelfTest:input_type -> api.RunSelfTestParams
+	13, // 46: api.SecurityModuleCmd.GetRuleSetReport:input_type -> api.GetRuleSetReportParams
+	15, // 47: api.SecurityModuleCmd.ReloadPolicies:input_type -> api.ReloadPoliciesParams
+	17, // 48: api.SecurityModuleCmd.GetLoadedPolicies:input_type -> api.GetLoadedPoliciesParams
+	3,  // 49: api.SecurityModuleCmd.DumpNetworkNamespace:input_type -> api.DumpNetworkNamespaceParams
+	33, // 50: api.SecurityModuleCmd.DumpDiscarders:input_type -> api.DumpDiscardersParams
+	36, // 51: api.SecurityModuleCmd.DumpActivity:input_type -> api.ActivityDumpParams
+	40, // 52: api.SecurityModuleCmd.ListActivityDumps:input_type -> api.ActivityDumpListParams
+	42, // 53: api.SecurityModuleCmd.StopActivityDump:input_type -> api.ActivityDumpStopParams
+	44, // 54: api.SecurityModuleCmd.TranscodingRequest:input_type -> api.TranscodingRequestParams
+	54, // 55: api.SecurityModuleCmd.ListSecurityProfiles:input_type -> api.SecurityProfileListParams
+	56, // 56: api.SecurityModuleCmd.SaveSecurityProfile:input_type -> api.SecurityProfileSaveParams
+	0,  // 57: api.SecurityAgentAPI.SendEvent:input_type -> api.SecurityEventMessage
+	46, // 58: api.SecurityAgentAPI.SendActivityDumpStream:input_type -> api.ActivityDumpStreamMessage
+	0,  // 59: api.SecurityModuleEvent.GetEventStream:output_type -> api.SecurityEventMessage
+	46, // 60: api.SecurityModuleEvent.GetActivityDumpStream:output_type -> api.ActivityDumpStreamMessage
+	2,  // 61: api.SecurityModuleCmd.DumpProcessCache:output_type -> api.SecurityDumpProcessCacheMessage
+	6,  // 62: api.SecurityModuleCmd.GetConfig:output_type -> api.SecurityConfigMessage
+	29, // 63: api.SecurityModuleCmd.GetStatus:output_type -> api.Status
+	20, // 64: api.SecurityModuleCmd.RunSelfTest:output_type -> api.SecuritySelfTestResultMessage
+	14, // 65: api.SecurityModuleCmd.GetRuleSetReport:output_type -> api.GetRuleSetReportMessage
+	16, // 66: api.SecurityModuleCmd.ReloadPolicies:output_type -> api.ReloadPoliciesResultMessage
+	18, // 67: api.SecurityModuleCmd.GetLoadedPolicies:output_type -> api.GetLoadedPoliciesMessage
+	4,  // 68: api.SecurityModuleCmd.DumpNetworkNamespace:output_type -> api.DumpNetworkNamespaceMessage
+	34, // 69: api.SecurityModuleCmd.DumpDiscarders:output_type -> api.DumpDiscardersMessage
+	39, // 70: api.SecurityModuleCmd.DumpActivity:output_type -> api.ActivityDumpMessage
+	41, // 71: api.SecurityModuleCmd.ListActivityDumps:output_type -> api.ActivityDumpListMessage
+	43, // 72: api.SecurityModuleCmd.StopActivityDump:output_type -> api.ActivityDumpStopMessage
+	45, // 73: api.SecurityModuleCmd.TranscodingRequest:output_type -> api.TranscodingRequestMessage
+	55, // 74: api.SecurityModuleCmd.ListSecurityProfiles:output_type -> api.SecurityProfileListMessage
+	57, // 75: api.SecurityModuleCmd.SaveSecurityProfile:output_type -> api.SecurityProfileSaveMessage
+	63, // 76: api.SecurityAgentAPI.SendEvent:output_type -> google.protobuf.Empty
+	63, // 77: api.SecurityAgentAPI.SendActivityDumpStream:output_type -> google.protobuf.Empty
+	59, // [59:78] is the sub-list for method output_type
+	40, // [40:59] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_pkg_security_proto_api_api_proto_init() }

--- a/pkg/security/proto/api/api.proto
+++ b/pkg/security/proto/api/api.proto
@@ -191,6 +191,7 @@ message ActivityDumpParams {
     StorageRequestParams Storage = 3;
     string ContainerID = 4;
     string CGroupID = 5;
+    bool Host = 6;
 }
 
 message MetadataMessage {
@@ -243,10 +244,12 @@ message ActivityDumpStopParams {
     string Name = 1;
     string ContainerID = 2;
     string CGroupID = 3;
+    bool All = 4;
 }
 
 message ActivityDumpStopMessage {
     string Error = 1;
+    repeated ActivityDumpMessage Dumps = 2;
 }
 
 message TranscodingRequestParams {

--- a/pkg/security/proto/api/api_vtproto.pb.go
+++ b/pkg/security/proto/api/api_vtproto.pb.go
@@ -1895,6 +1895,16 @@ func (m *ActivityDumpParams) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Host {
+		i--
+		if m.Host {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x30
+	}
 	if len(m.CGroupID) > 0 {
 		i -= len(m.CGroupID)
 		copy(dAtA[i:], m.CGroupID)
@@ -2377,6 +2387,16 @@ func (m *ActivityDumpStopParams) MarshalToSizedBufferVT(dAtA []byte) (int, error
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.All {
+		i--
+		if m.All {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
 	if len(m.CGroupID) > 0 {
 		i -= len(m.CGroupID)
 		copy(dAtA[i:], m.CGroupID)
@@ -2430,6 +2450,18 @@ func (m *ActivityDumpStopMessage) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Dumps) > 0 {
+		for iNdEx := len(m.Dumps) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Dumps[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+		}
 	}
 	if len(m.Error) > 0 {
 		i -= len(m.Error)
@@ -4028,6 +4060,9 @@ func (m *ActivityDumpParams) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.Host {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -4229,6 +4264,9 @@ func (m *ActivityDumpStopParams) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.All {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -4242,6 +4280,12 @@ func (m *ActivityDumpStopMessage) SizeVT() (n int) {
 	l = len(m.Error)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Dumps) > 0 {
+		for _, e := range m.Dumps {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -9051,6 +9095,26 @@ func (m *ActivityDumpParams) UnmarshalVT(dAtA []byte) error {
 			}
 			m.CGroupID = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Host", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Host = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10420,6 +10484,26 @@ func (m *ActivityDumpStopParams) UnmarshalVT(dAtA []byte) error {
 			}
 			m.CGroupID = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field All", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.All = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10502,6 +10586,40 @@ func (m *ActivityDumpStopMessage) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Error = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Dumps", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Dumps = append(m.Dumps, &ActivityDumpMessage{})
+			if err := m.Dumps[len(m.Dumps)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/security/security_profile/errors.go
+++ b/pkg/security/security_profile/errors.go
@@ -15,3 +15,10 @@ var ErrActivityDumpManagerDisabled = errors.New("ActivityDumpManager is disabled
 
 // ErrSecurityProfileManagerDisabled is returned when the security profile manager is disabled
 var ErrSecurityProfileManagerDisabled = errors.New("SecurityProfileManager is disabled")
+
+// ErrHostDumpDisabled is returned when a host-wide activity dump is requested but the feature is not enabled
+var ErrHostDumpDisabled = errors.New("host activity dump is disabled: set runtime_security_config.activity_dump.host_dump.enabled to true")
+
+// ErrHostDumpV2Unsupported is returned when a host-wide activity dump is requested while the V2 profile
+// manager is active (which does not support the on-demand activity dump API)
+var ErrHostDumpV2Unsupported = errors.New("host activity dump is not supported with the V2 security profile manager (runtime_security_config.security_profile.v2.enabled=true)")

--- a/pkg/security/security_profile/grpc.go
+++ b/pkg/security/security_profile/grpc.go
@@ -57,6 +57,30 @@ func (m *Manager) DumpActivity(params *api.ActivityDumpParams) (*api.ActivityDum
 		}, ErrActivityDumpManagerDisabled
 	}
 
+	// host-wide mode: rather than tracing a single cgroup, restart the capture
+	// window of every dump the manager is already tracing. Gated behind its own
+	// config switch and never forwards to the remote backend (see StopActivityDump).
+	if params.GetHost() {
+		if !m.config.RuntimeSecurity.ActivityDumpHostDumpEnabled {
+			return &api.ActivityDumpMessage{Error: ErrHostDumpDisabled.Error()}, ErrHostDumpDisabled
+		}
+
+		m.m.Lock()
+		defer m.m.Unlock()
+
+		// Open the window with a full-host baseline: reset the tree of any
+		// already-active dumps (and clear the ignore-list so previously-stopped
+		// cgroups are traceable again), then start a fresh dump for every other
+		// currently-running cgroup so the window captures everything running now
+		// -- not only cgroups that happen to exec after this point.
+		reset := m.resetAllDumps()
+		snapped := m.snapshotAllCgroups()
+		seclog.Infof("host-wide capture window (re)started: %d active dumps reset, %d cgroups snapshotted", reset, snapped)
+		return &api.ActivityDumpMessage{
+			Metadata: &api.MetadataMessage{Name: fmt.Sprintf("host-wide capture window started (%d reset + %d snapshotted = %d cgroups)", reset, snapped, reset+snapped)},
+		}, nil
+	}
+
 	if params.GetContainerID() == "" && params.GetCGroupID() == "" {
 		err := errors.New("you must specify one selector between containerID and cgroupID")
 		return &api.ActivityDumpMessage{Error: err.Error()}, err
@@ -116,6 +140,42 @@ func (m *Manager) DumpActivity(params *api.ActivityDumpParams) (*api.ActivityDum
 	return newDump.Profile.ToSecurityActivityDumpMessage(timeout, m.configuredStorageRequests), nil
 }
 
+// finalizeDumpLocked stops kernel-side collection for a dump and marks its cgroup
+// to be ignored from snapshots so it is not immediately re-created. It does NOT
+// persist the dump. The caller must hold m.m and remove the dump from
+// m.activeDumps.
+func (m *Manager) finalizeDumpLocked(ad *dump.ActivityDump) {
+	m.finalizeKernelEventCollection(ad, true)
+	// mark the cgroup to ignore from snapshot to prevent re-creation
+	m.ignoreFromSnapshot[ad.Profile.Metadata.CGroupContext.CGroupPathKey.Inode] = true
+	seclog.Infof("tracing stopped for [%s]", ad.GetSelectorStr())
+}
+
+// persistStoppedDump persists an already-finalized dump using the provided storage
+// requests. When sendToProfiles is true (and security profiles are enabled) the
+// profile is also queued to the profile manager. This performs encoding and I/O
+// (potentially a remote upload) and must NOT be called while holding m.m. It
+// returns a message describing the dump.
+func (m *Manager) persistStoppedDump(ad *dump.ActivityDump, storageRequests map[config.StorageFormat][]config.StorageRequest, sendToProfiles bool) *api.ActivityDumpMessage {
+	// persist dump if not empty
+	if !ad.Profile.IsEmpty() && ad.Profile.GetWorkloadSelector() != nil {
+		if err := m.persist(ad.Profile, storageRequests); err != nil {
+			seclog.Errorf("couldn't persist dump [%s]: %v", ad.GetSelectorStr(), err)
+		} else if sendToProfiles && m.config.RuntimeSecurity.SecurityProfileEnabled {
+			select {
+			case m.newProfiles <- ad.Profile:
+			default:
+				// drop the profile and log error if the channel is full
+				seclog.Warnf("couldn't send new profile to the manager: channel is full")
+			}
+		}
+	} else {
+		m.emptyDropped.Inc()
+	}
+
+	return ad.Profile.ToSecurityActivityDumpMessage(ad.GetTimeout(), storageRequests)
+}
+
 // StopActivityDump stops an active activity dump
 func (m *Manager) StopActivityDump(params *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
 	if !m.config.RuntimeSecurity.ActivityDumpEnabled {
@@ -124,46 +184,54 @@ func (m *Manager) StopActivityDump(params *api.ActivityDumpStopParams) (*api.Act
 		}, ErrActivityDumpManagerDisabled
 	}
 
-	m.m.Lock()
-	defer m.m.Unlock()
+	// host-wide mode: stop every active dump and persist each to LOCAL storage only
+	// (never forwarded to the remote backend, and not fed into the security profile
+	// pipeline). Gated behind its own config switch. Finalization happens under the
+	// lock; the encode+write of each dump is done after releasing it so a slow disk
+	// cannot stall the CWS event pipeline.
+	if params.GetAll() {
+		if !m.config.RuntimeSecurity.ActivityDumpHostDumpEnabled {
+			return &api.ActivityDumpStopMessage{Error: ErrHostDumpDisabled.Error()}, ErrHostDumpDisabled
+		}
+
+		m.m.Lock()
+		stopped := m.activeDumps
+		m.activeDumps = nil
+		for _, ad := range stopped {
+			m.finalizeDumpLocked(ad)
+		}
+		m.m.Unlock()
+
+		dumps := make([]*api.ActivityDumpMessage, 0, len(stopped))
+		for _, ad := range stopped {
+			dumps = append(dumps, m.persistStoppedDump(ad, m.localStorageRequests, false))
+		}
+		return &api.ActivityDumpStopMessage{Dumps: dumps}, nil
+	}
 
 	if params.GetName() == "" && params.GetContainerID() == "" && params.GetCGroupID() == "" {
 		err := errors.New("you must specify one selector between name, containerID and cgroupID")
 		return &api.ActivityDumpStopMessage{Error: err.Error()}, err
 	}
 
-	toDelete := -1
+	// find and finalize the matching dump under the lock, then persist it after
+	// releasing the lock so encoding/upload does not stall the event pipeline.
+	m.m.Lock()
+	var stopped *dump.ActivityDump
 	for i, ad := range m.activeDumps {
 		if (params.GetName() != "" && ad.Profile.Metadata.Name == params.GetName()) ||
 			(params.GetContainerID() != "" && ad.Profile.Metadata.ContainerID == containerutils.ContainerID(params.GetContainerID())) ||
 			(params.GetCGroupID() != "" && ad.Profile.Metadata.CGroupContext.CGroupID == containerutils.CGroupID(params.GetCGroupID())) {
-			m.finalizeKernelEventCollection(ad, true)
-			// mark the cgroup to ignore from snapshot to prevent re-creation
-			m.ignoreFromSnapshot[ad.Profile.Metadata.CGroupContext.CGroupPathKey.Inode] = true
-			seclog.Infof("tracing stopped for [%s]", ad.GetSelectorStr())
-			toDelete = i
-
-			// persist dump if not empty
-			if !ad.Profile.IsEmpty() && ad.Profile.GetWorkloadSelector() != nil {
-				if err := m.persist(ad.Profile, m.configuredStorageRequests); err != nil {
-					seclog.Errorf("couldn't persist dump [%s]: %v", ad.GetSelectorStr(), err)
-				} else if m.config.RuntimeSecurity.SecurityProfileEnabled {
-					select {
-					case m.newProfiles <- ad.Profile:
-					default:
-						// drop the profile and log error if the channel is full
-						seclog.Warnf("couldn't send new profile to the manager: channel is full")
-					}
-				}
-			} else {
-				m.emptyDropped.Inc()
-			}
+			m.finalizeDumpLocked(ad)
+			m.activeDumps = append(m.activeDumps[:i], m.activeDumps[i+1:]...)
+			stopped = ad
 			break
 		}
 	}
+	m.m.Unlock()
 
-	if toDelete >= 0 {
-		m.activeDumps = append(m.activeDumps[:toDelete], m.activeDumps[toDelete+1:]...)
+	if stopped != nil {
+		m.persistStoppedDump(stopped, m.configuredStorageRequests, true)
 		return &api.ActivityDumpStopMessage{}, nil
 	}
 

--- a/pkg/security/security_profile/load_controller.go
+++ b/pkg/security/security_profile/load_controller.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
+	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
@@ -74,6 +76,86 @@ func (m *Manager) nextPartialDump(prev *dump.ActivityDump) *dump.ActivityDump {
 	newDump.Cookie = prev.Cookie
 
 	return newDump
+}
+
+// resetAllDumps restarts the capture window of every active dump: it swaps each
+// dump's accumulated tree for a fresh, empty one while keeping kernel-side
+// collection running (same cookie, same traced cgroup/PIDs). Pre-window activity
+// is discarded, not persisted. This backs the host-wide "start" so that the
+// capture window lines up with a CI job boundary rather than agent/VM boot.
+// Returns the number of dumps that were reset.
+func (m *Manager) resetAllDumps() int {
+	// Clear the snapshot ignore-list so cgroups that were stopped in a previous
+	// capture cycle (which get added here to prevent re-creation) become
+	// traceable again. Without this, a stop followed by a start would never
+	// re-trace the cgroups that were active in the prior cycle.
+	clear(m.ignoreFromSnapshot)
+
+	previous := m.activeDumps
+	m.activeDumps = nil
+
+	var reset int
+	for _, ad := range previous {
+		// build the replacement dump before tearing down the old one (same cookie)
+		newDump := m.nextPartialDump(ad)
+
+		// stop the old dump but keep the cgroup spot, and drop its data (no persist)
+		m.finalizeKernelEventCollection(ad, false)
+
+		if err := m.insertActivityDump(newDump); err != nil {
+			seclog.Errorf("couldn't reset tracing [%s]: %v", newDump.GetSelectorStr(), err)
+			continue
+		}
+		reset++
+	}
+	return reset
+}
+
+// snapshotAllCgroups starts a dump for every currently-known cgroup that is not
+// already being traced, so a host-wide capture window opens with a full baseline
+// of everything running now (each new dump snapshots the cgroup's current
+// process tree) rather than only picking up cgroups that exec after the window
+// opens. Caller must hold m.m. Returns the number of cgroups newly traced.
+func (m *Manager) snapshotAllCgroups() int {
+	// cgroup inodes already being traced, to avoid duplicate starts
+	traced := make(map[uint64]bool, len(m.activeDumps))
+	for _, ad := range m.activeDumps {
+		traced[ad.Profile.Metadata.CGroupContext.CGroupPathKey.Inode] = true
+	}
+
+	// Collect the current cgroups first and create the dumps afterwards:
+	// IterateCacheEntries holds the cgroup resolver lock, and dump creation
+	// (startDumpWithConfig -> insertActivityDump) calls back into that resolver,
+	// so creating dumps inside the callback would deadlock.
+	type cgroupInfo struct {
+		containerID   containerutils.ContainerID
+		cgroupContext model.CGroupContext
+	}
+	var cgroups []cgroupInfo
+	m.resolvers.CGroupResolver.IterateCacheEntries(func(entry *cgroupModel.CacheEntry) bool {
+		cgctx := entry.GetCGroupContext()
+		if len(cgctx.CGroupID) == 0 || traced[cgctx.CGroupPathKey.Inode] {
+			return false
+		}
+		cgroups = append(cgroups, cgroupInfo{
+			containerID:   entry.GetContainerID(),
+			cgroupContext: cgctx,
+		})
+		return false
+	})
+
+	now := time.Now()
+	var started int
+	for _, cg := range cgroups {
+		if err := m.startDumpWithConfig(cg.containerID, cg.cgroupContext, utils.NewCookie(), *m.defaultActivityDumpLoadConfig(now)); err != nil {
+			// most likely the traced-cgroup capacity was reached (bounded by
+			// traced_cgroups_count); log and keep going for the rest
+			seclog.Debugf("host snapshot: couldn't start tracing cgroup %s: %v", cg.cgroupContext.CGroupID, err)
+			continue
+		}
+		started++
+	}
+	return started
 }
 
 // getOverweightDumps returns the list of dumps that crossed the config.ActivityDumpMaxDumpSize threshold

--- a/pkg/security/security_profile/manager.go
+++ b/pkg/security/security_profile/manager.go
@@ -108,6 +108,9 @@ type Manager struct {
 	localStorage              *storage.Directory
 	remoteStorage             *storage.ActivityDumpRemoteStorageForwarder
 	configuredStorageRequests map[config.StorageFormat][]config.StorageRequest
+	// localStorageRequests is the local-storage-only subset of the configured requests. It is used by the
+	// host-wide dump path so those dumps are persisted to disk only and never forwarded to the remote backend.
+	localStorageRequests map[config.StorageFormat][]config.StorageRequest
 
 	activeDumps      []*dump.ActivityDump
 	snapshotQueue    chan *dump.ActivityDump
@@ -239,14 +242,22 @@ func NewManager(cfg *config.Config, statsdClient statsd.ClientInterface, ebpf *e
 		))
 	}
 
+	// keep a local-storage-only copy for the host-wide dump path (never forwarded to the backend)
+	localStorageRequests := slices.Clone(configuredStorageRequests)
+
 	// add remote storage requests
-	// the actual fields are not really used, but this allows to report the correct request
-	configuredStorageRequests = append(configuredStorageRequests, config.NewStorageRequest(
-		config.RemoteStorage,
-		config.Protobuf,
-		true, // force remote compression
-		"",
-	))
+	// the actual fields are not really used, but this allows to report the correct request.
+	// host_dump is a local-only mode: when it is enabled, the whole activity-dump subsystem
+	// (host stop, timeout cleanup, load-controller split, ...) persists to local storage only
+	// and nothing is ever forwarded to the remote backend.
+	if !cfg.RuntimeSecurity.ActivityDumpHostDumpEnabled {
+		configuredStorageRequests = append(configuredStorageRequests, config.NewStorageRequest(
+			config.RemoteStorage,
+			config.Protobuf,
+			true, // force remote compression
+			"",
+		))
+	}
 
 	contextTags := []string{"host:" + hostname}
 	// merge tags from config
@@ -307,6 +318,7 @@ func NewManager(cfg *config.Config, statsdClient statsd.ClientInterface, ebpf *e
 		localStorage:              localStorage,
 		remoteStorage:             remoteStorage,
 		configuredStorageRequests: perFormatStorageRequests(configuredStorageRequests),
+		localStorageRequests:      perFormatStorageRequests(localStorageRequests),
 
 		contextTags:      contextTags,
 		containerFilters: containerFilters,

--- a/pkg/security/security_profile/manager_test.go
+++ b/pkg/security/security_profile/manager_test.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
@@ -1938,5 +1939,38 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 
 			// TODO: also check profile stats and global metrics
 		})
+	}
+}
+
+func TestActivityDumpManager_hostDumpGating(t *testing.T) {
+	// host_dump disabled: both host start and host stop must be rejected
+	disabled := &Manager{config: &config.Config{RuntimeSecurity: &config.RuntimeSecurityConfig{
+		ActivityDumpEnabled:         true,
+		ActivityDumpHostDumpEnabled: false,
+	}}}
+
+	if _, err := disabled.DumpActivity(&api.ActivityDumpParams{Host: true}); !errors.Is(err, ErrHostDumpDisabled) {
+		t.Fatalf("host start: expected ErrHostDumpDisabled, got %v", err)
+	}
+	if _, err := disabled.StopActivityDump(&api.ActivityDumpStopParams{All: true}); !errors.Is(err, ErrHostDumpDisabled) {
+		t.Fatalf("host stop: expected ErrHostDumpDisabled, got %v", err)
+	}
+
+	// activity dumps disabled entirely: that check precedes the host gate
+	off := &Manager{config: &config.Config{RuntimeSecurity: &config.RuntimeSecurityConfig{
+		ActivityDumpEnabled: false,
+	}}}
+	if _, err := off.DumpActivity(&api.ActivityDumpParams{Host: true}); !errors.Is(err, ErrActivityDumpManagerDisabled) {
+		t.Fatalf("host start (AD off): expected ErrActivityDumpManagerDisabled, got %v", err)
+	}
+}
+
+func TestActivityDumpManagerV2_hostDumpUnsupported(t *testing.T) {
+	m := &ManagerV2{}
+	if _, err := m.DumpActivity(&api.ActivityDumpParams{Host: true}); !errors.Is(err, ErrHostDumpV2Unsupported) {
+		t.Fatalf("V2 host start: expected ErrHostDumpV2Unsupported, got %v", err)
+	}
+	if _, err := m.StopActivityDump(&api.ActivityDumpStopParams{All: true}); !errors.Is(err, ErrHostDumpV2Unsupported) {
+		t.Fatalf("V2 host stop: expected ErrHostDumpV2Unsupported, got %v", err)
 	}
 }

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -1369,13 +1369,19 @@ func (m *ManagerV2) ListActivityDumps(_ *api.ActivityDumpListParams) (*api.Activ
 
 // StopActivityDump stops an active activity dump.
 // NO-OP in V2: V2 doesn't manage activity dumps the traditional way.
-func (m *ManagerV2) StopActivityDump(_ *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
+func (m *ManagerV2) StopActivityDump(params *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
+	if params.GetAll() {
+		return &api.ActivityDumpStopMessage{Error: ErrHostDumpV2Unsupported.Error()}, ErrHostDumpV2Unsupported
+	}
 	return nil, nil
 }
 
 // DumpActivity dumps the activity.
 // NO-OP in V2: V2 doesn't support on-demand activity dumping through this API.
-func (m *ManagerV2) DumpActivity(_ *api.ActivityDumpParams) (*api.ActivityDumpMessage, error) {
+func (m *ManagerV2) DumpActivity(params *api.ActivityDumpParams) (*api.ActivityDumpMessage, error) {
+	if params.GetHost() {
+		return &api.ActivityDumpMessage{Error: ErrHostDumpV2Unsupported.Error()}, ErrHostDumpV2Unsupported
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds a **host-wide activity dump** capability to CWS: a start/stop "button" that captures every cgroup on the host at once, driven from the CLI.

- New CLI: `system-probe runtime activity-dump host start` / `host stop`
  - `host start` opens a capture window with a **full-host baseline**: it resets the tree of every active dump (fresh tree, same cookie, kernel collection uninterrupted), clears the snapshot ignore-list, and starts a fresh dump for every other currently-running cgroup (each snapshotting its current process tree). So the window captures everything running *now*, not just cgroups that happen to exec after it opens — this holds on repeated start/stop cycles too.
  - `host stop` stops every active dump and persists each one.
- New config switch `runtime_security_config.activity_dump.host_dump.enabled` (default **false**). It must be explicitly turned on, and enabling it pulls its prerequisites up (upward-only, logged): `activity_dump.enabled`, `trace_systemd_cgroups`, and `traced_cgroups_count` (raised to the max). So a single switch "just works".
- **Local-only, across the whole subsystem.** When `host_dump` is enabled, *every* persist path — host stop, timeout cleanup, load-controller split — writes to local storage; the remote storage request is dropped entirely, so nothing is ever forwarded to the backend (the cws-intake endpoint isn't even set up) and dumps are not fed into the security profile pipeline.
- Reuses the existing per-cgroup tracing engine — no changes to the kernel-side collection path. New proto fields (`Host`, `All`, `Dumps`) are additive/wire-compatible.

### How to use

Enable the feature (off by default) — this one switch also auto-enables its prerequisites:

```yaml
runtime_security_config:
  activity_dump:
    host_dump:
      enabled: true
```

Then, around the workload you want to capture (e.g. from a CI job's pre/post steps):

```bash
# pre-job: open the capture window (full-host baseline)
system-probe runtime activity-dump host start

# ... run the job ...

# post-job: stop every cgroup's dump and persist one file each
system-probe runtime activity-dump host stop
```

Dumps land in `activity_dump.local_storage.output_directory` (default `${run_path}/runtime-security/profiles`), one `.profile` per cgroup — collect that directory as a CI artifact. Inspect one with:

```bash
system-probe runtime activity-dump generate encoding --input <file>.profile --format json
```

Requires the V1 profile manager (`security_profile.v2.enabled=false`, the default). If you set a custom `local_storage.output_directory` while security profiles are enabled, it must equal `security_profile.dir` (or leave the default, which matches).

### Motivation

Capturing a behavioral recording of an entire host for a bounded window — primarily to spot anomalies in CI systems (e.g. ephemeral VM runners), where a GitHub Action opens the window at job start and harvests the per-cgroup dumps at job end. A single container/cgroup dump misses activity that escapes into sibling cgroups (docker build, service containers, systemd-run); host-wide capture catches it. Being local-only keeps the captured data on the box (no backend egress), which suits CI/forensic use.

### Describe how you validated your changes

Manually, on a Linux dev VM running `system-probe` standalone (host-native, no core agent):
- **Gate:** with `host_dump.enabled=false`, `host start` is rejected with a clear error; with it on, it works.
- **Auto-coupling:** with a minimal config (only `host_dump.enabled: true`), startup logs confirm `trace_systemd_cgroups` is enabled and `traced_cgroups_count` is raised 5→128; capture works end-to-end.
- **Full-host baseline across cycles:** two consecutive `host start`→`host stop` cycles each persisted all 26 host cgroups (the 2nd reported `0 reset + 26 snapshotted`), confirming a stop→start re-captures the whole host, not only newly-active cgroups.
- **Local-only:** every persisted dump shows `storage type: local_storage` with zero remote entries, and with `host_dump` on the cws-intake remote endpoint is not set up at all.
- **Capture correctness:** ran `id`, `whoami`, `cat /etc/passwd`, `nslookup`, `wget` directly on the host; the host session-scope dump contains exactly those execs plus the DNS queries, the `/etc/passwd` read, and sockets.
- **V2:** returns a clear "not supported under the V2 profile manager" error instead of a silent no-op.

Unit tests added and passing:
- config: prerequisite pull-up, upward-only (no lowering), off-is-noop.
- manager: host_dump gating (disabled → error, AD-off precedence), V2 unsupported.
- CLI: `host start` / `host stop` subcommand wiring.

### Additional Notes

- Draft: opening for early review of the approach.
- Concurrency: dump finalization runs under the manager lock, but each dump's encode+write happens after the lock is released, so disk I/O cannot stall the CWS event pipeline.
- Known caveats (documented, not blockers for the local/CI use case): host-wide capture is bounded by the existing `traced_cgroups_count` cap (128) and the fixed `traced_pids` eBPF map (8192) — on a very busy host capture can be silently partial; a telemetry/warning follow-up would be worthwhile. Enabling `host_dump` makes the agent's activity dumps fully local, so it can't be combined with normal backend-forwarded per-container dumps.
