### PR TITLE
Disable BEP path conversion to survive transient remote DNS errors

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,7 @@ common --experimental_ui_max_stdouterr_bytes=1073741819 # why?
 common --http_timeout_scaling=3.0 # At least one attempt reaches 30s (3,6,12,24,30,30,30,30) instead of only 10s (1,2,4,8,10,10,10,10)
 common --incompatible_default_to_explicit_init_py # https://github.com/bazel-contrib/rules_python/issues/2945
 common --incompatible_remote_local_fallback_for_remote_cache # works only if --remote_local_fallback is also set
+common --nobuild_event_json_file_path_conversion # don't fail the build on a transient BEP-upload error (no such host)
 common --remote_instance_name=ci/datadog-agent # entries missing from datadog-agent will be searched in remote-caching
 common --remote_local_fallback # best-effort on transient connection errors (no such host)
 common --remote_retries=1


### PR DESCRIPTION
### What does this PR do?
Disables Build Event Protocol path conversion, so `bazel test` no longer fails uploading BEP-referenced local files, such as the per-invocation profile, to the remote cache before writing the BEP JSON file.

### Motivation
`bazel test` jobs had been [failing at times](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%22Unable%20to%20write%20all%20BEP%20events%20to%20file%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1783239715475&to_ts=1784535715475&live=true) on:
```
ERROR: Unable to write all BEP events to file due to 'com.google.devtools.build.lib.remote.common.RemoteExecutionCapabilitiesException: io.grpc.StatusRuntimeException: UNAVAILABLE: Backend "ci/datadog-agent": Backend "ci/datadog-agent": Shard 1: connection error: desc = "transport: Error while dialing: dial tcp: lookup buildbarn-datadog-agent-storage-1.buildbarn-datadog-agent-storage.buildbarn.local-cluster.local-dc.fabric.dog on 169.254.20.10:53: no such host"'
```
This happens [after all tests passed](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1872800867), because writing the BEP may hit a transient DNS lookup failure against the Buildbarn storage backend while uploading a referenced local file.

We already tolerate this failure class for the main remote-cache path via `--remote_local_fallback`, but that fallback does not cover the separate BEP-upload path, which instead aborts the whole invocation.

As of today, we have no BES backend consuming the remote-referenced blobs, so the upload serves no purpose here.

### Additional Notes
bazelbuild/bazel#11473 reported this same fail-the-whole-build behavior in 2021, but the fix that shipped in 5.0 only made BEP uploads respect `no-cache` action tags, and left the underlying behavior we hit here unchanged before the issue was closed.