### PR TITLE
Remove experimental from dogstatsd stream socket option.

### DIFF
--- a/comp/dogstatsd/server/impl/server.go
+++ b/comp/dogstatsd/server/impl/server.go
@@ -418,7 +418,6 @@ func (s *dsdServer) start(context.Context) error {
 	}
 
 	if len(socketStreamPath) > 0 {
-		s.log.Warnf("dogstatsd_stream_socket is not yet supported, run it at your own risk")
 		unixListener, err := listeners.NewUDSStreamListener(packetsChannel, sharedPacketPoolManager, sharedUDSOobPoolManager, s.config, s.tCapture, s.wmeta, s.pidMap, s.listernersTelemetry, s.packetsTelemetry, s.telemetry)
 		if err != nil {
 			s.log.Errorf("Can't init listener: %s", err.Error())

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2502,7 +2502,7 @@ api_key:
 
 ## @param dogstatsd_stream_socket - string - optional - default: ""
 ## @env DD_DOGSTATSD_STREAM_SOCKET - string - optional - default: ""
-## Listen for Dogstatsd metrics on a Unix Socket using stream mode (SOCK_STREAM, *nix only).
+## Listen for Dogstatsd metrics on a Unix domain socket using stream mode (SOCK_STREAM, *nix only).
 ## Set to a valid and existing filesystem path to enable.
 ## Set to "" to disable this feature.
 ##

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2492,7 +2492,7 @@ api_key:
 
 ## @param dogstatsd_socket - string - optional - default: {{ if (or (eq .OS "linux") (eq .OS "aix")) }}"/var/run/datadog/dsd.socket"{{else}}""{{end}}
 ## @env DD_DOGSTATSD_SOCKET - string - optional - default: {{ if (or (eq .OS "linux") (eq .OS "aix")) }}"/var/run/datadog/dsd.socket"{{else}}""{{end}}
-## Listen for Dogstatsd metrics on a Unix Socket (*nix only).
+## Listen for Dogstatsd metrics on a Unix domain socket (*nix only).
 ## Set to a valid and existing filesystem path to enable.
 ## Set to "" to disable this feature.
 ##

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2497,9 +2497,18 @@ api_key:
 ## Set to "" to disable this feature.
 ##
 ## Please note that UDS receiver is not available in Windows.
-## Enabling this setting may result in unexpected behavior.
 #
 # dogstatsd_socket: {{ if (or (eq .OS "linux") (eq .OS "aix")) }}"/var/run/datadog/dsd.socket"{{else}}""{{end}}
+
+## @param dogstatsd_stream_socket - string - optional - default: ""
+## @env DD_DOGSTATSD_STREAM_SOCKET - string - optional - default: ""
+## Listen for Dogstatsd metrics on a Unix Socket using stream mode (SOCK_STREAM, *nix only).
+## Set to a valid and existing filesystem path to enable.
+## Set to "" to disable this feature.
+##
+## Please note that this is not available in Windows.
+#
+# dogstatsd_stream_socket: ""
 
 ## @param dogstatsd_origin_detection - boolean - optional - default: false
 ## @env DD_DOGSTATSD_ORIGIN_DETECTION - boolean - optional - default: false

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -2239,7 +2239,6 @@ properties:
       Please note that this is not available in Windows.
     tags:
     - template_section:Dogstatsd
-    comment: 'Experimental || Notice: empty means feature disabled'
   dogstatsd_origin_detection:
     node_type: setting
     type: boolean

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -2227,6 +2227,21 @@ properties:
       linux: /var/run/datadog/dsd.socket
       aix: /var/run/datadog/dsd.socket
       other: ''
+  dogstatsd_stream_socket:
+    node_type: setting
+    type: string
+    default: ''
+    visibility: public
+    description: |-
+      Listen for Dogstatsd metrics on a Unix Socket using stream mode (SOCK_STREAM, *nix only).
+      Set to a valid and existing filesystem path to enable.
+      Set to "" to disable this feature.
+
+      Please note that this is not available in Windows.
+      Enabling this setting may result in unexpected behavior.
+    tags:
+    - template_section:Dogstatsd
+    comment: 'Experimental || Notice: empty means feature disabled'
   dogstatsd_origin_detection:
     node_type: setting
     type: boolean
@@ -7989,11 +8004,6 @@ properties:
     node_type: setting
     type: boolean
     default: false
-  dogstatsd_stream_socket:
-    node_type: setting
-    type: string
-    default: ''
-    comment: 'Experimental || Notice: empty means feature disabled'
   dogstatsd_string_interner_size:
     node_type: setting
     type: integer

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -2215,7 +2215,7 @@ properties:
     type: string
     visibility: public
     description: |-
-      Listen for Dogstatsd metrics on a Unix Socket (*nix only).
+      Listen for Dogstatsd metrics on a Unix domain socket (*nix only).
       Set to a valid and existing filesystem path to enable.
       Set to "" to disable this feature.
 
@@ -2232,7 +2232,7 @@ properties:
     default: ''
     visibility: public
     description: |-
-      Listen for Dogstatsd metrics on a Unix Socket using stream mode (SOCK_STREAM, *nix only).
+      Listen for Dogstatsd metrics on a Unix domain socket using stream mode (SOCK_STREAM, *nix only).
       Set to a valid and existing filesystem path to enable.
       Set to "" to disable this feature.
 

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -2220,7 +2220,6 @@ properties:
       Set to "" to disable this feature.
 
       Please note that UDS receiver is not available in Windows.
-      Enabling this setting may result in unexpected behavior.
     tags:
     - template_section:Dogstatsd
     platform_default:
@@ -2238,7 +2237,6 @@ properties:
       Set to "" to disable this feature.
 
       Please note that this is not available in Windows.
-      Enabling this setting may result in unexpected behavior.
     tags:
     - template_section:Dogstatsd
     comment: 'Experimental || Notice: empty means feature disabled'

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1699,7 +1699,7 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 		"other": "",
 	}))
 
-	config.BindEnvAndSetDefault("dogstatsd_stream_socket", "") // Experimental || Notice: empty means feature disabled
+	config.BindEnvAndSetDefault("dogstatsd_stream_socket", "")
 	config.BindEnvAndSetDefault("dogstatsd_stream_log_too_big", false)
 	config.BindEnvAndSetDefault("dogstatsd_pipeline_autoadjust", false)
 	config.BindEnvAndSetDefault("dogstatsd_pipeline_count", 1)

--- a/releasenotes/notes/dogstatsd-stream-socket-stable-e9b7ac10f0e9861b.yaml
+++ b/releasenotes/notes/dogstatsd-stream-socket-stable-e9b7ac10f0e9861b.yaml
@@ -9,5 +9,5 @@
 enhancements:
   - |
     The ``dogstatsd_stream_socket`` configuration option, which lets DogStatsD
-    listen for metrics on a Unix Domain Socket using stream mode (``SOCK_STREAM``),
+    listen for metrics on a Unix domain socket using stream mode (``SOCK_STREAM``),
     is now considered stable.

--- a/releasenotes/notes/dogstatsd-stream-socket-stable-e9b7ac10f0e9861b.yaml
+++ b/releasenotes/notes/dogstatsd-stream-socket-stable-e9b7ac10f0e9861b.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ``dogstatsd_stream_socket`` configuration option, which lets DogStatsD
+    listen for metrics on a Unix Domain Socket using stream mode (``SOCK_STREAM``),
+    is now considered stable.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Removes the warning and exposes the `dogstatsd_stream_socket` configuration option.

### Motivation

The `dogstatsd_stream_socket` option has been available in the agent since 7.50. [PR](https://github.com/DataDog/datadog-agent/pull/20002). It has been hidden and a warning `dogstatsd_stream_socket is not yet supported, run it at your own risk` was shown when it was used.

We have dogfooded the option extensively and successfully, so there is no reason to not support this option.

### Describe how you validated your changes

### Additional Notes
