### PR TITLE
Remove useless go generate command in trace-agent build

### DIFF
--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -53,10 +53,6 @@ def build(
     )
     agent_bin = os.path.join(BIN_PATH, bin_name("trace-agent"))
 
-    # go generate only works if you are in the module the target file is in, so we
-    # need to move into the pkg/trace module.
-    with ctx.cd("./pkg/trace"):
-        ctx.run(f"go generate -mod={go_mod} {REPO_PATH}/pkg/trace/info", env=env)
     go_build(
         ctx,
         f"{REPO_PATH}/cmd/trace-agent",


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Remove useless go generate command in trace-agent build.

### Motivation
The command is a no-op, there is no generate command in any of the files of the package anymore.

I'm looking into cross-compiling trace-agent for AIX and I think if anything actually ran there it would fail or result in mixed AIX/Linux state.

### Describe how you validated your changes
CI

### Additional Notes
