### PR TITLE
Give integrations-core Renovate PR higher priority

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,8 @@
       {
         "matchDepNames": ["integrations-core"],
         "changelogUrl": "https://github.com/DataDog/integrations-core/compare/{{currentDigest}}..{{newDigest}}",
-        "schedule": ["* 2-6 * * 1,3"]
+        "schedule": ["* 2-6 * * 1,3"],
+        "prPriority": 10
       },
       {
         "matchDepNames": ["omnibus-ruby"],


### PR DESCRIPTION
<!-- dd-meta {"pullId":"4a5a9c13-1198-4a53-a4d8-ba206a5d05f0","source":"chat","resourceId":"a88c7485-206e-4d14-b47f-4afe38c22b44","workflowId":"d09dc98e-e086-46e9-abb5-0fe425a675b4","codeChangeId":"d09dc98e-e086-46e9-abb5-0fe425a675b4","sourceType":"slack"} -->
### What does this PR do?

Sets `prPriority: 10` on the `integrations-core` Renovate package rule so its digest update PR is created before other lower-priority dependency PRs.

### Motivation

Renovate's `prConcurrentLimit` rate-limits how many PRs can be open at once. The integrations-core digest update is important for release cadence, but it was getting deprioritized behind other dependency PRs, requiring manual intervention via the Dependency Dashboard checkbox (see #33469).

Setting a high `prPriority` ensures integrations-core PRs are opened first when Renovate processes the queue.

### Describe how you validated your changes

- Verified the JSON is syntactically valid.
- Confirmed that `prPriority: 10` matches the pattern already used for other high-priority rules (custom.regex manager, rshell) in this config.

### Additional Notes

Reference: https://github.com/DataDog/datadog-agent/issues/33469

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a88c7485-206e-4d14-b47f-4afe38c22b44)

Comment @datadog to request changes