### PR TITLE
fix(macos-ci): add after_script anchor to chmod workspace before git clean [Runner 18]

### DIFF
--- a/.gitlab/.pre/common/macos.yml
+++ b/.gitlab/.pre/common/macos.yml
@@ -98,3 +98,10 @@
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e install-tools --verbose
+
+.macos_runner_after_script:
+  - |
+    # Make workspace writable so the next job's git clean (clear_worktree) succeeds.
+    # GitLab Runner 18 fails hard on 'permission denied' during workspace cleanup.
+    # Builds like omnibus leave read-only files in dev/embedded/ that block git clean.
+    chmod -R u+w "${CI_PROJECT_DIR}" 2>/dev/null || true

--- a/.gitlab/.pre/common/macos.yml
+++ b/.gitlab/.pre/common/macos.yml
@@ -98,6 +98,8 @@
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e install-tools --verbose
+  after_script:
+    - !reference [.macos_runner_after_script]
 
 .macos_runner_after_script:
   - |

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -89,12 +89,16 @@
   # GOPROXY into its repository rules.
   before_script:
     - !reference [.sanitize_goproxy]
+  after_script:
+    - !reference [.macos_runner_after_script]
 
 .bazel:runner:macos-arm64:
   extends: .bazel:defs:cache:macos
   tags: [ "macos:sonoma-arm64", "specific:true" ]
   before_script:
     - !reference [.sanitize_goproxy]
+  after_script:
+    - !reference [.macos_runner_after_script]
 
 .bazel:runner:windows-amd64:
   extends: [ .bazel:defs:cache:windows, .windows_docker_default ]

--- a/.gitlab/build/package_build/dmg.yml
+++ b/.gitlab/build/package_build/dmg.yml
@@ -64,6 +64,7 @@
     - rm -rf "$OMNIBUS_GIT_CACHE_DIR" || true
   after_script:
     - sudo umount /Volumes/Agent || true
+    - !reference [.macos_runner_after_script]
   script:
     - set -eo pipefail
     - !reference [.vault_login]

--- a/.gitlab/build/source_test/macos.yml
+++ b/.gitlab/build/source_test/macos.yml
@@ -25,6 +25,7 @@ include:
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]
     - !reference [.upload_coverage_datadog]
+    - !reference [.macos_runner_after_script]
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/releasenotes/notes/fix-macos-runner18-git-clean-chmod-e1a2b3c4d5e6f789.yaml
+++ b/releasenotes/notes/fix-macos-runner18-git-clean-chmod-e1a2b3c4d5e6f789.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+- |
+    Fixed macOS CI jobs failing with ``permission denied`` during workspace cleanup
+    when running on GitLab Runner 18. Builds that produce read-only files in
+    ``dev/embedded/`` (e.g. omnibus, bazel tests) now run ``chmod -R u+w`` in
+    ``after_script`` so the next job's ``git clean`` can succeed.


### PR DESCRIPTION
## Problem

GitLab Runner 18 fails hard on `permission denied` errors during `clear_worktree` workspace cleanup. Runner 17.11 treated these as warnings and continued; Runner 18 exits non-zero, causing the **next** job to fail before it even starts.

Root cause: omnibus builds (e.g. `agent_dmg`) leave read-only files in `dev/embedded/lib/python3.13/` after building the embedded Python distribution. The next job's `git clean -ffdx` cannot remove them.

Example failure:
```
warning: failed to remove dev/embedded/lib/python3.13/termios.cpython-313-darwin.so: Permission denied
...
error: exit status 1
```

## Fix (Option A — after_script)

Adds a `.macos_runner_after_script` YAML anchor to `macos.yml`. Jobs that produce read-only build artifacts should add it to their `after_script`:

```yaml
after_script:
  - !reference [.macos_runner_after_script]
```

This runs `chmod -R u+w $CI_PROJECT_DIR` after the job completes, making files writable **before** the next job's `clear_worktree`.

## Alternative

See PR `fix/macos-runner-18-git-clean-flags-none` for an approach using `GIT_CLEAN_FLAGS: none` with manual cleanup instead.
