### PR TITLE
fix(macos-ci): add GIT_CLEAN_FLAGS helper for read-only artifact cleanup [Runner 18]

### DIFF
--- a/.gitlab/.pre/common/macos.yml
+++ b/.gitlab/.pre/common/macos.yml
@@ -98,3 +98,12 @@
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e install-tools --verbose
+
+.macos_git_clean_flags:
+  # Use GIT_CLEAN_FLAGS: none to disable automatic git clean, then call this
+  # anchor in before_script to chmod read-only files before manual cleanup.
+  # Required for jobs that produce read-only build artifacts (e.g. dev/embedded/).
+  - |
+    find "${CI_PROJECT_DIR}" -mindepth 1 \( -name "dev" -o -name "omnibus" \) -prune \
+      -exec chmod -R u+w {} + 2>/dev/null || true
+    git -C "${CI_PROJECT_DIR}" clean -ffd 2>/dev/null || true


### PR DESCRIPTION
## Problem

Same as `fix/macos-runner-18-git-clean-chmod-after-script` — GitLab Runner 18 fails hard on permission denied during workspace cleanup for jobs that produce read-only `dev/embedded/` files.

## Fix (Option B — GIT_CLEAN_FLAGS)

Adds a `.macos_git_clean_flags` YAML anchor. Jobs opt in by:
1. Setting `GIT_CLEAN_FLAGS: none` in their variables (disables automatic git clean)
2. Adding `!reference [.macos_git_clean_flags]` to `before_script` (does chmod + manual git clean)

More explicit than Option A but requires changes in each affected job definition.

## Alternative

See PR `fix/macos-runner-18-git-clean-chmod-after-script` for the simpler `after_script` approach.
