### PR TITLE
configfilesdiscovery: add config env vars collection scaffolding

### DIFF
--- a/comp/core/configfilesdiscovery/impl/collectors/kafka.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/kafka.go
@@ -26,25 +26,27 @@ func NewKafka() configfilesdiscoveryimpl.ConfigCollector {
 	return kafkaConfigCollector{}
 }
 
-func (c kafkaConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) ([]configfilesdiscoveryimpl.ConfigFile, error) {
+func (c kafkaConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (configfilesdiscoveryimpl.CollectedConfig, error) {
 	commandline, err := reader.ReadCommandline(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("read kafka command line: %w", err)
+		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read kafka command line: %w", err)
 	}
 
 	configPath, ok := kafkaGetConfigPath(commandline)
 	if !ok {
 		log.Debugf("config files discovery skipped kafka config collection: no explicit broker properties file path detected")
-		return nil, nil
+		return configfilesdiscoveryimpl.CollectedConfig{}, nil
 	}
 
 	file, err := reader.ReadFile(ctx, configPath)
 	if err != nil {
-		return nil, fmt.Errorf("read kafka config file %q: %w", configPath, err)
+		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read kafka config file %q: %w", configPath, err)
 	}
 	file.PayloadFormat = kafkaConfigPayloadFormat
 
-	return []configfilesdiscoveryimpl.ConfigFile{file}, nil
+	return configfilesdiscoveryimpl.CollectedConfig{
+		ConfigFiles: []configfilesdiscoveryimpl.ConfigFile{file},
+	}, nil
 }
 
 // kafkaGetConfigPath returns the broker properties file passed to the Kafka

--- a/comp/core/configfilesdiscovery/impl/collectors/kafka_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/kafka_test.go
@@ -163,17 +163,18 @@ func TestKafkaCollectorReadsDetectedConfig(t *testing.T) {
 	}
 	collector := NewKafka()
 
-	files, err := collector.Collect(context.Background(), reader)
+	collected, err := collector.Collect(context.Background(), reader)
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/etc/kafka/server.properties"}, reader.readFileCalls)
-	require.Len(t, files, 1)
+	require.Len(t, collected.ConfigFiles, 1)
 	assert.Equal(t, configfilesdiscoveryimpl.ConfigFile{
 		Path:          "/etc/kafka/server.properties",
 		Content:       []byte("broker.id=1\n"),
 		Truncated:     true,
 		PayloadFormat: kafkaConfigPayloadFormat,
-	}, files[0])
+	}, collected.ConfigFiles[0])
+	assert.Empty(t, collected.EnvVars)
 }
 
 func TestKafkaCollectorSkipsWhenNoConfigPathIsDetected(t *testing.T) {
@@ -184,11 +185,12 @@ func TestKafkaCollectorSkipsWhenNoConfigPathIsDetected(t *testing.T) {
 	}
 	collector := NewKafka()
 
-	files, err := collector.Collect(context.Background(), reader)
+	collected, err := collector.Collect(context.Background(), reader)
 
 	require.NoError(t, err)
 	assert.Empty(t, reader.readFileCalls)
-	assert.Empty(t, files)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Empty(t, collected.EnvVars)
 }
 
 func TestKafkaCollectorReturnsCommandlineErrors(t *testing.T) {
@@ -196,10 +198,10 @@ func TestKafkaCollectorReturnsCommandlineErrors(t *testing.T) {
 	reader := &kafkaCollectorTestReader{commandlineErr: expectedErr}
 	collector := NewKafka()
 
-	files, err := collector.Collect(context.Background(), reader)
+	collected, err := collector.Collect(context.Background(), reader)
 
 	require.ErrorIs(t, err, expectedErr)
-	assert.Nil(t, files)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
 }
 
 func TestKafkaCollectorReturnsReadFileErrors(t *testing.T) {
@@ -212,11 +214,11 @@ func TestKafkaCollectorReturnsReadFileErrors(t *testing.T) {
 	}
 	collector := NewKafka()
 
-	files, err := collector.Collect(context.Background(), reader)
+	collected, err := collector.Collect(context.Background(), reader)
 
 	require.ErrorIs(t, err, expectedErr)
 	assert.Equal(t, []string{"/etc/kafka/server.properties"}, reader.readFileCalls)
-	assert.Nil(t, files)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
 }
 
 type kafkaCollectorTestReader struct {

--- a/comp/core/configfilesdiscovery/impl/collectors/redis.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/redis.go
@@ -27,25 +27,27 @@ func NewRedis() configfilesdiscoveryimpl.ConfigCollector {
 	return redisConfigCollector{}
 }
 
-func (c redisConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) ([]configfilesdiscoveryimpl.ConfigFile, error) {
+func (c redisConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (configfilesdiscoveryimpl.CollectedConfig, error) {
 	commandline, err := reader.ReadCommandline(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("read redis command line: %w", err)
+		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read redis command line: %w", err)
 	}
 
 	configPath, ok := redisGetConfigPath(commandline)
 	if !ok {
 		log.Debugf("config files discovery skipped redis config collection: no explicit config file path detected")
-		return nil, nil
+		return configfilesdiscoveryimpl.CollectedConfig{}, nil
 	}
 
 	file, err := reader.ReadFile(ctx, configPath)
 	if err != nil {
-		return nil, fmt.Errorf("read redis config file %q: %w", configPath, err)
+		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read redis config file %q: %w", configPath, err)
 	}
 	file.PayloadFormat = redisConfigPayloadFormat
 
-	return []configfilesdiscoveryimpl.ConfigFile{file}, nil
+	return configfilesdiscoveryimpl.CollectedConfig{
+		ConfigFiles: []configfilesdiscoveryimpl.ConfigFile{file},
+	}, nil
 }
 
 // redisGetConfigPath returns the explicit config file path passed to

--- a/comp/core/configfilesdiscovery/impl/collectors/redis_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/redis_test.go
@@ -139,17 +139,18 @@ func TestRedisCollectorReadsDetectedConfig(t *testing.T) {
 	}
 	collector := NewRedis()
 
-	files, err := collector.Collect(context.Background(), reader)
+	collected, err := collector.Collect(context.Background(), reader)
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
-	require.Len(t, files, 1)
+	require.Len(t, collected.ConfigFiles, 1)
 	assert.Equal(t, configfilesdiscoveryimpl.ConfigFile{
 		Path:          "/etc/redis/redis.conf",
 		Content:       []byte("port 6379\n"),
 		Truncated:     true,
 		PayloadFormat: redisConfigPayloadFormat,
-	}, files[0])
+	}, collected.ConfigFiles[0])
+	assert.Empty(t, collected.EnvVars)
 }
 
 func TestRedisCollectorSkipsWhenNoConfigPathIsDetected(t *testing.T) {
@@ -160,11 +161,12 @@ func TestRedisCollectorSkipsWhenNoConfigPathIsDetected(t *testing.T) {
 	}
 	collector := NewRedis()
 
-	files, err := collector.Collect(context.Background(), reader)
+	collected, err := collector.Collect(context.Background(), reader)
 
 	require.NoError(t, err)
 	assert.Empty(t, reader.readFileCalls)
-	assert.Empty(t, files)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Empty(t, collected.EnvVars)
 }
 
 func TestRedisCollectorReturnsCommandlineErrors(t *testing.T) {
@@ -172,10 +174,10 @@ func TestRedisCollectorReturnsCommandlineErrors(t *testing.T) {
 	reader := &redisCollectorTestReader{commandlineErr: expectedErr}
 	collector := NewRedis()
 
-	files, err := collector.Collect(context.Background(), reader)
+	collected, err := collector.Collect(context.Background(), reader)
 
 	require.ErrorIs(t, err, expectedErr)
-	assert.Nil(t, files)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
 }
 
 func TestRedisCollectorReturnsReadFileErrors(t *testing.T) {
@@ -188,11 +190,11 @@ func TestRedisCollectorReturnsReadFileErrors(t *testing.T) {
 	}
 	collector := NewRedis()
 
-	files, err := collector.Collect(context.Background(), reader)
+	collected, err := collector.Collect(context.Background(), reader)
 
 	require.ErrorIs(t, err, expectedErr)
 	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
-	assert.Nil(t, files)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
 }
 
 type redisCollectorTestReader struct {

--- a/comp/core/configfilesdiscovery/impl/configfilesdiscovery_test.go
+++ b/comp/core/configfilesdiscovery/impl/configfilesdiscovery_test.go
@@ -435,6 +435,9 @@ func TestSchedulerSendsCollectedConfig(t *testing.T) {
 				Truncated: true,
 			},
 		},
+		envVars: []ConfigEnvVar{
+			{Name: "REDIS_PORT", Value: "6379"},
+		},
 	}
 	s := newADScheduler(
 		targetResolver{},
@@ -449,7 +452,7 @@ func TestSchedulerSendsCollectedConfig(t *testing.T) {
 	})
 
 	collectedConfigs := sender.waitForCollectedConfigs(t, 1)
-	assert.Equal(t, collectedConfig{
+	assert.Equal(t, CollectedConfig{
 		Integration: "redisdb",
 		Runtime:     RuntimeDocker,
 		RuntimeID:   "abc123",
@@ -460,7 +463,61 @@ func TestSchedulerSendsCollectedConfig(t *testing.T) {
 				Truncated: true,
 			},
 		},
+		EnvVars: []ConfigEnvVar{
+			{Name: "REDIS_PORT", Value: "6379"},
+		},
 	}, collectedConfigs[0])
+}
+
+func TestSchedulerSendsEnvOnlyCollectedConfig(t *testing.T) {
+	sender := &recordingCollectedConfigSender{}
+	collector := &recordingConfigCollector{
+		envVars: []ConfigEnvVar{
+			{Name: "REDIS_PORT", Value: "6379"},
+			{Name: "REDIS_TLS_ENABLED", Value: "true"},
+		},
+	}
+	s := newADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{"redisdb": collector},
+		sender,
+	)
+	defer s.Stop()
+
+	s.Schedule([]integration.Config{
+		checkConfig("redisdb", "docker://abc123"),
+	})
+
+	collectedConfigs := sender.waitForCollectedConfigs(t, 1)
+	assert.Equal(t, CollectedConfig{
+		Integration: "redisdb",
+		Runtime:     RuntimeDocker,
+		RuntimeID:   "abc123",
+		EnvVars: []ConfigEnvVar{
+			{Name: "REDIS_PORT", Value: "6379"},
+			{Name: "REDIS_TLS_ENABLED", Value: "true"},
+		},
+	}, collectedConfigs[0])
+}
+
+func TestSchedulerSkipsEmptyCollectedConfig(t *testing.T) {
+	sender := &recordingCollectedConfigSender{}
+	collector := &recordingConfigCollector{}
+	s := newADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{"redisdb": collector},
+		sender,
+	)
+
+	s.Schedule([]integration.Config{
+		checkConfig("redisdb", "docker://abc123"),
+	})
+
+	collector.waitForRuns(t, 1)
+	s.Stop()
+	assert.Empty(t, sender.recordedBatches())
 }
 
 func TestSchedulerBatchesMultipleCompletedConfigCollections(t *testing.T) {
@@ -569,6 +626,15 @@ func TestSchedulerFlushesOversizedConfigCollectionAlone(t *testing.T) {
 	assert.Greater(t, collectedConfigRawBytes(batches[0][0]), configCollectionBatchMaxRawConfigBytes)
 }
 
+func TestSchedulerCountsEnvVarsInCollectedConfigRawBytes(t *testing.T) {
+	assert.Equal(t, len("REDIS_PORT")+len("6379")+len("REDIS_TLS_ENABLED")+len("true"), collectedConfigRawBytes(CollectedConfig{
+		EnvVars: []ConfigEnvVar{
+			{Name: "REDIS_PORT", Value: "6379"},
+			{Name: "REDIS_TLS_ENABLED", Value: "true"},
+		},
+	}))
+}
+
 func TestSchedulerFlushesPendingConfigCollectionBatchOnStop(t *testing.T) {
 	sender := &recordingCollectedConfigSender{}
 	collector := &recordingConfigCollector{
@@ -654,7 +720,7 @@ func TestEventPlatformSenderSendsAgentDiscoveryPayload(t *testing.T) {
 	}, "test-host")
 
 	beforeSend := time.Now()
-	err := sender.SendCollectedConfigs([]collectedConfig{
+	err := sender.SendCollectedConfigs([]CollectedConfig{
 		{
 			Integration: testRedisIntegrationName,
 			Runtime:     RuntimeDocker,
@@ -672,6 +738,10 @@ func TestEventPlatformSenderSendsAgentDiscoveryPayload(t *testing.T) {
 					Truncated:     false,
 					PayloadFormat: testRedisConfigPayloadFormat,
 				},
+			},
+			EnvVars: []ConfigEnvVar{
+				{Name: "REDIS_PORT", Value: "6379"},
+				{Name: "REDIS_TLS_ENABLED", Value: "true"},
 			},
 		},
 		{
@@ -731,6 +801,16 @@ func TestEventPlatformSenderSendsAgentDiscoveryPayload(t *testing.T) {
 						PayloadFormat: testRedisConfigPayloadFormat,
 					},
 				},
+				EnvVars: []*agentdiscovery.AgentDiscoveryEnvVar{
+					{
+						Name:  "REDIS_PORT",
+						Value: "6379",
+					},
+					{
+						Name:  "REDIS_TLS_ENABLED",
+						Value: "true",
+					},
+				},
 			},
 			{
 				Integration:        testRedisIntegrationName,
@@ -757,7 +837,7 @@ func TestEventPlatformSenderSkipsEmptyCollections(t *testing.T) {
 		ok:        true,
 	}, "test-host")
 
-	err := sender.SendCollectedConfigs([]collectedConfig{
+	err := sender.SendCollectedConfigs([]CollectedConfig{
 		{
 			Integration: testRedisIntegrationName,
 			Runtime:     RuntimeDocker,
@@ -775,7 +855,7 @@ func TestEventPlatformSenderReturnsSendError(t *testing.T) {
 		ok:        true,
 	}, "test-host")
 
-	err := sender.SendCollectedConfigs([]collectedConfig{
+	err := sender.SendCollectedConfigs([]CollectedConfig{
 		{
 			Integration: testRedisIntegrationName,
 			Runtime:     RuntimeDocker,
@@ -831,6 +911,7 @@ type recordingConfigCollector struct {
 	runs    []runCall
 	unblock chan struct{}
 	files   []ConfigFile
+	envVars []ConfigEnvVar
 	err     error
 }
 
@@ -838,11 +919,11 @@ type runCall struct {
 	reader ConfigReader
 }
 
-func (c *recordingConfigCollector) Collect(ctx context.Context, reader ConfigReader) ([]ConfigFile, error) {
+func (c *recordingConfigCollector) Collect(ctx context.Context, reader ConfigReader) (CollectedConfig, error) {
 	if c.unblock != nil {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return CollectedConfig{}, ctx.Err()
 		case <-c.unblock:
 		}
 	}
@@ -852,25 +933,31 @@ func (c *recordingConfigCollector) Collect(ctx context.Context, reader ConfigRea
 	c.runs = append(c.runs, runCall{
 		reader: reader,
 	})
-	return c.files, c.err
+	if c.err != nil {
+		return CollectedConfig{}, c.err
+	}
+	return CollectedConfig{
+		ConfigFiles: c.files,
+		EnvVars:     c.envVars,
+	}, nil
 }
 
 type recordingCollectedConfigSender struct {
 	mu      sync.Mutex
-	batches [][]collectedConfig
+	batches [][]CollectedConfig
 	err     error
 }
 
-func (r *recordingCollectedConfigSender) SendCollectedConfigs(configs []collectedConfig) error {
+func (r *recordingCollectedConfigSender) SendCollectedConfigs(configs []CollectedConfig) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	copiedConfigs := make([]collectedConfig, len(configs))
+	copiedConfigs := make([]CollectedConfig, len(configs))
 	copy(copiedConfigs, configs)
 	r.batches = append(r.batches, copiedConfigs)
 	return r.err
 }
 
-func (r *recordingCollectedConfigSender) waitForCollectedConfigs(t *testing.T, count int) []collectedConfig {
+func (r *recordingCollectedConfigSender) waitForCollectedConfigs(t *testing.T, count int) []CollectedConfig {
 	t.Helper()
 
 	require.Eventually(t, func() bool {
@@ -884,7 +971,7 @@ func (r *recordingCollectedConfigSender) waitForCollectedConfigs(t *testing.T, c
 	return r.flattenCollectedConfigsLocked()
 }
 
-func (r *recordingCollectedConfigSender) waitForBatches(t *testing.T, count int) [][]collectedConfig {
+func (r *recordingCollectedConfigSender) waitForBatches(t *testing.T, count int) [][]CollectedConfig {
 	t.Helper()
 
 	require.Eventually(t, func() bool {
@@ -893,18 +980,22 @@ func (r *recordingCollectedConfigSender) waitForBatches(t *testing.T, count int)
 		return len(r.batches) >= count
 	}, 2*time.Second, 10*time.Millisecond)
 
+	return r.recordedBatches()
+}
+
+func (r *recordingCollectedConfigSender) recordedBatches() [][]CollectedConfig {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	batches := make([][]collectedConfig, len(r.batches))
+	batches := make([][]CollectedConfig, len(r.batches))
 	for i, batch := range r.batches {
-		batches[i] = make([]collectedConfig, len(batch))
+		batches[i] = make([]CollectedConfig, len(batch))
 		copy(batches[i], batch)
 	}
 	return batches
 }
 
-func (r *recordingCollectedConfigSender) flattenCollectedConfigsLocked() []collectedConfig {
-	var configs []collectedConfig
+func (r *recordingCollectedConfigSender) flattenCollectedConfigsLocked() []CollectedConfig {
+	var configs []CollectedConfig
 	for _, batch := range r.batches {
 		configs = append(configs, batch...)
 	}

--- a/comp/core/configfilesdiscovery/impl/evp_reporter.go
+++ b/comp/core/configfilesdiscovery/impl/evp_reporter.go
@@ -37,7 +37,7 @@ func newEventPlatformCollectedConfigSender(eventPlatform eventplatform.Component
 	return &eventPlatformCollectedConfigSender{forwarder: forwarder, hostID: hostID}
 }
 
-func (r *eventPlatformCollectedConfigSender) SendCollectedConfigs(configs []collectedConfig) error {
+func (r *eventPlatformCollectedConfigSender) SendCollectedConfigs(configs []CollectedConfig) error {
 	payloads := make([]*agentdiscovery.AgentDiscoveryPayload, 0, len(configs))
 	for _, config := range configs {
 		payload := agentDiscoveryPayloadFromCollectedConfig(config, time.Now())
@@ -65,7 +65,7 @@ func (r *eventPlatformCollectedConfigSender) SendCollectedConfigs(configs []coll
 	return nil
 }
 
-func agentDiscoveryPayloadFromCollectedConfig(config collectedConfig, ingestionTimestamp time.Time) *agentdiscovery.AgentDiscoveryPayload {
+func agentDiscoveryPayloadFromCollectedConfig(config CollectedConfig, ingestionTimestamp time.Time) *agentdiscovery.AgentDiscoveryPayload {
 	if len(config.ConfigFiles) == 0 && len(config.EnvVars) == 0 {
 		return nil
 	}

--- a/comp/core/configfilesdiscovery/impl/scheduler.go
+++ b/comp/core/configfilesdiscovery/impl/scheduler.go
@@ -45,26 +45,18 @@ type configCollectionWork struct {
 	readerFactory configReaderFactory
 }
 
-type collectedConfig struct {
-	Integration string
-	Runtime     RuntimeType
-	RuntimeID   string
-	ConfigFiles []ConfigFile
-	EnvVars     []ConfigEnvVar
-}
-
 type collectedConfigSender interface {
-	SendCollectedConfigs([]collectedConfig) error
+	SendCollectedConfigs([]CollectedConfig) error
 }
 
 type noopCollectedConfigSender struct{}
 
-func (noopCollectedConfigSender) SendCollectedConfigs([]collectedConfig) error {
+func (noopCollectedConfigSender) SendCollectedConfigs([]CollectedConfig) error {
 	return nil
 }
 
 type collectedConfigBatch struct {
-	configs        []collectedConfig
+	configs        []CollectedConfig
 	rawConfigBytes int
 }
 
@@ -72,7 +64,7 @@ func (b *collectedConfigBatch) hasConfigs() bool {
 	return len(b.configs) > 0
 }
 
-func (b *collectedConfigBatch) add(config collectedConfig) {
+func (b *collectedConfigBatch) add(config CollectedConfig) {
 	b.configs = append(b.configs, config)
 	b.rawConfigBytes += collectedConfigRawBytes(config)
 }
@@ -81,22 +73,25 @@ func (b *collectedConfigBatch) shouldFlush() bool {
 	return len(b.configs) >= configCollectionBatchMaxCollectedConfigs || b.rawConfigBytes >= configCollectionBatchMaxRawConfigBytes
 }
 
-func (b *collectedConfigBatch) wouldExceedByteLimit(config collectedConfig) bool {
+func (b *collectedConfigBatch) wouldExceedByteLimit(config CollectedConfig) bool {
 	return b.hasConfigs() && b.rawConfigBytes+collectedConfigRawBytes(config) > configCollectionBatchMaxRawConfigBytes
 }
 
-func (b *collectedConfigBatch) takeConfigs() []collectedConfig {
-	configs := make([]collectedConfig, len(b.configs))
+func (b *collectedConfigBatch) takeConfigs() []CollectedConfig {
+	configs := make([]CollectedConfig, len(b.configs))
 	copy(configs, b.configs)
 	b.configs = nil
 	b.rawConfigBytes = 0
 	return configs
 }
 
-func collectedConfigRawBytes(config collectedConfig) int {
+func collectedConfigRawBytes(config CollectedConfig) int {
 	var size int
 	for _, file := range config.ConfigFiles {
 		size += len(file.Content)
+	}
+	for _, envVar := range config.EnvVars {
+		size += len(envVar.Name) + len(envVar.Value)
 	}
 	return size
 }
@@ -205,7 +200,7 @@ func (s *adScheduler) runCollectionWorker() {
 			case <-s.ctx.Done():
 				return false
 			default:
-				log.Warnf("failed to send collected config files batch with %d collected configs: %v", len(configs), err)
+				log.Warnf("failed to send collected config batch with %d collected configs: %v", len(configs), err)
 			}
 		}
 		return true
@@ -240,43 +235,39 @@ func (s *adScheduler) runCollectionWorker() {
 }
 
 // runCollection executes one queued config collection. Returns a collected
-// config and true when collection succeeds and produces at least one config
-// file. Returns an empty collected config and false when there is nothing to add
-// to the batch.
-func (s *adScheduler) runCollection(work configCollectionWork) (collectedConfig, bool) {
+// config and true when collection succeeds and produces config data. Returns an
+// empty collected config and false when there is nothing to add to the batch.
+func (s *adScheduler) runCollection(work configCollectionWork) (CollectedConfig, bool) {
 	reader, err := work.readerFactory(work.target)
 	if err != nil {
 		log.Warnf("failed to build config reader for integration %q service %q runtime %q: %v", work.config.Name, work.config.ServiceID, work.target.runtime, err)
-		return collectedConfig{}, false
+		return CollectedConfig{}, false
 	}
 	defer reader.Close()
 
-	files, err := work.collector.Collect(s.ctx, reader)
+	collected, err := work.collector.Collect(s.ctx, reader)
 	if err != nil {
 		select {
 		case <-s.ctx.Done():
-			return collectedConfig{}, false
+			return CollectedConfig{}, false
 		default:
-			log.Warnf("failed to collect config files for integration %q service %q: %v", work.config.Name, work.config.ServiceID, err)
-			return collectedConfig{}, false
+			log.Warnf("failed to collect config data for integration %q service %q: %v", work.config.Name, work.config.ServiceID, err)
+			return CollectedConfig{}, false
 		}
 	}
 
-	if len(files) == 0 {
-		return collectedConfig{}, false
+	if len(collected.ConfigFiles) == 0 && len(collected.EnvVars) == 0 {
+		return CollectedConfig{}, false
 	}
 
-	config := collectedConfig{
-		Integration: work.config.Name,
-		Runtime:     work.target.runtime,
-		RuntimeID:   work.target.entityID,
-		ConfigFiles: files,
-	}
+	collected.Integration = work.config.Name
+	collected.Runtime = work.target.runtime
+	collected.RuntimeID = work.target.entityID
 
-	for _, file := range files {
+	for _, file := range collected.ConfigFiles {
 		log.Debugf("config files discovery collected config file: integration %q path %q size_bytes %d truncated %t", work.config.Name, file.Path, len(file.Content), file.Truncated)
 	}
-	return config, true
+	return collected, true
 }
 
 // Unschedule is required by the autodiscovery scheduler interface. Config file

--- a/comp/core/configfilesdiscovery/impl/types.go
+++ b/comp/core/configfilesdiscovery/impl/types.go
@@ -45,6 +45,15 @@ type ConfigEnvVar struct {
 	Value string
 }
 
+// CollectedConfig is the config data collected for one integration target.
+type CollectedConfig struct {
+	Integration string
+	Runtime     RuntimeType
+	RuntimeID   string
+	ConfigFiles []ConfigFile
+	EnvVars     []ConfigEnvVar
+}
+
 // TargetCommandline is the command line used to start the target service.
 type TargetCommandline struct {
 	Args       []string
@@ -62,9 +71,9 @@ type ConfigReader interface {
 
 type configReaderFactory func(target) (ConfigReader, error)
 
-// ConfigCollector reads integration-specific config files through a collector reader.
+// ConfigCollector reads integration-specific config data through a collector reader.
 type ConfigCollector interface {
-	Collect(context.Context, ConfigReader) ([]ConfigFile, error)
+	Collect(context.Context, ConfigReader) (CollectedConfig, error)
 }
 
 type targetResolver struct {


### PR DESCRIPTION
### What does this PR do?

Adds the config files discovery scaffolding needed to collect config files and environment variables through the same scheduler/sender path.

- Exports `CollectedConfig` as the shared collector result type.
- Changes collectors to return `CollectedConfig` instead of only `[]ConfigFile`.
- Updates scheduler batching to send file-only, env-only, and mixed collections.
- Includes env var name/value sizes in batch raw-byte accounting.
- Keeps Redis and Kafka file-only for now by returning `CollectedConfig{ConfigFiles: ...}`.
- Extends sender and scheduler tests for env-var payloads.

### Motivation

DSCVR-590

### Describe how you validated your changes

Unit tests. Per-integration tests will be added in follow-up PRs that adds allowlists for env vars.

### Additional Notes

This PR does not add per-integration env var allowlists. Redis and Kafka remain file-only in this slice; env vars are only sent when a collector explicitly returns them.

Docker & k8s config readers already have code to get env variables.