### PR TITLE
Remove most Bazel analysis cache thrashing in CI

### DIFF
--- a/omnibus/config/projects/agent-binaries.rb
+++ b/omnibus/config/projects/agent-binaries.rb
@@ -12,15 +12,11 @@ license_file "../LICENSE"
 
 homepage 'http://www.datadoghq.com'
 
+install_dir ENV["INSTALL_DIR"] || raise('INSTALL_DIR must be set in tasks/omnibus.py')
+
 if ohai['platform'] == "windows"
-  # Note: this is not the final install dir, not even the default one, just a convenient
-  # spaceless dir in which the agent will be built.
-  # Omnibus doesn't quote the Git commands it launches unfortunately, which makes it impossible
-  # to put a space here...
-  install_dir "C:/opt/datadog-agent/"
   maintainer 'Datadog Inc.' # Windows doesn't want our e-mail address :(
 else
-  install_dir ENV["INSTALL_DIR"] || '/opt/datadog-agent'
   maintainer 'Datadog Packages <package@datadoghq.com>'
 end
 

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -42,14 +42,10 @@ if ENV.has_key?("OMNIBUS_GIT_CACHE_DIR") && !BUILD_OCIRU
   Omnibus::Config.git_cache_dir ENV["OMNIBUS_GIT_CACHE_DIR"]
 end
 
+INSTALL_DIR = ENV["INSTALL_DIR"] || raise('INSTALL_DIR must be set in tasks/omnibus.py')
+
 if windows_target?
-  # Note: this is the path used by Omnibus to build the agent, the final install
-  # dir will be determined by the Windows installer. This path must not contain
-  # spaces because Omnibus doesn't quote the Git commands it launches.
-  INSTALL_DIR = 'C:/opt/datadog-agent/'
   PYTHON_3_EMBEDDED_DIR = format('%s/embedded3', INSTALL_DIR)
-else
-  INSTALL_DIR = ENV["INSTALL_DIR"] || '/opt/datadog-agent'
 end
 
 install_dir INSTALL_DIR

--- a/omnibus/config/projects/ddot.rb
+++ b/omnibus/config/projects/ddot.rb
@@ -38,15 +38,7 @@ if ENV.has_key?("OMNIBUS_GIT_CACHE_DIR")
   Omnibus::Config.git_cache_dir ENV["OMNIBUS_GIT_CACHE_DIR"]
 end
 
-if windows_target?
-  # Note: this is the path used by Omnibus to build the agent, the final install
-  # dir will be determined by the Windows installer. This path must not contain
-  # spaces because Omnibus doesn't quote the Git commands it launches.
-  INSTALL_DIR = 'C:/opt/datadog-agent'
-else
-  INSTALL_DIR = ENV["INSTALL_DIR"] || '/opt/datadog-agent'
-end
-
+INSTALL_DIR = ENV["INSTALL_DIR"] || raise('INSTALL_DIR must be set in tasks/omnibus.py')
 install_dir INSTALL_DIR
 
 third_party_licenses_path "LICENSES-ddot"

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -24,14 +24,11 @@ else
   COMPRESSION_LEVEL = 5
 end
 
+install_dir ENV["INSTALL_DIR"] || raise('INSTALL_DIR must be set in tasks/omnibus.py')
+
 if ohai['platform'] == "windows"
-  # Note: this is the path used by Omnibus to build the agent, the final install
-  # dir will be determined by the Windows installer. This path must not contain
-  # spaces because Omnibus doesn't quote the Git commands it launches.
-  install_dir "C:/opt/datadog-dogstatsd/"
   maintainer 'Datadog Inc.' # Windows doesn't want our e-mail address :(
 else
-  install_dir ENV["INSTALL_DIR"] || '/opt/datadog-dogstatsd'
   if redhat_target? || suse_target?
     maintainer 'Datadog, Inc <package@datadoghq.com>'
 

--- a/omnibus/config/projects/eudm.rb
+++ b/omnibus/config/projects/eudm.rb
@@ -32,10 +32,7 @@ if ENV.has_key?("OMNIBUS_GIT_CACHE_DIR")
   Omnibus::Config.git_cache_dir ENV["OMNIBUS_GIT_CACHE_DIR"]
 end
 
-# Dedicated install_dir so the produced ZIP unzips to the flat ext/eudm/ layout the extension
-# hook expects (binary + example config at the root). Must not contain spaces (Omnibus does not
-# quote the Git commands it launches). Matches EUDM_ARTIFACT_DIR in tasks/msi.py.
-INSTALL_DIR = 'C:/opt/datadog-agent-eudm'
+INSTALL_DIR = ENV['INSTALL_DIR'] || raise('INSTALL_DIR must be set in tasks/omnibus.py')
 install_dir INSTALL_DIR
 
 third_party_licenses_path "LICENSES-eudm"

--- a/omnibus/config/projects/installer.rb
+++ b/omnibus/config/projects/installer.rb
@@ -20,12 +20,7 @@ third_party_licenses "../LICENSE-3rdparty.csv"
 
 homepage 'http://www.datadoghq.com'
 
-if windows_target?
-  INSTALL_DIR = 'C:/opt/datadog-installer/'
-else
-  INSTALL_DIR = ENV['INSTALL_DIR'] || '/opt/datadog-installer'
-end
-
+INSTALL_DIR = ENV['INSTALL_DIR'] || raise('INSTALL_DIR must be set in tasks/omnibus.py')
 install_dir INSTALL_DIR
 
 if ENV.has_key?("OMNIBUS_WORKERS_OVERRIDE")

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -12,15 +12,11 @@ license_file "../LICENSE"
 
 homepage 'http://www.datadoghq.com'
 
+install_dir ENV["INSTALL_DIR"] || raise('INSTALL_DIR must be set in tasks/omnibus.py')
+
 if ohai['platform'] == "windows"
-  # Note: this is not the final install dir, not even the default one, just a convenient
-  # spaceless dir in which the agent will be built.
-  # Omnibus doesn't quote the Git commands it launches unfortunately, which makes it impossible
-  # to put a space here...
-  install_dir "C:/opt/datadog-agent/"
   maintainer 'Datadog Inc.' # Windows doesn't want our e-mail address :(
 else
-  install_dir ENV["INSTALL_DIR"] || '/opt/datadog-agent'
   if redhat_target? || suse_target?
     maintainer 'Datadog, Inc <package@datadoghq.com>'
 

--- a/omnibus/config/software/ai-usage-agent.rb
+++ b/omnibus/config/software/ai-usage-agent.rb
@@ -28,6 +28,6 @@ build do
   #   <install_dir>/ai_usage_native_host.yaml.example
   # (see pkg/fleet/installer/packages/datadog_agent_eudm_windows.go).
   if windows_target?
-    command "bazel run -- //cmd/ai_prompt_logger:install-extension --destdir=#{install_dir}", :live_stream => Omnibus.logger.live_stream(:info)
+    command "bazel run #{omnibazel_flags} -- //cmd/ai_prompt_logger:install-extension --destdir=#{install_dir}", :live_stream => Omnibus.logger.live_stream(:info)
   end
 end

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -2,18 +2,12 @@ name 'datadog-agent-dependencies'
 
 description "Enforce building dependencies as soon as possible so they can be cached"
 
-if heroku_target?
-  flavor_flag = "--//packages/agent:flavor=heroku"
-else
-  flavor_flag = fips_mode? ? "--//packages/agent:flavor=fips" : ""
-end
-
 dependency 'datadog-agent-data-plane' if (linux_target? || osx_target? || windows_target?) && !heroku_target?
 
 dependency 'datadog-agent-integrations-py3'
 
 build do
-    command "bazel run --//:install_dir=#{install_dir} #{flavor_flag} -- //packages/agent/dependencies:install --destdir=#{install_dir}",
+    command "bazel run #{omnibazel_flags} -- //packages/agent/dependencies:install --destdir=#{install_dir}",
         :live_stream => Omnibus.logger.live_stream(:info)
 end
 

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -21,20 +21,18 @@ build do
     license :project_license
 
     output_config_dir = ENV["OUTPUT_CONFIG_DIR"]
-    flavor_arg = ENV['AGENT_FLAVOR']
     # TODO too many things done here, should be split
     block do
         # Push all the pieces built with Bazel.
 
-        # TODO: flavor can be defaulted and set from the bazel wrapper based on the environment.
-        command "bazel run --//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/install_dir:install",
+        command "bazel run #{omnibazel_flags} -- //packages/install_dir:install",
             :live_stream => Omnibus.logger.live_stream(:info)
 
         if linux_target?
-            command "bazel run --//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/agent/linux:license_files_install --destdir=#{install_dir}",
+            command "bazel run #{omnibazel_flags} -- //packages/agent/linux:license_files_install --destdir=#{install_dir}",
                 :live_stream => Omnibus.logger.live_stream(:info)
         elsif osx_target?
-            command "bazel run --//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/agent/dependencies:license_files_install --destdir=#{install_dir}",
+            command "bazel run #{omnibazel_flags} -- //packages/agent/dependencies:license_files_install --destdir=#{install_dir}",
                 :live_stream => Omnibus.logger.live_stream(:info)
         end
 

--- a/omnibus/config/software/datadog-agent-installer-symlinks.rb
+++ b/omnibus/config/software/datadog-agent-installer-symlinks.rb
@@ -11,7 +11,7 @@ build do
   block do
     if linux_target? and install_dir == '/opt/datadog-agent'
       destdir = ENV["OMNIBUS_BASE_DIR"] || "/"
-      command "bazel run --//:install_dir=#{install_dir} -- //packages/agent/linux:install --destdir='#{destdir}'",
+      command "bazel run #{omnibazel_flags} -- //packages/agent/linux:install --destdir='#{destdir}'",
         :live_stream => Omnibus.logger.live_stream(:info)
       project.extra_package_file "/opt/datadog-packages/datadog-agent"
       project.extra_package_file "/opt/datadog-packages/run"

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -30,10 +30,7 @@ build do
   end
 
   # Install integrations and their configs
-  command "bazel run " \
-          "--//packages/agent:flavor=#{ENV.fetch('AGENT_FLAVOR', 'base')} " \
-          "--//:install_dir=#{install_dir} " \
-          "-- //deps/agent_integrations:install --destdir=#{install_dir}",
+  command "bazel run #{omnibazel_flags} -- //deps/agent_integrations:install --destdir=#{install_dir}",
     :live_stream => Omnibus.logger.live_stream(:info)
 
   # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -10,15 +10,6 @@ require 'pathname'
 
 name 'datadog-agent'
 
-# Flavor flag for bazel actions
-flavor_flag = ""
-if heroku_target?
-  flavor_flag = "--//packages/agent:flavor=heroku"
-elsif fips_mode?
-  flavor_flag = "--//packages/agent:flavor=fips"
-end
-bazel_flags = "#{flavor_flag} --//:install_dir='#{install_dir}'"
-
 # We don't want to build any dependencies in "repackaging mode" so all usual dependencies
 # need to go under this guard.
 unless do_repackage?
@@ -83,20 +74,20 @@ build do
     if ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?
       do_windows_sysprobe = "--windows-sysprobe"
     end
-    command "bazel run #{bazel_flags} -- //rtloader:install --destdir=\"#{install_dir}",
+    command "bazel run #{omnibazel_flags} -- //rtloader:install --destdir=\"#{install_dir}",
       :live_stream => Omnibus.logger.live_stream(:info)
     # Put the static rtloader library where it gets picked up by the go build linking to it
-    command "bazel run #{bazel_flags} -- //rtloader:install_static --destdir=\"#{project_dir}/rtloader/build/rtloader\"",
+    command "bazel run #{omnibazel_flags} -- //rtloader:install_static --destdir=\"#{project_dir}/rtloader/build/rtloader\"",
       :live_stream => Omnibus.logger.live_stream(:info)
     command "dda inv -- -e agent.build --exclude-rtloader --no-development --install-path=#{install_dir} --embedded-path=#{install_dir}/embedded #{do_windows_sysprobe} --flavor #{flavor_arg}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     command "dda inv -- -e systray.build", env: env, :live_stream => Omnibus.logger.live_stream(:info)
   else
-    command "bazel run #{bazel_flags} -- //rtloader:install --destdir='#{install_dir}'",
+    command "bazel run #{omnibazel_flags} -- //rtloader:install --destdir='#{install_dir}'",
       :live_stream => Omnibus.logger.live_stream(:info)
     command "dda inv -- -e agent.build --exclude-rtloader --no-development --install-path=#{install_dir} --embedded-path=#{install_dir}/embedded --flavor #{flavor_arg}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
   end
 
-  command "bazel run #{bazel_flags} -- //packages/agent/product:post_build_install --destdir=#{install_dir} --verbose", :live_stream => Omnibus.logger.live_stream(:info)
+  command "bazel run #{omnibazel_flags} -- //packages/agent/product:post_build_install --destdir=#{install_dir} --verbose", :live_stream => Omnibus.logger.live_stream(:info)
 
   # TODO: dda inv agent.build also builds datadog.yaml. We need to work with the
   # config team to find out if removing that will break their workflow.  If not,
@@ -113,7 +104,7 @@ build do
   # Stage Rust shared-library checks into checks.d (Linux only). Enabled checks
   # are listed in ENABLED_CHECKS in the rustchecks BUILD.bazel.
   if linux_target?
-    command "bazel run //pkg/collector/sharedlibrary/rustchecks:install -- --destdir=\"#{conf_dir}\"",
+    command "bazel run #{omnibazel_flags} //pkg/collector/sharedlibrary/rustchecks:install -- --destdir=\"#{conf_dir}\"",
       env: env,
       :live_stream => Omnibus.logger.live_stream(:info)
   end
@@ -253,12 +244,12 @@ build do
 
   # sd-agent (service discovery agent)
   if linux_target? and !heroku_target?
-    command "bazel run #{bazel_flags} //pkg/discovery/module/rust:install -- --destdir=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
+    command "bazel run #{omnibazel_flags} //pkg/discovery/module/rust:install -- --destdir=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
   end
 
   # dd-procmgrd (process manager daemon)
   if (linux_target? || windows_target?) && !heroku_target?
-    command "bazel run #{bazel_flags} //pkg/procmgr/rust:install -- --destdir=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
+    command "bazel run #{omnibazel_flags} //pkg/procmgr/rust:install -- --destdir=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
   end
 
   # Security agent
@@ -293,9 +284,9 @@ build do
   end
 
   if osx_target?
-    command "bazel run #{bazel_flags} -- //packages/macos/app:install --destdir=#{install_dir}", :live_stream => Omnibus.logger.live_stream(:info)
+    command "bazel run #{omnibazel_flags} -- //packages/macos/app:install --destdir=#{install_dir}", :live_stream => Omnibus.logger.live_stream(:info)
 
-    command "bazel run #{bazel_flags} -- //cmd/ai_prompt_logger:install --destdir=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
+    command "bazel run #{omnibazel_flags} -- //cmd/ai_prompt_logger:install --destdir=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
 
     # Systray GUI
     app_temp_dir = "#{install_dir}/Datadog Agent.app/Contents"

--- a/omnibus/config/software/datadog-dogstatsd.rb
+++ b/omnibus/config/software/datadog-dogstatsd.rb
@@ -48,7 +48,7 @@ build do
     end
     # Bazel places the yaml example, init scripts, service file, and creates
     # /etc/datadog-dogstatsd/ and /var/log/datadog/.
-    command_on_repo_root "bazel run --//:install_dir=#{install_dir} -- #{install_target} --destdir=/",
+    command "bazel run #{omnibazel_flags} -- #{install_target} --destdir=/",
       :live_stream => Omnibus.logger.live_stream(:info)
     mkdir "#{install_dir}/run"
     mkdir "#{install_dir}/scripts"

--- a/omnibus/config/software/datadog-iot-agent.rb
+++ b/omnibus/config/software/datadog-iot-agent.rb
@@ -52,12 +52,12 @@ build do
     delete 'bin/agent/dist/datadog.yaml'
 
     # Installs: bin/ and run/ dirs
-    command "bazel run --//packages/agent:flavor=iot --//:install_dir='#{install_dir}' -- " \
+    command "bazel run #{omnibazel_flags} -- " \
             "//packages/agent/iot:install --destdir=#{install_dir}", :live_stream => Omnibus.logger.live_stream(:info)
     copy 'bin/agent', "#{install_dir}/bin/"
 
     # Installs: example yaml
-    command "bazel run --//packages/agent:flavor=iot --//:install_dir='#{install_dir}' -- " \
+    command "bazel run #{omnibazel_flags} -- " \
             "//packages/agent/iot:install_example_config --destdir=/", :live_stream => Omnibus.logger.live_stream(:info)
 
     # /var/log/datadog is a runtime directory; not managed by Bazel packaging.

--- a/omnibus/config/software/init-scripts-agent.rb
+++ b/omnibus/config/software/init-scripts-agent.rb
@@ -14,7 +14,7 @@ build do
     if debian_target?
       # building into / is not acceptable. We'll continue to to that for now,
       # but the replacement has to build to a build output tree.
-      command "bazel run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/debian/etc:install --verbose --destdir=#{destdir}",
+      command "bazel run #{omnibazel_flags} -- //packages/debian/etc:install --verbose --destdir=#{destdir}",
         :live_stream => Omnibus.logger.live_stream(:info)
 
       # sysvinit support for debian only for now
@@ -27,7 +27,7 @@ build do
       project.extra_package_file '/etc/init.d/datadog-agent-data-plane'
       project.extra_package_file '/etc/init.d/datadog-agent-action'
     elsif redhat_target? || suse_target?
-      command "bazel run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/redhat/etc:install --verbose --destdir=#{destdir}",
+      command "bazel run #{omnibazel_flags} -- //packages/redhat/etc:install --verbose --destdir=#{destdir}",
         :live_stream => Omnibus.logger.live_stream(:info)
     end
     project.extra_package_file '/etc/init/datadog-agent.conf'

--- a/omnibus/config/software/init-scripts-ddot.rb
+++ b/omnibus/config/software/init-scripts-ddot.rb
@@ -7,16 +7,15 @@ always_build true
 build do
   # This is horrible.
   destdir = "/"
-  output_config_dir = ENV["OUTPUT_CONFIG_DIR"] || ""
   if linux_target?
     if debian_target?
-      command "bazel run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/ddot/debian:install --verbose --destdir=#{destdir}",
+      command "bazel run #{omnibazel_flags} -- //packages/ddot/debian:install --verbose --destdir=#{destdir}",
         :live_stream => Omnibus.logger.live_stream(:info)
 
       project.extra_package_file '/etc/init.d/datadog-agent-ddot'
       project.extra_package_file '/etc/init/datadog-agent-ddot.conf'
     elsif redhat_target? || suse_target?
-      command "bazel run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/ddot/redhat:install --verbose --destdir=#{destdir}",
+      command "bazel run #{omnibazel_flags} -- //packages/ddot/redhat:install --verbose --destdir=#{destdir}",
         :live_stream => Omnibus.logger.live_stream(:info)
 
       project.extra_package_file '/etc/init/datadog-agent-ddot.conf'

--- a/omnibus/config/software/init-scripts-iot-agent.rb
+++ b/omnibus/config/software/init-scripts-iot-agent.rb
@@ -7,17 +7,17 @@ always_build true
 build do
   if debian_target?
     # Installs: etc/init/datadog-agent.conf (upstart) and lib/systemd/system/datadog-agent.service.
-    command "bazel run --//packages/agent:flavor=iot --//:install_dir='#{install_dir}' -- //packages/agent/iot/debian:install --destdir=/", :live_stream => Omnibus.logger.live_stream(:info)
+    command "bazel run #{omnibazel_flags} -- //packages/agent/iot/debian:install --destdir=/", :live_stream => Omnibus.logger.live_stream(:info)
     project.extra_package_file '/etc/init/datadog-agent.conf'
     project.extra_package_file '/lib/systemd/system/datadog-agent.service'
   elsif redhat_target?
     # Installs: etc/init/datadog-agent.conf (upstart) and usr/lib/systemd/system/datadog-agent.service.
-    command "bazel run --//packages/agent:flavor=iot --//:install_dir='#{install_dir}' -- //packages/agent/iot/redhat:install --destdir=/", :live_stream => Omnibus.logger.live_stream(:info)
+    command "bazel run #{omnibazel_flags} -- //packages/agent/iot/redhat:install --destdir=/", :live_stream => Omnibus.logger.live_stream(:info)
     project.extra_package_file '/etc/init/datadog-agent.conf'
     project.extra_package_file '/usr/lib/systemd/system/datadog-agent.service'
   elsif suse_target?
     # SUSE does not use upstart; only the systemd unit is installed.
-    command "bazel run --//packages/agent:flavor=iot --//:install_dir='#{install_dir}' -- //packages/agent/iot/redhat:systemd_install --destdir=/", :live_stream => Omnibus.logger.live_stream(:info)
+    command "bazel run #{omnibazel_flags} -- //packages/agent/iot/redhat:systemd_install --destdir=/", :live_stream => Omnibus.logger.live_stream(:info)
     project.extra_package_file '/usr/lib/systemd/system/datadog-agent.service'
   end
 end

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -45,8 +45,6 @@ build do
     add_msgo_to_env(env)
   end
 
-  bazel_flags = "--//:install_dir=#{install_dir}"
-
   if linux_target?
     command "invoke installer.build #{fips_args} --no-cgo --run-path=/opt/datadog-packages/run --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     mkdir "#{install_dir}/bin"
@@ -60,9 +58,9 @@ build do
     end
 
     # Build both packages and dump them where gitlab will upload them.
-    command "bazel build #{bazel_flags} //packages/installer/linux:whole_distro_tar_deb", env: env, :live_stream => Omnibus.logger.live_stream(:info)
+    command "bazel build #{omnibazel_flags} //packages/installer/linux:whole_distro_tar_deb", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     # There are no convenience symlinks, so we need to do some path manipulations to get the absolute path.
-    command "bazel cquery #{bazel_flags} --output=files //packages/installer/linux:whole_distro_tar_deb | sed -e 's@bazel-out/@@' >/tmp/installer_linux_tar_deb_file.txt"
+    command "bazel cquery #{omnibazel_flags} --output=files //packages/installer/linux:whole_distro_tar_deb | sed -e 's@bazel-out/@@' >/tmp/installer_linux_tar_deb_file.txt"
     command "tar tvf $(bazel info output_path)/$(cat /tmp/installer_linux_tar_deb_file.txt)", :live_stream => Omnibus.logger.live_stream(:info)
 
     # Copy both the .deb and .rpm out to artifact outputs
@@ -75,7 +73,7 @@ build do
       omnibus_package_dir = "#{ci_project_dir}/omnibus/pkg"
     end
     if omnibus_package_dir
-      command "bazel run #{bazel_flags} -- //packages/installer/linux:copy_out --destdir=#{omnibus_package_dir}",
+      command "bazel run #{omnibazel_flags} -- //packages/installer/linux:copy_out --destdir=#{omnibus_package_dir}",
         :live_stream => Omnibus.logger.live_stream(:info)
     end
   elsif windows_target?

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -9,8 +9,6 @@ build do
   # 2.0 is the license version here, not the python version
   license "Python-2.0"
 
-  flavor_flag = fips_mode? ? "--//packages/agent:flavor=fips" : ""
-
-  command "bazel run #{flavor_flag} --//:install_dir=#{install_dir} -- @cpython//:install --destdir=#{install_dir}",
+  command "bazel run #{omnibazel_flags} -- @cpython//:install --destdir=#{install_dir}",
       :live_stream => Omnibus.logger.live_stream(:info)
 end

--- a/omnibus/lib/ostools.rb
+++ b/omnibus/lib/ostools.rb
@@ -62,3 +62,14 @@ end
 def fips_mode?()
   return ENV['AGENT_FLAVOR'] == "fips" && (linux_target? || windows_target?)
 end
+
+# Expose --//packages/agent:flavor, --//:install_dir and --//:output_config_dir, pinned from the corresponding omnibus
+# build environment variables.
+# 💡 Mirrors `_insert_omnibazel_flags` in tasks/libs/build/bazel.py.
+def omnibazel_flags()
+  flags = []
+  flags << "--//packages/agent:flavor=#{ENV['AGENT_FLAVOR']}" if ENV['AGENT_FLAVOR']
+  flags << "--//:install_dir=#{install_dir}"
+  flags << "--//:output_config_dir=#{ENV['OUTPUT_CONFIG_DIR']}"
+  flags.join(' ')
+end

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -24,6 +24,7 @@ from tasks.gointegrationtest import (
     CORE_AGENT_WINDOWS_IT_CONF,
     containerized_integration_tests,
 )
+from tasks.libs.build.bazel import bazel
 from tasks.libs.common.constants import CONTAINER_PLATFORM_MAPPING
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import (
@@ -459,7 +460,7 @@ def hacky_dev_image_build(
         # of truth: ENABLED_CHECKS in the rustchecks BUILD.bazel). The `:install`
         # target lays each cdylib into <destdir>/checks.d with 0500 perms.
         checks_d_staging = "bin/agent/dist/checks.d"
-        ctx.run("bazel run //pkg/collector/sharedlibrary/rustchecks:install -- --destdir=bin/agent/dist")
+        bazel(ctx, "run", "//pkg/collector/sharedlibrary/rustchecks:install", "--", "--destdir=bin/agent/dist")
         if os.path.isdir(checks_d_staging) and any(
             f.startswith("libdatadog-agent-") for f in os.listdir(checks_d_staging)
         ):

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shlex
 import shutil
 import subprocess
@@ -110,7 +111,7 @@ def bazel(
 
     if not (bazelisk := shutil.which("bazelisk")):  # `/usr/bin/bazel` may otherwise take precedence in DD Workspaces
         raise Exit(bazel_not_found_message("red"))
-    cmd = (("sudo",) if sudo else ()) + (bazelisk,) + args
+    cmd = (("sudo",) if sudo else ()) + (bazelisk, *_insert_omnibazel_flags(args))
     cmdline = (subprocess.list2cmdline if sys.platform == "win32" else shlex.join)(cmd)
     print(color_message(cmdline.replace(bazelisk, "bazel", 1), "bold"), file=sys.stderr)  # brevity: abspath -> bazel
     kwargs = {}
@@ -133,3 +134,20 @@ def bazel(
     if capture_stderr:
         captured.append(result.stderr)
     return "".join(captured)
+
+
+def _insert_omnibazel_flags(args: tuple[str, ...]) -> tuple[str, ...]:
+    """Insert --//packages/agent:flavor, --//:install_dir and --//:output_config_dir, pinned from the corresponding
+    omnibus build environment variables.
+    💡 Mirrors `omnibazel_flags` in omnibus/lib/ostools.rb.
+    """
+    flags = []
+    if agent_flavor := os.environ.get("AGENT_FLAVOR"):
+        flags.append(f"--//packages/agent:flavor={agent_flavor}")
+    if install_dir := os.environ.get("INSTALL_DIR"):
+        flags.append(f"--//:install_dir={install_dir}")
+        flags.append(f"--//:output_config_dir={os.environ.get("OUTPUT_CONFIG_DIR", "")}")
+    if not flags:
+        return args
+    index = next((i for i, a in enumerate(args) if not a.startswith("-")), len(args) - 1) + 1
+    return (*args[:index], *flags, *args[index:])

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -149,5 +149,6 @@ def _insert_omnibazel_flags(args: tuple[str, ...]) -> tuple[str, ...]:
         flags.append(f"--//:output_config_dir={os.environ.get("OUTPUT_CONFIG_DIR", "")}")
     if not flags:
         return args
-    index = next((i for i, a in enumerate(args) if not a.startswith("-")), len(args) - 1) + 1
+    # insert flags right after the bazel command, preserving startup options before it and subcommand arguments after it
+    index = next((i for i, a in enumerate(args, 1) if not a.startswith("-")), len(args))
     return (*args[:index], *flags, *args[index:])

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import platform
 import sys
 from datetime import datetime
 
@@ -374,13 +375,22 @@ def send_cache_miss_event(ctx, pipeline_id, job_name, job_id):
         print(r.text)
 
 
-def install_dir_for_project(project):
-    if project == "agent" or project == "iot-agent":
+def install_dir_for_project(project, *, for_platform: str | None = None):
+    if project in {"agent", "agent-binaries", "ddot", "iot-agent"}:
         folder = 'datadog-agent'
     elif project == 'dogstatsd':
         folder = 'datadog-dogstatsd'
+    elif project == 'eudm':
+        folder = 'datadog-agent-eudm'
     elif project == 'installer':
         folder = 'datadog-installer'
     else:
         raise NotImplementedError(f'Unknown project {project}')
-    return os.path.join('opt', folder)
+
+    if (for_platform or platform.system()).lower() == "windows":
+        # Note: this is the path used by Omnibus to build the agent, the final install
+        # dir will be determined by the Windows installer. This path must not contain
+        # spaces because Omnibus doesn't quote the Git commands it launches.
+        return f"C:/opt/{folder}"
+
+    return f"/opt/{folder}"

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -8,6 +8,7 @@ import tempfile
 import warnings
 from collections import defaultdict
 from collections.abc import Iterator
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import NamedTuple
 
 import requests
@@ -120,6 +121,8 @@ def get_omnibus_env(
     pip_config_file="pip.conf",
     custom_config_dir=None,
     fips_mode=False,
+    *,
+    install_dir,
 ):
     env = get_effective_dependencies_env()
 
@@ -166,6 +169,7 @@ def get_omnibus_env(
     if system_probe_bin:
         env['SYSTEM_PROBE_BIN'] = system_probe_bin
     env['AGENT_FLAVOR'] = flavor.name
+    env['INSTALL_DIR'] = install_dir
 
     if custom_config_dir:
         env["OUTPUT_CONFIG_DIR"] = custom_config_dir
@@ -254,6 +258,15 @@ def build(
     base_dir = _resolve_omnibus_path_override(base_dir, "OMNIBUS_BASE_DIR")
     cache_dir = _resolve_omnibus_path_override(cache_dir, "OMNIBUS_CACHE_DIR")
 
+    if not target_project:
+        target_project = "agent"
+
+    if flavor != AgentFlavor.base and target_project not in ["agent", "ddot", "installer"]:
+        print("flavors only make sense when building the agent, ddot or installer")
+        raise Exit(code=1)
+    if flavor.is_iot():
+        target_project = "iot-agent"
+
     env = get_omnibus_env(
         ctx,
         skip_sign=skip_sign,
@@ -264,16 +277,8 @@ def build(
         pip_config_file=pip_config_file,
         custom_config_dir=config_directory,
         fips_mode=fips_mode,
+        install_dir=install_directory or install_dir_for_project(target_project),
     )
-
-    if not target_project:
-        target_project = "agent"
-
-    if flavor != AgentFlavor.base and target_project not in ["agent", "ddot", "installer"]:
-        print("flavors only make sense when building the agent, ddot or installer")
-        raise Exit(code=1)
-    if flavor.is_iot():
-        target_project = "iot-agent"
 
     # Get the python_mirror from the PIP_INDEX_URL environment variable if it is not passed in the args
     python_mirror = python_mirror or os.environ.get("PIP_INDEX_URL")
@@ -310,8 +315,8 @@ def build(
             install_directory = install_dir_for_project(target_project)
         # Is the path starts with a /, it's considered the new root for the joined path
         # which effectively drops whatever was in omnibus_cache_dir
-        install_directory = install_directory.lstrip('/')
-        omnibus_cache_dir = os.path.join(omnibus_cache_dir, install_directory)
+        native_path = (PureWindowsPath if sys.platform == "win32" else PurePosixPath)(install_directory)
+        omnibus_cache_dir = os.path.join(omnibus_cache_dir, native_path.relative_to(native_path.anchor).as_posix())
         # We don't want to update the cache when not running on a CI
         # Individual developers are still able to leverage the cache by providing
         # the OMNIBUS_GIT_CACHE_DIR env variable, but they won't pull from the CI
@@ -411,6 +416,12 @@ def manifest(
     base_dir = _resolve_omnibus_path_override(base_dir, "OMNIBUS_BASE_DIR")
     cache_dir = _resolve_omnibus_path_override(cache_dir, "OMNIBUS_CACHE_DIR")
 
+    target_project = "agent"
+    if flavor.is_iot():
+        target_project = "iot-agent"
+    elif agent_binaries:
+        target_project = "agent-binaries"
+
     env = get_omnibus_env(
         ctx,
         skip_sign=skip_sign,
@@ -418,13 +429,8 @@ def manifest(
         system_probe_bin=system_probe_bin,
         go_mod_cache=go_mod_cache,
         flavor=flavor,
+        install_dir=install_dir_for_project(target_project, for_platform=platform),
     )
-
-    target_project = "agent"
-    if flavor.is_iot():
-        target_project = "iot-agent"
-    elif agent_binaries:
-        target_project = "agent-binaries"
 
     bundle_install_omnibus(ctx, gem_path, env)
 
@@ -479,7 +485,7 @@ def build_repackaged_agent(ctx, log_level="info"):
             key=_pipeline_id_of_package,
         )
 
-    env = get_omnibus_env(ctx, skip_sign=True, flavor=AgentFlavor.base)
+    env = get_omnibus_env(ctx, skip_sign=True, flavor=AgentFlavor.base, install_dir=install_dir_for_project("agent"))
 
     env['OMNIBUS_REPACKAGE_SOURCE_URL'] = f"https://apt.datad0g.com/{latest_package.filename}"
     env['OMNIBUS_REPACKAGE_SOURCE_SHA256'] = latest_package.sha256

--- a/tasks/unit_tests/libs/build/bazel_tests.py
+++ b/tasks/unit_tests/libs/build/bazel_tests.py
@@ -45,6 +45,23 @@ class TestBazel(unittest.TestCase):
             bazel(self._ctx(exit=1), "info", ignore_errors=True, capture_output=True, capture_stderr=True), "err\n"
         )
 
+    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_no_omnibazel_flag_to_insert(self, _):
+        ctx = self._ctx()
+        bazel(ctx, "run", "//:go")
+        self.assertEqual(ctx.run.call_args[0][0], "/bzlx run //:go")
+
+    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
+    @patch.dict(os.environ, {"AGENT_FLAVOR": "fips", "INSTALL_DIR": "/opt"})
+    def test_inserted_omnibazel_flags(self, _):
+        ctx = self._ctx()
+        bazel(ctx, "--batch", "run", "//:go")
+        self.assertEqual(
+            ctx.run.call_args[0][0],
+            "/bzlx --batch run --//packages/agent:flavor=fips --//:install_dir=/opt --//:output_config_dir= //:go",
+        )
+
     def _ctx(self, *, exit=0, stdout="out\n", stderr="err\n"):
         result = MagicMock()
         result.ok = exit == 0

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -10,6 +10,7 @@ from invoke.exceptions import Exit, UnexpectedExit
 from invoke.runners import Result
 
 from tasks import omnibus
+from tasks.libs.common.omnibus import install_dir_for_project
 
 
 class MockContextRaising(MockContext):
@@ -263,6 +264,34 @@ class TestOmnibusEnvPassthrough(unittest.TestCase):
             env = omnibus._passthrough_env_for_os({'OMNIBUS_BASE_DIR': '/var/cache/dd/omnibus'}, 'linux')
 
         self.assertNotIn('OMNIBUS_BASE_DIR', env)
+
+
+class TestInstallDirForProject(unittest.TestCase):
+    def test_install_dir_for_project(self):
+        with mock.patch("tasks.libs.common.omnibus.platform.system", return_value="Linux"):
+            self.assertEqual(install_dir_for_project("agent"), "/opt/datadog-agent")
+            self.assertEqual(install_dir_for_project("ddot"), "/opt/datadog-agent")
+            self.assertEqual(install_dir_for_project("dogstatsd"), "/opt/datadog-dogstatsd")
+            self.assertEqual(install_dir_for_project("eudm"), "/opt/datadog-agent-eudm")
+            self.assertEqual(install_dir_for_project("installer"), "/opt/datadog-installer")
+            self.assertEqual(install_dir_for_project("iot-agent"), "/opt/datadog-agent")
+        with self.assertRaises(NotImplementedError):
+            install_dir_for_project("not-a-real-project")
+
+    def test_install_dir_for_project_on_windows(self):
+        with mock.patch("tasks.libs.common.omnibus.platform.system", return_value="Windows"):
+            self.assertEqual(install_dir_for_project("agent"), "C:/opt/datadog-agent")
+            self.assertEqual(install_dir_for_project("ddot"), "C:/opt/datadog-agent")
+            self.assertEqual(install_dir_for_project("dogstatsd"), "C:/opt/datadog-dogstatsd")
+            self.assertEqual(install_dir_for_project("eudm"), "C:/opt/datadog-agent-eudm")
+            self.assertEqual(install_dir_for_project("installer"), "C:/opt/datadog-installer")
+            self.assertEqual(install_dir_for_project("iot-agent"), "C:/opt/datadog-agent")
+
+    def test_install_dir_for_project_for_platform_overrides_host_platform(self):
+        with mock.patch("tasks.libs.common.omnibus.platform.system", return_value="Linux"):
+            self.assertEqual(install_dir_for_project("agent", for_platform="windows"), "C:/opt/datadog-agent")
+        with mock.patch("tasks.libs.common.omnibus.platform.system", return_value="Windows"):
+            self.assertEqual(install_dir_for_project("agent", for_platform="linux"), "/opt/datadog-agent")
 
 
 class TestOmnibusInstall(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?
Pin `--//packages/agent:flavor`, `--//:install_dir`, and `--//:output_config_dir` to the values captured once from the corresponding omnibus build environment variables (`AGENT_FLAVOR`/`INSTALL_DIR`/`OUTPUT_CONFIG_DIR`), via new helpers:
- `omnibazel_flags` in `omnibus/lib/ostools.rb`,
- a matching `_insert_omnibazel_flags` in `tasks/libs/build/bazel.py`.

Switch every omnibus software file to call the shared helper instead of recomputing flags _ad hoc_ per call site.

To make that happen, `tasks/omnibus.py`'s `build` task populates `env['INSTALL_DIR']` the same way as `env['AGENT_FLAVOR']` and `env['OUTPUT_CONFIG_DIR']`, by extending the existing flavor-aware default (`install_dir_for_project` in `tasks/libs/common/omnibus.py`) to match each `omnibus/config/projects/*.rb` file's own Windows-vs-POSIX default.

### Motivation
Bazel discards its entire analysis cache whenever any of these `--//label:flag` options differs from the previous invocation on the same server, regardless of whether the target being built reads that flag, see: https://bazel.build/advanced/performance/iteration-speed.

Each omnibus software file and `dda inv`-invoked `bazel` call computed these flags independently, with drifting logic (flavor precedence, missing `output_config_dir`, `iot` flavor hardcoded), so consecutive `bazel ...` invocations across a single omnibus build kept invalidating each other's analysis cache.

Counting `discarding analysis cache` across every job in a [recent](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/125624478) `main` pipeline before this fix confirms real impact:
| Job | 64 occurrences |
| --- | --- |
| [`agent_deb-arm64-a7`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402512) | 1 |
| [`agent_deb-arm64-a7-fips`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402516) | 1 |
| [`agent_deb-x64-a7`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402510) | 1 |
| [`agent_deb-x64-a7-fips`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402514) | 1 |
| [`agent_dmg-arm64-a7`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402460) | 3[^1] |
| [`agent_dmg-x64-a7`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402459) | 3[^1] |
| [`agent_heroku_deb-x64-a7`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402461) | 3 |
| [`agent_rpm-arm64-a7`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402548) | 1 |
| [`agent_rpm-arm64-a7-fips`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402554) | 1 |
| [`agent_rpm-x64-a7`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402547) | 1 |
| [`agent_rpm-x64-a7-fips`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402553) | 1 |
| [`agent_suse-arm64-a7`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402551) | 1 |
| [`agent_suse-arm64-a7-fips`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402556) | 1 |
| [`agent_suse-x64-a7`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402550) | 1 |
| [`agent_suse-x64-a7-fips`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402555) | 1 |
| [`bazel:test:macos-arm64:base`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873401817) | 1[^1] |
| [`datadog-agent-7-arm64-fips`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402477) | 4 |
| [`datadog-agent-7-x64-fips`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402475) | 4 |
| [`datadog-agent-oci-arm64-a7`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402463) | 4 |
| [`datadog-agent-oci-arm64-a7-fips`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402465) | 4 |
| [`datadog-agent-oci-x64-a7`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402462) | 4 |
| [`datadog-agent-oci-x64-a7-fips`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402464) | 4 |
| [`generate_config_schema-macos`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873401939) | 1[^1] |
| [`iot-agent-arm64`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402481) | 1 |
| [`iot-agent-armhf`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402483) | 1 |
| [`iot-agent-x64`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402479) | 1 |
| [`tests_macos_gitlab_amd64`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873527734) | 1[^1] |
| [`windows_msi_and_bosh_zip_x64-a7`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402498) | 6 |
| [`windows_msi_and_bosh_zip_x64-a7-fips`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873402500) | 7 |

... and this only accounts for thrashing visible in the console output, which might exclude cases where the standard error is swallowed.

In the above `windows_msi_and_bosh_zip_x64-a7-fips` run, that's about ~48s of accumulated wasted analysis time, not to mention the time spent reexecuting any "dirty' action.

### Describe how you validated your changes
Local:
- `dda inv invoke-unit-tests.run --tests=bazel --directory=tasks/unit_tests/libs/build`,
- `dda inv invoke-unit-tests.run --tests=omnibus --directory=tasks/unit_tests`.

CI: counting `discarding analysis cache` on [pipeline 126432276](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/126432276) confirms the fix: all 28 tracked jobs show 0 occurrences, except the known-unrelated `agent_dmg-arm64-a7`/`agent_dmg-x64-a7` (1 each, the `rules_go` race flag[^1]).

No job shows a discard attributable to the three flags this PR pins.

### Additional Notes
Resorting to environment variables and having 2 parallel helpers (Python, Ruby) is from ideal, but all this is **transitional**:
- omnibus will go away (no more Ruby),
- python sequencing will be shrunk down to a large extent (esp. what drives omnibus).

[^1]: macOS CI executors aren't containerized, and the Bazel server there survives up to 8 hours (`--max_idle_secs=28800` in `.bazelrc`) of inactivity between jobs.
So a macOS job's first `bazel` invocation can still discard the analysis cache once, at job startup, when inheriting server state left over from an unrelated prior job on the same runner (e.g. a different `--@@rules_go+//go/config:race` value).