### PR TITLE
Increase Heroku lint memory on 6.53.x

### DIFF
--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -127,6 +127,8 @@ lint_flavor_heroku_linux-x64:
     - .linux_x64
   variables:
     FLAVORS: '--flavors heroku'
+    KUBERNETES_MEMORY_REQUEST: 32Gi
+    KUBERNETES_MEMORY_LIMIT: 32Gi
 
 # Exclude systemd because it cannot succeed on Centos 6: the image doesn't have the shared object required by
 # https://github.com/coreos/go-systemd/blob/c8cc474ba8655dfbdb0ac7fcc09b7faf5b643caf/sdjournal/functions.go#L46


### PR DESCRIPTION
## What

The 6.53.x Heroku-flavor Go lint job repeatedly exhausts its 16 GiB resource envelope while loading the `test/new-e2e` package graph. This causes either OOM failures or `go/packages` context-deadline failures even when the same commit passes on a later attempt.

This change gives only `lint_flavor_heroku_linux-x64` a 32 GiB memory request and limit. CPU/concurrency remains 16, the per-invocation timeout remains 25 minutes, and the lint target/module coverage is unchanged.

## Why

On [PR #53401](https://github.com/DataDog/datadog-agent/pull/53401), the job failed twice on different runners:

- [job 1873692527](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873692527): `test/new-e2e` package loading timed out
- [job 1873862284](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873862284): the same package-loading timeout after 66 minutes

The failures are extreme duration outliers. A seven-day repository sample had 517 terminal executions with a typical p95 duration of 532 seconds, while these attempts took 2,155 and 3,976 seconds. Prior 6.53.x pipelines also show OOM/timeout attempts followed by a fast successful retry, which points to resource starvation rather than a deterministic lint finding.

Current `main` uses 32 GiB for the equivalent Linux lint template with CPU/concurrency 16. This PR applies that established resource level only to the unstable Heroku job to minimize the 6.53.x backport scope.

## Validation

- `git diff --check`
- YAML parse with `yq`
- `dda inv lint-gitlab` passed all four preset contexts using a project-scoped token
- Pre-commit hooks passed
- Signed commit verified locally
- Skeptical review verified effective variables: Heroku flavor, CPU 16, 32 GiB request/limit; timeout and coverage unchanged

CI must confirm the Heroku lint runner receives the 32 GiB override and completes successfully.
