### PR TITLE
Remove dead `output_config_dir` from `dd_agent_pkg_mklink`

### DIFF
--- a/bazel/rules/dd_agent_pkg_mklink.bzl
+++ b/bazel/rules/dd_agent_pkg_mklink.bzl
@@ -4,10 +4,6 @@ load("@agent_volatile//:env_vars.bzl", "env_vars")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_pkg//pkg:providers.bzl", "PackageSymlinkInfo")
 
-# The place we will install to if we run bazel pkg_install without a destdir
-# We use /tmp for lack of a better safe space.
-DEFAULT_OUTPUT_CONFIG_DIR = "/tmp"
-
 # The location where the product should be installed on a user system.
 DEFAULT_PRODUCT_DIR = "/opt/datadog-agent"
 
@@ -17,11 +13,6 @@ def _dd_agent_pkg_mklink_impl(ctx):
 
     # TODO: Consider sharing common logic with dd_agent_expand_template IFF we find
     #       the alignment in variable names gets larger.
-    # TODO: should this be different for windows? Or should we have different variables for windows?
-    subs["output_config_dir"] = DEFAULT_OUTPUT_CONFIG_DIR
-    if ctx.attr._output_config_dir and BuildSettingInfo in ctx.attr._output_config_dir:
-        output_config_dir = ctx.attr._output_config_dir[BuildSettingInfo].value.rstrip("/")
-        subs["output_config_dir"] = output_config_dir
     subs["install_dir"] = DEFAULT_PRODUCT_DIR
     if ctx.attr._install_dir and BuildSettingInfo in ctx.attr._install_dir:
         install_dir = ctx.attr._install_dir[BuildSettingInfo].value
@@ -53,7 +44,6 @@ some default substitutions which are computed from the build environment.
 
 Default substitutions:
   {install_dir}:  The value of the flag //:install_dir
-  {output_config_dir}:  The value of the flag //:output_config_dir
   {build_version}: The pipeline build version.
 """,
     attrs = {
@@ -70,6 +60,5 @@ Default substitutions:
             default = "{}",  # Empty JSON
         ),
         "_install_dir": attr.label(default = "@@//:install_dir"),
-        "_output_config_dir": attr.label(default = "@@//:output_config_dir"),
     },
 )


### PR DESCRIPTION
### What does this PR do?
Drop `_output_config_dir` and its `DEFAULT_OUTPUT_CONFIG_DIR` default from `bazel/rules/dd_agent_pkg_mklink.bzl`.

### Motivation
Bazel's dependency tracking has no visibility into whether a read build-setting value is ever actually used in a rule's output.

Merely calling `ctx.attr._output_config_dir` and reading its `BuildSettingInfo` registers a real dependency on
`--//:output_config_dir`, forcing re-analysis of every `dd_agent_pkg_mklink` target whenever that flag's value changes, even though the substitution it feeds is never consumed.

The flag itself, `//:output_config_dir`, stays alive and used elsewhere (`dd_agent_expand_template.bzl`).

Only this rule's dead, never-exercised dependency on it goes away.

### Additional Notes
Found by working on:
- #53850.