### PR TITLE
Remove removal of setuptools .exe files from omnibus

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -39,13 +39,6 @@ build do
   # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
   command "#{python} -B -m pip check"
 
-  unless windows_target?
-    block "Remove .exe files" do
-      # setuptools come from supervisor and ddtrace
-      FileUtils.rm_f(Dir.glob("#{site_packages_path}/setuptools/*.exe"))
-    end
-  end
-
   # Remove openssl copies from libraries that depend on it, and patch as necessary.
   # The OpenSSL setup with FIPS is more delicate than in the regular Agent because it makes it harder
   # to control FIPS initialization; this has surfaced as problems with `cryptography` specifically, and


### PR DESCRIPTION
### What does this PR do?

It returns the omnibus block that deletes *.exe files from setuptools.

### Motivation

This was moved to integrations-core (https://github.com/DataDog/integrations-core/pull/24542), and that change has now made it to main (https://github.com/DataDog/datadog-agent/pull/53835). We no longer need to do this on the Omnibus side.

### Describe how you validated your changes

Look at size changes and file inventory to confirm we're not adding files back.

### Additional Notes
