### PR TITLE
chore: remove no-op `//nolint:gosimple` (noisy warnings)

### DIFF
--- a/pkg/collector/corechecks/containers/docker/events.go
+++ b/pkg/collector/corechecks/containers/docker/events.go
@@ -51,7 +51,6 @@ func (d *DockerCheck) retrieveEvents(du docker.Client) ([]*docker.ContainerEvent
 		return events, err
 	}
 
-	//nolint:gosimple // TODO(CINT) Fix gosimple linter
 	if !latest.IsZero() {
 		d.lastEventTime = latest.Add(1 * time.Nanosecond)
 	}

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -704,7 +704,6 @@ func (ns *networkState) mergeConnections(id string, active []ConnectionStats) (_
 
 		ns.updateConnWithStats(client, cookie, closedConn)
 
-		//nolint:gosimple // TODO(NET) Fix gosimple linter
 		if closedConn.Last.IsZero() {
 			// not reporting an "empty" connection
 			return false

--- a/pkg/util/docker/event_pull.go
+++ b/pkg/util/docker/event_pull.go
@@ -50,14 +50,12 @@ func (d *DockerUtil) processContainerEvent(ctx context.Context, msg events.Messa
 
 	// Container filtering
 	containerName, found := msg.Actor.Attributes["name"]
-	//nolint:gosimple // TODO(CINT) Fix gosimple linter
 	if !found {
 		// TODO: inspect?
 		m, _ := json.Marshal(msg)
 		return nil, fmt.Errorf("missing container name in event %s", string(m))
 	}
 	imageName, found := msg.Actor.Attributes["image"]
-	//nolint:gosimple // TODO(CINT) Fix gosimple linter
 	if !found {
 		// TODO: inspect?
 		m, _ := json.Marshal(msg)

--- a/pkg/util/docker/storage.go
+++ b/pkg/util/docker/storage.go
@@ -23,9 +23,8 @@ import (
 var (
 	// ErrStorageStatsNotAvailable is returned if the storage stats are not in the docker info.
 	ErrStorageStatsNotAvailable = errors.New("docker storage stats not available")
-	//nolint:gosimple // TODO(CINT) Fix gosimple linter
-	diskBytesRe = regexp.MustCompile(`([0-9.]+)\s?([a-zA-Z]+)`)
-	diskUnits   = map[string]uint64{
+	diskBytesRe                 = regexp.MustCompile(`([0-9.]+)\s?([a-zA-Z]+)`)
+	diskUnits                   = map[string]uint64{
 		"b":  1,
 		"kb": 1000,
 		"mb": 1000000,

--- a/pkg/util/ecs/detection.go
+++ b/pkg/util/ecs/detection.go
@@ -78,7 +78,6 @@ func queryCacheBool(cacheKey string, cacheMissEvalFunc func() (bool, time.Durati
 }
 
 func newBoolEntry(v bool) (bool, time.Duration) {
-	//nolint:gosimple // TODO(CINT) Fix gosimple linter
 	if v {
 		return v, 5 * time.Minute
 	}


### PR DESCRIPTION
### Motivation
Similar to #53786: `golangci-lint` v2 dropped the `gosimple` linter, folding its checks into `staticcheck` (enabled in `.golangci.yml`).

Every `//nolint:gosimple` directive is therefore already a no-op, but each one makes `golangci-lint` log a `Found unknown linters in //nolint directives` warning, which fires roughly [4500 times a week in CI](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%22Found%20unknown%20linters%22%20gosimple&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&fromUser=true&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1783720320007&to_ts=1784325120007&live=true).

### Describe how you validated your changes
Confirmed `staticcheck` still runs the checks `gosimple` used to own: a throwaway `if v == true { return true } else { return false }` gets flagged as `S1002: should omit comparison to bool constant, can be simplified to v (staticcheck)`.