### PR TITLE
Drop dead `sd-agent`/`dd-procmgrd` omnibus flags

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -250,7 +250,7 @@ build do
 
   end
 
-  # system-probe-lite (service discovery agent)
+  # sd-agent (service discovery agent)
   if linux_target? and !heroku_target?
     command "bazel run #{bazel_flags} //pkg/discovery/module/rust:install -- --destdir=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
   end

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -115,8 +115,6 @@ def get_omnibus_env(
     skip_sign=False,
     hardened_runtime=False,
     system_probe_bin=None,
-    with_sd_agent=False,  # No-op; kept for backward compatibility
-    with_dd_procmgrd=False,  # No-op; kept for backward compatibility
     go_mod_cache=None,
     flavor=AgentFlavor.base,
     pip_config_file="pip.conf",
@@ -233,8 +231,6 @@ def build(
     skip_sign=False,
     hardened_runtime=False,
     system_probe_bin=None,
-    with_sd_agent=False,  # No-op; kept for backward compatibility
-    with_dd_procmgrd=False,  # No-op; kept for backward compatibility
     go_mod_cache=None,
     python_mirror=None,
     pip_config_file="pip.conf",
@@ -263,8 +259,6 @@ def build(
         skip_sign=skip_sign,
         hardened_runtime=hardened_runtime,
         system_probe_bin=system_probe_bin,
-        with_sd_agent=with_sd_agent,
-        with_dd_procmgrd=with_dd_procmgrd,
         go_mod_cache=go_mod_cache,
         flavor=flavor,
         pip_config_file=pip_config_file,
@@ -410,8 +404,6 @@ def manifest(
     skip_sign=False,
     hardened_runtime=False,
     system_probe_bin=None,
-    with_sd_agent=False,
-    with_dd_procmgrd=False,
     go_mod_cache=None,
 ):
     flavor = AgentFlavor[flavor]
@@ -424,8 +416,6 @@ def manifest(
         skip_sign=skip_sign,
         hardened_runtime=hardened_runtime,
         system_probe_bin=system_probe_bin,
-        with_sd_agent=with_sd_agent,
-        with_dd_procmgrd=with_dd_procmgrd,
         go_mod_cache=go_mod_cache,
         flavor=flavor,
     )


### PR DESCRIPTION
### What does this PR do?
Remove the now-unused `with_sd_agent` and `with_dd_procmgrd` parameters from `tasks/omnibus.py` (`get_omnibus_env`, `build`, `manifest`), and fix the `sd-agent` comment in `omnibus/config/software/datadog-agent.rb`.

### Motivation
#46834 and #46837 moved the `dd-procmgrd` and `sd-agent` Bazel builds inline into omnibus packaging, gated by `WITH_DD_PROCMGRD` and `WITH_SD_AGENT`.
#47225 and #49584 later made both builds unconditional and turned the task parameters into no-ops kept for backward compatibility.
No caller has passed either flag since, so the plumbing across three functions became dead weight.

Separately, #47225 briefly renamed `sd-agent` to `system-probe-lite` in a comment, was reverted the same day, but the old name resurfaced in #47465 and has since drifted from the actual name used everywhere else in the codebase.