### PR TITLE
[ABLD-436] update openssl FIPS to 3.1.2

### DIFF
--- a/deps/openssl_fips/BUILD.bazel
+++ b/deps/openssl_fips/BUILD.bazel
@@ -1,0 +1,4 @@
+# This declares the package defining our setup for openssl_fips.
+# The BUILD file for openssl_fips itself is openssl_fips.BUILD.bazel
+
+package(default_visibility = ["//visibility:private"])

--- a/deps/openssl_fips/openssl_fips.BUILD.bazel
+++ b/deps/openssl_fips/openssl_fips.BUILD.bazel
@@ -1,7 +1,32 @@
+load("@@//compliance/rules:purl.bzl", "purl_for_generic")
+load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+load("@rules_license//rules:license.bzl", "license")
 load("@rules_python//python:defs.bzl", "py_binary")
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_package_metadata = [":license"],
+    default_visibility = ["//visibility:public"],
+)
+
+package_metadata(
+    name = "package_metadata",
+    attributes = [
+        ":license",
+    ],
+    purl = purl_for_generic(
+        download_url = "https://github.com/openssl/openssl/releases/download/openssl-{version}/openssl-{version}.tar.gz",
+        package = "openssl",
+        version = "3.1.2",
+    ),
+)
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:Apache-2.0"],
+    license_text = "LICENSE.txt",
+    visibility = ["//visibility:public"],
+)
 
 ENABLE_FIPS_CONFIG = [
     "--libdir=lib",
@@ -22,6 +47,12 @@ FIPS_LINUX = "fips.so"
 
 configure_make(
     name = "openssl_fips",
+    build_data = select({
+        "@platforms//os:windows": [
+            "@winlibs_mingw64//:windres",
+        ],
+        "//conditions:default": [],
+    }),
     configure_command = "Configure",
     configure_in_place = select({
         "@platforms//os:windows": True,
@@ -37,12 +68,7 @@ configure_make(
         "@platforms//os:windows": "perl",
         "//conditions:default": "",
     }),
-    build_data = select({
-        "@platforms//os:windows": [
-            "@winlibs_mingw64//:windres",
-        ],
-        "//conditions:default": [],
-    }),
+    copts = ["-O2"],
     env = select({
         "@platforms//os:windows": {
             # Configure resolves RC from RC or WINDRES, then emits it into Makefile.
@@ -51,9 +77,7 @@ configure_make(
         },
         "//conditions:default": {},
     }),
-    copts = ["-O2"],
     lib_source = ":all",
-    resource_size = "enormous",
     out_shared_libs = select({
         "@platforms//os:linux": [
             "ossl-modules/" + FIPS_LINUX,
@@ -63,6 +87,7 @@ configure_make(
         ],
         "//conditions:default": [],
     }),
+    resource_size = "enormous",
     # We don't build FIPS for macOS, therefore, incompatible.
     target_compatible_with = select({
         "@platforms//os:macos": ["@platforms//:incompatible"],
@@ -95,12 +120,12 @@ genrule(
     srcs = ["fipsinstall.sh"],
     outs = ["fipsinstall.sh.out"],
     cmd = "$(execpath :_configure_fips_tool) --input $< --output $@ '{{install_dir}}=$(INSTALL_DIR)/embedded'",
-    tools = [":_configure_fips_tool"],
-    toolchains = ["@@//:install_dir"],
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    toolchains = ["@@//:install_dir"],
+    tools = [":_configure_fips_tool"],
 )
 
 genrule(
@@ -111,8 +136,8 @@ genrule(
         "@platforms//os:windows": "$(execpath :_configure_fips_tool) --input $< --output $@ '{{embedded_ssl_dir}}=C:/Program Files/Datadog/Datadog Agent/embedded3/ssl'",
         "//conditions:default": "$(execpath :_configure_fips_tool) --input $< --output $@ '{{embedded_ssl_dir}}=$(INSTALL_DIR)/embedded/ssl'",
     }),
-    tools = [":_configure_fips_tool"],
     toolchains = ["@@//:install_dir"],
+    tools = [":_configure_fips_tool"],
 )
 
 # configure_fips.py also supports a legacy --destdir interface for manual use.

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -106,21 +106,6 @@ register_toolchains(
 )
 
 http_archive(
-    name = "openssl",
-    build_file = "//deps:openssl.BUILD.bazel",
-    patch_strip = 1,
-    patches = [
-        "//deps/openssl:0001-Set-the-install-name-to-use-rpath-instead-of-absolut.patch",
-    ],
-    sha256 = "a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8",
-    strip_prefix = "openssl-3.5.7",
-    urls = [
-        "https://github.com/openssl/openssl/releases/download/openssl-3.5.7/openssl-3.5.7.tar.gz",
-        "https://www.openssl.org/source/openssl-3.5.7.tar.gz",
-    ],
-)
-
-http_archive(
     name = "libffi",
     build_file = "//deps:libffi.BUILD.bazel",
     sha256 = "bc9842a18898bfacb0ed1252c4febcc7e78fa139fd27fdc7a3e30d9d9356119b",
@@ -401,17 +386,33 @@ http_archive(
 )
 
 http_archive(
+    name = "openssl",
+    build_file = "//deps:openssl.BUILD.bazel",
+    patch_strip = 1,
+    patches = [
+        "//deps/openssl:0001-Set-the-install-name-to-use-rpath-instead-of-absolut.patch",
+    ],
+    sha256 = "a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8",
+    strip_prefix = "openssl-3.5.7",
+    urls = [
+        "https://github.com/openssl/openssl/releases/download/openssl-3.5.7/openssl-3.5.7.tar.gz",
+        "https://www.openssl.org/source/openssl-3.5.7.tar.gz",
+    ],
+)
+
+http_archive(
     name = "openssl_fips",
     files = {
-        "openssl.cnf.tmp": "//deps:openssl_fips/openssl.cnf.tmp",
-        "fipsinstall.sh": "//deps:openssl_fips/fipsinstall.sh",
-        "configure_fips.py": "//deps:openssl_fips/configure_fips.py",
-        "BUILD.bazel": "//deps:openssl_fips.BUILD.bazel",
+        "BUILD.bazel": "//deps/openssl_fips:openssl_fips.BUILD.bazel",
+        "configure_fips.py": "//deps/openssl_fips:configure_fips.py",
+        "fipsinstall.sh": "//deps/openssl_fips:fipsinstall.sh",
+        "openssl.cnf.tmp": "//deps/openssl_fips:openssl.cnf.tmp",
     },
-    sha256 = "eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90",
-    strip_prefix = "openssl-3.0.9",
+    # The LTS openssl is different than the FIPS certified version. See https://openssl-library.org/source/
+    sha256 = "a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539",
+    strip_prefix = "openssl-3.1.2",
     urls = [
-        "https://www.openssl.org/source/openssl-3.0.9.tar.gz",
+        "https://github.com/openssl/openssl/releases/download/openssl-3.1.2/openssl-3.1.2.tar.gz",
     ],
 )
 

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -2,8 +2,8 @@ static_quality_gate_agent_deb_amd64:
   max_on_disk_size: 758.2 MiB
   max_on_wire_size: 181.27 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 709.84 MiB
-  max_on_wire_size: 175.54 MiB
+  max_on_disk_size: 710.52 MiB
+  max_on_wire_size: 175.48 MiB
 static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 315.23 MiB
   max_on_wire_size: 80.56 MiB
@@ -14,26 +14,26 @@ static_quality_gate_agent_rpm_amd64:
   max_on_disk_size: 758.17 MiB
   max_on_wire_size: 183.9 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 709.84 MiB
-  max_on_wire_size: 175.61 MiB
+  max_on_disk_size: 710.52 MiB
+  max_on_wire_size: 175.6 MiB
 static_quality_gate_agent_rpm_arm64:
   max_on_disk_size: 729.66 MiB
   max_on_wire_size: 164.95 MiB
 static_quality_gate_agent_rpm_arm64_fips:
-  max_on_disk_size: 688.86 MiB
-  max_on_wire_size: 158.67 MiB
+  max_on_disk_size: 688.91 MiB
+  max_on_wire_size: 158.68 MiB
 static_quality_gate_agent_suse_amd64:
   max_on_disk_size: 758.17 MiB
   max_on_wire_size: 183.88 MiB
 static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 709.84 MiB
-  max_on_wire_size: 175.7 MiB
+  max_on_disk_size: 710.52 MiB
+  max_on_wire_size: 175.74 MiB
 static_quality_gate_agent_suse_arm64:
   max_on_disk_size: 729.66 MiB
   max_on_wire_size: 164.89 MiB
 static_quality_gate_agent_suse_arm64_fips:
-  max_on_disk_size: 688.86 MiB
-  max_on_wire_size: 158.68 MiB
+  max_on_disk_size: 688.91 MiB
+  max_on_wire_size: 158.67 MiB
 static_quality_gate_docker_agent_amd64:
   max_on_disk_size: 813.79 MiB
   max_on_wire_size: 275.37 MiB


### PR DESCRIPTION
### What does this PR do?
- updates openssl_fips to version 3.1.2
- add missing license declarations.
- reorganize MODULE file to make it clearer we have 2 openssls at different versions.
- tidy up the organization of build overides.

### Motivation
- required for FIPS 140.3 compliance. 
- Read more in https://docs.google.com/document/d/1KLV_mnA6pJxXv6omcZuIAbaC4C_3N-ht95uC5LEB9CY/edit?tab=t.0

### Describe how you validated your changes
- e2e tests

### Additional notes
- This has a size exemption because it is essentially a CVE.
- This is one step of https://datadoghq.atlassian.net/browse/ABLD-437. 