### PR TITLE
Configure MCP servers

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,26 @@
+# AI agent assets
+
+This `/.agents/` directory stores configuration and other assets that are meant to be shared amongst all agent harnesses like Claude, Codex, Pi, etc.
+
+## Skills
+
+Agent skills are stored in the `skills/` subdirectory. Claude does not [yet](https://github.com/anthropics/claude-code/issues/6235) support this [convention](https://agentskills.io/client-implementation/adding-skills-support#where-to-scan), so we symlink `/.claude/skills/` to that directory.
+
+## MCP config
+
+The MCP servers are declared in `/agents.toml`, and will be moved to this directory when our tooling supports it.
+
+### Synchronizing
+
+Config is written into each tool's own config file by [dotagents](https://github.com/getsentry/dotagents), run through [mise](https://mise.en.dev). After changing a declaration, run:
+
+```
+mise run dotagents install   # or `mise run dotagents sync` to reconcile/repair offline
+```
+
+dotagents writes to every tool listed in the `agents` key of `agents.toml`, repairing the servers it declares while preserving undeclared servers and unrelated content in each file.
+
+### Maintained by hand
+
+- **Zed** (`/.zed/settings.json`) - not yet a dotagents target.
+- **`dd-slack`** - Slack has no dynamic client registration, so each client needs its own pre-registered Slack app bound to a fixed redirect URI. We configure this for Claude and Cursor because that's all Slack publishes at the time of writing. Registering our own Slack app with dynamic client registration will likely be required for broader support.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,17 @@
+# dd-slack is omitted because, although recent versions of Codex now support
+# an `mcp_servers.<name>.oauth.client_id` field, the only published Slack apps
+# are for Claude and Cursor. Trying to reuse Claude's authorizes as the "Claude"
+# app and can't reach the target private workspace, so a Datadog-owned Slack app
+# is required.
+
+[mcp_servers.dd-api]
+url = "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=all"
+
+[mcp_servers.dd-ci]
+url = "https://ddci-mcp.mcp.us1.ddbuild.io/internal/mcp"
+
+[mcp_servers.dd-google-workspace]
+url = "https://google-workspace-mcp-server-834963730936.us-central1.run.app/mcp"
+
+[mcp_servers.dd-atlassian]
+url = "https://mcp.atlassian.com/v1/mcp/authv2"

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "dd-api": {
+      "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=all"
+    },
+    "dd-ci": {
+      "url": "https://ddci-mcp.mcp.us1.ddbuild.io/internal/mcp"
+    },
+    "dd-google-workspace": {
+      "url": "https://google-workspace-mcp-server-834963730936.us-central1.run.app/mcp"
+    },
+    "dd-atlassian": {
+      "url": "https://mcp.atlassian.com/v1/mcp/authv2"
+    },
+    "dd-slack": {
+      "url": "https://mcp.slack.com/mcp",
+      "auth": {
+        "CLIENT_ID": "3660753192626.8903469228982"
+      }
+    }
+  }
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,8 @@
 /.claude/rules/allium.md                         @DataDog/single-machine-performance
 /.claude/rules/bazel.md                          @DataDog/agent-build
 /.claude/rules/msi.md                            @DataDog/windows-products
-/.agents/skills/codereview_guideline.md          @DataDog/agent-devx
+/.agents/*                                       @DataDog/agent-devx
+/.agents/skills/*                                @DataDog/agent-devx
 /.agents/skills/allium/                          @DataDog/single-machine-performance
 /.agents/skills/agent-supply-chain-newsletter/   @DataDog/agent-devx
 /.agents/skills/auto-jira/                       @DataDog/agent-devx
@@ -86,6 +87,8 @@
 /release.json                           @DataDog/agent-build @DataDog/agent-delivery @DataDog/agent-integrations
 /renovate.json                          @DataDog/agent-build
 /pyproject.toml                         @DataDog/agent-devx
+/agents.toml                            @DataDog/agent-devx
+/mise.toml                              @DataDog/agent-devx
 /repository.datadog.yml                 @DataDog/agent-devx
 /code-coverage.datadog.yml              @DataDog/agent-devx
 /service.datadog.yaml                   @DataDog/agent-delivery @DataDog/agent-devx

--- a/.gitignore
+++ b/.gitignore
@@ -245,11 +245,13 @@ AUTO_JIRA.md
 # Claude Code worktrees (local development, not for repo)
 .claude/worktrees/
 
-# Codex
-.codex/
+# Codex (commit the shared MCP config; ignore everything else Codex writes)
+.codex/*
+!.codex/config.toml
 
-# Zed config
-.zed
+# Zed config (commit the shared MCP config; ignore everything else)
+.zed/*
+!.zed/settings.json
 
 # Devcontainer
 .devcontainer/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,28 @@
+{
+  "mcpServers": {
+    "dd-api": {
+      "type": "http",
+      "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=all"
+    },
+    "dd-ci": {
+      "type": "http",
+      "url": "https://ddci-mcp.mcp.us1.ddbuild.io/internal/mcp"
+    },
+    "dd-google-workspace": {
+      "type": "http",
+      "url": "https://google-workspace-mcp-server-834963730936.us-central1.run.app/mcp"
+    },
+    "dd-atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp/authv2"
+    },
+    "dd-slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp",
+      "oauth": {
+        "clientId": "1601185624273.8899143856786",
+        "callbackPort": 3118
+      }
+    }
+  }
+}

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "dd-api": {
+      "type": "remote",
+      "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=all",
+      "enabled": true
+    },
+    "dd-ci": {
+      "type": "remote",
+      "url": "https://ddci-mcp.mcp.us1.ddbuild.io/internal/mcp",
+      "enabled": true
+    },
+    "dd-google-workspace": {
+      "type": "remote",
+      "url": "https://google-workspace-mcp-server-834963730936.us-central1.run.app/mcp",
+      "enabled": true
+    },
+    "dd-atlassian": {
+      "type": "remote",
+      "url": "https://mcp.atlassian.com/v1/mcp/authv2",
+      "enabled": true
+    }
+  }
+}

--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -4,3 +4,4 @@
 !tasks.json.template
 !copyright.code-snippets
 !extensions.json
+!mcp.json

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,20 @@
+{
+  "servers": {
+    "dd-api": {
+      "type": "http",
+      "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=all"
+    },
+    "dd-ci": {
+      "type": "http",
+      "url": "https://ddci-mcp.mcp.us1.ddbuild.io/internal/mcp"
+    },
+    "dd-google-workspace": {
+      "type": "http",
+      "url": "https://google-workspace-mcp-server-834963730936.us-central1.run.app/mcp"
+    },
+    "dd-atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp/authv2"
+    }
+  }
+}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,16 @@
+{
+  "context_servers": {
+    "dd-api": {
+      "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=all"
+    },
+    "dd-ci": {
+      "url": "https://ddci-mcp.mcp.us1.ddbuild.io/internal/mcp"
+    },
+    "dd-google-workspace": {
+      "url": "https://google-workspace-mcp-server-834963730936.us-central1.run.app/mcp"
+    },
+    "dd-atlassian": {
+      "url": "https://mcp.atlassian.com/v1/mcp/authv2"
+    }
+  }
+}

--- a/agents.toml
+++ b/agents.toml
@@ -1,0 +1,19 @@
+# dotagents declarations for this repo (https://github.com/getsentry/dotagents).
+# Run `mise run dotagents install` (or `sync`) to write each tool's MCP config.
+agents = ["claude", "codex", "cursor", "vscode", "opencode"]
+
+[[mcp]]
+name = "dd-api"
+url = "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=all"
+
+[[mcp]]
+name = "dd-ci"
+url = "https://ddci-mcp.mcp.us1.ddbuild.io/internal/mcp"
+
+[[mcp]]
+name = "dd-google-workspace"
+url = "https://google-workspace-mcp-server-834963730936.us-central1.run.app/mcp"
+
+[[mcp]]
+name = "dd-atlassian"
+url = "https://mcp.atlassian.com/v1/mcp/authv2"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,21 @@
+[settings]
+# Only explicit tasks/tools drive mise here; never act on .go-version,
+# .bazelversion, etc.
+idiomatic_version_file = false
+
+# Tools that do not fit DotSlash (no prebuilt artifact, or need a runtime) are
+# exposed as tasks and run via `mise run <tool>` / `mise <tool>`. Each task scopes
+# its own tools so running one installs only that tool, not the whole set.
+#
+# Task-scoped tools are not written to a lockfile, so the exact versions pinned
+# below provide our reproducibility. That loses nothing here since npm packages
+# are immutable per version, and the node runtime is checksum-verified by mise's
+# core backend on install. This is temporary until we devise a strategy for using
+# mise tool stubs in the same way as DotSlash files.
+[tasks.dotagents]
+description = "Sentry dotagents CLI"
+run = "dotagents"
+
+[tasks.dotagents.tools]
+node = "22.23.1"
+"npm:@sentry/dotagents" = "1.17.0"

--- a/renovate.json
+++ b/renovate.json
@@ -309,6 +309,25 @@
         "depNameTemplate": "datadog.dd",
         "datasourceTemplate": "custom.ansible-galaxy-datadog-dd",
         "versioningTemplate": "semver"
+      },
+      {
+        "customType": "regex",
+        "managerFilePatterns": ["mise.toml"],
+        "matchStrings": [
+          "\"npm:(?<depName>[^\"]+)\"\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+        ],
+        "datasourceTemplate": "npm",
+        "versioningTemplate": "npm"
+      },
+      {
+        "customType": "regex",
+        "managerFilePatterns": ["mise.toml"],
+        "matchStrings": [
+          "\\bnode\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+        ],
+        "depNameTemplate": "node",
+        "datasourceTemplate": "node",
+        "versioningTemplate": "node"
       }
     ],
     "customDatasources": {


### PR DESCRIPTION
### What does this PR do?

This moves over the MCP config we currently define in our dev env [here](https://github.com/DataDog/datadog-agent-buildimages/blob/main/dev-envs/linux/claude.sh) and [here](https://github.com/DataDog/datadog-agent-buildimages/blob/main/dev-envs/linux/codex.sh).

### Motivation

We want to remove all dependence on tools and config defined externally. For this change in particular, it's also far easier to configure and more compatible with the AI agent ecosystem.

### Additional Notes

I chose to use [dotagents](https://github.com/getsentry/dotagents) rather than writing our own tooling, for now, as it supports most of what we want and running JavaScript apps is pretty easy since mise is already [available](https://github.com/DataDog/datadog-agent-buildimages/blob/main/tools/dotslash/config/mise.json) in our dev envs.

I opened a [PR](https://github.com/getsentry/dotagents/pull/141) that adds support for Windows.